### PR TITLE
Fix file picker exception in web version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   highlight: ^0.7.0                # シンタックスハイライト
   shared_preferences: ^2.3.3       # 追加：ローカルストレージ
   provider: ^6.1.2  # 追加
-  file_picker: ^8.1.2  # 追加
+  file_picker: ^9.2.3  # Web版で安定動作するバージョン
   mime: ^1.0.6  # 追加
   path: ^1.9.0  # 追加
   google_fonts: ^6.1.0  # 追加


### PR DESCRIPTION
- Updated file_picker from ^8.1.2 to ^9.2.3
- Version 9.2.3 is stable on web and fixes LateInitializationError
- Issue was caused by improper platform instance initialization in production builds
- See: https://github.com/miguelpruivo/flutter_file_picker/issues/1602