### PR TITLE
Fix duplicate method and web build errors

### DIFF
--- a/lib/pages/note_editor_page.dart
+++ b/lib/pages/note_editor_page.dart
@@ -517,12 +517,6 @@ class _NoteEditorPageState extends State<NoteEditorPage>
     }
   }
 
-  // リマインダーダイアログを表示
-  Future<void> _showReminderDialog() async {
-    // 既存のリマインダー機能の実装...
-    // TODO: 実装が必要な場合は追加
-  }
-
   // AI機能メニューを表示
   void _showAIMenu() {
     showModalBottomSheet(


### PR DESCRIPTION
Removed duplicate _showReminderDialog stub (lines 521-524) that was causing compilation error. The correct implementation at lines 415-425 remains.

This fixes the build error:
Error: '_showReminderDialog' is already declared in this scope.