### PR TITLE
fix(blog-engagement): add Gemini reply fallback

### DIFF
--- a/.github/workflows/blog-engagement.yml
+++ b/.github/workflows/blog-engagement.yml
@@ -2,7 +2,7 @@ name: Blog Engagement (毎日・コメント返信/フォロー/重複削除)
 
 # 毎日 10:00 JST に Qiita/dev.to の engagement を処理する:
 # 1. 記事一覧取得 → 重複削除
-# 2. コメント取得 → Claude で返信
+# 2. コメント取得 → Claude → Gemini → template fallback で返信
 # 3. いいねしたユーザー → フォロー
 # 4. 結果を Supabase に保存 → アプリ画面で閲覧可能に
 
@@ -11,6 +11,7 @@ name: Blog Engagement (毎日・コメント返信/フォロー/重複削除)
 #   DEVTO_API_KEY           — dev.to設定 > Extensions > DEV Community API Keys
 #   SUPABASE_SERVICE_ROLE_KEY — Supabase > Project Settings > API > service_role
 #   ANTHROPIC_API_KEY       — console.anthropic.com (コメント返信AI生成用・任意)
+#   GEMINI_API_KEY          — Google AI Studio (Claude quota時のfallback・任意)
 
 on:
   schedule:
@@ -51,6 +52,7 @@ jobs:
           DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           # Self user IDs — CRITICAL: prevent infinite reply loop on own comments
           SELF_QIITA_USER: kanta13jp1
@@ -68,6 +70,7 @@ jobs:
           echo "| dry_run | ${{ github.event.inputs.dry_run || 'false' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Qiita token | ${{ secrets.QIITA_ACCESS_TOKEN != '' && 'set' || '❌ NOT SET' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| dev.to key | ${{ secrets.DEVTO_API_KEY != '' && 'set' || '⚠️ not set' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Claude key | ${{ secrets.ANTHROPIC_API_KEY != '' && 'set (AI返信)' || '⚠️ not set (template返信)' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Claude key | ${{ secrets.ANTHROPIC_API_KEY != '' && 'set (primary)' || '⚠️ not set' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Gemini key | ${{ secrets.GEMINI_API_KEY != '' && 'set (fallback)' || '⚠️ not set (template fallback)' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "ℹ️ Qiitaトークン未設定の場合: Settings > Secrets > QIITA_ACCESS_TOKEN を追加" >> $GITHUB_STEP_SUMMARY

--- a/docs/AI_FALLBACK_RUNBOOK.md
+++ b/docs/AI_FALLBACK_RUNBOOK.md
@@ -97,11 +97,11 @@ codex "supabase/functions/tools-hub/index.ts に action=habit.list を追加"
 | `ai-university-update.yml` | **なし** (RSS only) | 影響なし ✅ |
 | `quota-monitor.yml` | **なし** (監視のみ) | 影響なし ✅ |
 | `claude-agent-review.yml` | あり → Gemini fallback | Gemini でカバー ✅ |
-| `blog-engagement.yml` | optional | スキップ (コメント返信なし) ⚠️ |
+| `blog-engagement.yml` | Claude → Gemini → template | Gemini またはテンプレ返信で継続 ✅ |
 | `horse-racing-update.yml` | **なし** | 影響なし ✅ |
 | `wbs-staleness-audit.yml` | **なし** | 影響なし ✅ |
 
-**結論**: スケジュールタスクの大半はすでに Claude 非依存。`blog-engagement.yml` のコメント返信 AI 生成のみ停止するが、非クリティカル。
+**結論**: スケジュールタスクの大半はすでに Claude 非依存。`blog-engagement.yml` のコメント返信も Gemini / template fallback で継続する。
 
 ### Claude Code CLI ベースのタスク (手動代替手順)
 

--- a/docs/DEV_PROCESS_MULTI_AI.md
+++ b/docs/DEV_PROCESS_MULTI_AI.md
@@ -83,7 +83,7 @@ curl -s -o /dev/null -w "%{http_code}" \
 | `ai-university-update.yml` | なし (REST直接) | N/A | ✅ 問題なし |
 | `quota-monitor.yml` | なし (監視のみ) | N/A | ✅ 問題なし |
 | `cs-check.yml` | Claude Schedule | ❌ 未実装 | 要対応 |
-| `blog-engagement.yml` | Claude Haiku | ❌ 未実装 | 要対応 |
+| `blog-engagement.yml` | Claude Haiku | **Gemini → template** | ✅ 完了 (Codex#2 2026-04-28) |
 | `blog-backfill.yml` | Claude Haiku | ❌ 未実装 | 要対応 |
 | `claude-agent-review.yml` | Claude Sonnet | skip-on-quota 推奨 | 要対応 |
 | `blog-verify.yml` | Claude Haiku | ❌ 未実装 | 要対応 |
@@ -192,7 +192,7 @@ notebooklm ask "Edge Function設計方針の経緯"
 | 🔴 **P0** | blog-draft.yml Gemini fallback | ✅ PS#1 S26 | 2026-04-24 |
 | 🔴 **P0** | `GOOGLE_AI_API_KEY` + `GEMINI_API_KEY` + `SLACK_WEBHOOK_URL` secrets | ✅ **設定済 (2026-04-24)** | — |
 | 🟠 **P1** | ai-hub EF 自動quota routing | VSCode版 | 2026-04-26 |
-| 🟠 **P1** | blog-engagement.yml Gemini fallback | PS#2 | 2026-04-28 |
+| 🟠 **P1** | blog-engagement.yml Gemini fallback | ✅ Codex#2 | 2026-04-28 |
 | 🟠 **P1** | claude-agent-review.yml skip-on-quota | PS#1 | 2026-05-01 |
 | 🟡 **P2** | cs-check.yml Gemini fallback | PS#1 | 2026-05-05 |
 | 🟢 **P3** | Notion WBS mirror | Win版 | 2026-05-15 |

--- a/docs/cross-instance-prs/20260428_codex2_blog_engagement_fallback.md
+++ b/docs/cross-instance-prs/20260428_codex2_blog_engagement_fallback.md
@@ -1,0 +1,38 @@
+# Cross-Instance PR: blog-engagement Gemini fallback
+
+**作成**: Codex#2 / 2026-04-28
+**依頼先**: PS版#1 / PS版#2
+**優先度**: P1 — GHA fallback 広域ロードマップ
+**branch**: `codex/codex2-blog-engagement-fallback`
+
+---
+
+## 背景
+
+`docs/DEV_PROCESS_MULTI_AI.md` で `blog-engagement.yml Gemini fallback` が P1 / 2026-04-28 の要対応として残っていた。
+
+既存の `scripts/blog_engagement.py` は Claude API が使えない場合、Gemini を試さず template 返信へ落ちていた。
+
+---
+
+## 実施内容
+
+- `scripts/blog_engagement.py` に Claude → Gemini → template fallback を追加
+- `GEMINI_API_KEY` を `blog-engagement.yml` から渡すように変更
+- dev.to dry-run 時に `replied` が未定義になり得るバグを修正
+- `DEV_PROCESS_MULTI_AI.md` / `AI_FALLBACK_RUNBOOK.md` の状態を更新
+
+---
+
+## 検証
+
+- `python -m py_compile scripts/blog_engagement.py` 実行予定
+- `git diff --check` 実行予定
+- API 実呼び出しは secret が必要なため未実施予定
+
+---
+
+## 残リスク
+
+- Gemini API の実レスポンス検証は GitHub Actions / secrets 環境で確認が必要。
+- 自動返信内容は外部公開コメントになるため、初回は `workflow_dispatch dry_run=true` で確認推奨。

--- a/scripts/blog_engagement.py
+++ b/scripts/blog_engagement.py
@@ -3,7 +3,7 @@
 Blog engagement automation:
 1. Fetch all Qiita/dev.to articles
 2. Detect & delete duplicate articles
-3. Auto-reply to unanswered comments (via Claude Haiku)
+3. Auto-reply to unanswered comments (Claude → Gemini → template fallback)
 4. Auto-follow users who liked (Qiita only)
 5. Store engagement data in Supabase for app display
 
@@ -11,7 +11,8 @@ Required GitHub secrets:
   QIITA_ACCESS_TOKEN   — Qiita personal access token
   DEVTO_API_KEY        — dev.to API key (optional)
   SUPABASE_SERVICE_ROLE_KEY
-  ANTHROPIC_API_KEY    — for generating replies (optional, uses template fallback)
+  ANTHROPIC_API_KEY    — for generating replies (optional)
+  GEMINI_API_KEY       — fallback reply generation (optional, uses template fallback)
 """
 from __future__ import annotations
 
@@ -28,6 +29,9 @@ DEVTO_KEY = os.environ.get("DEVTO_API_KEY", "")
 SUPABASE_URL = "https://smmkxxavexumewbfaqpy.supabase.co"
 SUPABASE_KEY = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
 ANTHROPIC_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+GEMINI_KEY = os.environ.get("GEMINI_API_KEY", "")
+ANTHROPIC_API = "https://api.anthropic.com/v1/messages"
+GEMINI_API = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
 
 DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
 REPLY_DELAY = 3   # seconds between API calls
@@ -153,38 +157,67 @@ def sb_check(table: str, filters: dict) -> list:
 
 
 # ── AI reply generation ───────────────────────────────────────────
+def template_reply(author: str) -> str:
+    if author:
+        return f"{author}さん、コメントありがとうございます！参考になれば嬉しいです。"
+    return "コメントありがとうございます！参考になれば嬉しいです。"
+
+
+def call_claude_reply(prompt: str) -> str:
+    resp = requests.post(
+        ANTHROPIC_API,
+        headers={
+            "x-api-key": ANTHROPIC_KEY,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+        json={
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 250,
+            "messages": [{"role": "user", "content": prompt}],
+        },
+        timeout=30,
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(f"Claude API HTTP {resp.status_code}: {resp.text[:200]}")
+    return resp.json()["content"][0]["text"].strip()
+
+
+def call_gemini_reply(prompt: str) -> str:
+    resp = requests.post(
+        f"{GEMINI_API}?key={GEMINI_KEY}",
+        headers={"content-type": "application/json"},
+        json={
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {"maxOutputTokens": 250},
+        },
+        timeout=30,
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(f"Gemini API HTTP {resp.status_code}: {resp.text[:200]}")
+    data = resp.json()
+    return data["candidates"][0]["content"]["parts"][0]["text"].strip()
+
+
 def generate_reply(title: str, body: str, author: str) -> str:
-    if not ANTHROPIC_KEY:
-        return f"コメントありがとうございます！参考になれば嬉しいです 😊"
+    prompt = REPLY_PROMPT.format(title=title, author=author, body=body)
+    if ANTHROPIC_KEY:
+        try:
+            return call_claude_reply(prompt)
+        except Exception as e:
+            print(f"  ⚠️ Claude API error: {e} — falling back to Gemini", file=sys.stderr)
+    else:
+        print("  ⚠️ ANTHROPIC_API_KEY not set — trying Gemini", file=sys.stderr)
 
-    try:
-        resp = requests.post(
-            "https://api.anthropic.com/v1/messages",
-            headers={
-                "x-api-key": ANTHROPIC_KEY,
-                "anthropic-version": "2023-06-01",
-                "content-type": "application/json",
-            },
-            json={
-                "model": "claude-haiku-4-5-20251001",
-                "max_tokens": 250,
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": REPLY_PROMPT.format(
-                            title=title, author=author, body=body
-                        ),
-                    }
-                ],
-            },
-            timeout=30,
-        )
-        if resp.status_code == 200:
-            return resp.json()["content"][0]["text"].strip()
-    except Exception as e:
-        print(f"  ⚠️ Claude API error: {e}", file=sys.stderr)
+    if GEMINI_KEY:
+        try:
+            return call_gemini_reply(prompt)
+        except Exception as e:
+            print(f"  ⚠️ Gemini API error: {e} — using template reply", file=sys.stderr)
+    else:
+        print("  ⚠️ GEMINI_API_KEY not set — using template reply", file=sys.stderr)
 
-    return f"{author}さん、コメントありがとうございます！参考になれば嬉しいです。"
+    return template_reply(author)
 
 
 # ── Qiita engagement ──────────────────────────────────────────────
@@ -445,6 +478,7 @@ def process_devto() -> None:
                 reply_text = generate_reply(title, body, author)
                 replies_this_article += 1
 
+                replied = False
                 if not DRY_RUN:
                     r = devto_post("/comments", {
                         "comment": {


### PR DESCRIPTION
## Summary
- Add Claude -> Gemini -> template fallback for blog engagement auto-replies
- Pass GEMINI_API_KEY into blog-engagement.yml and show fallback status in the workflow summary
- Fix dev.to dry-run path where replied could be undefined
- Update fallback docs and add Codex#2 handoff

## Verification
- python -m py_compile scripts/blog_engagement.py
- git diff --check HEAD~1..HEAD

## Notes
- API calls require GitHub Actions secrets, so live reply generation was not exercised locally.
- First manual run should use workflow_dispatch dry_run=true.