### PR TITLE
feat: add dormant instance grace cron

### DIFF
--- a/.github/workflows/dormant-instance-grace-cron.yml
+++ b/.github/workflows/dormant-instance-grace-cron.yml
@@ -1,0 +1,64 @@
+name: Dormant Instance 30-Day Grace Cron
+
+on:
+  schedule:
+    # Weekly Monday 02:00 UTC = 11:00 JST.
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run only; do not comment or close issues"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: dormant-instance-grace-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DORMANT_LABELS: vscode-instance,ps1-instance,ps2-instance,ps3-instance,ps4-instance,ps5-instance,ps6-instance,web-instance,mobile-instance,codex1-instance,codex2-instance
+  GRACE_DAYS: "30"
+  WARN_DAYS: "14"
+
+jobs:
+  grace:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run dormant grace audit
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+        run: |
+          mkdir -p tmp/dormant-instance-grace
+          APPLY=false
+          if [ "$DRY_RUN" = "false" ]; then
+            APPLY=true
+          fi
+          python scripts/dormant_instance_grace.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --apply "$APPLY" \
+            --output tmp/dormant-instance-grace/report.json \
+            --github-step-summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload dormant grace report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dormant-instance-grace-report
+          path: tmp/dormant-instance-grace/report.json
+          if-no-files-found: ignore

--- a/scripts/dormant_instance_grace.py
+++ b/scripts/dormant_instance_grace.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Manage 30-day grace handling for dormant instance issues.
+
+The active fleet is Claude Code #1 + Codex #1. Historical instance labels such
+as vscode-instance or ps1-instance should not be closed immediately; this script
+posts a grace notice after WARN_DAYS and closes only after GRACE_DAYS when there
+is no recurrence signal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_DORMANT_LABELS = (
+    "vscode-instance",
+    "ps1-instance",
+    "ps2-instance",
+    "ps3-instance",
+    "ps4-instance",
+    "ps5-instance",
+    "ps6-instance",
+    "web-instance",
+    "mobile-instance",
+    "codex1-instance",
+    "codex2-instance",
+)
+
+SKIP_LABELS = {"workflow-failure"}
+GRACE_MARKER = "<!-- dormant-instance-grace:v1 -->"
+CLOSE_MARKER = "<!-- dormant-instance-auto-close:v1 -->"
+
+RECURRENCE_KEYWORDS = (
+    "reproduce",
+    "reproduced",
+    "still happens",
+    "still happening",
+    "happen again",
+    "happens again",
+    "happened again",
+    "recurs",
+    "recurring",
+    "再現",
+    "再発",
+)
+
+NON_RECURRENCE_MARKERS = (
+    "no recurrence",
+    "no reproduction",
+    "reproduction: none",
+    "reproduce if",
+    "if this recurs",
+    "再現なし",
+    "再現 0",
+    "再現 comment 0",
+    "再現報告 0",
+    "再現時",
+    "再現したら",
+)
+
+
+@dataclass
+class Decision:
+    number: int
+    title: str
+    url: str
+    label: str
+    age_days: int
+    action: str
+    reason: str
+
+
+def parse_bool(value: str | bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def dormant_labels_from_env() -> list[str]:
+    labels = os.environ.get("DORMANT_LABELS")
+    if not labels:
+        return list(DEFAULT_DORMANT_LABELS)
+    return [label.strip() for label in labels.split(",") if label.strip()]
+
+
+def label_names(issue: dict[str, Any]) -> set[str]:
+    return {
+        label.get("name", "")
+        for label in issue.get("labels", [])
+        if isinstance(label, dict)
+    }
+
+
+def has_grace_comment(comments: list[dict[str, Any]]) -> bool:
+    for comment in comments:
+        body = comment.get("body", "")
+        if GRACE_MARKER in body:
+            return True
+        if "Dormant Instance Grace Status" in body:
+            return True
+        if "dormant instance grace status" in body.lower():
+            return True
+    return False
+
+
+def is_recurrence_comment(comment: dict[str, Any]) -> bool:
+    body = comment.get("body", "")
+    lowered = body.lower()
+    if GRACE_MARKER in body or CLOSE_MARKER in body:
+        return False
+    if "dormant instance grace" in lowered:
+        return False
+    if any(marker in lowered for marker in NON_RECURRENCE_MARKERS):
+        return False
+    return any(keyword in lowered for keyword in RECURRENCE_KEYWORDS)
+
+
+def has_recurrence_comment(comments: list[dict[str, Any]]) -> bool:
+    return any(is_recurrence_comment(comment) for comment in comments)
+
+
+def decide_issue(
+    issue: dict[str, Any],
+    matched_label: str,
+    now: datetime,
+    warn_days: int,
+    grace_days: int,
+) -> Decision:
+    labels = label_names(issue)
+    created = parse_datetime(issue["createdAt"])
+    age_days = (now - created).days
+    comments = issue.get("comments", [])
+    number = int(issue["number"])
+    title = issue.get("title", "")
+    url = issue.get("url", "")
+
+    if labels & SKIP_LABELS:
+        return Decision(
+            number,
+            title,
+            url,
+            matched_label,
+            age_days,
+            "skip",
+            "workflow-failure label present",
+        )
+
+    if has_recurrence_comment(comments):
+        return Decision(
+            number,
+            title,
+            url,
+            matched_label,
+            age_days,
+            "skip",
+            "recurrence comment present",
+        )
+
+    if age_days >= grace_days:
+        return Decision(
+            number,
+            title,
+            url,
+            matched_label,
+            age_days,
+            "close",
+            f"age {age_days}d >= grace {grace_days}d",
+        )
+
+    if age_days >= warn_days:
+        if has_grace_comment(comments):
+            return Decision(
+                number,
+                title,
+                url,
+                matched_label,
+                age_days,
+                "noop",
+                "grace comment already present",
+            )
+        return Decision(
+            number,
+            title,
+            url,
+            matched_label,
+            age_days,
+            "warn",
+            f"age {age_days}d >= warn {warn_days}d",
+        )
+
+    return Decision(
+        number,
+        title,
+        url,
+        matched_label,
+        age_days,
+        "noop",
+        f"age {age_days}d < warn {warn_days}d",
+    )
+
+
+def run_gh(args: list[str]) -> str:
+    completed = subprocess.run(
+        ["gh", *args],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        text=True,
+    )
+    return completed.stdout
+
+
+def fetch_issues_for_label(repo: str, label: str) -> list[dict[str, Any]]:
+    raw = run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            label,
+            "--limit",
+            "200",
+            "--json",
+            "number,title,createdAt,labels,url",
+        ]
+    )
+    return json.loads(raw)
+
+
+def fetch_issue_details(repo: str, number: int) -> dict[str, Any]:
+    raw = run_gh(
+        [
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--comments",
+            "--json",
+            "number,title,createdAt,labels,comments,url",
+        ]
+    )
+    return json.loads(raw)
+
+
+def collect_dormant_issues(repo: str, labels: list[str]) -> list[tuple[dict[str, Any], str]]:
+    seen: dict[int, tuple[dict[str, Any], str]] = {}
+    for label in labels:
+        for issue in fetch_issues_for_label(repo, label):
+            number = int(issue["number"])
+            if number in seen:
+                continue
+            seen[number] = (fetch_issue_details(repo, number), label)
+    return list(seen.values())
+
+
+def warn_body(decision: Decision, issue: dict[str, Any], warn_days: int, grace_days: int) -> str:
+    created = parse_datetime(issue["createdAt"])
+    expiry = created + timedelta(days=grace_days)
+    remaining = max(grace_days - decision.age_days, 0)
+    return f"""{GRACE_MARKER}
+## Dormant Instance Grace Status
+
+This issue has dormant instance label `{decision.label}`. Current active routing
+is Claude Code #1 + Codex #1, so dormant-instance issues enter a {grace_days}-day
+grace window instead of being closed immediately.
+
+- Created: {created.date().isoformat()} ({decision.age_days} days ago)
+- Grace warning threshold: {warn_days} days
+- Planned close date: {expiry.date().isoformat()} ({remaining} days remaining)
+
+If the same problem reproduces in the current 2-instance fleet, please add a
+recurrence comment and replace the dormant label with `claude-code-instance` or
+`codex-instance`.
+"""
+
+
+def close_body(decision: Decision, issue: dict[str, Any], grace_days: int) -> str:
+    created = parse_datetime(issue["createdAt"])
+    return f"""{CLOSE_MARKER}
+## Dormant Instance Auto-Close
+
+This issue has dormant instance label `{decision.label}` and is
+{decision.age_days} days old. No recurrence signal was found during the
+{grace_days}-day grace window for the active Claude Code #1 + Codex #1 fleet.
+
+Reopen and relabel to `claude-code-instance` or `codex-instance` if it reproduces
+again in the current fleet.
+
+Created: {created.date().isoformat()}
+"""
+
+
+def apply_decision(
+    repo: str,
+    decision: Decision,
+    issue: dict[str, Any],
+    warn_days: int,
+    grace_days: int,
+    apply: bool,
+) -> None:
+    if not apply:
+        return
+    if decision.action == "warn":
+        run_gh(
+            [
+                "issue",
+                "comment",
+                str(decision.number),
+                "--repo",
+                repo,
+                "--body",
+                warn_body(decision, issue, warn_days, grace_days),
+            ]
+        )
+    elif decision.action == "close":
+        run_gh(
+            [
+                "issue",
+                "close",
+                str(decision.number),
+                "--repo",
+                repo,
+                "--comment",
+                close_body(decision, issue, grace_days),
+            ]
+        )
+
+
+def render_summary(report: dict[str, Any]) -> str:
+    lines = [
+        "# Dormant Instance Grace Report",
+        "",
+        f"- repo: `{report['repo']}`",
+        f"- apply: `{str(report['apply']).lower()}`",
+        f"- scanned issues: {report['scanned_issues']}",
+        f"- warn: {report['counts'].get('warn', 0)}",
+        f"- close: {report['counts'].get('close', 0)}",
+        f"- skip: {report['counts'].get('skip', 0)}",
+        f"- noop: {report['counts'].get('noop', 0)}",
+        "",
+        "| issue | label | age | action | reason |",
+        "| --- | --- | ---: | --- | --- |",
+    ]
+    for decision in report["decisions"]:
+        issue = f"[#{decision['number']}]({decision['url']})"
+        lines.append(
+            f"| {issue} | `{decision['label']}` | {decision['age_days']} | "
+            f"`{decision['action']}` | {decision['reason']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "kanta13jp1/my_web_app"))
+    parser.add_argument("--apply", default="false", help="true to comment/close, false for dry-run")
+    parser.add_argument("--labels", help="Comma-separated dormant labels override")
+    parser.add_argument("--warn-days", type=int, default=int(os.environ.get("WARN_DAYS", "14")))
+    parser.add_argument("--grace-days", type=int, default=int(os.environ.get("GRACE_DAYS", "30")))
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--github-step-summary", type=Path)
+    parser.add_argument("--now", help="ISO timestamp override for tests/manual dry-runs")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    args = parse_args(argv)
+    apply = parse_bool(args.apply)
+    labels = (
+        [label.strip() for label in args.labels.split(",") if label.strip()]
+        if args.labels
+        else dormant_labels_from_env()
+    )
+    now = parse_datetime(args.now) if args.now else datetime.now(timezone.utc)
+    issues = collect_dormant_issues(args.repo, labels)
+
+    decisions: list[Decision] = []
+    issue_by_number = {int(issue["number"]): issue for issue, _label in issues}
+    for issue, matched_label in issues:
+        decision = decide_issue(
+            issue,
+            matched_label,
+            now,
+            warn_days=args.warn_days,
+            grace_days=args.grace_days,
+        )
+        apply_decision(
+            args.repo,
+            decision,
+            issue,
+            warn_days=args.warn_days,
+            grace_days=args.grace_days,
+            apply=apply,
+        )
+        decisions.append(decision)
+
+    counts: dict[str, int] = {}
+    for decision in decisions:
+        counts[decision.action] = counts.get(decision.action, 0) + 1
+
+    report = {
+        "repo": args.repo,
+        "apply": apply,
+        "labels": labels,
+        "warn_days": args.warn_days,
+        "grace_days": args.grace_days,
+        "scanned_issues": len(issue_by_number),
+        "counts": counts,
+        "decisions": [asdict(decision) for decision in decisions],
+    }
+
+    summary = render_summary(report)
+    print(summary)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    if args.github_step_summary:
+        args.github_step_summary.parent.mkdir(parents=True, exist_ok=True)
+        args.github_step_summary.write_text(summary, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/dormant_instance_grace_test.py
+++ b/scripts/dormant_instance_grace_test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Unit tests for dormant_instance_grace.py."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+import dormant_instance_grace as grace
+
+
+NOW = datetime(2026, 5, 8, tzinfo=timezone.utc)
+
+
+def issue(
+    *,
+    number: int = 1962,
+    created_at: str = "2026-04-18T00:00:00Z",
+    labels: list[str] | None = None,
+    comments: list[str] | None = None,
+) -> dict:
+    return {
+        "number": number,
+        "title": "Dormant issue",
+        "url": f"https://github.com/kanta13jp1/my_web_app/issues/{number}",
+        "createdAt": created_at,
+        "labels": [{"name": label} for label in (labels or ["vscode-instance"])],
+        "comments": [{"body": body} for body in (comments or [])],
+    }
+
+
+class DormantInstanceGraceTest(unittest.TestCase):
+    def test_warns_after_threshold(self) -> None:
+        decision = grace.decide_issue(issue(), "vscode-instance", NOW, 14, 30)
+        self.assertEqual(decision.action, "warn")
+
+    def test_noops_when_grace_comment_exists(self) -> None:
+        decision = grace.decide_issue(
+            issue(comments=[f"{grace.GRACE_MARKER}\n## Dormant Instance Grace Status"]),
+            "vscode-instance",
+            NOW,
+            14,
+            30,
+        )
+        self.assertEqual(decision.action, "noop")
+        self.assertIn("already", decision.reason)
+
+    def test_closes_after_grace_window(self) -> None:
+        decision = grace.decide_issue(
+            issue(created_at="2026-04-01T00:00:00Z"),
+            "vscode-instance",
+            NOW,
+            14,
+            30,
+        )
+        self.assertEqual(decision.action, "close")
+
+    def test_skips_workflow_failure_label(self) -> None:
+        decision = grace.decide_issue(
+            issue(labels=["vscode-instance", "workflow-failure"], created_at="2026-04-01T00:00:00Z"),
+            "vscode-instance",
+            NOW,
+            14,
+            30,
+        )
+        self.assertEqual(decision.action, "skip")
+        self.assertIn("workflow-failure", decision.reason)
+
+    def test_skips_recurrence_comment(self) -> None:
+        decision = grace.decide_issue(
+            issue(created_at="2026-04-01T00:00:00Z", comments=["This still happens again today."]),
+            "vscode-instance",
+            NOW,
+            14,
+            30,
+        )
+        self.assertEqual(decision.action, "skip")
+        self.assertIn("recurrence", decision.reason)
+
+    def test_status_comment_is_not_recurrence(self) -> None:
+        self.assertFalse(
+            grace.is_recurrence_comment(
+                {
+                    "body": (
+                        f"{grace.GRACE_MARKER}\n"
+                        "If this recurs, relabel to codex-instance."
+                    )
+                }
+            )
+        )
+
+    def test_no_recurrence_phrase_is_not_recurrence(self) -> None:
+        self.assertFalse(grace.is_recurrence_comment({"body": "再現なし / no recurrence"}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

- Add weekly Dormant Instance 30-Day Grace Cron with dispatchable dry-run mode.
- Add dependency-free `scripts/dormant_instance_grace.py` for warn/close decisions, recurrence detection, and `workflow-failure` safety skip.
- Add focused unit coverage for warn, close, idempotent grace, recurrence, and safety skip behavior.

## Issue / Scope

Refs #1962. The current live #1962 dry-run is intentionally skipped because it still has the `workflow-failure` safety label; this keeps the dormant VSCode monitor issue open while the active fleet remains Claude Code #1 + Codex #1. Old Codex #2/#3 implementation work is absorbed by Codex #1 in this PR.

## Minimal E2E Gate

- Implementation-detail independent / black-box validation: workflow/script-only change; no Flutter UI or app runtime behavior changes.
- Minimal 3 cases: warn threshold, close threshold, and safety skip paths are covered by script tests plus live dry-run against #1962.
- E2E-Exception: no browser or Flutter E2E is needed because the change is a scheduled workflow plus repository script; the workflow is validated by YAML parsing and dry-run output.

## Validation

- `python scripts\dormant_instance_grace_test.py`
- `python -m py_compile scripts\dormant_instance_grace.py scripts\dormant_instance_grace_test.py`
- YAML parse for `.github/workflows/dormant-instance-grace-cron.yml`
- `python scripts\dormant_instance_grace.py --repo kanta13jp1/my_web_app --apply false --labels vscode-instance --output tmp\dormant-instance-grace\local-report.json --now 2026-05-08T00:00:00Z`
- `python scripts\check_github_actions_node_runtime.py`
- `python scripts\two_instance_audit.py --fail-on-active`
- `python scripts\check_minimal_e2e_gate_test.py`
- `python scripts\check_high_risk_ultrareview_gate_test.py`
- `git diff --check`
