### PR TITLE
feat(blog): automate protected publish status updates

### DIFF
--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -382,89 +382,21 @@ jobs:
           echo "[trace=$TRACE_ID] blog_posts status update: HTTP $HTTP"
 
       # ── Step 5: frontmatter を published: true に更新 ───────────────────
-      # PS#1 S21 (2026-04-20): BYPASS_RULES PAT 失効疑いで GH006 protected branch
-      # push reject → continue-on-error: true で warn-only 化 (published:true 更新は
-      # 次回 schedule で再試行 / 同一 draft 2 重投稿リスクは auto_select の orphan 検知で回避)
+      # Branch-protection safe: always push a status branch, then auto-merge when BLOG_PAT can.
+      # If auto-merge fails, the branch/PR remains as the manual fallback.
       - name: Step 5 - Mark draft as published
         if: steps.auto_select.outputs.has_draft == 'true' && github.event.inputs.dry_run != 'true'
-        continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.BYPASS_RULES || secrets.GITHUB_TOKEN }}
-          BYPASS_TOKEN: ${{ secrets.BYPASS_RULES }}
+          GH_TOKEN: ${{ secrets.BLOG_PAT || secrets.GH_PAT_BLOG_MERGE || secrets.BYPASS_RULES || github.token }}
+          BLOG_PAT: ${{ secrets.BLOG_PAT }}
+          GH_PAT_BLOG_MERGE: ${{ secrets.GH_PAT_BLOG_MERGE }}
+          BYPASS_RULES: ${{ secrets.BYPASS_RULES }}
+          GITHUB_TOKEN: ${{ github.token }}
+          DRAFT_PATH: ${{ steps.meta.outputs.draft_path }}
+          DRAFT_PATH_EN: ${{ github.event.inputs.draft_path_en }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          DRAFT_PATH="${{ steps.meta.outputs.draft_path }}"
-          DRAFT_PATH_EN="${{ github.event.inputs.draft_path_en }}"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-
-          # published マーカー付与 (frontmatter あり/なし両対応)
-          _mark_published() {
-            local f="$1"
-            if [ -z "$f" ] || [ ! -f "$f" ]; then return; fi
-            if grep -q "^published: false" "$f"; then
-              sed -i 's/^published: false/published: true/' "$f"
-            elif grep -q "^published:" "$f"; then
-              :
-            elif head -1 "$f" | grep -q "^---"; then
-              sed -i '0,/^---$/!b; /^---$/{ n; /^published:/!{ i published: true
-              } }' "$f"
-            else
-              TMP=$(mktemp)
-              printf -- "---\npublished: true\n---\n" > "$TMP"
-              cat "$f" >> "$TMP"
-              mv "$TMP" "$f"
-            fi
-          }
-
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            # スケジュール実行: main に直接 push (schedule は branch protection bypass 済み)
-            git checkout main 2>/dev/null || git checkout -b main origin/main
-            git pull origin main --ff-only
-            _mark_published "$DRAFT_PATH"
-            _mark_published "$DRAFT_PATH_EN"
-            git add "$DRAFT_PATH" ${DRAFT_PATH_EN:+"$DRAFT_PATH_EN"}
-            if git diff --cached --quiet; then
-              echo "📝 変更なし — スキップ"
-              exit 0
-            fi
-            COMMIT_MSG="docs: ブログ記事投稿完了 $(basename "$DRAFT_PATH")"
-            [ -n "$DRAFT_PATH_EN" ] && COMMIT_MSG="$COMMIT_MSG + $(basename "$DRAFT_PATH_EN")"
-            git commit -m "$COMMIT_MSG"
-            git config --local --unset-all http.https://github.com/.extraheader 2>/dev/null || true
-            git remote set-url origin "https://x-access-token:${BYPASS_TOKEN}@github.com/${{ github.repository }}.git"
-            git push origin HEAD:main
-            echo "✅ [SCHEDULED] published:true に更新 → main push 完了"
-          else
-            # 手動実行: branch 経由 (branch protection により main 直push 不可 = GH006)
-            BRANCH="blog-publish/${{ github.run_id }}-$(TZ=Asia/Tokyo date +'%Y%m%d-%H%M%S')"
-            git checkout -b "$BRANCH" origin/main
-            _mark_published "$DRAFT_PATH"
-            _mark_published "$DRAFT_PATH_EN"
-            git add "$DRAFT_PATH" ${DRAFT_PATH_EN:+"$DRAFT_PATH_EN"}
-            if git diff --cached --quiet; then
-              echo "📝 変更なし — スキップ"
-              exit 0
-            fi
-            COMMIT_MSG="docs: ブログ記事投稿完了 $(basename "$DRAFT_PATH")"
-            [ -n "$DRAFT_PATH_EN" ] && COMMIT_MSG="$COMMIT_MSG + $(basename "$DRAFT_PATH_EN")"
-            git commit -m "$COMMIT_MSG"
-            git push origin "$BRANCH"
-
-            # PR を作成 (PAT があれば自動merge、なければ手動マージ待ち)
-            if [ -n "${{ secrets.GH_PAT_BLOG_MERGE }}" ]; then
-              gh auth login --with-token <<< "${{ secrets.GH_PAT_BLOG_MERGE }}"
-              PR_URL=$(gh pr create --base main --head "$BRANCH" \
-                --title "$COMMIT_MSG" \
-                --body "Auto-merge by blog-publish workflow (published:true frontmatter update)" 2>&1 | tail -1)
-              echo "📝 PR作成: $PR_URL"
-              gh pr merge "$BRANCH" --auto --squash --delete-branch 2>&1 | head -3
-            else
-              echo "ℹ️ ブランチ '$BRANCH' を push しました (GH_PAT_BLOG_MERGE 未設定のため手動マージ)。"
-              echo "   マージ: git fetch origin $BRANCH && git merge origin/$BRANCH && git push origin main"
-            fi
-          fi
+          bash scripts/blog_mark_published_status.sh
 
       # ── Step 6: schedule_task_runs 記録 ─────────────────────────────────
       - name: Step 6 - schedule_task_runs 記録

--- a/docs/BLOG_PUBLISH_STATUS_AUTOMATION.md
+++ b/docs/BLOG_PUBLISH_STATUS_AUTOMATION.md
@@ -1,0 +1,32 @@
+# Blog Publish Status Automation
+
+Issue: #1304
+
+Published draft status updates no longer push directly to `main`. The
+`blog-publish.yml` workflow now delegates the frontmatter update to
+`scripts/blog_mark_published_status.sh`, which is safe under branch protection.
+
+## Flow
+
+1. After a successful publish, mark the selected draft and optional English
+   draft as `published: true`.
+2. Commit the change to `blog-publish/<run_id>-<timestamp>`.
+3. Push that branch with `BLOG_PAT` when configured. Fallback token order is:
+   `BLOG_PAT`, `GH_PAT_BLOG_MERGE`, `BYPASS_RULES`, then `GITHUB_TOKEN`.
+4. Create a PR to `main`.
+5. If the token can bypass/merge under branch protection, squash merge the PR
+   and delete the branch automatically.
+6. If PR creation or merge is unavailable, leave the branch/PR for manual
+   merge instead of retrying a protected direct push.
+
+## Required Secret
+
+Prefer `BLOG_PAT` as the dedicated publish-status token. It should have the
+least privilege that can push workflow-created branches, create pull requests,
+and merge the status PR according to the repository branch protection rules.
+
+## Local Checks
+
+```bash
+bash -n scripts/blog_mark_published_status.sh
+```

--- a/scripts/blog_mark_published_status.sh
+++ b/scripts/blog_mark_published_status.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mark published blog draft frontmatter in a branch-protection-safe way.
+# The workflow always writes the change to a temporary branch first. If BLOG_PAT
+# or a compatible fallback token can merge the PR, it is auto-merged; otherwise
+# the branch/PR remains as the manual fallback.
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "::error::${name} is required"
+    exit 1
+  fi
+}
+
+mark_published() {
+  local file="$1"
+  if [ -z "$file" ] || [ ! -f "$file" ]; then
+    return 0
+  fi
+
+  if grep -q "^published: false" "$file"; then
+    sed -i 's/^published: false/published: true/' "$file"
+  elif grep -q "^published:" "$file"; then
+    return 0
+  elif head -1 "$file" | grep -q "^---"; then
+    local tmp
+    tmp=$(mktemp)
+    awk '
+      NR == 1 && $0 == "---" { print; in_fm=1; next }
+      in_fm && $0 == "---" && !inserted { print "published: true"; inserted=1; print; in_fm=0; next }
+      { print }
+    ' "$file" > "$tmp"
+    mv "$tmp" "$file"
+  else
+    local tmp
+    tmp=$(mktemp)
+    printf -- "---\npublished: true\n---\n" > "$tmp"
+    cat "$file" >> "$tmp"
+    mv "$tmp" "$file"
+  fi
+}
+
+require_env DRAFT_PATH
+require_env GITHUB_REPOSITORY
+
+RUN_ID="${GITHUB_RUN_ID:-local}"
+TRACE="${TRACE_ID:-blog-publish-${RUN_ID}}"
+TOKEN="${BLOG_PAT:-${GH_PAT_BLOG_MERGE:-${BYPASS_RULES:-${GITHUB_TOKEN:-}}}}"
+BRANCH="blog-publish/${RUN_ID}-$(TZ=Asia/Tokyo date +'%Y%m%d-%H%M%S')"
+COMMIT_MSG="docs: mark blog draft published $(basename "$DRAFT_PATH")"
+if [ -n "${DRAFT_PATH_EN:-}" ]; then
+  COMMIT_MSG="$COMMIT_MSG + $(basename "$DRAFT_PATH_EN")"
+fi
+
+echo "[trace=$TRACE] status automation branch: $BRANCH"
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git fetch origin main
+git checkout -B "$BRANCH" origin/main
+
+mark_published "$DRAFT_PATH"
+mark_published "${DRAFT_PATH_EN:-}"
+
+git add "$DRAFT_PATH"
+if [ -n "${DRAFT_PATH_EN:-}" ] && [ -f "$DRAFT_PATH_EN" ]; then
+  git add "$DRAFT_PATH_EN"
+fi
+
+if git diff --cached --quiet; then
+  echo "[trace=$TRACE] no published flag changes; skipping status branch"
+  exit 0
+fi
+
+git commit -m "$COMMIT_MSG"
+
+if [ -n "$TOKEN" ]; then
+  git config --local --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+  git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+fi
+
+git push origin "$BRANCH"
+echo "[trace=$TRACE] pushed fallback branch $BRANCH"
+
+PR_URL=""
+if command -v gh >/dev/null 2>&1; then
+  export GH_TOKEN="${TOKEN:-${GH_TOKEN:-}}"
+  if [ -n "${GH_TOKEN:-}" ]; then
+    PR_URL=$(gh pr create \
+      --base main \
+      --head "$BRANCH" \
+      --title "$COMMIT_MSG" \
+      --body "Automated blog-publish status update. If auto-merge is unavailable, merge this PR manually." \
+      2>/tmp/blog-publish-pr-create.err || true)
+    if [ -n "$PR_URL" ]; then
+      echo "[trace=$TRACE] status PR: $PR_URL"
+      if gh pr merge "$PR_URL" --auto --squash --delete-branch 2>/tmp/blog-publish-pr-merge.err; then
+        echo "[trace=$TRACE] status PR auto-merged"
+      else
+        echo "::warning::[trace=$TRACE] status PR auto-merge failed; leaving fallback PR/branch."
+        cat /tmp/blog-publish-pr-merge.err || true
+      fi
+    else
+      echo "::warning::[trace=$TRACE] PR creation failed; branch remains for manual merge."
+      cat /tmp/blog-publish-pr-create.err || true
+    fi
+  else
+    echo "::warning::[trace=$TRACE] no GitHub token available for PR creation; branch remains for manual merge."
+  fi
+else
+  echo "::warning::[trace=$TRACE] gh CLI unavailable; branch remains for manual merge."
+fi
+
+{
+  echo "## Blog publish status automation"
+  echo ""
+  echo "| item | value |"
+  echo "| --- | --- |"
+  echo "| trace_id | \`$TRACE\` |"
+  echo "| branch | \`$BRANCH\` |"
+  echo "| pr | ${PR_URL:-not-created} |"
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"


### PR DESCRIPTION
## Summary

Fixes #1304.

Reworks the post-publish `published: true` update so it no longer relies on direct pushes to protected `main`.

## Changes

- Added `scripts/blog_mark_published_status.sh` to update selected drafts on `blog-publish/<run_id>-<timestamp>` branches.
- Uses token fallback order: `BLOG_PAT`, `GH_PAT_BLOG_MERGE`, `BYPASS_RULES`, then `GITHUB_TOKEN`.
- Creates a PR back to `main` and enables auto squash merge when the token/branch protection allow it.
- Leaves the branch/PR as a manual fallback if PR creation or auto-merge is unavailable.
- Simplified `blog-publish.yml` Step 5 to call the dedicated status automation script.
- Documented the protected-branch flow in `docs/BLOG_PUBLISH_STATUS_AUTOMATION.md`.

## 2-Instance Routing

- Codex Windows: GitHub Actions implementation for the branch-protection-safe publish-status automation.
- Claude Code Windows: no ownership change; design/spec WBS items stay on Claude Code per the 2-instance routing.

## Validation

- `sh -n scripts\blog_mark_published_status.sh`
- YAML parse for `.github/workflows/blog-publish.yml`
- `git diff --check -- .github\workflows\blog-publish.yml scripts\blog_mark_published_status.sh docs\BLOG_PUBLISH_STATUS_AUTOMATION.md`

Note: local `bash -n` maps to WSL on this Windows host and WSL is not installed, so Git `sh -n` was used for syntax validation. GitHub Actions runs this on Ubuntu with bash available.

## Minimal E2E Declaration

- Implementation-detail independent: yes, the workflow invokes the same shell entrypoint that will run in Actions.
- Minimal scope: 3 cases are covered by inspection and shell/YAML validation: status branch path, token fallback path, and manual fallback branch/PR path.
- Playwright/E2E: E2E-Exception: this is a GitHub Actions publish-status automation with no browser UI. Shell syntax and workflow YAML validation are the minimal black-box checks for this change.
