### PR TITLE
[codex] suppress Flutter web focus traversal layout noise

### DIFF
--- a/lib/utils/error_reporter.dart
+++ b/lib/utils/error_reporter.dart
@@ -201,28 +201,50 @@ class ErrorReporter {
         hasReleaseInkStack && (details == null || library.contains('widgets'));
   }
 
+  @visibleForTesting
+  bool isIgnorableFlutterWebFocusTraversalLayoutErrorForTesting(
+    String message,
+    StackTrace? stackTrace,
+  ) {
+    return _isIgnorableFlutterWebFocusTraversalLayoutError(
+      message,
+      stackTrace,
+      isWebOverride: true,
+    );
+  }
+
   // Flutter Web can trigger focus traversal before every candidate RenderBox
   // has completed layout. The framework path is minified in release builds, so
   // match the traversal shape instead of one exact symbol suffix.
   bool _isIgnorableFlutterWebFocusTraversalLayoutError(
     String message,
-    StackTrace? stackTrace,
-  ) {
-    if (!kIsWeb) return false;
+    StackTrace? stackTrace, {
+    bool? isWebOverride,
+  }) {
+    if (!(isWebOverride ?? kIsWeb)) return false;
     if (!message.contains('RenderBox was not laid out')) return false;
 
     final stack = stackTrace?.toString() ?? '';
     final hasDebugFocusTraversalStack =
         stack.contains('FocusTraversalPolicy') ||
             stack.contains('FocusTraversalGroup');
-    final hasReleaseFocusTraversalStack = stack.contains('.gN') &&
+    final hasReleaseFocusTraversalStackV1 = stack.contains('.gN') &&
         stack.contains('.gn') &&
         stack.contains('.ge') &&
         stack.contains('Object.e') &&
         stack.contains('Object.dy') &&
         stack.contains('.ak');
+    final hasReleaseFocusTraversalStackV2 = stack.contains('.gn') &&
+        stack.contains('.ge') &&
+        stack.contains('Object.e') &&
+        stack.contains('Object.d') &&
+        (stack.contains('.aF') || stack.contains('.aG')) &&
+        (stack.contains('.aU') || stack.contains('.aV')) &&
+        stack.contains('.at');
 
-    return hasDebugFocusTraversalStack || hasReleaseFocusTraversalStack;
+    return hasDebugFocusTraversalStack ||
+        hasReleaseFocusTraversalStackV1 ||
+        hasReleaseFocusTraversalStackV2;
   }
 
   /// AppLogger.error から呼ばれる (caught errors)

--- a/test/utils/error_reporter_test.dart
+++ b/test/utils/error_reporter_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/utils/error_reporter.dart';
+
+void main() {
+  test(
+    'ignores Flutter web focus traversal layout errors from current release',
+    () {
+      const message =
+          'Bad state: RenderBox was not laid out: minified:azD#35b6f';
+      final currentReleaseStack = StackTrace.fromString('''
+at Object.aX (https://my-web-app-b67f4.web.app/main.dart.js:3974:30)
+at azD.gO (https://my-web-app-b67f4.web.app/main.dart.js:118967:18)
+at azD.gng (https://my-web-app-b67f4.web.app/main.dart.js:118968:18)
+at iu.ge3 (https://my-web-app-b67f4.web.app/main.dart.js:135700:45)
+at Object.egE (https://my-web-app-b67f4.web.app/main.dart.js:29573:5)
+at Object.dJ8 (https://my-web-app-b67f4.web.app/main.dart.js:29537:5)
+at bs8.alY (https://my-web-app-b67f4.web.app/main.dart.js:136158:11)
+at bs8.aG3 (https://my-web-app-b67f4.web.app/main.dart.js:136162:22)
+at aiq.aVg (https://my-web-app-b67f4.web.app/main.dart.js:150561:45)
+at a82.atO (https://my-web-app-b67f4.web.app/main.dart.js:132893:52)
+''');
+      final previousReleaseStack = StackTrace.fromString('''
+at Object.aW (https://my-web-app-b67f4.web.app/main.dart.js:3974:30)
+at azw.gN (https://my-web-app-b67f4.web.app/main.dart.js:118480:18)
+at azw.gng (https://my-web-app-b67f4.web.app/main.dart.js:118481:18)
+at ir.ge3 (https://my-web-app-b67f4.web.app/main.dart.js:135213:45)
+at Object.efG (https://my-web-app-b67f4.web.app/main.dart.js:29571:5)
+at Object.dIe (https://my-web-app-b67f4.web.app/main.dart.js:29535:5)
+at brF.alP (https://my-web-app-b67f4.web.app/main.dart.js:135786:11)
+at brF.aFP (https://my-web-app-b67f4.web.app/main.dart.js:135790:22)
+at ail.aUW (https://my-web-app-b67f4.web.app/main.dart.js:150265:45)
+at a8_.atB (https://my-web-app-b67f4.web.app/main.dart.js:132591:52)
+''');
+
+      for (final stack in [currentReleaseStack, previousReleaseStack]) {
+        expect(
+          ErrorReporter.instance
+              .isIgnorableFlutterWebFocusTraversalLayoutErrorForTesting(
+            message,
+            stack,
+          ),
+          isTrue,
+        );
+      }
+    },
+  );
+
+  test('does not ignore unrelated RenderBox layout errors', () {
+    const message = 'Bad state: RenderBox was not laid out: RenderFlex#1234';
+    final stack = StackTrace.fromString('''
+at Object.throwError (main.dart.js:1:1)
+at CalendarEventsPage.build (main.dart.js:2:1)
+at RenderFlex.performLayout (main.dart.js:3:1)
+''');
+
+    expect(
+      ErrorReporter.instance
+          .isIgnorableFlutterWebFocusTraversalLayoutErrorForTesting(
+        message,
+        stack,
+      ),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Broaden the Flutter Web focus traversal layout-error filter for the current minified release stack.
- Add regression coverage for the reported `RenderBox was not laid out` stack and a negative unrelated-layout case.

## Root Cause

The app already treats a narrow Flutter Web focus traversal `RenderBox was not laid out` path as ignorable. Flutter 3.41 changed the minified release symbols, so the same framework path no longer matched the filter and escaped as an uncaught `main.dart.js` console error.

## Minimal E2E Gate

- The E2E test plan is implementation-detail independent and black-box: verify page startup has no uncaught app error, not the internal matcher implementation.
- Minimal plan is about three I/O cases: load `/calendar-events`, observe no app-side uncaught error, and keep existing public navigation smoke stable.
- Mechanism: Playwright public smoke/visual evidence remains the browser-level E2E mechanism.
- E2E-Exception: this PR only updates error classification for an existing Flutter Web framework noise path and adds focused regression tests for the reported stack; no new user input/output workflow is introduced.

## Validation

- `flutter analyze --no-pub lib\utils\error_reporter.dart test\utils\error_reporter_test.dart`
- `flutter test --no-pub test\utils\error_reporter_test.dart test\widgets\universal_ai_share_shell_test.dart test\pages\calendar_events_page_test.dart`
- `python scripts\quality_gate.py --fast`
