### PR TITLE
[codex] Preserve WBS stale repair sync aggregates

### DIFF
--- a/.github/workflows/issue-to-wbs.yml
+++ b/.github/workflows/issue-to-wbs.yml
@@ -243,41 +243,10 @@ jobs:
             echo "" >> /tmp/wbs-sync-responses.jsonl
           done < /tmp/wbs-sync-batches.txt
 
-          python3 <<'PY' > /tmp/wbs-sync-response.json
-          import json
-          from pathlib import Path
-
-          aggregate = {
-              "success": True,
-              "issue_count": 0,
-              "created": 0,
-              "updated": 0,
-              "completed_from_closed_issues": 0,
-              "duplicate_wbs_closed": 0,
-              "skipped": 0,
-              "issues_to_close": [],
-              "duplicate_wbs_tasks": [],
-              "batch_failures": [],
-          }
-          for line in Path("/tmp/wbs-sync-responses.jsonl").read_text(encoding="utf-8").splitlines():
-              if not line.strip():
-                  continue
-              response = json.loads(line)
-              aggregate["success"] = aggregate["success"] and bool(response.get("success", False))
-              for key in ["issue_count", "created", "updated", "completed_from_closed_issues", "duplicate_wbs_closed", "skipped"]:
-                  aggregate[key] += int(response.get(key) or 0)
-              aggregate["issues_to_close"].extend(response.get("issues_to_close") or [])
-              aggregate["duplicate_wbs_tasks"].extend(response.get("duplicate_wbs_tasks") or [])
-
-          failures_path = Path("/tmp/wbs-sync-failures.tsv")
-          if failures_path.exists() and failures_path.read_text(encoding="utf-8").strip():
-              aggregate["success"] = False
-              for line in failures_path.read_text(encoding="utf-8").splitlines():
-                  batch_number, http_code = line.split("\t", 1)
-                  aggregate["batch_failures"].append({"batch": int(batch_number), "http_code": http_code})
-
-          print(json.dumps(aggregate, ensure_ascii=False))
-          PY
+          python3 scripts/wbs_sync_aggregate.py \
+            --responses /tmp/wbs-sync-responses.jsonl \
+            --failures /tmp/wbs-sync-failures.tsv \
+            --output /tmp/wbs-sync-response.json
 
           cat /tmp/wbs-sync-response.json
 

--- a/docs/WBS_GITHUB_ISSUE_SYNC_RUNBOOK.md
+++ b/docs/WBS_GITHUB_ISSUE_SYNC_RUNBOOK.md
@@ -25,10 +25,17 @@ closed GitHub Issue still appearing in `wbs.priority_for_instance`.
    gh run watch <run-id> --exit-status
    ```
 
-4. Check the sync summary. A healthy run includes these response fields:
+4. Check the sync summary. The workflow prints the aggregate
+   `/tmp/wbs-sync-response.json`. A healthy run includes these response fields:
+   `success`, `issue_count`, `created`, `updated`, `skipped`,
    `wbs_task_scan_count`, `completed_from_closed_issues`,
-   `duplicate_wbs_closed`, `stale_wbs_repaired`, `duplicate_wbs_tasks`, and
-   `repaired_wbs_tasks`.
+   `duplicate_wbs_closed`, `stale_wbs_repaired`, `issues_to_close`,
+   `duplicate_wbs_tasks`, `repaired_wbs_tasks`, and `batch_failures`.
+
+   `wbs_task_scan_count` and `stale_wbs_repaired` are summed across batches.
+   `repaired_wbs_tasks` is merged across batches without dropping task IDs,
+   linked issue numbers, or repair reasons, so stale repair audits can be
+   traced from the workflow log.
 
 ## Drift Rules
 

--- a/scripts/wbs_sync_aggregate.py
+++ b/scripts/wbs_sync_aggregate.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Aggregate batched WBS GitHub Issue sync responses."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SUM_FIELDS = (
+    "issue_count",
+    "created",
+    "updated",
+    "completed_from_closed_issues",
+    "duplicate_wbs_closed",
+    "stale_wbs_repaired",
+    "wbs_task_scan_count",
+    "skipped",
+)
+
+LIST_FIELDS = (
+    "issues_to_close",
+    "duplicate_wbs_tasks",
+    "repaired_wbs_tasks",
+)
+
+
+def as_int(value: Any) -> int:
+    if value is None or value == "":
+        return 0
+    return int(value)
+
+
+def item_key(item: Any) -> str:
+    return json.dumps(item, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def extend_unique(target: list[Any], seen: set[str], items: Any) -> None:
+    if not isinstance(items, list):
+        return
+    for item in items:
+        key = item_key(item)
+        if key in seen:
+            continue
+        target.append(item)
+        seen.add(key)
+
+
+def iter_response_lines(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+
+    responses: list[dict[str, Any]] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        responses.append(json.loads(line))
+    return responses
+
+
+def read_failures(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+
+    failures: list[dict[str, Any]] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        batch_number, http_code = line.split("\t", 1)
+        failures.append({"batch": int(batch_number), "http_code": http_code})
+    return failures
+
+
+def aggregate_responses(
+    responses: list[dict[str, Any]],
+    failures: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    aggregate: dict[str, Any] = {
+        "success": True,
+        "issues_to_close": [],
+        "duplicate_wbs_tasks": [],
+        "repaired_wbs_tasks": [],
+        "batch_failures": [],
+    }
+    for field in SUM_FIELDS:
+        aggregate[field] = 0
+
+    seen_items = {field: set() for field in LIST_FIELDS}
+    for response in responses:
+        aggregate["success"] = aggregate["success"] and bool(response.get("success", False))
+        for field in SUM_FIELDS:
+            aggregate[field] += as_int(response.get(field))
+        for field in LIST_FIELDS:
+            extend_unique(aggregate[field], seen_items[field], response.get(field))
+
+    if failures:
+        aggregate["success"] = False
+        aggregate["batch_failures"].extend(failures)
+
+    return aggregate
+
+
+def aggregate_from_files(responses_path: Path, failures_path: Path) -> dict[str, Any]:
+    return aggregate_responses(
+        iter_response_lines(responses_path),
+        read_failures(failures_path),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--responses", type=Path, required=True)
+    parser.add_argument("--failures", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+
+    aggregate = aggregate_from_files(args.responses, args.failures)
+    output = json.dumps(aggregate, ensure_ascii=False)
+    if args.output:
+        args.output.write_text(output + "\n", encoding="utf-8")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/test_wbs_sync_aggregate.py
+++ b/test/scripts/test_wbs_sync_aggregate.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from wbs_sync_aggregate import aggregate_from_files, aggregate_responses
+
+
+class WbsSyncAggregateTest(unittest.TestCase):
+    def test_aggregates_repair_audit_fields(self) -> None:
+        repaired_task = {
+            "task_id": "task-1270-a",
+            "github_issue_number": 1270,
+            "reason": "closed issue was still in progress",
+        }
+        aggregate = aggregate_responses(
+            [
+                {
+                    "success": True,
+                    "issue_count": 2,
+                    "created": 1,
+                    "updated": 1,
+                    "completed_from_closed_issues": 1,
+                    "duplicate_wbs_closed": 0,
+                    "stale_wbs_repaired": 1,
+                    "wbs_task_scan_count": 10,
+                    "skipped": 0,
+                    "repaired_wbs_tasks": [repaired_task],
+                },
+                {
+                    "success": True,
+                    "issue_count": "3",
+                    "created": 0,
+                    "updated": 2,
+                    "completed_from_closed_issues": 0,
+                    "duplicate_wbs_closed": 1,
+                    "stale_wbs_repaired": 2,
+                    "wbs_task_scan_count": 12,
+                    "skipped": 1,
+                    "repaired_wbs_tasks": [
+                        repaired_task,
+                        {
+                            "task_id": "task-1272-b",
+                            "github_issue_number": 1272,
+                            "reason": "duplicate closed issue row",
+                        },
+                    ],
+                },
+            ]
+        )
+
+        self.assertTrue(aggregate["success"])
+        self.assertEqual(aggregate["issue_count"], 5)
+        self.assertEqual(aggregate["stale_wbs_repaired"], 3)
+        self.assertEqual(aggregate["wbs_task_scan_count"], 22)
+        self.assertEqual(len(aggregate["repaired_wbs_tasks"]), 2)
+        self.assertEqual(aggregate["repaired_wbs_tasks"][0]["task_id"], "task-1270-a")
+
+    def test_failed_batches_mark_aggregate_unsuccessful(self) -> None:
+        aggregate = aggregate_responses(
+            [{"success": True, "issue_count": 1}],
+            [{"batch": 2, "http_code": "504"}],
+        )
+
+        self.assertFalse(aggregate["success"])
+        self.assertEqual(aggregate["batch_failures"], [{"batch": 2, "http_code": "504"}])
+
+    def test_reads_workflow_temp_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            responses = base / "responses.jsonl"
+            failures = base / "failures.tsv"
+            responses.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "success": True,
+                                "issue_count": 1,
+                                "stale_wbs_repaired": 1,
+                                "wbs_task_scan_count": 4,
+                                "repaired_wbs_tasks": [{"task_id": "task-1"}],
+                            }
+                        ),
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            failures.write_text("", encoding="utf-8")
+
+            aggregate = aggregate_from_files(responses, failures)
+
+        self.assertEqual(aggregate["stale_wbs_repaired"], 1)
+        self.assertEqual(aggregate["wbs_task_scan_count"], 4)
+        self.assertEqual(aggregate["repaired_wbs_tasks"], [{"task_id": "task-1"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- Extract the WBS Issue sync batch aggregator into `scripts/wbs_sync_aggregate.py` so it can be unit tested outside the workflow.
- Preserve repair-audit fields in `/tmp/wbs-sync-response.json`: `stale_wbs_repaired`, `wbs_task_scan_count`, and merged `repaired_wbs_tasks`.
- Update `docs/WBS_GITHUB_ISSUE_SYNC_RUNBOOK.md` to match the final aggregate fields.

Closes #1692

## Minimal E2E Gate
- This is GitHub Actions aggregation behavior, not app UI/runtime behavior.
- Black-box contract: representative batch JSONL + failures TSV produce a final aggregate JSON that keeps repair counts and audit rows.
- E2E-Exception: workflow-script-only change covered by unit/smoke extraction test.

## Validation
- `python -m py_compile scripts\wbs_sync_aggregate.py`
- `$env:PYTHONPATH='.'; python test\scripts\test_wbs_sync_aggregate.py`
- `git diff --check`
