### PR TITLE
feat: add offline secure mode settings

### DIFF
--- a/lib/pages/edge_llm_playground_page.dart
+++ b/lib/pages/edge_llm_playground_page.dart
@@ -7,6 +7,7 @@ import 'package:uuid/uuid.dart';
 import '../models/ai_provider_registry.dart';
 import '../services/edge_llm_playground_service.dart';
 import '../widgets/ai_response_observability_panel.dart';
+import 'offline_secure_mode_settings_page.dart';
 
 class EdgeLlmPlaygroundPage extends StatefulWidget {
   final EdgeLlmPlaygroundService? service;
@@ -154,6 +155,18 @@ class _EdgeLlmPlaygroundPageState extends State<EdgeLlmPlaygroundPage> {
       backgroundColor: background,
       appBar: AppBar(
         title: const Text('Edge LLM Playground'),
+        actions: [
+          IconButton(
+            tooltip: 'オフライン設定',
+            icon: const Icon(Icons.security_outlined),
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const OfflineSecureModeSettingsPage(),
+              ),
+            ),
+          ),
+        ],
       ),
       body: SafeArea(
         child: SingleChildScrollView(

--- a/lib/pages/offline_secure_mode_settings_page.dart
+++ b/lib/pages/offline_secure_mode_settings_page.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+
+import '../services/offline_secure_mode_settings_service.dart';
+
+class OfflineSecureModeSettingsPage extends StatefulWidget {
+  final OfflineSecureModeSettingsService settingsService;
+
+  const OfflineSecureModeSettingsPage({
+    super.key,
+    this.settingsService = const OfflineSecureModeSettingsService(),
+  });
+
+  @override
+  State<OfflineSecureModeSettingsPage> createState() =>
+      _OfflineSecureModeSettingsPageState();
+}
+
+class _OfflineSecureModeSettingsPageState
+    extends State<OfflineSecureModeSettingsPage> {
+  final TextEditingController _modelPathController = TextEditingController();
+  final TextEditingController _vectorDbPathController = TextEditingController();
+
+  OfflineSecureModeSettings _settings = const OfflineSecureModeSettings();
+  bool _loading = true;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  @override
+  void dispose() {
+    _modelPathController.dispose();
+    _vectorDbPathController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadSettings() async {
+    setState(() {
+      _loading = true;
+    });
+    final settings = await widget.settingsService.loadSettings();
+    if (!mounted) return;
+    _modelPathController.text = settings.localModelPath;
+    _vectorDbPathController.text = settings.localVectorDbPath;
+    setState(() {
+      _settings = settings;
+      _loading = false;
+    });
+  }
+
+  Future<void> _saveSettings() async {
+    if (_saving) return;
+    setState(() {
+      _saving = true;
+    });
+    final next = _settings.copyWith(
+      localModelPath: _modelPathController.text,
+      localVectorDbPath: _vectorDbPathController.text,
+    );
+    final saved = await widget.settingsService.saveSettings(next);
+    if (!mounted) return;
+    setState(() {
+      _settings = saved;
+      _saving = false;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('オフラインセキュアモード設定を保存しました')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final outline = theme.colorScheme.outlineVariant;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('オフラインセキュアモード'),
+        actions: [
+          IconButton(
+            tooltip: '再読み込み',
+            onPressed: _loading || _saving ? null : _loadSettings,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                _StatusPanel(settings: _settings),
+                const SizedBox(height: 16),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: outline),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    children: [
+                      SwitchListTile(
+                        secondary: const Icon(Icons.security_outlined),
+                        title: const Text('オフラインセキュアモード'),
+                        subtitle: Text(
+                          _settings.enabled
+                              ? '外部API遮断ポリシーを適用します'
+                              : 'オンラインLLM呼び出しを許可します',
+                        ),
+                        value: _settings.enabled,
+                        onChanged: (value) {
+                          setState(() {
+                            _settings = _settings.copyWith(enabled: value);
+                          });
+                        },
+                      ),
+                      const Divider(height: 1),
+                      SwitchListTile(
+                        secondary: const Icon(Icons.public_off_outlined),
+                        title: const Text('外部API遮断'),
+                        subtitle: const Text('ON時はオンラインプロバイダーを遮断対象にします'),
+                        value: _settings.blockExternalApiWhenEnabled,
+                        onChanged: (value) {
+                          setState(() {
+                            _settings = _settings.copyWith(
+                              blockExternalApiWhenEnabled: value,
+                            );
+                          });
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<String>(
+                  initialValue: _settings.inferenceEngine,
+                  decoration: const InputDecoration(
+                    labelText: '推論エンジン',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: OfflineSecureModeSettings.supportedInferenceEngines
+                      .map(
+                        (engine) => DropdownMenuItem<String>(
+                          value: engine,
+                          child: Text(engine),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (value) {
+                    if (value == null) return;
+                    setState(() {
+                      _settings = _settings.copyWith(inferenceEngine: value);
+                    });
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: _modelPathController,
+                  decoration: const InputDecoration(
+                    labelText: 'ローカルモデルパス',
+                    hintText: r'C:\models\pleias-rag.gguf',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: _vectorDbPathController,
+                  decoration: const InputDecoration(
+                    labelText: 'ローカルベクトルDBパス',
+                    hintText: r'C:\rag\lancedb',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                FilledButton.icon(
+                  onPressed: _saving ? null : _saveSettings,
+                  icon: _saving
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.save_outlined),
+                  label: const Text('保存'),
+                ),
+              ],
+            ),
+    );
+  }
+}
+
+class _StatusPanel extends StatelessWidget {
+  final OfflineSecureModeSettings settings;
+
+  const _StatusPanel({required this.settings});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = settings.externalApiBlocked
+        ? theme.colorScheme.error
+        : theme.colorScheme.primary;
+    final icon = settings.externalApiBlocked
+        ? Icons.gpp_good_outlined
+        : Icons.cloud_outlined;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        border: Border.all(color: color.withValues(alpha: 0.35)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: color),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _policyTitle,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(_runtimeText),
+                  const SizedBox(height: 6),
+                  Text('推論エンジン: ${settings.inferenceEngine}'),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String get _policyTitle {
+    if (settings.externalApiBlocked) {
+      return '外部API遮断中';
+    }
+    if (settings.enabled) {
+      return 'オフラインON / 外部API許可';
+    }
+    return 'オンラインLLM許可';
+  }
+
+  String get _runtimeText {
+    if (settings.localRuntimeConfigured) {
+      return 'ローカルランタイム設定済み';
+    }
+    if (settings.enabled && settings.externalApiBlocked) {
+      return 'ローカルモデルまたはベクトルDBが未設定です';
+    }
+    return 'ローカルランタイム未設定';
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -7,6 +7,7 @@ import 'asset_management_page.dart';
 import 'financial_report_page.dart';
 import 'admin_analytics_page.dart';
 import 'feedback_page.dart';
+import 'offline_secure_mode_settings_page.dart';
 import 'theme_selector_page.dart';
 
 class SettingsPage extends StatelessWidget {
@@ -65,6 +66,18 @@ class SettingsPage extends StatelessWidget {
             onTap: () => Navigator.push(
               context,
               MaterialPageRoute(builder: (_) => const FinancialReportPage()),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.security_outlined),
+            title: const Text('オフラインセキュアモード'),
+            subtitle: const Text('ローカルRAGと外部API遮断ポリシー'),
+            trailing: const Icon(Icons.arrow_forward_ios),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const OfflineSecureModeSettingsPage(),
+              ),
             ),
           ),
           const Divider(),

--- a/lib/services/offline_secure_mode_settings_service.dart
+++ b/lib/services/offline_secure_mode_settings_service.dart
@@ -1,0 +1,139 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class OfflineSecureModeSettings {
+  static const bool defaultEnabled = false;
+  static const bool defaultBlockExternalApiWhenEnabled = true;
+  static const String defaultInferenceEngine = 'pleias-rag';
+  static const List<String> supportedInferenceEngines = <String>[
+    'pleias-rag',
+    'llama.cpp',
+    'ollama',
+    'localai',
+    'custom',
+  ];
+
+  final bool enabled;
+  final String localModelPath;
+  final String localVectorDbPath;
+  final String inferenceEngine;
+  final bool blockExternalApiWhenEnabled;
+
+  const OfflineSecureModeSettings({
+    this.enabled = defaultEnabled,
+    this.localModelPath = '',
+    this.localVectorDbPath = '',
+    this.inferenceEngine = defaultInferenceEngine,
+    this.blockExternalApiWhenEnabled = defaultBlockExternalApiWhenEnabled,
+  });
+
+  bool get localRuntimeConfigured =>
+      localModelPath.trim().isNotEmpty && localVectorDbPath.trim().isNotEmpty;
+
+  bool get externalApiBlocked => enabled && blockExternalApiWhenEnabled;
+
+  bool get onlineFallbackAllowed => !externalApiBlocked;
+
+  OfflineSecureModeSettings copyWith({
+    bool? enabled,
+    String? localModelPath,
+    String? localVectorDbPath,
+    String? inferenceEngine,
+    bool? blockExternalApiWhenEnabled,
+  }) {
+    return OfflineSecureModeSettings(
+      enabled: enabled ?? this.enabled,
+      localModelPath: localModelPath ?? this.localModelPath,
+      localVectorDbPath: localVectorDbPath ?? this.localVectorDbPath,
+      inferenceEngine: inferenceEngine ?? this.inferenceEngine,
+      blockExternalApiWhenEnabled:
+          blockExternalApiWhenEnabled ?? this.blockExternalApiWhenEnabled,
+    );
+  }
+
+  Map<String, dynamic> toAiHubPolicyPayload() {
+    return <String, dynamic>{
+      'offline_secure_mode': enabled,
+      'offline_external_api_blocked': externalApiBlocked,
+      'offline_runtime_configured': localRuntimeConfigured,
+      'offline_inference_engine': inferenceEngine,
+      if (localModelPath.trim().isNotEmpty)
+        'offline_local_model_path': localModelPath.trim(),
+      if (localVectorDbPath.trim().isNotEmpty)
+        'offline_local_vector_db_path': localVectorDbPath.trim(),
+    };
+  }
+}
+
+class OfflineSecureModeSettingsService {
+  static const String _enabledKey = 'offline_secure_mode_enabled_v1';
+  static const String _localModelPathKey =
+      'offline_secure_mode_local_model_path_v1';
+  static const String _localVectorDbPathKey =
+      'offline_secure_mode_local_vector_db_path_v1';
+  static const String _inferenceEngineKey =
+      'offline_secure_mode_inference_engine_v1';
+  static const String _blockExternalApiWhenEnabledKey =
+      'offline_secure_mode_block_external_api_when_enabled_v1';
+
+  const OfflineSecureModeSettingsService();
+
+  Future<OfflineSecureModeSettings> loadSettings({
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return OfflineSecureModeSettings(
+      enabled: store.getBool(_enabledKey) ??
+          OfflineSecureModeSettings.defaultEnabled,
+      localModelPath: _normalizedString(store.getString(_localModelPathKey)),
+      localVectorDbPath:
+          _normalizedString(store.getString(_localVectorDbPathKey)),
+      inferenceEngine: _normalizedEngine(store.getString(_inferenceEngineKey)),
+      blockExternalApiWhenEnabled:
+          store.getBool(_blockExternalApiWhenEnabledKey) ??
+              OfflineSecureModeSettings.defaultBlockExternalApiWhenEnabled,
+    );
+  }
+
+  Future<OfflineSecureModeSettings> saveSettings(
+    OfflineSecureModeSettings settings, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final normalized = settings.copyWith(
+      localModelPath: settings.localModelPath.trim(),
+      localVectorDbPath: settings.localVectorDbPath.trim(),
+      inferenceEngine: _normalizedEngine(settings.inferenceEngine),
+    );
+    await store.setBool(_enabledKey, normalized.enabled);
+    await store.setString(_localModelPathKey, normalized.localModelPath);
+    await store.setString(_localVectorDbPathKey, normalized.localVectorDbPath);
+    await store.setString(_inferenceEngineKey, normalized.inferenceEngine);
+    await store.setBool(
+      _blockExternalApiWhenEnabledKey,
+      normalized.blockExternalApiWhenEnabled,
+    );
+    return normalized;
+  }
+
+  Future<OfflineSecureModeSettings> saveEnabled(
+    bool enabled, {
+    SharedPreferences? prefs,
+  }) async {
+    final current = await loadSettings(prefs: prefs);
+    return saveSettings(current.copyWith(enabled: enabled), prefs: prefs);
+  }
+
+  String _normalizedString(String? raw) => raw?.trim() ?? '';
+
+  String _normalizedEngine(String? raw) {
+    final normalized = raw?.trim().toLowerCase();
+    if (normalized == null || normalized.isEmpty) {
+      return OfflineSecureModeSettings.defaultInferenceEngine;
+    }
+    if (OfflineSecureModeSettings.supportedInferenceEngines
+        .contains(normalized)) {
+      return normalized;
+    }
+    return OfflineSecureModeSettings.defaultInferenceEngine;
+  }
+}

--- a/test/services/offline_secure_mode_settings_service_test.dart
+++ b/test/services/offline_secure_mode_settings_service_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/offline_secure_mode_settings_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('loads safe defaults with online fallback allowed', () async {
+    const service = OfflineSecureModeSettingsService();
+
+    final settings = await service.loadSettings();
+
+    expect(settings.enabled, isFalse);
+    expect(settings.inferenceEngine, 'pleias-rag');
+    expect(settings.localRuntimeConfigured, isFalse);
+    expect(settings.externalApiBlocked, isFalse);
+    expect(settings.onlineFallbackAllowed, isTrue);
+    expect(
+      settings.toAiHubPolicyPayload(),
+      containsPair('offline_secure_mode', false),
+    );
+  });
+
+  test('persists offline runtime paths and external API policy', () async {
+    const service = OfflineSecureModeSettingsService();
+
+    final saved = await service.saveSettings(
+      const OfflineSecureModeSettings(
+        enabled: true,
+        localModelPath: r' C:\models\pleias-rag.gguf ',
+        localVectorDbPath: r' C:\rag\lancedb ',
+        inferenceEngine: 'ollama',
+        blockExternalApiWhenEnabled: true,
+      ),
+    );
+    final loaded = await service.loadSettings();
+
+    expect(saved.localModelPath, r'C:\models\pleias-rag.gguf');
+    expect(loaded.localVectorDbPath, r'C:\rag\lancedb');
+    expect(loaded.inferenceEngine, 'ollama');
+    expect(loaded.localRuntimeConfigured, isTrue);
+    expect(loaded.externalApiBlocked, isTrue);
+    expect(
+      loaded.toAiHubPolicyPayload(),
+      containsPair('offline_external_api_blocked', true),
+    );
+  });
+
+  test('normalizes unsupported inference engine to Pleias RAG', () async {
+    const service = OfflineSecureModeSettingsService();
+
+    await service.saveSettings(
+      const OfflineSecureModeSettings(inferenceEngine: 'remote-only'),
+    );
+
+    final loaded = await service.loadSettings();
+    expect(loaded.inferenceEngine, 'pleias-rag');
+  });
+}


### PR DESCRIPTION
## Summary
- add a SharedPreferences-backed offline secure mode settings model/service
- add a settings page for offline mode, local model path, local vector DB path, inference engine, and external API blocking policy
- link the settings page from app Settings and Edge LLM Playground
- add service tests for defaults, persistence, path normalization, and unsupported engine fallback

## Validation
- dart format lib\services\offline_secure_mode_settings_service.dart lib\pages\offline_secure_mode_settings_page.dart lib\pages\settings_page.dart lib\pages\edge_llm_playground_page.dart test\services\offline_secure_mode_settings_service_test.dart
- flutter test test\services\offline_secure_mode_settings_service_test.dart
- flutter analyze --no-pub lib\services\offline_secure_mode_settings_service.dart lib\pages\offline_secure_mode_settings_page.dart lib\pages\settings_page.dart lib\pages\edge_llm_playground_page.dart test\services\offline_secure_mode_settings_service_test.dart

## Minimal E2E Gate
- Implementation-detail independent: validates the user-visible requirement that offline secure mode settings can be saved and reloaded independently of the UI implementation.
- Minimal three command-level I/O cases:
  1. Empty settings store loads offline secure mode OFF with online fallback allowed.
  2. Saved local model/vector DB paths and external API blocking policy reload exactly after normalization.
  3. Unsupported inference engine input falls back to the Pleias RAG default.
- E2E mechanism: Flutter service-level test using `SharedPreferences.setMockInitialValues` to exercise the same persistence boundary used by the settings UI.
- E2E-Exception: #1654 is a settings/persistence slice; actual ai-hub external API blocking is tracked separately in #1655.

Closes #1654.
Related #1265, #1655, #1656.