### PR TITLE
fix: harden kg indexer nightly

### DIFF
--- a/.github/workflows/kg-indexer-nightly.yml
+++ b/.github/workflows/kg-indexer-nightly.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -46,27 +47,62 @@ jobs:
         shell: bash
         run: |
           mkdir -p tmp/kg-indexer
-          python scripts/kg_index_github_issues.py \
-            --repo "$GITHUB_REPOSITORY" \
-            --limit 200 \
-            --output tmp/kg-indexer/github-issues.jsonl \
-            ${{ steps.mode.outputs.args }}
-          python scripts/kg_index_wbs_tasks.py \
-            --limit 200 \
-            --output tmp/kg-indexer/wbs.jsonl \
-            ${{ steps.mode.outputs.args }}
-          python scripts/kg_index_docs.py \
-            --limit 500 \
-            --output tmp/kg-indexer/docs.jsonl \
-            ${{ steps.mode.outputs.args }}
-          python scripts/kg_index_memory_vault.py \
-            --limit 200 \
-            --output tmp/kg-indexer/memory.jsonl \
-            ${{ steps.mode.outputs.args }}
-          python scripts/kg_index_notebooklm_intake.py \
-            --limit 200 \
-            --output tmp/kg-indexer/notebooklm.jsonl \
-            ${{ steps.mode.outputs.args }}
+          failures=()
+
+          run_indexer() {
+            local name="$1"
+            shift
+            echo "::group::kg-indexer ${name}"
+            if "$@"; then
+              echo "::notice::kg-indexer ${name} completed"
+            else
+              local code="$?"
+              echo "::error::kg-indexer ${name} failed with exit code ${code}"
+              failures+=("${name}:${code}")
+            fi
+            echo "::endgroup::"
+          }
+
+          run_indexer github-issues \
+            python scripts/kg_index_github_issues.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --limit 200 \
+              --output tmp/kg-indexer/github-issues.jsonl \
+              ${{ steps.mode.outputs.args }}
+          run_indexer wbs \
+            python scripts/kg_index_wbs_tasks.py \
+              --limit 200 \
+              --output tmp/kg-indexer/wbs.jsonl \
+              ${{ steps.mode.outputs.args }}
+          run_indexer docs \
+            python scripts/kg_index_docs.py \
+              --limit 500 \
+              --output tmp/kg-indexer/docs.jsonl \
+              ${{ steps.mode.outputs.args }}
+          run_indexer memory \
+            python scripts/kg_index_memory_vault.py \
+              --limit 200 \
+              --output tmp/kg-indexer/memory.jsonl \
+              ${{ steps.mode.outputs.args }}
+          run_indexer notebooklm \
+            python scripts/kg_index_notebooklm_intake.py \
+              --limit 200 \
+              --output tmp/kg-indexer/notebooklm.jsonl \
+              ${{ steps.mode.outputs.args }}
+
+          artifact_count="$(find tmp/kg-indexer -maxdepth 1 -type f -name '*.jsonl' | wc -l | tr -d ' ')"
+          echo "kg-indexer artifact count: ${artifact_count}"
+          if [ "${artifact_count}" -eq 0 ]; then
+            printf '%s\n' "${failures[@]}" > tmp/kg-indexer/failures.txt
+            echo "::error::No kg-indexer artifacts were produced"
+            exit 1
+          fi
+
+          if [ "${#failures[@]}" -gt 0 ]; then
+            printf '%s\n' "${failures[@]}" > tmp/kg-indexer/failures.txt
+            echo "::error::Some kg indexers failed after producing ${artifact_count} artifact(s); uploaded partial artifacts before opening the failure issue."
+            exit 1
+          fi
 
       - name: Upload indexer artifacts
         if: always()

--- a/scripts/kg_index_workflow_test.py
+++ b/scripts/kg_index_workflow_test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Regression tests for kg-indexer-nightly workflow resilience."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "kg-indexer-nightly.yml"
+
+
+class KgIndexerWorkflowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_run_indexers_has_github_token(self) -> None:
+        self.assertIn("GH_TOKEN: ${{ github.token }}", self.text)
+
+    def test_indexers_run_fail_soft(self) -> None:
+        for marker in [
+            "failures=()",
+            "run_indexer()",
+            "artifact_count=",
+            "No kg-indexer artifacts were produced",
+            "uploaded partial artifacts before opening the failure issue",
+        ]:
+            self.assertIn(marker, self.text)
+
+    def test_all_expected_indexers_are_invoked(self) -> None:
+        for script in [
+            "scripts/kg_index_github_issues.py",
+            "scripts/kg_index_wbs_tasks.py",
+            "scripts/kg_index_docs.py",
+            "scripts/kg_index_memory_vault.py",
+            "scripts/kg_index_notebooklm_intake.py",
+        ]:
+            self.assertIn(script, self.text)
+
+    def test_failure_issue_step_is_preserved(self) -> None:
+        self.assertIn("Open or update failure issue", self.text)
+        self.assertIn("if: failure()", self.text)
+        self.assertIn("[Schedule監視] kg-indexer-nightly failure", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

- Fixes the nightly Knowledge Graph indexer root cause: the scheduled Actions job did not expose GitHub CLI authentication to the indexer step, so `kg_index_github_issues.py` exited before any artifacts were written.
- Adds a fail-soft indexer wrapper: all five source indexers run, partial artifacts are uploaded on failure, and the failure issue path remains active when any indexer fails.
- Adds a lightweight workflow regression test to pin auth wiring, fail-soft aggregation, expected indexer coverage, and the failure issue step.

Closes #2152

## Delegation / Instance Model

- Codex #1 (Windows app) owns the implementation and CI lane for this scoped PR.
- Claude Code #1 remains the design/review counterpart under the 2-instance model.
- Old Codex #2/#3 references in the issue are historical only; no sub-agent or additional Codex instance was started.

## Minimal E2E Gate

- Implementation-detail independent: validation checks workflow-observable inputs/outputs, not private helper internals.
- Minimal scope: 3 cases are covered by local validation: GitHub issues indexer auth smoke, all five JSONL artifact outputs, and failure issue preservation markers.
- E2E mechanism: no Flutter integration_test or Playwright route is relevant for this CI-only workflow change; `scripts/kg_index_workflow_test.py` plus local indexer smoke is the E2E-equivalent contract.
- E2E-Exception: no app runtime, UI route, or user-facing browser behavior changed; manual verification is the workflow syntax parse and five-indexer smoke run listed below.

## Visual E2E Evidence

- Not applicable: workflow/scripts-only change, no UI surface.

## High-risk Ultrareview Gate

- High-risk-ultrareview-exception: Claude Code #1 is the review owner; this is a scoped scheduler workflow repair with no app runtime change, no production deploy path change, no data migration, and no stored credential value change.

## Validation

- `python scripts\kg_index_workflow_test.py`
- YAML parse of `.github/workflows/kg-indexer-nightly.yml`
- Local smoke: all five `kg_index_*` scripts with `--limit 3` produced JSONL artifacts.
- `python scripts\check_minimal_e2e_gate_test.py`
- `python scripts\two_instance_audit.py --fail-on-active`
- `python scripts\check_no_verify_bypass.py --range origin/main..HEAD`
- `git diff --check` (passed; Windows checkout emitted LF/CRLF advisory only)

## Notes

- If every indexer fails, the workflow now writes `failures.txt` before exiting so upload-artifact no longer reports a missing `tmp/kg-indexer/` path.
- If only one source fails, the remaining sources still run; the step exits after aggregation so the existing failure issue automation can report the incident while preserving partial artifacts.
