### PR TITLE
Fix Flutter compilation errors in achievement notifications

### DIFF
--- a/lib/services/gamification_service.dart
+++ b/lib/services/gamification_service.dart
@@ -566,7 +566,7 @@ class GamificationService {
         }
 
         // Check points requirement
-        if (reward.requiredPoints != null && stats.totalPoints < reward.requiredPoints) {
+        if (reward.requiredPoints != null && stats.totalPoints < reward.requiredPoints!) {
           isUnlocked = false;
         }
 

--- a/lib/widgets/achievement_notification.dart
+++ b/lib/widgets/achievement_notification.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/achievement.dart';
 
 class AchievementNotification {
-  static void show(BuildContext context, Achievement achievement) {
+  static void show({required BuildContext context, required Achievement achievement}) {
     final overlay = Overlay.of(context);
     late OverlayEntry overlayEntry;
 
@@ -38,7 +38,7 @@ class AchievementNotification {
     for (var i = 0; i < achievements.length; i++) {
       Future.delayed(Duration(milliseconds: i * 300), () {
         if (context.mounted) {
-          show(context, achievements[i]);
+          show(context: context, achievement: achievements[i]);
         }
       });
     }


### PR DESCRIPTION
…issue

- Changed AchievementNotification.show() signature to use named parameters instead of positional
- Updated internal call in showMultiple() to use named parameters
- Fixed nullable int comparison error in gamification_service.dart by adding null assertion operator

This resolves all 4 compilation errors:
- lib/pages/note_editor_page.dart:283:35
- lib/pages/categories_page.dart:366:55
- lib/pages/share_note_dialog.dart:128:37
- lib/services/gamification_service.dart:569:73