### PR TITLE
fix: harden Edge Function deploy dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Check Edge Function imports
+        run: python scripts/check_edge_function_imports.py
+
       - name: Deno lint (Edge Functions)
         id: deno_lint
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -500,6 +500,33 @@ jobs:
           # preflight requests (which carry no Authorization header) are not
           # rejected by Supabase's platform-level JWT check.
 
+          supabase_deploy_attempt() {
+            local attempt=1
+            local max_attempts=3
+            local delay=20
+            while true; do
+              if command supabase "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "::error::supabase $* failed after ${max_attempts} attempts"
+                return 1
+              fi
+              echo "::warning::supabase $* failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s"
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          supabase() {
+            if [ "${1:-}" = "functions" ] && [ "${2:-}" = "deploy" ]; then
+              supabase_deploy_attempt "$@"
+            else
+              command supabase "$@"
+            fi
+          }
+
           # --- Standalone (5本: 複雑すぎてhub統合困難) ---
           # local-election-intelligence は line 275 にあり (並び順維持のため)
           supabase functions deploy get-home-dashboard --no-verify-jwt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ and GitHub Actions proves the result.
   clean fix PRs from a fresh worktree.
 - Codex #2 should take red CI, deploy unblockers, workflow drift, Edge Function
   failures, and GitHub/Notion/Slack synchronization issues.
+- Edge Function dependency resolution follows
+  `docs/adr/2026-04-30-edge-function-dependency-resolution.md`.
 - If a task needs product judgment, cross-instance arbitration, or NotebookLM
   synthesis before code can be safely changed, route it back to Claude Code and
   leave a short handoff note.

--- a/docs/adr/2026-04-30-edge-function-dependency-resolution.md
+++ b/docs/adr/2026-04-30-edge-function-dependency-resolution.md
@@ -1,0 +1,41 @@
+# ADR: Supabase Edge Function Dependency Resolution
+
+Date: 2026-04-30
+Status: Accepted
+
+## Context
+
+Production deploys failed repeatedly while bundling Edge Functions because Deno
+resolved `https://esm.sh/@supabase/supabase-js@2` through esm.sh and received
+HTTP 522. The application code was not the failing surface; the deploy pipeline
+was relying on a remote CDN resolution path that had already failed in earlier
+incidents.
+
+## Decision
+
+Supabase Edge Functions must import Supabase JS with:
+
+```ts
+import { createClient } from "npm:@supabase/supabase-js@2";
+```
+
+Do not add new Edge Function imports from
+`https://esm.sh/@supabase/supabase-js@2`. CI runs
+`scripts/check_edge_function_imports.py` to block regressions.
+
+The production deploy workflow also retries `supabase functions deploy` up to
+three times. Retry is a safety net for transient platform/network failures, not
+the primary dependency strategy.
+
+Dependency maps live in `supabase/functions/deno.json` via `imports`. Do not
+reintroduce the legacy root `import_map.json` fallback, because recent Supabase
+CLI output warns that import-map flags are deprecated for function deploys.
+
+## Consequences
+
+- Edge Function deploys no longer depend on esm.sh for Supabase JS.
+- Deploy logs avoid the deprecated root import-map fallback path.
+- CI turns a recurring operational incident into a deterministic failure before
+  merge.
+- New Edge Functions should be added to existing hubs where possible and should
+  reuse the same `npm:` import rule.

--- a/scripts/check_edge_function_imports.py
+++ b/scripts/check_edge_function_imports.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Guard Edge Function imports that make production deploys flaky."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+BANNED = "https://esm.sh/@supabase/supabase-js@2"
+DEFAULT_ROOT = Path("supabase/functions")
+DEFAULT_SUFFIXES = {".ts", ".json", ".jsonc"}
+
+
+def iter_files(root: Path):
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix not in DEFAULT_SUFFIXES:
+            continue
+        yield path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail if Supabase Edge Functions import supabase-js from esm.sh. "
+            "Use npm:@supabase/supabase-js@2 instead."
+        )
+    )
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    args = parser.parse_args()
+
+    if not args.root.exists():
+        print(f"Edge Function root not found: {args.root}")
+        return 1
+
+    offenders: list[tuple[Path, int, str]] = []
+    for path in iter_files(args.root):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for number, line in enumerate(text.splitlines(), start=1):
+            if BANNED in line:
+                offenders.append((path, number, line.strip()))
+
+    if offenders:
+        print("Banned Supabase JS import found in Edge Functions.")
+        print("Use npm:@supabase/supabase-js@2 to avoid esm.sh deploy-time 522s.")
+        for path, number, line in offenders:
+            print(f"- {path}:{number}: {line}")
+        return 1
+
+    print("Edge Function Supabase JS imports are deploy-resilient.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/functions/_shared/effort_router.ts
+++ b/supabase/functions/_shared/effort_router.ts
@@ -1,7 +1,7 @@
 import {
   createClient,
   SupabaseClient,
-} from "https://esm.sh/@supabase/supabase-js@2";
+} from "npm:@supabase/supabase-js@2";
 
 export type Effort = "low" | "medium" | "high" | "xhigh";
 

--- a/supabase/functions/_shared/task_budget.ts
+++ b/supabase/functions/_shared/task_budget.ts
@@ -1,7 +1,7 @@
 import {
   createClient,
   SupabaseClient,
-} from "https://esm.sh/@supabase/supabase-js@2";
+} from "npm:@supabase/supabase-js@2";
 
 export type BudgetScope = "ef" | "gha" | "instance" | "month";
 

--- a/supabase/functions/admin-hub/index.ts
+++ b/supabase/functions/admin-hub/index.ts
@@ -1,6 +1,6 @@
 ﻿// admin-hub — 管理・サポート・監視・分析統合EF
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -1,6 +1,6 @@
 ﻿// AI Assistant Edge Function: "The Five Emperors" (Ultimate Edition)
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js@2'
 import { AI_CHARACTER_PREAMBLE } from "../_shared/ai_character_preamble.ts"
 
 const corsHeaders = {

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -10,7 +10,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import {
   createClient,
   SupabaseClient,
-} from "https://esm.sh/@supabase/supabase-js@2";
+} from "npm:@supabase/supabase-js@2";
 import { AI_CHARACTER_PREAMBLE, prependCharacter } from "../_shared/ai_character_preamble.ts";
 import { selectEffort } from "../_shared/effort_router.ts";
 import {

--- a/supabase/functions/ai-writing-assistant/index.ts
+++ b/supabase/functions/ai-writing-assistant/index.ts
@@ -12,7 +12,7 @@
 // POST → improve / summarize / continue / translate / tone / titles / minutes / thread / blog
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { prependCharacter } from "../_shared/ai_character_preamble.ts";
 
 const corsHeaders = {

--- a/supabase/functions/app-hub/index.ts
+++ b/supabase/functions/app-hub/index.ts
@@ -7,7 +7,7 @@
 //   api-rate-limiter, music-collaboration
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type" };
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -3,7 +3,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import {
   createClient,
   SupabaseClient,
-} from "https://esm.sh/@supabase/supabase-js@2";
+} from "npm:@supabase/supabase-js@2";
 import {
   createSupabaseMemoReactionStore,
   handleMemoReactionAction,

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -4,7 +4,9 @@
     "lib": ["deno.window"],
     "strict": true
   },
-  "importMap": "./import_map.json",
+  "imports": {
+    "https://deno.land/": "https://deno.land/"
+  },
   "lint": {
     "rules": {
       "exclude": ["no-import-prefix"]

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -1,7 +1,80 @@
 {
   "version": "5",
-  "redirects": {
-    "https://esm.sh/@supabase/supabase-js@2": "https://esm.sh/@supabase/supabase-js@2.90.1"
+  "specifiers": {
+    "npm:@supabase/supabase-js@2": "2.105.1"
+  },
+  "npm": {
+    "@supabase/auth-js@2.105.1": {
+      "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.105.1": {
+      "integrity": "sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.1": {
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA=="
+    },
+    "@supabase/postgrest-js@2.105.1": {
+      "integrity": "sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.105.1": {
+      "integrity": "sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "@types/ws",
+        "tslib",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.105.1": {
+      "integrity": "sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@supabase/supabase-js@2.105.1": {
+      "integrity": "sha512-4gn6HmsAkCCVU7p8JmgKGhHJ5Btod4ZzSp8qKZf4JHaTxbhaIK86/usHzeLxWv7EJJDhBmILDmJOSOf9iF4CLA==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "@types/node@25.6.0": {
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "undici-types@7.19.2": {
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
+    },
+    "ws@8.20.0": {
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
+    }
   },
   "remote": {
     "https://deno.land/std@0.168.0/async/abortable.ts": "80b2ac399f142cc528f95a037a7d0e653296352d95c681e284533765961de409",
@@ -49,7 +122,6 @@
     "https://deno.land/std@0.224.0/http/server.ts": "f9313804bf6467a1704f45f76cb6cd0a3396a3b31c316035e6a4c2035d1ea514",
     "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
     "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
-    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
-    "https://esm.sh/@supabase/supabase-js@2.90.1": "fcf5e194d637ff365df76d1806e7c2f239905c4b08e83e5d95690a2b22e21a1d"
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   }
 }

--- a/supabase/functions/enterprise-hub/index.ts
+++ b/supabase/functions/enterprise-hub/index.ts
@@ -14,7 +14,7 @@
 // GET/POST ?action=<action> or body { action: "..." }
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/get-home-dashboard/index.ts
+++ b/supabase/functions/get-home-dashboard/index.ts
@@ -6,7 +6,7 @@
 // Consolidates 3 separate client-side DB calls into a single round-trip.
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -10,7 +10,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import {
   createClient,
   SupabaseClient,
-} from "https://esm.sh/@supabase/supabase-js@2";
+} from "npm:@supabase/supabase-js@2";
 import {
   getXAccountHandle,
   isXConfigured,

--- a/supabase/functions/growth-weekly-digest/index.ts
+++ b/supabase/functions/growth-weekly-digest/index.ts
@@ -1,5 +1,5 @@
 ﻿import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/guitar-recording-studio/index.ts
+++ b/supabase/functions/guitar-recording-studio/index.ts
@@ -1,5 +1,5 @@
 ﻿import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, type SupabaseClient, type User } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, type SupabaseClient, type User } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/health-check/index.ts
+++ b/supabase/functions/health-check/index.ts
@@ -5,7 +5,7 @@
 // Auth: public endpoint (no sensitive data returned — only boolean connectivity status).
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/import_map.json
+++ b/supabase/functions/import_map.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "https://deno.land/": "https://deno.land/"
-  }
-}

--- a/supabase/functions/lifestyle-hub/index.ts
+++ b/supabase/functions/lifestyle-hub/index.ts
@@ -11,7 +11,7 @@
 // GET/POST ?action=<action> or body { action: "..." }
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/media-hub/index.ts
+++ b/supabase/functions/media-hub/index.ts
@@ -8,7 +8,7 @@
 // GET/POST ?action=<action> or body { action: "..." }
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/memory-search-hub/deno.jsonc
+++ b/supabase/functions/memory-search-hub/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2"
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2"
   },
   "lint": {
     "rules": {

--- a/supabase/functions/memory-search-hub/index.ts
+++ b/supabase/functions/memory-search-hub/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { corsHeaders, jsonResponse } from "../_shared/edge.ts";
 import {
   logMcpInvocation,

--- a/supabase/functions/memory-search-hub/search/vector.ts
+++ b/supabase/functions/memory-search-hub/search/vector.ts
@@ -1,4 +1,4 @@
-import { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 export interface VectorMatch {
   file_path: string;

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -8,7 +8,7 @@
 // be kept in Supabase but removed from the deploy list.
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { getXAccountHandle, isXConfigured, postTweet, uploadMediaFromUrl } from "../_shared/x-client.ts";
 
 const corsHeaders = {

--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -11,7 +11,7 @@
 // All data stored in hub_data table (source column = feature name)
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -12,7 +12,7 @@
 // GET  ?view=templates | ?view=history
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
## Summary
- switch deployed Supabase Edge Functions from esm.sh Supabase JS imports to npm imports and refresh the Deno lock
- move dependency-map configuration into supabase/functions/deno.json and remove the legacy import_map.json fallback
- add a CI guard for banned esm.sh Supabase JS imports and retry Supabase function deploys on transient failures
- record the decision in an ADR and link it from AGENTS.md

## Verification
- python scripts/check_edge_function_imports.py
- python -m py_compile scripts/check_edge_function_imports.py
- YAML parse: .github/workflows/ci.yml, .github/workflows/deploy-prod.yml
- deno lint --config supabase/functions/deno.json supabase/functions/
- deno cache --config supabase/functions/deno.json supabase/functions/get-home-dashboard/index.ts supabase/functions/growth-hub/index.ts supabase/functions/memory-search-hub/index.ts
- deno test --allow-all --no-check --config supabase/functions/deno.json supabase/functions/
- git diff --check

Closes #1451