### PR TITLE
ci: issue knowledge vault lint warnings (#1978)

### DIFF
--- a/.github/workflows/knowledge-vault-lint.yml
+++ b/.github/workflows/knowledge-vault-lint.yml
@@ -1,12 +1,8 @@
-name: Knowledge Vault Lint (memory + docs 健康診断)
-
-# Win版#132 part 105 / 2026-05-01
-# Issues #976 + #1173 dogfood / SECOND_BRAIN #4 + INDIE #1
-# 週次で memory/ + docs/ の orphan / broken link / dup title / missing index 検出
+name: Knowledge Vault Lint (memory + docs health)
 
 on:
   schedule:
-    - cron: "0 2 * * 1"  # weekly / 月曜 02:00 UTC (= 11:00 JST)
+    - cron: "0 2 * * 1" # weekly Monday 02:00 UTC (= 11:00 JST)
   workflow_dispatch: {}
 
 concurrency:
@@ -15,6 +11,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   lint:
@@ -23,7 +20,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Checkout (full history)
+      - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
@@ -32,25 +29,30 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Compute date tag
         id: tag
         run: |
           DATE=$(TZ=UTC date +'%Y-%m-%d')
-          echo "date=$DATE" >> $GITHUB_OUTPUT
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
 
       - name: Run lint
+        id: lint
         run: |
-          # GHA 環境では memory/ は repo 内の memory/ を使う (= local override)
+          set +e
           python scripts/knowledge_vault_lint.py \
             --memory-dir memory \
-            --output "docs/knowledge-vault-lint/${{ steps.tag.outputs.date }}.md"
-        continue-on-error: true  # health < 90 でも commit は実施
+            --output "docs/knowledge-vault-lint/${{ steps.tag.outputs.date }}.md" \
+            --json-out "$RUNNER_TEMP/knowledge-vault-lint.json"
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          echo "json_path=$RUNNER_TEMP/knowledge-vault-lint.json" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: Commit lint report
         run: |
-          git config user.name  "knowledge-vault-lint[bot]"
+          git config user.name "knowledge-vault-lint[bot]"
           git config user.email "knowledge-vault-lint@users.noreply.github.com"
           git add docs/knowledge-vault-lint/ || true
           if git diff --staged --quiet; then
@@ -59,3 +61,37 @@ jobs:
             git commit -m "docs(lint): knowledge vault lint ${{ steps.tag.outputs.date }}"
             git push origin HEAD:main || git push --force-with-lease origin HEAD:main
           fi
+
+      - name: Open warning Issue when lint health is below target
+        if: steps.lint.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE="${{ steps.tag.outputs.date }}"
+          REPORT="docs/knowledge-vault-lint/${DATE}.md"
+          TITLE="[automation][P1] knowledge vault lint warning ${DATE}"
+          EXISTING=$(gh issue list --search "$TITLE in:title is:open" --json number --jq 'length')
+          if [ "$EXISTING" != "0" ]; then
+            echo "Skip: same-title open Issue already exists ($EXISTING)"
+            exit 0
+          fi
+
+          BODY="$RUNNER_TEMP/knowledge-vault-lint-issue.md"
+          {
+            echo "Knowledge Vault Lint reported health below the target threshold."
+            echo ""
+            echo "- Report: \`$REPORT\`"
+            echo "- Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Exit code: \`${{ steps.lint.outputs.exit_code }}\`"
+            echo ""
+            echo "The report excerpt below includes the top repair candidates for orphan files, broken links, duplicate titles, and missing index entries."
+            echo ""
+            sed -n '1,220p' "$REPORT"
+            echo ""
+            echo "(auto-opened by knowledge-vault-lint.yml)"
+          } > "$BODY"
+
+          gh issue create \
+            --title "$TITLE" \
+            --label "automation,enhancement,priority:high" \
+            --body-file "$BODY"

--- a/docs/CODEX_MEMORY_AUTOMATIONS.md
+++ b/docs/CODEX_MEMORY_AUTOMATIONS.md
@@ -31,7 +31,7 @@
 | **weekly** | AI tool changelog summarize → Issue (= deep) | GHA `ai-tool-changelog-watch.yml` | `scripts/ai_tool_changelog_to_issues.py` | Issue label `ai-tool-update` | ✅ Issue 自動作成 (= 月次) |
 | **weekly** | edge-function-audit (= EF 未接続検出) | GHA `edge-function-audit.yml` | EF coverage scanner | Issue label `edge-function` | ✅ Issue 自動作成 |
 | **weekly** | wbs-staleness-audit (= 60 日未更新検出) | GHA `wbs-staleness-audit.yml` | EF `tools-hub:wbs.audit` | cross-instance-pr 自動作成 | ✅ md ファイル自動作成 |
-| **weekly** | knowledge-vault-lint (= memory/ + docs/ orphan + broken link) | GHA `knowledge-vault-lint.yml` | `scripts/knowledge_vault_lint.py` | `docs/vault-health/health-YYYY-MM-DD.json` | ⚠️ Issue 接続未実装 (= 自動化候補) |
+| **weekly** | knowledge-vault-lint (= memory/ + docs/ orphan + broken link) | GHA `knowledge-vault-lint.yml` | `scripts/knowledge_vault_lint.py` | `docs/knowledge-vault-lint/YYYY-MM-DD.md` + warning Issue | ✅ health below target 時に上位修復候補付き Issue 自動作成 |
 | **weekly** | build-in-public extract (= ROADMAP-LOG → dev.to draft) | GHA `build-in-public-extract.yml` | `scripts/build_in_public_extract.py` | `docs/build-in-public/YYYY-MM-DD_devto_draft.md` | — (= manual review 必要) |
 | **monthly** | instance-role-audit (= 12 instance 役割妥当性) | GHA `instance-role-audit.yml` | `scripts/instance_role_audit.py` | `docs/instance-audit/audit-YYYY-MM.md` | ⚠️ Issue 接続未実装 (= 自動化候補) |
 | **monthly** | hook-rule-audit (= inject-rules.txt の rot/重複検出) | manual (= `/hook-rule-audit` skill) | hook-rule-audit skill | inject-rules.txt 整理 commit | ❌ 手動 only (= 自動化候補) |


### PR DESCRIPTION
## Summary
- Adds `issues: write` and captures the Knowledge Vault lint exit code without failing the report commit step.
- Opens a same-day de-duplicated warning Issue when lint health is below target, including a report excerpt with the top repair candidates.
- Updates the Codex memory automation matrix to show the warning Issue path.

Closes #1978

## Validation
- `python scripts\knowledge_vault_lint.py --memory-dir memory --output tmp\knowledge-vault-lint-check.md --json-out tmp\knowledge-vault-lint-check.json` generated report/json and returned health `40/100` as expected for a warning case.
- `python -m py_compile scripts\knowledge_vault_lint.py`
- `git diff --check`

## Minimal E2E Gate
- Implementation-detail independent: validates the scheduled monitor behavior rather than Python internals.
- Minimal cases: healthy run commits a report without opening an Issue; unhealthy run opens one Issue with report excerpt; repeated unhealthy run for the same date skips duplicate Issue creation.
- E2E mechanism: GitHub Actions `workflow_dispatch` for `knowledge-vault-lint.yml` after merge.
- E2E-Exception: not run locally because this change requires GitHub Actions token permissions and Issue creation side effects.

## Codex UI QA / Prototyping
No UI changed.

## High-risk Ultrareview
- Claude Code #1 review owner: Claude Code #1.
- High-risk-ultrareview-exception: workflow-only scheduled monitor; security impact is limited to repository-scoped `GITHUB_TOKEN` issue creation, rollback is reverting this PR, prod-smoke is the post-merge `workflow_dispatch`, observability is the committed lint report plus created Issue URL, and data-migration impact is none.
- No unresolved ultrareview findings: 0.