### PR TITLE
feat: 「我が闘争」システム — AIが日々の奮闘をコラム化

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:my_web_app/pages/agent_org_page.dart';
 import 'package:my_web_app/pages/behavior_review_page.dart';
 import 'package:my_web_app/pages/daily_habits_page.dart';
+import 'package:my_web_app/pages/my_struggle_page.dart';
 import 'package:my_web_app/pages/danshari_page.dart';
 import 'package:my_web_app/pages/email_cleanup_page.dart';
 import 'package:my_web_app/pages/payment_reminder_page.dart';
@@ -231,6 +232,10 @@ class MyApp extends StatelessWidget {
           case '/daily-habits':
             return MaterialPageRoute(
               builder: (_) => const DailyHabitsPage(),
+            );
+          case '/my-struggle':
+            return MaterialPageRoute(
+              builder: (_) => const MyStrugglePage(),
             );
           case '/feature-requests':
             return MaterialPageRoute(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -3963,6 +3963,36 @@ abstinence_slip_details: $slipDetailsText
                                 ),
                               ),
                             ),
+                            Card(
+                              elevation: 0,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                side: BorderSide(
+                                  color: Colors.grey.shade200,
+                                ),
+                              ),
+                              child: ListTile(
+                                leading: const Text(
+                                  '📜',
+                                  style: TextStyle(fontSize: 24),
+                                ),
+                                title: const Text(
+                                  '我が闘争',
+                                  style: TextStyle(
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                                subtitle: const Text(
+                                  '日々の奮闘をAIがコラムに',
+                                  style: TextStyle(fontSize: 12),
+                                ),
+                                trailing: const Icon(Icons.chevron_right),
+                                onTap: () => Navigator.pushNamed(
+                                  context,
+                                  '/my-struggle',
+                                ),
+                              ),
+                            ),
                             const SizedBox(height: 24),
                             _buildSectionHeader(
                               'OFFICE KPI SNAPSHOT',

--- a/lib/pages/my_struggle_page.dart
+++ b/lib/pages/my_struggle_page.dart
@@ -1,0 +1,385 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// 「我が闘争」システム
+/// 日々の暮らしの奮闘をAIがコラム形式で出力する。
+/// ユーザーの習慣達成状況・タスク・禁欲ガード状況を元に、
+/// その日の「闘い」を文学的に描写する。
+class MyStrugglePage extends StatefulWidget {
+  const MyStrugglePage({super.key});
+
+  @override
+  State<MyStrugglePage> createState() => _MyStrugglePageState();
+}
+
+class _MyStrugglePageState extends State<MyStrugglePage> {
+  final _supabase = Supabase.instance.client;
+  bool _loading = false;
+  bool _loadingHistory = true;
+  String? _column;
+  String? _error;
+  List<Map<String, dynamic>> _history = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadHistory();
+  }
+
+  Future<void> _loadHistory() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      if (mounted) setState(() => _loadingHistory = false);
+      return;
+    }
+    try {
+      final data = await _supabase
+          .from('my_struggle_columns')
+          .select()
+          .eq('user_id', userId)
+          .order('created_at', ascending: false)
+          .limit(30);
+      if (mounted) {
+        setState(() {
+          _history = List<Map<String, dynamic>>.from(data as List);
+          _loadingHistory = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('MyStrugglePage history load error: $e');
+      if (mounted) setState(() => _loadingHistory = false);
+    }
+  }
+
+  Future<Map<String, dynamic>> _gatherContext() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) return {};
+
+    final today = DateFormat('yyyy-MM-dd').format(DateTime.now());
+    final results = await Future.wait([
+      // 習慣
+      _supabase
+          .from('daily_habits')
+          .select('title, streak, best_streak')
+          .eq('user_id', userId)
+          .eq('is_active', true),
+      // 今日の習慣ログ
+      _supabase
+          .from('daily_habit_logs')
+          .select('habit_id')
+          .eq('user_id', userId)
+          .eq('completed_date', today),
+      // デイリータスク
+      _supabase
+          .from('daily_todos')
+          .select('title, is_completed')
+          .eq('user_id', userId)
+          .eq('task_date', today),
+    ]);
+
+    final habits = List<Map<String, dynamic>>.from(results[0] as List);
+    final habitLogs = List<Map<String, dynamic>>.from(results[1] as List);
+    final todos = List<Map<String, dynamic>>.from(results[2] as List);
+
+    return {
+      'date': today,
+      'habits_total': habits.length,
+      'habits_completed_today': habitLogs.length,
+      'habits': habits
+          .map(
+            (h) => '${h['title']} (streak: ${h['streak']}日)',
+          )
+          .toList(),
+      'todos_total': todos.length,
+      'todos_completed':
+          todos.where((t) => t['is_completed'] == true).length,
+      'todos': todos
+          .map(
+            (t) =>
+                '${t['title']} (${t['is_completed'] == true ? "完了" : "未完了"})',
+          )
+          .toList(),
+    };
+  }
+
+  Future<void> _generate() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+      _column = null;
+    });
+
+    try {
+      final context = await _gatherContext();
+      final contextJson = const JsonEncoder.withIndent('  ').convert(context);
+
+      final response = await _supabase.functions.invoke(
+        'ai-assistant',
+        body: {
+          'action': 'my_struggle_column',
+          'content': contextJson,
+        },
+      );
+
+      if (response.status != 200) {
+        throw Exception('API error: ${response.status}');
+      }
+
+      final data = response.data as Map<String, dynamic>?;
+      if (data == null || data['success'] != true) {
+        throw Exception(data?['error']?.toString() ?? 'Unknown error');
+      }
+
+      final result = data['result'] as Map<String, dynamic>? ?? {};
+      final column = result['column']?.toString() ?? '';
+      final title = result['title']?.toString() ?? '我が闘争';
+
+      // 保存
+      final userId = _supabase.auth.currentUser?.id;
+      if (userId != null && column.isNotEmpty) {
+        await _supabase.from('my_struggle_columns').insert({
+          'user_id': userId,
+          'title': title,
+          'column_text': column,
+          'context_data': context,
+        });
+      }
+
+      if (mounted) {
+        setState(() {
+          _column = '# $title\n\n$column';
+          _loading = false;
+        });
+        await _loadHistory();
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('我が闘争'),
+        elevation: 0,
+        actions: [
+          if (_column != null)
+            IconButton(
+              icon: const Icon(Icons.copy),
+              tooltip: 'コピー',
+              onPressed: () {
+                Clipboard.setData(ClipboardData(text: _column ?? ''));
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('コピーしました')),
+                );
+              },
+            ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // ヘッダー
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [Colors.grey.shade900, Colors.grey.shade700],
+              ),
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Column(
+              children: [
+                const Text(
+                  '📜',
+                  style: TextStyle(fontSize: 40),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  '我が闘争',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 24,
+                    fontWeight: FontWeight.w900,
+                    letterSpacing: 4,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '日々の暮らしの中にある、静かな闘いの記録',
+                  style: TextStyle(
+                    color: Colors.grey.shade300,
+                    fontSize: 12,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _loading ? null : _generate,
+                    icon: _loading
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Colors.white,
+                            ),
+                          )
+                        : const Icon(Icons.auto_fix_high),
+                    label: Text(_loading ? '執筆中...' : '今日の闘争を記す'),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: Colors.amber.shade800,
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // エラー表示
+          if (_error != null)
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.red.shade50,
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: Colors.red.shade200),
+              ),
+              child: Text(
+                _error!,
+                style: TextStyle(fontSize: 12, color: Colors.red.shade700),
+              ),
+            ),
+
+          // 今日のコラム
+          if (_column != null) ...[
+            Card(
+              elevation: 0,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+                side: BorderSide(color: Colors.amber.shade200),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(20),
+                child: SelectableText(
+                  _column!,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    height: 1.8,
+                    fontFamily: 'serif',
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+          ],
+
+          // 履歴
+          if (!_loadingHistory && _history.isNotEmpty) ...[
+            Text(
+              '過去の闘争記録',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w800,
+                color: Colors.grey.shade700,
+              ),
+            ),
+            const SizedBox(height: 8),
+            ..._history.map(_buildHistoryCard),
+          ],
+          if (_loadingHistory)
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.all(32),
+                child: CircularProgressIndicator(),
+              ),
+            ),
+          if (!_loadingHistory && _history.isEmpty && _column == null)
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: Column(
+                  children: [
+                    Icon(
+                      Icons.history_edu,
+                      size: 48,
+                      color: Colors.grey.shade400,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      'まだ闘争の記録がありません。\n「今日の闘争を記す」で最初の一篇を。',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Colors.grey.shade600,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHistoryCard(Map<String, dynamic> entry) {
+    final title = entry['title']?.toString() ?? '我が闘争';
+    final text = entry['column_text']?.toString() ?? '';
+    final createdAt = DateTime.tryParse(
+      entry['created_at']?.toString() ?? '',
+    );
+    final dateStr = createdAt != null
+        ? DateFormat('yyyy/MM/dd HH:mm').format(createdAt.toLocal())
+        : '';
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: Colors.grey.shade200),
+      ),
+      child: ExpansionTile(
+        tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+        title: Text(
+          title,
+          style: const TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        subtitle: Text(
+          dateStr,
+          style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+        ),
+        leading: const Text('📜', style: TextStyle(fontSize: 20)),
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: SelectableText(
+              text,
+              style: const TextStyle(
+                fontSize: 13,
+                height: 1.7,
+                fontFamily: 'serif',
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -350,6 +350,55 @@ serve(async (req) => {
             return new Response(JSON.stringify({ success: true, result: formattedResult }), { headers: corsHeaders });
         }
 
+        // --- 「我が闘争」コラム生成 ---
+        if (action === 'my_struggle_column') {
+            const contextData = requestContent ?? '{}';
+            const prompt = `あなたは文学的才能を持つコラムニストです。
+以下のユーザーの日常データを元に「我が闘争」というタイトルのコラムを書いてください。
+
+ルール:
+- 日常の些細な出来事（習慣の達成、タスクの消化、誘惑との戦い）を壮大に、文学的に描写する
+- ユーモアと自虐を交え、読んでいて楽しいコラムにする
+- 太宰治や村上春樹のような文体を意識する
+- 800〜1200字程度
+- 具体的なデータ（習慣の達成数、ストリーク日数など）があれば引用する
+- 最後に明日への決意で締める
+
+出力フォーマット (JSONのみ):
+{
+  "title": "我が闘争 — サブタイトル（その日のテーマ）",
+  "column": "コラム本文"
+}
+
+[ユーザーの今日のデータ]
+${contextData}`;
+
+            const resultStr = await runPromptWithStrategy(prompt);
+            const match = resultStr.match(/\{[\s\S]*\}/);
+            if (!match) {
+                return new Response(JSON.stringify({
+                    success: true,
+                    result: {
+                        title: '我が闘争 — 言葉にならぬ日',
+                        column: resultStr.substring(0, 1200),
+                    },
+                }), { headers: corsHeaders });
+            }
+            let parsed: Record<string, unknown>;
+            try {
+                parsed = JSON.parse(match[0]);
+            } catch {
+                parsed = { title: '我が闘争', column: resultStr.substring(0, 1200) };
+            }
+            return new Response(JSON.stringify({
+                success: true,
+                result: {
+                    title: typeof parsed.title === 'string' ? parsed.title : '我が闘争',
+                    column: typeof parsed.column === 'string' ? parsed.column : resultStr.substring(0, 1200),
+                },
+            }), { headers: corsHeaders });
+        }
+
         if (action === 'test_model') {
             const benchmarkPrompt = [
                 'You are running a connectivity benchmark.',

--- a/supabase/migrations/20260327000014_create_my_struggle_columns.sql
+++ b/supabase/migrations/20260327000014_create_my_struggle_columns.sql
@@ -1,0 +1,19 @@
+-- 「我が闘争」コラム保存テーブル
+CREATE TABLE IF NOT EXISTS my_struggle_columns (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title text NOT NULL DEFAULT '我が闘争',
+  column_text text NOT NULL,
+  context_data jsonb,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_my_struggle_columns_user_date
+  ON my_struggle_columns (user_id, created_at DESC);
+
+ALTER TABLE my_struggle_columns ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own struggle columns"
+  ON my_struggle_columns FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- 📜 「我が闘争」ページ新規作成
- ユーザーの習慣達成・タスク完了データからAIが文学的コラムを自動生成
- 過去のコラム履歴を30件まで閲覧可能
- CEO OFFICE セクションに導線追加

## Test plan
- [ ] /my-struggle でページが開くこと
- [ ] 「今日の闘争を記す」でAIコラムが生成されること
- [ ] 履歴が保存・表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)