### PR TITLE
feat(calendar): add event search (#2209)

### DIFF
--- a/lib/pages/calendar_events_page.dart
+++ b/lib/pages/calendar_events_page.dart
@@ -77,6 +77,29 @@ List<Map<String, dynamic>> sortCalendarEventsForDisplay(
   return events.toList()..sort(_compareCalendarEventsForDisplay);
 }
 
+@visibleForTesting
+List<Map<String, dynamic>> searchCalendarEventsForDisplay(
+  Iterable<Map<String, dynamic>> events,
+  String query,
+) {
+  final sorted = sortCalendarEventsForDisplay(events);
+  final terms = query
+      .trim()
+      .toLowerCase()
+      .split(RegExp(r'\s+'))
+      .where((term) => term.isNotEmpty)
+      .toList();
+  if (terms.isEmpty) return sorted;
+
+  return sorted.where((event) {
+    final searchable = [
+      _eventTitle(event),
+      event['description']?.toString() ?? '',
+    ].join(' ').toLowerCase();
+    return terms.every(searchable.contains);
+  }).toList();
+}
+
 int _compareCalendarEventsForDisplay(
   Map<String, dynamic> a,
   Map<String, dynamic> b,
@@ -132,6 +155,14 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   List<Map<String, dynamic>> get _selectedDayEvents {
     final key = _dateKey(_selectedDay);
     return sortCalendarEventsForDisplay(_eventsByDate[key] ?? []);
+  }
+
+  List<Map<String, dynamic>> get _allEvents {
+    return sortCalendarEventsForDisplay(
+      _eventsByDate.values.expand((events) {
+        return events;
+      }),
+    );
   }
 
   static String _dateKey(DateTime d) =>
@@ -298,6 +329,21 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
       _focusedDay = next;
     });
     _fetchMonth(next);
+  }
+
+  Future<void> _showEventSearch() async {
+    final selectedEvent = await showSearch<Map<String, dynamic>?>(
+      context: context,
+      delegate: _CalendarEventSearchDelegate(events: _allEvents),
+    );
+    if (selectedEvent == null || !mounted) return;
+    final start = _eventDateTime(selectedEvent, 'start_at');
+    if (start == null) return;
+    final selected = DateTime(start.year, start.month, start.day);
+    setState(() {
+      _selectedDay = selected;
+      _focusedDay = selected;
+    });
   }
 
   void _confirmDeleteEvent(BuildContext context, Map<String, dynamic> event) {
@@ -520,6 +566,12 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
       appBar: AppBar(
         title: const Text('カレンダー'),
         actions: [
+          IconButton(
+            key: const Key('calendar_events_search_button'),
+            icon: const Icon(Icons.search),
+            tooltip: 'Search events',
+            onPressed: _showEventSearch,
+          ),
           if (_isLoading)
             const Padding(
               padding: EdgeInsets.all(14),
@@ -956,6 +1008,109 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _CalendarEventSearchDelegate
+    extends SearchDelegate<Map<String, dynamic>?> {
+  _CalendarEventSearchDelegate({required this.events})
+      : super(searchFieldLabel: 'Search events');
+
+  final List<Map<String, dynamic>> events;
+
+  @override
+  List<Widget>? buildActions(BuildContext context) {
+    return [
+      if (query.isNotEmpty)
+        IconButton(
+          tooltip: 'Clear search',
+          icon: const Icon(Icons.close),
+          onPressed: () => query = '',
+        ),
+    ];
+  }
+
+  @override
+  Widget? buildLeading(BuildContext context) {
+    return IconButton(
+      tooltip: 'Back',
+      icon: const Icon(Icons.arrow_back),
+      onPressed: () => close(context, null),
+    );
+  }
+
+  @override
+  Widget buildResults(BuildContext context) => _buildMatches(context);
+
+  @override
+  Widget buildSuggestions(BuildContext context) => _buildMatches(context);
+
+  Widget _buildMatches(BuildContext context) {
+    final matches = searchCalendarEventsForDisplay(events, query);
+    if (events.isEmpty) {
+      return const Center(child: Text('No events loaded'));
+    }
+    if (matches.isEmpty) {
+      return const Center(child: Text('No matching events'));
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: matches.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final event = matches[index];
+        return _SearchResultTile(
+          event: event,
+          color: _CalendarEventsPageState._eventColor(event),
+          onTap: () => close(context, event),
+        );
+      },
+    );
+  }
+}
+
+class _SearchResultTile extends StatelessWidget {
+  const _SearchResultTile({
+    required this.event,
+    required this.color,
+    required this.onTap,
+  });
+
+  final Map<String, dynamic> event;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final description = event['description']?.toString().trim() ?? '';
+    final start = _eventDateTime(event, 'start_at');
+    final dateLabel = start == null ? 'No date' : _formatDate(start);
+    final subtitle = [
+      dateLabel,
+      _eventTimeLabel(event),
+      if (description.isNotEmpty) description,
+    ].where((value) => value.isNotEmpty).join(' - ');
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: color.withValues(alpha: 0.15),
+        child: Icon(Icons.event, color: color, size: 20),
+      ),
+      title: Text(
+        _eventTitle(event),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        subtitle,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodySmall,
+      ),
+      onTap: onTap,
     );
   }
 }

--- a/test/pages/calendar_events_page_test.dart
+++ b/test/pages/calendar_events_page_test.dart
@@ -84,6 +84,41 @@ void main() {
     );
   });
 
+  test('searchCalendarEventsForDisplay matches title and description', () {
+    Map<String, dynamic> event(
+      String title,
+      String description,
+      DateTime start,
+    ) {
+      return {
+        'title': title,
+        'description': description,
+        'start_at': start.toIso8601String(),
+        'end_at': start.add(const Duration(hours: 1)).toIso8601String(),
+      };
+    }
+
+    final day = DateTime(2026, 5, 9);
+    final matches = searchCalendarEventsForDisplay(
+      [
+        event(
+          'Budget review',
+          'Revise forecast',
+          day.add(const Duration(hours: 9)),
+        ),
+        event('Dentist', 'Annual cleaning', day.add(const Duration(hours: 13))),
+        event(
+          'Planning',
+          'Weekly roadmap',
+          day.add(const Duration(hours: 10)),
+        ),
+      ],
+      'annual cleaning',
+    );
+
+    expect(matches.map((event) => event['title']), ['Dentist']);
+  });
+
   Widget testWidget() {
     return MaterialApp(
       home: CalendarEventsPage(supabaseClient: mockSupabaseClient),
@@ -113,6 +148,66 @@ void main() {
     expect(find.text('00:00'), findsOneWidget);
     expect(find.text('23:00'), findsOneWidget);
   });
+
+  testWidgets(
+    'CalendarEventsPage searches loaded events and jumps to result day',
+    (tester) async {
+      final today = DateTime.now();
+      final selectedDay = DateTime(today.year, today.month, today.day);
+      final tomorrow = selectedDay.add(const Duration(days: 1));
+      final budgetStart = DateTime(
+        selectedDay.year,
+        selectedDay.month,
+        selectedDay.day,
+        9,
+      );
+      final dentistStart = DateTime(
+        tomorrow.year,
+        tomorrow.month,
+        tomorrow.day,
+        13,
+      );
+      stubCalendarList([
+        {
+          'event_id': 'event-budget',
+          'title': 'Budget review',
+          'description': 'Revise forecast',
+          'start_at': budgetStart.toIso8601String(),
+          'end_at': budgetStart.add(const Duration(hours: 1)).toIso8601String(),
+          'all_day': false,
+          'color': '#4285f4',
+        },
+        {
+          'event_id': 'event-dentist',
+          'title': 'Dentist',
+          'description': 'Annual cleaning',
+          'start_at': dentistStart.toIso8601String(),
+          'end_at':
+              dentistStart.add(const Duration(hours: 1)).toIso8601String(),
+          'all_day': false,
+          'color': '#34a853',
+        },
+      ]);
+
+      await tester.pumpWidget(testWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Budget review'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('calendar_events_search_button')));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'cleaning');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Dentist'), findsOneWidget);
+
+      await tester.tap(find.text('Dentist'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Dentist'), findsOneWidget);
+      expect(find.text('Budget review'), findsNothing);
+    },
+  );
 
   testWidgets('event tap opens detail sheet and edit saves calendar.update', (
     tester,


### PR DESCRIPTION
﻿## Summary

- Adds an AppBar search action to `/calendar-events`.
- Searches loaded calendar events by title and description with multi-term matching.
- Lets users tap a search result to jump back to the event's date in the calendar list.

Closes #2209
Related to #2204

## Minimal E2E Gate

- [x] Implementation-detail independent: a black-box E2E plan would verify visible input/output only: open calendar, enter a query, choose a result, and confirm the selected date's event list updates.
- [x] Minimal scope: 3 cases only: happy path title match, description match, and empty/no-match state.
- [ ] E2E included: Flutter `integration_test/` or Playwright `test/e2e/`.
- [x] E2E-Exception: this scoped PR adds covered widget-level interaction tests for the search route and avoids starting a browser/dev server in the constrained Windows session. Manual verification steps are: load `/calendar-events`, click search, type an event description term, tap the result, and confirm the destination date shows that event.

## Codex UI QA / Prototyping

- Changed route: `/calendar-events`.
- Codex in-app browser check: skipped to avoid leaving dev-server/browser processes; widget tests exercise the new visible search interaction.
- Playwright command/artifact: not added; covered by the E2E exception above.
- Generated imagery: No generated image was used.

## Validation

- `C:\app\flutter\bin\flutter.bat analyze --no-pub lib\pages\calendar_events_page.dart test\pages\calendar_events_page_test.dart`
- `C:\app\flutter\bin\flutter.bat test --no-pub test\pages\calendar_events_page_test.dart`
