### PR TITLE
docs(codex2): sync ops charter roles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ UIコンポーネントを新規作成・修正する際は、以下のファイ
 | `[CAVEMAN]` | 通信 fragments OK・code は normal | — |
 | `[MEMORY-DECAY]` | memory/ タイムスタンプ + shadow + cleanup | — |
 | `[WBS-SYNC]` | 毎セッション wbs.priority_for_instance + update_progress | — |
-| `[INSTANCE-ROLES]` | **12 スロット (10 Claude + 2 Codex) 役割分担** — Codex#1=SQL/algo, Codex#2=大規模 refactor (詳細 docs/MULTI_INSTANCE_FLEET.md) | — |
+| `[INSTANCE-ROLES]` | **12 スロット (10 Claude + 2 Codex) 役割分担** — Codex#1=横断調査/修正PR, Codex#2=CI/同期/運用 (詳細 docs/MULTI_INSTANCE_FLEET.md) | — |
 | `[CONCURRENCY]` | deploy-prod cancel-in-progress: false | — |
 | `[ROADMAP-LOG]` | docs/GROWTH_STRATEGY_ROADMAP.md 毎セッション末尾追記 | Rule 3 |
 | `[REAL-DATA]` | ダミーデータ禁止・Supabase リアルデータ使用 | Rule 4 |
@@ -118,10 +118,19 @@ UIコンポーネントを新規作成・修正する際は、以下のファイ
 
 > **⚠️ 重要 (2026-04-24 Win版#132 part 3 改訂)**: Claude Code 単独依存リスク顕在化 (Max プラン limit hit / context compaction ループ / Anthropic API outage) を受けて、**強制 task routing matrix** + **fallback plan** を `docs/DEV_PROCESS_MULTI_AI.md` に策定。新機能開発 / 新 AI 追加 / Migration 作成時は必ず同ドキュメントの routing matrix を参照。
 
-**設計思想**: Claude Code = CEO / アーキテクト専任 (判断・統合・memory 管理のみ)。
-実装タスクは Codex (SQL / algorithm) / Gemini Code Assist (長文 refactor) / GitHub Copilot (inline) / NotebookLM (リサーチ) に分散。
+**設計思想**: Claude Code = 設計判断・大きめの実装・既存設計に沿った機能追加・並列ワーカー・統合 / memory 管理。
+実装タスクと運用補助は Codex (横断調査 / 修正PR / CI・同期・レビュー補助) / Gemini Code Assist (Google・Flutter・Firebase系 / 長文 refactor) / GitHub Copilot (inline / テスト追加) / Manus AI (ブラウザ操作・外部SaaS確認) / NotebookLM (リサーチ / Master Brain) に分散。
 目標: Claude Code token 消費量を月 50% 削減 / 他 AI で代替可能率 70%+ (`docs/DEV_PROCESS_MULTI_AI.md` Phase 3 KPI)。
 Anthropic API outage 時も他 AI で開発継続可能な体制を確立する。
+
+**12インスタンス運用の正本**:
+- GitHub Issues / PR = 実行単位、担当、レビュー、完了判定
+- WBS / Notion = 進捗、依存関係、ロードマップ、管理ビュー
+- NotebookLM = 外部メモリー兼 Master Brain。判断履歴、設計意図、衝突回避ルール、学びの集約
+- Slack = 進行中の通知、ブロッカー、handoff、緊急調整
+- 各 worktree / branch = 実作業の隔離領域
+
+作業開始時は、担当領域の重複、同一ファイル / DBスキーマ / Edge Function / workflow の競合、Issue / WBS / Notion / PR / NotebookLM の状態不一致、Slack / Notion の形骸化、Gemini Code Assist / Copilot / Manus AI の活用余地を確認する。作業中も運用改善提案を範囲内として扱う。
 
 ### インスタンス別 推奨モデル / 制約表
 
@@ -132,8 +141,8 @@ Anthropic API outage 時も他 AI で開発継続可能な体制を確立する�
 | **PowerShell版 #1-6** | ルーティン: `claude-haiku-4-5` / 設計: `claude-sonnet-4-6` | `/fast` (定型作業) | `.claude/worktrees/instance-ps1` ... `instance-ps6` | 各PS固定担当 |
 | **WEB版** | `claude-sonnet-4-6` (変更不可の場合あり) | 通常 | GitHub MCP のみ | `notebooklm` / `flutter analyze` / `deno lint` / ローカルCLI **不可** |
 | **📱 スマホ版** | `claude-sonnet-4-6` | 通常 (画像分析重視) | GitHub MCP のみ | ローカルCLI **不可** / git/dart/flutter **不可** / **GitHub MCP のみ** で git 操作。**実機 UAT・モバイル不具合トリアージ専用** |
-| **Codex#1** | OpenAI Codex CLI | SQL生成・差分レビュー | `.claude/worktrees/instance-codex1` (`codex/codex1-wip`) | SQL / migration / seed 生成。PS#3 補助 |
-| **Codex#2** | OpenAI Codex CLI | Deno/algorithm 最適化 | `.claude/worktrees/instance-codex2` (`codex/codex2-wip`) | EF(Deno) / algorithm / バッチ改善。PS#5/#6 補助 |
+| **Codex#1** | OpenAI Codex CLI | 横断調査・修正PR・レビュー補助 | `.claude/worktrees/instance-codex1` (`codex/codex1-wip`) | SQL / migration レビュー補助。PS#3 / Win版 補助 |
+| **Codex#2** | OpenAI Codex CLI | CI・同期・運用・EF/GHA補助 | `.claude/worktrees/instance-codex2` (`codex/codex2-wip`) | EF(Deno) / algorithm / GHA補助。PS#1/#5/#6 補助 |
 
 **Worktree 運用ルール (ローカル編集インスタンス必須)**:
 - セッション開始時: `cd C:/Users/kanta/GitHub/my_web_app/.claude/worktrees/instance-<name>` で作業開始
@@ -171,6 +180,7 @@ Anthropic API outage 時も他 AI で開発継続可能な体制を確立する�
 | 行レベル補完 | **GitHub Copilot** | — | 不使用 |
 | 5分以内の修正 | **Copilot Inline Chat** | — | 不使用 |
 | 500行超リファクタリング | **Gemini Code Assist** | Copilot | 事前レビュー |
+| 横断調査 / 修正PR / レビュー補助 | **Codex#1** | Codex#2 | 仕様確認のみ |
 | SQL/アルゴリズム最適化 | **Codex#1/#2** | Copilot | 仕様確認のみ |
 | Migration (SQL DDL + seed) | **Codex#1** | Copilot | 命名則チェック |
 | AI大学 provider 追加 (seed SQL) | **Codex#1** (template ベース) | — | routing 判断のみ |
@@ -178,6 +188,7 @@ Anthropic API outage 時も他 AI で開発継続可能な体制を確立する�
 | Flutter widget 新規 | **Gemini** (DESIGN.md 参照) | Copilot | design-skills gate |
 | EF (Deno) 新 action | **Codex#2** | Copilot | deny-by-default 原則確認 |
 | GHA workflow (yml) | **Codex#2** | Copilot | 不使用 |
+| ブラウザ操作 / 外部SaaS確認 / 長手順実行 | **Manus AI** | Claude Code | 結果確認 |
 | 競合 21 社調査 | **NotebookLM Deep Research** | — | 統合レポート |
 | PR レビュー (GHA) | **Claude API** (claude-sonnet-4-6) | **Gemini 1.5 Flash** (自動 fallback) | 不使用 |
 | 設計・戦略・ルール遵守 | **Claude Code** 独占 | — | 主役 |
@@ -200,7 +211,7 @@ Anthropic API outage 時も他 AI で開発継続可能な体制を確立する�
 | --- | --- | --- |
 | **Generator-Verifier** | 品質が最重要。評価基準を明文化できる | `claude-agent-review.yml` (PR生成→Claudeレビュー) / `ci-auto-fix.yml` (修正→CI再実行) / `/deep-research` (NotebookLM生成→Claude統合) |
 | **Orchestrator-Subagent** | タスク分解が明確。サブタスクが短時間で完結 | `cs-check.yml` (FAQ返信/バグ修正/エスカレーション) / `github-issue-fix.yml` (Issue一覧→1件ずつ処理) / Claude Code Schedule (計画→実行→コミット) |
-| **Agent Teams** | 並行独立した長時間タスク。成果物が互いに干渉しない | **4インスタンス並行開発** (VSCode/Windowsアプリ/PowerShell/WEB版) + Gemini Code Assist / CODEX / GitHub Copilot 補完 / `ai-university-update.yml` (60プロバイダー 2時間毎 RSS) + Claude Schedule (4時間毎 NotebookLM Deep Research) |
+| **Agent Teams** | 並行独立した長時間タスク。成果物が互いに干渉しない | **12インスタンス並行開発** (Claude Code 10 + Codex 2) + Gemini Code Assist / GitHub Copilot / Manus AI 補完 / `ai-university-update.yml` + NotebookLM Master Brain |
 | **Message Bus** | イベント駆動。エコシステムが成長する | `workflow-failure-handler.yml` (失敗イベント→Issue→`cs-check`) / `feedback-issue-resolved.yml` (Issueクローズ→通知メール) / `edge-function-audit.yml` (EF未接続→Issue→`github-issue-fix`) |
 | **Shared State** | エージェントが互いの発見を活用。単一障害点を避けたい | `memory/` + NotebookLM Master Brain (セッション横断知識) / Supabase DB (全EFが読み書き) / `COMPRESSED_PROMPT_V3.md` (全インスタンス共有状態) |
 

--- a/docs/CODEX_WORKFLOW.md
+++ b/docs/CODEX_WORKFLOW.md
@@ -1,15 +1,15 @@
 # Codex 並行開発ワークフロー
 
-> 目的: Claude Code 10 インスタンスに、Codex 2 インスタンスを固定 worktree で追加し、SQL / EF / algorithm 系の実装を衝突少なく並行処理する。
+> 目的: Claude Code 10 インスタンスに、Codex 2 インスタンスを固定 worktree で追加し、横断調査 / 修正PR / CI・同期・運用 / レビュー補助を衝突少なく並行処理する。
 
 ## 1. インスタンス割当
 
 | インスタンス | worktree | branch | 主担当 | 補助先 |
 | --- | --- | --- | --- | --- |
-| Codex#1 | `.claude/worktrees/instance-codex1` | `codex/codex1-wip` | SQL / migration / seed 生成 | PS#3 |
-| Codex#2 | `.claude/worktrees/instance-codex2` | `codex/codex2-wip` | EF(Deno) / algorithm / GHA補助 | PS#5 / PS#6 |
+| Codex#1 | `.claude/worktrees/instance-codex1` | `codex/codex1-wip` | 横断調査 / 修正PR / SQL・migration レビュー補助 | PS#3 / Win版 |
+| Codex#2 | `.claude/worktrees/instance-codex2` | `codex/codex2-wip` | CI / 同期 / 運用 / EF(Deno)・GHA レビュー補助 | PS#1 / PS#5 / PS#6 |
 
-Codex は Claude Code の代替司令塔ではなく、実装補助枠として扱う。設計判断、cross-instance-pr、memory consolidation、最終統合判断は Claude Code 側に残す。
+Codex は Claude Code の代替司令塔ではなく、横断調査・修正PR・レビュー補助・CI/同期/運用まわりの補助枠として扱う。設計判断、cross-instance-pr、memory consolidation、最終統合判断は Claude Code 側に残す。
 
 ## 2. 起動手順
 
@@ -61,6 +61,7 @@ Codex#1 が触る範囲:
 
 - `supabase/migrations/**/*.sql`
 - SQL seed / data backfill
+- 横断調査結果の最小限の docs / handoff
 - SQL生成に必要な最小限の docs / handoff
 
 Codex#2 が触る範囲:
@@ -68,6 +69,7 @@ Codex#2 が触る範囲:
 - `supabase/functions/**`
 - algorithm / batch / scraper 改善
 - `.github/workflows/**` の小規模補助
+- CI / 同期 / 運用まわりの修正PR
 
 共通して避ける範囲:
 
@@ -76,7 +78,17 @@ Codex#2 が触る範囲:
 - WBS / memory の直接大規模編集
 - 他インスタンスの担当ファイル
 
-## 5. WBS 連携
+## 5. 正本チェック
+
+Codex 作業開始時は、実装前に次を確認する。
+
+- GitHub Issue / PR が実行単位として存在するか。なければ handoff に明記する。
+- WBS / Notion の進捗・依存関係と矛盾していないか。
+- NotebookLM に残すべき判断履歴や設計意図があるか。
+- Slack に通知すべきブロッカー、handoff、緊急調整があるか。
+- 同一ファイル、同一 DB スキーマ、同一 Edge Function、同一 workflow を他インスタンスが触っていないか。
+
+## 6. WBS 連携
 
 Codex CLI から WBS MCP を直接使えない場合は、作業完了時に次のどちらかで連携する。
 
@@ -85,7 +97,7 @@ Codex CLI から WBS MCP を直接使えない場合は、作業完了時に次�
 
 handoff には最低限、目的、変更ファイル、実行した検証、残リスク、次に見るべきインスタンスを記録する。
 
-## 6. 推奨検証
+## 7. 推奨検証
 
 SQL / migration:
 

--- a/docs/DEV_PROCESS_MULTI_AI.md
+++ b/docs/DEV_PROCESS_MULTI_AI.md
@@ -9,19 +9,24 @@
 
 ## 1. 強制 Task Routing Matrix
 
-**このルールに従って AI を選択する。Claude Code は「判断・統合・memory管理」のみ。**
+**このルールに従って AI を選択する。Claude Code は「設計判断・大きめ実装・既存設計に沿った機能追加・並列ワーカー・統合・memory管理」を担う。**
+
+12 インスタンス並行開発では、作業そのものと同時に運用改善も見る。正本は GitHub Issues / PR、WBS / Notion、NotebookLM、Slack、各 worktree / branch に分散しているため、作業開始時に状態の食い違いと担当領域の衝突を確認する。
 
 | タスク種別 | **Primary** | **Secondary** | **Tertiary** | Claude Code 役割 |
 | --- | --- | --- | --- | --- |
 | 行レベル補完 (< 10行) | GitHub Copilot | — | — | **不使用** |
 | 5分以内の修正 | Copilot Inline Chat | — | — | **不使用** |
 | 500行超リファクタリング | Gemini Code Assist | Copilot | Claude Code | 事前レビューのみ |
+| 横断調査 / 修正PR / レビュー補助 | **Codex#1** | Codex#2 | Claude Code | 仕様確認のみ |
+| CI / 同期 / 運用まわり | **Codex#2** | Codex#1 | Claude Code PS#1 | 完了判定のみ |
 | SQL / アルゴリズム最適化 | OpenAI Codex (`codex1`/`codex2`) | Copilot | Claude Code | 仕様確認のみ |
 | Migration (DDL + seed SQL) | **Codex#1** (template ベース) | Copilot | Claude Code | 命名則チェック |
 | AI大学 provider 追加 (seed SQL) | **Codex#1** (既存 SQL コピー改変) | — | Claude Code | routing 判断のみ |
 | ブログ・競合リサーチ | Claude Code WEB版 (WebSearch) | NotebookLM | Gemini Search | — |
 | NotebookLM Deep Research | Win版 CLI | Gemini Research | — | 統合・要約のみ |
 | UI/デザイン (新コンポーネント) | Claude Code VSCode版 + design-skills | Figma MCP | Copilot | 設計レビュー |
+| ブラウザ操作 / 外部SaaS確認 / 長手順実行 | Manus AI | Claude Code | — | 結果確認のみ |
 | アーキテクチャ判断 | **Claude Code** | NotebookLM + Copilot Chat | — | **専任** |
 | Dart バグ修正 (< 50行) | Copilot Inline Chat | Claude Code PS#5 | — | 必要時のみ |
 | EF バグ修正 (Deno) | **Codex#2** / Copilot | Claude Code PS#5 | — | deny-by-default確認 |
@@ -66,8 +71,8 @@ curl -s -o /dev/null -w "%{http_code}" \
 | **PS#5** | on-call バグ修正 | GitHub Copilot + GitHub MCP |
 | **PS#6** | horse_racing / バッチ | cron-batch.yml (Claude不要) ✅ |
 | **WEB版** | Issue起票 | GitHub MCP のみ (元々Claude不要) ✅ |
-| **Codex#1** | SQL / migration / seed生成 | `.claude/worktrees/instance-codex1` で継続 ✅ |
-| **Codex#2** | EF(Deno) / algorithm / GHA補助 | `.claude/worktrees/instance-codex2` で継続 ✅ |
+| **Codex#1** | 横断調査 / 修正PR / SQL・migrationレビュー補助 | `.claude/worktrees/instance-codex1` で継続 ✅ |
+| **Codex#2** | CI / 同期 / 運用 / EF・GHA補助 | `.claude/worktrees/instance-codex2` で継続 ✅ |
 
 **✅ = Claude quota枯渇でも自動継続**
 

--- a/docs/MULTI_INSTANCE_FLEET.md
+++ b/docs/MULTI_INSTANCE_FLEET.md
@@ -34,8 +34,8 @@
 
 | スロット | worktree path | branch | モデル | 主担当領域 |
 | --- | --- | --- | --- | --- |
-| **Codex#1** | `.claude/worktrees/instance-codex1` (要作成) | `codex/codex1-wip` | GPT-5.2-Codex | SQL + algorithm 最適化 + 数値計算 (馬学習ループ / WBS 同期 / migration tuning) |
-| **Codex#2** | `.claude/worktrees/instance-codex2` (要作成) | `codex/codex2-wip` | GPT-5.2-Codex | 大規模 refactor + CI fix + UI badge 系 (500+ 行 trailing comma / header version / lint cascade) |
+| **Codex#1** | `.claude/worktrees/instance-codex1` | `codex/codex1-wip` | GPT-5.2-Codex | 横断調査 / 修正 PR / SQL・migration レビュー補助 |
+| **Codex#2** | `.claude/worktrees/instance-codex2` | `codex/codex2-wip` | GPT-5.2-Codex | CI / 同期 / 運用まわり / EF(Deno)・GHA レビュー補助 |
 
 > **既存 Codex worktree の扱い**: 現在 `C:/Users/kanta/GitHub/my_web_app_ci_fix` /
 > `_horse_fix` / `_version_fix` / `_wbs_sync` の 4 本が ad-hoc に存在する。
@@ -47,7 +47,7 @@
 
 | 領域 | 主担当 | 副 (overflow 時) | 完全禁止 |
 | --- | --- | --- | --- |
-| `lib/` Flutter UI | VSCode版 | (なし) | Win版 / 全 PS版 / Codex#1 |
+| `lib/` Flutter UI | VSCode版 | Gemini Code Assist / Copilot (補助) | Win版 / 全 PS版 / Codex#1 / Codex#2 |
 | `supabase/functions/` EF | VSCode版 | Win版 (動画スクリプト系のみ) | 全 PS版 (workflow/seed/AI 大学経由のみ) |
 | `supabase/migrations/` | Win版 (schema) / PS#3-#5 (seed) | VSCode版 (新機能伴う schema) | — |
 | `.github/workflows/` | PS#1 | PS#5 (緊急時) | VSCode版 / Win版 / Codex |
@@ -58,9 +58,9 @@
 | AI 大学コンテンツ | PS#3 | Win版 (NotebookLM 由来のみ) | — |
 | 競合 172 社 (`competitors` table 系) | PS#4 | (なし) | — |
 | EF stale 移行 / anon-guard | PS#5 | (なし) | — |
-| 競馬モデル (`horse_*` table 系 / fetch スクリプト) | PS#6 | Codex#1 (アルゴリズム最適化のみ) | — |
-| **SQL アルゴリズム最適化** | **Codex#1** | Win版 (review のみ) | — |
-| **大規模 refactor (500+ 行)** | **Codex#2** | (なし) | — |
+| 競馬モデル (`horse_*` table 系 / fetch スクリプト) | PS#6 | Codex#2 (アルゴリズム / レビュー補助) | — |
+| **横断調査 / 修正 PR / レビュー補助** | **Codex#1** | Codex#2 | — |
+| **CI / 同期 / 運用まわり** | **Codex#2** | Codex#1 | — |
 | GitHub Issue / PR (リモート) | WEB版 / スマホ版 | 全インスタンス | — |
 
 ---
@@ -72,15 +72,17 @@
 各スロットは上表の **主担当領域のみ** を write する。副担当領域に踏み込むときは
 事前に `docs/cross-instance-prs/YYYYMMDD_<title>.md` を起票して主担当に通知。
 
-### 2. main ブランチへの push
+### 2. branch push と main 統合
 
-全スロットが `origin/main` を push target として共有 → push 前に必ず以下:
+全スロットはまず担当 branch に push する。`origin/main` への直 push は、競合確認・検証・統合判断が終わった場合のみ行う。
 
 ```bash
 git fetch origin main
 git log HEAD..origin/main --oneline   # 並行 push を検知
 git pull --rebase origin main          # 衝突時は手動 resolve
-git push origin HEAD:main              # bypass admin 権限で main 直 push
+git push -u origin HEAD                # まず担当 branch を更新
+# 統合確認後のみ:
+git push origin HEAD:main
 ```
 
 ### 3. Codex 特有の運用
@@ -100,15 +102,20 @@ Codex はユーザーが手動で起動する CLI / IDE プラグインのため
 | タスク種別 | 推奨スロット |
 | --- | --- |
 | 設計判断 / 戦略 / cross-instance-pr 起票 / memory consolidation | **Win版 / VSCode版** (Claude 専任) |
-| Flutter UI 実装 (新規 / 中規模) | VSCode版 |
-| Flutter UI 大規模 refactor (500+ 行) | **Codex#2** |
+| 大きめの実装 / 既存設計に沿った機能追加 | **Claude Code** 各担当 worktree |
+| Flutter UI 実装 (新規 / 中規模) | VSCode版 + Gemini Code Assist / Copilot |
+| Flutter UI 大規模 refactor (500+ 行) | VSCode版 + Gemini Code Assist |
 | EF 新規実装 | VSCode版 |
-| EF アルゴリズム最適化 (N+1 / 集計ロジック) | **Codex#1** |
+| EF アルゴリズム最適化 (N+1 / 集計ロジック) | VSCode版 / Codex#2 レビュー補助 |
 | Migration 新規 (schema) | Win版 |
 | Migration seed (AI 大学 / 競合) | PS#3 / PS#4 |
-| GHA workflow 修正 | PS#1 |
+| 修正 PR / 横断調査 / レビュー補助 | **Codex#1** |
+| GHA workflow 修正 / CI fix / 同期運用 | PS#1 / **Codex#2** |
 | ブログ dispatch | PS#2 |
-| 競馬モデル | PS#6 / Codex#1 (協働) |
+| IDE 内の短距離実装 / テスト追加 | GitHub Copilot |
+| 外部 SaaS 確認 / ブラウザ操作 / 長めの手順実行 | Manus AI |
+| 判断履歴 / 設計意図 / 学びの集約 | NotebookLM |
+| 競馬モデル | PS#6 / Codex#2 (協働) |
 | リモート PR レビュー / 緊急 hotfix (1 行) | WEB版 / スマホ版 |
 
 ---
@@ -125,8 +132,8 @@ C:/Users/kanta/GitHub/my_web_app                      [main]              ← pu
 ├── .claude/worktrees/instance-ps4                    [claude/ps4-wip]
 ├── .claude/worktrees/instance-ps5                    [claude/ps5-wip]
 ├── .claude/worktrees/instance-ps6                    [claude/ps6-wip]
-├── .claude/worktrees/instance-codex1                 [codex/codex1-wip]   ← 要作成
-└── .claude/worktrees/instance-codex2                 [codex/codex2-wip]   ← 要作成
+├── .claude/worktrees/instance-codex1                 [codex/codex1-wip]
+└── .claude/worktrees/instance-codex2                 [codex/codex2-wip]
 
 C:/Users/kanta/GitHub/my_web_app_ps                   [ps-main]            ← レガシー (PS版#1 が定常使用 - 検証中)
 C:/Users/kanta/GitHub/my_web_app_win                  [win-main]           ← レガシー (Win版が定常使用 - 検証中)
@@ -161,14 +168,15 @@ git worktree remove --force C:/Users/kanta/GitHub/my_web_app_version_fix
 git worktree remove --force C:/Users/kanta/GitHub/my_web_app_wbs_sync
 
 # Step 3: 標準 codex slot を作成
-git worktree add -b codex/codex1-wip .claude/worktrees/instance-codex1 main
-git worktree add -b codex/codex2-wip .claude/worktrees/instance-codex2 main
+powershell -ExecutionPolicy Bypass -File .claude/scripts/setup-instance-worktree.ps1 codex1
+powershell -ExecutionPolicy Bypass -File .claude/scripts/setup-instance-worktree.ps1 codex2
 ```
 
 ### 移行後の運用
 
 - Codex#1 タスク開始時 → `cd .claude/worktrees/instance-codex1 && git pull --rebase origin main`
-- 完了時 → `git push origin HEAD:main`
+- Codex#2 タスク開始時 → `cd .claude/worktrees/instance-codex2 && git pull --rebase origin main`
+- 完了時 → `git push -u origin codex/codex1-wip` / `git push -u origin codex/codex2-wip`
 - Claude Code (Win版) が memory/ + cross-instance-pr で結果を記録
 
 ---

--- a/docs/OPERATIONS_CHARTER.md
+++ b/docs/OPERATIONS_CHARTER.md
@@ -45,7 +45,7 @@
 | ツール | 強み | 主な使いどころ | 入れない場所 |
 | --- | --- | --- | --- |
 | **Claude Code (10 枠)** | 大きめ実装・既存設計沿いの追加・並列ワーカー・設計判断 | 新機能 EF / Flutter UI / docs / memory consolidation / cross-instance-pr 起票 | 横断調査の最適化 (= NotebookLM が上) |
-| **Codex (2 枠)** | 横断調査・修正 PR・CI/同期/運用まわり・レビュー補助 | 大規模 refactor / SQL 最適化 / 馬学習ループ / WBS 同期ロジック | 設計判断 (= Claude が上) / memory 書込 |
+| **Codex (2 枠)** | 横断調査・修正 PR・CI/同期/運用まわり・レビュー補助 | Codex#1 = 横断調査 / 修正 PR / SQL・migration レビュー補助、Codex#2 = CI / 同期 / 運用 / EF(Deno)・GHA レビュー補助 | 設計判断 (= Claude が上) / memory 書込 / UI設計 |
 | **Gemini Code Assist** | Google / Flutter / Firebase 系・コード理解補助・別視点レビュー | Flutter API 更新 / Firebase Hosting 設定 / Anthropic API outage 時の Dart 実装 fallback | 戦略判断 / 競合調査 |
 | **GitHub Copilot** | IDE 内の短距離実装・補完・テスト追加 | コーディング中の関数補完 / 単体テスト雛形 / lint fix の suggestion | 設計 / 大規模 refactor |
 | **Manus AI** | ブラウザ操作・外部 SaaS 確認・長めの手順実行 | Notion / Slack / Stripe 等の外部 SaaS UI 操作 / 手作業の連続自動化 | コード生成 / 設計判断 |
@@ -62,10 +62,10 @@ Q1: 設計判断 / 戦略 / cross-instance 調整?
 Q2: 横断調査 / 過去判断の集約必要?
    YES → NotebookLM Deep Research
    NO ↓
-Q3: 500+ 行 refactor / SQL 最適化 / algorithm 改善?
-   YES → Codex (#1 SQL系 / #2 refactor系)
+Q3: 横断調査 / 修正 PR / CI・同期・運用 / レビュー補助?
+   YES → Codex (#1 横断調査・修正PR / #2 CI・同期・運用)
    NO ↓
-Q4: Flutter / Firebase 専門知識が決め手?
+Q4: 500+ 行 refactor / Flutter / Firebase 専門知識が決め手?
    YES → Gemini Code Assist
    NO ↓
 Q5: IDE 内補完で済む 50 行未満?

--- a/docs/cross-instance-prs/20260428_codex2_ops_charter_sync.md
+++ b/docs/cross-instance-prs/20260428_codex2_ops_charter_sync.md
@@ -1,0 +1,48 @@
+# Cross-Instance PR: Codex#2 ops charter sync
+
+**作成**: Codex#2 / 2026-04-28
+**依頼先**: PS版#1 / Win版
+**優先度**: MEDIUM — 12インスタンス運用の正本ズレ修正
+**branch**: `codex/codex2-wip`
+
+---
+
+## 背景
+
+User 指示で、今後は 12 インスタンス並行開発を前提に、作業と同時に運用改善も常に見る方針になった。
+
+`docs/OPERATIONS_CHARTER.md` が追加された一方で、`CLAUDE.md` / `MULTI_INSTANCE_FLEET.md` / `CODEX_WORKFLOW.md` / `DEV_PROCESS_MULTI_AI.md` に古い Codex 役割定義が残っていた。
+
+---
+
+## 実施内容
+
+- Codex#1 を「横断調査 / 修正PR / SQL・migration レビュー補助」に統一
+- Codex#2 を「CI / 同期 / 運用 / EF(Deno)・GHA レビュー補助」に統一
+- Claude Code を「設計判断 + 大きめ実装 + 既存設計沿い機能追加 + 統合」に再定義
+- Gemini Code Assist / GitHub Copilot / Manus AI / NotebookLM の配置を routing に追記
+- `MULTI_INSTANCE_FLEET.md` の Codex worktree 未作成表記と直 push 前提を修正
+
+---
+
+## 変更ファイル
+
+- `CLAUDE.md`
+- `docs/OPERATIONS_CHARTER.md`
+- `docs/MULTI_INSTANCE_FLEET.md`
+- `docs/CODEX_WORKFLOW.md`
+- `docs/DEV_PROCESS_MULTI_AI.md`
+
+---
+
+## 検証
+
+- `git diff --check` 実行済み (改行 warning のみ)
+- docs-only 変更のため build / lint は対象外
+
+---
+
+## 残リスク
+
+- `~/.claude/hooks/inject-rules.txt` は repo 管理外のため、この branch では更新していない。
+- WBS / Notion / Slack の実データ同期は未実施。PS版#1 または Win版で確認が必要。


### PR DESCRIPTION
## Summary
- Align Codex#1/#2 roles across OPERATIONS_CHARTER, MULTI_INSTANCE_FLEET, CODEX_WORKFLOW, DEV_PROCESS_MULTI_AI, and CLAUDE.md
- Reframe Codex#2 as CI/sync/ops + EF/GHA review support instead of UI refactor ownership
- Add Codex#2 handoff under docs/cross-instance-prs

## Verification
- git diff --check HEAD~1..HEAD
- docs-only change; build/lint not run

## Notes
- Repository-external ~/.claude/hooks/inject-rules.txt was not updated in this branch.