### PR TITLE
ci: add MCP audit anomaly Phase C (#1577)

### DIFF
--- a/.github/workflows/mcp-audit-anomaly-cron.yml
+++ b/.github/workflows/mcp-audit-anomaly-cron.yml
@@ -1,0 +1,137 @@
+name: mcp-audit-anomaly-cron
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/mcp-audit-anomaly-cron.yml"
+      - "scripts/mcp_audit_anomaly.ts"
+      - "scripts/mcp_audit_anomaly_test.ts"
+      - "terraform/mcp_oauth_clients/**"
+  schedule:
+    - cron: "7 * * * *" # hourly :07
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run detection without writing anomaly_score or suspending clients"
+        required: false
+        default: "false"
+      suspend_clients:
+        description: "Suspend anomalous clients after marking audit rows"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-audit-anomaly
+  cancel-in-progress: false
+
+jobs:
+  script-test:
+    name: MCP audit anomaly script test
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Deno check
+        run: deno check scripts/mcp_audit_anomaly.ts scripts/mcp_audit_anomaly_test.ts
+
+      - name: Deno lint
+        run: deno lint scripts/mcp_audit_anomaly.ts scripts/mcp_audit_anomaly_test.ts
+
+      - name: Deno test
+        run: deno test scripts/mcp_audit_anomaly_test.ts
+
+  detect:
+    name: Detect MCP audit anomalies
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Detect anomaly
+        run: >
+          deno run
+          --allow-env
+          --allow-net
+          --allow-write=mcp-audit-anomaly-summary.json
+          scripts/mcp_audit_anomaly.ts
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MCP_AUDIT_ANOMALY_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          MCP_AUDIT_ANOMALY_SUSPEND: ${{ github.event.inputs.suspend_clients || 'false' }}
+          MCP_AUDIT_ANOMALY_SUMMARY: mcp-audit-anomaly-summary.json
+
+      - name: Summarize anomaly run
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f mcp-audit-anomaly-summary.json ]]; then
+            echo "## MCP audit anomaly cron" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          data = json.load(open("mcp-audit-anomaly-summary.json", encoding="utf-8"))
+          print(f"- checked_at: {data.get('checked_at')}")
+          print(f"- rows_scanned: {data.get('rows_scanned')}")
+          print(f"- anomalies: {len(data.get('anomalies', []))}")
+          print(f"- dry_run: {data.get('dry_run')}")
+          print(f"- suspend_enabled: {data.get('suspend_enabled')}")
+          PY
+          else
+            echo "mcp-audit-anomaly-summary.json was not created." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload anomaly summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcp-audit-anomaly-summary
+          path: mcp-audit-anomaly-summary.json
+          if-no-files-found: ignore
+
+  terraform-plan:
+    name: Terraform MCP OAuth client plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.8.5
+
+      - name: Terraform init
+        run: terraform -chdir=terraform/mcp_oauth_clients init -backend=false
+
+      - name: Terraform validate
+        run: terraform -chdir=terraform/mcp_oauth_clients validate
+
+      - name: Terraform plan example clients
+        run: >
+          terraform -chdir=terraform/mcp_oauth_clients plan
+          -input=false
+          -lock=false
+          -var-file=examples/clients.tfvars

--- a/docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md
+++ b/docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md
@@ -71,8 +71,10 @@ PR #2022 MERGED 2026-05-05 後 2 日経過. Codex 14 件 hand-off の進捗 veri
 
 ### Phase C. GHA cron + Terraform skeleton (= 推定 1h)
 
-7. `.github/workflows/mcp-audit-anomaly-cron.yml` — 親 spec §5.5. hourly :07 / `concurrency: cancel-in-progress: false` ([CONCURRENCY] rule). Slack Webhook env で alert.
-8. `terraform/mcp_oauth_clients/` skeleton — 親 spec §5.6 + Mercari Tip 1 応用. Custom Provider stub (= GHA で `terraform plan` のみ実行 / apply は別 PR).
+**Status**: ✅ Codex #1 Phase C PR prepared the anomaly cron, alerting script, and plan-only Terraform skeleton. Remaining phases D-E stay open.
+
+7. ✅ `.github/workflows/mcp-audit-anomaly-cron.yml` — 親 spec §5.5. hourly :07 / `concurrency: cancel-in-progress: false` ([CONCURRENCY] rule). Slack Webhook env で alert.
+8. ✅ `terraform/mcp_oauth_clients/` skeleton — 親 spec §5.6 + Mercari Tip 1 応用. Custom Provider stub (= GHA で `terraform plan` のみ実行 / apply は別 PR).
 
 ### Phase D. docs 3 件 (= 推定 1.5h)
 

--- a/scripts/mcp_audit_anomaly.ts
+++ b/scripts/mcp_audit_anomaly.ts
@@ -1,0 +1,486 @@
+const DEFAULT_RECENT_WINDOW_MINUTES = 5;
+const DEFAULT_BASELINE_HOURS = 24;
+const DEFAULT_MIN_INVOCATION_THRESHOLD = 30;
+const DEFAULT_MIN_FAILURE_THRESHOLD = 10;
+const DEFAULT_CROSS_SERVER_TOOL_THRESHOLD = 3;
+const DEFAULT_LIMIT = 10000;
+
+export interface AuditRow {
+  id?: string;
+  client_id: string;
+  tool_name: string;
+  response_status: number;
+  invoked_at: string;
+  origin_tag?: string | null;
+  cross_server_trace?: string | null;
+}
+
+export interface EvaluationOptions {
+  recentWindowMinutes?: number;
+  baselineHours?: number;
+  minInvocationThreshold?: number;
+  minFailureThreshold?: number;
+  crossServerToolThreshold?: number;
+}
+
+export interface ClientAnomaly {
+  client_id: string;
+  score: number;
+  recent_count: number;
+  recent_failures: number;
+  distinct_tools: number;
+  invocation_threshold: number;
+  failure_threshold: number;
+  reasons: string[];
+  recent_row_ids: string[];
+}
+
+interface EvaluationConfig {
+  recentWindowMinutes: number;
+  baselineHours: number;
+  minInvocationThreshold: number;
+  minFailureThreshold: number;
+  crossServerToolThreshold: number;
+}
+
+interface Summary {
+  checked_at: string;
+  rows_scanned: number;
+  recent_window_minutes: number;
+  baseline_hours: number;
+  dry_run: boolean;
+  suspend_enabled: boolean;
+  anomalies: ClientAnomaly[];
+}
+
+function configFromOptions(options: EvaluationOptions): EvaluationConfig {
+  return {
+    recentWindowMinutes: options.recentWindowMinutes ??
+      DEFAULT_RECENT_WINDOW_MINUTES,
+    baselineHours: options.baselineHours ?? DEFAULT_BASELINE_HOURS,
+    minInvocationThreshold: options.minInvocationThreshold ??
+      DEFAULT_MIN_INVOCATION_THRESHOLD,
+    minFailureThreshold: options.minFailureThreshold ??
+      DEFAULT_MIN_FAILURE_THRESHOLD,
+    crossServerToolThreshold: options.crossServerToolThreshold ??
+      DEFAULT_CROSS_SERVER_TOOL_THRESHOLD,
+  };
+}
+
+function asPositiveInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function boolEnv(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(p * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+function bucketStartMs(date: Date, bucketMinutes: number): number {
+  const bucketMs = bucketMinutes * 60 * 1000;
+  return Math.floor(date.getTime() / bucketMs) * bucketMs;
+}
+
+function increment(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function thresholdFromBaseline(
+  baselineCounts: number[],
+  multiplier: number,
+  minimum: number,
+): number {
+  return Math.max(
+    minimum,
+    Math.ceil(percentile(baselineCounts, 0.99) * multiplier),
+  );
+}
+
+export function evaluateMcpAuditAnomalies(
+  rows: AuditRow[],
+  now = new Date(),
+  options: EvaluationOptions = {},
+): ClientAnomaly[] {
+  const config = configFromOptions(options);
+  const recentStartMs = now.getTime() -
+    config.recentWindowMinutes * 60 * 1000;
+  const baselineStartMs = now.getTime() - config.baselineHours * 60 * 60 * 1000;
+
+  const recentRows: AuditRow[] = [];
+  const baselineRows: AuditRow[] = [];
+
+  for (const row of rows) {
+    const invokedAt = new Date(row.invoked_at);
+    const invokedMs = invokedAt.getTime();
+    if (!Number.isFinite(invokedMs) || invokedMs < baselineStartMs) {
+      continue;
+    }
+    if (invokedMs >= recentStartMs) {
+      recentRows.push(row);
+    } else {
+      baselineRows.push(row);
+    }
+  }
+
+  const baselineInvocationBuckets = new Map<string, number>();
+  const baselineFailureBuckets = new Map<string, number>();
+  for (const row of baselineRows) {
+    const bucket = bucketStartMs(
+      new Date(row.invoked_at),
+      config.recentWindowMinutes,
+    );
+    const key = `${row.client_id}:${bucket}`;
+    increment(baselineInvocationBuckets, key);
+    if (row.response_status >= 400) {
+      increment(baselineFailureBuckets, key);
+    }
+  }
+
+  const invocationBaselines = new Map<string, number[]>();
+  const failureBaselines = new Map<string, number[]>();
+  for (const [key, value] of baselineInvocationBuckets) {
+    const clientId = key.split(":")[0];
+    const values = invocationBaselines.get(clientId) ?? [];
+    values.push(value);
+    invocationBaselines.set(clientId, values);
+  }
+  for (const [key, value] of baselineFailureBuckets) {
+    const clientId = key.split(":")[0];
+    const values = failureBaselines.get(clientId) ?? [];
+    values.push(value);
+    failureBaselines.set(clientId, values);
+  }
+
+  const recentByClient = new Map<string, AuditRow[]>();
+  const traceStats = new Map<
+    string,
+    { clients: Set<string>; tools: Set<string> }
+  >();
+  for (const row of recentRows) {
+    const values = recentByClient.get(row.client_id) ?? [];
+    values.push(row);
+    recentByClient.set(row.client_id, values);
+
+    if (row.cross_server_trace) {
+      const stat = traceStats.get(row.cross_server_trace) ?? {
+        clients: new Set<string>(),
+        tools: new Set<string>(),
+      };
+      stat.clients.add(row.client_id);
+      stat.tools.add(row.tool_name);
+      traceStats.set(row.cross_server_trace, stat);
+    }
+  }
+
+  const crossServerReasons = new Map<string, string[]>();
+  for (const [trace, stat] of traceStats) {
+    if (
+      stat.clients.size > 1 ||
+      stat.tools.size >= config.crossServerToolThreshold
+    ) {
+      for (const clientId of stat.clients) {
+        const reasons = crossServerReasons.get(clientId) ?? [];
+        reasons.push(
+          `cross_server_trace ${trace} spans ${stat.clients.size} clients and ${stat.tools.size} tools`,
+        );
+        crossServerReasons.set(clientId, reasons);
+      }
+    }
+  }
+
+  const anomalies: ClientAnomaly[] = [];
+  for (const [clientId, clientRows] of recentByClient) {
+    const recentCount = clientRows.length;
+    const failures = clientRows.filter((row) => row.response_status >= 400)
+      .length;
+    const distinctTools = new Set(clientRows.map((row) => row.tool_name)).size;
+    const invocationThreshold = thresholdFromBaseline(
+      invocationBaselines.get(clientId) ?? [],
+      3,
+      config.minInvocationThreshold,
+    );
+    const failureThreshold = thresholdFromBaseline(
+      failureBaselines.get(clientId) ?? [],
+      3,
+      config.minFailureThreshold,
+    );
+
+    const reasons: string[] = [];
+    let score = 0;
+    if (recentCount > invocationThreshold) {
+      reasons.push(
+        `recent invocation count ${recentCount} exceeded threshold ${invocationThreshold}`,
+      );
+      score = Math.max(
+        score,
+        Math.min(
+          1,
+          0.7 + (recentCount - invocationThreshold) / invocationThreshold * 0.2,
+        ),
+      );
+    }
+    if (failures > failureThreshold) {
+      reasons.push(
+        `recent failure count ${failures} exceeded threshold ${failureThreshold}`,
+      );
+      score = Math.max(
+        score,
+        Math.min(
+          1,
+          0.8 + (failures - failureThreshold) / failureThreshold * 0.15,
+        ),
+      );
+    }
+
+    const traceReasons = crossServerReasons.get(clientId) ?? [];
+    if (traceReasons.length > 0) {
+      reasons.push(...traceReasons);
+      score = Math.max(score, 0.9);
+    }
+
+    if (
+      distinctTools >= config.crossServerToolThreshold + 2 &&
+      recentCount >= Math.max(10, config.crossServerToolThreshold * 2)
+    ) {
+      reasons.push(
+        `recent activity touched ${distinctTools} distinct tools in one ${config.recentWindowMinutes}m window`,
+      );
+      score = Math.max(score, 0.75);
+    }
+
+    if (reasons.length === 0) {
+      continue;
+    }
+
+    anomalies.push({
+      client_id: clientId,
+      score: Number(score.toFixed(2)),
+      recent_count: recentCount,
+      recent_failures: failures,
+      distinct_tools: distinctTools,
+      invocation_threshold: invocationThreshold,
+      failure_threshold: failureThreshold,
+      reasons,
+      recent_row_ids: clientRows.map((row) => row.id).filter((
+        id,
+      ): id is string => Boolean(id)),
+    });
+  }
+
+  return anomalies.sort((a, b) => b.score - a.score);
+}
+
+export function buildSlackPayload(summary: Summary): Record<string, unknown> {
+  const top = summary.anomalies.slice(0, 8);
+  const lines = top.map((anomaly) =>
+    `* ${anomaly.client_id}: score=${anomaly.score}, recent=${anomaly.recent_count}, failures=${anomaly.recent_failures}; ${
+      anomaly.reasons[0]
+    }`
+  );
+  const suffix = summary.anomalies.length > top.length
+    ? `\n...and ${summary.anomalies.length - top.length} more clients`
+    : "";
+  return {
+    text: `MCP audit anomaly alert: ${summary.anomalies.length} client(s)`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `*MCP audit anomaly alert*\nclients=${summary.anomalies.length} dry_run=${summary.dry_run} suspend_enabled=${summary.suspend_enabled}`,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `${lines.join("\n")}${suffix}`,
+        },
+      },
+    ],
+  };
+}
+
+async function fetchPostgrestJson<T>(
+  url: URL,
+  serviceRoleKey: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const headers = new Headers(init.headers);
+  headers.set("apikey", serviceRoleKey);
+  headers.set("Authorization", `Bearer ${serviceRoleKey}`);
+  headers.set("Accept", "application/json");
+  if (init.body) {
+    headers.set("Content-Type", "application/json");
+    headers.set("Prefer", "return=minimal");
+  }
+
+  const response = await fetch(url, { ...init, headers });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `PostgREST ${response.status} for ${url.pathname}: ${body}`,
+    );
+  }
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return await response.json() as T;
+}
+
+function postgrestUrl(supabaseUrl: string, path: string): URL {
+  const base = supabaseUrl.endsWith("/") ? supabaseUrl : `${supabaseUrl}/`;
+  return new URL(path.replace(/^\//, ""), base);
+}
+
+async function fetchAuditRows(
+  supabaseUrl: string,
+  serviceRoleKey: string,
+  since: Date,
+  limit: number,
+): Promise<AuditRow[]> {
+  const url = postgrestUrl(supabaseUrl, "/rest/v1/mcp_audit_log");
+  url.searchParams.set(
+    "select",
+    "id,client_id,tool_name,response_status,invoked_at,origin_tag,cross_server_trace",
+  );
+  url.searchParams.set("invoked_at", `gte.${since.toISOString()}`);
+  url.searchParams.set("order", "invoked_at.asc");
+  url.searchParams.set("limit", String(limit));
+  return await fetchPostgrestJson<AuditRow[]>(url, serviceRoleKey);
+}
+
+async function markAnomalyRows(
+  supabaseUrl: string,
+  serviceRoleKey: string,
+  anomaly: ClientAnomaly,
+): Promise<void> {
+  if (anomaly.recent_row_ids.length === 0) return;
+  const ids = anomaly.recent_row_ids.slice(0, 100);
+  const url = postgrestUrl(supabaseUrl, "/rest/v1/mcp_audit_log");
+  url.searchParams.set("id", `in.(${ids.join(",")})`);
+  await fetchPostgrestJson<void>(url, serviceRoleKey, {
+    method: "PATCH",
+    body: JSON.stringify({ anomaly_score: anomaly.score }),
+  });
+}
+
+async function suspendClient(
+  supabaseUrl: string,
+  serviceRoleKey: string,
+  anomaly: ClientAnomaly,
+): Promise<void> {
+  const url = postgrestUrl(supabaseUrl, "/rest/v1/mcp_oauth_clients");
+  url.searchParams.set("client_id", `eq.${anomaly.client_id}`);
+  await fetchPostgrestJson<void>(url, serviceRoleKey, {
+    method: "PATCH",
+    body: JSON.stringify({
+      suspended: true,
+      suspended_reason: `mcp-audit-anomaly-cron score=${anomaly.score}: ${
+        anomaly.reasons[0]
+      }`,
+      suspended_at: new Date().toISOString(),
+    }),
+  });
+}
+
+async function postSlack(webhookUrl: string, summary: Summary): Promise<void> {
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(buildSlackPayload(summary)),
+  });
+  if (!response.ok) {
+    throw new Error(`Slack webhook returned HTTP ${response.status}`);
+  }
+}
+
+async function main(): Promise<number> {
+  const args = new Set(Deno.args);
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required.");
+    return 1;
+  }
+
+  const recentWindowMinutes = asPositiveInteger(
+    Deno.env.get("MCP_AUDIT_ANOMALY_RECENT_MINUTES"),
+    DEFAULT_RECENT_WINDOW_MINUTES,
+  );
+  const baselineHours = asPositiveInteger(
+    Deno.env.get("MCP_AUDIT_ANOMALY_BASELINE_HOURS"),
+    DEFAULT_BASELINE_HOURS,
+  );
+  const limit = asPositiveInteger(
+    Deno.env.get("MCP_AUDIT_ANOMALY_LIMIT"),
+    DEFAULT_LIMIT,
+  );
+  const dryRun = args.has("--dry-run") ||
+    boolEnv(Deno.env.get("MCP_AUDIT_ANOMALY_DRY_RUN"));
+  const suspendEnabled = boolEnv(Deno.env.get("MCP_AUDIT_ANOMALY_SUSPEND"));
+  const summaryPath = Deno.env.get("MCP_AUDIT_ANOMALY_SUMMARY") ??
+    "mcp-audit-anomaly-summary.json";
+
+  const since = new Date(Date.now() - baselineHours * 60 * 60 * 1000);
+  const rows = await fetchAuditRows(supabaseUrl, serviceRoleKey, since, limit);
+  const anomalies = evaluateMcpAuditAnomalies(rows, new Date(), {
+    recentWindowMinutes,
+    baselineHours,
+  });
+  const summary: Summary = {
+    checked_at: new Date().toISOString(),
+    rows_scanned: rows.length,
+    recent_window_minutes: recentWindowMinutes,
+    baseline_hours: baselineHours,
+    dry_run: dryRun,
+    suspend_enabled: suspendEnabled,
+    anomalies,
+  };
+
+  await Deno.writeTextFile(summaryPath, JSON.stringify(summary, null, 2));
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (anomalies.length === 0) {
+    return 0;
+  }
+
+  if (!dryRun) {
+    for (const anomaly of anomalies) {
+      await markAnomalyRows(supabaseUrl, serviceRoleKey, anomaly);
+      if (suspendEnabled) {
+        await suspendClient(supabaseUrl, serviceRoleKey, anomaly);
+      }
+    }
+  }
+
+  const slackWebhookUrl = Deno.env.get("SLACK_WEBHOOK_URL") ?? "";
+  if (slackWebhookUrl) {
+    await postSlack(slackWebhookUrl, summary);
+  } else {
+    console.warn(
+      "SLACK_WEBHOOK_URL not configured; anomaly summary was not posted.",
+    );
+  }
+
+  return 0;
+}
+
+if (import.meta.main) {
+  Deno.exit(await main());
+}

--- a/scripts/mcp_audit_anomaly_test.ts
+++ b/scripts/mcp_audit_anomaly_test.ts
@@ -1,0 +1,122 @@
+import {
+  type AuditRow,
+  buildSlackPayload,
+  evaluateMcpAuditAnomalies,
+} from "./mcp_audit_anomaly.ts";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function row(
+  client_id: string,
+  minutesAgo: number,
+  response_status = 200,
+  tool_name = "wbs.tasks.list",
+  id: string = crypto.randomUUID(),
+  cross_server_trace?: string,
+): AuditRow {
+  const invoked = new Date(Date.UTC(2026, 4, 9, 0, 0, 0));
+  invoked.setUTCMinutes(invoked.getUTCMinutes() - minutesAgo);
+  return {
+    id,
+    client_id,
+    tool_name,
+    response_status,
+    invoked_at: invoked.toISOString(),
+    cross_server_trace,
+  };
+}
+
+Deno.test("evaluateMcpAuditAnomalies returns empty for quiet clients", () => {
+  const now = new Date(Date.UTC(2026, 4, 9, 0, 0, 0));
+  const rows = [
+    row("client-a", 2),
+    row("client-a", 8),
+    row("client-a", 20),
+    row("client-b", 3),
+  ];
+  const anomalies = evaluateMcpAuditAnomalies(rows, now, {
+    minInvocationThreshold: 5,
+    minFailureThreshold: 5,
+  });
+  assert(anomalies.length === 0, "quiet clients should not alert");
+});
+
+Deno.test("evaluateMcpAuditAnomalies detects recent invocation bursts", () => {
+  const now = new Date(Date.UTC(2026, 4, 9, 0, 0, 0));
+  const baseline = [
+    row("client-a", 30),
+    row("client-a", 40),
+    row("client-a", 50),
+  ];
+  const burst = Array.from({ length: 8 }, (_, i) => row("client-a", i % 4));
+  const anomalies = evaluateMcpAuditAnomalies([...baseline, ...burst], now, {
+    minInvocationThreshold: 5,
+    minFailureThreshold: 5,
+  });
+  assert(anomalies.length === 1, "burst should alert");
+  assert(anomalies[0].client_id === "client-a", "client-a should alert");
+  assert(anomalies[0].recent_count === 8, "recent count should be retained");
+});
+
+Deno.test("evaluateMcpAuditAnomalies detects failure bursts", () => {
+  const now = new Date(Date.UTC(2026, 4, 9, 0, 0, 0));
+  const rows = Array.from(
+    { length: 6 },
+    (_, i) => row("client-a", i % 4, 401, "memory.search"),
+  );
+  const anomalies = evaluateMcpAuditAnomalies(rows, now, {
+    minInvocationThreshold: 50,
+    minFailureThreshold: 5,
+  });
+  assert(anomalies.length === 1, "failure burst should alert");
+  assert(
+    anomalies[0].recent_failures === 6,
+    "failure count should be retained",
+  );
+});
+
+Deno.test("evaluateMcpAuditAnomalies detects cross-server traces", () => {
+  const now = new Date(Date.UTC(2026, 4, 9, 0, 0, 0));
+  const rows = [
+    row("client-a", 1, 200, "memory.search", "a1", "trace-1"),
+    row("client-b", 1, 200, "wbs.tasks.list", "b1", "trace-1"),
+  ];
+  const anomalies = evaluateMcpAuditAnomalies(rows, now, {
+    minInvocationThreshold: 50,
+    minFailureThreshold: 50,
+  });
+  assert(anomalies.length === 2, "both clients in cross trace should alert");
+  assert(
+    anomalies.every((anomaly) => anomaly.score >= 0.9),
+    "cross trace should have high score",
+  );
+});
+
+Deno.test("buildSlackPayload includes top anomaly details", () => {
+  const payload = buildSlackPayload({
+    checked_at: "2026-05-09T00:00:00.000Z",
+    rows_scanned: 1,
+    recent_window_minutes: 5,
+    baseline_hours: 24,
+    dry_run: false,
+    suspend_enabled: false,
+    anomalies: [{
+      client_id: "client-a",
+      score: 0.91,
+      recent_count: 31,
+      recent_failures: 0,
+      distinct_tools: 1,
+      invocation_threshold: 30,
+      failure_threshold: 10,
+      reasons: ["recent invocation count 31 exceeded threshold 30"],
+      recent_row_ids: ["row-1"],
+    }],
+  });
+  const text = JSON.stringify(payload);
+  assert(text.includes("client-a"), "payload should include client id");
+  assert(text.includes("score=0.91"), "payload should include score");
+});

--- a/terraform/mcp_oauth_clients/README.md
+++ b/terraform/mcp_oauth_clients/README.md
@@ -1,0 +1,27 @@
+# MCP OAuth Clients Terraform Skeleton
+
+Issue #1577 Phase C prepares the Terraform source-of-truth shape for MCP OAuth
+clients. This directory is intentionally plan-only: it validates client metadata
+and produces a normalized plan summary, but it does not write to Supabase yet.
+The custom provider/apply path will be added in a later PR after the provider
+contract is reviewed.
+
+## Local Plan
+
+```bash
+terraform init -backend=false
+terraform validate
+terraform plan -input=false -lock=false -var-file=examples/clients.tfvars
+```
+
+## Rules
+
+- `managed_by` must stay `terraform`.
+- Every client needs at least one HTTPS redirect URI.
+- Every client needs at least one Resource Indicator.
+- `reputation_score` stays in the 0-100 range.
+- `metadata_document_url` is optional and represents the future CIMD migration
+  path; `null` means Phase 1 DCR.
+
+`terraform apply` is intentionally not wired. Manual SQL inserts into
+`mcp_oauth_clients` remain outside the desired operating model.

--- a/terraform/mcp_oauth_clients/examples/clients.tfvars
+++ b/terraform/mcp_oauth_clients/examples/clients.tfvars
@@ -1,0 +1,14 @@
+mcp_oauth_clients = {
+  claude_desktop = {
+    client_name         = "Claude Desktop"
+    redirect_uris       = ["https://claude.ai/redirect"]
+    grant_types         = ["authorization_code", "refresh_token"]
+    scopes              = ["mcp:tools:read"]
+    resource_indicators = [
+      "urn:jibun:tool:memory-search",
+      "urn:jibun:tool:wbs",
+    ]
+    managed_by       = "terraform"
+    reputation_score = 75
+  }
+}

--- a/terraform/mcp_oauth_clients/main.tf
+++ b/terraform/mcp_oauth_clients/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_version = ">= 1.6.0"
+}
+
+locals {
+  normalized_clients = {
+    for key, client in var.mcp_oauth_clients : key => {
+      client_name           = client.client_name
+      redirect_uris         = client.redirect_uris
+      grant_types           = client.grant_types
+      scopes                = client.scopes
+      resource_indicators   = client.resource_indicators
+      managed_by            = client.managed_by
+      metadata_document_url = client.metadata_document_url
+      reputation_score      = client.reputation_score
+      rotation_due_at       = client.rotation_due_at
+    }
+  }
+}
+
+check "terraform_managed_only" {
+  assert {
+    condition = alltrue([
+      for client in values(var.mcp_oauth_clients) : client.managed_by == "terraform"
+    ])
+    error_message = "MCP OAuth clients must be managed_by=terraform."
+  }
+}
+
+check "resource_indicators_required" {
+  assert {
+    condition = alltrue([
+      for client in values(var.mcp_oauth_clients) : length(client.resource_indicators) > 0
+    ])
+    error_message = "Each MCP OAuth client must declare at least one Resource Indicator."
+  }
+}

--- a/terraform/mcp_oauth_clients/outputs.tf
+++ b/terraform/mcp_oauth_clients/outputs.tf
@@ -1,0 +1,9 @@
+output "mcp_oauth_client_plan" {
+  description = "Normalized MCP OAuth client declarations that a future provider will upsert."
+  value       = local.normalized_clients
+}
+
+output "mcp_oauth_client_count" {
+  description = "Number of MCP OAuth clients in this plan."
+  value       = length(local.normalized_clients)
+}

--- a/terraform/mcp_oauth_clients/variables.tf
+++ b/terraform/mcp_oauth_clients/variables.tf
@@ -1,0 +1,46 @@
+variable "mcp_oauth_clients" {
+  description = "Plan-only MCP OAuth client declarations for the future custom provider."
+  type = map(object({
+    client_name           = string
+    redirect_uris         = list(string)
+    grant_types           = optional(list(string), ["authorization_code", "refresh_token"])
+    scopes                = optional(list(string), [])
+    resource_indicators   = list(string)
+    managed_by            = optional(string, "terraform")
+    metadata_document_url = optional(string)
+    reputation_score      = optional(number, 50)
+    rotation_due_at       = optional(string)
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for client in values(var.mcp_oauth_clients) : length(client.redirect_uris) > 0
+    ])
+    error_message = "Each MCP OAuth client must declare at least one redirect URI."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for client in values(var.mcp_oauth_clients) : [
+        for uri in client.redirect_uris : startswith(uri, "https://")
+      ]
+    ]))
+    error_message = "MCP OAuth redirect URIs must use https://."
+  }
+
+  validation {
+    condition = alltrue([
+      for client in values(var.mcp_oauth_clients) :
+      client.reputation_score >= 0 && client.reputation_score <= 100
+    ])
+    error_message = "MCP OAuth reputation_score must be between 0 and 100."
+  }
+
+  validation {
+    condition = alltrue([
+      for client in values(var.mcp_oauth_clients) : client.managed_by == "terraform"
+    ])
+    error_message = "Manual MCP OAuth client declarations are not allowed here."
+  }
+}


### PR DESCRIPTION
Refs #1577

## Minimal E2E Gate

- Implementation-detail independent: validation is black-box at the script/workflow contract level and does not rely on private implementation details.
- Minimal scope: about 3 cases only: quiet clients do not alert, recent invocation/failure bursts alert, and cross-server traces alert.
- E2E mechanism: this is a non-UI security automation PR; the PR workflow adds Deno check/lint/test plus Terraform plan validation, while the repository-level Playwright smoke remains unchanged.
- E2E-Exception: no new browser E2E is added because there is no user-facing route or app behavior change; verification is through Deno unit tests, workflow YAML parse, and PR-time Terraform plan.

## Summary

Codex #1 implements the scoped Phase C slice from `docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md`.

- Adds `scripts/mcp_audit_anomaly.ts` to scan `mcp_audit_log` through Supabase REST, score recent client anomalies, mark audit rows, and optionally notify Slack.
- Keeps client suspension disabled unless `MCP_AUDIT_ANOMALY_SUSPEND=true` is explicitly supplied.
- Adds `mcp-audit-anomaly-cron.yml` on hourly `:07`, with PR-time Deno script checks and Terraform plan validation.
- Adds `terraform/mcp_oauth_clients/` as a plan-only MCP OAuth client skeleton; `terraform apply` and custom provider writes are intentionally out of scope.
- Updates the #1577 hand-off doc to mark Phase C prepared while keeping Phases D-E open.

## High-Risk Review Note

Reviewer: Claude Code #1

High-Risk-Ultrareview-Exception: scoped Phase C follows the already-merged Claude Code #1 security spec and hand-off (`docs/MCP_AUTH_HARDENING_SPEC.md` + `docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md`). This PR adds detection and plan-only IaC primitives; it does not enable automatic client suspension by default and does not apply Terraform changes.

Security notes:
- `SUPABASE_SERVICE_ROLE_KEY` is used only inside the scheduled/manual GitHub Action environment.
- Anomaly row marking is bounded to recent row IDs; client suspension requires an explicit workflow input/env opt-in.
- Slack notification is best-effort and skipped when `SLACK_WEBHOOK_URL` is absent.
- Terraform is validation-only; manual SQL remains outside the desired operating model.

Rollback:
- Disable or remove `.github/workflows/mcp-audit-anomaly-cron.yml`.
- Remove `scripts/mcp_audit_anomaly.ts`, its test, and `terraform/mcp_oauth_clients/`.
- No schema/data migration is included in this Phase C PR.

## Validation

- `deno fmt scripts/mcp_audit_anomaly.ts scripts/mcp_audit_anomaly_test.ts`
- `deno check scripts/mcp_audit_anomaly.ts scripts/mcp_audit_anomaly_test.ts`
- `deno lint scripts/mcp_audit_anomaly.ts scripts/mcp_audit_anomaly_test.ts`
- `deno test scripts/mcp_audit_anomaly_test.ts` (5 passed)
- YAML parse for `.github/workflows/mcp-audit-anomaly-cron.yml`
- `python scripts/check_github_actions_node_runtime.py`
- `python scripts/check_no_verify_bypass.py --range origin/main..HEAD`
- `git diff --check`

Local note: Terraform is not installed in this Windows app environment, so `terraform plan` is wired into the new PR workflow instead of being run locally.

## Resource Hygiene

- Started session with C: free ~74.53GB and no common dev-server listener.
- Parent repo dirty/conflicted state was not touched; this PR uses a clean scoped worktree.
- Claude MCP node and VSCode Dart/Deno LSP are parent-app processes and were not stopped.