### PR TITLE
Fix 406 error on user stats API endpoint

### DIFF
--- a/FIX_USER_STATS_406_ERROR.md
+++ b/FIX_USER_STATS_406_ERROR.md
@@ -1,0 +1,83 @@
+# Fix for 406 Error on user_stats Endpoint
+
+## Problem
+
+The application is receiving a **406 (Not Acceptable)** error when trying to access the `user_stats` table:
+
+```
+smmkxxavexumewbfaqpy.supabase.co/rest/v1/user_stats?select=total_points&user_id=eq.927f8dd2-3918-4bca-82ea-1619cb4810ef
+```
+
+## Root Cause
+
+The Row Level Security (RLS) policy on the `user_stats` table is too restrictive. The current policy only allows users to view **their own** stats:
+
+```sql
+CREATE POLICY "Users can view their own stats"
+  ON user_stats FOR SELECT
+  USING (auth.uid() = user_id);
+```
+
+However, the leaderboard functionality (`lib/services/gamification_service.dart` lines 509-553) needs to read **all users'** stats to display rankings. This mismatch causes the 406 error.
+
+## Solution
+
+Update the RLS policy to allow public read access to `user_stats` while maintaining security for write operations.
+
+### Steps to Fix
+
+1. **Open Supabase Dashboard**
+   - Go to https://app.supabase.com
+   - Select your project: `smmkxxavexumewbfaqpy`
+
+2. **Navigate to SQL Editor**
+   - Click on "SQL Editor" in the left sidebar
+   - Click "New query"
+
+3. **Run the Migration**
+   - Copy and paste the following SQL:
+
+```sql
+-- Fix user_stats RLS policies to allow leaderboard access
+-- This allows anyone to read user stats for leaderboard functionality
+-- while maintaining write security
+
+-- First, drop the existing restrictive SELECT policy
+DROP POLICY IF EXISTS "Users can view their own stats" ON user_stats;
+
+-- Create a new public read policy for leaderboard access
+CREATE POLICY "Anyone can view user stats for leaderboard"
+  ON user_stats FOR SELECT
+  USING (true);
+
+-- Verify the policies are correct
+SELECT schemaname, tablename, policyname, permissive, roles, cmd, qual
+FROM pg_policies
+WHERE tablename = 'user_stats';
+```
+
+4. **Click "Run"** to execute the migration
+
+5. **Verify the Fix**
+   - Refresh your application
+   - The 406 error should be resolved
+   - The leaderboard should now display all users
+
+## Security Considerations
+
+This change allows anyone (authenticated or anonymous) to read user stats, which is appropriate for a leaderboard feature. The following policies ensure data security:
+
+- **INSERT**: Only authenticated users can insert their own stats
+- **UPDATE**: Only authenticated users can update their own stats
+- **DELETE**: Handled automatically via CASCADE on user deletion
+
+User stats are intentionally public for competitive/social features like leaderboards.
+
+## Migration File
+
+The migration has been saved to:
+```
+supabase/migrations/20251109120000_fix_user_stats_leaderboard_rls.sql
+```
+
+This file is now part of your migration history for future deployments.

--- a/apply_user_stats_fix.sql
+++ b/apply_user_stats_fix.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- Fix for 406 Error on user_stats Endpoint
+-- ============================================================================
+-- Issue: Leaderboard cannot access user_stats due to restrictive RLS policy
+-- Solution: Allow public read access while maintaining write security
+-- Date: 2025-11-09
+-- ============================================================================
+
+-- Step 1: Drop the old restrictive policy
+DROP POLICY IF EXISTS "Users can view their own stats" ON user_stats;
+
+-- Step 2: Create new public read policy
+CREATE POLICY "Anyone can view user stats for leaderboard"
+  ON user_stats FOR SELECT
+  USING (true);
+
+-- Step 3: Verify the changes
+SELECT
+  schemaname,
+  tablename,
+  policyname,
+  permissive,
+  cmd,
+  qual
+FROM pg_policies
+WHERE tablename = 'user_stats'
+ORDER BY cmd, policyname;
+
+-- Expected output:
+-- - SELECT policy: "Anyone can view user stats for leaderboard" with qual = 'true'
+-- - INSERT policy: "Users can insert their own stats"
+-- - UPDATE policy: "Users can update their own stats"
+
+-- ============================================================================
+-- INSTRUCTIONS:
+-- ============================================================================
+-- 1. Go to https://app.supabase.com
+-- 2. Select your project (smmkxxavexumewbfaqpy)
+-- 3. Click "SQL Editor" in the sidebar
+-- 4. Click "New query"
+-- 5. Copy and paste this entire file
+-- 6. Click "Run" (or press Cmd/Ctrl + Enter)
+-- 7. Check the output to verify all policies are correct
+-- 8. Test your app - the 406 error should be resolved!
+-- ============================================================================

--- a/lib/services/gamification_service.dart
+++ b/lib/services/gamification_service.dart
@@ -507,6 +507,9 @@ class GamificationService {
   }
 
   // Get leaderboard
+  // Note: Requires public read access to user_stats table via RLS policy:
+  // "Anyone can view user stats for leaderboard"
+  // This allows the leaderboard to display all users' stats
   Future<List<LeaderboardEntry>> getLeaderboard({
     int limit = 100,
     String orderBy = 'total_points',
@@ -531,6 +534,8 @@ class GamificationService {
   }
 
   // Get user's rank
+  // Note: Requires public read access to user_stats table via RLS policy
+  // to compare user's stats against all other users
   Future<int?> getUserRank(String userId, {String orderBy = 'total_points'}) async {
     try {
       final allUsers = await _supabase

--- a/supabase/migrations/20251109120000_fix_user_stats_leaderboard_rls.sql
+++ b/supabase/migrations/20251109120000_fix_user_stats_leaderboard_rls.sql
@@ -1,0 +1,15 @@
+-- Fix user_stats RLS policies to allow leaderboard access
+-- Created: 2025-11-09
+-- Purpose: Allow anyone to read user_stats for leaderboard functionality while maintaining write security
+
+-- First, drop the existing restrictive SELECT policy
+DROP POLICY IF EXISTS "Users can view their own stats" ON user_stats;
+
+-- Create a new public read policy for leaderboard access
+-- This allows anyone (authenticated or anonymous) to read all user stats
+CREATE POLICY "Anyone can view user stats for leaderboard"
+  ON user_stats FOR SELECT
+  USING (true);
+
+-- Note: INSERT and UPDATE policies remain restricted to the user's own data
+-- This ensures users can only modify their own stats while everyone can view the leaderboard

--- a/supabase_migration.sql
+++ b/supabase_migration.sql
@@ -42,10 +42,11 @@ ALTER TABLE user_stats ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_achievements ENABLE ROW LEVEL SECURITY;
 
 -- 5. Create RLS policies for user_stats
--- Users can only read their own stats
-CREATE POLICY "Users can view their own stats"
+-- Allow anyone to read user stats (needed for leaderboard functionality)
+-- Updated: 2025-11-09 to fix 406 error on leaderboard
+CREATE POLICY "Anyone can view user stats for leaderboard"
   ON user_stats FOR SELECT
-  USING (auth.uid() = user_id);
+  USING (true);
 
 -- Users can insert their own stats
 CREATE POLICY "Users can insert their own stats"


### PR DESCRIPTION
## Problem
The application was receiving a 406 (Not Acceptable) error when accessing the user_stats table through the Supabase REST API, particularly affecting the leaderboard functionality.

Error URL:
smmkxxavexumewbfaqpy.supabase.co/rest/v1/user_stats?select=total_points&user_id=eq.927f8dd2-3918-4bca-82ea-1619cb4810ef

## Root Cause
The Row Level Security (RLS) policy on user_stats was too restrictive:
- Old policy: "Users can view their own stats" - USING (auth.uid() = user_id)
- This prevented the leaderboard from reading other users' stats
- The gamification_service.dart getLeaderboard() and getUserRank() methods need to read all users' stats to generate rankings

## Solution
Updated RLS policies to allow public read access while maintaining write security:

1. Created new migration: supabase/migrations/20251109120000_fix_user_stats_leaderboard_rls.sql
   - Drops old restrictive SELECT policy
   - Creates new policy: "Anyone can view user stats for leaderboard" - USING (true)

2. Updated base migration file: supabase_migration.sql
   - Changed SELECT policy to allow public reads
   - INSERT and UPDATE policies remain user-restricted for security

3. Added documentation:
   - FIX_USER_STATS_406_ERROR.md: Comprehensive fix guide with instructions
   - apply_user_stats_fix.sql: Ready-to-run SQL script for Supabase dashboard
   - Inline comments in gamification_service.dart explaining RLS requirements

## Security Considerations
- User stats are intentionally public for leaderboard/social features
- Write operations (INSERT/UPDATE) remain restricted to the data owner
- This aligns with the competitive/gamification nature of the app

## Testing
After applying the migration to Supabase:
1. The 406 error should be resolved
2. Leaderboard should display all users correctly
3. User rankings should calculate properly
4. Individual user stats remain updatable only by the owner

## Files Changed
- lib/services/gamification_service.dart: Added RLS policy documentation
- supabase_migration.sql: Updated base SELECT policy
- supabase/migrations/20251109120000_fix_user_stats_leaderboard_rls.sql: New migration
- FIX_USER_STATS_406_ERROR.md: Detailed fix documentation
- apply_user_stats_fix.sql: Quick-apply SQL script