### PR TITLE
Fix undefined method error in community service

### DIFF
--- a/lib/services/community_service.dart
+++ b/lib/services/community_service.dart
@@ -151,7 +151,7 @@ class CommunityService {
       final profiles = await _supabase
           .from('user_profiles')
           .select()
-          .in_('user_id', followerIds);
+          .inFilter('user_id', followerIds);
 
       return (profiles as List)
           .map((profile) => UserProfile.fromJson(profile))
@@ -180,7 +180,7 @@ class CommunityService {
       final profiles = await _supabase
           .from('user_profiles')
           .select()
-          .in_('user_id', followingIds);
+          .inFilter('user_id', followingIds);
 
       return (profiles as List)
           .map((profile) => UserProfile.fromJson(profile))


### PR DESCRIPTION
The method in_() doesn't exist in PostgrestFilterBuilder. The correct method name is inFilter() which is used to filter rows where a column value is in a list of values.

Fixed in:
- getFollowers() method (line 154)
- getFollowing() method (line 183)