### PR TITLE
[codex] Rebaseline WBS plans for two-instance flow

### DIFF
--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -68,6 +68,8 @@ class WbsTask {
   final int progress;
   final DateTime? startDate;
   final DateTime? endDate;
+  final DateTime? plannedStartDate;
+  final DateTime? plannedEndDate;
   final String? milestoneCode;
   final String priority;
   final String ownerInstance;
@@ -94,6 +96,8 @@ class WbsTask {
     required this.progress,
     this.startDate,
     this.endDate,
+    this.plannedStartDate,
+    this.plannedEndDate,
     this.milestoneCode,
     required this.priority,
     this.ownerInstance = '',
@@ -123,6 +127,12 @@ class WbsTask {
         endDate: m['end_date'] != null
             ? DateTime.tryParse(m['end_date'] as String)
             : null,
+        plannedStartDate: m['planned_start_date'] != null
+            ? DateTime.tryParse(m['planned_start_date'] as String)
+            : null,
+        plannedEndDate: m['planned_end_date'] != null
+            ? DateTime.tryParse(m['planned_end_date'] as String)
+            : null,
         milestoneCode: m['milestone_code'] as String?,
         priority: m['priority'] as String? ?? 'medium',
         ownerInstance: m['owner_instance'] as String? ??
@@ -136,10 +146,14 @@ class WbsTask {
       );
 
   /// 遅延日数 (今日 - end_date / 完了済 or 期限なし は 0)
+  DateTime? get scheduleStartDate => plannedStartDate ?? startDate;
+  DateTime? get scheduleEndDate => plannedEndDate ?? endDate;
+
   int get delayDays {
-    if (status == 'completed' || endDate == null) return 0;
+    final scheduleEnd = scheduleEndDate;
+    if (status == 'completed' || scheduleEnd == null) return 0;
     final now = DateTime.now();
-    final end = endDate!;
+    final end = scheduleEnd;
     final today = DateTime(now.year, now.month, now.day);
     final endDay = DateTime(end.year, end.month, end.day);
     final diff = today.difference(endDay).inDays;
@@ -164,7 +178,9 @@ class WbsTask {
       };
 
   String get instanceLabel => switch (instance) {
+        'claude' => 'Claude Code',
         'codex' => 'Codex',
+        'automation' => 'Automation',
         'gemini' => 'Gemini',
         'co-pilot' => 'Co-pilot',
         'copilot' => 'Co-pilot',
@@ -188,7 +204,9 @@ class WbsTask {
       };
 
   Color get instanceColor => switch (instance) {
+        'claude' => const Color(0xFF2563EB),
         'codex' => const Color(0xFF10B981),
+        'automation' => const Color(0xFFEAB308),
         'gemini' => const Color(0xFF4285F4),
         'co-pilot' => const Color(0xFF111827),
         'copilot' => const Color(0xFF111827),
@@ -212,7 +230,9 @@ class WbsTask {
       };
 
   String get ownerLabel => switch (ownerInstance) {
+        'claude' => 'Claude Code',
         'codex' => 'Codex',
+        'automation' => 'Automation',
         'gemini' => 'Gemini',
         'co-pilot' => 'Co-pilot',
         'copilot' => 'Co-pilot',
@@ -235,7 +255,9 @@ class WbsTask {
       };
 
   Color get ownerColor => switch (ownerInstance) {
+        'claude' => const Color(0xFF2563EB),
         'codex' => const Color(0xFF10B981),
+        'automation' => const Color(0xFFEAB308),
         'gemini' => const Color(0xFF4285F4),
         'co-pilot' => const Color(0xFF111827),
         'copilot' => const Color(0xFF111827),
@@ -307,10 +329,11 @@ int _compareWbsTasks(WbsTask a, WbsTask b) {
   final categoryCmp = a.categoryOrder.compareTo(b.categoryOrder);
   if (categoryCmp != 0) return categoryCmp;
 
-  final endDateCmp = _compareOptionalDate(a.endDate, b.endDate);
+  final endDateCmp = _compareOptionalDate(a.scheduleEndDate, b.scheduleEndDate);
   if (endDateCmp != 0) return endDateCmp;
 
-  final startDateCmp = _compareOptionalDate(a.startDate, b.startDate);
+  final startDateCmp =
+      _compareOptionalDate(a.scheduleStartDate, b.scheduleStartDate);
   if (startDateCmp != 0) return startDateCmp;
 
   return a.title.compareTo(b.title);
@@ -1508,7 +1531,8 @@ class _TaskRow extends StatelessWidget {
               ],
             ),
           ],
-          if (task.startDate != null || task.endDate != null) ...[
+          if (task.scheduleStartDate != null ||
+              task.scheduleEndDate != null) ...[
             const SizedBox(height: 4),
             Row(
               children: [
@@ -1520,10 +1544,10 @@ class _TaskRow extends StatelessWidget {
                 const SizedBox(width: 4),
                 Text(
                   [
-                    if (task.startDate != null)
-                      '開始予定: ${task.startDate!.year}/${task.startDate!.month.toString().padLeft(2, '0')}/${task.startDate!.day.toString().padLeft(2, '0')}',
-                    if (task.endDate != null)
-                      '完了予定: ${task.endDate!.year}/${task.endDate!.month.toString().padLeft(2, '0')}/${task.endDate!.day.toString().padLeft(2, '0')}',
+                    if (task.scheduleStartDate != null)
+                      '開始予定: ${task.scheduleStartDate!.year}/${task.scheduleStartDate!.month.toString().padLeft(2, '0')}/${task.scheduleStartDate!.day.toString().padLeft(2, '0')}',
+                    if (task.scheduleEndDate != null)
+                      '完了予定: ${task.scheduleEndDate!.year}/${task.scheduleEndDate!.month.toString().padLeft(2, '0')}/${task.scheduleEndDate!.day.toString().padLeft(2, '0')}',
                   ].join('  '),
                   style: TextStyle(
                     color: task.delayDays > 0
@@ -1997,8 +2021,9 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     final result = switch (_sortColumnKey) {
       '#' => _compareWbsTasks(a, b),
       'task' => _compareText(a.title, b.title),
-      'startDate' => _compareOptionalDate(a.startDate, b.startDate),
-      'endDate' => _compareOptionalDate(a.endDate, b.endDate),
+      'startDate' =>
+        _compareOptionalDate(a.scheduleStartDate, b.scheduleStartDate),
+      'endDate' => _compareOptionalDate(a.scheduleEndDate, b.scheduleEndDate),
       'instance' => _compareText(
           _instanceBadgeLabel(a),
           _instanceBadgeLabel(b),
@@ -2453,8 +2478,8 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
         '${t.progress}',
         t.status,
         t.priority,
-        _isoDate(t.startDate),
-        _isoDate(t.endDate),
+        _isoDate(t.scheduleStartDate),
+        _isoDate(t.scheduleEndDate),
         t.remainingWork,
         t.recoveryPlan,
         t.milestoneCode ?? '',
@@ -3082,12 +3107,12 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
           // Win版#132 part 86: 各 cell を Tooltip で wrap (= 列別 hover content 表示 / recovery 固定 bug 修正)
           if (_colVisible['startDate'] ?? true)
             Tooltip(
-              message: '開始予定: ${_formatDate(task.startDate)}',
+              message: '開始予定: ${_formatDate(task.scheduleStartDate)}',
               waitDuration: const Duration(milliseconds: 350),
               child: SizedBox(
                 width: _colWidths['startDate'] ?? 80,
                 child: Text(
-                  _formatDate(task.startDate),
+                  _formatDate(task.scheduleStartDate),
                   style: const TextStyle(
                     color: Color(0xFFB0B0C0),
                     fontSize: 11,
@@ -3100,13 +3125,13 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
           if (_colVisible['endDate'] ?? true)
             Tooltip(
               message: task.delayDays > 0
-                  ? '完了予定: ${_formatDate(task.endDate)} (${task.delayDays}日遅延)'
-                  : '完了予定: ${_formatDate(task.endDate)}',
+                  ? '完了予定: ${_formatDate(task.scheduleEndDate)} (${task.delayDays}日遅延)'
+                  : '完了予定: ${_formatDate(task.scheduleEndDate)}',
               waitDuration: const Duration(milliseconds: 350),
               child: SizedBox(
                 width: _colWidths['endDate'] ?? 80,
                 child: Text(
-                  _formatDate(task.endDate),
+                  _formatDate(task.scheduleEndDate),
                   style: TextStyle(
                     color: task.delayDays > 0
                         ? const Color(0xFFEF4444)
@@ -3553,8 +3578,8 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
   }
 
   Widget _buildTimelineRow(int index, WbsTask task) {
-    final start = task.startDate;
-    final end = task.endDate;
+    final start = task.scheduleStartDate;
+    final end = task.scheduleEndDate;
     if (start == null || end == null) {
       return const SizedBox.shrink();
     }
@@ -3973,15 +3998,18 @@ class _LightningLinePainter extends CustomPainter {
       final y = i * rowHeight + rowHeight / 2;
       double x = todayX;
 
-      if (t.startDate != null && t.endDate != null && t.status != 'completed') {
-        final startX = _dateToX(t.startDate!);
-        final endX = _dateToX(t.endDate!);
+      if (t.scheduleStartDate != null &&
+          t.scheduleEndDate != null &&
+          t.status != 'completed') {
+        final startX = _dateToX(t.scheduleStartDate!);
+        final endX = _dateToX(t.scheduleEndDate!);
         final barWidth = endX - startX;
         if (barWidth > 0) {
           // 期待進捗
-          final totalDays = t.endDate!.difference(t.startDate!).inDays;
+          final totalDays =
+              t.scheduleEndDate!.difference(t.scheduleStartDate!).inDays;
           final passedDays =
-              today.difference(t.startDate!).inDays.clamp(0, totalDays);
+              today.difference(t.scheduleStartDate!).inDays.clamp(0, totalDays);
           final expected = totalDays > 0 ? passedDays / totalDays : 0.0;
           final actual = t.progress / 100.0;
 
@@ -3997,7 +4025,7 @@ class _LightningLinePainter extends CustomPainter {
             }
           }
         }
-      } else if (t.status == 'completed' || t.endDate == null) {
+      } else if (t.status == 'completed' || t.scheduleEndDate == null) {
         // 完了済 or 期限なし → 今日 X 維持
         x = todayX;
       }

--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -5741,7 +5741,7 @@ serve(async (req) => {
           const limit = Math.min(Number(body.limit ?? 50), 200);
           let q = admin.from("wbs_tasks")
             .select(
-              "id, category, category_icon, category_order, title, description, instance, owner_instance, status, progress, start_date, end_date, planned_end_date, milestone_code, priority, remaining_work, updated_at, github_issue_number, github_issue_url, github_issue_state, github_issue_labels, github_issue_synced_at",
+              "id, category, category_icon, category_order, title, description, instance, owner_instance, status, progress, start_date, end_date, planned_start_date, planned_end_date, milestone_code, priority, remaining_work, updated_at, github_issue_number, github_issue_url, github_issue_state, github_issue_labels, github_issue_synced_at",
             );
           if (status) q = q.eq("status", status);
           if (updatedSince) q = q.gte("updated_at", updatedSince);
@@ -5770,7 +5770,7 @@ serve(async (req) => {
         case "wbs.update_progress": {
           // body: { id, progress?: 0-100, status?: 'in_progress'|'completed'|'blocked',
           //        recovery_plan?: string, end_date?: 'YYYY-MM-DD' (リスケ用),
-          //        planned_end_date?: 'YYYY-MM-DD', note?: string }
+          //        planned_start_date?: 'YYYY-MM-DD', planned_end_date?: 'YYYY-MM-DD', note?: string }
           // Win版#131 part 10: 遅延時 recovery_plan 必須化
           // Win版#131 part 14 / T2-Win: defense-in-depth EF validation
           //   DB trigger `wbs_enforce_recovery_plan_trg` も同仕様を block
@@ -5794,13 +5794,16 @@ serve(async (req) => {
             update.rescheduled_count =
               ((cur?.rescheduled_count as number) ?? 0) + 1;
           }
+          if (body.planned_start_date !== undefined) {
+            update.planned_start_date = String(body.planned_start_date);
+          }
           if (body.planned_end_date !== undefined) {
             update.planned_end_date = String(body.planned_end_date);
           }
           if (Object.keys(update).length === 0) {
             return json({
               error:
-                "progress, status, recovery_plan, end_date, or planned_end_date required",
+                "progress, status, recovery_plan, end_date, planned_start_date, or planned_end_date required",
             }, 400);
           }
 
@@ -5845,7 +5848,7 @@ serve(async (req) => {
           const { data, error } = await admin.from("wbs_tasks")
             .update(update).eq("id", id)
             .select(
-              "id, title, status, progress, recovery_plan, end_date, planned_end_date, rescheduled_count",
+              "id, title, status, progress, recovery_plan, end_date, planned_start_date, planned_end_date, rescheduled_count",
             )
             .single();
           if (error) {
@@ -6402,7 +6405,7 @@ serve(async (req) => {
         }
         case "wbs.add_task": {
           // body: { category, title, instance, owner_instance?, description?,
-          //        priority?, end_date?, planned_end_date?, milestone_code?,
+          //        priority?, end_date?, planned_start_date?, planned_end_date?, milestone_code?,
           //        github_issue_number?, github_issue_url?, github_issue_state?,
           //        github_issue_labels? }
           // PS#6 S23 (2026-04-21): instance を required 化 (ALL leak 防止)
@@ -6465,6 +6468,8 @@ serve(async (req) => {
             priority: String(body.priority ?? "medium"),
             start_date: body.start_date ?? null,
             end_date: body.end_date ?? null,
+            planned_start_date: body.planned_start_date ?? body.start_date ??
+              null,
             planned_end_date: body.planned_end_date ?? body.end_date ?? null,
             remaining_work: body.remaining_work ?? null,
             milestone_code: body.milestone_code ?? null,
@@ -6564,7 +6569,7 @@ serve(async (req) => {
           const nowIso = now.toISOString();
           const today = nowIso.slice(0, 10);
           const taskSelect =
-            "id, category, category_icon, category_order, title, description, instance, owner_instance, status, progress, start_date, end_date, planned_end_date, milestone_code, priority, remaining_work, recovery_plan, ai_review_status, created_at, updated_at, github_issue_number, github_issue_url, github_issue_state, github_issue_labels, github_issue_synced_at";
+            "id, category, category_icon, category_order, title, description, instance, owner_instance, status, progress, start_date, end_date, planned_start_date, planned_end_date, milestone_code, priority, remaining_work, recovery_plan, ai_review_status, created_at, updated_at, github_issue_number, github_issue_url, github_issue_state, github_issue_labels, github_issue_synced_at";
           const allTasks = await fetchAllWbsTasks(admin, taskSelect);
           const tasksByIssue = new Map<
             number,
@@ -6674,6 +6679,8 @@ serve(async (req) => {
               priority: githubIssuePriority(labels),
               start_date: keeper?.start_date ?? today,
               end_date: keeper?.end_date ?? githubIssueDueDate(labels, now),
+              planned_start_date: keeper?.planned_start_date ??
+                keeper?.start_date ?? today,
               planned_end_date: keeper?.planned_end_date ?? keeper?.end_date ??
                 githubIssueDueDate(labels, now),
               remaining_work: isClosed
@@ -7098,7 +7105,7 @@ serve(async (req) => {
             true,
           );
           const taskSelect =
-            "id, category, category_order, title, status, progress, priority, end_date, planned_end_date, updated_at, instance, owner_instance, recovery_plan, github_issue_number, github_issue_url, github_issue_state, github_issue_synced_at";
+            "id, category, category_order, title, status, progress, priority, end_date, planned_start_date, planned_end_date, updated_at, instance, owner_instance, recovery_plan, github_issue_number, github_issue_url, github_issue_state, github_issue_synced_at";
           const { data, error } = await admin.from("wbs_tasks")
             .select(taskSelect)
             .in("status", ["pending", "in_progress", "blocked"]);
@@ -7232,7 +7239,7 @@ serve(async (req) => {
         case "wbs.instance_workload": {
           // body: { instance?: string } 任意。全 instance の負荷と救援候補を返す。
           const taskSelect =
-            "id, category, category_order, title, status, progress, priority, end_date, planned_end_date, updated_at, instance, owner_instance, recovery_plan, github_issue_number, github_issue_url, github_issue_state, github_issue_synced_at";
+            "id, category, category_order, title, status, progress, priority, end_date, planned_start_date, planned_end_date, updated_at, instance, owner_instance, recovery_plan, github_issue_number, github_issue_url, github_issue_state, github_issue_synced_at";
           const { data, error } = await admin.from("wbs_tasks")
             .select(taskSelect)
             .in("status", ["pending", "in_progress", "blocked"]);

--- a/supabase/migrations/20260506070000_rebalance_wbs_two_instance_schedule.sql
+++ b/supabase/migrations/20260506070000_rebalance_wbs_two_instance_schedule.sql
@@ -1,0 +1,134 @@
+-- Rebaseline WBS plans for the two-instance operating model.
+--
+-- start_date/end_date are kept as actual fields.  The project Gantt UI now
+-- displays planned_start_date/planned_end_date when present, so this migration
+-- moves every open task onto a realistic forward-looking schedule without
+-- rewriting completed history.
+
+ALTER TABLE public.wbs_tasks DROP CONSTRAINT IF EXISTS wbs_tasks_instance_check;
+ALTER TABLE public.wbs_tasks ADD CONSTRAINT wbs_tasks_instance_check
+  CHECK (instance IN (
+    'claude', 'codex', 'codex1', 'codex2', 'cx', 'automation', 'auto', 'user', 'usr', 'human',
+    'gemini', 'co-pilot', 'copilot',
+    'vscode', 'win', 'windows',
+    'ps', 'ps1', 'ps2', 'ps3', 'ps4', 'ps5', 'ps6',
+    'web', 'mobile', 'schedule', 'scheduled', 'gha', 'github-actions', 'github-copilot', 'all'
+  ));
+
+ALTER TABLE public.wbs_tasks DROP CONSTRAINT IF EXISTS wbs_tasks_owner_instance_check;
+ALTER TABLE public.wbs_tasks ADD CONSTRAINT wbs_tasks_owner_instance_check
+  CHECK (owner_instance IN (
+    'claude', 'codex', 'codex1', 'codex2', 'cx', 'automation', 'auto', 'user', 'usr', 'human',
+    'gemini', 'co-pilot', 'copilot',
+    'vscode', 'win', 'windows',
+    'ps', 'ps1', 'ps2', 'ps3', 'ps4', 'ps5', 'ps6',
+    'web', 'mobile', 'schedule', 'scheduled', 'gha', 'github-actions', 'github-copilot', 'all'
+  ));
+
+WITH normalized AS (
+  SELECT
+    id,
+    title,
+    status,
+    progress,
+    priority,
+    updated_at,
+    COALESCE(planned_end_date, end_date, DATE '2099-12-31') AS old_deadline,
+    GREATEST(CURRENT_DATE, DATE '2026-05-06') AS anchor_date,
+    CASE
+      WHEN lower(trim(COALESCE(NULLIF(owner_instance, ''), NULLIF(instance, ''), 'codex'))) IN
+        ('codex', 'codex1', 'codex2', 'cx', 'ps2', 'ps5', 'ps6') THEN 'codex'
+      WHEN lower(trim(COALESCE(NULLIF(owner_instance, ''), NULLIF(instance, ''), 'codex'))) IN
+        ('claude', 'claude-code', 'win', 'windows', 'vscode', 'web', 'mobile', 'ps1', 'ps3', 'ps4') THEN 'claude'
+      WHEN lower(trim(COALESCE(NULLIF(owner_instance, ''), NULLIF(instance, ''), 'codex'))) IN
+        ('automation', 'auto', 'schedule', 'scheduled', 'gha', 'github-actions', 'gemini', 'co-pilot', 'copilot', 'github-copilot') THEN 'automation'
+      WHEN lower(trim(COALESCE(NULLIF(owner_instance, ''), NULLIF(instance, ''), 'codex'))) IN
+        ('user', 'usr', 'human') THEN 'user'
+      ELSE 'codex'
+    END AS lane,
+    CASE status
+      WHEN 'in_progress' THEN 0
+      WHEN 'pending' THEN 1
+      WHEN 'blocked' THEN 2
+      ELSE 3
+    END AS status_rank,
+    CASE priority
+      WHEN 'high' THEN 0
+      WHEN 'medium' THEN 1
+      WHEN 'low' THEN 2
+      ELSE 3
+    END AS priority_rank,
+    CASE
+      WHEN status = 'in_progress' THEN GREATEST(1, LEAST(3, CEIL((100 - COALESCE(progress, 0)) / 50.0)::int))
+      WHEN priority = 'high' THEN 2
+      ELSE 1
+    END AS duration_days
+  FROM public.wbs_tasks
+  WHERE COALESCE(status, 'pending') <> 'completed'
+    AND COALESCE(github_issue_state, '') <> 'CLOSED'
+),
+ranked AS (
+  SELECT
+    *,
+    row_number() OVER (
+      PARTITION BY lane
+      ORDER BY status_rank, priority_rank, old_deadline, updated_at NULLS LAST, title
+    ) - 1 AS lane_index
+  FROM normalized
+),
+scheduled AS (
+  SELECT
+    id,
+    lane,
+    old_deadline,
+    anchor_date,
+    duration_days,
+    CASE lane
+      WHEN 'claude' THEN 2
+      WHEN 'codex' THEN 2
+      WHEN 'automation' THEN 4
+      WHEN 'user' THEN 1
+      ELSE 2
+    END AS daily_capacity,
+    lane_index
+  FROM ranked
+),
+final_schedule AS (
+  SELECT
+    id,
+    lane,
+    old_deadline,
+    anchor_date,
+    (anchor_date + floor(lane_index::numeric / daily_capacity)::int)::date AS new_start_date,
+    (anchor_date + floor(lane_index::numeric / daily_capacity)::int + duration_days - 1)::date AS new_end_date
+  FROM scheduled
+)
+UPDATE public.wbs_tasks AS task
+SET
+  planned_start_date = final_schedule.new_start_date,
+  planned_end_date = final_schedule.new_end_date,
+  owner_instance = final_schedule.lane,
+  instance = final_schedule.lane,
+  recovery_plan = CASE
+    WHEN final_schedule.old_deadline < final_schedule.anchor_date THEN
+      trim(BOTH FROM CONCAT_WS(
+        E'\n',
+        NULLIF(task.recovery_plan, ''),
+        format(
+          '%s: 2インスタンス制(Claude Code 1 / Codex 1)へ再計画。実行可能開始=%s、完了可能=%sへ更新。',
+          to_char(final_schedule.anchor_date, 'YYYY-MM-DD'),
+          final_schedule.new_start_date,
+          final_schedule.new_end_date
+        )
+      ))
+    ELSE task.recovery_plan
+  END,
+  recovery_planned_at = CASE
+    WHEN final_schedule.old_deadline < final_schedule.anchor_date THEN now()
+    ELSE task.recovery_planned_at
+  END,
+  rescheduled_count = COALESCE(task.rescheduled_count, 0) + 1,
+  last_rebalanced_at = now(),
+  updated_at = now()
+FROM final_schedule
+WHERE task.id = final_schedule.id;


### PR DESCRIPTION
﻿## Summary
- Rebaseline all open WBS tasks onto a forward-looking two-instance schedule.
- Normalize active owners into Claude Code, Codex, Automation, or User lanes while keeping legacy lane values accepted for historical rows.
- Make Project Gantt and tools-hub read/write `planned_start_date` together with `planned_end_date`, so the columns labeled 開始予定/完了予定 use the planned fields instead of stale actual dates.

## Root Cause
The WBS table already had planned date columns, but the Gantt page and tools API still treated `start_date` / `end_date` as schedule fields. This made rows keep past dates like 05/03→05/06 even when they were not actually startable under the new two-instance workflow.

## Validation
- `dart analyze lib/pages/project_gantt_page.dart`
- `dart format --output=none --set-exit-if-changed lib/pages/project_gantt_page.dart`
- `deno check supabase/functions/tools-hub/index.ts`
- `deno lint supabase/functions/tools-hub/index.ts`
- `python scripts/check_migration_timestamps.py`
- `git diff --check`

Note: `deno fmt supabase/functions/tools-hub/index.ts` still hits Deno formatter instability on this large existing file; lint/check pass and CI does not require Deno fmt for this file.

## Minimal E2E Gate
- Implementation-detail independent / black-box: validate from the Project Gantt route as a user, without depending on Dart model internals or Supabase migration implementation details.
- Minimal plan: 3 cases: open WBS timeline and confirm planned start/end columns are populated from forward-looking dates; filter Claude Code/Codex/Automation and confirm two-instance lane labels render; export/copy WBS data and confirm planned start/end values are included.
- E2E mechanism: Playwright smoke or Flutter integration_test can cover these route-level input/output checks.
- E2E-Exception: no new integration_test file in this PR because the change is a schedule data rebaseline plus display/API field mapping; existing Public E2E stability smoke covers route availability and the black-box plan above is declared for reviewer follow-up.