### PR TITLE
fix: Actions ブランチ名衝突 + push rejected 修正

### DIFF
--- a/.github/workflows/cs-check.yml
+++ b/.github/workflows/cs-check.yml
@@ -142,8 +142,9 @@ jobs:
           DATETIME=$(TZ=Asia/Tokyo date +%Y-%m-%d-%H)
           DATE=$(TZ=Asia/Tokyo date +%Y-%m-%d)
           HOUR=$(TZ=Asia/Tokyo date +%H)
+          RUN_ID="${{ github.run_id }}"
           FILEPATH="docs/cs-notes/${DATETIME}.md"
-          BRANCH="cs-check-${DATETIME}"
+          BRANCH="cs-check-${DATETIME}-${RUN_ID}"
 
           mkdir -p docs/cs-notes
 
@@ -182,7 +183,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git checkout -b "$BRANCH"
+          git fetch origin main
+          git checkout -b "$BRANCH" origin/main
+          git add docs/cs-notes/
           git commit -m "自動: CS チェック ${DATETIME}:00 (GitHub Actions)"
           git push origin "$BRANCH"
 

--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -130,8 +130,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          DATETIME=$(TZ=Asia/Tokyo date +%Y-%m-%d)
-          BRANCH="daily-report-${DATETIME}"
+          DATE=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+          RUN_ID="${{ github.run_id }}"
+          BRANCH="daily-report-${DATE}-${RUN_ID}"
 
           git add docs/daily-reports/
           if git diff --cached --quiet; then
@@ -142,14 +143,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git checkout -b "$BRANCH"
-          git commit -m "自動: 日次レポート ${DATETIME}"
+          # リモートの最新を取得してからブランチ作成
+          git fetch origin main
+          git checkout -b "$BRANCH" origin/main
+          git add docs/daily-reports/
+          git commit -m "自動: 日次レポート ${DATE}"
           git push origin "$BRANCH"
 
           set +e
           PR_URL=$(gh pr create \
-            --title "自動: 日次レポート ${DATETIME}" \
-            --body "日次レポート自動生成 (GitHub Actions)" \
+            --title "自動: 日次レポート ${DATE}" \
+            --body "日次レポート自動生成 (GitHub Actions run #${RUN_ID})" \
             --base main \
             --head "$BRANCH")
           PR_EXIT=$?


### PR DESCRIPTION
## Summary
- ブランチ名に `github.run_id` 付与で衝突回避
- `origin/main` ベースでブランチ作成 (fetch first エラー解消)
- X投稿HTTP 400 → 503 (X API側障害) で解決済み確認

## 修正した問題
| 問題 | 修正 |
|---|---|
| `daily-report-2026-03-28` が既に存在 | → `daily-report-2026-03-28-12345678` (run_id付与) |
| `Updates were rejected because the remote contains work` | → `origin/main` ベースでブランチ作成 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)