### PR TITLE
ci: cap WBS Notion mirror sync time

### DIFF
--- a/.github/workflows/issue-to-wbs.yml
+++ b/.github/workflows/issue-to-wbs.yml
@@ -295,5 +295,6 @@ jobs:
             -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
             -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
             -H "Content-Type: application/json" \
+            --max-time 30 \
             -d '{"action":"notion.sync_wbs","limit":100,"offset":0}' \
             || true


### PR DESCRIPTION
## Summary
- add `--max-time 30` to the Notion mirror curl in `issue-to-wbs.yml`
- keeps GitHub Issues WBS Sync from hanging indefinitely when the Notion mirror endpoint is slow

## Verification
- PyYAML parsed `.github/workflows/issue-to-wbs.yml`
- `git diff --check`

Refs #1307