### PR TITLE
feat: add schedule resilience watch

### DIFF
--- a/.github/workflows/schedule-resilience-watch.yml
+++ b/.github/workflows/schedule-resilience-watch.yml
@@ -1,0 +1,54 @@
+name: Schedule Resilience Watch
+
+on:
+  schedule:
+    - cron: "22 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Inspect schedules without retrying runs or writing issues"
+        required: false
+        default: "false"
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: schedule-resilience-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    name: Watch scheduled workflow resilience
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Watch scheduled workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p tmp/schedule-resilience
+          DRY_RUN_ARG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_ARG="--dry-run"
+          fi
+          python scripts/schedule_resilience_watch.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --max-attempts 2 \
+            --output tmp/schedule-resilience/report.json \
+            --github-step-summary "$GITHUB_STEP_SUMMARY" \
+            $DRY_RUN_ARG
+
+      - name: Upload resilience report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: schedule-resilience-report
+          path: tmp/schedule-resilience/
+          if-no-files-found: warn

--- a/docs/SCHEDULE_TASKS.md
+++ b/docs/SCHEDULE_TASKS.md
@@ -915,3 +915,30 @@ python scripts/ai_tool_watch.py --print-only
 `codex_session_check.py` に dirty worktree、upstream gone、base branch 直編集、origin/main 未取得などの警告が
 出た場合は、実装前に新しい worktree / branch へ移るか、Codex#2 に sync / CI 側の修復として回す。
 
+
+## NotebookLM 9b8885ef Schedule Resilience Guard (#1783)
+
+NotebookLM `9b8885ef` ("Automating SaaS Operations with Claude Code Schedule") is applied as a
+cross-cutting guard instead of duplicating retry code inside every scheduled workflow.
+
+**Workflow**: `.github/workflows/schedule-resilience-watch.yml`
+**Script**: `scripts/schedule_resilience_watch.py`
+**Scope**: `daily-report.yml`, `cs-check.yml`, `competitor-monitoring.yml`, `infra-health-check.yml`
+
+Guard contract:
+
+1. **Retry**: when the latest scheduled run failed and `run_attempt < 2`, rerun failed jobs once through the GitHub Actions API.
+2. **Fallback**: when retry is exhausted, the run conclusion is unexpected, or no recent scheduled run exists, keep the guard itself green and preserve a JSON artifact for triage.
+3. **Alerting**: open or update a `workflow-failure` issue titled `[Schedule監視] <task> ...` with run URL, status, attempt, and the Codex #1 ownership note.
+4. **Freshness**: hourly schedules (`cs-check`, `infra-health-check`) must have a scheduled run within 3h; daily schedules (`daily-report`, `competitor-monitoring`) within 30h.
+
+2-instance routing:
+
+- Claude Code #1 owns automation pattern design and doc triage.
+- Codex #1 owns the old PS#1 workflow-health implementation lane and GitHub Actions CI integration.
+
+Manual dry run:
+
+```bash
+python scripts/schedule_resilience_watch.py --repo kanta13jp1/my_web_app --dry-run --output tmp/schedule-resilience/report.json
+```

--- a/scripts/schedule_resilience_watch.py
+++ b/scripts/schedule_resilience_watch.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Retry and alert guard for scheduled GitHub Actions workflows.
+
+The guard watches a small set of production schedules, retries failed scheduled
+runs once, and opens/updates a workflow-failure issue when retry is exhausted or
+the schedule has stopped producing runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+OK_CONCLUSIONS = {"success", "skipped", "neutral"}
+BAD_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "startup_failure",
+    "timed_out",
+}
+
+
+@dataclass(frozen=True)
+class WorkflowTarget:
+    key: str
+    workflow_file: str
+    max_age_hours: int
+
+
+TARGETS = (
+    WorkflowTarget("daily-report", "daily-report.yml", 30),
+    WorkflowTarget("cs-check", "cs-check.yml", 3),
+    WorkflowTarget("competitor-monitoring", "competitor-monitoring.yml", 30),
+    WorkflowTarget("infra-health-check", "infra-health-check.yml", 3),
+)
+
+
+def parse_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized).astimezone(timezone.utc)
+
+
+def run_url(run: dict[str, Any]) -> str:
+    return str(run.get("html_url") or run.get("url") or "")
+
+
+def evaluate_target(
+    target: WorkflowTarget,
+    runs: list[dict[str, Any]],
+    now: datetime,
+    *,
+    max_attempts: int,
+) -> dict[str, Any]:
+    if not runs:
+        return {
+            "target": target.key,
+            "action": "alert",
+            "reason": "missing-run",
+            "title": f"[Schedule監視] {target.key} missing run",
+            "body": (
+                f"No scheduled run was found for `{target.workflow_file}`. "
+                "This may mean the schedule is disabled or GitHub Actions did "
+                "not dispatch it."
+            ),
+        }
+
+    latest = runs[0]
+    status = str(latest.get("status") or "unknown")
+    conclusion = str(latest.get("conclusion") or "")
+    run_attempt = int(latest.get("run_attempt") or 1)
+    created_at = parse_time(str(latest.get("created_at") or ""))
+    age_hours = None
+    if created_at is not None:
+        age_hours = (now - created_at).total_seconds() / 3600
+
+    base = {
+        "target": target.key,
+        "workflow_file": target.workflow_file,
+        "run_id": latest.get("id"),
+        "run_attempt": run_attempt,
+        "status": status,
+        "conclusion": conclusion,
+        "url": run_url(latest),
+        "created_at": latest.get("created_at"),
+        "age_hours": round(age_hours, 2) if age_hours is not None else None,
+    }
+
+    if status != "completed":
+        return {**base, "action": "observe", "reason": f"run-{status}"}
+
+    if conclusion in OK_CONCLUSIONS:
+        if age_hours is not None and age_hours > target.max_age_hours:
+            return {
+                **base,
+                "action": "alert",
+                "reason": "stale-success",
+                "title": f"[Schedule監視] {target.key} stale schedule",
+                "body": (
+                    f"Latest scheduled run for `{target.workflow_file}` is "
+                    f"{age_hours:.1f}h old, exceeding the {target.max_age_hours}h guard."
+                ),
+            }
+        return {**base, "action": "healthy", "reason": "latest-success"}
+
+    if conclusion in BAD_CONCLUSIONS:
+        if run_attempt < max_attempts:
+            return {
+                **base,
+                "action": "retry",
+                "reason": f"failed-attempt-{run_attempt}",
+            }
+        return {
+            **base,
+            "action": "alert",
+            "reason": "retry-exhausted",
+            "title": f"[Schedule監視] {target.key} failure",
+            "body": (
+                f"`{target.workflow_file}` failed after {run_attempt} attempt(s). "
+                f"Run: {run_url(latest)}"
+            ),
+        }
+
+    return {
+        **base,
+        "action": "alert",
+        "reason": f"unexpected-conclusion-{conclusion or 'empty'}",
+        "title": f"[Schedule監視] {target.key} unexpected conclusion",
+        "body": (
+            f"`{target.workflow_file}` ended with unexpected conclusion "
+            f"`{conclusion or 'empty'}`. Run: {run_url(latest)}"
+        ),
+    }
+
+
+class GitHubClient:
+    def __init__(self, repo: str, token: str, *, api_url: str = "https://api.github.com") -> None:
+        self.repo = repo
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+
+    def request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = Request(
+            f"{self.api_url}{path}",
+            data=data,
+            method=method,
+            headers=headers,
+        )
+        with urlopen(request, timeout=30) as response:
+            payload = response.read().decode("utf-8")
+            if not payload:
+                return {}
+            return json.loads(payload)
+
+    def scheduled_runs(self, workflow_file: str, *, limit: int) -> list[dict[str, Any]]:
+        query = urlencode({"branch": "main", "event": "schedule", "per_page": str(limit)})
+        path = f"/repos/{self.repo}/actions/workflows/{quote(workflow_file)}/runs?{query}"
+        payload = self.request("GET", path)
+        runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
+        return runs if isinstance(runs, list) else []
+
+    def rerun_failed_jobs(self, run_id: int) -> None:
+        self.request("POST", f"/repos/{self.repo}/actions/runs/{run_id}/rerun-failed-jobs", {})
+
+    def open_or_update_issue(self, title: str, body: str) -> str:
+        labels = "workflow-failure"
+        issues = self.request(
+            "GET",
+            f"/repos/{self.repo}/issues?{urlencode({'state': 'open', 'labels': labels, 'per_page': '100'})}",
+        )
+        if isinstance(issues, list):
+            for issue in issues:
+                if issue.get("title") == title and "pull_request" not in issue:
+                    number = issue.get("number")
+                    self.request("POST", f"/repos/{self.repo}/issues/{number}/comments", {"body": body})
+                    return str(issue.get("html_url") or "")
+
+        created = self.request(
+            "POST",
+            f"/repos/{self.repo}/issues",
+            {
+                "title": title,
+                "body": body,
+                "labels": ["bug", "automation", "priority:high", "workflow-failure"],
+            },
+        )
+        return str(created.get("html_url") or "")
+
+
+def issue_body(result: dict[str, Any], now: datetime) -> str:
+    lines = [
+        "Schedule resilience watch detected a problem.",
+        "",
+        f"- Target: `{result['target']}`",
+        f"- Workflow file: `{result.get('workflow_file', '')}`",
+        f"- Reason: `{result['reason']}`",
+        f"- Checked at: `{now.isoformat()}`",
+    ]
+    if result.get("run_id"):
+        lines.extend(
+            [
+                f"- Run ID: `{result['run_id']}`",
+                f"- Attempt: `{result.get('run_attempt')}`",
+                f"- Status/conclusion: `{result.get('status')}` / `{result.get('conclusion')}`",
+                f"- Run: {result.get('url')}",
+            ]
+        )
+    if result.get("body"):
+        lines.extend(["", str(result["body"])])
+    lines.extend(["", "Codex #1 route: old PS#1 workflow-health lane is absorbed by Codex #1."])
+    return "\n".join(lines)
+
+
+def render_summary(results: list[dict[str, Any]]) -> str:
+    lines = [
+        "## Schedule Resilience Watch",
+        "",
+        "| Target | Action | Reason | Run |",
+        "|---|---|---|---|",
+    ]
+    for result in results:
+        run = result.get("url") or ""
+        run_cell = f"[run]({run})" if run else "-"
+        lines.append(
+            f"| `{result['target']}` | `{result['action']}` | `{result['reason']}` | {run_cell} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "kanta13jp1/my_web_app"))
+    parser.add_argument("--max-attempts", type=int, default=2)
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--output", default="")
+    parser.add_argument("--github-step-summary", default=os.environ.get("GITHUB_STEP_SUMMARY", ""))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token and not args.dry_run:
+        print("GH_TOKEN or GITHUB_TOKEN is required.", file=sys.stderr)
+        return 2
+
+    now = datetime.now(timezone.utc)
+    client = GitHubClient(args.repo, token or "")
+    results: list[dict[str, Any]] = []
+
+    for target in TARGETS:
+        runs = client.scheduled_runs(target.workflow_file, limit=args.limit)
+        result = evaluate_target(target, runs, now, max_attempts=args.max_attempts)
+
+        if result["action"] == "retry":
+            if args.dry_run:
+                result["write"] = "dry-run-rerun"
+            else:
+                try:
+                    client.rerun_failed_jobs(int(result["run_id"]))
+                    result["write"] = "rerun-failed-jobs"
+                except HTTPError as exc:
+                    result["action"] = "alert"
+                    result["reason"] = f"rerun-failed-http-{exc.code}"
+                    result["title"] = f"[Schedule監視] {target.key} rerun failed"
+                    result["body"] = f"Failed to rerun `{target.workflow_file}` via GitHub API: HTTP {exc.code}."
+
+        if result["action"] == "alert":
+            body = issue_body(result, now)
+            if args.dry_run:
+                result["issue_url"] = "dry-run"
+            else:
+                result["issue_url"] = client.open_or_update_issue(str(result["title"]), body)
+
+        results.append(result)
+
+    summary = render_summary(results)
+    print(summary)
+
+    if args.github_step_summary:
+        with Path(args.github_step_summary).open("a", encoding="utf-8") as handle:
+            handle.write(summary)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps({"checked_at": now.isoformat(), "results": results}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/schedule_resilience_watch_test.py
+++ b/scripts/schedule_resilience_watch_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Tests for schedule_resilience_watch.py."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from schedule_resilience_watch import WorkflowTarget, evaluate_target, render_summary
+
+
+NOW = datetime(2026, 5, 8, 3, 0, tzinfo=timezone.utc)
+TARGET = WorkflowTarget("cs-check", "cs-check.yml", 3)
+
+
+def run(**overrides):
+    data = {
+        "id": 123,
+        "html_url": "https://github.example/runs/123",
+        "status": "completed",
+        "conclusion": "success",
+        "run_attempt": 1,
+        "created_at": (NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+    }
+    data.update(overrides)
+    return data
+
+
+class ScheduleResilienceWatchTest(unittest.TestCase):
+    def test_success_recent_is_healthy(self) -> None:
+        result = evaluate_target(TARGET, [run()], NOW, max_attempts=2)
+        self.assertEqual(result["action"], "healthy")
+        self.assertEqual(result["reason"], "latest-success")
+
+    def test_failed_first_attempt_requests_retry(self) -> None:
+        result = evaluate_target(
+            TARGET,
+            [run(conclusion="failure", run_attempt=1)],
+            NOW,
+            max_attempts=2,
+        )
+        self.assertEqual(result["action"], "retry")
+        self.assertEqual(result["reason"], "failed-attempt-1")
+
+    def test_failed_max_attempt_alerts(self) -> None:
+        result = evaluate_target(
+            TARGET,
+            [run(conclusion="failure", run_attempt=2)],
+            NOW,
+            max_attempts=2,
+        )
+        self.assertEqual(result["action"], "alert")
+        self.assertEqual(result["reason"], "retry-exhausted")
+        self.assertIn("[Schedule監視] cs-check failure", result["title"])
+
+    def test_stale_success_alerts(self) -> None:
+        result = evaluate_target(
+            TARGET,
+            [run(created_at=(NOW - timedelta(hours=5)).isoformat().replace("+00:00", "Z"))],
+            NOW,
+            max_attempts=2,
+        )
+        self.assertEqual(result["action"], "alert")
+        self.assertEqual(result["reason"], "stale-success")
+
+    def test_summary_mentions_actions(self) -> None:
+        summary = render_summary(
+            [
+                {"target": "cs-check", "action": "retry", "reason": "failed-attempt-1", "url": ""},
+                {"target": "daily-report", "action": "healthy", "reason": "latest-success", "url": "u"},
+            ]
+        )
+        self.assertIn("Schedule Resilience Watch", summary)
+        self.assertIn("failed-attempt-1", summary)
+        self.assertIn("[run](u)", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

- Adds `schedule-resilience-watch.yml`, an hourly guard for `daily-report`, `cs-check`, `competitor-monitoring`, and `infra-health-check` scheduled workflows.
- Adds `scripts/schedule_resilience_watch.py` to inspect latest scheduled runs, rerun failed jobs once, and open/update `workflow-failure` issues when retry is exhausted or a schedule goes stale.
- Documents the NotebookLM `9b8885ef` automation pattern in `docs/SCHEDULE_TASKS.md` under the 2-instance model.

Closes #1783

## Delegation / Instance Model

- Codex #1 (Windows app) owns this implementation and CI lane.
- Claude Code #1 remains the design/review counterpart.
- Old PS#1 workflow-health and Codex #2 references are historical only; Codex #1 absorbed the implementation work. No sub-agent or extra Codex instance was started.

## Minimal E2E Gate

- Implementation-detail independent: validation checks observable scheduled-run states and resulting retry/alert decisions, not private helper internals.
- Minimal scope: 3 core cases are covered by tests: first failed attempt reruns, exhausted failures alert, and stale schedules alert.
- E2E mechanism: this is a workflow/script/docs change, so no Flutter integration_test or Playwright route applies; the E2E-equivalent path is the real GitHub scheduled-run dry-run plus deterministic Python tests.
- E2E-Exception: no app UI or browser behavior changed; manual verification is the dry-run against live scheduled workflow metadata listed below.

## Validation

- `python scripts\schedule_resilience_watch_test.py`
- `python -m py_compile scripts\schedule_resilience_watch.py scripts\schedule_resilience_watch_test.py`
- YAML parse for `.github/workflows/schedule-resilience-watch.yml`
- Live dry-run: `python scripts\schedule_resilience_watch.py --repo kanta13jp1/my_web_app --dry-run --output <temp>`, all four targets reported `healthy`
- `python scripts\check_minimal_e2e_gate_test.py`
- `python scripts\two_instance_audit.py --fail-on-active`
- `python scripts\check_no_verify_bypass.py --range origin/main..HEAD`
- `git diff --check` (passed; Windows checkout emitted LF/CRLF advisory only)
