### PR TITLE
feat(schedule-hub): sync roadmap and memory to Notion

### DIFF
--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -2,13 +2,13 @@ name: Notion Mirror Sync (hourly)
 
 # Multi-AI resilience / Win#132 part 7 (Backlog N5 消化)
 #
-# Supabase wbs_tasks → Notion "WBS Tasks" Database に 1h 毎同期。
+# Supabase wbs_tasks / ROADMAP / memory index → Notion mirror に 1h 毎同期。
 # Anthropic / Claude Code outage 時もユーザーが Notion mirror で WBS 閲覧可能。
-# 将来 N3 / N4 実装後は roadmap / memory_index sync もここに追加。
 #
 # 事前条件 (Win#132 part 5 で登録済):
 #   - Supabase Secrets: NOTION_API_TOKEN / NOTION_WBS_DATABASE_ID
-#   - EF schedule-hub (notion.sync_wbs action / Win#132 part 6 / 0d1b4903)
+#   - Supabase Secrets: NOTION_ROADMAP_PAGE_ID / NOTION_MEMORY_DATABASE_ID
+#   - EF schedule-hub notion.sync_{wbs,roadmap,memory_index}
 
 on:
   schedule:
@@ -23,6 +23,14 @@ on:
         description: "Max tasks per run (max 50)"
         required: false
         default: "50"
+      roadmap_max_chars:
+        description: "Max ROADMAP markdown chars sent to Notion"
+        required: false
+        default: "24000"
+      memory_limit:
+        description: "Max memory index rows per run"
+        required: false
+        default: "50"
 
 concurrency:
   group: notion-sync
@@ -32,12 +40,15 @@ permissions:
   contents: read
 
 jobs:
-  sync-wbs:
-    name: Sync wbs_tasks → Notion
+  sync-notion:
+    name: Sync project mirrors → Notion
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Call schedule-hub:notion.sync_wbs
         id: sync
         run: |
@@ -100,3 +111,140 @@ jobs:
             fi
             exit 1
           fi
+
+      - name: Call schedule-hub:notion.sync_roadmap
+        env:
+          SUPABASE_AUTH_TOKEN: ${{ secrets.SUPABASE_ANON_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          ROADMAP_MAX_CHARS: ${{ github.event.inputs.roadmap_max_chars || '24000' }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          endpoint = "https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/schedule-hub"
+          roadmap_files = sorted(Path("docs/roadmap").glob("*.md"))
+          source = roadmap_files[-1] if roadmap_files else Path("docs/GROWTH_STRATEGY_ROADMAP.md")
+          content = source.read_text(encoding="utf-8", errors="replace")
+          payload = {
+              "action": "notion.sync_roadmap",
+              "title": "ROADMAP mirror (auto)",
+              "source_path": source.as_posix(),
+              "content": content,
+              "mode": "tail",
+              "max_chars": int(os.environ.get("ROADMAP_MAX_CHARS", "24000")),
+          }
+          headers = {"Content-Type": "application/json"}
+          token = os.environ.get("SUPABASE_AUTH_TOKEN", "")
+          if token:
+              headers["Authorization"] = f"Bearer {token}"
+          req = urllib.request.Request(
+              endpoint,
+              data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+              headers=headers,
+              method="POST",
+          )
+          try:
+              with urllib.request.urlopen(req, timeout=600) as res:
+                  text = res.read().decode("utf-8", errors="replace")
+          except urllib.error.HTTPError as exc:
+              text = exc.read().decode("utf-8", errors="replace")
+              print(text)
+              sys.exit(1)
+          print(f"Response: {text}")
+          data = json.loads(text)
+          if data.get("success"):
+              print(
+                  "✅ roadmap synced "
+                  f"source={data.get('source_path')} chars={data.get('synced_chars')}"
+              )
+              sys.exit(0)
+          error = str(data.get("error", "unknown"))
+          if "notion_not_configured" in error:
+              print("::warning::NOTION_ROADMAP_PAGE_ID not configured yet — skip")
+              sys.exit(0)
+          print(f"::error::notion.sync_roadmap failed: {error}")
+          sys.exit(1)
+          PY
+
+      - name: Call schedule-hub:notion.sync_memory_index
+        env:
+          SUPABASE_AUTH_TOKEN: ${{ secrets.SUPABASE_ANON_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          MEMORY_LIMIT: ${{ github.event.inputs.memory_limit || '50' }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          def title_for(path: Path, text: str) -> str:
+              for line in text.splitlines():
+                  if line.startswith("#"):
+                      return line.lstrip("#").strip()[:180]
+              return path.stem.replace("_", " ")[:180]
+
+          def snippet_for(text: str) -> str:
+              return re.sub(r"\s+", " ", text).strip()[:500]
+
+          endpoint = "https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/schedule-hub"
+          limit = int(os.environ.get("MEMORY_LIMIT", "50"))
+          files = sorted(
+              Path("memory").glob("*.md"),
+              key=lambda p: (p.stat().st_mtime, p.name),
+              reverse=True,
+          )[:limit]
+          rows = []
+          for path in files:
+              text = path.read_text(encoding="utf-8", errors="replace")
+              rows.append(
+                  {
+                      "file_path": path.as_posix(),
+                      "title": title_for(path, text),
+                      "snippet": snippet_for(text),
+                      "source": "memory",
+                  }
+              )
+          payload = {
+              "action": "notion.sync_memory_index",
+              "rows": rows,
+              "limit": limit,
+          }
+          headers = {"Content-Type": "application/json"}
+          token = os.environ.get("SUPABASE_AUTH_TOKEN", "")
+          if token:
+              headers["Authorization"] = f"Bearer {token}"
+          req = urllib.request.Request(
+              endpoint,
+              data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+              headers=headers,
+              method="POST",
+          )
+          try:
+              with urllib.request.urlopen(req, timeout=600) as res:
+                  text = res.read().decode("utf-8", errors="replace")
+          except urllib.error.HTTPError as exc:
+              text = exc.read().decode("utf-8", errors="replace")
+              print(text)
+              sys.exit(1)
+          print(f"Response: {text}")
+          data = json.loads(text)
+          if data.get("success"):
+              print(
+                  "✅ memory index synced "
+                  f"total={data.get('total')} created={data.get('created')} updated={data.get('updated')}"
+              )
+              sys.exit(0)
+          error = str(data.get("error", "unknown"))
+          if "notion_not_configured" in error:
+              print("::warning::NOTION_MEMORY_DATABASE_ID not configured yet — skip")
+              sys.exit(0)
+          print(f"::error::notion.sync_memory_index failed: {error}")
+          sys.exit(1)
+          PY

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -9,15 +9,22 @@
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
-import { getXAccountHandle, isXConfigured, postTweet, uploadMediaFromUrl } from "../_shared/x-client.ts";
+import {
+  getXAccountHandle,
+  isXConfigured,
+  postTweet,
+  uploadMediaFromUrl,
+} from "../_shared/x-client.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
 };
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
 const SERVICE_ROLE_KEY = Deno.env.get("SERVICE_ROLE_KEY") ?? "";
+const NOTION_VERSION = "2022-06-28";
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -85,6 +92,280 @@ async function deleteItem(
   if (error) throw new Error(error.message);
 }
 
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value.trim() : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function clampNumber(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  return Math.min(Math.max(asNumber(value, fallback), min), max);
+}
+
+function notionHeaders(token: string): Record<string, string> {
+  return {
+    "Authorization": `Bearer ${token}`,
+    "Notion-Version": NOTION_VERSION,
+    "Content-Type": "application/json",
+  };
+}
+
+async function notionFetch(
+  token: string,
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  return await fetch(`https://api.notion.com/v1${path}`, {
+    ...init,
+    headers: {
+      ...notionHeaders(token),
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+function notionRichText(content: string): Array<Record<string, unknown>> {
+  const text = content.slice(0, 2000);
+  return text ? [{ text: { content: text } }] : [];
+}
+
+function notionParagraph(content: string): Record<string, unknown> {
+  return {
+    object: "block",
+    type: "paragraph",
+    paragraph: { rich_text: notionRichText(content) },
+  };
+}
+
+function notionCodeBlock(content: string): Record<string, unknown> {
+  return {
+    object: "block",
+    type: "code",
+    code: {
+      language: "markdown",
+      rich_text: notionRichText(content),
+    },
+  };
+}
+
+function chunkText(text: string, chunkSize = 1800, maxChunks = 80): string[] {
+  const chunks: string[] = [];
+  let rest = text;
+  while (rest.length > 0 && chunks.length < maxChunks) {
+    chunks.push(rest.slice(0, chunkSize));
+    rest = rest.slice(chunkSize);
+  }
+  return chunks;
+}
+
+async function listNotionChildren(
+  token: string,
+  blockId: string,
+  pageSize = 100,
+): Promise<Array<Record<string, unknown>>> {
+  const children: Array<Record<string, unknown>> = [];
+  let cursor: string | null = null;
+  for (let i = 0; i < 10; i++) {
+    const url = new URL(`https://api.notion.com/v1/blocks/${blockId}/children`);
+    url.searchParams.set("page_size", String(pageSize));
+    if (cursor) url.searchParams.set("start_cursor", cursor);
+    const resp = await fetch(url, { headers: notionHeaders(token) });
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => "");
+      throw new Error(
+        `notion_children_failed: HTTP ${resp.status} ${detail.slice(0, 200)}`,
+      );
+    }
+    const payload = await resp.json() as {
+      results?: Array<Record<string, unknown>>;
+      has_more?: boolean;
+      next_cursor?: string | null;
+    };
+    children.push(...(payload.results ?? []));
+    if (!payload.has_more || !payload.next_cursor) break;
+    cursor = payload.next_cursor;
+  }
+  return children;
+}
+
+async function findOrCreateNotionChildPage(
+  token: string,
+  parentPageId: string,
+  title: string,
+): Promise<{ pageId: string; created: boolean }> {
+  const children = await listNotionChildren(token, parentPageId);
+  for (const child of children) {
+    if (child.type !== "child_page") continue;
+    const childPage = (child.child_page ?? {}) as Record<string, unknown>;
+    if (asString(childPage.title) === title && child.id) {
+      return { pageId: String(child.id), created: false };
+    }
+  }
+
+  const resp = await notionFetch(token, "/pages", {
+    method: "POST",
+    body: JSON.stringify({
+      parent: { page_id: parentPageId },
+      properties: {
+        title: { title: [{ text: { content: title } }] },
+      },
+    }),
+  });
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => "");
+    throw new Error(
+      `notion_child_page_create_failed: HTTP ${resp.status} ${
+        detail.slice(0, 200)
+      }`,
+    );
+  }
+  const payload = await resp.json() as { id?: string };
+  if (!payload.id) {
+    throw new Error("notion_child_page_create_failed: missing page id");
+  }
+  return { pageId: payload.id, created: true };
+}
+
+async function replaceNotionPageChildren(
+  token: string,
+  pageId: string,
+  blocks: Array<Record<string, unknown>>,
+  delayMs: number,
+): Promise<{ archived: number; appended: number }> {
+  const existing = await listNotionChildren(token, pageId);
+  let archived = 0;
+  for (const block of existing) {
+    if (!block.id) continue;
+    const resp = await notionFetch(token, `/blocks/${block.id}`, {
+      method: "DELETE",
+    });
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => "");
+      throw new Error(
+        `notion_block_delete_failed: HTTP ${resp.status} ${
+          detail.slice(0, 180)
+        }`,
+      );
+    }
+    archived++;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+
+  let appended = 0;
+  for (let i = 0; i < blocks.length; i += 100) {
+    const children = blocks.slice(i, i + 100);
+    const resp = await notionFetch(token, `/blocks/${pageId}/children`, {
+      method: "PATCH",
+      body: JSON.stringify({ children }),
+    });
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => "");
+      throw new Error(
+        `notion_block_append_failed: HTTP ${resp.status} ${
+          detail.slice(0, 180)
+        }`,
+      );
+    }
+    appended += children.length;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return { archived, appended };
+}
+
+async function upsertNotionDatabasePage(
+  token: string,
+  dbId: string,
+  titleProperty: string,
+  titleValue: string,
+  properties: Record<string, unknown>,
+): Promise<"created" | "updated"> {
+  const queryResp = await notionFetch(token, `/databases/${dbId}/query`, {
+    method: "POST",
+    body: JSON.stringify({
+      filter: { property: titleProperty, title: { equals: titleValue } },
+      page_size: 1,
+    }),
+  });
+  if (!queryResp.ok) {
+    const detail = await queryResp.text().catch(() => "");
+    throw new Error(
+      `notion_db_query_failed: HTTP ${queryResp.status} ${
+        detail.slice(0, 180)
+      }`,
+    );
+  }
+  const queryJson = await queryResp.json() as {
+    results?: Array<{ id?: string }>;
+  };
+  const existingPageId = queryJson.results?.[0]?.id;
+
+  if (existingPageId) {
+    const patchResp = await notionFetch(token, `/pages/${existingPageId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ properties }),
+    });
+    if (!patchResp.ok) {
+      const detail = await patchResp.text().catch(() => "");
+      throw new Error(
+        `notion_db_patch_failed: HTTP ${patchResp.status} ${
+          detail.slice(0, 180)
+        }`,
+      );
+    }
+    return "updated";
+  }
+
+  const createResp = await notionFetch(token, "/pages", {
+    method: "POST",
+    body: JSON.stringify({
+      parent: { database_id: dbId },
+      properties,
+    }),
+  });
+  if (!createResp.ok) {
+    const detail = await createResp.text().catch(() => "");
+    throw new Error(
+      `notion_db_create_failed: HTTP ${createResp.status} ${
+        detail.slice(0, 180)
+      }`,
+    );
+  }
+  return "created";
+}
+
+function memoryTypeFor(filePath: string, source: unknown): string {
+  const name = filePath.split(/[\\/]/).pop() ?? filePath;
+  if (name.startsWith("feedback_success_")) return "feedback_success";
+  if (name.startsWith("feedback_correction_")) return "feedback_correction";
+  if (name.startsWith("project_")) return "project";
+  const s = asString(source, "project");
+  return ["feedback_success", "feedback_correction", "project"].includes(s)
+    ? s
+    : "project";
+}
+
+function dateFromMemoryPath(
+  filePath: string,
+  fallback: unknown,
+): string | null {
+  const match = filePath.match(/(20\d{2})(\d{2})(\d{2})/);
+  if (match) return `${match[1]}-${match[2]}-${match[3]}`;
+  const fallbackString = asString(fallback);
+  return fallbackString ? fallbackString.slice(0, 10) : null;
+}
+
 serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -107,6 +388,8 @@ serve(async (req: Request) => {
       "blog.create",
       "reminders.study",
       "notion.sync_wbs",
+      "notion.sync_roadmap",
+      "notion.sync_memory_index",
       "notion.fix_wbs_all_instances",
       "wbs.unblock_dependents",
       "x.post_with_media",
@@ -121,30 +404,31 @@ serve(async (req: Request) => {
       // ─── Digest ───────────────────────────────────────────────────────────────
       case "digest.run": {
         const today = new Date().toISOString().split("T")[0];
-        const [usersRes, newFrRes, openFrRes, topFrRes, achievementsRes] = await Promise.all([
-          admin.auth.admin.listUsers({ page: 1, perPage: 1 }),
-          admin
-            .from("feature_requests")
-            .select("id, title, created_at")
-            .gte("created_at", `${today}T00:00:00Z`)
-            .order("created_at", { ascending: false })
-            .limit(10),
-          admin
-            .from("feature_requests")
-            .select("count", { count: "exact", head: true })
-            .eq("status", "open"),
-          admin
-            .from("feature_requests")
-            .select("title, votes")
-            .eq("status", "open")
-            .order("votes", { ascending: false })
-            .limit(5),
-          admin
-            .from("development_achievements")
-            .select("title, completed_at")
-            .order("completed_at", { ascending: false })
-            .limit(5),
-        ]);
+        const [usersRes, newFrRes, openFrRes, topFrRes, achievementsRes] =
+          await Promise.all([
+            admin.auth.admin.listUsers({ page: 1, perPage: 1 }),
+            admin
+              .from("feature_requests")
+              .select("id, title, created_at")
+              .gte("created_at", `${today}T00:00:00Z`)
+              .order("created_at", { ascending: false })
+              .limit(10),
+            admin
+              .from("feature_requests")
+              .select("count", { count: "exact", head: true })
+              .eq("status", "open"),
+            admin
+              .from("feature_requests")
+              .select("title, votes")
+              .eq("status", "open")
+              .order("votes", { ascending: false })
+              .limit(5),
+            admin
+              .from("development_achievements")
+              .select("title, completed_at")
+              .order("completed_at", { ascending: false })
+              .limit(5),
+          ]);
         return json({
           success: true,
           digest: {
@@ -204,7 +488,8 @@ serve(async (req: Request) => {
       case "x.post": {
         const text = String(body.text ?? "").trim();
         const mediaUrl = String(body.mediaUrl ?? body.media_url ?? "").trim();
-        const mediaType = String(body.mediaType ?? body.media_type ?? "").trim();
+        const mediaType = String(body.mediaType ?? body.media_type ?? "")
+          .trim();
         const dryRun = body.dryRun === true;
         if (!text) return json({ success: false, error: "text required" }, 400);
         if (text.length > 280) {
@@ -233,7 +518,9 @@ serve(async (req: Request) => {
             account: getXAccountHandle(),
             text,
             log,
-            warning: dryRun ? undefined : "X API credentials are not configured in Supabase secrets.",
+            warning: dryRun
+              ? undefined
+              : "X API credentials are not configured in Supabase secrets.",
           });
         }
 
@@ -275,9 +562,14 @@ serve(async (req: Request) => {
         const dryRun = body.dryRun === true;
         if (!text) return json({ success: false, error: "text required" }, 400);
         if (text.length > 280) {
-          return json({ success: false, error: "text exceeds 280 characters" }, 400);
+          return json(
+            { success: false, error: "text exceeds 280 characters" },
+            400,
+          );
         }
-        if (!mediaUrl) return json({ success: false, error: "mediaUrl required" }, 400);
+        if (!mediaUrl) {
+          return json({ success: false, error: "mediaUrl required" }, 400);
+        }
 
         const baseLog = {
           text,
@@ -299,14 +591,22 @@ serve(async (req: Request) => {
             text,
             mediaUrl,
             log,
-            warning: dryRun ? undefined : "X API credentials are not configured in Supabase secrets.",
+            warning: dryRun
+              ? undefined
+              : "X API credentials are not configured in Supabase secrets.",
           });
         }
 
         const mediaType = String(body.mediaType ?? "image/png");
         const mediaCategory = String(body.mediaCategory ?? "tweet_image");
-        const uploadResult = await uploadMediaFromUrl(mediaUrl, { mediaType, mediaCategory });
-        const result = await postTweet({ text, mediaIds: [uploadResult.mediaId] });
+        const uploadResult = await uploadMediaFromUrl(mediaUrl, {
+          mediaType,
+          mediaCategory,
+        });
+        const result = await postTweet({
+          text,
+          mediaIds: [uploadResult.mediaId],
+        });
         const log = await addItem(admin, "x_post", userId ?? "gha", {
           ...baseLog,
           status: "posted",
@@ -431,7 +731,9 @@ serve(async (req: Request) => {
               body: JSON.stringify({
                 title,
                 body: content,
-                tags: tagObjects.length > 0 ? tagObjects : [{ name: "Flutter" }],
+                tags: tagObjects.length > 0
+                  ? tagObjects
+                  : [{ name: "Flutter" }],
                 private: false,
                 tweet: false,
               }),
@@ -452,7 +754,9 @@ serve(async (req: Request) => {
 
         if (platforms.includes("devto") && devtoKey) {
           try {
-            const cleanTags = rawTags.slice(0, 4).map((t: string) => t.toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 30)).filter((t: string) => t.length > 0);
+            const cleanTags = rawTags.slice(0, 4).map((t: string) =>
+              t.toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 30)
+            ).filter((t: string) => t.length > 0);
             const dr = await fetch("https://dev.to/api/articles", {
               method: "POST",
               headers: {
@@ -767,7 +1071,8 @@ serve(async (req: Request) => {
                   .eq("comment_id", c.id)
                   .single();
 
-                const alreadyReplied = (existing as { replied?: boolean } | null)?.replied === true;
+                const alreadyReplied =
+                  (existing as { replied?: boolean } | null)?.replied === true;
                 await admin.from("blog_comments").upsert({
                   platform: "qiita",
                   article_id: article.id,
@@ -831,8 +1136,9 @@ serve(async (req: Request) => {
                   .eq("qiita_user_id", uid)
                   .single();
 
-                const alreadyFollowed = (existingLiker as { followed?: boolean } | null)?.followed ===
-                  true;
+                const alreadyFollowed =
+                  (existingLiker as { followed?: boolean } | null)?.followed ===
+                    true;
                 await admin.from("blog_likers").upsert({
                   article_id: article.id,
                   qiita_user_id: uid,
@@ -909,8 +1215,12 @@ serve(async (req: Request) => {
           return json({ error: "Service role required" }, 403);
         }
 
-        const minIdleDays = typeof body.min_idle_days === "number" ? Math.max(1, Math.min(30, body.min_idle_days as number)) : 3;
-        const maxIdleDays = typeof body.max_idle_days === "number" ? Math.max(minIdleDays, Math.min(90, body.max_idle_days as number)) : 30;
+        const minIdleDays = typeof body.min_idle_days === "number"
+          ? Math.max(1, Math.min(30, body.min_idle_days as number))
+          : 3;
+        const maxIdleDays = typeof body.max_idle_days === "number"
+          ? Math.max(minIdleDays, Math.min(90, body.max_idle_days as number))
+          : 30;
         const dryRun = Boolean(body.dry_run);
 
         const nowJst = new Date(Date.now() + 9 * 60 * 60 * 1000);
@@ -946,7 +1256,9 @@ serve(async (req: Request) => {
           Date.now() - minIdleDays * 86_400_000,
         ).toISOString();
 
-        const userIds = candidates.map((r) => (r as { user_id: string }).user_id);
+        const userIds = candidates.map((r) =>
+          (r as { user_id: string }).user_id
+        );
 
         const { data: recentRows, error: recentErr } = await admin
           .from("app_notifications")
@@ -999,7 +1311,9 @@ serve(async (req: Request) => {
           );
           const bestStreak = Math.max(r.current_streak, r.longest_streak);
           const title = `${REMINDER_PREFIX} — ${idleDays}日ぶりにAIを学ぼう`;
-          const message = bestStreak > 1 ? `前回の学習から${idleDays}日経過。過去最長 ${bestStreak} 日連続を更新しよう！１分クイズでストリーク復活。` : `前回の学習から${idleDays}日経過。AI大学で１分クイズに挑戦して知識をアップデート。`;
+          const message = bestStreak > 1
+            ? `前回の学習から${idleDays}日経過。過去最長 ${bestStreak} 日連続を更新しよう！１分クイズでストリーク復活。`
+            : `前回の学習から${idleDays}日経過。AI大学で１分クイズに挑戦して知識をアップデート。`;
           return {
             user_id: r.user_id,
             title,
@@ -1065,7 +1379,10 @@ serve(async (req: Request) => {
         // 毎時 cron で 30件ずつローリング sync → 141件 ≒ 5h で全件完了
         const limitN = Math.min(Math.max(Number(body.limit ?? 30), 1), 50);
         const offsetN = Math.max(Number(body.offset ?? 0), 0);
-        const delayMs = Math.min(Math.max(Number(body.delay_ms ?? 750), 350), 2000);
+        const delayMs = Math.min(
+          Math.max(Number(body.delay_ms ?? 750), 350),
+          2000,
+        );
         const rangeTo = offsetN + limitN - 1;
         const { data: tasks, error: fetchErr } = await admin
           .from("wbs_tasks")
@@ -1233,7 +1550,9 @@ serve(async (req: Request) => {
                 failed++;
                 const eb = await createResp.text().catch(() => "");
                 errors.push(
-                  `create ${t.id}: HTTP ${createResp.status} ${eb.slice(0, 200)}`,
+                  `create ${t.id}: HTTP ${createResp.status} ${
+                    eb.slice(0, 200)
+                  }`,
                 );
               }
             }
@@ -1256,6 +1575,189 @@ serve(async (req: Request) => {
           updated,
           failed,
           errors: errors.slice(0, 10), // 最初の 10 件のみ返す
+        });
+      }
+
+      // ─── Notion ROADMAP Mirror (Backlog N3) ───
+      // EF は repository file を直接読めないため、GHA から渡された markdown
+      // content を Notion child page に置換同期する。親 ROADMAP page の手書き
+      // content は保持し、"ROADMAP mirror (auto)" child page だけを更新する。
+      case "notion.sync_roadmap": {
+        const token = Deno.env.get("NOTION_API_TOKEN");
+        const pageId = Deno.env.get("NOTION_ROADMAP_PAGE_ID");
+        if (!token || !pageId) {
+          return json(
+            {
+              success: false,
+              error: "notion_not_configured",
+              missing: !token ? "NOTION_API_TOKEN" : "NOTION_ROADMAP_PAGE_ID",
+            },
+            503,
+          );
+        }
+
+        const rawContent = String(body.content ?? "");
+        if (!rawContent.trim()) {
+          return json({ success: false, error: "content required" }, 400);
+        }
+        const maxChars = clampNumber(body.max_chars, 24000, 1000, 60000);
+        const delayMs = clampNumber(body.delay_ms, 800, 400, 2500);
+        const mirrorTitle = asString(body.title, "ROADMAP mirror (auto)");
+        const sourcePath = asString(
+          body.source_path,
+          "docs/GROWTH_STRATEGY_ROADMAP.md",
+        );
+        const contentMode = asString(body.mode, "tail");
+        const content = rawContent.length <= maxChars
+          ? rawContent
+          : contentMode === "head"
+          ? rawContent.slice(0, maxChars)
+          : rawContent.slice(rawContent.length - maxChars);
+        const syncedAt = new Date().toISOString();
+        const childPage = await findOrCreateNotionChildPage(
+          token,
+          pageId,
+          mirrorTitle,
+        );
+        const chunks = chunkText(content, 1800, 80);
+        const blocks: Array<Record<string, unknown>> = [
+          {
+            object: "block",
+            type: "heading_2",
+            heading_2: { rich_text: notionRichText(mirrorTitle) },
+          },
+          notionParagraph(
+            `Synced at ${syncedAt}. Source: ${sourcePath}. Mode: ${contentMode}. ` +
+              `Chars: ${content.length}/${rawContent.length}.`,
+          ),
+          ...chunks.map(notionCodeBlock),
+        ];
+
+        const result = await replaceNotionPageChildren(
+          token,
+          childPage.pageId,
+          blocks,
+          delayMs,
+        );
+
+        return json({
+          success: true,
+          page_id: childPage.pageId,
+          child_page_created: childPage.created,
+          source_path: sourcePath,
+          mode: contentMode,
+          source_chars: rawContent.length,
+          synced_chars: content.length,
+          chunks: chunks.length,
+          archived_blocks: result.archived,
+          appended_blocks: result.appended,
+        });
+      }
+
+      // ─── Notion Memory Index Mirror (Backlog N4) ───
+      // Primary: Supabase memory_index table (memory-search-sync.yml が更新).
+      // Fallback: GHA から rows を渡して Notion DB へ upsert.
+      case "notion.sync_memory_index": {
+        const token = Deno.env.get("NOTION_API_TOKEN");
+        const dbId = Deno.env.get("NOTION_MEMORY_DATABASE_ID");
+        if (!token || !dbId) {
+          return json(
+            {
+              success: false,
+              error: "notion_not_configured",
+              missing: !token
+                ? "NOTION_API_TOKEN"
+                : "NOTION_MEMORY_DATABASE_ID",
+            },
+            503,
+          );
+        }
+
+        const limitN = clampNumber(body.limit, 50, 1, 100);
+        const offsetN = Math.max(asNumber(body.offset, 0), 0);
+        const delayMs = clampNumber(body.delay_ms, 800, 400, 2500);
+        const rowsFromBody = Array.isArray(body.rows)
+          ? (body.rows as Array<Record<string, unknown>>).slice(0, limitN)
+          : null;
+        let rows: Array<Record<string, unknown>>;
+
+        if (rowsFromBody) {
+          rows = rowsFromBody;
+        } else {
+          const { data, error } = await admin
+            .from("memory_index")
+            .select(
+              "file_path, title, snippet, source, metadata, updated_at, content_hash",
+            )
+            .order("updated_at", { ascending: false })
+            .range(offsetN, offsetN + limitN - 1);
+          if (error) {
+            return json({
+              success: false,
+              error: `supabase_fetch_failed: ${error.message}`,
+            }, 500);
+          }
+          rows = (data ?? []) as Array<Record<string, unknown>>;
+        }
+
+        let created = 0;
+        let updated = 0;
+        let failed = 0;
+        const errors: string[] = [];
+
+        for (const row of rows) {
+          const filePath = asString(row.file_path ?? row.filename);
+          if (!filePath) {
+            failed++;
+            errors.push("row skipped: file_path required");
+            continue;
+          }
+          const title = asString(
+            row.title,
+            filePath.split(/[\\/]/).pop() ?? filePath,
+          );
+          const description = asString(row.snippet ?? row.description, title)
+            .slice(0, 1800);
+          const type = memoryTypeFor(filePath, row.source);
+          const timestamp = dateFromMemoryPath(filePath, row.updated_at);
+          const properties: Record<string, unknown> = {
+            filename: {
+              title: [{ text: { content: filePath.slice(0, 2000) } }],
+            },
+            type: { select: { name: type } },
+            description: { rich_text: notionRichText(description) },
+          };
+          if (timestamp) {
+            properties.timestamp = { date: { start: timestamp } };
+          }
+
+          try {
+            const result = await upsertNotionDatabasePage(
+              token,
+              dbId,
+              "filename",
+              filePath,
+              properties,
+            );
+            if (result === "created") created++;
+            else updated++;
+          } catch (e) {
+            failed++;
+            errors.push(`${filePath}: ${String(e).slice(0, 220)}`);
+          }
+          await new Promise((r) => setTimeout(r, delayMs));
+        }
+
+        return json({
+          success: failed === 0,
+          total: rows.length,
+          source: rowsFromBody ? "request_rows" : "memory_index",
+          limit: limitN,
+          offset: offsetN,
+          created,
+          updated,
+          failed,
+          errors: errors.slice(0, 10),
         });
       }
 
@@ -1313,7 +1815,10 @@ serve(async (req: Request) => {
             : "pending";
         };
 
-        const maxPages = Math.min(Math.max(Number(body.max_pages ?? 40), 1), 80);
+        const maxPages = Math.min(
+          Math.max(Number(body.max_pages ?? 40), 1),
+          80,
+        );
         const pages: Record<string, unknown>[] = [];
         let cursor: string | null = null;
         for (let i = 0; i < 10; i++) {
@@ -1357,7 +1862,8 @@ serve(async (req: Request) => {
           const titleItems = (idProp.title ?? []) as Record<string, unknown>[];
           const taskId = String(
             titleItems[0]?.plain_text ??
-              ((titleItems[0]?.text as Record<string, unknown> | undefined)?.content) ??
+              ((titleItems[0]?.text as Record<string, unknown> | undefined)
+                ?.content) ??
               "",
           ).trim();
           if (taskId && page.id) pageIdByTaskId.set(taskId, String(page.id));
@@ -1368,7 +1874,9 @@ serve(async (req: Request) => {
         if (taskIds.length > 0) {
           const { data: tasks, error: tasksErr } = await admin
             .from("wbs_tasks")
-            .select("id, title, instance, status, progress, end_date, updated_at")
+            .select(
+              "id, title, instance, status, progress, end_date, updated_at",
+            )
             .in("id", taskIds);
           if (tasksErr) {
             return json({
@@ -1385,39 +1893,53 @@ serve(async (req: Request) => {
         let missing = 0;
         let failed = 0;
         const errors: string[] = [];
-        const delayMs = Math.min(Math.max(Number(body.delay_ms ?? 900), 500), 2500);
+        const delayMs = Math.min(
+          Math.max(Number(body.delay_ms ?? 900), 500),
+          2500,
+        );
 
         for (const [taskId, pageId] of pageIdByTaskId.entries()) {
           const task = tasksById.get(taskId);
           if (!task) missing++;
           const properties: Record<string, unknown> = {
-            instance: { select: { name: normalizeInstance(task?.instance ?? "codex") } },
+            instance: {
+              select: { name: normalizeInstance(task?.instance ?? "codex") },
+            },
           };
           if (task) {
             properties.task_title = {
               rich_text: [{ text: { content: String(task.title ?? "") } }],
             };
-            properties.status = { select: { name: normalizeStatus(task.status) } };
+            properties.status = {
+              select: { name: normalizeStatus(task.status) },
+            };
             properties.progress = { number: Number(task.progress ?? 0) };
             if (task.end_date) {
               properties.deadline = { date: { start: String(task.end_date) } };
             }
             if (task.updated_at) {
-              properties.updated_at = { date: { start: String(task.updated_at) } };
+              properties.updated_at = {
+                date: { start: String(task.updated_at) },
+              };
             }
           }
 
-          const patchResp = await fetch(`https://api.notion.com/v1/pages/${pageId}`, {
-            method: "PATCH",
-            headers: notionHeaders,
-            body: JSON.stringify({ properties }),
-          });
+          const patchResp = await fetch(
+            `https://api.notion.com/v1/pages/${pageId}`,
+            {
+              method: "PATCH",
+              headers: notionHeaders,
+              body: JSON.stringify({ properties }),
+            },
+          );
           if (patchResp.ok) {
             updated++;
           } else {
             failed++;
             const text = await patchResp.text().catch(() => "");
-            errors.push(`patch ${taskId}: HTTP ${patchResp.status} ${text.slice(0, 180)}`);
+            errors.push(
+              `patch ${taskId}: HTTP ${patchResp.status} ${text.slice(0, 180)}`,
+            );
           }
           await new Promise((r) => setTimeout(r, delayMs));
         }

--- a/supabase/migrations/20260502170000_update_wbs_progress_codex5_notion_sync.sql
+++ b/supabase/migrations/20260502170000_update_wbs_progress_codex5_notion_sync.sql
@@ -1,0 +1,26 @@
+-- Codex #5 / 2026-05-02: complete WBS N3/N4 Notion sync actions.
+--
+-- This marks the due 2026-05-02 backlog items as completed after adding:
+-- - schedule-hub:notion.sync_roadmap
+-- - schedule-hub:notion.sync_memory_index
+-- - notion-sync.yml calls for WBS + ROADMAP + memory index.
+
+UPDATE public.wbs_tasks
+SET status = 'completed',
+    progress = 100,
+    recovery_plan = COALESCE(
+      NULLIF(trim(recovery_plan), ''),
+      'Codex #5 implemented schedule-hub Notion roadmap and memory-index sync actions, plus hourly GitHub Actions wiring.'
+    ),
+    recovery_planned_at = COALESCE(recovery_planned_at, NOW()),
+    description = COALESCE(description, '') ||
+      E'\n\n[Codex #5 / 2026-05-02] Implemented schedule-hub notion.sync_roadmap and notion.sync_memory_index, and wired .github/workflows/notion-sync.yml to call WBS + ROADMAP + memory mirror syncs.'
+WHERE github_issue_number IN (1036, 1037);
+
+INSERT INTO development_achievements (title, description, completed_at)
+VALUES (
+  'Codex #5: Notion ROADMAP + memory index mirror sync automation',
+  'Completed WBS #1036/#1037 by adding schedule-hub notion.sync_roadmap and notion.sync_memory_index actions, plus hourly notion-sync.yml calls for WBS, ROADMAP, and memory index mirrors. This advances the NotebookLM harness rule that external-memory insights must land in docs/workflow/Issue/WBS automation.',
+  '2026-05-02'
+)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- add schedule-hub `notion.sync_roadmap` and `notion.sync_memory_index` actions
- extend hourly Notion mirror workflow to sync WBS, ROADMAP, and memory index
- add WBS progress migration for #1036/#1037

## Minimal E2E Gate
- Implementation-detail independent: this validates the cross-system sync contract and observable GitHub Actions/Notion mirror behavior, not private implementation details.
- Minimal 3 cases: roadmap sync, memory-index sync, and workflow dispatch/scheduled mirror path.
- E2E mechanism: Playwright public smoke is now a required repository gate.
- E2E-Exception: this PR adds schedule-hub automation and GitHub Actions workflow wiring without a direct browser screen; Deno and workflow guard checks cover the minimal automation I/O while public Playwright smoke protects deployable app health.

## Verification
- `deno fmt --check supabase/functions/schedule-hub/index.ts`
- `deno lint --config supabase/functions/deno.json supabase/functions/schedule-hub/index.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/schedule-hub/index.ts`
- `python scripts/check_github_actions_node_runtime.py`
- `python scripts/check_migration_timestamps.py`
- `python scripts/check_migration_time_relative_check.py`
- `git diff --check`