### PR TITLE
fix: preflight WBS issue-instance duplicates (#2360)

### DIFF
--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -7247,6 +7247,131 @@ serve(async (req) => {
             });
             stats.stale_wbs_repaired += 1;
           };
+          const completeDuplicateWbsTask = async ({
+            duplicate,
+            keptId,
+            issueNumber,
+            issueUrl,
+            state,
+            labels,
+            canonicalTitle,
+            note,
+            reason,
+            context,
+          }: {
+            duplicate: Record<string, unknown>;
+            keptId: unknown;
+            issueNumber: number;
+            issueUrl: string;
+            state: string;
+            labels: string[];
+            canonicalTitle: string;
+            note: string;
+            reason: string;
+            context: string;
+          }) => {
+            const duplicateId = String(duplicate.id ?? "");
+            if (!duplicateId) return;
+            const duplicateRepairReasons = githubIssueTaskRepairReasons(
+              duplicate,
+              issueNumber,
+              state,
+              canonicalTitle,
+            );
+            duplicateRepairReasons.push(reason);
+            const statusPatch = {
+              status: "completed",
+              progress: 100,
+              ai_review_status: "manual_override",
+              remaining_work: note,
+            };
+            const metadataPatch = {
+              github_issue_number: issueNumber,
+              github_issue_url: issueUrl ||
+                String(duplicate.github_issue_url ?? "") ||
+                null,
+              github_issue_state: state,
+              github_issue_labels: labels.length
+                ? labels
+                : (duplicate.github_issue_labels ?? []),
+              github_issue_synced_at: nowIso,
+            };
+            const { error: statusError } = await admin.from("wbs_tasks")
+              .update(statusPatch)
+              .eq("id", duplicateId);
+            if (statusError) throw new Error(statusError.message);
+            const { error: metadataError } = await admin.from("wbs_tasks")
+              .update(metadataPatch)
+              .eq("id", duplicateId);
+            if (metadataError) throw new Error(metadataError.message);
+            Object.assign(duplicate, statusPatch, metadataPatch);
+            recordWbsRepair(
+              duplicate,
+              issueNumber,
+              duplicateRepairReasons,
+              context,
+            );
+            duplicateWbsTasks.push({
+              id: duplicateId,
+              kept_id: keptId,
+              issue_number: issueNumber,
+              reason,
+            });
+            stats.duplicate_wbs_closed += 1;
+          };
+          const completeActiveIssueInstanceConflicts = async ({
+            issueNumber,
+            lane,
+            keepId,
+            issueUrl,
+            state,
+            labels,
+            canonicalTitle,
+          }: {
+            issueNumber: number;
+            lane: string;
+            keepId: string;
+            issueUrl: string;
+            state: string;
+            labels: string[];
+            canonicalTitle: string;
+          }) => {
+            const { data: activeTasks, error: activeTasksError } = await admin
+              .from("wbs_tasks")
+              .select(taskSelect)
+              .eq("github_issue_number", issueNumber)
+              .eq("instance", lane)
+              .neq("status", "completed")
+              .order("created_at", { ascending: true, nullsFirst: true })
+              .order("id", { ascending: true });
+            if (activeTasksError) throw new Error(activeTasksError.message);
+            for (
+              const activeTask of (activeTasks ?? []) as Array<
+                Record<string, unknown>
+              >
+            ) {
+              const activeTaskId = String(activeTask.id ?? "");
+              if (!activeTaskId || activeTaskId === keepId) continue;
+              const inMemoryTask = allTasks.find((task) =>
+                String(task.id ?? "") === activeTaskId
+              ) ?? activeTask;
+              await completeDuplicateWbsTask({
+                duplicate: inMemoryTask,
+                keptId: keepId || "pending-canonical",
+                issueNumber,
+                issueUrl,
+                state,
+                labels,
+                canonicalTitle,
+                note:
+                  `Duplicate active WBS task for GitHub Issue #${issueNumber} and instance ${lane}; kept WBS task ${
+                    keepId || "pending canonical"
+                  } as canonical.`,
+                reason: "duplicate_issue_instance",
+                context: "issue_instance_preflight",
+              });
+            }
+          };
 
           for (const [issueNumber, issue] of issuesByNumber.entries()) {
             const issueTitle = String(issue.title ?? `Issue #${issueNumber}`)
@@ -7337,6 +7462,28 @@ serve(async (req) => {
               github_issue_synced_at: nowIso,
             };
             const canonicalTitle = String(payload.title ?? "");
+            const activeIssueInstanceRows = await admin.from("wbs_tasks")
+              .select("id")
+              .eq("github_issue_number", issueNumber)
+              .eq("instance", lane)
+              .neq("status", "completed")
+              .order("created_at", { ascending: true, nullsFirst: true })
+              .order("id", { ascending: true });
+            if (activeIssueInstanceRows.error) {
+              throw new Error(activeIssueInstanceRows.error.message);
+            }
+            const activeIssueInstanceKeepId = keeper?.id
+              ? String(keeper.id)
+              : String(activeIssueInstanceRows.data?.[0]?.id ?? "");
+            await completeActiveIssueInstanceConflicts({
+              issueNumber,
+              lane,
+              keepId: activeIssueInstanceKeepId,
+              issueUrl,
+              state,
+              labels,
+              canonicalTitle,
+            });
             if (!isClosed && currentCompleted && !closureReady) {
               payload.remaining_work =
                 "GitHub Issue is still open; WBS completion must pass AI review before the issue can be closed.";
@@ -7426,54 +7573,19 @@ serve(async (req) => {
               !isCompletedWbsTask(task)
             );
             for (const duplicate of activeDuplicateTasksBeforeUpdate) {
-              const duplicateNote =
-                `Duplicate of WBS task ${keeper.id}; GitHub Issue #${issueNumber} is kept on one canonical WBS row.`;
-              const duplicateStatus = "completed";
-              const duplicateProgress = 100;
-              const duplicateRepairReasons = githubIssueTaskRepairReasons(
+              await completeDuplicateWbsTask({
                 duplicate,
+                keptId: keeper.id,
                 issueNumber,
+                issueUrl,
                 state,
+                labels,
                 canonicalTitle,
-              );
-              duplicateRepairReasons.push("duplicate_wbs_row");
-              const { error: duplicateError } = await admin.from("wbs_tasks")
-                .update({
-                  status: duplicateStatus,
-                  progress: duplicateProgress,
-                  ai_review_status: "manual_override",
-                  remaining_work: duplicateNote,
-                  github_issue_number: issueNumber,
-                  github_issue_url: issueUrl,
-                  github_issue_state: state,
-                  github_issue_labels: labels,
-                  github_issue_synced_at: nowIso,
-                })
-                .eq("id", String(duplicate.id));
-              if (duplicateError) throw new Error(duplicateError.message);
-              Object.assign(duplicate, {
-                status: duplicateStatus,
-                progress: duplicateProgress,
-                ai_review_status: "manual_override",
-                remaining_work: duplicateNote,
-                github_issue_number: issueNumber,
-                github_issue_url: issueUrl,
-                github_issue_state: state,
-                github_issue_labels: labels,
-                github_issue_synced_at: nowIso,
+                note:
+                  `Duplicate of WBS task ${keeper.id}; GitHub Issue #${issueNumber} is kept on one canonical WBS row.`,
+                reason: "duplicate_wbs_row",
+                context: "issue_duplicate_pre_update",
               });
-              recordWbsRepair(
-                duplicate,
-                issueNumber,
-                duplicateRepairReasons,
-                "issue_duplicate_pre_update",
-              );
-              duplicateWbsTasks.push({
-                id: duplicate.id,
-                kept_id: keeper.id,
-                issue_number: issueNumber,
-              });
-              stats.duplicate_wbs_closed += 1;
             }
 
             const { data: updated, error: updateError } = await admin.from(
@@ -7585,54 +7697,19 @@ serve(async (req) => {
               !isCompletedWbsTask(task)
             );
             for (const duplicate of duplicateTasks) {
-              const duplicateNote =
-                `Duplicate of WBS task ${updatedKeeper.id}; GitHub Issue #${issueNumber} is kept on one canonical WBS row.`;
-              const duplicateStatus = "completed";
-              const duplicateProgress = 100;
-              const duplicateRepairReasons = githubIssueTaskRepairReasons(
+              await completeDuplicateWbsTask({
                 duplicate,
+                keptId: updatedKeeper.id,
                 issueNumber,
+                issueUrl,
                 state,
+                labels,
                 canonicalTitle,
-              );
-              duplicateRepairReasons.push("duplicate_wbs_row");
-              const { error: duplicateError } = await admin.from("wbs_tasks")
-                .update({
-                  status: duplicateStatus,
-                  progress: duplicateProgress,
-                  ai_review_status: "manual_override",
-                  remaining_work: duplicateNote,
-                  github_issue_number: issueNumber,
-                  github_issue_url: issueUrl,
-                  github_issue_state: state,
-                  github_issue_labels: labels,
-                  github_issue_synced_at: nowIso,
-                })
-                .eq("id", String(duplicate.id));
-              if (duplicateError) throw new Error(duplicateError.message);
-              Object.assign(duplicate, {
-                status: duplicateStatus,
-                progress: duplicateProgress,
-                ai_review_status: "manual_override",
-                remaining_work: duplicateNote,
-                github_issue_number: issueNumber,
-                github_issue_url: issueUrl,
-                github_issue_state: state,
-                github_issue_labels: labels,
-                github_issue_synced_at: nowIso,
+                note:
+                  `Duplicate of WBS task ${updatedKeeper.id}; GitHub Issue #${issueNumber} is kept on one canonical WBS row.`,
+                reason: "duplicate_wbs_row",
+                context: "issue_duplicate_update",
               });
-              recordWbsRepair(
-                duplicate,
-                issueNumber,
-                duplicateRepairReasons,
-                "issue_duplicate_update",
-              );
-              duplicateWbsTasks.push({
-                id: duplicate.id,
-                kept_id: updatedKeeper.id,
-                issue_number: issueNumber,
-              });
-              stats.duplicate_wbs_closed += 1;
             }
           }
 
@@ -7691,6 +7768,7 @@ serve(async (req) => {
                 continue;
               }
               const issueNumber = githubIssueNumberFromTask(duplicate);
+              if (!issueNumber) continue;
               const issue = issueNumber
                 ? issuesByNumber.get(issueNumber)
                 : null;
@@ -7711,64 +7789,20 @@ serve(async (req) => {
                   String(issue.title ?? `Issue #${issueNumber}`).trim()
                 }`
                 : String(keeper.title ?? duplicate.title ?? "");
-              const duplicateNote =
-                `Duplicate GitHub-origin WBS title; kept WBS task ${keeper.id} as canonical.`;
-              const duplicateStatus = "completed";
-              const duplicateProgress = 100;
-              const duplicateRepairReasons = githubIssueTaskRepairReasons(
+              await completeDuplicateWbsTask({
                 duplicate,
-                Number(issueNumber),
+                issueNumber,
+                issueUrl,
                 state,
+                labels,
                 canonicalTitle,
-              );
-              duplicateRepairReasons.push("duplicate_title");
-              const { error: duplicateError } = await admin.from("wbs_tasks")
-                .update({
-                  status: duplicateStatus,
-                  progress: duplicateProgress,
-                  ai_review_status: "manual_override",
-                  remaining_work: duplicateNote,
-                  github_issue_url:
-                    (issueUrl || String(duplicate.github_issue_url ?? "")) ||
-                    null,
-                  github_issue_number: issueNumber,
-                  github_issue_state: state,
-                  github_issue_labels: labels.length
-                    ? labels
-                    : (duplicate.github_issue_labels ?? []),
-                  github_issue_synced_at: nowIso,
-                })
-                .eq("id", duplicateId);
-              if (duplicateError) throw new Error(duplicateError.message);
-              Object.assign(duplicate, {
-                status: duplicateStatus,
-                progress: duplicateProgress,
-                ai_review_status: "manual_override",
-                remaining_work: duplicateNote,
-                github_issue_number: issueNumber,
-                github_issue_url: issueUrl ||
-                  String(duplicate.github_issue_url ?? "") ||
-                  null,
-                github_issue_state: state,
-                github_issue_labels: labels.length
-                  ? labels
-                  : (duplicate.github_issue_labels ?? []),
-                github_issue_synced_at: nowIso,
-              });
-              recordWbsRepair(
-                duplicate,
-                Number(issueNumber),
-                duplicateRepairReasons,
-                "title_duplicate_update",
-              );
-              duplicateTaskIds.add(duplicateId);
-              duplicateWbsTasks.push({
-                id: duplicateId,
-                kept_id: keeper.id,
-                issue_number: issueNumber,
+                keptId: keeper.id,
+                note:
+                  `Duplicate GitHub-origin WBS title; kept WBS task ${keeper.id} as canonical.`,
                 reason: "duplicate_title",
+                context: "title_duplicate_update",
               });
-              stats.duplicate_wbs_closed += 1;
+              duplicateTaskIds.add(duplicateId);
             }
           }
 


### PR DESCRIPTION
﻿## Summary
- Add a WBS Sync preflight pass for active `(github_issue_number, instance)` rows before canonical GitHub Issue updates.
- Complete duplicate WBS rows in two phases: first mark `status=completed`, then mirror GitHub metadata, so the partial unique index is not touched while the row is still active.
- Reuse the two-phase completion helper for issue duplicates and title duplicates surfaced during scheduled sync.

## Context
Follow-up to #2362 after manual GitHub Issues WBS Sync run `25682299350` still failed on batches 4/8/9 with `wbs_tasks_issue_instance_active_unique`.

## Validation
- `deno fmt supabase/functions/tools-hub/index.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/tools-hub/index.ts`
- `deno lint --config supabase/functions/deno.json supabase/functions/tools-hub/index.ts`
- `python scripts/check_edge_function_imports.py`
- `git diff --check`

## High-risk review gate
- High-risk reviewer: Claude Code #1
- Exception: `high-risk-ultrareview-exception`
- Security: no new secrets, auth surfaces, or public endpoints; only WBS Sync duplicate repair ordering changes.
- Rollback: revert this PR; WBS Sync will return to the prior conflict behavior.
- Data migration: none. Runtime repair only marks duplicate WBS mirror rows completed.
- Production smoke: after merge, confirm deploy-prod success and manual GitHub Issues WBS Sync success.
- Observability: WBS Sync response reports `duplicate_wbs_closed`, `repaired_wbs_tasks`, and failed batch details.
- Unresolved ultrareview findings: none.

## Minimal E2E declaration
- The E2E test is implementation-detail independent and validates externally observable scheduler outcomes, not helper internals.
- E2E-Exception: backend scheduler/runtime repair only; no browser UI path changed.
- Minimal logical cases:
  1. Given an active duplicate issue-instance row, when sync runs, then duplicate is completed before canonical update.
  2. Given a title duplicate row, when sync runs, then status is completed before GitHub metadata is mirrored.
  3. Given no duplicates, when sync runs, then canonical updates continue without extra closure rows.
