### PR TITLE
feat: add low-risk PR digestion automation (#1565)

### DIFF
--- a/.github/workflows/low-risk-pr-digestion.yml
+++ b/.github/workflows/low-risk-pr-digestion.yml
@@ -1,0 +1,107 @@
+name: Low-Risk PR Digestion
+
+on:
+  schedule:
+    - cron: "17 21 * * *"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional single PR number to classify"
+        required: false
+        type: string
+      comment_on_pr:
+        description: "Comment the report on the single PR"
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      max_prs:
+        description: "Open PRs to inspect in queue mode"
+        required: true
+        default: "20"
+        type: string
+      max_issues:
+        description: "Open Issues to inspect in queue mode"
+        required: true
+        default: "20"
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: low-risk-pr-digestion-${{ github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.inputs.pr_number }}
+      COMMENT_ON_PR: ${{ github.event.inputs.comment_on_pr || 'false' }}
+      MAX_PRS: ${{ github.event.inputs.max_prs || '20' }}
+      MAX_ISSUES: ${{ github.event.inputs.max_issues || '20' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Validate inputs
+        run: |
+          set -euo pipefail
+          if [ -n "${PR_NUMBER:-}" ] && ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number must be numeric when provided"
+            exit 1
+          fi
+          if ! [[ "$MAX_PRS" =~ ^[0-9]+$ ]] || ! [[ "$MAX_ISSUES" =~ ^[0-9]+$ ]]; then
+            echo "::error::max_prs and max_issues must be numeric"
+            exit 1
+          fi
+
+      - name: Classify low-risk queue
+        run: |
+          set -euo pipefail
+          args=(
+            --repo "$GITHUB_REPOSITORY"
+            --max-prs "$MAX_PRS"
+            --max-issues "$MAX_ISSUES"
+            --output-md /tmp/low-risk-pr-digest.md
+            --output-json /tmp/low-risk-pr-digest.json
+          )
+          if [ -n "${PR_NUMBER:-}" ]; then
+            args+=(--pr-number "$PR_NUMBER")
+          fi
+          python scripts/low_risk_pr_digest.py "${args[@]}"
+
+      - name: Write job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f /tmp/low-risk-pr-digest.md ]; then
+            cat /tmp/low-risk-pr-digest.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Low-risk PR digestion did not produce a report." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload digest artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: low-risk-pr-digest-${{ github.run_id }}
+          path: |
+            /tmp/low-risk-pr-digest.md
+            /tmp/low-risk-pr-digest.json
+          if-no-files-found: ignore
+
+      - name: Comment on single PR
+        if: success() && env.PR_NUMBER != '' && env.COMMENT_ON_PR == 'true'
+        run: |
+          set -euo pipefail
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file /tmp/low-risk-pr-digest.md

--- a/docs/automation/low-risk-pr-digestion.md
+++ b/docs/automation/low-risk-pr-digestion.md
@@ -1,0 +1,74 @@
+# Low-Risk PR Digestion
+
+Issue: #1565
+
+This workflow turns "small enough to automate" work into a visible queue, not an
+auto-merge path. It supports the current two-instance flow:
+
+- Claude Code #1 owns boundaries, exception policy, and high-risk judgment.
+- Codex #1 owns the classifier implementation, workflow wiring, and scoped PRs.
+- GitHub Actions owns evidence artifacts and required checks.
+
+## Candidate Conditions
+
+A PR can be marked as a low-risk digestion candidate only when all of these are
+true:
+
+- changed files are limited to docs, deterministic check scripts, tests,
+  selected WBS/Issue workflows, dependency metadata, or Dependabot config;
+- file count is 12 or less and total churn is 600 lines or less;
+- labels and title/body do not mention high-risk areas;
+- the PR is not a draft;
+- required checks still run before review.
+
+Issues can be listed as candidates only when they carry a low-risk label such as
+`documentation`, `docs`, `dependencies`, `dependabot`, `automation`, or `wbs`
+and do not contain high-risk keywords.
+
+## Stop Conditions
+
+Autonomous digestion stops immediately for:
+
+- secrets, credentials, tokens, auth, payment, billing, Stripe, subscriptions;
+- database migrations, RLS, `service_role`, Supabase Edge Functions;
+- production deploy, Firebase deploy, release tags, Slack/notification delivery;
+- mobile release, legal, tax, or business-owner decisions;
+- unclassified file paths, more than 12 files, large churn, or draft PRs.
+
+Stopped items must be routed back to Claude Code #1 or the user before any patch
+is attempted.
+
+## Evidence Contract
+
+Every autonomous report or scoped PR must include:
+
+- source Issue or PR number;
+- changed-file scope;
+- candidate evidence and stop reasons;
+- required checks that must pass;
+- explicit merge policy: `human_approval_required`.
+
+The automation may comment with a low-risk review summary, but it never calls
+`gh pr review --approve`, never merges, and never pushes to protected branches.
+
+## Workflow
+
+`Low-Risk PR Digestion` runs in two modes:
+
+- scheduled queue scan: classify recent open PRs and Issues, then upload a
+  Markdown/JSON artifact and write the job summary;
+- manual single-PR scan: classify one PR and optionally comment the report on
+  that PR.
+
+The report complements `pr-review-routing.yml`: review routing handles existing
+review comments, while low-risk digestion decides whether a small PR/Issue is
+safe enough for autonomous attention.
+
+## Local Commands
+
+```powershell
+python scripts\low_risk_pr_digest_test.py
+$outMd = Join-Path $env:TEMP 'low-risk-pr-digest.md'
+$outJson = Join-Path $env:TEMP 'low-risk-pr-digest.json'
+python scripts\low_risk_pr_digest.py --repo kanta13jp1/my_web_app --max-prs 2 --max-issues 2 --output-md $outMd --output-json $outJson
+```

--- a/docs/automation/pr-review-routing.md
+++ b/docs/automation/pr-review-routing.md
@@ -36,5 +36,7 @@ later Codex or Claude Code session can continue from the same evidence.
 - #1557 clusters CI failures and duplicate workflow-failure Issues.
 - #1637 evaluates issue digests and backlog shape.
 - #1559 routes Claude Code/Codex changelog changes into automation.
+- #1565 classifies low-risk PR/Issue candidates before any autonomous review
+  comment is posted.
 - #1685 only routes PR review comments and requested changes into repair or
   handoff queues.

--- a/scripts/low_risk_pr_digest.py
+++ b/scripts/low_risk_pr_digest.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Classify low-risk PR/Issue candidates without approving or merging them."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+MAX_LOW_RISK_FILES = 12
+MAX_LOW_RISK_CHURN = 600
+
+LOW_RISK_LABELS = {
+    "documentation",
+    "docs",
+    "dependencies",
+    "dependabot",
+    "automation",
+    "wbs",
+}
+
+HIGH_RISK_LABELS = {
+    "security",
+    "supabase",
+    "edge-function",
+    "mobile",
+    "workflow-failure",
+    "priority:critical",
+}
+
+LOW_RISK_PATH_PATTERNS = (
+    r"^docs/",
+    r"^test/",
+    r"^scripts/[^/]+_test\.py$",
+    r"^scripts/check_[^/]+\.py$",
+    r"^scripts/.*_gate(_test)?\.py$",
+    r"^\.github/workflows/(minimal-e2e-gate|pr-review-routing|wbs-[^/]+|issue-[^/]+)\.yml$",
+    r"^\.github/dependabot\.yml$",
+    r"^package(-lock)?\.json$",
+    r"^requirements\.txt$",
+)
+
+HIGH_RISK_PATH_PATTERNS = (
+    r"^supabase/migrations/",
+    r"^supabase/functions/",
+    r"^lib/(auth|billing|payments|subscription|firebase|supabase)/",
+    r"^\.github/workflows/(deploy|.*deploy.*|ci-auto-fix|claude-agent-review).*\.yml$",
+    r"^firebase\.json$",
+    r"^firestore\.",
+    r"^storage\.",
+    r"(^|/)\.env",
+    r"secret",
+    r"credential",
+    r"service[_-]?role",
+    r"rls",
+)
+
+HIGH_RISK_TEXT_PATTERNS = (
+    r"\bsecret\b",
+    r"\bcredential\b",
+    r"\btoken\b",
+    r"\bauth\b",
+    r"\bpayment\b",
+    r"\bbilling\b",
+    r"\bstripe\b",
+    r"\bsubscription\b",
+    r"\bproduction\b",
+    r"\bdeploy\b",
+    r"\bmigration\b",
+    r"\brls\b",
+    r"\bservice[_ -]?role\b",
+    r"\blegal\b",
+    r"\btax\b",
+)
+
+
+def norm_path(path: str) -> str:
+    return path.replace("\\", "/").lstrip("./")
+
+
+def matches_any(patterns: tuple[str, ...], value: str) -> bool:
+    return any(re.search(pattern, value, flags=re.IGNORECASE) for pattern in patterns)
+
+
+def label_names(raw_labels: list[dict[str, Any]] | list[str] | None) -> set[str]:
+    names: set[str] = set()
+    for label in raw_labels or []:
+        if isinstance(label, str):
+            names.add(label.lower())
+        elif isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str):
+                names.add(name.lower())
+    return names
+
+
+def file_paths(files: list[dict[str, Any]] | list[str] | None) -> list[str]:
+    paths: list[str] = []
+    for item in files or []:
+        if isinstance(item, str):
+            paths.append(norm_path(item))
+        elif isinstance(item, dict):
+            path = item.get("path") or item.get("filename")
+            if isinstance(path, str):
+                paths.append(norm_path(path))
+    return paths
+
+
+def file_churn(files: list[dict[str, Any]] | None, additions: int = 0, deletions: int = 0) -> int:
+    churn = 0
+    for item in files or []:
+        if not isinstance(item, dict):
+            continue
+        churn += int(item.get("additions") or 0) + int(item.get("deletions") or 0)
+    return churn if churn else additions + deletions
+
+
+def classify_paths(paths: list[str]) -> tuple[str, list[str], list[str]]:
+    stop_reasons: list[str] = []
+    evidence: list[str] = []
+    if not paths:
+        return "medium", ["No changed files were available for classification."], evidence
+    if len(paths) > MAX_LOW_RISK_FILES:
+        stop_reasons.append(f"Changed file count {len(paths)} exceeds {MAX_LOW_RISK_FILES}.")
+
+    unknown_paths: list[str] = []
+    for path in paths:
+        if matches_any(HIGH_RISK_PATH_PATTERNS, path):
+            stop_reasons.append(f"High-risk path: {path}")
+        elif matches_any(LOW_RISK_PATH_PATTERNS, path):
+            evidence.append(f"Low-risk path: {path}")
+        else:
+            unknown_paths.append(path)
+
+    if unknown_paths:
+        stop_reasons.append("Unclassified paths require manual review: " + ", ".join(unknown_paths[:8]))
+
+    return ("low" if not stop_reasons else "high"), stop_reasons, evidence
+
+
+def classify_pr(pr: dict[str, Any]) -> dict[str, Any]:
+    labels = label_names(pr.get("labels"))
+    paths = file_paths(pr.get("files"))
+    churn = file_churn(
+        pr.get("files") if isinstance(pr.get("files"), list) else [],
+        int(pr.get("additions") or 0),
+        int(pr.get("deletions") or 0),
+    )
+    risk, stop_reasons, evidence = classify_paths(paths)
+    text = f"{pr.get('title', '')}\n{pr.get('body', '')}"
+
+    if labels & HIGH_RISK_LABELS:
+        stop_reasons.append("High-risk labels: " + ", ".join(sorted(labels & HIGH_RISK_LABELS)))
+    if matches_any(HIGH_RISK_TEXT_PATTERNS, text):
+        stop_reasons.append("Title/body contains high-risk keywords.")
+    if churn > MAX_LOW_RISK_CHURN:
+        stop_reasons.append(f"Churn {churn} exceeds {MAX_LOW_RISK_CHURN}.")
+    if pr.get("isDraft"):
+        stop_reasons.append("Draft PRs are not autonomous-review candidates.")
+
+    low_label_evidence = sorted(labels & LOW_RISK_LABELS)
+    if low_label_evidence:
+        evidence.append("Low-risk labels: " + ", ".join(low_label_evidence))
+
+    final_risk = "low" if risk == "low" and not stop_reasons else "high"
+    return {
+        "kind": "pull_request",
+        "number": pr.get("number"),
+        "title": pr.get("title", ""),
+        "url": pr.get("url", ""),
+        "risk": final_risk,
+        "candidate": final_risk == "low",
+        "changed_files": paths,
+        "churn": churn,
+        "evidence": evidence,
+        "stop_reasons": stop_reasons,
+        "required_checks": [
+            "CI / Lint, Format, and Test",
+            "Security Check",
+            "Minimal E2E Gate",
+            "AI Agent Code Review",
+        ],
+        "allowed_action": "comment_only_autonomous_review",
+        "merge_policy": "human_approval_required",
+    }
+
+
+def classify_issue(issue: dict[str, Any]) -> dict[str, Any]:
+    labels = label_names(issue.get("labels"))
+    text = f"{issue.get('title', '')}\n{issue.get('body', '')}"
+    stop_reasons: list[str] = []
+    evidence: list[str] = []
+    if labels & HIGH_RISK_LABELS:
+        stop_reasons.append("High-risk labels: " + ", ".join(sorted(labels & HIGH_RISK_LABELS)))
+    if matches_any(HIGH_RISK_TEXT_PATTERNS, text):
+        stop_reasons.append("Title/body contains high-risk keywords.")
+    if labels & LOW_RISK_LABELS:
+        evidence.append("Low-risk labels: " + ", ".join(sorted(labels & LOW_RISK_LABELS)))
+    else:
+        stop_reasons.append("No low-risk routing label is present.")
+    return {
+        "kind": "issue",
+        "number": issue.get("number"),
+        "title": issue.get("title", ""),
+        "url": issue.get("url", ""),
+        "risk": "low" if not stop_reasons else "high",
+        "candidate": not stop_reasons,
+        "evidence": evidence,
+        "stop_reasons": stop_reasons,
+        "allowed_action": "open_scoped_pr_with_evidence",
+        "merge_policy": "human_approval_required",
+    }
+
+
+def run_gh_json(args: list[str]) -> Any:
+    proc = subprocess.run(
+        ["gh", *args],
+        text=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "gh command failed")
+    text = proc.stdout.strip()
+    return json.loads(text) if text else {}
+
+
+def fetch_pr(repo: str, number: int) -> dict[str, Any]:
+    return run_gh_json(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,url,labels,files,additions,deletions,isDraft,headRefName",
+        ]
+    )
+
+
+def fetch_open_prs(repo: str, limit: int) -> list[dict[str, Any]]:
+    items = run_gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number",
+        ]
+    )
+    return [fetch_pr(repo, int(item["number"])) for item in items]
+
+
+def fetch_open_issues(repo: str, limit: int) -> list[dict[str, Any]]:
+    return run_gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,body,url,labels",
+        ]
+    )
+
+
+def read_json(path: str | None, default: Any) -> Any:
+    if not path:
+        return default
+    source = Path(path)
+    if not source.exists():
+        return default
+    return json.loads(source.read_text(encoding="utf-8"))
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Low-Risk PR Digestion Report",
+        "",
+        f"- Repository: `{report['repo']}`",
+        f"- Generated: `{report['generated_at']}`",
+        f"- Mode: `{report['mode']}`",
+        "- Autonomous action: comment/report only; never approve, merge, or push to protected branches.",
+        "",
+        "## Pull Requests",
+        "",
+    ]
+    pr_items = report.get("pull_requests", [])
+    if not pr_items:
+        lines.append("- None inspected.")
+    for item in pr_items:
+        mark = "candidate" if item["candidate"] else "blocked"
+        lines.append(f"- PR #{item['number']} {mark}: {item['title']}")
+        lines.append(f"  - Risk: `{item['risk']}`")
+        lines.append(f"  - Merge policy: `{item['merge_policy']}`")
+        if item.get("changed_files"):
+            lines.append("  - Scope: " + ", ".join(f"`{path}`" for path in item["changed_files"][:10]))
+        if item["evidence"]:
+            lines.append("  - Evidence: " + " / ".join(item["evidence"][:4]))
+        if item["stop_reasons"]:
+            lines.append("  - Stop reasons: " + " / ".join(item["stop_reasons"][:4]))
+        lines.append("  - Required checks: " + ", ".join(f"`{check}`" for check in item["required_checks"]))
+
+    lines.extend(["", "## Issues", ""])
+    issue_items = report.get("issues", [])
+    if not issue_items:
+        lines.append("- None inspected.")
+    for item in issue_items:
+        mark = "candidate" if item["candidate"] else "blocked"
+        lines.append(f"- Issue #{item['number']} {mark}: {item['title']}")
+        lines.append(f"  - Risk: `{item['risk']}`")
+        if item["evidence"]:
+            lines.append("  - Evidence: " + " / ".join(item["evidence"][:4]))
+        if item["stop_reasons"]:
+            lines.append("  - Stop reasons: " + " / ".join(item["stop_reasons"][:4]))
+
+    lines.extend(
+        [
+            "",
+            "## Stop Conditions",
+            "",
+            "- Any secret, auth, payment, billing, RLS, service_role, migration, Supabase function, production deploy, legal, or tax signal stops autonomous digestion.",
+            "- Draft PRs, unclassified file paths, large churn, or more than 12 changed files require Claude Code #1 or user routing.",
+            "- Candidate PRs may receive an autonomous comment with evidence, but human approval remains required before merge.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr-number", type=int)
+    parser.add_argument("--max-prs", type=int, default=20)
+    parser.add_argument("--max-issues", type=int, default=20)
+    parser.add_argument("--prs-json", help="Offline PR JSON fixture.")
+    parser.add_argument("--issues-json", help="Offline Issue JSON fixture.")
+    parser.add_argument("--output-md", default="/tmp/low-risk-pr-digest.md")
+    parser.add_argument("--output-json", default="/tmp/low-risk-pr-digest.json")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.prs_json:
+        prs = read_json(args.prs_json, [])
+    elif args.pr_number:
+        prs = [fetch_pr(args.repo, args.pr_number)]
+    else:
+        prs = fetch_open_prs(args.repo, args.max_prs)
+
+    issues = read_json(args.issues_json, None)
+    if issues is None:
+        issues = [] if args.pr_number else fetch_open_issues(args.repo, args.max_issues)
+
+    report = {
+        "repo": args.repo,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "mode": "single-pr" if args.pr_number else "queue",
+        "pull_requests": [classify_pr(item) for item in prs],
+        "issues": [classify_issue(item) for item in issues],
+    }
+    output_json = Path(args.output_json)
+    output_md = Path(args.output_md)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    output_md.write_text(render_markdown(report), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "pull_requests": len(report["pull_requests"]),
+                "pr_candidates": sum(1 for item in report["pull_requests"] if item["candidate"]),
+                "issues": len(report["issues"]),
+                "issue_candidates": sum(1 for item in report["issues"] if item["candidate"]),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/low_risk_pr_digest_test.py
+++ b/scripts/low_risk_pr_digest_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+from low_risk_pr_digest import classify_issue, classify_pr
+
+
+class LowRiskPrDigestTest(unittest.TestCase):
+    def test_docs_only_pr_is_candidate(self) -> None:
+        result = classify_pr(
+            {
+                "number": 1,
+                "title": "docs: update runbook",
+                "labels": [{"name": "documentation"}],
+                "files": [{"path": "docs/automation/example.md", "additions": 12, "deletions": 2}],
+            }
+        )
+
+        self.assertTrue(result["candidate"])
+        self.assertEqual(result["risk"], "low")
+
+    def test_migration_path_blocks_candidate(self) -> None:
+        result = classify_pr(
+            {
+                "number": 2,
+                "title": "fix migration",
+                "labels": [{"name": "automation"}],
+                "files": [{"path": "supabase/migrations/20260501000000_change.sql"}],
+            }
+        )
+
+        self.assertFalse(result["candidate"])
+        self.assertTrue(any("High-risk path" in reason for reason in result["stop_reasons"]))
+
+    def test_workflow_with_secrets_keyword_blocks_candidate(self) -> None:
+        result = classify_pr(
+            {
+                "number": 3,
+                "title": "ci: adjust secret deploy",
+                "labels": [{"name": "automation"}],
+                "files": [{"path": ".github/workflows/deploy-prod.yml"}],
+            }
+        )
+
+        self.assertFalse(result["candidate"])
+        self.assertGreaterEqual(len(result["stop_reasons"]), 2)
+
+    def test_large_file_count_blocks_candidate(self) -> None:
+        result = classify_pr(
+            {
+                "number": 4,
+                "title": "docs: bulk update",
+                "labels": [{"name": "documentation"}],
+                "files": [{"path": f"docs/bulk/{idx}.md"} for idx in range(13)],
+            }
+        )
+
+        self.assertFalse(result["candidate"])
+        self.assertTrue(any("Changed file count" in reason for reason in result["stop_reasons"]))
+
+    def test_low_risk_issue_requires_low_risk_label(self) -> None:
+        result = classify_issue(
+            {
+                "number": 5,
+                "title": "Document a workflow",
+                "labels": [{"name": "documentation"}],
+            }
+        )
+
+        self.assertTrue(result["candidate"])
+
+    def test_secret_issue_is_not_candidate(self) -> None:
+        result = classify_issue(
+            {
+                "number": 6,
+                "title": "Rotate production secret",
+                "labels": [{"name": "documentation"}],
+            }
+        )
+
+        self.assertFalse(result["candidate"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `scripts/low_risk_pr_digest.py` and tests to classify low-risk PR/Issue candidates with explicit stop reasons, required checks, and human-approval merge policy.
- Add scheduled/manual `low-risk-pr-digestion.yml` that produces Markdown/JSON artifacts and optional single-PR comments without approving, merging, or pushing.
- Document #1565 boundaries for the current Claude Code #1 + Codex #1 two-instance flow and link it from PR review routing docs.

## Minimal E2E Gate
- The E2E test is implementation-detail independent.
- The plan is minimal, about three I/O cases.
- E2E mechanism: CLI-level classifier tests plus a real GitHub-data smoke exercise candidate/blocked outputs without depending on private app state.
- Cases: docs-only PR is a low-risk candidate, migration/workflow-secret signals are blocked, large file count and secret Issues stop autonomous digestion.
- Browser UI E2E is not applicable to this automation/reporting-only change; the existing public smoke and visual evidence jobs still run in CI.

## Verification
- `python scripts\low_risk_pr_digest_test.py`
- `python -m py_compile scripts\low_risk_pr_digest.py scripts\low_risk_pr_digest_test.py`
- `python scripts\low_risk_pr_digest.py --repo kanta13jp1/my_web_app --max-prs 2 --max-issues 2 --output-md $env:TEMP\low-risk-pr-digest-smoke.md --output-json $env:TEMP\low-risk-pr-digest-smoke.json`
- `git diff --check HEAD~1..HEAD`

Closes #1565.