### PR TITLE
[codex] Track Copilot review minutes in CI automation

### DIFF
--- a/.github/workflows/ci-auto-fix.yml
+++ b/.github/workflows/ci-auto-fix.yml
@@ -19,6 +19,7 @@ jobs:
     name: Auto-Fix CI Failures
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
+    # Copilot cloud-agent custom image evaluation: docs/COPILOT_CLOUD_AGENT_CI_EVALUATION.md
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/quota-monitor.yml
+++ b/.github/workflows/quota-monitor.yml
@@ -167,6 +167,60 @@ jobs:
                   f.write('status=error\nusage_json={}\n')
           EOF
 
+      - name: Build Copilot Code Review Minutes Gauge
+        id: copilot_review_minutes
+        env:
+          COPILOT_REVIEW_RUNS_30D: ${{ vars.COPILOT_REVIEW_RUNS_30D || '0' }}
+          COPILOT_REVIEW_AVG_MINUTES: ${{ vars.COPILOT_REVIEW_AVG_MINUTES || '4' }}
+          COPILOT_REVIEW_MINUTES_BUDGET: ${{ vars.COPILOT_REVIEW_MINUTES_BUDGET || '200' }}
+          GITHUB_REPOSITORY_PRIVATE: ${{ github.event.repository.private }}
+        run: |
+          python3 - << 'EOF'
+          import json
+          import os
+          from datetime import date
+
+          def number_from_env(name, default):
+              raw = os.environ.get(name, str(default))
+              try:
+                  return float(raw)
+              except ValueError:
+                  return float(default)
+
+          billing_start = date(2026, 6, 1)
+          today = date.today()
+          days_until = (billing_start - today).days
+          private_repo = os.environ.get('GITHUB_REPOSITORY_PRIVATE', 'false').lower() == 'true'
+          runs_30d = number_from_env('COPILOT_REVIEW_RUNS_30D', 0)
+          avg_minutes = number_from_env('COPILOT_REVIEW_AVG_MINUTES', 4)
+          budget_minutes = number_from_env('COPILOT_REVIEW_MINUTES_BUDGET', 200)
+          estimated_minutes = round(runs_30d * avg_minutes, 2)
+          usage_pct = round((estimated_minutes / budget_minutes * 100), 1) if budget_minutes > 0 else 0
+          billing_active = today >= billing_start
+          warning_window = 0 <= days_until <= 14
+          alert = private_repo and budget_minutes > 0 and usage_pct >= 80 and (billing_active or warning_window)
+
+          gauge = {
+              'tool': 'github_copilot_code_review_minutes',
+              'billing_starts_on': billing_start.isoformat(),
+              'billing_active': billing_active,
+              'days_until_billing': max(days_until, 0),
+              'private_repo_actions_minutes_apply': private_repo,
+              'estimated_reviews_30d': runs_30d,
+              'avg_minutes_per_review_est': avg_minutes,
+              'estimated_minutes_30d': estimated_minutes,
+              'budget_minutes_30d': budget_minutes,
+              'usage_pct_est': usage_pct,
+              'alert': alert,
+              'source': 'https://github.blog/changelog/2026-04-27-github-copilot-code-review-will-start-consuming-github-actions-minutes-on-june-1-2026/',
+              'note': 'Set repository variables COPILOT_REVIEW_RUNS_30D, COPILOT_REVIEW_AVG_MINUTES, and COPILOT_REVIEW_MINUTES_BUDGET to tune this gauge.',
+          }
+          print(f"Copilot code review minutes gauge: {estimated_minutes}/{budget_minutes} min ({usage_pct}%), billing_active={billing_active}, private_repo={private_repo}")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write('status=ok\n')
+              f.write(f'usage_json={json.dumps(gauge)}\n')
+          EOF
+
       - name: Check Gemini Code Assist Quota
         id: gemini
         env:
@@ -212,6 +266,7 @@ jobs:
           ANTHROPIC_USAGE: ${{ steps.anthropic.outputs.usage_json }}
           OPENAI_USAGE: ${{ steps.openai.outputs.usage_json }}
           COPILOT_USAGE: ${{ steps.copilot.outputs.usage_json }}
+          COPILOT_REVIEW_USAGE: ${{ steps.copilot_review_minutes.outputs.usage_json }}
           GEMINI_USAGE: ${{ steps.gemini.outputs.usage_json }}
         run: |
           python3 - << 'EOF'
@@ -228,7 +283,7 @@ jobs:
           }
           today = date.today().isoformat()
 
-          tools = ['ANTHROPIC_USAGE', 'OPENAI_USAGE', 'COPILOT_USAGE', 'GEMINI_USAGE']
+          tools = ['ANTHROPIC_USAGE', 'OPENAI_USAGE', 'COPILOT_USAGE', 'COPILOT_REVIEW_USAGE', 'GEMINI_USAGE']
           for env_key in tools:
               raw = os.environ.get(env_key, '{}')
               if not raw or raw == '{}':
@@ -258,6 +313,7 @@ jobs:
           ANTHROPIC_USAGE: ${{ steps.anthropic.outputs.usage_json }}
           OPENAI_USAGE: ${{ steps.openai.outputs.usage_json }}
           COPILOT_USAGE: ${{ steps.copilot.outputs.usage_json }}
+          COPILOT_REVIEW_USAGE: ${{ steps.copilot_review_minutes.outputs.usage_json }}
           GEMINI_USAGE: ${{ steps.gemini.outputs.usage_json }}
         run: |
           python3 - << 'EOF'
@@ -272,6 +328,7 @@ jobs:
               ('ANTHROPIC_USAGE', 'Claude (Anthropic)'),
               ('OPENAI_USAGE', 'OpenAI (CODEX)'),
               ('COPILOT_USAGE', 'GitHub Copilot'),
+              ('COPILOT_REVIEW_USAGE', 'Copilot Code Review Actions minutes'),
               ('GEMINI_USAGE', 'Gemini Code Assist'),
           ]:
               raw = os.environ.get(env_key, '{}')

--- a/docs/AI_FALLBACK_RUNBOOK.md
+++ b/docs/AI_FALLBACK_RUNBOOK.md
@@ -252,6 +252,12 @@ Codex CLI が **Memory** を持つようになり、past task の preference / p
 - Cloud agent **+20% startup** (Actions custom image) — `ci-auto-fix.yml` 高速化候補
 - **Model selection for Claude / Codex agents on github.com** — Copilot から Claude / Codex 直接呼出 (= fleet 連携の bridge)
 - Copilot **code review が Actions minutes 消費開始** (2026-06-01〜) — quota 影響を `quota-monitor.yml` に反映必要
+- 2026-05-03 実装: `quota-monitor.yml` に **Copilot Code Review Actions minutes gauge** を追加。
+  - GitHub 公式 changelog の発効日: **2026-06-01**
+  - private repo では Copilot code review が AI Credits に加えて Actions minutes を消費する。
+  - repo variables `COPILOT_REVIEW_RUNS_30D`, `COPILOT_REVIEW_AVG_MINUTES`, `COPILOT_REVIEW_MINUTES_BUDGET` で見積もりを調整する。
+  - public repo は Actions minutes 無料枠の扱いが変わらないため、gauge は budget pressure の可視化に使う。
+  - Source: https://github.blog/changelog/2026-04-27-github-copilot-code-review-will-start-consuming-github-actions-minutes-on-june-1-2026/
 
 ### Claude Code 2026-05 (`/tui` + push notification + project purge + /resume PR URL)
 

--- a/docs/AI_FLEET_SYNERGY_PLAYBOOK.md
+++ b/docs/AI_FLEET_SYNERGY_PLAYBOOK.md
@@ -129,6 +129,8 @@ INDIE_DEV_VELOCITY (= indie 視点の規律) と直交する **「fleet 視点�
 
 Codex は **Stop Hooks** で CI/CD pipeline pass まで task 完了をブロック.
 
+**2026-05-03 追記**: Copilot Code Review は 2026-06-01 から private repo で GitHub Actions minutes も消費するため、レビュー自動化は **Actions budget cap も deterministic guardrail** として扱う。`quota-monitor.yml` の `github_copilot_code_review_minutes` gauge が 80% 以上になったら、Copilot review の自動起動を絞り、Claude/Codex の API review と `flutter analyze` / `flutter test` / `deno lint` へ逃がす。
+
 **なぜ重要か**: AI は「**それっぽく完了**」を返すことがある. 人間 review もスケールしない → fleet 規模では **deterministic gate** だけが信頼可能な validation.
 
 **どう適用するか**:

--- a/docs/COPILOT_CLOUD_AGENT_CI_EVALUATION.md
+++ b/docs/COPILOT_CLOUD_AGENT_CI_EVALUATION.md
@@ -1,0 +1,50 @@
+# Copilot Cloud Agent CI Evaluation
+
+Date: 2026-05-03
+Owner: Codex #2
+Issue: #1707
+
+## Decision
+
+Do not replace `ci-auto-fix.yml` with a custom Actions image yet. Keep the
+current `ubuntu-latest` workflow and use this report as the comparison baseline
+until Copilot cloud-agent custom images are configured for the repository or
+organization.
+
+## Why
+
+- GitHub's 2026-04-27 changelog says Copilot cloud agent startup is over 20%
+  faster when the agent environment is prebuilt with GitHub Actions custom
+  images.
+- `ci-auto-fix.yml` is a normal GitHub Actions workflow, not the Copilot cloud
+  agent runtime itself. Changing its `runs-on` value would not prove the Copilot
+  cloud-agent startup gain.
+- The safe first step is to keep deterministic CI repair stable, then measure a
+  custom-image pilot from Copilot-assigned issues or `@copilot` PR mentions.
+
+## Pilot Criteria
+
+Adopt a custom Actions image only when all criteria are met:
+
+- The image preinstalls Flutter stable, Deno v2, Node, and the repository's
+  common caches without embedding secrets.
+- A Copilot cloud-agent task using the image starts at least 15% faster than the
+  default environment across five comparable issue assignments.
+- The image refresh cadence is automated and visible in GitHub Actions.
+- `quota-monitor.yml` shows Copilot code-review Actions minutes below 80% of the
+  configured monthly budget.
+
+## Current Integration
+
+- `scripts/ai_tool_watch.py` now watches the Copilot custom-image changelog,
+  Copilot code-review Actions minutes changelog, and Claude/Codex model
+  selection changelog.
+- `quota-monitor.yml` now emits a `github_copilot_code_review_minutes` gauge.
+- `docs/AI_FALLBACK_RUNBOOK.md` records the 2026-06-01 billing start date and
+  repository variables used by the gauge.
+
+## Sources
+
+- https://github.blog/changelog/2026-04-27-copilot-cloud-agent-starts-20-faster-with-actions-custom-images/
+- https://github.blog/changelog/2026-04-27-github-copilot-code-review-will-start-consuming-github-actions-minutes-on-june-1-2026/
+- https://github.blog/changelog/2026-04-14-model-selection-for-claude-and-codex-agents-on-github-com/

--- a/docs/ai-tool-watch/README.md
+++ b/docs/ai-tool-watch/README.md
@@ -1,15 +1,18 @@
 # AI Tool Watch
 
 This directory is the session-start and scheduled watch surface for official
-Claude Code and Codex changes.
+Claude Code, Codex, Gemini Code Assist, and GitHub Copilot changes.
 
 ## What It Watches
 
 - Claude Code changelog, hooks reference, and GitHub Actions docs.
 - Codex changelog, Codex use cases, and Codex overview.
+- Gemini Code Assist release notes and GitHub code review docs.
+- GitHub Copilot changelog entries for code-review Actions minutes, cloud
+  agent custom images, and Claude/Codex agent model selection.
 - Workflow keywords that affect this repo: hooks, schedules, GitHub Actions,
-  Automations, in-app browser, models, worktrees, MCP, cost controls, CI, and
-  review gates.
+  Automations, in-app browser, models, worktrees, MCP, agent routing, cost
+  controls, CI, and review gates.
 - NotebookLM harness notebook
   `bc58b50b-5fc4-4840-9a62-b397d6d3b65a`, used as the Master Brain routing
   reference for Claude Code 10 instances plus Codex 2 instances.
@@ -50,6 +53,10 @@ started manually. It updates the report/state files and comments on issue
 - Codex model, browser, computer-use, worktree, or subagent changes route to
   Codex #1 execution and UI verification work unless the item is CI/deploy
   related.
+- Gemini Code Assist agent-mode or GitHub-review changes route to fallback
+  review and quota policy work.
+- Copilot cloud-agent, code-review billing, or Claude/Codex agent-selection
+  changes route to #1707 and Codex #2 CI/quota automation.
 - Schedule, GitHub Actions, and automation changes route to WBS/CI/deploy
   automation, normally owned by Codex #2.
 - MCP, connector, Slack, and integration changes route to connector reliability

--- a/scripts/ai_tool_watch.py
+++ b/scripts/ai_tool_watch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Watch official Claude Code and Codex pages for workflow-relevant changes.
+"""Watch official AI coding-tool pages for workflow-relevant changes.
 
 The script is intentionally dependency-free so it can run in GitHub Actions,
 Codex sessions, Claude Code hooks, or a plain local shell.
@@ -71,6 +71,36 @@ SOURCES: list[Source] = [
         "https://openai.com/codex/",
         "Codex",
     ),
+    Source(
+        "gemini-code-assist-release-notes",
+        "Gemini Code Assist release notes",
+        "https://cloud.google.com/gemini/docs/codeassist/release-notes",
+        "Gemini Code Assist",
+    ),
+    Source(
+        "gemini-code-assist-github-review",
+        "Gemini Code Assist GitHub review docs",
+        "https://developers.google.com/gemini-code-assist/docs/review-github-code",
+        "Gemini Code Assist",
+    ),
+    Source(
+        "github-copilot-code-review-minutes",
+        "Copilot code review Actions minutes",
+        "https://github.blog/changelog/2026-04-27-github-copilot-code-review-will-start-consuming-github-actions-minutes-on-june-1-2026/",
+        "GitHub Copilot",
+    ),
+    Source(
+        "github-copilot-cloud-agent-custom-images",
+        "Copilot cloud agent custom images",
+        "https://github.blog/changelog/2026-04-27-copilot-cloud-agent-starts-20-faster-with-actions-custom-images/",
+        "GitHub Copilot",
+    ),
+    Source(
+        "github-agent-model-selection",
+        "Claude and Codex agent model selection",
+        "https://github.blog/changelog/2026-04-14-model-selection-for-claude-and-codex-agents-on-github-com/",
+        "GitHub Agents",
+    ),
 ]
 
 
@@ -114,7 +144,24 @@ KEYWORDS: dict[str, list[str]] = {
         "VSCode",
         "Visual Studio Code",
     ],
+    "agent-routing": [
+        "agent mode",
+        "cloud agent",
+        "code review",
+        "custom image",
+        "custom images",
+        "model selection",
+        "JetBrains",
+        "IntelliJ",
+        "Claude",
+        "Codex",
+        "Gemini Code Assist",
+    ],
     "quality-cost": [
+        "AI Credits",
+        "Actions minutes",
+        "billing",
+        "budget",
         "OpenTelemetry",
         "cost",
         "quota",
@@ -156,8 +203,15 @@ IMPACT_ROUTES: dict[str, dict[str, Any]] = {
             "and NotebookLM knowledge capture."
         ),
     },
+    "agent-routing": {
+        "issues": ["#1707", "#1706", "#1422"],
+        "action": (
+            "Route to fleet agent routing: Copilot/Claude/Codex/Gemini model "
+            "selection, PR review ownership, and CI cost guardrails."
+        ),
+    },
     "quality-cost": {
-        "issues": ["#1380", "#1374", "#1336", "#1352"],
+        "issues": ["#1707", "#1380", "#1374", "#1336", "#1352"],
         "action": (
             "Route to cost and safety controls: deny-by-default checks, budget "
             "routing, and telemetry before wider automation."
@@ -263,6 +317,21 @@ def extract_latest_signal(source: Source, text: str) -> str:
         match = re.search(r"GPT-5\.5 and Codex app updates", text)
         if match:
             return "GPT-5.5 and Codex app updates"
+    if source.slug == "gemini-code-assist-release-notes":
+        match = re.search(r"\b([A-Z][a-z]+ \d{1,2}, 20\d{2})\b", text)
+        if match:
+            return f"latest dated entry / {match.group(1)}"
+        match = re.search(r"\b(VS Code Gemini Code Assist \d+\.\d+\.\d+)\b", text)
+        if match:
+            return match.group(1)
+    if source.slug == "gemini-code-assist-github-review":
+        return "Gemini Code Assist GitHub code review docs"
+    if source.slug == "github-copilot-code-review-minutes":
+        return "2026-06-01 / Copilot code review consumes Actions minutes"
+    if source.slug == "github-copilot-cloud-agent-custom-images":
+        return "2026-04-27 / Copilot cloud agent custom images"
+    if source.slug == "github-agent-model-selection":
+        return "2026-04-14 / Claude and Codex agent model selection"
     title = re.search(r"([A-Z][A-Za-z0-9 .,/+-]{8,90})", text)
     return title.group(1).strip() if title else "No title detected"
 
@@ -343,7 +412,11 @@ def analyze(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
 
     changed_sources = [item for item in report_sources if item["changed"] or item["first_seen"]]
     active_groups = sorted({group for item in report_sources for group in item["keyword_groups"]})
-    high_priority_groups = [group for group in active_groups if group in {"hooks", "schedule", "codex-runtime"}]
+    high_priority_groups = [
+        group
+        for group in active_groups
+        if group in {"hooks", "schedule", "codex-runtime", "agent-routing", "quality-cost"}
+    ]
 
     report = {
         "checked_at": checked_at,


### PR DESCRIPTION
## Summary

- Expand `scripts/ai_tool_watch.py` to watch official Gemini Code Assist and GitHub Copilot sources in addition to Claude Code and Codex.
- Add a `github_copilot_code_review_minutes` gauge to `quota-monitor.yml` with tunable repository variables for expected review runs, average minutes, and monthly budget.
- Record the Copilot cloud-agent custom image comparison baseline and the 2026-06-01 Copilot Code Review Actions minutes billing start date in docs.

## Impact

Codex #2 session-start and scheduled monitoring now routes Gemini/Copilot tool changes into WBS/Issue/CI automation instead of only watching Claude Code/Codex. `quota-monitor.yml` can surface Copilot review budget pressure before private-repo reviews start consuming Actions minutes.

## Minimal E2E Gate

This PR changes workflow/docs/script automation, not app UI. The E2E plan is implementation-detail independent and black-box: validate observable workflow/report inputs and outputs rather than internal implementation details.

Minimal plan, about three I/O cases:

1. `scripts/ai_tool_watch.py --print-only` reads official source URLs and outputs Gemini/Copilot routing groups.
2. `quota-monitor.yml` parses as YAML and emits the Copilot review minutes JSON gauge from repository variable inputs.
3. The existing Playwright public smoke remains the E2E mechanism for app availability; no new `integration_test` file is needed because no application-code path changed.

E2E-Exception: docs/workflow/script-only PR; no app-code change detected.

## Validation

- `python -m py_compile scripts\ai_tool_watch.py`
- `python scripts\ai_tool_watch.py --print-only`
- PyYAML parse for `.github/workflows/quota-monitor.yml` and `.github/workflows/ci-auto-fix.yml`
- `git diff --cached --check`

Note: `actionlint` is not installed in this local environment, so workflow validation used PyYAML parsing plus Git diff whitespace checks.

Closes #1707
