### PR TITLE
[codex] Add high-risk ultrareview gate

### DIFF
--- a/.github/workflows/claude-agent-review.yml
+++ b/.github/workflows/claude-agent-review.yml
@@ -206,6 +206,50 @@ jobs:
             echo "**PR**: #${{ github.event.pull_request.number || 'N/A' }} | **Actor**: ${{ github.actor }}"
           } >> $GITHUB_STEP_SUMMARY
 
+  high-risk-ultrareview-gate:
+    name: High-risk ultrareview gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Collect changed files
+        run: |
+          mkdir -p .ci-logs
+          git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            > .ci-logs/high-risk-changed-files.txt
+
+      - name: Check high-risk ultrareview contract
+        run: |
+          set +e
+          python scripts/check_high_risk_ultrareview_gate.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --changed-files .ci-logs/high-risk-changed-files.txt \
+            > .ci-logs/high-risk-ultrareview-gate.txt 2>&1
+          status=$?
+          cat .ci-logs/high-risk-ultrareview-gate.txt
+          cat .ci-logs/high-risk-ultrareview-gate.txt >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Upload gate evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: high-risk-ultrareview-gate
+          path: .ci-logs/high-risk-*.txt
+          if-no-files-found: ignore
+
   # --- bc58b50b #1765/#1779: claude ultrareview (opt-in, workflow_dispatch only) ---
   # Runs comprehensive multi-agent review via Claude Code CLI.
   # Triggered manually; never blocks PRs; billed separately.

--- a/docs/automation/high-risk-ultrareview-gate.md
+++ b/docs/automation/high-risk-ultrareview-gate.md
@@ -1,0 +1,55 @@
+# High-Risk Ultrareview Gate
+
+Issue: #1569
+
+This gate supports the current two-instance operating model:
+
+- Claude Code #1 owns high-risk review judgment, exception policy, and any
+  manual `/ultrareview` run.
+- Codex #1 owns deterministic GitHub Actions wiring, tests, and scoped PRs.
+
+The workflow does not start extra agents. It detects high-risk PRs and requires
+the PR body to record Claude Code #1 ultrareview evidence or a visible exception
+reason before merge checks can pass.
+
+## High-Risk Triggers
+
+The gate treats a PR as high-risk when it sees any of these signals:
+
+- labels such as `security`, `supabase`, `edge-function`, `workflow-failure`,
+  `priority:critical`, `deploy`, or `production`;
+- database migrations, Supabase Edge Functions, auth/billing/payment code,
+  production deploy workflows, Firebase config, secrets, credentials,
+  `service_role`, or RLS paths;
+- PR title/body keywords for secrets, credentials, tokens, auth, billing,
+  production deploy, migrations, RLS, or service-role access.
+
+## PR Body Contract
+
+For high-risk PRs, include a section like this:
+
+```markdown
+## High-risk Ultrareview Gate
+- Reviewer: Claude Code #1
+- Evidence: Claude ultrareview completed for PR #123.
+- Perspectives covered: security, rollback, data migration, prod smoke, observability.
+- Unresolved findings: none.
+```
+
+If ultrareview cannot be run before merge, the exception must be visible in the
+PR body:
+
+```markdown
+## High-risk Ultrareview Gate
+- Reviewer: Claude Code #1
+- High-Risk-Ultrareview-Exception: workflow-only bootstrap; owner accepted follow-up review after merge.
+```
+
+Empty placeholders and hidden comments do not satisfy the gate.
+
+## Local Verification
+
+```powershell
+python scripts\check_high_risk_ultrareview_gate_test.py
+python scripts\check_high_risk_ultrareview_gate.py --body-file .\tmp-pr-body.md --changed-files .\tmp-changed-files.txt
+```

--- a/scripts/check_high_risk_ultrareview_gate.py
+++ b/scripts/check_high_risk_ultrareview_gate.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Require Claude Code #1 ultrareview evidence for high-risk PRs.
+
+The gate is intentionally deterministic: it detects high-risk labels, paths, and
+PR text, then checks that the PR body records Claude Code #1 ultrareview
+evidence or a visible exception reason. It does not call an AI model itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+HIGH_RISK_LABELS = {
+    "security",
+    "supabase",
+    "edge-function",
+    "workflow-failure",
+    "priority:critical",
+    "deploy",
+    "production",
+}
+
+HIGH_RISK_PATH_PATTERNS = (
+    r"^supabase/migrations/",
+    r"^supabase/functions/",
+    r"^lib/(auth|billing|payments|subscription|firebase|supabase)/",
+    r"^\.github/workflows/(deploy|.*deploy.*|ci-auto-fix|claude-agent-review|workflow-failure-handler).*\.yml$",
+    r"^firebase\.json$",
+    r"^firestore\.",
+    r"^storage\.",
+    r"(^|/)\.env",
+    r"secret",
+    r"credential",
+    r"service[_-]?role",
+    r"rls",
+)
+
+HIGH_RISK_TEXT_PATTERNS = (
+    r"\bsecret\b",
+    r"\bcredential\b",
+    r"\btoken\b",
+    r"\bauth\b",
+    r"\bpayment\b",
+    r"\bbilling\b",
+    r"\bstripe\b",
+    r"\bsubscription\b",
+    r"\bproduction\b",
+    r"\bdeploy\b",
+    r"\bmigration\b",
+    r"\brls\b",
+    r"\bservice[_ -]?role\b",
+)
+
+ULTRAREVIEW_PATTERNS = (
+    r"\bclaude\s+ultrareview\b",
+    r"/ultrareview\b",
+    r"\bultrareview\b",
+)
+
+INSTANCE_PATTERNS = (
+    r"\bClaude Code #1\b",
+    r"\bClaude Code 1\b",
+)
+
+NO_UNRESOLVED_PATTERNS = (
+    r"\bno unresolved\b",
+    r"\bunresolved\s+(findings?|items?|comments?)\s*[:=-]?\s*(0|none|no)\b",
+    r"\bunresolved\s*[:=-]\s*(0|none|no)\b",
+)
+
+REQUIRED_PERSPECTIVES = {
+    "security": r"\bsecurity\b",
+    "rollback": r"\brollback\b",
+    "data migration": r"\bdata[- ]migration\b|\bmigration\b",
+    "prod smoke": r"\bprod(?:uction)?[- ]smoke\b|\bprod(?:uction)? smoke\b",
+    "observability": r"\bobservability\b",
+}
+
+EXCEPTION_PATTERNS = (
+    r"high[- ]risk[- ]ultrareview[- ]exception",
+    r"ultrareview[- ]exception",
+)
+
+
+def normalize_path(path: str) -> str:
+    path = path.replace("\ufeff", "").replace("\\", "/")
+    return path[2:] if path.startswith("./") else path
+
+
+def has_any(patterns: tuple[str, ...], text: str) -> bool:
+    return any(re.search(pattern, text, flags=re.IGNORECASE) for pattern in patterns)
+
+
+def read_changed_files(path: str | None) -> list[str]:
+    if not path:
+        return []
+    source = Path(path)
+    if not source.exists():
+        return []
+    return [
+        normalize_path(line.strip())
+        for line in source.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def event_payload(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    source = Path(path)
+    if not source.exists():
+        return {}
+    return json.loads(source.read_text(encoding="utf-8"))
+
+
+def pr_body(payload: dict[str, Any], body_file: str | None) -> str:
+    if body_file:
+        source = Path(body_file)
+        if source.exists():
+            return source.read_text(encoding="utf-8")
+    pr = payload.get("pull_request")
+    if isinstance(pr, dict):
+        body = pr.get("body")
+        return body if isinstance(body, str) else ""
+    return ""
+
+
+def pr_title(payload: dict[str, Any]) -> str:
+    pr = payload.get("pull_request")
+    if isinstance(pr, dict):
+        title = pr.get("title")
+        return title if isinstance(title, str) else ""
+    return ""
+
+
+def pr_labels(payload: dict[str, Any]) -> set[str]:
+    pr = payload.get("pull_request")
+    labels = pr.get("labels", []) if isinstance(pr, dict) else []
+    names: set[str] = set()
+    for item in labels:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            names.add(item["name"].lower())
+    return names
+
+
+def path_risk_reasons(changed_files: list[str]) -> list[str]:
+    reasons: list[str] = []
+    for raw_path in changed_files:
+        path = normalize_path(raw_path)
+        if has_any(HIGH_RISK_PATH_PATTERNS, path):
+            reasons.append(f"High-risk path: {path}")
+    return reasons
+
+
+def text_risk_reasons(title: str, body: str) -> list[str]:
+    text = f"{title}\n{body}"
+    if has_any(HIGH_RISK_TEXT_PATTERNS, text):
+        return ["Title/body contains high-risk keywords."]
+    return []
+
+
+def label_risk_reasons(labels: set[str]) -> list[str]:
+    hits = sorted(labels & HIGH_RISK_LABELS)
+    return ["High-risk labels: " + ", ".join(hits)] if hits else []
+
+
+def has_visible_exception_reason(body: str) -> bool:
+    for line in body.splitlines():
+        if not has_any(EXCEPTION_PATTERNS, line):
+            continue
+        cleaned = re.sub(r"<!--.*?-->", "", line).strip()
+        cleaned = re.sub(
+            r"(?i)high[- ]risk[- ]ultrareview[- ]exception|ultrareview[- ]exception",
+            "",
+            cleaned,
+        )
+        cleaned = cleaned.strip(" :-[]\t")
+        if len(cleaned) >= 12:
+            return True
+    return False
+
+
+def has_exception_marker(body: str) -> bool:
+    return has_any(EXCEPTION_PATTERNS, body)
+
+
+def missing_perspectives(body: str) -> list[str]:
+    return [
+        name
+        for name, pattern in REQUIRED_PERSPECTIVES.items()
+        if not re.search(pattern, body, flags=re.IGNORECASE)
+    ]
+
+
+def validate(
+    body: str,
+    changed_files: list[str],
+    labels: set[str],
+    title: str = "",
+) -> tuple[bool, list[str], bool, list[str]]:
+    risk_reasons: list[str] = []
+    risk_reasons.extend(path_risk_reasons(changed_files))
+    risk_reasons.extend(label_risk_reasons(labels))
+    risk_reasons.extend(text_risk_reasons(title, body))
+
+    high_risk = bool(risk_reasons)
+    if not high_risk:
+        return True, ["No high-risk triggers detected."], False, []
+
+    messages: list[str] = []
+    exception_declared = has_visible_exception_reason(body)
+    exception_marker = has_exception_marker(body)
+
+    if not has_any(INSTANCE_PATTERNS, body):
+        messages.append("High-risk PR body must name Claude Code #1 as the review owner.")
+    if exception_marker and not exception_declared:
+        messages.append("High-risk ultrareview exception reason must be visible.")
+
+    if exception_declared:
+        return not messages, messages or ["Visible ultrareview exception declared."], True, risk_reasons
+
+    if not has_any(ULTRAREVIEW_PATTERNS, body):
+        messages.append("High-risk PR body must include Claude ultrareview evidence or an exception reason.")
+
+    missing = missing_perspectives(body)
+    if missing:
+        messages.append(
+            "High-risk ultrareview evidence must cover: " + ", ".join(missing) + "."
+        )
+
+    if not has_any(NO_UNRESOLVED_PATTERNS, body):
+        messages.append("High-risk PR body must state that unresolved ultrareview findings are 0/none.")
+
+    return not messages, messages, True, risk_reasons
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", help="GitHub event JSON path")
+    parser.add_argument("--body-file", help="Local markdown file to validate")
+    parser.add_argument("--changed-files", help="Newline-separated changed file list")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    payload = event_payload(args.event)
+    body = pr_body(payload, args.body_file)
+    title = pr_title(payload)
+    changed_files = read_changed_files(args.changed_files)
+    labels = pr_labels(payload)
+
+    ok, messages, high_risk, risk_reasons = validate(body, changed_files, labels, title)
+    print(f"High-risk ultrareview gate: {'PASS' if ok else 'FAIL'}")
+    print(f"High-risk triggers detected: {'yes' if high_risk else 'no'}")
+    if changed_files:
+        print(f"Changed files inspected: {len(changed_files)}")
+    for reason in risk_reasons:
+        print(f"- trigger: {reason}")
+    for message in messages:
+        print(f"- {message}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_high_risk_ultrareview_gate_test.py
+++ b/scripts/check_high_risk_ultrareview_gate_test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+from check_high_risk_ultrareview_gate import validate
+
+
+GOOD_BODY = """
+## High-risk Ultrareview Gate
+- Reviewer: Claude Code #1
+- Evidence: Claude ultrareview completed for this PR.
+- Perspectives covered: security, rollback, data migration, prod smoke, observability.
+- Unresolved findings: none.
+"""
+
+
+class HighRiskUltrareviewGateTest(unittest.TestCase):
+    def test_low_risk_docs_change_passes_without_declaration(self) -> None:
+        ok, messages, high_risk, reasons = validate(
+            "",
+            ["docs/automation/example.md"],
+            set(),
+        )
+
+        self.assertTrue(ok, messages)
+        self.assertFalse(high_risk)
+        self.assertEqual(reasons, [])
+
+    def test_migration_change_requires_ultrareview_evidence(self) -> None:
+        ok, messages, high_risk, reasons = validate(
+            "Routine schema update.",
+            ["supabase/migrations/20260508090000_add_table.sql"],
+            set(),
+        )
+
+        self.assertFalse(ok)
+        self.assertTrue(high_risk)
+        self.assertTrue(any("High-risk path" in item for item in reasons))
+        self.assertTrue(any("ultrareview evidence" in item for item in messages))
+
+    def test_complete_ultrareview_evidence_passes(self) -> None:
+        ok, messages, high_risk, _ = validate(
+            GOOD_BODY,
+            [".github/workflows/deploy-prod.yml"],
+            {"security"},
+        )
+
+        self.assertTrue(ok, messages)
+        self.assertTrue(high_risk)
+
+    def test_missing_review_perspectives_fail(self) -> None:
+        body = """
+        ## High-risk Ultrareview Gate
+        - Reviewer: Claude Code #1
+        - Evidence: Claude ultrareview completed.
+        - Unresolved findings: 0
+        """
+        ok, messages, high_risk, _ = validate(
+            body,
+            ["supabase/functions/foo/index.ts"],
+            set(),
+        )
+
+        self.assertFalse(ok)
+        self.assertTrue(high_risk)
+        self.assertTrue(any("security" in item and "observability" in item for item in messages))
+
+    def test_visible_exception_passes_when_review_owner_is_named(self) -> None:
+        body = """
+        ## High-risk Ultrareview Gate
+        - Reviewer: Claude Code #1
+        - High-Risk-Ultrareview-Exception: workflow-only bootstrap; Claude Code #1 review will be requested after merge.
+        """
+        ok, messages, high_risk, _ = validate(
+            body,
+            [".github/workflows/claude-agent-review.yml"],
+            set(),
+        )
+
+        self.assertTrue(ok, messages)
+        self.assertTrue(high_risk)
+
+    def test_exception_without_visible_reason_does_not_pass(self) -> None:
+        body = """
+        ## High-risk Ultrareview Gate
+        - Reviewer: Claude Code #1
+        - High-Risk-Ultrareview-Exception: <!-- reason -->
+        """
+        ok, messages, high_risk, _ = validate(
+            body,
+            [".github/workflows/claude-agent-review.yml"],
+            set(),
+        )
+
+        self.assertFalse(ok)
+        self.assertTrue(high_risk)
+        self.assertTrue(any("exception reason" in item for item in messages))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a deterministic high-risk ultrareview gate to `AI Agent PR Review` for pull requests.
- Detect high-risk labels, paths, and PR text for migrations, Edge Functions, auth/billing, secrets, deploy workflows, RLS, and service-role access.
- Require PR body evidence naming Claude Code #1, covering security, rollback, data migration, prod smoke, and observability, with no unresolved findings; otherwise require a visible exception reason.
- Document the two-instance operating split: Claude Code #1 owns high-risk judgment, Codex #1 owns deterministic gate wiring.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: bootstrap PR for the deterministic gate itself; the PR records the required contract and CI evidence, and no extra AI instances are started.

## Minimal E2E Gate
- This workflow/script/doc change is implementation-detail independent and black-box from the app user's perspective.
- Minimal coverage is about three I/O cases: low-risk PR passes, high-risk PR without ultrareview evidence fails, and visible exception passes.
- Mechanism: Python unit tests for the gate plus the existing public Playwright E2E stability smoke in CI.

## Validation
- `python scripts\check_high_risk_ultrareview_gate_test.py`
- `python scripts\check_minimal_e2e_gate_test.py`
- `python scripts\two_instance_audit.py --fail-on-active`
- Parsed `.github/workflows/claude-agent-review.yml` with PyYAML
- `git diff --check`
- `python scripts\check_no_verify_bypass.py --range origin/main..HEAD`

Closes #1569