### PR TITLE
ci: add Lefthook quality gate (#1596)

### DIFF
--- a/.github/workflows/minimal-e2e-gate.yml
+++ b/.github/workflows/minimal-e2e-gate.yml
@@ -52,6 +52,11 @@ jobs:
             "${{ github.event.pull_request.head.sha }}" \
             > .ci-logs/changed-files.txt
 
+      - name: Check hook bypass markers
+        run: >
+          python scripts/check_no_verify_bypass.py
+          --range "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
       - name: Check minimal E2E PR contract
         run: >
           python scripts/check_minimal_e2e_gate.py

--- a/docs/automation/local-quality-gates.md
+++ b/docs/automation/local-quality-gates.md
@@ -1,0 +1,87 @@
+# Local Quality Gates
+
+Issue: #1596
+
+This repository uses Lefthook to make local agent commits follow the same
+deterministic checks that GitHub Actions enforces.
+
+## Setup
+
+```powershell
+npm ci
+npm run hooks:install
+npm run hooks:validate
+```
+
+Lefthook installs scripts under `.git/hooks/`. Those generated files are local
+workspace state and must not be committed. The `hooks:install` script uses
+`lefthook install --force` so shared worktrees that already set
+`core.hooksPath` still receive the current hook definitions.
+
+## Hook Flow
+
+| Hook | Gate | Purpose |
+| --- | --- | --- |
+| `pre-commit` | `python scripts/pre_commit_quality_gate.py` | Runs Python smoke tests, Edge Function import checks, `flutter analyze`, and Deno lint, then stamps the Git tree only after the fast gate succeeds. |
+| `prepare-commit-msg` | `python scripts/no_verify_sentinel.py assert-pre-commit ...` | Blocks commits whose index did not pass `pre-commit`. This hook is not skipped by `git commit --no-verify`. |
+| `commit-msg` | `python scripts/check_no_verify_bypass.py --message-file ...` | Rejects explicit quality-gate bypass markers in commit messages. |
+| `pre-push` | `python scripts/quality_gate.py --full` | Adds formatting, VM tests, and Edge Function Deno tests before pushing. Browser smoke stays in GitHub Actions by default and can be opted in locally. |
+
+All Lefthook jobs use `parallel: false` on purpose. The gates are short enough
+that deterministic ordering is more useful than local parallelism: the
+`pre-commit` stamp must be written only after the fast gate succeeds, and
+`prepare-commit-msg` / `commit-msg` should fail with stable, readable output.
+
+## Commands
+
+```powershell
+npm run quality:fast
+npm run quality:full
+npm run quality:browser
+npm run quality:no-verify
+```
+
+`quality:fast` is the normal pre-commit path. `quality:full` is intentionally
+heavier and mirrors the PR CI path closely enough to catch failures before a
+branch leaves the machine. Local browser smoke is opt-in because Windows Chrome
+and Edge can fail inside editor-hosted agent sessions while the GitHub Actions
+browser runner remains stable:
+
+```powershell
+$env:CODEX_INCLUDE_BROWSER_SMOKE = '1'
+npm run quality:full
+```
+
+## No-Verify Policy
+
+Do not use `git commit --no-verify` or `LEFTHOOK=0` for project work. Do not add
+`Quality-Gate-Bypass:` or `Quality-Gate-Exception:` commit trailers; the CI
+range scanner treats both as forbidden bypass markers. The `prepare-commit-msg`
+hook requires a fresh pre-commit success stamp for the current Git tree, so a
+normal `--no-verify` commit is stopped locally. Git sequencer operations such as
+rebase, merge, cherry-pick, and revert are allowed to continue because they
+replay commits rather than create a new unchecked working-tree commit.
+
+If a hook itself is broken, open or update a GitHub issue and fix the hook in a
+small PR. Do not hide the failure in a product PR. For true emergency recovery,
+create a temporary local-only branch, repair the hook or failing check, then
+recommit normally before opening a PR.
+
+Exception requests are handled outside commit metadata: leave the reason, risk,
+and replacement validation evidence on the PR or issue, route the decision to
+Claude Code #1, then land a normal checked commit after the approved mitigation
+is in place.
+
+## Ownership
+
+- Claude Code #1 owns hook design, quality-gate scope, and exception policy.
+- Codex #1 owns cross-cutting implementation, CI/GitHub Actions wiring, Edge
+  Function checks, deterministic automation drift, and UI/browser verification.
+- GitHub Actions owns final merge-blocking evidence once required checks are
+  green.
+
+## PR Enforcement
+
+`.github/workflows/minimal-e2e-gate.yml` runs
+`scripts/check_no_verify_bypass.py` across the PR commit range. If a bypass
+marker reaches GitHub, the PR fails before review.

--- a/docs/automation/static-analysis-ci.md
+++ b/docs/automation/static-analysis-ci.md
@@ -11,10 +11,29 @@ pushes, and `workflow_call` deploy preflights:
 - `deno lint --config supabase/functions/deno.json supabase/functions/`
 - `dart format --output=none --set-exit-if-changed .`
 - VM tests, web import smoke tests, security checks, and production web build
+- `scripts/check_no_verify_bypass.py` through the Minimal E2E Gate workflow,
+  which fails PRs that carry local hook-bypass markers
 
 `analysis_options.yaml` defines Dart analyzer errors and lints. Formatting is now
 a hard gate instead of a warning so CI blocks merges when generated or manual
 Dart edits skip `dart format`.
+
+## Local Lefthook Mirror
+
+Local commits should install the same fast gate through Lefthook:
+
+```powershell
+npm ci
+npm run hooks:install
+npm run quality:fast
+```
+
+The local hook flow is documented in
+[`docs/automation/local-quality-gates.md`](local-quality-gates.md). In short,
+`pre-commit` runs the fast gate, `prepare-commit-msg` blocks
+`git commit --no-verify` by requiring a fresh pre-commit stamp, and `pre-push`
+runs the fuller local CI mirror. Browser smoke remains in GitHub Actions by
+default and can be included locally with `CODEX_INCLUDE_BROWSER_SMOKE=1`.
 
 ## Auto-Fix Path
 
@@ -31,9 +50,10 @@ analysis errors still fail visibly for manual correction.
 
 ## Agent Handoff
 
-- Codex #2 owns deterministic CI, formatting, and workflow automation changes.
-- Claude Code should run `claude ultrareview [target]` or `/ultrareview` for
-  high-risk architecture, auth, database, or production deploy changes.
+- Claude Code #1 owns high-risk architecture, auth, database, production deploy,
+  hook-scope, and exception-policy review.
+- Codex #1 owns deterministic CI, formatting, workflow automation, and scoped
+  implementation changes under the current two-instance development flow.
 - Codex in-app browser checks remain the default for UI-facing changes after a
   local dev server is available.
 - Automatic approval reviews are suitable for low-risk workflow or docs changes

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,26 @@
+min_version: 2.1.0
+skip_lfs: true
+
+pre-commit:
+  parallel: false
+  jobs:
+    - name: fast quality gate
+      run: python scripts/pre_commit_quality_gate.py
+
+prepare-commit-msg:
+  parallel: false
+  jobs:
+    - name: block no-verify bypass
+      run: python scripts/no_verify_sentinel.py assert-pre-commit --message-file "{1}" --source "{2}"
+
+commit-msg:
+  parallel: false
+  jobs:
+    - name: reject hook bypass markers
+      run: python scripts/check_no_verify_bypass.py --message-file "{1}"
+
+pre-push:
+  parallel: false
+  jobs:
+    - name: full quality gate
+      run: python scripts/quality_gate.py --full

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@playwright/test": "^1.59.1"
+        "@playwright/test": "^1.59.1",
+        "lefthook": "^2.1.6"
       }
     },
     "node_modules/@playwright/test": {
@@ -38,6 +39,169 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.6.tgz",
+      "integrity": "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "2.1.6",
+        "lefthook-darwin-x64": "2.1.6",
+        "lefthook-freebsd-arm64": "2.1.6",
+        "lefthook-freebsd-x64": "2.1.6",
+        "lefthook-linux-arm64": "2.1.6",
+        "lefthook-linux-x64": "2.1.6",
+        "lefthook-openbsd-arm64": "2.1.6",
+        "lefthook-openbsd-x64": "2.1.6",
+        "lefthook-windows-arm64": "2.1.6",
+        "lefthook-windows-x64": "2.1.6"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.6.tgz",
+      "integrity": "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.6.tgz",
+      "integrity": "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.6.tgz",
+      "integrity": "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.6.tgz",
+      "integrity": "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.6.tgz",
+      "integrity": "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.6.tgz",
+      "integrity": "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.6.tgz",
+      "integrity": "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.6.tgz",
+      "integrity": "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.6.tgz",
+      "integrity": "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.6.tgz",
+      "integrity": "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/playwright": {
       "version": "1.59.1",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,16 @@
     "e2e:smoke": "playwright test test/e2e/public_smoke.spec.ts",
     "e2e:visual": "playwright test test/e2e/visual_evidence.spec.ts",
     "workflow:guard": "python scripts/check_remote_synced.py --require-clean",
-    "workflow:blog-publish": "bash scripts/t1-dispatch.sh"
+    "workflow:blog-publish": "bash scripts/t1-dispatch.sh",
+    "hooks:install": "lefthook install --force",
+    "hooks:validate": "lefthook validate",
+    "quality:browser": "flutter test --platform chrome test/web_import_smoke_test.dart",
+    "quality:fast": "python scripts/quality_gate.py --fast",
+    "quality:full": "python scripts/quality_gate.py --full",
+    "quality:no-verify": "python scripts/check_no_verify_bypass.py --range HEAD~1..HEAD"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1"
+    "@playwright/test": "^1.59.1",
+    "lefthook": "^2.1.6"
   }
 }

--- a/scripts/check_no_verify_bypass.py
+++ b/scripts/check_no_verify_bypass.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Fail when commits or commit messages carry hook-bypass markers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+BYPASS_PATTERNS = (
+    r"Quality-Gate-Bypass\s*:",
+    r"Quality-Gate-Exception\s*:",
+    r"CODEX_ALLOW_HOOK_BYPASS",
+    r"\bLEFTHOOK=0\b",
+    r"\bgit\s+commit\b[^\n]*--no-verify\b",
+)
+
+
+def find_bypass_markers(text: str) -> list[str]:
+    markers: list[str] = []
+    for pattern in BYPASS_PATTERNS:
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            markers.append(pattern)
+    return markers
+
+
+def run_git_log(commit_range: str) -> str:
+    proc = subprocess.run(
+        ["git", "log", "--format=%B%x00", commit_range],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip(), file=sys.stderr)
+        return ""
+    return proc.stdout
+
+
+def event_range(payload: dict[str, Any]) -> str | None:
+    pr = payload.get("pull_request")
+    if isinstance(pr, dict):
+        base = pr.get("base", {})
+        head = pr.get("head", {})
+        if isinstance(base, dict) and isinstance(head, dict):
+            base_sha = base.get("sha")
+            head_sha = head.get("sha")
+            if isinstance(base_sha, str) and isinstance(head_sha, str):
+                return f"{base_sha}..{head_sha}"
+
+    before = payload.get("before")
+    after = payload.get("after")
+    if isinstance(before, str) and isinstance(after, str):
+        if before and after and not set(before) <= {"0"}:
+            return f"{before}..{after}"
+    return None
+
+
+def read_event(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    source = Path(path)
+    if not source.exists():
+        return {}
+    return json.loads(source.read_text(encoding="utf-8"))
+
+
+def read_message_file(path: str | None) -> str:
+    if not path:
+        return ""
+    source = Path(path)
+    if not source.exists():
+        return ""
+    return source.read_text(encoding="utf-8", errors="replace")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--message-file", help="Commit message file to inspect.")
+    parser.add_argument("--range", dest="commit_range", help="Git commit range to inspect.")
+    parser.add_argument("--github-event", help="GitHub event JSON path for deriving a range.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    text = read_message_file(args.message_file)
+
+    commit_range = args.commit_range
+    if not commit_range:
+        commit_range = event_range(read_event(args.github_event))
+    if commit_range:
+        text += "\n" + run_git_log(commit_range)
+    elif not text:
+        text = run_git_log("HEAD~1..HEAD")
+
+    markers = find_bypass_markers(text)
+    if markers:
+        print("Hook bypass marker detected. Recommit through Lefthook quality gates.")
+        for marker in markers:
+            print(f"- matched: {marker}")
+        return 1
+
+    print("No hook bypass markers detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_no_verify_bypass_test.py
+++ b/scripts/check_no_verify_bypass_test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+from check_no_verify_bypass import event_range, find_bypass_markers
+
+
+class NoVerifyBypassTest(unittest.TestCase):
+    def test_allows_normal_commit_message(self) -> None:
+        self.assertEqual(find_bypass_markers("fix: update CI gate"), [])
+
+    def test_detects_quality_gate_bypass_trailer(self) -> None:
+        markers = find_bypass_markers("Quality-Gate-Bypass: pre-commit-not-run")
+
+        self.assertTrue(markers)
+
+    def test_detects_quality_gate_exception_trailer(self) -> None:
+        markers = find_bypass_markers("Quality-Gate-Exception: emergency")
+
+        self.assertTrue(markers)
+
+    def test_detects_no_verify_command_text(self) -> None:
+        markers = find_bypass_markers("used git commit --no-verify during emergency")
+
+        self.assertTrue(markers)
+
+    def test_derives_pull_request_range(self) -> None:
+        payload = {
+            "pull_request": {
+                "base": {"sha": "base123"},
+                "head": {"sha": "head456"},
+            }
+        }
+
+        self.assertEqual(event_range(payload), "base123..head456")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/no_verify_sentinel.py
+++ b/scripts/no_verify_sentinel.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Require a successful pre-commit gate before Git prepares commit messages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+MAX_STAMP_AGE_SECONDS = 300
+GIT_OPERATION_MARKERS = (
+    "rebase-merge",
+    "rebase-apply",
+    "MERGE_HEAD",
+    "CHERRY_PICK_HEAD",
+    "REVERT_HEAD",
+    "sequencer",
+)
+
+
+def run_git(args: list[str]) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    return proc.stdout.strip()
+
+
+def current_tree() -> str:
+    return run_git(["write-tree"])
+
+
+def stamp_path() -> Path:
+    return Path(run_git(["rev-parse", "--git-path", "codex-quality/pre-commit-stamp.json"]))
+
+
+def git_path(name: str) -> Path:
+    return Path(run_git(["rev-parse", "--git-path", name]))
+
+
+def has_git_operation_state(
+    resolver: Callable[[str], Path] = git_path,
+) -> bool:
+    return any(resolver(marker).exists() for marker in GIT_OPERATION_MARKERS)
+
+
+def write_stamp(path: Path, tree: str, now: float | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "tree": tree,
+        "created_at": now if now is not None else time.time(),
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def read_stamp(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def stamp_matches(
+    payload: dict[str, Any] | None,
+    tree: str,
+    now: float | None = None,
+    max_age_seconds: int = MAX_STAMP_AGE_SECONDS,
+) -> bool:
+    if not payload:
+        return False
+    if payload.get("tree") != tree:
+        return False
+    created_at = payload.get("created_at")
+    if not isinstance(created_at, (int, float)):
+        return False
+    current_time = now if now is not None else time.time()
+    return 0 <= current_time - float(created_at) <= max_age_seconds
+
+
+def mark_pre_commit() -> int:
+    path = stamp_path()
+    tree = current_tree()
+    write_stamp(path, tree)
+    print(f"Marked pre-commit quality gate for tree {tree[:12]}.")
+    return 0
+
+
+def assert_pre_commit() -> int:
+    if has_git_operation_state():
+        return 0
+
+    path = stamp_path()
+    tree = current_tree()
+    if stamp_matches(read_stamp(path), tree):
+        return 0
+
+    print(
+        "Pre-commit quality gate did not run for this index. "
+        "Commit normally after `npm run hooks:install`; do not use `git commit --no-verify`.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    subcommands.add_parser("mark-pre-commit")
+    assert_parser = subcommands.add_parser("assert-pre-commit")
+    assert_parser.add_argument("--message-file", help="Git commit message file path.")
+    assert_parser.add_argument("--source", default="", help="Git prepare-commit-msg source.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.command == "mark-pre-commit":
+        return mark_pre_commit()
+    if args.command == "assert-pre-commit":
+        return assert_pre_commit()
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/no_verify_sentinel_test.py
+++ b/scripts/no_verify_sentinel_test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from no_verify_sentinel import (
+    assert_pre_commit,
+    has_git_operation_state,
+    read_stamp,
+    stamp_matches,
+    write_stamp,
+)
+
+
+class NoVerifySentinelTest(unittest.TestCase):
+    def test_stamp_matches_current_tree_and_age(self) -> None:
+        payload = {"tree": "abc123", "created_at": 100.0}
+
+        self.assertTrue(stamp_matches(payload, "abc123", now=120.0))
+
+    def test_rejects_stale_stamp(self) -> None:
+        payload = {"tree": "abc123", "created_at": 100.0}
+
+        self.assertFalse(stamp_matches(payload, "abc123", now=500.0))
+
+    def test_rejects_different_tree(self) -> None:
+        payload = {"tree": "abc123", "created_at": 100.0}
+
+        self.assertFalse(stamp_matches(payload, "def456", now=120.0))
+
+    def test_round_trips_stamp_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "stamp.json"
+            write_stamp(path, "tree789", now=100.0)
+
+            self.assertEqual(read_stamp(path), {"created_at": 100.0, "tree": "tree789"})
+
+    def test_allows_git_sequencer_operations(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "rebase-merge").mkdir()
+
+            self.assertTrue(has_git_operation_state(lambda name: root / name))
+
+    def test_assert_pre_commit_requires_matching_stamp(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            stamp = Path(temp_dir) / "stamp.json"
+            with (
+                patch("no_verify_sentinel.has_git_operation_state", return_value=False),
+                patch("no_verify_sentinel.stamp_path", return_value=stamp),
+                patch("no_verify_sentinel.current_tree", return_value="tree123"),
+            ):
+                self.assertEqual(assert_pre_commit(), 1)
+
+                write_stamp(stamp, "tree123")
+
+                self.assertEqual(assert_pre_commit(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pre_commit_quality_gate.py
+++ b/scripts/pre_commit_quality_gate.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Run the fast quality gate and stamp the Git tree only after success."""
+
+from __future__ import annotations
+
+import sys
+
+import no_verify_sentinel
+import quality_gate
+
+
+def main() -> int:
+    gate_code = quality_gate.main(["--fast"])
+    if gate_code != 0:
+        return gate_code
+    return no_verify_sentinel.mark_pre_commit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Run the local quality gates shared by Lefthook and humans."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GateCommand:
+    name: str
+    args: list[str]
+    required_binary: str | None = None
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def has_deno_tests(root: Path) -> bool:
+    return any((root / "supabase" / "functions").glob("**/*.test.ts"))
+
+
+def include_browser_smoke() -> bool:
+    if os.environ.get("CI", "").lower() == "true":
+        return True
+    return os.environ.get("CODEX_INCLUDE_BROWSER_SMOKE", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def base_commands() -> list[GateCommand]:
+    python = sys.executable
+    return [
+        GateCommand(
+            "minimal e2e gate tests",
+            [python, "scripts/check_minimal_e2e_gate_test.py"],
+        ),
+        GateCommand(
+            "no-verify bypass tests",
+            [python, "scripts/check_no_verify_bypass_test.py"],
+        ),
+        GateCommand(
+            "no-verify sentinel tests",
+            [python, "scripts/no_verify_sentinel_test.py"],
+        ),
+        GateCommand(
+            "edge function import check",
+            [python, "scripts/check_edge_function_imports.py"],
+        ),
+        GateCommand(
+            "github actions node runtime floor",
+            [python, "scripts/check_github_actions_node_runtime.py"],
+        ),
+    ]
+
+
+def fast_commands() -> list[GateCommand]:
+    return [
+        *base_commands(),
+        GateCommand("flutter analyze", ["flutter", "analyze"], "flutter"),
+        GateCommand(
+            "deno lint edge functions",
+            [
+                "deno",
+                "lint",
+                "--config",
+                "supabase/functions/deno.json",
+                "supabase/functions/",
+            ],
+            "deno",
+        ),
+    ]
+
+
+def full_commands(root: Path) -> list[GateCommand]:
+    commands = [
+        *fast_commands(),
+        GateCommand(
+            "dart format check",
+            ["dart", "format", "--output=none", "--set-exit-if-changed", "."],
+            "dart",
+        ),
+        GateCommand("flutter vm tests", ["flutter", "test", "--coverage"], "flutter"),
+    ]
+    if include_browser_smoke():
+        commands.append(
+            GateCommand(
+                "flutter web import smoke",
+                [
+                    "flutter",
+                    "test",
+                    "--platform",
+                    "chrome",
+                    "test/web_import_smoke_test.dart",
+                ],
+                "flutter",
+            )
+        )
+    if has_deno_tests(root):
+        commands.append(
+            GateCommand(
+                "deno test edge functions",
+                [
+                    "deno",
+                    "test",
+                    "--allow-all",
+                    "--no-check",
+                    "--config",
+                    "supabase/functions/deno.json",
+                    "supabase/functions/",
+                ],
+                "deno",
+            )
+        )
+    return commands
+
+
+def resolve_args(command: GateCommand) -> list[str] | None:
+    if command.required_binary is None:
+        return command.args
+    resolved = shutil.which(command.required_binary)
+    if resolved is None:
+        return None
+    return [resolved, *command.args[1:]]
+
+
+def command_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for key in (
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_PREFIX",
+        "GIT_QUARANTINE_PATH",
+        "GIT_WORK_TREE",
+        "CHROME_CRASHPAD_PIPE_NAME",
+    ):
+        env.pop(key, None)
+    return env
+
+
+def run_gate(command: GateCommand, root: Path) -> int:
+    print(f"==> {command.name}", flush=True)
+    resolved_args = resolve_args(command)
+    if resolved_args is None:
+        print(f"missing required command: {command.required_binary}", file=sys.stderr)
+        return 127
+    proc = subprocess.run(resolved_args, cwd=root, env=command_env(), check=False)
+    if proc.returncode != 0:
+        print(f"gate failed: {command.name} (exit {proc.returncode})", file=sys.stderr)
+    return proc.returncode
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--fast", action="store_true", help="Run pre-commit quality gates.")
+    mode.add_argument("--full", action="store_true", help="Run pre-push quality gates.")
+    mode.add_argument("--list", action="store_true", help="Print the commands without running them.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    root = repo_root()
+    commands = full_commands(root) if args.full else fast_commands()
+
+    if args.list:
+        for command in commands:
+            print(f"{command.name}: {' '.join(command.args)}")
+        return 0
+
+    for command in commands:
+        code = run_gate(command, root)
+        if code != 0:
+            return code
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- Adopt the stronger Lefthook quality-gate design from the older #1621 path into a fresh Codex #1 scoped branch.
- Add pre-commit stamping plus `prepare-commit-msg` enforcement so `git commit --no-verify` cannot silently skip the fast gate.
- Add commit-range bypass marker scanning to the Minimal E2E Gate and document the current Claude Code #1 + Codex #1 ownership model.
- Resolve the #1621/#1627 routing ambiguity by treating `Quality-Gate-Exception:` as a forbidden bypass marker and routing exception decisions through issue/PR evidence instead.

## Minimal E2E Gate
- The E2E test is implementation-detail independent.
- The plan is minimal, about three I/O cases.
- E2E mechanism: CLI-level hook policy checks plus the existing Minimal E2E Gate workflow inspect real commit messages/ranges and Lefthook configuration without depending on private app state.
- Cases: normal commit text passes marker scan, explicit bypass/exception marker fails marker scan, missing pre-commit stamp is rejected while sequencer operations remain allowed.
- Browser UI E2E is not applicable to this tooling-only change; the existing public smoke and visual evidence jobs still run in CI.

## Verification
- `python scripts\check_no_verify_bypass_test.py`
- `python scripts\no_verify_sentinel_test.py`
- `python -m py_compile scripts\check_no_verify_bypass.py scripts\check_no_verify_bypass_test.py scripts\no_verify_sentinel.py scripts\no_verify_sentinel_test.py scripts\pre_commit_quality_gate.py scripts\quality_gate.py`
- `python scripts\quality_gate.py --list`
- `npm ci --ignore-scripts --no-audit --fund=false`
- `npm run hooks:validate`
- `git diff --check HEAD~1..HEAD`

Closes #1596.
Supersedes #1621.
Supersedes #1627.