### PR TITLE
fix: harden repaired WBS migrations

### DIFF
--- a/supabase/migrations/20260426143500_wbs_reaffirm_tome_codex_owner.sql
+++ b/supabase/migrations/20260426143500_wbs_reaffirm_tome_codex_owner.sql
@@ -2,10 +2,48 @@
 --
 -- These tasks were implemented by Codex in this session. Some external syncs can
 -- rewrite instance from closed GitHub state; keep the WBS owner accurate.
+--
+-- Production may already contain Codex-owned rows for these titles from earlier
+-- WBS syncs. Keep one row per title before setting instance='codex' so the
+-- unique index on (title, instance) stays satisfied during repair re-runs.
 
-update public.wbs_tasks
+drop table if exists pg_temp.wbs_tome_codex_titles;
+create temp table wbs_tome_codex_titles on commit drop as
+select distinct title
+from public.wbs_tasks
+where github_issue_number in (756, 757, 758);
+
+delete from public.wbs_tasks t
+using (
+  select id
+  from (
+    select
+      candidate.id,
+      row_number() over (
+        partition by candidate.title
+        order by
+          case when candidate.instance = 'codex' then 0 else 1 end,
+          candidate.created_at asc,
+          candidate.id
+      ) as keep_rank
+    from public.wbs_tasks candidate
+    join wbs_tome_codex_titles target
+      on target.title = candidate.title
+    where candidate.github_issue_number in (756, 757, 758)
+       or candidate.instance = 'codex'
+  ) ranked
+  where keep_rank > 1
+) duplicate
+where t.id = duplicate.id;
+
+update public.wbs_tasks as task
 set
   instance = 'codex',
   owner_instance = 'codex',
   updated_at = now()
-where github_issue_number in (756, 757, 758);
+from wbs_tome_codex_titles target
+where task.title = target.title
+  and (
+    task.github_issue_number in (756, 757, 758)
+    or task.instance = 'codex'
+  );

--- a/supabase/migrations/20260427004000_wbs_codex_life_ai_operating_loop.sql
+++ b/supabase/migrations/20260427004000_wbs_codex_life_ai_operating_loop.sql
@@ -18,7 +18,7 @@ DELETE FROM public.wbs_tasks
 WHERE id = 'a4a5b0db-2e0b-401d-abc3-0c1c8d7154f0'::uuid
   AND instance = 'codex'
   AND owner_instance = 'codex'
-  AND title LIKE '???AI%';
+  AND title LIKE '%AI%';
 
 INSERT INTO public.wbs_tasks (
   category,
@@ -39,10 +39,10 @@ INSERT INTO public.wbs_tasks (
 )
 VALUES (
   'AI Strategy',
-  '🤖',
+  'AI',
   15,
-  '全機能AI連携・ライフ浪費ゼロ運用ループ',
-  'Codex担当。既存の全機能AI戦略モニタとライフ浪費ゼロ司令塔を活かし、今日の1手・拡張しない条件・毎日のKGI/CSF/KPI再計算をUIに接続した。',
+  'Life AI operating loop and waste-zero runbook',
+  'Codex applied the existing cross-feature AI strategy monitor and life-waste service to expose one daily operating action, no-expansion guardrails, and recurring KGI/CSF/KPI review without adding a duplicate dashboard.',
   'codex',
   'codex',
   'completed',


### PR DESCRIPTION
﻿## Summary
- Fixes #1511.
- Makes `20260426143500_wbs_reaffirm_tome_codex_owner.sql` idempotent when production already has Codex-owned Tome WBS rows for issue #756-#758.
- Normalizes `20260427004000_wbs_codex_life_ai_operating_loop.sql` to ASCII-safe SQL values so the repaired migration chain does not stop at the next statement.

## Root Cause
The production deploy failed while re-running repaired WBS migrations:

```text
Applying migration 20260426143500_wbs_reaffirm_tome_codex_owner.sql...
ERROR: duplicate key value violates unique constraint "wbs_tasks_title_instance_unique"
Key (title, instance)=([Issue #756] [追加要望] 【Tome】プレゼン資料の自動生成（投資家向け / 社内報告）, codex) already exists.
```

## Validation
- `git diff --check`
- `python scripts/check_migration_timestamps.py`
- `python scripts/check_migration_time_relative_check.py`
- `supabase db query --linked --output table --file <temp rollback file>` with:
  - `20260426143500_wbs_reaffirm_tome_codex_owner.sql`
  - `20260427004000_wbs_codex_life_ai_operating_loop.sql`
  - wrapped in `begin; ... rollback;`

## Operation Note
This follows the NotebookLM Harness Engineering direction for the 12-instance flow: treat CI/deploy failures as deterministic guardrail feedback, verify the fix against the real linked environment with rollback, then ship through PR/deploy automation.

Closes #1511
