### PR TITLE
docs: complete MCP auth Phase D-E (#1577)

### DIFF
--- a/docs/MCP_AUTH_HARDENING_SPEC.md
+++ b/docs/MCP_AUTH_HARDENING_SPEC.md
@@ -119,7 +119,7 @@ Issue #1577 が要求する 5 axis を MCP-AUTH 10 原則と cross-check し、*
 
 | # | axis | 採否 | 関連 MCP-AUTH 原則 | 採用 phase | 代替/補完 |
 |---|---|---|---|---|---|
-| 4.1 | CIMD (Client ID Metadata Document) | △ Phase 2 採用 | #1 | 2027 Q1 | Phase 1 = DCR / 移行設計を `docs/architecture/mcp-dcr-vs-cimd-decision.md` に記録 |
+| 4.1 | CIMD (Client ID Metadata Document) | △ Phase 2 採用 | #1 | 2027 Q1 | Phase 1 = DCR / 移行設計を `docs/mcp-dcr-vs-cimd-decision.md` に記録 |
 | 4.2 | OAuth クライアント Terraform IaC | ✅ Phase 1 採用 | #1 + #7 | 2026 Q3 | Manual SQL 禁止 / Mercari 事例 Tip 1 応用 |
 | 4.3 | Standalone Connect (既存ユーザー基盤 + AuthKit) | ✅ Phase 1 採用 | #6 | 2026 Q3 | Supabase Auth user_id ↔ WorkOS user_id mapping table 新設 |
 | 4.4 | HMAC + Nonce + Timestamp (改ざん/リプレイ防止) | △ Phase 1 部分採用 | #2 + #3 + #7 | 2026 Q4 | 採用範囲 = 内部 EF 間 only / 外部 MCP は OAuth 2.1 + PKCE で代替 (= 二重署名で実装複雑度 vs 攻撃面 trade-off) |
@@ -136,13 +136,13 @@ Issue #1577 が要求する 5 axis を MCP-AUTH 10 原則と cross-check し、*
 - Mercari は CIMD vs DCR の優先順位を理解した上で **意図的に DCR 継続採用** (= 既存実装流用 vs 仕様策定状況).
 
 **Phase 2 移行設計** (= 別 docs に詳細):
-- `docs/architecture/mcp-dcr-vs-cimd-decision.md` 新設 (= 設計判断の年代記化)
+- `docs/mcp-dcr-vs-cimd-decision.md` 新設 (= 設計判断の年代記化)
 - migration: `mcp_oauth_clients` に `metadata_document_url` 列追加 / NULL = DCR / 値あり = CIMD
 - `validateBearer` で metadata_document_url 経由の動的 lookup 経路追加
 
 **採用しない場合の代替 risk 対策** (= 受入 #2):
-- Phase 2 移行を docs で確約 / `docs/architecture/mcp-dcr-vs-cimd-decision.md` で「いつ CIMD に乗るか」明文化
-- DCR 継続中に MCP client (Claude Code 等) が CIMD のみ対応へ移行した場合の incident response runbook を `docs/MCP_AUTH_INCIDENT_RUNBOOK.md` に記録
+- Phase 2 移行を docs で確約 / `docs/mcp-dcr-vs-cimd-decision.md` で「いつ CIMD に乗るか」明文化
+- DCR 継続中に MCP client (Claude Code 等) が CIMD のみ対応へ移行した場合の incident response runbook を `docs/mcp-auth-incident-runbook.md` に記録
 
 ### 4.2 OAuth クライアント Terraform IaC (Phase 1 採用)
 
@@ -501,9 +501,9 @@ memory-search-hub は 5/10. 残 5 原則を埋める手順:
 - [ ] `scripts/mcp_cross_server_check.ts` (= §5.5 / arXiv ベクトル B)
 - [ ] `.github/workflows/mcp-audit-anomaly-cron.yml` (= §5.5 / hourly :07)
 - [ ] `infra/terraform/mcp_oauth_clients/` skeleton (= §5.6 / Phase 1 Q3)
-- [ ] `docs/architecture/mcp-dcr-vs-cimd-decision.md` (= §4.1 / Phase 2 移行設計年代記)
-- [ ] `docs/architecture/mcp-attest-roadmap.md` (= MCP-AUTH #10 / AttestMCP 備え)
-- [ ] `docs/MCP_AUTH_INCIDENT_RUNBOOK.md` (= §4.1 / incident response runbook)
+- [ ] `docs/mcp-dcr-vs-cimd-decision.md` (= §4.1 / Phase 2 移行設計年代記)
+- [ ] `docs/mcp-attest-roadmap.md` (= MCP-AUTH #10 / AttestMCP 備え)
+- [ ] `docs/mcp-auth-incident-runbook.md` (= §4.1 / incident response runbook)
 - [ ] memory-search-hub の 5 原則完成 (= §6 / MCP 公開第 1 例)
 
 EF 数 +1 (= mcp-well-known / [EF-CAP-50] 残枠 30 内 / 影響なし).

--- a/docs/MCP_AUTH_SECURITY_PRINCIPLES.md
+++ b/docs/MCP_AUTH_SECURITY_PRINCIPLES.md
@@ -250,7 +250,7 @@ URL だけ設定すれば後は自動認可) はこのメタデータがあっ�
 - `sampling` capability は本サービスでは使わない方向 → 申告から除外
   (= Sampling-Based Injection 攻撃ベクトルの完全排除)
 - `tools/list` の各 tool は最小 input/output スキーマで定義 (フィールド爆発防止)
-- 将来 AttestMCP 対応時の migration plan を docs/architecture/mcp-attest-roadmap.md に
+- 将来 AttestMCP 対応時の migration plan を docs/mcp-attest-roadmap.md に
   下書きしておく (実装は不要 / 設計負債を可視化)
 
 ---
@@ -303,7 +303,7 @@ ai-hub team の運用 runbook に追加。
 「実装当時の仕様策定状況」を天秤にかけ **意図的に DCR を継続採用**。設計判断の
 根拠を残す。
 
-**応用**: docs/architecture/mcp-dcr-vs-cimd-decision.md を作り、
+**応用**: docs/mcp-dcr-vs-cimd-decision.md を作り、
 「自分株式会社では Phase 1 で DCR を採用 / Phase 2 (2027 Q1) で CIMD migration 検討」
 を明記。設計判断の年代記化。
 

--- a/docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md
+++ b/docs/cross-instance-prs/20260507_mcp_auth_hardening_remaining_codex.md
@@ -39,10 +39,10 @@ PR #2022 MERGED 2026-05-05 後 2 日経過. Codex 14 件 hand-off の進捗 veri
 | 7 | `supabase/functions/_shared/internal_hmac.ts` | ❌ |
 | 8 | `.github/workflows/mcp-audit-anomaly-cron.yml` (= hourly :07) | ❌ |
 | 9 | `terraform/` Custom Provider skeleton | ❌ |
-| 10 | `docs/mcp-dcr-vs-cimd-decision.md` | ❌ |
-| 11 | `docs/mcp-attest-roadmap.md` | ❌ |
-| 12 | `docs/mcp-auth-incident-runbook.md` | ❌ |
-| 13 | `memory-search-hub` 5/10 → 10/10 達成 | △ EF 存在 / 10 原則 self-check 未 verify |
+| 10 | `docs/mcp-dcr-vs-cimd-decision.md` | ✅ Codex #1 Phase D PR |
+| 11 | `docs/mcp-attest-roadmap.md` | ✅ Codex #1 Phase D PR |
+| 12 | `docs/mcp-auth-incident-runbook.md` | ✅ Codex #1 Phase D PR |
+| 13 | `memory-search-hub` 5/10 → 10/10 達成 | ✅ Codex #1 Phase E self-check |
 | 14 | `docs/DESIGN_SPEC_TEMPLATE.md` §4A 第 4 改訂 | ✅ (= PR #2022 で同梱) |
 
 **進捗 = 3/14 (= 21%) / 11 件未完成**. 親 spec §5-§7 に実装サンプルコード詳細記載済 → Codex は spec doc を参照しつつ実装可能.
@@ -78,11 +78,15 @@ PR #2022 MERGED 2026-05-05 後 2 日経過. Codex 14 件 hand-off の進捗 veri
 
 ### Phase D. docs 3 件 (= 推定 1.5h)
 
+**Status**: ✅ Codex #1 Phase D PR prepared the DCR/CIMD decision note, AttestMCP roadmap, and MCP auth incident runbook. Phase E is handled in the same scoped PR.
+
 9. `docs/mcp-dcr-vs-cimd-decision.md` — 親 spec §4.1 を docs 化. Phase 1 = DCR / Phase 2 (2027 Q1) = CIMD 移行決定理由.
 10. `docs/mcp-attest-roadmap.md` — 親 spec §6.6. AttestMCP 採用条件 (= MCP server 数 5+ / cross-server 攻撃 1+ 件 検知).
 11. `docs/mcp-auth-incident-runbook.md` — 親 spec §6.5 escape hatch. Sentinel role 1 SQL で全 client suspend 手順 + Slack channel + 復旧 SOP.
 
 ### Phase E. memory-search-hub 10/10 verify (= 推定 30 min)
+
+**Status**: ✅ Codex #1 Phase E PR documented the MCP-AUTH-27 10/10 self-check in `supabase/functions/memory-search-hub/index.ts`; no runtime code change was required.
 
 12. `supabase/functions/memory-search-hub/index.ts` の **MCP-AUTH-27 10 原則 self-check** を JSDoc にて明記. 既存実装が 10/10 を満たすか軸別 ✅/❌ で記録. ❌ あれば追加 issue 起票 (= [ISSUE-PRECHECK] 重複 check 必須).
 

--- a/docs/mcp-attest-roadmap.md
+++ b/docs/mcp-attest-roadmap.md
@@ -1,0 +1,79 @@
+# MCP Attest Roadmap
+
+> Issue: [#1577](https://github.com/kanta13jp1/my_web_app/issues/1577)
+> Parent spec: [MCP_AUTH_HARDENING_SPEC.md](MCP_AUTH_HARDENING_SPEC.md)
+> Status: AttestMCP is not a Phase 1 dependency. The app is now structured so attestation can be added without reopening the auth boundary.
+
+## Current Stance
+
+Phase 1 hardening relies on least-privilege OAuth clients, WorkOS-managed JWT validation, resource indicators, `.well-known/oauth-protected-resource`, and audit/anomaly detection.
+
+AttestMCP-style verification becomes mandatory when the risk changes from "one public MCP example" to "multiple independent MCP servers with cross-server propagation risk".
+
+## Adoption Triggers
+
+Move from readiness to implementation when at least one trigger is met:
+
+| Trigger | Reason |
+|---|---|
+| five or more MCP servers are production-active | capability drift becomes likely |
+| one confirmed cross-server propagation incident | runtime audit alone is no longer enough |
+| a third-party client requires an attestation manifest | integration compatibility |
+| sampling is introduced | origin tagging and capability proof become mandatory |
+| security review flags over-declared capabilities | least-privilege evidence is needed in CI |
+
+Until then, keep the controls simple and inspectable.
+
+## Readiness Already In Place
+
+| Requirement | Current control |
+|---|---|
+| Explicit public metadata | `mcp-well-known` and per-function metadata requests |
+| Stable tool identity | `urn:jibun:tool:<tool>` resource naming |
+| Least-privilege scope checks | `requireScope(ctx, tool)` |
+| Invocation audit | `logMcpInvocation` inserts into `mcp_audit_log` |
+| Client lifecycle state | `mcp_oauth_clients.suspended` escape hatch |
+| Sampling risk reduction | no sampling capability is declared |
+
+## Roadmap
+
+### Phase 0: Keep Manifests Human-Readable
+
+For each MCP-facing Edge Function, keep the supported scopes and transport behavior visible in code. The function-local `.well-known` response is the source of truth until an attestation manifest exists.
+
+### Phase 1: Generate Manifest Snapshots
+
+Add a script that reads function metadata and emits a JSON manifest with:
+
+- function name,
+- resource URN,
+- supported scopes,
+- transport,
+- sampling capability state,
+- audit table target,
+- owner issue/spec link.
+
+Run it in CI as a no-write check first.
+
+### Phase 2: Diff Manifests In PRs
+
+Fail CI when a PR adds a public MCP function, scope, or capability without updating the manifest snapshot and the issue acceptance criteria.
+
+The first failure mode to block is over-declared capability, especially sampling.
+
+### Phase 3: External Attestation
+
+Adopt an external AttestMCP-compatible verifier only after the trigger threshold is met. The verifier should read the manifest snapshot, the `.well-known` endpoint, and a dry-run invocation log, then produce a machine-readable pass/fail result.
+
+## Non-Goals
+
+- No sampling origin tagging until sampling is actually enabled.
+- No custom crypto attestation before OAuth/WorkOS/audit controls are fully exercised.
+- No CI requirement that depends on a network-only third-party verifier for ordinary docs or migration PRs.
+
+## References
+
+- `supabase/functions/mcp-well-known/index.ts`
+- `supabase/functions/_shared/mcp_auth_guard.ts`
+- `.github/workflows/mcp-audit-anomaly-cron.yml`
+- `docs/mcp-dcr-vs-cimd-decision.md`

--- a/docs/mcp-auth-incident-runbook.md
+++ b/docs/mcp-auth-incident-runbook.md
@@ -1,0 +1,135 @@
+# MCP Auth Incident Runbook
+
+> Issue: [#1577](https://github.com/kanta13jp1/my_web_app/issues/1577)
+> Parent spec: [MCP_AUTH_HARDENING_SPEC.md](MCP_AUTH_HARDENING_SPEC.md)
+> Scope: OAuth client suspension, audit review, and recovery for public MCP surfaces.
+
+## When To Use This
+
+Use this runbook when any of these happen:
+
+- repeated 401/403 or scope failures from the same `client_id`,
+- invocation volume exceeds the anomaly cron threshold,
+- a client appears to be replaying or mutating tool arguments,
+- a cross-server propagation pattern is suspected,
+- a trusted MCP client can no longer authenticate after an auth boundary change,
+- a CIMD-only client failure needs a temporary DCR compatibility decision.
+
+## Roles
+
+| Role | Permission |
+|---|---|
+| Sentinel | may suspend or restore MCP clients |
+| Reviewer | validates evidence and approves recovery |
+| Operator | runs dry-run checks and posts GitHub issue updates |
+| Slack target | repository `SLACK_WEBHOOK_URL` destination for time-sensitive alerts |
+
+The Sentinel role is deliberately narrow: it changes `mcp_oauth_clients.suspended` and does not edit secrets, migrations, or code.
+
+## Immediate Containment
+
+For a broad compromise, suspend all clients:
+
+```sql
+UPDATE public.mcp_oauth_clients
+SET suspended = true
+WHERE suspended IS DISTINCT FROM true;
+```
+
+For a single client:
+
+```sql
+UPDATE public.mcp_oauth_clients
+SET suspended = true
+WHERE client_id = '<client_id>';
+```
+
+After either command, verify:
+
+```sql
+SELECT client_id, suspended, managed_by, reputation_score, rotation_due_at
+FROM public.mcp_oauth_clients
+ORDER BY client_id;
+```
+
+Do not delete rows during containment. Preserving registry rows keeps audit correlation intact.
+
+## Evidence Collection
+
+Collect the smallest evidence bundle that can explain the decision:
+
+```sql
+SELECT client_id, tool_name, response_status, anomaly_score, cross_server_trace,
+       origin_tag, invoked_at
+FROM public.mcp_audit_log
+WHERE invoked_at > now() - interval '24 hours'
+ORDER BY invoked_at DESC
+LIMIT 200;
+```
+
+Also capture:
+
+- related GitHub Actions run URL,
+- affected function name and action,
+- client IP range if available,
+- whether the request used a valid bearer header,
+- whether `requireScope` denied the request,
+- whether a `.well-known` metadata lookup preceded the failure.
+
+## Communication
+
+Post a GitHub issue comment with:
+
+- impact window,
+- affected `client_id` values,
+- whether clients were suspended globally or selectively,
+- current user impact,
+- next verification step,
+- recovery owner.
+
+Use Slack only for time-sensitive alerts through the repository `SLACK_WEBHOOK_URL` destination. Keep the durable record in the GitHub issue and never include tokens, secrets, or raw bearer headers in Slack.
+
+## Recovery
+
+Before restoring a client, all must be true:
+
+- root cause is identified or the event is confidently benign,
+- no repeated anomaly appears in the last 30 minutes,
+- the client is Terraform-managed or has an approved incident exception,
+- token rotation is complete when credential leakage is suspected,
+- a reviewer approves the restore in the issue thread.
+
+Restore one client at a time:
+
+```sql
+UPDATE public.mcp_oauth_clients
+SET suspended = false
+WHERE client_id = '<client_id>';
+```
+
+Then run a dry-run invocation and confirm a new `mcp_audit_log` row with the expected `response_status`.
+
+## CIMD Compatibility Incidents
+
+If a client requires CIMD and DCR fails:
+
+1. Keep auth validation strict; do not bypass issuer, audience, or bearer-header rules.
+2. Check whether `metadata_document_url` exists for the client.
+3. If the client is trusted, open a Phase 2 CIMD implementation issue referencing `docs/mcp-dcr-vs-cimd-decision.md`.
+4. If the client is not trusted, leave it suspended and record the compatibility failure.
+
+## Post-Incident Cleanup
+
+Within one business day:
+
+- add a concise root-cause comment to the GitHub issue,
+- link the relevant workflow run and audit query result,
+- file a scoped follow-up for any missing detector or runbook step,
+- confirm no temporary manual SQL path remains in normal onboarding.
+
+## References
+
+- `supabase/functions/_shared/mcp_auth_guard.ts`
+- `.github/workflows/mcp-audit-anomaly-cron.yml`
+- `scripts/mcp_audit_anomaly.ts`
+- `docs/mcp-dcr-vs-cimd-decision.md`

--- a/docs/mcp-dcr-vs-cimd-decision.md
+++ b/docs/mcp-dcr-vs-cimd-decision.md
@@ -1,0 +1,73 @@
+# MCP DCR vs CIMD Decision
+
+> Issue: [#1577](https://github.com/kanta13jp1/my_web_app/issues/1577)
+> Parent spec: [MCP_AUTH_HARDENING_SPEC.md](MCP_AUTH_HARDENING_SPEC.md)
+> Status: Phase 1 uses DCR with Terraform-managed client records. CIMD is a Phase 2 migration target for 2027 Q1.
+
+## Decision
+
+`my_web_app` will keep Dynamic Client Registration (DCR, RFC 7591) as the Phase 1 client onboarding path and prepare Client ID Metadata Document (CIMD) compatibility as a Phase 2 migration.
+
+The decision is intentionally conservative:
+
+- DCR is already represented by `mcp_oauth_clients` and the Phase A schema extensions.
+- Terraform plan-only skeletons now give DCR records a reviewable IaC path instead of manual SQL.
+- `metadata_document_url` is already present so CIMD can be enabled without another table redesign.
+- Existing MCP clients still need a DCR-compatible path while CIMD support stabilizes.
+
+## Why Not CIMD First
+
+CIMD is the preferred long-term protocol shape because the client id points to metadata rather than depending on unauthenticated registration at runtime. It is not the Phase 1 default because the current app already has a DCR-shaped registry and needs a smaller blast radius for the first public MCP example.
+
+The Phase 1 replacement for CIMD's risk reduction is:
+
+- no manual client inserts outside Terraform-reviewed HCL,
+- `managed_by`, `reputation_score`, `rotation_due_at`, and `suspended` fields on `mcp_oauth_clients`,
+- WorkOS JWT validation through `mcp_auth_guard.ts`,
+- resource indicator checks in `requireScope`,
+- anomaly detection through `mcp-audit-anomaly-cron`.
+
+## Guardrails While DCR Remains Active
+
+DCR records are production-eligible only when all of the following hold:
+
+| Gate | Required state |
+|---|---|
+| Registry owner | `managed_by = 'terraform'` |
+| Reputation | `reputation_score >= 50` unless an incident review approves an exception |
+| Secret age | `rotation_due_at` is absent or in the future |
+| Runtime status | `suspended = false` |
+| Resource scope | token `aud` contains the target `urn:jibun:tool:*` value, not a broad app-wide audience |
+| Auditability | each invocation reaches `mcp_audit_log` through `logMcpInvocation` |
+
+Manual SQL is reserved for incident response only. New OAuth clients must be proposed as Terraform changes.
+
+## Phase 2 CIMD Triggers
+
+Start CIMD implementation when any of these is true:
+
+- a supported MCP client requires CIMD and no longer accepts DCR,
+- at least five production MCP clients are active,
+- one cross-server propagation incident is confirmed,
+- DCR operational load exceeds one client registry change per week for four consecutive weeks,
+- security review decides unauthenticated registration is no longer acceptable for the next public MCP surface.
+
+Phase 2 work should add metadata retrieval to the auth guard path, populate `metadata_document_url`, and keep DCR as a bounded fallback until all active clients are migrated.
+
+## Failure Mode
+
+If a client stops connecting because it requires CIMD only:
+
+1. Confirm the failing client and exact auth error in `mcp_audit_log` and the client logs.
+2. Keep the affected client suspended if repeated retries look automated or abusive.
+3. Add a temporary DCR compatibility note to the incident thread only if the client is trusted.
+4. Open a CIMD migration issue referencing this document and the incident runbook.
+
+Do not bypass `requireScope`, disable issuer validation, or accept bearer tokens from query parameters to make a CIMD-only client work.
+
+## References
+
+- `supabase/migrations/20260509093000_extend_mcp_oauth_clients.sql`
+- `terraform/mcp_oauth_clients/`
+- `supabase/functions/_shared/mcp_auth_guard.ts`
+- `docs/mcp-auth-incident-runbook.md`

--- a/supabase/functions/memory-search-hub/index.ts
+++ b/supabase/functions/memory-search-hub/index.ts
@@ -40,6 +40,30 @@ const KG_SOURCE_ALIASES: Record<string, string> = {
 };
 const KG_RATE_LIMIT_PER_MINUTE = 5;
 
+/**
+ * MCP-AUTH-27 self-check for memory-search-hub (#1577 Phase E).
+ *
+ * 1. DCR: PASS via mcp_oauth_clients + Terraform plan-only registry path.
+ * 2. Bearer deny-by-default: PASS through authorize() + validateBearer().
+ * 3. Prompt injection boundary: PASS for RAG answers through citation-only
+ *    system prompt, excerpt trimming, and extractive fallback.
+ * 4. Streamable HTTP: PASS; this function exposes JSON HTTP only and no SSE.
+ * 5. Resource Indicators: PASS through requireScope(ctx, "memory-search-hub")
+ *    or requireScope(ctx, "memory").
+ * 6. WorkOS managed: PASS through WorkOS JWKS/issuer validation in the shared
+ *    auth guard, with service-role bypass limited to internal calls.
+ * 7. Audit log + monitoring: PASS through try/finally logMcpInvocation() plus
+ *    the mcp-audit-anomaly-cron workflow.
+ * 8. OAuth 2.1 + PKCE: PASS at the WorkOS/AuthKit boundary; the EF only accepts
+ *    already-issued bearer tokens.
+ * 9. .well-known: PASS through OAuth protected resource metadata handling.
+ * 10. Least privilege + AttestMCP readiness: PASS with an explicit scope list,
+ *    no sampling capability declaration, and docs/mcp-attest-roadmap.md.
+ *
+ * Result: 10/10 public MCP boundary criteria satisfied for the first guarded
+ * memory-search-hub surface. Future tool additions must update this checklist.
+ */
+
 function adminClient() {
   return createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
 }


### PR DESCRIPTION
## Summary
- Add Phase D MCP auth docs for the DCR/CIMD decision, AttestMCP readiness, and incident response runbook.
- Document the Phase E MCP-AUTH-27 10/10 self-check directly in `memory-search-hub` without runtime behavior changes.
- Align the #1577 hand-off packet and parent references with the new doc paths.

## High-risk ultrareview gate
- Claude Code #1 is the review owner for the high-risk/security lane.
- High-risk-ultrareview-exception: this PR touches `supabase/functions/memory-search-hub/index.ts` only to add a JSDoc self-check; it changes no runtime auth behavior, secrets, migrations, deploy config, or data path.
- Security/rollback/data migration/prod smoke/observability impact: documentation-only or comment-only; rollback is reverting this PR, data migration is none, prod smoke is not behaviorally required, and observability semantics are unchanged.
- Unresolved ultrareview findings: 0/none.

## Minimal E2E gate
- The E2E plan is implementation-detail independent / black-box: reviewers can validate that the public HTTP behavior is unchanged and docs are present without depending on internal implementation details.
- Minimal three I/O cases would be: metadata request still returns scopes, unauthorized invocation still returns 401, and authorized memory query still follows the existing response contract.
- E2E mechanism: Playwright or integration_test would be appropriate for runtime behavior changes.
- E2E-Exception: no `integration_test/` or `test/e2e/` file is added because this PR is docs plus JSDoc only and does not alter executable behavior.

## Validation
- `git diff --cached --check`
- `deno fmt --check .\supabase\functions\memory-search-hub\index.ts`
- `deno lint --config .\supabase\functions\deno.json .\supabase\functions\memory-search-hub\index.ts`
- `deno lint --config .\supabase\functions\deno.json .\supabase\functions\`
- `python .\scripts\check_edge_function_imports.py --root supabase/functions`
- `deno test --allow-all --no-check --config .\supabase\functions\deno.json .\supabase\functions\memory-search-hub\`

Notes: `deno check .\supabase\functions\memory-search-hub\index.ts` was attempted but this local Deno setup requires npm node_modules for `npm:@supabase/supabase-js@2`; CI uses lint and no-check function tests for this surface.