### PR TITLE
chore: add Lefthook quality gate

### DIFF
--- a/.github/workflows/lefthook-quality-gate.yml
+++ b/.github/workflows/lefthook-quality-gate.yml
@@ -1,0 +1,70 @@
+name: Lefthook Quality Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+      - develop
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: lefthook-quality-gate-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  replay-local-gates:
+    name: Replay local quality gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.38.x"
+          channel: stable
+          cache: true
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Check hook-bypass markers
+        run: python scripts/check_no_verify_policy.py --event-path "$GITHUB_EVENT_PATH"
+
+      - name: Replay pre-commit hooks
+        run: npx lefthook run pre-commit --all-files
+
+      - name: Replay pre-push hooks
+        run: npx lefthook run pre-push

--- a/.lefthook/commit-msg/run_quality_gate.py
+++ b/.lefthook/commit-msg/run_quality_gate.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from run_lefthook_job import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.lefthook/pre-commit/run_quality_gate.py
+++ b/.lefthook/pre-commit/run_quality_gate.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from run_lefthook_job import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.lefthook/pre-push/run_quality_gate.py
+++ b/.lefthook/pre-push/run_quality_gate.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from run_lefthook_job import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/automation/lefthook-quality-gate.md
+++ b/docs/automation/lefthook-quality-gate.md
@@ -1,0 +1,61 @@
+# Lefthook Quality Gate
+
+Issue: #1596
+
+This repository uses Lefthook to make the local developer path and the PR path
+run the same fast quality gates. The hook jobs call Python wrappers under
+`.lefthook/` so Windows PowerShell sessions do not depend on Git Bash being
+healthy. Local hooks are useful feedback. GitHub Actions is the source of truth
+because Git does not record whether `git commit --no-verify` was used.
+
+## Local Setup
+
+Run once per worktree:
+
+```powershell
+npm ci
+npm run hooks:install
+```
+
+Some Codex/Claude worktrees inherit a repository-level `core.hooksPath`. If
+Lefthook prints that warning, use manual replay for the current worktree and let
+CI enforce the gate:
+
+```powershell
+npm run hooks:pre-commit
+npm run hooks:pre-push
+```
+
+## Gate Map
+
+| Gate | Local hook | CI replay | Owner |
+| --- | --- | --- | --- |
+| Migration timestamp collision check | `pre-commit` | `Lefthook Quality Gate` | Codex |
+| Edge Function import smoke | `pre-commit` | `Lefthook Quality Gate` | Codex |
+| Explicit hook-bypass marker scan | `commit-msg` / `pre-commit` | `Lefthook Quality Gate` | Claude Code review owner |
+| `flutter analyze` | `pre-push` | `Lefthook Quality Gate` | Codex |
+| Targeted Flutter tests | Existing `CI` workflow | Existing `CI` workflow | Codex |
+| Edge Function lint | `pre-push` | `Lefthook Quality Gate` | Codex #2 |
+| Time-relative migration risk check | `pre-push` | `Lefthook Quality Gate` | Codex #1 / Codex #2 |
+
+The main `CI` workflow still runs the full build and broader test suite. The
+Lefthook workflow exists to prove that bypassed local hooks would still fail in
+PR before merge. Targeted Flutter tests stay in the existing CI path because the
+Windows PowerShell runner can leave stale Dart processes when `flutter test`
+hangs locally; keeping those tests in CI avoids turning local hooks into a
+developer blocker.
+
+## Exception Procedure
+
+Avoid `--no-verify`. If a production incident or broken local toolchain requires
+an exception, get Claude Code approval first, then add this line to the commit
+message:
+
+```text
+Quality-Gate-Exception: <issue-or-pr-url>
+```
+
+The PR must still have a green `Lefthook Quality Gate` check before merge. If
+the workflow fails, route the failure to Codex #2 for CI/operations or Codex #1
+for migration/data review. Codex #4 may take bounded quality-gate follow-up
+work when the root worktree is dirty and a fresh worktree is available.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,40 @@
+commit-msg:
+  jobs:
+    - name: no-verify-policy
+      script: run_quality_gate.py
+      runner: python
+      args: commit-msg {1}
+
+pre-commit:
+  parallel: true
+  jobs:
+    - name: migration-collisions
+      script: run_quality_gate.py
+      runner: python
+      args: migration-collisions
+      glob: "supabase/migrations/*.sql"
+    - name: edge-imports
+      script: run_quality_gate.py
+      runner: python
+      args: edge-imports
+      glob: "supabase/functions/**/*.{ts,json,jsonc}"
+    - name: no-verify-policy
+      script: run_quality_gate.py
+      runner: python
+      args: no-verify-local
+
+pre-push:
+  parallel: false
+  jobs:
+    - name: flutter-analyze
+      script: run_quality_gate.py
+      runner: python
+      args: flutter-analyze
+    - name: edge-lint
+      script: run_quality_gate.py
+      runner: python
+      args: edge-lint
+    - name: migration-time-relative
+      script: run_quality_gate.py
+      runner: python
+      args: migration-time-relative

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,8 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "my_web_app",
       "devDependencies": {
-        "@playwright/test": "^1.59.1"
+        "@playwright/test": "^1.59.1",
+        "lefthook": "^2.1.6"
       }
     },
     "node_modules/@playwright/test": {
@@ -38,6 +40,169 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.6.tgz",
+      "integrity": "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "2.1.6",
+        "lefthook-darwin-x64": "2.1.6",
+        "lefthook-freebsd-arm64": "2.1.6",
+        "lefthook-freebsd-x64": "2.1.6",
+        "lefthook-linux-arm64": "2.1.6",
+        "lefthook-linux-x64": "2.1.6",
+        "lefthook-openbsd-arm64": "2.1.6",
+        "lefthook-openbsd-x64": "2.1.6",
+        "lefthook-windows-arm64": "2.1.6",
+        "lefthook-windows-x64": "2.1.6"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.6.tgz",
+      "integrity": "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.6.tgz",
+      "integrity": "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.6.tgz",
+      "integrity": "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.6.tgz",
+      "integrity": "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.6.tgz",
+      "integrity": "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.6.tgz",
+      "integrity": "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.6.tgz",
+      "integrity": "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.6.tgz",
+      "integrity": "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.6.tgz",
+      "integrity": "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.6.tgz",
+      "integrity": "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/playwright": {
       "version": "1.59.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
+  "name": "my_web_app",
   "private": true,
   "scripts": {
     "e2e": "playwright test",
-    "e2e:smoke": "playwright test test/e2e/public_smoke.spec.ts"
+    "e2e:smoke": "playwright test test/e2e/public_smoke.spec.ts",
+    "hooks:install": "lefthook install",
+    "hooks:pre-commit": "lefthook run pre-commit --all-files",
+    "hooks:pre-push": "lefthook run pre-push"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1"
+    "@playwright/test": "^1.59.1",
+    "lefthook": "^2.1.6"
   }
 }

--- a/scripts/check_no_verify_policy.py
+++ b/scripts/check_no_verify_policy.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Detect explicit hook-bypass signals in commit messages and PR ranges.
+
+Git does not record whether a commit was created with `git commit --no-verify`.
+This guard catches explicit bypass markers that people often leave in commit
+messages, while the Lefthook GitHub Action replays the hook commands to catch
+the practical effect of a skipped local hook.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(errors="replace")
+
+
+BYPASS_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"git\s+commit\b[^\n]*\s--no-verify\b", re.IGNORECASE),
+    re.compile(r"\s--no-verify\b", re.IGNORECASE),
+    re.compile(r"\[skip[ _-]?hooks?\]", re.IGNORECASE),
+    re.compile(r"\[skip[ _-]?lefthook\]", re.IGNORECASE),
+    re.compile(r"\b(?:LEFTHOOK|HUSKY)\s*=\s*0\b", re.IGNORECASE),
+    re.compile(r"\blefthook\s+(?:skip|disable)\b", re.IGNORECASE),
+)
+EXCEPTION_RE = re.compile(r"^Quality-Gate-Exception:\s*(\S.+)$", re.IGNORECASE | re.MULTILINE)
+RANGE_SEP = "\x1e"
+FIELD_SEP = "\x1f"
+
+
+@dataclass(frozen=True)
+class BypassSignal:
+    source: str
+    pattern: str
+    line: str
+
+
+def has_exception_marker(text: str) -> bool:
+    return bool(EXCEPTION_RE.search(text))
+
+
+def find_bypass_signals(source: str, text: str) -> list[BypassSignal]:
+    if has_exception_marker(text):
+        return []
+
+    signals: list[BypassSignal] = []
+    for line in text.splitlines():
+        for pattern in BYPASS_PATTERNS:
+            if pattern.search(line):
+                signals.append(
+                    BypassSignal(
+                        source=source,
+                        pattern=pattern.pattern,
+                        line=line.strip(),
+                    )
+                )
+                break
+    return signals
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def resolve_range_from_event(event_path: str | None) -> tuple[str, str] | None:
+    if not event_path:
+        return None
+
+    path = Path(event_path)
+    if not path.exists():
+        return None
+
+    event = json.loads(read_text(path))
+    pull_request = event.get("pull_request")
+    if pull_request:
+        return pull_request["base"]["sha"], pull_request["head"]["sha"]
+
+    before = event.get("before")
+    after = event.get("after")
+    if before and after and not str(before).startswith("0000000"):
+        return str(before), str(after)
+
+    return None
+
+
+def git_log_messages(base: str, head: str) -> list[tuple[str, str]]:
+    result = subprocess.run(
+        [
+            "git",
+            "log",
+            "--format=%H%x1f%B%x1e",
+            f"{base}..{head}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    commits: list[tuple[str, str]] = []
+    for record in result.stdout.split(RANGE_SEP):
+        record = record.strip()
+        if not record:
+            continue
+        if FIELD_SEP not in record:
+            continue
+        sha, message = record.split(FIELD_SEP, 1)
+        commits.append((sha.strip(), message.strip()))
+    return commits
+
+
+def print_result(signals: list[BypassSignal]) -> int:
+    if not signals:
+        print("OK no explicit hook-bypass markers found")
+        return 0
+
+    print("FAIL explicit hook-bypass marker(s) detected:")
+    for signal in signals:
+        print(f"- {signal.source}: {signal.line}")
+    print("")
+    print("Do not bypass local gates silently. If an emergency exception is approved,")
+    print("add `Quality-Gate-Exception: <issue-or-pr-url>` to the commit message")
+    print("and make sure the Lefthook Quality Gate workflow is green before merge.")
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--commit-msg-file", type=Path)
+    parser.add_argument("--event-path", default=os.environ.get("GITHUB_EVENT_PATH"))
+    parser.add_argument("--range", dest="commit_range")
+    parser.add_argument("--local", action="store_true")
+    args = parser.parse_args()
+
+    signals: list[BypassSignal] = []
+
+    if args.commit_msg_file:
+        signals.extend(
+            find_bypass_signals(
+                str(args.commit_msg_file),
+                read_text(args.commit_msg_file),
+            )
+        )
+        return print_result(signals)
+
+    commit_range: tuple[str, str] | None = None
+    if args.commit_range:
+        if ".." not in args.commit_range:
+            print("--range must be formatted as base..head", file=sys.stderr)
+            return 2
+        base, head = args.commit_range.split("..", 1)
+        commit_range = (base, head)
+    else:
+        commit_range = resolve_range_from_event(args.event_path)
+
+    if commit_range:
+        base, head = commit_range
+        for sha, message in git_log_messages(base, head):
+            short = sha[:12]
+            signals.extend(find_bypass_signals(f"commit {short}", message))
+        return print_result(signals)
+
+    if args.local:
+        print("OK no commit range available in local pre-commit context")
+        return 0
+
+    print("No commit range resolved; bypass marker scan skipped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_no_verify_policy_test.py
+++ b/scripts/check_no_verify_policy_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+
+from check_no_verify_policy import find_bypass_signals
+
+
+class NoVerifyPolicyTest(unittest.TestCase):
+    def test_detects_no_verify_flag(self) -> None:
+        signals = find_bypass_signals(
+            "commit abc123",
+            "temporary unblock\n\ngit commit --no-verify was used",
+        )
+        self.assertEqual(len(signals), 1)
+
+    def test_detects_skip_hooks_marker(self) -> None:
+        signals = find_bypass_signals("commit abc123", "fix lint [skip hooks]")
+        self.assertEqual(len(signals), 1)
+
+    def test_allows_approved_exception_marker(self) -> None:
+        signals = find_bypass_signals(
+            "commit abc123",
+            "emergency unblock --no-verify\n\nQuality-Gate-Exception: https://github.com/kanta13jp1/my_web_app/issues/1596",
+        )
+        self.assertEqual(signals, [])
+
+    def test_does_not_flag_plain_topic_text(self) -> None:
+        signals = find_bypass_signals(
+            "commit abc123",
+            "docs: explain no-verify quality gate policy",
+        )
+        self.assertEqual(signals, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run_lefthook_job.py
+++ b/scripts/run_lefthook_job.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Run Lefthook jobs without relying on Git Bash on Windows."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+WINDOWS_EXECUTABLE_FALLBACKS: dict[str, tuple[Path, ...]] = {
+    "flutter": (
+        Path("C:/app/flutter/bin/flutter.bat"),
+        Path("C:/app/flutter/bin/flutter"),
+    ),
+}
+
+
+def resolve_command(command: list[str]) -> list[str]:
+    executable = command[0]
+    if os.name == "nt":
+        for fallback in WINDOWS_EXECUTABLE_FALLBACKS.get(executable, ()):
+            if fallback.exists():
+                return [str(fallback), *command[1:]]
+
+    if shutil.which(executable):
+        return command
+
+    return command
+
+
+def run(command: list[str]) -> int:
+    os.chdir(REPO_ROOT)
+    command = resolve_command(command)
+    print("$ " + " ".join(command))
+    try:
+        completed = subprocess.run(command, check=False)
+    except FileNotFoundError as exc:
+        print(f"missing executable: {exc.filename}", file=sys.stderr)
+        return 127
+    return completed.returncode
+
+
+def command_for(job: str, args: list[str]) -> list[str]:
+    python = sys.executable
+    commands: dict[str, list[str]] = {
+        "migration-collisions": [python, "scripts/check_migration_timestamps.py"],
+        "edge-imports": [python, "scripts/check_edge_function_imports.py"],
+        "no-verify-local": [python, "scripts/check_no_verify_policy.py", "--local"],
+        "flutter-analyze": ["flutter", "analyze"],
+        "edge-lint": [
+            "deno",
+            "lint",
+            "--config",
+            "supabase/functions/deno.json",
+            "supabase/functions/",
+        ],
+        "migration-time-relative": [
+            python,
+            "scripts/check_migration_time_relative_check.py",
+        ],
+    }
+
+    if job == "commit-msg":
+        if not args:
+            raise ValueError("commit-msg requires the commit message file path")
+        return [python, "scripts/check_no_verify_policy.py", "--commit-msg-file", args[0]]
+
+    if job not in commands:
+        raise ValueError(f"unknown Lefthook job: {job}")
+    return commands[job]
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        print("usage: run_lefthook_job.py <job> [args...]", file=sys.stderr)
+        return 2
+
+    job, rest = argv[0], argv[1:]
+    try:
+        command = command_for(job, rest)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    return run(command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds Lefthook v2.1.6 config and npm scripts for local `commit-msg`, `pre-commit`, and `pre-push` quality gates.
- Adds a `Lefthook Quality Gate` GitHub Actions workflow to replay local gates in PRs, so skipped local hooks are caught before merge.
- Adds explicit hook-bypass marker detection plus docs for Windows PowerShell worktrees, role ownership, and exception handling.

## Minimal E2E Gate
- The E2E plan is implementation-detail independent / black-box because this PR changes development tooling, scripts, docs, and CI wiring rather than app runtime behavior.
- The plan is minimal: about three I/O cases remain covered by the existing Playwright public smoke gate for load, route visibility, and basic interaction stability.
- E2E mechanism: Playwright via the existing `Minimal E2E Gate` workflow; no new `integration_test/` or `test/e2e/` file is needed for this non-app-code change.

## Verification
- `python scripts/check_no_verify_policy_test.py`
- `python -m py_compile scripts/check_no_verify_policy.py scripts/check_no_verify_policy_test.py scripts/run_lefthook_job.py .lefthook/commit-msg/run_quality_gate.py .lefthook/pre-commit/run_quality_gate.py .lefthook/pre-push/run_quality_gate.py`
- `npx lefthook validate`
- `npx lefthook run pre-commit --all-files`
- `npx lefthook run pre-push` (passes `flutter analyze`, Deno lint, migration time-relative check)

Refs #1596.
Refs #1620.