### PR TITLE
Fix fourth image download failure in Flutter web

### DIFF
--- a/lib/services/note_card_service.dart
+++ b/lib/services/note_card_service.dart
@@ -143,15 +143,23 @@ class NoteCardService {
 
           if (byteData != null) {
             debugPrint('SUCCESS: Image captured on attempt ${attempt + 1}!');
-            return byteData.buffer.asUint8List();
+            final result = byteData.buffer.asUint8List();
+
+            // 画像オブジェクトを破棄してWebGLリソースを解放
+            image.dispose();
+
+            return result;
           } else {
             debugPrint('ERROR: ByteData is null on attempt ${attempt + 1}');
+            // エラーの場合も画像を破棄
+            image.dispose();
           }
         } catch (e) {
           debugPrint('ERROR during toImage attempt ${attempt + 1}: $e');
           if (attempt < 2) {
             debugPrint('Waiting before retry...');
-            await Future.delayed(const Duration(milliseconds: 1000));
+            // WebGLコンテキストのリカバリーのため、より長い待機時間
+            await Future.delayed(const Duration(milliseconds: 2000));
           }
         }
       }

--- a/lib/widgets/share_note_card_dialog.dart
+++ b/lib/widgets/share_note_card_dialog.dart
@@ -497,9 +497,10 @@ class _ShareNoteCardDialogState extends State<ShareNoteCardDialog> {
 
         successCount++;
 
-        // 次の画像キャプチャまで少し待つ
+        // 次の画像キャプチャまで少し待つ（WebGLリソースの解放を待つ）
         if (i < _repaintKeys.length - 1) {
-          await Future.delayed(const Duration(milliseconds: 300));
+          // Web環境ではより長い待機時間が必要
+          await Future.delayed(const Duration(milliseconds: 2000));
         }
       }
 
@@ -563,9 +564,10 @@ class _ShareNoteCardDialogState extends State<ShareNoteCardDialog> {
 
         allImageBytes.add(imageBytes);
 
-        // 次の画像キャプチャまで少し待つ
+        // 次の画像キャプチャまで少し待つ（WebGLリソースの解放を待つ）
         if (i < _repaintKeys.length - 1) {
-          await Future.delayed(const Duration(milliseconds: 300));
+          // Web環境ではより長い待機時間が必要
+          await Future.delayed(const Duration(milliseconds: 2000));
         }
       }
 


### PR DESCRIPTION
- Explicitly dispose Image objects after use to release WebGL resources
- Increase delay between image captures from 300ms to 2000ms
- Increase retry delay from 1000ms to 2000ms for WebGL context recovery
- Fixes "Cannot read properties of null (reading 'readPixels')" error that occurred when capturing the 4th image

This resolves the issue where capturing 4 or more images would fail due to WebGL context exhaustion in the browser.