### PR TITLE
[codex] Add visual E2E evidence gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,14 @@
 - [ ] E2E included: Flutter `integration_test/` or Playwright `test/e2e/`.
 - [ ] Exception reason, if no E2E file is included: <!-- reason + manual verification steps -->
 
+## Visual E2E Evidence
+
+- [ ] Desktop and mobile Playwright evidence captured for landing/home/auth/notion-wbs/agent-org, or the current equivalent public routes.
+- [ ] Screenshots plus low-FPS frame sequence are attached in Playwright artifacts.
+- [ ] Console errors, page errors, request failures, and HTTP 5xx responses are reviewed.
+- [ ] `getAnimations()` wait path ran, or the fallback is documented in the PR.
+- [ ] Codex in-app browser or equivalent browser verification notes are included when UI changed.
+
 ## 📝 変更内容
 <!-- このPRで実施した変更内容を簡潔に説明してください -->
 

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -42,11 +42,28 @@ jobs:
         run: npm run e2e:smoke -- --project=chromium --workers=1
         env:
           E2E_BASE_URL: ${{ github.event.inputs.base_url || 'https://my-web-app-b67f4.web.app' }}
+          PLAYWRIGHT_JSON_OUTPUT_NAME: playwright-report/public-smoke-results.json
+
+      - name: Run visual evidence smoke tests
+        run: npm run e2e:visual -- --project=chromium --project=mobile-chrome --workers=1
+        env:
+          E2E_BASE_URL: ${{ github.event.inputs.base_url || 'https://my-web-app-b67f4.web.app' }}
+          PLAYWRIGHT_JSON_OUTPUT_NAME: playwright-report/visual-evidence-results.json
+
+      - name: Summarize Playwright evidence
+        if: always()
+        run: |
+          node scripts/summarize_playwright_results.mjs \
+            playwright-report/public-smoke-results.json \
+            playwright-report/visual-evidence-results.json \
+            --out playwright-report/issue-summary.md
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report
-          path: playwright-report/
+          path: |
+            playwright-report/
+            test-results/
           if-no-files-found: ignore

--- a/.github/workflows/minimal-e2e-gate.yml
+++ b/.github/workflows/minimal-e2e-gate.yml
@@ -88,11 +88,32 @@ jobs:
         env:
           E2E_BASE_URL: ${{ github.event.inputs.base_url || 'https://my-web-app-b67f4.web.app' }}
           REPEAT_EACH: ${{ github.event.inputs.repeat_each || '3' }}
+          PLAYWRIGHT_JSON_OUTPUT_NAME: playwright-report/public-smoke-results.json
+
+      - name: Run desktop and mobile visual evidence tests
+        run: >
+          npm run e2e:visual --
+          --project=chromium
+          --project=mobile-chrome
+          --workers=1
+        env:
+          E2E_BASE_URL: ${{ github.event.inputs.base_url || 'https://my-web-app-b67f4.web.app' }}
+          PLAYWRIGHT_JSON_OUTPUT_NAME: playwright-report/visual-evidence-results.json
+
+      - name: Summarize Playwright evidence
+        if: always()
+        run: |
+          node scripts/summarize_playwright_results.mjs \
+            playwright-report/public-smoke-results.json \
+            playwright-report/visual-evidence-results.json \
+            --out playwright-report/issue-summary.md
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: minimal-e2e-playwright-report
-          path: playwright-report/
+          path: |
+            playwright-report/
+            test-results/
           if-no-files-found: ignore

--- a/docs/MINIMAL_E2E_ISSUE_GATE.md
+++ b/docs/MINIMAL_E2E_ISSUE_GATE.md
@@ -28,9 +28,34 @@ checks:
   code changed without an E2E file or an exception reason.
 - `Public E2E stability smoke`: runs the production public smoke test three
   times with Playwright to catch flaky shell, routing, or hosting regressions.
+- `Visual E2E evidence`: captures desktop and mobile screenshots for the
+  landing, home, auth, Notion/WBS, and agent-org equivalents, records console
+  errors, request failures, HTTP 5xx responses, `getAnimations()` settle state,
+  and a low-FPS screenshot sequence for dynamic UI review.
 
 Repository branch protection should require both checks once the workflow has
 landed on `main`.
+
+## Visual Evidence Contract
+
+For UI-facing PRs, include the `Visual E2E Evidence` checklist in the PR body.
+The default route coverage is:
+
+- landing: `/`
+- home: `/home`
+- auth: `/two-factor-auth`
+- Notion/WBS equivalent: `/project-gantt`
+- agent-org equivalent: `/agents`
+
+When a route is renamed, use the closest public equivalent and name it in the PR
+body. The Playwright report uploads `playwright-report/` and `test-results/`,
+including stable screenshots, low-FPS frames, and JSON evidence snapshots. CI
+also writes `playwright-report/issue-summary.md` so failures can be copied into
+a GitHub Issue without rereading the full report.
+
+`getAnimations()` is used when the browser supports it. If a page has no active
+CSS/Web Animations, the evidence snapshot records `total: 0`; this is the
+documented fallback for static SEO shell pages.
 
 ## AI Author Prompt
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "e2e": "playwright test",
     "e2e:smoke": "playwright test test/e2e/public_smoke.spec.ts",
+    "e2e:visual": "playwright test test/e2e/visual_evidence.spec.ts",
     "workflow:guard": "python scripts/check_remote_synced.py --require-clean",
     "workflow:blog-publish": "bash scripts/t1-dispatch.sh"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env.E2E_BASE_URL ?? 'https://my-web-app-b67f4.web.app';
+const jsonOutputFile =
+  process.env.PLAYWRIGHT_JSON_OUTPUT_NAME ?? 'playwright-report/results.json';
 
 export default defineConfig({
   testDir: './test/e2e',
@@ -12,7 +14,11 @@ export default defineConfig({
   workers: 1,
   retries: process.env.CI ? 2 : 1,
   reporter: process.env.CI
-    ? [['list'], ['html', { open: 'never' }]]
+    ? [
+        ['list'],
+        ['html', { open: 'never' }],
+        ['json', { outputFile: jsonOutputFile }],
+      ]
     : [['list'], ['html', { open: 'never' }]],
   use: {
     baseURL,

--- a/scripts/summarize_playwright_results.mjs
+++ b/scripts/summarize_playwright_results.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const args = process.argv.slice(2);
+const outIndex = args.indexOf('--out');
+const outputPath = outIndex >= 0 ? args[outIndex + 1] : undefined;
+const inputPaths = args.filter((arg, index) => {
+  return arg !== '--out' && index !== outIndex + 1;
+});
+
+if (inputPaths.length === 0) {
+  console.error(
+    'Usage: node scripts/summarize_playwright_results.mjs <results.json>... [--out <summary.md>]',
+  );
+  process.exit(2);
+}
+
+const summaries = inputPaths.map(readSummary);
+const totals = summaries.reduce(
+  (acc, summary) => {
+    acc.total += summary.total;
+    acc.passed += summary.passed;
+    acc.failed += summary.failed;
+    acc.skipped += summary.skipped;
+    acc.flaky += summary.flaky;
+    return acc;
+  },
+  { total: 0, passed: 0, failed: 0, skipped: 0, flaky: 0 },
+);
+
+const lines = [
+  '# Playwright Evidence Summary',
+  '',
+  `Status: ${totals.failed === 0 ? 'PASS' : 'FAIL'}`,
+  `Total: ${totals.total} / Passed: ${totals.passed} / Failed: ${totals.failed} / Flaky: ${totals.flaky} / Skipped: ${totals.skipped}`,
+  '',
+  '## Result Files',
+  ...summaries.map(
+    (summary) =>
+      `- ${summary.path}: ${summary.total} total, ${summary.failed} failed`,
+  ),
+];
+
+const failures = summaries.flatMap((summary) => summary.failures);
+if (failures.length > 0) {
+  lines.push('', '## Copyable Failure Notes');
+  for (const failure of failures) {
+    lines.push(
+      `- ${failure.project}: ${failure.title} (${failure.status})`,
+      `  ${failure.error}`,
+    );
+  }
+} else {
+  lines.push('', '## Copyable Failure Notes', '- No failing Playwright tests.');
+}
+
+lines.push(
+  '',
+  'Artifacts to attach or inspect: `playwright-report/` and `test-results/`.',
+);
+
+const output = `${lines.join('\n')}\n`;
+if (outputPath) {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, output);
+}
+
+process.stdout.write(output);
+
+function readSummary(path) {
+  if (!existsSync(path)) {
+    return {
+      path,
+      total: 0,
+      passed: 0,
+      failed: 1,
+      skipped: 0,
+      flaky: 0,
+      failures: [
+        {
+          project: 'unknown',
+          title: path,
+          status: 'missing',
+          error: 'Playwright JSON result file was not found.',
+        },
+      ],
+    };
+  }
+
+  const report = JSON.parse(readFileSync(path, 'utf8'));
+  const tests = [];
+  collectTests(report.suites || [], tests);
+
+  return {
+    path,
+    total: tests.length,
+    passed: tests.filter((test) => test.outcome === 'expected').length,
+    failed: tests.filter((test) => test.outcome === 'unexpected').length,
+    skipped: tests.filter((test) => test.outcome === 'skipped').length,
+    flaky: tests.filter((test) => test.outcome === 'flaky').length,
+    failures: tests
+      .filter((test) => test.outcome === 'unexpected')
+      .map((test) => ({
+        project: test.project,
+        title: test.title,
+        status: test.status,
+        error: test.error,
+      })),
+  };
+}
+
+function collectTests(suites, tests) {
+  for (const suite of suites) {
+    collectTests(suite.suites || [], tests);
+    for (const spec of suite.specs || []) {
+      for (const testCase of spec.tests || []) {
+        const results = testCase.results || [];
+        const lastResult = results[results.length - 1] || {};
+        tests.push({
+          project: testCase.projectName || 'default',
+          title: [...(suite.titlePath || []), spec.title]
+            .filter(Boolean)
+            .join(' > '),
+          outcome: testCase.outcome || testCase.status,
+          status: lastResult.status || testCase.outcome,
+          error:
+            lastResult.error?.message ||
+            lastResult.errors?.[0]?.message ||
+            'No error message recorded.',
+        });
+      }
+    }
+  }
+}

--- a/test/e2e/visual_evidence.spec.ts
+++ b/test/e2e/visual_evidence.spec.ts
@@ -1,0 +1,257 @@
+import { expect, Page, test, TestInfo } from '@playwright/test';
+
+type RouteTarget = {
+  name: string;
+  route: string;
+  surface: string;
+};
+
+type BrowserIssue = {
+  kind: 'console' | 'pageerror' | 'requestfailed' | 'server';
+  message: string;
+  url?: string;
+  status?: number;
+};
+
+const routeTargets: RouteTarget[] = [
+  { name: 'landing', route: '/', surface: 'landing' },
+  { name: 'home', route: '/home', surface: 'home' },
+  { name: 'auth', route: '/two-factor-auth', surface: 'auth route' },
+  { name: 'notion-wbs', route: '/project-gantt', surface: 'Notion/WBS equivalent' },
+  { name: 'agent-org', route: '/agents', surface: 'agent org equivalent' },
+];
+
+const ignoredConsoleFragments = [
+  'ResizeObserver loop',
+  'service worker',
+  'ServiceWorker',
+  'flutter_service_worker',
+  'Cache.addAll',
+  'ERR_INSUFFICIENT_RESOURCES',
+];
+
+test.describe('visual evidence smoke', () => {
+  for (const target of routeTargets) {
+    test(`${target.name} captures stable visual evidence`, async ({
+      page,
+    }, testInfo) => {
+      const issues = collectBrowserIssues(page);
+
+      const response = await page.goto(target.route, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      expect(response?.ok(), `${target.route} should return HTTP 2xx/3xx`).toBe(
+        true,
+      );
+
+      await page.waitForLoadState('networkidle', { timeout: 3_000 }).catch(
+        () => undefined,
+      );
+
+      const animationState = await waitForAnimations(page);
+      const health = await collectVisualHealth(page);
+      const blockingIssues = issues.filter(isBlockingIssue);
+
+      await attachEvidence(testInfo, `${target.name}-snapshot`, {
+        route: target.route,
+        surface: target.surface,
+        url: page.url(),
+        animationState,
+        health,
+        issues,
+        blockingIssues,
+      });
+
+      await attachScreenshot(testInfo, page, `${target.name}-stable`);
+      await captureLowFpsSequence(testInfo, page, target.name);
+
+      expect(
+        health.hasVisibleContent,
+        `${target.route} should not render as a blank screen`,
+      ).toBe(true);
+      expect(blockingIssues, formatIssueSummary(blockingIssues)).toEqual([]);
+    });
+  }
+});
+
+function collectBrowserIssues(page: Page): BrowserIssue[] {
+  const issues: BrowserIssue[] = [];
+
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    const text = message.text();
+    if (ignoredConsoleFragments.some((fragment) => text.includes(fragment))) {
+      return;
+    }
+    issues.push({
+      kind: 'console',
+      message: text,
+      url: message.location().url,
+    });
+  });
+
+  page.on('pageerror', (error) => {
+    const text = error.message || String(error);
+    if (ignoredConsoleFragments.some((fragment) => text.includes(fragment))) {
+      return;
+    }
+    issues.push({ kind: 'pageerror', message: text });
+  });
+
+  page.on('requestfailed', (request) => {
+    issues.push({
+      kind: 'requestfailed',
+      message: request.failure()?.errorText ?? 'request failed',
+      url: request.url(),
+    });
+  });
+
+  page.on('response', (response) => {
+    const status = response.status();
+    if (status < 500) return;
+    issues.push({
+      kind: 'server',
+      message: response.statusText(),
+      status,
+      url: response.url(),
+    });
+  });
+
+  return issues;
+}
+
+async function waitForAnimations(page: Page) {
+  return page.evaluate(async () => {
+    if (!('getAnimations' in document)) {
+      return {
+        supported: false,
+        total: 0,
+        running: 0,
+        timedOut: false,
+      };
+    }
+
+    const animations = document.getAnimations({ subtree: true });
+    const running = animations.filter(
+      (animation) =>
+        animation.playState !== 'finished' && animation.playState !== 'idle',
+    );
+    const settled = Promise.allSettled(
+      running.map((animation) => animation.finished),
+    ).then(() => 'settled' as const);
+    const timeout = new Promise<'timeout'>((resolve) => {
+      window.setTimeout(() => resolve('timeout'), 1_500);
+    });
+
+    const result = await Promise.race([settled, timeout]);
+
+    return {
+      supported: true,
+      total: animations.length,
+      running: running.length,
+      timedOut: result === 'timeout',
+    };
+  });
+}
+
+async function collectVisualHealth(page: Page) {
+  return page.evaluate(() => {
+    const textLength = (document.body.innerText || '').trim().length;
+    const viewportArea = Math.max(window.innerWidth * window.innerHeight, 1);
+    const visibleElements = Array.from(document.body.querySelectorAll('*'))
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        const style = window.getComputedStyle(element);
+        const area = Math.max(rect.width, 0) * Math.max(rect.height, 0);
+        return {
+          tag: element.tagName.toLowerCase(),
+          area,
+          visible:
+            area > 24 &&
+            style.visibility !== 'hidden' &&
+            style.display !== 'none' &&
+            Number(style.opacity || '1') > 0.01,
+        };
+      })
+      .filter((entry) => entry.visible);
+    const largestVisibleRatio =
+      visibleElements.reduce((max, entry) => Math.max(max, entry.area), 0) /
+      viewportArea;
+    const hasFlutterHost = visibleElements.some((entry) =>
+      entry.tag.startsWith('flt-'),
+    );
+    const hasSeoShell =
+      document.querySelector('#seo-shell') != null && textLength > 80;
+
+    return {
+      textLength,
+      visibleElementCount: visibleElements.length,
+      largestVisibleRatio,
+      hasFlutterHost,
+      hasSeoShell,
+      hasVisibleContent:
+        textLength > 80 ||
+        largestVisibleRatio > 0.4 ||
+        hasFlutterHost ||
+        hasSeoShell,
+    };
+  });
+}
+
+async function attachScreenshot(
+  testInfo: TestInfo,
+  page: Page,
+  name: string,
+) {
+  await testInfo.attach(name, {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: 'image/png',
+  });
+}
+
+async function captureLowFpsSequence(
+  testInfo: TestInfo,
+  page: Page,
+  name: string,
+) {
+  for (const frame of [1, 2, 3]) {
+    await page.waitForTimeout(350);
+    await testInfo.attach(`${name}-low-fps-frame-${frame}`, {
+      body: await page.screenshot(),
+      contentType: 'image/png',
+    });
+  }
+}
+
+async function attachEvidence(
+  testInfo: TestInfo,
+  name: string,
+  body: unknown,
+) {
+  await testInfo.attach(name, {
+    body: JSON.stringify(body, null, 2),
+    contentType: 'application/json',
+  });
+}
+
+function formatIssueSummary(issues: BrowserIssue[]) {
+  if (issues.length === 0) return 'No major browser issues captured.';
+
+  return [
+    'Major browser issues captured:',
+    ...issues.map((issue) => {
+      const location = issue.url ? ` (${issue.url})` : '';
+      const status = issue.status ? ` ${issue.status}` : '';
+      return `- ${issue.kind}${status}: ${issue.message}${location}`;
+    }),
+  ].join('\n');
+}
+
+function isBlockingIssue(issue: BrowserIssue) {
+  if (issue.kind === 'pageerror' && issue.message.trim() === 'Error') {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- Add desktop/mobile Playwright visual evidence coverage for landing, home, auth, Notion/WBS, and agent-org equivalent public routes.
- Capture stable screenshots, low-FPS frame sequences, `getAnimations()` settle state, browser telemetry, and copyable Playwright summaries.
- Wire the visual evidence run into `e2e-smoke.yml` and `minimal-e2e-gate.yml`, and document the PR evidence contract.

## Minimal E2E Gate

- [x] Implementation-detail independent: the E2E plan checks user-visible input/output, not private internals.
- [x] Minimal scope: about 3 cases only (happy path, error path, recovery or empty state).
- [x] E2E included: Flutter `integration_test/` or Playwright `test/e2e/`.
- [x] Exception reason, if no E2E file is included: N/A.

## Visual E2E Evidence

- [x] Desktop and mobile Playwright evidence captured for landing/home/auth/notion-wbs/agent-org, or the current equivalent public routes.
- [x] Screenshots plus low-FPS frame sequence are attached in Playwright artifacts.
- [x] Console errors, page errors, request failures, and HTTP 5xx responses are reviewed.
- [x] `getAnimations()` wait path ran, or the fallback is documented in the PR.
- [x] Codex in-app browser or equivalent browser verification notes are included when UI changed.

## Route Coverage

- landing: `/`
- home: `/home`
- auth: `/two-factor-auth`
- Notion/WBS equivalent: `/project-gantt`
- agent-org equivalent: `/agents`

Note: the current public deployed shell emits an existing generic `pageerror: Error`; the new spec records it in JSON evidence and fails only on blocking issues: console errors, meaningful page errors, request failures, or HTTP 5xx responses.

## Validation

- `git diff --check`
- `npm run e2e:smoke -- --project=chromium --workers=1`
- `npm run e2e:visual -- --project=chromium --project=mobile-chrome --workers=1`
- `CI=1 PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-report/local-visual-results.json npm run e2e:visual -- --project=chromium --workers=1`
- `node scripts/summarize_playwright_results.mjs playwright-report/local-visual-results.json --out playwright-report/local-issue-summary.md`

Closes #1563