### PR TITLE
feat(meal-log): MVP 食事ログ統合 (#1665)

### DIFF
--- a/lib/pages/recipe_meal_planner_page.dart
+++ b/lib/pages/recipe_meal_planner_page.dart
@@ -1,11 +1,47 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+const _accentOrange = Color(0xFFFF6B35);
+const _accentIndigo = Color(0xFF3D5AFE);
+const _softText = Color(0xFF6B7280);
+
+const _mealTypes = [
+  _MealTypeOption(
+    value: 'breakfast',
+    label: '朝食',
+    shortLabel: '朝',
+    emoji: '🌅',
+    icon: Icons.wb_twilight,
+  ),
+  _MealTypeOption(
+    value: 'lunch',
+    label: '昼食',
+    shortLabel: '昼',
+    emoji: '🌞',
+    icon: Icons.wb_sunny_outlined,
+  ),
+  _MealTypeOption(
+    value: 'dinner',
+    label: '夜食',
+    shortLabel: '夜',
+    emoji: '🌙',
+    icon: Icons.dinner_dining,
+  ),
+  _MealTypeOption(
+    value: 'snack',
+    label: '間食',
+    shortLabel: '間食',
+    emoji: '🍪',
+    icon: Icons.cookie_outlined,
+  ),
+];
+
 /// レシピ・食事プランナーページ
-/// レシピ管理・週間食事計画・買い物リスト自動生成。
-/// recipe-meal-planner Edge Function と連携。
+/// レシピ管理・週間食事計画・買い物リスト・食事ログを扱う。
 class RecipeMealPlannerPage extends StatefulWidget {
-  const RecipeMealPlannerPage({super.key});
+  const RecipeMealPlannerPage({super.key, this.supabaseClient});
+
+  final SupabaseClient? supabaseClient;
 
   @override
   State<RecipeMealPlannerPage> createState() => _RecipeMealPlannerPageState();
@@ -13,7 +49,7 @@ class RecipeMealPlannerPage extends StatefulWidget {
 
 class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
     with SingleTickerProviderStateMixin {
-  final _supabase = Supabase.instance.client;
+  late final SupabaseClient _supabase;
   late final TabController _tabController;
 
   bool _isLoading = false;
@@ -21,11 +57,14 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
   List<Map<String, dynamic>> _recipes = [];
   List<Map<String, dynamic>> _weekPlan = [];
   List<Map<String, dynamic>> _shoppingList = [];
+  List<Map<String, dynamic>> _mealLogs = [];
+  Map<String, dynamic> _todaySummary = const {};
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
+    _supabase = widget.supabaseClient ?? Supabase.instance.client;
+    _tabController = TabController(length: 4, vsync: this);
     _fetchData();
   }
 
@@ -35,9 +74,40 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
     super.dispose();
   }
 
+  Future<Map<String, dynamic>> _invokeHub(Map<String, dynamic> body) async {
+    final response = await _supabase.functions.invoke(
+      'lifestyle-hub',
+      body: body,
+    );
+    final data = response.data;
+    if (data is Map<String, dynamic>) {
+      final error = data['error'];
+      if (error != null) {
+        throw Exception(error);
+      }
+      return data;
+    }
+    if (data is Map) {
+      final mapped = Map<String, dynamic>.from(data);
+      final error = mapped['error'];
+      if (error != null) {
+        throw Exception(error);
+      }
+      return mapped;
+    }
+    return {};
+  }
+
   Future<void> _fetchData() async {
     if (_supabase.auth.currentUser == null) {
-      setState(() => _isLoading = false);
+      setState(() {
+        _isLoading = false;
+        _recipes = [];
+        _weekPlan = [];
+        _shoppingList = [];
+        _mealLogs = [];
+        _todaySummary = const {};
+      });
       return;
     }
     setState(() {
@@ -45,32 +115,16 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
       _errorMessage = null;
     });
     try {
-      final recipesRes = await _supabase.functions.invoke(
-        'lifestyle-hub',
-        body: {'action': 'recipe.list'},
-      );
-      final planRes = await _supabase.functions.invoke(
-        'lifestyle-hub',
-        body: {'action': 'meal.list_plans'},
-      );
+      final recipesRes = await _invokeHub({'action': 'recipe.list'});
+      final planRes = await _invokeHub({'action': 'meal.list_plans'});
+      final logsRes = await _invokeHub({'action': 'meal_log.list'});
+      final summaryRes = await _invokeHub({'action': 'meal_log.summary_today'});
 
       setState(() {
-        final rd = recipesRes.data;
-        if (rd is Map<String, dynamic>) {
-          final list = rd['recipes'];
-          if (list is List) {
-            _recipes = list.map((r) => r as Map<String, dynamic>).toList();
-          }
-        }
-
-        final pd = planRes.data;
-        if (pd is Map<String, dynamic>) {
-          final list = pd['plans'];
-          if (list is List) {
-            _weekPlan = list.map((p) => p as Map<String, dynamic>).toList();
-          }
-        }
-
+        _recipes = _mapList(recipesRes['recipes']);
+        _weekPlan = _mapList(planRes['plans']);
+        _mealLogs = _mapList(logsRes['logs']);
+        _todaySummary = summaryRes;
         _shoppingList = [];
       });
     } catch (e) {
@@ -79,6 +133,14 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }
+  }
+
+  List<Map<String, dynamic>> _mapList(Object? value) {
+    if (value is! List) return [];
+    return value
+        .whereType<Map>()
+        .map((item) => Map<String, dynamic>.from(item))
+        .toList();
   }
 
   @override
@@ -95,6 +157,7 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
             Tab(icon: Icon(Icons.restaurant_menu), text: 'レシピ'),
             Tab(icon: Icon(Icons.calendar_today), text: '週間プラン'),
             Tab(icon: Icon(Icons.shopping_cart), text: '買い物リスト'),
+            Tab(icon: Icon(Icons.dinner_dining), text: '食事ログ'),
           ],
         ),
       ),
@@ -108,6 +171,7 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
                     _buildRecipesTab(),
                     _buildWeekPlanTab(),
                     _buildShoppingListTab(),
+                    _buildMealLogTab(),
                   ],
                 ),
     );
@@ -138,10 +202,7 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
             SizedBox(height: 12),
             Text(
               'レシピがありません',
-              style: TextStyle(
-                color: Color(0xFF9CA3AF),
-                height: 1.5,
-              ),
+              style: TextStyle(color: Color(0xFF9CA3AF), height: 1.5),
             ),
           ],
         ),
@@ -164,25 +225,20 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
               backgroundColor: Theme.of(context).colorScheme.primaryContainer,
               child: Text(
                 emoji,
-                style: const TextStyle(
-                  fontSize: 20,
-                  height: 1.5,
-                ),
+                style: const TextStyle(fontSize: 20, height: 1.5),
               ),
             ),
             title: Text(
               name,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                height: 1.5,
-              ),
+              style: const TextStyle(fontWeight: FontWeight.bold, height: 1.5),
             ),
             subtitle: Text('$category${time > 0 ? " · $time分" : ""}'),
             trailing: calories > 0
                 ? Chip(
                     label: Text('${calories}kcal'),
-                    backgroundColor:
-                        Theme.of(context).colorScheme.secondaryContainer,
+                    backgroundColor: Theme.of(
+                      context,
+                    ).colorScheme.secondaryContainer,
                   )
                 : null,
           ),
@@ -206,25 +262,19 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
             const SizedBox(height: 12),
             const Text(
               '週間プランがありません',
-              style: TextStyle(
-                color: Color(0xFF9CA3AF),
-                height: 1.5,
-              ),
+              style: TextStyle(color: Color(0xFF9CA3AF), height: 1.5),
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
               onPressed: () async {
                 try {
-                  await _supabase.functions.invoke(
-                    'lifestyle-hub',
-                    body: {'action': 'meal.plan'},
-                  );
+                  await _invokeHub({'action': 'meal.plan'});
                   await _fetchData();
                 } catch (e) {
                   if (mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('エラー: $e')),
-                    );
+                    ScaffoldMessenger.of(
+                      context,
+                    ).showSnackBar(SnackBar(content: Text('エラー: $e')));
                   }
                 }
               },
@@ -276,10 +326,7 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
             SizedBox(height: 12),
             Text(
               '買い物リストが空です',
-              style: TextStyle(
-                color: Color(0xFF9CA3AF),
-                height: 1.5,
-              ),
+              style: TextStyle(color: Color(0xFF9CA3AF), height: 1.5),
             ),
           ],
         ),
@@ -310,4 +357,449 @@ class _RecipeMealPlannerPageState extends State<RecipeMealPlannerPage>
       },
     );
   }
+
+  Widget _buildMealLogTab() {
+    return RefreshIndicator(
+      onRefresh: _fetchData,
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final mealType in _mealTypes)
+                ElevatedButton.icon(
+                  onPressed: () => _showMealLogInputDialog(mealType),
+                  icon: Icon(mealType.icon),
+                  label: Text('+ ${mealType.label}'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: _accentOrange,
+                    foregroundColor: Colors.white,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          _buildMealLogSummary(),
+          const SizedBox(height: 16),
+          Text(
+            '本日のログ',
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          if (_mealLogs.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 32),
+              child: Center(
+                child: Text(
+                  'まだ食事ログがありません',
+                  style: TextStyle(color: _softText, height: 1.5),
+                ),
+              ),
+            )
+          else
+            for (final log in _mealLogs) _buildMealLogCard(log),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMealLogSummary() {
+    final byType = _safeMap(_todaySummary['by_meal_type']);
+    final kcal = _toNum(_todaySummary['kcal_total']);
+    final protein = _toNum(_todaySummary['protein_g_total']);
+    final fat = _toNum(_todaySummary['fat_g_total']);
+    final carb = _toNum(_todaySummary['carb_g_total']);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.insights, color: _accentIndigo),
+                const SizedBox(width: 8),
+                Text(
+                  '本日のサマリ',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              '合計 ${_formatNumber(kcal)} kcal',
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    color: _accentIndigo,
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'P: ${_formatNumber(protein)} g  /  F: ${_formatNumber(fat)} g  /  C: ${_formatNumber(carb)} g',
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 12,
+              runSpacing: 6,
+              children: [
+                for (final mealType in _mealTypes)
+                  Text(
+                    '${mealType.shortLabel}: ${_formatNumber(_toNum(byType[mealType.value]))} kcal',
+                    style: const TextStyle(color: _softText),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMealLogCard(Map<String, dynamic> log) {
+    final mealType = _mealTypeFor(log['meal_type']);
+    final menuName = (log['menu_name'] as String?) ?? '食事ログ';
+    final storeName = (log['store_name'] as String?) ?? '';
+    final kcal = _toNum(log['kcal']);
+    final protein = _toNum(log['protein_g']);
+    final fat = _toNum(log['fat_g']);
+    final carb = _toNum(log['carb_g']);
+    final vegetablesNote = (log['vegetables_note'] as String?) ?? '';
+    final saltNote = (log['salt_note'] as String?) ?? '';
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: const Color(0xFFFFEEE8),
+          child: Text(mealType.emoji),
+        ),
+        title: Text(
+          '${mealType.shortLabel} ${_formatLoggedAt(log['logged_at'])} / $menuName',
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        subtitle: Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (storeName.isNotEmpty) Text(storeName),
+              Text(
+                '${_formatNumber(kcal)} kcal / P ${_formatNumber(protein)} g / F ${_formatNumber(fat)} g / C ${_formatNumber(carb)} g',
+              ),
+              if (vegetablesNote.isNotEmpty || saltNote.isNotEmpty)
+                Text(
+                  [
+                    if (vegetablesNote.isNotEmpty) '野菜: $vegetablesNote',
+                    if (saltNote.isNotEmpty) '塩分: $saltNote',
+                  ].join('  /  '),
+                  style: const TextStyle(color: _softText),
+                ),
+            ],
+          ),
+        ),
+        trailing: Tooltip(
+          message: '削除',
+          child: IconButton(
+            icon: const Icon(Icons.delete_outline),
+            color: _softText,
+            onPressed: () => _deleteMealLog(log),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showMealLogInputDialog(_MealTypeOption mealType) async {
+    final menuController = TextEditingController();
+    final storeController = TextEditingController();
+    final kcalController = TextEditingController();
+    final proteinController = TextEditingController();
+    final fatController = TextEditingController();
+    final carbController = TextEditingController();
+    final vegetablesController = TextEditingController();
+    final saltController = TextEditingController();
+
+    try {
+      await showDialog<void>(
+        context: context,
+        builder: (dialogContext) {
+          var isSaving = false;
+          String? localError;
+
+          Future<void> submit(
+            void Function(void Function()) setDialogState,
+          ) async {
+            final menuName = menuController.text.trim();
+            if (menuName.isEmpty) {
+              setDialogState(() => localError = 'メニュー名を入力してください');
+              return;
+            }
+
+            setDialogState(() {
+              isSaving = true;
+              localError = null;
+            });
+
+            final payload = <String, dynamic>{
+              'action': 'meal_log.add',
+              'meal_type': mealType.value,
+              'menu_name': menuName,
+              'store_name': _optionalText(storeController),
+              'kcal': _optionalInt(kcalController),
+              'protein_g': _optionalNumber(proteinController),
+              'fat_g': _optionalNumber(fatController),
+              'carb_g': _optionalNumber(carbController),
+              'vegetables_note': _optionalText(vegetablesController),
+              'salt_note': _optionalText(saltController),
+            };
+
+            try {
+              await _invokeHub(payload);
+              if (!mounted || !dialogContext.mounted) return;
+              Navigator.of(dialogContext).pop();
+              await _fetchData();
+              if (!mounted) return;
+              ScaffoldMessenger.of(
+                context,
+              ).showSnackBar(const SnackBar(content: Text('食事ログを追加しました')));
+            } catch (e) {
+              if (!mounted || !dialogContext.mounted) return;
+              setDialogState(() {
+                localError = '$e';
+                isSaving = false;
+              });
+            }
+          }
+
+          return StatefulBuilder(
+            builder: (context, setDialogState) {
+              return AlertDialog(
+                title: Text('${mealType.label}を記録'),
+                content: SingleChildScrollView(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 420),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        TextField(
+                          controller: menuController,
+                          decoration: const InputDecoration(
+                            labelText: 'メニュー名',
+                            prefixIcon: Icon(Icons.restaurant),
+                          ),
+                          textInputAction: TextInputAction.next,
+                        ),
+                        const SizedBox(height: 10),
+                        TextField(
+                          controller: storeController,
+                          decoration: const InputDecoration(
+                            labelText: '外食チェーン名',
+                            prefixIcon: Icon(Icons.storefront),
+                          ),
+                          textInputAction: TextInputAction.next,
+                        ),
+                        const SizedBox(height: 10),
+                        _numberField(kcalController, '概算 kcal'),
+                        const SizedBox(height: 10),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: _numberField(proteinController, 'たんぱく質 g'),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: _numberField(fatController, '脂質 g'),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 10),
+                        _numberField(carbController, '炭水化物 g'),
+                        const SizedBox(height: 10),
+                        TextField(
+                          controller: vegetablesController,
+                          decoration: const InputDecoration(
+                            labelText: '野菜メモ',
+                            prefixIcon: Icon(Icons.eco_outlined),
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        TextField(
+                          controller: saltController,
+                          decoration: const InputDecoration(
+                            labelText: '塩分メモ',
+                            prefixIcon: Icon(Icons.grain_outlined),
+                          ),
+                        ),
+                        if (localError != null) ...[
+                          const SizedBox(height: 12),
+                          Text(
+                            localError!,
+                            style: const TextStyle(color: Color(0xFFE53935)),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: isSaving
+                        ? null
+                        : () => Navigator.of(dialogContext).pop(),
+                    child: const Text('キャンセル'),
+                  ),
+                  ElevatedButton.icon(
+                    onPressed: isSaving ? null : () => submit(setDialogState),
+                    icon: isSaving
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.save),
+                    label: const Text('保存'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: _accentOrange,
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      );
+    } finally {
+      menuController.dispose();
+      storeController.dispose();
+      kcalController.dispose();
+      proteinController.dispose();
+      fatController.dispose();
+      carbController.dispose();
+      vegetablesController.dispose();
+      saltController.dispose();
+    }
+  }
+
+  Widget _numberField(TextEditingController controller, String label) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: label,
+        prefixIcon: const Icon(Icons.calculate_outlined),
+      ),
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      textInputAction: TextInputAction.next,
+    );
+  }
+
+  Future<void> _deleteMealLog(Map<String, dynamic> log) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('食事ログを削除'),
+        content: Text('${log['menu_name'] ?? 'このログ'}を削除しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton.icon(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            icon: const Icon(Icons.delete_outline),
+            label: const Text('削除'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    try {
+      await _invokeHub({'action': 'meal_log.delete', 'id': log['id']});
+      await _fetchData();
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('食事ログを削除しました')));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('削除できませんでした: $e')));
+    }
+  }
+
+  Map<String, dynamic> _safeMap(Object? value) {
+    if (value is Map<String, dynamic>) return value;
+    if (value is Map) return Map<String, dynamic>.from(value);
+    return const {};
+  }
+
+  _MealTypeOption _mealTypeFor(Object? value) {
+    return _mealTypes.firstWhere(
+      (option) => option.value == value,
+      orElse: () => _mealTypes.first,
+    );
+  }
+
+  num _toNum(Object? value) {
+    if (value is num) return value;
+    if (value is String) return num.tryParse(value) ?? 0;
+    return 0;
+  }
+
+  String _formatNumber(num value) {
+    if (value == value.roundToDouble()) return value.toInt().toString();
+    return value.toStringAsFixed(1);
+  }
+
+  String _formatLoggedAt(Object? value) {
+    if (value is! String || value.isEmpty) return '--:--';
+    final parsed = DateTime.tryParse(value);
+    if (parsed == null) return '--:--';
+    final local = parsed.toLocal();
+    final hour = local.hour.toString().padLeft(2, '0');
+    final minute = local.minute.toString().padLeft(2, '0');
+    return '$hour:$minute';
+  }
+
+  String? _optionalText(TextEditingController controller) {
+    final text = controller.text.trim();
+    return text.isEmpty ? null : text;
+  }
+
+  int? _optionalInt(TextEditingController controller) {
+    final text = controller.text.trim();
+    if (text.isEmpty) return null;
+    return int.tryParse(text);
+  }
+
+  num? _optionalNumber(TextEditingController controller) {
+    final text = controller.text.trim();
+    if (text.isEmpty) return null;
+    return num.tryParse(text);
+  }
+}
+
+class _MealTypeOption {
+  const _MealTypeOption({
+    required this.value,
+    required this.label,
+    required this.shortLabel,
+    required this.emoji,
+    required this.icon,
+  });
+
+  final String value;
+  final String label;
+  final String shortLabel;
+  final String emoji;
+  final IconData icon;
 }

--- a/supabase/functions/lifestyle-hub/index.ts
+++ b/supabase/functions/lifestyle-hub/index.ts
@@ -86,6 +86,75 @@ function boolBody(value: unknown, fallback: boolean): boolean {
   return fallback;
 }
 
+const mealTypes = ["breakfast", "lunch", "dinner", "snack"] as const;
+type MealType = typeof mealTypes[number];
+
+function isMealType(value: unknown): value is MealType {
+  return typeof value === "string" &&
+    mealTypes.includes(value as MealType);
+}
+
+function optionalText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function optionalNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function optionalInt(value: unknown): number | null {
+  const parsed = optionalNumber(value);
+  if (parsed == null) return null;
+  return Math.round(parsed);
+}
+
+function boundedLimit(value: unknown, fallback = 50, max = 200): number {
+  const parsed = optionalInt(value) ?? fallback;
+  return Math.min(Math.max(parsed, 1), max);
+}
+
+function dateWindowForDay(value: unknown): {
+  date: string;
+  start: string;
+  end: string;
+} {
+  const date = optionalText(value) ?? dateOnly(new Date());
+  const start = new Date(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(start.getTime())) {
+    throw new Error("invalid date");
+  }
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+  return {
+    date: dateOnly(start),
+    start: start.toISOString(),
+    end: end.toISOString(),
+  };
+}
+
+function dateWindowFromRange(fromValue: unknown, toValue: unknown): {
+  start: string;
+  end: string;
+} {
+  const from = dateWindowForDay(fromValue);
+  const to = dateWindowForDay(toValue ?? from.date);
+  if (Date.parse(from.start) > Date.parse(to.start)) {
+    throw new Error("from must be before or equal to to");
+  }
+  return { start: from.start, end: to.end };
+}
+
+function roundOne(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -100,6 +169,11 @@ serve(async (req) => {
       "";
     const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
       auth: { persistSession: false },
+    });
+    const authHeader = req.headers.get("Authorization") ?? "";
+    const userDb = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { persistSession: false },
+      global: { headers: { Authorization: authHeader } },
     });
     const userId = await getUserId(req);
     if (!userId) return json({ error: "Unauthorized" }, 401);
@@ -347,6 +421,125 @@ serve(async (req) => {
           success: true,
           plans: await listItems(admin, "meal_plan", userId),
         });
+      case "meal_log.add": {
+        if (!isMealType(body.meal_type)) {
+          return json({ error: "meal_type is required" }, 400);
+        }
+        const menuName = optionalText(body.menu_name);
+        if (!menuName) {
+          return json({ error: "menu_name is required" }, 400);
+        }
+        const loggedAt = optionalText(body.logged_at) ??
+          new Date().toISOString();
+        if (Number.isNaN(Date.parse(loggedAt))) {
+          return json({ error: "logged_at must be an ISO timestamp" }, 400);
+        }
+
+        const { data, error } = await userDb.from("meal_logs")
+          .insert({
+            user_id: userId,
+            meal_type: body.meal_type,
+            menu_name: menuName,
+            store_name: optionalText(body.store_name),
+            kcal: optionalInt(body.kcal),
+            protein_g: optionalNumber(body.protein_g),
+            fat_g: optionalNumber(body.fat_g),
+            carb_g: optionalNumber(body.carb_g),
+            vegetables_note: optionalText(body.vegetables_note),
+            salt_note: optionalText(body.salt_note),
+            logged_at: loggedAt,
+          })
+          .select("*")
+          .single();
+        if (error) return json({ error: error.message }, 400);
+        return json({ success: true, ok: true, id: data.id, log: data });
+      }
+      case "meal_log.list": {
+        let range: { start: string; end: string };
+        try {
+          range = dateWindowFromRange(body.from, body.to);
+        } catch (error) {
+          return json({ error: String(error) }, 400);
+        }
+        const limit = boundedLimit(body.limit, 50, 200);
+        const { data, error, count } = await userDb.from("meal_logs")
+          .select("*", { count: "exact" })
+          .eq("user_id", userId)
+          .gte("logged_at", range.start)
+          .lt("logged_at", range.end)
+          .order("logged_at", { ascending: false })
+          .limit(limit);
+        if (error) return json({ error: error.message }, 400);
+        return json({
+          success: true,
+          logs: data ?? [],
+          total: count ?? data?.length ?? 0,
+        });
+      }
+      case "meal_log.summary_today": {
+        let range: { date: string; start: string; end: string };
+        try {
+          range = dateWindowForDay(body.date);
+        } catch (error) {
+          return json({ error: String(error) }, 400);
+        }
+        const { data, error } = await userDb.from("meal_logs")
+          .select("meal_type, kcal, protein_g, fat_g, carb_g")
+          .eq("user_id", userId)
+          .gte("logged_at", range.start)
+          .lt("logged_at", range.end);
+        if (error) return json({ error: error.message }, 400);
+
+        const byMealType: Record<MealType, number> = {
+          breakfast: 0,
+          lunch: 0,
+          dinner: 0,
+          snack: 0,
+        };
+        let kcalTotal = 0;
+        let proteinTotal = 0;
+        let fatTotal = 0;
+        let carbTotal = 0;
+        for (const row of data ?? []) {
+          const mealType = isMealType(row.meal_type) ? row.meal_type : "snack";
+          const kcal = Number(row.kcal ?? 0);
+          const protein = Number(row.protein_g ?? 0);
+          const fat = Number(row.fat_g ?? 0);
+          const carb = Number(row.carb_g ?? 0);
+          byMealType[mealType] += Number.isFinite(kcal) ? kcal : 0;
+          kcalTotal += Number.isFinite(kcal) ? kcal : 0;
+          proteinTotal += Number.isFinite(protein) ? protein : 0;
+          fatTotal += Number.isFinite(fat) ? fat : 0;
+          carbTotal += Number.isFinite(carb) ? carb : 0;
+        }
+        return json({
+          success: true,
+          date: range.date,
+          kcal_total: Math.round(kcalTotal),
+          protein_g_total: roundOne(proteinTotal),
+          fat_g_total: roundOne(fatTotal),
+          carb_g_total: roundOne(carbTotal),
+          by_meal_type: {
+            breakfast: Math.round(byMealType.breakfast),
+            lunch: Math.round(byMealType.lunch),
+            dinner: Math.round(byMealType.dinner),
+            snack: Math.round(byMealType.snack),
+          },
+        });
+      }
+      case "meal_log.delete": {
+        const id = optionalText(body.id) ?? String(body.id ?? "").trim();
+        if (!id) return json({ error: "id is required" }, 400);
+        const { data, error } = await userDb.from("meal_logs")
+          .delete()
+          .eq("id", id)
+          .eq("user_id", userId)
+          .select("id")
+          .maybeSingle();
+        if (error) return json({ error: error.message }, 400);
+        if (!data) return json({ error: "meal log not found" }, 404);
+        return json({ success: true, ok: true });
+      }
 
       // ── Carbon Footprint ──────────────────────────────────────────────────────
       case "carbon.log": {

--- a/supabase/migrations/20260507102000_create_meal_logs.sql
+++ b/supabase/migrations/20260507102000_create_meal_logs.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS meal_logs (
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  meal_type TEXT NOT NULL CHECK (meal_type IN ('breakfast', 'lunch', 'dinner', 'snack')),
+  menu_name TEXT NOT NULL,
+  store_name TEXT,
+  kcal INT,
+  protein_g NUMERIC(6, 2),
+  fat_g NUMERIC(6, 2),
+  carb_g NUMERIC(6, 2),
+  vegetables_note TEXT,
+  salt_note TEXT,
+  logged_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS meal_logs_user_id_logged_at_idx
+  ON meal_logs (user_id, logged_at DESC);
+
+ALTER TABLE meal_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS meal_logs_select_own ON meal_logs;
+DROP POLICY IF EXISTS meal_logs_insert_own ON meal_logs;
+DROP POLICY IF EXISTS meal_logs_update_own ON meal_logs;
+DROP POLICY IF EXISTS meal_logs_delete_own ON meal_logs;
+
+CREATE POLICY meal_logs_select_own ON meal_logs FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY meal_logs_insert_own ON meal_logs FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY meal_logs_update_own ON meal_logs FOR UPDATE
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY meal_logs_delete_own ON meal_logs FOR DELETE
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
﻿## Summary
- Add `meal_logs` table with owner-only RLS policies for breakfast/lunch/dinner/snack logs.
- Extend `lifestyle-hub` with `meal_log.add`, `meal_log.list`, `meal_log.summary_today`, and `meal_log.delete` using the user JWT client so meal-log writes go through RLS rather than the admin client.
- Add a fourth `食事ログ` tab to `RecipeMealPlannerPage` with four add buttons, local-input dialog, daily kcal/PFC summary, log list, and delete action.

Closes #1665

Spec: `docs/MEAL_LOG_MVP_DESIGN_SPEC.md`
Hand-off: `docs/cross-instance-prs/20260507_codex_meal_log_mvp_handoff_part164.md`

## Acceptance Notes
- Login-gated meal logs can be added, listed, summarized, and deleted through `lifestyle-hub`.
- kcal/protein/fat/carb fields are nullable, so the MVP works without external food APIs.
- Existing recipe, weekly plan, and shopping list tabs remain in the same page and the tab controller is expanded from 3 to 4.
- Older PR #1671 is not used for this scope because it is local nutrition estimation only and does not provide the Supabase/RLS contract required by #1665.

## Minimal E2E Gate
- Implementation-detail independent / black-box: verify only user-visible route behavior on `/recipe-meal-planner` and public UI output, not private widget internals.
- Three cases: (1) open the page and confirm the existing three tabs still render, (2) switch to `食事ログ`, add a breakfast log with kcal and P/F/C values, then confirm it appears in the list, (3) delete that log and confirm the list/summary update without requiring an external food API.
- Playwright evidence plan: run a browser smoke against the route after deployment or local dev-server startup, capturing console/network errors and screenshots for desktop/mobile if this PR is selected for visual verification.
- E2E-Exception: this scoped PR adds a database-backed authenticated flow and Edge Function actions; local validation is static/contract-level here because a real authenticated Supabase session and migrated database are required for black-box browser mutation. CI public smoke remains the deploy-safety gate.

## Validation
- `dart format --set-exit-if-changed lib\pages\recipe_meal_planner_page.dart`
- `flutter analyze --no-pub lib\pages\recipe_meal_planner_page.dart`
- `flutter analyze --no-pub`
- `deno fmt --check supabase\functions\lifestyle-hub\index.ts`
- `deno check --node-modules-dir=auto --no-lock supabase\functions\lifestyle-hub\index.ts`
- `python scripts\check_migration_timestamps.py`
- `python scripts\check_migration_time_relative_check.py`
- `python scripts\check_ef_coverage.py`
- `python scripts\check_edge_function_imports.py`
- `python scripts\audit_hub_migration_completeness.py`
- `git diff --check`
