### PR TITLE
fix(wbs-auto-reschedule): bump upload-artifact v4→v6

### DIFF
--- a/.github/workflows/wbs-auto-reschedule.yml
+++ b/.github/workflows/wbs-auto-reschedule.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wbs-reschedule-result
           path: |


### PR DESCRIPTION
Node runtime floor check (= scripts/check_github_actions_node_runtime.py / floor=v6) が deploy-prod CI gate で失敗したため、wbs-auto-reschedule.yml の actions/upload-artifact を v6 へ bump。

🤖 Generated with [Claude Code](https://claude.com/claude-code)