### PR TITLE
[codex] Fix Android release AAR metadata requirements

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,6 +38,7 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -72,4 +73,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 06 01:18:28 JST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 


### PR DESCRIPTION
## Summary
- Continues #1495 after #1515 unblocked the native mobile entrypoint.
- Fixes the Android AAB `checkReleaseAarMetadata` failure from run `25203834827` by upgrading Android Gradle Plugin to `8.9.1` and Gradle wrapper to `8.11.1`.
- Enables Android core library desugaring for `flutter_local_notifications` and adds `desugar_jdk_libs:2.1.5`.

## Validation
- `python scripts/check_mobile_release_readiness.py`
- `flutter pub get --dry-run`
- `flutter analyze lib/main_mobile.dart`
- `git diff --check`

## Local Limitation
- This worktree does not include a local Android SDK / Gradle wrapper script, so the hosted mobile workflow remains the authoritative AAB validation.

## References
- Android AAB failure run: https://github.com/kanta13jp1/my_web_app/actions/runs/25203834827
- Android Gradle Plugin 8.9 release notes: https://developer.android.com/build/releases/agp-8-9-0-release-notes