### PR TITLE
[codex] Add AI officer tool approval gate UI

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -4,6 +4,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import '../pages/abstinence_guard_page.dart';
 import '../pages/admin_analytics_page.dart';
 import '../pages/agent_org_page.dart';
+import '../pages/agent_tool_approval_page.dart';
 import '../pages/ai_company_builder_page.dart';
 import '../pages/ai_secretary_page.dart';
 import '../pages/my_skills_page.dart';
@@ -292,6 +293,8 @@ String? _homeToolRoutePathForId(String id) {
       return '/real-world-danshari';
     case 'agent-org':
       return '/agents';
+    case 'agent-tool-approvals':
+      return '/agent-tool-approvals';
     case 'admin-analytics':
       return '/admin';
     case 'edge-function-status':
@@ -1022,6 +1025,23 @@ List<HomeToolEntry> buildHomeToolCatalog({
       color: const Color(0xFFFF6B35),
       keywords: const <String>['管理者', '分析', 'dashboard'],
       onOpen: (context) => _pushPage(context, const AdminAnalyticsPage()),
+    ),
+    HomeToolEntry(
+      id: 'agent-tool-approvals',
+      sectionId: 'growth',
+      title: 'AI役員 承認ゲート',
+      subtitle: '高リスクなAIツール実行をCEOが承認・拒否する',
+      icon: Icons.verified_user_outlined,
+      color: const Color(0xFF0D9488),
+      keywords: const <String>[
+        'AI役員',
+        '承認',
+        '監査',
+        'approval',
+        'scope',
+        'tool',
+      ],
+      onOpen: (context) => _pushPage(context, AgentToolApprovalPage()),
     ),
     HomeToolEntry(
       id: 'edge-function-status',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:my_web_app/data/home_tool_catalog.dart';
 import 'package:my_web_app/models/site_guide_catalog_item.dart';
 import 'package:my_web_app/pages/abstinence_guard_page.dart';
 import 'package:my_web_app/pages/agent_org_page.dart';
+import 'package:my_web_app/pages/agent_tool_approval_page.dart';
 import 'package:my_web_app/pages/ai_company_builder_page.dart';
 import 'package:my_web_app/pages/ai_agent_page.dart';
 import 'package:my_web_app/pages/behavior_review_page.dart';
@@ -492,6 +493,10 @@ class _MyAppState extends State<MyApp> {
             return MaterialPageRoute(builder: (_) => const HomePage());
           case '/agents':
             return MaterialPageRoute(builder: (_) => AgentOrgPage());
+          case '/agent-tool-approvals':
+            return MaterialPageRoute(
+              builder: (_) => AgentToolApprovalPage(),
+            );
           case '/ai-company-builder':
             return MaterialPageRoute(
               builder: (_) => const AiCompanyBuilderPage(),

--- a/lib/pages/agent_tool_approval_page.dart
+++ b/lib/pages/agent_tool_approval_page.dart
@@ -1,0 +1,452 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../services/agent_tool_approval_service.dart';
+
+class AgentToolApprovalPage extends StatefulWidget {
+  final AgentToolApprovalService service;
+
+  AgentToolApprovalPage({
+    super.key,
+    AgentToolApprovalService? service,
+  }) : service = service ?? AgentToolApprovalService();
+
+  @override
+  State<AgentToolApprovalPage> createState() => _AgentToolApprovalPageState();
+}
+
+class _AgentToolApprovalPageState extends State<AgentToolApprovalPage> {
+  List<AgentToolApprovalLog> _logs = const <AgentToolApprovalLog>[];
+  bool _isLoading = true;
+  bool _showPendingOnly = true;
+  String? _errorText;
+  final Set<String> _decidingIds = <String>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = true;
+      _errorText = null;
+    });
+
+    try {
+      final logs = await widget.service.fetchRecentLogs();
+      if (!mounted) return;
+      setState(() {
+        _logs = logs;
+        _isLoading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _errorText = error.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  List<AgentToolApprovalLog> get _visibleLogs {
+    if (!_showPendingOnly) return _logs;
+    return _logs.where((log) => log.isPendingApproval).toList(growable: false);
+  }
+
+  Future<void> _decide(
+    AgentToolApprovalLog log,
+    AgentToolApprovalDecision decision,
+  ) async {
+    setState(() => _decidingIds.add(log.id));
+    try {
+      final updated = await widget.service.decide(
+        logId: log.id,
+        decision: decision,
+      );
+      if (!mounted) return;
+      setState(() {
+        _logs = _logs
+            .map((item) => item.id == updated.id ? updated : item)
+            .toList(growable: false);
+      });
+      final verb = decision == AgentToolApprovalDecision.approved ? '承認' : '拒否';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('$verbを監査ログへ記録しました')),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('承認判断の保存に失敗しました: $error'),
+          backgroundColor: const Color(0xFFB91C1C),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _decidingIds.remove(log.id));
+      }
+    }
+  }
+
+  Future<void> _copyApprovalPayload(AgentToolApprovalLog log) async {
+    final payload = log.buildApprovalPayloadJson(
+      approvedBy: 'ceo',
+      approvedAt: DateTime.now(),
+    );
+    await Clipboard.setData(ClipboardData(text: payload));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('次回実行用の承認メタデータをコピーしました')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pendingCount = _logs.where((log) => log.isPendingApproval).length;
+    final approvedCount = _logs.where((log) => log.isApproved).length;
+    final rejectedCount = _logs.where((log) => log.isRejected).length;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('AI役員 承認ゲート'),
+        actions: [
+          IconButton(
+            tooltip: '再読み込み',
+            onPressed: _load,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            _buildSummary(
+              pendingCount: pendingCount,
+              approvedCount: approvedCount,
+              rejectedCount: rejectedCount,
+            ),
+            const SizedBox(height: 12),
+            SegmentedButton<bool>(
+              segments: const [
+                ButtonSegment<bool>(
+                  value: true,
+                  label: Text('承認待ち'),
+                  icon: Icon(Icons.pending_actions_outlined),
+                ),
+                ButtonSegment<bool>(
+                  value: false,
+                  label: Text('すべて'),
+                  icon: Icon(Icons.history_outlined),
+                ),
+              ],
+              selected: {_showPendingOnly},
+              onSelectionChanged: (selection) {
+                setState(() => _showPendingOnly = selection.first);
+              },
+            ),
+            const SizedBox(height: 16),
+            if (_isLoading)
+              const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(32),
+                  child: CircularProgressIndicator(),
+                ),
+              )
+            else if (_errorText != null)
+              _buildNotice(
+                icon: Icons.error_outline,
+                title: '読み込みに失敗しました',
+                message: _errorText!,
+                color: const Color(0xFFB91C1C),
+              )
+            else if (_visibleLogs.isEmpty)
+              _buildNotice(
+                icon: Icons.verified_user_outlined,
+                title: _showPendingOnly ? '承認待ちはありません' : '監査ログはありません',
+                message: _showPendingOnly
+                    ? '高リスク操作が停止されたとき、ここにCEO承認待ちとして表示されます。'
+                    : 'agent_tool_execution_logs に記録が作成されると、この画面で確認できます。',
+                color: const Color(0xFF0D9488),
+              )
+            else
+              ..._visibleLogs.map(_buildLogCard),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSummary({
+    required int pendingCount,
+    required int approvedCount,
+    required int rejectedCount,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Theme.of(context).dividerColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '高リスク操作のCEO承認',
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'send / delete / purchase / discount / external_share などは、AI役員が実行する前にここで監査できます。',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              height: 1.6,
+            ),
+          ),
+          const SizedBox(height: 14),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildMetricChip('承認待ち', pendingCount, const Color(0xFFFF6B35)),
+              _buildMetricChip('承認済み', approvedCount, const Color(0xFF0D9488)),
+              _buildMetricChip('拒否済み', rejectedCount, const Color(0xFFB91C1C)),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMetricChip(String label, int value, Color color) {
+    return Chip(
+      avatar: CircleAvatar(
+        backgroundColor: color.withValues(alpha: 0.12),
+        child: Text(
+          '$value',
+          style: TextStyle(color: color, fontSize: 12),
+        ),
+      ),
+      label: Text(label),
+      side: BorderSide(color: color.withValues(alpha: 0.35)),
+    );
+  }
+
+  Widget _buildNotice({
+    required IconData icon,
+    required String title,
+    required String message,
+    required Color color,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: color),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(fontWeight: FontWeight.w800),
+                ),
+                const SizedBox(height: 4),
+                Text(message, style: const TextStyle(height: 1.6)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLogCard(AgentToolApprovalLog log) {
+    final status = _statusText(log);
+    final statusColor = _statusColor(log);
+    final isBusy = _decidingIds.contains(log.id);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      elevation: 1,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 5,
+                  ),
+                  decoration: BoxDecoration(
+                    color: statusColor.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Text(
+                    status,
+                    style: TextStyle(
+                      color: statusColor,
+                      fontWeight: FontWeight.w800,
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+                const Spacer(),
+                Text(
+                  _formatDate(log.createdAt),
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              log.toolName,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800),
+            ),
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _smallChip('実行主体', log.actorRole ?? 'unknown'),
+                _smallChip(
+                  '要求スコープ',
+                  log.requestedScopes.isEmpty
+                      ? '未指定'
+                      : log.requestedScopes.join(', '),
+                ),
+                if (log.highRiskScopes.isNotEmpty)
+                  _smallChip('高リスク', log.highRiskScopes.join(', ')),
+              ],
+            ),
+            if (log.sideEffects != null) ...[
+              const SizedBox(height: 10),
+              _infoBlock('想定される副作用', log.sideEffects!),
+            ],
+            if (log.blockedReason != null) ...[
+              const SizedBox(height: 10),
+              _infoBlock('停止理由', log.blockedReason!),
+            ],
+            if (log.payload.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              _infoBlock('実行ペイロード', _compactPayload(log.payload)),
+            ],
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                FilledButton.icon(
+                  onPressed: log.isPendingApproval && !isBusy
+                      ? () => _decide(log, AgentToolApprovalDecision.approved)
+                      : null,
+                  icon: isBusy
+                      ? const SizedBox.square(
+                          dimension: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.check_circle_outline),
+                  label: const Text('承認'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: log.isPendingApproval && !isBusy
+                      ? () => _decide(log, AgentToolApprovalDecision.rejected)
+                      : null,
+                  icon: const Icon(Icons.block_outlined),
+                  label: const Text('拒否'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: () => _copyApprovalPayload(log),
+                  icon: const Icon(Icons.copy_outlined),
+                  label: const Text('承認メタデータ'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _smallChip(String label, String value) {
+    return Chip(
+      label: Text('$label: $value'),
+      visualDensity: VisualDensity.compact,
+    );
+  }
+
+  Widget _infoBlock(String label, String value) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 4),
+          SelectableText(value, style: const TextStyle(height: 1.5)),
+        ],
+      ),
+    );
+  }
+
+  String _statusText(AgentToolApprovalLog log) {
+    if (log.isApproved) return '承認済み';
+    if (log.isRejected) return '拒否済み';
+    if (log.isPendingApproval) return '承認待ち';
+    if (log.allowed) return '許可済み';
+    return '停止済み';
+  }
+
+  Color _statusColor(AgentToolApprovalLog log) {
+    if (log.isApproved || log.allowed) return const Color(0xFF0D9488);
+    if (log.isRejected) return const Color(0xFFB91C1C);
+    if (log.isPendingApproval) return const Color(0xFFFF6B35);
+    return const Color(0xFF64748B);
+  }
+
+  String _compactPayload(Map<String, dynamic> payload) {
+    final text = const JsonEncoder.withIndent('  ').convert(payload);
+    if (text.length <= 900) return text;
+    return '${text.substring(0, 900)}...';
+  }
+
+  String _formatDate(DateTime? value) {
+    if (value == null) return '';
+    final local = value.toLocal();
+    String two(int number) => number.toString().padLeft(2, '0');
+    return '${local.year}/${two(local.month)}/${two(local.day)} '
+        '${two(local.hour)}:${two(local.minute)}';
+  }
+}

--- a/lib/services/agent_tool_approval_service.dart
+++ b/lib/services/agent_tool_approval_service.dart
@@ -1,0 +1,195 @@
+import 'dart:convert';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+enum AgentToolApprovalDecision {
+  approved,
+  rejected,
+}
+
+class AgentToolApprovalLog {
+  final String id;
+  final String toolName;
+  final String? actorRole;
+  final bool allowed;
+  final bool requiresApproval;
+  final String? approvalDecision;
+  final String? approvedBy;
+  final DateTime? approvedAt;
+  final String? blockedReason;
+  final String? sideEffects;
+  final List<String> requestedScopes;
+  final List<String> allowedScopes;
+  final List<String> highRiskScopes;
+  final Map<String, dynamic> payload;
+  final DateTime? createdAt;
+  final DateTime? evaluatedAt;
+
+  const AgentToolApprovalLog({
+    required this.id,
+    required this.toolName,
+    required this.actorRole,
+    required this.allowed,
+    required this.requiresApproval,
+    required this.approvalDecision,
+    required this.approvedBy,
+    required this.approvedAt,
+    required this.blockedReason,
+    required this.sideEffects,
+    required this.requestedScopes,
+    required this.allowedScopes,
+    required this.highRiskScopes,
+    required this.payload,
+    required this.createdAt,
+    required this.evaluatedAt,
+  });
+
+  factory AgentToolApprovalLog.fromMap(Map<String, dynamic> row) {
+    return AgentToolApprovalLog(
+      id: row['id']?.toString() ?? '',
+      toolName: row['tool_name']?.toString() ?? 'unknown_tool',
+      actorRole: _nullableString(row['actor_role']),
+      allowed: _toBool(row['allowed']),
+      requiresApproval: _toBool(row['requires_approval']),
+      approvalDecision: _nullableString(row['approval_decision']),
+      approvedBy: _nullableString(row['approved_by']),
+      approvedAt: _parseDate(row['approved_at']),
+      blockedReason: _nullableString(row['blocked_reason']),
+      sideEffects: _nullableString(row['side_effects']),
+      requestedScopes: _stringList(row['requested_scopes']),
+      allowedScopes: _stringList(row['allowed_scopes']),
+      highRiskScopes: _stringList(row['high_risk_scopes']),
+      payload: _payloadMap(row['payload']),
+      createdAt: _parseDate(row['created_at']),
+      evaluatedAt: _parseDate(row['evaluated_at']),
+    );
+  }
+
+  bool get isPendingApproval {
+    final normalized = approvalDecision?.trim().toLowerCase();
+    return requiresApproval &&
+        !allowed &&
+        normalized != 'approved' &&
+        normalized != 'rejected';
+  }
+
+  bool get isApproved => approvalDecision?.trim().toLowerCase() == 'approved';
+
+  bool get isRejected => approvalDecision?.trim().toLowerCase() == 'rejected';
+
+  String buildApprovalPayloadJson({
+    required String approvedBy,
+    DateTime? approvedAt,
+  }) {
+    final timestamp = (approvedAt ?? DateTime.now()).toUtc().toIso8601String();
+    return const JsonEncoder.withIndent('  ').convert({
+      'tool_name': toolName,
+      'requested_scopes': requestedScopes,
+      'approval': {
+        'decision': 'approved',
+        'approved_by': approvedBy,
+        'approved_at': timestamp,
+      },
+    });
+  }
+
+  static String? _nullableString(dynamic value) {
+    final text = value?.toString().trim();
+    if (text == null || text.isEmpty) return null;
+    return text;
+  }
+
+  static bool _toBool(dynamic value) {
+    if (value is bool) return value;
+    if (value is String) return value.toLowerCase() == 'true';
+    return false;
+  }
+
+  static List<String> _stringList(dynamic value) {
+    if (value is List) {
+      return value
+          .map((item) => item?.toString().trim() ?? '')
+          .where((item) => item.isNotEmpty)
+          .toList(growable: false);
+    }
+    if (value is String && value.trim().isNotEmpty) {
+      return value
+          .split(',')
+          .map((item) => item.trim())
+          .where((item) => item.isNotEmpty)
+          .toList(growable: false);
+    }
+    return const <String>[];
+  }
+
+  static Map<String, dynamic> _payloadMap(dynamic value) {
+    if (value is Map) return Map<String, dynamic>.from(value);
+    if (value is String && value.trim().isNotEmpty) {
+      final decoded = jsonDecode(value);
+      if (decoded is Map) return Map<String, dynamic>.from(decoded);
+    }
+    return const <String, dynamic>{};
+  }
+
+  static DateTime? _parseDate(dynamic value) {
+    if (value == null) return null;
+    return DateTime.tryParse(value.toString());
+  }
+}
+
+class AgentToolApprovalService {
+  final SupabaseClient _supabase;
+
+  AgentToolApprovalService({SupabaseClient? supabaseClient})
+      : _supabase = supabaseClient ?? Supabase.instance.client;
+
+  Future<List<AgentToolApprovalLog>> fetchRecentLogs({int limit = 80}) async {
+    final rows = await _supabase
+        .from('agent_tool_execution_logs')
+        .select(
+          'id, actor_role, tool_name, allowed, blocked_reason, payload, '
+          'created_at, requested_scopes, allowed_scopes, high_risk_scopes, '
+          'requires_approval, approval_decision, approved_by, approved_at, '
+          'side_effects, evaluated_at',
+        )
+        .order('created_at', ascending: false)
+        .limit(limit);
+
+    return rows
+        .whereType<Map>()
+        .map(
+          (row) => AgentToolApprovalLog.fromMap(
+            Map<String, dynamic>.from(row),
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  Future<AgentToolApprovalLog> decide({
+    required String logId,
+    required AgentToolApprovalDecision decision,
+  }) async {
+    final user = _supabase.auth.currentUser;
+    final actor = user?.email ?? user?.id ?? 'ceo';
+    final now = DateTime.now().toUtc().toIso8601String();
+    final decisionText = decision.name;
+
+    final row = await _supabase
+        .from('agent_tool_execution_logs')
+        .update({
+          'approval_decision': decisionText,
+          'approved_by': actor,
+          'approved_at': now,
+        })
+        .eq('id', logId)
+        .select(
+          'id, actor_role, tool_name, allowed, blocked_reason, payload, '
+          'created_at, requested_scopes, allowed_scopes, high_risk_scopes, '
+          'requires_approval, approval_decision, approved_by, approved_at, '
+          'side_effects, evaluated_at',
+        )
+        .single();
+
+    return AgentToolApprovalLog.fromMap(Map<String, dynamic>.from(row));
+  }
+}

--- a/supabase/migrations/20260502223000_update_wbs_progress_agent_tool_approval_ui.sql
+++ b/supabase/migrations/20260502223000_update_wbs_progress_agent_tool_approval_ui.sql
@@ -1,0 +1,22 @@
+-- WBS update / Issue #846: CEO approval screen for high-risk AI officer tools.
+
+UPDATE public.wbs_tasks
+SET status = 'in_progress',
+    progress = GREATEST(progress, 60),
+    recovery_plan = 'Approval UI is now implemented as /agent-tool-approvals. Remaining work is authenticated smoke with a real JWT, broader external tool execution wiring, and production deploy evidence.',
+    recovery_planned_at = COALESCE(recovery_planned_at, NOW()),
+    remaining_work = 'Run authenticated ai-hub:agent.tool_policy.evaluate smoke, wire more external tool paths into the policy gate, and verify approval/denial rows in agent_tool_execution_logs.',
+    description = COALESCE(description, '') ||
+      E'\n\n[Codex #1 2026-05-02] Issue #846 advanced: added /agent-tool-approvals so CEO can review high-risk AI officer tool requests, inspect actor/tool/scopes/side effects/payload, approve or reject, and copy approval metadata for the next server-side execution attempt.'
+WHERE github_issue_number = 846;
+
+INSERT INTO public.development_achievements (title, description, completed_at)
+SELECT
+  'Codex #1: AI officer tool approval UI (#846)',
+  'Added /agent-tool-approvals, a CEO approval and audit screen for agent_tool_execution_logs. The page displays pending high-risk tool requests, requested scopes, side effects, payload previews, approve/reject decisions, and copyable approval metadata for server-side ai-hub policy evaluation.',
+  '2026-05-02'
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.development_achievements
+  WHERE title = 'Codex #1: AI officer tool approval UI (#846)'
+);

--- a/test/services/agent_tool_approval_service_test.dart
+++ b/test/services/agent_tool_approval_service_test.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/agent_tool_approval_service.dart';
+
+void main() {
+  test('AgentToolApprovalLog parses pending high-risk approval rows', () {
+    final log = AgentToolApprovalLog.fromMap({
+      'id': 'log-1',
+      'tool_name': 'x.post',
+      'actor_role': 'cmo',
+      'allowed': false,
+      'requires_approval': true,
+      'approval_decision': 'pending',
+      'requested_scopes': ['create', 'external_share'],
+      'allowed_scopes': ['read', 'suggest', 'create', 'external_share'],
+      'high_risk_scopes': ['external_share'],
+      'blocked_reason': 'approval_required',
+      'side_effects': 'Post to X timeline.',
+      'payload': {'text': 'hello'},
+      'created_at': '2026-05-02T12:00:00Z',
+    });
+
+    expect(log.id, 'log-1');
+    expect(log.toolName, 'x.post');
+    expect(log.actorRole, 'cmo');
+    expect(log.isPendingApproval, isTrue);
+    expect(log.requestedScopes, ['create', 'external_share']);
+    expect(log.highRiskScopes, ['external_share']);
+    expect(log.payload['text'], 'hello');
+  });
+
+  test('approval payload keeps tool name, scopes, and CEO metadata', () {
+    final log = AgentToolApprovalLog.fromMap({
+      'id': 'log-2',
+      'tool_name': 'payments.purchase',
+      'allowed': false,
+      'requires_approval': true,
+      'requested_scopes': 'purchase',
+      'high_risk_scopes': ['purchase'],
+    });
+
+    final payload = jsonDecode(
+      log.buildApprovalPayloadJson(
+        approvedBy: 'ceo@example.com',
+        approvedAt: DateTime.utc(2026, 5, 2, 12),
+      ),
+    ) as Map<String, dynamic>;
+
+    expect(payload['tool_name'], 'payments.purchase');
+    expect(payload['requested_scopes'], ['purchase']);
+    expect(payload['approval'], {
+      'decision': 'approved',
+      'approved_by': 'ceo@example.com',
+      'approved_at': '2026-05-02T12:00:00.000Z',
+    });
+  });
+}


### PR DESCRIPTION
﻿## Summary
- Add `/agent-tool-approvals`, a CEO approval/audit screen for high-risk AI officer tool requests.
- Add `AgentToolApprovalService` for reading `agent_tool_execution_logs`, recording approve/reject decisions, and producing copyable approval metadata for the next server-side run.
- Add Home catalog and route wiring plus a WBS progress migration for Issue #846.

## Validation
- `dart analyze lib\pages\agent_tool_approval_page.dart lib\services\agent_tool_approval_service.dart lib\main.dart lib\data\home_tool_catalog.dart`
- `flutter test test\services\agent_tool_approval_service_test.dart --no-pub`
- `python scripts\check_migration_timestamps.py`
- `git diff --check`

## Notes
#845 remains blocked on a real WorkOS/AuthKit-issued bearer token for authenticated MCP smoke. This PR advances the next top WBS item, #846, by adding the missing approval UI/audit slice.

Fixes #846
