### PR TITLE
[codex] Add time waste refresh action logging

### DIFF
--- a/lib/widgets/time_waste_guard_widget.dart
+++ b/lib/widgets/time_waste_guard_widget.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:intl/intl.dart';
@@ -8,6 +11,8 @@ import 'package:intl/intl.dart';
 /// ワンタップで「今やめる」宣言し、代替行動を提示する。
 class TimeWasteGuardWidget extends StatefulWidget {
   const TimeWasteGuardWidget({super.key});
+
+  static const int continuousUseReminderMinutes = 120;
 
   static const List<String> guardItemIds = <String>[
     'x_twitter',
@@ -23,6 +28,12 @@ class TimeWasteGuardWidget extends StatefulWidget {
   static String dateKeyFor(DateTime date) =>
       DateFormat('yyyy-MM-dd').format(date);
 
+  static String refreshActionCountKeyFor(DateTime date) =>
+      'twg_refresh_actions_${dateKeyFor(date)}';
+
+  static String refreshActionLastKeyFor(DateTime date) =>
+      'twg_refresh_last_action_${dateKeyFor(date)}';
+
   static Future<int> loadSlipCountFor(DateTime date) async {
     final prefs = await SharedPreferences.getInstance();
     final dateKey = dateKeyFor(date);
@@ -33,6 +44,27 @@ class TimeWasteGuardWidget extends StatefulWidget {
     return total;
   }
 
+  static Future<int> loadRefreshActionCountFor(DateTime date) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(refreshActionCountKeyFor(date)) ?? 0;
+  }
+
+  static Future<String?> loadLastRefreshActionFor(DateTime date) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(refreshActionLastKeyFor(date));
+  }
+
+  static Future<void> recordRefreshAction({
+    required DateTime date,
+    required String action,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final countKey = refreshActionCountKeyFor(date);
+    final nextCount = (prefs.getInt(countKey) ?? 0) + 1;
+    await prefs.setInt(countKey, nextCount);
+    await prefs.setString(refreshActionLastKeyFor(date), action);
+  }
+
   @override
   State<TimeWasteGuardWidget> createState() => _TimeWasteGuardWidgetState();
 }
@@ -40,7 +72,20 @@ class TimeWasteGuardWidget extends StatefulWidget {
 class _TimeWasteGuardWidgetState extends State<TimeWasteGuardWidget> {
   final Map<String, bool> _activeGuards = {};
   final Map<String, int> _todaySlips = {};
+  final math.Random _random = math.Random();
   bool _isExpanded = false;
+  Timer? _sessionReminderTimer;
+  DateTime? _sessionStartedAt;
+  int _refreshActionCount = 0;
+  String? _lastRefreshAction;
+
+  static const List<String> _refreshActionSuggestions = <String>[
+    '10分だけ外を歩く',
+    '画面から離れて本を1ページ読む',
+    '肩と首を3分ストレッチする',
+    '水を飲んで窓際で立つ',
+    '次の具体的な作業を紙に1行書く',
+  ];
 
   static const _items = [
     _GuardItem(
@@ -112,7 +157,15 @@ class _TimeWasteGuardWidgetState extends State<TimeWasteGuardWidget> {
   @override
   void initState() {
     super.initState();
+    _sessionStartedAt = DateTime.now();
     _loadState();
+    _startSessionReminderTimer();
+  }
+
+  @override
+  void dispose() {
+    _sessionReminderTimer?.cancel();
+    super.dispose();
   }
 
   String get _todayKey => DateFormat('yyyy-MM-dd').format(DateTime.now());
@@ -126,12 +179,107 @@ class _TimeWasteGuardWidgetState extends State<TimeWasteGuardWidget> {
           prefs.getBool('twg_active_${_todayKey}_${item.id}') ?? false;
       slips[item.id] = prefs.getInt('twg_slips_${_todayKey}_${item.id}') ?? 0;
     }
+    final today = DateTime.now();
+    final refreshActionCount =
+        prefs.getInt(TimeWasteGuardWidget.refreshActionCountKeyFor(today)) ?? 0;
+    final lastRefreshAction =
+        prefs.getString(TimeWasteGuardWidget.refreshActionLastKeyFor(today));
     if (mounted) {
       setState(() {
         _activeGuards.addAll(guards);
         _todaySlips.addAll(slips);
+        _refreshActionCount = refreshActionCount;
+        _lastRefreshAction = lastRefreshAction;
       });
     }
+  }
+
+  void _startSessionReminderTimer() {
+    _sessionReminderTimer?.cancel();
+    _sessionReminderTimer = Timer.periodic(
+      const Duration(minutes: 1),
+      (_) => _maybeShowContinuousUseReminder(),
+    );
+  }
+
+  String _pickRefreshAction() {
+    final index = _random.nextInt(_refreshActionSuggestions.length);
+    return _refreshActionSuggestions[index];
+  }
+
+  Future<void> _maybeShowContinuousUseReminder() async {
+    final startedAt = _sessionStartedAt;
+    if (!mounted || startedAt == null) return;
+
+    final elapsed = DateTime.now().difference(startedAt);
+    if (elapsed.inMinutes < TimeWasteGuardWidget.continuousUseReminderMinutes) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final reminderKey =
+        'twg_session_reminded_${_todayKey}_${startedAt.millisecondsSinceEpoch}';
+    if (prefs.getBool(reminderKey) ?? false) return;
+    await prefs.setBool(reminderKey, true);
+
+    final action = _pickRefreshAction();
+    if (!mounted) return;
+    final completed = await _showRefreshReminderDialog(action);
+    if (completed == true) {
+      await _recordRefreshAction(action);
+    }
+    if (!mounted) return;
+    setState(() {
+      _sessionStartedAt = DateTime.now();
+    });
+  }
+
+  Future<bool?> _showRefreshReminderDialog(String action) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('リフレッシュの時間です'),
+          content: Text(
+            '約2時間連続で利用しています。短く画面から離れてください。\n\n提案アクション:\n$action',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('後で'),
+            ),
+            FilledButton.icon(
+              onPressed: () => Navigator.of(context).pop(true),
+              icon: const Icon(Icons.check),
+              label: const Text('実行した'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _recordRefreshAction(String action) async {
+    final today = DateTime.now();
+    await TimeWasteGuardWidget.recordRefreshAction(
+      date: today,
+      action: action,
+    );
+    final refreshActionCount =
+        await TimeWasteGuardWidget.loadRefreshActionCountFor(today);
+    final lastRefreshAction =
+        await TimeWasteGuardWidget.loadLastRefreshActionFor(today);
+    if (!mounted) return;
+    setState(() {
+      _refreshActionCount = refreshActionCount;
+      _lastRefreshAction = lastRefreshAction;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('リフレッシュ行動を記録しました: $action'),
+        duration: const Duration(seconds: 3),
+      ),
+    );
   }
 
   Future<void> _activateGuard(String itemId) async {
@@ -255,94 +403,157 @@ class _TimeWasteGuardWidgetState extends State<TimeWasteGuardWidget> {
           if (_isExpanded)
             Padding(
               padding: const EdgeInsets.fromLTRB(10, 0, 10, 10),
-              child: Wrap(
-                spacing: 6,
-                runSpacing: 6,
-                children: _items.map((item) {
-                  final isActive = _activeGuards[item.id] ?? false;
-                  final slips = _todaySlips[item.id] ?? 0;
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildRefreshActionPanel(),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: _items.map((item) {
+                      final isActive = _activeGuards[item.id] ?? false;
+                      final slips = _todaySlips[item.id] ?? 0;
 
-                  return GestureDetector(
-                    onTap: () {
-                      if (isActive) {
-                        _recordSlip(item.id);
-                      } else {
-                        _activateGuard(item.id);
-                      }
-                    },
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 10,
-                        vertical: 6,
-                      ),
-                      decoration: BoxDecoration(
-                        color: isActive
-                            ? item.color.withAlpha(20)
-                            : Theme.of(context)
-                                .colorScheme
-                                .surfaceContainerHigh,
-                        borderRadius: BorderRadius.circular(10),
-                        border: Border.all(
-                          color: isActive
-                              ? item.color.withAlpha(80)
-                              : Theme.of(context)
-                                  .colorScheme
-                                  .surfaceContainerHighest,
-                        ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            item.emoji,
-                            style: const TextStyle(
-                              fontSize: 16,
-                              height: 1.5,
-                            ),
+                      return GestureDetector(
+                        onTap: () {
+                          if (isActive) {
+                            _recordSlip(item.id);
+                          } else {
+                            _activateGuard(item.id);
+                          }
+                        },
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10,
+                            vertical: 6,
                           ),
-                          const SizedBox(width: 4),
-                          Text(
-                            item.label,
-                            style: TextStyle(
-                              fontSize: 12,
-                              fontWeight: isActive
-                                  ? FontWeight.w700
-                                  : FontWeight.normal,
+                          decoration: BoxDecoration(
+                            color: isActive
+                                ? item.color.withAlpha(20)
+                                : Theme.of(context)
+                                    .colorScheme
+                                    .surfaceContainerHigh,
+                            borderRadius: BorderRadius.circular(10),
+                            border: Border.all(
                               color: isActive
-                                  ? item.color
-                                  : Theme.of(context).colorScheme.onSurface,
-                              height: 1.5,
+                                  ? item.color.withAlpha(80)
+                                  : Theme.of(context)
+                                      .colorScheme
+                                      .surfaceContainerHighest,
                             ),
                           ),
-                          if (slips > 0) ...[
-                            const SizedBox(width: 4),
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 4,
-                                vertical: 1,
-                              ),
-                              decoration: BoxDecoration(
-                                color: Colors.red,
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                              child: Text(
-                                '$slips',
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                item.emoji,
                                 style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 9,
-                                  fontWeight: FontWeight.w700,
+                                  fontSize: 16,
                                   height: 1.5,
                                 ),
                               ),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
-                  );
-                }).toList(),
+                              const SizedBox(width: 4),
+                              Text(
+                                item.label,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: isActive
+                                      ? FontWeight.w700
+                                      : FontWeight.normal,
+                                  color: isActive
+                                      ? item.color
+                                      : Theme.of(context).colorScheme.onSurface,
+                                  height: 1.5,
+                                ),
+                              ),
+                              if (slips > 0) ...[
+                                const SizedBox(width: 4),
+                                Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 4,
+                                    vertical: 1,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: Colors.red,
+                                    borderRadius: BorderRadius.circular(6),
+                                  ),
+                                  child: Text(
+                                    '$slips',
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 9,
+                                      fontWeight: FontWeight.w700,
+                                      height: 1.5,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                ],
               ),
             ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRefreshActionPanel() {
+    return Container(
+      key: const Key('time_waste_refresh_action_panel'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFF009688).withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: const Color(0xFF009688).withValues(alpha: 0.20),
+        ),
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.directions_walk,
+            color: Color(0xFF009688),
+            size: 18,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '今日のリフレッシュ: $_refreshActionCount回',
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFF00796B),
+                    height: 1.5,
+                  ),
+                ),
+                if (_lastRefreshAction != null)
+                  Text(
+                    '直近: $_lastRefreshAction',
+                    style: const TextStyle(
+                      fontSize: 11,
+                      color: Color(0xFF00796B),
+                      height: 1.5,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          TextButton.icon(
+            key: const Key('time_waste_log_refresh_action'),
+            onPressed: () => _recordRefreshAction(_pickRefreshAction()),
+            icon: const Icon(Icons.check_circle_outline, size: 16),
+            label: const Text('記録'),
+          ),
         ],
       ),
     );

--- a/test/widgets/time_waste_guard_widget_test.dart
+++ b/test/widgets/time_waste_guard_widget_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/time_waste_guard_widget.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('records refresh actions for the selected day', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final date = DateTime(2026, 5, 2, 10);
+
+    await TimeWasteGuardWidget.recordRefreshAction(
+      date: date,
+      action: '10分だけ外を歩く',
+    );
+    await TimeWasteGuardWidget.recordRefreshAction(
+      date: date,
+      action: '画面から離れて本を1ページ読む',
+    );
+
+    expect(await TimeWasteGuardWidget.loadRefreshActionCountFor(date), 2);
+    expect(
+      await TimeWasteGuardWidget.loadLastRefreshActionFor(date),
+      '画面から離れて本を1ページ読む',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a 2-hour continuous-use refresh reminder to the time-waste guard widget.
- Records completed refresh actions in SharedPreferences and shows today's count / latest action in the expanded guard panel.
- Adds a focused widget helper test for refresh action persistence.

## Context
- WBS: #1270 Diary of a Digital Architect Logic and Impulse checklist follow-up.
- NotebookLM harness mapping: Codex executes scoped changes; deterministic checks remain required before merge.

## Minimal E2E Gate
- Implementation-detail independent: planned verification is from the user-visible home guard panel and reminder dialog behavior, not private widget state.
- Minimal I/O plan: about three cases only: continuous-use reminder appears after threshold, executing a suggested action increments today's count, and returning to the expanded panel shows the latest action for recovery/review.
- E2E mechanism: Flutter integration_test should cover this home-flow once the Dart/Flutter toolchain stops timing out.
- E2E-Exception: draft PR created before adding integration_test because local dart format/analyze/test commands are timing out in this Windows session while another Flutter smoke test and VS Code Dart services are active.

## Validation
- PASS: git diff --check origin/main..HEAD
- BLOCKED: dart format --output=none timed out on this Windows session.
- BLOCKED: dart analyze / flutter analyze timed out while VS Code Dart language-server/tooling-daemon and another flutter web_import_smoke_test were active.

## Follow-up
- Re-run dart format, flutter analyze, and flutter test in CI or a clean Dart toolchain session before marking ready for review.
- Add the Minimal E2E integration_test described above before moving this PR out of draft.