### PR TITLE
Add random philosopher quotes to SNS sharing

### DIFF
--- a/lib/models/philosopher_quote.dart
+++ b/lib/models/philosopher_quote.dart
@@ -212,6 +212,18 @@ class PhilosopherQuote {
       imageUrl: 'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=800&h=800&fit=crop',
       authorDescription: 'ドイツの精神分析学者・社会心理学者',
     ),
+    PhilosopherQuote(
+      quote: '義を見てせざるは勇無きなり',
+      author: '孔子',
+      imageUrl: 'https://images.unsplash.com/photo-1557862921-37829c790f19?w=800&h=800&fit=crop',
+      authorDescription: '古代中国の思想家',
+    ),
+    PhilosopherQuote(
+      quote: '祈りは神を変えず、祈る者を変える',
+      author: 'セーレン・キルケゴール',
+      imageUrl: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=800&h=800&fit=crop',
+      authorDescription: 'デンマークの哲学者',
+    ),
   ];
 
   /// ランダムに名言を取得
@@ -224,7 +236,13 @@ class PhilosopherQuote {
 
   /// 完全にランダムに名言を取得（毎回異なる）
   static PhilosopherQuote getRandomAlways() {
-    final randomIndex = DateTime.now().microsecondsSinceEpoch % quotes.length;
+    // より良いランダム性を確保するため、複数の要素を組み合わせる
+    final now = DateTime.now();
+    final seed = now.microsecondsSinceEpoch +
+                 now.millisecondsSinceEpoch * 31 +
+                 now.second * 97 +
+                 now.millisecond * 197;
+    final randomIndex = seed % quotes.length;
     return quotes[randomIndex];
   }
 }

--- a/lib/pages/share_philosopher_quote_dialog.dart
+++ b/lib/pages/share_philosopher_quote_dialog.dart
@@ -34,10 +34,23 @@ class SharePhilosopherQuoteDialog extends StatefulWidget {
 class _SharePhilosopherQuoteDialogState
     extends State<SharePhilosopherQuoteDialog> {
   PhilosopherQuote _selectedQuote = PhilosopherQuote.getRandomAlways();
+  int _selectedQuoteId = 0;
   bool _includeAppLogo = true;
   bool _isGenerating = false;
   bool _showPreview = false;
   final GlobalKey _repaintKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    _updateSelectedQuoteId();
+  }
+
+  void _updateSelectedQuoteId() {
+    // 現在選択されている名言のIDを取得
+    _selectedQuoteId = PhilosopherQuote.quotes.indexOf(_selectedQuote);
+    if (_selectedQuoteId < 0) _selectedQuoteId = 0;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -159,6 +172,7 @@ class _SharePhilosopherQuoteDialogState
                             onPressed: () {
                               setState(() {
                                 _selectedQuote = PhilosopherQuote.getRandomAlways();
+                                _updateSelectedQuoteId();
                                 _showPreview = false;
                               });
                             },
@@ -212,6 +226,100 @@ class _SharePhilosopherQuoteDialogState
                           ),
                         ),
 
+                        const SizedBox(height: 24),
+
+                        // SNSシェアセクション
+                        const Divider(),
+                        const SizedBox(height: 16),
+
+                        const Text(
+                          'SNSで直接シェア（OGP画像付き）',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        const Text(
+                          '下のボタンから、哲学者の名言と画像をSNSに直接シェアできます',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+
+                        // SNSシェアボタン
+                        Wrap(
+                          spacing: 12,
+                          runSpacing: 12,
+                          alignment: WrapAlignment.center,
+                          children: [
+                            // Twitter
+                            ElevatedButton.icon(
+                              icon: const Icon(Icons.share, size: 20),
+                              label: const Text('Twitter'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: const Color(0xFF1DA1F2),
+                                foregroundColor: Colors.white,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 20,
+                                  vertical: 12,
+                                ),
+                              ),
+                              onPressed: _shareToTwitter,
+                            ),
+                            // Facebook
+                            ElevatedButton.icon(
+                              icon: const Icon(Icons.share, size: 20),
+                              label: const Text('Facebook'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: const Color(0xFF1877F2),
+                                foregroundColor: Colors.white,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 20,
+                                  vertical: 12,
+                                ),
+                              ),
+                              onPressed: _shareToFacebook,
+                            ),
+                            // LINE
+                            ElevatedButton.icon(
+                              icon: const Icon(Icons.share, size: 20),
+                              label: const Text('LINE'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: const Color(0xFF06C755),
+                                foregroundColor: Colors.white,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 20,
+                                  vertical: 12,
+                                ),
+                              ),
+                              onPressed: _shareToLine,
+                            ),
+                          ],
+                        ),
+
+                        const SizedBox(height: 24),
+                        const Divider(),
+                        const SizedBox(height: 16),
+
+                        // 画像ダウンロードセクション
+                        const Text(
+                          '画像をダウンロード',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        const Text(
+                          '画像だけをダウンロードしたい場合は、プレビューを表示してからダウンロードしてください',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey,
+                          ),
+                        ),
                         const SizedBox(height: 16),
 
                         // シェアメッセージプレビュー
@@ -494,6 +602,97 @@ class _SharePhilosopherQuoteDialogState
     } catch (e) {
       debugPrint('Error sharing philosopher quote card: $e');
       rethrow;
+    }
+  }
+
+  // SNSシェアメソッド（動的OGP対応）
+  Future<void> _shareToTwitter() async {
+    try {
+      await AppShareService.shareToTwitterWithDynamicOgp(
+        quoteId: _selectedQuoteId,
+        level: widget.userLevel,
+        totalPoints: widget.totalPoints,
+        currentStreak: widget.currentStreak,
+      );
+
+      if (mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Twitterシェア画面を開きました！'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('エラー: $e'),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _shareToFacebook() async {
+    try {
+      await AppShareService.shareToFacebookWithDynamicOgp(
+        quoteId: _selectedQuoteId,
+      );
+
+      if (mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Facebookシェア画面を開きました！'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('エラー: $e'),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _shareToLine() async {
+    try {
+      await AppShareService.shareToLineWithDynamicOgp(
+        quoteId: _selectedQuoteId,
+        level: widget.userLevel,
+        totalPoints: widget.totalPoints,
+        currentStreak: widget.currentStreak,
+      );
+
+      if (mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('LINEシェア画面を開きました！'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('エラー: $e'),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+      }
     }
   }
 }

--- a/supabase/functions/_shared/quotes.ts
+++ b/supabase/functions/_shared/quotes.ts
@@ -204,6 +204,18 @@ export const quotes: PhilosopherQuote[] = [
     author: "エーリッヒ・フロム",
     imageUrl: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=800&h=800&fit=crop",
     authorDescription: "ドイツの精神分析学者・社会心理学者"
+  },
+  {
+    quote: "義を見てせざるは勇無きなり",
+    author: "孔子",
+    imageUrl: "https://images.unsplash.com/photo-1557862921-37829c790f19?w=800&h=800&fit=crop",
+    authorDescription: "古代中国の思想家"
+  },
+  {
+    quote: "祈りは神を変えず、祈る者を変える",
+    author: "セーレン・キルケゴール",
+    imageUrl: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=800&h=800&fit=crop",
+    authorDescription: "デンマークの哲学者"
   }
 ];
 


### PR DESCRIPTION
…buttons with OGP images

Changes:
- Add 2 new philosopher quotes (Confucius and Kierkegaard)
- Improve randomization algorithm for quote selection
- Add direct SNS share buttons (Twitter, Facebook, LINE) in SharePhilosopherQuoteDialog
- All SNS shares now include dynamic OGP images
- Better organization of share dialog with separate sections for SNS share and image download

This ensures users can easily share philosopher quotes with OGP images on social media, and each share displays a different random quote.