### PR TITLE
feat(mcp): persist auth audit log

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,108 @@
 {
   "version": "5",
+  "specifiers": {
+    "npm:@playwright/test@^1.59.1": "1.59.1",
+    "npm:@supabase/supabase-js@2": "2.105.1"
+  },
+  "npm": {
+    "@playwright/test@1.59.1": {
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dependencies": [
+        "playwright"
+      ],
+      "bin": true
+    },
+    "@supabase/auth-js@2.105.1": {
+      "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.105.1": {
+      "integrity": "sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.1": {
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA=="
+    },
+    "@supabase/postgrest-js@2.105.1": {
+      "integrity": "sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.105.1": {
+      "integrity": "sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "@types/ws",
+        "tslib",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.105.1": {
+      "integrity": "sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@supabase/supabase-js@2.105.1": {
+      "integrity": "sha512-4gn6HmsAkCCVU7p8JmgKGhHJ5Btod4ZzSp8qKZf4JHaTxbhaIK86/usHzeLxWv7EJJDhBmILDmJOSOf9iF4CLA==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "@types/node@25.6.0": {
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "playwright-core@1.59.1": {
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "bin": true
+    },
+    "playwright@1.59.1": {
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "undici-types@7.19.2": {
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
+    },
+    "ws@8.20.0": {
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
+    }
+  },
   "redirects": {
     "https://esm.sh/@supabase/supabase-js@2": "https://esm.sh/@supabase/supabase-js@2.90.1"
   },
@@ -50,6 +153,86 @@
     "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
     "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
     "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
+    "https://deno.land/x/jose@v5.9.6/index.ts": "e6e894e8c2b3a11c4071ee1008eb7d85a373ff68b5fbe5d7791d7384cfdee523",
+    "https://deno.land/x/jose@v5.9.6/jwe/compact/decrypt.ts": "43c80cb2dd0545df1b0aed37b710e0c02cd58781236eb0426fa2dd65bf250d8f",
+    "https://deno.land/x/jose@v5.9.6/jwe/compact/encrypt.ts": "b3be13ddddea2ea638cf188cbe1c1572085edd84f7d657cdd488dbba7c2a86c7",
+    "https://deno.land/x/jose@v5.9.6/jwe/flattened/decrypt.ts": "69ac436e2880b0cf03dfcddb38f24b862cab568c900fd5ec965561ae9aa3224d",
+    "https://deno.land/x/jose@v5.9.6/jwe/flattened/encrypt.ts": "0f2b4245b3fec9f7b55748f8b7d430d397aecb4884a858f0d5ce618a8d601e31",
+    "https://deno.land/x/jose@v5.9.6/jwe/general/decrypt.ts": "115e034ffffa542dc4bc361f33cc1550a5d3d1c301d02c9785b2410c5008c40e",
+    "https://deno.land/x/jose@v5.9.6/jwe/general/encrypt.ts": "40efbe7f473f21933eba57aba133ab16df8e153d96946b6ede62572146970cd4",
+    "https://deno.land/x/jose@v5.9.6/jwk/embedded.ts": "9235337249f10a04a046a02897e0db4be8244fc731ac0638f4ad5c091280b58c",
+    "https://deno.land/x/jose@v5.9.6/jwk/thumbprint.ts": "362b6d36a716f569ac3f6a97bb41a7fb3265f971d5563f05cca73ce03432e42a",
+    "https://deno.land/x/jose@v5.9.6/jwks/local.ts": "2a948310bc9c534c3c044d52f8cf015fc7075bf8e7e845950fa578bd77d51f2e",
+    "https://deno.land/x/jose@v5.9.6/jwks/remote.ts": "948c451ebde9978628a7f6e543ef0827584ee2b434d1360d6964776f41be3094",
+    "https://deno.land/x/jose@v5.9.6/jws/compact/sign.ts": "112b4904316458c7d8cfef48309eefe977b9720d061f81477a7c72247a4f8821",
+    "https://deno.land/x/jose@v5.9.6/jws/compact/verify.ts": "37cdbe53267550b236344e4e7d7bf1dfd94fd1887fd785110d4cf88a4aa93408",
+    "https://deno.land/x/jose@v5.9.6/jws/flattened/sign.ts": "bbdeafd7d00873ad032a9136e770897ab202cce5ed5cef249470a2faf4ad0fe4",
+    "https://deno.land/x/jose@v5.9.6/jws/flattened/verify.ts": "4f4124773f97c6a0ddf7f84d5a28e0c39e10daf033ddd9c7287891c2403e2484",
+    "https://deno.land/x/jose@v5.9.6/jws/general/sign.ts": "5b977a752ea0261af76608aad8fbcc7ccc9302c62aae8da9dbfead3080ae4515",
+    "https://deno.land/x/jose@v5.9.6/jws/general/verify.ts": "134aeb53aa8e6fdbf1cb38a6cc2f4d40eafa3ea5e465d05ea250c24e3b190922",
+    "https://deno.land/x/jose@v5.9.6/jwt/decrypt.ts": "62e9ff765afea505d325d8aec61e70c2a3e75d0f56dc53b020e42940ab5bd398",
+    "https://deno.land/x/jose@v5.9.6/jwt/encrypt.ts": "0785771759eeaddf74e841cb7430c3af6d793bcef726ad46fb6047297c1cae1d",
+    "https://deno.land/x/jose@v5.9.6/jwt/produce.ts": "4ec3e3966f6d1ce057159c0569a00aacfc2189b4a3c1c395ff992f673942b92c",
+    "https://deno.land/x/jose@v5.9.6/jwt/sign.ts": "b3770b2c880935e0f3049dcbeecf940a1fade71609c4e7e6a51152dfa7bc3655",
+    "https://deno.land/x/jose@v5.9.6/jwt/unsecured.ts": "4002917b0ec0e89962fc8c75edead3a1dc267944f6d51089bf753db8d9fd5b86",
+    "https://deno.land/x/jose@v5.9.6/jwt/verify.ts": "0bdd020d3a06f387f42d63586817fc3bb4104830d9a74c87eb0a5bed2881245c",
+    "https://deno.land/x/jose@v5.9.6/key/export.ts": "1edf905818bcfcbba02c7dd369caf6fb61b6e19d30d4e4d2cd01030ab90f8b2d",
+    "https://deno.land/x/jose@v5.9.6/key/generate_key_pair.ts": "e841708aa07c95167b9f079f420311c22be837319ab0e7b70b68bdafdae2b4ea",
+    "https://deno.land/x/jose@v5.9.6/key/generate_secret.ts": "3f1bb5f8ef4340f20da3464cc7d0258abcee28f6ee7c72626f7048cc7aaa8b2a",
+    "https://deno.land/x/jose@v5.9.6/key/import.ts": "4cec770702f38a3883102776804b05414b7415105c48b9e41f201de08f3b9b5d",
+    "https://deno.land/x/jose@v5.9.6/lib/aesgcmkw.ts": "6d307f6710b2879fdde07c8e39688ece9019f02170334aa216db4878fc7a6ac8",
+    "https://deno.land/x/jose@v5.9.6/lib/buffer_utils.ts": "0b64941bf694bc810b2c917b61474be46c54854da76bb42b20f1642102542ff1",
+    "https://deno.land/x/jose@v5.9.6/lib/cek.ts": "a474becfe1c2d86fbcf3a24cdcd96274beb8d61bd17926e5f345001f39df922b",
+    "https://deno.land/x/jose@v5.9.6/lib/check_iv_length.ts": "118eb531167126c8421d71a21f2cfdc10a658c933e178b33395ef3e962c54f80",
+    "https://deno.land/x/jose@v5.9.6/lib/check_key_type.ts": "633b9b7e08b913dfdb7a9dfdf224cb89e54849e35ca9b396603e898994f8ca51",
+    "https://deno.land/x/jose@v5.9.6/lib/check_p2s.ts": "2f5549e121c43019ac85a3bb3fe8cb98a397122dcaa80f3cd8bf5fcf314e1f67",
+    "https://deno.land/x/jose@v5.9.6/lib/crypto_key.ts": "b75ba81390a90ea741cf174117d96e7851b221ebd9b0dfb806061175c24aed4f",
+    "https://deno.land/x/jose@v5.9.6/lib/decrypt_key_management.ts": "1996df67cfa015131cbf83dd1374852c78de9ee615a10e08fe7a0f9ec3d63811",
+    "https://deno.land/x/jose@v5.9.6/lib/encrypt_key_management.ts": "e79354c3c2bdfeff07dd61e925de0aa1027f8d21e454c774d08c778e09edc269",
+    "https://deno.land/x/jose@v5.9.6/lib/epoch.ts": "cd608f73f6c100e8156c6020ec2bce6757e01759793f0d6aab23908d3d2ea933",
+    "https://deno.land/x/jose@v5.9.6/lib/format_pem.ts": "b5230682e7a89609238015b77f33afd248f3e0f69bcb5895eece2f86d83100f6",
+    "https://deno.land/x/jose@v5.9.6/lib/invalid_key_input.ts": "b82cda3b49cf56806000a85343b005a05735b90e0886ce421a81c71d9088c375",
+    "https://deno.land/x/jose@v5.9.6/lib/is_disjoint.ts": "a3f7ef698413700d0f268314fc879421c134460ced9538518e5feb3eb64d3efe",
+    "https://deno.land/x/jose@v5.9.6/lib/is_jwk.ts": "cabe3150418db9082eafe083705d7e0b1a36a055eeae60f801fb7860813fdf93",
+    "https://deno.land/x/jose@v5.9.6/lib/is_object.ts": "43549ddc51a3b3d4c22b953b191a961fbb61fb5081e8efb88ad075afa1f4d214",
+    "https://deno.land/x/jose@v5.9.6/lib/iv.ts": "4766d9ad87b478bb7344094f38c8561181b72f8678edd1b5226d1e0f9ab677fc",
+    "https://deno.land/x/jose@v5.9.6/lib/jwt_claims_set.ts": "6f3445f718e7d8519c2ba265a65c564feed4aab52bda860bae974756e826eb09",
+    "https://deno.land/x/jose@v5.9.6/lib/private_symbols.ts": "54b4f384282e686c4484cd71249cea2edb860426c2b1927d94cb3438de9e64ca",
+    "https://deno.land/x/jose@v5.9.6/lib/secs.ts": "40e09916007b3a393f20265ea84dc1df43974e86ec796ce0e5e6724f5917a2b8",
+    "https://deno.land/x/jose@v5.9.6/lib/validate_algorithms.ts": "6b20f4b5f6935cd9edcd6eb2128226144ba792eaa7c47966c666a51baf1682eb",
+    "https://deno.land/x/jose@v5.9.6/lib/validate_crit.ts": "b1214ae1413c969efdca2392c6feea9c3b92c531fc7e137c23397e0430421b86",
+    "https://deno.land/x/jose@v5.9.6/runtime/aeskw.ts": "a32bc607d00031ecc42976b69f4e90d73cbac1bc465d1fbace373a8433105d72",
+    "https://deno.land/x/jose@v5.9.6/runtime/asn1.ts": "013a633b824c18663c8c7f7ec8691bfe3dfef82ee58650de0c6d8ee26154bb6a",
+    "https://deno.land/x/jose@v5.9.6/runtime/base64url.ts": "74ecb18b90de56bcc4424b6c911cfe49b56dd4a316978f5c8ee9a23560069636",
+    "https://deno.land/x/jose@v5.9.6/runtime/bogus.ts": "4f1c967b0d9b4e7105e16ad8c173da55708f377ee5e201d8ee5fc613f3417f08",
+    "https://deno.land/x/jose@v5.9.6/runtime/check_cek_length.ts": "2ee093fcb273602449ed7863ab6bd4dd2a7aeff99507e0573e3cd4b8d8099e5d",
+    "https://deno.land/x/jose@v5.9.6/runtime/check_key_length.ts": "7d23fb5910f9ba10383ca0600b63620ff078c7be7788e0626ec1f215992b67be",
+    "https://deno.land/x/jose@v5.9.6/runtime/decrypt.ts": "c53c80b90892b45f39d58e75a46f53032b131f2d9f5b6b74ddd215c79ca3ed8b",
+    "https://deno.land/x/jose@v5.9.6/runtime/digest.ts": "cee73fad56ce596ffedc56811d174ab413e7981eb847eb67c0e77f213cc2ac2d",
+    "https://deno.land/x/jose@v5.9.6/runtime/ecdhes.ts": "787c277cf841c89b462fc40cc05f5ddec9da89e9fc693cb3238936362c522ebd",
+    "https://deno.land/x/jose@v5.9.6/runtime/encrypt.ts": "a5a89b21010d3dda51544020fe4b2ab0d5d91e10044490fccc1af3d5104e8547",
+    "https://deno.land/x/jose@v5.9.6/runtime/fetch_jwks.ts": "34b71aa6bbd51984d1009792499ea17133dcb11bf2f2d8fba60e8090d900fc20",
+    "https://deno.land/x/jose@v5.9.6/runtime/generate.ts": "62f49bc476267d6321eb63040eaeeabbc44ec9a6a10346f2c1238f86e00744cb",
+    "https://deno.land/x/jose@v5.9.6/runtime/get_sign_verify_key.ts": "8e45cd5f6d5a3ae97013e849863b089b26a2a53fdfb613562a1025eaed201c8e",
+    "https://deno.land/x/jose@v5.9.6/runtime/is_key_like.ts": "2380270e1ff76c2b481f50d8057a10bcc1f33962c0f5ab35dc90e236f036731d",
+    "https://deno.land/x/jose@v5.9.6/runtime/jwk_to_key.ts": "5f26c13e737377e501b3817d51c4000fbdfb1736f2da924462a54400552af621",
+    "https://deno.land/x/jose@v5.9.6/runtime/key_to_jwk.ts": "f101d297b1fc9269a9595231899dc06e29e195f6223543b8d4cf651f6559f0f3",
+    "https://deno.land/x/jose@v5.9.6/runtime/normalize_key.ts": "6d25f61fbe4d756dfe390062dba6e73775092af62f0071170ebb3f71bb6fd5d2",
+    "https://deno.land/x/jose@v5.9.6/runtime/pbes2kw.ts": "ad084eb8dd144df8fd5d7e0b824806e35475398be0d3871c2016c3c467e24b19",
+    "https://deno.land/x/jose@v5.9.6/runtime/random.ts": "3e9c8d08208e5dc186ae659535f0018303ff3b56615335bf0dfb5904fe36aab7",
+    "https://deno.land/x/jose@v5.9.6/runtime/rsaes.ts": "124b6e87d8569b39d6f550b371303c79e9eb28aa0d9b14025eeaffe50282c987",
+    "https://deno.land/x/jose@v5.9.6/runtime/runtime.ts": "d748ecb0c1b57020d6f6c41b4458cce74b4d15ab919c38a0ec32d12cee7f5976",
+    "https://deno.land/x/jose@v5.9.6/runtime/sign.ts": "1524f8855538ca5fd607cd681f804ba421b0ec58f562118f3c635324ba053f90",
+    "https://deno.land/x/jose@v5.9.6/runtime/subtle_dsa.ts": "f66955982c3565bf9d8f80220bee5b5737654582b38ea187143cfe26a20e279a",
+    "https://deno.land/x/jose@v5.9.6/runtime/subtle_rsaes.ts": "26147da83932ebf7266d69ddd408f269395de05ddde64ba4e1585571bb61bd93",
+    "https://deno.land/x/jose@v5.9.6/runtime/timing_safe_equal.ts": "fc5b3f4132cec56630eac4677fef2b519707a9c6a257f8ae86515b0d86ff5f6b",
+    "https://deno.land/x/jose@v5.9.6/runtime/verify.ts": "d391e2286b47485247b475016c66999f5146a1cf8331115385a9ba629251c15e",
+    "https://deno.land/x/jose@v5.9.6/runtime/webcrypto.ts": "3365b7d62eaa7e6befe5e2f4f67aa7859805c41b87064433b6e70f94501aa36e",
+    "https://deno.land/x/jose@v5.9.6/util/base64url.ts": "0e09492d36de17c3b40646486b3a31ae7ce060d1bfa7185a52f659aaffc3da0b",
+    "https://deno.land/x/jose@v5.9.6/util/decode_jwt.ts": "a6347360591bd60b076d115fc231e3ecd84aef319922a6c6e94554e68863e3af",
+    "https://deno.land/x/jose@v5.9.6/util/decode_protected_header.ts": "3412c8aacffee93148478f14a0ebb97b2ff060944f49dd233223d262f592ee36",
+    "https://deno.land/x/jose@v5.9.6/util/errors.ts": "b7ecf22990ce73a42650fd09666fb7174fcd91eec387aa26b361269c8022220f",
+    "https://deno.land/x/jose@v5.9.6/util/runtime.ts": "088cae7df0d285065f141d880c5c21a572234997082337d1125d7f1603059642",
     "https://esm.sh/@supabase/supabase-js@2.90.1": "fcf5e194d637ff365df76d1806e7c2f239905c4b08e83e5d95690a2b22e21a1d"
   },
   "workspace": {

--- a/docs/AGENT_TOOL_POLICY.md
+++ b/docs/AGENT_TOOL_POLICY.md
@@ -38,6 +38,13 @@ Before an Edge Function executes an external tool, it should call
 `evaluateAgentToolPolicy()`. If `blockedReason` is present, the function should
 skip execution and persist `auditPayload` to the audit log.
 
+`mcp_auth_guard.logMcpInvocation()` now writes MCP calls to `mcp_audit_log`
+through the Supabase service role when runtime secrets are present, and falls
+back to structured console logging in local/test environments. This gives the
+approval gate work a durable server-side audit trail before high-risk tool
+actions such as `send`, `purchase`, and `external_share` are wired to blocking
+CEO approval screens.
+
 This follows the Harness Engineering direction from NotebookLM
 `bc58b50b-5fc4-4840-9a62-b397d6d3b65a`: Claude Code, Codex, and external AI
 agents should operate inside explicit scopes, approval gates, and audit logs.

--- a/supabase/functions/_shared/mcp_auth_guard.ts
+++ b/supabase/functions/_shared/mcp_auth_guard.ts
@@ -249,7 +249,23 @@ export function requireScope(ctx: McpAuthContext, tool: string): boolean {
  * 呼び出し例:
  *   await logMcpInvocation(ctx, "judgment.get", { date: "2026-04-28" }, 200, req);
  */
-// deno-lint-ignore require-await -- skeleton state; supabase INSERT (await) wired in part 50+
+function normalizeRequestIp(raw: string): string | null {
+  const first = raw.split(",")[0]?.trim() ?? "";
+  if (!first) return null;
+  if (/^[0-9.]+$/.test(first)) return first;
+  if (/^[0-9a-fA-F:]+$/.test(first)) return first;
+  return null;
+}
+
+function toAuditJson(value: unknown): unknown {
+  if (value == null) return null;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return { unserializable: String(value).slice(0, 500) };
+  }
+}
+
 export async function logMcpInvocation(
   ctx: McpAuthContext | null,
   toolName: string,
@@ -259,17 +275,26 @@ export async function logMcpInvocation(
 ): Promise<void> {
   const ip = req.headers.get("x-forwarded-for") ??
     req.headers.get("cf-connecting-ip") ?? "";
-  // TODO (Win版#132 part 50+): supabase service role で
-  // INSERT INTO mcp_audit_log (client_id, tool_name, request_args, response_status,
-  //                            request_ip, invoked_at)
-  // VALUES ($1, $2, $3, $4, $5, now());
+  const admin = getAdminClient();
+  if (admin) {
+    const { error } = await admin.from("mcp_audit_log").insert({
+      client_id: ctx?.client_id ?? "anonymous",
+      tool_name: toolName || "unknown",
+      request_args: toAuditJson(requestArgs),
+      response_status: responseStatus,
+      request_ip: normalizeRequestIp(ip),
+    });
+    if (!error) return;
+    console.warn("[mcp-audit] insert failed", error.message);
+  }
+
   console.log(
     "[mcp-audit]",
     JSON.stringify({
       client_id: ctx?.client_id ?? "anonymous",
       tool_name: toolName,
       response_status: responseStatus,
-      ip: ip.split(",")[0]?.trim() || null,
+      ip: normalizeRequestIp(ip),
       args_preview: typeof requestArgs === "string"
         ? requestArgs.slice(0, 200)
         : JSON.stringify(requestArgs).slice(0, 200),

--- a/supabase/functions/_shared/mcp_auth_guard_test.ts
+++ b/supabase/functions/_shared/mcp_auth_guard_test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  logMcpInvocation,
+  type McpAuthContext,
+  requireScope,
+  toolResourceUrn,
+} from "./mcp_auth_guard.ts";
+
+Deno.test("toolResourceUrn builds scoped MCP resource names", () => {
+  assertEquals(toolResourceUrn("memory"), "urn:jibun:tool:memory");
+});
+
+Deno.test("requireScope allows wildcard audience and all scope", () => {
+  const ctx: McpAuthContext = {
+    client_id: "test-client",
+    scopes: ["all"],
+    aud: ["urn:jibun:tool:*"],
+  };
+
+  assertEquals(requireScope(ctx, "memory"), true);
+});
+
+Deno.test("requireScope rejects mismatched audience", () => {
+  const ctx: McpAuthContext = {
+    client_id: "test-client",
+    scopes: ["memory"],
+    aud: ["urn:jibun:tool:calendar"],
+  };
+
+  assertEquals(requireScope(ctx, "memory"), false);
+});
+
+Deno.test("logMcpInvocation falls back safely without Supabase env", async () => {
+  const ctx: McpAuthContext = {
+    client_id: "test-client",
+    scopes: ["all"],
+    aud: ["urn:jibun:tool:*"],
+  };
+  const req = new Request("https://example.test/mcp", {
+    headers: { "x-forwarded-for": "203.0.113.10" },
+  });
+
+  await logMcpInvocation(ctx, "memory.search", { q: "audit" }, 200, req);
+});


### PR DESCRIPTION
## Summary
- persist MCP auth guard invocations to \\mcp_audit_log\\ when Supabase service-role runtime secrets are available
- keep structured console fallback for local/test environments
- add Deno coverage for MCP resource/scope checks and audit fallback
- update AGENT_TOOL_POLICY docs for Issue #846 follow-up

## Verification
- \\deno test --allow-all --no-check --config supabase/functions/deno.json supabase/functions/_shared/mcp_auth_guard_test.ts supabase/functions/_shared/agent_tool_policy_test.ts\\
- \\deno lint --config supabase/functions/deno.json supabase/functions/_shared/mcp_auth_guard.ts supabase/functions/_shared/mcp_auth_guard_test.ts supabase/functions/_shared/agent_tool_policy.ts supabase/functions/_shared/agent_tool_policy_test.ts\\
- \\python scripts/check_migration_timestamps.py\\

Refs #846