### PR TITLE
fix: handle WBS issue-instance sync conflicts (#2360)

### DIFF
--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -1174,6 +1174,25 @@ function isWbsTitleInstanceUniqueConflict(
       text.includes("key (title, instance)"));
 }
 
+function isWbsIssueInstanceActiveUniqueConflict(
+  error: { code?: string; message?: string; details?: string } | null,
+): boolean {
+  if (!error) return false;
+  const text = `${error.message ?? ""} ${error.details ?? ""}`.toLowerCase();
+  const isUniqueViolation = error.code === "23505" ||
+    text.includes("duplicate key value violates unique constraint");
+  return isUniqueViolation &&
+    (text.includes("wbs_tasks_issue_instance_active_unique") ||
+      text.includes("key (github_issue_number, instance)"));
+}
+
+function isWbsGithubSyncUniqueConflict(
+  error: { code?: string; message?: string; details?: string } | null,
+): boolean {
+  return isWbsTitleInstanceUniqueConflict(error) ||
+    isWbsIssueInstanceActiveUniqueConflict(error);
+}
+
 function githubIssueLabelNames(issue: Record<string, unknown>): string[] {
   const labels = issue.labels;
   if (!Array.isArray(labels)) return [];
@@ -7331,16 +7350,27 @@ serve(async (req) => {
                 .select(taskSelect)
                 .single();
               if (createError) {
-                if (!isWbsTitleInstanceUniqueConflict(createError)) {
+                if (!isWbsGithubSyncUniqueConflict(createError)) {
                   throw new Error(createError.message);
                 }
-                const { data: conflictingTasks, error: conflictFindError } =
-                  await admin.from("wbs_tasks")
+                const conflictQuery = isWbsIssueInstanceActiveUniqueConflict(
+                    createError,
+                  )
+                  ? admin.from("wbs_tasks")
+                    .select(taskSelect)
+                    .eq("github_issue_number", issueNumber)
+                    .eq("instance", lane)
+                    .neq("status", "completed")
+                    .order("created_at", { ascending: true })
+                    .limit(1)
+                  : admin.from("wbs_tasks")
                     .select(taskSelect)
                     .eq("title", String(payload.title ?? ""))
                     .eq("instance", lane)
                     .order("created_at", { ascending: true })
                     .limit(1);
+                const { data: conflictingTasks, error: conflictFindError } =
+                  await conflictQuery;
                 if (conflictFindError) {
                   throw new Error(conflictFindError.message);
                 }
@@ -7391,6 +7421,61 @@ serve(async (req) => {
               continue;
             }
 
+            const activeDuplicateTasksBeforeUpdate = existing.filter((task) =>
+              String(task.id ?? "") !== String(keeper.id ?? "") &&
+              !isCompletedWbsTask(task)
+            );
+            for (const duplicate of activeDuplicateTasksBeforeUpdate) {
+              const duplicateNote =
+                `Duplicate of WBS task ${keeper.id}; GitHub Issue #${issueNumber} is kept on one canonical WBS row.`;
+              const duplicateStatus = "completed";
+              const duplicateProgress = 100;
+              const duplicateRepairReasons = githubIssueTaskRepairReasons(
+                duplicate,
+                issueNumber,
+                state,
+                canonicalTitle,
+              );
+              duplicateRepairReasons.push("duplicate_wbs_row");
+              const { error: duplicateError } = await admin.from("wbs_tasks")
+                .update({
+                  status: duplicateStatus,
+                  progress: duplicateProgress,
+                  ai_review_status: "manual_override",
+                  remaining_work: duplicateNote,
+                  github_issue_number: issueNumber,
+                  github_issue_url: issueUrl,
+                  github_issue_state: state,
+                  github_issue_labels: labels,
+                  github_issue_synced_at: nowIso,
+                })
+                .eq("id", String(duplicate.id));
+              if (duplicateError) throw new Error(duplicateError.message);
+              Object.assign(duplicate, {
+                status: duplicateStatus,
+                progress: duplicateProgress,
+                ai_review_status: "manual_override",
+                remaining_work: duplicateNote,
+                github_issue_number: issueNumber,
+                github_issue_url: issueUrl,
+                github_issue_state: state,
+                github_issue_labels: labels,
+                github_issue_synced_at: nowIso,
+              });
+              recordWbsRepair(
+                duplicate,
+                issueNumber,
+                duplicateRepairReasons,
+                "issue_duplicate_pre_update",
+              );
+              duplicateWbsTasks.push({
+                id: duplicate.id,
+                kept_id: keeper.id,
+                issue_number: issueNumber,
+              });
+              stats.duplicate_wbs_closed += 1;
+            }
+
             const { data: updated, error: updateError } = await admin.from(
               "wbs_tasks",
             )
@@ -7408,17 +7493,29 @@ serve(async (req) => {
             let conflictRepairTask: Record<string, unknown> | null = null;
             let conflictRepairReasons: string[] = [];
             if (updateError) {
-              if (!isWbsTitleInstanceUniqueConflict(updateError)) {
+              if (!isWbsGithubSyncUniqueConflict(updateError)) {
                 throw new Error(updateError.message);
               }
-              const { data: conflictingTasks, error: conflictFindError } =
-                await admin.from("wbs_tasks")
+              const conflictQuery = isWbsIssueInstanceActiveUniqueConflict(
+                  updateError,
+                )
+                ? admin.from("wbs_tasks")
+                  .select(taskSelect)
+                  .eq("github_issue_number", issueNumber)
+                  .eq("instance", lane)
+                  .neq("id", String(keeper.id))
+                  .neq("status", "completed")
+                  .order("created_at", { ascending: true })
+                  .limit(1)
+                : admin.from("wbs_tasks")
                   .select(taskSelect)
                   .eq("title", String(payload.title ?? ""))
                   .eq("instance", lane)
                   .neq("id", String(keeper.id))
                   .order("created_at", { ascending: true })
                   .limit(1);
+              const { data: conflictingTasks, error: conflictFindError } =
+                await conflictQuery;
               if (conflictFindError) throw new Error(conflictFindError.message);
               const conflictingTask = (conflictingTasks ?? [])[0] as
                 | Record<string, unknown>
@@ -7484,7 +7581,8 @@ serve(async (req) => {
               allTasks.push(updatedKeeper);
             }
             const duplicateTasks = existing.filter((task) =>
-              String(task.id ?? "") !== String(updatedKeeper.id ?? "")
+              String(task.id ?? "") !== String(updatedKeeper.id ?? "") &&
+              !isCompletedWbsTask(task)
             );
             for (const duplicate of duplicateTasks) {
               const duplicateNote =


### PR DESCRIPTION
﻿## Summary
- handle `wbs_tasks_issue_instance_active_unique` conflicts during `wbs.sync_github_issues`
- complete active duplicate WBS rows before updating the canonical GitHub issue row so the active unique index is respected
- recover both title-instance and issue-instance unique conflicts when insert/update races find an existing canonical row

## Root cause
Post-#2171 WBS Sync was failing in batches 4/8/9 with HTTP 500:
`duplicate key value violates unique constraint "wbs_tasks_issue_instance_active_unique"`.
The sync updated the canonical row before marking active duplicate rows completed, which can violate the new active `(github_issue_number, instance)` unique index.

## Validation
- `deno fmt supabase/functions/tools-hub/index.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/tools-hub/index.ts`
- `deno lint --config supabase/functions/deno.json supabase/functions/tools-hub/index.ts`
- `python scripts/check_edge_function_imports.py`

## High-risk ultrareview gate
Claude Code #1 is the high-risk review owner for this two-instance workflow.

High-risk-ultrareview-exception: Codex #1 is applying a scoped production hotfix for the WBS sync post-deploy blocker. The change only narrows recovery for existing WBS duplicate rows inside `tools-hub`; it does not add a data migration, secret access, new external integration, payment path, or service-role expansion beyond the existing sync action.

Perspective coverage: security = no new credentials or auth surface; rollback = revert this PR to restore prior sync behavior; data migration = none, only runtime duplicate-row completion already performed by the sync; prod smoke = deploy-prod plus a manual GitHub Issues WBS Sync run must pass after merge; observability = workflow logs show batch success/failure and duplicate repair stats. Unresolved ultrareview findings: none.

## Minimal E2E gate
The E2E plan is implementation-detail independent and black-box: verify workflow input/output, not private implementation internals.

Minimal plan, about three I/O cases:
1. Trigger GitHub Issues WBS Sync on main.
2. Confirm batches that previously hit active issue-instance duplicate conflicts complete without HTTP 500.
3. Confirm the aggregated WBS sync response stays `success: true` and downstream close/mirror steps run.

E2E mechanism: this is covered by GitHub Actions workflow execution rather than browser Playwright. E2E-Exception: the change is a server-side scheduled sync conflict recovery path with no user-facing browser flow, so no `integration_test/` or `test/e2e/` file is added.

## Notes
Follow-up to PR #2360 deploy verification: deploy-prod succeeded, but WBS Sync failed reproducibly on the active issue-instance unique index.
