### PR TITLE
Fix trailing comma lint error in note editor

### DIFF
--- a/lib/pages/note_editor_page.dart
+++ b/lib/pages/note_editor_page.dart
@@ -90,7 +90,7 @@ class _NoteEditorPageState extends State<NoteEditorPage>
       content: _contentController.text,
       categoryId: _selectedCategoryId != null ? int.tryParse(_selectedCategoryId!) : null,
       timestamp: DateTime.now(),
-    ));
+    ),);
 
     // テキストコントローラーにリスナーを追加
     _titleController.addListener(_onTextChanged);


### PR DESCRIPTION
- Added trailing comma after NoteSnapshot() call in initState()
- Ensures compliance with require_trailing_commas lint rule
- Resolves linter error at line 93