### PR TITLE
fix(web): set Flutter base href for Firebase Hosting

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-  <base href="$FLUTTER_BASE_HREF">
+  <base href="/">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">


### PR DESCRIPTION
## Summary
- Replace unresolved $FLUTTER_BASE_HREF placeholder with / in web/index.html
- Prevent deployed Flutter Web from staying on the bootstrap/landing loading screen when the placeholder is served as-is

## Verification
- git diff --check origin/main...HEAD
- lutter analyze lib/pages/user_tasks_page.dart was attempted but timed out after 120s in this worktree

## Notes
- WBS user task AI assist UI/action is already present on current origin/main; this PR focuses on the remaining deploy bootstrap blocker so the latest app can load.