### PR TITLE
Fix header version badge click crash

### DIFF
--- a/lib/widgets/global_header_clock_bar.dart
+++ b/lib/widgets/global_header_clock_bar.dart
@@ -130,34 +130,39 @@ class _GlobalHeaderClockBarState extends State<GlobalHeaderClockBar> {
                   child: Semantics(
                     label: 'アプリバージョン $versionText',
                     button: true,
-                    child: InkWell(
-                      key: const Key('global_header_version_badge'),
+                    child: Material(
+                      color: Colors.transparent,
                       borderRadius: BorderRadius.circular(10),
-                      onTap: () => Navigator.of(context).pushNamed('/settings'),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 2,
-                        ),
-                        decoration: BoxDecoration(
-                          color: versionBadgeBg,
-                          borderRadius: BorderRadius.circular(10),
-                          border: Border.all(
-                            color: versionBadgeBorder,
-                            width: 1,
+                      child: InkWell(
+                        key: const Key('global_header_version_badge'),
+                        borderRadius: BorderRadius.circular(10),
+                        onTap: () =>
+                            Navigator.of(context).pushNamed('/settings'),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 2,
                           ),
-                        ),
-                        child: Text(
-                          versionText,
-                          key: const Key('global_header_version_text'),
-                          style: TextStyle(
-                            fontSize: 11,
-                            fontWeight: FontWeight.w700,
-                            color: versionBadgeFg,
-                            height: 1.4,
-                            fontFeatures: const [
-                              FontFeature.tabularFigures(),
-                            ],
+                          decoration: BoxDecoration(
+                            color: versionBadgeBg,
+                            borderRadius: BorderRadius.circular(10),
+                            border: Border.all(
+                              color: versionBadgeBorder,
+                              width: 1,
+                            ),
+                          ),
+                          child: Text(
+                            versionText,
+                            key: const Key('global_header_version_text'),
+                            style: TextStyle(
+                              fontSize: 11,
+                              fontWeight: FontWeight.w700,
+                              color: versionBadgeFg,
+                              height: 1.4,
+                              fontFeatures: const [
+                                FontFeature.tabularFigures(),
+                              ],
+                            ),
                           ),
                         ),
                       ),


### PR DESCRIPTION
## Summary
- Wrap the global header version badge InkWell in a transparent Material ancestor
- Prevent the web click/hover path from throwing a null check error when the badge tries to paint ink

## Verification
- git diff --check -- lib/widgets/global_header_clock_bar.dart

Note: local dart/flutter format and analyze commands timed out in this workspace, so I kept the change scoped and syntax-preserving.