### PR TITLE
docs: apply NotebookLM harness routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ python scripts/ai_tool_watch.py --print-only
 
 Use the report to route new Claude Code or Codex capabilities into WBS, issues,
 GitHub Actions, hooks, or review automation.
+For NotebookLM-driven sessions, treat notebook
+`bc58b50b-5fc4-4840-9a62-b397d6d3b65a` as the current harness-engineering
+reference: Claude Code designs the environment, Codex executes scoped changes,
+and GitHub Actions proves the result.
 
 ## Role Split
 
@@ -23,7 +27,7 @@ GitHub Actions, hooks, or review automation.
 - Codex #2 owns CI, synchronization, operations, Edge Functions, GitHub Actions,
   and deterministic automation.
 
-## Codex #2 Defaults
+## Codex Defaults
 
 - Work from a scoped branch and keep unrelated user changes intact.
 - Prefer deterministic checks over agent claims: `flutter analyze`,
@@ -34,3 +38,11 @@ GitHub Actions, hooks, or review automation.
 - When an official Claude Code or Codex changelog mentions hooks, schedules,
   models, in-app browser, worktrees, MCP, or cost controls, connect it to the
   nearest existing issue before creating a new one.
+- Codex #1 should take broad but bounded work from the WBS top list:
+  migrations, data import/export, UI verification, stale automation audits, and
+  clean fix PRs from a fresh worktree.
+- Codex #2 should take red CI, deploy unblockers, workflow drift, Edge Function
+  failures, and GitHub/Notion/Slack synchronization issues.
+- If a task needs product judgment, cross-instance arbitration, or NotebookLM
+  synthesis before code can be safely changed, route it back to Claude Code and
+  leave a short handoff note.

--- a/docs/CODEX_WORKFLOW.md
+++ b/docs/CODEX_WORKFLOW.md
@@ -218,3 +218,50 @@ Codex に出したが想定と違う結果 → cross-instance-pr に「Claude (W
 ---
 
 *Win版#132 part 53 追加 / 2026-04-28*
+
+## 7. Harness Engineering Intake (NotebookLM bc58b50b / 2026-04-30)
+
+### 背景
+
+NotebookLM `bc58b50b-5fc4-4840-9a62-b397d6d3b65a`
+「Codex vs Claude Code: The Ultimate AI Development Synergy」の要点は、個別エージェントの性能比較ではなく、
+**正しい答えを出しやすい開発環境を設計する Harness Engineering** である。
+
+本プロジェクトでは、Claude Code 10 枠 + Codex 2 枠 + GitHub Actions + NotebookLM を次の役割で固定する。
+
+| 面 | 主担当 | 完了条件 |
+| --- | --- | --- |
+| 問題設定 / 設計判断 | Claude Code | handoff に判断理由・代替案・検証方針が残る |
+| 横断実装 / SQL / migration / UI確認 | Codex#1 | clean worktree の PR と deterministic check が残る |
+| CI / deploy / sync / Edge Function / GHA | Codex#2 | red check が green になり、再発防止メモが残る |
+| 外部記憶 / Master Brain | NotebookLM | ノート由来の知見が WBS・Issue・docs・workflow のいずれかに反映される |
+| 真実の場 | GitHub Actions | lint / test / deploy / sync の結果で成否を判定する |
+
+### 5 レーン運用
+
+NotebookLM の示す「AI agent synergy」は、次の 5 レーンに分けて WBS 上へ流す。
+
+| レーン | 実装先 | 初回確認 |
+| --- | --- | --- |
+| Agent-in-agent / MCP | Claude Code が設計、Codex#2 が CI 化 | MCP/connector 設定がドキュメント化され、手動操作なしに疎通確認できる |
+| Codex browser / UI QA | Codex#1 | UI 変更 PR にスクリーンショット・console エラー確認・必要なら Playwright が付く |
+| StatusLine / PreCompact / hooks | Claude Code | session start / pre-compact / post-tool-use のどこで品質ゲートを置くか決まる |
+| Worktrees / Memory / long-running state | Codex#1/#2 | 固定 worktree と担当 branch が WBS/Issue と一致する |
+| Skill activation / tool search | Claude Code + Codex | 使う skill/tool を session start で宣言し、不要なコンテキスト展開を避ける |
+
+### セッション開始チェック
+
+Codex #1/#2 は作業開始時に次を実施する。
+
+1. `python scripts/ai_tool_watch.py --print-only` で Claude Code / Codex 公式情報を確認する。
+2. WBS の上位 20 件を見て、期限超過・CI失敗・同期ズレ・手動作業が反復している項目を優先する。
+3. 役割境界に従い、Codex#1 は横断実装 / UI検証 / SQL、Codex#2 は CI / deploy / sync を優先する。
+4. NotebookLM 由来の提案は、Issue / PR / docs / workflow / hook のどれかに落ちるまで完了扱いにしない。
+5. 作業完了後、PR URL・検証結果・残タスクを WBS/Issue へ同期できる形で残す。
+
+### 再配分ルール
+
+- 同じ種類の CI 失敗が 2 回以上続く場合、Codex#2 に「再発防止 workflow 化」を振る。
+- UI/console エラーが本番で再発する場合、Codex#1 に「browser QA + screenshot gate」を振る。
+- cross-instance 競合、設計判断、NotebookLM の概念蒸留が必要な場合、Claude Code に戻す。
+- 手動確認が 3 回以上出る WBS タスクは、スケジュールタスク・GitHub Actions・Edge Function の候補として起票する。

--- a/docs/SCHEDULE_TASKS.md
+++ b/docs/SCHEDULE_TASKS.md
@@ -845,3 +845,60 @@ Haiku 4.5 + effort=medium で signals を bundle → JSON 形式 findings 出力
 - 1 週後: 既存 issue 半数 closed (= 開発反映 cycle 健全)
 - 緊急時: `workflow_dispatch` + `force_full_scan=true` で 13 機能即時 audit
 
+---
+
+### Task: ai-tool-harness-review (毎日 06:15 JST / セッション開始時)
+
+**起源**: NotebookLM `bc58b50b-5fc4-4840-9a62-b397d6d3b65a`
+「Codex vs Claude Code: The Ultimate AI Development Synergy」適用 / 2026-04-30
+**Workflow**: `.github/workflows/ai-tool-watch.yml`
+**Script**: `scripts/ai_tool_watch.py`
+**Report**: `docs/ai-tool-watch/latest-report.md`
+
+#### 目的
+
+Claude Code / Codex の公式変更と NotebookLM の Harness Engineering 方針を毎日・毎セッションで照合し、
+12 インスタンスの担当分担、WBS 優先度、スケジュールタスク候補、GitHub Actions 品質ゲートへ反映する。
+
+#### Step 1: 公式情報を取得
+
+`scripts/ai_tool_watch.py` が以下の一次情報を取得する。
+
+- Claude Code changelog: `https://code.claude.com/docs/en/changelog`
+- Claude Code hooks: `https://code.claude.com/docs/en/hooks`
+- Claude Code GitHub Actions: `https://code.claude.com/docs/en/github-actions`
+- Codex changelog: `https://developers.openai.com/codex/changelog`
+- Codex use cases: `https://developers.openai.com/codex/use-cases/`
+- Codex overview: `https://openai.com/codex/`
+
+#### Step 2: NotebookLM Harness へ写像
+
+検出したキーワードを次の担当へ振り分ける。
+
+| 検出カテゴリ | 担当 | WBS 反映先 |
+| --- | --- | --- |
+| hooks / SessionStart / PostToolUse / Stop | Claude Code | 品質ゲート設計、hook runbook、セッション開始ルール |
+| model / in-app browser / computer use / worktree | Codex#1 | UI検証、横断修正、クリーン worktree PR |
+| CI / GitHub Actions / deploy / sync | Codex#2 | red check 修復、deploy unblock、WBS/Issue/Notion同期 |
+| MCP / Slack / Notion / connector | Claude Code + Codex#2 | 連携基盤、通知、外部メモリ同期 |
+| cost / quota / sandbox / permission | Claude Code | 自動化範囲、deny-by-default、予算・権限境界 |
+
+#### Step 3: 出力と反映
+
+- `docs/ai-tool-watch/latest-report.md` を更新する。
+- high-priority change があれば `#1422` へ comment する。
+- 新しい hook / workflow / automation 候補がある場合は GitHub Issue を起票する。
+- WBS 上位 20 件に手動反復タスクがある場合、`feature-review` または新規 Schedule タスクへ昇格する。
+- 既存 PR が clean / checks pass なら merge queue 候補に入れ、conflict PR は Codex#2 に回す。
+
+#### セッション開始の手動確認
+
+ローカルでは次を実行する。
+
+```powershell
+python scripts/ai_tool_watch.py --print-only
+```
+
+出力に `changed/new official sources` がある場合は、必ず「WBS route / GitHub issue / hook / workflow / PR」の
+いずれかに落とし、NotebookLM のメモだけで完了にしない。
+

--- a/docs/ai-tool-watch/README.md
+++ b/docs/ai-tool-watch/README.md
@@ -10,6 +10,9 @@ Claude Code and Codex changes.
 - Workflow keywords that affect this repo: hooks, schedules, GitHub Actions,
   Automations, in-app browser, models, worktrees, MCP, cost controls, CI, and
   review gates.
+- NotebookLM harness notebook
+  `bc58b50b-5fc4-4840-9a62-b397d6d3b65a`, used as the Master Brain routing
+  reference for Claude Code 10 instances plus Codex 2 instances.
 
 ## How To Run
 
@@ -34,8 +37,11 @@ started manually. It updates the report/state files and comments on issue
 - Claude Code hooks, SessionStart, PostToolUse, Stop, or ultrareview changes
   route to Claude Code quality-gate work.
 - Codex model, browser, computer-use, worktree, or subagent changes route to
-  Codex execution and UI verification work.
+  Codex #1 execution and UI verification work unless the item is CI/deploy
+  related.
 - Schedule, GitHub Actions, and automation changes route to WBS/CI/deploy
-  automation.
+  automation, normally owned by Codex #2.
 - MCP, connector, Slack, and integration changes route to connector reliability
   and NotebookLM knowledge capture.
+- Repeated manual WBS work becomes a candidate for a scheduled task, hook, or
+  GitHub Actions gate.

--- a/scripts/ai_tool_watch.py
+++ b/scripts/ai_tool_watch.py
@@ -166,6 +166,40 @@ IMPACT_ROUTES: dict[str, dict[str, Any]] = {
 }
 
 
+HARNESS_NOTEBOOK = {
+    "id": "bc58b50b-5fc4-4840-9a62-b397d6d3b65a",
+    "title": "Codex vs Claude Code: The Ultimate AI Development Synergy",
+}
+
+
+HARNESS_LANES = [
+    (
+        "Claude Code",
+        "Owns problem framing, architecture, review gates, and hook design.",
+    ),
+    (
+        "Codex #1",
+        "Owns cross-cutting implementation, SQL/migration review, "
+        "UI/browser QA, and scoped fix PRs.",
+    ),
+    (
+        "Codex #2",
+        "Owns CI repair, synchronization, Edge Functions, GitHub Actions, "
+        "and deterministic automation.",
+    ),
+    (
+        "GitHub Actions",
+        "Owns reproducible proof: lint, tests, deploy checks, stale-audit jobs, "
+        "and report artifacts.",
+    ),
+    (
+        "NotebookLM",
+        "Acts as external memory and Master Brain; it informs routing but does "
+        "not replace repository checks.",
+    ),
+]
+
+
 def now_iso() -> str:
     return dt.datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -375,9 +409,21 @@ def render_markdown(report: dict[str, Any]) -> str:
         [
             "",
             "## NotebookLM Harness Mapping",
-            "- Claude Code remains the design, review, and quality-gate owner.",
-            "- Codex remains the implementation, CI repair, test generation, and worktree execution owner.",
-            "- GitHub Actions is the deterministic harness: reports are useful only when they flow into checks, issues, or PRs.",
+            f"- Source notebook: `{HARNESS_NOTEBOOK['title']}` (`{HARNESS_NOTEBOOK['id']}`)",
+        ]
+    )
+    for owner, action in HARNESS_LANES:
+        lines.append(f"- **{owner}**: {action}")
+
+    lines.extend(
+        [
+            "- Practical rule: every detected tool change must become a WBS route, GitHub issue, hook, workflow check, or PR; notes alone are not complete.",
+            "",
+            "## 12-Instance Routing Reminder",
+            "- Claude Code instances take ambiguous design and cross-instance coordination.",
+            "- Codex #1 takes mechanical implementation and broad repo scans that need a clean worktree.",
+            "- Codex #2 takes failing checks, deploy unblockers, and sync/automation drift.",
+            "- Rebalance owners when the WBS top-20 contains repeated manual work, repeated CI failures, or stale handoffs.",
             "",
             "<!-- generated-by: scripts/ai_tool_watch.py -->",
         ]


### PR DESCRIPTION
## Summary
- Apply NotebookLM `bc58b50b-5fc4-4840-9a62-b397d6d3b65a` as the Claude Code/Codex harness-routing reference.
- Extend `ai_tool_watch` reports with NotebookLM mapping, Codex #1/#2 split, and 12-instance rebalance reminders.
- Document the daily/session-start `ai-tool-harness-review` flow for WBS, Issues, hooks, workflows, and PR routing.

## Verification
- `python -m py_compile scripts\\ai_tool_watch.py`
- `python scripts\\ai_tool_watch.py --print-only`
- `git diff --check`