### PR TITLE
feat(billing): add Stripe freemium foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,22 @@ FIREBASE_HOSTING_SITE=your_firebase_hosting_site_here
 GOOGLE_AI_API_KEY=your_google_ai_api_key_here
 
 # ================================
+# Stripe Billing Configuration
+# ================================
+# Secret key used only by Supabase Edge Functions
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key_here
+
+# Webhook signing secret for supabase/functions/stripe-webhook
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
+
+# Stripe recurring price IDs used by schedule-hub billing actions
+STRIPE_PRO_PRICE_ID=price_your_pro_monthly_price_id_here
+STRIPE_TEAM_PRICE_ID=price_your_team_monthly_price_id_here
+
+# Public app base URL used for Stripe return URLs
+PUBLIC_SITE_URL=https://my-web-app-b6f7f4.web.app
+
+# ================================
 # Environment Identifier
 # ================================
 # Environment name: development, staging, production

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -584,6 +584,7 @@ jobs:
           deploy_function admin-hub --no-verify-jwt
           deploy_function app-hub --no-verify-jwt
           deploy_function schedule-hub --no-verify-jwt
+          deploy_function stripe-webhook --no-verify-jwt
 
           # --- Mega-Hub (5本: 旧Tier2全統合) ---
           deploy_function tools-hub --no-verify-jwt
@@ -599,7 +600,7 @@ jobs:
           deploy_function viral-video-ad-generator --no-verify-jwt
           deploy_function memory-search-hub --no-verify-jwt
 
-          # Total: 20 functions deployed (ハードキャップ50本に対し20本 — 余裕30本)
+          # Total: 21 functions deployed (ハードキャップ50本に対し21本 — 余裕29本)
           # memo-reactions → core-hub に統合済み (b4c91bc2 2026-04-24)
           #
           # Hub対応表:
@@ -781,7 +782,7 @@ jobs:
             echo "| コミット | \`${SHA}\` |"
             echo "| Actor | ${{ github.actor }} |"
             echo "| 本番URL | https://my-web-app-b67f4.web.app/ |"
-            echo "| Edge Functions | 15本デプロイ済み (ハードキャップ50本以下) |"
+            echo "| Edge Functions | 21本デプロイ済み (ハードキャップ50本以下) |"
           } >> $GITHUB_STEP_SUMMARY
 
   # -----------------------------------------------------------------

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1131,6 +1131,10 @@ class _MyAppState extends State<MyApp> {
             return MaterialPageRoute(
               builder: (_) => const SubscriptionBillingPage(),
             );
+          case '/billing':
+            return MaterialPageRoute(
+              builder: (_) => const SubscriptionBillingPage(),
+            );
           case '/appointment-scheduler':
             return MaterialPageRoute(
               builder: (_) => const AppointmentSchedulerPage(),

--- a/lib/pages/subscription_billing_page.dart
+++ b/lib/pages/subscription_billing_page.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
 
+import '../services/billing_service.dart';
 import '../widgets/paddle_approval_readiness_card.dart';
 
-/// サブスクリプション請求ページ
-/// subscription-billing Edge Function と連携して請求情報を管理
 class SubscriptionBillingPage extends StatefulWidget {
   const SubscriptionBillingPage({super.key});
 
@@ -14,11 +13,11 @@ class SubscriptionBillingPage extends StatefulWidget {
 }
 
 class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
-  final _supabase = Supabase.instance.client;
-  bool _isLoading = false;
+  final _service = BillingService();
+  bool _isLoading = true;
+  bool _isOpeningStripe = false;
   String? _errorMessage;
-  Map<String, dynamic>? _billingInfo;
-  List<dynamic> _invoices = [];
+  BillingStatus? _status;
 
   @override
   void initState() {
@@ -27,42 +26,81 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
   }
 
   Future<void> _fetchBillingInfo() async {
-    if (_supabase.auth.currentUser == null) {
-      setState(() => _isLoading = false);
-      return;
-    }
     setState(() {
       _isLoading = true;
       _errorMessage = null;
     });
     try {
-      final response = await _supabase.functions.invoke(
-        'app-hub',
-        body: {'action': 'billing.status'},
-      );
-      final data = response.data;
-      if (data is Map<String, dynamic>) {
-        setState(() {
-          _billingInfo = data['billing'] as Map<String, dynamic>?;
-          _invoices = data['invoices'] as List? ?? [];
-        });
-      }
+      final status = await _service.fetchStatus();
+      if (mounted) setState(() => _status = status);
     } catch (e) {
       if (mounted) {
-        setState(() => _errorMessage = '請求情報の取得に失敗しました: $e');
+        setState(() => _errorMessage = '課金情報の取得に失敗しました: $e');
       }
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }
   }
 
+  Future<void> _openCheckout(String tier) async {
+    await _openStripeSession(() {
+      return _service.createCheckoutSession(
+        tier: tier,
+        returnUrl: _currentReturnUrl,
+      );
+    });
+  }
+
+  Future<void> _openPortal() async {
+    await _openStripeSession(() {
+      return _service.createPortalSession(returnUrl: _currentReturnUrl);
+    });
+  }
+
+  Future<void> _openStripeSession(
+    Future<dynamic> Function() createSession,
+  ) async {
+    setState(() {
+      _isOpeningStripe = true;
+      _errorMessage = null;
+    });
+    try {
+      final session = await createSession();
+      final url = (session as dynamic).url as String;
+      final uri = Uri.parse(url);
+      if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+        throw BillingServiceException('Stripe URL を開けませんでした');
+      }
+    } catch (e) {
+      if (mounted) setState(() => _errorMessage = 'Stripe連携に失敗しました: $e');
+    } finally {
+      if (mounted) setState(() => _isOpeningStripe = false);
+    }
+  }
+
+  String get _currentReturnUrl {
+    final uri = Uri.base;
+    if (uri.hasScheme && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return uri.replace(path: '/subscription-billing', query: '').toString();
+    }
+    return 'https://my-web-app-b6f7f4.web.app/subscription-billing';
+  }
+
   @override
   Widget build(BuildContext context) {
+    final status = _status ??
+        const BillingStatus(
+          tier: 'free',
+          status: 'active',
+          aiQueryCount: 0,
+          efCallCount: 0,
+        );
     return Scaffold(
       appBar: AppBar(
-        title: const Text('サブスクリプション・請求'),
+        title: const Text('サブスクリプション・課金'),
         actions: [
           IconButton(
+            tooltip: '更新',
             icon: const Icon(Icons.refresh),
             onPressed: _fetchBillingInfo,
           ),
@@ -75,17 +113,7 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  if (_errorMessage != null)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 12),
-                      child: Text(
-                        _errorMessage!,
-                        style: const TextStyle(
-                          color: Color(0xFFE53935),
-                          height: 1.5,
-                        ),
-                      ),
-                    ),
+                  if (_errorMessage != null) _ErrorBanner(_errorMessage!),
                   PaddleApprovalReadinessCard(
                     compact: true,
                     touchesRegulatedData: true,
@@ -94,112 +122,280 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
                     },
                   ),
                   const SizedBox(height: 16),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            '現在のプラン',
-                            style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold,
-                              height: 1.5,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          if (_billingInfo != null) ...[
-                            _infoRow(
-                              'プラン',
-                              _billingInfo!['plan']?.toString() ?? 'Free',
-                            ),
-                            _infoRow(
-                              'ステータス',
-                              _billingInfo!['status']?.toString() ?? '-',
-                            ),
-                            _infoRow(
-                              '次回更新日',
-                              _billingInfo!['next_billing_date']?.toString() ??
-                                  '-',
-                            ),
-                          ] else
-                            const Text('プラン情報なし'),
-                        ],
-                      ),
-                    ),
+                  _CurrentPlanCard(status: status, onOpenPortal: _openPortal),
+                  const SizedBox(height: 16),
+                  _PlanGrid(
+                    currentTier: status.tier,
+                    isBusy: _isOpeningStripe,
+                    onUpgrade: _openCheckout,
                   ),
                   const SizedBox(height: 16),
-                  const Text(
-                    '請求履歴',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                      height: 1.5,
-                    ),
-                  ),
-                  const Divider(),
-                  if (_invoices.isEmpty)
-                    const Center(
-                      child: Padding(
-                        padding: EdgeInsets.all(16),
-                        child: Text('請求履歴はありません'),
-                      ),
-                    )
-                  else
-                    ListView.builder(
-                      shrinkWrap: true,
-                      physics: const NeverScrollableScrollPhysics(),
-                      itemCount: _invoices.length,
-                      itemBuilder: (context, index) {
-                        final invoice = _invoices[index];
-                        final amount =
-                            invoice is Map ? (invoice['amount'] ?? '-') : '-';
-                        final date = invoice is Map
-                            ? (invoice['date'] ?? invoice['created_at'] ?? '-')
-                            : '-';
-                        final status =
-                            invoice is Map ? (invoice['status'] ?? '-') : '-';
-                        return Card(
-                          margin: const EdgeInsets.symmetric(vertical: 4),
-                          child: ListTile(
-                            leading: const Icon(Icons.receipt_outlined),
-                            title: Text('¥$amount'),
-                            subtitle: Text(date.toString()),
-                            trailing: Chip(
-                              label: Text(status.toString()),
-                              backgroundColor: status.toString() == 'paid'
-                                  ? const Color(0xFFC8E6C9)
-                                  : const Color(0xFFFFE0B2),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
+                  _UsageCard(status: status),
+                  const SizedBox(height: 16),
+                  const _SetupNoticeCard(),
                 ],
               ),
             ),
     );
   }
+}
 
-  Widget _infoRow(String label, String value) {
+class _ErrorBanner extends StatelessWidget {
+  const _ErrorBanner(this.message);
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFEBEE),
+        border: Border.all(color: const Color(0xFFE57373)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(message, style: const TextStyle(color: Color(0xFFC62828))),
+    );
+  }
+}
+
+class _CurrentPlanCard extends StatelessWidget {
+  const _CurrentPlanCard({required this.status, required this.onOpenPortal});
+
+  final BillingStatus status;
+  final VoidCallback onOpenPortal;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.workspace_premium_outlined),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    '現在のプラン',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: status.isPro ? onOpenPortal : null,
+                  icon: const Icon(Icons.manage_accounts_outlined),
+                  label: const Text('管理'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                Chip(label: Text(status.tier.toUpperCase())),
+                Chip(label: Text(status.status)),
+                if (status.currentPeriodEnd != null)
+                  Chip(
+                    label: Text(
+                      '次回更新 ${_formatDate(status.currentPeriodEnd!)}',
+                    ),
+                  ),
+                if (status.cancelAtPeriodEnd)
+                  const Chip(label: Text('期間末で解約予定')),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PlanGrid extends StatelessWidget {
+  const _PlanGrid({
+    required this.currentTier,
+    required this.isBusy,
+    required this.onUpgrade,
+  });
+
+  final String currentTier;
+  final bool isBusy;
+  final Future<void> Function(String tier) onUpgrade;
+
+  @override
+  Widget build(BuildContext context) {
+    const plans = [
+      _Plan('free', 'Free', '¥0', 'AI質問 30回/月・基本機能'),
+      _Plan('pro', 'Pro', '¥980/月', '無制限利用・AI大学フル機能・優先処理'),
+      _Plan('team', 'Team', '¥2,980/席', 'チーム共有・監査ログ・高度な自動化'),
+    ];
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final columns = constraints.maxWidth >= 900
+            ? 3
+            : constraints.maxWidth >= 620
+                ? 2
+                : 1;
+        return GridView.count(
+          crossAxisCount: columns,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          crossAxisSpacing: 12,
+          mainAxisSpacing: 12,
+          childAspectRatio: columns == 1 ? 2.8 : 1.45,
+          children: [
+            for (final plan in plans)
+              _PlanCard(
+                plan: plan,
+                isCurrent: currentTier == plan.tier,
+                isBusy: isBusy,
+                onUpgrade: () => onUpgrade(plan.tier),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _PlanCard extends StatelessWidget {
+  const _PlanCard({
+    required this.plan,
+    required this.isCurrent,
+    required this.isBusy,
+    required this.onUpgrade,
+  });
+
+  final _Plan plan;
+  final bool isCurrent;
+  final bool isBusy;
+  final VoidCallback onUpgrade;
+
+  @override
+  Widget build(BuildContext context) {
+    final isFree = plan.tier == 'free';
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(isFree ? Icons.spa_outlined : Icons.auto_awesome),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    plan.name,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                if (isCurrent) const Chip(label: Text('利用中')),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              plan.price,
+              style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Expanded(child: Text(plan.description)),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: isFree || isCurrent || isBusy ? null : onUpgrade,
+                icon: isBusy
+                    ? const SizedBox.square(
+                        dimension: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.lock_open_outlined),
+                label: Text(isCurrent ? '現在のプラン' : 'Stripeで開始'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UsageCard extends StatelessWidget {
+  const _UsageCard({required this.status});
+
+  final BillingStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '今月の利用量',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            _metric('AI質問', '${status.aiQueryCount} 回'),
+            _metric('Edge Function 呼び出し', '${status.efCallCount} 回'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _metric(String label, String value) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Row(
         children: [
-          SizedBox(
-            width: 100,
-            child: Text(
-              label,
-              style: const TextStyle(
-                color: Color(0xFFB0B0B0),
-                height: 1.5,
-              ),
-            ),
-          ),
-          Expanded(child: Text(value)),
+          Expanded(child: Text(label)),
+          Text(value, style: const TextStyle(fontWeight: FontWeight.bold)),
         ],
       ),
     );
   }
+}
+
+class _SetupNoticeCard extends StatelessWidget {
+  const _SetupNoticeCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Card(
+      child: Padding(
+        padding: EdgeInsets.all(16),
+        child: Text(
+          'Stripe本番連携には Supabase secrets に STRIPE_SECRET_KEY、'
+          'STRIPE_WEBHOOK_SECRET、STRIPE_PRO_PRICE_ID を設定してください。',
+        ),
+      ),
+    );
+  }
+}
+
+class _Plan {
+  const _Plan(this.tier, this.name, this.price, this.description);
+
+  final String tier;
+  final String name;
+  final String price;
+  final String description;
+}
+
+String _formatDate(DateTime date) {
+  final local = date.toLocal();
+  return '${local.year}/${local.month.toString().padLeft(2, '0')}/'
+      '${local.day.toString().padLeft(2, '0')}';
 }

--- a/lib/services/billing_service.dart
+++ b/lib/services/billing_service.dart
@@ -1,0 +1,141 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class BillingServiceException implements Exception {
+  BillingServiceException(this.message, {this.statusCode});
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() => 'BillingServiceException($statusCode): $message';
+}
+
+class BillingStatus {
+  const BillingStatus({
+    required this.tier,
+    required this.status,
+    required this.aiQueryCount,
+    required this.efCallCount,
+    this.currentPeriodEnd,
+    this.cancelAtPeriodEnd = false,
+  });
+
+  final String tier;
+  final String status;
+  final int aiQueryCount;
+  final int efCallCount;
+  final DateTime? currentPeriodEnd;
+  final bool cancelAtPeriodEnd;
+
+  bool get isPro => tier == 'pro' || tier == 'team';
+
+  factory BillingStatus.fromJson(Map<String, dynamic> json) {
+    final billing = _asMap(json['billing']);
+    final usage = _asMap(json['usage']);
+    return BillingStatus(
+      tier: billing['tier']?.toString() ?? 'free',
+      status: billing['status']?.toString() ?? 'active',
+      aiQueryCount: _asInt(usage['ai_query_count']),
+      efCallCount: _asInt(usage['ef_call_count']),
+      currentPeriodEnd: _parseDate(billing['current_period_end']),
+      cancelAtPeriodEnd: billing['cancel_at_period_end'] == true,
+    );
+  }
+}
+
+class BillingCheckoutSession {
+  const BillingCheckoutSession({required this.url, this.id});
+
+  final String url;
+  final String? id;
+
+  factory BillingCheckoutSession.fromJson(Map<String, dynamic> json) {
+    final url = json['checkout_url']?.toString() ?? '';
+    if (url.isEmpty) {
+      throw BillingServiceException('Stripe Checkout URL が返されませんでした');
+    }
+    return BillingCheckoutSession(url: url, id: json['id']?.toString());
+  }
+}
+
+class BillingPortalSession {
+  const BillingPortalSession({required this.url, this.id});
+
+  final String url;
+  final String? id;
+
+  factory BillingPortalSession.fromJson(Map<String, dynamic> json) {
+    final url = json['portal_url']?.toString() ?? '';
+    if (url.isEmpty) {
+      throw BillingServiceException('Stripe Portal URL が返されませんでした');
+    }
+    return BillingPortalSession(url: url, id: json['id']?.toString());
+  }
+}
+
+class BillingService {
+  BillingService({SupabaseClient? client})
+      : _client = client ?? Supabase.instance.client;
+
+  final SupabaseClient _client;
+
+  Future<BillingStatus> fetchStatus() async {
+    final data = await _invokeBillingAction('billing.status', {});
+    return BillingStatus.fromJson(data);
+  }
+
+  Future<BillingCheckoutSession> createCheckoutSession({
+    required String tier,
+    required String returnUrl,
+  }) async {
+    final data = await _invokeBillingAction('billing.create_checkout_session', {
+      'tier': tier,
+      'return_url': returnUrl,
+    });
+    return BillingCheckoutSession.fromJson(data);
+  }
+
+  Future<BillingPortalSession> createPortalSession({
+    required String returnUrl,
+  }) async {
+    final data = await _invokeBillingAction('billing.create_portal_session', {
+      'return_url': returnUrl,
+    });
+    return BillingPortalSession.fromJson(data);
+  }
+
+  Future<Map<String, dynamic>> _invokeBillingAction(
+    String action,
+    Map<String, dynamic> params,
+  ) async {
+    final res = await _client.functions.invoke(
+      'schedule-hub',
+      body: {'action': action, ...params},
+    );
+    final data = _asMap(res.data);
+    if (res.status != 200 || data['success'] == false) {
+      final message = data['error']?.toString() ?? 'HTTP ${res.status}';
+      throw BillingServiceException(message, statusCode: res.status);
+    }
+    return data;
+  }
+}
+
+Map<String, dynamic> _asMap(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) {
+    return value.map((key, val) => MapEntry(key.toString(), val));
+  }
+  return <String, dynamic>{};
+}
+
+int _asInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.round();
+  return int.tryParse(value?.toString() ?? '') ?? 0;
+}
+
+DateTime? _parseDate(Object? value) {
+  final text = value?.toString();
+  return text == null || text.isEmpty ? null : DateTime.tryParse(text);
+}

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -121,6 +121,121 @@ function asStringList(value: unknown, fallback: string[]): string[] {
     : fallback;
 }
 
+function billingPriceId(tier: string): string {
+  const normalized = tier === "team" ? "TEAM" : "PRO";
+  return Deno.env.get(`STRIPE_${normalized}_PRICE_ID`) ??
+    Deno.env.get(`STRIPE_PRICE_${normalized}`) ??
+    "";
+}
+
+function stripeSecretKey(): string {
+  return Deno.env.get("STRIPE_SECRET_KEY") ?? "";
+}
+
+function normalizeCheckoutTier(value: unknown): "pro" | "team" {
+  return String(value ?? "pro").toLowerCase() === "team" ? "team" : "pro";
+}
+
+function currentBillingPeriodStart(): string {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+    .toISOString()
+    .slice(0, 10);
+}
+
+function billingReturnUrl(value: unknown, fallbackPath: string): string {
+  const raw = asString(value);
+  if (raw) {
+    try {
+      const url = new URL(raw);
+      if (url.protocol === "http:" || url.protocol === "https:") {
+        return url.toString();
+      }
+    } catch {
+      // Fall through to the deployment fallback.
+    }
+  }
+  const base = Deno.env.get("PUBLIC_SITE_URL") ??
+    Deno.env.get("SITE_URL") ??
+    "https://my-web-app-b6f7f4.web.app";
+  return new URL(fallbackPath, base).toString();
+}
+
+function withBillingParam(url: string, value: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("billing", value);
+  return parsed.toString();
+}
+
+async function stripePostForm(
+  path: string,
+  params: Record<string, string>,
+): Promise<Record<string, unknown>> {
+  const key = stripeSecretKey();
+  if (!key) {
+    throw new Error("STRIPE_SECRET_KEY not configured");
+  }
+  const response = await fetch(`https://api.stripe.com/v1${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams(params),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const err = asRecord(data.error) ?? {};
+    throw new Error(
+      asString(err.message) || `Stripe API failed: ${response.status}`,
+    );
+  }
+  return asRecord(data) ?? {};
+}
+
+async function getBillingSubscription(
+  admin: SupabaseClient,
+  userId: string,
+): Promise<Record<string, unknown> | null> {
+  const { data, error } = await admin
+    .from("billing_subscriptions")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return asRecord(data);
+}
+
+async function getOrCreateStripeCustomer(
+  admin: SupabaseClient,
+  userId: string,
+): Promise<string> {
+  const current = await getBillingSubscription(admin, userId);
+  const existingCustomer = asString(current?.stripe_customer_id);
+  if (existingCustomer) return existingCustomer;
+
+  const { data: userData, error: userError } = await admin.auth.admin
+    .getUserById(userId);
+  if (userError) throw new Error(userError.message);
+
+  const customer = await stripePostForm("/customers", {
+    email: userData.user?.email ?? "",
+    "metadata[user_id]": userId,
+  });
+  const customerId = asString(customer.id);
+  if (!customerId) throw new Error("Stripe customer id missing");
+
+  const { error } = await admin.from("billing_subscriptions").upsert({
+    user_id: userId,
+    stripe_customer_id: customerId,
+    tier: asString(current?.tier, "free"),
+    status: asString(current?.status, "active"),
+    metadata: { ...(asRecord(current?.metadata) ?? {}), source: "checkout" },
+  }, { onConflict: "user_id" });
+  if (error) throw new Error(error.message);
+  return customerId;
+}
+
 function defaultNewsSignalFeeds(): Array<Record<string, string>> {
   return [
     {
@@ -1379,6 +1494,84 @@ serve(async (req: Request) => {
     }
 
     switch (action) {
+      case "billing.status": {
+        const billing = await getBillingSubscription(admin, userId!);
+        const periodStart = currentBillingPeriodStart();
+        const { data: usage, error: usageError } = await admin
+          .from("billing_usage_counters")
+          .select("*")
+          .eq("user_id", userId!)
+          .eq("period_start", periodStart)
+          .maybeSingle();
+        if (usageError) throw new Error(usageError.message);
+        return json({
+          success: true,
+          billing: billing ?? {
+            user_id: userId,
+            tier: "free",
+            status: "active",
+            current_period_end: null,
+            cancel_at_period_end: false,
+          },
+          usage: usage ?? {
+            user_id: userId,
+            period_start: periodStart,
+            ai_query_count: 0,
+            ef_call_count: 0,
+          },
+        });
+      }
+
+      case "billing.create_checkout_session": {
+        const tier = normalizeCheckoutTier(body.tier);
+        const priceId = billingPriceId(tier);
+        if (!priceId) {
+          return json({
+            error: `STRIPE_${tier.toUpperCase()}_PRICE_ID not configured`,
+          }, 503);
+        }
+        const customerId = await getOrCreateStripeCustomer(admin, userId!);
+        const returnUrl = billingReturnUrl(
+          body.return_url,
+          "/subscription-billing",
+        );
+        const session = await stripePostForm("/checkout/sessions", {
+          mode: "subscription",
+          customer: customerId,
+          "line_items[0][price]": priceId,
+          "line_items[0][quantity]": "1",
+          success_url: withBillingParam(returnUrl, "success"),
+          cancel_url: withBillingParam(returnUrl, "cancel"),
+          allow_promotion_codes: "true",
+          "metadata[user_id]": userId!,
+          "metadata[tier]": tier,
+          "subscription_data[metadata][user_id]": userId!,
+          "subscription_data[metadata][tier]": tier,
+        });
+        return json({
+          success: true,
+          id: session.id,
+          checkout_url: session.url,
+        });
+      }
+
+      case "billing.create_portal_session": {
+        const customerId = await getOrCreateStripeCustomer(admin, userId!);
+        const returnUrl = billingReturnUrl(
+          body.return_url,
+          "/subscription-billing",
+        );
+        const session = await stripePostForm("/billing_portal/sessions", {
+          customer: customerId,
+          return_url: returnUrl,
+        });
+        return json({
+          success: true,
+          id: session.id,
+          portal_url: session.url,
+        });
+      }
+
       // ─── Digest ───────────────────────────────────────────────────────────────
       case "digest.run": {
         const today = new Date().toISOString().split("T")[0];

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,253 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SERVICE_ROLE_KEY = Deno.env.get("SERVICE_ROLE_KEY") ?? "";
+const STRIPE_SECRET_KEY = Deno.env.get("STRIPE_SECRET_KEY") ?? "";
+const STRIPE_WEBHOOK_SECRET = Deno.env.get("STRIPE_WEBHOOK_SECRET") ?? "";
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value.trim() : fallback;
+}
+
+function normalizeTier(value: unknown): "free" | "pro" | "team" {
+  const text = asString(value).toLowerCase();
+  if (text === "team") return "team";
+  if (text === "pro") return "pro";
+  return "free";
+}
+
+function normalizeStatus(value: unknown): string {
+  const text = asString(value, "active").toLowerCase();
+  return [
+      "active",
+      "past_due",
+      "canceled",
+      "trialing",
+      "incomplete",
+    ].includes(text)
+    ? text
+    : "active";
+}
+
+function currentPeriodEnd(value: unknown): string | null {
+  const seconds = Number(value ?? 0);
+  return Number.isFinite(seconds) && seconds > 0
+    ? new Date(seconds * 1000).toISOString()
+    : null;
+}
+
+function parseStripeSignature(header: string): {
+  timestamp: string;
+  signatures: string[];
+} {
+  const parts = header.split(",");
+  let timestamp = "";
+  const signatures: string[] = [];
+  for (const part of parts) {
+    const [key, value] = part.split("=", 2);
+    if (key === "t") timestamp = value ?? "";
+    if (key === "v1" && value) signatures.push(value);
+  }
+  return { timestamp, signatures };
+}
+
+async function hmacSha256Hex(secret: string, payload: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(payload),
+  );
+  return Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function safeEqualHex(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+  let diff = 0;
+  for (let index = 0; index < left.length; index++) {
+    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return diff === 0;
+}
+
+async function verifyStripeEvent(rawBody: string, signatureHeader: string) {
+  if (!STRIPE_WEBHOOK_SECRET) {
+    throw new Error("STRIPE_WEBHOOK_SECRET not configured");
+  }
+  const { timestamp, signatures } = parseStripeSignature(signatureHeader);
+  if (!timestamp || signatures.length === 0) {
+    throw new Error("invalid signature header");
+  }
+  const expected = await hmacSha256Hex(
+    STRIPE_WEBHOOK_SECRET,
+    `${timestamp}.${rawBody}`,
+  );
+  if (!signatures.some((sig) => safeEqualHex(sig, expected))) {
+    throw new Error("invalid signature");
+  }
+  return JSON.parse(rawBody) as Record<string, unknown>;
+}
+
+async function stripeGet(path: string): Promise<Record<string, unknown>> {
+  if (!STRIPE_SECRET_KEY) throw new Error("STRIPE_SECRET_KEY not configured");
+  const response = await fetch(`https://api.stripe.com/v1${path}`, {
+    headers: { Authorization: `Bearer ${STRIPE_SECRET_KEY}` },
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const err = asRecord(data.error) ?? {};
+    throw new Error(
+      asString(err.message) || `Stripe API failed: ${response.status}`,
+    );
+  }
+  return asRecord(data) ?? {};
+}
+
+async function userIdForCustomer(
+  admin: SupabaseClient,
+  customerId: string,
+): Promise<string> {
+  const { data, error } = await admin
+    .from("billing_subscriptions")
+    .select("user_id")
+    .eq("stripe_customer_id", customerId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return asString(asRecord(data)?.user_id);
+}
+
+async function upsertSubscriptionFromStripe(
+  admin: SupabaseClient,
+  subscription: Record<string, unknown>,
+  fallbackUserId = "",
+): Promise<void> {
+  const metadata = asRecord(subscription.metadata) ?? {};
+  const customerId = asString(subscription.customer);
+  const userId = asString(metadata.user_id) ||
+    fallbackUserId ||
+    await userIdForCustomer(admin, customerId);
+  if (!userId || !customerId) return;
+
+  const { error } = await admin.from("billing_subscriptions").upsert({
+    user_id: userId,
+    stripe_customer_id: customerId,
+    stripe_subscription_id: asString(subscription.id) || null,
+    tier: normalizeTier(metadata.tier),
+    status: normalizeStatus(subscription.status),
+    current_period_end: currentPeriodEnd(subscription.current_period_end),
+    cancel_at_period_end: subscription.cancel_at_period_end === true,
+    metadata: {
+      stripe_event_source: "stripe-webhook",
+      stripe_subscription_metadata: metadata,
+      latest_invoice: asString(subscription.latest_invoice),
+    },
+  }, { onConflict: "user_id" });
+  if (error) throw new Error(error.message);
+}
+
+async function handleCheckoutCompleted(
+  admin: SupabaseClient,
+  session: Record<string, unknown>,
+): Promise<void> {
+  const metadata = asRecord(session.metadata) ?? {};
+  const userId = asString(metadata.user_id);
+  const customerId = asString(session.customer);
+  const subscriptionId = asString(session.subscription);
+  if (!userId || !customerId) return;
+
+  const { error } = await admin.from("billing_subscriptions").upsert({
+    user_id: userId,
+    stripe_customer_id: customerId,
+    stripe_subscription_id: subscriptionId || null,
+    tier: normalizeTier(metadata.tier || "pro"),
+    status: "active",
+    metadata: {
+      stripe_event_source: "checkout.session.completed",
+      stripe_checkout_session_id: asString(session.id),
+    },
+  }, { onConflict: "user_id" });
+  if (error) throw new Error(error.message);
+
+  if (subscriptionId) {
+    const subscription = await stripeGet(`/subscriptions/${subscriptionId}`);
+    await upsertSubscriptionFromStripe(admin, subscription, userId);
+  }
+}
+
+async function markPastDue(
+  admin: SupabaseClient,
+  invoice: Record<string, unknown>,
+): Promise<void> {
+  const subscriptionId = asString(invoice.subscription);
+  const customerId = asString(invoice.customer);
+  let userId = "";
+  if (customerId) userId = await userIdForCustomer(admin, customerId);
+  if (!userId) return;
+
+  const { error } = await admin
+    .from("billing_subscriptions")
+    .update({
+      status: "past_due",
+      stripe_subscription_id: subscriptionId || undefined,
+      metadata: {
+        stripe_event_source: "invoice.payment_failed",
+        invoice_id: asString(invoice.id),
+      },
+    })
+    .eq("user_id", userId);
+  if (error) throw new Error(error.message);
+}
+
+serve(async (req: Request) => {
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+  try {
+    const signature = req.headers.get("stripe-signature") ?? "";
+    if (!signature) return json({ error: "missing stripe-signature" }, 400);
+    const rawBody = await req.text();
+    const event = await verifyStripeEvent(rawBody, signature);
+    const type = asString(event.type);
+    const data = asRecord(asRecord(event.data)?.object) ?? {};
+    const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+    if (type === "checkout.session.completed") {
+      await handleCheckoutCompleted(admin, data);
+    } else if (
+      type === "customer.subscription.created" ||
+      type === "customer.subscription.updated" ||
+      type === "customer.subscription.deleted"
+    ) {
+      await upsertSubscriptionFromStripe(admin, data);
+    } else if (type === "invoice.payment_failed") {
+      await markPastDue(admin, data);
+    }
+
+    return json({ received: true });
+  } catch (error) {
+    return json({
+      error: error instanceof Error ? error.message : String(error),
+    }, 400);
+  }
+});

--- a/supabase/migrations/20260505203000_create_billing_tables.sql
+++ b/supabase/migrations/20260505203000_create_billing_tables.sql
@@ -1,0 +1,64 @@
+-- Billing foundation for Stripe freemium rollout (#1305).
+
+create table if not exists public.billing_subscriptions (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  stripe_customer_id text unique,
+  stripe_subscription_id text unique,
+  tier text not null default 'free' check (tier in ('free', 'pro', 'team')),
+  status text not null default 'active'
+    check (status in ('active', 'past_due', 'canceled', 'trialing', 'incomplete')),
+  current_period_end timestamptz,
+  cancel_at_period_end boolean not null default false,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.billing_usage_counters (
+  user_id uuid references auth.users(id) on delete cascade,
+  period_start date not null,
+  ai_query_count integer not null default 0 check (ai_query_count >= 0),
+  ef_call_count integer not null default 0 check (ef_call_count >= 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, period_start)
+);
+
+create index if not exists billing_subscriptions_customer_idx
+  on public.billing_subscriptions (stripe_customer_id);
+
+create index if not exists billing_subscriptions_subscription_idx
+  on public.billing_subscriptions (stripe_subscription_id);
+
+create or replace function public.set_billing_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists billing_subscriptions_updated_at
+  on public.billing_subscriptions;
+create trigger billing_subscriptions_updated_at
+before update on public.billing_subscriptions
+for each row execute function public.set_billing_updated_at();
+
+drop trigger if exists billing_usage_counters_updated_at
+  on public.billing_usage_counters;
+create trigger billing_usage_counters_updated_at
+before update on public.billing_usage_counters
+for each row execute function public.set_billing_updated_at();
+
+alter table public.billing_subscriptions enable row level security;
+alter table public.billing_usage_counters enable row level security;
+
+drop policy if exists billing_sub_self_read on public.billing_subscriptions;
+create policy billing_sub_self_read on public.billing_subscriptions
+for select using (auth.uid() = user_id);
+
+drop policy if exists billing_usage_self_read on public.billing_usage_counters;
+create policy billing_usage_self_read on public.billing_usage_counters
+for select using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- Adds Supabase billing tables for Stripe-backed Free/Pro/Team subscriptions and monthly usage counters.
- Adds `schedule-hub` billing actions for current status, Stripe Checkout session creation, and Stripe Billing Portal session creation.
- Adds a dedicated `stripe-webhook` Edge Function with signature verification for checkout, subscription, and payment-failure events.
- Rebuilds `/subscription-billing` and adds `/billing` as a clean Flutter route using `BillingService`.
- Documents required Stripe secrets and deploys `stripe-webhook` in production deploy workflow.

## Scope / WBS
- Refs #1305
- 2-instance split: Claude Code #1 completed the design handoff; Codex #1 implemented the backend/API/UI slice.
- This intentionally does not close #1305 yet because Stripe Dashboard price IDs and Supabase secrets must be set in the live environment before production checkout can be verified.

## Validation
- `dart analyze lib/services/billing_service.dart lib/pages/subscription_billing_page.dart lib/main.dart`
- `deno lint --config supabase/functions/deno.json supabase/functions/schedule-hub/index.ts supabase/functions/stripe-webhook/index.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/schedule-hub/index.ts supabase/functions/stripe-webhook/index.ts`
- `git diff --cached --check`

## Minimal E2E Gate
The E2E test is implementation-detail independent: it verifies the public billing route, Stripe redirect, and database-visible subscription result rather than private method names, file structure, or helper implementation.

Smoke plan after secrets are configured:
1. Open `/billing` while signed in and confirm Free plan + usage counters render.
2. Click Pro upgrade and confirm Stripe Checkout URL opens.
3. Send a signed Stripe test webhook for `checkout.session.completed` and confirm `billing_subscriptions.tier = pro`.

E2E-Exception: Live Stripe checkout cannot be completed in CI without project-specific `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, and Stripe recurring price IDs.

## Remaining ops work
- Set Supabase secrets: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRO_PRICE_ID`, optional `STRIPE_TEAM_PRICE_ID`, `PUBLIC_SITE_URL`.
- Register the deployed `stripe-webhook` URL in the Stripe Dashboard.
- Run the three-case smoke test above and then close #1305.
