### PR TITLE
feat: add signed MSIX packaging for Windows companion

### DIFF
--- a/.github/workflows/windows-companion-build.yml
+++ b/.github/workflows/windows-companion-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_release:
-        description: 'Publish jibun-windows-companion.zip to GitHub Releases'
+        description: 'Publish Windows Companion artifacts to GitHub Releases'
         required: true
         default: false
         type: boolean
@@ -20,13 +20,16 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: windows-companion-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build-windows:
-    name: Build Windows ZIP
+    name: Build Windows ZIP/MSIX
     runs-on: windows-latest
     timeout-minutes: 45
 
@@ -82,11 +85,36 @@ jobs:
           Compress-Archive -Path (Join-Path $releaseDir '*') -DestinationPath $zipPath -Force
           Get-Item -LiteralPath $zipPath | Select-Object FullName, Length, LastWriteTime
 
+      - name: Package and sign Windows MSIX
+        shell: pwsh
+        env:
+          WINDOWS_MSIX_PFX_BASE64: ${{ secrets.WINDOWS_MSIX_PFX_BASE64 }}
+          WINDOWS_MSIX_PFX_PASSWORD: ${{ secrets.WINDOWS_MSIX_PFX_PASSWORD }}
+          WINDOWS_MSIX_PUBLISHER: ${{ secrets.WINDOWS_MSIX_PUBLISHER }}
+          WINDOWS_MSIX_PUBLISHER_DISPLAY_NAME: ${{ secrets.WINDOWS_MSIX_PUBLISHER_DISPLAY_NAME }}
+        run: |
+          $releaseDir = Join-Path $PWD 'build\windows\x64\runner\Release'
+          $distDir = Join-Path $PWD 'dist'
+          $publisher = if ($env:WINDOWS_MSIX_PUBLISHER) { $env:WINDOWS_MSIX_PUBLISHER } else { 'CN=Jibun Windows Companion' }
+          $publisherDisplayName = if ($env:WINDOWS_MSIX_PUBLISHER_DISPLAY_NAME) { $env:WINDOWS_MSIX_PUBLISHER_DISPLAY_NAME } else { 'Jibun Inc.' }
+          $msixVersion = "1.0.${{ github.run_number }}.${{ github.run_attempt }}"
+          .\tools\windows-companion\msix\New-WindowsCompanionMsix.ps1 `
+            -ReleaseDir $releaseDir `
+            -OutputDir $distDir `
+            -Version $msixVersion `
+            -Publisher $publisher `
+            -PublisherDisplayName $publisherDisplayName `
+            -CertificateBase64 $env:WINDOWS_MSIX_PFX_BASE64 `
+            -CertificatePassword $env:WINDOWS_MSIX_PFX_PASSWORD
+
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v6
         with:
           name: jibun-windows-companion
-          path: dist/jibun-windows-companion.zip
+          path: |
+            dist/jibun-windows-companion.zip
+            dist/jibun-windows-companion.msix
+            dist/jibun-windows-companion.cer
           if-no-files-found: error
           retention-days: 30
 
@@ -99,5 +127,10 @@ jobs:
           body: |
             Windows companion app build for local smart cleanup workflows.
 
-            Download `jibun-windows-companion.zip`, extract it, and run `my_web_app.exe`.
-          files: dist/jibun-windows-companion.zip
+            Prefer `jibun-windows-companion.msix` for installation.
+            If the MSIX is self-signed, import `jibun-windows-companion.cer` into Trusted People first.
+            `jibun-windows-companion.zip` remains available as the portable fallback.
+          files: |
+            dist/jibun-windows-companion.zip
+            dist/jibun-windows-companion.msix
+            dist/jibun-windows-companion.cer

--- a/docs/WINDOWS_COMPANION_APP.md
+++ b/docs/WINDOWS_COMPANION_APP.md
@@ -17,13 +17,48 @@ The executable is created under:
 build\windows\x64\runner\Release\my_web_app.exe
 ```
 
-## Package
+## Portable Package
 
 ```powershell
 New-Item -ItemType Directory -Force -Path build\windows\x64\runner\Release\scripts\SmartCleanup
 Copy-Item tools\windows-companion\SmartCleanup\*.ps1 build\windows\x64\runner\Release\scripts\SmartCleanup -Force
 Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath dist\jibun-windows-companion.zip -Force
 ```
+
+## MSIX Package
+
+MSIX gives the companion app a normal Windows install/update surface. The
+repository builds both:
+
+- `jibun-windows-companion.msix`: signed Windows app package.
+- `jibun-windows-companion.cer`: public certificate for self-signed builds.
+- `jibun-windows-companion.zip`: portable fallback.
+
+Local package command:
+
+```powershell
+.\tools\windows-companion\msix\New-WindowsCompanionMsix.ps1 `
+  -ReleaseDir build\windows\x64\runner\Release `
+  -OutputDir dist `
+  -Version 1.0.0.0 `
+  -Publisher 'CN=Jibun Windows Companion'
+```
+
+For production signing, configure these GitHub repository secrets:
+
+```text
+WINDOWS_MSIX_PFX_BASE64
+WINDOWS_MSIX_PFX_PASSWORD
+WINDOWS_MSIX_PUBLISHER
+WINDOWS_MSIX_PUBLISHER_DISPLAY_NAME
+```
+
+`WINDOWS_MSIX_PUBLISHER` must match the certificate subject, for example
+`CN=Jibun Windows Companion`.
+
+If `WINDOWS_MSIX_PFX_BASE64` is not configured, the workflow creates a
+self-signed certificate and publishes the `.cer` next to the `.msix`. The user
+must trust that certificate before installing the MSIX.
 
 ## Release
 
@@ -36,6 +71,18 @@ The stable download URL used by the web app is:
 
 ```text
 https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.zip
+```
+
+The stable MSIX URL used by the web app is:
+
+```text
+https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.msix
+```
+
+The public certificate URL for self-signed builds is:
+
+```text
+https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.cer
 ```
 
 ## Safety Model

--- a/lib/pages/windows_app_install_page.dart
+++ b/lib/pages/windows_app_install_page.dart
@@ -5,12 +5,18 @@ import '../utils/web_image_downloader.dart';
 class WindowsAppInstallPage extends StatelessWidget {
   const WindowsAppInstallPage({super.key});
 
+  static const latestMsixUrl =
+      'https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.msix';
+  static const latestCertificateUrl =
+      'https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.cer';
   static const latestZipUrl =
       'https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.zip';
   static const workflowUrl =
       'https://github.com/kanta13jp1/my_web_app/actions/workflows/windows-companion-build.yml';
+  static const guideUrl =
+      'https://github.com/kanta13jp1/my_web_app/blob/main/docs/WINDOWS_COMPANION_APP.md';
   static const issueUrl =
-      'https://github.com/kanta13jp1/my_web_app/issues/1493';
+      'https://github.com/kanta13jp1/my_web_app/issues/1498';
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +25,7 @@ class WindowsAppInstallPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Windowsアプリ版'),
+        title: const Text('Windows アプリ版'),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(20),
@@ -36,25 +42,30 @@ class WindowsAppInstallPage extends StatelessWidget {
                   runSpacing: 10,
                   children: [
                     FilledButton.icon(
+                      onPressed: () => openWebUrl(latestMsixUrl),
+                      icon: const Icon(Icons.install_desktop_outlined),
+                      label: const Text('MSIX をインストール'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: () => openWebUrl(latestCertificateUrl),
+                      icon: const Icon(Icons.verified_user_outlined),
+                      label: const Text('証明書を取得'),
+                    ),
+                    OutlinedButton.icon(
                       onPressed: () => openWebUrl(latestZipUrl),
-                      icon: const Icon(Icons.download_for_offline_outlined),
-                      label: const Text('Windows版ZIPをダウンロード'),
+                      icon: const Icon(Icons.archive_outlined),
+                      label: const Text('ZIP 版'),
                     ),
                     OutlinedButton.icon(
                       onPressed: () => openWebUrl(workflowUrl),
                       icon: const Icon(Icons.build_circle_outlined),
-                      label: const Text('ビルド履歴を見る'),
+                      label: const Text('ビルド履歴'),
                     ),
                     OutlinedButton.icon(
                       onPressed: () => Navigator.of(context)
                           .pushNamed('/local-smart-cleanup'),
                       icon: const Icon(Icons.cleaning_services_outlined),
                       label: const Text('スマート整理を開く'),
-                    ),
-                    OutlinedButton.icon(
-                      onPressed: () => openWebUrl(issueUrl),
-                      icon: const Icon(Icons.flag_outlined),
-                      label: const Text('P0 Issue'),
                     ),
                   ],
                 ),
@@ -65,27 +76,30 @@ class WindowsAppInstallPage extends StatelessWidget {
                     const cards = <Widget>[
                       _StepCard(
                         number: '1',
-                        title: 'ZIPを取得',
-                        body: '最新版の配布ZIPをダウンロードします。',
-                        icon: Icons.file_download_outlined,
+                        title: 'MSIX を取得',
+                        body:
+                            '通常は MSIX を使います。Windows のアプリとして登録され、更新管理もしやすくなります。',
+                        icon: Icons.install_desktop_outlined,
                       ),
                       _StepCard(
                         number: '2',
-                        title: '任意フォルダに展開',
-                        body: 'Downloads以外の固定フォルダに展開すると更新管理が安定します。',
-                        icon: Icons.folder_open_outlined,
+                        title: '証明書を信頼',
+                        body:
+                            '自己署名ビルドの場合だけ、同梱の .cer を Trusted People に登録してからインストールします。',
+                        icon: Icons.verified_outlined,
                       ),
                       _StepCard(
                         number: '3',
                         title: 'アプリを起動',
-                        body: '展開先の my_web_app.exe を起動します。',
+                        body:
+                            'インストール後は Jibun Windows Companion としてスタートメニューから起動できます。',
                         icon: Icons.desktop_windows_outlined,
                       ),
                       _StepCard(
                         number: '4',
                         title: '承認して実行',
-                        body: 'スキャン結果を確認し、承認済みの候補だけをローカルで処理します。',
-                        icon: Icons.verified_user_outlined,
+                        body: 'スキャン結果を確認し、承認済みの候補だけをローカルPCで処理します。',
+                        icon: Icons.task_alt_outlined,
                       ),
                     ];
                     if (wide) {
@@ -118,6 +132,15 @@ class WindowsAppInstallPage extends StatelessWidget {
                 const SizedBox(height: 16),
                 _RolePanel(theme: theme),
                 const SizedBox(height: 16),
+                _LinkPanel(
+                  theme: theme,
+                  msixUrl: latestMsixUrl,
+                  certUrl: latestCertificateUrl,
+                  zipUrl: latestZipUrl,
+                  guideUrl: guideUrl,
+                  issueUrl: issueUrl,
+                ),
+                const SizedBox(height: 16),
                 Container(
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
@@ -125,7 +148,7 @@ class WindowsAppInstallPage extends StatelessWidget {
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
-                    '安定ダウンロードURL: $latestZipUrl',
+                    'MSIX が利用できない場合も、ZIP 版を展開して my_web_app.exe を起動できます。',
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: colorScheme.onSurfaceVariant,
                     ),
@@ -183,7 +206,7 @@ class _HeroPanel extends StatelessWidget {
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'Web版ではできないローカルPCのスキャン、承認済み整理、Windowsタスク登録をWindowsアプリ側で実行します。',
+                  'Web 版ではできないローカルPCのスキャン、承認済み整理、Windows タスク登録をアプリ側で実行します。',
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: colorScheme.onSurfaceVariant,
                   ),
@@ -271,16 +294,20 @@ class _RolePanel extends StatelessWidget {
     final colorScheme = theme.colorScheme;
     final rows = <({String label, String body})>[
       (
-        label: 'Web版',
-        body: 'インストール導線、レポート確認、承認CSV編集を担当します。',
+        label: 'MSIX',
+        body: 'Windows にアプリとして登録し、今後の更新や署名検証に乗せる標準配布形式です。',
       ),
       (
-        label: 'Windows版',
-        body: 'ローカルPCのファイル確認とPowerShell実行を担当します。',
+        label: '証明書',
+        body: '本番証明書が未設定の場合は自己署名になります。初回だけ .cer を信頼してから使います。',
+      ),
+      (
+        label: 'ZIP',
+        body: 'インストールが難しい環境向けのポータブル fallback として残しています。',
       ),
       (
         label: 'PowerShell',
-        body: '承認済み候補だけを検証し、ごみ箱移動と結果ログ保存を行います。',
+        body: '承認済み候補だけを検証し、ごみ箱移動と結果ログ保存をローカルで実行します。',
       ),
     ];
 
@@ -295,7 +322,7 @@ class _RolePanel extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            '役割分担',
+            '配布方式',
             style: theme.textTheme.titleMedium?.copyWith(
               fontWeight: FontWeight.w700,
             ),
@@ -344,6 +371,71 @@ class _RoleLine extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _LinkPanel extends StatelessWidget {
+  const _LinkPanel({
+    required this.theme,
+    required this.msixUrl,
+    required this.certUrl,
+    required this.zipUrl,
+    required this.guideUrl,
+    required this.issueUrl,
+  });
+
+  final ThemeData theme;
+  final String msixUrl;
+  final String certUrl;
+  final String zipUrl;
+  final String guideUrl;
+  final String issueUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    final links = <({String label, String url})>[
+      (label: 'MSIX', url: msixUrl),
+      (label: '証明書', url: certUrl),
+      (label: 'ZIP fallback', url: zipUrl),
+      (label: '運用手順', url: guideUrl),
+      (label: 'Issue #1498', url: issueUrl),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'ダウンロードリンク',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 10),
+          for (final link in links)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: InkWell(
+                onTap: () => openWebUrl(link.url),
+                child: Text(
+                  '${link.label}: ${link.url}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.primary,
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/tools/windows-companion/msix/New-WindowsCompanionMsix.ps1
+++ b/tools/windows-companion/msix/New-WindowsCompanionMsix.ps1
@@ -1,0 +1,210 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$ReleaseDir,
+  [Parameter(Mandatory = $true)][string]$OutputDir,
+  [string]$Version = '1.0.0.0',
+  [string]$Publisher = 'CN=Jibun Windows Companion',
+  [string]$PublisherDisplayName = 'Jibun Inc.',
+  [string]$CertificateBase64,
+  [string]$CertificatePassword
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Find-WindowsSdkTool {
+  param([Parameter(Mandatory = $true)][string]$ToolName)
+
+  $roots = @(
+    "${env:ProgramFiles(x86)}\Windows Kits\10\bin",
+    "$env:ProgramFiles\Windows Kits\10\bin"
+  ) | Where-Object { $_ -and (Test-Path -LiteralPath $_) }
+
+  foreach ($root in $roots) {
+    $tool = Get-ChildItem -LiteralPath $root -Recurse -Filter $ToolName -File -ErrorAction SilentlyContinue |
+      Where-Object { $_.FullName -match '\\x64\\' } |
+      Sort-Object FullName -Descending |
+      Select-Object -First 1
+    if ($tool) {
+      return $tool.FullName
+    }
+  }
+
+  throw "$ToolName was not found. Install the Windows 10/11 SDK."
+}
+
+function ConvertTo-MsixVersion {
+  param([Parameter(Mandatory = $true)][string]$RawVersion)
+
+  $parts = $RawVersion.Split('.') | ForEach-Object {
+    $value = 0
+    if ([int]::TryParse($_, [ref]$value)) {
+      [Math]::Min([Math]::Max($value, 0), 65535)
+    } else {
+      0
+    }
+  }
+
+  while ($parts.Count -lt 4) {
+    $parts += 0
+  }
+  return ($parts[0..3] -join '.')
+}
+
+function Escape-XmlText {
+  param([string]$Value)
+
+  return [Security.SecurityElement]::Escape($Value)
+}
+
+function New-ResizedPng {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination,
+    [Parameter(Mandatory = $true)][int]$Width,
+    [Parameter(Mandatory = $true)][int]$Height
+  )
+
+  Add-Type -AssemblyName System.Drawing
+  $sourceImage = [Drawing.Image]::FromFile($Source)
+  $bitmap = New-Object Drawing.Bitmap $Width, $Height
+  $graphics = [Drawing.Graphics]::FromImage($bitmap)
+  try {
+    $graphics.Clear([Drawing.Color]::Transparent)
+    $graphics.InterpolationMode = [Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+    $graphics.SmoothingMode = [Drawing.Drawing2D.SmoothingMode]::HighQuality
+    $graphics.PixelOffsetMode = [Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+    $graphics.DrawImage($sourceImage, 0, 0, $Width, $Height)
+    $bitmap.Save($Destination, [Drawing.Imaging.ImageFormat]::Png)
+  } finally {
+    $graphics.Dispose()
+    $bitmap.Dispose()
+    $sourceImage.Dispose()
+  }
+}
+
+function New-MsixCertificate {
+  param(
+    [Parameter(Mandatory = $true)][string]$Subject,
+    [Parameter(Mandatory = $true)][string]$PfxPath,
+    [Parameter(Mandatory = $true)][string]$CerPath,
+    [Parameter(Mandatory = $true)][securestring]$Password
+  )
+
+  $cert = New-SelfSignedCertificate `
+    -Type Custom `
+    -Subject $Subject `
+    -FriendlyName 'Jibun Windows Companion MSIX Signing' `
+    -KeyAlgorithm RSA `
+    -KeyLength 2048 `
+    -KeyUsage DigitalSignature `
+    -CertStoreLocation 'Cert:\CurrentUser\My' `
+    -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3')
+
+  Export-PfxCertificate -Cert $cert -FilePath $PfxPath -Password $Password | Out-Null
+  Export-Certificate -Cert $cert -FilePath $CerPath | Out-Null
+  Remove-Item -LiteralPath "Cert:\CurrentUser\My\$($cert.Thumbprint)" -Force -ErrorAction SilentlyContinue
+}
+
+$releaseDirResolved = (Resolve-Path -LiteralPath $ReleaseDir).Path
+if (-not (Test-Path -LiteralPath (Join-Path $releaseDirResolved 'my_web_app.exe'))) {
+  throw "my_web_app.exe was not found in release directory: $releaseDirResolved"
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+$outputDirResolved = (Resolve-Path -LiteralPath $OutputDir).Path
+$packageRoot = Join-Path $outputDirResolved 'msix-package'
+$assetsDir = Join-Path $packageRoot 'Assets'
+$msixPath = Join-Path $outputDirResolved 'jibun-windows-companion.msix'
+$cerPath = Join-Path $outputDirResolved 'jibun-windows-companion.cer'
+$pfxPath = Join-Path $outputDirResolved 'jibun-windows-companion-signing.pfx'
+
+Remove-Item -LiteralPath $packageRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $assetsDir | Out-Null
+Copy-Item -Path (Join-Path $releaseDirResolved '*') -Destination $packageRoot -Recurse -Force
+
+$iconSource = Join-Path $PWD 'web\icons\Icon-512.png'
+if (-not (Test-Path -LiteralPath $iconSource)) {
+  $iconSource = Join-Path $PWD 'web\favicon.png'
+}
+if (-not (Test-Path -LiteralPath $iconSource)) {
+  throw 'No source icon was found under web/icons or web/favicon.png.'
+}
+
+New-ResizedPng -Source $iconSource -Destination (Join-Path $assetsDir 'StoreLogo.png') -Width 50 -Height 50
+New-ResizedPng -Source $iconSource -Destination (Join-Path $assetsDir 'Square44x44Logo.png') -Width 44 -Height 44
+New-ResizedPng -Source $iconSource -Destination (Join-Path $assetsDir 'Square71x71Logo.png') -Width 71 -Height 71
+New-ResizedPng -Source $iconSource -Destination (Join-Path $assetsDir 'Square150x150Logo.png') -Width 150 -Height 150
+New-ResizedPng -Source $iconSource -Destination (Join-Path $assetsDir 'Wide310x150Logo.png') -Width 310 -Height 150
+New-ResizedPng -Source $iconSource -Destination (Join-Path $assetsDir 'Square310x310Logo.png') -Width 310 -Height 310
+
+$msixVersion = ConvertTo-MsixVersion -RawVersion $Version
+$manifest = @"
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+  <Identity Name="Kanta13jp1.JibunWindowsCompanion" Publisher="$(Escape-XmlText $Publisher)" Version="$msixVersion" ProcessorArchitecture="x64" />
+  <Properties>
+    <DisplayName>Jibun Windows Companion</DisplayName>
+    <PublisherDisplayName>$(Escape-XmlText $PublisherDisplayName)</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22621.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="ja-jp" />
+    <Resource Language="en-us" />
+  </Resources>
+  <Applications>
+    <Application Id="JibunWindowsCompanion" Executable="my_web_app.exe" EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+        DisplayName="Jibun Windows Companion"
+        Description="Local smart cleanup companion for Jibun App"
+        BackgroundColor="#00897B"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile
+          Square71x71Logo="Assets\Square71x71Logo.png"
+          Wide310x150Logo="Assets\Wide310x150Logo.png"
+          Square310x310Logo="Assets\Square310x310Logo.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>
+"@
+$manifest | Set-Content -LiteralPath (Join-Path $packageRoot 'AppxManifest.xml') -Encoding UTF8
+
+$makeAppx = Find-WindowsSdkTool -ToolName 'makeappx.exe'
+$signTool = Find-WindowsSdkTool -ToolName 'signtool.exe'
+& $makeAppx pack /d $packageRoot /p $msixPath /overwrite
+if ($LASTEXITCODE -ne 0) {
+  throw "makeappx failed with exit code $LASTEXITCODE"
+}
+
+$plainPassword = if ($CertificatePassword) { $CertificatePassword } else { [guid]::NewGuid().ToString('N') }
+$securePassword = ConvertTo-SecureString -String $plainPassword -AsPlainText -Force
+if ($CertificateBase64) {
+  [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($CertificateBase64))
+  $cert = New-Object Security.Cryptography.X509Certificates.X509Certificate2
+  $cert.Import($pfxPath, $plainPassword, 'Exportable')
+  [IO.File]::WriteAllBytes($cerPath, $cert.Export([Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+} else {
+  New-MsixCertificate -Subject $Publisher -PfxPath $pfxPath -CerPath $cerPath -Password $securePassword
+}
+
+& $signTool sign /fd SHA256 /f $pfxPath /p $plainPassword $msixPath
+if ($LASTEXITCODE -ne 0) {
+  throw "signtool failed with exit code $LASTEXITCODE"
+}
+
+Remove-Item -LiteralPath $pfxPath -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $packageRoot -Recurse -Force -ErrorAction SilentlyContinue
+
+Get-Item -LiteralPath $msixPath, $cerPath | Select-Object FullName, Length, LastWriteTime


### PR DESCRIPTION
﻿## Summary
- package the Windows Companion app as a signed MSIX in addition to the existing portable ZIP
- add a PowerShell MSIX packaging script that uses Windows SDK makeappx/signtool and supports production PFX secrets
- update the `/windows-app` install page and docs with MSIX, certificate, and ZIP fallback download paths

## Release behavior
- `WINDOWS_MSIX_PFX_BASE64` + `WINDOWS_MSIX_PFX_PASSWORD` can be set for a trusted signing certificate
- without those secrets, CI creates a self-signed `.cer` alongside the `.msix` so local installation can still be validated
- ZIP remains available for portable use

Closes #1498

## Validation
- `dart analyze lib\pages\windows_app_install_page.dart lib\windows_companion_main.dart`
- PowerShell parse check for `tools\windows-companion\msix\New-WindowsCompanionMsix.ps1`
- local `flutter build windows --release --no-tree-shake-icons --target lib\windows_companion_main.dart` produced `my_web_app.exe`
- local MSIX package/sign run produced `jibun-windows-companion.msix` and `jibun-windows-companion.cer`
- local ZIP package run produced `jibun-windows-companion.zip`
