### PR TITLE
feat(calendar): Google Calendar 風 時間単位 schedule 登録

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -29146,4 +29146,28 @@ User 第 2 弾 ask (= same session continuation): 「WBS 期限近順 + 2 instan
 - 理念的貢献: 「**spec 誤前提即訂正 verify pattern**」第 1 例 (= part 187 spec の `cleanup_reports/` 期待を 1 session 内 actual output 確認 → comment 訂正) + 「**startup auto-fire 2/3 verify within 30 sec**」pattern 第 1 例 + 「**verify-only session = no new spec**」discipline 厳守 / 119 part 連続 dogfood
 
 ### Commit
-- (= 本 docs PR の merge commit / 後追記)
+- b51ca38d (= PR [#2201](https://github.com/kanta13jp1/my_web_app/pull/2201)) — docs(roadmap): part 188 — auto-fire 完全 verify (2/3 ✅) + spec 訂正
+
+## 2026-05-09 — Win版#132 part 188-b (Win Claude / Claude Code 続き)
+
+### Session Summary (= verify-only 解除 / user 新規 task = calendar 時間単位化)
+- **User ask**: Google Calendar 風 時間単位 schedule 登録要望 (= screenshot https://my-web-app-b67f4.web.app/calendar-events / 現状「終日 only」)
+- **frontend-only fix ship**: `lib/pages/calendar_events_page.dart` 改修
+  - 「終日」default `true` → `false` (= 時間指定 default)
+  - 開始/終了 **TimePicker** 追加 (= `showTimePicker` / hour:minute granularity)
+  - 終日 toggle 時 time picker 非表示
+  - 開始時刻変更時 終了 ≤ 開始 → 開始 + 60 min auto-bump
+  - `_EventCard` time label = `HH:MM - HH:MM` range 表示 (= `start_at` + `end_at` 両方使用)
+  - 旧 `all_day=true` event は引き続き「終日」表示 (= backward compat)
+- **Backend 改修なし** (= `app-hub` EF `calendar.create` 既に `start_at` / `end_at` ISO 8601 受付 / `hub_data.metadata` JSONB 格納 / [EF-CAP-50] 影響なし)
+- **dart format ✅ + flutter analyze 0 issues ✅** (= 47.8s)
+- **[NO-SCOPE-CREEP] 厳守** (= `pubspec.lock` 自動 pub-update revert / calendar feature のみ commit)
+
+### Philosophy Alignment (Win#132 part 188-b)
+- 主要実装: user 直接報告 UX 改善 (= 終日 only → 時間単位) frontend-only fix
+- 該当原則: #2 (ミッション = カレンダー実用化) + #5 (商品=価値 = 時間単位 = 実用 calendar) + #6 (時間最適化 = backend 改修なしで UX 大幅向上) + #7 (資産負債 = 「終日 only」UX 負債解消) + #8 (KPI = backward compat 維持) + #9 (IPO = small frontend tweak でも standard PR template 遵守)
+- 整合性スコア: 6/9 ✅ ([PHILOSOPHY-22] gate 通過)
+- 理念的貢献: 「**user screenshot direct ask → frontend-only fix → 即 ship**」pattern 第 1 例 (= verify-only mode 中でも user 直接 ask 優先) + 「**EF + DB schema 改修なしで frontend UX 改善**」pattern 第 N 例累積 / 119 part 連続 dogfood
+
+### Commit
+- (= 本 feature PR の merge commit / 後追記)

--- a/lib/pages/calendar_events_page.dart
+++ b/lib/pages/calendar_events_page.dart
@@ -96,12 +96,14 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   Future<void> _createEvent({
     required String title,
     required DateTime startAt,
+    DateTime? endAt,
     String description = '',
     bool allDay = false,
     String color = '#4285f4',
   }) async {
     try {
-      final end = allDay ? startAt : startAt.add(const Duration(hours: 1));
+      final end =
+          allDay ? startAt : (endAt ?? startAt.add(const Duration(hours: 1)));
       await _supabase.functions.invoke(
         'app-hub',
         body: {
@@ -314,9 +316,14 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     final titleCtrl = TextEditingController();
     final descCtrl = TextEditingController();
     var eventDate = _selectedDay;
-    var allDay = true;
+    var allDay = false;
+    var startTime = const TimeOfDay(hour: 9, minute: 0);
+    var endTime = const TimeOfDay(hour: 10, minute: 0);
     final colors = ['#4285f4', '#ea4335', '#34a853', '#fbbc05', '#9334e6'];
     var selectedColor = colors.first;
+
+    String fmtTime(TimeOfDay t) =>
+        '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
 
     showDialog(
       context: context,
@@ -372,11 +379,62 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
                     Checkbox(
                       value: allDay,
                       onChanged: (v) =>
-                          setDialogState(() => allDay = v ?? true),
+                          setDialogState(() => allDay = v ?? false),
                     ),
                     const Text('終日'),
                   ],
                 ),
+                if (!allDay) ...[
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      const Icon(Icons.schedule, size: 18),
+                      const SizedBox(width: 8),
+                      const Text('開始'),
+                      const SizedBox(width: 8),
+                      OutlinedButton(
+                        onPressed: () async {
+                          final picked = await showTimePicker(
+                            context: ctx,
+                            initialTime: startTime,
+                          );
+                          if (picked != null) {
+                            setDialogState(() {
+                              startTime = picked;
+                              final startMinutes =
+                                  picked.hour * 60 + picked.minute;
+                              final endMinutes =
+                                  endTime.hour * 60 + endTime.minute;
+                              if (endMinutes <= startMinutes) {
+                                final next = startMinutes + 60;
+                                endTime = TimeOfDay(
+                                  hour: (next ~/ 60) % 24,
+                                  minute: next % 60,
+                                );
+                              }
+                            });
+                          }
+                        },
+                        child: Text(fmtTime(startTime)),
+                      ),
+                      const SizedBox(width: 8),
+                      const Text('終了'),
+                      const SizedBox(width: 8),
+                      OutlinedButton(
+                        onPressed: () async {
+                          final picked = await showTimePicker(
+                            context: ctx,
+                            initialTime: endTime,
+                          );
+                          if (picked != null) {
+                            setDialogState(() => endTime = picked);
+                          }
+                        },
+                        child: Text(fmtTime(endTime)),
+                      ),
+                    ],
+                  ),
+                ],
                 const SizedBox(height: 8),
                 const Text(
                   'カラー:',
@@ -430,9 +488,28 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
                 final title = titleCtrl.text.trim();
                 if (title.isEmpty) return;
                 Navigator.pop(ctx);
+                final startDateTime = allDay
+                    ? DateTime(eventDate.year, eventDate.month, eventDate.day)
+                    : DateTime(
+                        eventDate.year,
+                        eventDate.month,
+                        eventDate.day,
+                        startTime.hour,
+                        startTime.minute,
+                      );
+                final endDateTime = allDay
+                    ? null
+                    : DateTime(
+                        eventDate.year,
+                        eventDate.month,
+                        eventDate.day,
+                        endTime.hour,
+                        endTime.minute,
+                      );
                 _createEvent(
                   title: title,
-                  startAt: eventDate,
+                  startAt: startDateTime,
+                  endAt: endDateTime,
                   description: descCtrl.text.trim(),
                   allDay: allDay,
                   color: selectedColor,
@@ -463,17 +540,23 @@ class _EventCard extends StatelessWidget {
     final title = event['title']?.toString() ?? 'タイトルなし';
     final description = event['description']?.toString() ?? '';
     final startAt = event['start_at']?.toString() ?? '';
+    final endAt = event['end_at']?.toString() ?? '';
     final allDay = event['all_day'] == true;
 
+    String fmt(DateTime d) =>
+        '${d.hour.toString().padLeft(2, '0')}:${d.minute.toString().padLeft(2, '0')}';
+
     String timeLabel = '';
-    if (!allDay && startAt.isNotEmpty) {
-      final dt = DateTime.tryParse(startAt)?.toLocal();
-      if (dt != null) {
-        timeLabel =
-            '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
-      }
-    } else {
+    if (allDay) {
       timeLabel = '終日';
+    } else if (startAt.isNotEmpty) {
+      final start = DateTime.tryParse(startAt)?.toLocal();
+      final end = DateTime.tryParse(endAt)?.toLocal();
+      if (start != null && end != null) {
+        timeLabel = '${fmt(start)} - ${fmt(end)}';
+      } else if (start != null) {
+        timeLabel = fmt(start);
+      }
     }
 
     return Card(


### PR DESCRIPTION
## Summary

User 要望: カレンダーイベントを Google Calendar のように **時間単位 (= HH:MM)** で登録可能に。

### 変更内容 (= frontend-only)

- 「終日」default `true` → `false` (= 時間指定が default)
- 開始/終了 **TimePicker** 追加 (= `showTimePicker` / hour:minute granularity)
- 終日 toggle 時 time picker 非表示
- 開始時刻変更時の終了時刻 auto-bump (= 終了 ≤ 開始 → 開始 + 60 min に補正)
- `_EventCard` の time label = `HH:MM - HH:MM` range 表示 (= `start_at` + `end_at` 両方使用)

### Backend 改修なし

- `app-hub` EF の `calendar.create` action は既に `start_at` / `end_at` を ISO 8601 文字列で受付
- `hub_data.metadata` JSONB に格納済 → schema 改修「不要」 / [EF-CAP-50] 影響なし

### Backward compat

- 既存 `all_day=true` event = 引き続き「終日」表示
- 既存 `end_at` なしの旧 event = `start_at` のみ表示 (= 単一時刻 fallback)

## Minimal E2E

- skip via `no-e2e-needed` label (= small frontend dialog UX tweak / 既存 calendar EF 既動作 / 実装詳細に依存しない playwright I/O 3 ケースは将来 calendar 専用 e2e fixture 追加時にまとめて)

## High-risk ultrareview gate

- Review owner: **Claude Code #1**
- ultrareview-exception: frontend-only UI tweak (= dialog に showTimePicker 追加 + allDay default 反転 + EventCard time range 表示) / backend EF + DB schema 改修 0 / security 影響 0 / RLS 影響 0 / payment/auth/billing 文脈なし / 「migration」語は「schema migration 不要」の文脈 (= 改修なし宣言) / rollback = revert 1 commit でフロントだけ復元可 / production deploy 既存 GHA 通常 lane / observability 既存 console + Supabase log 経路維持

## Test plan

- [x] dart format ✅ (= 1 file changed)
- [x] flutter analyze ✅ (= 0 issues / 47.8s)
- [x] [DART-FORMAT] 厳守 (= 絶対パス + pipe なし)
- [x] [REBASE] 厳守 (= origin/main 2 commit ahead → rebase OK)
- [x] [STASH-SAFETY] 厳守 (= WIP commit + reset HEAD~1 経由)
- [x] [NO-SCOPE-CREEP] 厳守 (= pubspec.lock 自動更新は revert / calendar feature のみ commit)
- [ ] 本番 UI 動作確認 (= my-web-app-b67f4.web.app/calendar-events で開始/終了 time picker + HH:MM - HH:MM range 表示確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)