### PR TITLE
chore: check Claude remote control at session start

### DIFF
--- a/scripts/codex_session_check.py
+++ b/scripts/codex_session_check.py
@@ -51,6 +51,10 @@ def run_command(args: list[str], cwd: Path) -> CommandResult:
         )
     except FileNotFoundError as exc:
         return CommandResult(127, "", str(exc))
+    except PermissionError as exc:
+        return CommandResult(126, "", str(exc))
+    except OSError as exc:
+        return CommandResult(126, "", str(exc))
     return CommandResult(proc.returncode, proc.stdout.strip(), proc.stderr.strip())
 
 
@@ -111,11 +115,118 @@ def env_snapshot() -> dict[str, str]:
     return {key: os.environ.get(key, "not-exposed") for key in keys}
 
 
-def codex_cli_version(root: Path) -> str:
-    result = run_command(["codex", "--version"], root)
+def cli_version(command: str, root: Path) -> str:
+    result = run_command([command, "--version"], root)
+    if result.code != 0 and os.name == "nt":
+        result = run_command([f"{command}.cmd", "--version"], root)
     if result.code != 0:
         return "unavailable"
     return result.stdout or result.stderr or "unknown"
+
+
+def codex_cli_version(root: Path) -> str:
+    return cli_version("codex", root)
+
+
+def claude_code_version(root: Path) -> str:
+    return cli_version("claude", root)
+
+
+def default_claude_settings_path() -> Path:
+    override = os.environ.get("CLAUDE_SETTINGS_PATH")
+    if override:
+        return Path(override)
+    return Path.home() / ".claude" / "settings.json"
+
+
+def normalized_key_path(path: list[str]) -> str:
+    return ".".join(path).lower().replace("_", "").replace("-", "").replace(" ", "")
+
+
+def is_remote_control_flag_path(path: list[str]) -> bool:
+    normalized = normalized_key_path(path)
+    if "remotecontrol" not in normalized:
+        return False
+    return any(
+        token in normalized
+        for token in [
+            "enable",
+            "enabled",
+            "allsessions",
+            "autosession",
+            "always",
+        ]
+    )
+
+
+def collect_remote_control_flags(
+    value: Any,
+    path: list[str] | None = None,
+) -> list[tuple[list[str], bool]]:
+    current_path = path or []
+    flags: list[tuple[list[str], bool]] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            flags.extend(collect_remote_control_flags(item, [*current_path, str(key)]))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            flags.extend(collect_remote_control_flags(item, [*current_path, str(index)]))
+    elif isinstance(value, bool) and is_remote_control_flag_path(current_path):
+        flags.append((current_path, value))
+    return flags
+
+
+def analyze_claude_remote_control(
+    root: Path,
+    settings_path: Path | None = None,
+) -> dict[str, Any]:
+    path = settings_path or default_claude_settings_path()
+    version = claude_code_version(root)
+    status = "unknown"
+    evidence = "No known Remote Control all-sessions setting was found."
+    settings_state = "missing"
+    flag_path: str | None = None
+
+    if path.exists():
+        settings_state = "found"
+        try:
+            data = json.loads(path.read_text(encoding="utf-8-sig"))
+            flags = collect_remote_control_flags(data)
+            true_flags = [item for item in flags if item[1]]
+            false_flags = [item for item in flags if not item[1]]
+            if true_flags:
+                status = "enabled"
+                flag_path = ".".join(true_flags[0][0])
+                evidence = f"Detected true setting at `{flag_path}`."
+            elif false_flags:
+                status = "disabled"
+                flag_path = ".".join(false_flags[0][0])
+                evidence = f"Detected false setting at `{flag_path}`."
+        except json.JSONDecodeError as exc:
+            settings_state = "invalid-json"
+            evidence = f"Could not parse Claude settings JSON: {exc}"
+        except OSError as exc:
+            settings_state = "unreadable"
+            evidence = f"Could not read Claude settings: {exc}"
+
+    return {
+        "version": version,
+        "settings_path": str(path),
+        "settings_state": settings_state,
+        "all_sessions_status": status,
+        "flag_path": flag_path,
+        "evidence": evidence,
+        "manual_steps": [
+            "Open Claude Code locally.",
+            "Run `/config`.",
+            "Set `Enable Remote Control for all sessions` to `true`.",
+            "Start a normal interactive session and verify it appears in `claude.ai/code`.",
+        ],
+        "admin_note": (
+            "Team/Enterprise plans also require an admin to enable the Remote Control "
+            "toggle in Claude Code admin settings."
+        ),
+    }
 
 
 def parse_semver(text: str) -> tuple[int, int, int] | None:
@@ -137,6 +248,7 @@ def analyze(cwd: Path) -> dict[str, Any]:
     remote_url = git_text(["remote", "get-url", "origin"], root, default="unknown")
     worktrees = worktree_entries(root)
     codex_version = codex_cli_version(root)
+    claude_remote_control = analyze_claude_remote_control(root)
 
     warnings: list[str] = []
     if dirty_lines:
@@ -161,6 +273,16 @@ def analyze(cwd: Path) -> dict[str, Any]:
         warnings.append(
             "Codex CLI is older than 0.128.0; persisted `/goal` workflows are not ready"
         )
+    claude_version = claude_remote_control["version"]
+    parsed_claude_version = parse_semver(claude_version)
+    if claude_version == "unavailable":
+        warnings.append("Claude Code CLI is unavailable on PATH; Remote Control cannot be verified")
+    elif parsed_claude_version and parsed_claude_version < (2, 1, 79):
+        warnings.append("Claude Code is older than 2.1.79; Remote Control slash command support is not ready")
+    if claude_remote_control["all_sessions_status"] != "enabled":
+        warnings.append(
+            "Claude Code Remote Control all-sessions mode is not verified as enabled; run `/config` in Claude Code"
+        )
 
     return {
         "root": str(root),
@@ -174,6 +296,7 @@ def analyze(cwd: Path) -> dict[str, Any]:
         "dirty_paths": dirty_lines[:20],
         "remote": remote_url,
         "codex_cli_version": codex_version,
+        "claude_remote_control": claude_remote_control,
         "worktrees": worktrees,
         "environment": env_snapshot(),
         "warnings": warnings,
@@ -198,6 +321,23 @@ def render_markdown(report: dict[str, Any]) -> str:
     ]
     for key, value in report["environment"].items():
         lines.append(f"- `{key}`: `{value}`")
+
+    remote = report["claude_remote_control"]
+    lines.extend(
+        [
+            "",
+            "## Claude Code Remote Control",
+            f"- Claude Code CLI: `{remote['version']}`",
+            f"- Settings: `{remote['settings_path']}` ({remote['settings_state']})",
+            f"- All-session Remote Control: `{remote['all_sessions_status']}`",
+            f"- Evidence: {remote['evidence']}",
+        ]
+    )
+    if remote["all_sessions_status"] != "enabled":
+        lines.append("- Required manual steps:")
+        for step in remote["manual_steps"]:
+            lines.append(f"  - {step}")
+        lines.append(f"- Team/Enterprise note: {remote['admin_note']}")
 
     lines.extend(["", "## Warnings"])
     if report["warnings"]:

--- a/scripts/codex_session_check_test.py
+++ b/scripts/codex_session_check_test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from codex_session_check import (
+    collect_remote_control_flags,
+    is_remote_control_flag_path,
+)
+
+
+class ClaudeRemoteControlDetectionTest(unittest.TestCase):
+    def test_detects_all_session_remote_control_flag(self) -> None:
+        data = {
+            "claudeCode": {
+                "remoteControl": {
+                    "enableForAllSessions": True,
+                },
+            },
+        }
+
+        flags = collect_remote_control_flags(data)
+
+        self.assertEqual(flags, [(["claudeCode", "remoteControl", "enableForAllSessions"], True)])
+
+    def test_detects_disabled_remote_control_flag(self) -> None:
+        data = {
+            "remote_control": {
+                "enabled_for_all_sessions": False,
+            },
+        }
+
+        flags = collect_remote_control_flags(data)
+
+        self.assertEqual(flags, [(["remote_control", "enabled_for_all_sessions"], False)])
+
+    def test_ignores_unrelated_remote_setting(self) -> None:
+        data = {
+            "remote": {
+                "host": "example.com",
+            },
+            "permissions": {
+                "enabled": True,
+            },
+        }
+
+        flags = collect_remote_control_flags(data)
+
+        self.assertEqual(flags, [])
+
+    def test_key_path_normalization_matches_expected_variants(self) -> None:
+        self.assertTrue(
+            is_remote_control_flag_path(
+                ["settings", "remote-control", "enabled for all sessions"]
+            )
+        )
+        self.assertTrue(
+            is_remote_control_flag_path(
+                ["settings", "remote_control", "always_enabled"]
+            )
+        )
+
+    def test_missing_settings_key_stays_unknown_by_absence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "settings.json"
+            path.write_text('{"permissions":{"defaultMode":"bypassPermissions"}}', encoding="utf-8")
+            flags = collect_remote_control_flags({"permissions": {"defaultMode": "bypassPermissions"}})
+
+        self.assertEqual(flags, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Claude Code Remote Control status to the Codex session-start report
- detect Windows npm CLI shims via .cmd fallback for Codex and Claude version checks
- add unittest coverage for Remote Control setting detection

## Validation
- python -m py_compile scripts\codex_session_check.py scripts\codex_session_check_test.py
- python scripts\codex_session_check_test.py
- python scripts\codex_session_check.py

## Minimal E2E Gate
- Implementation-detail independent: this is a tooling-only session-start report change and does not inspect or depend on app UI internals.
- Minimal plan: three command-level I/O cases cover CLI version detection, Remote Control setting detection, and session report rendering.
- E2E mechanism: Python unittest plus direct script execution; no Flutter integration_test or Playwright route exists because no app route or user-facing product flow changed.
- E2E-Exception: tooling-only session-start check; no app route or user-facing product flow changed.

Closes #1657
Related #1268