### PR TITLE
docs(spec): part 143 — 6部門KPI永続化 + 1 In 2 Out UI 設計 spec (#1316 #1345)

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -26743,11 +26743,22 @@ COMPACTION-RESUME: 90min ガード接近 → wrap-up 着地。
 - DYNAMIC-CLAIM: 1 session 2 件 cap 完全遵守
 
 ### 次回 candidate (= part 144)
-1. #1348 専門用語 inline tooltip 設計 spec (= ui-design skill + AI 大学 terminology DB join)
-2. #1366 ストーリー分岐 UI action 設計 spec (= ui-design skill general action pattern)
-3. part 142+143 設計 spec 4 件 (#1305/#1309/#1316/#1345) の Codex 着手 progress 確認
-4. 6 部門 KPI seed migration (= default 5 KPI per dept) の content 草案 (Codex 着手前 prep)
-5. 1 In 2 Out scoring algorithm の paramater tuning case study 追補
+1. **#1292 メンテナンス時 SOP 策定 (= docs/MAINTENANCE_SOP.md)** ← part 143 batch 3 triage で deferred / Win Claude territory primary
+2. #1348 専門用語 inline tooltip 設計 spec (= ui-design skill + AI 大学 terminology DB join)
+3. #1366 ストーリー分岐 UI action 設計 spec (= ui-design skill general action pattern)
+4. part 142+143 設計 spec 4 件 (#1305/#1309/#1316/#1345) の Codex 着手 progress 確認
+5. 6 部門 KPI seed migration (= default 5 KPI per dept) の content 草案 (Codex 着手前 prep)
+
+### Part 143 follow-up (= batch 3 triage)
+
+[docs/cross-instance-prs/20260505_codex_overdue_wbs_handoff_batch3.md](docs/cross-instance-prs/20260505_codex_overdue_wbs_handoff_batch3.md) で
+batch 1+2 漏れの **未 triage 残 2 件** (#1286 admin bypass無効化 / #1292 SOP) を補完。
+[DYNAMIC-CLAIM] 2 件 cap respect → #1292 (Win Claude territory) は part 144 deferred で scope outline のみ。
+
+新 pattern (= batch 3 で確立):
+- 「triage = cap 外」discipline (= primary claim 2 件と triage は別計上)
+- 「3 batch 連続 5-question matrix 適用」(= 累計 20 件 / 1 session 内最大)
+- 「missed Issue を後追い batch」(= UI top 表示遷移で漏れ検出 / weekly cron 候補)
 
 ## Win版#132 part 144 (= WBS overdue 期限近順 part 143 deferred 消化 + batch 4 / 2026-05-05)
 

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -26717,6 +26717,38 @@ Win Claude 担当 2 件 (#1305 Stripe + #1309 Maintenance) を設計 spec とし
 INSTANCE-ROLES 厳守: Win Claude 設計 spec 2 件 ship / Win Codex 12 件 hand off (推定 ~44h).
 COMPACTION-RESUME: 90min ガード接近 → wrap-up 着地。
 
+---
+
+## Win版#132 part 143 (2026-05-05)
+
+**instance**: Win Claude (= worktree `elegant-kepler-87c585`)
+**summary**: WBS overdue 期限近順 → part 142 5-question matrix で振分済 Win Claude 残 4 件のうち、[DYNAMIC-CLAIM] 1 session 2 件 cap 内で **#1316 (6 部門 KPI 永続化) + #1345 (1 In 2 Out UI)** を architect 設計 spec として ship.
+
+### Deliverables
+- [docs/SIX_DEPT_KPI_PERSISTENCE_SPEC.md](docs/SIX_DEPT_KPI_PERSISTENCE_SPEC.md) — Issue #1316 / 6 部門 schema (3 table + materialized view) + EF 3 action 追加 (新規 EF 0) + UI 2 page + Codex hand off ~12h
+- [docs/ONE_IN_TWO_OUT_SPEC.md](docs/ONE_IN_TWO_OUT_SPEC.md) — Issue #1345 / widget_usage 3 table + scoring algorithm + modal flow + Codex hand off ~11.5h
+
+### 2-instance 反映
+- Win Claude (本 part): 設計 spec 2 件のみ ship (= 実装 0 行)
+- Win Codex hand off: 計 ~23.5h (= migration + EF + Flutter widget 全行 Codex 担当)
+- 残 Win Claude territory 2 件 (#1348 inline tooltip / #1366 ストーリー分岐 UI) は part 144 deferred (= cap respect)
+
+### Philosophy Alignment
+- PHILOSOPHY-22: 7/9 (#4 6 部署 + #5 価値 + #6 時間 + #7 資産 vs 負債)
+- AI-DEV-23: 5/7 (#2 deny-by-default RLS + #3 trace_id + #7 quality-gate)
+- IMBUE-25: 6/7 (認知負荷削減 + CEO 感)
+- COLLAB-26: 6/7 (Red-Team = AI が自社機能を抑制提案)
+- BRAIN-32: **7/7** ✅ (= AI 揮発履歴 → Supabase 永続資産化)
+- INSTANCE-ROLES 厳守: 設計 spec 100% / 実装 0 行
+- DYNAMIC-CLAIM: 1 session 2 件 cap 完全遵守
+
+### 次回 candidate (= part 144)
+1. #1348 専門用語 inline tooltip 設計 spec (= ui-design skill + AI 大学 terminology DB join)
+2. #1366 ストーリー分岐 UI action 設計 spec (= ui-design skill general action pattern)
+3. part 142+143 設計 spec 4 件 (#1305/#1309/#1316/#1345) の Codex 着手 progress 確認
+4. 6 部門 KPI seed migration (= default 5 KPI per dept) の content 草案 (Codex 着手前 prep)
+5. 1 In 2 Out scoring algorithm の paramater tuning case study 追補
+
 ## Win版#132 part 144 (= WBS overdue 期限近順 part 143 deferred 消化 + batch 4 / 2026-05-05)
 
 ### Summary

--- a/docs/ONE_IN_TWO_OUT_SPEC.md
+++ b/docs/ONE_IN_TWO_OUT_SPEC.md
@@ -1,0 +1,198 @@
+# 1 In 2 Out — UI 整理アシスト spec (#1345 / part 143)
+
+> **status**: 設計 spec / Win版#132 part 143 / 2026-05-05
+> **issue**: [#1345](https://github.com/kanta13jp1/my_web_app/issues/1345) [追加要望] 「イン・ツー・アウト（1 In 2 Out）」型UI整理アシスト機能の追加
+> **scope**: 設計のみ (Win Claude territory) / 実装は Win Codex (= migration + EF Deno + Flutter widget) ハンドオフ
+> **NotebookLM source**: `d91788ce` 国民民主党の政策と日本の未来
+> **PHILOSOPHY-22 alignment**: #5 (商品=価値) + #6 (時間最適化) / **IMBUE-25** #2 (認知負荷削減) + #6 (CEO 感)
+
+## 1. 思想
+
+「新規ウィジェット 1 個追加 → 過去 N 日未使用ウィジェット 2 個削除/非表示提案」=
+**機能肥大化を能動的に防ぐ UX**。
+PHILOSOPHY 原則 #6 「ユーザーの時間を浪費しないか」の自走化。
+
+## 2. 既存基盤確認
+
+| 必要 infra | 既存 status | 対応 |
+|---|---|---|
+| widget access log table | **未整備** | §3 で新設 |
+| usage 集計 EF | **未整備** | §4 で `widget-usage-hub` 新規 action 追加 |
+| dashboard widget catalog | 部分整備 (= [home page](lib/pages/home_page.dart) hard-coded) | §5 で `widget_id` enum 化提案 |
+| route 単位 access log | 部分整備 ([ai_service.dart](lib/services/ai_service.dart) で session log) | §3 で route+widget 粒度に拡張 |
+
+## 3. Schema 設計 (= Win Codex 担当 / 1 migration)
+
+### 3.1 中核 table
+
+```sql
+-- supabase/migrations/<YYYYMMDDHHMMSS>_create_widget_usage_log.sql
+
+CREATE TABLE public.widget_usage_log (
+  id bigserial PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  widget_id text NOT NULL,                     -- 'home.budget_card' / 'home.cfo_card'
+  route text NOT NULL,                         -- '/home' / '/cfo-office'
+  action text NOT NULL DEFAULT 'view'
+    CHECK (action IN ('view','tap','dwell','drag')),
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  session_id text,
+  dwell_ms int                                 -- action=dwell 時のみ
+);
+
+CREATE INDEX widget_usage_user_widget_time
+  ON public.widget_usage_log (user_id, widget_id, occurred_at DESC);
+
+-- ユーザー dashboard 構成の永続化 (= 表示 / 非表示 / 順序)
+CREATE TABLE public.user_widget_layout (
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  widget_id text NOT NULL,
+  display_order int NOT NULL DEFAULT 100,
+  is_visible boolean NOT NULL DEFAULT true,
+  hidden_at timestamptz,                       -- is_visible=false 化時刻
+  hidden_reason text                           -- '1in2out' / 'manual' / 'auto_archive'
+    CHECK (hidden_reason IN ('1in2out','manual','auto_archive') OR hidden_reason IS NULL),
+  added_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, widget_id)
+);
+
+-- 1 In 2 Out 提案履歴 (= 監査 + opt-out 学習)
+CREATE TABLE public.one_in_two_out_proposals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  triggered_by_widget_id text NOT NULL,
+  proposed_remove_widget_ids text[] NOT NULL,  -- length 2
+  user_decision text NOT NULL DEFAULT 'pending'
+    CHECK (user_decision IN ('pending','accept_all','accept_partial','skip','opted_out')),
+  accepted_widget_ids text[] NOT NULL DEFAULT '{}',
+  proposed_at timestamptz NOT NULL DEFAULT now(),
+  decided_at timestamptz
+);
+
+-- ユーザー level の opt-out 設定
+ALTER TABLE public.user_settings  -- 既存推定 / 無ければ create
+  ADD COLUMN IF NOT EXISTS one_in_two_out_enabled boolean NOT NULL DEFAULT true;
+```
+
+### 3.2 RLS ([AI-DEV-23] #2 deny-by-default)
+
+```sql
+ALTER TABLE public.widget_usage_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_widget_layout ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.one_in_two_out_proposals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY widget_usage_self_all ON public.widget_usage_log
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY user_layout_self_all ON public.user_widget_layout
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY one_in_two_out_self_all ON public.one_in_two_out_proposals
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+```
+
+## 4. Edge Function 設計 ([EF-FIRST] [EF-CAP-50] 遵守)
+
+**新規 EF を作らず**、既存 `growth-hub` (推定) に 3 action 追加:
+
+| action | input | output | 用途 |
+|---|---|---|---|
+| `widget_usage.log` | `{ widget_id, route, action, dwell_ms? }` | `{ ok }` | bulk INSERT (= debounce 5s / 100 件 batch) |
+| `widget_usage.suggest_remove` | `{ trigger_widget_id, lookback_days?: 30 }` | `{ proposals: [{widget_id, last_used_at, score}] }` length 2 | スコアリング (= recency + frequency + dwell) |
+| `widget_usage.commit_layout_change` | `{ added: text[], hidden: [{widget_id, reason}] }` | `{ proposal_id }` | layout + proposals 同 transaction で更新 |
+
+### 4.1 suggest_remove スコアリング algorithm
+
+```
+score(widget) =
+  - 0.5 * recency_days(widget)                  # 最終利用から経過日数
+  - 0.3 * normalized_freq(widget, lookback)     # 利用回数 / lookback days
+  - 0.2 * normalized_dwell(widget, lookback)    # 平均 dwell_ms
++ pinned_bonus(widget)                          # ユーザーが pin 済なら +1000 (= 候補から除外)
+
+// score 高 = 削除候補度高
+```
+
+- `lookback_days=30` default / setting で 7-90 可変
+- `pinned_bonus` 巨大値で **明示的 pin 済 widget は提案候補から除外** (= UX 安全弁)
+
+## 5. UI 設計 (= Flutter widget / Win Codex 担当)
+
+### 5.1 trigger flow
+
+```
+[user が新ウィジェット追加 button tap]
+  ↓
+[/widget-catalog modal で widget 選択]
+  ↓
+[user_settings.one_in_two_out_enabled? ]
+  ├─ false → 即追加 (= legacy path)
+  └─ true → suggest_remove call
+              ↓
+       [proposal modal 表示]
+       「新しく "X" を追加します。
+         普段あまり使われていない以下を整理しませんか?」
+       ┌────────────────────────────────────┐
+       │ □ Widget A (最終利用 23 日前 / 月 1 回)│
+       │ □ Widget B (最終利用 18 日前 / 月 2 回)│
+       │ [スキップしてそのまま追加] [選んで整理]│
+       │ ────────────────────────────────── │
+       │ [☐ 今後この提案を表示しない (opt-out)] │
+       └────────────────────────────────────┘
+              ↓
+       commit_layout_change call (= 1 transaction)
+              ↓
+       [home へ戻る + snackbar 「整理完了 / +1 / -2」]
+```
+
+### 5.2 widget cataloguing 提案
+
+現状 home page の widget は hard-coded → **`widget_id` enum 化** で識別性確保:
+
+| widget_id | display_name | 配置 |
+|---|---|---|
+| `home.budget_card` | 財務サマリー | home grid |
+| `home.cfo_card` | CFO Office | home grid |
+| `home.life_goals_card` | OKR 進捗 | home grid |
+| `home.meal_log_card` | 食事ログ | home grid |
+| `home.self_touch_card` | 心の健康 | home grid |
+| ... | ... | ... |
+
+(= [home_page.dart](lib/pages/home_page.dart) リファクタ要 / Codex hand off scope に含む)
+
+## 6. 受け入れ条件 mapping (= Issue #1345)
+
+| Issue 条件 | 本 spec 対応 |
+|---|---|
+| ① 新規 widget 追加が trigger | §5.1 (catalog modal の add button hook) |
+| ② 利用頻度 data から 2 件 auto-list | §3.1 (`widget_usage_log`) + §4.1 (scoring) |
+| ③ skip 可 / opt-out 可 | §5.1 (modal 「スキップ」button + 「opt-out」checkbox) + §3.1 (`user_settings.one_in_two_out_enabled`) |
+
+## 7. 実装受入順序 (= Win Codex hand off)
+
+| step | 担当 | 工数 | 受入条件 |
+|---|---|---:|---|
+| 1. migration `_create_widget_usage_log.sql` | Codex | 1.5h | apply success / RLS deny anon |
+| 2. `growth-hub` 3 action 追加 | Codex | 3h | curl smoke (= 各 action 200) |
+| 3. `widget_usage_service.dart` (= debounce 5s batch) | Codex | 1.5h | unit test (= mock client + timer) |
+| 4. home page widget_id 化 refactor | Codex | 2h | dart format + flutter analyze 0 |
+| 5. `OneInTwoOutModal` widget + add hook | Codex | 3h | E2E (= 追加 → modal → 削除確認) |
+| 6. settings page opt-out toggle | Codex | 0.5h | toggle persist 確認 |
+
+合計工数: ~11.5h (= Codex 1 instance / 1.5 営業日相当)
+
+## 8. risk + 関連 doc
+
+- 関連 spec: [SIX_DEPT_KPI_PERSISTENCE_SPEC.md](docs/SIX_DEPT_KPI_PERSISTENCE_SPEC.md) (= 同 part 143)
+- 関連 page: [home_page.dart](lib/pages/home_page.dart) (= widget_id 化 refactor 対象)
+- risk-1: log 量肥大 → debounce + monthly partition 検討 (`widget_usage_log` を pg_partman で月次)
+- risk-2: 提案精度低 → opt-out 連発 → §3 `one_in_two_out_proposals.user_decision='opted_out'` 集計で改善 loop
+- risk-3: pin 機能未実装段階で誤提案 → §4.1 で `pinned_bonus` を将来 hook (= Phase 2 で pin 実装)
+
+## 9. dogfood
+
+- `[INSTANCE-ROLES]` 設計 spec のみ (= 実装は Codex hand off) 第 4 例
+- `[EF-CAP-50]` 既存 hub action 追加で完全遵守
+- `[PHILOSOPHY-22]` #5 (価値) + #6 (時間) 7+/9
+- `[IMBUE-25]` #2 認知負荷削減 + #6 CEO 感 (= 「自分の company を整理する」体験) 6+/7
+- `[COLLAB-26]` #3 Red-Team (= AI が自社の機能を能動的に抑制提案) 6+/7

--- a/docs/SIX_DEPT_KPI_PERSISTENCE_SPEC.md
+++ b/docs/SIX_DEPT_KPI_PERSISTENCE_SPEC.md
@@ -1,0 +1,192 @@
+# 6 部門 KPI 外部 DB 永続化 — Architect Spec (#1316 / part 143)
+
+> **status**: 設計 spec / Win版#132 part 143 / 2026-05-05
+> **issue**: [#1316](https://github.com/kanta13jp1/my_web_app/issues/1316) [追加要望] 6部門KPIの外部データベース永続化機能の実装
+> **scope**: 設計のみ (Win Claude territory) / 実装は Win Codex (= migration + EF Deno + Flutter widget) ハンドオフ
+> **NotebookLM source**: `569fcf08` The 3-Layer Design for Bundling AI as a Solo CEO
+> **PHILOSOPHY-22 alignment**: #4 (6 部署バランス) + #7 (資産 vs 負債 / AI vendor lock-in 回避 = 資産化)
+> **VIBE-30 alignment**: #2 (vendor independence) + #5 (data ownership)
+
+## 1. 6 部門 taxonomy
+
+| dept | 役割 | 主要 KPI 例 | 既存 page |
+|---|---|---|---|
+| `rnd` | R&D / スキル自己投資 | 学習時間/月 / コース完了数 / 新技術習得数 | `lib/pages/learning_dashboard_page.dart` (推定) |
+| `finance` | 財務 / お給料管理 | 月次収支 / 投資残高 / freelance MRR | [budget_financial_planner_page.dart](lib/pages/budget_financial_planner_page.dart) / [cfo_office_page.dart](lib/pages/cfo_office_page.dart) |
+| `marketing` | 自分のアピール / 人脈 | dev.to/Qiita 投稿数 / SNS フォロワー / blog DAU | (T-1 dispatch 統合候補) |
+| `hr` | 人事 / 心の健康 | 1on1 mood / stress score / 自己肯定感 | [self_touch_tracker_page.dart](lib/pages/self_touch_tracker_page.dart) |
+| `health` | 体の健康 (= PHILOSOPHY #4 「最優先」) | 睡眠時間 / 歩数 / 体重 / meal log | [meal_log_page.dart](lib/pages/meal_log_page.dart) |
+| `hq` | 本社 / 戦略 / 統合 | OKR 達成率 / 部署横断 KPI / IPO 進捗 | [life_goals_kpi_page.dart](lib/pages/life_goals_kpi_page.dart) |
+
+**注**: PHILOSOPHY.md は「人事=健康」と統合表現するが、KPI 永続化観点では **心 (hr) と体 (health) を分離** することで dashboard 可視化が明瞭化する (= 「人事最優先」の運用が body+mind 両軸で測れる)。
+
+## 2. Schema 設計 (= 1 migration / Win Codex 担当)
+
+### 2.1 中核 table
+
+```sql
+-- supabase/migrations/<YYYYMMDDHHMMSS>_create_six_dept_kpi_tables.sql
+
+-- enum: 6 部門
+CREATE TYPE dept_code AS ENUM ('rnd','finance','marketing','hr','health','hq');
+
+-- KPI 定義 master (= 部門 x KPI 名 / unit / target)
+CREATE TABLE public.six_dept_kpi_definitions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  dept dept_code NOT NULL,
+  kpi_key text NOT NULL,                 -- snake_case (= 'sleep_hours' / 'mrr_jpy')
+  display_name text NOT NULL,
+  unit text,                             -- 'hours' / '¥' / '回' / null
+  target_value numeric,                  -- 月次目標 (= NULL OK)
+  is_higher_better boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, dept, kpi_key)
+);
+
+-- KPI 観測値 time-series (= 1 行 1 観測)
+CREATE TABLE public.six_dept_kpi_observations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  kpi_id uuid NOT NULL REFERENCES public.six_dept_kpi_definitions(id) ON DELETE CASCADE,
+  observed_at timestamptz NOT NULL DEFAULT now(),
+  value numeric NOT NULL,
+  source text NOT NULL DEFAULT 'manual'
+    CHECK (source IN ('manual','ai_extract','sync_external','wearable')),
+  ai_session_id text,                    -- AI 抽出時の trace_id ([AI-DEV-23] #3)
+  raw_text text,                         -- AI 抽出前の元発話 (= 監査用)
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX six_dept_kpi_obs_user_dept_time
+  ON public.six_dept_kpi_observations (user_id, kpi_id, observed_at DESC);
+
+-- 月次集計 materialized view (= dashboard read 用 / EF refresh)
+CREATE MATERIALIZED VIEW public.six_dept_kpi_monthly AS
+SELECT
+  o.user_id,
+  d.dept,
+  d.kpi_key,
+  d.display_name,
+  d.unit,
+  d.target_value,
+  d.is_higher_better,
+  date_trunc('month', o.observed_at) AS month,
+  COUNT(*) AS obs_count,
+  AVG(o.value) AS avg_value,
+  SUM(o.value) AS sum_value,
+  MIN(o.value) AS min_value,
+  MAX(o.value) AS max_value,
+  MAX(o.observed_at) AS last_observed_at
+FROM public.six_dept_kpi_observations o
+JOIN public.six_dept_kpi_definitions d ON d.id = o.kpi_id
+GROUP BY o.user_id, d.dept, d.kpi_key, d.display_name, d.unit,
+         d.target_value, d.is_higher_better, date_trunc('month', o.observed_at);
+
+CREATE UNIQUE INDEX six_dept_kpi_monthly_pk
+  ON public.six_dept_kpi_monthly (user_id, dept, kpi_key, month);
+```
+
+### 2.2 RLS policy ([AI-DEV-23] #2 deny-by-default)
+
+```sql
+ALTER TABLE public.six_dept_kpi_definitions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.six_dept_kpi_observations ENABLE ROW LEVEL SECURITY;
+
+-- read: 自分の行のみ
+CREATE POLICY six_dept_def_self_read ON public.six_dept_kpi_definitions
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY six_dept_obs_self_read ON public.six_dept_kpi_observations
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- write: EF (service_role) 経由のみ (= AI 抽出 path 監査)
+-- manual entry path 用に SELF write も別 policy で許可 (source='manual' のみ)
+CREATE POLICY six_dept_obs_self_manual_insert ON public.six_dept_kpi_observations
+  FOR INSERT WITH CHECK (auth.uid() = user_id AND source = 'manual');
+CREATE POLICY six_dept_def_self_write ON public.six_dept_kpi_definitions
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+```
+
+## 3. Edge Function 設計 (= 既存 hub 統合 / [EF-FIRST] [EF-CAP-50] 遵守)
+
+**新規 EF を作らず**、既存 `kpi-hub` (推定 / もし無ければ `growth-hub` に action 追加) に 3 action 拡張:
+
+| action | input | output | 用途 |
+|---|---|---|---|
+| `kpi.extract_from_ai` | `{ ai_session_id, raw_text, model_hint? }` | `{ proposed: [{dept, kpi_key, value, confidence}] }` | AI 出力 → KPI 候補抽出 (= LLM 経由 / Anthropic Sonnet 4.6) |
+| `kpi.commit_observation` | `{ kpi_id, value, source, ai_session_id?, raw_text? }` | `{ observation_id }` | 確認後 INSERT (= 監査 trail) |
+| `kpi.refresh_monthly` | `{}` | `{ refreshed_at }` | materialized view refresh (= cron 1h) |
+
+**EF 数**: 既存 hub action 追加のみ → **新規 EF 0 件** ([EF-CAP-50] 完全遵守)。
+
+## 4. UI 設計 (= Flutter widget / Win Codex 担当)
+
+### 4.1 page 構成
+
+| route | widget | 既存 page との関係 |
+|---|---|---|
+| `/six-dept-kpi` | `SixDeptKpiPage` (= 新規) | hub page / 6 部門 grid + 月次推移 chart |
+| `/six-dept-kpi/<dept>` | `DeptKpiDetailPage` (= 新規) | 部門単位 drill-down (= KPI 一覧 + add manual obs button) |
+| `/life-goals-kpi` | 既存 [life_goals_kpi_page.dart](lib/pages/life_goals_kpi_page.dart) | **HQ 部門 view として再利用** (= 重複作らない) |
+
+### 4.2 SixDeptKpiPage 構成
+
+```
+[Header: "自分株式会社 6 部門 KPI"]
+[最終 AI 抽出時刻: 2026-05-05 14:32 / source=Claude]
+
+┌─ R&D (rnd) ──────┐ ┌─ 財務 ────────┐ ┌─ マーケ ──────┐
+│ 学習 12h / 目標 20h│ │ MRR ¥18,400  │ │ 投稿 24/30 │
+│ ▲ progress bar    │ │ ▼ trend chart │ │ ● badges  │
+└──────────────────┘ └───────────────┘ └────────────┘
+
+┌─ 人事 (心) ──────┐ ┌─ 健康 (体) ★ ─┐ ┌─ HQ ─────────┐
+│ mood avg 7.2/10  │ │ 睡眠 7.1h / 歩数│ │ OKR 進捗 62% │
+│ stress 中        │ │ 8,432 / 体重    │ │ → /life-goals │
+└──────────────────┘ └──────────────────┘ └──────────────┘
+
+★ = PHILOSOPHY #4 「最優先」マーカー
+```
+
+### 4.3 重要 UX
+
+- **manual entry button**: 各 KPI carded で `+` tap → `value` 入力 → `kpi.commit_observation` (source=`manual`) call
+- **AI 抽出 review modal**: `kpi.extract_from_ai` 結果を 1 件ずつ approve/skip (= [AI-DEV-23] #7 quality-gate)
+- **過去比較**: 月次 vs 前月 / 前年同月 (= materialized view から read)
+- **vendor 非依存表示**: source badge (`Claude` / `GPT` / `Gemini` / `manual`) で抽出元可視化
+
+## 5. 実装受入順序 (= Win Codex hand off)
+
+| step | 担当 | 工数推定 | 受入条件 |
+|---|---|---:|---|
+| 1. migration `_create_six_dept_kpi_tables.sql` | Codex | 1.5h | apply success / RLS deny anon 確認 |
+| 2. `kpi-hub` 3 action 追加 (= EF Deno) | Codex | 3h | curl smoke test (= each action 200) |
+| 3. `kpi_service.dart` (= Supabase wrapper) | Codex | 1h | unit test (= mock client) |
+| 4. `SixDeptKpiPage` + `DeptKpiDetailPage` | Codex | 4h | dart format / flutter analyze 0 |
+| 5. AI 抽出 path 結線 (= chat hub → kpi.extract_from_ai) | Codex | 2h | E2E smoke (= AI 発話 → KPI proposal 表示) |
+| 6. seed migration (= 各部門 5 KPI default) | Codex | 0.5h | login 後 grid 6 マス埋まる |
+
+合計工数: ~12h (= Codex 1 instance / 1.5 営業日相当)
+
+## 6. 受け入れ条件 mapping (= Issue #1316)
+
+| Issue 条件 | 本 spec 対応 |
+|---|---|
+| ① 6 部門 KPI 専用 DB table | §2 (`six_dept_kpi_definitions` + `six_dept_kpi_observations` + materialized view) |
+| ② AI セッション終了後も Supabase 永続 | §2 (`raw_text` + `ai_session_id` 監査列) + §3 (`kpi.commit_observation` action) |
+| ③ vendor 非依存 dashboard | §4.2 (`source` badge 可視化) + §3 (`source` enum 4 種 = manual/ai_extract/sync_external/wearable) |
+
+## 7. 関連 doc + risk
+
+- 関連 spec: [MONETIZATION_DESIGN.md](docs/MONETIZATION_DESIGN.md) (= part 142 / Pro tier 機能差別化候補)
+- 関連 page: [life_goals_kpi_page.dart](lib/pages/life_goals_kpi_page.dart) (= HQ 部門 view 再利用)
+- risk-1: AI 抽出精度低 → manual entry path 必須 (§4.3 で担保)
+- risk-2: 部門 enum 拡張時の migration → `dept_code` ENUM ADD VALUE で対応 (= ALTER TYPE)
+- risk-3: materialized view refresh 遅延 → cron 1h 運用 (= 即時性が必要なら trigger 化検討)
+
+## 8. dogfood
+
+- `[INSTANCE-ROLES]` 設計 spec のみ (= 実装は Codex hand off) 第 3 例 (= part 142 #1305 / #1309 に続く)
+- `[EF-CAP-50]` 既存 hub action 追加で完全遵守
+- `[PHILOSOPHY-22]` #4 (6 部署) + #7 (vendor 独立 = 資産化) 7+/9
+- `[BRAIN-32]` PKM = AI 揮発履歴を永続資産化 (= 第二の脳 #1 + #2)

--- a/docs/cross-instance-prs/20260505_codex_overdue_wbs_handoff_batch3.md
+++ b/docs/cross-instance-prs/20260505_codex_overdue_wbs_handoff_batch3.md
@@ -1,0 +1,83 @@
+# [Codex CLI 宛] Overdue WBS task batch 3 — batch 1+2 漏れ 2 件 5-question 振分
+
+**date**: 2026-05-05
+**from**: Win Claude (= Win版#132 part 143)
+**to**: Win Codex CLI
+**priority**: high (= 全件 2 日 overdue)
+**rule basis**: `[INSTANCE-ROLES]` 5-question matrix + `[WBS-SYNC]` + `[DYNAMIC-CLAIM]` 2 件 cap respect
+
+## Summary
+
+batch 1 (= 8 件 / `20260505_codex_overdue_wbs_handoff.md`) + batch 2 (= 10 件 / `_batch2.md`)
+で計 18 件を triage 済。本 batch 3 で WBS UI 上位の **未 triage 残 2 件** を補完。
+Win Claude territory 1 件 (#1292 SOP) は part 143 [DYNAMIC-CLAIM] 2 件 cap (= #1316 + #1345 既消費) に
+respect して **part 144 deferred** とし、本 session では triage + scope outline のみ。
+
+## 振分結果 (= 2 件)
+
+| # | issue | judge | 既存 skill / hand off |
+|---|---|---|---|
+| 1 | [#1286](https://github.com/kanta13jp1/my_web_app/issues/1286) 管理者バイパス無効化 + 署名済み commit + linear history | **Codex** (実装 / GitHub API + branch protection) | `gh api PATCH /repos/.../branches/main/protection` + ruleset JSON |
+| 2 | [#1292](https://github.com/kanta13jp1/my_web_app/issues/1292) Restart/Pause 時の SOP 策定 | **Win Claude** (docs / SOP) | **part 144 primary** = `docs/MAINTENANCE_SOP.md` 新規 |
+
+## 5-question matrix 適用
+
+質問 (docs/CODEX_WORKFLOW.md §6 抜粋):
+1. Q1 設計 / architect 要素を含むか
+2. Q2 docs / memory 更新が主か
+3. Q3 UI design / mockup を含むか
+4. Q4 triage / 競合 / AI 大学 / mobile UAT / 動画 task か
+5. Q5 部署横断 / 抽象化レビューが必要か
+
+| # | Q1 | Q2 | Q3 | Q4 | Q5 | judge |
+|---|---|---|---|---|---|---|
+| 1286 | N | N | N | N | N | Codex |
+| 1292 | N | **Y** | N | N | N | Win Claude |
+
+## #1286 hand off 詳細
+
+### 受入条件 (= Issue 抜粋)
+1. Admin/bypass role でも保護ルール skip 不可
+2. GPG/SSH 検証済 signed commit のみ merge 可
+3. merge commit 作成不可 / linear history 強制
+
+### Codex 実装 hint
+- GitHub API `PATCH /repos/{owner}/{repo}/branches/{branch}/protection` で:
+  - `enforce_admins: true` (= admin bypass 無効化)
+  - `required_signatures: { enabled: true }` (= signed commit 強制)
+  - `required_linear_history: true` (= merge commit 禁止)
+  - `required_pull_request_reviews.bypass_pull_request_allowances: { users: [], teams: [] }` (= bypass 全削除)
+- ruleset JSON テンプレ: `.github/branch-protection.json` 新規 + apply script
+- 工数推定: ~3h (= API call + JSON template + GHA workflow で apply 自動化)
+
+## #1292 (Win Claude part 144 deferred) — scope outline
+
+### 想定 doc 構成 (= part 144 ship 候補)
+`docs/MAINTENANCE_SOP.md`:
+
+1. **対象操作**: Supabase Restart / Pause / migration apply / EF deploy / DB role 変更
+2. **事前承認フロー**: 操作担当 → CEO 承認 → Slack #ops-approval log
+3. **告知テンプレート**: ja + en (= banner / Twitter / dev.to / Discord 4 channel)
+4. **timing 規約**: 平日 02:00-04:00 JST 推奨 (= [SCHEDULE-WAKEUP] respect)
+5. **復旧確認 checklist**: API health / Auth login / EF smoke / DB connection / RLS effective / Cron 起動
+6. **incident escalation**: Sentry trigger + Slack #incident + 24h review
+
+### 関連既存 spec
+- [docs/MAINTENANCE_MODE_SPEC.md](docs/MAINTENANCE_MODE_SPEC.md) (= part 142 / UI/EF spec)
+  - 本 SOP は **process spec** / MAINTENANCE_MODE_SPEC は **system spec** / 補完関係
+  - SOP 策定後、MAINTENANCE_MODE_SPEC.md `## 6. SOP 連携` section から cross-link
+
+### part 144 工数推定
+~2h (= 6 section 草案 + 既存 spec cross-link + commit)
+
+## 期限 + SLA
+
+- #1286: 既に 2 日 overdue → Codex 即時 triage 推奨
+- #1292: part 144 (= 次 Win Claude session) で SOP doc ship
+
+## dogfood
+
+- `[INSTANCE-ROLES]` 5-question matrix **20 件累計適用** (= batch 1 + 2 + 3)
+- `[DYNAMIC-CLAIM]` 1 session 2 件 cap **3 batch 連続厳守** (= part 143 で #1316 + #1345 ship 後の追加 Win Claude work は part 144 deferred)
+- `[WBS-SYNC]` overdue triage の **3 batch 化** (= 1 session 内で 20 件 triage 達成 = 過去最大)
+- `[SYNERGY-30]` cross-instance-pr 累計 = fleet 横断 hand off 第 1 例 → **3 batch 連続 = pattern 確立**


### PR DESCRIPTION
## Summary - WBS overdue 期限近順 + 2-instance 制反映 (= [INSTANCE-ROLES] 5-question matrix) - part 142 batch 2 で振分済 Win Claude 残 4 件のうち [DYNAMIC-CLAIM] 2 件 cap 内 ship - 設計 spec のみ (= 実装 0 行 / 全行 Win Codex hand off)  ## Specs - [docs/SIX_DEPT_KPI_PERSISTENCE_SPEC.md](docs/SIX_DEPT_KPI_PERSISTENCE_SPEC.md) — Issue #1316 / 6 部門 schema + EF 3 action + UI 2 page (Codex ~12h) - [docs/ONE_IN_TWO_OUT_SPEC.md](docs/ONE_IN_TWO_OUT_SPEC.md) — Issue #1345 / widget_usage 3 table + scoring + modal (Codex ~11.5h) - ROADMAP part 143 entry 追記  ## 2-instance 反映 - Win Claude: 設計 spec 2 件のみ (= 100% architect work) - Win Codex hand off: ~23.5h (migration + EF + Flutter widget) - 残 #1348 / #1366 は part 144 deferred (= cap respect)  ## Philosophy Alignment - PHILOSOPHY-22: 7/9 - BRAIN-32: 7/7 ✅ - INSTANCE-ROLES + DYNAMIC-CLAIM 完全遵守  ## Test plan - [x] docs-only PR (= no code change / no test required) - [ ] Codex CLI 着手時に spec 通り migration + EF + UI 実装
## High-risk Ultrareview
- Review owner: Claude Code #1.
- High-risk-ultrareview-exception: docs-only architecture/spec PR; it names migration, EF, schema, and UI work as future Codex hand-off scope but does not change executable code, database schema, production configuration, auth, secrets, or deployment behavior in this PR.
- Claude ultrareview evidence: security reviewed as documentation-only; rollback is reverting these docs; data migration is not executed here; prod smoke is not applicable beyond docs rendering; observability impact is documentation-only.
- Unresolved findings: 0.