### PR TITLE
Fix Android Sentry Kotlin release build

### DIFF
--- a/.github/workflows/mobile-release-build.yml
+++ b/.github/workflows/mobile-release-build.yml
@@ -10,6 +10,15 @@ on:
       - 'docs/MOBILE_SIMULTANEOUS_RELEASE.md'
   workflow_dispatch:
     inputs:
+      platform:
+        description: 'Artifacts to build'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - android
+          - ios
       build_name:
         description: 'Flutter build name, for example 1.0.0'
         required: false
@@ -60,7 +69,9 @@ jobs:
   android-aab:
     name: Android AAB
     needs: metadata-check
-    if: github.event_name != 'pull_request'
+    if: >
+      github.event_name != 'pull_request' &&
+      (github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'android')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -150,7 +161,9 @@ jobs:
   ios-no-codesign:
     name: iOS Simulator CI Artifact
     needs: metadata-check
-    if: github.event_name != 'pull_request'
+    if: >
+      github.event_name != 'pull_request' &&
+      (github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'ios')
     runs-on: macos-15
     timeout-minutes: 60
 
@@ -213,7 +226,9 @@ jobs:
       - android-aab
       - ios-no-codesign
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/mobile-v') || inputs.publish_release == true
+    if: >
+      (startsWith(github.ref, 'refs/tags/mobile-v') || inputs.publish_release == true) &&
+      (github.event_name == 'push' || inputs.platform == 'all')
     timeout-minutes: 10
 
     steps:

--- a/docs/MOBILE_SIMULTANEOUS_RELEASE.md
+++ b/docs/MOBILE_SIMULTANEOUS_RELEASE.md
@@ -29,6 +29,17 @@ Manual build:
 
 ```powershell
 gh workflow run mobile-release-build.yml `
+  -f platform=all `
+  -f build_name=1.0.0 `
+  -f build_number=1 `
+  -f publish_release=false
+```
+
+Android-only build while iOS native route split is pending:
+
+```powershell
+gh workflow run mobile-release-build.yml `
+  -f platform=android `
   -f build_name=1.0.0 `
   -f build_number=1 `
   -f publish_release=false

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -784,18 +784,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
-  jni_flutter:
-    dependency: transitive
-    description:
-      name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
+    version: "0.14.2"
   json_annotation:
     dependency: transitive
     description:
@@ -1008,10 +1000,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1216,18 +1208,18 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "599701ca0693a74da361bc780b0752e1abc98226cf5095f6b069648116c896bb"
+      sha256: "1f78300740739ff4b4920802687879231554350eab73eb229778f463aabda440"
       url: "https://pub.dev"
     source: hosted
-    version: "8.14.2"
+    version: "9.19.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "5ba2cf40646a77d113b37a07bd69f61bb3ec8a73cbabe5537b05a7c89d2656f8"
+      sha256: "168bbb120f7684dee6c0e100817f56ee1925bc2eb7fa55a71253337640c7e241"
       url: "https://pub.dev"
     source: hosted
-    version: "8.14.2"
+    version: "9.19.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   flutter_secure_storage: ^10.0.0
   pdf: ^3.11.1                     # PDF生成 (選挙KPIレポート出力)
   printing: ^5.13.2                # PDF印刷 (選挙KPIレポート出力)
-  sentry_flutter: ^8.14.2
+  sentry_flutter: ^9.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- upgrade `sentry_flutter` / `sentry` to 9.19.0 so Android release builds are not stuck on Sentry's older Kotlin language settings
- add a `platform` workflow_dispatch input (`all`, `android`, `ios`) so Android AAB can be verified independently while #1505 handles the iOS/web-only route split
- document the Android-only artifact run path in the mobile release runbook

## Issues

Progress toward #1495.
Closes #1504 if Android-only workflow_dispatch passes after merge.

## Failed Run Addressed

- Workflow dispatch run `25201247124` failed in Android `:sentry_flutter:compileReleaseKotlin` with `Language version 1.6 is no longer supported`.
- The same run also confirmed iOS remains blocked by #1505, so this PR separates Android verification from iOS verification.

## Validation

- `python scripts/check_mobile_release_readiness.py`
- `flutter pub get --dry-run`
- YAML parse for `.github/workflows/mobile-release-build.yml`
- `flutter analyze`