### PR TITLE
Fix font fallback rendering issue on Flutter Web

### DIFF
--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -68,7 +68,9 @@ class ThemeService extends ChangeNotifier {
         seedColor: _primaryColor,
         brightness: Brightness.light,
       ),
-      textTheme: GoogleFonts.notoSansJpTextTheme(), // ← 追加
+      textTheme: GoogleFonts.notoSansJpTextTheme().apply(
+        fontFamilyFallback: ['Noto Sans', 'Noto Color Emoji', 'sans-serif'],
+      ),
       appBarTheme: AppBarTheme(
         elevation: 0,
         centerTitle: false,
@@ -100,8 +102,9 @@ class ThemeService extends ChangeNotifier {
         brightness: Brightness.dark,
       ),
       textTheme: GoogleFonts.notoSansJpTextTheme(
-        // ← 追加
         ThemeData.dark().textTheme,
+      ).apply(
+        fontFamilyFallback: ['Noto Sans', 'Noto Color Emoji', 'sans-serif'],
       ),
       appBarTheme: AppBarTheme(
         elevation: 0,

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,13 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
+  <!-- Google Fonts preconnect for faster loading -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+  <!-- Preload Noto Sans JP and fallback fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Sans:wght@400;500;700&family=Noto+Color+Emoji&display=swap" rel="stylesheet">
+
   <title>my_web_app</title>
   <link rel="manifest" href="manifest.json">
 </head>


### PR DESCRIPTION
- Added Google Fonts preconnect links to web/index.html for faster font loading
- Preloaded Noto Sans JP, Noto Sans, and Noto Color Emoji fonts via Google Fonts CDN
- Updated ThemeService to include explicit font fallback chain for both light and dark themes
- Applied fontFamilyFallback to ensure proper rendering of special characters, emojis, and symbols

This resolves the "Could not find a set of Noto fonts to display all missing characters" warning by providing a comprehensive font stack with proper fallback support.