### PR TITLE
fix: repair stale closed Issue WBS sync

### DIFF
--- a/.github/workflows/issue-to-wbs.yml
+++ b/.github/workflows/issue-to-wbs.yml
@@ -20,17 +20,95 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
+      - name: Install REST issue fetcher
+        run: |
+          cat > /tmp/fetch-github-issues.py <<'PY'
+          import json
+          import os
+          import sys
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          output_path = sys.argv[1]
+          repo = os.environ["REPO"]
+          token = os.environ["GH_TOKEN"]
+          base_url = f"https://api.github.com/repos/{repo}/issues"
+          fields = {
+              "state": "all",
+              "per_page": "100",
+              "sort": "updated",
+              "direction": "desc",
+          }
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+              "User-Agent": "my-web-app-wbs-sync",
+          }
+
+          def fetch_page(page):
+              query = urllib.parse.urlencode({**fields, "page": str(page)})
+              request = urllib.request.Request(f"{base_url}?{query}", headers=headers)
+              for attempt in range(1, 4):
+                  try:
+                      with urllib.request.urlopen(request, timeout=30) as response:
+                          return json.loads(response.read().decode("utf-8"))
+                  except urllib.error.HTTPError as exc:
+                      if exc.code not in {502, 503, 504} or attempt == 3:
+                          raise
+                      print(
+                          f"::warning::GitHub REST issues page {page} returned HTTP {exc.code}; retrying",
+                          flush=True,
+                      )
+                  except urllib.error.URLError as exc:
+                      if attempt == 3:
+                          raise
+                      print(
+                          f"::warning::GitHub REST issues page {page} failed: {exc}; retrying",
+                          flush=True,
+                      )
+                  time.sleep(2 * attempt)
+
+          issues = []
+          page = 1
+          while True:
+              items = fetch_page(page)
+              issue_items = [item for item in items if "pull_request" not in item]
+              for item in issue_items:
+                  issues.append(
+                      {
+                          "number": item["number"],
+                          "title": item.get("title") or "",
+                          "url": item.get("html_url") or item.get("url") or "",
+                          "state": str(item.get("state") or "").upper(),
+                          "labels": [{"name": label.get("name", "")} for label in item.get("labels", [])],
+                          "author": {"login": (item.get("user") or {}).get("login", "")},
+                          "createdAt": item.get("created_at") or "",
+                          "updatedAt": item.get("updated_at") or "",
+                      }
+                  )
+              print(
+                  f"Fetched GitHub issues page {page}: {len(issue_items)} issues "
+                  f"({len(items) - len(issue_items)} PRs skipped)",
+                  flush=True,
+              )
+              if len(items) < 100:
+                  break
+              page += 1
+
+          with open(output_path, "w", encoding="utf-8") as fh:
+              json.dump(issues, fh, ensure_ascii=False)
+          print(f"Wrote {len(issues)} GitHub issues to {output_path}")
+          PY
+
       - name: Fetch GitHub issues
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          gh issue list \
-            --repo "$REPO" \
-            --state all \
-            --limit 5000 \
-            --json number,title,url,state,labels,author,createdAt,updatedAt \
-            > /tmp/issues.json
+          python3 /tmp/fetch-github-issues.py /tmp/issues.json
 
           python3 - <<'PY'
           import json
@@ -38,8 +116,6 @@ jobs:
           with open("/tmp/issues.json", encoding="utf-8") as fh:
               issues = json.load(fh)
           print(f"Fetched {len(issues)} GitHub issues for WBS sync")
-          if len(issues) >= 5000:
-              print("::warning::GitHub issue fetch reached the 5000 item cap; WBS sync may still be incomplete.")
           PY
 
       - name: Close duplicate GitHub issues
@@ -86,12 +162,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          gh issue list \
-            --repo "$REPO" \
-            --state all \
-            --limit 5000 \
-            --json number,title,url,state,labels,author,createdAt,updatedAt \
-            > /tmp/issues.json
+          python3 /tmp/fetch-github-issues.py /tmp/issues.json
 
           python3 - <<'PY'
           import json
@@ -99,8 +170,6 @@ jobs:
           with open("/tmp/issues.json", encoding="utf-8") as fh:
               issues = json.load(fh)
           print(f"Refetched {len(issues)} GitHub issues after dedupe")
-          if len(issues) >= 5000:
-              print("::warning::GitHub issue refetch reached the 5000 item cap; WBS sync may still be incomplete.")
           PY
 
       - name: Sync issues to WBS

--- a/docs/WBS_GITHUB_ISSUE_SYNC_RUNBOOK.md
+++ b/docs/WBS_GITHUB_ISSUE_SYNC_RUNBOOK.md
@@ -1,0 +1,49 @@
+# WBS GitHub Issue Sync Runbook
+
+This runbook keeps GitHub Issues and `wbs_tasks` aligned when a session sees a
+closed GitHub Issue still appearing in `wbs.priority_for_instance`.
+
+## Safe Resync
+
+1. Confirm the latest `main` deploy finished, because `tools-hub` is deployed by
+   `Deploy to Production`.
+
+   ```bash
+   gh run list --workflow "Deploy to Production" --branch main --limit 3
+   ```
+
+2. Run the full Issue -> WBS sync from `main`.
+
+   ```bash
+   gh workflow run "GitHub Issues WBS Sync" --ref main
+   ```
+
+3. Watch the run until it completes.
+
+   ```bash
+   gh run list --workflow "GitHub Issues WBS Sync" --limit 5
+   gh run watch <run-id> --exit-status
+   ```
+
+4. Check the sync summary. A healthy run includes these response fields:
+   `wbs_task_scan_count`, `completed_from_closed_issues`,
+   `duplicate_wbs_closed`, `stale_wbs_repaired`, `duplicate_wbs_tasks`, and
+   `repaired_wbs_tasks`.
+
+## Drift Rules
+
+- Prefer the explicit `[Issue #NNN]` prefix in WBS titles over stale
+  `github_issue_number` metadata.
+- If GitHub says an Issue is closed, every linked WBS row must become
+  `completed` with `progress = 100` or be excluded from priority routing.
+- Duplicate WBS rows for the same Issue should keep one canonical row and mark
+  the rest as duplicate/completed when the Issue is closed.
+- The sync workflow fetches GitHub Issues with REST pagination and retries
+  transient 502/503/504 responses.
+
+## Known Backfill
+
+Migration `20260503053400_repair_stale_closed_issue_wbs_rows.sql` repairs the
+observed stale rows for closed Issues `#1270`, `#1272`, and `#1274`. Future
+drift should be repaired by `tools-hub:wbs.sync_github_issues` and reported in
+`repaired_wbs_tasks`.

--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -1029,21 +1029,30 @@ async function handleMcpFacade(
 function parseGithubIssueNumber(value: unknown): number | null {
   const text = String(value ?? "");
   const match = text.match(
-    /(?:github\.com\/kanta13jp1\/my_web_app\/issues\/|\[Issue #)(\d+)/i,
+    /github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+)|(?:^|[\s([])(?:github\s+)?issue\s*#\s*(\d+)\]?/i,
   );
   if (!match) return null;
-  const issueNumber = Number(match[1]);
+  const issueNumber = Number(match.slice(1).find((group) => group) ?? 0);
   return Number.isFinite(issueNumber) && issueNumber > 0 ? issueNumber : null;
+}
+
+function explicitGithubIssueNumberFromTask(
+  task: Record<string, unknown>,
+): number | null {
+  const explicit = Number(task.github_issue_number ?? 0);
+  return Number.isFinite(explicit) && explicit > 0 ? explicit : null;
 }
 
 function githubIssueNumberFromTask(
   task: Record<string, unknown>,
 ): number | null {
-  const explicit = Number(task.github_issue_number ?? 0);
-  if (Number.isFinite(explicit) && explicit > 0) return explicit;
-  return parseGithubIssueNumber(
-    `${task.title ?? ""} ${task.description ?? ""}`,
-  );
+  const titleIssueNumber = parseGithubIssueNumber(task.title);
+  if (titleIssueNumber) return titleIssueNumber;
+  const urlIssueNumber = parseGithubIssueNumber(task.github_issue_url);
+  if (urlIssueNumber) return urlIssueNumber;
+  const explicit = explicitGithubIssueNumberFromTask(task);
+  if (explicit) return explicit;
+  return parseGithubIssueNumber(task.description);
 }
 
 function normalizeDuplicateKey(value: unknown): string {
@@ -1086,6 +1095,84 @@ function githubIssueNumber(issue: Record<string, unknown>): number | null {
 function githubIssueState(issue: Record<string, unknown>): "OPEN" | "CLOSED" {
   const state = String(issue.state ?? "").trim().toUpperCase();
   return state === "CLOSED" || state === "CLOSE" ? "CLOSED" : "OPEN";
+}
+
+function normalizedMirroredGithubIssueState(value: unknown): string {
+  const state = String(value ?? "").trim().toUpperCase();
+  return state === "CLOSE" ? "CLOSED" : state;
+}
+
+function githubIssueTaskRepairReasons(
+  task: Record<string, unknown>,
+  issueNumber: number,
+  issueState: string,
+  canonicalTitle: string,
+): string[] {
+  const reasons = new Set<string>();
+  const explicit = explicitGithubIssueNumberFromTask(task);
+  if (!explicit) {
+    reasons.add("github_issue_number_missing");
+  } else if (explicit !== issueNumber) {
+    reasons.add("github_issue_number_mismatch");
+  }
+
+  const titleIssueNumber = parseGithubIssueNumber(task.title);
+  if (titleIssueNumber !== null && titleIssueNumber !== issueNumber) {
+    reasons.add("title_issue_number_mismatch");
+  }
+
+  const urlIssueNumber = parseGithubIssueNumber(task.github_issue_url);
+  if (urlIssueNumber !== null && urlIssueNumber !== issueNumber) {
+    reasons.add("github_issue_url_mismatch");
+  }
+
+  const mirroredState = normalizedMirroredGithubIssueState(
+    task.github_issue_state,
+  );
+  if (!mirroredState) {
+    reasons.add("github_issue_state_missing");
+  } else if (mirroredState !== issueState) {
+    reasons.add("github_issue_state_stale");
+  }
+
+  if (String(task.title ?? "") !== canonicalTitle) {
+    reasons.add("title_stale");
+  }
+
+  if (issueState === "CLOSED" && !isCompletedWbsTask(task)) {
+    reasons.add("closed_issue_active_wbs");
+  }
+
+  return [...reasons];
+}
+
+async function fetchAllWbsTasks(
+  admin: SupabaseClient,
+  taskSelect: string,
+): Promise<Array<Record<string, unknown>>> {
+  const pageSize = 1000;
+  const maxPages = 50;
+  const tasks: Array<Record<string, unknown>> = [];
+
+  for (let page = 0; page < maxPages; page += 1) {
+    const from = page * pageSize;
+    const to = from + pageSize - 1;
+    const { data, error } = await admin.from("wbs_tasks")
+      .select(taskSelect)
+      .order("created_at", { ascending: true, nullsFirst: true })
+      .order("id", { ascending: true })
+      .range(from, to);
+    if (error) throw new Error(error.message);
+
+    const rows = (data ?? []) as unknown as Array<Record<string, unknown>>;
+    tasks.push(...rows);
+    if (rows.length < pageSize) return tasks;
+  }
+
+  throw new Error(
+    `wbs.sync_github_issues scanned at least ${pageSize * maxPages} rows; ` +
+      "increase the WBS pagination cap before syncing.",
+  );
 }
 
 function githubIssueOwnerInstance(labels: string[]): string {
@@ -5654,15 +5741,7 @@ serve(async (req) => {
           const today = nowIso.slice(0, 10);
           const taskSelect =
             "id, category, category_icon, category_order, title, description, instance, owner_instance, status, progress, start_date, end_date, planned_end_date, milestone_code, priority, remaining_work, recovery_plan, ai_review_status, created_at, updated_at, github_issue_number, github_issue_url, github_issue_state, github_issue_labels, github_issue_synced_at";
-          const { data: existingTasks, error: existingError } = await admin
-            .from("wbs_tasks")
-            .select(taskSelect)
-            .limit(5000);
-          if (existingError) throw new Error(existingError.message);
-
-          const allTasks = [...(existingTasks ?? [])] as Array<
-            Record<string, unknown>
-          >;
+          const allTasks = await fetchAllWbsTasks(admin, taskSelect);
           const tasksByIssue = new Map<
             number,
             Array<Record<string, unknown>>
@@ -5687,11 +5766,33 @@ serve(async (req) => {
             updated: 0,
             completed_from_closed_issues: 0,
             duplicate_wbs_closed: 0,
+            stale_wbs_repaired: 0,
             skipped: 0,
           };
           const issuesToClose: Array<Record<string, unknown>> = [];
           const closedIssueNumbers = new Set<number>();
           const duplicateWbsTasks: Array<Record<string, unknown>> = [];
+          const repairedWbsTasks: Array<Record<string, unknown>> = [];
+          const repairedWbsTaskIds = new Set<string>();
+          const recordWbsRepair = (
+            task: Record<string, unknown>,
+            issueNumber: number,
+            reasons: string[],
+            context: string,
+          ) => {
+            const id = String(task.id ?? "");
+            if (!id || reasons.length === 0 || repairedWbsTaskIds.has(id)) {
+              return;
+            }
+            repairedWbsTaskIds.add(id);
+            repairedWbsTasks.push({
+              id,
+              issue_number: issueNumber,
+              reasons,
+              context,
+            });
+            stats.stale_wbs_repaired += 1;
+          };
 
           for (const [issueNumber, issue] of issuesByNumber.entries()) {
             const issueTitle = String(issue.title ?? `Issue #${issueNumber}`)
@@ -5762,6 +5863,7 @@ serve(async (req) => {
               github_issue_labels: labels,
               github_issue_synced_at: nowIso,
             };
+            const canonicalTitle = String(payload.title ?? "");
             if (!isClosed && currentCompleted && !closureReady) {
               payload.remaining_work =
                 "GitHub Issue is still open; WBS completion must pass AI review before the issue can be closed.";
@@ -5792,6 +5894,12 @@ serve(async (req) => {
                   | Record<string, unknown>
                   | undefined;
                 if (!conflictingTask?.id) throw new Error(createError.message);
+                const conflictRepairReasons = githubIssueTaskRepairReasons(
+                  conflictingTask,
+                  issueNumber,
+                  state,
+                  canonicalTitle,
+                );
 
                 const { data: recovered, error: recoveryError } = await admin
                   .from("wbs_tasks")
@@ -5810,6 +5918,14 @@ serve(async (req) => {
                 } else {
                   allTasks.push(recoveredTask);
                 }
+                recordWbsRepair(
+                  conflictingTask,
+                  issueNumber,
+                  conflictRepairReasons.length
+                    ? conflictRepairReasons
+                    : ["title_instance_conflict_recovered"],
+                  "insert_conflict_recovery",
+                );
                 stats.updated += 1;
                 if (isClosed) stats.completed_from_closed_issues += 1;
                 continue;
@@ -5829,6 +5945,14 @@ serve(async (req) => {
               .select(taskSelect)
               .single();
             let updatedKeeper = updated as Record<string, unknown> | null;
+            const keeperRepairReasons = githubIssueTaskRepairReasons(
+              keeper,
+              issueNumber,
+              state,
+              canonicalTitle,
+            );
+            let conflictRepairTask: Record<string, unknown> | null = null;
+            let conflictRepairReasons: string[] = [];
             if (updateError) {
               if (!isWbsTitleInstanceUniqueConflict(updateError)) {
                 throw new Error(updateError.message);
@@ -5846,6 +5970,13 @@ serve(async (req) => {
                 | Record<string, unknown>
                 | undefined;
               if (!conflictingTask?.id) throw new Error(updateError.message);
+              conflictRepairTask = conflictingTask;
+              conflictRepairReasons = githubIssueTaskRepairReasons(
+                conflictingTask,
+                issueNumber,
+                state,
+                canonicalTitle,
+              );
 
               const { data: recovered, error: recoveryError } = await admin
                 .from("wbs_tasks")
@@ -5863,6 +5994,22 @@ serve(async (req) => {
             }
             stats.updated += 1;
             if (isClosed) stats.completed_from_closed_issues += 1;
+            recordWbsRepair(
+              keeper,
+              issueNumber,
+              keeperRepairReasons,
+              "canonical_update",
+            );
+            if (conflictRepairTask) {
+              recordWbsRepair(
+                conflictRepairTask,
+                issueNumber,
+                conflictRepairReasons.length
+                  ? conflictRepairReasons
+                  : ["title_instance_conflict_recovered"],
+                "update_conflict_recovery",
+              );
+            }
             if (
               !isClosed && closureReady && !closedIssueNumbers.has(issueNumber)
             ) {
@@ -5892,6 +6039,13 @@ serve(async (req) => {
               const duplicateProgress = isClosed
                 ? 100
                 : Math.max(0, Math.min(99, Number(duplicate.progress ?? 0)));
+              const duplicateRepairReasons = githubIssueTaskRepairReasons(
+                duplicate,
+                issueNumber,
+                state,
+                canonicalTitle,
+              );
+              duplicateRepairReasons.push("duplicate_wbs_row");
               const { error: duplicateError } = await admin.from("wbs_tasks")
                 .update({
                   status: duplicateStatus,
@@ -5908,6 +6062,22 @@ serve(async (req) => {
                 })
                 .eq("id", String(duplicate.id));
               if (duplicateError) throw new Error(duplicateError.message);
+              Object.assign(duplicate, {
+                status: duplicateStatus,
+                progress: duplicateProgress,
+                remaining_work: duplicateNote,
+                github_issue_number: issueNumber,
+                github_issue_url: issueUrl,
+                github_issue_state: state,
+                github_issue_labels: labels,
+                github_issue_synced_at: nowIso,
+              });
+              recordWbsRepair(
+                duplicate,
+                issueNumber,
+                duplicateRepairReasons,
+                "issue_duplicate_update",
+              );
               duplicateWbsTasks.push({
                 id: duplicate.id,
                 kept_id: updatedKeeper.id,
@@ -5984,7 +6154,14 @@ serve(async (req) => {
               const labels = issue ? githubIssueLabelNames(issue) : [];
               const state = issue
                 ? githubIssueState(issue)
-                : String(duplicate.github_issue_state ?? "OPEN");
+                : (normalizedMirroredGithubIssueState(
+                  duplicate.github_issue_state,
+                ) || "OPEN");
+              const canonicalTitle = issue
+                ? `[Issue #${issueNumber}] ${
+                  String(issue.title ?? `Issue #${issueNumber}`).trim()
+                }`
+                : String(keeper.title ?? duplicate.title ?? "");
               const duplicateNote =
                 `Duplicate GitHub-origin WBS title; kept WBS task ${keeper.id} as canonical.`;
               const duplicateStatus = state === "CLOSED"
@@ -5993,6 +6170,13 @@ serve(async (req) => {
               const duplicateProgress = state === "CLOSED"
                 ? 100
                 : Math.max(0, Math.min(99, Number(duplicate.progress ?? 0)));
+              const duplicateRepairReasons = githubIssueTaskRepairReasons(
+                duplicate,
+                Number(issueNumber),
+                state,
+                canonicalTitle,
+              );
+              duplicateRepairReasons.push("duplicate_title");
               const { error: duplicateError } = await admin.from("wbs_tasks")
                 .update({
                   status: duplicateStatus,
@@ -6004,6 +6188,7 @@ serve(async (req) => {
                   github_issue_url:
                     (issueUrl || String(duplicate.github_issue_url ?? "")) ||
                     null,
+                  github_issue_number: issueNumber,
                   github_issue_state: state,
                   github_issue_labels: labels.length
                     ? labels
@@ -6012,6 +6197,26 @@ serve(async (req) => {
                 })
                 .eq("id", duplicateId);
               if (duplicateError) throw new Error(duplicateError.message);
+              Object.assign(duplicate, {
+                status: duplicateStatus,
+                progress: duplicateProgress,
+                remaining_work: duplicateNote,
+                github_issue_number: issueNumber,
+                github_issue_url: issueUrl ||
+                  String(duplicate.github_issue_url ?? "") ||
+                  null,
+                github_issue_state: state,
+                github_issue_labels: labels.length
+                  ? labels
+                  : (duplicate.github_issue_labels ?? []),
+                github_issue_synced_at: nowIso,
+              });
+              recordWbsRepair(
+                duplicate,
+                Number(issueNumber),
+                duplicateRepairReasons,
+                "title_duplicate_update",
+              );
               duplicateTaskIds.add(duplicateId);
               duplicateWbsTasks.push({
                 id: duplicateId,
@@ -6027,9 +6232,11 @@ serve(async (req) => {
             success: true,
             repo,
             issue_count: issueRecords.length,
+            wbs_task_scan_count: allTasks.length,
             ...stats,
             issues_to_close: issuesToClose,
             duplicate_wbs_tasks: duplicateWbsTasks,
+            repaired_wbs_tasks: repairedWbsTasks,
           });
         }
         case "wbs.priority_for_instance": {

--- a/supabase/migrations/20260503053400_repair_stale_closed_issue_wbs_rows.sql
+++ b/supabase/migrations/20260503053400_repair_stale_closed_issue_wbs_rows.sql
@@ -1,0 +1,32 @@
+-- Codex #1 / 2026-05-03:
+-- Backfill known stale GitHub-closed WBS mirrors reported in #1648/#1687.
+--
+-- The durable fix lives in tools-hub:wbs.sync_github_issues. This migration is
+-- intentionally narrow so the already-observed stale rows stop blocking the
+-- top WBS priority list on the next production deploy.
+
+UPDATE public.wbs_tasks
+SET status = 'completed',
+    progress = 100,
+    github_issue_state = 'CLOSED',
+    github_issue_synced_at = NOW(),
+    ai_review_status = COALESCE(ai_review_status, 'pending'),
+    remaining_work = 'GitHub Issue is closed; Codex #1 backfill mirrored this WBS row as completed.',
+    recovery_plan = COALESCE(
+      NULLIF(recovery_plan, ''),
+      'Backfilled by migration 20260503053400 after GitHub closed-state drift was detected.'
+    ),
+    recovery_planned_at = COALESCE(recovery_planned_at, NOW())
+WHERE status <> 'completed'
+  AND (
+    github_issue_number IN (1270, 1272, 1274)
+    OR title ~* '^\[Issue #(1270|1272|1274)\]'
+  );
+
+INSERT INTO public.development_achievements (title, description, completed_at)
+VALUES (
+  'Codex #1: repaired stale closed GitHub Issue WBS mirrors',
+  'Backfilled known stale WBS rows for closed GitHub Issues #1270, #1272, and #1274 while hardening tools-hub sync to repair future title/metadata drift.',
+  '2026-05-03'
+)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- take over the REST-paginated GitHub Issue fetcher from #1684 so `issue-to-wbs.yml` no longer depends on one large `gh issue list` GraphQL call
- harden `tools-hub:wbs.sync_github_issues` so WBS title prefixes / GitHub URLs can repair stale or mismatched `github_issue_number` metadata
- return `wbs_task_scan_count`, `stale_wbs_repaired`, and `repaired_wbs_tasks` for auditability, and backfill the known stale closed rows for #1270/#1272/#1274
- add a runbook for safe manual resync after deploy

## Minimal E2E Declaration
- The E2E test is implementation-detail independent and black-box: it validates the observable Issue -> WBS sync contract and the GitHub Actions workflow behavior, not private helper internals.
- The smoke plan is minimal, about three I/O cases: successful REST issue fetch, stale title/metadata repair for closed Issues, and priority-list removal after WBS completion.
- The E2E mechanism is Playwright public smoke plus the existing GitHub Issues WBS Sync workflow after production deploy.
- E2E-Exception: no new `integration_test/` or `test/e2e/` file is added because this PR changes an Edge Function sync route, a GitHub Actions maintenance workflow, docs, and a narrow DB backfill; the observable workflow/API contract is covered by the existing smoke gate and post-merge WBS sync run.

## Validation
- `deno check supabase/functions/tools-hub/index.ts`
- `deno lint supabase/functions/tools-hub/index.ts`
- `deno fmt --check supabase/functions/tools-hub/index.ts docs/WBS_GITHUB_ISSUE_SYNC_RUNBOOK.md`
- `python scripts/check_migration_timestamps.py`
- `git diff --cached --check`
- `git diff --check`
- `actionlint .github/workflows/issue-to-wbs.yml` could not run locally because `actionlint` is not installed in this Windows app environment.

Closes #1687
Closes #1648
Supersedes #1684