### PR TITLE
[codex] Gate AI tool updates for two-instance flow

### DIFF
--- a/.claude/inject-rules.txt
+++ b/.claude/inject-rules.txt
@@ -18,6 +18,8 @@ RULES (毎ターン inject / pointer hub / 詳細展開 = docs/RULES_INDEX.md):
 
 [INSTANCE-ROLES] (part 130 / 2 instance) Win Claude = architect/設計/docs/memory/UI design/triage/AI 大学/競合/mobile UAT/動画 / Win Codex = 実装/修正PR/SQL/EF Deno/GHA/T-1 dispatch/競馬/Karpathy Compile-Lint. Codex 振分 5 質問 (docs/CODEX_WORKFLOW.md §6) で 1 つでも YES = Win Claude / 全 NO = Win Codex. SLA: Issue → 24h triage. 詳細: docs/RULES_INDEX.md
 
+[AI-TOOL-VERIFY] (2026-05-07 #1706) Claude fullscreen/TUI-style rendering, remote/push notifications, Codex memory, Gemini fallback models, and Copilot agent claims are verify-first. Check official sources via scripts/check_versions.py --web before fleet adoption. 2-instance flow stays Claude Code #1 (policy/review) + Codex #1 (scoped PR/CI/cleanup). 詳細: docs/AI_FALLBACK_RUNBOOK.md
+
 [CONCURRENCY] (Win#109) deploy-prod/dev/staging cancel-in-progress: false. 並行 push でも全 commit 順次 deploy. 後発 push 最大 11min × 並行数 待機.
 
 [AUTO-REPLY] 任意 auto-reply (Qiita/dev.to/Slack/Discord) は author == 自分 で必ず skip + MAX_REPLIES_PER_ARTICLE/RUN cap 併設. comment_id ベースは bot 自己ループ検出不能.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,8 @@
 
 このディレクトリには、CI/CDパイプラインを構成するGitHub Actionsワークフローが含まれています。
 
+2026-05-07 #1706: AI-tool workflow changes must cite official sources, stay in the Claude Code #1 + Codex #1 two-instance flow, and avoid starting persistent local dev server / node / dart processes.
+
 ## 📋 ワークフロー一覧
 
 | ワークフロー | ファイル | トリガー | 用途 |

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * **プロジェクト名**: 自分株式会社 (Me Inc.)
 * **コンセプト**: ユーザーはCEO。実務は全てAI（CXO）が担当する経営シミュレーション型生産性アプリ。
 * **技術スタック**: Flutter (Web), Supabase (Auth, DB, Edge Functions), AI (Gemini/OpenAI/Anthropic).
+* **AI tool update gate (2026-05-07 #1706)**: Claude/Codex/Gemini/Copilot changes must be verified against official sources, then routed through the two-instance flow in `docs/AI_FALLBACK_RUNBOOK.md`.
 
 ## 2. 組織構造 (AI Agents) & 機能マップ
 

--- a/docs/AI_FALLBACK_RUNBOOK.md
+++ b/docs/AI_FALLBACK_RUNBOOK.md
@@ -1,5 +1,40 @@
 # AI Fallback Runbook — 自分株式会社
 
+## 2026-05-07 Official AI Tool Update Gate (#1706)
+
+This runbook now treats AI-tool release claims as "verify before routing". Use
+these official sources before promoting a tool into the production fallback
+path:
+
+- Claude Code: official settings and memory docs confirm managed settings,
+  notification channels, hooks, and CLAUDE.md memory hierarchy. Do not require
+  unverified slash commands such as `/tui` or `/resume <PR URL>` unless a
+  current Claude Code release note confirms them.
+- OpenAI Codex: use the official Codex docs and OpenAI Docs MCP. Codex work is
+  routed through the Windows Codex #1 worktree and must keep AGENTS.md /
+  `~/.codex/config.toml` as pointer-based instruction memory, not a giant prompt.
+- Gemini Code Assist: agent mode is available in VS Code and IntelliJ, but
+  remains preview-gated. Gemini 3.1 Pro / 3.0 Flash availability depends on
+  license, waitlist, or release-channel status, so it is a candidate fallback
+  only after local availability is verified.
+- GitHub Copilot: official changelog confirms Copilot coding agent startup
+  improvements and Claude/Codex partner-agent availability. Treat performance
+  claims as changelog-scoped; this runbook records the official 50% startup
+  improvement, not the older unverified 20% figure.
+
+Official source pointers:
+
+- https://docs.anthropic.com/en/docs/claude-code/settings
+- https://docs.anthropic.com/en/docs/claude-code/memory
+- https://developers.openai.com/codex/cloud
+- https://developers.openai.com/learn/docs-mcp
+- https://developers.google.com/gemini-code-assist/resources/release-notes
+- https://docs.cloud.google.com/gemini/docs/codeassist/gemini-3
+- https://github.blog/changelog/2026-02-26-claude-and-codex-now-available-for-copilot-business-pro-users/
+- https://github.blog/changelog/2026-03-19-copilot-coding-agent-now-starts-work-50-faster/
+
+Related ai-tool-update Issues: #1644, #1645, #1646, #1647, #1706.
+
 > 作成: 2026-04-24 (PS#6 S26)  
 > 目的: Claude Code quota 制限時に開発・自動化が完全停止しないための手順書
 

--- a/docs/AI_FLEET_SYNERGY_PLAYBOOK.md
+++ b/docs/AI_FLEET_SYNERGY_PLAYBOOK.md
@@ -95,6 +95,8 @@ INDIE_DEV_VELOCITY (= indie 視点の規律) と直交する **「fleet 視点�
 
 **ルール本文**: 各 instance が読む configuration file (= CLAUDE.md / AGENTS.md / inject-rules.txt) は **巨大化禁止 / 50-200 行上限**. それ以上は **pointer 化** (= "details: docs/X.md") して immutable ADR + executable test suite を **single source of truth** とする.
 
+**2026-05-07 #1706 update**: Codex 側の persistent memory / instruction pointer は **`AGENTS.md` + `~/.codex/AGENTS.md` + `~/.codex/config.toml`** を検出対象に含める. 2 instance 制では Claude Code #1 が policy/review, Codex #1 が `scripts/check_versions.py` evidence と scoped PR を担当する.
+
 **なぜ重要か**: configuration 巨大化 = 各 instance が古い state を hallucinate して矛盾 commit を発する **fleet drift** の根本原因.
 - 現状診断: CLAUDE.md ~200 行 / inject-rules.txt 30+ rules → **境界線**
 - 各 rule に詳細 docs を pointer 化することで **bloat 防止**

--- a/docs/MULTI_INSTANCE_FLEET.md
+++ b/docs/MULTI_INSTANCE_FLEET.md
@@ -8,6 +8,13 @@
 > **運用憲章 (5 正本 + 6 AI 役割 + 監査)**: [`docs/OPERATIONS_CHARTER.md`](./OPERATIONS_CHARTER.md) を併せて参照.
 > **移行ログ**: [`docs/FLEET_2_INSTANCE_TRANSITION.md`](./FLEET_2_INSTANCE_TRANSITION.md).
 
+## 2026-05-07 AI Tool Update Overlay (#1706)
+
+- Keep the active fleet at exactly two local app instances: **Claude Code #1 (Windows app)** for architecture/review/docs triage and **Codex #1 (Windows app)** for scoped implementation PRs, CI, merge, and cleanup.
+- Treat Claude fullscreen/TUI rendering, remote notifications, Codex memory, Gemini fallback models, and GitHub Copilot agent updates as **verify-first capabilities**. Enable or document them only after checking the official source links recorded in [`AI_FALLBACK_RUNBOOK.md`](./AI_FALLBACK_RUNBOOK.md).
+- Smartphone/push handoff is an escalation channel, not a third active instance. It may notify the human owner or surface UAT context, but implementation still returns to Claude Code #1 + Codex #1.
+- `scripts/check_versions.py --web` is the lightweight session-start evidence command for this overlay. It prints official URLs and detects Codex instruction/memory pointers without starting dev servers or large local processes.
+
 ---
 
 ## 現行 2 instance (= active)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@
 
 **最終更新**: 2026-04-17
 
+**AI tool update gate (2026-05-07 #1706)**: Claude/Codex/Gemini/Copilot capability claims are verified through official sources and the Claude Code #1 + Codex #1 two-instance flow before adoption.
+
 ---
 
 ## 📌 常時参照ドキュメント

--- a/docs/ai-tool-watch/README.md
+++ b/docs/ai-tool-watch/README.md
@@ -1,7 +1,12 @@
 # AI Tool Watch
 
 This directory is the session-start and scheduled watch surface for official
-Claude Code and Codex changes.
+Claude Code, Codex, Gemini Code Assist, and GitHub Copilot changes.
+
+2026-05-07 #1706 gate: new AI-tool capability claims must be verified against
+official sources before they are adopted by the active two-instance flow:
+Claude Code #1 (Windows app) for policy/review and Codex #1 (Windows app) for
+scoped implementation PRs, CI, merge, and cleanup.
 
 ## What It Watches
 
@@ -12,7 +17,8 @@ Claude Code and Codex changes.
   review gates.
 - NotebookLM harness notebook
   `bc58b50b-5fc4-4840-9a62-b397d6d3b65a`, used as the Master Brain routing
-  reference for Claude Code 10 instances plus Codex 2 instances.
+  reference after it is normalized to the current Claude Code #1 plus Codex #1
+  two-instance operating model.
 
 ## How To Run
 
@@ -48,10 +54,9 @@ started manually. It updates the report/state files and comments on issue
 - Claude Code hooks, SessionStart, PostToolUse, Stop, or ultrareview changes
   route to Claude Code quality-gate work.
 - Codex model, browser, computer-use, worktree, or subagent changes route to
-  Codex #1 execution and UI verification work unless the item is CI/deploy
-  related.
+  Codex #1 execution and UI verification work.
 - Schedule, GitHub Actions, and automation changes route to WBS/CI/deploy
-  automation, normally owned by Codex #2.
+  automation, normally owned by Codex #1 as scoped PR work.
 - MCP, connector, Slack, and integration changes route to connector reliability
   and NotebookLM knowledge capture.
 - Repeated manual WBS work becomes a candidate for a scheduled task, hook, or

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -3,6 +3,8 @@
 NotebookLM Deep Research の生成物・要約・競合調査成果物を格納する。
 **WEB版インスタンス (claude.ai/code)** が主担当。
 
+2026-05-07 #1706: WEB版は dormant reference. New AI-tool features and research claims route through Claude Code #1 review plus Codex #1 scoped implementation evidence.
+
 ## 使い方
 
 ```bash
@@ -27,7 +29,7 @@ notebooklm ask "調査結果のサマリーを教えて" > docs/research/YYYY-MM
 
 ## ルール
 
-- このディレクトリは WEB版 Claude Code の write 権限スコープ
-- 他インスタンスは読み取り専用 (cross-instance-pr で要望提出可)
+- このディレクトリは WEB版 Claude Code の旧 write 権限スコープ. 2-instance 制では Claude Code #1 が review し、Codex #1 は scoped PR でのみ編集する
+- 他インスタンスは dormant / 読み取り専用 (cross-instance-pr で要望提出可)
 - 機密情報・APIキー・個人情報は含めない
 - 成果物は `notebooklm source add` で Master Brain にも蓄積する

--- a/docs/tool-versions.md
+++ b/docs/tool-versions.md
@@ -11,6 +11,7 @@
 | ツール | 現在バージョン | 最終確認日 | 確認インスタンス |
 | --- | --- | --- | --- |
 | **Claude Code** (CLI) | `2.1.110` | 2026-04-16 | Windowsアプリ版 |
+| **OpenAI Codex CLI** (CLI) | `unknown` | 2026-05-07 | Codex #1 Windows app / memory pointers: `AGENTS.md`, `~/.codex/config.toml` |
 | **Claude Code** (VSCode ext) | `2.1.109` | 2026-04-16 | VSCode版 |
 | **Gemini Code Assist** (VSCode ext) | `2.78.0` | 2026-04-16 | VSCode版 |
 | **OpenAI ChatGPT** (VSCode ext) | `26.409.20454` | 2026-04-16 | VSCode版 |

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -21,6 +21,26 @@ CONSTRAINTS_FILE = os.path.join(REPO_ROOT, "docs", "instance-constraints.md")
 TODAY = date.today().isoformat()
 WEB_MODE = "--web" in sys.argv
 AUTO_UPDATE = "--update" in sys.argv
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+OFFICIAL_TOOL_SOURCES = {
+    "Claude Code settings": "https://docs.anthropic.com/en/docs/claude-code/settings",
+    "Claude Code memory": "https://docs.anthropic.com/en/docs/claude-code/memory",
+    "Gemini Code Assist release notes": "https://developers.google.com/gemini-code-assist/resources/release-notes",
+    "Gemini 3 Code Assist": "https://docs.cloud.google.com/gemini/docs/codeassist/gemini-3",
+    "GitHub Copilot changelog": "https://github.blog/changelog/",
+    "OpenAI Codex docs": "https://developers.openai.com/codex/cloud",
+    "OpenAI Docs MCP": "https://developers.openai.com/learn/docs-mcp",
+}
+
+CODEX_MEMORY_POINTERS = [
+    ("repo AGENTS.md", os.path.join(REPO_ROOT, "AGENTS.md")),
+    ("home AGENTS.md", os.path.expanduser("~/.codex/AGENTS.md")),
+    ("home config.toml", os.path.expanduser("~/.codex/config.toml")),
+]
 
 # ──────────────────────────────────────────────
 # 現在バージョン収集
@@ -35,6 +55,11 @@ def run(cmd: list[str]) -> str:
 
 def get_claude_code_version() -> str:
     out = run(["claude", "--version"])
+    m = re.search(r"(\d+\.\d+\.\d+)", out)
+    return m.group(1) if m else "unknown"
+
+def get_codex_cli_version() -> str:
+    out = run(["codex", "--version"])
     m = re.search(r"(\d+\.\d+\.\d+)", out)
     return m.group(1) if m else "unknown"
 
@@ -57,9 +82,28 @@ def get_flutter_version() -> str:
     m = re.search(r"Flutter\s+(\d+\.\d+\.\d+)", out)
     return m.group(1) if m else "unknown"
 
+def semver_tuple(value: str) -> tuple[int, int, int]:
+    m = re.search(r"(\d+)\.(\d+)\.(\d+)", value)
+    if not m:
+        return (0, 0, 0)
+    return tuple(int(part) for part in m.groups())
+
+def version_at_least(value: str, minimum: str) -> bool:
+    return semver_tuple(value) >= semver_tuple(minimum)
+
+def detect_codex_memory_pointers() -> list[str]:
+    pointers: list[str] = []
+    for label, path in CODEX_MEMORY_POINTERS:
+        if os.path.exists(path):
+            pointers.append(f"{label}: {path}")
+    return pointers
+
 # ──────────────────────────────────────────────
 # 既知バージョン読み込み
 # ──────────────────────────────────────────────
+
+def normalize_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
 
 def load_known_versions() -> dict[str, str]:
     known: dict[str, str] = {}
@@ -67,10 +111,22 @@ def load_known_versions() -> dict[str, str]:
         with open(VERSIONS_FILE, "r", encoding="utf-8") as f:
             for line in f:
                 # Match table rows like: | **Claude Code** (CLI) | `2.1.110` | ...
-                m = re.search(r"\|\s*\*\*(.+?)\*\*.*?\|\s*`([^`]+)`\s*\|", line)
+                m = re.search(
+                    r"\|\s*\*\*(.+?)\*\*(?:\s*\(([^)]*)\))?\s*\|\s*`([^`]+)`\s*\|",
+                    line,
+                )
                 if m:
-                    key = m.group(1).lower().replace(" ", "_")
-                    known[key] = m.group(2)
+                    base_key = normalize_key(m.group(1))
+                    qualifier_key = normalize_key(m.group(2) or "")
+                    version = m.group(3)
+                    if qualifier_key:
+                        known[f"{base_key}_{qualifier_key}"] = version
+                        if base_key.endswith(f"_{qualifier_key}"):
+                            known[base_key] = version
+                        else:
+                            known.setdefault(base_key, version)
+                    else:
+                        known[base_key] = version
     except FileNotFoundError:
         pass
     return known
@@ -83,10 +139,8 @@ def main() -> int:
     if WEB_MODE:
         print("=== WEB版モード: CLIコマンドは実行されません ===")
         print("以下のURLでリリースを手動確認してください:")
-        print("  Claude Code  : https://github.com/anthropics/claude-code/releases")
-        print("  Gemini       : https://marketplace.visualstudio.com/items?itemName=google.geminicodeassist")
-        print("  Copilot      : https://marketplace.visualstudio.com/items?itemName=github.copilot")
-        print("  OpenAI models: https://platform.openai.com/docs/models")
+        for name, url in OFFICIAL_TOOL_SOURCES.items():
+            print(f"  {name:<32}: {url}")
         print("更新があれば docs/tool-versions.md を GitHub MCP 経由で更新してください。")
         return 0
 
@@ -96,10 +150,24 @@ def main() -> int:
     # Claude Code CLI
     cc_ver = get_claude_code_version()
     known = load_known_versions()
-    old_cc = known.get("claude_code", "unknown")
+    old_cc = known.get("claude_code_cli", known.get("claude_code", "unknown"))
     print(f"Claude Code CLI : {cc_ver} (既知: {old_cc})")
     if cc_ver != "unknown" and cc_ver != old_cc:
         updates.append(("Claude Code CLI", old_cc, cc_ver))
+
+    # OpenAI Codex CLI + instruction/memory pointers
+    codex_ver = get_codex_cli_version()
+    old_codex = known.get("openai_codex_cli", known.get("codex_cli", "unknown"))
+    print(f"OpenAI Codex CLI: {codex_ver} (known: {old_codex})")
+    if codex_ver != "unknown" and codex_ver != old_codex:
+        updates.append(("OpenAI Codex CLI", old_codex, codex_ver))
+    codex_pointers = detect_codex_memory_pointers()
+    if codex_pointers:
+        print("Codex instruction/memory pointers:")
+        for pointer in codex_pointers:
+            print(f"  - {pointer}")
+    else:
+        print("Codex instruction/memory pointers: not found (check AGENTS.md / ~/.codex/config.toml)")
 
     # VSCode 拡張
     if not WEB_MODE:
@@ -113,13 +181,22 @@ def main() -> int:
         for ext_id, (name, key) in ext_map.items():
             ver = exts.get(ext_id, "not installed")
             old = known.get(key, "unknown")
+            if name == "Gemini Code Assist" and ver not in ("not installed", "unknown"):
+                if version_at_least(ver, "2.77.1"):
+                    print("  Gemini agent-mode log attribution: OK (2.77.1+)")
+                else:
+                    print("  Gemini agent-mode log attribution: update to 2.77.1+")
             print(f"{name:<30}: {ver} (既知: {old})")
             if ver not in ("not installed", "unknown") and ver != old:
                 updates.append((name, old, ver))
+        print("Gemini 3.1 Pro / 3.0 Flash availability is license and release-channel gated; verify in Google Code Assist before routing production fallback.")
 
     # Flutter
     fl_ver = get_flutter_version()
-    old_fl = known.get("dart/flutter", "unknown")
+    old_fl = known.get(
+        "dart_flutter_sdk",
+        known.get("dart_flutter", known.get("dart/flutter", "unknown")),
+    )
     print(f"Flutter/Dart SDK               : {fl_ver} (既知: {old_fl})")
     if fl_ver != "unknown" and fl_ver != old_fl:
         updates.append(("Flutter/Dart SDK", old_fl, fl_ver))
@@ -190,6 +267,7 @@ def _update_versions_file(updates: list[tuple[str, str, str]]) -> None:
 
     tool_to_row_key = {
         "Claude Code CLI": "Claude Code** (CLI)",
+        "OpenAI Codex CLI": "OpenAI Codex CLI** (CLI)",
         "Claude Code VSCode ext": "Claude Code** (VSCode ext)",
         "Gemini Code Assist": "Gemini Code Assist** (VSCode ext)",
         "GitHub Copilot": "GitHub Copilot** (VSCode ext)",


### PR DESCRIPTION
﻿## Summary
- Add the #1706 verify-before-routing gate for Claude Code, Codex, Gemini Code Assist, and GitHub Copilot updates.
- Update `scripts/check_versions.py` so session checks print official source URLs, detect Codex CLI plus instruction/memory pointers, preserve UTF-8 output under PowerShell piping, and avoid collapsing CLI/VSCode version rows.
- Refresh fleet and README surfaces for the current Claude Code #1 + Codex #1 two-instance flow, with related ai-tool-update links.

## Official sources checked
- https://docs.anthropic.com/en/docs/claude-code/settings
- https://docs.anthropic.com/en/docs/claude-code/memory
- https://developers.openai.com/codex/cloud
- https://developers.openai.com/learn/docs-mcp
- https://developers.google.com/gemini-code-assist/resources/release-notes
- https://docs.cloud.google.com/gemini/docs/codeassist/gemini-3
- https://github.blog/changelog/2026-02-26-claude-and-codex-now-available-for-copilot-business-pro-users/
- https://github.blog/changelog/2026-03-19-copilot-coding-agent-now-starts-work-50-faster/

## Validation
- `python -m py_compile scripts\check_versions.py`
- `python scripts\check_versions.py --web`
- `python scripts\check_versions.py | Select-Object -First 60`
- `git diff --check`
- `python scripts\worktree_registry.py preflight --instance codex1 --issue 1706 --staged --fail-on high` (Medium only: primary worktree dirty)
- `python scripts\instance_conflict_predictor.py --staged --fail-on never` (Medium: stale open docs overlaps #1708/#1602/#1600, no high conflict)

## Minimal E2E declaration
The E2E test is implementation-detail independent.
The plan is minimal, about three I/O cases.
- Web mode prints official URLs without executing CLI probes.
- Normal mode detects Codex memory pointers and survives PowerShell pipe/UTF-8 output.
- Gemini fallback claims remain availability-gated instead of production-routed.

Closes #1706
Refs #1644 #1645 #1646 #1647
