### PR TITLE
security: add managed MCP policy gate

### DIFF
--- a/.github/workflows/managed-mcp-policy.yml
+++ b/.github/workflows/managed-mcp-policy.yml
@@ -1,0 +1,57 @@
+name: Managed MCP Policy Audit
+
+on:
+  pull_request:
+    paths:
+      - "config/managed-mcp.json"
+      - "docs/automation/managed-mcp-access-control.md"
+      - "docs/AGENT_TOOL_POLICY.md"
+      - "AGENTS.md"
+      - "scripts/check_managed_mcp_policy.py"
+      - "scripts/check_managed_mcp_policy_test.py"
+      - "scripts/codex_session_check.py"
+      - ".github/workflows/managed-mcp-policy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Validate managed MCP register
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate managed MCP policy
+        run: python scripts/check_managed_mcp_policy.py --config config/managed-mcp.json
+
+      - name: Run managed MCP unit tests
+        run: python scripts/check_managed_mcp_policy_test.py
+
+      - name: Session-start scan against repo-managed settings
+        run: |
+          mkdir -p .ci-logs
+          python scripts/check_managed_mcp_policy.py \
+            --config config/managed-mcp.json \
+            --session-start \
+            --settings .claude/settings.json \
+            --settings .claude/settings.local.json \
+            --json > .ci-logs/managed-mcp-session.json
+
+      - name: Codex session check JSON
+        run: python scripts/codex_session_check.py --json > .ci-logs/codex-session-check.json
+
+      - name: Upload managed MCP audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: managed-mcp-policy-audit
+          path: .ci-logs/
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,9 +53,9 @@ same notebook.
 - Codex #1 owns scoped implementation, cross-cutting investigation,
   SQL/migration review, CI, synchronization, operations, Edge Functions,
   GitHub Actions, deterministic automation, branch cleanup, and fix PRs.
-- Codex #2 and older PS/WEB/mobile/Gemini/Copilot lanes are historical labels
-  only. Do not start extra live instances unless the user explicitly reactivates
-  them.
+- Historical extra Codex lanes and older PS/WEB/mobile/Gemini/Copilot lanes are
+  dormant labels only. Codex #1 absorbs their implementation and CI duties under
+  the current two-instance flow unless the user explicitly reactivates them.
 - Use `docs/AGENT_DELEGATION_PROTOCOL.md` as the current handoff and review
   contract for WBS tasks.
 
@@ -73,8 +73,9 @@ same notebook.
 - Codex #1 should take broad but bounded work from the WBS top list:
   migrations, data import/export, UI verification, stale automation audits, and
   clean fix PRs from a fresh worktree.
-- Codex #2 should take red CI, deploy unblockers, workflow drift, Edge Function
-  failures, and GitHub/Notion/Slack synchronization issues.
+- Codex #1 should also absorb historical extra-Codex work: red CI, deploy
+  unblockers, workflow drift, Edge Function failures, and GitHub/Notion/Slack
+  synchronization issues.
 - If local `SUPABASE_SERVICE_ROLE_KEY` is unavailable, use GitHub Actions
   `WBS Progress Update (manual)` (`wbs-progress-update.yml`) to dispatch one
   `wbs.update_progress` call with task id, progress, status, Issue/PR reference,

--- a/config/managed-mcp.json
+++ b/config/managed-mcp.json
@@ -1,0 +1,570 @@
+{
+  "schemaVersion": 1,
+  "status": "active",
+  "defaultDecision": "deny",
+  "lastUpdated": "2026-05-08",
+  "ownerModel": {
+    "activeInstances": [
+      "Claude Code #1",
+      "Codex #1"
+    ],
+    "policyOwner": "Claude Code #1",
+    "implementationOwner": "Codex #1",
+    "notes": "Historical extra Codex WBS labels are absorbed by Codex #1 under the current two-instance flow."
+  },
+  "sessionStartPolicy": {
+    "warnOnUnmanagedServer": true,
+    "warnOnDeniedServer": true,
+    "warnOnExpiredAuth": true,
+    "warnOnDangerousPermissions": true
+  },
+  "highRiskScopes": [
+    "admin",
+    "delete",
+    "send",
+    "purchase",
+    "external_share",
+    "credential_access",
+    "shell_execute",
+    "filesystem_write",
+    "production_write"
+  ],
+  "dangerousPermissionPatterns": [
+    "defaultMode\\s*=\\s*bypassPermissions",
+    "skipDangerousModePermissionPrompt\\s*=\\s*true",
+    "sandbox\\s*=\\s*elevated",
+    "Bash\\(git reset",
+    "Bash\\(git checkout --",
+    "Bash\\(rm -rf",
+    "Bash\\(del ",
+    "Bash\\(taskkill",
+    "PowerShell\\(Stop-Process",
+    "printenv\\s+.*(KEY|TOKEN|SECRET)",
+    "service[_ -]?role"
+  ],
+  "allowedMcpServers": [
+    {
+      "id": "github",
+      "displayName": "GitHub",
+      "aliases": [
+        "github@openai-curated",
+        "github@claude-plugins-official",
+        "mcp__codex_apps__github",
+        "mcp__plugin_github_github",
+        "mcp__github"
+      ],
+      "purpose": "Issue, PR, branch, review comment, and CI evidence work for WBS execution.",
+      "permissions": [
+        "read",
+        "suggest",
+        "create_comment",
+        "update_comment",
+        "ci_log_read"
+      ],
+      "dataClassification": [
+        "source_code",
+        "issue_metadata",
+        "ci_logs"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "merge",
+        "delete",
+        "admin",
+        "external_share"
+      ],
+      "auditLog": "GitHub issue comments, PR timeline, branch history, and Actions logs.",
+      "allowedReason": "Required for Codex #1 to ship scoped PRs and prove CI green under WBS due-date order.",
+      "auth": {
+        "required": true,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "notion",
+      "displayName": "Notion",
+      "aliases": [
+        "notion@openai-curated",
+        "mcp_servers.notion",
+        "notion"
+      ],
+      "purpose": "Read and summarize Notion specs or implementation plans when explicitly referenced.",
+      "permissions": [
+        "read",
+        "suggest"
+      ],
+      "dataClassification": [
+        "internal_docs",
+        "planning_notes"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "create",
+        "update",
+        "delete",
+        "external_share"
+      ],
+      "auditLog": "Notion page history plus issue/PR links that cite the readback.",
+      "allowedReason": "Supports spec-to-implementation intake without adding extra live agent instances.",
+      "auth": {
+        "required": true,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "slack",
+      "displayName": "Slack",
+      "aliases": [
+        "slack@openai-curated",
+        "slack"
+      ],
+      "purpose": "Read Slack context and draft updates for WBS coordination when the user asks.",
+      "permissions": [
+        "read",
+        "suggest"
+      ],
+      "dataClassification": [
+        "internal_messages",
+        "coordination_notes"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "send",
+        "external_share",
+        "delete"
+      ],
+      "auditLog": "Slack message permalink plus issue/PR note before any outbound send.",
+      "allowedReason": "Coordination data may inform WBS routing, but outbound writes stay human-approved.",
+      "auth": {
+        "required": true,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "google-drive",
+      "displayName": "Google Drive",
+      "aliases": [
+        "google-drive@openai-curated",
+        "google-docs@openai-curated",
+        "google-sheets@openai-curated",
+        "google-slides@openai-curated",
+        "claude.ai google drive",
+        "google drive"
+      ],
+      "purpose": "Read referenced Drive, Docs, Sheets, and Slides artifacts for issue evidence.",
+      "permissions": [
+        "read",
+        "suggest"
+      ],
+      "dataClassification": [
+        "internal_docs",
+        "user_files"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "create",
+        "update",
+        "delete",
+        "external_share"
+      ],
+      "auditLog": "Drive file URL, readback summary, and issue/PR link.",
+      "allowedReason": "Needed for referenced source intake while preserving manual approval for file writes.",
+      "auth": {
+        "required": true,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "google-calendar",
+      "displayName": "Google Calendar",
+      "aliases": [
+        "google-calendar@openai-curated",
+        "claude.ai google calendar",
+        "google calendar"
+      ],
+      "purpose": "Read availability and daily context when calendar evidence is explicitly requested.",
+      "permissions": [
+        "read",
+        "suggest"
+      ],
+      "dataClassification": [
+        "calendar_metadata",
+        "personal_schedule"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "create",
+        "update",
+        "delete",
+        "external_share"
+      ],
+      "auditLog": "Calendar action summary and issue/PR link before any change.",
+      "allowedReason": "Calendar context may guide WBS scheduling, while event mutations remain approval-gated.",
+      "auth": {
+        "required": true,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "gmail",
+      "displayName": "Gmail",
+      "aliases": [
+        "gmail@openai-curated",
+        "gmail"
+      ],
+      "purpose": "Read referenced email threads and draft replies only when the user asks.",
+      "permissions": [
+        "read",
+        "suggest"
+      ],
+      "dataClassification": [
+        "email_metadata",
+        "private_messages"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "send",
+        "delete",
+        "external_share"
+      ],
+      "auditLog": "Email thread reference plus explicit user approval before send/delete.",
+      "allowedReason": "Useful for user-requested inbox triage without autonomous outbound email.",
+      "auth": {
+        "required": true,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "notebooklm",
+      "displayName": "NotebookLM",
+      "aliases": [
+        "notebooklm",
+        "notebooklm-py"
+      ],
+      "purpose": "Harness-engineering source intake and long-context research summaries.",
+      "permissions": [
+        "read",
+        "suggest",
+        "source_add"
+      ],
+      "dataClassification": [
+        "internal_docs",
+        "research_notes"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "external_share",
+        "delete",
+        "bulk_upload"
+      ],
+      "auditLog": "Notebook id, source URL/path, generated summary, and issue/PR link.",
+      "allowedReason": "Issue #1586 depends on NotebookLM recheck evidence, but source changes stay recorded.",
+      "auth": {
+        "required": true,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "context7",
+      "displayName": "Context7",
+      "aliases": [
+        "context7",
+        "mcp__context7"
+      ],
+      "purpose": "Read-only public documentation lookup for implementation details.",
+      "permissions": [
+        "read",
+        "suggest"
+      ],
+      "dataClassification": [
+        "public_docs"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "external_share",
+        "write",
+        "admin"
+      ],
+      "auditLog": "Issue/PR note with the package or documentation source consulted.",
+      "allowedReason": "Public-doc lookup is allowed when scoped; any write-capable variant is denied by default.",
+      "auth": {
+        "required": false,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "playwright",
+      "displayName": "Playwright MCP",
+      "aliases": [
+        "mcp__playwright",
+        "playwright"
+      ],
+      "purpose": "Browser screenshots, console inspection, and visual evidence for UI checks.",
+      "permissions": [
+        "read",
+        "suggest",
+        "browser_interact"
+      ],
+      "dataClassification": [
+        "public_web",
+        "local_app_state"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "credential_entry",
+        "purchase",
+        "external_share"
+      ],
+      "auditLog": "Playwright artifacts, screenshots, and PR validation summary.",
+      "allowedReason": "UI verification needs deterministic browser evidence without adding extra live instances.",
+      "auth": {
+        "required": false,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "claude-mem",
+      "displayName": "Claude Memory Search",
+      "aliases": [
+        "claude-mem@thedotmack",
+        "mcp__plugin_claude-mem_mcp-search",
+        "plugin_claude-mem_mcp-search"
+      ],
+      "purpose": "Read-only local memory lookup for handoff and historical context.",
+      "permissions": [
+        "read",
+        "suggest"
+      ],
+      "dataClassification": [
+        "local_memory",
+        "project_notes"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "delete",
+        "external_share",
+        "bulk_export"
+      ],
+      "auditLog": "Issue/PR note that identifies which memory source informed the change.",
+      "allowedReason": "Memory lookup reduces duplicate WBS investigation while writes remain outside Codex #1 scope.",
+      "auth": {
+        "required": false,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "scheduled-tasks",
+      "displayName": "Scheduled Tasks",
+      "aliases": [
+        "mcp__scheduled-tasks",
+        "scheduled-tasks"
+      ],
+      "purpose": "Read existing scheduled task state when reconciling automation issues.",
+      "permissions": [
+        "read"
+      ],
+      "dataClassification": [
+        "automation_metadata"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "create",
+        "update",
+        "delete"
+      ],
+      "auditLog": "Automation id, issue link, and explicit user approval for mutations.",
+      "allowedReason": "Read-only schedule inspection helps avoid duplicate automations.",
+      "auth": {
+        "required": false,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "browser-use",
+      "displayName": "Browser Use",
+      "aliases": [
+        "browser-use@openai-bundled",
+        "browser-use"
+      ],
+      "purpose": "In-app browser navigation for local or public UI inspection.",
+      "permissions": [
+        "read",
+        "suggest",
+        "browser_interact"
+      ],
+      "dataClassification": [
+        "public_web",
+        "local_app_state"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "credential_entry",
+        "purchase",
+        "external_share"
+      ],
+      "auditLog": "Browser target URL and screenshot/console evidence in the PR summary.",
+      "allowedReason": "Codex #1 can gather UI evidence without launching another development instance.",
+      "auth": {
+        "required": false,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "documents",
+      "displayName": "Documents Runtime",
+      "aliases": [
+        "documents@openai-primary-runtime",
+        "documents"
+      ],
+      "purpose": "Local document rendering and verification for explicit file tasks.",
+      "permissions": [
+        "read",
+        "suggest",
+        "local_file_write"
+      ],
+      "dataClassification": [
+        "local_files"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "external_share",
+        "delete"
+      ],
+      "auditLog": "Changed local file path and render verification summary.",
+      "allowedReason": "Local runtime is allowed for user-requested document artifacts only.",
+      "auth": {
+        "required": false,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "spreadsheets",
+      "displayName": "Spreadsheets Runtime",
+      "aliases": [
+        "spreadsheets@openai-primary-runtime",
+        "spreadsheets"
+      ],
+      "purpose": "Local spreadsheet inspection, formatting, and verification for explicit file tasks.",
+      "permissions": [
+        "read",
+        "suggest",
+        "local_file_write"
+      ],
+      "dataClassification": [
+        "local_files"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "external_share",
+        "delete"
+      ],
+      "auditLog": "Changed local file path and verification summary.",
+      "allowedReason": "Local runtime is allowed for user-requested spreadsheet artifacts only.",
+      "auth": {
+        "required": false,
+        "status": "managed",
+        "expiresAt": null
+      }
+    },
+    {
+      "id": "presentations",
+      "displayName": "Presentations Runtime",
+      "aliases": [
+        "presentations@openai-primary-runtime",
+        "presentations"
+      ],
+      "purpose": "Local slide deck rendering and verification for explicit file tasks.",
+      "permissions": [
+        "read",
+        "suggest",
+        "local_file_write"
+      ],
+      "dataClassification": [
+        "local_files"
+      ],
+      "approver": "Claude Code #1",
+      "humanApprovalRequiredFor": [
+        "external_share",
+        "delete"
+      ],
+      "auditLog": "Changed local file path and render verification summary.",
+      "allowedReason": "Local runtime is allowed for user-requested presentation artifacts only.",
+      "auth": {
+        "required": false,
+        "status": "managed",
+        "expiresAt": null
+      }
+    }
+  ],
+  "deniedMcpServers": [
+    {
+      "id": "unmanaged-external",
+      "displayName": "Unmanaged external MCP server",
+      "aliases": [
+        "unknown-marketplace",
+        "third-party-mcp"
+      ],
+      "deniedReason": "Default-deny boundary: no external MCP server may be added without this file recording purpose, scopes, data classification, approver, and audit log.",
+      "approver": "Claude Code #1",
+      "reviewAfter": "2026-08-31"
+    },
+    {
+      "id": "direct-production-db",
+      "displayName": "Direct production database MCP",
+      "aliases": [
+        "prod-db",
+        "production-db",
+        "service-role-db"
+      ],
+      "deniedReason": "Production data access must go through reviewed Supabase scripts, GitHub Actions, or explicit user-approved runbooks.",
+      "approver": "Claude Code #1",
+      "reviewAfter": "2026-08-31"
+    },
+    {
+      "id": "context7-write",
+      "displayName": "Context7 write-capable variant",
+      "aliases": [
+        "context7-write",
+        "context7-admin"
+      ],
+      "deniedReason": "Context7 is approved for public documentation lookup only; write/admin variants are out of scope.",
+      "approver": "Claude Code #1",
+      "reviewAfter": "2026-08-31"
+    },
+    {
+      "id": "caveman",
+      "displayName": "Caveman plugin marketplace",
+      "aliases": [
+        "caveman@caveman",
+        "caveman"
+      ],
+      "deniedReason": "Not part of the two-instance WBS execution lane; re-enable only with a task-specific packet and approval.",
+      "approver": "Claude Code #1",
+      "reviewAfter": "2026-08-31"
+    },
+    {
+      "id": "superpowers",
+      "displayName": "Superpowers plugin marketplace",
+      "aliases": [
+        "superpowers@superpowers-marketplace",
+        "superpowers"
+      ],
+      "deniedReason": "Broad plugin surface is not required for scoped WBS PRs and must remain blocked unless explicitly approved.",
+      "approver": "Claude Code #1",
+      "reviewAfter": "2026-08-31"
+    }
+  ]
+}

--- a/docs/AGENT_TOOL_POLICY.md
+++ b/docs/AGENT_TOOL_POLICY.md
@@ -59,3 +59,22 @@ CEO approval screens.
 This follows the Harness Engineering direction from NotebookLM
 `bc58b50b-5fc4-4840-9a62-b397d6d3b65a`: Claude Code, Codex, and external AI
 agents should operate inside explicit scopes, approval gates, and audit logs.
+
+## Managed MCP Server Control
+
+Issue #1586 adds a repo-managed MCP access register:
+
+- authoritative config: `config/managed-mcp.json`
+- policy notes: `docs/automation/managed-mcp-access-control.md`
+- deterministic checker: `scripts/check_managed_mcp_policy.py`
+
+The default decision is deny. Any MCP server or plugin connector that is not in
+`allowedMcpServers` or `deniedMcpServers` must be treated as unmanaged at
+session start. Allowed entries must record purpose, permissions, data
+classification, approver, human-approval scopes, audit log, and reason. Denied
+entries must record a denial reason and review date.
+
+`scripts/codex_session_check.py` includes the managed MCP snapshot so local
+sessions warn on unmanaged servers, denied servers, expired or auth-required
+connectors, and dangerous permission settings. CI validates the JSON register
+without reading local secrets.

--- a/docs/automation/managed-mcp-access-control.md
+++ b/docs/automation/managed-mcp-access-control.md
@@ -1,0 +1,69 @@
+# Managed MCP Access Control
+
+Status: active / 2026-05-08 / Issue #1586
+
+The active development model is Claude Code #1 plus Codex #1 only. Historical
+Codex #2, Codex #3, PS, WEB, mobile, Gemini, and Copilot labels are routing
+metadata, not live instances.
+
+## Delegation Packet
+
+- WBS / Issue: #1586 managed-mcp.json MCP server organization access control
+- Due date: 2026-05-16
+- Current owner: Codex #1 implementation; Claude Code #1 policy and review boundary
+- Branch: codex/codex1-managed-mcp-policy-1586
+- Worktree: C:\Users\kanta\GitHub\my_web_app_wbs_sync
+- Allowed write set: config/managed-mcp.json, scripts/check_managed_mcp_policy.py, scripts/check_managed_mcp_policy_test.py, scripts/codex_session_check.py, docs/automation/managed-mcp-access-control.md, docs/AGENT_TOOL_POLICY.md, AGENTS.md, .github/workflows/managed-mcp-policy.yml
+- Prohibited write set: secrets, local credentials, production data, unrelated Flutter UI, Supabase migrations/functions
+- Required validation: managed MCP policy test, codex session JSON check, two-instance audit, minimal E2E gate test, no hook-bypass marker check, GitHub Actions green
+- Expected output: scoped PR, CI evidence, merged branch cleanup, Issue completion comment
+- Risk triggers that must return to Claude Code: new write-capable MCP server, production credential access, outbound Slack/Gmail/Drive writes, denied server exception, auth model change
+- Memory/disk hygiene action for this session: check C: free space and process pressure before/after; prune worktrees and git gc after merge
+
+## Managed Register
+
+The authoritative register is `config/managed-mcp.json`.
+
+- `allowedMcpServers` records purpose, permissions, data classification,
+  approver, human-approval scopes, audit log, auth status, and allow reason.
+- `deniedMcpServers` records denied aliases, reason, approver, and review date.
+- `defaultDecision` is `deny`, so any server not recorded in either list is
+  unmanaged and must trigger a session-start warning.
+
+Required issue #1586 integrations are present in the register: GitHub, Notion,
+Slack, Google Drive, NotebookLM, and Context7. Related Google Calendar, Gmail,
+Playwright, Browser Use, Claude Memory, and local document runtimes are also
+recorded because they appear in the active Codex/Claude tool surface.
+
+## Session-Start Gate
+
+`scripts/codex_session_check.py` now includes a Managed MCP Policy section. It
+imports `scripts/check_managed_mcp_policy.py` and scans repo settings plus local
+Claude/Codex settings when available.
+
+Warnings are emitted for:
+
+- active servers not listed in `allowedMcpServers` or `deniedMcpServers`
+- active servers that are explicitly denied
+- NotebookLM/connector auth cache entries that report re-authentication needed
+- dangerous local permission settings such as bypass mode, elevated sandbox,
+  destructive process/file commands, or credential-printing command patterns
+
+The session check is intentionally warning-first. CI validates the managed JSON
+deterministically, while local sessions surface risk without printing secrets.
+
+## Human Approval And Audit
+
+High-privilege SaaS operations remain human-approved:
+
+- Slack/Gmail sends, external shares, deletes, and bulk exports require explicit
+  user approval and must cite a permalink or thread reference.
+- GitHub merges, branch deletes, and admin writes require PR/issue timeline
+  evidence.
+- Drive/Docs/Sheets/Slides writes require target-document readback and a
+  recorded issue/PR link.
+- Production database or service-role access is denied as a direct MCP path and
+  must go through reviewed scripts, GitHub Actions, or an explicit runbook.
+
+Adding or changing a server requires a PR that updates the JSON register, this
+document when policy changes, and the managed MCP policy CI gate.

--- a/scripts/check_managed_mcp_policy.py
+++ b/scripts/check_managed_mcp_policy.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+"""Validate managed MCP access control and session-start warnings.
+
+Issue #1586 requires a repo-managed allow/deny register for MCP servers. This
+script keeps the contract deterministic: it validates the management JSON and
+can also scan local agent settings for unmanaged servers, auth warnings, and
+dangerous permission knobs without printing secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tomllib
+from dataclasses import asdict, dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = REPO_ROOT / "config" / "managed-mcp.json"
+
+REQUIRED_ALLOWED_FIELDS = {
+    "id",
+    "displayName",
+    "aliases",
+    "purpose",
+    "permissions",
+    "dataClassification",
+    "approver",
+    "humanApprovalRequiredFor",
+    "auditLog",
+    "allowedReason",
+    "auth",
+}
+
+REQUIRED_DENIED_FIELDS = {
+    "id",
+    "displayName",
+    "aliases",
+    "deniedReason",
+    "approver",
+    "reviewAfter",
+}
+
+REQUIRED_INTEGRATIONS = {
+    "github",
+    "notion",
+    "slack",
+    "google-drive",
+    "notebooklm",
+    "context7",
+}
+
+SECRET_KEYS = {
+    "key",
+    "token",
+    "secret",
+    "password",
+    "authorization",
+    "credential",
+}
+
+
+@dataclass(frozen=True)
+class SessionFinding:
+    severity: str
+    kind: str
+    source: str
+    server: str
+    message: str
+
+
+def normalize_id(value: str) -> str:
+    normalized = value.strip().lower().replace("\\", "/")
+    normalized = normalized.replace("@", "-at-")
+    normalized = re.sub(r"[^a-z0-9._/-]+", "-", normalized)
+    normalized = re.sub(r"-+", "-", normalized).strip("-")
+    return normalized
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def load_policy(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
+    return load_json(path)
+
+
+def string_list(value: Any) -> bool:
+    return isinstance(value, list) and bool(value) and all(isinstance(item, str) for item in value)
+
+
+def policy_ids(policy: dict[str, Any], key: str) -> list[str]:
+    entries = policy.get(key)
+    if not isinstance(entries, list):
+        return []
+    return [entry.get("id", "") for entry in entries if isinstance(entry, dict)]
+
+
+def entry_aliases(entry: dict[str, Any]) -> list[str]:
+    aliases = entry.get("aliases", [])
+    if not isinstance(aliases, list):
+        aliases = []
+    return [str(entry.get("id", "")), *[str(alias) for alias in aliases]]
+
+
+def alias_maps(policy: dict[str, Any]) -> tuple[dict[str, str], dict[str, str]]:
+    allowed: dict[str, str] = {}
+    denied: dict[str, str] = {}
+    for key, target in [("allowedMcpServers", allowed), ("deniedMcpServers", denied)]:
+        entries = policy.get(key, [])
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            entry_id = str(entry.get("id", ""))
+            for alias in entry_aliases(entry):
+                target[normalize_id(alias)] = entry_id
+    return allowed, denied
+
+
+def validate_policy(policy: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    if policy.get("schemaVersion") != 1:
+        errors.append("schemaVersion must be 1.")
+    if policy.get("status") != "active":
+        errors.append("status must be active.")
+    if policy.get("defaultDecision") != "deny":
+        errors.append("defaultDecision must be deny.")
+
+    owner = policy.get("ownerModel")
+    if not isinstance(owner, dict):
+        errors.append("ownerModel must be an object.")
+    else:
+        active = owner.get("activeInstances")
+        if active != ["Claude Code #1", "Codex #1"]:
+            errors.append("ownerModel.activeInstances must be Claude Code #1 + Codex #1 only.")
+
+    high_risk = policy.get("highRiskScopes")
+    if not string_list(high_risk):
+        errors.append("highRiskScopes must be a non-empty string array.")
+        high_risk_set: set[str] = set()
+    else:
+        high_risk_set = {item.lower() for item in high_risk}
+
+    danger_patterns = policy.get("dangerousPermissionPatterns")
+    if not string_list(danger_patterns):
+        errors.append("dangerousPermissionPatterns must be a non-empty string array.")
+    else:
+        for pattern in danger_patterns:
+            try:
+                re.compile(pattern, flags=re.IGNORECASE)
+            except re.error as exc:
+                errors.append(f"dangerousPermissionPatterns contains invalid regex `{pattern}`: {exc}.")
+
+    allowed = policy.get("allowedMcpServers")
+    denied = policy.get("deniedMcpServers")
+    if not isinstance(allowed, list) or not allowed:
+        errors.append("allowedMcpServers must be a non-empty array.")
+        allowed = []
+    if not isinstance(denied, list) or not denied:
+        errors.append("deniedMcpServers must be a non-empty array.")
+        denied = []
+
+    seen_ids: set[str] = set()
+    seen_aliases: dict[str, str] = {}
+
+    for section, entries, required in [
+        ("allowedMcpServers", allowed, REQUIRED_ALLOWED_FIELDS),
+        ("deniedMcpServers", denied, REQUIRED_DENIED_FIELDS),
+    ]:
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                errors.append(f"{section}[{index}] must be an object.")
+                continue
+            missing = sorted(required - set(entry))
+            if missing:
+                errors.append(f"{section}[{index}] is missing required fields: {', '.join(missing)}.")
+                continue
+            entry_id = str(entry["id"])
+            normalized_entry_id = normalize_id(entry_id)
+            if normalized_entry_id in seen_ids:
+                errors.append(f"Duplicate MCP server id `{entry_id}`.")
+            seen_ids.add(normalized_entry_id)
+            if not string_list(entry.get("aliases")):
+                errors.append(f"{section}.{entry_id}.aliases must be a non-empty string array.")
+            for alias in entry_aliases(entry):
+                normalized_alias = normalize_id(alias)
+                if normalized_alias in seen_aliases and seen_aliases[normalized_alias] != entry_id:
+                    errors.append(
+                        f"Alias `{alias}` is shared by `{seen_aliases[normalized_alias]}` and `{entry_id}`."
+                    )
+                seen_aliases[normalized_alias] = entry_id
+
+            if section == "allowedMcpServers":
+                for field in [
+                    "purpose",
+                    "approver",
+                    "auditLog",
+                    "allowedReason",
+                ]:
+                    if not str(entry.get(field, "")).strip():
+                        errors.append(f"allowedMcpServers.{entry_id}.{field} must be non-empty.")
+                for field in ["permissions", "dataClassification", "humanApprovalRequiredFor"]:
+                    if not string_list(entry.get(field)):
+                        errors.append(f"allowedMcpServers.{entry_id}.{field} must be a non-empty string array.")
+                auth = entry.get("auth")
+                if not isinstance(auth, dict):
+                    errors.append(f"allowedMcpServers.{entry_id}.auth must be an object.")
+                else:
+                    if not isinstance(auth.get("required"), bool):
+                        errors.append(f"allowedMcpServers.{entry_id}.auth.required must be boolean.")
+                    if auth.get("status") not in {"managed", "active", "not_required"}:
+                        errors.append(
+                            f"allowedMcpServers.{entry_id}.auth.status must be managed, active, or not_required."
+                        )
+                scopes = {str(item).lower() for item in entry.get("permissions", [])}
+                if scopes & high_risk_set and not string_list(entry.get("humanApprovalRequiredFor")):
+                    errors.append(
+                        f"allowedMcpServers.{entry_id} has high-risk scopes but no human approval list."
+                    )
+            else:
+                for field in ["deniedReason", "approver", "reviewAfter"]:
+                    if not str(entry.get(field, "")).strip():
+                        errors.append(f"deniedMcpServers.{entry_id}.{field} must be non-empty.")
+
+    allowed_ids = {normalize_id(item) for item in policy_ids(policy, "allowedMcpServers")}
+    denied_ids = {normalize_id(item) for item in policy_ids(policy, "deniedMcpServers")}
+    overlap = sorted(allowed_ids & denied_ids)
+    if overlap:
+        errors.append("Server ids cannot be both allowed and denied: " + ", ".join(overlap) + ".")
+
+    missing_required = sorted(REQUIRED_INTEGRATIONS - allowed_ids)
+    if missing_required:
+        errors.append(
+            "Required issue #1586 integrations missing from allowedMcpServers: "
+            + ", ".join(missing_required)
+            + "."
+        )
+
+    raw_policy = json.dumps(policy, ensure_ascii=False)
+    if re.search(r"\bCodex #?[23]\b", raw_policy, flags=re.IGNORECASE):
+        errors.append("managed MCP policy must not assign active work to Codex #2 or Codex #3.")
+
+    return errors
+
+
+def default_session_paths(root: Path, include_home: bool = False) -> list[Path]:
+    paths = [
+        root / ".claude" / "settings.json",
+        root / ".claude" / "settings.local.json",
+    ]
+    if include_home:
+        home = Path.home()
+        paths.extend(
+            [
+                home / ".claude" / "settings.json",
+                home / ".claude" / "settings.local.json",
+                home / ".claude" / "mcp-needs-auth-cache.json",
+                home / ".codex" / "config.toml",
+            ]
+        )
+    return paths
+
+
+def sanitize_scalar(key: str, value: Any) -> str:
+    lowered = key.lower()
+    if any(secret in lowered for secret in SECRET_KEYS):
+        return "<redacted>"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        return value if len(value) <= 120 else value[:117] + "..."
+    return type(value).__name__
+
+
+def flatten_settings(value: Any, prefix: str = "") -> list[tuple[str, str]]:
+    flattened: list[tuple[str, str]] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            key_str = str(key)
+            path = f"{prefix}.{key_str}" if prefix else key_str
+            flattened.extend(flatten_settings(item, path))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            flattened.extend(flatten_settings(item, f"{prefix}.{index}"))
+    else:
+        key = prefix.rsplit(".", 1)[-1]
+        flattened.append((prefix, sanitize_scalar(key, value)))
+    return flattened
+
+
+def extract_mcp_from_permissions(permissions: Any) -> set[str]:
+    servers: set[str] = set()
+    if not isinstance(permissions, dict):
+        return servers
+    allow = permissions.get("allow", [])
+    if not isinstance(allow, list):
+        return servers
+    for item in allow:
+        if not isinstance(item, str):
+            continue
+        for match in re.finditer(r"\bmcp__([A-Za-z0-9_.@/-]+)__", item):
+            servers.add(match.group(1))
+        if "notebooklm" in item.lower():
+            servers.add("notebooklm")
+    return servers
+
+
+def extract_servers_from_json(path: Path, data: dict[str, Any]) -> tuple[set[str], list[str]]:
+    servers: set[str] = set()
+    danger_evidence: list[str] = []
+
+    mcp_servers = data.get("mcpServers")
+    if isinstance(mcp_servers, dict):
+        servers.update(str(key) for key in mcp_servers)
+
+    enabled_plugins = data.get("enabledPlugins")
+    if isinstance(enabled_plugins, dict):
+        for key, value in enabled_plugins.items():
+            if value is True:
+                servers.add(str(key))
+
+    servers.update(extract_mcp_from_permissions(data.get("permissions")))
+
+    for key_path, value in flatten_settings(data):
+        danger_evidence.append(f"{path}::{key_path}={value}")
+    return servers, danger_evidence
+
+
+def extract_servers_from_toml(path: Path, data: dict[str, Any]) -> tuple[set[str], list[str]]:
+    servers: set[str] = set()
+    danger_evidence: list[str] = []
+
+    mcp_servers = data.get("mcp_servers")
+    if isinstance(mcp_servers, dict):
+        servers.update(str(key) for key in mcp_servers)
+
+    plugins = data.get("plugins")
+    if isinstance(plugins, dict):
+        for key, value in plugins.items():
+            if isinstance(value, dict) and value.get("enabled") is True:
+                servers.add(str(key))
+
+    for key_path, value in flatten_settings(data):
+        danger_evidence.append(f"{path}::{key_path}={value}")
+    return servers, danger_evidence
+
+
+def auth_cache_servers(path: Path, data: dict[str, Any]) -> list[SessionFinding]:
+    findings: list[SessionFinding] = []
+    for key in data:
+        findings.append(
+            SessionFinding(
+                severity="warning",
+                kind="auth_required",
+                source=str(path),
+                server=str(key),
+                message=f"Auth cache reports `{key}` needs re-authentication.",
+            )
+        )
+    return findings
+
+
+def load_settings_file(path: Path) -> tuple[set[str], list[str], list[SessionFinding]]:
+    if not path.exists():
+        return set(), [], []
+    if path.suffix.lower() == ".json":
+        data = load_json(path)
+        if path.name == "mcp-needs-auth-cache.json":
+            return set(data.keys()), [], auth_cache_servers(path, data)
+        servers, danger = extract_servers_from_json(path, data)
+        return servers, danger, []
+    if path.suffix.lower() == ".toml":
+        data = tomllib.loads(path.read_text(encoding="utf-8-sig"))
+        servers, danger = extract_servers_from_toml(path, data)
+        return servers, danger, []
+    return set(), [], []
+
+
+def match_policy_server(server: str, allowed: dict[str, str], denied: dict[str, str]) -> tuple[str, str | None]:
+    normalized = normalize_id(server)
+    if normalized in denied:
+        return "denied", denied[normalized]
+    if normalized in allowed:
+        return "allowed", allowed[normalized]
+    for aliases, status in [(denied, "denied"), (allowed, "allowed")]:
+        for alias, entry_id in aliases.items():
+            if alias and (normalized.endswith(alias) or alias.endswith(normalized)):
+                return status, entry_id
+    return "unmanaged", None
+
+
+def dangerous_findings(
+    evidence: list[str],
+    patterns: list[str],
+    max_findings: int = 25,
+) -> list[SessionFinding]:
+    findings: list[SessionFinding] = []
+    compiled = [re.compile(pattern, flags=re.IGNORECASE) for pattern in patterns]
+    for item in evidence:
+        if len(findings) >= max_findings:
+            findings.append(
+                SessionFinding(
+                    severity="warning",
+                    kind="dangerous_permission",
+                    source="settings",
+                    server="settings",
+                    message="Additional dangerous permission findings were truncated.",
+                )
+            )
+            return findings
+        for pattern in compiled:
+            if pattern.search(item):
+                source, _, detail = item.partition("::")
+                findings.append(
+                    SessionFinding(
+                        severity="warning",
+                        kind="dangerous_permission",
+                        source=source,
+                        server="settings",
+                        message=f"Dangerous permission setting matched `{pattern.pattern}` at `{detail}`.",
+                    )
+                )
+                break
+    return findings
+
+
+def config_auth_findings(policy: dict[str, Any]) -> list[SessionFinding]:
+    findings: list[SessionFinding] = []
+    today = date.today()
+    for entry in policy.get("allowedMcpServers", []):
+        if not isinstance(entry, dict):
+            continue
+        auth = entry.get("auth")
+        if not isinstance(auth, dict):
+            continue
+        entry_id = str(entry.get("id", "unknown"))
+        expires_at = auth.get("expiresAt")
+        if isinstance(expires_at, str) and expires_at:
+            try:
+                if date.fromisoformat(expires_at) < today:
+                    findings.append(
+                        SessionFinding(
+                            severity="warning",
+                            kind="auth_expired",
+                            source="managed-mcp.json",
+                            server=entry_id,
+                            message=f"`{entry_id}` auth expiry date `{expires_at}` is in the past.",
+                        )
+                    )
+            except ValueError:
+                findings.append(
+                    SessionFinding(
+                        severity="warning",
+                        kind="auth_expiry_invalid",
+                        source="managed-mcp.json",
+                        server=entry_id,
+                        message=f"`{entry_id}` auth expiry date `{expires_at}` is invalid.",
+                    )
+                )
+    return findings
+
+
+def session_findings(
+    policy: dict[str, Any],
+    settings_paths: list[Path],
+) -> list[SessionFinding]:
+    allowed, denied = alias_maps(policy)
+    findings: list[SessionFinding] = []
+    danger_evidence: list[str] = []
+    active_servers: list[tuple[str, str]] = []
+
+    for path in settings_paths:
+        try:
+            servers, danger, auth_findings = load_settings_file(path)
+        except (json.JSONDecodeError, OSError, tomllib.TOMLDecodeError) as exc:
+            findings.append(
+                SessionFinding(
+                    severity="warning",
+                    kind="settings_unreadable",
+                    source=str(path),
+                    server="settings",
+                    message=f"Could not inspect settings file: {exc}",
+                )
+            )
+            continue
+        danger_evidence.extend(danger)
+        findings.extend(auth_findings)
+        active_servers.extend((str(path), server) for server in sorted(servers))
+
+    for source, server in active_servers:
+        status, entry_id = match_policy_server(server, allowed, denied)
+        if status == "denied":
+            findings.append(
+                SessionFinding(
+                    severity="error",
+                    kind="denied_server_active",
+                    source=source,
+                    server=server,
+                    message=f"`{server}` is active but denied by managed MCP policy as `{entry_id}`.",
+                )
+            )
+        elif status == "unmanaged":
+            findings.append(
+                SessionFinding(
+                    severity="warning",
+                    kind="unmanaged_server",
+                    source=source,
+                    server=server,
+                    message=f"`{server}` is not recorded in allowedMcpServers or deniedMcpServers.",
+                )
+            )
+
+    patterns = policy.get("dangerousPermissionPatterns")
+    if isinstance(patterns, list):
+        findings.extend(dangerous_findings(danger_evidence, [str(item) for item in patterns]))
+    findings.extend(config_auth_findings(policy))
+    return findings
+
+
+def build_report(
+    policy: dict[str, Any],
+    validation_errors: list[str],
+    findings: list[SessionFinding],
+    config_path: Path = DEFAULT_CONFIG,
+) -> dict[str, Any]:
+    return {
+        "config": str(config_path),
+        "valid": not validation_errors,
+        "validation_errors": validation_errors,
+        "allowed_count": len(policy.get("allowedMcpServers", []) or []),
+        "denied_count": len(policy.get("deniedMcpServers", []) or []),
+        "session_findings": [asdict(finding) for finding in findings],
+        "session_warning_count": sum(1 for finding in findings if finding.severity == "warning"),
+        "session_error_count": sum(1 for finding in findings if finding.severity == "error"),
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"Managed MCP policy: {'PASS' if report['valid'] else 'FAIL'}",
+        f"Allowed servers: {report['allowed_count']}",
+        f"Denied servers: {report['denied_count']}",
+    ]
+    if report["validation_errors"]:
+        lines.append("Validation errors:")
+        for error in report["validation_errors"]:
+            lines.append(f"- {error}")
+    if report["session_findings"]:
+        lines.append("Session-start findings:")
+        for item in report["session_findings"]:
+            lines.append(
+                f"- [{item['severity']}] {item['kind']} {item['server']}: {item['message']}"
+            )
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--json", action="store_true", help="Print JSON report.")
+    parser.add_argument("--session-start", action="store_true", help="Scan settings files for warnings.")
+    parser.add_argument("--include-home", action="store_true", help="Include ~/.claude and ~/.codex settings.")
+    parser.add_argument("--settings", type=Path, action="append", default=[], help="Settings file to scan.")
+    parser.add_argument(
+        "--strict-session",
+        action="store_true",
+        help="Exit non-zero when session-start findings include warnings or errors.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
+    args = parse_args(argv)
+    policy = load_policy(args.config)
+    validation_errors = validate_policy(policy)
+    findings: list[SessionFinding] = []
+    if args.session_start:
+        paths = args.settings or default_session_paths(REPO_ROOT, include_home=args.include_home)
+        findings = session_findings(policy, paths)
+
+    report = build_report(policy, validation_errors, findings, args.config)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(render_text(report))
+
+    if validation_errors:
+        return 1
+    if args.strict_session and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_managed_mcp_policy_test.py
+++ b/scripts/check_managed_mcp_policy_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_managed_mcp_policy import (
+    DEFAULT_CONFIG,
+    load_policy,
+    session_findings,
+    validate_policy,
+)
+
+
+class ManagedMcpPolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = load_policy(DEFAULT_CONFIG)
+
+    def test_default_policy_is_valid(self) -> None:
+        errors = validate_policy(self.policy)
+        self.assertEqual(errors, [])
+
+    def test_required_integrations_are_enforced(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["allowedMcpServers"] = [
+            entry for entry in policy["allowedMcpServers"] if entry["id"] != "github"
+        ]
+
+        errors = validate_policy(policy)
+
+        self.assertTrue(any("github" in error for error in errors), errors)
+
+    def test_unmanaged_server_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = Path(tmp) / "settings.json"
+            settings.write_text(
+                json.dumps({"mcpServers": {"random-ai": {"command": "random-ai"}}}),
+                encoding="utf-8",
+            )
+
+            findings = session_findings(self.policy, [settings])
+
+        self.assertTrue(any(f.kind == "unmanaged_server" for f in findings), findings)
+
+    def test_denied_server_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = Path(tmp) / "settings.json"
+            settings.write_text(
+                json.dumps({"enabledPlugins": {"caveman@caveman": True}}),
+                encoding="utf-8",
+            )
+
+            findings = session_findings(self.policy, [settings])
+
+        self.assertTrue(any(f.kind == "denied_server_active" for f in findings), findings)
+
+    def test_auth_cache_maps_to_session_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = Path(tmp) / "mcp-needs-auth-cache.json"
+            cache.write_text(
+                json.dumps({"claude.ai Google Drive": {"timestamp": 1778049805068}}),
+                encoding="utf-8",
+            )
+
+            findings = session_findings(self.policy, [cache])
+
+        self.assertTrue(any(f.kind == "auth_required" for f in findings), findings)
+
+    def test_codex_toml_plugins_are_mapped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "config.toml"
+            config.write_text(
+                '\n'.join(
+                    [
+                        '[mcp_servers.notion]',
+                        'url = "https://mcp.notion.com/mcp"',
+                        '[plugins."github@openai-curated"]',
+                        'enabled = true',
+                        '[plugins."slack@openai-curated"]',
+                        'enabled = true',
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            findings = session_findings(self.policy, [config])
+
+        unmanaged = [finding for finding in findings if finding.kind == "unmanaged_server"]
+        self.assertEqual(unmanaged, [])
+
+    def test_dangerous_permission_is_reported_without_secret_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = Path(tmp) / "settings.json"
+            settings.write_text(
+                json.dumps(
+                    {
+                        "permissions": {
+                            "defaultMode": "bypassPermissions",
+                            "allow": ["Bash(printenv SUPABASE_SERVICE_ROLE_KEY)"],
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            findings = session_findings(self.policy, [settings])
+
+        danger = [finding for finding in findings if finding.kind == "dangerous_permission"]
+        self.assertTrue(danger, findings)
+        self.assertFalse(any("gho_" in finding.message for finding in danger))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/codex_session_check.py
+++ b/scripts/codex_session_check.py
@@ -15,7 +15,7 @@ import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -313,6 +313,59 @@ def notebooklm_snapshot(root: Path) -> dict[str, Any]:
     }
 
 
+def managed_mcp_snapshot(root: Path) -> dict[str, Any]:
+    config_path = root / "config" / "managed-mcp.json"
+    if not config_path.exists():
+        return {
+            "state": "missing",
+            "config": str(config_path),
+            "validation_errors": ["config/managed-mcp.json is missing"],
+            "session_findings": [],
+            "session_warning_count": 0,
+            "session_error_count": 0,
+        }
+    try:
+        from check_managed_mcp_policy import (
+            default_session_paths,
+            load_policy,
+            session_findings,
+            validate_policy,
+        )
+    except Exception as exc:
+        return {
+            "state": "unavailable",
+            "config": str(config_path),
+            "validation_errors": [f"could not import managed MCP checker: {exc}"],
+            "session_findings": [],
+            "session_warning_count": 0,
+            "session_error_count": 0,
+        }
+    try:
+        policy = load_policy(config_path)
+        validation_errors = validate_policy(policy)
+        findings = session_findings(
+            policy,
+            default_session_paths(root, include_home=True),
+        )
+    except Exception as exc:
+        return {
+            "state": "error",
+            "config": str(config_path),
+            "validation_errors": [f"managed MCP check failed: {exc}"],
+            "session_findings": [],
+            "session_warning_count": 0,
+            "session_error_count": 0,
+        }
+    return {
+        "state": "ok" if not validation_errors else "invalid",
+        "config": str(config_path),
+        "validation_errors": validation_errors,
+        "session_findings": [asdict(finding) for finding in findings],
+        "session_warning_count": sum(1 for finding in findings if finding.severity == "warning"),
+        "session_error_count": sum(1 for finding in findings if finding.severity == "error"),
+    }
+
+
 def parse_semver(text: str) -> tuple[int, int, int] | None:
     match = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
     if not match:
@@ -334,6 +387,7 @@ def analyze(cwd: Path) -> dict[str, Any]:
     codex_version = codex_cli_version(root)
     notebooklm = notebooklm_snapshot(root)
     claude_remote_control = analyze_claude_remote_control(root)
+    managed_mcp = managed_mcp_snapshot(root)
 
     warnings: list[str] = []
     if dirty_lines:
@@ -384,6 +438,14 @@ def analyze(cwd: Path) -> dict[str, Any]:
         warnings.append(
             "Claude Code Remote Control all-sessions mode is not verified as enabled; run `/config` in Claude Code"
         )
+    if managed_mcp["validation_errors"]:
+        warnings.append("managed MCP policy validation failed")
+    for finding in managed_mcp["session_findings"][:12]:
+        warnings.append(f"managed MCP {finding['kind']}: {finding['message']}")
+    if len(managed_mcp["session_findings"]) > 12:
+        warnings.append(
+            f"managed MCP additional findings truncated: {len(managed_mcp['session_findings']) - 12}"
+        )
 
     return {
         "root": str(root),
@@ -399,6 +461,7 @@ def analyze(cwd: Path) -> dict[str, Any]:
         "codex_cli_version": codex_version,
         "notebooklm": notebooklm,
         "claude_remote_control": claude_remote_control,
+        "managed_mcp": managed_mcp,
         "worktrees": worktrees,
         "environment": env_snapshot(),
         "warnings": warnings,
@@ -453,6 +516,22 @@ def render_markdown(report: dict[str, Any]) -> str:
         for step in remote["manual_steps"]:
             lines.append(f"  - {step}")
         lines.append(f"- Team/Enterprise note: {remote['admin_note']}")
+
+    managed_mcp = report["managed_mcp"]
+    lines.extend(
+        [
+            "",
+            "## Managed MCP Policy",
+            f"- State: `{managed_mcp['state']}`",
+            f"- Config: `{managed_mcp['config']}`",
+            f"- Validation errors: `{len(managed_mcp['validation_errors'])}`",
+            f"- Session warnings/errors: `{managed_mcp['session_warning_count']} / {managed_mcp['session_error_count']}`",
+        ]
+    )
+    for finding in managed_mcp["session_findings"][:8]:
+        lines.append(
+            f"- `{finding['severity']}` `{finding['kind']}` `{finding['server']}`: {finding['message']}"
+        )
 
     lines.extend(["", "## Warnings"])
     if report["warnings"]:


### PR DESCRIPTION
﻿## Summary

- Adds `config/managed-mcp.json` as the default-deny MCP allow/deny register for Issue #1586.
- Adds deterministic validation, unit tests, and a GitHub Actions gate for managed MCP policy changes.
- Wires `scripts/codex_session_check.py` to warn at session start on unmanaged servers, denied servers, auth-required cache entries, and dangerous permission settings.
- Updates active guidance so historical extra Codex lanes are absorbed by Codex #1 under the Claude Code #1 + Codex #1 flow.

## Delegation Packet

- WBS / Issue: #1586 `[追加要望][P1] managed-mcp.jsonによるMCPサーバー組織アクセス統制`
- Due date: 2026-05-16
- Current owner: Codex #1 implementation; Claude Code #1 policy/review boundary
- Branch: `codex/codex1-managed-mcp-policy-1586`
- Worktree: `C:\Users\kanta\GitHub\my_web_app_wbs_sync`
- Allowed write set: `config/managed-mcp.json`, managed MCP checker/tests, `scripts/codex_session_check.py`, managed MCP docs, `AGENTS.md`, `.github/workflows/managed-mcp-policy.yml`
- Prohibited write set: secrets, local credentials, production data, unrelated Flutter UI, Supabase migrations/functions
- Required validation: managed MCP policy tests, session-start scan, two-instance audit, minimal E2E gate test, hook-bypass marker check, GitHub Actions green
- Risk triggers that return to Claude Code #1: new write-capable MCP server, production credential access, denied-server exception, auth model change
- Memory/disk hygiene action: pre-check completed; post-merge cleanup will run `git worktree prune`, `git gc --auto`, process/port check, and C: free-space check

## Validation

- `python scripts\check_managed_mcp_policy.py --config config\managed-mcp.json`
- `python scripts\check_managed_mcp_policy_test.py`
- `python scripts\two_instance_audit.py --fail-on-active`
- `python scripts\check_minimal_e2e_gate_test.py`
- `python scripts\check_no_verify_bypass.py --range origin/main..HEAD`
- `git diff --check HEAD~1..HEAD`
- YAML parse: `.github/workflows/managed-mcp-policy.yml`

## Minimal E2E Gate

- This is implementation-detail independent / black-box for the runtime app: no Flutter, Supabase runtime, or user-facing app surface changes are included.
- Minimal plan: three cases are covered by deterministic I/O checks: valid managed config passes, unmanaged/denied server settings emit warnings/errors, and dangerous permissions/auth-required cache entries are reported without leaking secret values.
- E2E mechanism: Python policy tests plus the managed MCP GitHub Actions gate; existing Playwright public smoke remains covered by the repository Minimal E2E Gate.
- E2E-Exception: policy/docs/CI-only access-control wiring; no app-code path requires a new `integration_test/` or `test/e2e/` file.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: policy/config-only MCP access-control gate; no runtime credential access, no production deploy behavior, no database migration, and no outbound SaaS write path is added.

Closes #1586
