### PR TITLE
fix: make meal logs migration idempotent (#2119)

### DIFF
--- a/supabase/migrations/20260507102000_create_meal_logs.sql
+++ b/supabase/migrations/20260507102000_create_meal_logs.sql
@@ -15,6 +15,9 @@ CREATE TABLE IF NOT EXISTS meal_logs (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+ALTER TABLE meal_logs
+  ADD COLUMN IF NOT EXISTS logged_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
 CREATE INDEX IF NOT EXISTS meal_logs_user_id_logged_at_idx
   ON meal_logs (user_id, logged_at DESC);
 


### PR DESCRIPTION
## Summary
- Fixes #2119 by making the meal log migration safe when `meal_logs` already exists without `logged_at`.
- Adds `ALTER TABLE meal_logs ADD COLUMN IF NOT EXISTS logged_at ...` before the `meal_logs_user_id_logged_at_idx` index is created.

## Validation
- `git diff --check`
- PowerShell ordering check: `logged_at` ALTER line appears before the index creation.

## Minimal E2E
The E2E test is implementation-detail independent.
The plan is minimal, about three I/O cases.
E2E mechanism: CI/deploy migration replay verifies the production path; local static ordering check covers the failed migration case before PR CI.

Cases:
- Fresh database: `CREATE TABLE IF NOT EXISTS` creates `logged_at`; the follow-up ALTER is a no-op.
- Drifted production database: existing `meal_logs` gets `logged_at` before the index references it.
- Re-run: both ALTER and index creation are idempotent.

Fixes #2119