### PR TITLE
[codex] Fix Tome WBS migration duplicate handling

### DIFF
--- a/supabase/migrations/20260426143500_wbs_reaffirm_tome_codex_owner.sql
+++ b/supabase/migrations/20260426143500_wbs_reaffirm_tome_codex_owner.sql
@@ -3,9 +3,46 @@
 -- These tasks were implemented by Codex in this session. Some external syncs can
 -- rewrite instance from closed GitHub state; keep the WBS owner accurate.
 
-update public.wbs_tasks
+-- Production may already have Codex-owned rows with the same title from earlier
+-- WBS syncs. Collapse those duplicates before reaffirming Codex ownership so
+-- the (title, instance) unique index does not fail during migration repair.
+drop table if exists pg_temp.wbs_tome_completed_titles;
+create temp table wbs_tome_completed_titles on commit drop as
+select distinct title
+from public.wbs_tasks
+where github_issue_number in (756, 757, 758);
+
+delete from public.wbs_tasks t
+using (
+  select id
+  from (
+    select
+      candidate.id,
+      row_number() over (
+        partition by candidate.title
+        order by
+          case when candidate.instance = 'codex' then 0 else 1 end,
+          candidate.created_at asc,
+          candidate.id
+      ) as keep_rank
+    from public.wbs_tasks candidate
+    join wbs_tome_completed_titles target
+      on target.title = candidate.title
+    where candidate.github_issue_number in (756, 757, 758)
+       or candidate.instance = 'codex'
+  ) ranked
+  where keep_rank > 1
+) duplicate
+where t.id = duplicate.id;
+
+update public.wbs_tasks as task
 set
   instance = 'codex',
   owner_instance = 'codex',
   updated_at = now()
-where github_issue_number in (756, 757, 758);
+from wbs_tome_completed_titles target
+where task.title = target.title
+  and (
+    task.github_issue_number in (756, 757, 758)
+    or task.instance = 'codex'
+  );


### PR DESCRIPTION
## Summary
- Fixes #1511.
- Makes `20260426143500_wbs_reaffirm_tome_codex_owner.sql` idempotent when production already has Codex-owned WBS rows for Tome issues 756-758.
- Collapses duplicate title candidates before reaffirming `instance = 'codex'` to avoid `wbs_tasks_title_instance_unique` failures.

## Validation
- `git diff --check`
- `python scripts/check_migration_timestamps.py`
- `python scripts/check_migration_time_relative_check.py`

## Notes
- This follows the same production-safe pattern that let `20260426122000_wbs_krisp_audio_quality_requests.sql` pass in deploy run `25202344704` before the Tome migration surfaced.