### PR TITLE
auto: issue #660 [追加要望] 長期：独自ユーザーデータをファインチューニングに活用（Scale EGP的アプローチ）

### DIFF
--- a/docs/issue-fix-plans/issue-660.md
+++ b/docs/issue-fix-plans/issue-660.md
@@ -1,0 +1,48 @@
+# Issue Fix Plan #660
+
+- Issue: [[追加要望] 長期：独自ユーザーデータをファインチューニングに活用（Scale EGP的アプローチ）](https://github.com/kanta13jp1/my_web_app/issues/660)
+- Labels: enhancement
+- Workflow: `.github/workflows/github-issue-fix.yml`
+- CI repair pair: `.github/workflows/ci-auto-fix.yml`
+- Run: https://github.com/kanta13jp1/my_web_app/actions/runs/24918786745
+
+## Goal
+
+[追加要望] 長期：独自ユーザーデータをファインチューニングに活用（Scale EGP的アプローチ）
+
+## Current Context
+
+```text
+Home画面の追加要望フォームから登録されました。
+
+## 要望
+長期：独自ユーザーデータをファインチューニングに活用（Scale EGP的アプローチ）
+
+## 期待する成果
+長期：独自ユーザーデータをファインチューニングに活用（Scale EGP的アプローチ）
+
+## 分類
+- カテゴリ: 機能追加
+- 優先度: medium
+- 登録者: kanta13jp@gmail.com
+- 登録日時: 2026-04-22T16:59:48.326Z
+
+## WBS連携
+このIssue作成後、同じ内容をWBSのユーザー要望タスクとして登録します。
+
+```
+
+## Autonomous Repair Loop
+
+1. Reproduce the smallest failing path for this issue.
+2. Apply the minimum safe fix on this branch.
+3. Let normal CI run on the draft PR.
+4. If CI fails on mechanical issues, `ci-auto-fix.yml` attempts `dart fix --apply` and `deno fmt`.
+5. Merge only after CI is green and the issue scope is satisfied.
+
+## Checklist
+
+- [ ] Reproduction is clear
+- [ ] Smallest safe fix is implemented
+- [ ] Analyze/tests/CI are checked
+- [ ] PR notes explain the change and the remaining risk


### PR DESCRIPTION
## Summary

- bootstrap the autonomous repair lane for #660
- create a dedicated fix branch and plan file
- pair this lane with `ci-auto-fix.yml` for small CI repair commits

Closes #660

## Repair Loop

1. `github-issue-fix.yml` created branch `issue-fix/660-scale-egp-24918786745`
2. make the smallest fix needed for the issue
3. let CI run normally
4. if CI fails on mechanical fixes, `ci-auto-fix.yml` will try `dart fix --apply` and `deno fmt`
5. merge after green CI and issue-scope confirmation

## Plan File

- `docs/issue-fix-plans/issue-660.md`
