### PR TITLE
Fix AI assistant API rate limit error

### DIFF
--- a/lib/pages/note_editor_page.dart
+++ b/lib/pages/note_editor_page.dart
@@ -412,6 +412,18 @@ class _NoteEditorPageState extends State<NoteEditorPage>
     );
   }
 
+  // AIエラーメッセージのフォーマット
+  String _formatAIError(dynamic error) {
+    if (error is AIServiceException) {
+      if (error.isRateLimitError) {
+        return 'AI機能の使用制限に達しました。しばらく待ってから再度お試しください。';
+      }
+      return error.message;
+    }
+    // その他のエラーは一般的なメッセージ
+    return 'AI処理に失敗しました。しばらく待ってから再度お試しください。';
+  }
+
   // AI文章改善
   Future<void> _improveText() async {
     if (_contentController.text.isEmpty) {
@@ -440,7 +452,10 @@ class _NoteEditorPageState extends State<NoteEditorPage>
       if (mounted) {
         setState(() => _isAIProcessing = false);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エラー: $e')),
+          SnackBar(
+            content: Text(_formatAIError(e)),
+            backgroundColor: Colors.red,
+          ),
         );
       }
     }
@@ -474,7 +489,10 @@ class _NoteEditorPageState extends State<NoteEditorPage>
       if (mounted) {
         setState(() => _isAIProcessing = false);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エラー: $e')),
+          SnackBar(
+            content: Text(_formatAIError(e)),
+            backgroundColor: Colors.red,
+          ),
         );
       }
     }
@@ -508,7 +526,10 @@ class _NoteEditorPageState extends State<NoteEditorPage>
       if (mounted) {
         setState(() => _isAIProcessing = false);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エラー: $e')),
+          SnackBar(
+            content: Text(_formatAIError(e)),
+            backgroundColor: Colors.red,
+          ),
         );
       }
     }
@@ -545,7 +566,10 @@ class _NoteEditorPageState extends State<NoteEditorPage>
       if (mounted) {
         setState(() => _isAIProcessing = false);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エラー: $e')),
+          SnackBar(
+            content: Text(_formatAIError(e)),
+            backgroundColor: Colors.red,
+          ),
         );
       }
     }
@@ -597,7 +621,10 @@ class _NoteEditorPageState extends State<NoteEditorPage>
       if (mounted) {
         setState(() => _isAIProcessing = false);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エラー: $e')),
+          SnackBar(
+            content: Text(_formatAIError(e)),
+            backgroundColor: Colors.red,
+          ),
         );
       }
     }
@@ -671,7 +698,10 @@ class _NoteEditorPageState extends State<NoteEditorPage>
       if (mounted) {
         setState(() => _isAIProcessing = false);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エラー: $e')),
+          SnackBar(
+            content: Text(_formatAIError(e)),
+            backgroundColor: Colors.red,
+          ),
         );
       }
     }


### PR DESCRIPTION
This commit addresses the 429 rate limit errors from OpenAI API by adding:

1. Edge Function (supabase/functions/ai-assistant/index.ts):
   - Detect 429 status from OpenAI API responses
   - Return proper 429 status code to client (instead of generic 400)
   - Include retry-after header information in error response
   - Add errorType field to distinguish rate limit errors

2. Client Service (lib/services/ai_service.dart):
   - Add AIServiceException class for better error handling
   - Implement exponential backoff retry logic (up to 3 retries)
   - Honor retry-after values from server responses
   - Apply retry logic to all AI operations (improve, summarize, expand, translate, suggestTitles)
   - Add detailed logging for retry attempts

3. UI Layer (lib/pages/note_editor_page.dart):
   - Add _formatAIError() helper method for user-friendly error messages
   - Display specific message for rate limit errors
   - Show red background on error snackbars for visibility
   - Apply improved error handling to all AI features

Benefits:
- Users no longer see cryptic "OpenAI API error: 429" messages
- Automatic retry with exponential backoff reduces manual intervention
- Clear user feedback when rate limits are reached
- Logging helps debug rate limit issues in production