### PR TITLE
Fix mobile release artifact build dependencies

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,7 +7,6 @@ import Foundation
 
 import app_links
 import audioplayers_darwin
-import device_info_plus
 import file_picker
 import file_selector_macos
 import flutter_local_notifications
@@ -22,7 +21,6 @@ import url_launcher_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
-  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -345,22 +345,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
-  device_info_plus:
-    dependency: "direct main"
-    description:
-      name: device_info_plus
-      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
-      url: "https://pub.dev"
-    source: hosted
-    version: "12.4.0"
-  device_info_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: device_info_plus_platform_interface
-      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.3"
   equatable:
     dependency: transitive
     description:
@@ -711,14 +695,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
-  image_gallery_saver:
-    dependency: "direct main"
-    description:
-      name: image_gallery_saver
-      sha256: "0aba74216a4d9b0561510cb968015d56b701ba1bd94aace26aacdd8ae5761816"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
   image_picker:
     dependency: "direct main"
     description:
@@ -1697,14 +1673,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
-  win32_registry:
-    dependency: transitive
-    description:
-      name: win32_registry
-      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   wkt_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,13 +35,11 @@ dependencies:
   cross_file: ^0.3.4+2             # 共有ファイルラッパー
   share_plus: ^12.0.1              # 共有（SNS/共有シート）
   path_provider: ^2.1.5            # 保存先パス取得
-  image_gallery_saver: ^2.0.3      # ギャラリーへ保存
 
   logger: ^2.0.2                   # ログ出力
   timeago: ^3.7.0                  # 相対時刻表示（例: 3分前）
   fl_chart: ^1.0.0                 # グラフ描画
   package_info_plus: ^8.0.0        # アプリ情報（バージョン等）
-  device_info_plus: ^12.4.0        # デバイス情報
   uuid: ^4.3.3                     # UUID生成
   image_picker: ^1.2.2
   google_generative_ai: ^0.4.7


### PR DESCRIPTION
## Summary
- remove unused `image_gallery_saver` and `device_info_plus` direct dependencies that break the first mobile artifact workflow run
- refresh the macOS generated plugin registrant after dependency removal
- keep the mobile release workflow unchanged and let the existing artifact jobs prove Android/iOS builds on Actions

## Issue

Progress toward #1495.

## Failed Run Addressed

- Workflow dispatch run `25200326211` failed because:
  - Android AAB hit `image_gallery_saver` without an AGP namespace
  - iOS no-codesign build hit `device_info_plus` using `isiOSAppOnVision` unavailable to the runner SDK

## Validation

- `python scripts/check_mobile_release_readiness.py`
- `flutter pub get --dry-run`
- `flutter analyze`