### PR TITLE
feat: add MCP auth Phase B edge primitives (#1577)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -599,8 +599,9 @@ jobs:
           deploy_function ai-writing-assistant --no-verify-jwt
           deploy_function viral-video-ad-generator --no-verify-jwt
           deploy_function memory-search-hub --no-verify-jwt
+          deploy_function mcp-well-known --no-verify-jwt
 
-          # Total: 21 functions deployed (ハードキャップ50本に対し21本 — 余裕29本)
+          # Total: 22 functions deployed (ハードキャップ50本に対し22本 — 余裕28本)
           # memo-reactions → core-hub に統合済み (b4c91bc2 2026-04-24)
           #
           # Hub対応表:

--- a/docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md
+++ b/docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md
@@ -63,9 +63,11 @@ PR #2022 MERGED 2026-05-05 後 2 日経過. Codex 14 件 hand-off の進捗 veri
 
 ### Phase B. EF 2 件 + shared 1 件 (= 推定 2.5h)
 
-4. `supabase/functions/mcp-well-known/index.ts` — 親 spec §5.4 そのまま (= 30 行 / unauthenticated / Cache-Control 1h). `MCP_RESOURCE_URL` + `WORKOS_ISSUER` env 必要.
-5. `supabase/functions/_shared/internal_hmac.ts` — 親 spec §4.4. **内部 EF 間のみ** (= 外部 MCP 受け口は OAuth 2.1+PKCE). HMAC-SHA256 + Nonce (UUID) + Timestamp (±5 min skew) 検証.
-6. `supabase/config.toml` の `mcp-well-known` 登録 (= unauthenticated / public function).
+**Status**: ✅ Codex #1 Phase B PR prepared the public metadata function, internal HMAC helper, function registration, and focused tests. Remaining phases C-E stay open.
+
+4. ✅ `supabase/functions/mcp-well-known/index.ts` — 親 spec §5.4 そのまま (= unauthenticated / Cache-Control 1h). `MCP_RESOURCE_URL` + `WORKOS_ISSUER` env 必要.
+5. ✅ `supabase/functions/_shared/internal_hmac.ts` — 親 spec §4.4. **内部 EF 間のみ** (= 外部 MCP 受け口は OAuth 2.1+PKCE). HMAC-SHA256 + Nonce (UUID) + Timestamp (±5 min skew) 検証.
+6. ✅ `supabase/config.toml` の `mcp-well-known` 登録 (= unauthenticated / public function).
 
 ### Phase C. GHA cron + Terraform skeleton (= 推定 1h)
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -190,3 +190,8 @@ entrypoint = "./functions/viral-video-generator/index.ts"
 [functions.health-check]
 enabled = true
 verify_jwt = false
+
+[functions.mcp-well-known]
+enabled = true
+verify_jwt = false
+entrypoint = "./functions/mcp-well-known/index.ts"

--- a/supabase/functions/_shared/internal_hmac.ts
+++ b/supabase/functions/_shared/internal_hmac.ts
@@ -1,0 +1,183 @@
+const SIGNATURE_ALGORITHM = "hmac-sha256";
+const DEFAULT_SKEW_MS = 5 * 60 * 1000;
+const nonceCache = new Map<string, number>();
+
+export type InternalHmacVerifyResult = {
+  ok: boolean;
+  reason?: string;
+};
+
+export type InternalHmacOptions = {
+  secret?: string;
+  now?: Date;
+  skewMs?: number;
+};
+
+export type InternalHmacParts = {
+  method: string;
+  path: string;
+  body: string;
+  timestamp: string;
+  nonce: string;
+};
+
+function encoder(): TextEncoder {
+  return new TextEncoder();
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  return await crypto.subtle.importKey(
+    "raw",
+    encoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder().encode(value));
+  return bytesToHex(new Uint8Array(digest));
+}
+
+export async function buildInternalHmacPayload(
+  parts: InternalHmacParts,
+): Promise<string> {
+  const bodyHash = await sha256Hex(parts.body);
+  return [
+    parts.method.toUpperCase(),
+    parts.path,
+    parts.timestamp,
+    parts.nonce,
+    bodyHash,
+  ].join(":");
+}
+
+export async function signInternalHmacParts(
+  parts: InternalHmacParts,
+  secret: string,
+): Promise<string> {
+  const key = await hmacKey(secret);
+  const payload = await buildInternalHmacPayload(parts);
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder().encode(payload),
+  );
+  return `${SIGNATURE_ALGORITHM}:${bytesToHex(new Uint8Array(signature))}`;
+}
+
+export async function buildInternalHmacHeaders(
+  method: string,
+  path: string,
+  body: string,
+  secret: string,
+  now = new Date(),
+  nonce = crypto.randomUUID(),
+): Promise<Headers> {
+  const timestamp = Math.floor(now.getTime() / 1000).toString();
+  const signature = await signInternalHmacParts(
+    { method, path, body, timestamp, nonce },
+    secret,
+  );
+  const headers = new Headers();
+  headers.set("X-Internal-Signature", signature);
+  headers.set("X-Internal-Timestamp", timestamp);
+  headers.set("X-Internal-Nonce", nonce);
+  return headers;
+}
+
+function pruneNonceCache(nowMs: number): void {
+  for (const [nonce, expiresAt] of nonceCache) {
+    if (expiresAt <= nowMs) nonceCache.delete(nonce);
+  }
+}
+
+function validUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    .test(value);
+}
+
+function timingSafeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+  let diff = 0;
+  for (let index = 0; index < left.length; index++) {
+    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return diff === 0;
+}
+
+export async function verifyInternalHmacParts(
+  parts: InternalHmacParts,
+  signature: string,
+  options: InternalHmacOptions = {},
+): Promise<InternalHmacVerifyResult> {
+  const secret = options.secret ?? Deno.env.get("INTERNAL_HMAC_SECRET") ?? "";
+  if (!secret) return { ok: false, reason: "missing_secret" };
+
+  const nowMs = (options.now ?? new Date()).getTime();
+  const skewMs = options.skewMs ?? DEFAULT_SKEW_MS;
+  const timestampSeconds = Number(parts.timestamp);
+  if (!Number.isFinite(timestampSeconds)) {
+    return { ok: false, reason: "invalid_timestamp" };
+  }
+
+  const timestampMs = timestampSeconds * 1000;
+  if (Math.abs(nowMs - timestampMs) > skewMs) {
+    return { ok: false, reason: "timestamp_skew" };
+  }
+
+  if (!validUuid(parts.nonce)) {
+    return { ok: false, reason: "invalid_nonce" };
+  }
+
+  pruneNonceCache(nowMs);
+  if (nonceCache.has(parts.nonce)) {
+    return { ok: false, reason: "nonce_replay" };
+  }
+
+  const expected = await signInternalHmacParts(parts, secret);
+  if (!timingSafeEqual(signature, expected)) {
+    return { ok: false, reason: "signature_mismatch" };
+  }
+
+  nonceCache.set(parts.nonce, nowMs + skewMs);
+  return { ok: true };
+}
+
+export async function verifyInternalHmacRequest(
+  req: Request,
+  options: InternalHmacOptions = {},
+): Promise<InternalHmacVerifyResult> {
+  const signature = req.headers.get("X-Internal-Signature") ?? "";
+  const timestamp = req.headers.get("X-Internal-Timestamp") ?? "";
+  const nonce = req.headers.get("X-Internal-Nonce") ?? "";
+  if (!signature || !timestamp || !nonce) {
+    return { ok: false, reason: "missing_headers" };
+  }
+  if (!signature.startsWith(`${SIGNATURE_ALGORITHM}:`)) {
+    return { ok: false, reason: "invalid_signature_scheme" };
+  }
+
+  const url = new URL(req.url);
+  const body = await req.clone().text();
+  return await verifyInternalHmacParts(
+    {
+      method: req.method,
+      path: url.pathname,
+      body,
+      timestamp,
+      nonce,
+    },
+    signature,
+    options,
+  );
+}
+
+export function clearInternalHmacNonceCacheForTest(): void {
+  nonceCache.clear();
+}

--- a/supabase/functions/_shared/internal_hmac_test.ts
+++ b/supabase/functions/_shared/internal_hmac_test.ts
@@ -1,0 +1,117 @@
+import {
+  assertEquals,
+  assertNotEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildInternalHmacHeaders,
+  clearInternalHmacNonceCacheForTest,
+  sha256Hex,
+  verifyInternalHmacRequest,
+} from "./internal_hmac.ts";
+
+const SECRET = "test-secret-with-enough-entropy";
+const NOW = new Date("2026-05-09T00:00:00Z");
+const NONCE = "018f3b68-6d8f-4b62-9f9b-2e826b33c000";
+
+Deno.test("sha256Hex returns deterministic hex", async () => {
+  assertEquals(
+    await sha256Hex("hello"),
+    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+  );
+});
+
+Deno.test("verifyInternalHmacRequest accepts a fresh signed request", async () => {
+  clearInternalHmacNonceCacheForTest();
+  const body = JSON.stringify({ action: "memory.search" });
+  const headers = await buildInternalHmacHeaders(
+    "POST",
+    "/functions/v1/memory-search-hub",
+    body,
+    SECRET,
+    NOW,
+    NONCE,
+  );
+  const req = new Request(
+    "https://example.test/functions/v1/memory-search-hub",
+    {
+      method: "POST",
+      headers,
+      body,
+    },
+  );
+
+  assertEquals(
+    await verifyInternalHmacRequest(req, { secret: SECRET, now: NOW }),
+    { ok: true },
+  );
+});
+
+Deno.test("verifyInternalHmacRequest rejects nonce replay", async () => {
+  clearInternalHmacNonceCacheForTest();
+  const body = "{}";
+  const headers = await buildInternalHmacHeaders(
+    "POST",
+    "/internal/call",
+    body,
+    SECRET,
+    NOW,
+    NONCE,
+  );
+  const req = new Request("https://example.test/internal/call", {
+    method: "POST",
+    headers,
+    body,
+  });
+
+  assertEquals(
+    await verifyInternalHmacRequest(req, { secret: SECRET, now: NOW }),
+    { ok: true },
+  );
+  assertEquals(
+    await verifyInternalHmacRequest(req, { secret: SECRET, now: NOW }),
+    { ok: false, reason: "nonce_replay" },
+  );
+});
+
+Deno.test("verifyInternalHmacRequest rejects tampered bodies and stale timestamps", async () => {
+  clearInternalHmacNonceCacheForTest();
+  const headers = await buildInternalHmacHeaders(
+    "POST",
+    "/internal/call",
+    '{"ok":true}',
+    SECRET,
+    NOW,
+    NONCE,
+  );
+  const tampered = new Request("https://example.test/internal/call", {
+    method: "POST",
+    headers,
+    body: '{"ok":false}',
+  });
+
+  assertEquals(
+    await verifyInternalHmacRequest(tampered, { secret: SECRET, now: NOW }),
+    { ok: false, reason: "signature_mismatch" },
+  );
+
+  clearInternalHmacNonceCacheForTest();
+  const late = new Date(NOW.getTime() + 6 * 60 * 1000);
+  const stale = new Request("https://example.test/internal/call", {
+    method: "POST",
+    headers,
+    body: '{"ok":true}',
+  });
+  assertEquals(
+    await verifyInternalHmacRequest(stale, { secret: SECRET, now: late }),
+    { ok: false, reason: "timestamp_skew" },
+  );
+});
+
+Deno.test("buildInternalHmacHeaders produces unique nonce by default", async () => {
+  const first = await buildInternalHmacHeaders("GET", "/a", "", SECRET, NOW);
+  const second = await buildInternalHmacHeaders("GET", "/a", "", SECRET, NOW);
+  assertNotEquals(
+    first.get("X-Internal-Nonce"),
+    second.get("X-Internal-Nonce"),
+  );
+});

--- a/supabase/functions/mcp-well-known/index.ts
+++ b/supabase/functions/mcp-well-known/index.ts
@@ -1,0 +1,98 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { corsHeaders, jsonResponse } from "../_shared/edge.ts";
+
+const WELL_KNOWN_PATH = "/.well-known/oauth-protected-resource";
+const CACHE_CONTROL = "public, max-age=3600";
+
+function optionalEnv(name: string): string {
+  return (Deno.env.get(name) ?? "").trim();
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function isWellKnownRequest(req: Request): boolean {
+  const { pathname } = new URL(req.url);
+  return pathname === WELL_KNOWN_PATH ||
+    pathname.endsWith(`/mcp-well-known${WELL_KNOWN_PATH}`) ||
+    pathname.endsWith(WELL_KNOWN_PATH);
+}
+
+export function buildMcpWellKnownMetadata(): Record<string, unknown> | null {
+  const resource = optionalEnv("MCP_RESOURCE_URL");
+  const authorizationServers = uniqueStrings([
+    optionalEnv("WORKOS_AUTHKIT_URL"),
+    optionalEnv("WORKOS_AUTHKIT_DOMAIN"),
+    optionalEnv("WORKOS_ISSUER"),
+  ]);
+
+  if (!resource || authorizationServers.length === 0) return null;
+
+  return {
+    resource,
+    resource_name: "Jibun Inc MCP",
+    authorization_servers: authorizationServers,
+    scopes_supported: [
+      "memory",
+      "memory.search",
+      "memory.query_route",
+      "memory.rank",
+      "memory.related",
+      "memory.stats",
+      "memory.rag.query",
+      "rag.query",
+    ],
+    bearer_methods_supported: ["header"],
+    resource_signing_alg_values_supported: ["RS256"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+    token_validation: {
+      resource_indicators_required: true,
+      issuer_trailing_slash_tolerant: true,
+      pkce_required: true,
+    },
+    capabilities: {
+      tools: true,
+      sampling: false,
+    },
+  };
+}
+
+export function handleMcpWellKnownRequest(
+  req: Request,
+): Response {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "GET" || !isWellKnownRequest(req)) {
+    return new Response("Not Found", {
+      status: 404,
+      headers: {
+        ...corsHeaders,
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  const metadata = buildMcpWellKnownMetadata();
+  if (!metadata) {
+    return jsonResponse(
+      { error: "mcp_well_known_not_configured" },
+      500,
+    );
+  }
+
+  return new Response(JSON.stringify(metadata), {
+    status: 200,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+      "Cache-Control": CACHE_CONTROL,
+    },
+  });
+}
+
+if (import.meta.main) {
+  serve(handleMcpWellKnownRequest);
+}

--- a/supabase/functions/mcp-well-known/index_test.ts
+++ b/supabase/functions/mcp-well-known/index_test.ts
@@ -1,0 +1,89 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildMcpWellKnownMetadata,
+  handleMcpWellKnownRequest,
+} from "./index.ts";
+
+function withEnv(name: string, value: string | null): () => void {
+  const previous = Deno.env.get(name);
+  if (value === null) Deno.env.delete(name);
+  else Deno.env.set(name, value);
+  return () => {
+    if (previous === undefined) Deno.env.delete(name);
+    else Deno.env.set(name, previous);
+  };
+}
+
+Deno.test("buildMcpWellKnownMetadata advertises resource and excludes sampling", () => {
+  const restoreResource = withEnv(
+    "MCP_RESOURCE_URL",
+    "https://example.test/mcp",
+  );
+  const restoreIssuer = withEnv("WORKOS_ISSUER", "https://issuer.example.test");
+  const restoreAuthKit = withEnv("WORKOS_AUTHKIT_URL", "");
+  try {
+    const metadata = buildMcpWellKnownMetadata()!;
+    assertEquals(metadata.resource, "https://example.test/mcp");
+    assertEquals(metadata.authorization_servers, [
+      "https://issuer.example.test",
+    ]);
+    assertEquals(
+      (metadata.capabilities as Record<string, unknown>).sampling,
+      false,
+    );
+  } finally {
+    restoreResource();
+    restoreIssuer();
+    restoreAuthKit();
+  }
+});
+
+Deno.test("handleMcpWellKnownRequest returns cacheable metadata without auth", async () => {
+  const restoreResource = withEnv(
+    "MCP_RESOURCE_URL",
+    "https://example.test/mcp",
+  );
+  const restoreIssuer = withEnv("WORKOS_ISSUER", "https://issuer.example.test");
+  try {
+    const res = await handleMcpWellKnownRequest(
+      new Request(
+        "https://example.test/functions/v1/mcp-well-known/.well-known/oauth-protected-resource",
+      ),
+    );
+    const body = await res.json();
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("Cache-Control"), "public, max-age=3600");
+    assertEquals(body.resource, "https://example.test/mcp");
+  } finally {
+    restoreResource();
+    restoreIssuer();
+  }
+});
+
+Deno.test("handleMcpWellKnownRequest returns 404 for non metadata paths", async () => {
+  const res = await handleMcpWellKnownRequest(
+    new Request("https://example.test/functions/v1/mcp-well-known/health"),
+  );
+  assertEquals(res.status, 404);
+});
+
+Deno.test("handleMcpWellKnownRequest fails closed when env is missing", async () => {
+  const restoreResource = withEnv("MCP_RESOURCE_URL", null);
+  const restoreIssuer = withEnv("WORKOS_ISSUER", null);
+  const restoreAuthKit = withEnv("WORKOS_AUTHKIT_URL", null);
+  const restoreDomain = withEnv("WORKOS_AUTHKIT_DOMAIN", null);
+  try {
+    const res = await handleMcpWellKnownRequest(
+      new Request(
+        "https://example.test/functions/v1/mcp-well-known/.well-known/oauth-protected-resource",
+      ),
+    );
+    assertEquals(res.status, 500);
+    assertEquals(await res.json(), { error: "mcp_well_known_not_configured" });
+  } finally {
+    restoreResource();
+    restoreIssuer();
+    restoreAuthKit();
+    restoreDomain();
+  }
+});


### PR DESCRIPTION
Refs #1577

## Minimal E2E Gate

- Implementation-detail independent: the validation plan is black-box and checks HTTP input/output only, not private implementation details.
- Minimal scope: about 3 cases only: public metadata happy path, missing configuration error path, and wrong path 404.
- E2E mechanism: Playwright public-route smoke remains the repository-level browser E2E mechanism; this Phase B PR also covers the new Edge endpoint with focused Deno request tests.
- E2E-Exception: no new Playwright route is added because the endpoint is non-UI OAuth metadata; manual verification is covered by Deno request tests and deploy-prod function registration.

## Summary

Codex #1 implements the scoped Phase B slice from `docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md`.

- Adds `supabase/functions/mcp-well-known/index.ts` as an unauthenticated OAuth protected-resource metadata endpoint with one-hour cache headers.
- Adds `supabase/functions/_shared/internal_hmac.ts` for internal EF-to-EF HMAC-SHA256 signing/verification with UUID nonce replay guard and +/-5 minute timestamp skew validation.
- Registers `mcp-well-known` as `verify_jwt = false` in `supabase/config.toml` and deploys it in `deploy-prod.yml`.
- Updates the #1577 hand-off doc to mark Phase B prepared while keeping Phases C-E open.

## High-Risk Review Note

Reviewer: Claude Code #1

High-Risk-Ultrareview-Exception: scoped Phase B implementation follows the already-merged Claude Code #1 security spec and hand-off (`docs/MCP_AUTH_HARDENING_SPEC.md` + `docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md`). This PR does not broaden the external MCP auth model beyond the spec; it adds a public metadata endpoint and an internal-only HMAC helper with focused tests. Claude ultrareview is not run from this Codex #1 Windows app session; the exception is explicit for the high-risk gate.

Security notes:
- `mcp-well-known` is intentionally unauthenticated and only returns configuration metadata.
- Sampling remains disabled in advertised capabilities.
- `internal_hmac.ts` is for internal EF calls only; external MCP requests remain OAuth 2.1 + PKCE guarded.
- Missing env fails closed for the metadata endpoint.

Rollback:
- Remove `mcp-well-known` from `deploy-prod.yml` and `supabase/config.toml`, then remove the new function/helper files.
- No schema/data migration is included in this Phase B PR.

## Validation

- `deno fmt supabase/functions/_shared/internal_hmac.ts supabase/functions/_shared/internal_hmac_test.ts supabase/functions/mcp-well-known/index.ts supabase/functions/mcp-well-known/index_test.ts`
- `deno lint --config supabase/functions/deno.json supabase/functions/`
- `deno test --allow-all --no-check --config supabase/functions/deno.json supabase/functions/` (51 passed)
- `python scripts/check_edge_function_imports.py`
- `python scripts/check_github_actions_node_runtime.py`
- `git diff --check`

## Resource Hygiene

- Started session with C: free ~78.39GB and no common dev-server listener.
- Ran Tier 1.6 worktree cleanup dry-run, Tier 1.7 disk hog telemetry, and Tier 1.8/1.9 cache dry-run.
- Skipped destructive cache apply while active toolchains and parent app processes are running.