### PR TITLE
fix(wbs): make gantt controls readable

### DIFF
--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:ui' show PointerDeviceKind;
 
 import 'package:flutter/material.dart';
@@ -662,6 +663,7 @@ class _ProjectGanttPageState extends State<ProjectGanttPage>
             filterInstance: _filterInstance,
             onFilterInstance: (v) => setState(() => _filterInstance = v),
             milestoneRisks: _milestoneRisks,
+            onRefreshWbs: _loadWbs,
           ),
           _MyProjectsTab(
             projects: _projects,
@@ -1870,6 +1872,7 @@ class _GanttTimelineTab extends StatefulWidget {
   final ValueChanged<String?> onFilterInstance;
   // Win版#131 part 13: マイルストーン risk
   final List<Map<String, dynamic>> milestoneRisks;
+  final Future<void> Function()? onRefreshWbs;
 
   const _GanttTimelineTab({
     required this.milestones,
@@ -1880,6 +1883,7 @@ class _GanttTimelineTab extends StatefulWidget {
     required this.filterInstance,
     required this.onFilterInstance,
     required this.milestoneRisks,
+    this.onRefreshWbs,
   });
 
   @override
@@ -1898,10 +1902,10 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     'endDate': 104,
     'instance': 70,
     'progress': 50,
-    'remaining': 200,
-    'depends': 150,
-    'recovery': 180,
-    'flags': 36, // Win#131 part 22: 遅延 ⚠ flag column
+    'remaining': 160,
+    'depends': 120,
+    'recovery': 160,
+    'flags': 64, // Win#131 part 22: 注意 flag column
   };
 
   // 列幅 min/max constraints (= drag 時の clamp 値)
@@ -1915,7 +1919,7 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     'remaining': 120,
     'depends': 100,
     'recovery': 120,
-    'flags': 36,
+    'flags': 64,
   };
   static const Map<String, double> _colMaxWidths = {
     '#': 80,
@@ -1927,7 +1931,7 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     'remaining': 600,
     'depends': 400,
     'recovery': 600,
-    'flags': 36, // = 固定 (resize 不要)
+    'flags': 64, // = 固定 (resize 不要)
   };
   // resizable=false の列 (= drag handle 非表示)
   static const Set<String> _colNonResizable = {'#', 'flags'};
@@ -1958,8 +1962,8 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
           .fold<double>(0, (sum, e) => sum + (_colWidths[e.key] ?? 0)) +
       16; // padding
   static const _rowHeight = 32.0;
-  static const _headerHeight = 64.0;
-  static const _dayWidth = 6.0;
+  static const _headerHeight = 72.0;
+  static const _dayWidth = 7.0;
   static const _bgColor = Color(0xFF0F0F14);
   static const _panelColor = Color(0xFF1A1A24);
   static const _gridLine = Color(0xFF2A2A36);
@@ -1968,6 +1972,9 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
   final _leftScroll = ScrollController();
   final _rightScroll = ScrollController();
   final _timelineHScroll = ScrollController();
+  final _overallHScroll = ScrollController();
+  bool _aiReportLoading = false;
+  bool _repairLoading = false;
 
   // Win版#132 part 83: column resize — drag 中の hover key (= handle 強調表示用)
   String? _hoveredResizeColKey;
@@ -2139,6 +2146,7 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     _leftScroll.dispose();
     _rightScroll.dispose();
     _timelineHScroll.dispose();
+    _overallHScroll.dispose();
     super.dispose();
   }
 
@@ -2177,6 +2185,18 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
   double _dateToX(DateTime date) {
     final days = date.difference(_timelineStart).inDays;
     return days * _dayWidth;
+  }
+
+  void _scrollWholeGridToGraph() {
+    if (!_overallHScroll.hasClients) return;
+    final target = (_leftPanelWidth - 56)
+        .clamp(0.0, _overallHScroll.position.maxScrollExtent)
+        .toDouble();
+    _overallHScroll.animateTo(
+      target,
+      duration: const Duration(milliseconds: 260),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   List<WbsTask> get _orderedTasks {
@@ -2221,101 +2241,140 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
           Expanded(
             child: ScrollConfiguration(
               behavior: const _GanttDragScrollBehavior(),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // 左パネル (# / タスク名 / 担当)
-                  SizedBox(
-                    width: _leftPanelWidth,
-                    child: Column(
-                      children: [
-                        _buildLeftColumnHeader(),
-                        Expanded(
-                          child: ListView.builder(
-                            controller: _leftScroll,
-                            itemCount: tasks.length,
-                            itemExtent: _rowHeight,
-                            itemBuilder: (_, i) => _buildLeftRow(i, tasks[i]),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  // 右タイムライン (横スクロール)
-                  Expanded(
-                    child: Scrollbar(
-                      controller: _timelineHScroll,
-                      thumbVisibility: true,
-                      trackVisibility: true,
-                      interactive: true,
-                      thickness: 8,
-                      scrollbarOrientation: ScrollbarOrientation.bottom,
-                      child: SingleChildScrollView(
-                        controller: _timelineHScroll,
-                        scrollDirection: Axis.horizontal,
-                        primary: false,
-                        child: SizedBox(
-                          width: _timelineWidth,
-                          child: Column(
-                            children: [
-                              _buildMonthHeader(),
-                              Expanded(
-                                child: Stack(
-                                  children: [
-                                    // グリッド + Today ライン
-                                    Positioned.fill(
-                                      child: CustomPaint(
-                                        painter: _GanttGridPainter(
-                                          start: _timelineStart,
-                                          end: _timelineEnd,
-                                          dayWidth: _dayWidth,
-                                          todayX: _dateToX(DateTime.now()),
-                                        ),
-                                      ),
-                                    ),
-                                    // タスクバー行
-                                    ListView.builder(
-                                      controller: _rightScroll,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  const minTimelineViewport = 560.0;
+                  final wholeWidth = math.max(
+                    constraints.maxWidth,
+                    _leftPanelWidth + minTimelineViewport,
+                  );
+                  final timelineViewportWidth =
+                      math.max(minTimelineViewport, wholeWidth - _leftPanelWidth);
+                  return Scrollbar(
+                    controller: _overallHScroll,
+                    thumbVisibility: true,
+                    trackVisibility: true,
+                    interactive: true,
+                    thickness: 8,
+                    scrollbarOrientation: ScrollbarOrientation.top,
+                    child: SingleChildScrollView(
+                      controller: _overallHScroll,
+                      scrollDirection: Axis.horizontal,
+                      primary: false,
+                      child: SizedBox(
+                        width: wholeWidth,
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            // 左パネル (# / タスク名 / 担当)
+                            SizedBox(
+                              width: _leftPanelWidth,
+                              child: Column(
+                                children: [
+                                  _buildLeftColumnHeader(),
+                                  Expanded(
+                                    child: ListView.builder(
+                                      controller: _leftScroll,
                                       itemCount: tasks.length,
                                       itemExtent: _rowHeight,
                                       itemBuilder: (_, i) =>
-                                          _buildTimelineRow(i, tasks[i]),
+                                          _buildLeftRow(i, tasks[i]),
                                     ),
-                                    // Win版#131 part 10: イナズマ線 (lightning line)
-                                    // 今日時点での進捗実態を zigzag で可視化
-                                    Positioned.fill(
-                                      child: IgnorePointer(
-                                        child: AnimatedBuilder(
-                                          animation: _rightScroll,
-                                          builder: (context, _) => CustomPaint(
-                                            painter: _LightningLinePainter(
-                                              tasks: tasks,
-                                              dayWidth: _dayWidth,
-                                              rowHeight: _rowHeight,
-                                              timelineStart: _timelineStart,
-                                              today: DateTime.now(),
-                                              verticalOffset:
-                                                  _rightScroll.hasClients
-                                                      ? _rightScroll.offset
-                                                      : 0,
-                                            ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            // 右タイムライン (横スクロール)
+                            SizedBox(
+                              width: timelineViewportWidth,
+                              child: Scrollbar(
+                                controller: _timelineHScroll,
+                                thumbVisibility: true,
+                                trackVisibility: true,
+                                interactive: true,
+                                thickness: 8,
+                                scrollbarOrientation:
+                                    ScrollbarOrientation.bottom,
+                                child: SingleChildScrollView(
+                                  controller: _timelineHScroll,
+                                  scrollDirection: Axis.horizontal,
+                                  primary: false,
+                                  child: SizedBox(
+                                    width: _timelineWidth,
+                                    child: Column(
+                                      children: [
+                                        _buildMonthHeader(),
+                                        Expanded(
+                                          child: Stack(
+                                            children: [
+                                              // グリッド + Today ライン
+                                              Positioned.fill(
+                                                child: CustomPaint(
+                                                  painter: _GanttGridPainter(
+                                                    start: _timelineStart,
+                                                    end: _timelineEnd,
+                                                    dayWidth: _dayWidth,
+                                                    todayX:
+                                                        _dateToX(DateTime.now()),
+                                                  ),
+                                                ),
+                                              ),
+                                              // タスクバー行
+                                              ListView.builder(
+                                                controller: _rightScroll,
+                                                itemCount: tasks.length,
+                                                itemExtent: _rowHeight,
+                                                itemBuilder: (_, i) =>
+                                                    _buildTimelineRow(
+                                                  i,
+                                                  tasks[i],
+                                                ),
+                                              ),
+                                              // Win版#131 part 10: イナズマ線 (lightning line)
+                                              // 今日時点での進捗実態を zigzag で可視化
+                                              Positioned.fill(
+                                                child: IgnorePointer(
+                                                  child: AnimatedBuilder(
+                                                    animation: _rightScroll,
+                                                    builder: (context, _) =>
+                                                        CustomPaint(
+                                                      painter:
+                                                          _LightningLinePainter(
+                                                        tasks: tasks,
+                                                        dayWidth: _dayWidth,
+                                                        rowHeight: _rowHeight,
+                                                        timelineStart:
+                                                            _timelineStart,
+                                                        today: DateTime.now(),
+                                                        verticalOffset:
+                                                            _rightScroll
+                                                                    .hasClients
+                                                                ? _rightScroll
+                                                                    .offset
+                                                                : 0,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                              // マイルストーンの縦線 + 菱形
+                                              ...widget.milestones
+                                                  .map(_buildMilestoneMark),
+                                            ],
                                           ),
                                         ),
-                                      ),
+                                      ],
                                     ),
-                                    // マイルストーンの縦線 + 菱形
-                                    ...widget.milestones
-                                        .map(_buildMilestoneMark),
-                                  ],
+                                  ),
                                 ),
                               ),
-                            ],
-                          ),
+                            ),
+                          ],
                         ),
                       ),
                     ),
-                  ),
-                ],
+                  );
+                },
               ),
             ),
           ),
@@ -2407,43 +2466,126 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     );
   }
 
+  String _buildLocalAiReport() {
+    final tasks = _orderedTasks;
+    final open = tasks.where((t) => !t.isEffectivelyCompleted).toList();
+    final delayed = open.where((t) => t.delayDays > 0).toList();
+    final noNext =
+        open.where((t) => _cleanDisplayText(t.remainingWork) == null).length;
+    final noAction =
+        open.where((t) => _cleanDisplayText(t.recoveryPlan) == null).length;
+    final blockers = open.where((t) => _visibleBlockers(t).isNotEmpty).length;
+    final inverted = open.where((t) => t.hasInvertedSchedule).length;
+    final avgProgress = tasks.isEmpty
+        ? 0
+        : (tasks.fold<int>(0, (sum, t) => sum + t.progress) / tasks.length)
+            .round();
+    final dueSoon = open.where((t) {
+      final end = t.scheduleEndDate;
+      if (end == null) return false;
+      final days = end.difference(DateTime.now()).inDays;
+      return days >= 0 && days <= 7;
+    }).toList();
+    final byOwner = <String, int>{};
+    for (final task in open) {
+      final owner = _instanceBadgeLabel(task);
+      byOwner[owner] = (byOwner[owner] ?? 0) + 1;
+    }
+    final ownerSummary = byOwner.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final urgent = [...open]
+      ..sort((a, b) {
+        final delay = b.delayDays.compareTo(a.delayDays);
+        if (delay != 0) return delay;
+        return _compareOptionalDate(a.scheduleEndDate, b.scheduleEndDate);
+      });
+
+    final buf = StringBuffer()
+      ..writeln('### 即時診断')
+      ..writeln('- 表示中: ${tasks.length}件 / 未完了: ${open.length}件 / 平均進捗: $avgProgress%')
+      ..writeln('- 遅延: ${delayed.length}件 / 期限7日以内: ${dueSoon.length}件 / 日付補正: $inverted件')
+      ..writeln('- 次にやること未記入: $noNext件 / 状態・対処未記入: $noAction件 / ブロック要因あり: $blockers件');
+    if (ownerSummary.isNotEmpty) {
+      buf.writeln(
+        '- 担当別未完了: ${ownerSummary.take(4).map((e) => '${e.key} ${e.value}件').join(' / ')}',
+      );
+    }
+    buf.writeln('\n### 先に見るべきタスク');
+    for (final task in urgent.take(5)) {
+      buf.writeln(
+        '- ${_compactText(task.title, max: 46)}: ${_statusActionLabel(task)}',
+      );
+    }
+    buf.writeln('\n### 改善提案');
+    if (noNext > 0) {
+      buf.writeln('- 「次にやること」が未記入のタスクを、担当ごとに3件ずつ具体化する。');
+    }
+    if (delayed.isNotEmpty) {
+      buf.writeln('- 遅延タスクは「状態 / 対処」を先に埋め、予定変更は依存修復後に行う。');
+    }
+    if (inverted > 0) {
+      buf.writeln('- 日付補正タスクは元データの開始予定・完了予定を見直す。');
+    }
+    if (blockers > 0) {
+      buf.writeln('- ブロック要因ありのタスクは依存先完了日を確認し、開始可能日を再計算する。');
+    }
+    return buf.toString();
+  }
+
   // Win版#131 part 20: AI 概観 + 依存関係自動修復
   Future<void> _showAiReport() async {
-    if (Supabase.instance.client.auth.currentUser == null) return;
-    showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (_) => const AlertDialog(
-        backgroundColor: Color(0xFF141414),
-        title: Text(
-          '🧠 AI 概観取得中...',
-          style: TextStyle(color: Colors.white, height: 1.5),
-        ),
-        content: Center(
-          child: SizedBox(
-            width: 24,
-            height: 24,
-            child: CircularProgressIndicator(
-              color: Color(0xFFA855F7),
-              strokeWidth: 2,
+    if (_aiReportLoading) return;
+    setState(() => _aiReportLoading = true);
+    final localReport = _buildLocalAiReport();
+    final user = Supabase.instance.client.auth.currentUser;
+    var loadingDialogShown = false;
+    if (user != null) {
+      loadingDialogShown = true;
+      showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => const AlertDialog(
+          backgroundColor: Color(0xFF141414),
+          title: Text(
+            '🧠 AI 補足取得中...',
+            style: TextStyle(color: Colors.white, height: 1.5),
+          ),
+          content: Center(
+            child: SizedBox(
+              width: 24,
+              height: 24,
+              child: CircularProgressIndicator(
+                color: Color(0xFFA855F7),
+                strokeWidth: 2,
+              ),
             ),
           ),
         ),
-      ),
-    );
-    String? report;
-    try {
-      final resp = await Supabase.instance.client.functions.invoke(
-        'tools-hub',
-        body: {'action': 'wbs.ai_status_report'},
       );
-      final data = resp.data as Map<String, dynamic>?;
-      report = data?['report'] as String? ?? '取得失敗';
+    }
+    String? remoteReport;
+    try {
+      if (user != null) {
+        final resp = await Supabase.instance.client.functions.invoke(
+          'tools-hub',
+          body: {'action': 'wbs.ai_status_report'},
+        );
+        final data = resp.data as Map<String, dynamic>?;
+        remoteReport = data?['report'] as String?;
+      }
     } catch (e) {
-      report = 'エラー: $e';
+      remoteReport = 'AI補足の取得に失敗しました: $e';
     }
     if (!mounted) return;
-    Navigator.of(context).pop();
+    if (loadingDialogShown) Navigator.of(context).pop();
+    setState(() => _aiReportLoading = false);
+    final report = [
+      localReport,
+      if (remoteReport != null && remoteReport.trim().isNotEmpty)
+        '---\n### AI補足\n$remoteReport'
+      else if (user == null)
+        '---\n### AI補足\nログイン時のみサーバーAI補足を取得します。上記の即時診断は画面上のWBSから生成しています。',
+    ].join('\n\n');
     showDialog<void>(
       context: context,
       builder: (_) => AlertDialog(
@@ -2453,7 +2595,7 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
             Icon(Icons.psychology_alt, color: Color(0xFFA855F7)),
             SizedBox(width: 8),
             Text(
-              'AI 概観報告',
+              'AI 概観（即時診断）',
               style: TextStyle(color: Colors.white, height: 1.5),
             ),
           ],
@@ -2469,7 +2611,7 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
               ),
             ),
             child: Text(
-              report ?? '',
+              report,
               style: const TextStyle(
                 color: Color(0xFFE2E8F0),
                 fontSize: 13,
@@ -2520,8 +2662,8 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
       '優先度',
       '開始予定',
       '完了予定',
-      '残作業',
-      'リカバリープラン',
+      '次にやること',
+      '状態/対処',
       'マイルストーン',
       'GitHubIssue状態',
       'GitHubIssue#',
@@ -2542,8 +2684,8 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
         t.priority,
         _isoDate(t.scheduleStartDate),
         _isoDate(t.scheduleEndDate),
-        t.remainingWork,
-        t.recoveryPlan,
+        _nextActionLabel(t),
+        _statusActionLabel(t),
         t.milestoneCode ?? '',
         t.githubIssueState,
         issueNo?.toString() ?? '',
@@ -2571,21 +2713,36 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
   }
 
   Future<void> _autoRepairDependencies() async {
-    if (Supabase.instance.client.auth.currentUser == null) return;
+    if (_repairLoading) return;
+    if (Supabase.instance.client.auth.currentUser == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('依存修復にはログインが必要です')),
+      );
+      return;
+    }
+    setState(() => _repairLoading = true);
     try {
+      final blockerCount =
+          _orderedTasks.where((t) => _visibleBlockers(t).isNotEmpty).length;
       final resp = await Supabase.instance.client.functions.invoke(
         'tools-hub',
         body: {'action': 'wbs.auto_repair_dependencies'},
       );
       final data = resp.data as Map<String, dynamic>?;
       final repairs = (data?['repairs'] as List?) ?? [];
+      final refreshWbs = widget.onRefreshWbs;
+      if (refreshWbs != null) {
+        await refreshWbs();
+      }
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
             repairs.isEmpty
-                ? '✅ 依存関係 整合済 (修復対象 0 件)'
-                : '🔧 ${repairs.length} タスクの start_date を自動修復しました',
+                ? blockerCount == 0
+                    ? '✅ ブロック要因はありません。修復不要です'
+                    : '✅ 依存関係は整合済です (修復対象 0 件)'
+                : '🔧 ${repairs.length}件を修復し、WBSを再読み込みしました',
           ),
           backgroundColor: const Color(0xFF22C55E),
         ),
@@ -2595,6 +2752,8 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('自動修復エラー: $e')),
       );
+    } finally {
+      if (mounted) setState(() => _repairLoading = false);
     }
   }
 
@@ -2610,7 +2769,7 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
       'remaining': '次作業',
       'depends': 'ブロック',
       'recovery': '状態/対処',
-      'flags': '⚠',
+      'flags': '注意',
     };
     return Container(
       color: const Color(0xFF0F0F18),
@@ -2828,37 +2987,79 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
             ],
           ),
           const Spacer(),
-          // Win版#131 part 20: AI 概観 + 自動修復 button
-          SizedBox(
-            height: 28,
-            child: OutlinedButton.icon(
-              onPressed: _showAiReport,
-              icon: const Icon(Icons.psychology_alt, size: 14),
-              label: const Text(
-                'AI 概観',
-                style: TextStyle(fontSize: 11, height: 1.5),
-              ),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: const Color(0xFFA855F7),
-                side: const BorderSide(color: Color(0xFFA855F7)),
-                padding: const EdgeInsets.symmetric(horizontal: 8),
+          Tooltip(
+            message: '表が広くてグラフが隠れている場合、右側のガント領域へ移動します。',
+            child: SizedBox(
+              height: 28,
+              child: OutlinedButton.icon(
+                onPressed: _scrollWholeGridToGraph,
+                icon: const Icon(Icons.timeline, size: 14),
+                label: const Text(
+                  'グラフへ',
+                  style: TextStyle(fontSize: 11, height: 1.5),
+                ),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: const Color(0xFF60A5FA),
+                  side: const BorderSide(color: Color(0xFF60A5FA)),
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                ),
               ),
             ),
           ),
           const SizedBox(width: 6),
-          SizedBox(
-            height: 28,
-            child: OutlinedButton.icon(
-              onPressed: _autoRepairDependencies,
-              icon: const Icon(Icons.auto_fix_high, size: 14),
-              label: const Text(
-                '依存自動修復',
-                style: TextStyle(fontSize: 11, height: 1.5),
+          // Win版#131 part 20: AI 概観 + 自動修復 button
+          Tooltip(
+            message: '表示中WBSをローカル診断し、可能ならAI補足も取得します。',
+            child: SizedBox(
+              height: 28,
+              child: OutlinedButton.icon(
+                onPressed: _aiReportLoading ? null : _showAiReport,
+                icon: _aiReportLoading
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.psychology_alt, size: 14),
+                label: Text(
+                  _aiReportLoading ? '分析中' : 'AI 概観',
+                  style: const TextStyle(fontSize: 11, height: 1.5),
+                ),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: const Color(0xFFA855F7),
+                  disabledForegroundColor:
+                      const Color(0xFFA855F7).withValues(alpha: 0.45),
+                  side: const BorderSide(color: Color(0xFFA855F7)),
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                ),
               ),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: const Color(0xFF22C55E),
-                side: const BorderSide(color: Color(0xFF22C55E)),
-                padding: const EdgeInsets.symmetric(horizontal: 8),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Tooltip(
+            message: '依存関係由来の日程矛盾を検査し、修復後にWBSを再読み込みします。',
+            child: SizedBox(
+              height: 28,
+              child: OutlinedButton.icon(
+                onPressed: _repairLoading ? null : _autoRepairDependencies,
+                icon: _repairLoading
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.auto_fix_high, size: 14),
+                label: Text(
+                  _repairLoading ? '修復中' : '依存修復',
+                  style: const TextStyle(fontSize: 11, height: 1.5),
+                ),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: const Color(0xFF22C55E),
+                  disabledForegroundColor:
+                      const Color(0xFF22C55E).withValues(alpha: 0.45),
+                  side: const BorderSide(color: Color(0xFF22C55E)),
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                ),
               ),
             ),
           ),
@@ -3036,10 +3237,118 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
           header('remaining', '次にやること'),
           header('depends', 'ブロック要因'),
           header('recovery', '状態 / 対処'),
-          header('flags', '⚠', align: TextAlign.center),
+          header('flags', '注意', align: TextAlign.center),
         ],
       ),
     );
+  }
+
+  String? _cleanDisplayText(String raw) {
+    final text = raw.trim().replaceAll(RegExp(r'\s+'), ' ');
+    if (text.isEmpty) return null;
+    final lower = text.toLowerCase();
+    const internalMarkers = [
+      'github issue source of truth',
+      'sync keeps wbs',
+      'tbd',
+      'pre-push backfill',
+      'duplicate of wbs task',
+      '遅延 detect',
+      '延定 detect',
+    ];
+    if (internalMarkers.any((marker) => lower.contains(marker))) return null;
+    return text;
+  }
+
+  String _compactText(String text, {int max = 54}) {
+    final normalized = text.trim().replaceAll(RegExp(r'\s+'), ' ');
+    if (normalized.length <= max) return normalized;
+    return '${normalized.substring(0, max - 1)}…';
+  }
+
+  String _nextActionLabel(WbsTask task) {
+    final text = _cleanDisplayText(task.remainingWork);
+    if (text != null) return _compactText(text, max: 64);
+    if (task.isEffectivelyCompleted) return '完了';
+    if (task.isDelayedNoPlan) return '遅延対応を記入';
+    if (task.delayDays > 0) return '遅延対応を確認';
+    if (task.progress > 0) return '進行中: 次手順未記入';
+    if (_extractIssueNumber(task.title) != null) return 'Issueを確認して着手';
+    return '次手順未記入';
+  }
+
+  Color _nextActionColor(WbsTask task) {
+    if (_cleanDisplayText(task.remainingWork) != null) {
+      return const Color(0xFFE2E8F0);
+    }
+    if (task.isDelayedNoPlan || task.delayDays > 0) {
+      return const Color(0xFFF97316);
+    }
+    return const Color(0xFF94A3B8);
+  }
+
+  List<String> _visibleBlockers(WbsTask task) => task.dependsOnTitles
+      .map(_cleanDisplayText)
+      .whereType<String>()
+      .map((t) => _compactText(t, max: 44))
+      .toList();
+
+  String _blockerLabel(WbsTask task) {
+    final blockers = _visibleBlockers(task);
+    if (blockers.isEmpty) return 'なし';
+    if (blockers.length == 1) return blockers.single;
+    return '${blockers.length}件: ${blockers.first}';
+  }
+
+  String _statusActionLabel(WbsTask task) {
+    if (task.isEffectivelyCompleted) return '完了';
+    if (task.hasInvertedSchedule) return '日付補正済';
+    final recovery = _cleanDisplayText(task.recoveryPlan);
+    if (task.delayDays > 0) {
+      if (recovery != null) {
+        return '${task.delayDays}日遅延: ${_compactText(recovery, max: 42)}';
+      }
+      return '${task.delayDays}日遅延: 対処未記入';
+    }
+    if (recovery != null) return _compactText(recovery, max: 58);
+    final end = task.scheduleEndDate;
+    if (end != null) {
+      final days = end.difference(DateTime.now()).inDays;
+      if (days >= 0 && days <= 7) return '期限近い: 残$days日';
+    }
+    if (task.progress > 0) return '進行中';
+    return '未着手';
+  }
+
+  Color _statusActionColor(WbsTask task) {
+    if (task.isEffectivelyCompleted) return const Color(0xFF22C55E);
+    if (task.hasInvertedSchedule) return const Color(0xFFFBBF24);
+    if (task.isDelayedNoPlan) return const Color(0xFFEF4444);
+    if (task.delayDays > 0) return const Color(0xFFF97316);
+    if (_cleanDisplayText(task.recoveryPlan) != null) {
+      return const Color(0xFFE2E8F0);
+    }
+    return const Color(0xFF94A3B8);
+  }
+
+  String _attentionLabel(WbsTask task) {
+    if (task.isEffectivelyCompleted) return '完了';
+    if (task.hasInvertedSchedule) return '日付';
+    if (task.isDelayedNoPlan) return '要対処';
+    if (task.delayDays > 0) return '遅延';
+    if (_cleanDisplayText(task.remainingWork) == null) return '未記入';
+    return 'OK';
+  }
+
+  Color _attentionColor(WbsTask task) {
+    if (task.isEffectivelyCompleted) return const Color(0xFF22C55E);
+    if (task.hasInvertedSchedule) return const Color(0xFFFBBF24);
+    if (task.isDelayedNoPlan) return const Color(0xFFEF4444);
+    if (task.delayDays > 0) return const Color(0xFFF97316);
+    if (_cleanDisplayText(task.remainingWork) == null) {
+      return const Color(0xFF94A3B8);
+    }
+    return const Color(0xFF38BDF8);
   }
 
   Widget _buildLeftRow(int index, WbsTask task) {
@@ -3279,70 +3588,61 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
             ),
           if (_colVisible['remaining'] ?? true)
             Tooltip(
-              message: task.remainingWork.isNotEmpty
-                  ? '残作業: ${task.remainingWork}'
-                  : '残作業: (未記入 / クリックで指示送信)',
+              message: _cleanDisplayText(task.remainingWork) != null
+                  ? '次にやること: ${_cleanDisplayText(task.remainingWork)}'
+                  : '次にやること: ${_nextActionLabel(task)}',
               waitDuration: const Duration(milliseconds: 350),
               child: SizedBox(
                 width: _colWidths['remaining'] ?? 200,
-                child: _emptyOrText(
-                  text: task.remainingWork,
-                  task: task,
-                  field: 'remaining_work',
-                  color: const Color(0xFF9CA3AF),
+                child: _readableStatusCell(
+                  label: _nextActionLabel(task),
+                  color: _nextActionColor(task),
+                  onTap: _cleanDisplayText(task.remainingWork) == null
+                      ? () => _sendInstructionToInstance(task, 'remaining_work')
+                      : null,
                 ),
               ),
             ),
           if (_colVisible['depends'] ?? true)
             Tooltip(
-              message: task.dependsOnTitles.isEmpty
-                  ? '依存: なし'
-                  : '依存: ${task.dependsOnTitles.join(", ")}',
+              message: _visibleBlockers(task).isEmpty
+                  ? 'ブロック要因: なし'
+                  : 'ブロック要因: ${_visibleBlockers(task).join(" / ")}',
               waitDuration: const Duration(milliseconds: 350),
               child: SizedBox(
                 width: _colWidths['depends'] ?? 150,
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 4, right: 4),
-                  child: Text(
-                    task.dependsOnTitles.isEmpty
-                        ? 'なし'
-                        : task.dependsOnTitles.join(' / '),
-                    style: TextStyle(
-                      color: task.dependsOnTitles.isEmpty
-                          ? const Color(0xFF64748B)
-                          : const Color(0xFFA855F7),
-                      fontSize: 10,
-                      height: 1.5,
-                    ),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
+                child: _readableStatusCell(
+                  label: _blockerLabel(task),
+                  color: _visibleBlockers(task).isEmpty
+                      ? const Color(0xFF64748B)
+                      : const Color(0xFFA855F7),
                 ),
               ),
             ),
           if (_colVisible['recovery'] ?? true)
             Tooltip(
-              message: task.recoveryPlan.isNotEmpty
-                  ? 'リカバリー案: ${task.recoveryPlan}'
-                  : 'リカバリー案: (未記入 / クリックで指示送信)',
+              message: '状態 / 対処: ${_statusActionLabel(task)}',
               waitDuration: const Duration(milliseconds: 350),
               child: SizedBox(
                 width: _colWidths['recovery'] ?? 180,
-                child: _recoveryCell(task),
+                child: _readableStatusCell(
+                  label: _statusActionLabel(task),
+                  color: _statusActionColor(task),
+                  onTap: _cleanDisplayText(task.recoveryPlan) == null &&
+                          !task.isEffectivelyCompleted
+                      ? () => _sendInstructionToInstance(task, 'recovery_plan')
+                      : null,
+                ),
               ),
             ),
-          // Win版#131 part 22: 遅延 ⚠ flag column (大きめ視覚マーカー)
+          // Win版#131 part 22: 注意 flag column (短い状態 badge)
           if (_colVisible['flags'] ?? true)
             Tooltip(
-              message: isDelayedNoPlan
-                  ? '⚠ ${task.delayDays}日遅延・リカバリー案未記入 (要対処)'
-                  : isDelayed
-                      ? '${task.delayDays}日遅延'
-                      : '遅延なし',
+              message: '注意: ${_attentionLabel(task)}',
               waitDuration: const Duration(milliseconds: 350),
               child: SizedBox(
                 width: _colWidths['flags'] ?? 36,
-                child: _delayFlagCell(task),
+                child: _attentionBadge(task),
               ),
             ),
         ],
@@ -3350,120 +3650,83 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     ); // Win版#132 part 86: Tooltip 削除 — Container + Row 構造のみ (閉じ括弧 1 つ減)
   }
 
-  // Win版#131 part 23: 空セルを「指示送信」ボタンに変換
-  // 残作業 / リカバリー案 が空の時、担当 instance に直接指示送信できる
-  Widget _emptyOrText({
-    required String text,
-    required WbsTask task,
-    required String field,
+  Widget _readableStatusCell({
+    required String label,
     required Color color,
+    VoidCallback? onTap,
   }) {
-    if (text.isNotEmpty) {
-      return Padding(
-        padding: const EdgeInsets.only(left: 4, right: 4),
-        child: Text(
-          text,
-          style: TextStyle(color: color, fontSize: 10, height: 1.5),
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
+    final text = Padding(
+      padding: const EdgeInsets.only(left: 4, right: 4),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 10,
+          fontWeight: onTap == null ? FontWeight.w500 : FontWeight.w700,
+          height: 1.5,
         ),
-      );
-    }
-    final label = field == 'remaining_work' ? '未記入' : '案なし';
-    final tooltip = field == 'remaining_work'
-        ? '次にやることが未記入です。クリックすると担当へ記入依頼を作成します。'
-        : '状態 / 対処が未記入です。クリックすると担当へ記入依頼を作成します。';
-    return Tooltip(
-      message: tooltip,
-      waitDuration: const Duration(milliseconds: 350),
-      child: Padding(
-        padding: const EdgeInsets.only(left: 4, right: 4),
-        child: InkWell(
-          onTap: () => _sendInstructionToInstance(task, field),
-          borderRadius: BorderRadius.circular(3),
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-            decoration: BoxDecoration(
-              color: const Color(0xFF334155).withValues(alpha: 0.28),
-              borderRadius: BorderRadius.circular(3),
-              border: Border.all(
-                color: const Color(0xFF64748B).withValues(alpha: 0.35),
-                width: 0.5,
-              ),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(
-                  Icons.edit_note_outlined,
-                  size: 11,
-                  color: Color(0xFF94A3B8),
-                ),
-                const SizedBox(width: 3),
-                Flexible(
-                  child: Text(
-                    label,
-                    style: const TextStyle(
-                      color: Color(0xFFCBD5E1),
-                      fontSize: 9,
-                      fontWeight: FontWeight.w600,
-                      height: 1.3,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
-            ),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+    if (onTap == null) return text;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(4),
+      child: Container(
+        margin: const EdgeInsets.only(left: 2, right: 4, top: 5, bottom: 5),
+        padding: const EdgeInsets.symmetric(horizontal: 5),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: color.withValues(alpha: 0.35), width: 0.5),
+        ),
+        alignment: Alignment.centerLeft,
+        child: Text(
+          label,
+          style: TextStyle(
+            color: color,
+            fontSize: 10,
+            fontWeight: FontWeight.w700,
+            height: 1.3,
           ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
       ),
     );
   }
 
-  // Win版#131 part 22: 大きめ delay flag cell
-  Widget _delayFlagCell(WbsTask task) {
-    if (task.status == 'completed') {
-      return const Center(
+  Widget _attentionBadge(WbsTask task) {
+    final label = _attentionLabel(task);
+    final color = _attentionColor(task);
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.14),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: color.withValues(alpha: 0.4), width: 0.5),
+        ),
         child: Text(
-          '✓',
+          label,
           style: TextStyle(
-            color: Color(0xFF22C55E),
-            fontSize: 14,
-            fontWeight: FontWeight.w700,
+            color: color,
+            fontSize: 9,
+            fontWeight: FontWeight.w800,
             height: 1.2,
           ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
-      );
-    }
-    if (task.isDelayedNoPlan) {
-      return Tooltip(
-        message: '🚨 ${task.delayDays}日遅延・リカバリー案未記入',
-        child: const Center(
-          child: Text(
-            '🚨',
-            style: TextStyle(fontSize: 16, height: 1.2),
-          ),
-        ),
-      );
-    }
-    if (task.delayDays > 0) {
-      return Tooltip(
-        message: '⚠ ${task.delayDays}日遅延',
-        child: const Center(
-          child: Text(
-            '⚠',
-            style: TextStyle(fontSize: 16, height: 1.2),
-          ),
-        ),
-      );
-    }
-    return const SizedBox.shrink();
+      ),
+    );
   }
 
   // Win版#131 part 23: 担当 instance に直接指示送信 (cross-instance-pr 自動生成)
   Future<void> _sendInstructionToInstance(WbsTask task, String field) async {
     if (Supabase.instance.client.auth.currentUser == null) return;
-    final fieldLabel = field == 'remaining_work' ? '残作業' : 'リカバリー案 / 状態';
+    final fieldLabel = field == 'remaining_work' ? '次にやること' : '状態 / 対処';
     final controller = TextEditingController();
     final result = await showDialog<String>(
       context: context,
@@ -3570,93 +3833,6 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
   String _formatDate(DateTime? d) {
     if (d == null) return '—';
     return '${d.year}/${d.month.toString().padLeft(2, '0')}/${d.day.toString().padLeft(2, '0')}';
-  }
-
-  Widget _recoveryCell(WbsTask task) {
-    if (task.status == 'completed') {
-      return const Padding(
-        padding: EdgeInsets.only(left: 4),
-        child: Text(
-          '✅ 完了',
-          style: TextStyle(
-            color: Color(0xFF4CAF50),
-            fontSize: 10,
-            height: 1.5,
-          ),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-      );
-    }
-    if (task.hasInvertedSchedule) {
-      return const Padding(
-        padding: EdgeInsets.only(left: 4),
-        child: Text(
-          '日付補正: 開始<=完了で表示',
-          style: TextStyle(
-            color: Color(0xFFFBBF24),
-            fontSize: 10,
-            fontWeight: FontWeight.w700,
-            height: 1.5,
-          ),
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-      );
-    }
-    if (task.isDelayedNoPlan) {
-      return Padding(
-        padding: const EdgeInsets.only(left: 4),
-        child: Text(
-          '⚠ ${task.delayDays}日遅延・未記入 (要対処)',
-          style: const TextStyle(
-            color: Color(0xFFEF4444),
-            fontSize: 10,
-            fontWeight: FontWeight.w700,
-            height: 1.5,
-          ),
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-      );
-    }
-    if (task.delayDays > 0 && task.recoveryPlan.isNotEmpty) {
-      return Padding(
-        padding: const EdgeInsets.only(left: 4),
-        child: Text(
-          '🟠 ${task.delayDays}日遅延 / ${task.recoveryPlan}',
-          style: const TextStyle(
-            color: Color(0xFFF97316),
-            fontSize: 10,
-            height: 1.5,
-          ),
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-      );
-    }
-    if (task.recoveryPlan.isNotEmpty) {
-      return Padding(
-        padding: const EdgeInsets.only(left: 4),
-        child: Text(
-          task.recoveryPlan,
-          style: const TextStyle(
-            color: Color(0xFF9CA3AF),
-            fontSize: 10,
-            height: 1.5,
-          ),
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-      );
-    }
-    // Win版#131 part 23: 空セルは「指示送信」ボタンに変換
-    return _emptyOrText(
-      text: '',
-      task: task,
-      field: 'recovery_plan',
-      color: const Color(0xFF9CA3AF),
-    );
   }
 
   Widget _instanceBadge(WbsTask task) {
@@ -3897,6 +4073,14 @@ class _MonthHeaderPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final line = Paint()..color = const Color(0xFF3A3A48);
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, size.width, 34),
+      Paint()..color = const Color(0xFF181824),
+    );
+    canvas.drawRect(
+      Rect.fromLTWH(0, 34, size.width, size.height - 34),
+      Paint()..color = const Color(0xFF12121B),
+    );
 
     // 月ヘッダー (上段)
     DateTime monthCursor = DateTime(start.year, start.month, 1);
@@ -3955,7 +4139,7 @@ class _MonthHeaderPainter extends CustomPainter {
           ),
           textDirection: TextDirection.ltr,
         )..layout();
-        tp.paint(canvas, Offset(x + 2, 35));
+        tp.paint(canvas, Offset(x + 2, 43));
       }
       day = day.add(const Duration(days: 1));
       x += dayWidth;
@@ -3969,7 +4153,7 @@ class _MonthHeaderPainter extends CustomPainter {
     while (tickDay.isBefore(end)) {
       if (tickDay.weekday == DateTime.monday || tickDay.day == 1) {
         canvas.drawLine(
-          Offset(tickX, size.height - 10),
+          Offset(tickX, 36),
           Offset(tickX, size.height - 1),
           tickPaint,
         );
@@ -3988,8 +4172,8 @@ class _MonthHeaderPainter extends CustomPainter {
     // 月/日セクション境界
     final midLinePaint = Paint()..color = const Color(0xFF2A2A36);
     canvas.drawLine(
-      const Offset(0, 30),
-      Offset(size.width, 30),
+      const Offset(0, 34),
+      Offset(size.width, 34),
       midLinePaint,
     );
 

--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -2248,8 +2248,8 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
                     constraints.maxWidth,
                     _leftPanelWidth + minTimelineViewport,
                   );
-                  final timelineViewportWidth =
-                      math.max(minTimelineViewport, wholeWidth - _leftPanelWidth);
+                  final timelineViewportWidth = math.max(
+                      minTimelineViewport, wholeWidth - _leftPanelWidth);
                   return Scrollbar(
                     controller: _overallHScroll,
                     thumbVisibility: true,
@@ -2314,8 +2314,8 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
                                                     start: _timelineStart,
                                                     end: _timelineEnd,
                                                     dayWidth: _dayWidth,
-                                                    todayX:
-                                                        _dateToX(DateTime.now()),
+                                                    todayX: _dateToX(
+                                                        DateTime.now()),
                                                   ),
                                                 ),
                                               ),
@@ -2493,8 +2493,7 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     }
     final ownerSummary = byOwner.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
-    final urgent = [...open]
-      ..sort((a, b) {
+    final urgent = [...open]..sort((a, b) {
         final delay = b.delayDays.compareTo(a.delayDays);
         if (delay != 0) return delay;
         return _compareOptionalDate(a.scheduleEndDate, b.scheduleEndDate);
@@ -2502,9 +2501,12 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
 
     final buf = StringBuffer()
       ..writeln('### 即時診断')
-      ..writeln('- 表示中: ${tasks.length}件 / 未完了: ${open.length}件 / 平均進捗: $avgProgress%')
-      ..writeln('- 遅延: ${delayed.length}件 / 期限7日以内: ${dueSoon.length}件 / 日付補正: $inverted件')
-      ..writeln('- 次にやること未記入: $noNext件 / 状態・対処未記入: $noAction件 / ブロック要因あり: $blockers件');
+      ..writeln(
+          '- 表示中: ${tasks.length}件 / 未完了: ${open.length}件 / 平均進捗: $avgProgress%')
+      ..writeln(
+          '- 遅延: ${delayed.length}件 / 期限7日以内: ${dueSoon.length}件 / 日付補正: $inverted件')
+      ..writeln(
+          '- 次にやること未記入: $noNext件 / 状態・対処未記入: $noAction件 / ブロック要因あり: $blockers件');
     if (ownerSummary.isNotEmpty) {
       buf.writeln(
         '- 担当別未完了: ${ownerSummary.take(4).map((e) => '${e.key} ${e.value}件').join(' / ')}',

--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -2249,7 +2249,9 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
                     _leftPanelWidth + minTimelineViewport,
                   );
                   final timelineViewportWidth = math.max(
-                      minTimelineViewport, wholeWidth - _leftPanelWidth);
+                    minTimelineViewport,
+                    wholeWidth - _leftPanelWidth,
+                  );
                   return Scrollbar(
                     controller: _overallHScroll,
                     thumbVisibility: true,
@@ -2315,7 +2317,8 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
                                                     end: _timelineEnd,
                                                     dayWidth: _dayWidth,
                                                     todayX: _dateToX(
-                                                        DateTime.now()),
+                                                      DateTime.now(),
+                                                    ),
                                                   ),
                                                 ),
                                               ),
@@ -2502,11 +2505,14 @@ class _GanttTimelineTabState extends State<_GanttTimelineTab> {
     final buf = StringBuffer()
       ..writeln('### 即時診断')
       ..writeln(
-          '- 表示中: ${tasks.length}件 / 未完了: ${open.length}件 / 平均進捗: $avgProgress%')
+        '- 表示中: ${tasks.length}件 / 未完了: ${open.length}件 / 平均進捗: $avgProgress%',
+      )
       ..writeln(
-          '- 遅延: ${delayed.length}件 / 期限7日以内: ${dueSoon.length}件 / 日付補正: $inverted件')
+        '- 遅延: ${delayed.length}件 / 期限7日以内: ${dueSoon.length}件 / 日付補正: $inverted件',
+      )
       ..writeln(
-          '- 次にやること未記入: $noNext件 / 状態・対処未記入: $noAction件 / ブロック要因あり: $blockers件');
+        '- 次にやること未記入: $noNext件 / 状態・対処未記入: $noAction件 / ブロック要因あり: $blockers件',
+      );
     if (ownerSummary.isNotEmpty) {
       buf.writeln(
         '- 担当別未完了: ${ownerSummary.take(4).map((e) => '${e.key} ${e.value}件').join(' / ')}',


### PR DESCRIPTION
## Summary
- Converts internal WBS boilerplate into readable labels for next action, blocker, status/action, and attention columns.
- Adds whole-grid horizontal scrolling plus a graph-jump control so the timeline can be reached when table columns fill the viewport.
- Adds clearer year/month/week ruler marks, stronger header bands, and a clearer today marker on the graph area.
- Improves AI overview with immediate local diagnostics before optional server AI output.
- Improves dependency repair with loading state, no-login feedback, reload after repair, and clearer result messages.

## Validation
- git diff --check HEAD~1..HEAD
- Local dart format/analyze could not complete because Dart/Flutter subprocesses repeatedly hung in this Windows worktree; GitHub Actions is the validation source for Dart checks.

## Minimal E2E
The E2E test is implementation-detail independent.

Manual visual plan: open /project-gantt, verify the right-side columns no longer show internal boilerplate, use the graph-jump control or top horizontal scrollbar to reveal the graph, confirm date ticks are visible, and confirm AI overview/dependency repair show loading and clear feedback.

E2E-Exception: This is a visual Flutter Web WBS readability/control fix. Automated pixel E2E was not added in this patch; CI plus manual visual verification cover the scoped behavior.