### PR TITLE
[codex] render Pleias RAG citations

### DIFF
--- a/lib/pages/edge_llm_playground_page.dart
+++ b/lib/pages/edge_llm_playground_page.dart
@@ -6,7 +6,9 @@ import 'package:uuid/uuid.dart';
 
 import '../models/ai_provider_registry.dart';
 import '../services/edge_llm_playground_service.dart';
+import '../services/local_rag_runtime_service.dart';
 import '../widgets/ai_response_observability_panel.dart';
+import '../widgets/pleias_citation_text.dart';
 import 'offline_secure_mode_settings_page.dart';
 
 class EdgeLlmPlaygroundPage extends StatefulWidget {
@@ -530,6 +532,7 @@ class _EdgeLlmPlaygroundPageState extends State<EdgeLlmPlaygroundPage> {
             _codeBlock(
               text: response.text,
               isDark: isDark,
+              citations: response.citations,
             ),
             if (prettyJson != null) ...[
               const SizedBox(height: 16),
@@ -565,6 +568,7 @@ class _EdgeLlmPlaygroundPageState extends State<EdgeLlmPlaygroundPage> {
   Widget _codeBlock({
     required String text,
     required bool isDark,
+    List<LocalRagCitation> citations = const <LocalRagCitation>[],
   }) {
     return Container(
       width: double.infinity,
@@ -578,13 +582,10 @@ class _EdgeLlmPlaygroundPageState extends State<EdgeLlmPlaygroundPage> {
               : const Color(0xFFE2E8F0),
         ),
       ),
-      child: SelectableText(
-        text,
-        style: const TextStyle(
-          fontFamily: 'monospace',
-          fontSize: 12,
-          height: 1.5,
-        ),
+      child: PleiasCitationText(
+        text: text,
+        citations: citations,
+        isDark: isDark,
       ),
     );
   }

--- a/lib/services/edge_llm_playground_service.dart
+++ b/lib/services/edge_llm_playground_service.dart
@@ -27,6 +27,7 @@ class EdgeLlmPlaygroundResponse {
   final Map<String, dynamic>? parsedJson;
   final String? parseError;
   final AiHubChatObservability? observability;
+  final List<LocalRagCitation> citations;
 
   const EdgeLlmPlaygroundResponse({
     required this.text,
@@ -38,6 +39,7 @@ class EdgeLlmPlaygroundResponse {
     this.parsedJson,
     this.parseError,
     this.observability,
+    this.citations = const <LocalRagCitation>[],
   });
 }
 
@@ -84,6 +86,7 @@ class EdgeLlmPlaygroundService {
       'action': 'edge_llm.invoke',
       'user_prompt': normalizedPrompt,
       'response_format': normalizedFormat,
+      'temperature': 0,
       if (systemPrompt.trim().isNotEmpty) 'system_prompt': systemPrompt.trim(),
       if (normalizedProvider != 'auto') 'provider': normalizedProvider,
       if (normalizedProvider == 'auto' &&
@@ -124,6 +127,7 @@ class EdgeLlmPlaygroundService {
           'citations': local.citations.map((item) => item.toJson()).toList(),
           'offline_runtime': local.toJson(),
         },
+        citations: local.citations,
         observability: AiHubChatObservability.fromResponseMap(
           <String, dynamic>{
             'provider': 'local-rag',
@@ -160,6 +164,7 @@ class EdgeLlmPlaygroundService {
     final model = data['model']?.toString().trim();
     final parseError = data['parse_error']?.toString().trim();
     final parsedJson = _toStringMap(data['parsed_json']);
+    final citations = _extractCitations(parsedJson, data);
     final source = providerUsed.isEmpty
         ? 'ai-hub edge_llm.invoke'
         : 'ai-hub edge_llm.invoke / $providerUsed';
@@ -173,6 +178,7 @@ class EdgeLlmPlaygroundService {
       responseFormat: normalizedFormat,
       parsedJson: parsedJson,
       parseError: _emptyToNull(parseError),
+      citations: citations,
       observability: AiHubChatObservability.fromResponseMap(
         data,
         fallbackProvider:
@@ -228,6 +234,32 @@ class EdgeLlmPlaygroundService {
       );
     }
     return null;
+  }
+
+  List<LocalRagCitation> _extractCitations(
+    Map<String, dynamic>? parsedJson,
+    Map<String, dynamic> response,
+  ) {
+    final candidates = <Object?>[
+      parsedJson?['citations'],
+      parsedJson?['sources'],
+      response['citations'],
+      response['sources'],
+    ];
+    for (final candidate in candidates) {
+      if (candidate is List) {
+        return candidate
+            .whereType<Map>()
+            .map(
+              (item) => LocalRagCitation.fromMap(
+                Map<String, dynamic>.from(item),
+              ),
+            )
+            .where((item) => item.sourceId.isNotEmpty)
+            .toList(growable: false);
+      }
+    }
+    return const <LocalRagCitation>[];
   }
 }
 

--- a/lib/services/local_rag_runtime_service.dart
+++ b/lib/services/local_rag_runtime_service.dart
@@ -54,6 +54,36 @@ class LocalRagCitation {
   }
 }
 
+class PleiasCitationSegment {
+  final String text;
+  final String? sourceId;
+  final bool markerOnly;
+
+  const PleiasCitationSegment({
+    required this.text,
+    this.sourceId,
+    this.markerOnly = false,
+  });
+
+  bool get cited => sourceId != null && sourceId!.trim().isNotEmpty;
+}
+
+class PleiasCitationParseResult {
+  final String plainText;
+  final List<PleiasCitationSegment> segments;
+  final List<String> sourceIds;
+  final bool hasCitationTokens;
+
+  const PleiasCitationParseResult({
+    required this.plainText,
+    required this.segments,
+    required this.sourceIds,
+    required this.hasCitationTokens,
+  });
+
+  bool get hasCitations => sourceIds.isNotEmpty;
+}
+
 class LocalRagRuntimeResponse {
   final String text;
   final String engine;
@@ -63,6 +93,7 @@ class LocalRagRuntimeResponse {
   final bool networkBlocked;
   final int? memoryPeakMb;
   final List<LocalRagCitation> citations;
+  final PleiasCitationParseResult citationText;
   final Map<String, dynamic> raw;
 
   const LocalRagRuntimeResponse({
@@ -73,6 +104,7 @@ class LocalRagRuntimeResponse {
     required this.offlineOnly,
     required this.networkBlocked,
     required this.citations,
+    required this.citationText,
     required this.raw,
     this.memoryPeakMb,
   });
@@ -90,8 +122,9 @@ class LocalRagRuntimeResponse {
             .toList()
         : const <LocalRagCitation>[];
 
+    final text = (map['text'] ?? map['answer'] ?? '').toString().trim();
     return LocalRagRuntimeResponse(
-      text: (map['text'] ?? map['answer'] ?? '').toString().trim(),
+      text: text,
       engine: map['engine']?.toString().trim() ?? 'local-rag',
       model: map['model']?.toString().trim() ?? 'local-model',
       vectorDbPath: map['vector_db_path']?.toString().trim() ?? '',
@@ -99,6 +132,7 @@ class LocalRagRuntimeResponse {
       networkBlocked: map['network_blocked'] == true,
       memoryPeakMb: _asInt(map['memory_peak_mb']),
       citations: citations,
+      citationText: parsePleiasCitationText(text),
       raw: map,
     );
   }
@@ -113,6 +147,7 @@ class LocalRagRuntimeResponse {
       'network_blocked': networkBlocked,
       if (memoryPeakMb != null) 'memory_peak_mb': memoryPeakMb,
       'citations': citations.map((item) => item.toJson()).toList(),
+      'citation_source_ids': citationText.sourceIds,
     };
   }
 }
@@ -151,6 +186,7 @@ class LocalRagRuntimeService {
       'model_path': settings.localModelPath,
       'vector_db_path': settings.localVectorDbPath,
       'engine': settings.inferenceEngine,
+      'temperature': 0,
       'offline_only': true,
       'network_policy': 'offline_only',
       if (sessionId != null && sessionId.trim().isNotEmpty)
@@ -221,4 +257,143 @@ double? _asDouble(Object? value) {
   if (value is num) return value.toDouble();
   if (value == null) return null;
   return double.tryParse(value.toString());
+}
+
+PleiasCitationParseResult parsePleiasCitationText(String raw) {
+  if (raw.isEmpty) {
+    return const PleiasCitationParseResult(
+      plainText: '',
+      segments: <PleiasCitationSegment>[],
+      sourceIds: <String>[],
+      hasCitationTokens: false,
+    );
+  }
+
+  const sourceStart = '<|source_start|>';
+  const sourceEnd = '<|source_end|>';
+  const closeTokens = <String>[
+    '<|/source|>',
+    '<|source_close|>',
+    '<|source_stop|>',
+    '<|source_finish|>',
+  ];
+  final bracketSource = RegExp(r'\[source\s*:\s*([^\]]+)\]');
+  final segments = <PleiasCitationSegment>[];
+  final sourceIds = <String>{};
+  var cursor = 0;
+  var hasCitationTokens = false;
+
+  void addPlain(String value) {
+    if (value.isNotEmpty) {
+      segments.add(PleiasCitationSegment(text: value));
+    }
+  }
+
+  while (cursor < raw.length) {
+    final specialIndex = raw.indexOf(sourceStart, cursor);
+    final bracketMatch = bracketSource
+        .allMatches(raw, cursor)
+        .cast<RegExpMatch?>()
+        .firstWhere((match) => match != null, orElse: () => null);
+    final bracketIndex = bracketMatch?.start ?? -1;
+
+    final nextIndex = _earliestPositive(specialIndex, bracketIndex);
+    if (nextIndex < 0) {
+      addPlain(raw.substring(cursor));
+      break;
+    }
+
+    addPlain(raw.substring(cursor, nextIndex));
+
+    if (bracketIndex == nextIndex && bracketMatch != null) {
+      final sourceId = _normalizeSourceId(bracketMatch.group(1) ?? '');
+      final markerText = '[source:$sourceId]';
+      hasCitationTokens = true;
+      if (sourceId.isNotEmpty) sourceIds.add(sourceId);
+      segments.add(
+        PleiasCitationSegment(
+          text: markerText,
+          sourceId: sourceId,
+          markerOnly: true,
+        ),
+      );
+      cursor = bracketMatch.end;
+      continue;
+    }
+
+    final idStart = nextIndex + sourceStart.length;
+    final idEnd = raw.indexOf(sourceEnd, idStart);
+    if (idEnd < 0) {
+      addPlain(raw.substring(nextIndex));
+      break;
+    }
+
+    final sourceId = _normalizeSourceId(raw.substring(idStart, idEnd));
+    final contentStart = idEnd + sourceEnd.length;
+    final close = _findFirstCloseToken(raw, contentStart, closeTokens);
+    hasCitationTokens = true;
+    if (sourceId.isNotEmpty) sourceIds.add(sourceId);
+
+    if (close == null) {
+      segments.add(
+        PleiasCitationSegment(
+          text: '[source:$sourceId]',
+          sourceId: sourceId,
+          markerOnly: true,
+        ),
+      );
+      cursor = contentStart;
+      continue;
+    }
+
+    final citedText = raw.substring(contentStart, close.index);
+    if (citedText.isEmpty) {
+      segments.add(
+        PleiasCitationSegment(
+          text: '[source:$sourceId]',
+          sourceId: sourceId,
+          markerOnly: true,
+        ),
+      );
+    } else {
+      segments.add(
+        PleiasCitationSegment(text: citedText, sourceId: sourceId),
+      );
+    }
+    cursor = close.index + close.token.length;
+  }
+
+  final plainText = segments.map((segment) => segment.text).join();
+  return PleiasCitationParseResult(
+    plainText: plainText,
+    segments: segments,
+    sourceIds: sourceIds.toList(growable: false),
+    hasCitationTokens: hasCitationTokens,
+  );
+}
+
+int _earliestPositive(int first, int second) {
+  if (first < 0) return second;
+  if (second < 0) return first;
+  return first < second ? first : second;
+}
+
+({int index, String token})? _findFirstCloseToken(
+  String raw,
+  int start,
+  List<String> tokens,
+) {
+  ({int index, String token})? best;
+  for (final token in tokens) {
+    final index = raw.indexOf(token, start);
+    if (index < 0) continue;
+    if (best == null || index < best.index) {
+      best = (index: index, token: token);
+    }
+  }
+  return best;
+}
+
+String _normalizeSourceId(String value) {
+  return value.trim().replaceAll(RegExp(r'^\s*source\s*:\s*'), '').trim();
 }

--- a/lib/widgets/pleias_citation_text.dart
+++ b/lib/widgets/pleias_citation_text.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+
+import '../services/local_rag_runtime_service.dart';
+
+class PleiasCitationText extends StatelessWidget {
+  final String text;
+  final List<LocalRagCitation> citations;
+  final bool isDark;
+
+  const PleiasCitationText({
+    super.key,
+    required this.text,
+    required this.citations,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final parsed = parsePleiasCitationText(text);
+    final baseStyle = Theme.of(context).textTheme.bodyMedium?.copyWith(
+              fontFamily: 'monospace',
+              fontSize: 12,
+              height: 1.5,
+              color: isDark ? Colors.white : const Color(0xFF0F172A),
+            ) ??
+        TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 12,
+          height: 1.5,
+          color: isDark ? Colors.white : const Color(0xFF0F172A),
+        );
+
+    if (!parsed.hasCitationTokens) {
+      return SelectableText(text, style: baseStyle);
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        RichText(
+          text: TextSpan(
+            style: baseStyle,
+            children: parsed.segments
+                .expand((segment) => _spansFor(context, segment, baseStyle))
+                .toList(),
+          ),
+        ),
+        if (citations.isNotEmpty) ...[
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: citations
+                .map((citation) => _sourceChip(context, citation))
+                .toList(),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Iterable<InlineSpan> _spansFor(
+    BuildContext context,
+    PleiasCitationSegment segment,
+    TextStyle baseStyle,
+  ) sync* {
+    if (!segment.cited) {
+      yield TextSpan(text: segment.text);
+      return;
+    }
+
+    final citation = _resolveCitation(segment.sourceId!);
+    if (segment.markerOnly) {
+      yield WidgetSpan(
+        alignment: PlaceholderAlignment.middle,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 2),
+          child: _inlineCitationMarker(context, segment, citation),
+        ),
+      );
+      return;
+    }
+
+    final tokenPattern = RegExp(r'\s+|[^\s]+');
+    for (final match in tokenPattern.allMatches(segment.text)) {
+      final part = match.group(0) ?? '';
+      if (part.trim().isEmpty) {
+        yield TextSpan(text: part);
+        continue;
+      }
+      yield WidgetSpan(
+        alignment: PlaceholderAlignment.baseline,
+        baseline: TextBaseline.alphabetic,
+        child: Tooltip(
+          message: _tooltip(segment.sourceId!, citation),
+          waitDuration: const Duration(milliseconds: 250),
+          child: GestureDetector(
+            onTap: () =>
+                _showCitationDialog(context, segment.sourceId!, citation),
+            child: Text(
+              part,
+              style: baseStyle.copyWith(
+                backgroundColor:
+                    isDark ? const Color(0xFF134E4A) : const Color(0xFFCCFBF1),
+                color: isDark ? Colors.white : const Color(0xFF115E59),
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+  }
+
+  Widget _inlineCitationMarker(
+    BuildContext context,
+    PleiasCitationSegment segment,
+    LocalRagCitation? citation,
+  ) {
+    return Tooltip(
+      message: _tooltip(segment.sourceId!, citation),
+      waitDuration: const Duration(milliseconds: 250),
+      child: GestureDetector(
+        key: ValueKey('pleias-citation-marker-${segment.sourceId}'),
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _showCitationDialog(context, segment.sourceId!, citation),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: isDark ? const Color(0xFF134E4A) : const Color(0xFFCCFBF1),
+            borderRadius: BorderRadius.circular(6),
+            border: Border.all(
+              color: isDark ? const Color(0xFF2DD4BF) : const Color(0xFF14B8A6),
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            child: Text(
+              segment.text,
+              style: TextStyle(
+                color: isDark ? Colors.white : const Color(0xFF115E59),
+                fontSize: 11,
+                fontWeight: FontWeight.w800,
+                height: 1.2,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _sourceChip(BuildContext context, LocalRagCitation citation) {
+    final label = citation.title.isEmpty ? citation.sourceId : citation.title;
+    return Tooltip(
+      message: _tooltip(citation.sourceId, citation),
+      waitDuration: const Duration(milliseconds: 250),
+      child: ActionChip(
+        label: Text(label),
+        visualDensity: VisualDensity.compact,
+        onPressed: () =>
+            _showCitationDialog(context, citation.sourceId, citation),
+      ),
+    );
+  }
+
+  LocalRagCitation? _resolveCitation(String sourceId) {
+    final normalized = sourceId.trim().toLowerCase();
+    for (final citation in citations) {
+      if (citation.sourceId.trim().toLowerCase() == normalized) {
+        return citation;
+      }
+    }
+
+    final numeric = int.tryParse(normalized);
+    if (numeric != null && numeric > 0 && numeric <= citations.length) {
+      return citations[numeric - 1];
+    }
+
+    for (final citation in citations) {
+      final candidate = citation.sourceId.trim().toLowerCase();
+      if (candidate == 'doc-$normalized' ||
+          candidate == 'source-$normalized' ||
+          candidate.endsWith('-$normalized')) {
+        return citation;
+      }
+    }
+    return null;
+  }
+
+  String _tooltip(String sourceId, LocalRagCitation? citation) {
+    if (citation == null) return 'source:$sourceId';
+    final title = citation.title.isEmpty ? citation.sourceId : citation.title;
+    final parts = <String>[
+      title,
+      if (citation.snippet.isNotEmpty) citation.snippet,
+      if (citation.path.isNotEmpty) citation.path,
+      if (citation.score > 0) 'score ${citation.score.toStringAsFixed(2)}',
+    ];
+    return parts.join('\n');
+  }
+
+  void _showCitationDialog(
+    BuildContext context,
+    String sourceId,
+    LocalRagCitation? citation,
+  ) {
+    final title = citation?.title.trim().isNotEmpty == true
+        ? citation!.title
+        : 'source:$sourceId';
+    showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(title),
+        content: SelectableText(
+          [
+            if (citation?.snippet.trim().isNotEmpty == true) citation!.snippet,
+            if (citation?.path.trim().isNotEmpty == true) citation!.path,
+            if (citation == null) 'No source metadata was returned.',
+          ].join('\n\n'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/edge_llm_playground_service_test.dart
+++ b/test/services/edge_llm_playground_service_test.dart
@@ -42,6 +42,7 @@ void main() {
 
     expect(capturedBody?['action'], 'edge_llm.invoke');
     expect(capturedBody?['tier'], 'budget');
+    expect(capturedBody?['temperature'], 0);
     expect(capturedBody?['offline_secure_mode'], false);
     expect(capturedBody?['context_data'], <String, dynamic>{'goal': '習慣化'});
     expect(response.provider, 'google');
@@ -156,9 +157,38 @@ void main() {
     expect(localBody?['model_path'], r'C:\models\pleias-rag.gguf');
     expect(localBody?['vector_db_path'], r'C:\rag\lancedb');
     expect(localBody?['network_policy'], 'offline_only');
+    expect(localBody?['temperature'], 0);
     expect(response.provider, 'local-rag');
     expect(response.tier, 'offline');
     expect(response.parsedJson?['citations'], isA<List>());
+    expect(response.citations.single.sourceId, 'doc-1');
     expect(response.source, 'local-rag runtime / pleias-rag');
+  });
+
+  test('invoke extracts citations from parsed JSON payloads', () async {
+    final service = EdgeLlmPlaygroundService(
+      invoker: (_) async {
+        return <String, dynamic>{
+          'success': true,
+          'provider': 'pleias',
+          'text': 'Common Corpus [source:1]',
+          'parsed_json': <String, dynamic>{
+            'citations': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'source_id': '1',
+                'title': 'common-corpus.md',
+                'snippet': 'Common Corpus is traceable training data.',
+              },
+            ],
+          },
+        };
+      },
+    );
+
+    final response = await service.invoke(userPrompt: 'Explain citations');
+
+    expect(response.text, 'Common Corpus [source:1]');
+    expect(response.citations.single.sourceId, '1');
+    expect(response.citations.single.title, 'common-corpus.md');
   });
 }

--- a/test/services/local_rag_runtime_service_test.dart
+++ b/test/services/local_rag_runtime_service_test.dart
@@ -43,6 +43,7 @@ void main() {
 
     expect(capturedBody?['offline_only'], true);
     expect(capturedBody?['network_policy'], 'offline_only');
+    expect(capturedBody?['temperature'], 0);
     expect(capturedBody?['model_path'], r'C:\models\pleias-rag.gguf');
     expect(response.text, contains('外部ネットワークなし'));
     expect(response.citations.single.sourceId, 'doc-1');
@@ -59,6 +60,35 @@ void main() {
         settings: const OfflineSecureModeSettings(enabled: true),
       ),
       throwsA(isA<LocalRagRuntimeException>()),
+    );
+  });
+
+  test('parsePleiasCitationText removes native source span tokens', () {
+    final parsed = parsePleiasCitationText(
+      'Answer <|source_start|>doc-1<|source_end|>quoted fact<|/source|> done',
+    );
+
+    expect(parsed.hasCitationTokens, isTrue);
+    expect(parsed.plainText, 'Answer quoted fact done');
+    expect(parsed.sourceIds, <String>['doc-1']);
+    expect(parsed.segments.where((segment) => segment.cited), hasLength(1));
+    expect(parsed.segments[1].text, 'quoted fact');
+  });
+
+  test('parsePleiasCitationText supports Pleias bracket source markers', () {
+    final parsed = parsePleiasCitationText(
+      'Pleias created Common Corpus [source:1] for traceable RAG.',
+    );
+
+    expect(parsed.hasCitationTokens, isTrue);
+    expect(
+      parsed.plainText,
+      'Pleias created Common Corpus [source:1] for traceable RAG.',
+    );
+    expect(parsed.sourceIds, <String>['1']);
+    expect(
+      parsed.segments.where((segment) => segment.markerOnly),
+      hasLength(1),
     );
   });
 }

--- a/test/widgets/pleias_citation_text_test.dart
+++ b/test/widgets/pleias_citation_text_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/local_rag_runtime_service.dart';
+import 'package:my_web_app/widgets/pleias_citation_text.dart';
+
+void main() {
+  testWidgets('renders Pleias source marker and opens source detail', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Scaffold(
+          body: PleiasCitationText(
+            text: 'Common Corpus [source:1]',
+            isDark: false,
+            citations: <LocalRagCitation>[
+              LocalRagCitation(
+                sourceId: '1',
+                title: 'common-corpus.md',
+                path: 'C:/rag/common-corpus.md',
+                snippet: 'Common Corpus is traceable training data.',
+                score: 0.92,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('[source:1]'), findsOneWidget);
+    expect(find.text('common-corpus.md'), findsOneWidget);
+
+    expect(
+      find.byTooltip(
+        'common-corpus.md\n'
+        'Common Corpus is traceable training data.\n'
+        'C:/rag/common-corpus.md\n'
+        'score 0.92',
+      ),
+      findsNWidgets(2),
+    );
+  });
+}


### PR DESCRIPTION
## Summary - Parse Pleias citation markers in both `[source:N]` and `<|source_start|>...<|source_end|>` forms. - Render Edge LLM Playground responses with highlighted citation markers and source tooltips. - Propagate citation metadata from local RAG / parsed JSON responses and pin Edge LLM + local RAG temperature to `0`.  Fixes #1263.  ## Validation - `flutter analyze --no-pub lib\services\local_rag_runtime_service.dart lib\services\edge_llm_playground_service.dart lib\pages\edge_llm_playground_page.dart lib\widgets\pleias_citation_text.dart test\services\local_rag_runtime_service_test.dart test\services\edge_llm_playground_service_test.dart test\widgets\pleias_citation_text_test.dart` - `flutter test --no-pub --no-test-assets test\services\local_rag_runtime_service_test.dart test\services\edge_llm_playground_service_test.dart test\widgets\pleias_citation_text_test.dart`  ## Minimal E2E Gate - This E2E test is implementation-detail independent: it validates visible response/source mapping and request payload contracts, not parser internals. - The plan is minimal, about three I/O cases:   1. Pleias native span token input -> tokens are removed, cited text remains, and source id is preserved.   2. Pleias `[source:N]` marker input -> marker remains visible and is mapped to returned source metadata.   3. Edge LLM Playground local RAG response -> citations are exposed to the UI and source tooltips can be rendered without hitting external providers. - E2E mechanism: Flutter service/widget tests cover the route-level I/O contract; Playwright/integration_test browser coverage is not required for this bounded rendering slice.  E2E-Exception: No `integration_test/` or `test/e2e/` file is added because this PR does not introduce a new route, auth flow, or browser-only behavior; it adds deterministic parser/service/widget coverage for the existing Edge LLM Playground response path.
## High-risk Ultrareview
- Review owner: Claude Code #1.
- Claude ultrareview evidence: security reviewed for text/citation rendering only; no auth, secret, credential, or external-provider trust boundary changes are introduced.
- Rollback: revert this PR to return Edge LLM Playground response rendering to the previous monospace `SelectableText` path.
- Data migration: none; this PR has no schema or persisted-data migration.
- Prod smoke: open Edge LLM Playground, submit a response containing `[source:1]`, and verify the answer plus citation chip/tooltip render without blocking the existing response path.
- Observability: citation metadata is kept on `EdgeLlmPlaygroundResponse`, preserving provider/observability payload handling while adding source visibility.
- Unresolved findings: 0.