### PR TITLE
docs(codex): add §8 PR body / synchronize gotchas

### DIFF
--- a/docs/CODEX_WORKFLOW.md
+++ b/docs/CODEX_WORKFLOW.md
@@ -277,3 +277,67 @@ This document keeps older Codex#2 / PS#1-6 / multi-worktree guidance as
 legacy history only. New Codex work should use one Codex Windows app instance,
 one active branch, and one shared dev server unless the user explicitly asks for
 an exception.
+
+## 8. PR body / synchronize gotchas (Win版#132 part 183-184 / 2026-05-09)
+
+Win Claude part 183 で発見した PR 操作系の落とし穴。Codex / 全 instance 共通。
+
+### 8.1 `gh pr edit --body` silent fail
+
+**症状**: `gh pr edit <n> --body "$(cat body.md)"` 実行で GraphQL deprecation warning は出るが exit 0 で返る → body 実際には更新されない。
+
+**原因**: `gh pr edit` は GraphQL UpdatePullRequest mutation 経由 / 大幅な body 差分や特殊文字で silent fail (警告のみで abort しない)。
+
+**Recipe (= 大幅 update / 1KB+ body 差分時)**:
+
+```bash
+# REST API direct PATCH (= GraphQL bypass)
+BODY=$(cat <<'EOF'
+... new PR body markdown ...
+EOF
+)
+gh api -X PATCH repos/<owner>/<repo>/pulls/<n> \
+  -F body="$BODY" \
+  --jq '.body | length'
+
+# Verify reflected
+gh api repos/<owner>/<repo>/pulls/<n> --jq '.body | length'
+```
+
+**検出**: `gh pr view <n> --json body --jq '.body | length'` で update 前後の文字数比較。期待値より少なければ silent fail。
+
+### 8.2 PR body update のみで workflow 再 trigger されない
+
+**症状**: `pull_request` event listening の workflow (= minimal-e2e-gate / ultrareview-gate 等) は `synchronize` event を listen するが、body edit 単独では発火しない。
+
+**原因**: GitHub Actions の `pull_request: types: [synchronize]` は commit push trigger / body edit は `edited` event。
+
+**Recipe (= body 修正後 gate 再評価したい時)**:
+
+```bash
+# Empty commit で synchronize trigger
+git commit --allow-empty -m "ci: re-trigger gate after body update"
+git push origin <branch>
+```
+
+### 8.3 minimal-e2e-gate skip label canonical
+
+**症状**: `gh pr edit --add-label test` 等で適当 label 付けても gate skip しない。
+
+**Recipe**: skip label canonical = `docs-only` OR `no-e2e-needed` (完全一致).
+
+```bash
+gh api -X POST repos/<owner>/<repo>/issues/<n>/labels \
+  -f "labels[]=docs-only"
+git commit --allow-empty -m "ci: re-trigger after skip label"
+git push origin <branch>
+```
+
+### 8.4 適用判断
+
+- **少量 update (= 数行 / <500 chars)**: `gh pr edit --body` で OK
+- **大幅 update (= 1KB+ / 仕様 scope 拡張等)**: `gh api -X PATCH` 直叩き必須
+- **gate 再評価**: 必ず empty commit synchronize trigger
+- **skip label**: canonical 文字列のみ / typo NG
+
+参照: `feedback_correction_20260509_gh_pr_edit_silent_fail.md` (= part 183 dual-gate compliance recovery 教訓)

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -28991,4 +28991,27 @@ User 第 2 弾 ask (= same session continuation): 「WBS 期限近順 + 2 instan
 - 理念的貢献: gate compliance pattern を memory に dogfood 化 = 次回再発時の time-to-recovery 短縮
 
 ### Commit
-- (= 本 docs PR の merge commit / 後追記)
+- `8940b70ef` (= PR #2177 merge / docs-only roadmap append for part 183)
+
+## 2026-05-09 — Win版#132 part 184 (Win Claude / Claude Code)
+
+### Session Summary
+- **CODEX_WORKFLOW.md §8 PR body / synchronize gotchas 常駐記録 ship** (= 前 session 教訓 24h 以内 docs 化)
+  - §8.1 `gh pr edit --body` silent fail → `gh api -X PATCH` 直叩き recipe + 検出 (= body length 比較)
+  - §8.2 PR body update のみで workflow 再 trigger されない → empty commit synchronize trigger
+  - §8.3 minimal-e2e-gate skip label canonical = `docs-only` OR `no-e2e-needed` 完全一致
+  - §8.4 適用判断 (= <500 chars `gh pr edit` OK / 1KB+ `gh api -X PATCH` 必須)
+- **PR #2180 self-recipe dogfood**: `docs-only` label 即適用 → minimal-e2e + ultrareview gate 即 PASS / empty commit synchronize trigger 即 dogfood
+- **Issue #2171 T+1 day verify**: skip 確定 (= 既 part 183 で T+1 status comment 済 / next check 2026-05-12 = T+3)
+- **inject-rules.txt KPI finding**: rule count 38 vs expected 37 (= drift なし / 動作影響なし / 別 PR 候補 = `scripts/sync_inject_rules.py:83` `EXPECTED_RULE_COUNT` bump)
+- **production smoke**: `/calendar-events` 200 OK / 0.5s (= part 183 deploy 確認)
+- **memory ship 1 件**: project_20260509_win132_part184
+
+### Philosophy Alignment (Win#132 part 184)
+- 主要実装: individual session memory → fleet shared docs 昇格 (= operational gotcha 24h 以内常駐記録)
+- 該当原則: #2 (ミッション = 自分株式会社知識資産化) + #5 (商品 = 価値増大 = Codex も同じ落とし穴避けられる) + #6 (時間最適化 = 24h 内 docs 化) + #7 (資産負債 = memory のみ知識 → docs 資産化) + #8 (KPI = 知識共有率) + #9 (IPO = 全 instance 自走可能性向上)
+- 整合性スコア: 8/9 ✅ ([PHILOSOPHY-22] gate 通過)
+- 理念的貢献: memory feedback_correction → docs operational section 昇格 model 確立 / 114 part 連続 dogfood
+
+### Commit
+- (= 本 docs PR #2180 の merge commit / 後追記)


### PR DESCRIPTION
## Summary

- `docs/CODEX_WORKFLOW.md` 末尾に **§8 PR body / synchronize gotchas** 新設 (= +64 行)
- Win版#132 part 183 dual-gate compliance recovery 教訓を 4 サブセクション化
  - §8.1 `gh pr edit --body` silent fail → `gh api -X PATCH` 直叩き recipe
  - §8.2 PR body update のみで workflow 再 trigger されない → empty commit synchronize trigger
  - §8.3 minimal-e2e-gate skip label canonical (= `docs-only` / `no-e2e-needed`)
  - §8.4 適用判断 (= 少量/大幅 update 分岐 + skip label typo NG)
- 参照: `feedback_correction_20260509_gh_pr_edit_silent_fail.md` (= part 183 教訓 memory)

## Why

part 183 で PR #2172 dual-gate FAIL → body 1654→4626 拡充時に `gh pr edit --body` silent fail 発生。
`gh api -X PATCH` 直叩きで recover したが、operational 知識が memory のみで Codex session 非共有。
今回 CODEX_WORKFLOW.md 常駐記録化で全 instance 参照可能に。

## Test plan

- [x] markdown 構文正常 (= `gh pr view` で render 確認)
- [x] origin/main rebase 5 commits 取込済 (Codex #2179 + #1557 merge 含む)
- [x] `docs-only` label 付与 → minimal-e2e-gate skip 期待 (= dogfood §8.3 recipe)
- [ ] PR merge 後、Codex CLI 次 session で `docs/CODEX_WORKFLOW.md §8` 参照可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)