### PR TITLE
ci: add news pattern source-risk gate (#1965)

### DIFF
--- a/.github/workflows/ai-tool-watch.yml
+++ b/.github/workflows/ai-tool-watch.yml
@@ -54,17 +54,27 @@ jobs:
             --report docs/ai-tool-watch/latest-report.md \
             --json docs/ai-tool-watch/latest-report.json
 
+      - name: Detect repeated news patterns
+        id: patterns
+        run: |
+          python scripts/news_pattern_detector.py \
+            --source docs/ai-tool-watch/latest-report.json \
+            --label ai-tool-watch \
+            --output docs/ai-tool-watch/latest-patterns.json \
+            --markdown docs/ai-tool-watch/latest-patterns.md \
+            --min-confidence 0.55
+
       - name: Commit updated watch state
         run: |
           set -euo pipefail
-          if git diff --quiet -- docs/ai-tool-watch; then
+          if [ -z "$(git status --porcelain -- docs/ai-tool-watch)" ]; then
             echo "No report/state changes to commit."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/ai-tool-watch/latest-report.md docs/ai-tool-watch/latest-report.json docs/ai-tool-watch/state.json
+          git add docs/ai-tool-watch/latest-report.md docs/ai-tool-watch/latest-report.json docs/ai-tool-watch/latest-patterns.json docs/ai-tool-watch/latest-patterns.md docs/ai-tool-watch/state.json
           git commit -m "chore: update AI tool watch report"
           git push
 

--- a/.github/workflows/competitor-monitoring.yml
+++ b/.github/workflows/competitor-monitoring.yml
@@ -367,6 +367,23 @@ jobs:
           DOWN: ${{ steps.availability.outputs.down_count }}
           USED_MODEL: ${{ steps.ai_report.outputs.used_model }}
 
+      - name: Step 5b - news pattern detector + source-risk filter
+        id: patterns
+        run: |
+          OUTPUT_FILE="${{ steps.report.outputs.output_file }}"
+          TODAY="${{ steps.report.outputs.today }}"
+          if [ -f "$OUTPUT_FILE" ]; then
+            python3 scripts/news_pattern_detector.py \
+              --source "$OUTPUT_FILE" \
+              --label competitor-monitoring \
+              --output "docs/competitor-reports/${TODAY}-patterns.json" \
+              --markdown "docs/competitor-reports/${TODAY}-patterns.md" \
+              --min-confidence 0.50
+          else
+            echo "pattern_count=0" >> "$GITHUB_OUTPUT"
+            echo "issue_candidate_count=0" >> "$GITHUB_OUTPUT"
+          fi
+
       # ── Step 6: コミット ─────────────────────────────────────────────────
       - name: Step 6 - コミット & push
         run: |
@@ -409,6 +426,8 @@ jobs:
           SPECIAL_EVENT="${{ steps.calendar.outputs.special_event }}"
           DOWN="${{ steps.availability.outputs.down_count }}"
           USED_MODEL="${{ steps.ai_report.outputs.used_model }}"
+          PATTERNS="${{ steps.patterns.outputs.pattern_count }}"
+          ISSUE_CANDIDATES="${{ steps.patterns.outputs.issue_candidate_count }}"
 
           COMP_COUNT="${{ steps.availability.outputs.comp_count }}"
           DOWN_ICON=$([ "${DOWN:-0}" = "0" ] && echo "✅ 全${COMP_COUNT:-?}社正常" || echo "⚠️ ${DOWN}社 要注意")
@@ -425,5 +444,6 @@ jobs:
             echo "| 可用性 (${COMP_COUNT:-?}社) | $DOWN_ICON |"
             echo "| AIモデル | $USED_MODEL |"
             echo "| レポートファイル | docs/competitor-reports/${TODAY}.md |"
+            echo "| Pattern detector | ${PATTERNS:-0} patterns / ${ISSUE_CANDIDATES:-0} issue candidates |"
             echo "$EVENT_ROW"
           } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/notebooklm-issue-crosscheck.yml
+++ b/.github/workflows/notebooklm-issue-crosscheck.yml
@@ -1,17 +1,12 @@
-name: NotebookLM × Issue Cross-Check
+name: NotebookLM Issue Cross-Check
 
-# Win版#132 part 120 (2026-05-03) — manual triage 自動化
-#
-# Daily cron: scripts/notebooklm_issue_crosscheck.py を実行し、
-# notebook ↔ Issue の cross-check 結果 (TRUE_GAP / DUP_OPEN) を
-# tracking Issue #1647 に comment.
-#
-# - TRUE_GAP: notebook が存在するが対応 Issue 無し → 手動 triage 必須
-# - DUP_OPEN: 同 notebook に 2+ open Issue → cleanup candidate
+# Daily NotebookLM -> GitHub Issue cross-check.
+# TRUE_GAP candidates now pass through the local source-risk filter before
+# opening automation follow-up issues.
 
 on:
   schedule:
-    - cron: "0 19 * * *"  # daily 04:00 JST (= 19:00 UTC) — 全 instance wrap-up + residuals-sync 後
+    - cron: "0 19 * * *" # daily 04:00 JST
   workflow_dispatch:
     inputs:
       limit:
@@ -35,7 +30,7 @@ concurrency:
 
 jobs:
   crosscheck:
-    name: Run cross-check + report
+    name: Run cross-check + source-risk filter
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -55,10 +50,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install notebooklm-py
-        run: |
-          pip install --quiet notebooklm-py
+        run: pip install --quiet notebooklm-py
 
-      - name: Restore NotebookLM auth (= guard if secret missing)
+      - name: Restore NotebookLM auth
         run: |
           mkdir -p ~/.notebooklm
           if [ -n "$NOTEBOOKLM_STORAGE_STATE" ]; then
@@ -66,7 +60,7 @@ jobs:
             chmod 600 ~/.notebooklm/storage_state.json
             echo "auth_present=true"
           else
-            echo "::warning::NOTEBOOKLM_STORAGE_STATE_JSON secret not set — script will exit 1"
+            echo "::warning::NOTEBOOKLM_STORAGE_STATE_JSON secret not set; script will exit 1"
             echo "auth_present=false"
           fi
 
@@ -77,50 +71,95 @@ jobs:
           PYTHONUTF8=1 python scripts/notebooklm_issue_crosscheck.py \
             --limit "${{ inputs.limit || '200' }}" \
             --comment-on-issue "${{ inputs.comment_target || '1647' }}" \
+            --json-out crosscheck_report.json \
             > crosscheck_report.txt 2>crosscheck_err.txt || true
           echo "--- stdout ---"
           cat crosscheck_report.txt
           echo "--- stderr ---"
           cat crosscheck_err.txt
 
-      - name: Open Issue if many TRUE_GAPs (≥3)
+      - name: Filter TRUE_GAP signals
+        id: patterns
         if: always()
         run: |
-          GAPS=$(grep -c "^- \`" crosscheck_report.txt 2>/dev/null || echo 0)
-          # rough heuristic: TRUE_GAP section + DUP_OPEN section listed entries
-          if grep -q "^## TRUE_GAP" crosscheck_report.txt; then
+          if [ -s crosscheck_report.json ]; then
+            python scripts/news_pattern_detector.py \
+              --source crosscheck_report.json \
+              --label notebooklm-issue-crosscheck \
+              --output crosscheck_patterns.json \
+              --markdown crosscheck_patterns.md \
+              --min-confidence 0.50
+          else
+            echo '{"entries":[],"patterns":[],"issue_candidates":[]}' > crosscheck_patterns.json
+            echo "# News Pattern Detector Report" > crosscheck_patterns.md
+            echo "" >> crosscheck_patterns.md
+            echo "- Cross-check JSON was not produced." >> crosscheck_patterns.md
+            echo "pattern_count=0" >> "$GITHUB_OUTPUT"
+            echo "issue_candidate_count=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open Issue if many filtered TRUE_GAPs
+        if: always()
+        run: |
+          if grep -q "^## TRUE_GAP" crosscheck_report.txt 2>/dev/null; then
             TRUE_GAP_COUNT=$(awk '/## TRUE_GAP/,/^$/{ if (/^- /) print }' crosscheck_report.txt | wc -l)
           else
             TRUE_GAP_COUNT=0
           fi
+          if [ -s crosscheck_patterns.json ]; then
+            FILTERED_TRUE_GAP_COUNT=$(python3 - <<'PY'
+          import json
+          with open('crosscheck_patterns.json', encoding='utf-8') as f:
+              data = json.load(f)
+          count = 0
+          for row in data.get('entries', []):
+              entry = row.get('entry', {})
+              result = row.get('filter', {})
+              if entry.get('raw', {}).get('classification') == 'TRUE_GAP' and result.get('verdict') != 'drop':
+                  count += 1
+          print(count)
+          PY
+          )
+          else
+            FILTERED_TRUE_GAP_COUNT="$TRUE_GAP_COUNT"
+          fi
+
           echo "TRUE_GAP_COUNT=$TRUE_GAP_COUNT"
-          if [ "$TRUE_GAP_COUNT" -ge 3 ]; then
+          echo "FILTERED_TRUE_GAP_COUNT=$FILTERED_TRUE_GAP_COUNT"
+          if [ "$FILTERED_TRUE_GAP_COUNT" -ge 3 ]; then
             TODAY=$(date -u '+%Y-%m-%d')
-            TITLE="[automation] NotebookLM × Issue cross-check: $TRUE_GAP_COUNT TRUE_GAP $TODAY"
+            TITLE="[automation] NotebookLM x Issue cross-check: $FILTERED_TRUE_GAP_COUNT TRUE_GAP $TODAY"
             EXISTING=$(gh issue list --search "$TITLE in:title is:open" --json number --jq 'length')
             if [ "$EXISTING" = "0" ]; then
               {
-                echo "## NotebookLM × Issue cross-check 自動検出 ($(date -u '+%Y-%m-%d %H:%M UTC'))"
+                echo "## NotebookLM x Issue cross-check ($(date -u '+%Y-%m-%d %H:%M UTC'))"
                 echo ""
-                echo "**TRUE_GAP**: $TRUE_GAP_COUNT 件 (= notebook 存在するが対応 Issue 無し)"
+                echo "**TRUE_GAP**: $TRUE_GAP_COUNT raw / $FILTERED_TRUE_GAP_COUNT actionable after source-risk filter."
                 echo ""
-                echo "## 詳細"
+                echo "## Raw cross-check"
                 echo ""
                 echo '```'
                 cat crosscheck_report.txt
                 echo '```'
                 echo ""
-                echo "## 推奨対応"
+                echo "## Source-risk filter"
                 echo ""
-                echo "1. 各 notebook を内容確認"
-                echo "2. 担当 instance を判断 → cross-instance-pr or 直接 Issue 作成"
-                echo "3. DUP_OPEN は重複 Issue を close + 主 Issue にコメント統合"
+                echo '```'
+                cat crosscheck_patterns.md 2>/dev/null || true
+                echo '```'
                 echo ""
-                echo "## 関連"
+                echo "## Recommended action"
                 echo ""
-                echo "- script: \`scripts/notebooklm_issue_crosscheck.py\` (= Win版#132 part 120)"
+                echo "1. Review each actionable TRUE_GAP before creating implementation work."
+                echo "2. Route under the 2-instance policy: Claude Code #1 for design/review, Codex #1 for scoped implementation/CI."
+                echo "3. Merge duplicate open issues into the canonical issue before starting a PR."
+                echo ""
+                echo "## Related"
+                echo ""
+                echo "- script: \`scripts/notebooklm_issue_crosscheck.py\`"
+                echo "- source-risk filter: \`scripts/news_pattern_detector.py\` + \`scripts/fake_news_filter.py\`"
                 echo "- workflow: \`.github/workflows/notebooklm-issue-crosscheck.yml\`"
-                echo "- Issue [#1647](https://github.com/kanta13jp1/my_web_app/issues/1647) (= Codex Memory + Thread Automations)"
+                echo "- Issue [#1647](https://github.com/kanta13jp1/my_web_app/issues/1647)"
                 echo ""
                 echo "(auto-opened by notebooklm-issue-crosscheck.yml)"
               } > issue_body.md
@@ -129,5 +168,18 @@ jobs:
               echo "Skip: same-title open Issue already exists ($EXISTING)"
             fi
           else
-            echo "TRUE_GAP < 3 → no Issue auto-opened"
+            echo "filtered TRUE_GAP < 3 - no Issue auto-opened"
           fi
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: notebooklm-crosscheck-reports
+          path: |
+            crosscheck_report.txt
+            crosscheck_err.txt
+            crosscheck_report.json
+            crosscheck_patterns.json
+            crosscheck_patterns.md
+          if-no-files-found: ignore

--- a/scripts/ai_tool_watch.py
+++ b/scripts/ai_tool_watch.py
@@ -193,17 +193,13 @@ HARNESS_NOTEBOOK = {
 HARNESS_LANES = [
     (
         "Claude Code",
-        "Owns problem framing, architecture, review gates, and hook design.",
+        "Claude Code #1 owns problem framing, architecture, review gates, and hook design.",
     ),
     (
         "Codex #1",
         "Owns cross-cutting implementation, SQL/migration review, "
-        "UI/browser QA, and scoped fix PRs.",
-    ),
-    (
-        "Codex #2",
-        "Owns CI repair, synchronization, Edge Functions, GitHub Actions, "
-        "and deterministic automation.",
+        "UI/browser QA, CI repair, Edge Functions, GitHub Actions, "
+        "and legacy Codex #2/#3 implementation lanes.",
     ),
     (
         "GitHub Actions",
@@ -455,10 +451,10 @@ def render_markdown(report: dict[str, Any]) -> str:
         [
             "- Practical rule: every detected tool change must become a WBS route, GitHub issue, hook, workflow check, or PR; notes alone are not complete.",
             "",
-            "## 12-Instance Routing Reminder",
-            "- Claude Code instances take ambiguous design and cross-instance coordination.",
-            "- Codex #1 takes mechanical implementation and broad repo scans that need a clean worktree.",
-            "- Codex #2 takes failing checks, deploy unblockers, and sync/automation drift.",
+            "## 2-Instance Routing Reminder",
+            "- Claude Code #1 takes ambiguous design, architecture, review policy, and cross-instance coordination.",
+            "- Codex #1 takes scoped implementation, CI/deploy unblockers, Edge Functions, GitHub Actions, and broad repo scans that need a clean worktree.",
+            "- Legacy Codex #2/#3 lanes are absorbed by Codex #1; do not start extra instances for changelog follow-up work.",
             "- Rebalance owners when the WBS top-20 contains repeated manual work, repeated CI failures, or stale handoffs.",
             "",
             "<!-- generated-by: scripts/ai_tool_watch.py -->",

--- a/scripts/fake_news_filter.py
+++ b/scripts/fake_news_filter.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Score news-like signals before they enter automation queues.
+
+The filter is intentionally dependency-free. It does not try to decide truth;
+it highlights weak sourcing, social-only claims, sensational language, and
+HTTP/source failures so downstream workflows can route risky items to review
+instead of creating issues or drafts automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+UTC = dt.timezone.utc
+
+OFFICIAL_DOMAIN_HINTS = (
+    "anthropic.com",
+    "apple.com",
+    "blog.google",
+    "claude.com",
+    "cloud.google.com",
+    "cursor.com",
+    "developers.google.com",
+    "developers.openai.com",
+    "docs.devin.ai",
+    "docs.github.com",
+    "github.blog",
+    "github.com",
+    "microsoft.com",
+    "notion.so",
+    "openai.com",
+    "supabase.com",
+)
+
+SOCIAL_DOMAINS = (
+    "bsky.app",
+    "facebook.com",
+    "instagram.com",
+    "linkedin.com",
+    "reddit.com",
+    "tiktok.com",
+    "x.com",
+    "youtube.com",
+)
+
+SENSATIONAL_TERMS = (
+    "100x",
+    "breakthrough",
+    "crazy",
+    "destroy",
+    "explodes",
+    "guaranteed",
+    "insane",
+    "kill",
+    "secret",
+    "shocking",
+)
+
+UNVERIFIED_TERMS = (
+    "alleged",
+    "anonymous",
+    "claim",
+    "claims",
+    "leak",
+    "leaked",
+    "rumor",
+    "rumour",
+    "single-source",
+    "unconfirmed",
+    "unverified",
+)
+
+
+@dataclass(frozen=True)
+class NormalizedEntry:
+    entry_id: str
+    title: str
+    text: str
+    url: str
+    source: str
+    source_label: str
+    status: int | None
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class FilterResult:
+    entry_id: str
+    title: str
+    url: str
+    source: str
+    source_label: str
+    confidence: float
+    verdict: str
+    risk_flags: list[str]
+    reasons: list[str]
+
+
+def now_iso() -> str:
+    return dt.datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def stable_id(*parts: str) -> str:
+    import hashlib
+
+    payload = "\n".join(part for part in parts if part).encode("utf-8", "replace")
+    return "nf-" + hashlib.sha256(payload).hexdigest()[:12]
+
+
+def clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))
+
+
+def domain_from_url(url: str) -> str:
+    if not url:
+        return ""
+    parsed = urlparse(url if "://" in url else f"https://{url}")
+    return (parsed.netloc or "").lower().removeprefix("www.")
+
+
+def is_official_domain(url: str) -> bool:
+    domain = domain_from_url(url)
+    return any(domain == hint or domain.endswith(f".{hint}") for hint in OFFICIAL_DOMAIN_HINTS)
+
+
+def is_social_domain(url: str) -> bool:
+    domain = domain_from_url(url)
+    return any(domain == hint or domain.endswith(f".{hint}") for hint in SOCIAL_DOMAINS)
+
+
+def text_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, list):
+        return " ".join(text_value(item) for item in value)
+    if isinstance(value, dict):
+        return " ".join(text_value(item) for item in value.values())
+    return str(value).strip()
+
+
+def extract_status(entry: dict[str, Any]) -> int | None:
+    for key in ("status", "http_status", "httpCode", "http"):
+        value = entry.get(key)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            match = re.search(r"\b(\d{3})\b", value)
+            if match:
+                return int(match.group(1))
+    return None
+
+
+def normalize_entry(item: Any, source_label: str = "") -> NormalizedEntry:
+    if not isinstance(item, dict):
+        title = text_value(item)[:120] or "untitled"
+        text = text_value(item)
+        return NormalizedEntry(
+            entry_id=stable_id(title, text),
+            title=title,
+            text=text,
+            url="",
+            source="",
+            source_label=source_label,
+            status=None,
+            raw={"value": item},
+        )
+
+    title = (
+        text_value(item.get("title"))
+        or text_value(item.get("name"))
+        or text_value(item.get("latest_signal"))
+        or text_value(item.get("slug"))
+        or "untitled"
+    )
+    url = text_value(item.get("url") or item.get("source_url") or item.get("website"))
+    source = text_value(item.get("owner") or item.get("source") or item.get("name"))
+    snippets = item.get("snippets")
+    text = " ".join(
+        part
+        for part in (
+            title,
+            text_value(item.get("summary")),
+            text_value(item.get("body")),
+            text_value(item.get("description")),
+            text_value(item.get("latest_signal")),
+            text_value(snippets),
+            text_value(item.get("classification")),
+        )
+        if part
+    )
+    entry_id = text_value(item.get("id") or item.get("entry_id")) or stable_id(title, url, text)
+    return NormalizedEntry(
+        entry_id=entry_id,
+        title=title[:180],
+        text=text,
+        url=url,
+        source=source,
+        source_label=source_label,
+        status=extract_status(item),
+        raw=item,
+    )
+
+
+def entries_from_json(data: Any, source_label: str = "") -> list[NormalizedEntry]:
+    if isinstance(data, list):
+        return [normalize_entry(item, source_label) for item in data]
+    if not isinstance(data, dict):
+        return [normalize_entry(data, source_label)]
+
+    if isinstance(data.get("sources"), list):
+        return [normalize_entry(item, source_label or "ai-tool-watch") for item in data["sources"]]
+
+    notebook_rows: list[dict[str, Any]] = []
+    for key, classification in (("true_gap", "TRUE_GAP"), ("dup_open", "DUP_OPEN")):
+        rows = data.get(key)
+        if isinstance(rows, list):
+            for row in rows:
+                if isinstance(row, dict):
+                    notebook_rows.append({**row, "classification": classification})
+    if notebook_rows:
+        return [normalize_entry(item, source_label or "notebooklm-issue-crosscheck") for item in notebook_rows]
+
+    for key in ("entries", "items", "notebooks", "changed_sources"):
+        rows = data.get(key)
+        if isinstance(rows, list):
+            return [normalize_entry(item, source_label) for item in rows]
+
+    return [normalize_entry(data, source_label)]
+
+
+def entries_from_text(text: str, source_label: str = "") -> list[NormalizedEntry]:
+    entries: list[NormalizedEntry] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("<!--"):
+            continue
+        if stripped.startswith("|") and stripped.endswith("|") and "---" not in stripped:
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) >= 2 and cells[0].lower() not in {"name", "competitor", "url"}:
+                title = cells[0]
+                url = next((cell for cell in cells if cell.startswith("http")), "")
+                status = next((cell for cell in cells if "HTTP" in cell), "")
+                entries.append(
+                    normalize_entry(
+                        {
+                            "title": title,
+                            "url": url,
+                            "status": status,
+                            "summary": " ".join(cells),
+                        },
+                        source_label,
+                    )
+                )
+                continue
+        if stripped.startswith(("- ", "* ", "## ")):
+            entries.append(normalize_entry(stripped.lstrip("-*# "), source_label))
+    return entries
+
+
+def load_entries(path: Path, source_label: str = "") -> list[NormalizedEntry]:
+    if str(path) == "-":
+        content = sys.stdin.read()
+        return entries_from_text(content, source_label)
+    content = path.read_text(encoding="utf-8", errors="replace")
+    if path.suffix.lower() == ".json":
+        return entries_from_json(json.loads(content), source_label or path.stem)
+    return entries_from_text(content, source_label or path.stem)
+
+
+def assess_entry(entry: NormalizedEntry, min_confidence: float = 0.6) -> FilterResult:
+    text = f"{entry.title}\n{entry.text}".lower()
+    score = 0.55
+    reasons: list[str] = []
+    flags: list[str] = []
+
+    if entry.url:
+        score += 0.12
+        reasons.append("has source URL")
+        if is_official_domain(entry.url):
+            score += 0.18
+            reasons.append("source domain is official or primary")
+        if is_social_domain(entry.url):
+            score -= 0.22
+            flags.append("social_only_source")
+            reasons.append("social source needs corroboration")
+    else:
+        score -= 0.16
+        flags.append("missing_source_url")
+        reasons.append("missing source URL")
+
+    if entry.status is not None:
+        if 200 <= entry.status < 400:
+            score += 0.08
+            reasons.append(f"HTTP {entry.status} reachable")
+        elif entry.status >= 400 or entry.status == 0:
+            score -= 0.12
+            flags.append("source_http_problem")
+            reasons.append(f"source HTTP status {entry.status}")
+
+    sensational_hits = [term for term in SENSATIONAL_TERMS if term in text]
+    if sensational_hits:
+        score -= min(0.18, 0.06 * len(sensational_hits))
+        flags.append("sensational_language")
+        reasons.append("sensational terms: " + ", ".join(sensational_hits[:4]))
+
+    unverified_hits = [term for term in UNVERIFIED_TERMS if term in text]
+    if unverified_hits:
+        score -= min(0.22, 0.07 * len(unverified_hits))
+        flags.append("unverified_language")
+        reasons.append("unverified terms: " + ", ".join(unverified_hits[:4]))
+
+    if len(entry.text) >= 80:
+        score += 0.04
+        reasons.append("has enough context for review")
+
+    classification = str(entry.raw.get("classification", ""))
+    if classification == "TRUE_GAP":
+        score -= 0.04
+        reasons.append("TRUE_GAP requires human triage before issue creation")
+
+    confidence = round(clamp(score), 3)
+    if confidence >= min_confidence and "social_only_source" not in flags:
+        verdict = "pass"
+    elif confidence >= max(0.35, min_confidence - 0.22):
+        verdict = "review"
+    else:
+        verdict = "drop"
+
+    return FilterResult(
+        entry_id=entry.entry_id,
+        title=entry.title,
+        url=entry.url,
+        source=entry.source,
+        source_label=entry.source_label,
+        confidence=confidence,
+        verdict=verdict,
+        risk_flags=flags,
+        reasons=reasons,
+    )
+
+
+def filter_entries(entries: list[NormalizedEntry], min_confidence: float = 0.6) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for entry in entries:
+        result = assess_entry(entry, min_confidence=min_confidence)
+        results.append({"entry": asdict(entry), "filter": asdict(result)})
+    return results
+
+
+def summarize(results: list[dict[str, Any]]) -> dict[str, Any]:
+    by_verdict = {"pass": 0, "review": 0, "drop": 0}
+    risk_flags: dict[str, int] = {}
+    for row in results:
+        result = row["filter"]
+        by_verdict[result["verdict"]] = by_verdict.get(result["verdict"], 0) + 1
+        for flag in result["risk_flags"]:
+            risk_flags[flag] = risk_flags.get(flag, 0) + 1
+    return {
+        "total": len(results),
+        "by_verdict": by_verdict,
+        "risk_flags": dict(sorted(risk_flags.items())),
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Fake-News Filter Report",
+        "",
+        f"- Generated at: `{payload['generated_at']}`",
+        f"- Entries: `{payload['summary']['total']}`",
+        f"- Verdicts: `{payload['summary']['by_verdict']}`",
+        "",
+        "## Review Queue",
+    ]
+    review_rows = [
+        row for row in payload["entries"] if row["filter"]["verdict"] in {"review", "drop"}
+    ]
+    if not review_rows:
+        lines.append("- No risky entries detected.")
+    else:
+        for row in review_rows[:30]:
+            result = row["filter"]
+            flags = ", ".join(result["risk_flags"]) or "none"
+            lines.append(
+                f"- `{result['verdict']}` {result['title']} "
+                f"(confidence={result['confidence']}, flags={flags})"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", action="append", required=True, help="JSON/Markdown source path; repeatable")
+    parser.add_argument("--output", default="", help="Write JSON report to this path")
+    parser.add_argument("--markdown", default="", help="Write Markdown report to this path")
+    parser.add_argument("--source-label", default="", help="Override source label for all inputs")
+    parser.add_argument("--min-confidence", type=float, default=0.6)
+    parser.add_argument("--print-only", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    entries: list[NormalizedEntry] = []
+    for raw_path in args.input:
+        entries.extend(load_entries(Path(raw_path), args.source_label))
+
+    results = filter_entries(entries, min_confidence=args.min_confidence)
+    payload = {
+        "generated_at": now_iso(),
+        "min_confidence": args.min_confidence,
+        "summary": summarize(results),
+        "entries": results,
+    }
+    rendered = render_markdown(payload)
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    if args.markdown:
+        md = Path(args.markdown)
+        md.parent.mkdir(parents=True, exist_ok=True)
+        md.write_text(rendered, encoding="utf-8", newline="\n")
+    if args.print_only or not args.output:
+        print(rendered)
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        summary = payload["summary"]
+        with open(output, "a", encoding="utf-8") as fh:
+            fh.write(f"filter_pass_count={summary['by_verdict'].get('pass', 0)}\n")
+            fh.write(f"filter_review_count={summary['by_verdict'].get('review', 0)}\n")
+            fh.write(f"filter_drop_count={summary['by_verdict'].get('drop', 0)}\n")
+            if args.output:
+                fh.write(f"filter_report={args.output}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/news_pattern_detector.py
+++ b/scripts/news_pattern_detector.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Detect repeated product/news patterns after source-risk filtering.
+
+This script consumes JSON or Markdown reports already produced by repository
+automation, runs the local fake-news filter, clusters surviving entries by
+company/topic, and writes a small JSON/Markdown report. It is deterministic and
+does not call external LLM APIs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.fake_news_filter import (
+        NormalizedEntry,
+        filter_entries,
+        load_entries,
+        now_iso,
+        summarize,
+    )
+except ImportError:  # pragma: no cover - used when executed as scripts/news_pattern_detector.py
+    from fake_news_filter import (  # type: ignore
+        NormalizedEntry,
+        filter_entries,
+        load_entries,
+        now_iso,
+        summarize,
+    )
+
+
+COMPANY_TERMS: dict[str, tuple[str, ...]] = {
+    "anthropic": ("anthropic", "claude", "claude code"),
+    "cursor": ("cursor",),
+    "devin": ("devin", "cognition"),
+    "github": ("github", "copilot"),
+    "google": ("google", "gemini", "notebooklm"),
+    "microsoft": ("microsoft", "azure", "copilot studio"),
+    "notion": ("notion",),
+    "openai": ("openai", "codex", "chatgpt"),
+    "supabase": ("supabase",),
+}
+
+TOPIC_TERMS: dict[str, tuple[str, ...]] = {
+    "agentic-workflows": ("agent", "agents", "automation", "workflow", "orchestration"),
+    "ci-quality": ("ci", "test", "quality", "review", "gate", "ultrareview"),
+    "cost-pricing": ("price", "pricing", "cost", "billing", "credit", "quota", "100x"),
+    "mcp-integration": ("mcp", "connector", "tool", "integration"),
+    "news-confidence": ("fake", "rumor", "unverified", "single-source", "source"),
+    "product-release": ("release", "changelog", "launch", "ga", "version"),
+    "security-policy": ("auth", "hmac", "permission", "security", "origin"),
+}
+
+
+def stable_key(*parts: str) -> str:
+    payload = "\n".join(parts).encode("utf-8", "replace")
+    return "np-" + hashlib.sha256(payload).hexdigest()[:12]
+
+
+def tags_for(text: str, table: dict[str, tuple[str, ...]]) -> list[str]:
+    lowered = text.lower()
+    tags = []
+    for tag, terms in table.items():
+        if any(re.search(rf"\b{re.escape(term.lower())}\b", lowered) for term in terms):
+            tags.append(tag)
+    return tags
+
+
+def entry_text(row: dict[str, Any]) -> str:
+    entry = row["entry"]
+    return " ".join(
+        str(entry.get(key, ""))
+        for key in ("title", "text", "url", "source", "source_label")
+        if entry.get(key)
+    )
+
+
+def cluster_key(row: dict[str, Any]) -> tuple[str, str]:
+    text = entry_text(row)
+    companies = tags_for(text, COMPANY_TERMS)
+    topics = tags_for(text, TOPIC_TERMS)
+    company = companies[0] if companies else "multi-source"
+    topic = topics[0] if topics else "general-signal"
+    return company, topic
+
+
+def detect_patterns(
+    filtered_rows: list[dict[str, Any]],
+    min_confidence: float = 0.55,
+    issue_threshold: int = 3,
+    max_patterns: int = 20,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in filtered_rows:
+        result = row["filter"]
+        if result["verdict"] == "drop" or result["confidence"] < min_confidence:
+            continue
+        company, topic = cluster_key(row)
+        groups[(company, topic)].append(row)
+        if company != "multi-source":
+            groups[("multi-source", topic)].append(row)
+
+    patterns: list[dict[str, Any]] = []
+    for (company, topic), rows in groups.items():
+        if len(rows) < 2:
+            continue
+        avg_conf = round(sum(r["filter"]["confidence"] for r in rows) / len(rows), 3)
+        flags = sorted({flag for r in rows for flag in r["filter"]["risk_flags"]})
+        titles = [r["entry"]["title"] for r in rows[:5]]
+        risk_level = "review" if flags else "normal"
+        patterns.append(
+            {
+                "id": stable_key(company, topic, *titles),
+                "company": company,
+                "topic": topic,
+                "entry_count": len(rows),
+                "average_confidence": avg_conf,
+                "risk_level": risk_level,
+                "risk_flags": flags,
+                "evidence_titles": titles,
+                "recommended_action": recommended_action(company, topic, risk_level),
+            }
+        )
+
+    patterns.sort(key=lambda p: (p["entry_count"], p["average_confidence"]), reverse=True)
+    patterns = patterns[:max_patterns]
+    issue_candidates = [
+        pattern
+        for pattern in patterns
+        if pattern["entry_count"] >= issue_threshold
+        and pattern["average_confidence"] >= max(min_confidence, 0.62)
+        and pattern["risk_level"] != "review"
+    ]
+    return patterns, issue_candidates
+
+
+def recommended_action(company: str, topic: str, risk_level: str) -> str:
+    if risk_level == "review":
+        return "Hold for human review before creating issues or blog drafts."
+    if topic == "cost-pricing":
+        return "Compare pricing impact against Jibun Company cost discipline and WBS priorities."
+    if topic == "ci-quality":
+        return "Route to CI/readiness gate owners if repeated failures or quality gates are affected."
+    if topic == "product-release":
+        return "Route changed release signals into WBS/issue triage with source links."
+    if company != "multi-source":
+        return f"Review {company} movement for competitor-monitoring follow-up."
+    return "Review repeated signal for a scoped follow-up issue only if source confidence stays high."
+
+
+def build_report(
+    source_paths: list[str],
+    entries: list[NormalizedEntry],
+    filtered_rows: list[dict[str, Any]],
+    min_confidence: float,
+    issue_threshold: int,
+    max_patterns: int,
+) -> dict[str, Any]:
+    patterns, issue_candidates = detect_patterns(
+        filtered_rows,
+        min_confidence=min_confidence,
+        issue_threshold=issue_threshold,
+        max_patterns=max_patterns,
+    )
+    return {
+        "generated_at": now_iso(),
+        "source_files": source_paths,
+        "min_confidence": min_confidence,
+        "entries_total": len(entries),
+        "filter_summary": summarize(filtered_rows),
+        "entries": filtered_rows,
+        "patterns": patterns,
+        "issue_candidates": issue_candidates,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# News Pattern Detector Report",
+        "",
+        f"- Generated at: `{report['generated_at']}`",
+        f"- Sources: `{', '.join(report['source_files'])}`",
+        f"- Entries scanned: `{report['entries_total']}`",
+        f"- Patterns: `{len(report['patterns'])}`",
+        f"- Issue candidates: `{len(report['issue_candidates'])}`",
+        "",
+        "## Patterns",
+    ]
+    if not report["patterns"]:
+        lines.append("- No repeated high-confidence pattern detected.")
+    else:
+        for pattern in report["patterns"]:
+            lines.append(
+                f"- **{pattern['company']} / {pattern['topic']}**: "
+                f"{pattern['entry_count']} entries, confidence={pattern['average_confidence']}, "
+                f"risk={pattern['risk_level']}"
+            )
+            lines.append(f"  - Action: {pattern['recommended_action']}")
+            for title in pattern["evidence_titles"][:3]:
+                lines.append(f"  - Evidence: {title}")
+
+    lines.extend(["", "## Filter Summary", ""])
+    lines.append("```json")
+    lines.append(json.dumps(report["filter_summary"], ensure_ascii=False, indent=2))
+    lines.append("```")
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", action="append", required=True, help="JSON/Markdown report path; repeatable")
+    parser.add_argument("--output", required=True, help="Write JSON pattern report")
+    parser.add_argument("--markdown", default="", help="Write Markdown pattern report")
+    parser.add_argument("--label", default="", help="Source label override for filter entries")
+    parser.add_argument("--min-confidence", type=float, default=0.55)
+    parser.add_argument("--issue-threshold", type=int, default=3)
+    parser.add_argument("--max-patterns", type=int, default=20)
+    parser.add_argument("--print-only", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    entries: list[NormalizedEntry] = []
+    for source in args.source:
+        entries.extend(load_entries(Path(source), args.label))
+
+    filtered_rows = filter_entries(entries, min_confidence=args.min_confidence)
+    report = build_report(
+        args.source,
+        entries,
+        filtered_rows,
+        min_confidence=args.min_confidence,
+        issue_threshold=args.issue_threshold,
+        max_patterns=args.max_patterns,
+    )
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    rendered = render_markdown(report)
+    if args.markdown:
+        markdown_path = Path(args.markdown)
+        markdown_path.parent.mkdir(parents=True, exist_ok=True)
+        markdown_path.write_text(rendered, encoding="utf-8", newline="\n")
+    if args.print_only:
+        print(rendered)
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as fh:
+            fh.write(f"pattern_count={len(report['patterns'])}\n")
+            fh.write(f"issue_candidate_count={len(report['issue_candidates'])}\n")
+            fh.write(f"pattern_report={args.output}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/notebooklm_issue_crosscheck.py
+++ b/scripts/notebooklm_issue_crosscheck.py
@@ -179,6 +179,8 @@ def main() -> int:
     ap.add_argument("--dup-only", action="store_true", help="Show only DUP_OPEN entries")
     ap.add_argument("--comment-on-issue", type=int, default=0,
                     help="Post summary as comment to given Issue number")
+    ap.add_argument("--json-out", default="",
+                    help="Write the full machine-readable report to this path")
     ap.add_argument("--limit", type=int, default=200,
                     help="Max notebooks to process (safety cap)")
     args = ap.parse_args()
@@ -219,6 +221,11 @@ def main() -> int:
     else:
         report = render_text(checks)
     print(report)
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8", newline="\n") as f:
+            f.write(render_json(checks))
+            f.write("\n")
 
     if args.comment_on_issue:
         body = (

--- a/test/scripts/test_news_pattern_detector.py
+++ b/test/scripts/test_news_pattern_detector.py
@@ -1,0 +1,128 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import fake_news_filter
+from scripts import news_pattern_detector
+
+
+class FakeNewsFilterTest(unittest.TestCase):
+    def test_official_source_passes_with_high_confidence(self) -> None:
+        entry = fake_news_filter.normalize_entry(
+            {
+                "title": "Claude Code changelog",
+                "url": "https://code.claude.com/docs/en/changelog",
+                "status": 200,
+                "latest_signal": "2.1.136 release notes add workflow changes",
+            },
+            "unit",
+        )
+
+        result = fake_news_filter.assess_entry(entry, min_confidence=0.60)
+
+        self.assertEqual(result.verdict, "pass")
+        self.assertGreaterEqual(result.confidence, 0.80)
+        self.assertNotIn("social_only_source", result.risk_flags)
+
+    def test_social_only_claim_routes_to_review(self) -> None:
+        entry = fake_news_filter.normalize_entry(
+            {
+                "title": "Insane secret trading leak",
+                "url": "https://x.com/example/status/1",
+                "summary": "single-source rumor claims guaranteed 100x return",
+            },
+            "unit",
+        )
+
+        result = fake_news_filter.assess_entry(entry, min_confidence=0.60)
+
+        self.assertIn(result.verdict, {"review", "drop"})
+        self.assertIn("social_only_source", result.risk_flags)
+        self.assertIn("unverified_language", result.risk_flags)
+
+
+class NewsPatternDetectorTest(unittest.TestCase):
+    def test_ai_tool_watch_json_clusters_repeated_agent_signals(self) -> None:
+        data = {
+            "sources": [
+                {
+                    "name": "Claude Code changelog",
+                    "owner": "Claude Code",
+                    "url": "https://code.claude.com/docs/en/changelog",
+                    "status": 200,
+                    "latest_signal": "Agent workflow release with CI gate support",
+                    "snippets": ["agent workflow CI gate release"],
+                },
+                {
+                    "name": "Codex changelog",
+                    "owner": "Codex",
+                    "url": "https://developers.openai.com/codex/changelog",
+                    "status": 200,
+                    "latest_signal": "Agent workflow automation release",
+                    "snippets": ["agent workflow automation release"],
+                },
+            ]
+        }
+        entries = fake_news_filter.entries_from_json(data, "ai-tool-watch")
+        filtered = fake_news_filter.filter_entries(entries, min_confidence=0.55)
+
+        patterns, issue_candidates = news_pattern_detector.detect_patterns(
+            filtered,
+            min_confidence=0.55,
+            issue_threshold=2,
+        )
+
+        self.assertTrue(patterns)
+        self.assertEqual(patterns[0]["topic"], "agentic-workflows")
+        self.assertTrue(issue_candidates)
+
+    def test_cli_writes_json_and_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "signals.json"
+            output = root / "patterns.json"
+            markdown = root / "patterns.md"
+            source.write_text(
+                json.dumps(
+                    {
+                        "sources": [
+                            {
+                                "name": "Cursor changelog",
+                                "url": "https://cursor.com/changelog",
+                                "status": 200,
+                                "latest_signal": "Agent workflow release",
+                            },
+                            {
+                                "name": "Devin release notes",
+                                "url": "https://docs.devin.ai/release-notes",
+                                "status": 200,
+                                "latest_signal": "Agent workflow release",
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            exit_code = news_pattern_detector.main(
+                [
+                    "--source",
+                    str(source),
+                    "--output",
+                    str(output),
+                    "--markdown",
+                    str(markdown),
+                    "--issue-threshold",
+                    "2",
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(output.exists())
+            self.assertIn("News Pattern Detector", markdown.read_text(encoding="utf-8"))
+            self.assertTrue(json.loads(output.read_text(encoding="utf-8"))["patterns"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1965

## Summary
- Adds dependency-free `scripts/fake_news_filter.py` and `scripts/news_pattern_detector.py` for source-risk scoring, repeated signal clustering, JSON/Markdown reports, and GitHub Actions outputs.
- Wires the detector into `competitor-monitoring.yml`, `ai-tool-watch.yml`, and `notebooklm-issue-crosscheck.yml`.
- Adds `--json-out` to `notebooklm_issue_crosscheck.py` so TRUE_GAP candidates can be filtered before auto-opening follow-up Issues.
- Updates AI Tool Watch routing copy for the current 2-instance policy: Claude Code #1 + Codex #1; legacy Codex #2/#3 lanes are absorbed by Codex #1.

## Minimal E2E Gate
- Implementation-detail independent: validation exercises script input/output contracts rather than private implementation internals.
- Minimal scope: three cases cover official source pass, social-only/unverified review/drop, and repeated agent workflow pattern detection.
- E2E mechanism: Playwright/browser E2E is not applicable because this PR changes workflow/script automation only, not Flutter UI or public routes.
- Minimal E2E Exception: no application-code path changed; black-box CLI tests plus workflow YAML parse are the appropriate I/O verification for this scoped automation PR.

## Visual E2E Evidence
- N/A: no visual UI changed; no desktop/mobile screenshot artifact is meaningful for this script/workflow-only PR.

## High-Risk Ultrareview
- High-risk-ultrareview-exception: Claude Code #1 is the designated review owner, but this Codex #1 scoped PR only adds deterministic workflow/script gates and does not touch production data, secrets, deploy credentials, Supabase functions, or migrations.
- Exception reason: a live Claude ultrareview is not required before PR creation because the risk is bounded to generated reports/artifacts and PR body gates; GitHub checks remain the merge gate.
- Security: no new secret, token, credential, service role, network credential storage, or user data write path is introduced.
- Rollback: revert this single PR to remove the two scripts, tests, and three workflow insertions; generated pattern reports are non-authoritative artifacts.
- Data migration: none; no database schema, Supabase migration, RLS, or production table mutation.
- Prod smoke: no production deploy behavior changes; after merge, existing deploy-prod and the scheduled workflow/manual dispatch checks are sufficient smoke coverage.
- Observability: workflows write JSON/Markdown pattern reports and expose `pattern_count` / `issue_candidate_count` through GitHub step outputs and summaries.
- Unresolved findings: 0 / none.

## Validation
- `python -m py_compile scripts\fake_news_filter.py scripts\news_pattern_detector.py scripts\notebooklm_issue_crosscheck.py scripts\ai_tool_watch.py`
- `python -m unittest discover -s test\scripts -p test_news_pattern_detector.py`
- `python scripts\news_pattern_detector.py --source docs\ai-tool-watch\latest-report.json --output $env:TEMP\latest-patterns-test.json --markdown $env:TEMP\latest-patterns-test.md --min-confidence 0.55 --print-only`
- PyYAML parse for `.github/workflows/ai-tool-watch.yml`, `.github/workflows/notebooklm-issue-crosscheck.yml`, `.github/workflows/competitor-monitoring.yml`
- `git diff --check`
- `actionlint` not installed locally; GitHub checks will cover workflow execution gates.

## Memory / Disk Hygiene
- Ran `scripts/worktree_cleanup.py --tier1 --max-runtime-sec=15` dry-run before implementation: 8 scanned / 0 candidates / `reclaimed_mb=0`.
- Did not remove Claude-owned worktrees or parent-app Node/Dart/Deno processes.