### PR TITLE
feat: route memory search from query reports

### DIFF
--- a/docs/issue-fix-plans/issue-1264.md
+++ b/docs/issue-fix-plans/issue-1264.md
@@ -1,0 +1,39 @@
+# Issue #1264 Query Report Routing
+
+## Goal
+
+Implement the first backend slice for Pleias-style query reports:
+
+- parse query report state from tags, JSON, or line-based metadata
+- rerun search with a reformulated query when the report says `reformulated`
+- stop retrieval and return a clarification response when the report says
+  `unclear`
+
+## Implementation
+
+- Added `supabase/functions/memory-search-hub/query_report.ts` as a pure parser
+  and routing decision helper.
+- Added `memory.query_route` to `memory-search-hub`.
+- Kept `memory.search` behavior unchanged for existing callers.
+
+## Contract
+
+Input:
+
+```json
+{
+  "action": "memory.query_route",
+  "query": "Pleias",
+  "query_report": "state: reformulated\nsearch_query: Pleias Open Data Layers enterprise RAG"
+}
+```
+
+Output:
+
+- `200` with normal memory search results when the route is searchable.
+- `422` with `error=query_clarification_required` when the route is unclear.
+
+## Verification
+
+- `deno test --config supabase/functions/deno.json supabase/functions/memory-search-hub/query_report_test.ts`
+- `deno check --config supabase/functions/deno.json supabase/functions/memory-search-hub/index.ts`

--- a/supabase/functions/memory-search-hub/index.ts
+++ b/supabase/functions/memory-search-hub/index.ts
@@ -14,6 +14,7 @@ import {
   rankBm25,
   ScoredMemoryDocument,
 } from "./search/bm25.ts";
+import { buildQueryRouteDecision } from "./query_report.ts";
 import { rerankWithHaiku } from "./search/rerank.ts";
 import { vectorSearch } from "./search/vector.ts";
 
@@ -184,6 +185,57 @@ async function memorySearch(body: Body) {
   });
 }
 
+async function memoryQueryRoute(body: Body) {
+  const query = asString(body.query);
+  if (!query) return jsonResponse({ error: "query required" }, 400);
+
+  const rawReport = asString(
+    body.query_report ?? body.queryReport ?? body.report,
+  );
+  if (!rawReport) {
+    return jsonResponse({ error: "query_report required" }, 400);
+  }
+
+  const route = buildQueryRouteDecision(query, rawReport);
+  const queryRoute = {
+    state: route.state,
+    action: route.action,
+    original_query: query,
+    search_query: route.searchQuery,
+    used_reformulated_query:
+      route.action === "search" && route.searchQuery !== query,
+    feedback: route.feedback,
+    parsed_report: {
+      state: route.report.state,
+      reformulated_query: route.report.reformulatedQuery,
+      reason: route.report.reason,
+    },
+  };
+
+  if (route.action === "clarify") {
+    return jsonResponse({
+      success: false,
+      action: "memory.query_route",
+      error: "query_clarification_required",
+      query_route: queryRoute,
+    }, 422);
+  }
+
+  const response = await memorySearch({
+    ...body,
+    query: route.searchQuery,
+  });
+  const payload = await response.json() as Record<string, unknown>;
+  return jsonResponse({
+    ...payload,
+    action: "memory.query_route",
+    original_action: payload.action,
+    original_query: query,
+    query: route.searchQuery,
+    query_route: queryRoute,
+  }, response.status);
+}
+
 async function memoryRank(body: Body) {
   const query = asString(body.query);
   const candidates = asStringArray(body.candidates ?? body.file_paths, 20);
@@ -287,6 +339,7 @@ serve(async (req: Request) => {
       buildOAuthProtectedResourceMetadata(req.url, "memory-search-hub", [
         "memory",
         "memory.search",
+        "memory.query_route",
         "memory.rank",
         "memory.related",
         "memory.stats",
@@ -316,6 +369,9 @@ serve(async (req: Request) => {
     switch (action) {
       case "memory.search":
         response = await memorySearch(body);
+        break;
+      case "memory.query_route":
+        response = await memoryQueryRoute(body);
         break;
       case "memory.rank":
         response = await memoryRank(body);

--- a/supabase/functions/memory-search-hub/query_report.ts
+++ b/supabase/functions/memory-search-hub/query_report.ts
@@ -1,0 +1,207 @@
+export type QueryReportState =
+  | "trivial"
+  | "reformulated"
+  | "unclear"
+  | "unknown";
+
+export interface ParsedQueryReport {
+  state: QueryReportState;
+  reformulatedQuery: string | null;
+  reason: string | null;
+  raw: string;
+}
+
+export interface QueryRouteDecision {
+  action: "search" | "clarify";
+  state: QueryReportState;
+  searchQuery: string;
+  feedback: string | null;
+  report: ParsedQueryReport;
+}
+
+const STATE_FIELDS = [
+  "state",
+  "status",
+  "query_state",
+  "queryStatus",
+  "classification",
+] as const;
+
+const REFORMULATED_QUERY_FIELDS = [
+  "reformulated_query",
+  "reformulatedQuery",
+  "reformulated",
+  "rewritten_query",
+  "rewrittenQuery",
+  "search_query",
+  "searchQuery",
+  "query",
+] as const;
+
+const REASON_FIELDS = ["reason", "message", "feedback", "explanation"] as const;
+
+function normalizeState(value: string): QueryReportState {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return "unknown";
+  if (
+    normalized.includes("reformulated") ||
+    normalized.includes("reformulate") ||
+    normalized.includes("rewritten") ||
+    normalized.includes("rewrite")
+  ) {
+    return "reformulated";
+  }
+  if (
+    normalized.includes("unclear") ||
+    normalized.includes("ambiguous") ||
+    normalized.includes("clarify") ||
+    normalized.includes("insufficient")
+  ) {
+    return "unclear";
+  }
+  if (
+    normalized.includes("trivial") ||
+    normalized.includes("clear") ||
+    normalized.includes("answerable")
+  ) {
+    return "trivial";
+  }
+  return "unknown";
+}
+
+function firstJsonObject(text: string): Record<string, unknown> | null {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start < 0 || end <= start) return null;
+  try {
+    const parsed = JSON.parse(text.slice(start, end + 1));
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function valueFromRecord(
+  record: Record<string, unknown> | null,
+  fields: readonly string[],
+): string {
+  if (!record) return "";
+  const lowerFields = fields.map((field) => field.toLowerCase());
+  for (const [key, value] of Object.entries(record)) {
+    if (!lowerFields.includes(key.toLowerCase())) continue;
+    if (typeof value === "string") return value.trim();
+    if (typeof value === "number" || typeof value === "boolean") {
+      return String(value);
+    }
+  }
+  return "";
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function valueFromTags(text: string, fields: readonly string[]): string {
+  for (const field of fields) {
+    const escaped = escapeRegExp(field);
+    const xmlPattern = new RegExp(
+      `<${escaped}[^>]*>([\\s\\S]*?)<\\/${escaped}>`,
+      "i",
+    );
+    const xmlMatch = text.match(xmlPattern);
+    if (xmlMatch?.[1]) return xmlMatch[1].trim();
+
+    const sentinelPattern = new RegExp(
+      `<\\|${escaped}\\|>([\\s\\S]*?)<\\|\\/${escaped}\\|>`,
+      "i",
+    );
+    const sentinelMatch = text.match(sentinelPattern);
+    if (sentinelMatch?.[1]) return sentinelMatch[1].trim();
+  }
+  return "";
+}
+
+function valueFromLines(text: string, fields: readonly string[]): string {
+  for (const field of fields) {
+    const escaped = escapeRegExp(field);
+    const pattern = new RegExp(`^\\s*${escaped}\\s*[:=]\\s*(.+)$`, "im");
+    const match = text.match(pattern);
+    if (match?.[1]) return match[1].trim();
+  }
+  return "";
+}
+
+function readValue(
+  text: string,
+  record: Record<string, unknown> | null,
+  fields: readonly string[],
+): string {
+  return valueFromRecord(record, fields) ||
+    valueFromTags(text, fields) ||
+    valueFromLines(text, fields);
+}
+
+export function parseQueryReport(rawReport: string): ParsedQueryReport {
+  const raw = rawReport.trim();
+  const record = firstJsonObject(raw);
+  const stateValue = readValue(raw, record, STATE_FIELDS);
+  const reformulatedQuery = readValue(raw, record, REFORMULATED_QUERY_FIELDS);
+  const reason = readValue(raw, record, REASON_FIELDS);
+
+  return {
+    state: normalizeState(stateValue || raw),
+    reformulatedQuery: reformulatedQuery || null,
+    reason: reason || null,
+    raw,
+  };
+}
+
+export function buildQueryRouteDecision(
+  originalQuery: string,
+  rawReport: string,
+): QueryRouteDecision {
+  const query = originalQuery.trim();
+  const report = parseQueryReport(rawReport);
+
+  if (report.state === "unclear") {
+    return {
+      action: "clarify",
+      state: report.state,
+      searchQuery: query,
+      feedback: report.reason ??
+        "入力意図が不明瞭です。検索対象、条件、知りたい結論をもう少し具体的にしてください。",
+      report,
+    };
+  }
+
+  if (report.state === "reformulated") {
+    if (!report.reformulatedQuery) {
+      return {
+        action: "clarify",
+        state: report.state,
+        searchQuery: query,
+        feedback:
+          "クエリは再定式化が必要と判定されましたが、再検索用クエリが見つかりませんでした。検索語を具体化してください。",
+        report,
+      };
+    }
+    return {
+      action: "search",
+      state: report.state,
+      searchQuery: report.reformulatedQuery,
+      feedback: report.reason,
+      report,
+    };
+  }
+
+  return {
+    action: "search",
+    state: report.state,
+    searchQuery: query,
+    feedback: report.reason,
+    report,
+  };
+}

--- a/supabase/functions/memory-search-hub/query_report_test.ts
+++ b/supabase/functions/memory-search-hub/query_report_test.ts
@@ -1,0 +1,71 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildQueryRouteDecision,
+  parseQueryReport,
+} from "./query_report.ts";
+
+Deno.test("parseQueryReport reads reformulated XML style tags", () => {
+  const report = parseQueryReport(`
+    <query_report>
+      <status>reformulated</status>
+      <reformulated_query>Pleias RAG citation token handling</reformulated_query>
+      <reason>Original query was too broad.</reason>
+    </query_report>
+  `);
+
+  assertEquals(report.state, "reformulated");
+  assertEquals(
+    report.reformulatedQuery,
+    "Pleias RAG citation token handling",
+  );
+  assertEquals(report.reason, "Original query was too broad.");
+});
+
+Deno.test("buildQueryRouteDecision reruns search with reformulated query", () => {
+  const route = buildQueryRouteDecision(
+    "Pleias",
+    [
+      "state: reformulated",
+      "search_query: Pleias Open Data Layers enterprise RAG",
+    ].join("\n"),
+  );
+
+  assertEquals(route.action, "search");
+  assertEquals(route.state, "reformulated");
+  assertEquals(route.searchQuery, "Pleias Open Data Layers enterprise RAG");
+});
+
+Deno.test("buildQueryRouteDecision stops unclear queries before search", () => {
+  const route = buildQueryRouteDecision(
+    "あれを調べて",
+    JSON.stringify({
+      state: "unclear",
+      feedback: "対象が不足しています。",
+    }),
+  );
+
+  assertEquals(route.action, "clarify");
+  assertEquals(route.state, "unclear");
+  assertEquals(route.feedback, "対象が不足しています。");
+});
+
+Deno.test("buildQueryRouteDecision falls back to original query for trivial reports", () => {
+  const route = buildQueryRouteDecision(
+    "Pleias citation tokens",
+    "<|state|>trivial<|/state|>",
+  );
+
+  assertEquals(route.action, "search");
+  assertEquals(route.state, "trivial");
+  assertEquals(route.searchQuery, "Pleias citation tokens");
+});
+
+Deno.test("buildQueryRouteDecision asks for clarification when reformulated query is missing", () => {
+  const route = buildQueryRouteDecision(
+    "Pleias",
+    "status: reformulated",
+  );
+
+  assertEquals(route.action, "clarify");
+  assertEquals(route.state, "reformulated");
+});


### PR DESCRIPTION
## Summary
- add a pure Pleias-style query report parser for memory-search-hub
- add memory.query_route so reformulated reports rerun search with the rewritten query
- return query_clarification_required for unclear reports before retrieval starts

## Minimal E2E Gate
- Implementation-detail independent black-box I/O plan using the Edge Function API boundary rather than parser internals.
- Minimal three cases:
  1. Input: query_report says reformulated with search_query -> Output: memory.query_route searches with the reformulated query and returns query_route.used_reformulated_query=true.
  2. Input: query_report says unclear with feedback -> Output: memory.query_route returns 422 query_clarification_required before retrieval.
  3. Input: query_report says trivial -> Output: memory.query_route searches with the original query.
- E2E mechanism: this slice is an Edge Function API contract suitable for Playwright/API smoke coverage; deterministic Deno tests cover the same I/O contract now.
- E2E-Exception: no browser integration_test file is added because this PR exposes a backend-only Edge Function action with no new user-facing route.

## Validation
- deno test --config supabase/functions/deno.json supabase/functions/memory-search-hub/query_report_test.ts
- deno check --config supabase/functions/deno.json supabase/functions/memory-search-hub/index.ts
- deno lint --config supabase/functions/deno.json supabase/functions/memory-search-hub/query_report.ts supabase/functions/memory-search-hub/query_report_test.ts supabase/functions/memory-search-hub/index.ts
- git diff --check

Fixes #1264