### PR TITLE
fix(wbs): sync planned_start_date in reschedule_realistic + raise disk-cleanup report threshold

### DIFF
--- a/docs/DISK_HYGIENE_RUNBOOK.md
+++ b/docs/DISK_HYGIENE_RUNBOOK.md
@@ -60,8 +60,8 @@
 
 | 残量 | action | 通知方法 |
 |---|---|---|
-| ≥ 50 GB | 通常運転 | log のみ (= `~/.claude/logs/disk-cleanup-YYYYMMDD.log`) |
-| 25-50 GB | report 書き出し | `~/cleanup_reports/disk_report_<ts>.md` (= 既存 cleanup_report_notify.ps1 が pickup) |
+| ≥ 80 GB | 通常運転 | log のみ (= `~/.claude/logs/disk-cleanup-YYYYMMDD.log`) |
+| 25-80 GB | report 書き出し | `~/cleanup_reports/disk_report_<ts>.md` (= 既存 cleanup_report_notify.ps1 が pickup) — fleet-loaded box では毎セッション report 出力 (= part 158 で 50→80 GB 厳格化 / 圧縮可視化) |
 | 10-25 GB | **WARN** | `additionalContext` 経由で Claude に「`/disk-cleanup` 推奨」surface |
 | < 10 GB | **ALERT** | `additionalContext` で「即座に `/disk-cleanup` 実行」surface (= ビルド失敗 risk) |
 

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -27922,3 +27922,28 @@ WBS タイムラインの全 1144 open タスク (= UI 表示 918 件は Supabas
 - [ISSUE-PRECHECK] N/A (= 起票なし)
 
 **83 part 連続 dogfood** (= part 75 → part 157 / 2 month 連続)
+
+## Win版#132 part 158 2026-05-06 (Win Claude / 84 part 連続 dogfood)
+
+### 着地サマリ
+
+part 157 follow-up 2 件:
+
+1. **disk-cleanup hook report 閾値 50→80 GB 厳格化** — Tier 1 自体は無条件実行されていたが report が < 50 GB でしか書かれず、fleet-loaded box (= C: 60 GB 帯) では report 0 件で圧縮効果が観測できなかった。閾値を 80 GB へ上げて毎セッション report 出力 → 圧縮可視化。
+2. **`wbs.reschedule_realistic` で `planned_start_date` 同期更新 bug fix** — /project-gantt screenshot で start > end の違和感観察 → root cause 特定 (= EF が `planned_start_date` のみ更新漏れ / UI `scheduleStartDate` getter は `plannedStartDate` 優先) → 1 行 update payload 追加。次 cron 走行で 1144 row 全 row が UI 整合する。
+
+parallel cap 4/8/12 は density 3.86/7.34/3.48 per day で適正 → 調整不要判定。
+
+### Commits
+
+- `0525b60d3` fix(wbs): sync planned_start_date in reschedule_realistic + raise disk-cleanup report threshold (PR #2075)
+
+### Philosophy Alignment
+
+- **PHILOSOPHY-22 9/9** (CEO 感 / mentor / 6 部署 / 商品 / 資本 / 資産負債 / KPI / IPO / mission)
+- **AI-DEV-23 7/7** (= part 157 と同 EF の 1 行 fix / 既存 audit log / 既存 quality-gate / regression-safe)
+- **INDIE-29 7/7** (shipping 速度 = 1 session で disk + EF + memory + ROADMAP 完結)
+- **PLATFORM-31 5+/7** (= 観察 → root cause → 1 行 fix の高 leverage 規律)
+- [ISSUE-PRECHECK] N/A (= 起票なし)
+
+**84 part 連続 dogfood** (= part 75 → part 158 / 2 month 連続)

--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -6349,6 +6349,7 @@ serve(async (req) => {
                 .update({
                   start_date: u.start_date,
                   end_date: u.end_date,
+                  planned_start_date: u.start_date,
                   planned_end_date: u.end_date,
                 })
                 .eq("id", u.id);


### PR DESCRIPTION
## Summary

Two coordinated follow-ups to part 157 (= the WBS auto-reschedule
infra ship):

### 1. `wbs.reschedule_realistic` — also update `planned_start_date`

After part 157's full rebaseline (1144 rows, all 3 tiers) the gantt
UI still showed pre-rebaseline 開始予定 dates like `09/16` against new
完了予定 dates like `05/17`. Root cause: the EF only updated
`start_date` / `end_date` / `planned_end_date`, but the UI's
`scheduleStartDate` getter at `lib/pages/project_gantt_page.dart:164`
prefers `plannedStartDate` when present.

Fix is one line: also write `planned_start_date: u.start_date` in the
update payload. The next daily 06:00 JST cron (or a manual dispatch
of `.github/workflows/wbs-auto-reschedule.yml`) clears the stale
display.

### 2. `docs/DISK_HYGIENE_RUNBOOK.md` — report threshold 50 to 80 GB

Doc sync for a matching change to `~/.claude/hooks/disk-cleanup.ps1`
(= user-home, not repo-tracked). On the fleet-loaded box, the report
write now triggers every session, so each session's compaction is
observable instead of silent.

## Minimal E2E plan

This is a minimal E2E plan with about 3 I/O cases, framed as black-box
and implementation-detail independent — the EF is invoked over its
admin HTTP surface and the contract is observed via `monitoring_events`
+ the rendered gantt UI, not via internal column-by-column assertions:

1. `dry_run=true` returns `success=true` with `would_update >= 1100`,
   `by_priority` covering all 3 tiers, and `start <= end` for every
   sample row.
2. `dry_run=false` returns `success=true`, `errors=0`, and
   `monitoring_events` records `wbs.reschedule_realistic` with
   `severity=info`.
3. After (2), the gantt UI at `/project-gantt` shows `scheduleStartDate
   <= scheduleEndDate` for at least the previously-mismatched sample
   (Issue #1568, #1563, etc.), proving `planned_start_date` is now
   synced (= the fix this PR adds).

These cases do not depend on internal Dart class shape or Deno function
layout — they only check observable I/O: HTTP response shape,
`monitoring_events` row, and the rendered timeline.

## E2E-Exception

E2E-Exception: This PR is a 1-line column-set extension to an existing
admin-only EF action (`wbs.reschedule_realistic`) plus an unrelated
docs threshold sync. The new column (`planned_start_date`) is already
read by the UI gantt page (verified via `scheduleStartDate` getter
chain). No new code path, no new endpoint, no new user-facing surface.
The minimal 3-case I/O plan above is verified post-deploy by the
existing `wbs-auto-reschedule` daily cron (and its workflow_dispatch
variant), so no new integration_test/ file is added.

## Test plan

- [ ] CI green
- [ ] After deploy: manually dispatch `wbs-auto-reschedule.yml` and
      confirm gantt UI 開始予定 / 完了予定 columns no longer mismatch
- [ ] `monitoring_events` shows `severity=info` and `errors=0`
- [x] Local smoke test of `disk-cleanup.ps1` already done

Refs: Win版#132 part 158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
