### PR TITLE
ci: automate dependency updates and Firebase deploy runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # GitHub Actions の自動更新
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -8,21 +7,49 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "github-actions"
     commit-message:
       prefix: "ci"
+    rebase-strategy: "auto"
 
-  # Python pip パッケージの自動更新 (requirements.txt)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:10"
+      timezone: "Asia/Tokyo"
+    groups:
+      npm-dev-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "deps"
+    rebase-strategy: "auto"
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:15"
+      time: "09:20"
       timezone: "Asia/Tokyo"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
@@ -30,11 +57,10 @@ updates:
     commit-message:
       prefix: "deps"
     ignore:
-      # メジャーバージョンアップは手動で対応
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    rebase-strategy: "auto"
 
-  # Flutter / Dart pub パッケージの自動更新
   - package-ecosystem: "pub"
     directory: "/"
     schedule:
@@ -42,6 +68,10 @@ updates:
       day: "monday"
       time: "09:30"
       timezone: "Asia/Tokyo"
+    groups:
+      flutter-dependencies:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -49,6 +79,6 @@ updates:
     commit-message:
       prefix: "deps"
     ignore:
-      # メジャーバージョンアップは手動で対応
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    rebase-strategy: "auto"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -604,14 +604,43 @@ jobs:
         run: |
           sed -i 's|/ogp\.png"|/ogp.png?v=${{ steps.version.outputs.version }}"|g' build/web/index.html
 
-      - name: Deploy to Firebase Hosting (Production)
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        continue-on-error: true  # 509 Bandwidth Exceeded 発生中 (2026-04-18) — 復旧後に削除
+      - name: Setup Node for Firebase CLI
+        uses: actions/setup-node@v6
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_PROD }}"
-          projectId: ${{ secrets.FIREBASE_PROJECT_ID }}
-          channelId: live
+          node-version: "24"
+          cache: npm
+
+      - name: Deploy to Firebase Hosting (Production)
+        id: firebase_cli_deploy
+        continue-on-error: true  # 509 Bandwidth Exceeded 発生中 (2026-04-18) — 復旧後に削除
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          key_file="$(mktemp)"
+          output_file="$(mktemp)"
+          cleanup() {
+            rm -f "$key_file" "$output_file"
+          }
+          trap cleanup EXIT
+
+          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_PROD }}' > "$key_file"
+          export GOOGLE_APPLICATION_CREDENTIALS="$key_file"
+
+          npx -y firebase-tools@latest deploy \
+            --only hosting \
+            --project "${{ secrets.FIREBASE_PROJECT_ID }}" \
+            --json > "$output_file"
+
+          cat "$output_file"
+
+          deploy_url="$(jq -r '.result.hosting[]?.url // empty' "$output_file" | head -n 1)"
+          if [ -z "$deploy_url" ]; then
+            deploy_url="https://${{ secrets.FIREBASE_PROJECT_ID }}.web.app"
+          fi
+
+          echo "details_url=$deploy_url" >> "$GITHUB_OUTPUT"
+          echo "Firebase Hosting live deploy complete: $deploy_url"
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks
 

--- a/docs/automation/dependency-update-automation.md
+++ b/docs/automation/dependency-update-automation.md
@@ -1,0 +1,44 @@
+# Dependency Update Automation
+
+Issue: #1371
+
+## Scope
+
+This repository uses Dependabot to open dependency update pull requests for:
+
+- GitHub Actions workflows
+- npm packages in the repository root
+- Python packages in `requirements.txt`
+- Flutter/Dart packages in `pubspec.yaml`
+
+Existing CI runs on Dependabot pull requests, so generated updates are validated by the same lint, format, test, build, security, and PR summary checks as normal changes.
+
+## Schedule
+
+Dependabot runs weekly on Monday morning in Asia/Tokyo:
+
+- 09:00 GitHub Actions
+- 09:10 npm
+- 09:20 pip
+- 09:30 pub
+
+Patch and minor updates are grouped by ecosystem to reduce PR noise. Major updates for pip and pub are intentionally left for manual review because they can affect runtime behavior across Flutter Web and Supabase Edge Functions.
+
+## Production Deploy Runtime
+
+The production Firebase Hosting deployment no longer depends on `FirebaseExtended/action-hosting-deploy@v0`. The upstream action still declares a Node.js 20 runtime, while GitHub Actions is moving JavaScript actions to Node.js 24 by default on June 2, 2026 and removing Node.js 20 on September 16, 2026.
+
+Production deploy now installs and runs `firebase-tools@latest` through Node.js 24 with the same service account secret used before. This keeps the deployment path aligned with the Node.js 24 transition while preserving the existing post-deploy version verification.
+
+## Agent Workflow Notes
+
+- Codex #2 owns small, low-risk automation fixes such as Dependabot coverage, workflow runtime updates, and CI/deploy maintenance.
+- Claude Code remains the preferred reviewer for high-risk changes, especially auth, database migrations, and architecture changes.
+- When Codex in-app browser verification is available, UI-facing dependency updates should include a rendered smoke check in addition to CI.
+- Claude Code `/ultrareview` is recommended before merging workflow changes that alter production deploy behavior.
+
+## References
+
+- GitHub Actions Node.js 20 deprecation: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+- Firebase Hosting deploy action release stream: https://github.com/FirebaseExtended/action-hosting-deploy/releases
+- Firebase deploy action manifest: https://raw.githubusercontent.com/FirebaseExtended/action-hosting-deploy/v0.10.0/action.yml


### PR DESCRIPTION
## Summary
- extend Dependabot coverage to npm and group updates across GitHub Actions, npm, pip, and pub
- move production Firebase Hosting deploy off FirebaseExtended/action-hosting-deploy@v0 and onto Node 24 + firebase-tools@latest
- document the dependency update automation, deploy runtime rationale, and Codex/Claude handoff notes

## Verification
- python/PyYAML parsed .github/dependabot.yml and .github/workflows/deploy-prod.yml
- npm ci --ignore-scripts
- npx -y firebase-tools@latest --version => 15.16.0
- git diff --check

Refs #1307
Closes #1371