### PR TITLE
feat: add AI share button display controls

### DIFF
--- a/lib/pages/ai_share_button_settings_page.dart
+++ b/lib/pages/ai_share_button_settings_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/ai_share_button_settings_panel.dart';
+
+class AiShareButtonSettingsPage extends StatelessWidget {
+  const AiShareButtonSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('AIシェアボタン')),
+      body: const SafeArea(
+        child: SingleChildScrollView(child: AiShareButtonSettingsPanel()),
+      ),
+    );
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -119,10 +119,10 @@ class SettingsPage extends StatelessWidget {
               child: Text(
                 AppVersion.display,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.onSurface.withValues(alpha: 0.5),
-                ),
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.5),
+                    ),
               ),
             ),
           ),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../core/app_version.dart';
 import '../services/theme_service.dart';
+import 'ai_share_button_settings_page.dart';
 import 'profile_settings_page.dart';
 import 'asset_management_page.dart';
 import 'financial_report_page.dart';
@@ -48,6 +49,18 @@ class SettingsPage extends StatelessWidget {
             onTap: () => Navigator.push(
               context,
               MaterialPageRoute(builder: (_) => const ThemeSelectorPage()),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.auto_awesome_motion_outlined),
+            title: const Text('AIシェアボタン'),
+            subtitle: const Text('表示と位置'),
+            trailing: const Icon(Icons.arrow_forward_ios),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const AiShareButtonSettingsPage(),
+              ),
             ),
           ),
           ListTile(
@@ -106,11 +119,10 @@ class SettingsPage extends StatelessWidget {
               child: Text(
                 AppVersion.display,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context)
-                          .colorScheme
-                          .onSurface
-                          .withValues(alpha: 0.5),
-                    ),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.5),
+                ),
               ),
             ),
           ),

--- a/lib/services/ai_share_button_preferences_service.dart
+++ b/lib/services/ai_share_button_preferences_service.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum AiShareButtonPosition { topLeft, topRight, bottomLeft, bottomRight }
+
+class AiShareButtonPreferences {
+  static const AiShareButtonPosition defaultPosition =
+      AiShareButtonPosition.bottomRight;
+
+  final bool visible;
+  final AiShareButtonPosition position;
+
+  const AiShareButtonPreferences({
+    this.visible = true,
+    this.position = defaultPosition,
+  });
+
+  AiShareButtonPreferences copyWith({
+    bool? visible,
+    AiShareButtonPosition? position,
+  }) {
+    return AiShareButtonPreferences(
+      visible: visible ?? this.visible,
+      position: position ?? this.position,
+    );
+  }
+}
+
+class AiShareButtonPreferencesService {
+  static const String _visibleKey = 'ai_share_button_visible_v1';
+  static const String _positionKey = 'ai_share_button_position_v1';
+
+  const AiShareButtonPreferencesService();
+
+  Future<AiShareButtonPreferences> loadPreferences({
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return AiShareButtonPreferences(
+      visible: store.getBool(_visibleKey) ?? true,
+      position: _positionFromStorage(store.getString(_positionKey)),
+    );
+  }
+
+  Future<AiShareButtonPreferences> savePreferences(
+    AiShareButtonPreferences preferences, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    await store.setBool(_visibleKey, preferences.visible);
+    await store.setString(
+      _positionKey,
+      _positionToStorage(preferences.position),
+    );
+    return preferences;
+  }
+
+  Future<AiShareButtonPreferences> saveVisible(
+    bool visible, {
+    SharedPreferences? prefs,
+  }) async {
+    final current = await loadPreferences(prefs: prefs);
+    return savePreferences(current.copyWith(visible: visible), prefs: prefs);
+  }
+
+  Future<AiShareButtonPreferences> savePosition(
+    AiShareButtonPosition position, {
+    SharedPreferences? prefs,
+  }) async {
+    final current = await loadPreferences(prefs: prefs);
+    return savePreferences(current.copyWith(position: position), prefs: prefs);
+  }
+
+  static AiShareButtonPosition _positionFromStorage(String? value) {
+    switch (value) {
+      case 'top_left':
+        return AiShareButtonPosition.topLeft;
+      case 'top_right':
+        return AiShareButtonPosition.topRight;
+      case 'bottom_left':
+        return AiShareButtonPosition.bottomLeft;
+      case 'bottom_right':
+        return AiShareButtonPosition.bottomRight;
+      default:
+        return AiShareButtonPreferences.defaultPosition;
+    }
+  }
+
+  static String _positionToStorage(AiShareButtonPosition position) {
+    switch (position) {
+      case AiShareButtonPosition.topLeft:
+        return 'top_left';
+      case AiShareButtonPosition.topRight:
+        return 'top_right';
+      case AiShareButtonPosition.bottomLeft:
+        return 'bottom_left';
+      case AiShareButtonPosition.bottomRight:
+        return 'bottom_right';
+    }
+  }
+}
+
+class AiShareButtonPreferencesController extends ChangeNotifier {
+  final AiShareButtonPreferencesService service;
+
+  AiShareButtonPreferences _preferences = const AiShareButtonPreferences();
+  Future<void>? _loadFuture;
+  int _revision = 0;
+
+  AiShareButtonPreferencesController({
+    this.service = const AiShareButtonPreferencesService(),
+  });
+
+  AiShareButtonPreferences get preferences => _preferences;
+
+  Future<void> load() {
+    return _loadFuture ??= _loadPreferences();
+  }
+
+  Future<void> reload() {
+    _loadFuture = _loadPreferences();
+    return _loadFuture!;
+  }
+
+  Future<void> updateVisible(bool visible) {
+    return updatePreferences(_preferences.copyWith(visible: visible));
+  }
+
+  Future<void> updatePosition(AiShareButtonPosition position) {
+    return updatePreferences(_preferences.copyWith(position: position));
+  }
+
+  Future<void> updatePreferences(AiShareButtonPreferences next) async {
+    final previous = _preferences;
+    _revision += 1;
+    _preferences = next;
+    notifyListeners();
+
+    try {
+      await service.savePreferences(next);
+      _loadFuture = Future<void>.value();
+    } catch (_) {
+      _preferences = previous;
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  Future<void> _loadPreferences() async {
+    final revision = _revision;
+    final loaded = await service.loadPreferences();
+    if (revision != _revision) return;
+    _preferences = loaded;
+    notifyListeners();
+  }
+}
+
+final aiShareButtonPreferencesController = AiShareButtonPreferencesController();

--- a/lib/widgets/ai_share_button_settings_panel.dart
+++ b/lib/widgets/ai_share_button_settings_panel.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+
+import '../services/ai_share_button_preferences_service.dart';
+
+class AiShareButtonSettingsPanel extends StatefulWidget {
+  final EdgeInsetsGeometry padding;
+
+  const AiShareButtonSettingsPanel({
+    super.key,
+    this.padding = const EdgeInsets.all(16),
+  });
+
+  @override
+  State<AiShareButtonSettingsPanel> createState() =>
+      _AiShareButtonSettingsPanelState();
+}
+
+class _AiShareButtonSettingsPanelState
+    extends State<AiShareButtonSettingsPanel> {
+  AiShareButtonPreferencesController get _controller =>
+      aiShareButtonPreferencesController;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.load();
+  }
+
+  Future<void> _updateVisible(bool visible) async {
+    try {
+      await _controller.updateVisible(visible);
+    } catch (_) {
+      _showSaveError();
+    }
+  }
+
+  Future<void> _updatePosition(AiShareButtonPosition position) async {
+    try {
+      await _controller.updatePosition(position);
+    } catch (_) {
+      _showSaveError();
+    }
+  }
+
+  void _showSaveError() {
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('AIシェアボタン設定の保存に失敗しました')));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final preferences = _controller.preferences;
+        return Padding(
+          padding: widget.padding,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SwitchListTile.adaptive(
+                contentPadding: EdgeInsets.zero,
+                secondary: Icon(
+                  preferences.visible
+                      ? Icons.visibility_outlined
+                      : Icons.visibility_off_outlined,
+                ),
+                title: const Text('AIシェアボタン'),
+                subtitle: Text(preferences.visible ? '表示中' : '非表示'),
+                value: preferences.visible,
+                onChanged: _updateVisible,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                '表示位置',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 8),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: SegmentedButton<AiShareButtonPosition>(
+                  showSelectedIcon: false,
+                  segments: AiShareButtonPosition.values
+                      .map(
+                        (position) => ButtonSegment<AiShareButtonPosition>(
+                          value: position,
+                          icon: Icon(position.icon),
+                          label: Text(position.label),
+                        ),
+                      )
+                      .toList(),
+                  selected: <AiShareButtonPosition>{preferences.position},
+                  onSelectionChanged: (selection) {
+                    if (selection.isNotEmpty) {
+                      _updatePosition(selection.first);
+                    }
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+extension _AiShareButtonPositionUi on AiShareButtonPosition {
+  String get label {
+    switch (this) {
+      case AiShareButtonPosition.topLeft:
+        return '左上';
+      case AiShareButtonPosition.topRight:
+        return '右上';
+      case AiShareButtonPosition.bottomLeft:
+        return '左下';
+      case AiShareButtonPosition.bottomRight:
+        return '右下';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case AiShareButtonPosition.topLeft:
+        return Icons.north_west;
+      case AiShareButtonPosition.topRight:
+        return Icons.north_east;
+      case AiShareButtonPosition.bottomLeft:
+        return Icons.south_west;
+      case AiShareButtonPosition.bottomRight:
+        return Icons.south_east;
+    }
+  }
+}

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -3,15 +3,17 @@ import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../services/ai_share_button_preferences_service.dart';
 import '../services/universal_x_share_service.dart';
+import 'ai_share_button_settings_panel.dart';
 
 final universalAiShareRouteObserver = UniversalAiShareRouteObserver();
 
 class UniversalAiShareRouteObserver extends NavigatorObserver {
   final ValueNotifier<UniversalSharePageContext> currentPage =
       ValueNotifier<UniversalSharePageContext>(
-    UniversalSharePageContext.fromRouteName('/'),
-  );
+        UniversalSharePageContext.fromRouteName('/'),
+      );
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -36,7 +38,7 @@ class UniversalAiShareRouteObserver extends NavigatorObserver {
   }
 }
 
-class UniversalAiShareShell extends StatelessWidget {
+class UniversalAiShareShell extends StatefulWidget {
   final Widget child;
   final GlobalKey<NavigatorState> navigatorKey;
 
@@ -47,27 +49,61 @@ class UniversalAiShareShell extends StatelessWidget {
   });
 
   @override
+  State<UniversalAiShareShell> createState() => _UniversalAiShareShellState();
+}
+
+class _UniversalAiShareShellState extends State<UniversalAiShareShell> {
+  AiShareButtonPreferencesController get _preferencesController =>
+      aiShareButtonPreferencesController;
+
+  @override
+  void initState() {
+    super.initState();
+    _preferencesController.load();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        Positioned.fill(child: child),
-        ValueListenableBuilder<UniversalSharePageContext>(
-          valueListenable: universalAiShareRouteObserver.currentPage,
-          builder: (context, page, _) {
-            return Positioned(
-              right: 16,
-              bottom: 20,
-              child: SafeArea(
-                child: _UniversalAiShareFab(
-                  page: page,
-                  navigatorKey: navigatorKey,
-                ),
-              ),
+        Positioned.fill(child: widget.child),
+        AnimatedBuilder(
+          animation: _preferencesController,
+          builder: (context, _) {
+            final preferences = _preferencesController.preferences;
+            if (!preferences.visible) return const SizedBox.shrink();
+
+            return ValueListenableBuilder<UniversalSharePageContext>(
+              valueListenable: universalAiShareRouteObserver.currentPage,
+              builder: (context, page, _) {
+                return _positionedFab(
+                  preferences.position,
+                  SafeArea(
+                    child: _UniversalAiShareFab(
+                      page: page,
+                      navigatorKey: widget.navigatorKey,
+                    ),
+                  ),
+                );
+              },
             );
           },
         ),
       ],
     );
+  }
+
+  Widget _positionedFab(AiShareButtonPosition position, Widget child) {
+    switch (position) {
+      case AiShareButtonPosition.topLeft:
+        return Positioned(left: 16, top: 20, child: child);
+      case AiShareButtonPosition.topRight:
+        return Positioned(right: 16, top: 20, child: child);
+      case AiShareButtonPosition.bottomLeft:
+        return Positioned(left: 16, bottom: 20, child: child);
+      case AiShareButtonPosition.bottomRight:
+        return Positioned(right: 16, bottom: 20, child: child);
+    }
   }
 }
 
@@ -75,10 +111,7 @@ class _UniversalAiShareFab extends StatelessWidget {
   final UniversalSharePageContext page;
   final GlobalKey<NavigatorState> navigatorKey;
 
-  const _UniversalAiShareFab({
-    required this.page,
-    required this.navigatorKey,
-  });
+  const _UniversalAiShareFab({required this.page, required this.navigatorKey});
 
   void _openShareDialog() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -92,22 +125,82 @@ class _UniversalAiShareFab extends StatelessWidget {
     });
   }
 
+  void _openSettingsSheet() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final overlayContext = navigatorKey.currentState?.overlay?.context;
+      if (overlayContext == null || !overlayContext.mounted) return;
+      showModalBottomSheet<void>(
+        context: overlayContext,
+        useRootNavigator: true,
+        showDragHandle: true,
+        builder: (_) => const SafeArea(
+          child: AiShareButtonSettingsPanel(
+            padding: EdgeInsets.fromLTRB(20, 0, 20, 20),
+          ),
+        ),
+      );
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final isLoggedIn = Supabase.instance.client.auth.currentSession != null;
     final colorScheme = Theme.of(context).colorScheme;
-    return TooltipVisibility(
-      visible: false,
-      child: FloatingActionButton.extended(
-        heroTag: 'universal-ai-share-fab',
-        backgroundColor: isLoggedIn
-            ? colorScheme.primaryContainer
-            : colorScheme.surfaceContainerHighest,
-        foregroundColor:
-            isLoggedIn ? colorScheme.onPrimaryContainer : colorScheme.onSurface,
-        onPressed: _openShareDialog,
-        icon: const Icon(Icons.auto_awesome),
-        label: const Text('AIシェア'),
+    final backgroundColor = isLoggedIn
+        ? colorScheme.primaryContainer
+        : colorScheme.surfaceContainerHighest;
+    final foregroundColor = isLoggedIn
+        ? colorScheme.onPrimaryContainer
+        : colorScheme.onSurface;
+
+    return Material(
+      color: backgroundColor,
+      elevation: 6,
+      shadowColor: Colors.black.withValues(alpha: 0.24),
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Tooltip(
+            message: 'AIシェア',
+            child: InkWell(
+              onTap: _openShareDialog,
+              child: Padding(
+                padding: const EdgeInsetsDirectional.fromSTEB(16, 12, 12, 12),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.auto_awesome, color: foregroundColor),
+                    const SizedBox(width: 8),
+                    Text(
+                      'AIシェア',
+                      style: TextStyle(
+                        color: foregroundColor,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Container(
+            width: 1,
+            height: 28,
+            color: colorScheme.outlineVariant.withValues(alpha: 0.78),
+          ),
+          Tooltip(
+            message: 'AIシェアボタン設定',
+            child: IconButton(
+              onPressed: _openSettingsSheet,
+              icon: const Icon(Icons.tune),
+              color: foregroundColor,
+              constraints: const BoxConstraints.tightFor(width: 44, height: 48),
+              padding: EdgeInsets.zero,
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -116,10 +209,7 @@ class _UniversalAiShareFab extends StatelessWidget {
 class UniversalAiShareDialog extends StatefulWidget {
   final UniversalSharePageContext page;
 
-  const UniversalAiShareDialog({
-    super.key,
-    required this.page,
-  });
+  const UniversalAiShareDialog({super.key, required this.page});
 
   @override
   State<UniversalAiShareDialog> createState() => _UniversalAiShareDialogState();
@@ -166,8 +256,9 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
         _draft = draft;
         _textController.text = draft.text;
         _loadingDraft = false;
-        _statusMessage =
-            draft.fallbackUsed ? 'AI生成が不安定なため、安全な定型文を使っています' : null;
+        _statusMessage = draft.fallbackUsed
+            ? 'AI生成が不安定なため、安全な定型文を使っています'
+            : null;
       });
     } catch (error) {
       if (_disposed || !mounted) return;
@@ -193,8 +284,9 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
       if (_disposed || !mounted) return;
       setState(() {
         _imageUrl = result.url;
-        _statusMessage =
-            result.url == null ? '画像生成URLを取得できませんでした' : 'シェア画像を生成しました';
+        _statusMessage = result.url == null
+            ? '画像生成URLを取得できませんでした'
+            : 'シェア画像を生成しました';
       });
     } catch (error) {
       if (_disposed || !mounted) return;
@@ -365,8 +457,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
                       _generatingVideo
                           ? '動画生成中'
                           : _hedraGenerationId == null
-                              ? '動画生成'
-                              : '動画確認',
+                          ? '動画生成'
+                          : '動画確認',
                     ),
                   ),
                 ],
@@ -416,7 +508,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           label: const Text('X画面'),
         ),
         FilledButton.icon(
-          onPressed: _loadingDraft ||
+          onPressed:
+              _loadingDraft ||
                   _posting ||
                   textLength > UniversalXShareService.maxTweetLength
               ? null
@@ -475,8 +568,9 @@ class _CreativePipelineCard extends StatelessWidget {
 
     return DecoratedBox(
       decoration: BoxDecoration(
-        color:
-            theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.62),
+        color: theme.colorScheme.surfaceContainerHighest.withValues(
+          alpha: 0.62,
+        ),
         borderRadius: BorderRadius.circular(14),
         border: Border.all(
           color: theme.colorScheme.outlineVariant.withValues(alpha: 0.72),

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -12,8 +12,8 @@ final universalAiShareRouteObserver = UniversalAiShareRouteObserver();
 class UniversalAiShareRouteObserver extends NavigatorObserver {
   final ValueNotifier<UniversalSharePageContext> currentPage =
       ValueNotifier<UniversalSharePageContext>(
-        UniversalSharePageContext.fromRouteName('/'),
-      );
+    UniversalSharePageContext.fromRouteName('/'),
+  );
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -149,9 +149,8 @@ class _UniversalAiShareFab extends StatelessWidget {
     final backgroundColor = isLoggedIn
         ? colorScheme.primaryContainer
         : colorScheme.surfaceContainerHighest;
-    final foregroundColor = isLoggedIn
-        ? colorScheme.onPrimaryContainer
-        : colorScheme.onSurface;
+    final foregroundColor =
+        isLoggedIn ? colorScheme.onPrimaryContainer : colorScheme.onSurface;
 
     return Material(
       color: backgroundColor,
@@ -256,9 +255,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
         _draft = draft;
         _textController.text = draft.text;
         _loadingDraft = false;
-        _statusMessage = draft.fallbackUsed
-            ? 'AI生成が不安定なため、安全な定型文を使っています'
-            : null;
+        _statusMessage =
+            draft.fallbackUsed ? 'AI生成が不安定なため、安全な定型文を使っています' : null;
       });
     } catch (error) {
       if (_disposed || !mounted) return;
@@ -284,9 +282,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
       if (_disposed || !mounted) return;
       setState(() {
         _imageUrl = result.url;
-        _statusMessage = result.url == null
-            ? '画像生成URLを取得できませんでした'
-            : 'シェア画像を生成しました';
+        _statusMessage =
+            result.url == null ? '画像生成URLを取得できませんでした' : 'シェア画像を生成しました';
       });
     } catch (error) {
       if (_disposed || !mounted) return;
@@ -457,8 +454,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
                       _generatingVideo
                           ? '動画生成中'
                           : _hedraGenerationId == null
-                          ? '動画生成'
-                          : '動画確認',
+                              ? '動画生成'
+                              : '動画確認',
                     ),
                   ),
                 ],
@@ -508,8 +505,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           label: const Text('X画面'),
         ),
         FilledButton.icon(
-          onPressed:
-              _loadingDraft ||
+          onPressed: _loadingDraft ||
                   _posting ||
                   textLength > UniversalXShareService.maxTweetLength
               ? null

--- a/test/services/ai_share_button_preferences_service_test.dart
+++ b/test/services/ai_share_button_preferences_service_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/ai_share_button_preferences_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('loads visible bottom-right defaults', () async {
+    const service = AiShareButtonPreferencesService();
+
+    final preferences = await service.loadPreferences();
+
+    expect(preferences.visible, isTrue);
+    expect(preferences.position, AiShareButtonPosition.bottomRight);
+  });
+
+  test('persists visibility and selected position', () async {
+    const service = AiShareButtonPreferencesService();
+
+    await service.savePreferences(
+      const AiShareButtonPreferences(
+        visible: false,
+        position: AiShareButtonPosition.topLeft,
+      ),
+    );
+
+    final preferences = await service.loadPreferences();
+
+    expect(preferences.visible, isFalse);
+    expect(preferences.position, AiShareButtonPosition.topLeft);
+  });
+
+  test('falls back to bottom-right when stored position is unknown', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'ai_share_button_visible_v1': false,
+      'ai_share_button_position_v1': 'center_screen',
+    });
+    const service = AiShareButtonPreferencesService();
+
+    final preferences = await service.loadPreferences();
+
+    expect(preferences.visible, isFalse);
+    expect(preferences.position, AiShareButtonPosition.bottomRight);
+  });
+}


### PR DESCRIPTION
## Summary
- Add persisted AI share button visibility and corner-position preferences
- Add an inline tune control on the floating AI share button
- Add /settings access for re-enabling the button after hiding it

## Tests
- flutter test --no-pub test\services\ai_share_button_preferences_service_test.dart
- flutter analyze --no-pub lib\services\ai_share_button_preferences_service.dart lib\widgets\ai_share_button_settings_panel.dart lib\pages\ai_share_button_settings_page.dart lib\widgets\universal_ai_share_shell.dart lib\pages\settings_page.dart

## Minimal E2E Contract
- E2E-Exception: No integration_test/ or Playwright file was added because this PR only changes a global preference shell and persistence service; behavior is covered by a focused service test and the existing public smoke still covers page load.
- Future E2E test would be implementation-detail independent.
- Future E2E plan is minimal, about three I/O cases: open the calendar page and tune panel; move the button to another corner and reload; hide the button and re-enable it from Settings.
- E2E mechanism would be Playwright or Flutter integration_test, whichever owns the existing web route smoke.