### PR TITLE
[codex] Evaluate Codex goal workflow adoption

### DIFF
--- a/docs/codex-cli-evals/20260501_goal_workflows.md
+++ b/docs/codex-cli-evals/20260501_goal_workflows.md
@@ -1,0 +1,94 @@
+# Codex CLI 0.128.0 `/goal` Workflows Evaluation
+
+Issue: https://github.com/kanta13jp1/my_web_app/issues/1492
+
+Source checked on 2026-05-01:
+
+- OpenAI Codex release `rust-v0.128.0`
+- Local CLI probe: `codex --version` -> `codex-cli 0.126.0-alpha.8`
+- Local CLI probe: `codex --help`
+
+## Decision
+
+**NO-GO for immediate fleet adoption. GO for tracked pilot after Codex CLI upgrade.**
+
+The release is highly relevant to Codex #2 because persisted `/goal` workflows
+map directly to long-running CI, synchronization, Edge Function, and GitHub
+Actions tasks. The local runtime is still older than 0.128.0, so this session
+cannot prove the feature with a live `/goal` run.
+
+## Why It Matters
+
+Codex #2 currently handles work that often spans multiple checks or sessions:
+
+- red CI investigation and reruns,
+- deploy stability and workflow drift,
+- Edge Function dependency and lint repair,
+- scheduled report/watch maintenance,
+- GitHub issue and WBS synchronization.
+
+Those are good candidates for persisted goals because the task state should
+survive pauses, context compaction, and multi-step verification.
+
+## Adoption Gate
+
+Adopt `/goal` workflows only when all of these are true:
+
+- `codex --version` is `0.128.0` or newer on the target Codex instance.
+- `codex --help` exposes `/goal` or the matching app-server goal APIs in the
+  installed runtime.
+- A pilot goal can be paused, resumed, and cleared without losing the linked
+  branch, issue, PR, and validation checklist.
+- A failed or abandoned goal leaves a deterministic handoff in GitHub issue or
+  `docs/cross-instance-prs/`.
+
+## Pilot Candidates
+
+| Candidate | Owner | Fit | Notes |
+| --- | --- | --- | --- |
+| CI failure drain | Codex #2 | High | Keep failing check, log URL, local branch, fix attempt, and rerun status in one persisted goal. |
+| Edge Function dependency audit | Codex #2 | High | Long enough to benefit from pause/resume; deterministic lint/check proof. |
+| Mobile release artifact rollout | Codex #2 | Medium | Useful after Android/iOS signing secrets exist. |
+| Migration collision review | Codex #1 | Medium | Better for Codex #1 unless CI workflow repair is involved. |
+
+## Proposed First Pilot
+
+Use the next failing PR check as the first pilot:
+
+1. Create a `/goal` named `codex2-ci-failure-drain`.
+2. Store PR URL, failing check URL, branch, suspected owner, and next command.
+3. Pause after the first root-cause note.
+4. Resume in a fresh session and verify the state is enough to continue.
+5. Clear the goal only after PR checks pass or a handoff comment is posted.
+
+Success means the resumed session avoids re-reading the whole PR/check context
+and still performs deterministic validation before handoff or merge.
+
+## Workflow/Docs Changes
+
+Implemented in this evaluation PR:
+
+- `scripts/codex_session_check.py` now prints the local Codex CLI version.
+- The same session-start check warns when Codex CLI is older than 0.128.0,
+  because persisted `/goal` workflows are not ready on older runtimes.
+
+Recommended after upgrade:
+
+- Add a short `/goal` usage note to `AGENTS.md` after the runtime is upgraded.
+- Add a scheduled issue comment or WBS update when a persisted goal is older
+  than 24 hours without progress.
+
+## Current Blockers
+
+- Local runtime is `codex-cli 0.126.0-alpha.8`, below the evaluated release.
+- No live `/goal` command was available to prove pause/resume behavior in this
+  session.
+- App-server API integration details should be rechecked after the local CLI
+  upgrade because the feature is new and may change quickly.
+
+## Final Routing
+
+- Keep issue #1492 open until the local Codex #2 runtime is upgraded and one
+  pilot goal is completed.
+- Route upgrade execution and app-server checks to Codex #2.
+- Route broader fleet policy changes to Claude Code after the pilot.

--- a/docs/cross-instance-prs/20260501_codex2_goal_workflows_eval.md
+++ b/docs/cross-instance-prs/20260501_codex2_goal_workflows_eval.md
@@ -52,3 +52,20 @@ OpenAI Codex CLI 0.128.0 (2026-04-30) で **persisted `/goal` workflows** が追
 本 cross-instance-pr は scheduled daily-development が起票 (= AI_FLEET_SYNERGY #3
 Automate Feature Monitoring の end-to-end loop / 自動 issue 起票 → 自動 triage →
 自動 cross-instance-pr 起票 までの完成形 第 1 例)。
+
+## Codex#2 reply (2026-05-01)
+
+Evaluation recorded:
+[`docs/codex-cli-evals/20260501_goal_workflows.md`](../codex-cli-evals/20260501_goal_workflows.md)
+
+Decision: **NO-GO for immediate fleet adoption; GO for a tracked pilot after
+Codex CLI upgrade.**
+
+Reason: local runtime is currently `codex-cli 0.126.0-alpha.8`, while the
+evaluated release is `rust-v0.128.0`. The feature maps well to Codex#2 CI,
+sync, Edge Function, and GitHub Actions work, but this instance cannot prove
+pause/resume/clear behavior until the runtime is upgraded.
+
+Next pilot after upgrade: `codex2-ci-failure-drain` for the next failing PR
+check, with PR URL, check URL, branch, next command, validation status, and
+handoff target persisted in the goal state.

--- a/scripts/codex_session_check.py
+++ b/scripts/codex_session_check.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -35,6 +36,21 @@ def run_git(args: list[str], cwd: Path) -> CommandResult:
         stderr=subprocess.PIPE,
         check=False,
     )
+    return CommandResult(proc.returncode, proc.stdout.strip(), proc.stderr.strip())
+
+
+def run_command(args: list[str], cwd: Path) -> CommandResult:
+    try:
+        proc = subprocess.run(
+            args,
+            cwd=str(cwd),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return CommandResult(127, "", str(exc))
     return CommandResult(proc.returncode, proc.stdout.strip(), proc.stderr.strip())
 
 
@@ -95,6 +111,20 @@ def env_snapshot() -> dict[str, str]:
     return {key: os.environ.get(key, "not-exposed") for key in keys}
 
 
+def codex_cli_version(root: Path) -> str:
+    result = run_command(["codex", "--version"], root)
+    if result.code != 0:
+        return "unavailable"
+    return result.stdout or result.stderr or "unknown"
+
+
+def parse_semver(text: str) -> tuple[int, int, int] | None:
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
 def analyze(cwd: Path) -> dict[str, Any]:
     root = git_root(cwd)
     branch = git_text(["branch", "--show-current"], root, default="detached")
@@ -106,6 +136,7 @@ def analyze(cwd: Path) -> dict[str, Any]:
     dirty_lines = [line for line in dirty.splitlines() if line.strip()]
     remote_url = git_text(["remote", "get-url", "origin"], root, default="unknown")
     worktrees = worktree_entries(root)
+    codex_version = codex_cli_version(root)
 
     warnings: list[str] = []
     if dirty_lines:
@@ -123,6 +154,13 @@ def analyze(cwd: Path) -> dict[str, Any]:
         warnings.append("current branch is a protected base branch")
     if origin_main == "unknown":
         warnings.append("origin/main is unavailable; run git fetch origin main")
+    parsed_codex_version = parse_semver(codex_version)
+    if codex_version == "unavailable":
+        warnings.append("Codex CLI is unavailable on PATH")
+    elif parsed_codex_version and parsed_codex_version < (0, 128, 0):
+        warnings.append(
+            "Codex CLI is older than 0.128.0; persisted `/goal` workflows are not ready"
+        )
 
     return {
         "root": str(root),
@@ -135,6 +173,7 @@ def analyze(cwd: Path) -> dict[str, Any]:
         "dirty_count": len(dirty_lines),
         "dirty_paths": dirty_lines[:20],
         "remote": remote_url,
+        "codex_cli_version": codex_version,
         "worktrees": worktrees,
         "environment": env_snapshot(),
         "warnings": warnings,
@@ -153,6 +192,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         f"- Ahead/behind: `{report['ahead'] if report['ahead'] is not None else '?'} / {report['behind'] if report['behind'] is not None else '?'}`",
         f"- Dirty paths: `{report['dirty_count']}`",
         f"- Remote: `{report['remote']}`",
+        f"- Codex CLI: `{report['codex_cli_version']}`",
         "",
         "## Permission / Sandbox Snapshot",
     ]


### PR DESCRIPTION
## Summary

- Records the Codex #2 evaluation for Codex CLI 0.128.0 persisted `/goal` workflows.
- Adds a GO/NO-GO gate and first pilot candidate for CI failure drain workflows.
- Updates the cross-instance handoff with the Codex #2 reply.
- Extends `scripts/codex_session_check.py` to print the local Codex CLI version and warn when it is below 0.128.0.

## Issue

Progress for #1492.

## Validation

- `codex --version` -> `codex-cli 0.126.0-alpha.8`
- `codex --help`
- `python scripts/codex_session_check.py`
- `python scripts/codex_session_check.py --json`
- `python -m py_compile scripts/codex_session_check.py`
- `git diff --cached --check`

## Decision

NO-GO for immediate fleet adoption because the local runtime is still below 0.128.0. GO for a tracked pilot after Codex CLI is upgraded and `/goal` pause/resume/clear behavior can be proven.