### PR TITLE
[codex] Add mobile release artifact automation

### DIFF
--- a/.github/workflows/mobile-release-build.yml
+++ b/.github/workflows/mobile-release-build.yml
@@ -1,0 +1,241 @@
+name: Build Mobile Release Artifacts
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/mobile-release-build.yml'
+      - 'android/**'
+      - 'ios/**'
+      - 'scripts/check_mobile_release_readiness.py'
+      - 'docs/MOBILE_SIMULTANEOUS_RELEASE.md'
+  workflow_dispatch:
+    inputs:
+      build_name:
+        description: 'Flutter build name, for example 1.0.0'
+        required: false
+        default: ''
+        type: string
+      build_number:
+        description: 'Flutter build number. Defaults to the GitHub run number.'
+        required: false
+        default: ''
+        type: string
+      publish_release:
+        description: 'Publish artifacts to GitHub Releases'
+        required: true
+        default: false
+        type: boolean
+      release_tag:
+        description: 'Release tag to create when publish_release is true'
+        required: false
+        default: 'mobile-latest'
+        type: string
+  push:
+    tags:
+      - 'mobile-v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: mobile-release-build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_VERSION: '3.38.x'
+
+jobs:
+  metadata-check:
+    name: Mobile Metadata Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check mobile release metadata
+        run: python scripts/check_mobile_release_readiness.py
+
+  android-aab:
+    name: Android AAB
+    needs: metadata-check
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Resolve build version
+        shell: bash
+        run: |
+          build_name="${{ inputs.build_name }}"
+          build_number="${{ inputs.build_number }}"
+          if [ -z "$build_name" ]; then
+            build_name="$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d '+' -f 1)"
+          fi
+          if [ -z "$build_number" ]; then
+            build_number="${GITHUB_RUN_NUMBER}"
+          fi
+          echo "BUILD_NAME=$build_name" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$build_number" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Check mobile release metadata
+        run: python scripts/check_mobile_release_readiness.py
+
+      - name: Configure Android release signing
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' }}
+        shell: bash
+        run: |
+          test -n "$ANDROID_KEYSTORE_PASSWORD"
+          test -n "$ANDROID_KEY_ALIAS"
+          test -n "$ANDROID_KEY_PASSWORD"
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
+          {
+            echo "storePassword=$ANDROID_KEYSTORE_PASSWORD"
+            echo "keyPassword=$ANDROID_KEY_PASSWORD"
+            echo "keyAlias=$ANDROID_KEY_ALIAS"
+            echo "storeFile=app/upload-keystore.jks"
+          } > android/key.properties
+
+      - name: Note unsigned Android fallback
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 == '' }}
+        run: |
+          echo "::warning::ANDROID_KEYSTORE_BASE64 is not configured. Android release artifact will use the debug signing fallback and is not Play-upload ready."
+
+      - name: Build Android App Bundle
+        run: >
+          flutter build appbundle --release --no-tree-shake-icons
+          --build-name "$BUILD_NAME"
+          --build-number "$BUILD_NUMBER"
+
+      - name: Package Android artifact
+        shell: bash
+        run: |
+          mkdir -p dist/android
+          cp build/app/outputs/bundle/release/app-release.aab dist/android/jibun-android-release.aab
+          ls -lh dist/android/jibun-android-release.aab
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: jibun-android-release-aab
+          path: dist/android/jibun-android-release.aab
+          if-no-files-found: error
+          retention-days: 30
+
+  ios-no-codesign:
+    name: iOS No-Codesign Archive
+    needs: metadata-check
+    if: github.event_name != 'pull_request'
+    runs-on: macos-15
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Resolve build version
+        shell: bash
+        run: |
+          build_name="${{ inputs.build_name }}"
+          build_number="${{ inputs.build_number }}"
+          if [ -z "$build_name" ]; then
+            build_name="$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d '+' -f 1)"
+          fi
+          if [ -z "$build_number" ]; then
+            build_number="${GITHUB_RUN_NUMBER}"
+          fi
+          echo "BUILD_NAME=$build_name" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$build_number" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Check mobile release metadata
+        run: python scripts/check_mobile_release_readiness.py
+
+      - name: Build iOS app without code signing
+        run: >
+          flutter build ios --release --no-codesign --no-tree-shake-icons
+          --build-name "$BUILD_NAME"
+          --build-number "$BUILD_NUMBER"
+
+      - name: Package iOS app bundle
+        shell: bash
+        run: |
+          mkdir -p dist/ios
+          test -d build/ios/iphoneos/Runner.app
+          ditto -c -k --sequesterRsrc --keepParent build/ios/iphoneos/Runner.app dist/ios/jibun-ios-runner-no-codesign.zip
+          ls -lh dist/ios/jibun-ios-runner-no-codesign.zip
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: jibun-ios-runner-no-codesign
+          path: dist/ios/jibun-ios-runner-no-codesign.zip
+          if-no-files-found: error
+          retention-days: 30
+
+  publish-release:
+    name: Publish Mobile Release
+    needs:
+      - android-aab
+      - ios-no-codesign
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/mobile-v') || inputs.publish_release == true
+    timeout-minutes: 10
+
+    steps:
+      - name: Download mobile artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish GitHub Release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ startsWith(github.ref, 'refs/tags/mobile-v') && github.ref_name || inputs.release_tag }}
+          name: Jibun Mobile Artifacts
+          body: |
+            Mobile release artifacts for iOS and Android.
+
+            - Android: `jibun-android-release.aab`
+            - iOS: `jibun-ios-runner-no-codesign.zip`
+
+            The iOS artifact is intentionally not code signed. Use the checklist in
+            `docs/MOBILE_SIMULTANEOUS_RELEASE.md` before TestFlight upload.
+          files: |
+            dist/jibun-android-release.aab
+            dist/jibun-ios-runner-no-codesign.zip

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,8 +23,17 @@ if (flutterVersionName == null) {
     flutterVersionName = "1.0"
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.withReader("UTF-8") { reader ->
+        keystoreProperties.load(reader)
+    }
+}
+def hasReleaseKeystore = keystorePropertiesFile.exists()
+
 android {
-    namespace = "com.example.my_web_app"
+    namespace = "jp.kanta13.jibun"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -34,8 +43,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.my_web_app"
+        applicationId = "jp.kanta13.jibun"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = flutter.minSdkVersion
@@ -44,11 +52,20 @@ android {
         versionName = flutterVersionName
     }
 
+    signingConfigs {
+        release {
+            if (hasReleaseKeystore) {
+                keyAlias = keystoreProperties["keyAlias"]
+                keyPassword = keystoreProperties["keyPassword"]
+                storeFile = file(keystoreProperties["storeFile"])
+                storePassword = keystoreProperties["storePassword"]
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
+            signingConfig = hasReleaseKeystore ? signingConfigs.release : signingConfigs.debug
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <application
-        android:label="my_web_app"
+        android:label="自分株式会社"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/kotlin/com/example/my_web_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/my_web_app/MainActivity.kt
@@ -1,5 +1,0 @@
-package com.example.my_web_app
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity: FlutterActivity()

--- a/android/app/src/main/kotlin/jp/kanta13/jibun/MainActivity.kt
+++ b/android/app/src/main/kotlin/jp/kanta13/jibun/MainActivity.kt
@@ -1,0 +1,5 @@
+package jp.kanta13.jibun
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,0 +1,4 @@
+storePassword=replace-with-keystore-password
+keyPassword=replace-with-key-password
+keyAlias=upload
+storeFile=app/upload-keystore.jks

--- a/docs/MOBILE_SIMULTANEOUS_RELEASE.md
+++ b/docs/MOBILE_SIMULTANEOUS_RELEASE.md
@@ -1,0 +1,109 @@
+# iOS / Android Simultaneous Release Runbook
+
+Issue: https://github.com/kanta13jp1/my_web_app/issues/1495
+
+## Scope
+
+Codex #2 owns the deterministic build and release automation. Claude Code keeps
+store policy, product gates, review conditions, and final go/no-go ownership.
+Codex #1 should take code-level mobile compatibility fixes that are not workflow
+or signing automation.
+
+## Current App Metadata
+
+| Item | Value |
+| --- | --- |
+| App display name | 自分株式会社 |
+| Android applicationId / namespace | `jp.kanta13.jibun` |
+| iOS bundle identifier | `jp.kanta13.jibun` |
+| Flutter build workflow | `.github/workflows/mobile-release-build.yml` |
+| Metadata gate | `python scripts/check_mobile_release_readiness.py` |
+
+Do not upload to either store until the bundle identifiers are confirmed as the
+final public identifiers. Changing them after a first store upload is painful or
+impossible.
+
+## GitHub Actions
+
+Manual build:
+
+```powershell
+gh workflow run mobile-release-build.yml `
+  -f build_name=1.0.0 `
+  -f build_number=1 `
+  -f publish_release=false
+```
+
+Release build:
+
+```powershell
+git tag mobile-v1.0.0
+git push origin mobile-v1.0.0
+```
+
+Artifacts:
+
+- Android AAB: `jibun-android-release.aab`
+- iOS no-codesign app bundle zip: `jibun-ios-runner-no-codesign.zip`
+
+The Android artifact is Play-upload ready only when the Android signing secrets
+are configured. Without those secrets, the workflow deliberately falls back to a
+debug-signed release artifact for build verification only. The iOS artifact
+proves the Flutter/Xcode build but is not a TestFlight-ready IPA. A signed
+archive still needs Apple Developer team, provisioning profile, certificate, and
+App Store Connect API key.
+
+## Required Secrets Before Store Distribution
+
+Android / Google Play:
+
+- `ANDROID_KEYSTORE_BASE64`
+- `ANDROID_KEYSTORE_PASSWORD`
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
+
+iOS / TestFlight:
+
+- `APPLE_TEAM_ID`
+- `APP_STORE_CONNECT_KEY_ID`
+- `APP_STORE_CONNECT_ISSUER_ID`
+- `APP_STORE_CONNECT_API_KEY_P8`
+- Signing certificate and provisioning profile, or a Fastlane Match equivalent
+
+## Release Checklist
+
+- [ ] Confirm final Android applicationId and iOS bundle identifier.
+- [ ] Confirm app display name, icon, splash, screenshots, and store category.
+- [ ] Run `python scripts/check_mobile_release_readiness.py`.
+- [ ] Run Android AAB workflow and keep the artifact.
+- [ ] Run iOS no-codesign workflow and keep the artifact.
+- [ ] Configure Android signing and Google Play internal testing upload.
+- [ ] Configure iOS signing and TestFlight upload.
+- [ ] Verify Supabase redirect URLs, Google login, deep links, and notification permissions.
+- [ ] Create a shared release note for both platforms.
+- [ ] Gate release on both platforms passing the same product smoke checklist.
+
+## Known Blockers / Handoff
+
+- Local Windows validation cannot run Android builds until `ANDROID_HOME` points
+  to an installed Android SDK.
+- This branch adds no-codesign iOS archive automation. TestFlight upload needs
+  Apple signing material and should be wired after the developer account values
+  are confirmed.
+- If the full `lib/main.dart` mobile build fails in GitHub Actions because of
+  web-only imports, route the code split to Codex #1. Codex #2 should keep the
+  workflow green by adding a mobile-safe target only after Claude Code confirms
+  the product surface for the first app release.
+
+## Automation Follow-up
+
+The session-start AI tooling watch on 2026-05-01 still points new Codex and
+Claude Code changes into `codex-runtime`, `hooks`, `integration`,
+`quality-cost`, and `schedule`. For mobile release work, the nearest automation
+hooks are:
+
+- scheduled mobile build smoke after metadata/signing is stable,
+- automatic issue update when `mobile-release-build.yml` fails,
+- release-tag workflow that publishes both platform artifacts from one tag,
+- mobile UAT task generation for the dedicated mobile instance.

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myWebApp;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.kanta13.jibun;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myWebApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.kanta13.jibun.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myWebApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.kanta13.jibun.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myWebApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.kanta13.jibun.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myWebApp;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.kanta13.jibun;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myWebApp;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.kanta13.jibun;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>My Web App</string>
+	<string>自分株式会社</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>my_web_app</string>
+	<string>Jibun</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -23,11 +23,11 @@
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>NSCameraUsageDescription</key>
-	<string>アイテムの撮影や画像解析のためにカメラを使用します。</string>
+	<string>アイデアの撮影や画像解析のためにカメラを使用します。</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>画像の解析やアップロードのために写真ライブラリにアクセスします。</string>
+	<string>画像の解析やアップロードのために写真ライブラリへアクセスします。</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>音声メモや演奏の録音のためにマイクを使用します。</string>
+	<string>音声メモや音声入力の録音のためにマイクを使用します。</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Validate native mobile release metadata before store builds."""
+
+from __future__ import annotations
+
+import plistlib
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ANDROID_NS = "{http://schemas.android.com/apk/res/android}"
+MOJIBAKE_MARKERS = ("繧", "縺", "譁", "荳", "蜈", "逕", "�", "", "\ufffd")
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def fail_if(condition: bool, message: str, failures: list[str]) -> None:
+    if condition:
+        failures.append(message)
+
+
+def extract_quoted_assignment(content: str, key: str) -> str | None:
+    match = re.search(rf"\b{re.escape(key)}\s*=\s*\"([^\"]+)\"", content)
+    return match.group(1) if match else None
+
+
+def check_android(failures: list[str]) -> None:
+    build_gradle = read_text(ROOT / "android/app/build.gradle")
+    namespace = extract_quoted_assignment(build_gradle, "namespace")
+    application_id = extract_quoted_assignment(build_gradle, "applicationId")
+
+    fail_if(not namespace, "Android namespace is missing.", failures)
+    fail_if(not application_id, "Android applicationId is missing.", failures)
+    fail_if(
+        bool(application_id and application_id.startswith("com.example")),
+        "Android applicationId still uses the com.example placeholder.",
+        failures,
+    )
+    fail_if(
+        bool(namespace and namespace.startswith("com.example")),
+        "Android namespace still uses the com.example placeholder.",
+        failures,
+    )
+
+    manifest = ET.parse(ROOT / "android/app/src/main/AndroidManifest.xml")
+    application = manifest.getroot().find("application")
+    label = application.get(f"{ANDROID_NS}label") if application is not None else None
+    fail_if(not label, "Android application label is missing.", failures)
+    fail_if(
+        label in {"my_web_app", "My Web App"},
+        "Android application label still uses the Flutter placeholder.",
+        failures,
+    )
+
+    if application_id:
+        activity_path = (
+            ROOT
+            / "android/app/src/main/kotlin"
+            / Path(*application_id.split("."))
+            / "MainActivity.kt"
+        )
+        fail_if(
+            not activity_path.exists(),
+            f"Android MainActivity package path is missing: {activity_path.relative_to(ROOT)}",
+            failures,
+        )
+
+
+def check_ios(failures: list[str]) -> None:
+    with (ROOT / "ios/Runner/Info.plist").open("rb") as plist_file:
+        plist = plistlib.load(plist_file)
+
+    display_name = plist.get("CFBundleDisplayName")
+    bundle_name = plist.get("CFBundleName")
+    fail_if(not display_name, "iOS CFBundleDisplayName is missing.", failures)
+    fail_if(
+        display_name in {"My Web App", "my_web_app"},
+        "iOS CFBundleDisplayName still uses the Flutter placeholder.",
+        failures,
+    )
+    fail_if(not bundle_name, "iOS CFBundleName is missing.", failures)
+    fail_if(
+        bundle_name == "my_web_app",
+        "iOS CFBundleName still uses the Flutter placeholder.",
+        failures,
+    )
+
+    for key in (
+        "NSCameraUsageDescription",
+        "NSPhotoLibraryUsageDescription",
+        "NSMicrophoneUsageDescription",
+    ):
+        value = plist.get(key, "")
+        fail_if(
+            len(value.strip()) < 12,
+            f"iOS {key} is missing a user-facing purpose string.",
+            failures,
+        )
+        fail_if(
+            any(marker in value for marker in MOJIBAKE_MARKERS),
+            f"iOS {key} appears to contain mojibake.",
+            failures,
+        )
+
+    pbxproj = read_text(ROOT / "ios/Runner.xcodeproj/project.pbxproj")
+    bundle_ids = set(re.findall(r"PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);", pbxproj))
+    fail_if(not bundle_ids, "iOS PRODUCT_BUNDLE_IDENTIFIER is missing.", failures)
+    fail_if(
+        any(bundle_id.startswith("com.example") for bundle_id in bundle_ids),
+        "iOS PRODUCT_BUNDLE_IDENTIFIER still uses the com.example placeholder.",
+        failures,
+    )
+
+
+def main() -> int:
+    failures: list[str] = []
+    check_android(failures)
+    check_ios(failures)
+
+    if failures:
+        print("Mobile release readiness check failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("Mobile release readiness check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow for iOS/Android mobile release artifacts.
- Adds a deterministic mobile metadata readiness gate for native app identifiers, labels, iOS usage strings, and placeholder bundle IDs.
- Updates native package metadata from Flutter placeholders to `jp.kanta13.jibun` / `自分株式会社`.
- Documents the simultaneous iOS/Android release runbook and required signing secrets.

## Issue

Closes progress toward #1495.

## Validation

- `python scripts/check_mobile_release_readiness.py`
- `Info.plist` XML parse with PowerShell XML loader
- YAML parse for `.github/workflows/mobile-release-build.yml`
- `git diff --cached --check`
- `flutter pub get --dry-run`

## Known Local Limitation

`flutter build apk --debug --no-tree-shake-icons` cannot complete on this Windows machine because no Android SDK is configured: `No Android SDK found. Try setting the ANDROID_HOME environment variable.` The workflow is intended to run the Android build on GitHub-hosted Ubuntu and the iOS no-codesign archive on GitHub-hosted macOS.