### PR TITLE
[codex] Detect NotebookLM auth during session check

### DIFF
--- a/docs/ai-tool-watch/README.md
+++ b/docs/ai-tool-watch/README.md
@@ -17,6 +17,8 @@ Claude Code and Codex changes.
 ## How To Run
 
 ```powershell
+python scripts/codex_session_check.py
+
 python scripts/ai_tool_watch.py `
   --state docs/ai-tool-watch/state.json `
   --report docs/ai-tool-watch/latest-report.md `
@@ -25,6 +27,16 @@ python scripts/ai_tool_watch.py `
 
 Use `--no-save-state` during a manual session-start read if you want a dry
 inspection without changing the baseline.
+
+`codex_session_check.py` runs a soft `notebooklm list` probe and confirms that
+the harness notebook is visible before a NotebookLM-driven session continues.
+If the CLI reports an expired login, run `notebooklm login` locally and rerun
+the check before using `notebooklm ask`.
+
+Never commit or upload NotebookLM browser state. The default
+`%USERPROFILE%\.notebooklm\storage_state.json` file is a local auth artifact,
+not a project secret, and it must stay out of GitHub Actions logs, issues, PR
+comments, and repository files.
 
 ## Automation
 

--- a/scripts/codex_session_check.py
+++ b/scripts/codex_session_check.py
@@ -20,6 +20,10 @@ from pathlib import Path
 from typing import Any
 
 
+NOTEBOOKLM_HARNESS_ID = "bc58b50b-5fc4-4840-9a62-b397d6d3b65a"
+NOTEBOOKLM_LIST_TIMEOUT_SECONDS = 20
+
+
 @dataclass(frozen=True)
 class CommandResult:
     code: int
@@ -39,7 +43,15 @@ def run_git(args: list[str], cwd: Path) -> CommandResult:
     return CommandResult(proc.returncode, proc.stdout.strip(), proc.stderr.strip())
 
 
-def run_command(args: list[str], cwd: Path) -> CommandResult:
+def coerce_completed_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def run_command(args: list[str], cwd: Path, timeout: int | None = None) -> CommandResult:
     try:
         proc = subprocess.run(
             args,
@@ -48,9 +60,16 @@ def run_command(args: list[str], cwd: Path) -> CommandResult:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=False,
+            timeout=timeout,
         )
     except FileNotFoundError as exc:
         return CommandResult(127, "", str(exc))
+    except subprocess.TimeoutExpired as exc:
+        return CommandResult(
+            124,
+            coerce_completed_output(exc.stdout).strip(),
+            coerce_completed_output(exc.stderr).strip(),
+        )
     return CommandResult(proc.returncode, proc.stdout.strip(), proc.stderr.strip())
 
 
@@ -118,6 +137,55 @@ def codex_cli_version(root: Path) -> str:
     return result.stdout or result.stderr or "unknown"
 
 
+def first_nonempty_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def notebooklm_cli_status(root: Path) -> dict[str, Any]:
+    result = run_command(
+        ["notebooklm", "list"],
+        root,
+        timeout=NOTEBOOKLM_LIST_TIMEOUT_SECONDS,
+    )
+    combined_output = "\n".join(part for part in [result.stdout, result.stderr] if part)
+    harness_visible = (
+        NOTEBOOKLM_HARNESS_ID in combined_output
+        or NOTEBOOKLM_HARNESS_ID.split("-", 1)[0] in combined_output
+    )
+
+    if result.code == 0:
+        status = "ok"
+        message = ""
+    elif result.code == 127:
+        status = "unavailable"
+        message = "notebooklm CLI is unavailable on PATH"
+        harness_visible = None
+    elif result.code == 124:
+        status = "timeout"
+        message = f"notebooklm list timed out after {NOTEBOOKLM_LIST_TIMEOUT_SECONDS}s"
+        harness_visible = None
+    elif "Authentication expired" in combined_output or "notebooklm login" in combined_output:
+        status = "auth_expired"
+        message = "NotebookLM CLI authentication expired; run `notebooklm login`"
+        harness_visible = None
+    else:
+        status = "error"
+        message = first_nonempty_line(combined_output) or "notebooklm list failed"
+        harness_visible = None
+
+    return {
+        "status": status,
+        "exit_code": result.code,
+        "harness_notebook_id": NOTEBOOKLM_HARNESS_ID,
+        "harness_visible": harness_visible,
+        "message": message,
+    }
+
+
 def parse_semver(text: str) -> tuple[int, int, int] | None:
     match = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
     if not match:
@@ -137,6 +205,7 @@ def analyze(cwd: Path) -> dict[str, Any]:
     remote_url = git_text(["remote", "get-url", "origin"], root, default="unknown")
     worktrees = worktree_entries(root)
     codex_version = codex_cli_version(root)
+    notebooklm = notebooklm_cli_status(root)
 
     warnings: list[str] = []
     if dirty_lines:
@@ -161,6 +230,19 @@ def analyze(cwd: Path) -> dict[str, Any]:
         warnings.append(
             "Codex CLI is older than 0.128.0; persisted `/goal` workflows are not ready"
         )
+    notebooklm_status = notebooklm["status"]
+    if notebooklm_status == "auth_expired":
+        warnings.append("NotebookLM CLI authentication expired; run `notebooklm login`")
+    elif notebooklm_status == "unavailable":
+        warnings.append("NotebookLM CLI is unavailable on PATH")
+    elif notebooklm_status == "timeout":
+        warnings.append("NotebookLM list timed out; auth state was not verified")
+    elif notebooklm_status == "error":
+        warnings.append("NotebookLM list failed; auth state was not verified")
+    elif notebooklm_status == "ok" and notebooklm["harness_visible"] is False:
+        warnings.append(
+            f"NotebookLM harness notebook `{NOTEBOOKLM_HARNESS_ID}` was not visible in `notebooklm list`"
+        )
 
     return {
         "root": str(root),
@@ -174,6 +256,7 @@ def analyze(cwd: Path) -> dict[str, Any]:
         "dirty_paths": dirty_lines[:20],
         "remote": remote_url,
         "codex_cli_version": codex_version,
+        "notebooklm": notebooklm,
         "worktrees": worktrees,
         "environment": env_snapshot(),
         "warnings": warnings,
@@ -194,8 +277,18 @@ def render_markdown(report: dict[str, Any]) -> str:
         f"- Remote: `{report['remote']}`",
         f"- Codex CLI: `{report['codex_cli_version']}`",
         "",
-        "## Permission / Sandbox Snapshot",
+        "## NotebookLM CLI",
+        f"- Status: `{report['notebooklm']['status']}`",
+        f"- Harness notebook: `{report['notebooklm']['harness_notebook_id']}`",
+        f"- Harness visible in list: `{report['notebooklm']['harness_visible']}`",
     ]
+    if report["notebooklm"]["message"]:
+        lines.append(f"- Note: {report['notebooklm']['message']}")
+
+    lines.extend([
+        "",
+        "## Permission / Sandbox Snapshot",
+    ])
     for key, value in report["environment"].items():
         lines.append(f"- `{key}`: `{value}`")
 

--- a/scripts/codex_session_check_test.py
+++ b/scripts/codex_session_check_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import TestCase, main
+from unittest.mock import patch
+
+import codex_session_check
+from codex_session_check import CommandResult, NOTEBOOKLM_HARNESS_ID
+
+
+class NotebookLmCliStatusTest(TestCase):
+    def status_for(self, result: CommandResult) -> dict[str, object]:
+        def fake_run_command(
+            args: list[str],
+            cwd: Path,
+            timeout: int | None = None,
+        ) -> CommandResult:
+            self.assertEqual(args, ["notebooklm", "list"])
+            self.assertEqual(cwd, Path("."))
+            self.assertEqual(timeout, codex_session_check.NOTEBOOKLM_LIST_TIMEOUT_SECONDS)
+            return result
+
+        with patch.object(codex_session_check, "run_command", side_effect=fake_run_command):
+            return codex_session_check.notebooklm_cli_status(Path("."))
+
+    def test_ok_when_harness_notebook_is_visible(self) -> None:
+        status = self.status_for(
+            CommandResult(0, f"Codex vs Claude Code {NOTEBOOKLM_HARNESS_ID}", "")
+        )
+
+        self.assertEqual(status["status"], "ok")
+        self.assertTrue(status["harness_visible"])
+        self.assertEqual(status["message"], "")
+
+    def test_warns_when_harness_notebook_is_missing(self) -> None:
+        status = self.status_for(CommandResult(0, "other-notebook", ""))
+
+        self.assertEqual(status["status"], "ok")
+        self.assertFalse(status["harness_visible"])
+
+    def test_reports_auth_expiry_without_signin_url(self) -> None:
+        status = self.status_for(
+            CommandResult(
+                1,
+                "",
+                "Error: Authentication expired or invalid.\nRun 'notebooklm login' to re-authenticate.",
+            )
+        )
+
+        self.assertEqual(status["status"], "auth_expired")
+        self.assertIsNone(status["harness_visible"])
+        self.assertIn("notebooklm login", str(status["message"]))
+
+    def test_reports_missing_cli(self) -> None:
+        status = self.status_for(CommandResult(127, "", "not found"))
+
+        self.assertEqual(status["status"], "unavailable")
+        self.assertIsNone(status["harness_visible"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a soft `notebooklm list` probe to `scripts/codex_session_check.py` so session-start reports detect missing CLI, timeout, expired auth, and missing harness notebook visibility.
- Add a dependency-free unittest for NotebookLM CLI status classification.
- Document the NotebookLM auth-state safety rule in `docs/ai-tool-watch/README.md`, including that `storage_state.json` must never be committed or logged.

Closes #1589.

## Verification
- `python scripts\codex_session_check_test.py`
- `python -m py_compile scripts\codex_session_check.py scripts\codex_session_check_test.py`
- `python scripts\codex_session_check.py --json` (NotebookLM status `ok`, harness notebook visible)
- `git diff --check -- scripts/codex_session_check.py scripts/codex_session_check_test.py docs/ai-tool-watch/README.md`

## Minimal E2E Gate
- E2E-Exception: scripts/docs-only session-start automation change; no application UI or user-facing browser flow is modified.
- The verification is implementation-detail independent for application behavior: it exercises the CLI contract and does not inspect Flutter/UI internals.
- Minimal I/O plan, about 3 cases: NotebookLM harness visible succeeds, expired NotebookLM auth reports `auth_expired`, and missing CLI reports `unavailable`.