### PR TITLE
Add missing awardPoints method to GamificationService

### DIFF
--- a/lib/services/gamification_service.dart
+++ b/lib/services/gamification_service.dart
@@ -103,6 +103,23 @@ class GamificationService {
     }
   }
 
+  // Award points with optional reason for tracking
+  Future<UserStats> awardPoints(
+    String userId,
+    int points, {
+    String? reason,
+  }) async {
+    try {
+      if (reason != null) {
+        AppLogger.info('Awarding $points points to user $userId: $reason');
+      }
+      return await addPoints(userId, points);
+    } catch (e, stackTrace) {
+      AppLogger.error('Error awarding points', error: e, stackTrace: stackTrace);
+      rethrow;
+    }
+  }
+
   // Track activity and update streak
   Future<UserStats> trackActivity(String userId) async {
     try {


### PR DESCRIPTION
Adds a new awardPoints method that accepts an optional reason parameter for better tracking and logging of point awards. This method wraps the existing addPoints method.