### PR TITLE
[infra] Add docs rotate automation (#1984 axis E)

### DIFF
--- a/.github/workflows/docs-rotate-cron.yml
+++ b/.github/workflows/docs-rotate-cron.yml
@@ -1,0 +1,165 @@
+name: docs-rotate-monthly
+
+on:
+  schedule:
+    - cron: "0 18 1 * *" # monthly at 18:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: docs-rotate-monthly
+  cancel-in-progress: false
+
+jobs:
+  rotate:
+    name: Rotate aged schedule docs
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    env:
+      ISSUE_NUMBER: "1984"
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Dry-run docs rotate
+        shell: pwsh
+        run: |
+          python scripts/docs_rotate.py `
+            --json-out docs-rotate-dry-run.json
+
+      - name: Apply docs rotate
+        shell: pwsh
+        run: |
+          python scripts/docs_rotate.py `
+            --apply `
+            --json-out docs-rotate-apply.json
+
+      - name: Upload rotate reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: docs-rotate-report
+          path: |
+            docs-rotate-dry-run.json
+            docs-rotate-apply.json
+          if-no-files-found: ignore
+
+      - name: Create rotate PR
+        id: pr
+        shell: pwsh
+        run: |
+          $summary = Get-Content -Raw -LiteralPath docs-rotate-apply.json | ConvertFrom-Json
+          if ([int]$summary.moved -eq 0) {
+            "created=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "url=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            exit 0
+          }
+
+          $branch = "automation/docs-rotate-$env:GITHUB_RUN_ID"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b $branch
+          foreach ($path in @("docs/cs-notes", "docs/daily-reports", "docs/auto-blog", "docs/_archive")) {
+            if (Test-Path $path) {
+              git add $path
+            }
+          }
+          if (-not (git diff --cached --name-only)) {
+            "created=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "url=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            exit 0
+          }
+          git commit -m "docs: rotate aged schedule outputs"
+          git push -u origin $branch
+
+          $body = @"
+          ## Summary
+          - Rotate schedule-output docs older than $($summary.age_days) days into `$($summary.archive_root)`.
+          - Source buckets: `$($summary.targets -join "`, `")`.
+
+          ## Rotation Report
+          | metric | value |
+          | --- | --- |
+          | files scanned | $($summary.files_scanned) |
+          | candidates | $($summary.candidates) |
+          | moved | $($summary.moved) |
+          | moved MB | $($summary.moved_mb) |
+          | workflow run | $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID |
+
+          Refs #1984 axis E.
+          "@
+
+          Set-Content -LiteralPath docs-rotate-pr.md -Value $body -Encoding utf8
+          $url = gh pr create `
+            --repo $env:GITHUB_REPOSITORY `
+            --base main `
+            --head $branch `
+            --title "[infra] Rotate aged schedule docs (#1984 axis E)" `
+            --body-file docs-rotate-pr.md
+          "created=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "url=$url" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Comment monthly report to Issue
+        if: always()
+        shell: pwsh
+        run: |
+          $summaryPath = "docs-rotate-apply.json"
+          if (-not (Test-Path $summaryPath)) {
+            $summaryPath = "docs-rotate-dry-run.json"
+          }
+
+          if (Test-Path $summaryPath) {
+            $summary = Get-Content -Raw -LiteralPath $summaryPath | ConvertFrom-Json
+            $mode = $summary.mode
+            $scanned = $summary.files_scanned
+            $candidates = $summary.candidates
+            $moved = $summary.moved
+            $failed = $summary.failed
+            $movedMb = $summary.moved_mb
+          } else {
+            $mode = "failed-before-summary"
+            $scanned = "n/a"
+            $candidates = "n/a"
+            $moved = "n/a"
+            $failed = "n/a"
+            $movedMb = "n/a"
+          }
+
+          $prUrl = "${{ steps.pr.outputs.url }}"
+          if (-not $prUrl) {
+            $prUrl = "none"
+          }
+
+          $body = @"
+          ## docs-rotate-monthly
+
+          | metric | value |
+          | --- | --- |
+          | mode | $mode |
+          | files scanned | $scanned |
+          | candidates | $candidates |
+          | moved | $moved |
+          | failed | $failed |
+          | moved MB | $movedMb |
+          | PR | $prUrl |
+          | run | $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID |
+
+          This keeps active schedule-output folders small by moving aged files into `docs/_archive` through a reviewable PR when there are changes.
+          "@
+
+          Set-Content -LiteralPath docs-rotate-comment.md -Value $body -Encoding utf8
+          gh issue comment $env:ISSUE_NUMBER --repo $env:GITHUB_REPOSITORY --body-file docs-rotate-comment.md

--- a/docs/DISK_HYGIENE_RUNBOOK.md
+++ b/docs/DISK_HYGIENE_RUNBOOK.md
@@ -196,6 +196,15 @@ python scripts/worktree_cleanup.py --json-out tmp/worktree-cleanup.json
 - NotebookLM cache: known cache/log/temp directory の child のみ、default 7 日超で prune。`storage_state.json` / cookie/token 系は protected。
 - `.github/workflows/dev-cache-cleanup-cron.yml`: hosted Windows runner で dry-run -> safe apply -> artifact upload -> Issue #1984 comment。GHA は local C: を直接 reclaim できないため、Windows app session / local scheduled task でも同 script を使う。
 
+### 3.9 Docs rotate automation (= Issue #1984 axis E / Codex #1)
+
+`scripts/docs_rotate.py` は schedule-output docs の active folder を小さく保つための portable/CI 版。default は dry-run で、実 move は `--apply` 明示時のみ。
+
+- 対象: `docs/cs-notes`, `docs/daily-reports`, `docs/auto-blog`。
+- retention: filename 内の `YYYY-MM-DD` を使って 90 日超を判定。CI checkout では mtime が更新されるため、mtime は使わない。
+- archive: `docs/_archive/<YYYY-MM>/<source>/filename` へ move。上書きはせず、既存 destination があれば skip。
+- `.github/workflows/docs-rotate-cron.yml`: monthly dry-run -> apply -> artifact upload -> Issue #1984 comment。変更がある場合だけ `automation/docs-rotate-<run_id>` branch と reviewable PR を作る。
+
 ## 4. 監視 KPI
 
 毎セッション自動記録 (= `~/.claude/logs/disk-cleanup-YYYYMMDD.log`):
@@ -344,10 +353,10 @@ HDD 圧迫と並行して **RAM 圧迫** も Win 開発環境の継続課題. pa
 | B | 動画ファイル削減 | n/a | #1724 待ち |
 | C | Cache 清掃 (= Flutter / npm / pip / notebooklm) | Win Codex | **✅ 着地** (= `scripts/dev_cache_cleanup.py` + weekly workflow / local apply required for C:) |
 | D | **Memory cleanup** | **Win Claude** | **✅ 着地 part 155-b** (= memory-cleanup.ps1 / 5 step / 閾値 gating) |
-| E | docs rotate (= cs-notes / daily-reports 90 日 archive) | Win Codex | **未着** |
+| E | docs rotate (= cs-notes / daily-reports 90 日 archive) | Win Codex | **✅ 着地** (= `scripts/docs_rotate.py` + monthly PR workflow) |
 | F | transcript ローテーション | (= disk-cleanup step 5 で 30 日 gzip 化済 part 154-a) | ✅ |
 
-= 6 axis 中 D ✅ (= 本 part 着地) + F ✅ + C 部分着地 + A/B/E 残.
+= 6 axis 中 A/C/D/E/F ✅。B は #1724 secrets blocker 解消後に動画削減 PR。
 
 ## 11. 関連 docs / files (= memory 拡張版)
 

--- a/docs/cross-instance-prs/20260505_codex_memory_hdd_reduction_axis_a_b_c_e.md
+++ b/docs/cross-instance-prs/20260505_codex_memory_hdd_reduction_axis_a_b_c_e.md
@@ -106,7 +106,10 @@ on:
   - Codex #1 implementation: dependency-free `scripts/dev_cache_cleanup.py` with dry-run default, explicit `--apply`, clean-worktree guard for `flutter clean`, npm/pnpm/pub/pip cache commands, and age-gated NotebookLM cache pruning.
   - Weekly workflow: `.github/workflows/dev-cache-cleanup-cron.yml` runs dry-run -> safe apply on the hosted Windows runner, uploads JSON reports, and comments the summary to Issue #1984.
   - Note: GitHub Actions validates the path and cleans only its ephemeral runner. Local C: drive reclaim still requires a Windows app session or local scheduled task invoking the same script.
-- [ ] axis E: `scripts/docs_rotate.py` + `docs-rotate-cron.yml` で 90 日 archive 自動化
+- [x] axis E: `scripts/docs_rotate.py` + `docs-rotate-cron.yml` で 90 日 archive 自動化
+  - Codex #1 implementation: dependency-free `scripts/docs_rotate.py` with dry-run default, explicit `--apply`, filename-date retention, and archive moves into `docs/_archive/<YYYY-MM>/<source>/`.
+  - Monthly workflow: `.github/workflows/docs-rotate-cron.yml` runs dry-run -> apply on the hosted Windows runner, uploads JSON reports, comments the summary to Issue #1984, and opens a reviewable PR only when files moved.
+  - Validation note: current tracked `docs/cs-notes` / `docs/daily-reports` files are younger than 90 days, so the normal dry-run has 0 candidates; future-date validation proves the selector path without moving files.
 
 ## 関連 docs
 

--- a/scripts/docs_rotate.py
+++ b/scripts/docs_rotate.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Archive aged schedule-output docs for Issue #1984 axis E.
+
+The default mode is a dry-run report. Use --apply to move files whose filename
+contains a date older than the retention window. Filename dates are used instead
+of filesystem mtimes because CI checkouts refresh mtimes on every run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_TARGETS = (
+    "docs/cs-notes",
+    "docs/daily-reports",
+    "docs/auto-blog",
+)
+DEFAULT_ARCHIVE_ROOT = "docs/_archive"
+DATE_RE = re.compile(r"(20\d{2}-\d{2}-\d{2})")
+
+
+@dataclass
+class RotationCandidate:
+    source: str
+    destination: str
+    source_bucket: str
+    archive_month: str
+    file_date: str
+    age_days: int
+    size_bytes: int
+    status: str
+    reason: str
+    moved: bool = False
+
+
+def git_root(cwd: Path) -> Path:
+    current = cwd.resolve(strict=False)
+    for path in (current, *current.parents):
+        if (path / ".git").exists():
+            return path
+    raise RuntimeError(f"not inside a git worktree: {cwd}")
+
+
+def norm_path(path: Path) -> str:
+    return os.path.normcase(str(path.resolve(strict=False)))
+
+
+def same_or_child(child: Path, parent: Path) -> bool:
+    child_s = norm_path(child)
+    parent_s = norm_path(parent)
+    return child_s == parent_s or child_s.startswith(parent_s + os.sep)
+
+
+def parse_iso_date(value: str) -> date:
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def file_date_from_name(path: Path) -> date | None:
+    match = DATE_RE.search(path.name)
+    if not match:
+        return None
+    try:
+        return parse_iso_date(match.group(1))
+    except ValueError:
+        return None
+
+
+def relative_posix(root: Path, path: Path) -> str:
+    return path.resolve(strict=False).relative_to(root.resolve(strict=False)).as_posix()
+
+
+def archive_destination(root: Path, archive_root: Path, source_dir: Path, source: Path) -> Path:
+    file_date = file_date_from_name(source)
+    if file_date is None:
+        raise ValueError(f"source filename does not contain a date: {source}")
+    month = file_date.strftime("%Y-%m")
+    bucket = source_dir.name
+    return archive_root / month / bucket / source.name
+
+
+def iter_target_files(root: Path, targets: list[str]) -> list[tuple[Path, Path]]:
+    files: list[tuple[Path, Path]] = []
+    for target in targets:
+        target_dir = (root / target).resolve(strict=False)
+        if not target_dir.exists() or not target_dir.is_dir():
+            continue
+        if not same_or_child(target_dir, root):
+            continue
+        for path in sorted(target_dir.iterdir(), key=lambda item: item.name):
+            if not path.is_file():
+                continue
+            if path.name == ".gitkeep":
+                continue
+            files.append((target_dir, path))
+    return files
+
+
+def collect_candidates(
+    *,
+    root: Path,
+    targets: list[str],
+    archive_root: Path,
+    today: date,
+    age_days: int,
+) -> tuple[list[RotationCandidate], dict[str, int], int]:
+    candidates: list[RotationCandidate] = []
+    skipped: dict[str, int] = {}
+    scanned = 0
+
+    def count_skip(reason: str) -> None:
+        skipped[reason] = skipped.get(reason, 0) + 1
+
+    archive_root = archive_root.resolve(strict=False)
+    for source_dir, source in iter_target_files(root, targets):
+        scanned += 1
+        file_date = file_date_from_name(source)
+        if file_date is None:
+            count_skip("filename has no YYYY-MM-DD date")
+            continue
+        age = (today - file_date).days
+        if age < age_days:
+            count_skip(f"younger than {age_days} days")
+            continue
+        destination = archive_destination(root, archive_root, source_dir, source)
+        if destination.exists():
+            count_skip("archive destination already exists")
+            continue
+        try:
+            size_bytes = source.stat().st_size
+        except OSError:
+            count_skip("source stat failed")
+            continue
+        candidates.append(
+            RotationCandidate(
+                source=relative_posix(root, source),
+                destination=relative_posix(root, destination),
+                source_bucket=source_dir.name,
+                archive_month=file_date.strftime("%Y-%m"),
+                file_date=file_date.isoformat(),
+                age_days=age,
+                size_bytes=size_bytes,
+                status="planned",
+                reason="dry-run; pass --apply to move",
+            )
+        )
+    return candidates, skipped, scanned
+
+
+def move_candidates(root: Path, candidates: list[RotationCandidate]) -> None:
+    for candidate in candidates:
+        source = root / candidate.source
+        destination = root / candidate.destination
+        try:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(source), str(destination))
+        except OSError as exc:
+            candidate.status = "failed"
+            candidate.reason = str(exc)
+            candidate.moved = False
+            continue
+        candidate.status = "success"
+        candidate.reason = "moved to archive"
+        candidate.moved = True
+
+
+def size_mb(value: int) -> float:
+    return round(value / (1024 * 1024), 3)
+
+
+def summary_payload(
+    *,
+    root: Path,
+    archive_root: Path,
+    targets: list[str],
+    today: date,
+    age_days: int,
+    apply: bool,
+    scanned: int,
+    skipped: dict[str, int],
+    candidates: list[RotationCandidate],
+) -> dict[str, Any]:
+    moved = [item for item in candidates if item.moved]
+    failed = [item for item in candidates if item.status == "failed"]
+    total_bytes = sum(item.size_bytes for item in candidates)
+    moved_bytes = sum(item.size_bytes for item in moved)
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "mode": "apply" if apply else "dry-run",
+        "root": str(root),
+        "archive_root": relative_posix(root, archive_root),
+        "targets": targets,
+        "today": today.isoformat(),
+        "age_days": age_days,
+        "files_scanned": scanned,
+        "candidates": len(candidates),
+        "moved": len(moved),
+        "failed": len(failed),
+        "candidate_bytes": total_bytes,
+        "candidate_mb": size_mb(total_bytes),
+        "moved_bytes": moved_bytes,
+        "moved_mb": size_mb(moved_bytes),
+        "skipped": skipped,
+        "items": [asdict(item) for item in candidates],
+    }
+
+
+def print_report(payload: dict[str, Any]) -> None:
+    print("")
+    print("=== Docs Rotate Report ===")
+    print(f"mode: {payload['mode']}")
+    print(f"today: {payload['today']}")
+    print(f"age_days: {payload['age_days']}")
+    print(f"archive_root: {payload['archive_root']}")
+    print("")
+    print(f"files scanned: {payload['files_scanned']}")
+    print(f"candidates:    {payload['candidates']}")
+    print(f"moved:         {payload['moved']}")
+    print(f"failed:        {payload['failed']}")
+    print(f"candidate MB:  {payload['candidate_mb']}")
+    print(f"moved MB:      {payload['moved_mb']}")
+    if payload["skipped"]:
+        print("")
+        print("Skipped:")
+        for reason, count in sorted(payload["skipped"].items()):
+            print(f"- {reason}: {count}")
+    if payload["items"]:
+        print("")
+        print("Candidates:")
+        for item in payload["items"][:40]:
+            print(f"- {item['source']} -> {item['destination']} ({item['status']})")
+        if len(payload["items"]) > 40:
+            print(f"- ... {len(payload['items']) - 40} more")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="Repository/worktree root.")
+    parser.add_argument("--age-days", type=int, default=90, help="Minimum file age in days.")
+    parser.add_argument("--archive-root", default=DEFAULT_ARCHIVE_ROOT)
+    parser.add_argument(
+        "--target",
+        action="append",
+        default=None,
+        help="Target directory relative to repo root. Repeatable.",
+    )
+    parser.add_argument("--today", help="Override today's date as YYYY-MM-DD for validation.")
+    parser.add_argument("--apply", action="store_true", help="Move candidates into the archive.")
+    parser.add_argument("--json", action="store_true", help="Print the machine-readable summary.")
+    parser.add_argument("--json-out", type=Path, help="Write the machine-readable summary.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    root = git_root(args.root)
+    today = parse_iso_date(args.today) if args.today else date.today()
+    targets = args.target or list(DEFAULT_TARGETS)
+    archive_root = (root / args.archive_root).resolve(strict=False)
+    if not same_or_child(archive_root, root):
+        raise RuntimeError(f"archive root must stay inside repo: {archive_root}")
+
+    candidates, skipped, scanned = collect_candidates(
+        root=root,
+        targets=targets,
+        archive_root=archive_root,
+        today=today,
+        age_days=args.age_days,
+    )
+    if args.apply:
+        move_candidates(root, candidates)
+
+    payload = summary_payload(
+        root=root,
+        archive_root=archive_root,
+        targets=targets,
+        today=today,
+        age_days=args.age_days,
+        apply=args.apply,
+        scanned=scanned,
+        skipped=skipped,
+        candidates=candidates,
+    )
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print_report(payload)
+    return 1 if payload["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- Add dependency-free `scripts/docs_rotate.py` for #1984 axis E with dry-run default, explicit `--apply`, filename-date retention, and JSON summaries.
- Add `.github/workflows/docs-rotate-cron.yml` to run monthly dry-run -> apply, upload reports, comment to Issue #1984, and open a reviewable PR only when aged docs moved.
- Update the disk hygiene runbook and cross-instance handoff so axis E is marked complete; axis B remains blocked by #1724.

## Validation
- `python -m py_compile scripts\\docs_rotate.py`
- `python scripts\\docs_rotate.py --json`
- `python scripts\\docs_rotate.py --today 2026-08-10 --json`
- `python scripts\\docs_rotate.py --apply --json` (current repo no-op, 0 candidates moved)
- temp repo smoke: `--apply` moved one 2026-01 cs-note into `docs/_archive/2026-01/cs-notes/` and kept one 2026-05 note active
- `git diff --check`

## Minimal E2E Gate
- Implementation-detail independent / black-box contract: validate the docs-rotate CLI and workflow from inputs, filesystem outputs, and JSON summaries, not internal implementation choices.
- Minimal three I/O cases: current-date dry-run scans tracked active docs and reports 0 candidates; future-date dry-run reports all dated files as planned archive moves without moving them; temp repo apply moves only the aged file and keeps the young file in place.
- E2E-Exception: this PR changes scripts, docs, and GitHub Actions workflow only; it does not change app code or user-facing UI, so Playwright or Flutter integration_test coverage is not required.

Refs #1984 axis E. Axis B remains blocked by #1724.