### PR TITLE
docs: add Windows dev setup guide (#1356)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 * **技術スタック**: Flutter (Web), Supabase (Auth, DB, Edge Functions), AI (Gemini/OpenAI/Anthropic).
 * **AI tool update gate (2026-05-07 #1706)**: Claude/Codex/Gemini/Copilot changes must be verified against official sources, then routed through the two-instance flow in `docs/AI_FALLBACK_RUNBOOK.md`.
 
+## Windows 開発環境セットアップ
+
+新規 Windows 11 環境では、初期セットアップとプロキシ解除手順を
+[docs/setup/windows-dev-setup.md](docs/setup/windows-dev-setup.md) にまとめています。
+一括インストールは以下を使用します。
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/setup_windows_dev.ps1
+```
+
 ## 2. 組織構造 (AI Agents) & 機能マップ
 
 ユーザー（CEO）を支えるAI役員たちの構造図については、以下のファイルを参照してください。

--- a/docs/setup/windows-dev-setup.md
+++ b/docs/setup/windows-dev-setup.md
@@ -1,0 +1,138 @@
+# Windows development setup and proxy troubleshooting
+
+This guide is the onboarding path for a fresh Windows 11 machine working on
+`my_web_app`. It covers the baseline installer script and the proxy cleanup
+steps for common `ENOTFOUND`, `ECONNRESET`, `407 Proxy Authentication Required`,
+and package registry failures.
+
+## Quick start
+
+Run PowerShell as your normal user from the repository root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/setup_windows_dev.ps1
+```
+
+Preview without installing anything:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/setup_windows_dev.ps1 -DryRun
+```
+
+Clear stale proxy settings before installing:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/setup_windows_dev.ps1 -ClearProxy
+```
+
+## What the script installs
+
+The script uses `winget` for machine tools and the `code` CLI for VS Code
+extensions. It prints each step before running it, skips already installed
+winget packages, and prints a version summary at the end.
+
+| Area | Items |
+| --- | --- |
+| Core CLI | Git, GitHub CLI, Node.js LTS, Python 3.12, Deno |
+| App tooling | Visual Studio Code, OpenJDK 17, AWS CLI |
+| VS Code | Dart, Flutter, Deno, PowerShell, GitHub Actions, Copilot, Docker, Prettier, ESLint |
+
+After the script finishes, open a new terminal and run:
+
+```powershell
+git --version
+node --version
+npm --version
+python --version
+deno --version
+gh --version
+java --version
+```
+
+Flutter itself is intentionally not installed by the script because teams often
+pin the SDK through FVM, a local SDK cache, or a managed corporate image. Use
+the repository's current Flutter setup notes before adding a global SDK.
+
+## Proxy troubleshooting
+
+If install commands fail with DNS or proxy errors, first inspect the current
+settings:
+
+```powershell
+Get-ChildItem Env:*proxy*
+npm config get proxy
+npm config get https-proxy
+git config --global --get http.proxy
+git config --global --get https.proxy
+```
+
+Clear user and process proxy variables:
+
+```powershell
+$names = @(
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'no_proxy'
+)
+
+foreach ($name in $names) {
+  [Environment]::SetEnvironmentVariable($name, $null, 'User')
+  [Environment]::SetEnvironmentVariable($name, $null, 'Process')
+  Remove-Item -LiteralPath "Env:\$name" -ErrorAction SilentlyContinue
+}
+```
+
+Clear npm and Git proxy config:
+
+```powershell
+npm config delete proxy
+npm config delete https-proxy
+git config --global --unset http.proxy
+git config --global --unset https.proxy
+```
+
+Reset winget sources when package discovery is broken:
+
+```powershell
+winget source reset --force
+winget source update
+winget search Git.Git
+```
+
+Then retry the setup script:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/setup_windows_dev.ps1
+```
+
+## VS Code extension issues
+
+If `code --install-extension` fails:
+
+1. Open VS Code once.
+2. Press `Ctrl+Shift+P`.
+3. Run `Shell Command: Install 'code' command in PATH` if available.
+4. Close and reopen PowerShell.
+5. Retry with winget skipped:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/setup_windows_dev.ps1 -SkipWinget
+```
+
+If the extension gallery itself is blocked by a corporate proxy, clear proxy
+settings as above and confirm VS Code has no stale `http.proxy` value in user
+settings.
+
+## Recovery checklist
+
+- Run `scripts/setup_windows_dev.ps1 -DryRun` to confirm the planned steps.
+- Run `scripts/setup_windows_dev.ps1 -ClearProxy -SkipVSCodeExtensions` if
+  winget or npm fails before VS Code is available.
+- Open a new terminal after installation so PATH changes are loaded.
+- Run `gh auth login` before GitHub issue, PR, or Actions work.
+- Run `flutter doctor` only after confirming the repository's Flutter SDK path.

--- a/scripts/setup_windows_dev.ps1
+++ b/scripts/setup_windows_dev.ps1
@@ -1,0 +1,205 @@
+<#
+.SYNOPSIS
+Installs the baseline Windows developer tools for my_web_app.
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts/setup_windows_dev.ps1
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts/setup_windows_dev.ps1 -ClearProxy -DryRun
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$SkipWinget,
+    [switch]$SkipVSCodeExtensions,
+    [switch]$ClearProxy,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProxyVariables = @(
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy"
+)
+
+$WingetPackages = @(
+    @{ Id = "Git.Git"; Name = "Git" },
+    @{ Id = "Microsoft.VisualStudioCode"; Name = "Visual Studio Code" },
+    @{ Id = "OpenJS.NodeJS.LTS"; Name = "Node.js LTS" },
+    @{ Id = "EclipseAdoptium.Temurin.17.JDK"; Name = "OpenJDK 17" },
+    @{ Id = "Python.Python.3.12"; Name = "Python 3.12" },
+    @{ Id = "Amazon.AWSCLI"; Name = "AWS CLI" },
+    @{ Id = "GitHub.cli"; Name = "GitHub CLI" },
+    @{ Id = "DenoLand.Deno"; Name = "Deno" }
+)
+
+$VSCodeExtensions = @(
+    "Dart-Code.dart-code",
+    "Dart-Code.flutter",
+    "denoland.vscode-deno",
+    "ms-vscode.powershell",
+    "GitHub.vscode-github-actions",
+    "GitHub.copilot",
+    "GitHub.copilot-chat",
+    "ms-azuretools.vscode-docker",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+)
+
+function Write-Section {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Invoke-SetupStep {
+    param(
+        [string]$Description,
+        [scriptblock]$Action
+    )
+
+    Write-Section $Description
+    if ($DryRun) {
+        Write-Host "[dry-run] $Description"
+        return
+    }
+
+    try {
+        & $Action
+    } catch {
+        Write-Host "[failed] $Description" -ForegroundColor Red
+        Write-Host $_.Exception.Message -ForegroundColor Red
+        Write-Host "See docs/setup/windows-dev-setup.md for proxy troubleshooting." -ForegroundColor Yellow
+        throw
+    }
+}
+
+function Test-CommandExists {
+    param([string]$Command)
+    return [bool](Get-Command $Command -ErrorAction SilentlyContinue)
+}
+
+function Clear-ProxyConfiguration {
+    Invoke-SetupStep "Clear proxy environment variables and package-manager proxy settings" {
+        foreach ($name in $ProxyVariables) {
+            [Environment]::SetEnvironmentVariable($name, $null, "User")
+            [Environment]::SetEnvironmentVariable($name, $null, "Process")
+            Remove-Item -LiteralPath "Env:\$name" -ErrorAction SilentlyContinue
+            Write-Host "cleared $name"
+        }
+
+        if (Test-CommandExists "npm") {
+            npm config delete proxy | Out-Host
+            npm config delete https-proxy | Out-Host
+        }
+
+        if (Test-CommandExists "git") {
+            git config --global --unset http.proxy 2>$null
+            git config --global --unset https.proxy 2>$null
+        }
+    }
+}
+
+function Test-WingetPackageInstalled {
+    param([string]$PackageId)
+
+    $output = winget list --id $PackageId --exact 2>$null | Out-String
+    return ($LASTEXITCODE -eq 0 -and $output -match [regex]::Escape($PackageId))
+}
+
+function Install-WingetPackage {
+    param(
+        [string]$PackageId,
+        [string]$PackageName
+    )
+
+    Invoke-SetupStep "Install $PackageName ($PackageId)" {
+        if (Test-WingetPackageInstalled $PackageId) {
+            Write-Host "$PackageName is already installed."
+            return
+        }
+
+        winget install `
+            --id $PackageId `
+            --exact `
+            --silent `
+            --accept-package-agreements `
+            --accept-source-agreements
+    }
+}
+
+function Install-VSCodeExtension {
+    param([string]$ExtensionId)
+
+    Invoke-SetupStep "Install VS Code extension $ExtensionId" {
+        if (-not (Test-CommandExists "code")) {
+            Write-Host "VS Code CLI 'code' is not on PATH. Open VS Code once and run 'Shell Command: Install code command in PATH' if needed." -ForegroundColor Yellow
+            return
+        }
+
+        code --install-extension $ExtensionId --force
+    }
+}
+
+function Show-VersionSummary {
+    Write-Section "Version summary"
+    $commands = @("git", "node", "npm", "python", "deno", "gh", "aws", "java", "code")
+    foreach ($command in $commands) {
+        if (-not (Test-CommandExists $command)) {
+            Write-Host "${command}: not found" -ForegroundColor Yellow
+            continue
+        }
+
+        try {
+            $line = (& $command --version 2>$null | Select-Object -First 1)
+            Write-Host "${command}: $line"
+        } catch {
+            Write-Host "${command}: installed, version check failed" -ForegroundColor Yellow
+        }
+    }
+}
+
+Write-Section "my_web_app Windows developer setup"
+Write-Host "DryRun: $DryRun"
+Write-Host "SkipWinget: $SkipWinget"
+Write-Host "SkipVSCodeExtensions: $SkipVSCodeExtensions"
+Write-Host "ClearProxy: $ClearProxy"
+
+if ($ClearProxy) {
+    Clear-ProxyConfiguration
+}
+
+if (-not $SkipWinget) {
+    if (-not $DryRun -and -not (Test-CommandExists "winget")) {
+        throw "winget is not available. Install App Installer from Microsoft Store first."
+    }
+
+    foreach ($package in $WingetPackages) {
+        Install-WingetPackage -PackageId $package["Id"] -PackageName $package["Name"]
+    }
+}
+
+if (-not $SkipVSCodeExtensions) {
+    foreach ($extension in $VSCodeExtensions) {
+        Install-VSCodeExtension -ExtensionId $extension
+    }
+}
+
+if ($DryRun) {
+    Write-Section "Version summary"
+    Write-Host "[dry-run] skipped version checks"
+} else {
+    Show-VersionSummary
+}
+
+Write-Section "Done"
+Write-Host "Next: run 'flutter doctor', 'dart --version', and 'deno --version' after opening a new terminal."


### PR DESCRIPTION
## Summary
- Adds a Windows onboarding PowerShell script for baseline developer tools and VS Code extensions.
- Adds a proxy troubleshooting guide for environment variables, npm, Git, winget, and VS Code extension issues.
- Links the guide from README so new contributors can find it quickly.

Closes #1356

## Validation
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\setup_windows_dev.ps1 -DryRun`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\setup_windows_dev.ps1 -DryRun -SkipWinget -SkipVSCodeExtensions`
- `git diff --cached --check`

## Minimal E2E Gate
- Implementation-detail independent: validates onboarding flow from the script entrypoint and README link, not internal function names.
- Minimal cases: dry-run full plan; dry-run with winget and VS Code extension steps skipped; documentation path reachable from README.
- E2E mechanism: manual Windows PowerShell dry-run before installing tools.
- E2E-Exception: real package installation was not run because it would mutate the local machine.

## Codex UI QA / Prototyping
No UI changed.