### PR TITLE
fix(ci): exempt completed WBS progress migration

### DIFF
--- a/scripts/check_migration_time_relative_check.py
+++ b/scripts/check_migration_time_relative_check.py
@@ -26,6 +26,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(errors="replace")
+
 MIGRATIONS_DIR = Path("supabase/migrations")
 
 FUNC_DEF_RE = re.compile(

--- a/supabase/migrations/20260501130000_update_wbs_progress_win132_part111.sql
+++ b/supabase/migrations/20260501130000_update_wbs_progress_win132_part111.sql
@@ -1,7 +1,9 @@
 -- WBS update — #974 SECOND_BRAIN ingest pipeline 完了 (Win版#132 part 111 / 2026-05-01)
 --
 -- Phase 6 自律 cycle 継続. 上から順 Win territory task #974 (= AI 第二の脳 Ingest).
-
+-- nocheck: time-relative
+-- Safe: this migration marks the touched WBS row completed, so
+-- wbs_enforce_recovery_plan() returns before CURRENT_DATE checks run.
 UPDATE wbs_tasks
 SET status = 'completed',
     progress = 100,


### PR DESCRIPTION
## Summary
- Mark the completed-only WBS progress migration as time-relative safe with the existing nocheck convention.
- Keep the migration checker from crashing on Windows cp932 terminals by using replace-on-output errors.

## Verification
- $env:GITHUB_BASE_SHA='206c3f018f9f95da6ec5e546c1756d9cc9c70db8'; python scripts/check_migration_time_relative_check.py
- python scripts/check_migration_timestamps.py
- git diff --check

Refs #1473.