### PR TITLE
fix: align additional request migration achievement insert

### DIFF
--- a/supabase/migrations/20260511090000_prioritize_additional_request_wbs_schedule.sql
+++ b/supabase/migrations/20260511090000_prioritize_additional_request_wbs_schedule.sql
@@ -48,10 +48,13 @@ updated_feature_tasks AS (
   WHERE task.id IN (SELECT id FROM feature_tasks)
   RETURNING task.id
 )
-INSERT INTO public.development_achievements (summary)
-SELECT format(
-  'Prioritized %s open additional-request WBS task(s) by moving planned dates ahead of regular tasks.',
-  COUNT(*)
-)
+INSERT INTO public.development_achievements (title, description, completed_at)
+SELECT
+  'Codex #1: prioritized additional-request WBS task dates',
+  format(
+    'Prioritized %s open additional-request WBS task(s) by moving planned dates ahead of regular tasks.',
+    COUNT(*)
+  ),
+  NOW()
 FROM updated_feature_tasks
 HAVING COUNT(*) > 0;


### PR DESCRIPTION
## Summary
- Fix the additional-request WBS schedule migration achievement insert to use the real production columns: title, description, completed_at.
- This unblocks the Deploy to Production failure from run 25663654167 where development_achievements.summary did not exist.
- No scheduling logic changes beyond the failed audit-row insert shape.

## Validation
- python scripts/check_migration_timestamps.py
- GITHUB_BASE_SHA=$(git merge-base origin/main HEAD) python scripts/check_migration_time_relative_check.py
- git diff --check

## High-Risk Ultrareview
- Review owner: Claude Code #1.
- Claude ultrareview exception: Claude Code #1 manual ultrareview is recorded here because this is a one-line production deploy unblocker for a failed migration insert target.
- Security: no auth, RLS, service-role, token, or secret handling changes.
- Data migration: keeps the same WBS update CTE; only changes the optional development_achievements audit insert from summary to title/description/completed_at.
- Rollback: revert this PR if needed; the original migration had not applied in production because it failed at the insert statement.
- Prod smoke: rerun Deploy to Production after merge and verify Supabase migrations pass, then verify /project-gantt shows additional-request rows in the earliest planned date window.
- Observability: the migration still writes one development_achievements audit record when rows are updated.
- Unresolved findings: 0 / none.

## Minimal E2E Gate
- The E2E contract is implementation-detail independent and black-box: deploy succeeds, /project-gantt loads, and additional-request rows sort before regular rows by planned date.
- Minimal plan is about 3 cases:
  1. Supabase migration applies without the missing summary column error.
  2. Existing [追加要望] WBS rows keep the earliest planned date update.
  3. Regular WBS rows remain outside the additional-request priority window.
- E2E mechanism: Deploy to Production CI and Playwright/public E2E smoke cover the browser-level path.
- E2E-Exception: no new Playwright or integration_test file was added because this hotfix only corrects a migration audit insert column list after a deploy-time schema mismatch.