### PR TITLE
[codex] Add asset liability monthly history and CSV backup

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -1,0 +1,389 @@
+enum AssetLiabilityAccountKind {
+  cash,
+  deposit,
+  securities,
+  cardLoan,
+  shoppingDebt,
+  creditCard,
+  utility,
+  otherAsset,
+  otherLiability,
+}
+
+class AssetLiabilityAccount {
+  final String id;
+  final String name;
+  final AssetLiabilityAccountKind kind;
+  final double balance;
+  final int? paymentDay;
+  final String? paymentSourceAccountName;
+  final double annualRate;
+  final double minimumPaymentRate;
+  final double minimumPaymentFloor;
+  final bool fullPaymentEstimate;
+
+  const AssetLiabilityAccount({
+    required this.id,
+    required this.name,
+    required this.kind,
+    required this.balance,
+    this.paymentDay,
+    this.paymentSourceAccountName,
+    this.annualRate = 0,
+    this.minimumPaymentRate = 0,
+    this.minimumPaymentFloor = 0,
+    this.fullPaymentEstimate = false,
+  });
+
+  bool get isAsset => balance > 0;
+  bool get isLiability => balance < 0;
+  double get liabilityBalance => isLiability ? balance.abs() : 0;
+}
+
+class AssetLiabilityDebtRow {
+  final String id;
+  final String name;
+  final AssetLiabilityAccountKind kind;
+  final double balance;
+  final int? paymentDay;
+  final String? paymentSourceAccountId;
+  final String? paymentSourceAccountName;
+  final double annualRate;
+  final double minimumPaymentEstimate;
+  final double? manualPaymentAmount;
+  final double scheduledPaymentAmount;
+  final double monthlyInterestEstimate;
+  final double principalPaymentEstimate;
+  final double balanceAfterPaymentEstimate;
+  final double liabilityShare;
+  final String priorityLabel;
+  final bool paymentAmountEstimated;
+  final bool paid;
+
+  const AssetLiabilityDebtRow({
+    required this.id,
+    required this.name,
+    required this.kind,
+    required this.balance,
+    required this.paymentDay,
+    required this.paymentSourceAccountId,
+    required this.paymentSourceAccountName,
+    required this.annualRate,
+    required this.minimumPaymentEstimate,
+    required this.manualPaymentAmount,
+    required this.scheduledPaymentAmount,
+    required this.monthlyInterestEstimate,
+    required this.principalPaymentEstimate,
+    required this.balanceAfterPaymentEstimate,
+    required this.liabilityShare,
+    required this.priorityLabel,
+    required this.paymentAmountEstimated,
+    required this.paid,
+  });
+}
+
+class AssetLiabilityPaymentDayRisk {
+  final int paymentDay;
+  final DateTime paymentDate;
+  final List<String> accountNames;
+  final double balanceTotal;
+  final double minimumPaymentEstimateTotal;
+  final double scheduledPaymentTotal;
+  final double manualPaymentTotal;
+  final double interestEstimateTotal;
+  final int manualPaymentCount;
+  final int estimatedPaymentCount;
+  final bool isPast;
+  final bool isToday;
+
+  const AssetLiabilityPaymentDayRisk({
+    required this.paymentDay,
+    required this.paymentDate,
+    required this.accountNames,
+    required this.balanceTotal,
+    required this.minimumPaymentEstimateTotal,
+    required this.scheduledPaymentTotal,
+    required this.manualPaymentTotal,
+    required this.interestEstimateTotal,
+    required this.manualPaymentCount,
+    required this.estimatedPaymentCount,
+    required this.isPast,
+    required this.isToday,
+  });
+
+  bool get isUpcoming => !isPast && !isToday;
+  bool get hasManualPayments => manualPaymentCount > 0;
+  bool get hasEstimatedPayments => estimatedPaymentCount > 0;
+}
+
+enum AssetLiabilityCashRiskLevel {
+  normal,
+  watch,
+  caution,
+  short,
+}
+
+enum AssetLiabilityCashflowEventType {
+  payment,
+  income,
+}
+
+class AssetLiabilityIncomePlan {
+  final String id;
+  final DateTime date;
+  final String name;
+  final double amount;
+  final String? destinationAccountId;
+  final String? destinationAccountName;
+  final bool received;
+
+  const AssetLiabilityIncomePlan({
+    required this.id,
+    required this.date,
+    required this.name,
+    required this.amount,
+    required this.destinationAccountId,
+    required this.destinationAccountName,
+    required this.received,
+  });
+}
+
+class AssetLiabilityRecurringIncomeTemplate {
+  final String id;
+  final int dayOfMonth;
+  final String name;
+  final double amount;
+  final String? destinationAccountId;
+  final String? destinationAccountName;
+
+  const AssetLiabilityRecurringIncomeTemplate({
+    required this.id,
+    required this.dayOfMonth,
+    required this.name,
+    required this.amount,
+    required this.destinationAccountId,
+    required this.destinationAccountName,
+  });
+}
+
+class AssetLiabilityCashflowRow {
+  final AssetLiabilityCashflowEventType eventType;
+  final String accountId;
+  final String accountName;
+  final int paymentDay;
+  final DateTime paymentDate;
+  final String? paymentSourceAccountId;
+  final String? paymentSourceAccountName;
+  final String? destinationAccountId;
+  final String? destinationAccountName;
+  final double paymentAmount;
+  final bool paymentAmountEstimated;
+  final bool paid;
+  final bool received;
+  final bool overdue;
+  final double cashBeforePayment;
+  final double cashAfterPayment;
+  final AssetLiabilityCashRiskLevel riskLevel;
+
+  const AssetLiabilityCashflowRow({
+    required this.eventType,
+    required this.accountId,
+    required this.accountName,
+    required this.paymentDay,
+    required this.paymentDate,
+    required this.paymentSourceAccountId,
+    required this.paymentSourceAccountName,
+    required this.destinationAccountId,
+    required this.destinationAccountName,
+    required this.paymentAmount,
+    required this.paymentAmountEstimated,
+    required this.paid,
+    required this.received,
+    required this.overdue,
+    required this.cashBeforePayment,
+    required this.cashAfterPayment,
+    required this.riskLevel,
+  });
+
+  bool get isPayment => eventType == AssetLiabilityCashflowEventType.payment;
+  bool get isIncome => eventType == AssetLiabilityCashflowEventType.income;
+}
+
+class AssetLiabilityAccountCashflowSummary {
+  final String accountId;
+  final String accountName;
+  final double currentBalance;
+  final double upcomingPayments;
+  final double upcomingIncome;
+  final double projectedBalance;
+  final AssetLiabilityCashRiskLevel riskLevel;
+
+  const AssetLiabilityAccountCashflowSummary({
+    required this.accountId,
+    required this.accountName,
+    required this.currentBalance,
+    required this.upcomingPayments,
+    required this.upcomingIncome,
+    required this.projectedBalance,
+    required this.riskLevel,
+  });
+
+  bool get isShort => projectedBalance < 0;
+  double get shortfall => isShort ? projectedBalance.abs() : 0;
+}
+
+class AssetLiabilityTransferSuggestion {
+  final String fromAccountId;
+  final String fromAccountName;
+  final String toAccountId;
+  final String toAccountName;
+  final double amount;
+  final DateTime? neededBy;
+
+  const AssetLiabilityTransferSuggestion({
+    required this.fromAccountId,
+    required this.fromAccountName,
+    required this.toAccountId,
+    required this.toAccountName,
+    required this.amount,
+    required this.neededBy,
+  });
+}
+
+class AssetLiabilityMonthlySnapshot {
+  final String monthKey;
+  final DateTime savedAt;
+  final double positiveAssetTotal;
+  final double liabilityTotal;
+  final double netWorth;
+  final double cashLikeTotal;
+  final double monthlyScheduledPaymentTotal;
+  final double monthlyPaidPaymentTotal;
+  final double monthlyUnpaidPaymentTotal;
+  final int overduePaymentCount;
+
+  const AssetLiabilityMonthlySnapshot({
+    required this.monthKey,
+    required this.savedAt,
+    required this.positiveAssetTotal,
+    required this.liabilityTotal,
+    required this.netWorth,
+    required this.cashLikeTotal,
+    required this.monthlyScheduledPaymentTotal,
+    required this.monthlyPaidPaymentTotal,
+    required this.monthlyUnpaidPaymentTotal,
+    required this.overduePaymentCount,
+  });
+}
+
+class AssetLiabilityMonthlySnapshotComparison {
+  final AssetLiabilityMonthlySnapshot snapshot;
+  final double? positiveAssetDelta;
+  final double? liabilityDelta;
+  final double? netWorthDelta;
+  final double? cashLikeDelta;
+
+  const AssetLiabilityMonthlySnapshotComparison({
+    required this.snapshot,
+    required this.positiveAssetDelta,
+    required this.liabilityDelta,
+    required this.netWorthDelta,
+    required this.cashLikeDelta,
+  });
+
+  bool get hasPrevious => netWorthDelta != null;
+}
+
+class AssetLiabilityCsvExportBundle {
+  final String monthlyHistoryCsv;
+  final String paymentScheduleCsv;
+  final String incomePlansCsv;
+  final String accountCashflowCsv;
+
+  const AssetLiabilityCsvExportBundle({
+    required this.monthlyHistoryCsv,
+    required this.paymentScheduleCsv,
+    required this.incomePlansCsv,
+    required this.accountCashflowCsv,
+  });
+}
+
+class AssetLiabilityWorkbook {
+  final DateTime baseDate;
+  final List<AssetLiabilityAccount> accounts;
+  final List<AssetLiabilityDebtRow> debtMasterRows;
+  final List<AssetLiabilityDebtRow> repaymentPriorityRows;
+  final List<AssetLiabilityPaymentDayRisk> paymentDayRisks;
+  final List<AssetLiabilityCashflowRow> cashflowRows;
+  final List<AssetLiabilityIncomePlan> incomePlans;
+  final List<AssetLiabilityAccountCashflowSummary> accountCashflowSummaries;
+  final List<AssetLiabilityTransferSuggestion> transferSuggestions;
+  final double cashLikeTotal;
+  final double securitiesTotal;
+  final double positiveAssetTotal;
+  final double liabilityTotal;
+  final double netWorth;
+  final double monthlyMinimumPaymentEstimateTotal;
+  final double monthlyScheduledPaymentTotal;
+  final double monthlyUnpaidPaymentTotal;
+  final double monthlyUnreceivedIncomeTotal;
+  final double cashAfterMinimumPayments;
+  final double cashAfterScheduledPayments;
+  final double debtToAssetRatio;
+  final double topFourDebtShare;
+  final int manualPaymentCount;
+  final int estimatedPaymentCount;
+
+  const AssetLiabilityWorkbook({
+    required this.baseDate,
+    required this.accounts,
+    required this.debtMasterRows,
+    required this.repaymentPriorityRows,
+    required this.paymentDayRisks,
+    required this.cashflowRows,
+    required this.incomePlans,
+    required this.accountCashflowSummaries,
+    required this.transferSuggestions,
+    required this.cashLikeTotal,
+    required this.securitiesTotal,
+    required this.positiveAssetTotal,
+    required this.liabilityTotal,
+    required this.netWorth,
+    required this.monthlyMinimumPaymentEstimateTotal,
+    required this.monthlyScheduledPaymentTotal,
+    required this.monthlyUnpaidPaymentTotal,
+    required this.monthlyUnreceivedIncomeTotal,
+    required this.cashAfterMinimumPayments,
+    required this.cashAfterScheduledPayments,
+    required this.debtToAssetRatio,
+    required this.topFourDebtShare,
+    required this.manualPaymentCount,
+    required this.estimatedPaymentCount,
+  });
+
+  List<AssetLiabilityCashflowRow> get overdueCashflowRows {
+    return cashflowRows.where((row) => row.overdue).toList();
+  }
+
+  bool get hasOverduePayments => overdueCashflowRows.isNotEmpty;
+
+  List<AssetLiabilityAccountCashflowSummary> get shortAccountSummaries {
+    return accountCashflowSummaries
+        .where((summary) => summary.isShort)
+        .toList();
+  }
+
+  bool get hasAccountShortage => shortAccountSummaries.isNotEmpty;
+
+  List<AssetLiabilityIncomePlan> get unassignedDestinationIncomePlans {
+    return incomePlans
+        .where(
+          (plan) => !plan.received && plan.destinationAccountId == null,
+        )
+        .toList();
+  }
+
+  bool get hasUnassignedDestinationIncomePlans {
+    return unassignedDestinationIncomePlans.isNotEmpty;
+  }
+}

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -14,14 +14,19 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/models/debt_repayment_plan.dart';
 import 'package:my_web_app/models/kgi_csf_kpi.dart';
+import 'package:my_web_app/services/asset_liability_history_service.dart';
+import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
 import 'package:my_web_app/services/smbc_csv_import_service.dart';
 import 'package:my_web_app/services/waste_tracking_service.dart';
+import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:web/web.dart' as web;
@@ -98,6 +103,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, String?> _lastUpdatedDates = {};
   Map<String, AssetWatchlistEntry> _watchlistByType = {};
   final Map<String, GlobalKey> _assetRowKeys = <String, GlobalKey>{};
+  Map<String, double> _monthlyPaymentOverrides = <String, double>{};
+  Set<String> _monthlyPaidAccountNames = <String>{};
+  Map<String, String> _paymentSourceAccountIds = <String, String>{};
+  Map<String, String> _defaultPaymentSourceAccountIds = <String, String>{};
+  List<AssetLiabilityIncomePlan> _monthlyIncomePlans =
+      <AssetLiabilityIncomePlan>[];
+  List<AssetLiabilityRecurringIncomeTemplate> _recurringIncomeTemplates =
+      <AssetLiabilityRecurringIncomeTemplate>[];
+  List<AssetLiabilityMonthlySnapshot> _monthlySnapshots =
+      <AssetLiabilityMonthlySnapshot>[];
+  String? _loadedAssetLiabilityMonthKey;
+  bool _isSavingAssetLiabilitySnapshot = false;
+  final Map<String, TextEditingController> _monthlyPaymentControllers =
+      <String, TextEditingController>{};
 
   // --- グラフデータ ---
   List<LineChartBarData> _lineChartBars = [];
@@ -139,6 +158,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   bool _isLoadingTasks = false;
 
   // --- 返済計画用 ---
+  final AssetLiabilityMonthlyStateStore _assetLiabilityMonthlyStateStore =
+      const AssetLiabilityMonthlyStateStore();
+  final AssetLiabilityPlanningService _assetLiabilityPlanner =
+      const AssetLiabilityPlanningService();
+  final AssetLiabilityHistoryService _assetLiabilityHistoryService =
+      const AssetLiabilityHistoryService();
   final DebtLockdownService _debtLockdownService = const DebtLockdownService();
   final DebtRepaymentPlannerService _debtRepaymentPlanner =
       const DebtRepaymentPlannerService();
@@ -184,13 +209,23 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   void initState() {
     super.initState();
     _loadDataFromSupabase();
+    _loadAssetLiabilityMonthlyState();
     _loadWatchlistEntries();
     _fetchRecentFlows();
     _fetchSubscriptions();
     _fetchMustTasks();
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
-      setState(() => _now = DateTime.now());
+      final previousMonthKey =
+          AssetLiabilityMonthlyStateStore.formatMonthKey(_now);
+      final nextNow = DateTime.now();
+      final nextMonthKey =
+          AssetLiabilityMonthlyStateStore.formatMonthKey(nextNow);
+      setState(() => _now = nextNow);
+      if (nextMonthKey != previousMonthKey &&
+          nextMonthKey != _loadedAssetLiabilityMonthKey) {
+        unawaited(_loadAssetLiabilityMonthlyState());
+      }
     });
     _fetchTodayClosing();
     _loadSourceOptionsFromDb();
@@ -203,6 +238,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   @override
   void dispose() {
     _controllers.forEach((_, controller) => controller.dispose());
+    _monthlyPaymentControllers.forEach((_, controller) => controller.dispose());
     _flowMemoController.dispose();
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
@@ -719,6 +755,780 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _assetData[latestDate] ??
         const <String, double>{};
     return Map<String, double>.from(snapshot);
+  }
+
+  Map<String, double> _latestSnapshotForDisplay() {
+    final dateKeys = <String>{
+      ..._assetData.keys,
+      ..._effectiveAssetDataByDate.keys,
+    }.toList()
+      ..sort();
+    if (dateKeys.isEmpty) return {};
+
+    final latestDate = dateKeys.last;
+    final snapshot = _effectiveAssetDataByDate[latestDate] ??
+        _assetData[latestDate] ??
+        const <String, double>{};
+    return Map<String, double>.from(snapshot);
+  }
+
+  Future<void> _loadAssetLiabilityMonthlyState() async {
+    try {
+      final targetMonth = _now;
+      final monthKey =
+          AssetLiabilityMonthlyStateStore.formatMonthKey(targetMonth);
+      final state =
+          await _assetLiabilityMonthlyStateStore.loadMonth(targetMonth);
+      final defaultSources =
+          await _assetLiabilityMonthlyStateStore.loadDefaultPaymentSources();
+      final templates =
+          await _assetLiabilityMonthlyStateStore.loadRecurringIncomeTemplates();
+      final monthlySnapshots =
+          await _assetLiabilityMonthlyStateStore.loadMonthlySnapshots();
+      final incomePlansWithTemplates =
+          AssetLiabilityMonthlyStateStore.applyRecurringIncomeTemplates(
+        month: targetMonth,
+        templates: templates,
+        existingPlans: state.incomePlans,
+      );
+      final generatedTemplatePlans =
+          incomePlansWithTemplates.length != state.incomePlans.length;
+      if (!mounted) return;
+      setState(() {
+        _monthlyPaymentOverrides = Map<String, double>.from(
+          state.paymentOverrides,
+        );
+        _monthlyPaidAccountNames = Set<String>.from(state.paidAccountNames);
+        _paymentSourceAccountIds = Map<String, String>.from(
+          state.paymentSourceAccountIds,
+        );
+        _defaultPaymentSourceAccountIds = Map<String, String>.from(
+          defaultSources,
+        );
+        _monthlyIncomePlans = List<AssetLiabilityIncomePlan>.from(
+          incomePlansWithTemplates,
+        );
+        _recurringIncomeTemplates =
+            List<AssetLiabilityRecurringIncomeTemplate>.from(templates);
+        _monthlySnapshots =
+            List<AssetLiabilityMonthlySnapshot>.from(monthlySnapshots);
+        _loadedAssetLiabilityMonthKey = monthKey;
+        _syncMonthlyPaymentControllers();
+      });
+      if (generatedTemplatePlans) {
+        unawaited(_saveAssetLiabilityMonthlyState());
+      }
+    } catch (e) {
+      debugPrint('Error loading asset liability monthly state: $e');
+    }
+  }
+
+  Future<void> _saveAssetLiabilityMonthlyState() async {
+    try {
+      await _assetLiabilityMonthlyStateStore.saveMonth(
+        month: _now,
+        state: AssetLiabilityMonthlyState(
+          paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
+          paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
+          paymentSourceAccountIds: Map<String, String>.from(
+            _paymentSourceAccountIds,
+          ),
+          incomePlans: List<AssetLiabilityIncomePlan>.from(
+            _monthlyIncomePlans,
+          ),
+        ),
+      );
+    } catch (e) {
+      debugPrint('Error saving asset liability monthly state: $e');
+    }
+  }
+
+  Future<void> _saveCurrentAssetLiabilitySnapshot(
+    AssetLiabilityWorkbook workbook,
+  ) async {
+    setState(() {
+      _isSavingAssetLiabilitySnapshot = true;
+    });
+    try {
+      final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(_now);
+      final snapshot = _assetLiabilityHistoryService.buildSnapshot(
+        monthKey: monthKey,
+        workbook: workbook,
+        savedAt: DateTime.now(),
+      );
+      await _assetLiabilityMonthlyStateStore.saveMonthlySnapshot(snapshot);
+      final snapshots =
+          await _assetLiabilityMonthlyStateStore.loadMonthlySnapshots();
+      if (!mounted) return;
+      setState(() {
+        _monthlySnapshots = List<AssetLiabilityMonthlySnapshot>.from(snapshots);
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('$monthKey のスナップショットを保存しました')),
+      );
+    } catch (e) {
+      debugPrint('Error saving asset liability monthly snapshot: $e');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('スナップショット保存に失敗しました: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSavingAssetLiabilitySnapshot = false;
+        });
+      }
+    }
+  }
+
+  void _downloadAssetLiabilityCsvBundle(AssetLiabilityWorkbook workbook) {
+    final bundle = _assetLiabilityHistoryService.buildCsvExportBundle(
+      monthlySnapshots: _monthlySnapshots,
+      workbook: workbook,
+    );
+    final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(_now);
+    final stamp = DateFormat('yyyyMMdd_HHmm').format(DateTime.now());
+    downloadCsvFile(
+      bundle.monthlyHistoryCsv,
+      'asset_liability_monthly_history_${monthKey}_$stamp.csv',
+    );
+    downloadCsvFile(
+      bundle.paymentScheduleCsv,
+      'asset_liability_payment_schedule_${monthKey}_$stamp.csv',
+    );
+    downloadCsvFile(
+      bundle.incomePlansCsv,
+      'asset_liability_income_plans_${monthKey}_$stamp.csv',
+    );
+    downloadCsvFile(
+      bundle.accountCashflowCsv,
+      'asset_liability_account_cashflow_${monthKey}_$stamp.csv',
+    );
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('資産/負債ボードのCSV 4種類を出力しました')),
+    );
+  }
+
+  void _scheduleAssetLiabilityStateIdMigration(
+    AssetLiabilityWorkbook workbook,
+  ) {
+    final legacyKeyToAccountId = <String, String>{};
+    for (final row in workbook.debtMasterRows) {
+      legacyKeyToAccountId[row.name] = row.id;
+      legacyKeyToAccountId[row.name.trim()] = row.id;
+    }
+    final migrated = AssetLiabilityMonthlyStateStore.migrateLegacyKeys(
+      state: AssetLiabilityMonthlyState(
+        paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
+        paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
+        paymentSourceAccountIds: Map<String, String>.from(
+          _paymentSourceAccountIds,
+        ),
+        incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
+      ),
+      legacyKeyToAccountId: legacyKeyToAccountId,
+    );
+    final migratedDefaultSources = _migrateStringMapKeysAndValues(
+      _defaultPaymentSourceAccountIds,
+      legacyKeyToAccountId,
+    );
+    if (_sameDoubleMap(
+          _monthlyPaymentOverrides,
+          migrated.paymentOverrides,
+        ) &&
+        _sameStringSet(
+          _monthlyPaidAccountNames,
+          migrated.paidAccountNames,
+        ) &&
+        _sameStringMap(
+          _paymentSourceAccountIds,
+          migrated.paymentSourceAccountIds,
+        ) &&
+        _sameStringMap(
+          _defaultPaymentSourceAccountIds,
+          migratedDefaultSources,
+        )) {
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {
+        _monthlyPaymentOverrides = Map<String, double>.from(
+          migrated.paymentOverrides,
+        );
+        _monthlyPaidAccountNames = Set<String>.from(migrated.paidAccountNames);
+        _paymentSourceAccountIds = Map<String, String>.from(
+          migrated.paymentSourceAccountIds,
+        );
+        _defaultPaymentSourceAccountIds = Map<String, String>.from(
+          migratedDefaultSources,
+        );
+        _syncMonthlyPaymentControllers();
+      });
+      unawaited(_saveAssetLiabilityMonthlyState());
+      unawaited(_saveDefaultPaymentSources());
+    });
+  }
+
+  Map<String, String> _migrateStringMapKeysAndValues(
+    Map<String, String> source,
+    Map<String, String> legacyKeyToAccountId,
+  ) {
+    final migrated = <String, String>{};
+    for (final entry in source.entries) {
+      final key = legacyKeyToAccountId[entry.key] ?? entry.key;
+      final value = legacyKeyToAccountId[entry.value] ?? entry.value;
+      migrated[key] = value;
+    }
+    return migrated;
+  }
+
+  bool _sameDoubleMap(Map<String, double> a, Map<String, double> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final entry in a.entries) {
+      if (b[entry.key] != entry.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _sameStringSet(Set<String> a, Set<String> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    return a.containsAll(b);
+  }
+
+  bool _sameStringMap(Map<String, String> a, Map<String, String> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final entry in a.entries) {
+      if (b[entry.key] != entry.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void _syncMonthlyPaymentControllers() {
+    for (final entry in _monthlyPaymentControllers.entries) {
+      final hasOverride = _monthlyPaymentOverrides.containsKey(entry.key);
+      final amount = _monthlyPaymentOverrides[entry.key];
+      final text =
+          hasOverride && amount != null ? amount.round().toString() : '';
+      if (entry.value.text != text) {
+        entry.value.text = text;
+      }
+    }
+  }
+
+  TextEditingController _monthlyPaymentControllerFor(
+    AssetLiabilityDebtRow row,
+  ) {
+    return _monthlyPaymentControllers.putIfAbsent(
+      row.id,
+      () => TextEditingController(
+        text: row.manualPaymentAmount == null
+            ? ''
+            : row.manualPaymentAmount!.round().toString(),
+      ),
+    );
+  }
+
+  void _updateMonthlyPaymentOverride(String accountId, String rawValue) {
+    final normalized = rawValue.replaceAll(',', '').trim();
+    final amount = normalized.isEmpty ? null : double.tryParse(normalized);
+    setState(() {
+      if (amount == null || amount < 0) {
+        _monthlyPaymentOverrides.remove(accountId);
+      } else {
+        _monthlyPaymentOverrides[accountId] = amount;
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _clearMonthlyPaymentOverride(String accountId) {
+    _monthlyPaymentControllers[accountId]?.clear();
+    setState(() {
+      _monthlyPaymentOverrides.remove(accountId);
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _toggleMonthlyPaymentPaid(String accountId, bool paid) {
+    setState(() {
+      if (paid) {
+        _monthlyPaidAccountNames.add(accountId);
+      } else {
+        _monthlyPaidAccountNames.remove(accountId);
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _updatePaymentSourceAccount(
+      String liabilityId, String? sourceAccountId) {
+    setState(() {
+      if (sourceAccountId == null || sourceAccountId.isEmpty) {
+        _paymentSourceAccountIds.remove(liabilityId);
+      } else {
+        _paymentSourceAccountIds[liabilityId] = sourceAccountId;
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  Future<void> _saveDefaultPaymentSources() async {
+    try {
+      await _assetLiabilityMonthlyStateStore.saveDefaultPaymentSources(
+        Map<String, String>.from(_defaultPaymentSourceAccountIds),
+      );
+    } catch (e) {
+      debugPrint('Error saving asset liability default sources: $e');
+    }
+  }
+
+  Future<void> _saveRecurringIncomeTemplates() async {
+    try {
+      await _assetLiabilityMonthlyStateStore.saveRecurringIncomeTemplates(
+        List<AssetLiabilityRecurringIncomeTemplate>.from(
+          _recurringIncomeTemplates,
+        ),
+      );
+    } catch (e) {
+      debugPrint('Error saving recurring income templates: $e');
+    }
+  }
+
+  void _updateDefaultPaymentSourceAccount(
+    String liabilityId,
+    String? sourceAccountId,
+  ) {
+    setState(() {
+      if (sourceAccountId == null || sourceAccountId.isEmpty) {
+        _defaultPaymentSourceAccountIds.remove(liabilityId);
+      } else {
+        _defaultPaymentSourceAccountIds[liabilityId] = sourceAccountId;
+      }
+    });
+    unawaited(_saveDefaultPaymentSources());
+  }
+
+  Future<void> _copyPreviousMonthSettings() async {
+    final copied =
+        await _assetLiabilityMonthlyStateStore.copyPreviousMonthToMonth(_now);
+    final incomePlansWithTemplates =
+        AssetLiabilityMonthlyStateStore.applyRecurringIncomeTemplates(
+      month: _now,
+      templates: _recurringIncomeTemplates,
+      existingPlans: copied.incomePlans,
+    );
+
+    if (!mounted) return;
+    setState(() {
+      _monthlyPaymentOverrides = Map<String, double>.from(
+        copied.paymentOverrides,
+      );
+      _monthlyPaidAccountNames = <String>{};
+      _paymentSourceAccountIds = Map<String, String>.from(
+        copied.paymentSourceAccountIds,
+      );
+      _monthlyIncomePlans = incomePlansWithTemplates;
+      _syncMonthlyPaymentControllers();
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('前月設定をコピーしました。支払済み・入金済み状態はコピーしていません。'),
+      ),
+    );
+  }
+
+  String _generatedPlanIdForTemplate(
+    AssetLiabilityRecurringIncomeTemplate template,
+    DateTime month,
+  ) {
+    return 'recurring_${template.id}_${AssetLiabilityMonthlyStateStore.formatMonthKey(month)}';
+  }
+
+  AssetLiabilityIncomePlan _incomePlanForTemplate(
+    AssetLiabilityRecurringIncomeTemplate template,
+    DateTime month, {
+    bool received = false,
+  }) {
+    final lastDay = DateTime(month.year, month.month + 1, 0).day;
+    return AssetLiabilityIncomePlan(
+      id: _generatedPlanIdForTemplate(template, month),
+      date: DateTime(
+        month.year,
+        month.month,
+        min(template.dayOfMonth.clamp(1, 31).toInt(), lastDay),
+      ),
+      name: template.name,
+      amount: template.amount,
+      destinationAccountId: template.destinationAccountId,
+      destinationAccountName: template.destinationAccountName,
+      received: received,
+    );
+  }
+
+  void _toggleIncomeReceived(String incomeId, bool received) {
+    setState(() {
+      _monthlyIncomePlans = [
+        for (final plan in _monthlyIncomePlans)
+          plan.id == incomeId
+              ? AssetLiabilityIncomePlan(
+                  id: plan.id,
+                  date: plan.date,
+                  name: plan.name,
+                  amount: plan.amount,
+                  destinationAccountId: plan.destinationAccountId,
+                  destinationAccountName: plan.destinationAccountName,
+                  received: received,
+                )
+              : plan,
+      ];
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _deleteIncomePlan(String incomeId) {
+    setState(() {
+      _monthlyIncomePlans = _monthlyIncomePlans
+          .where((plan) => plan.id != incomeId)
+          .toList(growable: false);
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _deleteRecurringIncomeTemplate(String templateId) {
+    final currentMonthKey =
+        AssetLiabilityMonthlyStateStore.formatMonthKey(_now);
+    setState(() {
+      _recurringIncomeTemplates = _recurringIncomeTemplates
+          .where((template) => template.id != templateId)
+          .toList(growable: false);
+      _monthlyIncomePlans = _monthlyIncomePlans
+          .where(
+            (plan) => plan.id != 'recurring_${templateId}_$currentMonthKey',
+          )
+          .toList(growable: false);
+    });
+    unawaited(_saveRecurringIncomeTemplates());
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  Future<void> _showIncomePlanDialog(
+    AssetLiabilityWorkbook workbook, {
+    AssetLiabilityIncomePlan? existing,
+  }) async {
+    final nameController = TextEditingController(text: existing?.name ?? '');
+    final amountController = TextEditingController(
+      text: existing == null ? '' : existing.amount.round().toString(),
+    );
+    var selectedDate = existing?.date ?? _now;
+    var selectedDestinationId = existing?.destinationAccountId;
+    var received = existing?.received ?? false;
+    final destinationOptions = _paymentSourceAccountOptions(workbook);
+
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              title: Text(existing == null ? '収入予定を追加' : '収入予定を編集'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('日付'),
+                      subtitle:
+                          Text(DateFormat('yyyy/MM/dd').format(selectedDate)),
+                      trailing: const Icon(Icons.calendar_today_outlined),
+                      onTap: () async {
+                        final picked = await showDatePicker(
+                          context: context,
+                          initialDate: selectedDate,
+                          firstDate: DateTime(_now.year, _now.month, 1),
+                          lastDate: DateTime(_now.year, _now.month + 1, 0),
+                        );
+                        if (picked != null) {
+                          setDialogState(() => selectedDate = picked);
+                        }
+                      },
+                    ),
+                    TextField(
+                      controller: nameController,
+                      decoration: const InputDecoration(labelText: '名称'),
+                    ),
+                    TextField(
+                      controller: amountController,
+                      keyboardType: TextInputType.number,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.allow(RegExp(r'[0-9,]')),
+                      ],
+                      decoration: const InputDecoration(labelText: '金額'),
+                    ),
+                    DropdownButtonFormField<String>(
+                      initialValue: selectedDestinationId ?? '',
+                      decoration: const InputDecoration(labelText: '入金先口座'),
+                      items: [
+                        const DropdownMenuItem<String>(
+                          value: '',
+                          child: Text('未設定'),
+                        ),
+                        for (final account in destinationOptions)
+                          DropdownMenuItem<String>(
+                            value: account.id,
+                            child: Text(account.name),
+                          ),
+                      ],
+                      onChanged: (value) {
+                        setDialogState(() {
+                          selectedDestinationId =
+                              value == null || value.isEmpty ? null : value;
+                        });
+                      },
+                    ),
+                    CheckboxListTile(
+                      contentPadding: EdgeInsets.zero,
+                      value: received,
+                      onChanged: (value) {
+                        setDialogState(() => received = value ?? false);
+                      },
+                      title: const Text('入金済み'),
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                FilledButton(
+                  onPressed: () {
+                    final name = nameController.text.trim();
+                    final amount = double.tryParse(
+                      amountController.text.replaceAll(',', '').trim(),
+                    );
+                    if (name.isEmpty || amount == null || amount <= 0) {
+                      return;
+                    }
+                    String? destinationName;
+                    for (final account in destinationOptions) {
+                      if (account.id == selectedDestinationId) {
+                        destinationName = account.name;
+                        break;
+                      }
+                    }
+                    final plan = AssetLiabilityIncomePlan(
+                      id: existing?.id ??
+                          'income_${DateTime.now().microsecondsSinceEpoch}',
+                      date: selectedDate,
+                      name: name,
+                      amount: amount,
+                      destinationAccountId: selectedDestinationId,
+                      destinationAccountName: destinationName,
+                      received: received,
+                    );
+                    setState(() {
+                      _monthlyIncomePlans = [
+                        for (final current in _monthlyIncomePlans)
+                          if (current.id != plan.id) current,
+                        plan,
+                      ]..sort((a, b) => a.date.compareTo(b.date));
+                    });
+                    unawaited(_saveAssetLiabilityMonthlyState());
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text('保存'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    nameController.dispose();
+    amountController.dispose();
+  }
+
+  Future<void> _showRecurringIncomeTemplateDialog(
+    AssetLiabilityWorkbook workbook, {
+    AssetLiabilityRecurringIncomeTemplate? existing,
+  }) async {
+    final nameController = TextEditingController(text: existing?.name ?? '');
+    final amountController = TextEditingController(
+      text: existing == null ? '' : existing.amount.round().toString(),
+    );
+    final dayController = TextEditingController(
+      text: existing == null ? '' : existing.dayOfMonth.toString(),
+    );
+    var selectedDestinationId = existing?.destinationAccountId;
+    final destinationOptions = _paymentSourceAccountOptions(workbook);
+
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              title: Text(existing == null ? '定期収入を追加' : '定期収入を編集'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: nameController,
+                      decoration: const InputDecoration(labelText: '名称'),
+                    ),
+                    TextField(
+                      controller: dayController,
+                      keyboardType: TextInputType.number,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.digitsOnly,
+                      ],
+                      decoration: const InputDecoration(labelText: '毎月の日付'),
+                    ),
+                    TextField(
+                      controller: amountController,
+                      keyboardType: TextInputType.number,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.allow(RegExp(r'[0-9,]')),
+                      ],
+                      decoration: const InputDecoration(labelText: '金額'),
+                    ),
+                    DropdownButtonFormField<String>(
+                      initialValue: selectedDestinationId ?? '',
+                      decoration: const InputDecoration(labelText: '入金先口座'),
+                      items: [
+                        const DropdownMenuItem<String>(
+                          value: '',
+                          child: Text('未設定'),
+                        ),
+                        for (final account in destinationOptions)
+                          DropdownMenuItem<String>(
+                            value: account.id,
+                            child: Text(account.name),
+                          ),
+                      ],
+                      onChanged: (value) {
+                        setDialogState(() {
+                          selectedDestinationId =
+                              value == null || value.isEmpty ? null : value;
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                FilledButton(
+                  onPressed: () {
+                    final name = nameController.text.trim();
+                    final day = int.tryParse(dayController.text.trim());
+                    final amount = double.tryParse(
+                      amountController.text.replaceAll(',', '').trim(),
+                    );
+                    if (name.isEmpty ||
+                        day == null ||
+                        day < 1 ||
+                        amount == null ||
+                        amount <= 0) {
+                      return;
+                    }
+                    String? destinationName;
+                    for (final account in destinationOptions) {
+                      if (account.id == selectedDestinationId) {
+                        destinationName = account.name;
+                        break;
+                      }
+                    }
+                    final template = AssetLiabilityRecurringIncomeTemplate(
+                      id: existing?.id ??
+                          'income_template_${DateTime.now().microsecondsSinceEpoch}',
+                      dayOfMonth: day.clamp(1, 31).toInt(),
+                      name: name,
+                      amount: amount,
+                      destinationAccountId: selectedDestinationId,
+                      destinationAccountName: destinationName,
+                    );
+                    final generatedId =
+                        _generatedPlanIdForTemplate(template, _now);
+                    final previousGeneratedPlan =
+                        _monthlyIncomePlans.where((plan) {
+                      return plan.id == generatedId;
+                    }).toList();
+                    final generatedPlan = _incomePlanForTemplate(
+                      template,
+                      _now,
+                      received: previousGeneratedPlan.isNotEmpty
+                          ? previousGeneratedPlan.first.received
+                          : false,
+                    );
+                    setState(() {
+                      _recurringIncomeTemplates = [
+                        for (final current in _recurringIncomeTemplates)
+                          if (current.id != template.id) current,
+                        template,
+                      ]..sort((a, b) {
+                          final day = a.dayOfMonth.compareTo(b.dayOfMonth);
+                          if (day != 0) {
+                            return day;
+                          }
+                          return a.name.compareTo(b.name);
+                        });
+                      _monthlyIncomePlans = [
+                        for (final current in _monthlyIncomePlans)
+                          if (current.id != generatedId) current,
+                        generatedPlan,
+                      ]..sort((a, b) => a.date.compareTo(b.date));
+                    });
+                    unawaited(_saveRecurringIncomeTemplates());
+                    unawaited(_saveAssetLiabilityMonthlyState());
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text('保存'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    nameController.dispose();
+    amountController.dispose();
+    dayController.dispose();
+  }
+
+  List<AssetLiabilityAccount> _paymentSourceAccountOptions(
+    AssetLiabilityWorkbook workbook,
+  ) {
+    return workbook.accounts
+        .where(
+          (account) =>
+              account.balance > 0 &&
+              (account.kind == AssetLiabilityAccountKind.cash ||
+                  account.kind == AssetLiabilityAccountKind.deposit),
+        )
+        .toList()
+      ..sort((a, b) => b.balance.compareTo(a.balance));
   }
 
   List<Map<String, dynamic>> _liabilitiesFromSnapshot(
@@ -3785,6 +4595,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             const SizedBox(height: 16),
             _buildDebtPlannerCard(), // 借金返済プラン
             const SizedBox(height: 16),
+            _buildAssetLiabilityWorkbookBoard(),
+            const SizedBox(height: 16),
             Container(
               key: _keyStock,
               child: _buildAssetLiabilityCard(),
@@ -5460,6 +6272,1384 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ],
       ),
     );
+  }
+
+  Widget _buildAssetLiabilityWorkbookBoard() {
+    final latestSnapshot = _latestSnapshotForDisplay();
+    if (latestSnapshot.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final workbook = _assetLiabilityPlanner.buildWorkbook(
+      latestSnapshot: latestSnapshot,
+      baseDate: _now,
+      monthlyPaymentOverrides: _monthlyPaymentOverrides,
+      paidAccountNames: _monthlyPaidAccountNames,
+      paymentSourceAccountIds: _paymentSourceAccountIds,
+      defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
+      incomePlans: _monthlyIncomePlans,
+    );
+    _scheduleAssetLiabilityStateIdMigration(workbook);
+    final warningColor = workbook.cashAfterScheduledPayments < 0
+        ? const Color(0xFFB91C1C)
+        : const Color(0xFF0D9488);
+
+    return Card(
+      key: const Key('asset_liability_workbook_board'),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Row(
+              children: [
+                Icon(
+                  Icons.table_chart_outlined,
+                  color: Color(0xFF0F766E),
+                ),
+                SizedBox(width: 8),
+                Text(
+                  '資産/負債 管理ボード',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'プラス=資産、マイナス=負債として、残高・支払日・今月支払予定額を分けて確認します。',
+              style: TextStyle(
+                fontSize: 11,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _buildOverviewStatChip(
+                  label: '手元現金',
+                  value: _formatManagementYen(workbook.cashLikeTotal),
+                  color: const Color(0xFF0D9488),
+                ),
+                _buildOverviewStatChip(
+                  label: '証券',
+                  value: _formatManagementYen(workbook.securitiesTotal),
+                  color: const Color(0xFF2563EB),
+                ),
+                _buildOverviewStatChip(
+                  label: '資産合計',
+                  value: _formatManagementYen(workbook.positiveAssetTotal),
+                  color: const Color(0xFF0D9488),
+                ),
+                _buildOverviewStatChip(
+                  label: '負債合計',
+                  value: _formatManagementYen(workbook.liabilityTotal),
+                  color: const Color(0xFFB91C1C),
+                ),
+                _buildOverviewStatChip(
+                  label: '純資産',
+                  value: _formatManagementYen(workbook.netWorth),
+                  color: workbook.netWorth < 0
+                      ? const Color(0xFFB91C1C)
+                      : const Color(0xFF0D9488),
+                ),
+                _buildOverviewStatChip(
+                  label: '負債倍率',
+                  value: workbook.debtToAssetRatio.isInfinite
+                      ? '算出不可'
+                      : '${workbook.debtToAssetRatio.toStringAsFixed(1)}倍',
+                  color: const Color(0xFFFF6B35),
+                ),
+                _buildOverviewStatChip(
+                  label: '推定最低支払額',
+                  value: _formatManagementYen(
+                    workbook.monthlyMinimumPaymentEstimateTotal,
+                  ),
+                  color: const Color(0xFF7C3AED),
+                ),
+                _buildOverviewStatChip(
+                  label: '今月支払予定額',
+                  value: _formatManagementYen(
+                    workbook.monthlyScheduledPaymentTotal,
+                  ),
+                  color: const Color(0xFF4F46E5),
+                ),
+                _buildOverviewStatChip(
+                  label: '未払い予定額',
+                  value: _formatManagementYen(
+                    workbook.monthlyUnpaidPaymentTotal,
+                  ),
+                  color: const Color(0xFFD97706),
+                ),
+                _buildOverviewStatChip(
+                  label: '未入金予定額',
+                  value: _formatManagementYen(
+                    workbook.monthlyUnreceivedIncomeTotal,
+                  ),
+                  color: const Color(0xFF0D9488),
+                ),
+                _buildOverviewStatChip(
+                  label: '支払後手元',
+                  value: _formatManagementYen(
+                    workbook.cashAfterScheduledPayments,
+                  ),
+                  color: warningColor,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            _buildAssetWorkbookEstimateNotice(workbook),
+            if (workbook.hasOverduePayments) ...[
+              const SizedBox(height: 8),
+              _buildAssetWorkbookOverdueWarning(workbook),
+            ],
+            const SizedBox(height: 12),
+            _buildAssetWorkbookWarning(workbook),
+            const SizedBox(height: 16),
+            _buildAssetWorkbookPaymentList(workbook),
+            const SizedBox(height: 16),
+            _buildIncomePlanSection(workbook),
+            const SizedBox(height: 16),
+            _buildAssetCashflowTable(workbook),
+            const SizedBox(height: 16),
+            _buildAccountCashflowSection(workbook),
+            const SizedBox(height: 16),
+            _buildMonthlySnapshotSection(workbook),
+            const SizedBox(height: 16),
+            _buildTransferSuggestionSection(workbook),
+            const SizedBox(height: 16),
+            _buildAssetWorkbookDebtTable(workbook),
+            const SizedBox(height: 16),
+            _buildAssetWorkbookPriorityList(workbook),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAssetWorkbookEstimateNotice(AssetLiabilityWorkbook workbook) {
+    final hasManual = workbook.manualPaymentCount > 0;
+    final status = hasManual
+        ? '実額 ${workbook.manualPaymentCount}件 / 推定 ${workbook.estimatedPaymentCount}件'
+        : '全件が推定値';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFF59E0B).withValues(alpha: 0.3),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.info_outline,
+            size: 20,
+            color: Color(0xFFD97706),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '推定最低支払額は参考値です。実際の請求額とは異なる場合があります。請求確定後は手入力値を優先してください。$status',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetWorkbookOverdueWarning(AssetLiabilityWorkbook workbook) {
+    final overdueRows = workbook.overdueCashflowRows;
+    final overdueTotal = overdueRows.fold<double>(
+      0,
+      (sum, row) => sum + row.paymentAmount,
+    );
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFEF2F2),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFB91C1C).withValues(alpha: 0.3),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.priority_high_rounded,
+            size: 20,
+            color: Color(0xFFB91C1C),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '期限超過の未払いが${overdueRows.length}件あります。対象: ${overdueRows.map((row) => row.accountName).join('、')} / 合計 ${_formatManagementYen(overdueTotal)}',
+              style: const TextStyle(
+                color: Color(0xFF7F1D1D),
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetWorkbookWarning(AssetLiabilityWorkbook workbook) {
+    final isShort = workbook.cashAfterScheduledPayments < 0;
+    final color = isShort ? const Color(0xFFB91C1C) : const Color(0xFF0D9488);
+    final background =
+        isShort ? const Color(0xFFFEF2F2) : const Color(0xFFECFDF5);
+    final title = isShort ? '今月支払予定額ベースで手元資金が不足' : '今月支払予定額は手元資金内';
+    final detail = isShort
+        ? '不足見込: ${_formatManagementYen(workbook.cashAfterScheduledPayments.abs())}'
+        : '支払後手元見込: ${_formatManagementYen(workbook.cashAfterScheduledPayments)}';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.28)),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            isShort ? Icons.warning_amber_rounded : Icons.check_circle_outline,
+            color: color,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: color,
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+                Text(
+                  '$detail / 上位4件の負債割合: ${_formatManagementPercent(workbook.topFourDebtShare)}',
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurface,
+                    fontSize: 12,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetWorkbookPaymentList(AssetLiabilityWorkbook workbook) {
+    if (workbook.paymentDayRisks.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '支払日別リスク',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...workbook.paymentDayRisks.map(_buildPaymentRiskRow),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPaymentRiskRow(AssetLiabilityPaymentDayRisk risk) {
+    final color = risk.isToday
+        ? const Color(0xFFFF6B35)
+        : risk.isPast
+            ? const Color(0xFF64748B)
+            : const Color(0xFFB91C1C);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 56,
+            padding: const EdgeInsets.symmetric(
+              horizontal: 8,
+              vertical: 6,
+            ),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              '${risk.paymentDay}日',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: color,
+                fontWeight: FontWeight.bold,
+                height: 1.3,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  risk.accountNames.join('、'),
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w600,
+                    height: 1.4,
+                  ),
+                ),
+                Text(
+                  '${_paymentRiskStatusLabel(risk)} / 残高 ${_formatManagementYen(risk.balanceTotal)} / 支払予定 ${_formatManagementYen(risk.scheduledPaymentTotal)}（${_paymentRiskPaymentSourceLabel(risk)}） / 推定最低支払額 ${_formatManagementYen(risk.minimumPaymentEstimateTotal)}',
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    fontSize: 12,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildIncomePlanSection(AssetLiabilityWorkbook workbook) {
+    final plans = workbook.incomePlans;
+    final unassignedPlans = workbook.unassignedDestinationIncomePlans;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  '収入予定',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              Wrap(
+                spacing: 4,
+                runSpacing: 4,
+                alignment: WrapAlignment.end,
+                children: [
+                  TextButton.icon(
+                    onPressed: _copyPreviousMonthSettings,
+                    icon: const Icon(Icons.copy_all_outlined),
+                    label: const Text('前月コピー'),
+                  ),
+                  TextButton.icon(
+                    onPressed: () =>
+                        _showRecurringIncomeTemplateDialog(workbook),
+                    icon: const Icon(Icons.event_repeat_outlined),
+                    label: const Text('定期収入'),
+                  ),
+                  TextButton.icon(
+                    onPressed: () => _showIncomePlanDialog(workbook),
+                    icon: const Icon(Icons.add),
+                    label: const Text('追加'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          Text(
+            '入金済み・支払済みにした項目は、現在の口座残高に反映済みとして扱います。まだ残高を更新していない場合はチェックしないでください。',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          if (unassignedPlans.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            _buildUnassignedIncomeWarning(unassignedPlans),
+          ],
+          if (_recurringIncomeTemplates.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            _buildRecurringIncomeTemplateList(workbook),
+          ],
+          const SizedBox(height: 8),
+          if (plans.isEmpty)
+            Text(
+              '今月の収入予定は未登録です。',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+              ),
+            )
+          else
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: DataTable(
+                headingRowHeight: 36,
+                dataRowMinHeight: 44,
+                dataRowMaxHeight: 56,
+                columns: const [
+                  DataColumn(label: Text('日付'), numeric: true),
+                  DataColumn(label: Text('名称')),
+                  DataColumn(label: Text('金額'), numeric: true),
+                  DataColumn(label: Text('入金先口座')),
+                  DataColumn(label: Text('入金済み')),
+                  DataColumn(label: Text('操作')),
+                ],
+                rows: [
+                  for (final plan in plans)
+                    DataRow(
+                      cells: [
+                        DataCell(Text(DateFormat('M/d').format(plan.date))),
+                        DataCell(Text(plan.name)),
+                        DataCell(Text(_formatManagementYen(plan.amount))),
+                        DataCell(Text(plan.destinationAccountName ?? '未設定')),
+                        DataCell(
+                          Checkbox(
+                            value: plan.received,
+                            onChanged: (value) => _toggleIncomeReceived(
+                              plan.id,
+                              value ?? false,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                tooltip: '編集',
+                                icon: const Icon(Icons.edit_outlined, size: 18),
+                                onPressed: () => _showIncomePlanDialog(
+                                  workbook,
+                                  existing: plan,
+                                ),
+                              ),
+                              IconButton(
+                                tooltip: '削除',
+                                icon:
+                                    const Icon(Icons.delete_outline, size: 18),
+                                onPressed: () => _deleteIncomePlan(plan.id),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUnassignedIncomeWarning(
+    List<AssetLiabilityIncomePlan> plans,
+  ) {
+    final names = plans.map((plan) => plan.name).join('、');
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFF59E0B).withValues(alpha: 0.3),
+        ),
+      ),
+      child: Text(
+        '入金先口座未設定の収入予定があります。全体資金繰りには反映しますが、口座別資金繰りには反映されません。対象: $names',
+        style: const TextStyle(
+          color: Color(0xFF92400E),
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          height: 1.5,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRecurringIncomeTemplateList(
+    AssetLiabilityWorkbook workbook,
+  ) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final template in _recurringIncomeTemplates)
+          InputChip(
+            avatar: const Icon(Icons.event_repeat_outlined, size: 18),
+            label: Text(
+              '${template.dayOfMonth}日 ${template.name} ${_formatManagementYen(template.amount)}',
+            ),
+            onPressed: () => _showRecurringIncomeTemplateDialog(
+              workbook,
+              existing: template,
+            ),
+            onDeleted: () => _deleteRecurringIncomeTemplate(template.id),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildAssetCashflowTable(AssetLiabilityWorkbook workbook) {
+    if (workbook.cashflowRows.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '支払日順 資金繰り',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            height: 1.4,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '入金済み・支払済みにした項目は、現在の口座残高に反映済みとして扱います。まだ残高を更新していない場合はチェックしないでください。',
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            fontSize: 12,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            headingRowHeight: 36,
+            dataRowMinHeight: 44,
+            dataRowMaxHeight: 56,
+            columns: const [
+              DataColumn(label: Text('支払日'), numeric: true),
+              DataColumn(label: Text('支払先')),
+              DataColumn(label: Text('支払原資口座')),
+              DataColumn(label: Text('支払予定額'), numeric: true),
+              DataColumn(label: Text('区分')),
+              DataColumn(label: Text('支払済み')),
+              DataColumn(label: Text('支払後手元'), numeric: true),
+              DataColumn(label: Text('危険度')),
+            ],
+            rows: [
+              for (final row in workbook.cashflowRows)
+                DataRow(
+                  cells: [
+                    DataCell(Text('${row.paymentDay}日')),
+                    DataCell(Text(row.accountName)),
+                    DataCell(
+                      row.isPayment
+                          ? _buildPaymentSourceDropdown(row, workbook)
+                          : Text(row.destinationAccountName ?? '未設定'),
+                    ),
+                    DataCell(Text(_formatManagementYen(row.paymentAmount))),
+                    DataCell(Text(_cashflowKindLabel(row))),
+                    DataCell(_buildPaymentProgressChip(row)),
+                    DataCell(Text(_formatManagementYen(row.cashAfterPayment))),
+                    DataCell(_buildCashflowStatusChip(row)),
+                  ],
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPaymentSourceDropdown(
+    AssetLiabilityCashflowRow row,
+    AssetLiabilityWorkbook workbook,
+  ) {
+    final options = _paymentSourceAccountOptions(workbook);
+    final monthlySelected = _paymentSourceAccountIds[row.accountId];
+    final defaultSelected = _defaultPaymentSourceAccountIds[row.accountId];
+    final selected = monthlySelected ?? defaultSelected;
+    final validSelected =
+        selected != null && options.any((account) => account.id == selected);
+    final isDefaultSelected =
+        validSelected && defaultSelected != null && defaultSelected == selected;
+    return SizedBox(
+      width: 300,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Expanded(
+            child: DropdownButton<String>(
+              value: validSelected ? selected : '',
+              isExpanded: true,
+              items: [
+                const DropdownMenuItem<String>(
+                  value: '',
+                  child: Text('未設定'),
+                ),
+                for (final account in options)
+                  DropdownMenuItem<String>(
+                    value: account.id,
+                    child: Text(account.name),
+                  ),
+              ],
+              onChanged: (value) => _updatePaymentSourceAccount(
+                row.accountId,
+                value == null || value.isEmpty ? null : value,
+              ),
+            ),
+          ),
+          Tooltip(
+            message: isDefaultSelected ? 'デフォルトを解除' : 'この口座をデフォルトにする',
+            child: IconButton(
+              icon: Icon(
+                isDefaultSelected ? Icons.push_pin : Icons.push_pin_outlined,
+                size: 18,
+              ),
+              color: isDefaultSelected ? const Color(0xFF0D9488) : null,
+              onPressed: validSelected
+                  ? () => _updateDefaultPaymentSourceAccount(
+                        row.accountId,
+                        isDefaultSelected ? null : selected,
+                      )
+                  : null,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCashRiskChip(AssetLiabilityCashRiskLevel riskLevel) {
+    final color = _cashRiskColor(riskLevel);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        _cashRiskLabel(riskLevel),
+        style: TextStyle(
+          color: color,
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          height: 1.2,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPaymentProgressChip(AssetLiabilityCashflowRow row) {
+    final reflected = row.isIncome ? row.received : row.paid;
+    final label = reflected
+        ? '反映済み'
+        : row.overdue
+            ? (row.isIncome ? '入金遅れ' : '期限超過')
+            : (row.isIncome ? '入金待ち' : '未払い');
+    final color = reflected
+        ? const Color(0xFF0D9488)
+        : row.overdue
+            ? const Color(0xFFB91C1C)
+            : const Color(0xFFD97706);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          height: 1.2,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCashflowStatusChip(AssetLiabilityCashflowRow row) {
+    if (row.overdue) {
+      return _buildTextStatusChip(
+        label: row.isIncome ? '入金遅れ' : '期限超過',
+        color: const Color(0xFFB91C1C),
+      );
+    }
+    return _buildCashRiskChip(row.riskLevel);
+  }
+
+  String _cashflowKindLabel(AssetLiabilityCashflowRow row) {
+    if (row.isIncome) {
+      return '入金';
+    }
+    return row.paymentAmountEstimated ? '推定' : '実額';
+  }
+
+  Widget _buildTextStatusChip({
+    required String label,
+    required Color color,
+  }) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          height: 1.2,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAccountCashflowSection(AssetLiabilityWorkbook workbook) {
+    final summaries = workbook.accountCashflowSummaries;
+    if (summaries.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '口座別資金繰り',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            height: 1.4,
+          ),
+        ),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            headingRowHeight: 36,
+            dataRowMinHeight: 44,
+            dataRowMaxHeight: 56,
+            columns: const [
+              DataColumn(label: Text('口座')),
+              DataColumn(label: Text('現在残高'), numeric: true),
+              DataColumn(label: Text('今後の支払い'), numeric: true),
+              DataColumn(label: Text('今後の入金'), numeric: true),
+              DataColumn(label: Text('支払後残高'), numeric: true),
+              DataColumn(label: Text('判定')),
+            ],
+            rows: [
+              for (final summary in summaries)
+                DataRow(
+                  cells: [
+                    DataCell(Text(summary.accountName)),
+                    DataCell(
+                        Text(_formatManagementYen(summary.currentBalance))),
+                    DataCell(
+                      Text(_formatManagementYen(summary.upcomingPayments)),
+                    ),
+                    DataCell(
+                        Text(_formatManagementYen(summary.upcomingIncome))),
+                    DataCell(
+                      Text(_formatManagementYen(summary.projectedBalance)),
+                    ),
+                    DataCell(_buildCashRiskChip(summary.riskLevel)),
+                  ],
+                ),
+            ],
+          ),
+        ),
+        if (workbook.hasAccountShortage) ...[
+          const SizedBox(height: 8),
+          _buildAccountShortageWarning(workbook),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildAccountShortageWarning(AssetLiabilityWorkbook workbook) {
+    final details = workbook.shortAccountSummaries
+        .map(
+          (summary) =>
+              '${summary.accountName}: ${_formatManagementYen(summary.shortfall)}不足',
+        )
+        .join(' / ');
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFEF2F2),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFB91C1C).withValues(alpha: 0.3),
+        ),
+      ),
+      child: Text(
+        '口座別に見ると不足があります。$details',
+        style: const TextStyle(
+          color: Color(0xFF7F1D1D),
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          height: 1.5,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMonthlySnapshotSection(AssetLiabilityWorkbook workbook) {
+    final comparisons = _assetLiabilityHistoryService.compareSnapshots(
+      _monthlySnapshots,
+    );
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  '月次履歴（保存時点）',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                alignment: WrapAlignment.end,
+                children: [
+                  FilledButton.icon(
+                    onPressed: _isSavingAssetLiabilitySnapshot
+                        ? null
+                        : () => _saveCurrentAssetLiabilitySnapshot(workbook),
+                    icon: _isSavingAssetLiabilitySnapshot
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.save_outlined),
+                    label: const Text('スナップショット保存'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: () => _downloadAssetLiabilityCsvBundle(workbook),
+                    icon: const Icon(Icons.download_outlined),
+                    label: const Text('CSV出力'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '保存値は月末確定ではなく保存時点の値です。月次履歴・支払予定・収入予定・口座別資金繰りをCSV出力できます。',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 8),
+          if (comparisons.isEmpty)
+            Text(
+              'まだ月次スナップショットはありません。',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+              ),
+            )
+          else
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: DataTable(
+                headingRowHeight: 36,
+                dataRowMinHeight: 44,
+                dataRowMaxHeight: 56,
+                columns: const [
+                  DataColumn(label: Text('月')),
+                  DataColumn(label: Text('資産合計'), numeric: true),
+                  DataColumn(label: Text('前月比'), numeric: true),
+                  DataColumn(label: Text('負債合計'), numeric: true),
+                  DataColumn(label: Text('前月比'), numeric: true),
+                  DataColumn(label: Text('純資産'), numeric: true),
+                  DataColumn(label: Text('前月比'), numeric: true),
+                  DataColumn(label: Text('手元現金'), numeric: true),
+                  DataColumn(label: Text('前月比'), numeric: true),
+                  DataColumn(label: Text('支払予定'), numeric: true),
+                  DataColumn(label: Text('実支払済み'), numeric: true),
+                  DataColumn(label: Text('未払い'), numeric: true),
+                  DataColumn(label: Text('期限超過'), numeric: true),
+                ],
+                rows: [
+                  for (final comparison in comparisons)
+                    DataRow(
+                      cells: [
+                        DataCell(Text(comparison.snapshot.monthKey)),
+                        DataCell(
+                          Text(
+                            _formatManagementYen(
+                              comparison.snapshot.positiveAssetTotal,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementDeltaYen(
+                              comparison.positiveAssetDelta,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementYen(
+                              comparison.snapshot.liabilityTotal,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementDeltaYen(
+                              comparison.liabilityDelta,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementYen(
+                              comparison.snapshot.netWorth,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementDeltaYen(comparison.netWorthDelta),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementYen(
+                              comparison.snapshot.cashLikeTotal,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementDeltaYen(comparison.cashLikeDelta),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementYen(
+                              comparison.snapshot.monthlyScheduledPaymentTotal,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementYen(
+                              comparison.snapshot.monthlyPaidPaymentTotal,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementYen(
+                              comparison.snapshot.monthlyUnpaidPaymentTotal,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text('${comparison.snapshot.overduePaymentCount}件'),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTransferSuggestionSection(AssetLiabilityWorkbook workbook) {
+    if (workbook.transferSuggestions.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFECFDF5),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFF0D9488).withValues(alpha: 0.25),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '口座間移動の提案',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'この提案は不足額ベースの簡易提案です。実際の引落順、手数料、入金予定は確認してください。',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (final suggestion in workbook.transferSuggestions)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Text(
+                '${suggestion.fromAccountName}から${suggestion.toAccountName}へ ${_formatManagementYen(suggestion.amount)} 移動すると、${suggestion.neededBy == null ? '今月の支払い' : DateFormat('M/d').format(suggestion.neededBy!)}を安全に通過しやすくなります。',
+                style: const TextStyle(fontSize: 12, height: 1.5),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetWorkbookDebtTable(AssetLiabilityWorkbook workbook) {
+    if (workbook.debtMasterRows.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final rows = workbook.debtMasterRows.take(10).toList();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '負債マスタ（残高順）',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            height: 1.4,
+          ),
+        ),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            headingRowHeight: 36,
+            dataRowMinHeight: 60,
+            dataRowMaxHeight: 76,
+            columns: const [
+              DataColumn(label: Text('項目')),
+              DataColumn(label: Text('種別')),
+              DataColumn(label: Text('残高'), numeric: true),
+              DataColumn(label: Text('支払日'), numeric: true),
+              DataColumn(label: Text('推定最低支払額'), numeric: true),
+              DataColumn(label: Text('今月支払予定額'), numeric: true),
+              DataColumn(label: Text('区分')),
+              DataColumn(label: Text('支払済み')),
+              DataColumn(label: Text('年利'), numeric: true),
+              DataColumn(label: Text('月利息'), numeric: true),
+              DataColumn(label: Text('負債割合'), numeric: true),
+            ],
+            rows: [
+              for (final row in rows)
+                DataRow(
+                  cells: [
+                    DataCell(Text(row.name)),
+                    DataCell(Text(_assetKindLabel(row.kind))),
+                    DataCell(Text(_formatManagementYen(row.balance))),
+                    DataCell(
+                      Text(
+                        row.paymentDay == null ? '未設定' : '${row.paymentDay}日',
+                      ),
+                    ),
+                    DataCell(
+                      Text(_formatManagementYen(row.minimumPaymentEstimate)),
+                    ),
+                    DataCell(_buildMonthlyPaymentInput(row)),
+                    DataCell(_buildPaymentAmountSourceChip(row)),
+                    DataCell(_buildPaidCheckbox(row)),
+                    DataCell(Text(_formatManagementPercent(row.annualRate))),
+                    DataCell(
+                      Text(
+                        _formatManagementYen(row.monthlyInterestEstimate),
+                      ),
+                    ),
+                    DataCell(
+                        Text(_formatManagementPercent(row.liabilityShare))),
+                  ],
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMonthlyPaymentInput(AssetLiabilityDebtRow row) {
+    final controller = _monthlyPaymentControllerFor(row);
+    return SizedBox(
+      width: 150,
+      child: TextField(
+        controller: controller,
+        keyboardType: TextInputType.number,
+        inputFormatters: [
+          FilteringTextInputFormatter.allow(RegExp(r'[0-9,]')),
+        ],
+        onChanged: (value) => _updateMonthlyPaymentOverride(row.id, value),
+        decoration: InputDecoration(
+          isDense: true,
+          hintText: _formatManagementYen(row.minimumPaymentEstimate),
+          helperText: row.paymentAmountEstimated ? '未入力時は推定' : '実額を優先',
+          suffixIcon: row.paymentAmountEstimated
+              ? null
+              : IconButton(
+                  tooltip: '手入力値をクリア',
+                  icon: const Icon(Icons.clear, size: 16),
+                  onPressed: () => _clearMonthlyPaymentOverride(row.id),
+                ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPaymentAmountSourceChip(AssetLiabilityDebtRow row) {
+    final isEstimated = row.paymentAmountEstimated;
+    final color =
+        isEstimated ? const Color(0xFFD97706) : const Color(0xFF0D9488);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        isEstimated ? '推定' : '実額',
+        style: TextStyle(
+          color: color,
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          height: 1.2,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPaidCheckbox(AssetLiabilityDebtRow row) {
+    return Checkbox(
+      value: row.paid,
+      onChanged: (value) => _toggleMonthlyPaymentPaid(row.id, value ?? false),
+    );
+  }
+
+  Widget _buildAssetWorkbookPriorityList(AssetLiabilityWorkbook workbook) {
+    final rows = workbook.repaymentPriorityRows.take(4).toList();
+    if (rows.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFF59E0B).withValues(alpha: 0.3),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '返済優先（推定金利順）',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (var index = 0; index < rows.length; index++)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${index + 1}.',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '${rows[index].name} / ${_formatManagementYen(rows[index].balance)} / 年利 ${_formatManagementPercent(rows[index].annualRate)} / ${rows[index].priorityLabel}',
+                      style: const TextStyle(height: 1.5),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          Text(
+            '今月支払予定額が未入力のものは、契約条件ベースの推定最低支払額で表示しています。',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _paymentRiskStatusLabel(AssetLiabilityPaymentDayRisk risk) {
+    if (risk.isToday) return '今日';
+    if (risk.isPast) return '通過済み';
+    return '今月これから';
+  }
+
+  String _paymentRiskPaymentSourceLabel(AssetLiabilityPaymentDayRisk risk) {
+    if (!risk.hasEstimatedPayments) {
+      return '全て実額';
+    }
+    if (!risk.hasManualPayments) {
+      return '全て推定';
+    }
+    return '実額 ${risk.manualPaymentCount}件 / 推定 ${risk.estimatedPaymentCount}件';
+  }
+
+  String _cashRiskLabel(AssetLiabilityCashRiskLevel riskLevel) {
+    switch (riskLevel) {
+      case AssetLiabilityCashRiskLevel.short:
+        return '資金ショート';
+      case AssetLiabilityCashRiskLevel.caution:
+        return '要注意';
+      case AssetLiabilityCashRiskLevel.watch:
+        return '警戒';
+      case AssetLiabilityCashRiskLevel.normal:
+        return '通常';
+    }
+  }
+
+  Color _cashRiskColor(AssetLiabilityCashRiskLevel riskLevel) {
+    switch (riskLevel) {
+      case AssetLiabilityCashRiskLevel.short:
+        return const Color(0xFFB91C1C);
+      case AssetLiabilityCashRiskLevel.caution:
+        return const Color(0xFFFF6B35);
+      case AssetLiabilityCashRiskLevel.watch:
+        return const Color(0xFFD97706);
+      case AssetLiabilityCashRiskLevel.normal:
+        return const Color(0xFF0D9488);
+    }
+  }
+
+  String _assetKindLabel(AssetLiabilityAccountKind kind) {
+    switch (kind) {
+      case AssetLiabilityAccountKind.cash:
+        return '現金';
+      case AssetLiabilityAccountKind.deposit:
+        return '現金預金';
+      case AssetLiabilityAccountKind.securities:
+        return '証券';
+      case AssetLiabilityAccountKind.cardLoan:
+        return 'カードローン';
+      case AssetLiabilityAccountKind.shoppingDebt:
+        return 'ショッピング債務';
+      case AssetLiabilityAccountKind.creditCard:
+        return 'クレカ';
+      case AssetLiabilityAccountKind.utility:
+        return '通信/公共料金';
+      case AssetLiabilityAccountKind.otherAsset:
+        return 'その他資産';
+      case AssetLiabilityAccountKind.otherLiability:
+        return 'その他負債';
+    }
+  }
+
+  String _formatManagementYen(num value) {
+    final sign = value < 0 ? '-' : '';
+    return '$sign¥${NumberFormat('#,###').format(value.abs().round())}';
+  }
+
+  String _formatManagementDeltaYen(num? value) {
+    if (value == null) {
+      return '前月データなし';
+    }
+    if (value == 0) {
+      return '±¥0';
+    }
+    final sign = value > 0 ? '+' : '-';
+    return '$sign¥${NumberFormat('#,###').format(value.abs().round())}';
+  }
+
+  String _formatManagementPercent(num value) {
+    return '${(value * 100).toStringAsFixed(1)}%';
   }
 
   // ①資産 ②負債 の入力カード

--- a/lib/services/asset_liability_history_service.dart
+++ b/lib/services/asset_liability_history_service.dart
@@ -1,0 +1,216 @@
+import 'package:intl/intl.dart';
+
+import '../models/asset_liability_workbook.dart';
+
+class AssetLiabilityHistoryService {
+  const AssetLiabilityHistoryService();
+
+  AssetLiabilityMonthlySnapshot buildSnapshot({
+    required String monthKey,
+    required AssetLiabilityWorkbook workbook,
+    required DateTime savedAt,
+  }) {
+    final paidPaymentTotal = workbook.debtMasterRows.fold<double>(
+      0,
+      (sum, row) => row.paid ? sum + row.scheduledPaymentAmount : sum,
+    );
+    final overduePaymentCount = workbook.cashflowRows
+        .where((row) => row.isPayment && row.overdue)
+        .length;
+
+    return AssetLiabilityMonthlySnapshot(
+      monthKey: monthKey,
+      savedAt: savedAt,
+      positiveAssetTotal: workbook.positiveAssetTotal,
+      liabilityTotal: workbook.liabilityTotal,
+      netWorth: workbook.netWorth,
+      cashLikeTotal: workbook.cashLikeTotal,
+      monthlyScheduledPaymentTotal: workbook.monthlyScheduledPaymentTotal,
+      monthlyPaidPaymentTotal: paidPaymentTotal,
+      monthlyUnpaidPaymentTotal: workbook.monthlyUnpaidPaymentTotal,
+      overduePaymentCount: overduePaymentCount,
+    );
+  }
+
+  List<AssetLiabilityMonthlySnapshotComparison> compareSnapshots(
+    List<AssetLiabilityMonthlySnapshot> snapshots,
+  ) {
+    final sorted = List<AssetLiabilityMonthlySnapshot>.from(snapshots)
+      ..sort((a, b) => a.monthKey.compareTo(b.monthKey));
+    final comparisons = <AssetLiabilityMonthlySnapshotComparison>[];
+    for (var index = 0; index < sorted.length; index++) {
+      final current = sorted[index];
+      final previous = index == 0 ? null : sorted[index - 1];
+      comparisons.add(
+        AssetLiabilityMonthlySnapshotComparison(
+          snapshot: current,
+          positiveAssetDelta: previous == null
+              ? null
+              : current.positiveAssetTotal - previous.positiveAssetTotal,
+          liabilityDelta: previous == null
+              ? null
+              : current.liabilityTotal - previous.liabilityTotal,
+          netWorthDelta:
+              previous == null ? null : current.netWorth - previous.netWorth,
+          cashLikeDelta: previous == null
+              ? null
+              : current.cashLikeTotal - previous.cashLikeTotal,
+        ),
+      );
+    }
+    return comparisons.reversed.toList(growable: false);
+  }
+
+  AssetLiabilityCsvExportBundle buildCsvExportBundle({
+    required List<AssetLiabilityMonthlySnapshot> monthlySnapshots,
+    required AssetLiabilityWorkbook workbook,
+  }) {
+    return AssetLiabilityCsvExportBundle(
+      monthlyHistoryCsv: buildMonthlyHistoryCsv(monthlySnapshots),
+      paymentScheduleCsv: buildPaymentScheduleCsv(workbook),
+      incomePlansCsv: buildIncomePlansCsv(workbook),
+      accountCashflowCsv: buildAccountCashflowCsv(workbook),
+    );
+  }
+
+  String buildMonthlyHistoryCsv(
+    List<AssetLiabilityMonthlySnapshot> snapshots,
+  ) {
+    final sorted = List<AssetLiabilityMonthlySnapshot>.from(snapshots)
+      ..sort((a, b) => a.monthKey.compareTo(b.monthKey));
+    return _csv(
+      [
+        const <Object?>[
+          '対象月',
+          '保存日時',
+          '資産合計',
+          '負債合計',
+          '純資産',
+          '手元現金',
+          '今月支払予定総額',
+          '実支払済み総額',
+          '未払い総額',
+          '期限超過件数',
+        ],
+        for (final snapshot in sorted)
+          <Object?>[
+            snapshot.monthKey,
+            DateFormat('yyyy-MM-dd HH:mm:ss').format(snapshot.savedAt),
+            snapshot.positiveAssetTotal,
+            snapshot.liabilityTotal,
+            snapshot.netWorth,
+            snapshot.cashLikeTotal,
+            snapshot.monthlyScheduledPaymentTotal,
+            snapshot.monthlyPaidPaymentTotal,
+            snapshot.monthlyUnpaidPaymentTotal,
+            snapshot.overduePaymentCount,
+          ],
+      ],
+    );
+  }
+
+  String buildPaymentScheduleCsv(AssetLiabilityWorkbook workbook) {
+    final rows = workbook.cashflowRows.where((row) => row.isPayment).toList();
+    return _csv(
+      [
+        const <Object?>[
+          '日付',
+          '支払先',
+          '支払原資口座',
+          '支払予定額',
+          '実額/推定',
+          '支払済み',
+          '期限超過',
+          '支払後手元資金',
+        ],
+        for (final row in rows)
+          <Object?>[
+            DateFormat('yyyy-MM-dd').format(row.paymentDate),
+            row.accountName,
+            row.paymentSourceAccountName ?? '未設定',
+            row.paymentAmount,
+            row.paymentAmountEstimated ? '推定' : '実額',
+            row.paid ? '済' : '未済',
+            row.overdue ? '期限超過' : '',
+            row.cashAfterPayment,
+          ],
+      ],
+    );
+  }
+
+  String buildIncomePlansCsv(AssetLiabilityWorkbook workbook) {
+    return _csv(
+      [
+        const <Object?>[
+          '日付',
+          '名称',
+          '金額',
+          '入金先口座',
+          '入金済み',
+        ],
+        for (final plan in workbook.incomePlans)
+          <Object?>[
+            DateFormat('yyyy-MM-dd').format(plan.date),
+            plan.name,
+            plan.amount,
+            plan.destinationAccountName ?? '未設定',
+            plan.received ? '済' : '未済',
+          ],
+      ],
+    );
+  }
+
+  String buildAccountCashflowCsv(AssetLiabilityWorkbook workbook) {
+    return _csv(
+      [
+        const <Object?>[
+          '口座',
+          '現在残高',
+          '今後の支払い',
+          '今後の入金',
+          '支払後残高',
+          '判定',
+        ],
+        for (final summary in workbook.accountCashflowSummaries)
+          <Object?>[
+            summary.accountName,
+            summary.currentBalance,
+            summary.upcomingPayments,
+            summary.upcomingIncome,
+            summary.projectedBalance,
+            _cashRiskLabel(summary.riskLevel),
+          ],
+      ],
+    );
+  }
+
+  String _csv(List<List<Object?>> rows) {
+    return rows
+        .map((row) => row.map((cell) => _escapeCsvCell(cell)).join(','))
+        .join('\n');
+  }
+
+  String _escapeCsvCell(Object? value) {
+    final text = value?.toString() ?? '';
+    if (text.contains(',') ||
+        text.contains('"') ||
+        text.contains('\n') ||
+        text.contains('\r')) {
+      return '"${text.replaceAll('"', '""')}"';
+    }
+    return text;
+  }
+
+  String _cashRiskLabel(AssetLiabilityCashRiskLevel riskLevel) {
+    switch (riskLevel) {
+      case AssetLiabilityCashRiskLevel.short:
+        return '資金ショート';
+      case AssetLiabilityCashRiskLevel.caution:
+        return '要注意';
+      case AssetLiabilityCashRiskLevel.watch:
+        return '警戒';
+      case AssetLiabilityCashRiskLevel.normal:
+        return '通常';
+    }
+  }
+}

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -1,0 +1,726 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:intl/intl.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AssetLiabilityMonthlyState {
+  final Map<String, double> paymentOverrides;
+  final Set<String> paidAccountNames;
+  final Map<String, String> paymentSourceAccountIds;
+  final List<AssetLiabilityIncomePlan> incomePlans;
+
+  const AssetLiabilityMonthlyState({
+    this.paymentOverrides = const <String, double>{},
+    this.paidAccountNames = const <String>{},
+    this.paymentSourceAccountIds = const <String, String>{},
+    this.incomePlans = const <AssetLiabilityIncomePlan>[],
+  });
+
+  bool get isEmpty =>
+      paymentOverrides.isEmpty &&
+      paidAccountNames.isEmpty &&
+      paymentSourceAccountIds.isEmpty &&
+      incomePlans.isEmpty;
+}
+
+class AssetLiabilityMonthlyStateStore {
+  static const String paymentPrefsKey =
+      'asset_liability_monthly_payment_overrides_v1';
+  static const String paidPrefsKey = 'asset_liability_paid_accounts_v1';
+  static const String paymentSourcePrefsKey =
+      'asset_liability_payment_source_accounts_v1';
+  static const String incomePrefsKey = 'asset_liability_income_plans_v1';
+  static const String defaultPaymentSourcePrefsKey =
+      'asset_liability_default_payment_source_accounts_v1';
+  static const String recurringIncomeTemplatePrefsKey =
+      'asset_liability_recurring_income_templates_v1';
+  static const String monthlySnapshotPrefsKey =
+      'asset_liability_monthly_snapshots_v1';
+
+  const AssetLiabilityMonthlyStateStore();
+
+  Future<AssetLiabilityMonthlyState> loadMonth(DateTime month) async {
+    final prefs = await SharedPreferences.getInstance();
+    final monthKey = formatMonthKey(month);
+    return AssetLiabilityMonthlyState(
+      paymentOverrides: paymentOverridesForMonth(
+        prefs.getString(paymentPrefsKey),
+        monthKey,
+      ),
+      paidAccountNames: paidAccountsForMonth(
+        prefs.getString(paidPrefsKey),
+        monthKey,
+      ),
+      paymentSourceAccountIds: paymentSourceAccountsForMonth(
+        prefs.getString(paymentSourcePrefsKey),
+        monthKey,
+      ),
+      incomePlans: incomePlansForMonth(
+        prefs.getString(incomePrefsKey),
+        monthKey,
+      ),
+    );
+  }
+
+  Future<void> saveMonth({
+    required DateTime month,
+    required AssetLiabilityMonthlyState state,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final monthKey = formatMonthKey(month);
+
+    final allPayments = decodePaymentOverrides(
+      prefs.getString(paymentPrefsKey),
+    );
+    if (state.paymentOverrides.isEmpty) {
+      allPayments.remove(monthKey);
+    } else {
+      allPayments[monthKey] = Map<String, double>.from(
+        state.paymentOverrides,
+      );
+    }
+
+    final allPaidAccounts = decodePaidAccounts(
+      prefs.getString(paidPrefsKey),
+    );
+    if (state.paidAccountNames.isEmpty) {
+      allPaidAccounts.remove(monthKey);
+    } else {
+      allPaidAccounts[monthKey] = Set<String>.from(state.paidAccountNames);
+    }
+
+    await prefs.setString(paymentPrefsKey, jsonEncode(allPayments));
+    await prefs.setString(
+      paidPrefsKey,
+      jsonEncode(_encodePaid(allPaidAccounts)),
+    );
+
+    final allPaymentSources = decodePaymentSourceAccounts(
+      prefs.getString(paymentSourcePrefsKey),
+    );
+    if (state.paymentSourceAccountIds.isEmpty) {
+      allPaymentSources.remove(monthKey);
+    } else {
+      allPaymentSources[monthKey] = Map<String, String>.from(
+        state.paymentSourceAccountIds,
+      );
+    }
+    await prefs.setString(
+      paymentSourcePrefsKey,
+      jsonEncode(allPaymentSources),
+    );
+
+    final allIncomePlans = decodeIncomePlans(
+      prefs.getString(incomePrefsKey),
+    );
+    if (state.incomePlans.isEmpty) {
+      allIncomePlans.remove(monthKey);
+    } else {
+      allIncomePlans[monthKey] = List<AssetLiabilityIncomePlan>.from(
+        state.incomePlans,
+      );
+    }
+    await prefs.setString(
+      incomePrefsKey,
+      jsonEncode(_encodeIncomePlans(allIncomePlans)),
+    );
+  }
+
+  Future<Map<String, String>> loadDefaultPaymentSources() async {
+    final prefs = await SharedPreferences.getInstance();
+    return decodeStringMap(prefs.getString(defaultPaymentSourcePrefsKey));
+  }
+
+  Future<void> saveDefaultPaymentSources(
+    Map<String, String> sources,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      defaultPaymentSourcePrefsKey,
+      jsonEncode(_cleanStringMap(sources)),
+    );
+  }
+
+  Future<List<AssetLiabilityRecurringIncomeTemplate>>
+      loadRecurringIncomeTemplates() async {
+    final prefs = await SharedPreferences.getInstance();
+    return decodeRecurringIncomeTemplates(
+      prefs.getString(recurringIncomeTemplatePrefsKey),
+    );
+  }
+
+  Future<void> saveRecurringIncomeTemplates(
+    List<AssetLiabilityRecurringIncomeTemplate> templates,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      recurringIncomeTemplatePrefsKey,
+      jsonEncode(_encodeRecurringIncomeTemplates(templates)),
+    );
+  }
+
+  Future<AssetLiabilityMonthlyState> copyPreviousMonthToMonth(
+    DateTime targetMonth,
+  ) async {
+    final previousMonth = DateTime(targetMonth.year, targetMonth.month - 1);
+    final previousState = await loadMonth(previousMonth);
+    final copied = copyPreviousMonthState(
+      previousState: previousState,
+      targetMonth: targetMonth,
+    );
+    await saveMonth(month: targetMonth, state: copied);
+    return copied;
+  }
+
+  Future<List<AssetLiabilityMonthlySnapshot>> loadMonthlySnapshots() async {
+    final prefs = await SharedPreferences.getInstance();
+    return decodeMonthlySnapshots(prefs.getString(monthlySnapshotPrefsKey));
+  }
+
+  Future<void> saveMonthlySnapshot(
+    AssetLiabilityMonthlySnapshot snapshot,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final snapshots = decodeMonthlySnapshots(
+      prefs.getString(monthlySnapshotPrefsKey),
+    );
+    final nextSnapshots = <AssetLiabilityMonthlySnapshot>[
+      for (final current in snapshots)
+        if (current.monthKey != snapshot.monthKey) current,
+      snapshot,
+    ]..sort((a, b) => a.monthKey.compareTo(b.monthKey));
+    await prefs.setString(
+      monthlySnapshotPrefsKey,
+      jsonEncode(_encodeMonthlySnapshots(nextSnapshots)),
+    );
+  }
+
+  static String formatMonthKey(DateTime month) {
+    return DateFormat('yyyy-MM').format(month);
+  }
+
+  static AssetLiabilityMonthlyState copyPreviousMonthState({
+    required AssetLiabilityMonthlyState previousState,
+    required DateTime targetMonth,
+  }) {
+    final targetMonthKey = formatMonthKey(targetMonth);
+    final lastDay = DateTime(targetMonth.year, targetMonth.month + 1, 0).day;
+    final copiedIncomePlans = <AssetLiabilityIncomePlan>[
+      for (final plan in previousState.incomePlans)
+        AssetLiabilityIncomePlan(
+          id: 'copy_${targetMonthKey}_${plan.id}',
+          date: DateTime(
+            targetMonth.year,
+            targetMonth.month,
+            min(plan.date.day, lastDay),
+          ),
+          name: plan.name,
+          amount: plan.amount,
+          destinationAccountId: plan.destinationAccountId,
+          destinationAccountName: plan.destinationAccountName,
+          received: false,
+        ),
+    ]..sort((a, b) => a.date.compareTo(b.date));
+
+    return AssetLiabilityMonthlyState(
+      paymentOverrides: Map<String, double>.from(
+        previousState.paymentOverrides,
+      ),
+      paymentSourceAccountIds: Map<String, String>.from(
+        previousState.paymentSourceAccountIds,
+      ),
+      incomePlans: copiedIncomePlans,
+    );
+  }
+
+  static List<AssetLiabilityIncomePlan> applyRecurringIncomeTemplates({
+    required DateTime month,
+    required List<AssetLiabilityRecurringIncomeTemplate> templates,
+    required List<AssetLiabilityIncomePlan> existingPlans,
+  }) {
+    final monthKey = formatMonthKey(month);
+    final lastDay = DateTime(month.year, month.month + 1, 0).day;
+    final result = List<AssetLiabilityIncomePlan>.from(existingPlans);
+    final existingIds = result.map((plan) => plan.id).toSet();
+
+    for (final template in templates) {
+      final id = 'recurring_${template.id}_$monthKey';
+      if (existingIds.contains(id)) {
+        continue;
+      }
+      result.add(
+        AssetLiabilityIncomePlan(
+          id: id,
+          date: DateTime(
+            month.year,
+            month.month,
+            min(template.dayOfMonth.clamp(1, 31).toInt(), lastDay),
+          ),
+          name: template.name,
+          amount: template.amount,
+          destinationAccountId: template.destinationAccountId,
+          destinationAccountName: template.destinationAccountName,
+          received: false,
+        ),
+      );
+    }
+
+    result.sort((a, b) => a.date.compareTo(b.date));
+    return result;
+  }
+
+  static Map<String, String> decodeStringMap(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, String>{};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return <String, String>{};
+    }
+
+    return _cleanStringMap(
+      decoded.map<String, String>(
+        (key, value) => MapEntry(key.toString(), value.toString()),
+      ),
+    );
+  }
+
+  static Map<String, Map<String, double>> decodePaymentOverrides(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, Map<String, double>>{};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return <String, Map<String, double>>{};
+    }
+
+    return decoded.map<String, Map<String, double>>((month, values) {
+      final monthKey = month.toString();
+      final payments = <String, double>{};
+      if (values is Map) {
+        for (final entry in values.entries) {
+          final rawAmount = entry.value;
+          final amount = rawAmount is num
+              ? rawAmount.toDouble()
+              : double.tryParse(rawAmount.toString().replaceAll(',', ''));
+          if (amount != null && amount >= 0) {
+            payments[entry.key.toString()] = amount;
+          }
+        }
+      }
+      return MapEntry(monthKey, payments);
+    });
+  }
+
+  static Map<String, Set<String>> decodePaidAccounts(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, Set<String>>{};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return <String, Set<String>>{};
+    }
+
+    return decoded.map<String, Set<String>>((month, values) {
+      final monthKey = month.toString();
+      final accounts = <String>{};
+      if (values is Iterable) {
+        for (final value in values) {
+          final accountName = value.toString().trim();
+          if (accountName.isNotEmpty) {
+            accounts.add(accountName);
+          }
+        }
+      }
+      return MapEntry(monthKey, accounts);
+    });
+  }
+
+  static Map<String, Map<String, String>> decodePaymentSourceAccounts(
+    String? raw,
+  ) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, Map<String, String>>{};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return <String, Map<String, String>>{};
+    }
+
+    return decoded.map<String, Map<String, String>>((month, values) {
+      final monthKey = month.toString();
+      final sources = <String, String>{};
+      if (values is Map) {
+        for (final entry in values.entries) {
+          final sourceId = entry.value.toString().trim();
+          if (sourceId.isNotEmpty) {
+            sources[entry.key.toString()] = sourceId;
+          }
+        }
+      }
+      return MapEntry(monthKey, sources);
+    });
+  }
+
+  static Map<String, List<AssetLiabilityIncomePlan>> decodeIncomePlans(
+    String? raw,
+  ) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, List<AssetLiabilityIncomePlan>>{};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return <String, List<AssetLiabilityIncomePlan>>{};
+    }
+
+    return decoded.map<String, List<AssetLiabilityIncomePlan>>((month, values) {
+      final monthKey = month.toString();
+      final plans = <AssetLiabilityIncomePlan>[];
+      if (values is Iterable) {
+        for (final rawPlan in values) {
+          if (rawPlan is! Map) {
+            continue;
+          }
+          final id = rawPlan['id']?.toString().trim();
+          final dateText = rawPlan['date']?.toString();
+          final name = rawPlan['name']?.toString().trim();
+          final rawAmount = rawPlan['amount'];
+          final amount = rawAmount is num
+              ? rawAmount.toDouble()
+              : double.tryParse(rawAmount.toString().replaceAll(',', ''));
+          final date = dateText == null ? null : DateTime.tryParse(dateText);
+          if (id == null ||
+              id.isEmpty ||
+              date == null ||
+              name == null ||
+              name.isEmpty ||
+              amount == null ||
+              amount <= 0) {
+            continue;
+          }
+          plans.add(
+            AssetLiabilityIncomePlan(
+              id: id,
+              date: date,
+              name: name,
+              amount: amount,
+              destinationAccountId:
+                  rawPlan['destinationAccountId']?.toString().trim(),
+              destinationAccountName:
+                  rawPlan['destinationAccountName']?.toString().trim(),
+              received: rawPlan['received'] == true,
+            ),
+          );
+        }
+      }
+      plans.sort((a, b) => a.date.compareTo(b.date));
+      return MapEntry(monthKey, plans);
+    });
+  }
+
+  static List<AssetLiabilityRecurringIncomeTemplate>
+      decodeRecurringIncomeTemplates(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <AssetLiabilityRecurringIncomeTemplate>[];
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Iterable) {
+      return <AssetLiabilityRecurringIncomeTemplate>[];
+    }
+
+    final templates = <AssetLiabilityRecurringIncomeTemplate>[];
+    for (final rawTemplate in decoded) {
+      if (rawTemplate is! Map) {
+        continue;
+      }
+      final id = rawTemplate['id']?.toString().trim();
+      final name = rawTemplate['name']?.toString().trim();
+      final rawDay = rawTemplate['dayOfMonth'];
+      final rawAmount = rawTemplate['amount'];
+      final day = rawDay is num ? rawDay.toInt() : int.tryParse('$rawDay');
+      final amount = rawAmount is num
+          ? rawAmount.toDouble()
+          : double.tryParse(rawAmount.toString().replaceAll(',', ''));
+      if (id == null ||
+          id.isEmpty ||
+          name == null ||
+          name.isEmpty ||
+          day == null ||
+          day < 1 ||
+          amount == null ||
+          amount <= 0) {
+        continue;
+      }
+      templates.add(
+        AssetLiabilityRecurringIncomeTemplate(
+          id: id,
+          dayOfMonth: day.clamp(1, 31).toInt(),
+          name: name,
+          amount: amount,
+          destinationAccountId:
+              _cleanNullableString(rawTemplate['destinationAccountId']),
+          destinationAccountName:
+              _cleanNullableString(rawTemplate['destinationAccountName']),
+        ),
+      );
+    }
+    templates.sort((a, b) {
+      final day = a.dayOfMonth.compareTo(b.dayOfMonth);
+      if (day != 0) {
+        return day;
+      }
+      return a.name.compareTo(b.name);
+    });
+    return templates;
+  }
+
+  static List<AssetLiabilityMonthlySnapshot> decodeMonthlySnapshots(
+    String? raw,
+  ) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <AssetLiabilityMonthlySnapshot>[];
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Iterable) {
+      return <AssetLiabilityMonthlySnapshot>[];
+    }
+
+    final snapshots = <AssetLiabilityMonthlySnapshot>[];
+    for (final rawSnapshot in decoded) {
+      if (rawSnapshot is! Map) {
+        continue;
+      }
+      final monthKey = rawSnapshot['monthKey']?.toString().trim();
+      final savedAtText = rawSnapshot['savedAt']?.toString();
+      final savedAt =
+          savedAtText == null ? null : DateTime.tryParse(savedAtText);
+      final positiveAssetTotal =
+          _parseNonNullDouble(rawSnapshot['positiveAssetTotal']);
+      final liabilityTotal = _parseNonNullDouble(rawSnapshot['liabilityTotal']);
+      final netWorth = _parseNonNullDouble(rawSnapshot['netWorth']);
+      final cashLikeTotal = _parseNonNullDouble(rawSnapshot['cashLikeTotal']);
+      final monthlyScheduledPaymentTotal =
+          _parseNonNullDouble(rawSnapshot['monthlyScheduledPaymentTotal']);
+      final monthlyPaidPaymentTotal =
+          _parseNonNullDouble(rawSnapshot['monthlyPaidPaymentTotal']);
+      final monthlyUnpaidPaymentTotal =
+          _parseNonNullDouble(rawSnapshot['monthlyUnpaidPaymentTotal']);
+      final overduePaymentCount =
+          _parseNonNullInt(rawSnapshot['overduePaymentCount']);
+      if (monthKey == null ||
+          monthKey.isEmpty ||
+          savedAt == null ||
+          positiveAssetTotal == null ||
+          liabilityTotal == null ||
+          netWorth == null ||
+          cashLikeTotal == null ||
+          monthlyScheduledPaymentTotal == null ||
+          monthlyPaidPaymentTotal == null ||
+          monthlyUnpaidPaymentTotal == null ||
+          overduePaymentCount == null) {
+        continue;
+      }
+      snapshots.add(
+        AssetLiabilityMonthlySnapshot(
+          monthKey: monthKey,
+          savedAt: savedAt,
+          positiveAssetTotal: positiveAssetTotal,
+          liabilityTotal: liabilityTotal,
+          netWorth: netWorth,
+          cashLikeTotal: cashLikeTotal,
+          monthlyScheduledPaymentTotal: monthlyScheduledPaymentTotal,
+          monthlyPaidPaymentTotal: monthlyPaidPaymentTotal,
+          monthlyUnpaidPaymentTotal: monthlyUnpaidPaymentTotal,
+          overduePaymentCount: overduePaymentCount,
+        ),
+      );
+    }
+    snapshots.sort((a, b) => a.monthKey.compareTo(b.monthKey));
+    return snapshots;
+  }
+
+  static Map<String, double> paymentOverridesForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return Map<String, double>.from(
+      decodePaymentOverrides(raw)[monthKey] ?? const <String, double>{},
+    );
+  }
+
+  static Set<String> paidAccountsForMonth(String? raw, String monthKey) {
+    return Set<String>.from(
+      decodePaidAccounts(raw)[monthKey] ?? const <String>{},
+    );
+  }
+
+  static Map<String, String> paymentSourceAccountsForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return Map<String, String>.from(
+      decodePaymentSourceAccounts(raw)[monthKey] ?? const <String, String>{},
+    );
+  }
+
+  static List<AssetLiabilityIncomePlan> incomePlansForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return List<AssetLiabilityIncomePlan>.from(
+      decodeIncomePlans(raw)[monthKey] ?? const <AssetLiabilityIncomePlan>[],
+    );
+  }
+
+  static AssetLiabilityMonthlyState migrateLegacyKeys({
+    required AssetLiabilityMonthlyState state,
+    required Map<String, String> legacyKeyToAccountId,
+  }) {
+    final migratedPayments = <String, double>{};
+    for (final entry in state.paymentOverrides.entries) {
+      final migratedKey = legacyKeyToAccountId[entry.key] ?? entry.key;
+      if (legacyKeyToAccountId.containsKey(entry.key)) {
+        migratedPayments.putIfAbsent(migratedKey, () => entry.value);
+      } else {
+        migratedPayments[migratedKey] = entry.value;
+      }
+    }
+
+    final migratedPaidAccounts = <String>{};
+    for (final accountKey in state.paidAccountNames) {
+      migratedPaidAccounts.add(legacyKeyToAccountId[accountKey] ?? accountKey);
+    }
+
+    final migratedPaymentSources = <String, String>{};
+    for (final entry in state.paymentSourceAccountIds.entries) {
+      final liabilityId = legacyKeyToAccountId[entry.key] ?? entry.key;
+      final sourceId = legacyKeyToAccountId[entry.value] ?? entry.value;
+      migratedPaymentSources[liabilityId] = sourceId;
+    }
+
+    return AssetLiabilityMonthlyState(
+      paymentOverrides: migratedPayments,
+      paidAccountNames: migratedPaidAccounts,
+      paymentSourceAccountIds: migratedPaymentSources,
+      incomePlans: state.incomePlans,
+    );
+  }
+
+  static Map<String, List<String>> _encodePaid(
+    Map<String, Set<String>> source,
+  ) {
+    return source.map((month, accounts) {
+      final sorted = accounts.toList()..sort();
+      return MapEntry(month, sorted);
+    });
+  }
+
+  static List<Map<String, Object?>> _encodeRecurringIncomeTemplates(
+    List<AssetLiabilityRecurringIncomeTemplate> templates,
+  ) {
+    final sorted = List<AssetLiabilityRecurringIncomeTemplate>.from(templates)
+      ..sort((a, b) {
+        final day = a.dayOfMonth.compareTo(b.dayOfMonth);
+        if (day != 0) {
+          return day;
+        }
+        return a.name.compareTo(b.name);
+      });
+    return [
+      for (final template in sorted)
+        <String, Object?>{
+          'id': template.id,
+          'dayOfMonth': template.dayOfMonth,
+          'name': template.name,
+          'amount': template.amount,
+          'destinationAccountId': template.destinationAccountId,
+          'destinationAccountName': template.destinationAccountName,
+        },
+    ];
+  }
+
+  static List<Map<String, Object?>> _encodeMonthlySnapshots(
+    List<AssetLiabilityMonthlySnapshot> snapshots,
+  ) {
+    final sorted = List<AssetLiabilityMonthlySnapshot>.from(snapshots)
+      ..sort((a, b) => a.monthKey.compareTo(b.monthKey));
+    return [
+      for (final snapshot in sorted)
+        <String, Object?>{
+          'monthKey': snapshot.monthKey,
+          'savedAt': snapshot.savedAt.toIso8601String(),
+          'positiveAssetTotal': snapshot.positiveAssetTotal,
+          'liabilityTotal': snapshot.liabilityTotal,
+          'netWorth': snapshot.netWorth,
+          'cashLikeTotal': snapshot.cashLikeTotal,
+          'monthlyScheduledPaymentTotal': snapshot.monthlyScheduledPaymentTotal,
+          'monthlyPaidPaymentTotal': snapshot.monthlyPaidPaymentTotal,
+          'monthlyUnpaidPaymentTotal': snapshot.monthlyUnpaidPaymentTotal,
+          'overduePaymentCount': snapshot.overduePaymentCount,
+        },
+    ];
+  }
+
+  static Map<String, List<Map<String, Object?>>> _encodeIncomePlans(
+    Map<String, List<AssetLiabilityIncomePlan>> source,
+  ) {
+    return source.map((month, plans) {
+      final sorted = List<AssetLiabilityIncomePlan>.from(plans)
+        ..sort((a, b) => a.date.compareTo(b.date));
+      return MapEntry(
+        month,
+        [
+          for (final plan in sorted)
+            <String, Object?>{
+              'id': plan.id,
+              'date': DateFormat('yyyy-MM-dd').format(plan.date),
+              'name': plan.name,
+              'amount': plan.amount,
+              'destinationAccountId': plan.destinationAccountId,
+              'destinationAccountName': plan.destinationAccountName,
+              'received': plan.received,
+            },
+        ],
+      );
+    });
+  }
+
+  static Map<String, String> _cleanStringMap(Map<String, String> source) {
+    final result = <String, String>{};
+    for (final entry in source.entries) {
+      final key = entry.key.trim();
+      final value = entry.value.trim();
+      if (key.isNotEmpty && value.isNotEmpty) {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  static String? _cleanNullableString(Object? source) {
+    final value = source?.toString().trim();
+    return value == null || value.isEmpty ? null : value;
+  }
+
+  static double? _parseNonNullDouble(Object? source) {
+    if (source is num) {
+      return source.toDouble();
+    }
+    if (source == null) {
+      return null;
+    }
+    return double.tryParse(source.toString().replaceAll(',', ''));
+  }
+
+  static int? _parseNonNullInt(Object? source) {
+    if (source is num) {
+      return source.toInt();
+    }
+    if (source == null) {
+      return null;
+    }
+    return int.tryParse(source.toString().replaceAll(',', ''));
+  }
+}

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -1,0 +1,902 @@
+import 'dart:math';
+
+import '../models/asset_liability_workbook.dart';
+
+class AssetLiabilityPlanningService {
+  const AssetLiabilityPlanningService();
+
+  AssetLiabilityWorkbook buildWorkbook({
+    required Map<String, double> latestSnapshot,
+    required DateTime baseDate,
+    Map<String, double> monthlyPaymentOverrides = const <String, double>{},
+    Set<String> paidAccountNames = const <String>{},
+    Map<String, String> paymentSourceAccountIds = const <String, String>{},
+    Map<String, String> defaultPaymentSourceAccountIds =
+        const <String, String>{},
+    List<AssetLiabilityIncomePlan> incomePlans =
+        const <AssetLiabilityIncomePlan>[],
+  }) {
+    final accounts = latestSnapshot.entries
+        .where((entry) => entry.key.trim().isNotEmpty && entry.value != 0)
+        .map(
+          (entry) => _classifyAccount(
+            name: entry.key.trim(),
+            balance: entry.value,
+          ),
+        )
+        .toList()
+      ..sort(_compareAccounts);
+    final accountsById = <String, AssetLiabilityAccount>{
+      for (final account in accounts) account.id: account,
+    };
+    final resolvedIncomePlans = _resolveIncomePlans(
+      incomePlans: incomePlans,
+      accountsById: accountsById,
+    );
+    final effectivePaymentSourceAccountIds = <String, String>{
+      ...defaultPaymentSourceAccountIds,
+      ...paymentSourceAccountIds,
+    };
+
+    final positiveAssetTotal = accounts.fold<double>(
+      0,
+      (sum, account) => account.balance > 0 ? sum + account.balance : sum,
+    );
+    final liabilityTotal = accounts.fold<double>(
+      0,
+      (sum, account) => account.balance < 0 ? sum + account.balance : sum,
+    );
+    final netWorth = positiveAssetTotal + liabilityTotal;
+    final cashLikeTotal = accounts.fold<double>(
+      0,
+      (sum, account) => _isCashLike(account) ? sum + account.balance : sum,
+    );
+    final securitiesTotal = accounts.fold<double>(
+      0,
+      (sum, account) => account.kind == AssetLiabilityAccountKind.securities
+          ? sum + account.balance
+          : sum,
+    );
+
+    final debtMasterRows = accounts
+        .where((account) => account.isLiability)
+        .map(
+          (account) => _buildDebtRow(
+            account: account,
+            liabilityTotal: liabilityTotal,
+            monthlyPaymentOverrides: monthlyPaymentOverrides,
+            paidAccountNames: paidAccountNames,
+            paymentSourceAccountIds: effectivePaymentSourceAccountIds,
+            accountsById: accountsById,
+          ),
+        )
+        .toList()
+      ..sort((a, b) => b.balance.abs().compareTo(a.balance.abs()));
+
+    final repaymentPriorityRows = List<AssetLiabilityDebtRow>.from(
+      debtMasterRows,
+    )..sort(_compareDebtPriority);
+
+    final paymentDayRisks = _buildPaymentDayRisks(
+      rows: debtMasterRows,
+      baseDate: baseDate,
+    );
+    final cashflowRows = _buildCashflowRows(
+      rows: debtMasterRows,
+      incomePlans: resolvedIncomePlans,
+      baseDate: baseDate,
+      startingCash: cashLikeTotal,
+    );
+    final accountCashflowSummaries = _buildAccountCashflowSummaries(
+      accounts: accounts,
+      cashflowRows: cashflowRows,
+    );
+    final transferSuggestions = _buildTransferSuggestions(
+      summaries: accountCashflowSummaries,
+      cashflowRows: cashflowRows,
+    );
+
+    final monthlyMinimumPaymentEstimateTotal = debtMasterRows.fold<double>(
+      0,
+      (sum, row) => sum + row.minimumPaymentEstimate,
+    );
+    final monthlyScheduledPaymentTotal = debtMasterRows.fold<double>(
+      0,
+      (sum, row) => sum + row.scheduledPaymentAmount,
+    );
+    final monthlyUnpaidPaymentTotal = debtMasterRows.fold<double>(
+      0,
+      (sum, row) => row.paid ? sum : sum + row.scheduledPaymentAmount,
+    );
+    final monthlyUnreceivedIncomeTotal = resolvedIncomePlans.fold<double>(
+      0,
+      (sum, plan) => plan.received ? sum : sum + plan.amount,
+    );
+    final topFourDebtTotal = debtMasterRows.take(4).fold<double>(
+          0,
+          (sum, row) => sum + row.balance.abs(),
+        );
+    final manualPaymentCount =
+        debtMasterRows.where((row) => !row.paymentAmountEstimated).length;
+    final estimatedPaymentCount =
+        debtMasterRows.where((row) => row.paymentAmountEstimated).length;
+    final cashAfterScheduledPayments = cashLikeTotal -
+        monthlyUnpaidPaymentTotal +
+        monthlyUnreceivedIncomeTotal;
+
+    return AssetLiabilityWorkbook(
+      baseDate: baseDate,
+      accounts: accounts,
+      debtMasterRows: debtMasterRows,
+      repaymentPriorityRows: repaymentPriorityRows,
+      paymentDayRisks: paymentDayRisks,
+      cashflowRows: cashflowRows,
+      incomePlans: resolvedIncomePlans,
+      accountCashflowSummaries: accountCashflowSummaries,
+      transferSuggestions: transferSuggestions,
+      cashLikeTotal: cashLikeTotal,
+      securitiesTotal: securitiesTotal,
+      positiveAssetTotal: positiveAssetTotal,
+      liabilityTotal: liabilityTotal,
+      netWorth: netWorth,
+      monthlyMinimumPaymentEstimateTotal: monthlyMinimumPaymentEstimateTotal,
+      monthlyScheduledPaymentTotal: monthlyScheduledPaymentTotal,
+      monthlyUnpaidPaymentTotal: monthlyUnpaidPaymentTotal,
+      monthlyUnreceivedIncomeTotal: monthlyUnreceivedIncomeTotal,
+      cashAfterMinimumPayments: cashAfterScheduledPayments,
+      cashAfterScheduledPayments: cashAfterScheduledPayments,
+      debtToAssetRatio: positiveAssetTotal <= 0
+          ? double.infinity
+          : liabilityTotal.abs() / positiveAssetTotal,
+      topFourDebtShare:
+          liabilityTotal == 0 ? 0 : topFourDebtTotal / liabilityTotal.abs(),
+      manualPaymentCount: manualPaymentCount,
+      estimatedPaymentCount: estimatedPaymentCount,
+    );
+  }
+
+  AssetLiabilityAccount _classifyAccount({
+    required String name,
+    required double balance,
+  }) {
+    final key = _normalize(name);
+
+    if (balance > 0) {
+      if (_containsAny(key, const <String>['証券', 'securities', 'stock'])) {
+        return AssetLiabilityAccount(
+          id: _accountIdForName(name),
+          name: name,
+          kind: AssetLiabilityAccountKind.securities,
+          balance: balance,
+        );
+      }
+      if (_containsAny(key, const <String>['財布', '現金', 'cash'])) {
+        return AssetLiabilityAccount(
+          id: _accountIdForName(name),
+          name: name,
+          kind: AssetLiabilityAccountKind.cash,
+          balance: balance,
+        );
+      }
+      if (_containsAny(key, const <String>['銀行', '支店', 'bank'])) {
+        return AssetLiabilityAccount(
+          id: _accountIdForName(name),
+          name: name,
+          kind: AssetLiabilityAccountKind.deposit,
+          balance: balance,
+        );
+      }
+      return AssetLiabilityAccount(
+        id: _accountIdForName(name),
+        name: name,
+        kind: AssetLiabilityAccountKind.otherAsset,
+        balance: balance,
+      );
+    }
+
+    if (_containsAll(key, const <String>['アコム', 'ショッピング'])) {
+      return _liability(
+        name: name,
+        balance: balance,
+        kind: AssetLiabilityAccountKind.shoppingDebt,
+        paymentDay: 8,
+        annualRate: 0.15,
+        minimumPaymentRate: 0.03,
+        minimumPaymentFloor: 3000,
+      );
+    }
+    if (_containsAll(key, const <String>['アコム', 'ローン'])) {
+      return _consumerFinance(
+        name: name,
+        balance: balance,
+        paymentDay: 8,
+      );
+    }
+    if (_containsAny(key, const <String>['モビット', 'mobit'])) {
+      return _consumerFinance(
+        name: name,
+        balance: balance,
+        paymentDay: 15,
+      );
+    }
+    if (_containsAny(key, const <String>['じぶん', 'jibun'])) {
+      return _bankLoan(
+        name: name,
+        balance: balance,
+        paymentDay: 27,
+      );
+    }
+    if (_accountIdForName(name) == 'smbc_card_loan') {
+      return _bankLoan(
+        name: name,
+        balance: balance,
+        paymentDay: 15,
+      );
+    }
+    if (_containsAll(key, const <String>['三井住友', 'cl'])) {
+      return _bankLoan(
+        name: name,
+        balance: balance,
+        paymentDay: 15,
+      );
+    }
+    if (_containsAny(key, const <String>['横浜銀行'])) {
+      return _bankLoan(
+        name: name,
+        balance: balance,
+        paymentDay: 15,
+      );
+    }
+    if (_containsAny(key, const <String>['aupay', 'aupayカード'])) {
+      return _creditCard(
+        name: name,
+        balance: balance,
+        paymentDay: 10,
+      );
+    }
+    if (_containsAny(key, const <String>['paypay'])) {
+      return _creditCard(
+        name: name,
+        balance: balance,
+        paymentDay: 27,
+      );
+    }
+    if (_containsAny(key, const <String>['ファミペイ', 'famipay'])) {
+      return _creditCard(
+        name: name,
+        balance: balance,
+        paymentDay: 27,
+      );
+    }
+    if (key == 'au' || _containsAny(key, const <String>['通信', '携帯'])) {
+      return _liability(
+        name: name,
+        balance: balance,
+        kind: AssetLiabilityAccountKind.utility,
+        paymentDay: 11,
+        annualRate: 0,
+        minimumPaymentRate: 1,
+        minimumPaymentFloor: balance.abs(),
+        fullPaymentEstimate: true,
+      );
+    }
+    if (_containsAny(key, const <String>['カード', 'card', 'クレカ'])) {
+      return _creditCard(
+        name: name,
+        balance: balance,
+        paymentDay: null,
+      );
+    }
+    if (_containsAny(key, const <String>['ローン', 'loan', '銀行'])) {
+      return _bankLoan(
+        name: name,
+        balance: balance,
+        paymentDay: null,
+      );
+    }
+
+    return _liability(
+      name: name,
+      balance: balance,
+      kind: AssetLiabilityAccountKind.otherLiability,
+      annualRate: 0.12,
+      minimumPaymentRate: 0.03,
+      minimumPaymentFloor: 3000,
+    );
+  }
+
+  AssetLiabilityAccount _consumerFinance({
+    required String name,
+    required double balance,
+    required int? paymentDay,
+  }) =>
+      _liability(
+        name: name,
+        balance: balance,
+        kind: AssetLiabilityAccountKind.cardLoan,
+        paymentDay: paymentDay,
+        annualRate: 0.18,
+        minimumPaymentRate: 0.04,
+        minimumPaymentFloor: 4000,
+      );
+
+  AssetLiabilityAccount _bankLoan({
+    required String name,
+    required double balance,
+    required int? paymentDay,
+  }) =>
+      _liability(
+        name: name,
+        balance: balance,
+        kind: AssetLiabilityAccountKind.cardLoan,
+        paymentDay: paymentDay,
+        annualRate: 0.145,
+        minimumPaymentRate: 0.03,
+        minimumPaymentFloor: 3000,
+      );
+
+  AssetLiabilityAccount _creditCard({
+    required String name,
+    required double balance,
+    required int? paymentDay,
+  }) =>
+      _liability(
+        name: name,
+        balance: balance,
+        kind: AssetLiabilityAccountKind.creditCard,
+        paymentDay: paymentDay,
+        annualRate: 0.15,
+        minimumPaymentRate: 0.03,
+        minimumPaymentFloor: 3000,
+      );
+
+  AssetLiabilityAccount _liability({
+    required String name,
+    required double balance,
+    required AssetLiabilityAccountKind kind,
+    int? paymentDay,
+    required double annualRate,
+    required double minimumPaymentRate,
+    required double minimumPaymentFloor,
+    bool fullPaymentEstimate = false,
+  }) =>
+      AssetLiabilityAccount(
+        id: _accountIdForName(name),
+        name: name,
+        kind: kind,
+        balance: balance,
+        paymentDay: paymentDay,
+        annualRate: annualRate,
+        minimumPaymentRate: minimumPaymentRate,
+        minimumPaymentFloor: minimumPaymentFloor,
+        fullPaymentEstimate: fullPaymentEstimate,
+      );
+
+  AssetLiabilityDebtRow _buildDebtRow({
+    required AssetLiabilityAccount account,
+    required double liabilityTotal,
+    required Map<String, double> monthlyPaymentOverrides,
+    required Set<String> paidAccountNames,
+    required Map<String, String> paymentSourceAccountIds,
+    required Map<String, AssetLiabilityAccount> accountsById,
+  }) {
+    final principal = account.liabilityBalance;
+    final interest = principal * account.annualRate / 12;
+    final minimumPayment = account.fullPaymentEstimate
+        ? principal + interest
+        : min(
+            principal + interest,
+            max(
+              account.minimumPaymentFloor,
+              principal * account.minimumPaymentRate,
+            ),
+          );
+    final manualPayment = _manualPaymentAmountFor(
+      account: account,
+      monthlyPaymentOverrides: monthlyPaymentOverrides,
+    );
+    final scheduledPayment = manualPayment ?? minimumPayment;
+    final principalPayment = max(0.0, scheduledPayment - interest);
+    final afterPayment = -max(0.0, principal + interest - scheduledPayment);
+    final paymentSourceAccountId = paymentSourceAccountIds[account.id];
+    final paymentSourceAccountName = paymentSourceAccountId == null
+        ? null
+        : accountsById[paymentSourceAccountId]?.name;
+
+    return AssetLiabilityDebtRow(
+      id: account.id,
+      name: account.name,
+      kind: account.kind,
+      balance: account.balance,
+      paymentDay: account.paymentDay,
+      paymentSourceAccountId: paymentSourceAccountId,
+      paymentSourceAccountName: paymentSourceAccountName,
+      annualRate: account.annualRate,
+      minimumPaymentEstimate: minimumPayment,
+      manualPaymentAmount: manualPayment,
+      scheduledPaymentAmount: scheduledPayment,
+      monthlyInterestEstimate: interest,
+      principalPaymentEstimate: principalPayment,
+      balanceAfterPaymentEstimate: afterPayment,
+      liabilityShare:
+          liabilityTotal == 0 ? 0 : principal / liabilityTotal.abs(),
+      priorityLabel: _priorityLabel(account.annualRate),
+      paymentAmountEstimated: manualPayment == null,
+      paid: paidAccountNames.contains(account.id) ||
+          paidAccountNames.contains(account.name.trim()) ||
+          paidAccountNames.contains(account.name),
+    );
+  }
+
+  List<AssetLiabilityPaymentDayRisk> _buildPaymentDayRisks({
+    required List<AssetLiabilityDebtRow> rows,
+    required DateTime baseDate,
+  }) {
+    final byDay = <int, List<AssetLiabilityDebtRow>>{};
+    for (final row in rows) {
+      final day = row.paymentDay;
+      if (day == null) {
+        continue;
+      }
+      byDay.putIfAbsent(day, () => <AssetLiabilityDebtRow>[]).add(row);
+    }
+
+    final result = <AssetLiabilityPaymentDayRisk>[];
+    for (final entry in byDay.entries) {
+      final day = entry.key;
+      final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
+      final resolvedDay = day.clamp(1, lastDay).toInt();
+      final paymentDate = DateTime(
+        baseDate.year,
+        baseDate.month,
+        resolvedDay,
+      );
+      final rowsForDay = entry.value
+        ..sort((a, b) => b.balance.abs().compareTo(a.balance.abs()));
+      result.add(
+        AssetLiabilityPaymentDayRisk(
+          paymentDay: day,
+          paymentDate: paymentDate,
+          accountNames: rowsForDay.map((row) => row.name).toList(),
+          balanceTotal: rowsForDay.fold<double>(
+            0,
+            (sum, row) => sum + row.balance,
+          ),
+          minimumPaymentEstimateTotal: rowsForDay.fold<double>(
+            0,
+            (sum, row) => sum + row.minimumPaymentEstimate,
+          ),
+          scheduledPaymentTotal: rowsForDay.fold<double>(
+            0,
+            (sum, row) => sum + row.scheduledPaymentAmount,
+          ),
+          manualPaymentTotal: rowsForDay.fold<double>(
+            0,
+            (sum, row) => sum + (row.manualPaymentAmount ?? 0),
+          ),
+          interestEstimateTotal: rowsForDay.fold<double>(
+            0,
+            (sum, row) => sum + row.monthlyInterestEstimate,
+          ),
+          manualPaymentCount:
+              rowsForDay.where((row) => !row.paymentAmountEstimated).length,
+          estimatedPaymentCount:
+              rowsForDay.where((row) => row.paymentAmountEstimated).length,
+          isPast: paymentDate.isBefore(_dateOnly(baseDate)),
+          isToday: paymentDate == _dateOnly(baseDate),
+        ),
+      );
+    }
+
+    result.sort((a, b) => a.paymentDay.compareTo(b.paymentDay));
+    return result;
+  }
+
+  List<AssetLiabilityCashflowRow> _buildCashflowRows({
+    required List<AssetLiabilityDebtRow> rows,
+    required List<AssetLiabilityIncomePlan> incomePlans,
+    required DateTime baseDate,
+    required double startingCash,
+  }) {
+    final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
+    final result = <AssetLiabilityCashflowRow>[];
+    for (final plan in incomePlans) {
+      final paymentDate = _dateOnly(plan.date);
+      result.add(
+        AssetLiabilityCashflowRow(
+          eventType: AssetLiabilityCashflowEventType.income,
+          accountId: plan.id,
+          accountName: plan.name,
+          paymentDay: paymentDate.day,
+          paymentDate: paymentDate,
+          paymentSourceAccountId: null,
+          paymentSourceAccountName: null,
+          destinationAccountId: plan.destinationAccountId,
+          destinationAccountName: plan.destinationAccountName,
+          paymentAmount: plan.amount,
+          paymentAmountEstimated: false,
+          paid: false,
+          received: plan.received,
+          overdue: !plan.received && !paymentDate.isAfter(_dateOnly(baseDate)),
+          cashBeforePayment: 0,
+          cashAfterPayment: 0,
+          riskLevel: AssetLiabilityCashRiskLevel.normal,
+        ),
+      );
+    }
+
+    for (final row in rows.where((row) => row.paymentDay != null)) {
+      final paymentDay = row.paymentDay!;
+      final resolvedDay = paymentDay.clamp(1, lastDay).toInt();
+      final paymentDate = DateTime(
+        baseDate.year,
+        baseDate.month,
+        resolvedDay,
+      );
+      final overdue = !row.paid && !paymentDate.isAfter(_dateOnly(baseDate));
+      result.add(
+        AssetLiabilityCashflowRow(
+          eventType: AssetLiabilityCashflowEventType.payment,
+          accountId: row.id,
+          accountName: row.name,
+          paymentDay: paymentDay,
+          paymentDate: paymentDate,
+          paymentSourceAccountId: row.paymentSourceAccountId,
+          paymentSourceAccountName: row.paymentSourceAccountName,
+          destinationAccountId: null,
+          destinationAccountName: null,
+          paymentAmount: row.scheduledPaymentAmount,
+          paymentAmountEstimated: row.paymentAmountEstimated,
+          paid: row.paid,
+          received: false,
+          overdue: overdue,
+          cashBeforePayment: 0,
+          cashAfterPayment: 0,
+          riskLevel: AssetLiabilityCashRiskLevel.normal,
+        ),
+      );
+    }
+
+    result.sort((a, b) {
+      final date = a.paymentDate.compareTo(b.paymentDate);
+      if (date != 0) {
+        return date;
+      }
+      if (a.eventType != b.eventType) {
+        return a.isIncome ? -1 : 1;
+      }
+      return b.paymentAmount.compareTo(a.paymentAmount);
+    });
+
+    var runningCash = startingCash;
+    return [
+      for (final row in result)
+        () {
+          final before = runningCash;
+          final delta = row.isIncome
+              ? (row.received ? 0 : row.paymentAmount)
+              : (row.paid ? 0 : -row.paymentAmount);
+          final after = before + delta;
+          runningCash = after;
+          return AssetLiabilityCashflowRow(
+            eventType: row.eventType,
+            accountId: row.accountId,
+            accountName: row.accountName,
+            paymentDay: row.paymentDay,
+            paymentDate: row.paymentDate,
+            paymentSourceAccountId: row.paymentSourceAccountId,
+            paymentSourceAccountName: row.paymentSourceAccountName,
+            destinationAccountId: row.destinationAccountId,
+            destinationAccountName: row.destinationAccountName,
+            paymentAmount: row.paymentAmount,
+            paymentAmountEstimated: row.paymentAmountEstimated,
+            paid: row.paid,
+            received: row.received,
+            overdue: row.overdue,
+            cashBeforePayment: before,
+            cashAfterPayment: after,
+            riskLevel: _cashRiskLevel(after),
+          );
+        }(),
+    ];
+  }
+
+  AssetLiabilityCashRiskLevel _cashRiskLevel(double cashAfterPayment) {
+    if (cashAfterPayment < 0) {
+      return AssetLiabilityCashRiskLevel.short;
+    }
+    if (cashAfterPayment < 10000) {
+      return AssetLiabilityCashRiskLevel.caution;
+    }
+    if (cashAfterPayment < 30000) {
+      return AssetLiabilityCashRiskLevel.watch;
+    }
+    return AssetLiabilityCashRiskLevel.normal;
+  }
+
+  List<AssetLiabilityIncomePlan> _resolveIncomePlans({
+    required List<AssetLiabilityIncomePlan> incomePlans,
+    required Map<String, AssetLiabilityAccount> accountsById,
+  }) {
+    final result = <AssetLiabilityIncomePlan>[];
+    for (final plan in incomePlans) {
+      final destination = plan.destinationAccountId == null
+          ? null
+          : accountsById[plan.destinationAccountId];
+      result.add(
+        AssetLiabilityIncomePlan(
+          id: plan.id,
+          date: _dateOnly(plan.date),
+          name: plan.name,
+          amount: plan.amount,
+          destinationAccountId: plan.destinationAccountId,
+          destinationAccountName:
+              destination?.name ?? plan.destinationAccountName,
+          received: plan.received,
+        ),
+      );
+    }
+    result.sort((a, b) => a.date.compareTo(b.date));
+    return result;
+  }
+
+  List<AssetLiabilityAccountCashflowSummary> _buildAccountCashflowSummaries({
+    required List<AssetLiabilityAccount> accounts,
+    required List<AssetLiabilityCashflowRow> cashflowRows,
+  }) {
+    final cashLikeAccounts = accounts.where(_isCashLike).toList()
+      ..sort((a, b) => b.balance.compareTo(a.balance));
+    return [
+      for (final account in cashLikeAccounts)
+        () {
+          final payments = cashflowRows.fold<double>(
+            0,
+            (sum, row) => row.isPayment &&
+                    !row.paid &&
+                    row.paymentSourceAccountId == account.id
+                ? sum + row.paymentAmount
+                : sum,
+          );
+          final income = cashflowRows.fold<double>(
+            0,
+            (sum, row) => row.isIncome &&
+                    !row.received &&
+                    row.destinationAccountId == account.id
+                ? sum + row.paymentAmount
+                : sum,
+          );
+          final projected = account.balance - payments + income;
+          return AssetLiabilityAccountCashflowSummary(
+            accountId: account.id,
+            accountName: account.name,
+            currentBalance: account.balance,
+            upcomingPayments: payments,
+            upcomingIncome: income,
+            projectedBalance: projected,
+            riskLevel: _cashRiskLevel(projected),
+          );
+        }(),
+    ];
+  }
+
+  List<AssetLiabilityTransferSuggestion> _buildTransferSuggestions({
+    required List<AssetLiabilityAccountCashflowSummary> summaries,
+    required List<AssetLiabilityCashflowRow> cashflowRows,
+  }) {
+    final donors = summaries
+        .where((summary) => summary.projectedBalance > 30000)
+        .toList()
+      ..sort((a, b) => b.projectedBalance.compareTo(a.projectedBalance));
+    final shortages = summaries.where((summary) => summary.isShort).toList()
+      ..sort((a, b) => a.projectedBalance.compareTo(b.projectedBalance));
+
+    final suggestions = <AssetLiabilityTransferSuggestion>[];
+    for (final shortage in shortages) {
+      final donor = donors.firstWhere(
+        (summary) => summary.accountId != shortage.accountId,
+        orElse: () => const AssetLiabilityAccountCashflowSummary(
+          accountId: '',
+          accountName: '',
+          currentBalance: 0,
+          upcomingPayments: 0,
+          upcomingIncome: 0,
+          projectedBalance: 0,
+          riskLevel: AssetLiabilityCashRiskLevel.short,
+        ),
+      );
+      if (donor.accountId.isEmpty) {
+        continue;
+      }
+      final donorSurplus = donor.projectedBalance - 30000;
+      if (donorSurplus <= 0) {
+        continue;
+      }
+      final amount = min(shortage.shortfall, donorSurplus);
+      if (amount <= 0) {
+        continue;
+      }
+      suggestions.add(
+        AssetLiabilityTransferSuggestion(
+          fromAccountId: donor.accountId,
+          fromAccountName: donor.accountName,
+          toAccountId: shortage.accountId,
+          toAccountName: shortage.accountName,
+          amount: amount,
+          neededBy: _firstNeededDateForAccount(
+            shortage.accountId,
+            cashflowRows,
+          ),
+        ),
+      );
+    }
+    return suggestions;
+  }
+
+  DateTime? _firstNeededDateForAccount(
+    String accountId,
+    List<AssetLiabilityCashflowRow> cashflowRows,
+  ) {
+    for (final row in cashflowRows) {
+      if (row.isPayment &&
+          !row.paid &&
+          row.paymentSourceAccountId == accountId) {
+        return row.paymentDate;
+      }
+    }
+    return null;
+  }
+
+  int _compareAccounts(
+    AssetLiabilityAccount a,
+    AssetLiabilityAccount b,
+  ) {
+    if (a.isAsset != b.isAsset) {
+      return a.isAsset ? -1 : 1;
+    }
+    return b.balance.abs().compareTo(a.balance.abs());
+  }
+
+  int _compareDebtPriority(
+    AssetLiabilityDebtRow a,
+    AssetLiabilityDebtRow b,
+  ) {
+    final rate = b.annualRate.compareTo(a.annualRate);
+    if (rate != 0) {
+      return rate;
+    }
+    return b.balance.abs().compareTo(a.balance.abs());
+  }
+
+  String _accountIdForName(String name) {
+    final key = _normalize(name);
+
+    if (_containsAll(key, const <String>['アコム', 'ショッピング'])) {
+      return 'acom_shopping';
+    }
+    if (_containsAll(key, const <String>['アコム', 'ローン'])) {
+      return 'acom_card_loan';
+    }
+    if (_containsAny(key, const <String>['モビット', 'mobit'])) {
+      return 'mobit';
+    }
+    if (_containsAny(key, const <String>['じぶん', 'jibun'])) {
+      return 'jibun_bank_card_loan';
+    }
+    if (_containsAny(
+          key,
+          const <String>['smbcカードローン', 'smbccardloan', 'smbccl'],
+        ) ||
+        _containsAll(key, const <String>['三井住友', 'cl']) ||
+        _containsAll(key, const <String>['三井住友', 'カードローン'])) {
+      return 'smbc_card_loan';
+    }
+    if (_containsAny(key, const <String>['横浜銀行'])) {
+      return 'yokohama_bank';
+    }
+    if (_containsAny(key, const <String>['aupay'])) {
+      return 'aupay_card';
+    }
+    if (_containsAny(key, const <String>['paypay'])) {
+      return 'paypay_card';
+    }
+    if (_containsAny(key, const <String>['ファミペイ', 'famipay'])) {
+      return 'famipay_card';
+    }
+    if (key == 'au' || _containsAny(key, const <String>['通信', '携帯'])) {
+      return 'au';
+    }
+    if (_containsAny(key, const <String>['三菱ufjeスマート証券', 'eスマート証券'])) {
+      return 'mufg_esmart_securities';
+    }
+    if (_containsAny(key, const <String>['財布', 'wallet'])) {
+      return 'wallet_cash';
+    }
+    if (_containsAll(key, const <String>['三井住友', '大塚'])) {
+      return 'smbc_otsuka_branch';
+    }
+    if (_containsAll(key, const <String>['三井住友', '神田'])) {
+      return 'smbc_kanda_branch';
+    }
+
+    return _fallbackAccountId(name);
+  }
+
+  String _fallbackAccountId(String name) {
+    final ascii = _normalize(name)
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '_')
+        .replaceAll(RegExp(r'_+'), '_')
+        .replaceAll(RegExp(r'^_|_$'), '');
+    if (ascii.isNotEmpty) {
+      return 'custom_$ascii';
+    }
+
+    var hash = 0x811c9dc5;
+    for (final codeUnit in name.codeUnits) {
+      hash ^= codeUnit;
+      hash = (hash * 0x01000193) & 0xffffffff;
+    }
+    return 'custom_${hash.toRadixString(16).padLeft(8, '0')}';
+  }
+
+  bool _isCashLike(AssetLiabilityAccount account) {
+    return account.balance > 0 &&
+        (account.kind == AssetLiabilityAccountKind.cash ||
+            account.kind == AssetLiabilityAccountKind.deposit);
+  }
+
+  double? _manualPaymentAmountFor({
+    required AssetLiabilityAccount account,
+    required Map<String, double> monthlyPaymentOverrides,
+  }) {
+    final trimmedName = account.name.trim();
+    final amount = monthlyPaymentOverrides[account.id] ??
+        monthlyPaymentOverrides[trimmedName] ??
+        monthlyPaymentOverrides[account.name];
+    if (amount == null || amount < 0) {
+      return null;
+    }
+    return amount;
+  }
+
+  String _priorityLabel(double annualRate) {
+    if (annualRate >= 0.18) {
+      return '最優先';
+    }
+    if (annualRate >= 0.15) {
+      return '高';
+    }
+    if (annualRate > 0) {
+      return '確認';
+    }
+    return '期日優先';
+  }
+
+  String _normalize(String source) {
+    return source
+        .toLowerCase()
+        .replaceAll(RegExp(r'\s+'), '')
+        .replaceAll('　', '');
+  }
+
+  bool _containsAny(String source, List<String> keywords) {
+    for (final keyword in keywords) {
+      if (source.contains(_normalize(keyword))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool _containsAll(String source, List<String> keywords) {
+    for (final keyword in keywords) {
+      if (!source.contains(_normalize(keyword))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  DateTime _dateOnly(DateTime source) {
+    return DateTime(source.year, source.month, source.day);
+  }
+}

--- a/test/services/asset_liability_history_service_test.dart
+++ b/test/services/asset_liability_history_service_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_history_service.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  group('AssetLiabilityHistoryService', () {
+    const historyService = AssetLiabilityHistoryService();
+    const planningService = AssetLiabilityPlanningService();
+
+    test('builds monthly snapshot with paid, unpaid, and overdue totals', () {
+      final workbook = planningService.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'モビット': -100000,
+          'auPayカード': -10000,
+        },
+        baseDate: DateTime(2026, 5, 20),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 10000,
+          'aupay_card': 5000,
+        },
+        paidAccountNames: const <String>{
+          'aupay_card',
+        },
+      );
+
+      final snapshot = historyService.buildSnapshot(
+        monthKey: '2026-05',
+        workbook: workbook,
+        savedAt: DateTime(2026, 5, 20, 9),
+      );
+
+      expect(snapshot.monthKey, '2026-05');
+      expect(snapshot.monthlyScheduledPaymentTotal, 15000);
+      expect(snapshot.monthlyPaidPaymentTotal, 5000);
+      expect(snapshot.monthlyUnpaidPaymentTotal, 10000);
+      expect(snapshot.overduePaymentCount, 1);
+    });
+
+    test('calculates month-over-month deltas', () {
+      final comparisons = historyService.compareSnapshots(
+        <AssetLiabilityMonthlySnapshot>[
+          AssetLiabilityMonthlySnapshot(
+            monthKey: '2026-05',
+            savedAt: DateTime(2026, 5, 31),
+            positiveAssetTotal: 100000,
+            liabilityTotal: -7000000,
+            netWorth: -6900000,
+            cashLikeTotal: 50000,
+            monthlyScheduledPaymentTotal: 120000,
+            monthlyPaidPaymentTotal: 80000,
+            monthlyUnpaidPaymentTotal: 40000,
+            overduePaymentCount: 1,
+          ),
+          AssetLiabilityMonthlySnapshot(
+            monthKey: '2026-06',
+            savedAt: DateTime(2026, 6, 30),
+            positiveAssetTotal: 130000,
+            liabilityTotal: -6800000,
+            netWorth: -6670000,
+            cashLikeTotal: 70000,
+            monthlyScheduledPaymentTotal: 100000,
+            monthlyPaidPaymentTotal: 100000,
+            monthlyUnpaidPaymentTotal: 0,
+            overduePaymentCount: 0,
+          ),
+        ],
+      );
+
+      expect(comparisons.first.snapshot.monthKey, '2026-06');
+      expect(comparisons.first.positiveAssetDelta, 30000);
+      expect(comparisons.first.liabilityDelta, 200000);
+      expect(comparisons.first.netWorthDelta, 230000);
+      expect(comparisons.first.cashLikeDelta, 20000);
+      expect(comparisons.last.hasPrevious, isFalse);
+    });
+
+    test('generates CSV data for history, payments, income, and accounts', () {
+      final workbook = planningService.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'bank': 10000,
+          'モビット': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 20000,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          'mobit': 'custom_bank',
+        },
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'income_bonus',
+            date: DateTime(2026, 5, 10),
+            name: 'Bonus, side income',
+            amount: 30000,
+            destinationAccountId: 'custom_bank',
+            destinationAccountName: null,
+            received: false,
+          ),
+        ],
+      );
+
+      final bundle = historyService.buildCsvExportBundle(
+        monthlySnapshots: <AssetLiabilityMonthlySnapshot>[
+          AssetLiabilityMonthlySnapshot(
+            monthKey: '2026-05',
+            savedAt: DateTime(2026, 5, 31, 20),
+            positiveAssetTotal: 60000,
+            liabilityTotal: -100000,
+            netWorth: -40000,
+            cashLikeTotal: 60000,
+            monthlyScheduledPaymentTotal: 20000,
+            monthlyPaidPaymentTotal: 0,
+            monthlyUnpaidPaymentTotal: 20000,
+            overduePaymentCount: 0,
+          ),
+        ],
+        workbook: workbook,
+      );
+
+      expect(bundle.monthlyHistoryCsv, contains('対象月,保存日時,資産合計'));
+      expect(bundle.monthlyHistoryCsv, contains('2026-05'));
+      expect(bundle.paymentScheduleCsv, contains('支払先'));
+      expect(bundle.paymentScheduleCsv, contains('モビット'));
+      expect(bundle.incomePlansCsv, contains('"Bonus, side income"'));
+      expect(bundle.accountCashflowCsv, contains('口座,現在残高'));
+      expect(bundle.accountCashflowCsv, contains('bank'));
+    });
+  });
+}

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -1,0 +1,239 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('AssetLiabilityMonthlyStateStore', () {
+    const store = AssetLiabilityMonthlyStateStore();
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('saves and restores monthly paid statuses', () async {
+      await store.saveMonth(
+        month: DateTime(2026, 5, 13),
+        state: AssetLiabilityMonthlyState(
+          paymentOverrides: const <String, double>{
+            'モビット': 70000,
+          },
+          paidAccountNames: const <String>{
+            'auPayカード',
+          },
+          paymentSourceAccountIds: const <String, String>{
+            'mobit': 'custom_bank',
+          },
+          incomePlans: <AssetLiabilityIncomePlan>[
+            AssetLiabilityIncomePlan(
+              id: 'income_salary',
+              date: DateTime(2026, 5, 25),
+              name: 'Salary',
+              amount: 250000,
+              destinationAccountId: 'custom_bank',
+              destinationAccountName: 'Bank',
+              received: false,
+            ),
+          ],
+        ),
+      );
+
+      final loadedMay = await store.loadMonth(DateTime(2026, 5, 20));
+      final loadedJune = await store.loadMonth(DateTime(2026, 6, 1));
+
+      expect(loadedMay.paymentOverrides['モビット'], 70000);
+      expect(loadedMay.paidAccountNames, contains('auPayカード'));
+      expect(loadedMay.paymentSourceAccountIds['mobit'], 'custom_bank');
+      expect(loadedMay.incomePlans.single.name, 'Salary');
+      expect(loadedJune.paymentOverrides, isEmpty);
+      expect(loadedJune.paidAccountNames, isEmpty);
+      expect(loadedJune.paymentSourceAccountIds, isEmpty);
+      expect(loadedJune.incomePlans, isEmpty);
+    });
+
+    test('keeps zero yen as a valid manual payment amount', () {
+      const raw = '{"2026-05":{"PayPayカード":0,"モビット":"70,000"}}';
+
+      final decoded = AssetLiabilityMonthlyStateStore.paymentOverridesForMonth(
+        raw,
+        '2026-05',
+      );
+
+      expect(decoded['PayPayカード'], 0);
+      expect(decoded['モビット'], 70000);
+    });
+
+    test('falls back to estimated payment after manual amount is cleared',
+        () async {
+      await store.saveMonth(
+        month: DateTime(2026, 5, 13),
+        state: const AssetLiabilityMonthlyState(
+          paymentOverrides: <String, double>{
+            'モビット': 70000,
+          },
+          paymentSourceAccountIds: <String, String>{
+            'mobit': 'custom_bank',
+          },
+        ),
+      );
+      await store.saveMonth(
+        month: DateTime(2026, 5, 13),
+        state: const AssetLiabilityMonthlyState(),
+      );
+
+      final loaded = await store.loadMonth(DateTime(2026, 5, 13));
+
+      expect(loaded.paymentOverrides, isEmpty);
+      expect(loaded.paidAccountNames, isEmpty);
+      expect(loaded.paymentSourceAccountIds, isEmpty);
+      expect(loaded.incomePlans, isEmpty);
+    });
+
+    test('migrates legacy display-name keys to stable account ids', () {
+      final migrated = AssetLiabilityMonthlyStateStore.migrateLegacyKeys(
+        state: const AssetLiabilityMonthlyState(
+          paymentOverrides: <String, double>{
+            'モビット': 70000,
+          },
+          paidAccountNames: <String>{
+            'auPayカード',
+          },
+          paymentSourceAccountIds: <String, String>{
+            'モビット': '銀行口座',
+          },
+        ),
+        legacyKeyToAccountId: const <String, String>{
+          'モビット': 'mobit',
+          'auPayカード': 'aupay_card',
+          '銀行口座': 'custom_bank',
+        },
+      );
+
+      expect(migrated.paymentOverrides, <String, double>{'mobit': 70000});
+      expect(migrated.paidAccountNames, <String>{'aupay_card'});
+      expect(migrated.paymentSourceAccountIds, <String, String>{
+        'mobit': 'custom_bank',
+      });
+    });
+
+    test('copies previous month settings without paid or received state',
+        () async {
+      await store.saveMonth(
+        month: DateTime(2026, 5, 13),
+        state: AssetLiabilityMonthlyState(
+          paymentOverrides: const <String, double>{
+            'mobit': 70000,
+          },
+          paidAccountNames: const <String>{
+            'mobit',
+          },
+          paymentSourceAccountIds: const <String, String>{
+            'mobit': 'custom_bank',
+          },
+          incomePlans: <AssetLiabilityIncomePlan>[
+            AssetLiabilityIncomePlan(
+              id: 'salary',
+              date: DateTime(2026, 5, 31),
+              name: 'Salary',
+              amount: 250000,
+              destinationAccountId: 'custom_bank',
+              destinationAccountName: 'Bank',
+              received: true,
+            ),
+          ],
+        ),
+      );
+
+      final copied = await store.copyPreviousMonthToMonth(
+        DateTime(2026, 6, 10),
+      );
+      final loaded = await store.loadMonth(DateTime(2026, 6, 20));
+
+      expect(copied.paymentOverrides, <String, double>{'mobit': 70000});
+      expect(copied.paymentSourceAccountIds, <String, String>{
+        'mobit': 'custom_bank',
+      });
+      expect(copied.paidAccountNames, isEmpty);
+      expect(copied.incomePlans.single.date, DateTime(2026, 6, 30));
+      expect(copied.incomePlans.single.received, isFalse);
+      expect(loaded.paidAccountNames, isEmpty);
+      expect(loaded.incomePlans.single.received, isFalse);
+    });
+
+    test('saves and restores default payment source accounts', () async {
+      await store.saveDefaultPaymentSources(const <String, String>{
+        'mobit': 'custom_bank',
+        'acom_card_loan': 'wallet_cash',
+      });
+
+      final loaded = await store.loadDefaultPaymentSources();
+
+      expect(loaded, <String, String>{
+        'mobit': 'custom_bank',
+        'acom_card_loan': 'wallet_cash',
+      });
+    });
+
+    test('applies recurring income templates to the target month', () async {
+      final plans =
+          AssetLiabilityMonthlyStateStore.applyRecurringIncomeTemplates(
+        month: DateTime(2026, 2, 1),
+        templates: const <AssetLiabilityRecurringIncomeTemplate>[
+          AssetLiabilityRecurringIncomeTemplate(
+            id: 'salary',
+            dayOfMonth: 31,
+            name: 'Salary',
+            amount: 250000,
+            destinationAccountId: 'custom_bank',
+            destinationAccountName: 'Bank',
+          ),
+        ],
+        existingPlans: const <AssetLiabilityIncomePlan>[],
+      );
+
+      expect(plans.single.id, 'recurring_salary_2026-02');
+      expect(plans.single.date, DateTime(2026, 2, 28));
+      expect(plans.single.received, isFalse);
+      expect(plans.single.destinationAccountId, 'custom_bank');
+    });
+
+    test('saves and updates monthly snapshots by month', () async {
+      await store.saveMonthlySnapshot(
+        AssetLiabilityMonthlySnapshot(
+          monthKey: '2026-05',
+          savedAt: DateTime(2026, 5, 31, 20),
+          positiveAssetTotal: 100000,
+          liabilityTotal: -7000000,
+          netWorth: -6900000,
+          cashLikeTotal: 50000,
+          monthlyScheduledPaymentTotal: 120000,
+          monthlyPaidPaymentTotal: 80000,
+          monthlyUnpaidPaymentTotal: 40000,
+          overduePaymentCount: 1,
+        ),
+      );
+      await store.saveMonthlySnapshot(
+        AssetLiabilityMonthlySnapshot(
+          monthKey: '2026-05',
+          savedAt: DateTime(2026, 5, 31, 21),
+          positiveAssetTotal: 110000,
+          liabilityTotal: -6900000,
+          netWorth: -6790000,
+          cashLikeTotal: 60000,
+          monthlyScheduledPaymentTotal: 130000,
+          monthlyPaidPaymentTotal: 130000,
+          monthlyUnpaidPaymentTotal: 0,
+          overduePaymentCount: 0,
+        ),
+      );
+
+      final snapshots = await store.loadMonthlySnapshots();
+
+      expect(snapshots, hasLength(1));
+      expect(snapshots.single.monthKey, '2026-05');
+      expect(snapshots.single.positiveAssetTotal, 110000);
+      expect(snapshots.single.monthlyPaidPaymentTotal, 130000);
+      expect(snapshots.single.overduePaymentCount, 0);
+    });
+  });
+}

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1,0 +1,479 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  group('AssetLiabilityPlanningService.buildWorkbook', () {
+    const service = AssetLiabilityPlanningService();
+
+    final snapshot = <String, double>{
+      '三井住友銀行大塚支店': 25677,
+      '三井住友銀行CL': -481281,
+      '三井住友銀行神田支店': 2645,
+      '横浜銀行': -161437,
+      'アコムカードローン': -699446,
+      'アコムショッピング': -2234106,
+      'モビット': -1553260,
+      'じぶん銀行カードローン': -994562,
+      'au': -32152,
+      'auPayカード': -513770,
+      'PayPayカード': -487324,
+      'ファミペイカード': -97380,
+      '三菱UFJ eスマート証券': 57155,
+      '財布': 11000,
+    };
+
+    test('matches the Excel-style asset liability summary', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+      );
+
+      expect(workbook.cashLikeTotal.round(), 39322);
+      expect(workbook.securitiesTotal.round(), 57155);
+      expect(workbook.positiveAssetTotal.round(), 96477);
+      expect(workbook.liabilityTotal.round(), -7254718);
+      expect(workbook.netWorth.round(), -7158241);
+      expect(workbook.debtToAssetRatio, closeTo(75.1963, 0.001));
+      expect(workbook.topFourDebtShare, closeTo(0.7556, 0.001));
+    });
+
+    test('groups liability balances by payment day', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+      );
+
+      final riskByDay = {
+        for (final risk in workbook.paymentDayRisks) risk.paymentDay: risk,
+      };
+
+      expect(riskByDay[8]?.balanceTotal.round(), -2933552);
+      expect(riskByDay[10]?.balanceTotal.round(), -513770);
+      expect(riskByDay[11]?.balanceTotal.round(), -32152);
+      expect(riskByDay[15]?.balanceTotal.round(), -2195978);
+      expect(riskByDay[27]?.balanceTotal.round(), -1579266);
+      expect(riskByDay[8]?.isPast, isTrue);
+      expect(riskByDay[15]?.isUpcoming, isTrue);
+    });
+
+    test('builds debt master rows with type, rate, and priority signals', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+      );
+
+      final largest = workbook.debtMasterRows.first;
+      expect(largest.name, 'アコムショッピング');
+      expect(largest.kind, AssetLiabilityAccountKind.shoppingDebt);
+      expect(largest.paymentDay, 8);
+      expect(largest.liabilityShare, closeTo(0.308, 0.001));
+
+      final topPriority = workbook.repaymentPriorityRows.first;
+      expect(topPriority.name, anyOf('アコムカードローン', 'モビット'));
+      expect(topPriority.annualRate, 0.18);
+      expect(topPriority.priorityLabel, '最優先');
+    });
+
+    test('prefers manually entered monthly payment over the estimate', () {
+      final baseline = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+      );
+      final baselineMobit = baseline.debtMasterRows.firstWhere(
+        (row) => row.name == 'モビット',
+      );
+
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+        monthlyPaymentOverrides: const <String, double>{
+          'モビット': 70000,
+        },
+      );
+      final mobit = workbook.debtMasterRows.firstWhere(
+        (row) => row.name == 'モビット',
+      );
+
+      expect(mobit.manualPaymentAmount, 70000);
+      expect(mobit.scheduledPaymentAmount, 70000);
+      expect(mobit.paymentAmountEstimated, isFalse);
+      expect(
+        workbook.monthlyScheduledPaymentTotal,
+        closeTo(
+          baseline.monthlyMinimumPaymentEstimateTotal -
+              baselineMobit.minimumPaymentEstimate +
+              70000,
+          0.001,
+        ),
+      );
+      expect(
+        workbook.cashAfterScheduledPayments,
+        closeTo(
+          workbook.cashLikeTotal - workbook.monthlyScheduledPaymentTotal,
+          0.001,
+        ),
+      );
+    });
+
+    test('uses the estimated minimum payment when manual input is absent', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+      );
+
+      final auPay = workbook.debtMasterRows.firstWhere(
+        (row) => row.name == 'auPayカード',
+      );
+
+      expect(auPay.manualPaymentAmount, isNull);
+      expect(auPay.paymentAmountEstimated, isTrue);
+      expect(
+        auPay.scheduledPaymentAmount,
+        closeTo(auPay.minimumPaymentEstimate, 0.001),
+      );
+      expect(workbook.manualPaymentCount, 0);
+      expect(workbook.estimatedPaymentCount, workbook.debtMasterRows.length);
+    });
+
+    test('treats zero yen as a valid manually entered payment', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+        monthlyPaymentOverrides: const <String, double>{
+          'PayPayカード': 0,
+        },
+      );
+
+      final payPay = workbook.debtMasterRows.firstWhere(
+        (row) => row.name == 'PayPayカード',
+      );
+
+      expect(payPay.manualPaymentAmount, 0);
+      expect(payPay.scheduledPaymentAmount, 0);
+      expect(payPay.paymentAmountEstimated, isFalse);
+    });
+
+    test('reflects manual and estimated sources in payment day risk', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+        monthlyPaymentOverrides: const <String, double>{
+          'モビット': 70000,
+        },
+      );
+
+      final risk15 = workbook.paymentDayRisks.firstWhere(
+        (risk) => risk.paymentDay == 15,
+      );
+      final risk27 = workbook.paymentDayRisks.firstWhere(
+        (risk) => risk.paymentDay == 27,
+      );
+
+      expect(risk15.hasManualPayments, isTrue);
+      expect(risk15.hasEstimatedPayments, isTrue);
+      expect(risk15.manualPaymentCount, 1);
+      expect(risk15.estimatedPaymentCount, 2);
+      expect(risk15.manualPaymentTotal, 70000);
+      expect(
+        risk15.scheduledPaymentTotal,
+        greaterThan(risk15.minimumPaymentEstimateTotal),
+      );
+
+      expect(risk27.hasManualPayments, isFalse);
+      expect(risk27.hasEstimatedPayments, isTrue);
+    });
+
+    test('reflects paid status in debt rows and cashflow rows', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          '財布': 50000,
+          'アコムカードローン': -100000,
+          'auPayカード': -10000,
+          'モビット': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        paidAccountNames: const <String>{
+          'auPayカード',
+        },
+      );
+
+      final auPay = workbook.debtMasterRows.firstWhere(
+        (row) => row.name == 'auPayカード',
+      );
+      final auPayCashflow = workbook.cashflowRows.firstWhere(
+        (row) => row.accountName == 'auPayカード',
+      );
+
+      expect(auPay.paid, isTrue);
+      expect(auPayCashflow.paid, isTrue);
+      expect(auPayCashflow.cashBeforePayment, auPayCashflow.cashAfterPayment);
+      expect(
+        workbook.monthlyUnpaidPaymentTotal,
+        workbook.monthlyScheduledPaymentTotal - auPay.scheduledPaymentAmount,
+      );
+    });
+
+    test('restores monthly state by stable id after display name changes', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          '財布': 50000,
+          'SMBCカードローン': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'smbc_card_loan': 12345,
+        },
+        paidAccountNames: const <String>{
+          'smbc_card_loan',
+        },
+      );
+
+      final row = workbook.debtMasterRows.single;
+      final cashflowRow = workbook.cashflowRows.single;
+
+      expect(row.id, 'smbc_card_loan');
+      expect(row.name, 'SMBCカードローン');
+      expect(row.manualPaymentAmount, 12345);
+      expect(row.paid, isTrue);
+      expect(cashflowRow.accountId, 'smbc_card_loan');
+      expect(cashflowRow.paid, isTrue);
+    });
+
+    test('marks unpaid payments due today or earlier as overdue', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          '財布': 50000,
+          'モビット': -100000,
+          'PayPayカード': -10000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 10000,
+          'paypay_card': 5000,
+        },
+      );
+
+      final mobit = workbook.cashflowRows.firstWhere(
+        (row) => row.accountId == 'mobit',
+      );
+      final payPay = workbook.cashflowRows.firstWhere(
+        (row) => row.accountId == 'paypay_card',
+      );
+
+      expect(mobit.overdue, isTrue);
+      expect(payPay.overdue, isFalse);
+      expect(workbook.hasOverduePayments, isTrue);
+      expect(workbook.overdueCashflowRows, hasLength(1));
+    });
+
+    test('builds cashflow rows by payment day with risk levels', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          '財布': 25000,
+          'アコムカードローン': -100000,
+          'auPayカード': -10000,
+          'モビット': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'アコムカードローン': 10000,
+          'auPayカード': 8000,
+          'モビット': 9000,
+        },
+      );
+
+      expect(
+        workbook.cashflowRows.map((row) => row.paymentDay).toList(),
+        <int>[8, 10, 15],
+      );
+      expect(workbook.cashflowRows[0].cashAfterPayment, 15000);
+      expect(
+        workbook.cashflowRows[0].riskLevel,
+        AssetLiabilityCashRiskLevel.watch,
+      );
+      expect(workbook.cashflowRows[1].cashAfterPayment, 7000);
+      expect(
+        workbook.cashflowRows[1].riskLevel,
+        AssetLiabilityCashRiskLevel.caution,
+      );
+      expect(workbook.cashflowRows[2].cashAfterPayment, -2000);
+      expect(
+        workbook.cashflowRows[2].riskLevel,
+        AssetLiabilityCashRiskLevel.short,
+      );
+    });
+
+    test('reflects unreceived income plans in chronological cashflow', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 10000,
+          'mobit': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 20000,
+        },
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'income_salary',
+            date: DateTime(2026, 5, 14),
+            name: 'Salary',
+            amount: 15000,
+            destinationAccountId: 'custom_cash',
+            destinationAccountName: null,
+            received: false,
+          ),
+        ],
+      );
+
+      expect(
+        workbook.cashflowRows.map((row) => row.eventType).toList(),
+        <AssetLiabilityCashflowEventType>[
+          AssetLiabilityCashflowEventType.income,
+          AssetLiabilityCashflowEventType.payment,
+        ],
+      );
+      expect(workbook.cashflowRows.first.cashAfterPayment, 25000);
+      expect(workbook.cashflowRows.last.cashAfterPayment, 5000);
+      expect(workbook.monthlyUnreceivedIncomeTotal, 15000);
+      expect(workbook.cashAfterScheduledPayments, 5000);
+    });
+
+    test('does not double count received income plans', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 10000,
+          'mobit': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 20000,
+        },
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'income_received',
+            date: DateTime(2026, 5, 14),
+            name: 'Received salary',
+            amount: 15000,
+            destinationAccountId: 'custom_cash',
+            destinationAccountName: null,
+            received: true,
+          ),
+        ],
+      );
+
+      expect(workbook.monthlyUnreceivedIncomeTotal, 0);
+      expect(workbook.cashflowRows.first.cashAfterPayment, 10000);
+      expect(workbook.cashflowRows.last.cashAfterPayment, -10000);
+      expect(workbook.cashAfterScheduledPayments, -10000);
+    });
+
+    test('calculates account-level cashflow and shortage warnings', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'bank': 10000,
+          'mobit': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 20000,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          'mobit': 'custom_bank',
+        },
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'income_bank',
+            date: DateTime(2026, 5, 10),
+            name: 'Bank deposit',
+            amount: 5000,
+            destinationAccountId: 'custom_bank',
+            destinationAccountName: null,
+            received: false,
+          ),
+        ],
+      );
+
+      final bankSummary = workbook.accountCashflowSummaries.firstWhere(
+        (summary) => summary.accountId == 'custom_bank',
+      );
+
+      expect(bankSummary.currentBalance, 10000);
+      expect(bankSummary.upcomingPayments, 20000);
+      expect(bankSummary.upcomingIncome, 5000);
+      expect(bankSummary.projectedBalance, -5000);
+      expect(workbook.hasAccountShortage, isTrue);
+      expect(workbook.transferSuggestions.single.amount, 5000);
+      expect(workbook.transferSuggestions.single.toAccountId, 'custom_bank');
+    });
+
+    test('applies default payment source to unset monthly items', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'bank': 10000,
+          'mobit': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 20000,
+        },
+        defaultPaymentSourceAccountIds: const <String, String>{
+          'mobit': 'custom_bank',
+        },
+      );
+
+      final mobit = workbook.debtMasterRows.singleWhere(
+        (row) => row.id == 'mobit',
+      );
+      final bankSummary = workbook.accountCashflowSummaries.firstWhere(
+        (summary) => summary.accountId == 'custom_bank',
+      );
+
+      expect(mobit.paymentSourceAccountId, 'custom_bank');
+      expect(bankSummary.upcomingPayments, 20000);
+      expect(bankSummary.projectedBalance, -10000);
+      expect(workbook.hasAccountShortage, isTrue);
+    });
+
+    test('keeps unassigned income out of account-level cashflow warnings', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 10000,
+          'mobit': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 20000,
+        },
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'income_unassigned',
+            date: DateTime(2026, 5, 10),
+            name: 'Unassigned salary',
+            amount: 15000,
+            destinationAccountId: null,
+            destinationAccountName: null,
+            received: false,
+          ),
+        ],
+      );
+
+      final cashSummary = workbook.accountCashflowSummaries.firstWhere(
+        (summary) => summary.accountId == 'custom_cash',
+      );
+
+      expect(workbook.monthlyUnreceivedIncomeTotal, 15000);
+      expect(workbook.hasUnassignedDestinationIncomePlans, isTrue);
+      expect(
+        workbook.unassignedDestinationIncomePlans.single.name,
+        'Unassigned salary',
+      );
+      expect(cashSummary.upcomingIncome, 0);
+      expect(cashSummary.projectedBalance, 10000);
+      expect(workbook.cashAfterScheduledPayments, 5000);
+    });
+  });
+}


### PR DESCRIPTION
﻿## 概要

資産/負債ボードに、月次履歴・スナップショット保存・CSVバックアップ機能を追加しました。

これにより、今月の資金繰り管理だけでなく、保存時点の資産/負債状況を月次で記録し、前月比やCSVバックアップで後から確認できるようにしています。

## 主な変更

- 「月次履歴（保存時点）」セクションを追加
- 今月のスナップショット保存機能を追加
- 月次履歴の前月比表示に対応
- 前月データがない場合は「前月データなし」と表示
- CSVバックアップ機能を追加
  - 月次履歴
  - 支払予定
  - 収入予定
  - 口座別資金繰り
- CSVファイル名に対象月を追加
  - 例: `asset_liability_monthly_history_2026-05_yyyyMMdd_HHmm.csv`
- 月次履歴・CSV生成処理を `AssetLiabilityHistoryService` に分離
- 月次スナップショットの保存・復元を `AssetLiabilityMonthlyStateStore` に追加
- 関連テストを追加

## 補足

月次履歴は月末確定値ではなく、保存ボタンを押した時点のスナップショットとして扱います。

## Minimal E2E Gate

このPRのE2E確認は implementation-detail independent な black-box 観点で行います。対象は資産/負債ボードの主要I/Oに絞った minimal three I/O cases です。

- スナップショット保存後、月次履歴に保存時点の資産/負債・純資産が表示される
- 前月データがない場合は「前月データなし」と表示され、前月比が誤表示されない
- CSVバックアップ操作で、月次履歴・支払予定・収入予定・口座別資金繰りの出力導線が確認できる

E2E mechanism: 既存の Playwright public smoke / visual evidence checks で画面起動と主要表示の安定性を確認します。

E2E-Exception: このPRでは新規 integration_test/ または test/e2e/ ファイルは追加していません。差分の中心はサービス層の集計・CSV生成と既存ページへの表示追加であり、ローカルではサービス層テスト 27件とWeb起動確認で検証済みです。新規E2Eは後続で資産管理ページ全体の操作導線をまとめて追加するのが適切です。

## 検証

最新 `origin/main` へ rebase 後、以下を確認済みです。

- `dart format ...`: OK、変更なし
- `dart analyze ...`: No issues found
- `flutter test --no-pub ...`: 27 tests passed
- `git diff --check`: OK
- Dart/Flutter プロセス残存なし
- 作業ツリー clean

## ブランチ状態

- Branch: `codex/asset-liability-page`
- Commit: `5da7182e0 Add asset liability monthly history and CSV backup`
- Remote tracking: `origin/codex/asset-liability-page`
