### PR TITLE
EMERGENCY: Disable signup trigger to restore service

### DIFF
--- a/supabase/migrations/20251109000002_disable_trigger_emergency.sql
+++ b/supabase/migrations/20251109000002_disable_trigger_emergency.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- EMERGENCY: Completely disable trigger to allow signups
+-- ============================================================
+-- This migration completely removes the trigger to allow user signups
+-- We'll add it back later once we fix the root cause
+-- Date: 2025-11-09 (Critical Emergency)
+-- ============================================================
+
+-- Completely remove the trigger
+DROP TRIGGER IF EXISTS create_referral_code_on_signup ON auth.users;
+
+-- Drop the function as well
+DROP FUNCTION IF EXISTS create_user_referral_code();
+
+-- ============================================================
+-- NOTE: This allows signups to work, but referral codes and
+-- onboarding status won't be initialized automatically.
+-- We'll add a background job or manual process to handle this later.
+-- ============================================================
+
+COMMENT ON TABLE referral_codes IS
+'Referral codes table - trigger temporarily disabled to fix signup issues';
+
+COMMENT ON TABLE user_onboarding IS
+'Onboarding tracking - trigger temporarily disabled to fix signup issues';


### PR DESCRIPTION
Problem:
- Signup still failing with 500 error even after previous fixes
- "Database error saving new user"
- Blocking all new user registrations

Solution:
- Completely disable the create_referral_code_on_signup trigger
- Remove the function temporarily
- This allows signups to work immediately
- We'll implement referral codes separately later

Impact:
- Signups will work
- Referral codes won't be auto-generated (acceptable tradeoff)
- Onboarding status won't be auto-initialized (can be done on first login)