### PR TITLE
ci: retry Supabase function deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,21 @@ jobs:
       - name: Check Edge Function deploy count (ハードキャップ50本以下)
         run: |
           # deploy-prod.yml のデプロイリストを抽出 (macro-hub体制 — Tier1/Tier2廃止)
-          DEPLOYED=$(grep "supabase functions deploy" .github/workflows/deploy-prod.yml \
-            | grep -v "^#\|#" | awk '{print $4}' | sort)
+          DEPLOYED=$(python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          pattern = re.compile(
+              r'^\s*(?:supabase\s+functions\s+deploy|deploy_function)\s+([A-Za-z0-9_-]+)\b'
+          )
+          deployed = []
+          for line in Path('.github/workflows/deploy-prod.yml').read_text(encoding='utf-8').splitlines():
+              match = pattern.search(line)
+              if match:
+                  deployed.append(match.group(1))
+          print('\n'.join(sorted(set(deployed))))
+          PY
+          )
           DEPLOY_COUNT=$(echo "$DEPLOYED" | grep -c . || true)
           # supabase/functions/ の実EFディレクトリ数 (_shared除く)
           EXISTING=$(find supabase/functions -maxdepth 1 -mindepth 1 -type d \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -499,35 +499,65 @@ jobs:
           # All browser-facing functions use --no-verify-jwt so that CORS OPTIONS
           # preflight requests (which carry no Authorization header) are not
           # rejected by Supabase's platform-level JWT check.
+          #
+          # Remote dependency CDNs can occasionally return transient 5xx errors
+          # while the Supabase CLI builds each function graph. Retry per
+          # function so one flaky import does not block the whole deploy lane.
+          deploy_function() {
+            local function_name="$1"
+            shift
+            local attempt
+            local sleep_seconds
+
+            for attempt in 1 2 3; do
+              echo "::group::Deploy ${function_name} (attempt ${attempt}/3)"
+              if supabase functions deploy "$function_name" "$@"; then
+                echo "::endgroup::"
+                return 0
+              fi
+
+              local exit_code=$?
+              echo "::endgroup::"
+
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::supabase functions deploy ${function_name} failed after ${attempt} attempts (exit ${exit_code})"
+                return "$exit_code"
+              fi
+
+              sleep_seconds=$((attempt * 20))
+              echo "::warning::supabase functions deploy ${function_name} failed with ${exit_code}; retrying in ${sleep_seconds}s"
+              sleep "$sleep_seconds"
+            done
+          }
 
           # --- Standalone (5本: 複雑すぎてhub統合困難) ---
           # local-election-intelligence は line 275 にあり (並び順維持のため)
-          supabase functions deploy get-home-dashboard --no-verify-jwt
-          supabase functions deploy ai-assistant --no-verify-jwt
-          supabase functions deploy growth-weekly-digest --no-verify-jwt
-          supabase functions deploy guitar-recording-studio --no-verify-jwt
+          deploy_function get-home-dashboard --no-verify-jwt
+          deploy_function ai-assistant --no-verify-jwt
+          deploy_function growth-weekly-digest --no-verify-jwt
+          deploy_function guitar-recording-studio --no-verify-jwt
 
           # --- Macro-Hub (6本: 旧Tier1全統合) ---
-          supabase functions deploy core-hub --no-verify-jwt
-          supabase functions deploy growth-hub --no-verify-jwt
-          supabase functions deploy ai-hub --no-verify-jwt
-          supabase functions deploy admin-hub --no-verify-jwt
-          supabase functions deploy app-hub --no-verify-jwt
-          supabase functions deploy schedule-hub --no-verify-jwt
+          deploy_function core-hub --no-verify-jwt
+          deploy_function growth-hub --no-verify-jwt
+          deploy_function ai-hub --no-verify-jwt
+          deploy_function admin-hub --no-verify-jwt
+          deploy_function app-hub --no-verify-jwt
+          deploy_function schedule-hub --no-verify-jwt
 
           # --- Mega-Hub (5本: 旧Tier2全統合) ---
-          supabase functions deploy tools-hub --no-verify-jwt
-          supabase functions deploy media-hub --no-verify-jwt
-          supabase functions deploy enterprise-hub --no-verify-jwt
-          supabase functions deploy social-commerce-hub --no-verify-jwt
-          supabase functions deploy lifestyle-hub --no-verify-jwt
-          supabase functions deploy local-election-intelligence --no-verify-jwt
+          deploy_function tools-hub --no-verify-jwt
+          deploy_function media-hub --no-verify-jwt
+          deploy_function enterprise-hub --no-verify-jwt
+          deploy_function social-commerce-hub --no-verify-jwt
+          deploy_function lifestyle-hub --no-verify-jwt
+          deploy_function local-election-intelligence --no-verify-jwt
 
           # --- Public health-check (認証不要・スケジュールタスクからの死活監視用) ---
-          supabase functions deploy health-check --no-verify-jwt
-          supabase functions deploy ai-writing-assistant --no-verify-jwt
-          supabase functions deploy viral-video-ad-generator --no-verify-jwt
-          supabase functions deploy memory-search-hub --no-verify-jwt
+          deploy_function health-check --no-verify-jwt
+          deploy_function ai-writing-assistant --no-verify-jwt
+          deploy_function viral-video-ad-generator --no-verify-jwt
+          deploy_function memory-search-hub --no-verify-jwt
 
           # Total: 20 functions deployed (ハードキャップ50本に対し20本 — 余裕30本)
           # memo-reactions → core-hub に統合済み (b4c91bc2 2026-04-24)

--- a/.github/workflows/stale-ef-completeness-check.yml
+++ b/.github/workflows/stale-ef-completeness-check.yml
@@ -21,6 +21,9 @@ jobs:
     name: Audit stale EF references
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v6
 
@@ -31,7 +34,7 @@ jobs:
         run: python3 scripts/check_ef_coverage.py
 
       - name: Create Issue on failure
-        if: failure()
+        if: failure() && github.event_name != 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |

--- a/scripts/check_ef_coverage.py
+++ b/scripts/check_ef_coverage.py
@@ -10,10 +10,13 @@ def main():
 
     # Read deployed EFs from deploy-prod.yml
     deploy_yml = os.path.join(repo_root, '.github/workflows/deploy-prod.yml')
+    deploy_line = re.compile(
+        r'^\s*(?:supabase\s+functions\s+deploy|deploy_function)\s+([A-Za-z0-9_-]+)\b'
+    )
     deployed = []
     with open(deploy_yml, encoding='utf-8') as f:
         for line in f:
-            m = re.search(r'functions deploy (\S+)', line)
+            m = deploy_line.search(line)
             if m:
                 deployed.append(m.group(1).rstrip())
 


### PR DESCRIPTION
## Summary
- Wrap Supabase Edge Function deploy commands in a per-function retry helper.
- Retry each function up to 3 times with short backoff so transient CDN/import failures do not block production deploys.
- This directly addresses the Deploy to Production failure in run 25160856981 where growth-hub bundling failed on esm.sh 522 for @supabase/supabase-js@2.90.1.

## Validation
- git diff --check
- bash -n check of retry helper snippet

## Operational note
This follows the NotebookLM Harness Engineering pattern: keep deterministic CI gates strict, but make external-service flakes self-healing before they become WBS/manual work.