### PR TITLE
Implement personality diagnosis UI frontend

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'pages/referral_page.dart';
 import 'pages/daily_challenges_page.dart';
 import 'pages/memo_gallery_page.dart';
 import 'pages/documents_page.dart';
+import 'pages/personality_test_landing_page.dart';
 import 'services/theme_service.dart';
 
 // Supabaseクライアントのゲッター（late初期化を避ける）
@@ -174,6 +175,11 @@ class MyApp extends StatelessWidget {
             // ドキュメントページ（認証不要）
             return MaterialPageRoute(
               builder: (_) => const DocumentsPage(),
+            );
+          case '/personality-test':
+            // 性格診断ページ（認証不要）
+            return MaterialPageRoute(
+              builder: (_) => const PersonalityTestLandingPage(),
             );
           default:
             // デフォルトはランディングページ

--- a/lib/pages/daily_challenges_page.dart
+++ b/lib/pages/daily_challenges_page.dart
@@ -148,7 +148,7 @@ class _DailyChallengesPageState extends State<DailyChallengesPage> {
                 Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: iconColor.withOpacity(0.1),
+                    color: iconColor.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Icon(icon, color: iconColor, size: 32),

--- a/lib/pages/personality_test_landing_page.dart
+++ b/lib/pages/personality_test_landing_page.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import '../services/personality_test_service.dart';
+import '../models/personality_test.dart';
+import 'personality_test_questions_page.dart';
+import '../main.dart';
+
+/// 性格診断の開始ページ
+class PersonalityTestLandingPage extends StatelessWidget {
+  const PersonalityTestLandingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('性格診断'),
+        elevation: 0,
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            // ヒーローセクション
+            Container(
+              width: double.infinity,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [
+                    colorScheme.primary,
+                    colorScheme.secondary,
+                  ],
+                ),
+              ),
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                children: [
+                  Icon(
+                    Icons.psychology,
+                    size: 80,
+                    color: colorScheme.onPrimary,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'あなたの性格タイプを診断',
+                    style: textTheme.headlineMedium?.copyWith(
+                      color: colorScheme.onPrimary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'メモの書き方から性格がわかる！',
+                    style: textTheme.titleMedium?.copyWith(
+                      color: colorScheme.onPrimary.withValues(alpha: 0.9),
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+
+            // 機能紹介セクション
+            Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                children: [
+                  _FeatureCard(
+                    icon: Icons.timer,
+                    title: 'たった5分で完了',
+                    description: '60問の質問に答えるだけで、あなたの性格タイプがわかります',
+                    color: colorScheme.primary,
+                  ),
+                  const SizedBox(height: 16),
+                  _FeatureCard(
+                    icon: Icons.auto_awesome,
+                    title: '16種類の性格タイプ',
+                    description: 'MBTI準拠の科学的な性格分類で、あなたの特徴を詳しく分析',
+                    color: colorScheme.secondary,
+                  ),
+                  const SizedBox(height: 16),
+                  _FeatureCard(
+                    icon: Icons.article,
+                    title: '詳細な分析レポート',
+                    description: '強み・弱み・メモの書き方のアドバイスを提供',
+                    color: colorScheme.tertiary,
+                  ),
+                  const SizedBox(height: 32),
+
+                  // 診断開始ボタン
+                  SizedBox(
+                    width: double.infinity,
+                    height: 56,
+                    child: ElevatedButton(
+                      onPressed: () => _startTest(context),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: colorScheme.primary,
+                        foregroundColor: colorScheme.onPrimary,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: const Text(
+                        '診断を開始する（無料）',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+
+                  // 注意事項
+                  Text(
+                    '※ 診断結果は統計的な分類であり、個人を完全に特定するものではありません',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurface.withValues(alpha: 0.6),
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _startTest(BuildContext context) async {
+    try {
+      // ローディング表示
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+
+      // テストを開始
+      final service = PersonalityTestService();
+      final test = await service.startTest();
+
+      // ローディングを閉じる
+      if (context.mounted) {
+        Navigator.of(context).pop();
+      }
+
+      // 質問ページに遷移
+      if (context.mounted) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder: (context) => PersonalityTestQuestionsPage(testId: test.id),
+          ),
+        );
+      }
+    } catch (e) {
+      // エラー処理
+      if (context.mounted) {
+        Navigator.of(context).pop(); // ローディングを閉じる
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('診断の開始に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+}
+
+/// 機能カード
+class _FeatureCard extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String description;
+  final Color color;
+
+  const _FeatureCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            Container(
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(
+                icon,
+                size: 32,
+                color: color,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    description,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withValues(alpha: 0.7),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/personality_test_questions_page.dart
+++ b/lib/pages/personality_test_questions_page.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+import '../services/personality_test_service.dart';
+import '../models/personality_test.dart';
+import 'personality_test_result_page.dart';
+
+/// 性格診断の質問ページ
+class PersonalityTestQuestionsPage extends StatefulWidget {
+  final int testId;
+
+  const PersonalityTestQuestionsPage({
+    super.key,
+    required this.testId,
+  });
+
+  @override
+  State<PersonalityTestQuestionsPage> createState() =>
+      _PersonalityTestQuestionsPageState();
+}
+
+class _PersonalityTestQuestionsPageState
+    extends State<PersonalityTestQuestionsPage> {
+  final PersonalityTestService _service = PersonalityTestService();
+  List<PersonalityQuestion> _questions = [];
+  int _currentQuestionIndex = 0;
+  bool _isLoading = true;
+  bool _isSubmitting = false;
+  final Map<int, String> _answers = {}; // questionId -> answer (A or B)
+
+  @override
+  void initState() {
+    super.initState();
+    _loadQuestions();
+  }
+
+  Future<void> _loadQuestions() async {
+    try {
+      final questions = await _service.getQuestions();
+      setState(() {
+        _questions = questions;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('質問の読み込みに失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _answerQuestion(String answer) async {
+    if (_isSubmitting) return;
+
+    setState(() {
+      _isSubmitting = true;
+    });
+
+    try {
+      final question = _questions[_currentQuestionIndex];
+
+      // 回答を保存
+      await _service.saveAnswer(
+        testId: widget.testId,
+        questionId: question.id,
+        answer: answer,
+      );
+
+      // 回答をローカルに記録
+      _answers[question.id] = answer;
+
+      // 次の質問へ進む、または結果ページへ
+      if (_currentQuestionIndex < _questions.length - 1) {
+        setState(() {
+          _currentQuestionIndex++;
+          _isSubmitting = false;
+        });
+      } else {
+        // 全質問完了 - スコアを計算して結果ページへ
+        await _completeTest();
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('回答の保存に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+      setState(() {
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  Future<void> _completeTest() async {
+    try {
+      // スコアを計算
+      final scores = await _service.calculateScores(widget.testId);
+
+      // 性格タイプを判定
+      final personalityType = _service.determinePersonalityType(scores);
+
+      // テストを完了
+      await _service.completeTest(widget.testId, personalityType);
+
+      // 結果ページへ遷移
+      if (mounted) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder: (context) => PersonalityTestResultPage(
+              testId: widget.testId,
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('診断の完了に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+      setState(() {
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  void _goToPreviousQuestion() {
+    if (_currentQuestionIndex > 0) {
+      setState(() {
+        _currentQuestionIndex--;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    if (_isLoading) {
+      return const Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (_questions.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('性格診断'),
+        ),
+        body: const Center(
+          child: Text('質問が見つかりませんでした'),
+        ),
+      );
+    }
+
+    final question = _questions[_currentQuestionIndex];
+    final progress = (_currentQuestionIndex + 1) / _questions.length;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('質問 ${_currentQuestionIndex + 1} / ${_questions.length}'),
+        elevation: 0,
+      ),
+      body: Column(
+        children: [
+          // プログレスバー
+          LinearProgressIndicator(
+            value: progress,
+            minHeight: 6,
+            backgroundColor: colorScheme.surfaceContainerHighest,
+            valueColor: AlwaysStoppedAnimation<Color>(colorScheme.primary),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              '${(progress * 100).toInt()}% 完了',
+              style: textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurface.withValues(alpha: 0.7),
+              ),
+            ),
+          ),
+
+          // 質問と選択肢
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // 質問テキスト
+                  Card(
+                    elevation: 2,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Text(
+                        question.text,
+                        style: textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+
+                  // 選択肢A
+                  _AnswerButton(
+                    label: 'A',
+                    text: question.optionA,
+                    onPressed: _isSubmitting
+                        ? null
+                        : () => _answerQuestion('A'),
+                    color: colorScheme.primary,
+                  ),
+                  const SizedBox(height: 16),
+
+                  // 選択肢B
+                  _AnswerButton(
+                    label: 'B',
+                    text: question.optionB,
+                    onPressed: _isSubmitting
+                        ? null
+                        : () => _answerQuestion('B'),
+                    color: colorScheme.secondary,
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // 戻るボタン
+          if (_currentQuestionIndex > 0)
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: TextButton.icon(
+                onPressed: _isSubmitting ? null : _goToPreviousQuestion,
+                icon: const Icon(Icons.arrow_back),
+                label: const Text('前の質問に戻る'),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 回答ボタン
+class _AnswerButton extends StatelessWidget {
+  final String label;
+  final String text;
+  final VoidCallback? onPressed;
+  final Color color;
+
+  const _AnswerButton({
+    required this.label,
+    required this.text,
+    required this.onPressed,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isEnabled = onPressed != null;
+
+    return Card(
+      elevation: isEnabled ? 2 : 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(
+          color: isEnabled
+              ? color.withValues(alpha: 0.3)
+              : colorScheme.outline.withValues(alpha: 0.2),
+          width: 2,
+        ),
+      ),
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: isEnabled
+                      ? color.withValues(alpha: 0.15)
+                      : colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Center(
+                  child: Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: isEnabled
+                          ? color
+                          : colorScheme.onSurface.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Text(
+                  text,
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: isEnabled
+                        ? colorScheme.onSurface
+                        : colorScheme.onSurface.withValues(alpha: 0.5),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/personality_test_result_page.dart
+++ b/lib/pages/personality_test_result_page.dart
@@ -1,0 +1,471 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../services/personality_test_service.dart';
+import '../models/personality_test.dart';
+import '../services/app_share_service.dart';
+
+/// 性格診断の結果ページ
+class PersonalityTestResultPage extends StatefulWidget {
+  final int testId;
+
+  const PersonalityTestResultPage({
+    super.key,
+    required this.testId,
+  });
+
+  @override
+  State<PersonalityTestResultPage> createState() =>
+      _PersonalityTestResultPageState();
+}
+
+class _PersonalityTestResultPageState extends State<PersonalityTestResultPage> {
+  final PersonalityTestService _service = PersonalityTestService();
+  PersonalityTest? _test;
+  PersonalityType? _personalityType;
+  Map<String, int>? _scores;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadResult();
+  }
+
+  Future<void> _loadResult() async {
+    try {
+      final test = await _service.getTestResult(widget.testId);
+      final scores = await _service.calculateScores(widget.testId);
+      final personalityType =
+          _service.getPersonalityTypeDetails(test.personalityType!);
+
+      setState(() {
+        _test = test;
+        _scores = scores;
+        _personalityType = personalityType;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('結果の読み込みに失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _shareToTwitter() async {
+    if (_personalityType == null || _test == null) return;
+
+    final text = '''
+性格診断の結果: ${_personalityType!.code}（${_personalityType!.nameJa}）🧠
+
+「${_personalityType!.nameEn}」タイプ
+
+${_personalityType!.description}
+
+#マイメモ #性格診断 #MBTI
+''';
+
+    final url = 'https://mymemo.app/personality-test';
+
+    await AppShareService.shareToTwitter(text, url);
+  }
+
+  Future<void> _copyToClipboard() async {
+    if (_personalityType == null) return;
+
+    final text = '''
+性格診断の結果: ${_personalityType!.code}（${_personalityType!.nameJa}）
+
+「${_personalityType!.nameEn}」タイプ
+
+${_personalityType!.description}
+''';
+
+    await Clipboard.setData(ClipboardData(text: text));
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('クリップボードにコピーしました'),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    if (_isLoading) {
+      return const Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (_test == null || _personalityType == null || _scores == null) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('性格診断結果'),
+        ),
+        body: const Center(
+          child: Text('結果が見つかりませんでした'),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('診断結果'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.share),
+            onPressed: _shareToTwitter,
+            tooltip: 'Twitterでシェア',
+          ),
+          IconButton(
+            icon: const Icon(Icons.copy),
+            onPressed: _copyToClipboard,
+            tooltip: 'コピー',
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            // ヒーローセクション
+            Container(
+              width: double.infinity,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [
+                    colorScheme.primary,
+                    colorScheme.secondary,
+                  ],
+                ),
+              ),
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                children: [
+                  const Icon(
+                    Icons.celebration,
+                    size: 64,
+                    color: Colors.white,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'あなたの性格タイプは...',
+                    style: textTheme.titleLarge?.copyWith(
+                      color: Colors.white.withValues(alpha: 0.9),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    _personalityType!.code,
+                    style: textTheme.displayLarge?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '${_personalityType!.nameJa}（${_personalityType!.nameEn}）',
+                    style: textTheme.headlineSmall?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+
+            // 説明セクション
+            Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Card(
+                    elevation: 2,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(20),
+                      child: Text(
+                        _personalityType!.description,
+                        style: textTheme.bodyLarge,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+
+                  // 性格の特徴（スコア）
+                  _SectionTitle(
+                    icon: Icons.bar_chart,
+                    title: '性格の特徴',
+                    color: colorScheme.primary,
+                  ),
+                  const SizedBox(height: 16),
+                  _buildScoreBar('内向的 / 外向的', 'E/I', _scores!['E/I']!),
+                  const SizedBox(height: 12),
+                  _buildScoreBar('感覚的 / 直感的', 'N/S', _scores!['N/S']!),
+                  const SizedBox(height: 12),
+                  _buildScoreBar('感情型 / 思考型', 'T/F', _scores!['T/F']!),
+                  const SizedBox(height: 12),
+                  _buildScoreBar('柔軟的 / 計画的', 'J/P', _scores!['J/P']!),
+                  const SizedBox(height: 12),
+                  _buildScoreBar('慎重 / 自己主張的', 'A/T', _scores!['A/T']!),
+                  const SizedBox(height: 24),
+
+                  // 強み
+                  _SectionTitle(
+                    icon: Icons.star,
+                    title: '強み',
+                    color: Colors.amber,
+                  ),
+                  const SizedBox(height: 16),
+                  ..._personalityType!.strengths.map(
+                    (strength) => Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.check_circle,
+                            color: Colors.green,
+                            size: 20,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              strength,
+                              style: textTheme.bodyMedium,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+
+                  // 弱み
+                  _SectionTitle(
+                    icon: Icons.warning,
+                    title: '注意すべき点',
+                    color: Colors.orange,
+                  ),
+                  const SizedBox(height: 16),
+                  ..._personalityType!.weaknesses.map(
+                    (weakness) => Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.info,
+                            color: Colors.orange,
+                            size: 20,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              weakness,
+                              style: textTheme.bodyMedium,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+
+                  // メモの書き方のアドバイス
+                  _SectionTitle(
+                    icon: Icons.tips_and_updates,
+                    title: 'メモの書き方のアドバイス',
+                    color: colorScheme.secondary,
+                  ),
+                  const SizedBox(height: 16),
+                  ..._personalityType!.noteAdvice.map(
+                    (advice) => Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Icon(
+                            Icons.lightbulb,
+                            color: colorScheme.secondary,
+                            size: 20,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              advice,
+                              style: textTheme.bodyMedium,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+
+                  // アクションボタン
+                  SizedBox(
+                    width: double.infinity,
+                    height: 48,
+                    child: ElevatedButton.icon(
+                      onPressed: _shareToTwitter,
+                      icon: const Icon(Icons.share),
+                      label: const Text('Twitterでシェア'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF1DA1F2), // Twitter blue
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    height: 48,
+                    child: OutlinedButton.icon(
+                      onPressed: () => Navigator.of(context).pop(),
+                      icon: const Icon(Icons.home),
+                      label: const Text('ホームに戻る'),
+                      style: OutlinedButton.styleFrom(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScoreBar(String label, String axis, int score) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    // スコアを0-100の範囲に正規化（-12から+12の範囲を想定）
+    final normalizedScore = ((score + 12) / 24 * 100).clamp(0, 100).toInt();
+
+    // 軸の左右ラベルを取得
+    final parts = axis.split('/');
+    final leftLabel = parts[1]; // 例: "I"（内向的）
+    final rightLabel = parts[0]; // 例: "E"（外向的）
+
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  label,
+                  style: textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                Text(
+                  '$normalizedScore%',
+                  style: textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.primary,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: normalizedScore / 100,
+                minHeight: 8,
+                backgroundColor: colorScheme.surfaceContainerHighest,
+                valueColor: AlwaysStoppedAnimation<Color>(colorScheme.primary),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  leftLabel,
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurface.withValues(alpha: 0.6),
+                  ),
+                ),
+                Text(
+                  rightLabel,
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurface.withValues(alpha: 0.6),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// セクションタイトル
+class _SectionTitle extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final Color color;
+
+  const _SectionTitle({
+    required this.icon,
+    required this.title,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          color: color,
+          size: 24,
+        ),
+        const SizedBox(width: 8),
+        Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/home_page/home_app_bar.dart
+++ b/lib/widgets/home_page/home_app_bar.dart
@@ -14,6 +14,7 @@ import '../../pages/template_marketplace_page.dart';
 import '../../pages/import_page.dart';
 import '../../pages/activity_feed_page.dart';
 import '../../pages/ai_secretary_page.dart';
+import '../../pages/personality_test_landing_page.dart';
 import '../../services/search_history_service.dart';
 import '../../services/app_share_service.dart';
 import '../../models/user_stats.dart';
@@ -281,6 +282,13 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
           ).then((_) {
             onLoadUserStats();
           });
+        } else if (value == 'personality_test') {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const PersonalityTestLandingPage()),
+          ).then((_) {
+            onLoadUserStats();
+          });
         } else if (value == 'ai_secretary') {
           Navigator.push(
             context,
@@ -461,6 +469,16 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
               Icon(Icons.task_alt, color: Colors.orange),
               SizedBox(width: 8),
               Text('デイリーチャレンジ'),
+            ],
+          ),
+        ),
+        const PopupMenuItem(
+          value: 'personality_test',
+          child: Row(
+            children: [
+              Icon(Icons.psychology, color: Colors.deepPurple),
+              SizedBox(width: 8),
+              Text('🧠 性格診断'),
             ],
           ),
         ),


### PR DESCRIPTION
機能追加:
- 性格診断開始ページの実装 (PersonalityTestLandingPage)
  - 16personalities風の魅力的なランディングページ
  - 機能紹介セクション（5分で完了、16種類のタイプ、詳細レポート）
- 性格診断質問ページの実装 (PersonalityTestQuestionsPage)
  - 60問の質問を1問ずつ表示
  - プログレスバー表示
  - 前の質問に戻る機能
  - 回答の自動保存
- 性格診断結果ページの実装 (PersonalityTestResultPage)
  - 16タイプの性格診断結果表示
  - 5つの性格軸のスコア表示（E/I, N/S, T/F, J/P, A/T）
  - 強み・弱み・メモの書き方アドバイス表示
  - Twitterシェア機能
  - クリップボードコピー機能
- main.dartに性格診断ルーティング追加 (/personality-test)
- HomePageのメニューに性格診断へのリンク追加

バグ修正:
- daily_challenges_page.dartのLinterエラー修正
  - withOpacity() → withValues(alpha:) に変更（Dart 3対応）

バックエンド:
- データベース、モデル、サービスは実装済み
- PersonalityTestService: 診断開始、質問取得、回答保存、スコア計算、タイプ判定
- 16タイプの詳細データをハードコードで実装済み