### PR TITLE
ci: route NotebookLM session ops (#1638)

### DIFF
--- a/.github/workflows/notebooklm-session-ops-routes.yml
+++ b/.github/workflows/notebooklm-session-ops-routes.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate NotebookLM session-ops routes
         run: python scripts/check_notebooklm_session_ops_routes.py

--- a/.github/workflows/notebooklm-session-ops-routes.yml
+++ b/.github/workflows/notebooklm-session-ops-routes.yml
@@ -1,0 +1,23 @@
+name: NotebookLM Session Ops Routes
+
+on:
+  pull_request:
+    paths:
+      - "config/notebooklm-session-ops-routes.json"
+      - "docs/NOTEBOOKLM_SESSION_OPS_ROUTING.md"
+      - "docs/notebooklm-intake/**"
+      - "docs/ai-tool-watch/**"
+      - "scripts/check_notebooklm_session_ops_routes.py"
+      - ".github/workflows/notebooklm-session-ops-routes.yml"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate NotebookLM session-ops routes
+        run: python scripts/check_notebooklm_session_ops_routes.py

--- a/config/notebooklm-session-ops-routes.json
+++ b/config/notebooklm-session-ops-routes.json
@@ -1,0 +1,473 @@
+{
+  "schemaVersion": 1,
+  "issue": 1638,
+  "status": "active",
+  "lastReviewed": "2026-05-14",
+  "latestNotebooklmReport": "docs/notebooklm-intake/latest-report.md",
+  "latestAiToolWatchReport": "docs/ai-tool-watch/latest-report.md",
+  "ownerModel": {
+    "activeInstances": [
+      "Claude Code #1",
+      "Codex #1"
+    ],
+    "designOwner": "Claude Code #1",
+    "implementationOwner": "Codex #1",
+    "externalMemoryOwner": "NotebookLM",
+    "notes": "Legacy Codex #2/#3 lanes are dormant; any implementation lane is absorbed by Codex #1 under the two-instance policy."
+  },
+  "verificationPolicy": {
+    "notebooklmIsAdvisory": true,
+    "requireOfficialOrAiToolWatchEvidence": true,
+    "forbidRawNotebooklmDump": true,
+    "requireExistingIssueOrRepoLanding": true,
+    "allowedLandingTypes": [
+      "config",
+      "docs",
+      "issue",
+      "script",
+      "workflow"
+    ]
+  },
+  "routes": [
+    {
+      "shortId": "1aced136",
+      "title": "Claude Code Masterclass: From Foundations to Agentic Workflows",
+      "routeId": "agentic-session-workflow",
+      "disposition": "adopt-with-gate",
+      "owner": "Claude Code #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Claude Code changelog"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "hooks"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/CLAUDE_CODE_MASTERCLASS_AGENTIC_WORKFLOW.md"
+        },
+        {
+          "type": "docs",
+          "path": "docs/DEV_PROCESS_MULTI_AI.md"
+        },
+        {
+          "type": "config",
+          "path": "config/context-injection-map.json"
+        },
+        {
+          "type": "issue",
+          "issue": 1638
+        }
+      ],
+      "nextAction": "Use the two-instance routing rules before turning masterclass workflow advice into hooks, CI, or WBS changes."
+    },
+    {
+      "shortId": "9b8885ef",
+      "title": "Automating SaaS Operations with Claude Code Schedule",
+      "routeId": "schedule-automation-proof",
+      "disposition": "adopt-with-gate",
+      "owner": "Codex #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Claude Code GitHub Actions"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "schedule"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/SCHEDULE_TASKS.md"
+        },
+        {
+          "type": "workflow",
+          "path": ".github/workflows/schedule-resilience-watch.yml"
+        },
+        {
+          "type": "issue",
+          "issue": 1783
+        },
+        {
+          "type": "issue",
+          "issue": 1638
+        }
+      ],
+      "nextAction": "Prefer deterministic GitHub Actions proof before adopting any NotebookLM-derived schedule behavior."
+    },
+    {
+      "shortId": "ed1aac00",
+      "title": "Mastering Claude: A Guide to Intelligent Collaboration",
+      "routeId": "collaboration-operating-model",
+      "disposition": "route-only",
+      "owner": "Claude Code #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Claude Code changelog"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "integration"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/AI_FLEET_SYNERGY_PLAYBOOK.md"
+        },
+        {
+          "type": "docs",
+          "path": "docs/FLEET_2_INSTANCE_TRANSITION.md"
+        },
+        {
+          "type": "docs",
+          "path": "docs/WBS_2_INSTANCE_ROUTING.md"
+        },
+        {
+          "type": "issue",
+          "issue": 1638
+        }
+      ],
+      "nextAction": "Keep collaboration guidance as routing context unless a future official signal creates a narrow implementation task."
+    },
+    {
+      "shortId": "d89ae1f5",
+      "title": "Building Long-Term Memory for Claude Code: claude-mem vs. DIY Hooks",
+      "routeId": "memory-and-hook-state",
+      "disposition": "adopt-with-gate",
+      "owner": "Claude Code #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Claude Code hooks reference"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "hooks"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/CODEX_MEMORY_AUTOMATIONS.md"
+        },
+        {
+          "type": "docs",
+          "path": "docs/PRECOMPACT_MEMORY_BACKUP_SPEC.md"
+        },
+        {
+          "type": "script",
+          "path": "scripts/codex_session_check.py"
+        },
+        {
+          "type": "issue",
+          "issue": 1564
+        },
+        {
+          "type": "issue",
+          "issue": 1647
+        }
+      ],
+      "nextAction": "Treat memory advice as hook or session-check work only after it can be validated by repo checks."
+    },
+    {
+      "shortId": "b74e9ada",
+      "title": "Code with Claude Opening Keynote",
+      "routeId": "official-keynote-triage",
+      "disposition": "route-only",
+      "owner": "Claude Code #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Claude Code changelog"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "codex-runtime"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/AI_FLEET_SYNERGY_PLAYBOOK.md"
+        },
+        {
+          "type": "docs",
+          "path": "docs/CODEX_UI_QA_PLAYBOOK.md"
+        },
+        {
+          "type": "issue",
+          "issue": 1646
+        },
+        {
+          "type": "issue",
+          "issue": 1787
+        }
+      ],
+      "nextAction": "Adopt only claims that appear in official changelogs or the AI Tool Watch report."
+    },
+    {
+      "shortId": "64fc639e",
+      "title": "Automating Technical Blogs with Claude Code and Supabase Edge Functions",
+      "routeId": "blog-news-automation",
+      "disposition": "adopt-with-gate",
+      "owner": "Codex #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Claude Code GitHub Actions"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "schedule"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/BLOG_NEWS_AUTOMATION_RUNBOOK.md"
+        },
+        {
+          "type": "workflow",
+          "path": ".github/workflows/blog-news-prod-smoke.yml"
+        },
+        {
+          "type": "issue",
+          "issue": 1950
+        },
+        {
+          "type": "issue",
+          "issue": 1638
+        }
+      ],
+      "nextAction": "Route blog automation changes through smoke-proofed workflows before any external publish step."
+    },
+    {
+      "shortId": "f0895eb0",
+      "title": "Claude Code Remote Control Guide",
+      "routeId": "remote-control-state-check",
+      "disposition": "manual-or-verify-only",
+      "owner": "Claude Code #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Claude Code changelog"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "integration"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/INSTANCE_CONFIG.md"
+        },
+        {
+          "type": "script",
+          "path": "scripts/codex_session_check.py"
+        },
+        {
+          "type": "issue",
+          "issue": 1962
+        },
+        {
+          "type": "issue",
+          "issue": 1638
+        }
+      ],
+      "nextAction": "Keep Remote Control as a local verification/manual setting; never infer it from NotebookLM alone."
+    },
+    {
+      "shortId": "52daba63",
+      "title": "Claude Code: The Agentic Future of Terminal Programming",
+      "routeId": "terminal-agent-boundary",
+      "disposition": "route-only",
+      "owner": "Claude Code #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Codex overview"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "codex-runtime"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/CODEX_WORKFLOW.md"
+        },
+        {
+          "type": "docs",
+          "path": "docs/AGENT_TOOL_POLICY.md"
+        },
+        {
+          "type": "config",
+          "path": "config/managed-mcp.json"
+        },
+        {
+          "type": "issue",
+          "issue": 1638
+        }
+      ],
+      "nextAction": "Use repo tool policy and worktree isolation as the boundary before terminal-agent workflow changes."
+    },
+    {
+      "shortId": "c3b1d9f2",
+      "title": "Claude API Cost Optimization Strategies",
+      "routeId": "quality-cost-controls",
+      "disposition": "adopt-with-gate",
+      "owner": "Codex #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Claude Code changelog"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "quality-cost"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/AI_FALLBACK_RUNBOOK.md"
+        },
+        {
+          "type": "docs",
+          "path": "docs/AGENT_TOOL_POLICY.md"
+        },
+        {
+          "type": "issue",
+          "issue": 1638
+        }
+      ],
+      "nextAction": "Convert cost advice into budget or fallback checks only when official source evidence is present."
+    },
+    {
+      "shortId": "9871b0b1",
+      "title": "Claude Code and Obsidian: Building Your AI Second Brain",
+      "routeId": "second-brain-memory-consolidation",
+      "disposition": "adopt-with-gate",
+      "owner": "Claude Code #1",
+      "implementationOwner": "Codex #1",
+      "verifiedBy": [
+        {
+          "type": "notebooklm-report",
+          "path": "docs/notebooklm-intake/latest-report.md",
+          "issue": 1638
+        },
+        {
+          "type": "official-source-signal",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "source": "Claude Code hooks reference"
+        },
+        {
+          "type": "ai-tool-watch-group",
+          "path": "docs/ai-tool-watch/latest-report.md",
+          "group": "integration"
+        }
+      ],
+      "landingTargets": [
+        {
+          "type": "docs",
+          "path": "docs/SECOND_BRAIN_PRINCIPLES.md"
+        },
+        {
+          "type": "docs",
+          "path": "docs/OBSIDIAN_INGEST_PIPELINE.md"
+        },
+        {
+          "type": "docs",
+          "path": "docs/NOTEBOOKLM_GUIDE.md"
+        },
+        {
+          "type": "issue",
+          "issue": 1638
+        }
+      ],
+      "nextAction": "Use Second Brain content as memory consolidation context, not as an unreviewed source of implementation facts."
+    }
+  ]
+}

--- a/docs/NOTEBOOKLM_SESSION_OPS_ROUTING.md
+++ b/docs/NOTEBOOKLM_SESSION_OPS_ROUTING.md
@@ -1,0 +1,67 @@
+# NotebookLM Session-Ops Routing
+
+Issue: #1638
+
+This runbook keeps Claude Code operations notebooks useful without letting
+NotebookLM become an unreviewed source of implementation facts.
+
+## Operating Rule
+
+NotebookLM is advisory memory. A NotebookLM item can influence repo work only
+when it is connected to at least one of these:
+
+- an official source signal captured by `docs/ai-tool-watch/latest-report.md`
+- an AI Tool Watch routing group such as `hooks`, `schedule`, or `quality-cost`
+- an existing GitHub Issue, repo doc, hook, script, config, or workflow
+
+The current route manifest is:
+
+- `config/notebooklm-session-ops-routes.json`
+
+The validation command is:
+
+```powershell
+python scripts/check_notebooklm_session_ops_routes.py
+```
+
+## Two-Instance Boundary
+
+Active development lanes are only:
+
+- Claude Code #1: ambiguous design, review policy, architecture, and local
+  Claude settings that require interactive confirmation.
+- Codex #1: scoped implementation, CI proof, repo config, docs, scripts, and
+  GitHub Actions checks.
+
+Old Codex #2/#3 lanes must stay dormant. If an old NotebookLM route mentions a
+legacy lane, Codex #1 absorbs the implementation side and records the active
+two-instance owner in the manifest.
+
+## Route Groups
+
+The manifest maps session-ops notebooks into concrete repo surfaces:
+
+- agentic workflow: `docs/CLAUDE_CODE_MASTERCLASS_AGENTIC_WORKFLOW.md`,
+  `docs/DEV_PROCESS_MULTI_AI.md`, and `config/context-injection-map.json`
+- schedule automation: `docs/SCHEDULE_TASKS.md` and
+  `.github/workflows/schedule-resilience-watch.yml`
+- memory and hooks: `docs/CODEX_MEMORY_AUTOMATIONS.md`,
+  `docs/PRECOMPACT_MEMORY_BACKUP_SPEC.md`, and `scripts/codex_session_check.py`
+- Remote Control: `docs/INSTANCE_CONFIG.md` and
+  `scripts/codex_session_check.py`
+- blog/news automation: `docs/BLOG_NEWS_AUTOMATION_RUNBOOK.md` and
+  `.github/workflows/blog-news-prod-smoke.yml`
+- Second Brain: `docs/SECOND_BRAIN_PRINCIPLES.md`,
+  `docs/OBSIDIAN_INGEST_PIPELINE.md`, and `docs/NOTEBOOKLM_GUIDE.md`
+- cost controls: `docs/AI_FALLBACK_RUNBOOK.md` and
+  `docs/AGENT_TOOL_POLICY.md`
+
+## Session Checklist
+
+1. Read `docs/notebooklm-intake/latest-report.md`.
+2. Confirm the item is routed to an existing Issue or has an explicit skip.
+3. Read `docs/ai-tool-watch/latest-report.md` for official source signals.
+4. Update the manifest only when the target doc/config/workflow exists.
+5. Run `python scripts/check_notebooklm_session_ops_routes.py`.
+6. Put the PR through normal CI and keep #1638 open unless every route has
+   shipped and any local Claude settings are manually verified.

--- a/docs/notebooklm-intake/README.md
+++ b/docs/notebooklm-intake/README.md
@@ -26,3 +26,13 @@ The gate writes:
 NotebookLM is an external memory source. Claims from NotebookLM should route
 work, but implementation still needs repository checks, official or primary
 source verification, and GitHub Actions proof.
+
+## Claude Code Session-Ops Routes
+
+For #1638 Claude Code operations notebooks, use
+`config/notebooklm-session-ops-routes.json` and
+`docs/NOTEBOOKLM_SESSION_OPS_ROUTING.md`. The guard command is:
+
+```powershell
+python scripts/check_notebooklm_session_ops_routes.py
+```

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -836,14 +836,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -928,18 +920,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1533,26 +1525,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   time:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -836,6 +836,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -920,18 +928,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1525,26 +1533,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/scripts/check_notebooklm_session_ops_routes.py
+++ b/scripts/check_notebooklm_session_ops_routes.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Validate the #1638 NotebookLM session-ops route manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CONFIG_PATH = Path("config/notebooklm-session-ops-routes.json")
+NOTEBOOKLM_REPORT_PATH = Path("docs/notebooklm-intake/latest-report.md")
+AI_TOOL_REPORT_PATH = Path("docs/ai-tool-watch/latest-report.md")
+ISSUE_NUMBER = 1638
+ACTIVE_INSTANCES = ["Claude Code #1", "Codex #1"]
+REQUIRED_SHORT_IDS = {
+    "1aced136",
+    "9b8885ef",
+    "ed1aac00",
+    "d89ae1f5",
+    "b74e9ada",
+    "64fc639e",
+    "f0895eb0",
+    "52daba63",
+    "c3b1d9f2",
+    "9871b0b1",
+}
+ALLOWED_OWNERS = {"Claude Code #1", "Codex #1", "Automation", "User"}
+ALLOWED_LANDING_TYPES = {"config", "docs", "issue", "script", "workflow"}
+REQUIRED_AI_TOOL_GROUPS = {
+    "codex-runtime",
+    "hooks",
+    "integration",
+    "quality-cost",
+    "schedule",
+}
+REQUIRED_OFFICIAL_SOURCES = {
+    "Claude Code changelog",
+    "Claude Code hooks reference",
+    "Claude Code GitHub Actions",
+    "Codex overview",
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8-sig")
+
+
+def validate_path(root: Path, raw_path: str, *, failures: list[str], context: str) -> None:
+    path = Path(raw_path)
+    if path.is_absolute():
+        failures.append(f"{context}: path must be repo-relative: {raw_path}")
+        return
+    if not (root / path).exists():
+        failures.append(f"{context}: missing repo path: {raw_path}")
+
+
+def evidence_types(route: dict[str, Any]) -> set[str]:
+    return {str(item.get("type", "")) for item in route.get("verifiedBy", []) if isinstance(item, dict)}
+
+
+def route_landing_types(route: dict[str, Any]) -> set[str]:
+    return {
+        str(item.get("type", ""))
+        for item in route.get("landingTargets", [])
+        if isinstance(item, dict)
+    }
+
+
+def validate_config(root: Path, config: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if config.get("schemaVersion") != 1:
+        failures.append("schemaVersion must be 1")
+    if config.get("issue") != ISSUE_NUMBER:
+        failures.append(f"issue must be {ISSUE_NUMBER}")
+    if config.get("status") != "active":
+        failures.append("status must be active")
+
+    owner = config.get("ownerModel", {})
+    if not isinstance(owner, dict):
+        failures.append("ownerModel must be an object")
+    else:
+        if owner.get("activeInstances") != ACTIVE_INSTANCES:
+            failures.append("ownerModel.activeInstances must be Claude Code #1 + Codex #1")
+        if owner.get("implementationOwner") != "Codex #1":
+            failures.append("ownerModel.implementationOwner must be Codex #1")
+        active_instances = owner.get("activeInstances", [])
+        if any(instance in active_instances for instance in ["Codex #2", "Codex #3"]):
+            failures.append("ownerModel must not activate old Codex #2/#3 lanes")
+
+    policy = config.get("verificationPolicy", {})
+    if not isinstance(policy, dict):
+        failures.append("verificationPolicy must be an object")
+    else:
+        if not policy.get("notebooklmIsAdvisory"):
+            failures.append("verificationPolicy.notebooklmIsAdvisory must be true")
+        if not policy.get("requireOfficialOrAiToolWatchEvidence"):
+            failures.append("verificationPolicy.requireOfficialOrAiToolWatchEvidence must be true")
+        if not policy.get("forbidRawNotebooklmDump"):
+            failures.append("verificationPolicy.forbidRawNotebooklmDump must be true")
+        allowed = set(policy.get("allowedLandingTypes", []))
+        if allowed != ALLOWED_LANDING_TYPES:
+            failures.append(
+                "verificationPolicy.allowedLandingTypes must match the approved landing types"
+            )
+
+    for field in ("latestNotebooklmReport", "latestAiToolWatchReport"):
+        value = str(config.get(field, ""))
+        if not value:
+            failures.append(f"{field} is required")
+        else:
+            validate_path(root, value, failures=failures, context=field)
+
+    routes = config.get("routes", [])
+    if not isinstance(routes, list) or not routes:
+        failures.append("routes must be a non-empty list")
+        return failures
+
+    route_ids = set()
+    short_ids = set()
+    for index, route in enumerate(routes):
+        context = f"routes[{index}]"
+        if not isinstance(route, dict):
+            failures.append(f"{context}: route must be an object")
+            continue
+        short_id = str(route.get("shortId", "")).strip()
+        route_id = str(route.get("routeId", "")).strip()
+        if not short_id:
+            failures.append(f"{context}: shortId is required")
+        if not route_id:
+            failures.append(f"{context}: routeId is required")
+        if route_id in route_ids:
+            failures.append(f"{context}: duplicate routeId {route_id}")
+        route_ids.add(route_id)
+        if short_id in short_ids:
+            failures.append(f"{context}: duplicate shortId {short_id}")
+        short_ids.add(short_id)
+
+        if route.get("owner") not in ALLOWED_OWNERS:
+            failures.append(f"{context}: owner must be one of {sorted(ALLOWED_OWNERS)}")
+        if route.get("implementationOwner") != "Codex #1":
+            failures.append(f"{context}: implementationOwner must be Codex #1")
+        if any(owner in str(route) for owner in ["Codex #2", "Codex #3"]):
+            failures.append(f"{context}: old Codex #2/#3 lanes must not be active")
+        if not str(route.get("title", "")).strip():
+            failures.append(f"{context}: title is required")
+        if not str(route.get("nextAction", "")).strip():
+            failures.append(f"{context}: nextAction is required")
+
+        evidence = route.get("verifiedBy", [])
+        if not isinstance(evidence, list) or not evidence:
+            failures.append(f"{context}: verifiedBy must be a non-empty list")
+        else:
+            kinds = evidence_types(route)
+            if "notebooklm-report" not in kinds:
+                failures.append(f"{context}: verifiedBy must include notebooklm-report")
+            if not ({"official-source-signal", "ai-tool-watch-group"} & kinds):
+                failures.append(
+                    f"{context}: verifiedBy must include official source or AI Tool Watch evidence"
+                )
+            for evidence_index, item in enumerate(evidence):
+                if not isinstance(item, dict):
+                    failures.append(f"{context}.verifiedBy[{evidence_index}]: must be an object")
+                    continue
+                path = item.get("path")
+                if path:
+                    validate_path(
+                        root,
+                        str(path),
+                        failures=failures,
+                        context=f"{context}.verifiedBy[{evidence_index}]",
+                    )
+
+        targets = route.get("landingTargets", [])
+        if not isinstance(targets, list) or not targets:
+            failures.append(f"{context}: landingTargets must be a non-empty list")
+        else:
+            target_types = route_landing_types(route)
+            if not target_types <= ALLOWED_LANDING_TYPES:
+                failures.append(f"{context}: unknown landing target type {sorted(target_types)}")
+            if not target_types:
+                failures.append(f"{context}: at least one landing target is required")
+            for target_index, item in enumerate(targets):
+                if not isinstance(item, dict):
+                    failures.append(f"{context}.landingTargets[{target_index}]: must be an object")
+                    continue
+                target_type = str(item.get("type", ""))
+                if target_type in {"config", "docs", "script", "workflow"}:
+                    path = item.get("path")
+                    if not path:
+                        failures.append(
+                            f"{context}.landingTargets[{target_index}]: path is required"
+                        )
+                    else:
+                        validate_path(
+                            root,
+                            str(path),
+                            failures=failures,
+                            context=f"{context}.landingTargets[{target_index}]",
+                        )
+                if target_type == "issue":
+                    issue = item.get("issue")
+                    if not isinstance(issue, int) or issue <= 0:
+                        failures.append(
+                            f"{context}.landingTargets[{target_index}]: issue must be a positive integer"
+                        )
+
+    missing = sorted(REQUIRED_SHORT_IDS - short_ids)
+    if missing:
+        failures.append(f"missing required #1638 NotebookLM routes: {', '.join(missing)}")
+    return failures
+
+
+def validate_reports(root: Path, config: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    notebook_report = read_text(root / NOTEBOOKLM_REPORT_PATH)
+    ai_tool_report = read_text(root / AI_TOOL_REPORT_PATH)
+
+    for short_id in REQUIRED_SHORT_IDS:
+        if short_id not in notebook_report and short_id not in json.dumps(config):
+            failures.append(f"NotebookLM route short id missing from report/config: {short_id}")
+    if "#1638" not in notebook_report:
+        failures.append("NotebookLM latest report must route at least one item to #1638")
+    if "Candidate Issue Drafts" not in notebook_report or "- None." not in notebook_report:
+        failures.append("NotebookLM latest report must show no candidate issue drafts")
+
+    for group in REQUIRED_AI_TOOL_GROUPS:
+        if group not in ai_tool_report:
+            failures.append(f"AI Tool Watch report missing routing group: {group}")
+    for source in REQUIRED_OFFICIAL_SOURCES:
+        if source not in ai_tool_report:
+            failures.append(f"AI Tool Watch report missing official source signal: {source}")
+    if "Claude Code #1" not in ai_tool_report or "Codex #1" not in ai_tool_report:
+        failures.append("AI Tool Watch report must include the two-instance routing reminder")
+    return failures
+
+
+def build_snapshot(root: Path) -> dict[str, Any]:
+    config = load_json(root / CONFIG_PATH)
+    failures = validate_config(root, config)
+    failures.extend(validate_reports(root, config))
+    routes = config.get("routes", [])
+    return {
+        "state": "ok" if not failures else "invalid",
+        "config": str(CONFIG_PATH),
+        "issue": config.get("issue"),
+        "route_count": len(routes) if isinstance(routes, list) else 0,
+        "short_ids": [route.get("shortId") for route in routes if isinstance(route, dict)],
+        "validation_errors": failures,
+    }
+
+
+def render_markdown(snapshot: dict[str, Any]) -> str:
+    lines = [
+        "# NotebookLM Session-Ops Routes Check",
+        "",
+        f"- State: `{snapshot['state']}`",
+        f"- Config: `{snapshot['config']}`",
+        f"- Issue: `#{snapshot['issue']}`",
+        f"- Routes: `{snapshot['route_count']}`",
+        f"- Short IDs: `{', '.join(snapshot['short_ids'])}`",
+        "",
+        "## Validation",
+    ]
+    if snapshot["validation_errors"]:
+        for error in snapshot["validation_errors"]:
+            lines.append(f"- {error}")
+    else:
+        lines.append("- All #1638 NotebookLM session-ops routes are verified and landed.")
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print JSON instead of Markdown.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    args = parse_args(argv)
+    snapshot = build_snapshot(repo_root())
+    if args.json:
+        print(json.dumps(snapshot, ensure_ascii=False, indent=2))
+    else:
+        print(render_markdown(snapshot))
+    return 0 if snapshot["state"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- add a #1638 NotebookLM session-ops route manifest for the two-instance policy
- add a checker and PR workflow so NotebookLM routes must have AI Tool Watch / official-source evidence plus repo landing targets
- document the session checklist for resuming Claude Code operations notebooks from `latest-report.md`

## Minimal E2E Gate

- Implementation-detail independent black-box plan: validate route manifests from repository inputs and checker output, not UI internals.
- Minimal 3 cases: valid manifest passes; missing official-source evidence fails; missing repo landing target fails.
- E2E mechanism: no Playwright or Flutter integration_test file is added because this PR changes docs/config/script/workflow guardrails only.
- E2E-Exception: No application UI or runtime route changed; the Python checker plus PR workflow is the appropriate proof for this slice.

## Validation

- `python scripts/check_notebooklm_session_ops_routes.py`
- `python scripts/check_notebooklm_session_ops_routes.py --json`
- `python -m json.tool config/notebooklm-session-ops-routes.json`
- `python -m py_compile scripts/check_notebooklm_session_ops_routes.py`
- `python scripts/check_github_actions_node_runtime.py`
- `git diff --check`

Closes #1638