### PR TITLE
fix: repair WBS schedule migration achievement insert (#2354)

### DIFF
--- a/supabase/migrations/20260511090000_prioritize_additional_request_wbs_schedule.sql
+++ b/supabase/migrations/20260511090000_prioritize_additional_request_wbs_schedule.sql
@@ -48,10 +48,14 @@ updated_feature_tasks AS (
   WHERE task.id IN (SELECT id FROM feature_tasks)
   RETURNING task.id
 )
-INSERT INTO public.development_achievements (summary)
-SELECT format(
-  'Prioritized %s open additional-request WBS task(s) by moving planned dates ahead of regular tasks.',
-  COUNT(*)
-)
+INSERT INTO public.development_achievements (title, description, completed_at)
+SELECT
+  'Codex #1: prioritized additional-request WBS schedule',
+  format(
+    'Prioritized %s open additional-request WBS task(s) by moving planned dates ahead of regular tasks.',
+    COUNT(*)
+  ),
+  NOW()
 FROM updated_feature_tasks
-HAVING COUNT(*) > 0;
+HAVING COUNT(*) > 0
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
﻿## Summary
- Fix the WBS scheduling migration generated on main so it writes to `development_achievements(title, description, completed_at)` instead of the non-existent `summary` column.
- Keep the existing WBS task date rebalance behavior unchanged.

## Root cause
Deploy to Production run 25663654167 failed in `Run Supabase migrations` because `20260511090000_prioritize_additional_request_wbs_schedule.sql` attempted `INSERT INTO public.development_achievements (summary)`, but the table schema uses `title`, `description`, and `completed_at`.

## Minimal E2E Gate
- Scope: production migration hotfix only; no frontend route or user workflow changes.
- E2E-Exception: a browser E2E would not exercise the failing path before deploy, because the failure is in Supabase migration application. The meaningful black-box validation is the deploy-prod migration step succeeding on main after merge.
- Post-merge smoke: confirm Deploy to Production succeeds and closes/updates #2354 via workflow-failure recovery.

## High-risk Ultrareview Gate
- High-risk area: production database migration.
- Review owner: Claude Code #1.
- High-Risk-Ultrareview-Exception: emergency one-line schema compatibility fix for a main deploy blocker under the Claude Code #1 + Codex #1 two-instance policy; no old Codex #2/#3 or subagents used.
- Security: no auth, RLS, secret, or permission behavior changes; the update only changes an audit insert column list to an existing schema pattern.
- Rollback: revert this PR or repair the failed migration version if deploy surfaces a new migration error.
- Prod smoke: deploy-prod must rerun successfully on main and pass Supabase migration application.
- Observability: #2354 workflow-failure issue and deploy run logs remain the recovery signal; a later successful Deploy to Production run should close/update the issue automatically.
- Data impact: no destructive DDL/DML; existing WBS task update CTE is unchanged.
- Unresolved ultrareview findings: none.

## Validation
- `git diff --check`
- Log inspection: #2354 / deploy run 25663654167 / job 75334049918

Fixes #2354.
