### PR TITLE
feat(quota): Hedra APIクレジット残量監視を追加

### DIFF
--- a/.github/workflows/quota-monitor.yml
+++ b/.github/workflows/quota-monitor.yml
@@ -254,6 +254,96 @@ jobs:
                   f.write('status=error\nusage_json={}\n')
           EOF
 
+      - name: Check Hedra API Credits
+        id: hedra
+        env:
+          HEDRA_API_KEY: ${{ secrets.HEDRA_API_KEY }}
+          HEDRA_CREDIT_WARNING_THRESHOLD: ${{ vars.HEDRA_CREDIT_WARNING_THRESHOLD || '50' }}
+          HEDRA_CREDIT_CRITICAL_THRESHOLD: ${{ vars.HEDRA_CREDIT_CRITICAL_THRESHOLD || '20' }}
+          HEDRA_CREDIT_STOP_THRESHOLD: ${{ vars.HEDRA_CREDIT_STOP_THRESHOLD || '5' }}
+        run: |
+          python3 - << 'EOF'
+          import os, requests, json
+
+          api_key = os.environ.get('HEDRA_API_KEY', '')
+          warning = int(os.environ.get('HEDRA_CREDIT_WARNING_THRESHOLD', '50') or 50)
+          critical = int(os.environ.get('HEDRA_CREDIT_CRITICAL_THRESHOLD', '20') or 20)
+          stop = int(os.environ.get('HEDRA_CREDIT_STOP_THRESHOLD', '5') or 5)
+
+          if not api_key:
+              print('HEDRA_API_KEY not set — skipping')
+              with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                  f.write('status=skipped\nusage_json={}\n')
+              exit(0)
+
+          try:
+              resp = requests.get(
+                  'https://api.hedra.com/web-app/public/billing/credits',
+                  headers={'X-API-Key': api_key},
+                  timeout=10,
+              )
+              if resp.ok:
+                  data = resp.json()
+                  remaining = int(data.get('remaining', 0) or 0)
+                  expiring = int(data.get('expiring', 0) or 0)
+                  used = int(data.get('used', 0) or 0)
+                  severity = 'ok'
+                  threshold = warning
+                  if remaining <= stop:
+                      severity = 'stop'
+                      threshold = stop
+                  elif remaining <= critical:
+                      severity = 'critical'
+                      threshold = critical
+                  elif remaining <= warning:
+                      severity = 'warning'
+                      threshold = warning
+                  alert = severity != 'ok'
+                  print(f'Hedra credits: remaining={remaining} used={used} expiring={expiring} severity={severity}')
+                  payload = {
+                      'tool': 'hedra',
+                      'remaining': remaining,
+                      'used': used,
+                      'expiring': expiring,
+                      'workspace_credits': data.get('workspace_credits', {}),
+                      'alert': alert,
+                      'severity': severity,
+                      'threshold': threshold,
+                      'warning_threshold': warning,
+                      'critical_threshold': critical,
+                      'stop_threshold': stop,
+                      'source': 'hedra.get_credits',
+                  }
+                  with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                      f.write('status=ok\n')
+                      f.write(f'usage_json={json.dumps(payload, separators=(",", ":"))}\n')
+              else:
+                  print(f'Hedra credits API error: {resp.status_code}')
+                  payload = {
+                      'tool': 'hedra',
+                      'status': resp.status_code,
+                      'error': resp.text[:200],
+                      'alert': True,
+                      'severity': 'unknown',
+                      'source': 'hedra.get_credits',
+                  }
+                  with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                      f.write('status=api_error\n')
+                      f.write(f'usage_json={json.dumps(payload, separators=(",", ":"))}\n')
+          except Exception as e:
+              print(f'Error: {e}')
+              payload = {
+                  'tool': 'hedra',
+                  'error': str(e),
+                  'alert': True,
+                  'severity': 'unknown',
+                  'source': 'hedra.get_credits',
+              }
+              with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                  f.write('status=error\n')
+                  f.write(f'usage_json={json.dumps(payload, separators=(",", ":"))}\n')
+          EOF
+
       - name: Save quota data to Supabase
         if: ${{ github.event.inputs.dry_run != 'true' }}
         env:
@@ -262,13 +352,17 @@ jobs:
           OPENAI_USAGE: ${{ steps.openai.outputs.usage_json }}
           COPILOT_USAGE: ${{ steps.copilot.outputs.usage_json }}
           GEMINI_USAGE: ${{ steps.gemini.outputs.usage_json }}
+          HEDRA_USAGE: ${{ steps.hedra.outputs.usage_json }}
+          QUOTA_ALERT_WEBHOOK_URL: ${{ secrets.QUOTA_ALERT_WEBHOOK_URL }}
         run: |
           python3 - << 'EOF'
           import os, requests, json
           from datetime import date
 
           service_key = os.environ['SUPABASE_SERVICE_ROLE_KEY']
-          base_url = 'https://smmkxxavexumewbfaqpy.supabase.co/rest/v1/ai_quota_usage'
+          rest_base_url = 'https://smmkxxavexumewbfaqpy.supabase.co/rest/v1'
+          quota_url = f'{rest_base_url}/ai_quota_usage'
+          notification_url = f'{rest_base_url}/app_notifications'
           headers = {
               'apikey': service_key,
               'Authorization': f'Bearer {service_key}',
@@ -277,7 +371,7 @@ jobs:
           }
           today = date.today().isoformat()
 
-          tools = ['ANTHROPIC_USAGE', 'OPENAI_USAGE', 'COPILOT_USAGE', 'GEMINI_USAGE']
+          tools = ['ANTHROPIC_USAGE', 'OPENAI_USAGE', 'COPILOT_USAGE', 'GEMINI_USAGE', 'HEDRA_USAGE']
           for env_key in tools:
               raw = os.environ.get(env_key, '{}')
               if not raw or raw == '{}':
@@ -292,11 +386,32 @@ jobs:
                       'usage_json': data,
                       'alert': data.get('alert', False)
                   }
-                  resp = requests.post(base_url, headers=headers, json=row, timeout=10)
+                  resp = requests.post(quota_url, headers=headers, json=row, timeout=10)
                   if resp.ok:
                       print(f"Saved {data['tool']} quota data")
                   else:
                       print(f"Failed to save {data['tool']}: {resp.status_code} {resp.text[:100]}")
+                  if data.get('tool') == 'hedra' and data.get('alert'):
+                      remaining = data.get('remaining', 'unknown')
+                      severity = data.get('severity', 'warning')
+                      message = (
+                          f"Hedra API credits are low: remaining={remaining}, "
+                          f"severity={severity}, threshold={data.get('threshold', 'n/a')}."
+                      )
+                      notification = {
+                          'user_id': None,
+                          'title': 'Hedra API credits alert',
+                          'message': message,
+                          'type': 'system',
+                          'link': '/quota-dashboard',
+                          'is_read': False,
+                      }
+                      nresp = requests.post(notification_url, headers=headers, json=notification, timeout=10)
+                      print(f"Hedra notification status: {nresp.status_code}")
+                      webhook = os.environ.get('QUOTA_ALERT_WEBHOOK_URL', '')
+                      if webhook:
+                          wresp = requests.post(webhook, json={'text': message}, timeout=10)
+                          print(f"Hedra webhook status: {wresp.status_code}")
               except Exception as e:
                   print(f'Error saving {env_key}: {e}')
           EOF
@@ -308,6 +423,7 @@ jobs:
           OPENAI_USAGE: ${{ steps.openai.outputs.usage_json }}
           COPILOT_USAGE: ${{ steps.copilot.outputs.usage_json }}
           GEMINI_USAGE: ${{ steps.gemini.outputs.usage_json }}
+          HEDRA_USAGE: ${{ steps.hedra.outputs.usage_json }}
         run: |
           python3 - << 'EOF'
           import os, json
@@ -322,6 +438,7 @@ jobs:
               ('OPENAI_USAGE', 'OpenAI (CODEX)'),
               ('COPILOT_USAGE', 'GitHub Copilot'),
               ('GEMINI_USAGE', 'Gemini Code Assist'),
+              ('HEDRA_USAGE', 'Hedra API credits'),
           ]:
               raw = os.environ.get(env_key, '{}')
               if not raw or raw == '{}':

--- a/docs/HEDRA_CREDIT_MONITORING.md
+++ b/docs/HEDRA_CREDIT_MONITORING.md
@@ -1,0 +1,59 @@
+# Hedra API Credit Monitoring
+
+Status: WBS #1296 implementation slice
+Owner lane: Codex (Windows app)
+Runtime: GitHub Actions quota monitor + Supabase `ai_quota_usage` + `/quota-dashboard`
+
+## What Runs
+
+`AI Quota Monitor` now checks Hedra API credits every day with the official credits endpoint:
+
+```text
+GET https://api.hedra.com/web-app/public/billing/credits
+Header: X-API-Key: <HEDRA_API_KEY>
+```
+
+The monitor stores the result as an `ai_quota_usage` row where `tool = hedra`.
+
+Stored fields include:
+
+- `remaining`
+- `used`
+- `expiring`
+- `workspace_credits`
+- `severity`
+- `threshold`
+- `warning_threshold`
+- `critical_threshold`
+- `stop_threshold`
+
+## Alert Policy
+
+Default thresholds:
+
+- warning: `remaining <= 50`
+- critical: `remaining <= 20`
+- stop: `remaining <= 5`
+
+These can be overridden with repository variables:
+
+- `HEDRA_CREDIT_WARNING_THRESHOLD`
+- `HEDRA_CREDIT_CRITICAL_THRESHOLD`
+- `HEDRA_CREDIT_STOP_THRESHOLD`
+
+When Hedra is below threshold, the workflow:
+
+- sets `alert = true` in `ai_quota_usage`
+- writes a GitHub Actions summary
+- inserts a global in-app notification linking to `/quota-dashboard`
+- posts to `QUOTA_ALERT_WEBHOOK_URL` if that secret is configured
+
+## User-Facing Failure Mode
+
+`ai-assistant` maps Hedra billing/credit failures to `status = credit_shortage`.
+
+The text reply remains available, but video generation is paused with a clear message so a credit shortage is not mistaken for a generic system outage.
+
+## Verification
+
+Use `workflow_dispatch` with `dry_run=true` to validate endpoint connectivity without writing Supabase rows.

--- a/lib/pages/admin/quota_dashboard_page.dart
+++ b/lib/pages/admin/quota_dashboard_page.dart
@@ -30,6 +30,7 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
     'openai': 'OpenAI GPT',
     'github_copilot': 'GitHub Copilot',
     'gemini': 'Google Gemini',
+    'hedra': 'Hedra API',
   };
 
   // ツールごとの月次上限 (USD)
@@ -37,6 +38,7 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
     'anthropic': 50.0,
     'openai': 20.0,
     'github_copilot': 10.0,
+    'hedra': 0.0,
     'gemini': 0.0, // 無料枠
   };
 
@@ -45,6 +47,7 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
     'openai': Icons.psychology,
     'github_copilot': Icons.code,
     'gemini': Icons.auto_fix_high,
+    'hedra': Icons.video_camera_front_outlined,
   };
 
   @override
@@ -236,7 +239,13 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
   }
 
   Widget _buildToolCards() {
-    final tools = ['anthropic', 'openai', 'github_copilot', 'gemini'];
+    final tools = [
+      'anthropic',
+      'openai',
+      'github_copilot',
+      'gemini',
+      'hedra',
+    ];
     return Column(
       children: tools.map((tool) {
         final row = _rowForTool(tool);
@@ -257,6 +266,12 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
     final usageJson = row?['usage_json'] as Map<String, dynamic>? ?? {};
     final costUsd = (usageJson['cost_usd'] as num?)?.toDouble() ?? 0.0;
     final tokens = (usageJson['tokens'] as num?)?.toInt();
+    final remainingCredits = (usageJson['remaining'] as num?)?.toInt();
+    final usedCredits = (usageJson['used'] as num?)?.toInt();
+    final expiringCredits = (usageJson['expiring'] as num?)?.toInt();
+    final creditThreshold = (usageJson['threshold'] as num?)?.toInt();
+    final severity = usageJson['severity']?.toString();
+    final errorMessage = usageJson['error']?.toString();
     final checkedAt = row?['checked_at'] as String?;
     final limit = _toolLimits[tool] ?? 0.0;
     final progress = (limit > 0) ? (costUsd / limit).clamp(0.0, 1.0) : 0.0;
@@ -337,7 +352,26 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
               const SizedBox(height: 12),
               Row(
                 children: [
-                  if (costUsd > 0 || limit > 0) ...[
+                  if (remainingCredits != null) ...[
+                    Text(
+                      '$remainingCredits',
+                      style: TextStyle(
+                        color: isAlert ? _alertRed : Colors.white,
+                        fontSize: 22,
+                        fontWeight: FontWeight.bold,
+                        height: 1.5,
+                      ),
+                    ),
+                    const Text(
+                      ' credits remaining',
+                      style: TextStyle(
+                        color: Colors.white54,
+                        fontSize: 13,
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                  ] else if (costUsd > 0 || limit > 0) ...[
                     Text(
                       '\$${costUsd.toStringAsFixed(2)}',
                       style: TextStyle(
@@ -370,6 +404,36 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
                     ),
                 ],
               ),
+              if (usedCredits != null || expiringCredits != null) ...[
+                const SizedBox(height: 6),
+                Text(
+                  [
+                    if (usedCredits != null) 'used: $usedCredits',
+                    if (expiringCredits != null) 'expiring: $expiringCredits',
+                    if (creditThreshold != null)
+                      'alert threshold: $creditThreshold',
+                    if (severity != null) 'severity: $severity',
+                  ].join(' / '),
+                  style: const TextStyle(
+                    color: Colors.white54,
+                    fontSize: 12,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+              if (errorMessage != null && errorMessage.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                Text(
+                  errorMessage,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: _alertRed,
+                    fontSize: 12,
+                    height: 1.5,
+                  ),
+                ),
+              ],
               if (limit > 0) ...[
                 const SizedBox(height: 8),
                 ClipRRect(
@@ -493,13 +557,12 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
               final date =
                   (row['checked_at'] as String? ?? '').substring(0, 10);
               final usage = row['usage_json'] as Map<String, dynamic>? ?? {};
-              final cost = (usage['cost_usd'] as num?)?.toDouble() ?? 0.0;
               final isAlert = row['alert'] == true;
               return TableRow(
                 children: [
                   _tableCell(_toolNames[tool] ?? tool),
                   _tableCell(date),
-                  _tableCell('\$${cost.toStringAsFixed(2)}'),
+                  _tableCell(_historyMetric(usage)),
                   Padding(
                     padding:
                         const EdgeInsets.symmetric(horizontal: 6, vertical: 6),
@@ -536,5 +599,18 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
     if (tokens >= 1000000) return '${(tokens / 1000000).toStringAsFixed(1)}M';
     if (tokens >= 1000) return '${(tokens / 1000).toStringAsFixed(0)}K';
     return '$tokens';
+  }
+
+  String _historyMetric(Map<String, dynamic> usage) {
+    final remainingCredits = (usage['remaining'] as num?)?.toInt();
+    if (remainingCredits != null) return '$remainingCredits cr';
+    final cost = (usage['cost_usd'] as num?)?.toDouble() ??
+        (usage['cost_usd_est'] as num?)?.toDouble();
+    if (cost != null) return '\$${cost.toStringAsFixed(2)}';
+    final tokens = (usage['tokens'] as num?)?.toInt();
+    if (tokens != null) return '${_formatTokens(tokens)} tok';
+    final status = usage['status']?.toString();
+    if (status != null && status.isNotEmpty) return status;
+    return '-';
   }
 }

--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -367,18 +367,22 @@ serve(async (req) => {
         );
       } catch (error: unknown) {
         const reason = error instanceof Error ? error.message : String(error);
+        const creditShortage = isHedraCreditError(undefined, reason);
         return new Response(
           JSON.stringify({
             success: true,
             result: {
               provider: "hedra",
-              status: "fallback_text",
+              status: creditShortage ? "credit_shortage" : "fallback_text",
               script,
               id: null,
               videoUrl: null,
               previewUrl: null,
               downloadUrl: null,
               reason,
+              userMessage: creditShortage
+                ? "Hedra API credits are low. The text reply is available, but video generation is paused until credits are replenished."
+                : undefined,
             },
           }),
           { headers: corsHeaders },
@@ -940,12 +944,14 @@ ${entryData}`;
         .single();
       if (fetchErr || !skill) throw new Error("Skill not found");
       // use_count をインクリメント (fire-and-forget)
-      supabaseClient
-        .from("user_skills")
-        .update({
-          use_count: ((skill as { use_count?: number }).use_count ?? 0) + 1,
-        })
-        .eq("id", skillId)
+      void Promise.resolve(
+        supabaseClient
+          .from("user_skills")
+          .update({
+            use_count: ((skill as { use_count?: number }).use_count ?? 0) + 1,
+          })
+          .eq("id", skillId),
+      )
         .then(() => {/* ignore */})
         .catch(() => {/* ignore */});
       const prompt = requestContent
@@ -1454,6 +1460,24 @@ function firstNonEmptyString(...values: unknown[]): string | null {
   return null;
 }
 
+function isHedraCreditError(
+  status: number | undefined,
+  message: string,
+): boolean {
+  if (status === 402) return true;
+  return /credit|billing|balance|payment|required top.?up|insufficient|quota|out of credits|not enough/i
+    .test(message);
+}
+
+function buildHedraCreditErrorMessage(status: number, message: string): string {
+  return [
+    "Hedra API credits are insufficient.",
+    `status=${status}`,
+    `detail=${message}`,
+    "Open /quota-dashboard to check remaining credits and replenish before retrying video generation.",
+  ].join(" ");
+}
+
 function buildHedraAvatarImage(data: AIRequest): string | null {
   const avatarImageUrl = data.avatarImageUrl?.trim();
   if (avatarImageUrl) return avatarImageUrl;
@@ -1558,6 +1582,9 @@ async function createHedraVideo(
       (parsed as Record<string, unknown> | null)?.message,
       rawText,
     ) ?? `Hedra request failed with status ${response.status}`;
+    if (isHedraCreditError(response.status, message)) {
+      throw new Error(buildHedraCreditErrorMessage(response.status, message));
+    }
     throw new Error(message);
   }
 


### PR DESCRIPTION
## Summary
- Fixes #1296 by adding Hedra API credit monitoring to `AI Quota Monitor` using Hedra's official `GET /billing/credits` endpoint.
- Stores Hedra credit balance in `ai_quota_usage`, surfaces it in `/quota-dashboard`, and creates a global in-app notification plus optional webhook alert when thresholds are crossed.
- Maps Hedra billing/credit failures in `ai-assistant` to `status=credit_shortage` so users see a clear credit-shortage message instead of a generic outage.

## 2-Instance Routing
- Owner lane: Codex (Windows app), because this is workflow/Edge Function implementation.
- Claude Code lane remains focused on design/spec work such as #1305/#1309.

## Verification
- `dart format lib/pages/admin/quota_dashboard_page.dart`
- `dart analyze lib/pages/admin/quota_dashboard_page.dart`
- `deno fmt --check supabase/functions/ai-assistant/index.ts`
- `deno check supabase/functions/ai-assistant/index.ts`
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/quota-monitor.yml', encoding='utf-8'))"`
- `git diff --check -- .github/workflows/quota-monitor.yml lib/pages/admin/quota_dashboard_page.dart supabase/functions/ai-assistant/index.ts docs/HEDRA_CREDIT_MONITORING.md`

## Minimal E2E Declaration
Implementation-detail independent / black-box checks for this slice:
1. Admin opens `/quota-dashboard` and sees a Hedra API card with remaining/used/expiring credits when `ai_quota_usage.tool=hedra` exists.
2. Scheduled quota monitor writes a Hedra row and emits an alert when remaining credits are below warning/critical/stop thresholds.
3. User asks for an assistant video while Hedra returns a billing/credit error, and the response is `status=credit_shortage` with a clear user message while text fallback remains available.

E2E-Exception: This PR changes a scheduled GitHub Actions monitor and a Supabase Edge Function failure mapping; live Hedra/Supabase credentials are required for full Playwright/E2E coverage, so CI-safe static, Dart, Deno, YAML, and diff checks are used here.

Source: https://www.hedra.com/docs/api-reference/public/get-credits
