### PR TITLE
[codex] feat: import SMBC CSV flow records

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -2,22 +2,29 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'package:http/http.dart' as http;
+import 'dart:js_interop'
+    // ignore: uri_does_not_exist
+    if (dart.library.io) 'package:my_web_app/utils/js_interop_vm_stub.dart';
 import 'dart:math'; // ← ★この1行を追加してください！
-import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:fl_chart/fl_chart.dart';
-import 'package:intl/intl.dart';
-import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 import 'package:my_web_app/models/debt_repayment_plan.dart';
 import 'package:my_web_app/models/kgi_csf_kpi.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
+import 'package:my_web_app/services/smbc_csv_import_service.dart';
 import 'package:my_web_app/services/waste_tracking_service.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:web/web.dart' as web;
 
 enum AssetManagementInitialFocus {
   overview,
@@ -81,6 +88,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   bool _isLoadingClosing = false;
   bool _isFetchingSmbc = false;
   bool _isFetchingJibun = false;
+  bool _isImportingSmbcCsv = false;
 
   // --- 資産・負債（ストック）用変数 ---
   Map<String, TextEditingController> _controllers = {};
@@ -164,6 +172,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   static const double _compactWidthBreakpoint = 420;
   static const List<String> _flowTypeOptions = ['支出', '収入', '振替'];
+  static const String _smbcCsvSource = '[三井住友銀行]';
+  static final RegExp _flowImportMarkerPattern =
+      RegExp(r'\s*\[import:smbc:[^\]]+\]\s*$');
+  static final RegExp _smbcImportKeyPattern =
+      RegExp(r'\[import:(smbc:[^\]]+)\]\s*$');
   bool get _isCompact =>
       MediaQuery.sizeOf(context).width < _compactWidthBreakpoint;
 
@@ -259,6 +272,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   String get _defaultFlowSource =>
       _sourceOptions.contains('[その他]') ? '[その他]' : _sourceOptions.last;
+
+  String _stripFlowImportMarker(String description) =>
+      description.replaceFirst(_flowImportMarkerPattern, '').trim();
+
+  String? _extractSmbcImportKey(String description) {
+    final match = _smbcImportKeyPattern.firstMatch(description.trim());
+    return match?.group(1);
+  }
+
+  String _withFlowImportMarker(String description, String importKey) =>
+      '${description.trim()} [import:$importKey]';
 
   String _sourceLabel(String source) =>
       source.replaceAll('[', '').replaceAll(']', '').trim();
@@ -2619,6 +2643,143 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  Future<void> _pickAndImportSmbcCsv() async {
+    if (_isImportingSmbcCsv) return;
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) return;
+
+    setState(() => _isImportingSmbcCsv = true);
+    try {
+      final result = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['csv'],
+        allowMultiple: false,
+        withData: true,
+      );
+      if (result == null || result.files.isEmpty) return;
+
+      final file = result.files.single;
+      final bytes = file.bytes;
+      if (bytes == null || bytes.isEmpty) {
+        throw Exception('CSVデータを読み込めませんでした');
+      }
+
+      final text = _decodeSmbcCsvBytes(bytes);
+      final parsed = const SmbcCsvImportService().parse(text);
+      if (parsed.transactions.isEmpty) {
+        throw Exception('登録できる三井住友銀行の入出金明細が見つかりませんでした');
+      }
+
+      final knownImportKeys = <String>{};
+      for (final flow in _recentFlows) {
+        final key =
+            _extractSmbcImportKey(flow['description']?.toString() ?? '');
+        if (key != null) {
+          knownImportKeys.add(key);
+        }
+      }
+      final records = <Map<String, dynamic>>[];
+      var duplicateCount = 0;
+
+      for (final transaction in parsed.transactions) {
+        if (knownImportKeys.contains(transaction.importKey)) {
+          duplicateCount += 1;
+          continue;
+        }
+        knownImportKeys.add(transaction.importKey);
+        final flowType = transaction.isDeposit ? '収入' : '支出';
+        records.add({
+          'user_id': userId,
+          'action_type': transaction.actionType,
+          'amount': transaction.amount,
+          'description': _withFlowImportMarker(
+            _composeFlowDescription(
+              flowType: flowType,
+              source: _smbcCsvSource,
+              memo: transaction.displayMemo,
+            ),
+            transaction.importKey,
+          ),
+          'occurred_at': transaction.date.toUtc().toIso8601String(),
+        });
+      }
+
+      for (var i = 0; i < records.length; i += 200) {
+        final chunk = records.sublist(i, min(i + 200, records.length));
+        await _supabase.from('wealth_struggles').insert(chunk);
+      }
+
+      final latestDate = parsed.latestDate;
+      final latestBalance = parsed.latestBalance;
+      if (mounted) {
+        setState(() {
+          if (!_sourceOptions.contains(_smbcCsvSource)) {
+            _sourceOptions = [..._sourceOptions, _smbcCsvSource];
+          }
+          if (latestDate != null) {
+            _selectedFlowHistoryMonth = _monthStart(latestDate);
+          }
+          if (latestBalance != null) {
+            _applyFetchedAssetBalance(
+              assetName: '三井住友銀行',
+              balance: latestBalance.toDouble(),
+            );
+          }
+        });
+      }
+
+      await _fetchRecentFlows();
+      await _fetchTodayClosing();
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '三井住友CSVを取り込みました: ${records.length}件登録 / '
+            '$duplicateCount件重複スキップ / ${parsed.skippedRows}行スキップ',
+          ),
+          backgroundColor: const Color(0xFF047857),
+        ),
+      );
+    } catch (e) {
+      debugPrint('Error importing SMBC CSV: $e');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('三井住友CSVの取込に失敗しました: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isImportingSmbcCsv = false);
+      }
+    }
+  }
+
+  String _decodeSmbcCsvBytes(Uint8List bytes) {
+    try {
+      final text = utf8.decode(bytes);
+      if (_looksLikeSmbcCsv(text)) return text;
+    } catch (_) {
+      // SMBC exports are commonly CP932/Shift_JIS. Fall through to TextDecoder.
+    }
+
+    try {
+      final text = web.TextDecoder('shift_jis').decode(bytes.toJS);
+      if (_looksLikeSmbcCsv(text)) return text;
+    } catch (e) {
+      debugPrint('Shift_JIS decode failed: $e');
+    }
+
+    final malformed = utf8.decode(bytes, allowMalformed: true);
+    if (_looksLikeSmbcCsv(malformed)) return malformed;
+    throw const FormatException('三井住友銀行CSVの列名を判定できませんでした');
+  }
+
+  bool _looksLikeSmbcCsv(String text) =>
+      text.contains('年月日') &&
+      text.contains('お引出し') &&
+      text.contains('お預入れ') &&
+      text.contains('お取り扱い内容');
+
   String _composeFlowDescription({
     required String flowType,
     required String source,
@@ -2658,7 +2819,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     String description, {
     String? actionType,
   }) {
-    final normalizedDescription = description.trim();
+    final normalizedDescription = _stripFlowImportMarker(description.trim());
     final isExpense = _isExpenseActionType(actionType ?? '');
     final wasteCategory = isExpense
         ? WasteTrackingService.extractWasteCategory(normalizedDescription)
@@ -6379,6 +6540,23 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 fontSize: 11,
                 color: Color(0xFF9CA3AF),
                 height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: OutlinedButton.icon(
+                onPressed: _isImportingSmbcCsv ? null : _pickAndImportSmbcCsv,
+                icon: _isImportingSmbcCsv
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.upload_file),
+                label: Text(
+                  _isImportingSmbcCsv ? '三井住友CSV取込中...' : '三井住友CSV取込',
+                ),
               ),
             ),
             const SizedBox(height: 16),

--- a/lib/services/smbc_csv_import_service.dart
+++ b/lib/services/smbc_csv_import_service.dart
@@ -1,0 +1,265 @@
+class SmbcCsvImportResult {
+  const SmbcCsvImportResult({
+    required this.transactions,
+    required this.skippedRows,
+  });
+
+  final List<SmbcCsvTransaction> transactions;
+  final int skippedRows;
+
+  int get withdrawalCount =>
+      transactions.where((item) => item.isWithdrawal).length;
+
+  int get depositCount => transactions.where((item) => item.isDeposit).length;
+
+  DateTime? get latestDate {
+    DateTime? latest;
+    for (final item in transactions) {
+      if (latest == null || item.date.isAfter(latest)) {
+        latest = item.date;
+      }
+    }
+    return latest;
+  }
+
+  int? get latestBalance {
+    DateTime? latest;
+    int? balance;
+    for (final item in transactions) {
+      final itemBalance = item.balance;
+      if (itemBalance == null) continue;
+      if (latest == null || item.date.isAfter(latest)) {
+        latest = item.date;
+        balance = itemBalance;
+      }
+    }
+    return balance;
+  }
+}
+
+class SmbcCsvTransaction {
+  const SmbcCsvTransaction({
+    required this.date,
+    required this.amount,
+    required this.content,
+    required this.importKey,
+    this.isDeposit = false,
+    this.balance,
+    this.memo,
+    this.label,
+  });
+
+  final DateTime date;
+  final int amount;
+  final String content;
+  final String importKey;
+  final bool isDeposit;
+  final int? balance;
+  final String? memo;
+  final String? label;
+
+  bool get isWithdrawal => !isDeposit;
+
+  String get actionType => isDeposit ? 'conquer' : 'expense';
+
+  String get displayMemo {
+    final parts = <String>[
+      content.trim(),
+      if ((memo ?? '').trim().isNotEmpty) (memo ?? '').trim(),
+      if ((label ?? '').trim().isNotEmpty) (label ?? '').trim(),
+    ].where((part) => part.isNotEmpty).toList();
+    return parts.isEmpty ? '三井住友銀行CSV取込' : parts.join(' / ');
+  }
+}
+
+class SmbcCsvImportService {
+  const SmbcCsvImportService();
+
+  static const _dateHeader = '年月日';
+  static const _withdrawalHeader = 'お引出し';
+  static const _depositHeader = 'お預入れ';
+  static const _contentHeader = 'お取り扱い内容';
+  static const _balanceHeader = '残高';
+  static const _memoHeader = 'メモ';
+  static const _labelHeader = 'ラベル';
+
+  SmbcCsvImportResult parse(final String csvText) {
+    final rows = _parseCsvRows(csvText)
+        .where((row) => row.any((cell) => cell.trim().isNotEmpty))
+        .toList();
+    if (rows.isEmpty) {
+      throw const FormatException('CSVに明細行がありません');
+    }
+
+    final header = rows.first.map(_normalizeHeader).toList();
+    final dateIndex = _requiredIndex(header, _dateHeader);
+    final withdrawalIndex = _requiredIndex(header, _withdrawalHeader);
+    final depositIndex = _requiredIndex(header, _depositHeader);
+    final contentIndex = _requiredIndex(header, _contentHeader);
+    final balanceIndex = _optionalIndex(header, _balanceHeader);
+    final memoIndex = _optionalIndex(header, _memoHeader);
+    final labelIndex = _optionalIndex(header, _labelHeader);
+
+    final duplicateOrdinals = <String, int>{};
+    final transactions = <SmbcCsvTransaction>[];
+    var skippedRows = 0;
+
+    for (final row in rows.skip(1)) {
+      final date = _parseDate(_cell(row, dateIndex));
+      final withdrawal = _parseAmount(_cell(row, withdrawalIndex));
+      final deposit = _parseAmount(_cell(row, depositIndex));
+      final content = _cell(row, contentIndex).trim();
+      final balance =
+          balanceIndex == null ? null : _parseAmount(_cell(row, balanceIndex));
+      final memo = memoIndex == null ? '' : _cell(row, memoIndex).trim();
+      final label = labelIndex == null ? '' : _cell(row, labelIndex).trim();
+
+      if (date == null || ((withdrawal ?? 0) <= 0 && (deposit ?? 0) <= 0)) {
+        skippedRows += 1;
+        continue;
+      }
+
+      void addTransaction({
+        required final int amount,
+        required final bool isDeposit,
+      }) {
+        final base = [
+          _dateKey(date),
+          amount.toString(),
+          isDeposit ? 'deposit' : 'withdrawal',
+          content,
+          balance?.toString() ?? '',
+          memo,
+          label,
+        ].join('|');
+        final ordinal = (duplicateOrdinals[base] ?? 0) + 1;
+        duplicateOrdinals[base] = ordinal;
+        transactions.add(
+          SmbcCsvTransaction(
+            date: date,
+            amount: amount,
+            content: content.isEmpty ? '三井住友銀行CSV取込' : content,
+            importKey: 'smbc:${_dateKey(date)}:${_shortHash(base)}:$ordinal',
+            isDeposit: isDeposit,
+            balance: balance,
+            memo: memo.isEmpty ? null : memo,
+            label: label.isEmpty ? null : label,
+          ),
+        );
+      }
+
+      if ((withdrawal ?? 0) > 0) {
+        addTransaction(amount: withdrawal!, isDeposit: false);
+      }
+      if ((deposit ?? 0) > 0) {
+        addTransaction(amount: deposit!, isDeposit: true);
+      }
+    }
+
+    return SmbcCsvImportResult(
+      transactions: transactions,
+      skippedRows: skippedRows,
+    );
+  }
+
+  static List<List<String>> _parseCsvRows(final String input) {
+    final rows = <List<String>>[];
+    var row = <String>[];
+    final cell = StringBuffer();
+    var inQuotes = false;
+
+    for (var i = 0; i < input.length; i += 1) {
+      final char = input[i];
+      if (char == '"') {
+        if (inQuotes && i + 1 < input.length && input[i + 1] == '"') {
+          cell.write('"');
+          i += 1;
+        } else {
+          inQuotes = !inQuotes;
+        }
+        continue;
+      }
+      if (!inQuotes && char == ',') {
+        row.add(cell.toString());
+        cell.clear();
+        continue;
+      }
+      if (!inQuotes && (char == '\n' || char == '\r')) {
+        if (char == '\r' && i + 1 < input.length && input[i + 1] == '\n') {
+          i += 1;
+        }
+        row.add(cell.toString());
+        cell.clear();
+        rows.add(row);
+        row = <String>[];
+        continue;
+      }
+      cell.write(char);
+    }
+
+    if (cell.isNotEmpty || row.isNotEmpty) {
+      row.add(cell.toString());
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  static int _requiredIndex(final List<String> header, final String name) {
+    final index = _optionalIndex(header, name);
+    if (index == null) {
+      throw FormatException('CSVに「$name」列がありません');
+    }
+    return index;
+  }
+
+  static int? _optionalIndex(final List<String> header, final String name) {
+    final normalizedName = _normalizeHeader(name);
+    final index = header.indexOf(normalizedName);
+    return index < 0 ? null : index;
+  }
+
+  static String _cell(final List<String> row, final int index) {
+    if (index < 0 || index >= row.length) return '';
+    return row[index];
+  }
+
+  static String _normalizeHeader(final String value) =>
+      value.replaceFirst('\ufeff', '').trim();
+
+  static DateTime? _parseDate(final String value) {
+    final parts = value.trim().split(RegExp(r'[/\-]'));
+    if (parts.length != 3) return null;
+    final year = int.tryParse(parts[0]);
+    final month = int.tryParse(parts[1]);
+    final day = int.tryParse(parts[2]);
+    if (year == null || month == null || day == null) return null;
+    if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+    return DateTime(year, month, day);
+  }
+
+  static int? _parseAmount(final String value) {
+    final normalized = value
+        .replaceAll(',', '')
+        .replaceAll('￥', '')
+        .replaceAll('¥', '')
+        .trim();
+    if (normalized.isEmpty) return null;
+    final parsed = int.tryParse(normalized);
+    if (parsed == null) return null;
+    return parsed.abs();
+  }
+
+  static String _dateKey(final DateTime date) =>
+      '${date.year.toString().padLeft(4, '0')}'
+      '${date.month.toString().padLeft(2, '0')}'
+      '${date.day.toString().padLeft(2, '0')}';
+
+  static String _shortHash(final String value) {
+    var hash = 0x811c9dc5;
+    for (final unit in value.codeUnits) {
+      hash ^= unit;
+      hash = (hash * 0x01000193) & 0xffffffff;
+    }
+    return hash.toRadixString(16).padLeft(8, '0');
+  }
+}

--- a/test/services/smbc_csv_import_service_test.dart
+++ b/test/services/smbc_csv_import_service_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/smbc_csv_import_service.dart';
+
+void main() {
+  group('SmbcCsvImportService', () {
+    test('parses withdrawals and deposits from SMBC CSV', () {
+      const csv = '''
+年月日,お引出し,お預入れ,お取り扱い内容,残高,メモ,ラベル
+2026/4/29,26210,,"FAMIPAY",191103,"",
+2026/4/27,,990,"振込 ニッポンチュウオウケイバカイ",287313,"競馬払戻","income"
+''';
+
+      final result = const SmbcCsvImportService().parse(csv);
+
+      expect(result.transactions, hasLength(2));
+      expect(result.withdrawalCount, 1);
+      expect(result.depositCount, 1);
+      expect(result.latestBalance, 191103);
+      expect(result.transactions.first.actionType, 'expense');
+      expect(result.transactions.first.displayMemo, 'FAMIPAY');
+      expect(result.transactions.last.actionType, 'conquer');
+      expect(
+        result.transactions.last.displayMemo,
+        '振込 ニッポンチュウオウケイバカイ / 競馬払戻 / income',
+      );
+    });
+
+    test('keeps duplicate-looking rows by assigning stable ordinals', () {
+      const csv = '''
+年月日,お引出し,お預入れ,お取り扱い内容,残高,メモ,ラベル
+2026/4/29,500,,"コンビニ",10000,"",
+2026/4/29,500,,"コンビニ",9500,"",
+2026/4/29,500,,"コンビニ",9500,"",
+''';
+
+      final result = const SmbcCsvImportService().parse(csv);
+
+      expect(result.transactions, hasLength(3));
+      expect(
+        result.transactions.map((item) => item.importKey).toSet(),
+        hasLength(3),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What changed

- Added a 三井住友CSV取込 button to the asset management flow record section.
- Added SMBC CSV parsing for `年月日`, `お引出し`, `お預入れ`, `お取り扱い内容`, `残高`, `メモ`, and `ラベル`.
- Registers withdrawals as expense records and deposits as income records in `wealth_struggles`.
- Handles UTF-8 and Shift_JIS/CP932-style CSV decoding to avoid Japanese mojibake.
- Adds import markers so repeated CSV imports skip already-imported transactions while keeping the marker hidden from normal display/edit parsing.
- Adds parser unit tests for withdrawal/deposit parsing and duplicate-looking row handling.

## Why

Users need to import SMBC transaction CSV files as income/expense records instead of manually entering each bank transaction.

## Validation

- `flutter analyze lib/pages/asset_management_page.dart lib/services/smbc_csv_import_service.dart test/services/smbc_csv_import_service_test.dart`
- `flutter test test/services/smbc_csv_import_service_test.dart`