### PR TITLE
docs: define two-instance delegation protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,14 @@ same notebook.
 ## Role Split
 
 - Claude Code owns planning, architecture, review, and quality-gate design.
-- Codex #1 owns cross-cutting investigation, SQL/migration review, and fix PRs.
-- Codex #2 owns CI, synchronization, operations, Edge Functions, GitHub Actions,
-  and deterministic automation.
+- Codex #1 owns scoped implementation, cross-cutting investigation,
+  SQL/migration review, CI, synchronization, operations, Edge Functions,
+  GitHub Actions, deterministic automation, branch cleanup, and fix PRs.
+- Codex #2 and older PS/WEB/mobile/Gemini/Copilot lanes are historical labels
+  only. Do not start extra live instances unless the user explicitly reactivates
+  them.
+- Use `docs/AGENT_DELEGATION_PROTOCOL.md` as the current handoff and review
+  contract for WBS tasks.
 
 ## Codex Defaults
 

--- a/docs/AGENT_DELEGATION_PROTOCOL.md
+++ b/docs/AGENT_DELEGATION_PROTOCOL.md
@@ -1,0 +1,123 @@
+# Agent Delegation Protocol
+
+Status: canonical operating protocol / 2026-05-07 / Issue #1568
+
+This project now runs development with exactly two human-operated instances:
+
+- Claude Code #1 (Windows app): planning, architecture, research, product judgment, UX triage, WBS design, review boundaries, and wrap-up.
+- Codex #1 (Windows app): scoped implementation, CI, GitHub PRs, Edge Functions, workflows, branch cleanup, and deterministic verification.
+
+Historical lanes such as PS#1-6, WEB, mobile, Gemini, Copilot, Codex #2, and ad-hoc sub-fleet labels are dormant mappings only. They must not be started as additional live instances unless the user explicitly reactivates them.
+
+## Routing Rule
+
+Work WBS items from the nearest due date first.
+
+Local tool check on 2026-05-07:
+
+- `claude --version`: `2.1.126 (Claude Code)`
+- `claude mcp serve --help`: available; do not leave a long-running MCP server open unless a task explicitly needs it.
+- `codex --version`: `codex-cli 0.128.0`
+
+Use this decision gate before changing files:
+
+| Question | If yes | If no |
+| --- | --- | --- |
+| Does the task need product judgment, architecture, or a trade-off decision? | Claude Code owns the decision note. | Continue. |
+| Does it change shared rules, memory, WBS policy, or cross-instance process? | Claude Code owns the spec and review boundary. | Continue. |
+| Is it implementation, CI, GitHub Actions, Edge Function, SQL, or deterministic UI repair? | Codex owns the PR. | Continue. |
+| Does it touch payments, security, permissions, production data, or user-visible irreversible behavior? | Claude Code approves before Codex ships. | Continue. |
+| Is the task obsolete under the two-instance flow? | Close or supersede the Issue with a comment. | Implement normally. |
+
+## Delegation Packet
+
+Every delegated task must include this packet. If any field is unknown, write `TBD` and assign the owner of that decision.
+
+```markdown
+## Delegation Packet
+
+- WBS / Issue:
+- Due date:
+- Current owner: Claude Code #1 / Codex #1 / User / Automation
+- Objective:
+- Branch:
+- Worktree:
+- Allowed write set:
+- Prohibited write set:
+- Required validation:
+- Expected output:
+- Risk triggers that must return to Claude Code:
+- Memory/disk hygiene action for this session:
+
+## Result Contract
+
+- Changed files:
+- Validation result:
+- PR / Issue links:
+- Remaining risk:
+- Next owner:
+```
+
+## Write Boundary
+
+Use narrow ownership. One task may be split across both instances only when their write sets are disjoint.
+
+| Area | Owner | Notes |
+| --- | --- | --- |
+| Architecture, decision records, WBS policy | Claude Code #1 | Codex may edit only from an explicit packet. |
+| Flutter UI implementation and tests | Codex #1 | Claude Code provides UX intent or acceptance criteria when needed. |
+| Supabase Edge Functions and SQL | Codex #1 | Escalate schema-risk or production-data decisions. |
+| GitHub Actions, CI, deploy repair | Codex #1 | Claude Code reviews policy changes. |
+| Memory, NotebookLM, wrap-up records | Claude Code #1 | Codex may add handoff notes and issue comments. |
+| Branch/worktree cleanup | Codex #1 | Never delete an unmerged or dirty worktree without evidence. |
+
+## Intake, Review, And Discard
+
+When Codex returns a PR or branch:
+
+1. Confirm the Issue/WBS id and due date match the packet.
+2. Confirm changed files are inside the allowed write set.
+3. Confirm the validation commands actually ran, or that CI passed equivalent checks.
+4. Confirm unresolved risks are explicit.
+5. Merge only after checks are green or after the user explicitly accepts the residual risk.
+6. Delete merged branches and prune stale worktree metadata.
+
+Discard instead of merge when:
+
+- The branch edits prohibited files.
+- The branch includes unrelated cleanup or formatting churn.
+- The implementation duplicates a feature already merged.
+- The Issue has become obsolete under the current two-instance flow.
+- The validation result is missing and CI does not cover the changed surface.
+
+## Session Hygiene Gate
+
+Every session must perform a cheap resource check before wrap-up:
+
+```powershell
+Get-PSDrive C
+Get-Process | Sort-Object WorkingSet64 -Descending | Select-Object -First 12 ProcessName,Id,@{Name='MB';Expression={[math]::Round($_.WorkingSet64/1MB,1)}}
+git worktree prune
+git gc --auto
+```
+
+Safe cleanup candidates:
+
+- Stop orphaned `dart`, `flutter`, `node`, `git`, or `deno` processes that are not serving the active task.
+- Delete local branches only after the matching PR is merged or the Issue is explicitly closed as obsolete.
+- Remove missing-worktree metadata with `git worktree prune`.
+- Prefer docs-only or CI-only verification when local Flutter tooling is hanging and GitHub Actions already covers the surface.
+
+Never clean:
+
+- Active user documents.
+- Dirty worktrees without a recorded handoff.
+- OneDrive folders that may still be syncing user data.
+- Browser/Obsidian sessions the user is actively inspecting.
+
+## Acceptance Mapping For Issue #1568
+
+- Conflict-free decomposition: enforced by the `Allowed write set` and `Prohibited write set` fields.
+- Result completeness: enforced by the `Result Contract`.
+- High-risk routing: enforced by the routing gate and risk triggers.
+- Two-instance constraint: canonical roles reduce live human agents to Claude Code #1 and Codex #1.

--- a/docs/WBS_2_INSTANCE_ROUTING.md
+++ b/docs/WBS_2_INSTANCE_ROUTING.md
@@ -1,6 +1,8 @@
 # WBS 2-Instance Routing
 
-Last updated: 2026-05-05
+Last updated: 2026-05-07
+
+Canonical delegation protocol: [`docs/AGENT_DELEGATION_PROTOCOL.md`](./AGENT_DELEGATION_PROTOCOL.md).
 
 The WBS screen keeps historical `instance` and `owner_instance` values intact, but the active operating view is now projected into two human-operated development lanes:
 
@@ -22,4 +24,6 @@ WBS execution policy:
 2. If a task is obsolete because of the 2-instance Windows app flow, close or supersede the GitHub issue instead of implementing the old lane literally.
 3. For Codex-owned implementation tasks, ship a narrow PR and record cross-instance handoff notes.
 4. For Claude Code-owned design tasks, create the spec or decision note first, then hand implementation to Codex only when code changes are clear.
+5. Every handoff must include Issue/WBS id, branch, worktree, allowed write set, prohibited write set, validation command, unresolved risk, and the next owner.
+6. Every session must include a cheap memory/disk hygiene check before wrap-up.
 

--- a/docs/cross-instance-prs/20260507_issue1568_2_instance_delegation_protocol.md
+++ b/docs/cross-instance-prs/20260507_issue1568_2_instance_delegation_protocol.md
@@ -1,0 +1,48 @@
+# Issue #1568: 2-Instance Delegation Protocol
+
+## Triage
+
+- WBS / Issue: #1568
+- Due date shown in WBS: 2026-05-17
+- Priority order: nearest active task after closing stale CI Issue #2079
+- Current owner: Claude Code #1 for architecture, Codex #1 for docs PR and GitHub hygiene
+- Decision: implement the delegation protocol as a docs-only PR because the task is about routing, packet shape, review, and discard rules.
+
+## Delegation Packet
+
+- Branch: `codex/wbs-1568-delegation-protocol-20260507`
+- Worktree: `C:\Users\kanta\GitHub\my_web_app\.claude\worktrees\focused-darwin-bcd64f`
+- Allowed write set:
+  - `docs/AGENT_DELEGATION_PROTOCOL.md`
+  - `docs/WBS_2_INSTANCE_ROUTING.md`
+  - `AGENTS.md`
+  - `docs/cross-instance-prs/20260507_issue1568_2_instance_delegation_protocol.md`
+- Prohibited write set:
+  - Application runtime code
+  - Supabase migrations or Edge Functions
+  - WBS database data
+  - User local Obsidian vault files
+- Required validation:
+  - `git diff --check`
+  - GitHub Actions on PR
+- Expected output:
+  - Canonical two-instance routing rule
+  - Delegation packet template
+  - Review/intake/discard checklist
+  - Per-session memory/disk hygiene gate
+
+## Result Contract
+
+- Changed files: recorded in the PR.
+- Validation result:
+  - `claude --version` -> `2.1.126 (Claude Code)`
+  - `claude mcp serve --help` -> command is available; no long-running server was started.
+  - `codex --version` -> `codex-cli 0.128.0`
+  - docs-only local `git diff --check`, plus CI.
+- Session hygiene:
+  - C: free space snapshot -> `85.56 GB`
+  - Ran `git worktree prune`
+  - Ran `git gc --auto`
+  - Stopped stale `dart.exe` PID `44536`; a new `dart.exe` was respawned by active tooling, so no further forced cleanup was applied.
+- Remaining risk: none for runtime behavior; local Flutter tooling is not required for docs-only changes.
+- Next owner: Codex #1 to merge PR and close #1568 after green checks.


### PR DESCRIPTION
## Summary
- Add the canonical two-instance Agent Delegation Protocol for WBS work.
- Update WBS routing and Codex operating guidance to remove active Codex #2/legacy lane assumptions.
- Record the #1568 delegation packet, validation, and session hygiene results.

## Minimal E2E Gate

- [x] Implementation-detail independent: this docs-only change has no app runtime behavior; any future E2E must check user-visible input/output, not private internals.
- [x] Minimal scope: if app behavior later changes from this protocol, the minimal E2E plan is about 3 cases only: happy path, error path, and recovery/empty state.
- [x] E2E mechanism: use Flutter `integration_test/` or Playwright `test/e2e/` for implementation PRs that apply this protocol.
- [x] E2E-Exception: docs-only protocol update; manual verification is `git diff --check` plus GitHub Actions.

## Validation
- `claude --version` -> 2.1.126 (Claude Code)
- `claude mcp serve --help` -> command available; no long-running server started
- `codex --version` -> codex-cli 0.128.0
- `git diff --check`
- Session hygiene: C: free 85.56 GB, `git worktree prune`, `git gc --auto`, stopped stale dart PID 44536; active tooling respawned dart so no further forced cleanup

Closes #1568