### PR TITLE
ci: fix MCP audit cron Supabase URL secret (#1577)

### DIFF
--- a/.github/workflows/mcp-audit-anomaly-cron.yml
+++ b/.github/workflows/mcp-audit-anomaly-cron.yml
@@ -74,7 +74,7 @@ jobs:
           --allow-write=mcp-audit-anomaly-summary.json
           scripts/mcp_audit_anomaly.ts
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           MCP_AUDIT_ANOMALY_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}

--- a/docs/MCP_AUTH_HARDENING_SPEC.md
+++ b/docs/MCP_AUTH_HARDENING_SPEC.md
@@ -437,7 +437,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Detect anomaly
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           # SQL: client_id × 5min での invocation 数 > p99×3 で suspended=true + Slack alert


### PR DESCRIPTION
Refs #1577.

## Summary
- switch the MCP audit anomaly cron to the repo's existing SUPABASE_URL_PROD secret
- keep the hardening spec example aligned with the shipped workflow

## Minimal E2E Gate
- This is an implementation-detail independent workflow/env fix; no application-code behavior changes are included.
- The minimal E2E plan is about three I/O cases: workflow dry-run receives the production Supabase URL, the anomaly script can query/write summary in dry-run, and suspend mode remains disabled by default.
- E2E mechanism: GitHub Actions workflow_dispatch dry-run, plus existing PR Playwright/public smoke coverage from the Minimal E2E workflow.

## High-Risk Review Note
Reviewer: Claude Code #1.
High-Risk-Ultrareview-Exception: scoped secret-name fix after PR #2191 dry-run evidence showed SUPABASE_URL was empty while the repository standard secret is SUPABASE_URL_PROD.
Coverage: security is limited to using the existing production Supabase URL secret without exposing values; data migration is not touched; prod smoke is covered by deploy-prod plus mcp-audit-anomaly-cron workflow_dispatch dry-run after merge; observability is preserved through the cron summary artifact and Slack path.
Unresolved ultrareview findings: none.

## Validation
- yaml parse for .github/workflows/mcp-audit-anomaly-cron.yml
- python scripts/check_github_actions_node_runtime.py
- python scripts/check_no_verify_bypass.py --range origin/main..HEAD
- git diff --check

## Rollback
- Revert this PR to restore the previous secret name; no database or runtime data changes are included.