### PR TITLE
fix: add daily-report freshness guard

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@
 | **Deploy to Development** | `deploy-dev.yml` | `develop` へのpush | 開発環境デプロイ (concurrency制御・timeout付き) |
 | **Deploy to Staging** | `deploy-staging.yml` | `staging` へのpush | ステージング環境デプロイ (concurrency制御・timeout付き) |
 | **Deploy to Production** | `deploy-prod.yml` | `main` へのpush | 本番環境デプロイ + バージョニング (concurrency制御・timeout付き) |
-| **Daily Report** | `daily-report.yml` | 毎日 08:58 JST / 手動 | 日次レポート生成 + X投稿 + 競合モニタリング + schedule_task_runs記録 + Job Summary |
+| **Daily Report** | `daily-report.yml` | 毎日 07:30 JST / 手動 | 日次レポート生成 + X投稿 + 競合モニタリング + schedule_task_runs記録 + Job Summary |
 | **CS Check** | `cs-check.yml` | 毎時 07分 / 手動 | CS自動対応 + PR自動レビュー + schedule_task_runs記録 + Job Summary |
 | **Edge Function Audit** | `edge-function-audit.yml` | 毎時 47分 / 手動 | EF UI導線カバレッジチェック + schedule_task_runs記録 + Job Summary |
 | **Infra Health Check** | `infra-health-check.yml` | 毎時 37分 / 手動 | Firebase + 重要EF 6件監視 + schedule_task_runs記録 + Job Summary |
@@ -42,7 +42,7 @@
 | `dependabot` 自動更新 | ✅ Actions + pub + pip (毎週月曜) |
 | **Claude Managed Agents 統合** | ✅ claude-agent-review.yml (`ANTHROPIC_API_KEY` 要設定) |
 | **ユーザーフィードバックパイプライン** | ✅ feedback-issue-resolved.yml (`SUPABASE_SERVICE_ROLE_KEY` 使用) |
-| **CI失敗自動修復** | ✅ ci-auto-fix.yml (`dart fix --apply` + `deno fmt` → PR自動コミット) |
+| **CI失敗自動修復** | ✅ ci-auto-fix.yml (`dart fix --apply` + `dart format` + `deno fmt` → PR自動コミット) |
 | **YouTube競合分析自動化** | ✅ youtube-analysis.yml (`yt-dlp` 毎日スナップショット → TSV更新) |
 | **技術記事手動投稿** | ✅ blog-publish.yml (Qiita/dev.to `workflow_dispatch` + dry_run対応) |
 | **AI大学コンテンツ週次自動更新** | ✅ ai-university-update.yml (毎週月曜 11:00 JST RSS取得・UPSERT) |

--- a/.github/workflows/cs-check.yml
+++ b/.github/workflows/cs-check.yml
@@ -179,6 +179,26 @@ jobs:
             }' > /tmp/flutter-analyze-cache.json
           echo "✅ flutter-analyze-cache: conclusion=$CONCLUSION"
 
+      - name: Step 5.5 - daily-report freshness guard
+        id: daily_report
+        run: |
+          git fetch origin main --quiet
+          set +e
+          python scripts/check_daily_report_freshness.py \
+            --ref origin/main \
+            --json \
+            --github-output "$GITHUB_OUTPUT" \
+            > /tmp/daily-report-freshness.json
+          CHECK_EXIT=$?
+          set -e
+          cat /tmp/daily-report-freshness.json
+          if [ "$CHECK_EXIT" -eq 0 ]; then
+            echo "✅ daily-report freshness confirmed"
+          else
+            echo "⚠️ daily-report freshness check failed"
+          fi
+          exit 0
+
       - name: Step 3/6 - Update cache files via GitHub API (branch protection bypass)
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
@@ -254,9 +274,11 @@ jobs:
         run: |
           TICKET_COUNT="${{ steps.tickets.outputs.ticket_count }}"
           HEALTHY="${{ steps.health.outputs.healthy }}"
+          DAILY_REPORT="${{ steps.daily_report.outputs.fresh }}"
           STATUS="success"
           [ "$HEALTHY" != "true" ] && STATUS="partial"
-          SUMMARY="CS Check: tickets=${TICKET_COUNT}, infra_healthy=${HEALTHY}"
+          [ "$DAILY_REPORT" != "true" ] && STATUS="partial"
+          SUMMARY="CS Check: tickets=${TICKET_COUNT}, infra_healthy=${HEALTHY}, daily_report_fresh=${DAILY_REPORT}"
           curl -s -o /dev/null \
             -X POST \
             -H "apikey: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
@@ -274,7 +296,9 @@ jobs:
           HTTP="${{ steps.tickets.outputs.http_code }}"
           PR_COUNT="${{ steps.pr_review.outputs.pr_count }}"
           HEALTHY="${{ steps.health.outputs.healthy }}"
+          DAILY_REPORT="${{ steps.daily_report.outputs.fresh }}"
           HEALTH_ICON=$([ "$HEALTHY" = "true" ] && echo "✅" || echo "⚠️")
+          DAILY_ICON=$([ "$DAILY_REPORT" = "true" ] && echo "✅" || echo "⚠️")
           {
             echo "## CS Check $(TZ=Asia/Tokyo date +'%Y-%m-%d %H:%M JST')"
             echo ""
@@ -283,5 +307,6 @@ jobs:
             echo "| サポートチケット | ${TICKETS}件 (HTTP ${HTTP}) |"
             echo "| オープンPR | ${PR_COUNT}件 |"
             echo "| インフラ | ${HEALTH_ICON} healthy=${HEALTHY} |"
+            echo "| daily-report | ${DAILY_ICON} fresh=${DAILY_REPORT} |"
             echo "| キャッシュ更新 | GitHub API 方式 |"
           } >> $GITHUB_STEP_SUMMARY

--- a/docs/SCHEDULE_TASKS.md
+++ b/docs/SCHEDULE_TASKS.md
@@ -58,12 +58,21 @@ X への自動投稿先: **@kanta13jp1**
 ```bash
 # 今日のレポートファイルが存在するか確認
 ls docs/daily-reports/YYYY-MM-DD.md 2>/dev/null
+
+# 推奨: レポート・schedule-log・metrics の複数シグナルで確認する
+git fetch origin main --quiet
+python scripts/check_daily_report_freshness.py --date YYYY-MM-DD --ref origin/main --json
 ```
 
-**ケース A: ファイルが存在し `<!-- generated-by: github-actions -->` を含む場合**
+**ケース A: ファイルが存在し `<!-- generated-by: github-actions -->` または `<!-- generated-by: claude-schedule -->` を含む場合**
 
 Read ツールでファイルを読み込み、概要セクション（ユーザー数・リクエスト数等）を
 そのまま利用する。Step 3・Step 4 は Actions 実施済みとしてスキップ可。
+
+> 誤検知防止: `git log --author='Claude Schedule'` だけで未実行判定しないこと。
+> GitHub Actions / Claude Schedule / 復旧ジョブのどれが完了させても、
+> `docs/daily-reports/YYYY-MM-DD.md` と `docs/schedule-logs/daily-report-YYYY-MM-DD-00.json`
+> を正本として扱う。
 
 **ケース B: ファイルが存在しない場合（Actions 未実行 or 失敗）**
 

--- a/docs/automation/daily-report-freshness.md
+++ b/docs/automation/daily-report-freshness.md
@@ -1,0 +1,39 @@
+# Daily Report Freshness Guard
+
+Issue: #1447
+
+## Problem
+
+The 2026-04-30 daily report was generated, but a schedule monitor opened a
+false alarm because it relied on a narrow git-log query. The durable completion
+signals are not a single author or commit subject.
+
+## Source Of Truth
+
+`daily-report` is considered fresh when the current JST date has a report file
+and at least one corroborating signal:
+
+- `docs/daily-reports/YYYY-MM-DD.md`
+- `docs/schedule-logs/daily-report-YYYY-MM-DD-00.json`
+- `docs/metrics/daily-metrics.json`
+
+Use `scripts/check_daily_report_freshness.py` instead of author-only grep:
+
+```bash
+git fetch origin main --quiet
+python scripts/check_daily_report_freshness.py --ref origin/main --json
+```
+
+## Automation
+
+`cs-check.yml` now runs the freshness guard every hour and records the result in
+both the GitHub Step Summary and `schedule_task_runs` summary. A stale
+daily-report result downgrades the CS check status to `partial` without failing
+the whole workflow, leaving room for the existing recovery lanes to continue.
+
+## Agent Handoff
+
+- Codex #2 owns deterministic schedule monitors and false-positive reduction.
+- Claude Schedule owns the narrative report and AI analysis sections.
+- Claude Code `/ultrareview` is only needed if this guard grows into a broader
+  schedule recovery redesign.

--- a/scripts/check_daily_report_freshness.py
+++ b/scripts/check_daily_report_freshness.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Check whether the daily-report task produced today's durable outputs.
+
+This intentionally avoids using a single git author or commit subject as the
+source of truth. The daily-report lane can be completed by GitHub Actions,
+Claude Schedule, or a recovery job, so the durable artifacts are the report
+file, schedule log, and metrics snapshot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+
+GENERATED_MARKERS = (
+    "<!-- generated-by: github-actions -->",
+    "<!-- generated-by: claude-schedule",
+)
+
+
+def jst_today() -> str:
+    return datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y-%m-%d")
+
+
+def read_text(root: Path, rel_path: str, ref: str | None) -> str | None:
+    if ref:
+        # Git paths always use forward slashes, even on Windows.
+        git_path = rel_path.replace("\\", "/")
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{git_path}"],
+            cwd=root,
+            encoding="utf-8",
+            errors="replace",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout
+
+    path = root / rel_path
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def load_json(root: Path, rel_path: str, ref: str | None) -> dict[str, Any] | None:
+    text = read_text(root, rel_path, ref)
+    if text is None:
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def check(date: str, root: Path, ref: str | None) -> dict[str, Any]:
+    report_path = f"docs/daily-reports/{date}.md"
+    log_path = f"docs/schedule-logs/daily-report-{date}-00.json"
+    metrics_path = "docs/metrics/daily-metrics.json"
+
+    report_text = read_text(root, report_path, ref)
+    report_exists = report_text is not None
+    report_marker = False
+    if report_text is not None:
+        report_marker = any(marker in report_text for marker in GENERATED_MARKERS)
+        report_marker = report_marker or f"日次レポート {date}" in report_text
+
+    schedule_log = load_json(root, log_path, ref)
+    schedule_log_success = False
+    if schedule_log:
+        expected_saved = schedule_log.get("details", {}).get("daily_report_saved")
+        schedule_log_success = (
+            schedule_log.get("task_id") == "daily-report"
+            and schedule_log.get("status") == "success"
+            and (expected_saved in (None, report_path) or str(expected_saved).endswith(f"{date}.md"))
+        )
+
+    metrics = load_json(root, metrics_path, ref)
+    metrics_match = bool(metrics and metrics.get("report_date") == date)
+
+    # A report file is the durable artifact. The marker/log/metrics are
+    # corroborating signals that prevent stale checkout and author-grep mistakes.
+    fresh = report_exists and (report_marker or schedule_log_success or metrics_match)
+
+    return {
+        "date": date,
+        "fresh": fresh,
+        "ref": ref or "worktree",
+        "signals": {
+            "report_exists": report_exists,
+            "report_marker": report_marker,
+            "schedule_log_success": schedule_log_success,
+            "metrics_report_date_matches": metrics_match,
+        },
+        "paths": {
+            "report": report_path,
+            "schedule_log": log_path,
+            "metrics": metrics_path,
+        },
+        "reason": "daily-report artifacts are fresh"
+        if fresh
+        else "missing daily-report report file or corroborating freshness signal",
+    }
+
+
+def write_github_output(path: str | None, result: dict[str, Any]) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"fresh={str(result['fresh']).lower()}\n")
+        handle.write(f"date={result['date']}\n")
+        handle.write(f"reason={result['reason']}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date", default=jst_today(), help="Report date in YYYY-MM-DD (JST default)")
+    parser.add_argument("--root", default=".", help="Repository root")
+    parser.add_argument("--ref", default=None, help="Optional git ref to inspect, e.g. origin/main")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="Optional GitHub Actions output file",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    result = check(args.date, root, args.ref)
+    write_github_output(args.github_output, result)
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        status = "fresh" if result["fresh"] else "stale"
+        print(f"daily-report {args.date}: {status} ({result['reason']})")
+
+    return 0 if result["fresh"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
﻿## Summary
- Closes #1447 by replacing author-only daily-report monitoring with a deterministic freshness guard.
- Adds `scripts/check_daily_report_freshness.py` to validate report, schedule-log, and metrics artifacts on the current JST date.
- Wires the guard into `cs-check.yml` so hourly CS checks report `daily_report_fresh` in the summary and `schedule_task_runs`.
- Documents the source-of-truth signals and updates stale workflow timing/CI auto-fix notes.

## Verification
- `python -m py_compile scripts/check_daily_report_freshness.py`
- YAML parse for `.github/workflows/cs-check.yml`
- `python scripts/check_daily_report_freshness.py --date 2026-04-30 --ref origin/main --json`
- `git diff --check origin/main..HEAD`

## Notes
- 2026-04-30 daily-report is confirmed fresh via `docs/daily-reports/2026-04-30.md` and `docs/schedule-logs/daily-report-2026-04-30-00.json`.
- Claude Code latest checked: 2.1.123 (2026-04-29); Codex latest checked: CLI 0.125.0 / GPT-5.5 Codex update (2026-04-24).
