### PR TITLE
ci: add blog news production smoke (#1950)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,6 +13,7 @@
 | **Deploy to Staging** | `deploy-staging.yml` | `staging` へのpush | ステージング環境デプロイ (concurrency制御・timeout付き) |
 | **Deploy to Production** | `deploy-prod.yml` | `main` へのpush | 本番環境デプロイ + バージョニング (concurrency制御・timeout付き) |
 | **Release Readiness Gate** | `release-readiness.yml` | deploy-prod success / daily 06:40 JST / manual | #1556 alpha gate: migration + EF import + Deno lint + readiness hub Deno check + Flutter build + production route + tools-hub/schedule-hub + Notion + Slack + WBS update |
+| **Blog News Production Smoke** | `blog-news-prod-smoke.yml` | deploy-prod success / manual | #1950 blog/news E2E guard: `/blog`, `/blog/compose`, `/news-rss`, optional `/blog/post?id=<postId>`, RSS Edge Function, and read-only `blog_posts` queue state |
 | **Daily Report** | `daily-report.yml` | 毎日 07:30 JST / 手動 | 日次レポート生成 + X投稿 + 競合モニタリング + schedule_task_runs記録 + Job Summary |
 | **CS Check** | `cs-check.yml` | 毎時 07分 / 手動 | CS自動対応 + PR自動レビュー + schedule_task_runs記録 + Job Summary |
 | **Edge Function Audit** | `edge-function-audit.yml` | 毎時 47分 / 手動 | EF UI導線カバレッジチェック + schedule_task_runs記録 + Job Summary |

--- a/.github/workflows/blog-news-prod-smoke.yml
+++ b/.github/workflows/blog-news-prod-smoke.yml
@@ -1,0 +1,56 @@
+name: Blog News Production Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_rss:
+        description: "true to skip live RSS Edge Function smoke"
+        required: false
+        default: "false"
+  workflow_run:
+    workflows: ["Deploy to Production"]
+    types: [completed]
+
+concurrency:
+  group: blog-news-prod-smoke
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Blog/news production smoke
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SITE_URL: https://my-web-app-b67f4.web.app
+      SUPABASE_URL: https://smmkxxavexumewbfaqpy.supabase.co
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SKIP_RSS: ${{ github.event.inputs.skip_rss || 'false' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run production smoke
+        run: |
+          mkdir -p tmp/blog-news-prod-smoke
+          ARGS=(
+            --site-url "$SITE_URL"
+            --supabase-url "$SUPABASE_URL"
+            --report tmp/blog-news-prod-smoke/report.json
+          )
+          if [ "$SKIP_RSS" = "true" ]; then
+            ARGS+=(--skip-rss)
+          fi
+          python3 scripts/blog_news_prod_smoke.py "${ARGS[@]}"
+
+      - name: Upload smoke report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: blog-news-prod-smoke-report
+          path: tmp/blog-news-prod-smoke/report.json
+          if-no-files-found: ignore

--- a/docs/BLOG_NEWS_AUTOMATION_RUNBOOK.md
+++ b/docs/BLOG_NEWS_AUTOMATION_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Blog and News Automation Runbook
 
-Last updated: 2026-05-05
+Last updated: 2026-05-12
 
 ## Blog Flow
 
@@ -20,6 +20,8 @@ Last updated: 2026-05-05
 - Qiita tags are limited to 5 and dev.to tags to 4 by `schedule-hub`.
 - Existing `blog-engagement.yml` syncs engagement, and the UI exposes manual
   sync for recovery.
+- Production route and RSS regressions are caught by
+  `blog-news-prod-smoke.yml` before manual external posting checks are needed.
 
 ## News Flow
 
@@ -56,6 +58,22 @@ Last updated: 2026-05-05
    `NEWS_SIGNAL_LINT_START` and `NEWS_SIGNAL_LINT_END`.
 5. If a `ready` post has an error or high-risk finding, the action moves it back
    to `draft` so the publish workflow cannot send it without review.
+
+## Production Smoke Flow
+
+1. `.github/workflows/blog-news-prod-smoke.yml` runs after a successful
+   production deploy and can also be run manually.
+2. `scripts/blog_news_prod_smoke.py` checks the public Flutter routes:
+   `/blog`, `/blog/compose`, and `/news-rss`.
+3. When `SUPABASE_SERVICE_ROLE_KEY` is available, the smoke performs read-only
+   `blog_posts` checks for the latest posted article and the `ready` queue. If a
+   posted article exists, it also checks `/blog/post?id=<postId>`.
+4. The smoke calls `tools-hub` `rss.fetch_latest` with the public anon key read
+   from `lib/main.dart`. Source outages are reported as warnings when the Edge
+   Function still returns a structured partial-success payload.
+5. The smoke writes `tmp/blog-news-prod-smoke/report.json` as an Actions
+   artifact. It never calls `blog.publish_post`, `blog.auto_publish`, or
+   external posting APIs.
 
 ## Two-Instance Operating Rule
 

--- a/scripts/blog_news_prod_smoke.py
+++ b/scripts/blog_news_prod_smoke.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Production smoke checks for the blog/news automation surface.
+
+The script intentionally keeps write-side checks optional. Public route and RSS
+Edge Function checks can run on every production deploy, while service-role
+checks only read blog_posts queue state when the secret is available.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SITE_URL = "https://my-web-app-b67f4.web.app"
+DEFAULT_SUPABASE_URL = "https://smmkxxavexumewbfaqpy.supabase.co"
+DEFAULT_RSS_FEEDS = [
+    {
+        "title": "Google AI Blog",
+        "url": "https://blog.google/technology/ai/rss/",
+        "category": "AI",
+    },
+    {
+        "title": "OpenAI News",
+        "url": "https://openai.com/news/rss.xml",
+        "category": "AI",
+    },
+]
+APP_MARKERS = ("flutter_bootstrap.js", "main.dart.js", "自分株式会社")
+
+
+@dataclass
+class SmokeCheck:
+    name: str
+    status: str
+    details: dict[str, Any]
+
+
+def normalize_base_url(value: str) -> str:
+    return value.rstrip("/")
+
+
+def check(name: str, status: str, **details: Any) -> SmokeCheck:
+    return SmokeCheck(name=name, status=status, details=details)
+
+
+def request_text(url: str, timeout: int) -> tuple[int, str, str]:
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "my-web-app-blog-news-prod-smoke/1.0"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        body = response.read().decode("utf-8", errors="replace")
+        content_type = response.headers.get("content-type", "")
+        return int(response.status), content_type, body
+
+
+def request_json(
+    url: str,
+    payload: dict[str, Any] | None,
+    headers: dict[str, str],
+    timeout: int,
+    method: str | None = None,
+) -> tuple[int, dict[str, Any] | list[Any]]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers=headers,
+        method=method or ("POST" if payload is not None else "GET"),
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        raw = response.read().decode("utf-8", errors="replace")
+        parsed = json.loads(raw) if raw.strip() else {}
+        return int(response.status), parsed
+
+
+def load_anon_key(repo_root: Path) -> str:
+    env_key = os.environ.get("SUPABASE_ANON_KEY", "").strip()
+    if env_key:
+        return env_key
+    main_dart = repo_root / "lib" / "main.dart"
+    if not main_dart.exists():
+        return ""
+    text = main_dart.read_text(encoding="utf-8", errors="replace")
+    match = re.search(r"anonKey:\s*[\r\n\s]*'([^']+)'", text)
+    return match.group(1).strip() if match else ""
+
+
+def check_public_routes(site_url: str, timeout: int, post_id: str = "") -> list[SmokeCheck]:
+    routes = [
+        ("blog_index", "/blog"),
+        ("blog_compose", "/blog/compose"),
+        ("news_rss", "/news-rss"),
+    ]
+    if post_id:
+        routes.append(("blog_post", f"/blog/post?id={urllib.parse.quote(post_id)}"))
+
+    checks: list[SmokeCheck] = []
+    for name, route in routes:
+        url = f"{normalize_base_url(site_url)}{route}"
+        try:
+            status, content_type, body = request_text(url, timeout)
+        except urllib.error.HTTPError as exc:
+            checks.append(check(name, "fail", url=url, http_status=exc.code))
+            continue
+        except Exception as exc:  # pragma: no cover - exact transport errors vary.
+            checks.append(check(name, "fail", url=url, error=str(exc)))
+            continue
+
+        has_marker = any(marker in body for marker in APP_MARKERS)
+        if status != 200 or "text/html" not in content_type.lower() or not has_marker:
+            checks.append(
+                check(
+                    name,
+                    "fail",
+                    url=url,
+                    http_status=status,
+                    content_type=content_type,
+                    app_marker=has_marker,
+                )
+            )
+        else:
+            checks.append(
+                check(
+                    name,
+                    "pass",
+                    url=url,
+                    http_status=status,
+                    content_type=content_type,
+                )
+            )
+    return checks
+
+
+def service_headers(key: str) -> dict[str, str]:
+    return {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+
+
+def query_blog_queue_state(
+    supabase_url: str,
+    service_key: str,
+    timeout: int,
+) -> tuple[list[SmokeCheck], str]:
+    if not service_key:
+        return [
+            check(
+                "blog_posts_queue_read",
+                "warn",
+                reason="SUPABASE_SERVICE_ROLE_KEY not provided; skipped read-only queue smoke.",
+            )
+        ], ""
+
+    base = normalize_base_url(supabase_url)
+    headers = service_headers(service_key)
+    checks: list[SmokeCheck] = []
+    latest_post_id = ""
+
+    latest_url = (
+        f"{base}/rest/v1/blog_posts?"
+        "select=id,title,status,created_at&status=in.(posted,published)"
+        "&order=created_at.desc&limit=1"
+    )
+    ready_url = (
+        f"{base}/rest/v1/blog_posts?"
+        "select=id,title,status,created_at&status=eq.ready"
+        "&order=created_at.asc&limit=5"
+    )
+
+    try:
+        latest_status, latest_rows = request_json(
+            latest_url,
+            payload=None,
+            headers=headers,
+            timeout=timeout,
+            method="GET",
+        )
+        if isinstance(latest_rows, list) and latest_rows:
+            first = latest_rows[0]
+            if isinstance(first, dict):
+                latest_post_id = str(first.get("id") or "")
+        checks.append(
+            check(
+                "blog_posts_latest_post_read",
+                "pass",
+                http_status=latest_status,
+                found=bool(latest_post_id),
+            )
+        )
+    except Exception as exc:
+        checks.append(check("blog_posts_latest_post_read", "fail", error=str(exc)))
+
+    try:
+        ready_status, ready_rows = request_json(
+            ready_url,
+            payload=None,
+            headers=headers,
+            timeout=timeout,
+            method="GET",
+        )
+        ready_count = len(ready_rows) if isinstance(ready_rows, list) else 0
+        checks.append(
+            check(
+                "blog_posts_ready_queue_read",
+                "pass",
+                http_status=ready_status,
+                ready_count=ready_count,
+            )
+        )
+    except Exception as exc:
+        checks.append(check("blog_posts_ready_queue_read", "fail", error=str(exc)))
+
+    return checks, latest_post_id
+
+
+def check_rss_fetch(
+    supabase_url: str,
+    anon_key: str,
+    timeout: int,
+    feeds: list[dict[str, str]],
+) -> SmokeCheck:
+    if not anon_key:
+        return check(
+            "rss_fetch_latest",
+            "warn",
+            reason="SUPABASE_ANON_KEY not provided and could not be read from lib/main.dart.",
+        )
+    endpoint = f"{normalize_base_url(supabase_url)}/functions/v1/tools-hub"
+    payload = {
+        "action": "rss.fetch_latest",
+        "feeds": feeds,
+        "per_feed_limit": 3,
+        "limit": 8,
+        "signal_limit": 4,
+    }
+    try:
+        status, data = request_json(
+            endpoint,
+            payload=payload,
+            headers=service_headers(anon_key),
+            timeout=timeout,
+        )
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return check(
+            "rss_fetch_latest",
+            "fail",
+            http_status=exc.code,
+            error=body[:500],
+        )
+    except Exception as exc:  # pragma: no cover - exact transport errors vary.
+        return check("rss_fetch_latest", "fail", error=str(exc))
+
+    if not isinstance(data, dict) or data.get("success") is not True:
+        return check("rss_fetch_latest", "fail", http_status=status, response=data)
+
+    item_count = len(data.get("items") or [])
+    signal_count = len(data.get("signals") or [])
+    error_count = len(data.get("errors") or [])
+    status_name = "pass" if item_count > 0 else "warn"
+    return check(
+        "rss_fetch_latest",
+        status_name,
+        http_status=status,
+        source_count=data.get("source_count"),
+        item_count=item_count,
+        signal_count=signal_count,
+        error_count=error_count,
+    )
+
+
+def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    repo_root = Path(args.repo_root)
+    service_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+    anon_key = load_anon_key(repo_root)
+    checks: list[SmokeCheck] = []
+
+    queue_checks, latest_post_id = query_blog_queue_state(
+        args.supabase_url,
+        service_key,
+        args.timeout,
+    )
+    checks.extend(queue_checks)
+    checks.extend(check_public_routes(args.site_url, args.timeout, latest_post_id))
+    if not args.skip_rss:
+        checks.append(
+            check_rss_fetch(
+                args.supabase_url,
+                anon_key,
+                args.timeout,
+                DEFAULT_RSS_FEEDS,
+            )
+        )
+
+    failures = [item for item in checks if item.status == "fail"]
+    return {
+        "status": "fail" if failures else "pass",
+        "site_url": normalize_base_url(args.site_url),
+        "supabase_url": normalize_base_url(args.supabase_url),
+        "checks": [asdict(item) for item in checks],
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--site-url", default=os.environ.get("SITE_URL", DEFAULT_SITE_URL))
+    parser.add_argument(
+        "--supabase-url",
+        default=os.environ.get("SUPABASE_URL", DEFAULT_SUPABASE_URL),
+    )
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--timeout", type=int, default=20)
+    parser.add_argument("--skip-rss", action="store_true")
+    parser.add_argument("--report", default="")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    report = build_report(args)
+    text = json.dumps(report, ensure_ascii=False, indent=2)
+    print(text)
+    if args.report:
+        report_path = Path(args.report)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(text + "\n", encoding="utf-8")
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/supabase/migrations/20260512114500_update_wbs_progress_blog_news_prod_smoke_codex1.sql
+++ b/supabase/migrations/20260512114500_update_wbs_progress_blog_news_prod_smoke_codex1.sql
@@ -1,0 +1,26 @@
+-- Codex #1: Issue #1950 blog/news production smoke slice.
+--
+-- This records the deterministic production E2E guard for blog/news routes,
+-- RSS Edge Function behavior, and read-only blog_posts queue visibility.
+
+UPDATE public.wbs_tasks
+SET status = 'in_progress',
+    progress = GREATEST(progress, 45),
+    recovery_plan = COALESCE(
+      NULLIF(trim(recovery_plan), ''),
+      'Codex #1 added blog/news production smoke automation. Remaining work: run external posting with real Qiita/dev.to credentials when user-approved, keep ready queue healthy, and close #1950 after live side-effect checks are accepted.'
+    ),
+    recovery_planned_at = COALESCE(recovery_planned_at, NOW()),
+    description = COALESCE(description, '') ||
+      E'\n\n[Codex #1 / 2026-05-12] Issue #1950 advanced: production smoke now checks /blog, /blog/compose, /news-rss, optional /blog/post?id=<postId>, tools-hub rss.fetch_latest, and read-only blog_posts queue state after deploy.'
+WHERE github_issue_number = 1950;
+
+INSERT INTO public.development_achievements (title, description, completed_at)
+SELECT
+  'Codex #1: blog/news production smoke (#1950)',
+  'Added a deterministic GitHub Actions production smoke for blog/news routes, RSS Edge Function behavior, and read-only blog_posts queue visibility while keeping external publish side effects behind existing manual/user-approved gates.',
+  '2026-05-12'
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.development_achievements
+  WHERE title = 'Codex #1: blog/news production smoke (#1950)'
+);

--- a/test/scripts/test_blog_news_prod_smoke.py
+++ b/test/scripts/test_blog_news_prod_smoke.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import blog_news_prod_smoke as smoke  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, status: int, body: str, content_type: str = "application/json"):
+        self.status = status
+        self._body = body.encode("utf-8")
+        self.headers = {"content-type": content_type}
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class BlogNewsProdSmokeTest(unittest.TestCase):
+    def test_load_anon_key_from_main_dart(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "lib").mkdir()
+            (root / "lib" / "main.dart").write_text(
+                "await Supabase.initialize(\n  anonKey:\n      'anon-token',\n);\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(smoke.load_anon_key(root), "anon-token")
+
+    def test_public_routes_require_flutter_marker(self) -> None:
+        def fake_urlopen(_req: object, timeout: int = 0) -> FakeResponse:
+            self.assertGreater(timeout, 0)
+            return FakeResponse(200, "<html><script src=\"flutter_bootstrap.js\"></script>", "text/html")
+
+        with patch.object(smoke.urllib.request, "urlopen", fake_urlopen):
+            checks = smoke.check_public_routes("https://example.test/", timeout=3)
+
+        self.assertEqual([item.status for item in checks], ["pass", "pass", "pass"])
+
+    def test_rss_fetch_accepts_success_with_empty_items_as_warning(self) -> None:
+        def fake_urlopen(_req: object, timeout: int = 0) -> FakeResponse:
+            body = {
+                "success": True,
+                "source_count": 2,
+                "items": [],
+                "signals": [],
+                "errors": [{"source": "A", "url": "https://a.test/rss", "error": "down"}],
+            }
+            return FakeResponse(200, json.dumps(body))
+
+        with patch.object(smoke.urllib.request, "urlopen", fake_urlopen):
+            result = smoke.check_rss_fetch(
+                "https://supabase.test",
+                "anon-token",
+                timeout=3,
+                feeds=smoke.DEFAULT_RSS_FEEDS,
+            )
+
+        self.assertEqual(result.status, "warn")
+        self.assertEqual(result.details["item_count"], 0)
+        self.assertEqual(result.details["error_count"], 1)
+
+    def test_blog_queue_read_skips_without_service_role_key(self) -> None:
+        checks, post_id = smoke.query_blog_queue_state("https://supabase.test", "", timeout=3)
+
+        self.assertEqual(post_id, "")
+        self.assertEqual(checks[0].status, "warn")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

- add `scripts/blog_news_prod_smoke.py` for read-only production checks of `/blog`, `/blog/compose`, `/news-rss`, optional `/blog/post?id=<postId>`, and `tools-hub` `rss.fetch_latest`
- add `blog-news-prod-smoke.yml` so the smoke runs after successful production deploys and can be triggered manually
- document the smoke in the blog/news runbook and record #1950 WBS progress

## Scope

This is the Codex #1 deterministic slice for #1950. It does not publish to Qiita/dev.to, does not call `blog.publish_post` or `blog.auto_publish`, and keeps live external posting behind the existing user-approved/manual credential gates.

## Verification

- `python -m py_compile scripts\blog_news_prod_smoke.py`
- `python test\scripts\test_blog_news_prod_smoke.py`
- `python -m unittest discover -s test\scripts -p "test_blog_news_prod_smoke.py"`
- `python scripts\check_migration_timestamps.py`
- `python scripts\check_migration_time_relative_check.py`
- `git diff --check`
- `python scripts\blog_news_prod_smoke.py --repo-root . --report tmp\blog-news-prod-smoke-local\report.json`

Local production smoke result: pass. `/blog`, `/blog/compose`, `/news-rss`, and `rss.fetch_latest` returned healthy read-only responses; `SUPABASE_SERVICE_ROLE_KEY` was absent locally, so queue read was skipped as a warning.

## Minimal E2E Gate

- Black-box cases are independent of implementation details:
  1. public Flutter routes return HTTP 200 HTML with app bootstrap markers
  2. `tools-hub` `rss.fetch_latest` returns a structured `success: true` response with `items/signals/errors` shape, tolerating source outages as warnings when the Edge Function remains healthy
  3. when `SUPABASE_SERVICE_ROLE_KEY` is present, `blog_posts` latest-post and ready-queue reads run without write-side publish actions
- Playwright is not required for this slice because the acceptance surface is deploy-time HTTP/Edge Function reachability, not browser interaction state.
- E2E-Exception: no external publishing side effects are executed in CI; live Qiita/dev.to publishing remains user-approved only.

## High-risk Ultrareview Gate

- Risk reason: production workflow + Supabase migration metadata + production smoke path.
- Claude Code #1 review owner: requested for any product/credential policy concerns before closing #1950.
- High-risk-ultrareview-exception: this PR is read-only for production behavior, has no credential writes, and does not invoke external posting APIs.
- Rollback: revert this PR to remove the workflow/script/docs/WBS progress row; no data-destructive migration is included.
- Observability: Actions artifact `blog-news-prod-smoke-report` contains the JSON report for each run.

Refs #1950
