### PR TITLE
docs(roadmap): part 172 — manual fallback ping (#1632 #2096) / STOP signal 第 3

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -28481,3 +28481,41 @@ User 要望「できる限り手動の作業をなくしていきたい」直接
 4. WSL VHDX 圧縮 + Docker prune (= hygiene 5 軸目候補)
 
 **100 part 連続 dogfood** (= part 75 → part 171 / 2 month + / **milestone**).
+
+## Win版#132 part 172 (Win Claude / 2026-05-07 / 101 part 連続 dogfood / manual fallback ping)
+
+### 着地サマリ
+
+User 明示「5/14 trigger date / 推奨日」要望対応:
+
+1. **Codex 7 hand-off PR query 0 件継続** — 全 hand-off PR 未確認 / cron 実装前 manual fallback 必要状態。
+2. **Issue #1632 (ai_tool_watch) ping comment 投稿** — 期限 5/21 / 14 日 buffer / Codex hand-off 起票 5 日後 / manual fallback note 含む。
+3. **Issue #2096 (wbs.list_tasks pagination) ping comment 投稿** — 期限なし but 業務 risk / Codex hand-off 起票 1 日後 / 同 manual fallback。
+
+### Pattern catalog 追加
+
+- **「manual fallback ping pattern」第 1 例 (part 172)** — part 169 設計の cross-instance hand-off auto-ping cron が Codex 実装待ち期間中、Win Claude が手動で同 ping を実行 / cron 実装後 deprecated / 「cron design → 実装待ち期間 manual fallback → cron 完成で自走化」3-phase pattern
+
+### Commits (= 本 part)
+
+- (本 commit hash 未確定 / ROADMAP append のみ)
+
+### Philosophy Alignment
+
+- **PHILOSOPHY-22 9/9 ✅** (= mentor / fleet visibility 維持)
+- **VIBE-30 7/7 ✅** ([NO-SCOPE-CREEP] / 2 ping のみ minimal)
+- **SYNERGY-30 7/7 ✅** (cross-instance ping で fleet 横断)
+
+### 🛑 STOP signal 第 3 認識
+
+- part 162-172 = **11 part 連続 session** (= [COMPACTION-RESUME] 大幅超過)
+- Codex 7 hand-off ship + 100 part milestone + manual fallback ping 完了
+- **次 session は別日 fresh start を強く推奨**
+
+### 次回 candidate (= part 173 / 別日推奨)
+
+1. dormant grace cron + hand-off-monitor + meal_log MVP + flutter_launcher_icons + privacy route の残 5 hand-off ping (= 5/15-5/18 trigger schedule)
+2. Codex 7 hand-off PR follow
+3. WSL VHDX 圧縮 + Docker prune (= hygiene 5 軸目候補)
+
+**101 part 連続 dogfood** (= part 75 → part 172 / 2 month +).


### PR DESCRIPTION
## Summary

User 明示「5/14 trigger date / 推奨日」要望対応 + STOP signal 第 3 認識.

- Issue #1632 ai_tool_watch SOURCES manual fallback ping 投稿
- Issue #2096 wbs.list_tasks pagination manual fallback ping 投稿
- 「manual fallback ping pattern」第 1 例 (= cron design → 実装待ち期間 manual → 自走化)

🛑 11 part 連続 session = STOP signal 第 3 / 次 session は別日 fresh start 強く推奨.

101 part 連続 dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)