### PR TITLE
feat(workflow): 未Pushコミット時のworkflow dispatchをブロック

### DIFF
--- a/docs/GHA_DISPATCH_GUARD.md
+++ b/docs/GHA_DISPATCH_GUARD.md
@@ -29,4 +29,3 @@ NPM wrappers:
 npm run workflow:guard
 npm run workflow:blog-publish -- <slug> [platforms]
 ```
-

--- a/docs/GHA_DISPATCH_GUARD.md
+++ b/docs/GHA_DISPATCH_GUARD.md
@@ -1,0 +1,32 @@
+# GitHub Actions Dispatch Guard
+
+Last updated: 2026-05-05
+
+Use `scripts/check_remote_synced.py` before manually dispatching workflows that read files from the repository, especially blog publishing and deploy helpers.
+
+Default check:
+
+```bash
+python scripts/check_remote_synced.py --remote origin --branch main
+```
+
+Strict dispatch check:
+
+```bash
+python scripts/check_remote_synced.py --remote origin --branch main --require-clean
+```
+
+Behavior:
+
+- Fetches `origin/main` before comparing refs.
+- Blocks when `HEAD` contains commits that are not reachable from `origin/main`.
+- With `--require-clean`, blocks meaningful uncommitted files as well.
+- Ignores `.claude/settings.local.json` by default because it is local app state.
+
+NPM wrappers:
+
+```bash
+npm run workflow:guard
+npm run workflow:blog-publish -- <slug> [platforms]
+```
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "private": true,
   "scripts": {
     "e2e": "playwright test",
-    "e2e:smoke": "playwright test test/e2e/public_smoke.spec.ts"
+    "e2e:smoke": "playwright test test/e2e/public_smoke.spec.ts",
+    "workflow:guard": "python scripts/check_remote_synced.py --require-clean",
+    "workflow:blog-publish": "bash scripts/t1-dispatch.sh"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1"

--- a/scripts/check_remote_synced.py
+++ b/scripts/check_remote_synced.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Block workflow dispatch when local commits are not on the remote branch."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import subprocess
+import sys
+from pathlib import Path
+
+
+DEFAULT_IGNORE_PATHS = (".claude/settings.local.json",)
+
+
+def run_git(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def git_text(args: list[str]) -> str:
+    return run_git(args).stdout.strip()
+
+
+def normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def ignored(path: str, patterns: tuple[str, ...]) -> bool:
+    normalized = normalize_path(path)
+    return any(fnmatch.fnmatch(normalized, pattern) for pattern in patterns)
+
+
+def meaningful_status(ignore_paths: tuple[str, ...]) -> list[str]:
+    result = run_git(["status", "--porcelain"], check=False)
+    lines: list[str] = []
+    for raw in result.stdout.splitlines():
+        if len(raw) < 4:
+            continue
+        path = raw[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1].strip()
+        if ignored(path, ignore_paths):
+            continue
+        lines.append(raw)
+    return lines
+
+
+def unpushed_commits(target_ref: str) -> list[str]:
+    result = run_git(["merge-base", "--is-ancestor", "HEAD", target_ref], check=False)
+    if result.returncode == 0:
+        return []
+    return git_text(["log", "--oneline", f"{target_ref}..HEAD"]).splitlines()
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument(
+        "--require-clean",
+        action="store_true",
+        help="Also block meaningful uncommitted files before dispatch.",
+    )
+    parser.add_argument(
+        "--ignore-path",
+        action="append",
+        default=list(DEFAULT_IGNORE_PATHS),
+        help="Glob path to ignore for --require-clean. Repeatable.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    target_ref = f"{args.remote}/{args.branch}"
+
+    if run_git(["rev-parse", "--is-inside-work-tree"], check=False).returncode != 0:
+        print("ERROR: not inside a git worktree.", file=sys.stderr)
+        return 2
+
+    run_git(["fetch", "--quiet", args.remote, args.branch])
+
+    local_head = git_text(["rev-parse", "--short", "HEAD"])
+    remote_head = git_text(["rev-parse", "--short", target_ref])
+
+    commits = unpushed_commits(target_ref)
+    if commits:
+        print(
+            f"ERROR: local HEAD {local_head} is not pushed to {target_ref} "
+            f"({remote_head}).",
+            file=sys.stderr,
+        )
+        print("Push or merge these commits before dispatching a workflow:", file=sys.stderr)
+        for commit in commits:
+            print(f"  {commit}", file=sys.stderr)
+        return 1
+
+    if args.require_clean:
+        dirty = meaningful_status(tuple(args.ignore_path))
+        if dirty:
+            print(
+                "ERROR: meaningful uncommitted files are present. "
+                "Commit and push them before dispatching a workflow.",
+                file=sys.stderr,
+            )
+            for line in dirty:
+                print(f"  {line}", file=sys.stderr)
+            return 1
+
+    print(f"OK: local HEAD {local_head} is already contained in {target_ref} ({remote_head}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/t1-dispatch.sh
+++ b/scripts/t1-dispatch.sh
@@ -18,6 +18,12 @@ if [ ! -f "$JA_PATH" ] && [ ! -f "$EN_PATH" ]; then
   exit 1
 fi
 
+python scripts/check_remote_synced.py \
+  --remote origin \
+  --branch main \
+  --require-clean \
+  --ignore-path ".claude/settings.local.json"
+
 echo "📋 Dispatch plan:"
 echo "  JA: $JA_PATH ($([ -f "$JA_PATH" ] && echo exists || echo missing))"
 echo "  EN: $EN_PATH ($([ -f "$EN_PATH" ] && echo exists || echo missing))"


### PR DESCRIPTION
## Minimal E2E Gate
- [x] Implementation-detail independent: this is a command-line guard; validation checks observable CLI exit codes and terminal messages, not private implementation internals.
- [x] Minimal scope: 3 cases only: synced HEAD passes, feature-branch/unpushed commits fail, and meaningful dirty files fail while `.claude/settings.local.json` is ignored.
- [x] E2E mechanism considered: no browser Playwright path is needed because this does not change app UI; the workflow-equivalent check is CLI execution of `scripts/check_remote_synced.py` before `gh workflow run`.
- [x] E2E-Exception: no `integration_test/` or `test/e2e/` file is included because #1283 is a local workflow-dispatch safety guard, not a user-facing Flutter/browser change.

## Summary
- Added `scripts/check_remote_synced.py` to fetch `origin/main` and block workflow dispatch when local HEAD is not reachable from the remote branch.
- Added `--require-clean` support with default ignore for `.claude/settings.local.json`.
- Wired the guard into `scripts/t1-dispatch.sh` before `gh workflow run blog-publish.yml`.
- Added npm wrappers and docs for the guard.

## Validation
- `python -m py_compile scripts/check_remote_synced.py`
- `python scripts/check_remote_synced.py --remote origin --branch main` observed expected failure on the feature branch with unpushed commits.
- `git diff --check origin/main...HEAD`

## WBS
- Closes #1283
