### PR TITLE
[codex] Add Supabase persistence foundation for asset liability board

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -1,0 +1,507 @@
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+
+/// Supabase persistence draft for the asset/liability board.
+///
+/// Proposed tables:
+/// - asset_liability_monthly_states
+///   - user_id uuid not null
+///   - month_key text not null
+///   - payment_overrides jsonb not null default '{}'
+///   - paid_account_ids jsonb not null default '[]'
+///   - payment_source_account_ids jsonb not null default '{}'
+///   - income_plans jsonb not null default '[]'
+///   - created_at timestamptz not null default now()
+///   - updated_at timestamptz not null default now()
+///   - primary key (user_id, month_key)
+/// - asset_liability_user_settings
+///   - user_id uuid primary key
+///   - default_payment_source_account_ids jsonb not null default '{}'
+///   - recurring_income_templates jsonb not null default '[]'
+///   - created_at timestamptz not null default now()
+///   - updated_at timestamptz not null default now()
+/// - asset_liability_monthly_snapshots
+///   - user_id uuid not null
+///   - month_key text not null
+///   - saved_at timestamptz not null
+///   - positive_asset_total numeric not null
+///   - liability_total numeric not null
+///   - net_worth numeric not null
+///   - cash_like_total numeric not null
+///   - monthly_scheduled_payment_total numeric not null
+///   - monthly_paid_payment_total numeric not null
+///   - monthly_unpaid_payment_total numeric not null
+///   - overdue_payment_count integer not null
+///   - created_at timestamptz not null default now()
+///   - updated_at timestamptz not null default now()
+///   - primary key (user_id, month_key)
+class AssetLiabilitySupabaseTablePlan {
+  static const String monthlyStatesTable = 'asset_liability_monthly_states';
+  static const String userSettingsTable = 'asset_liability_user_settings';
+  static const String monthlySnapshotsTable =
+      'asset_liability_monthly_snapshots';
+
+  static const List<String> monthlyStateColumns = <String>[
+    'user_id',
+    'month_key',
+    'payment_overrides',
+    'paid_account_ids',
+    'payment_source_account_ids',
+    'income_plans',
+    'created_at',
+    'updated_at',
+  ];
+
+  static const List<String> userSettingsColumns = <String>[
+    'user_id',
+    'default_payment_source_account_ids',
+    'recurring_income_templates',
+    'created_at',
+    'updated_at',
+  ];
+
+  static const List<String> monthlySnapshotColumns = <String>[
+    'user_id',
+    'month_key',
+    'saved_at',
+    'positive_asset_total',
+    'liability_total',
+    'net_worth',
+    'cash_like_total',
+    'monthly_scheduled_payment_total',
+    'monthly_paid_payment_total',
+    'monthly_unpaid_payment_total',
+    'overdue_payment_count',
+    'created_at',
+    'updated_at',
+  ];
+
+  const AssetLiabilitySupabaseTablePlan._();
+}
+
+class AssetLiabilityPersistenceSnapshot {
+  final String monthKey;
+  final AssetLiabilityMonthlyState monthlyState;
+  final Map<String, String> defaultPaymentSourceAccountIds;
+  final List<AssetLiabilityRecurringIncomeTemplate> recurringIncomeTemplates;
+  final List<AssetLiabilityMonthlySnapshot> monthlySnapshots;
+
+  const AssetLiabilityPersistenceSnapshot({
+    required this.monthKey,
+    required this.monthlyState,
+    required this.defaultPaymentSourceAccountIds,
+    required this.recurringIncomeTemplates,
+    required this.monthlySnapshots,
+  });
+}
+
+class AssetLiabilityMonthlyStatePayload {
+  final String monthKey;
+  final Map<String, double> paymentOverrides;
+  final Set<String> paidAccountIds;
+  final Map<String, String> paymentSourceAccountIds;
+  final List<AssetLiabilityIncomePlan> incomePlans;
+
+  const AssetLiabilityMonthlyStatePayload({
+    required this.monthKey,
+    required this.paymentOverrides,
+    required this.paidAccountIds,
+    required this.paymentSourceAccountIds,
+    required this.incomePlans,
+  });
+
+  factory AssetLiabilityMonthlyStatePayload.fromState({
+    required String monthKey,
+    required AssetLiabilityMonthlyState state,
+  }) {
+    return AssetLiabilityMonthlyStatePayload(
+      monthKey: monthKey,
+      paymentOverrides: Map<String, double>.from(state.paymentOverrides),
+      paidAccountIds: Set<String>.from(state.paidAccountNames),
+      paymentSourceAccountIds: Map<String, String>.from(
+        state.paymentSourceAccountIds,
+      ),
+      incomePlans: List<AssetLiabilityIncomePlan>.from(state.incomePlans),
+    );
+  }
+
+  factory AssetLiabilityMonthlyStatePayload.fromSupabaseJson(
+    Map<String, Object?> json,
+  ) {
+    final monthKey =
+        _readString(json, 'month_key') ?? _readString(json, 'monthKey') ?? '';
+    return AssetLiabilityMonthlyStatePayload(
+      monthKey: monthKey,
+      paymentOverrides: _readDoubleMap(json, 'payment_overrides') ??
+          _readDoubleMap(json, 'paymentOverrides') ??
+          const <String, double>{},
+      paidAccountIds: _readStringSet(json, 'paid_account_ids') ??
+          _readStringSet(json, 'paidAccountIds') ??
+          const <String>{},
+      paymentSourceAccountIds:
+          _readStringMap(json, 'payment_source_account_ids') ??
+              _readStringMap(json, 'paymentSourceAccountIds') ??
+              const <String, String>{},
+      incomePlans: _readIncomePlans(json, 'income_plans') ??
+          _readIncomePlans(json, 'incomePlans') ??
+          const <AssetLiabilityIncomePlan>[],
+    );
+  }
+
+  AssetLiabilityMonthlyState toState() {
+    return AssetLiabilityMonthlyState(
+      paymentOverrides: Map<String, double>.from(paymentOverrides),
+      paidAccountNames: Set<String>.from(paidAccountIds),
+      paymentSourceAccountIds: Map<String, String>.from(
+        paymentSourceAccountIds,
+      ),
+      incomePlans: List<AssetLiabilityIncomePlan>.from(incomePlans),
+    );
+  }
+
+  Map<String, Object?> toSupabaseJson({
+    required String userId,
+    DateTime? updatedAt,
+  }) {
+    final timestamp = updatedAt?.toUtc().toIso8601String();
+    return <String, Object?>{
+      'user_id': userId,
+      'month_key': monthKey,
+      'payment_overrides': Map<String, double>.from(paymentOverrides),
+      'paid_account_ids': (paidAccountIds.toList()..sort()),
+      'payment_source_account_ids': Map<String, String>.from(
+        paymentSourceAccountIds,
+      ),
+      'income_plans': [for (final plan in incomePlans) _encodeIncomePlan(plan)],
+      if (timestamp != null) 'updated_at': timestamp,
+    };
+  }
+}
+
+class AssetLiabilityUserSettingsPayload {
+  final Map<String, String> defaultPaymentSourceAccountIds;
+  final List<AssetLiabilityRecurringIncomeTemplate> recurringIncomeTemplates;
+
+  const AssetLiabilityUserSettingsPayload({
+    required this.defaultPaymentSourceAccountIds,
+    required this.recurringIncomeTemplates,
+  });
+
+  factory AssetLiabilityUserSettingsPayload.fromSupabaseJson(
+    Map<String, Object?> json,
+  ) {
+    return AssetLiabilityUserSettingsPayload(
+      defaultPaymentSourceAccountIds:
+          _readStringMap(json, 'default_payment_source_account_ids') ??
+              _readStringMap(json, 'defaultPaymentSourceAccountIds') ??
+              const <String, String>{},
+      recurringIncomeTemplates:
+          _readRecurringIncomeTemplates(json, 'recurring_income_templates') ??
+              _readRecurringIncomeTemplates(json, 'recurringIncomeTemplates') ??
+              const <AssetLiabilityRecurringIncomeTemplate>[],
+    );
+  }
+
+  Map<String, Object?> toSupabaseJson({
+    required String userId,
+    DateTime? updatedAt,
+  }) {
+    final timestamp = updatedAt?.toUtc().toIso8601String();
+    return <String, Object?>{
+      'user_id': userId,
+      'default_payment_source_account_ids': Map<String, String>.from(
+        defaultPaymentSourceAccountIds,
+      ),
+      'recurring_income_templates': [
+        for (final template in recurringIncomeTemplates)
+          _encodeRecurringIncomeTemplate(template),
+      ],
+      if (timestamp != null) 'updated_at': timestamp,
+    };
+  }
+}
+
+class AssetLiabilityMonthlySnapshotPayload {
+  final AssetLiabilityMonthlySnapshot snapshot;
+
+  const AssetLiabilityMonthlySnapshotPayload({required this.snapshot});
+
+  factory AssetLiabilityMonthlySnapshotPayload.fromSupabaseJson(
+    Map<String, Object?> json,
+  ) {
+    final monthKey =
+        _readString(json, 'month_key') ?? _readString(json, 'monthKey') ?? '';
+    final savedAtText =
+        _readString(json, 'saved_at') ?? _readString(json, 'savedAt');
+    final savedAt = DateTime.tryParse(savedAtText ?? '') ?? DateTime(1970);
+    return AssetLiabilityMonthlySnapshotPayload(
+      snapshot: AssetLiabilityMonthlySnapshot(
+        monthKey: monthKey,
+        savedAt: savedAt,
+        positiveAssetTotal: _readDouble(json, 'positive_asset_total') ??
+            _readDouble(json, 'positiveAssetTotal') ??
+            0,
+        liabilityTotal: _readDouble(json, 'liability_total') ??
+            _readDouble(json, 'liabilityTotal') ??
+            0,
+        netWorth: _readDouble(json, 'net_worth') ??
+            _readDouble(json, 'netWorth') ??
+            0,
+        cashLikeTotal: _readDouble(json, 'cash_like_total') ??
+            _readDouble(json, 'cashLikeTotal') ??
+            0,
+        monthlyScheduledPaymentTotal:
+            _readDouble(json, 'monthly_scheduled_payment_total') ??
+                _readDouble(json, 'monthlyScheduledPaymentTotal') ??
+                0,
+        monthlyPaidPaymentTotal:
+            _readDouble(json, 'monthly_paid_payment_total') ??
+                _readDouble(json, 'monthlyPaidPaymentTotal') ??
+                0,
+        monthlyUnpaidPaymentTotal:
+            _readDouble(json, 'monthly_unpaid_payment_total') ??
+                _readDouble(json, 'monthlyUnpaidPaymentTotal') ??
+                0,
+        overduePaymentCount: _readInt(json, 'overdue_payment_count') ??
+            _readInt(json, 'overduePaymentCount') ??
+            0,
+      ),
+    );
+  }
+
+  Map<String, Object?> toSupabaseJson({
+    required String userId,
+    DateTime? updatedAt,
+  }) {
+    final timestamp = updatedAt?.toUtc().toIso8601String();
+    return <String, Object?>{
+      'user_id': userId,
+      'month_key': snapshot.monthKey,
+      'saved_at': snapshot.savedAt.toUtc().toIso8601String(),
+      'positive_asset_total': snapshot.positiveAssetTotal,
+      'liability_total': snapshot.liabilityTotal,
+      'net_worth': snapshot.netWorth,
+      'cash_like_total': snapshot.cashLikeTotal,
+      'monthly_scheduled_payment_total': snapshot.monthlyScheduledPaymentTotal,
+      'monthly_paid_payment_total': snapshot.monthlyPaidPaymentTotal,
+      'monthly_unpaid_payment_total': snapshot.monthlyUnpaidPaymentTotal,
+      'overdue_payment_count': snapshot.overduePaymentCount,
+      if (timestamp != null) 'updated_at': timestamp,
+    };
+  }
+}
+
+Map<String, Object?> _encodeIncomePlan(AssetLiabilityIncomePlan plan) {
+  return <String, Object?>{
+    'id': plan.id,
+    'date': _dateOnly(plan.date),
+    'name': plan.name,
+    'amount': plan.amount,
+    'destinationAccountId': plan.destinationAccountId,
+    'destinationAccountName': plan.destinationAccountName,
+    'received': plan.received,
+  };
+}
+
+Map<String, Object?> _encodeRecurringIncomeTemplate(
+  AssetLiabilityRecurringIncomeTemplate template,
+) {
+  return <String, Object?>{
+    'id': template.id,
+    'dayOfMonth': template.dayOfMonth,
+    'name': template.name,
+    'amount': template.amount,
+    'destinationAccountId': template.destinationAccountId,
+    'destinationAccountName': template.destinationAccountName,
+  };
+}
+
+AssetLiabilityIncomePlan? _decodeIncomePlan(Object? source) {
+  if (source is! Map) {
+    return null;
+  }
+  final id = _cleanString(source['id']);
+  final date = DateTime.tryParse(_cleanString(source['date']) ?? '');
+  final name = _cleanString(source['name']);
+  final amount = _parseDouble(source['amount']);
+  if (id == null ||
+      date == null ||
+      name == null ||
+      amount == null ||
+      amount <= 0) {
+    return null;
+  }
+  return AssetLiabilityIncomePlan(
+    id: id,
+    date: date,
+    name: name,
+    amount: amount,
+    destinationAccountId: _cleanString(source['destinationAccountId']),
+    destinationAccountName: _cleanString(source['destinationAccountName']),
+    received: source['received'] == true,
+  );
+}
+
+AssetLiabilityRecurringIncomeTemplate? _decodeRecurringIncomeTemplate(
+  Object? source,
+) {
+  if (source is! Map) {
+    return null;
+  }
+  final id = _cleanString(source['id']);
+  final name = _cleanString(source['name']);
+  final day = _parseInt(source['dayOfMonth']);
+  final amount = _parseDouble(source['amount']);
+  if (id == null ||
+      name == null ||
+      day == null ||
+      day < 1 ||
+      amount == null ||
+      amount <= 0) {
+    return null;
+  }
+  return AssetLiabilityRecurringIncomeTemplate(
+    id: id,
+    dayOfMonth: day.clamp(1, 31).toInt(),
+    name: name,
+    amount: amount,
+    destinationAccountId: _cleanString(source['destinationAccountId']),
+    destinationAccountName: _cleanString(source['destinationAccountName']),
+  );
+}
+
+List<AssetLiabilityIncomePlan>? _readIncomePlans(
+  Map<String, Object?> json,
+  String key,
+) {
+  final source = json[key];
+  if (source is! Iterable) {
+    return null;
+  }
+  final plans = <AssetLiabilityIncomePlan>[];
+  for (final value in source) {
+    final plan = _decodeIncomePlan(value);
+    if (plan != null) {
+      plans.add(plan);
+    }
+  }
+  plans.sort((a, b) => a.date.compareTo(b.date));
+  return plans;
+}
+
+List<AssetLiabilityRecurringIncomeTemplate>? _readRecurringIncomeTemplates(
+  Map<String, Object?> json,
+  String key,
+) {
+  final source = json[key];
+  if (source is! Iterable) {
+    return null;
+  }
+  final templates = <AssetLiabilityRecurringIncomeTemplate>[];
+  for (final value in source) {
+    final template = _decodeRecurringIncomeTemplate(value);
+    if (template != null) {
+      templates.add(template);
+    }
+  }
+  templates.sort((a, b) {
+    final day = a.dayOfMonth.compareTo(b.dayOfMonth);
+    if (day != 0) {
+      return day;
+    }
+    return a.name.compareTo(b.name);
+  });
+  return templates;
+}
+
+Map<String, double>? _readDoubleMap(Map<String, Object?> json, String key) {
+  final source = json[key];
+  if (source is! Map) {
+    return null;
+  }
+  final result = <String, double>{};
+  for (final entry in source.entries) {
+    final amount = _parseDouble(entry.value);
+    if (amount != null && amount >= 0) {
+      result[entry.key.toString()] = amount;
+    }
+  }
+  return result;
+}
+
+Map<String, String>? _readStringMap(Map<String, Object?> json, String key) {
+  final source = json[key];
+  if (source is! Map) {
+    return null;
+  }
+  final result = <String, String>{};
+  for (final entry in source.entries) {
+    final mapKey = _cleanString(entry.key);
+    final value = _cleanString(entry.value);
+    if (mapKey != null && value != null) {
+      result[mapKey] = value;
+    }
+  }
+  return result;
+}
+
+Set<String>? _readStringSet(Map<String, Object?> json, String key) {
+  final source = json[key];
+  if (source is! Iterable) {
+    return null;
+  }
+  final result = <String>{};
+  for (final value in source) {
+    final text = _cleanString(value);
+    if (text != null) {
+      result.add(text);
+    }
+  }
+  return result;
+}
+
+String? _readString(Map<String, Object?> json, String key) {
+  return _cleanString(json[key]);
+}
+
+double? _readDouble(Map<String, Object?> json, String key) {
+  return _parseDouble(json[key]);
+}
+
+int? _readInt(Map<String, Object?> json, String key) {
+  return _parseInt(json[key]);
+}
+
+String? _cleanString(Object? source) {
+  final value = source?.toString().trim();
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  return value;
+}
+
+double? _parseDouble(Object? source) {
+  if (source is num) {
+    return source.toDouble();
+  }
+  if (source == null) {
+    return null;
+  }
+  return double.tryParse(source.toString().replaceAll(',', ''));
+}
+
+int? _parseInt(Object? source) {
+  if (source is num) {
+    return source.toInt();
+  }
+  if (source == null) {
+    return null;
+  }
+  return int.tryParse(source.toString().replaceAll(',', ''));
+}
+
+String _dateOnly(DateTime date) {
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '${date.year}-$month-$day';
+}

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -20,6 +20,7 @@ import 'package:my_web_app/models/kgi_csf_kpi.dart';
 import 'package:my_web_app/services/asset_liability_history_service.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 import 'package:my_web_app/services/asset_liability_planning_service.dart';
+import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
@@ -45,6 +46,7 @@ class AssetManagementPage extends StatefulWidget {
   final AssetManagementInitialFocus initialFocus;
   final bool emphasizeMonthlyFlow;
   final AssetWatchlistService watchlistService;
+  final AssetLiabilityRepository? assetLiabilityRepository;
   final String? entryLabel;
   final String? entryDescription;
 
@@ -53,6 +55,7 @@ class AssetManagementPage extends StatefulWidget {
     this.initialFocus = AssetManagementInitialFocus.overview,
     this.emphasizeMonthlyFlow = false,
     this.watchlistService = const AssetWatchlistService(),
+    this.assetLiabilityRepository,
     this.entryLabel,
     this.entryDescription,
   });
@@ -159,8 +162,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   bool _isLoadingTasks = false;
 
   // --- 返済計画用 ---
-  final AssetLiabilityMonthlyStateStore _assetLiabilityMonthlyStateStore =
-      const AssetLiabilityMonthlyStateStore();
+  late final AssetLiabilityRepository _assetLiabilityRepository;
   final AssetLiabilityPlanningService _assetLiabilityPlanner =
       const AssetLiabilityPlanningService();
   final AssetLiabilityHistoryService _assetLiabilityHistoryService =
@@ -211,6 +213,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   @override
   void initState() {
     super.initState();
+    _assetLiabilityRepository = widget.assetLiabilityRepository ??
+        const SharedPreferencesAssetLiabilityRepository();
     _loadDataFromSupabase();
     _loadAssetLiabilityMonthlyState();
     _loadWatchlistEntries();
@@ -772,15 +776,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(
         targetMonth,
       );
-      final state = await _assetLiabilityMonthlyStateStore.loadMonth(
-        targetMonth,
-      );
+      final state = await _assetLiabilityRepository.loadMonth(targetMonth);
       final defaultSources =
-          await _assetLiabilityMonthlyStateStore.loadDefaultPaymentSources();
+          await _assetLiabilityRepository.loadDefaultPaymentSources();
       final templates =
-          await _assetLiabilityMonthlyStateStore.loadRecurringIncomeTemplates();
+          await _assetLiabilityRepository.loadRecurringIncomeTemplates();
       final monthlySnapshots =
-          await _assetLiabilityMonthlyStateStore.loadMonthlySnapshots();
+          await _assetLiabilityRepository.loadMonthlySnapshots();
       final incomePlansWithTemplates =
           AssetLiabilityMonthlyStateStore.applyRecurringIncomeTemplates(
         month: targetMonth,
@@ -822,7 +824,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Future<void> _saveAssetLiabilityMonthlyState() async {
     try {
-      await _assetLiabilityMonthlyStateStore.saveMonth(
+      await _assetLiabilityRepository.saveMonth(
         month: _now,
         state: AssetLiabilityMonthlyState(
           paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
@@ -851,9 +853,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         workbook: workbook,
         savedAt: DateTime.now(),
       );
-      await _assetLiabilityMonthlyStateStore.saveMonthlySnapshot(snapshot);
-      final snapshots =
-          await _assetLiabilityMonthlyStateStore.loadMonthlySnapshots();
+      await _assetLiabilityRepository.saveMonthlySnapshot(snapshot);
+      final snapshots = await _assetLiabilityRepository.loadMonthlySnapshots();
       if (!mounted) return;
       setState(() {
         _monthlySnapshots = List<AssetLiabilityMonthlySnapshot>.from(snapshots);
@@ -1077,7 +1078,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Future<void> _saveDefaultPaymentSources() async {
     try {
-      await _assetLiabilityMonthlyStateStore.saveDefaultPaymentSources(
+      await _assetLiabilityRepository.saveDefaultPaymentSources(
         Map<String, String>.from(_defaultPaymentSourceAccountIds),
       );
     } catch (e) {
@@ -1087,7 +1088,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Future<void> _saveRecurringIncomeTemplates() async {
     try {
-      await _assetLiabilityMonthlyStateStore.saveRecurringIncomeTemplates(
+      await _assetLiabilityRepository.saveRecurringIncomeTemplates(
         List<AssetLiabilityRecurringIncomeTemplate>.from(
           _recurringIncomeTemplates,
         ),
@@ -1112,8 +1113,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Future<void> _copyPreviousMonthSettings() async {
-    final copied =
-        await _assetLiabilityMonthlyStateStore.copyPreviousMonthToMonth(_now);
+    final copied = await _assetLiabilityRepository.copyPreviousMonthToMonth(
+      _now,
+    );
     final incomePlansWithTemplates =
         AssetLiabilityMonthlyStateStore.applyRecurringIncomeTemplates(
       month: _now,

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1,0 +1,107 @@
+import 'package:my_web_app/models/asset_liability_persistence.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+
+abstract class AssetLiabilityRepository {
+  const AssetLiabilityRepository();
+
+  Future<AssetLiabilityMonthlyState> loadMonth(DateTime month);
+
+  Future<void> saveMonth({
+    required DateTime month,
+    required AssetLiabilityMonthlyState state,
+  });
+
+  Future<Map<String, String>> loadDefaultPaymentSources();
+
+  Future<void> saveDefaultPaymentSources(Map<String, String> sources);
+
+  Future<List<AssetLiabilityRecurringIncomeTemplate>>
+      loadRecurringIncomeTemplates();
+
+  Future<void> saveRecurringIncomeTemplates(
+    List<AssetLiabilityRecurringIncomeTemplate> templates,
+  );
+
+  Future<AssetLiabilityMonthlyState> copyPreviousMonthToMonth(
+    DateTime targetMonth,
+  );
+
+  Future<List<AssetLiabilityMonthlySnapshot>> loadMonthlySnapshots();
+
+  Future<void> saveMonthlySnapshot(AssetLiabilityMonthlySnapshot snapshot);
+
+  Future<AssetLiabilityPersistenceSnapshot> loadPersistenceSnapshot(
+    DateTime month,
+  ) async {
+    return AssetLiabilityPersistenceSnapshot(
+      monthKey: AssetLiabilityMonthlyStateStore.formatMonthKey(month),
+      monthlyState: await loadMonth(month),
+      defaultPaymentSourceAccountIds: await loadDefaultPaymentSources(),
+      recurringIncomeTemplates: await loadRecurringIncomeTemplates(),
+      monthlySnapshots: await loadMonthlySnapshots(),
+    );
+  }
+}
+
+class SharedPreferencesAssetLiabilityRepository
+    extends AssetLiabilityRepository {
+  final AssetLiabilityMonthlyStateStore store;
+
+  const SharedPreferencesAssetLiabilityRepository({
+    this.store = const AssetLiabilityMonthlyStateStore(),
+  });
+
+  @override
+  Future<AssetLiabilityMonthlyState> loadMonth(DateTime month) {
+    return store.loadMonth(month);
+  }
+
+  @override
+  Future<void> saveMonth({
+    required DateTime month,
+    required AssetLiabilityMonthlyState state,
+  }) {
+    return store.saveMonth(month: month, state: state);
+  }
+
+  @override
+  Future<Map<String, String>> loadDefaultPaymentSources() {
+    return store.loadDefaultPaymentSources();
+  }
+
+  @override
+  Future<void> saveDefaultPaymentSources(Map<String, String> sources) {
+    return store.saveDefaultPaymentSources(sources);
+  }
+
+  @override
+  Future<List<AssetLiabilityRecurringIncomeTemplate>>
+      loadRecurringIncomeTemplates() {
+    return store.loadRecurringIncomeTemplates();
+  }
+
+  @override
+  Future<void> saveRecurringIncomeTemplates(
+    List<AssetLiabilityRecurringIncomeTemplate> templates,
+  ) {
+    return store.saveRecurringIncomeTemplates(templates);
+  }
+
+  @override
+  Future<AssetLiabilityMonthlyState> copyPreviousMonthToMonth(
+    DateTime targetMonth,
+  ) {
+    return store.copyPreviousMonthToMonth(targetMonth);
+  }
+
+  @override
+  Future<List<AssetLiabilityMonthlySnapshot>> loadMonthlySnapshots() {
+    return store.loadMonthlySnapshots();
+  }
+
+  @override
+  Future<void> saveMonthlySnapshot(AssetLiabilityMonthlySnapshot snapshot) {
+    return store.saveMonthlySnapshot(snapshot);
+  }
+}

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -1,0 +1,362 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_persistence.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+import 'package:my_web_app/services/asset_liability_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('AssetLiabilityRepository', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('saves and restores monthly state through local repository', () async {
+      const repository = SharedPreferencesAssetLiabilityRepository();
+      final month = DateTime(2026, 5, 14);
+
+      await repository.saveMonth(
+        month: month,
+        state: AssetLiabilityMonthlyState(
+          paymentOverrides: const <String, double>{
+            'mobit': 70000,
+            'kddi_provider': 5764,
+          },
+          paidAccountNames: const <String>{'kddi_provider'},
+          paymentSourceAccountIds: const <String, String>{
+            'mobit': 'smbc_otsuka',
+          },
+          incomePlans: <AssetLiabilityIncomePlan>[
+            AssetLiabilityIncomePlan(
+              id: 'salary',
+              date: DateTime(2026, 5, 25),
+              name: 'Salary',
+              amount: 250000,
+              destinationAccountId: 'smbc_otsuka',
+              destinationAccountName: 'SMBC Otsuka',
+              received: false,
+            ),
+          ],
+        ),
+      );
+
+      final restored = await repository.loadMonth(DateTime(2026, 5, 31));
+
+      expect(restored.paymentOverrides['mobit'], 70000);
+      expect(restored.paymentOverrides['kddi_provider'], 5764);
+      expect(restored.paidAccountNames, contains('kddi_provider'));
+      expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
+      expect(restored.incomePlans.single.name, 'Salary');
+      expect(restored.incomePlans.single.received, isFalse);
+    });
+
+    test(
+      'keeps SharedPreferences persistence working without Supabase',
+      () async {
+        const repository = SharedPreferencesAssetLiabilityRepository();
+
+        await repository.saveDefaultPaymentSources(const <String, String>{
+          'kddi_provider': 'smbc_otsuka',
+        });
+        await repository.saveRecurringIncomeTemplates(
+          const <AssetLiabilityRecurringIncomeTemplate>[
+            AssetLiabilityRecurringIncomeTemplate(
+              id: 'salary',
+              dayOfMonth: 25,
+              name: 'Salary',
+              amount: 250000,
+              destinationAccountId: 'smbc_otsuka',
+              destinationAccountName: 'SMBC Otsuka',
+            ),
+          ],
+        );
+
+        final defaults = await repository.loadDefaultPaymentSources();
+        final templates = await repository.loadRecurringIncomeTemplates();
+
+        expect(defaults, <String, String>{'kddi_provider': 'smbc_otsuka'});
+        expect(templates.single.id, 'salary');
+        expect(templates.single.destinationAccountId, 'smbc_otsuka');
+      },
+    );
+
+    test('saves and restores monthly snapshots through repository', () async {
+      const repository = SharedPreferencesAssetLiabilityRepository();
+      final snapshot = AssetLiabilityMonthlySnapshot(
+        monthKey: '2026-05',
+        savedAt: DateTime.utc(2026, 5, 31, 12),
+        positiveAssetTotal: 120000,
+        liabilityTotal: -7200000,
+        netWorth: -7080000,
+        cashLikeTotal: 60000,
+        monthlyScheduledPaymentTotal: 180000,
+        monthlyPaidPaymentTotal: 100000,
+        monthlyUnpaidPaymentTotal: 80000,
+        overduePaymentCount: 1,
+      );
+
+      await repository.saveMonthlySnapshot(snapshot);
+
+      final snapshots = await repository.loadMonthlySnapshots();
+
+      expect(snapshots, hasLength(1));
+      expect(snapshots.single.monthKey, '2026-05');
+      expect(snapshots.single.monthlyUnpaidPaymentTotal, 80000);
+    });
+
+    test('builds a full local persistence snapshot', () async {
+      const repository = SharedPreferencesAssetLiabilityRepository();
+      final month = DateTime(2026, 5, 1);
+
+      await repository.saveMonth(
+        month: month,
+        state: const AssetLiabilityMonthlyState(
+          paymentOverrides: <String, double>{'mobit': 70000},
+        ),
+      );
+      await repository.saveDefaultPaymentSources(const <String, String>{
+        'mobit': 'smbc_otsuka',
+      });
+      await repository.saveMonthlySnapshot(
+        AssetLiabilityMonthlySnapshot(
+          monthKey: '2026-05',
+          savedAt: DateTime.utc(2026, 5, 31, 12),
+          positiveAssetTotal: 120000,
+          liabilityTotal: -7200000,
+          netWorth: -7080000,
+          cashLikeTotal: 60000,
+          monthlyScheduledPaymentTotal: 180000,
+          monthlyPaidPaymentTotal: 100000,
+          monthlyUnpaidPaymentTotal: 80000,
+          overduePaymentCount: 1,
+        ),
+      );
+
+      final snapshot = await repository.loadPersistenceSnapshot(month);
+
+      expect(snapshot.monthKey, '2026-05');
+      expect(snapshot.monthlyState.paymentOverrides['mobit'], 70000);
+      expect(snapshot.defaultPaymentSourceAccountIds['mobit'], 'smbc_otsuka');
+      expect(snapshot.monthlySnapshots.single.netWorth, -7080000);
+    });
+
+    test(
+      'supports fake repository implementations for Supabase-free tests',
+      () async {
+        final repository = _FakeAssetLiabilityRepository();
+        final month = DateTime(2026, 6, 1);
+
+        await repository.saveMonth(
+          month: month,
+          state: const AssetLiabilityMonthlyState(
+            paymentOverrides: <String, double>{'kddi_provider': 5764},
+          ),
+        );
+        await repository.saveMonthlySnapshot(
+          AssetLiabilityMonthlySnapshot(
+            monthKey: '2026-06',
+            savedAt: DateTime.utc(2026, 6, 30, 12),
+            positiveAssetTotal: 100000,
+            liabilityTotal: -7000000,
+            netWorth: -6900000,
+            cashLikeTotal: 50000,
+            monthlyScheduledPaymentTotal: 160000,
+            monthlyPaidPaymentTotal: 160000,
+            monthlyUnpaidPaymentTotal: 0,
+            overduePaymentCount: 0,
+          ),
+        );
+
+        final restored = await repository.loadPersistenceSnapshot(month);
+
+        expect(restored.monthlyState.paymentOverrides['kddi_provider'], 5764);
+        expect(restored.monthlySnapshots.single.monthKey, '2026-06');
+      },
+    );
+  });
+
+  group('Asset liability Supabase payloads', () {
+    test('round-trips monthly state payload', () {
+      final state = AssetLiabilityMonthlyState(
+        paymentOverrides: const <String, double>{'mobit': 70000},
+        paidAccountNames: const <String>{'kddi_provider'},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'salary',
+            date: DateTime(2026, 5, 25),
+            name: 'Salary',
+            amount: 250000,
+            destinationAccountId: 'smbc_otsuka',
+            destinationAccountName: 'SMBC Otsuka',
+            received: true,
+          ),
+        ],
+      );
+
+      final payload = AssetLiabilityMonthlyStatePayload.fromState(
+        monthKey: '2026-05',
+        state: state,
+      );
+      final row = payload.toSupabaseJson(
+        userId: 'user-1',
+        updatedAt: DateTime.utc(2026, 5, 14),
+      );
+      final restored = AssetLiabilityMonthlyStatePayload.fromSupabaseJson(
+        row,
+      ).toState();
+
+      expect(row['user_id'], 'user-1');
+      expect(row['month_key'], '2026-05');
+      expect(restored.paymentOverrides['mobit'], 70000);
+      expect(restored.paidAccountNames, contains('kddi_provider'));
+      expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
+      expect(restored.incomePlans.single.received, isTrue);
+    });
+
+    test('round-trips settings and snapshot payloads', () {
+      const settings = AssetLiabilityUserSettingsPayload(
+        defaultPaymentSourceAccountIds: <String, String>{
+          'mobit': 'smbc_otsuka',
+        },
+        recurringIncomeTemplates: <AssetLiabilityRecurringIncomeTemplate>[
+          AssetLiabilityRecurringIncomeTemplate(
+            id: 'salary',
+            dayOfMonth: 25,
+            name: 'Salary',
+            amount: 250000,
+            destinationAccountId: 'smbc_otsuka',
+            destinationAccountName: 'SMBC Otsuka',
+          ),
+        ],
+      );
+      final settingsRow = settings.toSupabaseJson(userId: 'user-1');
+      final restoredSettings =
+          AssetLiabilityUserSettingsPayload.fromSupabaseJson(settingsRow);
+
+      expect(
+        restoredSettings.defaultPaymentSourceAccountIds['mobit'],
+        'smbc_otsuka',
+      );
+      expect(restoredSettings.recurringIncomeTemplates.single.id, 'salary');
+
+      final snapshot = AssetLiabilityMonthlySnapshot(
+        monthKey: '2026-05',
+        savedAt: DateTime.utc(2026, 5, 31, 12),
+        positiveAssetTotal: 120000,
+        liabilityTotal: -7200000,
+        netWorth: -7080000,
+        cashLikeTotal: 60000,
+        monthlyScheduledPaymentTotal: 180000,
+        monthlyPaidPaymentTotal: 100000,
+        monthlyUnpaidPaymentTotal: 80000,
+        overduePaymentCount: 1,
+      );
+      final snapshotRow = AssetLiabilityMonthlySnapshotPayload(
+        snapshot: snapshot,
+      ).toSupabaseJson(userId: 'user-1');
+      final restoredSnapshot =
+          AssetLiabilityMonthlySnapshotPayload.fromSupabaseJson(
+        snapshotRow,
+      ).snapshot;
+
+      expect(snapshotRow['user_id'], 'user-1');
+      expect(restoredSnapshot.monthKey, '2026-05');
+      expect(restoredSnapshot.netWorth, -7080000);
+      expect(restoredSnapshot.overduePaymentCount, 1);
+    });
+
+    test('documents Supabase table names and required identity columns', () {
+      expect(
+        AssetLiabilitySupabaseTablePlan.monthlyStatesTable,
+        'asset_liability_monthly_states',
+      );
+      expect(
+        AssetLiabilitySupabaseTablePlan.monthlyStateColumns,
+        containsAll(<String>['user_id', 'month_key', 'updated_at']),
+      );
+      expect(
+        AssetLiabilitySupabaseTablePlan.monthlySnapshotColumns,
+        containsAll(<String>['user_id', 'month_key', 'created_at']),
+      );
+    });
+  });
+}
+
+class _FakeAssetLiabilityRepository extends AssetLiabilityRepository {
+  final Map<String, AssetLiabilityMonthlyState> _states =
+      <String, AssetLiabilityMonthlyState>{};
+  final Map<String, String> _defaultSources = <String, String>{};
+  final List<AssetLiabilityRecurringIncomeTemplate> _templates =
+      <AssetLiabilityRecurringIncomeTemplate>[];
+  final List<AssetLiabilityMonthlySnapshot> _snapshots =
+      <AssetLiabilityMonthlySnapshot>[];
+
+  @override
+  Future<AssetLiabilityMonthlyState> loadMonth(DateTime month) async {
+    return _states[AssetLiabilityMonthlyStateStore.formatMonthKey(month)] ??
+        const AssetLiabilityMonthlyState();
+  }
+
+  @override
+  Future<void> saveMonth({
+    required DateTime month,
+    required AssetLiabilityMonthlyState state,
+  }) async {
+    _states[AssetLiabilityMonthlyStateStore.formatMonthKey(month)] = state;
+  }
+
+  @override
+  Future<Map<String, String>> loadDefaultPaymentSources() async {
+    return Map<String, String>.from(_defaultSources);
+  }
+
+  @override
+  Future<void> saveDefaultPaymentSources(Map<String, String> sources) async {
+    _defaultSources
+      ..clear()
+      ..addAll(sources);
+  }
+
+  @override
+  Future<List<AssetLiabilityRecurringIncomeTemplate>>
+      loadRecurringIncomeTemplates() async {
+    return List<AssetLiabilityRecurringIncomeTemplate>.from(_templates);
+  }
+
+  @override
+  Future<void> saveRecurringIncomeTemplates(
+    List<AssetLiabilityRecurringIncomeTemplate> templates,
+  ) async {
+    _templates
+      ..clear()
+      ..addAll(templates);
+  }
+
+  @override
+  Future<AssetLiabilityMonthlyState> copyPreviousMonthToMonth(
+    DateTime targetMonth,
+  ) async {
+    final previousMonth = DateTime(targetMonth.year, targetMonth.month - 1);
+    final copied = AssetLiabilityMonthlyStateStore.copyPreviousMonthState(
+      previousState: await loadMonth(previousMonth),
+      targetMonth: targetMonth,
+    );
+    await saveMonth(month: targetMonth, state: copied);
+    return copied;
+  }
+
+  @override
+  Future<List<AssetLiabilityMonthlySnapshot>> loadMonthlySnapshots() async {
+    return List<AssetLiabilityMonthlySnapshot>.from(_snapshots);
+  }
+
+  @override
+  Future<void> saveMonthlySnapshot(
+    AssetLiabilityMonthlySnapshot snapshot,
+  ) async {
+    _snapshots.removeWhere((current) => current.monthKey == snapshot.monthKey);
+    _snapshots.add(snapshot);
+    _snapshots.sort((a, b) => a.monthKey.compareTo(b.monthKey));
+  }
+}


### PR DESCRIPTION
﻿## 概要

資産/負債ボードの月次状態を、将来 Supabase 保存へ移行できるようにするための保存モデルと Repository 層を追加しました。

今回のPRでは SharedPreferences 運用を廃止せず、既存のローカル保存を主経路のまま維持しています。UIは直接保存実装を呼ばず、`AssetLiabilityRepository` 経由で月次状態を読み書きします。

## 主な変更

- Supabase保存用のpayload/modelを追加
  - 月次状態
  - 収入予定
  - 定期収入テンプレート
  - 支払原資口座設定
  - 月次スナップショット
- Supabaseテーブル案を `AssetLiabilitySupabaseTablePlan` とdoc commentで整理
- `AssetLiabilityRepository` interfaceを追加
- `SharedPreferencesAssetLiabilityRepository` を追加し、既存 `AssetLiabilityMonthlyStateStore` をadapter化
- 資産管理ページの月次状態保存をRepository経由に差し替え
- Supabase未接続でもテストできるfake repositoryのテストを追加
- SharedPreferences保存の後方互換テストを追加

## 補足

このPRでは実DBへの完全移行、Supabase migration、RLS、Edge Function、production database writeは追加していません。次の段階で `AssetLiabilityRepository` のSupabase実装とmigrationを別PRで扱えるようにする土台作りです。

## Minimal E2E Gate

- [x] Implementation-detail independent: Repository contract and persistence payload tests verify saved input can be restored through the public repository API.
- [x] Minimal scope: covered monthly state, settings/templates, and snapshot persistence paths.
- [ ] E2E included: not included.
- [x] E2E-Exception: service-layer persistence foundation only; no new user-visible workflow or route was added. Manual verification is covered by repository tests, asset/liability service tests, full `flutter test`, and `dart analyze`.

## Visual E2E Evidence

- UI layout/interaction changes: not applicable. The page now accepts a repository dependency and still uses the existing SharedPreferences-backed implementation by default.
- Browser visual QA: not run because this PR does not add or modify visible UI components.
- Generated imagery: no generated image was used.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Supabase keyword only; this PR adds payload/interface/table-plan foundations and does not add migrations, RLS, Edge Functions, secrets, auth, or production database writes. Deterministic local validation completed; full database migration review should happen in the follow-up Supabase implementation PR.

## 検証

最新 `origin/main` へ rebase 後、以下を確認済みです。

- `flutter pub get --enforce-lockfile`: OK
- `dart format --output=none --set-exit-if-changed ...`: OK
- `dart analyze`: No issues found
- 資産/負債関連 `flutter test --no-pub ...`: 39 tests passed
- 全体 `flutter test --no-pub`: 411 tests passed
- `git diff --check origin/main...HEAD`: OK

補足:
ローカルの Pub cache に欠けたパッケージがあり、一度 `dart pub cache repair` で復旧してから再検証しました。コード差分やlockfile変更はありません。
