### PR TITLE
Improve SNS sharing with quotes and images

### DIFF
--- a/lib/models/philosopher_quote.dart
+++ b/lib/models/philosopher_quote.dart
@@ -1,0 +1,122 @@
+/// 哲学者の名言データモデル
+class PhilosopherQuote {
+  final String quote;
+  final String author;
+  final String imageUrl;
+  final String? authorDescription; // オプション: 哲学者の簡単な説明
+
+  const PhilosopherQuote({
+    required this.quote,
+    required this.author,
+    required this.imageUrl,
+    this.authorDescription,
+  });
+
+  /// 哲学者の名言リスト（日本語）
+  static const List<PhilosopherQuote> quotes = [
+    PhilosopherQuote(
+      quote: '何かを学ぶとき、実際にそれを行なうことによって我々は学ぶ。',
+      author: 'アリストテレス',
+      imageUrl: 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?w=800&h=800&fit=crop',
+      authorDescription: '古代ギリシアの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '無知の知。私が知っているのは、自分が何も知らないということだけだ。',
+      author: 'ソクラテス',
+      imageUrl: 'https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?w=800&h=800&fit=crop',
+      authorDescription: '古代ギリシアの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '知恵の始まりは定義にあり。',
+      author: 'プラトン',
+      imageUrl: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=800&h=800&fit=crop',
+      authorDescription: '古代ギリシアの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '我思う、ゆえに我あり。',
+      author: 'ルネ・デカルト',
+      imageUrl: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=800&h=800&fit=crop',
+      authorDescription: '近世哲学の祖',
+    ),
+    PhilosopherQuote(
+      quote: '経験なき概念は空虚であり、概念なき経験は盲目である。',
+      author: 'イマヌエル・カント',
+      imageUrl: 'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?w=800&h=800&fit=crop',
+      authorDescription: 'ドイツの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '深淵を覗く時、深淵もまたこちらを覗いている。',
+      author: 'フリードリヒ・ニーチェ',
+      imageUrl: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=800&h=800&fit=crop',
+      authorDescription: 'ドイツの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '千里の道も一歩から。',
+      author: '老子',
+      imageUrl: 'https://images.unsplash.com/photo-1552374196-1ab2a1c593e8?w=800&h=800&fit=crop',
+      authorDescription: '古代中国の哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '学びて思わざれば則ち罔し、思いて学ばざれば則ち殆し。',
+      author: '孔子',
+      imageUrl: 'https://images.unsplash.com/photo-1557862921-37829c790f19?w=800&h=800&fit=crop',
+      authorDescription: '古代中国の思想家',
+    ),
+    PhilosopherQuote(
+      quote: '人間は自由の刑に処せられている。',
+      author: 'ジャン＝ポール・サルトル',
+      imageUrl: 'https://images.unsplash.com/photo-1528892952291-009c663ce843?w=800&h=800&fit=crop',
+      authorDescription: 'フランスの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '汝自身を知れ。',
+      author: 'ソクラテス',
+      imageUrl: 'https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?w=800&h=800&fit=crop',
+      authorDescription: '古代ギリシアの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '習慣は第二の天性なり。',
+      author: 'アリストテレス',
+      imageUrl: 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?w=800&h=800&fit=crop',
+      authorDescription: '古代ギリシアの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '真の知恵とは、自分が無知であることを知ることである。',
+      author: 'ソクラテス',
+      imageUrl: 'https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?w=800&h=800&fit=crop',
+      authorDescription: '古代ギリシアの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '人間は考える葦である。',
+      author: 'ブレーズ・パスカル',
+      imageUrl: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=800&h=800&fit=crop',
+      authorDescription: 'フランスの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '善く生きることは、善く考えることである。',
+      author: 'マルクス・アウレリウス',
+      imageUrl: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=800&h=800&fit=crop',
+      authorDescription: 'ローマ皇帝・ストア派哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '継続は力なり。小さな一歩の積み重ねが偉大な達成につながる。',
+      author: 'アリストテレス',
+      imageUrl: 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?w=800&h=800&fit=crop',
+      authorDescription: '古代ギリシアの哲学者',
+    ),
+  ];
+
+  /// ランダムに名言を取得
+  static PhilosopherQuote getRandom() {
+    final now = DateTime.now();
+    // 日付ベースで名言を選択（毎日同じ名言）
+    final index = (now.day + now.month + now.year) % quotes.length;
+    return quotes[index];
+  }
+
+  /// 完全にランダムに名言を取得（毎回異なる）
+  static PhilosopherQuote getRandomAlways() {
+    final randomIndex = DateTime.now().microsecondsSinceEpoch % quotes.length;
+    return quotes[randomIndex];
+  }
+}

--- a/lib/pages/share_philosopher_quote_dialog.dart
+++ b/lib/pages/share_philosopher_quote_dialog.dart
@@ -1,0 +1,499 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'dart:typed_data';
+import 'dart:io';
+import '../models/philosopher_quote.dart';
+import '../widgets/philosopher_quote_card.dart';
+import '../services/note_card_service.dart';
+import '../services/app_share_service.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+// Web用
+import 'dart:html' as html;
+
+/// 哲学者の名言をシェアするダイアログ
+class SharePhilosopherQuoteDialog extends StatefulWidget {
+  final int? userLevel;
+  final int? totalPoints;
+  final int? currentStreak;
+  final String? levelTitle;
+
+  const SharePhilosopherQuoteDialog({
+    super.key,
+    this.userLevel,
+    this.totalPoints,
+    this.currentStreak,
+    this.levelTitle,
+  });
+
+  @override
+  State<SharePhilosopherQuoteDialog> createState() =>
+      _SharePhilosopherQuoteDialogState();
+}
+
+class _SharePhilosopherQuoteDialogState
+    extends State<SharePhilosopherQuoteDialog> {
+  PhilosopherQuote _selectedQuote = PhilosopherQuote.getRandom();
+  bool _includeAppLogo = true;
+  bool _isGenerating = false;
+  bool _showPreview = false;
+  final GlobalKey _repaintKey = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 700, maxHeight: 700),
+        child: Stack(
+          children: [
+            // メインコンテンツ
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // ヘッダー
+                Container(
+                  padding: const EdgeInsets.all(24),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.format_quote, color: Colors.blue, size: 28),
+                      const SizedBox(width: 12),
+                      const Flexible(
+                        child: Text(
+                          '哲学者の名言をシェア',
+                          style: TextStyle(
+                            fontSize: 24,
+                            fontWeight: FontWeight.bold,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const Spacer(),
+                      IconButton(
+                        icon: const Icon(Icons.close),
+                        onPressed: () => Navigator.pop(context),
+                      ),
+                    ],
+                  ),
+                ),
+
+                const Divider(height: 1),
+
+                // スクロール可能なコンテンツ
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // 名言選択
+                        const Text(
+                          '今日の名言',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+
+                        // 名言表示
+                        Container(
+                          padding: const EdgeInsets.all(20),
+                          decoration: BoxDecoration(
+                            color: Colors.blue.withOpacity(0.05),
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(
+                              color: Colors.blue.withOpacity(0.2),
+                            ),
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                children: [
+                                  const Icon(
+                                    Icons.format_quote,
+                                    color: Colors.blue,
+                                    size: 24,
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    _selectedQuote.author,
+                                    style: const TextStyle(
+                                      fontSize: 18,
+                                      fontWeight: FontWeight.bold,
+                                      color: Colors.blue,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                _selectedQuote.quote,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  height: 1.6,
+                                  color: Colors.black87,
+                                ),
+                              ),
+                              if (_selectedQuote.authorDescription != null) ...[
+                                const SizedBox(height: 8),
+                                Text(
+                                  _selectedQuote.authorDescription!,
+                                  style: const TextStyle(
+                                    fontSize: 14,
+                                    color: Colors.grey,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+
+                        const SizedBox(height: 16),
+
+                        // 名言を変更するボタン
+                        Center(
+                          child: OutlinedButton.icon(
+                            icon: const Icon(Icons.refresh),
+                            label: const Text('別の名言に変更'),
+                            onPressed: () {
+                              setState(() {
+                                _selectedQuote = PhilosopherQuote.getRandomAlways();
+                                _showPreview = false;
+                              });
+                            },
+                          ),
+                        ),
+
+                        const SizedBox(height: 24),
+
+                        // オプション
+                        const Text(
+                          'オプション',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+
+                        const SizedBox(height: 8),
+
+                        CheckboxListTile(
+                          title: const Text('アプリロゴを表示'),
+                          subtitle: const Text('「マイメモ」のロゴを含める'),
+                          value: _includeAppLogo,
+                          onChanged: (value) {
+                            setState(() {
+                              _includeAppLogo = value ?? true;
+                              _showPreview = false;
+                            });
+                          },
+                          controlAffinity: ListTileControlAffinity.leading,
+                          contentPadding: EdgeInsets.zero,
+                        ),
+
+                        const SizedBox(height: 16),
+
+                        // プレビューボタン
+                        Center(
+                          child: OutlinedButton.icon(
+                            icon: const Icon(Icons.visibility),
+                            label: Text(_showPreview
+                                ? 'プレビュー準備完了 ✓'
+                                : 'プレビューを表示'),
+                            style: _showPreview
+                                ? OutlinedButton.styleFrom(
+                                    side: const BorderSide(
+                                        color: Colors.green, width: 2),
+                                    foregroundColor: Colors.green,
+                                  )
+                                : null,
+                            onPressed: _handlePreview,
+                          ),
+                        ),
+
+                        const SizedBox(height: 16),
+
+                        // シェアメッセージプレビュー
+                        const Text(
+                          'シェアメッセージプレビュー',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.grey,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Container(
+                          padding: const EdgeInsets.all(16),
+                          decoration: BoxDecoration(
+                            color: Colors.grey.withOpacity(0.1),
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: Colors.grey.withOpacity(0.3)),
+                          ),
+                          child: Text(
+                            _getShareMessage(),
+                            style: const TextStyle(
+                              fontSize: 12,
+                              color: Colors.black87,
+                            ),
+                            maxLines: 10,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                const Divider(height: 1),
+
+                // ボタンエリア
+                Container(
+                  padding: const EdgeInsets.all(24),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: const Text('キャンセル'),
+                      ),
+                      const SizedBox(width: 12),
+                      // Web版ではダウンロードボタンを表示
+                      if (kIsWeb)
+                        ElevatedButton.icon(
+                          icon: _isGenerating
+                              ? const SizedBox(
+                                  width: 20,
+                                  height: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
+                              : const Icon(Icons.download),
+                          label: Text(_isGenerating ? '生成中...' : 'ダウンロード'),
+                          onPressed: (_isGenerating || !_showPreview)
+                              ? null
+                              : _generateAndDownload,
+                        )
+                      else
+                        // モバイル版では共有ボタン
+                        ElevatedButton.icon(
+                          icon: _isGenerating
+                              ? const SizedBox(
+                                  width: 20,
+                                  height: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
+                              : const Icon(Icons.share),
+                          label: Text(_isGenerating ? '生成中...' : '共有する'),
+                          onPressed:
+                              (_isGenerating || !_showPreview) ? null : _generateAndShare,
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+
+            // プレビュー表示エリア（画面外に配置）
+            if (_showPreview)
+              Positioned(
+                left: -10000,
+                top: -10000,
+                child: RepaintBoundary(
+                  key: _repaintKey,
+                  child: PhilosopherQuoteCard(
+                    quote: _selectedQuote,
+                    includeAppLogo: _includeAppLogo,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _getShareMessage() {
+    if (widget.userLevel != null &&
+        widget.totalPoints != null &&
+        widget.currentStreak != null) {
+      return AppShareService.getPhilosopherQuoteWithStats(
+        level: widget.userLevel!,
+        totalPoints: widget.totalPoints!,
+        currentStreak: widget.currentStreak!,
+        levelTitle: widget.levelTitle,
+      );
+    } else {
+      return AppShareService.getPhilosopherQuoteMessage();
+    }
+  }
+
+  // プレビュー処理
+  Future<void> _handlePreview() async {
+    setState(() {
+      _showPreview = true;
+    });
+
+    // レンダリング待機
+    await Future.delayed(const Duration(milliseconds: 500));
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('✓ プレビュー準備完了！「ダウンロード」ボタンをクリックしてください'),
+          duration: Duration(seconds: 2),
+          backgroundColor: Colors.green,
+        ),
+      );
+    }
+  }
+
+  // Web版: ダウンロード機能
+  Future<void> _generateAndDownload() async {
+    setState(() {
+      _isGenerating = true;
+    });
+
+    try {
+      // 少し待ってからキャプチャ開始
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      // スクリーンショットを撮る
+      final imageBytes = await NoteCardService.captureWidgetSimple(_repaintKey);
+
+      if (imageBytes == null) {
+        throw Exception('画像の生成に失敗しました。');
+      }
+
+      if (!mounted) {
+        return;
+      }
+
+      // Web版: ダウンロード
+      final blob = html.Blob([imageBytes]);
+      final url = html.Url.createObjectUrlFromBlob(blob);
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final filename = 'philosopher_quote_$timestamp.png';
+
+      final anchor = html.AnchorElement(href: url)
+        ..setAttribute('download', filename)
+        ..click();
+
+      html.Url.revokeObjectUrl(url);
+
+      if (!mounted) {
+        return;
+      }
+
+      Navigator.pop(context);
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('名言カードをダウンロードしました！'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('エラー: $e\nもう一度「プレビューを表示」ボタンを押してから再度お試しください。'),
+          backgroundColor: Colors.red,
+          duration: const Duration(seconds: 4),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      }
+    }
+  }
+
+  // モバイル版: 共有機能
+  Future<void> _generateAndShare() async {
+    setState(() {
+      _isGenerating = true;
+    });
+
+    try {
+      // 少し待ってからキャプチャ開始
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      // スクリーンショットを撮る
+      final imageBytes = await NoteCardService.captureWidgetSimple(_repaintKey);
+
+      if (imageBytes == null) {
+        throw Exception('画像の生成に失敗しました。');
+      }
+
+      if (!mounted) {
+        return;
+      }
+
+      // 画像を共有
+      await _shareImage(imageBytes);
+
+      if (!mounted) {
+        return;
+      }
+
+      Navigator.pop(context);
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('名言カードを共有しました！'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('エラー: $e\nもう一度「プレビューを表示」ボタンを押してから再度お試しください。'),
+          backgroundColor: Colors.red,
+          duration: const Duration(seconds: 4),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      }
+    }
+  }
+
+  // 画像を共有するヘルパー関数
+  Future<void> _shareImage(Uint8List imageBytes) async {
+    try {
+      final tempDir = await getTemporaryDirectory();
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final filename = 'philosopher_quote_$timestamp.png';
+      final file = File('${tempDir.path}/$filename');
+      await file.writeAsBytes(imageBytes);
+
+      // 共有
+      await Share.shareXFiles(
+        [XFile(file.path)],
+        text: _getShareMessage(),
+      );
+    } catch (e) {
+      debugPrint('Error sharing philosopher quote card: $e');
+      rethrow;
+    }
+  }
+}

--- a/lib/services/app_share_service.dart
+++ b/lib/services/app_share_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'dart:html' as html;
+import '../models/philosopher_quote.dart';
 
 /// アプリ自体をSNSでシェアするためのサービス
 class AppShareService {
@@ -161,6 +162,92 @@ $appUrl
     // 日付ベースでメッセージを選択（毎日同じユーザーは同じメッセージ）
     final index = (now.day + now.month) % shareMessages.length;
     return shareMessages[index];
+  }
+
+  /// 哲学者の名言を含むシェアメッセージを取得
+  static String getPhilosopherQuoteMessage() {
+    final quote = PhilosopherQuote.getRandom();
+
+    return '''💭 今日の名言 - ${quote.author}
+
+「${quote.quote}」
+
+━━━━━━━━━━━━━━
+✨ 日々の学びを記録しよう ✨
+━━━━━━━━━━━━━━
+
+$appNameは、哲学者たちの知恵とともに
+あなたの学びをサポートします。
+
+メモを書くことで：
+📝 学びを深く定着させる
+🎯 思考を整理する
+🏆 継続の習慣を身につける
+
+━━━━━━━━━━━━━━
+🎮 ゲーム感覚で楽しく継続 🎮
+━━━━━━━━━━━━━━
+
+✨ レベルアップシステム
+✨ 28種類のアチーブメント
+✨ 連続記録の可視化
+✨ 全国ランキング
+
+完全無料で今すぐ始める👇
+$appUrl
+
+#マイメモ #${quote.author} #名言 #哲学 #学び #メモ習慣 #自己成長 #継続は力なり''';
+  }
+
+  /// 哲学者の名言を含むカスタムメッセージ（実績付き）
+  static String getPhilosopherQuoteWithStats({
+    required int level,
+    required int totalPoints,
+    required int currentStreak,
+    String? levelTitle,
+  }) {
+    final quote = PhilosopherQuote.getRandom();
+    final title = levelTitle ?? _getLevelTitle(level);
+
+    // レベルに応じた追加メッセージ
+    String achievement = '';
+    if (level >= 20) {
+      achievement = '🌟 最高レベル到達！';
+    } else if (level >= 15) {
+      achievement = '🏆 上級者レベル！';
+    } else if (level >= 10) {
+      achievement = '📈 成長中！';
+    } else if (level >= 5) {
+      achievement = '🚀 順調に継続中！';
+    } else {
+      achievement = '✨ 習慣化への第一歩！';
+    }
+
+    return '''💭 今日の名言 - ${quote.author}
+
+「${quote.quote}」
+
+$achievement
+継続の力を実感しています！
+
+━━━━━━━━━━━━━━
+💎 私の実績 💎
+━━━━━━━━━━━━━━
+
+🏆 称号: $title
+📊 レベル: Lv.$level
+⭐ 総ポイント: ${totalPoints.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')} pt
+🔥 連続記録: ${currentStreak}日継続中
+
+━━━━━━━━━━━━━━
+
+$appNameで、哲学者たちの知恵とともに
+あなたも学びの習慣を始めませんか？
+
+完全無料で今すぐ体験👇
+$appUrl
+
+#マイメモ #${quote.author} #レベル$level #$title #名言 #哲学 #習慣化 #${currentStreak}日連続''';
   }
 
   /// カスタムメッセージでシェア

--- a/lib/widgets/home_page/home_app_bar.dart
+++ b/lib/widgets/home_page/home_app_bar.dart
@@ -4,6 +4,7 @@ import '../../pages/categories_page.dart';
 import '../../pages/stats_page.dart';
 import '../../pages/leaderboard_page.dart';
 import '../../pages/settings_page.dart';
+import '../../pages/share_philosopher_quote_dialog.dart';
 import '../../services/search_history_service.dart';
 import '../../services/app_share_service.dart';
 import '../../models/user_stats.dart';
@@ -644,6 +645,28 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
                       ],
                     ),
                     const SizedBox(height: 12),
+                    // 哲学者の名言をシェア（NEW!）
+                    _buildShareButton(
+                      context,
+                      icon: Icons.format_quote,
+                      label: '哲学者の名言をシェア',
+                      color: Colors.purple.shade700,
+                      subtitle: '今日の名言を美しいカードでシェア',
+                      badge: 'NEW',
+                      onTap: () {
+                        Navigator.pop(context);
+                        showDialog(
+                          context: context,
+                          builder: (_) => SharePhilosopherQuoteDialog(
+                            userLevel: userStats?.currentLevel,
+                            totalPoints: userStats?.totalPoints,
+                            currentStreak: userStats?.currentStreak,
+                            levelTitle: userStats?.levelTitle,
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 8),
                     if (userStats != null) ...[
                       _buildShareButton(
                         context,
@@ -937,6 +960,7 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
     required Color color,
     required VoidCallback onTap,
     String? subtitle,
+    String? badge,
   }) {
     return InkWell(
       onTap: onTap,
@@ -963,13 +987,39 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    label,
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w600,
-                      color: color,
-                    ),
+                  Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          label,
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            color: color,
+                          ),
+                        ),
+                      ),
+                      if (badge != null) ...[
+                        const SizedBox(width: 8),
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [Colors.pink.shade400, Colors.orange.shade400],
+                            ),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Text(
+                            badge,
+                            style: const TextStyle(
+                              fontSize: 10,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
                   if (subtitle != null) ...[
                     const SizedBox(height: 2),

--- a/lib/widgets/philosopher_quote_card.dart
+++ b/lib/widgets/philosopher_quote_card.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import '../models/philosopher_quote.dart';
+
+/// 哲学者の名言カードウィジェット（OGP画像生成用）
+class PhilosopherQuoteCard extends StatelessWidget {
+  final PhilosopherQuote quote;
+  final bool includeAppLogo;
+
+  const PhilosopherQuoteCard({
+    super.key,
+    required this.quote,
+    this.includeAppLogo = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1200,
+      height: 630, // OGP標準サイズ
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Colors.blue.shade900,
+            Colors.purple.shade900,
+            Colors.indigo.shade900,
+          ],
+        ),
+      ),
+      child: Stack(
+        children: [
+          // 背景パターン
+          Positioned.fill(
+            child: Opacity(
+              opacity: 0.1,
+              child: CustomPaint(
+                painter: _PatternPainter(),
+              ),
+            ),
+          ),
+
+          // メインコンテンツ
+          Padding(
+            padding: const EdgeInsets.all(60),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 名言テキスト
+                Container(
+                  padding: const EdgeInsets.all(40),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.95),
+                    borderRadius: BorderRadius.circular(20),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.3),
+                        blurRadius: 20,
+                        offset: const Offset(0, 10),
+                      ),
+                    ],
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // 引用符アイコン
+                      const Icon(
+                        Icons.format_quote,
+                        size: 40,
+                        color: Colors.blue,
+                      ),
+                      const SizedBox(height: 20),
+
+                      // 名言
+                      Text(
+                        quote.quote,
+                        style: const TextStyle(
+                          fontSize: 36,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.black87,
+                          height: 1.5,
+                        ),
+                      ),
+
+                      const SizedBox(height: 30),
+
+                      // 著者名と説明
+                      Row(
+                        children: [
+                          Container(
+                            width: 5,
+                            height: 50,
+                            decoration: BoxDecoration(
+                              color: Colors.blue,
+                              borderRadius: BorderRadius.circular(3),
+                            ),
+                          ),
+                          const SizedBox(width: 20),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  quote.author,
+                                  style: const TextStyle(
+                                    fontSize: 32,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.blue,
+                                  ),
+                                ),
+                                if (quote.authorDescription != null)
+                                  Text(
+                                    quote.authorDescription!,
+                                    style: const TextStyle(
+                                      fontSize: 20,
+                                      color: Colors.grey,
+                                    ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+
+                const Spacer(),
+
+                // アプリロゴとタグライン
+                if (includeAppLogo)
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 30,
+                      vertical: 20,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.9),
+                      borderRadius: BorderRadius.circular(15),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 50,
+                          height: 50,
+                          decoration: BoxDecoration(
+                            color: Colors.blue,
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: const Icon(
+                            Icons.edit_note,
+                            color: Colors.white,
+                            size: 30,
+                          ),
+                        ),
+                        const SizedBox(width: 15),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              'マイメモ',
+                              style: TextStyle(
+                                fontSize: 28,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.black87,
+                              ),
+                            ),
+                            Text(
+                              '哲学者と学ぶメモ習慣',
+                              style: TextStyle(
+                                fontSize: 16,
+                                color: Colors.grey.shade700,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 背景パターンペインター
+class _PatternPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 2
+      ..style = PaintingStyle.stroke;
+
+    // グリッドパターンを描画
+    const spacing = 50.0;
+    for (double i = 0; i < size.width; i += spacing) {
+      canvas.drawLine(
+        Offset(i, 0),
+        Offset(i, size.height),
+        paint,
+      );
+    }
+    for (double i = 0; i < size.height; i += spacing) {
+      canvas.drawLine(
+        Offset(0, i),
+        Offset(size.width, i),
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}


### PR DESCRIPTION
- Create PhilosopherQuote model with 15 famous philosophical quotes
- Add SharePhilosopherQuoteDialog for sharing quotes as images
- Create PhilosopherQuoteCard widget for generating beautiful quote cards
- Update AppShareService with philosopher quote message generation
- Add philosopher quote share option to home app bar with NEW badge
- Include both text-based and image-based sharing options
- Support user stats integration in quote messages

This feature allows users to share inspirational philosophical quotes along with the app, making SNS sharing more engaging and meaningful.