### PR TITLE
Fix duplicate key error in personality scores

### DIFF
--- a/lib/services/personality_test_service.dart
+++ b/lib/services/personality_test_service.dart
@@ -92,11 +92,14 @@ class PersonalityTestService {
 
       // スコアを保存
       for (var entry in scores.entries) {
-        await _supabase.from('personality_scores').upsert({
-          'test_id': testId,
-          'axis': entry.key,
-          'score': entry.value,
-        });
+        await _supabase.from('personality_scores').upsert(
+          {
+            'test_id': testId,
+            'axis': entry.key,
+            'score': entry.value,
+          },
+          onConflict: 'test_id,axis',
+        );
       }
 
       return scores;

--- a/supabase/migrations/20251111130000_add_personality_scores_update_policy.sql
+++ b/supabase/migrations/20251111130000_add_personality_scores_update_policy.sql
@@ -1,0 +1,8 @@
+-- 性格診断スコアのUPDATEポリシーを追加
+-- 作成日: 2025年11月11日
+-- 目的: upsert操作が正常に動作するようにUPDATEポリシーを追加
+
+-- personality_scoresテーブルにUPDATEポリシーを追加
+CREATE POLICY "Users can update their own scores"
+  ON personality_scores FOR UPDATE
+  USING (test_id IN (SELECT id FROM personality_tests WHERE user_id = auth.uid()));


### PR DESCRIPTION
Adds missing UPDATE policy for personality_scores table and specifies onConflict parameter in upsert operation to properly handle duplicate score entries when recalculating test results.

- Add UPDATE policy to allow users to update their own scores
- Specify onConflict parameter in upsert to target test_id,axis constraint
- Resolves PostgrestException with code 23505 (duplicate key violation)