### PR TITLE
[codex] guard ai hub offline secure mode

### DIFF
--- a/supabase/functions/_shared/offline_secure_mode.ts
+++ b/supabase/functions/_shared/offline_secure_mode.ts
@@ -1,0 +1,123 @@
+export type EnvReader = (key: string) => string | undefined;
+
+export type OfflineSecureModeConfig = {
+  enabled: boolean;
+  source: string | null;
+  localRuntimeConfigured: boolean;
+  localRuntimeEndpointConfigured: boolean;
+  localModelPathConfigured: boolean;
+  localVectorDbPathConfigured: boolean;
+};
+
+export type OfflineBlockedPayload = {
+  success: false;
+  status: "offlineSecureModeBlocked";
+  error: "offline_secure_mode_enabled";
+  offline_blocked: true;
+  action: string;
+  provider: string | null;
+  model: string | null;
+  local_runtime_configured: boolean;
+  local_runtime_endpoint_configured: boolean;
+  local_model_path_configured: boolean;
+  local_vector_db_path_configured: boolean;
+  required_next_step: "configure_local_runtime";
+  message: string;
+};
+
+const OFFLINE_MODE_ENV_KEYS = [
+  "AI_OFFLINE_SECURE_MODE",
+  "OFFLINE_SECURE_MODE",
+  "MY_WEB_APP_OFFLINE_SECURE_MODE",
+];
+
+const LOCAL_RUNTIME_ENDPOINT_KEYS = [
+  "LOCAL_LLM_ENDPOINT",
+  "LOCAL_RAG_ENDPOINT",
+  "AI_LOCAL_RUNTIME_ENDPOINT",
+];
+
+const LOCAL_MODEL_PATH_KEYS = [
+  "LOCAL_LLM_MODEL_PATH",
+  "LOCAL_MODEL_PATH",
+  "PLEIAS_MODEL_PATH",
+];
+
+const LOCAL_VECTOR_DB_PATH_KEYS = [
+  "LOCAL_VECTOR_DB_PATH",
+  "LOCAL_LANCEDB_PATH",
+  "LANCEDB_PATH",
+];
+
+function defaultEnvReader(key: string): string | undefined {
+  return Deno.env.get(key) ?? undefined;
+}
+
+export function envFlagEnabled(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  return ["1", "true", "yes", "on", "enabled"].includes(
+    value.trim().toLowerCase(),
+  );
+}
+
+function hasAnyEnv(keys: string[], readEnv: EnvReader): boolean {
+  return keys.some((key) => {
+    const value = readEnv(key);
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
+export function readOfflineSecureModeConfig(
+  readEnv: EnvReader = defaultEnvReader,
+): OfflineSecureModeConfig {
+  const source =
+    OFFLINE_MODE_ENV_KEYS.find((key) => envFlagEnabled(readEnv(key))) ?? null;
+  const localRuntimeEndpointConfigured = hasAnyEnv(
+    LOCAL_RUNTIME_ENDPOINT_KEYS,
+    readEnv,
+  );
+  const localModelPathConfigured = hasAnyEnv(LOCAL_MODEL_PATH_KEYS, readEnv);
+  const localVectorDbPathConfigured = hasAnyEnv(
+    LOCAL_VECTOR_DB_PATH_KEYS,
+    readEnv,
+  );
+
+  return {
+    enabled: source !== null,
+    source,
+    localRuntimeConfigured: localRuntimeEndpointConfigured ||
+      (localModelPathConfigured && localVectorDbPathConfigured),
+    localRuntimeEndpointConfigured,
+    localModelPathConfigured,
+    localVectorDbPathConfigured,
+  };
+}
+
+export function buildOfflineBlockedPayload(
+  action: string,
+  options: {
+    provider?: string | null;
+    model?: string | null;
+    readEnv?: EnvReader;
+  } = {},
+): OfflineBlockedPayload | null {
+  const config = readOfflineSecureModeConfig(options.readEnv);
+  if (!config.enabled) return null;
+
+  return {
+    success: false,
+    status: "offlineSecureModeBlocked",
+    error: "offline_secure_mode_enabled",
+    offline_blocked: true,
+    action,
+    provider: options.provider ?? null,
+    model: options.model ?? null,
+    local_runtime_configured: config.localRuntimeConfigured,
+    local_runtime_endpoint_configured: config.localRuntimeEndpointConfigured,
+    local_model_path_configured: config.localModelPathConfigured,
+    local_vector_db_path_configured: config.localVectorDbPathConfigured,
+    required_next_step: "configure_local_runtime",
+    message:
+      "Offline secure mode is enabled. External AI providers are blocked; configure the local runtime before invoking AI.",
+  };
+}

--- a/supabase/functions/_shared/offline_secure_mode_test.ts
+++ b/supabase/functions/_shared/offline_secure_mode_test.ts
@@ -1,0 +1,71 @@
+import {
+  buildOfflineBlockedPayload,
+  envFlagEnabled,
+  readOfflineSecureModeConfig,
+} from "./offline_secure_mode.ts";
+
+Deno.test("envFlagEnabled recognizes explicit truthy values", () => {
+  for (const value of ["1", "true", "TRUE", "yes", "on", "enabled"]) {
+    if (!envFlagEnabled(value)) {
+      throw new Error(`expected ${value} to be truthy`);
+    }
+  }
+  for (const value of [undefined, "", "0", "false", "off"]) {
+    if (envFlagEnabled(value)) {
+      throw new Error(`expected ${value} to be falsey`);
+    }
+  }
+});
+
+Deno.test("offline secure mode stays disabled without an explicit flag", () => {
+  const config = readOfflineSecureModeConfig(() => undefined);
+
+  if (config.enabled) throw new Error("offline mode should be disabled");
+  if (
+    buildOfflineBlockedPayload("edge_llm.invoke", {
+      readEnv: () => undefined,
+    })
+  ) {
+    throw new Error("disabled offline mode must not block requests");
+  }
+});
+
+Deno.test("offline secure mode blocks external providers without local runtime", () => {
+  const readEnv = (key: string) =>
+    key === "AI_OFFLINE_SECURE_MODE" ? "true" : undefined;
+
+  const payload = buildOfflineBlockedPayload("edge_llm.invoke", {
+    provider: "openai",
+    model: "gpt-4o-mini",
+    readEnv,
+  });
+
+  if (!payload?.offline_blocked) throw new Error("payload should block");
+  if (payload.provider !== "openai") throw new Error("provider not preserved");
+  if (payload.local_runtime_configured) {
+    throw new Error("local runtime should be reported missing");
+  }
+});
+
+Deno.test("offline secure mode reports configured local runtime hints", () => {
+  const readEnv = (key: string) => {
+    const values: Record<string, string> = {
+      OFFLINE_SECURE_MODE: "1",
+      LOCAL_LLM_ENDPOINT: "http://127.0.0.1:11434",
+    };
+    return values[key];
+  };
+
+  const payload = buildOfflineBlockedPayload("provider.chat", {
+    provider: "anthropic",
+    readEnv,
+  });
+
+  if (!payload?.offline_blocked) throw new Error("payload should block");
+  if (!payload.local_runtime_configured) {
+    throw new Error("local runtime hint should be configured");
+  }
+  if (!payload.local_runtime_endpoint_configured) {
+    throw new Error("local endpoint hint should be configured");
+  }
+});

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -23,6 +23,7 @@ import {
   checkBudget,
   recordSpend,
 } from "../_shared/task_budget.ts";
+import { buildOfflineBlockedPayload } from "../_shared/offline_secure_mode.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -51,6 +52,15 @@ function json(data: unknown, status = 200): Response {
     status,
     headers: { ...corsHeaders, "Content-Type": "application/json" },
   });
+}
+
+function offlineSecureModeResponse(
+  action: string,
+  provider?: string | null,
+  model?: string | null,
+): Response | null {
+  const payload = buildOfflineBlockedPayload(action, { provider, model });
+  return payload ? json(payload, 503) : null;
 }
 
 // AI大学プロバイダー統一呼び出し設定 (Phase 2)
@@ -519,11 +529,24 @@ async function callSingleProvider(
     text?: string;
     modelUsed?: string;
     error?: string;
+    offlineBlocked?: boolean;
     isRetriable: boolean;
   }
 > {
   const cfg = PROVIDER_CONFIGS[providerId];
   if (!cfg) return { ok: false, error: "unknown provider", isRetriable: false };
+  const offlinePayload = buildOfflineBlockedPayload("provider.call", {
+    provider: providerId,
+    model: model ?? cfg.defaultModel,
+  });
+  if (offlinePayload) {
+    return {
+      ok: false,
+      error: "offlineSecureModeBlocked",
+      offlineBlocked: true,
+      isRetriable: false,
+    };
+  }
   const apiKey = Deno.env.get(cfg.envKey) ?? "";
   if (!apiKey) {
     return { ok: false, error: "apiKeyRequired", isRetriable: false };
@@ -2438,6 +2461,13 @@ async function embedTextsWithGemini(
   apiKey: string,
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
+  const offlinePayload = buildOfflineBlockedPayload("gemini.embedding", {
+    provider: "google",
+    model: "gemini-embedding-001",
+  });
+  if (offlinePayload) {
+    throw new Error("offlineSecureModeBlocked");
+  }
   const response = await fetch(
     "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents",
     {
@@ -2616,6 +2646,13 @@ async function callGemini(
   apiKey: string,
   image?: InlineImage,
 ): Promise<string> {
+  const offlinePayload = buildOfflineBlockedPayload("gemini.generateContent", {
+    provider: "google",
+    model: "gemini-2.5-flash",
+  });
+  if (offlinePayload) {
+    throw new Error("offlineSecureModeBlocked");
+  }
   const parts: Record<string, unknown>[] = [{ text: prompt }];
   if (image) {
     parts.push({
@@ -2654,6 +2691,12 @@ async function callManusTask(
   apiKey: string,
   image?: InlineImage,
 ): Promise<ManusTaskResult> {
+  const offlinePayload = buildOfflineBlockedPayload("manus.task.create", {
+    provider: "manus",
+  });
+  if (offlinePayload) {
+    throw new Error("offlineSecureModeBlocked");
+  }
   const baseUrl = (Deno.env.get("MANUS_API_BASE_URL") ??
     "https://api.manus.ai/v2").replace(/\/+$/, "");
   const manusPrompt = image
@@ -2796,6 +2839,12 @@ serve(async (req: Request) => {
       }
 
       case "judgment.get.legacy": {
+        const offlineResponse = offlineSecureModeResponse(
+          "judgment.get.legacy",
+          "google",
+          "gemini-2.5-flash",
+        );
+        if (offlineResponse) return offlineResponse;
         const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
         if (!geminiKey) {
           return json({ error: "GEMINI_API_KEY not configured" }, 503);
@@ -2831,6 +2880,10 @@ serve(async (req: Request) => {
         }
 
         const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
+        const offlineEmbeddingBlocked = buildOfflineBlockedPayload(
+          "search.query.embedding",
+          { provider: "google", model: "gemini-embedding-001" },
+        );
 
         try {
           await syncNoteSearchIndex(admin, userId);
@@ -2841,7 +2894,7 @@ serve(async (req: Request) => {
         let queryEmbedding: number[] | null = null;
         let searchMode = "text_fallback";
 
-        if (geminiKey) {
+        if (geminiKey && !offlineEmbeddingBlocked) {
           try {
             await embedPendingNoteSearchRows(admin, userId, geminiKey);
             const embeddings = await embedTextsWithGemini(
@@ -2900,10 +2953,18 @@ serve(async (req: Request) => {
           totalResults: results.length,
           searchMode,
           explanation,
+          offline_blocked: Boolean(offlineEmbeddingBlocked),
+          offline_blocked_action: offlineEmbeddingBlocked?.action ?? null,
         });
       }
 
       case "tags.suggest": {
+        const offlineResponse = offlineSecureModeResponse(
+          "tags.suggest",
+          "google",
+          "gemini-2.5-flash",
+        );
+        if (offlineResponse) return offlineResponse;
         const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
         if (!geminiKey) {
           return json({ error: "GEMINI_API_KEY not configured" }, 503);
@@ -2920,6 +2981,12 @@ serve(async (req: Request) => {
       }
 
       case "secretary.task": {
+        const offlineResponse = offlineSecureModeResponse(
+          "secretary.task",
+          "google",
+          "gemini-2.5-flash",
+        );
+        if (offlineResponse) return offlineResponse;
         const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
         if (!geminiKey) {
           return json({ error: "GEMINI_API_KEY not configured" }, 503);
@@ -2944,6 +3011,12 @@ serve(async (req: Request) => {
       }
 
       case "summarize.text": {
+        const offlineResponse = offlineSecureModeResponse(
+          "summarize.text",
+          null,
+          null,
+        );
+        if (offlineResponse) return offlineResponse;
         const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
         const openaiKey = Deno.env.get("OPENAI_API_KEY") ?? "";
         const text = String(body.text ?? "");
@@ -3062,6 +3135,12 @@ serve(async (req: Request) => {
         const responseMode = asString(body.response_mode) || "text";
         const requestedProvider = asString(body.provider) ||
           asString(body.ai_provider) || "gemini";
+        const offlineResponse = offlineSecureModeResponse(
+          "my_agent.chat",
+          requestedProvider,
+          null,
+        );
+        if (offlineResponse) return offlineResponse;
         const agentProvider = requestedProvider === "manus"
           ? "manus"
           : "gemini";
@@ -3187,6 +3266,12 @@ serve(async (req: Request) => {
         if (existing.length > 0) {
           return json({ success: true, challenges: existing });
         }
+        const offlineResponse = offlineSecureModeResponse(
+          "challenges.list",
+          "google",
+          "gemini-2.5-flash",
+        );
+        if (offlineResponse) return offlineResponse;
         const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
         if (!geminiKey) return json({ success: true, challenges: [] });
         const prompt =
@@ -3207,6 +3292,12 @@ serve(async (req: Request) => {
       }
 
       case "trigger.analyze": {
+        const offlineResponse = offlineSecureModeResponse(
+          "trigger.analyze",
+          "google",
+          "gemini-2.5-flash",
+        );
+        if (offlineResponse) return offlineResponse;
         const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
         if (!geminiKey) {
           return json({ error: "GEMINI_API_KEY not configured" }, 503);
@@ -3226,6 +3317,12 @@ serve(async (req: Request) => {
       }
 
       case "analyze.reality": {
+        const offlineResponse = offlineSecureModeResponse(
+          "analyze.reality",
+          "google",
+          "gemini-2.5-flash",
+        );
+        if (offlineResponse) return offlineResponse;
         const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
         if (!geminiKey) {
           return json({ error: "GEMINI_API_KEY not configured" }, 503);
@@ -3731,6 +3828,12 @@ serve(async (req: Request) => {
       // ── AI大学 v2: Memory Agent ──────────────────────────────────────────
       case "learner.update_profile": {
         if (!userId) return json({ error: "Unauthorized" }, 401);
+        const offlineResponse = offlineSecureModeResponse(
+          "learner.update_profile",
+          "anthropic",
+          "claude-opus-4-7",
+        );
+        if (offlineResponse) return offlineResponse;
         const sessionSummary = String(body.session_summary ?? "");
         const scores = body.scores ?? [];
         const claudeKey = Deno.env.get("ANTHROPIC_API_KEY") ?? "";
@@ -3791,6 +3894,12 @@ serve(async (req: Request) => {
       // ── AI大学 v2: Hybrid LLM ────────────────────────────────────────────
       case "quiz.evaluate": {
         if (!userId) return json({ error: "Unauthorized" }, 401);
+        const offlineResponse = offlineSecureModeResponse(
+          "quiz.evaluate",
+          "groq",
+          "llama-3.3-70b-versatile",
+        );
+        if (offlineResponse) return offlineResponse;
         const question = String(body.question ?? "");
         const userAnswer = String(body.user_answer ?? "");
         const correctAnswer = String(body.correct_answer ?? "");
@@ -3845,6 +3954,12 @@ serve(async (req: Request) => {
 
       case "quiz.explain": {
         if (!userId) return json({ error: "Unauthorized" }, 401);
+        const offlineResponse = offlineSecureModeResponse(
+          "quiz.explain",
+          "anthropic",
+          "claude-opus-4-7",
+        );
+        if (offlineResponse) return offlineResponse;
         const question = String(body.question ?? "");
         const userAnswer = String(body.user_answer ?? "");
         const correctAnswer = String(body.correct_answer ?? "");
@@ -3906,6 +4021,13 @@ serve(async (req: Request) => {
             message: `Provider "${providerId}" はまだ実装されていません。`,
           }, 400);
         }
+        const requestedModel = String(body.model ?? cfg.defaultModel);
+        const offlineResponse = offlineSecureModeResponse(
+          "provider.chat",
+          providerId,
+          requestedModel,
+        );
+        if (offlineResponse) return offlineResponse;
         const apiKey = Deno.env.get(cfg.envKey) ?? "";
         if (!apiKey) {
           return json({
@@ -3941,7 +4063,7 @@ serve(async (req: Request) => {
             body: JSON.stringify(
               cfg.buildBody(
                 finalMessages,
-                String(body.model ?? cfg.defaultModel),
+                requestedModel,
               ),
             ),
           });
@@ -4013,6 +4135,12 @@ serve(async (req: Request) => {
             exceeded_scope_id: budget.exceeded_scope_id,
           }, 429);
         }
+        const offlineResponse = offlineSecureModeResponse(
+          "provider.chat_auto",
+          null,
+          asString(body.model) || null,
+        );
+        if (offlineResponse) return offlineResponse;
 
         const requestedTier = body.tier as Tier | undefined;
         const messages = Array.isArray(body.messages) ? body.messages : null;
@@ -4144,6 +4272,13 @@ serve(async (req: Request) => {
 
         const requestedTier = body.tier as Tier | undefined;
         const providerId = asString(body.provider) || undefined;
+        const explicitModel = asString(body.model) || undefined;
+        const offlineResponse = offlineSecureModeResponse(
+          "edge_llm.invoke",
+          providerId ?? null,
+          explicitModel ?? null,
+        );
+        if (offlineResponse) return offlineResponse;
         const systemPrompt = asString(body.system_prompt);
         const userPrompt = asString(body.user_prompt) ||
           asString(body.prompt) ||
@@ -4196,7 +4331,6 @@ serve(async (req: Request) => {
         const sessionId = body.session_id != null
           ? String(body.session_id)
           : null;
-        const explicitModel = asString(body.model) || undefined;
 
         let resultText: string | undefined;
         let usedProvider: string | undefined;
@@ -4623,6 +4757,12 @@ serve(async (req: Request) => {
 
       // ---- Election analysis (Gemini direct, JSON mode) ----
       case "election.analyze": {
+        const offlineResponse = offlineSecureModeResponse(
+          "election.analyze",
+          "google",
+          "gemini-2.5-flash",
+        );
+        if (offlineResponse) return offlineResponse;
         const geminiApiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
         if (!geminiApiKey) {
           return json({ success: false, error: "GEMINI_API_KEY not set" }, 500);


### PR DESCRIPTION
﻿## Summary
- Add a shared offline secure mode helper for Supabase Edge Functions.
- Block ai-hub external AI provider paths when `AI_OFFLINE_SECURE_MODE`, `OFFLINE_SECURE_MODE`, or `MY_WEB_APP_OFFLINE_SECURE_MODE` is enabled.
- Return safe responses with `offline_blocked=true`, provider/model metadata, and local runtime configuration hints instead of calling OpenAI, Anthropic, Google, Groq, OpenRouter, DeepInfra-compatible provider paths, or Manus.
- Keep `search.query` on text fallback when Gemini embeddings are blocked.

Fixes #1655.

## Minimal E2E Gate
- Implementation-detail independent: validation checks externally visible response contracts (`offline_blocked`, status, provider/model, local runtime hints), not internal env variable parsing implementation.
- Minimal plan: about three I/O cases are covered: offline disabled does not block, offline enabled without local runtime blocks with `local_runtime_configured=false`, and offline enabled with a local endpoint still blocks external providers while reporting the configured local runtime hint.
- E2E mechanism: this is an Edge Function guard slice covered by Deno helper checks and `deno check`/`deno lint`; no browser route is introduced.
- E2E-Exception: Playwright or Flutter `integration_test` is not added because the behavior is server-side provider egress gating, not a user-facing browser flow. A follow-up can add deployed tools-hub/ai-hub smoke once the offline env flag is available in a staging function.

## Validation
- `deno check supabase\\functions\\ai-hub\\index.ts`
- `deno lint supabase\\functions\\_shared\\offline_secure_mode.ts supabase\\functions\\_shared\\offline_secure_mode_test.ts supabase\\functions\\ai-hub\\index.ts`
- `deno eval --ext=ts ...` manual assertions for offline helper behavior

## Local Runner Note
- `deno test --allow-env supabase\\functions\\_shared\\offline_secure_mode_test.ts` panicked in local Windows Deno 2.7.12 with a named pipe `invalid handle` error before test execution. The helper was checked with `deno check` and equivalent `deno eval` assertions in this session.
