### PR TITLE
fix: omit invalid Hedra TTS model id

### DIFF
--- a/supabase/functions/viral-video-ad-generator/hedra_tts.test.ts
+++ b/supabase/functions/viral-video-ad-generator/hedra_tts.test.ts
@@ -64,6 +64,19 @@ Deno.test("Hedra TTS retry payload strips invalid model_id only from text_to_spe
   assertFalse("model_id" in strippedAudio);
 });
 
+Deno.test("Hedra TTS retry payload leaves non-TTS audio untouched", () => {
+  const body = {
+    type: "video",
+    audio_generation: {
+      type: "audio",
+      model_id: "d11481da-b973-4e72-ade0-7e8a86915bbf",
+      url: "https://example.com/audio.mp3",
+    },
+  };
+
+  assertEquals(stripHedraTextToSpeechModelId(body), body);
+});
+
 Deno.test("Hedra invalid text_to_speech model errors are recognized", () => {
   assert(
     isHedraInvalidTextToSpeechModelError(

--- a/supabase/functions/viral-video-ad-generator/hedra_tts.test.ts
+++ b/supabase/functions/viral-video-ad-generator/hedra_tts.test.ts
@@ -1,0 +1,75 @@
+import {
+  assert,
+  assertEquals,
+  assertFalse,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildHedraTextToSpeechAudioGeneration,
+  isHedraInvalidTextToSpeechModelError,
+  resolveConfiguredHedraTextToSpeechModelId,
+  stripHedraTextToSpeechModelId,
+} from "./hedra_tts.ts";
+
+Deno.test("Hedra TTS generation omits model_id when no override is configured", () => {
+  const audioGeneration = buildHedraTextToSpeechAudioGeneration({
+    voiceId: "voice-1",
+    modelId: null,
+    text: "Hello",
+    language: "english",
+  });
+
+  assertEquals(audioGeneration.type, "text_to_speech");
+  assertEquals(audioGeneration.voice_id, "voice-1");
+  assertFalse("model_id" in audioGeneration);
+});
+
+Deno.test("Hedra TTS generation includes valid configured model_id", () => {
+  const modelId = "d11481da-b973-4e72-ade0-7e8a86915bbf";
+  const audioGeneration = buildHedraTextToSpeechAudioGeneration({
+    voiceId: "voice-1",
+    modelId,
+    text: "Hello",
+    language: "english",
+  });
+
+  assertEquals(audioGeneration.model_id, modelId);
+});
+
+Deno.test("Hedra TTS configured model_id accepts only UUID values", () => {
+  assertEquals(
+    resolveConfiguredHedraTextToSpeechModelId(
+      "d11481da-b973-4e72-ade0-7e8a86915bbf",
+    ),
+    "d11481da-b973-4e72-ade0-7e8a86915bbf",
+  );
+  assertEquals(resolveConfiguredHedraTextToSpeechModelId("not-a-uuid"), null);
+  assertEquals(resolveConfiguredHedraTextToSpeechModelId("   "), null);
+});
+
+Deno.test("Hedra TTS retry payload strips invalid model_id only from text_to_speech audio", () => {
+  const body = {
+    type: "video",
+    audio_generation: {
+      type: "text_to_speech",
+      voice_id: "voice-1",
+      model_id: "d11481da-b973-4e72-ade0-7e8a86915bbf",
+      text: "Hello",
+    },
+  };
+
+  const stripped = stripHedraTextToSpeechModelId(body);
+  assertEquals(stripped["type"], "video");
+  const strippedAudio = stripped["audio_generation"] as Record<string, unknown>;
+  assertEquals(strippedAudio["voice_id"], "voice-1");
+  assertFalse("model_id" in strippedAudio);
+});
+
+Deno.test("Hedra invalid text_to_speech model errors are recognized", () => {
+  assert(
+    isHedraInvalidTextToSpeechModelError(
+      new Error(
+        'Hedra API 400: {"messages":["model d11481da-b973-4e72-ade0-7e8a86915bbf not valid for generation type text_to_speech"]}',
+      ),
+    ),
+  );
+});

--- a/supabase/functions/viral-video-ad-generator/hedra_tts.ts
+++ b/supabase/functions/viral-video-ad-generator/hedra_tts.ts
@@ -1,0 +1,84 @@
+export type HedraTextToSpeechAudioGeneration = {
+  type: "text_to_speech";
+  voice_id: string;
+  text: string;
+  stability: number;
+  speed: number;
+  language: string;
+  model_id?: string;
+};
+
+export function resolveConfiguredHedraTextToSpeechModelId(
+  configuredValue: string | null | undefined,
+): string | null {
+  const configured = firstNonEmptyString(configuredValue);
+  if (!configured) return null;
+  return isUuid(configured) ? configured : null;
+}
+
+export function buildHedraTextToSpeechAudioGeneration(params: {
+  voiceId: string;
+  modelId?: string | null;
+  text: string;
+  language: string;
+}): HedraTextToSpeechAudioGeneration {
+  const audioGeneration: HedraTextToSpeechAudioGeneration = {
+    type: "text_to_speech",
+    voice_id: params.voiceId,
+    text: params.text,
+    stability: 0.5,
+    speed: 1.0,
+    language: params.language,
+  };
+  if (params.modelId) {
+    audioGeneration.model_id = params.modelId;
+  }
+  return audioGeneration;
+}
+
+export function stripHedraTextToSpeechModelId(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const audioGeneration = asRecord(body["audio_generation"]);
+  if (
+    audioGeneration == null ||
+    audioGeneration["type"] !== "text_to_speech" ||
+    audioGeneration["model_id"] == null
+  ) {
+    return body;
+  }
+
+  const strippedAudioGeneration = { ...audioGeneration };
+  delete strippedAudioGeneration["model_id"];
+  return { ...body, audio_generation: strippedAudioGeneration };
+}
+
+export function isHedraInvalidTextToSpeechModelError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  return normalized.includes("not valid for generation type text_to_speech") ||
+    (normalized.includes("model") &&
+      normalized.includes("not valid") &&
+      normalized.includes("text_to_speech"));
+}
+
+function isUuid(value: string | null): boolean {
+  return value != null &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      .test(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function firstNonEmptyString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+}

--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -13,6 +13,12 @@
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import {
+  buildHedraTextToSpeechAudioGeneration,
+  isHedraInvalidTextToSpeechModelError,
+  resolveConfiguredHedraTextToSpeechModelId,
+  stripHedraTextToSpeechModelId,
+} from "./hedra_tts.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -495,7 +501,9 @@ async function createHedraPresenterVideo(params: {
     params.voice,
     params.lang,
   );
-  const ttsModelId = await resolveHedraTextToSpeechModelId(params.apiKey);
+  const ttsModelId = resolveConfiguredHedraTextToSpeechModelId(
+    HEDRA_TTS_MODEL_ID,
+  );
   const hedraLanguage = hedraLanguageForLang(params.lang);
   const ttsScript = scriptForHedraVoice(
     params.script,
@@ -503,33 +511,57 @@ async function createHedraPresenterVideo(params: {
     params.title,
   )
     .join("\n");
-  const payload = await hedraJsonRequest(params.apiKey, "/generations", {
-    method: "POST",
-    body: {
-      type: "video",
-      ai_model_id: HEDRA_AVATAR_MODEL_ID,
-      start_keyframe_url: imageUrl,
-      audio_generation: {
-        type: "text_to_speech",
-        voice_id: voiceId,
-        model_id: ttsModelId,
-        text: ttsScript.slice(0, 1800),
-        stability: 0.5,
-        speed: 1.0,
-        language: hedraLanguage,
-      },
-      generated_video_inputs: {
-        text_prompt: `${params.title ?? "Share update"}\n${params.prompt}`,
-        aspect_ratio: "16:9",
-        resolution: "540p",
-        enhance_prompt: true,
-      },
+  const generationBody: Record<string, unknown> = {
+    type: "video",
+    ai_model_id: HEDRA_AVATAR_MODEL_ID,
+    start_keyframe_url: imageUrl,
+    audio_generation: buildHedraTextToSpeechAudioGeneration({
+      voiceId,
+      modelId: ttsModelId,
+      text: ttsScript.slice(0, 1800),
+      language: hedraLanguage,
+    }),
+    generated_video_inputs: {
+      text_prompt: `${params.title ?? "Share update"}\n${params.prompt}`,
+      aspect_ratio: "16:9",
+      resolution: "540p",
+      enhance_prompt: true,
     },
-  });
+  };
+  const payload = await createHedraGenerationWithTtsModelFallback(
+    params.apiKey,
+    generationBody,
+    ttsModelId != null,
+  );
   return await pollHedraGeneration(
     params.apiKey,
     normalizeHedraVideoResponse(payload),
   );
+}
+
+async function createHedraGenerationWithTtsModelFallback(
+  apiKey: string,
+  body: Record<string, unknown>,
+  canRetryWithoutTtsModel: boolean,
+): Promise<unknown> {
+  try {
+    return await hedraJsonRequest(apiKey, "/generations", {
+      method: "POST",
+      body,
+    });
+  } catch (error) {
+    if (
+      !canRetryWithoutTtsModel ||
+      !isHedraInvalidTextToSpeechModelError(error)
+    ) {
+      throw error;
+    }
+
+    return await hedraJsonRequest(apiKey, "/generations", {
+      method: "POST",
+      body: stripHedraTextToSpeechModelId(body),
+    });
+  }
 }
 
 async function getHedraGenerationStatus(
@@ -607,72 +639,6 @@ async function resolveHedraVoiceId(
     throw new Error("Hedra voice_id could not be resolved");
   }
   return voiceId;
-}
-
-async function resolveHedraTextToSpeechModelId(
-  apiKey: string,
-): Promise<string> {
-  const configured = firstNonEmptyString(HEDRA_TTS_MODEL_ID);
-  if (configured) {
-    if (!isUuid(configured)) {
-      throw new Error("HEDRA_TTS_MODEL_ID must be a UUID");
-    }
-    return configured;
-  }
-
-  const targetedModels = await listHedraModels(apiKey, "text_to_speech");
-  const allModels = targetedModels.length > 0
-    ? targetedModels
-    : await listHedraModels(apiKey);
-  const ttsModel = allModels
-    .map((model) => asRecord(model))
-    .find((model) => isHedraTextToSpeechModel(model));
-  const modelId = firstNonEmptyString(ttsModel?.["id"]);
-  if (!modelId) {
-    throw new Error(
-      "Hedra text_to_speech model_id could not be resolved; set HEDRA_TTS_MODEL_ID",
-    );
-  }
-  return modelId;
-}
-
-async function listHedraModels(
-  apiKey: string,
-  type?: string,
-): Promise<unknown[]> {
-  const query = type == null ? "" : `?types=${encodeURIComponent(type)}`;
-  const payload = await hedraJsonRequest(apiKey, `/models${query}`, {
-    method: "GET",
-  });
-  if (Array.isArray(payload)) return payload;
-  const data = asRecord(payload)?.["data"];
-  return Array.isArray(data) ? data : [];
-}
-
-function isHedraTextToSpeechModel(
-  model: Record<string, unknown> | null,
-): boolean {
-  const id = firstNonEmptyString(model?.["id"]);
-  if (!id) return false;
-  const type = normalizeHedraModelType(model?.["type"]);
-  if (type === "text_to_speech" || type === "tts") return true;
-  const haystack = `${model?.["name"] ?? ""} ${model?.["description"] ?? ""}`
-    .toLowerCase();
-  return [
-    "text to speech",
-    "text-to-speech",
-    "tts",
-    "elevenlabs",
-    "minimax",
-    "voice",
-    "speech",
-  ].some((marker) => haystack.includes(marker));
-}
-
-function normalizeHedraModelType(value: unknown): string {
-  return typeof value === "string"
-    ? value.trim().toLowerCase().replaceAll("-", "_").replaceAll(" ", "_")
-    : "";
 }
 
 async function hedraJsonRequest(


### PR DESCRIPTION
## Summary
- Stop auto-selecting Hedra `/models` entries as TTS `model_id` values.
- Send `audio_generation.model_id` only when `HEDRA_TTS_MODEL_ID` is a valid UUID override.
- Retry Hedra generation once without `model_id` when the API rejects it for `text_to_speech`.
- Add Deno coverage for TTS payload building, UUID guard, retry stripping, and error detection.

## Minimal E2E Gate
- E2E-Exception: This is a server-side Edge Function provider payload fix; a browser Playwright or Flutter integration_test would not exercise Hedra without live credentials, so Deno tests are the minimal E2E-style mechanism for the input/output contract.
- The plan is implementation-detail independent at the provider boundary and intentionally minimal: three cases cover no configured model, valid configured model, and invalid Hedra text_to_speech model retry behavior.
- Mechanism: Deno Edge Function tests plus CI smoke; no `integration_test/` or `test/e2e/` file is added for this provider-only patch.

## High-Risk Ultrareview
- Review owner: Claude Code #1.
- High-risk-ultrareview-exception: Scoped Supabase Edge Function Hedra payload fallback only; no secrets, auth, RLS, storage policy, or data migration changes.
- Security: no new secret exposure and `HEDRA_TTS_MODEL_ID` remains optional/validated as UUID.
- Rollback: revert PR #2327 to restore the previous Hedra payload behavior.
- Data migration: none.
- Prod smoke: generate an AI share image, then trigger video generation and confirm Hedra accepts the text_to_speech request.
- Observability: existing Edge Function error response continues to surface Hedra API errors if the retry also fails.
- Unresolved findings: 0.

## Validation
- `deno lint --config supabase/functions/deno.json supabase/functions/viral-video-ad-generator`
- `deno test --allow-all --no-check --config supabase/functions/deno.json supabase/functions/viral-video-ad-generator`
- `deno check --config supabase/functions/deno.json supabase/functions/viral-video-ad-generator/index.ts supabase/functions/viral-video-ad-generator/hedra_tts.test.ts`
- `deno lint --config supabase/functions/deno.json supabase/functions/`
- `deno test --allow-all --no-check --config supabase/functions/deno.json supabase/functions/`