### PR TITLE
feat(home): add 1 In 2 Out assist

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -1064,6 +1064,24 @@ List<HomeToolEntry> buildHomeToolCatalog({
           _pushPage(context, const DeploymentMonitoringSetupPage()),
     ),
     HomeToolEntry(
+      id: 'one-in-two-out-assist',
+      sectionId: 'growth',
+      title: '1 In 2 Out UI整理アシスト',
+      subtitle: '新規ウィジェット追加時に、利用頻度の低い2件を整理候補にする',
+      icon: Icons.rule_folder_outlined,
+      color: const Color(0xFF7C3AED),
+      keywords: const <String>[
+        '1 In 2 Out',
+        'UI整理',
+        'ウィジェット',
+        '利用頻度',
+        '認知負荷',
+      ],
+      onOpen: (context) => Navigator.of(context).pushNamed(
+        '/one-in-two-out-assist',
+      ),
+    ),
+    HomeToolEntry(
       id: 'ai-search',
       sectionId: 'growth',
       title: 'AI ノート検索',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -268,6 +268,7 @@ import 'package:my_web_app/pages/admin_notification_hub_page.dart';
 import 'package:my_web_app/pages/competitor_feature_sync_page.dart';
 import 'package:my_web_app/pages/daily_judgment_page.dart';
 import 'package:my_web_app/pages/deployment_monitoring_setup_page.dart';
+import 'package:my_web_app/pages/one_in_two_out_assist_page.dart';
 import 'package:my_web_app/pages/ai_university_content_page.dart';
 import 'package:my_web_app/pages/development_achievements_page.dart';
 import 'package:my_web_app/pages/invoice_generator_page.dart';
@@ -1691,6 +1692,12 @@ class _MyAppState extends State<MyApp> {
           case '/deployment-monitoring':
             return MaterialPageRoute(
               builder: (_) => const DeploymentMonitoringSetupPage(),
+            );
+          case '/one-in-two-out':
+          case '/one-in-two-out-assist':
+            return MaterialPageRoute(
+              builder: (_) => const OneInTwoOutAssistPage(),
+              settings: RouteSettings(name: settings.name),
             );
           case '/dev/claude-design-importer':
             return MaterialPageRoute(

--- a/lib/pages/one_in_two_out_assist_page.dart
+++ b/lib/pages/one_in_two_out_assist_page.dart
@@ -1,0 +1,400 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../data/home_tool_catalog.dart';
+import '../services/home_tool_usage_service.dart';
+import '../services/one_in_two_out_assist_service.dart';
+
+class OneInTwoOutAssistPage extends StatefulWidget {
+  const OneInTwoOutAssistPage({super.key});
+
+  @override
+  State<OneInTwoOutAssistPage> createState() => _OneInTwoOutAssistPageState();
+}
+
+class _OneInTwoOutAssistPageState extends State<OneInTwoOutAssistPage> {
+  static const String _optOutKey = 'one_in_two_out_prompt_opt_out_v1';
+
+  final _assistService = const OneInTwoOutAssistService();
+  final _incomingController = TextEditingController(text: '新しい分析カード');
+
+  bool _loading = true;
+  bool _promptOptedOut = false;
+  String? _statusMessage;
+  List<WidgetUsageSignal> _signals = const <WidgetUsageSignal>[];
+  OneInTwoOutSuggestion? _latestSuggestion;
+  final Set<String> _hiddenWidgetIds = <String>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSignals();
+  }
+
+  @override
+  void dispose() {
+    _incomingController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadSignals() async {
+    setState(() => _loading = true);
+    final prefs = await SharedPreferences.getInstance();
+    final catalog = buildHomeToolCatalog();
+    final candidates = catalog.map(
+      (entry) => HomeToolUsageCandidate(
+        id: entry.id,
+        title: entry.title,
+        sectionId: entry.sectionId,
+        routePath: entry.routePath,
+        isPinned: _isProtectedWidget(entry.id),
+        isVisible: !_hiddenWidgetIds.contains(entry.id),
+      ),
+    );
+    final signals = await HomeToolUsageService.loadUsageSignals(
+      candidates: candidates,
+      prefs: prefs,
+    );
+    if (!mounted) return;
+    setState(() {
+      _signals = signals;
+      _promptOptedOut = prefs.getBool(_optOutKey) ?? false;
+      _loading = false;
+    });
+  }
+
+  Future<void> _triggerWidgetAdd() async {
+    final incomingTitle = _incomingController.text.trim().isEmpty
+        ? '新しいウィジェット'
+        : _incomingController.text.trim();
+    final suggestion = _assistService.buildSuggestion(
+      incomingWidgetId: 'custom.${incomingTitle.hashCode}',
+      incomingWidgetTitle: incomingTitle,
+      existingWidgets: _signals.where(
+        (signal) => !_hiddenWidgetIds.contains(signal.id),
+      ),
+    );
+
+    setState(() {
+      _latestSuggestion = suggestion;
+      _statusMessage = null;
+    });
+
+    if (_promptOptedOut) {
+      setState(() {
+        _statusMessage = '提案を表示せずに「$incomingTitle」を追加しました。';
+      });
+      return;
+    }
+
+    await _showSuggestionDialog(suggestion);
+  }
+
+  Future<void> _showSuggestionDialog(OneInTwoOutSuggestion suggestion) async {
+    final selected =
+        suggestion.candidates.map((candidate) => candidate.signal.id).toSet();
+    var optOut = false;
+
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              title: Text('「${suggestion.incomingWidgetTitle}」を追加します'),
+              content: SizedBox(
+                width: 560,
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text('あまり使われていないウィジェットを2つ整理できます。'),
+                      const SizedBox(height: 12),
+                      for (final candidate in suggestion.candidates)
+                        CheckboxListTile(
+                          value: selected.contains(candidate.signal.id),
+                          onChanged: (value) {
+                            setDialogState(() {
+                              if (value ?? false) {
+                                selected.add(candidate.signal.id);
+                              } else {
+                                selected.remove(candidate.signal.id);
+                              }
+                            });
+                          },
+                          title: Text(candidate.signal.title),
+                          subtitle: Text(candidate.reason),
+                          controlAffinity: ListTileControlAffinity.leading,
+                          contentPadding: EdgeInsets.zero,
+                        ),
+                      const Divider(height: 24),
+                      CheckboxListTile(
+                        value: optOut,
+                        onChanged: (value) {
+                          setDialogState(() => optOut = value ?? false);
+                        },
+                        title: const Text('今後この提案を表示しない'),
+                        controlAffinity: ListTileControlAffinity.leading,
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    _skipSuggestion(suggestion, optOut: optOut);
+                  },
+                  child: const Text('スキップして追加'),
+                ),
+                FilledButton.icon(
+                  onPressed: selected.isEmpty
+                      ? null
+                      : () {
+                          Navigator.of(context).pop();
+                          _acceptSuggestion(
+                            suggestion,
+                            selectedIds: selected,
+                            optOut: optOut,
+                          );
+                        },
+                  icon: const Icon(Icons.playlist_remove),
+                  label: const Text('選んで整理'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _skipSuggestion(
+    OneInTwoOutSuggestion suggestion, {
+    required bool optOut,
+  }) async {
+    await _persistOptOutIfNeeded(optOut);
+    if (!mounted) return;
+    setState(() {
+      _statusMessage = '整理をスキップして「${suggestion.incomingWidgetTitle}」を追加しました。';
+    });
+  }
+
+  Future<void> _acceptSuggestion(
+    OneInTwoOutSuggestion suggestion, {
+    required Set<String> selectedIds,
+    required bool optOut,
+  }) async {
+    await _persistOptOutIfNeeded(optOut);
+    if (!mounted) return;
+    setState(() {
+      _hiddenWidgetIds.addAll(selectedIds);
+      _signals = _signals
+          .map(
+            (signal) => selectedIds.contains(signal.id)
+                ? WidgetUsageSignal(
+                    id: signal.id,
+                    title: signal.title,
+                    sectionId: signal.sectionId,
+                    routePath: signal.routePath,
+                    openCount: signal.openCount,
+                    lastUsedAt: signal.lastUsedAt,
+                    isPinned: signal.isPinned,
+                    isVisible: false,
+                  )
+                : signal,
+          )
+          .toList(growable: false);
+      _statusMessage =
+          '「${suggestion.incomingWidgetTitle}」を追加し、${selectedIds.length}件を非表示候補にしました。';
+    });
+  }
+
+  Future<void> _persistOptOutIfNeeded(bool optOut) async {
+    if (!optOut) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_optOutKey, true);
+    if (mounted) {
+      setState(() => _promptOptedOut = true);
+    }
+  }
+
+  bool _isProtectedWidget(String id) {
+    return id == 'settings' || id == 'user-tasks' || id == 'wbs-user-tasks';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final suggestion = _latestSuggestion;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('1 In 2 Out UI整理アシスト'),
+        actions: [
+          IconButton(
+            tooltip: '利用状況を再読み込み',
+            onPressed: _loadSignals,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                _buildAddPanel(),
+                if (_statusMessage != null) ...[
+                  const SizedBox(height: 12),
+                  _buildStatusBanner(_statusMessage!),
+                ],
+                if (suggestion != null) ...[
+                  const SizedBox(height: 16),
+                  _buildSuggestionPreview(suggestion),
+                ],
+                const SizedBox(height: 16),
+                _buildUsageList(),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildAddPanel() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              '新規ウィジェット追加',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _incomingController,
+              decoration: const InputDecoration(
+                labelText: '追加するウィジェット名',
+                prefixIcon: Icon(Icons.add_box_outlined),
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SwitchListTile(
+              value: !_promptOptedOut,
+              onChanged: (value) async {
+                final prefs = await SharedPreferences.getInstance();
+                await prefs.setBool(_optOutKey, !value);
+                if (mounted) {
+                  setState(() => _promptOptedOut = !value);
+                }
+              },
+              title: const Text('追加時に整理提案を表示'),
+              secondary: const Icon(Icons.rule_folder_outlined),
+              contentPadding: EdgeInsets.zero,
+            ),
+            const SizedBox(height: 12),
+            FilledButton.icon(
+              onPressed: _triggerWidgetAdd,
+              icon: const Icon(Icons.auto_fix_high),
+              label: const Text('追加フローを開始'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatusBanner(String message) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            const Icon(Icons.check_circle_outline),
+            const SizedBox(width: 8),
+            Expanded(child: Text(message)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSuggestionPreview(OneInTwoOutSuggestion suggestion) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '最新提案: ${suggestion.incomingWidgetTitle}',
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 12),
+            for (final candidate in suggestion.candidates)
+              ListTile(
+                leading: const Icon(Icons.remove_circle_outline),
+                title: Text(candidate.signal.title),
+                subtitle: Text(candidate.reason),
+                trailing: Text(candidate.score.toStringAsFixed(0)),
+              ),
+            if (!suggestion.hasTwoCandidates)
+              const Padding(
+                padding: EdgeInsets.only(top: 8),
+                child: Text('候補が2件未満です。固定済み/非表示の項目は除外しています。'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUsageList() {
+    final visibleSignals = _signals
+        .where((signal) => !_hiddenWidgetIds.contains(signal.id))
+        .toList(growable: false);
+    final hiddenSignals = _signals
+        .where((signal) => _hiddenWidgetIds.contains(signal.id))
+        .toList(growable: false);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '利用頻度データ',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '表示中 ${visibleSignals.length} 件 / 非表示候補 ${hiddenSignals.length} 件',
+            ),
+            const SizedBox(height: 12),
+            for (final signal in visibleSignals.take(12))
+              ListTile(
+                leading: Icon(
+                  signal.isPinned ? Icons.push_pin : Icons.widgets_outlined,
+                ),
+                title: Text(signal.title),
+                subtitle: Text(
+                  signal.lastUsedAt == null
+                      ? '利用履歴なし'
+                      : '最終利用: ${signal.lastUsedAt}',
+                ),
+                trailing: Text('${signal.openCount}回'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/home_tool_usage_service.dart
+++ b/lib/services/home_tool_usage_service.dart
@@ -1,7 +1,13 @@
+import 'dart:convert';
+
 import 'package:shared_preferences/shared_preferences.dart';
+
+import 'one_in_two_out_assist_service.dart';
 
 class HomeToolUsageService {
   static const String _recentToolsKey = 'home_recent_tool_ids_v1';
+  static const String _usageCountsKey = 'home_tool_usage_counts_v1';
+  static const String _lastUsedAtKey = 'home_tool_last_used_at_v1';
   static const int _maxRecentTools = 6;
 
   static Future<List<String>> loadRecentToolIds({
@@ -14,6 +20,7 @@ class HomeToolUsageService {
   static Future<void> recordToolUse(
     String toolId, {
     SharedPreferences? prefs,
+    DateTime? now,
   }) async {
     final store = prefs ?? await SharedPreferences.getInstance();
     final existing = List<String>.from(
@@ -24,10 +31,95 @@ class HomeToolUsageService {
       ...existing.where((entry) => entry != toolId),
     ].take(_maxRecentTools).toList();
     await store.setStringList(_recentToolsKey, next);
+
+    final counts = _decodeIntMap(store.getString(_usageCountsKey));
+    counts[toolId] = (counts[toolId] ?? 0) + 1;
+    await store.setString(_usageCountsKey, jsonEncode(counts));
+
+    final lastUsedAt = _decodeStringMap(store.getString(_lastUsedAtKey));
+    lastUsedAt[toolId] = (now ?? DateTime.now()).toUtc().toIso8601String();
+    await store.setString(_lastUsedAtKey, jsonEncode(lastUsedAt));
+  }
+
+  static Future<List<WidgetUsageSignal>> loadUsageSignals({
+    required Iterable<HomeToolUsageCandidate> candidates,
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final counts = _decodeIntMap(store.getString(_usageCountsKey));
+    final lastUsedAt = _decodeStringMap(store.getString(_lastUsedAtKey));
+
+    return candidates
+        .map(
+          (candidate) => WidgetUsageSignal(
+            id: candidate.id,
+            title: candidate.title,
+            sectionId: candidate.sectionId,
+            routePath: candidate.routePath,
+            openCount: counts[candidate.id] ?? 0,
+            lastUsedAt: _tryParseDateTime(lastUsedAt[candidate.id]),
+            isPinned: candidate.isPinned,
+            isVisible: candidate.isVisible,
+          ),
+        )
+        .toList(growable: false);
   }
 
   static Future<void> clear({SharedPreferences? prefs}) async {
     final store = prefs ?? await SharedPreferences.getInstance();
     await store.remove(_recentToolsKey);
+    await store.remove(_usageCountsKey);
+    await store.remove(_lastUsedAtKey);
   }
+
+  static Map<String, int> _decodeIntMap(String? value) {
+    if (value == null || value.isEmpty) return <String, int>{};
+    try {
+      final decoded = jsonDecode(value);
+      if (decoded is! Map) return <String, int>{};
+      return decoded.map(
+        (key, rawValue) => MapEntry(
+          key.toString(),
+          rawValue is num ? rawValue.toInt() : int.tryParse('$rawValue') ?? 0,
+        ),
+      );
+    } catch (_) {
+      return <String, int>{};
+    }
+  }
+
+  static Map<String, String> _decodeStringMap(String? value) {
+    if (value == null || value.isEmpty) return <String, String>{};
+    try {
+      final decoded = jsonDecode(value);
+      if (decoded is! Map) return <String, String>{};
+      return decoded
+          .map((key, rawValue) => MapEntry(key.toString(), '$rawValue'));
+    } catch (_) {
+      return <String, String>{};
+    }
+  }
+
+  static DateTime? _tryParseDateTime(String? value) {
+    if (value == null || value.isEmpty) return null;
+    return DateTime.tryParse(value)?.toLocal();
+  }
+}
+
+class HomeToolUsageCandidate {
+  const HomeToolUsageCandidate({
+    required this.id,
+    required this.title,
+    required this.sectionId,
+    this.routePath,
+    this.isPinned = false,
+    this.isVisible = true,
+  });
+
+  final String id;
+  final String title;
+  final String sectionId;
+  final String? routePath;
+  final bool isPinned;
+  final bool isVisible;
 }

--- a/lib/services/one_in_two_out_assist_service.dart
+++ b/lib/services/one_in_two_out_assist_service.dart
@@ -1,0 +1,113 @@
+class WidgetUsageSignal {
+  const WidgetUsageSignal({
+    required this.id,
+    required this.title,
+    required this.sectionId,
+    required this.openCount,
+    required this.lastUsedAt,
+    this.routePath,
+    this.isPinned = false,
+    this.isVisible = true,
+  });
+
+  final String id;
+  final String title;
+  final String sectionId;
+  final String? routePath;
+  final int openCount;
+  final DateTime? lastUsedAt;
+  final bool isPinned;
+  final bool isVisible;
+}
+
+class OneInTwoOutRemovalCandidate {
+  const OneInTwoOutRemovalCandidate({
+    required this.signal,
+    required this.staleDays,
+    required this.score,
+    required this.reason,
+  });
+
+  final WidgetUsageSignal signal;
+  final int staleDays;
+  final double score;
+  final String reason;
+}
+
+class OneInTwoOutSuggestion {
+  const OneInTwoOutSuggestion({
+    required this.incomingWidgetId,
+    required this.incomingWidgetTitle,
+    required this.generatedAt,
+    required this.candidates,
+    this.canSkip = true,
+    this.canOptOut = true,
+  });
+
+  final String incomingWidgetId;
+  final String incomingWidgetTitle;
+  final DateTime generatedAt;
+  final List<OneInTwoOutRemovalCandidate> candidates;
+  final bool canSkip;
+  final bool canOptOut;
+
+  bool get hasTwoCandidates => candidates.length >= 2;
+}
+
+class OneInTwoOutAssistService {
+  const OneInTwoOutAssistService();
+
+  OneInTwoOutSuggestion buildSuggestion({
+    required String incomingWidgetId,
+    required String incomingWidgetTitle,
+    required Iterable<WidgetUsageSignal> existingWidgets,
+    DateTime? now,
+    int candidateCount = 2,
+  }) {
+    final generatedAt = now ?? DateTime.now();
+    final ranked = existingWidgets
+        .where(
+          (signal) =>
+              signal.id != incomingWidgetId &&
+              signal.isVisible &&
+              !signal.isPinned,
+        )
+        .map((signal) => _rank(signal, generatedAt))
+        .toList()
+      ..sort((a, b) {
+        final byScore = b.score.compareTo(a.score);
+        if (byScore != 0) return byScore;
+        return a.signal.title.compareTo(b.signal.title);
+      });
+
+    return OneInTwoOutSuggestion(
+      incomingWidgetId: incomingWidgetId,
+      incomingWidgetTitle: incomingWidgetTitle,
+      generatedAt: generatedAt,
+      candidates: ranked.take(candidateCount).toList(growable: false),
+    );
+  }
+
+  OneInTwoOutRemovalCandidate _rank(
+    WidgetUsageSignal signal,
+    DateTime now,
+  ) {
+    final lastUsedAt = signal.lastUsedAt;
+    final staleDays = lastUsedAt == null
+        ? 999
+        : now.difference(lastUsedAt).inDays.clamp(0, 999);
+    final lowFrequencyBonus = (10 - signal.openCount.clamp(0, 10)) * 4.0;
+    final neverUsedBonus = lastUsedAt == null ? 40.0 : 0.0;
+    final score = staleDays + lowFrequencyBonus + neverUsedBonus;
+    final reason = lastUsedAt == null
+        ? '利用履歴なし / 利用${signal.openCount}回'
+        : '$staleDays日未使用 / 利用${signal.openCount}回';
+
+    return OneInTwoOutRemovalCandidate(
+      signal: signal,
+      staleDays: staleDays,
+      score: score,
+      reason: reason,
+    );
+  }
+}

--- a/test/services/home_tool_usage_service_test.dart
+++ b/test/services/home_tool_usage_service_test.dart
@@ -10,15 +10,44 @@ void main() {
 
   test('records recent tools with newest first and no duplicates', () async {
     final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.utc(2026, 5, 5, 1);
 
-    await HomeToolUsageService.recordToolUse('alpha', prefs: prefs);
-    await HomeToolUsageService.recordToolUse('beta', prefs: prefs);
-    await HomeToolUsageService.recordToolUse('alpha', prefs: prefs);
+    await HomeToolUsageService.recordToolUse('alpha', prefs: prefs, now: now);
+    await HomeToolUsageService.recordToolUse(
+      'beta',
+      prefs: prefs,
+      now: now.add(const Duration(minutes: 1)),
+    );
+    await HomeToolUsageService.recordToolUse(
+      'alpha',
+      prefs: prefs,
+      now: now.add(const Duration(minutes: 2)),
+    );
 
     expect(
       await HomeToolUsageService.loadRecentToolIds(prefs: prefs),
       <String>['alpha', 'beta'],
     );
+
+    final signals = await HomeToolUsageService.loadUsageSignals(
+      prefs: prefs,
+      candidates: const [
+        HomeToolUsageCandidate(
+          id: 'alpha',
+          title: 'Alpha',
+          sectionId: 'personal',
+        ),
+        HomeToolUsageCandidate(
+          id: 'beta',
+          title: 'Beta',
+          sectionId: 'personal',
+        ),
+      ],
+    );
+
+    expect(signals.first.id, 'alpha');
+    expect(signals.first.openCount, 2);
+    expect(signals.first.lastUsedAt, isNotNull);
   });
 
   test('keeps only the latest six tools', () async {
@@ -40,5 +69,30 @@ void main() {
       await HomeToolUsageService.loadRecentToolIds(prefs: prefs),
       <String>['seven', 'six', 'five', 'four', 'three', 'two'],
     );
+  });
+
+  test('clear removes recency and usage signals', () async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await HomeToolUsageService.recordToolUse(
+      'alpha',
+      prefs: prefs,
+      now: DateTime.utc(2026, 5, 5),
+    );
+    await HomeToolUsageService.clear(prefs: prefs);
+
+    expect(await HomeToolUsageService.loadRecentToolIds(prefs: prefs), isEmpty);
+    final signals = await HomeToolUsageService.loadUsageSignals(
+      prefs: prefs,
+      candidates: const [
+        HomeToolUsageCandidate(
+          id: 'alpha',
+          title: 'Alpha',
+          sectionId: 'personal',
+        ),
+      ],
+    );
+    expect(signals.single.openCount, 0);
+    expect(signals.single.lastUsedAt, isNull);
   });
 }

--- a/test/services/one_in_two_out_assist_service_test.dart
+++ b/test/services/one_in_two_out_assist_service_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/one_in_two_out_assist_service.dart';
+
+void main() {
+  test('lists two stale low-usage widgets for a new widget prompt', () {
+    const service = OneInTwoOutAssistService();
+    final now = DateTime.utc(2026, 5, 5, 12);
+
+    final suggestion = service.buildSuggestion(
+      incomingWidgetId: 'new-widget',
+      incomingWidgetTitle: '新しい分析カード',
+      now: now,
+      existingWidgets: [
+        WidgetUsageSignal(
+          id: 'frequent',
+          title: '毎日使う',
+          sectionId: 'today',
+          openCount: 30,
+          lastUsedAt: now.subtract(const Duration(days: 1)),
+        ),
+        WidgetUsageSignal(
+          id: 'stale-a',
+          title: '古いカードA',
+          sectionId: 'personal',
+          openCount: 1,
+          lastUsedAt: now.subtract(const Duration(days: 45)),
+        ),
+        const WidgetUsageSignal(
+          id: 'never',
+          title: '未使用カード',
+          sectionId: 'personal',
+          openCount: 0,
+          lastUsedAt: null,
+        ),
+        WidgetUsageSignal(
+          id: 'pinned',
+          title: '固定カード',
+          sectionId: 'personal',
+          openCount: 0,
+          lastUsedAt: now.subtract(const Duration(days: 120)),
+          isPinned: true,
+        ),
+      ],
+    );
+
+    expect(suggestion.hasTwoCandidates, isTrue);
+    expect(
+      suggestion.candidates.map((candidate) => candidate.signal.id),
+      <String>['never', 'stale-a'],
+    );
+    expect(suggestion.canSkip, isTrue);
+    expect(suggestion.canOptOut, isTrue);
+  });
+
+  test('does not suggest incoming, hidden, or pinned widgets', () {
+    const service = OneInTwoOutAssistService();
+
+    final suggestion = service.buildSuggestion(
+      incomingWidgetId: 'incoming',
+      incomingWidgetTitle: '追加予定',
+      now: DateTime.utc(2026, 5, 5),
+      existingWidgets: const [
+        WidgetUsageSignal(
+          id: 'incoming',
+          title: '追加予定',
+          sectionId: 'personal',
+          openCount: 0,
+          lastUsedAt: null,
+        ),
+        WidgetUsageSignal(
+          id: 'hidden',
+          title: '非表示',
+          sectionId: 'personal',
+          openCount: 0,
+          lastUsedAt: null,
+          isVisible: false,
+        ),
+        WidgetUsageSignal(
+          id: 'pinned',
+          title: '固定',
+          sectionId: 'personal',
+          openCount: 0,
+          lastUsedAt: null,
+          isPinned: true,
+        ),
+        WidgetUsageSignal(
+          id: 'candidate',
+          title: '候補',
+          sectionId: 'personal',
+          openCount: 0,
+          lastUsedAt: null,
+        ),
+      ],
+    );
+
+    expect(suggestion.candidates, hasLength(1));
+    expect(suggestion.candidates.single.signal.id, 'candidate');
+  });
+}


### PR DESCRIPTION
﻿## Summary
- Extend `HomeToolUsageService` so existing home/work-menu taps now persist open counts and last-used timestamps in addition to the recent list.
- Add `OneInTwoOutAssistService` to rank stale, low-frequency, non-pinned widgets and return about 3 cases worth of deterministic skip/opt-out behavior through unit coverage.
- Add `/one-in-two-out-assist` and a home catalog entry so a new widget add flow shows a prompt with two cleanup candidates, skip, and opt-out controls.

## 2-instance workflow
- Claude Code #1 (Windows app): architecture/spec/WBS review owner for #1345.
- Codex #1 (Windows app): implementation, tests, PR, and CI owner for this app-side pass.

## Validation
- `dart analyze lib\\main.dart`
- `dart analyze lib\\services\\home_tool_usage_service.dart lib\\services\\one_in_two_out_assist_service.dart lib\\pages\\one_in_two_out_assist_page.dart lib\\data\\home_tool_catalog.dart test\\services\\home_tool_usage_service_test.dart test\\services\\one_in_two_out_assist_service_test.dart`
- `flutter test test\\services\\home_tool_usage_service_test.dart test\\services\\one_in_two_out_assist_service_test.dart`
- `git diff --check`

## Minimal E2E declaration
Implementation-detail independent: the visible user contract is that adding a widget opens a 1 In 2 Out prompt, lists two low-usage candidates, and lets the user skip or opt out. The behavior is covered with about 3 cases in service-level tests for ranking, exclusions, and persisted usage signals. E2E-Exception reason: no Playwright or integration_test was added because this pass keeps the scope to local SharedPreferences-backed app logic and a lightweight Flutter route; CI smoke should cover route compilation while avoiding extra browser/runtime cost in the 2-instance memory budget.

Closes #1345
