### PR TITLE
Guard Notion WBS schema sync

### DIFF
--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -86,6 +86,12 @@ jobs:
               echo "::warning::NOTION_* secrets not configured yet — skip (set in Supabase dashboard)"
               exit 0
             fi
+            # Explicit preflight result from schedule-hub:notion.sync_wbs.
+            if echo "$ERROR" | grep -q "notion_schema_mismatch"; then
+              MISSING=$(echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(', '.join([f'{p.get(\"name\")}:{p.get(\"type\")}' for p in d.get('missing_properties', [])] + [f'{p.get(\"name\")}:{p.get(\"actual\")}->{p.get(\"type\")}' for p in d.get('mismatched_properties', [])]))" 2>/dev/null || echo "")
+              echo "::warning::Notion WBS DB schema mismatch - add/repair required properties: ${MISSING:-id:title, task_title:rich_text, instance:select, status:select, progress:number, deadline:date, updated_at:date}"
+              exit 0
+            fi
             # Notion DB property schema mismatch (e.g. task_title not created yet) → soft-fail
             if echo "$RESP" | grep -q "is not a property that exists"; then
               echo "::warning::Notion DB schema mismatch — add required properties to Notion WBS DB (task_title rich_text / instance select / status select / progress number / deadline date / updated_at date)"

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -345,6 +345,76 @@ async function upsertNotionDatabasePage(
   return "created";
 }
 
+type RequiredNotionProperty = {
+  name: string;
+  type: string;
+};
+
+const NOTION_WBS_REQUIRED_PROPERTIES: RequiredNotionProperty[] = [
+  { name: "id", type: "title" },
+  { name: "task_title", type: "rich_text" },
+  { name: "instance", type: "select" },
+  { name: "status", type: "select" },
+  { name: "progress", type: "number" },
+  { name: "deadline", type: "date" },
+  { name: "updated_at", type: "date" },
+];
+
+async function validateNotionDatabaseSchema(
+  token: string,
+  dbId: string,
+  required: RequiredNotionProperty[],
+): Promise<{
+  ok: boolean;
+  error?: string;
+  status?: number;
+  detail?: string;
+  missing: RequiredNotionProperty[];
+  mismatched: Array<RequiredNotionProperty & { actual: string }>;
+  detected: Record<string, string>;
+}> {
+  const resp = await notionFetch(token, `/databases/${dbId}`);
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => "");
+    return {
+      ok: false,
+      error: "notion_schema_fetch_failed",
+      status: resp.status,
+      detail: detail.slice(0, 300),
+      missing: [],
+      mismatched: [],
+      detected: {},
+    };
+  }
+
+  const payload = await resp.json() as {
+    properties?: Record<string, Record<string, unknown>>;
+  };
+  const properties = payload.properties ?? {};
+  const detected: Record<string, string> = {};
+  for (const [name, property] of Object.entries(properties)) {
+    detected[name] = asString(property.type, "unknown");
+  }
+
+  const missing: RequiredNotionProperty[] = [];
+  const mismatched: Array<RequiredNotionProperty & { actual: string }> = [];
+  for (const property of required) {
+    const actual = detected[property.name];
+    if (!actual) {
+      missing.push(property);
+    } else if (actual !== property.type) {
+      mismatched.push({ ...property, actual });
+    }
+  }
+
+  return {
+    ok: missing.length === 0 && mismatched.length === 0,
+    missing,
+    mismatched,
+    detected,
+  };
+}
+
 function memoryTypeFor(filePath: string, source: unknown): string {
   const name = filePath.split(/[\\/]/).pop() ?? filePath;
   if (name.startsWith("feedback_success_")) return "feedback_success";
@@ -1377,6 +1447,37 @@ serve(async (req: Request) => {
         // Supabase 側から最新 WBS (last_edited 順 30 件) を取得
         // 30件 × ~150ms/task ≈ 4.5s sleep + HTTP = ~30s 合計 (Supabase 150s limit に余裕)
         // 毎時 cron で 30件ずつローリング sync → 141件 ≒ 5h で全件完了
+        const schema = await validateNotionDatabaseSchema(
+          token,
+          dbId,
+          NOTION_WBS_REQUIRED_PROPERTIES,
+        );
+        if (schema.error) {
+          return json({
+            success: false,
+            error: schema.error,
+            detail: schema.detail ?? "",
+          }, schema.status ?? 502);
+        }
+        if (!schema.ok) {
+          return json({
+            success: false,
+            error: "notion_schema_mismatch",
+            missing_properties: schema.missing,
+            mismatched_properties: schema.mismatched,
+            required_properties: NOTION_WBS_REQUIRED_PROPERTIES,
+            detected_properties: schema.detected,
+          }, 422);
+        }
+        if (body.schema_only === true) {
+          return json({
+            success: true,
+            schema_ok: true,
+            required_properties: NOTION_WBS_REQUIRED_PROPERTIES,
+            detected_properties: schema.detected,
+          });
+        }
+
         const limitN = Math.min(Math.max(Number(body.limit ?? 30), 1), 50);
         const offsetN = Math.max(Number(body.offset ?? 0), 0);
         const delayMs = Math.min(

--- a/supabase/migrations/20260502183000_update_wbs_progress_codex3_notion_wbs_schema_guard.sql
+++ b/supabase/migrations/20260502183000_update_wbs_progress_codex3_notion_wbs_schema_guard.sql
@@ -1,0 +1,50 @@
+-- Codex #3 / 2026-05-02: advance Issue #1299 Notion WBS DB sync.
+--
+-- Implemented a fail-closed schema preflight for schedule-hub:notion.sync_wbs
+-- so hourly sync no longer burns a full batch before discovering that the
+-- Notion database is missing required properties.
+
+UPDATE public.wbs_tasks
+SET status = CASE
+      WHEN status = 'completed' THEN status
+      ELSE 'in_progress'
+    END,
+    progress = CASE
+      WHEN status = 'completed' THEN progress
+      ELSE GREATEST(COALESCE(progress, 0), 60)
+    END,
+    recovery_plan = COALESCE(
+      NULLIF(trim(recovery_plan), ''),
+      'Notion WBS sync now has a schedule-hub schema preflight. Remaining user-side work: create/repair the Notion WBS DB properties reported by notion_schema_mismatch, then rerun notion-sync.yml.'
+    ),
+    recovery_planned_at = COALESCE(recovery_planned_at, NOW()),
+    description = COALESCE(description, '') ||
+      E'\n\n[Codex #3 / 2026-05-02] Hardened schedule-hub:notion.sync_wbs with a Notion DB schema preflight for id/title, task_title, instance, status, progress, deadline, and updated_at. notion-sync.yml now soft-fails with the exact missing/mismatched properties instead of creating repeated workflow-failure issues.'
+WHERE github_issue_number = 1299
+  AND title ILIKE '%Notion WBS%';
+
+INSERT INTO development_achievements (title, description, completed_at)
+VALUES (
+  'Codex #3: Notion WBS sync schema preflight',
+  'Added schedule-hub:notion.sync_wbs schema validation and notion-sync.yml handling for notion_schema_mismatch, reducing repeated manual triage and aligning WBS/Notion/NotebookLM automation.',
+  '2026-05-02'
+)
+ON CONFLICT DO NOTHING;
+
+-- Top PowerShell WBS item: BYPASS_RULES can be verified for existence only.
+-- The PAT value and branch-protection bypass capability cannot be read back
+-- from GitHub; final completion still needs a workflow smoke test with no GH006.
+UPDATE public.wbs_tasks
+SET status = CASE
+      WHEN status = 'completed' THEN status
+      ELSE 'in_progress'
+    END,
+    progress = CASE
+      WHEN status = 'completed' THEN progress
+      ELSE GREATEST(COALESCE(progress, 0), 95)
+    END,
+    recovery_plan = 'BYPASS_RULES exists in GitHub Actions secrets as of Codex #3 verification on 2026-05-02. Remaining: observe/trigger one protected-branch push workflow and rotate only if GH006 or permission errors recur.',
+    recovery_planned_at = COALESCE(recovery_planned_at, NOW()),
+    description = COALESCE(description, '') ||
+      E'\n\n[Codex #3 / 2026-05-02] Verified repository secret BYPASS_RULES exists with gh secret list. Secret values and bypass capability are not readable via GitHub API, so final proof remains workflow smoke-test only.'
+WHERE title ILIKE '%BYPASS_RULES%';


### PR DESCRIPTION
## Summary
- Add a schema preflight for `schedule-hub:notion.sync_wbs` before batch syncing WBS rows to Notion.
- Return structured `notion_schema_mismatch` details for missing/mismatched Notion properties.
- Teach `.github/workflows/notion-sync.yml` to soft-fail with a precise warning instead of creating repeated workflow-failure noise.
- Add a WBS progress migration for Issue #1299 and the BYPASS_RULES verification state.

## Verification
- `deno fmt --check supabase/functions/schedule-hub/index.ts`
- `deno lint supabase/functions/schedule-hub/index.ts`
- `deno check supabase/functions/schedule-hub/index.ts`
- `git diff --check HEAD`
- `gh secret list --repo kanta13jp1/my_web_app` confirmed `BYPASS_RULES` and Notion secrets exist.

## Minimal E2E Declaration
- The E2E plan is implementation-detail independent: it validates externally visible `schedule-hub:notion.sync_wbs` responses and workflow behavior, not internal helper names.
- The minimal plan is about three I/O cases: schema OK with `schema_only=true`, missing required Notion property returns `notion_schema_mismatch`, and the workflow soft-fails with a warning for that error.
- E2E mechanism: GitHub Actions/workflow smoke plus Edge Function HTTP integration behavior, comparable to Playwright/integration_test style external verification.
- E2E-Exception: this PR does not add `integration_test/` or `test/e2e/` files because the changed path is a Supabase Edge Function plus GitHub Actions handling that requires live Notion/GitHub secrets. The deterministic coverage here is `deno fmt/lint/check`, `git diff --check`, and CI workflow smoke.

## Remaining Manual Proof
- GitHub does not expose secret values or branch-protection bypass capability via API. Final BYPASS_RULES completion still needs one protected-branch push/workflow smoke test with no GH006 or permission errors.

## Routing
- Advances WBS/Issue #1299 Notion WBS Tasks DB sync.
- BYPASS_RULES remains at smoke-test-only proof stage.

Created by Codex #3 (PowerShell) on 2026-05-02 JST.