### PR TITLE
fix(web): Flutter base href を Hosting 用に固定

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-  <base href="$FLUTTER_BASE_HREF">
+  <base href="/">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">


### PR DESCRIPTION
﻿## Summary
- Set web/index.html base href to `/` so Flutter web can initialize on Firebase Hosting even when the placeholder is not expanded.
- Restores production from the stuck SEO shell / Loading application screen caused by `The base href has to end with a "/"`.

## Verification
- Deployed Firebase Hosting for `my-web-app-b67f4` with only `build/web/index.html` changed.
- Confirmed live HTML now contains `<base href="/">`.
- Confirmed headless Chrome removes the SEO shell and creates `flutter-view` / `flt-glass-pane` on https://my-web-app-b67f4.web.app/.
