### PR TITLE
feat: add thought stuck support sheet

### DIFF
--- a/lib/widgets/thought_interrupt_quick_widget.dart
+++ b/lib/widgets/thought_interrupt_quick_widget.dart
@@ -66,6 +66,17 @@ class ThoughtInterruptQuickWidget extends StatelessWidget {
     );
   }
 
+  void _showTotSupportSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => const _TotSupportSheet(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -117,6 +128,21 @@ class ThoughtInterruptQuickWidget extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              key: const Key('thought_interrupt_tot_support_button'),
+              onPressed: () => _showTotSupportSheet(context),
+              icon: const Icon(Icons.psychology_alt_outlined, size: 18),
+              label: const Text('行き詰まり・思考サポート'),
+              style: FilledButton.styleFrom(
+                backgroundColor: const Color(0xFF0F766E),
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 10),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
           Wrap(
             spacing: 6,
             runSpacing: 6,
@@ -161,6 +187,51 @@ class ThoughtInterruptQuickWidget extends StatelessWidget {
   }
 }
 
+class _TotSupportState {
+  const _TotSupportState({
+    required this.id,
+    required this.label,
+    required this.icon,
+    required this.primaryAction,
+    required this.refreshMethod,
+    required this.organizeTool,
+  });
+
+  final String id;
+  final String label;
+  final IconData icon;
+  final String primaryAction;
+  final String refreshMethod;
+  final String organizeTool;
+}
+
+const List<_TotSupportState> _totSupportStates = [
+  _TotSupportState(
+    id: 'words',
+    label: '言葉が出ない',
+    icon: Icons.chat_bubble_outline,
+    primaryAction: '目線を上げて、言いたい単語を3つだけ箇条書きにする。',
+    refreshMethod: '利き手ではない手で頭をゆっくり撫で、肩を2回回す。',
+    organizeTool: 'メモに「対象 / 感情 / 次の一文」を1行ずつ書く。',
+  ),
+  _TotSupportState(
+    id: 'focus',
+    label: '集中できない',
+    icon: Icons.center_focus_strong,
+    primaryAction: '椅子に深く座り直し、足裏を床につけて視界の物を1つ減らす。',
+    refreshMethod: '30秒の腹式呼吸を行い、終わったら次の1手だけ決める。',
+    organizeTool: '今やる作業を「2分で終わる粒度」に分解する。',
+  ),
+  _TotSupportState(
+    id: 'stress',
+    label: '緊張が強い',
+    icon: Icons.self_improvement,
+    primaryAction: '顎と肩の力を抜き、手を机の上に置いて接触行動を止める。',
+    refreshMethod: '温かい飲み物か水を取り、息を長く吐く呼吸を3回行う。',
+    organizeTool: '不安を書き出し、制御できることだけ丸で囲む。',
+  ),
+];
+
 class _ImpulseItem {
   _ImpulseItem(
     this.id,
@@ -176,6 +247,156 @@ class _ImpulseItem {
   final Color color;
   final String eliminationAction;
   final String replacementAction;
+}
+
+class _TotSupportSheet extends StatefulWidget {
+  const _TotSupportSheet();
+
+  @override
+  State<_TotSupportSheet> createState() => _TotSupportSheetState();
+}
+
+class _TotSupportSheetState extends State<_TotSupportSheet> {
+  _TotSupportState _selectedState = _totSupportStates.first;
+  double _stressLevel = 3;
+
+  @override
+  Widget build(BuildContext context) {
+    final color =
+        _stressLevel >= 4 ? const Color(0xFFE53935) : const Color(0xFF0F766E);
+    final stressLabel = _stressLevel.round();
+
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: EdgeInsets.only(
+          left: 20,
+          right: 20,
+          top: 16,
+          bottom: 24 + MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Column(
+          key: const Key('thought_interrupt_tot_support_sheet'),
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFE0E0E0),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Container(
+                  width: 42,
+                  height: 42,
+                  decoration: BoxDecoration(
+                    color: color.withValues(alpha: 0.12),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    _selectedState.icon,
+                    color: color,
+                    size: 22,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                const Expanded(
+                  child: Text(
+                    '行き詰まり・思考サポート',
+                    style: TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w800,
+                      height: 1.5,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 14),
+            const Text(
+              '今の状態',
+              style: TextStyle(fontWeight: FontWeight.w800, height: 1.5),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _totSupportStates.map((state) {
+                return ChoiceChip(
+                  key: Key('thought_interrupt_tot_state_${state.id}'),
+                  label: Text(state.label),
+                  selected: state.id == _selectedState.id,
+                  onSelected: (_) {
+                    setState(() => _selectedState = state);
+                  },
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'ストレスレベル $stressLabel / 5',
+              style: TextStyle(
+                color: color,
+                fontWeight: FontWeight.w800,
+                height: 1.5,
+              ),
+            ),
+            Slider(
+              key: const Key('thought_interrupt_tot_stress_slider'),
+              value: _stressLevel,
+              min: 1,
+              max: 5,
+              divisions: 4,
+              label: '$stressLabel',
+              activeColor: color,
+              onChanged: (value) => setState(() => _stressLevel = value),
+            ),
+            _ActionTile(
+              icon: Icons.accessibility_new,
+              color: color,
+              title: '姿勢リセット',
+              body: _selectedState.primaryAction,
+            ),
+            const SizedBox(height: 10),
+            _ActionTile(
+              icon: Icons.spa_outlined,
+              color: const Color(0xFF4CAF50),
+              title: 'リフレッシュ手法',
+              body: _selectedState.refreshMethod,
+            ),
+            const SizedBox(height: 10),
+            _ActionTile(
+              icon: Icons.edit_note,
+              color: const Color(0xFF3D5AFE),
+              title: '思考整理ツール',
+              body: _stressLevel >= 4
+                  ? '${_selectedState.organizeTool} まず60秒で止め、続きは次の休憩後に回す。'
+                  : _selectedState.organizeTool,
+            ),
+            const SizedBox(height: 20),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: () => Navigator.pop(context),
+                icon: const Icon(Icons.check, size: 18),
+                label: const Text('作業に戻る'),
+                style: FilledButton.styleFrom(
+                  backgroundColor: color,
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _InterventionSheet extends StatelessWidget {

--- a/test/widgets/thought_interrupt_quick_widget_test.dart
+++ b/test/widgets/thought_interrupt_quick_widget_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/thought_interrupt_quick_widget.dart';
+
+void main() {
+  testWidgets('ThoughtInterruptQuickWidget opens TOT support sheet',
+      (WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ThoughtInterruptQuickWidget(),
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const Key('thought_interrupt_tot_support_button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('thought_interrupt_tot_support_sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('言葉が出ない'), findsWidgets);
+    expect(find.text('ストレスレベル 3 / 5'), findsOneWidget);
+    expect(find.textContaining('言いたい単語を3つ'), findsOneWidget);
+
+    await tester
+        .tap(find.byKey(const Key('thought_interrupt_tot_state_stress')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('顎と肩の力を抜き'), findsOneWidget);
+
+    final slider = tester.widget<Slider>(
+      find.byKey(const Key('thought_interrupt_tot_stress_slider')),
+    );
+    slider.onChanged?.call(5);
+    await tester.pumpAndSettle();
+
+    expect(find.text('ストレスレベル 5 / 5'), findsOneWidget);
+    expect(find.textContaining('まず60秒で止め'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add a visible 行き詰まり・思考サポート action to the ThoughtInterruptQuickWidget
- let users choose the current state and stress level before receiving support
- show posture reset, refresh, and thought-organization guidance tailored to the selected state

## Validation
- dart analyze lib/widgets/thought_interrupt_quick_widget.dart test/widgets/thought_interrupt_quick_widget_test.dart
- flutter test --no-pub -r expanded --concurrency=1 --timeout=30s test/widgets/thought_interrupt_quick_widget_test.dart

## Minimal E2E Gate
- The E2E plan is implementation-detail independent and black-box: validate user-visible input/output only.
- Minimal plan: three I/O cases via Flutter integration_test if expanded: open the support sheet from the visible action button, select a different current state, and raise stress level to confirm the visible guidance changes.
- E2E-Exception: this PR keeps coverage at widget level because it updates one embedded Flutter widget and no new end-to-end route; adding Playwright or integration_test would duplicate the tested visible behavior.

Closes #1274