### PR TITLE
feat: surface competitive intel intake (#1660)

### DIFF
--- a/lib/widgets/competitor_monitoring_card.dart
+++ b/lib/widgets/competitor_monitoring_card.dart
@@ -1,6 +1,78 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+class CompetitiveIntelNotebook {
+  const CompetitiveIntelNotebook({
+    required this.shortId,
+    required this.title,
+    required this.route,
+    required this.issueNumber,
+    required this.sourcePolicy,
+    required this.evidence,
+    required this.primarySourceRequired,
+  });
+
+  final String shortId;
+  final String title;
+  final String route;
+  final int issueNumber;
+  final String sourcePolicy;
+  final String evidence;
+  final bool primarySourceRequired;
+}
+
+@visibleForTesting
+const competitiveIntelNotebookQueue = <CompetitiveIntelNotebook>[
+  CompetitiveIntelNotebook(
+    shortId: '0829f536',
+    title:
+        'Google I/O 2026: Strategic Defense and Competitive Analysis Briefing',
+    route: 'competitive-intel',
+    issueNumber: 1660,
+    sourcePolicy: 'routing_only',
+    evidence: 'docs/STRATEGIC_INTELLIGENCE_2026Q2.md section 3',
+    primarySourceRequired: true,
+  ),
+  CompetitiveIntelNotebook(
+    shortId: 'f167dcc3',
+    title: 'Competitive AI Intelligence Report: The Multi-Agent Convergence',
+    route: 'competitive-intel',
+    issueNumber: 1660,
+    sourcePolicy: 'routing_only',
+    evidence: 'docs/STRATEGIC_INTELLIGENCE_2026Q2.md section 1',
+    primarySourceRequired: true,
+  ),
+  CompetitiveIntelNotebook(
+    shortId: 'c60da02b',
+    title:
+        'Strategic Intelligence Scoreboard: May 2026 Competitive Analysis Summary',
+    route: 'competitive-intel',
+    issueNumber: 1660,
+    sourcePolicy: 'routing_only',
+    evidence: 'docs/STRATEGIC_INTELLIGENCE_2026Q2.md sections 1-3',
+    primarySourceRequired: true,
+  ),
+  CompetitiveIntelNotebook(
+    shortId: 'd83954af',
+    title: 'Competitor Discovery Report: April 2026 Status Update',
+    route: 'competitive-intel',
+    issueNumber: 1660,
+    sourcePolicy: 'routing_only',
+    evidence: 'docs/notebooklm-intake/latest-report.md',
+    primarySourceRequired: true,
+  ),
+  CompetitiveIntelNotebook(
+    shortId: '17cd45cd',
+    title:
+        'Competitive Intelligence Report: 2026 AI Infrastructure and Marketplace Trends',
+    route: 'competitive-intel',
+    issueNumber: 1660,
+    sourcePolicy: 'routing_only',
+    evidence: 'docs/STRATEGIC_INTELLIGENCE_2026Q2.md section 2',
+    primarySourceRequired: true,
+  ),
+];
+
 /// 管理者ダッシュボード用: 競合サイト可用性モニタリングカード。
 /// get-competitor-monitoring Edge Function からデータを取得して表示。
 class CompetitorMonitoringCard extends StatefulWidget {
@@ -138,29 +210,23 @@ class _CompetitorMonitoringCardState extends State<CompetitorMonitoringCard> {
                 ],
               ),
             ],
+            const SizedBox(height: 12),
+            _buildCompetitiveIntelQueue(),
             const SizedBox(height: 8),
             if (_error != null)
               Text(
                 _error!,
-                style: const TextStyle(
-                  color: Colors.red,
-                  height: 1.5,
-                ),
+                style: const TextStyle(color: Colors.red, height: 1.5),
               )
             else if (_loading && _competitors.isEmpty)
-              const SizedBox(
-                height: 40,
-              )
+              const SizedBox(height: 40)
             else if (_competitors.isEmpty)
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   const Text(
                     'データがありません。',
-                    style: TextStyle(
-                      color: Color(0xFFB0B0B0),
-                      height: 1.5,
-                    ),
+                    style: TextStyle(color: Color(0xFFB0B0B0), height: 1.5),
                   ),
                   const SizedBox(height: 8),
                   FilledButton.icon(
@@ -193,6 +259,110 @@ class _CompetitorMonitoringCardState extends State<CompetitorMonitoringCard> {
               ..._competitors.map(_buildRow),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildCompetitiveIntelQueue() {
+    final textTheme = Theme.of(context).textTheme;
+    const accent = Color(0xFF3D5AFE);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: accent.withValues(alpha: 0.22)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.policy, size: 16, color: accent),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  'NotebookLM competitive intake',
+                  style: textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              const _SourcePolicyChip(label: '#1660', color: accent),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Routing metadata only. Verify with primary or official sources before scoring, copy, or WBS priority changes.',
+            style: textTheme.bodySmall?.copyWith(
+              color: const Color(0xFFB0B0B0),
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (final notebook in competitiveIntelNotebookQueue)
+            _buildCompetitiveIntelNotebookRow(notebook),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCompetitiveIntelNotebookRow(
+    final CompetitiveIntelNotebook notebook,
+  ) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.18),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              notebook.shortId,
+              style: textTheme.labelSmall?.copyWith(
+                color: const Color(0xFFB8C4FF),
+                fontFeatures: const [FontFeature.tabularFigures()],
+                height: 1.2,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  notebook.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: textTheme.bodySmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  '${notebook.route} / ${notebook.sourcePolicy} / ${notebook.evidence}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: textTheme.labelSmall?.copyWith(
+                    color: const Color(0xFFB0B0B0),
+                    height: 1.3,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -253,6 +423,34 @@ class _CompetitorMonitoringCardState extends State<CompetitorMonitoringCard> {
     if (pct >= 90) return Colors.green;
     if (pct >= 70) return const Color(0xFFFF6B35);
     return Colors.red;
+  }
+}
+
+class _SourcePolicyChip extends StatelessWidget {
+  const _SourcePolicyChip({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.32)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          height: 1.2,
+        ),
+      ),
+    );
   }
 }
 

--- a/test/widgets/competitor_monitoring_card_test.dart
+++ b/test/widgets/competitor_monitoring_card_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/competitor_monitoring_card.dart';
+
+void main() {
+  test(
+    'competitive intel queue covers routed NotebookLM sources for #1660',
+    () {
+      final ids = competitiveIntelNotebookQueue
+          .map((final notebook) => notebook.shortId)
+          .toSet();
+
+      expect(
+        ids,
+        containsAll(<String>{
+          '0829f536',
+          'f167dcc3',
+          'c60da02b',
+          'd83954af',
+          '17cd45cd',
+        }),
+      );
+    },
+  );
+
+  test(
+    'competitive intel queue keeps NotebookLM claims in source policy hold',
+    () {
+      for (final notebook in competitiveIntelNotebookQueue) {
+        expect(notebook.issueNumber, 1660);
+        expect(notebook.route, 'competitive-intel');
+        expect(notebook.sourcePolicy, 'routing_only');
+        expect(notebook.primarySourceRequired, isTrue);
+        expect(notebook.evidence, isNot(contains('hold_for_source_policy')));
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Surface the #1660 NotebookLM competitive-intel queue inside the competitor monitoring card.
- Mark each notebook as routing-only source-policy metadata, with primary/official-source verification required before UI scoring, product copy, or WBS priority changes.
- Add a widget-level test for the routed NotebookLM IDs and source-policy guardrails.

## Minimal E2E Gate
- The E2E contract is implementation-detail independent / black-box: a user only needs to see the competitor monitoring card, the routed NotebookLM IDs, and the source-policy warning.
- Minimal plan: three I/O cases, covering card render, #1660 NotebookLM queue visibility, and source-policy guard visibility.
- E2E mechanism: Playwright or Flutter integration_test can cover this if the admin route is expanded in a follow-up.
- E2E-Exception: no new integration_test/ or test/e2e/ file is added because this PR is a static admin-card source-policy surface with no new navigation, backend mutation, or external I/O; widget tests plus the existing Public E2E stability smoke cover the scoped risk.

## Validation
- flutter analyze --no-pub lib\widgets\competitor_monitoring_card.dart test\widgets\competitor_monitoring_card_test.dart
- flutter test --no-pub test\widgets\competitor_monitoring_card_test.dart
- python scripts\notebooklm_intake_gate.py --input-json docs\notebooklm-intake\latest-snapshot.json --gh-dedup --print-only
- $env:PYTHONPATH=(Get-Location).Path; python test\scripts\test_notebooklm_intake_gate.py

Closes #1660