### PR TITLE
docs: route AI tool updates under two-instance policy (#1787)

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,0 +1,33 @@
+# Copilot Custom Agents Design
+
+This directory is a design registry for future GitHub Copilot Custom Agents. It
+does not enable autonomous project execution by itself.
+
+## Current Policy
+
+- Claude Code #1 owns adoption decisions, risk review, and product/process
+  judgment for new AI-tool capabilities.
+- Codex #1 owns scoped implementation PRs, CI repair, merge follow-up, WBS sync
+  verification, branch/worktree cleanup, and local memory/disk hygiene.
+- GitHub Copilot Custom Agents are advisory only. They may suggest changes in
+  GitHub or the editor, but they must not merge, deploy, write production data,
+  rotate secrets, or run side-effecting automation.
+- Old Codex #2/#3 and PowerShell lane ownership is historical. Do not start
+  those lanes for WBS work; Codex #1 absorbs implementable CI/GHA/Edge/docs
+  tasks under the two-instance policy.
+
+## Candidate Agent Shapes
+
+| Agent | Intended scope | Guardrail |
+| --- | --- | --- |
+| `ci-triage-agent` | Summarize failing workflow logs and propose a minimal patch. | Codex #1 must inspect logs, implement the patch, and confirm CI green. |
+| `docs-routing-agent` | Draft documentation deltas from official AI-tool release notes. | Claude Code #1 must approve adopt/defer/ignore; Codex #1 owns the PR. |
+| `calendar-ui-agent` | Suggest UI copy or test cases for calendar surfaces. | No direct deploy or production data mutation. |
+
+## Activation Checklist
+
+1. Link an Issue and WBS row with an explicit owner.
+2. Confirm the release signal from an official source or `docs/ai-tool-changelog`.
+3. Keep the output advisory unless Codex #1 converts it into a normal scoped PR.
+4. Record memory/disk hygiene and close all task-originated processes before
+   wrap-up.

--- a/docs/AI_FALLBACK_RUNBOOK.md
+++ b/docs/AI_FALLBACK_RUNBOOK.md
@@ -1,5 +1,39 @@
 # AI Fallback Runbook — 自分株式会社
 
+## #1787 2026-05 AI Tool Routing Update
+
+This update folds the May 2026 AI-tool signals into the current two-instance
+operating model:
+
+- Claude Code #1 reviews adoption risk and decides adopt/defer/ignore for
+  Claude Code, Codex CLI, Copilot, Gemini Code Assist, Cursor, and Devin release
+  signals.
+- Codex #1 owns scoped implementation, CI, merge follow-up, WBS sync
+  verification, branch/worktree cleanup, and session memory/disk hygiene.
+- Codex #2 and Codex #3 stay historical. Do not start dormant Codex lanes,
+  PowerShell lane instances, or extra subagents to process WBS tasks.
+- Use `docs/ai-tool-changelog/2026-05.md` as the local source summary and verify
+  any release claim against the official source before promoting it into a
+  production fallback path.
+- Copilot Custom Agents are design-only until explicitly activated. The current
+  registry lives in `.github/agents/README.md`; agents are advisory and must not
+  merge, deploy, write production data, or run side-effecting automation.
+
+Adoption notes for this cycle:
+
+- Claude Code v2.1.121 MCP `alwaysLoad` and `claude plugin prune` can reduce
+  tool-search friction, but Claude Code #1 must approve any managed-setting or
+  plugin-store change.
+- Claude Code v2.1.116 `/resume` speed and MCP startup improvements support
+  long-session recovery, but they do not change the two-instance cap.
+- Claude Code v2.1.122 Bedrock service-tier selection and v2.1.108 prompt-cache
+  flags are provider-configuration candidates, not default environment changes.
+- OpenAI Codex CLI rust-v0.128.0 persisted `/goal` workflows are a future
+  Codex #1 planning aid; normal WBS work still uses scoped branches and PRs.
+- Cursor context-usage breakdown, Gemini Code Assist release notes, and Devin
+  CI-aware auto-fix are advisory signals unless a local verified workflow is
+  explicitly routed.
+
 ## 2026-05-07 Official AI Tool Update Gate (#1706)
 
 This runbook now treats AI-tool release claims as "verify before routing". Use

--- a/docs/DEV_PROCESS_MULTI_AI.md
+++ b/docs/DEV_PROCESS_MULTI_AI.md
@@ -7,6 +7,26 @@
 
 ---
 
+## #1787 Current Two-Instance Routing Update (2026-05-13)
+
+Live owners: Claude Code #1 and Codex #1 only. Do not start old Codex #2/#3,
+PowerShell lane instances, or extra subagents for normal WBS execution. Historical
+tables below are retained as migration context, but this section is the current
+override when a row mentions dormant lanes.
+
+| Surface | Current owner | Notes |
+| --- | --- | --- |
+| AI tool release adoption and risk decision | Claude Code #1 | Verify official release notes before adopting Claude Code, Codex CLI, Copilot, Gemini, Cursor, or Devin signals. |
+| Scoped implementation, CI, PR, merge follow-up, and cleanup | Codex #1 | Codex #1 absorbs the old Codex #2 implementation lane for CI, sync, GitHub Actions, Edge Functions, and docs/script PRs. |
+| GitHub Copilot Custom Agents | Advisory only | Use `.github/agents/README.md` as the design registry. Copilot agents must not merge, deploy, or run side-effecting automation. |
+| Gemini Code Assist / Cursor / Devin signals | Candidate fallback or review input | Use only after local availability and official source verification; never as an extra autonomous project instance. |
+
+For monthly AI-tool updates, start from
+`docs/ai-tool-changelog/2026-05.md` and
+`docs/cross-instance-prs/drafts/ai-tool-update/2026-05_ai_tool_update_cross_instance_drafts.md`.
+Claude Code #1 decides adopt/defer/ignore; Codex #1 implements the approved
+scoped slice and records memory/disk hygiene before wrap-up.
+
 ## 1. 強制 Task Routing Matrix
 
 **このルールに従って AI を選択する。Claude Code は「設計判断・大きめ実装・既存設計に沿った機能追加・並列ワーカー・統合・memory管理」を担う。**
@@ -20,9 +40,9 @@
 | 行レベル補完 (< 10行) | GitHub Copilot | — | — | **不使用** |
 | 5分以内の修正 | Copilot Inline Chat | — | — | **不使用** |
 | 500行超リファクタリング | Gemini Code Assist | Copilot | Claude Code | 事前レビューのみ |
-| 横断調査 / 修正PR / レビュー補助 | **Codex#1** | Codex#2 | Claude Code | 仕様確認のみ |
-| CI / 同期 / 運用まわり | **Codex#2** | Codex#1 | Claude Code PS#1 | 完了判定のみ |
-| SQL / アルゴリズム最適化 | OpenAI Codex (`codex1`/`codex2`) | Copilot | Claude Code | 仕様確認のみ |
+| 横断調査 / 修正PR / レビュー補助 | **Codex #1** | Claude Code #1 | Copilot advisory | 仕様確認のみ |
+| CI / 同期 / 運用まわり | **Codex #1** | Claude Code #1 | gh CLI / Python | 完了判定のみ |
+| SQL / アルゴリズム最適化 | **Codex #1** | Copilot | Claude Code #1 | 仕様確認のみ |
 | Migration (DDL + seed SQL) | **Codex#1** (template ベース) | Copilot | Claude Code | 命名則チェック |
 | AI大学 provider 追加 (seed SQL) | **Codex#1** (既存 SQL コピー改変) | — | Claude Code | routing 判断のみ |
 | ブログ・競合リサーチ | Claude Code WEB版 (WebSearch) | NotebookLM | Gemini Search | — |
@@ -31,8 +51,8 @@
 | ブラウザ操作 / 外部SaaS確認 / 長手順実行 | Manus AI | Claude Code | — | 結果確認のみ |
 | アーキテクチャ判断 | **Claude Code** | NotebookLM + Copilot Chat | — | **専任** |
 | Dart バグ修正 (< 50行) | Copilot Inline Chat | Claude Code PS#5 | — | 必要時のみ |
-| EF バグ修正 (Deno) | **Codex#2** / Copilot | Claude Code PS#5 | — | deny-by-default確認 |
-| GHA Workflow 作成・修正 | **Codex#2** / Claude Code PS#1 | Copilot | gh CLI スクリプト | WF health 専任 |
+| EF バグ修正 (Deno) | **Codex #1** / Copilot | Claude Code #1 | — | deny-by-default確認 |
+| GHA Workflow 作成・修正 | **Codex #1** / Claude Code #1 | Copilot | gh CLI スクリプト | WF health 専任 |
 | PR review (自動) | claude-agent-review.yml | GitHub Copilot PR review | — | — |
 | quota監視・アラート | quota-monitor.yml (Python) | — | — | **不使用** |
 
@@ -73,8 +93,8 @@ curl -s -o /dev/null -w "%{http_code}" \
 | **PS#5** | on-call バグ修正 | GitHub Copilot + GitHub MCP |
 | **PS#6** | horse_racing / バッチ | cron-batch.yml (Claude不要) ✅ |
 | **WEB版** | Issue起票 | GitHub MCP のみ (元々Claude不要) ✅ |
-| **Codex#1** | 横断調査 / 修正PR / SQL・migrationレビュー補助 | `.claude/worktrees/instance-codex1` で継続 ✅ |
-| **Codex#2** | CI / 同期 / 運用 / EF・GHA補助 | `.claude/worktrees/instance-codex2` で継続 ✅ |
+| **Codex #1** | 横断調査 / 修正PR / SQL・migrationレビュー補助 / CI / 同期 / 運用 / EF・GHA補助 | Codex Windows app worktree で継続 ✅ |
+| **Codex #2** | historical only | 2026-05 two-instance policy: do not start; work is absorbed by Codex #1 |
 
 **✅ = Claude quota枯渇でも自動継続**
 

--- a/scripts/check_ai_tool_update_routing.py
+++ b/scripts/check_ai_tool_update_routing.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Check #1787 AI-tool routing docs for the two-instance policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_MARKERS: dict[str, tuple[str, ...]] = {
+    "docs/AI_FALLBACK_RUNBOOK.md": (
+        "#1787 2026-05 AI Tool Routing Update",
+        "Claude Code #1 reviews adoption risk",
+        "Codex #1 owns scoped implementation",
+        "Codex #2 and Codex #3 stay historical",
+        "docs/ai-tool-changelog/2026-05.md",
+        ".github/agents/README.md",
+    ),
+    "docs/DEV_PROCESS_MULTI_AI.md": (
+        "#1787 Current Two-Instance Routing Update",
+        "Live owners: Claude Code #1 and Codex #1 only.",
+        "Codex #1 absorbs the old Codex #2 implementation lane",
+        "Do not start old Codex #2/#3",
+    ),
+    ".github/agents/README.md": (
+        "# Copilot Custom Agents Design",
+        "advisory only",
+        "Claude Code #1 owns adoption decisions",
+        "Codex #1 owns scoped implementation PRs",
+        "must not merge, deploy, write production data",
+    ),
+}
+
+
+def missing_markers(root: Path = ROOT) -> list[str]:
+    missing: list[str] = []
+    for relative_path, markers in REQUIRED_MARKERS.items():
+        path = root / relative_path
+        if not path.exists():
+            missing.append(f"{relative_path}: missing file")
+            continue
+        text = path.read_text(encoding="utf-8")
+        for marker in markers:
+            if marker not in text:
+                missing.append(f"{relative_path}: missing marker {marker!r}")
+    return missing
+
+
+def main() -> int:
+    missing = missing_markers()
+    if missing:
+        for item in missing:
+            print(item)
+        return 1
+    print("#1787 AI-tool routing docs: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_ai_tool_update_routing_test.py
+++ b/scripts/check_ai_tool_update_routing_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_ai_tool_update_routing import REQUIRED_MARKERS, missing_markers
+
+
+class AiToolUpdateRoutingTest(unittest.TestCase):
+    def test_repo_docs_include_required_markers(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+
+        self.assertEqual(missing_markers(root), [])
+
+    def test_missing_file_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = missing_markers(Path(tmp))
+
+        self.assertTrue(any("missing file" in item for item in missing))
+
+    def test_contract_tracks_all_three_docs(self) -> None:
+        self.assertEqual(
+            set(REQUIRED_MARKERS),
+            {
+                "docs/AI_FALLBACK_RUNBOOK.md",
+                "docs/DEV_PROCESS_MULTI_AI.md",
+                ".github/agents/README.md",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -49,6 +49,10 @@ def base_commands() -> list[GateCommand]:
             [python, "scripts/check_codex_ui_qa_playbook_test.py"],
         ),
         GateCommand(
+            "ai tool update routing tests",
+            [python, "scripts/check_ai_tool_update_routing_test.py"],
+        ),
+        GateCommand(
             "dynamic context injection tests",
             [python, "scripts/context_injection_check_test.py"],
         ),


### PR DESCRIPTION
﻿## Summary
- Update the AI fallback runbook with the #1787 May 2026 AI-tool routing policy under the current Claude Code #1 + Codex #1 model.
- Refresh the multi-AI routing matrix so old Codex #2 CI/GHA/Edge ownership is explicitly absorbed by Codex #1.
- Add a design-only `.github/agents/README.md` for future Copilot Custom Agents and a deterministic routing-doc check wired into `quality_gate.py`.

## Validation
- `python scripts/check_ai_tool_update_routing.py`
- `python scripts/check_ai_tool_update_routing_test.py`
- `python -m py_compile scripts/check_ai_tool_update_routing.py scripts/check_ai_tool_update_routing_test.py scripts/quality_gate.py`
- `python scripts/quality_gate.py --list | Select-String -Pattern "ai tool update routing|flutter analyze|deno lint"`
- `git diff --check`

## Minimal E2E Gate
- Implementation-detail independent: this is a docs/script routing update with no app-code behavior change.
- Minimal plan: three cases are enough here: routing-doc contract passes, routing-doc unittest passes, and public Playwright E2E smoke remains the CI mechanism.
- E2E-Exception: no new integration_test or test/e2e file is needed because no application runtime surface changed; the existing Playwright public smoke still verifies deployment health.

## Notes
- Refs #1787. This is the Codex #1 scoped routing/docs slice; it does not activate extra instances or side-effecting Copilot agents.
- Local full Flutter/Deno quality gate was intentionally left to GitHub checks because this docs/script slice ran with low local C: free space and no runtime code changes.
