### PR TITLE
docs: LINE を第18競合として追加

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -1,9 +1,9 @@
 # 成長戦略ロードマップ - 自分株式会社
 
 作成日: 2025-11-10
-最終更新: 2026-03-27 session27 (追加: Discord を第17競合として追加)
+最終更新: 2026-03-27 session28 (追加: LINE を第18競合として追加)
 現時点の登録者数: 4人
-最重要目的: Notion・EverNote・MoneyForward・X・Animaworks・Claude Code・Codex・netkeiba・OpenClaw・Claude Cowork・Chatwork・Slack・ジョブカン・Amazon・Google・Microsoft・Discord を上回る規模の知的生産・資産管理・SNS 統合プラットフォームを作る
+最重要目的: Notion・EverNote・MoneyForward・X・Animaworks・Claude Code・Codex・netkeiba・OpenClaw・Claude Cowork・Chatwork・Slack・ジョブカン・Amazon・Google・Microsoft・Discord・LINE を上回る規模の知的生産・資産管理・SNS 統合プラットフォームを作る
 運用原則: flutter analyze を常に 0 に保ち、複雑な処理は可能な限り Supabase Edge Function へ移す
 
 ---
@@ -43,6 +43,7 @@
 - Google: ~4,300,000,000 users 規模 (Google Workspace・Search・Android・YouTube・Cloud)
 - Microsoft: ~1,500,000,000 users 規模 (Microsoft 365・Windows・Azure・LinkedIn・GitHub)
 - Discord: ~200,000,000 monthly active users 規模 (ゲーム・コミュニティ・ボイスチャット・サーバー管理)
+- LINE: ~196,000,000 monthly active users 規模 (メッセージング・決済・ニュース・日本/台湾/タイ/インドネシア)
 
 2026-03-24 に再確認した公開ベンチマークの前提は次の通り。
 
@@ -59,7 +60,7 @@
 - Slack: 世界的シェアを誇るビジネスチャット・連携プラットフォーム (~6,500 万ユーザー)
 - ジョブカン: 導入実績 25 万社を超える国内シェアトップクラスのバックオフィスシステム (~500 万ユーザー推定)
 
-自分株式会社 はこれら 17 のサービスを上回るために、移行、AI、共有、紹介、法人展開を同時に強化する。
+自分株式会社 はこれら 18 のサービスを上回るために、移行、AI、共有、紹介、法人展開を同時に強化する。
 
 ---
 

--- a/supabase/migrations/20260327000005_add_line_growth_plan.sql
+++ b/supabase/migrations/20260327000005_add_line_growth_plan.sql
@@ -1,0 +1,5 @@
+-- Add vs LINE to growth_plans table
+-- LINE: ~196,000,000 monthly active users (Japan/Taiwan/Thailand/Indonesia messaging + fintech)
+INSERT INTO growth_plans (label, deadline, target, features_done, features_total)
+VALUES ('vs LINE', '2036年12月31日', 196000000, 3, 25)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- `growth_plans` に LINE (1.96億MAU, 期限2036年12月) を追加
- ロードマップを18競合に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)