### PR TITLE
feat(integration): add external format mapping

### DIFF
--- a/lib/pages/import_page.dart
+++ b/lib/pages/import_page.dart
@@ -2,10 +2,12 @@ import 'dart:async';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../pages/landing_page.dart';
+import '../services/external_format_service.dart';
 import '../services/gamification_service.dart';
 import '../services/growth_acquisition_service.dart';
 import '../services/import_service.dart';
@@ -27,10 +29,23 @@ class _ImportPageState extends State<ImportPage> {
   ImportExecutionResult? _lastImportResult;
   String? _selectedSource;
   final TextEditingController _notionTokenController = TextEditingController();
+  final TextEditingController _externalFormatInputController =
+      TextEditingController(
+    text: ExternalFormatService.sampleText('ssim'),
+  );
+  final ExternalFormatService _externalFormatService =
+      const ExternalFormatService();
+  ExternalFormatProfile _externalFormatProfile =
+      ExternalFormatService.defaultProfile('ssim');
+  ExternalFormatTransformResult? _externalFormatPreview;
+  String _externalFormatId = 'ssim';
+  String? _externalFormatExport;
+  bool _isSavingExternalMapping = false;
 
   @override
   void dispose() {
     _notionTokenController.dispose();
+    _externalFormatInputController.dispose();
     super.dispose();
   }
 
@@ -244,6 +259,76 @@ class _ImportPageState extends State<ImportPage> {
     }
   }
 
+  void _selectExternalFormat(String? formatId) {
+    final nextFormatId = formatId ?? 'ssim';
+    setState(() {
+      _externalFormatId = nextFormatId;
+      _externalFormatProfile =
+          ExternalFormatService.defaultProfile(nextFormatId);
+      _externalFormatInputController.text =
+          ExternalFormatService.sampleText(nextFormatId);
+      _externalFormatPreview = null;
+      _externalFormatExport = null;
+    });
+  }
+
+  void _updateExternalMapping(
+    int index,
+    ExternalFieldMapping Function(ExternalFieldMapping mapping) update,
+  ) {
+    final mappings = List<ExternalFieldMapping>.from(
+      _externalFormatProfile.mappings,
+    );
+    mappings[index] = update(mappings[index]);
+    setState(() {
+      _externalFormatProfile = _externalFormatProfile.copyWith(
+        mappings: mappings,
+      );
+      _externalFormatPreview = null;
+      _externalFormatExport = null;
+    });
+  }
+
+  void _previewExternalFormat() {
+    final result = _externalFormatService.transform(
+      inputText: _externalFormatInputController.text,
+      profile: _externalFormatProfile,
+    );
+    setState(() {
+      _externalFormatPreview = result;
+      _externalFormatExport = _externalFormatService.exportDelimited(
+        result,
+        _externalFormatProfile.delimiter,
+      );
+    });
+  }
+
+  Future<void> _copyExternalExport() async {
+    final exportText = _externalFormatExport;
+    if (exportText == null || exportText.trim().isEmpty) {
+      _previewExternalFormat();
+    }
+    final text = _externalFormatExport;
+    if (text == null || text.trim().isEmpty) return;
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) return;
+    _showMessage('出力CSVをコピーしました。');
+  }
+
+  Future<void> _saveExternalMappingProfile() async {
+    setState(() => _isSavingExternalMapping = true);
+    try {
+      await _externalFormatService.saveProfile(_externalFormatProfile);
+      if (!mounted) return;
+      _showMessage('外部連携マッピングを保存しました。');
+    } catch (error) {
+      if (!mounted) return;
+      _showMessage('マッピング保存に失敗しました: $error');
+    } finally {
+      if (mounted) setState(() => _isSavingExternalMapping = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final preview = _preview;
@@ -299,6 +384,8 @@ class _ImportPageState extends State<ImportPage> {
               ),
             ],
           ),
+          const SizedBox(height: 24),
+          _externalFormatPanel(),
           const SizedBox(height: 24),
           if (_isLoading) const LinearProgressIndicator(),
           if (_lastImportResult != null) ...[
@@ -460,6 +547,220 @@ class _ImportPageState extends State<ImportPage> {
                 ),
               ),
           ],
+        ],
+      ),
+    );
+  }
+
+  Widget _externalFormatPanel() {
+    final preview = _externalFormatPreview;
+    final exportText = _externalFormatExport;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                const Icon(Icons.hub_outlined),
+                const Text(
+                  '外部標準フォーマット連携',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w800,
+                    height: 1.5,
+                  ),
+                ),
+                Chip(
+                  avatar: const Icon(Icons.rule, size: 18),
+                  label: Text(_externalFormatProfile.label),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'SSIM/AIDX 風の連携ファイルを取り込み、連携先ごとに必要な項目だけを動的にマッピングして、正規化済みデータとして出力します。',
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              initialValue: _externalFormatId,
+              decoration: const InputDecoration(
+                labelText: 'フォーマット定義',
+                border: OutlineInputBorder(),
+              ),
+              items: const [
+                DropdownMenuItem(value: 'ssim', child: Text('SSIMスケジュール')),
+                DropdownMenuItem(value: 'aidx', child: Text('AIDX運航イベント')),
+              ],
+              onChanged: _selectExternalFormat,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _externalFormatInputController,
+              minLines: 5,
+              maxLines: 8,
+              decoration: const InputDecoration(
+                labelText: '受信CSV / 標準テキスト',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '項目マッピング',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            ..._externalFormatProfile.mappings.asMap().entries.map(
+                  (entry) => _externalMappingRow(entry.key, entry.value),
+                ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                FilledButton.icon(
+                  onPressed: _previewExternalFormat,
+                  icon: const Icon(Icons.visibility_outlined),
+                  label: const Text('マッピング結果を確認'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: preview == null ? null : _copyExternalExport,
+                  icon: const Icon(Icons.copy),
+                  label: const Text('出力CSVをコピー'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _isSavingExternalMapping
+                      ? null
+                      : _saveExternalMappingProfile,
+                  icon: _isSavingExternalMapping
+                      ? const SizedBox.square(
+                          dimension: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.save_outlined),
+                  label: Text(
+                    _isSavingExternalMapping ? '保存中...' : 'マッピングを保存',
+                  ),
+                ),
+              ],
+            ),
+            if (preview != null) ...[
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  Chip(label: Text('${preview.rows.length} rows')),
+                  Chip(label: Text('${preview.outputFields.length} fields')),
+                  if (preview.warnings.isNotEmpty)
+                    Chip(label: Text('${preview.warnings.length} warnings')),
+                ],
+              ),
+              if (preview.warnings.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                ...preview.warnings.map(
+                  (warning) => Text(
+                    '- $warning',
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                      height: 1.5,
+                    ),
+                  ),
+                ),
+              ],
+              const SizedBox(height: 12),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: DataTable(
+                  columns: preview.outputFields
+                      .map((field) => DataColumn(label: Text(field)))
+                      .toList(),
+                  rows: preview.rows.take(5).map((row) {
+                    return DataRow(
+                      cells: preview.outputFields
+                          .map((field) => DataCell(Text(row[field] ?? '')))
+                          .toList(),
+                    );
+                  }).toList(),
+                ),
+              ),
+              if (exportText != null && exportText.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                SelectableText(
+                  exportText,
+                  maxLines: 6,
+                  style: const TextStyle(fontFamily: 'monospace'),
+                ),
+              ],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _externalMappingRow(int index, ExternalFieldMapping mapping) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          FilterChip(
+            label: const Text('送信'),
+            selected: mapping.include,
+            onSelected: (value) => _updateExternalMapping(
+              index,
+              (current) => current.copyWith(include: value),
+            ),
+          ),
+          FilterChip(
+            label: const Text('必須'),
+            selected: mapping.requiredField,
+            onSelected: (value) => _updateExternalMapping(
+              index,
+              (current) => current.copyWith(requiredField: value),
+            ),
+          ),
+          SizedBox(
+            width: 220,
+            child: TextFormField(
+              key: ValueKey('external-source-$_externalFormatId-$index'),
+              initialValue: mapping.sourceField,
+              decoration: const InputDecoration(
+                labelText: '元項目',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              onChanged: (value) => _updateExternalMapping(
+                index,
+                (current) => current.copyWith(sourceField: value),
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 220,
+            child: TextFormField(
+              key: ValueKey('external-target-$_externalFormatId-$index'),
+              initialValue: mapping.targetField,
+              decoration: const InputDecoration(
+                labelText: '出力項目',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              onChanged: (value) => _updateExternalMapping(
+                index,
+                (current) => current.copyWith(targetField: value),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/services/external_format_service.dart
+++ b/lib/services/external_format_service.dart
@@ -1,0 +1,391 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class ExternalFieldMapping {
+  final String sourceField;
+  final String targetField;
+  final bool include;
+  final bool requiredField;
+
+  const ExternalFieldMapping({
+    required this.sourceField,
+    required this.targetField,
+    this.include = true,
+    this.requiredField = false,
+  });
+
+  ExternalFieldMapping copyWith({
+    String? sourceField,
+    String? targetField,
+    bool? include,
+    bool? requiredField,
+  }) {
+    return ExternalFieldMapping(
+      sourceField: sourceField ?? this.sourceField,
+      targetField: targetField ?? this.targetField,
+      include: include ?? this.include,
+      requiredField: requiredField ?? this.requiredField,
+    );
+  }
+
+  factory ExternalFieldMapping.fromJson(Map<String, dynamic> json) {
+    return ExternalFieldMapping(
+      sourceField: json['source_field']?.toString() ?? '',
+      targetField: json['target_field']?.toString() ?? '',
+      include: json['include'] != false,
+      requiredField: json['required'] == true,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'source_field': sourceField,
+      'target_field': targetField,
+      'include': include,
+      'required': requiredField,
+    };
+  }
+}
+
+class ExternalFormatProfile {
+  final String id;
+  final String label;
+  final String delimiter;
+  final List<ExternalFieldMapping> mappings;
+
+  const ExternalFormatProfile({
+    required this.id,
+    required this.label,
+    required this.delimiter,
+    required this.mappings,
+  });
+
+  ExternalFormatProfile copyWith({
+    String? id,
+    String? label,
+    String? delimiter,
+    List<ExternalFieldMapping>? mappings,
+  }) {
+    return ExternalFormatProfile(
+      id: id ?? this.id,
+      label: label ?? this.label,
+      delimiter: delimiter ?? this.delimiter,
+      mappings: mappings ?? this.mappings,
+    );
+  }
+
+  factory ExternalFormatProfile.fromJson(Map<String, dynamic> json) {
+    final mappingsJson =
+        json['mappings'] as List<dynamic>? ?? const <dynamic>[];
+    return ExternalFormatProfile(
+      id: json['id']?.toString() ?? 'custom',
+      label: json['label']?.toString() ?? 'Custom mapping',
+      delimiter: json['delimiter']?.toString() ?? ',',
+      mappings: mappingsJson
+          .whereType<Map>()
+          .map(
+            (mapping) => ExternalFieldMapping.fromJson(
+              Map<String, dynamic>.from(mapping),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'label': label,
+      'delimiter': delimiter,
+      'mappings': mappings.map((mapping) => mapping.toJson()).toList(),
+    };
+  }
+}
+
+class ExternalFormatTransformResult {
+  final List<String> outputFields;
+  final List<Map<String, String>> rows;
+  final List<String> warnings;
+
+  const ExternalFormatTransformResult({
+    required this.outputFields,
+    required this.rows,
+    this.warnings = const <String>[],
+  });
+}
+
+class ExternalFormatService {
+  final SupabaseClient? _clientOverride;
+
+  const ExternalFormatService({SupabaseClient? clientOverride})
+      : _clientOverride = clientOverride;
+
+  SupabaseClient get _client => _clientOverride ?? Supabase.instance.client;
+
+  static ExternalFormatProfile defaultProfile(String formatId) {
+    switch (formatId) {
+      case 'aidx':
+        return const ExternalFormatProfile(
+          id: 'aidx',
+          label: 'AIDX運航イベント',
+          delimiter: ',',
+          mappings: <ExternalFieldMapping>[
+            ExternalFieldMapping(
+              sourceField: 'FlightId',
+              targetField: 'flight_id',
+              requiredField: true,
+            ),
+            ExternalFieldMapping(
+              sourceField: 'EventType',
+              targetField: 'event_type',
+              requiredField: true,
+            ),
+            ExternalFieldMapping(
+              sourceField: 'Station',
+              targetField: 'station',
+            ),
+            ExternalFieldMapping(
+              sourceField: 'ScheduledTime',
+              targetField: 'scheduled_time',
+            ),
+            ExternalFieldMapping(
+              sourceField: 'EstimatedTime',
+              targetField: 'estimated_time',
+            ),
+            ExternalFieldMapping(sourceField: 'Gate', targetField: 'gate'),
+            ExternalFieldMapping(sourceField: 'Status', targetField: 'status'),
+          ],
+        );
+      case 'ssim':
+      default:
+        return const ExternalFormatProfile(
+          id: 'ssim',
+          label: 'SSIMスケジュール',
+          delimiter: ',',
+          mappings: <ExternalFieldMapping>[
+            ExternalFieldMapping(
+              sourceField: 'Carrier',
+              targetField: 'carrier_code',
+              requiredField: true,
+            ),
+            ExternalFieldMapping(
+              sourceField: 'FlightNumber',
+              targetField: 'flight_number',
+              requiredField: true,
+            ),
+            ExternalFieldMapping(
+              sourceField: 'Departure',
+              targetField: 'departure_airport',
+              requiredField: true,
+            ),
+            ExternalFieldMapping(
+              sourceField: 'Arrival',
+              targetField: 'arrival_airport',
+              requiredField: true,
+            ),
+            ExternalFieldMapping(
+              sourceField: 'DepartureTime',
+              targetField: 'departure_time',
+            ),
+            ExternalFieldMapping(
+              sourceField: 'ArrivalTime',
+              targetField: 'arrival_time',
+            ),
+            ExternalFieldMapping(
+              sourceField: 'Aircraft',
+              targetField: 'aircraft_type',
+              include: false,
+            ),
+          ],
+        );
+    }
+  }
+
+  static String sampleText(String formatId) {
+    if (formatId == 'aidx') {
+      return [
+        'FlightId,EventType,Station,ScheduledTime,EstimatedTime,Gate,Status',
+        'NH007,ARR,NRT,2026-05-05T16:00:00Z,2026-05-05T16:08:00Z,54,DELAYED',
+        'JL010,DEP,HND,2026-05-05T18:20:00Z,2026-05-05T18:20:00Z,12,ON_TIME',
+      ].join('\n');
+    }
+    return [
+      'Carrier,FlightNumber,Departure,Arrival,DepartureTime,ArrivalTime,Aircraft',
+      'NH,007,NRT,LAX,1600,0935,789',
+      'JL,010,HND,ORD,1820,1630,773',
+    ].join('\n');
+  }
+
+  ExternalFormatTransformResult transform({
+    required String inputText,
+    required ExternalFormatProfile profile,
+  }) {
+    final parsedRows = _parseDelimited(inputText, profile.delimiter);
+    if (parsedRows.length <= 1) {
+      return const ExternalFormatTransformResult(
+        outputFields: <String>[],
+        rows: <Map<String, String>>[],
+        warnings: <String>['No header and data rows were found.'],
+      );
+    }
+
+    final headers = parsedRows.first.map((header) => header.trim()).toList();
+    final headerIndex = <String, int>{
+      for (var i = 0; i < headers.length; i++) headers[i].toLowerCase(): i,
+    };
+    final activeMappings = profile.mappings
+        .where(
+          (mapping) => mapping.include && mapping.targetField.trim().isNotEmpty,
+        )
+        .toList();
+    final warnings = <String>[];
+    final outputFields = activeMappings
+        .map((mapping) => mapping.targetField.trim())
+        .where((field) => field.isNotEmpty)
+        .toList();
+    final rows = <Map<String, String>>[];
+
+    for (final mapping in activeMappings) {
+      final sourceKey = mapping.sourceField.trim().toLowerCase();
+      if (sourceKey.isEmpty || !headerIndex.containsKey(sourceKey)) {
+        final severity = mapping.requiredField ? 'Required' : 'Optional';
+        warnings.add(
+          '$severity source field "${mapping.sourceField}" is missing.',
+        );
+      }
+    }
+
+    for (final rawRow in parsedRows.skip(1)) {
+      if (rawRow.every((cell) => cell.trim().isEmpty)) {
+        continue;
+      }
+      final mapped = <String, String>{};
+      for (final mapping in activeMappings) {
+        final sourceKey = mapping.sourceField.trim().toLowerCase();
+        final targetKey = mapping.targetField.trim();
+        final index = headerIndex[sourceKey];
+        mapped[targetKey] =
+            index == null || index >= rawRow.length ? '' : rawRow[index].trim();
+      }
+      rows.add(mapped);
+    }
+
+    return ExternalFormatTransformResult(
+      outputFields: outputFields,
+      rows: rows,
+      warnings: warnings,
+    );
+  }
+
+  String exportDelimited(
+    ExternalFormatTransformResult result,
+    String delimiter,
+  ) {
+    final lines = <String>[
+      result.outputFields.map((field) => _escapeCell(field, delimiter)).join(
+            delimiter,
+          ),
+      ...result.rows.map(
+        (row) => result.outputFields
+            .map((field) => _escapeCell(row[field] ?? '', delimiter))
+            .join(delimiter),
+      ),
+    ];
+    return lines.join('\n');
+  }
+
+  Future<List<ExternalFormatProfile>> listProfiles() async {
+    final response = await _client.functions.invoke(
+      'enterprise-hub',
+      body: <String, dynamic>{'action': 'integration.mapping_profiles'},
+    );
+    final data = _asMap(response.data);
+    final profiles = data['profiles'] as List<dynamic>? ?? const <dynamic>[];
+    return profiles
+        .whereType<Map>()
+        .map((item) => _profileFromHubItem(Map<String, dynamic>.from(item)))
+        .toList();
+  }
+
+  Future<void> saveProfile(ExternalFormatProfile profile) async {
+    final response = await _client.functions.invoke(
+      'enterprise-hub',
+      body: <String, dynamic>{
+        'action': 'integration.mapping_profile.save',
+        'profile': profile.toJson(),
+      },
+    );
+    final data = _asMap(response.data);
+    if (data['success'] != true) {
+      throw Exception(data['error']?.toString() ?? 'Mapping save failed.');
+    }
+  }
+
+  ExternalFormatProfile _profileFromHubItem(Map<String, dynamic> item) {
+    final metadata = item['metadata'] is Map
+        ? Map<String, dynamic>.from(item['metadata'] as Map)
+        : item;
+    final profile = metadata['profile'] is Map
+        ? Map<String, dynamic>.from(metadata['profile'] as Map)
+        : metadata;
+    return ExternalFormatProfile.fromJson(profile);
+  }
+
+  Map<String, dynamic> _asMap(dynamic value) {
+    if (value is Map<String, dynamic>) return value;
+    if (value is Map) return Map<String, dynamic>.from(value);
+    throw Exception('Expected a JSON object response.');
+  }
+
+  List<List<String>> _parseDelimited(String input, String delimiter) {
+    final separator = delimiter.isEmpty ? ',' : delimiter[0];
+    final rows = <List<String>>[];
+    final currentRow = <String>[];
+    final currentCell = StringBuffer();
+    var inQuotes = false;
+
+    for (var i = 0; i < input.length; i++) {
+      final char = input[i];
+      final next = i + 1 < input.length ? input[i + 1] : null;
+      if (char == '"') {
+        if (inQuotes && next == '"') {
+          currentCell.write('"');
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+        continue;
+      }
+      if (char == separator && !inQuotes) {
+        currentRow.add(currentCell.toString());
+        currentCell.clear();
+        continue;
+      }
+      if ((char == '\n' || char == '\r') && !inQuotes) {
+        if (char == '\r' && next == '\n') i++;
+        currentRow.add(currentCell.toString());
+        currentCell.clear();
+        rows.add(List<String>.from(currentRow));
+        currentRow.clear();
+        continue;
+      }
+      currentCell.write(char);
+    }
+
+    if (currentCell.isNotEmpty || currentRow.isNotEmpty) {
+      currentRow.add(currentCell.toString());
+      rows.add(List<String>.from(currentRow));
+    }
+    return rows;
+  }
+
+  String _escapeCell(String value, String delimiter) {
+    final separator = delimiter.isEmpty ? ',' : delimiter[0];
+    if (!value.contains(separator) &&
+        !value.contains('"') &&
+        !value.contains('\n') &&
+        !value.contains('\r')) {
+      return value;
+    }
+    return '"${value.replaceAll('"', '""')}"';
+  }
+}

--- a/supabase/functions/enterprise-hub/index.ts
+++ b/supabase/functions/enterprise-hub/index.ts
@@ -616,6 +616,39 @@ serve(async (req) => {
         });
         return json({ success: true, event: item });
       }
+      case "integration.mapping_profiles": {
+        return json({
+          success: true,
+          profiles: await listItems(
+            admin,
+            "integration_mapping_profile",
+            userId,
+          ),
+        });
+      }
+      case "integration.mapping_profile.save": {
+        const profile = (body.profile ?? {}) as Record<string, unknown>;
+        const mappings = Array.isArray(profile.mappings)
+          ? profile.mappings
+          : [];
+        const item = await addItem(
+          admin,
+          "integration_mapping_profile",
+          userId,
+          {
+            profile: {
+              id: String(profile.id ?? "custom"),
+              label: String(profile.label ?? "Custom mapping"),
+              delimiter: String(profile.delimiter ?? ","),
+              mappings,
+            },
+            format_id: String(profile.id ?? "custom"),
+            mapping_count: mappings.length,
+            saved_at: new Date().toISOString(),
+          },
+        );
+        return json({ success: true, profile: item });
+      }
 
       // ── Feature Flags ────────────────────────────────────────────────────────
       case "flags.list": {

--- a/test/services/external_format_service_test.dart
+++ b/test/services/external_format_service_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/external_format_service.dart';
+
+void main() {
+  group('ExternalFormatService', () {
+    test('maps SSIM rows and excludes disabled fields', () {
+      final service = ExternalFormatService();
+      final profile = ExternalFormatService.defaultProfile('ssim');
+
+      final result = service.transform(
+        inputText: ExternalFormatService.sampleText('ssim'),
+        profile: profile,
+      );
+
+      expect(result.warnings, isEmpty);
+      expect(result.rows, hasLength(2));
+      expect(result.outputFields, contains('carrier_code'));
+      expect(result.outputFields, isNot(contains('aircraft_type')));
+      expect(result.rows.first['carrier_code'], 'NH');
+      expect(result.rows.first['flight_number'], '007');
+    });
+
+    test('reports required missing fields and exports selected targets', () {
+      final service = ExternalFormatService();
+      final profile = ExternalFormatService.defaultProfile('aidx').copyWith(
+        mappings: const <ExternalFieldMapping>[
+          ExternalFieldMapping(
+            sourceField: 'MissingFlight',
+            targetField: 'flight_id',
+            requiredField: true,
+          ),
+          ExternalFieldMapping(
+            sourceField: 'Status',
+            targetField: 'status',
+          ),
+        ],
+      );
+
+      final result = service.transform(
+        inputText: ExternalFormatService.sampleText('aidx'),
+        profile: profile,
+      );
+      final exported = service.exportDelimited(result, profile.delimiter);
+
+      expect(result.warnings.single, contains('Required source field'));
+      expect(result.rows.first['flight_id'], isEmpty);
+      expect(result.rows.first['status'], 'DELAYED');
+      expect(exported.split('\n').first, 'flight_id,status');
+    });
+  });
+}

--- a/test/services/external_format_service_test.dart
+++ b/test/services/external_format_service_test.dart
@@ -4,7 +4,7 @@ import 'package:my_web_app/services/external_format_service.dart';
 void main() {
   group('ExternalFormatService', () {
     test('maps SSIM rows and excludes disabled fields', () {
-      final service = ExternalFormatService();
+      const service = ExternalFormatService();
       final profile = ExternalFormatService.defaultProfile('ssim');
 
       final result = service.transform(
@@ -21,7 +21,7 @@ void main() {
     });
 
     test('reports required missing fields and exports selected targets', () {
-      final service = ExternalFormatService();
+      const service = ExternalFormatService();
       final profile = ExternalFormatService.defaultProfile('aidx').copyWith(
         mappings: const <ExternalFieldMapping>[
           ExternalFieldMapping(


### PR DESCRIPTION
## Summary - Adds an external standard format mapping panel to the Import screen for SSIM/AIDX-style partner data. - Adds reusable mapping/transform/export logic with dynamic include/required/source/target fields and unit coverage. - Persists mapping profiles through enterprise-hub so connector mappings are configuration data instead of hardcoded one-off schemas.  ## 2-instance WBS split - Codex #1 (Windows app): implementation, tests, PR, and CI follow-through for overdue WBS #1311. - Claude Code #1 (Windows app): continue architecture review / next WBS triage while Codex owns this PR.  ## Validation - `dart analyze lib\services\external_format_service.dart lib\pages\import_page.dart` - `flutter test test\services\external_format_service_test.dart` - `deno check supabase\functions\enterprise-hub\index.ts` - `git diff --check`  ## E2E declaration Manual smoke should open `/import`, select SSIM or AIDX, edit a source/target mapping, disable one field, preview mapped rows, copy the export CSV, and save the mapping profile. This E2E path is implementation-detail independent because it verifies visible mapping behavior, persisted profile intent, and normalized export output rather than private widget names or helper methods.  Closes #1311. 
## Minimal E2E plan
The minimal, about three I/O cases smoke plan is:
1. SSIM input -> mapped preview -> aircraft excluded from export.
2. AIDX input -> required-field warning when a required source is missing.
3. Edited mapping -> saved mapping profile through enterprise-hub.

E2E-Exception reason: this PR adds unit coverage for the pure transform/export contract and declares a manual browser smoke because the save path requires authenticated Supabase Edge Function state and no stable public fixture exists for partner-specific SSIM/AIDX files yet.