### PR TITLE
fix: prevent embedded AI share images from reaching Hedra

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -141,10 +141,7 @@ class UniversalXShareService {
       );
       final parsed = _parseDraft(response.text, context, fallback);
       if (_isUsableText(parsed.text, context.url)) {
-        return parsed.copyWith(
-          fallbackUsed: false,
-          source: response.source,
-        );
+        return parsed.copyWith(fallbackUsed: false, source: response.source);
       }
     } catch (_) {
       // The global share button must remain usable even when AI routing fails.
@@ -179,6 +176,17 @@ class UniversalXShareService {
     String? imageUrl,
     String? hedraGenerationId,
   }) async {
+    final normalizedImageUrl = _emptyToNull(imageUrl);
+    if (normalizedImageUrl != null && !_isPublicHttpUrl(normalizedImageUrl)) {
+      return const UniversalXMediaResult(
+        url: null,
+        status: 'fallback_text',
+        raw: {
+          'videoReason':
+              'Hedra avatar image must be a public URL. Regenerate the share image so it can be stored before video generation.',
+        },
+      );
+    }
     final requestBody = <String, dynamic>{
       'type': 'presenter_video',
       'template': _videoTemplateFor(context),
@@ -192,7 +200,6 @@ class UniversalXShareService {
       'source': 'universal_x_share',
       'route': context.routePath,
     };
-    final normalizedImageUrl = _emptyToNull(imageUrl);
     if (normalizedImageUrl != null) {
       requestBody['imageUrl'] = normalizedImageUrl;
     }
@@ -222,10 +229,14 @@ class UniversalXShareService {
     String? mediaUrl,
     bool dryRun = false,
   }) async {
+    final normalizedMediaUrl = _emptyToNull(mediaUrl);
     final data = await _invoke('growth-hub', {
       'action': 'x.post',
       'text': sanitizeTweet(text, url: context.url),
-      'mediaUrl': mediaUrl,
+      'mediaUrl':
+          normalizedMediaUrl != null && _isPublicHttpUrl(normalizedMediaUrl)
+              ? normalizedMediaUrl
+              : null,
       'dryRun': dryRun,
       'source': 'universal_x_share',
       'route': context.routePath,
@@ -485,5 +496,17 @@ ${draft.videoPrompt}
   static String? _emptyToNull(String? value) {
     final trimmed = value?.trim() ?? '';
     return trimmed.isEmpty ? null : trimmed;
+  }
+
+  static bool isEmbeddedDataUrl(String? value) {
+    return value?.trimLeft().toLowerCase().startsWith('data:') == true;
+  }
+
+  static bool _isPublicHttpUrl(String value) {
+    final uri = Uri.tryParse(value);
+    return uri != null &&
+        (uri.scheme == 'https' || uri.scheme == 'http') &&
+        uri.host.isNotEmpty &&
+        value.length <= 2083;
   }
 }

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -425,9 +425,21 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
     return value == null || value.isEmpty || value == 'null' ? null : value;
   }
 
+  static String _mediaDisplayText(String mediaUrl) {
+    if (UniversalXShareService.isEmbeddedDataUrl(mediaUrl)) {
+      return 'Generated image is embedded data. Regenerate it to store a public URL before video generation or X posting.';
+    }
+    return mediaUrl.length <= 240
+        ? mediaUrl
+        : '${mediaUrl.substring(0, 220)}...';
+  }
+
   static String _videoStatusMessage(UniversalXMediaResult result) {
     if (result.url != null) return 'シェア動画を生成しました';
     final reason = _extractString(result.raw, 'videoReason');
+    if (reason != null && reason.contains('public URL')) {
+      return 'Video needs a public image URL. Please regenerate the share image, then retry video generation.';
+    }
     if (reason == 'Hedra avatar video requires imageUrl') {
       return '先に画像生成を実行してから、動画生成を開始してください';
     }
@@ -518,7 +530,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
               ),
               if (mediaUrl != null) ...[
                 const SizedBox(height: 12),
-                SelectableText('添付メディア: $mediaUrl'),
+                SelectableText('添付メディア: ${_mediaDisplayText(mediaUrl)}'),
               ],
               if (_statusMessage != null) ...[
                 const SizedBox(height: 12),

--- a/supabase/functions/media-hub/index.ts
+++ b/supabase/functions/media-hub/index.ts
@@ -19,6 +19,7 @@ const corsHeaders = {
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
 const SERVICE_ROLE_KEY = Deno.env.get("SERVICE_ROLE_KEY") ?? "";
+const GENERATED_IMAGE_BUCKET = "ai-generated-images";
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -90,6 +91,52 @@ function imageSizeForModel(model: string, requested: string): string {
   return ["1024x1024", "1024x1792", "1792x1024"].includes(requested)
     ? requested
     : "1792x1024";
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function storageSafeSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") ||
+    "anonymous";
+}
+
+async function persistGeneratedImageToStorage(
+  admin: SupabaseClient,
+  b64Json: string,
+  userId: string,
+): Promise<string | null> {
+  try {
+    const bytes = base64ToBytes(b64Json);
+    const datePrefix = new Date().toISOString().slice(0, 10);
+    const path = [
+      "openai",
+      storageSafeSegment(userId),
+      datePrefix,
+      `${crypto.randomUUID()}.png`,
+    ].join("/");
+    const { error } = await admin.storage
+      .from(GENERATED_IMAGE_BUCKET)
+      .upload(path, bytes, {
+        contentType: "image/png",
+        cacheControl: "604800",
+        upsert: false,
+      });
+    if (error) throw error;
+    const { data } = admin.storage.from(GENERATED_IMAGE_BUCKET).getPublicUrl(
+      path,
+    );
+    return data.publicUrl;
+  } catch (error) {
+    console.warn("Generated image storage upload failed", error);
+    return null;
+  }
 }
 
 async function listItems(
@@ -489,6 +536,10 @@ serve(async (req) => {
 
         const imageUrl = generated?.url ?? "";
         const b64Json = generated?.b64_json ?? "";
+        const storedImageUrl = !imageUrl && b64Json
+          ? await persistGeneratedImageToStorage(admin, b64Json, userId)
+          : null;
+        const publicImageUrl = imageUrl || storedImageUrl || "";
         const dataUrl = b64Json ? `data:image/png;base64,${b64Json}` : "";
         if (!imageUrl && !b64Json) {
           return json({
@@ -501,7 +552,7 @@ serve(async (req) => {
         const item = persist
           ? await addItem(admin, "ai_image", userId, {
             prompt,
-            url: imageUrl || dataUrl,
+            url: publicImageUrl || dataUrl,
             size: usedSize,
             style,
             quality,
@@ -514,7 +565,8 @@ serve(async (req) => {
         return json({
           success: true,
           image: item,
-          url: imageUrl || dataUrl,
+          url: publicImageUrl || dataUrl,
+          storageUrl: storedImageUrl,
           b64Json: returnB64 ? b64Json : undefined,
           prompt,
           size: usedSize,

--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -479,9 +479,15 @@ async function createHedraPresenterVideo(params: {
   imageUrl: string | null;
   lang: "ja" | "en";
 }): Promise<HedraVideoResult> {
-  const imageUrl = firstNonEmptyString(params.imageUrl);
-  if (!imageUrl) {
+  const rawImageUrl = firstNonEmptyString(params.imageUrl);
+  if (!rawImageUrl) {
     throw new Error("Hedra avatar video requires imageUrl");
+  }
+  const imageUrl = normalizeHedraStartKeyframeUrl(rawImageUrl);
+  if (!imageUrl) {
+    throw new Error(
+      "Hedra avatar image must be a public http(s) URL under 2083 characters. Regenerate the share image so it can be stored before video generation.",
+    );
   }
 
   const voiceId = await resolveHedraVoiceId(
@@ -792,6 +798,19 @@ function firstNonEmptyString(...values: unknown[]): string | null {
     }
   }
   return null;
+}
+
+function normalizeHedraStartKeyframeUrl(value: string | null): string | null {
+  if (!value) return null;
+  if (value.length > 2083) return null;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:"
+      ? value
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function firstNumber(...values: unknown[]): number | null {

--- a/supabase/migrations/20260510143000_create_ai_generated_images_bucket.sql
+++ b/supabase/migrations/20260510143000_create_ai_generated_images_bucket.sql
@@ -1,0 +1,17 @@
+-- Store OpenAI-generated share images as short public URLs for downstream
+-- video providers such as Hedra. Hedra rejects inline data URLs because
+-- start_keyframe_url must be a normal URL under its length limit.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'ai-generated-images',
+  'ai-generated-images',
+  true,
+  10485760,
+  ARRAY['image/png', 'image/jpeg', 'image/webp']
+)
+ON CONFLICT (id) DO UPDATE
+SET
+  public = true,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -73,60 +73,103 @@ void main() {
     expect(capturedBody?['mediaUrl'], 'https://example.com/share.png');
   });
 
-  test('generateVideo uses My Finance mobile UX template for finance pages',
-      () async {
+  test('postToX omits embedded data URL media', () async {
     Map<String, dynamic>? capturedBody;
+    final service = UniversalXShareService(
+      functionInvoker: (functionName, body) async {
+        capturedBody = body;
+        return {'success': true, 'posted': true};
+      },
+    );
+
+    await service.postToX(
+      context: page,
+      text: 'Share text ${page.url}',
+      mediaUrl: 'data:image/png;base64,${'a' * 3000}',
+    );
+
+    expect(capturedBody?['mediaUrl'], isNull);
+  });
+
+  test(
+    'generateVideo uses My Finance mobile UX template for finance pages',
+    () async {
+      Map<String, dynamic>? capturedBody;
+      String? capturedFunction;
+      final service = UniversalXShareService(
+        functionInvoker: (functionName, body) async {
+          capturedFunction = functionName;
+          capturedBody = body;
+          return {'success': true, 'status': 'fallback_text'};
+        },
+      );
+      const financePage = UniversalSharePageContext(
+        routePath: '/asset-management',
+        title: 'Asset Management',
+        url: 'https://my-web-app-b67f4.web.app/asset-management',
+      );
+      final draft = UniversalXShareService.buildFallbackDraft(financePage);
+
+      await service.generateVideo(
+        context: financePage,
+        draft: draft,
+        imageUrl: 'https://example.com/share.png',
+      );
+
+      expect(capturedFunction, 'viral-video-ad-generator');
+      expect(capturedBody?['template'], 'mobile_ux_validation');
+      expect(capturedBody?['title'], 'マイファイナンス');
+      expect(capturedBody?['preferredModel'], 'seedance-2.0');
+      expect(capturedBody?['imageUrl'], 'https://example.com/share.png');
+      expect(capturedBody?['creativePipeline'], const [
+        'gpt-image-2',
+        'gpt-5.5',
+        'seedance-2.0',
+      ]);
+      expect(
+        capturedBody?['customPrompt'],
+        contains('Moving smartphone app UX validation video'),
+      );
+    },
+  );
+
+  test(
+    'generateVideo can poll an existing Hedra generation and use download URL',
+    () async {
+      Map<String, dynamic>? capturedBody;
+      final service = UniversalXShareService(
+        functionInvoker: (functionName, body) async {
+          capturedBody = body;
+          return {
+            'success': true,
+            'videoStatus': 'complete',
+            'generatedDownloadUrl': 'https://example.com/video.mp4',
+          };
+        },
+      );
+
+      final draft = UniversalXShareService.buildFallbackDraft(page);
+      final result = await service.generateVideo(
+        context: page,
+        draft: draft,
+        hedraGenerationId: '123e4567-e89b-12d3-a456-426614174000',
+      );
+
+      expect(result.url, 'https://example.com/video.mp4');
+      expect(result.status, 'complete');
+      expect(
+        capturedBody?['hedraGenerationId'],
+        '123e4567-e89b-12d3-a456-426614174000',
+      );
+    },
+  );
+
+  test('generateVideo does not forward embedded data URLs to Hedra', () async {
     String? capturedFunction;
     final service = UniversalXShareService(
       functionInvoker: (functionName, body) async {
         capturedFunction = functionName;
-        capturedBody = body;
-        return {
-          'success': true,
-          'status': 'fallback_text',
-        };
-      },
-    );
-    const financePage = UniversalSharePageContext(
-      routePath: '/asset-management',
-      title: 'Asset Management',
-      url: 'https://my-web-app-b67f4.web.app/asset-management',
-    );
-    final draft = UniversalXShareService.buildFallbackDraft(financePage);
-
-    await service.generateVideo(
-      context: financePage,
-      draft: draft,
-      imageUrl: 'https://example.com/share.png',
-    );
-
-    expect(capturedFunction, 'viral-video-ad-generator');
-    expect(capturedBody?['template'], 'mobile_ux_validation');
-    expect(capturedBody?['title'], 'マイファイナンス');
-    expect(capturedBody?['preferredModel'], 'seedance-2.0');
-    expect(capturedBody?['imageUrl'], 'https://example.com/share.png');
-    expect(
-      capturedBody?['creativePipeline'],
-      const ['gpt-image-2', 'gpt-5.5', 'seedance-2.0'],
-    );
-    expect(
-      capturedBody?['customPrompt'],
-      contains('Moving smartphone app UX validation video'),
-    );
-  });
-
-  test(
-      'generateVideo can poll an existing Hedra generation and use download URL',
-      () async {
-    Map<String, dynamic>? capturedBody;
-    final service = UniversalXShareService(
-      functionInvoker: (functionName, body) async {
-        capturedBody = body;
-        return {
-          'success': true,
-          'videoStatus': 'complete',
-          'generatedDownloadUrl': 'https://example.com/video.mp4',
-        };
+        return {'success': true, 'status': 'unexpected'};
       },
     );
 
@@ -134,14 +177,22 @@ void main() {
     final result = await service.generateVideo(
       context: page,
       draft: draft,
-      hedraGenerationId: '123e4567-e89b-12d3-a456-426614174000',
+      imageUrl: 'data:image/png;base64,${'a' * 3000}',
     );
 
-    expect(result.url, 'https://example.com/video.mp4');
-    expect(result.status, 'complete');
+    expect(capturedFunction, isNull);
+    expect(result.status, 'fallback_text');
+    expect(result.raw['videoReason'], contains('public URL'));
+  });
+
+  test('isEmbeddedDataUrl detects generated inline images', () {
     expect(
-      capturedBody?['hedraGenerationId'],
-      '123e4567-e89b-12d3-a456-426614174000',
+      UniversalXShareService.isEmbeddedDataUrl('data:image/png;base64,abc'),
+      isTrue,
+    );
+    expect(
+      UniversalXShareService.isEmbeddedDataUrl('https://example.com/a.png'),
+      isFalse,
     );
   });
 }


### PR DESCRIPTION
## Summary
- Persist OpenAI b64 share images into the public Supabase Storage bucket ai-generated-images, so Hedra receives a short http(s) start_keyframe_url.
- Guard AI share video generation and X posting from embedded data URLs / overlong URLs, and shorten media text in the dialog.
- Add the storage bucket migration and service tests for embedded media fallback behavior.

## Minimal E2E Gate
- Implementation-detail independent black-box coverage: CI runs the Playwright public E2E stability smoke against the deployed Flutter shell, while targeted service/widget tests cover the provider I/O boundaries changed here.
- Minimal three cases: public image URL is forwarded to Hedra, embedded data URL is blocked before Hedra, and embedded data URL media is omitted before X posting.
- E2E mechanism: Playwright public E2E stability smoke plus focused Flutter service/widget tests.
- E2E-Exception: No new integration_test/ or test/e2e/ file is added because this fix normalizes Edge Function payload/storage behavior and media URL forwarding, while existing Playwright smoke already covers route boot and the new unit/widget tests cover the changed I/O cases.

## High-Risk Ultrareview
- Review owner: Claude Code #1.
- Claude ultrareview evidence:
  - Security: no new client-side secrets; Storage upload uses the existing server-side Supabase service client path, and the client only receives public image URLs.
  - Rollback: revert this PR to restore previous inline image behavior; the added bucket is additive and harmless if unused.
  - Data migration: migration only creates/updates the public ai-generated-images Storage bucket with image MIME limits and a 10 MB cap.
  - Prod smoke: Public E2E stability smoke passed in PR checks; local and pre-push gates passed.
  - Observability: media-hub warns when generated image storage upload fails and falls back without crashing; Hedra rejection is converted to a friendly fallback path before API call when possible.
- Unresolved findings: 0 / none.

## Validation
- flutter analyze --no-pub lib\\services\\universal_x_share_service.dart lib\\widgets\\universal_ai_share_shell.dart test\\services\\universal_x_share_service_test.dart
- flutter test --no-pub test\\services\\universal_x_share_service_test.dart test\\widgets\\universal_ai_share_shell_test.dart
- deno lint supabase\\functions\\media-hub\\index.ts supabase\\functions\\viral-video-ad-generator\\index.ts
- pre-push full quality gate: flutter analyze, deno lint, dart format check, flutter vm tests (336 passed)