### PR TITLE
ci: add config size monitor (#1849)

### DIFF
--- a/.github/workflows/config-size-monitor.yml
+++ b/.github/workflows/config-size-monitor.yml
@@ -1,0 +1,69 @@
+name: Config Size Monitor
+
+on:
+  schedule:
+    - cron: "0 0 1 * *" # monthly, first day 00:00 UTC
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Fail the workflow when config size warnings are found"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: config-size-monitor
+  cancel-in-progress: false
+
+jobs:
+  monitor:
+    name: Check CLAUDE.md and inject-rules size
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Run config size monitor
+        id: monitor
+        run: |
+          python scripts/config_size_monitor.py \
+            --json-output config-size-report.json \
+            --issue-body config-size-issue.md
+          cat config-size-report.json
+
+      - name: Open warning issue
+        if: steps.monitor.outputs.has_warnings == 'true'
+        run: |
+          TITLE="[automation][P2] config size monitor warning"
+          EXISTING=$(gh issue list --search "$TITLE in:title is:open" --json number --jq 'length')
+          if [ "$EXISTING" != "0" ]; then
+            echo "Skip: same-title open Issue already exists ($EXISTING)"
+            exit 0
+          fi
+          gh issue create \
+            --title "$TITLE" \
+            --label "automation,enhancement,priority:medium" \
+            --body-file config-size-issue.md
+
+      - name: Strict mode exit
+        if: steps.monitor.outputs.has_warnings == 'true' && github.event.inputs.strict == 'true'
+        run: exit 1

--- a/scripts/config_size_monitor.py
+++ b/scripts/config_size_monitor.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Monitor pointer-hub config files for size drift.
+
+The project keeps behavior and product memory in docs, while CLAUDE.md and
+inject-rules.txt should remain small pointer hubs. This script is intentionally
+simple so GitHub Actions can run it monthly and open a warning issue when the
+hub files start carrying too much detail again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_CLAUDE_LIMIT = 300
+DEFAULT_INJECT_RULES_LIMIT = 500
+
+DEFAULT_REQUIRED_POINTERS = (
+    "docs/PHILOSOPHY.md",
+    "docs/AI_DEV_PRINCIPLES.md",
+    "docs/AI_CHARACTER_PRINCIPLES.md",
+    "docs/IMBUE_PATTERNS.md",
+    "docs/COLLAB_AI_PATTERNS.md",
+    "docs/AI_VIDEO_PRINCIPLES.md",
+    "docs/VIBE_CODING_PRINCIPLES.md",
+    "docs/PLATFORM_EVOLUTION_PRINCIPLES.md",
+    "docs/SECOND_BRAIN_PRINCIPLES.md",
+    "docs/INDIE_DEV_VELOCITY_PRINCIPLES.md",
+    "docs/AI_FLEET_SYNERGY_PLAYBOOK.md",
+    "docs/MCP_AUTH_SECURITY_PRINCIPLES.md",
+)
+
+DOC_POINTER_RE = re.compile(r"(?:\]\(|\s|^)(docs/[A-Za-z0-9_./-]+\.md)")
+
+
+@dataclass(frozen=True)
+class SizeCheck:
+    key: str
+    path: str
+    limit: int
+    lines: int | None
+    exists: bool
+
+    @property
+    def status(self) -> str:
+        if not self.exists:
+            return "missing"
+        if self.lines is not None and self.lines > self.limit:
+            return "over_limit"
+        return "ok"
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "path": self.path,
+            "limit": self.limit,
+            "lines": self.lines,
+            "exists": self.exists,
+            "status": self.status,
+        }
+
+
+def repo_relative(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def count_lines(path: Path) -> int:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if text == "":
+        return 0
+    return text.count("\n") + (0 if text.endswith("\n") else 1)
+
+
+def check_size(key: str, path: Path, root: Path, limit: int) -> SizeCheck:
+    if not path.exists():
+        return SizeCheck(key, repo_relative(path, root), limit, None, False)
+    return SizeCheck(key, repo_relative(path, root), limit, count_lines(path), True)
+
+
+def extract_doc_pointers(paths: list[Path], root: Path) -> set[str]:
+    pointers: set[str] = set()
+    for path in paths:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for match in DOC_POINTER_RE.finditer(text):
+            pointers.add(match.group(1).strip())
+    return pointers
+
+
+def evaluate(
+    *,
+    root: Path,
+    claude_path: Path,
+    inject_rules_path: Path,
+    claude_limit: int,
+    inject_rules_limit: int,
+    required_pointers: tuple[str, ...],
+) -> dict[str, Any]:
+    size_checks = [
+        check_size("claude_md", claude_path, root, claude_limit),
+        check_size("inject_rules", inject_rules_path, root, inject_rules_limit),
+    ]
+    source_paths = [claude_path, inject_rules_path]
+    pointers = extract_doc_pointers(source_paths, root)
+    missing_required_pointers = [
+        pointer
+        for pointer in required_pointers
+        if pointer not in pointers or not (root / pointer).exists()
+    ]
+    dangling_pointers = [
+        pointer for pointer in sorted(pointers) if not (root / pointer).exists()
+    ]
+    warnings = [
+        f"{check.key}:{check.status}"
+        for check in size_checks
+        if check.status != "ok"
+    ]
+    if missing_required_pointers:
+        warnings.append("required_pointers:missing")
+    if dangling_pointers:
+        warnings.append("doc_pointers:dangling")
+
+    return {
+        "size_checks": [check.to_json() for check in size_checks],
+        "required_pointers": list(required_pointers),
+        "missing_required_pointers": missing_required_pointers,
+        "dangling_pointers": dangling_pointers,
+        "has_warnings": bool(warnings),
+        "warnings": warnings,
+    }
+
+
+def render_summary(report: dict[str, Any]) -> str:
+    lines = [
+        "## Config Size Monitor",
+        "",
+        "| Target | Lines | Limit | Status |",
+        "|---|---:|---:|---|",
+    ]
+    for check in report["size_checks"]:
+        line_count = "-" if check["lines"] is None else str(check["lines"])
+        lines.append(
+            f"| `{check['path']}` | {line_count} | {check['limit']} | `{check['status']}` |"
+        )
+    lines.extend(
+        [
+            "",
+            f"- Missing required pointers: {len(report['missing_required_pointers'])}",
+            f"- Dangling docs pointers: {len(report['dangling_pointers'])}",
+            f"- Result: {'warning' if report['has_warnings'] else 'ok'}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_issue_body(report: dict[str, Any]) -> str:
+    lines = [
+        "Config size monitor detected pointer-hub drift.",
+        "",
+        render_summary(report).rstrip(),
+        "",
+        "### Recovery",
+        "",
+        "1. Move durable behavior or product memory out of `CLAUDE.md` into `docs/`.",
+        "2. Consolidate repeated hook rules in `.claude/inject-rules.txt` into `docs/RULES_INDEX.md`.",
+        "3. Keep `CLAUDE.md` and inject rules as pointer hubs only.",
+        "",
+        "Routing: Claude Code owns config policy and Codex owns the monitoring workflow.",
+        "",
+        "Source: `scripts/config_size_monitor.py` / `.github/workflows/config-size-monitor.yml`.",
+    ]
+    if report["missing_required_pointers"]:
+        lines.extend(["", "### Missing Required Pointers", ""])
+        lines.extend(f"- `{pointer}`" for pointer in report["missing_required_pointers"])
+    if report["dangling_pointers"]:
+        lines.extend(["", "### Dangling Docs Pointers", ""])
+        lines.extend(f"- `{pointer}`" for pointer in report["dangling_pointers"])
+    return "\n".join(lines) + "\n"
+
+
+def write_github_output(report: dict[str, Any], path: str) -> None:
+    if not path:
+        return
+    missing_required = ",".join(report["missing_required_pointers"])
+    dangling = ",".join(report["dangling_pointers"])
+    lines = [
+        f"has_warnings={str(report['has_warnings']).lower()}",
+        f"missing_required_count={len(report['missing_required_pointers'])}",
+        f"dangling_count={len(report['dangling_pointers'])}",
+        f"missing_required={missing_required}",
+        f"dangling={dangling}",
+    ]
+    for check in report["size_checks"]:
+        lines.append(f"{check['key']}_lines={check['lines'] or 0}")
+        lines.append(f"{check['key']}_status={check['status']}")
+    with Path(path).open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--claude-path", default="CLAUDE.md")
+    parser.add_argument("--inject-rules-path", default=".claude/inject-rules.txt")
+    parser.add_argument("--claude-limit", type=int, default=DEFAULT_CLAUDE_LIMIT)
+    parser.add_argument("--inject-rules-limit", type=int, default=DEFAULT_INJECT_RULES_LIMIT)
+    parser.add_argument("--json-output", default="")
+    parser.add_argument("--issue-body", default="")
+    parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
+    parser.add_argument("--github-step-summary", default=os.environ.get("GITHUB_STEP_SUMMARY", ""))
+    parser.add_argument("--strict", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    root = Path(args.root).resolve()
+    report = evaluate(
+        root=root,
+        claude_path=(root / args.claude_path).resolve(),
+        inject_rules_path=(root / args.inject_rules_path).resolve(),
+        claude_limit=args.claude_limit,
+        inject_rules_limit=args.inject_rules_limit,
+        required_pointers=DEFAULT_REQUIRED_POINTERS,
+    )
+    summary = render_summary(report)
+    print(summary)
+
+    if args.json_output:
+        Path(args.json_output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    if args.issue_body:
+        Path(args.issue_body).write_text(render_issue_body(report), encoding="utf-8")
+    if args.github_step_summary:
+        with Path(args.github_step_summary).open("a", encoding="utf-8") as handle:
+            handle.write(summary)
+    write_github_output(report, args.github_output)
+
+    if args.strict and report["has_warnings"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/config_size_monitor_test.py
+++ b/scripts/config_size_monitor_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Unit tests for config_size_monitor.py."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import config_size_monitor as monitor
+
+
+def write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+class ConfigSizeMonitorTest(unittest.TestCase):
+    def test_counts_lines_and_passes_at_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(root / "CLAUDE.md", "a\nb\n")
+            write(root / ".claude/inject-rules.txt", "rule\n")
+            write(root / "docs/PHILOSOPHY.md", "# Philosophy\n")
+
+            report = monitor.evaluate(
+                root=root,
+                claude_path=root / "CLAUDE.md",
+                inject_rules_path=root / ".claude/inject-rules.txt",
+                claude_limit=2,
+                inject_rules_limit=1,
+                required_pointers=(),
+            )
+
+            self.assertFalse(report["has_warnings"])
+            self.assertEqual(report["size_checks"][0]["lines"], 2)
+            self.assertEqual(report["size_checks"][0]["status"], "ok")
+
+    def test_warns_when_claude_md_exceeds_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(root / "CLAUDE.md", "a\nb\nc\n")
+            write(root / ".claude/inject-rules.txt", "rule\n")
+
+            report = monitor.evaluate(
+                root=root,
+                claude_path=root / "CLAUDE.md",
+                inject_rules_path=root / ".claude/inject-rules.txt",
+                claude_limit=2,
+                inject_rules_limit=10,
+                required_pointers=(),
+            )
+
+            self.assertTrue(report["has_warnings"])
+            self.assertEqual(report["size_checks"][0]["status"], "over_limit")
+
+    def test_warns_for_missing_required_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(root / "CLAUDE.md", "[Other](docs/OTHER.md)\n")
+            write(root / ".claude/inject-rules.txt", "")
+            write(root / "docs/OTHER.md", "# Other\n")
+
+            report = monitor.evaluate(
+                root=root,
+                claude_path=root / "CLAUDE.md",
+                inject_rules_path=root / ".claude/inject-rules.txt",
+                claude_limit=100,
+                inject_rules_limit=100,
+                required_pointers=("docs/PHILOSOPHY.md",),
+            )
+
+            self.assertTrue(report["has_warnings"])
+            self.assertEqual(report["missing_required_pointers"], ["docs/PHILOSOPHY.md"])
+
+    def test_warns_for_dangling_doc_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(root / "CLAUDE.md", "[Missing](docs/MISSING.md)\n")
+            write(root / ".claude/inject-rules.txt", "")
+
+            report = monitor.evaluate(
+                root=root,
+                claude_path=root / "CLAUDE.md",
+                inject_rules_path=root / ".claude/inject-rules.txt",
+                claude_limit=100,
+                inject_rules_limit=100,
+                required_pointers=(),
+            )
+
+            self.assertTrue(report["has_warnings"])
+            self.assertEqual(report["dangling_pointers"], ["docs/MISSING.md"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

Adds a monthly Config Size Monitor for #1849.

- Adds `scripts/config_size_monitor.py` to check `CLAUDE.md`, `.claude/inject-rules.txt`, required docs pointers, and dangling docs links.
- Adds unit coverage for size-limit, missing-pointer, and dangling-pointer cases.
- Adds `.github/workflows/config-size-monitor.yml` to run monthly and open a deduplicated warning issue when pointer hubs drift.

Closes #1849

## Minimal E2E Gate

- Implementation-detail independent: this PR does not change application behavior; the validation checks observable script output files and workflow outputs.
- Minimal scope: about three I/O cases are covered by unit tests: over-limit, missing required pointer, and dangling docs pointer.
- E2E mechanism: no Flutter `integration_test/` or Playwright app E2E is needed for this non-app automation change.
- E2E-Exception: no user-facing route, widget, or browser flow changed; validation is script-level plus GitHub Actions wiring.

## Codex UI QA / Prototyping

- Changed routes/surfaces: none.
- Codex in-app browser check: not applicable; no UI/layout/interaction changed.
- Playwright command or artifact: not applicable for this script/workflow-only change.
- Desktop and mobile viewport findings: not applicable.
- Generated imagery status: no generated image was used.
- Generated imagery is not being used as proof of the actual product state.

## Validation

- `python scripts\config_size_monitor_test.py`
- `python scripts\config_size_monitor.py --json-output config-size-report.json --issue-body config-size-issue.md`
- `python -m py_compile scripts\config_size_monitor.py scripts\config_size_monitor_test.py`
- `git diff --check`

Current report: `CLAUDE.md` 62/300 lines, `.claude/inject-rules.txt` 71/500 lines, 0 missing required pointers, 0 dangling docs pointers.

## Notes

High-risk ultrareview exception: workflow-only monthly monitoring; it does not touch production deploy, auth, data migration, payment, or Supabase runtime paths.
Claude Code #1 remains the config-policy owner; unresolved findings: none.
