### PR TITLE
fix: cockpit ActionChip label contrast on dark theme

### DIFF
--- a/lib/widgets/home_tier/system_fixed_features_list.dart
+++ b/lib/widgets/home_tier/system_fixed_features_list.dart
@@ -14,7 +14,13 @@ class SystemFixedFeaturesList extends StatelessWidget {
         children: kHomeSystemFixed.map((f) {
           return ActionChip(
             avatar: Icon(f.icon, size: 16, color: f.color),
-            label: Text(f.label, style: const TextStyle(fontSize: 12)),
+            label: Text(
+              f.label,
+              style: const TextStyle(
+                fontSize: 12,
+                color: Color(0xFFE2E8F0),
+              ),
+            ),
             backgroundColor: const Color(0xFF1A1A1A),
             side: BorderSide(color: f.color.withValues(alpha: 0.3)),
             onPressed: () => Navigator.pushNamed(context, f.route),


### PR DESCRIPTION
## Summary

経営コックピット (`/home`) の「システム固定機能」セクションで、pill 形 ActionChip のラベル (AI秘書 / デイリー判定 / ノート / AI大学) がダーク背景 (`#1A1A1A`) 上で低コントラストになり読めない問題を修正。

## 変更内容

`lib/widgets/home_tier/system_fixed_features_list.dart`:
```dart
// Before
label: Text(f.label, style: const TextStyle(fontSize: 12)),
// After
label: Text(
  f.label,
  style: const TextStyle(fontSize: 12, color: Color(0xFFE2E8F0)),
),
```

## 発見経緯

iPhone で本番サイト <https://my-web-app-b67f4.web.app/> を開いたユーザーから screenshot 付き報告。mobile-bug-triage skill に従い Issue → PR の順で対応。

## Closes

- #503

## Test plan

- [x] `flutter analyze lib/widgets/home_tier/system_fixed_features_list.dart` — No issues found
- [x] `dart format --set-exit-if-changed` — 0 changed
- [ ] CI (Lint, Format, Test) 全通過
- [ ] デプロイ後 iPhone / Android 実機でラベル視認性確認 (Phase C)

## mobile-bug-triage checklist

- [x] Touch target ≥ 48dp (ActionChip 既定 OK)
- [x] dark mode contrast 改善 (slate-200 #E2E8F0 → background #1A1A1A で WCAG AA 合格)
- [x] Light mode 影響確認済 (ダーク前提のため問題なし)

## Philosophy alignment

原則 3 (優しい mentor) — 読めない UI は支援にならない

---

🤖 Generated via mobile-bug-triage workflow — 📱 スマホ版 Claude Code
https://claude.ai/code/session_01TdAKpsFQxxqWGteB8wVAoK