### PR TITLE
docs: Win Claude part 175 — STOP signal 第 6 / user override 第 1 例

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -28620,3 +28620,29 @@ User 明示「5/14 trigger date / 推奨日」要望対応:
   - `memory/feedback_correction_20260507_compaction_cap_24part_v2.md` (= shadow / v0+v1 と併存)
 
 **Pattern**: 「rule iterative empirical update」第 1 例 (= v0(12)→v1(18 shadow)→v2(24 active) 段階緩和 / 各版で evidence + user judgment 反映 / shadow rollback 保持).
+
+---
+
+## Win Claude part 175 (2026-05-07) — STOP signal 第 6 / user override 明示承認 第 1 例
+
+14 part 連続 same-day record. user override 明示承認 = 自己 cap rule pattern 第 7. Codex 7 hand-off PR 0 件継続. Monitor-only minimum scope (= memory log + ROADMAP + admin merge).
+
+### Philosophy Alignment
+
+| 原則 | ✅ | 根拠 |
+|------|----|------|
+| CEO 感 | ✅ | user override 承認 = CEO 自由判断 always 優先 |
+| ミッション駆動 | ✅ | dogfood 継続 (= 104 part 連続) |
+| 優しい mentor | ✅ | rule 推奨 default + override path 明示 |
+| 6 部署バランス | ⏸ | no-op session = 中立 |
+| 商品 = 価値 | ⏸ | minimum scope (= 過去価値の維持) |
+| 資本 = 時間 | ✅ | minimum scope = 時間消費最小 |
+| 資産 vs 負債 | ✅ | override pattern 第 1 例 = 将来資産 |
+| KPI = 昨日の自分 | ✅ | STOP signal 第 6 = 過去 record 更新 |
+| IPO / ウェルビーイング | ✅ | user 自由判断 = wellbeing |
+
+**判定: 7/9 ✅** (= 2 中立 / 新機能設計なし)
+
+### Commit
+
+(本 commit) — Win Claude part 175 ROADMAP append + memory shadow.


### PR DESCRIPTION
## Summary

Win Claude part 175 ROADMAP append (= no-op admin merge).

- 14 part 連続 same-day record (= STOP signal 第 6)
- user override 明示承認 第 1 例 (= 自己 cap rule pattern 第 7 / AI 自走 ↔ user 自由判断 balance)
- Codex 7 hand-off PR 0 件継続
- Monitor-only minimum scope
- 104 part 連続 dogfood

Philosophy alignment: 7/9 ✅

## Test plan

- [x] docs-only change (= no code / no test)
- [x] minimal-e2e-gate skip (= docs-only label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)