### PR TITLE
docs(triage): part 179 — Codex #1569 verify + 3 issue triage hand-off (#2152)

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -28812,3 +28812,44 @@ User 2026-05-08 ask「**毎回のセッションで必ず** メモリ + HDD 圧�
 - 「**既存 doc 章追加 pattern**」(= 新規 spec md 増殖回避) 第 3 例 — DISK_HYGIENE_RUNBOOK.md §12 拡張
 - 「**Win Claude triage + Codex 実装委譲**」pattern 連続例 ([INSTANCE-ROLES] dogfood)
 - 108 part 連続 dogfood / 19 part 連続 cross-day (cap_24part_v2 残 5)
+
+---
+
+## 2026-05-08 11:00 JST — Win版#132 part 179 (Win Claude / Codex 自走着地 verify + 3 issue triage)
+
+### Summary
+
+Codex CLI が単独で着地した Issue #1569 (= high-risk PR ultrareview gate) を verify-only で確認 + 5/19 deadline 3 P1 issue を [INSTANCE-ROLES] 5 質問 score で triage + #2152 を Codex hand-off doc ship。
+
+### Ship
+
+- **Codex 自走着地 verify** (= 関与なし): Issue #1569 CLOSED 2026-05-08T01:28:04Z / PR #2155 squash merged commit `36935f38a` / `.github/workflows/claude-agent-review.yml` + `scripts/check_high_risk_ultrareview_gate.py` (+472 lines) / CI 7 checks green
+- `docs/cross-instance-prs/20260508_codex_kg_indexer_fix_part179.md` — Codex hand-off (Issue #2152 / 期限 2026-05-19 / 11 day grace)
+- Issue [#1586 comment](https://github.com/kanta13jp1/my_web_app/issues/1586#issuecomment-4402664362) — Win Claude defer status (= managed-mcp.json spec ship 別 session)
+- Issue [#1598 comment](https://github.com/kanta13jp1/my_web_app/issues/1598#issuecomment-4402664552) — Win Claude defer status (= DeepEval 評価観点 spec ship 別 session)
+- Issue [#2152 comment](https://github.com/kanta13jp1/my_web_app/issues/2152#issuecomment-4402664757) — Codex hand-off ack
+
+### Triage matrix ([INSTANCE-ROLES] 5 質問 score)
+
+| Issue | score | 担当 | 着地 |
+|---|---|---|---|
+| #1569 high-risk ultrareview gate | n/a (already CLOSED by Codex) | Codex | ✅ commit `36935f38a` |
+| #1586 managed-mcp.json | 4/5 | Win Claude (architect) | spec ship 別 session |
+| #1598 DeepEval/promptfoo | 1/5 (split) | Win Claude design + Codex #2 CI | Win Claude design 別 session |
+| #2152 kg-indexer-nightly failure | 0/5 | Codex (GHA fix) | hand-off doc ship |
+
+### Philosophy Alignment
+
+- **PHILOSOPHY-22** = 6/9 ✅ (= CEO triage role + mentor delegation + 商品=価値 = 5 正本同期)
+- **OPS-28** = 5 正本 ✅ (= Issues + PR + WBS + worktree+branch + Notion 不変)
+- **SYNERGY-30** = 5/7 ✅ (= cross-instance-pr / [INSTANCE-ROLES] dogfood / verify-only pattern 第 1 例)
+
+### Pattern dogfood
+
+- 「**Codex 自走着地 verify-only**」pattern 第 1 例 — Win Claude が hand-off せず Codex が独立着地 → triage 時 commit + Issue close 状態で verify のみ / cap_24 conservation 完璧
+- 「**[INSTANCE-ROLES] 5 質問機械的振り分け**」第 2 例 — 3 issue 各 30 sec 以内 score 化 / triage 速度向上
+- 109 part 連続 dogfood / 20 part 連続 cross-day (cap_24part_v2 残 4) / 次 session = fresh start 強推奨
+
+### Commit
+
+- PR #TBD (= admin squash merge 予定 / branch `claude/nostalgic-gagarin-03deac`)

--- a/docs/cross-instance-prs/20260508_codex_kg_indexer_fix_part179.md
+++ b/docs/cross-instance-prs/20260508_codex_kg_indexer_fix_part179.md
@@ -1,0 +1,58 @@
+# [cross-instance-pr] kg-indexer-nightly failure 修正 — Issue #2152 hand-off
+
+**To**: Win版 (Codex CLI) — 実装/修正PR/SQL/EF Deno/GHA role
+**From**: Win版 (Claude Code) — Win版#132 part 179 / triage
+**Priority**: medium
+**Date**: 2026-05-08
+**Deadline**: 2026-05-19 (= 11 day grace / WBS top 5 期限)
+**Related**: [Issue #2152](https://github.com/kanta13jp1/my_web_app/issues/2152) / [`.github/workflows/kg-indexer-nightly.yml`](../../.github/workflows/kg-indexer-nightly.yml)
+
+## 背景
+
+Knowledge Graph nightly indexer (= [run 25518994705](https://github.com/kanta13jp1/my_web_app/actions/runs/25518994705)) が 2026-05-07 20:01 UTC scheduled run で **exit code 1** で失敗.
+
+Annotation: `No files were found with the provided path: tmp/kg-indexer/. No artifacts will be uploaded.`
+
+= "Run indexers" step (= 5 indexer 連続実行) が中途失敗 → tmp/kg-indexer/ 出力 0 件 → upload artifact 警告.
+
+## 該当ファイル
+
+- `.github/workflows/kg-indexer-nightly.yml` (= workflow)
+- `scripts/kg_index_common.py`
+- `scripts/kg_index_docs.py`
+- `scripts/kg_index_github_issues.py`
+- `scripts/kg_index_memory_vault.py`
+- `scripts/kg_index_notebooklm_intake.py`
+- `scripts/kg_index_wbs_tasks.py`
+
+## 依頼事項 (= Codex 実装範囲)
+
+### 1. Failure 原因特定
+
+```bash
+gh run view 25518994705 --log-failed
+```
+
+= どの indexer で fail か特定. `commit 7e76026e7e0b915f051b2e82d7b276e8ed878cc9` 時点の state で再現.
+
+### 2. 修正方針 (= 推奨優先順)
+
+1. **個別 indexer fail を fail-soft 化** — 1 indexer fail でも他 4 indexer 継続. 最終 step で artifact 0 件なら exit 1, 1+ 件なら exit 0.
+2. **root cause fix** — 失敗 indexer (= memory_vault / notebooklm_intake のいずれか可能性高) の例外処理改善.
+
+### 3. Acceptance criteria
+
+- [ ] kg-indexer-nightly が連続 3 日 success (= 5/9, 5/10, 5/11)
+- [ ] tmp/kg-indexer/ に 5 indexer 全 artifact 出力
+- [ ] PR description で「Issue #2152 修正 / fail-soft 化 + root cause fix」明示
+- [ ] 失敗 issue auto-open は維持 (= "Open or update failure issue" step 健全)
+
+## 委譲外 (= Win Claude 担当)
+
+- なし. Self-contained.
+
+## Reference
+
+- Issue: [#2152](https://github.com/kanta13jp1/my_web_app/issues/2152)
+- Failed run: <https://github.com/kanta13jp1/my_web_app/actions/runs/25518994705>
+- Workflow: [`.github/workflows/kg-indexer-nightly.yml`](../../.github/workflows/kg-indexer-nightly.yml)


### PR DESCRIPTION
## Summary

Win版#132 part 179 (= Win Claude / 2026-05-08 11:00 JST):

- **Codex 自走着地 verify-only 第 1 例** — Issue #1569 high-risk ultrareview gate を Win Claude 関与なしで Codex CLI が単独着地 (PR #2155 squash merged commit `36935f38a`). Win Claude は triage 時に commit + Issue close 状態で verify のみ.
- **5/19 deadline 3 P1 issue triage** ([INSTANCE-ROLES] 5 質問 score 化):
  - #1586 managed-mcp.json (4/5) → Win Claude (architect) / spec ship 別 session defer / status comment
  - #1598 DeepEval/promptfoo (1/5 split) → Win Claude design + Codex #2 CI / Win Claude design 別 session defer / status comment
  - #2152 kg-indexer-nightly failure (0/5) → Codex (GHA fix) / hand-off doc ship
- **Codex hand-off**: `docs/cross-instance-prs/20260508_codex_kg_indexer_fix_part179.md` (期限 2026-05-19 / 11 day grace / fail-soft 化 + root cause fix 推奨)
- **ROADMAP-LOG**: part 179 append (= [ROADMAP-LOG] rule)

## STOP signal

109 part 連続 dogfood / 20 part 連続 cross-day = `cap_24part_v2` 残 4 part. 大規模 spec 詰込なし (= triage + verify + hand-off only). 次 session = fresh start 強推奨.

## Pattern dogfood

- 「Codex 自走着地 verify-only」第 1 例 (= cap_24 conservation 完璧)
- 「[INSTANCE-ROLES] 5 質問機械的振り分け」第 2 例 (= 1 issue 30 sec 以内)

## Files changed

- `docs/GROWTH_STRATEGY_ROADMAP.md` — part 179 ROADMAP-LOG append
- `docs/cross-instance-prs/20260508_codex_kg_indexer_fix_part179.md` — Codex hand-off (new)

## Test plan

- [x] Codex commit `36935f38a` 内容確認 (= +473 lines / claude-agent-review.yml + check_high_risk_ultrareview_gate.py)
- [x] Issue #1569 CLOSED 確認 (= 2026-05-08T01:28:04Z / Codex #1 completion note 投稿済)
- [x] kg-indexer-nightly run [25518994705](https://github.com/kanta13jp1/my_web_app/actions/runs/25518994705) failure annotation 確認 (= "No files were found with the provided path: tmp/kg-indexer/")
- [x] Issue #1586 / #1598 / #2152 status comments 投稿済
- [ ] admin squash merge 後 ROADMAP-LOG 反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)