### PR TITLE
[codex] Focus Home and add Release Notes page

### DIFF
--- a/lib/data/home_system_fixed.dart
+++ b/lib/data/home_system_fixed.dart
@@ -22,7 +22,7 @@ const List<HomeFixedFeature> kHomeSystemFixed = [
     color: Color(0xFF4F46E5),
   ),
   HomeFixedFeature(
-    route: '/ai-assistant',
+    route: '/ai-secretary',
     label: 'AI秘書',
     icon: Icons.smart_toy_outlined,
     color: Color(0xFF6366F1),
@@ -44,5 +44,11 @@ const List<HomeFixedFeature> kHomeSystemFixed = [
     label: 'AI大学',
     icon: Icons.school_outlined,
     color: Color(0xFF6366F1),
+  ),
+  HomeFixedFeature(
+    route: '/release-notes',
+    label: 'Release Notes',
+    icon: Icons.new_releases_outlined,
+    color: Color(0xFF0D9488),
   ),
 ];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -214,6 +214,7 @@ import 'package:my_web_app/pages/real_estate_tracker_page.dart';
 import 'package:my_web_app/pages/spreadsheet_database_page.dart';
 import 'package:my_web_app/pages/travel_itinerary_planner_page.dart';
 import 'package:my_web_app/pages/changelog_manager_page.dart';
+import 'package:my_web_app/pages/release_notes_page.dart';
 import 'package:my_web_app/pages/pet_care_manager_page.dart';
 import 'package:my_web_app/pages/photo_gallery_manager_page.dart';
 import 'package:my_web_app/pages/elearning_course_manager_page.dart';
@@ -1333,6 +1334,10 @@ class _MyAppState extends State<MyApp> {
           case '/changelog':
             return MaterialPageRoute(
               builder: (_) => const ChangelogManagerPage(),
+            );
+          case '/release-notes':
+            return MaterialPageRoute(
+              builder: (_) => const ReleaseNotesPage(),
             );
           case '/pet-care':
             return MaterialPageRoute(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -65,6 +65,7 @@ import '../widgets/home_tier/system_fixed_features_list.dart';
 import '../widgets/home_tier/user_pinned_features_list.dart';
 import '../widgets/home_tier/new_features_list.dart';
 import '../widgets/home_tier/ai_recommended_features_list.dart';
+import '../widgets/home_tier/popular_features_list.dart';
 import '../utils/feature_tap_logger.dart';
 
 class HomePage extends StatefulWidget {
@@ -77,6 +78,8 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  static const bool _showLegacyHomeSections = false;
+
   // ✅ 改善ポイント:
   // build() のたびに _fetchTotalAssets() が走るのを防ぐため Future をキャッシュする
   late Future<String> _totalAssetsFuture;
@@ -5325,556 +5328,566 @@ abstinence_slip_details: $slipDetailsText
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            _buildHopsonInspiredHomeHero(
-                              context,
+                            ..._buildCuratedHomeSections(
                               isDark: isDark,
                               isCompact: isCompact,
-                              snapshot: opsSnapshot,
-                              nextAction: nextAction,
                             ),
-                            const SizedBox(height: 12),
-                            // AI プロバイダー API キー未設定バナー (Windows版#94)
-                            const ApiKeyStatusBanner(),
-                            const ProactiveDiagnosticsCard(),
-                            const SizedBox(height: 8),
-                            // 最上部: AI大学キラーコンテンツバナー
-                            const AiUniversityHomeCard(),
-                            const SizedBox(height: 8),
-                            // 5階層カスタマイズパネル
-                            const CollapsibleHomeSection(
-                              storageKey: 'home_tier_recent',
-                              title: '最近使った機能',
-                              icon: Icons.history,
-                              iconColor: Color(0xFFFF6B35),
-                              initiallyExpanded: true,
-                              child: RecentFeaturesList(),
-                            ),
-                            const SizedBox(height: 4),
-                            const CollapsibleHomeSection(
-                              storageKey: 'home_tier_system',
-                              title: 'システム固定機能',
-                              icon: Icons.lock_outline,
-                              iconColor: Color(0xFF6366F1),
-                              initiallyExpanded: true,
-                              child: SystemFixedFeaturesList(),
-                            ),
-                            const SizedBox(height: 4),
-                            const CollapsibleHomeSection(
-                              storageKey: 'home_tier_pinned',
-                              title: 'お気に入り (ピン留め)',
-                              icon: Icons.push_pin_outlined,
-                              iconColor: Color(0xFF6366F1),
-                              initiallyExpanded: true,
-                              child: UserPinnedFeaturesList(),
-                            ),
-                            const SizedBox(height: 4),
-                            const CollapsibleHomeSection(
-                              storageKey: 'home_tier_new',
-                              title: '最近追加された機能',
-                              icon: Icons.new_releases_outlined,
-                              iconColor: Color(0xFFFF6B35),
-                              initiallyExpanded: false,
-                              child: NewFeaturesList(),
-                            ),
-                            const SizedBox(height: 4),
-                            const CollapsibleHomeSection(
-                              storageKey: 'home_tier_recommend',
-                              title: 'AI おすすめ機能',
-                              icon: Icons.auto_awesome,
-                              iconColor: Color(0xFF6366F1),
-                              initiallyExpanded: false,
-                              child: AiRecommendedFeaturesList(),
-                            ),
-                            const SizedBox(height: 8),
-                            // AI競馬的中率リーダーボード
-                            ListTile(
-                              dense: true,
-                              leading: const Icon(
-                                Icons.leaderboard_outlined,
-                                color: Color(0xFFFF6B35),
-                                size: 20,
-                              ),
-                              title: const Text(
-                                'AI競馬 的中率リーダーボード',
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 13,
-                                  fontWeight: FontWeight.w600,
-                                  height: 1.5,
-                                ),
-                              ),
-                              subtitle: const Text(
-                                'プロバイダー別1着的中率・3連単率',
-                                style: TextStyle(
-                                  color: Color(0xFF94A3B8),
-                                  fontSize: 11,
-                                  height: 1.5,
-                                ),
-                              ),
-                              trailing: const Icon(
-                                Icons.chevron_right,
-                                size: 16,
-                                color: Color(0xFF64748B),
-                              ),
-                              onTap: () => Navigator.pushNamed(
+                            if (_showLegacyHomeSections) ...[
+                              const SizedBox(height: 40),
+                              _buildHopsonInspiredHomeHero(
                                 context,
-                                '/horse-provider-leaderboard',
+                                isDark: isDark,
+                                isCompact: isCompact,
+                                snapshot: opsSnapshot,
+                                nextAction: nextAction,
                               ),
-                            ),
-                            const SizedBox(height: 8),
-                            // ギター録音スタジオ
-                            const _GuitarMainFeatureBanner(),
-                            const SizedBox(height: 10),
-                            // 競合21社 vs 開発進捗バー (アコーディオン)
-                            const CollapsibleHomeSection(
-                              storageKey: 'home_section_growth_roadmap',
-                              title: 'GROWTH ROADMAP',
-                              icon: Icons.flag_outlined,
-                              iconColor: Color(0xFF6366F1),
-                              initiallyExpanded: false,
-                              child: GrowthRoadmapProgressCard(),
-                            ),
-                            const SizedBox(height: 12),
-                            if (WelcomeNewUserCard.shouldShow()) ...[
-                              const WelcomeNewUserCard(),
-                              const SizedBox(height: 10),
-                            ],
-                            const ProfileCompletionBanner(),
-                            const ProfileProgressCard(),
-                            const ReferralShareCard(),
-                            const SizedBox(height: 10),
-                            _buildIntegratedBriefingCard(
-                              context,
-                              isDark,
-                              isCompact,
-                              opsSnapshot,
-                            ),
-                            const _PersonalityTypeBanner(),
-                            const SizedBox(height: 10),
-                            _buildMonthlyCashflowPriorityCard(
-                              context,
-                              opsSnapshot,
-                              isHighlighted: highlightMonthlyFlow,
-                            ),
-                            const SizedBox(height: 14),
-                            _buildNextActionBubble(
-                              context,
-                              nextAction,
-                              opsSnapshot,
-                              aiNudge: aiNudge,
-                              isAiNudgeLoading: isAiLoading,
-                            ),
-                            const SizedBox(height: 14),
-                            _buildForcedTaskPanel(context, opsSnapshot),
-                            const SizedBox(height: 14),
-                            _buildCompletionGoalPanel(
-                              context,
-                              opsSnapshot,
-                              isHighlighted: highlightBeatYesterday,
-                            ),
-                            const SizedBox(height: 14),
-                            _buildAbstinenceGuardPanel(context, opsSnapshot),
-                            const SizedBox(height: 20),
-                            _buildSectionHeader(
-                              'CEO OFFICE',
-                              Icons.business_center,
-                              const Color(0xFFE53935),
-                              key: const Key('home_section_ceo_office'),
-                            ),
-                            _buildCeoCard(context),
-                            const SizedBox(height: 12),
-                            // AI 秘書カード
-                            Card(
-                              elevation: 0,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(14),
-                                side: BorderSide(
-                                  color: const Color(0xFF3D5AFE)
-                                      .withValues(alpha: 0.24),
-                                ),
+                              const SizedBox(height: 12),
+                              // AI プロバイダー API キー未設定バナー (Windows版#94)
+                              const ApiKeyStatusBanner(),
+                              const ProactiveDiagnosticsCard(),
+                              const SizedBox(height: 8),
+                              // 最上部: AI大学キラーコンテンツバナー
+                              const AiUniversityHomeCard(),
+                              const SizedBox(height: 8),
+                              // 5階層カスタマイズパネル
+                              const CollapsibleHomeSection(
+                                storageKey: 'home_tier_recent',
+                                title: '最近使った機能',
+                                icon: Icons.history,
+                                iconColor: Color(0xFFFF6B35),
+                                initiallyExpanded: true,
+                                child: RecentFeaturesList(),
                               ),
-                              child: InkWell(
-                                borderRadius: BorderRadius.circular(14),
-                                onTap: () => _runTrackedAction(
-                                  'ai-secretary',
-                                  () => Navigator.of(context).push(
-                                    MaterialPageRoute<void>(
-                                      settings: const RouteSettings(
-                                        name: '/ai-secretary',
-                                      ),
-                                      builder: (_) => const AISecretaryPage(
-                                        autoRunOnOpen: true,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                                child: Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 16,
-                                    vertical: 14,
-                                  ),
-                                  child: Row(
-                                    children: [
-                                      Container(
-                                        width: 40,
-                                        height: 40,
-                                        decoration: BoxDecoration(
-                                          color: const Color(0xFF3D5AFE)
-                                              .withValues(alpha: 0.08),
-                                          borderRadius:
-                                              BorderRadius.circular(10),
-                                        ),
-                                        child: const Icon(
-                                          Icons.support_agent,
-                                          color: Color(0xFF3D5AFE),
-                                        ),
-                                      ),
-                                      const SizedBox(width: 14),
-                                      const Expanded(
-                                        child: Column(
-                                          crossAxisAlignment:
-                                              CrossAxisAlignment.start,
-                                          children: [
-                                            Text(
-                                              'AI 秘書',
-                                              style: TextStyle(
-                                                fontWeight: FontWeight.w700,
-                                                fontSize: 14,
-                                                height: 1.5,
-                                              ),
-                                            ),
-                                            SizedBox(height: 2),
-                                            Text(
-                                              '戦略提案・全部署横断指示・本日のタスク生成',
-                                              style: TextStyle(
-                                                fontSize: 12,
-                                                height: 1.5,
-                                              ),
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                      const Icon(Icons.chevron_right),
-                                    ],
-                                  ),
-                                ),
+                              const SizedBox(height: 4),
+                              const CollapsibleHomeSection(
+                                storageKey: 'home_tier_system',
+                                title: 'システム固定機能',
+                                icon: Icons.lock_outline,
+                                iconColor: Color(0xFF6366F1),
+                                initiallyExpanded: true,
+                                child: SystemFixedFeaturesList(),
                               ),
-                            ),
-                            const SizedBox(height: 12),
-                            const TimeWasteGuardWidget(),
-                            const SizedBox(height: 12),
-                            _buildLifeWasteEliminationPanel(
-                              isDark,
-                              isCompact,
-                              opsSnapshot,
-                            ),
-                            const SizedBox(height: 12),
-                            _buildMorningBriefingCard(
-                              context,
-                              isHighlighted: highlightMorning,
-                            ),
-                            const SizedBox(height: 12),
-                            Card(
-                              elevation: 0,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(14),
-                                side: BorderSide(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .outlineVariant,
-                                ),
+                              const SizedBox(height: 4),
+                              const CollapsibleHomeSection(
+                                storageKey: 'home_tier_pinned',
+                                title: 'お気に入り (ピン留め)',
+                                icon: Icons.push_pin_outlined,
+                                iconColor: Color(0xFF6366F1),
+                                initiallyExpanded: true,
+                                child: UserPinnedFeaturesList(),
                               ),
-                              child: ListTile(
-                                leading: Container(
-                                  width: 40,
-                                  height: 40,
-                                  decoration: BoxDecoration(
-                                    color: Theme.of(context).brightness ==
-                                            Brightness.dark
-                                        ? const Color(0xFF2D2040)
-                                        : const Color(0xFFEDE7F6),
-                                    borderRadius: BorderRadius.circular(10),
-                                  ),
-                                  child: const Icon(
-                                    Icons.repeat,
-                                    color: Color(0xFF4338CA),
-                                  ),
+                              const SizedBox(height: 4),
+                              const CollapsibleHomeSection(
+                                storageKey: 'home_tier_new',
+                                title: '最近追加された機能',
+                                icon: Icons.new_releases_outlined,
+                                iconColor: Color(0xFFFF6B35),
+                                initiallyExpanded: false,
+                                child: NewFeaturesList(),
+                              ),
+                              const SizedBox(height: 4),
+                              const CollapsibleHomeSection(
+                                storageKey: 'home_tier_recommend',
+                                title: 'AI おすすめ機能',
+                                icon: Icons.auto_awesome,
+                                iconColor: Color(0xFF6366F1),
+                                initiallyExpanded: false,
+                                child: AiRecommendedFeaturesList(),
+                              ),
+                              const SizedBox(height: 8),
+                              // AI競馬的中率リーダーボード
+                              ListTile(
+                                dense: true,
+                                leading: const Icon(
+                                  Icons.leaderboard_outlined,
+                                  color: Color(0xFFFF6B35),
+                                  size: 20,
                                 ),
                                 title: const Text(
-                                  '毎日の習慣',
+                                  'AI競馬 的中率リーダーボード',
                                   style: TextStyle(
-                                    fontWeight: FontWeight.w700,
-                                    fontSize: 14,
+                                    color: Colors.white,
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
                                     height: 1.5,
                                   ),
                                 ),
                                 subtitle: const Text(
-                                  'マネフォ更新・体重記録など',
+                                  'プロバイダー別1着的中率・3連単率',
                                   style: TextStyle(
-                                    fontSize: 12,
+                                    color: Color(0xFF94A3B8),
+                                    fontSize: 11,
                                     height: 1.5,
                                   ),
                                 ),
-                                trailing: const Icon(Icons.chevron_right),
-                                onTap: () => _runTrackedAction(
-                                  'daily-habits',
-                                  () => Navigator.pushNamed(
-                                    context,
-                                    '/daily-habits',
+                                trailing: const Icon(
+                                  Icons.chevron_right,
+                                  size: 16,
+                                  color: Color(0xFF64748B),
+                                ),
+                                onTap: () => Navigator.pushNamed(
+                                  context,
+                                  '/horse-provider-leaderboard',
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              // ギター録音スタジオ
+                              const _GuitarMainFeatureBanner(),
+                              const SizedBox(height: 10),
+                              // 競合21社 vs 開発進捗バー (アコーディオン)
+                              const CollapsibleHomeSection(
+                                storageKey: 'home_section_growth_roadmap',
+                                title: 'GROWTH ROADMAP',
+                                icon: Icons.flag_outlined,
+                                iconColor: Color(0xFF6366F1),
+                                initiallyExpanded: false,
+                                child: GrowthRoadmapProgressCard(),
+                              ),
+                              const SizedBox(height: 12),
+                              if (WelcomeNewUserCard.shouldShow()) ...[
+                                const WelcomeNewUserCard(),
+                                const SizedBox(height: 10),
+                              ],
+                              const ProfileCompletionBanner(),
+                              const ProfileProgressCard(),
+                              const ReferralShareCard(),
+                              const SizedBox(height: 10),
+                              _buildIntegratedBriefingCard(
+                                context,
+                                isDark,
+                                isCompact,
+                                opsSnapshot,
+                              ),
+                              const _PersonalityTypeBanner(),
+                              const SizedBox(height: 10),
+                              _buildMonthlyCashflowPriorityCard(
+                                context,
+                                opsSnapshot,
+                                isHighlighted: highlightMonthlyFlow,
+                              ),
+                              const SizedBox(height: 14),
+                              _buildNextActionBubble(
+                                context,
+                                nextAction,
+                                opsSnapshot,
+                                aiNudge: aiNudge,
+                                isAiNudgeLoading: isAiLoading,
+                              ),
+                              const SizedBox(height: 14),
+                              _buildForcedTaskPanel(context, opsSnapshot),
+                              const SizedBox(height: 14),
+                              _buildCompletionGoalPanel(
+                                context,
+                                opsSnapshot,
+                                isHighlighted: highlightBeatYesterday,
+                              ),
+                              const SizedBox(height: 14),
+                              _buildAbstinenceGuardPanel(context, opsSnapshot),
+                              const SizedBox(height: 20),
+                              _buildSectionHeader(
+                                'CEO OFFICE',
+                                Icons.business_center,
+                                const Color(0xFFE53935),
+                                key: const Key('home_section_ceo_office'),
+                              ),
+                              _buildCeoCard(context),
+                              const SizedBox(height: 12),
+                              // AI 秘書カード
+                              Card(
+                                elevation: 0,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(14),
+                                  side: BorderSide(
+                                    color: const Color(0xFF3D5AFE)
+                                        .withValues(alpha: 0.24),
+                                  ),
+                                ),
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(14),
+                                  onTap: () => _runTrackedAction(
+                                    'ai-secretary',
+                                    () => Navigator.of(context).push(
+                                      MaterialPageRoute<void>(
+                                        settings: const RouteSettings(
+                                          name: '/ai-secretary',
+                                        ),
+                                        builder: (_) => const AISecretaryPage(
+                                          autoRunOnOpen: true,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                  child: Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 16,
+                                      vertical: 14,
+                                    ),
+                                    child: Row(
+                                      children: [
+                                        Container(
+                                          width: 40,
+                                          height: 40,
+                                          decoration: BoxDecoration(
+                                            color: const Color(0xFF3D5AFE)
+                                                .withValues(alpha: 0.08),
+                                            borderRadius:
+                                                BorderRadius.circular(10),
+                                          ),
+                                          child: const Icon(
+                                            Icons.support_agent,
+                                            color: Color(0xFF3D5AFE),
+                                          ),
+                                        ),
+                                        const SizedBox(width: 14),
+                                        const Expanded(
+                                          child: Column(
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
+                                            children: [
+                                              Text(
+                                                'AI 秘書',
+                                                style: TextStyle(
+                                                  fontWeight: FontWeight.w700,
+                                                  fontSize: 14,
+                                                  height: 1.5,
+                                                ),
+                                              ),
+                                              SizedBox(height: 2),
+                                              Text(
+                                                '戦略提案・全部署横断指示・本日のタスク生成',
+                                                style: TextStyle(
+                                                  fontSize: 12,
+                                                  height: 1.5,
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                        const Icon(Icons.chevron_right),
+                                      ],
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                            const SizedBox(height: 24),
-                            _buildSectionHeader(
-                              'OFFICE KPI SNAPSHOT',
-                              Icons.space_dashboard,
-                              const Color(0xFF3D5AFE),
-                              key: const Key('home_section_office_kpi_summary'),
-                            ),
-                            _buildOfficeKpiSummary(
-                              context,
-                              isDark,
-                              isCompact,
-                              opsSnapshot,
-                            ),
-                            const SizedBox(height: 24),
-                            _buildSectionHeader(
-                              'AI FEATURE STRATEGY MONITOR',
-                              Icons.auto_graph,
-                              const Color(0xFF7C3AED),
-                              key: const Key(
-                                'home_section_feature_strategy_monitor',
+                              const SizedBox(height: 12),
+                              const TimeWasteGuardWidget(),
+                              const SizedBox(height: 12),
+                              _buildLifeWasteEliminationPanel(
+                                isDark,
+                                isCompact,
+                                opsSnapshot,
                               ),
-                            ),
-                            _buildFeatureStrategyMonitor(isDark, isCompact),
-                            const SizedBox(height: 24),
-                            _buildSectionHeader(
-                              'SITE GUIDE AI',
-                              Icons.support_agent_outlined,
-                              const Color(0xFF4F46E5),
-                              key: const Key('home_section_site_guide_ai'),
-                            ),
-                            _buildSiteGuideAiCard(isDark, isCompact),
-                            const SizedBox(height: 24),
-                            _buildSectionHeader(
-                              '追加要望フォーム',
-                              Icons.add_task_outlined,
-                              const Color(0xFF0F766E),
-                              key: const Key('home_section_feature_request'),
-                            ),
-                            _buildHomeFeatureRequestForm(isDark, isCompact),
-                            const SizedBox(height: 24),
-                            _buildSectionHeader(
-                              'KPI SUMMARY',
-                              Icons.show_chart,
-                              const Color(0xFF3D5AFE),
-                            ),
-                            _buildKpiSummary(
-                              context,
-                              isDark,
-                              isCompact,
-                              opsSnapshot,
-                            ),
-                            const SizedBox(height: 24),
-                            _buildSectionHeader(
-                              'OPERATIONS CALENDAR',
-                              Icons.calendar_month,
-                              const Color(0xFFB0B0B0),
-                              key:
-                                  const Key('home_section_operations_calendar'),
-                            ),
-                            _buildCalendarPanel(context, opsSnapshot),
-                            const SizedBox(height: 24),
-                            _buildSectionHeader(
-                              'SPECIAL PROJECT',
-                              Icons.rocket_launch,
-                              const Color(0xFF3D5AFE),
-                            ),
-                            Card(
-                              elevation: 6,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16),
+                              const SizedBox(height: 12),
+                              _buildMorningBriefingCard(
+                                context,
+                                isHighlighted: highlightMorning,
                               ),
-                              color: Colors.transparent,
-                              child: Ink(
-                                decoration: BoxDecoration(
-                                  gradient: const LinearGradient(
-                                    begin: Alignment.topLeft,
-                                    end: Alignment.bottomRight,
-                                    colors: [
-                                      Color(0xFF3F46CC),
-                                      Color(0xFF4F46E5),
-                                    ],
+                              const SizedBox(height: 12),
+                              Card(
+                                elevation: 0,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(14),
+                                  side: BorderSide(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .outlineVariant,
                                   ),
-                                  borderRadius: BorderRadius.circular(16),
-                                  boxShadow: const [
-                                    BoxShadow(
-                                      color: Color(0x403D5AFE),
-                                      blurRadius: 18,
-                                      offset: Offset(0, 8),
-                                    ),
-                                  ],
                                 ),
                                 child: ListTile(
-                                  contentPadding: const EdgeInsets.symmetric(
-                                    horizontal: 20,
-                                    vertical: 16,
-                                  ),
-                                  leading: const CircleAvatar(
-                                    backgroundColor: Colors.white,
-                                    radius: 28,
-                                    child: Icon(
-                                      Icons.campaign,
-                                      color: Color(0xFF3D5AFE),
-                                      size: 30,
+                                  leading: Container(
+                                    width: 40,
+                                    height: 40,
+                                    decoration: BoxDecoration(
+                                      color: Theme.of(context).brightness ==
+                                              Brightness.dark
+                                          ? const Color(0xFF2D2040)
+                                          : const Color(0xFFEDE7F6),
+                                      borderRadius: BorderRadius.circular(10),
+                                    ),
+                                    child: const Icon(
+                                      Icons.repeat,
+                                      color: Color(0xFF4338CA),
                                     ),
                                   ),
                                   title: const Text(
-                                    '2026 衆院選 勝利戦略室',
+                                    '毎日の習慣',
                                     style: TextStyle(
-                                      fontWeight: FontWeight.bold,
-                                      fontSize: 16,
-                                      color: Colors.white,
+                                      fontWeight: FontWeight.w700,
+                                      fontSize: 14,
                                       height: 1.5,
                                     ),
                                   ),
-                                  subtitle: Text(
-                                    'AI参謀と連携し、地域特性を踏まえた勝利戦略を立案します。',
+                                  subtitle: const Text(
+                                    'マネフォ更新・体重記録など',
                                     style: TextStyle(
-                                      color:
-                                          Colors.white.withValues(alpha: 0.7),
+                                      fontSize: 12,
                                       height: 1.5,
                                     ),
                                   ),
-                                  trailing: const Icon(
-                                    Icons.arrow_forward_ios,
-                                    size: 16,
-                                    color: Colors.white,
-                                  ),
+                                  trailing: const Icon(Icons.chevron_right),
                                   onTap: () => _runTrackedAction(
-                                    'election-strategy',
-                                    () => Navigator.of(context)
-                                        .pushNamed('/election-strategy'),
+                                    'daily-habits',
+                                    () => Navigator.pushNamed(
+                                      context,
+                                      '/daily-habits',
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                            const SizedBox(height: 12),
-                            Card(
-                              elevation: 6,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16),
+                              const SizedBox(height: 24),
+                              _buildSectionHeader(
+                                'OFFICE KPI SNAPSHOT',
+                                Icons.space_dashboard,
+                                const Color(0xFF3D5AFE),
+                                key: const Key(
+                                  'home_section_office_kpi_summary',
+                                ),
                               ),
-                              color: Colors.transparent,
-                              child: Ink(
-                                decoration: BoxDecoration(
-                                  gradient: const LinearGradient(
-                                    begin: Alignment.topLeft,
-                                    end: Alignment.bottomRight,
-                                    colors: [
-                                      Color(0xFF0F766E),
-                                      Color(0xFF16A34A),
+                              _buildOfficeKpiSummary(
+                                context,
+                                isDark,
+                                isCompact,
+                                opsSnapshot,
+                              ),
+                              const SizedBox(height: 24),
+                              _buildSectionHeader(
+                                'AI FEATURE STRATEGY MONITOR',
+                                Icons.auto_graph,
+                                const Color(0xFF7C3AED),
+                                key: const Key(
+                                  'home_section_feature_strategy_monitor',
+                                ),
+                              ),
+                              _buildFeatureStrategyMonitor(isDark, isCompact),
+                              const SizedBox(height: 24),
+                              _buildSectionHeader(
+                                'SITE GUIDE AI',
+                                Icons.support_agent_outlined,
+                                const Color(0xFF4F46E5),
+                                key: const Key('home_section_site_guide_ai'),
+                              ),
+                              _buildSiteGuideAiCard(isDark, isCompact),
+                              const SizedBox(height: 24),
+                              _buildSectionHeader(
+                                '追加要望フォーム',
+                                Icons.add_task_outlined,
+                                const Color(0xFF0F766E),
+                                key: const Key('home_section_feature_request'),
+                              ),
+                              _buildHomeFeatureRequestForm(isDark, isCompact),
+                              const SizedBox(height: 24),
+                              _buildSectionHeader(
+                                'KPI SUMMARY',
+                                Icons.show_chart,
+                                const Color(0xFF3D5AFE),
+                              ),
+                              _buildKpiSummary(
+                                context,
+                                isDark,
+                                isCompact,
+                                opsSnapshot,
+                              ),
+                              const SizedBox(height: 24),
+                              _buildSectionHeader(
+                                'OPERATIONS CALENDAR',
+                                Icons.calendar_month,
+                                const Color(0xFFB0B0B0),
+                                key: const Key(
+                                  'home_section_operations_calendar',
+                                ),
+                              ),
+                              _buildCalendarPanel(context, opsSnapshot),
+                              const SizedBox(height: 24),
+                              _buildSectionHeader(
+                                'SPECIAL PROJECT',
+                                Icons.rocket_launch,
+                                const Color(0xFF3D5AFE),
+                              ),
+                              Card(
+                                elevation: 6,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                                color: Colors.transparent,
+                                child: Ink(
+                                  decoration: BoxDecoration(
+                                    gradient: const LinearGradient(
+                                      begin: Alignment.topLeft,
+                                      end: Alignment.bottomRight,
+                                      colors: [
+                                        Color(0xFF3F46CC),
+                                        Color(0xFF4F46E5),
+                                      ],
+                                    ),
+                                    borderRadius: BorderRadius.circular(16),
+                                    boxShadow: const [
+                                      BoxShadow(
+                                        color: Color(0x403D5AFE),
+                                        blurRadius: 18,
+                                        offset: Offset(0, 8),
+                                      ),
                                     ],
                                   ),
-                                  borderRadius: BorderRadius.circular(16),
-                                  boxShadow: const [
-                                    BoxShadow(
-                                      color: Color(0x404CAF50),
-                                      blurRadius: 18,
-                                      offset: Offset(0, 8),
+                                  child: ListTile(
+                                    contentPadding: const EdgeInsets.symmetric(
+                                      horizontal: 20,
+                                      vertical: 16,
                                     ),
-                                  ],
-                                ),
-                                child: ListTile(
-                                  contentPadding: const EdgeInsets.symmetric(
-                                    horizontal: 20,
-                                    vertical: 16,
-                                  ),
-                                  leading: const CircleAvatar(
-                                    backgroundColor: Colors.white,
-                                    radius: 28,
-                                    child: Icon(
-                                      Icons.how_to_vote,
-                                      color: Color(0xFF4CAF50),
-                                      size: 30,
+                                    leading: const CircleAvatar(
+                                      backgroundColor: Colors.white,
+                                      radius: 28,
+                                      child: Icon(
+                                        Icons.campaign,
+                                        color: Color(0xFF3D5AFE),
+                                        size: 30,
+                                      ),
                                     ),
-                                  ),
-                                  title: const Text(
-                                    '2027 統一地方選 700必達管理室',
-                                    style: TextStyle(
-                                      fontWeight: FontWeight.bold,
-                                      fontSize: 16,
+                                    title: const Text(
+                                      '2026 衆院選 勝利戦略室',
+                                      style: TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                        fontSize: 16,
+                                        color: Colors.white,
+                                        height: 1.5,
+                                      ),
+                                    ),
+                                    subtitle: Text(
+                                      'AI参謀と連携し、地域特性を踏まえた勝利戦略を立案します。',
+                                      style: TextStyle(
+                                        color:
+                                            Colors.white.withValues(alpha: 0.7),
+                                        height: 1.5,
+                                      ),
+                                    ),
+                                    trailing: const Icon(
+                                      Icons.arrow_forward_ios,
+                                      size: 16,
                                       color: Colors.white,
-                                      height: 1.5,
                                     ),
-                                  ),
-                                  subtitle: Text(
-                                    '県連別の純増配分と月次KPIをまとめて管理し、'
-                                    '未配分ギャップや公認内定の遅れを可視化します。',
-                                    style: TextStyle(
-                                      color:
-                                          Colors.white.withValues(alpha: 0.7),
-                                      height: 1.5,
+                                    onTap: () => _runTrackedAction(
+                                      'election-strategy',
+                                      () => Navigator.of(context)
+                                          .pushNamed('/election-strategy'),
                                     ),
-                                  ),
-                                  trailing: const Icon(
-                                    Icons.arrow_forward_ios,
-                                    size: 16,
-                                    color: Colors.white,
-                                  ),
-                                  onTap: () => _runTrackedAction(
-                                    'local-election-700',
-                                    () => Navigator.of(context)
-                                        .pushNamed('/local-election-700'),
                                   ),
                                 ),
                               ),
-                            ),
-                            const SizedBox(height: 24),
-                            _buildSectionHeader(
-                              'QUICK ACCESS',
-                              Icons.dashboard_customize,
-                              const Color(0xFF3D5AFE),
-                            ),
-                            _buildQuickAccessMenu(
-                              context,
-                              isCompact,
-                              shouldLockExploratoryMenus:
-                                  shouldLockExploratoryMenus,
-                              highlightedToolIds: highlightedToolIds,
-                              badgeLabels: toolBadgeLabels,
-                            ),
-                            const SizedBox(height: 24),
-                            _buildSectionHeader(
-                              'RECENT TOOLS',
-                              Icons.history,
-                              const Color(0xFF3D5AFE),
-                            ),
-                            _buildRecentToolsMenu(context, isCompact),
-                            const SizedBox(height: 16),
-                            // 開発・成長実績 (アコーディオン / 初期折りたたみ)
-                            const CollapsibleHomeSection(
-                              storageKey: 'home_section_dev_achievements',
-                              title: '開発・成長実績',
-                              icon: Icons.bar_chart,
-                              iconColor: Color(0xFF10B981),
-                              initiallyExpanded: false,
-                              child: DevelopmentAchievementsCard(),
-                            ),
-                            const SizedBox(height: 12),
-                            // Edge Functions 実装状況 (アコーディオン / 初期折りたたみ)
-                            const CollapsibleHomeSection(
-                              storageKey: 'home_section_edge_functions',
-                              title: 'Edge Functions 実装状況',
-                              icon: Icons.bolt_outlined,
-                              iconColor: Color(0xFF6366F1),
-                              initiallyExpanded: false,
-                              child: EdgeFunctionSummaryCard(),
-                            ),
-                            const SizedBox(height: 16),
-                            _buildUiStatusButton(context),
-                            const SizedBox(height: 40),
+                              const SizedBox(height: 12),
+                              Card(
+                                elevation: 6,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                                color: Colors.transparent,
+                                child: Ink(
+                                  decoration: BoxDecoration(
+                                    gradient: const LinearGradient(
+                                      begin: Alignment.topLeft,
+                                      end: Alignment.bottomRight,
+                                      colors: [
+                                        Color(0xFF0F766E),
+                                        Color(0xFF16A34A),
+                                      ],
+                                    ),
+                                    borderRadius: BorderRadius.circular(16),
+                                    boxShadow: const [
+                                      BoxShadow(
+                                        color: Color(0x404CAF50),
+                                        blurRadius: 18,
+                                        offset: Offset(0, 8),
+                                      ),
+                                    ],
+                                  ),
+                                  child: ListTile(
+                                    contentPadding: const EdgeInsets.symmetric(
+                                      horizontal: 20,
+                                      vertical: 16,
+                                    ),
+                                    leading: const CircleAvatar(
+                                      backgroundColor: Colors.white,
+                                      radius: 28,
+                                      child: Icon(
+                                        Icons.how_to_vote,
+                                        color: Color(0xFF4CAF50),
+                                        size: 30,
+                                      ),
+                                    ),
+                                    title: const Text(
+                                      '2027 統一地方選 700必達管理室',
+                                      style: TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                        fontSize: 16,
+                                        color: Colors.white,
+                                        height: 1.5,
+                                      ),
+                                    ),
+                                    subtitle: Text(
+                                      '県連別の純増配分と月次KPIをまとめて管理し、'
+                                      '未配分ギャップや公認内定の遅れを可視化します。',
+                                      style: TextStyle(
+                                        color:
+                                            Colors.white.withValues(alpha: 0.7),
+                                        height: 1.5,
+                                      ),
+                                    ),
+                                    trailing: const Icon(
+                                      Icons.arrow_forward_ios,
+                                      size: 16,
+                                      color: Colors.white,
+                                    ),
+                                    onTap: () => _runTrackedAction(
+                                      'local-election-700',
+                                      () => Navigator.of(context)
+                                          .pushNamed('/local-election-700'),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(height: 24),
+                              _buildSectionHeader(
+                                'QUICK ACCESS',
+                                Icons.dashboard_customize,
+                                const Color(0xFF3D5AFE),
+                              ),
+                              _buildQuickAccessMenu(
+                                context,
+                                isCompact,
+                                shouldLockExploratoryMenus:
+                                    shouldLockExploratoryMenus,
+                                highlightedToolIds: highlightedToolIds,
+                                badgeLabels: toolBadgeLabels,
+                              ),
+                              const SizedBox(height: 24),
+                              _buildSectionHeader(
+                                'RECENT TOOLS',
+                                Icons.history,
+                                const Color(0xFF3D5AFE),
+                              ),
+                              _buildRecentToolsMenu(context, isCompact),
+                              const SizedBox(height: 16),
+                              // 開発・成長実績 (アコーディオン / 初期折りたたみ)
+                              const CollapsibleHomeSection(
+                                storageKey: 'home_section_dev_achievements',
+                                title: '開発・成長実績',
+                                icon: Icons.bar_chart,
+                                iconColor: Color(0xFF10B981),
+                                initiallyExpanded: false,
+                                child: DevelopmentAchievementsCard(),
+                              ),
+                              const SizedBox(height: 12),
+                              // Edge Functions 実装状況 (アコーディオン / 初期折りたたみ)
+                              const CollapsibleHomeSection(
+                                storageKey: 'home_section_edge_functions',
+                                title: 'Edge Functions 実装状況',
+                                icon: Icons.bolt_outlined,
+                                iconColor: Color(0xFF6366F1),
+                                initiallyExpanded: false,
+                                child: EdgeFunctionSummaryCard(),
+                              ),
+                              const SizedBox(height: 16),
+                              _buildUiStatusButton(context),
+                              const SizedBox(height: 40),
+                            ],
                           ],
                         ),
                       ),
@@ -5907,6 +5920,81 @@ abstinence_slip_details: $slipDetailsText
     if (page is ElectionStrategyPage) return '/election-strategy';
     if (page is ElectionVictoryPage) return '/local-election-700';
     return null;
+  }
+
+  List<Widget> _buildCuratedHomeSections({
+    required bool isDark,
+    required bool isCompact,
+  }) {
+    return [
+      _buildSectionHeader(
+        'SITE GUIDE AI',
+        Icons.support_agent_outlined,
+        const Color(0xFF4F46E5),
+        key: const Key('home_section_site_guide_ai'),
+      ),
+      _buildSiteGuideAiCard(isDark, isCompact),
+      const SizedBox(height: 16),
+      const CollapsibleHomeSection(
+        key: Key('home_tier_recent'),
+        storageKey: 'home_tier_recent',
+        title: '最近使った機能',
+        icon: Icons.history,
+        iconColor: Color(0xFFFF6B35),
+        initiallyExpanded: true,
+        child: RecentFeaturesList(),
+      ),
+      const SizedBox(height: 4),
+      const CollapsibleHomeSection(
+        key: Key('home_tier_popular'),
+        storageKey: 'home_tier_popular',
+        title: 'よく使われる機能（ユーザー全体）',
+        icon: Icons.trending_up,
+        iconColor: Color(0xFF0D9488),
+        initiallyExpanded: true,
+        child: PopularFeaturesList(),
+      ),
+      const SizedBox(height: 4),
+      const CollapsibleHomeSection(
+        key: Key('home_tier_system'),
+        storageKey: 'home_tier_system',
+        title: 'システム固定機能',
+        icon: Icons.lock_outline,
+        iconColor: Color(0xFF6366F1),
+        initiallyExpanded: true,
+        child: SystemFixedFeaturesList(),
+      ),
+      const SizedBox(height: 4),
+      const CollapsibleHomeSection(
+        key: Key('home_tier_pinned'),
+        storageKey: 'home_tier_pinned',
+        title: 'お気に入り（ピン止め）',
+        icon: Icons.push_pin_outlined,
+        iconColor: Color(0xFF6366F1),
+        initiallyExpanded: true,
+        child: UserPinnedFeaturesList(),
+      ),
+      const SizedBox(height: 4),
+      const CollapsibleHomeSection(
+        key: Key('home_tier_new'),
+        storageKey: 'home_tier_new',
+        title: '最近追加された機能',
+        icon: Icons.new_releases_outlined,
+        iconColor: Color(0xFFFF6B35),
+        initiallyExpanded: true,
+        child: NewFeaturesList(),
+      ),
+      const SizedBox(height: 4),
+      const CollapsibleHomeSection(
+        key: Key('home_tier_recommend'),
+        storageKey: 'home_tier_recommend',
+        title: 'AIおすすめ機能',
+        icon: Icons.auto_awesome,
+        iconColor: Color(0xFF6366F1),
+        initiallyExpanded: true,
+        child: AiRecommendedFeaturesList(),
+      ),
+    ];
   }
 
   Widget _buildUiStatusButton(BuildContext context) {

--- a/lib/pages/release_notes_page.dart
+++ b/lib/pages/release_notes_page.dart
@@ -1,0 +1,452 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:url_launcher/url_launcher.dart';
+
+import '../core/app_version.dart';
+
+class ReleaseNoteLink {
+  final String type;
+  final String title;
+  final String url;
+
+  const ReleaseNoteLink({
+    required this.type,
+    required this.title,
+    required this.url,
+  });
+
+  factory ReleaseNoteLink.fromJson(Map<String, dynamic> json) {
+    return ReleaseNoteLink(
+      type: json['type']?.toString() ?? 'link',
+      title: json['title']?.toString() ?? json['type']?.toString() ?? 'Link',
+      url: json['url']?.toString() ?? '',
+    );
+  }
+}
+
+class ReleaseNoteChange {
+  final String category;
+  final String summary;
+  final List<ReleaseNoteLink> links;
+
+  const ReleaseNoteChange({
+    required this.category,
+    required this.summary,
+    this.links = const [],
+  });
+
+  factory ReleaseNoteChange.fromJson(Map<String, dynamic> json) {
+    return ReleaseNoteChange(
+      category: json['category']?.toString() ?? 'change',
+      summary: json['summary']?.toString() ?? '',
+      links: _parseLinks(json['links']),
+    );
+  }
+}
+
+class ReleaseNoteVersion {
+  final String version;
+  final String build;
+  final String date;
+  final String category;
+  final String summary;
+  final List<ReleaseNoteLink> links;
+  final List<ReleaseNoteChange> changes;
+
+  const ReleaseNoteVersion({
+    required this.version,
+    required this.build,
+    required this.date,
+    required this.category,
+    required this.summary,
+    this.links = const [],
+    this.changes = const [],
+  });
+
+  factory ReleaseNoteVersion.fromJson(Map<String, dynamic> json) {
+    return ReleaseNoteVersion(
+      version: json['version']?.toString() ?? 'dev',
+      build: json['build']?.toString() ?? '',
+      date: json['date']?.toString() ?? '',
+      category: json['category']?.toString() ?? 'release',
+      summary: json['summary']?.toString() ?? '',
+      links: _parseLinks(json['links']),
+      changes: (json['changes'] as List? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(ReleaseNoteChange.fromJson)
+          .toList(growable: false),
+    );
+  }
+
+  String get versionLabel {
+    if (build.isEmpty || build == '0') return 'v$version';
+    return 'v$version (build $build)';
+  }
+
+  String get searchableText {
+    return [
+      version,
+      build,
+      date,
+      category,
+      summary,
+      ...links.map((link) => '${link.type} ${link.title} ${link.url}'),
+      ...changes.map(
+        (change) => '${change.category} ${change.summary} '
+            '${change.links.map((link) => link.title).join(' ')}',
+      ),
+    ].join(' ').toLowerCase();
+  }
+}
+
+class ReleaseNotesDocument {
+  final String generatedAt;
+  final ReleaseNoteVersion current;
+  final List<ReleaseNoteVersion> versions;
+
+  const ReleaseNotesDocument({
+    required this.generatedAt,
+    required this.current,
+    required this.versions,
+  });
+
+  factory ReleaseNotesDocument.fromJson(Map<String, dynamic> json) {
+    final currentJson = json['current'] as Map<String, dynamic>? ?? {};
+    final versions = (json['versions'] as List? ?? const [])
+        .whereType<Map<String, dynamic>>()
+        .map(ReleaseNoteVersion.fromJson)
+        .toList(growable: false);
+    final current = ReleaseNoteVersion.fromJson(currentJson);
+    return ReleaseNotesDocument(
+      generatedAt: json['generatedAt']?.toString() ?? '',
+      current: current,
+      versions: versions.isEmpty ? [current] : versions,
+    );
+  }
+}
+
+class ReleaseNotesPage extends StatefulWidget {
+  final ReleaseNotesDocument? initialDocument;
+
+  const ReleaseNotesPage({
+    super.key,
+    this.initialDocument,
+  });
+
+  @override
+  State<ReleaseNotesPage> createState() => _ReleaseNotesPageState();
+}
+
+class _ReleaseNotesPageState extends State<ReleaseNotesPage> {
+  final TextEditingController _searchController = TextEditingController();
+  ReleaseNotesDocument? _document;
+  String _query = '';
+  String? _selectedVersion;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    final initialDocument = widget.initialDocument;
+    if (initialDocument != null) {
+      _document = initialDocument;
+      _selectedVersion = initialDocument.current.version;
+      _loading = false;
+    } else {
+      _load();
+    }
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load({bool refresh = false}) async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final cacheKey = refresh
+          ? DateTime.now().millisecondsSinceEpoch.toString()
+          : 'startup';
+      final response = await http.get(
+        Uri.base.resolve('release-notes.json?t=$cacheKey'),
+        headers: const {'Cache-Control': 'no-cache'},
+      );
+      if (response.statusCode != 200) {
+        throw StateError('HTTP ${response.statusCode}');
+      }
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('release-notes.json root must be object');
+      }
+      final document = ReleaseNotesDocument.fromJson(decoded);
+      if (!mounted) return;
+      setState(() {
+        _document = document;
+        _selectedVersion = document.current.version;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final document = _document;
+    final versions = _filteredVersions(document?.versions ?? const []);
+    final selected = _selectedVersionFor(versions, document?.current);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Release Notes'),
+        actions: [
+          IconButton(
+            tooltip: '再読み込み',
+            icon: const Icon(Icons.refresh),
+            onPressed: () => _load(refresh: true),
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : document == null
+              ? _buildError(theme)
+              : ListView(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+                  children: [
+                    _buildCurrentSummary(theme, document.current),
+                    const SizedBox(height: 12),
+                    TextField(
+                      key: const Key('release_notes_search_field'),
+                      controller: _searchController,
+                      decoration: const InputDecoration(
+                        prefixIcon: Icon(Icons.search),
+                        labelText: 'バージョン、PR、カテゴリで検索',
+                        border: OutlineInputBorder(),
+                      ),
+                      onChanged: (value) => setState(() => _query = value),
+                    ),
+                    const SizedBox(height: 16),
+                    if (_error != null) _buildInlineWarning(theme),
+                    _buildVersionChips(versions),
+                    const SizedBox(height: 16),
+                    if (selected == null)
+                      const Center(child: Text('該当するRelease Notesがありません'))
+                    else
+                      _buildVersionDetail(theme, selected),
+                  ],
+                ),
+    );
+  }
+
+  Widget _buildCurrentSummary(ThemeData theme, ReleaseNoteVersion current) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer.withValues(alpha: 0.45),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: theme.colorScheme.primary.withValues(alpha: 0.2),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.new_releases_outlined),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    current.versionLabel,
+                    key: const Key('release_notes_current_version'),
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+                Text(AppVersion.display, style: theme.textTheme.labelMedium),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(current.summary),
+            if (current.date.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Text('Date: ${current.date}', style: theme.textTheme.bodySmall),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInlineWarning(ThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Text(
+        'release-notes.jsonを読み込めませんでした: $_error',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildError(ThemeData theme) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, color: theme.colorScheme.error, size: 40),
+            const SizedBox(height: 12),
+            Text(_error ?? 'Release Notesを読み込めませんでした'),
+            const SizedBox(height: 12),
+            FilledButton.icon(
+              onPressed: () => _load(refresh: true),
+              icon: const Icon(Icons.refresh),
+              label: const Text('再読み込み'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVersionChips(List<ReleaseNoteVersion> versions) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: versions.map((version) {
+        final selected = version.version == _selectedVersion;
+        return ChoiceChip(
+          key: Key('release_notes_version_${version.version}'),
+          label: Text(version.versionLabel),
+          selected: selected,
+          onSelected: (_) => setState(() => _selectedVersion = version.version),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildVersionDetail(ThemeData theme, ReleaseNoteVersion version) {
+    return Card(
+      key: const Key('release_notes_detail_card'),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              version.versionLabel,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text('${version.category} / ${version.date}'),
+            const SizedBox(height: 12),
+            Text(version.summary),
+            const SizedBox(height: 12),
+            _buildLinks(version.links),
+            const Divider(height: 28),
+            Text('Changes', style: theme.textTheme.titleSmall),
+            const SizedBox(height: 8),
+            if (version.changes.isEmpty)
+              const Text('このバージョンの個別変更リンクはまだありません。')
+            else
+              ...version.changes.map(_buildChangeTile),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChangeTile(ReleaseNoteChange change) {
+    return ListTile(
+      dense: true,
+      contentPadding: EdgeInsets.zero,
+      leading: CircleAvatar(
+        radius: 14,
+        child: Text(
+          change.category.isEmpty ? '?' : change.category[0].toUpperCase(),
+          style: const TextStyle(fontSize: 11),
+        ),
+      ),
+      title: Text(change.summary),
+      subtitle: change.links.isEmpty ? null : _buildLinks(change.links),
+    );
+  }
+
+  Widget _buildLinks(List<ReleaseNoteLink> links) {
+    if (links.isEmpty) return const SizedBox.shrink();
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: links.map((link) {
+        return OutlinedButton.icon(
+          onPressed: () => _openLink(link.url),
+          icon: const Icon(Icons.open_in_new, size: 16),
+          label: Text(link.title),
+        );
+      }).toList(),
+    );
+  }
+
+  List<ReleaseNoteVersion> _filteredVersions(
+    List<ReleaseNoteVersion> versions,
+  ) {
+    final query = _query.trim().toLowerCase();
+    if (query.isEmpty) return versions;
+    return versions
+        .where((version) => version.searchableText.contains(query))
+        .toList(growable: false);
+  }
+
+  ReleaseNoteVersion? _selectedVersionFor(
+    List<ReleaseNoteVersion> versions,
+    ReleaseNoteVersion? current,
+  ) {
+    if (versions.isEmpty) return null;
+    final selected = _selectedVersion;
+    if (selected != null) {
+      for (final version in versions) {
+        if (version.version == selected) return version;
+      }
+    }
+    if (current != null && versions.any((v) => v.version == current.version)) {
+      return current;
+    }
+    return versions.first;
+  }
+
+  Future<void> _openLink(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    await launchUrl(uri, webOnlyWindowName: '_blank');
+  }
+}
+
+List<ReleaseNoteLink> _parseLinks(Object? value) {
+  if (value is! List) return const [];
+  return value
+      .whereType<Map<String, dynamic>>()
+      .map(ReleaseNoteLink.fromJson)
+      .where((link) => link.url.isNotEmpty)
+      .toList(growable: false);
+}

--- a/lib/widgets/collapsible_home_section.dart
+++ b/lib/widgets/collapsible_home_section.dart
@@ -46,6 +46,18 @@ class _CollapsibleHomeSectionState extends State<CollapsibleHomeSection>
   bool? _expanded;
   late final AnimationController _anim;
 
+  String get _effectiveTitle {
+    return switch (widget.storageKey) {
+      'home_tier_recent' => '最近使った機能',
+      'home_tier_popular' => 'よく使われる機能（ユーザー全体）',
+      'home_tier_system' => 'システム固定機能',
+      'home_tier_pinned' => 'お気に入り（ピン止め）',
+      'home_tier_new' => '最近追加された機能',
+      'home_tier_recommend' => 'AIおすすめ機能',
+      _ => widget.title,
+    };
+  }
+
   @override
   void initState() {
     super.initState();
@@ -123,7 +135,7 @@ class _CollapsibleHomeSectionState extends State<CollapsibleHomeSection>
                   ],
                   Expanded(
                     child: Text(
-                      widget.title,
+                      _effectiveTitle,
                       style: TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w700,

--- a/lib/widgets/global_header_clock_bar.dart
+++ b/lib/widgets/global_header_clock_bar.dart
@@ -142,8 +142,8 @@ class _GlobalHeaderClockBarState extends State<GlobalHeaderClockBar> {
                           child: InkWell(
                             key: const Key('global_header_version_badge'),
                             borderRadius: BorderRadius.circular(10),
-                            onTap: () =>
-                                Navigator.of(context).pushNamed('/settings'),
+                            onTap: () => Navigator.of(context)
+                                .pushNamed('/release-notes'),
                             child: Container(
                               padding: const EdgeInsets.symmetric(
                                 horizontal: 8,

--- a/lib/widgets/home_tier/ai_recommended_features_list.dart
+++ b/lib/widgets/home_tier/ai_recommended_features_list.dart
@@ -10,6 +10,24 @@ class AiRecommendedFeaturesList extends StatefulWidget {
 }
 
 class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
+  static const List<Map<String, dynamic>> _fallbackItems = [
+    {
+      'feature_route': '/site-guide-ai',
+      'label': 'サイト案内AI',
+      'reason': '目的に近い入口をAIに案内してもらえます。',
+    },
+    {
+      'feature_route': '/release-notes',
+      'label': 'Release Notes',
+      'reason': '最近追加された機能や修正をバージョン別に確認できます。',
+    },
+    {
+      'feature_route': '/ai-university',
+      'label': 'AI大学',
+      'reason': '最新AIツールの学習とランキング確認を続けられます。',
+    },
+  ];
+
   List<Map<String, dynamic>> _items = [];
   bool _loading = true;
   String? _error;
@@ -23,7 +41,10 @@ class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
   Future<void> _load() async {
     final user = Supabase.instance.client.auth.currentUser;
     if (user == null) {
-      setState(() => _loading = false);
+      setState(() {
+        _items = _fallbackItems;
+        _loading = false;
+      });
       return;
     }
     try {
@@ -35,7 +56,8 @@ class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
       final items = data?['recommendations'] as List<dynamic>? ?? [];
       if (mounted) {
         setState(() {
-          _items = items.cast<Map<String, dynamic>>();
+          _items = items.whereType<Map<String, dynamic>>().toList();
+          if (_items.isEmpty) _items = _fallbackItems;
           _loading = false;
         });
       }
@@ -43,6 +65,7 @@ class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
       if (mounted) {
         setState(() {
           _error = e.toString();
+          _items = _fallbackItems;
           _loading = false;
         });
       }
@@ -63,7 +86,7 @@ class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
             ),
             SizedBox(width: 10),
             Text(
-              'AIがあなたにおすすめの機能を分析中...',
+              'AIがおすすめ機能を分析中...',
               style: TextStyle(
                 color: Color(0xFF94A3B8),
                 fontSize: 12,
@@ -74,61 +97,110 @@ class _AiRecommendedFeaturesListState extends State<AiRecommendedFeaturesList> {
         ),
       );
     }
-    if (_error != null || _items.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.all(16),
-        child: Text(
-          'おすすめ機能を取得できませんでした。後でお試しください。',
-          style: TextStyle(
-            color: Color(0xFF94A3B8),
-            fontSize: 13,
-            height: 1.5,
-          ),
-        ),
-      );
-    }
+
     return Column(
-      children: _items.map((item) {
-        final label =
-            item['label'] as String? ?? item['feature_route'] as String? ?? '';
-        final reason = item['reason'] as String? ?? '';
-        final route = item['feature_route'] as String? ?? '';
-        return ListTile(
-          dense: true,
-          leading: const Icon(
-            Icons.auto_awesome,
-            size: 18,
-            color: Color(0xFF6366F1),
-          ),
-          title: Text(
-            label,
-            style: const TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.w600,
-              color: Colors.white,
-              height: 1.5,
+      children: [
+        if (_error != null)
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'おすすめの取得に失敗したため、固定候補を表示しています。',
+                style: TextStyle(
+                  color: Color(0xFF94A3B8),
+                  fontSize: 12,
+                  height: 1.5,
+                ),
+              ),
             ),
           ),
-          subtitle: reason.isNotEmpty
-              ? Text(
-                  reason,
-                  style: const TextStyle(
-                    fontSize: 11,
-                    color: Color(0xFF94A3B8),
-                    height: 1.5,
-                  ),
-                )
-              : null,
-          trailing: const Icon(
-            Icons.chevron_right,
-            size: 16,
-            color: Color(0xFF64748B),
-          ),
-          onTap: route.isNotEmpty
-              ? () => Navigator.pushNamed(context, route)
-              : null,
-        );
-      }).toList(),
+        ..._items.map((item) {
+          final route = _normalizeRoute(
+            _stringValue(item['feature_route']) ??
+                _stringValue(item['route']) ??
+                _stringValue(item['id']) ??
+                '',
+          );
+          final label = _stringValue(item['label']) ??
+              _stringValue(item['feature_label']) ??
+              _fallbackLabel(route) ??
+              _stringValue(item['title']) ??
+              'おすすめ機能';
+          final reason = _stringValue(item['reason']) ?? _fallbackReason(route);
+          return ListTile(
+            dense: true,
+            leading: const Icon(
+              Icons.auto_awesome,
+              size: 18,
+              color: Color(0xFF6366F1),
+            ),
+            title: Text(
+              label,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: Colors.white,
+                height: 1.5,
+              ),
+            ),
+            subtitle: reason.isNotEmpty
+                ? Text(
+                    reason,
+                    style: const TextStyle(
+                      fontSize: 11,
+                      color: Color(0xFF94A3B8),
+                      height: 1.5,
+                    ),
+                  )
+                : null,
+            trailing: const Icon(
+              Icons.chevron_right,
+              size: 16,
+              color: Color(0xFF64748B),
+            ),
+            onTap: route.isEmpty
+                ? null
+                : () => Navigator.pushNamed(context, route),
+          );
+        }),
+      ],
     );
+  }
+
+  static String _normalizeRoute(String value) {
+    final route = value.trim();
+    if (route.isEmpty) return '';
+    return route.startsWith('/') ? route : '/$route';
+  }
+
+  static String? _fallbackLabel(String route) {
+    if (route.isEmpty) return null;
+    return route.substring(1).replaceAll('-', ' ');
+  }
+
+  static String _fallbackReason(String route) {
+    if (route == '/release-notes') {
+      return '最近の変更点をバージョン別に確認できます。';
+    }
+    if (route == '/site-guide-ai') {
+      return '迷ったときに次の入口をすばやく探せます。';
+    }
+    return '利用頻度と固定導線から優先候補として表示しています。';
+  }
+
+  static String? _stringValue(Object? value) {
+    if (value == null) return null;
+    final text = value.toString().trim();
+    if (text.isEmpty || _isLikelyMojibake(text)) return null;
+    return text;
+  }
+
+  static bool _isLikelyMojibake(String text) {
+    return text.contains('縺') ||
+        text.contains('繝') ||
+        text.contains('譁') ||
+        text.contains('蟄') ||
+        text.contains('螟');
   }
 }

--- a/lib/widgets/home_tier/new_features_list.dart
+++ b/lib/widgets/home_tier/new_features_list.dart
@@ -52,7 +52,7 @@ class _NewFeaturesListState extends State<NewFeaturesList> {
       return const Padding(
         padding: EdgeInsets.all(16),
         child: Text(
-          '直近14日間に追加された機能はありません',
+          '直近14日間に追加された機能はありません。',
           style: TextStyle(
             color: Color(0xFF94A3B8),
             fontSize: 13,
@@ -63,9 +63,9 @@ class _NewFeaturesListState extends State<NewFeaturesList> {
     }
     return Column(
       children: _items.map((item) {
-        final label = item['feature_label'] as String;
+        final label = item['feature_label'] as String? ?? '新機能';
         final desc = item['description'] as String? ?? '';
-        final route = item['feature_route'] as String;
+        final route = _normalizeRoute(item['feature_route'] as String? ?? '');
         return ListTile(
           dense: true,
           leading: const Icon(
@@ -97,9 +97,16 @@ class _NewFeaturesListState extends State<NewFeaturesList> {
             size: 16,
             color: Color(0xFF64748B),
           ),
-          onTap: () => Navigator.pushNamed(context, route),
+          onTap:
+              route.isEmpty ? null : () => Navigator.pushNamed(context, route),
         );
       }).toList(),
     );
+  }
+
+  static String _normalizeRoute(String value) {
+    final route = value.trim();
+    if (route.isEmpty) return '';
+    return route.startsWith('/') ? route : '/$route';
   }
 }

--- a/lib/widgets/home_tier/popular_features_list.dart
+++ b/lib/widgets/home_tier/popular_features_list.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class PopularFeaturesList extends StatefulWidget {
+  const PopularFeaturesList({super.key});
+
+  @override
+  State<PopularFeaturesList> createState() => _PopularFeaturesListState();
+}
+
+class _PopularFeaturesListState extends State<PopularFeaturesList> {
+  static const List<Map<String, dynamic>> _fallbackItems = [
+    {
+      'feature_route': '/site-guide-ai',
+      'feature_label': 'サイト案内AI',
+      'use_count': 0,
+    },
+    {
+      'feature_route': '/ai-university',
+      'feature_label': 'AI大学',
+      'use_count': 0,
+    },
+    {
+      'feature_route': '/project-gantt',
+      'feature_label': 'WBS',
+      'use_count': 0,
+    },
+    {
+      'feature_route': '/release-notes',
+      'feature_label': 'Release Notes',
+      'use_count': 0,
+    },
+  ];
+
+  List<Map<String, dynamic>> _items = const [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final resp = await Supabase.instance.client.functions.invoke(
+        'ai-hub',
+        body: {
+          'action': 'home.popular',
+          'window_days': 30,
+          'limit': 8,
+        },
+      );
+      final data = resp.data as Map<String, dynamic>?;
+      final features = data?['features'] as List<dynamic>? ?? const [];
+      final items = features
+          .whereType<Map<String, dynamic>>()
+          .where((item) => (item['feature_route'] as String? ?? '').isNotEmpty)
+          .toList(growable: false);
+      if (!mounted) return;
+      setState(() {
+        _items = items.isEmpty ? _fallbackItems : items;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _items = _fallbackItems;
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Padding(
+        padding: EdgeInsets.all(16),
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: _items.map((item) {
+          final route = _normalizeRoute(item['feature_route'] as String? ?? '');
+          final label = (item['feature_label'] as String?) ??
+              (item['label'] as String?) ??
+              _fallbackLabel(route);
+          final countValue = item['use_count'];
+          final count = countValue is num ? countValue.toInt() : 0;
+          return ActionChip(
+            avatar: const Icon(
+              Icons.trending_up,
+              size: 16,
+              color: Color(0xFF0D9488),
+            ),
+            label: Text(
+              count > 0 ? '$label  $count' : label,
+              style: const TextStyle(
+                fontSize: 12,
+                color: Color(0xFFE2E8F0),
+                height: 1.5,
+              ),
+            ),
+            backgroundColor: const Color(0xFF10201D),
+            side: const BorderSide(color: Color(0xFF0D9488), width: 0.8),
+            onPressed: route.isEmpty
+                ? null
+                : () => Navigator.pushNamed(context, route),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  static String _normalizeRoute(String value) {
+    final route = value.trim();
+    if (route.isEmpty) return '';
+    return route.startsWith('/') ? route : '/$route';
+  }
+
+  static String _fallbackLabel(String route) {
+    if (route.isEmpty) return '機能';
+    return route.substring(1).replaceAll('-', ' ');
+  }
+}

--- a/lib/widgets/home_tier/recent_features_list.dart
+++ b/lib/widgets/home_tier/recent_features_list.dart
@@ -31,12 +31,11 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
           .eq('user_id', user.id)
           .order('tapped_at', ascending: false)
           .limit(8);
-      // deduplicate by route
       final seen = <String>{};
       final deduped = <Map<String, dynamic>>[];
-      for (final r in rows) {
-        final route = r['feature_route'] as String;
-        if (seen.add(route)) deduped.add(r);
+      for (final row in rows) {
+        final route = row['feature_route'] as String? ?? '';
+        if (route.isNotEmpty && seen.add(route)) deduped.add(row);
       }
       if (mounted) {
         setState(() {
@@ -61,7 +60,7 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
       return const Padding(
         padding: EdgeInsets.all(16),
         child: Text(
-          'まだ履歴がありません',
+          'まだ利用履歴がありません。',
           style: TextStyle(
             color: Color(0xFF94A3B8),
             fontSize: 13,
@@ -76,8 +75,9 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
         spacing: 8,
         runSpacing: 8,
         children: _items.map((item) {
+          final route = _normalizeRoute(item['feature_route'] as String? ?? '');
           final label = item['feature_label'] as String? ??
-              (item['feature_route'] as String).split('/').last;
+              route.substring(1).replaceAll('-', ' ');
           return ActionChip(
             label: Text(
               label,
@@ -89,13 +89,18 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
             ),
             backgroundColor: const Color(0xFF1A1A1A),
             side: const BorderSide(color: Color(0xFF2A2A2A)),
-            onPressed: () => Navigator.pushNamed(
-              context,
-              item['feature_route'] as String,
-            ),
+            onPressed: route.isEmpty
+                ? null
+                : () => Navigator.pushNamed(context, route),
           );
         }).toList(),
       ),
     );
+  }
+
+  static String _normalizeRoute(String value) {
+    final route = value.trim();
+    if (route.isEmpty) return '';
+    return route.startsWith('/') ? route : '/$route';
   }
 }

--- a/lib/widgets/home_tier/user_pinned_features_list.dart
+++ b/lib/widgets/home_tier/user_pinned_features_list.dart
@@ -64,7 +64,7 @@ class _UserPinnedFeaturesListState extends State<UserPinnedFeaturesList> {
       return const Padding(
         padding: EdgeInsets.all(16),
         child: Text(
-          '機能カードの📌をタップしてピン留めできます',
+          '機能カードのピンを押すとここに表示されます。',
           style: TextStyle(
             color: Color(0xFF94A3B8),
             fontSize: 13,
@@ -79,9 +79,9 @@ class _UserPinnedFeaturesListState extends State<UserPinnedFeaturesList> {
         spacing: 8,
         runSpacing: 8,
         children: _items.map((item) {
-          final label = item['feature_label'] as String? ??
-              (item['feature_route'] as String).split('/').last;
-          final route = item['feature_route'] as String;
+          final route = _normalizeRoute(item['feature_route'] as String? ?? '');
+          final label =
+              item['feature_label'] as String? ?? _fallbackLabel(route);
           return InputChip(
             label: Text(
               label,
@@ -89,13 +89,29 @@ class _UserPinnedFeaturesListState extends State<UserPinnedFeaturesList> {
             ),
             backgroundColor: const Color(0xFF1E1E2E),
             side: const BorderSide(color: Color(0xFF6366F1), width: 0.8),
-            deleteIcon:
-                const Icon(Icons.push_pin, size: 14, color: Color(0xFF6366F1)),
-            onDeleted: () => _unpin(route),
-            onPressed: () => Navigator.pushNamed(context, route),
+            deleteIcon: const Icon(
+              Icons.push_pin,
+              size: 14,
+              color: Color(0xFF6366F1),
+            ),
+            onDeleted: route.isEmpty ? null : () => _unpin(route),
+            onPressed: route.isEmpty
+                ? null
+                : () => Navigator.pushNamed(context, route),
           );
         }).toList(),
       ),
     );
+  }
+
+  static String _normalizeRoute(String value) {
+    final route = value.trim();
+    if (route.isEmpty) return '';
+    return route.startsWith('/') ? route : '/$route';
+  }
+
+  static String _fallbackLabel(String route) {
+    if (route.isEmpty) return 'ピン止め機能';
+    return route.substring(1).replaceAll('-', ' ');
   }
 }

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -4567,13 +4567,13 @@ serve(async (req: Request) => {
         const userId = String(body.user_id ?? "");
         if (!userId) return json({ error: "user_id required" }, 400);
         const { data: usage } = await admin.from("user_feature_usage")
-          .select("feature_id, last_used_at, use_count")
+          .select("feature_route, tapped_at")
           .eq("user_id", userId)
-          .order("last_used_at", { ascending: false })
+          .order("tapped_at", { ascending: false })
           .limit(30);
         const recent = new Set(
           (usage ?? []).map((r: Record<string, unknown>) =>
-            String(r.feature_id)
+            String(r.feature_route)
           ),
         );
         const recommendations: Array<Record<string, unknown>> = [];
@@ -4619,6 +4619,50 @@ serve(async (req: Request) => {
           if (recommendations.length >= 5) break;
         }
         return json({ success: true, recommendations });
+      }
+
+      case "home.popular": {
+        const limit = Math.min(Math.max(Number(body.limit ?? 8), 1), 20);
+        const windowDays = Math.min(
+          Math.max(Number(body.window_days ?? 30), 1),
+          365,
+        );
+        const since = new Date(
+          Date.now() - windowDays * 24 * 60 * 60 * 1000,
+        ).toISOString();
+        const { data, error } = await admin.from("user_feature_usage")
+          .select("feature_route, feature_label, tapped_at")
+          .gte("tapped_at", since)
+          .limit(2000);
+        if (error) return json({ error: error.message }, 400);
+
+        const byRoute = new Map<
+          string,
+          { feature_route: string; feature_label: string; use_count: number }
+        >();
+        for (const row of data ?? []) {
+          const rawRoute = String(row.feature_route ?? "").trim();
+          if (!rawRoute) continue;
+          const route = rawRoute.startsWith("/") ? rawRoute : `/${rawRoute}`;
+          const current = byRoute.get(route) ?? {
+            feature_route: route,
+            feature_label: String(row.feature_label ?? route),
+            use_count: 0,
+          };
+          current.use_count += 1;
+          if (!current.feature_label || current.feature_label === route) {
+            current.feature_label = String(row.feature_label ?? route);
+          }
+          byRoute.set(route, current);
+        }
+
+        const features = [...byRoute.values()]
+          .sort((a, b) =>
+            b.use_count - a.use_count ||
+            a.feature_label.localeCompare(b.feature_label)
+          )
+          .slice(0, limit);
+        return json({ success: true, features });
       }
 
       // ── Observability (Win版#131 part 4 / NotebookLM f56cc07c) ────────────────

--- a/test/pages/release_notes_page_test.dart
+++ b/test/pages/release_notes_page_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/release_notes_page.dart';
+
+void main() {
+  testWidgets('ReleaseNotesPage shows current version and filters by query', (
+    tester,
+  ) async {
+    const current = ReleaseNoteVersion(
+      version: '1.2.3',
+      build: '456',
+      date: '2026-05-02',
+      category: 'feature',
+      summary: 'Feature rollout',
+      links: [
+        ReleaseNoteLink(
+          type: 'pull_request',
+          title: 'PR #1694',
+          url: 'https://github.com/kanta13jp1/my_web_app/pull/1694',
+        ),
+      ],
+      changes: [
+        ReleaseNoteChange(
+          category: 'feature',
+          summary: 'Added release note data generation',
+          links: [
+            ReleaseNoteLink(
+              type: 'pull_request',
+              title: 'PR #1694',
+              url: 'https://github.com/kanta13jp1/my_web_app/pull/1694',
+            ),
+          ],
+        ),
+      ],
+    );
+    const bugfix = ReleaseNoteVersion(
+      version: '1.2.2',
+      build: '455',
+      date: '2026-05-01',
+      category: 'fix',
+      summary: 'Bug fix release',
+      changes: [
+        ReleaseNoteChange(
+          category: 'fix',
+          summary: 'Fixed WBS sync timeout',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: ReleaseNotesPage(
+          initialDocument: ReleaseNotesDocument(
+            generatedAt: '2026-05-02T00:00:00Z',
+            current: current,
+            versions: [current, bugfix],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Release Notes'), findsOneWidget);
+    expect(find.text('v1.2.3 (build 456)'), findsAtLeastNWidgets(1));
+    expect(find.text('Feature rollout'), findsAtLeastNWidgets(1));
+    expect(find.text('PR #1694'), findsAtLeastNWidgets(1));
+
+    await tester.enterText(
+      find.byKey(const Key('release_notes_search_field')),
+      'bug',
+    );
+    await tester.pump();
+
+    expect(find.text('Bug fix release'), findsOneWidget);
+    expect(find.text('Fixed WBS sync timeout'), findsOneWidget);
+    expect(find.text('v1.2.2 (build 455)'), findsAtLeastNWidgets(1));
+  });
+}


### PR DESCRIPTION
## Summary
- Focus Home on the requested seven guidance sections and keep the legacy Home stack disabled behind an internal flag.
- Add a `/release-notes` page that reads `web/release-notes.json`, supports version/category/PR search, and links the global version badge plus system fixed feature entry to it.
- Add popular-feature aggregation through `ai-hub` and improve Home tier fallback states so anonymous or sparse-history users still get usable routes.

## Minimal E2E Gate
- E2E-Exception: A new `integration_test/` or `test/e2e/` file is not added in this PR because the route-level browser coverage is already exercised by the existing Playwright `Public E2E stability smoke` workflow, and the new Release Notes behavior is covered by a focused widget test.
- The E2E plan is implementation-detail independent / black-box: inspect only visible Home section labels, navigation, and Release Notes search results.
- Minimal plan: three cases / 3 cases: (1) open Home and verify the requested seven sections, (2) click the version badge or system fixed Release Notes route, (3) search Release Notes by version, PR, or category.
- Mechanism: Playwright public smoke now; a dedicated Flutter integration_test can be added later if this Home flow becomes a recurring release gate.

## Validation
- `flutter analyze`
- `flutter test --no-pub test\pages\release_notes_page_test.dart -r expanded`
- `deno fmt --check supabase\functions\ai-hub\index.ts`
- `git diff --check`

Closes #1682
