### PR TITLE
Fix memo text input on mobile app

### DIFF
--- a/lib/pages/note_editor_page.dart
+++ b/lib/pages/note_editor_page.dart
@@ -546,6 +546,8 @@ class _NoteEditorPageState extends State<NoteEditorPage>
                           maxLines: null,
                           expands: true,
                           textAlignVertical: TextAlignVertical.top,
+                          keyboardType: TextInputType.multiline,
+                          textInputAction: TextInputAction.newline,
                         ),
                       ),
                     ],

--- a/lib/pages/shared_note_page.dart
+++ b/lib/pages/shared_note_page.dart
@@ -332,6 +332,8 @@ class _SharedNotePageState extends State<SharedNotePage> {
                                 maxLines: null,
                                 expands: true,
                                 textAlignVertical: TextAlignVertical.top,
+                                keyboardType: TextInputType.multiline,
+                                textInputAction: TextInputAction.newline,
                                 readOnly: !(_shareInfo?.canWrite ?? false),
                               ),
                             ),


### PR DESCRIPTION
スマホのキーボードで改行が正しく機能しない問題を解決。
- note_editor_page.dart: コンテンツ入力フィールドに keyboardType と textInputAction を追加
- shared_note_page.dart: 同様の修正を共有メモページにも適用

これにより、モバイルキーボードに改行ボタンが表示され、
長文メモの入力と改行が正しく動作するようになります。