### PR TITLE
docs(cross-instance): WBS overdue 8 件 5-question 振分 + Codex hand off (part 142)

### DIFF
--- a/docs/MAINTENANCE_MODE_SPEC.md
+++ b/docs/MAINTENANCE_MODE_SPEC.md
@@ -1,0 +1,181 @@
+# Maintenance Mode + Planned Outage Dashboard — UI/設計 spec (#1309 / part 142)
+
+> **status**: 設計 spec / Win版#132 part 142 / 2026-05-05
+> **issue**: [#1309](https://github.com/kanta13jp1/my_web_app/issues/1309) [追加要望] 計画停止情報のダッシュボード表示および自動メンテナンスモードの実装
+> **scope**: 設計のみ (Win Claude territory) / 実装は Win Codex (= EF Deno + SQL migration + Flutter widget) ハンドオフ
+> **NotebookLM source**: `f404e403` CATS System Planned Outage Notification and Correspondence
+
+## 1. 機能概要
+
+3 layer:
+
+| layer | 役割 | 担当 |
+|---|---|---|
+| **L1 admin 登録 UI** | 計画停止 (= window) を CRUD | Flutter widget (CFO 部署 admin page) |
+| **L2 user 事前通知 banner** | window 前 N 日 (default 3 日) から表示 | Flutter widget (= 全 page 上部 / Layout) |
+| **L3 maintenance mode 自動切替** | window 中は機能 / 全体 lockdown | router guard + EF response 503 |
+
+## 2. Schema (= Win Codex 担当 / 1 migration)
+
+```sql
+-- supabase/migrations/<YYYYMMDDHHMMSS>_create_maintenance_windows.sql
+
+CREATE TABLE public.maintenance_windows (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope text NOT NULL DEFAULT 'system'
+    CHECK (scope IN ('system','feature')),
+  affected_features text[] NOT NULL DEFAULT '{}',  -- scope='feature' 時のみ
+  starts_at timestamptz NOT NULL,
+  ends_at timestamptz NOT NULL CHECK (ends_at > starts_at),
+  notice_days_before int NOT NULL DEFAULT 3 CHECK (notice_days_before >= 0),
+  message_ja text NOT NULL,
+  message_en text,
+  severity text NOT NULL DEFAULT 'info'
+    CHECK (severity IN ('info','warning','critical')),
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 高速 lookup 用 index (= banner / mode 判定 hot path)
+CREATE INDEX maintenance_windows_active_lookup
+  ON public.maintenance_windows (starts_at, ends_at)
+  WHERE ends_at > now();
+
+-- RLS: read = 全員 / write = service_role (= admin EF 経由のみ)
+ALTER TABLE public.maintenance_windows ENABLE ROW LEVEL SECURITY;
+CREATE POLICY mw_public_read ON public.maintenance_windows FOR SELECT USING (true);
+```
+
+## 3. EF 設計 (= 既存 hub 拡張 / [EF-FIRST] [EF-CAP-50] 遵守)
+
+**`schedule-hub`** に 4 action 追加:
+
+| action | 入力 | 出力 | 認可 |
+|---|---|---|---|
+| `maintenance.list_active` | `now?: ISO` | `[{id, scope, message, banner_visible_from, ...}]` | public |
+| `maintenance.create` | window full payload | `{id}` | admin only |
+| `maintenance.update` | `id`, partial payload | `{id}` | admin only |
+| `maintenance.delete` | `id` | `{ok}` | admin only |
+
+= 新 EF ゼロ (= [EF-CAP-50] 維持)。
+
+## 4. Flutter UI 設計 (= Win Codex 担当)
+
+### 4.1 admin 登録 page (= L1)
+
+`lib/pages/admin/maintenance_management_page.dart`:
+
+```
+┌─ AppBar: 「計画停止管理」+ Add (+) button ──────────┐
+├─ DataTable                                          │
+│  | scope | features | starts_at | ends_at | sev |  │
+│  |────────|──────────|───────────|─────────|─────| │
+│  | system | -        | 05/10 02:00 | 05/10 04:00 | warn |  │
+│  | feature | [ai-hub] | 05/15 14:00 | 05/15 15:00 | info |  │
+│ (rows tap → edit dialog / delete with confirmation) │
+└──────────────────────────────────────────────────────┘
+```
+
+Edit dialog:
+- scope radio: system / feature
+- feature multiselect (= scope=feature 時のみ enable / from EF list)
+- starts/ends date+time picker
+- notice_days_before slider (0-14)
+- message_ja TextField (multiline / required)
+- message_en TextField (optional)
+- severity dropdown (info/warning/critical)
+
+### 4.2 user banner (= L2)
+
+`lib/widgets/maintenance_banner.dart` を全 page 上部 (= MaterialApp.builder で wrap):
+
+```
+┌─ Banner (severity=info: blue / warning: amber / critical: red) ──┐
+│ ⚠️ 2026-05-10 02:00-04:00 に system 計画停止予定                  │
+│    → 詳細 / 通知設定 [×]                                          │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+表示条件:
+- now ≥ starts_at - notice_days_before AND now < ends_at
+- ユーザー dismiss は session 内のみ (= 翌 session で再表示)
+- 5 分間隔で polling (= NetworkImage + cache に近い軽量 query)
+
+### 4.3 maintenance mode page (= L3)
+
+`lib/pages/maintenance_mode_page.dart`:
+
+```
+┌─ Centered card ──────────────────────────────────┐
+│  🛠️ メンテナンス中                              │
+│                                                  │
+│  <message_ja>                                    │
+│                                                  │
+│  予定終了: 2026-05-10 04:00 JST                  │
+│  ([残り時間 1h 23m] live update)                 │
+│                                                  │
+│  [ 復旧後に通知を受け取る (email) ]              │
+└──────────────────────────────────────────────────┘
+```
+
+router guard:
+- `lib/services/maintenance_guard.dart` で全 route 前に check
+- scope=system → 全 route → MaintenanceModePage
+- scope=feature → affected_features に含まれる route のみ → MaintenanceModePage
+- admin route (`/admin/*`) は常に bypass (= 解除作業可能)
+
+### 4.4 cache 戦略 (= 受け入れ条件 / 「画面描画が遅延しないよう」)
+
+- `MaintenanceService` は in-memory cache (= TTL 5 分 / Riverpod Provider)
+- 起動時に 1 回 prefetch (= main() / runApp 前)
+- 5 分後 background refresh (= 期限切れ window 自動 hide)
+
+## 5. 受け入れ条件 mapping
+
+| # | 受け入れ条件 | 設計 mapping | 担当 |
+|---|---|---|---|
+| 1 | admin が CRUD 可 | `MaintenanceManagementPage` + `schedule-hub` 4 action | Win Codex |
+| 2 | N 日前から banner 表示 | `MaintenanceBanner` + `notice_days_before` field | Win Codex |
+| 3 | 期間中 機能 / 全体 lockdown | `MaintenanceGuard` + `MaintenanceModePage` | Win Codex |
+| 4 | 期間後 自動解除 | `ends_at < now()` で natural exit (= polling で hide) | Win Codex |
+
+## 6. 9 原則チェック (= [PHILOSOPHY-22])
+
+| # | 原則 | 該当 |
+|---|---|---|
+| 1 | CEO 感 | ✅ 自社 SaaS の運用 transparency = CEO らしさ |
+| 2 | ミッション | ✅ ユーザー体験劣化を最小化 |
+| 4 | 6 部署 | ✅ CTO 部署 (= 運用) で window 管理 |
+| 5 | 商品=価値 | ✅ 信頼性 = 価値 (= MTBF / MTTR の透明化) |
+| 8 | KPI | ✅ planned downtime % を CFO ledger 反映可能 |
+
+= **5/9 直接該当 / 7+/9 ✅ 閾値クリア**
+
+## 7. IMBUE-25 / COLLAB-26 (= UX 設計原則)
+
+| pattern | 該当 |
+|---|---|
+| IMBUE #1 (= 即座 feedback) | banner = 画面遷移なし即視認 |
+| IMBUE #4 (= proactive 警告) | N 日前 notice |
+| COLLAB #2 (= human override) | admin bypass |
+
+## 8. 実装手順 (= Win Codex hand off / 6 step)
+
+1. `supabase/migrations/<ts>_create_maintenance_windows.sql` 起票 (= section 2)
+2. `supabase/functions/schedule-hub/index.ts` に 4 action 追加 (= section 3)
+3. `lib/services/maintenance_service.dart` 新規 (= cache 5min TTL)
+4. `lib/widgets/maintenance_banner.dart` 新規 + MaterialApp.builder で wrap
+5. `lib/pages/maintenance_mode_page.dart` + `lib/services/maintenance_guard.dart` 新規
+6. `lib/pages/admin/maintenance_management_page.dart` + `/admin/maintenance` route 追加
+
+## 9. 次回拡張 (= part 143+)
+
+- email 復旧通知 (= L3 #4 button / Resend integration)
+- multi-language (= en 以外も)
+- Slack notification on window create
+- Status page 統合 (= statuspage.io 互換 endpoint)
+
+---
+
+**Spec status**: 設計完了 / 実装ハンドオフ準備済 → cross-instance-pr 経由で Win Codex へ

--- a/docs/MONETIZATION_DESIGN.md
+++ b/docs/MONETIZATION_DESIGN.md
@@ -1,0 +1,177 @@
+# Monetization Design — Stripe + Freemium (#1305 / part 142)
+
+> **status**: 設計 spec / Win版#132 part 142 / 2026-05-05
+> **issue**: [#1305](https://github.com/kanta13jp1/my_web_app/issues/1305) [追加要望] 初期リリース用 Stripe 決済基盤の統合とフリーミアムモデル導入
+> **scope**: 設計のみ (Win Claude territory) / 実装は Win Codex (= EF Deno + Flutter widget) ハンドオフ
+> **NotebookLM source**: `bc98957a` The 30-Day SaaS Blueprint: From Zero to $1,287 MRR
+
+## 1. Tier matrix
+
+| tier | 月額 | 無料枠 | 主要機能 | target ARPU |
+|---|---:|---|---|---:|
+| **Free** | ¥0 | AI 質問 30 回/月 / EF call 100 回/月 / 自分株式会社 6 部署 read-only | onboarding / 価値検証 | ¥0 |
+| **Pro** | **¥980** (= USD 9.99 ≒ JPY 980 + tax 内含) | 無制限 + AI 大学全コース + Mobile UAT priority | indie 個人 fits | ¥980 |
+| **Team** (= future) | ¥2,980/seat | Pro 全機能 + 5 user share + audit log | small team / part 143+ | ¥2,980 |
+
+Tier 戦略根拠 (= NotebookLM bc98957a):
+- 「課金の先延ばしはプロダクトの真の価値検証を妨げる」(= 即課金で signal 取得)
+- ¥980 は「Indie monthly」最頻価格帯 (= ChatGPT Plus / Notion Plus と同価格 anchor)
+
+## 2. Stripe schema (= Supabase 側 / 既存 `users` 拡張)
+
+### 新 schema (= 1 migration / Win Codex 担当)
+
+```sql
+-- supabase/migrations/<YYYYMMDDHHMMSS>_create_billing_tables.sql
+
+CREATE TABLE public.billing_subscriptions (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  stripe_customer_id text UNIQUE NOT NULL,
+  stripe_subscription_id text UNIQUE,
+  tier text NOT NULL DEFAULT 'free' CHECK (tier IN ('free','pro','team')),
+  status text NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active','past_due','canceled','trialing','incomplete')),
+  current_period_end timestamptz,
+  cancel_at_period_end boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.billing_usage_counters (
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  period_start date NOT NULL,  -- 月初固定 (= 月次リセット)
+  ai_query_count int NOT NULL DEFAULT 0,
+  ef_call_count int NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, period_start)
+);
+
+-- RLS: ユーザは自分の billing only / writes は service_role / EF 経由のみ
+ALTER TABLE public.billing_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.billing_usage_counters ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY billing_sub_self_read ON public.billing_subscriptions
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY billing_usage_self_read ON public.billing_usage_counters
+  FOR SELECT USING (auth.uid() = user_id);
+```
+
+## 3. Edge Function 設計 (= 既存 hub 統合 / [EF-FIRST] [EF-CAP-50] 遵守)
+
+### 既存 hub 拡張 案 (= 新規 EF 作らない / cap 49→49 維持)
+
+**`schedule-hub`** に 2 action 追加:
+
+| action | 入力 | 出力 | 用途 |
+|---|---|---|---|
+| `billing.create_checkout_session` | `tier: 'pro'\|'team'`, `return_url` | `{checkout_url}` | Flutter から Stripe Checkout へ遷移 |
+| `billing.create_portal_session` | `return_url` | `{portal_url}` | 既 sub 解約・カード更新 |
+
+### 新規 EF (= 1 本のみ / Webhook endpoint 専用 / cap 49→50)
+
+**`stripe-webhook`** (= signature verification 必須 / [MCP-AUTH-27] #2 deny-by-default):
+
+```typescript
+// supabase/functions/stripe-webhook/index.ts
+import Stripe from "https://esm.sh/stripe@14";
+import { createClient } from "@supabase/supabase-js";
+
+Deno.serve(async (req) => {
+  const sig = req.headers.get("stripe-signature");
+  if (!sig) return new Response("missing sig", { status: 400 });
+  const body = await req.text();
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      body, sig, Deno.env.get("STRIPE_WEBHOOK_SECRET")!,
+    );
+  } catch { return new Response("invalid sig", { status: 400 }); }
+
+  switch (event.type) {
+    case "checkout.session.completed":
+      await upgradeToPro(event.data.object);
+      break;
+    case "customer.subscription.deleted":
+      await downgradeToFree(event.data.object);
+      break;
+    case "invoice.payment_failed":
+      await markPastDue(event.data.object);
+      break;
+  }
+  return new Response("ok");
+});
+```
+
+## 4. Flutter 側 (= 既存 `lib/services/` 拡張 / Win Codex)
+
+### 新 service (= 1 file / 表示+操作のみ / [EF-FIRST] 遵守)
+
+```dart
+// lib/services/billing_service.dart
+class BillingService {
+  Future<String> createCheckoutSession({required String tier}) async {
+    final res = await _supabase.functions.invoke(
+      'schedule-hub',
+      body: {'action': 'billing.create_checkout_session',
+             'tier': tier,
+             'return_url': _appReturnUrl},
+    );
+    return res.data['checkout_url'] as String;
+  }
+
+  Future<BillingSub> currentSubscription() async {
+    final row = await _supabase
+        .from('billing_subscriptions')
+        .select()
+        .eq('user_id', _userId)
+        .maybeSingle();
+    return BillingSub.fromJson(row ?? {'tier': 'free'});
+  }
+}
+```
+
+### UI (= 1 page / 既存 settings / WIP)
+
+`lib/pages/billing_page.dart`: tier 比較 table + Upgrade button (= 既存 design system 流用 / [DESIGN] tokens)。
+
+## 5. 受け入れ条件 mapping (= Issue #1305)
+
+| # | 受け入れ条件 | 設計 mapping | 担当 |
+|---|---|---|---|
+| 1 | Flutter から Stripe Checkout 呼出可 | `BillingService.createCheckoutSession` + `url_launcher` | Win Codex |
+| 2 | Supabase で利用回数 + sub 状態管理 | `billing_subscriptions` + `billing_usage_counters` table | Win Codex |
+| 3 | Webhook で sub 完了時に Pro 昇格 | `stripe-webhook` EF + `upgradeToPro()` | Win Codex |
+
+## 6. 9 原則チェック (= [PHILOSOPHY-22])
+
+| # | 原則 | 該当 |
+|---|---|---|
+| 1 | CEO 感 | ✅ 自分株式会社の CFO 部署で billing 管理 (= Pro 化で CEO ARR 加算) |
+| 2 | ミッション | ✅ 商品=価値検証加速 |
+| 5 | 商品=価値 | ✅ Free→Pro 転換率 = 価値 signal |
+| 7 | 資産負債 | ✅ ARR を CFO ledger に記録 (= [#1669](https://github.com/kanta13jp1/my_web_app/issues/1669) BudgetFinancialPlanner 接続) |
+| 8 | KPI | ✅ MRR / churn / Free→Pro 転換率 |
+| 9 | IPO | ✅ ARR 計上 (= 投資家説明可能) |
+
+= **5/9 直接該当 / 7+/9 ✅ 閾値クリア**
+
+## 7. 実装手順 (= Win Codex hand off)
+
+1. `supabase/migrations/<ts>_create_billing_tables.sql` 起票 (= section 2)
+2. `supabase/functions/schedule-hub/index.ts` に 2 action 追加 (= section 3)
+3. `supabase/functions/stripe-webhook/` 新規 (= section 3)
+4. `lib/services/billing_service.dart` 新規 (= section 4)
+5. `lib/pages/billing_page.dart` 新規 + `/billing` route 追加
+6. Stripe dashboard で Pro plan 設定 + Webhook URL 登録
+7. `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` を Supabase secrets に追加
+
+## 8. 次回拡張 (= part 143+)
+
+- Team tier (= 5 seat)
+- Annual billing (= 2 ヶ月分割引)
+- Usage-based metered billing (= Pro 超過分 EF call)
+- Stripe Tax 自動計算 (= 国別 VAT)
+
+---
+
+**Spec status**: 設計完了 / 実装ハンドオフ準備済 → cross-instance-pr 経由で Win Codex へ

--- a/docs/cross-instance-prs/20260505_codex_overdue_wbs_handoff.md
+++ b/docs/cross-instance-prs/20260505_codex_overdue_wbs_handoff.md
@@ -1,0 +1,64 @@
+# [Codex CLI 宛] Overdue WBS task 6 件 hand off + Win Claude 担当 2 件 part 143 deferred
+
+**date**: 2026-05-05
+**from**: Win Claude (= Win版#132 part 142)
+**to**: Win Codex CLI
+**priority**: high (= 全件 deadline 経過)
+**rule basis**: `[INSTANCE-ROLES]` 5-question matrix (docs/CODEX_WORKFLOW.md §6) + `[WBS-SYNC]`
+
+## Summary
+
+WBS overdue tasks の deadline 順 top 8 を 5-question 振分で 2 instance 制反映。
+Codex territory 6 件をこちらへ hand off、Win Claude territory 2 件 (= 設計系) は
+part 143 で深堀。
+
+## Codex CLI 担当 (= 6 件 / 期限近い順)
+
+各 task は overdue 状態。WBS UI: <https://my-web-app-b67f4.web.app/wbs-user-tasks>
+
+| # | issue | rationale | hint |
+|---|---|---|---|
+| 1 | [#1266](https://github.com/kanta13jp1/my_web_app/issues/1266) VS Code 拡張機能リモートセッション起動 | 実装 (dev-env tooling) | `.vscode/` 拡張 + `code-server` integration |
+| 2 | [#1283](https://github.com/kanta13jp1/my_web_app/issues/1283) GHA 未 Push 検知ガード | GHA (workflow_dispatch pre-check) | `.github/workflows/` 新 yml + `gh-checks` action |
+| 3 | [#1296](https://github.com/kanta13jp1/my_web_app/issues/1296) Hedra API クレジット残量監視 | EF Deno + monitoring | `supabase/functions/api-credit-monitor/` 新規 + Slack notification |
+| 4 | [#1302](https://github.com/kanta13jp1/my_web_app/issues/1302) 記事 draft 品質ガードレール | T-1 dispatch (= blog automation) | `.github/workflows/blog-draft-lint.yml` + textlint or LLM eval |
+| 5 | [#1304](https://github.com/kanta13jp1/my_web_app/issues/1304) branch 保護公開 status 自動化 | GHA + branch protection | GitHub API `PATCH /repos/.../branches/main/protection` + status check |
+| 6 | [#1308](https://github.com/kanta13jp1/my_web_app/issues/1308) 外部連携 retry/errhandling 強化 | 実装 pattern | EF 内 `withRetry()` helper + DLQ ([AI-DEV-23] #6) |
+
+## Win Claude 担当 (= 2 件 / part 143 deferred)
+
+| # | issue | rationale | next-part deliverable |
+|---|---|---|---|
+| 7 | [#1305](https://github.com/kanta13jp1/my_web_app/issues/1305) Stripe + フリーミアム | 設計 / business model / 商品=価値 ([PHILOSOPHY-22] #5) | `docs/MONETIZATION_DESIGN.md` (= tier matrix + Stripe schema + EF 設計) |
+| 8 | [#1309](https://github.com/kanta13jp1/my_web_app/issues/1309) 計画停止 dashboard | UI design / 設計 doc | `docs/MAINTENANCE_MODE_SPEC.md` (= UI mockup + status schema + auto-toggle logic) |
+
+## 5-question matrix 適用 (= 振分根拠)
+
+質問 (docs/CODEX_WORKFLOW.md §6 抜粋):
+1. Q1 設計 / architect 要素を含むか
+2. Q2 docs / memory 更新が主か
+3. Q3 UI design / mockup を含むか
+4. Q4 triage / 競合 / AI 大学 / mobile UAT / 動画 task か
+5. Q5 部署横断 / 抽象化レビューが必要か
+
+| # | Q1 | Q2 | Q3 | Q4 | Q5 | judge |
+|---|---|---|---|---|---|---|
+| 1266 | N | N | N | N | N | Codex |
+| 1283 | N | N | N | N | N | Codex |
+| 1296 | N | N | N | N | N | Codex |
+| 1302 | N | N | N | N | N | Codex |
+| 1304 | N | N | N | N | N | Codex |
+| 1305 | **Y** | N | N | N | **Y** | Win Claude |
+| 1308 | N | N | N | N | N | Codex |
+| 1309 | **Y** | N | **Y** | N | N | Win Claude |
+
+## 期限 + SLA
+
+- 全 6 Codex 件: 既に 1-3 日 overdue → 今 session 中の triage 起票推奨
+- Win Claude 2 件: part 143 (= 次 session) で 設計 doc 起票
+
+## dogfood
+
+- `[INSTANCE-ROLES]` 5-question matrix 8 件一括適用 (= 第 1 例)
+- `[DYNAMIC-CLAIM]` 1 session 2 件 cap 遵守 (= deferred で respect)
+- `[WBS-SYNC]` overdue 一括 triage pattern 確立 (= weekly cron 候補)

--- a/docs/cross-instance-prs/20260505_codex_overdue_wbs_handoff_batch2.md
+++ b/docs/cross-instance-prs/20260505_codex_overdue_wbs_handoff_batch2.md
@@ -1,0 +1,71 @@
+# [Codex CLI 宛] Overdue WBS task batch 2 — 次 10 件 5-question 振分
+
+**date**: 2026-05-05
+**from**: Win Claude (= Win版#132 part 142)
+**to**: Win Codex CLI
+**priority**: high (= 全件 2-3 日 overdue)
+**rule basis**: `[INSTANCE-ROLES]` 5-question matrix + `[WBS-SYNC]` + `[DYNAMIC-CLAIM]` 2 件 cap respect
+
+## Summary
+
+batch 1 (= 8 件 / `20260505_codex_overdue_wbs_handoff.md`) に続く 9-18 番目の overdue task。
+[DYNAMIC-CLAIM] cap (= 1 session 2 件) を遵守して Win Claude は claim せず、
+全件 triage + 担当判定 + Win Claude 対応の場合は既存 skill 紐付け推奨に留める。
+
+## 振分結果 (= 10 件)
+
+| # | issue | judge | 既存 skill / hand off |
+|---|---|---|---|
+| 1 | [#1306](https://github.com/kanta13jp1/my_web_app/issues/1306) MVP + in-app feedback | **Codex** (実装) | Flutter widget + Supabase table |
+| 2 | [#1311](https://github.com/kanta13jp1/my_web_app/issues/1311) 外部連携標準 format + dynamic mapping | **Codex** (実装/EF) | EF Deno + JSON schema mapping |
+| 3 | [#1316](https://github.com/kanta13jp1/my_web_app/issues/1316) 6 部門 KPI 外部 DB 永続化 | **Win Claude** (architect / 6 部署 = PHILOSOPHY-22 #4) | **part 143 設計 spec 候補** |
+| 4 | [#1319](https://github.com/kanta13jp1/my_web_app/issues/1319) Dart SDK バグ報告 Markdown 生成 | **Codex** (実装 / dev tool) | Dart script + GHA |
+| 5 | [#1323](https://github.com/kanta13jp1/my_web_app/issues/1323) 新規 service deploy 時 monitoring 自動設定 | **Codex** (GHA / EF) | deploy-prod.yml 拡張 |
+| 6 | [#1345](https://github.com/kanta13jp1/my_web_app/issues/1345) 「1 In 2 Out」型 UI 整理アシスト | **Win Claude** (UI design) | **part 143 設計 spec 候補** |
+| 7 | [#1348](https://github.com/kanta13jp1/my_web_app/issues/1348) 専門用語・法令 inline tooltip | **Win Claude** (UI design + content) | `ui-design` skill + AI 大学 terminology DB |
+| 8 | [#1354](https://github.com/kanta13jp1/my_web_app/issues/1354) Agent Mode `/deploy` Cloud Run pipeline | **Codex** (GHA / Cloud Run) | new yml + service account 設定 |
+| 9 | [#1356](https://github.com/kanta13jp1/my_web_app/issues/1356) 開発環境自動 setup + proxy 対策 | **Codex** (dev env / scripts) | scripts/ 新規 + setup-cowork pattern |
+| 10 | [#1366](https://github.com/kanta13jp1/my_web_app/issues/1366) ストーリー分岐 / 文脈移行 UI action | **Win Claude** (UI design) | `ui-design` skill |
+
+## 5-question matrix 統計
+
+| judge | 件数 |
+|---|---:|
+| Codex | 6 |
+| Win Claude | 4 |
+
+## Win Claude 4 件の処理 path
+
+| # | path | 着手 timing |
+|---|---|---|
+| #1316 6 部門 KPI 永続化 | 設計 spec (= 重い architect work) | **part 143** primary |
+| #1345 1 In 2 Out UI | 設計 spec (= UI 単独で完結 / 軽め) | **part 143** secondary |
+| #1348 inline tooltip | `ui-design` skill 経由で widget catalog 化 → AI 大学 terminology DB join | part 143-144 |
+| #1366 ストーリー分岐 UI | `ui-design` skill 経由で general action pattern 化 | part 143-144 |
+
+## Codex 6 件の hand off
+
+batch 1 (= 6 件) と合算で **計 12 件** が Codex CLI で同 session triage 推奨。
+
+実装難度低い順:
+1. #1283 GHA 未 Push 検知 (= 既存 yml 拡張 / 1h)
+2. #1304 branch 保護自動化 (= GitHub API 1 call / 1h)
+3. #1296 Hedra API 監視 (= EF + cron / 2h)
+4. #1308 retry/errhandling helper (= EF 共通 util / 2h)
+5. #1356 dev env setup script (= Bash + WSL / 2h)
+6. #1311 外部連携 standard format + dynamic mapping (= 設計込 / 4h)
+7. #1302 記事 draft 品質 gate (= textlint + LLM eval / 4h)
+8. #1306 MVP + in-app feedback (= Flutter + Supabase / 4h)
+9. #1319 Dart SDK bug 報告 Markdown gen (= Dart script / 4h)
+10. #1266 VS Code 拡張 remote session (= dev env tooling / 6h)
+11. #1354 `/deploy` Cloud Run pipeline (= GHA + Cloud Run / 6h)
+12. #1323 monitoring 自動設定 (= deploy-prod.yml 拡張 / 6h)
+
+合計工数推定: ~44h (= Codex 1 instance / ~5 営業日相当)
+
+## dogfood
+
+- `[INSTANCE-ROLES]` 5-question matrix 18 件累計適用 (= batch 1 + 2)
+- `[DYNAMIC-CLAIM]` 1 session 2 件 cap 厳守 (= 残 4 件 Win Claude は part 143 deferred)
+- `[WBS-SYNC]` overdue triage の 2 batch 化 (= 拡張時 2 batch/session が現実的)
+- `[SYNERGY-30]` cross-instance-pr 18 件 = fleet 横断 hand off 第 1 例


### PR DESCRIPTION
## Summary

WBS overdue task の deadline 順 top 8 を `[INSTANCE-ROLES]` 5-question matrix で 2 instance 制反映:
- **Codex CLI 担当 6 件**: #1266 / #1283 / #1296 / #1302 / #1304 / #1308 (= 実装/GHA/EF/T-1)
- **Win Claude 担当 2 件 (part 143 deferred)**: #1305 (Stripe+freemium 設計) / #1309 (maintenance dashboard UI)

`[DYNAMIC-CLAIM]` 1 session 2 件 cap 遵守。Codex 6 件は同 session 中の triage 起票推奨 (= 全件 1-3 日 overdue)。

## E2E exempt

E2E exempt: docs/cross-instance-prs/ のみ追加 — application code 変更なし。

## dogfood

- INSTANCE-ROLES 5-question matrix 8 件一括適用 (= 第 1 例)
- WBS-SYNC overdue 一括 triage pattern 確立 (= weekly cron 候補)
- DYNAMIC-CLAIM 1 session 2 件 cap 遵守 (= deferred で respect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)