### PR TITLE
docs(roadmap): part 171 — 100 part milestone / STOP signal 第 2 / monitor-only

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -28439,3 +28439,45 @@ User 要望「できる限り手動の作業をなくしていきたい」直接
 4. WSL VHDX 圧縮 + Docker prune (= hygiene 5 軸目候補)
 
 **99 part 連続 dogfood** (= part 75 → part 170 / 2 month +).
+
+## Win版#132 part 171 (Win Claude / 2026-05-07 / 100 part 連続 dogfood / monitor-only / STOP-2)
+
+### 着地サマリ
+
+[COMPACTION-RESUME] respect 継続 / STOP signal 第 2 認識:
+
+1. **Codex 7 hand-off PR query 0 件継続** — meal_log / ai_tool_watch / launcher_icons / privacy / dormant grace / wbs.list_tasks / hand-off-monitor 全 0 PR / 14-18 日 buffer 状態継続。
+2. **5/14 trigger date NOT yet 確認** — 今日 5/7 = ai_tool_watch hand-off 起票当日 (= 0 day mark) / 残 14 日。**5/14 = 残 7 日 trigger** に到達していない / 早 ping は spam risk のため skip。
+3. **100 part 連続 dogfood milestone 達成** — part 75 → 171 で 100 part 連続。Win Claude 自進化 cycle 1 stage milestone。
+
+### Pattern catalog 追加
+
+- **「5/14 trigger date premature ping skip」pattern 第 1 例** — user 要望「fresh start」と「trigger date」の不一致時は **trigger date 厳守** で premature ping 回避 / [SCHEDULE-WAKEUP] respect / Codex spam 防止
+- **「100 part 連続 dogfood milestone」pattern 第 1 例** — part 75 起点 / 2 month + 連続 / Win Claude 自進化 cycle infrastructure 成熟期 entry signal
+
+### Commits (= 本 part)
+
+- (本 commit hash 未確定 / ROADMAP append のみ minimal)
+
+### Philosophy Alignment
+
+- **PHILOSOPHY-22 9/9 ✅** (= mentor / 自己 限界認識 + trigger date discipline)
+- **VIBE-30 7/7 ✅** ([NO-SCOPE-CREEP] / premature ping skip dogfood)
+- **INDIE-29 7/7 ✅** (shipping 速度: monitor-only minimal で sustainability 維持)
+
+### 🛑 STOP signal 第 2 認識
+
+- part 162-171 = **10 part 連続 session**
+- Codex 7 hand-off ship 全完了
+- Phase 1→2 dogfood 累積 9 例 milestone
+- 100 part 連続 dogfood milestone 達成
+- **次 session = 5/14 trigger date 待ち or 別日 fresh start 強く推奨** (= 同日 8+ part = 詰込過多 / [COMPACTION-RESUME] 違反 risk 上昇)
+
+### 次回 candidate (= part 172 / 5/14 待ち推奨)
+
+1. **5/14 (= 1 week from today / part 163 期限残 7 日 trigger date)** で ai_tool_watch SOURCES Codex ping
+2. dormant grace + wbs.list_tasks + hand-off-monitor (= 1 week 経過) も併せて ping
+3. Codex 7 hand-off PR 一括 query
+4. WSL VHDX 圧縮 + Docker prune (= hygiene 5 軸目候補)
+
+**100 part 連続 dogfood** (= part 75 → part 171 / 2 month + / **milestone**).


### PR DESCRIPTION
## Summary

100 part 連続 dogfood milestone 達成 + STOP signal 第 2 認識.

- Codex 7 hand-off PR 0 件継続 (= 14-18 日 buffer)
- 5/14 trigger NOT yet (= 今日 5/7 = 0 day mark / premature ping skip)
- 「5/14 trigger date premature ping skip」pattern 第 1 例
- 「100 part 連続 dogfood milestone」pattern 第 1 例

🛑 次 session は 5/14 trigger date 待ち or 別日 fresh start 強く推奨.

100 part 連続 dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)