### PR TITLE
fix: point Windows installer links at release tag

### DIFF
--- a/docs/WINDOWS_COMPANION_APP.md
+++ b/docs/WINDOWS_COMPANION_APP.md
@@ -70,19 +70,19 @@ Run the `Build Windows Companion App` workflow from GitHub Actions.
 The stable download URL used by the web app is:
 
 ```text
-https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.zip
+https://github.com/kanta13jp1/my_web_app/releases/download/windows-companion-latest/jibun-windows-companion.zip
 ```
 
 The stable MSIX URL used by the web app is:
 
 ```text
-https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.msix
+https://github.com/kanta13jp1/my_web_app/releases/download/windows-companion-latest/jibun-windows-companion.msix
 ```
 
 The public certificate URL for self-signed builds is:
 
 ```text
-https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.cer
+https://github.com/kanta13jp1/my_web_app/releases/download/windows-companion-latest/jibun-windows-companion.cer
 ```
 
 ## Safety Model

--- a/lib/pages/windows_app_install_page.dart
+++ b/lib/pages/windows_app_install_page.dart
@@ -6,11 +6,11 @@ class WindowsAppInstallPage extends StatelessWidget {
   const WindowsAppInstallPage({super.key});
 
   static const latestMsixUrl =
-      'https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.msix';
+      'https://github.com/kanta13jp1/my_web_app/releases/download/windows-companion-latest/jibun-windows-companion.msix';
   static const latestCertificateUrl =
-      'https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.cer';
+      'https://github.com/kanta13jp1/my_web_app/releases/download/windows-companion-latest/jibun-windows-companion.cer';
   static const latestZipUrl =
-      'https://github.com/kanta13jp1/my_web_app/releases/latest/download/jibun-windows-companion.zip';
+      'https://github.com/kanta13jp1/my_web_app/releases/download/windows-companion-latest/jibun-windows-companion.zip';
   static const workflowUrl =
       'https://github.com/kanta13jp1/my_web_app/actions/workflows/windows-companion-build.yml';
   static const guideUrl =


### PR DESCRIPTION
﻿## Summary
- point Windows Companion installer links at the dedicated `windows-companion-latest` release tag
- avoid GitHub `releases/latest` redirecting to unrelated app releases

## Validation
- `dart analyze lib\pages\windows_app_install_page.dart lib\windows_companion_main.dart`
- `curl -I -L` for the MSIX and CER tag-specific download URLs returns 200 OK
