### PR TITLE
[codex] fix AI share overlay context

### DIFF
--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -53,6 +53,9 @@ class UniversalAiShareShell extends StatefulWidget {
 }
 
 class _UniversalAiShareShellState extends State<UniversalAiShareShell> {
+  OverlayEntry? _overlayEntry;
+  OverlayState? _overlayState;
+
   AiShareButtonPreferencesController get _preferencesController =>
       aiShareButtonPreferencesController;
 
@@ -60,36 +63,81 @@ class _UniversalAiShareShellState extends State<UniversalAiShareShell> {
   void initState() {
     super.initState();
     _preferencesController.load();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _syncOverlayEntry();
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant UniversalAiShareShell oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.navigatorKey != widget.navigatorKey) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _syncOverlayEntry();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _removeOverlayEntry();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        Positioned.fill(child: widget.child),
-        AnimatedBuilder(
-          animation: _preferencesController,
-          builder: (context, _) {
-            final preferences = _preferencesController.preferences;
-            if (!preferences.visible) return const SizedBox.shrink();
+    return widget.child;
+  }
 
-            return ValueListenableBuilder<UniversalSharePageContext>(
-              valueListenable: universalAiShareRouteObserver.currentPage,
-              builder: (context, page, _) {
-                return _positionedFab(
-                  preferences.position,
-                  SafeArea(
-                    child: _UniversalAiShareFab(
-                      page: page,
-                      navigatorKey: widget.navigatorKey,
-                    ),
-                  ),
-                );
-              },
+  void _syncOverlayEntry() {
+    if (!mounted) return;
+
+    final overlayState = widget.navigatorKey.currentState?.overlay;
+    if (overlayState == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _syncOverlayEntry();
+      });
+      return;
+    }
+
+    if (_overlayEntry != null && identical(_overlayState, overlayState)) {
+      return;
+    }
+
+    _removeOverlayEntry();
+    _overlayState = overlayState;
+    _overlayEntry = OverlayEntry(builder: _buildOverlayEntry);
+    overlayState.insert(_overlayEntry!);
+  }
+
+  void _removeOverlayEntry() {
+    _overlayEntry?.remove();
+    _overlayEntry = null;
+    _overlayState = null;
+  }
+
+  Widget _buildOverlayEntry(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _preferencesController,
+      builder: (context, _) {
+        final preferences = _preferencesController.preferences;
+        if (!preferences.visible) return const SizedBox.shrink();
+
+        return ValueListenableBuilder<UniversalSharePageContext>(
+          valueListenable: universalAiShareRouteObserver.currentPage,
+          builder: (context, page, _) {
+            return _positionedFab(
+              preferences.position,
+              SafeArea(
+                child: _UniversalAiShareFab(
+                  page: page,
+                  navigatorKey: widget.navigatorKey,
+                ),
+              ),
             );
           },
-        ),
-      ],
+        );
+      },
     );
   }
 
@@ -112,6 +160,14 @@ class _UniversalAiShareFab extends StatelessWidget {
   final GlobalKey<NavigatorState> navigatorKey;
 
   const _UniversalAiShareFab({required this.page, required this.navigatorKey});
+
+  bool get _isLoggedIn {
+    try {
+      return Supabase.instance.client.auth.currentSession != null;
+    } catch (_) {
+      return false;
+    }
+  }
 
   void _openShareDialog() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -144,7 +200,7 @@ class _UniversalAiShareFab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isLoggedIn = Supabase.instance.client.auth.currentSession != null;
+    final isLoggedIn = _isLoggedIn;
     final colorScheme = Theme.of(context).colorScheme;
     final backgroundColor = isLoggedIn
         ? colorScheme.primaryContainer

--- a/test/widgets/universal_ai_share_shell_test.dart
+++ b/test/widgets/universal_ai_share_shell_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/ai_share_button_preferences_service.dart';
+import 'package:my_web_app/widgets/universal_ai_share_shell.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    await aiShareButtonPreferencesController.reload();
+  });
+
+  testWidgets('AI share tooltip is hosted inside the navigator overlay',
+      (tester) async {
+    await tester.pumpWidget(_buildShell());
+    await tester.pump();
+
+    expect(find.byTooltip('AIシェア'), findsOneWidget);
+
+    await tester.longPress(find.byTooltip('AIシェア'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('settings sheet opens from the overlay-hosted share button',
+      (tester) async {
+    await tester.pumpWidget(_buildShell());
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('AIシェアボタン設定'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('表示位置'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Widget _buildShell() {
+  final navigatorKey = GlobalKey<NavigatorState>();
+  return MaterialApp(
+    navigatorKey: navigatorKey,
+    builder: (context, child) {
+      return UniversalAiShareShell(
+        navigatorKey: navigatorKey,
+        child: child ?? const SizedBox.shrink(),
+      );
+    },
+    home: const Scaffold(body: Text('home')),
+  );
+}


### PR DESCRIPTION
## Summary
- Host the universal AI share floating button in the Navigator overlay via `OverlayEntry` instead of rendering it as a sibling of `Navigator` from `MaterialApp.builder`.
- Keep the existing visibility and position preferences while making the button safe for `Tooltip`, dialogs, and bottom sheets.
- Add widget regression coverage for showing the AI share tooltip and opening the settings sheet.

## Root Cause
The floating AI share button was rendered outside the app's `Overlay`, so Flutter overlay consumers such as `Tooltip` could throw `No Overlay widget found.` on `/calendar-events` and leave the page covered by a modal barrier.

## Minimal E2E Gate
- The E2E plan is implementation-detail independent / black-box: verify only visible UI behavior on `/calendar-events`, not the internal `OverlayEntry` implementation.
- Minimal plan: three cases, about 3 input/output checks: load the calendar page without console overlay failure, open the AI share settings sheet, and confirm the button can be hidden or moved without blocking calendar interaction.
- E2E mechanism: Playwright public smoke is the right mechanism for browser evidence; this PR relies on existing Playwright smoke plus focused Flutter widget regression tests.
- E2E-Exception: no new `integration_test/` or `test/e2e/` file is added because the failure is a Flutter overlay context regression that is deterministic in widget tests and already covered by the added tooltip/settings tests.

## Validation
- `$env:FLUTTER_SUPPRESS_ANALYTICS='true'; flutter analyze --no-pub lib\\widgets\\universal_ai_share_shell.dart test\\widgets\\universal_ai_share_shell_test.dart`
- `$env:FLUTTER_SUPPRESS_ANALYTICS='true'; flutter test --no-pub test\\widgets\\universal_ai_share_shell_test.dart --reporter expanded`