### PR TITLE
Fix type mismatch in AI service argument

### DIFF
--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -6,7 +6,7 @@ import '../main.dart';
 class AIServiceException implements Exception {
   final String message;
   final String? errorType;
-  final int? retryAfter;
+  final String? retryAfter;
 
   AIServiceException(this.message, {this.errorType, this.retryAfter});
 


### PR DESCRIPTION
Changed AIServiceException.retryAfter from int? to String? to match its actual usage throughout the code. The field was being set with .toString() and consumed with int.parse(), making String the correct type.

Fixes type error at lib/services/ai_service.dart:53