### PR TITLE
fix: enable Android desugaring for mobile artifacts

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,8 +38,9 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {
@@ -72,4 +73,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 06 01:18:28 JST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 


### PR DESCRIPTION
## Summary
- enable Android core library desugaring for the mobile artifact workflow
- add the desugar_jdk_libs dependency required by flutter_local_notifications

## Verification
- flutter analyze android/app/build.gradle lib/main_mobile.dart
- python scripts/check_mobile_release_readiness.py
- flutter build web --target lib/main_mobile.dart --no-pub

Follow-up for #1505 after the manual mobile dispatch found Android AAB failing on desugaring.