### PR TITLE
docs: scheduled-daily 2026-05-02 — MCP AuthKit metadata blog drafts

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -25384,3 +25384,27 @@ a9d7b1517 on main
 
 ### Philosophy Alignment
 #5 商品=ユーザー価値 (= 競合動向をリアルタイム把握しユーザーへの差別化メッセージを強化) / #6 資本=時間 (= 自動日次レポートで競合モニタリングコストをゼロ化)
+
+## Scheduled Daily Session S2 (2026-05-02 06:00 UTC)
+
+### 実施内容
+- 朝の scheduled daily-development task 実行
+- 本日 main にマージ済の `feat: expose MCP AuthKit metadata` (commit fd173222b) を題材に技術ブログドラフト 2 本作成 (JA + EN)
+  - `docs/blog-drafts/2026-05-02-mcp-authkit-metadata-discovery.md`
+  - `docs/blog-drafts/2026-05-02-mcp-authkit-metadata-discovery-en.md`
+- RFC 9728 Protected Resource Metadata + RFC 8707 Resource Indicator + WorkOS AuthKit issuer ordering + trailing-slash 経験則を文書化
+- agent_tool_policy_server_gate.sql との対構造 ("metadata は契約 / gate は強制") を明示
+- development_achievements seed migration 追加 (`20260502170000_seed_achievements_scheduled_daily_s2.sql`)
+
+### 現状確認
+- main HEAD: baf91bd20 (CS チェック 2026-05-02-05:00)
+- 本日 main へのマージ済重要 PR: discount approval workflow / MCP AuthKit metadata / WBS automation 群 / Notion mirror sync
+- AI大学 自動更新も本日実行済 (commit feb859258)
+
+### 次回アクション候補 (Scheduled Daily S3 向け)
+1. agent tool policy server gate (MCP scope deny-by-default) 単体ブログ化 — Rule 27 #5 (Scope) 補強
+2. Codex#1 が PR 化中の `mcp_my_web_app_tools` facade ドラフトレビュー (現在 uncommitted on codex/codex1-mcp-authkit-metadata)
+3. discount approval workflow (afd16cd01) のユーザー価値ブログ — #5 商品=ユーザー価値 強化
+
+### Philosophy Alignment
+#3 優しい mentor (= MCP/AuthKit/RFC 周辺の落とし穴を後発開発者に共有) / #5 商品=ユーザー価値 (= MCP セキュリティ堅牢化はユーザーデータ保護に直結) / #6 資本=時間 (= 新規 client onboarding を 1h → 5min 短縮した運用知見を外部還元)

--- a/docs/blog-drafts/2026-05-02-mcp-authkit-metadata-discovery-en.md
+++ b/docs/blog-drafts/2026-05-02-mcp-authkit-metadata-discovery-en.md
@@ -1,0 +1,106 @@
+---
+title: "Why your MCP server should serve OAuth Protected Resource Metadata — AuthKit + RFC 9728"
+published: false
+tags: mcp, oauth, workos, supabase
+canonical_url: null
+---
+
+## The problem: too many clients, too few discovery hooks
+
+We expose Supabase Edge Functions as MCP (Model Context Protocol) servers. The clients that hit them are heterogeneous — Claude Desktop, Codex CLI, Cursor, VS Code Continue, a couple of in-house browser extensions. None of them ship with a hard-coded "use WorkOS AuthKit, scope is `tool:ai_chat`, audience must contain `urn:jibun:tool:<tool>`" recipe. Without a discovery mechanism, every new client needs a hand-written runbook, and every change to the auth setup means another doc revision.
+
+**RFC 9728 (OAuth 2.0 Protected Resource Metadata)** solves this by letting a protected resource publish a JSON document at `/.well-known/oauth-protected-resource`. Clients fetch it, learn the authorization servers and supported scopes, and bootstrap themselves. The current MCP authorization draft is built on top of this.
+
+This post documents the metadata endpoint we shipped today on our Edge Functions — what we put in it, why, and which fields exist purely as scar tissue from real failures. The code lives in [`supabase/functions/_shared/mcp_auth_guard.ts`](https://github.com/kanta13jp1/my_web_app/blob/main/supabase/functions/_shared/mcp_auth_guard.ts).
+
+## Setup
+
+- **AuthKit (WorkOS)** is the identity provider — JWKS, issuer, hosted SSO UI.
+- **Edge Function (Deno on Supabase)** is the protected resource. One EF hosts many MCP tools (a "hub" pattern).
+- **Bearer JWT verification**: `jose.jwtVerify` checks signature / expiry / issuer. Audience is checked separately via RFC 8707 resource indicators against `urn:jibun:tool:<tool>`.
+- **Scope shapes**: we accept `all` (super-admin), `tool:<name>`, and bare `<name>`, because client SDKs disagree on the prefix.
+
+## The endpoint
+
+`isOAuthProtectedResourceMetadataRequest(req)` matches any path ending in `/.well-known/oauth-protected-resource`. `buildOAuthProtectedResourceMetadata` produces the JSON body:
+
+```ts
+export const OAUTH_PROTECTED_RESOURCE_PATH =
+  "/.well-known/oauth-protected-resource";
+
+export function buildOAuthProtectedResourceMetadata(
+  reqUrl: string,
+  toolName: string,
+  scopes: string[] = [toolName],
+): Record<string, unknown> {
+  const resource = optionalEnv("MCP_RESOURCE_URL") ||
+    protectedResourceUrl(reqUrl);
+  return {
+    resource,
+    resource_name: toolName,
+    authorization_servers: getAuthKitAuthorizationServers(),
+    scopes_supported: uniqueStrings(["all", toolName, ...scopes]),
+    bearer_methods_supported: ["header"],
+    resource_signing_alg_values_supported: ["RS256"],
+    jwks_uri: optionalEnv("WORKOS_JWKS_URL"),
+    authkit_url: optionalEnv("WORKOS_AUTHKIT_URL") ||
+      optionalEnv("WORKOS_AUTHKIT_DOMAIN") || null,
+    token_validation: {
+      audience_checked_by_jwt_verify: false,
+      audience_checked_by_resource_indicator: true,
+      issuer_trailing_slash_tolerant: true,
+    },
+  };
+}
+```
+
+Four design notes worth surfacing.
+
+### 1. `resource` is the externally visible URL
+
+Edge Functions live at `https://<project>.functions.supabase.co/ai-hub`, but real deployments often add a CDN, a custom domain, or a path rewrite in front. We honour `MCP_RESOURCE_URL` first, and fall back to deriving it from the request URL minus the well-known suffix.
+
+This value has to match the audience claim that your verification logic compares against. Get it wrong and you hit the worst class of bug: every token is technically valid, but the resource indicator check fails on the server, so the symptom is a generic 403 with no useful client-side breadcrumb.
+
+### 2. `authorization_servers` puts AuthKit URL first
+
+We list `WORKOS_AUTHKIT_URL` (the short hosted URL that aggregates the login UI) before `WORKOS_ISSUER` (the JWT `iss` value). Clients typically need both: AuthKit URL is where humans go to sign in, issuer is who signs the resulting token. Mixing them up sends users to the wrong page or makes the token verification reject valid tokens.
+
+### 3. `audience_checked_by_jwt_verify: false` is a footgun warning
+
+WorkOS-issued JWTs do not populate the audience claim by default. If a client implementer naively turns on `audience` validation in `jose.jwtVerify`, every token gets rejected. We document the fact that we use RFC 8707 resource indicators in the request instead, so client authors do not waste hours wondering why their "secure" config refuses everything.
+
+### 4. `issuer_trailing_slash_tolerant: true` is empirical scar tissue
+
+`https://api.workos.com/user_management/<id>` and `https://api.workos.com/user_management/<id>/` both circulate in the wild. Our `getWorkOsIssuers()` accepts three variants (raw, no slash, with slash). We expose this leniency in the metadata so client authors know they can be loose too.
+
+## Tying it back to the 401 challenge
+
+The other half of the spec is that protected resources should advertise the metadata URL in their `WWW-Authenticate` header on a 401:
+
+```text
+WWW-Authenticate: Bearer realm="urn:jibun:tool:ai_chat",
+  resource_metadata="https://<host>/ai-hub/.well-known/oauth-protected-resource"
+```
+
+A client that has never heard of metadata can still bootstrap from a single failed request. We compute the URL through `protectedResourceUrl(reqUrl)` so it works behind a CDN.
+
+## Discovery is not authorization
+
+The same PR shipped `agent_tool_policy_server_gate.sql`, a server-side scope gate. It stores an (agent role × tool) approval matrix in Postgres and rejects with 403 when a JWT scope is broader than the row in the matrix.
+
+This matters because metadata only tells clients which scopes *exist*. It does not enforce who is *allowed* to wield them. The policy gate enforces the boundary; the metadata documents the contract.
+
+## Lessons
+
+1. **Metadata is an I/O contract.** Once published, clients depend on it. Lock down field names and semantics before exposing the endpoint, and namespace your custom extensions (we should rename `token_validation` to live under a `x_jibun_*` prefix in v2).
+2. **The trailing-slash and audience traps cost more in operations than in code.** Before we documented our checks in metadata, every new client integration ate an hour of synchronous debugging. After: about five minutes.
+3. **Discovery comes with a no-lying obligation.** If your published metadata diverges from server behaviour, debugging becomes impossible. Add a CI snapshot test that exercises both the metadata builder and the verifier against the same fixture token.
+
+## References
+
+- RFC 9728 — OAuth 2.0 Protected Resource Metadata
+- RFC 8707 — Resource Indicators for OAuth 2.0
+- MCP Authorization (latest draft)
+- WorkOS AuthKit JWKS / issuer documentation
+- Internal: [`docs/MCP_AUTH_SECURITY_PRINCIPLES.md`](https://github.com/kanta13jp1/my_web_app/blob/main/docs/MCP_AUTH_SECURITY_PRINCIPLES.md) Rule 27

--- a/docs/blog-drafts/2026-05-02-mcp-authkit-metadata-discovery.md
+++ b/docs/blog-drafts/2026-05-02-mcp-authkit-metadata-discovery.md
@@ -1,0 +1,107 @@
+---
+title: "MCP サーバーが OAuth Protected Resource Metadata を返すべき理由 — AuthKit と RFC 9728"
+emoji: "🔐"
+type: "tech"
+topics: ["mcp", "oauth", "workos", "supabase", "deno"]
+published: false
+---
+
+## なぜ MCP サーバーに `.well-known/oauth-protected-resource` が要るのか
+
+自分株式会社では Supabase Edge Function を MCP (Model Context Protocol) サーバーとして公開している。クライアントは Claude / Codex / Cursor / VS Code Continue / 自前ブラウザ拡張など多岐にわたる。これらが「どの認可サーバーで token を取れば良いのか」を自律的に発見できないと、新しい client が増えるたびに「ベアラー token は WorkOS AuthKit から / scope は `tool:ai_chat` 形式 / audience は `urn:jibun:tool:<tool>` を含めて」と運用ドキュメントを配り回るハメになる。
+
+これを避けるための仕様が **RFC 9728 (OAuth 2.0 Protected Resource Metadata)** で、要は「保護リソースが `/.well-known/oauth-protected-resource` を返せば、client はそれを見て authorization_servers と scopes を学習できる」というものだ。MCP の最新ドラフトもこの discovery を前提に組み立てられている。
+
+このエントリは、自分株式会社の Edge Function に protected resource metadata を実装した際の設計メモ。コードは [`supabase/functions/_shared/mcp_auth_guard.ts`](https://github.com/kanta13jp1/my_web_app/blob/main/supabase/functions/_shared/mcp_auth_guard.ts) にある。
+
+## 設計の前提
+
+- **AuthKit (WorkOS)** が ID プロバイダ。WorkOS が JWKS / issuer / SSO 画面を提供。
+- **Edge Function (Deno on Supabase)** が保護リソース。1 EF = 複数 MCP tool を載せる「ハブ」構成。
+- **Bearer JWT 検証**: `jose` の `jwtVerify` で署名・有効期限・issuer を確認、audience は `urn:jibun:tool:<tool>` resource indicator (RFC 8707) で別軸検証。
+- **scope の形**: `all` (super-admin) / `tool:<name>` / `<name>` の 3 種を許容。client SDK の癖に合わせて緩めにパース。
+
+## metadata エンドポイントの形
+
+`isOAuthProtectedResourceMetadataRequest(req)` が `/.well-known/oauth-protected-resource` で終わる pathname を判定し、`buildOAuthProtectedResourceMetadata` が JSON を組み立てる。
+
+```ts
+export const OAUTH_PROTECTED_RESOURCE_PATH =
+  "/.well-known/oauth-protected-resource";
+
+export function buildOAuthProtectedResourceMetadata(
+  reqUrl: string,
+  toolName: string,
+  scopes: string[] = [toolName],
+): Record<string, unknown> {
+  const resource = optionalEnv("MCP_RESOURCE_URL") ||
+    protectedResourceUrl(reqUrl);
+  return {
+    resource,
+    resource_name: toolName,
+    authorization_servers: getAuthKitAuthorizationServers(),
+    scopes_supported: uniqueStrings(["all", toolName, ...scopes]),
+    bearer_methods_supported: ["header"],
+    resource_signing_alg_values_supported: ["RS256"],
+    jwks_uri: optionalEnv("WORKOS_JWKS_URL"),
+    authkit_url: optionalEnv("WORKOS_AUTHKIT_URL") ||
+      optionalEnv("WORKOS_AUTHKIT_DOMAIN") || null,
+    token_validation: {
+      audience_checked_by_jwt_verify: false,
+      audience_checked_by_resource_indicator: true,
+      issuer_trailing_slash_tolerant: true,
+    },
+  };
+}
+```
+
+ポイントを 4 つに絞る。
+
+### 1. `resource` は client 側から見た外向き URL
+
+Supabase の Edge Function は `https://<project>.functions.supabase.co/ai-hub` のような URL で公開されるが、CDN や独自ドメインを挟む場合に変わる。`MCP_RESOURCE_URL` を環境変数で先に許し、なければリクエストの `req.url` から `.well-known` 部分を切り落として算出する。
+
+audience claim と一致させる必要があるので、ここを誤ると「token は valid なのに resource indicator の照合で落ちる」という最も診断しにくい失敗が出る。
+
+### 2. `authorization_servers` は AuthKit URL を最優先
+
+`WORKOS_AUTHKIT_URL` (UI flow を集約する short URL) を最初に並べ、その後ろに `WORKOS_ISSUER` (JWT の `iss`) を続ける。理由は、AuthKit URL は client が「ログイン UI を開く先」として、issuer は「トークンの署名者」として使うためで、両方ないと自前 client では完結しない。
+
+### 3. `audience_checked_by_jwt_verify: false` は事故防止
+
+WorkOS のデフォルト JWT は audience claim を埋めない。`jose.jwtVerify` の `audience` オプションを安易に有効化すると、全 token が拒否される地獄が始まる。代わりに RFC 8707 の `resource` indicator で audience をリクエスト時に明示し、サーバ側で `urn:jibun:tool:<tool>` を含むかをチェックする方針を取った。この事実を metadata に書いておくと、client 実装者が「audience が空なのは正常」と判断できる。
+
+### 4. `issuer_trailing_slash_tolerant: true` は経験則
+
+`https://api.workos.com/user_management/<id>` と `https://api.workos.com/user_management/<id>/` が両方流通する。`getWorkOsIssuers()` で trailing slash を 3 通り許容しているのと整合させるためのフラグ。client 側の SDK でも明示的に rstrip するかどうか分かれるので、metadata で「ゆるい」ことを宣言するのは安全側。
+
+## 401 challenge との連動
+
+仕様上もう 1 つ重要なのは、保護リソースが 401 を返すときに `WWW-Authenticate` ヘッダで metadata の URL を指し示すこと。これにより、metadata の存在を知らない client でも、最初の 401 をきっかけに discovery loop に入れる。実装は `mcp_auth_guard` の challenge 構築に組み込んだ。
+
+```text
+WWW-Authenticate: Bearer realm="urn:jibun:tool:ai_chat",
+  resource_metadata="https://<host>/ai-hub/.well-known/oauth-protected-resource"
+```
+
+実体は `protectedResourceUrl(reqUrl)` で組むので、CDN 配下でも client は正しい場所を見にいける。
+
+## scope と server-side gate のペア
+
+discovery は半分でしかなく、もう半分は「`all` scope を勝手に与えない」サーバ側ゲート。同じ PR で入った `agent_tool_policy_server_gate.sql` が、エージェントロール × tool の許諾マトリクスを DB に持たせて、JWT の scope が DB の許諾より広いケースを 403 で弾く。
+
+「メタデータで宣言した scope は本当にその scope しか使えない」を担保するのは、結局は server 側のチェックである。client が学習できるのはあくまで「scope の存在」であって「権限の境界」ではない。
+
+## 学んだこと
+
+1. **metadata は I/O 契約だ。** 一度公開したら client が依存するので、フィールド名と意味は最初に固める。`token_validation` のような独自拡張は名前空間を切ってもよかった。
+2. **trailing slash と audience の罠は実装より運用で焼かれる。** docs に「こうチェックしている」を書ききれていなかった頃は、新規 client 接続のたびに 1 時間溶けた。metadata に書いてからは新規接続が 5 分で済む。
+3. **discovery の代償は「嘘をつかない責任」。** metadata が宣言した authorization_servers / scopes と、実 server の挙動が乖離するとデバッグ不可能になる。CI で metadata と code を両方読むスナップショットテストを足す価値がある。
+
+## 参考
+
+- RFC 9728 — OAuth 2.0 Protected Resource Metadata
+- RFC 8707 — Resource Indicators for OAuth 2.0
+- MCP Authorization (latest draft)
+- WorkOS AuthKit — JWKS / issuer 仕様
+- 自分株式会社 [`docs/MCP_AUTH_SECURITY_PRINCIPLES.md`](https://github.com/kanta13jp1/my_web_app/blob/main/docs/MCP_AUTH_SECURITY_PRINCIPLES.md) Rule 27

--- a/supabase/migrations/20260502170000_seed_achievements_scheduled_daily_s2.sql
+++ b/supabase/migrations/20260502170000_seed_achievements_scheduled_daily_s2.sql
@@ -1,0 +1,10 @@
+-- Scheduled daily-development task: 2026-05-02
+-- Blog drafts (JA + EN) documenting MCP AuthKit metadata + RFC 9728 protected resource endpoint
+
+INSERT INTO development_achievements (title, description, completed_at)
+VALUES (
+  'Blog Draft: MCP AuthKit Metadata + RFC 9728 Protected Resource Discovery',
+  'Wrote JA + EN technical blog drafts (docs/blog-drafts/2026-05-02-mcp-authkit-metadata-discovery{,-en}.md) covering the MCP server discovery endpoint shipped in commit fd173222b. Documents the /.well-known/oauth-protected-resource handler in mcp_auth_guard.ts, AuthKit + WorkOS issuer ordering, RFC 8707 resource indicator audience checks, trailing-slash issuer tolerance, the WWW-Authenticate 401 challenge link to the metadata URL, and the agent_tool_policy_server_gate.sql server-side scope gate as the missing half of discovery. Drafts saved with published: false ready for editorial review.',
+  '2026-05-02'
+)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- JA + EN blog drafts (`docs/blog-drafts/2026-05-02-mcp-authkit-metadata-discovery{,-en}.md`) explaining the RFC 9728 protected resource metadata endpoint shipped in commit fd173222b
- Companion `development_achievements` seed (`supabase/migrations/20260502170000_seed_achievements_scheduled_daily_s2.sql`)
- ROADMAP appended with S2 session log + S3 follow-up candidates

Generated by the scheduled `daily-development` task. Drafts ship with `published: false` for editorial review.

## Test plan
- [ ] Confirm migration timestamp is unique (no collision)
- [ ] Editor pass on JA / EN drafts before flipping `published: true`
- [ ] Optional: spawn dispatch task to publish via dev.to / Qiita / Zenn pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)