### PR TITLE
perf + fix: Notion import memory opt & AI大学 X share (WEB版)

### DIFF
--- a/lib/pages/gemini_university_v2_page.dart
+++ b/lib/pages/gemini_university_v2_page.dart
@@ -2901,6 +2901,15 @@ class _AiUniversityPageState extends State<AiUniversityPage>
             '$url';
     }
 
+    // Web: OS native share sheet omits X on Windows/desktop → open X intent
+    // directly. Native platforms keep the familiar SharePlus flow.
+    if (kIsWeb) {
+      final intent = Uri.parse(
+        'https://twitter.com/intent/tweet?text=${Uri.encodeComponent(text)}',
+      );
+      await launchUrl(intent, mode: LaunchMode.externalApplication);
+      return;
+    }
     await SharePlus.instance.share(ShareParams(text: text));
   }
 

--- a/lib/widgets/ai_university_home_card.dart
+++ b/lib/widgets/ai_university_home_card.dart
@@ -1,9 +1,11 @@
 import 'dart:math' show max, min;
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// AI大学ホームカード — ホーム最上部に表示するキラーコンテンツバナー
 ///
@@ -149,6 +151,15 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
             '$learnedText$streakText\n'
             'https://my-web-app-b67f4.web.app/#/ai-university';
 
+    // Web: OS native share sheet omits X on Windows/desktop → open X intent
+    // directly. Native platforms keep the familiar SharePlus flow.
+    if (kIsWeb) {
+      final intent = Uri.parse(
+        'https://twitter.com/intent/tweet?text=${Uri.encodeComponent(shareText)}',
+      );
+      await launchUrl(intent, mode: LaunchMode.externalApplication);
+      return;
+    }
     await SharePlus.instance.share(
       ShareParams(text: shareText),
     );

--- a/supabase/functions/growth-import-preview/notion_api.test.ts
+++ b/supabase/functions/growth-import-preview/notion_api.test.ts
@@ -155,3 +155,54 @@ Deno.test("fetchNotionBlockTree handles pagination and depth warnings", async ()
   ]);
   assertStrictEquals(urlCalls.length, 3);
 });
+
+Deno.test("fetchNotionBlockTree strips unused Notion metadata to save memory", async () => {
+  const fetchImpl: typeof fetch = () =>
+    Promise.resolve(Response.json({
+      results: [
+        {
+          id: "b1",
+          type: "paragraph",
+          object: "block",
+          created_time: "2026-01-01T00:00:00.000Z",
+          last_edited_time: "2026-01-02T00:00:00.000Z",
+          created_by: { object: "user", id: "u1" },
+          last_edited_by: { object: "user", id: "u2" },
+          parent: { type: "page_id", page_id: "p1" },
+          archived: false,
+          has_children: false,
+          paragraph: {
+            color: "default",
+            rich_text: [
+              {
+                plain_text: "hi",
+                type: "text",
+                annotations: {
+                  bold: true,
+                  italic: false,
+                  color: "red",
+                },
+                href: "https://example.com",
+                text: { content: "hi", link: { url: "https://example.com" } },
+              },
+            ],
+          },
+        },
+      ],
+      has_more: false,
+      next_cursor: null,
+    }));
+
+  const result = await fetchNotionBlockTree("root", {
+    headers: { Authorization: "Bearer token" },
+    fetchImpl,
+  });
+
+  assertStrictEquals(result.blocks.length, 1);
+  const block = result.blocks[0];
+  assertEquals(Object.keys(block).sort(), ["id", "paragraph", "type"]);
+  const paragraph = block.paragraph as { rich_text: { plain_text: string }[] };
+  assertEquals(paragraph.rich_text, [{ plain_text: "hi" }]);
+  assertStrictEquals((block as Record<string, unknown>).created_time, undefined);
+  assertStrictEquals((block as Record<string, unknown>).parent, undefined);
+});

--- a/supabase/functions/growth-import-preview/notion_api.ts
+++ b/supabase/functions/growth-import-preview/notion_api.ts
@@ -301,6 +301,30 @@ async function searchNotionObjects<T>(
   return results;
 }
 
+// Strip Notion's heavy per-block metadata (annotations, mentions, timestamps,
+// parent refs, etc.) so recursive previews hold only the text we actually render.
+function slimNotionBlock(rawBlock: NotionBlockNode): NotionBlockNode {
+  const slim: NotionBlockNode = { type: rawBlock.type };
+  if (rawBlock.id) slim.id = rawBlock.id;
+  if (rawBlock.has_children) slim.has_children = rawBlock.has_children;
+
+  const inner = rawBlock[rawBlock.type] as NotionBlockInner | undefined;
+  if (inner) {
+    const slimInner: NotionBlockInner = {};
+    if (inner.rich_text?.length) {
+      slimInner.rich_text = inner.rich_text.map((text) => ({
+        plain_text: text.plain_text ?? "",
+      }));
+    }
+    if (inner.checked !== undefined) slimInner.checked = inner.checked;
+    if (inner.title !== undefined) slimInner.title = inner.title;
+    if (inner.language !== undefined) slimInner.language = inner.language;
+    slim[rawBlock.type] = slimInner;
+  }
+
+  return slim;
+}
+
 export async function fetchNotionBlockTree(
   blockId: string,
   options: BlockTreeOptions,
@@ -347,7 +371,7 @@ export async function fetchNotionBlockTree(
         }
 
         state.remainingBlocks--;
-        const block: NotionBlockNode = { ...rawBlock };
+        const block = slimNotionBlock(rawBlock);
 
         if (block.has_children && block.id) {
           if (depth >= maxDepth) {
@@ -386,7 +410,8 @@ export async function buildNotionApiPreview(
     "Content-Type": "application/json",
   };
 
-  const warnings: string[] = [];
+  const warningSet = new Set<string>();
+  const addWarning = (warning: string) => warningSet.add(warning);
   const notes: ImportedNoteDraft[] = [];
 
   const pages = await searchNotionObjects<NotionPage>(
@@ -406,9 +431,9 @@ export async function buildNotionApiPreview(
         ...options,
       });
       content = notionBlocksToText(blockTree.blocks);
-      warnings.push(...blockTree.warnings);
+      blockTree.warnings.forEach(addWarning);
     } catch {
-      warnings.push(`Failed to fetch content for "${title}".`);
+      addWarning(`Failed to fetch content for "${title}".`);
     }
 
     notes.push({
@@ -451,11 +476,11 @@ export async function buildNotionApiPreview(
       }
     }
   } catch {
-    warnings.push("Failed to search for Notion databases.");
+    addWarning("Failed to search for Notion databases.");
   }
 
   if (notes.length === 0) {
-    warnings.push(
+    addWarning(
       "No pages or database entries found. Check the integration token and page access permissions.",
     );
   }
@@ -465,7 +490,7 @@ export async function buildNotionApiPreview(
     sourceLabel: "Notion (API連携)",
     fileName: "notion_api",
     notes,
-    warnings,
+    warnings: Array.from(warningSet),
     previewMode: "edge-function",
   };
 }


### PR DESCRIPTION
## Summary

WEB版 セッション (旧ルール) で実装した 2 件をマージ。次セッションからは report-only 体制に移行。

- **perf(growth-import-preview)**: Notion API ブロック取得で重い metadata (annotations/mentions/timestamps/parent 等) を剥がして slim 化 + warnings を Set でデデュープ。深いページ × 200 ブロック × 複数ページの RAM 圧を削減。
- **fix(ai-university)**: Windows/desktop で `share_plus` が OS ネイティブ共有シート (Outlook/Teams/Copilot/近距離共有) に流れて X が選べなかった不具合を修正。Web では `https://twitter.com/intent/tweet` を `url_launcher` で直接開く (native は SharePlus 継続)。`AppShareService.shareToTwitter` と同じ定石パターン。

## Commits

- `ce3666b` perf(growth-import-preview): slim Notion blocks + dedupe warnings
- `3884ef8` fix(ai-university): open X intent directly on Web share

## Test plan

- [ ] VSCode版で `flutter analyze` 0 エラー確認
- [ ] VSCode版で `deno lint supabase/functions/growth-import-preview/` 0 エラー確認
- [ ] VSCode版で `deno test supabase/functions/growth-import-preview/notion_api.test.ts` 全通過 (新規 slim block 回帰テスト含む)
- [ ] 本番 deploy 後、Windows Chrome で AI大学シェアボタン → X intent が直接開くことを確認
- [ ] iOS/Android ネイティブで SharePlus シートが従来どおり開くことを確認

## 次セッションからの体制

WEB版は **report-only** (screenshot → Issue 発行) に移行。実装は PS#5 (on-call) が拾う。
