### PR TITLE
Fix Flutter document viewer layout and asset loading

### DIFF
--- a/lib/widgets/markdown_preview.dart
+++ b/lib/widgets/markdown_preview.dart
@@ -19,6 +19,8 @@ class MarkdownPreview extends StatelessWidget {
     return Markdown(
       data: data,
       selectable: selectable,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
       styleSheet: MarkdownStyleSheet(
         // 見出しスタイル
         h1: const TextStyle(


### PR DESCRIPTION
- Add shrinkWrap: true to Markdown widget to prevent unbounded height
- Add physics: NeverScrollableScrollPhysics() to disable nested scrolling
- Fixes "Vertical viewport was given unbounded height" error
- Allows outer SingleChildScrollView to handle all scrolling