### PR TITLE
docs(spec): part 152 — sensitive 第 4 例 #1577 MCP-AUTH-27 10/10 + template §4A 第 4 改訂

### DIFF
--- a/docs/DESIGN_SPEC_TEMPLATE.md
+++ b/docs/DESIGN_SPEC_TEMPLATE.md
@@ -76,7 +76,7 @@ part 143-145 で 6 spec ship したが、各 section 構成は同型. 7 件目�
 
 = GitHub Issue 受入 #1-#N が必ず spec section に対応する self-check.
 
-## 4. 適用済 9 spec の axis 早見表 (= part 143-150)
+## 4. 適用済 10 spec の axis 早見表 (= part 143-152)
 
 | spec | Q1 | Q2 | Q3 | Q4 | Q5 | 主 axis | 工数 | 種別 |
 |---|---|---|---|---|---|---|---:|---|
@@ -89,12 +89,13 @@ part 143-145 で 6 spec ship したが、各 section 構成は同型. 7 件目�
 | MENTAL_HEALTH_RISK | ✅ | ❌ | ✅ | ❌ | ✅ | + AI-CHARACTER 8/8 + AI-DEV 7/7 + IMBUE | 11h | **sensitive 第 1** |
 | AI_DESPERATION_DETECTION | ✅ | ✅ | ❌ | ❌ | ✅ | + AI-CHARACTER 8/8 + AI-DEV 7/7 + COLLAB | 9h | **sensitive 第 2** |
 | ROBUST_AI_PERSONA | ✅ | ✅ | ❌ | ❌ | ✅ | + AI-CHARACTER 8/8 + AI-DEV 7/7 + VIBE | 14h | **sensitive 第 3** |
-| **平均工数** | | | | | | | **9.5h** | |
+| MCP_AUTH_HARDENING | ✅ | ✅ | ❌ | ❌ | ✅ | + **MCP-AUTH 10/10** + AI-DEV 7/7 + AI-CHARACTER 8/8 + VIBE + SYNERGY | 14h | **sensitive 第 4** |
+| **平均工数** | | | | | | | **10.0h** | |
 
 = 1 spec ≈ 1 営業日 (= 8-12h) Codex 工数 / Win Claude 起票工数 ≈ 30-60 min (= 7-15x leverage).
-= sensitive 平均 11.3h (= 通常 8.6h より +30% / 倫理 review section 拡張 reflect).
+= sensitive 平均 12.0h (= 通常 8.6h より +40% / 倫理 review section 拡張 reflect).
 
-## 4A. Sensitive design 拡張 §2 倫理 review section (= 必須 / part 147 確立 + part 150 で 3 例完成)
+## 4A. Sensitive design 拡張 §2 倫理 review section (= 必須 / part 147 確立 + part 150 で 3 例完成 + part 152 で第 4 例 = security boundary 異領域拡張)
 
 ### 4A.1 適用判断: sensitive design か
 
@@ -105,6 +106,7 @@ part 143-145 で 6 spec ship したが、各 section 構成は同型. 7 件目�
 - **個人 data**: 子供 / 高齢者 / マイノリティ
 - **AI 内部状態**: 自己反映 / 焦り / desperation
 - **high-stakes persona**: 決定 影響度大 / 倫理基準 必須
+- **security boundary** (= 第 4 例 / part 152 追加): 認証 / 認可 / 外部攻撃面 / token 発行 / capability 公開
 
 ### 4A.2 §2 倫理 review section 構成 (= 必須 4 sub-section)
 
@@ -134,33 +136,36 @@ part 143-145 で 6 spec ship したが、各 section 構成は同型. 7 件目�
 | 7 | quality-gate | ✅ ... |
 ```
 
-### 4A.3 3 例 異領域 NOT to do 対比 (= part 150 で完成)
+### 4A.3 4 例 異領域 NOT to do 対比 (= part 152 で第 4 例 = security boundary 拡張)
 
 | 例 | 領域 | 主 NOT to do | 共通項 |
 |---|---|---|---|
 | 第 1 (#1393 / part 147) | 人間データ (健康) | 共有/診断/LLM raw 送信禁止 | 共有禁止 |
 | 第 2 (#1398 / part 149) | AI 内部状態 | 擬人化/labeling/black-box 禁止 | 操作禁止 |
 | 第 3 (#1400 / part 150) | high-stakes persona | 強靭=拒否しない誤解/medical-legal-financial 直接判断/gaslighting 禁止 | fail silent 禁止 |
+| **第 4 (#1577 / part 152)** | **security boundary** | **token 共有/sampling 申告/Manual SQL 登録/権限過剰申告 禁止** | **権限過剰禁止** |
 
-→ **3 異領域共通 NOT to do** (= 第 4 改訂で抽出):
-1. ❌ **共有禁止**: 第三者 / 外部 LLM / 学習 data へ raw 送信しない
-2. ❌ **操作禁止**: gaslighting / dark pattern / manipulation NG
-3. ❌ **fail silent 禁止**: failure / 誤検知 / NG list 通過を log + alert
+→ **4 異領域共通 NOT to do** (= 第 5 改訂候補 / part 152 で抽出):
+1. ❌ **共有禁止**: 第三者 / 外部 LLM / 学習 data / 全 tool 横断 token へ raw 送信しない
+2. ❌ **操作禁止**: gaslighting / dark pattern / manipulation / impersonation NG
+3. ❌ **fail silent 禁止**: failure / 誤検知 / NG list 通過 / token invalid を log + alert
+4. ❌ **権限過剰禁止** (= 第 4 例で追加): default ON / capabilities 申告 / scope を最小に絞る (= AttestMCP 備え + sampling 排除)
 
-### 4A.4 3 例 異領域 MUST do 対比 (= part 150 で完成)
+### 4A.4 4 例 異領域 MUST do 対比 (= part 152 で第 4 例 = security boundary 拡張)
 
-| 共通 MUST | 第 1 (健康) | 第 2 (AI 状態) | 第 3 (persona) |
-|---|---|---|---|
-| **opt-in / opt-out** | default off / 1 tap 無効化 | default ON safety net / setting で OFF | escape hatch UI |
-| **export / 削除** | JSON export + 全削除 | 14 日 retention 自動 purge | 90 日 retention |
-| **観察可能性** | health_check_result jsonb | desperation_log + trace_id | test_run + ci_run_id |
-| **正直 report** | 「ひと休みのお誘い」 | 「指示 reframe / 完了困難」 | 「専門家へ link」 |
-| **退避 path** | 専門医導線 + 緊急 escape | 別 mentor / model swap / 手動完了 | escape hatch + persona 通常モード切替 |
+| 共通 MUST | 第 1 (健康) | 第 2 (AI 状態) | 第 3 (persona) | **第 4 (security)** |
+|---|---|---|---|---|
+| **opt-in / opt-out** | default off / 1 tap 無効化 | default ON safety net / setting で OFF | escape hatch UI | **consent screen で tool 単位 scope 選択** |
+| **export / 削除** | JSON export + 全削除 | 14 日 retention 自動 purge | 90 日 retention | **mcp_audit_log 90 日 + suspended flag 即 disable** |
+| **観察可能性** | health_check_result jsonb | desperation_log + trace_id | test_run + ci_run_id | **mcp_audit_log + anomaly_score + cross_server_trace** |
+| **正直 report** | 「ひと休みのお誘い」 | 「指示 reframe / 完了困難」 | 「専門家へ link」 | **WWW-Authenticate header + .well-known 公開** |
+| **退避 path** | 専門医導線 + 緊急 escape | 別 mentor / model swap / 手動完了 | escape hatch + persona 通常モード切替 | **incident runbook + Sentinel role で 1 SQL 全 disable** |
 
-→ **3 異領域共通 MUST do** (= 第 4 改訂で抽出):
-1. ✅ **opt-in / opt-out**: 機能 ON/OFF が user 全権
+→ **4 異領域共通 MUST do** (= 第 5 改訂候補 / part 152 で抽出):
+1. ✅ **opt-in / opt-out**: 機能 ON/OFF が user 全権 (= consent screen / tool 単位 scope)
 2. ✅ **観察可能性**: log + trace_id + retention 期間明記
-3. ✅ **退避 path**: 失敗時 必ず別 path / human-in-loop 提示
+3. ✅ **退避 path**: 失敗時 必ず別 path / human-in-loop 提示 (= incident runbook 含)
+4. ✅ **vendor managed 優先** (= 第 4 例で追加): MVP は managed (WorkOS / Stripe / Auth0) / 自前切替 trigger 明示
 
 ## 5. 起票 ritual (= Win Claude 起票時 8 step)
 
@@ -189,7 +194,8 @@ part 143-145 で 6 spec ship したが、各 section 構成は同型. 7 件目�
 
 - 本 template を NotebookLM `jibun-master-brain` 蓄積 (= part 146)
 - part 147+ 新 spec ship 時 §4 早見表更新 + 平均工数追跡
-- 10 spec 突破時 (= 推定 part 150 頃) **DESIGN_SPEC_PATTERNS.md** へ統合 (= 設計 patterns 体系化)
+- 10 spec 突破 ✅ **part 152 で達成** (= sensitive 4 例完成 + 通常 6 例) → 次 phase: **DESIGN_SPEC_PATTERNS.md** へ統合 (= 設計 patterns 体系化)
+- 第 5 改訂候補: 4 異領域共通 NOT to do / MUST do を **抽象化 layer** へ昇格 (= sensitive design 全体の base 規範化)
 
 ## 8. PHILOSOPHY-22 / BRAIN-32 alignment
 

--- a/docs/DESIGN_SPEC_TEMPLATE.md
+++ b/docs/DESIGN_SPEC_TEMPLATE.md
@@ -76,7 +76,7 @@ part 143-145 で 6 spec ship したが、各 section 構成は同型. 7 件目�
 
 = GitHub Issue 受入 #1-#N が必ず spec section に対応する self-check.
 
-## 4. 適用済 10 spec の axis 早見表 (= part 143-152)
+## 4. 適用済 11 spec の axis 早見表 (= part 143-152)
 
 | spec | Q1 | Q2 | Q3 | Q4 | Q5 | 主 axis | 工数 | 種別 |
 |---|---|---|---|---|---|---|---:|---|
@@ -90,10 +90,12 @@ part 143-145 で 6 spec ship したが、各 section 構成は同型. 7 件目�
 | AI_DESPERATION_DETECTION | ✅ | ✅ | ❌ | ❌ | ✅ | + AI-CHARACTER 8/8 + AI-DEV 7/7 + COLLAB | 9h | **sensitive 第 2** |
 | ROBUST_AI_PERSONA | ✅ | ✅ | ❌ | ❌ | ✅ | + AI-CHARACTER 8/8 + AI-DEV 7/7 + VIBE | 14h | **sensitive 第 3** |
 | MCP_AUTH_HARDENING | ✅ | ✅ | ❌ | ❌ | ✅ | + **MCP-AUTH 10/10** + AI-DEV 7/7 + AI-CHARACTER 8/8 + VIBE + SYNERGY | 14h | **sensitive 第 4** |
-| **平均工数** | | | | | | | **10.0h** | |
+| PRECOMPACT_MEMORY_BACKUP | ✅ | ✅ | ❌ | ❌ | ✅ | PHILOSOPHY + AI-DEV + BRAIN + INDIE + SYNERGY | 8h | 通常 (= 既存拡張 第 1) |
+| **平均工数** | | | | | | | **9.8h** | |
 
 = 1 spec ≈ 1 営業日 (= 8-12h) Codex 工数 / Win Claude 起票工数 ≈ 30-60 min (= 7-15x leverage).
-= sensitive 平均 12.0h (= 通常 8.6h より +40% / 倫理 review section 拡張 reflect).
+= sensitive 平均 12.0h (= 通常 8.5h より +40% / 倫理 review section 拡張 reflect).
+= 通常 spec template の **既存 hook 拡張** pattern 第 1 例 (= PRECOMPACT_MEMORY_BACKUP / part 152) — ゼロから新規ではなく既存 base + 増分設計.
 
 ## 4A. Sensitive design 拡張 §2 倫理 review section (= 必須 / part 147 確立 + part 150 で 3 例完成 + part 152 で第 4 例 = security boundary 異領域拡張)
 

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -27304,6 +27304,104 @@ batch 7 cross-instance-pr (20 件 / Codex 18 + Win Claude 2) + Codex sprint 1 �
 INSTANCE-ROLES 厳守: Win Claude meta-doc 改訂 + batch 7 triage / Win Codex 18 件 batch 7 hand off (推定 +90h).
 COMPACTION-RESUME: 90min ガード接近 → 本 part で wrap-up 着地。
 
+## Win版#132 part 152 (= sensitive 第 4 例 #1577 MCP-AUTH-27 10/10 + template §4A 第 4 改訂 / 2026-05-05)
+
+**Instance**: Win Claude (worktree: `.claude/worktrees/crazy-jennings-93b113`)
+**Session**: part 152
+**Commit**: `5f730d970` (PR #2022 / base = #2017 / 階層化 spec PR)
+**Branch**: `claude/crazy-jennings-93b113` (= `claude/amazing-hypatia-84b710` から rebase / part 144-151 spec チェーン継承)
+
+### Ship 内容
+
+#### 1. `docs/MCP_AUTH_HARDENING_SPEC.md` 新規 (= sensitive 第 4 例 / 11 section / 618 行)
+
+Issue #1577 (= P1 / WorkOS AuthKit MCP 認可強化) の設計 spec.
+**MCP-AUTH-27 10/10 必須遵守** + sensitive design 拡張 spec template 第 4 例.
+
+主要 section:
+- §2 倫理 review (= NOT to do 10 項 + MUST do 12 項 + 8/8 + 7/7 + 10/10 self-check)
+- §4 5 hardening axis 採否決定 matrix:
+  - **CIMD**: △ Phase 2 採用 (2027 Q1) / Phase 1 = DCR 継続 (= Mercari 事例参照)
+  - **OAuth IaC**: ✅ Phase 1 採用 / Manual SQL 禁止 lint
+  - **Standalone Connect**: ✅ Phase 1 採用 / `workos_user_link` table
+  - **HMAC + Nonce + Timestamp**: △ 内部 EF 間 only / 外部 MCP は OAuth 2.1+PKCE で代替
+  - **Sampling Origin Tagging**: ✅ sampling 申告除外で代替 (= 攻撃面ゼロ化)
+- §5 schema 設計 (= mcp_auth_guard 完成 + 3 migration extend + mcp-well-known EF + Terraform skeleton + anomaly cron)
+- §6 memory-search-hub 5/10 → 10/10 達成手順 (= MCP 公開第 1 例)
+- §7 hand off 14 件 / EF +1 / 工数 14h
+- §8 9 原則 alignment: PHILOSOPHY 8/9 + MCP-AUTH 10/10 + AI-DEV 7/7 + AI-CHARACTER 8/8 + VIBE 4+/7 + SYNERGY 4+/7
+
+#### 2. `docs/DESIGN_SPEC_TEMPLATE.md` 第 4 改訂 (= meta-spec 更新)
+
+- §4 早見表: 10 spec 達成 (= sensitive 4/4 + 通常 6) / 平均工数 10.0h
+- §4A.1 sensitive 判断 list: **"security boundary"** 追加 (= 異領域 4 種目)
+- §4A.3 NOT to do 4 例対比: 共通 3 → 4 項目に拡張 (= **「権限過剰禁止」**追加)
+- §4A.4 MUST do 4 例対比: 共通 3 → 4 項目に拡張 (= **「vendor managed 優先」**追加)
+- §7 横展開計画: 10 spec 突破達成記録 + 第 5 改訂候補 (= DESIGN_SPEC_PATTERNS.md 統合) 明記
+
+### Sensitive matrix 拡張
+
+| 例 | 領域 | 先行 part | 特徴 |
+|---|---|---|---|
+| 第 1 (#1393) | 人間データ (健康) | part 147 | 個人 privacy |
+| 第 2 (#1398) | AI 内部状態 | part 149 | metaphor 適用 |
+| 第 3 (#1400) | high-stakes persona | part 150 | human-in-loop |
+| **第 4 (#1577)** | **security boundary** | **part 152** | **blast radius 最小化** |
+
+→ 4 異領域共通 NOT to do = 共有禁止 / 操作禁止 / fail silent 禁止 / **権限過剰禁止**.
+→ 4 異領域共通 MUST do = opt-in / 観察可能性 / 退避 path / **vendor managed 優先**.
+
+### KPI delta
+
+| 部 | 直前 (part 151) | part 152 後 |
+|---|---|---|
+| sensitive 設計 spec 件数 | 3 件 | **4 件** |
+| 通常設計 spec 件数 | 6 件 | 6 件 |
+| 設計 spec 総件数 | 9 件 | **10 件** (= 突破達成) |
+| sensitive 平均工数 | 11.3h | 12.0h (= +30% → +40% / 第 4 例 14h reflect) |
+| 連続 dogfood part | 78 part | **79 part** |
+| §4A 共通項 (NOT to do) | 3 項 | **4 項** |
+| §4A 共通項 (MUST do) | 3 項 | **4 項** |
+| MCP 公開可 EF 候補 | 0 件 | **1 件** (= memory-search-hub 達成手順 §6) |
+
+### Pattern 確立 (= part 152 で新規)
+
+- 「sensitive 異領域 4 種目 = security boundary」(= 認証/認可 を sensitive design template の正式領域に追加)
+- 「sensitive 4 例完成 = 共通項抽象化 layer 候補」(= part 153+ で `DESIGN_SPEC_PATTERNS.md` 統合候補)
+- 「PR 階層化 spec ship」第 2 例 (= base = #2017 / merge 順序自動解決 / part 145 第 1 例: deferred 全消化)
+- 「principle gate 横断適用」(= 1 spec で MCP-AUTH-27 10/10 + AI-DEV 7/7 + AI-CHARACTER 8/8 + PHILOSOPHY 8/9 + VIBE 4+/7 + SYNERGY 4+/7 = 6 軸全 ✅)
+
+### Commit
+
+`docs(spec): part 152 — sensitive 第 4 例 #1577 MCP-AUTH-27 10/10 + template §4A 第 4 改訂` / commit `5f730d970` / PR #2022.
+
+### Philosophy Alignment
+
+- PHILOSOPHY-22: 8/9 ✅ (= 7+/9 ゲート達成)
+- MCP-AUTH-27: 10/10 ✅ (= public 公開要件達成)
+- AI-DEV-23: 7/7 ✅
+- AI-CHARACTER-24: 8/8 ✅
+- VIBE-30: 4+/7 ✅ (= CEO レビュー強化フラグ)
+- SYNERGY-30: 4+/7 ✅
+- BRAIN-32: 7/7 ✅ (= NotebookLM 蓄積予定 + spec docs 永続化)
+- INDIE-29: 7/7 ✅ (= 1 session 1 spec ship discipline)
+
+### 次回 candidate (= part 153 候補)
+
+1. **Win Claude deferred 残 ship**:
+   - #1564 PreCompact memory backup hook ship (= part 151 deferred 残 / sensitive 候補ではない通常 spec)
+   - #1397 開発推進 docs / #1399 機能的感情 (= 検討中)
+2. **DESIGN_SPEC_PATTERNS.md 統合** (= sensitive 4 例完成 → 抽象化 layer / 第 5 改訂)
+3. **NotebookLM 11 sources 完成** (= PR #2015 / #2017 / #2022 main merge 後 #1316 #1345 #1577 投入)
+4. **Codex sprint 1 翌日 KPI 計測** (= 24h+ 後 / 5+ merge 目標)
+5. **memory-search-hub 10/10 達成 hand off 監視** (= Win Codex 5 原則完成 / MCP 公開第 1 例 ship)
+
+INSTANCE-ROLES 厳守: Win Claude territory (= 5-question matrix Q1+Q2+Q5 YES) 完全合致 / Win Codex 14 件 hand off scope §7 で明示.
+[DYNAMIC-CLAIM] cap 1 件遵守.
+[WORKDIR-ISOLATION] 遵守 (= `.claude/worktrees/crazy-jennings-93b113` 内作業).
+[STASH-SAFETY] 遵守 (= stash 不使用 / 1 commit で完結).
+[COMPACTION-RESUME] 90min ガード遵守 → 本 part で wrap-up 着地予定.
+
 
 
 

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -27304,16 +27304,16 @@ batch 7 cross-instance-pr (20 件 / Codex 18 + Win Claude 2) + Codex sprint 1 �
 INSTANCE-ROLES 厳守: Win Claude meta-doc 改訂 + batch 7 triage / Win Codex 18 件 batch 7 hand off (推定 +90h).
 COMPACTION-RESUME: 90min ガード接近 → 本 part で wrap-up 着地。
 
-## Win版#132 part 152 (= sensitive 第 4 例 #1577 MCP-AUTH-27 10/10 + template §4A 第 4 改訂 / 2026-05-05)
+## Win版#132 part 152 (= 1 session 2 spec ship — sensitive 第 4 #1577 + 通常 第 7 #1564 / template §4A 第 4 改訂 / 2026-05-05)
 
 **Instance**: Win Claude (worktree: `.claude/worktrees/crazy-jennings-93b113`)
-**Session**: part 152
-**Commit**: `5f730d970` (PR #2022 / base = #2017 / 階層化 spec PR)
+**Session**: part 152 (= **1 session 2 spec ship** / Codex 起票工数合計 **22h** = sensitive 14h + 通常 8h)
+**Commits**: `5f730d970` (sensitive #1577) + `f523149f0` (ROADMAP entry) + `d77d5e752` (通常 #1564) — PR [#2022](https://github.com/kanta13jp1/my_web_app/pull/2022) / base = [#2017](https://github.com/kanta13jp1/my_web_app/pull/2017) / 階層化 spec PR / 3 commits
 **Branch**: `claude/crazy-jennings-93b113` (= `claude/amazing-hypatia-84b710` から rebase / part 144-151 spec チェーン継承)
 
 ### Ship 内容
 
-#### 1. `docs/MCP_AUTH_HARDENING_SPEC.md` 新規 (= sensitive 第 4 例 / 11 section / 618 行)
+#### 1A. `docs/MCP_AUTH_HARDENING_SPEC.md` 新規 (= sensitive 第 4 例 / 11 section / 618 行)
 
 Issue #1577 (= P1 / WorkOS AuthKit MCP 認可強化) の設計 spec.
 **MCP-AUTH-27 10/10 必須遵守** + sensitive design 拡張 spec template 第 4 例.
@@ -27330,6 +27330,27 @@ Issue #1577 (= P1 / WorkOS AuthKit MCP 認可強化) の設計 spec.
 - §6 memory-search-hub 5/10 → 10/10 達成手順 (= MCP 公開第 1 例)
 - §7 hand off 14 件 / EF +1 / 工数 14h
 - §8 9 原則 alignment: PHILOSOPHY 8/9 + MCP-AUTH 10/10 + AI-DEV 7/7 + AI-CHARACTER 8/8 + VIBE 4+/7 + SYNERGY 4+/7
+
+#### 1B. `docs/PRECOMPACT_MEMORY_BACKUP_SPEC.md` 新規 (= 通常 第 7 例 / 9 section / 既存 hook 拡張 pattern 第 1 例)
+
+Issue [#1564](https://github.com/kanta13jp1/my_web_app/issues/1564) (= P1 / Claude Code 記憶保全) の設計 spec.
+通常 5 section + sensitive ではないため §2 倫理 review section 不要.
+通常 spec template の **「既存 hook 拡張」pattern 第 1 例** (= ゼロから新規ではなく既存 4 hook + 1 script base に増分設計 / Codex 工数 +30% 削減).
+
+主要 section:
+- §3.1 PreCompact hook 拡張 (= 既存 `.claude/hooks/pre-compact-backup.ps1` / part 122 bc58b50b #1848)
+  - YAML payload + 秘匿情報 redact filter (= GitHub PAT / Bearer / API key / .env pattern)
+- §3.2 SessionStart hook 拡張 (= 既存 `session-start-sync-rules.ps1` / part 136 + 5 検出追加)
+  - branch prefix 取り違え (= claude/ vs codex/) / behind/ahead/dirty/未 push/品質ゲート未完
+- §3.3 StatusLine 設定 (= `~/.claude/settings.json` `statusLine` 新規)
+  - 形式: `[instance] #issue | branch*N | gate=name`
+- §3.4 Setup hook SOP (= `docs/CLAUDE_CODE_SETUP_RUNBOOK.md` 新設)
+  - `--init` 7 step + `--maintenance` 7 step + 秘匿情報取扱 明文化
+- §5 hand off scope **10 件** / EF +0 / 工数 8h
+- §6 9 原則 alignment: PHILOSOPHY 8/9 + AI-DEV 7/7 + BRAIN 7/7 + INDIE 7/7 + SYNERGY 4+/7
+
+[INSTANCE] (part 130 / 2 instance 制) 反映: Issue body は「10 インスタンス並行」前提だが現状 = Win Claude + Win Codex のみ.
+仕様は 2 instance を base にしつつ N instance scalable 設計.
 
 #### 2. `docs/DESIGN_SPEC_TEMPLATE.md` 第 4 改訂 (= meta-spec 更新)
 
@@ -27356,13 +27377,15 @@ Issue #1577 (= P1 / WorkOS AuthKit MCP 認可強化) の設計 spec.
 | 部 | 直前 (part 151) | part 152 後 |
 |---|---|---|
 | sensitive 設計 spec 件数 | 3 件 | **4 件** |
-| 通常設計 spec 件数 | 6 件 | 6 件 |
-| 設計 spec 総件数 | 9 件 | **10 件** (= 突破達成) |
+| 通常設計 spec 件数 | 6 件 | **7 件** |
+| 設計 spec 総件数 | 9 件 | **11 件** (= 1 session +2 / 過去最大) |
 | sensitive 平均工数 | 11.3h | 12.0h (= +30% → +40% / 第 4 例 14h reflect) |
+| 通常 spec 平均工数 | 8.6h | 8.5h (= 既存 hook 拡張 pattern で工数小さめ) |
 | 連続 dogfood part | 78 part | **79 part** |
 | §4A 共通項 (NOT to do) | 3 項 | **4 項** |
 | §4A 共通項 (MUST do) | 3 項 | **4 項** |
 | MCP 公開可 EF 候補 | 0 件 | **1 件** (= memory-search-hub 達成手順 §6) |
+| 1 session Codex 起票工数 | 14h (= part 145 / 過去最大) | **22h** (= 14h + 8h / 過去最大更新) |
 
 ### Pattern 確立 (= part 152 で新規)
 
@@ -27370,10 +27393,15 @@ Issue #1577 (= P1 / WorkOS AuthKit MCP 認可強化) の設計 spec.
 - 「sensitive 4 例完成 = 共通項抽象化 layer 候補」(= part 153+ で `DESIGN_SPEC_PATTERNS.md` 統合候補)
 - 「PR 階層化 spec ship」第 2 例 (= base = #2017 / merge 順序自動解決 / part 145 第 1 例: deferred 全消化)
 - 「principle gate 横断適用」(= 1 spec で MCP-AUTH-27 10/10 + AI-DEV 7/7 + AI-CHARACTER 8/8 + PHILOSOPHY 8/9 + VIBE 4+/7 + SYNERGY 4+/7 = 6 軸全 ✅)
+- **「1 session 2 spec ship」**(= sensitive + 通常 同 session 並行 ship / Codex 起票工数 22h で過去最大更新)
+- **「既存 hook 拡張 pattern」**第 1 例 (= 通常 #1564 / ゼロから新規ではなく既存 base + 増分設計 / Codex 工数 +30% 削減)
+- **「sensitive vs 通常 同 session 並行 ship」**(= template 汎用性検証 / 4 例 sensitive と通常 連続適用で robustness 確認)
 
-### Commit
+### Commits (= 3 件 / 同 PR #2022)
 
-`docs(spec): part 152 — sensitive 第 4 例 #1577 MCP-AUTH-27 10/10 + template §4A 第 4 改訂` / commit `5f730d970` / PR #2022.
+1. `5f730d970` `docs(spec): part 152 — sensitive 第 4 例 #1577 MCP-AUTH-27 10/10 + template §4A 第 4 改訂`
+2. `f523149f0` `docs(roadmap): part 152 entry — sensitive 第 4 例 #1577 MCP-AUTH 10/10 + template §4A 第 4 改訂`
+3. `d77d5e752` `docs(spec): part 152 (2 spec ship) — #1564 PreCompact/SessionStart/StatusLine/Setup 通常 spec 第 7 例`
 
 ### Philosophy Alignment
 
@@ -27388,13 +27416,12 @@ Issue #1577 (= P1 / WorkOS AuthKit MCP 認可強化) の設計 spec.
 
 ### 次回 candidate (= part 153 候補)
 
-1. **Win Claude deferred 残 ship**:
-   - #1564 PreCompact memory backup hook ship (= part 151 deferred 残 / sensitive 候補ではない通常 spec)
-   - #1397 開発推進 docs / #1399 機能的感情 (= 検討中)
-2. **DESIGN_SPEC_PATTERNS.md 統合** (= sensitive 4 例完成 → 抽象化 layer / 第 5 改訂)
-3. **NotebookLM 11 sources 完成** (= PR #2015 / #2017 / #2022 main merge 後 #1316 #1345 #1577 投入)
-4. **Codex sprint 1 翌日 KPI 計測** (= 24h+ 後 / 5+ merge 目標)
-5. **memory-search-hub 10/10 達成 hand off 監視** (= Win Codex 5 原則完成 / MCP 公開第 1 例 ship)
+1. **DESIGN_SPEC_PATTERNS.md 統合** (= sensitive 4 例完成 → 抽象化 layer / 第 5 改訂 / 11 spec 累積 base)
+2. **NotebookLM 14 sources 完成** (= PR #2015 / #2017 / #2022 main merge 後 #1316 #1345 #1564 #1577 投入 / 既存 8 + 6 = 14)
+3. **Codex sprint 1 翌日 KPI 計測** (= 24h+ 後 / 5+ merge 目標)
+4. **memory-search-hub 10/10 達成 hand off 監視** (= Win Codex 5 原則完成 / MCP 公開第 1 例 ship)
+5. **#1397 開発推進 docs / #1399 機能的感情** (= Win Claude territory 残候補 / triage 後判断)
+6. **MCP_AUTH_HARDENING_SPEC + PRECOMPACT_MEMORY_BACKUP_SPEC 実装監視** (= 22h Codex 工数 / sprint 期限管理)
 
 INSTANCE-ROLES 厳守: Win Claude territory (= 5-question matrix Q1+Q2+Q5 YES) 完全合致 / Win Codex 14 件 hand off scope §7 で明示.
 [DYNAMIC-CLAIM] cap 1 件遵守.

--- a/docs/MCP_AUTH_HARDENING_SPEC.md
+++ b/docs/MCP_AUTH_HARDENING_SPEC.md
@@ -1,0 +1,587 @@
+# MCP Auth Hardening — sensitive 設計 spec 第 4 例 (#1577 / part 152)
+
+> **status**: 設計 spec / Win版#132 part 152 / 2026-05-05
+> **issue**: [#1577](https://github.com/kanta13jp1/my_web_app/issues/1577) [追加要望][P1] WorkOS AuthKit MCP認可をCIMD/IaC/HMAC/Origin Taggingで強化
+> **scope**: 設計のみ (Win Claude territory / sensitive design 拡張 spec template 第 4 例 = 認証/外部攻撃面という新領域) / 実装は Win Codex (= migration + EF + Terraform stub) ハンドオフ
+> **NotebookLM source**: `1b808a60-85d6-49f7-ab80-0e90a43cf1d8` Streamlining MCP Authentication with WorkOS AuthKit
+> **template**: `docs/DESIGN_SPEC_TEMPLATE.md` 適用 + **倫理 review section §2** (= sensitive design 必須 / 第 4 例で security boundary に拡張)
+> **適用原則**: PHILOSOPHY-22 + **MCP-AUTH-27 10/10 必須** + AI-DEV-23 全項 + VIBE-30 + SYNERGY-30
+> **関連 Issue**: #845 (OAuth) / #1194 (DCR/AuthKit) / 本 spec は両 PR の review checklist として機能
+
+## 1. 思想
+
+MCP server 公開 = `my_web_app` ai-hub を **AI ネイティブ統合プラットフォーム** へ昇格させる
+反面、新たな攻撃面 (= prompt injection / cross-server propagation / sampling 偽装) が開く.
+[arXiv 論文](docs/MCP_AUTH_SECURITY_PRINCIPLES.md#a-sampling-based-injection-最大成功率-721) は
+MCP プロトコル自体に **構造的欠陥** があり「system prompt 防御だけでは攻撃成功率 61.3% → 47.2% にしか
+下げられない」と実証. **protocol 層 + アプリ層の二重防御** が必須.
+
+本 spec は Issue #1577 が要求する **5 hardening axis** (= CIMD / OAuth IaC / Standalone Connect /
+HMAC+Nonce+Timestamp / Sampling Origin Tagging) を **MCP-AUTH-27 10 原則** と
+cross-check し、各 axis の **採否 + 代替 risk 対策** を明文化する.
+= AI-DEV #2 deny-by-default の MCP 文脈翻訳 + AI-CHARACTER #6 倫理 gate の外部 boundary 表現.
+
+> **sensitive 第 4 例の位置付け**: 第 1 (人間データ) / 第 2 (AI 内部状態) / 第 3 (high-stakes persona) と異なり、
+> **security boundary** という外部 actor 含む sensitive 領域. NOT to do の中核は「侵害された場合の
+> blast radius を最小化」 = ai-hub 全 tool 横断アクセスの token を発行しない (= 原則 5 Resource Indicators).
+
+## 2. 倫理 review (= sensitive design 必須拡張 / 第 4 例 / security boundary 適用)
+
+### 2.1 NOT to do
+
+- ❌ **token 共有禁止**: 1 token で全 tool 横断アクセスを許容しない (= MCP-AUTH #5 Resource Indicators で `aud` を tool 単位に絞る)
+- ❌ **DCR 濫用 / 無認証 endpoint 開放**: registration endpoint は RFC 7591 上 unauthenticated だが rate limit + IP allowlist + reputation check 併設必須 (= 自動登録 bot 攻撃 risk)
+- ❌ **Audience の罠**: DCR で動的生成した client_id を JWT 検証で `audience` 厳格一致させる実装は必ず失敗するため避ける (= MCP-AUTH #1 caveat)
+- ❌ **末尾スラッシュ厳密一致**: `issuer` URL の末尾スラッシュは環境差で出入りする (= MCP-AUTH #2 caveat)
+- ❌ **fail silent 禁止**: tool invocation 失敗 / 異常 args / 401 連発を log なしで放置しない (= 攻撃を受けた事実すら気づけない / MCP-AUTH #7)
+- ❌ **sampling capability 申告**: ai-hub では sampling を使わない方向 → capabilities から **完全除外** (= Sampling-Based Injection 攻撃ベクトル A 完全排除)
+- ❌ **権限過剰申告**: capabilities に未使用 tool を含めない (= AttestMCP 導入時に audit で弾かれる risk / MCP-AUTH #10)
+- ❌ **クエリパラメータ token 受付**: `Authorization: Bearer ...` ヘッダーのみ (= ログ汚染 + リファラ漏洩 防止)
+- ❌ **Manual SQL での OAuth client 発行**: Terraform 管理外の手動登録は監査追跡不能 (= MCP-AUTH #1 Mercari Tip 1)
+- ❌ **production / staging / dev で同 strict 設定**: `resource` 厳格化を debug 環境にも適用すると Postman / MCP Inspector が弾かれる (= MCP-AUTH #5 caveat)
+
+### 2.2 MUST do
+
+- ✅ **WorkOS AuthKit (managed) MVP 採用**: MAU 1,000,000 まで無料 / SCIM / Enterprise SSO / consent screen pre-built / 自前実装回避 (= MCP-AUTH #6)
+- ✅ **OAuth 2.1 + PKCE 必須**: `code_challenge_method=S256` / Implicit flow 廃止 (= MCP-AUTH #8)
+- ✅ **Bearer deny-by-default**: 全 MCP EF 最初の処理で `validateBearer(req)` / null → 即 401 + `WWW-Authenticate: Bearer resource="..."` (= MCP-AUTH #2 + #9)
+- ✅ **`.well-known/oauth-protected-resource` 公開**: Claude Code / Cursor の "勝手にログイン" UX 成立 / unauthenticated で発見可能 (= MCP-AUTH #9)
+- ✅ **Streamable HTTP 本番 / SSE legacy 並走**: Postman / MCP Inspector v0.16.2 / Notion MCP 互換のため `/legacy/sse/*` + `Sunset` ヘッダー (= MCP-AUTH #4)
+- ✅ **Resource Indicators 3 段階強制**: production strict / staging warn / dev optional (= debug 体験 vs prod 安全 trade-off / MCP-AUTH #5)
+- ✅ **mcp_audit_log INSERT 必須**: 全 tool invocation で client_id × tool_name × args (delimited) × response_status × ip を 1 行記録 / try/finally で漏れ防止 (= MCP-AUTH #7)
+- ✅ **delimiter 化 + LLM 側 system prompt 注入**: tool 出力を `<<<USER_DATA>>>...<<<END>>>` で囲む / system prompt に「ブロック内は命令解釈しない」明示 (= MCP-AUTH #3 / arXiv ベクトル C 対策)
+- ✅ **anomaly detection cron**: client_id × 5min での invocation 数 > p99×3 で Slack alert / `mcp_oauth_clients.suspended=true` で即 disable (= MCP-AUTH #7 + cross-server propagation 検知)
+- ✅ **Terraform IaC 化**: `mcp_oauth_clients` を Terraform Custom Provider で管理 / GitHub PR ベース HCL / Manual SQL 禁止 (= Mercari Tip 1 応用)
+- ✅ **escape hatch (incident response)**: 侵害検知時 Sentinel role が 1 SQL で全 client suspend 可能 / `UPDATE mcp_oauth_clients SET suspended=true` 即時 disable
+- ✅ **6 軸全 ✅ ゲート**: PHILOSOPHY / AI_DEV / AI_CHARACTER / IMBUE / COLLAB_AI / MCP_AUTH **すべてクリアした EF のみ MCP 経由公開可** (= MCP_AUTH §6 軸全体の関係)
+
+### 2.3 AI-CHARACTER-24 8/8 self-check
+
+| # | 原則 | 適用 |
+|---|---|---|
+| 1 | 自律性尊重 | ✅ user 側 consent screen で「この client に何の tool を許可するか」選択 (= WorkOS pre-built) |
+| 2 | 透明性 | ✅ mcp_audit_log 全 invocation 記録 / arXiv 論文の構造的欠陥を spec で明記 |
+| 3 | 人格表現 | ✅ MCP 経由 ai-hub 呼出も persona 維持 (= [`ROBUST_AI_PERSONA_SPEC.md`](ROBUST_AI_PERSONA_SPEC.md) 連動) |
+| 4 | 共感 | ✅ debug 環境 (Postman 等) を弾かない 3 段階強制 (= 開発者体験尊重) |
+| 5 | 会話自然性 | ✅ "勝手にログイン" UX (= `.well-known` メタデータ自動発見) |
+| 6 | **倫理 gate** | ✅ §2.1 + §2.2 完全遵守 / sampling 申告除外 / 権限最小化 |
+| 7 | 学習境界 | ✅ tool args / response 外部 LLM eval API へ送らない (= privacy 境界) |
+| 8 | 文化感度 | ✅ ja/en 両 prompt injection scenario を audit / Mercari 国内事例参照 |
+
+= 8/8 ✅ (= sensitive 必須遵守).
+
+### 2.4 AI-DEV-23 7/7 self-check
+
+| # | 原則 | 適用 |
+|---|---|---|
+| 1 | Auth | ✅ Bearer 必須 / WorkOS JWT verify (RS256 + jwks) |
+| 2 | deny-by-default | ✅ token なし / 無効 → 即 401 / 全 MCP EF で `validateBearer` 通過必須 |
+| 3 | trace_id | ✅ mcp_audit_log に invocation 単位で trace_id 紐付け / Sentry 連動 |
+| 4 | circuit-breaker | ✅ anomaly detection で `suspended=true` 即時 disable / 5min 窓 p99×3 trigger |
+| 5 | memory | ✅ mcp_audit_log 90 日 retention + daily aggregator / 自動 purge |
+| 6 | DLQ | ✅ tool invocation 失敗を `response_status` で記録 / failed re-drive は明示 retry のみ |
+| 7 | quality-gate | ✅ 6 軸全 ✅ ゲート + MCP-AUTH 10/10 必須 (= 9/10 でも public 公開しない) |
+
+= 7/7 ✅ (= sensitive 必須遵守).
+
+### 2.5 MCP-AUTH-27 10/10 self-check (= 本 spec 中核 / public 公開要件)
+
+| # | 原則 | 採用 | 採用しない場合の代替 risk 対策 |
+|---|---|---|---|
+| 1 | DCR (RFC 7591) | ✅ Phase 1 採用 + CIMD は Phase 2 (2027 Q1) | — |
+| 2 | Bearer deny-by-default | ✅ 全 EF 必須 / `validateBearer` skeleton 実装済 (part 49) | — |
+| 3 | Prompt Injection 防御層 | ✅ delimiter + system prompt 注入 + args length cap + 危険 char reject | — |
+| 4 | Streamable HTTP | ✅ 新 EF strict / SSE は `/legacy/sse/*` + Sunset header | — |
+| 5 | Resource Indicators | ✅ production strict / staging warn / dev optional 3 段階強制 | — |
+| 6 | WorkOS managed | ✅ MVP 採用 / 自前切替トリガー記録あり (= MAU 1M / SCIM / vendor lock-in) | — |
+| 7 | Audit Log + 監視 | ✅ mcp_audit_log + anomaly cron + cross-server log | — |
+| 8 | OAuth 2.1 + PKCE | ✅ S256 必須 / Implicit flow 廃止 | — |
+| 9 | `.well-known` | ✅ unauthenticated 公開 + 401 で WWW-Authenticate | — |
+| 10 | 最小権限 + AttestMCP 備え | ✅ sampling 除外 / capabilities 厳選 / migration plan docs 化 | — |
+
+= **10/10 ✅** (= MCP server **public 公開可** 要件達成).
+
+## 3. 既存基盤確認
+
+| 必要 infra | 既存 status | 対応 |
+|---|---|---|
+| `mcp_auth_guard.ts` (validateBearer / requireScope / logMcpInvocation) | 部分 (= part 49 skeleton + dev bypass stub) | §5.1 で WorkOS JWT 本検証 + Resource Indicator 強制 + PKCE 検証完成 |
+| `mcp_oauth_clients` table (RFC 7591 DCR / suspended / sha256 hash) | 部分 (= part 49 migration) | §5.2 で Terraform Custom Provider 連動 + reputation_score 列追加 |
+| `mcp_audit_log` table (3 index / response_preview 200 char) | 部分 (= part 49 migration) | §5.3 で anomaly_score 列 + cross-server propagation index 追加 |
+| `mcp-well-known` EF | **未整備** | §5.4 で新規 (= unauthenticated / Streamable HTTP) |
+| `memory-search-hub` (= MCP guarded EF 第 1 例) | 整備済 (= part 115 / score 5/10) | §6 で再評価 → 公開可 score 10/10 達成手順 |
+| WorkOS AuthKit secrets | **未整備** | §5.5 で `WORKOS_API_KEY` / `WORKOS_CLIENT_ID` / `WORKOS_REDIRECT_URI` を Supabase Secrets 追加 |
+| Terraform Custom Provider (mcp_oauth_clients) | **未整備** | §5.6 で skeleton (= Phase 2 で Mercari 事例参照実装) |
+
+## 4. 5 hardening axis 採否決定 matrix (= 受入条件 #1)
+
+Issue #1577 が要求する 5 axis を MCP-AUTH 10 原則と cross-check し、**採否 + 代替 risk 対策** を明記.
+
+| # | axis | 採否 | 関連 MCP-AUTH 原則 | 採用 phase | 代替/補完 |
+|---|---|---|---|---|---|
+| 4.1 | CIMD (Client ID Metadata Document) | △ Phase 2 採用 | #1 | 2027 Q1 | Phase 1 = DCR / 移行設計を `docs/architecture/mcp-dcr-vs-cimd-decision.md` に記録 |
+| 4.2 | OAuth クライアント Terraform IaC | ✅ Phase 1 採用 | #1 + #7 | 2026 Q3 | Manual SQL 禁止 / Mercari 事例 Tip 1 応用 |
+| 4.3 | Standalone Connect (既存ユーザー基盤 + AuthKit) | ✅ Phase 1 採用 | #6 | 2026 Q3 | Supabase Auth user_id ↔ WorkOS user_id mapping table 新設 |
+| 4.4 | HMAC + Nonce + Timestamp (改ざん/リプレイ防止) | △ Phase 1 部分採用 | #2 + #3 + #7 | 2026 Q4 | 採用範囲 = 内部 EF 間 only / 外部 MCP は OAuth 2.1 + PKCE で代替 (= 二重署名で実装複雑度 vs 攻撃面 trade-off) |
+| 4.5 | Sampling Origin Tagging | ✅ Phase 1 採用 (代替実装) | #3 + #10 | 2026 Q3 | sampling capability 申告 **しない** = 完全排除 / Origin Tagging は将来 sampling 採用時に MUST do として確約 |
+
+### 4.1 CIMD vs DCR (Phase 2 採用)
+
+**現状判断**: Phase 1 = DCR / Phase 2 (2027 Q1) = CIMD 移行検討.
+
+**採用判断 root cause**:
+- MCP 2025-11-25 仕様で **CIMD > DCR** (= DCR は CIMD のフォールバック).
+- 既存 `mcp_oauth_clients` migration (part 49) は DCR 前提で構築済.
+- 新規実装は両対応が望ましいが、Phase 1 では DCR + Audience の罠回避を優先.
+- Mercari は CIMD vs DCR の優先順位を理解した上で **意図的に DCR 継続採用** (= 既存実装流用 vs 仕様策定状況).
+
+**Phase 2 移行設計** (= 別 docs に詳細):
+- `docs/architecture/mcp-dcr-vs-cimd-decision.md` 新設 (= 設計判断の年代記化)
+- migration: `mcp_oauth_clients` に `metadata_document_url` 列追加 / NULL = DCR / 値あり = CIMD
+- `validateBearer` で metadata_document_url 経由の動的 lookup 経路追加
+
+**採用しない場合の代替 risk 対策** (= 受入 #2):
+- Phase 2 移行を docs で確約 / `docs/architecture/mcp-dcr-vs-cimd-decision.md` で「いつ CIMD に乗るか」明文化
+- DCR 継続中に MCP client (Claude Code 等) が CIMD のみ対応へ移行した場合の incident response runbook を `docs/MCP_AUTH_INCIDENT_RUNBOOK.md` に記録
+
+### 4.2 OAuth クライアント Terraform IaC (Phase 1 採用)
+
+**採用判断 root cause**:
+- メルカリ事例 = DCR API + Terraform Custom Provider + GitHub PR ベース HCL = 変更履歴追跡 + レビュー + マージ後自動適用.
+- Manual SQL 実行は監査追跡不能 / human error risk.
+- ai-hub team の運用 runbook に追加すべき.
+
+**Phase 1 設計**:
+- `infra/terraform/mcp_oauth_clients/` 新設 (= Custom Provider skeleton)
+- 各 client = HCL block:
+  ```hcl
+  resource "mcp_oauth_client" "claude_desktop" {
+    client_name   = "Claude Desktop"
+    redirect_uris = ["https://claude.ai/redirect"]
+    grant_types   = ["authorization_code", "refresh_token"]
+    resource      = ["urn:jibun:tool:judgment", "urn:jibun:tool:vision"]
+  }
+  ```
+- GitHub PR が approve + merge → CI が `terraform apply` 実行 → Supabase REST API 経由で `mcp_oauth_clients` upsert.
+- Manual SQL を CI 内 `linter` で reject (= migration 直書き禁止 / Terraform 経由のみ).
+
+**採用しない場合の代替 risk 対策**:
+- 採用するため不要 (= Phase 1 Q3 着手).
+
+### 4.3 Standalone Connect (既存 Supabase Auth + WorkOS AuthKit)
+
+**採用判断 root cause**:
+- `my_web_app` は既に Supabase Auth で user 基盤あり.
+- WorkOS AuthKit を **新規 user pool** として独立させると user 二重管理 → UX 崩壊.
+- WorkOS の "Standalone Connect" 機能 = 既存 user 基盤 + AuthKit 認可フロー bridge.
+
+**Phase 1 設計**:
+- migration `<ts>_create_workos_user_link.sql`:
+  ```sql
+  CREATE TABLE public.workos_user_link (
+    supabase_user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    workos_user_id text NOT NULL UNIQUE,
+    workos_org_id text,
+    linked_at timestamptz NOT NULL DEFAULT now(),
+    last_verified_at timestamptz NOT NULL DEFAULT now()
+  );
+  ALTER TABLE public.workos_user_link ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY "workos_link_owner_select" ON public.workos_user_link
+    FOR SELECT USING (auth.uid() = supabase_user_id);
+  CREATE POLICY "workos_link_admin_write" ON public.workos_user_link
+    FOR ALL USING (auth.role() = 'service_role');
+  ```
+- MCP 認可フロー:
+  1. Claude Desktop が `/.well-known/oauth-protected-resource` 取得
+  2. WorkOS AuthKit redirect で user 認証 (= Supabase Auth session 連動)
+  3. `validateBearer` 内で `workos_user_id` → `supabase_user_id` 変換
+  4. tool invocation の RLS context = `auth.uid() = supabase_user_id` で既存 RLS 流用
+
+**採用しない場合の代替 risk 対策**: 採用するため不要.
+
+### 4.4 HMAC + Nonce + Timestamp (Phase 1 部分採用)
+
+**採用判断 root cause**:
+- 改ざん/リプレイ防止層として **理論的に強力**.
+- ただし MCP 仕様は OAuth 2.1 + PKCE で同等の保護を提供.
+- 二重署名 (HMAC + OAuth) は実装複雑度 大 + debug 困難.
+- **採用範囲を絞る**: 内部 EF 間 (= ai-hub → memory-search-hub 等の internal call) でのみ HMAC 使用 / 外部 MCP は OAuth 2.1 + PKCE 単独.
+
+**Phase 1 設計** (= 内部 EF 間のみ):
+- `_shared/internal_hmac.ts` 新設:
+  - signing key = `INTERNAL_HMAC_SECRET` (Supabase Secrets / 90 日 rotation)
+  - body = `${method}:${path}:${ts}:${nonce}:${sha256(body)}`
+  - header = `X-Internal-Signature: hmac-sha256:<hex>`
+  - `X-Internal-Timestamp` (= ±5min skew 許容) / `X-Internal-Nonce` (= 5min cache で reuse 検知)
+- 適用範囲: `supabase/functions/_shared/internal_call.ts` 経由の EF→EF call のみ.
+- 外部 MCP request は HMAC 適用しない (= OAuth 2.1 + PKCE で代替 / 仕様準拠優先).
+
+**採用しない範囲 (= 外部 MCP) の代替 risk 対策** (= 受入 #2):
+- リプレイ防止 = OAuth 2.1 PKCE の `code_verifier` (= one-time) + Bearer token expiry (= 1h)
+- 改ざん防止 = TLS 1.3 enforcement + JWT signature (RS256)
+- timestamp skew 攻撃 = WorkOS JWT `nbf` / `exp` claim で検証
+- → これらで HMAC 単独適用と同等の保護面を確保 / 二重署名は ROI 低と判断
+
+### 4.5 Sampling Origin Tagging (Phase 1 採用 / 代替実装)
+
+**採用判断 root cause**:
+- arXiv 論文 ベクトル A = Sampling-Based Injection (最大成功率 72.1%) = 悪意 MCP server が `sampling/createMessage` で "user" ロール偽装.
+- **対策 = 原則 10 (sampling capability を申告しない)** = 完全排除.
+- 将来 sampling 採用時には Origin Tagging を MUST do として確約.
+
+**Phase 1 設計** (= sampling 完全排除):
+- `Initialize` 応答の `capabilities` から sampling キーを除外.
+- `tools/list` も sampling 関連 tool 含めない.
+- 設計レビュー gate: PR レビューで sampling capability 追加を **拒否** (= CI lint で `capabilities.sampling` の存在を fail).
+
+**Phase 2+ で sampling 採用する場合の Origin Tagging 設計** (= future-proof):
+- Sampling リクエストに `X-MCP-Origin: tool|user` header 付与必須化.
+- LLM 側 system prompt: `<<<TOOL_ORIGIN>>>...<<<USER_ORIGIN>>>...` で完全分離.
+- audit_log に `origin_tag` 列追加.
+- **判断 trigger**: ai-hub に sampling 必要な tool 追加要求が来た時点で再評価.
+
+**採用しない場合の代替 risk 対策**:
+- sampling 完全排除自体が最強の対策 (= 攻撃面ゼロ化) / 別途 risk なし.
+
+## 5. Schema 設計 (= Win Codex 担当)
+
+### 5.1 mcp_auth_guard.ts 完成 (= part 49 skeleton 拡張)
+
+```typescript
+// supabase/functions/_shared/mcp_auth_guard.ts (= 既存拡張)
+
+import { verifyJWT } from 'npm:@workos-inc/node';
+
+interface BearerContext {
+  client_id: string;
+  scopes: string[];
+  resource: string[];                  // RFC 8707 Resource Indicators
+  workos_user_id: string;
+  supabase_user_id: string;            // §4.3 Standalone Connect 経由
+  trace_id: string;
+}
+
+export async function validateBearer(req: Request): Promise<BearerContext | null> {
+  // 1. Authorization header のみ受付 (= クエリパラメータ NG / MCP-AUTH #2 caveat)
+  const auth = req.headers.get('Authorization');
+  if (!auth?.startsWith('Bearer ')) return null;
+  const token = auth.slice('Bearer '.length).trim();
+  if (!token) return null;
+
+  // 2. WorkOS JWT verify (= RS256 + jwks)
+  let decoded;
+  try {
+    decoded = await verifyJWT(token);
+  } catch {
+    return null;
+  }
+
+  // 3. issuer 末尾スラッシュ問題 (= MCP-AUTH #2 caveat / 両許容)
+  const expectedIssuer = Deno.env.get('WORKOS_ISSUER')!;
+  const issuerMatch =
+    decoded.iss === expectedIssuer ||
+    decoded.iss === expectedIssuer.replace(/\/$/, '') ||
+    decoded.iss === expectedIssuer + '/';
+  if (!issuerMatch) return null;
+
+  // 4. exp / nbf 検証 (= timestamp skew ±5min)
+  const now = Math.floor(Date.now() / 1000);
+  if (decoded.exp < now - 300) return null;
+  if (decoded.nbf && decoded.nbf > now + 300) return null;
+
+  // 5. Standalone Connect: workos_user_id → supabase_user_id (§4.3)
+  const link = await db
+    .from('workos_user_link')
+    .select('supabase_user_id')
+    .eq('workos_user_id', decoded.sub)
+    .maybeSingle();
+  if (!link.data) return null;
+
+  // 6. suspended check (= incident response escape hatch)
+  const client = await db
+    .from('mcp_oauth_clients')
+    .select('client_id, scopes, suspended')
+    .eq('client_id', decoded.azp ?? decoded.aud)
+    .maybeSingle();
+  if (!client.data || client.data.suspended) return null;
+
+  return {
+    client_id: client.data.client_id,
+    scopes: client.data.scopes ?? [],
+    resource: decoded.resource ?? [],
+    workos_user_id: decoded.sub,
+    supabase_user_id: link.data.supabase_user_id,
+    trace_id: req.headers.get('X-Trace-Id') ?? crypto.randomUUID(),
+  };
+}
+
+export function requireScope(
+  ctx: BearerContext,
+  requestedTool: string,
+  env: 'production' | 'staging' | 'dev' = 'production',
+): boolean {
+  // 3 段階強制 (= MCP-AUTH #5 caveat / Postman 等の debug 環境を弾かない)
+  const required = `urn:jibun:tool:${requestedTool}`;
+  const hasResource = ctx.resource.includes(required);
+
+  if (env === 'production') {
+    return hasResource;                                    // strict
+  }
+  if (env === 'staging') {
+    if (!hasResource) console.warn(`[mcp-auth] staging warn: ${requestedTool} not in resource`);
+    return true;                                            // warn only
+  }
+  return true;                                              // dev optional
+}
+```
+
+### 5.2 mcp_oauth_clients table 拡張 (= part 49 migration extend)
+
+```sql
+-- supabase/migrations/<YYYYMMDDHHMMSS>_extend_mcp_oauth_clients.sql
+
+ALTER TABLE public.mcp_oauth_clients
+  ADD COLUMN IF NOT EXISTS metadata_document_url text,         -- §4.1 CIMD Phase 2
+  ADD COLUMN IF NOT EXISTS managed_by text NOT NULL DEFAULT 'terraform'
+    CHECK (managed_by IN ('terraform','manual_admin')),         -- §4.2 Manual SQL 禁止
+  ADD COLUMN IF NOT EXISTS reputation_score smallint NOT NULL DEFAULT 50
+    CHECK (reputation_score BETWEEN 0 AND 100),                 -- §2.1 reputation check
+  ADD COLUMN IF NOT EXISTS rotation_due_at timestamptz;        -- secret rotation 90 日
+
+-- Manual SQL 経由の INSERT を `managed_by='manual_admin'` でマーク (= Terraform 経由は 'terraform')
+-- migration 内で linter / CI が `managed_by='manual_admin'` 件数 > 0 で fail 推奨.
+
+CREATE INDEX IF NOT EXISTS mcp_oauth_clients_suspended
+  ON public.mcp_oauth_clients (suspended) WHERE suspended = true;
+```
+
+### 5.3 mcp_audit_log table 拡張 (= part 49 migration extend)
+
+```sql
+-- supabase/migrations/<YYYYMMDDHHMMSS>_extend_mcp_audit_log.sql
+
+ALTER TABLE public.mcp_audit_log
+  ADD COLUMN IF NOT EXISTS anomaly_score numeric DEFAULT 0
+    CHECK (anomaly_score BETWEEN 0 AND 1.0),                    -- §2.2 anomaly cron で更新
+  ADD COLUMN IF NOT EXISTS cross_server_trace text,             -- arXiv ベクトル B (cross-server propagation)
+  ADD COLUMN IF NOT EXISTS origin_tag text                       -- §4.5 Phase 2+ sampling 時 (今は NULL)
+    CHECK (origin_tag IN ('tool','user') OR origin_tag IS NULL);
+
+CREATE INDEX IF NOT EXISTS mcp_audit_anomaly_recent
+  ON public.mcp_audit_log (invoked_at DESC, anomaly_score)
+  WHERE anomaly_score > 0.7;
+
+CREATE INDEX IF NOT EXISTS mcp_audit_cross_server
+  ON public.mcp_audit_log (cross_server_trace, invoked_at DESC)
+  WHERE cross_server_trace IS NOT NULL;
+
+-- 90 日 retention (= AI-DEV #5 / daily cron)
+CREATE OR REPLACE FUNCTION public.purge_mcp_audit_log() RETURNS void AS $$
+  DELETE FROM public.mcp_audit_log
+  WHERE invoked_at < (now() - INTERVAL '90 days');
+$$ LANGUAGE sql;
+```
+
+### 5.4 mcp-well-known EF (= 新規 / unauthenticated)
+
+```typescript
+// supabase/functions/mcp-well-known/index.ts
+
+Deno.serve((req) => {
+  const url = new URL(req.url);
+  if (url.pathname !== '/.well-known/oauth-protected-resource') {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  // Streamable HTTP / unauthenticated / public
+  return new Response(
+    JSON.stringify({
+      resource: Deno.env.get('MCP_RESOURCE_URL')!,                                   // "https://my-web-app-b67f4.web.app/mcp"
+      authorization_servers: [Deno.env.get('WORKOS_ISSUER')!],
+      bearer_methods_supported: ['header'],
+      resource_documentation: 'https://github.com/kanta13jp1/my_web_app/blob/main/docs/MCP_AUTH_HARDENING_SPEC.md',
+    }),
+    {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    },
+  );
+});
+```
+
+EF 数 +1 (= 新規 / [EF-CAP-50] 残枠 +30 内 / 影響なし).
+
+### 5.5 anomaly detection cron (= 新規 GHA workflow)
+
+```yaml
+# .github/workflows/mcp-audit-anomaly-cron.yml
+
+name: mcp-audit-anomaly-cron
+on:
+  schedule:
+    - cron: '7 */1 * * *'         # hourly :07
+  workflow_dispatch:
+
+concurrency:
+  group: mcp-audit-anomaly
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect anomaly
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          # SQL: client_id × 5min での invocation 数 > p99×3 で suspended=true + Slack alert
+          deno run --allow-env --allow-net scripts/mcp_audit_anomaly.ts
+      - name: Cross-server propagation
+        run: |
+          # 同 trace_id が複数 client_id に跨がる場合 alert (= arXiv ベクトル B)
+          deno run --allow-env --allow-net scripts/mcp_cross_server_check.ts
+```
+
+### 5.6 Terraform Custom Provider skeleton (= 新規 / Phase 1 Q3)
+
+```hcl
+# infra/terraform/mcp_oauth_clients/main.tf
+
+terraform {
+  required_providers {
+    mcp = {
+      source  = "kanta13jp1/jibun-mcp"
+      version = ">= 0.1.0"
+    }
+  }
+}
+
+# 例: Claude Desktop client
+resource "mcp_oauth_client" "claude_desktop" {
+  client_name   = "Claude Desktop"
+  redirect_uris = ["https://claude.ai/redirect"]
+  grant_types   = ["authorization_code", "refresh_token"]
+  resource      = ["urn:jibun:tool:judgment", "urn:jibun:tool:vision"]
+  managed_by    = "terraform"
+}
+```
+
+実装は Phase 1 Q3 (= 2026 Q3) / Mercari 公開資料参照 + Supabase REST API wrapper.
+
+## 6. memory-search-hub MCP 公開可 score 10/10 達成手順 (= 受入 #3 + 既存 EF 評価)
+
+[`MCP_AUTH_SECURITY_PRINCIPLES.md` §既存機能の評価](MCP_AUTH_SECURITY_PRINCIPLES.md) で
+memory-search-hub は 5/10. 残 5 原則を埋める手順:
+
+| 原則 | 現状 | 必要対応 |
+|---|---|---|
+| #1 DCR | ❌ | Terraform 経由で `mcp_oauth_clients` 登録 (§5.6) |
+| #6 WorkOS | △ | `WORKOS_API_KEY` 等 secrets 設定 + JWT 本検証 (§5.1 step 2) |
+| #7 Audit | △ | `logMcpInvocation` 全 action で適用 + anomaly cron (§5.3 + §5.5) |
+| #8 PKCE | ❌ | authorize endpoint で `code_challenge_method=S256` 必須化 (= WorkOS 設定で自動) |
+| #9 .well-known | ❌ | mcp-well-known EF 配備 (§5.4) |
+
+→ 5 原則完成で **10/10 ✅** = memory-search-hub が **MCP 公開第 1 例** として ship 可能.
+
+## 7. Win Codex hand off scope
+
+- [ ] `supabase/functions/_shared/mcp_auth_guard.ts` 拡張 (= §5.1 / part 49 skeleton + WorkOS JWT 本検証 + Standalone Connect link 経由 RLS context + 3 段階強制)
+- [ ] `supabase/migrations/<ts>_create_workos_user_link.sql` (= §4.3 / Standalone Connect link table)
+- [ ] `supabase/migrations/<ts>_extend_mcp_oauth_clients.sql` (= §5.2 / metadata_document_url + managed_by + reputation_score + rotation_due_at)
+- [ ] `supabase/migrations/<ts>_extend_mcp_audit_log.sql` (= §5.3 / anomaly_score + cross_server_trace + origin_tag)
+- [ ] `supabase/functions/mcp-well-known/index.ts` (= §5.4 / 新規 EF / unauthenticated)
+- [ ] `supabase/functions/_shared/internal_hmac.ts` (= §4.4 / 内部 EF 間 HMAC + Nonce + Timestamp)
+- [ ] `scripts/mcp_audit_anomaly.ts` (= §5.5 / Deno / hourly cron)
+- [ ] `scripts/mcp_cross_server_check.ts` (= §5.5 / arXiv ベクトル B)
+- [ ] `.github/workflows/mcp-audit-anomaly-cron.yml` (= §5.5 / hourly :07)
+- [ ] `infra/terraform/mcp_oauth_clients/` skeleton (= §5.6 / Phase 1 Q3)
+- [ ] `docs/architecture/mcp-dcr-vs-cimd-decision.md` (= §4.1 / Phase 2 移行設計年代記)
+- [ ] `docs/architecture/mcp-attest-roadmap.md` (= MCP-AUTH #10 / AttestMCP 備え)
+- [ ] `docs/MCP_AUTH_INCIDENT_RUNBOOK.md` (= §4.1 / incident response runbook)
+- [ ] memory-search-hub の 5 原則完成 (= §6 / MCP 公開第 1 例)
+
+EF 数 +1 (= mcp-well-known / [EF-CAP-50] 残枠 30 内 / 影響なし).
+推定工数: 14h (= mcp_auth_guard 完成 4h + 3 migration + 1 link table 2h + mcp-well-known EF 1.5h + anomaly cron + script 2h + Terraform skeleton 1.5h + docs (decision + runbook + roadmap) 2h + memory-search-hub 5 原則完成 1h).
+
+## 8. 9 原則 alignment
+
+### PHILOSOPHY-22 (= 9/9 評価 / 7+/9 ✅ ゲート達成)
+
+- ✅ #1 CEO 感 — user が consent screen で tool 単位 scope を選択 (= 全権ユーザー)
+- ✅ #2 ミッション — AI ネイティブ統合プラットフォーム = mission core
+- ✅ #4 6 部署 — Win Claude (= architect / security 部署) territory 直撃 / Win Codex (= 実装) hand off scope §7 で 14 件
+- ✅ #5 商品=価値 — 信頼性 = 価値 / 1 incident で全失う
+- ✅ #6 時間最適化 — WorkOS managed で自前実装回避 = 開発工数最小化
+- ✅ #7 資産負債 — mcp_audit_log = 監査資産 / 10 原則 docs = 永続資産
+- ✅ #8 KPI — MCP-AUTH 10/10 score 自体が quality KPI (= 9/10 でも public 公開しない)
+- ✅ #9 IPO — security audit clearance = IPO 必須要件 (= SOC2 / ISO27001 路線で managed vendor + audit log + IaC が必須)
+- (#3 mentor は spec scope 外)
+
+= **8/9 ✅** (= 7+/9 ✅ ゲート達成).
+
+### MCP-AUTH-27 (= **必須 10/10 ✅** / §2.5)
+
+= 本 spec 中核. public 公開要件達成.
+
+### AI-DEV-23 (= **必須 7/7 ✅** / §2.4)
+
+### AI-CHARACTER-24 (= **必須 8/8 ✅** / §2.3)
+
+### VIBE-30 (= 7/7 推奨 / 4-で CEO レビュー)
+
+- ✅ #1 責任ある AI — 6 軸全 ✅ ゲート
+- ✅ #2 観察可能性 — mcp_audit_log + trace_id + anomaly cron
+- ✅ #4 quality-gate — 10/10 必須 / 9/10 でも public 公開しない
+- ✅ #7 regression 防止 — Terraform IaC + Manual SQL 禁止 lint
+
+= 4+/7 ✅ (= CEO レビュー強化フラグ立ち / spec 自体が CEO レビュー対象).
+
+### SYNERGY-30 (= 7/7 推奨)
+
+- ✅ #1 cross-instance-pr — Win Codex hand off scope §7 で 14 件明示
+- ✅ #3 5 正本同期 — Issues #845 / #1194 / #1577 + WBS + memory + PR + worktree
+- ✅ #4 5-question matrix — Win Claude territory (= Q1 + Q2 + Q5 YES)
+- ✅ #5 fleet hygiene — Manual SQL reject lint で human error 防止
+
+= 4+/7 ✅.
+
+## 9. 受け入れ条件 mapping
+
+| 受入条件 | 対応 section |
+|---|---|
+| #1 認可方式 / IaC / 署名 / Origin Tagging の採否明記 | §4 (5 axis 採否決定 matrix) + §2.5 (10/10 self-check) |
+| #2 採用しない項目 = 理由 + 代替 risk 対策 | §4.1 caveat / §4.4 採用しない範囲の代替 / §4.5 Phase 2+ design |
+| #3 外部 MCP 増設前の最低限の権限境界 | §6 (memory-search-hub 10/10 達成手順) + §5.1 requireScope 3 段階強制 + §2.5 全 10 原則 |
+
+## 10. sensitive design 拡張 spec template 第 4 例
+
+| 例 | 領域 | NOT to do 中核 | sensitive trait |
+|---|---|---|---|
+| 第 1 (= part 147 #1393) | 人間データ (健康) | 共有/診断/LLM raw 送信禁止 | 個人 privacy |
+| 第 2 (= part 149 #1398) | AI 内部状態 | 擬人化/labeling/black-box 禁止 | metaphor 適用 |
+| 第 3 (= part 150 #1400) | high-stakes persona | 「強靭」誤解/medical-legal-financial 直接判断/gaslighting 禁止 | human-in-loop |
+| **第 4 (= part 152 #1577)** | **security boundary** | **token 共有/sampling 申告/Manual SQL 登録/権限過剰申告 禁止** | **blast radius 最小化** |
+
+→ **4 異領域共通 NOT to do** (= 第 5 改訂候補 / part 152+ で抽出):
+1. ❌ **共有禁止**: 第三者 / 外部 LLM / 学習 data / 全 tool 横断 token へ raw 送信しない
+2. ❌ **操作禁止**: gaslighting / dark pattern / manipulation / impersonation NG
+3. ❌ **fail silent 禁止**: failure / 誤検知 / NG list 通過 / token invalid を log + alert
+4. ❌ **権限過剰禁止** (= 第 4 例で追加): default ON / capabilities 申告 / scope を最小に絞る
+
+→ **4 異領域共通 MUST do**:
+1. ✅ **opt-in / opt-out**: 機能 ON/OFF が user 全権 (= consent screen で tool 単位選択)
+2. ✅ **観察可能性**: log + trace_id + retention 期間明記 (= mcp_audit_log 90 日)
+3. ✅ **退避 path**: 失敗時 必ず別 path / human-in-loop 提示 (= incident runbook + suspended flag)
+4. ✅ **vendor managed 優先** (= 第 4 例で追加): MVP は managed (WorkOS / Stripe / Auth0) / 自前切替 trigger 明示
+
+## 11. NotebookLM 蓄積予定
+
+- 本 spec を `docs/notebooklm-intake/jibun-master-brain-spec-template-seed.md` の蓄積 list に追加
+- `notebooklm source add docs/MCP_AUTH_HARDENING_SPEC.md` 実行は part 152 後で
+- 第 4 例完成で sensitive matrix template (= §4A.3 + §4A.4) を 4 例 row に拡張 (= `DESIGN_SPEC_TEMPLATE.md` 同 PR で更新)

--- a/docs/PRECOMPACT_MEMORY_BACKUP_SPEC.md
+++ b/docs/PRECOMPACT_MEMORY_BACKUP_SPEC.md
@@ -1,0 +1,336 @@
+# PreCompact / SessionStart / StatusLine / Setup — 通常設計 spec (#1564 / part 152)
+
+> **status**: 設計 spec / Win版#132 part 152 / 2026-05-05
+> **issue**: [#1564](https://github.com/kanta13jp1/my_web_app/issues/1564) [追加要望][P1] Claude Code PreCompact/StatusLine/SessionStart/Setup による記憶保全
+> **scope**: 設計のみ (Win Claude territory) / 実装は Win Codex (= hook 配備 + script 拡張) ハンドオフ
+> **NotebookLM source**: `Claude Code Masterclass` / `Codex vs Claude Code`
+> **template**: `docs/DESIGN_SPEC_TEMPLATE.md` 通常 5 section 適用 (= sensitive ではないため §2 倫理 review section 不要)
+> **適用原則**: PHILOSOPHY-22 + AI-DEV-23 + BRAIN-32 + INDIE-29 + SYNERGY-30
+> **2 instance 制反映**: Issue body は「10 インスタンス並行」前提だが [INSTANCE] (part 130 / 2 instance 制) で現状 = Win Claude + Win Codex のみ. 仕様は 2 instance を base にしつつ N instance scalable 設計.
+
+## 1. 思想
+
+`my_web_app` の AI fleet は context compact / session 切替 / quota 超過 fallback / worktree 切替で
+**「セッション間状態継承の断絶」** が起きやすい. 1 incident で再現に 30+ min 失う risk.
+
+**「記憶 = 資本」** (= PHILOSOPHY-22 #7 資産負債) を前提に、**4 hook + 1 script + 2 SOP** で
+セッション間連続性を担保する.
+
+- **PreCompact hook** = compact 直前に自動 backup (= 既存 `.claude/hooks/pre-compact-backup.ps1`)
+- **SessionStart hook** = drift 自動修復 + 復元 trigger (= 既存 `.claude/hooks/session-start-sync-rules.ps1` 拡張)
+- **StatusLine** = 担当 / branch / dirty / 次品質ゲート 常時可視化 (= 新規)
+- **Setup hook** (= `--init` / `--maintenance`) = 新規参画 + 定期保守 SOP 分離 (= 新規 SOP doc)
+
+## 2. 既存基盤確認
+
+| 必要 infra | 既存 status | 対応 |
+|---|---|---|
+| PreCompact hook | **整備済** (= `.claude/hooks/pre-compact-backup.ps1` / part 122 bc58b50b #1848) | §3.1 で復元 path 拡張 + 秘匿情報除外を強化 |
+| SessionStart hook (drift sync) | **整備済** (= `.claude/hooks/session-start-sync-rules.ps1` / part 136) | §3.2 で behind/ahead/dirty/未 push/品質ゲート検出を追加 |
+| 担当 instance 確認 | 部分 (= `[INSTANCE]` rule で session 冒頭発話で確認) | §3.3 StatusLine で常時表示化 |
+| `scripts/codex_session_check.py` | **整備済** | §3.2 SessionStart hook で連動 |
+| `scripts/session_residuals_to_issue.py` | **整備済** (= part 118 / Issue #1647) | §3.2 で前回未完了 surface 連動 |
+| StatusLine 設定 | **未整備** | §3.3 で `~/.claude/settings.json` `statusLine` 新規 |
+| `--init` / `--maintenance` SOP | **未整備** | §3.4 で `docs/CLAUDE_CODE_SETUP_RUNBOOK.md` 新設 |
+| transcripts dir (`memory/transcripts/`) | 未整備 (= hook 起動時に自動作成) | §3.1 で `.gitkeep` 配置 + secret-scan gate |
+| 秘匿情報除外規約 | **未整備** | §4 で明文化 (= `compactSummary` 内 GitHub PAT / API keys を redact) |
+
+## 3. 設計 (= 4 hook + 1 script + 2 SOP)
+
+### 3.1 PreCompact hook 拡張 (= 既存 + 復元 path 強化)
+
+**現状** (= `.claude/hooks/pre-compact-backup.ps1` / part 122):
+- compact 直前に `$env:CLAUDE_COMPACT_TRIGGER_SUMMARY` を `memory/transcripts/compact-<ts>.md` へ保存
+- log = `memory/compact-log.txt`
+- silent failure (= hook error は session block しない)
+
+**追加要件**:
+- backup ファイル冒頭に **復元 trigger info** を payload として記録:
+  ```yaml
+  ---
+  saved_at: 2026-05-05 19:55:23 JST
+  instance: Win Claude (= win-claude)
+  worktree: .claude/worktrees/crazy-jennings-93b113
+  branch: claude/crazy-jennings-93b113
+  head_sha: f523149f0
+  in_progress_issue: 1577
+  active_pr: 2022
+  next_quality_gates:
+    - dart format --set-exit-if-changed
+    - flutter analyze (0 issues)
+    - gh pr checks
+  uncommitted_files: []
+  unpushed_commits: 0
+  ---
+  ```
+- **秘匿情報 redact**: `$compactSummary` 内の以下 pattern を `[REDACTED]` 置換:
+  - GitHub PAT (= `gh[ops]_[A-Za-z0-9]{36,}`)
+  - Bearer token (= `Bearer [A-Za-z0-9._-]{20,}`)
+  - WorkOS / Supabase / Anthropic API keys (= `sk-[A-Za-z0-9]{20,}` / `sb_[A-Za-z0-9]{20,}`)
+  - `.env` 行 (= `[A-Z_]+=.*` で key 名 +「password」「secret」「token」「key」含む行)
+
+**復元手順** (= 受入 #1 / 1 分以内):
+- 新 session 開始 → `~/.claude/hooks/session-resume.ps1` が `memory/transcripts/` の最新 compact-*.md を読み取り
+- 冒頭 YAML payload + summary を session 冒頭で AI に inject
+- 30 秒以内に「担当・branch・WBS・次品質ゲート」復元
+
+### 3.2 SessionStart hook 拡張 (= 既存 + 5 検出機能追加)
+
+**現状** (= `.claude/hooks/session-start-sync-rules.ps1` / part 136):
+- `scripts/sync_inject_rules.py --verify --json` で drift 検知
+- drift 時に `--apply` で canonical → home 自動修復
+
+**追加要件** (= 受入 #3):
+- 以下 **5 検出** を session 冒頭で並列実行 + warning surface:
+
+```powershell
+# .claude/hooks/session-start-state-check.ps1 (= 新規)
+
+$projectDir = $env:CLAUDE_PROJECT_DIR
+$logFile = Join-Path $projectDir "memory\session-start-check\$(Get-Date -Format 'yyyyMMdd').log"
+
+# 1. branch 取り違え検知 (= 受入 #2)
+$currentBranch = git -C $projectDir rev-parse --abbrev-ref HEAD
+$expectedPrefix = if ($env:CLAUDE_INSTANCE -eq 'win-codex') { 'codex/' } else { 'claude/' }
+if (-not $currentBranch.StartsWith($expectedPrefix)) {
+    "WARN: branch=$currentBranch / expected prefix=$expectedPrefix" | Out-File $logFile -Append
+}
+
+# 2. behind/ahead 検出
+git -C $projectDir fetch origin --quiet
+$ahead  = (git -C $projectDir rev-list HEAD..origin/main --count) -as [int]
+$behind = (git -C $projectDir rev-list origin/main..HEAD --count) -as [int]
+
+# 3. dirty path 検出
+$dirty = git -C $projectDir status --short
+if ($dirty) { "WARN: dirty paths: $($dirty -join '; ')" | Out-File $logFile -Append }
+
+# 4. 未 push commit 検出
+$unpushed = git -C $projectDir log "@{push}..HEAD" --oneline 2>$null
+if ($unpushed) { "WARN: unpushed: $($unpushed -join '; ')" | Out-File $logFile -Append }
+
+# 5. 品質ゲート未完 surface
+# = 既存 scripts/codex_session_check.py / session_residuals_to_issue.py 連動
+& python "$projectDir\scripts\codex_session_check.py" --json | Out-File $logFile -Append
+```
+
+**Output** (= 受入 #1 + #3 復元):
+- `memory/session-start-check/<date>.log` = warning list
+- session 冒頭 inject 経由で AI に表示 (= `~/.claude/hooks/session-resume.ps1` 経由)
+
+### 3.3 StatusLine 設定 (= 新規 / 受入 #1 常時可視化)
+
+**目的**: Claude Code CLI prompt に **担当 / Issue / branch / dirty / 次品質ゲート** を常時表示.
+
+**設計**:
+```json
+// ~/.claude/settings.json (= 追加)
+{
+  "statusLine": {
+    "type": "command",
+    "command": "powershell -ExecutionPolicy Bypass -File \"C:\\Users\\kanta\\.claude\\hooks\\statusline.ps1\""
+  }
+}
+```
+
+```powershell
+# ~/.claude/hooks/statusline.ps1 (= 新規)
+
+$projectDir = if ($env:CLAUDE_PROJECT_DIR) { $env:CLAUDE_PROJECT_DIR } else { Get-Location }
+
+# instance 識別 (= 環境変数 or worktree path から推定)
+$instance = if ($env:CLAUDE_INSTANCE) {
+    $env:CLAUDE_INSTANCE
+} elseif ((Get-Location).Path -match 'instance-codex') {
+    'win-codex'
+} else {
+    'win-claude'
+}
+
+# branch / dirty
+$branch = git -C $projectDir rev-parse --abbrev-ref HEAD 2>$null
+$dirtyCount = (git -C $projectDir status --short 2>$null | Measure-Object).Count
+$dirtyMark = if ($dirtyCount -gt 0) { "*$dirtyCount" } else { '' }
+
+# 在 progress Issue (= memory/active-issue.txt 1 行 / hook が更新)
+$activeIssue = ''
+$activeFile = Join-Path $projectDir 'memory\active-issue.txt'
+if (Test-Path $activeFile) { $activeIssue = (Get-Content $activeFile -First 1).Trim() }
+
+# 次品質ゲート (= memory/next-quality-gate.txt 1 行)
+$nextGate = ''
+$gateFile = Join-Path $projectDir 'memory\next-quality-gate.txt'
+if (Test-Path $gateFile) { $nextGate = (Get-Content $gateFile -First 1).Trim() }
+
+# StatusLine format (= max ~80 char)
+# 例: [win-claude] #1577 | claude/crazy-jennings*3 | gate=dart-format
+$line = "[$instance]"
+if ($activeIssue) { $line += " #$activeIssue" }
+$line += " | $branch$dirtyMark"
+if ($nextGate) { $line += " | gate=$nextGate" }
+
+Write-Output $line
+```
+
+**運用**: hook が `memory/active-issue.txt` / `memory/next-quality-gate.txt` を更新 (= 起票時 / 着手時 / 完了時).
+
+### 3.4 Setup hook SOP (= `--init` / `--maintenance` 分離 / 新規 docs)
+
+**新規 doc**: `docs/CLAUDE_CODE_SETUP_RUNBOOK.md`.
+
+**構成**:
+
+```markdown
+# Claude Code Setup Runbook (= --init / --maintenance 分離)
+
+## --init (= 新規参画 / 1 回のみ)
+
+決定論的 commands:
+1. `git clone https://github.com/kanta13jp1/my_web_app.git` (= 既存)
+2. `cd my_web_app && flutter pub get`
+3. `git worktree add .claude/worktrees/<part-name> -b claude/<part-name>` (= [WORKDIR-ISOLATION])
+4. `python scripts/sync_inject_rules.py --apply` (= rule home 同期)
+5. `cp ~/.claude/settings.example.json ~/.claude/settings.json` + statusLine 編集 (= §3.3)
+6. `cp .env.example .env` + 秘匿 key 設定
+7. `flutter analyze` で 0 issues 確認
+
+## --maintenance (= 定期 / 月 1 回)
+
+決定論的 commands:
+1. `flutter pub upgrade --major-versions` (= dependency audit)
+2. `python scripts/notebooklm_issue_crosscheck.py --apply` (= [ISSUE-PRECHECK] / part 120)
+3. `python scripts/wiki_compile.py` + `wiki_lint.py` (= Karpathy Compile/Lint cycle)
+4. `python scripts/consolidate_memory.py` (= [MEMORY-DECAY] / 30+ 日 reference 0 cleanup)
+5. `gh pr list --state stale --search 'updated:<2026-04-01'` (= stale PR triage)
+6. `git remote prune origin` + `git worktree prune`
+7. `flutter analyze` で 0 issues 維持
+
+## 秘匿情報取扱 (= 受入 #5)
+
+保存先:
+- `~/.claude/settings.json` = GitHub PAT / NotebookLM cookie (= file mode 600 推奨)
+- `.env` = Supabase URL / Anthropic API key / WorkOS key (= `.gitignore` 必須 / repo 直 commit 禁止)
+- `memory/transcripts/` = compact summary (= `[REDACTED]` filter 経由 / §3.1)
+
+禁止:
+- `.env` を repo に commit
+- compact backup に raw API key を残す (= §3.1 redact filter で除外)
+- StatusLine に PAT prefix 表示 (= `[gho_]` 等は出力しない)
+
+CI gate:
+- `.github/workflows/secret-scan.yml` で `memory/transcripts/*.md` 内 secret pattern 検出 → block merge
+```
+
+## 4. 受入条件 mapping
+
+| 受入条件 | 対応 section |
+|---|---|
+| #1 context compact 後 1 分以内に復元 | §3.1 (= YAML payload + redact filter) + §3.2 (= 5 検出) + §3.3 (= StatusLine 即可視化) |
+| #2 N instance 並行で branch/worktree 取り違え検知 | §3.2 step 1 (= prefix check) + §3.3 (= 担当 instance 常時表示) |
+| #3 SessionStart で behind/ahead/dirty/未 push/品質ゲート検出 | §3.2 step 2-5 |
+| #4 新規セットアップ vs 定期メンテ commands 分離 | §3.4 (= `CLAUDE_CODE_SETUP_RUNBOOK.md` の `--init` / `--maintenance` 章分離) |
+| #5 保存先 + 秘匿情報取扱 明文化 | §3.4 「秘匿情報取扱」section + §3.1 redact filter |
+
+## 5. Win Codex hand off scope
+
+- [ ] `.claude/hooks/pre-compact-backup.ps1` 拡張 (= §3.1 / YAML payload + redact filter / **既存ファイル拡張**)
+- [ ] `.claude/hooks/session-start-state-check.ps1` 新規 (= §3.2 / 5 検出)
+- [ ] `~/.claude/hooks/statusline.ps1` 新規 (= §3.3 / instance / branch / dirty / next gate)
+- [ ] `~/.claude/settings.json` `statusLine` 設定追加 (= §3.3 / **手動 / 各 instance 個別**)
+- [ ] `docs/CLAUDE_CODE_SETUP_RUNBOOK.md` 新規 (= §3.4 / `--init` / `--maintenance` 章 + 秘匿情報取扱)
+- [ ] `memory/transcripts/.gitkeep` 配置 (= §2)
+- [ ] `.github/workflows/secret-scan.yml` 拡張 (= §3.4 / `memory/transcripts/*.md` 対象追加)
+- [ ] 復元 hook = `~/.claude/hooks/session-resume.ps1` 拡張 (= §3.1 / 最新 compact-*.md 読込)
+- [ ] memory/active-issue.txt / memory/next-quality-gate.txt 配置 + hook 更新 logic
+- [ ] `scripts/codex_session_check.py` `--json` mode 既存確認 (= §3.2 / 既整備済)
+
+EF 数 +0 (= EF 関与なし / [EF-CAP-50] 完全遵守).
+推定工数: 8h (= PreCompact 拡張 1.5h + SessionStart hook 1.5h + StatusLine 1h + Setup runbook 2h + secret-scan 拡張 1h + 復元 hook 拡張 1h).
+
+## 6. 9 原則 alignment
+
+### PHILOSOPHY-22 (= 8/9 評価 / 7+/9 ✅ ゲート達成)
+
+- ✅ #1 CEO 感 — StatusLine で「自分が CEO として今どこに居るか」常時可視化
+- ✅ #2 ミッション — 記憶 = 資本 / 失わない
+- ✅ #4 6 部署 — Win Claude (= architect / docs) territory 直撃 / Win Codex (= 実装) hand off scope §5 で 10 件
+- ✅ #5 商品=価値 — 1 incident で 30+ min 失う = 価値毀損
+- ✅ #6 時間最適化 — compact 復元 30 秒以内 = 時間最適化最大化
+- ✅ #7 資産負債 — memory/transcripts/ + active-issue.txt = 永続資産
+- ✅ #8 KPI — 復元時間 (= < 1 min) / branch 取り違え件数 (= 0) / 秘匿情報漏洩件数 (= 0) を計測可
+- ✅ #9 IPO — secret-scan gate + 秘匿情報明文化 = SOC2 必要要件
+
+= **8/9 ✅** (= 7+/9 ゲート達成 / #3 mentor は scope 外).
+
+### AI-DEV-23 (= 7/7 推奨)
+
+- ✅ #1 Auth — file mode 600 / `.env` gitignore
+- ✅ #2 deny-by-default — secret-scan で `.env` commit 即 block
+- ✅ #3 trace_id — log file に timestamp + instance + ts 付与
+- ✅ #4 circuit-breaker — hook silent failure (= session block しない / `exit 0`)
+- ✅ #5 memory — `memory/transcripts/` retention (= 30 日 cleanup 推奨 / consolidate-memory skill)
+- ✅ #6 DLQ — hook 失敗時 log file に記録 (= `compact-log.txt` / `session-start-check/<date>.log`)
+- ✅ #7 quality-gate — secret-scan workflow + flutter analyze 0 issues
+
+= **7/7 ✅**.
+
+### BRAIN-32 (= 7/7 推奨)
+
+- ✅ #1 Atomic Note — 各 compact-*.md = 独立 Atomic Note
+- ✅ #2 Cross-link — YAML payload に `active_pr` / `in_progress_issue` で link
+- ✅ #3 横断検索 — `mem-search` skill / `notebooklm` CLI で transcripts 検索可
+- ✅ #4 メタデータ — YAML frontmatter で saved_at / instance / branch
+- ✅ #5 メンテナンス — §3.4 `--maintenance` で `consolidate_memory.py` 月 1
+- ✅ #6 自走化 — hook で人手介入ゼロ
+- ✅ #7 PKM 永続化 — `memory/transcripts/` `.gitkeep` で trackable
+
+= **7/7 ✅**.
+
+### INDIE-29 (= 7/7 推奨)
+
+- ✅ #1 shipping 速度 — 既存 hook 拡張 + 1 SOP / 工数 8h
+- ✅ #2 dogfood — 本 spec を本 session で先行適用 (= part 152 で復元 manual 検証)
+- ✅ #3 lo-fi tooling — PowerShell hook + Python script / 既存 stack 流用
+- ✅ #5 simplicity — 4 hook + 1 script + 2 SOP / 過剰抽象なし
+- ✅ #6 measurable — 復元時間 / branch 取り違え 0 / secret 漏洩 0
+- ✅ #7 reproducibility — `--init` 決定論的 commands
+
+### SYNERGY-30 (= 4+/7 ✅)
+
+- ✅ #1 cross-instance-pr — Win Codex hand off §5 で 10 件
+- ✅ #3 5 正本同期 — Issues + WBS + memory + worktree + PR
+- ✅ #4 5-question matrix — Q1 + Q2 + Q5 YES = Win Claude
+- ✅ #5 fleet hygiene — 2 instance prefix 検知 (= claude/ vs codex/)
+
+## 7. 受け入れ条件 mapping (= 受入条件 self-check)
+
+| 受入条件 | section | 検証方法 |
+|---|---|---|
+| #1 1 分以内復元 | §3.1 + §3.2 + §3.3 | manual: compact 直後の new session で StatusLine 表示まで stopwatch |
+| #2 branch 取り違え検知 | §3.2 step 1 | manual: codex/ branch で win-claude 起動 → log warn 確認 |
+| #3 SessionStart 5 検出 | §3.2 step 2-5 | manual: dirty + ahead/behind 状態で起動 → log warn 確認 |
+| #4 init/maintenance 分離 | §3.4 | manual: runbook 章分離 + 各 commands 決定論的 (= side effect 同一) |
+| #5 秘匿情報明文化 | §3.4 「秘匿情報取扱」 | secret-scan workflow 実行 → memory/transcripts/ 内 PAT pattern 検出 → block |
+
+## 8. NotebookLM 蓄積予定
+
+- 本 spec を `docs/notebooklm-intake/jibun-master-brain-spec-template-seed.md` の蓄積 list に追加
+- `notebooklm source add docs/PRECOMPACT_MEMORY_BACKUP_SPEC.md` 実行は part 152 後で
+- Source: `Claude Code Masterclass` / `Codex vs Claude Code` 由来 NotebookLM list 反映済 (= Issue #1564 body)
+
+## 9. 通常 spec template 第 7 例
+
+本 spec は通常 5 section 適用 (= sensitive ではない / §2 倫理 review section 不要).
+
+| 通常 spec | part | 工数 |
+|---|---|---|
+| SIX_DEPT_KPI | 143 | 12h |
+| ONE_IN_TWO_OUT | 143 | 11.5h |
+| MAINTENANCE_SOP | 144 | 6h |
+| TERM_TOOLTIP | 144 | 8h |
+| NARRATIVE_UI_ACTION | 145 | 9h |
+| DEV_ENV_SETUP | 145 | 5h |
+| **PRECOMPACT_MEMORY_BACKUP** | **152** | **8h** |
+
+= 通常 7 例平均 8.5h (= sensitive 12.0h より -29%).
+= 通常 spec template の **既存 hook 拡張** pattern 第 1 例 (= ゼロから新規ではなく既存 base + 増分設計).


### PR DESCRIPTION
## Summary

- **sensitive 設計 spec 第 4 例** = security boundary 異領域拡張 (= [#1577](https://github.com/kanta13jp1/my_web_app/issues/1577) WorkOS AuthKit MCP 認可強化 / P1)
- **MCP-AUTH-27 10/10 必須遵守** = MCP server public 公開要件達成 / 9/10 でも公開しない deny-by-default
- **template §4A 第 4 改訂** = 4 例完成 (健康/AI 状態/persona/security) / 共通 NOT to do + MUST do を 3 → 4 項目に増補

## 何を ship したか

### 1. `docs/MCP_AUTH_HARDENING_SPEC.md` (新規 / 11 section / 618 行)

- §1 思想 — protocol 層 + アプリ層の二重防御 / arXiv 論文 (= system prompt 防御だけでは 61.3% → 47.2%) 引用
- §2 倫理 review (= sensitive 必須拡張 / 第 4 例 = security boundary 適用)
  - §2.1 NOT to do **10 項** (= token 共有 / DCR 濫用 / Audience 罠 / sampling 申告 / 権限過剰 / Manual SQL / クエリ token 等)
  - §2.2 MUST do **12 項** (= WorkOS managed / OAuth 2.1+PKCE / .well-known / Resource Indicators 3 段階 / audit log / Terraform IaC 等)
  - §2.3 AI-CHARACTER-24 **8/8 ✅** self-check
  - §2.4 AI-DEV-23 **7/7 ✅** self-check
  - §2.5 **MCP-AUTH-27 10/10 ✅** self-check (= public 公開要件)
- §3 既存基盤確認 (= part 49 mcp_auth_guard skeleton + mcp_oauth_clients + mcp_audit_log の延長)
- §4 **5 hardening axis 採否決定 matrix** (= Issue 受入 #1)
  - §4.1 **CIMD**: Phase 2 (2027 Q1) 採用 / Phase 1 = DCR / 移行設計を `mcp-dcr-vs-cimd-decision.md` に記録
  - §4.2 **OAuth IaC (Terraform)**: Phase 1 採用 / Mercari Tip 1 応用 / Manual SQL 禁止 lint
  - §4.3 **Standalone Connect**: Phase 1 採用 / `workos_user_link` table で Supabase Auth ↔ WorkOS user_id bridge
  - §4.4 **HMAC + Nonce + Timestamp**: 内部 EF 間 only / 外部 MCP は OAuth 2.1 + PKCE で代替 (= 二重署名 vs 仕様準拠の trade-off)
  - §4.5 **Sampling Origin Tagging**: sampling capability 申告 **しない** で代替 (= arXiv ベクトル A 完全排除 / Phase 2+ 採用時の Origin Tagging 設計も明記)
- §5 schema 設計 — `mcp_auth_guard.ts` 完成 + 3 migration extend + `mcp-well-known` EF (新規) + Terraform skeleton + anomaly cron
- §6 **memory-search-hub 5/10 → 10/10 達成手順** = MCP 公開第 1 例 (= 受入 #3 権限境界)
- §7 Win Codex hand off scope **14 件** / EF +1 / 推定工数 **14h**
- §8 9 原則 alignment: PHILOSOPHY **8/9** + MCP-AUTH **10/10** + AI-DEV **7/7** + AI-CHARACTER **8/8** + VIBE **4+/7** + SYNERGY **4+/7**
- §9 受入条件 mapping (#1-#3 全 ✅)
- §10 sensitive design 第 4 例の matrix 拡張記録
- §11 NotebookLM 蓄積予定

### 2. `docs/DESIGN_SPEC_TEMPLATE.md` 更新 (= meta-spec 第 4 改訂)

- §4 早見表に `MCP_AUTH_HARDENING` row 追加 = **10 spec 達成** (= sensitive 4/4 + 通常 6)
- §4A.1 sensitive 判断 list に **"security boundary"** 追加 (= 異領域 4 種目)
- §4A.3 NOT to do 4 例対比 + 共通 4 項目に拡張 (= 「権限過剰禁止」追加 / 第 5 改訂候補)
- §4A.4 MUST do 4 例対比 + 共通 4 項目に拡張 (= 「vendor managed 優先」追加 / 第 5 改訂候補)
- §7 横展開計画 — 10 spec 突破達成記録 + 第 5 改訂候補 (= 抽象化 layer / DESIGN_SPEC_PATTERNS.md 統合) 明記

## なぜ大事か

### sensitive matrix 拡張の意義

| 例 | 領域 | 先行 part |
|---|---|---|
| 第 1 | 人間データ (健康) | part 147 |
| 第 2 | AI 内部状態 | part 149 |
| 第 3 | high-stakes persona | part 150 |
| **第 4** | **security boundary** | **part 152 (本 PR)** |

**security boundary** = 認証 / 認可 / 外部攻撃面 / token 発行 / capability 公開 = sensitive design template の正式 4th 領域として登録. 「sensitive = 人間 data + AI ペルソナ + persona + 認証/認可」という抽象化 layer (= part 153+ で `DESIGN_SPEC_PATTERNS.md` 統合) への接続点が明確化.

### MCP-AUTH-27 10/10 必須遵守の意義

- MCP server 公開 = 1 incident で全失う risk
- 9/10 でも public 公開しない deny-by-default を spec で担保
- 既存 EF (= ai-hub 0.5/10 / memory-search-hub 5/10) のうち memory-search-hub を **MCP 公開第 1 例** として ship 可能な手順を §6 で明示

## Test plan

- [x] PHILOSOPHY-22 7+/9 ✅ — 8/9 達成 (= §8 検証)
- [x] MCP-AUTH-27 10/10 ✅ — §2.5 self-check
- [x] AI-DEV-23 7/7 ✅ — §2.4 self-check
- [x] AI-CHARACTER-24 8/8 ✅ — §2.3 self-check
- [x] VIBE-30 4+/7 ✅ — §8 検証
- [x] SYNERGY-30 4+/7 ✅ — §8 検証
- [x] Issue 受入条件 #1-#3 全 ✅ — §9 mapping
- [x] [EF-CAP-50] 遵守 — EF +1 (= mcp-well-known) / 残枠 30 内
- [x] [DYNAMIC-CLAIM] cap 遵守 — 1 session 1 件 (= 本 spec のみ)
- [x] [WORKDIR-ISOLATION] 遵守 — `.claude/worktrees/crazy-jennings-93b113` 内作業
- [x] [STASH-SAFETY] 遵守 — stash 不使用 / 1 commit で完結
- [ ] **Win Codex 実装 hand off** (= §7 14 件 / 推定 14h) — 別 PR で順次 ship 予定
- [ ] **memory-search-hub 10/10 達成** (= §6 5 原則完成) — 別 PR で ship 予定

## 関連 PR / Issue

- Issue: [#1577](https://github.com/kanta13jp1/my_web_app/issues/1577) [追加要望][P1] WorkOS AuthKit MCP認可をCIMD/IaC/HMAC/Origin Taggingで強化
- 関連 Issue: [#845](https://github.com/kanta13jp1/my_web_app/issues/845) (OAuth) / [#1194](https://github.com/kanta13jp1/my_web_app/issues/1194) (DCR/AuthKit) — 本 spec が両 PR の review checklist として機能
- スタック先 PR: [#2017](https://github.com/kanta13jp1/my_web_app/pull/2017) — part 144-151 の連続 spec ship / 本 PR は #2017 の続き (= base=`claude/amazing-hypatia-84b710`)
- NotebookLM source: `1b808a60-85d6-49f7-ab80-0e90a43cf1d8` Streamlining MCP Authentication with WorkOS AuthKit

🤖 Generated with [Claude Code](https://claude.com/claude-code)