### PR TITLE
[codex] #772 RAG Knowledge Graph Phase 1

### DIFF
--- a/.github/workflows/kg-indexer-nightly.yml
+++ b/.github/workflows/kg-indexer-nightly.yml
@@ -1,0 +1,116 @@
+name: Knowledge Graph Indexer Nightly
+
+on:
+  schedule:
+    - cron: "30 19 * * *" # 04:30 JST
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Upsert records into Supabase when secrets are present"
+        required: false
+        default: "true"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  index:
+    name: Build Knowledge Graph source records
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve apply mode
+        id: mode
+        shell: bash
+        run: |
+          APPLY_INPUT="${{ inputs.apply }}"
+          if [ -z "$APPLY_INPUT" ]; then
+            APPLY_INPUT="true"
+          fi
+          if [ "$APPLY_INPUT" = "true" ] && [ -n "$SUPABASE_URL" ] && [ -n "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+            echo "args=--apply" >> "$GITHUB_OUTPUT"
+            echo "apply=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "args=" >> "$GITHUB_OUTPUT"
+            echo "apply=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run indexers
+        shell: bash
+        run: |
+          mkdir -p tmp/kg-indexer
+          python scripts/kg_index_github_issues.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --limit 200 \
+            --output tmp/kg-indexer/github-issues.jsonl \
+            ${{ steps.mode.outputs.args }}
+          python scripts/kg_index_wbs_tasks.py \
+            --limit 200 \
+            --output tmp/kg-indexer/wbs.jsonl \
+            ${{ steps.mode.outputs.args }}
+          python scripts/kg_index_docs.py \
+            --limit 500 \
+            --output tmp/kg-indexer/docs.jsonl \
+            ${{ steps.mode.outputs.args }}
+          python scripts/kg_index_memory_vault.py \
+            --limit 200 \
+            --output tmp/kg-indexer/memory.jsonl \
+            ${{ steps.mode.outputs.args }}
+          python scripts/kg_index_notebooklm_intake.py \
+            --limit 200 \
+            --output tmp/kg-indexer/notebooklm.jsonl \
+            ${{ steps.mode.outputs.args }}
+
+      - name: Upload indexer artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kg-indexer-records
+          path: tmp/kg-indexer/
+          if-no-files-found: warn
+
+      - name: Open or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: "[Schedule監視] kg-indexer-nightly failure"
+        shell: bash
+        run: |
+          BODY="$(mktemp)"
+          {
+            echo "Knowledge Graph nightly indexer failed."
+            echo ""
+            echo "- Workflow: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Apply mode: ${{ steps.mode.outputs.apply }}"
+            echo "- Commit: $GITHUB_SHA"
+          } > "$BODY"
+          EXISTING="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "$ISSUE_TITLE in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body-file "$BODY"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$ISSUE_TITLE" --body-file "$BODY" --label bug --label automation --label priority:high
+          fi
+
+      - name: Job Summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Knowledge Graph Indexer"
+            echo ""
+            echo "| Item | Value |"
+            echo "|---|---|"
+            echo "| Apply | ${{ steps.mode.outputs.apply }} |"
+            echo "| Artifact | kg-indexer-records |"
+            echo ""
+            find tmp/kg-indexer -maxdepth 1 -type f -name '*.jsonl' -print0 2>/dev/null | while IFS= read -r -d '' file; do
+              echo "- $(basename "$file"): $(wc -l < "$file") records"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/kg-indexer-nightly.yml
+++ b/.github/workflows/kg-indexer-nightly.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload indexer artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kg-indexer-records
           path: tmp/kg-indexer/

--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -129,6 +129,7 @@ import '../pages/form_builder_page.dart';
 import '../pages/gift_registry_page.dart';
 import '../pages/growth_automation_controller_page.dart';
 import '../pages/knowledge_base_page.dart';
+import '../pages/knowledge_graph_page.dart';
 import '../pages/landing_ab_test_page.dart';
 import '../pages/loyalty_points_page.dart';
 import '../pages/meeting_manager_page.dart';
@@ -1854,6 +1855,23 @@ List<HomeToolEntry> buildHomeToolCatalog({
         'ドキュメント',
       ],
       onOpen: (context) => _pushPage(context, const KnowledgeBasePage()),
+    ),
+    HomeToolEntry(
+      id: 'knowledge-graph',
+      sectionId: 'knowledge',
+      title: 'Knowledge Graph RAG',
+      subtitle: 'Issues, WBS, docs, memory, and NotebookLM with citations',
+      icon: Icons.hub_outlined,
+      color: const Color(0xFF0F766E),
+      keywords: const <String>[
+        'knowledge graph',
+        'rag',
+        'citations',
+        'issues',
+        'wbs',
+        'notebooklm',
+      ],
+      onOpen: (context) => _pushPage(context, const KnowledgeGraphPage()),
     ),
     HomeToolEntry(
       id: 'semantic-search',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -142,6 +142,7 @@ import 'package:my_web_app/pages/carbon_footprint_tracker_page.dart';
 import 'package:my_web_app/pages/donation_crowdfunding_page.dart';
 import 'package:my_web_app/pages/emergency_contacts_page.dart';
 import 'package:my_web_app/pages/knowledge_base_page.dart';
+import 'package:my_web_app/pages/knowledge_graph_page.dart';
 import 'package:my_web_app/pages/meeting_manager_page.dart';
 import 'package:my_web_app/pages/news_rss_aggregator_page.dart';
 import 'package:my_web_app/pages/semantic_search_page.dart';
@@ -1728,6 +1729,11 @@ class _MyAppState extends State<MyApp> {
           case '/memory-search':
             return MaterialPageRoute(
               builder: (_) => const MemorySearchHubPage(),
+            );
+          case '/knowledge-graph':
+            return MaterialPageRoute(
+              builder: (_) => const KnowledgeGraphPage(),
+              settings: const RouteSettings(name: '/knowledge-graph'),
             );
           default:
             if (uri.path.startsWith('/vs-')) {

--- a/lib/pages/knowledge_graph_page.dart
+++ b/lib/pages/knowledge_graph_page.dart
@@ -1,0 +1,321 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class KnowledgeGraphPage extends StatefulWidget {
+  const KnowledgeGraphPage({super.key});
+
+  @override
+  State<KnowledgeGraphPage> createState() => _KnowledgeGraphPageState();
+}
+
+class _KnowledgeGraphPageState extends State<KnowledgeGraphPage> {
+  static const _sourceOptions = <String>[
+    'issues',
+    'wbs',
+    'docs',
+    'memory',
+    'notebooklm',
+  ];
+
+  final _queryController = TextEditingController();
+  final _selectedSources = <String>{..._sourceOptions};
+  bool _loading = false;
+  bool _useLlm = true;
+  String? _error;
+  String? _answer;
+  String? _status;
+  String? _traceId;
+  List<Map<String, dynamic>> _citations = [];
+
+  Future<void> _query() async {
+    final query = _queryController.text.trim();
+    if (query.isEmpty || _selectedSources.isEmpty) return;
+    setState(() {
+      _loading = true;
+      _error = null;
+      _answer = null;
+      _status = null;
+      _traceId = null;
+      _citations = [];
+    });
+
+    try {
+      final userId = Supabase.instance.client.auth.currentUser?.id;
+      final response = await Supabase.instance.client.functions.invoke(
+        'memory-search-hub',
+        body: {
+          'action': 'memory.rag.query',
+          'query': query,
+          'top_k': 8,
+          'sources': _selectedSources.toList()..sort(),
+          'use_llm': _useLlm,
+          if (userId != null) 'user_id': userId,
+        },
+      );
+      final data = response.data as Map<String, dynamic>? ?? {};
+      final citations = (data['citations'] as List? ?? [])
+          .whereType<Map>()
+          .map((item) => item.cast<String, dynamic>())
+          .toList();
+      if (!mounted) return;
+      setState(() {
+        _answer = data['answer'] as String?;
+        _status = data['answer_status'] as String?;
+        _traceId = data['trace_id'] as String?;
+        _citations = citations;
+      });
+    } catch (error) {
+      if (mounted) setState(() => _error = error.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _openCitation(String? rawUrl) async {
+    if (rawUrl == null || rawUrl.isEmpty || !rawUrl.startsWith('http')) return;
+    final uri = Uri.tryParse(rawUrl);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Color _statusColor(String? status) {
+    switch (status) {
+      case 'ok':
+        return const Color(0xFF0F766E);
+      case 'stale_index':
+        return const Color(0xFFB45309);
+      case 'llm_failure':
+        return const Color(0xFF9F1239);
+      case 'no_results':
+        return const Color(0xFF52525B);
+      default:
+        return const Color(0xFF334155);
+    }
+  }
+
+  @override
+  void dispose() {
+    _queryController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final statusColor = _statusColor(_status);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Knowledge Graph RAG'),
+        backgroundColor: const Color(0xFF0F766E),
+        foregroundColor: Colors.white,
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final source in _sourceOptions)
+                  FilterChip(
+                    label: Text(source),
+                    selected: _selectedSources.contains(source),
+                    onSelected: (selected) {
+                      setState(() {
+                        if (selected) {
+                          _selectedSources.add(source);
+                        } else {
+                          _selectedSources.remove(source);
+                        }
+                      });
+                    },
+                  ),
+                FilterChip(
+                  label: const Text('LLM'),
+                  selected: _useLlm,
+                  onSelected: (selected) => setState(() => _useLlm = selected),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _queryController,
+                    minLines: 2,
+                    maxLines: 4,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      hintText: 'Ask about the project',
+                      prefixIcon: Icon(Icons.hub_outlined),
+                    ),
+                    onSubmitted: (_) => _query(),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                SizedBox(
+                  height: 56,
+                  child: FilledButton.icon(
+                    onPressed: _loading ? null : _query,
+                    icon: _loading
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.search),
+                    label: const Text('Query'),
+                  ),
+                ),
+              ],
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 12),
+              Text(_error!, style: const TextStyle(color: Color(0xFFB91C1C))),
+            ],
+            if (_answer != null) ...[
+              const SizedBox(height: 18),
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  border: Border.all(color: const Color(0xFFE2E8F0)),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Chip(
+                          label: Text(_status ?? 'unknown'),
+                          backgroundColor: statusColor.withAlpha(28),
+                          labelStyle: TextStyle(
+                            color: statusColor,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        if (_traceId != null)
+                          Text(
+                            _traceId!,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: const Color(0xFF64748B),
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    SelectableText(
+                      _answer!,
+                      style: theme.textTheme.bodyLarge?.copyWith(height: 1.45),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+            if (_citations.isNotEmpty) ...[
+              const SizedBox(height: 18),
+              Text(
+                'Citations',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const SizedBox(height: 8),
+              for (var i = 0; i < _citations.length; i++)
+                _CitationTile(
+                  index: i + 1,
+                  citation: _citations[i],
+                  onOpen: _openCitation,
+                ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CitationTile extends StatelessWidget {
+  const _CitationTile({
+    required this.index,
+    required this.citation,
+    required this.onOpen,
+  });
+
+  final int index;
+  final Map<String, dynamic> citation;
+  final Future<void> Function(String? rawUrl) onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sourceUrl = citation['source_url'] as String?;
+    final confidence = citation['confidence'];
+    final confidenceText =
+        confidence is num ? '${(confidence * 100).round()}%' : 'n/a';
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: const BorderSide(color: Color(0xFFE2E8F0)),
+      ),
+      child: ListTile(
+        minVerticalPadding: 12,
+        leading: CircleAvatar(
+          backgroundColor: const Color(0xFFE0F2FE),
+          foregroundColor: const Color(0xFF0369A1),
+          child: Text('$index'),
+        ),
+        title: Text(
+          citation['title'] as String? ?? sourceUrl ?? 'Untitled',
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Padding(
+          padding: const EdgeInsets.only(top: 6),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                citation['excerpt'] as String? ?? '',
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                children: [
+                  Text('type: ${citation['source_type'] ?? 'unknown'}'),
+                  Text('confidence: $confidenceText'),
+                  Text('synced: ${citation['last_synced_at'] ?? 'unknown'}'),
+                ],
+              ),
+            ],
+          ),
+        ),
+        trailing: sourceUrl != null && sourceUrl.startsWith('http')
+            ? IconButton(
+                tooltip: 'Open source',
+                icon: const Icon(Icons.open_in_new),
+                onPressed: () => onOpen(sourceUrl),
+              )
+            : null,
+        titleTextStyle: theme.textTheme.titleSmall?.copyWith(
+          fontWeight: FontWeight.w700,
+          color: const Color(0xFF0F172A),
+        ),
+      ),
+    );
+  }
+}

--- a/scripts/kg_index_common.py
+++ b/scripts/kg_index_common.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Shared helpers for the Knowledge Graph Phase 1 indexers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import textwrap
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ALLOWED_SOURCE_TYPES = {"issue", "wbs", "doc", "memory", "notebooklm"}
+DEFAULT_OUTPUT_DIR = Path("tmp/kg-indexer")
+GITHUB_BLOB_BASE = "https://github.com/kanta13jp1/my_web_app/blob/main"
+
+PII_PATTERNS: dict[str, re.Pattern[str]] = {
+    "email": re.compile(r"[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}"),
+    "phone": re.compile(r"(?:\+\d{1,3}[-.\s]?\d{6,14}|0[789]0[-.\s]?\d{4}[-.\s]?\d{4}|0\d{1,4}[-.\s]\d{1,4}[-.\s]\d{4})"),
+    "my_number": re.compile(r"\b\d{12}\b"),
+    "ip_address": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+    "credit_card": re.compile(r"\b(?:\d[ -]?){13,19}\b"),
+}
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    source_type: str
+    source_id: str
+    title: str
+    content: str
+    source_url: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    last_synced_at: str = field(default_factory=lambda: now_iso())
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore").lstrip("\ufeff")
+
+
+def first_heading(text: str, fallback: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip() or fallback
+    return fallback
+
+
+def repo_relative(path: Path, root: Path) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def github_blob_url(relative_path: str) -> str:
+    return f"{GITHUB_BLOB_BASE}/{relative_path}"
+
+
+def content_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def excerpt(content: str, width: int = 280) -> str:
+    return textwrap.shorten(" ".join(content.split()), width=width, placeholder="...")
+
+
+def luhn_valid(value: str) -> bool:
+    digits = [int(ch) for ch in re.sub(r"\D", "", value)]
+    if len(digits) < 13:
+        return False
+    checksum = 0
+    parity = len(digits) % 2
+    for index, digit in enumerate(digits):
+        if index % 2 == parity:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        checksum += digit
+    return checksum % 10 == 0
+
+
+def detect_pii(text: str) -> list[str]:
+    categories: list[str] = []
+    for name, pattern in PII_PATTERNS.items():
+        matches = pattern.findall(text)
+        if not matches:
+            continue
+        if name == "credit_card" and not any(luhn_valid(match) for match in matches):
+            continue
+        categories.append(name)
+    return categories
+
+
+def record_payload(record: SourceRecord) -> dict[str, Any]:
+    if record.source_type not in ALLOWED_SOURCE_TYPES:
+        raise ValueError(f"unsupported source_type: {record.source_type}")
+    content = record.content.strip()
+    return {
+        "source_type": record.source_type,
+        "source_id": record.source_id,
+        "source_url": record.source_url,
+        "title": record.title.strip() or record.source_id,
+        "content": content,
+        "excerpt": excerpt(content),
+        "content_hash": content_hash(content),
+        "metadata": record.metadata,
+        "last_synced_at": record.last_synced_at,
+        "updated_at": now_iso(),
+    }
+
+
+def filter_payloads(
+    records: Iterable[SourceRecord],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    payloads: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for record in records:
+        categories = detect_pii("\n".join([record.title, record.content]))
+        if categories:
+            skipped.append(
+                {
+                    "source_type": record.source_type,
+                    "source_id": record.source_id,
+                    "source_url": record.source_url,
+                    "categories": categories,
+                    "skipped_at": now_iso(),
+                }
+            )
+            continue
+        payloads.append(record_payload(record))
+    return payloads, skipped
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True))
+            handle.write("\n")
+            count += 1
+    return count
+
+
+def upsert_supabase(
+    payloads: list[dict[str, Any]],
+    *,
+    supabase_url: str,
+    service_role_key: str,
+) -> int:
+    if not payloads:
+        return 0
+    endpoint = (
+        f"{supabase_url.rstrip('/')}/rest/v1/kg_embeddings"
+        "?on_conflict=source_type,source_id"
+    )
+    data = json.dumps(payloads).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint,
+        data=data,
+        method="POST",
+        headers={
+            "apikey": service_role_key,
+            "Authorization": f"Bearer {service_role_key}",
+            "Content-Type": "application/json",
+            "Prefer": "resolution=merge-duplicates",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        if response.status not in {200, 201, 204}:
+            raise RuntimeError(f"Supabase upsert failed: HTTP {response.status}")
+    return len(payloads)
+
+
+def add_common_args(
+    parser: argparse.ArgumentParser,
+    *,
+    default_output: str,
+) -> None:
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT_DIR / default_output))
+    parser.add_argument("--audit-log", default=str(DEFAULT_OUTPUT_DIR / "pii-skips.jsonl"))
+    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--supabase-url", default=os.environ.get("SUPABASE_URL", ""))
+    parser.add_argument(
+        "--service-role-key",
+        default=os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+        or os.environ.get("SERVICE_ROLE_KEY", ""),
+    )
+
+
+def finish(records: Iterable[SourceRecord], args: argparse.Namespace) -> dict[str, Any]:
+    payloads, skipped = filter_payloads(records)
+    written = write_jsonl(Path(args.output), payloads)
+    skipped_count = write_jsonl(Path(args.audit_log), skipped)
+    applied = 0
+    if args.apply:
+        if not args.supabase_url or not args.service_role_key:
+            raise SystemExit("--apply requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY")
+        applied = upsert_supabase(
+            payloads,
+            supabase_url=args.supabase_url,
+            service_role_key=args.service_role_key,
+        )
+    stats = {
+        "output": args.output,
+        "written": written,
+        "skipped_pii": skipped_count,
+        "applied": applied,
+    }
+    print(json.dumps(stats, ensure_ascii=False, sort_keys=True))
+    return stats

--- a/scripts/kg_index_docs.py
+++ b/scripts/kg_index_docs.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Build Knowledge Graph records from public docs markdown files."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from kg_index_common import (
+    SourceRecord,
+    add_common_args,
+    finish,
+    first_heading,
+    github_blob_url,
+    read_text,
+    repo_relative,
+)
+
+
+def build_records(root: Path, limit: int) -> list[SourceRecord]:
+    docs_root = root / "docs"
+    records: list[SourceRecord] = []
+    if not docs_root.exists():
+        return records
+    for path in sorted(docs_root.rglob("*.md")):
+        if len(records) >= limit:
+            break
+        relative = repo_relative(path, root)
+        parts = set(path.parts)
+        if ".git" in parts or "node_modules" in parts:
+            continue
+        text = read_text(path)
+        if not text.strip():
+            continue
+        records.append(
+            SourceRecord(
+                source_type="doc",
+                source_id=relative,
+                title=first_heading(text, path.stem),
+                content=text,
+                source_url=github_blob_url(relative),
+                metadata={"path": relative},
+            )
+        )
+    return records
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    add_common_args(parser, default_output="docs.jsonl")
+    args = parser.parse_args()
+    finish(build_records(Path(args.root), args.limit), args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kg_index_github_issues.py
+++ b/scripts/kg_index_github_issues.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Build Knowledge Graph records from GitHub Issues."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from kg_index_common import SourceRecord, add_common_args, finish, now_iso
+
+
+def run_gh(args: list[str]) -> Any:
+    completed = subprocess.run(
+        ["gh", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return json.loads(completed.stdout or "[]")
+
+
+def load_issue_list(repo: str, limit: int) -> list[dict[str, Any]]:
+    return run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,body,url,labels,updatedAt",
+        ]
+    )
+
+
+def with_comments(repo: str, issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    enriched: list[dict[str, Any]] = []
+    for issue in issues:
+        number = str(issue.get("number") or "")
+        if not number:
+            continue
+        detail = run_gh(
+            [
+                "issue",
+                "view",
+                number,
+                "--repo",
+                repo,
+                "--json",
+                "comments",
+            ]
+        )
+        issue = dict(issue)
+        issue["comments"] = detail.get("comments") or []
+        enriched.append(issue)
+    return enriched
+
+
+def issue_content(issue: dict[str, Any]) -> str:
+    labels = [
+        str(label.get("name"))
+        for label in issue.get("labels") or []
+        if isinstance(label, dict) and label.get("name")
+    ]
+    comments = []
+    for comment in issue.get("comments") or []:
+        if isinstance(comment, dict) and comment.get("body"):
+            comments.append(str(comment["body"]))
+    return "\n\n".join(
+        part
+        for part in [
+            f"#{issue.get('number')} {issue.get('title')}",
+            f"labels: {', '.join(labels)}" if labels else "",
+            str(issue.get("body") or ""),
+            "\n\n".join(comments),
+        ]
+        if part
+    )
+
+
+def build_records(
+    issues: list[dict[str, Any]],
+    *,
+    repo: str,
+) -> list[SourceRecord]:
+    records: list[SourceRecord] = []
+    for issue in issues:
+        number = issue.get("number")
+        if number is None:
+            continue
+        content = issue_content(issue)
+        if not content.strip():
+            continue
+        labels = [
+            str(label.get("name"))
+            for label in issue.get("labels") or []
+            if isinstance(label, dict) and label.get("name")
+        ]
+        records.append(
+            SourceRecord(
+                source_type="issue",
+                source_id=str(number),
+                title=str(issue.get("title") or f"Issue #{number}"),
+                content=content,
+                source_url=str(
+                    issue.get("url") or f"https://github.com/{repo}/issues/{number}"
+                ),
+                metadata={
+                    "repo": repo,
+                    "number": number,
+                    "labels": labels,
+                    "updated_at": issue.get("updatedAt"),
+                },
+                last_synced_at=str(issue.get("updatedAt") or now_iso()),
+            )
+        )
+    return records
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default="kanta13jp1/my_web_app")
+    parser.add_argument("--issues-json")
+    parser.add_argument("--include-comments", action="store_true")
+    add_common_args(parser, default_output="github-issues.jsonl")
+    args = parser.parse_args()
+
+    if args.issues_json:
+        issues = json.loads(Path(args.issues_json).read_text(encoding="utf-8"))
+    else:
+        issues = load_issue_list(args.repo, args.limit)
+        if args.include_comments:
+            issues = with_comments(args.repo, issues)
+    finish(build_records(issues, repo=args.repo), args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kg_index_memory_vault.py
+++ b/scripts/kg_index_memory_vault.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Build Knowledge Graph records from curated memory/vault notes."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from kg_index_common import (
+    SourceRecord,
+    add_common_args,
+    finish,
+    first_heading,
+    github_blob_url,
+    read_text,
+    repo_relative,
+)
+
+
+TEXT_EXTENSIONS = {".md", ".markdown", ".txt", ".json", ".jsonl"}
+
+
+def build_records(root: Path, limit: int) -> list[SourceRecord]:
+    vault = root / "memory" / "vault"
+    records: list[SourceRecord] = []
+    if not vault.exists():
+        return records
+    for path in sorted(vault.rglob("*")):
+        if len(records) >= limit:
+            break
+        if not path.is_file() or path.suffix.lower() not in TEXT_EXTENSIONS:
+            continue
+        text = read_text(path)
+        if not text.strip():
+            continue
+        relative = repo_relative(path, root)
+        records.append(
+            SourceRecord(
+                source_type="memory",
+                source_id=relative,
+                title=first_heading(text, path.stem),
+                content=text,
+                source_url=github_blob_url(relative),
+                metadata={"path": relative, "source": "memory-vault"},
+            )
+        )
+    return records
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    add_common_args(parser, default_output="memory.jsonl")
+    args = parser.parse_args()
+    finish(build_records(Path(args.root), args.limit), args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kg_index_notebooklm_intake.py
+++ b/scripts/kg_index_notebooklm_intake.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Build Knowledge Graph records from NotebookLM intake artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from kg_index_common import (
+    SourceRecord,
+    add_common_args,
+    finish,
+    first_heading,
+    github_blob_url,
+    read_text,
+    repo_relative,
+)
+
+
+NOTEBOOK_ID = "54b6f2f2-6831-4376-b2dd-99a1a4bf90ec"
+TEXT_EXTENSIONS = {".md", ".markdown", ".txt", ".json", ".jsonl"}
+
+
+def json_to_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for key in ("title", "summary", "body", "content", "text"):
+            item = value.get(key)
+            if isinstance(item, str):
+                parts.append(item)
+        if parts:
+            return "\n\n".join(parts)
+    if isinstance(value, list):
+        return "\n".join(json_to_text(item) for item in value)
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def read_artifact_text(path: Path) -> str:
+    if path.suffix.lower() == ".json":
+        return json_to_text(json.loads(read_text(path)))
+    if path.suffix.lower() == ".jsonl":
+        parts: list[str] = []
+        for line in read_text(path).splitlines():
+            if not line.strip():
+                continue
+            try:
+                parts.append(json_to_text(json.loads(line)))
+            except json.JSONDecodeError:
+                parts.append(line)
+        return "\n".join(parts)
+    return read_text(path)
+
+
+def build_records(root: Path, limit: int, notebook_id: str) -> list[SourceRecord]:
+    intake = root / "docs" / "notebooklm-intake"
+    records: list[SourceRecord] = []
+    if not intake.exists():
+        return records
+    for path in sorted(intake.rglob("*")):
+        if len(records) >= limit:
+            break
+        if not path.is_file() or path.suffix.lower() not in TEXT_EXTENSIONS:
+            continue
+        text = read_artifact_text(path)
+        if not text.strip():
+            continue
+        relative = repo_relative(path, root)
+        records.append(
+            SourceRecord(
+                source_type="notebooklm",
+                source_id=f"{notebook_id}:{relative}",
+                title=first_heading(text, path.stem),
+                content=text,
+                source_url=github_blob_url(relative),
+                metadata={
+                    "path": relative,
+                    "notebook_id": notebook_id,
+                    "source": "notebooklm-intake",
+                },
+            )
+        )
+    return records
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--notebook-id", default=NOTEBOOK_ID)
+    add_common_args(parser, default_output="notebooklm.jsonl")
+    args = parser.parse_args()
+    finish(build_records(Path(args.root), args.limit, args.notebook_id), args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kg_index_wbs_tasks.py
+++ b/scripts/kg_index_wbs_tasks.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Build Knowledge Graph records from WBS and cross-instance task docs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from kg_index_common import (
+    SourceRecord,
+    add_common_args,
+    finish,
+    first_heading,
+    github_blob_url,
+    read_text,
+    repo_relative,
+)
+
+
+WBS_GLOBS = [
+    "docs/WBS*.md",
+    "docs/BUSINESS_WBS*.md",
+    "docs/cross-instance-prs/*.md",
+]
+
+
+def build_records(root: Path, limit: int) -> list[SourceRecord]:
+    records: list[SourceRecord] = []
+    seen: set[Path] = set()
+    for pattern in WBS_GLOBS:
+        for path in sorted(root.glob(pattern)):
+            if len(records) >= limit:
+                return records
+            if path in seen or not path.is_file():
+                continue
+            seen.add(path)
+            text = read_text(path)
+            if not text.strip():
+                continue
+            relative = repo_relative(path, root)
+            records.append(
+                SourceRecord(
+                    source_type="wbs",
+                    source_id=relative,
+                    title=first_heading(text, path.stem),
+                    content=text,
+                    source_url=github_blob_url(relative),
+                    metadata={"path": relative, "source": "wbs-doc"},
+                )
+            )
+    return records
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    add_common_args(parser, default_output="wbs.jsonl")
+    args = parser.parse_args()
+    finish(build_records(Path(args.root), args.limit), args)
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/functions/memory-search-hub/index.ts
+++ b/supabase/functions/memory-search-hub/index.ts
@@ -16,13 +16,29 @@ import {
 } from "./search/bm25.ts";
 import { buildQueryRouteDecision } from "./query_report.ts";
 import { rerankWithHaiku } from "./search/rerank.ts";
-import { vectorSearch } from "./search/vector.ts";
+import { embedTextWithGemini, vectorSearch } from "./search/vector.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SERVICE_ROLE_KEY = Deno.env.get("SERVICE_ROLE_KEY") ??
   Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
 type Body = Record<string, unknown>;
+
+const KG_DEFAULT_SOURCE_TYPES = ["issue", "wbs", "doc", "memory", "notebooklm"];
+const KG_SOURCE_ALIASES: Record<string, string> = {
+  issue: "issue",
+  issues: "issue",
+  github: "issue",
+  github_issues: "issue",
+  wbs: "wbs",
+  doc: "doc",
+  docs: "doc",
+  documentation: "doc",
+  memory: "memory",
+  notebooklm: "notebooklm",
+  "notebooklm-intake": "notebooklm",
+};
+const KG_RATE_LIMIT_PER_MINUTE = 5;
 
 function adminClient() {
   return createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
@@ -44,6 +60,36 @@ function asStringArray(value: unknown, max = 20): string[] {
     .map((entry) => asString(entry))
     .filter(Boolean)
     .slice(0, max);
+}
+
+function normalizeKgSourceTypes(value: unknown): string[] {
+  const raw = Array.isArray(value) ? value : KG_DEFAULT_SOURCE_TYPES;
+  const normalized = raw
+    .map((entry) => KG_SOURCE_ALIASES[asString(entry).toLowerCase()])
+    .filter(Boolean);
+  const unique = Array.from(new Set(normalized));
+  return unique.length > 0 ? unique : KG_DEFAULT_SOURCE_TYPES;
+}
+
+function normalizeUuid(value: unknown): string | null {
+  const raw = asString(value);
+  if (
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      .test(raw)
+  ) {
+    return raw;
+  }
+  return null;
+}
+
+function clientKeyFor(ctx: McpAuthContext | null, userId: string | null): string {
+  return userId ?? ctx?.client_id ?? "anonymous";
+}
+
+function trimText(value: string, maxChars: number): string {
+  const compact = value.replace(/\s+/g, " ").trim();
+  if (compact.length <= maxChars) return compact;
+  return `${compact.slice(0, maxChars - 3)}...`;
 }
 
 async function authorize(req: Request): Promise<McpAuthContext | Response> {
@@ -90,6 +136,75 @@ async function loadRecentDocuments(limit = 1500): Promise<MemoryDocument[]> {
   return ((data ?? []) as Array<Record<string, unknown>>)
     .map(normalizeDoc)
     .filter((doc) => doc.file_path && doc.content);
+}
+
+function normalizeKgDoc(row: Record<string, unknown>): MemoryDocument {
+  const sourceType = String(row.source_type ?? "doc");
+  const sourceId = String(row.source_id ?? row.id ?? "");
+  const sourceUrl = String(row.source_url ?? "");
+  const metadata = row.metadata && typeof row.metadata === "object"
+    ? row.metadata as Record<string, unknown>
+    : {};
+  return {
+    file_path: `${sourceType}:${sourceId}`,
+    title: row.title == null ? null : String(row.title),
+    content: String(row.content ?? ""),
+    snippet: row.excerpt == null ? null : String(row.excerpt),
+    updated_at: row.last_synced_at == null ? null : String(row.last_synced_at),
+    metadata: {
+      ...metadata,
+      kg: true,
+      source_id: sourceId,
+      source_type: sourceType,
+      source_url: sourceUrl,
+      last_synced_at: row.last_synced_at == null
+        ? null
+        : String(row.last_synced_at),
+    },
+  };
+}
+
+async function loadRecentKgDocuments(
+  sourceTypes: string[],
+  limit = 2000,
+): Promise<MemoryDocument[]> {
+  const { data, error } = await adminClient()
+    .from("kg_embeddings")
+    .select(
+      "source_id,source_type,source_url,title,content,excerpt,metadata,last_synced_at",
+    )
+    .in("source_type", sourceTypes)
+    .order("last_synced_at", { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return ((data ?? []) as Array<Record<string, unknown>>)
+    .map(normalizeKgDoc)
+    .filter((doc) => doc.file_path && doc.content);
+}
+
+async function kgVectorSearch(
+  client: ReturnType<typeof adminClient>,
+  query: string,
+  sourceTypes: string[],
+  limit = 20,
+): Promise<ScoredMemoryDocument[]> {
+  const apiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
+  if (!apiKey) return [];
+  const embedding = await embedTextWithGemini(query, apiKey);
+  const { data, error } = await client.rpc("match_kg_embeddings", {
+    query_embedding: embedding,
+    match_count: limit,
+    match_threshold: 0.5,
+    source_filter: sourceTypes,
+  });
+  if (error) throw error;
+  return ((data ?? []) as Array<Record<string, unknown>>)
+    .map((row) => ({
+      ...normalizeKgDoc(row),
+      score: Number(row.score ?? 0),
+      match_reason: "vector",
+    }))
+    .filter((doc) => doc.file_path && doc.content && doc.score > 0);
 }
 
 async function loadDocumentsByPath(paths: string[]): Promise<MemoryDocument[]> {
@@ -182,6 +297,255 @@ async function memorySearch(body: Body) {
       vector_candidates: vector.length,
     },
     results: results.map(toResult),
+  });
+}
+
+function citationFor(doc: ScoredMemoryDocument, maxScore: number) {
+  const metadata = doc.metadata ?? {};
+  const sourceType = String(metadata.source_type ?? "memory");
+  const sourceUrl = String(metadata.source_url ?? doc.file_path);
+  const confidence = maxScore <= 0 ? 0 : doc.score / maxScore;
+  return {
+    source_type: sourceType,
+    source_url: sourceUrl,
+    title: doc.title ?? doc.file_path,
+    excerpt: trimText(doc.snippet ?? doc.content, 280),
+    confidence: Number(Math.max(0, Math.min(1, confidence)).toFixed(4)),
+    last_synced_at: doc.updated_at ?? metadata.last_synced_at ?? null,
+  };
+}
+
+function citationsAreStale(
+  citations: Array<Record<string, unknown>>,
+): boolean {
+  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+  return citations.some((citation) => {
+    const raw = asString(citation["last_synced_at"]);
+    if (!raw) return true;
+    const timestamp = new Date(raw).getTime();
+    return Number.isFinite(timestamp) && timestamp < cutoff;
+  });
+}
+
+function extractiveAnswer(
+  query: string,
+  citations: Array<Record<string, unknown>>,
+): string {
+  if (citations.length === 0) {
+    return "No matching project artifacts were found for this query.";
+  }
+  const lines = citations.slice(0, 3).map((citation, index) =>
+    `[${index + 1}] ${String(citation["excerpt"] ?? "")}`
+  );
+  return trimText(
+    [
+      `Query: ${query}`,
+      "The strongest matching project artifacts say:",
+      ...lines,
+      "Use the citations to inspect the source before acting on the answer.",
+    ].join("\n"),
+    1400,
+  );
+}
+
+function ragMessages(query: string, citations: Array<Record<string, unknown>>) {
+  const context = citations.map((citation, index) =>
+    [
+      `[${index + 1}] ${citation["title"] ?? citation["source_url"]}`,
+      `type: ${citation["source_type"]}`,
+      `url: ${citation["source_url"]}`,
+      `excerpt: ${citation["excerpt"]}`,
+    ].join("\n")
+  ).join("\n\n");
+  return [
+    {
+      role: "system",
+      content:
+        "Answer only from the provided project citations. If the citations are insufficient, say so. Keep the answer concise and include bracket citations like [1].",
+    },
+    {
+      role: "user",
+      content: `Question:\n${query}\n\nProject citations:\n${context}`,
+    },
+  ];
+}
+
+async function generateLlmRagAnswer(
+  body: Body,
+  query: string,
+  citations: Array<Record<string, unknown>>,
+  traceId: string,
+): Promise<string | null> {
+  if (body.use_llm === false || citations.length === 0) return null;
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
+  try {
+    const response = await fetch(`${SUPABASE_URL}/functions/v1/ai-hub`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        "Content-Type": "application/json",
+      },
+      signal: controller.signal,
+      body: JSON.stringify({
+        action: "provider.chat_auto",
+        tier: asString(body.tier) || "free",
+        trace_id: traceId,
+        messages: ragMessages(query, citations),
+      }),
+    });
+    const payload = await response.json() as Record<string, unknown>;
+    const text = asString(payload["text"]);
+    if (!response.ok || payload["success"] === false || !text) {
+      throw new Error(
+        `ai-hub provider.chat_auto failed: ${
+          asString(payload["status"]) || response.status
+        }`,
+      );
+    }
+    return text;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function assertKgRateLimit(
+  client: ReturnType<typeof adminClient>,
+  clientKey: string,
+): Promise<Response | null> {
+  const since = new Date(Date.now() - 60 * 1000).toISOString();
+  try {
+    const { count, error } = await client
+      .from("kg_query_logs")
+      .select("trace_id", { count: "exact", head: true })
+      .eq("client_key", clientKey)
+      .gte("created_at", since);
+    if (error) throw error;
+    if ((count ?? 0) >= KG_RATE_LIMIT_PER_MINUTE) {
+      return jsonResponse({
+        error: "rate_limited",
+        limit: KG_RATE_LIMIT_PER_MINUTE,
+        window_seconds: 60,
+      }, 429);
+    }
+  } catch (error) {
+    console.warn("kg rate limit skipped", error);
+  }
+  return null;
+}
+
+async function logKgQuery(
+  client: ReturnType<typeof adminClient>,
+  entry: Record<string, unknown>,
+) {
+  try {
+    await client.from("kg_query_logs").insert(entry);
+  } catch (error) {
+    console.warn("kg query log skipped", error);
+  }
+}
+
+async function memoryRagQuery(body: Body, ctx: McpAuthContext | null) {
+  const startedAt = performance.now();
+  const query = asString(body.query);
+  if (!query) return jsonResponse({ error: "query required" }, 400);
+
+  const topK = asPositiveInt(body.top_k, 8, 12);
+  const sourceTypes = normalizeKgSourceTypes(body.sources);
+  const traceId = crypto.randomUUID();
+  const userId = normalizeUuid(body.user_id);
+  const clientKey = clientKeyFor(ctx, userId);
+  const client = adminClient();
+
+  const rateLimited = await assertKgRateLimit(client, clientKey);
+  if (rateLimited) return rateLimited;
+
+  let docs: MemoryDocument[] = [];
+  let kgLoadError = "";
+  try {
+    docs = await loadRecentKgDocuments(sourceTypes);
+  } catch (error) {
+    kgLoadError = String(error);
+    console.warn("kg document load skipped", error);
+  }
+
+  if (docs.length === 0 && sourceTypes.includes("memory")) {
+    try {
+      docs = (await loadRecentDocuments()).map((doc) => ({
+        ...doc,
+        metadata: {
+          ...(doc.metadata ?? {}),
+          kg: false,
+          source_type: "memory",
+          source_id: doc.file_path,
+          source_url: doc.file_path,
+          last_synced_at: doc.updated_at,
+        },
+      }));
+    } catch (error) {
+      console.warn("memory fallback skipped", error);
+    }
+  }
+
+  const bm25 = rankBm25(query, docs, 50);
+  let vector: ScoredMemoryDocument[] = [];
+  if (!kgLoadError) {
+    try {
+      vector = await kgVectorSearch(client, query, sourceTypes, 20);
+    } catch (error) {
+      console.warn("kg vector stage skipped", error);
+    }
+  }
+  const results = mergeHybridResults(bm25, vector, topK);
+  const maxScore = Math.max(...results.map((item) => item.score), 0.0001);
+  const citations = results.map((doc) => citationFor(doc, maxScore));
+
+  let answerStatus = citations.length === 0
+    ? "no_results"
+    : citationsAreStale(citations)
+    ? "stale_index"
+    : "ok";
+  let answer = extractiveAnswer(query, citations);
+
+  if (citations.length > 0) {
+    try {
+      answer = await generateLlmRagAnswer(body, query, citations, traceId) ??
+        answer;
+    } catch (error) {
+      console.warn("kg llm stage failed", error);
+      if (answerStatus === "ok") answerStatus = "llm_failure";
+    }
+  }
+
+  await logKgQuery(client, {
+    trace_id: traceId,
+    user_id: userId,
+    client_key: clientKey,
+    query,
+    sources: sourceTypes,
+    top_k: topK,
+    answer_status: answerStatus,
+    citation_count: citations.length,
+    latency_ms: Math.round(performance.now() - startedAt),
+  });
+
+  return jsonResponse({
+    success: true,
+    action: "memory.rag.query",
+    query,
+    answer,
+    citations,
+    trace_id: traceId,
+    answer_status: answerStatus,
+    sources: sourceTypes,
+    stages: {
+      kg_documents: docs.length,
+      bm25_candidates: bm25.length,
+      vector_candidates: vector.length,
+      kg_load_error: kgLoadError || null,
+    },
   });
 }
 
@@ -343,6 +707,9 @@ serve(async (req: Request) => {
         "memory.rank",
         "memory.related",
         "memory.stats",
+        "memory.rag.query",
+        "rag.query",
+        "memory-search-hub.rag.query",
       ]),
     );
   }
@@ -369,6 +736,11 @@ serve(async (req: Request) => {
     switch (action) {
       case "memory.search":
         response = await memorySearch(body);
+        break;
+      case "memory.rag.query":
+      case "rag.query":
+      case "memory-search-hub.rag.query":
+        response = await memoryRagQuery(body, ctx);
         break;
       case "memory.query_route":
         response = await memoryQueryRoute(body);

--- a/supabase/functions/memory-search-hub/index.ts
+++ b/supabase/functions/memory-search-hub/index.ts
@@ -82,7 +82,10 @@ function normalizeUuid(value: unknown): string | null {
   return null;
 }
 
-function clientKeyFor(ctx: McpAuthContext | null, userId: string | null): string {
+function clientKeyFor(
+  ctx: McpAuthContext | null,
+  userId: string | null,
+): string {
   return userId ?? ctx?.client_id ?? "anonymous";
 }
 

--- a/supabase/migrations/20260507013000_create_kg_embeddings.sql
+++ b/supabase/migrations/20260507013000_create_kg_embeddings.sql
@@ -1,0 +1,149 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS public.kg_embeddings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_id text NOT NULL,
+  source_type text NOT NULL CHECK (
+    source_type IN ('issue', 'wbs', 'doc', 'memory', 'notebooklm')
+  ),
+  source_url text NOT NULL DEFAULT '',
+  title text,
+  content text NOT NULL,
+  excerpt text,
+  content_hash text NOT NULL,
+  embedding vector(768),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  last_synced_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  search_vector tsvector GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(excerpt, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(content, '')), 'C')
+  ) STORED,
+  CONSTRAINT kg_embeddings_source_unique UNIQUE (source_type, source_id)
+);
+
+COMMENT ON COLUMN public.kg_embeddings.embedding IS
+  'Phase 1 uses 768-d Gemini embeddings to match memory_index and memory-search-hub vector search.';
+
+CREATE INDEX IF NOT EXISTS kg_embeddings_source_type_idx
+  ON public.kg_embeddings (source_type, last_synced_at DESC);
+
+CREATE INDEX IF NOT EXISTS kg_embeddings_content_hash_idx
+  ON public.kg_embeddings (content_hash);
+
+CREATE INDEX IF NOT EXISTS kg_embeddings_search_vector_idx
+  ON public.kg_embeddings USING gin (search_vector);
+
+CREATE INDEX IF NOT EXISTS kg_embeddings_embedding_idx
+  ON public.kg_embeddings
+  USING ivfflat (embedding vector_cosine_ops)
+  WITH (lists = 100)
+  WHERE embedding IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.kg_query_logs (
+  trace_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  client_key text NOT NULL DEFAULT 'anonymous',
+  query text NOT NULL,
+  sources text[] NOT NULL DEFAULT ARRAY['issue','wbs','doc','memory','notebooklm'],
+  top_k integer NOT NULL DEFAULT 8 CHECK (top_k BETWEEN 1 AND 20),
+  answer_status text NOT NULL CHECK (
+    answer_status IN ('ok', 'no_results', 'stale_index', 'llm_failure')
+  ),
+  citation_count integer NOT NULL DEFAULT 0 CHECK (citation_count >= 0),
+  latency_ms integer NOT NULL DEFAULT 0 CHECK (latency_ms >= 0),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS kg_query_logs_user_time_idx
+  ON public.kg_query_logs (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS kg_query_logs_client_time_idx
+  ON public.kg_query_logs (client_key, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS kg_query_logs_status_time_idx
+  ON public.kg_query_logs (answer_status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.kg_indexer_failures (
+  id bigserial PRIMARY KEY,
+  source_type text NOT NULL CHECK (
+    source_type IN ('issue', 'wbs', 'doc', 'memory', 'notebooklm')
+  ),
+  source_id text NOT NULL DEFAULT '',
+  source_url text NOT NULL DEFAULT '',
+  error_message text NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  resolved_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS kg_indexer_failures_open_idx
+  ON public.kg_indexer_failures (source_type, created_at DESC)
+  WHERE resolved_at IS NULL;
+
+ALTER TABLE public.kg_embeddings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kg_query_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kg_indexer_failures ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "kg_embeddings_service_all" ON public.kg_embeddings
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY "kg_query_logs_service_all" ON public.kg_query_logs
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY "kg_query_logs_owner_select" ON public.kg_query_logs
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "kg_indexer_failures_service_all" ON public.kg_indexer_failures
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE OR REPLACE FUNCTION public.match_kg_embeddings(
+  query_embedding vector(768),
+  match_count integer DEFAULT 8,
+  match_threshold double precision DEFAULT 0.5,
+  source_filter text[] DEFAULT NULL
+)
+RETURNS TABLE (
+  source_id text,
+  source_type text,
+  source_url text,
+  title text,
+  content text,
+  excerpt text,
+  metadata jsonb,
+  last_synced_at timestamptz,
+  score double precision
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    e.source_id,
+    e.source_type,
+    e.source_url,
+    e.title,
+    e.content,
+    e.excerpt,
+    e.metadata,
+    e.last_synced_at,
+    1 - (e.embedding <=> query_embedding) AS score
+  FROM public.kg_embeddings e
+  WHERE e.embedding IS NOT NULL
+    AND (
+      source_filter IS NULL
+      OR cardinality(source_filter) = 0
+      OR e.source_type = ANY(source_filter)
+    )
+    AND 1 - (e.embedding <=> query_embedding) >= match_threshold
+  ORDER BY e.embedding <=> query_embedding
+  LIMIT LEAST(GREATEST(match_count, 1), 50);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.match_kg_embeddings(vector, integer, double precision, text[])
+  TO service_role;

--- a/test/scripts/test_kg_index_common.py
+++ b/test/scripts/test_kg_index_common.py
@@ -1,0 +1,71 @@
+import tempfile
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.kg_index_common import (
+    SourceRecord,
+    content_hash,
+    detect_pii,
+    filter_payloads,
+    record_payload,
+    write_jsonl,
+)
+
+
+class KgIndexCommonTest(unittest.TestCase):
+    def test_detect_pii_catches_email_and_luhn_card(self) -> None:
+        hits = detect_pii("Contact test@example.com or card 4242 4242 4242 4242")
+
+        self.assertIn("email", hits)
+        self.assertIn("credit_card", hits)
+
+    def test_filter_payloads_skips_pii_records(self) -> None:
+        clean = SourceRecord(
+            source_type="doc",
+            source_id="docs/clean.md",
+            title="Clean",
+            content="Project docs without personal data.",
+        )
+        pii = SourceRecord(
+            source_type="issue",
+            source_id="1",
+            title="Leak",
+            content="mail me at owner@example.com",
+        )
+
+        payloads, skipped = filter_payloads([clean, pii])
+
+        self.assertEqual(len(payloads), 1)
+        self.assertEqual(payloads[0]["source_id"], "docs/clean.md")
+        self.assertEqual(len(skipped), 1)
+        self.assertEqual(skipped[0]["source_type"], "issue")
+
+    def test_record_payload_has_stable_hash_and_excerpt(self) -> None:
+        record = SourceRecord(
+            source_type="wbs",
+            source_id="docs/WBS.md",
+            title="WBS",
+            content="alpha " * 100,
+        )
+
+        payload = record_payload(record)
+
+        self.assertEqual(payload["content_hash"], content_hash(record.content.strip()))
+        self.assertLessEqual(len(payload["excerpt"]), 280)
+
+    def test_write_jsonl_creates_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "nested" / "records.jsonl"
+            count = write_jsonl(output, [{"a": 1}, {"b": 2}])
+
+            self.assertEqual(count, 2)
+            self.assertEqual(len(output.read_text(encoding="utf-8").splitlines()), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add Knowledge Graph Phase 1 storage for `kg_embeddings`, query logs, indexer failure DLQ, RLS, and pgvector matching.
- Add `memory.rag.query` / `memory-search-hub.rag.query` to `memory-search-hub` with source filters, citations, trace logging, stale-index status, rate limiting, and ai-hub best-effort summary fallback.
- Add five KG indexers plus nightly workflow artifacts/failure issue routing, and expose a dedicated Flutter `/knowledge-graph` page/home entry.

Closes #772

## Minimal E2E Gate
- The E2E contract is implementation-detail independent and black-box: user input, source filters, and citation-bearing output are the observable boundary.
- Minimal plan: three cases, covering successful cited answer, no-results answer, and stale/LLM-failure status rendering.
- E2E mechanism: Playwright public smoke is already required in CI for this PR.
- E2E-Exception: no new `integration_test/` or `test/e2e/` file is added because this PR wires a Supabase Edge Function plus GitHub-indexed data that needs deployed secrets/tables; local coverage is handled by Python indexer tests, Deno check, Flutter analyzer, and existing Playwright smoke.

## Validation
- `python -m py_compile scripts\kg_index_common.py scripts\kg_index_docs.py scripts\kg_index_wbs_tasks.py scripts\kg_index_memory_vault.py scripts\kg_index_notebooklm_intake.py scripts\kg_index_github_issues.py`
- `python test\scripts\test_kg_index_common.py`
- `deno check --no-lock --config supabase\functions\memory-search-hub\deno.jsonc supabase\functions\memory-search-hub\index.ts`
- `flutter analyze --no-pub`
- `git diff --check origin/main...HEAD`
- Smoke ran all five indexers with `--limit 3` and no Supabase apply.