### PR TITLE
test(tome): align deck studio assertions with Japanese output

### DIFF
--- a/test/services/tome_deck_studio_service_test.dart
+++ b/test/services/tome_deck_studio_service_test.dart
@@ -33,9 +33,9 @@ void main() {
     expect(plan.kpi['visual_blocks'], 5);
     expect(
       plan.pages.map((page) => page.title),
-      contains('Infographic export'),
+      contains('インフォグラフィック書き出し'),
     );
-    expect(plan.automationNotes.join('\n'), contains('quiz failures'));
+    expect(plan.automationNotes.join('\n'), contains('クイズ失敗'));
   });
 
   test('parses Airtable-style rows for competitor deck issue 758', () {
@@ -53,7 +53,7 @@ void main() {
     expect(plan.liveIntegrationReady, isFalse);
     expect(plan.kpi['airtable_rows_used'], 3);
     expect(plan.pages.first.narrative, contains('Tome, Gamma, Airtable'));
-    expect(markdown, contains('Automation Notes'));
+    expect(markdown, contains('自動化メモ'));
     expect(markdown, contains('Airtable'));
   });
 }


### PR DESCRIPTION
## Summary

- Update Tome Deck Studio service tests to assert the current Japanese-localized deck titles and markdown section headings.
- Keep service implementation unchanged; this fixes the CI mismatch tracked in #1997.

## Test plan

- [x] `flutter test test/services/tome_deck_studio_service_test.dart`
- [x] `dart analyze test/services/tome_deck_studio_service_test.dart lib/services/tome_deck_studio_service.dart`

## Minimal E2E Declaration

- The E2E approach is implementation-detail independent: this PR is test-only and verifies the service contract through generated deck output, not internal helper implementation.
- The plan is intentionally minimal, about three I/O cases already covered by the focused service test: investor deck, AI University infographic deck, and competitor Airtable deck.
- E2E mechanism: no `integration_test` or Playwright run is needed because there is no runtime app-code change; the focused Flutter service test is the appropriate smoke for this mismatch.

Fixes #1997