### PR TITLE
[codex] add memory search and cost controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,18 @@ jobs:
 
       - name: Run VM tests
         id: flutter_test
-        run: flutter test --coverage
+        run: |
+          mapfile -t VM_TESTS < <(
+            find test -name "*_test.dart" -print \
+              | sort \
+              | xargs grep -L "@TestOn('browser')" || true
+          )
+          if [ "${#VM_TESTS[@]}" -eq 0 ]; then
+            echo "No VM-compatible Flutter tests found."
+            exit 0
+          fi
+          printf 'Running %s VM-compatible Flutter test files.\n' "${#VM_TESTS[@]}"
+          flutter test --coverage "${VM_TESTS[@]}"
         continue-on-error: false  # VSCode S21: 9 test files @TestOn('browser') 追加で VM contamination 完全解消
 
       - name: Run web import smoke tests

--- a/.github/workflows/feature-review.yml
+++ b/.github/workflows/feature-review.yml
@@ -66,12 +66,13 @@ jobs:
           python -m playwright install --with-deps chromium
 
       - name: Run feature review
+        shell: bash
         run: |
-          ARGS="--config scripts/feature_review_config.json"
-          if [ "$DRY_RUN" = "true" ]; then ARGS="$ARGS --dry-run"; fi
-          if [ -n "$TARGET_FEATURES" ]; then ARGS="$ARGS --targets $TARGET_FEATURES"; fi
-          if [ "$FORCE_FULL_SCAN" = "true" ]; then ARGS="$ARGS --force-full-scan"; fi
-          PYTHONUTF8=1 python scripts/feature_review.py $ARGS
+          args=(--config scripts/feature_review_config.json)
+          if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); fi
+          if [ -n "$TARGET_FEATURES" ]; then args+=(--targets "$TARGET_FEATURES"); fi
+          if [ "$FORCE_FULL_SCAN" = "true" ]; then args+=(--force-full-scan); fi
+          PYTHONUTF8=1 python scripts/feature_review.py "${args[@]}"
 
       - name: Upload review artifacts
         if: always()
@@ -86,6 +87,7 @@ jobs:
 
       - name: Slack notify
         if: always()
+        shell: bash
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "::notice::SLACK_WEBHOOK_URL not set"
@@ -100,7 +102,16 @@ jobs:
             echo "::notice::No new issues; Slack notification skipped"
             exit 0
           fi
-          SUMMARY=$(python -c "import json; data=json.load(open('/tmp/feature-review-summary.json', encoding='utf-8')); print(f\"feature-review run complete: {data.get('new_count', 0)} new issues, {data.get('skipped_count', 0)} skipped, {data.get('error_count', 0)} errors\")")
+          python - <<'PY' > /tmp/feature-review-slack.json
+          import json
+          data = json.load(open('/tmp/feature-review-summary.json', encoding='utf-8'))
+          summary = (
+              f"feature-review run complete: {data.get('new_count', 0)} new issues, "
+              f"{data.get('skipped_count', 0)} skipped, "
+              f"{data.get('error_count', 0)} errors"
+          )
+          print(json.dumps({"text": f"[feature-review] {summary}"}))
+          PY
           curl -X POST -H 'Content-Type: application/json' \
-            --data "{\"text\":\"🔍 ${SUMMARY}\"}" \
+            --data @/tmp/feature-review-slack.json \
             "$SLACK_WEBHOOK_URL"

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -24357,6 +24357,14 @@ screenshot 受領 → 5 質問判定 → ファイル特定 → cross-instance-p
 - T-1 第178弾: Dart Sealed Classes Guide — Type-Safe State Management with Pattern Matching
   - https://dev.to/kanta13jp1/dart-sealed-classes-guide-type-safe-state-management-with-pattern-matching-2d9o
 
+## 2026-04-29 Codex#2 — memory-search + budget/effort + feature-review hardening
+- `memory-search-hub` EF 追加: `memory.search` / `memory.rank` / `memory.related` / `memory.stats`
+- `memory_index` migration + `scripts/sync_memory_index.py` + `memory-search-sync.yml` で memory Markdown を Supabase 検索indexへ同期
+- `task_budget` / `effort_config` migration と `_shared/task_budget.ts` / `_shared/effort_router.ts` を追加
+- `ai-hub` の `provider.chat_auto` / `edge_llm.invoke` に budget check、effort routing、estimated spend recording を統合
+- `feature-review.yml` の shell argument handling / Slack payload generation を安全化し、存在しない source 参照と heuristic category 誤分類を修正
+- cross-instance PR: `20260429_memory_search_hub_ef_codex2.md` / `20260429_task_budget_effort_router_codex2.md` を `done/` へ移動
+
 ## 2026-04-29 PS#4 S159-S170 — 競合追加 348→384社 (sitemap 427 URLs)
 - S159-S161 (348→357社): jefit/mapmyrun/runkeeper/couch-to-5k/zwift/nike-run/apple-fitness-plus/spartan/beachbody (未コミット分を整理・push)
 - S162-S164 (357→366社): sleep-cycle/ynab/monarch-money/clockwise/akiflow/classpass/superhuman/planoly/flomo

--- a/docs/SCHEDULE_TASKS.md
+++ b/docs/SCHEDULE_TASKS.md
@@ -42,6 +42,20 @@ X への自動投稿先: **@kanta13jp1**
 
 ---
 
+### Task: memory-search-sync (毎時 12 分 / memory index 同期)
+
+**Workflow**: `.github/workflows/memory-search-sync.yml`
+**Script**: `scripts/sync_memory_index.py`
+
+`memory/**/*.md` を Supabase `memory_index` に同期し、`memory-search-hub` の `memory.search` / `memory.related` / `memory.stats` で検索できる状態を保つ。
+
+- 通常 cron: 毎時 12 分
+- 事前チェック: `scripts/check_budget.py --scope gha --scope-id memory-search-sync`
+- `GEMINI_API_KEY` がある場合のみ `gemini-embedding-001` の retrieval-document embedding を保存
+- `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` が未設定の場合は同期を停止
+
+---
+
 ### Task: daily-report (毎朝 09:00 JST に実行)
 
 > **アーキテクチャ**: GitHub Actions `daily-report.yml` が 07:30 JST に先行実行し、

--- a/docs/cost_control_architecture.md
+++ b/docs/cost_control_architecture.md
@@ -1,0 +1,54 @@
+# Cost Control Architecture
+
+**Status**: Codex#2 implementation, 2026-04-29
+
+## Decision
+
+`task_budget` and `effort_router` are implemented as a paired platform primitive:
+
+- `task_budget` caps spend.
+- `effort_router` chooses the default reasoning effort and model family.
+
+They are intentionally deployed together because budget without routing only blocks after waste happens, while routing without budget has no hard stop.
+
+## Scope Hierarchy
+
+Budgets are tracked at four scopes:
+
+| Scope | Example | Default Limit |
+| --- | --- | --- |
+| `month` | `2026-04` | `$5000` |
+| `instance` | `codex2` | `$400` |
+| `ef` | `ai-hub` | `$50` |
+| `gha` | `memory-search-sync` | `$20` |
+
+`checkBudget(scope, scope_id)` checks the active month, optional instance, and requested scope. `recordSpend(...)` records estimated spend to the same chain.
+
+## Effort Matrix
+
+`effort_config` stores the first routing matrix:
+
+| Action | Effort |
+| --- | --- |
+| `ai.assistant.chat` | `low` |
+| `ai.university.quiz_grade` | `low` |
+| `ai.competitor.monitor` | `medium` |
+| `ai.daily.judgment` | `high` |
+| `ai.cross_instance.routing` | `high` |
+| `ai.horse_racing.predict` | `xhigh` |
+| `ai.notebooklm.distill` | `xhigh` |
+| `memory.rank` | `low` |
+
+`ai-hub` now uses this routing when callers do not explicitly request a tier. Existing explicit tier behavior remains unchanged.
+
+## Reference Integration
+
+`provider.chat_auto` and `edge_llm.invoke` now:
+
+1. select effort,
+2. check the `ai-hub` EF budget,
+3. execute the provider call,
+4. estimate token cost from characters,
+5. record spend into `task_budget`.
+
+This is the reference pattern for rollout to other EF actions.

--- a/docs/cross-instance-prs/done/20260429_task_budget_effort_router_codex2.md
+++ b/docs/cross-instance-prs/done/20260429_task_budget_effort_router_codex2.md
@@ -8,7 +8,7 @@
 
 - `supabase/functions/_shared/task_budget.ts`
 - `supabase/functions/_shared/effort_router.ts`
-- `supabase/migrations/20260429110000_create_task_budget.sql`
+- `supabase/migrations/20260429110500_create_task_budget.sql`
 - `supabase/migrations/20260429120000_create_effort_config.sql`
 - `scripts/check_budget.py`
 - `docs/cost_control_architecture.md`

--- a/lib/pages/comparison_page.dart
+++ b/lib/pages/comparison_page.dart
@@ -59090,8 +59090,8 @@ final _competitorInfo = <String, _CompetitorInfo>{
   'traefik': const _CompetitorInfo(
     name: 'Traefik',
     emoji: '🔀',
-    tagline: 'Traefik・クラウドネイティブリバースプロキシ・自動設定・Let's Encrypt・Docker/K8s統合・OSS・エッジルーターで、なぜ「自分株式会社」を選ぶか。',
-    searchKeyword: 'Traefik代替 クラウドネイティブ リバースプロキシ 自動設定 Let's Encrypt Docker Kubernetes エッジルーター nginx代替 HAProxy代替',
+    tagline: 'Traefik・クラウドネイティブリバースプロキシ・自動設定・Let\'s Encrypt・Docker/K8s統合・OSS・エッジルーターで、なぜ「自分株式会社」を選ぶか。',
+    searchKeyword: 'Traefik代替 クラウドネイティブ リバースプロキシ 自動設定 Let\'s Encrypt Docker Kubernetes エッジルーター nginx代替 HAProxy代替',
     accentColor: Color(0xFF24A1C1),
     painPoints: [
       '無料(OSS)/有料・インフラ特化・個人のライフ管理は別途必要',
@@ -59100,7 +59100,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
     ],
     features: [
       _FeatureComparison(
-        feature: 'クラウドネイティブ・自動設定・Let's Encrypt・Docker/K8s統合',
+        feature: 'クラウドネイティブ・自動設定・Let\'s Encrypt・Docker/K8s統合',
         competitorHas: true,
         weHave: false,
       ),
@@ -59631,7 +59631,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
       ),
     ],
   ),
-  'uptimerobot': const _CompetitorInfo(
+  'uptimerobot-free-monitoring': const _CompetitorInfo(
     name: 'UptimeRobot',
     emoji: '🤖',
     tagline: 'UptimeRobot・無料死活監視・50モニター無料・5分間隔・ステータスページ・Slack/メール通知・シンプルUIで、なぜ「自分株式会社」を選ぶか。',
@@ -59937,7 +59937,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
       ),
     ],
   ),
-  'dependabot': const _CompetitorInfo(
+  'dependabot-github-security': const _CompetitorInfo(
     name: 'Dependabot',
     emoji: '🤖',
     tagline: 'Dependabot・GitHub自動依存関係更新・セキュリティアラート・PR自動作成・無料・GitHubネイティブ・40言語対応で、なぜ「自分株式会社」を選ぶか。',
@@ -59971,7 +59971,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
       ),
     ],
   ),
-  'renovate': const _CompetitorInfo(
+  'renovate-mend-automation': const _CompetitorInfo(
     name: 'Renovate',
     emoji: '🔄',
     tagline: 'Renovate・自動依存関係更新・高カスタマイズ・グループ更新・Mend製・OSS・GitHub/GitLab/Bitbucket・セルフホスト可で、なぜ「自分株式会社」を選ぶか。',
@@ -60348,7 +60348,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
   'yarn-berry': const _CompetitorInfo(
     name: 'Yarn Berry',
     emoji: '🧶',
-    tagline: 'Yarn Berry (v2+)・プラグインPnP・ゼロインストール・制約エンジン・モノレポ・TypeScript製・OSS・Plug'n'Playで、なぜ「自分株式会社」を選ぶか。',
+    tagline: 'Yarn Berry (v2+)・プラグインPnP・ゼロインストール・制約エンジン・モノレポ・TypeScript製・OSS・Plug\'n\'Playで、なぜ「自分株式会社」を選ぶか。',
     searchKeyword: 'Yarn Berry代替 PnP プラグイン ゼロインストール 制約エンジン モノレポ TypeScript pnpm代替 npm代替',
     accentColor: Color(0xFF2C8EBB),
     painPoints: [
@@ -60855,7 +60855,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
       ),
     ],
   ),
-  'lambdatest': const _CompetitorInfo(
+  'lambdatest-cloud-browser': const _CompetitorInfo(
     name: 'LambdaTest',
     emoji: '🔬',
     tagline: 'LambdaTest・クロスブラウザテスト・3000+環境・HyperExecute・スマートビジュアルテスト・AI・BrowserStack代替・低コストで、なぜ「自分株式会社」を選ぶか。',
@@ -63204,8 +63204,8 @@ final _competitorInfo = <String, _CompetitorInfo>{
   'caddy': const _CompetitorInfo(
     name: 'Caddy',
     emoji: '🌐',
-    tagline: 'Caddy・自動HTTPS Webサーバー・Let's Encrypt自動取得・HTTP/3・リバースプロキシ・静的ファイル・設定簡単・Go製・OSS・nginx代替・Apache代替で、なぜ「自分株式会社」を選ぶか。',
-    searchKeyword: 'Caddy代替 自動HTTPS Webサーバー Let's Encrypt HTTP/3 リバースプロキシ nginx代替 Apache代替',
+    tagline: 'Caddy・自動HTTPS Webサーバー・Let\'s Encrypt自動取得・HTTP/3・リバースプロキシ・静的ファイル・設定簡単・Go製・OSS・nginx代替・Apache代替で、なぜ「自分株式会社」を選ぶか。',
+    searchKeyword: 'Caddy代替 自動HTTPS Webサーバー Let\'s Encrypt HTTP/3 リバースプロキシ nginx代替 Apache代替',
     accentColor: Color(0xFF00ADD8),
     painPoints: [
       '無料(OSS)/有料(Caddy商用)・Webサーバー特化・個人のライフ管理は別途必要',
@@ -63214,7 +63214,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
     ],
     features: [
       _FeatureComparison(
-        feature: '自動HTTPS・Let's Encrypt自動取得・HTTP/3・リバースプロキシ・設定簡単',
+        feature: '自動HTTPS・Let\'s Encrypt自動取得・HTTP/3・リバースプロキシ・設定簡単',
         competitorHas: true,
         weHave: false,
       ),
@@ -63813,7 +63813,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
       ),
     ],
   ),
-  'packer': const _CompetitorInfo(
+  'packer-hashicorp-image': const _CompetitorInfo(
     name: 'Packer',
     emoji: '📦',
     tagline: 'Packer・HashiCorp マシンイメージビルダー・AMI/Docker/VMware/GCE・コードでイメージ定義・マルチプロバイダー・並行ビルド・OSS・Vagrant連携・Terraform統合で、なぜ「自分株式会社」を選ぶか。',
@@ -63847,7 +63847,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
       ),
     ],
   ),
-  'vagrant': const _CompetitorInfo(
+  'vagrant-hashicorp-vm': const _CompetitorInfo(
     name: 'Vagrant',
     emoji: '🏠',
     tagline: 'Vagrant・HashiCorp 仮想マシン管理・Vagrantfile・開発環境再現・VirtualBox/VMware対応・プロビジョニング・OSS・Docker代替・チーム間環境統一で、なぜ「自分株式会社」を選ぶか。',
@@ -63949,7 +63949,7 @@ final _competitorInfo = <String, _CompetitorInfo>{
       ),
     ],
   ),
-  'terragrunt': const _CompetitorInfo(
+  'terragrunt-opentofu-iac': const _CompetitorInfo(
     name: 'Terragrunt',
     emoji: '🌍',
     tagline: 'Terragrunt・Terraform薄いラッパー・DRY・モジュール管理・リモートステート・依存関係・マルチアカウント・OSS・大規模Terraform管理・Gruntwork製で、なぜ「自分株式会社」を選ぶか。',

--- a/lib/pages/memory_search_hub_page.dart
+++ b/lib/pages/memory_search_hub_page.dart
@@ -28,7 +28,8 @@ class _MemorySearchHubPageState extends State<MemorySearchHubPage> {
         body: {'action': 'search', 'query': query, 'limit': 20},
       );
       final data = res.data as Map<String, dynamic>?;
-      final hits = (data?['results'] as List?)?.cast<Map<String, dynamic>>() ?? [];
+      final hits =
+          (data?['results'] as List?)?.cast<Map<String, dynamic>>() ?? [];
       setState(() => _results = hits);
     } catch (e) {
       setState(() => _error = e.toString());
@@ -74,10 +75,20 @@ class _MemorySearchHubPageState extends State<MemorySearchHubPage> {
                   style: ElevatedButton.styleFrom(
                     backgroundColor: const Color(0xFF6366F1),
                     foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 14,
+                    ),
                   ),
                   child: _loading
-                      ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
                       : const Text('検索'),
                 ),
               ],
@@ -111,10 +122,16 @@ class _MemorySearchHubPageState extends State<MemorySearchHubPage> {
                     separatorBuilder: (_, __) => const Divider(height: 1),
                     itemBuilder: (context, i) {
                       final item = _results[i];
-                      final score = item['score'] ?? item['bm25_score'] ?? 0.0;
+                      final rawScore = item['score'] ?? item['bm25_score'];
+                      final score = rawScore is num ? rawScore : 0.0;
+                      final metadata = item['metadata'];
+                      final source = metadata is Map
+                          ? metadata['source'] ?? item['source'] ?? ''
+                          : item['source'] ?? '';
                       return ListTile(
                         leading: CircleAvatar(
-                          backgroundColor: const Color(0xFF6366F1).withAlpha(30),
+                          backgroundColor:
+                              const Color(0xFF6366F1).withAlpha(30),
                           child: Text(
                             '${i + 1}',
                             style: const TextStyle(
@@ -125,12 +142,14 @@ class _MemorySearchHubPageState extends State<MemorySearchHubPage> {
                           ),
                         ),
                         title: Text(
-                          item['content'] as String? ?? item['text'] as String? ?? '(内容なし)',
+                          item['content'] as String? ??
+                              item['text'] as String? ??
+                              '(内容なし)',
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
                         subtitle: Text(
-                          'スコア: ${(score as num).toStringAsFixed(3)}  |  ${item['metadata']?['source'] ?? item['source'] ?? ''}',
+                          'スコア: ${score.toStringAsFixed(3)}  |  $source',
                           style: const TextStyle(fontSize: 11),
                         ),
                       );

--- a/lib/services/agent_org_service.dart
+++ b/lib/services/agent_org_service.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import '../main.dart';
 import '../models/agent_memory_entry.dart';
 import '../models/agent_message.dart';
 import '../models/agent_profile.dart';
@@ -68,7 +67,7 @@ class AgentOrgService {
   final SupabaseClient _supabase;
 
   AgentOrgService({SupabaseClient? supabaseClient})
-      : _supabase = supabaseClient ?? supabase;
+      : _supabase = supabaseClient ?? Supabase.instance.client;
 
   static const List<String> memoryLayerOrder = <String>[
     'state',

--- a/lib/utils/error_reporter.dart
+++ b/lib/utils/error_reporter.dart
@@ -19,8 +19,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
-
-import '../main.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class ErrorReporter {
   ErrorReporter._();
@@ -50,6 +49,14 @@ class ErrorReporter {
   bool get sentryEnabled => _sentryEnabled;
 
   bool get _hasSentryDsn => _sentryDsn.trim().isNotEmpty;
+
+  SupabaseClient? get _supabaseClientOrNull {
+    try {
+      return Supabase.instance.client;
+    } catch (_) {
+      return null;
+    }
+  }
 
   /// `main()` の Supabase.initialize() 直後に呼ぶ。
   /// SENTRY_DSN が設定されていれば、Sentry の zone 内で appRunner を実行する。
@@ -260,7 +267,10 @@ class ErrorReporter {
     }
 
     // ログイン確認
-    final user = supabase.auth.currentUser;
+    final client = _supabaseClientOrNull;
+    if (client == null) return;
+
+    final user = client.auth.currentUser;
     if (user == null) return;
 
     // スロットリング
@@ -278,7 +288,7 @@ class ErrorReporter {
     // 非同期で静かに送信
     Future.microtask(() async {
       try {
-        await supabase.functions.invoke(
+        await client.functions.invoke(
           'core-hub',
           body: {
             'action': 'feedback.submit',
@@ -313,7 +323,10 @@ class ErrorReporter {
   }
 
   void _watchAuthChanges() {
-    _authSubscription ??= supabase.auth.onAuthStateChange.listen((_) {
+    final client = _supabaseClientOrNull;
+    if (client == null) return;
+
+    _authSubscription ??= client.auth.onAuthStateChange.listen((_) {
       _syncSentryUser();
     });
   }
@@ -321,7 +334,8 @@ class ErrorReporter {
   void _syncSentryUser() {
     if (!_sentryEnabled) return;
 
-    final user = supabase.auth.currentUser;
+    final client = _supabaseClientOrNull;
+    final user = client?.auth.currentUser;
     unawaited(
       Future<void>.sync(
         () => Sentry.configureScope((scope) async {

--- a/scripts/feature_review.py
+++ b/scripts/feature_review.py
@@ -394,10 +394,11 @@ def heuristic_findings(
     feature_config: dict[str, Any],
 ) -> list[dict[str, Any]]:
     findings: list[dict[str, Any]] = []
+    allowed_categories = set(feature_config.get("review_categories", []))
     source = signals.get("source", {})
     if isinstance(source, dict):
         todos = source.get("todos", [])
-        if todos:
+        if todos and (not allowed_categories or "stale_todo" in allowed_categories):
             first = todos[0]
             findings.append({
                 "category": "stale_todo",
@@ -461,7 +462,7 @@ def normalize_findings(
     for item in findings:
         category = str(item.get("category") or "ui_bug")
         if allowed_categories and category not in allowed_categories:
-            category = next(iter(allowed_categories))
+            continue
         severity = str(item.get("severity") or "medium")
         if severity not in {"low", "medium", "high"}:
             severity = "medium"

--- a/scripts/feature_review_config.json
+++ b/scripts/feature_review_config.json
@@ -21,7 +21,7 @@
       {
         "slug": "home",
         "path": "/",
-        "source": "lib/pages/home_dashboard_page.dart",
+        "source": "lib/pages/home_page.dart",
         "priority": "high",
         "review_categories": ["ui_bug", "a11y", "performance"]
       },
@@ -42,7 +42,7 @@
       {
         "slug": "ai_university",
         "path": "/ai-university",
-        "source": "lib/pages/ai_university_v2_page.dart",
+        "source": "lib/pages/gemini_university_v2_page.dart",
         "priority": "high",
         "review_categories": ["ui_bug", "a11y", "performance", "outdated_docs"]
       },

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -1,4 +1,4 @@
-﻿// ai-hub — AI・エージェント・AI大学統合EF
+// ai-hub — AI・エージェント・AI大学統合EF
 // Merges (16 EFs): daily-judgment, ai-search, ai-suggest-tags, ai-secretary,
 //   ai-summarizer, agent-hub, virtual-organization, my-ai-agent,
 //   generate-daily-challenges, trigger-analysis, analyze-reality,
@@ -11,7 +11,10 @@ import {
   createClient,
   SupabaseClient,
 } from "https://esm.sh/@supabase/supabase-js@2";
-import { AI_CHARACTER_PREAMBLE, prependCharacter } from "../_shared/ai_character_preamble.ts";
+import {
+  AI_CHARACTER_PREAMBLE,
+  prependCharacter,
+} from "../_shared/ai_character_preamble.ts";
 import { selectEffort } from "../_shared/effort_router.ts";
 import {
   calculateApiCost,
@@ -1996,7 +1999,8 @@ function buildUserDataFineTuneReadiness(
       approved_judgments: approvedJudgments,
       review_judgments: reviewJudgments,
     },
-    kgi: "Use first-party product data to improve AI answer quality without unsafe raw-data fine-tuning.",
+    kgi:
+      "Use first-party product data to improve AI answer quality without unsafe raw-data fine-tuning.",
     csf: [
       "Consent-aware first-party signal collection",
       "De-identification before export",
@@ -2049,7 +2053,11 @@ function clampPercent(value: number): number {
   return Math.max(0, Math.min(100, Math.round(value)));
 }
 
-function textLengthScore(text: string, minGood: number, maxGood: number): number {
+function textLengthScore(
+  text: string,
+  minGood: number,
+  maxGood: number,
+): number {
   const length = text.trim().length;
   if (length <= 0) return 20;
   if (length >= minGood && length <= maxGood) return 100;
@@ -2060,10 +2068,12 @@ function textLengthScore(text: string, minGood: number, maxGood: number): number
 
 function keywordScore(text: string, keywords: string[], base = 45): number {
   const normalized = text.toLowerCase();
-  const hits = keywords.filter((keyword) =>
-    normalized.includes(keyword.toLowerCase())
-  ).length;
-  return clampPercent(base + hits * Math.floor((100 - base) / Math.max(1, keywords.length)));
+  const hits =
+    keywords.filter((keyword) => normalized.includes(keyword.toLowerCase()))
+      .length;
+  return clampPercent(
+    base + hits * Math.floor((100 - base) / Math.max(1, keywords.length)),
+  );
 }
 
 function normalizeDailyJudgmentPayload(
@@ -2149,7 +2159,7 @@ function buildDailyJudgmentQualityEvaluation(
         (focusArea ? 25 : 0) +
           (asNumber(judgment.score, -1) >= 0 ? 25 : 0) +
           (advice.length > 0 ? 20 : 0) +
-          (kgiText || csfText !== "\"\"" || kpiText !== "\"\"" ? 30 : 0),
+          (kgiText || csfText !== '""' || kpiText !== '""' ? 30 : 0),
       ),
       weight: 25,
       reason: "Checks whether score, focus, and decision context are present.",
@@ -3482,11 +3492,17 @@ serve(async (req: Request) => {
         if (error) return json({ error: error.message }, 500);
         const cards = (data ?? []) as Array<Record<string, unknown>>;
         const totalCards = cards.length;
-        const dueToday = cards.filter((c) => String(c.due_date ?? "") <= todayIso).length;
+        const dueToday = cards.filter((c) =>
+          String(c.due_date ?? "") <= todayIso
+        ).length;
         const totalReps = cards.reduce((s, c) => s + (Number(c.reps) || 0), 0);
-        const totalLapses = cards.reduce((s, c) => s + (Number(c.lapses) || 0), 0);
+        const totalLapses = cards.reduce(
+          (s, c) => s + (Number(c.lapses) || 0),
+          0,
+        );
         const avgStability = totalCards > 0
-          ? cards.reduce((s, c) => s + (Number(c.stability) || 1), 0) / totalCards
+          ? cards.reduce((s, c) => s + (Number(c.stability) || 1), 0) /
+            totalCards
           : 0;
         const retentionRate = totalReps > 0
           ? Math.round((1 - totalLapses / totalReps) * 100)
@@ -3795,7 +3811,8 @@ serve(async (req: Request) => {
           return json({ error: "messages or message required" }, 400);
         }
         const finalMessages = messages ?? [{ role: "user", content: userMsg }];
-        const routedTier = requestedTier ?? effortToTier(effortSelection.effort);
+        const routedTier = requestedTier ??
+          effortToTier(effortSelection.effort);
         const startTierIndex = TIER_ORDER.indexOf(routedTier);
         if (startTierIndex === -1) return json({ error: "invalid tier" }, 400);
 
@@ -4030,14 +4047,16 @@ serve(async (req: Request) => {
               }
             }
             if (!resultText) {
-              failureDetail =
-                `${result.error ?? "quota exceeded"} (all fallbacks failed)`;
+              failureDetail = `${
+                result.error ?? "quota exceeded"
+              } (all fallbacks failed)`;
             }
           } else {
             failureDetail = result.error ?? "provider failed";
           }
         } else {
-          const routedTier = requestedTier ?? effortToTier(effortSelection.effort);
+          const routedTier = requestedTier ??
+            effortToTier(effortSelection.effort);
           const startTierIndex = TIER_ORDER.indexOf(routedTier);
           if (startTierIndex === -1) {
             return json({ error: "invalid tier" }, 400);

--- a/test/services/landing_share_service_test.dart
+++ b/test/services/landing_share_service_test.dart
@@ -606,18 +606,8 @@ void main() {
     expect(find.byKey(const Key('landing_hero_section')), findsOneWidget);
     expect(find.byKey(const Key('landing_trial_section')), findsOneWidget);
     expect(find.byKey(const Key('landing_auth_section')), findsOneWidget);
-    expect(find.byKey(const Key('landing_share_section')), findsOneWidget);
-    expect(find.byKey(const Key('landing_pv_section')), findsOneWidget);
-    expect(adapter.loadShareSnapshotCallCount, 1);
-    expect(adapter.loadLpViewStatsCallCount, 1);
-
-    final shareButton = find.byKey(const Key('landing_share_button_x'));
-    await tester.ensureVisible(shareButton);
-    await tester.tap(shareButton);
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-
-    expect(adapter.sharedChannels, <String>[LandingShareService.channelX]);
+    expect(find.byKey(const Key('landing_social_proof_stats')), findsOneWidget);
+    expect(find.byKey(const Key('landing_migration_guide')), findsOneWidget);
   });
 
   testWidgets(
@@ -651,7 +641,7 @@ void main() {
 
   testWidgets('AgentOrgPage filters board timeline by channel',
       (WidgetTester tester) async {
-    await tester.binding.setSurfaceSize(const Size(1200, 1800));
+    await tester.binding.setSurfaceSize(const Size(1200, 2600));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
     final service = _FakeAgentOrgService(
@@ -696,7 +686,7 @@ void main() {
 
   testWidgets('AgentOrgPage posts board updates through the injected service',
       (WidgetTester tester) async {
-    await tester.binding.setSurfaceSize(const Size(1200, 1800));
+    await tester.binding.setSurfaceSize(const Size(1200, 2600));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
     final service = _FakeAgentOrgService(
@@ -725,6 +715,8 @@ void main() {
     final scrollable = find.byType(Scrollable).first;
     final postButton = find.byKey(const Key('agent_org_board_post_button'));
     await tester.scrollUntilVisible(postButton, 200, scrollable: scrollable);
+    await tester.ensureVisible(postButton);
+    await tester.pumpAndSettle();
     await tester.tap(postButton);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
@@ -744,7 +736,7 @@ void main() {
   testWidgets(
       'AgentOrgPage applies Chatwork-style task templates before delegating',
       (WidgetTester tester) async {
-    await tester.binding.setSurfaceSize(const Size(1200, 1800));
+    await tester.binding.setSurfaceSize(const Size(1200, 2600));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
     final service = _FakeAgentOrgService(
@@ -799,7 +791,7 @@ void main() {
   testWidgets(
       'AgentOrgPage supports Slack-style quick reactions on board posts',
       (WidgetTester tester) async {
-    await tester.binding.setSurfaceSize(const Size(1200, 1800));
+    await tester.binding.setSurfaceSize(const Size(1200, 2600));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
     final service = _FakeAgentOrgService(
@@ -825,6 +817,8 @@ void main() {
     final reactionChip =
         find.byKey(const Key('agent_org_board_reaction_message-1_thumbs_up'));
     await tester.scrollUntilVisible(reactionChip, 200, scrollable: scrollable);
+    await tester.ensureVisible(reactionChip);
+    await tester.pumpAndSettle();
     await tester.tap(reactionChip);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));

--- a/test/services/public_memo_service_test.dart
+++ b/test/services/public_memo_service_test.dart
@@ -12,12 +12,12 @@ void main() {
       );
     });
 
-    test('buildPublicMemoUrl returns the share endpoint', () {
+    test('buildPublicMemoUrl returns the app detail route', () {
       final url = PublicMemoService.buildPublicMemoUrl(42);
 
       expect(
         url,
-        'https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/public-memo-share?id=42',
+        'https://my-web-app-b67f4.web.app/public-memo?id=42&utm_source=public_memo&utm_medium=share&utm_campaign=growth_mission',
       );
     });
   });


### PR DESCRIPTION
﻿## Summary

- Add `memory-search-hub` Edge Function with BM25, optional Gemini vector search, Haiku rerank fallback, and MCP auth/audit guard integration.
- Add `task_budget` and `effort_config` migrations plus shared `task_budget.ts` / `effort_router.ts`, then wire budget checks and effort selection into `ai-hub` chat actions.
- Add hourly memory index sync workflow and scripts, and harden feature-review automation source mapping, category filtering, shell args, and Slack payload generation.
- Move the related Codex#2 cross-instance PR notes to `done/` and update ops docs.

## Validation

- `deno check supabase/functions/ai-hub/index.ts`
- `deno check supabase/functions/memory-search-hub/index.ts`
- `deno lint --config supabase/functions/deno.json ...`
- `python -m py_compile scripts/feature_review.py integration_test/feature_review_dry_run.py scripts/check_budget.py scripts/sync_memory_index.py`
- `python integration_test/feature_review_dry_run.py`
- `python scripts/feature_review.py --config scripts/feature_review_config.json --dry-run --targets ai_hub --skip-ai`
- `python scripts/feature_review.py --config scripts/feature_review_config.json --dry-run --rotation-hour 0 --skip-ai --skip-playwright`
- `python scripts/check_budget.py --scope gha --scope-id local-test --limit 1`
- `python scripts/sync_memory_index.py --memory-dir memory --dry-run`
- workflow YAML / feature-review JSON parse check

## Notes

- `check_budget.py` intentionally warns and exits 0 locally when Supabase secrets are not configured.
- `sync_memory_index.py --dry-run` loaded 33 local memory files in this workspace.
