### PR TITLE
Debug share quote API endpoint

### DIFF
--- a/supabase/functions/share-quote/index.ts
+++ b/supabase/functions/share-quote/index.ts
@@ -222,11 +222,7 @@ serve(async (req) => {
       "frame-ancestors 'none'"
     ].join('; ');
 
-    // UTF-8エンコーディングを明示的に行う
-    const encoder = new TextEncoder();
-    const encodedHtml = encoder.encode(html);
-
-    return new Response(encodedHtml, {
+    return new Response(html, {
       headers: {
         ...corsHeaders,
         'Content-Type': 'text/html; charset=utf-8',


### PR DESCRIPTION
Remove manual TextEncoder encoding step that was causing mojibake. Pass HTML string directly to Response constructor, allowing proper UTF-8 interpretation via Content-Type header and meta charset tag.