### PR TITLE
feat: add AI journal feedback loop

### DIFF
--- a/docs/issue-fix-plans/issue-1271.md
+++ b/docs/issue-fix-plans/issue-1271.md
@@ -1,0 +1,20 @@
+# Issue #1271: AI日記分析・フィードバック
+
+## Goal
+
+Daily diary entries should turn into actionable feedback: emotion/trigger analysis, next-day action proposals, and saved records that can be reviewed later.
+
+## Implemented slice
+
+- `mental_health_records` table with RLS and AI analysis columns.
+- `lifestyle-hub` actions:
+  - `journal.analyze`: save or load a diary record, analyze it with `ai-hub` when available, fall back to deterministic local analysis, and create next-day `daily_todos`.
+  - `journal.list`: list the user's recent diary analysis records.
+- `MentalHealthTrackerPage` now has clean Japanese copy, an "AI分析して保存" flow, history cards, tags, and next-action display.
+
+## Validation
+
+- `deno test --config supabase/functions/deno.json supabase/functions/lifestyle-hub/journal_analysis_test.ts`
+- `deno check --config supabase/functions/deno.json supabase/functions/lifestyle-hub/index.ts`
+- `deno lint --config supabase/functions/deno.json supabase/functions/lifestyle-hub/index.ts supabase/functions/lifestyle-hub/journal_analysis.ts supabase/functions/lifestyle-hub/journal_analysis_test.ts`
+- `flutter analyze lib/pages/mental_health_tracker_page.dart`

--- a/lib/pages/mental_health_tracker_page.dart
+++ b/lib/pages/mental_health_tracker_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-/// AIメンタルヘルスケアページ
-/// 気分・ストレス・睡眠・感情を記録しAIが統合分析。
-/// Calm / Headspace / Woebot 対抗。
 class MentalHealthTrackerPage extends StatefulWidget {
   const MentalHealthTrackerPage({super.key});
 
@@ -14,20 +11,21 @@ class MentalHealthTrackerPage extends StatefulWidget {
 
 class _MentalHealthTrackerPageState extends State<MentalHealthTrackerPage> {
   final _supabase = Supabase.instance.client;
+  final _noteCtrl = TextEditingController();
 
   bool _loading = false;
+  bool _saving = false;
   String? _error;
+  String? _latestSummary;
+  int _createdTaskCount = 0;
   List<Map<String, dynamic>> _records = [];
 
   int _moodScore = 3;
   int _stressScore = 3;
   int _sleepHours = 7;
-  final _noteCtrl = TextEditingController();
-  bool _saving = false;
 
   static const _moodLabels = ['最悪', '悪い', '普通', '良い', '最高'];
-  static const _moodIcons = ['😞', '😔', '😐', '🙂', '😄'];
-  static const _stressLabels = ['なし', '少し', '普通', '多め', '限界'];
+  static const _stressLabels = ['なし', '少し', '普通', '多い', '限界'];
 
   @override
   void initState() {
@@ -48,14 +46,21 @@ class _MentalHealthTrackerPageState extends State<MentalHealthTrackerPage> {
     });
     try {
       final userId = _supabase.auth.currentUser?.id;
-      if (userId == null) return;
+      if (userId == null) {
+        setState(() => _records = []);
+        return;
+      }
       final data = await _supabase
           .from('mental_health_records')
           .select()
           .eq('user_id', userId)
           .order('recorded_at', ascending: false)
           .limit(30);
-      setState(() => _records = (data as List).cast<Map<String, dynamic>>());
+      setState(() {
+        _records = (data as List)
+            .map((item) => Map<String, dynamic>.from(item as Map))
+            .toList();
+      });
     } catch (e) {
       if (!mounted) return;
       setState(() => _error = e.toString());
@@ -64,42 +69,72 @@ class _MentalHealthTrackerPageState extends State<MentalHealthTrackerPage> {
     }
   }
 
-  Future<void> _save() async {
-    final userId = _supabase.auth.currentUser?.id;
-    if (userId == null) return;
-    setState(() => _saving = true);
+  Future<void> _saveAndAnalyze() async {
+    if (_noteCtrl.text.trim().isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('日記メモを入力してください')),
+      );
+      return;
+    }
+    setState(() {
+      _saving = true;
+      _latestSummary = null;
+      _createdTaskCount = 0;
+    });
     try {
-      await _supabase.from('mental_health_records').insert({
-        'user_id': userId,
-        'mood_score': _moodScore,
-        'stress_score': _stressScore,
-        'sleep_hours': _sleepHours,
-        'note': _noteCtrl.text.trim().isEmpty ? null : _noteCtrl.text.trim(),
-        'recorded_at': DateTime.now().toIso8601String(),
-      });
-      _noteCtrl.clear();
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('記録を保存しました')),
-        );
+      final response = await _supabase.functions.invoke(
+        'lifestyle-hub',
+        body: {
+          'action': 'journal.analyze',
+          'note': _noteCtrl.text.trim(),
+          'mood_score': _moodScore,
+          'stress_score': _stressScore,
+          'sleep_hours': _sleepHours,
+          'create_tomorrow_tasks': true,
+        },
+      );
+      final data = Map<String, dynamic>.from(response.data as Map);
+      if (data['success'] != true) {
+        throw Exception(data['error'] ?? 'AI分析に失敗しました');
       }
+      final insight = Map<String, dynamic>.from(data['insight'] as Map);
+      final createdTasks = (data['created_tasks'] as List?) ?? const [];
+      _noteCtrl.clear();
+      if (!mounted) return;
+      setState(() {
+        _latestSummary = insight['summary'] as String?;
+        _createdTaskCount = createdTasks.length;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('AI分析を保存し、翌日のTODOを${createdTasks.length}件作成しました'),
+        ),
+      );
       await _load();
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('保存失敗: $e')),
-        );
-      }
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('保存に失敗しました: $e')),
+      );
     } finally {
       if (mounted) setState(() => _saving = false);
     }
+  }
+
+  List<String> _stringList(Object? value) {
+    if (value is List) {
+      return value.map((item) => item.toString()).where((item) {
+        return item.trim().isNotEmpty;
+      }).toList();
+    }
+    return const [];
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('AIメンタルヘルスケア'),
+        title: const Text('AI日記フィードバック'),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
@@ -108,12 +143,16 @@ class _MentalHealthTrackerPageState extends State<MentalHealthTrackerPage> {
           ),
         ],
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
           children: [
             _buildRecordCard(),
+            if (_latestSummary != null) ...[
+              const SizedBox(height: 12),
+              _buildLatestResult(),
+            ],
             const SizedBox(height: 20),
             _buildHistorySection(),
           ],
@@ -131,91 +170,125 @@ class _MentalHealthTrackerPageState extends State<MentalHealthTrackerPage> {
           children: [
             const Row(
               children: [
-                Icon(Icons.favorite, color: Color(0xFFFF6B35)),
+                Icon(Icons.psychology_alt, color: Color(0xFFFF6B35)),
                 SizedBox(width: 8),
                 Text(
-                  '今日の状態を記録',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                    height: 1.5,
-                  ),
+                  '今日の思考と行動を記録',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                 ),
               ],
             ),
+            const SizedBox(height: 8),
+            const Text(
+              '日記を保存するとAIが感情・支出・健康・仕事のトリガーを分析し、明日のTODOへ小さな行動を追加します。',
+            ),
             const SizedBox(height: 16),
-            Text(
-              '気分: ${_moodIcons[_moodScore - 1]} ${_moodLabels[_moodScore - 1]}',
-              style: const TextStyle(
-                fontWeight: FontWeight.w600,
-                height: 1.5,
-              ),
+            _buildSlider(
+              label: '気分',
+              value: _moodScore,
+              labels: _moodLabels,
+              activeColor: const Color(0xFF3D5AFE),
+              onChanged: (value) => setState(() => _moodScore = value),
             ),
-            Slider(
-              value: _moodScore.toDouble(),
-              min: 1,
-              max: 5,
-              divisions: 4,
-              onChanged: (v) => setState(() => _moodScore = v.round()),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'ストレス: ${_stressLabels[_stressScore - 1]}',
-              style: const TextStyle(
-                fontWeight: FontWeight.w600,
-                height: 1.5,
-              ),
-            ),
-            Slider(
-              value: _stressScore.toDouble(),
-              min: 1,
-              max: 5,
-              divisions: 4,
+            _buildSlider(
+              label: 'ストレス',
+              value: _stressScore,
+              labels: _stressLabels,
               activeColor: const Color(0xFFFF6B35),
-              onChanged: (v) => setState(() => _stressScore = v.round()),
+              onChanged: (value) => setState(() => _stressScore = value),
             ),
-            const SizedBox(height: 8),
             Text(
-              '睡眠時間: $_sleepHours時間',
-              style: const TextStyle(
-                fontWeight: FontWeight.w600,
-                height: 1.5,
-              ),
+              '睡眠: $_sleepHours時間',
+              style: const TextStyle(fontWeight: FontWeight.w600),
             ),
             Slider(
               value: _sleepHours.toDouble(),
               min: 1,
               max: 12,
               divisions: 11,
-              activeColor: const Color(0xFF3D5AFE),
-              onChanged: (v) => setState(() => _sleepHours = v.round()),
+              onChanged: (value) => setState(() => _sleepHours = value.round()),
             ),
             const SizedBox(height: 12),
             TextField(
               controller: _noteCtrl,
               decoration: const InputDecoration(
-                labelText: 'メモ (任意)',
+                labelText: '日記メモ',
+                hintText: '今日起きたこと、感情が動いた瞬間、支出や健康の気づきなど',
                 border: OutlineInputBorder(),
                 prefixIcon: Icon(Icons.edit_note),
               ),
-              maxLines: 2,
+              maxLines: 5,
             ),
             const SizedBox(height: 12),
             SizedBox(
               width: double.infinity,
               child: FilledButton.icon(
-                onPressed: _saving ? null : _save,
+                onPressed: _saving ? null : _saveAndAnalyze,
                 icon: _saving
                     ? const SizedBox(
                         width: 16,
                         height: 16,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: Colors.white,
-                        ),
+                        child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Icon(Icons.save),
-                label: const Text('記録を保存'),
+                    : const Icon(Icons.auto_awesome),
+                label: const Text('AI分析して保存'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSlider({
+    required String label,
+    required int value,
+    required List<String> labels,
+    required Color activeColor,
+    required ValueChanged<int> onChanged,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '$label: ${labels[value - 1]}',
+          style: const TextStyle(fontWeight: FontWeight.w600),
+        ),
+        Slider(
+          value: value.toDouble(),
+          min: 1,
+          max: 5,
+          divisions: 4,
+          activeColor: activeColor,
+          onChanged: (next) => onChanged(next.round()),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLatestResult() {
+    return Card(
+      color: const Color(0xFFEFF6FF),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Icon(Icons.check_circle, color: Color(0xFF0F766E)),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'AI分析が完了しました',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(_latestSummary!),
+                  const SizedBox(height: 6),
+                  Text('翌日のTODOに$_createdTaskCount件追加しました'),
+                ],
               ),
             ),
           ],
@@ -232,26 +305,7 @@ class _MentalHealthTrackerPageState extends State<MentalHealthTrackerPage> {
       return Card(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Column(
-            children: [
-              const Icon(
-                Icons.info_outline,
-                color: Color(0xFF3D5AFE),
-                size: 40,
-              ),
-              const SizedBox(height: 8),
-              const Text('mental_health_records テーブルを作成すると履歴が表示されます'),
-              const SizedBox(height: 4),
-              Text(
-                _error!,
-                style: const TextStyle(
-                  fontSize: 11,
-                  color: Color(0xFFB0B0B0),
-                  height: 1.5,
-                ),
-              ),
-            ],
-          ),
+          child: Text('履歴を取得できませんでした: $_error'),
         ),
       );
     }
@@ -259,7 +313,7 @@ class _MentalHealthTrackerPageState extends State<MentalHealthTrackerPage> {
       return const Card(
         child: Padding(
           padding: EdgeInsets.all(24),
-          child: Center(child: Text('記録がありません。今日の状態を記録してみましょう。')),
+          child: Center(child: Text('まだ記録がありません。今日の状態を保存してみましょう。')),
         ),
       );
     }
@@ -267,45 +321,87 @@ class _MentalHealthTrackerPageState extends State<MentalHealthTrackerPage> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Text(
-          '過去の記録',
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-            height: 1.5,
-          ),
+          '過去のAI日記分析',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 8),
-        ..._records.map(
-          (r) => Card(
-            margin: const EdgeInsets.only(bottom: 8),
-            child: ListTile(
-              leading: Text(
-                _moodIcons[(r['mood_score'] as int? ?? 3) - 1],
-                style: const TextStyle(
-                  fontSize: 24,
-                  height: 1.5,
-                ),
-              ),
-              title: Text(
-                '気分: ${_moodLabels[(r['mood_score'] as int? ?? 3) - 1]}  '
-                'ストレス: ${_stressLabels[(r['stress_score'] as int? ?? 3) - 1]}',
-              ),
-              subtitle: Text(
-                '睡眠: ${r['sleep_hours'] ?? '-'}時間'
-                '${r['note'] != null ? '  ${r['note']}' : ''}',
-              ),
-              trailing: Text(
-                (r['recorded_at'] as String? ?? '').substring(0, 10),
-                style: const TextStyle(
-                  fontSize: 11,
-                  color: Color(0xFFB0B0B0),
-                  height: 1.5,
-                ),
-              ),
-            ),
-          ),
-        ),
+        ..._records.map(_buildRecordTile),
       ],
     );
+  }
+
+  Widget _buildRecordTile(Map<String, dynamic> record) {
+    final tags = [
+      ..._stringList(record['emotion_tags']),
+      ..._stringList(record['trigger_tags']),
+    ];
+    final actions = _stringList(record['next_actions']);
+    final date = (record['recorded_at'] as String? ?? '').take(10);
+    return Card(
+      margin: const EdgeInsets.only(bottom: 10),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    date.isEmpty ? '記録日未設定' : date,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                Chip(
+                  label: Text('リスク ${record['risk_level'] ?? 'low'}'),
+                  visualDensity: VisualDensity.compact,
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              record['ai_summary'] as String? ??
+                  record['note'] as String? ??
+                  '分析待ちの記録です',
+            ),
+            if (tags.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: tags.map((tag) => Chip(label: Text(tag))).toList(),
+              ),
+            ],
+            if (actions.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              const Text(
+                '明日の提案',
+                style: TextStyle(fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 4),
+              ...actions.map(
+                (action) => Padding(
+                  padding: const EdgeInsets.only(bottom: 2),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text('・'),
+                      Expanded(child: Text(action)),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+extension on String {
+  String take(int length) {
+    if (length <= 0) return '';
+    return this.length <= length ? this : substring(0, length);
   }
 }

--- a/supabase/functions/lifestyle-hub/index.ts
+++ b/supabase/functions/lifestyle-hub/index.ts
@@ -12,6 +12,7 @@
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { buildJournalInsight, coerceJournalInsight, extractFirstJsonObject } from "./journal_analysis.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -58,6 +59,16 @@ async function addItem(admin: SupabaseClient, source: string, userId: string, me
   return data;
 }
 
+function dateOnly(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function boolBody(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return !["false", "0", "no", "off"].includes(value.toLowerCase());
+  return fallback;
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
 
@@ -93,6 +104,141 @@ serve(async (req) => {
         return json({ success: true, log: item });
       }
       case "fitness.list_weight": return json({ success: true, weights: await listItems(admin, "weight_log", userId) });
+
+      // ── Journal AI feedback ─────────────────────────────────────────────────
+      case "journal.list": {
+        const limit = Math.min(Math.max(Number(body.limit ?? 30), 1), 100);
+        const { data, error } = await admin.from("mental_health_records")
+          .select("*")
+          .eq("user_id", userId)
+          .order("recorded_at", { ascending: false })
+          .limit(limit);
+        if (error) return json({ error: error.message }, 400);
+        return json({ success: true, records: data ?? [] });
+      }
+      case "journal.analyze": {
+        const recordId = String(body.record_id ?? "").trim();
+        const note = String(body.note ?? "").trim();
+        if (!recordId && !note) return json({ error: "note or record_id is required" }, 400);
+
+        const moodScore = Math.max(1, Math.min(5, Number(body.mood_score ?? 3)));
+        const stressScore = Math.max(1, Math.min(5, Number(body.stress_score ?? 3)));
+        const sleepHours = Math.max(0, Math.min(24, Number(body.sleep_hours ?? 7)));
+        const recordedAt = String(body.recorded_at ?? new Date().toISOString());
+
+        let record: Record<string, unknown> | null = null;
+        if (recordId) {
+          const { data, error } = await admin.from("mental_health_records")
+            .select("*")
+            .eq("id", recordId)
+            .eq("user_id", userId)
+            .single();
+          if (error || !data) return json({ error: error?.message ?? "record not found" }, 404);
+          record = data as Record<string, unknown>;
+        } else {
+          const { data, error } = await admin.from("mental_health_records")
+            .insert({
+              user_id: userId,
+              mood_score: moodScore,
+              stress_score: stressScore,
+              sleep_hours: sleepHours,
+              note,
+              recorded_at: recordedAt,
+            })
+            .select("*")
+            .single();
+          if (error) return json({ error: error.message }, 400);
+          record = data as Record<string, unknown>;
+        }
+
+        const analysisInput = {
+          note: String(record.note ?? note),
+          moodScore: Number(record.mood_score ?? moodScore),
+          stressScore: Number(record.stress_score ?? stressScore),
+          sleepHours: Number(record.sleep_hours ?? sleepHours),
+        };
+        const fallback = buildJournalInsight(analysisInput);
+        let insight = fallback;
+        let model = "local-journal-heuristic";
+
+        try {
+          const aiPrompt = [
+            "あなたは日記から自己改善のヒントを抽出するAIです。",
+            "出力はJSONのみ。キーは summary, emotion_tags, trigger_tags, next_actions, risk_level, focus_area。",
+            "risk_level は low/medium/high。focus_area は spending/health/mental/work/general。",
+            "next_actions は明日実行できる15分以内の行動を最大3件。",
+            "",
+            `気分スコア: ${analysisInput.moodScore}/5`,
+            `ストレススコア: ${analysisInput.stressScore}/5`,
+            `睡眠時間: ${analysisInput.sleepHours}h`,
+            `日記: ${analysisInput.note}`,
+          ].join("\n");
+          const aiResp = await fetch(`${SUPABASE_URL}/functions/v1/ai-hub`, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ action: "provider.chat", provider: "groq", message: aiPrompt }),
+          });
+          const aiData = await aiResp.json() as Record<string, unknown>;
+          const text = String(aiData.text ?? "");
+          if (aiData.success === true && text.trim()) {
+            insight = coerceJournalInsight(extractFirstJsonObject(text), fallback);
+            model = String(aiData.model_used ?? "groq");
+          }
+        } catch {
+          insight = fallback;
+        }
+
+        const analyzedAt = new Date().toISOString();
+        const { data: updated, error: updateError } = await admin
+          .from("mental_health_records")
+          .update({
+            ai_summary: insight.summary,
+            emotion_tags: insight.emotion_tags,
+            trigger_tags: insight.trigger_tags,
+            next_actions: insight.next_actions,
+            risk_level: insight.risk_level,
+            focus_area: insight.focus_area,
+            ai_model: model,
+            analyzed_at: analyzedAt,
+            analysis_report: { ...insight, generated_at: analyzedAt, source: model },
+          })
+          .eq("id", String(record.id))
+          .eq("user_id", userId)
+          .select("*")
+          .single();
+        if (updateError) return json({ error: updateError.message }, 400);
+
+        const createdTasks: Array<Record<string, unknown>> = [];
+        if (boolBody(body.create_tomorrow_tasks, true)) {
+          const tomorrow = new Date();
+          tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+          const tomorrowDate = dateOnly(tomorrow);
+          for (const actionText of insight.next_actions.slice(0, 3)) {
+            const { data: task, error: taskError } = await admin
+              .from("daily_todos")
+              .insert({
+                user_id: userId,
+                task: actionText,
+                is_completed: false,
+                is_important: insight.risk_level !== "low",
+                category: "journal_ai",
+                estimated_minutes: 15,
+                difficulty: "easy",
+                task_date: tomorrowDate,
+                due_date: `${tomorrowDate}T09:00:00.000Z`,
+                details: `AI日記分析から生成: ${insight.summary} / record=${record.id}`,
+              })
+              .select("id, task, task_date, category")
+              .single();
+            if (!taskError && task) createdTasks.push(task as Record<string, unknown>);
+          }
+        }
+
+        return json({ success: true, record: updated, insight, created_tasks: createdTasks });
+      }
 
       // ── Recipe & Meal Planner ─────────────────────────────────────────────────
       case "recipe.list": return json({ success: true, recipes: await listItems(admin, "recipe", userId) });

--- a/supabase/functions/lifestyle-hub/journal_analysis.ts
+++ b/supabase/functions/lifestyle-hub/journal_analysis.ts
@@ -1,0 +1,173 @@
+export interface JournalAnalysisInput {
+  note: string;
+  moodScore?: number;
+  stressScore?: number;
+  sleepHours?: number;
+}
+
+export interface JournalInsight {
+  summary: string;
+  emotion_tags: string[];
+  trigger_tags: string[];
+  next_actions: string[];
+  risk_level: "low" | "medium" | "high";
+  focus_area: "spending" | "health" | "mental" | "work" | "general";
+}
+
+const keywordGroups = {
+  spending: [
+    "浪費",
+    "支出",
+    "購入",
+    "買",
+    "課金",
+    "セール",
+    "amazon",
+    "馬券",
+    "ギャンブル",
+  ],
+  health: ["睡眠", "眠", "疲", "体調", "食", "運動", "痛", "薬", "体重"],
+  mental: ["不安", "焦", "怒", "つら", "落ち込", "孤独", "ストレス"],
+  work: ["仕事", "締切", "会議", "開発", "レビュー", "実装", "タスク"],
+} as const;
+
+function includesAny(text: string, words: readonly string[]): boolean {
+  const lower = text.toLowerCase();
+  return words.some((word) => lower.includes(word.toLowerCase()));
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+export function buildJournalInsight(
+  input: JournalAnalysisInput,
+): JournalInsight {
+  const note = input.note.trim();
+  const mood = Number(input.moodScore ?? 3);
+  const stress = Number(input.stressScore ?? 3);
+  const sleep = Number(input.sleepHours ?? 7);
+
+  const triggerTags: string[] = [];
+  if (includesAny(note, keywordGroups.spending)) {
+    triggerTags.push("支出トリガー");
+  }
+  if (includesAny(note, keywordGroups.health)) triggerTags.push("健康トリガー");
+  if (includesAny(note, keywordGroups.mental)) triggerTags.push("感情トリガー");
+  if (includesAny(note, keywordGroups.work)) triggerTags.push("仕事トリガー");
+  if (stress >= 4) triggerTags.push("高ストレス");
+  if (sleep <= 5) triggerTags.push("睡眠不足");
+
+  const emotionTags: string[] = [];
+  if (mood <= 2) emotionTags.push("低調");
+  if (mood >= 4) emotionTags.push("前向き");
+  if (stress >= 4) emotionTags.push("緊張");
+  if (stress <= 2) emotionTags.push("安定");
+  if (triggerTags.length === 0) emotionTags.push("観察中");
+
+  const focusArea: JournalInsight["focus_area"] = triggerTags.includes(
+      "支出トリガー",
+    )
+    ? "spending"
+    : triggerTags.includes("健康トリガー") || triggerTags.includes("睡眠不足")
+    ? "health"
+    : triggerTags.includes("感情トリガー") || triggerTags.includes("高ストレス")
+    ? "mental"
+    : triggerTags.includes("仕事トリガー")
+    ? "work"
+    : "general";
+
+  const nextActions: string[] = [];
+  if (focusArea === "spending") {
+    nextActions.push("明日の購入判断は24時間保留して、必要性を1行で記録する");
+  }
+  if (focusArea === "health") {
+    nextActions.push(
+      "明日は就寝予定時刻を先に決め、睡眠前30分の画面時間を減らす",
+    );
+  }
+  if (focusArea === "mental") {
+    nextActions.push(
+      "朝に5分だけ感情ログを書き、強い反応の前後関係を分けて見る",
+    );
+  }
+  if (focusArea === "work") {
+    nextActions.push(
+      "最初の作業を15分で終わる単位に分け、開始前に完了条件を書く",
+    );
+  }
+  nextActions.push("今日の気づきを1つだけ明日の最優先タスクに反映する");
+
+  const riskScore = (mood <= 2 ? 1 : 0) + (stress >= 4 ? 1 : 0) +
+    (sleep <= 5 ? 1 : 0) + (triggerTags.length >= 2 ? 1 : 0);
+  const riskLevel: JournalInsight["risk_level"] = riskScore >= 3
+    ? "high"
+    : riskScore >= 1
+    ? "medium"
+    : "low";
+
+  const summary = triggerTags.length > 0
+    ? `今日の記録では${
+      triggerTags.join("・")
+    }が目立ちます。明日は小さな先回り行動に落とすと再現性が上がります。`
+    : "今日の記録は大きな乱れが少なく、継続観察に向いています。明日は良かった行動を1つだけ再現しましょう。";
+
+  return {
+    summary,
+    emotion_tags: unique(emotionTags),
+    trigger_tags: unique(triggerTags),
+    next_actions: unique(nextActions).slice(0, 3),
+    risk_level: riskLevel,
+    focus_area: focusArea,
+  };
+}
+
+export function extractFirstJsonObject(
+  text: string,
+): Record<string, unknown> | null {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start < 0 || end <= start) return null;
+  try {
+    const parsed = JSON.parse(text.slice(start, end + 1));
+    return parsed && typeof parsed === "object"
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return unique(value.map((item) => String(item).trim()));
+}
+
+export function coerceJournalInsight(
+  raw: Record<string, unknown> | null,
+  fallback: JournalInsight,
+): JournalInsight {
+  if (!raw) return fallback;
+  const risk = String(raw.risk_level ?? fallback.risk_level);
+  const focus = String(raw.focus_area ?? fallback.focus_area);
+  return {
+    summary: String(raw.summary ?? fallback.summary).trim() || fallback.summary,
+    emotion_tags: stringArray(raw.emotion_tags).length > 0
+      ? stringArray(raw.emotion_tags)
+      : fallback.emotion_tags,
+    trigger_tags: stringArray(raw.trigger_tags).length > 0
+      ? stringArray(raw.trigger_tags)
+      : fallback.trigger_tags,
+    next_actions: stringArray(raw.next_actions).length > 0
+      ? stringArray(raw.next_actions).slice(0, 3)
+      : fallback.next_actions,
+    risk_level: risk === "high" || risk === "medium" || risk === "low"
+      ? risk
+      : fallback.risk_level,
+    focus_area:
+      focus === "spending" || focus === "health" || focus === "mental" ||
+        focus === "work" || focus === "general"
+        ? focus
+        : fallback.focus_area,
+  };
+}

--- a/supabase/functions/lifestyle-hub/journal_analysis_test.ts
+++ b/supabase/functions/lifestyle-hub/journal_analysis_test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildJournalInsight,
+  coerceJournalInsight,
+  extractFirstJsonObject,
+} from "./journal_analysis.ts";
+
+Deno.test("buildJournalInsight detects spending and stress triggers", () => {
+  const insight = buildJournalInsight({
+    note: "セールで余計な購入をしそうになり、仕事の締切でストレスも強かった。",
+    moodScore: 2,
+    stressScore: 5,
+    sleepHours: 5,
+  });
+
+  assertEquals(insight.focus_area, "spending");
+  assertEquals(insight.risk_level, "high");
+  assertEquals(insight.trigger_tags.includes("支出トリガー"), true);
+  assertEquals(insight.trigger_tags.includes("高ストレス"), true);
+  assertEquals(insight.next_actions.length > 0, true);
+});
+
+Deno.test("extractFirstJsonObject parses JSON wrapped in prose", () => {
+  const parsed = extractFirstJsonObject(
+    '結果です: {"summary":"ok","next_actions":["a"]} 以上',
+  );
+
+  assertEquals(parsed?.summary, "ok");
+});
+
+Deno.test("coerceJournalInsight keeps fallback when AI JSON is partial", () => {
+  const fallback = buildJournalInsight({
+    note: "よく眠れて安定していた。",
+    moodScore: 4,
+    stressScore: 1,
+    sleepHours: 8,
+  });
+  const insight = coerceJournalInsight({ summary: "短い要約" }, fallback);
+
+  assertEquals(insight.summary, "短い要約");
+  assertEquals(insight.next_actions, fallback.next_actions);
+  assertEquals(insight.risk_level, fallback.risk_level);
+});

--- a/supabase/migrations/20260502213000_create_journal_ai_analysis.sql
+++ b/supabase/migrations/20260502213000_create_journal_ai_analysis.sql
@@ -1,0 +1,73 @@
+CREATE TABLE IF NOT EXISTS public.mental_health_records (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  mood_score integer NOT NULL DEFAULT 3,
+  stress_score integer NOT NULL DEFAULT 3,
+  sleep_hours numeric NOT NULL DEFAULT 7,
+  note text,
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.mental_health_records
+  ADD COLUMN IF NOT EXISTS analysis_report jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS ai_summary text,
+  ADD COLUMN IF NOT EXISTS emotion_tags text[] NOT NULL DEFAULT ARRAY[]::text[],
+  ADD COLUMN IF NOT EXISTS trigger_tags text[] NOT NULL DEFAULT ARRAY[]::text[],
+  ADD COLUMN IF NOT EXISTS next_actions text[] NOT NULL DEFAULT ARRAY[]::text[],
+  ADD COLUMN IF NOT EXISTS risk_level text NOT NULL DEFAULT 'low',
+  ADD COLUMN IF NOT EXISTS focus_area text NOT NULL DEFAULT 'general',
+  ADD COLUMN IF NOT EXISTS ai_model text,
+  ADD COLUMN IF NOT EXISTS analyzed_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_mental_health_records_user_recorded
+  ON public.mental_health_records (user_id, recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mental_health_records_analyzed
+  ON public.mental_health_records (user_id, analyzed_at DESC NULLS LAST);
+
+ALTER TABLE public.mental_health_records ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  CREATE POLICY "mental_health_records_select_own"
+    ON public.mental_health_records
+    FOR SELECT
+    USING (auth.uid() = user_id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  CREATE POLICY "mental_health_records_insert_own"
+    ON public.mental_health_records
+    FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  CREATE POLICY "mental_health_records_update_own"
+    ON public.mental_health_records
+    FOR UPDATE
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  CREATE POLICY "mental_health_records_delete_own"
+    ON public.mental_health_records
+    FOR DELETE
+    USING (auth.uid() = user_id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+COMMENT ON TABLE public.mental_health_records IS
+  'Daily mood and diary records with AI-generated feedback and next-day actions.';


### PR DESCRIPTION
﻿## Summary
- Add `mental_health_records` with RLS and AI analysis columns for daily diary records.
- Add `lifestyle-hub` `journal.analyze` / `journal.list` actions; analysis uses `ai-hub` when available and deterministic local fallback, then creates next-day `daily_todos`.
- Refresh `MentalHealthTrackerPage` with readable Japanese UI, AI save/analyze flow, history, tags, and next-action display.

Fixes #1271

## Validation
- `deno test --config supabase/functions/deno.json supabase/functions/lifestyle-hub/journal_analysis_test.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/lifestyle-hub/index.ts`
- `deno lint --config supabase/functions/deno.json supabase/functions/lifestyle-hub/index.ts supabase/functions/lifestyle-hub/journal_analysis.ts supabase/functions/lifestyle-hub/journal_analysis_test.ts`
- `flutter analyze lib/pages/mental_health_tracker_page.dart`
- `git diff --check`

## Minimal E2E Declaration
Implementation-detail independent black-box I/O plan:
1. POST `lifestyle-hub` with `action=journal.analyze`, diary text, mood/stress/sleep scores, and an authenticated user; expect a saved record, an `insight.summary`, trigger/emotion tags, and next-day tasks.
2. POST `lifestyle-hub` with `action=journal.list`; expect the saved AI diary record to be returned for the same user.
3. Open `/mental-health-tracker`, enter diary text, click `AI分析して保存`; expect the completion message, refreshed history, and next-action cards without relying on internal helper names.

E2E-Exception: the new Edge Function action has a deterministic Deno unit test for parser/fallback behavior; full browser auth + Supabase write flow remains covered by the existing public smoke gate and can be promoted to a dedicated authenticated Playwright flow later.
