### PR TITLE
feat: 思考妨害排除機能の設計書 + abstinence_slips テーブル

### DIFF
--- a/docs/technical/THOUGHT_INTERRUPT_ELIMINATOR_DESIGN.md
+++ b/docs/technical/THOUGHT_INTERRUPT_ELIMINATOR_DESIGN.md
@@ -1,0 +1,110 @@
+# 思考妨害排除機能 設計書
+
+## 概要
+
+自分の思考をぶった切ってくる「邪魔」を特定して排除する機能。
+既存の禁欲ガード (`abstinence_guard_page.dart`) を拡張し、
+**パターン認識** + **AI診断** + **リアルタイム介入** を追加する。
+
+## 現状 (既に実装済み)
+
+`AbstinenceGuardStore` に以下のプリセットが存在:
+
+| ID | ラベル | カテゴリ |
+|----|--------|----------|
+| sns | SNS | デジタル |
+| mobile_games | スマホゲーム | デジタル |
+| video | 動画 | デジタル |
+| manga | 漫画 | デジタル |
+| smartphone | スマホ | デジタル |
+| masturbation | マスターベーション | 衝動 |
+| smoking | 煙草 | 衝動 |
+| alcohol | 酒 | 衝動 |
+| lust | 性欲 | 衝動 |
+| dating_apps | 出会い・異性探索 | 衝動 |
+| gambling | ギャンブル | 衝動 |
+| eating_out | 外食 | 衝動 |
+| touch_hair | 髪をさわる | 癖 |
+| touch_beard | 髭をさわる | 癖 |
+
+## 追加すべき機能
+
+### 1. 思考妨害パターン診断 (新規)
+
+ユーザーに以下の質問をして、最大の思考妨害要因を特定する:
+
+```
+Q1: 集中が途切れた時、最初に何をしますか？
+  → SNS / ゲーム / 動画 / 漫画 / スマホを手に取る / 食べ物を探す
+
+Q2: 作業中に衝動が来た時、何をしたくなりますか？
+  → タバコ / 酒 / オナニー / 出会い系 / ギャンブル / 間食
+
+Q3: 1日のうち、最も集中が途切れやすい時間帯は？
+  → 朝 / 昼食後 / 午後 / 夕方 / 夜 / 深夜
+
+Q4: 集中が途切れる前に気づく「サイン」はありますか？
+  → 手が無意識に動く / 目が泳ぐ / 姿勢が崩れる / あくびが出る / 何も感じない
+```
+
+結果から「あなたの最大の思考妨害」を特定し、禁欲ガードの該当項目を自動有効化。
+
+### 2. リアルタイム介入ウィジェット (新規)
+
+ホーム画面に「今この瞬間の妨害を排除」ボタンを追加:
+
+```
+🛡️ 思考妨害を排除
+今の衝動: [SNS] [ゲーム] [動画] [オナニー] [タバコ]
+↑ タップで即座に排除アクションを表示
+```
+
+タップすると、該当の `eliminationAction` と `replacementAction` を表示し、
+slip をカウントする。
+
+### 3. 週次パターンレポート (新規)
+
+slip データから週次パターンを分析:
+- 最も slip が多い曜日
+- 最も slip が多い時間帯 (要: slip時のタイムスタンプ記録)
+- 連続防衛日数 (streak)
+- 改善トレンド
+
+### 4. AI による介入提案
+
+`ai-assistant` Edge Function を使い、slip パターンから
+パーソナライズされた介入策を生成:
+
+```
+「あなたは金曜の夜にSNSとオナニーのslipが集中しています。
+ 金曜18時以降はスマホを別室に置き、
+ 代わりに本を1章読む習慣に置き換えることを提案します。」
+```
+
+## データベース変更 (マイグレーション)
+
+### abstinence_slips テーブル (新規)
+
+```sql
+CREATE TABLE IF NOT EXISTS abstinence_slips (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid REFERENCES auth.users(id),
+  item_id text NOT NULL,
+  slipped_at timestamptz NOT NULL DEFAULT now(),
+  context text,  -- 'morning' | 'afternoon' | 'night' | etc.
+  trigger_note text,  -- ユーザーが入力する「何がきっかけだったか」
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+現状は SharedPreferences (ローカル) に保存しているが、
+パターン分析にはサーバーサイドに移行する必要がある。
+
+## 実装担当
+
+| タスク | 担当 |
+|--------|------|
+| abstinence_slips テーブル | Windows版 (マイグレーション) |
+| 禁欲ガードUI改善 | VSCode版 (lib/) |
+| AI 介入提案 | Web版 (Edge Function) |
+| 思考妨害診断UI | VSCode版 (lib/) |

--- a/supabase/migrations/20260327000008_create_abstinence_slips.sql
+++ b/supabase/migrations/20260327000008_create_abstinence_slips.sql
@@ -1,0 +1,60 @@
+-- 思考妨害排除: slip ログをサーバーサイドに記録
+-- SharedPreferences → Supabase に移行し、パターン分析を可能にする
+
+CREATE TABLE IF NOT EXISTS abstinence_slips (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid NOT NULL,
+  item_id text NOT NULL,
+  slipped_at timestamptz NOT NULL DEFAULT now(),
+  day_of_week int GENERATED ALWAYS AS (EXTRACT(DOW FROM slipped_at AT TIME ZONE 'Asia/Tokyo')::int) STORED,
+  hour_of_day int GENERATED ALWAYS AS (EXTRACT(HOUR FROM slipped_at AT TIME ZONE 'Asia/Tokyo')::int) STORED,
+  trigger_note text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- ユーザー別・日付別のslip集計を高速化
+CREATE INDEX IF NOT EXISTS idx_abstinence_slips_user_date
+  ON abstinence_slips (user_id, slipped_at DESC);
+
+-- item_id別のパターン分析用
+CREATE INDEX IF NOT EXISTS idx_abstinence_slips_item
+  ON abstinence_slips (item_id, slipped_at DESC);
+
+-- 曜日・時間帯のパターン分析用
+CREATE INDEX IF NOT EXISTS idx_abstinence_slips_pattern
+  ON abstinence_slips (user_id, day_of_week, hour_of_day);
+
+-- RLS
+ALTER TABLE abstinence_slips ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_own_slips"
+  ON abstinence_slips
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "service_role_full_access_slips"
+  ON abstinence_slips
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- 週次パターン分析用のビュー
+CREATE OR REPLACE VIEW abstinence_weekly_pattern AS
+SELECT
+  user_id,
+  item_id,
+  day_of_week,
+  hour_of_day,
+  COUNT(*) as slip_count,
+  MAX(slipped_at) as last_slip
+FROM abstinence_slips
+WHERE slipped_at >= NOW() - INTERVAL '30 days'
+GROUP BY user_id, item_id, day_of_week, hour_of_day
+ORDER BY slip_count DESC;
+
+COMMENT ON TABLE abstinence_slips IS '思考妨害の逸脱ログ (禁欲ガードのslip記録)';
+COMMENT ON COLUMN abstinence_slips.item_id IS 'sns, video, masturbation, smoking 等のプリセットID';
+COMMENT ON COLUMN abstinence_slips.trigger_note IS 'ユーザーが入力する「何がきっかけだったか」メモ';
+COMMENT ON COLUMN abstinence_slips.day_of_week IS '曜日 (0=日曜, 6=土曜) - 自動計算';
+COMMENT ON COLUMN abstinence_slips.hour_of_day IS '時間帯 (0-23, JST) - 自動計算';


### PR DESCRIPTION
## Summary
- 思考妨害排除機能の設計書 (パターン診断・リアルタイム介入・AI提案)
- `abstinence_slips` テーブル作成 (slip ログをサーバーサイドに移行)
- 曜日・時間帯パターン分析ビュー

## 背景
既存の禁欲ガードにはプリセット(SNS/ゲーム/動画/漫画/オナニー/煙草/酒/異性)があるが、
「思考を妨害するパターンを特定する」機能が不足していた

## Test plan
- [ ] マイグレーション実行後、abstinence_slips テーブルが作成されること
- [ ] abstinence_weekly_pattern ビューが機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)