### PR TITLE
feat: Voice AI Chat + 会話記憶 + check_versions.py (claude/frosty-hamilton)

### DIFF
--- a/.github/COMPRESSED_PROMPT_V3.md
+++ b/.github/COMPRESSED_PROMPT_V3.md
@@ -7,30 +7,51 @@ Flutter Web + Supabase で **21競合を統合するAIライフマネジメン�
 
 ---
 
-## 🔀 3インスタンス + マルチAI並行開発スコープ（WEB版廃止 2026-04-17）
+## 🔀 4インスタンス + Multi-AI 並行開発スコープ（2026-04-16 更新）
 
-| インスタンス | 担当範囲 (write 権限) | 専任ルール |
+### Claude Code 4インスタンス構成
+
+> **制約対応表**: WEB版(claude.ai/code)はローカルCLI時限あり—— `notebooklm`・`flutter analyze`・`deno lint`・ローカルPythonスクリプトは不可。WebSearch / WebFetch / GitHub MCP は利用可。
+
+| インスタンス | 担当範囲 (write 権限) | 専任ルール | 推奨モデル | 制約 |
+| --- | --- | --- | --- | --- |
+| **VSCode版** | `lib/` (Flutter UI) + `supabase/functions/` (EF) + `docs/DESIGN.md` | Rule 16 (表示チェック+修正) / Rule 19 (UI改善) / `flutter analyze` + `deno lint` 0エラー | `claude-sonnet-4-6` | なし |
+| **Windowsアプリ版** | `docs/` (DESIGN.md除く) + `supabase/migrations/` + **notebooklm CLI主担当** | Rule 10 (docs全件分析) / AI大学プロバイダー追加 / **Master Brain更新** | `claude-sonnet-4-6` | なし |
+| **PowerShell版** | `.github/workflows/` + `.mcp.json` + `docs/MULTI_INSTANCE_COORDINATION.md` | Rule 17 (CI/CD最適化) / Scheduleタスク owner | `claude-haiku-4-5` (次元作業) or `sonnet-4-6` (設計) | なし |
+| **WEB版** | `docs/blog-drafts/` + `docs/competitor-reports/` + GitHub PR/Issues主担当 | Rule 11 (AI大学 WebSearch経由) / T-1 ブログ / 競合リサーチ / Code Review MCP | `claude-sonnet-4-6` | notebooklm・ローカルCLI **不可** |
+
+### 外部AI統合（補完役割）
+
+| AI ツール | 役割 | 使用タイミング |
 | --- | --- | --- |
-| **VSCode版 (Claude Code)** | `lib/` (Flutter UI・219ページ) + `supabase/functions/` (EF) + `docs/DESIGN.md` | Rule 16 (表示チェック+修正) / Rule 19 (UI改善) 専任 / `flutter analyze` + `deno lint` 0エラー |
-| **Windowsアプリ版 (Claude Code)** | `docs/` (DESIGN.md除く) + `supabase/migrations/` (seed + schema 両方) | Rule 10 (docs全件分析) 主担当 / AI大学プロバイダー追加 |
-| **PowerShell版 (Claude Code)** | `.github/workflows/` + `.mcp.json` + `docs/MULTI_INSTANCE_COORDINATION.md` | Rule 17 (CI/CD最適化) 専任 / Schedule タスク owner / クォータ監視管理 / MCP設定管理 |
+| **GitHub Copilot** | VSCode内インライン補完・PR自動レビュー | コード補完 (`Ctrl+Enter`) / インラインChat (`Ctrl+I`) / `claude-agent-review.yml` PR審査 |
+| **Gemini Code Assist** | 長文コード理解・Google API統合・テスト生成 | Cloud Shell / JetBrains / VSCode で複雑な EF ロジック・Dart リファクタリング支援 |
+| **OpenAI CODEX** | アルゴリズム生成・コード変換・SQL最適化 | Supabase クエリ最適化 / Edge Function の複雑なビジネスロジック実装支援 |
+
+### AI選択フロー
+
+```text
+行レベル補完 (秒単位)        → GitHub Copilot (Ctrl+Enter)
+インライン修正 (分単位)       → GitHub Copilot Inline Chat (Ctrl+I)
+複雑なDart/Flutter実装       → Gemini Code Assist (長コンテキスト強み)
+アルゴリズム / SQL 最適化     → CODEX (コード特化強み)
+設計・戦略・長期判断          → Claude Code (Memory + ROADMAP統合)
+ブログ / 競合リサーチ       → Claude Code WEB版 (WebSearch/WebFetch)
+NotebookLM Deep Research  → Windowsアプリ版 (notebooklm CLI専任)
+```
+
+### クオータ監視
+
+`quota-monitor.yml` (毎日 09:00 JST) が各ツールの使用状況を `ai_quota_usage` テーブルに記録。
+
+| ツール | 監視方法 | アラート閾値 |
+| --- | --- | --- |
+| Claude (Anthropic API) | `/v1/usage` API | 月次 $50 超過 |
+| OpenAI (CODEX) | `/v1/usage` API | 月次 $20 超過 |
+| Gemini Code Assist | Google Cloud Monitoring API | 月次クオータ 80% |
+| GitHub Copilot | GitHub `/user/copilot_billing` API | シート数上限近接 |
+
 | **GitHub Copilot (統合AI)** | VSCode 内インライン補完・チャット・PR レビュー / 全インスタンス横断支援 | Inline Chat: `I#` 接頭辞で簡易修正 / Copilot Chat: 複雑な判断・アーキテクチャ / `claude-agent-review.yml`: PR自動レビュー |
-
-### フォールバック AI ツール (Claude MAX レート制限到達時のみ使用)
-
-> **通常運用**: Claude Code 3インスタンスのみ使用。フォールバックは Claude が 429 / 月次 $50 超過のときだけ発動。NotebookLM のみ制限に関係なく常時使用必須 (Rule 21)。
-
-| ツール | 発動条件 | ファイル種別 | 用途 |
-| --- | --- | --- | --- |
-| **Gemini Code Assist** | Claude 429 / $50超過 | `.dart` | Flutter/Dart IDE補完 (Google製言語に最適化) |
-| **CODEX CLI** (OpenAI) | Claude 429 / $50超過 | `.py` / `.ts` | Pythonスクリプト・TypeScript EF draft |
-| **GitHub Copilot** | Claude 429 / $50超過 + **常時PR自動レビュー** | `.yml` / `.sql` / `.md` | YAML補完・PR自動レビュー |
-| **NotebookLM** | **常時使用必須 (Rule 21)** | 全種別 | 3ファイル以上同時読み込み・URL分析・競合調査 |
-
-**フォールバック発動ルール**:
-1. `quota-monitor.yml` が月次閾値超過を検知 → `ai_quota_usage.alert=true`
-2. `cs-check.yml` 次回実行時に GitHub Issue 自動生成「⚠️ Claude レート制限到達」
-3. Issue 本文に「推奨フォールバック AI + ファイル種別対応表」を記載
 
 **緊急横断権限**: blocking が発生し他インスタンスを待てない場合、`docs/cross-instance-prs/YYYYMMDD_<内容>.md` に変更提案をコミット可。担当インスタンスが次セッションで採否を判断してマージする。
 
@@ -229,12 +250,14 @@ notion, evernote, moneyforward, x, animaworks, claude-code, codex, netkeiba, ope
 17. **毎セッション: GitHub Actions ワークフロー最適化チェック（PowerShell版 専任）** — PowerShell版が `.github/workflows/` を毎セッション見直す: (a) 常にエラーになるステップを無効化、(b) push + workflow_call 二重起動防止、(c) `continue-on-error: true` 乱用排除、(d) timeout-minutes 実態確認。**加えて全ブランチの CI 失敗を監視し `.github/ci-failures/<sha>.json` に記録する（他インスタンスは次セッション冒頭で確認）**。改善後は ROADMAP に記録する
 18. **毎セッション: AI大学コンテンツ → 開発ワークフロー反映（全インスタンス）** — `ai_university_content` の最新 `news` または NotebookLM Master Brain に蓄積した AI ニュースを開発に活かす。評価軸: (a) **モデルアップグレード** — 新モデルが利用可能なら既存 EF (`ai-assistant`/`daily-judgment`/`gemini-election-analysis` 等) のモデルパラメータを更新、(b) **新 API 機能取り込み** — 音声生成・リアルタイム検索・画像生成など新機能を既存機能に統合できないか検討、(c) **コスト最適化** — より安価なモデルが登場したらバッチ処理 EF への採用を検討、(d) **差別化機能のヒント** — 競合 AI の新機能からユーザー価値を逆算して未実装機能のアイデアを ROADMAP に追記。実施手順: `notebooklm ask "最新AIニュースから開発に使えそうな機能・APIを抽出して"` → 既存 EF との接続可能性を評価 → ROADMAP 追記 → 即対応可能なものは今セッションで実装
 19. **毎セッション: UI改善ツールチェーン実行（VSCode版 専任）** — VSCode版のみ必須。`Claude Code` × `Nanobanana API` × `Figma MCP` × `AIDesigner MCP` × `design-skills` サブエージェント × `docs/DESIGN.md` を組み合わせて毎セッション UI を 1ページ以上改善する。**実施手順**: (1) `design-skills` サブエージェントで改善対象ページを `docs/DESIGN.md` と照合し「DESIGN.md 違反箇所・改善提案」を列挙、(2) **Figma MCP** でデザインコンポーネントを参照、(3) **AIDesigner MCP** でDesktop/Mobile 両対応改善案を生成、(4) **Nanobanana API** でデザインアセットを取得しコードに反映、(5) `lib/` に実装 → `flutter analyze 0エラー` → commit → ROADMAP 記録。**他2インスタンスはデザイン違反 lint レポート生成まで（コード修正は VSCode版 の cross-instance-pr へ）**。詳細: `docs/DESIGN_TOOLING_SETUP.md`
-20. **毎セッション: 6 MCP プラグイン活用（全インスタンス・必須）** — `.mcp.json` に設定済みの Playwright / Context7 / GitHub MCP / Magic / Code Review / Superpowers を積極的に使う。Rule 8 UI確認→Playwright自動スクリーンショット / 外部ライブラリ調査→Context7 / PR作成→GitHub MCP / 新UIウィジェット→Magic MCP / 実装後→Code Review MCP
-21. **毎回必須: NotebookLM 経由でトークン削減** — 全インスタンス (VSCode/Windowsアプリ/PowerShell版) に適用。(a) 3ファイル以上同時読み込み → `notebooklm source add` → `notebooklm ask`, (b) URL・競合サイト分析 → `notebooklm source add URL`, (c) 競合21社調査 → `notebooklm source add-research`, (d) ドキュメント全体俯瞰 → source追加後に要約, (e) セッション終了時 → `notebooklm source add ./memory/*.md` で Master Brain 蓄積必須。Claude 直接処理は「判断・編集・統合」のみ。トークン節約効果 ~95%。| 22. **毎セッション冒頭: バージョン確認・制約解消チェック・Learning Mode** (Rule 22) — (1) `claude --version && npm show @anthropic-ai/claude-code dist-tags.latest` で確認。更新があれば `npm update -g @anthropic-ai/claude-code`。(2) **必ず `docs/INSTANCE_CONFIG.md` の「推奨プロンプト」セクションを参照**してセッション開始プロンプトをコピーして使う。(3) **Learning Mode**: git log -5 + MEMORY.md を読んでコンテキストを把握 → 3ファイル以上読む場合はNotebookLMに委譲。(4) バージョン更新があった場合: リリースノートで新機能確認 → INSTANCE_CONFIG.md を更新 → 役割分担を見直す。(5) フォールバックAI (Claude 429/$50超過時のみ): `.dart`→Gemini Code Assist / `.py`/`.ts`→CODEX CLI / `.yml`/`.sql`→GitHub Copilot。(6) Routines (Desktop専用): Windowsアプリ版が Pro:5回/日, Max:15回/日 の範囲でGHA代替として活用。(7) ultrathink/think deeply 等の拡張思考トリガーを各セッションで積極活用する
 
 ---
 
-## 🤖 GitHub Copilot 統合（全インスタンス横断支援）
+## 🤖 外部AI統合詳細（GitHub Copilot / Gemini Code Assist / CODEX）
+
+Claude Code 4インスタンスを主軸に、以下3ツールを補完役割で活用。Claude Code のトークンを「判断・設計・統合」に集中させ、反復的な補完・実装支援は外部AIに委譲する。
+
+### GitHub Copilot
 
 GitHub Copilot は VS Code 内での **即座のコード補完・インライン Chat・PR 自動レビュー** を担当。Claude Code Schedule との役割分担で開発を加速。
 
@@ -327,16 +350,53 @@ Copilot からの提案を `accept` する前に必ず以下を確認:
 - [ ] 依頼のスコープ内の修正か？（Rule #6 シンプルさ優先）
 - [ ] 元のプロジェクト方針に一貫しているか？ （Notion/Supabase/Flutter Web 標準に従っているか）
 
+### Gemini Code Assist 使用ガイド
+
+**強み**: 長いコンテキスト（100K+）・Google API 知識・テスト自動生成
+
+```text
+// Gemini Code Assist で推奨する用途
+1. 長い Dart ファイルのリファクタリング (500行以上)
+2. Supabase Edge Function の Deno テスト生成
+3. Google Calendar / Firebase 連携の実装支援
+4. データモデル設計のレビューと改善提案
+
+// 使用禁止パターン
+❌ プロジェクト固有のルール (Rule #1-#19) を無視した提案を受け入れる
+❌ EFハードキャップ (50本) を超える新 EF 生成
+```
+
+**VS Code での設定**: 拡張機能「Gemini Code Assist」をインストール → Google アカウントでサインイン
+
+### OpenAI CODEX 使用ガイド
+
+**強み**: コード特化・SQL生成・アルゴリズム最適化・多言語変換
+
+```text
+// CODEX で推奨する用途
+1. Supabase PostgreSQL クエリの最適化 (N+1解消・インデックス設計)
+2. Python スクリプト (fetch_yt.py / notebooklm_research.py) の改善
+3. TypeScript Edge Function のアルゴリズム実装
+4. Dart ↔ TypeScript コード変換支援
+
+// API エンドポイント (Edge Function から呼び出す場合)
+POST https://api.openai.com/v1/chat/completions
+Authorization: Bearer $OPENAI_API_KEY
+model: "gpt-4.1" | "o4-mini" | "codex-mini-latest"
+```
+
+**Supabase Secret**: `OPENAI_API_KEY` を設定済みの場合、`ai-assistant` EF の CODEX モードで利用可能
+
 ---
 
-## ⚙️ GitHub Actions CI/CD（全25ワークフロー）
+## ⚙️ GitHub Actions CI/CD（全20ワークフロー）
 
-**全25本に完備済み**: `concurrency:` + `timeout-minutes:` + `$GITHUB_STEP_SUMMARY` + `permissions:`
+**全20本に完備済み**: `concurrency:` + `timeout-minutes:` + `$GITHUB_STEP_SUMMARY` + `permissions:`
 
 | ワークフロー | トリガー | 特記事項 |
 | --- | --- | --- |
 | `ci.yml` | PR + push (staging/develop) ※main は deploy-prod が workflow_call で実行 | flutter analyze **強制** + deno lint **強制** + EF未分類警告 |
-| `deploy-prod.yml` | push → main | CI再利用 + バージョン自動生成 + GitHub Release / ⚠️ 2026-04-16: deno lint(no-unused-vars) + dart format(139files) + trailing_commas(5件) → PS版#本セッションで修正済み ✅ |
+| `deploy-prod.yml` | push → main | CI再利用 + バージョン自動生成 + GitHub Release |
 | `deploy-staging.yml` | push → staging | CI再利用 + staging channel デプロイ |
 | `deploy-dev.yml` | push → develop | CI再利用 + dev channel デプロイ |
 | `daily-report.yml` | 07:30 JST 毎日 | Supabase API + X投稿 + 競合モニタリング (Claude Scheduleの1.5時間前) |
@@ -354,12 +414,6 @@ Copilot からの提案を `accept` する前に必ず以下を確認:
 | `ai-university-update.yml` | **2時間毎** + dispatch | AI大学コンテンツ自動更新 (18プロバイダー RSS → Supabase UPSERT → PR auto-merge)。Claude Schedule (4時間毎) が NotebookLM でリッチコンテンツを上書き |
 | `ai-university-reminder.yml` | ⚠️ 新規 (2026-04-16) | AI大学学習リマインダー通知 (未実装学習者向け) |
 | `horse-racing-update.yml` | ⚠️ 新規 (2026-04-16) | 競馬AI予想パイプラインの定期更新 (JRA/NAR データ取得・モデル学習) |
-| `quota-monitor.yml` | 毎日 09:00 JST + dispatch | AI クォータ監視 (Claude/OpenAI/Gemini/Copilot) → `ai_quota_usage` UPSERT → 閾値超過時アラート |
-| `blog-draft.yml` | 毎日 07:00 JST + dispatch | 直近 git log → Claude API でドラフト自動生成 → commit → `blog-publish.yml` トリガー |
-| `blog-publish.yml (batch)` / `blog-batch-publish.yml` | workflow_dispatch | 未投稿ドラフト全件一括投稿 — `max_posts` / `dry_run` 入力 |
-| `blog-engagement.yml` | 毎日 01:00 UTC (10:00 JST) + dispatch | Qiita/dev.to エンゲージメント取得・重複削除・コメント自動返信 (Claude Haiku)・いいね者フォロー → `blog_engagement` テーブル |
-| `blog-backfill.yml` | workflow_dispatch | 過去ドラフトのフロントマター AI 生成 + 一括投稿 |
-| `blog-verify.yml` | workflow_dispatch | 投稿済み記事のバリデーション |
 
 **dependabot**: Actions + pub + pip を毎週月曜自動PR (`flutter-version: '3.38.x'`)
 
@@ -369,7 +423,7 @@ Copilot からの提案を `accept` する前に必ず以下を確認:
 - セキュリティ: 読み取り専用4本に `persist-credentials: false` (edge-function-audit / dependency-audit / cron-batch / claude-agent-review) / `ci.yml` に Firebase/Google 認証ファイル検出
 - 堅牢性: Slack webhook `--max-time 10 || true` / 全3環境の notify に `continue-on-error: true`
 - ビルド統一: 全環境 `--no-tree-shake-icons` 適用
-- EF 管理: **ハードキャップ50本以下** (Tier1/Tier2廃止 / 現在16本デプロイ済み) / 16本構成: standalone 5本(get-home-dashboard/ai-assistant/growth-weekly-digest/guitar-recording-studio/local-election-intelligence) + macro-hub 6本(core/growth/ai/admin/app/schedule) + mega-hub 5本(tools/media/enterprise/social-commerce/lifestyle) / 新規機能は必ず既存hubのaction追加で対応
+- EF 管理: **ハードキャップ50本以下** (Tier1/Tier2廃止 / 現在15本デプロイ済み) / 15本構成: standalone 4本(get-home-dashboard/ai-assistant/growth-weekly-digest/guitar-recording-studio) + macro-hub 6本(core/growth/ai/admin/app/schedule) + mega-hub 5本(tools/media/enterprise/social-commerce/lifestyle) / 新規機能は必ず既存hubのaction追加で対応
 - **Claude Managed Agents 統合** (`claude-agent-review.yml`): static解析では検出できないルール違反・EF上限・アーキテクチャを PR 毎に自動レビュー
 - **フィードバックパイプライン** (`feedback-issue-resolved.yml`): Issue クローズ → HTML comment から `feature_request_id`/`app_feedback_id` 抽出 → PR cross-reference 取得 → リリース通知メール
 
@@ -467,10 +521,9 @@ web/sitemap.xml          # URL マップ
 
 | タスク / 課題 | 担当 | 優先度 | 詳細 |
 | --- | --- | --- | --- |
-| **PR #366: frosty-hamilton マージ** | PS版 | 🟡中 | Voice AI chat + conversation_messages migration + check_versions.py。CLAUDE.md / CV3 / ai-assistant.ts でコンフリクトあり → 手動解決後マージ |
 | **モバイルアプリ (iOS/Android) 対応** | VSCode版 | 🟡中 | Flutter モバイルビルド環境の整備と動作検証 |
 | **Notion API 連携のメモリ最適化** | Web版 | 🟡中 | `growth-import-preview` EF の再帰ブロック取得時のメモリ使用量最適化 |
-| **AI大学 新規プロバイダー検討** | Windows版 | 🟢低 | 67社目以降のプロバイダー（新興AI等）の追加評価 |
+| **AI大学 新規プロバイダー検討** | Windows版 | 🟢低 | 56社目以降のプロバイダー（Cohere standalone API, Voyage AI 等）の追加評価 |
 
 ### CI/CD改善 #C1: 2026-03-27 日次レポート分析からの反映 (PowerShell版#21, 2026-04-11)
 
@@ -516,28 +569,14 @@ web/sitemap.xml          # URL マップ
 - ✅ **第40弾 投稿成功** (Gemini CLI, 本セッション): `2026-04-13-three-instance-parallel-dev-en.md` → dev.to
 - ✅ **第41弾 投稿成功** (VSCode版#77 Design-Skills, 2026-04-16): `2026-04-11-personal-dashboard-notion-competitor.md` → Qiita+dev.to
 - ✅ **第42弾 投稿成功** (VSCode版#77 Design-Skills, 2026-04-16): `2026-04-10-dns-domain-manager.md` → Qiita+dev.to
-- ✅ **第43弾 投稿成功** (VSCode版#77, 2026-04-16): `2026-04-13-ai-university-41-providers-tabs.md` → Qiita+dev.to
-- ✅ **第44弾 投稿成功** (VSCode版#77, 2026-04-16): `2026-04-12-horse-racing-ai-pipeline.md` → Qiita+dev.to
-- ✅ **第45弾 投稿成功** (VSCode版#77, 2026-04-16): `2026-04-08-x-viral-pipeline-catalog-expansion.md` → Qiita+dev.to
-- ✅ **第46弾 投稿成功** (VSCode版#77, 2026-04-16): `2026-04-07-ai-writing-assistant-upgrade.md` → Qiita+dev.to
-- ✅ **第47弾 投稿成功** (VSCode版#77, 2026-04-16): `2026-04-06-public-guitar-gallery.md` → Qiita+dev.to
-- ✅ **第48弾 投稿成功** (VSCode版#78, 2026-04-16): `2026-04-08-guitar-x-auto-post.md` → Qiita+dev.to
-- ✅ **第49弾 投稿成功** (VSCode版#78, 2026-04-16): `2026-04-13-ai-university-54-providers-milestone.md` → Qiita+dev.to
-- ✅ **第50弾 投稿成功** (VSCode版#78, 2026-04-16): `2026-04-13-claude-mem-persistent-memory.md` → Qiita+dev.to
-- ✅ **第51弾 投稿成功** (VSCode版#78, 2026-04-16): `2026-04-10-budget-ai-advisor.md` → Qiita+dev.to
-- ✅ **第52弾 投稿成功** (VSCode版#78, 2026-04-16): `2026-04-12-ai-university-34-providers.md` → Qiita+dev.to
-- ✅ **第53弾 投稿成功** (PS版セッション, 2026-04-17): WEB版廃止記事 → Qiita+dev.to
-- 🔄 **blog-batch-publish.yml 実行中** (VSCode版#81, 2026-04-17): 未投稿ドラフト21本を一括投稿中 (`blog-engagement.yml` も同時実行中)
 - ⚠️ **blog-publish.yml Step5**: GITHUB_TOKEN はブランチ保護 (require PR) をバイパス不可。published:true 更新は手動マージが必要。BLOG_PAT シークレット設定で完全自動化可能。
-- ✅ **blog-publish.yml Step5 無限ループ修正** (VSCode版#81): frontmatter なしファイルも `_mark_published()` 4-case bash関数で処理済み。
 
-**次回候補**:
+**次回候補 (第13弾以降)**:
 
 | 優先度 | 下書き | 媒体 |
 | --- | --- | --- |
-| 高 | batch-publish 結果確認 (21本の成功/失敗確認) | Qiita/dev.to |
-| 中 | blog-engagement 結果確認 + `/blog-management` 画面で表示確認 | - |
-| 中 | その他 `docs/blog-drafts/` 残下書き | Qiita/dev.to |
+| 中 | `2026-04-08-guitar-x-auto-post.md` / その他蓄積下書き (52本) | Qiita/dev.to |
+| 中 | その他 `docs/blog-drafts/` 下書き (54本蓄積中) | Qiita/dev.to |
 
 **推定ROI**: #buildinpublic / #FlutterWeb / #Supabase / #Notion タグで開発者コミュニティに到達 → ユーザー4人からの脱却。
 
@@ -708,10 +747,10 @@ AI大学はユーザー数拡大のための**最重要差別化機能**。毎�
 
 **背景**: `gemini_university_v2_page.dart` が Gemini 特化のハードコードコンテンツ。**プロバイダー数は固定せず毎セッションで追加候補を検討**し、毎週 Claude Schedule が最新情報を自動更新する仕組みに改修。
 
-#### 現在の登録プロバイダー (Win版#本セッション: 66社)
+#### 現在の登録プロバイダー (Windows版#63: 60社)
 
 ```text
-google, openai, anthropic, microsoft, meta, x, deepseek, mistral, perplexity, groq, cohere, core, amazon, stability, huggingface, nvidia, ibm, sakana, baidu, oracle, reka, aleph_alpha, together_ai, fireworks_ai, replicate, writer, ai21, voyage, elevenlabs, openrouter, ollama, runway, suno, ideogram, udio, luma, kling, pika, assemblyai, twelve_labs, qwen, moonshot, midjourney, hailuo, adobe_firefly, 01ai, coze, apple, databricks, samsung, zhipu, character_ai, inflection, allenai, naver, adept, cerebras, prover, lmsys, falcon_tii, black_forest_labs, liquid_ai, snowflake, cognition, scale_ai, poolside
+google, openai, anthropic, microsoft, meta, x, deepseek, mistral, perplexity, groq, cohere, core, amazon, stability, huggingface, nvidia, ibm, sakana, baidu, oracle, reka, aleph_alpha, together_ai, fireworks_ai, replicate, writer, ai21, voyage, elevenlabs, openrouter, ollama, runway, suno, ideogram, udio, luma, kling, pika, assemblyai, twelve_labs, qwen, moonshot, midjourney, hailuo, adobe_firefly, 01ai, coze, apple, databricks, samsung, zhipu, character_ai, inflection, allenai, naver, adept, cerebras, prover, lmsys, falcon_tii
 ```
 
 新規プロバイダーを追加するたびにこのリストを更新する。

--- a/.github/COMPRESSED_PROMPT_V3.md
+++ b/.github/COMPRESSED_PROMPT_V3.md
@@ -9,55 +9,71 @@ Flutter Web + Supabase で **21競合を統合するAIライフマネジメン�
 
 ## 🔀 4インスタンス + Multi-AI 並行開発スコープ（2026-04-16 更新）
 
+> 詳細制約ログ・最新機能・次回推奨プロンプト: **`docs/instance-constraints.md`** 参照。
+> 新制約発見時はそのファイルに即追記し、この表の制約列も同時更新すること。
+
 ### Claude Code 4インスタンス構成
 
-> **制約対応表**: WEB版(claude.ai/code)はローカルCLI時限あり—— `notebooklm`・`flutter analyze`・`deno lint`・ローカルPythonスクリプトは不可。WebSearch / WebFetch / GitHub MCP は利用可。
-
-| インスタンス | 担当範囲 (write 権限) | 専任ルール | 推奨モデル | 制約 |
+| インスタンス | 担当範囲 | 推奨モデル | 推奨モード | 主な制約 |
 | --- | --- | --- | --- | --- |
-| **VSCode版** | `lib/` (Flutter UI) + `supabase/functions/` (EF) + `docs/DESIGN.md` | Rule 16 (表示チェック+修正) / Rule 19 (UI改善) / `flutter analyze` + `deno lint` 0エラー | `claude-sonnet-4-6` | なし |
-| **Windowsアプリ版** | `docs/` (DESIGN.md除く) + `supabase/migrations/` + **notebooklm CLI主担当** | Rule 10 (docs全件分析) / AI大学プロバイダー追加 / **Master Brain更新** | `claude-sonnet-4-6` | なし |
-| **PowerShell版** | `.github/workflows/` + `.mcp.json` + `docs/MULTI_INSTANCE_COORDINATION.md` | Rule 17 (CI/CD最適化) / Scheduleタスク owner | `claude-haiku-4-5` (次元作業) or `sonnet-4-6` (設計) | なし |
-| **WEB版** | `docs/blog-drafts/` + `docs/competitor-reports/` + GitHub PR/Issues主担当 | Rule 11 (AI大学 WebSearch経由) / T-1 ブログ / 競合リサーチ / Code Review MCP | `claude-sonnet-4-6` | notebooklm・ローカルCLI **不可** |
+| **VSCode版** | `lib/` + `supabase/functions/` + `docs/DESIGN.md` | `claude-sonnet-4-6` | 通常。複雑UI設計時 **Extended Thinking** | なし |
+| **Windowsアプリ版** | `docs/` + `supabase/migrations/` + notebooklm CLI専任 | `claude-sonnet-4-6` | 通常 + CAVEMAN | `PYTHONUTF8=1` 必須 / xlsxロック注意 |
+| **PowerShell版** | `.github/workflows/` + `.mcp.json` | 定型: `haiku-4-5` / 設計: `sonnet-4-6` | `/fast` (定型) / 通常 (設計) | GHA `${{}}` は env:ブロック経由 |
+| **WEB版** | `docs/blog-drafts/` + `docs/competitor-reports/` + GitHub PR/Issues | `claude-sonnet-4-6` | **Projects + Memory + Learning Mode** | notebooklm / flutter analyze / deno lint / ローカルCLI 不可 |
 
-### 外部AI統合（補完役割）
+### Claude 最新機能 活用ガイド
 
-| AI ツール | 役割 | 使用タイミング |
+| 機能 | 対応インスタンス | 使い所 |
 | --- | --- | --- |
-| **GitHub Copilot** | VSCode内インライン補完・PR自動レビュー | コード補完 (`Ctrl+Enter`) / インラインChat (`Ctrl+I`) / `claude-agent-review.yml` PR審査 |
-| **Gemini Code Assist** | 長文コード理解・Google API統合・テスト生成 | Cloud Shell / JetBrains / VSCode で複雑な EF ロジック・Dart リファクタリング支援 |
-| **OpenAI CODEX** | アルゴリズム生成・コード変換・SQL最適化 | Supabase クエリ最適化 / Edge Function の複雑なビジネスロジック実装支援 |
+| **Extended Thinking** | VSCode / Windowsアプリ | 複雑UI設計・DB schema・アーキテクチャ決定。`claude-opus-4` 推奨 |
+| **Projects機能** | WEB版 (claude.ai専用) | プロジェクト文脈・CLAUDE.md・履歴をセッション越えで永続化 |
+| **Memory機能** | WEB版 (claude.ai専用) | ユーザー設定・プロジェクトコンテキスト・よく使うパターンを記憶 |
+| **Learning Mode** | WEB版 (Projects経由) | Projectsにリポジトリマップ・CLAUDE.mdを読ませると次回からコンテキスト初期化不要 |
+| **Interleaved Thinking** | 全インスタンス | ツール実行中にも思考を継続。多ステップタスクで自動適用 |
+| **CAVEMANモード** | Windowsアプリ / PowerShell 主体 | コミュニケーショントークン～75%削減 |
+
+### 外部AI 最新モデル・機能
+
+| AI | 最新モデル | 主な機能 | このプロジェクトでの用途 |
+| --- | --- | --- | --- |
+| **GitHub Copilot** | GPT-4o / Claude Sonnet / Gemini Pro 選择可 | Inline補完 / Copilot Edits (複数ファイル同時編集) / Copilot Workspace (Issue→PR自動) / `@workspace` | VSCode版: EditsでFlutter多ファイル編集 / PS版: `gh copilot suggest` |
+| **Gemini Code Assist** | Gemini 2.5 Pro (2Mトークン) / Flash | Agent mode / Flutter/Dart特化 / 大規模リファクタ | EF全体横断分析 / Dart大規模リファクタ |
+| **OpenAI CODEX** | o3 (最強推論) / o4-mini (高速低コスト) / Codex CLI | SQL最適化 / アルゴリズム / ターミナル直実行 | Supabaseクエリ最適化 / PS版: `codex` CLI |
 
 ### AI選択フロー
 
 ```text
-行レベル補完 (秒単位)        → GitHub Copilot (Ctrl+Enter)
-インライン修正 (分単位)       → GitHub Copilot Inline Chat (Ctrl+I)
-複雑なDart/Flutter実装       → Gemini Code Assist (長コンテキスト強み)
-アルゴリズム / SQL 最適化     → CODEX (コード特化強み)
-設計・戦略・長期判断          → Claude Code (Memory + ROADMAP統合)
-ブログ / 競合リサーチ       → Claude Code WEB版 (WebSearch/WebFetch)
-NotebookLM Deep Research  → Windowsアプリ版 (notebooklm CLI専任)
+行レベル補完                  -> GitHub Copilot Inline (Ctrl+Enter)
+複数ファイル同時編集 (VSCode)    -> Copilot Edits
+複雑なDart/Flutter              -> Gemini 2.5 Pro (長コンテキスト+Flutter特化)
+SQL / アルゴリズム最適化          -> CODEX o3/o4-mini
+設計・戦略・長期判断            -> Claude Code (Memory + ROADMAP)
+複雑な推論・アーキテクチャ       -> Claude Extended Thinking (opus/sonnet)
+ブログ / 競合リサーチ           -> WEB版 (WebSearch/WebFetch/Projects)
+NotebookLM Deep Research      -> Windowsアプリ版専任 (notebooklm CLI)
+Issue -> PR 全自動              -> Copilot Workspace
 ```
 
-### クオータ監視
+### 制約発見時の更新フロー（全インスタンス共通）
 
-`quota-monitor.yml` (毎日 09:00 JST) が各ツールの使用状況を `ai_quota_usage` テーブルに記録。
+```text
+Step 1: docs/instance-constraints.md の「制約発見ログ」に追記
+Step 2: この表の制約列を更新
+Step 3: memory/feedback_correction_YYYYMMDD.md に記録
+Step 4: cross-instance-pr で他インスタンスへ周知
+```
 
-| ツール | 監視方法 | アラート閾値 |
+### クオータ監視 (quota-monitor.yml 毎日 09:00 JST)
+
+| ツール | 監視方法 | アラート閃値 |
 | --- | --- | --- |
-| Claude (Anthropic API) | `/v1/usage` API | 月次 $50 超過 |
-| OpenAI (CODEX) | `/v1/usage` API | 月次 $20 超過 |
-| Gemini Code Assist | Google Cloud Monitoring API | 月次クオータ 80% |
-| GitHub Copilot | GitHub `/user/copilot_billing` API | シート数上限近接 |
+| Claude (Anthropic API) | `/v1/usage` | 月次 $50 |
+| OpenAI (CODEX) | `/v1/usage` | 月次 $20 |
+| Gemini Code Assist | Google Cloud Monitoring | 月次クオータ 80% |
+| GitHub Copilot | `/user/copilot_billing` | シート数上限近接 |
 
-| **GitHub Copilot (統合AI)** | VSCode 内インライン補完・チャット・PR レビュー / 全インスタンス横断支援 | Inline Chat: `I#` 接頭辞で簡易修正 / Copilot Chat: 複雑な判断・アーキテクチャ / `claude-agent-review.yml`: PR自動レビュー |
-
-**緊急横断権限**: blocking が発生し他インスタンスを待てない場合、`docs/cross-instance-prs/YYYYMMDD_<内容>.md` に変更提案をコミット可。担当インスタンスが次セッションで採否を判断してマージする。
-
-**競合回避パターン（必須）**: `git stash → git pull --rebase origin main → git push origin main → git stash pop`
-衝突時: `git checkout --theirs <file>` → `git add` → `git rebase --continue`
-
+**緊急横断権限**: blocking 時は `docs/cross-instance-prs/YYYYMMDD_<内容>.md` に提案をコミット。担当インスタンスが次セッションで採否。
+**競合回避パターン**: `git stash -> git pull --rebase origin main -> git push -> git stash pop`
 ---
 
 ## 🏆 競合21社（全機能を統合して超える）

--- a/.github/COMPRESSED_PROMPT_V3.md
+++ b/.github/COMPRESSED_PROMPT_V3.md
@@ -63,6 +63,17 @@ Step 3: memory/feedback_correction_YYYYMMDD.md に記録
 Step 4: cross-instance-pr で他インスタンスへ周知
 ```
 
+### セッション開始時 バージョンチェック（全インスタンス必須）
+
+詳細: `docs/tool-versions.md` / チェックスクリプト: `scripts/check_versions.py`
+
+| インスタンス | 実行コマンド | 更新時のアクション |
+| --- | --- | --- |
+| VSCode / Windowsアプリ / PowerShell | `PYTHONUTF8=1 python3 scripts/check_versions.py` | 制約解消チェックリストを確認し `docs/tool-versions.md` を更新 |
+| WEB版 | WebFetch でリリースページを確認 | GitHub MCP 経由で `docs/tool-versions.md` を手動更新 |
+
+**新モデルリリース時**: `ai-assistant` EF の `DEFAULT_SYNTHESIS_MODEL` + 各 EF のモデルパラメータを更新する。
+
 ### クオータ監視 (quota-monitor.yml 毎日 09:00 JST)
 
 | ツール | 監視方法 | アラート閃値 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,13 @@ UIコンポーネントを新規作成・修正する際は、以下のファイ
    - 新しいUIウィジェットを作るとき → **Magic MCP** でベースを生成してから `docs/DESIGN.md` トークンを適用
    - 実装が一段落したら → **Code Review MCP** でセキュリティ・品質チェックを自動実行
 
+14. **制約・仕様変更を即記録（全インスタンス・必須）** — どのインスタンスでも新しい制約・モデル変更・モード仕様を発見したら即座に以下を実施する:
+   1. `docs/instance-constraints.md` の「制約発見ログ」に追記 (`| 日付 | インスタンス | 制約内容 | 代替手段 | セッション名 |`)
+   2. `.github/COMPRESSED_PROMPT_V3.md` の該当インスタンス行の制約列を更新
+   3. `memory/feedback_correction_YYYYMMDD.md` に記録
+   4. `docs/cross-instance-prs/YYYYMMDD_constraint.md` で他インスタンスへ周知
+   **対象範囲**: Claude モデル制限・WEB版の新たな不可操作・MCP ツール制限・GitHub Actions の仕様変更・外部AI (Copilot/Gemini/CODEX) のモデル変更すべてを含む
+
 ---
 
 ## Multi-AI ワークフロー（毎回必ず実行）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,131 +97,41 @@ UIコンポーネントを新規作成・修正する際は、以下のファイ
    - 新しいUIウィジェットを作るとき → **Magic MCP** でベースを生成してから `docs/DESIGN.md` トークンを適用
    - 実装が一段落したら → **Code Review MCP** でセキュリティ・品質チェックを自動実行
 
-14. **毎回必須: NotebookLM 経由でトークン削減 (Rule 21)** — 全インスタンス (VSCode/Windowsアプリ/PowerShell版) に適用。
-   - 3ファイル以上同時読み込み → `notebooklm source add` → `notebooklm ask`
-   - URL・競合サイト分析 → `notebooklm source add URL`
-   - 競合21社調査 → `notebooklm source add-research`
-   - ドキュメント全体俯瞰 → NotebookLM source 追加後に要約
-   - セッション終了時 → `notebooklm source add ./memory/*.md` で Master Brain 蓄積必須
-
-   Claude 直接処理は「判断・編集・統合」のみに限定。トークン節約効果 ~95%。
-
-15. **毎セッション冒頭: /recap + バージョン確認・リリースノート確認・制約解消チェック (Rule 22)** — 詳細は `docs/INSTANCE_CONFIG.md` を参照。
-
-   **Step 0: /recap — 公式 Learning Mode (v2.1.108+・全インスタンス共通)**
-
-   ```text
-   /recap
-   ```
-
-   セッション開始時に必ず `/recap` を実行し、前回の作業サマリーを確認してから作業開始する。
-   全インスタンス共通で動作する。
-
-   **Step 1: バージョン確認 (ローカルインスタンスのみ)**
-
-   ```bash
-   CURRENT=$(claude --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-   LATEST=$(npm show @anthropic-ai/claude-code dist-tags.latest)
-   echo "現在: $CURRENT / 最新: $LATEST"
-   ```
-
-   **Step 2: バージョンが古ければ更新**
-
-   ```bash
-   npm update -g @anthropic-ai/claude-code
-   ```
-
-   **Step 3: 更新があった場合は必ずリリースノートを確認**
-
-   ```bash
-   # WebFetch でリリースノートを確認 (全インスタンス共通)
-   # URL: https://claudefa.st/blog/guide/changelog
-   # または: https://github.com/anthropics/claude-code/releases
-   ```
-
-   リリースノート確認後、以下を実施する:
-
-   | 確認項目 | 対応 |
-   | --- | --- |
-   | **新機能追加** | `docs/INSTANCE_CONFIG.md` の「新機能」セクションに追記 → 開発フローへの組み込み可否を判断 → 有用であれば即 CLAUDE.md の該当 Rule に追記 |
-   | **他インスタンス制約の変化** | 同様に制約カタログを更新 |
-   | **Routines 上限変更** | `docs/INSTANCE_CONFIG.md` の Routines セクションを更新 |
-   | **モデル追加** | `docs/INSTANCE_CONFIG.md` の「利用可能モデル」表を更新 |
-
-   **Step 4: 制約・新機能を docs/INSTANCE_CONFIG.md に記録**
-
-   - 変更ログに `| YYYY-MM-DD | [変更内容] | [発見インスタンス] |` を追記
-   - 開発フローに組み込む新機能は CLAUDE.md の該当 Rule (Rule 8〜22) に追記するか新 Rule を追加
-   - 記憶: `memory/project_YYYYMMDD_[instance].md` にも要約を保存
-
-   **Step 5: 各インスタンスの推奨プロンプトを更新**
-
-   - 制約解消・新機能追加に合わせて `docs/INSTANCE_CONFIG.md` の推奨プロンプトを更新
-   - 次回セッション開始時は必ず同ファイルの推奨プロンプトを使用する
-
-   **他ツールのバージョン確認 (フォールバックAI)**
-
-   ```bash
-   # GitHub Copilot CLI
-   gh copilot --version 2>/dev/null || echo "not installed"
-   # リリースノート: https://github.blog/changelog/ (copilot で検索)
-
-   # Codex CLI (OpenAI)
-   codex --version 2>/dev/null || echo "not installed"
-   # リリースノート: https://github.com/openai/codex/releases
-
-   # Gemini Code Assist
-   # VS Code 拡張パネル → "Google Cloud Code" → バージョン確認
-   # リリースノート: https://cloud.google.com/code/docs/vscode/release-notes
-   ```
-
-   **利用可能モデル (2026-04-17 更新)**:
-
-   | モデル | ID | 用途 | 備考 |
-   | --- | --- | --- | --- |
-   | **Opus 4.7** 🆕 | `claude-opus-4-7` | **推奨**: agentic coding・複雑設計 | Extended Thinking なし。Adaptive Thinking あり |
-   | **Sonnet 4.6** | `claude-sonnet-4-6` | 日常実装・ultrathink使用時 | Extended Thinking ✅ |
-   | **Haiku 4.5** | `claude-haiku-4-5-20251001` | 定型処理 | Extended Thinking ✅ |
-   | ~~Opus 4.6~~ | ~~`claude-opus-4-6`~~ | レガシー → Opus 4.7 へ移行 | |
-   | ~~Haiku 3~~ | ~~`claude-3-haiku-20240307`~~ | **2026-04-19 廃止** | Haiku 4.5 へ移行 |
-
-   **拡張思考トリガー** (プロンプトに含めて起動):
-   > ⚠️ **Opus 4.7 は Extended Thinking 非対応。ultrathink を使う場合は Sonnet 4.6 を使用。**
-
-   | キーワード | 思考レベル | 使いどき |
-   | --- | --- | --- |
-   | `think` | Lv.1 | 設計確認 |
-   | `think deeply` | Lv.2 | 中程度の設計判断 |
-   | `think harder` | Lv.3 | 複雑なバグ・パフォーマンス |
-   | `think very hard` | Lv.4 | アーキテクチャ設計 |
-   | `ultrathink` | Lv.5 (最大) | 全体設計・競合戦略 (**Sonnet 4.6 で実行**) |
-
-   **Routines** (Windowsアプリ版 Desktop 専用): `code.claude.com/docs/en/routines` 参照。GitHub Actions の代替として積極活用する (Pro:5回/日, Max:15回/日)。
-
 ---
 
 ## Multi-AI ワークフロー（毎回必ず実行）
 
-**設計思想**: 「どの処理をどの AI に振るか」を設計することで、月 $20 プランで $200 相当の作業を実現する。
+**設計思想**: Claude Code 4インスタンス (VSCode/Windowsアプリ/PowerShell/WEB版) を主軸に、Gemini Code Assist・CODEX・GitHub Copilot を補完役で活用。
+「どの処理をどの AI に振るか」を設計することで、月 $20 プランで $200 相当の作業を実現する。
 Claude のトークンは「判断・編集・統合」のみに使い、重い分析は Google (NotebookLM/Gemini) に無料で投げる。
 
-### フォールバック AI ツール (Claude MAX レート制限到達時のみ使用)
+### インスタンス別 推奨モデル / 制約表
 
-> **通常運用**: Claude Code 3インスタンス (VSCode / Windowsアプリ / PowerShell) のみ使用。
-> フォールバックは Claude が **429 エラー / 月次 $50 超過** のときだけ発動。
-> NotebookLM のみ制限に関係なく **常時使用必須 (Rule 21)**。
-
-| ツール | 発動条件 | ファイル種別 | 用途 |
+| インスタンス | 推奨モデル | 推奨モード | 主な制約 |
 | --- | --- | --- | --- |
-| **Gemini Code Assist** | Claude 429 / $50超過 | `.dart` | Flutter/Dart IDE補完 (Google製言語に最適化) |
-| **CODEX CLI** (OpenAI) | Claude 429 / $50超過 | `.py` / `.ts` | Pythonスクリプト・TypeScript EF draft |
-| **GitHub Copilot** | Claude 429 / $50超過 + **常時PR自動レビュー** | `.yml` / `.sql` / `.md` | YAML補完・PR自動レビュー |
-| **NotebookLM** | **常時使用必須 (Rule 21)** | 全種別 | 3ファイル以上同時読み込み・URL分析・競合21社調査 |
+| **VSCode版** | `claude-sonnet-4-6` | 通常 (Flutter解析は深い思考要) | なし |
+| **Windowsアプリ版** | `claude-sonnet-4-6` | 通常 + CAVEMAN節約 | なし。`PYTHONUTF8=1` 必須 |
+| **PowerShell版** | ルーティン: `claude-haiku-4-5` / 設計: `claude-sonnet-4-6` | `/fast` (定型作業) | なし |
+| **WEB版** | `claude-sonnet-4-6` (変更不可の場合あり) | 通常 | `notebooklm` / `flutter analyze` / `deno lint` / ローカルCLI **不可** |
 
-**フォールバック発動ルール**:
-1. `quota-monitor.yml` が月次閾値超過を検知 → `ai_quota_usage.alert=true` 書き込み
-2. `cs-check.yml` 次回実行時に GitHub Issue 自動生成「⚠️ Claude レート制限到達」
-3. Issue 本文に「推奨フォールバック AI + ファイル種別対応表」を記載して手動切替を案内
+**WEB版代替パターン**:
+- `notebooklm ask` → WebSearch で代替
+- `flutter analyze` → 実行不可→ VSCode版に cross-instance-pr で検証依頼
+- `deno lint` → 実行不可 → EF変更は VSCode版に依頼
+- git commit → GitHub MCP (`mcp__plugin_github_github__create_or_update_file`) で代替
+
+### AI振り分け早見表
+
+| タスク | 最適ツール | 理由 |
+| --- | --- | --- |
+| 行レベル補完 | GitHub Copilot | 最速・ゼロ待機 |
+| 5分以内の修正 | Copilot Inline Chat | コンテキスト取得コスト不要 |
+| 500行超リファクタリング | Gemini Code Assist | 長コンテキスト強み |
+| SQL/アルゴリズム最適化 | OpenAI CODEX | コード特化モデル |
+| 設計・戦略・ルール遵守 | Claude Code | Memory + プロジェクト文脈 |
+| ブログ・競合リサーチ | Claude Code WEB版 (WebSearch/WebFetch) | ローカルCLI不要・GitHub MCP対応 |
+| NotebookLM Deep Research | Windowsアプリ版 (notebooklm CLI) | WEB版は notebooklm 不可 |
+| クオータ使用状況確認 | `quota-monitor.yml` Dashboard | Supabase `ai_quota_usage` テーブル |
 
 ### マルチエージェント協調パターン (新機能設計時に参照)
 
@@ -231,7 +141,7 @@ Claude のトークンは「判断・編集・統合」のみに使い、重い�
 | --- | --- | --- |
 | **Generator-Verifier** | 品質が最重要。評価基準を明文化できる | `claude-agent-review.yml` (PR生成→Claudeレビュー) / `ci-auto-fix.yml` (修正→CI再実行) / `/deep-research` (NotebookLM生成→Claude統合) |
 | **Orchestrator-Subagent** | タスク分解が明確。サブタスクが短時間で完結 | `cs-check.yml` (FAQ返信/バグ修正/エスカレーション) / `github-issue-fix.yml` (Issue一覧→1件ずつ処理) / Claude Code Schedule (計画→実行→コミット) |
-| **Agent Teams** | 並行独立した長時間タスク。成果物が互いに干渉しない | **3インスタンス並行開発** (VSCode/Windowsアプリ/PowerShell) / `ai-university-update.yml` (66プロバイダー 2時間毎 RSS) + Claude Schedule (4時間毎 NotebookLM Deep Research) |
+| **Agent Teams** | 並行独立した長時間タスク。成果物が互いに干渉しない | **4インスタンス並行開発** (VSCode/Windowsアプリ/PowerShell/WEB版) + Gemini Code Assist / CODEX / GitHub Copilot 補完 / `ai-university-update.yml` (60プロバイダー 2時間毎 RSS) + Claude Schedule (4時間毎 NotebookLM Deep Research) |
 | **Message Bus** | イベント駆動。エコシステムが成長する | `workflow-failure-handler.yml` (失敗イベント→Issue→`cs-check`) / `feedback-issue-resolved.yml` (Issueクローズ→通知メール) / `edge-function-audit.yml` (EF未接続→Issue→`github-issue-fix`) |
 | **Shared State** | エージェントが互いの発見を活用。単一障害点を避けたい | `memory/` + NotebookLM Master Brain (セッション横断知識) / Supabase DB (全EFが読み書き) / `COMPRESSED_PROMPT_V3.md` (全インスタンス共有状態) |
 
@@ -770,19 +680,7 @@ GitHub PRの自動コードレビュー。
 
 ---
 
-### Task: blog-draft (毎日 07:00 JST — GitHub Actions 自動化済み)
-
-> **2026-04-17 更新**: `blog-draft.yml` GitHub Actions ワークフローに移行。
-> 毎日 07:00 JST に直近 git log を Anthropic API (Claude Sonnet 4.5) に投げてドラフト自動生成 → commit → `blog-publish.yml` を自動トリガー。
-> Claude Schedule タスクとしての手動実行は不要だが、特別な記事を書きたい場合は以下の手順で手動実行可能:
->
-> ```bash
-> gh workflow run blog-draft.yml -f target_date=YYYY-MM-DD -f days=1
-> ```
->
-> 以下は Claude が手動でドラフトを書く場合の参考仕様。自動生成で品質が不足する場合に上書き用テンプレートとして使用する。
-
-### Task: blog-draft (手動モード・参考仕様)
+### Task: blog-draft (毎日 08:00 JST に実行)
 
 技術ブログの下書きを生成し、投稿管理テーブルに記録する。
 
@@ -1012,7 +910,7 @@ AI大学コンテンツを最新情報に自動更新する。**プロバイダ�
 #### 現在の登録プロバイダー
 
 ```text
-google, openai, anthropic, microsoft, meta, x, deepseek, mistral, perplexity, groq, cohere, core, amazon, stability, huggingface, nvidia, ibm, sakana, baidu, oracle, reka, aleph_alpha, together_ai, fireworks_ai, replicate, writer, ai21, voyage, elevenlabs, openrouter, ollama, runway, suno, ideogram, udio, luma, kling, pika, assemblyai, twelve_labs, qwen, moonshot, midjourney, hailuo, adobe_firefly, 01ai, coze, apple, databricks, samsung, zhipu, character_ai, inflection, allenai, naver, adept, cerebras, prover, black_forest_labs, liquid_ai, black_forest_labs, liquid_ai
+google, openai, anthropic, microsoft, meta, x, deepseek, mistral, perplexity, groq, cohere, core, amazon, stability, huggingface, nvidia, ibm, sakana, baidu, oracle, reka, aleph_alpha, together_ai, fireworks_ai, replicate, writer, ai21, voyage, elevenlabs, openrouter, ollama, runway, suno, ideogram, udio, luma, kling, pika, assemblyai, twelve_labs, qwen, moonshot, midjourney, hailuo, adobe_firefly, 01ai, coze, apple, databricks, samsung, zhipu, character_ai, inflection, allenai, naver, adept, cerebras, prover, lmsys, falcon_tii
 ```
 
 登録済みプロバイダーは `ai_university_content` テーブルの `provider` カラム個別値で確認できる。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,19 @@ UIコンポーネントを新規作成・修正する際は、以下のファイ
    - 新しいUIウィジェットを作るとき → **Magic MCP** でベースを生成してから `docs/DESIGN.md` トークンを適用
    - 実装が一段落したら → **Code Review MCP** でセキュリティ・品質チェックを自動実行
 
-14. **制約・仕様変更を即記録（全インスタンス・必須）** — どのインスタンスでも新しい制約・モデル変更・モード仕様を発見したら即座に以下を実施する:
+14. **セッション開始時: ツールバージョンチェック（全インスタンス・必須）** — セッション冒頭で以下を実行する。バージョン変更があれば制約解消チェックと役割分担の見直しを行う。
+   - **デスクトップ版 (VSCode/Windowsアプリ/PowerShell)**: `PYTHONUTF8=1 python3 scripts/check_versions.py` を実行
+   - **WEB版**: `python3 scripts/check_versions.py --web` は不可 → 下記URLを WebFetch で確認し手動更新
+     - Claude Code: `https://github.com/anthropics/claude-code/releases`
+     - Gemini: `https://marketplace.visualstudio.com/items?itemName=google.geminicodeassist`
+   - **バージョン更新時の対応**:
+     1. `docs/tool-versions.md` を更新 (`--update` フラグで自動更新可)
+     2. `docs/tool-versions.md` の「制約解消チェックリスト」を確認
+     3. 解消された制約を `docs/instance-constraints.md` から削除
+     4. `.github/COMPRESSED_PROMPT_V3.md` の制約列を更新
+   - **新モデルリリース時** (例: `claude-sonnet-4-7` 等): `supabase/functions/ai-assistant/index.ts` の `DEFAULT_SYNTHESIS_MODEL` + 各 EF のモデルパラメータを更新する
+
+15. **制約・仕様変更を即記録（全インスタンス・必須）** — どのインスタンスでも新しい制約・モデル変更・モード仕様を発見したら即座に以下を実施する:
    1. `docs/instance-constraints.md` の「制約発見ログ」に追記 (`| 日付 | インスタンス | 制約内容 | 代替手段 | セッション名 |`)
    2. `.github/COMPRESSED_PROMPT_V3.md` の該当インスタンス行の制約列を更新
    3. `memory/feedback_correction_YYYYMMDD.md` に記録

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -6431,7 +6431,6 @@ Web版スコープ (EF のみ) のため、UI 目視確認は対象外。
   - CLAUDE.md 実装ロードマップ: 全行を完了ステータスに修正
 
 ### 技術的発見
-
 - Write tool で絵文字多用ファイルを書くと 1 byte になる silent fail → `wc -c` で検証必須
 - TS2367: literal type と `""` の比較は `: string` アノテーションで回避
 
@@ -6543,7 +6542,7 @@ Web版スコープ (EF のみ) のため、UI 目視確認は対象外。
 ### T-1 累積実績 (2026-04-12)
 
 | 弾 | 記事 | Qiita | dev.to |
-| --- | --- | --- | --- |
+|---|---|---|---|
 | 第1弾 | CS自動化 | ✅ | ✅ |
 | 第2弾 | 通知センター | ✅ | ✅ |
 | 第3弾 | notification-center | ✅ | ✅ |
@@ -6939,7 +6938,7 @@ Web版スコープ (EF のみ) のため、UI 目視確認は対象外。
 - LP: 130のこと (Baidu PR未処理で実質131のこと予定)
 - ページ数: 215 (brain_dump / project_gantt / business_card_manager / family_calendar 追加)
 - EF deployed: 99本 (Tier1上限)
-- AI大学プロバイダー UI: 17社対応 (gemini_university_v2_page.dart_providerMeta)
+- AI大学プロバイダー UI: 17社対応 (gemini_university_v2_page.dart _providerMeta)
 - ユーザー数: 4人
 
 ### 2026-04-16 セッション実装済み (全7タスク完了)
@@ -6968,7 +6967,7 @@ Web版スコープ (EF のみ) のため、UI 目視確認は対象外。
 - **スキップ理由**: Step 3 ブラウザ表示確認後に design-skills サブエージェント呼び出しとして計画。本セッションでは lint 0 エラー達成を優先
 - **次セッション対応**: `/design-skills` ページまたはホーム画面のデザイン監査を実施
 
-#### Step 5: docs/ 全件分析 ✅
+#### Step 5: docs/ 全件分析 ✅ 
 
 - **実施**: docs/ の 5 主要ファイルを分析 (CICD_SETUP_GUIDE, CONTRIBUTING, MULTI_INSTANCE_COORDINATION, README, DESIGN_TOOLING_SETUP)
 - **結果**: ✅ 全ファイル最新・矛盾なし
@@ -7040,7 +7039,7 @@ Web版スコープ (EF のみ) のため、UI 目視確認は対象外。
 
 ### 統合詳細 (action分岐パターン)
 
-```text
+```
 schedule-manager ?action=monitor  ← schedule-task-monitor  (実行ログ一覧)
 schedule-manager ?action=health   ← schedule-health-check  (健全性チェック)
 schedule-manager ?action=results  ← schedule-result-tracker(結果追跡)
@@ -7069,7 +7068,7 @@ schedule-manager ?action=log_*    ← schedule-execution-logger (実行記録)
 
 ### EF統合詳細
 
-```text
+```
 agent-hub ?action=departments     ← agent-department-manager
 agent-hub ?action=performance     ← agent-performance-monitor
 agent-hub ?action=personality     ← agent-personality
@@ -7095,7 +7094,6 @@ agent-hub POST {action:runtime_cycle} ← agent-runtime-cycle
 ## VSCode版 #60 (2026-04-12) — EF Tier2全統合: mega-hub 5本でaction分岐
 
 ### 目標
-
 Supabase EF 上限99本の中で、Tier2の全150本をTier1デプロイ済みにする。
 action分岐パターンで5つのmega-hubに統合。
 
@@ -7130,7 +7128,6 @@ action分岐パターンで5つのmega-hubに統合。
 ## VSCode版 #61 (2026-04-12) — EFハードキャップ50本 + Tier1/Tier2廃止
 
 ### 目標
-
 EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15hubで管理。
 
 ### 実施内容
@@ -7167,9 +7164,8 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 - スケジュールヘルス: ✅ 正常 (24時間で7コミット確認)
 
 **競合動向サマリー**:
-
 | 競合 | 更新内容 | 自分株式会社への影響 |
-| ----- | --------- | ------------------- |
+|-----|---------|-------------------|
 | Notion | 4/10タブカスタマイズ・4/9カバーアート・4/6デスクトップ音声入力・3.4ダッシュボードビュー | パーソナルダッシュボード機能の実装を検討 |
 | Slack | MCP サーバー公開 (Claude/Cursor 対応)・Semantic Search Pro 拡張 | tools-hub に send-to-slack アクション追加の好機 |
 | GitHub | Copilot Autopilot Public Preview・ネスト型サブエージェント・Rubber Duck (+75%推論) | ai-assistant EF の品質向上で対抗 |
@@ -7188,7 +7184,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | lifestyle-hub/index.ts 実装 (29本Tier2統合: fitness/recipe/travel/IoT/notification等) | ✅ |
 | 2 | PS版#44 rebase + hub endpoint へのDart呼び出し修正 | ✅ |
 | 3 | viral_ad_campaign_page: viral-growth-engine/viral-ad-generator → growth-hub | ✅ |
@@ -7212,7 +7208,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 作業内容
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | get-support-tickets: reply-support-request の POST ロジックを吸収 | ✅ |
 | 2 | get-public-memo-ogp: get-public-memo-preview の JSON SEO メタデータを吸収 (?action=preview) | ✅ |
 | 3 | development-achievements: development-stats の get_stats アクションを吸収 | ✅ |
@@ -7238,7 +7234,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 作業内容
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | CORS修正: growth-referral → growth-hub (referral.list) × 4ファイル | ✅ |
 | 2 | CORS修正: growth-acquisition-signal → growth-hub (acquisition.track) × 2ファイル | ✅ |
 | 3 | CORS修正: feature-request-manager → core-hub (feedback.submit) | ✅ |
@@ -7265,7 +7261,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 作業内容
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | PS版#45完了確認: 廃止EF→hub Dart移行12ファイル既コミット済み | ✅ |
 | 2 | referral_page.dart / growth_mission_service.dart 既修正確認 | ✅ |
 | 3 | flutter analyze 0エラー確認 | ✅ |
@@ -7288,7 +7284,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 作業内容
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | Dart EF移行: viral_ad_campaign_page.dart (growth-hub対応) | ✅ |
 | 2 | Dart EF移行: admin_analytics_page.dart (8箇所hub対応) | ✅ |
 | 3 | Dart EF移行: competitor_monitoring_card.dart (admin-hub対応) | ✅ |
@@ -7313,7 +7309,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 追記: Reka AI 20社目追加完了 (同セッション)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 9 | AI大学20社目: Reka AI (動画理解・OpenAI互換API) migration seed | ✅ |
 | 10 | cross-instance-pr: VSCode版向けReka UI追加依頼 | ✅ |
 | 11 | docs Rule #10: 3件数値修正 (EF 250本→15本/Tier廃止/workflow 17→18本) | ✅ |
@@ -7325,7 +7321,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 作業内容
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | AI大学21社目: Aleph Alpha (欧州AI主権・GDPR準拠・AtMan説明可能AI) migration seed | ✅ |
 | 2 | AI大学22社目: Together AI (200+OSSモデル・Fine-tuning・OpenAI互換) migration seed | ✅ |
 | 3 | cross-instance-pr 2件: aleph_alpha_provider_ui / together_ai_provider_ui (VSCode版待ち) | ✅ |
@@ -7348,7 +7344,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 作業内容
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | AI大学23社目: Fireworks AI (高速推論・Function Calling・FLUX画像生成) migration seed | ✅ |
 | 2 | AI大学24社目: Replicate (FLUX/SD/Whisper/MusicGen・モデルホスティング) migration seed | ✅ |
 | 3 | cross-instance-pr 2件: fireworks_ai_provider_ui / replicate_provider_ui (VSCode版待ち) | ✅ |
@@ -7371,7 +7367,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 作業内容
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | AI大学25社目: Writer (Palmyra LLM・Knowledge Graph・ビジネスAI特化) migration seed | ✅ |
 | 2 | AI大学26社目: AI21 Labs (Jamba 256K・SSM+Transformer・MoE) migration seed | ✅ |
 | 3 | cross-instance-pr 2件: writer_provider_ui / ai21_provider_ui (VSCode版待ち) | ✅ |
@@ -7397,7 +7393,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: CORS全解消 — 廃止EF 10本→hub移行
 
 | 廃止EF | 移行先 | アクション |
-| -------- | -------- | ----------- |
+|--------|--------|-----------|
 | weather-widget | tools-hub | get_weather |
 | wiki-database | enterprise-hub | wiki.* |
 | voice-memo-transcriber | media-hub | transcribe.* |
@@ -7428,7 +7424,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: Rule17 CI/CDビルド最適化 + T-1第8弾記事作成 + blog-publish.yml修復
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | ci.yml: Tier1/Tier2廃止→ハードキャップ50本チェック (continue-on-error: false) | ✅ |
 | 2 | T-1第8弾: `docs/blog-drafts/2026-04-12-ai-university-20-providers-hub-architecture.md` 作成 | ✅ |
 | 3 | schedule-hub: `blog.auto_publish` action追加 + publicActions認証バイパス修正 | ✅ |
@@ -7455,7 +7451,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: AI大学 Voyage AI・ElevenLabs 追加 (27・28社目)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | Voyage AI (voyage) migration: `20260412018000_seed_voyage_ai_university.sql` | ✅ |
 | 2 | ElevenLabs (elevenlabs) migration: `20260412019000_seed_elevenlabs_ai_university.sql` | ✅ |
 | 3 | cross-instance-pr: `20260412_voyage_provider_ui.md` (VSCode版向けUI追加依頼) | ✅ |
@@ -7495,7 +7491,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: AI大学 OpenRouter・Ollama 追加 (29・30社目)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | OpenRouter (openrouter) migration: `20260412020000_seed_openrouter_ai_university.sql` | ✅ |
 | 2 | Ollama (ollama) migration: `20260412021000_seed_ollama_ai_university.sql` | ✅ |
 | 3 | cross-instance-pr: `20260412_openrouter_provider_ui.md` | ✅ |
@@ -7535,7 +7531,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: AI大学 Runway・Suno AI 追加 (31・32社目) — 動画・音楽モダリティ解禁
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | Runway (runway) migration: `20260412022000_seed_runway_ai_university.sql` | ✅ |
 | 2 | Suno AI (suno) migration: `20260412023000_seed_suno_ai_university.sql` | ✅ |
 | 3 | cross-instance-pr: `20260412_runway_provider_ui.md` | ✅ |
@@ -7568,7 +7564,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: T-1 第9・10弾投稿 + blog-publish.yml Step5修正
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | T-1第9弾: `docs/blog-drafts/2026-04-12-cors-fix-ef-hub-migration.md` 作成 | ✅ |
 | 2 | T-1第9弾: Qiita/dev.to 投稿成功 | ✅ |
 | 3 | T-1第10弾: `docs/blog-drafts/2026-04-09-pomodoro-focus-timer.md` Qiita/dev.to 投稿成功 | ✅ |
@@ -7603,7 +7599,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: T-1 第11弾投稿 + wrap-up完了
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | MEMORY.md index更新 (feedback_success/project_20260412_ps47) | ✅ |
 | 2 | project_20260412_ps47.md 作成 | ✅ |
 | 3 | T-1第11弾: `docs/blog-drafts/2026-04-11-personal-dashboard-notion-competitor.md` dispatch | ✅ |
@@ -7634,7 +7630,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: AI大学 Ideogram・Udio 追加 (33・34社目)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | Ideogram (ideogram) migration: `20260412026000_seed_ideogram_ai_university.sql` | ✅ |
 | 2 | Udio (udio) migration: `20260412027000_seed_udio_ai_university.sql` | ✅ |
 | 3 | cross-instance-pr: `20260412_ideogram_provider_ui.md` | ✅ |
@@ -7659,7 +7655,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: docs Rule #10 + COMPRESSED_PROMPT 整合性修正 (migration追加一時停止)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | cross-instance-prs 25件 pending 確認 → migration追加を一時停止 | ✅ |
 | 2 | docs/MULTI_INSTANCE_COORDINATION.md: 211ページ→215ページ修正 | ✅ |
 | 3 | COMPRESSED_PROMPT_V3.md: Rule7「EF上限99本」→「ハードキャップ50本」に修正 | ✅ |
@@ -7684,7 +7680,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: T-1 連続投稿10本 (第12〜21弾) + Rule17確認
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | Rule17: 全ワークフロー健全性確認 (infra/ai-university/edge-audit 全て成功) | ✅ |
 | 2 | T-1第12弾: dns-domain-manager.md Qiita/dev.to投稿 | ✅ |
 | 3 | T-1第13弾: budget-ai-advisor.md Qiita/dev.to投稿 | ✅ |
@@ -7731,7 +7727,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: AI大学 pika + assemblyai 追加 (37-38社目)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | cross-instance-prs 0件確認 (luma+kling UI処理済み) → migration続行 | ✅ |
 | 2 | `pika` (Pika Labs) seed migration 作成 (032000) | ✅ |
 | 3 | `assemblyai` (AssemblyAI) seed migration 作成 (033000) | ✅ |
@@ -7757,7 +7753,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: AI大学 luma + kling 追加 (35-36社目) — migration再開
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | cross-instance-prs 0件確認 → migration再開判断 | ✅ |
 | 2 | `luma` (Luma AI) seed migration 作成 (030000) | ✅ |
 | 3 | `kling` (Kling AI) seed migration 作成 (031000) | ✅ |
@@ -7782,7 +7778,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: docs Rule#10 全件クリーン (technical 4件 + user-docs 1件アーカイブ化)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | cross-instance-prs 25件 pending 確認 → migration追加一時停止継続 | ✅ |
 | 2 | docs/technical/VIRAL_GROWTH / THOUGHT_INTERRUPT 確認 → 現役ドキュメント・クリーン | ✅ |
 | 3 | `BACKEND_MIGRATION_ROADMAP_DETAILED.md` アーカイブノーティス追加 | ✅ |
@@ -7795,7 +7791,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### docs/technical/ 全件確認完了
 
 | ファイル | 状態 |
-| --------- | ------ |
+|---------|------|
 | BACKEND_MIGRATION_PLAN.md | ✅ 既アーカイブ (#28) |
 | BACKEND_MIGRATION_ROADMAP_DETAILED.md | ✅ アーカイブ化 (#56) |
 | BRANCH_PROTECTION_SETUP.md | ✅ 現役 |
@@ -7828,7 +7824,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: docs Rule#10 (roadmaps/technical 3件アーカイブ化) + Rule#18 (AIモデル確認)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | cross-instance-prs 25件 pending 確認 → migration追加一時停止継続 | ✅ |
 | 2 | `COMPETITOR_ANALYSIS_2025.md` アーカイブノーティス追加 | ✅ |
 | 3 | `BUSINESS_OPERATIONS_PLAN.md` アーカイブノーティス追加 | ✅ |
@@ -7853,7 +7849,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: AI大学次候補評価 (discovery mode) + docs全件鮮度確認
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | cross-instance-prs 25件 pending 確認 → migration追加一時停止継続 | ✅ |
 | 2 | ai-university-add-provider discovery mode: 新候補6社を3軸評価 | ✅ |
 | 3 | Luma AI(9/9) → Kling AI(8/9) → Pika(7/9) を次回追加推奨候補として確定 | ✅ |
@@ -7877,7 +7873,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: docs全件鮮度確認 (migration一時停止継続)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | cross-instance-prs 25件 pending 確認 → migration追加一時停止継続 | ✅ |
 | 2 | docs/CONTRIBUTING.md 鮮度確認 → 問題なし | ✅ |
 | 3 | docs/DESIGN_TOOLING_SETUP.md 鮮度確認 → 問題なし | ✅ |
@@ -7902,7 +7898,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: T-1残り全投稿 + 新記事執筆 + actions/checkout v6対応 + blog-publish競合修正
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | Rule17: 全ワークフロー健全性確認 | ✅ |
 | 2 | T-1残り6本バッチdispatch (2026-03-28/31系) | ✅ |
 | 3 | T-1新記事執筆: blog-publish自動化記事 (GitHub Actions × Supabase) | ✅ |
@@ -7937,7 +7933,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: 競馬AI自動予想パイプライン実装
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | DB migration: horse_races/horse_entries/horse_predictions/horse_results/horse_accuracy_stats | ✅ |
 | 2 | tools-hub EF: horseracing.today/predict_all/predictions/store_results/accuracy (8 actions更新) | ✅ |
 | 3 | scripts/fetch_horse_racing.py: netkeiba.com スクレイパー (stdlib only) | ✅ |
@@ -7967,7 +7963,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: Rule18 モデル確認 + growth-hub 実データ対応 + docs全件分析
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | Rule18: ai-assistant EF claude-haiku-4-5-20251001 確認 (HEAD済み) | ✅ |
 | 2 | growth-hub roadmap.progress 実データ対応 (_applyAchievements + growth_plans テーブル) | ✅ |
 | 3 | deno lint 272ファイル 0エラー確認 | ✅ |
@@ -7994,7 +7990,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: T-1 6本dispatch + 新記事2本執筆・投稿 + Rule17確認
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | Rule17: 全ワークフロー健全性確認 | ✅ |
 | 2 | 3ドラフトにfrontmatter追加 (zenn-schedule/edge-functions-cicd/cvr-tracking) | ✅ |
 | 3 | T-1第29・30・31弾: 3ドラフト Qiita/dev.to投稿成功 | ✅ |
@@ -8031,7 +8027,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: AI大学 twelve_labs 追加 (39社目) + cohere 既存コンテンツ更新
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | cross-instance-prs 1件 (pika+assemblyai) 確認 → migration続行判断 | ✅ |
 | 2 | `twelve_labs` (Twelve Labs) seed migration 作成 (034000) | ✅ |
 | 3 | `cohere` 既登録確認 → ON CONFLICT DO UPDATE で既存コンテンツ更新 (035000) | ✅ |
@@ -8062,7 +8058,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | markdownlint 0エラー化 (MD060 compact + cross-instance-prs ignore) | ✅ |
 | 2 | Rule 10: docs/ 全件分析 → 全ファイルクリーン確認 | ✅ |
 | 3 | Rule 19: design-skills指摘8件修正 (AI大学ページ design token適用) | ✅ |
@@ -8098,7 +8094,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | 日次レポート生成 (`docs/daily-reports/2026-04-13.md`) | ✅ |
 | 2 | 競合モニタリングレポート生成 (`docs/competitor-reports/2026-04-13.md`) | ✅ |
 | 3 | viral-growth-engine `auto_post_now` 実行 | ⚠️ 接続ブロック |
@@ -8127,7 +8123,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了: AI大学 qwen + moonshot 追加 (40-41社目)
 
 | # | 作業内容 | 状態 |
-| --- | --------- | ------ |
+|---|---------|------|
 | 1 | cross-instance-prs 28件確認 → 全件 `done` → pending 0件 → migration続行 | ✅ |
 | 2 | `qwen` (Alibaba Cloud) seed migration 作成 (036000) | ✅ |
 | 3 | `moonshot` (Moonshot AI / Kimi) seed migration 作成 (037000) | ✅ |
@@ -8137,7 +8133,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 今セッションの追加プロバイダー
 
 | # | provider | 評価 | 特徴 |
-| --- | --------- | ------ | ------ |
+|---|---------|------|------|
 | 40 | `qwen` (Alibaba Cloud) | 7/9 | Qwen2.5-72B OSS最強クラス・DashScope API・29言語 |
 | 41 | `moonshot` (Moonshot AI) | 6/9 | Kimi 128K超長文・PDF直接処理・OpenAI互換 |
 
@@ -8159,7 +8155,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | ノートエディタ `/tabs` コマンド追加 (Notion 3.4 パリティ) | ✅ (af20e484) |
 | 2 | AI大学 Qwen + Moonshot UI 追加 (40-41社目) | ✅ (af20e484) |
 | 3 | tools-hub `slack.post` / `slack.search` アクション追加 | ✅ |
@@ -8187,7 +8183,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | deploy-prod SQLSTATE 42P10 修正 (UNIQUE制約追加 migration) | ✅ (eaf7f673) |
 | 2 | setup-python v5→v6 Node.js 24対応 (3ワークフロー) | ✅ (d9d16835) |
 | 3 | T-1第33弾: AI大学40社+deployfix記事 Qiita/dev.to 投稿 | ✅ 投稿完了 |
@@ -8195,12 +8191,10 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 | 5 | docs Rule10 全件クリーン確認 (CICD_SETUP_GUIDE等) | ✅ |
 
 ### T-1 第33弾 投稿URL
-
 - Qiita: https://qiita.com/kanta13jp1/items/3c22818934c7f1beae25
 - dev.to: https://dev.to/kanta13jp1/aida-xue-40she-ti-zhi-wan-cheng-supabase-on-conflictben-fan-depuroizhang-hai-woxiu-zheng-sitahua-3ddh
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: **41社** / LP: 126のこと
 - GitHub Actions ワークフロー: **18本** (全て正常稼働)
 - deploy-prod: **成功** (UNIQUE制約修正後)
@@ -8218,7 +8212,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | Rule10 docs全件分析 (Explore委譲) — 3件の修正点を検出 | ✅ |
 | 2 | docs/README.md: 4インスタンス→3インスタンス修正 | ✅ (c7ecdd59) |
 | 3 | docs/CICD_SETUP_GUIDE.md: 18本→17本修正 | ✅ (c7ecdd59) |
@@ -8228,18 +8222,15 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 | 7 | COMPRESSED_PROMPT_V3: プロバイダー数 41→43社 更新 | ✅ |
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: **43社** / LP: 126のこと
 - GitHub Actions ワークフロー: **17本** (3インスタンス体制)
 - 次回migration番号帯: 040000〜
 
 ### 追加プロバイダー詳細
-
 - **Midjourney**: 画像生成AIの代名詞。V6/V7・Niji(アニメ)・Omni Reference機能。1600万人超の有料ユーザー
 - **Hailuo AI (MiniMax)**: 動画(Director Model/Subject Reference)+音声TTS+100万tokenLLM。国際API提供済み
 
 ### 次回Windows版優先タスク
-
 - 🟡 AI大学 44-45社目候補: 01.AI (Yi-series) / Adobe Firefly / Character.ai
 - 🟢 cross-instance-pr 処理後の確認 (VSCode版 UI更新後)
 - 🟢 Rule10 継続 (docs/cross-instance-prs/ 整理)
@@ -8251,7 +8242,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | Rule10 docs全件分析 (Explore委譲) — 全クリーン | ✅ |
 | 2 | Discovery評価: Adobe Firefly(9/9)・01.AI(7/9) → 採用 / Character.ai(5/9) → 見送り | ✅ |
 | 3 | AI大学44社目: Adobe Firefly seed migration 追加 | ✅ (8ae886d0) |
@@ -8261,18 +8252,15 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 | 7 | cross-instance-pr: VSCode版(UI追加)・PS版(yml更新) へ依頼 | ✅ |
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: **45社** / LP: 126のこと
 - GitHub Actions ワークフロー: **17本**
 - 次回migration番号帯: 042000〜
 
 ### 追加プロバイダー詳細
-
 - **Adobe Firefly**: 商業利用安全な生成AI(スコア9/9)。Photoshop/Illustrator深統合。Firefly API公開済み
 - **01.AI (Yi)**: 李開復創業(スコア7/9)。OpenAI互換API。Yi-Lightning $0.14/100万token超低コスト
 
 ### 次回Windows版優先タスク
-
 - 🟡 AI大学 46-47社目候補: Coze (ByteDance) / Poe (Quora) / Apple Intelligence
 - 🟢 cross-instance-pr 処理後の確認 (VSCode版 UI更新後 → 45社UIを確認)
 - 🟢 Rule10 継続 (毎セッション)
@@ -8284,25 +8272,22 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | NAR EUC-JP 文字化け根本解消: `errors="replace"` 確定デコード | ✅ (c8f75a71) |
 | 2 | デバッグ print 文 3行を削除 | ✅ (c8f75a71) |
 | 3 | 前セッションの失敗コミット (9f3b4523) を正しく上書き | ✅ |
 
 ### 技術的詳細
-
 - **問題**: `raw.decode("euc-jp")` strict → UnicodeDecodeError → UTF-8 フォールスルー → CJK Extension A ゴミ文字
 - **解決**: `if "nar.netkeiba.com/race/" in url: return raw.decode("euc-jp", errors="replace")`
 - **URL識別**: `/race/` パスで shutuba/result ページを特定 (race list は `/top/` で UTF-8)
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: 45社 / LP: 126のこと
 - horse-racing-update.yml: 毎時00分 UTC 自動実行 (NAR 15場 + JRA 10場)
 - NAR文字化け: 根本解消済み (次回GH Actions実行でクリーンデータ生成)
 
 ### 次回VSCode版優先タスク
-
 - 🔴 AI大学 45社 UI追加 (cross-instance-pr pending確認)
 - 🟡 COMPRESSED_PROMPT_V3 数値同期 (AI大学45社・219ページ)
 - 🟢 horse_racing 次回GH Actions実行後の文字化け解消確認
@@ -8314,7 +8299,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | Rule10 docs全件クリーン確認 | ✅ |
 | 2 | AI大学46社目: Coze (ByteDance) seed migration | ✅ (05df3b35) |
 | 3 | AI大学47社目: Apple Intelligence seed migration | ✅ (05df3b35) |
@@ -8322,12 +8307,10 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 | 5 | cross-instance-pr: VSCode版+PS版へ依頼 | ✅ |
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: **47社** / LP: 126のこと
 - 次回migration番号帯: 044000〜
 
 ### 次回Windows版優先タスク
-
 - 🟡 AI大学 48-49社目候補: Samsung Galaxy AI / Inflection Pi / Databricks DBRX
 - 🟢 cross-instance-pr 処理確認
 
@@ -8336,7 +8319,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | 01AI・Coze migration の bash quoting artifact 修正 (2箇所+6箇所→`''`) | ✅ (8677971d) |
 | 2 | blog-publish.yml Step3/4/6/JobSummary のシェルクォーティング根本修正 | ✅ (c6c6d5d5) |
 | 3 | T-1第34弾 再dispatch・dev.to公開完了 | ✅ published |
@@ -8344,16 +8327,13 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 | 5 | deploy-prod migration artifact 全件クリーン確認 | ✅ ALL CLEAN |
 
 ### 技術メモ
-
 - blog-publish.yml: `${{ steps.meta.outputs.title }}` を `run:` 内の bash 文字列に直接展開すると title 内の `"` が bash 構文エラーを引き起こす → `env:` ブロック経由で安全に渡す
 - SQL migration: bash quoting pattern `'"'"'` は PostgreSQL で SQLSTATE 42601 → `''` に置換
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: 47社 / LP: 126のこと
 
 ### 次回PowerShell版優先タスク
-
 - 🔴 deploy-prod in_progress 完了確認 → 失敗なら追加調査
 - 🟡 Rule 17 継続監視: ai-university-update.yml qwen/moonshot RSS追加検討
 - 🟢 T-1 第35弾記事候補: blog-publish.yml クォーティング修正の技術記事
@@ -8365,19 +8345,17 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | Rule10 docs全件クリーン確認 | ✅ |
 | 2 | AI大学48社目: Databricks (DBRX) seed migration | ✅ (fbbdef0f) |
 | 3 | AI大学49社目: Samsung Galaxy AI seed migration | ✅ (fbbdef0f) |
 | 4 | CLAUDE.md + COMPRESSED_PROMPT_V3: 47→49社 | ✅ (fbbdef0f) |
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: **49社** / LP: 126のこと
 - 次回migration: 046000〜
 
 ### 次回Windows版優先タスク
-
 - 🔴 AI大学 50社目 (キリ番) — 候補: Anthropic系Tools/Cursor/Vercel AI SDK
 - 🟢 cross-instance-pr 処理確認
 
@@ -8388,18 +8366,16 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | cross-instance-prs 5件処理 (Win#58/#59/#61/#62/#63) | ✅ (a1e16945) |
 | 2 | AI大学 47社 UI完成: pika/assemblyai/twelve_labs/midjourney/hailuo/adobe_firefly/01ai/coze/apple | ✅ (a1e16945) |
-| 3 | gemini_university_v2_page.dart:_providerMeta + _Quiz +_fallback 各9エントリ追加 | ✅ |
+| 3 | gemini_university_v2_page.dart: _providerMeta + _Quiz + _fallback 各9エントリ追加 | ✅ |
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: **DB 52社 / UI 47社** / LP: 126のこと
 - cross-instance-prs: 0件 pending (5件 done 完了)
 
 ### 次回VSCode版優先タスク
-
 - 🔴 AI大学 48-52社 UI追加 (databricks/samsung/zhipu/character_ai/inflection — cross-instance-pr確認)
 - 🟡 Rule 19: UI改善 (design-skills + Figma MCP)
 - 🟢 Rule 16: 本番表示チェック
@@ -8411,7 +8387,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | AI大学53社目 Allen AI (OLMo-2) 追加 — Paul Allen設立・完全OSS・GPT-4クラス (7/9) | ✅ |
 | 2 | AI大学54社目 Naver (HyperCLOVA X) 追加 — 韓国最大・LINE日本展開・100言語 (6/9) | ✅ |
 | 3 | cross-instance-pr: allenai/naver UI追加をVSCode版に依頼 | ✅ |
@@ -8419,12 +8395,10 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 | 5 | CLAUDE.md / COMPRESSED_PROMPT_V3.md: 52社→54社 更新 | ✅ |
 
 ### 現状数値
-
 - EF: 15本 / AI大学: **DB 54社 / UI 47社** (VSCode版が追加次第UI対応)
 - cross-instance-prs pending: 7件 (VSCode版向け: midjourney/hailuo/adobe_firefly/01ai/coze/apple/databricks/samsung/zhipu/character_ai/inflection/allenai/naver)
 
 ### 次回候補 (55社目以降)
-
 - TII Falcon (falcon): UAE政府支援・Falcon-180B商用無料 (5/9 — 様子見)
 - Kakao (KoGPT): 韓国SNS最大手・カカオトーク統合 (5/9)
 - LG AI Research (EXAONE): 韓国製造業AI・マルチモーダル (5/9)
@@ -8437,7 +8411,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | Rule 17: 全ワークフロー健全確認 — 8本全て success/skipped | ✅ |
 | 2 | deploy-prod 24339196557: 10:44 JST 完全成功確認 (SQLSTATE 42601 危機解消) | ✅ |
 | 3 | T-1第35弾 EN記事作成: blog-publish automation (GitHub Actions × Supabase) | ✅ |
@@ -8446,17 +8420,14 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 | 6 | AI大学学習リマインダーワークフロー新規作成 (毎日09:00 JST) | ✅ |
 
 ### 成果物
-
 - dev.to T-1第35弾: https://dev.to/kanta13jp1/how-i-published-21-technical-articles-in-one-day-using-github-actions-supabase-8cm
 - .github/workflows/ai-university-reminder.yml: 新規追加 (notification-center send_study_reminders)
 
 ### 現状数値
-
 - EF: 15本 / AI大学: DB 54社 / UI 47社 / Workflows: 20本
 - T-1: 第35弾投稿完了
 
 ### 次回PS版優先タスク
-
 - T-1 第36弾: EF hub統合アーキテクチャ記事 (250本→15本への大移行) JP + EN
 - github-issue-fix.yml 最適化確認
 - ai-university-reminder ドライラン実行確認
@@ -8468,18 +8439,16 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | cross-instance-prs 7件処理 (Win#64-#67) | ✅ (9dd62054/411b0de6) |
 | 2 | AI大学 DB 54社 = UI 54社 完全同期達成 | ✅ |
 | 3 | 追加 UI: databricks/samsung/zhipu/character_ai/inflection/allenai/naver | ✅ |
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: **DB 54社 = UI 54社** / LP: 126のこと
 - cross-instance-prs: 1件 pending (horse_prev_race_ui — 馬カード前走情報表示)
 
 ### 次回VSCode版優先タスク
-
 - 🟡 horse_prev_race_ui 処理 (馬カードに prev_finish/age_sex/horse_weight 追加表示)
 - 🟢 Rule 16: 本番表示チェック (AI大学 54社タブ確認)
 - 🟢 Rule 19: UI改善
@@ -8491,19 +8460,17 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | cross-instance-pr 20260413_horse_prev_race_ui.md 処理 | ✅ (3f04deaa) |
 | 2 | 競馬予想ページ: 馬カードに前走情報・馬体重・年齢性別追加 | ✅ |
 | 3 | 前走着順の色分け (1着=金/2-3着=緑/4-5着=薄白/その他=グレー) | ✅ |
 | 4 | flutter analyze 0エラー確認 | ✅ |
 
 ### 現状数値
-
 - EF: 15本 / ページ数: 219 / AI大学: DB 54社 = UI 54社 / LP: 126のこと
 - cross-instance-prs: 0件 pending
 
 ### 次回VSCode版優先タスク
-
 - 🟢 Rule 16: 本番表示チェック (競馬予想ページ・AI大学 54社タブ確認)
 - 🟢 Rule 19: UI改善 (LP / ホーム)
 - 🟢 COMPRESSED_PROMPT_V3 数値同期確認
@@ -8515,24 +8482,21 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | Rule 17: 8ワークフロー全て healthy 確認 | ✅ |
 | 2 | T-1第36弾 JP+EN記事作成: 3インスタンス並行Claude Code開発 | ✅ |
 | 3 | T-1第36弾 dispatch: Qiita+dev.to 同時投稿成功 (11:54 JST) | ✅ |
 | 4 | COMPRESSED_PROMPT_V3.md: 第34-36弾 投稿記録追加 | ✅ |
 
 ### 成果物
-
 - Qiita T-1第36弾: https://qiita.com/kanta13jp1/items/cd4ba18c7329700edf80
 - dev.to T-1第36弾: https://dev.to/kanta13jp1/running-3-parallel-claude-code-instances-to-triple-my-solo-dev-velocity-2g2p
 
 ### 現状数値
-
 - EF: 15本 / AI大学: DB 54社 / UI 54社 / Workflows: 20本
 - T-1: 第36弾投稿完了
 
 ### 次回PS版優先タスク
-
 - T-1 第37弾: AI大学54社達成マイルストーン記事 JP+EN
 - ai-university-reminder dry_run手動実行で対象ユーザー数確認
 - deploy-prod 安定性継続監視
@@ -8544,23 +8508,20 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | セッション再開: git status確認・VSCode版#70(競馬前走UI)完了確認 | ✅ |
 | 2 | AI大学55社目 Adept AI (ACT/Fuyu) migration追加 | ✅ |
 | 3 | CLAUDE.md / COMPRESSED_PROMPT_V3.md: 55社に更新 | ✅ |
 | 4 | cross-instance-pr: Adept AIのUI追加依頼 (VSCode版宛) | ✅ |
 
 ### 成果物
-
 - migration: `20260413052000_seed_adept_ai_university.sql`
 - cross-instance-pr: `docs/cross-instance-prs/20260413_adept_provider_ui.md`
 
 ### 現状数値
-
 - EF: 15本 / AI大学: DB 55社 / UI 54社 (Adept pending) / Workflows: 20本
 
 ### 次回Windows版優先タスク
-
 - AI大学 56社目以降: Kakao KoGPT / LG EXAONE / Cohere Command R+ 候補
 - Rule 10: docs/ 戦略ドキュメント確認 (毎セッション必須)
 
@@ -8571,7 +8532,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | blog-publish branches 4本バッチマージ (published:true更新) | ✅ |
 | 2 | T-1第37弾 JP+EN記事作成: AI大学54社達成マイルストーン | ✅ |
 | 3 | T-1第37弾 dispatch: Qiita+dev.to 同時投稿成功 (14:37 JST) | ✅ |
@@ -8579,18 +8540,15 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 | 5 | ai-university-reminder dry_run確認: HTTP 200 eligible=0 (正常動作) | ✅ |
 
 ### 成果物
-
 - Qiita T-1第37弾: https://qiita.com/kanta13jp1/items/b5870d38756aa0a30897
 - dev.to T-1第37弾: https://dev.to/kanta13jp1/building-an-ai-learning-platform-with-54-providers-in-3-days-flutter-supabase-4263
 - ai-university-reminder: schedule-hub reminders.study に修正・正常稼働確認
 
 ### 現状数値
-
 - EF: 16本 (local-election-intelligence追加分) / AI大学: DB 54社 / Workflows: 20本
 - T-1: 第37弾投稿完了
 
 ### 次回PS版優先タスク
-
 - T-1 第38弾: 次の技術記事 (競馬AI自動予想パイプライン候補)
 - blog-publish branches 残34本のバッチマージ
 - Rule 17 継続監視
@@ -8602,24 +8560,21 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | Rule 17: 9ワークフロー全て healthy 確認 (WF failure handler skipped=正常) | ✅ |
 | 2 | blog-publish branch 1本マージ (T-1第37弾 published:true) | ✅ |
 | 3 | T-1第38弾 JP+EN記事作成: 競馬AI予想パイプライン | ✅ |
 | 4 | T-1第38弾 dispatch: Qiita+dev.to 同時投稿成功 (14:48 JST) | ✅ |
 
 ### 成果物
-
 - Qiita T-1第38弾: https://qiita.com/kanta13jp1/items/6ba7c8b2d333fe45487a
 - dev.to T-1第38弾: https://dev.to/kanta13jp1/building-a-fully-automated-horse-racing-ai-prediction-pipeline-with-flutter-supabase-22p4
 
 ### 現状数値
-
 - EF: 16本 / AI大学: DB 54社 / UI 54社 / Workflows: 20本
 - T-1: 第38弾投稿完了
 
 ### 次回PS版優先タスク
-
 - T-1 第39弾: GitHub Actions CI最適化記事 (25分→効率化) JP+EN
 - blog-publish 残ブランチ バッチマージ
 - Rule 17 継続監視
@@ -8631,7 +8586,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | AI大学55社目 Adept AI の UI表示設定・クイズ・フォールバック追加 | ✅ |
 | 2 | `AiUniversityHomeCard` を DB件数ベース表示へ更新し、旧「9社以上」表記を解消 | ✅ |
 | 3 | `user_manual_page.dart` のホーム最上部導線を AI大学バナー基準へ更新 | ✅ |
@@ -8639,13 +8594,11 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 | 5 | Rule 18: NotebookLM で最新AIニュース取得を試行 | ⚠️ `notebooklm login` 期限切れで未実施 |
 
 ### 現状数値
-
 - ページ数: 219
 - AI大学: DB 55社 / UI 55社
 - ホーム AI大学バナー: DB登録件数に追従する表示へ更新
 
 ### 次回VSCode版優先タスク
-
 - 🟢 Rule 16: 本番表示チェック (ホーム / AI大学 / ランキング)
 - 🟡 Rule 19: ホーム / AI大学バナーのモバイル余白と文言AB改善
 - 🟡 Rule 18: `notebooklm login` 後に最新AIニュース3件を ROADMAP へ反映
@@ -8657,7 +8610,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | `growth-import-preview` の Notion API ロジックを `notion_api.ts` に分離 | ✅ |
 | 2 | Notion ページ本文の再帰ブロック取得・pagination 対応を追加 | ✅ |
 | 3 | Notion API 429 rate limit 用 retry/backoff を追加 | ✅ |
@@ -8672,13 +8625,11 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 - `markdownlint` 実行済み (pass)
 
 ### 現状メモ
-
 - Notion API preview はページ本文の1階層取得から、子ブロック再帰取得に拡張
 - 429 応答時は `Retry-After` 優先で待機し、再試行後に継続
 - 深すぎるネストとブロック総数は preview 応答性を守るため warnings 付きで打ち切る
 
 ### 次回VSCode版優先タスク
-
 - 🟢 Rule 16: import ページを含む本番表示チェック
 - 🟡 import preview warnings を UI 上でより読みやすく整理
 - 🟡 Rule 18: `notebooklm login` 後に最新AIニュース3件を ROADMAP へ反映
@@ -8690,7 +8641,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | ------ | ------ |
+|---|------|------|
 | 1 | ユーザー実行の `notebooklm login` 成功を確認 | ✅ |
 | 2 | NotebookLM CLI で `list` / `use` / `source add-research` / `source list` を再試行 | ✅ |
 | 3 | NotebookLM notebook単位 RPC エラーを確認し、Rule 18 は公式ソース fallback で継続 | ✅ |
@@ -8743,7 +8694,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | --- | --- |
+|---|---|---|
 | 1 | `.github/COMPRESSED_PROMPT_V3.md` を 100 行ずつ再読し、VSCode スコープと Rule 18 / Rule 19 / Master Brain 手順を再確認 | ✅ |
 | 2 | Master Brain memory を再確認し、NotebookLM 再認証後も notebook 単位 RPC エラーが残っている状況を引き継ぎ | ✅ |
 | 3 | `analyze-reality` / `ai-writing-assistant` / `enterprise-hub` / `guitar-recording-studio` の `gemini-2.0-flash` 呼び出しを `gemini-2.5-flash` に更新 | ✅ |
@@ -8775,7 +8726,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | --- | --- |
+|---|---|---|
 | 1 | `.github/COMPRESSED_PROMPT_V3.md` を再読し、Rule 15 / Rule 16 / Rule 19 の今回優先事項を整理 | ✅ |
 | 2 | Master Brain memory と ROADMAP 末尾を確認し、前回の Gemini 更新後に続けるべき VSCode スコープ作業を確認 | ✅ |
 | 3 | `AiUniversityHomeCard` を新規ユーザー / 継続ユーザーで出し分ける CTA に再設計 | ✅ |
@@ -8807,7 +8758,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | --- | --- |
+|---|---|---|
 | 1 | `.github/COMPRESSED_PROMPT_V3.md` と ROADMAP 末尾を再確認し、VSCode 直近優先を `AI大学ランキング` UI 改善と判断 | ✅ |
 | 2 | `lib/pages/ai_university_ranking_page.dart` をホームカード準拠の Orange + Indigo ダークトークンへ全面刷新 | ✅ |
 | 3 | ヒーロー要約、メトリクスタイル、空状態、エラー状態、ランキングカードをモバイルでも崩れにくい構成へ再設計 | ✅ |
@@ -8835,6 +8786,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 - 🟡 AI大学ランキング画面の実データ表示を本番で確認し、必要なら余白・折返し・点数列の視認性を微調整
 - 🟡 NotebookLM CLI の notebook単位 RPC エラー原因を確認し、Master Brain 深掘り調査を再開
 
+
 ## セッション記録 (2026-04-16 Gemini CLI)
 
 - ✅ markdownlint エラー修正 (docs/session-notes/ 配下)
@@ -8848,7 +8800,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 ### 完了タスク
 
 | # | タスク | 状態 |
-| --- | --- | --- |
+|---|---|---|
 | 1 | **タスク T-1 第11弾**: `2026-04-11-personal-dashboard-notion-competitor.md` → Qiita + dev.to 投稿成功 | ✅ |
 | 2 | **タスク T-1 第12弾**: `2026-04-10-dns-domain-manager.md` → Qiita + dev.to 投稿成功 | ✅ |
 | 3 | **COMPRESSED_PROMPT_V3.md**: タスク T-1 セクション更新 (第11〜12弾追加) | ✅ |
@@ -8866,7 +8818,7 @@ EFを50本以下に削減し、Tier1/Tier2分類を完全廃止。全機能を15
 WebSearch と専門分析により、以下の候補を評価:
 
 | プロバイダー | 技術革新 | API可用 | 話題性 | 合計 | 決定 |
-| --- | --- | --- | --- | --- | --- |
+|---|---|---|---|---|---|
 | **Core** | 3/3 | 3/3 | 3/3 | **9/9** | ✅ 追加 |
 | **Cerebras** | 3/3 | 2/3 | 3/3 | **8/9** | ✅ 追加 |
 | **Prover** | 3/3 | 2/3 | 2/3 | **7/9** | ✅ 追加 |
@@ -8901,6 +8853,7 @@ WebSearch と専門分析により、以下の候補を評価:
 2. 🟢 **Web/モバイル表示チェック** (Rule #16): https://my-web-app-b67f4.web.app/ の AI大学ランキング画面確認
 3. 🟢 **本番 DB migration 適用**: Supabase prod に `supabase db push` を実行し、Core/Cerebras/Prover を有効化
 
+
 ## VSCode��#77 �Z�p�L�����e (2026-04-16)
 
 ### ���{���e
@@ -8923,14 +8876,17 @@ WebSearch と専門分析により、以下の候補を評価:
 4. **UI���P�c�[���`�F�[�� (Rule #19)**: design-skills �T�u�G�[�W�F���g�� 1 �y�[�W�ȏ���P
 5. **�~�ω��������e�p�� (�^�X�N T-1)**: �c�� 47 �{�̋L�����e
 
-**Rule 15 �ǉ��L�^**: �V�K�v���o�C�*�[���� WebSearch + ��僊�T�[�`�ŕ]���BDarkbloom (�I���f�o�C�XAI/Mac���*) �𐄏��E���Z�b�V�����Œǉ������\��B
+
+
+**Rule 15 �ǉ��L�^**: �V�K�v���o�C�_�[���� WebSearch + ��僊�T�[�`�ŕ]���BDarkbloom (�I���f�o�C�XAI/Mac���_) �𐄏��E���Z�b�V�����Œǉ������\��B
+
 
 ## Windows版#63 セッション記録 (2026-04-16)
 
 ### 実施内容
 
 | # | 作業 | 状態 |
-| --- | --- | --- |
+|---|---|---|
 | 1 | **Rule 10**: docs/ 戦略ドキュメント全件分析 — 矛盾3件修正 | ✅ |
 | 2 | docs/README.md 最終更新日: 2026-04-12 → 2026-04-16 | ✅ |
 | 3 | docs/CICD_SETUP_GUIDE.md: ワークフロー数 17本 → 19本 に更新 | ✅ |
@@ -8943,7 +8899,7 @@ WebSearch と専門分析により、以下の候補を評価:
 ### 新規プロバイダー選定理由
 
 | プロバイダー | キー | 選定理由 |
-| --- | --- | --- |
+|---|---|---|
 | Lmsys / Chatbot Arena | lmsys | Chatbot Arenaで業界標準Eloベンチマーク運営・透明性・教育価値最高 |
 | Falcon (TII) | falcon_tii | UAE発・Apache 2.0完全オープン・ローカルデプロイ学習に最適 |
 
@@ -8952,12 +8908,13 @@ WebSearch と専門分析により、以下の候補を評価:
 - cross-instance-pr 発行: VSCode版に lmsys/falcon_tii の UI追加を依頼
 - docs/ 追加確認: CONTRIBUTING.md の Flutter SDK バージョン照合
 
+
 ## Windows版#64 セッション記録 (2026-04-16)
 
 ### 実施内容: 4インスタンス + Multi-AI体制 + クォータ監視 構築
 
 | # | 作業 | 状態 |
-| --- | --- | --- |
+|---|---|---|
 | 1 | **4インスタンス体制へ移行**: WEB版 (claude.ai/code) 復活 — ブログ/競合リサーチ担当 | ✅ |
 | 2 | **外部AI統合**: Gemini Code Assist + OpenAI CODEX + GitHub Copilot 役割定義 | ✅ |
 | 3 | COMPRESSED_PROMPT_V3.md: 3インスタンス→4インスタンス + AI振り分けフロー追加 | ✅ |
@@ -8969,7 +8926,7 @@ WebSearch と専門分析により、以下の候補を評価:
 ### Multi-AI 役割分担 (確定版)
 
 | ツール | 役割 | 閾値アラート |
-| --- | --- | --- |
+|---|---|---|
 | Claude Code VSCode版 | Flutter UI + EF + Rule16/19 | — |
 | Claude Code Windowsアプリ版 | docs + migrations + Rule10 | — |
 | Claude Code PowerShell版 | CI/CD + workflows + Rule17 | — |
@@ -8992,348 +8949,24 @@ ai_quota_usage (tool, checked_at, usage_json, alert)
 - GitHub Secrets に `GOOGLE_AI_API_KEY` / `OPENAI_API_KEY` 追加を検討 (quota-monitor有効化)
 - WEB版インスタンスに担当タスク引継ぎ (blog-drafts / competitor-reports)
 
-## VSCode版#78 セッション記録 (2026-04-16)
-
-### 実施内容
-
-| # | タスク | 状態 |
-| --- | --- | --- |
-| 1 | **タスク T-1 第48〜52弾**: 5本 Qiita+dev.to 投稿成功 | ✅ |
-| 2 | **Rule 15 AI大学 新規2社追加**: Black Forest Labs + Liquid AI (58社→60社) | ✅ |
-| 3 | **Rule 8 本番確認 + CORS修正**: growth-acquisition-report→growth-hub 移行 | ✅ |
-| 4 | **Rule 19 UI改善**: AI大学ホームカード デザイントークン5箇所修正 | ✅ |
-
-### AI大学 新規プロバイダー追加 (2026-04-16 VSCode版#78)
-
-| プロバイダー | 技術革新 | API可用 | 話題性 | 合計 | 決定 |
-| --- | --- | --- | --- | --- | --- |
-| **Black Forest Labs** | 3/3 | 3/3 | 3/3 | **9/9** | ✅ 追加 |
-| **Liquid AI** | 3/3 | 2/3 | 2/3 | **7/9** | ✅ 追加 |
-| Hyperbolic | 2/3 | 3/3 | 2/3 | 7/9 | 📌 次点 |
-
-### Rule 19 UI修正詳細 (ai_university_home_card.dart)
-
-- gradient:  → 、 →  (heroGradient 準拠)
-- boxShadow: インディゴグロー  追加 (AI機能識別)
-- →  (2箇所)
-- accent:  →  (indigoLight → indigo 本値)
-
-### CORS バグ修正
-
-- (deleted EF) への呼び出しを  に移行
-- L872 修正
-
-### 次回優先タスク
-
-1. 🟡 **ブログ投稿第53弾以降**: 残り約42本の下書きから継続投稿
-2. 🟢 **AI大学 Hyperbolic 追加**: 次点 (7/9) のプロバイダー
-3. 🟢 **本番 DB migration 適用**: Supabase prod に Black Forest Labs / Liquid AI を有効化
-4. 🟢 **Rule 17 GH Actions 最適化**: 次回 PowerShell インスタンスで実施
-
----
-
-## PowerShell版#本セッション セッション記録 (2026-04-16)
-
-### 実施内容
-
-| # | タスク | 状態 |
-| --- | --- | --- |
-| 1 | **4インスタンス体制確立**: WEB版 (claude.ai/code) 復活・役割分担明確化 | ✅ |
-| 2 | **フォールバック AI 統合**: Gemini Code Assist / CODEX CLI / GitHub Copilot (Claude 429時のみ) | ✅ |
-| 3 | **Rule 21 追加**: NotebookLM 必須活用 (3ファイル以上・URL分析・競合調査) | ✅ |
-| 4 | **quota-monitor.yml 修正**: checkout v6 / setup-python v6 / SUPABASE_SERVICE_ROLE_KEY 統一 | ✅ |
-| 5 | **COMPRESSED_PROMPT_V3.md 更新**: 4インスタンス表・フォールバックAI節・Rule 21・WF数20本 | ✅ |
-| 6 | **CLAUDE.md 更新**: Multi-AI ワークフロー節にフォールバックAI表・4インスタンス更新 | ✅ |
-| 7 | **MULTI_INSTANCE_COORDINATION.md 更新**: 4インスタンス体制・WEB版スコープ追加 | ✅ |
-| 8 | **docs/research/ 新設**: WEB版 NotebookLM Deep Research 成果物置き場 | ✅ |
-| 9 | **cross-instance-pr 発行**: VSCode版へ admin-hub quota.* + QuotaDashboardPage 実装依頼 | ✅ |
-
-### 新規ファイル
-
-- `.github/workflows/quota-monitor.yml` — 毎日 09:00 JST / 4ツール監視 / Supabase UPSERT
-- `supabase/migrations/20260416130000_create_ai_quota_usage.sql` — ai_quota_usage テーブル
-- `docs/research/README.md` — WEB版専用スコープ
-- `docs/cross-instance-prs/20260416_quota_dashboard_ui.md` — VSCode版への委譲
-
-### 次回優先タスク (PS版)
-
-1. 🟡 **Rule 17 全20本確認**: quota-monitor.yml 追加後の全ワークフロー健全確認
-2. 🟢 **VSCode版 quota dashboard 実装完了待ち**: cross-instance-pr レビュー・マージ
-3. 🟢 **WEB版インスタンス起動**: claude.ai/code でブログ英語翻訳 + NotebookLM Deep Research 開始
-4. 🟢 **horse-racing-update.yml 修正確認**: actions/checkout@v4→v6 適用済みか再確認
-
----
-
-## Windowsアプリ版#本セッション セッション記録 (2026-04-17)
-
-### 実施内容
-
-| # | タスク | 状態 |
-| --- | --- | --- |
-| 1 | **バージョンチェック** (check_versions.py実行): バージョン変更なし、制約解消不要 | ✅ |
-| 2 | **Rule 10 docs全件分析**: README.md (3インスタンス→4インスタンス修正) / COMPRESSED_PROMPT_V3プロバイダーリスト重複修正 (black_forest_labs/liquid_ai重複削除 + lmsys/falcon_tii追加) | ✅ |
-| 3 | **AI大学 62社→64社**: Snowflake (Cortex AI + Arctic) + Cognition (Devin 自律AIエンジニア) 追加 | ✅ |
-| 4 | **COMPRESSED_PROMPT_V3更新**: プロバイダーリスト64社に更新 | ✅ |
-
-### 新規ファイル
-
-- `supabase/migrations/20260416210000_seed_snowflake_ai_university.sql` — Snowflake AI (Cortex + Arctic)
-- `supabase/migrations/20260416211000_seed_cognition_ai_university.sql` — Cognition AI (Devin)
-
-### 修正ファイル
-
-- `docs/README.md:15` — `3インスタンス並行開発` → `4インスタンス + マルチAI並行開発`
-- `.github/COMPRESSED_PROMPT_V3.md` — プロバイダー重複削除・lmsys/falcon_tii/snowflake/cognition追加 → 62→64社
-
-### 現在の数値サマリー
-
-- EF: **15本** / ページ数: **221** / AI大学: **64社** / LP: 126のこと
-
-### 次回優先タスク (Win版)
-
-1. 🟡 **AI大学65社目以降**: Poolside AI (コーディング特化) / Scale AI (データ+エンタープライズ) を評価
-2. 🟢 **notebooklm Master Brain更新**: 今セッションの新プロバイダー情報を蓄積
-3. 🟢 **frosty-hamilton PRのマージ確認**: バージョンチェックスクリプト等がmainに取り込まれているか確認
-
-## VSCode版 2026-04-17
-
-### 完了タスク
-
-- `docs/INSTANCE_CONFIG.md` + `CLAUDE.md` Rule 22 完成: markdownlint 0エラー達成・commit d9bcbd40
-- Rule 22 内容: /recap公式Learning Mode + バージョン確認 + リリースノートWebFetch確認 + 新機能追跡ログ表 + 5インスタンス推奨プロンプト
-
-### 現在の数値サマリー
-
-- EF: **15本** / ページ数: **221** / AI大学: **64社** / LP: 126のこと
-
-### 次回優先タスク (VSCode版)
-
-1. 🔴 **AI大学 v2 実装開始**: `docs/superpowers/plans/2026-04-16-ai-university-v2.md` (Task 1: SQL migration) — Subagent-Driven or Inline Execution選択後に着手
-2. 🟡 **Rule 8 Web/モバイル表示チェック**: Playwright MCP で本番URL確認
-3. 🟢 **GROQ_API_KEY設定確認**: supabase secrets set GROQ_API_KEY=... (P3実装前に必要)
-
----
-
-## Windowsアプリ版#Opus47対応 セッション記録 (2026-04-17)
-
-### 実施内容
-
-| # | タスク | 状態 |
-| --- | --- | --- |
-| 1 | **claude-opus-4-7 対応**: tool-versions.md作成 + INSTANCE_CONFIG/CLAUDE.md既更新確認 | ✅ |
-| 2 | **ai-assistant EF**: DEFAULT_EXTENDED_THINKING_MODEL = 'claude-opus-4-7' 定数追加 | ✅ |
-| 3 | **COMPRESSED_PROMPT_V3.md**: Opus 4.6 → Opus 4.7 残存参照2箇所修正 (WEB版行・Rule21) | ✅ |
-| 4 | **scripts/check_versions.py 強化版**: npm最新版取得 / リリースノートURL / devフロー組み込みチェックリスト / `--release-notes` フラグ追加 | ✅ |
-| 5 | **docs/tool-versions.md 新規作成**: リリースノート確認→devフロー組み込みマッピング追加、opus-4-7記録 | ✅ |
-| 6 | **役割分担更新**: Opus 4.7はExtended Thinking非対応 → ultrathink=Sonnet 4.6 を全インスタンスに明記 | ✅ |
-
-### 重要: claude-opus-4-7 仕様まとめ
-
-| 項目 | 内容 |
-| ------ | ------ |
-| **Extended Thinking** | ❌ 非対応 (ultrathink は Sonnet 4.6 で実行) |
-| **Adaptive Thinking** | ✅ 対応 |
-| **用途** | agentic coding・複雑設計・WEB版メインモデル |
-| **料金** | $5/$25 per MTok (Opus 4.6と同等) |
-
-### 修正ファイル
-
-- `supabase/functions/ai-assistant/index.ts` — DEFAULT_EXTENDED_THINKING_MODEL追加
-- `.github/COMPRESSED_PROMPT_V3.md` — Opus 4.6 → Opus 4.7 残存修正
-- `docs/tool-versions.md` — 新規作成 (mainブランチ初)
-- `scripts/check_versions.py` — 強化版 新規作成 (mainブランチ初)
-
-### 現在の数値サマリー
-
-- EF: **15本** / ページ数: **221** / AI大学: **64社** / LP: 126のこと
-
-### 次回優先タスク (Win版)
-
-1. 🔴 **frosty-hamilton PRマージ確認**: バージョンチェックスクリプト等をmainに統合
-2. 🟡 **AI大学65社目**: Poolside AI (コーディング特化) / Scale AI 評価
-3. 🟢 **notebooklm Master Brain更新**: Opus 4.7対応内容を蓄積
-
----
-
-## Windowsアプリ版#Opus47-2 セッション記録 (2026-04-17)
-
-### 実施内容
-
-| # | タスク | 状態 |
-| --- | --- | --- |
-| 1 | **Rule 22 (バージョンチェック)**: 変更なし。claude-opus-4-7台帳確認 ✅ | ✅ |
-| 2 | **Rule 10 docs修正**: INSTANCE_CONFIG "(明日)" → "(2026-04-19 退役)" / MULTI_INSTANCE_COORDINATION WEB版行修正 | ✅ |
-| 3 | **cross-instance-pr処理**: 20260417_opus47_multi_instance_update.md — MULTI_INSTANCE_COORDINATION直接修正で完了 | ✅ |
-| 4 | **AI大学 66社達成**: Scale AI (data/EGP/Scale Labs) + Poolside AI (Malibu/Point コーディング特化LLM) 追加 | ✅ |
-| 5 | **COMPRESSED_PROMPT_V3更新**: 64社→66社 (scale_ai, poolside追加) | ✅ |
-
-### 新規ファイル
-
-- `supabase/migrations/20260417090000_seed_scale_ai_ai_university.sql` — Scale AI (EGP/Evaluation/Labs)
-- `supabase/migrations/20260417091000_seed_poolside_ai_university.sql` — Poolside (Malibu/Point, AWS Bedrock)
-
-### 修正ファイル
-
-- `docs/INSTANCE_CONFIG.md:255` — `(明日)` 削除 → `2026-04-19 退役`
-- `docs/MULTI_INSTANCE_COORDINATION.md:16` — WEB版行 notebooklm不可・Opus 4.7明記
-- `.github/COMPRESSED_PROMPT_V3.md` — プロバイダーリスト 64→66社
-
-### 現在の数値サマリー
-
-- EF: **15本** / ページ数: **221** / AI大学: **66社** / LP: 126のこと
-
-### 次回優先タスク (Win版)
-
-1. 🟡 **AI大学67社目以降**: Harvey AI (法律特化) / Typeface (企業コンテンツAI) / Writer standalone API を評価
-2. 🟢 **notebooklm Master Brain更新**: 今セッション追加プロバイダー情報を蓄積
-3. 🟢 **Haiku 3廃止対応確認** (2026-04-19): EFに参照なし確認済みだが念のため当日再確認
-
----
-
-## VSCode版#80 (2026-04-17)
-
-### 実施内容
-
-| # | タスク | 状態 |
-| --- | --- | --- |
-| 1 | **cross-instance-pr処理**: `20260416_quota_dashboard_ui.md` — admin-hub quota.* + QuotaDashboardPage 実装 | ✅ |
-| 2 | **Voice AI チャットページ**: `ai_assistant_chat_page.dart` — Web Speech API + my_agent.chat (Gemini) | ✅ |
-| 3 | **Rule 16**: Playwright MCP browser 不可 (セッション内クローズ) → スキップ | ⚠️ |
-| 4 | **Rule 19**: design-skills agent審査 → 5件デザイントークン違反を新規ページで修正 | ✅ |
-
-### 新規ファイル
-
-- `lib/pages/admin/quota_dashboard_page.dart` — AI クォータ監視ダッシュボード (4ツール・進捗バー・アラート)
-- `lib/pages/ai_assistant_chat_page.dart` — Voice AI チャット (Web Speech API・my_agent.chat)
-
-### 修正ファイル
-
-- `supabase/functions/admin-hub/index.ts` — quota.latest / quota.list / quota.alert アクション追加
-- `lib/pages/admin_analytics_page.dart` — AI クォータ監視ナビカード追加
-- `lib/main.dart` — /quota-dashboard / /ai-assistant-chat ルート追加
-- デザイントークン修正 (surface2/surface3/green/red/letterSpacing)
-
-### 現在の数値サマリー
-
-- EF: **15本** / ページ数: **223** / AI大学: **66社** / LP: 126のこと
-
-### 次回優先タスク (VSCode版)
-
-1. 🔴 **AI大学 v2 Task 1**: SQL migrations (fsrs_cards + learner_profiles) — APIキー不要・即着手可能
-2. 🟡 **Rule 16 再試行**: 次セッション開始時にPlaywright MCPでスクリーンショット確認
-3. 🟡 **AI大学 v2 Task 2-3**: ai-hub FSRS actions + learner.update_profile (Claude Sonnet)
-4. 🟢 **T-1 技術記事**: Voice AI チャット + quota dashboard 実装記録をQiita/dev.toへ投稿
----
-
-## セッション記録: PowerShell版#本セッション (2026-04-17)
-
-### 実施内容
-
-| # | タスク | 状態 |
-| --- | --- | --- |
-| 1 | **Rule 22**: v2.1.111確認済み・INSTANCE_CONFIG.md更新完了 | ✅ |
-| 2 | **Rule 17**: 全20本チェック — 19本OK、deploy-staging.yml continue-on-error 4本(許容範囲) | ✅ |
-| 3 | **deploy-prod CI修正**: deno lint(no-unused-vars) + dart format(139files) + trailing_commas(5件) | ✅ 3コミット |
-| 4 | **quota-monitor調査**: 過去の失敗は古い式エラー — cd0f1ed5で修正済み。スケジュール実行は未確認(次回09:00 JST) | ✅ |
-| 5 | **frosty-hamilton PR作成**: PR #366 — Voice AI chat + conversation_messages migration + scripts/ | ✅ |
-| 6 | **T-1スケジュール確認**: 第52弾完了済み / 未投稿候補34本確認 / 次候補要frontmatter整備 | ✅ |
-
-### コミット
-
-- `fix: deno lint no-unused-vars — DEFAULT_EXTENDED_THINKING_MODEL`
-- `style: dart format 139ファイル一括フォーマット`
-- `fix: require_trailing_commas 5件 + dart format 3件`
-- `docs: INSTANCE_CONFIG.md v2.1.111対応`
-- `docs: COMPRESSED_PROMPT_V3.md deploy-prod修正記録 + PR#366追加`
-
-### 現在の数値サマリー
-
-- EF: **15本** / ページ数: **223** / AI大学: **66社** / LP: 126のこと
-- T-1: **第52弾完了** / 未投稿候補: ~34本 (frontmatter整備が必要なものあり)
-
-### 次回優先タスク (PowerShell版)
-
-1. 🔴 **deploy-prod CI確認**: 新run `24524412781` (b8bca877) の完了を確認 — 全チェック通過後にPR #366へ
-2. 🔴 **PR #366 コンフリクト解決**: frosty-hamilton ✕ main のマージ (ai-assistant.ts / CLAUDE.md / CV3)
-3. 🟡 **quota-monitor スケジュール実行確認**: 次回09:00 JST通過を確認
-4. ✅ **T-1 第53弾完了**: Qiita https://qiita.com/kanta13jp1/items/c6ee22c28d83903e6c3f / dev.to https://dev.to/kanta13jp1/why-i-killed-my-4th-claude-code-instance-lessons-from-multi-agent-indie-dev-2l1h
-5. 🟢 **`/less-permission-prompts` 実行**: settings.json 許可リスト最適化 (v2.1.111新機能)
-
----
-
-## VSCode版セッション #81 (2026-04-17)
-
-### 実施内容
-
-#### ブログ管理スイート完成
-
-1. **blog-publish.yml Step5 無限ループ修正** (e78cf127)
-   - `_mark_published()` bash関数: 4-case frontmatter処理
-   - `published: false` → replace / `published: true` → skip / frontmatterあり → insert / frontmatterなし → prepend
-
-2. **GROWTH_STRATEGY_ROADMAP.md markdownlint対応** (b8bca877)
-   - MD022/MD012/MD009: `--fix` で自動修正 (56件)
-   - MD060 (テーブルセパレーター): Python script で456件修正 `|---|` → `| --- | --- |`
-   - MD040 (コードフェンス言語): 2件 `sed` 修正
-   - `.markdownlintignore` から除外 → 以降 CI でチェック対象
-
-3. **blog-batch-publish.yml 新規作成**
-   - 未投稿ドラフト全件 (21本) 一括投稿
-   - `scripts/batch_publish.py`: 4-case frontmatter + EF呼び出し
-
-4. **blog-engagement.yml 新規作成** + **scripts/blog_engagement.py**
-   - Qiita/dev.to エンゲージメント取得・重複削除
-   - コメント自動返信 (Claude Haiku)
-   - いいね者フォロー (Qiita)
-   - Supabase `blog_engagement` / `blog_comments` / `blog_likers` テーブルに保存
-
-5. **blog_management_page.dart 新規作成**
-   - 管理画面: 記事一覧・エンゲージメント・コメント表示
-   - `/blog-management` ルート + admin_analytics_page からリンク
-
-6. **supabase/migrations/20260417120000_create_blog_engagement.sql**
-   - blog_engagement / blog_comments / blog_likers テーブル作成
-
-### ワークフロー実行状況
-
-- `blog-batch-publish.yml`: 実行中 (21本バッチ投稿)
-- `blog-engagement.yml`: キュー済み (Qiita/dev.to同期開始)
-
-### 現在の数値サマリー
-
-- EF: **15本** / ページ数: **223** / AI大学: **66社** / LP: 126のこと
-- T-1: **第53弾完了** / ブログ投稿: バッチ実行中
-
-### 次回優先タスク (VSCode版)
-
-1. 🔴 **blog-engagement.yml 実行結果確認**: Qiita/dev.to データが `blog_engagement` テーブルに入ったか
-2. 🔴 **blog_management_page.dart 動作確認**: `/blog-management` ページで記事・コメント表示確認
-3. 🟡 **batch publish 結果確認**: 21本のうち何本成功したか、失敗したものは手動投稿
-4. 🟡 **blog-engagement.yml 定期実行**: daily schedule (10:00 JST) が正常に動くか確認
-5. 🟢 **schedule-hub blog.sync_engagement アクション確認**: EFが blog_engagement と連携できるか
-
----
-
-## VSCode版#82 セッション記録 (2026-04-17)
-
-### 実施内容
-
-- **COMPRESSED_PROMPT_V3.md 更新**: WF数20→25・EF16本・standalone5本・AI大学67社目以降・T-1第53弾
-- **blog-batch-publish.yml GH006 修正**: 保護ブランチ直接push → unique branch + 手動マージ方式
-- **batch_publish.py バグ修正**: `any_ok or result.get("success")` → `any_ok` (Qiita 429時の誤マーク防止)
-- **settings.local.json 全ツール自動承認**: Bash/Read/Write/Edit/Glob/Grep/WebFetch/WebSearch/Agent/TodoWrite/Skill 追加
-- **blog-engagement.yml 確認**: run #24525802467 ✅ success (dev.toコメント返信動作確認)
-- **ブログ整合性監査 完了** (前セッション継続): 4ファイル修正・markdownlint 0エラー
-
-### コミット
-
-- `81a09397` chore: COMPRESSED_PROMPT_V3.md更新 — WF数20→25・EF16本・5本standalone・T-1第53弾追加
-- `9ca3e2dc` fix: blog-batch-publish GH006保護ブランチ直接push修正 + batch_publish.py ok:false誤マーク修正
-
-### 次回優先タスク
-
-1. 🔴 **AI大学 v2 計画実装開始**: 66社の学習コンテンツ品質向上・クイズ強化
-2. 🟡 **blog-batch-publish 再実行**: 残存 published:false ファイルの投稿 (Qiita 429で失敗した1本含む)
-3. 🟡 **T-1 第54弾記事**: 新規技術記事執筆・Qiita+dev.to投稿
-4. 🟢 **LP 126→130のこと追加**: 新機能説明の追加
-5. 🟢 **Rule 19 UI改善**: Figma/AIDesigner MCP でホーム画面・AI大学ページ改善
+## Windows版#64 セッション記録 (2026-04-16)
+
+### 実施内容: 音声AIアシスタント + 長期記憶実装
+
+**背景**: Voice AI GMAT Tutor with Long-Term Memory (ユーザー共有のNotebookLM記事) のアーキテクチャパターンを自分株式会社に適用。
+
+**実装ファイル**:
+- `supabase/migrations/20260416140000_create_conversation_messages.sql`
+  - `user_conversations` テーブル: セッション管理 (context: general_chat/ai_university_quiz/habit_coach)
+  - `conversation_messages` テーブル: user/assistant往復履歴、voice_usedフラグ、tokens_used
+  - RLS: ユーザーは自分のデータのみアクセス
+- `supabase/functions/ai-assistant/index.ts`: `chat` action 追加
+  - 直近10件の会話履歴をコンテキスト注入 (長期記憶パターン)
+  - `conversationId` でセッション管理、新規会話は自動作成
+  - `voiceUsed` フラグ対応
+- `docs/cross-instance-prs/20260416_voice_ai_chat_ui.md` (VSCode版向け)
+
+**次回優先タスク**:
+1. VSCode版: `ai_assistant_chat_page.dart` 実装 (Web Speech API + チャットUI)
+2. VSCode版: LPに「音声AIアシスタント」追加
+3. quota-monitor.yml: `GOOGLE_AI_API_KEY`と`OPENAI_API_KEY`のGitHub Secrets設定 (TODO: 手動)

--- a/docs/cross-instance-prs/20260416_voice_ai_chat_ui.md
+++ b/docs/cross-instance-prs/20260416_voice_ai_chat_ui.md
@@ -1,0 +1,101 @@
+# cross-instance-pr: 音声AIチャット UI実装
+
+作成: Windows版#64 (2026-04-16)
+宛先: VSCode版
+状態: pending
+
+## 背景
+
+Voice AI GMAT Tutor with Long-Term Memory (dev.to記事) のパターンを自分株式会社に適用。
+Windows版#64 で以下を実装済み:
+- `supabase/migrations/20260416140000_create_conversation_messages.sql`
+  - `user_conversations` テーブル (セッション管理)
+  - `conversation_messages` テーブル (user/assistantメッセージ、voice_used フラグ)
+- `supabase/functions/ai-assistant/index.ts`: `chat` action 追加
+  - 直近10件の会話履歴をコンテキスト注入 (長期記憶)
+  - `conversationId` で会話セッション管理
+  - `voiceUsed` フラグ対応
+
+## VSCode版タスク
+
+### 1. `lib/pages/ai_assistant_chat_page.dart` 新規作成
+
+```dart
+// 音声AIアシスタント チャット画面
+// - Web Speech API (SpeechRecognition) でマイク入力
+// - SpeechSynthesis API で音声出力
+// - ai-assistant EF の chat action を呼ぶ
+// - DesignTokens (Orange+Indigo) 適用
+
+// EF呼び出し例:
+// POST /ai-assistant
+// { "action": "chat", "message": userText, "conversationId": _convId,
+//   "voiceUsed": _voiceMode, "conversationContext": "general_chat" }
+// → { "reply": "...", "conversationId": "uuid", "messageId": "uuid" }
+```
+
+主要ウィジェット:
+- `ChatBubble` (user: 右寄せ orange, assistant: 左寄せ indigo)
+- `VoiceInputButton` (マイク → `window.SpeechRecognition` → テキスト認識)
+- `SpeakerButton` (メッセージごと → `window.speechSynthesis.speak()`)
+- `VoiceModeToggle` (オン時: 応答を自動読み上げ)
+
+Web Speech API アクセス方法 (dart:js or package:web):
+```dart
+import 'package:web/web.dart' as web;
+// or
+import 'dart:js' as js;
+
+// STT
+final recognition = js.JsObject(js.context['webkitSpeechRecognition']);
+recognition['lang'] = 'ja-JP';
+recognition['onresult'] = (e) { ... };
+recognition.callMethod('start');
+
+// TTS
+final utterance = js.JsObject(js.context['SpeechSynthesisUtterance'], [text]);
+js.context['speechSynthesis'].callMethod('speak', [utterance]);
+```
+
+### 2. `lib/main.dart` にルート追加
+
+```dart
+'/ai-assistant-chat': (context) => const AiAssistantChatPage(),
+```
+
+### 3. `lib/pages/landing_page.dart` に機能追加
+
+LP の「コア機能」リストに追記:
+```
+音声AIアシスタント（会話・長期記憶）
+```
+
+## EF chat action の仕様
+
+```
+POST https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/ai-assistant
+Authorization: Bearer <user_jwt>
+{
+  "action": "chat",
+  "message": "今日のタスクを整理して",
+  "conversationId": "uuid-or-empty-for-new",
+  "conversationContext": "general_chat",
+  "voiceUsed": false,
+  "model": "claude-sonnet-4-6"  // optional
+}
+
+Response:
+{
+  "success": true,
+  "reply": "了解です。以下のタスクを整理しました...",
+  "conversationId": "abc-123-def",
+  "messageId": "msg-456"
+}
+```
+
+## 参考
+
+- 元記事: "I Built a Voice AI GMAT Tutor with Long-Term Memory in 6 Weeks"
+- NotebookLM: c7e786bb-b4fb-466e-9382-efdb739b992f
+- DB migration: `20260416140000_create_conversation_messages.sql`
+- EF: `supabase/functions/ai-assistant/index.ts` (chat action, lines ~749)

--- a/docs/instance-constraints.md
+++ b/docs/instance-constraints.md
@@ -1,0 +1,202 @@
+# インスタンス別制約・モデル・モード 管理台帳
+
+> **更新ルール**: 新しい制約・仕様変更を発見したセッションが **即このファイルに追記** し、
+> `COMPRESSED_PROMPT_V3.md` の該当インスタンス行も同時に更新する。
+> 追記フォーマット: `| YYYY-MM-DD | インスタンス | 制約/変更内容 | 代替手段 | 発見セッション |`
+
+---
+
+## 制約発見ログ
+
+| 日付 | インスタンス | 制約・制限 | 代替手段 | 発見 |
+| --- | --- | --- | --- | --- |
+| 2026-04-16 | WEB版 | `notebooklm` CLI 実行不可 (ローカルPython環境なし) | WebSearch で代替 | Win版#64 |
+| 2026-04-16 | WEB版 | `flutter analyze` 実行不可 (Flutter SDK なし) | VSCode版に cross-instance-pr | Win版#64 |
+| 2026-04-16 | WEB版 | `deno lint` 実行不可 (Deno なし) | EF変更はVSCode版に委譲 | Win版#64 |
+| 2026-04-16 | WEB版 | `gh` CLI / ローカル `git` push 不可 | `mcp__plugin_github_github__push_files` / `create_or_update_file` | Win版#64 |
+| 2026-04-13 | WEB版 | `git stash` / `git rebase` 操作不可 | GitHub MCP でファイル単位更新 | PS版#52 |
+| 2026-04-11 | Windowsアプリ版 | Python実行時 CP932エラー | `PYTHONUTF8=1` プレフィックス必須 | Win版 |
+| 2026-04-11 | Windowsアプリ版 | xlsx ファイルが Windows でロックされ `git stash` 失敗 | `git stash --exclude=*.xlsx` → 特定ファイルのみ stash | Win版 |
+| 2026-04-11 | 全インスタンス | Edit ツールは Read 前に使用不可 (File not read yet) | 必ず Read → Edit の順。圧縮後は再 Read | 全 |
+| 2026-04-12 | VSCode版 | Write ツールは相対パスのみ有効 (絶対パス silent fail) | `lib/pages/foo.dart` 形式で指定 | VSCode#35 |
+| 2026-04-12 | 全インスタンス | Edit 後に linter が変更を巻き戻す場合あり | Edit → 即 `git add` (Python+即gitaddパターン) | VSCode#59 |
+| 2026-04-12 | PowerShell版 | GHA `${{ steps.X.outputs.Y }}` を bash 文字列に直接展開禁止 | `env:` ブロック経由で安全に渡す | PS#54 |
+
+---
+
+## インスタンス別 現行仕様 (2026-04-16 時点)
+
+### VSCode版 (Claude Code Desktop — Windows)
+
+| 項目 | 値 |
+| --- | --- |
+| **推奨モデル** | `claude-sonnet-4-6` |
+| **推奨モード** | 通常。複雑UI設計時は **Extended Thinking** (`--thinking` フラグ or API `thinking` param) |
+| **Claude最新機能** | Extended Thinking / Interleaved Thinking (ツール使用中思考) / CAVEMAN プラグイン |
+| **担当範囲** | `lib/` (Flutter) + `supabase/functions/` (EF) + `docs/DESIGN.md` |
+| **必須コマンド** | `flutter analyze` (0エラー必須) / `deno lint` (0エラー必須) |
+| **制約** | なし |
+| **Copilot連携** | Inline Chat (`Ctrl+I`) / Copilot Edits (複数ファイル同時編集) / `@workspace` |
+
+### Windowsアプリ版 (Claude Code Desktop — Windows)
+
+| 項目 | 値 |
+| --- | --- |
+| **推奨モデル** | `claude-sonnet-4-6` |
+| **推奨モード** | 通常 + CAVEMAN (token節約) |
+| **Claude最新機能** | Extended Thinking (DB schema設計時) / notebooklm skill / deep-research skill |
+| **担当範囲** | `docs/` (DESIGN.md除く) + `supabase/migrations/` + `notebooklm` CLI主担当 |
+| **必須コマンド** | `PYTHONUTF8=1 notebooklm ...` / Python スクリプト |
+| **制約** | Python実行時 `PYTHONUTF8=1` 必須 / xlsx ロック注意 |
+| **Copilot連携** | なし (Windowsアプリ版はIDE非依存) |
+
+### PowerShell版 (Claude Code Terminal — Windows)
+
+| 項目 | 値 |
+| --- | --- |
+| **推奨モデル** | ルーティン: `claude-haiku-4-5` / CI設計・新機能: `claude-sonnet-4-6` |
+| **推奨モード** | `/fast` (定型YAML編集) / 通常 (ワークフロー設計) |
+| **Claude最新機能** | CAVEMAN (PR/commit message圧縮) / schedule skill (Claude Code Schedule管理) |
+| **担当範囲** | `.github/workflows/` + `.mcp.json` + `docs/MULTI_INSTANCE_COORDINATION.md` |
+| **必須コマンド** | `gh workflow run` / `gh pr list` / `deno lint` (EF確認用) |
+| **制約** | GHA `${{ steps.X.outputs.Y }}` は env: ブロック経由で渡す |
+| **Copilot連携** | Terminal での `gh copilot suggest` / `gh copilot explain` |
+
+### WEB版 (claude.ai/code — ブラウザ)
+
+| 項目 | 値 |
+| --- | --- |
+| **推奨モデル** | `claude-sonnet-4-6` (claude.ai設定で変更。変更不可の場合あり) |
+| **推奨モード** | 通常 + **Projects機能** (プロジェクト専用コンテキスト永続化) + **Memory機能** (設定・パターン記憶) |
+| **Claude最新機能** | Projects / Memory / Extended Thinking (opus選択時) / **Learning Mode** (Projectsでコードベース学習) |
+| **担当範囲** | `docs/blog-drafts/` + `docs/competitor-reports/` + GitHub PR/Issues主担当 |
+| **利用可能MCP** | WebSearch / WebFetch / GitHub MCP / Code Review MCP / Figma MCP / AIDesigner MCP / Magic MCP / Playwright MCP |
+| **制約 (不可)** | `notebooklm` CLI / `flutter analyze` / `deno lint` / ローカルCLI全般 / `git` 直接操作 |
+| **代替パターン** | notebooklm → WebSearch / analyze/lint → cross-instance-pr / git → GitHub MCP |
+
+---
+
+## 外部AI 仕様・モード一覧 (2026-04-16 時点)
+
+### GitHub Copilot
+
+| 機能 | モデル選択肢 | 用途 |
+| --- | --- | --- |
+| **Inline補完** | GPT-4o (デフォルト) | 行補完・Next-line予測 |
+| **Copilot Chat** | GPT-4o / Claude Sonnet / Gemini Pro 選択可 | コード説明・リファクタ提案 |
+| **Copilot Edits** | GPT-4o | 複数ファイル同時編集 (VSCode版専用) |
+| **Copilot Workspace** | GPT-4o | Issue→実装計画→PR全自動生成 |
+| **@workspace** | GPT-4o | リポジトリ全体を文脈として使用 |
+| **gh copilot suggest** | GPT-4o | ターミナルCLIコマンド提案 (PS版で活用) |
+
+**このプロジェクトでの使い方**:
+- VSCode版: Inline補完 (`Ctrl+Enter`) + Copilot Edits で Flutter 多ファイル修正
+- PowerShell版: `gh copilot suggest "gh workflow run ..."` でCLI提案
+- WEB版: Copilot Workspace で GitHub Issue → 実装PR 自動化
+
+### Gemini Code Assist
+
+| モデル | 特徴 | 用途 |
+| --- | --- | --- |
+| **Gemini 2.5 Pro** | 2Mトークンコンテキスト / 最強推論 | 大規模リファクタ / 全EF横断分析 |
+| **Gemini 2.5 Flash** | 高速・低コスト | 定型コード生成・補完 |
+
+**このプロジェクトでの使い方**:
+- Flutter/Dart 大規模リファクタ (Google製フレームワーク = 相性最良)
+- `supabase/functions/` 全体横断分析 (2Mコンテキスト活用)
+- Agent mode: 自律的なコード変更 (VSCode Code Assist拡張)
+- 制約: `GEMINI_API_KEY` → quota-monitor.yml で監視
+
+### OpenAI CODEX (o3 / o4-mini)
+
+| モデル | 特徴 | 用途 |
+| --- | --- | --- |
+| **o3** | コーディングベンチ最高スコア / 深い推論 | 複雑アルゴリズム・SQL最適化 |
+| **o4-mini** | 高速・低コスト・コーディング特化 | 定型コード生成・変換 |
+| **Codex CLI** | ターミナルで直接実行・ファイル読み書き対応 | PowerShell版でローカル実行 |
+
+**このプロジェクトでの使い方**:
+- Supabase クエリ最適化 (PostgreSQL + RLS)
+- Edge Function の複雑なビジネスロジック
+- Codex CLI: PowerShell版で `codex "このSQL最適化して"` で使用
+- 制約: `OPENAI_API_KEY` → quota-monitor.yml で監視 (月次 $20 閾値)
+
+---
+
+## 制約発見時の更新ワークフロー
+
+```text
+【新制約発見時 — どのインスタンスでも必須】
+
+Step 1: このファイル (docs/instance-constraints.md) の「制約発見ログ」に追記
+        フォーマット: | YYYY-MM-DD | インスタンス名 | 制約内容 | 代替手段 | セッション名 |
+
+Step 2: COMPRESSED_PROMPT_V3.md の該当インスタンス行の「制約」列を更新
+        (Python replace スクリプト使用。WEB版は GitHub MCP 経由)
+
+Step 3: memory/feedback_correction_YYYYMMDD.md に記録
+        (auto-capture hook が自動記録する場合あり)
+
+Step 4: cross-instance-pr で他インスタンスへ周知
+        ファイル: docs/cross-instance-prs/YYYYMMDD_constraint_discovery.md
+
+Step 5: GROWTH_STRATEGY_ROADMAP.md のセッション記録に追記
+```
+
+---
+
+## 推奨次回セッション開始プロンプト
+
+### VSCode版
+
+```
+このインスタンスはVSCode版です。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、以下の順で実行してください:
+1. docs/cross-instance-prs/ の pending タスクをすべて処理
+2. Rule 16: 本番 https://my-web-app-b67f4.web.app/ をPlaywright MCP でスクリーンショット取得・表示チェック
+3. Rule 19: UI改善ツールチェーン (design-skills → Figma MCP → AIDesigner MCP → 実装)
+4. 新制約発見時は docs/instance-constraints.md に追記
+```
+
+### Windowsアプリ版
+
+```
+このインスタンスはWindowsアプリ版です。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、標準フローで実行してください:
+1. Rule 10: docs/ 全件分析 (矛盾・鮮度切れ修正)
+2. AI大学: WebSearch で新規プロバイダー候補を調査 → migration 追加
+3. notebooklm Master Brain 更新 (PYTHONUTF8=1 必須)
+4. 新制約発見時は docs/instance-constraints.md に追記
+```
+
+### PowerShell版
+
+```
+このインスタンスはPowerShell版です (推奨モデル: ルーティンはclaude-haiku-4-5)。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、以下の順で実行してください:
+1. Rule 17: .github/workflows/ 最適化チェック (エラーステップ削除・timeout確認)
+2. quota-monitor.yml の実行結果確認 (ai_quota_usage テーブル)
+3. T-1 ブログ投稿タスクのスケジュール確認
+4. 新制約発見時は docs/instance-constraints.md に追記
+```
+
+### WEB版
+
+```
+このインスタンスはWEB版(claude.ai/code)です。
+【制約】notebooklm CLI・flutter analyze・deno lint・ローカルCLI は実行不可。
+代替: notebooklm→WebSearch / git→GitHub MCP / analyze→cross-instance-pr依頼。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、WEB版許可タスクを実行してください:
+1. WebSearch で競合21社の最新情報をリサーチ → docs/competitor-reports/ に保存 (GitHub MCP)
+2. Rule 11: AI大学コンテンツ更新 (WebFetch → Supabase API 経由でupsert)
+3. GitHub MCP で open PR をレビュー (Code Review MCP 使用)
+4. 新制約発見時は docs/instance-constraints.md に追記 (GitHub MCP 経由でファイル更新)
+```

--- a/docs/instance-constraints.md
+++ b/docs/instance-constraints.md
@@ -152,6 +152,11 @@ Step 5: GROWTH_STRATEGY_ROADMAP.md のセッション記録に追記
 ```
 このインスタンスはVSCode版です。
 
+【セッション開始時必須】まずバージョンチェックを実行してください:
+  PYTHONUTF8=1 python3 scripts/check_versions.py
+バージョン更新があれば docs/tool-versions.md の制約解消チェックリストを確認し、
+解消済みなら docs/instance-constraints.md から該当行を削除して役割分担を見直すこと。
+
 .github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
 その後、以下の順で実行してください:
 1. docs/cross-instance-prs/ の pending タスクをすべて処理
@@ -165,6 +170,11 @@ Step 5: GROWTH_STRATEGY_ROADMAP.md のセッション記録に追記
 ```
 このインスタンスはWindowsアプリ版です。
 
+【セッション開始時必須】まずバージョンチェックを実行してください:
+  PYTHONUTF8=1 python3 scripts/check_versions.py
+バージョン更新があれば docs/tool-versions.md の制約解消チェックリストを確認し、
+解消済みなら docs/instance-constraints.md から該当行を削除して役割分担を見直すこと。
+
 .github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
 その後、標準フローで実行してください:
 1. Rule 10: docs/ 全件分析 (矛盾・鮮度切れ修正)
@@ -177,6 +187,11 @@ Step 5: GROWTH_STRATEGY_ROADMAP.md のセッション記録に追記
 
 ```
 このインスタンスはPowerShell版です (推奨モデル: ルーティンはclaude-haiku-4-5)。
+
+【セッション開始時必須】まずバージョンチェックを実行してください:
+  PYTHONUTF8=1 python3 scripts/check_versions.py
+バージョン更新があれば docs/tool-versions.md の制約解消チェックリストを確認し、
+解消済みなら docs/instance-constraints.md から該当行を削除して役割分担を見直すこと。
 
 .github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
 その後、以下の順で実行してください:
@@ -192,6 +207,14 @@ Step 5: GROWTH_STRATEGY_ROADMAP.md のセッション記録に追記
 このインスタンスはWEB版(claude.ai/code)です。
 【制約】notebooklm CLI・flutter analyze・deno lint・ローカルCLI は実行不可。
 代替: notebooklm→WebSearch / git→GitHub MCP / analyze→cross-instance-pr依頼。
+
+【セッション開始時必須】WEB版はCLIが使えないためWebFetchでリリース確認してください:
+  Claude Code  : https://github.com/anthropics/claude-code/releases
+  Gemini       : https://marketplace.visualstudio.com/items?itemName=google.geminicodeassist
+  Copilot      : https://marketplace.visualstudio.com/items?itemName=github.copilot
+  OpenAI models: https://platform.openai.com/docs/models
+バージョン変更があれば docs/tool-versions.md を GitHub MCP 経由で更新し、
+制約解消チェックリストを確認すること。
 
 .github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
 その後、WEB版許可タスクを実行してください:

--- a/docs/tool-versions.md
+++ b/docs/tool-versions.md
@@ -1,12 +1,12 @@
 # ツールバージョン管理台帳
 
 > **更新ルール**: セッション開始時に `scripts/check_versions.py` を実行し、
-> バージョンが上がっていれば①この台帳を更新②制約解消チェック③**リリースノート確認 → 新機能をdevフローへ組み込み**④役割分担見直しを行う。
+> バージョンが上がっていれば①この台帳を更新②制約解消チェック③役割分担見直しを行う。
 > WEB版は `check_versions.py` 実行不可 → WebFetch でリリースページを確認し手動更新。
 
 ---
 
-## 現在のバージョン (2026-04-17 時点)
+## 現在のバージョン (2026-04-16 時点)
 
 | ツール | 現在バージョン | 最終確認日 | 確認インスタンス |
 | --- | --- | --- | --- |
@@ -19,16 +19,15 @@
 | **Deno** | `2.6.5` | 2026-04-16 | Windowsアプリ版 |
 | **Claude Sonnet** (API model) | `claude-sonnet-4-6` | 2026-04-16 | 全インスタンス |
 | **Claude Haiku** (API model) | `claude-haiku-4-5` | 2026-04-16 | PowerShell版 |
-| **Claude Opus** (API model) | `claude-opus-4-7` | 2026-04-17 | 全インスタンス |
+| **Claude Opus** (API model) | `claude-opus-4` | 2026-04-16 | — |
 
 ---
 
 ## バージョンアップ履歴
 
-| 日付 | ツール | 旧バージョン | 新バージョン | 制約解消確認 | リリースノート新機能 | 対応 |
-| --- | --- | --- | --- | --- | --- | --- |
-| 2026-04-16 | Claude Code CLI | — | 2.1.110 | 初回記録 | — | — |
-| 2026-04-17 | Claude Opus API | `claude-opus-4` | `claude-opus-4-7` | 制約なし (APIモデル更新) | 要確認: https://www.anthropic.com/news | Extended Thinking タスクのモデルをopus-4-7に更新 |
+| 日付 | ツール | 旧バージョン | 新バージョン | 制約解消確認 | 対応 |
+| --- | --- | --- | --- | --- | --- |
+| 2026-04-16 | Claude Code CLI | — | 2.1.110 | 初回記録 | — |
 
 ---
 
@@ -46,15 +45,6 @@
 | WEB版での直接 `git` 操作 | WEB版 | `git status` が動くか |
 | Write ツールの絶対パス対応 | VSCode版 | `C:/Users/...` で Write 成功するか |
 | Edit ツールの Read 省略対応 | 全インスタンス | Read 前 Edit でエラーが出ないか |
-
-### Claude API モデル更新時
-
-| チェック項目 | 対応内容 |
-| --- | --- |
-| 新モデルのリリースノートを確認 | https://www.anthropic.com/news でFeatures/Capabilities変化を確認 |
-| EFのDEFAULT_SYNTHESIS_MODEL更新 | `supabase/functions/ai-assistant/index.ts` の定数を更新 |
-| Extended Thinking推奨モデルを更新 | COMPRESSED_PROMPT_V3.md・CLAUDE.md・instance-constraints.md を更新 |
-| 新機能をdevフローへ組み込み | 例: 新ツール使用API / 新モード / コンテキスト上限変化 → CLAUDE.mdに反映 |
 
 ### Gemini Code Assist
 
@@ -82,43 +72,27 @@
 
 ---
 
-## バージョンアップ → リリースノート確認 → devフロー組み込みマッピング
+## バージョンアップ → 役割分担見直しマッピング
 
 ```text
-【Claude API モデル更新時】
-  Step 1: リリースノート確認 (https://www.anthropic.com/news)
-    → 新機能例: 新ツール使用API / Extended Thinking強化 / コンテキスト上限変化 /
-                新モード (Interleaved Thinking等) / 価格変化
-  Step 2: 新機能をこのプロジェクトのdevフローへ組み込む
-    → 新モデル名を docs/tool-versions.md に記録
-    → ai-assistant/index.ts の DEFAULT_SYNTHESIS_MODEL (または Extended Thinking呼び出し) を更新
-    → COMPRESSED_PROMPT_V3.md の「Claude最新機能」テーブルを更新
-    → CLAUDE.md のインスタンス別モデル表を更新
-    → instance-constraints.md のモデル列を更新
-  Step 3: 制約解消チェック
-    → 新モデルで過去の制約 (コンテキスト不足・推論精度不足等) が解消されるか確認
-    → 解消済みなら instance-constraints.md から削除
-
-【Claude Code CLI/VSCode ext 更新時】
+Claude Code が新バージョンにアップデート
   → WEB版制約チェックリストを全確認
   → 解消された制約を docs/instance-constraints.md から削除
   → COMPRESSED_PROMPT_V3.md の制約列を更新
   → CLAUDE.md の代替パターン記述を削除/更新
 
-【GitHub Copilot がインストール/更新】
+GitHub Copilot がインストール/更新
   → Copilot Edits / Workspace の利用可否を確認
   → AI選択フローの「Copilot Edits → Flutter多ファイル編集」を有効化
   → VSCode版の推奨ツールに追記
 
-【Gemini Code Assist が更新】
+Gemini Code Assist が更新
   → Agent mode が安定したらEF全体分析タスクをGeminiに移管検討
   → コンテキスト上限が増えた場合は大規模リファクタタスクへ活用
-  → リリースノート: https://marketplace.visualstudio.com/items?itemName=google.geminicodeassist
 
-【新しい Claude モデルリリース (例: claude-sonnet-4-7, claude-opus-4-7) 】
+新しい Claude モデル (例: claude-sonnet-4-7, claude-opus-5) リリース
   → ai-assistant EF の DEFAULT_SYNTHESIS_MODEL を更新
   → daily-judgment / gemini-election-analysis のモデルパラメータを更新
-  → Extended Thinking推奨モデルを更新
   → この台帳の「現在のバージョン」テーブルを更新
 ```
 
@@ -129,7 +103,7 @@
 | ツール | リリースページ | 確認頻度 |
 | --- | --- | --- |
 | Claude Code | https://github.com/anthropics/claude-code/releases | 毎セッション (`claude --version`) |
-| Claude モデル | https://www.anthropic.com/news | 毎セッション (WEB版はWebFetch) |
+| Claude モデル | https://www.anthropic.com/news | 週1回 |
 | Gemini Code Assist | https://marketplace.visualstudio.com/items?itemName=google.geminicodeassist | 週1回 |
 | GitHub Copilot | https://marketplace.visualstudio.com/items?itemName=github.copilot | 週1回 |
 | OpenAI API モデル | https://platform.openai.com/docs/models | 週1回 |

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,43 +1,26 @@
 #!/usr/bin/env python3
 """
-check_versions.py — セッション開始時バージョンチェック (Rule 22)
+check_versions.py — セッション開始時バージョンチェック
 使用方法:
-  PYTHONUTF8=1 python3 scripts/check_versions.py [--update] [--web] [--release-notes]
-  --update        : tool-versions.md を自動更新する
-  --web           : WEB版モード (CLIコマンドをスキップ、URLのみ表示)
-  --release-notes : バージョン更新時にリリースノートURLを出力 (fetch は手動)
+  PYTHONUTF8=1 python3 scripts/check_versions.py [--update] [--web]
+  --update : tool-versions.md を自動更新する
+  --web    : WEB版モード (CLIコマンドをスキップ、URLのみ表示)
 
 出力:
   - バージョン変更があれば警告を表示
   - 解消可能な制約があれば docs/instance-constraints.md の確認を促す
-  - 新機能情報があれば devフロー組み込みを提案
   - 終了コード 0: 変更なし / 1: 更新あり / 2: エラー
 """
 
-import subprocess, sys, re, os
+import subprocess, sys, json, re, os
 from datetime import date
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 VERSIONS_FILE = os.path.join(REPO_ROOT, "docs", "tool-versions.md")
-CONSTRAINTS_FILE = os.path.join(REPO_ROOT, "docs", "INSTANCE_CONFIG.md")
+CONSTRAINTS_FILE = os.path.join(REPO_ROOT, "docs", "instance-constraints.md")
 TODAY = date.today().isoformat()
 WEB_MODE = "--web" in sys.argv
 AUTO_UPDATE = "--update" in sys.argv
-SHOW_RELEASE_NOTES = "--release-notes" in sys.argv
-
-# ──────────────────────────────────────────────
-# リリースノート URL 定義
-# ──────────────────────────────────────────────
-
-RELEASE_NOTE_URLS = {
-    "Claude Code CLI":        "https://github.com/anthropics/claude-code/releases",
-    "Claude Code VSCode ext": "https://github.com/anthropics/claude-code/releases",
-    "Gemini Code Assist":     "https://cloud.google.com/code/docs/vscode/release-notes",
-    "GitHub Copilot":         "https://github.blog/changelog/",
-    "OpenAI ChatGPT ext":     "https://github.com/openai/openai-vscode/releases",
-    "Flutter/Dart SDK":       "https://docs.flutter.dev/release/release-notes",
-    "Claude Models":          "https://www.anthropic.com/news",
-}
 
 # ──────────────────────────────────────────────
 # 現在バージョン収集
@@ -52,12 +35,6 @@ def run(cmd: list[str]) -> str:
 
 def get_claude_code_version() -> str:
     out = run(["claude", "--version"])
-    m = re.search(r"(\d+\.\d+\.\d+)", out)
-    return m.group(1) if m else "unknown"
-
-def get_latest_claude_code_version() -> str:
-    """npm registry から最新バージョンを取得"""
-    out = run(["npm", "show", "@anthropic-ai/claude-code", "dist-tags.latest"])
     m = re.search(r"(\d+\.\d+\.\d+)", out)
     return m.group(1) if m else "unknown"
 
@@ -88,21 +65,12 @@ def load_known_versions() -> dict[str, str]:
     known: dict[str, str] = {}
     try:
         with open(VERSIONS_FILE, "r", encoding="utf-8") as f:
-            seen_cc = False
             for line in f:
+                # Match table rows like: | **Claude Code** (CLI) | `2.1.110` | ...
                 m = re.search(r"\|\s*\*\*(.+?)\*\*.*?\|\s*`([^`]+)`\s*\|", line)
                 if m:
-                    name = m.group(1)
-                    ver  = m.group(2)
-                    key  = name.lower().replace(" ", "_").replace("/", "_")
-                    # Claude Code (CLI) と (VSCode ext) を区別
-                    if "claude_code" in key and "(cli)" in name.lower() and not seen_cc:
-                        known["claude_code_cli"] = ver
-                        seen_cc = True
-                    elif "claude_code" in key and "vscode" in name.lower():
-                        known["claude_code_vscode"] = ver
-                    else:
-                        known[key] = ver
+                    key = m.group(1).lower().replace(" ", "_")
+                    known[key] = m.group(2)
     except FileNotFoundError:
         pass
     return known
@@ -111,81 +79,59 @@ def load_known_versions() -> dict[str, str]:
 # 比較・レポート
 # ──────────────────────────────────────────────
 
-def print_release_note_reminder(tool: str, old: str, new: str) -> None:
-    url = RELEASE_NOTE_URLS.get(tool) or RELEASE_NOTE_URLS.get("Claude Code CLI")
-    print(f"\n📖 リリースノート確認 ({tool}: {old} → {new}):")
-    print(f"   URL: {url}")
-    print(f"   確認項目:")
-    print(f"     □ 新機能追加 → docs/INSTANCE_CONFIG.md に記録 → CLAUDE.md/devフローへ組み込み")
-    print(f"     □ WEB版制約の解消 → docs/INSTANCE_CONFIG.md の制約カタログを更新")
-    print(f"     □ モデル追加 → docs/tool-versions.md + INSTANCE_CONFIG.md を更新")
-    print(f"     □ Breaking Changes → 影響受けるEF/ワークフローを修正")
-
-
 def main() -> int:
     if WEB_MODE:
         print("=== WEB版モード: CLIコマンドは実行されません ===")
         print("以下のURLでリリースを手動確認してください:")
-        for tool, url in RELEASE_NOTE_URLS.items():
-            print(f"  {tool:<25}: {url}")
-        print()
-        print("Claude Opusモデル最新版 (2026-04-17): claude-opus-4-7")
-        print("  ⚠️ Opus 4.7 は Extended Thinking 非対応 → ultrathink は Sonnet 4.6 で実行")
+        print("  Claude Code  : https://github.com/anthropics/claude-code/releases")
+        print("  Gemini       : https://marketplace.visualstudio.com/items?itemName=google.geminicodeassist")
+        print("  Copilot      : https://marketplace.visualstudio.com/items?itemName=github.copilot")
+        print("  OpenAI models: https://platform.openai.com/docs/models")
         print("更新があれば docs/tool-versions.md を GitHub MCP 経由で更新してください。")
         return 0
 
-    print(f"=== バージョンチェック {TODAY} (Rule 22) ===")
+    print(f"=== バージョンチェック {TODAY} ===")
     updates: list[tuple[str, str, str]] = []  # (tool, old, new)
-    known = load_known_versions()
 
-    # ── Claude Code CLI ──
+    # Claude Code CLI
     cc_ver = get_claude_code_version()
-    cc_latest = get_latest_claude_code_version()
-    old_cc = known.get("claude_code_cli", "unknown")
-    print(f"Claude Code CLI  : 現在={cc_ver} / npm最新={cc_latest} (台帳={old_cc})")
-    if cc_latest != "unknown" and cc_ver != "unknown" and cc_latest != cc_ver:
-        print(f"  🆕 更新利用可能! → `npm update -g @anthropic-ai/claude-code` で更新")
+    known = load_known_versions()
+    old_cc = known.get("claude_code", "unknown")
+    print(f"Claude Code CLI : {cc_ver} (既知: {old_cc})")
     if cc_ver != "unknown" and cc_ver != old_cc:
         updates.append(("Claude Code CLI", old_cc, cc_ver))
 
-    # ── VSCode 拡張 ──
-    exts = get_vscode_ext_versions()
-    ext_map = {
-        "anthropic.claude-code":  ("Claude Code VSCode ext", "claude_code_vscode"),
-        "google.geminicodeassist": ("Gemini Code Assist",     "gemini_code_assist"),
-        "github.copilot":          ("GitHub Copilot",          "github_copilot"),
-        "openai.chatgpt":          ("OpenAI ChatGPT ext",      "openai_chatgpt"),
-    }
-    for ext_id, (name, key) in ext_map.items():
-        ver = exts.get(ext_id, "not installed")
-        old = known.get(key, "unknown")
-        print(f"{name:<30}: {ver} (台帳: {old})")
-        if ver not in ("not installed", "unknown") and ver != old:
-            updates.append((name, old, ver))
+    # VSCode 拡張
+    if not WEB_MODE:
+        exts = get_vscode_ext_versions()
+        ext_map = {
+            "anthropic.claude-code": ("Claude Code VSCode ext", "claude_code_vscode_ext"),
+            "google.geminicodeassist": ("Gemini Code Assist", "gemini_code_assist"),
+            "github.copilot": ("GitHub Copilot", "github_copilot"),
+            "openai.chatgpt": ("OpenAI ChatGPT ext", "openai_chatgpt"),
+        }
+        for ext_id, (name, key) in ext_map.items():
+            ver = exts.get(ext_id, "not installed")
+            old = known.get(key, "unknown")
+            print(f"{name:<30}: {ver} (既知: {old})")
+            if ver not in ("not installed", "unknown") and ver != old:
+                updates.append((name, old, ver))
 
-    # ── Flutter ──
+    # Flutter
     fl_ver = get_flutter_version()
-    old_fl = known.get("dart_flutter__sdk_", "unknown")
-    print(f"Flutter/Dart SDK               : {fl_ver} (台帳: {old_fl})")
+    old_fl = known.get("dart/flutter", "unknown")
+    print(f"Flutter/Dart SDK               : {fl_ver} (既知: {old_fl})")
     if fl_ver != "unknown" and fl_ver != old_fl:
         updates.append(("Flutter/Dart SDK", old_fl, fl_ver))
 
-    # ── Deno ──
+    # Deno
     deno_ver = get_deno_version()
     print(f"Deno                           : {deno_ver}")
 
-    # ── Claude モデル確認リマインダー ──
-    print()
-    print("📌 Claude API モデル確認 (台帳値):")
-    print(f"   Sonnet: {known.get('claude_sonnet__api_model_', 'claude-sonnet-4-6')}")
-    print(f"   Haiku : {known.get('claude_haiku__api_model_', 'claude-haiku-4-5')}")
-    print(f"   Opus  : {known.get('claude_opus__api_model_', 'claude-opus-4-7')}")
-    print("   ⚠️ Opus 4.7 は Extended Thinking 非対応 → ultrathink には Sonnet 4.6 を使用")
     print()
 
     if not updates:
         print("✅ すべて最新。バージョン変更なし。")
-        print("💡 新しい Claude モデルがリリースされた場合はユーザーが手動で教えてください。")
         return 0
 
     print(f"🆕 バージョン更新検出: {len(updates)} 件")
@@ -193,89 +139,90 @@ def main() -> int:
         print(f"   {tool}: {old} → {new}")
 
     print()
-    print("=" * 55)
-    print("📋 制約解消チェック + リリースノート確認 (Rule 22 Step 3-4)")
-    print("=" * 55)
+    print("=" * 50)
+    print("📋 制約解消チェック")
+    print("=" * 50)
 
     cc_updated = any("Claude Code" in t for t, _, _ in updates)
     if cc_updated:
         print("""
-Claude Code が更新されました:
-  □ WEB版で `notebooklm --version` が動くか → 解消なら INSTANCE_CONFIG.md 更新
+Claude Code が更新されました。WEB版の制約が解消されたか確認してください:
+  □ WEB版で `notebooklm --version` が動くか
   □ WEB版で `flutter analyze` が動くか
   □ WEB版で `deno lint` が動くか
   □ WEB版で `git status` が直接動くか
   □ Write ツールで絶対パスが使えるか
+解消されたら: docs/instance-constraints.md の該当行を削除/更新してください。
 """)
 
     gemini_updated = any("Gemini" in t for t, _, _ in updates)
     if gemini_updated:
         print("""
 Gemini Code Assist が更新されました:
-  □ Agent mode の安定稼働を確認
-  □ Flutter/Dart 補完品質を確認
-  □ コンテキスト上限の変化を確認
+  □ Agent mode が安定稼働するか確認
+  □ Flutter/Dart 補完品質に改善があるか
+  □ コンテキスト上限に変更があるか (リリースノート確認)
 """)
 
-    # リリースノート表示
-    if SHOW_RELEASE_NOTES or cc_updated or gemini_updated:
-        for tool, old, new in updates:
-            print_release_note_reminder(tool, old, new)
-
-    print()
-    print("📝 devフロー組み込みチェック (Rule 22 Step 4):")
-    print("   □ docs/INSTANCE_CONFIG.md の変更ログに追記")
-    print("   □ CLAUDE.md の該当 Rule に新機能を追記")
-    print("   □ docs/tool-versions.md のバージョン更新履歴を追記")
-    print("   □ 影響を受ける EF のモデルパラメータを更新")
+    copilot_updated = any("Copilot" in t for t, _, _ in updates)
+    if copilot_updated:
+        print("""
+GitHub Copilot が更新/インストールされました:
+  □ Copilot Edits (複数ファイル同時編集) が使えるか
+  □ Copilot Workspace が使えるか
+  □ `gh copilot suggest` CLI が動くか
+  → docs/tool-versions.md と docs/instance-constraints.md を更新してください。
+""")
 
     if AUTO_UPDATE:
         _update_versions_file(updates)
-        print(f"\n✅ docs/tool-versions.md を更新しました ({TODAY})")
+        print(f"✅ docs/tool-versions.md を更新しました ({TODAY})")
     else:
-        print("\n💡 自動更新: python3 scripts/check_versions.py --update")
-        print("💡 リリースノートも確認: python3 scripts/check_versions.py --release-notes")
+        print("💡 自動更新する場合: python3 scripts/check_versions.py --update")
 
     return 1  # 更新あり
 
 
 def _update_versions_file(updates: list[tuple[str, str, str]]) -> None:
     """tool-versions.md のバージョン数値を更新する"""
-    try:
-        with open(VERSIONS_FILE, "r", encoding="utf-8") as f:
-            content = f.read()
-    except FileNotFoundError:
-        print(f"⚠️  {VERSIONS_FILE} が見つかりません。先に作成してください。")
-        return
+    with open(VERSIONS_FILE, "r", encoding="utf-8") as f:
+        content = f.read()
 
     tool_to_row_key = {
-        "Claude Code CLI":        "Claude Code** (CLI)",
+        "Claude Code CLI": "Claude Code** (CLI)",
         "Claude Code VSCode ext": "Claude Code** (VSCode ext)",
-        "Gemini Code Assist":     "Gemini Code Assist** (VSCode ext)",
-        "GitHub Copilot":         "GitHub Copilot** (VSCode ext)",
-        "OpenAI ChatGPT ext":     "OpenAI ChatGPT** (VSCode ext)",
-        "Flutter/Dart SDK":       "Dart/Flutter** (SDK)",
+        "Gemini Code Assist": "Gemini Code Assist** (VSCode ext)",
+        "GitHub Copilot": "GitHub Copilot** (VSCode ext)",
+        "OpenAI ChatGPT ext": "OpenAI ChatGPT** (VSCode ext)",
+        "Flutter/Dart SDK": "Dart/Flutter** (SDK)",
     }
 
     for tool, old, new in updates:
         row_key = tool_to_row_key.get(tool)
-        if row_key and old not in ("unknown", "—"):
+        if row_key and old != "unknown":
             content = content.replace(
-                f"| `{old}` |",
-                f"| `{new}` |",
-                1,
+                f"{row_key} | `{old}`",
+                f"{row_key} | `{new}`",
+            )
+            # Also update the 最終確認日 column (second | after version)
+            # Simple approach: add history entry
+        elif row_key:
+            content = re.sub(
+                rf"(\| \*\*{re.escape(row_key)}\s*\|.*?)\|.*?\|.*?\|",
+                rf"\1| `{new}` | {TODAY} | — |",
+                content,
+                count=1,
             )
 
-    # 履歴エントリを追加 (既存の最後の履歴行の後に挿入)
-    history_entries = "\n".join(
-        f"| {TODAY} | {tool} | `{old}` | `{new}` | 要確認: {RELEASE_NOTE_URLS.get(tool, '')} | 要組み込み | — |"
+    # Append to history table
+    history_entry = "\n".join(
+        f"| {TODAY} | {tool} | `{old}` | `{new}` | 要確認 | — |"
         for tool, old, new in updates
     )
-    # 最後の履歴行を探して挿入
-    last_history_line = re.search(r"(\| 20\d{2}-\d{2}-\d{2} \|[^\n]+\n)(?!\| 20)", content)
-    if last_history_line:
-        insert_pos = last_history_line.end()
-        content = content[:insert_pos] + history_entries + "\n" + content[insert_pos:]
+    content = content.replace(
+        "| 2026-04-16 | Claude Code CLI | — | 2.1.110 | 初回記録 | — |",
+        f"| 2026-04-16 | Claude Code CLI | — | 2.1.110 | 初回記録 | — |\n{history_entry}",
+    )
 
     with open(VERSIONS_FILE, "w", encoding="utf-8") as f:
         f.write(content)

--- a/scripts/update_constraints_prompts.py
+++ b/scripts/update_constraints_prompts.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+update_constraints_prompts.py
+docs/instance-constraints.md の各インスタンス推奨プロンプトに
+セッション開始時バージョンチェック手順を追記する。
+"""
+import re, sys, os
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONSTRAINTS_FILE = os.path.join(REPO_ROOT, "docs", "instance-constraints.md")
+
+with open(CONSTRAINTS_FILE, "r", encoding="utf-8") as f:
+    content = f.read()
+
+# ---- VSCode版 ----
+OLD_VSCODE = """\
+### VSCode版
+
+```
+このインスタンスはVSCode版です。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、以下の順で実行してください:
+1. docs/cross-instance-prs/ の pending タスクをすべて処理
+2. Rule 16: 本番 https://my-web-app-b67f4.web.app/ をPlaywright MCP でスクリーンショット取得・表示チェック
+3. Rule 19: UI改善ツールチェーン (design-skills → Figma MCP → AIDesigner MCP → 実装)
+4. 新制約発見時は docs/instance-constraints.md に追記
+```"""
+
+NEW_VSCODE = """\
+### VSCode版
+
+```
+このインスタンスはVSCode版です。
+
+【セッション開始時必須】まずバージョンチェックを実行してください:
+  PYTHONUTF8=1 python3 scripts/check_versions.py
+バージョン更新があれば docs/tool-versions.md の制約解消チェックリストを確認し、
+解消済みなら docs/instance-constraints.md から該当行を削除して役割分担を見直すこと。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、以下の順で実行してください:
+1. docs/cross-instance-prs/ の pending タスクをすべて処理
+2. Rule 16: 本番 https://my-web-app-b67f4.web.app/ をPlaywright MCP でスクリーンショット取得・表示チェック
+3. Rule 19: UI改善ツールチェーン (design-skills → Figma MCP → AIDesigner MCP → 実装)
+4. 新制約発見時は docs/instance-constraints.md に追記
+```"""
+
+# ---- Windowsアプリ版 ----
+OLD_WIN = """\
+### Windowsアプリ版
+
+```
+このインスタンスはWindowsアプリ版です。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、標準フローで実行してください:
+1. Rule 10: docs/ 全件分析 (矛盾・鮮度切れ修正)
+2. AI大学: WebSearch で新規プロバイダー候補を調査 → migration 追加
+3. notebooklm Master Brain 更新 (PYTHONUTF8=1 必須)
+4. 新制約発見時は docs/instance-constraints.md に追記
+```"""
+
+NEW_WIN = """\
+### Windowsアプリ版
+
+```
+このインスタンスはWindowsアプリ版です。
+
+【セッション開始時必須】まずバージョンチェックを実行してください:
+  PYTHONUTF8=1 python3 scripts/check_versions.py
+バージョン更新があれば docs/tool-versions.md の制約解消チェックリストを確認し、
+解消済みなら docs/instance-constraints.md から該当行を削除して役割分担を見直すこと。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、標準フローで実行してください:
+1. Rule 10: docs/ 全件分析 (矛盾・鮮度切れ修正)
+2. AI大学: WebSearch で新規プロバイダー候補を調査 → migration 追加
+3. notebooklm Master Brain 更新 (PYTHONUTF8=1 必須)
+4. 新制約発見時は docs/instance-constraints.md に追記
+```"""
+
+# ---- PowerShell版 ----
+OLD_PS = """\
+### PowerShell版
+
+```
+このインスタンスはPowerShell版です (推奨モデル: ルーティンはclaude-haiku-4-5)。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、以下の順で実行してください:
+1. Rule 17: .github/workflows/ 最適化チェック (エラーステップ削除・timeout確認)
+2. quota-monitor.yml の実行結果確認 (ai_quota_usage テーブル)
+3. T-1 ブログ投稿タスクのスケジュール確認
+4. 新制約発見時は docs/instance-constraints.md に追記
+```"""
+
+NEW_PS = """\
+### PowerShell版
+
+```
+このインスタンスはPowerShell版です (推奨モデル: ルーティンはclaude-haiku-4-5)。
+
+【セッション開始時必須】まずバージョンチェックを実行してください:
+  PYTHONUTF8=1 python3 scripts/check_versions.py
+バージョン更新があれば docs/tool-versions.md の制約解消チェックリストを確認し、
+解消済みなら docs/instance-constraints.md から該当行を削除して役割分担を見直すこと。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、以下の順で実行してください:
+1. Rule 17: .github/workflows/ 最適化チェック (エラーステップ削除・timeout確認)
+2. quota-monitor.yml の実行結果確認 (ai_quota_usage テーブル)
+3. T-1 ブログ投稿タスクのスケジュール確認
+4. 新制約発見時は docs/instance-constraints.md に追記
+```"""
+
+# ---- WEB版 ----
+OLD_WEB = """\
+### WEB版
+
+```
+このインスタンスはWEB版(claude.ai/code)です。
+【制約】notebooklm CLI・flutter analyze・deno lint・ローカルCLI は実行不可。
+代替: notebooklm→WebSearch / git→GitHub MCP / analyze→cross-instance-pr依頼。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、WEB版許可タスクを実行してください:
+1. WebSearch で競合21社の最新情報をリサーチ → docs/competitor-reports/ に保存 (GitHub MCP)
+2. Rule 11: AI大学コンテンツ更新 (WebFetch → Supabase API 経由でupsert)
+3. GitHub MCP で open PR をレビュー (Code Review MCP 使用)
+4. 新制約発見時は docs/instance-constraints.md に追記 (GitHub MCP 経由でファイル更新)
+```"""
+
+NEW_WEB = """\
+### WEB版
+
+```
+このインスタンスはWEB版(claude.ai/code)です。
+【制約】notebooklm CLI・flutter analyze・deno lint・ローカルCLI は実行不可。
+代替: notebooklm→WebSearch / git→GitHub MCP / analyze→cross-instance-pr依頼。
+
+【セッション開始時必須】WEB版はCLIが使えないためWebFetchでリリース確認してください:
+  Claude Code  : https://github.com/anthropics/claude-code/releases
+  Gemini       : https://marketplace.visualstudio.com/items?itemName=google.geminicodeassist
+  Copilot      : https://marketplace.visualstudio.com/items?itemName=github.copilot
+  OpenAI models: https://platform.openai.com/docs/models
+バージョン変更があれば docs/tool-versions.md を GitHub MCP 経由で更新し、
+制約解消チェックリストを確認すること。
+
+.github/COMPRESSED_PROMPT_V3.md と docs/instance-constraints.md を確認してください。
+その後、WEB版許可タスクを実行してください:
+1. WebSearch で競合21社の最新情報をリサーチ → docs/competitor-reports/ に保存 (GitHub MCP)
+2. Rule 11: AI大学コンテンツ更新 (WebFetch → Supabase API 経由でupsert)
+3. GitHub MCP で open PR をレビュー (Code Review MCP 使用)
+4. 新制約発見時は docs/instance-constraints.md に追記 (GitHub MCP 経由でファイル更新)
+```"""
+
+replacements = [
+    (OLD_VSCODE, NEW_VSCODE, "VSCode版"),
+    (OLD_WIN,    NEW_WIN,    "Windowsアプリ版"),
+    (OLD_PS,     NEW_PS,     "PowerShell版"),
+    (OLD_WEB,    NEW_WEB,    "WEB版"),
+]
+
+changed = 0
+for old, new, name in replacements:
+    if old in content:
+        content = content.replace(old, new, 1)
+        print(f"✅ {name}: updated")
+        changed += 1
+    else:
+        print(f"⚠️  {name}: pattern not found — skipping")
+
+if changed == 0:
+    print("No changes made.")
+    sys.exit(1)
+
+with open(CONSTRAINTS_FILE, "w", encoding="utf-8") as f:
+    f.write(content)
+
+print(f"\nDone. {changed} section(s) updated in {CONSTRAINTS_FILE}")

--- a/scripts/update_cv3_instances.py
+++ b/scripts/update_cv3_instances.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Update COMPRESSED_PROMPT_V3.md instance section
+import re, sys
+
+path = 'C:/Users/kanta/GitHub/my_web_app/.claude/worktrees/frosty-hamilton/.github/COMPRESSED_PROMPT_V3.md'
+
+with open(path, 'r', encoding='utf-8') as f:
+    content = f.read()
+
+# ---- Find section boundaries ----
+start_marker = '## \U0001f500 4\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9 + Multi-AI'
+end_marker = '\n---\n\n## \U0001f3c6 \u7af6\u540821\u793e'
+
+start_idx = content.find(start_marker)
+end_idx   = content.find(end_marker, start_idx)
+
+if start_idx < 0 or end_idx < 0:
+    print(f'ERROR: markers not found (start={start_idx}, end={end_idx})')
+    sys.exit(1)
+
+print(f'Replacing chars {start_idx}..{end_idx}')
+
+new_section = '''\
+## \U0001f500 4\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9 + Multi-AI \u4e26\u884c\u958b\u767a\u30b9\u30b3\u30fc\u30d7\uff082026-04-16 \u66f4\u65b0\uff09
+
+> \u8a73\u7d30\u5236\u7d04\u30ed\u30b0\u30fb\u6700\u65b0\u6a5f\u80fd\u30fb\u6b21\u56de\u63a8\u5968\u30d7\u30ed\u30f3\u30d7\u30c8: **`docs/instance-constraints.md`** \u53c2\u7167\u3002
+> \u65b0\u5236\u7d04\u767a\u898b\u6642\u306f\u305d\u306e\u30d5\u30a1\u30a4\u30eb\u306b\u5373\u8ffd\u8a18\u3057\u3001\u3053\u306e\u8868\u306e\u5236\u7d04\u5217\u3082\u540c\u6642\u66f4\u65b0\u3059\u308b\u3053\u3068\u3002
+
+### Claude Code 4\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u69cb\u6210
+
+| \u30a4\u30f3\u30b9\u30bf\u30f3\u30b9 | \u62c5\u5f53\u7bc4\u56f2 | \u63a8\u5968\u30e2\u30c7\u30eb | \u63a8\u5968\u30e2\u30fc\u30c9 | \u4e3b\u306a\u5236\u7d04 |
+| --- | --- | --- | --- | --- |
+| **VSCode\u7248** | `lib/` + `supabase/functions/` + `docs/DESIGN.md` | `claude-sonnet-4-6` | \u901a\u5e38\u3002\u8907\u96d1UI\u8a2d\u8a08\u6642 **Extended Thinking** | \u306a\u3057 |
+| **Windows\u30a2\u30d7\u30ea\u7248** | `docs/` + `supabase/migrations/` + notebooklm CLI\u5c02\u4efb | `claude-sonnet-4-6` | \u901a\u5e38 + CAVEMAN | `PYTHONUTF8=1` \u5fc5\u9808 / xlsx\u30ed\u30c3\u30af\u6ce8\u610f |
+| **PowerShell\u7248** | `.github/workflows/` + `.mcp.json` | \u5b9a\u578b: `haiku-4-5` / \u8a2d\u8a08: `sonnet-4-6` | `/fast` (\u5b9a\u578b) / \u901a\u5e38 (\u8a2d\u8a08) | GHA `${{}}` \u306f env:\u30d6\u30ed\u30c3\u30af\u7d4c\u7531 |
+| **WEB\u7248** | `docs/blog-drafts/` + `docs/competitor-reports/` + GitHub PR/Issues | `claude-sonnet-4-6` | **Projects + Memory + Learning Mode** | notebooklm / flutter analyze / deno lint / \u30ed\u30fc\u30ab\u30ebCLI \u4e0d\u53ef |
+
+### Claude \u6700\u65b0\u6a5f\u80fd \u6d3b\u7528\u30ac\u30a4\u30c9
+
+| \u6a5f\u80fd | \u5bfe\u5fdc\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9 | \u4f7f\u3044\u6240 |
+| --- | --- | --- |
+| **Extended Thinking** | VSCode / Windows\u30a2\u30d7\u30ea | \u8907\u96d1UI\u8a2d\u8a08\u30fbDB schema\u30fb\u30a2\u30fc\u30ad\u30c6\u30af\u30c1\u30e3\u6c7a\u5b9a\u3002`claude-opus-4` \u63a8\u5968 |
+| **Projects\u6a5f\u80fd** | WEB\u7248 (claude.ai\u5c02\u7528) | \u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u6587\u8108\u30fbCLAUDE.md\u30fb\u5c65\u6b74\u3092\u30bb\u30c3\u30b7\u30e7\u30f3\u8d8a\u3048\u3067\u6c38\u7d9a\u5316 |
+| **Memory\u6a5f\u80fd** | WEB\u7248 (claude.ai\u5c02\u7528) | \u30e6\u30fc\u30b6\u30fc\u8a2d\u5b9a\u30fb\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u30b3\u30f3\u30c6\u30ad\u30b9\u30c8\u30fb\u3088\u304f\u4f7f\u3046\u30d1\u30bf\u30fc\u30f3\u3092\u8a18\u61b6 |
+| **Learning Mode** | WEB\u7248 (Projects\u7d4c\u7531) | Projects\u306b\u30ea\u30dd\u30b8\u30c8\u30ea\u30de\u30c3\u30d7\u30fbCLAUDE.md\u3092\u8aad\u307e\u305b\u308b\u3068\u6b21\u56de\u304b\u3089\u30b3\u30f3\u30c6\u30ad\u30b9\u30c8\u521d\u671f\u5316\u4e0d\u8981 |
+| **Interleaved Thinking** | \u5168\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9 | \u30c4\u30fc\u30eb\u5b9f\u884c\u4e2d\u306b\u3082\u601d\u8003\u3092\u7d99\u7d9a\u3002\u591a\u30b9\u30c6\u30c3\u30d7\u30bf\u30b9\u30af\u3067\u81ea\u52d5\u9069\u7528 |
+| **CAVEMAN\u30e2\u30fc\u30c9** | Windows\u30a2\u30d7\u30ea / PowerShell \u4e3b\u4f53 | \u30b3\u30df\u30e5\u30cb\u30b1\u30fc\u30b7\u30e7\u30f3\u30c8\u30fc\u30af\u30f3\uff5e75%\u524a\u6e1b |
+
+### \u5916\u90e8AI \u6700\u65b0\u30e2\u30c7\u30eb\u30fb\u6a5f\u80fd
+
+| AI | \u6700\u65b0\u30e2\u30c7\u30eb | \u4e3b\u306a\u6a5f\u80fd | \u3053\u306e\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3067\u306e\u7528\u9014 |
+| --- | --- | --- | --- |
+| **GitHub Copilot** | GPT-4o / Claude Sonnet / Gemini Pro \u9078\u62e9\u53ef | Inline\u88dc\u5b8c / Copilot Edits (\u8907\u6570\u30d5\u30a1\u30a4\u30eb\u540c\u6642\u7de8\u96c6) / Copilot Workspace (Issue\u2192PR\u81ea\u52d5) / `@workspace` | VSCode\u7248: Edits\u3067Flutter\u591a\u30d5\u30a1\u30a4\u30eb\u7de8\u96c6 / PS\u7248: `gh copilot suggest` |
+| **Gemini Code Assist** | Gemini 2.5 Pro (2M\u30c8\u30fc\u30af\u30f3) / Flash | Agent mode / Flutter/Dart\u7279\u5316 / \u5927\u898f\u6a21\u30ea\u30d5\u30a1\u30af\u30bf | EF\u5168\u4f53\u6a2a\u65ad\u5206\u6790 / Dart\u5927\u898f\u6a21\u30ea\u30d5\u30a1\u30af\u30bf |
+| **OpenAI CODEX** | o3 (\u6700\u5f37\u63a8\u8ad6) / o4-mini (\u9ad8\u901f\u4f4e\u30b3\u30b9\u30c8) / Codex CLI | SQL\u6700\u9069\u5316 / \u30a2\u30eb\u30b4\u30ea\u30ba\u30e0 / \u30bf\u30fc\u30df\u30ca\u30eb\u76f4\u5b9f\u884c | Supabase\u30af\u30a8\u30ea\u6700\u9069\u5316 / PS\u7248: `codex` CLI |
+
+### AI\u9078\u629e\u30d5\u30ed\u30fc
+
+```text
+\u884c\u30ec\u30d9\u30eb\u88dc\u5b8c                  -> GitHub Copilot Inline (Ctrl+Enter)
+\u8907\u6570\u30d5\u30a1\u30a4\u30eb\u540c\u6642\u7de8\u96c6 (VSCode)    -> Copilot Edits
+\u8907\u96d1\u306aDart/Flutter              -> Gemini 2.5 Pro (\u9577\u30b3\u30f3\u30c6\u30ad\u30b9\u30c8+Flutter\u7279\u5316)
+SQL / \u30a2\u30eb\u30b4\u30ea\u30ba\u30e0\u6700\u9069\u5316          -> CODEX o3/o4-mini
+\u8a2d\u8a08\u30fb\u6226\u7565\u30fb\u9577\u671f\u5224\u65ad            -> Claude Code (Memory + ROADMAP)
+\u8907\u96d1\u306a\u63a8\u8ad6\u30fb\u30a2\u30fc\u30ad\u30c6\u30af\u30c1\u30e3       -> Claude Extended Thinking (opus/sonnet)
+\u30d6\u30ed\u30b0 / \u7af6\u5408\u30ea\u30b5\u30fc\u30c1           -> WEB\u7248 (WebSearch/WebFetch/Projects)
+NotebookLM Deep Research      -> Windows\u30a2\u30d7\u30ea\u7248\u5c02\u4efb (notebooklm CLI)
+Issue -> PR \u5168\u81ea\u52d5              -> Copilot Workspace
+```
+
+### \u5236\u7d04\u767a\u898b\u6642\u306e\u66f4\u65b0\u30d5\u30ed\u30fc\uff08\u5168\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u5171\u901a\uff09
+
+```text
+Step 1: docs/instance-constraints.md \u306e\u300c\u5236\u7d04\u767a\u898b\u30ed\u30b0\u300d\u306b\u8ffd\u8a18
+Step 2: \u3053\u306e\u8868\u306e\u5236\u7d04\u5217\u3092\u66f4\u65b0
+Step 3: memory/feedback_correction_YYYYMMDD.md \u306b\u8a18\u9332
+Step 4: cross-instance-pr \u3067\u4ed6\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u3078\u5468\u77e5
+```
+
+### \u30af\u30aa\u30fc\u30bf\u76e3\u8996 (quota-monitor.yml \u6bce\u65e5 09:00 JST)
+
+| \u30c4\u30fc\u30eb | \u76e3\u8996\u65b9\u6cd5 | \u30a2\u30e9\u30fc\u30c8\u9583\u5024 |
+| --- | --- | --- |
+| Claude (Anthropic API) | `/v1/usage` | \u6708\u6b21 $50 |
+| OpenAI (CODEX) | `/v1/usage` | \u6708\u6b21 $20 |
+| Gemini Code Assist | Google Cloud Monitoring | \u6708\u6b21\u30af\u30aa\u30fc\u30bf 80% |
+| GitHub Copilot | `/user/copilot_billing` | \u30b7\u30fc\u30c8\u6570\u4e0a\u9650\u8fd1\u63a5 |
+
+**\u7dca\u6025\u6a2a\u65ad\u6a29\u9650**: blocking \u6642\u306f `docs/cross-instance-prs/YYYYMMDD_<\u5185\u5bb9>.md` \u306b\u63d0\u6848\u3092\u30b3\u30df\u30c3\u30c8\u3002\u62c5\u5f53\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u304c\u6b21\u30bb\u30c3\u30b7\u30e7\u30f3\u3067\u63a1\u5426\u3002
+**\u7af6\u5408\u56de\u907f\u30d1\u30bf\u30fc\u30f3**: `git stash -> git pull --rebase origin main -> git push -> git stash pop`\
+'''
+
+content = content[:start_idx] + new_section + content[end_idx:]
+
+with open(path, 'w', encoding='utf-8') as f:
+    f.write(content)
+
+print(f'Done. New content length: {len(content)}')

--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -101,6 +101,11 @@ interface AIRequest {
     promptTemplate?: string;
     skillModel?: string;
     skillTags?: string[];
+    // 音声AIチャット (long-term memory)
+    message?: string;
+    conversationId?: string;
+    conversationContext?: string;  // 'general_chat' | 'ai_university_quiz' | 'habit_coach'
+    voiceUsed?: boolean;
 }
 
 interface Fighter {
@@ -749,6 +754,85 @@ ${entryData}`;
              return new Response(JSON.stringify({ success: true, result }), { headers: corsHeaders });
         }
 
+        // ===== 音声AIチャット: 長期記憶付き会話 =====
+        if (action === 'chat') {
+            const userMessage = requestData.message ?? requestContent ?? '';
+            if (!userMessage.trim()) {
+                return new Response(JSON.stringify({ success: false, error: 'message is required' }), { headers: corsHeaders, status: 400 });
+            }
+
+            // サービスロールクライアント (RLS bypass で会話履歴を読み書き)
+            const serviceClient = createClient(
+                Deno.env.get('SUPABASE_URL') ?? '',
+                Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+            );
+
+            let conversationId: string = requestData.conversationId ?? '';
+
+            // 会話セッションが無ければ新規作成
+            if (!conversationId) {
+                const { data: conv, error: convErr } = await serviceClient
+                    .from('user_conversations')
+                    .insert({
+                        user_id: user.id,
+                        title: userMessage.slice(0, 50),
+                        context: requestData.conversationContext ?? 'general_chat',
+                    })
+                    .select('id')
+                    .single();
+                if (convErr) throw new Error(`Failed to create conversation: ${convErr.message}`);
+                conversationId = conv.id as string;
+            }
+
+            // 直近10件の会話履歴を取得 (長期記憶注入)
+            const { data: history } = await serviceClient
+                .from('conversation_messages')
+                .select('role, content')
+                .eq('conversation_id', conversationId)
+                .order('created_at', { ascending: false })
+                .limit(10);
+
+            const historyMessages = (history ?? []).reverse();
+            const historyText = historyMessages.length > 0
+                ? historyMessages.map((m: { role: string; content: string }) => `[${m.role}]: ${m.content}`).join('\n')
+                : '';
+
+            const prompt = historyText
+                ? `以下はこれまでの会話履歴です:\n${historyText}\n\n---\n[user]: ${userMessage}`
+                : userMessage;
+
+            // ユーザーメッセージを保存
+            await serviceClient.from('conversation_messages').insert({
+                conversation_id: conversationId,
+                role: 'user',
+                content: userMessage,
+                voice_used: requestData.voiceUsed ?? false,
+            });
+
+            // AI応答生成
+            const reply = await runPromptWithStrategy(prompt);
+
+            // アシスタントメッセージを保存
+            const { data: savedMsg } = await serviceClient
+                .from('conversation_messages')
+                .insert({
+                    conversation_id: conversationId,
+                    role: 'assistant',
+                    content: reply,
+                    model: targetModel ?? DEFAULT_SYNTHESIS_MODEL,
+                    voice_used: false,
+                })
+                .select('id')
+                .single();
+
+            return new Response(JSON.stringify({
+                success: true,
+                reply,
+                conversationId,
+                messageId: savedMsg?.id ?? null,
+            }), { headers: corsHeaders });
+        }
+
         return new Response(JSON.stringify({
             success: false,
             error: `Action "${action}" not found`,
@@ -759,6 +843,7 @@ ${entryData}`;
                 'improve', 'summarize', 'expand', 'translate',
                 'suggest_title', 'custom_prompt',
                 'save_skill', 'list_skills', 'delete_skill', 'run_skill',
+                'chat',
             ],
         }), { headers: corsHeaders, status: 404 });
 

--- a/supabase/migrations/20260416140000_create_conversation_messages.sql
+++ b/supabase/migrations/20260416140000_create_conversation_messages.sql
@@ -1,0 +1,83 @@
+-- 音声AIアシスタント 会話履歴テーブル
+-- Windows版#64 2026-04-16
+-- Voice AI GMAT Tutor パターンを自分株式会社に適用
+-- 長期記憶: 直近10件のメッセージをAIプロンプトに注入
+
+-- ユーザー会話セッション
+CREATE TABLE IF NOT EXISTS user_conversations (
+  id           uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id      uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  title        text,                          -- 任意タイトル (AIが自動生成可)
+  context      text NOT NULL DEFAULT 'general_chat',
+                                              -- 'general_chat' | 'ai_university_quiz' | 'habit_coach' | 'daily_journal'
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- 会話メッセージ (user/assistant の往復)
+CREATE TABLE IF NOT EXISTS conversation_messages (
+  id               uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  conversation_id  uuid REFERENCES user_conversations(id) ON DELETE CASCADE,
+  role             text NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+  content          text NOT NULL,
+  model            text,                      -- 応答したAIモデル (claude-sonnet-4-6 等)
+  voice_used       boolean NOT NULL DEFAULT false,  -- 音声入力/出力フラグ
+  tokens_used      integer,                   -- トークン数 (クォータ監視用)
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- インデックス: 会話別・時系列取得 (長期記憶注入の直近10件クエリ)
+CREATE INDEX IF NOT EXISTS conv_messages_conv_id_created
+  ON conversation_messages (conversation_id, created_at DESC);
+
+-- インデックス: ユーザー別会話一覧
+CREATE INDEX IF NOT EXISTS user_conversations_user_id
+  ON user_conversations (user_id, updated_at DESC);
+
+-- updated_at 自動更新トリガー
+CREATE OR REPLACE FUNCTION update_conversation_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE user_conversations SET updated_at = now()
+  WHERE id = NEW.conversation_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER conversation_messages_after_insert
+  AFTER INSERT ON conversation_messages
+  FOR EACH ROW EXECUTE FUNCTION update_conversation_updated_at();
+
+-- RLS: ユーザーは自分のデータのみアクセス可
+ALTER TABLE user_conversations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE conversation_messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "conversations_own_user"
+  ON user_conversations
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "conv_messages_own_user"
+  ON conversation_messages
+  USING (
+    EXISTS (
+      SELECT 1 FROM user_conversations
+      WHERE id = conversation_messages.conversation_id
+        AND user_id = auth.uid()
+    )
+  );
+
+-- サービスロールはすべてのデータにアクセス可 (AI assistant EF 用)
+CREATE POLICY "conversations_service_role"
+  ON user_conversations FOR ALL
+  USING (auth.role() = 'service_role');
+
+CREATE POLICY "conv_messages_service_role"
+  ON conversation_messages FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- コメント
+COMMENT ON TABLE user_conversations IS 'ユーザーとAIの会話セッション。音声AIアシスタント・AI大学クイズ・習慣コーチ等で使用。';
+COMMENT ON TABLE conversation_messages IS '会話メッセージ履歴。長期記憶として直近10件をAIプロンプトに注入する (Voice AI GMAT Tutor パターン)。';
+COMMENT ON COLUMN user_conversations.context IS 'general_chat | ai_university_quiz | habit_coach | daily_journal';
+COMMENT ON COLUMN conversation_messages.voice_used IS '音声入力 (STT) または音声出力 (TTS) を使用した場合 true';
+COMMENT ON COLUMN conversation_messages.tokens_used IS 'ai_quota_usage テーブルとの連携用トークン数記録';


### PR DESCRIPTION
## Summary

- `supabase/functions/ai-assistant/index.ts` — `chat` action 追加 (長期記憶付き音声AIチャット)
- `supabase/migrations/20260416140000_create_conversation_messages.sql` — 会話履歴テーブル作成
- `scripts/check_versions.py` — Claude Code/フォールバックAIバージョン自動確認スクリプト
- `scripts/update_constraints_prompts.py` / `update_cv3_instances.py` — インスタンス制約プロンプト自動更新
- `docs/instance-constraints.md` / `docs/tool-versions.md` — 制約台帳・バージョン台帳
- `docs/plans/20260416_voice_ai_chat_ui.md` — Voice AI Chat UI設計ドキュメント
- CLAUDE.md / COMPRESSED_PROMPT_V3.md / GROWTH_STRATEGY_ROADMAP.md 各種更新

## ⚠️ 注意: コンフリクトあり

以下のファイルは main と frosty-hamilton 双方で変更されているためコンフリクトが発生します:
- `CLAUDE.md`
- `.github/COMPRESSED_PROMPT_V3.md`
- `docs/GROWTH_STRATEGY_ROADMAP.md`
- `docs/tool-versions.md` (main のほうが新しい — frosty-hamilton 版は破棄推奨)
- `supabase/functions/ai-assistant/index.ts` (main 側に deno-lint-ignore fix あり)

**推奨**: main の最新状態を ours として解決し、frosty-hamilton からは migration + scripts のみ採用する。

## Test plan

- [ ] `deno lint supabase/functions/ai-assistant/index.ts` — 0エラー確認
- [ ] `flutter analyze` — 0エラー確認
- [ ] conversation_messages マイグレーション実行確認
- [ ] ai-assistant `chat` action エンドポイントテスト
- [ ] deploy-prod CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)