### PR TITLE
docs: add Codex UI QA playbook (#1646)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,23 @@
 
 ## Visual E2E Evidence
 
+- Reference: `docs/CODEX_UI_QA_PLAYBOOK.md`
 - [ ] Desktop and mobile Playwright evidence captured for landing/home/auth/notion-wbs/agent-org, or the current equivalent public routes.
 - [ ] Screenshots plus low-FPS frame sequence are attached in Playwright artifacts.
 - [ ] Console errors, page errors, request failures, and HTTP 5xx responses are reviewed.
 - [ ] `getAnimations()` wait path ran, or the fallback is documented in the PR.
 - [ ] Codex in-app browser or equivalent browser verification notes are included when UI changed.
+
+## Codex UI QA / Prototyping
+
+- [ ] Changed routes/surfaces are listed:
+- [ ] Codex in-app browser check is included for UI/layout/interaction changes, or this PR explains why it is not applicable.
+- [ ] Playwright command or artifact is listed, for example `npm run e2e:visual -- --project=chromium --project=mobile-chrome --workers=1`.
+- [ ] Desktop and mobile viewport findings are summarized.
+- [ ] Generated imagery status is recorded:
+  - [ ] No generated image was used.
+  - [ ] Generated image was used and the prompt, intended use, asset path, rights statement, and verification note are included.
+- [ ] Generated imagery is not being used as proof of the actual product state.
 
 ## 📝 変更内容
 <!-- このPRで実施した変更内容を簡潔に説明してください -->

--- a/docs/AI_FALLBACK_RUNBOOK.md
+++ b/docs/AI_FALLBACK_RUNBOOK.md
@@ -35,6 +35,11 @@ Official source pointers:
 
 Related ai-tool-update Issues: #1644, #1645, #1646, #1647, #1706.
 
+#1646 UI/browser QA and generated-image provenance are defined in
+`docs/CODEX_UI_QA_PLAYBOOK.md`. For UI PRs, Codex #1 must record route,
+viewport, screenshot/Playwright evidence, console/page/request review, and
+generated-image rights/provenance before marking the work review-ready.
+
 > 作成: 2026-04-24 (PS#6 S26)  
 > 目的: Claude Code quota 制限時に開発・自動化が完全停止しないための手順書
 

--- a/docs/CODEX_UI_QA_PLAYBOOK.md
+++ b/docs/CODEX_UI_QA_PLAYBOOK.md
@@ -1,0 +1,126 @@
+# Codex UI QA Playbook
+
+Issue: #1646  
+Owner lane: Codex #1 in the Windows app  
+Fleet rule: use only Claude Code #1 and Codex #1. Do not route this work to old Codex #2/#3 lanes.
+
+## Purpose
+
+Codex UI work must leave reviewable browser evidence, not only code diffs. This
+playbook turns in-app browser checks, Playwright visual evidence, console-error
+review, and image-generation provenance into a repeatable PR contract.
+
+Claude Code #1 owns product/design judgment when a visual decision changes the
+direction of the product. Codex #1 owns implementation, local browser
+verification, screenshots, and CI evidence.
+
+## UI PR Checklist
+
+Use this for any PR that changes `lib/`, `web/`, route behavior, visual assets,
+or user-visible copy.
+
+1. List the changed routes or surfaces in the PR body.
+2. Fill the Minimal E2E Gate section in `.github/PULL_REQUEST_TEMPLATE.md`.
+3. Fill the Visual E2E Evidence section in `.github/PULL_REQUEST_TEMPLATE.md`.
+4. Run targeted static checks for the touched stack.
+5. Capture browser evidence with Codex in-app browser, Playwright, or both.
+6. Record console/page errors, request failures, and HTTP 5xx findings.
+7. Attach or link screenshots, Playwright artifacts, or the exact reason the PR is documentation-only.
+8. If generated imagery is used, record the prompt, intended use, rights statement, and asset path.
+
+## Minimal Browser Evidence
+
+For user-facing UI changes, the minimum automated evidence is:
+
+- desktop viewport: `chromium` project, 1440 x 1000
+- mobile viewport: `mobile-chrome` project, Pixel 5 profile
+- screenshot: one stable screenshot per route and viewport
+- motion sanity: three low-FPS frames per route
+- browser issues: console errors, page errors, request failures, and HTTP 5xx responses
+- animation settling: `document.getAnimations({ subtree: true })` wait path or a documented fallback
+
+The current automation lives in:
+
+- `test/e2e/visual_evidence.spec.ts`
+- `test/e2e/public_smoke.spec.ts`
+- `.github/workflows/minimal-e2e-gate.yml`
+- `scripts/summarize_playwright_results.mjs`
+
+Run locally against production:
+
+```bash
+npm run e2e:visual -- --project=chromium --project=mobile-chrome --workers=1
+```
+
+Run locally against a dev server:
+
+```bash
+E2E_BASE_URL=http://127.0.0.1:3000 npm run e2e:visual -- --project=chromium --project=mobile-chrome --workers=1
+```
+
+If the UI route requires auth, seed data, or secrets unavailable in local
+browser automation, document the exception in the PR body and still include a
+Codex in-app browser or manual browser note for the reachable part of the flow.
+
+## Codex In-App Browser
+
+Use the Codex in-app browser when the PR changes layout, interaction,
+responsive behavior, or visible media.
+
+Record the route, viewport, and observation in the PR body:
+
+```text
+Codex browser evidence:
+- route: /example
+- viewport: desktop 1440x1000, mobile Pixel 5 equivalent
+- console/page errors: none observed
+- screenshots/artifacts: <link or artifact name>
+```
+
+The browser note is not a replacement for Playwright when the route is public
+and automatable. It is the extra human-in-the-loop check for framing,
+readability, interaction, and whether the result feels like the intended product.
+
+## Image Generation Policy
+
+Use generated bitmap images only when a raster asset is the correct artifact:
+
+- OGP cards, blog/social thumbnails, hero backgrounds, concept mockups, texture
+  studies, or illustrative product-state drafts
+- transparent-background cutouts or visual variants where the prompt and source
+  references can be recorded
+- temporary design exploration that is linked to a PR comment, docs note, or WBS task
+
+Prefer code, existing assets, SVG, or screenshots when the output should be
+deterministic:
+
+- app icons, logos, brand marks, buttons, badges, diagrams, charts, and
+  product UI primitives
+- screenshots used as evidence of the actual product state
+- branded/product/place/person imagery that must depict the real subject
+- legal, financial, medical, or compliance visuals where fidelity matters
+
+Every generated image used in a PR must include:
+
+- prompt or source reference
+- intended use
+- asset path or artifact link
+- rights statement: generated/owned/licensed, no third-party logo or trademark
+  claim unless explicitly permitted
+- verification note when it depicts a product, person, place, or branded object
+
+Generated imagery must not be used to imply an unverified real product state.
+If the image is only illustrative, label it as illustrative in the PR or docs.
+
+## Reviewable Output
+
+A UI/prototyping PR is complete when reviewers can answer these questions from
+the PR body and artifacts:
+
+- What changed for the user?
+- Which route and viewport were checked?
+- Were console/page/request failures reviewed?
+- What screenshots or Playwright artifacts prove the state?
+- Did generated imagery enter the product, and if so, where is its provenance?
+- Is the change connected to the relevant Issue or WBS task?
+

--- a/scripts/check_codex_ui_qa_playbook.py
+++ b/scripts/check_codex_ui_qa_playbook.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Validate the Codex UI QA playbook and PR-template hooks."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PLAYBOOK = Path("docs/CODEX_UI_QA_PLAYBOOK.md")
+PR_TEMPLATE = Path(".github/PULL_REQUEST_TEMPLATE.md")
+
+REQUIRED_PLAYBOOK_TERMS = (
+    "Issue: #1646",
+    "Claude Code #1",
+    "Codex #1",
+    "test/e2e/visual_evidence.spec.ts",
+    "test/e2e/public_smoke.spec.ts",
+    ".github/workflows/minimal-e2e-gate.yml",
+    "scripts/summarize_playwright_results.mjs",
+    "desktop viewport",
+    "mobile viewport",
+    "1440 x 1000",
+    "Pixel 5",
+    "console errors",
+    "page errors",
+    "request failures",
+    "HTTP 5xx",
+    "document.getAnimations",
+    "Codex in-app browser",
+    "prompt",
+    "intended use",
+    "asset path",
+    "rights statement",
+    "Generated imagery must not be used to imply an unverified real product state",
+)
+
+REQUIRED_TEMPLATE_TERMS = (
+    "docs/CODEX_UI_QA_PLAYBOOK.md",
+    "## Codex UI QA / Prototyping",
+    "Changed routes/surfaces",
+    "Codex in-app browser check",
+    "npm run e2e:visual",
+    "Desktop and mobile viewport findings",
+    "Generated imagery status",
+    "prompt, intended use, asset path, rights statement, and verification note",
+    "Generated imagery is not being used as proof of the actual product state",
+)
+
+
+def missing_terms(text: str, terms: tuple[str, ...]) -> list[str]:
+    return [term for term in terms if term not in text]
+
+
+def validate_repo(root: Path) -> list[str]:
+    failures: list[str] = []
+    for relative_path, terms in (
+        (PLAYBOOK, REQUIRED_PLAYBOOK_TERMS),
+        (PR_TEMPLATE, REQUIRED_TEMPLATE_TERMS),
+    ):
+        path = root / relative_path
+        if not path.exists():
+            failures.append(f"{relative_path}: file is missing")
+            continue
+        text = path.read_text(encoding="utf-8")
+        for term in missing_terms(text, terms):
+            failures.append(f"{relative_path}: missing required term: {term}")
+    return failures
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    failures = validate_repo(root)
+    if failures:
+        print("Codex UI QA playbook check: FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("Codex UI QA playbook check: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/check_codex_ui_qa_playbook_test.py
+++ b/scripts/check_codex_ui_qa_playbook_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from check_codex_ui_qa_playbook import (
+    REQUIRED_PLAYBOOK_TERMS,
+    REQUIRED_TEMPLATE_TERMS,
+    missing_terms,
+    validate_repo,
+)
+
+
+class CodexUiQaPlaybookTest(unittest.TestCase):
+    def test_repo_files_include_required_terms(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+
+        self.assertEqual(validate_repo(root), [])
+
+    def test_missing_terms_reports_absent_phrase(self) -> None:
+        self.assertEqual(
+            missing_terms("Codex in-app browser", ("Codex in-app browser", "HTTP 5xx")),
+            ["HTTP 5xx"],
+        )
+
+    def test_term_lists_cover_playbook_and_template_contracts(self) -> None:
+        self.assertIn("document.getAnimations", REQUIRED_PLAYBOOK_TERMS)
+        self.assertIn("rights statement", REQUIRED_PLAYBOOK_TERMS)
+        self.assertIn("npm run e2e:visual", REQUIRED_TEMPLATE_TERMS)
+        self.assertIn("Changed routes/surfaces", REQUIRED_TEMPLATE_TERMS)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -45,6 +45,10 @@ def base_commands() -> list[GateCommand]:
             [python, "scripts/check_minimal_e2e_gate_test.py"],
         ),
         GateCommand(
+            "codex ui qa playbook tests",
+            [python, "scripts/check_codex_ui_qa_playbook_test.py"],
+        ),
+        GateCommand(
             "no-verify bypass tests",
             [python, "scripts/check_no_verify_bypass_test.py"],
         ),


### PR DESCRIPTION
﻿## Summary
- Add `docs/CODEX_UI_QA_PLAYBOOK.md` for the #1646 Codex UI/browser QA and generated-image provenance contract.
- Connect the PR template to changed routes/surfaces, Codex in-app browser notes, desktop/mobile Playwright evidence, and generated imagery status.
- Add a lightweight Python guard plus unit tests, and wire it into the base `quality_gate.py` command list.

## Minimal E2E Gate
- Implementation-detail independent black-box I/O contract: this PR validates the review contract text, not Flutter internals.
- Minimal 3 cases: playbook required terms, PR template required terms, and missing-term failure behavior.
- E2E mechanism: existing Playwright visual evidence remains `test/e2e/visual_evidence.spec.ts` and `.github/workflows/minimal-e2e-gate.yml`; this PR documents and gates how Codex #1 must use it.
- E2E-Exception: docs/template/script-only PR; no app runtime or route behavior changed, so no new `integration_test/` or `test/e2e/` file is required.

## Codex UI QA / Prototyping
- Changed routes/surfaces are listed: none, documentation/template/tooling only.
- Codex in-app browser check is not applicable because there is no UI/layout/interaction runtime change.
- Playwright command or artifact is listed: existing reference command documented as `npm run e2e:visual -- --project=chromium --project=mobile-chrome --workers=1`.
- Desktop and mobile viewport findings are summarized: no runtime viewport change; the playbook requires desktop `chromium` 1440x1000 and mobile `mobile-chrome` Pixel 5 evidence for future UI PRs.
- Generated imagery status is recorded: no generated image was used.
- Generated imagery is not being used as proof of the actual product state.

## Validation
- `python scripts\check_codex_ui_qa_playbook.py`
- `python scripts\check_codex_ui_qa_playbook_test.py`
- `python scripts\check_minimal_e2e_gate_test.py`
- `git diff --check`

Closes #1646
