### PR TITLE
[codex] Add WBS role harness

### DIFF
--- a/.github/workflows/wbs-role-harness.yml
+++ b/.github/workflows/wbs-role-harness.yml
@@ -1,0 +1,124 @@
+name: WBS Role Harness
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Optional single Issue number to classify"
+        required: false
+        type: string
+      query:
+        description: "Issue search query used when issue_number is empty"
+        required: true
+        default: "label:priority:high label:wbs"
+        type: string
+      max_issues:
+        description: "Open Issues to inspect in queue mode"
+        required: true
+        default: "10"
+        type: string
+      comment_on_issue:
+        description: "Comment the report on the single Issue"
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+  pull_request:
+    paths:
+      - ".github/workflows/wbs-role-harness.yml"
+      - "docs/WBS_2_INSTANCE_ROUTING.md"
+      - "docs/automation/wbs-role-harness.md"
+      - "scripts/wbs_role_harness.py"
+      - "scripts/wbs_role_harness_test.py"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: wbs-role-harness-${{ inputs.issue_number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
+      QUERY: ${{ inputs.query || 'label:priority:high label:wbs' }}
+      MAX_ISSUES: ${{ inputs.max_issues || '10' }}
+      COMMENT_ON_ISSUE: ${{ inputs.comment_on_issue || 'false' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${ISSUE_NUMBER:-}" ] && ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::issue_number must be numeric when provided"
+            exit 1
+          fi
+          if ! [[ "$MAX_ISSUES" =~ ^[0-9]+$ ]]; then
+            echo "::error::max_issues must be numeric"
+            exit 1
+          fi
+          if [ -z "${ISSUE_NUMBER:-}" ] && [ -z "${QUERY:-}" ]; then
+            echo "::error::query is required when issue_number is empty"
+            exit 1
+          fi
+
+      - name: Run harness unit tests
+        run: python scripts/wbs_role_harness_test.py
+
+      - name: Generate role harness report
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tmp
+          args=(
+            --repo "$GITHUB_REPOSITORY"
+            --output-md tmp/wbs-role-harness.md
+            --output-json tmp/wbs-role-harness.json
+          )
+          if [ -n "${ISSUE_NUMBER:-}" ]; then
+            args+=(--issue-number "$ISSUE_NUMBER")
+          else
+            args+=(--query "$QUERY" --max-issues "$MAX_ISSUES")
+          fi
+          python scripts/wbs_role_harness.py "${args[@]}"
+
+      - name: Write job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f tmp/wbs-role-harness.md ]; then
+            cat tmp/wbs-role-harness.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "WBS role harness did not produce a report." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload role harness artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: wbs-role-harness-${{ github.run_id }}
+          path: |
+            tmp/wbs-role-harness.md
+            tmp/wbs-role-harness.json
+          if-no-files-found: ignore
+
+      - name: Comment on single Issue
+        if: success() && env.ISSUE_NUMBER != '' && env.COMMENT_ON_ISSUE == 'true'
+        run: gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file tmp/wbs-role-harness.md

--- a/docs/WBS_2_INSTANCE_ROUTING.md
+++ b/docs/WBS_2_INSTANCE_ROUTING.md
@@ -3,6 +3,7 @@
 Last updated: 2026-05-07
 
 Canonical delegation protocol: [`docs/AGENT_DELEGATION_PROTOCOL.md`](./AGENT_DELEGATION_PROTOCOL.md).
+Role harness report: [`docs/automation/wbs-role-harness.md`](./automation/wbs-role-harness.md).
 
 The WBS screen keeps historical `instance` and `owner_instance` values intact, but the active operating view is now projected into two human-operated development lanes:
 
@@ -26,4 +27,7 @@ WBS execution policy:
 4. For Claude Code-owned design tasks, create the spec or decision note first, then hand implementation to Codex only when code changes are clear.
 5. Every handoff must include Issue/WBS id, branch, worktree, allowed write set, prohibited write set, validation command, unresolved risk, and the next owner.
 6. Every session must include a cheap memory/disk hygiene check before wrap-up.
+7. Use `scripts/wbs_role_harness.py` to classify high-priority WBS Issues into
+   `single_scoped_pr`, `multi_pr_or_claude_first`, or
+   `blocked_until_owner_decision` before opening a scoped PR.
 

--- a/docs/automation/wbs-role-harness.md
+++ b/docs/automation/wbs-role-harness.md
@@ -1,0 +1,95 @@
+# WBS Role Harness
+
+Issue: #1636
+
+This harness turns a WBS/GitHub Issue into a fixed two-instance execution
+packet. It does not add more local agents. Historical mentions of Codex #2,
+Codex #3/#4, VSCode, Win, or PS lanes are treated as routing context only.
+
+Active execution lanes:
+
+- Claude Code #1 owns architecture, boundary decisions, exception policy, and
+  high-risk review.
+- Codex #1 owns fresh-worktree implementation, local verification, scoped PRs,
+  CI follow-through, merge, and cleanup.
+- GitHub Actions owns evidence artifacts, required checks, and deploy status.
+- User/Automation owns manual decisions, blocked states, and schedule-only work.
+
+## Classification
+
+`scripts/wbs_role_harness.py` classifies each Issue into one of these plans:
+
+- `automation_wbs`: Codex #1 opens a single scoped PR for scripts, workflows,
+  WBS docs, and evidence wiring.
+- `ui_validation`: Codex #1 owns the implementation PR and captures visual/E2E
+  evidence.
+- `scoped_implementation`: Codex #1 owns one narrow PR and normal tests.
+- `data_or_security`: Claude Code #1 writes or approves the design packet before
+  Codex touches migrations, RLS, service-role paths, or Edge Functions.
+- `claude_first`: Claude Code #1 starts with docs/ADR/review because the safe
+  implementation boundary is not yet clear.
+- `blocked_or_manual`: User/Automation must resolve the blocker before a PR.
+
+The script sorts generated plans by the first explicit due/deadline date it can
+find in the Issue body or comments. When WBS due dates are only visible in the
+WBS UI, pass the nearest Issue number explicitly.
+
+## Handoff Packet
+
+Every packet must include:
+
+- Issue/WBS id
+- branch
+- worktree
+- allowed write set
+- prohibited write set
+- validation command
+- unresolved risk
+- next owner
+
+The packet returns to Claude Code #1 when the task touches security, auth,
+payments, legal/tax decisions, migrations, RLS, `service_role`, Supabase Edge
+Functions, unclear ownership, or High conflict risk.
+
+## Conflict Rules
+
+- Start from a fresh task worktree based on latest `origin/main`.
+- Record planned paths before editing.
+- Use `scripts/worktree_registry.py preflight` for planned or staged paths.
+- Use `scripts/instance_conflict_predictor.py` when shared workflows,
+  migrations, or cross-instance docs are involved.
+- Stop and hand off to Claude Code #1 on High conflict risk.
+
+## Evidence Targets
+
+- PR body Minimal E2E Gate section
+- GitHub Actions report artifact
+- Issue closing comment or linked merged PR
+- WBS status/progress note when the Issue is not auto-closed
+- CI run URL, deploy run URL, and cleanup confirmation
+
+## Resource Hygiene
+
+Every session must record:
+
+- C drive free space before and after work
+- top memory processes before and after work
+- leftover dev server, dart, node, and git process check
+- branch/worktree state before and after work
+
+After merge, remove the task worktree, prune worktrees, run `git gc --auto`,
+and avoid leaving task-local dependency caches such as `node_modules`.
+
+## Local Commands
+
+```powershell
+python scripts\wbs_role_harness_test.py
+
+$outMd = Join-Path $env:TEMP 'wbs-role-harness.md'
+$outJson = Join-Path $env:TEMP 'wbs-role-harness.json'
+python scripts\wbs_role_harness.py `
+  --repo kanta13jp1/my_web_app `
+  --issue-number 1636 `
+  --output-md $outMd `
+  --output-json $outJson
+```

--- a/scripts/wbs_role_harness.py
+++ b/scripts/wbs_role_harness.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""Generate a two-instance execution plan for WBS/GitHub Issue tasks."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROLE_TEMPLATES = [
+    {
+        "role": "Claude Code #1",
+        "owns": "architecture, boundary decisions, exception policy, high-risk review",
+        "may_write": [
+            "docs/architecture/",
+            "docs/adr/",
+            "docs/issue-fix-plans/",
+            "review comments and handoff packets",
+        ],
+        "must_not_write": [
+            "Codex #1 task worktree files while implementation is in progress",
+            "production deploy changes without an explicit design note",
+        ],
+    },
+    {
+        "role": "Codex #1",
+        "owns": "fresh worktree, scoped implementation, local verification, PR/deploy follow-through",
+        "may_write": [
+            "issue-scoped scripts/docs/tests/workflows",
+            "the task branch and PR body",
+            "cleanup notes after merge",
+        ],
+        "must_not_write": [
+            "dirty primary-worktree files",
+            "Claude Code #1 worktrees",
+            "secrets or local credentials",
+        ],
+    },
+    {
+        "role": "GitHub Actions",
+        "owns": "required checks, artifacts, deploy result, non-agent evidence",
+        "may_write": [
+            "job summary",
+            "uploaded artifacts",
+            "optional issue or PR comment when explicitly enabled",
+        ],
+        "must_not_write": [
+            "protected branches",
+            "approval or merge decisions",
+        ],
+    },
+    {
+        "role": "User/Automation",
+        "owns": "manual decisions, schedule-only work, blocked-item routing",
+        "may_write": [
+            "WBS status and owner decisions",
+            "requested manual approvals",
+        ],
+        "must_not_write": [
+            "implementation patches without a human-operated instance owner",
+        ],
+    },
+]
+
+CLAUDE_KEYWORDS = (
+    r"\barchitecture\b",
+    r"\bdesign\b",
+    r"\breview\b",
+    r"\bsecurity\b",
+    r"\bauth\b",
+    r"\bpayment\b",
+    r"\bbilling\b",
+    r"\blegal\b",
+    r"\btax\b",
+    r"\bsecret\b",
+    r"\bcredential\b",
+    r"\bpolicy\b",
+    r"\bultrareview\b",
+)
+
+BLOCKED_KEYWORDS = (
+    r"\bblocked\b",
+    r"\bblocker\b",
+    r"\bwaiting\b",
+    r"\buser decision\b",
+    r"\bmanual\b",
+    r"\bowner decision\b",
+)
+
+AUTOMATION_KEYWORDS = (
+    r"\bworkflow\b",
+    r"\bci\b",
+    r"\bgithub actions\b",
+    r"\bautomation\b",
+    r"\bwbs sync\b",
+    r"\bwbs automation\b",
+    r"\bschedule\b",
+    r"\bharness\b",
+)
+
+UI_KEYWORDS = (
+    r"\bui\b",
+    r"\bux\b",
+    r"\bflutter\b",
+    r"\bvisual\b",
+    r"\bplaywright\b",
+    r"\be2e\b",
+)
+
+DATA_KEYWORDS = (
+    r"\bsql\b",
+    r"\bmigration\b",
+    r"\bsupabase\b",
+    r"\brls\b",
+    r"\bservice[_ -]?role\b",
+    r"\bedge function\b",
+)
+
+DATE_PATTERNS = (
+    re.compile(r"due[:= ]+(?P<date>20\d{2}[-/]\d{1,2}[-/]\d{1,2})", re.IGNORECASE),
+    re.compile(r"deadline[:= ]+(?P<date>20\d{2}[-/]\d{1,2}[-/]\d{1,2})", re.IGNORECASE),
+    re.compile(r"(?:due|deadline)\s+(?P<date>20\d{2}[-/]\d{1,2}[-/]\d{1,2})", re.IGNORECASE),
+    re.compile(r"(?:期限|完了予定)[:= ]*(?P<date>20\d{2}[-/]\d{1,2}[-/]\d{1,2})"),
+)
+
+
+def matches(patterns: tuple[str, ...], text: str) -> bool:
+    return any(re.search(pattern, text, flags=re.IGNORECASE) for pattern in patterns)
+
+
+def label_names(labels: list[dict[str, Any]] | list[str] | None) -> set[str]:
+    names: set[str] = set()
+    for label in labels or []:
+        if isinstance(label, str):
+            names.add(label.lower())
+        elif isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.add(label["name"].lower())
+    return names
+
+
+def comment_text(issue: dict[str, Any]) -> str:
+    comments = issue.get("comments") or []
+    bodies: list[str] = []
+    for comment in comments:
+        if isinstance(comment, dict) and isinstance(comment.get("body"), str):
+            bodies.append(comment["body"])
+    return "\n".join(bodies)
+
+
+def latest_comment(issue: dict[str, Any]) -> dict[str, str] | None:
+    comments = issue.get("comments") or []
+    parsed: list[dict[str, str]] = []
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        created_at = str(comment.get("createdAt") or "")
+        body = str(comment.get("body") or "")
+        url = str(comment.get("url") or "")
+        if created_at or body:
+            parsed.append({"created_at": created_at, "body": body, "url": url})
+    if not parsed:
+        return None
+    return sorted(parsed, key=lambda item: item["created_at"])[-1]
+
+
+def task_text(issue: dict[str, Any]) -> str:
+    return f"{issue.get('title', '')}\n{issue.get('body', '')}\n{comment_text(issue)}"
+
+
+def title_body_text(issue: dict[str, Any]) -> str:
+    return f"{issue.get('title', '')}\n{issue.get('body', '')}"
+
+
+def parse_due_date(issue: dict[str, Any]) -> str | None:
+    explicit = issue.get("due") or issue.get("due_date") or issue.get("deadline")
+    if isinstance(explicit, str):
+        parsed = parse_date_value(explicit)
+        if parsed:
+            return parsed
+    for pattern in DATE_PATTERNS:
+        for match in pattern.finditer(task_text(issue)):
+            parsed = parse_date_value(match.group("date"))
+            if parsed:
+                return parsed
+    return None
+
+
+def parse_date_value(value: str) -> str | None:
+    normalized = value.strip().replace("/", "-")
+    parts = normalized.split("-")
+    if len(parts) != 3:
+        return None
+    try:
+        year, month, day = (int(part) for part in parts)
+        return dt.date(year, month, day).isoformat()
+    except ValueError:
+        return None
+
+
+def task_kind(issue: dict[str, Any]) -> str:
+    text = title_body_text(issue)
+    comments = comment_text(issue)
+    labels = label_names(issue.get("labels"))
+    if matches(BLOCKED_KEYWORDS, f"{text}\n{comments}"):
+        return "blocked_or_manual"
+    if labels & {"security", "supabase", "edge-function"} or matches(DATA_KEYWORDS, text):
+        return "data_or_security"
+    if matches(CLAUDE_KEYWORDS, text):
+        return "claude_first"
+    if labels & {"flutter-web", "ux"} or matches(UI_KEYWORDS, text):
+        return "ui_validation"
+    if labels & {"automation"} or matches(AUTOMATION_KEYWORDS, f"{text}\n{comments}"):
+        return "automation_wbs"
+    if matches(DATA_KEYWORDS, comments):
+        return "data_or_security"
+    return "scoped_implementation"
+
+
+def split_recommendation(kind: str) -> str:
+    if kind in {"data_or_security", "claude_first"}:
+        return "multi_pr_or_claude_first"
+    if kind == "blocked_or_manual":
+        return "blocked_until_owner_decision"
+    return "single_scoped_pr"
+
+
+def write_set_for(kind: str) -> list[str]:
+    write_sets = {
+        "automation_wbs": [
+            "scripts/",
+            ".github/workflows/",
+            "docs/automation/",
+            "docs/WBS_2_INSTANCE_ROUTING.md",
+        ],
+        "ui_validation": [
+            "lib/",
+            "test/e2e/",
+            "docs/",
+        ],
+        "data_or_security": [
+            "docs/issue-fix-plans/ or docs/adr/ before implementation",
+            "supabase/migrations/ only after Claude Code #1 design approval",
+            "supabase/functions/ only after Claude Code #1 design approval",
+        ],
+        "claude_first": [
+            "docs/architecture/",
+            "docs/adr/",
+            "docs/issue-fix-plans/",
+        ],
+        "blocked_or_manual": [
+            "Issue comment only",
+            "WBS owner/status note only",
+        ],
+        "scoped_implementation": [
+            "Issue-specific files only",
+            "tests for changed behavior",
+            "docs for handoff evidence",
+        ],
+    }
+    return write_sets[kind]
+
+
+def next_owner_for(kind: str) -> str:
+    if kind in {"automation_wbs", "ui_validation", "scoped_implementation"}:
+        return "Codex #1"
+    if kind == "blocked_or_manual":
+        return "User/Automation"
+    return "Claude Code #1"
+
+
+def build_plan(issue: dict[str, Any]) -> dict[str, Any]:
+    kind = task_kind(issue)
+    latest = latest_comment(issue)
+    due_date = parse_due_date(issue)
+    return {
+        "issue": issue.get("number"),
+        "title": issue.get("title", ""),
+        "url": issue.get("url", ""),
+        "labels": sorted(label_names(issue.get("labels"))),
+        "due_date": due_date,
+        "kind": kind,
+        "next_owner": next_owner_for(kind),
+        "split": split_recommendation(kind),
+        "active_flow": "Claude Code #1 + Codex #1 + GitHub Actions evidence",
+        "retired_legacy_lanes": [
+            "Codex #2",
+            "Codex #3/#4",
+            "VSCode/Win/PS lane expansion",
+            "agent-in-agent execution",
+        ],
+        "roles": ROLE_TEMPLATES,
+        "write_set": write_set_for(kind),
+        "prohibited_write_set": [
+            "unrelated dirty primary-worktree files",
+            "secrets or local credentials",
+            "Claude Code #1 worktrees owned by another task",
+            "production deploy workflows without Claude Code #1 review",
+            "database migrations without explicit design note",
+        ],
+        "conflict_rules": [
+            "create a fresh task worktree from latest origin/main",
+            "register or record planned paths before editing",
+            "run worktree registry preflight for the planned or staged paths",
+            "run instance conflict predictor when paths touch shared workflows, migrations, or cross-instance docs",
+            "stop on High overlap and hand the packet to Claude Code #1",
+        ],
+        "validation": [
+            "python script/unit tests for changed automation",
+            "git diff --check HEAD~1..HEAD",
+            "PR required checks green",
+            "Deploy to Production green after merge",
+        ],
+        "evidence_targets": [
+            "PR body Minimal E2E Gate section",
+            "Issue closing comment or linked merged PR",
+            "GitHub Actions run URL",
+            "WBS status/progress note when the task is not auto-closed",
+            "worktree/branch cleanup confirmation",
+        ],
+        "handoff_packet_fields": [
+            "Issue/WBS id",
+            "branch",
+            "worktree",
+            "allowed write set",
+            "prohibited write set",
+            "validation command",
+            "unresolved risk",
+            "next owner",
+        ],
+        "handoff_to_claude_when": [
+            "risk is data_or_security or claude_first",
+            "the task needs product/legal/business judgment",
+            "the safe write set cannot be named before editing",
+            "conflict predictor or worktree registry reports High",
+        ],
+        "resource_hygiene": [
+            "record C drive free space before and after the task",
+            "record top memory processes before and after the task",
+            "avoid long-lived dev server, dart, node, and git leftovers",
+            "remove task node_modules/cache outputs through worktree cleanup",
+            "run git worktree prune and git gc --auto after merge cleanup",
+        ],
+        "latest_issue_comment": latest,
+    }
+
+
+def plan_sort_key(plan: dict[str, Any]) -> tuple[str, int]:
+    due = plan.get("due_date") or "9999-12-31"
+    number = int(plan.get("issue") or 0)
+    return due, number
+
+
+def run_gh_json(args: list[str]) -> Any:
+    proc = subprocess.run(
+        ["gh", *args],
+        text=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "gh command failed")
+    text = proc.stdout.strip()
+    return json.loads(text) if text else {}
+
+
+def fetch_issue(repo: str, number: int) -> dict[str, Any]:
+    return run_gh_json(
+        [
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--comments",
+            "--json",
+            "number,title,body,labels,url,state,comments,updatedAt",
+        ]
+    )
+
+
+def fetch_issue_queue(repo: str, query: str, limit: int) -> list[dict[str, Any]]:
+    items = run_gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--search",
+            query,
+            "--json",
+            "number",
+        ]
+    )
+    return [fetch_issue(repo, int(item["number"])) for item in items]
+
+
+def read_json(path: str | None, default: Any) -> Any:
+    if not path:
+        return default
+    source = Path(path)
+    if not source.exists():
+        return default
+    return json.loads(source.read_text(encoding="utf-8"))
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# WBS Role Harness Report",
+        "",
+        f"- Repository: `{report['repo']}`",
+        f"- Generated: `{report['generated_at']}`",
+        "- Active development lanes: Claude Code #1, Codex #1, GitHub Actions evidence, User/Automation decisions.",
+        "- Legacy multi-agent lanes are treated as historical context, not current execution owners.",
+        "",
+    ]
+    plans = report.get("plans", [])
+    if not plans:
+        lines.append("- No plans generated.")
+        return "\n".join(lines) + "\n"
+
+    for plan in plans:
+        title = plan["title"]
+        lines.extend(
+            [
+                f"## Issue #{plan['issue']} - {title}",
+                "",
+                f"- URL: {plan.get('url') or 'n/a'}",
+                f"- Due date: `{plan.get('due_date') or 'unknown'}`",
+                f"- Kind: `{plan['kind']}`",
+                f"- Next owner: `{plan['next_owner']}`",
+                f"- Split recommendation: `{plan['split']}`",
+                "",
+                "### Role Templates",
+                "",
+            ]
+        )
+        for role in plan["roles"]:
+            lines.append(f"- `{role['role']}`: {role['owns']}")
+        lines.extend(["", "### Write Set", ""])
+        lines.extend(f"- `{item}`" for item in plan["write_set"])
+        lines.extend(["", "### Prohibited Write Set", ""])
+        lines.extend(f"- {item}" for item in plan["prohibited_write_set"])
+        lines.extend(["", "### Conflict Rules", ""])
+        lines.extend(f"- {item}" for item in plan["conflict_rules"])
+        lines.extend(["", "### Validation", ""])
+        lines.extend(f"- `{item}`" for item in plan["validation"])
+        lines.extend(["", "### Evidence Targets", ""])
+        lines.extend(f"- {item}" for item in plan["evidence_targets"])
+        lines.extend(["", "### Handoff Packet Fields", ""])
+        lines.extend(f"- {item}" for item in plan["handoff_packet_fields"])
+        lines.extend(["", "### Handoff To Claude Code #1 When", ""])
+        lines.extend(f"- {item}" for item in plan["handoff_to_claude_when"])
+        lines.extend(["", "### Resource Hygiene", ""])
+        lines.extend(f"- {item}" for item in plan["resource_hygiene"])
+        latest = plan.get("latest_issue_comment")
+        if latest:
+            excerpt = " ".join(str(latest.get("body", "")).split())[:280]
+            lines.extend(
+                [
+                    "",
+                    "### Latest Issue Comment",
+                    "",
+                    f"- Created: `{latest.get('created_at') or 'unknown'}`",
+                    f"- URL: {latest.get('url') or 'n/a'}",
+                    f"- Excerpt: {excerpt}",
+                ]
+            )
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--issue-number", type=int)
+    parser.add_argument("--issues-json", help="Offline Issue JSON fixture.")
+    parser.add_argument("--max-issues", type=int, default=10)
+    parser.add_argument(
+        "--query",
+        default="label:priority:high label:wbs",
+        help="Issue search query used when --issue-number and --issues-json are omitted.",
+    )
+    parser.add_argument("--output-md", default="/tmp/wbs-role-harness.md")
+    parser.add_argument("--output-json", default="/tmp/wbs-role-harness.json")
+    return parser.parse_args(argv)
+
+
+def issues_from_args(args: argparse.Namespace) -> list[dict[str, Any]]:
+    if args.issues_json:
+        issues = read_json(args.issues_json, [])
+        if not isinstance(issues, list):
+            raise SystemExit("--issues-json must contain a JSON list")
+        return issues
+    if args.issue_number:
+        return [fetch_issue(args.repo, args.issue_number)]
+    return fetch_issue_queue(args.repo, args.query, args.max_issues)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    issues = issues_from_args(args)
+    plans = sorted((build_plan(issue) for issue in issues), key=plan_sort_key)
+    report = {
+        "repo": args.repo,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "query": None if args.issue_number or args.issues_json else args.query,
+        "plans": plans,
+    }
+    output_json = Path(args.output_json)
+    output_md = Path(args.output_md)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    output_md.write_text(render_markdown(report), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "plans": len(plans),
+                "owners": sorted({plan["next_owner"] for plan in plans}),
+                "splits": sorted({plan["split"] for plan in plans}),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/wbs_role_harness_test.py
+++ b/scripts/wbs_role_harness_test.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from wbs_role_harness import build_plan, main, parse_due_date, plan_sort_key
+
+
+class WbsRoleHarnessTest(unittest.TestCase):
+    def test_automation_wbs_issue_routes_to_codex1_only(self) -> None:
+        plan = build_plan(
+            {
+                "number": 1636,
+                "title": "Connect Codex role harness to WBS automation",
+                "body": "Define WBS automation templates.",
+                "labels": [{"name": "automation"}, {"name": "wbs"}],
+                "comments": [
+                    {
+                        "createdAt": "2026-05-02T19:33:06Z",
+                        "body": "Historical note mentioned Codex #2, but current flow is two-instance.",
+                        "url": "https://example.test/comment",
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(plan["kind"], "automation_wbs")
+        self.assertEqual(plan["next_owner"], "Codex #1")
+        self.assertEqual(plan["split"], "single_scoped_pr")
+        rendered_roles = json.dumps(plan["roles"])
+        self.assertIn("Codex #1", rendered_roles)
+        self.assertNotIn("Codex #2", rendered_roles)
+        self.assertIn("record C drive free space", " ".join(plan["resource_hygiene"]))
+
+    def test_security_or_migration_routes_to_claude_first(self) -> None:
+        plan = build_plan(
+            {
+                "number": 1724,
+                "title": "Supabase migration with service_role policy",
+                "labels": [{"name": "wbs"}],
+            }
+        )
+
+        self.assertEqual(plan["kind"], "data_or_security")
+        self.assertEqual(plan["next_owner"], "Claude Code #1")
+        self.assertEqual(plan["split"], "multi_pr_or_claude_first")
+        self.assertTrue(any("design approval" in item for item in plan["write_set"]))
+
+    def test_blocked_issue_routes_to_user_or_automation(self) -> None:
+        plan = build_plan(
+            {
+                "number": 1984,
+                "title": "Axis B is blocked by #1724",
+                "labels": [{"name": "wbs"}],
+            }
+        )
+
+        self.assertEqual(plan["kind"], "blocked_or_manual")
+        self.assertEqual(plan["next_owner"], "User/Automation")
+
+    def test_due_date_can_be_parsed_and_used_for_sorting(self) -> None:
+        early = build_plan({"number": 2, "title": "Task due 2026/05/18"})
+        later = build_plan({"number": 1, "title": "Task due 2026-05-19"})
+
+        self.assertEqual(parse_due_date({"title": "finish due 2026/05/18"}), "2026-05-18")
+        self.assertLess(plan_sort_key(early), plan_sort_key(later))
+
+    def test_cli_offline_fixture_writes_reports(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = root / "issues.json"
+            output_md = root / "report.md"
+            output_json = root / "report.json"
+            fixture.write_text(
+                json.dumps(
+                    [
+                        {
+                            "number": 10,
+                            "title": "WBS automation due 2026-05-19",
+                            "labels": [{"name": "automation"}, {"name": "wbs"}],
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            exit_code = main(
+                [
+                    "--repo",
+                    "kanta13jp1/my_web_app",
+                    "--issues-json",
+                    str(fixture),
+                    "--output-md",
+                    str(output_md),
+                    "--output-json",
+                    str(output_json),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("WBS Role Harness Report", output_md.read_text(encoding="utf-8"))
+            report = json.loads(output_json.read_text(encoding="utf-8"))
+            self.assertEqual(report["plans"][0]["issue"], 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/wbs_role_harness.py` to classify high-priority WBS Issues into two-instance execution packets
- add a manual/PR workflow that runs the harness, writes a summary, uploads artifacts, and can comment on a single Issue when requested
- document the active Claude Code #1 + Codex #1 + GitHub Actions evidence flow, handoff packet fields, conflict rules, and resource hygiene

## Two-instance scope
- Current owners are fixed to Claude Code #1, Codex #1, GitHub Actions evidence, and User/Automation decisions.
- Historical Codex #2/#3/#4, VSCode, Win, and PS lane references are retained only as context and are not reintroduced as execution owners.

## Minimal E2E Gate
The E2E test is implementation-detail independent.
The plan is minimal, about three I/O cases.
Mechanism: the harness is validated through its CLI and issue-like JSON inputs, checking generated routing outputs rather than internal helper structure.
Cases:
- automation/WBS Issue input produces a Codex #1 `single_scoped_pr` packet.
- migration/security Issue input produces a Claude Code #1 `multi_pr_or_claude_first` packet.
- blocked Issue input produces a User/Automation `blocked_until_owner_decision` packet.

## Validation
- `python scripts\wbs_role_harness_test.py`
- `python -m py_compile scripts\wbs_role_harness.py scripts\wbs_role_harness_test.py`
- `python scripts\wbs_role_harness.py --repo kanta13jp1/my_web_app --issue-number 1636 --output-md $env:TEMP\wbs-role-harness-1636-final.md --output-json $env:TEMP\wbs-role-harness-1636-final.json`
- `python scripts\worktree_registry.py preflight --instance codex1 --issue 1636 --staged --fail-on high` (Medium only: dirty primary worktree outside this scoped worktree)
- `python scripts\instance_conflict_predictor.py --changed-from origin/main --fail-on never --output $env:TEMP\instance-conflict-1636.md --json-out $env:TEMP\instance-conflict-1636.json` (Low)
- `git diff --cached --check`

Closes #1636