### PR TITLE
feat(krisp): add AI coach SDK handoff gates (#755)

### DIFF
--- a/docs/issue-fix-plans/issue-755.md
+++ b/docs/issue-fix-plans/issue-755.md
@@ -40,9 +40,15 @@ Home画面の追加要望フォームから登録されました。
 4. If CI fails on mechanical issues, `ci-auto-fix.yml` attempts `dart fix --apply` and `deno fmt`.
 5. Merge only after CI is green and the issue scope is satisfied.
 
+## Codex #1 Update
+
+- Added explicit SDK readiness gates for the future AI coach flow.
+- Added a browser-side audio pipeline handoff from mic capture through Krisp filtering, VAD, STT, and coach response.
+- Kept external blockers visible: Krisp SDK contract/API key and model distribution terms are still user/vendor decisions.
+
 ## Checklist
 
-- [ ] Reproduction is clear
-- [ ] Smallest safe fix is implemented
-- [ ] Analyze/tests/CI are checked
-- [ ] PR notes explain the change and the remaining risk
+- [x] Reproduction is clear
+- [x] Smallest safe fix is implemented
+- [x] Analyze/tests are checked locally
+- [x] PR notes explain the change and the remaining risk

--- a/docs/issue-fix-plans/issue-755.md
+++ b/docs/issue-fix-plans/issue-755.md
@@ -1,0 +1,48 @@
+# Issue Fix Plan #755
+
+- Issue: [[追加要望] 【Krisp】SDKを使った音声機能組み込み（将来のAIコーチ機能）](https://github.com/kanta13jp1/my_web_app/issues/755)
+- Labels: 
+- Workflow: `.github/workflows/github-issue-fix.yml`
+- CI repair pair: `.github/workflows/ci-auto-fix.yml`
+- Run: https://github.com/kanta13jp1/my_web_app/actions/runs/24945446240
+
+## Goal
+
+[追加要望] 【Krisp】SDKを使った音声機能組み込み（将来のAIコーチ機能）
+
+## Current Context
+
+```text
+Home画面の追加要望フォームから登録されました。
+
+## 要望
+【Krisp】SDKを使った音声機能組み込み（将来のAIコーチ機能）
+
+## 期待する成果
+【Krisp】SDKを使った音声機能組み込み（将来のAIコーチ機能）
+
+## 分類
+- カテゴリ: 機能追加
+- 優先度: medium
+- 登録者: kanta13jp@gmail.com
+- 登録日時: 2026-04-25T16:18:04.656Z
+
+## WBS連携
+このIssue作成後、同じ内容をWBSのユーザー要望タスクとして登録します。
+
+```
+
+## Autonomous Repair Loop
+
+1. Reproduce the smallest failing path for this issue.
+2. Apply the minimum safe fix on this branch.
+3. Let normal CI run on the draft PR.
+4. If CI fails on mechanical issues, `ci-auto-fix.yml` attempts `dart fix --apply` and `deno fmt`.
+5. Merge only after CI is green and the issue scope is satisfied.
+
+## Checklist
+
+- [ ] Reproduction is clear
+- [ ] Smallest safe fix is implemented
+- [ ] Analyze/tests/CI are checked
+- [ ] PR notes explain the change and the remaining risk

--- a/lib/pages/krisp_audio_quality_page.dart
+++ b/lib/pages/krisp_audio_quality_page.dart
@@ -32,6 +32,9 @@ class _KrispAudioQualityPageState extends State<KrispAudioQualityPage> {
   @override
   Widget build(BuildContext context) {
     final plan = _plan;
+    final handoff = plan.scenario == KrispAudioScenario.aiCoachSdk
+        ? _service.buildAiCoachHandoff()
+        : null;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Scaffold(
       backgroundColor:
@@ -84,6 +87,10 @@ class _KrispAudioQualityPageState extends State<KrispAudioQualityPage> {
                   _KpiPanel(plan: plan),
                   const SizedBox(height: 16),
                   _SdkPanel(plan: plan),
+                  if (handoff != null) ...[
+                    const SizedBox(height: 16),
+                    _AiCoachHandoffPanel(handoff: handoff),
+                  ],
                   const SizedBox(height: 16),
                   _RiskPanel(plan: plan),
                 ],
@@ -408,6 +415,129 @@ class _RiskPanel extends StatelessWidget {
                   ),
                   const SizedBox(width: 8),
                   Expanded(child: Text(risk)),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AiCoachHandoffPanel extends StatelessWidget {
+  const _AiCoachHandoffPanel({required this.handoff});
+
+  final KrispAiCoachHandoff handoff;
+
+  @override
+  Widget build(BuildContext context) {
+    final blockers = handoff.blockers.toList();
+    final statusColor = handoff.readyForSdkSpike
+        ? const Color(0xFF059669)
+        : const Color(0xFFD97706);
+    return _Panel(
+      title: 'AI coach handoff',
+      icon: Icons.record_voice_over_outlined,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: statusColor.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: statusColor.withValues(alpha: 0.3)),
+            ),
+            child: Text(
+              handoff.readyForSdkSpike
+                  ? 'Ready for SDK spike'
+                  : 'Blocked by ${blockers.length} external SDK gate(s)',
+              style: TextStyle(
+                color: statusColor,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          _InfoRow(
+            label: 'Gates',
+            value: '${handoff.satisfiedGateCount}/${handoff.gates.length}',
+          ),
+          _InfoRow(label: 'Issue', value: '#${handoff.issueNumber}'),
+          const SizedBox(height: 8),
+          ...handoff.gates.map(
+            (gate) => Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    gate.satisfied
+                        ? Icons.check_circle_outline
+                        : Icons.lock_outline,
+                    size: 18,
+                    color: gate.satisfied
+                        ? const Color(0xFF059669)
+                        : const Color(0xFFD97706),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '${gate.label} (${gate.owner})',
+                          style: const TextStyle(fontWeight: FontWeight.w700),
+                        ),
+                        Text(
+                          gate.nextAction,
+                          style: const TextStyle(
+                            color: Color(0xFF64748B),
+                            height: 1.4,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const Divider(height: 24),
+          Text(
+            'Pipeline',
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+          ),
+          const SizedBox(height: 8),
+          for (var i = 0; i < handoff.pipeline.length; i++)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  CircleAvatar(
+                    radius: 11,
+                    backgroundColor: const Color(0xFFE0F2FE),
+                    child: Text(
+                      '${i + 1}',
+                      style: const TextStyle(
+                        color: Color(0xFF0369A1),
+                        fontSize: 11,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '${handoff.pipeline[i].label}: '
+                      '${handoff.pipeline[i].input} -> '
+                      '${handoff.pipeline[i].output}',
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/lib/services/krisp_audio_quality_service.dart
+++ b/lib/services/krisp_audio_quality_service.dart
@@ -65,6 +65,58 @@ class KrispAudioPlan {
   }
 }
 
+class KrispSdkGate {
+  const KrispSdkGate({
+    required this.id,
+    required this.label,
+    required this.owner,
+    required this.satisfied,
+    required this.nextAction,
+  });
+
+  final String id;
+  final String label;
+  final String owner;
+  final bool satisfied;
+  final String nextAction;
+}
+
+class KrispAiCoachPipelineStep {
+  const KrispAiCoachPipelineStep({
+    required this.id,
+    required this.label,
+    required this.input,
+    required this.output,
+  });
+
+  final String id;
+  final String label;
+  final String input;
+  final String output;
+}
+
+class KrispAiCoachHandoff {
+  const KrispAiCoachHandoff({
+    required this.issueNumber,
+    required this.gates,
+    required this.pipeline,
+    required this.acceptanceChecks,
+  });
+
+  final int issueNumber;
+  final List<KrispSdkGate> gates;
+  final List<KrispAiCoachPipelineStep> pipeline;
+  final List<String> acceptanceChecks;
+
+  Iterable<KrispSdkGate> get blockers =>
+      gates.where((gate) => !gate.satisfied);
+
+  bool get readyForSdkSpike => blockers.isEmpty;
+
+  int get satisfiedGateCount =>
+      gates.where((gate) => gate.satisfied).length;
+}
+
 class KrispAudioQualityService {
   const KrispAudioQualityService();
 
@@ -217,16 +269,112 @@ class KrispAudioQualityService {
     return plans.firstWhere((plan) => plan.scenario == scenario);
   }
 
+  KrispAiCoachHandoff buildAiCoachHandoff() {
+    return const KrispAiCoachHandoff(
+      issueNumber: 755,
+      gates: [
+        KrispSdkGate(
+          id: 'contract',
+          label: 'Krisp Browser SDK contract and API key',
+          owner: 'user',
+          satisfied: false,
+          nextAction:
+              'Confirm SDK access, commercial terms, and allowed deployment domain.',
+        ),
+        KrispSdkGate(
+          id: 'model-distribution',
+          label: 'Noise model distribution terms',
+          owner: 'user',
+          satisfied: false,
+          nextAction:
+              'Confirm whether WASM/model assets can be bundled, cached, or fetched at runtime.',
+        ),
+        KrispSdkGate(
+          id: 'audio-runtime',
+          label: 'Web Audio runtime contract',
+          owner: 'codex',
+          satisfied: true,
+          nextAction:
+              'Keep the integration behind a feature flag and wire it after getUserMedia.',
+        ),
+        KrispSdkGate(
+          id: 'privacy-consent',
+          label: 'Voice privacy and retention policy',
+          owner: 'codex',
+          satisfied: true,
+          nextAction:
+              'Require explicit mic consent and default to no raw-audio persistence.',
+        ),
+        KrispSdkGate(
+          id: 'ai-coach-interface',
+          label: 'AI coach stream boundary',
+          owner: 'codex',
+          satisfied: true,
+          nextAction:
+              'Send only filtered PCM or transcript text into the coach turn pipeline.',
+        ),
+      ],
+      pipeline: [
+        KrispAiCoachPipelineStep(
+          id: 'capture',
+          label: 'Browser mic capture',
+          input: 'User media permission',
+          output: 'MediaStream',
+        ),
+        KrispAiCoachPipelineStep(
+          id: 'filter',
+          label: 'Krisp noise filter',
+          input: 'MediaStream audio track',
+          output: 'Filtered audio track or AudioWorklet node',
+        ),
+        KrispAiCoachPipelineStep(
+          id: 'turn-taking',
+          label: 'VAD and turn boundary',
+          input: 'Filtered PCM frames',
+          output: 'Stable user utterance segment',
+        ),
+        KrispAiCoachPipelineStep(
+          id: 'stt',
+          label: 'Speech-to-text',
+          input: 'Utterance segment',
+          output: 'Transcript with confidence',
+        ),
+        KrispAiCoachPipelineStep(
+          id: 'coach',
+          label: 'AI coach response',
+          input: 'Transcript plus session context',
+          output: 'Coach reply and next action',
+        ),
+      ],
+      acceptanceChecks: [
+        'Fallback to raw microphone input when Krisp SDK is unavailable.',
+        'No raw audio is stored unless the user explicitly enables recording.',
+        'Device switching rebuilds the filter chain without page reload.',
+        'STT and coach latency budgets are measured separately from filtering.',
+      ],
+    );
+  }
+
   String buildShareText(KrispAudioPlan plan) {
     final kpiText = plan.kpis
         .map((kpi) => '${kpi.label}: ${kpi.current}${kpi.unit}')
         .join(' / ');
-    return [
+    final lines = [
       plan.title,
       'KGI: ${plan.kgi}',
       'CSF: ${plan.csf.take(2).join(' / ')}',
       'KPI: $kpiText',
       'Source: ${plan.sourceUrl}',
-    ].join('\n');
+    ];
+    if (plan.scenario == KrispAudioScenario.aiCoachSdk) {
+      final handoff = buildAiCoachHandoff();
+      lines.add(
+        'SDK gates: ${handoff.satisfiedGateCount}/${handoff.gates.length}',
+      );
+      lines.add(
+        'Blockers: ${handoff.blockers.map((gate) => gate.id).join(', ')}',
+      );
+    }
+    return lines.join('\n');
   }
 }

--- a/lib/services/krisp_audio_quality_service.dart
+++ b/lib/services/krisp_audio_quality_service.dart
@@ -108,13 +108,11 @@ class KrispAiCoachHandoff {
   final List<KrispAiCoachPipelineStep> pipeline;
   final List<String> acceptanceChecks;
 
-  Iterable<KrispSdkGate> get blockers =>
-      gates.where((gate) => !gate.satisfied);
+  Iterable<KrispSdkGate> get blockers => gates.where((gate) => !gate.satisfied);
 
   bool get readyForSdkSpike => blockers.isEmpty;
 
-  int get satisfiedGateCount =>
-      gates.where((gate) => gate.satisfied).length;
+  int get satisfiedGateCount => gates.where((gate) => gate.satisfied).length;
 }
 
 class KrispAudioQualityService {

--- a/test/services/krisp_audio_quality_service_test.dart
+++ b/test/services/krisp_audio_quality_service_test.dart
@@ -58,7 +58,9 @@ void main() {
       );
       expect(
         handoff.acceptanceChecks,
-        contains('Fallback to raw microphone input when Krisp SDK is unavailable.'),
+        contains(
+          'Fallback to raw microphone input when Krisp SDK is unavailable.',
+        ),
       );
     });
   });

--- a/test/services/krisp_audio_quality_service_test.dart
+++ b/test/services/krisp_audio_quality_service_test.dart
@@ -37,6 +37,29 @@ void main() {
       expect(text, contains('CSF:'));
       expect(text, contains('KPI:'));
       expect(text, contains('https://sdk-docs.krisp.ai/docs/introduction'));
+      expect(text, contains('SDK gates: 3/5'));
+      expect(text, contains('contract'));
+      expect(text, contains('model-distribution'));
+    });
+
+    test('AI coach SDK handoff keeps external gates explicit', () {
+      final handoff = service.buildAiCoachHandoff();
+
+      expect(handoff.issueNumber, 755);
+      expect(handoff.readyForSdkSpike, isFalse);
+      expect(handoff.satisfiedGateCount, 3);
+      expect(
+        handoff.blockers.map((gate) => gate.id),
+        containsAll(<String>['contract', 'model-distribution']),
+      );
+      expect(
+        handoff.pipeline.map((step) => step.id).toList(),
+        <String>['capture', 'filter', 'turn-taking', 'stt', 'coach'],
+      );
+      expect(
+        handoff.acceptanceChecks,
+        contains('Fallback to raw microphone input when Krisp SDK is unavailable.'),
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- Add explicit Krisp SDK readiness gates for the future AI coach audio flow.
- Add a browser-side handoff pipeline from mic capture through Krisp filtering, VAD, STT, and coach response.
- Surface remaining external blockers in the share text and `/krisp-audio-quality` UI so the task is not treated as fully complete prematurely.
- Update `docs/issue-fix-plans/issue-755.md` with the Codex #1 handoff status.

Refs #755. This PR intentionally does not close #755 because Krisp SDK contract/API key and model distribution terms still require user/vendor confirmation.

## Local verification

- `dart analyze lib/services/krisp_audio_quality_service.dart lib/pages/krisp_audio_quality_page.dart test/services/krisp_audio_quality_service_test.dart`
- `flutter test test/services/krisp_audio_quality_service_test.dart`
- `git diff --check -- docs/issue-fix-plans/issue-755.md lib/pages/krisp_audio_quality_page.dart lib/services/krisp_audio_quality_service.dart test/services/krisp_audio_quality_service_test.dart`

## Remaining blockers

- Confirm Krisp Browser SDK access, API key, commercial terms, and allowed deployment domain.
- Confirm whether WASM/model assets can be bundled, cached, or fetched at runtime.