### PR TITLE
fix: X投稿のJSONエスケープを jq で安全に処理

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -94,22 +94,28 @@ jobs:
         if: steps.gitlog.outputs.count != '0'
         id: xpost
         run: |
-          # 直近のコミットから投稿文を生成
-          TOP_COMMIT=$(head -1 /tmp/recent_commits.txt | cut -d' ' -f2-)
+          # 直近のコミットから投稿文を生成 (特殊文字を除去)
+          TOP_COMMIT=$(head -1 /tmp/recent_commits.txt | cut -d' ' -f2- | tr -d '"\\' | cut -c1-60)
           COMMIT_COUNT=${{ steps.gitlog.outputs.count }}
 
-          TWEET="自分株式会社、今日も${COMMIT_COUNT}件の改善を実施🚀 ${TOP_COMMIT} https://my-web-app-b67f4.web.app/ #buildinpublic #FlutterWeb #Supabase"
+          TWEET="自分株式会社、今日も${COMMIT_COUNT}件の改善を実施 ${TOP_COMMIT} https://my-web-app-b67f4.web.app/ #buildinpublic #FlutterWeb"
 
-          # 140字制限
-          TWEET=$(echo "$TWEET" | cut -c1-140)
+          # 280字制限 (X API v2は280字)
+          TWEET=$(echo "$TWEET" | cut -c1-270)
 
+          # jq でJSON安全にエスケープ
+          JSON_PAYLOAD=$(jq -n --arg text "$TWEET" '{"text": $text}')
+          echo "📝 投稿文: $TWEET"
+
+          set +e
           POST_CODE=$(curl -s -o /tmp/xpost.json -w "%{http_code}" \
             -X POST \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"text\":\"$TWEET\"}" \
+            -d "$JSON_PAYLOAD" \
             "https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/post-x-update" \
             --max-time 15)
+          set -e
 
           echo "post_code=$POST_CODE" >> $GITHUB_OUTPUT
 
@@ -117,6 +123,7 @@ jobs:
             echo "✅ X投稿成功"
           else
             echo "⚠️ X投稿失敗 (HTTP $POST_CODE)"
+            cat /tmp/xpost.json 2>/dev/null || true
           fi
 
       - name: Step 5 - コミット & PR


### PR DESCRIPTION
## Summary
- X投稿 HTTP 400 を修正
- コミットメッセージの特殊文字がJSONを壊していた
- `jq -n --arg text` で安全にエスケープ
- エラー時にレスポンスボディを表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)