### PR TITLE
fix: satisfy deno require-await lint for deploy

### DIFF
--- a/supabase/functions/_shared/effort_router.ts
+++ b/supabase/functions/_shared/effort_router.ts
@@ -19,11 +19,10 @@ export interface EffortSelection {
   source: string;
 }
 
-// deno-lint-ignore require-await
-export async function selectEffort(
+export function selectEffort(
   _action: string,
   _body: unknown,
-): Promise<EffortSelection> {
+): EffortSelection {
   return {
     effort: "medium",
     source: "stub_default",

--- a/supabase/functions/_shared/task_budget.ts
+++ b/supabase/functions/_shared/task_budget.ts
@@ -21,11 +21,10 @@ export interface BudgetCheckResult {
   exceeded_scope_id?: string | null;
 }
 
-// deno-lint-ignore require-await
-export async function checkBudget(
+export function checkBudget(
   _scope: BudgetScope,
   _key: string,
-): Promise<BudgetCheckResult> {
+): BudgetCheckResult {
   return {
     ok: true,
     remaining_usd: 999999,
@@ -34,13 +33,12 @@ export async function checkBudget(
   };
 }
 
-export async function recordSpend(
+export function recordSpend(
   _scope: BudgetScope,
   _key: string,
   _costUsd: number,
-): Promise<void> {
+): void {
   // no-op stub
-  await Promise.resolve();
 }
 
 export function calculateApiCost(


### PR DESCRIPTION
## Summary\n- remove async from synchronous Edge Function budget/effort stubs\n- keep callers compatible because awaiting non-Promise values is valid\n- unblock production deploy Deno lint failure on main\n\n## Verification\n- deno lint --config supabase/functions/deno.json supabase/functions/