### PR TITLE
fix(ci): soft-fail memory embeddings on quota

### DIFF
--- a/.github/workflows/memory-search-sync.yml
+++ b/.github/workflows/memory-search-sync.yml
@@ -17,15 +17,15 @@ jobs:
 
       - name: Pre-flight budget check
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           python scripts/check_budget.py --scope gha --scope-id memory-search-sync --limit "${TASK_BUDGET_USD:-20}"
 
       - name: Sync memory index
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
-          python scripts/sync_memory_index.py --memory-dir memory --with-embeddings
+          python scripts/sync_memory_index.py --memory-dir memory --with-embeddings --soft-fail-embedding-quota

--- a/scripts/sync_memory_index.py
+++ b/scripts/sync_memory_index.py
@@ -15,6 +15,14 @@ from pathlib import Path
 
 EMBEDDING_DIMENSION = 768
 EMBEDDING_MODEL = "models/gemini-embedding-001"
+QUOTA_HTTP_CODES = {429, 503}
+QUOTA_ERROR_MARKERS = (
+    "RESOURCE_EXHAUSTED",
+    "quota",
+    "rate limit",
+    "rate-limit",
+    "rate_limited",
+)
 
 
 def title_for(path: Path, text: str) -> str:
@@ -48,6 +56,13 @@ def embedding_text_for(row: dict) -> str:
         str(row.get("content") or ""),
     ]
     return "\n".join(part for part in parts if part).strip()[:3500]
+
+
+def is_embedding_quota_error(status_code: int, body: str) -> bool:
+    if status_code in QUOTA_HTTP_CODES:
+        return True
+    lowered = body.lower()
+    return any(marker.lower() in lowered for marker in QUOTA_ERROR_MARKERS)
 
 
 def load_rows(memory_dir: Path) -> list[dict]:
@@ -155,6 +170,11 @@ def main() -> int:
         action="store_true",
         help="Generate Gemini retrieval-document embeddings when GEMINI_API_KEY is set.",
     )
+    parser.add_argument(
+        "--soft-fail-embedding-quota",
+        action="store_true",
+        help="Exit successfully when Gemini embedding quota is exhausted.",
+    )
     args = parser.parse_args()
 
     memory_dir = Path(args.memory_dir)
@@ -170,7 +190,18 @@ def main() -> int:
             try:
                 embed_rows(rows, gemini_api_key)
             except urllib.error.HTTPError as exc:
-                print(exc.read().decode("utf-8", errors="replace"), file=sys.stderr)
+                detail = exc.read().decode("utf-8", errors="replace")
+                print(detail, file=sys.stderr)
+                if args.soft_fail_embedding_quota and is_embedding_quota_error(
+                    exc.code,
+                    detail,
+                ):
+                    print(
+                        "::warning::Gemini embedding quota exhausted; "
+                        "memory sync skipped and will retry on the next run",
+                        file=sys.stderr,
+                    )
+                    return 0
                 return 1
         else:
             print("GEMINI_API_KEY not configured; embeddings skipped", file=sys.stderr)


### PR DESCRIPTION
## Summary
- use the configured production Supabase URL secret for Memory Search Sync
- add a soft-fail switch for Gemini embedding quota/rate-limit exhaustion
- let scheduled memory sync retry later instead of failing main on transient 429s

## Verification
- python -m py_compile scripts/sync_memory_index.py
- python scripts/sync_memory_index.py --memory-dir memory --dry-run
- python -c quota helper assertions
- git diff --check

Context: Memory Search Sync run 25163627530 failed with Gemini 429 RESOURCE_EXHAUSTED after embedding 16/33 rows.