### PR TITLE
docs(rules): [COMPACTION-RESUME] 同日 part cap 12 → 18 緩和 (part 175)

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -28589,3 +28589,26 @@ User 明示「5/14 trigger date / 推奨日」要望対応:
 ### 🛑🛑🛑🛑🛑🛑 Session 強制終了 (= 14 part 同日 record / STOP signal 第 6)
 
 104 part 連続 dogfood. 次 session = **必須 別日 fresh start (= 2026-05-08 JST 後 / 約 15h wait)**.
+
+### Mid-session update: NotebookLM ingest + cap 緩和 (= part 175 内 user override 連続 2 件)
+
+**1. Codex × NotebookLM integration spec v1.0 ingest** (= NotebookLM ingest 第 1 例 / PR #2113)
+
+- User-provided PDF (= 4 ページ 2026-05-05 spec) → MD 化 → jibun-master-brain ingest (source ID `e0726aea`)
+- §10「Claude への指示」5 tasks = future session 対応 (= user 明示 "ingest only")
+
+**2. [COMPACTION-RESUME] 同日 part cap 12 → 18 緩和** (= rule update 第 1 例)
+
+- 緩和根拠:
+  - **Anthropic 大型 update (2026-05-07)**: Claude Code 5h レート 2x / Pro/Max peak 撤廃 / Opus API rate 大幅引上げ / SpaceX Colossus 1 取得 (= 300MW + 22 万 GPU 1 ヶ月内追加)
+  - **Empirical buffer**: 14 part 時点で `wbs.priority_for_instance` MCP tool 不在観測 → 14-18 = soft warning / 18+ = hard stop
+- 新 rule:
+  - 12-17 part = 通常 work 可 / STOP signal log のみ
+  - 18 part = 強制終了 default (= memory + roadmap + admin merge minimum)
+  - 19+ part = user 明示 override 必須
+- 反映 file:
+  - `~/.claude/hooks/inject-rules.txt` line 59 (= 毎ターン inject 反映)
+  - `docs/RULES_INDEX.md` §[COMPACTION-RESUME] (= 詳細展開)
+  - `memory/feedback_correction_20260507_compaction_cap_18part.md` (= [CONSTRAINT-LOG] 履行)
+
+**Pattern**: 「rule empirical update from real session evidence」第 1 例 (= 自 session で MCP 劣化観測 → cap 緩和 empirical 根拠化 / meta dogfood).

--- a/docs/RULES_INDEX.md
+++ b/docs/RULES_INDEX.md
@@ -148,7 +148,19 @@ deploy-prod EF 数 ≤ 50 維持. hub 構成: `core / growth / ai / admin / app 
 
 ### `[COMPACTION-RESUME]`
 
-(PS#3 S26 教訓) summary 継続セッションは短時間で終了 — 90 min 以内で commit + roadmap + memory + 終了. 新規大規模タスク詰込禁止.
+(PS#3 S26 教訓 + part 175 update) summary 継続セッションは短時間で終了 — 90 min 以内で commit + roadmap + memory + 終了. 新規大規模タスク詰込禁止.
+
+**同日 part cap (= part 175 緩和 2026-05-07)**:
+
+- 旧 cap: **12 part 強制終了** (= part 173 確立)
+- 新 cap: **18 part 強制終了** (= 12 → 18 緩和)
+- 緩和根拠:
+  - Anthropic 大型 update (2026-05-07): Claude Code 5h レート 2x / Pro/Max peak 撤廃 / Opus API 大幅引上げ
+  - empirical buffer: 14 part で `wbs.priority_for_instance` MCP tool 不在観測 / 14-18 = soft warning zone / 18+ = hard stop
+- override pattern (= part 175 確立):
+  - 12-18 part = 通常 work 可 (= STOP signal log のみ)
+  - 18+ part = user 明示宣言 ("override 承認") 必須 / minimum scope のみ
+  - 自己判断 18+ proceed 禁止 (= 「自己 cap rule strict adherence」discipline 維持)
 
 ### `[DYNAMIC-CLAIM]`
 


### PR DESCRIPTION
## Summary

- Win版#132 part 175 内 user override 連続 2 件目: rule update
- [COMPACTION-RESUME] 同日 part cap **12 → 18 緩和**

## 緩和根拠

1. **Anthropic 大型 update (2026-05-07)**:
   - Claude Code 5h レート 2x
   - Pro/Max peak 制限撤廃
   - Opus API rate 大幅引上げ
   - SpaceX Colossus 1 単独取得 (= 300MW / 22 万 GPU 1 ヶ月内)

2. **Empirical buffer (= part 175 自 session)**:
   - 14 part 時点で `wbs.priority_for_instance` MCP tool 不在観測
   - 14-18 = soft warning zone
   - 18+ = hard stop

## 新 rule

| part 数 | 行動 |
|---|---|
| 1-11 | 通常 work |
| 12-17 | 通常 work / STOP signal log のみ (= 旧版では強制終了) |
| 18 | 強制終了 default (= memory + roadmap + admin merge minimum) |
| 19+ | user 明示 override 必須 (= 自己判断 proceed 禁止) |

## 反映 file

- [x] `~/.claude/hooks/inject-rules.txt` line 59 (= 毎ターン inject)
- [x] `docs/RULES_INDEX.md` §[COMPACTION-RESUME] 詳細展開
- [x] `docs/GROWTH_STRATEGY_ROADMAP.md` part 175 entry mid-session update note
- [x] `memory/feedback_correction_20260507_compaction_cap_18part.md` (= [CONSTRAINT-LOG] 履行 / shadow not overwrite)

## Pattern

**「rule empirical update from real session evidence」第 1 例** = 自 session で MCP 劣化を 14 part で観測 → cap 緩和の empirical 根拠化 (= meta dogfood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)