### PR TITLE
fix(wbs): ユーザータスクAI支援ボタンを復元

### DIFF
--- a/lib/pages/user_tasks_page.dart
+++ b/lib/pages/user_tasks_page.dart
@@ -21,6 +21,7 @@ class _UserTasksPageState extends State<UserTasksPage> {
   List<Map<String, dynamic>> _tasks = const [];
   bool _loading = true;
   bool _saving = false;
+  String? _assistTaskId;
   bool _showCompleted = false;
   String? _error;
 
@@ -290,6 +291,69 @@ class _UserTasksPageState extends State<UserTasksPage> {
     );
   }
 
+  Future<void> _openAiAssist(
+    Map<String, dynamic> task, {
+    required String mode,
+  }) async {
+    final taskId = '${task['id'] ?? ''}'.trim();
+    if (taskId.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('タスクIDを取得できませんでした')),
+      );
+      return;
+    }
+
+    setState(() {
+      _assistTaskId = taskId;
+    });
+
+    try {
+      final response = await _supabase.functions.invoke(
+        'tools-hub',
+        body: {
+          'action': 'wbs.user_task_ai_assist',
+          'task_id': taskId,
+          'mode': mode,
+        },
+      );
+      final data = response.data;
+      if (data is Map && data['error'] != null) {
+        throw Exception(data['error']);
+      }
+      final payload = data is Map
+          ? Map<String, dynamic>.from(data)
+          : <String, dynamic>{};
+      final guidanceRaw = payload['guidance'];
+      final guidance = guidanceRaw is Map
+          ? Map<String, dynamic>.from(guidanceRaw)
+          : <String, dynamic>{};
+
+      if (!mounted) return;
+      await showDialog<void>(
+        context: context,
+        builder: (context) => _AiAssistDialog(
+          taskTitle: '${payload['task_title'] ?? task['title'] ?? ''}',
+          mode: mode,
+          guidance: guidance,
+          generatedBy:
+              '${payload['generated_by'] ?? guidance['generated_by'] ?? ''}',
+        ),
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('AI支援の生成に失敗しました: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _assistTaskId = null;
+        });
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final activeTasks = _tasks.where((task) => task['status'] != 'completed');
@@ -314,7 +378,7 @@ class _UserTasksPageState extends State<UserTasksPage> {
             _SummaryPanel(
               total: activeTasks.length,
               urgent: urgentTasks,
-              saving: _saving,
+              saving: _saving || _assistTaskId != null,
             ),
             const SizedBox(height: 12),
             SwitchListTile(
@@ -350,6 +414,9 @@ class _UserTasksPageState extends State<UserTasksPage> {
                   dateFormat: _dateFormat,
                   urgent: _isUrgent(task),
                   saving: _saving,
+                  aiBusy: _assistTaskId == '${task['id'] ?? ''}',
+                  onBreakdown: () => _openAiAssist(task, mode: 'breakdown'),
+                  onProcedure: () => _openAiAssist(task, mode: 'procedure'),
                   onStart: () => _submitReport(
                     task,
                     reportStatus: 'in_progress',
@@ -435,6 +502,9 @@ class _UserTaskCard extends StatelessWidget {
   final DateFormat dateFormat;
   final bool urgent;
   final bool saving;
+  final bool aiBusy;
+  final VoidCallback onBreakdown;
+  final VoidCallback onProcedure;
   final VoidCallback onStart;
   final VoidCallback onReport;
   final VoidCallback onComplete;
@@ -444,6 +514,9 @@ class _UserTaskCard extends StatelessWidget {
     required this.dateFormat,
     required this.urgent,
     required this.saving,
+    required this.aiBusy,
+    required this.onBreakdown,
+    required this.onProcedure,
     required this.onStart,
     required this.onReport,
     required this.onComplete,
@@ -556,17 +629,29 @@ class _UserTaskCard extends StatelessWidget {
               runSpacing: 8,
               children: [
                 OutlinedButton.icon(
-                  onPressed: saving || completed ? null : onStart,
+                  onPressed: saving || completed || aiBusy ? null : onStart,
                   icon: const Icon(Icons.play_arrow),
                   label: const Text('着手'),
                 ),
+                OutlinedButton.icon(
+                  onPressed:
+                      saving || completed || aiBusy ? null : onBreakdown,
+                  icon: const Icon(Icons.account_tree_outlined),
+                  label: const Text('タスク分割'),
+                ),
+                OutlinedButton.icon(
+                  onPressed:
+                      saving || completed || aiBusy ? null : onProcedure,
+                  icon: const Icon(Icons.menu_book_outlined),
+                  label: const Text('手順を見る'),
+                ),
                 FilledButton.icon(
-                  onPressed: saving || completed ? null : onReport,
+                  onPressed: saving || completed || aiBusy ? null : onReport,
                   icon: const Icon(Icons.edit_note),
                   label: const Text('状況報告'),
                 ),
                 OutlinedButton.icon(
-                  onPressed: saving || completed ? null : onComplete,
+                  onPressed: saving || completed || aiBusy ? null : onComplete,
                   icon: const Icon(Icons.check_circle_outline),
                   label: const Text('完了'),
                 ),
@@ -660,6 +745,298 @@ class _MessagePanel extends StatelessWidget {
       ),
     );
   }
+}
+
+class _AiAssistDialog extends StatelessWidget {
+  final String taskTitle;
+  final String mode;
+  final Map<String, dynamic> guidance;
+  final String generatedBy;
+
+  const _AiAssistDialog({
+    required this.taskTitle,
+    required this.mode,
+    required this.guidance,
+    required this.generatedBy,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isBreakdown = mode == 'breakdown';
+    final summary = _aiText(guidance['summary']);
+    final subtasks = _aiMapList(guidance['subtasks']);
+    final steps = _aiMapList(guidance['steps']);
+    final prerequisites = _aiStringList(guidance['prerequisites']);
+    final blockers = _aiStringList(guidance['blockers']);
+    final checklist = _aiStringList(guidance['checklist']);
+    final source = generatedBy.trim().isNotEmpty
+        ? generatedBy.trim()
+        : _aiText(guidance['generated_by']);
+
+    return AlertDialog(
+      title: Text(isBreakdown ? 'AIタスク分割' : 'AI実施手順'),
+      content: SizedBox(
+        width: 680,
+        child: SingleChildScrollView(
+          child: SelectionArea(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  taskTitle,
+                  style: const TextStyle(fontWeight: FontWeight.w800),
+                ),
+                if (summary.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  _assistCard(
+                    context,
+                    icon: Icons.auto_awesome,
+                    title: 'AIの見立て',
+                    child: Text(summary),
+                  ),
+                ],
+                const SizedBox(height: 12),
+                if (isBreakdown)
+                  _subtasksSection(context, subtasks)
+                else
+                  _procedureSection(context, steps),
+                _listSection(
+                  context,
+                  icon: Icons.fact_check_outlined,
+                  title: '事前に確認すること',
+                  items: prerequisites,
+                ),
+                _listSection(
+                  context,
+                  icon: Icons.warning_amber_outlined,
+                  title: '詰まりやすい点',
+                  items: blockers,
+                ),
+                _listSection(
+                  context,
+                  icon: Icons.checklist_outlined,
+                  title: '完了前チェック',
+                  items: checklist,
+                ),
+                if (source.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    'generated by $source',
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('閉じる'),
+        ),
+      ],
+    );
+  }
+
+  Widget _subtasksSection(
+    BuildContext context,
+    List<Map<String, dynamic>> subtasks,
+  ) {
+    if (subtasks.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _sectionHeader(context, Icons.account_tree_outlined, '小さなタスク'),
+        const SizedBox(height: 8),
+        for (final entry in subtasks.asMap().entries) ...[
+          _assistCard(
+            context,
+            title:
+                '${entry.key + 1}. ${_aiText(entry.value['title']).isEmpty ? '小タスク' : _aiText(entry.value['title'])}',
+            subtitle: _aiText(entry.value['goal']),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _inlineList(_aiStringList(entry.value['steps'])),
+                if (_aiText(entry.value['done_when']).isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Text('完了条件: ${_aiText(entry.value['done_when'])}'),
+                ],
+                if (entry.value['estimated_minutes'] != null) ...[
+                  const SizedBox(height: 4),
+                  Text('目安: ${entry.value['estimated_minutes']}分'),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ],
+    );
+  }
+
+  Widget _procedureSection(
+    BuildContext context,
+    List<Map<String, dynamic>> steps,
+  ) {
+    if (steps.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _sectionHeader(context, Icons.menu_book_outlined, '実施手順'),
+        const SizedBox(height: 8),
+        for (final entry in steps.asMap().entries) ...[
+          _assistCard(
+            context,
+            title:
+                '${entry.key + 1}. ${_aiText(entry.value['title']).isEmpty ? '手順' : _aiText(entry.value['title'])}',
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (_aiText(entry.value['detail']).isNotEmpty)
+                  Text(_aiText(entry.value['detail'])),
+                if (_aiText(entry.value['expected_result']).isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Text('到達状態: ${_aiText(entry.value['expected_result'])}'),
+                ],
+                if (_aiText(entry.value['caution']).isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Text('注意: ${_aiText(entry.value['caution'])}'),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ],
+    );
+  }
+
+  Widget _listSection(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required List<String> items,
+  }) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _sectionHeader(context, icon, title),
+          const SizedBox(height: 6),
+          _inlineList(items),
+        ],
+      ),
+    );
+  }
+
+  Widget _sectionHeader(BuildContext context, IconData icon, String title) {
+    return Row(
+      children: [
+        Icon(icon, size: 18, color: Theme.of(context).colorScheme.primary),
+        const SizedBox(width: 6),
+        Text(title, style: const TextStyle(fontWeight: FontWeight.w800)),
+      ],
+    );
+  }
+
+  Widget _inlineList(List<String> items) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final item in items)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: Text('・$item'),
+          ),
+      ],
+    );
+  }
+
+  Widget _assistCard(
+    BuildContext context, {
+    IconData? icon,
+    required String title,
+    String? subtitle,
+    required Widget child,
+  }) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: Theme.of(context).colorScheme.outlineVariant,
+        ),
+        borderRadius: BorderRadius.circular(8),
+        color: Theme.of(context).colorScheme.surfaceContainerHighest
+            .withValues(alpha: 0.45),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                if (icon != null) ...[
+                  Icon(
+                    icon,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(width: 6),
+                ],
+                Expanded(
+                  child: Text(
+                    title,
+                    style: const TextStyle(fontWeight: FontWeight.w800),
+                  ),
+                ),
+              ],
+            ),
+            if (subtitle != null && subtitle.trim().isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                subtitle.trim(),
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            const SizedBox(height: 8),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _aiText(Object? value) => '${value ?? ''}'.trim();
+
+List<String> _aiStringList(Object? value) {
+  if (value is List) {
+    return value
+        .map((item) => _aiText(item))
+        .where((item) => item.isNotEmpty)
+        .toList();
+  }
+  final single = _aiText(value);
+  return single.isEmpty ? const [] : [single];
+}
+
+List<Map<String, dynamic>> _aiMapList(Object? value) {
+  if (value is! List) return const [];
+  return value
+      .whereType<Map>()
+      .map((item) => Map<String, dynamic>.from(item))
+      .toList();
 }
 
 class _ReportResult {

--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -210,6 +210,284 @@ function compareWbsTasks(a: Record<string, unknown>, b: Record<string, unknown>)
   return String(a.title ?? "").localeCompare(String(b.title ?? ""));
 }
 
+type WbsUserTaskAssistMode = "breakdown" | "procedure";
+
+function cleanAiJsonText(text: string): string {
+  let cleaned = text.trim();
+  if (cleaned.startsWith("```")) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, "").replace(/```$/g, "").trim();
+  }
+  const firstBrace = cleaned.indexOf("{");
+  const lastBrace = cleaned.lastIndexOf("}");
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    return cleaned.slice(firstBrace, lastBrace + 1);
+  }
+  return cleaned;
+}
+
+function stringArrayFromUnknown(value: unknown, fallback: string[] = []): string[] {
+  const values = Array.isArray(value) ? value : typeof value === "string" ? [value] : fallback;
+  return values
+    .map((item) => String(item ?? "").trim())
+    .filter((item) => item.length > 0)
+    .slice(0, 12);
+}
+
+function recordArrayFromUnknown(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => asRecord(item))
+    .filter((item): item is Record<string, unknown> => item !== null);
+}
+
+function normalizeWbsUserTaskAssist(
+  rawValue: unknown,
+  fallback: Record<string, unknown>,
+  mode: WbsUserTaskAssistMode,
+  generatedBy: string,
+): Record<string, unknown> {
+  const raw = asRecord(rawValue) ?? {};
+  const fallbackSubtasks = recordArrayFromUnknown(fallback.subtasks);
+  const fallbackSteps = recordArrayFromUnknown(fallback.steps);
+  const subtasks = recordArrayFromUnknown(raw.subtasks).slice(0, 8).map((item, index) => ({
+    title: String(item.title ?? `小タスク ${index + 1}`).trim(),
+    goal: String(item.goal ?? "").trim(),
+    steps: stringArrayFromUnknown(item.steps).slice(0, 6),
+    estimated_minutes: Number.isFinite(Number(item.estimated_minutes)) ? Number(item.estimated_minutes) : null,
+    done_when: String(item.done_when ?? "").trim(),
+  })).filter((item) => item.title.length > 0);
+  const steps = recordArrayFromUnknown(raw.steps).slice(0, 10).map((item, index) => ({
+    title: String(item.title ?? `手順 ${index + 1}`).trim(),
+    detail: String(item.detail ?? "").trim(),
+    expected_result: String(item.expected_result ?? "").trim(),
+    caution: String(item.caution ?? "").trim(),
+  })).filter((item) => item.title.length > 0);
+
+  return {
+    summary: String(raw.summary ?? fallback.summary ?? "").trim().slice(0, 600),
+    prerequisites: stringArrayFromUnknown(raw.prerequisites, stringArrayFromUnknown(fallback.prerequisites)).slice(0, 8),
+    subtasks: mode === "breakdown" && subtasks.length > 0 ? subtasks : fallbackSubtasks,
+    steps: mode === "procedure" && steps.length > 0 ? steps : fallbackSteps,
+    blockers: stringArrayFromUnknown(raw.blockers, stringArrayFromUnknown(fallback.blockers)).slice(0, 6),
+    checklist: stringArrayFromUnknown(raw.checklist, stringArrayFromUnknown(fallback.checklist)).slice(0, 8),
+    generated_by: generatedBy,
+  };
+}
+
+function fallbackWbsUserTaskAssist(
+  task: Record<string, unknown>,
+  mode: WbsUserTaskAssistMode,
+  generatedBy: string,
+): Record<string, unknown> {
+  const title = String(task.title ?? "ユーザータスク").trim();
+  const due = String(task.end_date ?? "").trim();
+  const dueText = due ? `期限は ${due} です。` : "期限が未設定なら先に確認してください。";
+  const commonPrerequisites = [
+    "タスクの完了条件を1文で書き出す",
+    "提出先・確認相手・必要書類を確認する",
+    "不明点を1つに絞ってメモする",
+  ];
+  const commonChecklist = [
+    "完了条件を満たした証跡を保存した",
+    "次に待つ相手や期限が明確になっている",
+    "WBSユーザータスク画面で状況報告を更新した",
+  ];
+  const subtasks = [
+    {
+      title: "完了条件を決める",
+      goal: `${title}で何が終われば完了かを明確にする。${dueText}`,
+      steps: ["関連メモとWBS説明を読む", "成果物・提出先・期限を1行で書く"],
+      estimated_minutes: 10,
+      done_when: "次に何を作る/送る/確認するかが1文で言える",
+    },
+    {
+      title: "必要情報を集める",
+      goal: "作業に必要な情報や書類をそろえる",
+      steps: ["手元にある資料を確認する", "足りない情報をチェックリスト化する"],
+      estimated_minutes: 20,
+      done_when: "不足情報がゼロ、または問い合わせ先が決まっている",
+    },
+    {
+      title: "最初の外部確認を送る",
+      goal: "相手待ちで止まらないように確認依頼を出す",
+      steps: ["質問を3点以内に絞る", "メール/Slack/フォームで送信する"],
+      estimated_minutes: 15,
+      done_when: "送信履歴と返信期限が残っている",
+    },
+    {
+      title: "進捗をWBSに戻す",
+      goal: "作業状況を共有して次の判断をしやすくする",
+      steps: ["進捗率を更新する", "詰まり・次アクションを記録する"],
+      estimated_minutes: 5,
+      done_when: "WBSユーザータスクに最新状況が反映されている",
+    },
+  ];
+  const steps = [
+    {
+      title: "目的と期限を確認する",
+      detail: `${title}の説明、期限、関連メモを確認し、今日終える範囲を決めます。${dueText}`,
+      expected_result: "今日の到達点が1つに絞られている",
+      caution: "完璧な全体像を作る前に、最初の確認行動を決めてください",
+    },
+    {
+      title: "必要な相手・資料を洗い出す",
+      detail: "提出先、承認者、参考URL、必要書類を箇条書きにします。",
+      expected_result: "不足している情報と問い合わせ先が分かる",
+      caution: "個人情報や契約情報は公開チャネルに貼らないでください",
+    },
+    {
+      title: "最小の実行単位で進める",
+      detail: "15分で終わる確認、作成、送信のどれか1つを実施します。",
+      expected_result: "作業が着手済みになり、次の待ち状態が明確になる",
+      caution: "相手待ちが発生したら返信期限をメモしてください",
+    },
+    {
+      title: "WBSへ状況報告する",
+      detail: "進捗率、実施内容、詰まり、次アクションをユーザータスク画面から更新します。",
+      expected_result: "他インスタンスが現在地を把握できる",
+      caution: "完了していない場合は次アクションを必ず残してください",
+    },
+  ];
+
+  return {
+    summary: mode === "breakdown"
+      ? `「${title}」を止めないため、15〜20分単位の小さな作業に分けました。`
+      : `「${title}」を進めるための実施順です。迷ったら上から1つずつ処理してください。`,
+    prerequisites: commonPrerequisites,
+    subtasks,
+    steps,
+    blockers: [
+      "完了条件が曖昧なまま作業を始める",
+      "確認相手が決まらず相手待ちにできない",
+      "証跡を残さず、後で進捗報告できない",
+    ],
+    checklist: commonChecklist,
+    generated_by: generatedBy,
+  };
+}
+
+async function generateWbsUserTaskAssistWithOpenAi(
+  prompt: string,
+  fallback: Record<string, unknown>,
+  mode: WbsUserTaskAssistMode,
+  task: Record<string, unknown>,
+  fallbackReason: string,
+): Promise<Record<string, unknown>> {
+  const openAiKey = Deno.env.get("OPENAI_API_KEY") ?? "";
+  if (!openAiKey) {
+    return fallbackWbsUserTaskAssist(task, mode, `fallback:${fallbackReason}:no_openai_key`);
+  }
+
+  try {
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${openAiKey}`,
+      },
+      body: JSON.stringify({
+        model: Deno.env.get("WBS_ASSIST_OPENAI_MODEL") ?? "gpt-4o-mini",
+        messages: [
+          { role: "system", content: "あなたはWBSユーザータスクの実務支援AIです。必ずJSONのみで回答してください。" },
+          { role: "user", content: prompt },
+        ],
+        response_format: { type: "json_object" },
+        temperature: 0.2,
+        max_tokens: 2200,
+      }),
+    });
+    if (!res.ok) {
+      return fallbackWbsUserTaskAssist(task, mode, `fallback:${fallbackReason}:openai_http_${res.status}`);
+    }
+    const data = await res.json() as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const text = data.choices?.[0]?.message?.content ?? "";
+    if (!text.trim()) {
+      return fallbackWbsUserTaskAssist(task, mode, `fallback:${fallbackReason}:empty_openai_response`);
+    }
+    const parsed = JSON.parse(cleanAiJsonText(text));
+    return normalizeWbsUserTaskAssist(
+      parsed,
+      fallback,
+      mode,
+      Deno.env.get("WBS_ASSIST_OPENAI_MODEL") ?? "gpt-4o-mini",
+    );
+  } catch (err) {
+    console.warn(`wbs.user_task_ai_assist OpenAI fallback failed: ${String(err)}`);
+    return fallbackWbsUserTaskAssist(task, mode, `fallback:${fallbackReason}:openai_error`);
+  }
+}
+
+async function generateWbsUserTaskAssist(
+  task: Record<string, unknown>,
+  mode: WbsUserTaskAssistMode,
+): Promise<Record<string, unknown>> {
+  const fallback = fallbackWbsUserTaskAssist(task, mode, "fallback");
+  const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
+  const prompt = [
+    "あなたはWBSユーザータスクの実務支援AIです。",
+    "ユーザーが手を止めずに進められるよう、抽象的な助言ではなく、今日実行できる粒度で返してください。",
+    mode === "breakdown"
+      ? "目的: タスクを15〜30分で実行できる小さなサブタスクに分割する。"
+      : "目的: 初心者でも迷わない詳細な実施手順を作る。",
+    "必ずJSONのみで返してください。Markdownや説明文は不要です。",
+    "JSON schema:",
+    `{"summary":"string","prerequisites":["string"],"subtasks":[{"title":"string","goal":"string","steps":["string"],"estimated_minutes":15,"done_when":"string"}],"steps":[{"title":"string","detail":"string","expected_result":"string","caution":"string"}],"blockers":["string"],"checklist":["string"]}`,
+    "対象タスク:",
+    JSON.stringify({
+      id: task.id,
+      title: task.title,
+      description: task.description,
+      category: task.category,
+      status: task.status,
+      progress: task.progress,
+      priority: task.priority,
+      end_date: task.end_date,
+      user_report_status: task.user_report_status,
+      user_report_note: task.user_report_note,
+      latest_report: task.latest_report ?? null,
+    }),
+  ].join("\n");
+
+  if (!geminiKey) {
+    return generateWbsUserTaskAssistWithOpenAi(prompt, fallback, mode, task, "no_gemini_key");
+  }
+
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${geminiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ role: "user", parts: [{ text: prompt }] }],
+          generationConfig: {
+            temperature: 0.25,
+            maxOutputTokens: 2200,
+            responseMimeType: "application/json",
+          },
+        }),
+      },
+    );
+    if (!res.ok) {
+      return generateWbsUserTaskAssistWithOpenAi(prompt, fallback, mode, task, `gemini_http_${res.status}`);
+    }
+    const data = await res.json() as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+    };
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+    if (!text.trim()) {
+      return generateWbsUserTaskAssistWithOpenAi(prompt, fallback, mode, task, "empty_gemini_response");
+    }
+    const parsed = JSON.parse(cleanAiJsonText(text));
+    return normalizeWbsUserTaskAssist(parsed, fallback, mode, "gemini-2.5-flash");
+  } catch (err) {
+    console.warn(`wbs.user_task_ai_assist fallback: ${String(err)}`);
+    return generateWbsUserTaskAssistWithOpenAi(prompt, fallback, mode, task, "gemini_error");
+  }
+}
+
 const WBS_INSTANCE_VALUES = [
   "codex",     // OpenAI Codex CLI
   "gemini",    // Google Gemini Code Assist
@@ -3657,6 +3935,53 @@ serve(async (req) => {
             status: "in_progress",
           });
         }
+
+        // ── WBS User Task AI Assist (UI向け) ───────────────────────────────
+        // user instance task を、AIで「小タスク化」または「詳細手順化」する。
+        // body: {task_id, mode: "breakdown" | "procedure"}
+        case "wbs.user_task_ai_assist": {
+          const taskId = String(body.task_id ?? body.id ?? "").trim();
+          const requestedMode = String(body.mode ?? "breakdown").trim();
+          const mode: WbsUserTaskAssistMode = requestedMode === "procedure" ? "procedure" : "breakdown";
+          if (!taskId) return json({ error: "task_id required" }, 400);
+
+          const { data: task, error: taskErr } = await admin
+            .from("wbs_tasks")
+            .select("id, category, title, description, status, progress, priority, end_date, instance, owner_instance, user_report_status, user_report_note, user_reported_at, updated_at")
+            .eq("id", taskId)
+            .maybeSingle();
+          if (taskErr) throw new Error(taskErr.message);
+          if (!task) return json({ error: "user task not found" }, 404);
+          if (task.instance !== "user" && task.owner_instance !== "user") {
+            return json({ error: "instance != 'user' / AI assist 不可", reason: "non_user_task" }, 403);
+          }
+
+          const { data: reports, error: reportErr } = await admin
+            .from("wbs_user_task_reports")
+            .select("status, progress, report_text, blockers, next_action, created_at")
+            .eq("task_id", taskId)
+            .order("created_at", { ascending: false })
+            .limit(1);
+          if (reportErr) {
+            console.warn(`wbs_user_task_reports latest fetch skipped: ${reportErr.message}`);
+          }
+
+          const taskWithReport = {
+            ...(task as Record<string, unknown>),
+            latest_report: reports?.[0] ?? null,
+          };
+          const guidance = await generateWbsUserTaskAssist(taskWithReport, mode);
+
+          return json({
+            success: true,
+            mode,
+            task_id: taskId,
+            task_title: task.title,
+            generated_by: guidance.generated_by ?? null,
+            guidance,
+          });
+        }
+
         // ── WBS Get User Tasks (UI向け) ──────────────────────────────────────
         case "wbs.get_user_tasks": {
           // UI から呼ぶユーザータスク一覧 (pending/in_progress/blocked + completed 直近10件)
@@ -4380,6 +4705,7 @@ ${reportText ? `> ${reportText}` : ""}`,
             "wbs.update_user_task_report",
             "wbs.user_task_report",
             "wbs.export_user_tasks_md",
+            "wbs.user_task_ai_assist",
             "wbs.get_user_tasks",
             "wbs.submit_user_task_report",
             "legal.harvey.complete",


### PR DESCRIPTION
## Summary
- Restore the WBS user-task AI assist buttons for task breakdown and detailed procedure guidance on /wbs-user-tasks.
- Add/restore the tools-hub action wbs.user_task_ai_assist with Gemini/OpenAI/fallback generation.
- Re-deployed 	ools-hub to Supabase so the backend action is already available in production.

## Verification
- deno check supabase/functions/tools-hub/index.ts
- deno lint supabase/functions/tools-hub/index.ts
- Local Flutter analyzer/build are currently blocked by stuck Dart processes on this workstation, so CI should be the authoritative web build check.