### PR TITLE
feat(wbs): enforce 2-instance routing

### DIFF
--- a/.github/COMPRESSED_PROMPT_V3.md
+++ b/.github/COMPRESSED_PROMPT_V3.md
@@ -1047,3 +1047,12 @@ S (Solutions)  = API呼び出し・計算コード → スクリプト
 ---
 
 > **インスタンス別スコープ早見表**: `lib/` + `supabase/functions/` + `docs/DESIGN.md` → **VSCode版** / `docs/` (DESIGN.md除く) + `supabase/migrations/` (seed + schema) → **Windowsアプリ版** / `.github/` + `.mcp.json` + `docs/MULTI_INSTANCE_COORDINATION.md` → **PowerShell版** / `memory/` + `docs/GROWTH_STRATEGY_ROADMAP.md` (末尾追記) + `docs/cross-instance-prs/` + `COMPRESSED_PROMPT_V3.md` (数値更新) → **全インスタンス共有**
+## Current 2-Instance Override (2026-05-05)
+
+Canonical development flow is now exactly two human-operated instances:
+
+- Claude Code #1 (Windows app): architecture, research, docs, UX triage, WBS design/spec, and old Win/VSCode/PS#1/PS#3/PS#4/WEB/mobile lanes.
+- Codex #1 (Windows app): implementation, CI, GitHub PR work, Edge Functions, workflows, and old Codex/PS#2/PS#5/PS#6 lanes.
+- User and Automation remain non-development lanes for manual decisions, scheduled jobs, and GitHub Actions.
+
+Any 3-instance, 12-fleet, Codex#2, or PS#1-6 routing below this section is historical legacy context only. New sessions must not start extra AI instances or extra dev servers unless explicitly requested by the user.

--- a/.github/workflows/instance-role-audit.yml
+++ b/.github/workflows/instance-role-audit.yml
@@ -4,6 +4,10 @@ name: Instance Role Audit (12 fleet 担当分担 monthly review)
 # AI_FLEET_SYNERGY 原則 #1 (Strict Instance Routing) dogfood
 # 過去 30 日の commit を instance 別に集計 / CLAUDE.md routing matrix 想定との乖離検出
 
+# Current canonical routing: Claude Code #1 (Windows app) + Codex #1
+# (Windows app). Old 12-fleet / PS#1-6 references in historical reports
+# are legacy-only and must not be used for new WBS ownership.
+
 on:
   schedule:
     - cron: "0 1 1 * *"  # monthly / 1 日 01:00 UTC (= 10:00 JST)

--- a/.github/workflows/two-instance-audit.yml
+++ b/.github/workflows/two-instance-audit.yml
@@ -1,0 +1,24 @@
+name: Two-Instance Routing Audit
+
+on:
+  pull_request:
+    paths:
+      - ".github/COMPRESSED_PROMPT_V3.md"
+      - ".github/workflows/**"
+      - "docs/**"
+      - "scripts/two_instance_audit.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Check canonical 2-instance routing markers
+        run: python scripts/two_instance_audit.py --fail-on-active

--- a/.github/workflows/wbs-staleness-audit.yml
+++ b/.github/workflows/wbs-staleness-audit.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   STALE_DAYS: 3 # この日数以上更新が無いインスタンスを overdue 扱い
-  INSTANCES: 'vscode win ps1 ps2 ps3 ps4 ps5 ps6'
+  INSTANCES: 'claude codex user automation'
 
 jobs:
   audit:
@@ -45,7 +45,7 @@ jobs:
               -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
               -H "Content-Type: application/json" \
               -d "{\"action\":\"wbs.list_tasks\",\"instance\":\"${INSTANCE}\"}")
-            # PS#1 S21: 元 heredoc は 12-sp leading whitespace で Python IndentationError → 常に 0
+            # Two-instance S21: keep heredoc parsing stable for Python one-liners.
             # 1-line 化して YAML block scalar と Python 両方の indentation 問題を解消
             RECENT_COUNT=$(echo "$RESPONSE" | python3 -c "import sys,json; from datetime import datetime,timezone,timedelta; d=json.load(sys.stdin); c=datetime.now(timezone.utc)-timedelta(days=${STALE_DAYS}); print(sum(1 for t in d.get('tasks',[]) if t.get('updated_at') and datetime.fromisoformat(t['updated_at'].replace('Z','+00:00'))>c))" || echo "0")
 
@@ -67,7 +67,7 @@ jobs:
         run: |
           DATE=$(date -u +%Y%m%d)
           mkdir -p docs/cross-instance-prs
-          # PS#1 S21: 同日 2 回目 run の branch collision 回避で run_id suffix 付加
+          # Two-instance S21: add run_id suffix to avoid same-day branch collisions.
           BRANCH="wbs-staleness/${DATE}-${{ github.run_id }}"
 
           git config user.name 'github-actions[bot]'
@@ -114,7 +114,7 @@ jobs:
             --base main \
             --head "$BRANCH" || true
 
-      # Win版#131 part 21: PS#5 不在 fallback - unassigned bug 4h+ 検出
+      # Win版#131 part 21 updated 2026-05-05: Codex #1 fallback - unassigned bug 4h+ audit.
       - name: Detect unassigned bugs (4h+)
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
@@ -138,28 +138,28 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git checkout -b "$BRANCH" 2>/dev/null || git checkout "$BRANCH"
 
-          FILE="docs/cross-instance-prs/${DATE}_unassigned_bugs_escalate_ps1.md"
+          FILE="docs/cross-instance-prs/${DATE}_unassigned_bugs_escalate_claude.md"
           cat > "$FILE" <<EOF
-          # 🚨 PS#5 不在 → PS#1 escalate: unassigned bug 4h+ 蓄積
+          # 🚨 Codex #1 fallback → Claude Code #1 escalate: unassigned bug 4h+ 蓄積
 
           - **検出日時**: $(date -u +%Y-%m-%dT%H:%M:%SZ)
           - **検出元**: \`.github/workflows/wbs-staleness-audit.yml\` (Win版#131 part 21)
 
-          ## 対象 Issue (PS#5 が 4h 以内に reach できなかった bug)
+          ## 対象 Issue (Codex #1 が 4h 以内に reach できなかった bug)
 
           $(echo "$OUT" | while IFS='|' read -r num title url; do echo "- [#$num] $title — $url"; done)
 
-          ## PS#1 アクション (Rule17 health check の流れで)
+          ## Claude Code #1 アクション (Rule17 health check の流れで)
 
           1. 各 Issue を確認
           2. severity 判定 (critical/high/normal)
-          3. PS#5 にメンション (もし PS#5 まだ起動していれば)
+          3. Codex #1 にメンション (もし Codex #1 まだ起動していれば)
           4. 重い修正 → /cross-instance-pr to=win/vscode で再 escalate
-          5. 軽量 → 自分 (PS#1) で即修正
+          5. 軽量 → Claude Code #1 で即修正
 
           ## SLA
 
-          - critical: **2h 以内** に PS#1 直接修正
+          - critical: **2h 以内** に Claude Code #1 直接修正
           - high: 4h 以内 cross-instance-pr or PR
           - normal: 翌日まで
 
@@ -170,12 +170,12 @@ jobs:
           EOF
 
           git add "$FILE"
-          git commit -m "audit: unassigned bug 4h+ escalate to PS#1 (${DATE})" || exit 0
+          git commit -m "audit: unassigned bug 4h+ escalate to Claude Code #1 (${DATE})" || exit 0
           git push origin "$BRANCH" || exit 0
 
           gh pr create \
-            --title "audit: PS#5 不在 → PS#1 escalate (${DATE})" \
-            --body "PS#5 が 4h 以内に reach できなかった unassigned bug を PS#1 にエスカレートします。" \
+            --title "audit: Codex #1 fallback -> Claude Code #1 escalate (${DATE})" \
+            --body "Codex #1 が 4h 以内に reach できなかった unassigned bug を Claude Code #1 にエスカレートします。" \
             --label "wbs-audit,bug-escalate,automated" \
             --base main \
             --head "$BRANCH" || true

--- a/docs/CODEX_WORKFLOW.md
+++ b/docs/CODEX_WORKFLOW.md
@@ -270,3 +270,10 @@ Codex #1/#2 は作業開始時に次を実施する。
 - UI/console エラーが本番で再発する場合、Codex#1 に「browser QA + screenshot gate」を振る。
 - cross-instance 競合、設計判断、NotebookLM の概念蒸留が必要な場合、Claude Code に戻す。
 - 手動確認が 3 回以上出る WBS タスクは、スケジュールタスク・GitHub Actions・Edge Function の候補として起票する。
+## Current 2-Instance Override (2026-05-05)
+
+Canonical flow is now Claude Code #1 (Windows app) + Codex #1 (Windows app).
+This document keeps older Codex#2 / PS#1-6 / multi-worktree guidance as
+legacy history only. New Codex work should use one Codex Windows app instance,
+one active branch, and one shared dev server unless the user explicitly asks for
+an exception.

--- a/docs/FLEET_2_INSTANCE_TRANSITION.md
+++ b/docs/FLEET_2_INSTANCE_TRANSITION.md
@@ -118,3 +118,8 @@ User 要望 (= 2026-05-04):
 - [`docs/AI_FALLBACK_RUNBOOK.md`](./AI_FALLBACK_RUNBOOK.md) — fallback
 - Issue [#1974](https://github.com/kanta13jp1/my_web_app/issues/1974) — CLAUDE.md 80 行 KPI (= 関連 context cost 削減)
 - part 128 memo — Karpathy AI 外部脳 dogfood map
+## Current 2-Instance Marker (2026-05-05)
+
+This transition note is legacy history plus the migration record. Current
+canonical operation is Claude Code #1 (Windows app) + Codex #1 (Windows app).
+Any 12-fleet, Codex#2, or PS#1-6 references below are historical mappings only.

--- a/docs/WBS_2_INSTANCE_ROUTING.md
+++ b/docs/WBS_2_INSTANCE_ROUTING.md
@@ -9,6 +9,13 @@ The WBS screen keeps historical `instance` and `owner_instance` values intact, b
 
 `User` and `Automation` remain visible as non-development lanes so manual decisions and scheduled/GitHub Actions work do not disappear into either agent lane.
 
+Implementation notes:
+
+- The WBS UI shows only `All`, `Claude Code`, `Codex`, `User`, and `Automation` chips. Historical VS/Win/PS#1-6/Gemini/Copilot chips are hidden from active operation.
+- `tools-hub:wbs.list_tasks`, `wbs.tasks.list`, `wbs.priority_for_instance`, and workload summaries project legacy DB values into the same four active lanes.
+- `claude` writes to legacy `win` only when a task must be persisted, and `automation` writes to legacy `schedule`. Existing historical `instance` values are not rewritten in place.
+- `gemini`, `co-pilot`, `schedule`, and `gha` are grouped as `Automation` because they are tools or scheduled jobs, not human development instances.
+
 WBS execution policy:
 
 1. Work from the nearest due date first.

--- a/docs/two-instance-audit/2026-05-05.md
+++ b/docs/two-instance-audit/2026-05-05.md
@@ -1,0 +1,45 @@
+# 2-Instance Routing Audit (2026-05-05)
+
+Canonical owner model: Claude Code #1 (Windows app) + Codex #1 (Windows app).
+Historical 12-fleet / PS#1-6 references are acceptable only when the file clearly marks them as legacy.
+
+| file | legacy refs | marker | status |
+| --- | ---: | --- | --- |
+| `.github/COMPRESSED_PROMPT_V3.md` | 3 | yes | ok |
+| `.github/workflows/instance-role-audit.yml` | 2 | yes | ok |
+| `.github/workflows/wbs-staleness-audit.yml` | 0 | yes | ok |
+| `docs/CODEX_WORKFLOW.md` | 19 | yes | ok |
+| `docs/FLEET_2_INSTANCE_TRANSITION.md` | 4 | yes | ok |
+| `docs/WBS_2_INSTANCE_ROUTING.md` | 3 | yes | ok |
+
+## Samples
+
+### `.github/COMPRESSED_PROMPT_V3.md`
+- L1054: `- Claude Code #1 (Windows app): architecture, research, docs, UX triage, WBS design/spec, and old Win/VSCode/PS#1/PS#3/PS#4/WEB/mobile lanes.`
+- L1055: `- Codex #1 (Windows app): implementation, CI, GitHub PR work, Edge Functions, workflows, and old Codex/PS#2/PS#5/PS#6 lanes.`
+- L1058: `Any 3-instance, 12-fleet, Codex#2, or PS#1-6 routing below this section is historical legacy context only. New sessions must not start extra AI instances or extra dev servers unless explicitly requested by the user.`
+
+### `.github/workflows/instance-role-audit.yml`
+- L1: `name: Instance Role Audit (12 fleet 担当分担 monthly review)`
+- L8: `# (Windows app). Old 12-fleet / PS#1-6 references in historical reports`
+
+### `docs/CODEX_WORKFLOW.md`
+- L3: `> 目的: Claude Code 10 インスタンスに、Codex 2 インスタンスを固定 worktree で追加し、横断調査 / 修正PR / CI・同期・運用 / レビュー補助を衝突少なく並行処理する。`
+- L9: `| Codex#1 | `.claude/worktrees/instance-codex1` | `codex/codex1-wip` | 横断調査 / 修正PR / SQL・migration レビュー補助 | PS#3 / Win版 |`
+- L10: `| Codex#2 | `.claude/worktrees/instance-codex2` | `codex/codex2-wip` | CI / 同期 / 運用 / EF(Deno)・GHA レビュー補助 | PS#1 / PS#5 / PS#6 |`
+- L24: `cd C:/Users/kanta/GitHub/my_web_app/.claude/worktrees/instance-codex2`
+- L34: `powershell -ExecutionPolicy Bypass -File .claude/scripts/setup-instance-worktree.ps1 codex1`
+- L35: `powershell -ExecutionPolicy Bypass -File .claude/scripts/setup-instance-worktree.ps1 codex2`
+- L42: `bash .claude/scripts/setup-instance-worktree.sh codex2`
+- L53: `git push -u origin codex/codex2-wip`
+
+### `docs/FLEET_2_INSTANCE_TRANSITION.md`
+- L21: `| Claude Code | VSCode / Win / PS#1-6 / WEB / スマホ = 10 instance | **Win版 (Claude Code)** = 1 instance |`
+- L22: `| Codex CLI | Codex#1 / Codex#2 + ad-hoc = 多数 | **Win版 (Codex CLI)** = 1 instance |`
+- L44: `| Codex#2 | CI / 同期 / 運用 / EF Deno / GHA | ✅ 継承 |`
+- L125: `Any 12-fleet, Codex#2, or PS#1-6 references below are historical mappings only.`
+
+### `docs/WBS_2_INSTANCE_ROUTING.md`
+- L7: `- Claude Code: architecture, research, docs, UX triage, old Win/VSCode/PS#1/PS#3/PS#4/WEB/mobile lanes.`
+- L8: `- Codex: implementation, CI, GitHub PR work, old Codex/PS#2/PS#5/PS#6 lanes.`
+- L14: `- The WBS UI shows only `All`, `Claude Code`, `Codex`, `User`, and `Automation` chips. Historical VS/Win/PS#1-6/Gemini/Copilot chips are hidden from active operation.`

--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -344,6 +344,10 @@ String _activeWbsInstanceKey(String raw) {
   if (key == 'schedule' ||
       key == 'gha' ||
       key == 'github-actions' ||
+      key == 'gemini' ||
+      key == 'co-pilot' ||
+      key == 'copilot' ||
+      key == 'github-copilot' ||
       key == 'automation' ||
       key == 'auto') {
     return 'automation';
@@ -2463,18 +2467,13 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
               ),
             ),
             const SizedBox(width: 6),
-            ..._activeWbsInstanceFilters
-                .where(
-              (filter) =>
-                  filter.value == 'claude' || filter.value == 'automation',
-            )
-                .map((filter) {
+            ..._activeWbsInstanceFilters.map((filter) {
               final on = widget.filterInstance == filter.value;
               return Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 2),
                 child: FilterChip(
                   label: Text(
-                    filter.label,
+                    filter.value == null ? '全て' : filter.label,
                     style: TextStyle(
                       color: on ? Colors.black : filter.color,
                       fontSize: 10,
@@ -2514,7 +2513,7 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
               ('📱', 'mobile', const Color(0xFFF97316)),
               ('⏰', 'schedule', const Color(0xFFEAB308)),
               ('🔧', 'gha', const Color(0xFF6B7280)),
-            ].map((t) {
+            ].where((_) => false).map((t) {
               if (t.$2 != null &&
                   !_activeWbsInstanceFilters
                       .any((filter) => filter.value == t.$2)) {

--- a/scripts/two_instance_audit.py
+++ b/scripts/two_instance_audit.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Audit active docs and workflows for stale multi-instance routing.
+
+The repository still keeps historical 12-fleet / PS#1-6 records. Those are
+allowed only when a file clearly marks the text as legacy. Active instructions
+for new sessions must point to Claude Code #1 + Codex #1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import date
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ACTIVE_FILES = [
+    ".github/COMPRESSED_PROMPT_V3.md",
+    ".github/workflows/instance-role-audit.yml",
+    ".github/workflows/wbs-staleness-audit.yml",
+    "docs/CODEX_WORKFLOW.md",
+    "docs/FLEET_2_INSTANCE_TRANSITION.md",
+    "docs/WBS_2_INSTANCE_ROUTING.md",
+]
+
+LEGACY_PATTERNS = [
+    re.compile(r"\bPS#?[1-6]\b", re.IGNORECASE),
+    re.compile(r"\bCodex#?2\b", re.IGNORECASE),
+    re.compile(r"\b12[- ]?fleet\b", re.IGNORECASE),
+    re.compile(r"\b3[- ]?instance\b", re.IGNORECASE),
+    re.compile(r"Claude Code 10", re.IGNORECASE),
+    re.compile(r"Codex 2", re.IGNORECASE),
+    re.compile(r"vscode win ps1", re.IGNORECASE),
+]
+
+CANONICAL_PATTERNS = [
+    re.compile(r"Current 2-Instance Override", re.IGNORECASE),
+    re.compile(r"2-instance", re.IGNORECASE),
+    re.compile(r"Claude Code #1", re.IGNORECASE),
+    re.compile(r"Codex #1", re.IGNORECASE),
+    re.compile(r"legacy", re.IGNORECASE),
+]
+
+
+@dataclass
+class Hit:
+    path: str
+    line: int
+    text: str
+
+
+@dataclass
+class FileAudit:
+    path: str
+    legacy_hits: int
+    canonical_marker: bool
+    status: str
+    samples: list[Hit]
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def scan_file(path: Path) -> FileAudit:
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    text = read_text(path)
+    canonical_marker = any(pattern.search(text) for pattern in CANONICAL_PATTERNS)
+    hits: list[Hit] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if any(pattern.search(line) for pattern in LEGACY_PATTERNS):
+            hits.append(Hit(rel, line_no, line.strip()[:220]))
+    status = "ok"
+    if hits and not canonical_marker:
+        status = "needs_marker"
+    return FileAudit(rel, len(hits), canonical_marker, status, hits[:8])
+
+
+def render_markdown(audits: list[FileAudit]) -> str:
+    today = date.today().isoformat()
+    lines = [
+        f"# 2-Instance Routing Audit ({today})",
+        "",
+        "Canonical owner model: Claude Code #1 (Windows app) + Codex #1 (Windows app).",
+        "Historical 12-fleet / PS#1-6 references are acceptable only when the file clearly marks them as legacy.",
+        "",
+        "| file | legacy refs | marker | status |",
+        "| --- | ---: | --- | --- |",
+    ]
+    for audit in audits:
+        marker = "yes" if audit.canonical_marker else "no"
+        lines.append(
+            f"| `{audit.path}` | {audit.legacy_hits} | {marker} | {audit.status} |"
+        )
+    lines.append("")
+    lines.append("## Samples")
+    for audit in audits:
+        if not audit.samples:
+            continue
+        lines.append("")
+        lines.append(f"### `{audit.path}`")
+        for hit in audit.samples:
+            lines.append(f"- L{hit.line}: `{hit.text}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--fail-on-active", action="store_true")
+    args = parser.parse_args()
+
+    audits = [
+        scan_file(REPO_ROOT / rel)
+        for rel in ACTIVE_FILES
+        if (REPO_ROOT / rel).exists()
+    ]
+    if args.json:
+        print(json.dumps([asdict(audit) for audit in audits], ensure_ascii=False, indent=2))
+    else:
+        markdown = render_markdown(audits)
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(markdown, encoding="utf-8")
+        print(markdown)
+    if args.fail_on_active and any(audit.status != "ok" for audit in audits):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -630,16 +630,45 @@ const WBS_INSTANCE_VALUES = [
   "user", // ユーザー手動操作タスク (法人登記/銀行口座/外部面談等)
 ];
 
+const WBS_ACTIVE_INSTANCE_VALUES = [
+  "claude",
+  "codex",
+  "user",
+  "automation",
+];
+
+const WBS_CODEX_LEGACY_INSTANCES = ["codex", "ps2", "ps5", "ps6"];
+const WBS_AUTOMATION_LEGACY_INSTANCES = [
+  "schedule",
+  "gha",
+  "gemini",
+  "co-pilot",
+];
+
 const WBS_OPEN_STATUSES = ["pending", "in_progress", "blocked"];
 
 function normalizeWbsInstance(value: unknown): string {
   const normalized = String(value ?? "").trim().toLowerCase();
+  if (
+    normalized === "claude" ||
+    normalized === "claude-code" ||
+    normalized === "claude-code-1"
+  ) return "win";
+  if (normalized === "automation" || normalized === "auto") return "schedule";
   if (normalized === "windows") return "win";
   if (normalized === "ps") return "ps1";
   if (normalized === "copilot" || normalized === "github-copilot") {
     return "co-pilot";
   }
   return WBS_INSTANCE_VALUES.includes(normalized) ? normalized : "codex";
+}
+
+function normalizeWbsActiveInstance(value: unknown): string {
+  const normalized = normalizeWbsInstance(value);
+  if (WBS_CODEX_LEGACY_INSTANCES.includes(normalized)) return "codex";
+  if (WBS_AUTOMATION_LEGACY_INSTANCES.includes(normalized)) return "automation";
+  if (normalized === "user") return "user";
+  return "claude";
 }
 
 function mcpArgsForAction(
@@ -856,7 +885,7 @@ async function handleMcpFacade(
     const rawInstance = String(args.instance ?? "codex").trim().toLowerCase();
     const instance = rawInstance === "all"
       ? "all"
-      : normalizeWbsInstance(rawInstance);
+      : normalizeWbsActiveInstance(rawInstance);
     const includeCompleted = parseBooleanish(args.include_completed, false);
     const status = String(args.status ?? "").trim();
     const validStatuses = ["pending", "in_progress", "blocked", "completed"];
@@ -865,9 +894,6 @@ async function handleMcpFacade(
       .select(
         "id, category, title, description, instance, owner_instance, status, progress, end_date, priority, remaining_work, updated_at, github_issue_number, github_issue_url",
       );
-    if (instance !== "all") {
-      query = query.or(`instance.eq.${instance},owner_instance.eq.${instance}`);
-    }
     if (validStatuses.includes(status)) {
       query = query.eq("status", status);
     } else if (!includeCompleted) {
@@ -877,13 +903,17 @@ async function handleMcpFacade(
     const { data, error } = await query;
     if (error) throw new Error(error.message);
 
-    const tasks = [...(data ?? [])].sort(compareWbsTasks).slice(0, limit);
+    const filtered = [...(data ?? [])].filter((task) =>
+      wbsTaskMatchesInstanceFilter(task, rawInstance)
+    );
+    const tasks = filtered.sort(compareWbsTasks).slice(0, limit);
     await logMcpInvocation(auth.ctx, toolName, args, 200, req);
     return mcpToolResponse(body, {
       success: true,
       tool: toolName,
       structuredContent: {
         count: tasks.length,
+        total: filtered.length,
         instance,
         tasks,
       },
@@ -1281,7 +1311,28 @@ function pickGithubIssueWbsKeeper(
 }
 
 function wbsTaskLane(task: Record<string, unknown>): string {
-  return normalizeWbsInstance(task.owner_instance ?? task.instance);
+  return normalizeWbsActiveInstance(task.owner_instance ?? task.instance);
+}
+
+function wbsTaskMatchesInstanceFilter(
+  task: Record<string, unknown>,
+  rawInstance: unknown,
+): boolean {
+  const raw = String(rawInstance ?? "").trim().toLowerCase();
+  if (!raw || raw === "all") return true;
+  if (
+    WBS_ACTIVE_INSTANCE_VALUES.includes(raw) ||
+    raw === "claude-code" ||
+    raw === "claude-code-1" ||
+    raw === "automation" ||
+    raw === "auto"
+  ) {
+    return wbsTaskLane(task) === normalizeWbsActiveInstance(raw);
+  }
+  const legacyInstance = normalizeWbsInstance(raw);
+  return normalizeWbsInstance(task.instance) === legacyInstance ||
+    normalizeWbsInstance(task.owner_instance ?? task.instance) ===
+      legacyInstance;
 }
 
 function wbsDeadline(task: Record<string, unknown>): string {
@@ -1319,7 +1370,7 @@ function wbsRescueScore(task: Record<string, unknown>, now: Date): number {
 
 function buildWbsWorkload(tasks: Array<Record<string, unknown>>, now: Date) {
   const today = new Date(now.toISOString().slice(0, 10));
-  const workload = WBS_INSTANCE_VALUES.map((instance) => {
+  const workload = WBS_ACTIVE_INSTANCE_VALUES.map((instance) => {
     const laneTasks = tasks.filter((task) => wbsTaskLane(task) === instance);
     const openTasks = laneTasks.filter((task) =>
       WBS_OPEN_STATUSES.includes(String(task.status ?? ""))
@@ -5680,7 +5731,7 @@ serve(async (req) => {
         // ─── WBS (Work Breakdown Structure) actions (Win版#128) ─────────
         case "wbs.list_tasks": {
           // インスタンス + status でフィルタしてタスク一覧取得
-          // body: { instance?: 'codex'|'vscode'|'win'|'ps1'..'ps6'|'web'|'mobile'|'schedule'|'gha',
+          // body: { instance?: 'all'|'claude'|'codex'|'user'|'automation' (legacy lanes are still accepted),
           //        status?: 'pending'|'in_progress'|'completed'|'blocked',
           //        updated_since?: 'YYYY-MM-DDTHH:MM:SSZ' (ISO-8601),
           //        limit?: 50 }
@@ -5692,14 +5743,17 @@ serve(async (req) => {
             .select(
               "id, category, category_icon, category_order, title, description, instance, owner_instance, status, progress, start_date, end_date, planned_end_date, milestone_code, priority, remaining_work, updated_at, github_issue_number, github_issue_url, github_issue_state, github_issue_labels, github_issue_synced_at",
             );
-          if (inst && inst !== "all") {
-            q = q.eq("instance", inst);
-          }
           if (status) q = q.eq("status", status);
           if (updatedSince) q = q.gte("updated_at", updatedSince);
           const { data, error } = await q;
           if (error) throw new Error(error.message);
-          const sortedTasks = [...(data ?? [])].sort(compareWbsTasks).slice(
+          const filteredTasks = [...(data ?? [])].filter((task) =>
+            wbsTaskMatchesInstanceFilter(
+              task as Record<string, unknown>,
+              inst ?? "all",
+            )
+          );
+          const sortedTasks = filteredTasks.sort(compareWbsTasks).slice(
             0,
             limit,
           );
@@ -5710,7 +5764,7 @@ serve(async (req) => {
             success: true,
             tasks: sortedTasks,
             milestones: milestones ?? [],
-            total: data?.length ?? 0,
+            total: filteredTasks.length,
           });
         }
         case "wbs.update_progress": {
@@ -6813,24 +6867,32 @@ serve(async (req) => {
         case "wbs.priority_for_instance": {
           // 指定インスタンスの優先タスク TOP 5 を返す (session-start-check 用)
           // 担当なしの場合は他 instance の滞留タスクを自担当へ救援 reassign する。
-          // body: { instance: 'codex'|'vscode'|'win'|'ps1'..'ps6'|'web'|'mobile'|'schedule'|'gha',
+          // body: { instance: 'claude'|'codex'|'user'|'automation' (legacy lanes are still accepted),
           //         auto_reassign?: true, limit?: 5 }
           const rawInstance = String(body.instance ?? "").trim();
           if (!rawInstance) return json({ error: "instance required" }, 400);
           const rawInstanceLower = rawInstance.toLowerCase();
           if (
             !WBS_INSTANCE_VALUES.includes(rawInstanceLower) &&
-            !["windows", "ps", "copilot", "github-copilot"].includes(
-              rawInstanceLower,
-            )
+            !WBS_ACTIVE_INSTANCE_VALUES.includes(rawInstanceLower) &&
+            ![
+              "windows",
+              "ps",
+              "copilot",
+              "github-copilot",
+              "claude-code",
+              "claude-code-1",
+              "automation",
+              "auto",
+            ].includes(rawInstanceLower)
           ) {
             return json({
               error: `instance must be one of: ${
-                WBS_INSTANCE_VALUES.join(", ")
+                WBS_ACTIVE_INSTANCE_VALUES.join(", ")
               }`,
             }, 400);
           }
-          const inst = normalizeWbsInstance(rawInstance);
+          const inst = normalizeWbsActiveInstance(rawInstance);
           const limit = Math.min(Math.max(Number(body.limit ?? 5), 1), 20);
           const autoReassign = parseBooleanish(
             body.auto_reassign ?? body.autoReassign,
@@ -6840,11 +6902,15 @@ serve(async (req) => {
             "id, category, category_order, title, status, progress, priority, end_date, planned_end_date, updated_at, instance, owner_instance, recovery_plan, github_issue_number, github_issue_url, github_issue_state, github_issue_synced_at";
           const { data, error } = await admin.from("wbs_tasks")
             .select(taskSelect)
-            .eq("instance", inst)
             .in("status", ["pending", "in_progress", "blocked"]);
           if (error) throw new Error(error.message);
           const ownTaskFilter = filterClosedGithubIssueWbsTasks(
-            [...(data ?? [])] as Array<Record<string, unknown>>,
+            [...(data ?? [])].filter((task) =>
+              wbsTaskMatchesInstanceFilter(
+                task as Record<string, unknown>,
+                rawInstance,
+              )
+            ) as Array<Record<string, unknown>>,
           );
           let topTasks = ownTaskFilter.activeTasks
             .sort(compareWbsTasks)
@@ -6866,12 +6932,13 @@ serve(async (req) => {
           );
           let reassignedTask: Record<string, unknown> | null = null;
 
-          if (topTasks.length === 0 && autoReassign) {
+          if (topTasks.length === 0 && autoReassign && inst !== "automation") {
             const candidate = pickWbsRescueCandidate(openTasks, inst, now);
             if (candidate) {
+              const legacyTarget = normalizeWbsInstance(rawInstance);
               const update: Record<string, unknown> = {
-                instance: inst,
-                owner_instance: inst,
+                instance: legacyTarget,
+                owner_instance: legacyTarget,
               };
               const needsRecoveryPlan = wbsOverdueDays(
                     candidate,
@@ -6979,7 +7046,7 @@ serve(async (req) => {
           return json({
             success: true,
             instance: body.instance
-              ? normalizeWbsInstance(body.instance)
+              ? normalizeWbsActiveInstance(body.instance)
               : null,
             workload: buildWbsWorkload(openTasks, now),
             rebalance_suggestions: buildWbsRebalanceSuggestions(openTasks, now),
@@ -6996,25 +7063,38 @@ serve(async (req) => {
           const myInstance = String(body.my_instance ?? "");
           const limitN = Math.min(Number(body.limit ?? 5), 20);
           if (!myInstance) return json({ error: "my_instance required" }, 400);
+          const myActiveInstance = normalizeWbsActiveInstance(myInstance);
 
           // 1. 自 instance の active task 数 fetch
-          const { count: myActiveCount } = await admin.from("wbs_tasks")
-            .select("id", { count: "exact", head: true })
-            .eq("instance", myInstance)
+          const { data: myActiveRaw, error: myActiveErr } = await admin.from(
+            "wbs_tasks",
+          )
+            .select("id, instance, owner_instance")
             .in("status", ["pending", "in_progress", "blocked"]);
+          if (myActiveErr) throw new Error(myActiveErr.message);
+          const myActiveCount = [...(myActiveRaw ?? [])].filter((task) =>
+            wbsTaskMatchesInstanceFilter(
+              task as Record<string, unknown>,
+              myActiveInstance,
+            )
+          ).length;
 
           // 2. 他 instance の active task 取得 (rebalance 候補)
           const { data: otherTasks, error } = await admin.from("wbs_tasks")
             .select(
               "id, category, title, instance, owner_instance, status, progress, priority, end_date, updated_at, last_rebalanced_at, github_issue_number, github_issue_url, github_issue_state, github_issue_synced_at",
             )
-            .neq("instance", myInstance)
             .in("status", ["pending", "in_progress", "blocked"])
             .neq("priority", "completed")
             .limit(200);
           if (error) throw new Error(error.message);
           const otherTaskFilter = filterClosedGithubIssueWbsTasks(
-            [...(otherTasks ?? [])] as Array<Record<string, unknown>>,
+            [...(otherTasks ?? [])].filter((task) =>
+              !wbsTaskMatchesInstanceFilter(
+                task as Record<string, unknown>,
+                myActiveInstance,
+              )
+            ) as Array<Record<string, unknown>>,
           );
 
           // 3. 抑制ルール: PS 専任 / IPO 専決 / 期限直前は除外
@@ -7120,7 +7200,8 @@ serve(async (req) => {
           return json({
             success: true,
             my_instance: myInstance,
-            my_active_count: myActiveCount ?? 0,
+            my_active_instance: myActiveInstance,
+            my_active_count: myActiveCount,
             candidates,
             closed_issue_exclusions: {
               total_count: otherTaskFilter.excludedTasks.length,


### PR DESCRIPTION
## Summary

Closes #1982.

- Projects historical WBS lanes into the active 2-instance operating model: Claude Code #1, Codex #1, User, and Automation.
- Updates the WBS UI filter chips and tools-hub WBS APIs/workload logic so old VS/Win/PS/Gemini/Copilot lanes no longer appear as active human development lanes.
- Adds a reusable two-instance routing audit script, a GitHub Actions check, and a generated 2026-05-05 audit report so old 12-fleet / Codex#2 / PS#1-6 references remain clearly legacy.

## Impact

New sessions should route work to exactly one Claude Code Windows app instance and one Codex Windows app instance. Existing historical `instance` and `owner_instance` values are preserved in the database, but active WBS views and priority queries project them into the four current lanes.

## Validation

- `dart format lib/pages/project_gantt_page.dart`
- `dart analyze lib/pages/project_gantt_page.dart`
- `deno lint supabase/functions/tools-hub/index.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/tools-hub/index.ts`
- `python scripts/two_instance_audit.py --fail-on-active --output docs/two-instance-audit/2026-05-05.md`
- `git diff --cached --check`

`deno fmt supabase/functions/tools-hub/index.ts` was attempted, but Deno reported `Formatting not stable` for this existing large file. Lint and type check passed.

## Minimal E2E Gate

Black-box, implementation independent check plan: minimal 3 cases via the existing public Playwright smoke path after deploy: WBS timeline loads, active lane chips are limited to All/Claude Code/Codex/User/Automation, and selecting Codex or Automation returns tasks without exposing old PS# lanes as visible filters.

E2E-Exception: this PR does not add a new dedicated `test/e2e/` file because the change is primarily WBS lane projection plus docs/workflow audit, and the repository-level Public E2E stability smoke already runs Playwright on every PR.