### PR TITLE
Fix Flutter web full-screen image capture overflow

### DIFF
--- a/lib/widgets/share_note_card_dialog.dart
+++ b/lib/widgets/share_note_card_dialog.dart
@@ -314,7 +314,7 @@ class _ShareNoteCardDialogState extends State<ShareNoteCardDialog> {
                 top: -10000,
                 child: SizedBox(
                   width: 1080,
-                  height: 1080,
+                  // 高さの制約を削除し、コンテンツに応じて自動調整
                   child: _buildCardWidget(),
                 ),
               ),


### PR DESCRIPTION
Remove fixed height constraint (1080px) from preview area in share dialog to allow dynamic height adjustment based on content length. This fixes the RenderFlex overflow issue and enables capturing the entire note content as a single image, regardless of length.