### PR TITLE
Fix mobile artifact CI build modes

### DIFF
--- a/.github/workflows/mobile-release-build.yml
+++ b/.github/workflows/mobile-release-build.yml
@@ -148,7 +148,7 @@ jobs:
           retention-days: 30
 
   ios-no-codesign:
-    name: iOS No-Codesign Archive
+    name: iOS Simulator CI Artifact
     needs: metadata-check
     if: github.event_name != 'pull_request'
     runs-on: macos-15
@@ -185,25 +185,25 @@ jobs:
       - name: Check mobile release metadata
         run: python scripts/check_mobile_release_readiness.py
 
-      - name: Build iOS app without code signing
+      - name: Build iOS simulator app
         run: >
-          flutter build ios --release --no-codesign --no-tree-shake-icons
+          flutter build ios --simulator --debug
           --build-name "$BUILD_NAME"
           --build-number "$BUILD_NUMBER"
 
-      - name: Package iOS app bundle
+      - name: Package iOS simulator app bundle
         shell: bash
         run: |
           mkdir -p dist/ios
-          test -d build/ios/iphoneos/Runner.app
-          ditto -c -k --sequesterRsrc --keepParent build/ios/iphoneos/Runner.app dist/ios/jibun-ios-runner-no-codesign.zip
-          ls -lh dist/ios/jibun-ios-runner-no-codesign.zip
+          test -d build/ios/iphonesimulator/Runner.app
+          ditto -c -k --sequesterRsrc --keepParent build/ios/iphonesimulator/Runner.app dist/ios/jibun-ios-runner-simulator-debug.zip
+          ls -lh dist/ios/jibun-ios-runner-simulator-debug.zip
 
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v6
         with:
-          name: jibun-ios-runner-no-codesign
-          path: dist/ios/jibun-ios-runner-no-codesign.zip
+          name: jibun-ios-runner-simulator-debug
+          path: dist/ios/jibun-ios-runner-simulator-debug.zip
           if-no-files-found: error
           retention-days: 30
 
@@ -232,10 +232,10 @@ jobs:
             Mobile release artifacts for iOS and Android.
 
             - Android: `jibun-android-release.aab`
-            - iOS: `jibun-ios-runner-no-codesign.zip`
+            - iOS: `jibun-ios-runner-simulator-debug.zip`
 
-            The iOS artifact is intentionally not code signed. Use the checklist in
-            `docs/MOBILE_SIMULTANEOUS_RELEASE.md` before TestFlight upload.
+            The iOS artifact is a simulator debug build for CI verification. Use the
+            checklist in `docs/MOBILE_SIMULTANEOUS_RELEASE.md` before TestFlight upload.
           files: |
             dist/jibun-android-release.aab
-            dist/jibun-ios-runner-no-codesign.zip
+            dist/jibun-ios-runner-simulator-debug.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.5.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 
 include ":app"

--- a/docs/MOBILE_SIMULTANEOUS_RELEASE.md
+++ b/docs/MOBILE_SIMULTANEOUS_RELEASE.md
@@ -44,14 +44,14 @@ git push origin mobile-v1.0.0
 Artifacts:
 
 - Android AAB: `jibun-android-release.aab`
-- iOS no-codesign app bundle zip: `jibun-ios-runner-no-codesign.zip`
+- iOS simulator CI app bundle zip: `jibun-ios-runner-simulator-debug.zip`
 
 The Android artifact is Play-upload ready only when the Android signing secrets
 are configured. Without those secrets, the workflow deliberately falls back to a
-debug-signed release artifact for build verification only. The iOS artifact
-proves the Flutter/Xcode build but is not a TestFlight-ready IPA. A signed
-archive still needs Apple Developer team, provisioning profile, certificate, and
-App Store Connect API key.
+debug-signed release artifact for build verification only. The iOS artifact is
+a simulator debug build that proves the Flutter/Xcode build path without Apple
+Developer credentials. A TestFlight-ready IPA still needs Apple Developer team,
+provisioning profile, certificate, and App Store Connect API key.
 
 ## Required Secrets Before Store Distribution
 
@@ -77,7 +77,7 @@ iOS / TestFlight:
 - [ ] Confirm app display name, icon, splash, screenshots, and store category.
 - [ ] Run `python scripts/check_mobile_release_readiness.py`.
 - [ ] Run Android AAB workflow and keep the artifact.
-- [ ] Run iOS no-codesign workflow and keep the artifact.
+- [ ] Run iOS simulator CI workflow and keep the artifact.
 - [ ] Configure Android signing and Google Play internal testing upload.
 - [ ] Configure iOS signing and TestFlight upload.
 - [ ] Verify Supabase redirect URLs, Google login, deep links, and notification permissions.
@@ -88,9 +88,10 @@ iOS / TestFlight:
 
 - Local Windows validation cannot run Android builds until `ANDROID_HOME` points
   to an installed Android SDK.
-- This branch adds no-codesign iOS archive automation. TestFlight upload needs
-  Apple signing material and should be wired after the developer account values
-  are confirmed.
+- The iOS workflow currently creates a simulator debug artifact so CI can prove
+  the Flutter/Xcode build without Apple signing material. TestFlight upload
+  needs Apple signing material and should be wired after the developer account
+  values are confirmed.
 - If the full `lib/main.dart` mobile build fails in GitHub Actions because of
   web-only imports, route the code split to Codex #1. Codex #2 should keep the
   workflow green by adding a mobile-safe target only after Claude Code confirms


### PR DESCRIPTION
## Summary
- upgrade Android Gradle Plugin to 8.6.0 and Kotlin Gradle Plugin to 2.2.0 for `share_plus` / Kotlin 2.2 metadata compatibility
- change the unsigned iOS CI artifact from a device Release build to a simulator Debug build that does not require Apple Developer Team signing
- update the simultaneous mobile release runbook and release asset names to match the CI-verifiable iOS artifact

## Issue

Progress toward #1495.

## Failed Run Addressed

- Follow-up workflow dispatch run `25200754856` failed because:
  - Android hit Kotlin metadata 2.2.0 with Kotlin Gradle Plugin 1.9.24
  - iOS no-codesign device Release still required a Development Team on the GitHub macOS runner

## Validation

- `python scripts/check_mobile_release_readiness.py`
- `flutter pub get --dry-run`
- YAML parse for `.github/workflows/mobile-release-build.yml`
- `flutter analyze`