### PR TITLE
[codex] Fix daily report artifact persistence

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -343,14 +343,37 @@ jobs:
           GH_TOKEN: ${{ secrets.BYPASS_RULES }}
           BYPASS_TOKEN: ${{ secrets.BYPASS_RULES }}
         run: |
-          DATE=${{ steps.report.outputs.date }}
+          DATE="${{ steps.report.outputs.date }}"
+          if [ -z "$DATE" ]; then
+            DATE=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+          fi
+          REPORT_FILE="${{ steps.report.outputs.filepath }}"
+          METRICS_FILE="docs/metrics/daily-metrics.json"
+          ARTIFACT_STAGING="$(mktemp -d)"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          if [ -n "$REPORT_FILE" ] && [ -f "$REPORT_FILE" ]; then
+            mkdir -p "$(dirname "$ARTIFACT_STAGING/$REPORT_FILE")"
+            cp "$REPORT_FILE" "$ARTIFACT_STAGING/$REPORT_FILE"
+          else
+            echo "::warning::Daily report file was not generated before commit step: ${REPORT_FILE:-unset}"
+          fi
+
+          if [ -f "$METRICS_FILE" ]; then
+            mkdir -p "$(dirname "$ARTIFACT_STAGING/$METRICS_FILE")"
+            cp "$METRICS_FILE" "$ARTIFACT_STAGING/$METRICS_FILE"
+          else
+            echo "::warning::Daily metrics file was not generated before commit step"
+          fi
+
           git fetch origin main
           git checkout main
           git reset --hard origin/main
+          if [ -d "$ARTIFACT_STAGING/docs" ]; then
+            cp -R "$ARTIFACT_STAGING/docs/." docs/
+          fi
           git add docs/daily-reports/ docs/metrics/
           if git diff --cached --quiet; then
             echo "📝 変更なし — スキップ"


### PR DESCRIPTION
## Summary
- Preserve generated daily report and metrics before the workflow syncs back to `origin/main`.
- Restore those artifacts after the sync so the commit step can actually stage and push `docs/daily-reports/` and `docs/metrics/`.

## Root cause
The daily-report workflow generated the report/metrics, then reset the working tree to `origin/main` before `git add`, discarding the generated artifacts. A separate AI university update could still create the dated report file without the daily-report marker, so the freshness monitor correctly reported stale output.

## Minimal E2E Gate
- This PR changes workflow artifact persistence only; no application-code path changed.
- The E2E plan remains implementation-detail independent and black-box.
- Minimal coverage is about three I/O cases: report file marker, schedule log success signal, and metrics report date freshness.
- Mechanism: existing Python freshness checks plus the public Playwright E2E stability smoke in CI.

## Validation
- Parsed `.github/workflows/daily-report.yml` with PyYAML
- `python test\scripts\test_daily_report_freshness.py`
- `python test\scripts\test_daily_report_staleness_issue.py`
- `git diff --check`
- `python scripts\check_no_verify_bypass.py --range origin/main..HEAD`

Closes #2153