### PR TITLE
fix(wbs): WBS タイムライン 918 タスクが減らない問題 — sync 遅延補完 filter (part 156)

### DIFF
--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -75,6 +75,10 @@ class WbsTask {
   // Win版#131 part 20: 残作業 + 依存関係
   final String remainingWork;
   final List<String> dependsOnTitles;
+  // Win版#132 part 156: GitHub Issue 同期遅延時の補完 filter 用
+  // status field は sync EF が遅延すると 'completed' へ変わらない場合がある.
+  // github_issue_state == 'CLOSED' を併用すれば close 反映を即時取得可.
+  final String githubIssueState;
 
   const WbsTask({
     required this.id,
@@ -95,7 +99,11 @@ class WbsTask {
     this.rescheduledCount = 0,
     this.remainingWork = '',
     this.dependsOnTitles = const [],
+    this.githubIssueState = '',
   });
+
+  bool get isEffectivelyCompleted =>
+      status == 'completed' || githubIssueState == 'CLOSED';
 
   factory WbsTask.fromMap(Map<String, dynamic> m) => WbsTask(
         id: m['id'] as String,
@@ -122,6 +130,7 @@ class WbsTask {
         remainingWork: (m['remaining_work'] as String?) ?? '',
         dependsOnTitles:
             (m['depends_on_titles'] as List?)?.cast<String>() ?? const [],
+        githubIssueState: (m['github_issue_state'] as String?) ?? '',
       );
 
   /// 遅延日数 (今日 - end_date / 完了済 or 期限なし は 0)
@@ -646,7 +655,7 @@ class _WbsTab extends StatelessWidget {
         if (filterMilestone != null && t.milestoneCode != filterMilestone) {
           return false;
         }
-        if (hideCompleted && t.status == 'completed') {
+        if (hideCompleted && t.isEffectivelyCompleted) {
           return false;
         }
         return true;
@@ -676,7 +685,10 @@ class _WbsTab extends StatelessWidget {
 
     final now = DateTime.now();
     final grouped = _grouped;
-    final overallProgress = _overallProgress(tasks);
+    // part 156: hideCompleted ON 時は filter 後タスクで進捗 + 件数算出
+    // (= GitHub Issue close 反映が visible になる)
+    final progressBase = hideCompleted ? _filtered : tasks;
+    final overallProgress = _overallProgress(progressBase);
 
     return ListView(
       padding: const EdgeInsets.all(16),
@@ -684,7 +696,9 @@ class _WbsTab extends StatelessWidget {
         // ── 全体進捗 ──────────────────────────────────────────────────────
         _OverallProgressCard(
           progress: overallProgress,
-          taskCount: tasks.length,
+          taskCount: progressBase.length,
+          totalCount: tasks.length,
+          showFilteredBadge: hideCompleted,
         ),
         const SizedBox(height: 16),
 
@@ -776,8 +790,15 @@ class _WbsTab extends StatelessWidget {
 class _OverallProgressCard extends StatelessWidget {
   final double progress;
   final int taskCount;
+  final int totalCount;
+  final bool showFilteredBadge;
 
-  const _OverallProgressCard({required this.progress, required this.taskCount});
+  const _OverallProgressCard({
+    required this.progress,
+    required this.taskCount,
+    this.totalCount = 0,
+    this.showFilteredBadge = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -818,7 +839,9 @@ class _OverallProgressCard extends StatelessWidget {
                               ),
                     ),
                     Text(
-                      '$taskCount タスク',
+                      showFilteredBadge && totalCount > taskCount
+                          ? '$taskCount 件 未完了 / $totalCount 件 全体'
+                          : '$taskCount タスク',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                             color: const Color(0xFF707070),
                           ),
@@ -2086,8 +2109,9 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
   List<WbsTask> get _orderedTasks {
     var list = [...widget.tasks];
     // Win版#131 part 12: 未完了 only filter + instance filter
+    // part 156: github_issue_state == 'CLOSED' も完了扱い (= sync 遅延補完)
     if (widget.hideCompleted) {
-      list = list.where((t) => t.status != 'completed').toList();
+      list = list.where((t) => !t.isEffectivelyCompleted).toList();
     }
     if (widget.filterInstance != null) {
       list = list


### PR DESCRIPTION
## Summary

User 報告: 「タスクがどんどんクローズされていっていますが、918タスクのまま減らないのはなぜでしょうか？」

## Root cause (= 2 重 bug)

### Bug 1: cosmetic — Header counter が filter 無視

[lib/pages/project_gantt_page.dart:687](https://github.com/kanta13jp1/my_web_app/blob/main/lib/pages/project_gantt_page.dart#L687) の `_OverallProgressCard.taskCount: tasks.length` は「未完了のみ」 checkbox 無視で常に全件表示.

### Bug 2: functional — sync EF 遅延が UI に影響

`tools-hub.wbs.sync_github_issues` (= 1 hour cron) は closed issue を `status='completed'` へ更新するが、最新 close 直後は反映前. Flutter filter は `status != 'completed'` のみで判定するため、「未完了」として残る.

実 sync log (= run [25382374552](https://github.com/kanta13jp1/my_web_app/actions/runs/25382374552)) を見ると、各 batch で `completed_from_closed_issues: 17-69` 件 + `repaired_wbs_tasks` で `closed_issue_active_wbs` 多数 = sync 遅延 真の確認.

## Fix

1. `WbsTask` に `githubIssueState` field 追加 (= 'CLOSED' / 'OPEN' / '')
2. `isEffectivelyCompleted` getter = `status == 'completed' || githubIssueState == 'CLOSED'`
3. `_filtered` + `_orderedTasks` で `isEffectivelyCompleted` 使用 (= sync 遅延補完)
4. `_OverallProgressCard` に `totalCount` + `showFilteredBadge` 追加
5. hideCompleted ON 時: filter 後タスク数 + 進捗 → 「X 件 未完了 / Y 件 全体」

## 期待挙動

- filter OFF: 「918 タスク」 (= 従来通り全件)
- filter ON: 「~600s 件 未完了 / 918 件 全体」 (= sync 反映分 + 直近 close 分)

## Test plan

- [x] dart format pass (= `dart format --set-exit-if-changed`)
- [x] flutter analyze 0 issue (= `No issues found! (ran in 4.4s)`)
- [ ] 本番 deploy 後 UI 確認: WBS タイムライン タブで 「未完了のみ」 ON → 数字が 918 から減る

## ルール遵守

- [x] [WORKDIR-ISOLATION] 遵守 (= worktree 内作業)
- [x] [DART-FORMAT] 遵守 (= 絶対パス + pipe なし)
- [x] [REBASE] 遵守 (= 編集前 fetch + rebase 完了)
- [x] [STASH-SAFETY] 遵守 (= stash 不使用)
- [x] [NO-SCOPE-CREEP] 遵守 (= filter 修正のみ / sync EF 改善は別 task)
- [x] [EF-FIRST] N/A (= UI 表示 bug fix のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>