### PR TITLE
feat: add v23 remaining compression hooks (#1564)

### DIFF
--- a/.claude/hooks/pretooluse-compression-budget.ps1
+++ b/.claude/hooks/pretooluse-compression-budget.ps1
@@ -1,0 +1,64 @@
+# Issue #1564: v23 Layer KK PreToolUse compression budget.
+# Tracks tool-use count and records every 10th-tool KPI snapshot. When C: free
+# space is below the aggressive threshold, it runs a capped non-blocking cleanup.
+
+param()
+
+$ErrorActionPreference = "SilentlyContinue"
+
+function Resolve-PythonCommand {
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        return @($python.Source)
+    }
+
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($py) {
+        return @($py.Source, "-3")
+    }
+
+    return @()
+}
+
+$projectDir = $env:CLAUDE_PROJECT_DIR
+if (-not $projectDir) { $projectDir = (Get-Location).Path }
+
+$scriptPath = Join-Path $projectDir "scripts\session_compression_guard.py"
+if (-not (Test-Path $scriptPath)) {
+    Write-Output "[KPI] session compression guard missing: $scriptPath"
+    exit 0
+}
+
+$pythonCommand = @(Resolve-PythonCommand)
+if ($pythonCommand.Count -eq 0) {
+    Write-Output "[KPI] python unavailable; pretooluse compression skipped"
+    exit 0
+}
+
+$arguments = @(
+    $scriptPath,
+    "--mode", "pretooluse",
+    "--root", $projectDir,
+    "--apply",
+    "--quiet",
+    "--tool-budget-interval", "10",
+    "--aggressive-free-gb", "22",
+    "--max-mid-fires", "5",
+    "--max-runtime-sec", "30"
+)
+
+if ($env:SESSION_COMPRESSION_TIER18 -eq "1") {
+    $arguments += "--tier18"
+}
+if ($env:SESSION_COMPRESSION_TIER19 -eq "1") {
+    $arguments += "--tier19"
+}
+
+$command = $pythonCommand[0]
+$prefixArgs = @()
+if ($pythonCommand.Count -gt 1) {
+    $prefixArgs = $pythonCommand[1..($pythonCommand.Count - 1)]
+}
+
+& $command @prefixArgs @arguments
+exit 0

--- a/.claude/hooks/session-end-auto-compress.ps1
+++ b/.claude/hooks/session-end-auto-compress.ps1
@@ -1,0 +1,71 @@
+# Issue #1564: v23 Layer LL SessionEnd/wrap-up auto-compress.
+# Runs a deterministic wrap-up compression pass. It is advisory by default and
+# only fails closed when SESSION_COMPRESSION_WRAPUP_ENFORCE=1 is set.
+
+param()
+
+$ErrorActionPreference = "SilentlyContinue"
+
+function Resolve-PythonCommand {
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        return @($python.Source)
+    }
+
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($py) {
+        return @($py.Source, "-3")
+    }
+
+    return @()
+}
+
+$projectDir = $env:CLAUDE_PROJECT_DIR
+if (-not $projectDir) { $projectDir = (Get-Location).Path }
+
+$scriptPath = Join-Path $projectDir "scripts\session_compression_guard.py"
+if (-not (Test-Path $scriptPath)) {
+    Write-Output "[KPI] session compression guard missing: $scriptPath"
+    exit 0
+}
+
+$pythonCommand = @(Resolve-PythonCommand)
+if ($pythonCommand.Count -eq 0) {
+    Write-Output "[KPI] python unavailable; wrap-up compression skipped"
+    exit 0
+}
+
+$arguments = @(
+    $scriptPath,
+    "--mode", "wrap-up",
+    "--root", $projectDir,
+    "--apply",
+    "--banner",
+    "--target-free-gb", "28",
+    "--max-runtime-sec", "120"
+)
+
+if ($env:SESSION_COMPRESSION_WRAPUP_ENFORCE -eq "1") {
+    $arguments += "--enforce"
+}
+if ($env:SESSION_COMPRESSION_TIER18 -eq "1") {
+    $arguments += "--tier18"
+}
+if ($env:SESSION_COMPRESSION_TIER19 -eq "1") {
+    $arguments += "--tier19"
+}
+
+$command = $pythonCommand[0]
+$prefixArgs = @()
+if ($pythonCommand.Count -gt 1) {
+    $prefixArgs = $pythonCommand[1..($pythonCommand.Count - 1)]
+}
+
+& $command @prefixArgs @arguments
+$exitCode = $LASTEXITCODE
+
+if ($env:SESSION_COMPRESSION_WRAPUP_ENFORCE -eq "1" -and $exitCode -ne 0) {
+    exit $exitCode
+}
+
+exit 0

--- a/.claude/hooks/userprompt-idle-gap-fire.ps1
+++ b/.claude/hooks/userprompt-idle-gap-fire.ps1
@@ -1,0 +1,56 @@
+# Issue #1564: v23 Layer MM UserPromptSubmit idle-gap auto-fire.
+# Performs a short cleanup when the last compression fire is older than the
+# idle-gap threshold. Cooldown prevents repeated fires during active work.
+
+param()
+
+$ErrorActionPreference = "SilentlyContinue"
+
+function Resolve-PythonCommand {
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        return @($python.Source)
+    }
+
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($py) {
+        return @($py.Source, "-3")
+    }
+
+    return @()
+}
+
+$projectDir = $env:CLAUDE_PROJECT_DIR
+if (-not $projectDir) { $projectDir = (Get-Location).Path }
+
+$scriptPath = Join-Path $projectDir "scripts\session_compression_guard.py"
+if (-not (Test-Path $scriptPath)) {
+    Write-Output "[KPI] session compression guard missing: $scriptPath"
+    exit 0
+}
+
+$pythonCommand = @(Resolve-PythonCommand)
+if ($pythonCommand.Count -eq 0) {
+    Write-Output "[KPI] python unavailable; idle-gap compression skipped"
+    exit 0
+}
+
+$arguments = @(
+    $scriptPath,
+    "--mode", "userprompt",
+    "--root", $projectDir,
+    "--apply",
+    "--quiet",
+    "--max-age-minutes", "30",
+    "--cooldown-minutes", "60",
+    "--max-runtime-sec", "30"
+)
+
+$command = $pythonCommand[0]
+$prefixArgs = @()
+if ($pythonCommand.Count -gt 1) {
+    $prefixArgs = $pythonCommand[1..($pythonCommand.Count - 1)]
+}
+
+& $command @prefixArgs @arguments
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,14 @@
     ],
     "PreToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/pretooluse-compression-budget.ps1"
+          }
+        ]
+      },
+      {
         "matcher": "mcp__plugin_github_github__create_or_update_file|mcp__github__push_files|mcp__plugin_github_github__push_files",
         "hooks": [
           {
@@ -71,6 +79,20 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/userprompt-kpi-banner.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/userprompt-idle-gap-fire.ps1"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/session-end-auto-compress.ps1"
           }
         ]
       }

--- a/.github/workflows/session-state-hooks.yml
+++ b/.github/workflows/session-state-hooks.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
     paths:
       - ".claude/hooks/pre-compact-backup.ps1"
+      - ".claude/hooks/pretooluse-compression-budget.ps1"
+      - ".claude/hooks/session-end-auto-compress.ps1"
       - ".claude/hooks/session-start-hard-gate.ps1"
       - ".claude/hooks/session-start-state-check.ps1"
       - ".claude/hooks/statusline.ps1"
+      - ".claude/hooks/userprompt-idle-gap-fire.ps1"
       - ".claude/hooks/userprompt-kpi-banner.ps1"
       - ".claude/settings.json"
       - ".github/workflows/session-state-hooks.yml"

--- a/docs/CLAUDE_CODE_SETUP_RUNBOOK.md
+++ b/docs/CLAUDE_CODE_SETUP_RUNBOOK.md
@@ -107,10 +107,21 @@ Default behavior is safe for repo-managed hooks:
 
 - SessionStart applies `scripts/dev_cache_cleanup.py --apply` when C: free
   space is below 26 GB or the last cleanup fire is older than 4 hours.
+- PreToolUse runs `.claude/hooks/pretooluse-compression-budget.ps1`, increments
+  a local tool-use counter, records every 10th-tool KPI snapshot, and runs a
+  capped 30-second cleanup only when C: free space is below 22 GB. The per-session
+  mid-fire cap is 5.
+- UserPromptSubmit runs `.claude/hooks/userprompt-idle-gap-fire.ps1` after the KPI
+  banner. It applies a 30-minute idle-gap cleanup with a 60-minute cooldown.
+- Stop runs `.claude/hooks/session-end-auto-compress.ps1` as the repo-managed
+  SessionEnd/wrap-up compression primitive. It is advisory unless
+  `SESSION_COMPRESSION_WRAPUP_ENFORCE=1` is set.
 - It exits zero by default so an unavailable Python runtime or a missed 28 GB
   target does not trap a user in a broken local shell.
 - Set `SESSION_COMPRESSION_FAIL_CLOSED=1` to enforce the 28 GB target and return
   a non-zero exit when cleanup fails or the target is still missed.
+- Set `SESSION_COMPRESSION_WRAPUP_ENFORCE=1` to make the wrap-up compression
+  primitive fail closed when the 28 GB target is missed.
 - Set `SESSION_COMPRESSION_DRY_RUN=1` while validating hook wiring without
   pruning caches.
 
@@ -119,6 +130,16 @@ the same `[KPI] C:<gb> RAM:<pct> last_fire:<min> fatigue:<state>` advisory. It
 does not run cleanup unless `SESSION_COMPRESSION_USERPROMPT_APPLY=1` is set,
 which keeps ordinary prompt entry lightweight while preserving the v23 idle-gap
 escape hatch.
+
+Manual verification examples:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude\hooks\pretooluse-compression-budget.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude\hooks\userprompt-idle-gap-fire.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude\hooks\session-end-auto-compress.ps1
+python scripts\session_compression_guard_test.py
+python scripts\check_session_state_hooks.py --scan-transcripts
+```
 
 ## StatusLine
 

--- a/scripts/check_session_state_hooks.py
+++ b/scripts/check_session_state_hooks.py
@@ -17,9 +17,12 @@ from pathlib import Path
 
 REQUIRED_FILES = [
     ".claude/hooks/pre-compact-backup.ps1",
+    ".claude/hooks/pretooluse-compression-budget.ps1",
+    ".claude/hooks/session-end-auto-compress.ps1",
     ".claude/hooks/session-start-hard-gate.ps1",
     ".claude/hooks/session-start-state-check.ps1",
     ".claude/hooks/statusline.ps1",
+    ".claude/hooks/userprompt-idle-gap-fire.ps1",
     ".claude/hooks/userprompt-kpi-banner.ps1",
     ".claude/settings.json",
     "docs/CLAUDE_CODE_SETUP_RUNBOOK.md",
@@ -86,6 +89,28 @@ def validate_settings(root: Path, errors: list[str]) -> None:
     ]
     if not any("userprompt-kpi-banner.ps1" in command for command in userprompt_commands):
         errors.append("UserPromptSubmit must run userprompt-kpi-banner.ps1")
+    if not any("userprompt-idle-gap-fire.ps1" in command for command in userprompt_commands):
+        errors.append("UserPromptSubmit must run userprompt-idle-gap-fire.ps1")
+
+    pretooluse_hooks = settings.get("hooks", {}).get("PreToolUse", [])
+    pretooluse_commands = [
+        str(hook.get("command", ""))
+        for group in pretooluse_hooks
+        for hook in group.get("hooks", [])
+        if isinstance(group, dict)
+    ]
+    if not any("pretooluse-compression-budget.ps1" in command for command in pretooluse_commands):
+        errors.append("PreToolUse must run pretooluse-compression-budget.ps1")
+
+    stop_hooks = settings.get("hooks", {}).get("Stop", [])
+    stop_commands = [
+        str(hook.get("command", ""))
+        for group in stop_hooks
+        for hook in group.get("hooks", [])
+        if isinstance(group, dict)
+    ]
+    if not any("session-end-auto-compress.ps1" in command for command in stop_commands):
+        errors.append("Stop must run session-end-auto-compress.ps1")
 
     precompact_hooks = settings.get("hooks", {}).get("PreCompact", [])
     precompact_commands = [
@@ -139,12 +164,27 @@ def validate_session_compression(root: Path, errors: list[str]) -> None:
     guard_label = "session_compression_guard.py"
     for needle in [
         "session_start_forced_fire",
+        "pretooluse_budget_snapshot",
+        "wrap_up_post",
         "session-delta.csv",
         "dev_cache_cleanup.py",
         "[KPI]",
         "SESSION_START_PHASE",
+        "PRETOOLUSE_PHASE",
+        "WRAP_UP_PHASE",
     ]:
         require_contains(errors, guard_text, needle, guard_label)
+
+    pretooluse_text = read_text(root, ".claude/hooks/pretooluse-compression-budget.ps1")
+    pretooluse_label = "pretooluse-compression-budget.ps1"
+    for needle in [
+        "--mode\", \"pretooluse",
+        "--tool-budget-interval\", \"10",
+        "--aggressive-free-gb\", \"22",
+        "--max-mid-fires\", \"5",
+        "session_compression_guard.py",
+    ]:
+        require_contains(errors, pretooluse_text, needle, pretooluse_label)
 
     hard_gate_text = read_text(root, ".claude/hooks/session-start-hard-gate.ps1")
     hard_gate_label = "session-start-hard-gate.ps1"
@@ -166,6 +206,26 @@ def validate_session_compression(root: Path, errors: list[str]) -> None:
         "session_compression_guard.py",
     ]:
         require_contains(errors, banner_text, needle, banner_label)
+
+    idle_gap_text = read_text(root, ".claude/hooks/userprompt-idle-gap-fire.ps1")
+    idle_gap_label = "userprompt-idle-gap-fire.ps1"
+    for needle in [
+        "--mode\", \"userprompt",
+        "--apply",
+        "--cooldown-minutes\", \"60",
+        "session_compression_guard.py",
+    ]:
+        require_contains(errors, idle_gap_text, needle, idle_gap_label)
+
+    wrap_up_text = read_text(root, ".claude/hooks/session-end-auto-compress.ps1")
+    wrap_up_label = "session-end-auto-compress.ps1"
+    for needle in [
+        "SESSION_COMPRESSION_WRAPUP_ENFORCE",
+        "--mode\", \"wrap-up",
+        "--target-free-gb\", \"28",
+        "session_compression_guard.py",
+    ]:
+        require_contains(errors, wrap_up_text, needle, wrap_up_label)
 
 
 def validate_statusline(root: Path, errors: list[str]) -> None:

--- a/scripts/session_compression_guard.py
+++ b/scripts/session_compression_guard.py
@@ -5,6 +5,9 @@ This script implements the safe, dependency-free parts of the v23 structural
 session compression contract for Issue #1564:
 
 - Layer JJ: SessionStart hard-gate decision and optional cleanup fire.
+- Layer KK: PreToolUse compression budget snapshot and capped mid-session fire.
+- Layer LL: SessionEnd/wrap-up compression pass.
+- Layer MM: UserPromptSubmit idle-gap cleanup fire.
 - Layer NN: SessionStart/UserPromptSubmit KPI banner.
 
 It writes state under the user's home directory by default so committed repo
@@ -29,6 +32,8 @@ from typing import Any
 
 SESSION_START_PHASE = "session_start_forced_fire"
 USERPROMPT_PHASE = "idle_gap_pre"
+PRETOOLUSE_PHASE = "pretooluse_budget_snapshot"
+WRAP_UP_PHASE = "wrap_up_post"
 STATE_VERSION = 1
 
 
@@ -310,6 +315,27 @@ def decide_userprompt(
     return True, "idle gap exceeded"
 
 
+def decide_pretooluse(
+    *,
+    state: dict[str, Any],
+    c_free_gb: float,
+    interval: int,
+    aggressive_free_gb: float,
+    max_mid_fires: int,
+) -> tuple[bool, bool, str]:
+    tool_count = int(state.get("tool_use_count_session") or 0) + 1
+    mid_fires = int(state.get("mid_fire_count_session") or 0)
+    state["tool_use_count_session"] = tool_count
+
+    if tool_count % interval != 0:
+        return False, False, f"tool_use_count {tool_count} not on {interval}-tool boundary"
+    if c_free_gb >= aggressive_free_gb:
+        return True, False, f"budget snapshot at tool_use_count {tool_count}; c_free_gb {c_free_gb:.2f} >= {aggressive_free_gb:.2f}"
+    if mid_fires >= max_mid_fires:
+        return True, False, f"mid-fire cap reached {mid_fires}/{max_mid_fires}"
+    return True, True, f"c_free_gb {c_free_gb:.2f} < {aggressive_free_gb:.2f} at tool_use_count {tool_count}"
+
+
 def run_guard(args: argparse.Namespace) -> GuardResult:
     now = iso_now(args.sample_now)
     state = load_state(args.state_path)
@@ -328,6 +354,9 @@ def run_guard(args: argparse.Namespace) -> GuardResult:
         fatigue=fatigue,
     )
 
+    cleanup_required = False
+    state_dirty = False
+
     if args.mode == "session-start":
         phase = SESSION_START_PHASE
         should_fire, reason = decide_session_start(
@@ -336,7 +365,12 @@ def run_guard(args: argparse.Namespace) -> GuardResult:
             min_free_gb=args.min_free_gb,
             max_age_hours=args.max_age_hours,
         )
-    else:
+        state["session_started_at"] = now.isoformat()
+        state["tool_use_count_session"] = 0
+        state["mid_fire_count_session"] = 0
+        state_dirty = True
+        cleanup_required = should_fire
+    elif args.mode == "userprompt":
         phase = USERPROMPT_PHASE
         should_fire, reason = decide_userprompt(
             now=now,
@@ -344,11 +378,27 @@ def run_guard(args: argparse.Namespace) -> GuardResult:
             max_age_minutes=args.max_age_minutes,
             cooldown_minutes=args.cooldown_minutes,
         )
+        cleanup_required = should_fire
+    elif args.mode == "pretooluse":
+        phase = PRETOOLUSE_PHASE
+        should_fire, cleanup_required, reason = decide_pretooluse(
+            state=state,
+            c_free_gb=c_free_before,
+            interval=args.tool_budget_interval,
+            aggressive_free_gb=args.aggressive_free_gb,
+            max_mid_fires=args.max_mid_fires,
+        )
+        state_dirty = True
+    else:
+        phase = WRAP_UP_PHASE
+        should_fire = True
+        cleanup_required = True
+        reason = "wrap-up compression required"
 
     cleanup = CleanupResult(status="skipped")
     c_free_after: float | None = None
     ram_after: float | None = None
-    if args.apply and should_fire:
+    if args.apply and should_fire and cleanup_required:
         cleanup = run_dev_cache_cleanup(args)
         if args.sample_free_gb_after is not None:
             c_free_after = args.sample_free_gb_after
@@ -374,9 +424,24 @@ def run_guard(args: argparse.Namespace) -> GuardResult:
         state["last_fire_at"] = now.isoformat()
         if args.mode == "userprompt":
             state["last_userprompt_fire_at"] = now.isoformat()
+        if args.mode == "pretooluse":
+            state["mid_fire_count_session"] = int(state.get("mid_fire_count_session") or 0) + 1
+        state_dirty = True
+
+    if args.apply and should_fire and not cleanup_required:
+        cleanup = CleanupResult(status="snapshot_only")
+
+    if args.apply and state_dirty:
         write_state(args.state_path, state)
 
-    decision = "fire" if should_fire and args.apply else "due" if should_fire else "skip"
+    if should_fire and args.apply and cleanup_required:
+        decision = "fire"
+    elif should_fire and args.apply:
+        decision = "snapshot"
+    elif should_fire:
+        decision = "due"
+    else:
+        decision = "skip"
     result = GuardResult(
         mode=args.mode,
         phase=phase,
@@ -406,7 +471,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     home_log = Path.home() / ".claude" / "logs" / "session-delta.csv"
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--mode", choices=("session-start", "userprompt"), default="session-start")
+    parser.add_argument(
+        "--mode",
+        choices=("session-start", "userprompt", "pretooluse", "wrap-up"),
+        default="session-start",
+    )
     parser.add_argument("--root", type=Path, default=repo_root)
     parser.add_argument("--drive", type=Path, default=default_drive_root())
     parser.add_argument("--state-path", type=Path, default=home_state)
@@ -416,12 +485,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--max-age-hours", type=float, default=4.0)
     parser.add_argument("--max-age-minutes", type=float, default=30.0)
     parser.add_argument("--cooldown-minutes", type=float, default=60.0)
+    parser.add_argument("--tool-budget-interval", type=int, default=10)
+    parser.add_argument("--aggressive-free-gb", type=float, default=22.0)
+    parser.add_argument("--max-mid-fires", type=int, default=5)
     parser.add_argument("--max-runtime-sec", type=int, default=120)
     parser.add_argument("--apply", action="store_true")
     parser.add_argument("--tier18", action="store_true")
     parser.add_argument("--tier19", action="store_true")
     parser.add_argument("--enforce", action="store_true")
     parser.add_argument("--banner", action="store_true")
+    parser.add_argument("--quiet", action="store_true")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--log-dry-run", action="store_true")
     parser.add_argument("--sample-free-gb", type=float)
@@ -438,7 +511,7 @@ def main(argv: list[str]) -> int:
 
     if args.json:
         print(json.dumps(asdict(result), ensure_ascii=False, indent=2))
-    else:
+    elif not args.quiet or result.should_fire:
         if args.banner:
             print(result.banner)
         print(f"{result.mode}: {result.decision} ({result.reason})")

--- a/scripts/session_compression_guard_test.py
+++ b/scripts/session_compression_guard_test.py
@@ -101,6 +101,47 @@ class SessionCompressionGuardTest(unittest.TestCase):
         self.assertFalse(result["should_fire"])
         self.assertIn("userprompt cooldown", result["reason"])
 
+    def test_pretooluse_records_budget_snapshot_on_tenth_tool(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            state = tmp / "state.json"
+            state.write_text(
+                json.dumps({"tool_use_count_session": 9, "mid_fire_count_session": 0, "fires": []}),
+                encoding="utf-8",
+            )
+            result = self.run_guard(
+                tmp,
+                "--mode",
+                "pretooluse",
+                "--apply",
+                "--sample-free-gb",
+                "24.0",
+                "--sample-now",
+                "2026-05-14T01:15:00+00:00",
+            )
+
+        self.assertTrue(result["should_fire"])
+        self.assertEqual(result["decision"], "snapshot")
+        self.assertEqual(result["cleanup"]["status"], "snapshot_only")
+        self.assertEqual(result["phase"], "pretooluse_budget_snapshot")
+
+    def test_wrap_up_is_always_due(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            result = self.run_guard(
+                tmp,
+                "--mode",
+                "wrap-up",
+                "--sample-free-gb",
+                "27.0",
+                "--sample-now",
+                "2026-05-14T01:15:00+00:00",
+            )
+
+        self.assertTrue(result["should_fire"])
+        self.assertEqual(result["phase"], "wrap_up_post")
+        self.assertEqual(result["reason"], "wrap-up compression required")
+
     def test_fatigue_flag_uses_last_three_reclaim_values(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             tmp = Path(raw)


### PR DESCRIPTION
﻿## Summary

- Complete the repo-managed v23 compression slice for Issue #1564 by adding Layer KK PreToolUse budget snapshots, Layer LL wrap-up compression, and Layer MM idle-gap cleanup.
- Wire the new PowerShell hooks in `.claude/settings.json`, extend the dependency-free guard, and cover the new modes in tests plus the session hook validator.
- Document the operating thresholds and manual verification commands in `docs/CLAUDE_CODE_SETUP_RUNBOOK.md`.

## Minimal E2E Gate

- Implementation-detail independent: the verification checks hook command input/output contracts and persisted KPI state, not private implementation details.
- Minimal scope: about three I/O cases only: PreToolUse 10th-call snapshot, idle-gap cooldown behavior, and wrap-up compression due decision.
- E2E mechanism: no browser E2E is included because this PR changes repo-managed Claude hook automation rather than user-facing UI; the equivalent end-to-end coverage is `python scripts/session_compression_guard_test.py` plus PowerShell hook parse checks and `python scripts/check_session_state_hooks.py --scan-transcripts`.
- E2E-Exception: UI/browser Playwright is not applicable for local hook wiring; the hook scripts are validated through CLI I/O and CI hook validation.

## Visual E2E Evidence

- Not applicable: no UI route, layout, generated imagery, or browser interaction changed.
- Console/page/request review is not applicable for repo-managed local hook automation.

## High-risk Ultrareview Gate

High-risk-ultrareview-exception: Claude Code #1 is the review owner; visible exception reason is that this is repo-managed local hook automation with no production deploy logic, no Supabase/data migration, no credential material, and no user-facing runtime surface. Codex #1 performed deterministic local validation and the CI hook validator is the reviewable safety artifact.

## Validation

- `python -m py_compile scripts\session_compression_guard.py scripts\session_compression_guard_test.py scripts\check_session_state_hooks.py`
- `python scripts\session_compression_guard_test.py`
- `python scripts\check_session_state_hooks.py --scan-transcripts`
- PowerShell parse checks for the new hook wrappers
- `git diff --check`
- `python scripts\codex_session_check.py --json` (existing user-home MCP warnings only)

Related to #1564
