### PR TITLE
feat(self-touch): PWA shortcuts + install banner (#1741)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -715,7 +715,10 @@ class _MyAppState extends State<MyApp> {
             return MaterialPageRoute(builder: (_) => const DailyHabitsPage());
           case '/self-touch-tracker':
             return MaterialPageRoute(
-              builder: (_) => const SelfTouchTrackerPage(),
+              builder: (_) => SelfTouchTrackerPage(
+                quickLogOnOpen: uri.queryParameters['action'] == 'quick_log',
+              ),
+              settings: RouteSettings(name: settings.name),
             );
           case '/abstinence-guard':
             return MaterialPageRoute(

--- a/lib/pages/abstinence_guard_page.dart
+++ b/lib/pages/abstinence_guard_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart'
 import 'package:intl/intl.dart';
 
 import '../services/abstinence_guard_store.dart';
+import '../widgets/pwa_install_banner.dart';
 
 class AbstinenceGuardPage extends StatefulWidget {
   final DateTime Function()? nowProvider;
@@ -438,6 +439,10 @@ class _AbstinenceGuardPageState extends State<AbstinenceGuardPage> {
               child: ListView(
                 padding: const EdgeInsets.all(16),
                 children: [
+                  const PwaInstallBanner(
+                    storageKey: 'abstinence_guard_pwa_install_banner',
+                  ),
+                  const SizedBox(height: 16),
                   Container(
                     padding: const EdgeInsets.all(16),
                     decoration: BoxDecoration(

--- a/lib/pages/self_touch_tracker_page.dart
+++ b/lib/pages/self_touch_tracker_page.dart
@@ -5,7 +5,12 @@ import 'package:flutter/material.dart';
 import '../services/abstinence_guard_store.dart';
 
 class SelfTouchTrackerPage extends StatefulWidget {
-  const SelfTouchTrackerPage({super.key});
+  final bool quickLogOnOpen;
+
+  const SelfTouchTrackerPage({
+    super.key,
+    this.quickLogOnOpen = false,
+  });
 
   @override
   State<SelfTouchTrackerPage> createState() => _SelfTouchTrackerPageState();
@@ -28,6 +33,7 @@ class _SelfTouchTrackerPageState extends State<SelfTouchTrackerPage>
   int _todayCount = 0;
   List<AbstinenceSlipDailyCount> _weekTrend = [];
   bool _loading = true;
+  bool _quickLogInProgress = false;
   late AnimationController _pulseCtrl;
   late Animation<double> _pulseAnim;
 
@@ -41,7 +47,10 @@ class _SelfTouchTrackerPageState extends State<SelfTouchTrackerPage>
     _pulseAnim = Tween<double>(begin: 1.0, end: 1.12).animate(
       CurvedAnimation(parent: _pulseCtrl, curve: Curves.easeInOut),
     );
-    _load();
+    final initialLoad = _load();
+    if (widget.quickLogOnOpen) {
+      initialLoad.whenComplete(_runQuickLog);
+    }
   }
 
   @override
@@ -76,15 +85,63 @@ class _SelfTouchTrackerPageState extends State<SelfTouchTrackerPage>
     return d.year == now.year && d.month == now.month && d.day == now.day;
   }
 
-  Future<void> _record() async {
-    await _pulseCtrl.forward(from: 0);
-    await AbstinenceGuardStore.incrementSlip(itemId: _itemId);
-    await _load();
+  Future<void> _record({
+    bool showSuccess = false,
+    bool showFailure = false,
+  }) async {
+    try {
+      await _pulseCtrl.forward(from: 0);
+      await AbstinenceGuardStore.incrementSlip(
+        itemId: _itemId,
+        triggerNote: 'self_touch_quick_log',
+      );
+      await _load();
+    } catch (_) {
+      if (!mounted || !showFailure) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Could not record.'),
+          action: SnackBarAction(
+            label: 'Retry',
+            onPressed: _runQuickLog,
+          ),
+        ),
+      );
+      return;
+    }
+
     if (!mounted) return;
+
+    if (showSuccess) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Recorded'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
 
     if (_todayCount >= _alertThreshold) {
       _showAlternativeActions();
     }
+  }
+
+  Future<void> _runQuickLog() async {
+    if (!mounted || _quickLogInProgress) {
+      return;
+    }
+    setState(() {
+      _quickLogInProgress = true;
+    });
+    await _record(showSuccess: true, showFailure: true);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _quickLogInProgress = false;
+    });
   }
 
   void _showAlternativeActions() {

--- a/lib/services/pwa_install_prompt.dart
+++ b/lib/services/pwa_install_prompt.dart
@@ -1,0 +1,2 @@
+export 'pwa_install_prompt_stub.dart'
+    if (dart.library.js_interop) 'pwa_install_prompt_web.dart';

--- a/lib/services/pwa_install_prompt_stub.dart
+++ b/lib/services/pwa_install_prompt_stub.dart
@@ -1,0 +1,13 @@
+class PwaInstallPromptController {
+  PwaInstallPromptController({
+    required void Function(bool isAvailable) onAvailabilityChanged,
+  });
+
+  bool get isAvailable => false;
+
+  void attach() {}
+
+  Future<bool> promptInstall() async => false;
+
+  void dispose() {}
+}

--- a/lib/services/pwa_install_prompt_web.dart
+++ b/lib/services/pwa_install_prompt_web.dart
@@ -1,0 +1,58 @@
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+class PwaInstallPromptController {
+  final void Function(bool isAvailable) _onAvailabilityChanged;
+
+  _BeforeInstallPromptEvent? _deferredPrompt;
+  JSFunction? _beforeInstallPromptListener;
+
+  PwaInstallPromptController({
+    required void Function(bool isAvailable) onAvailabilityChanged,
+  }) : _onAvailabilityChanged = onAvailabilityChanged;
+
+  bool get isAvailable => _deferredPrompt != null;
+
+  void attach() {
+    if (_beforeInstallPromptListener != null) {
+      return;
+    }
+
+    _beforeInstallPromptListener = ((web.Event event) {
+      event.preventDefault();
+      _deferredPrompt = _BeforeInstallPromptEvent(event);
+      _onAvailabilityChanged(true);
+    }).toJS;
+    web.window.addEventListener(
+      'beforeinstallprompt',
+      _beforeInstallPromptListener,
+    );
+  }
+
+  Future<bool> promptInstall() async {
+    final promptEvent = _deferredPrompt;
+    if (promptEvent == null) {
+      return false;
+    }
+
+    await promptEvent.prompt().toDart;
+    _deferredPrompt = null;
+    _onAvailabilityChanged(false);
+    return true;
+  }
+
+  void dispose() {
+    final listener = _beforeInstallPromptListener;
+    if (listener == null) {
+      return;
+    }
+    web.window.removeEventListener('beforeinstallprompt', listener);
+    _beforeInstallPromptListener = null;
+  }
+}
+
+@JS()
+extension type _BeforeInstallPromptEvent(web.Event _) implements web.Event {
+  external JSPromise<JSAny?> prompt();
+}

--- a/lib/widgets/pwa_install_banner.dart
+++ b/lib/widgets/pwa_install_banner.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/pwa_install_prompt.dart';
+
+class PwaInstallBanner extends StatefulWidget {
+  final String storageKey;
+  final Duration cooldown;
+  final bool debugForceVisible;
+  final DateTime Function()? nowProvider;
+
+  const PwaInstallBanner({
+    super.key,
+    this.storageKey = 'pwa_install_banner_dismissed_at',
+    this.cooldown = const Duration(days: 7),
+    this.debugForceVisible = false,
+    this.nowProvider,
+  });
+
+  @override
+  State<PwaInstallBanner> createState() => _PwaInstallBannerState();
+}
+
+class _PwaInstallBannerState extends State<PwaInstallBanner> {
+  bool _isLoading = true;
+  bool _isDismissed = false;
+  bool _canPromptInstall = false;
+  bool _installHintShown = false;
+  late final PwaInstallPromptController _installPromptController;
+
+  DateTime _now() => widget.nowProvider?.call() ?? DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    _installPromptController = PwaInstallPromptController(
+      onAvailabilityChanged: _handleInstallAvailabilityChanged,
+    );
+    _installPromptController.attach();
+    _loadDismissedState();
+  }
+
+  @override
+  void dispose() {
+    _installPromptController.dispose();
+    super.dispose();
+  }
+
+  void _handleInstallAvailabilityChanged(bool isAvailable) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _canPromptInstall = isAvailable;
+    });
+  }
+
+  Future<void> _loadDismissedState() async {
+    if (!kIsWeb && !widget.debugForceVisible) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isLoading = false;
+        _isDismissed = true;
+      });
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final dismissedAtValue = prefs.getString(widget.storageKey);
+    final dismissedAt =
+        dismissedAtValue == null ? null : DateTime.tryParse(dismissedAtValue);
+    final isDismissed =
+        dismissedAt != null && _now().difference(dismissedAt) < widget.cooldown;
+
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isLoading = false;
+      _isDismissed = isDismissed;
+    });
+  }
+
+  Future<void> _dismiss() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(widget.storageKey, _now().toIso8601String());
+
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isDismissed = true;
+    });
+  }
+
+  Future<void> _showInstallHint() async {
+    final didPrompt = await _installPromptController.promptInstall();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _installHintShown = true;
+    });
+    final message = didPrompt
+        ? 'Install prompt opened.'
+        : 'Use the browser install button to add this app.';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message), duration: const Duration(seconds: 3)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading || _isDismissed) {
+      return const SizedBox.shrink();
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      key: const Key('pwa_install_banner'),
+      color: colorScheme.primaryContainer.withValues(alpha: 0.72),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.install_mobile, color: colorScheme.onPrimaryContainer),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _installHintShown
+                        ? 'Install prompt ready'
+                        : _canPromptInstall
+                            ? 'Install this app'
+                            : 'Add to home screen',
+                    style: TextStyle(
+                      color: colorScheme.onPrimaryContainer,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Open the tracker from your home screen shortcut.',
+                    style: TextStyle(
+                      color: colorScheme.onPrimaryContainer.withValues(
+                        alpha: 0.8,
+                      ),
+                      fontSize: 12,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      FilledButton.icon(
+                        key: const Key('pwa_install_banner_install'),
+                        onPressed: _showInstallHint,
+                        icon: const Icon(Icons.add_to_home_screen, size: 18),
+                        label: Text(_canPromptInstall ? 'Install' : 'How'),
+                      ),
+                      TextButton.icon(
+                        key: const Key('pwa_install_banner_dismiss'),
+                        onPressed: _dismiss,
+                        icon: const Icon(Icons.close, size: 18),
+                        label: const Text('Later'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/widget/self_touch_tracker_quick_log_test.dart
+++ b/test/widget/self_touch_tracker_quick_log_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/self_touch_tracker_page.dart';
+import 'package:my_web_app/services/abstinence_guard_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('SelfTouchTrackerPage quick logs when opened from PWA shortcut', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: SelfTouchTrackerPage(quickLogOnOpen: true)),
+    );
+
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    final prefs = await SharedPreferences.getInstance();
+    final trend = await AbstinenceGuardStore.loadSlipCountsByDate(
+      itemId: 'touch_hair',
+      days: 1,
+      prefs: prefs,
+    );
+
+    expect(trend.single.count, 1);
+  });
+}

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -32,5 +32,20 @@
             "type": "image/png",
             "purpose": "maskable"
         }
+    ],
+    "shortcuts": [
+        {
+            "name": "Self Touch Tracker",
+            "short_name": "Track",
+            "description": "Record self contact now",
+            "url": "/self-touch-tracker?action=quick_log",
+            "icons": [
+                {
+                    "src": "icons/Icon-192.png",
+                    "sizes": "192x192",
+                    "type": "image/png"
+                }
+            ]
+        }
     ]
 }


### PR DESCRIPTION
## Summary
- Add a PWA manifest shortcut for `/self-touch-tracker?action=quick_log`.
- Add an AbstinenceGuardPage install banner with 7-day dismiss cooldown and web `beforeinstallprompt` support.
- Handle quick-log startup on SelfTouchTrackerPage and cover it with a widget test.

## Verification
- `flutter test --no-pub test\widget\self_touch_tracker_quick_log_test.dart`
- `flutter analyze --no-pub`
- `node -e "const fs=require(''fs''); const m=JSON.parse(fs.readFileSync(''web/manifest.json'',''utf8'')); const s=m.shortcuts?.[0]; if(!s || s.url!==''/self-touch-tracker?action=quick_log'') process.exit(1); console.log(s.url);"`

## Minimal E2E Gate
- The browser-level E2E plan is implementation-detail independent / black-box.
- Minimal plan: three I/O cases, covering shortcut URL input, quick-log record output, and install-banner dismiss cooldown output.
- E2E mechanism: Playwright or `integration_test` is the expected browser mechanism for a full follow-up check.
- E2E-Exception: this scoped PR uses a focused widget test plus existing Public E2E stability smoke because it only adds a manifest shortcut, one route flag, and a small PWA banner; full Lighthouse installability remains a manual release check.

## Scope
- iOS WidgetKit / Android Widget remains out of scope per the Win Claude hand-off packet.

Closes #1741