### PR TITLE
infra: add per-session compression primitives (#1984)

### DIFF
--- a/.github/workflows/dev-cache-cleanup-cron.yml
+++ b/.github/workflows/dev-cache-cleanup-cron.yml
@@ -46,6 +46,8 @@ jobs:
         run: |
           python scripts/dev_cache_cleanup.py `
             --include-worktrees `
+            --tier18 `
+            --tier19 `
             --json-out dev-cache-cleanup-dry-run.json
 
       - name: Apply safe runner cleanup
@@ -53,8 +55,15 @@ jobs:
         run: |
           python scripts/dev_cache_cleanup.py `
             --include-worktrees `
+            --tier18 `
+            --tier19 `
             --apply `
             --json-out dev-cache-cleanup-apply.json
+
+      - name: Collect disk hog telemetry
+        shell: pwsh
+        run: |
+          python scripts/disk_hog_telemetry.py --json > disk-hog-telemetry.json
 
       - name: Upload cleanup reports
         if: always()
@@ -64,6 +73,7 @@ jobs:
           path: |
             dev-cache-cleanup-dry-run.json
             dev-cache-cleanup-apply.json
+            disk-hog-telemetry.json
           if-no-files-found: ignore
 
       - name: Comment weekly report to Issue
@@ -85,6 +95,9 @@ jobs:
             $failed = $summary.counts.failed
             $estimated = $summary.estimated_reclaim_mb
             $actual = $summary.actual_reclaim_mb
+            $tier18Pnpm = $summary.metrics.tier_1_8_pnpm_MB
+            $tier18Npm = $summary.metrics.tier_1_8_npm_MB
+            $tier19Temp = $summary.metrics.temp_subtree_14d_MB
           } else {
             $mode = "failed-before-summary"
             $total = "n/a"
@@ -94,6 +107,20 @@ jobs:
             $failed = "n/a"
             $estimated = "n/a"
             $actual = "n/a"
+            $tier18Pnpm = "n/a"
+            $tier18Npm = "n/a"
+            $tier19Temp = "n/a"
+          }
+
+          if (Test-Path "disk-hog-telemetry.json") {
+            $telemetry = Get-Content -Raw -LiteralPath "disk-hog-telemetry.json" | ConvertFrom-Json
+            $uncovered = $telemetry.uncovered_total_mb
+            $autoPrune = $telemetry.auto_prune
+            $warningCount = $telemetry.warnings.Count
+          } else {
+            $uncovered = "n/a"
+            $autoPrune = "n/a"
+            $warningCount = "n/a"
           }
 
           $body = @"
@@ -109,6 +136,12 @@ jobs:
           | failed | $failed |
           | estimated reclaim MB | $estimated |
           | actual reclaim MB | $actual |
+          | tier_1_8_pnpm_MB | $tier18Pnpm |
+          | tier_1_8_npm_MB | $tier18Npm |
+          | temp_subtree_14d_MB | $tier19Temp |
+          | uncovered telemetry MB | $uncovered |
+          | telemetry auto prune | $autoPrune |
+          | telemetry warnings | $warningCount |
           | run | $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID |
 
           This validates scripts/dev_cache_cleanup.py on the hosted Windows runner. Local Windows app cleanup still runs from Codex/Claude sessions or a local scheduled task; GitHub Actions cannot reclaim local C: drive caches.

--- a/docs/DISK_HYGIENE_RUNBOOK.md
+++ b/docs/DISK_HYGIENE_RUNBOOK.md
@@ -751,6 +751,15 @@ Codex 振分 5 質問 score:
 
 = 8/9 ✅ ([PHILOSOPHY-22] gate 通過 / #4 6 部署 のみ marginal).
 
+### 14.11 Codex #1 implementation notes (= PR #1984 Tier 1.8/1.9/2.0)
+
+- `scripts/dev_cache_cleanup.py --tier18 --tier19` adds package-cache metrics (`tier_1_8_pnpm_MB`, `tier_1_8_npm_MB`, `tier_1_8_pub_MB`, `tier_1_8_pip_MB`, `tier_1_8_yarn_MB`, `tier_1_8_gh_MB`) and `temp_subtree_14d_MB`.
+- `.github/workflows/dev-cache-cleanup-cron.yml` validates Tier 1.8/1.9 in dry-run and safe apply on the hosted Windows runner.
+- `scripts/disk_hog_telemetry.py` emits the Tier 1.7 five-directory MAJOR_DIRS_MB telemetry and a 2 GB uncovered warning without automatic pruning.
+- `scripts/worktree_cleanup.py --tier1 --apply --max-runtime-sec=15` adds the SessionStart-friendly stale worktree prune primitive with idle/size/prefix/locked/current-worktree guards and a `reclaimed_mb=<int>` stdout line.
+- `scripts/session_delta_tracker.py --phase start|end` appends `~/.claude/logs/session-delta.csv` rows and creates warning files when median reclaim, 7-day C: delta, or absolute free-space thresholds are crossed.
+- `scripts/memory_trim_phase2.ps1` exposes `ram_trim_count` and `ram_trim_total_mb_freed` for hook integration without requiring administrator rights.
+
 ## 15. 毎セッション圧縮 status verify (= part 184 新設 / User 要望 v3 再確認 / 2-instance fleet)
 
 ### 15.1 hooks coverage 監査結果 (= 2026-05-09 part 184 verify)

--- a/scripts/dev_cache_cleanup.py
+++ b/scripts/dev_cache_cleanup.py
@@ -10,11 +10,13 @@ or GitHub Actions.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -65,6 +67,7 @@ class CleanupAction:
     target: str
     status: str
     reason: str
+    metric_key: str = ""
     command: list[str] = field(default_factory=list)
     before_mb: float | None = None
     after_mb: float | None = None
@@ -197,6 +200,7 @@ def command_action(
     apply: bool,
     before_paths: list[Path] | None = None,
     timeout: int = 300,
+    metric_key: str = "",
 ) -> CleanupAction:
     before = sum_existing_paths(before_paths or [])
     if not apply:
@@ -206,6 +210,7 @@ def command_action(
             target=target,
             status="planned",
             reason="dry-run; pass --apply to execute",
+            metric_key=metric_key,
             command=command,
             before_mb=before,
         )
@@ -220,6 +225,7 @@ def command_action(
         target=target,
         status=status,
         reason=reason,
+        metric_key=metric_key,
         command=command,
         before_mb=before,
         after_mb=after,
@@ -230,8 +236,15 @@ def command_action(
     )
 
 
-def skip_action(name: str, kind: str, target: str, reason: str) -> CleanupAction:
-    return CleanupAction(name=name, kind=kind, target=target, status="skipped", reason=reason)
+def skip_action(name: str, kind: str, target: str, reason: str, metric_key: str = "") -> CleanupAction:
+    return CleanupAction(
+        name=name,
+        kind=kind,
+        target=target,
+        status="skipped",
+        reason=reason,
+        metric_key=metric_key,
+    )
 
 
 def flutter_targets(root: Path, include_worktrees: bool) -> list[Path]:
@@ -351,10 +364,19 @@ def collect_tool_cache_actions(args: argparse.Namespace, root: Path) -> list[Cle
                 apply=args.apply,
                 before_paths=pnpm_store_paths(root),
                 timeout=args.command_timeout,
+                metric_key="tier_1_8_pnpm_MB",
             )
         )
     else:
-        actions.append(skip_action("pnpm store prune", "command", "pnpm store", "pnpm executable not found"))
+        actions.append(
+            skip_action(
+                "pnpm store prune",
+                "command",
+                "pnpm store",
+                "pnpm executable not found",
+                metric_key="tier_1_8_pnpm_MB",
+            )
+        )
 
     if command_available("dart"):
         actions.append(
@@ -366,6 +388,7 @@ def collect_tool_cache_actions(args: argparse.Namespace, root: Path) -> list[Cle
                 apply=args.apply,
                 before_paths=pub_cache_paths(),
                 timeout=args.command_timeout,
+                metric_key="tier_1_8_pub_command_MB",
             )
         )
     elif command_available("flutter"):
@@ -378,10 +401,19 @@ def collect_tool_cache_actions(args: argparse.Namespace, root: Path) -> list[Cle
                 apply=args.apply,
                 before_paths=pub_cache_paths(),
                 timeout=args.command_timeout,
+                metric_key="tier_1_8_pub_command_MB",
             )
         )
     else:
-        actions.append(skip_action("dart pub cache clean", "command", "pub cache", "dart/flutter executable not found"))
+        actions.append(
+            skip_action(
+                "dart pub cache clean",
+                "command",
+                "pub cache",
+                "dart/flutter executable not found",
+                metric_key="tier_1_8_pub_command_MB",
+            )
+        )
 
     pip_version = run_command([sys.executable, "-m", "pip", "--version"], cwd=root, timeout=30)
     if pip_version.code == 0:
@@ -394,10 +426,19 @@ def collect_tool_cache_actions(args: argparse.Namespace, root: Path) -> list[Cle
                 apply=args.apply,
                 before_paths=pip_cache_paths(root),
                 timeout=args.command_timeout,
+                metric_key="tier_1_8_pip_command_MB",
             )
         )
     else:
-        actions.append(skip_action("pip cache purge", "command", "pip cache", "python -m pip unavailable"))
+        actions.append(
+            skip_action(
+                "pip cache purge",
+                "command",
+                "pip cache",
+                "python -m pip unavailable",
+                metric_key="tier_1_8_pip_command_MB",
+            )
+        )
 
     return actions
 
@@ -435,6 +476,11 @@ def allowed_cleanup_roots(repo_root: Path) -> list[Path]:
         if value:
             roots.append(Path(value).resolve(strict=False))
     return dedupe_paths(roots)
+
+
+def is_allowed_cleanup_path(path: Path, repo_root: Path) -> bool:
+    resolved = path.resolve(strict=False)
+    return any(same_or_child(resolved, root) for root in allowed_cleanup_roots(repo_root))
 
 
 def is_safe_notebooklm_path(path: Path, repo_root: Path) -> bool:
@@ -477,6 +523,304 @@ def remove_child(path: Path) -> bool:
         return True
     except OSError:
         return False
+
+
+def deadline_from_seconds(seconds: int | float) -> float:
+    return time.monotonic() + max(1, float(seconds))
+
+
+def path_matches_any(path: Path, patterns: tuple[str, ...]) -> bool:
+    if not patterns:
+        return True
+    return any(fnmatch.fnmatch(path.name, pattern) for pattern in patterns)
+
+
+def stale_files(
+    root: Path,
+    max_age_days: int,
+    *,
+    patterns: tuple[str, ...] = (),
+    recursive: bool = True,
+    deadline: float | None = None,
+) -> list[Path]:
+    if not root.exists() or not root.is_dir():
+        return []
+    cutoff = time.time() - max_age_days * 24 * 60 * 60
+    iterator = root.rglob("*") if recursive else root.iterdir()
+    candidates: list[Path] = []
+    try:
+        for item in iterator:
+            if deadline is not None and time.monotonic() > deadline:
+                break
+            try:
+                if not item.is_file() or item.stat().st_mtime > cutoff:
+                    continue
+            except OSError:
+                continue
+            if path_matches_any(item, patterns):
+                candidates.append(item)
+    except OSError:
+        return candidates
+    return candidates
+
+
+def newest_mtime(path: Path, *, deadline: float | None = None) -> float | None:
+    try:
+        latest = path.stat().st_mtime
+    except OSError:
+        return None
+    if path.is_file():
+        return latest
+    try:
+        for item in path.rglob("*"):
+            if deadline is not None and time.monotonic() > deadline:
+                break
+            try:
+                latest = max(latest, item.stat().st_mtime)
+            except OSError:
+                continue
+    except OSError:
+        return latest
+    return latest
+
+
+def stale_child_dirs_by_latest_mtime(
+    root: Path,
+    max_age_days: int,
+    *,
+    deadline: float | None = None,
+) -> list[Path]:
+    if not root.exists() or not root.is_dir():
+        return []
+    cutoff = time.time() - max_age_days * 24 * 60 * 60
+    stale: list[Path] = []
+    try:
+        children = list(root.iterdir())
+    except OSError:
+        return []
+    for child in children:
+        if deadline is not None and time.monotonic() > deadline:
+            break
+        if not child.is_dir() or child.is_symlink():
+            continue
+        latest = newest_mtime(child, deadline=deadline)
+        if latest is not None and latest <= cutoff:
+            stale.append(child)
+    return stale
+
+
+def filesystem_prune_action(
+    *,
+    args: argparse.Namespace,
+    repo_root: Path,
+    name: str,
+    target: str,
+    candidates: list[Path],
+    reason: str,
+    metric_key: str,
+) -> CleanupAction:
+    safe_candidates = [
+        path
+        for path in dedupe_paths(candidates)
+        if path.exists() and is_allowed_cleanup_path(path, repo_root)
+    ]
+    before = sum_existing_paths(safe_candidates)
+    if not safe_candidates:
+        return CleanupAction(
+            name=name,
+            kind="filesystem",
+            target=target,
+            status="skipped",
+            reason="no safe stale paths found",
+            metric_key=metric_key,
+            before_mb=0.0,
+        )
+    if not args.apply:
+        return CleanupAction(
+            name=name,
+            kind="filesystem",
+            target=target,
+            status="planned",
+            reason=f"dry-run; {len(safe_candidates)} paths selected ({reason})",
+            metric_key=metric_key,
+            before_mb=before,
+        )
+
+    removed = 0
+    for path in safe_candidates:
+        if remove_child(path):
+            removed += 1
+    after = sum_existing_paths([path for path in safe_candidates if path.exists()])
+    status = "success" if removed == len(safe_candidates) else "failed"
+    return CleanupAction(
+        name=name,
+        kind="filesystem",
+        target=target,
+        status=status,
+        reason=f"removed {removed}/{len(safe_candidates)} paths ({reason})",
+        metric_key=metric_key,
+        before_mb=before,
+        after_mb=after,
+        reclaimed_mb=max(0.0, round(before - after, 1)),
+    )
+
+
+def default_env_path(env_name: str, *parts: str) -> list[Path]:
+    value = os.environ.get(env_name)
+    if not value:
+        return []
+    return [(Path(value) / Path(*parts)).resolve(strict=False)]
+
+
+def npm_content_roots(root: Path) -> list[Path]:
+    roots = []
+    for cache in npm_cache_paths(root):
+        roots.append(cache / "_cacache" / "content-v2" / "sha512")
+    roots.extend(path / "_cacache" / "content-v2" / "sha512" for path in default_env_path("LOCALAPPDATA", "npm-cache"))
+    roots.extend(path / "_cacache" / "content-v2" / "sha512" for path in default_env_path("APPDATA", "npm-cache"))
+    return dedupe_paths(roots)
+
+
+def pub_hosted_package_roots() -> list[Path]:
+    roots: list[Path] = []
+    for cache in pub_cache_paths():
+        hosted = cache / "hosted"
+        if not hosted.exists():
+            continue
+        try:
+            for host in hosted.iterdir():
+                if host.is_dir():
+                    roots.append(host)
+        except OSError:
+            continue
+    return dedupe_paths(roots)
+
+
+def yarn_cache_roots() -> list[Path]:
+    return dedupe_paths(
+        [
+            *default_env_path("LOCALAPPDATA", "Yarn", "Cache"),
+            *default_env_path("APPDATA", "Yarn", "Cache"),
+            Path.home() / ".cache" / "yarn",
+        ]
+    )
+
+
+def gh_cache_roots() -> list[Path]:
+    return dedupe_paths([Path.home() / ".cache" / "gh"])
+
+
+def collect_aggressive_cache_actions(args: argparse.Namespace, repo_root: Path) -> list[CleanupAction]:
+    deadline = deadline_from_seconds(args.max_runtime_sec)
+    actions: list[CleanupAction] = []
+
+    npm_candidates: list[Path] = []
+    for path in npm_content_roots(repo_root):
+        npm_candidates.extend(stale_files(path, args.npm_cache_age_days, deadline=deadline))
+    actions.append(
+        filesystem_prune_action(
+            args=args,
+            repo_root=repo_root,
+            name="npm cache stale content prune",
+            target="npm _cacache/content-v2/sha512",
+            candidates=npm_candidates,
+            reason=f"files older than {args.npm_cache_age_days} days",
+            metric_key="tier_1_8_npm_MB",
+        )
+    )
+
+    pub_candidates: list[Path] = []
+    for path in pub_hosted_package_roots():
+        pub_candidates.extend(stale_child_dirs_by_latest_mtime(path, args.pub_cache_age_days, deadline=deadline))
+    actions.append(
+        filesystem_prune_action(
+            args=args,
+            repo_root=repo_root,
+            name="pub hosted stale package prune",
+            target="pub hosted packages",
+            candidates=pub_candidates,
+            reason=f"package dirs with latest mtime older than {args.pub_cache_age_days} days",
+            metric_key="tier_1_8_pub_MB",
+        )
+    )
+
+    pip_candidates: list[Path] = []
+    for path in pip_cache_paths(repo_root):
+        pip_candidates.extend(stale_files(path, args.pip_cache_age_days, deadline=deadline))
+    actions.append(
+        filesystem_prune_action(
+            args=args,
+            repo_root=repo_root,
+            name="pip stale cache prune",
+            target="pip cache",
+            candidates=pip_candidates,
+            reason=f"files older than {args.pip_cache_age_days} days",
+            metric_key="tier_1_8_pip_MB",
+        )
+    )
+
+    yarn_candidates: list[Path] = []
+    for path in yarn_cache_roots():
+        yarn_candidates.extend(stale_files(path, args.yarn_cache_age_days, deadline=deadline))
+    actions.append(
+        filesystem_prune_action(
+            args=args,
+            repo_root=repo_root,
+            name="yarn stale cache prune",
+            target="yarn cache",
+            candidates=yarn_candidates,
+            reason=f"files older than {args.yarn_cache_age_days} days",
+            metric_key="tier_1_8_yarn_MB",
+        )
+    )
+
+    gh_candidates: list[Path] = []
+    for path in gh_cache_roots():
+        gh_candidates.extend(stale_files(path, args.gh_cache_age_days, deadline=deadline))
+    actions.append(
+        filesystem_prune_action(
+            args=args,
+            repo_root=repo_root,
+            name="gh stale cache prune",
+            target="gh cache",
+            candidates=gh_candidates,
+            reason=f"files older than {args.gh_cache_age_days} days",
+            metric_key="tier_1_8_gh_MB",
+        )
+    )
+
+    return actions
+
+
+def collect_temp_deep_sweep_actions(args: argparse.Namespace, repo_root: Path) -> list[CleanupAction]:
+    temp_root = Path(os.environ.get("TEMP") or os.environ.get("TMP") or tempfile.gettempdir()).resolve(strict=False)
+    deadline = deadline_from_seconds(args.max_runtime_sec)
+    dir_candidates = stale_child_dirs_by_latest_mtime(
+        temp_root,
+        args.temp_subtree_age_days,
+        deadline=deadline,
+    )
+    file_candidates = stale_files(
+        temp_root,
+        args.temp_file_age_days,
+        patterns=("*.tmp", "*.log", "*.etl", "*.dmp"),
+        recursive=False,
+        deadline=deadline,
+    )
+    return [
+        filesystem_prune_action(
+            args=args,
+            repo_root=repo_root,
+            name="temp subtree stale prune",
+            target=str(temp_root),
+            candidates=[*dir_candidates, *file_candidates],
+            reason=(
+                f"dirs older than {args.temp_subtree_age_days} days by latest mtime; "
+                f"root temp/log/etl/dmp files older than {args.temp_file_age_days} days"
+            ),
+            metric_key="temp_subtree_14d_MB",
+        )
+    ]
 
 
 def notebooklm_cleanup_action(args: argparse.Namespace, repo_root: Path, path: Path) -> CleanupAction:
@@ -581,6 +925,12 @@ def print_report(actions: list[CleanupAction], *, applied: bool) -> None:
         print(f"{status}: {totals.get(status, 0)}")
     print(f"estimated reclaim: {estimated_reclaim_mb(actions):.1f} MB")
     print(f"actual reclaim:    {actual_reclaim_mb(actions):.1f} MB")
+    metrics = metric_values(actions)
+    if metrics:
+        print("")
+        print("metrics:")
+        for key in sorted(metrics):
+            print(f"  {key}: {metrics[key]:.1f} MB")
 
 
 def status_counts(actions: list[CleanupAction]) -> dict[str, int]:
@@ -601,17 +951,32 @@ def actual_reclaim_mb(actions: list[CleanupAction]) -> float:
     return round(sum(action.reclaimed_mb or 0.0 for action in actions), 1)
 
 
+def metric_values(actions: list[CleanupAction]) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    for action in actions:
+        if not action.metric_key:
+            continue
+        value = action.reclaimed_mb
+        if value is None and action.status in {"planned", "success"}:
+            value = action.before_mb
+        metrics[action.metric_key] = round(metrics.get(action.metric_key, 0.0) + (value or 0.0), 1)
+    return metrics
+
+
 def summary_payload(args: argparse.Namespace, root: Path, actions: list[CleanupAction]) -> dict[str, Any]:
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "mode": "apply" if args.apply else "dry-run",
         "root": str(root),
         "include_worktrees": bool(args.include_worktrees),
+        "tier18": bool(args.tier18 or args.aggressive_cache_sweep),
+        "tier19": bool(args.tier19 or args.temp_deep_sweep),
         "cache_age_days": int(args.cache_age_days),
         "total": len(actions),
         "counts": status_counts(actions),
         "estimated_reclaim_mb": estimated_reclaim_mb(actions),
         "actual_reclaim_mb": actual_reclaim_mb(actions),
+        "metrics": metric_values(actions),
         "actions": [asdict(action) for action in actions],
     }
 
@@ -637,6 +1002,39 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Minimum age for NotebookLM cache children selected for pruning.",
     )
     parser.add_argument("--command-timeout", type=int, default=300, help="Per-command timeout in seconds.")
+    parser.add_argument(
+        "--tier18",
+        action="store_true",
+        help="Enable Tier 1.8 aggressive package cache sweep metrics.",
+    )
+    parser.add_argument(
+        "--aggressive-cache-sweep",
+        action="store_true",
+        help="Alias for --tier18.",
+    )
+    parser.add_argument(
+        "--tier19",
+        action="store_true",
+        help="Enable Tier 1.9 temp deep sweep metrics.",
+    )
+    parser.add_argument(
+        "--temp-deep-sweep",
+        action="store_true",
+        help="Alias for --tier19.",
+    )
+    parser.add_argument(
+        "--max-runtime-sec",
+        type=int,
+        default=60,
+        help="Soft runtime budget for filesystem sweeps.",
+    )
+    parser.add_argument("--npm-cache-age-days", type=int, default=30)
+    parser.add_argument("--pub-cache-age-days", type=int, default=30)
+    parser.add_argument("--pip-cache-age-days", type=int, default=14)
+    parser.add_argument("--yarn-cache-age-days", type=int, default=14)
+    parser.add_argument("--gh-cache-age-days", type=int, default=7)
+    parser.add_argument("--temp-subtree-age-days", type=int, default=14)
+    parser.add_argument("--temp-file-age-days", type=int, default=7)
     parser.add_argument("--json", action="store_true", help="Print the machine-readable summary.")
     parser.add_argument("--json-out", type=Path, help="Write the machine-readable summary.")
     return parser.parse_args(argv)
@@ -648,6 +1046,10 @@ def main(argv: list[str]) -> int:
     actions: list[CleanupAction] = []
     actions.extend(collect_flutter_actions(args, root))
     actions.extend(collect_tool_cache_actions(args, root))
+    if args.tier18 or args.aggressive_cache_sweep:
+        actions.extend(collect_aggressive_cache_actions(args, root))
+    if args.tier19 or args.temp_deep_sweep:
+        actions.extend(collect_temp_deep_sweep_actions(args, root))
     actions.extend(collect_notebooklm_actions(args, root))
 
     payload = summary_payload(args, root, actions)

--- a/scripts/dev_cache_cleanup_test.py
+++ b/scripts/dev_cache_cleanup_test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Unit tests for dev_cache_cleanup.py."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import dev_cache_cleanup as cleanup
+
+
+def touch_old(path: Path, days: int) -> None:
+    stamp = time.time() - days * 24 * 60 * 60
+    os.utime(path, (stamp, stamp))
+
+
+class DevCacheCleanupTest(unittest.TestCase):
+    def test_stale_child_dirs_use_latest_mtime(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            old_dir = root / "old"
+            old_dir.mkdir()
+            old_file = old_dir / "cache.bin"
+            old_file.write_bytes(b"x")
+            touch_old(old_file, 20)
+            touch_old(old_dir, 20)
+
+            mixed_dir = root / "mixed"
+            mixed_dir.mkdir()
+            fresh_file = mixed_dir / "fresh.bin"
+            fresh_file.write_bytes(b"x")
+            touch_old(mixed_dir, 20)
+
+            stale = cleanup.stale_child_dirs_by_latest_mtime(root, 14)
+
+        self.assertEqual(stale, [old_dir])
+
+    def test_temp_deep_sweep_reports_metric_in_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp_root = Path(tmp)
+            old_dir = temp_root / "old-installer"
+            old_dir.mkdir()
+            old_file = old_dir / "payload.bin"
+            old_file.write_bytes(b"x" * 1024)
+            touch_old(old_file, 20)
+            touch_old(old_dir, 20)
+
+            old_log = temp_root / "trace.log"
+            old_log.write_bytes(b"x" * 1024)
+            touch_old(old_log, 8)
+
+            env_before = os.environ.get("TEMP")
+            os.environ["TEMP"] = str(temp_root)
+            args = argparse.Namespace(
+                apply=False,
+                max_runtime_sec=10,
+                temp_subtree_age_days=14,
+                temp_file_age_days=7,
+            )
+            try:
+                actions = cleanup.collect_temp_deep_sweep_actions(args, temp_root)
+                payload = cleanup.summary_payload(
+                    argparse.Namespace(
+                        apply=False,
+                        include_worktrees=False,
+                        tier18=False,
+                        aggressive_cache_sweep=False,
+                        tier19=True,
+                        temp_deep_sweep=False,
+                        cache_age_days=7,
+                    ),
+                    temp_root,
+                    actions,
+                )
+            finally:
+                if env_before is None:
+                    os.environ.pop("TEMP", None)
+                else:
+                    os.environ["TEMP"] = env_before
+
+        self.assertEqual(actions[0].status, "planned")
+        self.assertEqual(actions[0].metric_key, "temp_subtree_14d_MB")
+        self.assertGreaterEqual(payload["metrics"]["temp_subtree_14d_MB"], 0.0)
+
+    def test_metric_values_prefers_actual_reclaim(self) -> None:
+        actions = [
+            cleanup.CleanupAction(
+                name="n",
+                kind="filesystem",
+                target="t",
+                status="success",
+                reason="done",
+                metric_key="tier_1_8_npm_MB",
+                before_mb=10.0,
+                reclaimed_mb=4.0,
+            )
+        ]
+
+        self.assertEqual(cleanup.metric_values(actions), {"tier_1_8_npm_MB": 4.0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/disk_hog_telemetry.py
+++ b/scripts/disk_hog_telemetry.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Emit Issue #1984 Tier 1.7 disk hog telemetry without pruning."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+MAJOR_DIRS = {
+    "cache_codex_runtimes_MB": (".cache", "codex-runtimes"),
+    "plugins_marketplaces_MB": (".claude", "plugins", "marketplaces"),
+    "projects_MB": (".claude", "projects"),
+    "vscode_workspaceStorage_MB": ("AppData", "Roaming", "Code", "User", "workspaceStorage"),
+    "npm_cache_MB": ("AppData", "Local", "npm-cache"),
+}
+UNCOVERED_KEYS = (
+    "cache_codex_runtimes_MB",
+    "plugins_marketplaces_MB",
+    "vscode_workspaceStorage_MB",
+)
+
+
+def directory_size_mb(path: Path) -> float:
+    if not path.exists():
+        return 0.0
+    total = 0
+    if path.is_file():
+        try:
+            return round(path.stat().st_size / (1024 * 1024), 1)
+        except OSError:
+            return 0.0
+    for item in path.rglob("*"):
+        try:
+            if item.is_file():
+                total += item.stat().st_size
+        except OSError:
+            continue
+    return round(total / (1024 * 1024), 1)
+
+
+def collect_metrics(home: Path) -> dict[str, float]:
+    return {
+        key: directory_size_mb(home.joinpath(*parts))
+        for key, parts in MAJOR_DIRS.items()
+    }
+
+
+def uncovered_total_mb(metrics: dict[str, float]) -> float:
+    return round(sum(metrics.get(key, 0.0) for key in UNCOVERED_KEYS), 1)
+
+
+def warning_messages(metrics: dict[str, float], threshold_mb: float) -> list[str]:
+    total = uncovered_total_mb(metrics)
+    if total <= threshold_mb:
+        return []
+    return [f"hygiene-uncovered dirs total {total} MB > {threshold_mb:g} MB threshold"]
+
+
+def append_log(path: Path, metrics: dict[str, float], warnings: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    lines = [f"[{ts}]   {key}: {value} MB" for key, value in metrics.items()]
+    lines.extend(f"[{ts}] WARN: {message}" for message in warnings)
+    with path.open("a", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(line + "\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--home", type=Path, default=Path.home())
+    parser.add_argument("--threshold-mb", type=float, default=2000.0)
+    parser.add_argument("--log-path", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    home = args.home.resolve(strict=False)
+    metrics = collect_metrics(home)
+    warnings = warning_messages(metrics, args.threshold_mb)
+    payload: dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "home": str(home),
+        "threshold_mb": args.threshold_mb,
+        "metrics": metrics,
+        "uncovered_total_mb": uncovered_total_mb(metrics),
+        "warnings": warnings,
+        "auto_prune": False,
+    }
+    if args.log_path:
+        append_log(args.log_path, metrics, warnings)
+        payload["log_path"] = str(args.log_path)
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        for key, value in metrics.items():
+            print(f"{key}: {value} MB")
+        for warning in warnings:
+            print(f"WARN: {warning}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/disk_hog_telemetry_test.py
+++ b/scripts/disk_hog_telemetry_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Unit tests for disk_hog_telemetry.py."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import disk_hog_telemetry as telemetry
+
+
+class DiskHogTelemetryTest(unittest.TestCase):
+    def test_collects_five_metrics_without_pruning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            target = home / ".cache" / "codex-runtimes"
+            target.mkdir(parents=True)
+            (target / "runtime.bin").write_bytes(b"x" * 2 * 1024 * 1024)
+
+            metrics = telemetry.collect_metrics(home)
+
+        self.assertEqual(set(metrics), set(telemetry.MAJOR_DIRS))
+        self.assertGreater(metrics["cache_codex_runtimes_MB"], 0)
+
+    def test_threshold_warning_uses_uncovered_dirs_only(self) -> None:
+        metrics = {key: 0.0 for key in telemetry.MAJOR_DIRS}
+        metrics["cache_codex_runtimes_MB"] = 1500.0
+        metrics["plugins_marketplaces_MB"] = 600.0
+        metrics["npm_cache_MB"] = 5000.0
+
+        warnings = telemetry.warning_messages(metrics, threshold_mb=2000.0)
+
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("2100.0 MB", warnings[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/memory_trim_phase2.ps1
+++ b/scripts/memory_trim_phase2.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+    Issue #1984 RAM trim Phase 2 helper.
+
+.DESCRIPTION
+    Trims working sets for idle, user-owned editor/agent processes without
+    requiring administrator rights. This is intended for SessionStart/End hook
+    integration and emits ram_trim_count / ram_trim_total_mb_freed metrics.
+#>
+
+param(
+    [int]$MinWorkingSetMB = 200,
+    [int]$MinAgeMinutes = 10,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$signature = @'
+[DllImport("psapi.dll")]
+public static extern bool EmptyWorkingSet(System.IntPtr hProcess);
+'@
+$api = Add-Type -MemberDefinition $signature -Name 'PsApiPhase2' -Namespace 'MemMgmt' -PassThru -ErrorAction SilentlyContinue
+
+$pattern = '^(claude|codex|code|cursor|node|electron)$'
+$targets = Get-Process -ErrorAction SilentlyContinue | Where-Object {
+    $_.ProcessName -match $pattern -and
+    $_.WorkingSet64 -gt ($MinWorkingSetMB * 1MB) -and
+    $null -ne $_.StartTime -and
+    ((Get-Date) - $_.StartTime).TotalMinutes -gt $MinAgeMinutes
+}
+
+$trimmed = 0
+$before = 0
+$after = 0
+
+foreach ($proc in $targets) {
+    try {
+        $before += $proc.WorkingSet64
+        if ($null -ne $api) {
+            [void]$api::EmptyWorkingSet($proc.Handle)
+        } else {
+            [void]$proc.MinWorkingSet
+            $proc.MinWorkingSet = 1MB
+        }
+        Start-Sleep -Milliseconds 50
+        $proc.Refresh()
+        $after += $proc.WorkingSet64
+        $trimmed += 1
+    } catch {
+        # Locked or already exited process: skip.
+    }
+}
+
+$freedMB = [math]::Round([math]::Max(0, $before - $after) / 1MB, 1)
+$payload = [ordered]@{
+    ram_trim_count = $trimmed
+    ram_trim_total_mb_freed = $freedMB
+    min_working_set_mb = $MinWorkingSetMB
+    min_age_minutes = $MinAgeMinutes
+}
+
+if ($Json) {
+    $payload | ConvertTo-Json -Compress
+} else {
+    "ram_trim_count=$trimmed ram_trim_total_mb_freed=$freedMB"
+}

--- a/scripts/session_delta_tracker.py
+++ b/scripts/session_delta_tracker.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Track per-session disk deltas for Issue #1984 Tier 2.0.
+
+The script appends a small CSV row at SessionStart and SessionEnd. It is safe to
+run locally or in CI; warning files are only emitted when a threshold is crossed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+
+HEADER = [
+    "ts",
+    "session_id",
+    "phase",
+    "c_free_gb",
+    "reclaim_mb_session",
+    "reclaim_mb_7d_median",
+]
+
+
+@dataclass(frozen=True)
+class DeltaRow:
+    ts: datetime
+    session_id: str
+    phase: str
+    c_free_gb: float
+    reclaim_mb_session: float | None
+    reclaim_mb_7d_median: float | None
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_timestamp(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def parse_optional_float(value: str) -> float | None:
+    if value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def read_rows(path: Path) -> list[DeltaRow]:
+    if not path.exists():
+        return []
+    rows: list[DeltaRow] = []
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for item in reader:
+            ts = parse_timestamp(item.get("ts", ""))
+            if ts is None:
+                continue
+            rows.append(
+                DeltaRow(
+                    ts=ts,
+                    session_id=item.get("session_id", ""),
+                    phase=item.get("phase", ""),
+                    c_free_gb=parse_optional_float(item.get("c_free_gb", "")) or 0.0,
+                    reclaim_mb_session=parse_optional_float(item.get("reclaim_mb_session", "")),
+                    reclaim_mb_7d_median=parse_optional_float(item.get("reclaim_mb_7d_median", "")),
+                )
+            )
+    return rows
+
+
+def append_row(path: Path, row: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    exists = path.exists()
+    with path.open("a", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=HEADER)
+        if not exists:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def c_free_gb() -> float:
+    target = "C:\\" if os.name == "nt" else str(Path.home())
+    try:
+        usage = shutil.disk_usage(target)
+    except OSError:
+        usage = shutil.disk_usage(str(Path.cwd()))
+    return round(usage.free / (1024**3), 2)
+
+
+def default_session_id() -> str:
+    explicit = os.environ.get("CLAUDE_SESSION_ID") or os.environ.get("CODEX_SESSION_ID")
+    if explicit:
+        return explicit[:16]
+    basis = str(Path.cwd().resolve(strict=False)).encode("utf-8", errors="ignore")
+    return hashlib.sha1(basis).hexdigest()[:8]
+
+
+def seven_day_reclaims(rows: list[DeltaRow], now: datetime) -> list[float]:
+    cutoff = now - timedelta(days=7)
+    return [
+        row.reclaim_mb_session
+        for row in rows
+        if row.phase == "end"
+        and row.ts >= cutoff
+        and row.reclaim_mb_session is not None
+        and row.reclaim_mb_session >= 0
+    ]
+
+
+def median_reclaim_mb(rows: list[DeltaRow], now: datetime) -> float | None:
+    values = seven_day_reclaims(rows, now)
+    if not values:
+        return None
+    return round(float(median(values)), 1)
+
+
+def latest_start_free(rows: list[DeltaRow], session_id: str) -> float | None:
+    for row in reversed(rows):
+        if row.session_id == session_id and row.phase == "start":
+            return row.c_free_gb
+    return None
+
+
+def c_free_delta_7d(rows: list[DeltaRow], current_free_gb: float, now: datetime) -> float | None:
+    cutoff = now - timedelta(days=7)
+    window = [row for row in rows if row.ts >= cutoff]
+    if not window:
+        return None
+    return round(current_free_gb - window[0].c_free_gb, 2)
+
+
+def warnings_for(
+    *,
+    current_free_gb: float,
+    reclaim_median_mb: float | None,
+    free_delta_7d_gb: float | None,
+    median_floor_mb: float,
+    free_floor_gb: float,
+    seven_day_delta_floor_gb: float,
+) -> list[str]:
+    warnings: list[str] = []
+    if reclaim_median_mb is not None and reclaim_median_mb < median_floor_mb:
+        warnings.append(f"7-day median reclaim {reclaim_median_mb} MB < {median_floor_mb:g} MB")
+    if free_delta_7d_gb is not None and free_delta_7d_gb < seven_day_delta_floor_gb:
+        warnings.append(f"C: free 7-day delta {free_delta_7d_gb} GB < {seven_day_delta_floor_gb:g} GB")
+    if current_free_gb < free_floor_gb:
+        warnings.append(f"C: free {current_free_gb} GB < {free_floor_gb:g} GB")
+    return warnings
+
+
+def write_warning(path: Path, warnings: list[str], payload: dict[str, Any]) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    target = path / f"warning_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}.md"
+    lines = [
+        "# Session Delta Warning",
+        "",
+        "## Warnings",
+        "",
+        *[f"- {item}" for item in warnings],
+        "",
+        "## Payload",
+        "",
+        "```json",
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        "```",
+        "",
+    ]
+    target.write_text("\n".join(lines), encoding="utf-8")
+    return target
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--phase", choices=("start", "end"), required=True)
+    parser.add_argument("--session-id", default=default_session_id())
+    parser.add_argument("--log-path", type=Path, default=Path.home() / ".claude" / "logs" / "session-delta.csv")
+    parser.add_argument("--warning-dir", type=Path, default=Path.home() / "cleanup_reports")
+    parser.add_argument("--c-free-gb", type=float, help="Override current C: free GB for tests.")
+    parser.add_argument("--reclaim-mb", type=float, help="Override session reclaim MB.")
+    parser.add_argument("--median-floor-mb", type=float, default=100.0)
+    parser.add_argument("--free-floor-gb", type=float, default=30.0)
+    parser.add_argument("--seven-day-delta-floor-gb", type=float, default=-3.0)
+    parser.add_argument("--no-warning-file", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    rows = read_rows(args.log_path)
+    now = now_utc()
+    current_free = round(args.c_free_gb if args.c_free_gb is not None else c_free_gb(), 2)
+
+    reclaim_mb = args.reclaim_mb
+    if reclaim_mb is None and args.phase == "end":
+        start_free = latest_start_free(rows, args.session_id)
+        if start_free is not None:
+            reclaim_mb = round((current_free - start_free) * 1024, 1)
+
+    reclaim_median = median_reclaim_mb(rows, now)
+    if reclaim_mb is not None:
+        reclaim_median = median_reclaim_mb(
+            [
+                *rows,
+                DeltaRow(now, args.session_id, args.phase, current_free, reclaim_mb, None),
+            ],
+            now,
+        )
+    free_delta = c_free_delta_7d(rows, current_free, now)
+    warnings = warnings_for(
+        current_free_gb=current_free,
+        reclaim_median_mb=reclaim_median,
+        free_delta_7d_gb=free_delta,
+        median_floor_mb=args.median_floor_mb,
+        free_floor_gb=args.free_floor_gb,
+        seven_day_delta_floor_gb=args.seven_day_delta_floor_gb,
+    )
+
+    row = {
+        "ts": now.isoformat().replace("+00:00", "Z"),
+        "session_id": args.session_id,
+        "phase": args.phase,
+        "c_free_gb": f"{current_free:.2f}",
+        "reclaim_mb_session": "" if reclaim_mb is None else f"{reclaim_mb:.1f}",
+        "reclaim_mb_7d_median": "" if reclaim_median is None else f"{reclaim_median:.1f}",
+    }
+    append_row(args.log_path, row)
+
+    payload: dict[str, Any] = {
+        "phase": args.phase,
+        "session_id": args.session_id,
+        "log_path": str(args.log_path),
+        "c_free_gb": current_free,
+        "reclaim_mb_session": reclaim_mb,
+        "reclaim_mb_7d_median": reclaim_median,
+        "c_free_delta_7d_gb": free_delta,
+        "warnings": warnings,
+        "warning_path": "",
+    }
+    if warnings and not args.no_warning_file:
+        payload["warning_path"] = str(write_warning(args.warning_dir, warnings, payload))
+
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(f"session_delta phase={args.phase} c_free_gb={current_free} warnings={len(warnings)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/session_delta_tracker_test.py
+++ b/scripts/session_delta_tracker_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Unit tests for session_delta_tracker.py."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import session_delta_tracker as tracker
+
+
+NOW = datetime(2026, 5, 9, 0, 0, tzinfo=timezone.utc)
+
+
+class SessionDeltaTrackerTest(unittest.TestCase):
+    def test_median_reclaim_uses_last_seven_days(self) -> None:
+        rows = [
+            tracker.DeltaRow(NOW - timedelta(days=8), "s1", "end", 70.0, 1.0, None),
+            tracker.DeltaRow(NOW - timedelta(days=1), "s2", "end", 71.0, 100.0, None),
+            tracker.DeltaRow(NOW, "s3", "end", 72.0, 300.0, None),
+        ]
+
+        self.assertEqual(tracker.median_reclaim_mb(rows, NOW), 200.0)
+
+    def test_warnings_cover_low_median_and_free_space(self) -> None:
+        warnings = tracker.warnings_for(
+            current_free_gb=29.0,
+            reclaim_median_mb=50.0,
+            free_delta_7d_gb=-4.0,
+            median_floor_mb=100.0,
+            free_floor_gb=30.0,
+            seven_day_delta_floor_gb=-3.0,
+        )
+
+        self.assertEqual(len(warnings), 3)
+
+    def test_append_and_read_rows_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "session-delta.csv"
+            tracker.append_row(
+                path,
+                {
+                    "ts": NOW.isoformat().replace("+00:00", "Z"),
+                    "session_id": "abc",
+                    "phase": "start",
+                    "c_free_gb": "80.00",
+                    "reclaim_mb_session": "",
+                    "reclaim_mb_7d_median": "",
+                },
+            )
+            rows = tracker.read_rows(path)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].session_id, "abc")
+        self.assertEqual(rows[0].c_free_gb, 80.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/worktree_cleanup.py
+++ b/scripts/worktree_cleanup.py
@@ -24,6 +24,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,7 @@ from typing import Any
 
 DEFAULT_BASE_REF = "origin/main"
 DEFAULT_SKIP_BRANCHES = {"main", "master", "develop", "staging"}
+DEFAULT_TIER1_SKIP_PREFIXES = ("codex/",)
 
 
 @dataclass(frozen=True)
@@ -47,6 +49,7 @@ class WorktreeEntry:
     branch_ref: str
     detached: bool
     bare: bool
+    locked: bool
 
     @property
     def branch(self) -> str:
@@ -68,6 +71,7 @@ class WorktreeDecision:
     upstream: str = ""
     uncommitted: int = 0
     size_mb: float = 0.0
+    idle_days: float = 0.0
     removed: bool = False
 
 
@@ -137,6 +141,7 @@ def parse_worktree_list(raw: str) -> list[WorktreeEntry]:
                 branch_ref=str(current.get("branch", "")),
                 detached=bool(current.get("detached", False)),
                 bare=bool(current.get("bare", False)),
+                locked=bool(current.get("locked", False)),
             )
         )
         current = {}
@@ -224,6 +229,19 @@ def directory_size_mb(path: Path) -> float:
     return round(total / (1024 * 1024), 1)
 
 
+def worktree_idle_days(path: Path, now: float | None = None) -> float:
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return 0.0
+    current = time.time() if now is None else now
+    return round(max(0.0, current - mtime) / (24 * 60 * 60), 1)
+
+
+def has_branch_prefix(branch: str, prefixes: tuple[str, ...]) -> bool:
+    return any(branch.startswith(prefix) for prefix in prefixes)
+
+
 def short_sha(value: str) -> str:
     return value[:12] if value else ""
 
@@ -239,6 +257,10 @@ def evaluate_worktree(
     measure_size: bool,
     allow_main_worktree: bool,
     allow_missing_upstream: bool,
+    tier1: bool,
+    min_idle_days: int,
+    min_size_mb: float,
+    tier1_skip_prefixes: tuple[str, ...],
 ) -> WorktreeDecision:
     path = Path(entry.path).resolve(strict=False)
     branch = entry.branch
@@ -258,6 +280,8 @@ def evaluate_worktree(
         return skip("missing worktree path")
     if entry.bare:
         return skip("bare worktree")
+    if entry.locked:
+        return skip("locked worktree")
     if same_or_child(cwd, path):
         return skip("current working directory")
     if not allow_main_worktree and norm_path(path) == norm_path(main_worktree):
@@ -268,6 +292,8 @@ def evaluate_worktree(
         return skip("detached HEAD")
     if branch in skip_branches:
         return skip("protected branch")
+    if tier1 and has_branch_prefix(branch, tier1_skip_prefixes):
+        return skip("protected branch prefix")
 
     dirty = status_lines(path)
     if dirty:
@@ -292,6 +318,11 @@ def evaluate_worktree(
         return skip(f"not merged into {base_ref}", upstream=upstream)
 
     size_mb = directory_size_mb(path) if measure_size else 0.0
+    idle_days = worktree_idle_days(path)
+    if tier1 and idle_days < min_idle_days:
+        return skip(f"idle < {min_idle_days} days", upstream=upstream, size_mb=size_mb, idle_days=idle_days)
+    if tier1 and size_mb < min_size_mb:
+        return skip(f"size < {min_size_mb:g} MB", upstream=upstream, size_mb=size_mb, idle_days=idle_days)
     return WorktreeDecision(
         path=str(path),
         branch=branch,
@@ -301,6 +332,7 @@ def evaluate_worktree(
         upstream=upstream,
         uncommitted=0,
         size_mb=size_mb,
+        idle_days=idle_days,
     )
 
 
@@ -349,15 +381,18 @@ def print_report(decisions: list[WorktreeDecision], *, applied: bool, base_ref: 
     candidates = [item for item in decisions if item.decision == "PRUNE"]
     removed = [item for item in candidates if item.removed]
     reclaim = sum(item.size_mb for item in candidates)
+    reclaimed = sum(item.size_mb for item in removed) if applied else reclaim
     print(f"worktrees scanned: {len(decisions)}")
     print(f"candidates:        {len(candidates)}")
     print(f"removed:           {len(removed)}")
     print(f"estimated reclaim: {reclaim:.1f} MB")
+    print(f"reclaimed_mb={int(round(reclaimed))}")
 
 
 def summary_payload(decisions: list[WorktreeDecision], *, applied: bool, base_ref: str) -> dict[str, Any]:
     candidates = [item for item in decisions if item.decision == "PRUNE"]
     removed = [item for item in candidates if item.removed]
+    reclaimed = sum(item.size_mb for item in removed) if applied else sum(item.size_mb for item in candidates)
     reasons: dict[str, int] = {}
     for item in decisions:
         key = f"{item.decision}: {item.reason}"
@@ -369,6 +404,7 @@ def summary_payload(decisions: list[WorktreeDecision], *, applied: bool, base_re
         "candidates": len(candidates),
         "removed": len(removed),
         "estimated_reclaim_mb": round(sum(item.size_mb for item in candidates), 1),
+        "reclaimed_mb": round(reclaimed, 1),
         "reasons": reasons,
         "worktrees": [asdict(item) for item in decisions],
     }
@@ -408,6 +444,25 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Skip candidate directory size measurement.",
     )
+    parser.add_argument(
+        "--tier1",
+        action="store_true",
+        help="SessionStart-friendly stale worktree prune mode for Issue #1984 Tier 1.6.",
+    )
+    parser.add_argument(
+        "--max-runtime-sec",
+        type=int,
+        default=0,
+        help="Soft runtime cap. Exhausted entries are skipped gracefully.",
+    )
+    parser.add_argument("--min-idle-days", type=int, default=7)
+    parser.add_argument("--min-size-mb", type=float, default=100.0)
+    parser.add_argument(
+        "--tier1-skip-prefix",
+        action="append",
+        default=list(DEFAULT_TIER1_SKIP_PREFIXES),
+        help="Branch prefix protected in --tier1 mode. Repeatable.",
+    )
     return parser.parse_args(argv)
 
 
@@ -429,20 +484,38 @@ def main(argv: list[str]) -> int:
 
     main_worktree = Path(entries[0].path).resolve(strict=False)
     open_prs = set() if args.ignore_open_prs else open_pr_branches(root)
-    decisions = [
-        evaluate_worktree(
-            entry,
-            cwd=cwd,
-            main_worktree=main_worktree,
-            base_ref=args.base_ref,
-            open_prs=open_prs,
-            skip_branches=set(args.skip_branch),
-            measure_size=not args.no_size,
-            allow_main_worktree=args.allow_main_worktree,
-            allow_missing_upstream=args.allow_missing_upstream,
+    deadline = time.monotonic() + args.max_runtime_sec if args.max_runtime_sec > 0 else None
+    decisions: list[WorktreeDecision] = []
+    for entry in entries:
+        if deadline is not None and time.monotonic() > deadline:
+            path = Path(entry.path).resolve(strict=False)
+            decisions.append(
+                WorktreeDecision(
+                    path=str(path),
+                    branch=entry.branch or "HEAD",
+                    decision="SKIP",
+                    reason="runtime budget exhausted",
+                    head=short_sha(entry.head),
+                )
+            )
+            continue
+        decisions.append(
+            evaluate_worktree(
+                entry,
+                cwd=cwd,
+                main_worktree=main_worktree,
+                base_ref=args.base_ref,
+                open_prs=open_prs,
+                skip_branches=set(args.skip_branch),
+                measure_size=not args.no_size,
+                allow_main_worktree=args.allow_main_worktree,
+                allow_missing_upstream=args.allow_missing_upstream,
+                tier1=args.tier1,
+                min_idle_days=args.min_idle_days,
+                min_size_mb=args.min_size_mb,
+                tier1_skip_prefixes=tuple(args.tier1_skip_prefix),
+            )
         )
-        for entry in entries
-    ]
 
     if args.apply:
         for decision in decisions:

--- a/scripts/worktree_cleanup_test.py
+++ b/scripts/worktree_cleanup_test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Unit tests for worktree_cleanup.py."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import worktree_cleanup as cleanup
+
+
+class WorktreeCleanupTest(unittest.TestCase):
+    def test_parse_worktree_list_marks_locked_entries(self) -> None:
+        raw = (
+            "worktree C:/repo\n"
+            "HEAD abc\n"
+            "branch refs/heads/main\n"
+            "\n"
+            "worktree C:/repo/.claude/worktrees/stale\n"
+            "HEAD def\n"
+            "branch refs/heads/feature/stale\n"
+            "locked\n"
+            "\n"
+        )
+
+        entries = cleanup.parse_worktree_list(raw)
+
+        self.assertFalse(entries[0].locked)
+        self.assertTrue(entries[1].locked)
+
+    def test_branch_prefix_protection_matches_codex_prefix(self) -> None:
+        self.assertTrue(cleanup.has_branch_prefix("codex/task", ("codex/",)))
+        self.assertFalse(cleanup.has_branch_prefix("feature/task", ("codex/",)))
+
+    def test_worktree_idle_days_uses_directory_mtime(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            stamp = time.time() - 9 * 24 * 60 * 60
+            os.utime(path, (stamp, stamp))
+
+            idle_days = cleanup.worktree_idle_days(path, now=time.time())
+
+        self.assertGreaterEqual(idle_days, 8.9)
+
+    def test_summary_payload_includes_reclaimed_mb_for_dry_run(self) -> None:
+        decision = cleanup.WorktreeDecision(
+            path="C:/repo/.claude/worktrees/stale",
+            branch="feature/stale",
+            decision="PRUNE",
+            reason="merged",
+            head="abc",
+            size_mb=123.4,
+        )
+
+        payload = cleanup.summary_payload([decision], applied=False, base_ref="origin/main")
+
+        self.assertEqual(payload["reclaimed_mb"], 123.4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add Tier 1.8/1.9 package-cache and temp deep-sweep metrics to `scripts/dev_cache_cleanup.py` and weekly validation.
- Add Tier 1.7 disk hog telemetry with no auto-prune, Tier 2.0 session delta tracking, RAM trim Phase 2 helper, and unit tests.
- Add `scripts/worktree_cleanup.py --tier1 --max-runtime-sec=15` for SessionStart-friendly stale worktree pruning with `reclaimed_mb=<int>` output.

## Validation
- `python -m py_compile scripts\dev_cache_cleanup.py scripts\worktree_cleanup.py scripts\session_delta_tracker.py scripts\disk_hog_telemetry.py`
- `python -m unittest discover -s scripts -p *_test.py`
- `python scripts\dev_cache_cleanup.py --tier18 --tier19 --max-runtime-sec 10 --json-out tmp\dev-cache-tier18-19-dry-run.json --json`
- `python scripts\worktree_cleanup.py --tier1 --max-runtime-sec 15 --json`
- `python scripts\disk_hog_telemetry.py --json`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\memory_trim_phase2.ps1 -MinWorkingSetMB 999999 -Json`

## Minimal E2E Gate
- The E2E plan is implementation-detail independent / black-box: this PR changes infra cleanup scripts, workflow reporting, and docs only, not app runtime behavior.
- Minimal plan: three I/O cases are covered by script-level tests and dry-runs: cache/temp cleanup JSON output, worktree tier1 JSON output, and disk telemetry/session delta JSON output.
- E2E mechanism: existing Playwright public smoke/visual checks run in the Minimal E2E Gate; no new `integration_test` file is needed because application-code change detected is no.

## Notes
- No automatic pruning is implemented for Codex runtime or Claude plugin marketplace directories; those remain telemetry-only.
- Local dry-run observed `uncovered_total_mb=1595.5` and no Tier 1.7 warning at the 2 GB threshold.

Refs #1984