### PR TITLE
feat: add Codex session safety check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,17 @@ actionable; detailed product memory stays in docs, issues, and NotebookLM.
 
 1. Check the working tree before editing.
 2. Prefer a fresh worktree from `origin/main` when the root tree is dirty.
-3. Run the official AI tooling watch:
+3. Record the Codex session/worktree safety snapshot:
+
+```powershell
+python scripts/codex_session_check.py
+```
+
+The report should show the current branch, upstream drift, dirty paths, nearby
+worktrees, and any exposed sandbox/approval environment variables. Treat
+warnings as routing signals before editing.
+
+4. Run the official AI tooling watch:
 
 ```powershell
 python scripts/ai_tool_watch.py --print-only

--- a/docs/CODEX_WORKFLOW.md
+++ b/docs/CODEX_WORKFLOW.md
@@ -253,11 +253,16 @@ NotebookLM の示す「AI agent synergy」は、次の 5 レーンに分けて W
 
 Codex #1/#2 は作業開始時に次を実施する。
 
-1. `python scripts/ai_tool_watch.py --print-only` で Claude Code / Codex 公式情報を確認する。
-2. WBS の上位 20 件を見て、期限超過・CI失敗・同期ズレ・手動作業が反復している項目を優先する。
-3. 役割境界に従い、Codex#1 は横断実装 / UI検証 / SQL、Codex#2 は CI / deploy / sync を優先する。
-4. NotebookLM 由来の提案は、Issue / PR / docs / workflow / hook のどれかに落ちるまで完了扱いにしない。
-5. 作業完了後、PR URL・検証結果・残タスクを WBS/Issue へ同期できる形で残す。
+1. `python scripts/codex_session_check.py` で branch / upstream / dirty state / worktree / sandbox snapshot を確認する。
+2. `python scripts/ai_tool_watch.py --print-only` で Claude Code / Codex 公式情報を確認する。
+3. WBS の上位 20 件を見て、期限超過・CI失敗・同期ズレ・手動作業が反復している項目を優先する。
+4. 役割境界に従い、Codex#1 は横断実装 / UI検証 / SQL、Codex#2 は CI / deploy / sync を優先する。
+5. NotebookLM 由来の提案は、Issue / PR / docs / workflow / hook のどれかに落ちるまで完了扱いにしない。
+6. 作業完了後、PR URL・検証結果・残タスクを WBS/Issue へ同期できる形で残す。
+
+`codex_session_check.py` は Codex CLI 0.125.0 系の permission profile / session state 改善を運用に反映する
+ための最小ハーネスである。Codex アプリ内部の権限状態を推測せず、実際の Git worktree と環境変数に
+露出している情報だけを記録する。
 
 ### 再配分ルール
 

--- a/docs/SCHEDULE_TASKS.md
+++ b/docs/SCHEDULE_TASKS.md
@@ -896,9 +896,13 @@ Claude Code / Codex の公式変更と NotebookLM の Harness Engineering 方針
 ローカルでは次を実行する。
 
 ```powershell
+python scripts/codex_session_check.py
 python scripts/ai_tool_watch.py --print-only
 ```
 
 出力に `changed/new official sources` がある場合は、必ず「WBS route / GitHub issue / hook / workflow / PR」の
 いずれかに落とし、NotebookLM のメモだけで完了にしない。
+
+`codex_session_check.py` に dirty worktree、upstream gone、base branch 直編集、origin/main 未取得などの警告が
+出た場合は、実装前に新しい worktree / branch へ移るか、Codex#2 に sync / CI 側の修復として回す。
 

--- a/scripts/codex_session_check.py
+++ b/scripts/codex_session_check.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Print a Codex session-start safety report.
+
+The check is intentionally dependency-free so it can run in Codex desktop,
+Codex CLI, Claude Code hooks, or GitHub Actions. It does not try to infer
+private Codex app state; it records the repo/worktree facts that make parallel
+agent work safe or risky.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    code: int
+    stdout: str
+    stderr: str
+
+
+def run_git(args: list[str], cwd: Path) -> CommandResult:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return CommandResult(proc.returncode, proc.stdout.strip(), proc.stderr.strip())
+
+
+def git_text(args: list[str], cwd: Path, default: str = "") -> str:
+    result = run_git(args, cwd)
+    if result.code != 0:
+        return default
+    return result.stdout
+
+
+def git_root(cwd: Path) -> Path:
+    root = git_text(["rev-parse", "--show-toplevel"], cwd)
+    if not root:
+        raise RuntimeError("not inside a git repository")
+    return Path(root)
+
+
+def upstream_name(root: Path) -> str | None:
+    upstream = git_text(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], root)
+    return upstream or None
+
+
+def ahead_behind(root: Path, upstream: str | None) -> tuple[int | None, int | None]:
+    if not upstream:
+        return None, None
+    counts = git_text(["rev-list", "--left-right", "--count", f"HEAD...{upstream}"], root)
+    if not counts:
+        return None, None
+    left, right = counts.split()
+    return int(left), int(right)
+
+
+def worktree_entries(root: Path) -> list[dict[str, str]]:
+    raw = git_text(["worktree", "list", "--porcelain"], root)
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in raw.splitlines():
+        if not line:
+            if current:
+                entries.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    if current:
+        entries.append(current)
+    return entries
+
+
+def env_snapshot() -> dict[str, str]:
+    keys = [
+        "CODEX_SANDBOX",
+        "CODEX_APPROVAL_POLICY",
+        "SANDBOX_MODE",
+        "APPROVAL_POLICY",
+        "MCP_SANDBOX",
+    ]
+    return {key: os.environ.get(key, "not-exposed") for key in keys}
+
+
+def analyze(cwd: Path) -> dict[str, Any]:
+    root = git_root(cwd)
+    branch = git_text(["branch", "--show-current"], root, default="detached")
+    head = git_text(["rev-parse", "--short", "HEAD"], root)
+    origin_main = git_text(["rev-parse", "--short", "origin/main"], root, default="unknown")
+    upstream = upstream_name(root)
+    ahead, behind = ahead_behind(root, upstream)
+    dirty = git_text(["status", "--porcelain"], root)
+    dirty_lines = [line for line in dirty.splitlines() if line.strip()]
+    remote_url = git_text(["remote", "get-url", "origin"], root, default="unknown")
+    worktrees = worktree_entries(root)
+
+    warnings: list[str] = []
+    if dirty_lines:
+        warnings.append(f"working tree has {len(dirty_lines)} uncommitted path(s)")
+    if not upstream:
+        warnings.append("branch has no upstream")
+    elif ahead is None or behind is None:
+        warnings.append(f"upstream `{upstream}` could not be compared")
+    else:
+        if behind:
+            warnings.append(f"branch is behind upstream by {behind} commit(s)")
+        if ahead:
+            warnings.append(f"branch is ahead of upstream by {ahead} commit(s)")
+    if branch in {"main", "master"}:
+        warnings.append("current branch is a protected base branch")
+    if origin_main == "unknown":
+        warnings.append("origin/main is unavailable; run git fetch origin main")
+
+    return {
+        "root": str(root),
+        "branch": branch,
+        "head": head,
+        "origin_main": origin_main,
+        "upstream": upstream,
+        "ahead": ahead,
+        "behind": behind,
+        "dirty_count": len(dirty_lines),
+        "dirty_paths": dirty_lines[:20],
+        "remote": remote_url,
+        "worktrees": worktrees,
+        "environment": env_snapshot(),
+        "warnings": warnings,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Codex Session Check",
+        "",
+        f"- Repo: `{report['root']}`",
+        f"- Branch: `{report['branch']}`",
+        f"- HEAD: `{report['head']}`",
+        f"- origin/main: `{report['origin_main']}`",
+        f"- Upstream: `{report['upstream'] or 'none'}`",
+        f"- Ahead/behind: `{report['ahead'] if report['ahead'] is not None else '?'} / {report['behind'] if report['behind'] is not None else '?'}`",
+        f"- Dirty paths: `{report['dirty_count']}`",
+        f"- Remote: `{report['remote']}`",
+        "",
+        "## Permission / Sandbox Snapshot",
+    ]
+    for key, value in report["environment"].items():
+        lines.append(f"- `{key}`: `{value}`")
+
+    lines.extend(["", "## Warnings"])
+    if report["warnings"]:
+        for warning in report["warnings"]:
+            lines.append(f"- {warning}")
+    else:
+        lines.append("- No blocking session-start warnings.")
+
+    lines.extend(["", "## Worktrees"])
+    for entry in report["worktrees"][:12]:
+        path = entry.get("worktree", "unknown")
+        branch = entry.get("branch", "detached")
+        head = entry.get("HEAD", "unknown")[:12]
+        lines.append(f"- `{path}` — `{branch}` @ `{head}`")
+
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print JSON instead of Markdown.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when the session has warnings.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
+    args = parse_args(argv)
+    report = analyze(Path.cwd())
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(render_markdown(report))
+    return 1 if args.strict and report["warnings"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add `scripts/codex_session_check.py` for Codex #1/#2 session-start worktree and permission/sandbox snapshots
- document the new check in `AGENTS.md`, `docs/CODEX_WORKFLOW.md`, and `docs/SCHEDULE_TASKS.md`
- route the Codex CLI 0.125.0 permission profile/session state signal into a deterministic repo harness

Closes #1445

## Verification
- `python -m py_compile scripts\\codex_session_check.py scripts\\ai_tool_watch.py`
- `python scripts\\codex_session_check.py`
- `git diff --check`