### PR TITLE
[codex] add self touch tracker

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -55,6 +55,7 @@ import '../pages/table_data_page.dart';
 import '../pages/tech_blog_tracker_page.dart';
 import '../pages/template_marketplace_page.dart';
 import '../pages/thought_anchor_page.dart';
+import '../pages/self_touch_tracker_page.dart';
 import '../pages/thought_capture_page.dart';
 import '../pages/wardrobe_page.dart';
 import '../pages/personality_test_questions_page.dart';
@@ -499,6 +500,16 @@ List<HomeToolEntry> buildHomeToolCatalog({
       color: const Color(0xFF607D8B),
       keywords: const <String>['行動', '発言', '振り返り'],
       onOpen: (context) => _pushPage(context, const BehaviorLogPage()),
+    ),
+    HomeToolEntry(
+      id: 'self-touch-tracker',
+      sectionId: 'personal',
+      title: '自己接触トラッカー',
+      subtitle: '髪や顔に手が伸びた瞬間を記録し、置き換え行動へ戻す',
+      icon: Icons.touch_app_outlined,
+      color: const Color(0xFF0891B2),
+      keywords: const <String>['自己接触', '髪', 'セルフケア', '思考サポート'],
+      onOpen: (context) => _pushPage(context, const SelfTouchTrackerPage()),
     ),
     HomeToolEntry(
       id: 'wip-limit',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,6 +55,7 @@ import 'package:my_web_app/pages/profile_settings_page.dart';
 import 'package:my_web_app/pages/public_profile_page.dart';
 import 'package:my_web_app/pages/tech_blog_tracker_page.dart';
 import 'package:my_web_app/pages/thought_anchor_page.dart';
+import 'package:my_web_app/pages/self_touch_tracker_page.dart';
 import 'package:my_web_app/pages/rewards_page.dart';
 import 'package:my_web_app/pages/admin_analytics_page.dart';
 import 'package:my_web_app/pages/admin/feedback_list_page.dart';
@@ -703,6 +704,10 @@ class _MyAppState extends State<MyApp> {
           case '/behavior-log':
             return MaterialPageRoute(
               builder: (_) => const BehaviorLogPage(),
+            );
+          case '/self-touch-tracker':
+            return MaterialPageRoute(
+              builder: (_) => const SelfTouchTrackerPage(),
             );
           case '/wip-limit':
             return MaterialPageRoute(

--- a/lib/pages/self_touch_tracker_page.dart
+++ b/lib/pages/self_touch_tracker_page.dart
@@ -1,0 +1,605 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../services/self_touch_tracker_service.dart';
+
+class SelfTouchTrackerPage extends StatefulWidget {
+  const SelfTouchTrackerPage({
+    super.key,
+    this.service = const SelfTouchTrackerService(),
+  });
+
+  final SelfTouchTrackerService service;
+
+  @override
+  State<SelfTouchTrackerPage> createState() => _SelfTouchTrackerPageState();
+}
+
+class _SelfTouchTrackerPageState extends State<SelfTouchTrackerPage> {
+  final _noteController = TextEditingController();
+  final _timeFormatter = DateFormat('M/d HH:mm');
+
+  bool _loading = true;
+  bool _saving = false;
+  String _selectedTrigger = 'stuck';
+  int _intensity = 3;
+  List<SelfTouchEvent> _events = const <SelfTouchEvent>[];
+  SelfTouchStats _stats = const SelfTouchStats(
+    totalCount: 0,
+    todayCount: 0,
+    last7DaysCount: 0,
+    last30MinutesCount: 0,
+    dailyCounts: <DateTime, int>{},
+    weeklyCounts: <DateTime, int>{},
+  );
+
+  static const List<_TriggerOption> _triggers = <_TriggerOption>[
+    _TriggerOption(
+      id: 'stuck',
+      label: '行き詰まり',
+      icon: Icons.psychology_alt_outlined,
+      color: Color(0xFF3D5AFE),
+    ),
+    _TriggerOption(
+      id: 'word_search',
+      label: '言葉が出ない',
+      icon: Icons.chat_bubble_outline,
+      color: Color(0xFF0891B2),
+    ),
+    _TriggerOption(
+      id: 'stress',
+      label: '緊張',
+      icon: Icons.monitor_heart_outlined,
+      color: Color(0xFFE53935),
+    ),
+    _TriggerOption(
+      id: 'boredom',
+      label: '退屈',
+      icon: Icons.hourglass_empty,
+      color: Color(0xFFFF6B35),
+    ),
+    _TriggerOption(
+      id: 'focus',
+      label: '集中時',
+      icon: Icons.center_focus_strong,
+      color: Color(0xFF059669),
+    ),
+  ];
+
+  _TriggerOption get _selectedTriggerOption => _triggers.firstWhere(
+        (trigger) => trigger.id == _selectedTrigger,
+        orElse: () => _triggers.first,
+      );
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    final snapshot = await widget.service.loadSnapshot();
+    if (!mounted) return;
+    setState(() {
+      _events = snapshot.events;
+      _stats = snapshot.stats;
+      _loading = false;
+    });
+  }
+
+  Future<void> _record() async {
+    if (_saving) return;
+    setState(() => _saving = true);
+    final trigger = _selectedTrigger;
+    final intensity = _intensity;
+    final note = _noteController.text;
+    final snapshot = await widget.service.recordEvent(
+      trigger: trigger,
+      intensity: intensity,
+      note: note,
+    );
+    if (!mounted) return;
+    setState(() {
+      _events = snapshot.events;
+      _stats = snapshot.stats;
+      _saving = false;
+    });
+    _noteController.clear();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('記録しました')),
+    );
+    if (snapshot.stats.shouldPromptReplacement) {
+      await _showReplacementSheet();
+    }
+  }
+
+  Future<void> _delete(SelfTouchEvent event) async {
+    final snapshot = await widget.service.deleteEvent(id: event.id);
+    if (!mounted) return;
+    setState(() {
+      _events = snapshot.events;
+      _stats = snapshot.stats;
+    });
+  }
+
+  Future<void> _showReplacementSheet() async {
+    final trigger = _selectedTriggerOption;
+    final plans = widget.service.replacementPlans(
+      trigger: _selectedTrigger,
+      intensity: _intensity,
+    );
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    CircleAvatar(
+                      backgroundColor: trigger.color.withValues(alpha: 0.12),
+                      child: Icon(trigger.icon, color: trigger.color),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        '${trigger.label}の置き換え',
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                ...plans.map(
+                  (plan) => Padding(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    child: _ReplacementPlanTile(plan: plan),
+                  ),
+                ),
+                const Text(
+                  '強い苦痛、抜毛、皮膚の傷、日常生活への支障がある場合は専門家へ相談してください。',
+                  style: TextStyle(fontSize: 12, color: Color(0xFF6B7280)),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final dailyBuckets = widget.service.dailyBuckets(stats: _stats, now: now);
+    final weeklyBuckets = widget.service.weeklyBuckets(stats: _stats, now: now);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('自己接触トラッカー'),
+        actions: [
+          IconButton(
+            onPressed: _showReplacementSheet,
+            icon: const Icon(Icons.self_improvement_outlined),
+            tooltip: '行き詰まり・思考サポート',
+          ),
+          IconButton(
+            onPressed: _loading ? null : _load,
+            icon: const Icon(Icons.refresh),
+            tooltip: '再読み込み',
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                _buildStatsHeader(),
+                const SizedBox(height: 12),
+                _buildQuickRecordCard(),
+                if (_stats.shouldPromptReplacement) ...[
+                  const SizedBox(height: 12),
+                  _buildPromptCard(),
+                ],
+                const SizedBox(height: 12),
+                _buildFrequencyCard(
+                  title: '日別頻度',
+                  icon: Icons.calendar_view_week_outlined,
+                  buckets: dailyBuckets,
+                  accent: const Color(0xFF3D5AFE),
+                ),
+                const SizedBox(height: 12),
+                _buildFrequencyCard(
+                  title: '週別頻度',
+                  icon: Icons.stacked_bar_chart,
+                  buckets: weeklyBuckets,
+                  accent: const Color(0xFF059669),
+                ),
+                const SizedBox(height: 12),
+                _buildRecentEventsCard(),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildStatsHeader() {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        _StatPill(
+          label: '今日',
+          value: '${_stats.todayCount}',
+          icon: Icons.today_outlined,
+          color: const Color(0xFF3D5AFE),
+        ),
+        _StatPill(
+          label: '7日',
+          value: '${_stats.last7DaysCount}',
+          icon: Icons.query_stats,
+          color: const Color(0xFF059669),
+        ),
+        _StatPill(
+          label: '30分',
+          value: '${_stats.last30MinutesCount}',
+          icon: Icons.timer_outlined,
+          color: const Color(0xFFFF6B35),
+        ),
+        _StatPill(
+          label: '累計',
+          value: '${_stats.totalCount}',
+          icon: Icons.storage_outlined,
+          color: const Color(0xFF607D8B),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildQuickRecordCard() {
+    final selected = _selectedTriggerOption;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(selected.icon, color: selected.color),
+                const SizedBox(width: 8),
+                Text(
+                  'ワンタップ記録',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _triggers.map((trigger) {
+                return ChoiceChip(
+                  avatar: Icon(trigger.icon, size: 18),
+                  label: Text(trigger.label),
+                  selected: _selectedTrigger == trigger.id,
+                  selectedColor: trigger.color.withValues(alpha: 0.16),
+                  onSelected: (_) {
+                    setState(() => _selectedTrigger = trigger.id);
+                  },
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 16),
+            Text('強さ $_intensity / 5'),
+            Slider(
+              value: _intensity.toDouble(),
+              min: 1,
+              max: 5,
+              divisions: 4,
+              label: '$_intensity',
+              onChanged: (value) => setState(() => _intensity = value.round()),
+            ),
+            TextField(
+              controller: _noteController,
+              minLines: 1,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: 'メモ',
+                prefixIcon: Icon(Icons.edit_note_outlined),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: _saving ? null : _record,
+                icon: _saving
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.touch_app_outlined),
+                label: const Text('いま記録'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPromptCard() {
+    return Card(
+      color: const Color(0xFFFFF7ED),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            const Icon(Icons.lightbulb_outline, color: Color(0xFFFF6B35)),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                _stats.last30MinutesCount >= 3
+                    ? '30分以内の記録が増えています。手をふさぐ代替動作に切り替えます。'
+                    : '今日の記録が増えています。短いリセットを入れます。',
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+            ),
+            TextButton(
+              onPressed: _showReplacementSheet,
+              child: const Text('見る'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFrequencyCard({
+    required String title,
+    required IconData icon,
+    required List<SelfTouchFrequencyBucket> buckets,
+    required Color accent,
+  }) {
+    final maxCount = buckets.fold<int>(
+      1,
+      (max, bucket) => bucket.count > max ? bucket.count : max,
+    );
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, color: accent),
+                const SizedBox(width: 8),
+                Text(title, style: Theme.of(context).textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: 12),
+            ...buckets.map((bucket) {
+              final ratio = bucket.count / maxCount;
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 56,
+                      child: Text(
+                        bucket.label,
+                        style: const TextStyle(fontSize: 12),
+                      ),
+                    ),
+                    Expanded(
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(4),
+                        child: LinearProgressIndicator(
+                          value: ratio,
+                          minHeight: 10,
+                          color: accent,
+                          backgroundColor: accent.withValues(alpha: 0.12),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    SizedBox(
+                      width: 28,
+                      child: Text(
+                        '${bucket.count}',
+                        textAlign: TextAlign.right,
+                        style: const TextStyle(fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRecentEventsCard() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.history, color: Color(0xFF607D8B)),
+                const SizedBox(width: 8),
+                Text('最近の記録', style: Theme.of(context).textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: 8),
+            if (_events.isEmpty)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: Center(child: Text('まだ記録がありません')),
+              )
+            else
+              ..._events.take(12).map((event) {
+                final trigger = _triggers.firstWhere(
+                  (item) => item.id == event.trigger,
+                  orElse: () => _triggers.first,
+                );
+                return ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: CircleAvatar(
+                    backgroundColor: trigger.color.withValues(alpha: 0.12),
+                    child: Icon(trigger.icon, color: trigger.color),
+                  ),
+                  title: Text('${trigger.label}  強さ${event.intensity}'),
+                  subtitle: Text(
+                    [
+                      _timeFormatter.format(event.occurredAt),
+                      if (event.note.isNotEmpty) event.note,
+                    ].join('  /  '),
+                  ),
+                  trailing: IconButton(
+                    onPressed: () => _delete(event),
+                    icon: const Icon(Icons.delete_outline),
+                    tooltip: '削除',
+                  ),
+                );
+              }),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TriggerOption {
+  const _TriggerOption({
+    required this.id,
+    required this.label,
+    required this.icon,
+    required this.color,
+  });
+
+  final String id;
+  final String label;
+  final IconData icon;
+  final Color color;
+}
+
+class _StatPill extends StatelessWidget {
+  const _StatPill({
+    required this.label,
+    required this.value,
+    required this.icon,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(minWidth: 96),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18, color: color),
+          const SizedBox(width: 8),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: const TextStyle(fontSize: 11, color: Color(0xFF6B7280)),
+              ),
+              Text(
+                value,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                  color: color,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReplacementPlanTile extends StatelessWidget {
+  const _ReplacementPlanTile({required this.plan});
+
+  final SelfTouchReplacementPlan plan;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: const Color(0xFFE5E7EB)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.timer_outlined, size: 18),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    '${plan.title}  ${plan.durationSeconds}秒',
+                    style: const TextStyle(fontWeight: FontWeight.w800),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ...plan.steps.map(
+              (step) => Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('・'),
+                    Expanded(child: Text(step)),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/self_touch_tracker_service.dart
+++ b/lib/services/self_touch_tracker_service.dart
@@ -1,0 +1,324 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SelfTouchEvent {
+  const SelfTouchEvent({
+    required this.id,
+    required this.occurredAt,
+    required this.trigger,
+    required this.intensity,
+    this.note = '',
+    this.replacementAction = '',
+  });
+
+  factory SelfTouchEvent.fromJson(Map<String, dynamic> json) {
+    return SelfTouchEvent(
+      id: json['id'] as String? ?? '',
+      occurredAt: DateTime.tryParse(json['occurred_at'] as String? ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      trigger: json['trigger'] as String? ?? 'unknown',
+      intensity: (json['intensity'] as num?)?.toInt().clamp(1, 5) ?? 3,
+      note: json['note'] as String? ?? '',
+      replacementAction: json['replacement_action'] as String? ?? '',
+    );
+  }
+
+  final String id;
+  final DateTime occurredAt;
+  final String trigger;
+  final int intensity;
+  final String note;
+  final String replacementAction;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'occurred_at': occurredAt.toIso8601String(),
+        'trigger': trigger,
+        'intensity': intensity,
+        'note': note,
+        'replacement_action': replacementAction,
+      };
+}
+
+class SelfTouchFrequencyBucket {
+  const SelfTouchFrequencyBucket({
+    required this.label,
+    required this.count,
+  });
+
+  final String label;
+  final int count;
+}
+
+class SelfTouchStats {
+  const SelfTouchStats({
+    required this.totalCount,
+    required this.todayCount,
+    required this.last7DaysCount,
+    required this.last30MinutesCount,
+    required this.dailyCounts,
+    required this.weeklyCounts,
+  });
+
+  final int totalCount;
+  final int todayCount;
+  final int last7DaysCount;
+  final int last30MinutesCount;
+  final Map<DateTime, int> dailyCounts;
+  final Map<DateTime, int> weeklyCounts;
+
+  bool get shouldPromptReplacement =>
+      last30MinutesCount >= 3 || todayCount >= 8;
+}
+
+class SelfTouchSnapshot {
+  const SelfTouchSnapshot({
+    required this.events,
+    required this.stats,
+  });
+
+  final List<SelfTouchEvent> events;
+  final SelfTouchStats stats;
+}
+
+class SelfTouchReplacementPlan {
+  const SelfTouchReplacementPlan({
+    required this.title,
+    required this.steps,
+    required this.durationSeconds,
+  });
+
+  final String title;
+  final List<String> steps;
+  final int durationSeconds;
+}
+
+class SelfTouchTrackerService {
+  const SelfTouchTrackerService();
+
+  static const String storageKey = 'self_touch_tracker_events_v1';
+  static const int maxStoredEvents = 300;
+
+  Future<SelfTouchSnapshot> loadSnapshot({
+    SharedPreferences? prefs,
+    DateTime? now,
+  }) async {
+    final resolvedPrefs = prefs ?? await SharedPreferences.getInstance();
+    final events = _decodeEvents(resolvedPrefs.getString(storageKey));
+    return SelfTouchSnapshot(
+      events: events,
+      stats: buildStats(events, now: now ?? DateTime.now()),
+    );
+  }
+
+  Future<SelfTouchSnapshot> recordEvent({
+    required String trigger,
+    required int intensity,
+    String note = '',
+    String replacementAction = '',
+    SharedPreferences? prefs,
+    DateTime? now,
+  }) async {
+    final resolvedPrefs = prefs ?? await SharedPreferences.getInstance();
+    final timestamp = now ?? DateTime.now();
+    final events = _decodeEvents(resolvedPrefs.getString(storageKey));
+    final event = SelfTouchEvent(
+      id: 'self-touch-${timestamp.microsecondsSinceEpoch}',
+      occurredAt: timestamp,
+      trigger: trigger,
+      intensity: intensity.clamp(1, 5),
+      note: note.trim(),
+      replacementAction: replacementAction.trim(),
+    );
+    final updated = <SelfTouchEvent>[event, ...events]
+        .take(maxStoredEvents)
+        .toList(growable: false);
+    await _saveEvents(resolvedPrefs, updated);
+    return SelfTouchSnapshot(
+      events: updated,
+      stats: buildStats(updated, now: timestamp),
+    );
+  }
+
+  Future<SelfTouchSnapshot> deleteEvent({
+    required String id,
+    SharedPreferences? prefs,
+    DateTime? now,
+  }) async {
+    final resolvedPrefs = prefs ?? await SharedPreferences.getInstance();
+    final updated = _decodeEvents(resolvedPrefs.getString(storageKey))
+        .where((event) => event.id != id)
+        .toList(growable: false);
+    await _saveEvents(resolvedPrefs, updated);
+    return SelfTouchSnapshot(
+      events: updated,
+      stats: buildStats(updated, now: now ?? DateTime.now()),
+    );
+  }
+
+  SelfTouchStats buildStats(
+    List<SelfTouchEvent> events, {
+    required DateTime now,
+  }) {
+    final today = _dayStart(now);
+    final sevenDaysAgo = today.subtract(const Duration(days: 6));
+    final thirtyMinutesAgo = now.subtract(const Duration(minutes: 30));
+    final dailyCounts = <DateTime, int>{};
+    final weeklyCounts = <DateTime, int>{};
+    var todayCount = 0;
+    var last7DaysCount = 0;
+    var last30MinutesCount = 0;
+
+    for (final event in events) {
+      final day = _dayStart(event.occurredAt);
+      dailyCounts[day] = (dailyCounts[day] ?? 0) + 1;
+
+      final week = _weekStart(event.occurredAt);
+      weeklyCounts[week] = (weeklyCounts[week] ?? 0) + 1;
+
+      if (day == today) todayCount += 1;
+      if (!day.isBefore(sevenDaysAgo) && !day.isAfter(today)) {
+        last7DaysCount += 1;
+      }
+      if (!event.occurredAt.isBefore(thirtyMinutesAgo) &&
+          !event.occurredAt.isAfter(now)) {
+        last30MinutesCount += 1;
+      }
+    }
+
+    return SelfTouchStats(
+      totalCount: events.length,
+      todayCount: todayCount,
+      last7DaysCount: last7DaysCount,
+      last30MinutesCount: last30MinutesCount,
+      dailyCounts: Map.unmodifiable(dailyCounts),
+      weeklyCounts: Map.unmodifiable(weeklyCounts),
+    );
+  }
+
+  List<SelfTouchFrequencyBucket> dailyBuckets({
+    required SelfTouchStats stats,
+    required DateTime now,
+    int days = 7,
+  }) {
+    final today = _dayStart(now);
+    return List<SelfTouchFrequencyBucket>.generate(days, (index) {
+      final day = today.subtract(Duration(days: days - index - 1));
+      return SelfTouchFrequencyBucket(
+        label: '${day.month}/${day.day}',
+        count: stats.dailyCounts[day] ?? 0,
+      );
+    });
+  }
+
+  List<SelfTouchFrequencyBucket> weeklyBuckets({
+    required SelfTouchStats stats,
+    required DateTime now,
+    int weeks = 4,
+  }) {
+    final thisWeek = _weekStart(now);
+    return List<SelfTouchFrequencyBucket>.generate(weeks, (index) {
+      final week = thisWeek.subtract(Duration(days: 7 * (weeks - index - 1)));
+      return SelfTouchFrequencyBucket(
+        label: '${week.month}/${week.day}週',
+        count: stats.weeklyCounts[week] ?? 0,
+      );
+    });
+  }
+
+  List<SelfTouchReplacementPlan> replacementPlans({
+    required String trigger,
+    required int intensity,
+  }) {
+    final base = <SelfTouchReplacementPlan>[
+      const SelfTouchReplacementPlan(
+        title: '手をふさぐ代替動作',
+        durationSeconds: 60,
+        steps: [
+          'ペン、ストレスボール、タオルのどれかを片手で持つ',
+          '肩を下げて、息を4秒吸って6秒吐く',
+          '触りたい衝動が下がるまで机の上に手を置く',
+        ],
+      ),
+      const SelfTouchReplacementPlan(
+        title: '状況ラベルをつける',
+        durationSeconds: 45,
+        steps: [
+          'いまの状態を「不安」「退屈」「言葉探し」のどれかで呼ぶ',
+          'ラベルだけをメモし、原因探しは後回しにする',
+          '次の1手を15分以内の作業に縮める',
+        ],
+      ),
+    ];
+
+    if (trigger == 'word_search' || trigger == 'stuck') {
+      return <SelfTouchReplacementPlan>[
+        const SelfTouchReplacementPlan(
+          title: '言葉探しの外部化',
+          durationSeconds: 90,
+          steps: [
+            '思い出したい言葉の周辺語を3つ書く',
+            '文の空欄に「あとで埋める」と置いて先に進む',
+            '2分後に戻る時刻を決める',
+          ],
+        ),
+        ...base,
+      ];
+    }
+    if (trigger == 'stress' || intensity >= 4) {
+      return <SelfTouchReplacementPlan>[
+        const SelfTouchReplacementPlan(
+          title: '緊張を下げる短いリセット',
+          durationSeconds: 120,
+          steps: [
+            '首と肩に力が入っていないか確認する',
+            '足裏を床につけ、視線を遠くへ移す',
+            '飲み物を一口飲んでから作業へ戻る',
+          ],
+        ),
+        ...base,
+      ];
+    }
+    return base;
+  }
+
+  List<SelfTouchEvent> _decodeEvents(String? raw) {
+    if (raw == null || raw.trim().isEmpty) return const <SelfTouchEvent>[];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return const <SelfTouchEvent>[];
+      return decoded
+          .whereType<Map>()
+          .map(
+            (item) => SelfTouchEvent.fromJson(
+              Map<String, dynamic>.from(item),
+            ),
+          )
+          .where((event) => event.id.isNotEmpty)
+          .toList(growable: false)
+        ..sort((a, b) => b.occurredAt.compareTo(a.occurredAt));
+    } catch (_) {
+      return const <SelfTouchEvent>[];
+    }
+  }
+
+  Future<void> _saveEvents(
+    SharedPreferences prefs,
+    List<SelfTouchEvent> events,
+  ) {
+    return prefs.setString(
+      storageKey,
+      jsonEncode(events.map((event) => event.toJson()).toList()),
+    );
+  }
+
+  DateTime _dayStart(DateTime value) {
+    return DateTime(value.year, value.month, value.day);
+  }
+
+  DateTime _weekStart(DateTime value) {
+    final day = _dayStart(value);
+    return day.subtract(Duration(days: day.weekday - DateTime.monday));
+  }
+}

--- a/test/pages/self_touch_tracker_page_test.dart
+++ b/test/pages/self_touch_tracker_page_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/self_touch_tracker_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('records a self-touch event from the quick action',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: SelfTouchTrackerPage()),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('自己接触トラッカー'), findsOneWidget);
+    expect(find.text('ワンタップ記録'), findsOneWidget);
+
+    await tester.tap(find.text('いま記録'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('行き詰まり'), findsWidgets);
+  });
+}

--- a/test/services/self_touch_tracker_service_test.dart
+++ b/test/services/self_touch_tracker_service_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/self_touch_tracker_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('recordEvent stores touch events and aggregates daily and weekly counts',
+      () async {
+    const service = SelfTouchTrackerService();
+    final prefs = await SharedPreferences.getInstance();
+
+    var snapshot = await service.recordEvent(
+      trigger: 'stuck',
+      intensity: 3,
+      prefs: prefs,
+      now: DateTime(2026, 5, 1, 10),
+    );
+    snapshot = await service.recordEvent(
+      trigger: 'word_search',
+      intensity: 4,
+      note: 'meeting memo',
+      prefs: prefs,
+      now: DateTime(2026, 5, 2, 9),
+    );
+
+    expect(snapshot.events, hasLength(2));
+    expect(snapshot.events.first.trigger, 'word_search');
+    expect(snapshot.stats.todayCount, 1);
+    expect(snapshot.stats.last7DaysCount, 2);
+
+    final daily = service.dailyBuckets(
+      stats: snapshot.stats,
+      now: DateTime(2026, 5, 2, 12),
+    );
+    expect(daily.last.count, 1);
+    expect(daily[daily.length - 2].count, 1);
+
+    final weekly = service.weeklyBuckets(
+      stats: snapshot.stats,
+      now: DateTime(2026, 5, 2, 12),
+    );
+    expect(weekly.last.count, 2);
+  });
+
+  test('replacement prompt turns on after repeated events in thirty minutes',
+      () async {
+    const service = SelfTouchTrackerService();
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime(2026, 5, 2, 14);
+
+    for (var i = 0; i < 3; i += 1) {
+      await service.recordEvent(
+        trigger: 'stress',
+        intensity: 4,
+        prefs: prefs,
+        now: now.add(Duration(minutes: i * 8)),
+      );
+    }
+
+    final snapshot = await service.loadSnapshot(
+      prefs: prefs,
+      now: now.add(const Duration(minutes: 20)),
+    );
+
+    expect(snapshot.stats.last30MinutesCount, 3);
+    expect(snapshot.stats.shouldPromptReplacement, isTrue);
+
+    final plans = service.replacementPlans(trigger: 'stress', intensity: 4);
+    expect(plans.first.title, contains('リセット'));
+    expect(
+      plans.expand((plan) => plan.steps),
+      contains('ペン、ストレスボール、タオルのどれかを片手で持つ'),
+    );
+  });
+
+  test('deleteEvent removes only the selected record', () async {
+    const service = SelfTouchTrackerService();
+    final prefs = await SharedPreferences.getInstance();
+
+    var snapshot = await service.recordEvent(
+      trigger: 'boredom',
+      intensity: 2,
+      prefs: prefs,
+      now: DateTime(2026, 5, 2, 10),
+    );
+    snapshot = await service.recordEvent(
+      trigger: 'focus',
+      intensity: 1,
+      prefs: prefs,
+      now: DateTime(2026, 5, 2, 11),
+    );
+
+    final remaining = await service.deleteEvent(
+      id: snapshot.events.first.id,
+      prefs: prefs,
+      now: DateTime(2026, 5, 2, 12),
+    );
+
+    expect(remaining.events, hasLength(1));
+    expect(remaining.events.single.trigger, 'boredom');
+    expect(remaining.stats.todayCount, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- Add /self-touch-tracker with one-tap self-touch logging, trigger/intensity selection, recent records, and replacement-action prompts.
- Persist events locally with SharedPreferences and aggregate daily/weekly frequencies for the chart cards.
- Register the feature in the home tool catalog and direct route table.
- Add service and widget tests for recording, thresholds, deletion, and route coverage.

Fixes #1272.

## Minimal E2E Gate
- Implementation-detail independent: the covered behavior is user-visible input/output, not storage internals or widget class names.
- Minimal plan: about three I/O cases are covered at the boundary: record event, replacement-prompt threshold, and delete event.
- E2E mechanism: Playwright or Flutter integration_test is not added in this slice because the feature is a local-only SharedPreferences tool surface with focused service/widget coverage and no hosted cross-service flow yet.
- E2E-Exception: a full browser E2E should be added when #1274 promotes the replacement-action sheet into broader thought-support entry points; manual verification is covered by the widget route smoke plus service tests in this PR.

## Validation
- dart analyze lib\\services\\self_touch_tracker_service.dart lib\\pages\\self_touch_tracker_page.dart
- flutter test test\\services\\self_touch_tracker_service_test.dart test\\pages\\self_touch_tracker_page_test.dart test\\routes\\direct_path_routes_test.dart

## Follow-up
- #1274 can reuse the replacement-action sheet for broader TOT/thought-support entry points across work screens.
- Full flutter analyze on lib/main.dart and home_tool_catalog.dart timed out on this Windows session; targeted route tests and page/service analysis passed.
