### PR TITLE
feat(maintenance): add planned outage mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,6 +62,7 @@ import 'package:my_web_app/pages/admin/feedback_list_page.dart';
 import 'package:my_web_app/pages/admin/quota_dashboard_page.dart';
 import 'package:my_web_app/pages/admin/blog_management_page.dart';
 import 'package:my_web_app/pages/admin/blog_draft_editor_page.dart';
+import 'package:my_web_app/pages/admin/maintenance_management_page.dart';
 import 'package:my_web_app/pages/blog_page.dart';
 import 'package:my_web_app/pages/home_insights_page.dart';
 import 'package:my_web_app/pages/life_goals_page.dart';
@@ -131,6 +132,7 @@ import 'package:my_web_app/pages/notifications_page.dart';
 import 'package:my_web_app/pages/wardrobe_page.dart';
 import 'package:my_web_app/services/gamification_service.dart';
 import 'package:my_web_app/services/growth_mission_service.dart';
+import 'package:my_web_app/widgets/maintenance_banner.dart';
 import 'package:my_web_app/widgets/universal_ai_share_shell.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -156,6 +158,7 @@ import 'package:my_web_app/pages/workflow_templates_page.dart';
 import 'package:my_web_app/pages/customer_feedback_page.dart';
 import 'package:my_web_app/pages/address_book_page.dart';
 import 'package:my_web_app/pages/subscription_billing_page.dart';
+import 'package:my_web_app/pages/maintenance_mode_page.dart';
 import 'package:my_web_app/pages/appointment_scheduler_page.dart';
 import 'package:my_web_app/pages/budget_financial_planner_page.dart';
 import 'package:my_web_app/pages/feature_flags_page.dart';
@@ -459,14 +462,18 @@ class _MyAppState extends State<MyApp> {
         return GlobalHeaderClockShell(
           child: UniversalAiShareShell(
             navigatorKey: _navigatorKey,
-            child: Column(
-              children: [
-                if (_showUpdateBanner)
-                  UpdateBanner(
-                    onDismiss: () => setState(() => _showUpdateBanner = false),
-                  ),
-                Expanded(child: child ?? const SizedBox.shrink()),
-              ],
+            child: MaintenanceShell(
+              routeListenable: universalAiShareRouteObserver.currentPage,
+              child: Column(
+                children: [
+                  if (_showUpdateBanner)
+                    UpdateBanner(
+                      onDismiss: () =>
+                          setState(() => _showUpdateBanner = false),
+                    ),
+                  Expanded(child: child ?? const SizedBox.shrink()),
+                ],
+              ),
             ),
           ),
         );
@@ -932,6 +939,14 @@ class _MyAppState extends State<MyApp> {
           case '/quota-dashboard':
             return MaterialPageRoute(
               builder: (_) => const QuotaDashboardPage(),
+            );
+          case '/admin/maintenance':
+            return MaterialPageRoute(
+              builder: (_) => const MaintenanceManagementPage(),
+            );
+          case '/maintenance':
+            return MaterialPageRoute(
+              builder: (_) => const MaintenanceModePage(),
             );
           case '/blog-management':
             return MaterialPageRoute(

--- a/lib/pages/admin/maintenance_management_page.dart
+++ b/lib/pages/admin/maintenance_management_page.dart
@@ -1,0 +1,500 @@
+import 'package:flutter/material.dart';
+import 'package:my_web_app/services/maintenance_service.dart';
+
+class MaintenanceManagementPage extends StatefulWidget {
+  const MaintenanceManagementPage({super.key, this.service});
+
+  final MaintenanceService? service;
+
+  @override
+  State<MaintenanceManagementPage> createState() =>
+      _MaintenanceManagementPageState();
+}
+
+class _MaintenanceManagementPageState extends State<MaintenanceManagementPage> {
+  late final MaintenanceService _service;
+  List<MaintenanceWindow> _windows = const [];
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? MaintenanceService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final rows = await _service.listWindows();
+      if (!mounted) return;
+      setState(() => _windows = rows);
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _error = error.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _openEditor([MaintenanceWindow? window]) async {
+    final saved = await showDialog<bool>(
+      context: context,
+      builder: (context) => _MaintenanceWindowDialog(
+        service: _service,
+        window: window,
+      ),
+    );
+    if (saved == true) _load();
+  }
+
+  Future<void> _delete(MaintenanceWindow window) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('計画停止を削除'),
+        content:
+            Text('${_formatDateTime(window.startsAt.toLocal())} の予定を削除しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('削除'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await _service.deleteWindow(window.id);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('削除しました')),
+    );
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('計画停止管理'),
+        actions: [
+          IconButton(
+            tooltip: '更新',
+            icon: const Icon(Icons.refresh),
+            onPressed: _load,
+          ),
+          IconButton(
+            tooltip: '追加',
+            icon: const Icon(Icons.add),
+            onPressed: () => _openEditor(),
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: _load,
+              child: ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  _SummaryCard(windows: _windows),
+                  const SizedBox(height: 16),
+                  if (_error != null)
+                    Card(
+                      color: Theme.of(context).colorScheme.errorContainer,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Text(_error!),
+                      ),
+                    ),
+                  if (_windows.isEmpty)
+                    const Card(
+                      child: Padding(
+                        padding: EdgeInsets.all(24),
+                        child: Text('登録済みの計画停止はありません。'),
+                      ),
+                    )
+                  else
+                    ..._windows.map(
+                      (window) => _WindowCard(
+                        window: window,
+                        onEdit: () => _openEditor(window),
+                        onDelete: () => _delete(window),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _openEditor(),
+        icon: const Icon(Icons.add),
+        label: const Text('計画停止を追加'),
+      ),
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({required this.windows});
+
+  final List<MaintenanceWindow> windows;
+
+  @override
+  Widget build(BuildContext context) {
+    final active = windows.where((window) => window.isActive).length;
+    final upcoming = windows
+        .where((window) => window.startsAt.isAfter(DateTime.now()))
+        .length;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Wrap(
+          spacing: 24,
+          runSpacing: 12,
+          children: [
+            _Metric(label: '登録', value: windows.length.toString()),
+            _Metric(label: '停止中', value: active.toString()),
+            _Metric(label: '予定', value: upcoming.toString()),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 120,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: Theme.of(context).textTheme.labelMedium),
+          Text(
+            value,
+            style: Theme.of(context)
+                .textTheme
+                .headlineSmall
+                ?.copyWith(fontWeight: FontWeight.bold),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WindowCard extends StatelessWidget {
+  const _WindowCard({
+    required this.window,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final MaintenanceWindow window;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        leading: Icon(
+          window.scope == 'system' ? Icons.public : Icons.extension,
+          color: window.isActive ? colors.error : colors.primary,
+        ),
+        title: Text(
+          '${window.scope == 'system' ? '全体' : window.affectedFeatures.join(', ')} '
+          '${_formatDateTime(window.startsAt.toLocal())} - ${_formatDateTime(window.endsAt.toLocal())}',
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(
+          '${window.severity} / ${window.noticeDaysBefore}日前通知\n${window.displayMessage}',
+          maxLines: 3,
+          overflow: TextOverflow.ellipsis,
+        ),
+        isThreeLine: true,
+        trailing: Wrap(
+          children: [
+            IconButton(
+              tooltip: '編集',
+              icon: const Icon(Icons.edit),
+              onPressed: onEdit,
+            ),
+            IconButton(
+              tooltip: '削除',
+              icon: const Icon(Icons.delete_outline),
+              onPressed: onDelete,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MaintenanceWindowDialog extends StatefulWidget {
+  const _MaintenanceWindowDialog({
+    required this.service,
+    this.window,
+  });
+
+  final MaintenanceService service;
+  final MaintenanceWindow? window;
+
+  @override
+  State<_MaintenanceWindowDialog> createState() =>
+      _MaintenanceWindowDialogState();
+}
+
+class _MaintenanceWindowDialogState extends State<_MaintenanceWindowDialog> {
+  late String _scope;
+  late String _severity;
+  late int _noticeDays;
+  late DateTime _startsAt;
+  late DateTime _endsAt;
+  late final TextEditingController _featuresController;
+  late final TextEditingController _messageController;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final window = widget.window;
+    final now = DateTime.now();
+    _scope = window?.scope ?? 'system';
+    _severity = window?.severity ?? 'info';
+    _noticeDays = window?.noticeDaysBefore ?? 3;
+    _startsAt = window?.startsAt.toLocal() ?? now.add(const Duration(days: 3));
+    _endsAt =
+        window?.endsAt.toLocal() ?? now.add(const Duration(days: 3, hours: 2));
+    _featuresController = TextEditingController(
+      text: window?.affectedFeatures.join(', ') ?? '',
+    );
+    _messageController = TextEditingController(text: window?.messageJa ?? '');
+  }
+
+  @override
+  void dispose() {
+    _featuresController.dispose();
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDateTime({required bool starts}) async {
+    final current = starts ? _startsAt : _endsAt;
+    final date = await showDatePicker(
+      context: context,
+      initialDate: current,
+      firstDate: DateTime.now().subtract(const Duration(days: 1)),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+    );
+    if (date == null || !mounted) return;
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(current),
+    );
+    if (time == null) return;
+    final picked =
+        DateTime(date.year, date.month, date.day, time.hour, time.minute);
+    setState(() {
+      if (starts) {
+        _startsAt = picked;
+        if (!_endsAt.isAfter(_startsAt)) {
+          _endsAt = _startsAt.add(const Duration(hours: 2));
+        }
+      } else {
+        _endsAt = picked;
+      }
+    });
+  }
+
+  Future<void> _save() async {
+    final features = _featuresController.text
+        .split(',')
+        .map((item) => normalizeFeatureKey(item))
+        .where((item) => item.isNotEmpty)
+        .toList(growable: false);
+    if (_scope == 'feature' && features.isEmpty) {
+      _showError('影響機能を1つ以上入力してください。');
+      return;
+    }
+    if (!_endsAt.isAfter(_startsAt)) {
+      _showError('終了日時は開始日時より後にしてください。');
+      return;
+    }
+    if (_messageController.text.trim().isEmpty) {
+      _showError('メッセージを入力してください。');
+      return;
+    }
+    setState(() => _saving = true);
+    final current = widget.window;
+    final window = MaintenanceWindow(
+      id: current?.id ?? '',
+      scope: _scope,
+      affectedFeatures: _scope == 'system' ? const [] : features,
+      startsAt: _startsAt,
+      endsAt: _endsAt,
+      noticeDaysBefore: _noticeDays,
+      messageJa: _messageController.text.trim(),
+      severity: _severity,
+    );
+    try {
+      if (current == null) {
+        await widget.service.createWindow(window);
+      } else {
+        await widget.service.updateWindow(window);
+      }
+      if (!mounted) return;
+      Navigator.pop(context, true);
+    } catch (error) {
+      _showError(error.toString());
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  void _showError(String message) {
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.window == null ? '計画停止を追加' : '計画停止を編集'),
+      content: SizedBox(
+        width: 520,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SegmentedButton<String>(
+                segments: const [
+                  ButtonSegment(value: 'system', label: Text('全体')),
+                  ButtonSegment(value: 'feature', label: Text('機能別')),
+                ],
+                selected: {_scope},
+                onSelectionChanged: (values) {
+                  setState(() => _scope = values.first);
+                },
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _featuresController,
+                enabled: _scope == 'feature',
+                decoration: const InputDecoration(
+                  labelText: '影響機能',
+                  hintText: 'ai-hub, blog-management',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: () => _pickDateTime(starts: true),
+                      icon: const Icon(Icons.event),
+                      label: Text('開始 ${_formatDateTime(_startsAt)}'),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: () => _pickDateTime(starts: false),
+                      icon: const Icon(Icons.event_available),
+                      label: Text('終了 ${_formatDateTime(_endsAt)}'),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                initialValue: _severity,
+                decoration: const InputDecoration(
+                  labelText: '重要度',
+                  border: OutlineInputBorder(),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'info', child: Text('info')),
+                  DropdownMenuItem(value: 'warning', child: Text('warning')),
+                  DropdownMenuItem(value: 'critical', child: Text('critical')),
+                ],
+                onChanged: (value) {
+                  if (value != null) setState(() => _severity = value);
+                },
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  const Text('事前通知'),
+                  Expanded(
+                    child: Slider(
+                      value: _noticeDays.toDouble(),
+                      min: 0,
+                      max: 14,
+                      divisions: 14,
+                      label: '$_noticeDays日前',
+                      onChanged: (value) {
+                        setState(() => _noticeDays = value.round());
+                      },
+                    ),
+                  ),
+                  SizedBox(width: 56, child: Text('$_noticeDays日前')),
+                ],
+              ),
+              TextField(
+                controller: _messageController,
+                maxLines: 4,
+                decoration: const InputDecoration(
+                  labelText: '表示メッセージ',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _saving ? null : () => Navigator.pop(context, false),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton.icon(
+          onPressed: _saving ? null : _save,
+          icon: _saving
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.save),
+          label: const Text('保存'),
+        ),
+      ],
+    );
+  }
+}
+
+String _formatDateTime(DateTime value) {
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${value.year}/${two(value.month)}/${two(value.day)} '
+      '${two(value.hour)}:${two(value.minute)}';
+}

--- a/lib/pages/maintenance_mode_page.dart
+++ b/lib/pages/maintenance_mode_page.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:my_web_app/services/maintenance_service.dart';
+
+class MaintenanceModePage extends StatefulWidget {
+  const MaintenanceModePage({super.key, this.window});
+
+  final MaintenanceWindow? window;
+
+  @override
+  State<MaintenanceModePage> createState() => _MaintenanceModePageState();
+}
+
+class _MaintenanceModePageState extends State<MaintenanceModePage> {
+  Timer? _timer;
+  DateTime _now = DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(seconds: 30), (_) {
+      if (mounted) setState(() => _now = DateTime.now());
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final window = widget.window;
+    final endsAt = window?.endsAt.toLocal();
+    final remaining = endsAt?.difference(_now);
+    final colors = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      backgroundColor: colors.surface,
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 560),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: colors.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: colors.outlineVariant),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(28),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.construction_rounded,
+                          color: colors.primary,
+                          size: 28,
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            'メンテナンス中',
+                            style: Theme.of(context)
+                                .textTheme
+                                .headlineSmall
+                                ?.copyWith(fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      window?.displayMessage ?? 'ただいまシステムメンテナンスを実施しています。',
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                    const SizedBox(height: 20),
+                    if (endsAt != null)
+                      _InfoRow(
+                        icon: Icons.event_available,
+                        label: '終了予定',
+                        value: _formatDateTime(endsAt),
+                      ),
+                    if (remaining != null)
+                      _InfoRow(
+                        icon: Icons.timer_outlined,
+                        label: '残り時間',
+                        value: _formatDuration(remaining),
+                      ),
+                    const SizedBox(height: 20),
+                    Text(
+                      '管理画面はメンテナンス中も操作できます。復旧後は自動で通常画面に戻ります。',
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.copyWith(color: colors.onSurfaceVariant),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        children: [
+          Icon(icon, size: 18, color: colors.onSurfaceVariant),
+          const SizedBox(width: 8),
+          SizedBox(
+            width: 76,
+            child: Text(
+              label,
+              style: TextStyle(color: colors.onSurfaceVariant),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _formatDateTime(DateTime value) {
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${value.year}/${two(value.month)}/${two(value.day)} '
+      '${two(value.hour)}:${two(value.minute)}';
+}
+
+String _formatDuration(Duration value) {
+  if (value.isNegative) return 'まもなく復旧します';
+  final hours = value.inHours;
+  final minutes = value.inMinutes.remainder(60);
+  if (hours > 0) return '$hours時間 $minutes分';
+  return '$minutes分';
+}

--- a/lib/services/maintenance_service.dart
+++ b/lib/services/maintenance_service.dart
@@ -1,0 +1,241 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class MaintenanceServiceException implements Exception {
+  MaintenanceServiceException(this.message, {this.statusCode});
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() => 'MaintenanceServiceException($statusCode): $message';
+}
+
+class MaintenanceWindow {
+  const MaintenanceWindow({
+    required this.id,
+    required this.scope,
+    required this.affectedFeatures,
+    required this.startsAt,
+    required this.endsAt,
+    required this.noticeDaysBefore,
+    required this.messageJa,
+    this.messageEn,
+    required this.severity,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  final String id;
+  final String scope;
+  final List<String> affectedFeatures;
+  final DateTime startsAt;
+  final DateTime endsAt;
+  final int noticeDaysBefore;
+  final String messageJa;
+  final String? messageEn;
+  final String severity;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  bool get isSystem => scope == 'system';
+
+  bool get isActive {
+    final now = DateTime.now();
+    return !now.isBefore(startsAt) && now.isBefore(endsAt);
+  }
+
+  DateTime get bannerVisibleFrom =>
+      startsAt.subtract(Duration(days: noticeDaysBefore));
+
+  String get displayMessage =>
+      messageJa.trim().isEmpty ? 'システムメンテナンスを予定しています。' : messageJa.trim();
+
+  bool affectsRoute(String routePath) {
+    if (isSystem) return true;
+    final normalized = normalizeFeatureKey(routePath);
+    return affectedFeatures.map(normalizeFeatureKey).any(
+          (feature) => feature == normalized || normalized.startsWith(feature),
+        );
+  }
+
+  Map<String, dynamic> toPayload() {
+    return {
+      if (id.isNotEmpty) 'id': id,
+      'scope': scope,
+      'affected_features': affectedFeatures,
+      'starts_at': startsAt.toUtc().toIso8601String(),
+      'ends_at': endsAt.toUtc().toIso8601String(),
+      'notice_days_before': noticeDaysBefore,
+      'message_ja': messageJa,
+      'message_en': messageEn,
+      'severity': severity,
+    };
+  }
+
+  factory MaintenanceWindow.fromJson(Map<String, dynamic> json) {
+    return MaintenanceWindow(
+      id: json['id']?.toString() ?? '',
+      scope: json['scope']?.toString() == 'feature' ? 'feature' : 'system',
+      affectedFeatures: _asStringList(json['affected_features']),
+      startsAt: _parseDate(json['starts_at']) ?? DateTime.now(),
+      endsAt: _parseDate(json['ends_at']) ?? DateTime.now(),
+      noticeDaysBefore: _asInt(json['notice_days_before'], fallback: 3),
+      messageJa: json['message_ja']?.toString() ?? '',
+      messageEn: json['message_en']?.toString(),
+      severity: _normalizeSeverity(json['severity']),
+      createdAt: _parseDate(json['created_at']),
+      updatedAt: _parseDate(json['updated_at']),
+    );
+  }
+}
+
+class MaintenanceSnapshot {
+  const MaintenanceSnapshot({
+    required this.windows,
+    required this.fetchedAt,
+  });
+
+  final List<MaintenanceWindow> windows;
+  final DateTime fetchedAt;
+
+  MaintenanceWindow? blockingWindowFor(String routePath) {
+    if (_isAdminRoute(routePath)) return null;
+    for (final window in windows) {
+      if (window.isActive && window.affectsRoute(routePath)) {
+        return window;
+      }
+    }
+    return null;
+  }
+
+  List<MaintenanceWindow> visibleBannersFor(String routePath) {
+    if (_isAdminRoute(routePath)) return const [];
+    return windows.where((window) {
+      return window.affectsRoute(routePath);
+    }).toList(growable: false);
+  }
+}
+
+class MaintenanceService {
+  MaintenanceService({SupabaseClient? client})
+      : _client = client ?? Supabase.instance.client;
+
+  static const cacheTtl = Duration(minutes: 5);
+  static MaintenanceSnapshot? _activeCache;
+
+  final SupabaseClient _client;
+
+  Future<MaintenanceSnapshot> fetchActive({bool force = false}) async {
+    final cached = _activeCache;
+    if (!force &&
+        cached != null &&
+        DateTime.now().difference(cached.fetchedAt) < cacheTtl) {
+      return cached;
+    }
+    final data = await _invoke('maintenance.list_active', {
+      'now': DateTime.now().toUtc().toIso8601String(),
+    });
+    final windows = _asList(data['windows'])
+        .map((item) => MaintenanceWindow.fromJson(_asMap(item)))
+        .toList(growable: false);
+    final snapshot = MaintenanceSnapshot(
+      windows: windows,
+      fetchedAt: DateTime.now(),
+    );
+    _activeCache = snapshot;
+    return snapshot;
+  }
+
+  Future<List<MaintenanceWindow>> listWindows() async {
+    final data = await _invoke('maintenance.list', {});
+    return _asList(data['windows'])
+        .map((item) => MaintenanceWindow.fromJson(_asMap(item)))
+        .toList(growable: false);
+  }
+
+  Future<MaintenanceWindow> createWindow(MaintenanceWindow window) async {
+    final data = await _invoke('maintenance.create', window.toPayload());
+    _activeCache = null;
+    return MaintenanceWindow.fromJson(_asMap(data['window']));
+  }
+
+  Future<MaintenanceWindow> updateWindow(MaintenanceWindow window) async {
+    final data = await _invoke('maintenance.update', window.toPayload());
+    _activeCache = null;
+    return MaintenanceWindow.fromJson(_asMap(data['window']));
+  }
+
+  Future<void> deleteWindow(String id) async {
+    await _invoke('maintenance.delete', {'id': id});
+    _activeCache = null;
+  }
+
+  Future<Map<String, dynamic>> _invoke(
+    String action,
+    Map<String, dynamic> params,
+  ) async {
+    final res = await _client.functions.invoke(
+      'schedule-hub',
+      body: {'action': action, ...params},
+    );
+    final data = _asMap(res.data);
+    if (res.status != 200 || data['success'] == false) {
+      final message = data['error']?.toString() ?? 'HTTP ${res.status}';
+      throw MaintenanceServiceException(message, statusCode: res.status);
+    }
+    return data;
+  }
+}
+
+String normalizeFeatureKey(String value) {
+  return value
+      .trim()
+      .toLowerCase()
+      .replaceFirst(RegExp(r'^/+'), '')
+      .split('?')
+      .first;
+}
+
+bool _isAdminRoute(String routePath) {
+  final normalized = normalizeFeatureKey(routePath);
+  return normalized == 'admin' ||
+      normalized.startsWith('admin/') ||
+      normalized == 'admin-feedback' ||
+      normalized == 'blog-management' ||
+      normalized == 'quota-dashboard';
+}
+
+Map<String, dynamic> _asMap(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) {
+    return value.map((key, val) => MapEntry(key.toString(), val));
+  }
+  return <String, dynamic>{};
+}
+
+List<dynamic> _asList(Object? value) {
+  return value is List ? value : const [];
+}
+
+List<String> _asStringList(Object? value) {
+  if (value is List) {
+    return value.map((item) => item.toString()).toList(growable: false);
+  }
+  return const [];
+}
+
+int _asInt(Object? value, {required int fallback}) {
+  if (value is int) return value;
+  if (value is num) return value.round();
+  return int.tryParse(value?.toString() ?? '') ?? fallback;
+}
+
+DateTime? _parseDate(Object? value) {
+  final text = value?.toString();
+  return text == null || text.isEmpty ? null : DateTime.tryParse(text);
+}
+
+String _normalizeSeverity(Object? value) {
+  final text = value?.toString();
+  return text == 'critical' || text == 'warning' ? text! : 'info';
+}

--- a/lib/services/maintenance_service.dart
+++ b/lib/services/maintenance_service.dart
@@ -132,7 +132,7 @@ class MaintenanceService {
         DateTime.now().difference(cached.fetchedAt) < cacheTtl) {
       return cached;
     }
-    final data = await _invoke('maintenance.list_active', {
+    final data = await _callMaintenanceAction('maintenance.list_active', {
       'now': DateTime.now().toUtc().toIso8601String(),
     });
     final windows = _asList(data['windows'])
@@ -147,30 +147,36 @@ class MaintenanceService {
   }
 
   Future<List<MaintenanceWindow>> listWindows() async {
-    final data = await _invoke('maintenance.list', {});
+    final data = await _callMaintenanceAction('maintenance.list', {});
     return _asList(data['windows'])
         .map((item) => MaintenanceWindow.fromJson(_asMap(item)))
         .toList(growable: false);
   }
 
   Future<MaintenanceWindow> createWindow(MaintenanceWindow window) async {
-    final data = await _invoke('maintenance.create', window.toPayload());
+    final data = await _callMaintenanceAction(
+      'maintenance.create',
+      window.toPayload(),
+    );
     _activeCache = null;
     return MaintenanceWindow.fromJson(_asMap(data['window']));
   }
 
   Future<MaintenanceWindow> updateWindow(MaintenanceWindow window) async {
-    final data = await _invoke('maintenance.update', window.toPayload());
+    final data = await _callMaintenanceAction(
+      'maintenance.update',
+      window.toPayload(),
+    );
     _activeCache = null;
     return MaintenanceWindow.fromJson(_asMap(data['window']));
   }
 
   Future<void> deleteWindow(String id) async {
-    await _invoke('maintenance.delete', {'id': id});
+    await _callMaintenanceAction('maintenance.delete', {'id': id});
     _activeCache = null;
   }
 
-  Future<Map<String, dynamic>> _invoke(
+  Future<Map<String, dynamic>> _callMaintenanceAction(
     String action,
     Map<String, dynamic> params,
   ) async {

--- a/lib/widgets/maintenance_banner.dart
+++ b/lib/widgets/maintenance_banner.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:my_web_app/pages/maintenance_mode_page.dart';
+import 'package:my_web_app/services/maintenance_service.dart';
+import 'package:my_web_app/services/universal_x_share_service.dart';
+
+class MaintenanceShell extends StatefulWidget {
+  const MaintenanceShell({
+    super.key,
+    required this.routeListenable,
+    required this.child,
+    this.service,
+  });
+
+  final ValueListenable<UniversalSharePageContext> routeListenable;
+  final Widget child;
+  final MaintenanceService? service;
+
+  @override
+  State<MaintenanceShell> createState() => _MaintenanceShellState();
+}
+
+class _MaintenanceShellState extends State<MaintenanceShell> {
+  late final MaintenanceService _service;
+  Timer? _timer;
+  MaintenanceSnapshot _snapshot = MaintenanceSnapshot(
+    windows: const [],
+    fetchedAt: DateTime.fromMillisecondsSinceEpoch(0),
+  );
+  final Set<String> _dismissedIds = <String>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? MaintenanceService();
+    _refresh(force: true);
+    _timer = Timer.periodic(MaintenanceService.cacheTtl, (_) {
+      _refresh(force: true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _refresh({bool force = false}) async {
+    try {
+      final snapshot = await _service.fetchActive(force: force);
+      if (!mounted) return;
+      setState(() => _snapshot = snapshot);
+    } catch (_) {
+      // Maintenance lookup must never block the normal application render path.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<UniversalSharePageContext>(
+      valueListenable: widget.routeListenable,
+      builder: (context, page, _) {
+        final routePath = page.routePath;
+        final blocking = _snapshot.blockingWindowFor(routePath);
+        final visibleBanners = _snapshot
+            .visibleBannersFor(routePath)
+            .where((window) => !_dismissedIds.contains(window.id))
+            .toList(growable: false);
+        return Column(
+          children: [
+            if (blocking == null && visibleBanners.isNotEmpty)
+              MaintenanceBanner(
+                window: visibleBanners.first,
+                onDismiss: () {
+                  setState(() => _dismissedIds.add(visibleBanners.first.id));
+                },
+              ),
+            Expanded(
+              child: blocking == null
+                  ? widget.child
+                  : MaintenanceModePage(window: blocking),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class MaintenanceBanner extends StatelessWidget {
+  const MaintenanceBanner({
+    super.key,
+    required this.window,
+    required this.onDismiss,
+  });
+
+  final MaintenanceWindow window;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = _bannerColors(window.severity);
+    final starts = window.startsAt.toLocal();
+    final ends = window.endsAt.toLocal();
+    return SafeArea(
+      bottom: false,
+      child: Material(
+        color: colors.background,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          decoration: BoxDecoration(
+            border: Border(bottom: BorderSide(color: colors.border)),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.info_outline, color: colors.foreground, size: 20),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  '${_formatDateTime(starts)}-${_formatTime(ends)} '
+                  '${window.isSystem ? '全体' : window.affectedFeatures.join(', ')} '
+                  'メンテナンス予定: ${window.displayMessage}',
+                  style: TextStyle(
+                    color: colors.foreground,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              IconButton(
+                tooltip: '閉じる',
+                icon: Icon(Icons.close, color: colors.foreground),
+                onPressed: onDismiss,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BannerColors {
+  const _BannerColors({
+    required this.background,
+    required this.foreground,
+    required this.border,
+  });
+
+  final Color background;
+  final Color foreground;
+  final Color border;
+}
+
+_BannerColors _bannerColors(String severity) {
+  switch (severity) {
+    case 'critical':
+      return const _BannerColors(
+        background: Color(0xFFFFEBEE),
+        foreground: Color(0xFFB71C1C),
+        border: Color(0xFFE57373),
+      );
+    case 'warning':
+      return const _BannerColors(
+        background: Color(0xFFFFF8E1),
+        foreground: Color(0xFF8A4B00),
+        border: Color(0xFFFFB74D),
+      );
+    default:
+      return const _BannerColors(
+        background: Color(0xFFE3F2FD),
+        foreground: Color(0xFF0D47A1),
+        border: Color(0xFF64B5F6),
+      );
+  }
+}
+
+String _formatDateTime(DateTime value) {
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${value.year}/${two(value.month)}/${two(value.day)} '
+      '${two(value.hour)}:${two(value.minute)}';
+}
+
+String _formatTime(DateTime value) {
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${two(value.hour)}:${two(value.minute)}';
+}

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -121,6 +121,104 @@ function asStringList(value: unknown, fallback: string[]): string[] {
     : fallback;
 }
 
+function normalizeMaintenanceScope(value: unknown): "system" | "feature" {
+  return asString(value).toLowerCase() === "feature" ? "feature" : "system";
+}
+
+function normalizeMaintenanceSeverity(
+  value: unknown,
+): "info" | "warning" | "critical" {
+  const normalized = asString(value, "info").toLowerCase();
+  if (normalized === "critical" || normalized === "warning") return normalized;
+  return "info";
+}
+
+function normalizeMaintenanceTimestamp(value: unknown, field: string): string {
+  const raw = asString(value);
+  const parsed = raw ? new Date(raw) : null;
+  if (!parsed || Number.isNaN(parsed.getTime())) {
+    throw new Error(`${field} must be a valid ISO timestamp`);
+  }
+  return parsed.toISOString();
+}
+
+function normalizeMaintenanceNoticeDays(value: unknown): number {
+  const raw = typeof value === "number" ? value : Number(value ?? 3);
+  if (!Number.isFinite(raw)) return 3;
+  return Math.max(0, Math.min(30, Math.round(raw)));
+}
+
+function maintenanceFeatureList(value: unknown): string[] {
+  return asStringList(value, [])
+    .map((item) => item.replace(/^\/+/, "").toLowerCase())
+    .filter(Boolean);
+}
+
+function maintenancePayload(
+  body: Record<string, unknown>,
+  userId: string | null,
+  partial = false,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (!partial || body.scope !== undefined) {
+    payload.scope = normalizeMaintenanceScope(body.scope);
+  }
+  if (!partial || body.affected_features !== undefined) {
+    payload.affected_features = maintenanceFeatureList(body.affected_features);
+  }
+  if (!partial || body.starts_at !== undefined) {
+    payload.starts_at = normalizeMaintenanceTimestamp(
+      body.starts_at,
+      "starts_at",
+    );
+  }
+  if (!partial || body.ends_at !== undefined) {
+    payload.ends_at = normalizeMaintenanceTimestamp(body.ends_at, "ends_at");
+  }
+  if (!partial || body.notice_days_before !== undefined) {
+    payload.notice_days_before = normalizeMaintenanceNoticeDays(
+      body.notice_days_before,
+    );
+  }
+  if (!partial || body.message_ja !== undefined) {
+    const message = asString(body.message_ja);
+    if (!message) throw new Error("message_ja is required");
+    payload.message_ja = message;
+  }
+  if (body.message_en !== undefined) {
+    payload.message_en = asString(body.message_en) || null;
+  }
+  if (!partial || body.severity !== undefined) {
+    payload.severity = normalizeMaintenanceSeverity(body.severity);
+  }
+  if (!partial && userId) payload.created_by = userId;
+  const scope = payload.scope ?? body.scope;
+  const features = payload.affected_features ?? body.affected_features;
+  if (scope === "feature" && maintenanceFeatureList(features).length === 0) {
+    throw new Error("affected_features is required for feature scope");
+  }
+  const starts = payload.starts_at ? new Date(String(payload.starts_at)) : null;
+  const ends = payload.ends_at ? new Date(String(payload.ends_at)) : null;
+  if (starts && ends && ends <= starts) {
+    throw new Error("ends_at must be after starts_at");
+  }
+  return payload;
+}
+
+function maintenanceWindowVisible(
+  row: Record<string, unknown>,
+  now: Date,
+): boolean {
+  const startsAt = new Date(asString(row.starts_at));
+  const endsAt = new Date(asString(row.ends_at));
+  if (Number.isNaN(startsAt.getTime()) || Number.isNaN(endsAt.getTime())) {
+    return false;
+  }
+  const noticeDays = normalizeMaintenanceNoticeDays(row.notice_days_before);
+  const visibleFrom = new Date(startsAt.getTime() - noticeDays * 86400000);
+  return now >= visibleFrom && now < endsAt;
+}
+
 function billingPriceId(tier: string): string {
   const normalized = tier === "team" ? "TEAM" : "PRO";
   return Deno.env.get(`STRIPE_${normalized}_PRICE_ID`) ??
@@ -1483,6 +1581,7 @@ serve(async (req: Request) => {
       "notion.fix_wbs_all_instances",
       "wbs.unblock_dependents",
       "x.post_with_media",
+      "maintenance.list_active",
     ];
     const serviceRoleRequest = isServiceRoleRequest(req);
     let userId: string | null = null;
@@ -1573,6 +1672,86 @@ serve(async (req: Request) => {
       }
 
       // ─── Digest ───────────────────────────────────────────────────────────────
+      case "maintenance.list_active": {
+        const now = new Date(asString(body.now) || new Date().toISOString());
+        if (Number.isNaN(now.getTime())) {
+          return json(
+            { success: false, error: "now must be ISO timestamp" },
+            400,
+          );
+        }
+        const { data, error } = await admin
+          .from("maintenance_windows")
+          .select("*")
+          .gt("ends_at", now.toISOString())
+          .order("starts_at", { ascending: true })
+          .limit(50);
+        if (error) throw new Error(error.message);
+        const windows = (data ?? [])
+          .map((row) => asRecord(row) ?? {})
+          .filter((row) => maintenanceWindowVisible(row, now))
+          .map((row) => {
+            const startsAt = new Date(asString(row.starts_at));
+            const noticeDays = normalizeMaintenanceNoticeDays(
+              row.notice_days_before,
+            );
+            return {
+              ...row,
+              banner_visible_from: new Date(
+                startsAt.getTime() - noticeDays * 86400000,
+              ).toISOString(),
+              active: startsAt <= now,
+            };
+          });
+        return json({ success: true, windows });
+      }
+
+      case "maintenance.list": {
+        const { data, error } = await admin
+          .from("maintenance_windows")
+          .select("*")
+          .order("starts_at", { ascending: false })
+          .limit(100);
+        if (error) throw new Error(error.message);
+        return json({ success: true, windows: data ?? [] });
+      }
+
+      case "maintenance.create": {
+        const payload = maintenancePayload(body, userId);
+        const { data, error } = await admin
+          .from("maintenance_windows")
+          .insert(payload)
+          .select("*")
+          .single();
+        if (error) throw new Error(error.message);
+        return json({ success: true, window: data });
+      }
+
+      case "maintenance.update": {
+        const id = asString(body.id);
+        if (!id) return json({ success: false, error: "id required" }, 400);
+        const payload = maintenancePayload(body, userId, true);
+        const { data, error } = await admin
+          .from("maintenance_windows")
+          .update(payload)
+          .eq("id", id)
+          .select("*")
+          .single();
+        if (error) throw new Error(error.message);
+        return json({ success: true, window: data });
+      }
+
+      case "maintenance.delete": {
+        const id = asString(body.id);
+        if (!id) return json({ success: false, error: "id required" }, 400);
+        const { error } = await admin
+          .from("maintenance_windows")
+          .delete()
+          .eq("id", id);
+        if (error) throw new Error(error.message);
+        return json({ success: true });
+      }
+
       case "digest.run": {
         const today = new Date().toISOString().split("T")[0];
         const [usersRes, newFrRes, openFrRes, topFrRes, achievementsRes] =

--- a/supabase/migrations/20260505211500_create_maintenance_windows.sql
+++ b/supabase/migrations/20260505211500_create_maintenance_windows.sql
@@ -1,0 +1,56 @@
+CREATE TABLE IF NOT EXISTS public.maintenance_windows (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope text NOT NULL DEFAULT 'system'
+    CHECK (scope IN ('system', 'feature')),
+  affected_features text[] NOT NULL DEFAULT '{}',
+  starts_at timestamptz NOT NULL,
+  ends_at timestamptz NOT NULL,
+  notice_days_before int NOT NULL DEFAULT 3
+    CHECK (notice_days_before >= 0 AND notice_days_before <= 30),
+  message_ja text NOT NULL,
+  message_en text,
+  severity text NOT NULL DEFAULT 'info'
+    CHECK (severity IN ('info', 'warning', 'critical')),
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (ends_at > starts_at),
+  CHECK (
+    scope = 'system'
+    OR cardinality(affected_features) > 0
+  )
+);
+
+CREATE INDEX IF NOT EXISTS maintenance_windows_lookup_idx
+  ON public.maintenance_windows (starts_at, ends_at);
+
+CREATE INDEX IF NOT EXISTS maintenance_windows_scope_idx
+  ON public.maintenance_windows (scope);
+
+CREATE OR REPLACE FUNCTION public.set_maintenance_windows_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS maintenance_windows_set_updated_at
+  ON public.maintenance_windows;
+
+CREATE TRIGGER maintenance_windows_set_updated_at
+  BEFORE UPDATE ON public.maintenance_windows
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_maintenance_windows_updated_at();
+
+ALTER TABLE public.maintenance_windows ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS maintenance_windows_public_read
+  ON public.maintenance_windows;
+
+CREATE POLICY maintenance_windows_public_read
+  ON public.maintenance_windows
+  FOR SELECT
+  USING (true);


### PR DESCRIPTION
## Summary
- Adds `maintenance_windows` migration for planned outage windows with notice days, severity, system/feature scope, and public read RLS.
- Extends `schedule-hub` with `maintenance.list_active`, `maintenance.list`, `maintenance.create`, `maintenance.update`, and `maintenance.delete` actions.
- Adds Flutter `MaintenanceService`, global `MaintenanceShell` banner/guard, maintenance mode page, and `/admin/maintenance` CRUD page.
- Wires the shell through `MaterialApp.builder` so active system/feature outages can show a notice banner and block affected routes while admin routes remain available.

## Scope / WBS
- Closes #1309
- 2-instance split: Claude Code #1 completed `docs/MAINTENANCE_MODE_SPEC.md`; Codex #1 implemented the SQL/API/UI slice.
- No new Edge Function was added; this keeps the EF count stable by extending `schedule-hub`.

## Validation
- `dart analyze lib/services/maintenance_service.dart lib/widgets/maintenance_banner.dart lib/pages/maintenance_mode_page.dart lib/pages/admin/maintenance_management_page.dart lib/main.dart`
- `deno lint --config supabase/functions/deno.json supabase/functions/schedule-hub/index.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/schedule-hub/index.ts`
- `git diff --cached --check`

## Minimal E2E Gate
The E2E test is implementation-detail independent: it verifies public user behavior rather than private helper names or file structure.

E2E-Exception: Live planned-outage enforcement needs the Supabase migration deployed plus an authenticated admin session to create a maintenance window; CI cannot safely mutate production maintenance state. The implementation is covered by targeted Dart analyze and Deno lint/check, with the manual smoke plan below for deployment verification.

Smoke plan:
1. Open `/admin/maintenance`, create a system outage starting now and ending later today.
2. Open `/home` and confirm the user is shown the maintenance mode page.
3. Change the outage to a future start with `notice_days_before = 3`, then confirm `/home` shows the banner but remains usable.
4. Open `/admin/maintenance` during the outage and confirm admin bypass still allows editing/deleting the window.

## Notes
- This PR follows the existing admin surface pattern: authenticated users call `schedule-hub`, which performs writes through the service-role client. A future shared admin-role model can tighten write authorization across all admin pages at once.