### PR TITLE
feat: add GA readiness gate (#1640)

### DIFF
--- a/.github/workflows/ga-readiness-gate.yml
+++ b/.github/workflows/ga-readiness-gate.yml
@@ -1,0 +1,98 @@
+name: GA Launch Readiness Gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ga-readiness-gate.yml"
+      - "docs/GA_LAUNCH_READINESS_GATE_SPEC.md"
+      - "docs/CORPORATE_FORMATION_RUNBOOK.md"
+      - "lib/pages/home_page.dart"
+      - "lib/widgets/ga_readiness_gate_panel.dart"
+      - "scripts/check_ga_readiness_gate.py"
+      - "supabase/functions/app-hub/**"
+      - "test/**"
+  schedule:
+    - cron: "55 21 * * *" # daily 06:55 JST
+  workflow_run:
+    workflows:
+      - "Deploy to Production"
+    types: [completed]
+
+concurrency:
+  group: ga-readiness-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FLUTTER_VERSION: "3.38.x"
+
+jobs:
+  ga-readiness:
+    name: GA readiness gate
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Validate GA readiness wiring
+        run: |
+          mkdir -p .ga-readiness
+          python scripts/check_ga_readiness_gate.py \
+            --output-json .ga-readiness/ga-readiness.json \
+            --summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Deno check app-hub GA action
+        run: >
+          deno check --config supabase/functions/deno.json
+          supabase/functions/app-hub/index.ts
+          supabase/functions/app-hub/ga_readiness.ts
+
+      - name: Deno test app-hub GA action
+        run: >
+          deno test --config supabase/functions/deno.json
+          supabase/functions/app-hub/ga_readiness_test.ts
+
+      - name: Flutter analyze
+        run: flutter analyze --no-fatal-warnings
+
+      - name: Flutter test
+        run: flutter test --reporter=compact
+
+      - name: Critical browser E2E
+        run: |
+          if [ -d e2e/critical ]; then
+            npx playwright test e2e/critical/
+          else
+            echo "e2e/critical is not present yet; tracked as a GA Axis A follow-up."
+          fi
+
+      - name: Upload GA readiness artifact
+        if: always() && hashFiles('.ga-readiness/**') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: ga-readiness-gate
+          path: .ga-readiness/
+          if-no-files-found: ignore

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -49,6 +49,7 @@ import '../widgets/profile_progress_card.dart';
 import '../widgets/proactive_diagnostics_card.dart';
 import '../widgets/development_achievements_card.dart';
 import '../widgets/edge_function_summary_card.dart';
+import '../widgets/ga_readiness_gate_panel.dart';
 import '../widgets/ai_university_home_card.dart';
 import '../widgets/api_key_status_banner.dart';
 import '../widgets/feature_strategy_monitor_panel.dart';
@@ -5970,6 +5971,8 @@ abstinence_slip_details: $slipDetailsText
         key: const Key('home_section_site_guide_ai'),
       ),
       _buildSiteGuideAiCard(isDark, isCompact),
+      const SizedBox(height: 8),
+      const GaReadinessGatePanel(),
       const SizedBox(height: 16),
       const CollapsibleHomeSection(
         key: Key('home_tier_recent'),

--- a/lib/widgets/ga_readiness_gate_panel.dart
+++ b/lib/widgets/ga_readiness_gate_panel.dart
@@ -93,9 +93,8 @@ class _GaReadinessGateBody extends StatelessWidget {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
     final baseColor = isDark ? const Color(0xFF0F172A) : Colors.white;
-    final borderColor = isDark
-        ? const Color(0xFF334155)
-        : const Color(0xFFE2E8F0);
+    final borderColor =
+        isDark ? const Color(0xFF334155) : const Color(0xFFE2E8F0);
     final progress = snapshot.overallProgress / 100;
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 4, 12, 10),
@@ -140,9 +139,8 @@ class _GaReadinessGateBody extends StatelessWidget {
               child: LinearProgressIndicator(
                 value: progress.clamp(0, 1),
                 minHeight: 8,
-                backgroundColor: isDark
-                    ? const Color(0xFF1E293B)
-                    : const Color(0xFFE5E7EB),
+                backgroundColor:
+                    isDark ? const Color(0xFF1E293B) : const Color(0xFFE5E7EB),
                 valueColor: AlwaysStoppedAnimation<Color>(
                   snapshot.gaEligible
                       ? const Color(0xFF0D9488)
@@ -160,9 +158,7 @@ class _GaReadinessGateBody extends StatelessWidget {
             ),
             if (snapshot.blockers.isNotEmpty) ...[
               const SizedBox(height: 12),
-              ...snapshot.blockers
-                  .take(3)
-                  .map(
+              ...snapshot.blockers.take(3).map(
                     (blocker) => Padding(
                       padding: const EdgeInsets.only(bottom: 6),
                       child: Row(
@@ -364,25 +360,25 @@ class _AxisColors {
 _AxisColors _axisColors(String status) {
   return switch (status) {
     'green' => const _AxisColors(
-      background: Color(0xFFEFFAF5),
-      border: Color(0xFF99F6C7),
-      foreground: Color(0xFF047857),
-    ),
+        background: Color(0xFFEFFAF5),
+        border: Color(0xFF99F6C7),
+        foreground: Color(0xFF047857),
+      ),
     'amber' => const _AxisColors(
-      background: Color(0xFFFFFBEB),
-      border: Color(0xFFFDE68A),
-      foreground: Color(0xFFB45309),
-    ),
+        background: Color(0xFFFFFBEB),
+        border: Color(0xFFFDE68A),
+        foreground: Color(0xFFB45309),
+      ),
     'red' => const _AxisColors(
-      background: Color(0xFFFEF2F2),
-      border: Color(0xFFFECACA),
-      foreground: Color(0xFFB91C1C),
-    ),
+        background: Color(0xFFFEF2F2),
+        border: Color(0xFFFECACA),
+        foreground: Color(0xFFB91C1C),
+      ),
     _ => const _AxisColors(
-      background: Color(0xFFF8FAFC),
-      border: Color(0xFFCBD5E1),
-      foreground: Color(0xFF475569),
-    ),
+        background: Color(0xFFF8FAFC),
+        border: Color(0xFFCBD5E1),
+        foreground: Color(0xFF475569),
+      ),
   };
 }
 

--- a/lib/widgets/ga_readiness_gate_panel.dart
+++ b/lib/widgets/ga_readiness_gate_panel.dart
@@ -1,0 +1,538 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'collapsible_home_section.dart';
+
+class GaReadinessGatePanel extends StatefulWidget {
+  const GaReadinessGatePanel({super.key});
+
+  @override
+  State<GaReadinessGatePanel> createState() => _GaReadinessGatePanelState();
+}
+
+class _GaReadinessGatePanelState extends State<GaReadinessGatePanel> {
+  late Future<_GaReadinessSnapshot> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _loadSnapshot();
+  }
+
+  void _refresh() {
+    setState(() {
+      _future = _loadSnapshot();
+    });
+  }
+
+  Future<_GaReadinessSnapshot> _loadSnapshot() async {
+    final fallback = _GaReadinessSnapshot.fallback();
+    if (Supabase.instance.client.auth.currentUser == null) {
+      return fallback.copyWith(sourceNote: 'Sign in to refresh from app-hub.');
+    }
+    try {
+      final response = await Supabase.instance.client.functions.invoke(
+        'app-hub',
+        body: {'action': 'agent.list_ga_axes'},
+      );
+      final rawData = response.data;
+      if (rawData is! Map) {
+        throw const FormatException('Invalid GA readiness response');
+      }
+      final data = Map<String, dynamic>.from(rawData);
+      final rawSnapshot = data['ga_readiness'];
+      if (rawSnapshot is! Map) {
+        throw const FormatException('Missing GA readiness payload');
+      }
+      return _GaReadinessSnapshot.fromJson(
+        Map<String, dynamic>.from(rawSnapshot),
+      );
+    } catch (error) {
+      return fallback.copyWith(sourceNote: 'Offline snapshot: $error');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CollapsibleHomeSection(
+      key: const Key('home_ga_readiness_gate_panel'),
+      storageKey: 'home_section_ga_readiness_gate',
+      title: 'GA READINESS GATE',
+      icon: Icons.verified_outlined,
+      iconColor: const Color(0xFF0D9488),
+      initiallyExpanded: false,
+      child: FutureBuilder<_GaReadinessSnapshot>(
+        future: _future,
+        builder: (context, snapshot) {
+          final data = snapshot.data ?? _GaReadinessSnapshot.fallback();
+          final isLoading = snapshot.connectionState == ConnectionState.waiting;
+          return _GaReadinessGateBody(
+            snapshot: data,
+            isLoading: isLoading,
+            onRefresh: _refresh,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _GaReadinessGateBody extends StatelessWidget {
+  final _GaReadinessSnapshot snapshot;
+  final bool isLoading;
+  final VoidCallback onRefresh;
+
+  const _GaReadinessGateBody({
+    required this.snapshot,
+    required this.isLoading,
+    required this.onRefresh,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final baseColor = isDark ? const Color(0xFF0F172A) : Colors.white;
+    final borderColor = isDark
+        ? const Color(0xFF334155)
+        : const Color(0xFFE2E8F0);
+    final progress = snapshot.overallProgress / 100;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 4, 12, 10),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: baseColor,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: borderColor),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: _GaReadinessSummary(
+                    snapshot: snapshot,
+                    progress: progress,
+                  ),
+                ),
+                Tooltip(
+                  message: 'Refresh GA readiness',
+                  child: IconButton(
+                    key: const Key('home_ga_readiness_refresh'),
+                    onPressed: isLoading ? null : onRefresh,
+                    icon: isLoading
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.refresh, size: 20),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(999),
+              child: LinearProgressIndicator(
+                value: progress.clamp(0, 1),
+                minHeight: 8,
+                backgroundColor: isDark
+                    ? const Color(0xFF1E293B)
+                    : const Color(0xFFE5E7EB),
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  snapshot.gaEligible
+                      ? const Color(0xFF0D9488)
+                      : const Color(0xFFF59E0B),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: snapshot.axes
+                  .map((axis) => _GaReadinessAxisChip(axis: axis))
+                  .toList(),
+            ),
+            if (snapshot.blockers.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              ...snapshot.blockers
+                  .take(3)
+                  .map(
+                    (blocker) => Padding(
+                      padding: const EdgeInsets.only(bottom: 6),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Icon(
+                            Icons.lock_clock_outlined,
+                            size: 16,
+                            color: Color(0xFFB45309),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              blocker,
+                              style: TextStyle(
+                                color: isDark
+                                    ? const Color(0xFFE2E8F0)
+                                    : const Color(0xFF334155),
+                                fontSize: 12,
+                                height: 1.4,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+            ],
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    snapshot.sourceNote,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: isDark
+                          ? const Color(0xFF94A3B8)
+                          : const Color(0xFF64748B),
+                      fontSize: 11,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                OutlinedButton.icon(
+                  onPressed: () =>
+                      Navigator.of(context).pushNamed('/project-gantt'),
+                  icon: const Icon(Icons.timeline, size: 16),
+                  label: const Text('WBS'),
+                  style: OutlinedButton.styleFrom(
+                    minimumSize: const Size(72, 38),
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                    textStyle: const TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      height: 1.2,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GaReadinessSummary extends StatelessWidget {
+  final _GaReadinessSnapshot snapshot;
+  final double progress;
+
+  const _GaReadinessSummary({required this.snapshot, required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          snapshot.gaEligible ? 'GA eligible' : 'GA blocked',
+          style: TextStyle(
+            color: snapshot.gaEligible
+                ? const Color(0xFF0D9488)
+                : const Color(0xFFB45309),
+            fontSize: 13,
+            fontWeight: FontWeight.w800,
+            height: 1.3,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '${snapshot.greenCount}/${snapshot.axisCount} green - '
+          '${snapshot.overallProgress}% ready',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: isDark ? const Color(0xFFE2E8F0) : const Color(0xFF1E293B),
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+            height: 1.4,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GaReadinessAxisChip extends StatelessWidget {
+  final _GaReadinessAxis axis;
+
+  const _GaReadinessAxisChip({required this.axis});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = _axisColors(axis.status);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 156, maxWidth: 220),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: colors.background,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: colors.border),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 28,
+              height: 28,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: colors.foreground.withValues(alpha: 0.14),
+                shape: BoxShape.circle,
+              ),
+              child: Text(
+                axis.code,
+                style: TextStyle(
+                  color: colors.foreground,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w900,
+                  height: 1,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    axis.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w800,
+                      height: 1.2,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${axis.progress}% - #${axis.issue}',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: colors.foreground,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      height: 1.2,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AxisColors {
+  final Color background;
+  final Color border;
+  final Color foreground;
+
+  const _AxisColors({
+    required this.background,
+    required this.border,
+    required this.foreground,
+  });
+}
+
+_AxisColors _axisColors(String status) {
+  return switch (status) {
+    'green' => const _AxisColors(
+      background: Color(0xFFEFFAF5),
+      border: Color(0xFF99F6C7),
+      foreground: Color(0xFF047857),
+    ),
+    'amber' => const _AxisColors(
+      background: Color(0xFFFFFBEB),
+      border: Color(0xFFFDE68A),
+      foreground: Color(0xFFB45309),
+    ),
+    'red' => const _AxisColors(
+      background: Color(0xFFFEF2F2),
+      border: Color(0xFFFECACA),
+      foreground: Color(0xFFB91C1C),
+    ),
+    _ => const _AxisColors(
+      background: Color(0xFFF8FAFC),
+      border: Color(0xFFCBD5E1),
+      foreground: Color(0xFF475569),
+    ),
+  };
+}
+
+class _GaReadinessSnapshot {
+  final bool gaEligible;
+  final int axisCount;
+  final int greenCount;
+  final int blockedCount;
+  final int overallProgress;
+  final List<String> blockers;
+  final List<_GaReadinessAxis> axes;
+  final String sourceNote;
+
+  const _GaReadinessSnapshot({
+    required this.gaEligible,
+    required this.axisCount,
+    required this.greenCount,
+    required this.blockedCount,
+    required this.overallProgress,
+    required this.blockers,
+    required this.axes,
+    this.sourceNote = 'Source: app-hub agent.list_ga_axes',
+  });
+
+  factory _GaReadinessSnapshot.fromJson(Map<String, dynamic> json) {
+    final summary = Map<String, dynamic>.from(json['summary'] as Map? ?? {});
+    final axes = (json['axes'] as List? ?? const [])
+        .whereType<Map>()
+        .map(
+          (axis) => _GaReadinessAxis.fromJson(Map<String, dynamic>.from(axis)),
+        )
+        .toList();
+    return _GaReadinessSnapshot(
+      gaEligible: json['ga_eligible'] == true,
+      axisCount: _asInt(summary['axis_count'], axes.length),
+      greenCount: _asInt(summary['green_count'], 0),
+      blockedCount: _asInt(summary['blocked_count'], 0),
+      overallProgress: _asInt(summary['overall_progress'], 0),
+      blockers: (summary['blockers'] as List? ?? const [])
+          .map((item) => item.toString())
+          .where((item) => item.trim().isNotEmpty)
+          .toList(),
+      axes: axes,
+    );
+  }
+
+  factory _GaReadinessSnapshot.fallback() {
+    const axes = _fallbackAxes;
+    return _GaReadinessSnapshot(
+      gaEligible: false,
+      axisCount: axes.length,
+      greenCount: 0,
+      blockedCount: axes.where((axis) => axis.status == 'blocked').length,
+      overallProgress: 24,
+      blockers: axes
+          .where((axis) => axis.blocker.isNotEmpty)
+          .map((axis) => '${axis.code}. ${axis.title}: ${axis.blocker}')
+          .toList(),
+      axes: axes,
+      sourceNote: 'Fallback snapshot: waiting for app-hub.',
+    );
+  }
+
+  _GaReadinessSnapshot copyWith({String? sourceNote}) {
+    return _GaReadinessSnapshot(
+      gaEligible: gaEligible,
+      axisCount: axisCount,
+      greenCount: greenCount,
+      blockedCount: blockedCount,
+      overallProgress: overallProgress,
+      blockers: blockers,
+      axes: axes,
+      sourceNote: sourceNote ?? this.sourceNote,
+    );
+  }
+}
+
+class _GaReadinessAxis {
+  final String code;
+  final String title;
+  final String status;
+  final int progress;
+  final int issue;
+  final String blocker;
+
+  const _GaReadinessAxis({
+    required this.code,
+    required this.title,
+    required this.status,
+    required this.progress,
+    required this.issue,
+    this.blocker = '',
+  });
+
+  factory _GaReadinessAxis.fromJson(Map<String, dynamic> json) {
+    return _GaReadinessAxis(
+      code: (json['code'] ?? '').toString(),
+      title: (json['title'] ?? '').toString(),
+      status: (json['status'] ?? 'blocked').toString(),
+      progress: _asInt(json['progress'], 0),
+      issue: _asInt(json['issue'], 0),
+      blocker: (json['blocker'] ?? '').toString(),
+    );
+  }
+}
+
+int _asInt(Object? value, int fallback) {
+  if (value is int) return value;
+  if (value is num) return value.round();
+  return int.tryParse(value?.toString() ?? '') ?? fallback;
+}
+
+const _fallbackAxes = [
+  _GaReadinessAxis(
+    code: 'A',
+    title: 'MVP Scope',
+    status: 'amber',
+    progress: 80,
+    issue: 1640,
+  ),
+  _GaReadinessAxis(
+    code: 'B',
+    title: 'Pricing v1.0',
+    status: 'blocked',
+    progress: 20,
+    issue: 1640,
+    blocker: 'Manual Paddle/legal approval is required.',
+  ),
+  _GaReadinessAxis(
+    code: 'C',
+    title: 'Legal Entity',
+    status: 'blocked',
+    progress: 0,
+    issue: 1662,
+    blocker: 'Corporate formation is a user/legal decision.',
+  ),
+  _GaReadinessAxis(
+    code: 'D',
+    title: 'Banking',
+    status: 'blocked',
+    progress: 0,
+    issue: 1662,
+    blocker: 'Bank account setup is user-owned.',
+  ),
+  _GaReadinessAxis(
+    code: 'E',
+    title: 'Video Secrets',
+    status: 'blocked',
+    progress: 20,
+    issue: 1724,
+    blocker: 'Repository secrets are still user-provided.',
+  ),
+];

--- a/scripts/check_ga_readiness_gate.py
+++ b/scripts/check_ga_readiness_gate.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Validate the GA readiness gate wiring for #1640."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_FILES = [
+    ".github/workflows/ga-readiness-gate.yml",
+    "docs/GA_LAUNCH_READINESS_GATE_SPEC.md",
+    "docs/CORPORATE_FORMATION_RUNBOOK.md",
+    "supabase/functions/app-hub/ga_readiness.ts",
+    "supabase/functions/app-hub/index.ts",
+    "lib/widgets/ga_readiness_gate_panel.dart",
+    "lib/pages/home_page.dart",
+]
+
+REQUIRED_AXIS_IDS = [
+    "mvp_scope",
+    "pricing_v1",
+    "legal_entity",
+    "banking",
+    "video_secrets",
+]
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def contains_all(text: str, tokens: Iterable[str]) -> bool:
+    return all(token in text for token in tokens)
+
+
+def build_report() -> dict[str, object]:
+    failures: list[str] = []
+    for path in REQUIRED_FILES:
+        require((ROOT / path).is_file(), f"missing required file: {path}", failures)
+
+    ga_source = read_text("supabase/functions/app-hub/ga_readiness.ts")
+    app_hub = read_text("supabase/functions/app-hub/index.ts")
+    home_page = read_text("lib/pages/home_page.dart")
+    panel = read_text("lib/widgets/ga_readiness_gate_panel.dart")
+    workflow = read_text(".github/workflows/ga-readiness-gate.yml")
+
+    require(
+        contains_all(ga_source, REQUIRED_AXIS_IDS),
+        "ga_readiness.ts does not expose every required GA axis",
+        failures,
+    )
+    require(
+        contains_all(ga_source, ["1640", "1662", "1724"]),
+        "ga_readiness.ts is missing the issue linkage for #1640/#1662/#1724",
+        failures,
+    )
+    require(
+        "agent.list_ga_axes" in app_hub and "handleGaReadinessAction" in app_hub,
+        "app-hub does not route agent.list_ga_axes",
+        failures,
+    )
+    require(
+        "GaReadinessGatePanel" in home_page
+        and "ga_readiness_gate_panel.dart" in home_page,
+        "home_page.dart does not surface the GA readiness panel",
+        failures,
+    )
+    require(
+        "agent.list_ga_axes" in panel
+        and "home_section_ga_readiness_gate" in panel,
+        "GA readiness panel is not wired to the app-hub action",
+        failures,
+    )
+    require(
+        contains_all(
+            workflow,
+            [
+                "GA Launch Readiness Gate",
+                "check_ga_readiness_gate.py",
+                "deno test",
+                "flutter analyze",
+                "flutter test --reporter=compact",
+            ],
+        ),
+        "workflow is missing one or more required GA gate checks",
+        failures,
+    )
+
+    axes = [
+        {"id": "mvp_scope", "issue": 1640, "owner": "Claude Code #1 + Codex #1"},
+        {"id": "pricing_v1", "issue": 1640, "owner": "User"},
+        {"id": "legal_entity", "issue": 1662, "owner": "User"},
+        {"id": "banking", "issue": 1662, "owner": "User"},
+        {"id": "video_secrets", "issue": 1724, "owner": "User"},
+    ]
+    return {
+        "success": not failures,
+        "failure_count": len(failures),
+        "failures": failures,
+        "axes": axes,
+    }
+
+
+def write_summary(path: Path, report: dict[str, object]) -> None:
+    lines = [
+        "# GA Launch Readiness Gate",
+        "",
+        f"Result: {'PASS' if report['success'] else 'FAIL'}",
+        f"Axis count: {len(report['axes'])}",
+        "",
+        "## Axes",
+    ]
+    for axis in report["axes"]:
+        axis_map = dict(axis)
+        lines.append(
+            f"- `{axis_map['id']}`: #{axis_map['issue']} ({axis_map['owner']})"
+        )
+    failures = report.get("failures") or []
+    if failures:
+        lines.extend(["", "## Failures"])
+        lines.extend(f"- {failure}" for failure in failures)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--summary", type=Path)
+    args = parser.parse_args()
+
+    report = build_report()
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    if args.summary:
+        args.summary.parent.mkdir(parents=True, exist_ok=True)
+        write_summary(args.summary, report)
+    return 0 if report["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/functions/app-hub/ga_readiness.ts
+++ b/supabase/functions/app-hub/ga_readiness.ts
@@ -1,0 +1,145 @@
+export type GaReadinessAxisStatus = "green" | "amber" | "red" | "blocked";
+
+export type GaReadinessAxis = {
+  id: string;
+  code: string;
+  title: string;
+  owner: string;
+  issue: number;
+  status: GaReadinessAxisStatus;
+  progress: number;
+  target_date: string;
+  evidence: string;
+  gate_command: string;
+  next_action: string;
+  blocker?: string;
+};
+
+export type GaReadinessSnapshot = {
+  generated_at: string;
+  ga_eligible: boolean;
+  summary: {
+    axis_count: number;
+    green_count: number;
+    blocked_count: number;
+    overall_progress: number;
+    blockers: string[];
+  };
+  axes: GaReadinessAxis[];
+};
+
+export const GA_READINESS_AXES: readonly GaReadinessAxis[] = [
+  {
+    id: "mvp_scope",
+    code: "A",
+    title: "MVP Scope",
+    owner: "Claude Code #1 + Codex #1",
+    issue: 1640,
+    status: "amber",
+    progress: 80,
+    target_date: "2026-06-30",
+    evidence: "docs/MVP_SCOPE_FROZEN.md",
+    gate_command: "flutter analyze && flutter test",
+    next_action: "Keep GA gate checks green and freeze remaining MVP deltas.",
+  },
+  {
+    id: "pricing_v1",
+    code: "B",
+    title: "Pricing v1.0",
+    owner: "User",
+    issue: 1640,
+    status: "blocked",
+    progress: 20,
+    target_date: "2026-07-31",
+    evidence: "Paddle product config + public pricing copy",
+    gate_command: "Paddle audit status",
+    next_action: "Register the production Paddle entity and approve pricing.",
+    blocker: "Manual Paddle/legal approval is required.",
+  },
+  {
+    id: "legal_entity",
+    code: "C",
+    title: "Legal Entity",
+    owner: "User",
+    issue: 1662,
+    status: "blocked",
+    progress: 0,
+    target_date: "2026-09-30",
+    evidence: "docs/CORPORATE_FORMATION_RUNBOOK.md",
+    gate_command: "Manual evidence URL",
+    next_action: "Attach corporate formation evidence once the entity exists.",
+    blocker: "Corporate formation is a user/legal decision.",
+  },
+  {
+    id: "banking",
+    code: "D",
+    title: "Banking",
+    owner: "User",
+    issue: 1662,
+    status: "blocked",
+    progress: 0,
+    target_date: "2026-10-15",
+    evidence: "Masked corporate bank account evidence",
+    gate_command: "Manual evidence URL",
+    next_action: "Attach a masked bank-account evidence URL after opening.",
+    blocker: "Bank account setup is user-owned.",
+  },
+  {
+    id: "video_secrets",
+    code: "E",
+    title: "Video Secrets",
+    owner: "User",
+    issue: 1724,
+    status: "blocked",
+    progress: 20,
+    target_date: "2026-05-15",
+    evidence: "Five GitHub Actions secrets visible via gh secret list",
+    gate_command: "notebooklm-video-pipeline.yml green",
+    next_action: "Register the five required video-pipeline secrets.",
+    blocker: "Repository secrets are still user-provided.",
+  },
+] as const;
+
+export class GaReadinessActionError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "GaReadinessActionError";
+    this.status = status;
+  }
+}
+
+export function handleGaReadinessAction(action: string): GaReadinessSnapshot {
+  if (action === "agent.list_ga_axes") {
+    return buildGaReadinessSnapshot();
+  }
+  throw new GaReadinessActionError(
+    `Unsupported GA readiness action: ${action}`,
+  );
+}
+
+export function buildGaReadinessSnapshot(
+  generatedAt = new Date(),
+): GaReadinessSnapshot {
+  const axes = GA_READINESS_AXES.map((axis) => ({ ...axis }));
+  const greenCount = axes.filter((axis) => axis.status === "green").length;
+  const blockedAxes = axes.filter((axis) => axis.status === "blocked");
+  const overallProgress = Math.round(
+    axes.reduce((sum, axis) => sum + axis.progress, 0) / axes.length,
+  );
+  return {
+    generated_at: generatedAt.toISOString(),
+    ga_eligible: greenCount === axes.length,
+    summary: {
+      axis_count: axes.length,
+      green_count: greenCount,
+      blocked_count: blockedAxes.length,
+      overall_progress: overallProgress,
+      blockers: blockedAxes.map((axis) =>
+        `${axis.code}. ${axis.title}: ${axis.blocker ?? "blocked"}`
+      ),
+    },
+    axes,
+  };
+}

--- a/supabase/functions/app-hub/ga_readiness_test.ts
+++ b/supabase/functions/app-hub/ga_readiness_test.ts
@@ -1,0 +1,43 @@
+import {
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildGaReadinessSnapshot,
+  GA_READINESS_AXES,
+  handleGaReadinessAction,
+} from "./ga_readiness.ts";
+
+Deno.test("GA readiness exposes the five launch axes", () => {
+  const snapshot = buildGaReadinessSnapshot(new Date("2026-05-11T00:00:00Z"));
+
+  assertEquals(snapshot.axes.map((axis) => axis.code), [
+    "A",
+    "B",
+    "C",
+    "D",
+    "E",
+  ]);
+  assertEquals(snapshot.summary.axis_count, 5);
+  assertEquals(snapshot.summary.overall_progress, 24);
+  assertEquals(snapshot.ga_eligible, false);
+});
+
+Deno.test("GA readiness keeps user-owned blockers explicit", () => {
+  const userOwnedBlockedAxes = GA_READINESS_AXES.filter((axis) =>
+    axis.status === "blocked" && axis.owner === "User"
+  );
+
+  assertEquals(userOwnedBlockedAxes.length, 4);
+  assertEquals(
+    userOwnedBlockedAxes.every((axis) => Boolean(axis.blocker)),
+    true,
+  );
+});
+
+Deno.test("handleGaReadinessAction routes the app-hub action", () => {
+  const snapshot = handleGaReadinessAction("agent.list_ga_axes");
+
+  assertEquals(snapshot.axes.length, 5);
+  assertThrows(() => handleGaReadinessAction("agent.unknown_ga_action"));
+});

--- a/supabase/functions/app-hub/index.ts
+++ b/supabase/functions/app-hub/index.ts
@@ -9,6 +9,10 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { AgentGpaActionError, handleAgentGpaAction } from "./agent_gpa.ts";
+import {
+  GaReadinessActionError,
+  handleGaReadinessAction,
+} from "./ga_readiness.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -751,12 +755,21 @@ serve(async (req: Request) => {
         return json({ success: true, ...result });
       }
 
+      // --- GA Launch Readiness Gate (#1640) ---
+      case "agent.list_ga_axes": {
+        const gaReadiness = handleGaReadinessAction(action);
+        return json({ success: true, ga_readiness: gaReadiness });
+      }
+
       default:
         return json({ error: `Unknown action: ${action}` }, 400);
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const status = err instanceof AgentGpaActionError ? err.status : 500;
+    const status = err instanceof AgentGpaActionError ||
+        err instanceof GaReadinessActionError
+      ? err.status
+      : 500;
     return json({ error: message }, status);
   }
 });


### PR DESCRIPTION
﻿## Summary
- add a GA Launch Readiness Gate workflow for #1640 with wiring validation, Deno checks, Flutter analyze/test, and optional critical E2E discovery
- expose `agent.list_ga_axes` from `app-hub` as the GA readiness SSOT for axes A-E (#1640/#1662/#1724)
- surface a collapsible GA Readiness Gate panel on Home with app-hub refresh, offline fallback, blockers, and WBS navigation

## Validation
- `python scripts/check_ga_readiness_gate.py`
- `deno fmt --check supabase/functions/app-hub/index.ts supabase/functions/app-hub/ga_readiness.ts supabase/functions/app-hub/ga_readiness_test.ts`
- `deno lint --config supabase/functions/deno.json supabase/functions/app-hub/ga_readiness.ts supabase/functions/app-hub/ga_readiness_test.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/app-hub/index.ts supabase/functions/app-hub/ga_readiness.ts`
- `deno test --config supabase/functions/deno.json supabase/functions/app-hub/ga_readiness_test.ts`
- `flutter analyze --no-fatal-warnings`
- `flutter test --reporter=compact`

## High-risk ultrareview gate
Claude Code #1 is the high-risk review owner for this two-instance workflow.

High-risk-ultrareview-exception: Codex #1 implemented the scoped handoff while Claude Code #1 remains the review owner; this PR adds a deterministic, authenticated read-only `agent.list_ga_axes` response plus Home visualization and CI wiring. It does not add a data migration, secret access, payment mutation, service-role client expansion, or production write path.

Perspective coverage: security = authenticated app-hub read-only action with static non-secret data; rollback = revert this PR to remove the action, widget, and workflow; data migration = none; prod smoke = post-merge deploy-prod plus GitHub Issues WBS Sync and the new GA readiness workflow; observability = workflow summary/artifact plus Home panel source note. Unresolved ultrareview findings: none.

## Minimal E2E gate
The E2E plan is implementation-detail independent and black-box: verify only input/output behavior visible to a signed-in user or workflow, not private widget internals.

Minimal plan, about three I/O cases:
1. Home opens with GA Readiness Gate collapsed, then expands without layout overflow.
2. Refresh calls `agent.list_ga_axes` and renders five axes A-E with blocked user-owned items visible.
3. The WBS button navigates to `/project-gantt`.

E2E mechanism: Playwright or Flutter integration_test can cover those cases once the repo has a critical E2E harness for Home. E2E-Exception: this PR currently relies on `flutter analyze`, `flutter test`, Deno tests, and the GA readiness workflow because it adds a passive read-only panel and static read model, with no new user mutation or production side effect.

## Notes
- Codex #1 absorbed the implementation side under the two-instance policy. User-owned blockers for pricing, legal entity, banking, and video secrets remain explicit rather than fabricated.
- `e2e/critical/` is not present yet; the workflow records it as a GA Axis A follow-up instead of failing the current gate.
