### PR TITLE
feat: add offline local RAG runtime harness

### DIFF
--- a/docs/offline_local_rag_runtime.md
+++ b/docs/offline_local_rag_runtime.md
@@ -1,0 +1,68 @@
+# Offline Local RAG Runtime
+
+This project cannot make a hosted Supabase Edge Function read files from a
+user's PC. Offline secure RAG therefore uses a local loopback runtime:
+
+- Flutter stores the local model path, vector DB path, and runtime URL.
+- Edge LLM Playground routes to `http://127.0.0.1:8765/rag` when offline secure
+  mode blocks external APIs and both local paths are configured.
+- The hosted `ai-hub` function continues to block external provider fetches and
+  returns `offline_blocked=true` / `localRuntimePending` when a browser or other
+  caller still reaches the cloud boundary.
+
+## Start The Runtime
+
+Create a local corpus directory and a local model marker or actual model file:
+
+```powershell
+New-Item -ItemType Directory -Force C:\rag\lancedb | Out-Null
+Set-Content C:\rag\lancedb\policy.md "Offline secure mode answers from local documents only."
+Set-Content C:\models\pleias-rag.gguf "replace with a real local model file"
+python scripts\local_rag_runtime.py --serve `
+  --model-path C:\models\pleias-rag.gguf `
+  --vector-db-path C:\rag\lancedb `
+  --memory-limit-mb 8192 `
+  --enforce-network-block
+```
+
+Then set the app's offline secure mode values:
+
+- Local model path: `C:\models\pleias-rag.gguf`
+- Local vector DB path: `C:\rag\lancedb`
+- Local RAG runtime URL: `http://127.0.0.1:8765/rag`
+- External API blocking: on
+
+## Validation
+
+One-shot validation without starting the HTTP server:
+
+```powershell
+python scripts\local_rag_runtime.py `
+  --query "How does offline secure mode answer?" `
+  --model-path C:\models\pleias-rag.gguf `
+  --vector-db-path C:\rag\lancedb `
+  --memory-limit-mb 8192 `
+  --enforce-network-block
+```
+
+Expected success contract:
+
+- `success=true`
+- `offline_only=true`
+- `network_blocked=true`
+- `memory_peak_mb <= 8192`
+- `citations` contains at least one local source
+
+Expected safe failure contract:
+
+- missing model path returns `success=false` and `status=missingModel`
+- missing vector DB path returns `success=false`
+- the app does not fall back to external providers while external API blocking
+  is enabled
+
+## Current Limit
+
+The bundled Python runtime is a deterministic offline extractive RAG harness.
+It validates the local-only transport, citation contract, and 8GB memory gate.
+Replacing the answer builder with a real Pleias/llama.cpp/Ollama command is the
+next production hardening step for real generative local inference.

--- a/lib/pages/offline_secure_mode_settings_page.dart
+++ b/lib/pages/offline_secure_mode_settings_page.dart
@@ -19,6 +19,7 @@ class _OfflineSecureModeSettingsPageState
     extends State<OfflineSecureModeSettingsPage> {
   final TextEditingController _modelPathController = TextEditingController();
   final TextEditingController _vectorDbPathController = TextEditingController();
+  final TextEditingController _runtimeUrlController = TextEditingController();
 
   OfflineSecureModeSettings _settings = const OfflineSecureModeSettings();
   bool _loading = true;
@@ -34,6 +35,7 @@ class _OfflineSecureModeSettingsPageState
   void dispose() {
     _modelPathController.dispose();
     _vectorDbPathController.dispose();
+    _runtimeUrlController.dispose();
     super.dispose();
   }
 
@@ -45,6 +47,7 @@ class _OfflineSecureModeSettingsPageState
     if (!mounted) return;
     _modelPathController.text = settings.localModelPath;
     _vectorDbPathController.text = settings.localVectorDbPath;
+    _runtimeUrlController.text = settings.localRuntimeUrl;
     setState(() {
       _settings = settings;
       _loading = false;
@@ -59,6 +62,7 @@ class _OfflineSecureModeSettingsPageState
     final next = _settings.copyWith(
       localModelPath: _modelPathController.text,
       localVectorDbPath: _vectorDbPathController.text,
+      localRuntimeUrl: _runtimeUrlController.text,
     );
     final saved = await widget.settingsService.saveSettings(next);
     if (!mounted) return;
@@ -173,6 +177,15 @@ class _OfflineSecureModeSettingsPageState
                     border: OutlineInputBorder(),
                   ),
                 ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: _runtimeUrlController,
+                  decoration: const InputDecoration(
+                    labelText: 'ローカルRAGランタイムURL',
+                    hintText: OfflineSecureModeSettings.defaultLocalRuntimeUrl,
+                    border: OutlineInputBorder(),
+                  ),
+                ),
                 const SizedBox(height: 20),
                 FilledButton.icon(
                   onPressed: _saving ? null : _saveSettings,
@@ -233,6 +246,8 @@ class _StatusPanel extends StatelessWidget {
                   Text(_runtimeText),
                   const SizedBox(height: 6),
                   Text('推論エンジン: ${settings.inferenceEngine}'),
+                  const SizedBox(height: 6),
+                  Text('ローカルRAG: ${settings.localRuntimeUrl}'),
                 ],
               ),
             ),

--- a/lib/services/edge_llm_playground_service.dart
+++ b/lib/services/edge_llm_playground_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../services/ai_hub_chat_service.dart';
+import 'local_rag_runtime_service.dart';
 import 'offline_secure_mode_settings_service.dart';
 
 typedef EdgeLlmPlaygroundInvoker = AiHubChatInvoker;
@@ -44,15 +45,19 @@ class EdgeLlmPlaygroundService {
   final SupabaseClient? _supabase;
   final EdgeLlmPlaygroundInvoker? _invoker;
   final OfflineSecureModeSettingsService _offlineSettingsService;
+  final LocalRagRuntimeService _localRagRuntimeService;
 
   const EdgeLlmPlaygroundService({
     SupabaseClient? supabase,
     EdgeLlmPlaygroundInvoker? invoker,
     OfflineSecureModeSettingsService offlineSettingsService =
         const OfflineSecureModeSettingsService(),
+    LocalRagRuntimeService localRagRuntimeService =
+        const LocalRagRuntimeService(),
   })  : _supabase = supabase,
         _invoker = invoker,
-        _offlineSettingsService = offlineSettingsService;
+        _offlineSettingsService = offlineSettingsService,
+        _localRagRuntimeService = localRagRuntimeService;
 
   Future<EdgeLlmPlaygroundResponse> invoke({
     required String userPrompt,
@@ -96,7 +101,41 @@ class EdgeLlmPlaygroundService {
       body['context_data'] = _parseContextDraft(normalizedContextDraft);
     }
 
-    final data = await _invoke(await _withOfflinePolicy(body));
+    final offlineSettings =
+        await _offlineSettingsService.loadSettingsOrDefaults();
+    if (offlineSettings.externalApiBlocked &&
+        offlineSettings.localRuntimeConfigured) {
+      final local = await _localRagRuntimeService.query(
+        query: normalizedPrompt,
+        settings: offlineSettings,
+        systemPrompt: systemPrompt,
+        contextData: body['context_data'],
+        sessionId: sessionId,
+        traceId: traceId,
+      );
+      return EdgeLlmPlaygroundResponse(
+        text: local.text,
+        source: 'local-rag runtime / ${local.engine}',
+        provider: 'local-rag',
+        tier: 'offline',
+        model: local.model,
+        responseFormat: normalizedFormat,
+        parsedJson: <String, dynamic>{
+          'citations': local.citations.map((item) => item.toJson()).toList(),
+          'offline_runtime': local.toJson(),
+        },
+        observability: AiHubChatObservability.fromResponseMap(
+          <String, dynamic>{
+            'provider': 'local-rag',
+            'model': local.model,
+            'action': 'edge_llm.invoke',
+          },
+          fallbackProvider: 'local-rag',
+        ),
+      );
+    }
+
+    final data = await _invoke(_withOfflinePolicy(body, offlineSettings));
     if (data['success'] != true) {
       final detail =
           (data['message'] ?? data['detail'] ?? 'LLM invocation failed')
@@ -162,10 +201,10 @@ class EdgeLlmPlaygroundService {
     };
   }
 
-  Future<Map<String, dynamic>> _withOfflinePolicy(
+  Map<String, dynamic> _withOfflinePolicy(
     Map<String, dynamic> body,
-  ) async {
-    final settings = await _offlineSettingsService.loadSettingsOrDefaults();
+    OfflineSecureModeSettings settings,
+  ) {
     return <String, dynamic>{
       ...body,
       ...settings.toAiHubPolicyPayload(),

--- a/lib/services/local_rag_runtime_service.dart
+++ b/lib/services/local_rag_runtime_service.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'offline_secure_mode_settings_service.dart';
+
+typedef LocalRagRuntimeInvoker = Future<Map<String, dynamic>> Function(
+  Map<String, dynamic> body,
+);
+
+class LocalRagRuntimeException implements Exception {
+  final String message;
+
+  const LocalRagRuntimeException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+class LocalRagCitation {
+  final String sourceId;
+  final String title;
+  final String path;
+  final String snippet;
+  final double score;
+
+  const LocalRagCitation({
+    required this.sourceId,
+    required this.title,
+    required this.path,
+    required this.snippet,
+    required this.score,
+  });
+
+  factory LocalRagCitation.fromMap(Map<String, dynamic> map) {
+    return LocalRagCitation(
+      sourceId: map['source_id']?.toString().trim() ?? '',
+      title: map['title']?.toString().trim() ?? '',
+      path: map['path']?.toString().trim() ?? '',
+      snippet: map['snippet']?.toString().trim() ?? '',
+      score: _asDouble(map['score']) ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'source_id': sourceId,
+      'title': title,
+      'path': path,
+      'snippet': snippet,
+      'score': score,
+    };
+  }
+}
+
+class LocalRagRuntimeResponse {
+  final String text;
+  final String engine;
+  final String model;
+  final String vectorDbPath;
+  final bool offlineOnly;
+  final bool networkBlocked;
+  final int? memoryPeakMb;
+  final List<LocalRagCitation> citations;
+  final Map<String, dynamic> raw;
+
+  const LocalRagRuntimeResponse({
+    required this.text,
+    required this.engine,
+    required this.model,
+    required this.vectorDbPath,
+    required this.offlineOnly,
+    required this.networkBlocked,
+    required this.citations,
+    required this.raw,
+    this.memoryPeakMb,
+  });
+
+  factory LocalRagRuntimeResponse.fromMap(Map<String, dynamic> map) {
+    final citationsRaw = map['citations'];
+    final citations = citationsRaw is List
+        ? citationsRaw
+            .whereType<Map>()
+            .map(
+              (item) => LocalRagCitation.fromMap(
+                Map<String, dynamic>.from(item),
+              ),
+            )
+            .toList()
+        : const <LocalRagCitation>[];
+
+    return LocalRagRuntimeResponse(
+      text: (map['text'] ?? map['answer'] ?? '').toString().trim(),
+      engine: map['engine']?.toString().trim() ?? 'local-rag',
+      model: map['model']?.toString().trim() ?? 'local-model',
+      vectorDbPath: map['vector_db_path']?.toString().trim() ?? '',
+      offlineOnly: map['offline_only'] != false,
+      networkBlocked: map['network_blocked'] == true,
+      memoryPeakMb: _asInt(map['memory_peak_mb']),
+      citations: citations,
+      raw: map,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'text': text,
+      'engine': engine,
+      'model': model,
+      'vector_db_path': vectorDbPath,
+      'offline_only': offlineOnly,
+      'network_blocked': networkBlocked,
+      if (memoryPeakMb != null) 'memory_peak_mb': memoryPeakMb,
+      'citations': citations.map((item) => item.toJson()).toList(),
+    };
+  }
+}
+
+class LocalRagRuntimeService {
+  final LocalRagRuntimeInvoker? _invoker;
+  final Duration timeout;
+
+  const LocalRagRuntimeService({
+    LocalRagRuntimeInvoker? invoker,
+    this.timeout = const Duration(seconds: 60),
+  }) : _invoker = invoker;
+
+  Future<LocalRagRuntimeResponse> query({
+    required String query,
+    required OfflineSecureModeSettings settings,
+    String systemPrompt = '',
+    Object? contextData,
+    String? sessionId,
+    String? traceId,
+  }) async {
+    final normalizedQuery = query.trim();
+    if (normalizedQuery.isEmpty) {
+      throw const LocalRagRuntimeException('Local RAG query is empty');
+    }
+    if (!settings.localRuntimeConfigured) {
+      throw const LocalRagRuntimeException(
+        'Local model path and vector DB path are required',
+      );
+    }
+
+    final body = <String, dynamic>{
+      'query': normalizedQuery,
+      'system_prompt': systemPrompt.trim(),
+      'context_data': contextData,
+      'model_path': settings.localModelPath,
+      'vector_db_path': settings.localVectorDbPath,
+      'engine': settings.inferenceEngine,
+      'offline_only': true,
+      'network_policy': 'offline_only',
+      if (sessionId != null && sessionId.trim().isNotEmpty)
+        'session_id': sessionId.trim(),
+      if (traceId != null && traceId.trim().isNotEmpty)
+        'trace_id': traceId.trim(),
+    };
+
+    final invoker = _invoker;
+    final data = invoker != null
+        ? await invoker(body)
+        : await _post(settings.localRuntimeUrl, body);
+    if (data['success'] != true) {
+      final detail =
+          (data['message'] ?? data['detail'] ?? 'Local RAG runtime failed')
+              .toString()
+              .trim();
+      throw LocalRagRuntimeException(
+        detail.isEmpty ? 'Local RAG runtime failed' : detail,
+      );
+    }
+
+    final response = LocalRagRuntimeResponse.fromMap(data);
+    if (response.text.isEmpty) {
+      throw const LocalRagRuntimeException('Local RAG response was empty');
+    }
+    return response;
+  }
+
+  Future<Map<String, dynamic>> _post(
+    String endpoint,
+    Map<String, dynamic> body,
+  ) async {
+    final uri = Uri.parse(endpoint);
+    final response = await http
+        .post(
+          uri,
+          headers: const <String, String>{
+            'content-type': 'application/json',
+          },
+          body: jsonEncode(body),
+        )
+        .timeout(timeout);
+    final decoded = jsonDecode(response.body);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    if (decoded is Map) {
+      return Map<String, dynamic>.from(decoded);
+    }
+    return <String, dynamic>{
+      'success': false,
+      'message': 'Unexpected local RAG response',
+      'status_code': response.statusCode,
+    };
+  }
+}
+
+int? _asInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value == null) return null;
+  return int.tryParse(value.toString());
+}
+
+double? _asDouble(Object? value) {
+  if (value is double) return value;
+  if (value is num) return value.toDouble();
+  if (value == null) return null;
+  return double.tryParse(value.toString());
+}

--- a/lib/services/offline_secure_mode_settings_service.dart
+++ b/lib/services/offline_secure_mode_settings_service.dart
@@ -4,6 +4,7 @@ class OfflineSecureModeSettings {
   static const bool defaultEnabled = false;
   static const bool defaultBlockExternalApiWhenEnabled = true;
   static const String defaultInferenceEngine = 'pleias-rag';
+  static const String defaultLocalRuntimeUrl = 'http://127.0.0.1:8765/rag';
   static const List<String> supportedInferenceEngines = <String>[
     'pleias-rag',
     'llama.cpp',
@@ -16,6 +17,7 @@ class OfflineSecureModeSettings {
   final String localModelPath;
   final String localVectorDbPath;
   final String inferenceEngine;
+  final String localRuntimeUrl;
   final bool blockExternalApiWhenEnabled;
 
   const OfflineSecureModeSettings({
@@ -23,6 +25,7 @@ class OfflineSecureModeSettings {
     this.localModelPath = '',
     this.localVectorDbPath = '',
     this.inferenceEngine = defaultInferenceEngine,
+    this.localRuntimeUrl = defaultLocalRuntimeUrl,
     this.blockExternalApiWhenEnabled = defaultBlockExternalApiWhenEnabled,
   });
 
@@ -38,6 +41,7 @@ class OfflineSecureModeSettings {
     String? localModelPath,
     String? localVectorDbPath,
     String? inferenceEngine,
+    String? localRuntimeUrl,
     bool? blockExternalApiWhenEnabled,
   }) {
     return OfflineSecureModeSettings(
@@ -45,6 +49,7 @@ class OfflineSecureModeSettings {
       localModelPath: localModelPath ?? this.localModelPath,
       localVectorDbPath: localVectorDbPath ?? this.localVectorDbPath,
       inferenceEngine: inferenceEngine ?? this.inferenceEngine,
+      localRuntimeUrl: localRuntimeUrl ?? this.localRuntimeUrl,
       blockExternalApiWhenEnabled:
           blockExternalApiWhenEnabled ?? this.blockExternalApiWhenEnabled,
     );
@@ -56,6 +61,7 @@ class OfflineSecureModeSettings {
       'offline_external_api_blocked': externalApiBlocked,
       'offline_runtime_configured': localRuntimeConfigured,
       'offline_inference_engine': inferenceEngine,
+      'offline_local_runtime_url': localRuntimeUrl,
       if (localModelPath.trim().isNotEmpty)
         'offline_local_model_path': localModelPath.trim(),
       if (localVectorDbPath.trim().isNotEmpty)
@@ -72,6 +78,8 @@ class OfflineSecureModeSettingsService {
       'offline_secure_mode_local_vector_db_path_v1';
   static const String _inferenceEngineKey =
       'offline_secure_mode_inference_engine_v1';
+  static const String _localRuntimeUrlKey =
+      'offline_secure_mode_local_runtime_url_v1';
   static const String _blockExternalApiWhenEnabledKey =
       'offline_secure_mode_block_external_api_when_enabled_v1';
 
@@ -98,6 +106,9 @@ class OfflineSecureModeSettingsService {
       localVectorDbPath:
           _normalizedString(store.getString(_localVectorDbPathKey)),
       inferenceEngine: _normalizedEngine(store.getString(_inferenceEngineKey)),
+      localRuntimeUrl: _normalizedRuntimeUrl(
+        store.getString(_localRuntimeUrlKey),
+      ),
       blockExternalApiWhenEnabled:
           store.getBool(_blockExternalApiWhenEnabledKey) ??
               OfflineSecureModeSettings.defaultBlockExternalApiWhenEnabled,
@@ -113,11 +124,13 @@ class OfflineSecureModeSettingsService {
       localModelPath: settings.localModelPath.trim(),
       localVectorDbPath: settings.localVectorDbPath.trim(),
       inferenceEngine: _normalizedEngine(settings.inferenceEngine),
+      localRuntimeUrl: _normalizedRuntimeUrl(settings.localRuntimeUrl),
     );
     await store.setBool(_enabledKey, normalized.enabled);
     await store.setString(_localModelPathKey, normalized.localModelPath);
     await store.setString(_localVectorDbPathKey, normalized.localVectorDbPath);
     await store.setString(_inferenceEngineKey, normalized.inferenceEngine);
+    await store.setString(_localRuntimeUrlKey, normalized.localRuntimeUrl);
     await store.setBool(
       _blockExternalApiWhenEnabledKey,
       normalized.blockExternalApiWhenEnabled,
@@ -134,6 +147,14 @@ class OfflineSecureModeSettingsService {
   }
 
   String _normalizedString(String? raw) => raw?.trim() ?? '';
+
+  String _normalizedRuntimeUrl(String? raw) {
+    final normalized = raw?.trim();
+    if (normalized == null || normalized.isEmpty) {
+      return OfflineSecureModeSettings.defaultLocalRuntimeUrl;
+    }
+    return normalized;
+  }
 
   String _normalizedEngine(String? raw) {
     final normalized = raw?.trim().toLowerCase();

--- a/scripts/local_rag_runtime.py
+++ b/scripts/local_rag_runtime.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Small offline-only RAG runtime harness for local validation.
+
+The harness intentionally uses only the Python standard library. It can run as a
+one-shot validator or as a localhost HTTP endpoint consumed by the Flutter app.
+For real model execution, start this process beside llama.cpp/Ollama/LocalAI and
+replace the extractive answer builder with a local generator command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import re
+import socket
+import sys
+import textwrap
+import time
+import tracemalloc
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+TEXT_EXTENSIONS = {".txt", ".md", ".markdown", ".json", ".jsonl"}
+TOKEN_RE = re.compile(r"[A-Za-z0-9_\u3040-\u30ff\u3400-\u9fff]{2,}")
+
+
+@dataclass(frozen=True)
+class Document:
+    source_id: str
+    title: str
+    path: str
+    text: str
+
+
+@contextlib.contextmanager
+def block_external_network() -> Any:
+    original_connect = socket.socket.connect
+
+    def guarded_connect(self: socket.socket, address: Any) -> Any:
+        host = address[0] if isinstance(address, tuple) and address else ""
+        if host not in {"127.0.0.1", "::1", "localhost"}:
+            raise OSError("external network is blocked for local RAG validation")
+        return original_connect(self, address)
+
+    socket.socket.connect = guarded_connect  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        socket.socket.connect = original_connect  # type: ignore[method-assign]
+
+
+def tokenize(text: str) -> set[str]:
+    return {item.lower() for item in TOKEN_RE.findall(text)}
+
+
+def read_json_text(path: Path) -> str:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict):
+        parts = []
+        for key in ("title", "body", "text", "content", "summary"):
+            value = data.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+        return "\n".join(parts)
+    if isinstance(data, list):
+        return "\n".join(str(item) for item in data)
+    return str(data)
+
+
+def read_jsonl_text(path: Path) -> str:
+    parts: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            parts.append(line)
+            continue
+        if isinstance(data, dict):
+            value = data.get("text") or data.get("content") or data.get("body")
+            parts.append(str(value if value is not None else data))
+        else:
+            parts.append(str(data))
+    return "\n".join(parts)
+
+
+def load_documents(vector_db_path: str) -> list[Document]:
+    source = Path(vector_db_path).expanduser()
+    if not source.exists():
+        raise FileNotFoundError(f"vector DB path not found: {source}")
+
+    files = [source] if source.is_file() else [
+        item for item in sorted(source.rglob("*"))
+        if item.is_file() and item.suffix.lower() in TEXT_EXTENSIONS
+    ]
+    documents: list[Document] = []
+    for index, path in enumerate(files, start=1):
+        try:
+            suffix = path.suffix.lower()
+            if suffix == ".json":
+                text = read_json_text(path)
+            elif suffix == ".jsonl":
+                text = read_jsonl_text(path)
+            else:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+        except Exception as exc:
+            text = f"Skipped unreadable document: {exc}"
+        text = text.lstrip("\ufeff")
+        if text.strip():
+            documents.append(
+                Document(
+                    source_id=f"doc-{index}",
+                    title=path.stem,
+                    path=str(path),
+                    text=text.strip(),
+                )
+            )
+    if not documents:
+        raise ValueError(f"no readable documents under vector DB path: {source}")
+    return documents
+
+
+def rank_documents(query: str, documents: list[Document]) -> list[tuple[float, Document]]:
+    query_tokens = tokenize(query)
+    ranked: list[tuple[float, Document]] = []
+    for doc in documents:
+        doc_tokens = tokenize(doc.text)
+        overlap = query_tokens & doc_tokens
+        count_hits = sum(doc.text.lower().count(token) for token in query_tokens)
+        score = (len(overlap) * 2.0 + count_hits * 0.35) / max(1, len(query_tokens))
+        if score > 0:
+            ranked.append((round(score, 4), doc))
+    if not ranked:
+        ranked = [(0.01, doc) for doc in documents[:3]]
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    return ranked[:5]
+
+
+def snippet_for(query: str, text: str, limit: int = 260) -> str:
+    sentences = re.split(r"(?<=[.!?\u3002\uff01\uff1f])\s+", text)
+    query_tokens = tokenize(query)
+    best = max(
+        sentences or [text],
+        key=lambda sentence: len(tokenize(sentence) & query_tokens),
+    )
+    return textwrap.shorten(best.strip().replace("\n", " "), width=limit)
+
+
+def answer_from_citations(query: str, ranked: list[tuple[float, Document]]) -> str:
+    parts = [snippet_for(query, doc.text, limit=180) for _, doc in ranked[:3]]
+    joined = " ".join(part for part in parts if part)
+    return textwrap.shorten(
+        f"{joined}\n\nSources: " + ", ".join(doc.title for _, doc in ranked[:3]),
+        width=1200,
+    )
+
+
+def run_rag(
+    *,
+    query: str,
+    model_path: str,
+    vector_db_path: str,
+    engine: str,
+    memory_limit_mb: int,
+    network_blocked: bool,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    model = Path(model_path).expanduser()
+    if not model.exists():
+        return {
+            "success": False,
+            "status": "missingModel",
+            "message": f"local model path not found: {model}",
+            "offline_only": True,
+            "network_blocked": network_blocked,
+        }
+
+    tracemalloc.start()
+    documents = load_documents(vector_db_path)
+    ranked = rank_documents(query, documents)
+    current_bytes, peak_bytes = tracemalloc.get_traced_memory()
+    del current_bytes
+    memory_peak_mb = int((peak_bytes / 1024 / 1024) + 0.999)
+    tracemalloc.stop()
+
+    if memory_peak_mb > memory_limit_mb:
+        return {
+            "success": False,
+            "status": "memoryLimitExceeded",
+            "message": f"peak {memory_peak_mb} MB exceeds {memory_limit_mb} MB",
+            "memory_peak_mb": memory_peak_mb,
+            "offline_only": True,
+            "network_blocked": network_blocked,
+        }
+
+    citations = [
+        {
+            "source_id": doc.source_id,
+            "title": doc.title,
+            "path": doc.path,
+            "snippet": snippet_for(query, doc.text),
+            "score": score,
+        }
+        for score, doc in ranked
+    ]
+    return {
+        "success": True,
+        "status": "ok",
+        "text": answer_from_citations(query, ranked),
+        "engine": engine,
+        "model": model.name,
+        "model_path": str(model),
+        "vector_db_path": str(Path(vector_db_path).expanduser()),
+        "offline_only": True,
+        "network_blocked": network_blocked,
+        "memory_peak_mb": memory_peak_mb,
+        "latency_ms": int((time.perf_counter() - started) * 1000),
+        "citations": citations,
+    }
+
+
+class RagHandler(BaseHTTPRequestHandler):
+    config: argparse.Namespace
+
+    def do_OPTIONS(self) -> None:
+        self._send_json({"success": True})
+
+    def do_POST(self) -> None:
+        if self.path.rstrip("/") != "/rag":
+            self._send_json({"success": False, "message": "not found"}, status=404)
+            return
+        length = int(self.headers.get("content-length") or "0")
+        payload = json.loads(self.rfile.read(length).decode("utf-8") or "{}")
+        result = run_rag(
+            query=str(payload.get("query") or payload.get("prompt") or ""),
+            model_path=str(payload.get("model_path") or self.config.model_path),
+            vector_db_path=str(payload.get("vector_db_path") or self.config.vector_db_path),
+            engine=str(payload.get("engine") or self.config.engine),
+            memory_limit_mb=int(payload.get("memory_limit_mb") or self.config.memory_limit_mb),
+            network_blocked=self.config.enforce_network_block,
+        )
+        self._send_json(result, status=200 if result.get("success") else 409)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        if not self.config.quiet:
+            super().log_message(format, *args)
+
+    def _send_json(self, body: dict[str, Any], status: int = 200) -> None:
+        encoded = json.dumps(body, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json; charset=utf-8")
+        self.send_header("access-control-allow-origin", "*")
+        self.send_header("access-control-allow-headers", "content-type")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--query", default="")
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--vector-db-path", required=True)
+    parser.add_argument("--engine", default="pleias-rag")
+    parser.add_argument("--memory-limit-mb", type=int, default=8192)
+    parser.add_argument("--enforce-network-block", action="store_true")
+    parser.add_argument("--serve", action="store_true")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--quiet", action="store_true")
+    return parser.parse_args(argv)
+
+
+def emit_json(body: dict[str, Any]) -> None:
+    encoded = json.dumps(body, ensure_ascii=False, indent=2).encode("utf-8")
+    sys.stdout.buffer.write(encoded + b"\n")
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    guard = block_external_network() if args.enforce_network_block else contextlib.nullcontext()
+    with guard:
+        if args.serve:
+            RagHandler.config = args
+            server = ThreadingHTTPServer((args.host, args.port), RagHandler)
+            print(f"local RAG runtime listening on http://{args.host}:{args.port}/rag")
+            server.serve_forever()
+            return 0
+        result = run_rag(
+            query=args.query,
+            model_path=args.model_path,
+            vector_db_path=args.vector_db_path,
+            engine=args.engine,
+            memory_limit_mb=args.memory_limit_mb,
+            network_blocked=args.enforce_network_block,
+        )
+        emit_json(result)
+        return 0 if result.get("success") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/supabase/functions/_shared/offline_secure_mode_guard.ts
+++ b/supabase/functions/_shared/offline_secure_mode_guard.ts
@@ -5,6 +5,7 @@ export type OfflineSecureModePolicy = {
   inferenceEngine: string;
   localModelPath: string;
   localVectorDbPath: string;
+  localRuntimeUrl: string;
 };
 
 export function parseOfflineSecureModePolicy(
@@ -20,6 +21,8 @@ export function parseOfflineSecureModePolicy(
     : parseBooleanish(body.offline_external_api_blocked, false);
   const localModelPath = asString(body.offline_local_model_path);
   const localVectorDbPath = asString(body.offline_local_vector_db_path);
+  const localRuntimeUrl = asString(body.offline_local_runtime_url) ||
+    "http://127.0.0.1:8765/rag";
   const inferredRuntimeConfigured = localModelPath.length > 0 &&
     localVectorDbPath.length > 0;
   const localRuntimeConfigured = body.offline_runtime_configured === undefined
@@ -34,6 +37,7 @@ export function parseOfflineSecureModePolicy(
     inferenceEngine: asString(body.offline_inference_engine) || "pleias-rag",
     localModelPath,
     localVectorDbPath,
+    localRuntimeUrl,
   };
 }
 
@@ -56,6 +60,7 @@ export function buildOfflineBlockedResponseBody(
     offline_secure_mode: policy.enabled,
     offline_runtime_configured: policy.localRuntimeConfigured,
     local_runtime_configured: policy.localRuntimeConfigured,
+    local_runtime_url: policy.localRuntimeUrl,
     offline_inference_engine: policy.inferenceEngine,
     action: context.action,
     provider: context.provider ?? null,

--- a/supabase/functions/_shared/offline_secure_mode_guard_test.ts
+++ b/supabase/functions/_shared/offline_secure_mode_guard_test.ts
@@ -49,6 +49,7 @@ Deno.test("offline guard reports pending local runtime when paths are configured
     offline_external_api_blocked: "true",
     offline_local_model_path: "C:/models/pleias-rag.gguf",
     offline_local_vector_db_path: "C:/rag/lancedb",
+    offline_local_runtime_url: "http://127.0.0.1:8765/rag",
     offline_inference_engine: "ollama",
   });
 
@@ -63,6 +64,7 @@ Deno.test("offline guard reports pending local runtime when paths are configured
       offline_blocked: true,
       offline_runtime_configured: true,
       offline_inference_engine: "ollama",
+      local_runtime_url: "http://127.0.0.1:8765/rag",
     },
   );
 });

--- a/test/scripts/test_local_rag_runtime.py
+++ b/test/scripts/test_local_rag_runtime.py
@@ -1,0 +1,60 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.local_rag_runtime import run_rag
+
+
+class LocalRagRuntimeTest(unittest.TestCase):
+    def test_run_rag_returns_citations_without_network(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            model = root / "pleias-rag.gguf"
+            docs = root / "lancedb"
+            docs.mkdir()
+            model.write_text("dummy local model marker", encoding="utf-8")
+            (docs / "policy.md").write_text(
+                "Offline secure mode answers from local documents only. "
+                "External API calls are blocked.",
+                encoding="utf-8",
+            )
+
+            result = run_rag(
+                query="How does offline secure mode answer?",
+                model_path=str(model),
+                vector_db_path=str(docs),
+                engine="pleias-rag",
+                memory_limit_mb=8192,
+                network_blocked=True,
+            )
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["offline_only"])
+        self.assertTrue(result["network_blocked"])
+        self.assertLessEqual(result["memory_peak_mb"], 8192)
+        self.assertEqual(result["citations"][0]["title"], "policy")
+        self.assertIn("Sources:", result["text"])
+
+    def test_run_rag_fails_safely_when_model_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docs = root / "lancedb"
+            docs.mkdir()
+            (docs / "manual.md").write_text("local doc", encoding="utf-8")
+
+            result = run_rag(
+                query="hello",
+                model_path=str(root / "missing.gguf"),
+                vector_db_path=str(docs),
+                engine="pleias-rag",
+                memory_limit_mb=8192,
+                network_blocked=True,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["status"], "missingModel")
+        self.assertTrue(result["offline_only"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/services/edge_llm_playground_service_test.dart
+++ b/test/services/edge_llm_playground_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/edge_llm_playground_service.dart';
+import 'package:my_web_app/services/local_rag_runtime_service.dart';
 import 'package:my_web_app/services/offline_secure_mode_settings_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -97,5 +98,67 @@ void main() {
     expect(capturedBody?['offline_secure_mode'], true);
     expect(capturedBody?['offline_external_api_blocked'], true);
     expect(capturedBody?['offline_runtime_configured'], false);
+  });
+
+  test('invoke routes to local RAG runtime when offline paths are configured',
+      () async {
+    const offlineSettings = OfflineSecureModeSettingsService();
+    await offlineSettings.saveSettings(
+      const OfflineSecureModeSettings(
+        enabled: true,
+        localModelPath: r'C:\models\pleias-rag.gguf',
+        localVectorDbPath: r'C:\rag\lancedb',
+        inferenceEngine: 'pleias-rag',
+        blockExternalApiWhenEnabled: true,
+      ),
+    );
+    var aiHubCalled = false;
+    Map<String, dynamic>? localBody;
+    final service = EdgeLlmPlaygroundService(
+      offlineSettingsService: offlineSettings,
+      invoker: (_) async {
+        aiHubCalled = true;
+        return <String, dynamic>{'success': false};
+      },
+      localRagRuntimeService: LocalRagRuntimeService(
+        invoker: (body) async {
+          localBody = body;
+          return <String, dynamic>{
+            'success': true,
+            'text': 'ローカル根拠だけで回答します。',
+            'engine': 'pleias-rag',
+            'model': 'pleias-rag.gguf',
+            'vector_db_path': r'C:\rag\lancedb',
+            'offline_only': true,
+            'network_blocked': true,
+            'citations': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'source_id': 'doc-1',
+                'title': 'policy.md',
+                'path': r'C:\rag\lancedb\policy.md',
+                'snippet': '外部APIなしで回答する。',
+                'score': 0.91,
+              },
+            ],
+          };
+        },
+      ),
+    );
+
+    final response = await service.invoke(
+      userPrompt: '社内規程を要約して',
+      responseFormat: 'json',
+      sessionId: 'session-local',
+    );
+
+    expect(aiHubCalled, isFalse);
+    expect(localBody?['query'], '社内規程を要約して');
+    expect(localBody?['model_path'], r'C:\models\pleias-rag.gguf');
+    expect(localBody?['vector_db_path'], r'C:\rag\lancedb');
+    expect(localBody?['network_policy'], 'offline_only');
+    expect(response.provider, 'local-rag');
+    expect(response.tier, 'offline');
+    expect(response.parsedJson?['citations'], isA<List>());
+    expect(response.source, 'local-rag runtime / pleias-rag');
   });
 }

--- a/test/services/local_rag_runtime_service_test.dart
+++ b/test/services/local_rag_runtime_service_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/local_rag_runtime_service.dart';
+import 'package:my_web_app/services/offline_secure_mode_settings_service.dart';
+
+void main() {
+  test('query returns cited local RAG response', () async {
+    Map<String, dynamic>? capturedBody;
+    final service = LocalRagRuntimeService(
+      invoker: (body) async {
+        capturedBody = body;
+        return <String, dynamic>{
+          'success': true,
+          'text': '外部ネットワークなしで回答します。',
+          'engine': 'pleias-rag',
+          'model': 'pleias-rag.gguf',
+          'vector_db_path': r'C:\rag\lancedb',
+          'offline_only': true,
+          'network_blocked': true,
+          'memory_peak_mb': 256,
+          'citations': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'source_id': 'doc-1',
+              'title': 'manual.md',
+              'path': r'C:\rag\lancedb\manual.md',
+              'snippet': 'ローカル検索根拠',
+              'score': 0.87,
+            },
+          ],
+        };
+      },
+    );
+
+    final response = await service.query(
+      query: 'ローカルRAGの根拠は？',
+      settings: const OfflineSecureModeSettings(
+        enabled: true,
+        localModelPath: r'C:\models\pleias-rag.gguf',
+        localVectorDbPath: r'C:\rag\lancedb',
+      ),
+      systemPrompt: '引用を返す',
+      sessionId: 'session-1',
+    );
+
+    expect(capturedBody?['offline_only'], true);
+    expect(capturedBody?['network_policy'], 'offline_only');
+    expect(capturedBody?['model_path'], r'C:\models\pleias-rag.gguf');
+    expect(response.text, contains('外部ネットワークなし'));
+    expect(response.citations.single.sourceId, 'doc-1');
+    expect(response.networkBlocked, isTrue);
+    expect(response.memoryPeakMb, 256);
+  });
+
+  test('query fails safely when local paths are not configured', () async {
+    const service = LocalRagRuntimeService();
+
+    expect(
+      () => service.query(
+        query: 'hello',
+        settings: const OfflineSecureModeSettings(enabled: true),
+      ),
+      throwsA(isA<LocalRagRuntimeException>()),
+    );
+  });
+}

--- a/test/services/offline_secure_mode_settings_service_test.dart
+++ b/test/services/offline_secure_mode_settings_service_test.dart
@@ -32,6 +32,7 @@ void main() {
         localModelPath: r' C:\models\pleias-rag.gguf ',
         localVectorDbPath: r' C:\rag\lancedb ',
         inferenceEngine: 'ollama',
+        localRuntimeUrl: ' http://127.0.0.1:8765/rag ',
         blockExternalApiWhenEnabled: true,
       ),
     );
@@ -40,11 +41,16 @@ void main() {
     expect(saved.localModelPath, r'C:\models\pleias-rag.gguf');
     expect(loaded.localVectorDbPath, r'C:\rag\lancedb');
     expect(loaded.inferenceEngine, 'ollama');
+    expect(loaded.localRuntimeUrl, 'http://127.0.0.1:8765/rag');
     expect(loaded.localRuntimeConfigured, isTrue);
     expect(loaded.externalApiBlocked, isTrue);
     expect(
       loaded.toAiHubPolicyPayload(),
       containsPair('offline_external_api_blocked', true),
+    );
+    expect(
+      loaded.toAiHubPolicyPayload(),
+      containsPair('offline_local_runtime_url', 'http://127.0.0.1:8765/rag'),
     );
   });
 


### PR DESCRIPTION
﻿## Summary
- add a localhost-only local RAG runtime contract for offline secure mode
- route Edge LLM Playground to the local RAG runtime when external APIs are blocked and local model/vector DB paths are configured
- add a standard-library Python runtime harness with citations, missing-path safe failures, network-block flag, and 8192 MB memory gate
- expose the local runtime URL in offline secure settings and in ai-hub offline-block metadata

## Validation
- `deno test --allow-env supabase\functions\_shared\offline_secure_mode_guard_test.ts`
- `deno check supabase\functions\_shared\offline_secure_mode_guard.ts supabase\functions\_shared\offline_secure_mode_guard_test.ts supabase\functions\ai-hub\index.ts`
- `flutter test --no-pub test\services\local_rag_runtime_service_test.dart test\services\edge_llm_playground_service_test.dart test\services\offline_secure_mode_settings_service_test.dart`
- `flutter analyze --no-pub lib\services\local_rag_runtime_service.dart lib\services\edge_llm_playground_service.dart lib\services\offline_secure_mode_settings_service.dart lib\pages\offline_secure_mode_settings_page.dart test\services\local_rag_runtime_service_test.dart test\services\edge_llm_playground_service_test.dart test\services\offline_secure_mode_settings_service_test.dart`
- `python -m unittest discover -s test\scripts -p test_local_rag_runtime.py`
- `python scripts\local_rag_runtime.py --query "How does offline secure mode answer?" --model-path <temp-model> --vector-db-path <temp-corpus> --memory-limit-mb 8192 --enforce-network-block`

## Minimal E2E Gate
Implementation-detail independent command-level I/O plan with three cases:
- offline secure mode ON + external API block ON + local paths configured -> Edge LLM Playground calls localhost RAG, never ai-hub provider fetch, and returns citations
- offline secure mode ON + missing model/vector path -> local RAG fails safely and ai-hub still returns `offline_blocked=true` instead of using external providers
- CLI runtime with `--enforce-network-block --memory-limit-mb 8192` -> returns `success=true`, `network_blocked=true`, `memory_peak_mb <= 8192`, and local citations

E2E mechanism:
- Flutter service tests cover client-side local runtime routing and ai-hub bypass
- Deno guard tests cover hosted ai-hub offline-block metadata
- Python unittest and CLI validation cover local-only RAG success, safe failure, citations, network block flag, and memory gate

E2E-Exception: real Pleias/Ollama/llama.cpp generative execution on a physical 8GB host remains tracked in #1656; this PR adds the runtime contract and validation harness but does not close #1656.

Related #1656, #1265, #1645.
