### PR TITLE
feat(wbs): reschedule_realistic EF action + daily auto cron

### DIFF
--- a/.github/workflows/wbs-auto-reschedule.yml
+++ b/.github/workflows/wbs-auto-reschedule.yml
@@ -1,0 +1,141 @@
+name: WBS Auto Reschedule
+
+# Win版#132 part 157 (2026-05-06) — User 依頼着地
+# 全 open WBS タスクの start_date / end_date を priority tier ベースで
+# 「実際に着手可能な日付」へ daily 再配置する。
+#
+# 仕組み:
+#  - daily 06:00 JST (= 21:00 UTC) に tools-hub:wbs.reschedule_realistic を invoke
+#  - 完了系 (status='completed' OR github_issue_state='CLOSED') は skip
+#  - priority tier (high/medium/low) で start = today + offset、end = start + duration
+#  - 同 tier 内は parallel_capacity 件並列で stagger
+#  - 結果サマリを Issue #1422 (= Codex Memory + Thread Automations 着地点) に comment
+
+on:
+  schedule:
+    - cron: "0 21 * * *"  # daily 06:00 JST
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (= no DB write)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: wbs-auto-reschedule
+  cancel-in-progress: false
+
+jobs:
+  reschedule:
+    name: Invoke wbs.reschedule_realistic
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: https://smmkxxavexumewbfaqpy.supabase.co
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      ISSUE_TRACKING_NUMBER: "1422"
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Invoke tools-hub:wbs.reschedule_realistic
+        id: invoke
+        run: |
+          set -euo pipefail
+          if [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+            echo "::error::SUPABASE_SERVICE_ROLE_KEY missing"
+            exit 1
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            BODY='{"action":"wbs.reschedule_realistic","dry_run":true}'
+          else
+            BODY='{"action":"wbs.reschedule_realistic","dry_run":false}'
+          fi
+          echo "Invoke body: $BODY"
+          RESP=$(curl -sS -X POST \
+            -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            --max-time 90 \
+            "${SUPABASE_URL}/functions/v1/tools-hub")
+          echo "$RESP" > reschedule_result.json
+          echo "Response bytes: $(wc -c < reschedule_result.json)"
+
+          SUCCESS=$(jq -r '.success // false' reschedule_result.json)
+          UPDATED=$(jq -r '.updated // .would_update // 0' reschedule_result.json)
+          OPEN=$(jq -r '.total_open // 0' reschedule_result.json)
+          ERR=$(jq -r '.errors_count // 0' reschedule_result.json)
+          {
+            echo "success=$SUCCESS"
+            echo "updated=$UPDATED"
+            echo "total_open=$OPEN"
+            echo "errors=$ERR"
+            echo "dry_run=$DRY_RUN"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build summary
+        id: summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## WBS Auto Reschedule"
+            echo ""
+            echo "- date: $(date -u +%Y-%m-%dT%H:%M:%SZ) (= $(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M JST'))"
+            echo "- dry_run: ${{ steps.invoke.outputs.dry_run }}"
+            echo "- success: ${{ steps.invoke.outputs.success }}"
+            echo "- total_open: ${{ steps.invoke.outputs.total_open }}"
+            echo "- updated: ${{ steps.invoke.outputs.updated }}"
+            echo "- errors: ${{ steps.invoke.outputs.errors }}"
+            echo ""
+            echo "<details><summary>by_priority</summary>"
+            echo ""
+            echo '```json'
+            jq '.by_priority // {}' reschedule_result.json
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "<details><summary>sample (first 10)</summary>"
+            echo ""
+            echo '```json'
+            jq '.sample // []' reschedule_result.json
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > summary.md
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on tracking issue
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -s summary.md ]; then
+            gh issue comment "$ISSUE_TRACKING_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file summary.md || true
+          fi
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wbs-reschedule-result
+          path: |
+            reschedule_result.json
+            summary.md
+          retention-days: 14

--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -6162,6 +6162,205 @@ serve(async (req) => {
             }, 200);
           }
         }
+        case "wbs.reschedule_realistic": {
+          // Win版#132 part 157 (2026-05-06):
+          // 全 open タスクの start_date / end_date を priority tier ベースで
+          // 「実際に着手可能な日付」へ再配置する。
+          //
+          // body:
+          //   dry_run?: boolean (default true)
+          //   priority_offset_days?: { high: number, medium: number, low: number }
+          //     (default {high: 7, medium: 30, low: 90})
+          //   duration_days?: { high: number, medium: number, low: number }
+          //     (default {high: 3, medium: 7, low: 14})
+          //   parallel_capacity?: { high: number, medium: number, low: number }
+          //     priority tier 内での並列着手可能数 (default {high: 4, medium: 8, low: 12})
+          //     スケジュール stagger は floor(queue_index / parallel_capacity) 日 ずらして配置
+          //
+          // 対象: status != 'completed' AND github_issue_state != 'CLOSED'
+          // skip: 上記完了系
+          const dryRun = body.dry_run !== false; // default true
+          const offsetIn =
+            (body.priority_offset_days as Record<string, number>) ?? {};
+          const durIn = (body.duration_days as Record<string, number>) ?? {};
+          const parIn = (body.parallel_capacity as Record<string, number>) ??
+            {};
+          const offset = {
+            high: Number(offsetIn.high ?? 7),
+            medium: Number(offsetIn.medium ?? 30),
+            low: Number(offsetIn.low ?? 90),
+          };
+          const duration = {
+            high: Number(durIn.high ?? 3),
+            medium: Number(durIn.medium ?? 7),
+            low: Number(durIn.low ?? 14),
+          };
+          const parallel = {
+            high: Math.max(1, Number(parIn.high ?? 4)),
+            medium: Math.max(1, Number(parIn.medium ?? 8)),
+            low: Math.max(1, Number(parIn.low ?? 12)),
+          };
+
+          const today = new Date();
+          today.setUTCHours(0, 0, 0, 0);
+          const fmt = (d: Date) => d.toISOString().slice(0, 10);
+          const addDays = (base: Date, days: number) => {
+            const d = new Date(base);
+            d.setUTCDate(d.getUTCDate() + days);
+            return d;
+          };
+
+          // 全 open タスクを取得 (完了系 skip)
+          const { data: rows, error: fetchErr } = await admin
+            .from("wbs_tasks")
+            .select(
+              "id, title, instance, owner_instance, priority, status, " +
+                "start_date, end_date, github_issue_state, category_order",
+            )
+            .neq("status", "completed");
+          if (fetchErr) {
+            return json({ success: false, error: fetchErr.message }, 200);
+          }
+          const all = (rows ?? []) as unknown as Array<
+            Record<string, unknown>
+          >;
+          const open = all.filter(
+            (r) => String(r.github_issue_state ?? "") !== "CLOSED",
+          );
+
+          // priority bucket 別 queue index を category_order, id で安定 sort
+          const buckets: Record<string, Array<Record<string, unknown>>> = {
+            high: [],
+            medium: [],
+            low: [],
+          };
+          for (const r of open) {
+            const p = String(r.priority ?? "medium").toLowerCase();
+            const tier = p === "high" || p === "urgent"
+              ? "high"
+              : p === "low" ? "low" : "medium";
+            buckets[tier].push(r);
+          }
+          for (const tier of Object.keys(buckets)) {
+            buckets[tier].sort((a, b) => {
+              const oa = Number(a.category_order ?? 999);
+              const ob = Number(b.category_order ?? 999);
+              if (oa !== ob) return oa - ob;
+              return String(a.id).localeCompare(String(b.id));
+            });
+          }
+
+          // queue index に基づき stagger 配置
+          const updates: Array<{
+            id: string;
+            start_date: string;
+            end_date: string;
+            tier: "high" | "medium" | "low";
+            stagger_days: number;
+          }> = [];
+          for (const tier of ["high", "medium", "low"] as const) {
+            const tasks = buckets[tier];
+            const offDays = offset[tier];
+            const durDays = duration[tier];
+            const par = parallel[tier];
+            for (let i = 0; i < tasks.length; i++) {
+              const t = tasks[i];
+              const stagger = Math.floor(i / par); // par 件並列、par 超で 1 日ずらす
+              const start = addDays(today, offDays + stagger);
+              const end = addDays(start, durDays);
+              updates.push({
+                id: String(t.id),
+                start_date: fmt(start),
+                end_date: fmt(end),
+                tier,
+                stagger_days: stagger,
+              });
+            }
+          }
+
+          // by_priority サマリ + sample 構築
+          const byPrio: Record<
+            string,
+            { count: number; first_start: string; last_end: string }
+          > = {};
+          for (const u of updates) {
+            const cur = byPrio[u.tier] ?? {
+              count: 0,
+              first_start: u.start_date,
+              last_end: u.end_date,
+            };
+            cur.count += 1;
+            if (u.start_date < cur.first_start) cur.first_start = u.start_date;
+            if (u.end_date > cur.last_end) cur.last_end = u.end_date;
+            byPrio[u.tier] = cur;
+          }
+          const sample = updates.slice(0, 10);
+
+          if (dryRun) {
+            return json({
+              success: true,
+              dry_run: true,
+              total_open: open.length,
+              total_skipped_completed: all.length - open.length,
+              would_update: updates.length,
+              by_priority: byPrio,
+              sample,
+              today: fmt(today),
+              params: { offset, duration, parallel },
+            });
+          }
+
+          // apply: 1 task ずつ update (Supabase JS は bulk update with different
+          // values per row が無いので loop / 918 row ≒ 数秒 / EF timeout 60s 内)
+          let updated = 0;
+          const errors: Array<{ id: string; error: string }> = [];
+          for (const u of updates) {
+            const { error } = await admin
+              .from("wbs_tasks")
+              .update({
+                start_date: u.start_date,
+                end_date: u.end_date,
+                planned_end_date: u.end_date,
+              })
+              .eq("id", u.id);
+            if (error) {
+              errors.push({ id: u.id, error: error.message });
+            } else {
+              updated += 1;
+            }
+          }
+
+          // monitoring_events に記録 (= scheduled task / GHA cron 監査用)
+          try {
+            await admin.from("monitoring_events").insert({
+              event_type: "wbs.reschedule_realistic",
+              severity: errors.length > 0 ? "warning" : "info",
+              metadata: {
+                total_open: open.length,
+                updated,
+                errors: errors.length,
+                by_priority: byPrio,
+                params: { offset, duration, parallel },
+                today: fmt(today),
+              },
+            });
+          } catch (_) {
+            // monitoring_events 未存在時は無視
+          }
+
+          return json({
+            success: errors.length === 0,
+            dry_run: false,
+            total_open: open.length,
+            updated,
+            errors_count: errors.length,
+            errors: errors.slice(0, 10),
+            by_priority: byPrio,
+            sample,
+            today: fmt(today),
+            params: { offset, duration, parallel },
+          });
+        }
         case "wbs.bulk_update": {
           // body: { updates: [{id, progress?, status?}, ...] }
           const updates = (body.updates as Array<Record<string, unknown>>) ??


### PR DESCRIPTION
﻿## Branch cleanup triage
This draft PR preserves $branch for review instead of deleting it during the 2026-05-06 branch cleanup.

## Why PR化
WBS timeline usability work: filtered task count and CSV download on lib/pages/project_gantt_page.dart. This directly supports the user's request to process WBS tasks by due date and keep the two-instance workflow visible.

## Review plan
- Rebase or refresh onto current main.
- Confirm the CSV output only reflects the current filtered WBS view.
- Confirm UI remains stable in the deployed /wbs-user-tasks timeline.

## Minimal E2E declaration
Implementation-detail independent recovery PR. Target smoke coverage is about 3 cases once the branch is refreshed. E2E-Exception reason: this PR is a stale-branch recovery wrapper and does not change production behavior until rebased and undrafted; Playwright or integration_test coverage will be added during the refresh pass.
