### PR TITLE
ci: reduce WBS sync batch timeout risk (#2360)

### DIFF
--- a/.github/workflows/issue-to-wbs.yml
+++ b/.github/workflows/issue-to-wbs.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
     steps:
       - name: Install REST issue fetcher
         run: |
@@ -179,8 +179,8 @@ jobs:
       - name: Sync issues to WBS
         env:
           REPO: ${{ github.repository }}
-          WBS_SYNC_BATCH_SIZE: "100"
-          WBS_SYNC_CURL_MAX_TIME: "90"
+          WBS_SYNC_BATCH_SIZE: "50"
+          WBS_SYNC_CURL_MAX_TIME: "120"
           WBS_SYNC_GLOBAL_REPAIRS: "false"
         run: |
           if [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
@@ -226,6 +226,7 @@ jobs:
             echo "Syncing WBS batch ${batch_number}/${total_batches}: ${payload_path}"
             attempt=1
             while true; do
+              set +e
               HTTP_CODE=$(curl -sS -o /tmp/wbs-sync-batch-response.json -w "%{http_code}" \
                 -X POST "$SUPABASE_URL/functions/v1/tools-hub" \
                 -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
@@ -234,6 +235,12 @@ jobs:
                 --connect-timeout 10 \
                 --max-time "$WBS_SYNC_CURL_MAX_TIME" \
                 --data-binary @"$payload_path")
+              CURL_EXIT=$?
+              set -e
+              if [ "$CURL_EXIT" -ne 0 ]; then
+                HTTP_CODE=599
+                printf '{"success":false,"error":"curl exited with %s"}\n' "$CURL_EXIT" > /tmp/wbs-sync-batch-response.json
+              fi
 
               if [ "$HTTP_CODE" -lt 500 ] || [ "$attempt" -ge 2 ]; then
                 break


### PR DESCRIPTION
﻿## Summary
- Lower GitHub Issues WBS Sync batch size from 100 to 50 to keep slow duplicate-repair batches below the curl timeout.
- Raise per-request curl max time to 120 seconds and job timeout to 45 minutes.
- Capture curl non-zero exits as HTTP 599 so retries/failure aggregation handle timeouts instead of bash `set -e` aborting mid-loop.

## Context
Follow-up to #2365: run `25688022079` no longer surfaced the unique conflict directly, but batch 4 timed out with `curl: (28)` and exited before the batch failure aggregator could run.

## Validation
- `git diff --check`
- Workflow snippet check for timeout/batch/curl-exit resilience fields.

## High-risk review gate
- High-risk reviewer: Claude Code #1
- Exception: `high-risk-ultrareview-exception`
- Security: no new secrets or permissions; workflow uses existing `SUPABASE_SERVICE_ROLE_KEY` path.
- Rollback: revert this PR to restore the previous WBS Sync batch and timeout settings.
- Data migration: none.
- Production smoke: after merge, confirm deploy-prod success and GitHub Issues WBS Sync success.
- Observability: curl timeout is now represented as HTTP 599 and included in existing batch failure logs.
- Unresolved ultrareview findings: none.

## Minimal E2E declaration
- The E2E test is implementation-detail independent and validates externally observable scheduler outcomes, not helper internals.
- E2E-Exception: GitHub Actions scheduler resilience only; no browser UI path changed.
- Minimal logical cases:
  1. Given a slow batch, when curl exits non-zero, then the workflow records HTTP 599 and can retry/aggregate it.
  2. Given normal batches, when sync runs, then all responses are aggregated as before.
  3. Given the full issue set, when sync runs, then smaller batches reduce per-request timeout risk.
