### PR TITLE
Fix memo editor button overflow on mobile

### DIFF
--- a/lib/pages/document_viewer_page.dart
+++ b/lib/pages/document_viewer_page.dart
@@ -145,12 +145,12 @@ class _DocumentViewerPageState extends State<DocumentViewerPage> {
                           decoration: BoxDecoration(
                             color: Theme.of(context)
                                 .primaryColor
-                                .withOpacity(0.05),
+                                .withValues(alpha: 0.05),
                             borderRadius: BorderRadius.circular(12),
                             border: Border.all(
                               color: Theme.of(context)
                                   .primaryColor
-                                  .withOpacity(0.1),
+                                  .withValues(alpha: 0.1),
                             ),
                           ),
                           child: Column(


### PR DESCRIPTION
- メモ編集画面のボタンオーバーフロー問題を修正
  - AppBarのボタンを2つに削減（メニュー、保存して閉じる）
  - BottomAppBarを追加（UNDO/REDO、お気に入り、AI、保存）
  - その他の機能はメニューに集約（ピン留め、リマインダー、タイマー、添付ファイル、ヘルプ）
  - スマホでもボタンがはみ出さなくなった

- withOpacity非推奨警告を修正
  - document_viewer_page.dartのwithOpacityをwithValues(alpha:)に変更
  - Dart 3の推奨APIに対応