### PR TITLE
fix(wbs): keep instance stable during rebaseline

### DIFF
--- a/supabase/migrations/20260506070000_rebalance_wbs_two_instance_schedule.sql
+++ b/supabase/migrations/20260506070000_rebalance_wbs_two_instance_schedule.sql
@@ -134,7 +134,8 @@ SET
   planned_start_date = final_schedule.new_start_date,
   planned_end_date = final_schedule.new_end_date,
   owner_instance = final_schedule.lane,
-  instance = final_schedule.lane,
+  -- Keep instance stable: multiple legacy lanes can share the same title and
+  -- would collide with the title+instance unique constraint when collapsed.
   recovery_plan = CASE
     WHEN final_schedule.old_deadline < final_schedule.anchor_date THEN
       trim(BOTH FROM CONCAT_WS(


### PR DESCRIPTION
## Summary
- Repair the WBS schedule rebaseline migration that failed in production on duplicate `(title, instance)` rows.
- Keep legacy `instance` values stable and use `owner_instance` for the active two-instance lane assignment.
- Preserve the realistic planned start/end schedule updates introduced by #2066.

## Why
Production deploy failed while applying `20260506070000_rebalance_wbs_two_instance_schedule.sql` because multiple legacy lanes can share the same task title. Collapsing all of them into `claude` / `codex` / `automation` / `user` can violate `wbs_tasks_title_instance_unique`. The UI and WBS ownership flow can read the active lane from `owner_instance`, so changing `instance` is unnecessary and risky.

## Validation
- `python scripts/check_migration_timestamps.py`
- `git diff --check`

## Minimal E2E Gate
- Implementation-detail independent / black-box: validate from the Project Gantt route as a user, without depending on Supabase migration internals.
- Minimal plan: open `/project-gantt`, confirm WBS tasks show future planned start/end dates, filter Claude Code/Codex/Automation lanes, and export/copy WBS rows to confirm planned dates remain populated.
- E2E mechanism: existing public route smoke covers availability; this migration-only hotfix is verified by the next production deploy applying the migration successfully.
- E2E-Exception: no new integration test file because this is a production migration repair for an already-reviewed WBS rebaseline.