### PR TITLE
feat(wbs): timeline 未完了件数表示 + CSV ダウンロード

### DIFF
--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -3,6 +3,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../utils/web_image_downloader.dart';
+
 const String _kGithubRepoUrl = 'https://github.com/kanta13jp1/my_web_app';
 final RegExp _kIssueNumberRegex = RegExp(r'\[Issue\s*#(\d+)\]');
 
@@ -2140,7 +2142,7 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
       color: _bgColor,
       child: Column(
         children: [
-          _buildHeader(tasks.length),
+          _buildHeader(tasks.length, widget.tasks.length),
           // Win版#131 part 22: 列表示制御 + Gantt instance filter
           _buildColumnToggleBar(),
           // Win版#131 part 13: マイルストーン risk warning banner
@@ -2400,6 +2402,87 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     );
   }
 
+  String _csvEscape(String s) {
+    if (s.contains(',') ||
+        s.contains('"') ||
+        s.contains('\n') ||
+        s.contains('\r')) {
+      return '"${s.replaceAll('"', '""')}"';
+    }
+    return s;
+  }
+
+  String _isoDate(DateTime? d) {
+    if (d == null) return '';
+    final y = d.year.toString().padLeft(4, '0');
+    final m = d.month.toString().padLeft(2, '0');
+    final day = d.day.toString().padLeft(2, '0');
+    return '$y-$m-$day';
+  }
+
+  void _exportCsv() {
+    final tasks = _orderedTasks;
+    final buf = StringBuffer();
+    const headers = [
+      '#',
+      'カテゴリ',
+      'タスク名',
+      '担当',
+      '進捗',
+      'ステータス',
+      '優先度',
+      '開始予定',
+      '完了予定',
+      '残作業',
+      'リカバリープラン',
+      'マイルストーン',
+      'GitHubIssue状態',
+      'GitHubIssue#',
+      'GitHubIssueURL',
+      'タスクID',
+    ];
+    buf.writeln(headers.join(','));
+    for (var i = 0; i < tasks.length; i++) {
+      final t = tasks[i];
+      final issueNo = _extractIssueNumber(t.title);
+      final fields = <String>[
+        '${i + 1}',
+        t.category,
+        t.title,
+        t.ownerInstance.isNotEmpty ? t.ownerInstance : t.instance,
+        '${t.progress}',
+        t.status,
+        t.priority,
+        _isoDate(t.startDate),
+        _isoDate(t.endDate),
+        t.remainingWork,
+        t.recoveryPlan,
+        t.milestoneCode ?? '',
+        t.githubIssueState,
+        issueNo?.toString() ?? '',
+        issueNo != null ? '$_kGithubRepoUrl/issues/$issueNo' : '',
+        t.id,
+      ].map(_csvEscape).toList();
+      buf.writeln(fields.join(','));
+    }
+
+    final now = DateTime.now();
+    final stamp =
+        '${now.year.toString().padLeft(4, '0')}${now.month.toString().padLeft(2, '0')}${now.day.toString().padLeft(2, '0')}-${now.hour.toString().padLeft(2, '0')}${now.minute.toString().padLeft(2, '0')}';
+    final scope = widget.hideCompleted ? 'open' : 'all';
+    downloadCsvFile(buf.toString(), 'wbs-timeline-$scope-$stamp.csv');
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          '📄 ${tasks.length} 件をCSVダウンロードしました (wbs-timeline-$scope-$stamp.csv)',
+        ),
+        backgroundColor: const Color(0xFF38BDF8),
+      ),
+    );
+  }
+
   Future<void> _autoRepairDependencies() async {
     if (Supabase.instance.client.auth.currentUser == null) return;
     try {
@@ -2573,7 +2656,10 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     );
   }
 
-  Widget _buildHeader(int taskCount) {
+  Widget _buildHeader(int taskCount, int totalCount) {
+    final filtered = widget.hideCompleted && totalCount > taskCount;
+    final countLabel =
+        filtered ? '未完了 $taskCount / 全体 $totalCount 件' : '$taskCount タスク';
     return Container(
       color: _panelColor,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
@@ -2596,10 +2682,12 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
           ),
           const SizedBox(width: 12),
           Text(
-            '$taskCount タスク',
-            style: const TextStyle(
-              color: Color(0xFF808090),
+            countLabel,
+            style: TextStyle(
+              color:
+                  filtered ? const Color(0xFFFF6B35) : const Color(0xFF808090),
               fontSize: 12,
+              fontWeight: filtered ? FontWeight.w600 : FontWeight.normal,
               height: 1.5,
             ),
           ),
@@ -2656,6 +2744,23 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
               style: OutlinedButton.styleFrom(
                 foregroundColor: const Color(0xFF22C55E),
                 side: const BorderSide(color: Color(0xFF22C55E)),
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          SizedBox(
+            height: 28,
+            child: OutlinedButton.icon(
+              onPressed: _exportCsv,
+              icon: const Icon(Icons.download, size: 14),
+              label: const Text(
+                'CSV',
+                style: TextStyle(fontSize: 11, height: 1.5),
+              ),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: const Color(0xFF38BDF8),
+                side: const BorderSide(color: Color(0xFF38BDF8)),
                 padding: const EdgeInsets.symmetric(horizontal: 8),
               ),
             ),


### PR DESCRIPTION
## Summary
- タイムラインヘッダの件数表示を filter 状態反映 (`未完了 X / 全体 Y 件` オレンジ強調) に変更 ([project_gantt_page.dart:2659](lib/pages/project_gantt_page.dart:2659))
- CSV ダウンロードボタン追加 (16 列 / 現ソート+filter 反映 / UTF-8 BOM)
- 既存 `utils/web_image_downloader.dart` の `downloadCsvFile` 流用 (新依存ゼロ)

## Why
ユーザー報告: GitHub Issue が closed されても WBS タイムラインの「918 タスク」表示が変わらず、フィルタ効果が見えなかった (= sync 遅延 + 表示が filter 後 count を `X タスク` 単独表示で総数か filter 後か判別不能)。新表示で filter 効果が一目瞭然。

CSV はタスク一覧を Excel/外部分析で確認したいというユーザー要望。

## Test plan
- [x] dart format --set-exit-if-changed (exit 0)
- [x] flutter analyze lib/pages/project_gantt_page.dart (No issues found)
- [ ] 本番 /project-gantt でタイムラインタブ → 「未完了のみ」ON/OFF で表示切替確認
- [ ] CSV ボタンクリックで `wbs-timeline-{open|all}-YYYYMMDD-HHMM.csv` ダウンロード確認
- [ ] Excel で開いて文字化けなし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)