### PR TITLE
feat: メール整理ルーチンチェックリスト + サブスク管理

### DIFF
--- a/lib/pages/email_cleanup_page.dart
+++ b/lib/pages/email_cleanup_page.dart
@@ -362,10 +362,30 @@ class _EmailCleanupPageState extends State<EmailCleanupPage> {
     }
   }
 
+  static const _routineSteps = [
+    '1. 未読メールを全件チェックし、不要なものを削除',
+    '2. メルマガ・プロモーションを確認し、不要なものは配信停止(unsubscribe)',
+    '3. 通知メール(SNS/アプリ)で不要なものは通知設定をOFF',
+    '4. サブスク関連メールを確認し、使っていないサービスは解約',
+    '5. フィルタ・ラベルを整理し、自動振り分けルールを追加',
+    '6. ゴミ箱・迷惑メールフォルダを空にする',
+    '7. 重要なメールにスター/フラグを付ける',
+  ];
+
+  List<bool> _routineChecks = [];
+
+  void _initRoutineChecks() {
+    if (_routineChecks.isEmpty) {
+      _routineChecks = List.filled(_routineSteps.length, false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    _initRoutineChecks();
     final needsCleanAccounts =
         _accounts.where((a) => a['is_active'] == true && _needsClean(a));
+    final routineDone = _routineChecks.where((c) => c).length;
 
     return Scaffold(
       appBar: AppBar(
@@ -386,11 +406,96 @@ class _EmailCleanupPageState extends State<EmailCleanupPage> {
                   children: [
                     if (needsCleanAccounts.isNotEmpty) ...[
                       _buildReminderBanner(needsCleanAccounts.length),
-                      const SizedBox(height: 16),
+                      const SizedBox(height: 12),
                     ],
+                    _buildRoutineCard(routineDone),
+                    const SizedBox(height: 16),
                     ..._accounts.map(_buildAccountCard),
                   ],
                 ),
+    );
+  }
+
+  Widget _buildRoutineCard(int doneCount) {
+    final progress = _routineSteps.isEmpty
+        ? 0.0
+        : doneCount / _routineSteps.length;
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(14),
+        side: BorderSide(
+          color: progress >= 1.0
+              ? Colors.green.shade200
+              : Colors.indigo.shade100,
+        ),
+      ),
+      child: ExpansionTile(
+        leading: Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: progress >= 1.0
+                ? Colors.green.shade50
+                : const Color(0xFFEDE7F6),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Icon(
+            progress >= 1.0 ? Icons.check_circle : Icons.checklist,
+            color: progress >= 1.0
+                ? Colors.green
+                : const Color(0xFF4338CA),
+          ),
+        ),
+        title: Text(
+          progress >= 1.0
+              ? '✅ 整理ルーチン完了！'
+              : '📋 メール整理ルーチン ($doneCount/${_routineSteps.length})',
+          style: const TextStyle(
+            fontWeight: FontWeight.w700,
+            fontSize: 14,
+          ),
+        ),
+        subtitle: progress < 1.0
+            ? LinearProgressIndicator(
+                value: progress,
+                backgroundColor: Colors.grey.shade200,
+                valueColor: const AlwaysStoppedAnimation(Color(0xFF4338CA)),
+                minHeight: 4,
+                borderRadius: BorderRadius.circular(2),
+              )
+            : null,
+        initiallyExpanded: progress < 1.0,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+            child: Column(
+              children: List.generate(_routineSteps.length, (i) {
+                return CheckboxListTile(
+                  value: _routineChecks[i],
+                  onChanged: (v) {
+                    setState(() => _routineChecks[i] = v ?? false);
+                  },
+                  title: Text(
+                    _routineSteps[i],
+                    style: TextStyle(
+                      fontSize: 13,
+                      decoration: _routineChecks[i]
+                          ? TextDecoration.lineThrough
+                          : null,
+                      color: _routineChecks[i] ? Colors.grey : null,
+                    ),
+                  ),
+                  controlAffinity: ListTileControlAffinity.leading,
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                );
+              }),
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/supabase/migrations/20260327000013_create_email_subscriptions.sql
+++ b/supabase/migrations/20260327000013_create_email_subscriptions.sql
@@ -1,0 +1,71 @@
+-- メールサブスク管理テーブル
+-- 不要なメルマガ・通知を特定し、解除を管理する
+
+CREATE TABLE IF NOT EXISTS email_subscriptions (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid NOT NULL,
+  email_account_id uuid REFERENCES email_accounts(id) ON DELETE CASCADE,
+  sender_name text NOT NULL,
+  sender_email text,
+  category text NOT NULL DEFAULT 'newsletter'
+    CHECK (category IN (
+      'newsletter', 'promotion', 'notification',
+      'subscription', 'social', 'other'
+    )),
+  action text NOT NULL DEFAULT 'keep'
+    CHECK (action IN ('keep', 'unsubscribe', 'filter', 'delete')),
+  is_processed boolean NOT NULL DEFAULT false,
+  processed_at timestamptz,
+  frequency text,
+  note text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE email_subscriptions IS '受信メールのサブスク・メルマガ管理';
+COMMENT ON COLUMN email_subscriptions.action IS 'keep=維持, unsubscribe=解除, filter=フィルタ設定, delete=削除';
+COMMENT ON COLUMN email_subscriptions.frequency IS '受信頻度メモ (毎日, 週1, 月1 等)';
+
+-- メール整理ルーチンのチェックリストテンプレート
+CREATE TABLE IF NOT EXISTS email_cleanup_routines (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid NOT NULL,
+  step_order int NOT NULL,
+  title text NOT NULL,
+  description text,
+  is_completed boolean NOT NULL DEFAULT false,
+  completed_date date,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE email_cleanup_routines IS 'メール整理ルーチンのチェックリスト';
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_email_subscriptions_user
+  ON email_subscriptions (user_id, is_processed);
+
+CREATE INDEX IF NOT EXISTS idx_email_cleanup_routines_user
+  ON email_cleanup_routines (user_id, step_order);
+
+-- RLS
+ALTER TABLE email_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE email_cleanup_routines ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_own_email_subscriptions"
+  ON email_subscriptions FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "users_own_email_cleanup_routines"
+  ON email_cleanup_routines FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "service_role_email_subscriptions"
+  ON email_subscriptions FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY "service_role_email_cleanup_routines"
+  ON email_cleanup_routines FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- メルマガ・サブスク管理テーブル (keep/unsubscribe/filter/delete)
- 7ステップの整理ルーチンチェックリストをメール整理ページに追加
- 進捗バー付き折りたたみカード

## Test plan
- [ ] ルーチンチェックリストのチェック/解除が正常動作
- [ ] 進捗バーが正しく更新されること
- [ ] flutter analyze 0エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)