### PR TITLE
[codex] Fix production WBS migration duplicate handling

### DIFF
--- a/supabase/migrations/20260426122000_wbs_krisp_audio_quality_requests.sql
+++ b/supabase/migrations/20260426122000_wbs_krisp_audio_quality_requests.sql
@@ -16,7 +16,39 @@
 -- - dart analyze lib/main.dart lib/data/home_tool_catalog.dart
 --   => no issues.
 
-update public.wbs_tasks
+-- Some environments already have Codex-owned rows for these GitHub issues from
+-- earlier WBS syncs. Keep one row per title before setting instance='codex' so
+-- the unique index on (title, instance) stays satisfied during repair re-runs.
+drop table if exists pg_temp.wbs_krisp_completed_titles;
+create temp table wbs_krisp_completed_titles on commit drop as
+select distinct title
+from public.wbs_tasks
+where github_issue_number in (752, 753, 754);
+
+delete from public.wbs_tasks t
+using (
+  select id
+  from (
+    select
+      candidate.id,
+      row_number() over (
+        partition by candidate.title
+        order by
+          case when candidate.instance = 'codex' then 0 else 1 end,
+          candidate.created_at asc,
+          candidate.id
+      ) as keep_rank
+    from public.wbs_tasks candidate
+    join wbs_krisp_completed_titles target
+      on target.title = candidate.title
+    where candidate.github_issue_number in (752, 753, 754)
+       or candidate.instance = 'codex'
+  ) ranked
+  where keep_rank > 1
+) duplicate
+where t.id = duplicate.id;
+
+update public.wbs_tasks as task
 set
   instance = 'codex',
   owner_instance = 'codex',
@@ -34,9 +66,43 @@ set
       E'\n\nDone 2026-04-26: Codex added Krisp audio quality cockpit. The route /krisp-audio-quality and Home entry now cover remote meetings, podcast/Tech Talk recording, and investor/client call quality with KGI/CSF/KPI, checklists, risks, and official Krisp reference links.'
   end,
   updated_at = now()
-where github_issue_number in (752, 753, 754);
+from wbs_krisp_completed_titles target
+where task.title = target.title
+  and (
+    task.github_issue_number in (752, 753, 754)
+    or task.instance = 'codex'
+  );
 
-update public.wbs_tasks
+drop table if exists pg_temp.wbs_krisp_sdk_titles;
+create temp table wbs_krisp_sdk_titles on commit drop as
+select distinct title
+from public.wbs_tasks
+where github_issue_number = 755;
+
+delete from public.wbs_tasks t
+using (
+  select id
+  from (
+    select
+      candidate.id,
+      row_number() over (
+        partition by candidate.title
+        order by
+          case when candidate.instance = 'codex' then 0 else 1 end,
+          candidate.created_at asc,
+          candidate.id
+      ) as keep_rank
+    from public.wbs_tasks candidate
+    join wbs_krisp_sdk_titles target
+      on target.title = candidate.title
+    where candidate.github_issue_number = 755
+       or candidate.instance = 'codex'
+  ) ranked
+  where keep_rank > 1
+) duplicate
+where t.id = duplicate.id;
+
+update public.wbs_tasks as task
 set
   instance = 'codex',
   owner_instance = 'codex',
@@ -54,4 +120,9 @@ set
       E'\n\nProgress 2026-04-26: Codex added Krisp SDK readiness planning to /krisp-audio-quality. Actual SDK embedding remains open until Krisp SDK credentials, model delivery, and WebRTC/Web Audio integration constraints are confirmed.'
   end,
   updated_at = now()
-where github_issue_number = 755;
+from wbs_krisp_sdk_titles target
+where task.title = target.title
+  and (
+    task.github_issue_number = 755
+    or task.instance = 'codex'
+  );


### PR DESCRIPTION
## Summary
- Fixes #1507.
- Makes `20260426122000_wbs_krisp_audio_quality_requests.sql` tolerant of already-synced Codex WBS rows before reassigning the Krisp issues to `instance = 'codex'`.
- Keeps one row per WBS title and updates the retained row, preventing `wbs_tasks_title_instance_unique` collisions during production migration repair reruns.

## Validation
- `git diff --check`
- `python scripts/check_migration_timestamps.py`
- `python scripts/check_migration_time_relative_check.py`

## Notes
- `supabase db lint --local --fail-on error` could not run because the local Postgres service on `127.0.0.1:54322` is not running in this VSCode instance.