### PR TITLE
fix(comparison): DALL-E価格文言の構文エラーを修正

### DIFF
--- a/lib/pages/comparison_page.dart
+++ b/lib/pages/comparison_page.dart
@@ -7684,9 +7684,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
     searchKeyword: 'DALL-E代替 DALL-E3代替 OpenAI画像生成代替',
     accentColor: Color(0xFF10A37F),
     painPoints: [
-      'DALL-EはChatGPT Plus(月額
-$
-20)統合の画像生成で単体アプリでない',
+      r'DALL-EはChatGPT Plus(月額$20)統合の画像生成で単体アプリでない',
       '財務管理・習慣追跡・タスク管理・AI大学など個人OS機能がない',
       'ChatGPT有料プラン前提でコストがかかる',
     ],


### PR DESCRIPTION
## Summary
- comparison_page.dart の DALL-E 価格文言で改行された $20 を raw string に修正
- main の production deploy を止めていた Flutter analyze エラーを解消

## Verification
- git diff --check
- Supabase tools-hub は先行してデプロイ済み
- ローカル dart format は 60s タイムアウトのため GitHub Actions で確認