### PR TITLE
fix: reduce false session safety warnings (#2105)

### DIFF
--- a/.github/workflows/codex-session-safety-cron.yml
+++ b/.github/workflows/codex-session-safety-cron.yml
@@ -51,14 +51,15 @@ jobs:
       - name: Run codex_session_check (JSON)
         id: check
         run: |
-          python scripts/codex_session_check.py --json > session_check.json
-          echo "Saved session_check.json ($(wc -c < session_check.json) bytes)"
+          SESSION_CHECK_JSON="$RUNNER_TEMP/session_check.json"
+          python scripts/codex_session_check.py --json > "$SESSION_CHECK_JSON"
+          echo "Saved session_check.json ($(wc -c < "$SESSION_CHECK_JSON") bytes)"
           # extract warning signals
-          BEHIND=$(jq -r '.behind // 0' session_check.json)
-          DIRTY=$(jq -r '.dirty_count // 0' session_check.json)
-          NB_STATE=$(jq -r '.notebooklm.state // "unknown"' session_check.json)
-          NB_COUNT=$(jq -r '.notebooklm.notebook_count // 0' session_check.json)
-          BC58_FOUND=$(jq -r '.notebooklm.harness_notebook_found // false' session_check.json)
+          BEHIND=$(jq -r '.behind // 0' "$SESSION_CHECK_JSON")
+          DIRTY=$(jq -r '.dirty_count // 0' "$SESSION_CHECK_JSON")
+          NB_STATE=$(jq -r '.notebooklm.state // "unknown"' "$SESSION_CHECK_JSON")
+          NB_COUNT=$(jq -r '.notebooklm.notebook_count // 0' "$SESSION_CHECK_JSON")
+          BC58_FOUND=$(jq -r '.notebooklm.harness_notebook_found // false' "$SESSION_CHECK_JSON")
 
           echo "behind=$BEHIND" >> $GITHUB_OUTPUT
           echo "dirty=$DIRTY" >> $GITHUB_OUTPUT
@@ -70,8 +71,8 @@ jobs:
           WARNINGS=()
           if [ "$BEHIND" -gt 50 ]; then WARNINGS+=("behind > 50 (= $BEHIND commits)"); fi
           if [ "$DIRTY" -gt 0 ]; then WARNINGS+=("dirty_count > 0 (= $DIRTY paths)"); fi
-          if [ "$NB_STATE" != "ok" ]; then WARNINGS+=("notebooklm state != ok (= $NB_STATE)"); fi
-          if [ "$BC58_FOUND" != "true" ]; then WARNINGS+=("bc58b50b harness notebook missing"); fi
+          if [ "$NB_STATE" != "ok" ] && [ "$NB_STATE" != "skipped_ci_unavailable" ]; then WARNINGS+=("notebooklm state != ok (= $NB_STATE)"); fi
+          if [ "$NB_STATE" = "ok" ] && [ "$BC58_FOUND" != "true" ]; then WARNINGS+=("bc58b50b harness notebook missing"); fi
 
           if [ ${#WARNINGS[@]} -eq 0 ]; then
             echo "has_warnings=false" >> $GITHUB_OUTPUT

--- a/scripts/codex_session_check.py
+++ b/scripts/codex_session_check.py
@@ -287,6 +287,10 @@ def notebooklm_snapshot(root: Path) -> dict[str, Any]:
     lowered = combined.lower()
     if result.code == 0:
         state = "ok"
+    elif result.code == 127 and os.environ.get("GITHUB_ACTIONS") == "true":
+        state = "skipped_ci_unavailable"
+        if not detail:
+            detail = "NotebookLM CLI is not installed on this GitHub Actions runner."
     elif result.code == 127:
         state = "unavailable"
     elif result.code == 124:
@@ -364,6 +368,8 @@ def analyze(cwd: Path) -> dict[str, Any]:
         warnings.append("NotebookLM CLI list hit a network/browser connection error")
     elif notebooklm["state"] == "error":
         warnings.append("NotebookLM CLI list failed")
+    elif notebooklm["state"] == "skipped_ci_unavailable":
+        pass
     elif not notebooklm["harness_notebook_found"]:
         warnings.append(
             "NotebookLM harness notebook bc58b50b-5fc4-4840-9a62-b397d6d3b65a was not found"

--- a/scripts/codex_session_check_test.py
+++ b/scripts/codex_session_check_test.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from codex_session_check import (
+    CommandResult,
     collect_remote_control_flags,
     is_remote_control_flag_path,
+    notebooklm_snapshot,
 )
 
 
@@ -69,6 +72,19 @@ class ClaudeRemoteControlDetectionTest(unittest.TestCase):
             flags = collect_remote_control_flags({"permissions": {"defaultMode": "bypassPermissions"}})
 
         self.assertEqual(flags, [])
+
+    def test_notebooklm_unavailable_is_skipped_on_github_actions(self) -> None:
+        with (
+            patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}),
+            patch(
+                "codex_session_check.run_command",
+                return_value=CommandResult(127, "", "notebooklm not found"),
+            ),
+        ):
+            snapshot = notebooklm_snapshot(Path("."))
+
+        self.assertEqual(snapshot["state"], "skipped_ci_unavailable")
+        self.assertFalse(snapshot["harness_notebook_found"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep codex-session-safety JSON output in `$RUNNER_TEMP` so the cron no longer counts its own `session_check.json` as an untracked dirty path
- treat NotebookLM CLI absence on GitHub Actions as a skipped hosted-runner check instead of a local auth/harness failure
- only warn about the bc58b50b harness when NotebookLM listing actually succeeds

## Verification
- `python scripts\codex_session_check_test.py`
- `git diff --check`

## Minimal E2E
The E2E test is implementation-detail independent.
The plan is minimal, about three I/O cases.
E2E mechanism: the scheduled session-safety workflow writes its probe JSON outside the checkout and derives warning outputs from that file.

Cases:
1. Clean GitHub Actions checkout writes JSON to `$RUNNER_TEMP` and keeps `dirty_count=0`.
2. Hosted runner without NotebookLM CLI reports `skipped_ci_unavailable` and does not open a NotebookLM warning issue.
3. Local runner with expired NotebookLM auth still reports the actionable auth-required warning.

Fixes #2105