### PR TITLE
ci: add MCP container isolation smoke (#1645)

### DIFF
--- a/.github/workflows/mcp-container-isolation-smoke.yml
+++ b/.github/workflows/mcp-container-isolation-smoke.yml
@@ -1,0 +1,58 @@
+name: MCP Container Isolation Smoke
+
+on:
+  pull_request:
+    paths:
+      - "config/mcp-container-isolation.json"
+      - "docs/MCP_CONTAINER_ISOLATION_RUNBOOK.md"
+      - "docs/AGENT_TOOL_POLICY.md"
+      - "docs/automation/managed-mcp-access-control.md"
+      - "scripts/check_mcp_container_isolation.py"
+      - "scripts/check_mcp_container_isolation_test.py"
+      - "tools/mcp-container-isolation/**"
+      - ".github/workflows/mcp-container-isolation-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-container-isolation-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Validate and launch low-risk MCP PoC
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate isolation contract
+        run: python scripts/check_mcp_container_isolation.py
+
+      - name: Run isolation unit tests
+        run: python scripts/check_mcp_container_isolation_test.py
+
+      - name: Launch low-risk MCP container PoC
+        run: python scripts/check_mcp_container_isolation.py --run-docker --require-docker
+
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## MCP Container Isolation Smoke"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Contract | \`config/mcp-container-isolation.json\` |"
+            echo "| PoC | \`tools/mcp-container-isolation\` |"
+            echo "| High-risk gate | \`docs/AGENT_TOOL_POLICY.md\` |"
+            echo "| Docker launch | \`python scripts/check_mcp_container_isolation.py --run-docker --require-docker\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/config/mcp-container-isolation.json
+++ b/config/mcp-container-isolation.json
@@ -1,0 +1,253 @@
+{
+  "schemaVersion": 1,
+  "status": "active",
+  "issue": 1645,
+  "lastUpdated": "2026-05-11",
+  "ownerModel": {
+    "activeInstances": [
+      "Claude Code #1",
+      "Codex #1"
+    ],
+    "policyOwner": "Claude Code #1",
+    "implementationOwner": "Codex #1",
+    "notes": "Historical extra Codex routing is absorbed by Codex #1 under the current two-instance flow."
+  },
+  "policySources": [
+    "docs/AGENT_TOOL_POLICY.md",
+    "docs/automation/managed-mcp-access-control.md",
+    "config/managed-mcp.json"
+  ],
+  "defaultIsolationDecision": "container_or_deny",
+  "dynamicMcpFlow": [
+    {
+      "step": "discover",
+      "owner": "Codex #1",
+      "evidence": "Issue, PR, or runbook note records the requested tool and source."
+    },
+    {
+      "step": "classify",
+      "owner": "Codex #1",
+      "evidence": "Map requested scopes to read/suggest/create/update/delete/send/purchase/external_share plus managed-mcp high-risk scopes."
+    },
+    {
+      "step": "approve",
+      "owner": "Claude Code #1",
+      "evidence": "High-risk scopes require explicit CEO approval metadata before launch."
+    },
+    {
+      "step": "launch_isolated",
+      "owner": "Codex #1",
+      "evidence": "Prefer containerized MCP execution with least privilege, no host secrets, and no ambient writable mounts."
+    },
+    {
+      "step": "audit",
+      "owner": "Codex #1",
+      "evidence": "Record workflow run, issue comment, PR summary, or durable MCP audit row."
+    },
+    {
+      "step": "fallback",
+      "owner": "Codex #1",
+      "evidence": "Fail closed or use a read-only documented fallback when the isolated launch is unavailable."
+    }
+  ],
+  "highRiskApprovalGate": {
+    "policy": "docs/AGENT_TOOL_POLICY.md",
+    "requiredApproval": "CEO",
+    "failureMode": "fail_closed",
+    "scopes": [
+      "delete",
+      "send",
+      "purchase",
+      "external_share",
+      "credential_access",
+      "shell_execute",
+      "filesystem_write",
+      "production_write"
+    ]
+  },
+  "serverExecutionMatrix": [
+    {
+      "id": "context7-docs",
+      "managedMcpId": "context7",
+      "risk": "low",
+      "executionForm": "Docker MCP catalog read-only container preferred; hosted read-only connector fallback.",
+      "permissions": [
+        "read",
+        "suggest"
+      ],
+      "containerIsolation": {
+        "required": true,
+        "networkMode": "egress_public_docs_only",
+        "readOnlyRootFilesystem": true,
+        "runAsNonRoot": true,
+        "capDrop": [
+          "ALL"
+        ],
+        "secrets": [],
+        "ports": []
+      },
+      "auditLog": "Issue/PR note with package, documentation source, and lookup summary.",
+      "failureFallback": "Use checked-in docs or skip lookup; do not fall back to unregistered host shell execution.",
+      "approvalRequiredFor": [
+        "write",
+        "admin",
+        "external_share"
+      ],
+      "approvalGate": "docs/AGENT_TOOL_POLICY.md"
+    },
+    {
+      "id": "tools-hub-read-facade",
+      "managedMcpId": "tools-hub",
+      "risk": "medium",
+      "executionForm": "Supabase Edge Function MCP facade with container-smoke contract for local read-only MCP fixtures.",
+      "permissions": [
+        "read",
+        "suggest",
+        "create"
+      ],
+      "containerIsolation": {
+        "required": true,
+        "networkMode": "configured_service_endpoint_only",
+        "readOnlyRootFilesystem": true,
+        "runAsNonRoot": true,
+        "capDrop": [
+          "ALL"
+        ],
+        "secrets": [
+          "managed_ci_secret_only"
+        ],
+        "ports": []
+      },
+      "auditLog": "tools-hub MCP smoke workflow, schedule_task_runs row, and PR/issue validation note.",
+      "failureFallback": "Use tools-hub MCP smoke in GitHub Actions or leave feature_request.create disabled.",
+      "approvalRequiredFor": [
+        "send",
+        "delete",
+        "external_share",
+        "production_write"
+      ],
+      "approvalGate": "docs/AGENT_TOOL_POLICY.md"
+    },
+    {
+      "id": "playwright-browser",
+      "managedMcpId": "playwright",
+      "risk": "medium",
+      "executionForm": "Containerized browser session or in-app browser with no credential entry unless explicitly approved.",
+      "permissions": [
+        "read",
+        "suggest",
+        "browser_interact"
+      ],
+      "containerIsolation": {
+        "required": false,
+        "networkMode": "target_url_only",
+        "readOnlyRootFilesystem": false,
+        "runAsNonRoot": true,
+        "capDrop": [
+          "ALL"
+        ],
+        "secrets": [],
+        "ports": []
+      },
+      "auditLog": "Browser URL, screenshot or console evidence, and PR validation summary.",
+      "failureFallback": "Skip browser evidence and mark the validation gap in the PR when no isolated browser is available.",
+      "approvalRequiredFor": [
+        "credential_entry",
+        "purchase",
+        "external_share"
+      ],
+      "approvalGate": "docs/AGENT_TOOL_POLICY.md"
+    },
+    {
+      "id": "slack-gmail-outbound",
+      "managedMcpId": "slack,gmail",
+      "risk": "high",
+      "executionForm": "Read/draft connector only by default; outbound send is blocked until approval metadata is present.",
+      "permissions": [
+        "read",
+        "suggest",
+        "send",
+        "external_share"
+      ],
+      "containerIsolation": {
+        "required": true,
+        "networkMode": "connector_endpoint_only",
+        "readOnlyRootFilesystem": true,
+        "runAsNonRoot": true,
+        "capDrop": [
+          "ALL"
+        ],
+        "secrets": [
+          "managed_connector_token_only"
+        ],
+        "ports": []
+      },
+      "auditLog": "Permalink/thread reference, explicit user approval, and issue/PR note before any outbound action.",
+      "failureFallback": "Keep draft local and do not send.",
+      "approvalRequiredFor": [
+        "send",
+        "delete",
+        "external_share"
+      ],
+      "approvalGate": "docs/AGENT_TOOL_POLICY.md"
+    },
+    {
+      "id": "direct-production-db",
+      "managedMcpId": "direct-production-db",
+      "risk": "denied",
+      "executionForm": "Denied as direct MCP. Use reviewed Supabase scripts, GitHub Actions, or explicit runbook instead.",
+      "permissions": [
+        "credential_access",
+        "production_write"
+      ],
+      "containerIsolation": {
+        "required": false,
+        "networkMode": "none",
+        "readOnlyRootFilesystem": true,
+        "runAsNonRoot": true,
+        "capDrop": [
+          "ALL"
+        ],
+        "secrets": [],
+        "ports": []
+      },
+      "auditLog": "Denied request is recorded in issue/PR notes; no production credential is exposed to MCP.",
+      "failureFallback": "Fail closed.",
+      "approvalRequiredFor": [
+        "credential_access",
+        "production_write"
+      ],
+      "approvalGate": "docs/AGENT_TOOL_POLICY.md"
+    }
+  ],
+  "pocLaunch": {
+    "id": "low-risk-stdio-poc",
+    "risk": "low",
+    "executionForm": "Local stdio MCP fixture in Docker Compose.",
+    "permissions": [
+      "read"
+    ],
+    "composeFile": "tools/mcp-container-isolation/docker-compose.yml",
+    "dockerfile": "tools/mcp-container-isolation/Dockerfile",
+    "fixtureInput": "tools/mcp-container-isolation/fixtures/smoke.jsonl",
+    "networkMode": "none",
+    "readOnlyRootFilesystem": true,
+    "runAsNonRoot": true,
+    "capDrop": [
+      "ALL"
+    ],
+    "noNewPrivileges": true,
+    "ports": [],
+    "secrets": [],
+    "auditLog": "mcp-container-isolation-smoke workflow summary plus PR/issue comment.",
+    "fallback": "If Docker is unavailable locally, run the Python fixture directly and require GitHub Actions smoke after merge."
+  },
+  "validation": {
+    "checker": "scripts/check_mcp_container_isolation.py",
+    "workflow": ".github/workflows/mcp-container-isolation-smoke.yml",
+    "requiredLocalCommands": [
+      "python scripts/check_mcp_container_isolation.py",
+      "python scripts/check_mcp_container_isolation_test.py"
+    ]
+  }
+}

--- a/docs/AGENT_TOOL_POLICY.md
+++ b/docs/AGENT_TOOL_POLICY.md
@@ -78,3 +78,24 @@ entries must record a denial reason and review date.
 sessions warn on unmanaged servers, denied servers, expired or auth-required
 connectors, and dangerous permission settings. CI validates the JSON register
 without reading local secrets.
+
+## Containerized MCP / Dynamic MCP Isolation
+
+Issue #1645 adds the container isolation layer for MCP and Dynamic MCP style
+tool discovery:
+
+- isolation contract: `config/mcp-container-isolation.json`
+- runbook and execution matrix: `docs/MCP_CONTAINER_ISOLATION_RUNBOOK.md`
+- deterministic checker: `scripts/check_mcp_container_isolation.py`
+- low-risk stdio PoC: `tools/mcp-container-isolation/`
+
+Dynamic tool discovery does not weaken this policy. A discovered MCP server must
+still be recorded in the managed MCP register or treated as unmanaged, classified
+by requested scope, launched through an isolated container path when execution is
+needed, and audited in the PR, issue, workflow summary, or durable MCP log.
+
+`delete`, `send`, `purchase`, and `external_share` keep the existing fail-closed
+CEO approval requirement. The MCP isolation contract also treats
+`credential_access`, `shell_execute`, `filesystem_write`, and
+`production_write` as high-risk launch scopes. A container boundary is not an
+approval substitute for those scopes.

--- a/docs/MCP_CONTAINER_ISOLATION_RUNBOOK.md
+++ b/docs/MCP_CONTAINER_ISOLATION_RUNBOOK.md
@@ -1,0 +1,77 @@
+# MCP Container Isolation Runbook
+
+Status: active / 2026-05-11 / Issue #1645
+
+This runbook defines the Codex #1 implementation slice for Docker MCP Toolkit /
+Dynamic MCP isolation. It keeps the active execution model at Claude Code #1
+plus Codex #1 only, and treats historical extra Codex lanes as routing metadata.
+
+Docker documents MCP Catalog and Toolkit as the Docker Desktop path for browsing
+and running MCP servers, and Dynamic MCP as the catalog/gateway feature that can
+discover tools during a session:
+
+- https://docs.docker.com/ai/mcp-catalog-and-toolkit/
+- https://docs.docker.com/ai/mcp-catalog-and-toolkit/dynamic-mcp/
+
+## Execution Matrix
+
+| MCP server or lane | Execution form | Permissions | Audit log | Failure fallback |
+| --- | --- | --- | --- | --- |
+| `context7-docs` | Docker MCP catalog read-only container preferred; hosted read-only connector fallback. | `read`, `suggest` | Issue/PR note with package, docs source, and lookup summary. | Use checked-in docs or skip lookup; no unregistered host shell fallback. |
+| `tools-hub-read-facade` | Supabase Edge Function MCP facade with container-smoke contract for local read-only MCP fixtures. | `read`, `suggest`, `create` | tools-hub MCP smoke workflow, `schedule_task_runs`, and PR/issue validation note. | Use tools-hub MCP smoke in GitHub Actions or keep `feature_request.create` disabled. |
+| `playwright-browser` | Containerized browser session or in-app browser without credential entry unless approved. | `read`, `suggest`, `browser_interact` | Browser URL, screenshot or console evidence, and PR validation summary. | Skip browser evidence and state the validation gap when no isolated browser is available. |
+| `slack-gmail-outbound` | Read/draft connector by default; outbound send blocked until approval metadata exists. | `read`, `suggest`, `send`, `external_share` | Permalink/thread reference, explicit user approval, and issue/PR note. | Keep draft local and do not send. |
+| `direct-production-db` | Denied as direct MCP. Use reviewed Supabase scripts, GitHub Actions, or explicit runbook instead. | `credential_access`, `production_write` | Denied request recorded in issue/PR notes; no production credential exposed to MCP. | Fail closed. |
+
+The authoritative machine-readable contract is
+`config/mcp-container-isolation.json`.
+
+## Dynamic MCP Flow
+
+1. Discover the requested external tool from the issue, PR, or session prompt.
+2. Classify the requested scopes against `docs/AGENT_TOOL_POLICY.md` and
+   `config/managed-mcp.json`.
+3. Require CEO approval metadata for high-risk scopes before launch.
+4. Prefer isolated container execution with least privilege, no host secrets,
+   and no ambient writable mounts.
+5. Record workflow run, issue comment, PR summary, or durable MCP audit row.
+6. Fall back to read-only documented paths or fail closed.
+
+## Low-Risk PoC
+
+The PoC is `tools/mcp-container-isolation/mcp_stdio_ping.py`, a tiny read-only
+JSON-RPC stdio MCP fixture. It exposes one tool, `echo.ping`, and does not need
+network, secrets, ports, or writable host mounts.
+
+Local validation:
+
+```powershell
+python scripts/check_mcp_container_isolation.py
+python scripts/check_mcp_container_isolation_test.py
+```
+
+Docker launch when Docker is available:
+
+```powershell
+python scripts/check_mcp_container_isolation.py --run-docker --require-docker
+```
+
+The Docker Compose service enforces:
+
+- `network_mode: none`
+- `read_only: true`
+- `cap_drop: ALL`
+- `no-new-privileges:true`
+- no `ports`, no `volumes`, no compose `secrets`
+- non-root `USER mcp`
+
+## Approval Gate Compatibility
+
+The high-risk scopes `delete`, `send`, `purchase`, and `external_share` retain
+the existing fail-closed CEO approval gate from `docs/AGENT_TOOL_POLICY.md`.
+This runbook also treats `credential_access`, `shell_execute`,
+`filesystem_write`, and `production_write` as high-risk MCP launch scopes.
+
+`scripts/check_mcp_container_isolation.py` fails when a high-risk permission is
+listed without a matching `approvalRequiredFor` entry or when an entry bypasses
+the Agent Tool Policy gate.

--- a/docs/automation/managed-mcp-access-control.md
+++ b/docs/automation/managed-mcp-access-control.md
@@ -35,6 +35,19 @@ Slack, Google Drive, NotebookLM, and Context7. Related Google Calendar, Gmail,
 Playwright, Browser Use, Claude Memory, and local document runtimes are also
 recorded because they appear in the active Codex/Claude tool surface.
 
+Issue #1645 adds a companion isolation contract for external MCP execution:
+
+- `config/mcp-container-isolation.json` records the execution form,
+  permissions, audit log, and failure fallback for representative MCP lanes.
+- `docs/MCP_CONTAINER_ISOLATION_RUNBOOK.md` is the human-readable runbook.
+- `scripts/check_mcp_container_isolation.py` validates that high-risk scopes
+  still reference `docs/AGENT_TOOL_POLICY.md` and that the low-risk Docker PoC
+  has no network, ports, secrets, host volumes, or writable root filesystem.
+
+The managed register remains authoritative for allow/deny classification. The
+container contract describes how an approved or read-only lane should execute;
+it does not grant permission to use an unmanaged or denied server.
+
 ## Session-Start Gate
 
 `scripts/codex_session_check.py` now includes a Managed MCP Policy section. It

--- a/scripts/check_mcp_container_isolation.py
+++ b/scripts/check_mcp_container_isolation.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Validate the #1645 MCP container isolation contract and PoC smoke."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = REPO_ROOT / "config" / "mcp-container-isolation.json"
+REQUIRED_HIGH_RISK_SCOPES = {
+    "delete",
+    "send",
+    "purchase",
+    "external_share",
+    "credential_access",
+    "shell_execute",
+    "filesystem_write",
+    "production_write",
+}
+REQUIRED_FLOW_STEPS = {
+    "discover",
+    "classify",
+    "approve",
+    "launch_isolated",
+    "audit",
+    "fallback",
+}
+ALLOWED_RISKS = {"low", "medium", "high", "denied"}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def string_list(value: Any, *, allow_empty: bool = False) -> bool:
+    return isinstance(value, list) and (allow_empty or bool(value)) and all(
+        isinstance(item, str) for item in value
+    )
+
+
+def repo_path(root: Path, relative_path: str) -> Path:
+    path = Path(relative_path)
+    if path.is_absolute():
+        raise ValueError(f"path must be relative to repo root: {relative_path}")
+    return root / path
+
+
+def lower_set(value: Any) -> set[str]:
+    if not isinstance(value, list):
+        return set()
+    return {str(item).strip().lower() for item in value}
+
+
+def validate_compose_contract(compose_text: str) -> list[str]:
+    errors: list[str] = []
+    normalized = compose_text.lower().replace("'", '"')
+    if 'network_mode: "none"' not in normalized and "network_mode: none" not in normalized:
+        errors.append("docker-compose.yml must set network_mode: none.")
+    if "read_only: true" not in normalized:
+        errors.append("docker-compose.yml must set read_only: true.")
+    if "cap_drop:" not in normalized or "- all" not in normalized:
+        errors.append("docker-compose.yml must drop all Linux capabilities.")
+    if "no-new-privileges:true" not in normalized:
+        errors.append("docker-compose.yml must set no-new-privileges:true.")
+
+    forbidden = {
+        "privileged: true": "privileged containers are not allowed.",
+        "network_mode: host": "host networking is not allowed.",
+        "ports:": "published ports are not allowed for the stdio PoC.",
+        "volumes:": "host volumes are not allowed for the stdio PoC.",
+        "secrets:": "compose secrets are not allowed for the low-risk PoC.",
+    }
+    for marker, message in forbidden.items():
+        if marker in normalized:
+            errors.append(message)
+    return errors
+
+
+def validate_dockerfile_contract(dockerfile_text: str) -> list[str]:
+    errors: list[str] = []
+    normalized = dockerfile_text.lower()
+    if "user mcp" not in normalized:
+        errors.append("Dockerfile must switch to the non-root mcp user.")
+    if "user root" in normalized:
+        errors.append("Dockerfile must not switch back to root.")
+    if "expose " in normalized:
+        errors.append("Dockerfile must not expose ports for the stdio PoC.")
+    if "add http://" in normalized or "add https://" in normalized:
+        errors.append("Dockerfile must not fetch remote URLs with ADD.")
+    return errors
+
+
+def validate_contract(root: Path, contract: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    if contract.get("schemaVersion") != 1:
+        errors.append("schemaVersion must be 1.")
+    if contract.get("status") != "active":
+        errors.append("status must be active.")
+    if contract.get("issue") != 1645:
+        errors.append("issue must be 1645.")
+    if contract.get("defaultIsolationDecision") != "container_or_deny":
+        errors.append("defaultIsolationDecision must be container_or_deny.")
+
+    owner = contract.get("ownerModel")
+    if not isinstance(owner, dict):
+        errors.append("ownerModel must be an object.")
+    elif owner.get("activeInstances") != ["Claude Code #1", "Codex #1"]:
+        errors.append("ownerModel.activeInstances must be Claude Code #1 + Codex #1 only.")
+
+    gate = contract.get("highRiskApprovalGate")
+    if not isinstance(gate, dict):
+        errors.append("highRiskApprovalGate must be an object.")
+        gate_policy = ""
+        gate_scopes: set[str] = set()
+    else:
+        gate_policy = str(gate.get("policy", ""))
+        gate_scopes = lower_set(gate.get("scopes"))
+        if gate_policy != "docs/AGENT_TOOL_POLICY.md":
+            errors.append("highRiskApprovalGate.policy must point to docs/AGENT_TOOL_POLICY.md.")
+        if str(gate.get("requiredApproval", "")).lower() != "ceo":
+            errors.append("highRiskApprovalGate.requiredApproval must be CEO.")
+        if gate.get("failureMode") != "fail_closed":
+            errors.append("highRiskApprovalGate.failureMode must be fail_closed.")
+        missing = sorted(REQUIRED_HIGH_RISK_SCOPES - gate_scopes)
+        if missing:
+            errors.append("highRiskApprovalGate.scopes missing: " + ", ".join(missing) + ".")
+
+    steps = {
+        str(item.get("step", ""))
+        for item in contract.get("dynamicMcpFlow", [])
+        if isinstance(item, dict)
+    }
+    missing_steps = sorted(REQUIRED_FLOW_STEPS - steps)
+    if missing_steps:
+        errors.append("dynamicMcpFlow missing steps: " + ", ".join(missing_steps) + ".")
+
+    matrix = contract.get("serverExecutionMatrix")
+    if not isinstance(matrix, list) or not matrix:
+        errors.append("serverExecutionMatrix must be a non-empty list.")
+        matrix = []
+
+    for index, entry in enumerate(matrix):
+        if not isinstance(entry, dict):
+            errors.append(f"serverExecutionMatrix[{index}] must be an object.")
+            continue
+        entry_id = str(entry.get("id", f"<index {index}>"))
+        for field in (
+            "managedMcpId",
+            "risk",
+            "executionForm",
+            "permissions",
+            "containerIsolation",
+            "auditLog",
+            "failureFallback",
+            "approvalRequiredFor",
+            "approvalGate",
+        ):
+            if field not in entry:
+                errors.append(f"{entry_id}: missing {field}.")
+
+        risk = str(entry.get("risk", "")).lower()
+        if risk not in ALLOWED_RISKS:
+            errors.append(f"{entry_id}: risk must be one of {', '.join(sorted(ALLOWED_RISKS))}.")
+
+        permissions = lower_set(entry.get("permissions"))
+        approvals = lower_set(entry.get("approvalRequiredFor"))
+        if not string_list(entry.get("permissions")):
+            errors.append(f"{entry_id}: permissions must be a non-empty string list.")
+        if not string_list(entry.get("approvalRequiredFor")):
+            errors.append(f"{entry_id}: approvalRequiredFor must be a non-empty string list.")
+        if not str(entry.get("auditLog", "")).strip():
+            errors.append(f"{entry_id}: auditLog must be non-empty.")
+        if not str(entry.get("failureFallback", "")).strip():
+            errors.append(f"{entry_id}: failureFallback must be non-empty.")
+
+        isolation = entry.get("containerIsolation")
+        if not isinstance(isolation, dict):
+            errors.append(f"{entry_id}: containerIsolation must be an object.")
+        else:
+            if not string_list(isolation.get("capDrop")) or "ALL" not in isolation.get("capDrop", []):
+                errors.append(f"{entry_id}: containerIsolation.capDrop must include ALL.")
+            if not isinstance(isolation.get("readOnlyRootFilesystem"), bool):
+                errors.append(f"{entry_id}: readOnlyRootFilesystem must be boolean.")
+            if not isinstance(isolation.get("runAsNonRoot"), bool):
+                errors.append(f"{entry_id}: runAsNonRoot must be boolean.")
+            if not isinstance(isolation.get("secrets"), list):
+                errors.append(f"{entry_id}: containerIsolation.secrets must be a list.")
+            if isolation.get("ports") != []:
+                errors.append(f"{entry_id}: containerIsolation.ports must be empty.")
+
+        high_scope_mentions = (permissions | approvals) & REQUIRED_HIGH_RISK_SCOPES
+        if risk == "low" and permissions & REQUIRED_HIGH_RISK_SCOPES:
+            errors.append(f"{entry_id}: low-risk entries cannot request high-risk permissions.")
+        if risk in {"high", "denied"} or high_scope_mentions:
+            if entry.get("approvalGate") != gate_policy:
+                errors.append(f"{entry_id}: high-risk scopes must reference {gate_policy}.")
+            missing_approvals = sorted((permissions & REQUIRED_HIGH_RISK_SCOPES) - approvals)
+            if missing_approvals:
+                errors.append(
+                    f"{entry_id}: high-risk permissions missing approvalRequiredFor: "
+                    + ", ".join(missing_approvals)
+                    + "."
+                )
+
+    poc = contract.get("pocLaunch")
+    if not isinstance(poc, dict):
+        errors.append("pocLaunch must be an object.")
+        return errors
+
+    if poc.get("risk") != "low":
+        errors.append("pocLaunch.risk must be low.")
+    if poc.get("networkMode") != "none":
+        errors.append("pocLaunch.networkMode must be none.")
+    if poc.get("readOnlyRootFilesystem") is not True:
+        errors.append("pocLaunch.readOnlyRootFilesystem must be true.")
+    if poc.get("runAsNonRoot") is not True:
+        errors.append("pocLaunch.runAsNonRoot must be true.")
+    if poc.get("noNewPrivileges") is not True:
+        errors.append("pocLaunch.noNewPrivileges must be true.")
+    if "ALL" not in poc.get("capDrop", []):
+        errors.append("pocLaunch.capDrop must include ALL.")
+    if poc.get("ports") != []:
+        errors.append("pocLaunch.ports must be empty.")
+    if poc.get("secrets") != []:
+        errors.append("pocLaunch.secrets must be empty.")
+    if not str(poc.get("auditLog", "")).strip():
+        errors.append("pocLaunch.auditLog must be non-empty.")
+
+    for field in ("composeFile", "dockerfile", "fixtureInput"):
+        value = poc.get(field)
+        if not isinstance(value, str) or not value:
+            errors.append(f"pocLaunch.{field} must be a relative path.")
+            continue
+        try:
+            path = repo_path(root, value)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        if not path.exists():
+            errors.append(f"pocLaunch.{field} does not exist: {value}.")
+
+    compose_file = poc.get("composeFile")
+    if isinstance(compose_file, str):
+        path = repo_path(root, compose_file)
+        if path.exists():
+            errors.extend(validate_compose_contract(path.read_text(encoding="utf-8")))
+
+    dockerfile = poc.get("dockerfile")
+    if isinstance(dockerfile, str):
+        path = repo_path(root, dockerfile)
+        if path.exists():
+            errors.extend(validate_dockerfile_contract(path.read_text(encoding="utf-8")))
+
+    raw_contract = json.dumps(contract, ensure_ascii=False)
+    if "Codex #2" in raw_contract or "Codex #3" in raw_contract:
+        errors.append("contract must not assign active work to Codex #2 or Codex #3.")
+
+    return errors
+
+
+def direct_smoke(root: Path, contract: dict[str, Any]) -> list[str]:
+    poc = contract.get("pocLaunch", {})
+    if not isinstance(poc, dict):
+        return ["pocLaunch must be valid before direct smoke."]
+    fixture = repo_path(root, str(poc.get("fixtureInput", "")))
+    server = root / "tools" / "mcp-container-isolation" / "mcp_stdio_ping.py"
+    if not fixture.exists() or not server.exists():
+        return ["direct smoke fixture or server is missing."]
+
+    proc = subprocess.run(
+        [sys.executable, str(server)],
+        input=fixture.read_text(encoding="utf-8"),
+        text=True,
+        cwd=root,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return [f"direct stdio smoke failed with exit {proc.returncode}: {proc.stderr.strip()}"]
+
+    responses: list[dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        try:
+            responses.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            return [f"direct stdio smoke emitted invalid JSON: {exc}"]
+
+    tools_response = next((item for item in responses if item.get("id") == "tools"), None)
+    if not tools_response:
+        return ["direct stdio smoke did not return a tools/list response."]
+    tools = tools_response.get("result", {}).get("tools", [])
+    tool_names = {item.get("name") for item in tools if isinstance(item, dict)}
+    if "echo.ping" not in tool_names:
+        return ["direct stdio smoke did not expose echo.ping."]
+
+    call_response = next((item for item in responses if item.get("id") == "call"), None)
+    content = call_response.get("result", {}).get("content", []) if isinstance(call_response, dict) else []
+    texts = [str(item.get("text", "")) for item in content if isinstance(item, dict)]
+    if not any("container-isolated" in text for text in texts):
+        return ["direct stdio smoke did not echo the container-isolated payload."]
+    return []
+
+
+def docker_smoke(root: Path, contract: dict[str, Any], *, require_docker: bool) -> tuple[list[str], list[str]]:
+    docker = shutil.which("docker")
+    if docker is None:
+        message = "docker command is not available; Docker launch smoke skipped locally."
+        return ([message] if require_docker else []), ([] if require_docker else [message])
+
+    poc = contract.get("pocLaunch", {})
+    if not isinstance(poc, dict):
+        return (["pocLaunch must be valid before Docker smoke."], [])
+
+    compose = repo_path(root, str(poc.get("composeFile", "")))
+    fixture = repo_path(root, str(poc.get("fixtureInput", "")))
+    compose_args = [docker, "compose", "-f", str(compose)]
+
+    build = subprocess.run(
+        [*compose_args, "build"],
+        cwd=compose.parent,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if build.returncode != 0:
+        return ([f"Docker compose build failed with exit {build.returncode}: {build.stderr.strip()}"], [])
+
+    run = subprocess.run(
+        [*compose_args, "run", "--rm", "-T", "mcp-low-risk-poc"],
+        cwd=compose.parent,
+        input=fixture.read_text(encoding="utf-8"),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if run.returncode != 0:
+        return ([f"Docker compose run failed with exit {run.returncode}: {run.stderr.strip()}"], [])
+    if "container-isolated" not in run.stdout:
+        return (["Docker compose run did not echo the container-isolated payload."], [])
+    return ([], ["Docker launch smoke passed."])
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--skip-direct-smoke", action="store_true")
+    parser.add_argument("--run-docker", action="store_true")
+    parser.add_argument("--require-docker", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
+    args = parse_args(argv)
+    root = REPO_ROOT
+    contract = load_json(args.config)
+    errors = validate_contract(root, contract)
+    warnings: list[str] = []
+
+    if not args.skip_direct_smoke:
+        errors.extend(direct_smoke(root, contract))
+
+    if args.run_docker:
+        docker_errors, docker_warnings = docker_smoke(root, contract, require_docker=args.require_docker)
+        errors.extend(docker_errors)
+        warnings.extend(docker_warnings)
+
+    report = {
+        "config": str(args.config),
+        "valid": not errors,
+        "warnings": warnings,
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print("MCP container isolation: " + ("PASS" if not errors else "FAIL"))
+        for warning in warnings:
+            print(f"warning: {warning}")
+        for error in errors:
+            print(f"error: {error}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_mcp_container_isolation_test.py
+++ b/scripts/check_mcp_container_isolation_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import unittest
+
+from check_mcp_container_isolation import (
+    DEFAULT_CONFIG,
+    direct_smoke,
+    load_json,
+    validate_compose_contract,
+    validate_contract,
+    validate_dockerfile_contract,
+    REPO_ROOT,
+)
+
+
+class McpContainerIsolationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.contract = load_json(DEFAULT_CONFIG)
+
+    def test_repo_contract_validates(self) -> None:
+        self.assertEqual(validate_contract(REPO_ROOT, self.contract), [])
+
+    def test_direct_stdio_smoke_exposes_read_only_tool(self) -> None:
+        self.assertEqual(direct_smoke(REPO_ROOT, self.contract), [])
+
+    def test_high_risk_permission_requires_matching_approval(self) -> None:
+        broken = copy.deepcopy(self.contract)
+        for entry in broken["serverExecutionMatrix"]:
+            if entry["id"] == "slack-gmail-outbound":
+                entry["approvalRequiredFor"] = ["delete"]
+
+        errors = validate_contract(REPO_ROOT, broken)
+
+        self.assertTrue(any("send" in error and "external_share" in error for error in errors), errors)
+
+    def test_low_risk_entry_cannot_request_send_scope(self) -> None:
+        broken = copy.deepcopy(self.contract)
+        broken["serverExecutionMatrix"][0]["permissions"].append("send")
+
+        errors = validate_contract(REPO_ROOT, broken)
+
+        self.assertTrue(any("low-risk entries" in error for error in errors), errors)
+
+    def test_compose_contract_rejects_host_network_and_ports(self) -> None:
+        errors = validate_compose_contract(
+            """
+            services:
+              mcp:
+                network_mode: host
+                read_only: true
+                cap_drop:
+                  - ALL
+                security_opt:
+                  - no-new-privileges:true
+                ports:
+                  - "8080:8080"
+            """
+        )
+
+        self.assertTrue(any("host networking" in error for error in errors), errors)
+        self.assertTrue(any("published ports" in error for error in errors), errors)
+
+    def test_dockerfile_contract_rejects_root_and_expose(self) -> None:
+        errors = validate_dockerfile_contract(
+            """
+            FROM python:3.12-alpine
+            USER root
+            EXPOSE 8080
+            """
+        )
+
+        self.assertTrue(any("root" in error for error in errors), errors)
+        self.assertTrue(any("expose" in error.lower() for error in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -53,6 +53,14 @@ def base_commands() -> list[GateCommand]:
             [python, "scripts/context_injection_check_test.py"],
         ),
         GateCommand(
+            "mcp container isolation contract",
+            [python, "scripts/check_mcp_container_isolation.py"],
+        ),
+        GateCommand(
+            "mcp container isolation tests",
+            [python, "scripts/check_mcp_container_isolation_test.py"],
+        ),
+        GateCommand(
             "no-verify bypass tests",
             [python, "scripts/check_no_verify_bypass_test.py"],
         ),

--- a/tools/mcp-container-isolation/Dockerfile
+++ b/tools/mcp-container-isolation/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-alpine
+
+RUN addgroup -S mcp && adduser -S -G mcp -h /app mcp
+WORKDIR /app
+
+COPY mcp_stdio_ping.py /app/mcp_stdio_ping.py
+RUN chmod 0555 /app/mcp_stdio_ping.py
+
+USER mcp
+ENTRYPOINT ["python", "/app/mcp_stdio_ping.py"]

--- a/tools/mcp-container-isolation/README.md
+++ b/tools/mcp-container-isolation/README.md
@@ -1,0 +1,23 @@
+# MCP Container Isolation PoC
+
+Issue #1645 uses this low-risk stdio MCP fixture to prove that an MCP server can
+launch without host network access, host secrets, published ports, or writable
+root filesystem assumptions.
+
+Local contract validation:
+
+```powershell
+python scripts/check_mcp_container_isolation.py
+python scripts/check_mcp_container_isolation_test.py
+```
+
+Docker launch smoke when Docker is available:
+
+```powershell
+python scripts/check_mcp_container_isolation.py --run-docker --require-docker
+```
+
+The Docker path builds `mcp-low-risk-poc` and sends
+`tools/mcp-container-isolation/fixtures/smoke.jsonl` to the container over
+stdio. The service uses `network_mode: none`, `read_only: true`, drops all
+Linux capabilities, and has no ports or host credential mounts.

--- a/tools/mcp-container-isolation/docker-compose.yml
+++ b/tools/mcp-container-isolation/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  mcp-low-risk-poc:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: my-web-app/mcp-low-risk-poc:1645
+    network_mode: "none"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=16m
+    environment:
+      MCP_SERVER_ID: low-risk-stdio-poc
+      MCP_AUDIT_HINT: issue-1645
+    stdin_open: true
+    tty: false

--- a/tools/mcp-container-isolation/fixtures/smoke.jsonl
+++ b/tools/mcp-container-isolation/fixtures/smoke.jsonl
@@ -1,0 +1,3 @@
+{"jsonrpc":"2.0","id":"init","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mcp-container-isolation-smoke","version":"1.0.0"}}}
+{"jsonrpc":"2.0","id":"tools","method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":"call","method":"tools/call","params":{"name":"echo.ping","arguments":{"message":"container-isolated"}}}

--- a/tools/mcp-container-isolation/mcp_stdio_ping.py
+++ b/tools/mcp-container-isolation/mcp_stdio_ping.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Tiny read-only JSON-RPC stdio fixture for the MCP isolation smoke."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+
+SERVER_ID = os.environ.get("MCP_SERVER_ID", "low-risk-stdio-poc")
+
+
+def response(request_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def error(request_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+
+
+def handle(message: dict[str, Any]) -> dict[str, Any]:
+    method = str(message.get("method", ""))
+    request_id = message.get("id")
+
+    if method == "initialize":
+        return response(
+            request_id,
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_ID, "version": "1.0.0"},
+            },
+        )
+
+    if method == "tools/list":
+        return response(
+            request_id,
+            {
+                "tools": [
+                    {
+                        "name": "echo.ping",
+                        "description": "Read-only smoke tool for container isolation.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {"type": "string"},
+                            },
+                            "additionalProperties": False,
+                        },
+                    }
+                ]
+            },
+        )
+
+    if method == "tools/call":
+        params = message.get("params") if isinstance(message.get("params"), dict) else {}
+        if params.get("name") != "echo.ping":
+            return error(request_id, -32602, "unknown tool")
+        arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
+        text = str(arguments.get("message", "pong"))
+        return response(
+            request_id,
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"{SERVER_ID}: {text}",
+                    }
+                ],
+                "isError": False,
+            },
+        )
+
+    return error(request_id, -32601, f"unsupported method: {method}")
+
+
+def main() -> int:
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(json.dumps(error(None, -32700, f"parse error: {exc}")), flush=True)
+            continue
+        print(json.dumps(handle(message), separators=(",", ":")), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary

- Add `config/mcp-container-isolation.json` plus `docs/MCP_CONTAINER_ISOLATION_RUNBOOK.md` for the #1645 MCP execution-form / permission / audit / fallback matrix.
- Add a low-risk stdio MCP PoC under `tools/mcp-container-isolation/` with Docker Compose isolation settings: no network, read-only root filesystem, no ports, no host volumes, no compose secrets, dropped capabilities, and non-root user.
- Add `scripts/check_mcp_container_isolation.py`, unit tests, quality-gate wiring, and a `MCP Container Isolation Smoke` workflow that can launch the PoC in GitHub Actions.

## Issue #1645 Acceptance Mapping

- Execution matrix: covered by the JSON contract and runbook table for Context7, tools-hub, browser, outbound SaaS, and direct production DB lanes.
- Low-risk MCP container PoC: covered by `tools/mcp-container-isolation/` and `python scripts/check_mcp_container_isolation.py --run-docker --require-docker` in the new workflow.
- High-risk scopes: `delete`, `send`, `purchase`, `external_share`, plus MCP launch risks such as `credential_access`, `shell_execute`, `filesystem_write`, and `production_write`, all remain tied to `docs/AGENT_TOOL_POLICY.md` and fail closed.

## High-risk Ultrareview Gate

- Active instances: Claude Code #1 + Codex #1 only; old Codex lanes are not assigned active work.
- Risk surface: policy/docs/CI only; no secrets, migrations, production data, or outbound SaaS writes.
- Security: improves least-privilege MCP execution by requiring no-network/no-port/no-secret low-risk PoC defaults and preserving fail-closed approval gates.
- Data migration: none. This PR does not add or modify Supabase migrations, database schemas, or production data paths.
- Prod smoke: standard deploy-prod after merge plus the new MCP Container Isolation Smoke workflow to confirm the low-risk Docker launch path.
- Approval model: container isolation is not an approval substitute; high-risk scopes still require CEO approval metadata.
- Rollback: revert this PR to remove the contract, workflow, and PoC files.
- Observability: PR checks, workflow summary, issue comment, and WBS sync after merge.
- No unresolved ultrareview findings. Unresolved findings: 0.
- Residual risk: local Windows Docker CLI is unavailable in this session, so local Docker launch is skipped; the GitHub Actions smoke is the container launch confirmation.

## Minimal E2E Gate

The implementation-detail independent behavior is: a low-risk MCP server can be validated and launched through an isolated container contract, while high-risk MCP requests remain blocked unless explicit approval metadata exists. The checker validates the contract, runs the stdio tool exchange directly, and the workflow runs the Docker launch path.

## Validation

- `python scripts/check_mcp_container_isolation.py`
- `python scripts/check_mcp_container_isolation_test.py`
- `python scripts/check_github_actions_node_runtime.py`
- `python scripts/check_managed_mcp_policy.py --config config/managed-mcp.json`
- `python scripts/check_managed_mcp_policy_test.py`
- `python scripts/check_minimal_e2e_gate_test.py`
- `python scripts/check_codex_ui_qa_playbook_test.py`
- `python scripts/context_injection_check_test.py`
- `python scripts/check_no_verify_bypass_test.py`
- `python scripts/no_verify_sentinel_test.py`
- `python scripts/check_wbs_sync_timeout_resilience.py`
- `python scripts/check_edge_function_imports.py`
- `python scripts/quality_gate.py --fast`
- `python scripts/check_mcp_container_isolation.py --run-docker --json` passed with warning: Docker command is unavailable locally.
- `git diff --check`

Closes #1645.

