### PR TITLE
[codex] Add feature-flagged Supabase sync for asset liability board

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -214,7 +214,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   void initState() {
     super.initState();
     _assetLiabilityRepository = widget.assetLiabilityRepository ??
-        const SharedPreferencesAssetLiabilityRepository();
+        AssetLiabilityRepositoryFactory.createDefault(
+          supabaseClient: _supabase,
+        );
     _loadDataFromSupabase();
     _loadAssetLiabilityMonthlyState();
     _loadWatchlistEntries();

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1,6 +1,14 @@
+import 'package:flutter/foundation.dart';
 import 'package:my_web_app/models/asset_liability_persistence.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+typedef AssetLiabilityUserIdProvider = String? Function();
+typedef AssetLiabilitySyncErrorHandler = void Function(
+  Object error,
+  StackTrace stackTrace,
+);
 
 abstract class AssetLiabilityRepository {
   const AssetLiabilityRepository();
@@ -41,6 +49,544 @@ abstract class AssetLiabilityRepository {
       recurringIncomeTemplates: await loadRecurringIncomeTemplates(),
       monthlySnapshots: await loadMonthlySnapshots(),
     );
+  }
+}
+
+abstract class AssetLiabilityRemoteStore {
+  const AssetLiabilityRemoteStore();
+
+  Future<AssetLiabilityMonthlyState?> loadMonth({
+    required String userId,
+    required DateTime month,
+  });
+
+  Future<void> saveMonth({
+    required String userId,
+    required DateTime month,
+    required AssetLiabilityMonthlyState state,
+  });
+
+  Future<Map<String, String>?> loadDefaultPaymentSources({
+    required String userId,
+  });
+
+  Future<void> saveDefaultPaymentSources({
+    required String userId,
+    required Map<String, String> sources,
+  });
+
+  Future<List<AssetLiabilityRecurringIncomeTemplate>?>
+      loadRecurringIncomeTemplates({required String userId});
+
+  Future<void> saveRecurringIncomeTemplates({
+    required String userId,
+    required List<AssetLiabilityRecurringIncomeTemplate> templates,
+  });
+
+  Future<List<AssetLiabilityMonthlySnapshot>?> loadMonthlySnapshots({
+    required String userId,
+  });
+
+  Future<void> saveMonthlySnapshot({
+    required String userId,
+    required AssetLiabilityMonthlySnapshot snapshot,
+  });
+}
+
+class AssetLiabilityRepositoryFactory {
+  static const String syncFlagName = 'ASSET_LIABILITY_SUPABASE_SYNC_ENABLED';
+  static const bool supabaseSyncEnabled = bool.fromEnvironment(syncFlagName);
+
+  const AssetLiabilityRepositoryFactory._();
+
+  static AssetLiabilityRepository createDefault({
+    SupabaseClient? supabaseClient,
+    AssetLiabilityRepository localRepository =
+        const SharedPreferencesAssetLiabilityRepository(),
+    bool syncEnabled = supabaseSyncEnabled,
+    AssetLiabilityRemoteStore? remoteStore,
+    AssetLiabilityUserIdProvider? userIdProvider,
+    AssetLiabilitySyncErrorHandler? onSyncError,
+  }) {
+    if (!syncEnabled) {
+      return localRepository;
+    }
+
+    final client = supabaseClient ?? Supabase.instance.client;
+    return FeatureFlaggedAssetLiabilityRepository(
+      localRepository: localRepository,
+      remoteStore: remoteStore ?? AssetLiabilitySupabaseRemoteStore(client),
+      syncEnabled: syncEnabled,
+      userIdProvider: userIdProvider ?? () => client.auth.currentUser?.id,
+      onSyncError: onSyncError,
+    );
+  }
+}
+
+class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
+  final AssetLiabilityRepository localRepository;
+  final AssetLiabilityRemoteStore? remoteStore;
+  final bool syncEnabled;
+  final AssetLiabilityUserIdProvider userIdProvider;
+  final AssetLiabilitySyncErrorHandler? onSyncError;
+
+  const FeatureFlaggedAssetLiabilityRepository({
+    required this.localRepository,
+    required this.remoteStore,
+    required this.syncEnabled,
+    required this.userIdProvider,
+    this.onSyncError,
+  });
+
+  @override
+  Future<AssetLiabilityMonthlyState> loadMonth(DateTime month) async {
+    final local = await localRepository.loadMonth(month);
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return local;
+    }
+
+    final remoteState = await _tryRemote(
+      () => remote.loadMonth(userId: userId, month: month),
+    );
+    if (remoteState == null || remoteState.isEmpty) {
+      if (!local.isEmpty) {
+        await _tryRemote(
+          () => remote.saveMonth(userId: userId, month: month, state: local),
+        );
+      }
+      return local;
+    }
+
+    if (local.isEmpty) {
+      await localRepository.saveMonth(month: month, state: remoteState);
+      return remoteState;
+    }
+
+    return local;
+  }
+
+  @override
+  Future<void> saveMonth({
+    required DateTime month,
+    required AssetLiabilityMonthlyState state,
+  }) async {
+    await localRepository.saveMonth(month: month, state: state);
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return;
+    }
+    await _tryRemote(
+      () => remote.saveMonth(userId: userId, month: month, state: state),
+    );
+  }
+
+  @override
+  Future<Map<String, String>> loadDefaultPaymentSources() async {
+    final local = await localRepository.loadDefaultPaymentSources();
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return local;
+    }
+
+    final remoteSources = await _tryRemote(
+      () => remote.loadDefaultPaymentSources(userId: userId),
+    );
+    if (remoteSources == null || remoteSources.isEmpty) {
+      if (local.isNotEmpty) {
+        await _tryRemote(
+          () =>
+              remote.saveDefaultPaymentSources(userId: userId, sources: local),
+        );
+      }
+      return local;
+    }
+
+    if (local.isEmpty) {
+      await localRepository.saveDefaultPaymentSources(remoteSources);
+      return remoteSources;
+    }
+
+    return local;
+  }
+
+  @override
+  Future<void> saveDefaultPaymentSources(Map<String, String> sources) async {
+    await localRepository.saveDefaultPaymentSources(sources);
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return;
+    }
+    await _tryRemote(
+      () => remote.saveDefaultPaymentSources(userId: userId, sources: sources),
+    );
+  }
+
+  @override
+  Future<List<AssetLiabilityRecurringIncomeTemplate>>
+      loadRecurringIncomeTemplates() async {
+    final local = await localRepository.loadRecurringIncomeTemplates();
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return local;
+    }
+
+    final remoteTemplates = await _tryRemote(
+      () => remote.loadRecurringIncomeTemplates(userId: userId),
+    );
+    if (remoteTemplates == null || remoteTemplates.isEmpty) {
+      if (local.isNotEmpty) {
+        await _tryRemote(
+          () => remote.saveRecurringIncomeTemplates(
+            userId: userId,
+            templates: local,
+          ),
+        );
+      }
+      return local;
+    }
+
+    if (local.isEmpty) {
+      await localRepository.saveRecurringIncomeTemplates(remoteTemplates);
+      return remoteTemplates;
+    }
+
+    return local;
+  }
+
+  @override
+  Future<void> saveRecurringIncomeTemplates(
+    List<AssetLiabilityRecurringIncomeTemplate> templates,
+  ) async {
+    await localRepository.saveRecurringIncomeTemplates(templates);
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return;
+    }
+    await _tryRemote(
+      () => remote.saveRecurringIncomeTemplates(
+        userId: userId,
+        templates: templates,
+      ),
+    );
+  }
+
+  @override
+  Future<AssetLiabilityMonthlyState> copyPreviousMonthToMonth(
+    DateTime targetMonth,
+  ) async {
+    final previousMonth = DateTime(targetMonth.year, targetMonth.month - 1);
+    final previousState = await loadMonth(previousMonth);
+    final copied = AssetLiabilityMonthlyStateStore.copyPreviousMonthState(
+      previousState: previousState,
+      targetMonth: targetMonth,
+    );
+    await saveMonth(month: targetMonth, state: copied);
+    return copied;
+  }
+
+  @override
+  Future<List<AssetLiabilityMonthlySnapshot>> loadMonthlySnapshots() async {
+    final local = await localRepository.loadMonthlySnapshots();
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return local;
+    }
+
+    final remoteSnapshots = await _tryRemote(
+      () => remote.loadMonthlySnapshots(userId: userId),
+    );
+    if (remoteSnapshots == null || remoteSnapshots.isEmpty) {
+      if (local.isNotEmpty) {
+        for (final snapshot in local) {
+          await _tryRemote(
+            () =>
+                remote.saveMonthlySnapshot(userId: userId, snapshot: snapshot),
+          );
+        }
+      }
+      return local;
+    }
+
+    if (local.isEmpty) {
+      for (final snapshot in remoteSnapshots) {
+        await localRepository.saveMonthlySnapshot(snapshot);
+      }
+      return remoteSnapshots;
+    }
+
+    return local;
+  }
+
+  @override
+  Future<void> saveMonthlySnapshot(
+    AssetLiabilityMonthlySnapshot snapshot,
+  ) async {
+    await localRepository.saveMonthlySnapshot(snapshot);
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return;
+    }
+    await _tryRemote(
+      () => remote.saveMonthlySnapshot(userId: userId, snapshot: snapshot),
+    );
+  }
+
+  AssetLiabilityRemoteStore? _remoteOrNull() {
+    return syncEnabled ? remoteStore : null;
+  }
+
+  String? _userIdOrNull() {
+    final userId = userIdProvider()?.trim();
+    return userId == null || userId.isEmpty ? null : userId;
+  }
+
+  Future<T?> _tryRemote<T>(Future<T> Function() action) async {
+    try {
+      return await action();
+    } catch (error, stackTrace) {
+      if (onSyncError != null) {
+        onSyncError!(error, stackTrace);
+      } else {
+        debugPrint('Asset liability Supabase sync skipped: $error');
+      }
+      return null;
+    }
+  }
+}
+
+class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
+  final SupabaseClient client;
+
+  const AssetLiabilitySupabaseRemoteStore(this.client);
+
+  @override
+  Future<AssetLiabilityMonthlyState?> loadMonth({
+    required String userId,
+    required DateTime month,
+  }) async {
+    final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(month);
+    final monthlyRow = await _loadPayloadRow(
+      AssetLiabilitySupabaseTablePlan.monthlyStatesTable,
+      userId: userId,
+      monthKey: monthKey,
+    );
+    final incomeRow = await _loadPayloadRow(
+      AssetLiabilitySupabaseTablePlan.incomePlansTable,
+      userId: userId,
+      monthKey: monthKey,
+    );
+    if (monthlyRow == null && incomeRow == null) {
+      return null;
+    }
+
+    final payload = <String, Object?>{
+      ...?monthlyRow,
+      ...?incomeRow,
+      'month_key': monthKey,
+    };
+    return AssetLiabilityMonthlyStatePayload.fromSupabaseJson(
+      payload,
+    ).toState();
+  }
+
+  @override
+  Future<void> saveMonth({
+    required String userId,
+    required DateTime month,
+    required AssetLiabilityMonthlyState state,
+  }) async {
+    final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(month);
+    final row = AssetLiabilityMonthlyStatePayload.fromState(
+      monthKey: monthKey,
+      state: state,
+    ).toSupabaseJson(userId: userId);
+
+    await _upsertPayloadRow(
+      AssetLiabilitySupabaseTablePlan.monthlyStatesTable,
+      userId: userId,
+      monthKey: monthKey,
+      payload: <String, Object?>{
+        'payment_overrides': row['payment_overrides'],
+        'paid_account_ids': row['paid_account_ids'],
+        'payment_source_account_ids': row['payment_source_account_ids'],
+      },
+    );
+    await _upsertPayloadRow(
+      AssetLiabilitySupabaseTablePlan.incomePlansTable,
+      userId: userId,
+      monthKey: monthKey,
+      payload: <String, Object?>{'income_plans': row['income_plans']},
+    );
+  }
+
+  @override
+  Future<Map<String, String>?> loadDefaultPaymentSources({
+    required String userId,
+  }) async {
+    final payload = await _loadPayloadRow(
+      AssetLiabilitySupabaseTablePlan.paymentSourceSettingsTable,
+      userId: userId,
+      monthKey: AssetLiabilitySupabaseTablePlan.globalMonthKey,
+    );
+    if (payload == null) {
+      return null;
+    }
+    return AssetLiabilityUserSettingsPayload.fromSupabaseJson(
+      payload,
+    ).defaultPaymentSourceAccountIds;
+  }
+
+  @override
+  Future<void> saveDefaultPaymentSources({
+    required String userId,
+    required Map<String, String> sources,
+  }) async {
+    final row = AssetLiabilityUserSettingsPayload(
+      defaultPaymentSourceAccountIds: sources,
+      recurringIncomeTemplates: const <AssetLiabilityRecurringIncomeTemplate>[],
+    ).toSupabaseJson(userId: userId);
+    await _upsertPayloadRow(
+      AssetLiabilitySupabaseTablePlan.paymentSourceSettingsTable,
+      userId: userId,
+      monthKey: AssetLiabilitySupabaseTablePlan.globalMonthKey,
+      payload: <String, Object?>{
+        'default_payment_source_account_ids':
+            row['default_payment_source_account_ids'],
+      },
+    );
+  }
+
+  @override
+  Future<List<AssetLiabilityRecurringIncomeTemplate>?>
+      loadRecurringIncomeTemplates({required String userId}) async {
+    final payload = await _loadPayloadRow(
+      AssetLiabilitySupabaseTablePlan.recurringIncomeTemplatesTable,
+      userId: userId,
+      monthKey: AssetLiabilitySupabaseTablePlan.globalMonthKey,
+    );
+    if (payload == null) {
+      return null;
+    }
+    return AssetLiabilityUserSettingsPayload.fromSupabaseJson(
+      payload,
+    ).recurringIncomeTemplates;
+  }
+
+  @override
+  Future<void> saveRecurringIncomeTemplates({
+    required String userId,
+    required List<AssetLiabilityRecurringIncomeTemplate> templates,
+  }) async {
+    final row = AssetLiabilityUserSettingsPayload(
+      defaultPaymentSourceAccountIds: const <String, String>{},
+      recurringIncomeTemplates: templates,
+    ).toSupabaseJson(userId: userId);
+    await _upsertPayloadRow(
+      AssetLiabilitySupabaseTablePlan.recurringIncomeTemplatesTable,
+      userId: userId,
+      monthKey: AssetLiabilitySupabaseTablePlan.globalMonthKey,
+      payload: <String, Object?>{
+        'recurring_income_templates': row['recurring_income_templates'],
+      },
+    );
+  }
+
+  @override
+  Future<List<AssetLiabilityMonthlySnapshot>?> loadMonthlySnapshots({
+    required String userId,
+  }) async {
+    final response = await client
+        .from(AssetLiabilitySupabaseTablePlan.monthlySnapshotsTable)
+        .select('month_key,payload')
+        .eq('user_id', userId)
+        .order('month_key');
+
+    final snapshots = <AssetLiabilityMonthlySnapshot>[];
+    for (final item in response) {
+      final monthKey = item['month_key']?.toString();
+      final payload = _payloadFromRow(item);
+      if (monthKey == null || monthKey.isEmpty || payload == null) {
+        continue;
+      }
+      snapshots.add(
+        AssetLiabilityMonthlySnapshotPayload.fromSupabaseJson(<String, Object?>{
+          ...payload,
+          'month_key': monthKey,
+        }).snapshot,
+      );
+    }
+    snapshots.sort((a, b) => a.monthKey.compareTo(b.monthKey));
+    return snapshots;
+  }
+
+  @override
+  Future<void> saveMonthlySnapshot({
+    required String userId,
+    required AssetLiabilityMonthlySnapshot snapshot,
+  }) async {
+    final row = AssetLiabilityMonthlySnapshotPayload(
+      snapshot: snapshot,
+    ).toSupabaseJson(userId: userId);
+    await _upsertPayloadRow(
+      AssetLiabilitySupabaseTablePlan.monthlySnapshotsTable,
+      userId: userId,
+      monthKey: snapshot.monthKey,
+      payload: Map<String, Object?>.from(row)
+        ..remove('user_id')
+        ..remove('month_key'),
+    );
+  }
+
+  Future<Map<String, Object?>?> _loadPayloadRow(
+    String table, {
+    required String userId,
+    required String monthKey,
+  }) async {
+    final response = await client
+        .from(table)
+        .select('payload')
+        .eq('user_id', userId)
+        .eq('month_key', monthKey)
+        .maybeSingle();
+    if (response == null) {
+      return null;
+    }
+    return _payloadFromRow(response);
+  }
+
+  Future<void> _upsertPayloadRow(
+    String table, {
+    required String userId,
+    required String monthKey,
+    required Map<String, Object?> payload,
+  }) async {
+    await client.from(table).upsert(
+      <String, Object?>{
+        'user_id': userId,
+        'month_key': monthKey,
+        'payload': payload,
+      },
+      onConflict: 'user_id,month_key',
+    );
+  }
+
+  Map<String, Object?>? _payloadFromRow(Map<dynamic, dynamic> row) {
+    final payload = row['payload'];
+    if (payload is Map) {
+      return payload.map<String, Object?>(
+        (key, value) => MapEntry(key.toString(), value),
+      );
+    }
+    return null;
   }
 }
 

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -175,6 +175,183 @@ void main() {
     );
   });
 
+  group('FeatureFlaggedAssetLiabilityRepository', () {
+    test('factory keeps Supabase sync disabled by default', () {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore();
+
+      final repository = AssetLiabilityRepositoryFactory.createDefault(
+        localRepository: local,
+        remoteStore: remote,
+      );
+
+      expect(AssetLiabilityRepositoryFactory.supabaseSyncEnabled, isFalse);
+      expect(repository, same(local));
+      expect(remote.calls, isEmpty);
+    });
+
+    test('does not call remote store when Supabase sync flag is off', () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore();
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: false,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+
+      await repository.saveMonth(month: month, state: _sampleMonthlyState());
+      final restored = await repository.loadMonth(month);
+
+      expect(restored.paymentOverrides['mobit'], 70000);
+      expect(remote.calls, isEmpty);
+    });
+
+    test(
+      'saves monthly data and settings through remote store when on',
+      () async {
+        final local = _FakeAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore();
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
+        final snapshot = _sampleSnapshot('2026-05');
+
+        await repository.saveMonth(month: month, state: _sampleMonthlyState());
+        await repository.saveDefaultPaymentSources(const <String, String>{
+          'mobit': 'smbc_otsuka',
+        });
+        await repository.saveRecurringIncomeTemplates(
+          <AssetLiabilityRecurringIncomeTemplate>[
+            _sampleRecurringIncomeTemplate(),
+          ],
+        );
+        await repository.saveMonthlySnapshot(snapshot);
+
+        expect(remote.monthState('2026-05')?.paymentOverrides['mobit'], 70000);
+        expect(remote.defaultPaymentSources['mobit'], 'smbc_otsuka');
+        expect(remote.recurringIncomeTemplates.single.id, 'salary');
+        expect(remote.monthlySnapshots.single.monthKey, '2026-05');
+      },
+    );
+
+    test('keeps local save when remote save fails', () async {
+      final errors = <Object>[];
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore()..failSaves = true;
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+        onSyncError: (error, _) => errors.add(error),
+      );
+      final month = DateTime(2026, 5);
+
+      await repository.saveMonth(month: month, state: _sampleMonthlyState());
+
+      final localState = await local.loadMonth(month);
+      expect(localState.paymentOverrides['mobit'], 70000);
+      expect(errors, isNotEmpty);
+      expect(remote.calls, contains('saveMonth:user-1:2026-05'));
+    });
+
+    test('uploads local monthly state when remote is empty', () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore();
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+      await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+      final restored = await repository.loadMonth(month);
+
+      expect(restored.paymentOverrides['mobit'], 70000);
+      expect(remote.monthState('2026-05')?.paymentOverrides['mobit'], 70000);
+    });
+
+    test('restores remote monthly state when local is empty', () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore()
+        ..seedMonth(DateTime(2026, 5), _sampleMonthlyState());
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+
+      final restored = await repository.loadMonth(month);
+      final localState = await local.loadMonth(month);
+
+      expect(restored.paymentOverrides['mobit'], 70000);
+      expect(localState.paymentOverrides['mobit'], 70000);
+    });
+
+    test('restores remote settings and snapshots when local is empty',
+        () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore()
+        ..seedDefaultPaymentSources(const <String, String>{
+          'mobit': 'smbc_otsuka',
+        })
+        ..seedRecurringIncomeTemplates(<AssetLiabilityRecurringIncomeTemplate>[
+          _sampleRecurringIncomeTemplate(),
+        ])
+        ..seedMonthlySnapshots(<AssetLiabilityMonthlySnapshot>[
+          _sampleSnapshot('2026-05'),
+        ]);
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+
+      final sources = await repository.loadDefaultPaymentSources();
+      final templates = await repository.loadRecurringIncomeTemplates();
+      final snapshots = await repository.loadMonthlySnapshots();
+
+      expect(sources['mobit'], 'smbc_otsuka');
+      expect(templates.single.id, 'salary');
+      expect(snapshots.single.monthKey, '2026-05');
+      expect((await local.loadDefaultPaymentSources())['mobit'], 'smbc_otsuka');
+      expect((await local.loadRecurringIncomeTemplates()).single.id, 'salary');
+      expect((await local.loadMonthlySnapshots()).single.monthKey, '2026-05');
+    });
+
+    test(
+      'keeps local repository usable when no Supabase user is available',
+      () async {
+        final local = _FakeAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore();
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          userIdProvider: () => null,
+        );
+        final month = DateTime(2026, 5);
+
+        await repository.saveMonth(month: month, state: _sampleMonthlyState());
+        final restored = await repository.loadMonth(month);
+
+        expect(restored.paymentOverrides['mobit'], 70000);
+        expect(remote.calls, isEmpty);
+      },
+    );
+  });
+
   group('Asset liability Supabase payloads', () {
     test('round-trips monthly state payload', () {
       final state = AssetLiabilityMonthlyState(
@@ -363,4 +540,209 @@ class _FakeAssetLiabilityRepository extends AssetLiabilityRepository {
     _snapshots.add(snapshot);
     _snapshots.sort((a, b) => a.monthKey.compareTo(b.monthKey));
   }
+}
+
+class _RecordingAssetLiabilityRemoteStore extends AssetLiabilityRemoteStore {
+  final List<String> calls = <String>[];
+  final Map<String, AssetLiabilityMonthlyState> _states =
+      <String, AssetLiabilityMonthlyState>{};
+  final Map<String, String> _defaultPaymentSources = <String, String>{};
+  final List<AssetLiabilityRecurringIncomeTemplate> _recurringIncomeTemplates =
+      <AssetLiabilityRecurringIncomeTemplate>[];
+  final List<AssetLiabilityMonthlySnapshot> _monthlySnapshots =
+      <AssetLiabilityMonthlySnapshot>[];
+
+  bool _hasDefaultPaymentSources = false;
+  bool _hasRecurringIncomeTemplates = false;
+  bool _hasMonthlySnapshots = false;
+  bool failSaves = false;
+
+  Map<String, String> get defaultPaymentSources =>
+      Map<String, String>.from(_defaultPaymentSources);
+
+  List<AssetLiabilityRecurringIncomeTemplate> get recurringIncomeTemplates =>
+      List<AssetLiabilityRecurringIncomeTemplate>.from(
+        _recurringIncomeTemplates,
+      );
+
+  List<AssetLiabilityMonthlySnapshot> get monthlySnapshots =>
+      List<AssetLiabilityMonthlySnapshot>.from(_monthlySnapshots);
+
+  AssetLiabilityMonthlyState? monthState(String monthKey) => _states[monthKey];
+
+  void seedMonth(DateTime month, AssetLiabilityMonthlyState state) {
+    _states[AssetLiabilityMonthlyStateStore.formatMonthKey(month)] = state;
+  }
+
+  void seedDefaultPaymentSources(Map<String, String> sources) {
+    _hasDefaultPaymentSources = true;
+    _defaultPaymentSources
+      ..clear()
+      ..addAll(sources);
+  }
+
+  void seedRecurringIncomeTemplates(
+    List<AssetLiabilityRecurringIncomeTemplate> templates,
+  ) {
+    _hasRecurringIncomeTemplates = true;
+    _recurringIncomeTemplates
+      ..clear()
+      ..addAll(templates);
+  }
+
+  void seedMonthlySnapshots(List<AssetLiabilityMonthlySnapshot> snapshots) {
+    _hasMonthlySnapshots = true;
+    _monthlySnapshots
+      ..clear()
+      ..addAll(snapshots)
+      ..sort((a, b) => a.monthKey.compareTo(b.monthKey));
+  }
+
+  @override
+  Future<AssetLiabilityMonthlyState?> loadMonth({
+    required String userId,
+    required DateTime month,
+  }) async {
+    final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(month);
+    calls.add('loadMonth:$userId:$monthKey');
+    return _states[monthKey];
+  }
+
+  @override
+  Future<void> saveMonth({
+    required String userId,
+    required DateTime month,
+    required AssetLiabilityMonthlyState state,
+  }) async {
+    final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(month);
+    calls.add('saveMonth:$userId:$monthKey');
+    _throwIfSavingFails();
+    _states[monthKey] = state;
+  }
+
+  @override
+  Future<Map<String, String>?> loadDefaultPaymentSources({
+    required String userId,
+  }) async {
+    calls.add('loadDefaultPaymentSources:$userId');
+    if (!_hasDefaultPaymentSources) {
+      return null;
+    }
+    return Map<String, String>.from(_defaultPaymentSources);
+  }
+
+  @override
+  Future<void> saveDefaultPaymentSources({
+    required String userId,
+    required Map<String, String> sources,
+  }) async {
+    calls.add('saveDefaultPaymentSources:$userId');
+    _throwIfSavingFails();
+    _hasDefaultPaymentSources = true;
+    _defaultPaymentSources
+      ..clear()
+      ..addAll(sources);
+  }
+
+  @override
+  Future<List<AssetLiabilityRecurringIncomeTemplate>?>
+      loadRecurringIncomeTemplates({required String userId}) async {
+    calls.add('loadRecurringIncomeTemplates:$userId');
+    if (!_hasRecurringIncomeTemplates) {
+      return null;
+    }
+    return List<AssetLiabilityRecurringIncomeTemplate>.from(
+      _recurringIncomeTemplates,
+    );
+  }
+
+  @override
+  Future<void> saveRecurringIncomeTemplates({
+    required String userId,
+    required List<AssetLiabilityRecurringIncomeTemplate> templates,
+  }) async {
+    calls.add('saveRecurringIncomeTemplates:$userId');
+    _throwIfSavingFails();
+    _hasRecurringIncomeTemplates = true;
+    _recurringIncomeTemplates
+      ..clear()
+      ..addAll(templates);
+  }
+
+  @override
+  Future<List<AssetLiabilityMonthlySnapshot>?> loadMonthlySnapshots({
+    required String userId,
+  }) async {
+    calls.add('loadMonthlySnapshots:$userId');
+    if (!_hasMonthlySnapshots) {
+      return null;
+    }
+    return List<AssetLiabilityMonthlySnapshot>.from(_monthlySnapshots);
+  }
+
+  @override
+  Future<void> saveMonthlySnapshot({
+    required String userId,
+    required AssetLiabilityMonthlySnapshot snapshot,
+  }) async {
+    calls.add('saveMonthlySnapshot:$userId:${snapshot.monthKey}');
+    _throwIfSavingFails();
+    _hasMonthlySnapshots = true;
+    _monthlySnapshots.removeWhere(
+      (current) => current.monthKey == snapshot.monthKey,
+    );
+    _monthlySnapshots.add(snapshot);
+    _monthlySnapshots.sort((a, b) => a.monthKey.compareTo(b.monthKey));
+  }
+
+  void _throwIfSavingFails() {
+    if (failSaves) {
+      throw StateError('remote save failed');
+    }
+  }
+}
+
+AssetLiabilityMonthlyState _sampleMonthlyState() {
+  return AssetLiabilityMonthlyState(
+    paymentOverrides: const <String, double>{'mobit': 70000},
+    paidAccountNames: const <String>{'kddi_provider'},
+    paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
+    incomePlans: <AssetLiabilityIncomePlan>[
+      AssetLiabilityIncomePlan(
+        id: 'salary',
+        date: DateTime(2026, 5, 25),
+        name: 'Salary',
+        amount: 250000,
+        destinationAccountId: 'smbc_otsuka',
+        destinationAccountName: 'SMBC Otsuka',
+        received: false,
+      ),
+    ],
+  );
+}
+
+AssetLiabilityRecurringIncomeTemplate _sampleRecurringIncomeTemplate() {
+  return const AssetLiabilityRecurringIncomeTemplate(
+    id: 'salary',
+    dayOfMonth: 25,
+    name: 'Salary',
+    amount: 250000,
+    destinationAccountId: 'smbc_otsuka',
+    destinationAccountName: 'SMBC Otsuka',
+  );
+}
+
+AssetLiabilityMonthlySnapshot _sampleSnapshot(String monthKey) {
+  return AssetLiabilityMonthlySnapshot(
+    monthKey: monthKey,
+    savedAt: DateTime.utc(2026, 5, 31, 12),
+    positiveAssetTotal: 120000,
+    liabilityTotal: -7200000,
+    netWorth: -7080000,
+    cashLikeTotal: 60000,
+    monthlyScheduledPaymentTotal: 180000,
+    monthlyPaidPaymentTotal: 100000,
+    monthlyUnpaidPaymentTotal: 80000,
+    overduePaymentCount: 1,
+  );
 }


### PR DESCRIPTION
﻿## 概要

資産/負債ボードのSupabase同期をfeature flag付きで追加しました。

既存のSharedPreferences保存を主経路として維持しつつ、`ASSET_LIABILITY_SUPABASE_SYNC_ENABLED` が有効な場合のみ `AssetLiabilityRepository` 経由でSupabaseへの保存/復元を試行します。UIからSupabaseを直接呼ばず、同期失敗時もローカル保存を壊さない構成です。

## 主な変更

- `AssetLiabilityRemoteStore` interfaceを追加
- `AssetLiabilityRepositoryFactory` を追加
  - feature flag default OFF
  - OFF時は既存の `SharedPreferencesAssetLiabilityRepository` のみ使用
  - ON時のみSupabase remote storeを合成
- `FeatureFlaggedAssetLiabilityRepository` を追加
  - local save first
  - remote sync best-effort
  - remote失敗時は非ブロッカーとして扱う
- `AssetLiabilitySupabaseRemoteStore` を追加
  - 月次状態
  - 収入予定
  - 定期収入テンプレート
  - 支払原資口座設定
  - 月次スナップショット
- 初回同期方針を実装
  - ローカルあり / remote空: remoteへアップロード
  - remoteあり / ローカル空: ローカルへ復元
  - 両方あり: 安全側としてローカルを維持
- 資産管理ページのRepository生成をfactory経由に変更
- feature flag / remote失敗 / 初回同期 / Supabase未設定相当のテストを追加

## スコープ外

- feature flagの本番ON化
- SharedPreferences保存の廃止
- UIからのSupabase直接呼び出し
- conflict解決UI
- 手動同期ボタン
- production data migration実行

## Minimal E2E Gate

- [x] Implementation-detail independent: Repository public API経由で保存/復元/初回同期/失敗時フォールバックを検証しています。
- [x] Minimal scope: 月次状態、支払原資口座設定、定期収入テンプレート、月次スナップショットを対象にしています。
- [ ] E2E included: not included.
- [x] E2E-Exception: feature flag default OFFのpersistence foundationで、通常ユーザー導線は既存SharedPreferences保存のままです。UI表示変更はRepository生成経路のみで、CIのservice-layer testsとanalyzeで確認します。

## Visual E2E Evidence

- UI layout/interaction changes: not applicable. 表示UIは変更せず、Repository生成経路のみ変更しています。
- Browser visual QA: not run because visible UI components were not added or changed.
- Generated imagery: no generated image was used.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Supabase同期コードを追加していますが、feature flag default OFFでproduction writeは通常有効化されません。Repository層に閉じ、UI直接Supabase writeは追加していません。同期失敗はローカル保存を維持するbest-effort扱いで、deterministic testsを追加済みです。

## 検証

最新 `origin/main` へrebase後、以下を確認済みです。

- `dart format --output=none --set-exit-if-changed ...`: OK、変更なし
- `flutter analyze`: No issues found
- `flutter test --no-pub test\\services\\asset_liability_repository_test.dart --reporter expanded`: 16 tests passed
- 資産/負債関連 `flutter test --no-pub ...`: 36 tests passed
- `git diff --check`: OK

補足:
ローカルの `flutter.bat` / `dartdev` lockが詰まる場面があったため、検証はFlutter tools snapshot経由で実行しています。全体 `flutter test --no-pub` は既存の `test/services/local_election_share_service_test.dart` の `setUpAll` で停止したため、このPRでは関連範囲のテストとGitHub CIを最終確認にしています。

## Files changed確認

想定ファイルのみです。

- `lib/pages/asset_management_page.dart`
- `lib/services/asset_liability_repository.dart`
- `test/services/asset_liability_repository_test.dart`