### PR TITLE
[codex] Guard GitHub Actions Node runtime floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,10 @@ jobs:
           fi
         continue-on-error: false  # migration 構文エラーはCIブロック
 
+      - name: Check GitHub Actions Node runtime floor
+        run: python scripts/check_github_actions_node_runtime.py
+        continue-on-error: false
+
       - name: Check formatting
         # #1372: treat Dart formatting as a required static-analysis gate.
         run: dart format --output=none --set-exit-if-changed .

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -138,6 +138,20 @@ jobs:
           fi
           echo "📦 pubspec.yaml 未固定パッケージ: ${UNCONSTRAINED_COUNT}件 (${UNCONSTRAINED})"
 
+      - name: Check GitHub Actions Node runtime floor
+        id: gha_node_runtime
+        run: |
+          echo "" >> /tmp/audit_report.txt
+          echo "## GitHub Actions Node runtime floor" >> /tmp/audit_report.txt
+          if python scripts/check_github_actions_node_runtime.py | tee /tmp/gha-node-runtime.txt; then
+            echo "OK: Node.js 24 runner transition floor satisfied." >> /tmp/audit_report.txt
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+          else
+            cat /tmp/gha-node-runtime.txt >> /tmp/audit_report.txt
+            echo "status=fail" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
       - name: Record to schedule_task_runs
         if: always()
         run: |

--- a/.github/workflows/mobile-release-build.yml
+++ b/.github/workflows/mobile-release-build.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: '17'

--- a/docs/automation/dependency-update-automation.md
+++ b/docs/automation/dependency-update-automation.md
@@ -30,6 +30,12 @@ The production Firebase Hosting deployment no longer depends on `FirebaseExtende
 
 Production deploy now installs and runs `firebase-tools@latest` through Node.js 24 with the same service account secret used before. This keeps the deployment path aligned with the Node.js 24 transition while preserving the existing post-deploy version verification.
 
+## GitHub Actions Runtime Guard
+
+Mobile release builds use `actions/setup-java@v5` so Android artifact jobs no longer emit the Node.js 20 runtime deprecation warning observed in run `25201820274`.
+
+`scripts/check_github_actions_node_runtime.py` is wired into CI and the weekly Dependency Audit workflow. It blocks regressions to action majors known to be below this repository's Node.js 24 transition floor, including `actions/setup-java@v4`. A scheduled Dependency Audit failure is routed through `workflow-failure-handler.yml`, which creates a GitHub Issue for follow-up.
+
 ## Agent Workflow Notes
 
 - Codex #2 owns small, low-risk automation fixes such as Dependabot coverage, workflow runtime updates, and CI/deploy maintenance.

--- a/scripts/check_github_actions_node_runtime.py
+++ b/scripts/check_github_actions_node_runtime.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Guard GitHub Actions against known Node.js runtime deprecation floors.
+
+GitHub Actions is moving JavaScript actions from Node.js 20 to Node.js 24.
+This check catches regressions to action majors that are known to trigger the
+Node.js 20 runner deprecation warning in this repository.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+WORKFLOW_DIR = Path(".github/workflows")
+
+MIN_ACTION_MAJOR = {
+    "actions/checkout": 6,
+    "actions/setup-node": 6,
+    "actions/setup-python": 6,
+    "actions/setup-java": 5,
+    "actions/upload-artifact": 6,
+    "actions/download-artifact": 6,
+    "actions/github-script": 9,
+}
+
+USES_RE = re.compile(
+    r"^\s*uses:\s*(?P<action>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@"
+    r"(?P<ref>v?(?P<major>\d+)(?:[.\w-]*)?)\s*(?:#.*)?$"
+)
+
+
+def main() -> int:
+    if not WORKFLOW_DIR.exists():
+        print(f"workflow directory not found: {WORKFLOW_DIR}", file=sys.stderr)
+        return 1
+
+    violations: list[str] = []
+    checked = 0
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            match = USES_RE.match(line)
+            if not match:
+                continue
+
+            action = match.group("action")
+            minimum_major = MIN_ACTION_MAJOR.get(action)
+            if minimum_major is None:
+                continue
+
+            checked += 1
+            major = int(match.group("major"))
+            if major < minimum_major:
+                violations.append(
+                    f"{path}:{line_number}: {action}@{match.group('ref')} "
+                    f"must be >= v{minimum_major} for the Node.js 24 runner transition"
+                )
+
+    if violations:
+        print("GitHub Actions Node runtime floor violations:")
+        for violation in violations:
+            print(f"- {violation}")
+        return 1
+
+    print(f"OK: checked {checked} GitHub Actions runtime-sensitive uses")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Fixes #1508.
- Upgrades the mobile Android artifact workflow from `actions/setup-java@v4` to `actions/setup-java@v5`.
- Adds `scripts/check_github_actions_node_runtime.py` and wires it into CI plus weekly Dependency Audit so old action majors are caught before Node.js 20 runner removal.
- Documents the runtime guard and scheduled failure-to-issue path.

## Validation
- `python -m py_compile scripts/check_github_actions_node_runtime.py`
- `python scripts/check_github_actions_node_runtime.py`
- Workflow YAML parse via PyYAML
- `git diff --check`

## Source Check
- `actions/setup-java` latest release checked with GitHub CLI: `v5.2.0` published 2026-01-22.
- `actions/setup-node` latest release checked with GitHub CLI: `v6.4.0` published 2026-04-20.
- `actions/checkout` latest release checked with GitHub CLI: `v6.0.2` published 2026-01-09.