### PR TITLE
fix: resolve migration timestamp collision

### DIFF
--- a/supabase/migrations/20260429310000_seed_achievements_ps4_s304.sql
+++ b/supabase/migrations/20260429310000_seed_achievements_ps4_s304.sql
@@ -1,10 +1,9 @@
--- PS#4 S304: 競合3社追加 783→786社 (gather/kumospace/wonder)
--- SEO: "Gather代替"/"Kumospace代替"/"Wonder代替" 検索流入獲得
+-- PS#4 S304: competitor additions for gather/kumospace/wonder
 
 INSERT INTO public.development_achievements (title, description, completed_at)
 VALUES (
-  'PS#4 S304: 競合3社追加 783→786社 (gather/kumospace/wonder)',
-  'comparison_page.dartにgather(バーチャルオフィス2Dメタバースリモートワーク/virtual-office/7C3AED)/kumospace(バーチャルイベントオフィス空間/virtual-office/0EA5E9)/wonder(バーチャルイベントネットワーキング/virtual-office/EC4899)の3社追加(783→786社)。',
+  'PS#4 S304: competitor additions for gather/kumospace/wonder',
+  'Added gather, kumospace, and wonder entries to comparison_page.dart with virtual-office metadata and brand colors.',
   '2026-04-29'
 )
 ON CONFLICT DO NOTHING;

--- a/supabase/migrations/20260429310000_seed_achievements_ps5_s115.sql
+++ b/supabase/migrations/20260429310000_seed_achievements_ps5_s115.sql
@@ -1,8 +1,0 @@
--- PS#5 Session 115: memory-search-hub EF + effort_router/task_budget 本実装 (Codex#2 merge)
-INSERT INTO development_achievements (title, description, completed_at)
-VALUES (
-  'PS#5 S115: memory-search-hub EF + effort_router/task_budget 本実装',
-  'Codex#2 branch (2476ea3a2) を main に統合。memory-search-hub (BM25+vector hybrid search, memory.search/rank/related/stats), effort_router.ts stub→本実装(217L), task_budget.ts stub→本実装(308L), 3 migrations (memory_index/task_budget/effort_config), check_budget.py, sync_memory_index.py, memory-search-sync.yml, deploy-prod.yml +memory-search-hub (20/50 EF)',
-  '2026-04-29'
-)
-ON CONFLICT DO NOTHING;

--- a/supabase/migrations/20260429310100_seed_achievements_ps5_s115.sql
+++ b/supabase/migrations/20260429310100_seed_achievements_ps5_s115.sql
@@ -1,0 +1,9 @@
+-- PS#5 S115: memory-search-hub EF plus effort and budget support
+
+INSERT INTO development_achievements (title, description, completed_at)
+VALUES (
+  'PS#5 S115: memory-search-hub EF plus effort and budget support',
+  'Merged Codex#2 memory-search-hub work, including BM25/vector search actions, effort_router and task_budget support, migrations, sync tooling, and deploy workflow updates.',
+  '2026-04-29'
+)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- rename the duplicate PS#5 achievement seed migration from 20260429310000 to 20260429310100
- replace two achievement seed strings with ASCII-safe SQL text so the next deploy does not trip over corrupted quotes

## Validation
- python scripts/check_migration_timestamps.py
- PYTHONIOENCODING=utf-8 python scripts/check_migration_time_relative_check.py

## Root Cause
The production deploy from #1424 stopped before Supabase migrations because two achievement seed files shared timestamp 20260429310000. The same files also contained fragile multibyte text in SQL string literals, so this hotfix keeps the data simple and deploy-safe.