### PR TITLE
ci: add alpha release readiness gate (#1556)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,6 +12,7 @@
 | **Deploy to Development** | `deploy-dev.yml` | `develop` へのpush | 開発環境デプロイ (concurrency制御・timeout付き) |
 | **Deploy to Staging** | `deploy-staging.yml` | `staging` へのpush | ステージング環境デプロイ (concurrency制御・timeout付き) |
 | **Deploy to Production** | `deploy-prod.yml` | `main` へのpush | 本番環境デプロイ + バージョニング (concurrency制御・timeout付き) |
+| **Release Readiness Gate** | `release-readiness.yml` | deploy-prod success / daily 06:40 JST / manual | #1556 alpha gate: migration + EF import + Deno + Flutter build + production route + tools-hub/schedule-hub + Notion + Slack + WBS update |
 | **Daily Report** | `daily-report.yml` | 毎日 07:30 JST / 手動 | 日次レポート生成 + X投稿 + 競合モニタリング + schedule_task_runs記録 + Job Summary |
 | **CS Check** | `cs-check.yml` | 毎時 07分 / 手動 | CS自動対応 + PR自動レビュー + schedule_task_runs記録 + Job Summary |
 | **Edge Function Audit** | `edge-function-audit.yml` | 毎時 47分 / 手動 | EF UI導線カバレッジチェック + schedule_task_runs記録 + Job Summary |

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,134 @@
+name: Release Readiness Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Production base URL to smoke test"
+        required: false
+        default: "https://my-web-app-b67f4.web.app"
+        type: string
+      update_wbs:
+        description: "Mark the synced WBS task for #1556 completed after a green gate"
+        required: false
+        default: true
+        type: boolean
+      send_slack_probe:
+        description: "Send a low-noise Slack webhook probe instead of only checking that the secret exists"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: "40 21 * * *" # daily 06:40 JST
+  workflow_run:
+    workflows:
+      - "Deploy to Production"
+    types: [completed]
+
+concurrency:
+  group: release-readiness-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DEFAULT_BASE_URL: https://my-web-app-b67f4.web.app
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD || 'https://smmkxxavexumewbfaqpy.supabase.co' }}
+  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  FLUTTER_VERSION: "3.38.x"
+  LANDING_GOOGLE_LOGIN_ENABLED: "true"
+
+jobs:
+  readiness:
+    name: Alpha release readiness
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Check migration timestamp collisions
+        run: python scripts/check_migration_timestamps.py
+
+      - name: Check Edge Function imports
+        run: python scripts/check_edge_function_imports.py
+
+      - name: Deno lint Edge Functions
+        run: deno lint --config supabase/functions/deno.json supabase/functions/
+
+      - name: Deno check Edge Function entrypoints
+        run: |
+          mapfile -t ENTRYPOINTS < <(find supabase/functions -maxdepth 2 -name index.ts | sort)
+          if [ "${#ENTRYPOINTS[@]}" -eq 0 ]; then
+            echo "No Edge Function entrypoints found"
+            exit 1
+          fi
+          deno check --config supabase/functions/deno.json "${ENTRYPOINTS[@]}"
+
+      - name: Flutter analyze
+        run: flutter analyze
+
+      - name: Flutter web release build
+        run: >
+          flutter build web --release --pwa-strategy=none --no-tree-shake-icons
+          --dart-define=LANDING_GOOGLE_LOGIN_ENABLED=true
+        env:
+          FLUTTER_WEB: true
+
+      - name: Production routes, hubs, Notion, Slack, and WBS smoke
+        env:
+          INPUT_BASE_URL: ${{ github.event.inputs.base_url }}
+          INPUT_UPDATE_WBS: ${{ github.event.inputs.update_wbs }}
+          INPUT_SEND_SLACK_PROBE: ${{ github.event.inputs.send_slack_probe }}
+        run: |
+          set -euo pipefail
+          mkdir -p .release-readiness
+
+          BASE_URL="${INPUT_BASE_URL:-$DEFAULT_BASE_URL}"
+          UPDATE_WBS="${INPUT_UPDATE_WBS:-true}"
+          SEND_SLACK_PROBE="${INPUT_SEND_SLACK_PROBE:-false}"
+
+          args=(
+            --base-url "$BASE_URL"
+            --supabase-url "$SUPABASE_URL"
+            --require-slack-webhook
+            --issue-number 1556
+            --output-json .release-readiness/runtime-smoke.json
+            --summary "$GITHUB_STEP_SUMMARY"
+          )
+
+          if [ "$UPDATE_WBS" = "true" ]; then
+            args+=(--update-wbs)
+          fi
+          if [ "$SEND_SLACK_PROBE" = "true" ]; then
+            args+=(--send-slack)
+          fi
+
+          python scripts/release_readiness_gate.py "${args[@]}"
+
+      - name: Upload readiness artifacts
+        if: always() && hashFiles('.release-readiness/**') != ''
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-readiness-runtime-smoke
+          path: .release-readiness/
+          if-no-files-found: ignore

--- a/.github/workflows/workflow-failure-handler.yml
+++ b/.github/workflows/workflow-failure-handler.yml
@@ -8,6 +8,7 @@ on:
       - "Deploy to Production"
       - "Deploy to Staging"
       - "Deploy to Development"
+      - "Release Readiness Gate"
       - "E2E Smoke"
       - "CI Auto-Fix (CI失敗自動修復)"
       # Schedule: コンテンツ

--- a/docs/automation/ci-cd-stability.md
+++ b/docs/automation/ci-cd-stability.md
@@ -2,6 +2,8 @@
 
 Issue: #1307
 
+Related readiness gate: #1556
+
 ## What Is Automated
 
 - `scripts/check_migration_timestamps.py` blocks duplicate Supabase migration timestamp prefixes before deploy.
@@ -9,6 +11,7 @@ Issue: #1307
 - The same script classifies migration push failures, extracts 14-digit migration versions, applies the safe Supabase repair status, and retries once.
 - CI captures Deno lint output into `.ci-logs/deno-lint.log` and appends a short digest to the GitHub Step Summary.
 - Production deploy uploads `.deploy-logs/` as an artifact when migration logs exist.
+- `release-readiness.yml` runs the alpha release gate manually, daily, and after successful `deploy-prod`: migration collision guard, Edge Function import guard, Deno lint/check, Flutter analyze/build, production route smoke, `tools-hub` / `schedule-hub` service-role smoke, Notion WBS preflight, Slack webhook readiness, and optional WBS completion for the synced #1556 task.
 
 ## Repair Rules
 
@@ -17,6 +20,7 @@ The deploy job still keeps the legacy preflight repair list as a conservative sa
 - `schema_migrations_pkey` or duplicate key errors repair extracted versions as `applied`.
 - `Remote migration versions not found` style errors repair extracted versions as `reverted`.
 - Unknown failures are not repaired automatically; the job fails and the digest/artifact points to the relevant log lines.
+- Release readiness failures are not self-repaired in the gate. `workflow-failure-handler.yml` monitors `Release Readiness Gate` and opens a `workflow-failure` issue with the failing run so the normal repair lane can take over.
 
 ## Agent Handoff
 
@@ -24,3 +28,4 @@ The deploy job still keeps the legacy preflight repair list as a conservative sa
 - Claude Code should run `/ultrareview` for high-risk DB migration or auth changes before merge.
 - Codex in-app browser checks are reserved for UI-facing deploy or smoke-test changes.
 - Automatic approval reviews are appropriate for low-risk workflow/docs changes after CI is green.
+- Under the current two-instance operating model, Codex #1 absorbs the former Codex #2 CI automation lane for #1556/#1557 scoped PRs.

--- a/scripts/release_readiness_gate.py
+++ b/scripts/release_readiness_gate.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Runtime smoke checks for the alpha release readiness gate.
+
+The workflow owns heavyweight static checks (Flutter analyze/build, Deno
+lint/check, migration timestamp checks). This helper keeps the runtime side
+dependency-free: production routes, Edge Function hub actions, Slack
+notification readiness, and the optional WBS completion update.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+DEFAULT_BASE_URL = "https://my-web-app-b67f4.web.app"
+DEFAULT_SUPABASE_URL = "https://smmkxxavexumewbfaqpy.supabase.co"
+DEFAULT_ROUTES = ("/", "/project-gantt", "/referral")
+USER_AGENT = "release-readiness-gate/1.0"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    category: str
+    status: str
+    detail: str
+    target: str = ""
+    http_status: int | None = None
+
+    @property
+    def failed(self) -> bool:
+        return self.status == "failure"
+
+
+def append_summary(summary_path: str | None, title: str, lines: list[str]) -> None:
+    if not summary_path:
+        return
+    path = Path(summary_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(f"\n## {title}\n\n")
+        for line in lines:
+            handle.write(f"{line}\n")
+
+
+def normalize_base_url(url: str) -> str:
+    cleaned = (url or DEFAULT_BASE_URL).strip()
+    if not cleaned:
+        cleaned = DEFAULT_BASE_URL
+    return cleaned.rstrip("/")
+
+
+def join_url(root: str, path: str) -> str:
+    root = normalize_base_url(root)
+    path = "/" + path.lstrip("/")
+    return f"{root}{path}"
+
+
+def decode_json(text: str) -> Any:
+    if not text.strip():
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def request_text(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+    timeout: int = 20,
+) -> tuple[int, str]:
+    request_headers = {
+        "User-Agent": USER_AGENT,
+        **(headers or {}),
+    }
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        request_headers.setdefault("Content-Type", "application/json")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers=request_headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            return int(response.status), body
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return int(exc.code), body
+
+
+def service_headers(service_role_key: str) -> dict[str, str]:
+    return {
+        "apikey": service_role_key,
+        "Authorization": f"Bearer {service_role_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def success_json(payload: Any) -> bool:
+    if isinstance(payload, dict) and payload.get("success") is False:
+        return False
+    return isinstance(payload, dict)
+
+
+def check_routes(base_url: str, routes: list[str], timeout: int) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    for route in routes:
+        url = join_url(base_url, route)
+        try:
+            status, text = request_text(url, timeout=timeout)
+            ok = 200 <= status < 400 and bool(text.strip())
+            results.append(
+                CheckResult(
+                    name=f"route {route}",
+                    category="production_http",
+                    status="success" if ok else "failure",
+                    detail="HTTP route returned a non-empty response"
+                    if ok
+                    else "HTTP route did not return a healthy response",
+                    target=url,
+                    http_status=status,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - exercised by workflow
+            results.append(
+                CheckResult(
+                    name=f"route {route}",
+                    category="production_http",
+                    status="failure",
+                    detail=str(exc),
+                    target=url,
+                )
+            )
+    return results
+
+
+def check_hub_action(
+    supabase_url: str,
+    service_role_key: str,
+    function_name: str,
+    action: str,
+    *,
+    timeout: int,
+) -> CheckResult:
+    if not service_role_key:
+        return CheckResult(
+            name=f"{function_name}:{action}",
+            category="edge_hub",
+            status="failure",
+            detail="SUPABASE_SERVICE_ROLE_KEY is required for release readiness hub smoke",
+        )
+
+    target = join_url(supabase_url or DEFAULT_SUPABASE_URL, f"/functions/v1/{function_name}")
+    try:
+        status, text = request_text(
+            target,
+            method="POST",
+            headers=service_headers(service_role_key),
+            payload={"action": action},
+            timeout=timeout,
+        )
+        payload = decode_json(text)
+        ok = 200 <= status < 300 and success_json(payload)
+        detail = "hub action returned success JSON" if ok else text[:500]
+        return CheckResult(
+            name=f"{function_name}:{action}",
+            category="edge_hub",
+            status="success" if ok else "failure",
+            detail=detail,
+            target=target,
+            http_status=status,
+        )
+    except Exception as exc:  # pragma: no cover - exercised by workflow
+        return CheckResult(
+            name=f"{function_name}:{action}",
+            category="edge_hub",
+            status="failure",
+            detail=str(exc),
+            target=target,
+        )
+
+
+def check_slack(
+    webhook_url: str,
+    *,
+    require_webhook: bool,
+    send_probe: bool,
+    timeout: int,
+) -> CheckResult:
+    if not webhook_url:
+        return CheckResult(
+            name="Slack webhook",
+            category="notification",
+            status="failure" if require_webhook else "skip",
+            detail="SLACK_WEBHOOK_URL is not configured",
+        )
+    if not send_probe:
+        return CheckResult(
+            name="Slack webhook",
+            category="notification",
+            status="success",
+            detail="SLACK_WEBHOOK_URL is configured; send probe disabled",
+        )
+    payload = {
+        "text": "Release readiness smoke reached Slack notification path.",
+    }
+    try:
+        status, text = request_text(
+            webhook_url,
+            method="POST",
+            payload=payload,
+            timeout=timeout,
+        )
+        ok = 200 <= status < 300
+        return CheckResult(
+            name="Slack webhook",
+            category="notification",
+            status="success" if ok else "failure",
+            detail="Slack accepted the readiness probe" if ok else text[:500],
+            http_status=status,
+        )
+    except Exception as exc:  # pragma: no cover - exercised by workflow
+        return CheckResult(
+            name="Slack webhook",
+            category="notification",
+            status="failure",
+            detail=str(exc),
+        )
+
+
+def find_wbs_task_id(
+    supabase_url: str,
+    service_role_key: str,
+    issue_number: int,
+    timeout: int,
+) -> tuple[str | None, str]:
+    query = urllib.parse.urlencode(
+        {
+            "select": "id,title,status,progress,github_issue_number",
+            "github_issue_number": f"eq.{issue_number}",
+            "order": "updated_at.desc",
+            "limit": "1",
+        }
+    )
+    target = join_url(supabase_url or DEFAULT_SUPABASE_URL, f"/rest/v1/wbs_tasks?{query}")
+    status, text = request_text(
+        target,
+        headers=service_headers(service_role_key),
+        timeout=timeout,
+    )
+    if not (200 <= status < 300):
+        return None, f"WBS lookup failed with HTTP {status}: {text[:300]}"
+    payload = decode_json(text)
+    if not isinstance(payload, list) or not payload:
+        return None, f"No WBS task found for GitHub issue #{issue_number}"
+    task = payload[0]
+    task_id = str(task.get("id") or "")
+    title = str(task.get("title") or "")
+    if not task_id:
+        return None, f"WBS task for issue #{issue_number} did not include id"
+    return task_id, title
+
+
+def update_wbs_success(
+    supabase_url: str,
+    service_role_key: str,
+    issue_number: int,
+    timeout: int,
+) -> CheckResult:
+    if not service_role_key:
+        return CheckResult(
+            name="WBS release gate update",
+            category="wbs",
+            status="skip",
+            detail="SUPABASE_SERVICE_ROLE_KEY missing; WBS update skipped",
+        )
+    try:
+        task_id, lookup_detail = find_wbs_task_id(
+            supabase_url,
+            service_role_key,
+            issue_number,
+            timeout,
+        )
+        if not task_id:
+            return CheckResult(
+                name="WBS release gate update",
+                category="wbs",
+                status="skip",
+                detail=lookup_detail,
+            )
+        target = join_url(supabase_url or DEFAULT_SUPABASE_URL, "/functions/v1/tools-hub")
+        status, text = request_text(
+            target,
+            method="POST",
+            headers=service_headers(service_role_key),
+            payload={
+                "action": "wbs.update_progress",
+                "id": task_id,
+                "progress": 100,
+                "status": "completed",
+                "note": (
+                    "Release Readiness Gate succeeded for alpha release "
+                    f"issue #{issue_number}."
+                ),
+            },
+            timeout=timeout,
+        )
+        payload = decode_json(text)
+        ok = 200 <= status < 300 and success_json(payload)
+        return CheckResult(
+            name="WBS release gate update",
+            category="wbs",
+            status="success" if ok else "failure",
+            detail=f"Updated WBS task {task_id} ({lookup_detail})"
+            if ok
+            else text[:500],
+            target=target,
+            http_status=status,
+        )
+    except Exception as exc:  # pragma: no cover - exercised by workflow
+        return CheckResult(
+            name="WBS release gate update",
+            category="wbs",
+            status="failure",
+            detail=str(exc),
+        )
+
+
+def render_markdown(results: list[CheckResult]) -> list[str]:
+    failed = sum(1 for result in results if result.status == "failure")
+    skipped = sum(1 for result in results if result.status == "skip")
+    lines = [
+        f"- Checked at: `{datetime.now(timezone.utc).isoformat()}`",
+        f"- Overall: `{'failure' if failed else 'success'}`",
+        f"- Failed checks: `{failed}`",
+        f"- Skipped checks: `{skipped}`",
+        "",
+        "| Category | Check | Status | HTTP | Target | Detail |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for result in results:
+        detail = result.detail.replace("\n", " ")[:240]
+        target = result.target or "-"
+        http_status = str(result.http_status) if result.http_status is not None else "-"
+        lines.append(
+            f"| `{result.category}` | `{result.name}` | `{result.status}` | "
+            f"`{http_status}` | {target} | {detail} |"
+        )
+    return lines
+
+
+def write_json_report(path: str | None, results: list[CheckResult]) -> None:
+    if not path:
+        return
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "success": not any(result.failed for result in results),
+        "results": [asdict(result) for result in results],
+    }
+    output.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run release readiness runtime smoke checks")
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", DEFAULT_BASE_URL))
+    parser.add_argument("--supabase-url", default=os.environ.get("SUPABASE_URL", DEFAULT_SUPABASE_URL))
+    parser.add_argument(
+        "--service-role-key",
+        default=os.environ.get("SUPABASE_SERVICE_ROLE_KEY", ""),
+    )
+    parser.add_argument("--slack-webhook-url", default=os.environ.get("SLACK_WEBHOOK_URL", ""))
+    parser.add_argument("--route", action="append", dest="routes")
+    parser.add_argument("--timeout-sec", type=int, default=20)
+    parser.add_argument("--summary")
+    parser.add_argument("--output-json")
+    parser.add_argument("--require-slack-webhook", action="store_true")
+    parser.add_argument("--send-slack", action="store_true")
+    parser.add_argument("--update-wbs", action="store_true")
+    parser.add_argument("--issue-number", type=int, default=1556)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    routes = args.routes or list(DEFAULT_ROUTES)
+
+    results: list[CheckResult] = []
+    results.extend(check_routes(args.base_url, routes, args.timeout_sec))
+    results.append(
+        check_hub_action(
+            args.supabase_url,
+            args.service_role_key,
+            "tools-hub",
+            "wbs.project_overview",
+            timeout=args.timeout_sec,
+        )
+    )
+    results.append(
+        check_hub_action(
+            args.supabase_url,
+            args.service_role_key,
+            "schedule-hub",
+            "health.check",
+            timeout=args.timeout_sec,
+        )
+    )
+    results.append(
+        check_hub_action(
+            args.supabase_url,
+            args.service_role_key,
+            "schedule-hub",
+            "notion.preflight_wbs",
+            timeout=args.timeout_sec,
+        )
+    )
+    results.append(
+        check_slack(
+            args.slack_webhook_url,
+            require_webhook=args.require_slack_webhook,
+            send_probe=args.send_slack,
+            timeout=args.timeout_sec,
+        )
+    )
+
+    if args.update_wbs and not any(result.failed for result in results):
+        results.append(
+            update_wbs_success(
+                args.supabase_url,
+                args.service_role_key,
+                args.issue_number,
+                args.timeout_sec,
+            )
+        )
+
+    lines = render_markdown(results)
+    append_summary(args.summary, "Release readiness runtime smoke", lines)
+    write_json_report(args.output_json, results)
+    print("\n".join(lines))
+    return 1 if any(result.failed for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/test_release_readiness_gate.py
+++ b/test/scripts/test_release_readiness_gate.py
@@ -1,0 +1,85 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "release_readiness_gate.py"
+spec = importlib.util.spec_from_file_location("release_readiness_gate", SCRIPT)
+release_readiness_gate = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = release_readiness_gate
+spec.loader.exec_module(release_readiness_gate)
+
+
+class ReleaseReadinessGateTest(unittest.TestCase):
+    def test_join_url_normalizes_slashes(self):
+        self.assertEqual(
+            release_readiness_gate.join_url("https://example.com/", "/project-gantt"),
+            "https://example.com/project-gantt",
+        )
+        self.assertEqual(
+            release_readiness_gate.join_url("https://example.com", "referral"),
+            "https://example.com/referral",
+        )
+
+    def test_success_json_requires_dict_and_no_false_success_flag(self):
+        self.assertTrue(release_readiness_gate.success_json({"success": True}))
+        self.assertTrue(release_readiness_gate.success_json({"ok": True}))
+        self.assertFalse(release_readiness_gate.success_json({"success": False}))
+        self.assertFalse(release_readiness_gate.success_json([{"success": True}]))
+
+    def test_render_markdown_counts_failures_and_skips(self):
+        results = [
+            release_readiness_gate.CheckResult(
+                name="route /",
+                category="production_http",
+                status="success",
+                detail="ok",
+                target="https://example.com/",
+                http_status=200,
+            ),
+            release_readiness_gate.CheckResult(
+                name="Slack webhook",
+                category="notification",
+                status="skip",
+                detail="missing",
+            ),
+            release_readiness_gate.CheckResult(
+                name="notion.preflight_wbs",
+                category="edge_hub",
+                status="failure",
+                detail="schema mismatch",
+                http_status=200,
+            ),
+        ]
+        rendered = "\n".join(release_readiness_gate.render_markdown(results))
+        self.assertIn("- Overall: `failure`", rendered)
+        self.assertIn("- Failed checks: `1`", rendered)
+        self.assertIn("- Skipped checks: `1`", rendered)
+        self.assertIn("notion.preflight_wbs", rendered)
+
+    def test_write_json_report_preserves_success_flag(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "release-readiness-test.json"
+            release_readiness_gate.write_json_report(
+                str(output),
+                [
+                    release_readiness_gate.CheckResult(
+                        name="route /",
+                        category="production_http",
+                        status="success",
+                        detail="ok",
+                    )
+                ],
+            )
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertTrue(payload["success"])
+            self.assertEqual(payload["results"][0]["name"], "route /")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `release-readiness.yml` for the #1556 alpha completion gate: manual, daily, and post-`deploy-prod` success
- add `scripts/release_readiness_gate.py` for production route, tools-hub/schedule-hub, Notion WBS preflight, Slack readiness, and optional WBS completion smoke
- enroll Release Readiness Gate in `workflow-failure-handler.yml` so failed runs open the normal `workflow-failure` repair lane

## Two-instance scope
- Codex #1 absorbed the former Codex #2 CI automation lane for this scoped PR
- no subagents / old Codex #2/#3 lanes started

## High-risk ultrareview gate
- Review owner: Claude Code #1
- high-risk-ultrareview-exception: workflow-only release-readiness automation; Claude ultrareview was not run in this Codex #1 scoped PR, and Claude Code #1 remains the named review owner for final review if requested
- Coverage: security = secrets stay in env and workflow permissions are read-only; rollback = remove/disable `release-readiness.yml` or revert the PR; data migration = no migration files changed and timestamp guard is included; prod smoke = production route smoke is part of the gate; observability = Step Summary + JSON artifact + workflow-failure issue routing
- Unresolved ultrareview findings: 0

## Minimal E2E gate
- The E2E test is implementation-detail independent / black-box: it checks public HTTP routes and hub I/O behavior, not private implementation internals
- The plan is minimal, about three I/O cases: production route response, service-role hub smoke, and Notion/Slack/WBS readiness signal
- E2E mechanism: existing Playwright public route smoke remains green, and this PR adds a runtime smoke helper for the release readiness workflow

## Local verification
- `python test/scripts/test_release_readiness_gate.py`
- `python -m unittest discover -s test/scripts -p "test_release_readiness_gate.py"`
- `python -m py_compile scripts/release_readiness_gate.py test/scripts/test_release_readiness_gate.py`
- `python scripts/check_github_actions_node_runtime.py`
- `python scripts/check_edge_function_imports.py`
- `python scripts/check_migration_timestamps.py`
- `$env:PYTHONUTF8='1'; python scripts/check_no_verify_bypass.py --range HEAD~1..HEAD`

Closes #1556