### PR TITLE
fix(ef): paginate wbs.list_tasks beyond 1000 rows (#2096)

### DIFF
--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -5739,17 +5739,27 @@ serve(async (req) => {
           const status = body.status as string | undefined;
           const updatedSince = body.updated_since as string | undefined;
           const limit = Math.min(Number(body.limit ?? 50), 200);
-          let q = admin.from("wbs_tasks")
-            .select(
-              "id, category, category_icon, category_order, title, description, instance, owner_instance, status, progress, start_date, end_date, planned_start_date, planned_end_date, milestone_code, priority, remaining_work, updated_at, github_issue_number, github_issue_url, github_issue_state, github_issue_labels, github_issue_synced_at",
-            );
-          if (status) q = q.eq("status", status);
-          if (updatedSince) q = q.gte("updated_at", updatedSince);
-          const { data, error } = await q;
-          if (error) throw new Error(error.message);
-          const filteredTasks = [...(data ?? [])].filter((task) =>
+          const taskSelect =
+            "id, category, category_icon, category_order, title, description, instance, owner_instance, status, progress, start_date, end_date, planned_start_date, planned_end_date, milestone_code, priority, remaining_work, updated_at, github_issue_number, github_issue_url, github_issue_state, github_issue_labels, github_issue_synced_at";
+          const pageSize = 1000;
+          const allTasks: Array<Record<string, unknown>> = [];
+          for (let offset = 0; ; offset += pageSize) {
+            let q = admin.from("wbs_tasks").select(taskSelect);
+            if (status) q = q.eq("status", status);
+            if (updatedSince) q = q.gte("updated_at", updatedSince);
+            const { data, error } = await q
+              .order("id", { ascending: true })
+              .range(offset, offset + pageSize - 1);
+            if (error) throw new Error(error.message);
+            const rows = (data ?? []) as unknown as Array<
+              Record<string, unknown>
+            >;
+            allTasks.push(...rows);
+            if (rows.length < pageSize) break;
+          }
+          const filteredTasks = allTasks.filter((task) =>
             wbsTaskMatchesInstanceFilter(
-              task as Record<string, unknown>,
+              task,
               inst ?? "all",
             )
           );


### PR DESCRIPTION
## Summary
- Paginate `wbs.list_tasks` with `.range()` so Supabase's default 1000-row select cap no longer truncates `/project-gantt` task counts.
- Keep the existing response shape and client-side `limit` slicing while making `total` reflect the full filtered task set.
- Use stable `id` ordering during page fetch, then preserve the existing `compareWbsTasks` display ordering.

## Validation
- `deno check --node-modules-dir=auto supabase/functions/tools-hub/index.ts`
- `deno lint supabase/functions/tools-hub/index.ts`
- `git diff --check`

## Notes
- `deno fmt supabase/functions/tools-hub/index.ts` currently fails with Deno formatter instability on this large existing file: `Formatting not stable. Bailed after 5 tries.` The edited block was manually kept in local style and passes `deno check` / `deno lint`.
- Production 1000+ row EF smoke should be run after deploy with service credentials; this PR removes the known code-level 1000-row cap.

## Minimal E2E Gate
E2E-Exception: scoped Edge Function data-fetch fix only; no Flutter route or visual UI surface changed in this PR.

Implementation-detail independent black-box validation plan: after deploy, call `tools-hub` `wbs.list_tasks` through the same public action contract used by `/project-gantt` and verify input/output behavior rather than internals.

Minimal 3 cases:
1. default request returns `tasks.length <= 50` and `total` equals the full filtered WBS count, including rows beyond 1000.
2. `status` and `updated_since` filters still affect both `tasks` and `total` before the final `limit` slice.
3. `instance` filtering still uses the existing response shape consumed by `/project-gantt`.

E2E mechanism: no Playwright file is added because this is an EF-only response-count fix; the deploy smoke is an HTTP black-box action call against `tools-hub`.

Fixes #2096