### PR TITLE
feat(deploy): auto-create monitoring setup

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -20,6 +20,7 @@ import '../pages/conveni_store_page.dart';
 import '../pages/daily_habits_page.dart';
 import '../pages/danshari_page.dart';
 import '../pages/decision_check_page.dart';
+import '../pages/deployment_monitoring_setup_page.dart';
 import '../pages/digest_queue_page.dart';
 import '../pages/edge_function_status_page.dart';
 import '../pages/edge_llm_playground_page.dart';
@@ -1043,6 +1044,24 @@ List<HomeToolEntry> buildHomeToolCatalog({
       color: const Color(0xFF607D8B),
       keywords: const <String>['Edge Function', 'API', 'status'],
       onOpen: (context) => _pushPage(context, const EdgeFunctionStatusPage()),
+    ),
+    HomeToolEntry(
+      id: 'deployment-monitoring',
+      sectionId: 'growth',
+      title: 'デプロイ監視自動設定',
+      subtitle: '新規サービス作成時に基本メトリクスと監視ダッシュボードを自動で用意',
+      icon: Icons.monitor_heart_outlined,
+      color: const Color(0xFF0F766E),
+      keywords: const <String>[
+        'deployment',
+        'monitoring',
+        'Datadog',
+        'CloudWatch',
+        '監視',
+        'デプロイ',
+      ],
+      onOpen: (context) =>
+          _pushPage(context, const DeploymentMonitoringSetupPage()),
     ),
     HomeToolEntry(
       id: 'ai-search',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -267,6 +267,7 @@ import 'package:my_web_app/pages/agent_hub_page.dart';
 import 'package:my_web_app/pages/admin_notification_hub_page.dart';
 import 'package:my_web_app/pages/competitor_feature_sync_page.dart';
 import 'package:my_web_app/pages/daily_judgment_page.dart';
+import 'package:my_web_app/pages/deployment_monitoring_setup_page.dart';
 import 'package:my_web_app/pages/ai_university_content_page.dart';
 import 'package:my_web_app/pages/development_achievements_page.dart';
 import 'package:my_web_app/pages/invoice_generator_page.dart';
@@ -1686,6 +1687,10 @@ class _MyAppState extends State<MyApp> {
           case '/app-analytics-dashboard':
             return MaterialPageRoute(
               builder: (_) => const AppAnalyticsDashboardPage(),
+            );
+          case '/deployment-monitoring':
+            return MaterialPageRoute(
+              builder: (_) => const DeploymentMonitoringSetupPage(),
             );
           case '/dev/claude-design-importer':
             return MaterialPageRoute(

--- a/lib/pages/deployment_monitoring_setup_page.dart
+++ b/lib/pages/deployment_monitoring_setup_page.dart
@@ -1,0 +1,447 @@
+import 'package:flutter/material.dart';
+import 'package:my_web_app/services/deployment_monitoring_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class DeploymentMonitoringSetupPage extends StatefulWidget {
+  const DeploymentMonitoringSetupPage({super.key});
+
+  @override
+  State<DeploymentMonitoringSetupPage> createState() =>
+      _DeploymentMonitoringSetupPageState();
+}
+
+class _DeploymentMonitoringSetupPageState
+    extends State<DeploymentMonitoringSetupPage> {
+  final _service = const DeploymentMonitoringService();
+  final _nameController = TextEditingController(text: 'customer-api');
+  final _supabase = Supabase.instance.client;
+
+  String _platform = DeploymentMonitoringService.supportedPlatforms.first;
+  String _provider = DeploymentMonitoringService.supportedProviders.first;
+  String _environment = 'production';
+  bool _autoMonitoringEnabled = true;
+  bool _saving = false;
+  String? _saveMessage;
+  DeploymentMonitoringSetup? _setup;
+
+  @override
+  void initState() {
+    super.initState();
+    _buildPreview();
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _buildPreview() {
+    setState(() {
+      _saveMessage = null;
+      _setup = _service.buildSetup(
+        DeploymentMonitoringRequest(
+          serviceName: _nameController.text,
+          platform: _platform,
+          environment: _environment,
+          provider: _provider,
+          autoMonitoringEnabled: _autoMonitoringEnabled,
+        ),
+      );
+    });
+  }
+
+  Future<void> _createSetup() async {
+    final setup = _setup;
+    if (setup == null) return;
+    setState(() {
+      _saving = true;
+      _saveMessage = null;
+    });
+    try {
+      if (_supabase.auth.currentUser != null) {
+        final response = await _supabase.functions.invoke(
+          'enterprise-hub',
+          body: {
+            'action': 'deployment.monitoring.setup',
+            ...setup.toJson(),
+          },
+        );
+        final data = response.data;
+        final ok =
+            response.status == 200 && data is Map && data['success'] == true;
+        if (!ok) {
+          throw Exception(data is Map ? data['error'] : 'save failed');
+        }
+      }
+      if (!mounted) return;
+      setState(() {
+        _saveMessage =
+            setup.autoMonitoringEnabled ? 'モニタリング設定を作成しました' : 'オプトアウトを記録しました';
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _saveMessage = '保存は未完了です: $error');
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final setup = _setup;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('デプロイ監視自動セットアップ'),
+        actions: [
+          IconButton(
+            tooltip: 'プレビュー更新',
+            onPressed: _buildPreview,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final wide = constraints.maxWidth >= 900;
+          final form = _buildForm();
+          final dashboard =
+              setup == null ? const SizedBox.shrink() : _buildDashboard(setup);
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: wide
+                ? Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(width: 360, child: form),
+                      const SizedBox(width: 16),
+                      Expanded(child: dashboard),
+                    ],
+                  )
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      form,
+                      const SizedBox(height: 16),
+                      dashboard,
+                    ],
+                  ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildForm() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              '新規サービス',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'サービス名',
+                prefixIcon: Icon(Icons.rocket_launch_outlined),
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (_) => _buildPreview(),
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              initialValue: _platform,
+              decoration: const InputDecoration(
+                labelText: 'デプロイ先',
+                border: OutlineInputBorder(),
+              ),
+              items: DeploymentMonitoringService.supportedPlatforms
+                  .map(
+                    (value) => DropdownMenuItem(
+                      value: value,
+                      child: Text(value),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (value) {
+                if (value == null) return;
+                setState(() => _platform = value);
+                _buildPreview();
+              },
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              initialValue: _environment,
+              decoration: const InputDecoration(
+                labelText: '環境',
+                border: OutlineInputBorder(),
+              ),
+              items: const [
+                DropdownMenuItem(
+                  value: 'production',
+                  child: Text('production'),
+                ),
+                DropdownMenuItem(value: 'staging', child: Text('staging')),
+                DropdownMenuItem(
+                  value: 'development',
+                  child: Text('development'),
+                ),
+              ],
+              onChanged: (value) {
+                if (value == null) return;
+                setState(() => _environment = value);
+                _buildPreview();
+              },
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              initialValue: _provider,
+              decoration: const InputDecoration(
+                labelText: '監視プロバイダー',
+                border: OutlineInputBorder(),
+              ),
+              items: DeploymentMonitoringService.supportedProviders
+                  .map(
+                    (value) => DropdownMenuItem(
+                      value: value,
+                      child: Text(value),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (value) {
+                if (value == null) return;
+                setState(() => _provider = value);
+                _buildPreview();
+              },
+            ),
+            const SizedBox(height: 8),
+            SwitchListTile(
+              value: _autoMonitoringEnabled,
+              title: const Text('基本監視を自動で有効化'),
+              subtitle: const Text('オフにするとオプトアウトとして記録します'),
+              contentPadding: EdgeInsets.zero,
+              onChanged: (value) {
+                setState(() => _autoMonitoringEnabled = value);
+                _buildPreview();
+              },
+            ),
+            const SizedBox(height: 12),
+            FilledButton.icon(
+              onPressed: _saving ? null : _createSetup,
+              icon: _saving
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.add_chart_outlined),
+              label: const Text('作成'),
+            ),
+            if (_saveMessage != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                _saveMessage!,
+                style: TextStyle(
+                  color: _saveMessage!.startsWith('保存は')
+                      ? Colors.red
+                      : Colors.green,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDashboard(DeploymentMonitoringSetup setup) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Icon(
+                  setup.autoMonitoringEnabled
+                      ? Icons.monitor_heart_outlined
+                      : Icons.visibility_off_outlined,
+                  color: setup.autoMonitoringEnabled
+                      ? const Color(0xFF0F766E)
+                      : Colors.orange,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        setup.serviceName,
+                        style: const TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      Text('${setup.platform} / ${setup.environment}'),
+                    ],
+                  ),
+                ),
+                Chip(label: Text(setup.statusLabel)),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        if (setup.metrics.isEmpty)
+          _buildOptOutPanel(setup)
+        else
+          _buildMetricsGrid(setup.metrics),
+        const SizedBox(height: 12),
+        _buildListPanel(
+          title: 'ダッシュボードに追加される項目',
+          icon: Icons.dashboard_customize_outlined,
+          items: setup.dashboardWidgets,
+        ),
+        const SizedBox(height: 12),
+        _buildListPanel(
+          title: '自動セットアップ手順',
+          icon: Icons.playlist_add_check_outlined,
+          items: setup.setupSteps,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOptOutPanel(DeploymentMonitoringSetup setup) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '監視は無効です',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '${setup.serviceName} は自動監視を使わない設定です。'
+              '本番公開前に手動監視またはWBSフォローアップを追加してください。',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMetricsGrid(List<MonitoringMetricTemplate> metrics) {
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: metrics.length,
+      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: 260,
+        mainAxisExtent: 150,
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+      ),
+      itemBuilder: (context, index) {
+        final metric = metrics[index];
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(14),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  metric.label,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '${metric.sampleValue}${metric.unit}',
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFF0F766E),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Warn ${metric.warningThreshold}${metric.unit} / '
+                  'Critical ${metric.criticalThreshold}${metric.unit}',
+                  style: const TextStyle(fontSize: 12),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  metric.description,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontSize: 12, color: Colors.grey),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildListPanel({
+    required String title,
+    required IconData icon,
+    required List<String> items,
+  }) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, size: 18, color: const Color(0xFF4F46E5)),
+                const SizedBox(width: 8),
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ...items.map(
+              (item) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Icon(
+                      Icons.check_circle,
+                      size: 16,
+                      color: Colors.green,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(child: Text(item)),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/deployment_monitoring_service.dart
+++ b/lib/services/deployment_monitoring_service.dart
@@ -1,0 +1,295 @@
+class DeploymentMonitoringRequest {
+  const DeploymentMonitoringRequest({
+    required this.serviceName,
+    required this.platform,
+    required this.environment,
+    required this.provider,
+    this.autoMonitoringEnabled = true,
+    this.thresholdOverrides = const <String, double>{},
+    this.createdAt,
+  });
+
+  final String serviceName;
+  final String platform;
+  final String environment;
+  final String provider;
+  final bool autoMonitoringEnabled;
+  final Map<String, double> thresholdOverrides;
+  final DateTime? createdAt;
+}
+
+class MonitoringMetricTemplate {
+  const MonitoringMetricTemplate({
+    required this.key,
+    required this.label,
+    required this.unit,
+    required this.warningThreshold,
+    required this.criticalThreshold,
+    required this.sampleValue,
+    required this.description,
+  });
+
+  final String key;
+  final String label;
+  final String unit;
+  final double warningThreshold;
+  final double criticalThreshold;
+  final double sampleValue;
+  final String description;
+
+  MonitoringMetricTemplate copyWith({
+    double? warningThreshold,
+    double? criticalThreshold,
+  }) {
+    return MonitoringMetricTemplate(
+      key: key,
+      label: label,
+      unit: unit,
+      warningThreshold: warningThreshold ?? this.warningThreshold,
+      criticalThreshold: criticalThreshold ?? this.criticalThreshold,
+      sampleValue: sampleValue,
+      description: description,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'key': key,
+      'label': label,
+      'unit': unit,
+      'warning_threshold': warningThreshold,
+      'critical_threshold': criticalThreshold,
+      'sample_value': sampleValue,
+      'description': description,
+    };
+  }
+}
+
+class DeploymentMonitoringSetup {
+  const DeploymentMonitoringSetup({
+    required this.id,
+    required this.serviceName,
+    required this.platform,
+    required this.environment,
+    required this.provider,
+    required this.autoMonitoringEnabled,
+    required this.metrics,
+    required this.dashboardWidgets,
+    required this.setupSteps,
+    required this.createdAt,
+    required this.statusLabel,
+  });
+
+  final String id;
+  final String serviceName;
+  final String platform;
+  final String environment;
+  final String provider;
+  final bool autoMonitoringEnabled;
+  final List<MonitoringMetricTemplate> metrics;
+  final List<String> dashboardWidgets;
+  final List<String> setupSteps;
+  final DateTime createdAt;
+  final String statusLabel;
+
+  int get metricCount => metrics.length;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'service_name': serviceName,
+      'platform': platform,
+      'environment': environment,
+      'provider': provider,
+      'auto_monitoring_enabled': autoMonitoringEnabled,
+      'metrics': metrics.map((metric) => metric.toJson()).toList(),
+      'dashboard_widgets': dashboardWidgets,
+      'setup_steps': setupSteps,
+      'created_at': createdAt.toUtc().toIso8601String(),
+      'status_label': statusLabel,
+    };
+  }
+}
+
+class DeploymentMonitoringService {
+  const DeploymentMonitoringService();
+
+  static const supportedPlatforms = <String>[
+    'Supabase Edge Function',
+    'Vercel Web App',
+    'AWS ECS / Lambda',
+    'Generic API Service',
+  ];
+
+  static const supportedProviders = <String>[
+    'Built-in dashboard',
+    'CloudWatch',
+    'Datadog',
+  ];
+
+  DeploymentMonitoringSetup buildSetup(DeploymentMonitoringRequest request) {
+    final createdAt = (request.createdAt ?? DateTime.now()).toUtc();
+    final serviceName = _normalizeServiceName(request.serviceName);
+    final id = '${_slug(serviceName)}-${createdAt.millisecondsSinceEpoch}';
+
+    if (!request.autoMonitoringEnabled) {
+      return DeploymentMonitoringSetup(
+        id: id,
+        serviceName: serviceName,
+        platform: request.platform,
+        environment: request.environment,
+        provider: request.provider,
+        autoMonitoringEnabled: false,
+        metrics: const <MonitoringMetricTemplate>[],
+        dashboardWidgets: const <String>[
+          'Opt-out audit trail',
+          'Manual monitoring reminder',
+        ],
+        setupSteps: const <String>[
+          'Record opt-out reason before production release',
+          'Create a WBS follow-up if the service becomes customer-facing',
+        ],
+        createdAt: createdAt,
+        statusLabel: 'Monitoring opt-out',
+      );
+    }
+
+    final metrics = defaultMetricsFor(request.platform).map((metric) {
+      final override = request.thresholdOverrides[metric.key];
+      if (override == null) return metric;
+      return metric.copyWith(
+        warningThreshold: override,
+        criticalThreshold: override * 1.25,
+      );
+    }).toList(growable: false);
+
+    return DeploymentMonitoringSetup(
+      id: id,
+      serviceName: serviceName,
+      platform: request.platform,
+      environment: request.environment,
+      provider: request.provider,
+      autoMonitoringEnabled: true,
+      metrics: metrics,
+      dashboardWidgets: _dashboardWidgetsFor(request.platform),
+      setupSteps: _setupStepsFor(request.provider, request.platform),
+      createdAt: createdAt,
+      statusLabel: 'Monitoring auto-enabled',
+    );
+  }
+
+  List<MonitoringMetricTemplate> defaultMetricsFor(String platform) {
+    final normalized = platform.toLowerCase();
+    final metrics = <MonitoringMetricTemplate>[
+      const MonitoringMetricTemplate(
+        key: 'availability',
+        label: 'Availability',
+        unit: '%',
+        warningThreshold: 99,
+        criticalThreshold: 95,
+        sampleValue: 99.9,
+        description: 'Successful health checks over the last 24 hours.',
+      ),
+      const MonitoringMetricTemplate(
+        key: 'error_rate',
+        label: 'Error rate',
+        unit: '%',
+        warningThreshold: 1,
+        criticalThreshold: 5,
+        sampleValue: 0.2,
+        description: 'HTTP 5xx or failed job ratio over the last hour.',
+      ),
+      const MonitoringMetricTemplate(
+        key: 'p95_latency',
+        label: 'p95 latency',
+        unit: 'ms',
+        warningThreshold: 800,
+        criticalThreshold: 1500,
+        sampleValue: 240,
+        description: '95th percentile response time.',
+      ),
+      const MonitoringMetricTemplate(
+        key: 'cpu_or_invocations',
+        label: 'CPU / invocations',
+        unit: 'score',
+        warningThreshold: 75,
+        criticalThreshold: 90,
+        sampleValue: 38,
+        description: 'CPU pressure or function invocation saturation.',
+      ),
+    ];
+    if (normalized.contains('edge') || normalized.contains('lambda')) {
+      metrics.add(
+        const MonitoringMetricTemplate(
+          key: 'cold_start',
+          label: 'Cold start',
+          unit: 'ms',
+          warningThreshold: 1200,
+          criticalThreshold: 2500,
+          sampleValue: 410,
+          description: 'Serverless cold start duration.',
+        ),
+      );
+    }
+    if (normalized.contains('ecs') || normalized.contains('generic')) {
+      metrics.add(
+        const MonitoringMetricTemplate(
+          key: 'memory_pressure',
+          label: 'Memory pressure',
+          unit: '%',
+          warningThreshold: 80,
+          criticalThreshold: 92,
+          sampleValue: 47,
+          description: 'Resident memory or container memory pressure.',
+        ),
+      );
+    }
+    return metrics;
+  }
+
+  List<String> _dashboardWidgetsFor(String platform) {
+    final widgets = <String>[
+      'Health summary',
+      'Latency and error trend',
+      'Recent incidents',
+      'Alert threshold table',
+    ];
+    if (platform.toLowerCase().contains('edge')) {
+      widgets.add('Function invocation heatmap');
+    }
+    return widgets;
+  }
+
+  List<String> _setupStepsFor(String provider, String platform) {
+    final steps = <String>[
+      'Create default health check target',
+      'Attach metric thresholds to the service record',
+      'Show metrics on the deployment monitoring dashboard',
+    ];
+    if (provider == 'CloudWatch') {
+      steps.add('Prepare CloudWatch alarm mapping for AWS resources');
+    } else if (provider == 'Datadog') {
+      steps.add('Prepare Datadog monitor payload for external sync');
+    } else {
+      steps.add('Keep metrics in the built-in dashboard until external sync');
+    }
+    if (platform.toLowerCase().contains('vercel')) {
+      steps.add('Track deployment URL and production alias health');
+    }
+    return steps;
+  }
+
+  String _normalizeServiceName(String value) {
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? 'new-service' : trimmed;
+  }
+
+  String _slug(String value) {
+    final slug = value
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+        .replaceAll(RegExp(r'^-+|-+$'), '');
+    return slug.isEmpty ? 'new-service' : slug;
+  }
+}

--- a/supabase/functions/enterprise-hub/index.ts
+++ b/supabase/functions/enterprise-hub/index.ts
@@ -72,6 +72,119 @@ async function addItem(
   return data;
 }
 
+function monitoringMetricsFor(
+  platform: string,
+): Array<Record<string, unknown>> {
+  const normalized = platform.toLowerCase();
+  const metrics: Array<Record<string, unknown>> = [
+    {
+      key: "availability",
+      label: "Availability",
+      unit: "%",
+      warning_threshold: 99,
+      critical_threshold: 95,
+      sample_value: 99.9,
+    },
+    {
+      key: "error_rate",
+      label: "Error rate",
+      unit: "%",
+      warning_threshold: 1,
+      critical_threshold: 5,
+      sample_value: 0.2,
+    },
+    {
+      key: "p95_latency",
+      label: "p95 latency",
+      unit: "ms",
+      warning_threshold: 800,
+      critical_threshold: 1500,
+      sample_value: 240,
+    },
+    {
+      key: "cpu_or_invocations",
+      label: "CPU / invocations",
+      unit: "score",
+      warning_threshold: 75,
+      critical_threshold: 90,
+      sample_value: 38,
+    },
+  ];
+  if (normalized.includes("edge") || normalized.includes("lambda")) {
+    metrics.push({
+      key: "cold_start",
+      label: "Cold start",
+      unit: "ms",
+      warning_threshold: 1200,
+      critical_threshold: 2500,
+      sample_value: 410,
+    });
+  }
+  if (normalized.includes("ecs") || normalized.includes("generic")) {
+    metrics.push({
+      key: "memory_pressure",
+      label: "Memory pressure",
+      unit: "%",
+      warning_threshold: 80,
+      critical_threshold: 92,
+      sample_value: 47,
+    });
+  }
+  return metrics;
+}
+
+function buildDeploymentMonitoringRecord(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const serviceName = textValue(body.service_name, "new-service");
+  const platform = textValue(body.platform, "Generic API Service");
+  const provider = textValue(body.provider, "Built-in dashboard");
+  const environment = textValue(body.environment, "production");
+  const autoMonitoringEnabled = body.auto_monitoring_enabled !== false;
+  const metrics = autoMonitoringEnabled
+    ? (Array.isArray(body.metrics) && body.metrics.length > 0
+      ? body.metrics
+      : monitoringMetricsFor(platform))
+    : [];
+  const dashboardWidgets = Array.isArray(body.dashboard_widgets)
+    ? body.dashboard_widgets
+    : autoMonitoringEnabled
+    ? [
+      "Health summary",
+      "Latency and error trend",
+      "Recent incidents",
+      "Alert threshold table",
+    ]
+    : ["Opt-out audit trail", "Manual monitoring reminder"];
+  const setupSteps = Array.isArray(body.setup_steps)
+    ? body.setup_steps
+    : autoMonitoringEnabled
+    ? [
+      "Create default health check target",
+      "Attach metric thresholds to the service record",
+      "Show metrics on the deployment monitoring dashboard",
+    ]
+    : [
+      "Record opt-out reason before production release",
+      "Create a WBS follow-up if the service becomes customer-facing",
+    ];
+
+  return {
+    service_name: serviceName,
+    platform,
+    provider,
+    environment,
+    auto_monitoring_enabled: autoMonitoringEnabled,
+    metrics,
+    dashboard_widgets: dashboardWidgets,
+    setup_steps: setupSteps,
+    status_label: autoMonitoringEnabled
+      ? "Monitoring auto-enabled"
+      : "Monitoring opt-out",
+    created_at: textValue(body.created_at, new Date().toISOString()),
+  };
+}
+
 type TomeCompetitorRow = {
   Product: string;
   Feature: string;
@@ -648,6 +761,35 @@ serve(async (req) => {
           },
         );
         return json({ success: true, profile: item });
+      }
+
+      // ── Deployment Monitoring ────────────────────────────────────────────────
+      case "deployment.monitoring_setups": {
+        return json({
+          success: true,
+          setups: await listItems(
+            admin,
+            "deployment_monitoring_setup",
+            userId,
+          ),
+        });
+      }
+      case "deployment.monitoring.setup": {
+        const record = buildDeploymentMonitoringRecord(body);
+        const item = await addItem(
+          admin,
+          "deployment_monitoring_setup",
+          userId,
+          {
+            ...record,
+            saved_at: new Date().toISOString(),
+          },
+        );
+        return json({
+          success: true,
+          setup: item,
+          monitoring: record,
+        });
       }
 
       // ── Feature Flags ────────────────────────────────────────────────────────

--- a/test/services/deployment_monitoring_service_test.dart
+++ b/test/services/deployment_monitoring_service_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/deployment_monitoring_service.dart';
+
+void main() {
+  group('DeploymentMonitoringService', () {
+    const service = DeploymentMonitoringService();
+
+    test('enables default monitoring for a new service deployment', () {
+      final setup = service.buildSetup(
+        DeploymentMonitoringRequest(
+          serviceName: 'Checkout API',
+          platform: 'Supabase Edge Function',
+          environment: 'production',
+          provider: 'Built-in dashboard',
+          createdAt: DateTime.utc(2026, 5, 5, 12),
+        ),
+      );
+
+      expect(setup.autoMonitoringEnabled, isTrue);
+      expect(setup.serviceName, 'Checkout API');
+      expect(setup.metrics.map((metric) => metric.key), contains('error_rate'));
+      expect(setup.metrics.map((metric) => metric.key), contains('cold_start'));
+      expect(setup.dashboardWidgets, contains('Health summary'));
+      expect(setup.statusLabel, 'Monitoring auto-enabled');
+    });
+
+    test('keeps an explicit opt-out auditable', () {
+      final setup = service.buildSetup(
+        DeploymentMonitoringRequest(
+          serviceName: 'Internal spike',
+          platform: 'Generic API Service',
+          environment: 'development',
+          provider: 'Datadog',
+          autoMonitoringEnabled: false,
+          createdAt: DateTime.utc(2026, 5, 5, 12),
+        ),
+      );
+
+      expect(setup.autoMonitoringEnabled, isFalse);
+      expect(setup.metrics, isEmpty);
+      expect(setup.dashboardWidgets, contains('Opt-out audit trail'));
+      expect(setup.setupSteps.join('\n'), contains('WBS follow-up'));
+    });
+
+    test('applies custom warning thresholds and keeps dashboard visible', () {
+      final setup = service.buildSetup(
+        DeploymentMonitoringRequest(
+          serviceName: '',
+          platform: 'AWS ECS / Lambda',
+          environment: 'staging',
+          provider: 'CloudWatch',
+          thresholdOverrides: const {'p95_latency': 500},
+          createdAt: DateTime.utc(2026, 5, 5, 12),
+        ),
+      );
+
+      final latency = setup.metrics.singleWhere(
+        (metric) => metric.key == 'p95_latency',
+      );
+      expect(setup.serviceName, 'new-service');
+      expect(latency.warningThreshold, 500);
+      expect(latency.criticalThreshold, 625);
+      expect(setup.metrics.map((metric) => metric.key), contains('cold_start'));
+      expect(setup.setupSteps.join('\n'), contains('CloudWatch'));
+    });
+  });
+}


### PR DESCRIPTION
## Minimal E2E Gate

- [x] Implementation-detail independent: the E2E plan checks user-visible input/output, not private internals.
- [x] Minimal scope: about 3 cases only (happy path, opt-out path, save/error recovery path).
- [x] E2E mechanism considered: Playwright or Flutter integration_test can cover `/deployment-monitoring` in a later browser pass.
- [x] E2E-Exception reason: no new integration_test/test/e2e file in this PR because targeted Dart service tests plus enterprise-hub type check cover the new setup contract, and local browser smoke is deferred to conserve memory under the 2-instance policy.

## Summary
- add a DeploymentMonitoringService that auto-generates default monitoring metrics, dashboard widgets, setup steps, and explicit opt-out records for new service deployments
- add `/deployment-monitoring` UI plus home catalog entry so users can create and preview monitoring setup before/after service creation
- add enterprise-hub actions `deployment.monitoring.setup` and `deployment.monitoring_setups` to persist/list generated setup records

## 2-instance policy
- Codex #1 (Windows app): implementation, tests, PR, CI follow-up
- Claude Code #1 (Windows app): WBS sequencing, architecture/design review, cross-instance handoff notes

## Validation
- `dart analyze lib\services\deployment_monitoring_service.dart lib\pages\deployment_monitoring_setup_page.dart test\services\deployment_monitoring_service_test.dart`
- `dart analyze lib\main.dart lib\data\home_tool_catalog.dart`
- `flutter test test\services\deployment_monitoring_service_test.dart`
- `deno check supabase\functions\enterprise-hub\index.ts`
- `git diff --check`

Closes #1323