### PR TITLE
Fix Column overflow in stats overview widget

### DIFF
--- a/lib/widgets/stats_overview_widget.dart
+++ b/lib/widgets/stats_overview_widget.dart
@@ -42,7 +42,7 @@ class StatsOverviewWidget extends StatelessWidget {
               physics: const NeverScrollableScrollPhysics(),
               mainAxisSpacing: 12,
               crossAxisSpacing: 12,
-              childAspectRatio: 2.8,
+              childAspectRatio: 2.2,
               children: [
                 _buildStatItem(
                   context,


### PR DESCRIPTION
Changed GridView childAspectRatio from 2.8 to 2.2 to provide more vertical space for stat items. This fixes the RenderFlex overflow of 18 pixels that occurred when the label and value text couldn't fit within the constrained height.