### PR TITLE
feat(legal): add inline term tooltips

### DIFF
--- a/lib/pages/legal_compliance_manager_page.dart
+++ b/lib/pages/legal_compliance_manager_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../widgets/paddle_approval_readiness_card.dart';
+import '../widgets/legal_term_tooltip_text.dart';
 
 /// Legal / compliance manager page
 /// - contracts and checklist come from legal-compliance-manager EF
@@ -419,6 +420,36 @@ class _LegalComplianceManagerPageState extends State<LegalComplianceManagerPage>
           ),
         ),
         const SizedBox(height: 12),
+        const Card(
+          child: Padding(
+            padding: EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.info_outline, color: Color(0xFF7C3AED)),
+                    SizedBox(width: 8),
+                    Text(
+                      '専門用語のインライン解説',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 8),
+                LegalTermTooltipText(
+                  text:
+                      '憲法審査会では、参議院の緊急集会、緊急政令、繰延投票、国民投票法附則4条、国家緊急権などを横断して論点整理します。',
+                  style: TextStyle(height: 1.6),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
         Card(
           child: Padding(
             padding: const EdgeInsets.all(16),
@@ -549,7 +580,10 @@ class _LegalComplianceManagerPageState extends State<LegalComplianceManagerPage>
                     style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                   ),
                   const SizedBox(height: 8),
-                  SelectableText(answer, style: const TextStyle(height: 1.6)),
+                  LegalTermTooltipText(
+                    text: answer,
+                    style: const TextStyle(height: 1.6),
+                  ),
                 ],
               ),
             ),

--- a/lib/services/legal_term_glossary_service.dart
+++ b/lib/services/legal_term_glossary_service.dart
@@ -1,0 +1,148 @@
+class LegalTermDefinition {
+  const LegalTermDefinition({
+    required this.term,
+    required this.definition,
+    required this.background,
+    required this.lawReferences,
+    this.aliases = const <String>[],
+  });
+
+  final String term;
+  final String definition;
+  final String background;
+  final List<String> lawReferences;
+  final List<String> aliases;
+
+  Iterable<String> get matchWords sync* {
+    yield term;
+    yield* aliases;
+  }
+
+  String get tooltipText {
+    final references =
+        lawReferences.isEmpty ? '' : '\n関連: ${lawReferences.join(' / ')}';
+    return '$term\n$definition\n$background$references';
+  }
+}
+
+class LegalTermMatch {
+  const LegalTermMatch({
+    required this.start,
+    required this.end,
+    required this.matchedText,
+    required this.definition,
+  });
+
+  final int start;
+  final int end;
+  final String matchedText;
+  final LegalTermDefinition definition;
+}
+
+class LegalTermGlossaryService {
+  const LegalTermGlossaryService({
+    this.definitions = defaultDefinitions,
+  });
+
+  final List<LegalTermDefinition> definitions;
+
+  static const List<LegalTermDefinition> defaultDefinitions =
+      <LegalTermDefinition>[
+    LegalTermDefinition(
+      term: '広範性要件',
+      definition: '憲法改正や緊急権の制度設計で、対象範囲が広すぎないかを確認する観点です。',
+      background: '権限の濫用や通常時への拡張を防ぐため、発動条件・期間・対象を明確にします。',
+      lawReferences: ['憲法改正論点', '緊急事態条項'],
+      aliases: ['広範性'],
+    ),
+    LegalTermDefinition(
+      term: '参議院の緊急集会',
+      definition: '衆議院解散中に国会の議決が必要な緊急事態で、参議院が暫定的に開く会議です。',
+      background: '日本国憲法54条2項・3項に規定され、後に衆議院の同意が必要になります。',
+      lawReferences: ['憲法54条'],
+      aliases: ['緊急集会'],
+    ),
+    LegalTermDefinition(
+      term: '緊急政令',
+      definition: '緊急時に行政が法律に準じる内容を定める命令を指す議論上の概念です。',
+      background: '国会中心主義との緊張があるため、事後承認や期限設定が重要になります。',
+      lawReferences: ['内閣法制', '緊急事態条項'],
+    ),
+    LegalTermDefinition(
+      term: '繰延投票',
+      definition: '災害などで予定日に投票できない地域の投票日を後ろへずらす制度です。',
+      background: '選挙の公平性と実施可能性を両立するため、対象地域や期間を限定して運用されます。',
+      lawReferences: ['公職選挙法57条'],
+    ),
+    LegalTermDefinition(
+      term: '国民投票法附則4条',
+      definition: '憲法改正国民投票制度の宿題として、関連制度の検討を求めた附則規定です。',
+      background: '投票環境、広告規制、運動の公平性などの継続論点と結びつきます。',
+      lawReferences: ['日本国憲法の改正手続に関する法律'],
+      aliases: ['附則4条'],
+    ),
+    LegalTermDefinition(
+      term: '国家緊急権',
+      definition: '戦争・大災害などで国家機能を維持するために例外的権限を認める考え方です。',
+      background: '人権制約や権力集中の危険があるため、厳格な発動要件と統制が不可欠です。',
+      lawReferences: ['比較憲法', '緊急事態条項'],
+    ),
+    LegalTermDefinition(
+      term: '緊急事態条項',
+      definition: '緊急時の権限・国会機能・選挙期日などを憲法に明記する提案群です。',
+      background: '災害対応の実効性と、権力濫用を防ぐ統制設計の両方が論点になります。',
+      lawReferences: ['憲法改正論点'],
+    ),
+    LegalTermDefinition(
+      term: '憲法審査会',
+      definition: '憲法や憲法改正原案を調査・審査する衆参両院の機関です。',
+      background: '各会派の意見表明、参考人質疑、論点整理の場として機能します。',
+      lawReferences: ['国会法102条の6'],
+    ),
+  ];
+
+  List<LegalTermMatch> matchTerms(String text) {
+    if (text.isEmpty) return const <LegalTermMatch>[];
+
+    final occupied = List<bool>.filled(text.length, false);
+    final matches = <LegalTermMatch>[];
+    final entries = <_GlossaryEntry>[
+      for (final definition in definitions)
+        for (final word in definition.matchWords)
+          if (word.isNotEmpty) _GlossaryEntry(word, definition),
+    ]..sort((a, b) => b.word.length.compareTo(a.word.length));
+
+    for (final entry in entries) {
+      var start = text.indexOf(entry.word);
+      while (start >= 0) {
+        final end = start + entry.word.length;
+        final overlaps =
+            occupied.sublist(start, end).any((alreadyUsed) => alreadyUsed);
+        if (!overlaps) {
+          for (var i = start; i < end; i++) {
+            occupied[i] = true;
+          }
+          matches.add(
+            LegalTermMatch(
+              start: start,
+              end: end,
+              matchedText: text.substring(start, end),
+              definition: entry.definition,
+            ),
+          );
+        }
+        start = text.indexOf(entry.word, end);
+      }
+    }
+
+    matches.sort((a, b) => a.start.compareTo(b.start));
+    return matches;
+  }
+}
+
+class _GlossaryEntry {
+  const _GlossaryEntry(this.word, this.definition);
+
+  final String word;
+  final LegalTermDefinition definition;
+}

--- a/lib/widgets/legal_term_tooltip_text.dart
+++ b/lib/widgets/legal_term_tooltip_text.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+import '../services/legal_term_glossary_service.dart';
+
+class LegalTermTooltipText extends StatelessWidget {
+  const LegalTermTooltipText({
+    super.key,
+    required this.text,
+    this.style,
+    this.glossary = const LegalTermGlossaryService(),
+  });
+
+  final String text;
+  final TextStyle? style;
+  final LegalTermGlossaryService glossary;
+
+  @override
+  Widget build(BuildContext context) {
+    final baseStyle = DefaultTextStyle.of(context).style.merge(style);
+    final highlightStyle = baseStyle.copyWith(
+      color: Theme.of(context).colorScheme.primary,
+      fontWeight: FontWeight.w700,
+      decoration: TextDecoration.underline,
+      decorationColor: Theme.of(context).colorScheme.primary,
+      decorationThickness: 1.4,
+    );
+    final matches = glossary.matchTerms(text);
+    if (matches.isEmpty) {
+      return Text(text, style: baseStyle);
+    }
+
+    final spans = <InlineSpan>[];
+    var cursor = 0;
+    for (final match in matches) {
+      if (cursor < match.start) {
+        spans.add(TextSpan(text: text.substring(cursor, match.start)));
+      }
+      spans.add(
+        WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: _LegalTermTooltipChip(
+            text: match.matchedText,
+            tooltip: match.definition.tooltipText,
+            style: highlightStyle,
+          ),
+        ),
+      );
+      cursor = match.end;
+    }
+    if (cursor < text.length) {
+      spans.add(TextSpan(text: text.substring(cursor)));
+    }
+
+    return RichText(
+      text: TextSpan(style: baseStyle, children: spans),
+    );
+  }
+}
+
+class _LegalTermTooltipChip extends StatefulWidget {
+  const _LegalTermTooltipChip({
+    required this.text,
+    required this.tooltip,
+    required this.style,
+  });
+
+  final String text;
+  final String tooltip;
+  final TextStyle style;
+
+  @override
+  State<_LegalTermTooltipChip> createState() => _LegalTermTooltipChipState();
+}
+
+class _LegalTermTooltipChipState extends State<_LegalTermTooltipChip> {
+  final _tooltipKey = GlobalKey<TooltipState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      key: _tooltipKey,
+      message: widget.tooltip,
+      showDuration: const Duration(seconds: 8),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _tooltipKey.currentState?.ensureTooltipVisible(),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: Theme.of(context)
+                .colorScheme
+                .primaryContainer
+                .withValues(alpha: 0.35),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
+            child: Text(widget.text, style: widget.style),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/legal_term_glossary_service_test.dart
+++ b/test/services/legal_term_glossary_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/legal_term_glossary_service.dart';
+
+void main() {
+  test('matches predefined legal terms in reading order', () {
+    const service = LegalTermGlossaryService();
+
+    final matches = service.matchTerms(
+      '憲法審査会では参議院の緊急集会、緊急政令、国家緊急権を議論した。',
+    );
+
+    expect(
+      matches.map((match) => match.definition.term),
+      <String>['憲法審査会', '参議院の緊急集会', '緊急政令', '国家緊急権'],
+    );
+  });
+
+  test('prefers the longest match and avoids overlapping aliases', () {
+    const service = LegalTermGlossaryService();
+
+    final matches = service.matchTerms('参議院の緊急集会は緊急集会とも呼ばれる。');
+
+    expect(matches, hasLength(2));
+    expect(matches.first.matchedText, '参議院の緊急集会');
+    expect(matches.last.matchedText, '緊急集会');
+  });
+
+  test('returns an empty list for plain text', () {
+    const service = LegalTermGlossaryService();
+
+    expect(service.matchTerms('今日は通常の契約レビューを行う。'), isEmpty);
+  });
+}


### PR DESCRIPTION
﻿## Summary
- Add a predefined legal/constitutional glossary for terms such as `広範性要件`, `参議院の緊急集会`, `緊急政令`, `繰延投票`, `国民投票法附則4条`, and `国家緊急権`.
- Add a reusable `LegalTermTooltipText` renderer that highlights matched terms, prefers longest non-overlapping matches, and opens tooltips on desktop hover or mobile tap.
- Apply the renderer to the Legal/Compliance Harvey sample text and response area.

## 2-instance workflow
- Claude Code #1 (Windows app): WBS ordering, source-policy interpretation, and future glossary expansion review.
- Codex #1 (Windows app): glossary matcher, tooltip widget, page integration, tests, PR, and CI.

## Validation
- `dart analyze lib\\services\\legal_term_glossary_service.dart lib\\widgets\\legal_term_tooltip_text.dart lib\\pages\\legal_compliance_manager_page.dart test\\services\\legal_term_glossary_service_test.dart`
- `flutter test test\\services\\legal_term_glossary_service_test.dart`
- `git diff --check`

## Minimal E2E declaration
Implementation-detail independent: the visible user contract is that legal text highlights predefined terms and shows definitions when the highlighted word is hovered or tapped. The matcher is covered with about 3 cases for reading order, longest-match overlap handling, and no-match text. E2E-Exception reason: no Playwright or integration_test was added because this pass is a lightweight renderer/service integration; CI compilation plus focused unit coverage validates the behavior while keeping the 2-instance memory budget low.

Closes #1348
