### PR TITLE
Refactor large file and fix layout overflow

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -5,7 +5,6 @@ import '../models/category.dart';
 import '../models/sort_type.dart';
 import 'auth_page.dart';
 import 'note_editor_page.dart';
-import 'categories_page.dart';
 import 'share_note_dialog.dart';
 import '../widgets/advanced_search_dialog.dart';
 import '../services/search_history_service.dart';
@@ -22,6 +21,8 @@ import '../utils/date_formatter.dart';
 import '../widgets/home_page/sort_dialog.dart';
 import '../widgets/home_page/date_filter_dialog.dart';
 import '../widgets/home_page/reminder_filter_dialog.dart';
+import '../widgets/home_page/user_stats_header.dart';
+import '../widgets/home_page/empty_state_view.dart';
 import '../widgets/home_page/category_filter_dialog.dart';
 import '../widgets/home_page/reminder_stats_banner.dart';
 import '../widgets/home_page/filter_chips_area.dart';
@@ -579,116 +580,9 @@ class _HomePageState extends State<HomePage> {
               children: [
                 // レベル表示（ゲーミフィケーション）
                 if (_userStats != null)
-                  GestureDetector(
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (_) => const StatsPage()),
-                      ).then((_) {
-                        _loadUserStats();
-                      });
-                    },
-                    child: Container(
-                      width: double.infinity,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 12,
-                      ),
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: [
-                            Theme.of(context).colorScheme.primaryContainer,
-                            Theme.of(context).colorScheme.secondaryContainer,
-                          ],
-                        ),
-                        border: Border(
-                          bottom: BorderSide(
-                            color: Theme.of(context).colorScheme.primary,
-                            width: 2,
-                          ),
-                        ),
-                      ),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  children: [
-                                    Text(
-                                      'レベル ${_userStats!.currentLevel}',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .titleMedium
-                                          ?.copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: Theme.of(context)
-                                                .colorScheme
-                                                .primary,
-                                          ),
-                                    ),
-                                    const SizedBox(width: 8),
-                                    Text(
-                                      _userStats!.levelTitle,
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .bodySmall
-                                          ?.copyWith(
-                                            color: Theme.of(context)
-                                                .colorScheme
-                                                .onPrimaryContainer,
-                                          ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 4),
-                                Row(
-                                  children: [
-                                    Icon(
-                                      Icons.stars,
-                                      size: 16,
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
-                                    ),
-                                    const SizedBox(width: 4),
-                                    Text(
-                                      '${_userStats!.totalPoints} pt',
-                                      style:
-                                          Theme.of(context).textTheme.bodySmall,
-                                    ),
-                                    if (_userStats!.currentStreak > 0) ...[
-                                      const SizedBox(width: 12),
-                                      Icon(
-                                        Icons.local_fire_department,
-                                        size: 16,
-                                        color: Colors.orange,
-                                      ),
-                                      const SizedBox(width: 4),
-                                      Text(
-                                        '${_userStats!.currentStreak}日連続',
-                                        style: Theme.of(context)
-                                            .textTheme
-                                            .bodySmall
-                                            ?.copyWith(
-                                              color: Colors.orange,
-                                              fontWeight: FontWeight.bold,
-                                            ),
-                                      ),
-                                    ],
-                                  ],
-                                ),
-                              ],
-                            ),
-                          ),
-                          Icon(
-                            Icons.chevron_right,
-                            color:
-                                Theme.of(context).colorScheme.onPrimaryContainer,
-                          ),
-                        ],
-                      ),
-                    ),
+                  UserStatsHeader(
+                    userStats: _userStats!,
+                    onStatsUpdated: _loadUserStats,
                   ),
                 // リマインダー統計バナー
                 ReminderStatsBanner(
@@ -767,91 +661,23 @@ class _HomePageState extends State<HomePage> {
                 // メモ一覧
                 Expanded(
                   child: _filteredNotes.isEmpty
-                      ? Center(
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Icon(
-                                hasAnyFilter || _showFavoritesOnly
-                                    ? Icons.search_off
-                                    : Icons.note_add_outlined,
-                                size: 80,
-                                color: Theme.of(context).brightness ==
-                                        Brightness.dark
-                                    ? Colors.grey[700]
-                                    : Colors.grey[400],
-                              ),
-                              const SizedBox(height: 16),
-                              Text(
-                                hasAnyFilter || _showFavoritesOnly
-                                    ? '該当するメモが見つかりません'
-                                    : 'メモがありません',
-                                style: TextStyle(
-                                  fontSize: 18,
-                                  color: Colors.grey[600],
-                                ),
-                              ),
-                              const SizedBox(height: 8),
-                              Text(
-                                hasAnyFilter || _showFavoritesOnly
-                                    ? 'フィルター条件を変更してみてください'
-                                    : '右下の + ボタンから新しいメモを作成\n📌でピン留めして重要なメモを上部に固定',
-                                style: TextStyle(
-                                  fontSize: 14,
-                                  color: Colors.grey[500],
-                                ),
-                                textAlign: TextAlign.center,
-                              ),
-                              // リマインダーフィルター時の特別メッセージ
-                              if (_reminderFilter != null &&
-                                  _notes.isNotEmpty) ...[
-                                const SizedBox(height: 16),
-                                Text(
-                                  _reminderFilter == 'overdue'
-                                      ? '期限切れのメモはありません'
-                                      : _reminderFilter == 'today'
-                                          ? '今日のリマインダーはありません'
-                                          : '24時間以内のリマインダーはありません',
-                                  style: TextStyle(
-                                    fontSize: 14,
-                                    color: Colors.grey[500],
-                                  ),
-                                ),
-                                const SizedBox(height: 8),
-                                ElevatedButton.icon(
-                                  icon: const Icon(Icons.alarm_add),
-                                  label: const Text('メモにリマインダーを設定'),
-                                  onPressed: () {
-                                    setState(() {
-                                      _reminderFilter = null;
-                                      _applyFilters();
-                                    });
-                                  },
-                                ),
-                              ],
-                              if (_showFavoritesOnly && _notes.isNotEmpty) ...[
-                                const SizedBox(height: 16),
-                                Text(
-                                  'お気に入りメモがまだありません',
-                                  style: TextStyle(
-                                    fontSize: 14,
-                                    color: Colors.grey[500],
-                                  ),
-                                ),
-                                const SizedBox(height: 8),
-                                ElevatedButton.icon(
-                                  icon: const Icon(Icons.star_border),
-                                  label: const Text('メモにスターをつけてみましょう'),
-                                  onPressed: () {
-                                    setState(() {
-                                      _showFavoritesOnly = false;
-                                      _applyFilters();
-                                    });
-                                  },
-                                ),
-                              ],
-                            ],
-                          ),
+                      ? EmptyStateView(
+                          hasAnyFilter: hasAnyFilter,
+                          showFavoritesOnly: _showFavoritesOnly,
+                          reminderFilter: _reminderFilter,
+                          allNotes: _notes,
+                          onClearReminderFilter: () {
+                            setState(() {
+                              _reminderFilter = null;
+                              _applyFilters();
+                            });
+                          },
+                          onClearFavoritesFilter: () {
+                            setState(() {
+                              _showFavoritesOnly = false;
+                              _applyFilters();
+                            });
+                          },
                         )
                       : RefreshIndicator(
                           onRefresh: () async {

--- a/lib/utils/content_chunk_processor.dart
+++ b/lib/utils/content_chunk_processor.dart
@@ -1,0 +1,49 @@
+import '../models/share_card_content_mode.dart';
+
+/// コンテンツを複数のチャンクに分割するユーティリティクラス
+class ContentChunkProcessor {
+  /// コンテンツを複数のチャンクに分割（動的文字数制限）
+  static List<String> splitContent(
+    String content,
+    ShareCardContentMode contentMode,
+  ) {
+    final maxChars = contentMode.maxCharsPerPage;
+
+    if (content.length <= maxChars) {
+      return [content];
+    }
+
+    final List<String> chunks = [];
+    int startIndex = 0;
+
+    while (startIndex < content.length) {
+      int endIndex = startIndex + maxChars;
+
+      // 最後のチャンクの場合
+      if (endIndex >= content.length) {
+        chunks.add(content.substring(startIndex));
+        break;
+      }
+
+      // 文の区切りで分割を試みる
+      int splitIndex = endIndex;
+
+      // 句点、改行、スペースで区切りを探す
+      for (int i = endIndex; i > startIndex + (maxChars ~/ 2); i--) {
+        if (i < content.length &&
+            (content[i] == '。' ||
+                content[i] == '.' ||
+                content[i] == '\n' ||
+                content[i] == ' ')) {
+          splitIndex = i + 1;
+          break;
+        }
+      }
+
+      chunks.add(content.substring(startIndex, splitIndex));
+      startIndex = splitIndex;
+    }
+
+    return chunks;
+  }
+}

--- a/lib/widgets/home_page/empty_state_view.dart
+++ b/lib/widgets/home_page/empty_state_view.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import '../../models/note.dart';
+
+/// ホームページの空状態表示ウィジェット
+/// メモがない場合やフィルター結果が空の場合に表示
+class EmptyStateView extends StatelessWidget {
+  final bool hasAnyFilter;
+  final bool showFavoritesOnly;
+  final String? reminderFilter;
+  final List<Note> allNotes;
+  final VoidCallback onClearReminderFilter;
+  final VoidCallback onClearFavoritesFilter;
+
+  const EmptyStateView({
+    Key? key,
+    required this.hasAnyFilter,
+    required this.showFavoritesOnly,
+    required this.reminderFilter,
+    required this.allNotes,
+    required this.onClearReminderFilter,
+    required this.onClearFavoritesFilter,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            hasAnyFilter || showFavoritesOnly
+                ? Icons.search_off
+                : Icons.note_add_outlined,
+            size: 80,
+            color: Theme.of(context).brightness == Brightness.dark
+                ? Colors.grey[700]
+                : Colors.grey[400],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            hasAnyFilter || showFavoritesOnly
+                ? '該当するメモが見つかりません'
+                : 'メモがありません',
+            style: TextStyle(
+              fontSize: 18,
+              color: Colors.grey[600],
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            hasAnyFilter || showFavoritesOnly
+                ? 'フィルター条件を変更してみてください'
+                : '右下の + ボタンから新しいメモを作成\n📌でピン留めして重要なメモを上部に固定',
+            style: TextStyle(
+              fontSize: 14,
+              color: Colors.grey[500],
+            ),
+            textAlign: TextAlign.center,
+          ),
+          // リマインダーフィルター時の特別メッセージ
+          if (reminderFilter != null && allNotes.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            Text(
+              reminderFilter == 'overdue'
+                  ? '期限切れのメモはありません'
+                  : reminderFilter == 'today'
+                      ? '今日のリマインダーはありません'
+                      : '24時間以内のリマインダーはありません',
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.grey[500],
+              ),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.alarm_add),
+              label: const Text('メモにリマインダーを設定'),
+              onPressed: onClearReminderFilter,
+            ),
+          ],
+          if (showFavoritesOnly && allNotes.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            Text(
+              'お気に入りメモがまだありません',
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.grey[500],
+              ),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.star_border),
+              label: const Text('メモにスターをつけてみましょう'),
+              onPressed: onClearFavoritesFilter,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/home_page/user_stats_header.dart
+++ b/lib/widgets/home_page/user_stats_header.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import '../../models/user_stats.dart';
+import '../../pages/stats_page.dart';
+
+/// ホームページのユーザー統計ヘッダーウィジェット
+/// レベル、ポイント、連続日数を表示し、タップで統計ページに遷移
+class UserStatsHeader extends StatelessWidget {
+  final UserStats userStats;
+  final VoidCallback onStatsUpdated;
+
+  const UserStatsHeader({
+    Key? key,
+    required this.userStats,
+    required this.onStatsUpdated,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const StatsPage()),
+        ).then((_) {
+          onStatsUpdated();
+        });
+      },
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 12,
+        ),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Theme.of(context).colorScheme.primaryContainer,
+              Theme.of(context).colorScheme.secondaryContainer,
+            ],
+          ),
+          border: Border(
+            bottom: BorderSide(
+              color: Theme.of(context).colorScheme.primary,
+              width: 2,
+            ),
+          ),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        'レベル ${userStats.currentLevel}',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        userStats.levelTitle,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onPrimaryContainer,
+                            ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.stars,
+                        size: 16,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        '${userStats.totalPoints} pt',
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                      if (userStats.currentStreak > 0) ...[
+                        const SizedBox(width: 12),
+                        Icon(
+                          Icons.local_fire_department,
+                          size: 16,
+                          color: Colors.orange,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          '${userStats.currentStreak}日連続',
+                          style:
+                              Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Colors.orange,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              color: Theme.of(context).colorScheme.onPrimaryContainer,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/share_note_card_dialog.dart
+++ b/lib/widgets/share_note_card_dialog.dart
@@ -8,6 +8,7 @@ import '../models/category.dart';
 import '../models/card_template.dart' as template;
 import '../widgets/note_card_widget.dart';
 import '../services/note_card_service.dart';
+import '../utils/content_chunk_processor.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 // Web用
@@ -404,48 +405,12 @@ class _ShareNoteCardDialogState extends State<ShareNoteCardDialog> {
     );
   }
 
-  // コンテンツを複数のチャンクに分割（動的文字数制限）
-  List<String> _splitContent(String content) {
-    final maxChars = _selectedContentMode.maxCharsPerPage;
-
-    if (content.length <= maxChars) {
-      return [content];
-    }
-
-    final List<String> chunks = [];
-    int startIndex = 0;
-
-    while (startIndex < content.length) {
-      int endIndex = startIndex + maxChars;
-
-      // 最後のチャンクの場合
-      if (endIndex >= content.length) {
-        chunks.add(content.substring(startIndex));
-        break;
-      }
-
-      // 文の区切りで分割を試みる
-      int splitIndex = endIndex;
-
-      // 句点、改行、スペースで区切りを探す
-      for (int i = endIndex; i > startIndex + (maxChars ~/ 2); i--) {
-        if (i < content.length && (content[i] == '。' || content[i] == '.' ||
-            content[i] == '\n' || content[i] == ' ')) {
-          splitIndex = i + 1;
-          break;
-        }
-      }
-
-      chunks.add(content.substring(startIndex, splitIndex));
-      startIndex = splitIndex;
-    }
-
-    return chunks;
-  }
-
   // 初期化または再構築時にキーとチャンクを準備
   void _prepareContentChunks() {
-    _contentChunks = _splitContent(widget.note.content);
+    _contentChunks = ContentChunkProcessor.splitContent(
+      widget.note.content,
+      _selectedContentMode,
+    );
 
     // 必要な数のGlobalKeyを生成
     _repaintKeys.clear();

--- a/lib/widgets/stats_overview_widget.dart
+++ b/lib/widgets/stats_overview_widget.dart
@@ -42,7 +42,7 @@ class StatsOverviewWidget extends StatelessWidget {
               physics: const NeverScrollableScrollPhysics(),
               mainAxisSpacing: 12,
               crossAxisSpacing: 12,
-              childAspectRatio: 2.5,
+              childAspectRatio: 3.0,
               children: [
                 _buildStatItem(
                   context,
@@ -127,7 +127,7 @@ class StatsOverviewWidget extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Container(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         color: color.withOpacity(0.1),
         borderRadius: BorderRadius.circular(8),
@@ -141,7 +141,7 @@ class StatsOverviewWidget extends StatelessWidget {
           Icon(
             icon,
             color: color,
-            size: 24,
+            size: 20,
           ),
           const SizedBox(width: 8),
           Expanded(
@@ -154,13 +154,15 @@ class StatsOverviewWidget extends StatelessWidget {
                   label,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurface.withOpacity(0.7),
+                    fontSize: 11,
                   ),
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1,
                 ),
+                const SizedBox(height: 2),
                 Text(
                   value,
-                  style: theme.textTheme.titleLarge?.copyWith(
+                  style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                     color: color,
                   ),


### PR DESCRIPTION
- Fix RenderFlex overflow in stats_overview_widget.dart by adjusting childAspectRatio and padding
- Remove unused import from home_page.dart
- Extract UserStatsHeader and EmptyStateView widgets from home_page.dart (959→785 lines)
- Extract ContentChunkProcessor utility from share_note_card_dialog.dart (845→810 lines)
- Improve code organization and maintainability