### PR TITLE
Implement points and achievements system

### DIFF
--- a/lib/models/achievement.dart
+++ b/lib/models/achievement.dart
@@ -91,6 +91,8 @@ enum AchievementCategory {
   sharing,
   organization,
   streak,
+  level,
+  points,
 }
 
 // Predefined achievements
@@ -230,6 +232,162 @@ class AchievementDefinitions {
           pointsReward: 200,
           category: AchievementCategory.streak,
           targetValue: 30,
+        ),
+
+        // Extended Notes achievements
+        Achievement(
+          id: 'note_creator_200',
+          title: 'メモコレクター',
+          description: '200個のメモを作成する',
+          icon: '📖',
+          pointsReward: 300,
+          category: AchievementCategory.notes,
+          targetValue: 200,
+        ),
+        Achievement(
+          id: 'note_creator_500',
+          title: 'メモアーキビスト',
+          description: '500個のメモを作成する',
+          icon: '🎖️',
+          pointsReward: 500,
+          category: AchievementCategory.notes,
+          targetValue: 500,
+        ),
+        Achievement(
+          id: 'note_creator_1000',
+          title: 'メモの神',
+          description: '1000個のメモを作成する',
+          icon: '👑',
+          pointsReward: 1000,
+          category: AchievementCategory.notes,
+          targetValue: 1000,
+        ),
+
+        // Extended Category achievements
+        Achievement(
+          id: 'category_expert',
+          title: 'カテゴリエキスパート',
+          description: '10個のカテゴリを作成する',
+          icon: '🎯',
+          pointsReward: 150,
+          category: AchievementCategory.categories,
+          targetValue: 10,
+        ),
+
+        // Extended Sharing achievements
+        Achievement(
+          id: 'share_expert',
+          title: 'シェアエキスパート',
+          description: '50個のメモを共有する',
+          icon: '📡',
+          pointsReward: 250,
+          category: AchievementCategory.sharing,
+          targetValue: 50,
+        ),
+        Achievement(
+          id: 'share_legend',
+          title: 'シェアの伝説',
+          description: '100個のメモを共有する',
+          icon: '🌍',
+          pointsReward: 500,
+          category: AchievementCategory.sharing,
+          targetValue: 100,
+        ),
+
+        // Extended Streak achievements
+        Achievement(
+          id: 'streak_60',
+          title: '60日連続',
+          description: '60日連続でメモを作成する',
+          icon: '🏅',
+          pointsReward: 400,
+          category: AchievementCategory.streak,
+          targetValue: 60,
+        ),
+        Achievement(
+          id: 'streak_90',
+          title: '90日連続',
+          description: '90日連続でメモを作成する',
+          icon: '🎊',
+          pointsReward: 600,
+          category: AchievementCategory.streak,
+          targetValue: 90,
+        ),
+        Achievement(
+          id: 'streak_365',
+          title: '1年連続',
+          description: '365日連続でメモを作成する',
+          icon: '🎆',
+          pointsReward: 2000,
+          category: AchievementCategory.streak,
+          targetValue: 365,
+        ),
+
+        // Level achievements
+        Achievement(
+          id: 'level_5',
+          title: 'レベル5到達',
+          description: 'レベル5に到達する',
+          icon: '⚡',
+          pointsReward: 50,
+          category: AchievementCategory.level,
+          targetValue: 5,
+        ),
+        Achievement(
+          id: 'level_10',
+          title: 'レベル10到達',
+          description: 'レベル10に到達する',
+          icon: '✨',
+          pointsReward: 100,
+          category: AchievementCategory.level,
+          targetValue: 10,
+        ),
+        Achievement(
+          id: 'level_20',
+          title: 'レベル20到達',
+          description: 'レベル20に到達する',
+          icon: '🌠',
+          pointsReward: 200,
+          category: AchievementCategory.level,
+          targetValue: 20,
+        ),
+        Achievement(
+          id: 'level_50',
+          title: 'レベル50到達',
+          description: 'レベル50に到達する',
+          icon: '💫',
+          pointsReward: 500,
+          category: AchievementCategory.level,
+          targetValue: 50,
+        ),
+
+        // Points achievements
+        Achievement(
+          id: 'points_1000',
+          title: '1000ポイント獲得',
+          description: '累計1000ポイントを獲得する',
+          icon: '💰',
+          pointsReward: 100,
+          category: AchievementCategory.points,
+          targetValue: 1000,
+        ),
+        Achievement(
+          id: 'points_5000',
+          title: '5000ポイント獲得',
+          description: '累計5000ポイントを獲得する',
+          icon: '💎',
+          pointsReward: 250,
+          category: AchievementCategory.points,
+          targetValue: 5000,
+        ),
+        Achievement(
+          id: 'points_10000',
+          title: '10000ポイント獲得',
+          description: '累計10000ポイントを獲得する',
+          icon: '👑',
+          pointsReward: 500,
+          category: AchievementCategory.points,
+          targetValue: 10000,
         ),
       ];
 }

--- a/lib/models/leaderboard_entry.dart
+++ b/lib/models/leaderboard_entry.dart
@@ -1,0 +1,41 @@
+class LeaderboardEntry {
+  final String userId;
+  final String? userName;
+  final int totalPoints;
+  final int currentLevel;
+  final int notesCreated;
+  final int currentStreak;
+  final int rank;
+
+  LeaderboardEntry({
+    required this.userId,
+    this.userName,
+    required this.totalPoints,
+    required this.currentLevel,
+    required this.notesCreated,
+    required this.currentStreak,
+    required this.rank,
+  });
+
+  factory LeaderboardEntry.fromJson(Map<String, dynamic> json, int rank) {
+    return LeaderboardEntry(
+      userId: json['user_id'] as String,
+      userName: json['user_name'] as String?,
+      totalPoints: json['total_points'] as int,
+      currentLevel: json['current_level'] as int,
+      notesCreated: json['notes_created'] as int,
+      currentStreak: json['current_streak'] as int,
+      rank: rank,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'user_id': userId,
+        'user_name': userName,
+        'total_points': totalPoints,
+        'current_level': currentLevel,
+        'notes_created': notesCreated,
+        'current_streak': currentStreak,
+        'rank': rank,
+      };
+}

--- a/lib/models/reward.dart
+++ b/lib/models/reward.dart
@@ -1,0 +1,229 @@
+class Reward {
+  final String id;
+  final String title;
+  final String description;
+  final String icon;
+  final RewardType type;
+  final int requiredLevel;
+  final String? requiredAchievementId;
+  final int? requiredPoints;
+  bool isUnlocked;
+  DateTime? unlockedAt;
+
+  Reward({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.type,
+    this.requiredLevel = 0,
+    this.requiredAchievementId,
+    this.requiredPoints,
+    this.isUnlocked = false,
+    this.unlockedAt,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'description': description,
+        'icon': icon,
+        'type': type.name,
+        'required_level': requiredLevel,
+        'required_achievement_id': requiredAchievementId,
+        'required_points': requiredPoints,
+        'is_unlocked': isUnlocked,
+        'unlocked_at': unlockedAt?.toIso8601String(),
+      };
+
+  factory Reward.fromJson(Map<String, dynamic> json) => Reward(
+        id: json['id'],
+        title: json['title'],
+        description: json['description'],
+        icon: json['icon'],
+        type: RewardType.values.firstWhere(
+          (e) => e.name == json['type'],
+          orElse: () => RewardType.theme,
+        ),
+        requiredLevel: json['required_level'] ?? 0,
+        requiredAchievementId: json['required_achievement_id'],
+        requiredPoints: json['required_points'],
+        isUnlocked: json['is_unlocked'] ?? false,
+        unlockedAt: json['unlocked_at'] != null
+            ? DateTime.parse(json['unlocked_at'])
+            : null,
+      );
+
+  Reward copyWith({
+    String? id,
+    String? title,
+    String? description,
+    String? icon,
+    RewardType? type,
+    int? requiredLevel,
+    String? requiredAchievementId,
+    int? requiredPoints,
+    bool? isUnlocked,
+    DateTime? unlockedAt,
+  }) {
+    return Reward(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      icon: icon ?? this.icon,
+      type: type ?? this.type,
+      requiredLevel: requiredLevel ?? this.requiredLevel,
+      requiredAchievementId: requiredAchievementId ?? this.requiredAchievementId,
+      requiredPoints: requiredPoints ?? this.requiredPoints,
+      isUnlocked: isUnlocked ?? this.isUnlocked,
+      unlockedAt: unlockedAt ?? this.unlockedAt,
+    );
+  }
+}
+
+enum RewardType {
+  theme,
+  icon,
+  feature,
+  badge,
+}
+
+// Predefined rewards
+class RewardDefinitions {
+  static List<Reward> getDefaultRewards() => [
+        // Theme rewards
+        Reward(
+          id: 'theme_ocean',
+          title: 'オーシャンテーマ',
+          description: '涼しげな青のテーマ',
+          icon: '🌊',
+          type: RewardType.theme,
+          requiredLevel: 5,
+        ),
+        Reward(
+          id: 'theme_forest',
+          title: 'フォレストテーマ',
+          description: '落ち着いた緑のテーマ',
+          icon: '🌲',
+          type: RewardType.theme,
+          requiredLevel: 10,
+        ),
+        Reward(
+          id: 'theme_sunset',
+          title: 'サンセットテーマ',
+          description: '温かみのあるオレンジのテーマ',
+          icon: '🌅',
+          type: RewardType.theme,
+          requiredLevel: 15,
+        ),
+        Reward(
+          id: 'theme_galaxy',
+          title: 'ギャラクシーテーマ',
+          description: '神秘的な紫のテーマ',
+          icon: '🌌',
+          type: RewardType.theme,
+          requiredLevel: 20,
+        ),
+        Reward(
+          id: 'theme_cherry',
+          title: 'チェリーブロッサムテーマ',
+          description: '華やかな桜色のテーマ',
+          icon: '🌸',
+          type: RewardType.theme,
+          requiredLevel: 30,
+        ),
+        Reward(
+          id: 'theme_gold',
+          title: 'ゴールドテーマ',
+          description: '豪華な金色のテーマ',
+          icon: '👑',
+          type: RewardType.theme,
+          requiredLevel: 50,
+        ),
+
+        // Badge rewards
+        Reward(
+          id: 'badge_beginner',
+          title: '初心者バッジ',
+          description: 'メモアプリを使い始めました',
+          icon: '🔰',
+          type: RewardType.badge,
+          requiredLevel: 1,
+        ),
+        Reward(
+          id: 'badge_writer',
+          title: 'ライターバッジ',
+          description: '多くのメモを作成しました',
+          icon: '✍️',
+          type: RewardType.badge,
+          requiredAchievementId: 'note_creator_100',
+        ),
+        Reward(
+          id: 'badge_organizer',
+          title: 'オーガナイザーバッジ',
+          description: 'カテゴリを使いこなしています',
+          icon: '📂',
+          type: RewardType.badge,
+          requiredAchievementId: 'category_master',
+        ),
+        Reward(
+          id: 'badge_sharer',
+          title: 'シェアラーバッジ',
+          description: '積極的に共有しています',
+          icon: '🌐',
+          type: RewardType.badge,
+          requiredAchievementId: 'share_master',
+        ),
+        Reward(
+          id: 'badge_consistent',
+          title: '継続バッジ',
+          description: '毎日欠かさず記録しています',
+          icon: '🔥',
+          type: RewardType.badge,
+          requiredAchievementId: 'streak_30',
+        ),
+        Reward(
+          id: 'badge_master',
+          title: 'マスターバッジ',
+          description: 'すべてを極めました',
+          icon: '🏆',
+          type: RewardType.badge,
+          requiredLevel: 50,
+          requiredPoints: 10000,
+        ),
+
+        // Feature rewards
+        Reward(
+          id: 'feature_advanced_search',
+          title: '高度な検索',
+          description: 'より詳細な検索が可能になります',
+          icon: '🔍',
+          type: RewardType.feature,
+          requiredLevel: 3,
+        ),
+        Reward(
+          id: 'feature_bulk_actions',
+          title: '一括操作',
+          description: '複数のメモを一度に操作できます',
+          icon: '⚡',
+          type: RewardType.feature,
+          requiredLevel: 7,
+        ),
+        Reward(
+          id: 'feature_custom_templates',
+          title: 'カスタムテンプレート',
+          description: '独自のメモテンプレートを作成できます',
+          icon: '📋',
+          type: RewardType.feature,
+          requiredLevel: 12,
+        ),
+        Reward(
+          id: 'feature_export',
+          title: 'エクスポート機能',
+          description: 'メモをPDFやMarkdownで出力できます',
+          icon: '📤',
+          type: RewardType.feature,
+          requiredLevel: 15,
+        ),
+      ];
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -14,6 +14,7 @@ import '../services/auto_archive_service.dart';
 import 'settings_page.dart';
 import '../widgets/share_note_card_dialog.dart';
 import 'stats_page.dart';
+import 'leaderboard_page.dart';
 import '../services/gamification_service.dart';
 import '../models/user_stats.dart';
 import '../widgets/level_display_widget.dart';
@@ -1630,6 +1631,13 @@ class _HomePageState extends State<HomePage> {
                 ).then((_) {
                   _loadUserStats();
                 });
+              } else if (value == 'leaderboard') {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const LeaderboardPage()),
+                ).then((_) {
+                  _loadUserStats();
+                });
               } else if (value == 'settings') {
                 Navigator.push(
                   context,
@@ -1735,6 +1743,16 @@ class _HomePageState extends State<HomePage> {
                     Icon(Icons.emoji_events, color: Colors.amber),
                     SizedBox(width: 8),
                     Text('統計・実績'),
+                  ],
+                ),
+              ),
+              const PopupMenuItem(
+                value: 'leaderboard',
+                child: Row(
+                  children: [
+                    Icon(Icons.leaderboard, color: Colors.purple),
+                    SizedBox(width: 8),
+                    Text('リーダーボード'),
                   ],
                 ),
               ),

--- a/lib/pages/leaderboard_page.dart
+++ b/lib/pages/leaderboard_page.dart
@@ -1,0 +1,397 @@
+import 'package:flutter/material.dart';
+import '../main.dart';
+import '../services/gamification_service.dart';
+import '../models/leaderboard_entry.dart';
+import '../models/user_stats.dart';
+
+class LeaderboardPage extends StatefulWidget {
+  const LeaderboardPage({super.key});
+
+  @override
+  State<LeaderboardPage> createState() => _LeaderboardPageState();
+}
+
+class _LeaderboardPageState extends State<LeaderboardPage> {
+  late final GamificationService _gamificationService;
+  List<LeaderboardEntry> _entries = [];
+  bool _isLoading = true;
+  String _orderBy = 'total_points';
+  int? _userRank;
+  UserStats? _userStats;
+
+  final Map<String, String> _orderByLabels = {
+    'total_points': '総ポイント',
+    'current_level': 'レベル',
+    'notes_created': 'メモ数',
+    'current_streak': '連続記録',
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _gamificationService = GamificationService();
+    _loadLeaderboard();
+    _loadUserStats();
+  }
+
+  Future<void> _loadLeaderboard() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final entries = await _gamificationService.getLeaderboard(
+        limit: 100,
+        orderBy: _orderBy,
+      );
+      final rank = await _gamificationService.getUserRank(
+        supabase.auth.currentUser!.id,
+        orderBy: _orderBy,
+      );
+
+      if (mounted) {
+        setState(() {
+          _entries = entries;
+          _userRank = rank;
+          _isLoading = false;
+        });
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('エラー: $error')),
+        );
+      }
+    }
+  }
+
+  Future<void> _loadUserStats() async {
+    try {
+      final stats = await _gamificationService.getUserStats(
+        supabase.auth.currentUser!.id,
+      );
+      if (mounted) {
+        setState(() {
+          _userStats = stats;
+        });
+      }
+    } catch (error) {
+      // エラーは無視（ランキング表示には影響しない）
+    }
+  }
+
+  String _getRankEmoji(int rank) {
+    switch (rank) {
+      case 1:
+        return '🥇';
+      case 2:
+        return '🥈';
+      case 3:
+        return '🥉';
+      default:
+        return '';
+    }
+  }
+
+  Color _getRankColor(int rank) {
+    switch (rank) {
+      case 1:
+        return Colors.amber;
+      case 2:
+        return Colors.grey;
+      case 3:
+        return Colors.brown;
+      default:
+        return Colors.blue;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentUserId = supabase.auth.currentUser!.id;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('リーダーボード'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _loadLeaderboard,
+            tooltip: '更新',
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // ユーザーの順位表示
+          if (_userStats != null && _userRank != null)
+            Container(
+              margin: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [
+                    Theme.of(context).primaryColor,
+                    Theme.of(context).primaryColor.withOpacity(0.7),
+                  ],
+                ),
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.1),
+                    blurRadius: 8,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    width: 60,
+                    height: 60,
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.3),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(
+                      child: Text(
+                        _userRank.toString(),
+                        style: const TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'あなたの順位',
+                          style: TextStyle(
+                            color: Colors.white70,
+                            fontSize: 12,
+                          ),
+                        ),
+                        Text(
+                          '${_userRank}位',
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 24,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        'Lv.${_userStats!.currentLevel}',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text(
+                        '${_userStats!.totalPoints}pt',
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+
+          // ソート選択
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                const Text(
+                  'ランキング:',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: SegmentedButton<String>(
+                    segments: _orderByLabels.entries.map((entry) {
+                      return ButtonSegment(
+                        value: entry.key,
+                        label: Text(
+                          entry.value,
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                      );
+                    }).toList(),
+                    selected: {_orderBy},
+                    onSelectionChanged: (Set<String> selected) {
+                      setState(() {
+                        _orderBy = selected.first;
+                      });
+                      _loadLeaderboard();
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          const Divider(height: 1),
+
+          // ランキングリスト
+          Expanded(
+            child: _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _entries.isEmpty
+                    ? const Center(
+                        child: Text(
+                          'まだランキングがありません',
+                          style: TextStyle(color: Colors.grey),
+                        ),
+                      )
+                    : ListView.builder(
+                        padding: const EdgeInsets.all(8),
+                        itemCount: _entries.length,
+                        itemBuilder: (context, index) {
+                          final entry = _entries[index];
+                          final isCurrentUser = entry.userId == currentUserId;
+                          final rankEmoji = _getRankEmoji(entry.rank);
+
+                          return Card(
+                            margin: const EdgeInsets.symmetric(
+                              vertical: 4,
+                              horizontal: 8,
+                            ),
+                            color: isCurrentUser
+                                ? Theme.of(context)
+                                    .primaryColor
+                                    .withOpacity(0.1)
+                                : null,
+                            child: ListTile(
+                              leading: Container(
+                                width: 50,
+                                height: 50,
+                                decoration: BoxDecoration(
+                                  color: _getRankColor(entry.rank)
+                                      .withOpacity(0.2),
+                                  shape: BoxShape.circle,
+                                  border: Border.all(
+                                    color: _getRankColor(entry.rank),
+                                    width: 2,
+                                  ),
+                                ),
+                                child: Center(
+                                  child: Text(
+                                    rankEmoji.isNotEmpty
+                                        ? rankEmoji
+                                        : '${entry.rank}',
+                                    style: TextStyle(
+                                      fontSize: rankEmoji.isNotEmpty ? 24 : 18,
+                                      fontWeight: FontWeight.bold,
+                                      color: rankEmoji.isEmpty
+                                          ? _getRankColor(entry.rank)
+                                          : null,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              title: Row(
+                                children: [
+                                  Text(
+                                    entry.userName ?? 'ユーザー',
+                                    style: TextStyle(
+                                      fontWeight: FontWeight.bold,
+                                      color: isCurrentUser
+                                          ? Theme.of(context).primaryColor
+                                          : null,
+                                    ),
+                                  ),
+                                  if (isCurrentUser) ...[
+                                    const SizedBox(width: 8),
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 8,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: Theme.of(context).primaryColor,
+                                        borderRadius: BorderRadius.circular(12),
+                                      ),
+                                      child: const Text(
+                                        'あなた',
+                                        style: TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 10,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ],
+                              ),
+                              subtitle: Text(
+                                'Lv.${entry.currentLevel} • ${entry.notesCreated}メモ • ${entry.currentStreak}日連続',
+                                style: const TextStyle(fontSize: 12),
+                              ),
+                              trailing: Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                crossAxisAlignment: CrossAxisAlignment.end,
+                                children: [
+                                  Text(
+                                    _getDisplayValue(entry),
+                                    style: TextStyle(
+                                      fontSize: 20,
+                                      fontWeight: FontWeight.bold,
+                                      color: _getRankColor(entry.rank),
+                                    ),
+                                  ),
+                                  Text(
+                                    _getDisplayLabel(),
+                                    style: const TextStyle(
+                                      fontSize: 11,
+                                      color: Colors.grey,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _getDisplayValue(LeaderboardEntry entry) {
+    switch (_orderBy) {
+      case 'total_points':
+        return '${entry.totalPoints}pt';
+      case 'current_level':
+        return 'Lv.${entry.currentLevel}';
+      case 'notes_created':
+        return '${entry.notesCreated}個';
+      case 'current_streak':
+        return '${entry.currentStreak}日';
+      default:
+        return '';
+    }
+  }
+
+  String _getDisplayLabel() {
+    return _orderByLabels[_orderBy] ?? '';
+  }
+}

--- a/lib/pages/rewards_page.dart
+++ b/lib/pages/rewards_page.dart
@@ -1,0 +1,409 @@
+import 'package:flutter/material.dart';
+import '../main.dart';
+import '../services/gamification_service.dart';
+import '../models/reward.dart';
+import '../models/user_stats.dart';
+
+class RewardsPage extends StatefulWidget {
+  const RewardsPage({super.key});
+
+  @override
+  State<RewardsPage> createState() => _RewardsPageState();
+}
+
+class _RewardsPageState extends State<RewardsPage> {
+  late final GamificationService _gamificationService;
+  List<Reward> _rewards = [];
+  UserStats? _userStats;
+  bool _isLoading = true;
+  RewardType? _filterType;
+
+  @override
+  void initState() {
+    super.initState();
+    _gamificationService = GamificationService();
+    _loadRewards();
+    _loadUserStats();
+  }
+
+  Future<void> _loadRewards() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final rewards = await _gamificationService.getUserRewards(
+        supabase.auth.currentUser!.id,
+      );
+
+      if (mounted) {
+        setState(() {
+          _rewards = rewards;
+          _isLoading = false;
+        });
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('エラー: $error')),
+        );
+      }
+    }
+  }
+
+  Future<void> _loadUserStats() async {
+    try {
+      final stats = await _gamificationService.getUserStats(
+        supabase.auth.currentUser!.id,
+      );
+      if (mounted) {
+        setState(() {
+          _userStats = stats;
+        });
+      }
+    } catch (error) {
+      // エラーは無視
+    }
+  }
+
+  List<Reward> get _filteredRewards {
+    if (_filterType == null) return _rewards;
+    return _rewards.where((r) => r.type == _filterType).toList();
+  }
+
+  int get _unlockedCount => _filteredRewards.where((r) => r.isUnlocked).length;
+  int get _totalCount => _filteredRewards.length;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('報酬'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _loadRewards,
+            tooltip: '更新',
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // 統計表示
+          Container(
+            margin: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [
+                  Colors.deepPurple,
+                  Colors.deepPurple.withOpacity(0.7),
+                ],
+              ),
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.1),
+                  blurRadius: 8,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    _buildStatItem(
+                      '🏆',
+                      '$_unlockedCount',
+                      'アンロック済み',
+                    ),
+                    Container(
+                      width: 1,
+                      height: 40,
+                      color: Colors.white.withOpacity(0.3),
+                    ),
+                    _buildStatItem(
+                      '🎁',
+                      '$_totalCount',
+                      '全報酬',
+                    ),
+                    Container(
+                      width: 1,
+                      height: 40,
+                      color: Colors.white.withOpacity(0.3),
+                    ),
+                    _buildStatItem(
+                      '⭐',
+                      '${((_unlockedCount / _totalCount) * 100).toStringAsFixed(0)}%',
+                      '達成率',
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+
+          // フィルター
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  _buildFilterChip(null, 'すべて', Icons.grid_view),
+                  const SizedBox(width: 8),
+                  _buildFilterChip(
+                      RewardType.theme, 'テーマ', Icons.palette),
+                  const SizedBox(width: 8),
+                  _buildFilterChip(
+                      RewardType.badge, 'バッジ', Icons.military_tech),
+                  const SizedBox(width: 8),
+                  _buildFilterChip(
+                      RewardType.feature, '機能', Icons.star),
+                ],
+              ),
+            ),
+          ),
+
+          const Divider(height: 1),
+
+          // 報酬リスト
+          Expanded(
+            child: _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _filteredRewards.isEmpty
+                    ? const Center(
+                        child: Text(
+                          '報酬がありません',
+                          style: TextStyle(color: Colors.grey),
+                        ),
+                      )
+                    : GridView.builder(
+                        padding: const EdgeInsets.all(16),
+                        gridDelegate:
+                            const SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: 2,
+                          crossAxisSpacing: 12,
+                          mainAxisSpacing: 12,
+                          childAspectRatio: 0.85,
+                        ),
+                        itemCount: _filteredRewards.length,
+                        itemBuilder: (context, index) {
+                          final reward = _filteredRewards[index];
+                          return _buildRewardCard(reward);
+                        },
+                      ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatItem(String icon, String value, String label) {
+    return Column(
+      children: [
+        Text(
+          icon,
+          style: const TextStyle(fontSize: 32),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: const TextStyle(
+            fontSize: 24,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 12,
+            color: Colors.white70,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFilterChip(RewardType? type, String label, IconData icon) {
+    final isSelected = _filterType == type;
+    return FilterChip(
+      selected: isSelected,
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16),
+          const SizedBox(width: 4),
+          Text(label),
+        ],
+      ),
+      onSelected: (selected) {
+        setState(() {
+          _filterType = selected ? type : null;
+        });
+      },
+    );
+  }
+
+  Widget _buildRewardCard(Reward reward) {
+    return Card(
+      elevation: reward.isUnlocked ? 4 : 1,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          gradient: reward.isUnlocked
+              ? LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [
+                    _getRewardColor(reward.type).withOpacity(0.3),
+                    _getRewardColor(reward.type).withOpacity(0.1),
+                  ],
+                )
+              : null,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // アイコン
+              Stack(
+                alignment: Alignment.center,
+                children: [
+                  Container(
+                    width: 80,
+                    height: 80,
+                    decoration: BoxDecoration(
+                      color: reward.isUnlocked
+                          ? _getRewardColor(reward.type).withOpacity(0.2)
+                          : Colors.grey.withOpacity(0.1),
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: reward.isUnlocked
+                            ? _getRewardColor(reward.type)
+                            : Colors.grey,
+                        width: 3,
+                      ),
+                    ),
+                    child: Center(
+                      child: Text(
+                        reward.icon,
+                        style: TextStyle(
+                          fontSize: 36,
+                          color: reward.isUnlocked ? null : Colors.grey,
+                        ),
+                      ),
+                    ),
+                  ),
+                  if (!reward.isUnlocked)
+                    Container(
+                      width: 80,
+                      height: 80,
+                      decoration: BoxDecoration(
+                        color: Colors.black.withOpacity(0.5),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Center(
+                        child: Icon(
+                          Icons.lock,
+                          color: Colors.white,
+                          size: 32,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 12),
+
+              // タイトル
+              Text(
+                reward.title,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.bold,
+                  color: reward.isUnlocked ? null : Colors.grey,
+                ),
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 4),
+
+              // 説明
+              Text(
+                reward.description,
+                style: TextStyle(
+                  fontSize: 11,
+                  color: reward.isUnlocked
+                      ? Colors.grey[600]
+                      : Colors.grey[400],
+                ),
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const Spacer(),
+
+              // 要件
+              if (!reward.isUnlocked) ...[
+                const Divider(),
+                Text(
+                  _getRequirementText(reward),
+                  style: const TextStyle(
+                    fontSize: 10,
+                    color: Colors.orange,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _getRewardColor(RewardType type) {
+    switch (type) {
+      case RewardType.theme:
+        return Colors.purple;
+      case RewardType.badge:
+        return Colors.amber;
+      case RewardType.feature:
+        return Colors.blue;
+      case RewardType.icon:
+        return Colors.green;
+    }
+  }
+
+  String _getRequirementText(Reward reward) {
+    final requirements = <String>[];
+
+    if (reward.requiredLevel > 0) {
+      final currentLevel = _userStats?.currentLevel ?? 1;
+      requirements.add('Lv.${reward.requiredLevel} (現在: Lv.$currentLevel)');
+    }
+
+    if (reward.requiredPoints != null) {
+      final currentPoints = _userStats?.totalPoints ?? 0;
+      requirements
+          .add('${reward.requiredPoints}pt (現在: ${currentPoints}pt)');
+    }
+
+    if (reward.requiredAchievementId != null) {
+      requirements.add('特定の実績が必要');
+    }
+
+    return requirements.join('\n');
+  }
+}

--- a/lib/pages/share_note_dialog.dart
+++ b/lib/pages/share_note_dialog.dart
@@ -3,6 +3,8 @@ import 'package:flutter/services.dart';
 import '../main.dart';
 import '../models/note.dart';
 import '../models/shared_note.dart';
+import '../services/gamification_service.dart'; // ゲーミフィケーション追加
+import '../widgets/achievement_notification.dart'; // 実績通知追加
 
 class ShareNoteDialog extends StatefulWidget {
   final Note note;
@@ -20,9 +22,13 @@ class _ShareNoteDialogState extends State<ShareNoteDialog> {
   DateTime? _expiresAt;
   bool _isCreating = false;
 
+  // ゲーミフィケーション用
+  late final GamificationService _gamificationService;
+
   @override
   void initState() {
     super.initState();
+    _gamificationService = GamificationService();
     _loadShares();
   }
 
@@ -98,6 +104,11 @@ class _ShareNoteDialogState extends State<ShareNoteDialog> {
 
       await _loadShares();
 
+      // ゲーミフィケーション: 共有イベント
+      final achievements = await _gamificationService.onNoteShared(
+        supabase.auth.currentUser!.id,
+      );
+
       if (!mounted) {
         return;
       }
@@ -110,6 +121,14 @@ class _ShareNoteDialogState extends State<ShareNoteDialog> {
       if (!context.mounted) {
         // ← contextチェックを追加
         return;
+      }
+
+      // 実績通知を表示
+      for (final achievement in achievements) {
+        AchievementNotification.show(
+          context: context,
+          achievement: achievement,
+        );
       }
 
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/pages/stats_page.dart
+++ b/lib/pages/stats_page.dart
@@ -6,6 +6,7 @@ import '../services/gamification_service.dart';
 import '../widgets/level_display_widget.dart';
 import '../widgets/stats_overview_widget.dart';
 import '../widgets/achievement_card_widget.dart';
+import 'rewards_page.dart';
 
 class StatsPage extends StatefulWidget {
   const StatsPage({Key? key}) : super(key: key);
@@ -79,6 +80,16 @@ class _StatsPageState extends State<StatsPage> {
       appBar: AppBar(
         title: const Text('統計・実績'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.card_giftcard),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const RewardsPage()),
+              );
+            },
+            tooltip: '報酬',
+          ),
           IconButton(
             icon: const Icon(Icons.refresh),
             onPressed: _loadData,


### PR DESCRIPTION
This commit significantly expands the gamification features:

1. Event Integration
   - Automatically award points and check achievements on user actions
   - Integrated into note creation, category creation, sharing, favorites, reminders, and attachments
   - Display achievement notifications when unlocked

2. Additional Achievements (17 → 31 achievements)
   - Extended note achievements: 200, 500, 1000 notes
   - Extended category achievement: 10 categories
   - Extended sharing achievements: 50, 100 shares
   - Extended streak achievements: 60, 90, 365 days
   - New level achievements: Level 5, 10, 20, 50
   - New points achievements: 1000, 5000, 10000 points
   - Added level and points achievement categories

3. Leaderboard Feature
   - Global rankings by points, level, notes, or streak
   - User rank display
   - Multiple sorting options
   - Visual ranking with medals for top 3 users

4. Reward System
   - Theme rewards unlockable at various levels
   - Badge rewards for achievements
   - Feature rewards for unlocking special functionality
   - Reward page showing locked/unlocked status
   - Requirement display for locked rewards

Files changed:
- Enhanced gamification service with reward and leaderboard methods
- Updated achievement definitions and categories
- Integrated event handlers in note editor, categories, and sharing
- Added leaderboard entry and reward models
- Created leaderboard and rewards pages
- Added navigation links to new features