### PR TITLE
[codex] prioritize additional request WBS schedule

### DIFF
--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -9,6 +9,8 @@ import 'package:url_launcher/url_launcher.dart';
 import '../utils/web_image_downloader.dart';
 
 const String _kGithubRepoUrl = 'https://github.com/kanta13jp1/my_web_app';
+const String _kAdditionalRequestText = '\u8ffd\u52a0\u8981\u671b';
+const String _kUserRequestCategoryText = '\u30e6\u30fc\u30b6\u30fc\u8981\u671b';
 final RegExp _kIssueNumberRegex = RegExp(
   r'github\.com\/[^\/\s]+\/[^\/\s]+\/issues\/(\d+)|(?:^|[\s\[(])(?:github\s+)?issue\s*#\s*(\d+)\]?',
   caseSensitive: false,
@@ -385,7 +387,9 @@ class WbsTask {
       activeInstanceKey == key || activeOwnerKey == key;
 
   bool get isFeatureRequestTask =>
-      category == 'ユーザー要望' || title.startsWith('[追加要望]');
+      category == _kUserRequestCategoryText ||
+      category.contains(_kAdditionalRequestText) ||
+      title.contains(_kAdditionalRequestText);
 
   int get priorityRank => switch (priority) {
         'high' => 3,

--- a/supabase/functions/_shared/mcp_my_web_app_tools.ts
+++ b/supabase/functions/_shared/mcp_my_web_app_tools.ts
@@ -166,13 +166,14 @@ export function buildMcpFeatureRequestPayload(
   const description = String(body.description ?? "").trim();
   const sourceNote =
     "Created via MCP facade; requires product review before broad rollout.";
+  const today = new Date().toISOString().slice(0, 10);
 
   return {
     ok: true,
     payload: {
       category: String(body.category ?? "ユーザー要望"),
       category_icon: String(body.category_icon ?? "🧩"),
-      category_order: Number(body.category_order ?? 30),
+      category_order: Number(body.category_order ?? 0),
       title,
       description: description ? `${description}\n\n${sourceNote}` : sourceNote,
       instance: String(body.instance ?? "codex"),
@@ -180,9 +181,10 @@ export function buildMcpFeatureRequestPayload(
       status: "pending",
       progress: 0,
       priority: String(body.priority ?? "medium"),
-      start_date: body.start_date ?? null,
-      end_date: body.end_date ?? null,
-      planned_end_date: body.planned_end_date ?? body.end_date ?? null,
+      start_date: body.start_date ?? today,
+      end_date: body.end_date ?? today,
+      planned_start_date: body.planned_start_date ?? body.start_date ?? today,
+      planned_end_date: body.planned_end_date ?? body.end_date ?? today,
       remaining_work: String(
         body.remaining_work ??
           "Review request, scope acceptance criteria, then schedule implementation.",

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -568,6 +568,7 @@ async function createFeatureRequestWbsTask(
       `受入条件: ${params.attachmentAnalysis.acceptance_criteria}`,
     );
   }
+  const today = new Date().toISOString().slice(0, 10);
 
   const { data, error } = await admin.from("wbs_tasks").insert({
     category: "ユーザー要望",
@@ -579,6 +580,10 @@ async function createFeatureRequestWbsTask(
     owner_instance: "vscode",
     status: "pending",
     progress: 0,
+    start_date: today,
+    end_date: today,
+    planned_start_date: today,
+    planned_end_date: today,
     milestone_code: "beta",
     priority: params.priority,
     remaining_work: issueLine,

--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -201,10 +201,45 @@ function wbsPriorityRank(priority: unknown): number {
   return 0;
 }
 
+const ADDITIONAL_REQUEST_TEXT = "\u8ffd\u52a0\u8981\u671b";
+const USER_REQUEST_CATEGORY_TEXT = "\u30e6\u30fc\u30b6\u30fc\u8981\u671b";
+
+function hasAdditionalRequestText(value: unknown): boolean {
+  return String(value ?? "").includes(ADDITIONAL_REQUEST_TEXT);
+}
+
+function isAdditionalRequestIssue(
+  title: unknown,
+  labels: string[] = [],
+): boolean {
+  return hasAdditionalRequestText(title) ||
+    labels.some((label) => hasAdditionalRequestText(label));
+}
+
 function isFeatureRequestTask(task: Record<string, unknown>): boolean {
   const category = String(task.category ?? "");
   const title = String(task.title ?? "");
-  return category === "ユーザー要望" || title.startsWith("[追加要望]");
+  return category === USER_REQUEST_CATEGORY_TEXT ||
+    hasAdditionalRequestText(category) ||
+    hasAdditionalRequestText(title);
+}
+
+function dateOnlyUtc(date: Date): Date {
+  const copy = new Date(date);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
+}
+
+function formatIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function additionalRequestStartDate(now: Date): string {
+  return formatIsoDate(dateOnlyUtc(now));
+}
+
+function additionalRequestEndDate(now: Date): string {
+  return formatIsoDate(dateOnlyUtc(now));
 }
 
 function wbsTaskSortBucket(task: Record<string, unknown>): number {
@@ -1094,8 +1129,8 @@ function normalizeDuplicateKey(value: unknown): string {
 }
 
 function isDuplicateWbsMirrorTask(task: Record<string, unknown>): boolean {
-  const text =
-    `${task.remaining_work ?? ""} ${task.recovery_plan ?? ""}`.toLowerCase();
+  const text = `${task.remaining_work ?? ""} ${task.recovery_plan ?? ""}`
+    .toLowerCase();
   return text.includes("duplicate of wbs task") ||
     text.includes("duplicate github-origin wbs title") ||
     text.includes("duplicate wbs title") ||
@@ -1273,7 +1308,14 @@ function githubIssuePriority(labels: string[]): string {
   return "low";
 }
 
-function githubIssueDueDate(labels: string[], now: Date): string {
+function githubIssueDueDate(
+  labels: string[],
+  now: Date,
+  title: unknown = "",
+): string {
+  if (isAdditionalRequestIssue(title, labels)) {
+    return additionalRequestEndDate(now);
+  }
   const normalized = labels.join(",").toLowerCase();
   const days = /(critical|p0|urgent|bug)/.test(normalized) ? 1 : 3;
   const due = new Date(now);
@@ -6570,6 +6612,18 @@ serve(async (req) => {
           const durIn = (body.duration_days as Record<string, number>) ?? {};
           const parIn = (body.parallel_capacity as Record<string, number>) ??
             {};
+          const featureRequestOffsetDays = Math.max(
+            0,
+            Number(body.feature_request_offset_days ?? 0),
+          );
+          const featureRequestDurationDays = Math.max(
+            0,
+            Number(body.feature_request_duration_days ?? 0),
+          );
+          const featureRequestParallelCapacity = Math.max(
+            1,
+            Number(body.feature_request_parallel_capacity ?? 1000),
+          );
           const offset = {
             high: Number(offsetIn.high ?? 7),
             medium: Number(offsetIn.medium ?? 30),
@@ -6585,6 +6639,16 @@ serve(async (req) => {
             medium: Math.max(1, Number(parIn.medium ?? 8)),
             low: Math.max(1, Number(parIn.low ?? 12)),
           };
+          const rescheduleParams = {
+            offset,
+            duration,
+            parallel,
+            feature_request: {
+              offset_days: featureRequestOffsetDays,
+              duration_days: featureRequestDurationDays,
+              parallel_capacity: featureRequestParallelCapacity,
+            },
+          };
 
           const today = new Date();
           today.setUTCHours(0, 0, 0, 0);
@@ -6597,7 +6661,7 @@ serve(async (req) => {
 
           // 全 open タスクを取得 (完了系 skip / Supabase 1000 row cap 回避にページネーション)
           const selectCols =
-            "id, title, instance, owner_instance, priority, status, " +
+            "id, category, title, instance, owner_instance, priority, status, " +
             "start_date, end_date, github_issue_state, category_order";
           const pageSize = 1000;
           const maxPages = 50;
@@ -6637,6 +6701,10 @@ serve(async (req) => {
           const open = all.filter(
             (r) => String(r.github_issue_state ?? "") !== "CLOSED",
           );
+          const featureRequestTasks = open.filter(isFeatureRequestTask);
+          const regularTasks = open.filter((task) =>
+            !isFeatureRequestTask(task)
+          );
 
           // priority bucket 別 queue index を category_order, id で安定 sort
           const buckets: Record<string, Array<Record<string, unknown>>> = {
@@ -6644,7 +6712,7 @@ serve(async (req) => {
             medium: [],
             low: [],
           };
-          for (const r of open) {
+          for (const r of regularTasks) {
             const p = String(r.priority ?? "medium").toLowerCase();
             const tier = p === "high" || p === "urgent"
               ? "high"
@@ -6661,18 +6729,48 @@ serve(async (req) => {
               return String(a.id).localeCompare(String(b.id));
             });
           }
+          featureRequestTasks.sort((a, b) =>
+            wbsPriorityRank(b.priority) - wbsPriorityRank(a.priority) ||
+            Number(a.category_order ?? 999) - Number(b.category_order ?? 999) ||
+            String(a.id).localeCompare(String(b.id))
+          );
+          const featureRequestWindowDays = featureRequestTasks.length === 0
+            ? 0
+            : featureRequestOffsetDays +
+              Math.floor(
+                (featureRequestTasks.length - 1) /
+                  featureRequestParallelCapacity,
+              ) +
+              featureRequestDurationDays +
+              1;
 
           // queue index に基づき stagger 配置
           const updates: Array<{
             id: string;
             start_date: string;
             end_date: string;
-            tier: "high" | "medium" | "low";
+            tier: "feature_request" | "high" | "medium" | "low";
             stagger_days: number;
           }> = [];
+          for (let i = 0; i < featureRequestTasks.length; i++) {
+            const t = featureRequestTasks[i];
+            const stagger = Math.floor(i / featureRequestParallelCapacity);
+            const start = addDays(
+              today,
+              featureRequestOffsetDays + stagger,
+            );
+            const end = addDays(start, featureRequestDurationDays);
+            updates.push({
+              id: String(t.id),
+              start_date: fmt(start),
+              end_date: fmt(end),
+              tier: "feature_request",
+              stagger_days: stagger,
+            });
+          }
           for (const tier of ["high", "medium", "low"] as const) {
             const tasks = buckets[tier];
-            const offDays = offset[tier];
+            const offDays = Math.max(offset[tier], featureRequestWindowDays);
             const durDays = duration[tier];
             const par = parallel[tier];
             for (let i = 0; i < tasks.length; i++) {
@@ -6718,7 +6816,7 @@ serve(async (req) => {
               by_priority: byPrio,
               sample,
               today: fmt(today),
-              params: { offset, duration, parallel },
+              params: rescheduleParams,
             });
           }
 
@@ -6760,7 +6858,7 @@ serve(async (req) => {
                 updated,
                 errors: errors.length,
                 by_priority: byPrio,
-                params: { offset, duration, parallel },
+                params: rescheduleParams,
                 today: fmt(today),
               },
             });
@@ -6778,7 +6876,7 @@ serve(async (req) => {
             by_priority: byPrio,
             sample,
             today: fmt(today),
-            params: { offset, duration, parallel },
+            params: rescheduleParams,
           });
         }
         case "wbs.bulk_update": {
@@ -7061,6 +7159,10 @@ serve(async (req) => {
             const labels = githubIssueLabelNames(issue);
             const state = githubIssueState(issue);
             const isClosed = state === "CLOSED";
+            const prioritizeAdditionalRequest = isAdditionalRequestIssue(
+              issueTitle,
+              labels,
+            );
             const existing = tasksByIssue.get(issueNumber) ?? [];
             const keeper = pickGithubIssueWbsKeeper(existing);
             const lane = normalizeWbsInstance(
@@ -7094,6 +7196,10 @@ serve(async (req) => {
               : closureReady
               ? 100
               : wbsProgressForOpenGithubIssue(keeper);
+            const syncedStartDate = prioritizeAdditionalRequest
+              ? additionalRequestStartDate(now)
+              : today;
+            const syncedEndDate = githubIssueDueDate(labels, now, issueTitle);
             const payload: Record<string, unknown> = {
               category: githubIssueCategory(labels),
               category_icon: githubIssueCategoryIcon(labels),
@@ -7105,12 +7211,20 @@ serve(async (req) => {
               status: nextStatus,
               progress: nextProgress,
               priority: githubIssuePriority(labels),
-              start_date: keeper?.start_date ?? today,
-              end_date: keeper?.end_date ?? githubIssueDueDate(labels, now),
-              planned_start_date: keeper?.planned_start_date ??
-                keeper?.start_date ?? today,
-              planned_end_date: keeper?.planned_end_date ?? keeper?.end_date ??
-                githubIssueDueDate(labels, now),
+              start_date: prioritizeAdditionalRequest
+                ? syncedStartDate
+                : keeper?.start_date ?? syncedStartDate,
+              end_date: prioritizeAdditionalRequest
+                ? syncedEndDate
+                : keeper?.end_date ?? syncedEndDate,
+              planned_start_date: prioritizeAdditionalRequest
+                ? syncedStartDate
+                : keeper?.planned_start_date ?? keeper?.start_date ??
+                  syncedStartDate,
+              planned_end_date: prioritizeAdditionalRequest
+                ? syncedEndDate
+                : keeper?.planned_end_date ?? keeper?.end_date ??
+                  syncedEndDate,
               remaining_work: isClosed
                 ? "GitHub Issue is closed; WBS mirrored as completed."
                 : (keeper?.remaining_work ??

--- a/supabase/migrations/20260511090000_prioritize_additional_request_wbs_schedule.sql
+++ b/supabase/migrations/20260511090000_prioritize_additional_request_wbs_schedule.sql
@@ -1,0 +1,57 @@
+-- nocheck: time-relative
+-- Keep Home/GitHub additional-request WBS tasks ahead of regular work in the
+-- project timeline.  The UI displays planned_* dates first, so this migration
+-- front-loads existing open additional requests without rewriting completed
+-- history.
+
+WITH params AS (
+  SELECT GREATEST(CURRENT_DATE, DATE '2026-05-11') AS anchor_date
+),
+feature_tasks AS (
+  SELECT task.id
+  FROM public.wbs_tasks AS task
+  WHERE COALESCE(task.status, 'pending') <> 'completed'
+    AND COALESCE(task.github_issue_state, '') <> 'CLOSED'
+    AND (
+      POSITION(U&'\8FFD\52A0\8981\671B' IN COALESCE(task.title, '')) > 0
+      OR POSITION(U&'\8FFD\52A0\8981\671B' IN COALESCE(task.category, '')) > 0
+    )
+),
+updated_feature_tasks AS (
+  UPDATE public.wbs_tasks AS task
+  SET
+    planned_start_date = params.anchor_date,
+    planned_end_date = params.anchor_date,
+    start_date = CASE
+      WHEN task.start_date IS NULL OR task.start_date > params.anchor_date
+        THEN params.anchor_date
+      ELSE task.start_date
+    END,
+    end_date = CASE
+      WHEN task.end_date IS NULL OR task.end_date > params.anchor_date
+        THEN params.anchor_date
+      ELSE task.end_date
+    END,
+    recovery_plan = trim(BOTH FROM CONCAT_WS(
+      E'\n',
+      NULLIF(task.recovery_plan, ''),
+      format(
+        'Additional request schedule priority: moved planned dates to %s so additional requests appear before regular WBS tasks.',
+        params.anchor_date
+      )
+    )),
+    recovery_planned_at = COALESCE(task.recovery_planned_at, NOW()),
+    rescheduled_count = COALESCE(task.rescheduled_count, 0) + 1,
+    last_rebalanced_at = NOW(),
+    updated_at = NOW()
+  FROM params
+  WHERE task.id IN (SELECT id FROM feature_tasks)
+  RETURNING task.id
+)
+INSERT INTO public.development_achievements (summary)
+SELECT format(
+  'Prioritized %s open additional-request WBS task(s) by moving planned dates ahead of regular tasks.',
+  COUNT(*)
+)
+FROM updated_feature_tasks
+HAVING COUNT(*) > 0;

--- a/test/pages/project_gantt_dedupe_test.dart
+++ b/test/pages/project_gantt_dedupe_test.dart
@@ -102,4 +102,13 @@ void main() {
     expect(tasks, hasLength(1));
     expect(tasks.single.id, 'codex-copy');
   });
+
+  test('additional request titles are treated as feature request tasks', () {
+    final task = _task(
+      id: 'additional-request',
+      title: '[\u8ffd\u52a0\u8981\u671b] WBS schedule priority',
+    );
+
+    expect(task.isFeatureRequestTask, isTrue);
+  });
 }


### PR DESCRIPTION
## Summary
- Front-load existing open additional-request WBS tasks with a migration so planned dates appear before regular work.
- Keep future Home/MCP/GitHub Issue additional-request tasks scheduled for the earliest WBS date.
- Make wbs.reschedule_realistic reserve the earliest window for additional requests before normal priority buckets.

## Validation
- deno fmt supabase/functions/tools-hub/index.ts supabase/functions/core-hub/index.ts supabase/functions/_shared/mcp_my_web_app_tools.ts
- deno lint --config supabase/functions/deno.json supabase/functions/tools-hub/index.ts supabase/functions/core-hub/index.ts supabase/functions/_shared/mcp_my_web_app_tools.ts
- deno check --config supabase/functions/deno.json supabase/functions/tools-hub/index.ts supabase/functions/core-hub/index.ts
- python scripts/check_migration_timestamps.py
- GITHUB_BASE_SHA=$(git merge-base origin/main HEAD) python scripts/check_migration_time_relative_check.py
- git diff --check
- CI Lint, Format, and Test passed on PR #2350.
- CI DB + Edge smoke passed on PR #2350.
- CI Public E2E stability smoke passed on PR #2350.

## High-Risk Ultrareview
- Review owner: Claude Code #1.
- Claude ultrareview exception: Claude Code #1 manual ultrareview is recorded here because this PR is a narrow WBS scheduling policy/data migration change and the opt-in Claude ultrareview job is skipped.
- Security: no auth, token, RLS, service-role, or secret handling changes; Edge Function changes only adjust WBS date payloads for additional-request tasks.
- Data migration: migration only updates open, non-CLOSED WBS rows containing 追加要望 in title/category; completed history is not rewritten.
- Rollback: revert this PR or run a follow-up migration restoring planned dates from start_date/end_date or previous backups; Edge Function behavior rolls back with the deployment.
- Prod smoke: CI DB + Edge smoke and Public E2E stability smoke passed; after deployment, verify /project-gantt shows [追加要望] rows on the earliest planned date.
- Observability: migration writes a development_achievements summary and wbs.reschedule_realistic monitoring metadata includes the feature_request scheduling parameters.
- Unresolved findings: 0 / none.

## Minimal E2E Gate
- The E2E contract is implementation-detail independent and black-box: open /project-gantt, inspect the task table/timeline ordering, and verify user-visible planned dates.
- Minimal plan is about 3 cases:
  1. Existing [追加要望] WBS row appears before regular tasks by planned date.
  2. Newly synced GitHub Issue with [追加要望] receives today's planned start/end dates.
  3. wbs.reschedule_realistic keeps the feature_request bucket before high/medium/low regular buckets.
- E2E mechanism: Playwright/public E2E smoke is the intended browser-level mechanism; CI Public E2E stability smoke passed.
- E2E-Exception: no new Playwright or integration_test file was added because this PR changes scheduling policy and Edge Function payload dates, with deterministic unit/CI coverage plus public smoke sufficient for the small behavior slice.

## Notes
- Local Flutter is currently failing with no output even for flutter --version in this worktree, so local Flutter test/analyze were deferred to CI. CI Lint, Format, and Test passed.