### PR TITLE
Fix RenderFlex overflow in stats overview widget

### DIFF
--- a/lib/widgets/stats_overview_widget.dart
+++ b/lib/widgets/stats_overview_widget.dart
@@ -42,7 +42,7 @@ class StatsOverviewWidget extends StatelessWidget {
               physics: const NeverScrollableScrollPhysics(),
               mainAxisSpacing: 12,
               crossAxisSpacing: 12,
-              childAspectRatio: 2.5,
+              childAspectRatio: 2.8,
               children: [
                 _buildStatItem(
                   context,
@@ -148,6 +148,7 @@ class StatsOverviewWidget extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
                   label,
@@ -155,6 +156,7 @@ class StatsOverviewWidget extends StatelessWidget {
                     color: theme.colorScheme.onSurface.withOpacity(0.7),
                   ),
                   overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
                 ),
                 Text(
                   value,
@@ -162,6 +164,8 @@ class StatsOverviewWidget extends StatelessWidget {
                     fontWeight: FontWeight.bold,
                     color: color,
                   ),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
                 ),
               ],
             ),


### PR DESCRIPTION
- Add mainAxisSize: MainAxisSize.min to Column to prevent expansion
- Add maxLines and overflow handling to both text widgets
- Increase childAspectRatio from 2.5 to 2.8 for more vertical space
- Resolves 12-pixel overflow error on the bottom of stat items