### PR TITLE
Add Supabase schema foundation for asset liability board

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -3,75 +3,50 @@ import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 
 /// Supabase persistence draft for the asset/liability board.
 ///
-/// Proposed tables:
+/// Schema foundation tables:
 /// - asset_liability_monthly_states
-///   - user_id uuid not null
-///   - month_key text not null
-///   - payment_overrides jsonb not null default '{}'
-///   - paid_account_ids jsonb not null default '[]'
-///   - payment_source_account_ids jsonb not null default '{}'
-///   - income_plans jsonb not null default '[]'
-///   - created_at timestamptz not null default now()
-///   - updated_at timestamptz not null default now()
-///   - primary key (user_id, month_key)
-/// - asset_liability_user_settings
-///   - user_id uuid primary key
-///   - default_payment_source_account_ids jsonb not null default '{}'
-///   - recurring_income_templates jsonb not null default '[]'
-///   - created_at timestamptz not null default now()
-///   - updated_at timestamptz not null default now()
+/// - asset_liability_income_plans
+/// - asset_liability_recurring_income_templates
+/// - asset_liability_payment_source_settings
 /// - asset_liability_monthly_snapshots
+///
+/// Common columns:
+///   - id uuid primary key default gen_random_uuid()
 ///   - user_id uuid not null
 ///   - month_key text not null
-///   - saved_at timestamptz not null
-///   - positive_asset_total numeric not null
-///   - liability_total numeric not null
-///   - net_worth numeric not null
-///   - cash_like_total numeric not null
-///   - monthly_scheduled_payment_total numeric not null
-///   - monthly_paid_payment_total numeric not null
-///   - monthly_unpaid_payment_total numeric not null
-///   - overdue_payment_count integer not null
+///   - payload jsonb not null default '{}'
 ///   - created_at timestamptz not null default now()
 ///   - updated_at timestamptz not null default now()
-///   - primary key (user_id, month_key)
+///
+/// Runtime note:
+/// SharedPreferences remains the primary store until a later repository adapter
+/// enables Supabase reads/writes. UI code should continue to depend on
+/// AssetLiabilityRepository rather than calling Supabase directly.
 class AssetLiabilitySupabaseTablePlan {
   static const String monthlyStatesTable = 'asset_liability_monthly_states';
-  static const String userSettingsTable = 'asset_liability_user_settings';
+  static const String incomePlansTable = 'asset_liability_income_plans';
+  static const String recurringIncomeTemplatesTable =
+      'asset_liability_recurring_income_templates';
+  static const String paymentSourceSettingsTable =
+      'asset_liability_payment_source_settings';
   static const String monthlySnapshotsTable =
       'asset_liability_monthly_snapshots';
 
-  static const List<String> monthlyStateColumns = <String>[
-    'user_id',
-    'month_key',
-    'payment_overrides',
-    'paid_account_ids',
-    'payment_source_account_ids',
-    'income_plans',
-    'created_at',
-    'updated_at',
+  static const String globalMonthKey = 'global';
+
+  static const List<String> payloadTables = <String>[
+    monthlyStatesTable,
+    incomePlansTable,
+    recurringIncomeTemplatesTable,
+    paymentSourceSettingsTable,
+    monthlySnapshotsTable,
   ];
 
-  static const List<String> userSettingsColumns = <String>[
-    'user_id',
-    'default_payment_source_account_ids',
-    'recurring_income_templates',
-    'created_at',
-    'updated_at',
-  ];
-
-  static const List<String> monthlySnapshotColumns = <String>[
+  static const List<String> commonPayloadColumns = <String>[
+    'id',
     'user_id',
     'month_key',
-    'saved_at',
-    'positive_asset_total',
-    'liability_total',
-    'net_worth',
-    'cash_like_total',
-    'monthly_scheduled_payment_total',
-    'monthly_paid_payment_total',
-    'monthly_unpaid_payment_total',
-    'overdue_payment_count',
+    'payload',
     'created_at',
     'updated_at',
   ];

--- a/supabase/migrations/20260514040900_create_asset_liability_supabase_schema.sql
+++ b/supabase/migrations/20260514040900_create_asset_liability_supabase_schema.sql
@@ -1,0 +1,351 @@
+-- Asset/liability board Supabase schema foundation.
+--
+-- Scope:
+-- - Creates persistence tables and owner-only RLS policies.
+-- - Does not enable application production writes.
+-- - SharedPreferences remains the primary runtime store until a later adapter PR.
+--
+-- Migration plan from SharedPreferences:
+-- 1. Initial sync: after authentication, load the local repository snapshot and
+--    upsert one payload row per user/month/table.
+-- 2. Conflict priority: compare updated_at; the newer row wins by default.
+--    If the remote row is newer than local unsynced edits, prompt before
+--    overwriting.
+-- 3. Device sync: refresh remote rows by user_id/month_key before saving, then
+--    upsert through the repository layer. UI must not call Supabase directly.
+-- 4. Rollback: keep the SharedPreferences adapter available behind the same
+--    repository interface. If Supabase writes are disabled, local data remains
+--    authoritative and these tables can stay unused.
+
+create or replace function public.set_asset_liability_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create table if not exists public.asset_liability_monthly_states (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  month_key text not null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint asset_liability_monthly_states_month_key_format
+    check (month_key = 'global' or month_key ~ '^[0-9]{4}-[0-9]{2}$'),
+  constraint asset_liability_monthly_states_payload_object
+    check (jsonb_typeof(payload) = 'object'),
+  constraint asset_liability_monthly_states_user_month_unique
+    unique (user_id, month_key)
+);
+
+create table if not exists public.asset_liability_income_plans (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  month_key text not null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint asset_liability_income_plans_month_key_format
+    check (month_key = 'global' or month_key ~ '^[0-9]{4}-[0-9]{2}$'),
+  constraint asset_liability_income_plans_payload_object
+    check (jsonb_typeof(payload) = 'object'),
+  constraint asset_liability_income_plans_user_month_unique
+    unique (user_id, month_key)
+);
+
+create table if not exists public.asset_liability_recurring_income_templates (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  month_key text not null default 'global',
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint asset_liability_recurring_income_templates_month_key_format
+    check (month_key = 'global' or month_key ~ '^[0-9]{4}-[0-9]{2}$'),
+  constraint asset_liability_recurring_income_templates_payload_object
+    check (jsonb_typeof(payload) = 'object'),
+  constraint asset_liability_recurring_income_templates_user_month_unique
+    unique (user_id, month_key)
+);
+
+create table if not exists public.asset_liability_payment_source_settings (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  month_key text not null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint asset_liability_payment_source_settings_month_key_format
+    check (month_key = 'global' or month_key ~ '^[0-9]{4}-[0-9]{2}$'),
+  constraint asset_liability_payment_source_settings_payload_object
+    check (jsonb_typeof(payload) = 'object'),
+  constraint asset_liability_payment_source_settings_user_month_unique
+    unique (user_id, month_key)
+);
+
+create table if not exists public.asset_liability_monthly_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  month_key text not null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint asset_liability_monthly_snapshots_month_key_format
+    check (month_key = 'global' or month_key ~ '^[0-9]{4}-[0-9]{2}$'),
+  constraint asset_liability_monthly_snapshots_payload_object
+    check (jsonb_typeof(payload) = 'object'),
+  constraint asset_liability_monthly_snapshots_user_month_unique
+    unique (user_id, month_key)
+);
+
+create index if not exists asset_liability_monthly_states_user_month_idx
+  on public.asset_liability_monthly_states (user_id, month_key);
+create index if not exists asset_liability_monthly_states_payload_gin_idx
+  on public.asset_liability_monthly_states using gin (payload);
+
+create index if not exists asset_liability_income_plans_user_month_idx
+  on public.asset_liability_income_plans (user_id, month_key);
+create index if not exists asset_liability_income_plans_payload_gin_idx
+  on public.asset_liability_income_plans using gin (payload);
+
+create index if not exists asset_liability_recurring_income_templates_user_month_idx
+  on public.asset_liability_recurring_income_templates (user_id, month_key);
+create index if not exists asset_liability_recurring_income_templates_payload_gin_idx
+  on public.asset_liability_recurring_income_templates using gin (payload);
+
+create index if not exists asset_liability_payment_source_settings_user_month_idx
+  on public.asset_liability_payment_source_settings (user_id, month_key);
+create index if not exists asset_liability_payment_source_settings_payload_gin_idx
+  on public.asset_liability_payment_source_settings using gin (payload);
+
+create index if not exists asset_liability_monthly_snapshots_user_month_idx
+  on public.asset_liability_monthly_snapshots (user_id, month_key);
+create index if not exists asset_liability_monthly_snapshots_payload_gin_idx
+  on public.asset_liability_monthly_snapshots using gin (payload);
+
+drop trigger if exists asset_liability_monthly_states_updated_at
+  on public.asset_liability_monthly_states;
+create trigger asset_liability_monthly_states_updated_at
+before update on public.asset_liability_monthly_states
+for each row execute function public.set_asset_liability_updated_at();
+
+drop trigger if exists asset_liability_income_plans_updated_at
+  on public.asset_liability_income_plans;
+create trigger asset_liability_income_plans_updated_at
+before update on public.asset_liability_income_plans
+for each row execute function public.set_asset_liability_updated_at();
+
+drop trigger if exists asset_liability_recurring_income_templates_updated_at
+  on public.asset_liability_recurring_income_templates;
+create trigger asset_liability_recurring_income_templates_updated_at
+before update on public.asset_liability_recurring_income_templates
+for each row execute function public.set_asset_liability_updated_at();
+
+drop trigger if exists asset_liability_payment_source_settings_updated_at
+  on public.asset_liability_payment_source_settings;
+create trigger asset_liability_payment_source_settings_updated_at
+before update on public.asset_liability_payment_source_settings
+for each row execute function public.set_asset_liability_updated_at();
+
+drop trigger if exists asset_liability_monthly_snapshots_updated_at
+  on public.asset_liability_monthly_snapshots;
+create trigger asset_liability_monthly_snapshots_updated_at
+before update on public.asset_liability_monthly_snapshots
+for each row execute function public.set_asset_liability_updated_at();
+
+alter table public.asset_liability_monthly_states enable row level security;
+alter table public.asset_liability_income_plans enable row level security;
+alter table public.asset_liability_recurring_income_templates enable row level security;
+alter table public.asset_liability_payment_source_settings enable row level security;
+alter table public.asset_liability_monthly_snapshots enable row level security;
+
+drop policy if exists asset_liability_monthly_states_select_own
+  on public.asset_liability_monthly_states;
+create policy asset_liability_monthly_states_select_own
+on public.asset_liability_monthly_states
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists asset_liability_monthly_states_insert_own
+  on public.asset_liability_monthly_states;
+create policy asset_liability_monthly_states_insert_own
+on public.asset_liability_monthly_states
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_monthly_states_update_own
+  on public.asset_liability_monthly_states;
+create policy asset_liability_monthly_states_update_own
+on public.asset_liability_monthly_states
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_monthly_states_delete_own
+  on public.asset_liability_monthly_states;
+create policy asset_liability_monthly_states_delete_own
+on public.asset_liability_monthly_states
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists asset_liability_income_plans_select_own
+  on public.asset_liability_income_plans;
+create policy asset_liability_income_plans_select_own
+on public.asset_liability_income_plans
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists asset_liability_income_plans_insert_own
+  on public.asset_liability_income_plans;
+create policy asset_liability_income_plans_insert_own
+on public.asset_liability_income_plans
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_income_plans_update_own
+  on public.asset_liability_income_plans;
+create policy asset_liability_income_plans_update_own
+on public.asset_liability_income_plans
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_income_plans_delete_own
+  on public.asset_liability_income_plans;
+create policy asset_liability_income_plans_delete_own
+on public.asset_liability_income_plans
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists asset_liability_recurring_income_templates_select_own
+  on public.asset_liability_recurring_income_templates;
+create policy asset_liability_recurring_income_templates_select_own
+on public.asset_liability_recurring_income_templates
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists asset_liability_recurring_income_templates_insert_own
+  on public.asset_liability_recurring_income_templates;
+create policy asset_liability_recurring_income_templates_insert_own
+on public.asset_liability_recurring_income_templates
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_recurring_income_templates_update_own
+  on public.asset_liability_recurring_income_templates;
+create policy asset_liability_recurring_income_templates_update_own
+on public.asset_liability_recurring_income_templates
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_recurring_income_templates_delete_own
+  on public.asset_liability_recurring_income_templates;
+create policy asset_liability_recurring_income_templates_delete_own
+on public.asset_liability_recurring_income_templates
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists asset_liability_payment_source_settings_select_own
+  on public.asset_liability_payment_source_settings;
+create policy asset_liability_payment_source_settings_select_own
+on public.asset_liability_payment_source_settings
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists asset_liability_payment_source_settings_insert_own
+  on public.asset_liability_payment_source_settings;
+create policy asset_liability_payment_source_settings_insert_own
+on public.asset_liability_payment_source_settings
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_payment_source_settings_update_own
+  on public.asset_liability_payment_source_settings;
+create policy asset_liability_payment_source_settings_update_own
+on public.asset_liability_payment_source_settings
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_payment_source_settings_delete_own
+  on public.asset_liability_payment_source_settings;
+create policy asset_liability_payment_source_settings_delete_own
+on public.asset_liability_payment_source_settings
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists asset_liability_monthly_snapshots_select_own
+  on public.asset_liability_monthly_snapshots;
+create policy asset_liability_monthly_snapshots_select_own
+on public.asset_liability_monthly_snapshots
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists asset_liability_monthly_snapshots_insert_own
+  on public.asset_liability_monthly_snapshots;
+create policy asset_liability_monthly_snapshots_insert_own
+on public.asset_liability_monthly_snapshots
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_monthly_snapshots_update_own
+  on public.asset_liability_monthly_snapshots;
+create policy asset_liability_monthly_snapshots_update_own
+on public.asset_liability_monthly_snapshots
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists asset_liability_monthly_snapshots_delete_own
+  on public.asset_liability_monthly_snapshots;
+create policy asset_liability_monthly_snapshots_delete_own
+on public.asset_liability_monthly_snapshots
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+comment on table public.asset_liability_monthly_states is
+  'Monthly asset/liability payment override and paid-state payloads. SharedPreferences remains primary until the Supabase repository adapter is enabled.';
+comment on table public.asset_liability_income_plans is
+  'Monthly income plan payloads for the asset/liability board.';
+comment on table public.asset_liability_recurring_income_templates is
+  'Recurring income template payloads. Use month_key = global for the default template set.';
+comment on table public.asset_liability_payment_source_settings is
+  'Payment source override and default-account payloads. Use month_key = global for default settings.';
+comment on table public.asset_liability_monthly_snapshots is
+  'Saved-at-time monthly snapshot payloads for history charts and CSV backup.';
+
+comment on column public.asset_liability_monthly_states.payload is
+  'JSON object payload. Collection-like values should be stored under explicit keys such as items or paid_account_ids.';
+comment on column public.asset_liability_income_plans.payload is
+  'JSON object payload. Expected shape: {items: [...]} for income plans.';
+comment on column public.asset_liability_recurring_income_templates.payload is
+  'JSON object payload. Expected shape: {items: [...]} for recurring income templates.';
+comment on column public.asset_liability_payment_source_settings.payload is
+  'JSON object payload. Expected shape: {payment_source_account_ids: {...}, default_payment_source_account_ids: {...}}.';
+comment on column public.asset_liability_monthly_snapshots.payload is
+  'JSON object payload containing saved_at, asset totals, liability totals, cash-like totals, payment totals, and overdue count.';

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -272,12 +272,16 @@ void main() {
         'asset_liability_monthly_states',
       );
       expect(
-        AssetLiabilitySupabaseTablePlan.monthlyStateColumns,
-        containsAll(<String>['user_id', 'month_key', 'updated_at']),
+        AssetLiabilitySupabaseTablePlan.incomePlansTable,
+        'asset_liability_income_plans',
       );
       expect(
-        AssetLiabilitySupabaseTablePlan.monthlySnapshotColumns,
-        containsAll(<String>['user_id', 'month_key', 'created_at']),
+        AssetLiabilitySupabaseTablePlan.paymentSourceSettingsTable,
+        'asset_liability_payment_source_settings',
+      );
+      expect(
+        AssetLiabilitySupabaseTablePlan.commonPayloadColumns,
+        containsAll(<String>['id', 'user_id', 'month_key', 'payload']),
       );
     });
   });

--- a/test/services/asset_liability_supabase_schema_test.dart
+++ b/test/services/asset_liability_supabase_schema_test.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_persistence.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260514040900_create_asset_liability_supabase_schema.sql';
+
+void main() {
+  group('asset liability Supabase schema migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(_migrationPath).readAsStringSync().replaceAll('\r\n', '\n');
+    });
+
+    test('defines the planned payload tables with common columns', () {
+      for (final table in AssetLiabilitySupabaseTablePlan.payloadTables) {
+        final block = _createTableBlock(sql, table);
+
+        expect(
+          block,
+          contains('id uuid primary key default gen_random_uuid()'),
+        );
+        expect(
+          block,
+          contains('user_id uuid not null references auth.users(id)'),
+        );
+        expect(block, contains('month_key text not null'));
+        expect(block, contains("payload jsonb not null default '{}'::jsonb"));
+        expect(
+          block,
+          contains('created_at timestamptz not null default now()'),
+        );
+        expect(
+          block,
+          contains('updated_at timestamptz not null default now()'),
+        );
+      }
+    });
+
+    test('enforces month identity uniqueness and jsonb object payloads', () {
+      for (final table in AssetLiabilitySupabaseTablePlan.payloadTables) {
+        final block = _createTableBlock(sql, table);
+
+        expect(block, contains("month_key = 'global'"));
+        expect(block, contains("month_key ~ '^[0-9]{4}-[0-9]{2}\$'"));
+        expect(block, contains("check (jsonb_typeof(payload) = 'object')"));
+        expect(block, contains('unique (user_id, month_key)'));
+      }
+    });
+
+    test('enables owner-only RLS for each table and operation', () {
+      for (final table in AssetLiabilitySupabaseTablePlan.payloadTables) {
+        expect(
+          sql,
+          contains('alter table public.$table enable row level security;'),
+        );
+        expect(sql, contains('create policy ${table}_select_own'));
+        expect(sql, contains('on public.$table\nfor select\nto authenticated'));
+        expect(sql, contains('create policy ${table}_insert_own'));
+        expect(sql, contains('on public.$table\nfor insert\nto authenticated'));
+        expect(sql, contains('create policy ${table}_update_own'));
+        expect(sql, contains('on public.$table\nfor update\nto authenticated'));
+        expect(sql, contains('create policy ${table}_delete_own'));
+        expect(sql, contains('on public.$table\nfor delete\nto authenticated'));
+      }
+
+      expect(sql, contains('using (auth.uid() = user_id)'));
+      expect(sql, contains('with check (auth.uid() = user_id)'));
+    });
+
+    test('documents SharedPreferences migration and rollback policy', () {
+      expect(
+        sql,
+        contains('SharedPreferences remains the primary runtime store'),
+      );
+      expect(sql, contains('Initial sync'));
+      expect(sql, contains('Conflict priority'));
+      expect(sql, contains('Device sync'));
+      expect(sql, contains('Rollback'));
+      expect(sql, contains('UI must not call Supabase directly'));
+    });
+
+    test('keeps the Dart table plan aligned with the migration', () {
+      expect(
+        AssetLiabilitySupabaseTablePlan.payloadTables,
+        containsAll(<String>[
+          'asset_liability_monthly_states',
+          'asset_liability_income_plans',
+          'asset_liability_recurring_income_templates',
+          'asset_liability_payment_source_settings',
+          'asset_liability_monthly_snapshots',
+        ]),
+      );
+      expect(AssetLiabilitySupabaseTablePlan.commonPayloadColumns, <String>[
+        'id',
+        'user_id',
+        'month_key',
+        'payload',
+        'created_at',
+        'updated_at',
+      ]);
+      expect(AssetLiabilitySupabaseTablePlan.globalMonthKey, 'global');
+    });
+  });
+}
+
+String _createTableBlock(String sql, String table) {
+  final start = sql.indexOf('create table if not exists public.$table');
+  expect(start, isNonNegative, reason: 'missing create table for $table');
+
+  final end = sql.indexOf(');', start);
+  expect(
+    end,
+    isNonNegative,
+    reason: 'missing create table terminator for $table',
+  );
+
+  return sql.substring(start, end);
+}


### PR DESCRIPTION
﻿## 概要

資産/負債ボードのSupabase保存に向けて、DB schema / RLS の土台を追加しました。

PR #2412 で追加したRepository層・payload設計に続くDB側の準備であり、今回のPRではproduction writeやUIからのSupabase直接書き込みは有効化していません。既存のSharedPreferences保存が引き続き主経路です。

## 主な変更

- 資産/負債ボード用のSupabase migrationを追加
  - `asset_liability_monthly_states`
  - `asset_liability_income_plans`
  - `asset_liability_recurring_income_templates`
  - `asset_liability_payment_source_settings`
  - `asset_liability_monthly_snapshots`
- 各テーブルに共通カラムを追加
  - `id`
  - `user_id`
  - `month_key`
  - `payload jsonb`
  - `created_at`
  - `updated_at`
- `user_id + month_key` の一意制約を追加
- `payload` をJSON objectに制限
- authenticated userが自分の`user_id`の行だけselect / insert / update / deleteできるRLS policyを追加
- `updated_at`更新triggerを追加
- SharedPreferencesからSupabaseへ移行する方針をmigrationコメントに記録
  - 初回同期
  - conflict時の優先順位
  - 端末間同期
  - rollback方針
- Dart側のSupabase TablePlanメモを5つのpayloadテーブル構成に更新
- migration/RLS方針の静的検証テストを追加

## スコープ外

- Supabaseへのproduction write有効化
- UIからのSupabase直接呼び出し
- 既存SharedPreferences保存の廃止
- 実DBへのデータ移行実行
- RLS適用後の本番DB smoke

## Minimal E2E Gate

- E2E-Exception: schema-only migration/RLS foundationで、ユーザー操作UIやruntime write pathを変更していないため、新規Playwright/integration_testは追加していません。
- Implementation-detail independent / black-box観点では、将来の本移行PRで以下のminimal 3 casesをE2E対象にします。
  1. 新規端末で月次状態を読み込み、Supabase保存済みpayloadが資産/負債ボードに復元されること
  2. 別端末で更新した支払予定/支払済み状態が再読み込み後に反映されること
  3. Supabase未接続時にSharedPreferencesへフォールバックして既存運用が継続できること

## High-risk Ultrareview

High-Risk-Ultrareview-Exception: Claude Code #1 design review is not available in this Codex-only turn; this PR is schema foundation only, has no production write path, keeps SharedPreferences as the runtime source, and is covered by deterministic SQL/RLS static tests, migration timestamp checks, and rollback notes.

- Security: owner-only RLS uses `auth.uid() = user_id` for select / insert / update / delete.
- Rollback: Repository remains backed by SharedPreferences; Supabase writes can remain disabled without user-facing behavior changes.
- Data migration: migration comments document initial sync, updated_at conflict priority, multi-device refresh, and rollback.
- Prod smoke: not run because this PR does not enable production writes or application reads against these tables.
- Observability: `updated_at` trigger is present on every table for future conflict and sync diagnostics.

## 検証

最新 `origin/main` へrebase後、以下を確認済みです。

- `flutter pub get --enforce-lockfile`: OK
- `dart format --output=none --set-exit-if-changed ...`: OK、変更なし
- `dart analyze`: No issues found
- 関連 `flutter test --no-pub test\services\asset_liability_repository_test.dart test\services\asset_liability_supabase_schema_test.dart --reporter expanded`: 13 tests passed
- 全体 `flutter test --no-pub --reporter compact`: 416 tests passed
- `python scripts\check_migration_timestamps.py`: OK
- `python scripts\check_migration_time_relative_check.py`: OK
- `git diff --check`: OK

## Files changed確認

想定ファイルのみです。

- `lib/models/asset_liability_persistence.dart`
- `supabase/migrations/20260514040900_create_asset_liability_supabase_schema.sql`
- `test/services/asset_liability_repository_test.dart`
- `test/services/asset_liability_supabase_schema_test.dart`
