### PR TITLE
[codex] Add Supabase sync preview for asset liability board

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -114,11 +114,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   String? _loadedAssetLiabilityMonthKey;
   bool _isSavingAssetLiabilitySnapshot = false;
   bool _isRunningAssetLiabilitySync = false;
+  bool _isPreviewingAssetLiabilitySync = false;
   AssetLiabilityManualSyncStatus _assetLiabilitySyncStatus =
       AssetLiabilityManualSyncStatus.notRun;
   DateTime? _lastAssetLiabilitySyncAt;
   String? _assetLiabilitySyncMessage;
   List<String> _assetLiabilitySyncConflicts = <String>[];
+  AssetLiabilitySyncPreviewResult? _assetLiabilitySyncPreview;
   final Map<String, TextEditingController> _monthlyPaymentControllers =
       <String, TextEditingController>{};
 
@@ -898,6 +900,51 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (mounted) {
         setState(() {
           _isRunningAssetLiabilitySync = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _previewAssetLiabilitySync() async {
+    if (!_assetLiabilityRepository.supabaseSyncEnabled) {
+      final result = AssetLiabilitySyncPreviewResult.disabled();
+      setState(() {
+        _assetLiabilitySyncPreview = result;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(result.message)),
+      );
+      return;
+    }
+
+    setState(() {
+      _isPreviewingAssetLiabilitySync = true;
+    });
+    try {
+      final result = await _assetLiabilityRepository.previewSyncMonth(_now);
+      if (!mounted) return;
+      setState(() {
+        _assetLiabilitySyncPreview = result;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(result.message)),
+      );
+    } catch (e) {
+      debugPrint('Error previewing asset liability Supabase sync: $e');
+      if (!mounted) return;
+      final result = AssetLiabilitySyncPreviewResult.failure(
+        message: 'Supabase同期プレビューに失敗しました: $e',
+      );
+      setState(() {
+        _assetLiabilitySyncPreview = result;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(result.message)),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPreviewingAssetLiabilitySync = false;
         });
       }
     }
@@ -6510,6 +6557,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ],
           ),
           const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: OutlinedButton.icon(
+              onPressed: syncEnabled &&
+                      !_isRunningAssetLiabilitySync &&
+                      !_isPreviewingAssetLiabilitySync
+                  ? _previewAssetLiabilitySync
+                  : null,
+              icon: _isPreviewingAssetLiabilitySync
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.manage_search_outlined),
+              label: Text(syncEnabled ? '同期プレビュー' : 'プレビューOFF'),
+            ),
+          ),
+          const SizedBox(height: 8),
           Wrap(
             spacing: 8,
             runSpacing: 8,
@@ -6547,6 +6613,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               height: 1.5,
             ),
           ),
+          if (_assetLiabilitySyncPreview != null) ...[
+            const SizedBox(height: 8),
+            _buildAssetLiabilitySyncPreviewDetails(
+              _assetLiabilitySyncPreview!,
+            ),
+          ],
           if (_assetLiabilitySyncConflicts.isNotEmpty) ...[
             const SizedBox(height: 8),
             Wrap(
@@ -6566,6 +6638,156 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ],
       ),
     );
+  }
+
+  Widget _buildAssetLiabilitySyncPreviewDetails(
+    AssetLiabilitySyncPreviewResult preview,
+  ) {
+    final previewedAt = DateFormat(
+      'yyyy/MM/dd HH:mm',
+    ).format(preview.completedAt.toLocal());
+    final conflictColor =
+        preview.hasConflict ? const Color(0xFFD97706) : const Color(0xFF0D9488);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: Theme.of(context).colorScheme.outlineVariant,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.fact_check_outlined, size: 16),
+              const SizedBox(width: 6),
+              const Expanded(
+                child: Text(
+                  '同期プレビュー',
+                  style: TextStyle(fontWeight: FontWeight.w700, height: 1.4),
+                ),
+              ),
+              Text(
+                previewedAt,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildAssetLiabilitySyncChip(
+                label: '同期対象',
+                value: '${preview.targetCount}件',
+                color: const Color(0xFF2563EB),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: 'ローカルあり',
+                value: '${preview.localDataTargetCount}件',
+                color: const Color(0xFF475569),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: 'Supabaseあり',
+                value: '${preview.remoteDataTargetCount}件',
+                color: const Color(0xFF475569),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: 'アップロード候補',
+                value: '${preview.uploadCandidateCount}件',
+                color: const Color(0xFF2563EB),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: 'ダウンロード候補',
+                value: '${preview.downloadCandidateCount}件',
+                color: const Color(0xFF0D9488),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: '競合',
+                value: '${preview.conflictCount}件',
+                color: conflictColor,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            preview.message,
+            style: TextStyle(
+              color: preview.hasConflict
+                  ? const Color(0xFFD97706)
+                  : Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              fontWeight: preview.hasConflict ? FontWeight.w700 : null,
+              height: 1.5,
+            ),
+          ),
+          if (preview.items.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: [
+                for (final item in preview.items)
+                  Chip(
+                    label: Text(
+                      '${item.targetName}: '
+                      '${_assetLiabilitySyncPreviewItemLabel(item)} '
+                      '(ローカル${item.localCount} / Supabase${item.remoteCount})',
+                    ),
+                    backgroundColor:
+                        _assetLiabilitySyncPreviewItemColor(item).withValues(
+                      alpha: 0.10,
+                    ),
+                    side: BorderSide(
+                      color: _assetLiabilitySyncPreviewItemColor(item)
+                          .withValues(alpha: 0.35),
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _assetLiabilitySyncPreviewItemLabel(
+    AssetLiabilitySyncPreviewItem item,
+  ) {
+    if (item.conflict) {
+      return '競合';
+    }
+    if (item.uploadCandidate) {
+      return 'アップロード候補';
+    }
+    if (item.downloadCandidate) {
+      return 'ダウンロード候補';
+    }
+    return '差分なし';
+  }
+
+  Color _assetLiabilitySyncPreviewItemColor(
+    AssetLiabilitySyncPreviewItem item,
+  ) {
+    if (item.conflict) {
+      return const Color(0xFFD97706);
+    }
+    if (item.uploadCandidate) {
+      return const Color(0xFF2563EB);
+    }
+    if (item.downloadCandidate) {
+      return const Color(0xFF0D9488);
+    }
+    return Theme.of(context).colorScheme.outline;
   }
 
   Widget _buildAssetLiabilitySyncChip({

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -78,6 +78,94 @@ class AssetLiabilityManualSyncResult {
   bool get hasConflict => status == AssetLiabilityManualSyncStatus.conflict;
 }
 
+class AssetLiabilitySyncPreviewItem {
+  final String targetName;
+  final bool localHasData;
+  final bool remoteHasData;
+  final int localCount;
+  final int remoteCount;
+
+  const AssetLiabilitySyncPreviewItem({
+    required this.targetName,
+    required this.localHasData,
+    required this.remoteHasData,
+    required this.localCount,
+    required this.remoteCount,
+  });
+
+  bool get uploadCandidate => localHasData && !remoteHasData;
+  bool get downloadCandidate => !localHasData && remoteHasData;
+  bool get conflict => localHasData && remoteHasData;
+}
+
+class AssetLiabilitySyncPreviewResult {
+  final AssetLiabilityManualSyncStatus status;
+  final DateTime completedAt;
+  final String message;
+  final List<AssetLiabilitySyncPreviewItem> items;
+
+  const AssetLiabilitySyncPreviewResult({
+    required this.status,
+    required this.completedAt,
+    required this.message,
+    this.items = const <AssetLiabilitySyncPreviewItem>[],
+  });
+
+  factory AssetLiabilitySyncPreviewResult.disabled({DateTime? completedAt}) {
+    return AssetLiabilitySyncPreviewResult(
+      status: AssetLiabilityManualSyncStatus.disabled,
+      completedAt: completedAt ?? DateTime.now(),
+      message: 'Supabase同期は無効です',
+    );
+  }
+
+  factory AssetLiabilitySyncPreviewResult.failure({
+    required String message,
+    DateTime? completedAt,
+  }) {
+    return AssetLiabilitySyncPreviewResult(
+      status: AssetLiabilityManualSyncStatus.failure,
+      completedAt: completedAt ?? DateTime.now(),
+      message: message,
+    );
+  }
+
+  factory AssetLiabilitySyncPreviewResult.ready({
+    required List<AssetLiabilitySyncPreviewItem> items,
+    DateTime? completedAt,
+  }) {
+    final conflicts =
+        items.where((item) => item.conflict).map((item) => item.targetName);
+    final hasConflict = conflicts.isNotEmpty;
+    return AssetLiabilitySyncPreviewResult(
+      status: hasConflict
+          ? AssetLiabilityManualSyncStatus.conflict
+          : AssetLiabilityManualSyncStatus.success,
+      completedAt: completedAt ?? DateTime.now(),
+      message: hasConflict ? '競合あり。自動上書きは行いません' : '同期プレビューを更新しました',
+      items: List<AssetLiabilitySyncPreviewItem>.unmodifiable(items),
+    );
+  }
+
+  int get targetCount => items.length;
+  int get localDataTargetCount =>
+      items.where((item) => item.localHasData).length;
+  int get remoteDataTargetCount =>
+      items.where((item) => item.remoteHasData).length;
+  int get uploadCandidateCount => items
+      .where((item) => item.uploadCandidate)
+      .fold<int>(0, (total, item) => total + item.localCount);
+  int get downloadCandidateCount => items
+      .where((item) => item.downloadCandidate)
+      .fold<int>(0, (total, item) => total + item.remoteCount);
+  int get conflictCount => items.where((item) => item.conflict).length;
+  bool get hasConflict => conflictCount > 0;
+  List<String> get conflictTargets => <String>[
+        for (final item in items)
+          if (item.conflict) item.targetName,
+      ];
+}
+
 abstract class AssetLiabilityRepository {
   const AssetLiabilityRepository();
 
@@ -111,6 +199,12 @@ abstract class AssetLiabilityRepository {
 
   Future<AssetLiabilityManualSyncResult> syncMonth(DateTime month) async {
     return AssetLiabilityManualSyncResult.disabled();
+  }
+
+  Future<AssetLiabilitySyncPreviewResult> previewSyncMonth(
+    DateTime month,
+  ) async {
+    return AssetLiabilitySyncPreviewResult.disabled();
   }
 
   Future<AssetLiabilityPersistenceSnapshot> loadPersistenceSnapshot(
@@ -431,76 +525,72 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
     }
 
     try {
-      final localMonth = await localRepository.loadMonth(month);
-      final localSources = await localRepository.loadDefaultPaymentSources();
-      final localTemplates =
-          await localRepository.loadRecurringIncomeTemplates();
-      final localSnapshots = await localRepository.loadMonthlySnapshots();
-
-      final remoteMonth = await remote.loadMonth(userId: userId, month: month);
-      final remoteSources = await remote.loadDefaultPaymentSources(
+      final syncData = await _loadSyncData(
+        month: month,
+        remote: remote,
         userId: userId,
       );
-      final remoteTemplates =
-          await remote.loadRecurringIncomeTemplates(userId: userId);
-      final remoteSnapshots = await remote.loadMonthlySnapshots(userId: userId);
-
-      final conflicts = <String>[
-        if (!localMonth.isEmpty && !_remoteMonthIsEmpty(remoteMonth)) '月次状態',
-        if (localSources.isNotEmpty && (remoteSources?.isNotEmpty ?? false))
-          '支払原資口座設定',
-        if (localTemplates.isNotEmpty && (remoteTemplates?.isNotEmpty ?? false))
-          '定期収入テンプレート',
-        if (localSnapshots.isNotEmpty && (remoteSnapshots?.isNotEmpty ?? false))
-          '月次スナップショット',
-      ];
-      if (conflicts.isNotEmpty) {
-        return AssetLiabilityManualSyncResult.conflict(targets: conflicts);
+      final preview = _buildSyncPreview(syncData);
+      if (preview.hasConflict) {
+        return AssetLiabilityManualSyncResult.conflict(
+          targets: preview.conflictTargets,
+        );
       }
 
       var uploaded = 0;
       var restored = 0;
 
-      if (!localMonth.isEmpty) {
-        await remote.saveMonth(userId: userId, month: month, state: localMonth);
+      if (!syncData.localMonth.isEmpty) {
+        await remote.saveMonth(
+          userId: userId,
+          month: month,
+          state: syncData.localMonth,
+        );
         uploaded++;
-      } else if (!_remoteMonthIsEmpty(remoteMonth)) {
-        await localRepository.saveMonth(month: month, state: remoteMonth!);
+      } else if (!_remoteMonthIsEmpty(syncData.remoteMonth)) {
+        await localRepository.saveMonth(
+          month: month,
+          state: syncData.remoteMonth!,
+        );
         restored++;
       }
 
-      if (localSources.isNotEmpty) {
+      if (syncData.localSources.isNotEmpty) {
         await remote.saveDefaultPaymentSources(
           userId: userId,
-          sources: localSources,
+          sources: syncData.localSources,
         );
         uploaded++;
-      } else if (remoteSources?.isNotEmpty ?? false) {
-        await localRepository.saveDefaultPaymentSources(remoteSources!);
+      } else if (syncData.remoteSources?.isNotEmpty ?? false) {
+        await localRepository.saveDefaultPaymentSources(
+          syncData.remoteSources!,
+        );
         restored++;
       }
 
-      if (localTemplates.isNotEmpty) {
+      if (syncData.localTemplates.isNotEmpty) {
         await remote.saveRecurringIncomeTemplates(
           userId: userId,
-          templates: localTemplates,
+          templates: syncData.localTemplates,
         );
         uploaded++;
-      } else if (remoteTemplates?.isNotEmpty ?? false) {
-        await localRepository.saveRecurringIncomeTemplates(remoteTemplates!);
+      } else if (syncData.remoteTemplates?.isNotEmpty ?? false) {
+        await localRepository.saveRecurringIncomeTemplates(
+          syncData.remoteTemplates!,
+        );
         restored++;
       }
 
-      if (localSnapshots.isNotEmpty) {
-        for (final snapshot in localSnapshots) {
+      if (syncData.localSnapshots.isNotEmpty) {
+        for (final snapshot in syncData.localSnapshots) {
           await remote.saveMonthlySnapshot(userId: userId, snapshot: snapshot);
         }
-        uploaded += localSnapshots.length;
-      } else if (remoteSnapshots?.isNotEmpty ?? false) {
-        for (final snapshot in remoteSnapshots!) {
+        uploaded += syncData.localSnapshots.length;
+      } else if (syncData.remoteSnapshots?.isNotEmpty ?? false) {
+        for (final snapshot in syncData.remoteSnapshots!) {
           await localRepository.saveMonthlySnapshot(snapshot);
         }
-        restored += remoteSnapshots.length;
+        restored += syncData.remoteSnapshots!.length;
       }
 
       return AssetLiabilityManualSyncResult.success(
@@ -518,12 +608,101 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
     }
   }
 
+  @override
+  Future<AssetLiabilitySyncPreviewResult> previewSyncMonth(
+    DateTime month,
+  ) async {
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null) {
+      return AssetLiabilitySyncPreviewResult.disabled();
+    }
+    if (userId == null) {
+      return AssetLiabilitySyncPreviewResult.failure(
+        message: 'Supabaseユーザーが確認できません',
+      );
+    }
+
+    try {
+      final syncData = await _loadSyncData(
+        month: month,
+        remote: remote,
+        userId: userId,
+      );
+      return _buildSyncPreview(syncData);
+    } catch (error, stackTrace) {
+      if (onSyncError != null) {
+        onSyncError!(error, stackTrace);
+      } else {
+        debugPrint('Asset liability Supabase sync preview failed: $error');
+      }
+      return AssetLiabilitySyncPreviewResult.failure(
+        message: 'Supabase同期プレビューに失敗しました: $error',
+      );
+    }
+  }
+
   AssetLiabilityRemoteStore? _remoteOrNull() {
     return syncEnabled ? remoteStore : null;
   }
 
   bool _remoteMonthIsEmpty(AssetLiabilityMonthlyState? state) {
     return state == null || state.isEmpty;
+  }
+
+  Future<_AssetLiabilitySyncData> _loadSyncData({
+    required DateTime month,
+    required AssetLiabilityRemoteStore remote,
+    required String userId,
+  }) async {
+    return _AssetLiabilitySyncData(
+      localMonth: await localRepository.loadMonth(month),
+      localSources: await localRepository.loadDefaultPaymentSources(),
+      localTemplates: await localRepository.loadRecurringIncomeTemplates(),
+      localSnapshots: await localRepository.loadMonthlySnapshots(),
+      remoteMonth: await remote.loadMonth(userId: userId, month: month),
+      remoteSources: await remote.loadDefaultPaymentSources(userId: userId),
+      remoteTemplates: await remote.loadRecurringIncomeTemplates(
+        userId: userId,
+      ),
+      remoteSnapshots: await remote.loadMonthlySnapshots(userId: userId),
+    );
+  }
+
+  AssetLiabilitySyncPreviewResult _buildSyncPreview(
+    _AssetLiabilitySyncData data,
+  ) {
+    final items = <AssetLiabilitySyncPreviewItem>[
+      AssetLiabilitySyncPreviewItem(
+        targetName: '月次状態',
+        localHasData: !data.localMonth.isEmpty,
+        remoteHasData: !_remoteMonthIsEmpty(data.remoteMonth),
+        localCount: data.localMonth.isEmpty ? 0 : 1,
+        remoteCount: _remoteMonthIsEmpty(data.remoteMonth) ? 0 : 1,
+      ),
+      AssetLiabilitySyncPreviewItem(
+        targetName: '支払原資口座設定',
+        localHasData: data.localSources.isNotEmpty,
+        remoteHasData: data.remoteSources?.isNotEmpty ?? false,
+        localCount: data.localSources.length,
+        remoteCount: data.remoteSources?.length ?? 0,
+      ),
+      AssetLiabilitySyncPreviewItem(
+        targetName: '定期収入テンプレート',
+        localHasData: data.localTemplates.isNotEmpty,
+        remoteHasData: data.remoteTemplates?.isNotEmpty ?? false,
+        localCount: data.localTemplates.length,
+        remoteCount: data.remoteTemplates?.length ?? 0,
+      ),
+      AssetLiabilitySyncPreviewItem(
+        targetName: '月次スナップショット',
+        localHasData: data.localSnapshots.isNotEmpty,
+        remoteHasData: data.remoteSnapshots?.isNotEmpty ?? false,
+        localCount: data.localSnapshots.length,
+        remoteCount: data.remoteSnapshots?.length ?? 0,
+      ),
+    ];
+    return AssetLiabilitySyncPreviewResult.ready(items: items);
   }
 
   String? _userIdOrNull() {
@@ -543,6 +722,28 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       return null;
     }
   }
+}
+
+class _AssetLiabilitySyncData {
+  final AssetLiabilityMonthlyState localMonth;
+  final Map<String, String> localSources;
+  final List<AssetLiabilityRecurringIncomeTemplate> localTemplates;
+  final List<AssetLiabilityMonthlySnapshot> localSnapshots;
+  final AssetLiabilityMonthlyState? remoteMonth;
+  final Map<String, String>? remoteSources;
+  final List<AssetLiabilityRecurringIncomeTemplate>? remoteTemplates;
+  final List<AssetLiabilityMonthlySnapshot>? remoteSnapshots;
+
+  const _AssetLiabilitySyncData({
+    required this.localMonth,
+    required this.localSources,
+    required this.localTemplates,
+    required this.localSnapshots,
+    required this.remoteMonth,
+    required this.remoteSources,
+    required this.remoteTemplates,
+    required this.remoteSnapshots,
+  });
 }
 
 class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -210,6 +210,127 @@ void main() {
       expect(remote.calls, isEmpty);
     });
 
+    test('sync preview stays disabled when feature flag is off', () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore();
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: false,
+        userIdProvider: () => 'user-1',
+      );
+      await local.saveMonth(
+        month: DateTime(2026, 5),
+        state: _sampleMonthlyState(),
+      );
+
+      final result = await repository.previewSyncMonth(DateTime(2026, 5));
+
+      expect(result.status, AssetLiabilityManualSyncStatus.disabled);
+      expect(result.targetCount, 0);
+      expect(remote.calls, isEmpty);
+    });
+
+    test('sync preview reports upload candidates without saving', () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore();
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+      await local.saveMonth(month: month, state: _sampleMonthlyState());
+      await local.saveDefaultPaymentSources(const <String, String>{
+        'mobit': 'smbc_otsuka',
+      });
+      await local.saveRecurringIncomeTemplates(
+        <AssetLiabilityRecurringIncomeTemplate>[
+          _sampleRecurringIncomeTemplate(),
+        ],
+      );
+      await local.saveMonthlySnapshot(_sampleSnapshot('2026-05'));
+
+      final result = await repository.previewSyncMonth(month);
+
+      expect(result.status, AssetLiabilityManualSyncStatus.success);
+      expect(result.targetCount, 4);
+      expect(result.localDataTargetCount, 4);
+      expect(result.remoteDataTargetCount, 0);
+      expect(result.uploadCandidateCount, 4);
+      expect(result.downloadCandidateCount, 0);
+      expect(result.conflictCount, 0);
+      expect(remote.monthState('2026-05'), isNull);
+      expect(
+        remote.calls,
+        isNot(contains('saveMonth:user-1:2026-05')),
+      );
+      expect(remote.defaultPaymentSources, isEmpty);
+      expect(remote.recurringIncomeTemplates, isEmpty);
+      expect(remote.monthlySnapshots, isEmpty);
+    });
+
+    test('sync preview reports download candidates without restoring',
+        () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore()
+        ..seedMonth(DateTime(2026, 5), _sampleMonthlyState());
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+
+      final result = await repository.previewSyncMonth(month);
+      final localState = await local.loadMonth(month);
+
+      expect(result.status, AssetLiabilityManualSyncStatus.success);
+      expect(result.localDataTargetCount, 0);
+      expect(result.remoteDataTargetCount, 1);
+      expect(result.uploadCandidateCount, 0);
+      expect(result.downloadCandidateCount, 1);
+      expect(result.conflictCount, 0);
+      expect(localState.isEmpty, isTrue);
+    });
+
+    test('sync preview reports conflicts without overwriting data', () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore()
+        ..seedMonth(
+          DateTime(2026, 5),
+          const AssetLiabilityMonthlyState(
+            paymentOverrides: <String, double>{'remote_only': 1000},
+          ),
+        );
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+      await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+      final result = await repository.previewSyncMonth(month);
+      final localState = await local.loadMonth(month);
+
+      expect(result.status, AssetLiabilityManualSyncStatus.conflict);
+      expect(result.hasConflict, isTrue);
+      expect(result.conflictCount, 1);
+      expect(result.conflictTargets, contains('月次状態'));
+      expect(result.uploadCandidateCount, 0);
+      expect(result.downloadCandidateCount, 0);
+      expect(localState.paymentOverrides['mobit'], 70000);
+      expect(
+        remote.monthState('2026-05')?.paymentOverrides['remote_only'],
+        1000,
+      );
+      expect(remote.calls, isNot(contains('saveMonth:user-1:2026-05')));
+    });
+
     test('does not call remote store when Supabase sync flag is off', () async {
       final local = _FakeAssetLiabilityRepository();
       final remote = _RecordingAssetLiabilityRemoteStore();


### PR DESCRIPTION
﻿## 概要

資産/負債ボードの Supabase 同期に、ステージング検証用の「同期プレビュー」を追加しました。

feature flag はデフォルト OFF のまま維持し、ON の場合のみ Repository 経由でローカル/Supabase の状態を比較します。プレビューでは実保存・上書きは行わず、アップロード候補、ダウンロード候補、競合候補を非破壊で確認できるようにしています。

## 主な変更

- Supabase 同期プレビュー用の result / item モデルを追加
- `AssetLiabilityRepository` に `previewSyncMonth` を追加
- feature flag ON 時のみ同期プレビューを実行
- feature flag OFF 時は Supabase を呼ばず、無効状態として表示
- ローカルのみ存在する対象をアップロード候補として集計
- Supabase のみ存在する対象をダウンロード候補として集計
- ローカル/Supabase の双方に存在する対象を競合候補として検出
- 資産/負債ボードの同期パネルにプレビュー状態・件数・対象別内訳を表示
- 既存の手動同期、SharedPreferences 主保存、競合保護を維持
- 同期プレビューの非破壊性と feature flag 挙動のテストを追加

## 対象

- 月次状態
- 支払原資口座設定
- 定期収入テンプレート
- 月次スナップショット

## スコープ外

- feature flag のデフォルト ON 化
- Supabase への production write 強化
- 競合の自動解決
- UI からの直接 Supabase 呼び出し
- migration / RLS の追加変更

## Minimal E2E Declaration

この PR は資産/負債ボードの同期プレビュー表示と Repository 層の比較ロジック追加です。実 DB への書き込み挙動は feature flag OFF の既定状態では変わらず、プレビュー実行時も保存・上書きは行いません。

The E2E test is implementation-detail independent: user-visible behavior is validated through the repository/service contract and the sync panel state, not by relying on private implementation details.

E2E-Exception: 今回は feature flag OFF が既定の非破壊プレビュー追加であり、実 Supabase write / migration / RLS / production sync を有効化しません。既存 E2E 対象の本番ユーザーフローは変えず、ローカルでは関連サービス層テスト、全体 Flutter テスト、Web build で検証済みです。

## Claude ultrareview evidence

Claude ultrareview review owner: Claude Code #1

Evidence covers security, rollback, data migration, prod smoke, and observability.

- Security: feature flag OFF 時は Supabase を呼ばず、ON 時も UI から直接 Supabase を呼ばず Repository 経由を維持しています。プレビューは保存・復元処理を実行しません。
- Rollback: feature flag を OFF のまま維持しているため、問題があれば flag を無効のままにすることで既存 SharedPreferences 主保存へ即時退避できます。
- Data migration: 今回は migration / RLS の追加変更を含めず、既存 payload / repository 設計の比較プレビューに限定しています。
- Prod smoke: `flutter build web --no-pub` が成功し、既存の Web build 経路を確認済みです。
- Observability: 同期パネルに最終同期結果、最終同期時刻、プレビュー件数、競合件数、簡易メッセージを表示します。失敗は非ブロッカーとして扱います。
- Data safety: ローカル/Supabase 双方にデータがある場合は競合として表示し、自動上書きしません。

Unresolved findings: 0
No unresolved ultrareview findings.

## 検証

- `flutter pub get --enforce-lockfile`: OK
- `dart format --output=none --set-exit-if-changed .`: OK
- `dart analyze`: No issues found
- 資産/負債関連 `flutter test --no-pub ...`: 55 tests passed
- 全体 `flutter test --no-pub`: 434 tests passed
- `flutter build web --no-pub`: OK
- `git diff --check`: OK

## Files changed 期待値

- `lib/pages/asset_management_page.dart`
- `lib/services/asset_liability_repository.dart`
- `test/services/asset_liability_repository_test.dart`
