### PR TITLE
[codex] suppress current Flutter web window error

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1042,7 +1042,7 @@
       var stack = String((error && error.stack) || '');
       var message = String((event && event.message) || (error && error.message) || '');
       var isMainBundle = stack.indexOf('main.dart.js') !== -1;
-      var isFocusTraversalRenderBox =
+      var isFocusTraversalRenderBoxV1 =
         isMainBundle &&
         stack.indexOf('.gN') !== -1 &&
         stack.indexOf('.gn') !== -1 &&
@@ -1050,6 +1050,17 @@
         stack.indexOf('Object.dy') !== -1 &&
         stack.indexOf('.ak') !== -1 &&
         stack.indexOf('a7') !== -1;
+      var isFocusTraversalRenderBoxV2 =
+        isMainBundle &&
+        stack.indexOf('.gn') !== -1 &&
+        stack.indexOf('.ge') !== -1 &&
+        stack.indexOf('Object.e') !== -1 &&
+        stack.indexOf('Object.d') !== -1 &&
+        (stack.indexOf('.aF') !== -1 || stack.indexOf('.aG') !== -1) &&
+        (stack.indexOf('.aU') !== -1 || stack.indexOf('.aV') !== -1) &&
+        stack.indexOf('.at') !== -1;
+      var isFocusTraversalRenderBox =
+        isFocusTraversalRenderBoxV1 || isFocusTraversalRenderBoxV2;
       var isInkResponseNull =
         message.indexOf('Null check operator used on a null value') !== -1 &&
         isMainBundle &&


### PR DESCRIPTION
﻿## Summary
- Extend the `web/index.html` window error suppressor to cover the current Flutter 3.41 minified focus traversal stack.
- Keeps the existing legacy stack and InkResponse filters intact.
- Complements #2317, which added the Dart-side ErrorReporter matcher.

## Validation
- `flutter test --no-pub --reporter expanded test\\utils\\error_reporter_test.dart`
- `python scripts\\quality_gate.py --fast`
- Node stack matcher check against the reported `aX/gO/gng/ge3/egE/dJ8/aG3/aVg/atO` stack

## Minimal E2E Gate Declaration
- Implementation-detail independent / black-box: a browser check should open `/calendar-events` and assert the page does not surface the known focus traversal `Uncaught Error` stack.
- I/O cases: route load, first-frame settle, and the calendar view remaining available after the delayed focus traversal callback.
- Mechanism: Playwright/browser observation is only the mechanism; the user-facing assertion is absence of the known window-level error.
- E2E-Exception: This is a narrow bootstrap error-filter update for a known recovered Flutter framework race; targeted stack verification plus the standard fast gate cover the change.