### PR TITLE
Fix referral codes API query and ListView layout error

### DIFF
--- a/lib/services/viral_growth_service.dart
+++ b/lib/services/viral_growth_service.dart
@@ -100,19 +100,19 @@ class ViralGrowthService {
       // 既存の紹介コードを取得
       final response = await _supabase
           .from('referral_codes')
-          .select('code')
+          .select('referral_code')
           .eq('user_id', userId)
           .maybeSingle();
 
       String referralCode;
       if (response != null) {
-        referralCode = response['code'] as String;
+        referralCode = response['referral_code'] as String;
       } else {
         // 新規作成（通常は既に存在するはず）
         referralCode = _generateRandomCode();
         await _supabase.from('referral_codes').insert({
           'user_id': userId,
-          'code': referralCode,
+          'referral_code': referralCode,
         });
       }
 


### PR DESCRIPTION
The referral_codes table uses 'referral_code' as the column name, not 'code'. This was causing 400 Bad Request errors when generating invite links. Fixed in three places:
- SELECT query to use 'referral_code'
- Response access to use response['referral_code']
- INSERT statement to use 'referral_code' key

Resolves PostgrestException: column referral_codes.code does not exist