### PR TITLE
fix(migrations): use canonical codex WBS instance

### DIFF
--- a/supabase/migrations/20260430070000_update_wbs_progress_win132_part98.sql
+++ b/supabase/migrations/20260430070000_update_wbs_progress_win132_part98.sql
@@ -24,8 +24,8 @@ INSERT INTO wbs_tasks (title, category, instance, owner_instance, priority, stat
 VALUES (
   '[AI_FLEET_SYNERGY #3] Claude Code + Codex CLI 月次 changelog watch cron',
   'CX',
-  'codex2',
-  'codex2',
+  'codex',
+  'codex',
   'high',
   'pending',
   10,
@@ -38,8 +38,8 @@ INSERT INTO wbs_tasks (title, category, instance, owner_instance, priority, stat
 VALUES (
   '[AI_FLEET_SYNERGY #1] インスタンス担当分担 monthly audit cron',
   'CX',
-  'codex2',
-  'codex2',
+  'codex',
+  'codex',
   'medium',
   'pending',
   0,
@@ -52,8 +52,8 @@ INSERT INTO wbs_tasks (title, category, instance, owner_instance, priority, stat
 VALUES (
   '[AI_FLEET_SYNERGY #4] CLAUDE.md / inject-rules.txt 行数 monthly 監視 cron',
   'CX',
-  'codex2',
-  'codex2',
+  'codex',
+  'codex',
   'medium',
   'pending',
   0,
@@ -112,8 +112,8 @@ INSERT INTO wbs_tasks (title, category, instance, owner_instance, priority, stat
 VALUES (
   'AI 大学 ai-hub に 学部/学科 4 actions 追加 (= Codex#2 territory)',
   'CX',
-  'codex2',
-  'codex2',
+  'codex',
+  'codex',
   'high',
   'pending',
   0,


### PR DESCRIPTION
## Summary
- replace invalid wbs_tasks.instance = 'codex2' values with the canonical codex value
- keep Codex #2 ownership details in titles/descriptions while satisfying the production WBS check constraint

## Verification
- python scripts/check_migration_timestamps.py
- PYTHONIOENCODING=utf-8 python scripts/check_migration_time_relative_check.py
- git diff --check

Context: Deploy to Production runs 25163640632 and 25164018440 failed in Run Supabase migrations with SQLSTATE 23514 on wbs_tasks_instance_check while applying 20260430070000_update_wbs_progress_win132_part98.sql.