### PR TITLE
Build quote sharing page with OGP tags

### DIFF
--- a/supabase/functions/generate-quote-image/index.ts
+++ b/supabase/functions/generate-quote-image/index.ts
@@ -116,8 +116,12 @@ serve(async (req) => {
   </g>
 </svg>`;
 
+    // UTF-8エンコーディングを明示的に行う
+    const encoder = new TextEncoder();
+    const encodedSvg = encoder.encode(svg);
+
     // SVGを返す
-    return new Response(svg, {
+    return new Response(encodedSvg, {
       headers: {
         ...corsHeaders,
         'Content-Type': 'image/svg+xml; charset=utf-8',

--- a/supabase/functions/share-quote/index.ts
+++ b/supabase/functions/share-quote/index.ts
@@ -208,7 +208,11 @@ serve(async (req) => {
   </body>
 </html>`;
 
-    return new Response(html, {
+    // UTF-8エンコーディングを明示的に行う
+    const encoder = new TextEncoder();
+    const encodedHtml = encoder.encode(html);
+
+    return new Response(encodedHtml, {
       headers: {
         ...corsHeaders,
         'Content-Type': 'text/html; charset=utf-8',


### PR DESCRIPTION
- Add TextEncoder to ensure proper UTF-8 encoding in share-quote function
- Add TextEncoder to ensure proper UTF-8 encoding in generate-quote-image function
- Fixes mojibake (character corruption) issue where Japanese characters were displaying as garbled text
- Both functions now explicitly encode strings as UTF-8 bytes before sending HTTP responses