### PR TITLE
feat: add local smart cleanup and Windows companion installer

### DIFF
--- a/.github/workflows/windows-companion-build.yml
+++ b/.github/workflows/windows-companion-build.yml
@@ -1,0 +1,103 @@
+name: Build Windows Companion App
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_release:
+        description: 'Publish jibun-windows-companion.zip to GitHub Releases'
+        required: true
+        default: false
+        type: boolean
+      release_tag:
+        description: 'Release tag to create when publish_release is true'
+        required: false
+        default: 'windows-companion-latest'
+        type: string
+  push:
+    tags:
+      - 'windows-companion-v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: windows-companion-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-windows:
+    name: Build Windows ZIP
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.38.x'
+          channel: 'stable'
+          cache: true
+
+      - name: Enable Windows desktop
+        run: flutter config --enable-windows-desktop
+
+      - name: Enable Git long paths
+        run: git config --global core.longpaths true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze Windows companion surface
+        run: |
+          flutter analyze `
+            lib/windows_companion_main.dart `
+            lib/pages/local_smart_cleanup_page.dart `
+            lib/pages/windows_app_install_page.dart `
+            lib/services/local_cleanup_result.dart `
+            lib/services/local_cleanup_service.dart `
+            lib/services/local_cleanup_service_io.dart `
+            lib/services/local_cleanup_service_stub.dart
+
+      - name: Build Windows release
+        run: flutter build windows --release --no-tree-shake-icons --target lib/windows_companion_main.dart
+
+      - name: Package Windows release
+        shell: pwsh
+        run: |
+          $releaseDir = Join-Path $PWD 'build\windows\x64\runner\Release'
+          if (-not (Test-Path -LiteralPath $releaseDir)) {
+            throw "Windows release directory not found: $releaseDir"
+          }
+          $scriptSource = Join-Path $PWD 'tools\windows-companion\SmartCleanup'
+          $scriptDest = Join-Path $releaseDir 'scripts\SmartCleanup'
+          New-Item -ItemType Directory -Force -Path $scriptDest | Out-Null
+          Copy-Item -LiteralPath (Join-Path $scriptSource 'Invoke-SmartCleanup.ps1') -Destination $scriptDest -Force
+          Copy-Item -LiteralPath (Join-Path $scriptSource 'Invoke-ApprovedCleanup.ps1') -Destination $scriptDest -Force
+          $distDir = Join-Path $PWD 'dist'
+          New-Item -ItemType Directory -Force -Path $distDir | Out-Null
+          $zipPath = Join-Path $distDir 'jibun-windows-companion.zip'
+          Compress-Archive -Path (Join-Path $releaseDir '*') -DestinationPath $zipPath -Force
+          Get-Item -LiteralPath $zipPath | Select-Object FullName, Length, LastWriteTime
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: jibun-windows-companion
+          path: dist/jibun-windows-companion.zip
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish GitHub Release asset
+        if: startsWith(github.ref, 'refs/tags/windows-companion-v') || inputs.publish_release == true
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ startsWith(github.ref, 'refs/tags/windows-companion-v') && github.ref_name || inputs.release_tag }}
+          name: Jibun Windows Companion
+          body: |
+            Windows companion app build for local smart cleanup workflows.
+
+            Download `jibun-windows-companion.zip`, extract it, and run `my_web_app.exe`.
+          files: dist/jibun-windows-companion.zip

--- a/docs/WINDOWS_COMPANION_APP.md
+++ b/docs/WINDOWS_COMPANION_APP.md
@@ -1,0 +1,47 @@
+# Windows Companion App
+
+The Windows companion app is the local execution surface for smart cleanup workflows that cannot run inside the hosted web app.
+
+## Build
+
+```powershell
+flutter config --enable-windows-desktop
+git config --global core.longpaths true
+flutter pub get
+flutter build windows --release --no-tree-shake-icons --target lib/windows_companion_main.dart
+```
+
+The executable is created under:
+
+```text
+build\windows\x64\runner\Release\my_web_app.exe
+```
+
+## Package
+
+```powershell
+New-Item -ItemType Directory -Force -Path build\windows\x64\runner\Release\scripts\SmartCleanup
+Copy-Item tools\windows-companion\SmartCleanup\*.ps1 build\windows\x64\runner\Release\scripts\SmartCleanup -Force
+Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath dist\jibun-windows-companion.zip -Force
+```
+
+## Release
+
+Run the `Build Windows Companion App` workflow from GitHub Actions.
+
+- Artifact only: run with `publish_release=false`.
+- Site download link: run with `publish_release=true` and `release_tag=windows-companion-latest`.
+
+The stable download URL used by the web app is:
+
+```text
+https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.zip
+```
+
+## Safety Model
+
+- The web app never deletes local files directly.
+- The Windows app runs on the user's PC and can call local PowerShell scripts.
+- Release ZIPs include the smart cleanup PowerShell scripts under `scripts\SmartCleanup`.
+- Cleanup must follow: scan, review CSV, approve rows, apply approved rows, save result logs.
+- Approved cleanup should move files to the Recycle Bin, not permanently delete them.

--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -33,6 +33,7 @@ import '../pages/home_insights_page.dart';
 import '../pages/import_page.dart';
 import '../pages/kanban_board_page.dart';
 import '../pages/life_goals_page.dart';
+import '../pages/local_smart_cleanup_page.dart';
 import '../pages/memory_drill_page.dart';
 import '../pages/mind_map_page.dart';
 import '../pages/mindless_task_page.dart';
@@ -528,6 +529,26 @@ List<HomeToolEntry> buildHomeToolCatalog({
       color: const Color(0xFF3D5AFE),
       keywords: const <String>['メール', '整理', '受信箱'],
       onOpen: (context) => _pushPage(context, const EmailCleanupPage()),
+      requiresClearDeck: true,
+    ),
+    HomeToolEntry(
+      id: 'local-smart-cleanup',
+      sectionId: 'personal',
+      title: 'ローカルPCスマート整理',
+      subtitle: 'Cドライブ重複レポートと承認CSVを確認',
+      icon: Icons.cleaning_services_outlined,
+      color: const Color(0xFF00897B),
+      keywords: const <String>[
+        'PC整理',
+        '重複',
+        'Cドライブ',
+        'Google Drive',
+        'cleanup',
+      ],
+      onOpen: (context) => _pushPage(
+        context,
+        const LocalSmartCleanupPage(),
+      ),
       requiresClearDeck: true,
     ),
     HomeToolEntry(

--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -34,6 +34,7 @@ import '../pages/import_page.dart';
 import '../pages/kanban_board_page.dart';
 import '../pages/life_goals_page.dart';
 import '../pages/local_smart_cleanup_page.dart';
+import '../pages/windows_app_install_page.dart';
 import '../pages/memory_drill_page.dart';
 import '../pages/mind_map_page.dart';
 import '../pages/mindless_task_page.dart';
@@ -548,6 +549,26 @@ List<HomeToolEntry> buildHomeToolCatalog({
       onOpen: (context) => _pushPage(
         context,
         const LocalSmartCleanupPage(),
+      ),
+      requiresClearDeck: true,
+    ),
+    HomeToolEntry(
+      id: 'windows-app',
+      sectionId: 'personal',
+      title: 'Windowsアプリ版',
+      subtitle: 'ローカルPC整理用のWindows Companion Appを入手',
+      icon: Icons.desktop_windows_outlined,
+      color: const Color(0xFF1565C0),
+      keywords: const <String>[
+        'Windows',
+        'Windowsアプリ',
+        'インストール',
+        'ローカルPC',
+        'cleanup',
+      ],
+      onOpen: (context) => _pushPage(
+        context,
+        const WindowsAppInstallPage(),
       ),
       requiresClearDeck: true,
     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:my_web_app/pages/wip_limit_page.dart';
 import 'package:my_web_app/pages/danshari_page.dart';
 import 'package:my_web_app/pages/email_cleanup_page.dart';
 import 'package:my_web_app/pages/local_smart_cleanup_page.dart';
+import 'package:my_web_app/pages/windows_app_install_page.dart';
 import 'package:my_web_app/pages/payment_reminder_page.dart';
 import 'package:my_web_app/pages/shopping_list_page.dart';
 import 'package:my_web_app/pages/digest_queue_page.dart';
@@ -666,6 +667,10 @@ class _MyAppState extends State<MyApp> {
           case '/local-smart-cleanup':
             return MaterialPageRoute(
               builder: (_) => const LocalSmartCleanupPage(),
+            );
+          case '/windows-app':
+            return MaterialPageRoute(
+              builder: (_) => const WindowsAppInstallPage(),
             );
           case '/payment-reminders':
             return MaterialPageRoute(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:my_web_app/pages/behavior_log_page.dart';
 import 'package:my_web_app/pages/wip_limit_page.dart';
 import 'package:my_web_app/pages/danshari_page.dart';
 import 'package:my_web_app/pages/email_cleanup_page.dart';
+import 'package:my_web_app/pages/local_smart_cleanup_page.dart';
 import 'package:my_web_app/pages/payment_reminder_page.dart';
 import 'package:my_web_app/pages/shopping_list_page.dart';
 import 'package:my_web_app/pages/digest_queue_page.dart';
@@ -661,6 +662,10 @@ class _MyAppState extends State<MyApp> {
           case '/email-cleanup':
             return MaterialPageRoute(
               builder: (_) => const EmailCleanupPage(),
+            );
+          case '/local-smart-cleanup':
+            return MaterialPageRoute(
+              builder: (_) => const LocalSmartCleanupPage(),
             );
           case '/payment-reminders':
             return MaterialPageRoute(

--- a/lib/pages/local_smart_cleanup_page.dart
+++ b/lib/pages/local_smart_cleanup_page.dart
@@ -1,0 +1,1589 @@
+import 'dart:convert';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../utils/web_image_downloader.dart';
+
+class LocalSmartCleanupPage extends StatefulWidget {
+  const LocalSmartCleanupPage({super.key});
+
+  @override
+  State<LocalSmartCleanupPage> createState() => _LocalSmartCleanupPageState();
+}
+
+class _LocalSmartCleanupPageState extends State<LocalSmartCleanupPage> {
+  static const _weekDays = <String, String>{
+    'SUN': '日曜',
+    'MON': '月曜',
+    'TUE': '火曜',
+    'WED': '水曜',
+    'THU': '木曜',
+    'FRI': '金曜',
+    'SAT': '土曜',
+  };
+
+  static const _defaultReportPath =
+      r'G:\マイドライブ\C-drive-archive\cleanup-reports\duplicate-report-latest.csv';
+  static const _defaultApprovalPath =
+      r'G:\マイドライブ\C-drive-archive\cleanup-reports\cleanup-approval-latest.csv';
+  static const _reportCommand =
+      r'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\Users\kanta\Scripts\SmartCleanup\Invoke-SmartCleanup.ps1"';
+  static const _applyCommand =
+      r'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\Users\kanta\Scripts\SmartCleanup\Invoke-ApprovedCleanup.ps1" -Apply';
+
+  final List<_DuplicateRow> _duplicates = <_DuplicateRow>[];
+  final List<_ApprovalRow> _approvals = <_ApprovalRow>[];
+  String? _reportFileName;
+  String? _approvalFileName;
+  String _statusText = 'CSVを読み込むと、重複候補・承認候補・定期実行コマンドを確認できます。';
+  bool _isBusy = false;
+  int _selectedTab = 0;
+  _CleanupFrequency _scheduleFrequency = _CleanupFrequency.weekly;
+  _CleanupScheduleKind _scheduleKind = _CleanupScheduleKind.reportOnly;
+  String _scheduleWeekday = 'SUN';
+  int _scheduleDayOfMonth = 1;
+  TimeOfDay _scheduleTime = const TimeOfDay(hour: 9, minute: 30);
+
+  int get _duplicateGroupCount => _duplicates
+      .map((row) => row.groupId)
+      .where((id) => id > 0)
+      .toSet()
+      .length;
+
+  int get _reviewableCount => _duplicates.where((row) => !row.isKeeper).length;
+
+  double get _reviewableMb => _duplicates
+      .where((row) => !row.isKeeper)
+      .fold<double>(0, (total, row) => total + row.sizeMb);
+
+  int get _approvedCount => _approvals.where((row) => row.approved).length;
+
+  double get _approvedMb => _approvals
+      .where((row) => row.approved)
+      .fold<double>(0, (total, row) => total + row.sizeMb);
+
+  Future<void> _pickDuplicateReport() async {
+    await _pickCsvFile(
+      onLoaded: (text, fileName) {
+        final table = _CsvTable.parse(text);
+        final rows = table.rows
+            .map(_DuplicateRow.fromMap)
+            .where((row) => row.path.isNotEmpty)
+            .toList();
+        setState(() {
+          _duplicates
+            ..clear()
+            ..addAll(rows);
+          _reportFileName = fileName;
+          _selectedTab = 0;
+          _statusText = rows.isEmpty
+              ? '重複レポートに表示できる候補はありません。'
+              : '${rows.length}件の重複行を読み込みました。';
+        });
+      },
+    );
+  }
+
+  Future<void> _pickApprovalCsv() async {
+    await _pickCsvFile(
+      onLoaded: (text, fileName) {
+        final table = _CsvTable.parse(text);
+        final rows = table.rows
+            .map(_ApprovalRow.fromMap)
+            .where(
+              (row) =>
+                  row.localPath.isNotEmpty || row.googleCopyPath.isNotEmpty,
+            )
+            .toList();
+        setState(() {
+          _approvals
+            ..clear()
+            ..addAll(rows);
+          _approvalFileName = fileName;
+          _selectedTab = 1;
+          _statusText = rows.isEmpty
+              ? '承認候補はありません。現在のレポートは確認のみで安全です。'
+              : '${rows.length}件の承認候補を読み込みました。';
+        });
+      },
+    );
+  }
+
+  Future<void> _pickCsvFile({
+    required void Function(String text, String fileName) onLoaded,
+  }) async {
+    setState(() => _isBusy = true);
+    try {
+      final result = await FilePicker.pickFiles(
+        withData: true,
+        type: FileType.custom,
+        allowedExtensions: const <String>['csv'],
+      );
+      if (result == null || result.files.isEmpty) {
+        return;
+      }
+      final file = result.files.single;
+      final bytes = file.bytes;
+      if (bytes == null) {
+        throw const FormatException('選択したCSVを読み込めませんでした。');
+      }
+      final text = _decodeCsv(bytes);
+      if (!mounted) {
+        return;
+      }
+      onLoaded(text, file.name);
+    } catch (error) {
+      if (mounted) {
+        _showMessage('CSVの読み込みに失敗しました: $error');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isBusy = false);
+      }
+    }
+  }
+
+  void _toggleApproval(int index, bool? value) {
+    if (value == null || index < 0 || index >= _approvals.length) {
+      return;
+    }
+    setState(() {
+      _approvals[index] = _approvals[index].copyWith(approved: value);
+      _statusText = value ? '承認候補を1件オンにしました。' : '承認候補を1件オフにしました。';
+    });
+  }
+
+  void _downloadApprovalCsv() {
+    downloadCsvFile(_buildApprovalCsv(), 'cleanup-approval-latest.csv');
+    _showMessage('承認CSVを保存しました。');
+  }
+
+  Future<void> _copyApprovalCsv() async {
+    await _copyText(_buildApprovalCsv(), '承認CSVをクリップボードへコピーしました。');
+  }
+
+  Future<void> _pickScheduleTime() async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: _scheduleTime,
+    );
+    if (picked == null) {
+      return;
+    }
+    setState(() => _scheduleTime = picked);
+  }
+
+  Future<void> _copyText(String text, String message) async {
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) {
+      return;
+    }
+    _showMessage(message);
+  }
+
+  String _buildApprovalCsv() {
+    const headers = <String>[
+      'Approved',
+      'Action',
+      'GroupId',
+      'SizeMB',
+      'Hash',
+      'LocalPath',
+      'GoogleCopyPath',
+      'Note',
+    ];
+    final records = <List<String>>[
+      headers,
+      ..._approvals.map((row) => row.toCsvRow()),
+    ];
+    return records.map(_encodeCsvRow).join('\r\n');
+  }
+
+  String get _scheduleTaskName {
+    return _scheduleKind == _CleanupScheduleKind.reportOnly
+        ? 'Codex Smart Cleanup Report'
+        : 'Codex Smart Cleanup Apply Approved';
+  }
+
+  String get _scheduleTaskRun {
+    return _scheduleKind == _CleanupScheduleKind.reportOnly
+        ? _reportCommand
+        : _applyCommand;
+  }
+
+  String get _scheduleCreateCommand {
+    final dayArg = switch (_scheduleFrequency) {
+      _CleanupFrequency.daily => '',
+      _CleanupFrequency.weekly => ' /D $_scheduleWeekday',
+      _CleanupFrequency.monthly => ' /D $_scheduleDayOfMonth',
+    };
+    return 'schtasks.exe /Create /TN "$_scheduleTaskName" '
+        '/TR \'$_scheduleTaskRun\' '
+        '/SC ${_scheduleFrequency.schtasksName}$dayArg '
+        '/ST ${_formatTaskTime(_scheduleTime)} /F';
+  }
+
+  String get _scheduleQueryCommand {
+    return 'schtasks.exe /Query /TN "$_scheduleTaskName" /V /FO LIST';
+  }
+
+  String get _scheduleRunCommand {
+    return 'schtasks.exe /Run /TN "$_scheduleTaskName"';
+  }
+
+  String get _scheduleDeleteCommand {
+    return 'schtasks.exe /Delete /TN "$_scheduleTaskName" /F';
+  }
+
+  String get _scheduleSummary {
+    final cadence = switch (_scheduleFrequency) {
+      _CleanupFrequency.daily => '毎日',
+      _CleanupFrequency.weekly =>
+        _weekDays[_scheduleWeekday] ?? _scheduleWeekday,
+      _CleanupFrequency.monthly => '毎月$_scheduleDayOfMonth日',
+    };
+    final action =
+        _scheduleKind == _CleanupScheduleKind.reportOnly ? 'レポート生成' : '承認済み適用';
+    return '$cadence ${_formatTaskTime(_scheduleTime)} / $action';
+  }
+
+  void _showMessage(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ローカルPCスマート整理'),
+      ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final wide = constraints.maxWidth >= 980;
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 1180),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _buildHeader(theme),
+                    const SizedBox(height: 16),
+                    _buildMetrics(wide),
+                    const SizedBox(height: 16),
+                    _buildActionPanel(theme, wide),
+                    const SizedBox(height: 16),
+                    _buildSchedulePanel(theme, wide),
+                    const SizedBox(height: 16),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: SegmentedButton<int>(
+                        selected: <int>{_selectedTab},
+                        segments: const <ButtonSegment<int>>[
+                          ButtonSegment<int>(
+                            value: 0,
+                            icon: Icon(Icons.folder_open),
+                            label: Text('重複'),
+                          ),
+                          ButtonSegment<int>(
+                            value: 1,
+                            icon: Icon(Icons.fact_check_outlined),
+                            label: Text('承認'),
+                          ),
+                        ],
+                        onSelectionChanged: (values) {
+                          setState(() => _selectedTab = values.first);
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 180),
+                      child: _selectedTab == 0
+                          ? _buildDuplicateSection(theme)
+                          : _buildApprovalSection(theme),
+                    ),
+                    const SizedBox(height: 16),
+                    _buildAutomationPanel(theme),
+                    const SizedBox(height: 24),
+                    Text(
+                      'この画面はローカルファイルを直接削除しません。承認CSVを作成し、PowerShellスクリプトとWindowsタスクスケジューラで実行します。',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildHeader(ThemeData theme) {
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 44,
+            height: 44,
+            decoration: BoxDecoration(
+              color: colorScheme.primaryContainer,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(
+              Icons.cleaning_services_outlined,
+              color: colorScheme.onPrimaryContainer,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'PC整理レポート',
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  _statusText,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (_isBusy)
+            const SizedBox.square(
+              dimension: 24,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMetrics(bool wide) {
+    final tiles = <Widget>[
+      _MetricTile(
+        icon: Icons.folder_copy_outlined,
+        label: '重複グループ',
+        value: '$_duplicateGroupCount',
+      ),
+      _MetricTile(
+        icon: Icons.rule_outlined,
+        label: '確認対象',
+        value: '$_reviewableCount',
+        detail: _formatSize(_reviewableMb),
+      ),
+      _MetricTile(
+        icon: Icons.verified_outlined,
+        label: '承認済み',
+        value: '$_approvedCount',
+        detail: _formatSize(_approvedMb),
+      ),
+    ];
+
+    if (wide) {
+      return Row(
+        children: [
+          for (var index = 0; index < tiles.length; index++) ...[
+            if (index > 0) const SizedBox(width: 12),
+            Expanded(child: tiles[index]),
+          ],
+        ],
+      );
+    }
+
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: tiles
+          .map(
+            (tile) => SizedBox(
+              width: 220,
+              child: tile,
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  Widget _buildActionPanel(ThemeData theme, bool wide) {
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              FilledButton.icon(
+                onPressed: _isBusy ? null : _pickDuplicateReport,
+                icon: const Icon(Icons.upload_file),
+                label: const Text('重複CSV'),
+              ),
+              OutlinedButton.icon(
+                onPressed: _isBusy ? null : _pickApprovalCsv,
+                icon: const Icon(Icons.fact_check_outlined),
+                label: const Text('承認CSV'),
+              ),
+              OutlinedButton.icon(
+                onPressed: _downloadApprovalCsv,
+                icon: const Icon(Icons.download),
+                label: const Text('承認CSV保存'),
+              ),
+              OutlinedButton.icon(
+                onPressed: _copyApprovalCsv,
+                icon: const Icon(Icons.content_copy),
+                label: const Text('承認CSVコピー'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          if (wide)
+            Row(
+              children: [
+                Expanded(
+                  child: _PathLine(
+                    label: '重複',
+                    value: _reportFileName ?? _defaultReportPath,
+                    onCopy: () => _copyText(
+                      _defaultReportPath,
+                      '重複CSVの標準パスをコピーしました。',
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _PathLine(
+                    label: '承認',
+                    value: _approvalFileName ?? _defaultApprovalPath,
+                    onCopy: () => _copyText(
+                      _defaultApprovalPath,
+                      '承認CSVの標準パスをコピーしました。',
+                    ),
+                  ),
+                ),
+              ],
+            )
+          else
+            Column(
+              children: [
+                _PathLine(
+                  label: '重複',
+                  value: _reportFileName ?? _defaultReportPath,
+                  onCopy: () => _copyText(
+                    _defaultReportPath,
+                    '重複CSVの標準パスをコピーしました。',
+                  ),
+                ),
+                const SizedBox(height: 8),
+                _PathLine(
+                  label: '承認',
+                  value: _approvalFileName ?? _defaultApprovalPath,
+                  onCopy: () => _copyText(
+                    _defaultApprovalPath,
+                    '承認CSVの標準パスをコピーしました。',
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDuplicateSection(ThemeData theme) {
+    if (_duplicates.isEmpty) {
+      return const _EmptyState(
+        icon: Icons.folder_open,
+        title: '重複CSVを読み込んでください',
+        message: 'duplicate-report-latest.csvを選ぶと、ハッシュ一致の重複をグループで確認できます。',
+      );
+    }
+
+    final groups = <int, List<_DuplicateRow>>{};
+    for (final row in _duplicates) {
+      groups.putIfAbsent(row.groupId, () => <_DuplicateRow>[]).add(row);
+    }
+
+    final entries = groups.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+
+    return Column(
+      key: const ValueKey<String>('duplicates'),
+      children: [
+        for (final entry in entries) ...[
+          _DuplicateGroupPanel(groupId: entry.key, rows: entry.value),
+          const SizedBox(height: 10),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildApprovalSection(ThemeData theme) {
+    if (_approvals.isEmpty) {
+      return const _EmptyState(
+        icon: Icons.fact_check_outlined,
+        title: '承認候補はありません',
+        message: 'cleanup-approval-latest.csvに候補が出た時だけ、ここでApprovedを切り替えます。',
+      );
+    }
+
+    return Column(
+      key: const ValueKey<String>('approvals'),
+      children: [
+        for (var index = 0; index < _approvals.length; index++) ...[
+          _ApprovalRowTile(
+            row: _approvals[index],
+            onChanged: (value) => _toggleApproval(index, value),
+          ),
+          const SizedBox(height: 10),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildSchedulePanel(ThemeData theme, bool wide) {
+    final colorScheme = theme.colorScheme;
+    final controls = <Widget>[
+      _ScheduleControl(
+        label: '頻度',
+        child: SegmentedButton<_CleanupFrequency>(
+          selected: <_CleanupFrequency>{_scheduleFrequency},
+          segments: const <ButtonSegment<_CleanupFrequency>>[
+            ButtonSegment<_CleanupFrequency>(
+              value: _CleanupFrequency.daily,
+              icon: Icon(Icons.today_outlined),
+              label: Text('毎日'),
+            ),
+            ButtonSegment<_CleanupFrequency>(
+              value: _CleanupFrequency.weekly,
+              icon: Icon(Icons.view_week_outlined),
+              label: Text('毎週'),
+            ),
+            ButtonSegment<_CleanupFrequency>(
+              value: _CleanupFrequency.monthly,
+              icon: Icon(Icons.calendar_month_outlined),
+              label: Text('毎月'),
+            ),
+          ],
+          onSelectionChanged: (values) {
+            setState(() => _scheduleFrequency = values.first);
+          },
+        ),
+      ),
+      if (_scheduleFrequency == _CleanupFrequency.weekly)
+        _ScheduleControl(
+          label: '曜日',
+          child: DropdownButtonFormField<String>(
+            initialValue: _scheduleWeekday,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+            items: _weekDays.entries
+                .map(
+                  (entry) => DropdownMenuItem<String>(
+                    value: entry.key,
+                    child: Text(entry.value),
+                  ),
+                )
+                .toList(),
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => _scheduleWeekday = value);
+              }
+            },
+          ),
+        ),
+      if (_scheduleFrequency == _CleanupFrequency.monthly)
+        _ScheduleControl(
+          label: '日付',
+          child: DropdownButtonFormField<int>(
+            initialValue: _scheduleDayOfMonth,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+            items: List<DropdownMenuItem<int>>.generate(
+              28,
+              (index) => DropdownMenuItem<int>(
+                value: index + 1,
+                child: Text('${index + 1}日'),
+              ),
+            ),
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => _scheduleDayOfMonth = value);
+              }
+            },
+          ),
+        ),
+      _ScheduleControl(
+        label: '時刻',
+        child: OutlinedButton.icon(
+          onPressed: _pickScheduleTime,
+          icon: const Icon(Icons.schedule),
+          label: Text(_formatTaskTime(_scheduleTime)),
+        ),
+      ),
+      _ScheduleControl(
+        label: '内容',
+        child: SegmentedButton<_CleanupScheduleKind>(
+          selected: <_CleanupScheduleKind>{_scheduleKind},
+          segments: const <ButtonSegment<_CleanupScheduleKind>>[
+            ButtonSegment<_CleanupScheduleKind>(
+              value: _CleanupScheduleKind.reportOnly,
+              icon: Icon(Icons.assignment_outlined),
+              label: Text('レポート'),
+            ),
+            ButtonSegment<_CleanupScheduleKind>(
+              value: _CleanupScheduleKind.applyApproved,
+              icon: Icon(Icons.recycling_outlined),
+              label: Text('承認適用'),
+            ),
+          ],
+          onSelectionChanged: (values) {
+            setState(() => _scheduleKind = values.first);
+          },
+        ),
+      ),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.event_repeat, color: colorScheme.primary),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  '定期実行',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              Text(
+                _scheduleSummary,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          if (wide)
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (var index = 0; index < controls.length; index++) ...[
+                  if (index > 0) const SizedBox(width: 12),
+                  Expanded(child: controls[index]),
+                ],
+              ],
+            )
+          else
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: controls
+                  .map(
+                    (control) => SizedBox(
+                      width: 260,
+                      child: control,
+                    ),
+                  )
+                  .toList(),
+            ),
+          const SizedBox(height: 14),
+          _CommandLine(
+            label: '登録/更新',
+            command: _scheduleCreateCommand,
+            onCopy: () => _copyText(
+              _scheduleCreateCommand,
+              'スケジュール登録コマンドをコピーしました。',
+            ),
+          ),
+          const SizedBox(height: 8),
+          _CommandLine(
+            label: '状態確認',
+            command: _scheduleQueryCommand,
+            onCopy: () => _copyText(
+              _scheduleQueryCommand,
+              'スケジュール確認コマンドをコピーしました。',
+            ),
+          ),
+          const SizedBox(height: 8),
+          _CommandLine(
+            label: '今すぐ実行',
+            command: _scheduleRunCommand,
+            onCopy: () => _copyText(
+              _scheduleRunCommand,
+              'スケジュール実行コマンドをコピーしました。',
+            ),
+          ),
+          const SizedBox(height: 8),
+          _CommandLine(
+            label: '削除',
+            command: _scheduleDeleteCommand,
+            onCopy: () => _copyText(
+              _scheduleDeleteCommand,
+              'スケジュール削除コマンドをコピーしました。',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAutomationPanel(ThemeData theme) {
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'ローカル実行',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 10),
+          _CommandLine(
+            label: 'レポート生成',
+            command: _reportCommand,
+            onCopy: () => _copyText(
+              _reportCommand,
+              'レポート生成コマンドをコピーしました。',
+            ),
+          ),
+          const SizedBox(height: 8),
+          _CommandLine(
+            label: '承認適用',
+            command: _applyCommand,
+            onCopy: () => _copyText(
+              _applyCommand,
+              '承認適用コマンドをコピーしました。',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ScheduleControl extends StatelessWidget {
+  const _ScheduleControl({
+    required this.label,
+    required this.child,
+  });
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 6),
+        child,
+      ],
+    );
+  }
+}
+
+class _DuplicateGroupPanel extends StatelessWidget {
+  const _DuplicateGroupPanel({
+    required this.groupId,
+    required this.rows,
+  });
+
+  final int groupId;
+  final List<_DuplicateRow> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final reviewableMb = rows
+        .where((row) => !row.isKeeper)
+        .fold<double>(0, (total, row) => total + row.sizeMb);
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Group $groupId',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              Text(
+                '${rows.length} files / ${_formatSize(reviewableMb)}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          for (final row in rows) ...[
+            _DuplicateFileLine(row: row),
+            if (row != rows.last) const SizedBox(height: 8),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _DuplicateFileLine extends StatelessWidget {
+  const _DuplicateFileLine({required this.row});
+
+  final _DuplicateRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final chipColor = row.isKeeper
+        ? colorScheme.primaryContainer
+        : row.recommendation == 'ReviewRemoveLocalCopy'
+            ? colorScheme.errorContainer
+            : colorScheme.tertiaryContainer;
+    final chipTextColor = row.isKeeper
+        ? colorScheme.onPrimaryContainer
+        : row.recommendation == 'ReviewRemoveLocalCopy'
+            ? colorScheme.onErrorContainer
+            : colorScheme.onTertiaryContainer;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            row.isKeeper ? Icons.check_circle_outline : Icons.pending_actions,
+            color: chipTextColor,
+            size: 20,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 6,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        color: chipColor,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        row.recommendationLabel,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: chipTextColor,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      '${_formatSize(row.sizeMb)}  ${row.lastWriteTime}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  row.path,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ApprovalRowTile extends StatelessWidget {
+  const _ApprovalRowTile({
+    required this.row,
+    required this.onChanged,
+  });
+
+  final _ApprovalRow row;
+  final ValueChanged<bool?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color:
+              row.approved ? colorScheme.primary : colorScheme.outlineVariant,
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Checkbox(
+            value: row.approved,
+            onChanged: onChanged,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${row.action} / Group ${row.groupId} / ${_formatSize(row.sizeMb)}',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                _LabeledPath(label: 'Local', value: row.localPath),
+                const SizedBox(height: 4),
+                _LabeledPath(label: 'Google', value: row.googleCopyPath),
+                if (row.note.isNotEmpty) ...[
+                  const SizedBox(height: 6),
+                  Text(
+                    row.note,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricTile extends StatelessWidget {
+  const _MetricTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.detail,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+  final String? detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, color: colorScheme.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      value,
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    if (detail != null) ...[
+                      const SizedBox(width: 8),
+                      Flexible(
+                        child: Text(
+                          detail!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PathLine extends StatelessWidget {
+  const _PathLine({
+    required this.label,
+    required this.value,
+    required this.onCopy,
+  });
+
+  final String label;
+  final String value;
+  final VoidCallback onCopy;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              value,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall,
+            ),
+          ),
+          IconButton(
+            tooltip: 'コピー',
+            onPressed: onCopy,
+            icon: const Icon(Icons.content_copy, size: 18),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CommandLine extends StatelessWidget {
+  const _CommandLine({
+    required this.label,
+    required this.command,
+    required this.onCopy,
+  });
+
+  final String label;
+  final String command;
+  final VoidCallback onCopy;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 92,
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SelectableText(
+                command,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton(
+            tooltip: 'コピー',
+            onPressed: onCopy,
+            icon: const Icon(Icons.content_copy, size: 18),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LabeledPath extends StatelessWidget {
+  const _LabeledPath({
+    required this.label,
+    required this.value,
+  });
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 56,
+          child: Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value.isEmpty ? '-' : value,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodySmall,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({
+    required this.icon,
+    required this.title,
+    required this.message,
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Container(
+      key: ValueKey<String>(title),
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        children: [
+          Icon(icon, size: 36, color: colorScheme.primary),
+          const SizedBox(height: 10),
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CsvTable {
+  const _CsvTable(this.rows);
+
+  final List<Map<String, String>> rows;
+
+  factory _CsvTable.parse(String text) {
+    final records = _parseRecords(text);
+    if (records.isEmpty) {
+      return const _CsvTable(<Map<String, String>>[]);
+    }
+    final headers = records.first
+        .map((header) => header.replaceFirst('\ufeff', '').trim())
+        .toList();
+    final rows = <Map<String, String>>[];
+    for (final record in records.skip(1)) {
+      final row = <String, String>{};
+      for (var index = 0; index < headers.length; index++) {
+        row[headers[index]] = index < record.length ? record[index] : '';
+      }
+      if (row.values.any((value) => value.trim().isNotEmpty)) {
+        rows.add(row);
+      }
+    }
+    return _CsvTable(rows);
+  }
+
+  static List<List<String>> _parseRecords(String text) {
+    final records = <List<String>>[];
+    var row = <String>[];
+    final cell = StringBuffer();
+    var inQuotes = false;
+
+    void finishCell() {
+      row.add(cell.toString());
+      cell.clear();
+    }
+
+    void finishRow() {
+      finishCell();
+      if (row.any((value) => value.trim().isNotEmpty)) {
+        records.add(row);
+      }
+      row = <String>[];
+    }
+
+    for (var index = 0; index < text.length; index++) {
+      final char = text[index];
+      if (inQuotes) {
+        if (char == '"') {
+          if (index + 1 < text.length && text[index + 1] == '"') {
+            cell.write('"');
+            index++;
+          } else {
+            inQuotes = false;
+          }
+        } else {
+          cell.write(char);
+        }
+        continue;
+      }
+
+      if (char == '"') {
+        inQuotes = true;
+      } else if (char == ',') {
+        finishCell();
+      } else if (char == '\n') {
+        finishRow();
+      } else if (char == '\r') {
+        if (index + 1 >= text.length || text[index + 1] != '\n') {
+          finishRow();
+        }
+      } else {
+        cell.write(char);
+      }
+    }
+
+    if (inQuotes || cell.isNotEmpty || row.isNotEmpty) {
+      finishRow();
+    }
+    return records;
+  }
+}
+
+class _DuplicateRow {
+  const _DuplicateRow({
+    required this.groupId,
+    required this.recommendation,
+    required this.sizeMb,
+    required this.hash,
+    required this.lastWriteTime,
+    required this.path,
+  });
+
+  final int groupId;
+  final String recommendation;
+  final double sizeMb;
+  final String hash;
+  final String lastWriteTime;
+  final String path;
+
+  bool get isKeeper => recommendation == 'Keep';
+
+  String get recommendationLabel {
+    switch (recommendation) {
+      case 'Keep':
+        return '保持';
+      case 'ReviewRemoveLocalCopy':
+        return 'ローカル削除候補';
+      case 'ReviewDuplicate':
+        return '重複確認';
+      default:
+        return recommendation.isEmpty ? '未分類' : recommendation;
+    }
+  }
+
+  factory _DuplicateRow.fromMap(Map<String, String> row) {
+    return _DuplicateRow(
+      groupId: _parseInt(_read(row, 'GroupId')),
+      recommendation: _read(row, 'Recommendation'),
+      sizeMb: _parseDouble(_read(row, 'SizeMB')),
+      hash: _read(row, 'Hash'),
+      lastWriteTime: _read(row, 'LastWriteTime'),
+      path: _read(row, 'Path'),
+    );
+  }
+}
+
+class _ApprovalRow {
+  const _ApprovalRow({
+    required this.approved,
+    required this.action,
+    required this.groupId,
+    required this.sizeMb,
+    required this.hash,
+    required this.localPath,
+    required this.googleCopyPath,
+    required this.note,
+  });
+
+  final bool approved;
+  final String action;
+  final int groupId;
+  final double sizeMb;
+  final String hash;
+  final String localPath;
+  final String googleCopyPath;
+  final String note;
+
+  _ApprovalRow copyWith({bool? approved}) {
+    return _ApprovalRow(
+      approved: approved ?? this.approved,
+      action: action,
+      groupId: groupId,
+      sizeMb: sizeMb,
+      hash: hash,
+      localPath: localPath,
+      googleCopyPath: googleCopyPath,
+      note: note,
+    );
+  }
+
+  List<String> toCsvRow() {
+    return <String>[
+      approved ? 'true' : 'false',
+      action,
+      '$groupId',
+      sizeMb.toStringAsFixed(2),
+      hash,
+      localPath,
+      googleCopyPath,
+      note,
+    ];
+  }
+
+  factory _ApprovalRow.fromMap(Map<String, String> row) {
+    return _ApprovalRow(
+      approved: _parseBool(_read(row, 'Approved')),
+      action: _read(row, 'Action'),
+      groupId: _parseInt(_read(row, 'GroupId')),
+      sizeMb: _parseDouble(_read(row, 'SizeMB')),
+      hash: _read(row, 'Hash'),
+      localPath: _read(row, 'LocalPath'),
+      googleCopyPath: _read(row, 'GoogleCopyPath'),
+      note: _read(row, 'Note'),
+    );
+  }
+}
+
+enum _CleanupFrequency {
+  daily('DAILY'),
+  weekly('WEEKLY'),
+  monthly('MONTHLY');
+
+  const _CleanupFrequency(this.schtasksName);
+
+  final String schtasksName;
+}
+
+enum _CleanupScheduleKind {
+  reportOnly,
+  applyApproved,
+}
+
+String _decodeCsv(Uint8List bytes) {
+  try {
+    return utf8.decode(bytes);
+  } on FormatException {
+    return latin1.decode(bytes);
+  }
+}
+
+String _read(Map<String, String> row, String key) {
+  return row[key]?.trim() ?? '';
+}
+
+int _parseInt(String value) {
+  return int.tryParse(value.trim()) ?? 0;
+}
+
+double _parseDouble(String value) {
+  return double.tryParse(value.trim()) ?? 0;
+}
+
+bool _parseBool(String value) {
+  switch (value.trim().toLowerCase()) {
+    case 'true':
+    case 'yes':
+    case 'y':
+    case '1':
+    case 'approved':
+      return true;
+    default:
+      return false;
+  }
+}
+
+String _formatSize(double sizeMb) {
+  if (sizeMb >= 1024) {
+    return '${(sizeMb / 1024).toStringAsFixed(2)} GB';
+  }
+  if (sizeMb >= 10) {
+    return '${sizeMb.toStringAsFixed(1)} MB';
+  }
+  return '${sizeMb.toStringAsFixed(2)} MB';
+}
+
+String _formatTaskTime(TimeOfDay time) {
+  final hour = time.hour.toString().padLeft(2, '0');
+  final minute = time.minute.toString().padLeft(2, '0');
+  return '$hour:$minute';
+}
+
+String _encodeCsvRow(List<String> values) {
+  return values.map(_encodeCsvCell).join(',');
+}
+
+String _encodeCsvCell(String value) {
+  final normalized = value.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  final needsQuote = normalized.contains(',') ||
+      normalized.contains('"') ||
+      normalized.contains('\n') ||
+      normalized.startsWith(' ') ||
+      normalized.endsWith(' ');
+  final escaped = normalized.replaceAll('"', '""');
+  return needsQuote ? '"$escaped"' : escaped;
+}

--- a/lib/pages/local_smart_cleanup_page.dart
+++ b/lib/pages/local_smart_cleanup_page.dart
@@ -4,6 +4,8 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../services/local_cleanup_result.dart';
+import '../services/local_cleanup_service.dart';
 import '../utils/web_image_downloader.dart';
 
 class LocalSmartCleanupPage extends StatefulWidget {
@@ -32,13 +34,23 @@ class _LocalSmartCleanupPageState extends State<LocalSmartCleanupPage> {
       r'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\Users\kanta\Scripts\SmartCleanup\Invoke-SmartCleanup.ps1"';
   static const _applyCommand =
       r'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\Users\kanta\Scripts\SmartCleanup\Invoke-ApprovedCleanup.ps1" -Apply';
+  static const _windowsReleaseUrl =
+      'https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.zip';
+  static const _windowsWorkflowUrl =
+      'https://github.com/kanta13jp1/my_web_app/actions/workflows/windows-companion-build.yml';
+  static const _windowsGuideUrl =
+      'https://github.com/kanta13jp1/my_web_app/blob/main/docs/WINDOWS_COMPANION_APP.md';
+  static const _trackingIssueUrl =
+      'https://github.com/kanta13jp1/my_web_app/issues/1493';
 
+  final LocalCleanupService _localCleanupService = const LocalCleanupService();
   final List<_DuplicateRow> _duplicates = <_DuplicateRow>[];
   final List<_ApprovalRow> _approvals = <_ApprovalRow>[];
   String? _reportFileName;
   String? _approvalFileName;
   String _statusText = 'CSVを読み込むと、重複候補・承認候補・定期実行コマンドを確認できます。';
   bool _isBusy = false;
+  bool _isRunningLocalAction = false;
   int _selectedTab = 0;
   _CleanupFrequency _scheduleFrequency = _CleanupFrequency.weekly;
   _CleanupScheduleKind _scheduleKind = _CleanupScheduleKind.reportOnly;
@@ -175,6 +187,34 @@ class _LocalSmartCleanupPageState extends State<LocalSmartCleanupPage> {
     setState(() => _scheduleTime = picked);
   }
 
+  Future<void> _runLocalAction(
+    String label,
+    Future<LocalCleanupResult> Function() action,
+  ) async {
+    if (_isRunningLocalAction) {
+      return;
+    }
+    setState(() => _isRunningLocalAction = true);
+    try {
+      final result = await action();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _statusText = result.success ? '$label が完了しました。' : '$label が完了しませんでした。';
+      });
+      _showMessage(result.displayMessage);
+    } finally {
+      if (mounted) {
+        setState(() => _isRunningLocalAction = false);
+      }
+    }
+  }
+
+  void _openUrl(String url) {
+    openWebUrl(url);
+  }
+
   Future<void> _copyText(String text, String message) async {
     await Clipboard.setData(ClipboardData(text: text));
     if (!mounted) {
@@ -276,6 +316,8 @@ class _LocalSmartCleanupPageState extends State<LocalSmartCleanupPage> {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     _buildHeader(theme),
+                    const SizedBox(height: 16),
+                    _buildWindowsInstallPanel(theme),
                     const SizedBox(height: 16),
                     _buildMetrics(wide),
                     const SizedBox(height: 16),
@@ -385,6 +427,83 @@ class _LocalSmartCleanupPageState extends State<LocalSmartCleanupPage> {
     );
   }
 
+  Widget _buildWindowsInstallPanel(ThemeData theme) {
+    final colorScheme = theme.colorScheme;
+    final supported = _localCleanupService.isSupported;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: supported
+            ? colorScheme.primaryContainer
+            : colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                supported ? Icons.desktop_windows : Icons.install_desktop,
+                color: supported
+                    ? colorScheme.onPrimaryContainer
+                    : colorScheme.primary,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  supported ? 'Windowsアプリ版で実行中' : 'Windowsアプリ版をインストール',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: supported ? colorScheme.onPrimaryContainer : null,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            supported
+                ? 'このビルドではレポート生成、承認適用、スケジュール操作をアプリから直接実行できます。'
+                : 'Windows版ではCドライブの重複スキャン、承認済みクリーンアップ、タスク登録をローカルで実行できます。',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: supported
+                  ? colorScheme.onPrimaryContainer
+                  : colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: [
+              FilledButton.icon(
+                onPressed: () => _openUrl(_windowsReleaseUrl),
+                icon: const Icon(Icons.download_for_offline_outlined),
+                label: const Text('最新版'),
+              ),
+              OutlinedButton.icon(
+                onPressed: () => _openUrl(_windowsWorkflowUrl),
+                icon: const Icon(Icons.inventory_2_outlined),
+                label: const Text('ビルド'),
+              ),
+              OutlinedButton.icon(
+                onPressed: () => _openUrl(_windowsGuideUrl),
+                icon: const Icon(Icons.article_outlined),
+                label: const Text('手順'),
+              ),
+              OutlinedButton.icon(
+                onPressed: () => _openUrl(_trackingIssueUrl),
+                icon: const Icon(Icons.task_alt),
+                label: const Text('Issue #1493'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildMetrics(bool wide) {
     final tiles = <Widget>[
       _MetricTile(
@@ -466,6 +585,12 @@ class _LocalSmartCleanupPageState extends State<LocalSmartCleanupPage> {
                 onPressed: _copyApprovalCsv,
                 icon: const Icon(Icons.content_copy),
                 label: const Text('承認CSVコピー'),
+              ),
+              OutlinedButton.icon(
+                onPressed: () =>
+                    Navigator.of(context).pushNamed('/windows-app'),
+                icon: const Icon(Icons.desktop_windows_outlined),
+                label: const Text('Windows版'),
               ),
             ],
           ),
@@ -771,6 +896,67 @@ class _LocalSmartCleanupPageState extends State<LocalSmartCleanupPage> {
               'スケジュール削除コマンドをコピーしました。',
             ),
           ),
+          if (_localCleanupService.isSupported) ...[
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                FilledButton.icon(
+                  onPressed: _isRunningLocalAction
+                      ? null
+                      : () => _runLocalAction(
+                            'スケジュール登録',
+                            () => _localCleanupService.runGeneratedCommand(
+                              _scheduleCreateCommand,
+                              action: 'Schedule create',
+                            ),
+                          ),
+                  icon: const Icon(Icons.event_available),
+                  label: const Text('登録'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _isRunningLocalAction
+                      ? null
+                      : () => _runLocalAction(
+                            'スケジュール確認',
+                            () => _localCleanupService.runGeneratedCommand(
+                              _scheduleQueryCommand,
+                              action: 'Schedule query',
+                            ),
+                          ),
+                  icon: const Icon(Icons.search),
+                  label: const Text('確認'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _isRunningLocalAction
+                      ? null
+                      : () => _runLocalAction(
+                            'スケジュール実行',
+                            () => _localCleanupService.runGeneratedCommand(
+                              _scheduleRunCommand,
+                              action: 'Schedule run',
+                            ),
+                          ),
+                  icon: const Icon(Icons.play_arrow),
+                  label: const Text('実行'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _isRunningLocalAction
+                      ? null
+                      : () => _runLocalAction(
+                            'スケジュール削除',
+                            () => _localCleanupService.runGeneratedCommand(
+                              _scheduleDeleteCommand,
+                              action: 'Schedule delete',
+                            ),
+                          ),
+                  icon: const Icon(Icons.delete_outline),
+                  label: const Text('削除'),
+                ),
+              ],
+            ),
+          ],
         ],
       ),
     );
@@ -812,6 +998,35 @@ class _LocalSmartCleanupPageState extends State<LocalSmartCleanupPage> {
               '承認適用コマンドをコピーしました。',
             ),
           ),
+          if (_localCleanupService.isSupported) ...[
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                FilledButton.icon(
+                  onPressed: _isRunningLocalAction
+                      ? null
+                      : () => _runLocalAction(
+                            'レポート生成',
+                            _localCleanupService.runReport,
+                          ),
+                  icon: const Icon(Icons.play_circle_outline),
+                  label: const Text('レポート生成'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _isRunningLocalAction
+                      ? null
+                      : () => _runLocalAction(
+                            '承認適用',
+                            _localCleanupService.applyApprovedCleanup,
+                          ),
+                  icon: const Icon(Icons.recycling_outlined),
+                  label: const Text('承認適用'),
+                ),
+              ],
+            ),
+          ],
         ],
       ),
     );

--- a/lib/pages/windows_app_install_page.dart
+++ b/lib/pages/windows_app_install_page.dart
@@ -1,0 +1,349 @@
+import 'package:flutter/material.dart';
+
+import '../utils/web_image_downloader.dart';
+
+class WindowsAppInstallPage extends StatelessWidget {
+  const WindowsAppInstallPage({super.key});
+
+  static const latestZipUrl =
+      'https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.zip';
+  static const workflowUrl =
+      'https://github.com/kanta13jp1/my_web_app/actions/workflows/windows-companion-build.yml';
+  static const issueUrl =
+      'https://github.com/kanta13jp1/my_web_app/issues/1493';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Windowsアプリ版'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(20),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 1080),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _HeroPanel(theme: theme),
+                const SizedBox(height: 16),
+                Wrap(
+                  spacing: 10,
+                  runSpacing: 10,
+                  children: [
+                    FilledButton.icon(
+                      onPressed: () => openWebUrl(latestZipUrl),
+                      icon: const Icon(Icons.download_for_offline_outlined),
+                      label: const Text('Windows版ZIPをダウンロード'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: () => openWebUrl(workflowUrl),
+                      icon: const Icon(Icons.build_circle_outlined),
+                      label: const Text('ビルド履歴を見る'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: () => Navigator.of(context)
+                          .pushNamed('/local-smart-cleanup'),
+                      icon: const Icon(Icons.cleaning_services_outlined),
+                      label: const Text('スマート整理を開く'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: () => openWebUrl(issueUrl),
+                      icon: const Icon(Icons.flag_outlined),
+                      label: const Text('P0 Issue'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                LayoutBuilder(
+                  builder: (context, constraints) {
+                    final wide = constraints.maxWidth >= 880;
+                    const cards = <Widget>[
+                      _StepCard(
+                        number: '1',
+                        title: 'ZIPを取得',
+                        body: '最新版の配布ZIPをダウンロードします。',
+                        icon: Icons.file_download_outlined,
+                      ),
+                      _StepCard(
+                        number: '2',
+                        title: '任意フォルダに展開',
+                        body: 'Downloads以外の固定フォルダに展開すると更新管理が安定します。',
+                        icon: Icons.folder_open_outlined,
+                      ),
+                      _StepCard(
+                        number: '3',
+                        title: 'アプリを起動',
+                        body: '展開先の my_web_app.exe を起動します。',
+                        icon: Icons.desktop_windows_outlined,
+                      ),
+                      _StepCard(
+                        number: '4',
+                        title: '承認して実行',
+                        body: 'スキャン結果を確認し、承認済みの候補だけをローカルで処理します。',
+                        icon: Icons.verified_user_outlined,
+                      ),
+                    ];
+                    if (wide) {
+                      return Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          for (var index = 0;
+                              index < cards.length;
+                              index++) ...[
+                            if (index > 0) const SizedBox(width: 12),
+                            Expanded(child: cards[index]),
+                          ],
+                        ],
+                      );
+                    }
+                    return Wrap(
+                      spacing: 12,
+                      runSpacing: 12,
+                      children: cards
+                          .map(
+                            (card) => SizedBox(
+                              width: 260,
+                              child: card,
+                            ),
+                          )
+                          .toList(),
+                    );
+                  },
+                ),
+                const SizedBox(height: 16),
+                _RolePanel(theme: theme),
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '安定ダウンロードURL: $latestZipUrl',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HeroPanel extends StatelessWidget {
+  const _HeroPanel({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: colorScheme.primaryContainer,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(
+              Icons.desktop_windows_outlined,
+              color: colorScheme.onPrimaryContainer,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Windows Companion App',
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Web版ではできないローカルPCのスキャン、承認済み整理、Windowsタスク登録をWindowsアプリ側で実行します。',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StepCard extends StatelessWidget {
+  const _StepCard({
+    required this.number,
+    required this.title,
+    required this.body,
+    required this.icon,
+  });
+
+  final String number;
+  final String title;
+  final String body;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 15,
+                backgroundColor: colorScheme.primaryContainer,
+                child: Text(
+                  number,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Icon(icon, color: colorScheme.primary),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            body,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RolePanel extends StatelessWidget {
+  const _RolePanel({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    final rows = <({String label, String body})>[
+      (
+        label: 'Web版',
+        body: 'インストール導線、レポート確認、承認CSV編集を担当します。',
+      ),
+      (
+        label: 'Windows版',
+        body: 'ローカルPCのファイル確認とPowerShell実行を担当します。',
+      ),
+      (
+        label: 'PowerShell',
+        body: '承認済み候補だけを検証し、ごみ箱移動と結果ログ保存を行います。',
+      ),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '役割分担',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 10),
+          for (final row in rows) ...[
+            _RoleLine(label: row.label, body: row.body),
+            if (row != rows.last) const Divider(height: 18),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _RoleLine extends StatelessWidget {
+  const _RoleLine({
+    required this.label,
+    required this.body,
+  });
+
+  final String label;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 96,
+          child: Text(
+            label,
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: colorScheme.primary,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            body,
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/services/local_cleanup_result.dart
+++ b/lib/services/local_cleanup_result.dart
@@ -1,0 +1,32 @@
+class LocalCleanupResult {
+  const LocalCleanupResult({
+    required this.action,
+    required this.exitCode,
+    required this.stdout,
+    required this.stderr,
+  });
+
+  factory LocalCleanupResult.unsupported(String action, String message) {
+    return LocalCleanupResult(
+      action: action,
+      exitCode: 1,
+      stdout: '',
+      stderr: message,
+    );
+  }
+
+  final String action;
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+
+  bool get success => exitCode == 0;
+
+  String get displayMessage {
+    final output = stdout.trim().isNotEmpty ? stdout.trim() : stderr.trim();
+    if (output.isEmpty) {
+      return success ? '$action completed.' : '$action failed.';
+    }
+    return output.split(RegExp(r'\r?\n')).take(4).join('\n');
+  }
+}

--- a/lib/services/local_cleanup_service.dart
+++ b/lib/services/local_cleanup_service.dart
@@ -1,0 +1,2 @@
+export 'local_cleanup_service_stub.dart'
+    if (dart.library.io) 'local_cleanup_service_io.dart';

--- a/lib/services/local_cleanup_service_io.dart
+++ b/lib/services/local_cleanup_service_io.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'local_cleanup_result.dart';
+
+class LocalCleanupService {
+  const LocalCleanupService();
+
+  bool get isSupported => Platform.isWindows;
+
+  String get supportLabel =>
+      Platform.isWindows ? 'Windows app' : '${Platform.operatingSystem} app';
+
+  Future<LocalCleanupResult> runReport() async {
+    return _runPowerShellScript(
+      'Invoke-SmartCleanup.ps1',
+      action: 'Smart cleanup report',
+    );
+  }
+
+  Future<LocalCleanupResult> applyApprovedCleanup() async {
+    return _runPowerShellScript(
+      'Invoke-ApprovedCleanup.ps1',
+      action: 'Approved cleanup',
+      arguments: const <String>['-Apply'],
+    );
+  }
+
+  Future<LocalCleanupResult> runGeneratedCommand(
+    String command, {
+    required String action,
+  }) async {
+    if (!Platform.isWindows) {
+      return LocalCleanupResult.unsupported(
+        action,
+        'Scheduled task operations are only available in the Windows app.',
+      );
+    }
+    return _runExecutable(
+      'powershell.exe',
+      <String>[
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        command,
+      ],
+      action: action,
+    );
+  }
+
+  Future<LocalCleanupResult> _runPowerShellScript(
+    String scriptName, {
+    required String action,
+    List<String> arguments = const <String>[],
+  }) async {
+    if (!Platform.isWindows) {
+      return LocalCleanupResult.unsupported(
+        action,
+        'Local PC cleanup actions are only available in the Windows app.',
+      );
+    }
+
+    final userProfile = Platform.environment['USERPROFILE'];
+    if (userProfile == null || userProfile.isEmpty) {
+      return LocalCleanupResult.unsupported(
+        action,
+        'USERPROFILE was not found. The cleanup script path cannot be resolved.',
+      );
+    }
+
+    final scriptPath = _resolveScriptPath(scriptName, userProfile);
+    if (scriptPath == null) {
+      final bundledPath =
+          '${File(Platform.resolvedExecutable).parent.path}\\scripts\\SmartCleanup\\$scriptName';
+      final profilePath = '$userProfile\\Scripts\\SmartCleanup\\$scriptName';
+      return LocalCleanupResult.unsupported(
+        action,
+        'Cleanup script not found. Checked: $bundledPath / $profilePath',
+      );
+    }
+
+    return _runExecutable(
+      'powershell.exe',
+      <String>[
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        scriptPath,
+        ...arguments,
+      ],
+      action: action,
+    );
+  }
+
+  String? _resolveScriptPath(String scriptName, String userProfile) {
+    final executableDir = File(Platform.resolvedExecutable).parent.path;
+    final candidates = <String>[
+      '$executableDir\\scripts\\SmartCleanup\\$scriptName',
+      '$userProfile\\Scripts\\SmartCleanup\\$scriptName',
+    ];
+    for (final scriptPath in candidates) {
+      if (File(scriptPath).existsSync()) {
+        return scriptPath;
+      }
+    }
+    return null;
+  }
+
+  Future<LocalCleanupResult> _runExecutable(
+    String executable,
+    List<String> arguments, {
+    required String action,
+  }) async {
+    try {
+      final result = await Process.run(
+        executable,
+        arguments,
+        runInShell: false,
+      );
+      return LocalCleanupResult(
+        action: action,
+        exitCode: result.exitCode,
+        stdout: '${result.stdout}',
+        stderr: '${result.stderr}',
+      );
+    } on ProcessException catch (error) {
+      return LocalCleanupResult.unsupported(action, error.message);
+    }
+  }
+}

--- a/lib/services/local_cleanup_service_stub.dart
+++ b/lib/services/local_cleanup_service_stub.dart
@@ -1,0 +1,33 @@
+import 'local_cleanup_result.dart';
+
+class LocalCleanupService {
+  const LocalCleanupService();
+
+  bool get isSupported => false;
+
+  String get supportLabel => 'Web版';
+
+  Future<LocalCleanupResult> runReport() async {
+    return LocalCleanupResult.unsupported(
+      'Smart cleanup report',
+      'Windowsアプリ版でのみローカルPC操作を実行できます。',
+    );
+  }
+
+  Future<LocalCleanupResult> applyApprovedCleanup() async {
+    return LocalCleanupResult.unsupported(
+      'Approved cleanup',
+      'Windowsアプリ版でのみ承認済みクリーンアップを実行できます。',
+    );
+  }
+
+  Future<LocalCleanupResult> runGeneratedCommand(
+    String command, {
+    required String action,
+  }) async {
+    return LocalCleanupResult.unsupported(
+      action,
+      'Windowsアプリ版でのみスケジュールタスクを操作できます。',
+    );
+  }
+}

--- a/lib/utils/web_image_downloader_stub.dart
+++ b/lib/utils/web_image_downloader_stub.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 // Web以外（テストやスマホ）では何もしない、またはログを出す
 void downloadImageFile(List<int> bytes, String fileName) {
@@ -7,7 +10,12 @@ void downloadImageFile(List<int> bytes, String fileName) {
 
 // URLを開く機能（スタブ）
 void openWebUrl(String url) {
-  debugPrint('Web以外: $url を開こうとしました');
+  final uri = Uri.tryParse(url);
+  if (uri == null) {
+    debugPrint('Invalid URL: $url');
+    return;
+  }
+  unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
 }
 
 // シェア機能（スタブ）

--- a/lib/windows_companion_main.dart
+++ b/lib/windows_companion_main.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+import 'pages/local_smart_cleanup_page.dart';
+import 'pages/windows_app_install_page.dart';
+
+void main() {
+  runApp(const WindowsCompanionApp());
+}
+
+class WindowsCompanionApp extends StatelessWidget {
+  const WindowsCompanionApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Jibun Windows Companion',
+      debugShowCheckedModeBanner: false,
+      locale: const Locale('ja', 'JP'),
+      supportedLocales: const <Locale>[
+        Locale('ja', 'JP'),
+        Locale('en', 'US'),
+      ],
+      localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0xFF00897B),
+      ),
+      initialRoute: '/local-smart-cleanup',
+      routes: <String, WidgetBuilder>{
+        '/windows-app': (_) => const WindowsAppInstallPage(),
+        '/local-smart-cleanup': (_) => const LocalSmartCleanupPage(),
+      },
+    );
+  }
+}

--- a/tools/windows-companion/SmartCleanup/Invoke-ApprovedCleanup.ps1
+++ b/tools/windows-companion/SmartCleanup/Invoke-ApprovedCleanup.ps1
@@ -1,0 +1,161 @@
+[CmdletBinding()]
+param(
+  [string]$ApprovalCsv,
+  [switch]$Apply
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-GoogleMyDriveRoot {
+  if (-not (Test-Path -LiteralPath 'G:\')) {
+    return $null
+  }
+
+  $visibleRoots = Get-ChildItem -LiteralPath 'G:\' -Directory -Force -ErrorAction SilentlyContinue |
+    Where-Object {
+      -not ($_.Attributes -band [IO.FileAttributes]::Hidden) -and
+      -not ($_.Attributes -band [IO.FileAttributes]::System)
+    }
+
+  return ($visibleRoots | Select-Object -First 1).FullName
+}
+
+function Test-UnderAnyRoot {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string[]]$Roots
+  )
+
+  foreach ($root in $Roots) {
+    if ($Path.StartsWith($root, [StringComparison]::OrdinalIgnoreCase)) {
+      return $true
+    }
+  }
+  return $false
+}
+
+function ConvertTo-BooleanApproval {
+  param([string]$Value)
+
+  return $Value -match '^(true|yes|y|1|approved)$'
+}
+
+function Send-FileToRecycleBin {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  Add-Type -AssemblyName Microsoft.VisualBasic
+  [Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile(
+    $Path,
+    [Microsoft.VisualBasic.FileIO.UIOption]::OnlyErrorDialogs,
+    [Microsoft.VisualBasic.FileIO.RecycleOption]::SendToRecycleBin
+  )
+}
+
+$googleRoot = Get-GoogleMyDriveRoot
+$reportRoot = if ($googleRoot) {
+  Join-Path $googleRoot 'C-drive-archive\cleanup-reports'
+} else {
+  Join-Path $env:USERPROFILE 'SmartCleanupReports'
+}
+
+if (-not $ApprovalCsv) {
+  $ApprovalCsv = Join-Path $reportRoot 'cleanup-approval-latest.csv'
+}
+
+if (-not (Test-Path -LiteralPath $ApprovalCsv)) {
+  throw "Approval CSV not found: $ApprovalCsv"
+}
+
+$allowedLocalRoots = @(
+  (Join-Path $env:USERPROFILE 'Downloads'),
+  (Join-Path $env:USERPROFILE 'Videos'),
+  (Join-Path $env:USERPROFILE 'Documents'),
+  (Join-Path $env:USERPROFILE 'Desktop')
+) | Where-Object { Test-Path -LiteralPath $_ } | ForEach-Object {
+  (Resolve-Path -LiteralPath $_).Path
+}
+
+$googleRootResolved = if ($googleRoot) {
+  (Resolve-Path -LiteralPath $googleRoot).Path
+} else {
+  $null
+}
+
+$rows = Import-Csv -LiteralPath $ApprovalCsv
+$approvedRows = @($rows | Where-Object {
+  (ConvertTo-BooleanApproval -Value $_.Approved) -and
+  $_.Action -eq 'RecycleLocalCopy'
+})
+
+New-Item -ItemType Directory -Force -Path $reportRoot | Out-Null
+$resultRows = New-Object System.Collections.Generic.List[object]
+foreach ($row in $approvedRows) {
+  $localPath = [string]$row.LocalPath
+  $googleCopyPath = [string]$row.GoogleCopyPath
+  $status = 'DryRun'
+  $message = ''
+
+  try {
+    if (-not (Test-Path -LiteralPath $localPath)) {
+      throw "Local file not found: $localPath"
+    }
+    if ($googleCopyPath -and -not (Test-Path -LiteralPath $googleCopyPath)) {
+      throw "Google copy not found: $googleCopyPath"
+    }
+
+    $localResolved = (Resolve-Path -LiteralPath $localPath).Path
+    if (-not (Test-UnderAnyRoot -Path $localResolved -Roots $allowedLocalRoots)) {
+      throw "Local path is outside approved cleanup roots: $localResolved"
+    }
+
+    $localHash = (Get-FileHash -LiteralPath $localResolved -Algorithm SHA256).Hash
+    if ($localHash -ne $row.Hash) {
+      throw "Local hash changed since approval CSV was generated: $localResolved"
+    }
+
+    if ($googleCopyPath) {
+      $googleResolved = (Resolve-Path -LiteralPath $googleCopyPath).Path
+      if ($googleRootResolved -and -not $googleResolved.StartsWith($googleRootResolved, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Google copy is outside Google Drive root: $googleResolved"
+      }
+      $googleHash = (Get-FileHash -LiteralPath $googleResolved -Algorithm SHA256).Hash
+      if ($googleHash -ne $row.Hash) {
+        throw "Google copy hash does not match approved duplicate hash: $googleResolved"
+      }
+    }
+
+    if ($Apply) {
+      Send-FileToRecycleBin -Path $localResolved
+      $status = 'Recycled'
+      $message = 'Moved local duplicate to Recycle Bin.'
+    } else {
+      $message = 'Verified. Re-run with -Apply to move to Recycle Bin.'
+    }
+  } catch {
+    $status = 'Skipped'
+    $message = $_.Exception.Message
+  }
+
+  $resultRows.Add([pscustomobject]@{
+    Status = $status
+    Message = $message
+    SizeMB = $row.SizeMB
+    LocalPath = $localPath
+    GoogleCopyPath = $googleCopyPath
+  })
+}
+
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$resultPath = Join-Path $reportRoot "approved-cleanup-result-$timestamp.csv"
+$latestResultPath = Join-Path $reportRoot 'approved-cleanup-result-latest.csv'
+$resultRows | Export-Csv -NoTypeInformation -Encoding UTF8 -Path $resultPath
+$resultRows | Export-Csv -NoTypeInformation -Encoding UTF8 -Path $latestResultPath
+
+Write-Output "Approved cleanup completed."
+Write-Output "Mode: $(if ($Apply) { 'Apply' } else { 'DryRun' })"
+Write-Output "Approved rows: $($approvedRows.Count)"
+Write-Output "Result CSV: $resultPath"
+if (-not $Apply) {
+  Write-Output 'No files were deleted or moved. Re-run with -Apply after reviewing the dry-run result.'
+}

--- a/tools/windows-companion/SmartCleanup/Invoke-SmartCleanup.ps1
+++ b/tools/windows-companion/SmartCleanup/Invoke-SmartCleanup.ps1
@@ -1,0 +1,253 @@
+[CmdletBinding()]
+param(
+  [int64]$MinimumBytes = 1MB
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-GoogleMyDriveRoot {
+  if (-not (Test-Path -LiteralPath 'G:\')) {
+    return $null
+  }
+
+  $visibleRoots = Get-ChildItem -LiteralPath 'G:\' -Directory -Force -ErrorAction SilentlyContinue |
+    Where-Object {
+      -not ($_.Attributes -band [IO.FileAttributes]::Hidden) -and
+      -not ($_.Attributes -band [IO.FileAttributes]::System)
+    }
+
+  return ($visibleRoots | Select-Object -First 1).FullName
+}
+
+function Test-ExcludedPath {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $parts = $Path -split '[\\/]'
+  $excludedNames = @(
+    '.git',
+    '.dart_tool',
+    '.gradle',
+    '.venv',
+    '.vscode',
+    '__pycache__',
+    'build',
+    'node_modules',
+    'venv'
+  )
+
+  foreach ($name in $excludedNames) {
+    if ($parts -contains $name) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+function New-ReportDirectory {
+  param([string]$GoogleRoot)
+
+  if ($GoogleRoot) {
+    $root = Join-Path $GoogleRoot 'C-drive-archive\cleanup-reports'
+  } else {
+    $root = Join-Path $env:USERPROFILE 'SmartCleanupReports'
+  }
+
+  New-Item -ItemType Directory -Force -Path $root | Out-Null
+  return $root
+}
+
+function Publish-LatestFile {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination,
+    [int]$Retries = 6,
+    [int]$DelayMilliseconds = 750
+  )
+
+  $tempPath = "$Destination.tmp-$PID-$([guid]::NewGuid().ToString('N'))"
+  Copy-Item -LiteralPath $Source -Destination $tempPath -Force -ErrorAction Stop
+
+  try {
+    for ($attempt = 1; $attempt -le $Retries; $attempt++) {
+      try {
+        Move-Item -LiteralPath $tempPath -Destination $Destination -Force -ErrorAction Stop
+        return $true
+      } catch {
+        if ($attempt -ge $Retries) {
+          Write-Warning "Could not refresh latest file: $Destination"
+          Write-Warning $_.Exception.Message
+          Write-Warning "Timestamped file remains available: $Source"
+          return $false
+        }
+        Start-Sleep -Milliseconds $DelayMilliseconds
+      }
+    }
+  } finally {
+    Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+  }
+}
+
+$googleRoot = Get-GoogleMyDriveRoot
+$archiveRoot = if ($googleRoot) { Join-Path $googleRoot 'C-drive-archive' } else { $null }
+$reportRoot = New-ReportDirectory -GoogleRoot $googleRoot
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$csvPath = Join-Path $reportRoot "duplicate-report-$timestamp.csv"
+$summaryPath = Join-Path $reportRoot "duplicate-summary-$timestamp.md"
+$approvalPath = Join-Path $reportRoot "cleanup-approval-$timestamp.csv"
+$latestCsvPath = Join-Path $reportRoot 'duplicate-report-latest.csv'
+$latestSummaryPath = Join-Path $reportRoot 'duplicate-summary-latest.md'
+$latestApprovalPath = Join-Path $reportRoot 'cleanup-approval-latest.csv'
+
+$candidateRoots = @(
+  (Join-Path $env:USERPROFILE 'Downloads'),
+  (Join-Path $env:USERPROFILE 'Videos'),
+  (Join-Path $env:USERPROFILE 'Documents'),
+  (Join-Path $env:USERPROFILE 'Desktop')
+)
+
+if ($archiveRoot -and (Test-Path -LiteralPath $archiveRoot)) {
+  $candidateRoots += $archiveRoot
+}
+
+$scanRoots = $candidateRoots |
+  Where-Object { $_ -and (Test-Path -LiteralPath $_) } |
+  Select-Object -Unique
+
+$files = foreach ($root in $scanRoots) {
+  Get-ChildItem -LiteralPath $root -Recurse -File -Force -ErrorAction SilentlyContinue |
+    Where-Object {
+      $_.Length -ge $MinimumBytes -and
+      -not (Test-ExcludedPath -Path $_.FullName) -and
+      $_.FullName -notlike (Join-Path $reportRoot '*')
+    } |
+    Select-Object FullName, Length, LastWriteTime
+}
+
+$sameSizeGroups = $files |
+  Group-Object Length |
+  Where-Object { $_.Count -gt 1 }
+
+$hashed = foreach ($group in $sameSizeGroups) {
+  foreach ($file in $group.Group) {
+    try {
+      $hash = Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256 -ErrorAction Stop
+      [pscustomobject]@{
+        FullName = $file.FullName
+        Length = [int64]$file.Length
+        LastWriteTime = $file.LastWriteTime
+        Hash = $hash.Hash
+      }
+    } catch {
+      [pscustomobject]@{
+        FullName = $file.FullName
+        Length = [int64]$file.Length
+        LastWriteTime = $file.LastWriteTime
+        Hash = ''
+      }
+    }
+  }
+}
+
+$duplicateHashGroups = $hashed |
+  Where-Object { $_.Hash } |
+  Group-Object Hash |
+  Where-Object { $_.Count -gt 1 }
+
+$rows = New-Object System.Collections.Generic.List[object]
+$groupIndex = 0
+foreach ($group in $duplicateHashGroups) {
+  $groupIndex++
+  $hasGoogleCopy = $false
+  if ($archiveRoot) {
+    $hasGoogleCopy = @($group.Group | Where-Object {
+      $_.FullName.StartsWith($archiveRoot, [StringComparison]::OrdinalIgnoreCase)
+    }).Count -gt 0
+  }
+
+  $ordered = $group.Group | Sort-Object `
+    @{ Expression = {
+      if ($archiveRoot -and $_.FullName.StartsWith($archiveRoot, [StringComparison]::OrdinalIgnoreCase)) { 0 } else { 1 }
+    } }, `
+    @{ Expression = 'LastWriteTime'; Descending = $true }, `
+    @{ Expression = 'FullName'; Ascending = $true }
+
+  $keeper = $ordered | Select-Object -First 1
+  foreach ($file in $ordered) {
+    $recommendation = if ($file.FullName -eq $keeper.FullName) {
+      'Keep'
+    } elseif ($hasGoogleCopy -and $file.FullName.StartsWith($env:USERPROFILE, [StringComparison]::OrdinalIgnoreCase)) {
+      'ReviewRemoveLocalCopy'
+    } else {
+      'ReviewDuplicate'
+    }
+
+    $rows.Add([pscustomobject]@{
+      GroupId = $groupIndex
+      Recommendation = $recommendation
+      SizeMB = [math]::Round($file.Length / 1MB, 2)
+      Hash = $file.Hash
+      LastWriteTime = $file.LastWriteTime.ToString('s')
+      Path = $file.FullName
+    })
+  }
+}
+
+$rows | Export-Csv -NoTypeInformation -Encoding UTF8 -Path $csvPath
+Publish-LatestFile -Source $csvPath -Destination $latestCsvPath | Out-Null
+
+$approvalRows = New-Object System.Collections.Generic.List[object]
+foreach ($row in ($rows | Where-Object { $_.Recommendation -eq 'ReviewRemoveLocalCopy' })) {
+  $googleCopy = $rows |
+    Where-Object {
+      $_.GroupId -eq $row.GroupId -and
+      $_.Recommendation -eq 'Keep' -and
+      $archiveRoot -and
+      $_.Path.StartsWith($archiveRoot, [StringComparison]::OrdinalIgnoreCase)
+    } |
+    Select-Object -First 1
+
+  $approvalRows.Add([pscustomobject]@{
+    Approved = 'false'
+    Action = 'RecycleLocalCopy'
+    GroupId = $row.GroupId
+    SizeMB = $row.SizeMB
+    Hash = $row.Hash
+    LocalPath = $row.Path
+    GoogleCopyPath = if ($googleCopy) { $googleCopy.Path } else { '' }
+    Note = 'Set Approved=true after manually confirming this local duplicate can be sent to Recycle Bin.'
+  })
+}
+
+$approvalRows | Export-Csv -NoTypeInformation -Encoding UTF8 -Path $approvalPath
+Publish-LatestFile -Source $approvalPath -Destination $latestApprovalPath | Out-Null
+
+$candidateBytes = ($rows |
+  Where-Object { $_.Recommendation -ne 'Keep' } |
+  Measure-Object SizeMB -Sum).Sum
+
+$summary = @(
+  '# Codex Smart Cleanup Report',
+  '',
+  "- Generated: $(Get-Date -Format s)",
+  "- Minimum file size: $([math]::Round($MinimumBytes / 1MB, 2)) MB",
+  "- Scan roots:",
+  ($scanRoots | ForEach-Object { "  - $_" }),
+  '',
+  "Duplicate groups: $($duplicateHashGroups.Count)",
+  "Reviewable duplicate volume: $([math]::Round(($candidateBytes / 1024), 2)) GB",
+  "Approval candidates: $($approvalRows.Count)",
+  '',
+  'No files were deleted or moved by this task.',
+  "CSV: $csvPath",
+  "Approval CSV: $approvalPath"
+)
+
+$summary | Set-Content -Encoding UTF8 -Path $summaryPath
+Publish-LatestFile -Source $summaryPath -Destination $latestSummaryPath | Out-Null
+
+Write-Output "Codex Smart Cleanup report generated."
+Write-Output "Summary: $summaryPath"
+Write-Output "CSV: $csvPath"
+Write-Output "Approval CSV: $approvalPath"


### PR DESCRIPTION
## Summary
- Adds `/windows-app` install page and Home catalog entry for the Windows Companion App.
- Adds `lib/windows_companion_main.dart` so the Windows desktop build can target only the local cleanup companion surface instead of the full web app.
- Adds `Build Windows Companion App` GitHub Actions workflow that builds, packages, uploads, and optionally publishes `jibun-windows-companion.zip`.
- Bundles safe smart-cleanup PowerShell scripts under `scripts/SmartCleanup` in the release ZIP.

## Verification
- `dart analyze lib\windows_companion_main.dart lib\pages\local_smart_cleanup_page.dart lib\pages\windows_app_install_page.dart lib\services\local_cleanup_result.dart lib\services\local_cleanup_service.dart lib\services\local_cleanup_service_io.dart lib\services\local_cleanup_service_stub.dart lib\utils\web_image_downloader_stub.dart`
- PowerShell script parse check for bundled SmartCleanup scripts
- `flutter build windows --release --no-tree-shake-icons --target lib\windows_companion_main.dart` from a short local path
- Local ZIP packaging smoke check

Closes #1493 when merged and released.