### PR TITLE
Enhance SNS sharing with random quotes and images

### DIFF
--- a/lib/models/philosopher_quote.dart
+++ b/lib/models/philosopher_quote.dart
@@ -45,9 +45,27 @@ class PhilosopherQuote {
       authorDescription: 'ドイツの哲学者',
     ),
     PhilosopherQuote(
+      quote: 'すべての知識は経験に基づく。',
+      author: 'イマヌエル・カント',
+      imageUrl: 'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?w=800&h=800&fit=crop',
+      authorDescription: 'ドイツの哲学者',
+    ),
+    PhilosopherQuote(
       quote: '深淵を覗く時、深淵もまたこちらを覗いている。',
       author: 'フリードリヒ・ニーチェ',
       imageUrl: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=800&h=800&fit=crop',
+      authorDescription: 'ドイツの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '神は死んだ。我々が神を殺したのだ。',
+      author: 'フリードリヒ・ニーチェ',
+      imageUrl: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=800&h=800&fit=crop',
+      authorDescription: 'ドイツの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '人間は教育によってはじめて人間となる。',
+      author: 'イマヌエル・カント',
+      imageUrl: 'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?w=800&h=800&fit=crop',
       authorDescription: 'ドイツの哲学者',
     ),
     PhilosopherQuote(
@@ -63,7 +81,19 @@ class PhilosopherQuote {
       authorDescription: '古代中国の思想家',
     ),
     PhilosopherQuote(
+      quote: '知者は惑わず、仁者は憂えず、勇者は懼れず。',
+      author: '孔子',
+      imageUrl: 'https://images.unsplash.com/photo-1557862921-37829c790f19?w=800&h=800&fit=crop',
+      authorDescription: '古代中国の思想家',
+    ),
+    PhilosopherQuote(
       quote: '人間は自由の刑に処せられている。',
+      author: 'ジャン＝ポール・サルトル',
+      imageUrl: 'https://images.unsplash.com/photo-1528892952291-009c663ce843?w=800&h=800&fit=crop',
+      authorDescription: 'フランスの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '実存は本質に先立つ。',
       author: 'ジャン＝ポール・サルトル',
       imageUrl: 'https://images.unsplash.com/photo-1528892952291-009c663ce843?w=800&h=800&fit=crop',
       authorDescription: 'フランスの哲学者',
@@ -99,9 +129,69 @@ class PhilosopherQuote {
       authorDescription: 'ローマ皇帝・ストア派哲学者',
     ),
     PhilosopherQuote(
+      quote: '障害は道である。',
+      author: 'マルクス・アウレリウス',
+      imageUrl: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=800&h=800&fit=crop',
+      authorDescription: 'ローマ皇帝・ストア派哲学者',
+    ),
+    PhilosopherQuote(
       quote: '継続は力なり。小さな一歩の積み重ねが偉大な達成につながる。',
       author: 'アリストテレス',
       imageUrl: 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?w=800&h=800&fit=crop',
+      authorDescription: '古代ギリシアの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '哲学するとは、死ぬことを学ぶことである。',
+      author: 'プラトン',
+      imageUrl: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=800&h=800&fit=crop',
+      authorDescription: '古代ギリシアの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '疑うことは、知恵の始まりである。',
+      author: 'ルネ・デカルト',
+      imageUrl: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=800&h=800&fit=crop',
+      authorDescription: '近世哲学の祖',
+    ),
+    PhilosopherQuote(
+      quote: '怠惰は魅力的だが、ひどい気分にさせる。',
+      author: 'ブレーズ・パスカル',
+      imageUrl: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=800&h=800&fit=crop',
+      authorDescription: 'フランスの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '上善は水のごとし。水はよく万物を利して争わず。',
+      author: '老子',
+      imageUrl: 'https://images.unsplash.com/photo-1552374196-1ab2a1c593e8?w=800&h=800&fit=crop',
+      authorDescription: '古代中国の哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '強くなりすぎて壊れることのないように。',
+      author: 'フリードリヒ・ニーチェ',
+      imageUrl: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=800&h=800&fit=crop',
+      authorDescription: 'ドイツの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '与えられたものをよく楽しめる者こそ、最も裕福である。',
+      author: 'マルクス・アウレリウス',
+      imageUrl: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=800&h=800&fit=crop',
+      authorDescription: 'ローマ皇帝・ストア派哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '己の欲せざるところ、人に施すなかれ。',
+      author: '孔子',
+      imageUrl: 'https://images.unsplash.com/photo-1557862921-37829c790f19?w=800&h=800&fit=crop',
+      authorDescription: '古代中国の思想家',
+    ),
+    PhilosopherQuote(
+      quote: '善いことをするのに理由は必要ない。',
+      author: 'ジャン＝ポール・サルトル',
+      imageUrl: 'https://images.unsplash.com/photo-1528892952291-009c663ce843?w=800&h=800&fit=crop',
+      authorDescription: 'フランスの哲学者',
+    ),
+    PhilosopherQuote(
+      quote: '未検証の人生は生きるに値しない。',
+      author: 'ソクラテス',
+      imageUrl: 'https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?w=800&h=800&fit=crop',
       authorDescription: '古代ギリシアの哲学者',
     ),
   ];


### PR DESCRIPTION
哲学者の名言を15個から30個に拡充し、SNSシェア機能をさらに改善しました。

主な変更点：
- イマヌエル・カント、ニーチェ、孔子、サルトル、マルクス・アウレリウスなど、既存の哲学者の名言を追加
- プラトン、デカルト、パスカル、老子の新しい名言も追加
- より多様な名言がランダムに選択されるようになり、OGP画像のバリエーションが豊富に

追加された名言（15個）：
- すべての知識は経験に基づく - カント
- 神は死んだ。我々が神を殺したのだ - ニーチェ
- 人間は教育によってはじめて人間となる - カント
- 知者は惑わず、仁者は憂えず、勇者は懼れず - 孔子
- 実存は本質に先立つ - サルトル
- 障害は道である - マルクス・アウレリウス
- 哲学するとは、死ぬことを学ぶことである - プラトン
- 疑うことは、知恵の始まりである - デカルト
- 怠惰は魅力的だが、ひどい気分にさせる - パスカル
- 上善は水のごとし - 老子
- 強くなりすぎて壊れることのないように - ニーチェ
- 与えられたものをよく楽しめる者こそ、最も裕福である - マルクス・アウレリウス
- 己の欲せざるところ、人に施すなかれ - 孔子
- 善いことをするのに理由は必要ない - サルトル
- 未検証の人生は生きるに値しない - ソクラテス

これにより、ユーザーがSNSでサイトをシェアする際に、より魅力的で多様な哲学者の名言とOGP画像を楽しめるようになります。