### PR TITLE
fix: throttle duplicate presence syncs

### DIFF
--- a/lib/services/growth_mission_service.dart
+++ b/lib/services/growth_mission_service.dart
@@ -1405,10 +1405,16 @@ $inviteUrl
 
 class GrowthPresenceNavigatorObserver extends NavigatorObserver
     with WidgetsBindingObserver {
+  static const Duration _immediatePresenceCooldown = Duration(seconds: 45);
+
   final GrowthMissionService _service;
   final GrowthAcquisitionService _acquisitionService;
   Timer? _heartbeatTimer;
   Timer? _metricsTimer;
+  Future<void>? _immediatePresenceSyncInFlight;
+  String? _immediatePresenceSyncInFlightPagePath;
+  DateTime? _lastImmediatePresenceSyncAt;
+  String? _lastImmediatePresenceSyncPagePath;
   String _currentPagePath = '/';
 
   GrowthPresenceNavigatorObserver({
@@ -1441,10 +1447,7 @@ class GrowthPresenceNavigatorObserver extends NavigatorObserver
     _heartbeatTimer?.cancel();
     _metricsTimer?.cancel();
     if (!_service.isPresenceTrackingAvailable) return;
-    _runSafely(
-      _service.syncPresence(pagePath: _currentPagePath),
-      'syncPresence',
-    );
+    _syncPresenceImmediately();
     _heartbeatTimer = Timer.periodic(const Duration(minutes: 2), (_) {
       _runSafely(
         _service.syncPresence(pagePath: _currentPagePath),
@@ -1499,6 +1502,38 @@ class GrowthPresenceNavigatorObserver extends NavigatorObserver
       'applyPendingReferralIfPossible',
     );
     _restartTimers();
+  }
+
+  void _syncPresenceImmediately() {
+    final pagePath = _currentPagePath;
+    final inFlight = _immediatePresenceSyncInFlight;
+    if (inFlight != null &&
+        _immediatePresenceSyncInFlightPagePath == pagePath) {
+      return;
+    }
+
+    final lastSyncedAt = _lastImmediatePresenceSyncAt;
+    if (_lastImmediatePresenceSyncPagePath == pagePath &&
+        lastSyncedAt != null &&
+        DateTime.now().difference(lastSyncedAt) < _immediatePresenceCooldown) {
+      return;
+    }
+
+    final syncFuture = _service.syncPresence(pagePath: pagePath);
+    _immediatePresenceSyncInFlight = syncFuture;
+    _immediatePresenceSyncInFlightPagePath = pagePath;
+    _lastImmediatePresenceSyncAt = DateTime.now();
+    _lastImmediatePresenceSyncPagePath = pagePath;
+
+    _runSafely(
+      syncFuture.whenComplete(() {
+        if (identical(_immediatePresenceSyncInFlight, syncFuture)) {
+          _immediatePresenceSyncInFlight = null;
+          _immediatePresenceSyncInFlightPagePath = null;
+        }
+      }),
+      'syncPresence',
+    );
   }
 
   void _runSafely(Future<void> future, String label) {

--- a/test/services/growth_mission_service_test.dart
+++ b/test/services/growth_mission_service_test.dart
@@ -1,7 +1,13 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/growth_acquisition_service.dart';
 import 'package:my_web_app/services/growth_mission_service.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('GrowthMissionService command center fallback', () {
     test('returns cross-functional brief when Supabase is unavailable',
         () async {
@@ -115,4 +121,62 @@ void main() {
       expect(snapshot.importPreviews.single.previewCount, 5);
     });
   });
+
+  group('GrowthPresenceNavigatorObserver', () {
+    test('suppresses duplicate immediate presence syncs for the same route',
+        () async {
+      final syncCompleter = Completer<void>();
+      final service = _FakePresenceService(syncCompleter.future);
+      final observer = GrowthPresenceNavigatorObserver(
+        service: service,
+        acquisitionService: const _NoopGrowthAcquisitionService(),
+      );
+      addTearDown(observer.dispose);
+
+      final route = MaterialPageRoute<void>(
+        settings: const RouteSettings(name: '/asset-management'),
+        builder: (_) => const SizedBox.shrink(),
+      );
+
+      observer.didPush(route, null);
+      observer.didPush(route, null);
+
+      expect(service.syncPresenceCalls, 1);
+      expect(service.syncedPagePaths, <String>['/asset-management']);
+
+      syncCompleter.complete();
+      await Future<void>.delayed(Duration.zero);
+    });
+  });
+}
+
+class _FakePresenceService extends GrowthMissionService {
+  _FakePresenceService(this._syncFuture);
+
+  final Future<void> _syncFuture;
+  final List<String> syncedPagePaths = <String>[];
+
+  int get syncPresenceCalls => syncedPagePaths.length;
+
+  @override
+  bool get isPresenceTrackingAvailable => true;
+
+  @override
+  Future<void> syncPresence({required String pagePath}) {
+    syncedPagePaths.add(pagePath);
+    return _syncFuture;
+  }
+
+  @override
+  Future<void> capturePendingReferralFromUri({Uri? currentUri}) async {}
+
+  @override
+  Future<void> applyPendingReferralIfPossible() async {}
+}
+
+class _NoopGrowthAcquisitionService extends GrowthAcquisitionService {
+  const _NoopGrowthAcquisitionService();
+
+  @override
+  Future<void> recordTouchpointForPagePath(String pagePath) async {}
 }


### PR DESCRIPTION
﻿## Summary
- Throttle duplicate immediate `user_presence` syncs for the same route while keeping the 2-minute heartbeat.
- Add coverage for duplicate route notifications so repeated `didPush` calls do not create duplicate immediate presence writes.
- Captured clean-browser evidence for the reported console noise: Playwright clean Chromium and clean Microsoft Edge profiles on `/asset-management` showed `Injecting <script> tag. Using callback.` but no `Unchecked runtime.lastError` entries.

## Minimal E2E Gate
- implementation-detail independent / black-box: console capture was run against the deployed `/asset-management` route, not internal widget state.
- minimal three cases / 3 cases:
  1. Clean Chromium opens `/asset-management` and captures console messages for 20 seconds.
  2. Clean Microsoft Edge opens `/asset-management` and captures console messages for 20 seconds.
  3. Duplicate navigator route notifications call presence sync only once for the same route.
- Playwright evidence: clean Chromium total console entries were 5 with 0 `Unchecked runtime.lastError`; clean Microsoft Edge total console entries were 1 with 0 `Unchecked runtime.lastError`.
- E2E-Exception: no new `test/e2e/` file because this is a narrow background sync throttle plus ad-hoc clean-browser console reproduction; the repository's public Playwright smoke still runs in CI.

## Validation
- `flutter analyze --no-pub lib\\services\\growth_mission_service.dart test\\services\\growth_mission_service_test.dart`
- `flutter test --no-pub test\\services\\growth_mission_service_test.dart`
- `python scripts/quality_gate.py --fast`
- pre-push full quality gate: flutter analyze, deno lint, dart format check, and 339 Flutter VM tests passed
