### PR TITLE
feat: 🪞 行動・発言の振り返りログ + AI考察

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:my_web_app/pages/daily_habits_page.dart';
 import 'package:my_web_app/pages/my_struggle_page.dart';
 import 'package:my_web_app/pages/prison_mode_page.dart';
 import 'package:my_web_app/pages/bookmark_folders_page.dart';
+import 'package:my_web_app/pages/behavior_log_page.dart';
 import 'package:my_web_app/pages/danshari_page.dart';
 import 'package:my_web_app/pages/email_cleanup_page.dart';
 import 'package:my_web_app/pages/payment_reminder_page.dart';
@@ -247,6 +248,10 @@ class MyApp extends StatelessWidget {
           case '/bookmark-folders':
             return MaterialPageRoute(
               builder: (_) => const BookmarkFoldersPage(),
+            );
+          case '/behavior-log':
+            return MaterialPageRoute(
+              builder: (_) => const BehaviorLogPage(),
             );
           case '/feature-requests':
             return MaterialPageRoute(

--- a/lib/pages/behavior_log_page.dart
+++ b/lib/pages/behavior_log_page.dart
@@ -1,0 +1,479 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// 行動・発言の振り返りログ
+/// すべての行動と発言を記録し、AIが考察を提供する。
+class BehaviorLogPage extends StatefulWidget {
+  const BehaviorLogPage({super.key});
+
+  @override
+  State<BehaviorLogPage> createState() => _BehaviorLogPageState();
+}
+
+class _BehaviorLogPageState extends State<BehaviorLogPage> {
+  final _supabase = Supabase.instance.client;
+  bool _loading = true;
+  List<Map<String, dynamic>> _logs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      if (mounted) setState(() => _loading = false);
+      return;
+    }
+    try {
+      final data = await _supabase
+          .from('behavior_log')
+          .select()
+          .eq('user_id', userId)
+          .order('occurred_at', ascending: false)
+          .limit(50);
+      if (mounted) {
+        setState(() {
+          _logs = List<Map<String, dynamic>>.from(data as List);
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('BehaviorLog load error: $e');
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _addEntry() async {
+    final contentCtrl = TextEditingController();
+    final contextCtrl = TextEditingController();
+    String kind = 'action';
+    int regretLevel = 0;
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setD) => AlertDialog(
+          title: const Text('行動・発言を記録'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SegmentedButton<String>(
+                  segments: const [
+                    ButtonSegment(
+                      value: 'action',
+                      icon: Icon(Icons.directions_run),
+                      label: Text('行動'),
+                    ),
+                    ButtonSegment(
+                      value: 'utterance',
+                      icon: Icon(Icons.chat_bubble_outline),
+                      label: Text('発言'),
+                    ),
+                  ],
+                  selected: {kind},
+                  onSelectionChanged: (v) => setD(() => kind = v.first),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: contentCtrl,
+                  maxLines: 3,
+                  decoration: InputDecoration(
+                    labelText: kind == 'action' ? '何をした？' : '何を言った？',
+                    hintText: kind == 'action'
+                        ? '例: 会議中にスマホをいじった'
+                        : '例: つい嫌味を言ってしまった',
+                    prefixIcon: const Icon(Icons.edit),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                TextField(
+                  controller: contextCtrl,
+                  decoration: const InputDecoration(
+                    labelText: '状況・相手 (任意)',
+                    hintText: '例: チームミーティング中、上司に対して',
+                    prefixIcon: Icon(Icons.people),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  '後悔レベル',
+                  style: TextStyle(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: List.generate(
+                    6,
+                    (i) => Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 2),
+                      child: ChoiceChip(
+                        label: Text(
+                          i == 0
+                              ? '😌'
+                              : i <= 2
+                                  ? '😐'
+                                  : i <= 4
+                                      ? '😟'
+                                      : '😰',
+                        ),
+                        selected: regretLevel == i,
+                        onSelected: (_) => setD(() => regretLevel = i),
+                      ),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    regretLevel == 0
+                        ? '問題なし'
+                        : regretLevel <= 2
+                            ? '少し気になる'
+                            : regretLevel <= 4
+                                ? '後悔している'
+                                : '深く反省',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: _regretColor(regretLevel),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('記録'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (result != true) return;
+    final content = contentCtrl.text.trim();
+    if (content.isEmpty) return;
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) return;
+
+    try {
+      await _supabase.from('behavior_log').insert({
+        'user_id': userId,
+        'kind': kind,
+        'content': content,
+        'context':
+            contextCtrl.text.trim().isEmpty ? null : contextCtrl.text.trim(),
+        'regret_level': regretLevel,
+      });
+      await _load();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('エラー: $e'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
+  Future<void> _analyzeEntry(Map<String, dynamic> entry) async {
+    if (entry['ai_analysis'] != null) return;
+    final entryId = entry['id']?.toString();
+    if (entryId == null) return;
+
+    try {
+      final response = await _supabase.functions.invoke(
+        'ai-assistant',
+        body: {
+          'action': 'behavior_analysis',
+          'content': jsonEncode({
+            'kind': entry['kind'],
+            'content': entry['content'],
+            'context': entry['context'],
+            'regret_level': entry['regret_level'],
+          }),
+        },
+      );
+      final data = response.data as Map<String, dynamic>?;
+      final resultMap = data?['result'] as Map<String, dynamic>?;
+      final analysis =
+          resultMap?['analysis']?.toString() ?? 'AI分析を取得できませんでした';
+
+      await _supabase.from('behavior_log').update({
+        'ai_analysis': analysis,
+      }).eq('id', entryId);
+      await _load();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('AI分析エラー: $e'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
+  Color _regretColor(int level) {
+    if (level == 0) return Colors.green;
+    if (level <= 2) return Colors.orange;
+    if (level <= 4) return Colors.red.shade700;
+    return Colors.red.shade900;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final todayLogs = _logs.where((l) {
+      final dt = DateTime.tryParse(l['occurred_at']?.toString() ?? '');
+      if (dt == null) return false;
+      final now = DateTime.now();
+      return dt.year == now.year &&
+          dt.month == now.month &&
+          dt.day == now.day;
+    }).toList();
+    final highRegret =
+        _logs.where((l) => (l['regret_level'] as int? ?? 0) >= 3).length;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('行動・発言の振り返り'),
+        elevation: 0,
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _addEntry,
+        icon: const Icon(Icons.add),
+        label: const Text('記録する'),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                // サマリーカード
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [Colors.indigo.shade800, Colors.indigo.shade600],
+                    ),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Column(
+                    children: [
+                      const Text(
+                        '🪞 自分を映す鏡',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 18,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'すべての行動と発言は、深く考えた結果であるべきだ',
+                        style: TextStyle(
+                          color: Colors.indigo.shade200,
+                          fontSize: 12,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          _buildStat('今日', '${todayLogs.length}件'),
+                          _buildStat('総記録', '${_logs.length}件'),
+                          _buildStat(
+                            '要反省',
+                            '$highRegret件',
+                            color: highRegret > 0
+                                ? Colors.red.shade300
+                                : Colors.green.shade300,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+
+                if (_logs.isEmpty)
+                  Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(32),
+                      child: Column(
+                        children: [
+                          Icon(
+                            Icons.psychology,
+                            size: 48,
+                            color: Colors.grey.shade400,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            '行動や発言を記録して\n振り返りを始めましょう',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              color: Colors.grey.shade600,
+                              fontSize: 13,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                else
+                  ..._logs.map(_buildLogCard),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildStat(String label, String value, {Color? color}) {
+    return Column(
+      children: [
+        Text(
+          value,
+          style: TextStyle(
+            color: color ?? Colors.white,
+            fontSize: 20,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        Text(
+          label,
+          style: TextStyle(color: Colors.indigo.shade200, fontSize: 11),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLogCard(Map<String, dynamic> entry) {
+    final kind = entry['kind']?.toString() ?? 'action';
+    final content = entry['content']?.toString() ?? '';
+    final ctx = entry['context']?.toString();
+    final regret = entry['regret_level'] as int? ?? 0;
+    final analysis = entry['ai_analysis']?.toString();
+    final dt = DateTime.tryParse(entry['occurred_at']?.toString() ?? '');
+    final dateStr = dt != null
+        ? DateFormat('MM/dd HH:mm').format(dt.toLocal())
+        : '';
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(
+          color: regret >= 3 ? Colors.red.shade200 : Colors.grey.shade200,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  kind == 'action'
+                      ? Icons.directions_run
+                      : Icons.chat_bubble_outline,
+                  size: 18,
+                  color: kind == 'action' ? Colors.blue : Colors.purple,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  kind == 'action' ? '行動' : '発言',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: kind == 'action' ? Colors.blue : Colors.purple,
+                  ),
+                ),
+                const Spacer(),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: _regretColor(regret).withAlpha(20),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    regret == 0
+                        ? '😌 OK'
+                        : regret <= 2
+                            ? '😐 微妙'
+                            : '😟 後悔$regret',
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: _regretColor(regret),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  dateStr,
+                  style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(content, style: const TextStyle(fontSize: 14)),
+            if (ctx != null && ctx.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                '📍 $ctx',
+                style: TextStyle(fontSize: 12, color: Colors.grey.shade600),
+              ),
+            ],
+            if (analysis != null) ...[
+              const SizedBox(height: 8),
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: Colors.indigo.shade50,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '🤖 AI考察',
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      analysis,
+                      style: const TextStyle(fontSize: 12, height: 1.5),
+                    ),
+                  ],
+                ),
+              ),
+            ] else ...[
+              const SizedBox(height: 6),
+              TextButton.icon(
+                onPressed: () => _analyzeEntry(entry),
+                icon: const Icon(Icons.psychology, size: 16),
+                label: const Text('AIに考察してもらう'),
+                style: TextButton.styleFrom(
+                  foregroundColor: Colors.indigo,
+                  textStyle: const TextStyle(fontSize: 12),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -4063,6 +4063,36 @@ abstinence_slip_details: $slipDetailsText
                                 ),
                               ),
                             ),
+                            Card(
+                              elevation: 0,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                side: BorderSide(
+                                  color: Colors.grey.shade200,
+                                ),
+                              ),
+                              child: ListTile(
+                                leading: const Text(
+                                  '🪞',
+                                  style: TextStyle(fontSize: 24),
+                                ),
+                                title: const Text(
+                                  '行動・発言の振り返り',
+                                  style: TextStyle(
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                                subtitle: const Text(
+                                  '全行動を記録しAIが考察',
+                                  style: TextStyle(fontSize: 12),
+                                ),
+                                trailing: const Icon(Icons.chevron_right),
+                                onTap: () => Navigator.pushNamed(
+                                  context,
+                                  '/behavior-log',
+                                ),
+                              ),
+                            ),
                             const SizedBox(height: 24),
                             _buildSectionHeader(
                               'OFFICE KPI SNAPSHOT',

--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -399,6 +399,42 @@ ${contextData}`;
             }), { headers: corsHeaders });
         }
 
+        // --- 行動・発言のAI考察 ---
+        if (action === 'behavior_analysis') {
+            const entryData = requestContent ?? '{}';
+            const prompt = `あなたは認知行動療法の専門家であり、自己改善コーチです。
+以下のユーザーの行動または発言を分析し、考察を提供してください。
+
+ルール:
+- 批判ではなく建設的なフィードバックを提供する
+- なぜその行動/発言をしたのか、背景にある心理を分析する
+- 次に同じ状況になった時、どうすればより良い選択ができるかを提案する
+- 200〜300字程度で簡潔に
+- 日本語で出力
+
+出力フォーマット (JSONのみ):
+{ "analysis": "考察テキスト" }
+
+[ユーザーの行動/発言データ]
+${entryData}`;
+
+            const resultStr = await runPromptWithStrategy(prompt);
+            const match = resultStr.match(/\{[\s\S]*\}/);
+            let analysis = resultStr.substring(0, 400);
+            if (match) {
+                try {
+                    const parsed = JSON.parse(match[0]);
+                    if (typeof parsed.analysis === 'string') {
+                        analysis = parsed.analysis;
+                    }
+                } catch { /* use raw */ }
+            }
+            return new Response(JSON.stringify({
+                success: true,
+                result: { analysis },
+            }), { headers: corsHeaders });
+        }
+
         if (action === 'test_model') {
             const benchmarkPrompt = [
                 'You are running a connectivity benchmark.',

--- a/supabase/migrations/20260327000018_create_behavior_log.sql
+++ b/supabase/migrations/20260327000018_create_behavior_log.sql
@@ -1,0 +1,23 @@
+-- 行動・発言振り返りログ
+CREATE TABLE IF NOT EXISTS behavior_log (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  kind text NOT NULL CHECK (kind IN ('action', 'utterance')),
+  content text NOT NULL,
+  context text,
+  regret_level int NOT NULL DEFAULT 0 CHECK (regret_level BETWEEN 0 AND 5),
+  reflection text,
+  ai_analysis text,
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_behavior_log_user_date
+  ON behavior_log (user_id, occurred_at DESC);
+
+ALTER TABLE behavior_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own behavior log"
+  ON behavior_log FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- 行動/発言を記録し、後悔レベル(0-5)を設定
- AIが認知行動療法ベースで考察を提供
- CEO OFFICEセクションに導線

## Test plan
- [ ] /behavior-log でページが開くこと
- [ ] 行動・発言の記録ができること
- [ ] AI考察が取得できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)