### PR TITLE
fix: align Android release JVM target

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,8 +39,8 @@ android {
 
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -46,6 +46,12 @@ def check_android(failures: list[str]) -> None:
         "Android namespace still uses the com.example placeholder.",
         failures,
     )
+    fail_if(
+        "sourceCompatibility = JavaVersion.VERSION_17" not in build_gradle
+        or "targetCompatibility = JavaVersion.VERSION_17" not in build_gradle,
+        "Android Java compatibility must target Java 17 to match release Kotlin tasks.",
+        failures,
+    )
 
     manifest = ET.parse(ROOT / "android/app/src/main/AndroidManifest.xml")
     application = manifest.getroot().find("application")


### PR DESCRIPTION
## Summary
- Align Android release Java source/target compatibility with Kotlin JVM target 17.
- Extend the mobile release readiness gate so this mismatch is caught before the expensive artifact build.

## Validation
- python -m py_compile scripts/check_mobile_release_readiness.py
- python scripts/check_mobile_release_readiness.py
- flutter pub get --dry-run
- flutter analyze lib/main_mobile.dart
- git diff --check

Refs #1495