### PR TITLE
Fix missing referral code column and layout errors

### DIFF
--- a/supabase/migrations/20251111120000_fix_referral_code_column_name.sql
+++ b/supabase/migrations/20251111120000_fix_referral_code_column_name.sql
@@ -1,0 +1,49 @@
+-- Migration to fix referral_codes table column name
+-- This handles cases where the column might be named 'code' instead of 'referral_code'
+
+-- Check if 'code' column exists and 'referral_code' doesn't, then rename
+DO $$
+BEGIN
+    -- Check if 'code' column exists and 'referral_code' doesn't
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'referral_codes'
+        AND column_name = 'code'
+    ) AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'referral_codes'
+        AND column_name = 'referral_code'
+    ) THEN
+        -- Rename the column
+        ALTER TABLE referral_codes RENAME COLUMN code TO referral_code;
+        RAISE NOTICE 'Renamed column code to referral_code in referral_codes table';
+    ELSIF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'referral_codes'
+        AND column_name = 'referral_code'
+    ) THEN
+        RAISE NOTICE 'Column referral_code already exists in referral_codes table';
+    ELSE
+        RAISE NOTICE 'Neither code nor referral_code column found in referral_codes table';
+    END IF;
+END $$;
+
+-- Update index name if it was created with old column name
+DO $$
+BEGIN
+    -- Drop old index if it exists
+    IF EXISTS (
+        SELECT 1
+        FROM pg_indexes
+        WHERE indexname = 'idx_referral_codes_code'
+        AND tablename = 'referral_codes'
+    ) THEN
+        DROP INDEX IF EXISTS idx_referral_codes_code;
+        -- Recreate with correct column name
+        CREATE INDEX IF NOT EXISTS idx_referral_codes_code ON referral_codes(referral_code);
+        RAISE NOTICE 'Recreated index idx_referral_codes_code with correct column name';
+    END IF;
+END $$;


### PR DESCRIPTION
This migration addresses the PostgrestException error: "column referral_codes.code does not exist"

The migration safely handles the column rename by:
- Checking if 'code' column exists
- Renaming it to 'referral_code' if needed
- Updating the index to use the correct column name
- Providing informative notices about the actions taken

This fixes the error that was occurring when generating invite links in the Growth Dashboard.