### PR TITLE
chore(skills): 3 wiki cleanup helpers を skill+command 二重 entry point 化 (part 142 #3)

### DIFF
--- a/.claude/commands/wiki-broken-cleanup.md
+++ b/.claude/commands/wiki-broken-cleanup.md
@@ -1,0 +1,58 @@
+---
+description: Karpathy Lint cycle 補完 — broken `[[wikilink]]` 真陽性を 4 カテゴリで backtick 化。wiki-broken-cleanup skill を呼ぶ thin slash wrapper (Karpathy Layer 3-2 / part 142 着地)。
+---
+
+# /wiki-broken-cleanup — Karpathy Lint cycle broken link cleanup
+
+Karpathy AI 外部脳 Lint cycle 後の broken `[[wikilink]]` を 4 カテゴリに分けて
+backtick 化する slash command。裏側は `.claude/skills/wiki-broken-cleanup/SKILL.md`
+(Layer 3-5 Agent Skill / part 142) 経由で `scripts/wiki_broken_cleanup.py` を呼ぶ。
+
+## 4 categories
+
+- **A dead memory file refs**: `[[stem]]` の file が存在しない (= 真 dead)
+- **B placeholder example refs**: `[[file]]` `[[<this file>]]` `[[wikilink]]` 等 (= 例文)
+- **C repo path refs**: `[[scripts/foo.py]]` `[[lib/.../foo.dart]]` (= cross-reference)
+- **D 任意 stem**: 動的検出された dead set
+
+## 実行
+
+`wiki-broken-cleanup` skill を Skill tool 経由で起動する。skill が未 surface の場合は直接:
+
+```bash
+# 1. fresh lint
+python scripts/knowledge_vault_lint.py \
+  --json-out docs/knowledge-vault-lint/$(date +%Y-%m-%d).json \
+  --output docs/knowledge-vault-lint/$(date +%Y-%m-%d).md
+
+# 2. dry-run
+python scripts/wiki_broken_cleanup.py \
+  --lint-json docs/knowledge-vault-lint/$(date +%Y-%m-%d).json --dry-run
+
+# 3. 本番
+python scripts/wiki_broken_cleanup.py \
+  --lint-json docs/knowledge-vault-lint/$(date +%Y-%m-%d).json
+```
+
+## 効果計測
+
+```bash
+python scripts/knowledge_vault_lint.py --report
+# broken 削減を確認 (= 理想 0)
+```
+
+## 後処理
+
+```bash
+find . -name "*.backup_part142_broken_cleanup" -not -path "./node_modules/*" -delete
+echo "- $(date +%Y-%m-%d) wiki-broken-cleanup: broken -<N> / Health +<N>" \
+  >> docs/GROWTH_STRATEGY_ROADMAP.md
+```
+
+## 関連
+
+- skill: `wiki-broken-cleanup` (.claude/skills/wiki-broken-cleanup/SKILL.md)
+- script: `scripts/wiki_broken_cleanup.py` (part 142)
+- 並列 cleanup: `/wiki-orphan-batch` `/wiki-dup-h1-cleanup`
+- 前段: `/wiki-lint`
+- 実績: part 142 で broken 95 → 0 (-95)

--- a/.claude/commands/wiki-dup-h1-cleanup.md
+++ b/.claude/commands/wiki-dup-h1-cleanup.md
@@ -1,0 +1,68 @@
+---
+description: Karpathy Lint cycle 補完 — duplicate H1 を path/stem suffix で unique 化。wiki-dup-h1-cleanup skill を呼ぶ thin slash wrapper (Karpathy Layer 3-2 / part 142 着地)。
+---
+
+# /wiki-dup-h1-cleanup — Karpathy Lint cycle duplicate H1 cleanup
+
+Karpathy AI 外部脳 Lint cycle 後の duplicate H1 を path/stem suffix で unique 化する
+slash command。裏側は `.claude/skills/wiki-dup-h1-cleanup/SKILL.md`
+(Layer 3-5 Agent Skill / part 142) 経由で `scripts/wiki_dup_h1_cleanup.py` を呼ぶ。
+
+## 2 type strategy
+
+- **Type A — 同 basename / 異 path**: H1 += suffix で unique 化
+  - `docs/archive/` → `[Archive]`
+  - `cross-instance-prs/done/` → `[Done]`
+  - `blog/cross-post/` → `[Cross-Post]`
+  - `blog/github-pages/` → `[GitHub Pages]`
+  - `blog/zenn/` → `[Zenn]`
+  - `competitor-reports/` → `[Competitor Report]`
+
+- **Type B — 異 basename / 同 H1 (= template H1)**: H1 += `— <filename-stem>`
+
+## 実行
+
+`wiki-dup-h1-cleanup` skill を Skill tool 経由で起動する。skill が未 surface の場合は直接:
+
+```bash
+# 1. fresh lint
+python scripts/knowledge_vault_lint.py \
+  --json-out docs/knowledge-vault-lint/$(date +%Y-%m-%d).json \
+  --output docs/knowledge-vault-lint/$(date +%Y-%m-%d).md
+
+# 2. dry-run
+python scripts/wiki_dup_h1_cleanup.py \
+  --lint-json docs/knowledge-vault-lint/$(date +%Y-%m-%d).json --dry-run
+
+# 3. 本番
+python scripts/wiki_dup_h1_cleanup.py \
+  --lint-json docs/knowledge-vault-lint/$(date +%Y-%m-%d).json
+```
+
+## 効果計測
+
+```bash
+python scripts/knowledge_vault_lint.py --report
+# duplicate 削減を確認 (= 理想 0)
+```
+
+## 残 dup 手動補正
+
+Type A archive 内の subdir 2 重 (e.g., `docs/archive/<file>.md` + `docs/archive/<sub>/<file>.md`) は
+両方に同 suffix が付くため、後者を `[Archive YYYY]` 等に手動置換。
+
+## 後処理
+
+```bash
+find . -name "*.backup_part142_dup_cleanup" -not -path "./node_modules/*" -delete
+echo "- $(date +%Y-%m-%d) wiki-dup-h1-cleanup: dup -<N> / Health +<N>" \
+  >> docs/GROWTH_STRATEGY_ROADMAP.md
+```
+
+## 関連
+
+- skill: `wiki-dup-h1-cleanup` (.claude/skills/wiki-dup-h1-cleanup/SKILL.md)
+- script: `scripts/wiki_dup_h1_cleanup.py` (part 142)
+- 並列 cleanup: `/wiki-orphan-batch` `/wiki-broken-cleanup`
+- 前段: `/wiki-lint`
+- 実績: part 142 で duplicate 30 → 0 (= 26 自動 + 4 手動補正)

--- a/.claude/commands/wiki-orphan-batch.md
+++ b/.claude/commands/wiki-orphan-batch.md
@@ -1,0 +1,55 @@
+---
+description: Karpathy Lint cycle 補完 — top-N orphan/missing-index を MEMORY index へ batch wikilink 化。wiki-orphan-batch skill を呼ぶ thin slash wrapper (Karpathy Layer 3-2 / part 142 着地)。
+---
+
+# /wiki-orphan-batch — Karpathy Lint cycle batch cleanup (orphan/missing-index)
+
+Karpathy AI 外部脳 Lint cycle 後の orphan/missing-index 大量項目を MEMORY index へ
+batch wikilink 化する slash command。裏側は `.claude/skills/wiki-orphan-batch/SKILL.md`
+(Layer 3-5 Agent Skill / part 142) 経由で `scripts/wiki_orphan_batch.py` を呼ぶ。
+
+## 実行
+
+`wiki-orphan-batch` skill を Skill tool 経由で起動する。skill が未 surface の場合は直接:
+
+```bash
+# 1. fresh lint
+python scripts/knowledge_vault_lint.py \
+  --json-out docs/knowledge-vault-lint/$(date +%Y-%m-%d).json \
+  --output docs/knowledge-vault-lint/$(date +%Y-%m-%d).md
+
+# 2. dry-run
+python scripts/wiki_orphan_batch.py --lint-json auto --top 50 --dry-run
+
+# 3. 本番 (orphan source / project_+feedback_success_)
+python scripts/wiki_orphan_batch.py --lint-json auto --top 50 \
+  --source orphans --prefixes "project_,feedback_success_" \
+  --marker "<!-- wiki-batch $(date +%Y-%m-%d) orphans -->"
+
+# 4. 本番 (missing_index source / 全 prefix)
+python scripts/wiki_orphan_batch.py --lint-json auto --top 250 \
+  --source missing_index \
+  --prefixes "project_,feedback_correction_,feedback_success_,query_artifact_,reference_,user_" \
+  --marker "<!-- wiki-batch $(date +%Y-%m-%d) missing-idx -->"
+```
+
+## 効果計測
+
+```bash
+python scripts/knowledge_vault_lint.py --report
+```
+
+## 後処理
+
+```bash
+echo "- $(date +%Y-%m-%d) wiki-orphan-batch: orphan -<N> / missing -<N> / Health +<N>" \
+  >> docs/GROWTH_STRATEGY_ROADMAP.md
+```
+
+## 関連
+
+- skill: `wiki-orphan-batch` (.claude/skills/wiki-orphan-batch/SKILL.md)
+- script: `scripts/wiki_orphan_batch.py` (part 142)
+- 並列 cleanup: `/wiki-broken-cleanup` `/wiki-dup-h1-cleanup`
+- 前段: `/wiki-lint`
+- 実績: part 142 で orphan -440 / missing -904 / Health 0→72

--- a/.claude/skills/wiki-broken-cleanup/SKILL.md
+++ b/.claude/skills/wiki-broken-cleanup/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: wiki-broken-cleanup
+description: |
+  Karpathy Lint cycle 後の broken `[[wikilink]]` を 4 カテゴリに分けて backtick 化する
+  自走 skill (= part 142 確立 / wiki_broken_cleanup.py thin wrapper)。
+  ユーザー発話 (= 「broken link cleanup」「wikilink 修正」「dead link 一掃」
+  「placeholder backtick 化」) を検知し scripts/wiki_broken_cleanup.py を呼ぶ。
+  Categories: A dead memory refs / B placeholder / C repo path / D 任意 stem。
+  Triggers on: "/wiki-broken-cleanup", "broken link cleanup", "wikilink 修正",
+  "dead link 一掃", "placeholder backtick 化", "broken link 真陽性 cleanup".
+---
+
+# Wiki Broken Cleanup Skill (Karpathy Lint cycle 補完 / part 142)
+
+Karpathy AI 外部脳の **Lint → 自動 cleanup 4 段 cycle** の 2 番目段。
+`scripts/wiki_broken_cleanup.py` (part 142) を呼んで broken `[[wikilink]]` を
+backtick 化 (= `[[xxx]]` → `` `xxx` ``) で wikilink 解析対象外にする。
+
+## いつ実行するか
+
+- `wiki-lint` で broken 50+ 検出時
+- 月次 cleanup で dup → broken → orphan の順で本 skill を 2 番目に走らせる
+- `/wiki-broken-cleanup` slash command 実行時
+- 「broken link 真陽性 cleanup」「placeholder noise 排除」発話時
+
+## 4 categories
+
+- **A dead memory file refs**: `[[stem]]` の file が存在しない (= 真 dead)
+- **B placeholder example refs**: `[[file]]` `[[<this file>]]` `[[wikilink]]` 等 (= 例文)
+- **C repo path refs**: `[[scripts/foo.py]]` `[[lib/.../foo.dart]]` (= cross-reference)
+- **D 任意 stem**: 動的検出された dead set
+
+## 実行ステップ
+
+### Step 1: 最新 lint JSON 取得
+
+```bash
+python scripts/knowledge_vault_lint.py \
+  --json-out docs/knowledge-vault-lint/$(date +%Y-%m-%d).json \
+  --output docs/knowledge-vault-lint/$(date +%Y-%m-%d).md
+```
+
+### Step 2: dry-run で件数事前確認
+
+```bash
+python scripts/wiki_broken_cleanup.py \
+  --lint-json docs/knowledge-vault-lint/$(date +%Y-%m-%d).json --dry-run
+```
+
+### Step 3: 本番適用
+
+```bash
+python scripts/wiki_broken_cleanup.py \
+  --lint-json docs/knowledge-vault-lint/$(date +%Y-%m-%d).json
+```
+
+backup file (`.backup_part142_broken_cleanup`) が自動作成される。
+
+### Step 4: 効果計測
+
+```bash
+python scripts/knowledge_vault_lint.py --report
+# broken 削減を確認 (= 理想 0)
+```
+
+### Step 5: backup 削除 (= clean commit 用)
+
+```bash
+find . -name "*.backup_part142_broken_cleanup" -not -path "./node_modules/*" -delete
+```
+
+### Step 6: ROADMAP-LOG 記録
+
+```bash
+echo "- $(date +%Y-%m-%d) wiki-broken-cleanup: broken -<N> / Health +<N>" \
+  >> docs/GROWTH_STRATEGY_ROADMAP.md
+```
+
+## 設計判断
+
+- backtick 化は wikilink 解析対象外にしつつ表示は維持 (= 元情報残す)
+- placeholder と dead と repo path を 1 script で同時 cleanup
+- `lint script の knowledge-vault-lint/ 自参照除外` patch (= part 142) と併用必須
+
+## 関連 skill
+
+- `wiki-lint`: 本 skill の前段 (= 検出)
+- `wiki-orphan-batch`: 並列 cleanup (= orphan)
+- `wiki-dup-h1-cleanup`: 並列 cleanup (= duplicate H1)
+
+## 実績 (= part 142 で確立)
+
+- broken 95 → 0 (-95) ✅ 単一 part 内達成

--- a/.claude/skills/wiki-dup-h1-cleanup/SKILL.md
+++ b/.claude/skills/wiki-dup-h1-cleanup/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: wiki-dup-h1-cleanup
+description: |
+  Karpathy Lint cycle 後の duplicate H1 を path/stem suffix で unique 化する自走 skill
+  (= part 142 確立 / wiki_dup_h1_cleanup.py thin wrapper)。
+  ユーザー発話 (= 「dup H1 cleanup」「duplicate title 解消」「重複タイトル fix」
+  「H1 unique 化」) を検知し scripts/wiki_dup_h1_cleanup.py を呼ぶ。
+  Type A path-rule (Archive/Done/Cross-Post/Zenn/etc) + Type B stem suffix。
+  Triggers on: "/wiki-dup-h1-cleanup", "dup H1 cleanup", "duplicate title 解消",
+  "重複タイトル fix", "H1 unique 化", "duplicate H1 batch".
+---
+
+# Wiki Duplicate H1 Cleanup Skill (Karpathy Lint cycle 補完 / part 142)
+
+Karpathy AI 外部脳の **Lint → 自動 cleanup 4 段 cycle** の 3 番目段。
+`scripts/wiki_dup_h1_cleanup.py` (part 142) を呼んで duplicate H1 を path/stem suffix
+で unique 化する。
+
+## いつ実行するか
+
+- `wiki-lint` で duplicate 10+ 検出時
+- 月次 cleanup の 1 番目 (= dup → broken → orphan の順)
+- `/wiki-dup-h1-cleanup` slash command 実行時
+- 「同じ H1 が複数 file に」発話時
+
+## 2 type strategy
+
+- **Type A — 同 basename / 異 path**: H1 += suffix で unique 化
+  - `docs/archive/` → `[Archive]`
+  - `cross-instance-prs/done/` → `[Done]`
+  - `blog/cross-post/` → `[Cross-Post]`
+  - `blog/github-pages/` → `[GitHub Pages]`
+  - `blog/zenn/` → `[Zenn]`
+  - `competitor-reports/` → `[Competitor Report]`
+
+- **Type B — 異 basename / 同 H1 (= template H1)**: H1 += `— <filename-stem>`
+
+## 実行ステップ
+
+### Step 1: 最新 lint JSON 取得
+
+```bash
+python scripts/knowledge_vault_lint.py \
+  --json-out docs/knowledge-vault-lint/$(date +%Y-%m-%d).json \
+  --output docs/knowledge-vault-lint/$(date +%Y-%m-%d).md
+```
+
+### Step 2: dry-run で件数事前確認
+
+```bash
+python scripts/wiki_dup_h1_cleanup.py \
+  --lint-json docs/knowledge-vault-lint/$(date +%Y-%m-%d).json --dry-run
+```
+
+### Step 3: 本番適用
+
+```bash
+python scripts/wiki_dup_h1_cleanup.py \
+  --lint-json docs/knowledge-vault-lint/$(date +%Y-%m-%d).json
+```
+
+backup file (`.backup_part142_dup_cleanup`) が自動作成される。
+
+### Step 4: 効果計測
+
+```bash
+python scripts/knowledge_vault_lint.py --report
+# duplicate 削減を確認 (= 理想 0)
+```
+
+### Step 5: 残 dup 手動補正 (= 同 archive subdir の 2 重)
+
+```bash
+# e.g., docs/archive/<file>.md と docs/archive/<sub>/<file>.md 両方に [Archive] が付く
+# → 後者を [Archive YYYY] に手動置換
+```
+
+### Step 6: backup 削除 (= clean commit 用)
+
+```bash
+find . -name "*.backup_part142_dup_cleanup" -not -path "./node_modules/*" -delete
+```
+
+### Step 7: ROADMAP-LOG 記録
+
+```bash
+echo "- $(date +%Y-%m-%d) wiki-dup-h1-cleanup: dup -<N> / Health +<N>" \
+  >> docs/GROWTH_STRATEGY_ROADMAP.md
+```
+
+## 設計判断
+
+- H1 一意化のみ (= file rename / delete 禁止 / human-in-the-loop)
+- 既存 path-rule で大半 cover / 残 edge case は手動 patch
+- backup 自動作成で reviewer 可視化
+
+## 関連 skill
+
+- `wiki-lint`: 本 skill の前段 (= 検出)
+- `wiki-orphan-batch`: 並列 cleanup (= orphan)
+- `wiki-broken-cleanup`: 並列 cleanup (= broken link)
+
+## 実績 (= part 142 で確立)
+
+- duplicate H1 30 → 0 (-30) ✅ 単一 part 内達成 (= 26 自動 + 4 手動補正)

--- a/.claude/skills/wiki-orphan-batch/SKILL.md
+++ b/.claude/skills/wiki-orphan-batch/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: wiki-orphan-batch
+description: |
+  Karpathy Lint cycle 後の orphan/missing-index 大量項目を MEMORY index へ
+  batch wikilink 化する自走 skill (= part 142 確立 / wiki_orphan_batch.py thin wrapper)。
+  ユーザー発話 (= 「orphan batch やって」「missing index 一掃」「memory index 追記」
+  「wikilink batch」) を検知し scripts/wiki_orphan_batch.py を呼ぶ。
+  --source orphans|missing_index + --prefixes <csv> で柔軟化。月次分割
+  MEMORY_<period>.md へ自動振分。
+  Triggers on: "/wiki-orphan-batch", "orphan batch", "missing index 一掃",
+  "memory index 追記", "wikilink batch", "MEMORY index 拡張", "vault index cleanup".
+---
+
+# Wiki Orphan Batch Skill (Karpathy Lint cycle 補完 / part 142)
+
+Karpathy AI 外部脳の **Lint → 自動 cleanup 4 段 cycle** の cleanup 段を担う skill。
+`scripts/wiki_orphan_batch.py` (part 142) を呼んで top-N 件の memory file orphan を
+MEMORY index へ `[[stem]]` 行として batch 追記する。
+
+## いつ実行するか
+
+- `wiki-lint` で orphan 100+ or missing-idx 200+ 検出時
+- 月次 cleanup の前段 (= dup → broken → orphan の順)
+- `/wiki-orphan-batch` slash command 実行時
+- 「memory index 拡張したい」「orphan 多すぎ」発話時
+
+## 実行ステップ
+
+### Step 1: 最新 lint JSON 取得
+
+```bash
+python scripts/knowledge_vault_lint.py \
+  --json-out docs/knowledge-vault-lint/$(date +%Y-%m-%d).json \
+  --output docs/knowledge-vault-lint/$(date +%Y-%m-%d).md
+```
+
+### Step 2: dry-run で件数事前確認
+
+```bash
+python scripts/wiki_orphan_batch.py --lint-json auto --top 50 --dry-run
+```
+
+### Step 3: 本番適用
+
+```bash
+# orphan source (= default)
+python scripts/wiki_orphan_batch.py --lint-json auto --top 50 \
+  --source orphans --prefixes "project_,feedback_success_" \
+  --marker "<!-- wiki-batch $(date +%Y-%m-%d) orphans -->"
+
+# missing_index source (= idx 拡張)
+python scripts/wiki_orphan_batch.py --lint-json auto --top 250 \
+  --source missing_index \
+  --prefixes "project_,feedback_correction_,feedback_success_,query_artifact_,reference_,user_" \
+  --marker "<!-- wiki-batch $(date +%Y-%m-%d) missing-idx -->"
+```
+
+### Step 4: 効果計測
+
+```bash
+python scripts/knowledge_vault_lint.py --report
+# orphan / missing-idx 削減を確認
+```
+
+### Step 5: ROADMAP-LOG 記録
+
+```bash
+echo "- $(date +%Y-%m-%d) wiki-orphan-batch: orphan -<N> / missing -<N> / Health +<N>" \
+  >> docs/GROWTH_STRATEGY_ROADMAP.md
+```
+
+## 設計判断
+
+- 既存 `scripts/wiki_orphan_batch.py` を skill 層から呼ぶ thin wrapper
+- `--marker` で重複防止 (= 同一 batch 二重 append 不能)
+- 月次分割 `MEMORY_<period>.md` へ `extract_yyyymm()` で自動振分
+- 自動修正は memory dir の MEMORY*.md のみ (= repo 影響なし / human-in-the-loop)
+
+## 関連 skill
+
+- `wiki-lint`: 本 skill の前段 (= 検出)
+- `wiki-broken-cleanup`: 並列 cleanup (= broken link)
+- `wiki-dup-h1-cleanup`: 並列 cleanup (= duplicate H1)
+- `wiki-compile`: index 構築の上位
+
+## 実績 (= part 142 で確立)
+
+- batch 1-5 で orphan 2553→2113 (-440) / missing-idx 907→3 (-904)
+- Health Score 0→72 単一 part 内達成


### PR DESCRIPTION
## Summary

Win版#132 part 142 follow-up #3 / 2026-05-05.

PR #2007 + #2008 で shipping した 3 helper script を `.claude/skills/` + `.claude/commands/` の二重 entry point 化。part 140 で確立した pattern (= skill + command 二重 entry point) の transfer。

## 新規 file (= 6)

- `.claude/skills/wiki-orphan-batch/SKILL.md` + `.claude/commands/wiki-orphan-batch.md`
- `.claude/skills/wiki-broken-cleanup/SKILL.md` + `.claude/commands/wiki-broken-cleanup.md`
- `.claude/skills/wiki-dup-h1-cleanup/SKILL.md` + `.claude/commands/wiki-dup-h1-cleanup.md`

## Loader smoke test (= 確認済)

- 全 3 skill が即 surface (= 自然言語 + slash 両 entry 動作確認)
- 既存 4 wiki skill (ingest/compile/query/lint) と命名空間整合

## 自然言語 trigger 例

| skill | trigger 発話 |
| --- | --- |
| wiki-orphan-batch | 「orphan batch やって」「missing index 一掃」「wikilink batch」 |
| wiki-broken-cleanup | 「broken link cleanup」「placeholder backtick 化」 |
| wiki-dup-h1-cleanup | 「dup H1 cleanup」「重複タイトル fix」「H1 unique 化」 |

## E2E exempt

E2E exempt: scripts/skills/commands docs only — application code 変更なし。Minimal E2E declaration 対象外。

## dogfood

- SECOND_BRAIN #4 (Lint cycle 自走化を skill 層まで拡張)
- INDIE_DEV_VELOCITY #1 (Memory)
- BRAIN-32 7/7 強化 (= 4 cycle 全段が skill + command で trigger 可能に)
- Karpathy Layer 3-2 + Layer 3-5 both 完成 (= part 140 pattern transfer 完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)