### PR TITLE
feat(calendar): add iCal import export (#2213)

### DIFF
--- a/lib/pages/calendar_events_page.dart
+++ b/lib/pages/calendar_events_page.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -9,7 +11,9 @@ import 'package:share_plus/share_plus.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:table_calendar/table_calendar.dart';
 
+import 'package:my_web_app/services/calendar_ics_service.dart';
 import 'package:my_web_app/services/notification_service.dart';
+import 'package:my_web_app/utils/web_text_downloader.dart';
 
 /// カレンダーイベントページ
 /// calendar-events Edge Function と連携してイベントを管理
@@ -19,8 +23,8 @@ class CalendarEventsPage extends StatefulWidget {
     super.key,
     SupabaseClient? supabaseClient,
     NotificationService? notificationService,
-  })  : _supabaseClient = supabaseClient,
-        _notificationService = notificationService;
+  }) : _supabaseClient = supabaseClient,
+       _notificationService = notificationService;
 
   final SupabaseClient? _supabaseClient;
   final NotificationService? _notificationService;
@@ -34,6 +38,8 @@ enum _CalendarView { month, week, day }
 enum _CalendarRecurrencePreset { none, daily, weekly, monthly, yearly, custom }
 
 enum _RecurrenceEditScope { thisEvent, following, all }
+
+enum _CalendarIcsAction { export, import }
 
 const String _defaultCalendarId = 'default';
 const String _defaultCalendarName = 'Default';
@@ -64,8 +70,8 @@ bool _eventIsAllDay(Map<String, dynamic> event) => event['all_day'] == true;
 
 String _eventTitle(Map<String, dynamic> event) =>
     event['title']?.toString().trim().isNotEmpty == true
-        ? event['title'].toString()
-        : 'Untitled';
+    ? event['title'].toString()
+    : 'Untitled';
 
 String _eventTimeLabel(Map<String, dynamic> event) {
   if (_eventIsAllDay(event)) return 'All-day';
@@ -89,8 +95,8 @@ String _eventDateTimeLabel(Map<String, dynamic> event) {
   if (end == null) return _formatDateTime(start);
   final endLabel =
       start.year == end.year && start.month == end.month && start.day == end.day
-          ? _formatClock(end)
-          : _formatDateTime(end);
+      ? _formatClock(end)
+      : _formatDateTime(end);
   return '${_formatDateTime(start)} - $endLabel';
 }
 
@@ -175,7 +181,8 @@ String calendarEventRecurrenceLabel(Map<String, dynamic> event) {
       rrule,
       options: const RecurrenceRuleFromStringOptions.lenient(),
     );
-    final hasCustomParts = rule.count != null ||
+    final hasCustomParts =
+        rule.count != null ||
         rule.until != null ||
         rule.hasByWeekDays ||
         rule.hasByMonthDays ||
@@ -296,8 +303,9 @@ bool _eventRangeOverlaps(
   DateTime rangeStart,
   DateTime rangeEnd,
 ) {
-  final safeEnd =
-      end.isAfter(start) ? end : start.add(const Duration(hours: 1));
+  final safeEnd = end.isAfter(start)
+      ? end
+      : start.add(const Duration(hours: 1));
   return safeEnd.isAfter(rangeStart) && start.isBefore(rangeEnd);
 }
 
@@ -306,8 +314,9 @@ DateTime snapCalendarEventStartToGrid(
   DateTime value, {
   int granularityMinutes = _calendarDragSnapMinutes,
 }) {
-  final safeGranularity =
-      granularityMinutes <= 0 ? _calendarDragSnapMinutes : granularityMinutes;
+  final safeGranularity = granularityMinutes <= 0
+      ? _calendarDragSnapMinutes
+      : granularityMinutes;
   final dayStart = DateTime(value.year, value.month, value.day);
   final minutes = value.difference(dayStart).inMinutes;
   final snappedMinutes = (minutes / safeGranularity).round() * safeGranularity;
@@ -338,7 +347,8 @@ _CalendarRecurrencePreset _recurrencePresetForRRule(String? rrule) {
       rrule,
       options: const RecurrenceRuleFromStringOptions.lenient(),
     );
-    final hasCustomParts = rule.count != null ||
+    final hasCustomParts =
+        rule.count != null ||
         rule.until != null ||
         rule.hasByWeekDays ||
         rule.hasByMonthDays ||
@@ -437,8 +447,9 @@ String? _buildCalendarRRule({
     frequency: _frequencyForPreset(preset),
     until: normalizedUntil,
     count: normalizedCount,
-    byWeekDays:
-        preset == _CalendarRecurrencePreset.custom ? byWeekDays : const [],
+    byWeekDays: preset == _CalendarRecurrencePreset.custom
+        ? byWeekDays
+        : const [],
   );
   return rule.toString();
 }
@@ -575,14 +586,14 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   }
 
   _CalendarListItem get _defaultCalendar => _calendars.firstWhere(
-        (calendar) => calendar.id == _defaultCalendarId,
-        orElse: () => const _CalendarListItem(
-          id: _defaultCalendarId,
-          name: _defaultCalendarName,
-          color: _defaultCalendarColor,
-          isDefault: true,
-        ),
-      );
+    (calendar) => calendar.id == _defaultCalendarId,
+    orElse: () => const _CalendarListItem(
+      id: _defaultCalendarId,
+      name: _defaultCalendarName,
+      color: _defaultCalendarColor,
+      isDefault: true,
+    ),
+  );
 
   _CalendarListItem _calendarForId(String id) {
     return _calendars.firstWhere(
@@ -703,8 +714,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     final data = res.data;
     final rawCalendars =
         data is Map<String, dynamic> && data['calendars'] is List
-            ? data['calendars'] as List
-            : <dynamic>[];
+        ? data['calendars'] as List
+        : <dynamic>[];
     final nextCalendars = <_CalendarListItem>[];
     for (final raw in rawCalendars) {
       if (raw is! Map) continue;
@@ -725,7 +736,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     }
     final knownIds = nextCalendars.map((calendar) => calendar.id).toSet();
     setState(() {
-      final shouldSelectAll = !_hasLoadedCalendars ||
+      final shouldSelectAll =
+          !_hasLoadedCalendars ||
           (_visibleCalendarIds.length == _calendars.length &&
               _calendars.every(
                 (calendar) => _visibleCalendarIds.contains(calendar.id),
@@ -774,8 +786,10 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
 
       final monthStart = DateTime(month.year, month.month);
       final visibleRangeStart = monthStart.subtract(const Duration(days: 7));
-      final visibleRangeEnd =
-          DateTime(month.year, month.month + 1).add(const Duration(days: 7));
+      final visibleRangeEnd = DateTime(
+        month.year,
+        month.month + 1,
+      ).add(const Duration(days: 7));
       final newMap = <String, List<Map<String, dynamic>>>{};
       final parsedEvents = <Map<String, dynamic>>[];
       for (final raw in rawEvents) {
@@ -821,8 +835,9 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     String? rrule,
   }) async {
     try {
-      final end =
-          allDay ? startAt : (endAt ?? startAt.add(const Duration(hours: 1)));
+      final end = allDay
+          ? startAt
+          : (endAt ?? startAt.add(const Duration(hours: 1)));
       final res = await _supabase.functions.invoke(
         'app-hub',
         body: {
@@ -840,8 +855,9 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
       );
       final data = res.data;
       final savedEvent = data is Map ? data['event'] : null;
-      final eventId =
-          savedEvent is Map ? savedEvent['event_id']?.toString() ?? '' : '';
+      final eventId = savedEvent is Map
+          ? savedEvent['event_id']?.toString() ?? ''
+          : '';
       if (eventId.isNotEmpty && reminderMinutes != null) {
         _scheduleInAppReminderTimer({
           'event_id': eventId,
@@ -887,8 +903,9 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
       return;
     }
     try {
-      final end =
-          allDay ? startAt : (endAt ?? startAt.add(const Duration(hours: 1)));
+      final end = allDay
+          ? startAt
+          : (endAt ?? startAt.add(const Duration(hours: 1)));
       await _supabase.functions.invoke(
         'app-hub',
         body: {
@@ -959,6 +976,117 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     }
   }
 
+  Future<void> _handleIcsAction(_CalendarIcsAction action) async {
+    switch (action) {
+      case _CalendarIcsAction.export:
+        await _exportCalendarIcs();
+        break;
+      case _CalendarIcsAction.import:
+        await _importCalendarIcs();
+        break;
+    }
+  }
+
+  Future<void> _exportCalendarIcs() async {
+    final ics = buildCalendarEventsIcs(_allEvents);
+    if (!ics.contains('BEGIN:VEVENT')) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('No events to export')));
+      return;
+    }
+
+    final stamp = DateTime.now().toIso8601String().substring(0, 10);
+    final fileName = 'calendar-events-$stamp.ics';
+    if (kIsWeb) {
+      downloadTextFile(ics, fileName, mimeType: 'text/calendar;charset=utf-8');
+    } else {
+      final bytes = Uint8List.fromList(utf8.encode(ics));
+      final file = XFile.fromData(
+        bytes,
+        name: fileName,
+        mimeType: 'text/calendar',
+      );
+      await SharePlus.instance.share(
+        ShareParams(
+          files: [file],
+          fileNameOverrides: [fileName],
+          subject: fileName,
+          text: 'Calendar events export',
+        ),
+      );
+    }
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Exported $fileName')));
+  }
+
+  Future<void> _importCalendarIcs() async {
+    try {
+      final picked = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['ics', 'ical'],
+        withData: true,
+      );
+      if (picked == null || picked.files.isEmpty) return;
+      final bytes = picked.files.single.bytes;
+      if (bytes == null) {
+        throw StateError('Selected .ics file could not be read.');
+      }
+
+      final content = utf8.decode(bytes, allowMalformed: true);
+      final parsed = parseCalendarEventsIcs(
+        content,
+        existingUids: calendarIcsUidsFromEvents(_allEvents),
+      );
+      if (parsed.events.isEmpty) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              parsed.skippedDuplicateCount > 0
+                  ? 'All imported events were duplicates.'
+                  : 'No importable events found in the .ics file.',
+            ),
+          ),
+        );
+        return;
+      }
+
+      final res = await _supabase.functions.invoke(
+        'app-hub',
+        body: {'action': 'calendar.bulk_create', 'events': parsed.events},
+      );
+      final data = res.data;
+      final createdCount = data is Map
+          ? (data['created_count'] as num?)?.toInt() ?? parsed.events.length
+          : parsed.events.length;
+      final backendSkipped = data is Map
+          ? (data['skipped_duplicate_count'] as num?)?.toInt() ?? 0
+          : 0;
+      await _fetchMonth(_focusedDay);
+
+      if (!mounted) return;
+      final skipped = parsed.skippedDuplicateCount + backendSkipped;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            skipped > 0
+                ? 'Imported $createdCount events. Skipped $skipped duplicates.'
+                : 'Imported $createdCount events.',
+          ),
+        ),
+      );
+    } catch (e) {
+      if (mounted) {
+        setState(() => _errorMessage = 'Failed to import .ics file: $e');
+      }
+    }
+  }
+
   Future<void> _createCalendar({
     required String name,
     required String color,
@@ -976,8 +1104,9 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
       );
       final data = res.data;
       final calendar = data is Map ? data['calendar'] : null;
-      final calendarId =
-          calendar is Map ? calendar['calendar_id']?.toString() ?? '' : '';
+      final calendarId = calendar is Map
+          ? calendar['calendar_id']?.toString() ?? ''
+          : '';
       if (calendarId.isNotEmpty) {
         _visibleCalendarIds.add(calendarId);
       }
@@ -1314,7 +1443,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
 
   @override
   Widget build(BuildContext context) {
-    final usesTimeline = _calendarView == _CalendarView.day ||
+    final usesTimeline =
+        _calendarView == _CalendarView.day ||
         _calendarView == _CalendarView.week;
 
     return Scaffold(
@@ -1333,6 +1463,32 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
             icon: const Icon(Icons.search),
             tooltip: 'Search events',
             onPressed: _showEventSearch,
+          ),
+          PopupMenuButton<_CalendarIcsAction>(
+            key: const Key('calendar_events_ics_menu'),
+            tooltip: 'Import or export iCal',
+            icon: const Icon(Icons.more_vert),
+            onSelected: _handleIcsAction,
+            itemBuilder: (context) => const [
+              PopupMenuItem<_CalendarIcsAction>(
+                key: Key('calendar_events_export_ics'),
+                value: _CalendarIcsAction.export,
+                child: ListTile(
+                  dense: true,
+                  leading: Icon(Icons.file_download_outlined),
+                  title: Text('Export .ics'),
+                ),
+              ),
+              PopupMenuItem<_CalendarIcsAction>(
+                key: Key('calendar_events_import_ics'),
+                value: _CalendarIcsAction.import,
+                child: ListTile(
+                  dense: true,
+                  leading: Icon(Icons.file_upload_outlined),
+                  title: Text('Import .ics'),
+                ),
+              ),
+            ],
           ),
           if (_isLoading)
             const Padding(
@@ -1452,71 +1608,68 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
                     onMove: _moveTimedEvent,
                   )
                 : _selectedDayEvents.isEmpty
-                    ? Center(
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(
-                              Icons.event_available,
-                              size: 48,
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.surfaceContainerHighest,
-                            ),
-                            const SizedBox(height: 8),
-                            Text(
-                              'この日のイベントはありません',
-                              style: TextStyle(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .outlineVariant,
-                                height: 1.5,
-                              ),
-                            ),
-                          ],
+                ? Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.event_available,
+                          size: 48,
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.surfaceContainerHighest,
                         ),
-                      )
-                    : ListView.builder(
-                        padding: const EdgeInsets.symmetric(horizontal: 12),
-                        itemCount: _selectedDayEvents.length,
-                        itemBuilder: (context, index) {
-                          final event = _selectedDayEvents[index];
-                          return _EventCard(
-                            event: event,
-                            color: _eventColor(event),
-                            onTap: () => _showEventDetailsSheet(context, event),
-                            onDelete: () {
-                              final eventId = calendarEventSeriesId(event);
-                              if (eventId.isEmpty) return;
-                              showDialog(
-                                context: context,
-                                builder: (ctx) => AlertDialog(
-                                  title: const Text('削除確認'),
-                                  content: Text('「${event['title']}」を削除しますか？'),
-                                  actions: [
-                                    TextButton(
-                                      onPressed: () => Navigator.pop(ctx),
-                                      child: const Text('キャンセル'),
-                                    ),
-                                    ElevatedButton(
-                                      style: ElevatedButton.styleFrom(
-                                        backgroundColor:
-                                            const Color(0xFFE53935),
-                                        foregroundColor: Colors.white,
-                                      ),
-                                      onPressed: () {
-                                        Navigator.pop(ctx);
-                                        _deleteEvent(eventId);
-                                      },
-                                      child: const Text('削除'),
-                                    ),
-                                  ],
+                        const SizedBox(height: 8),
+                        Text(
+                          'この日のイベントはありません',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.outlineVariant,
+                            height: 1.5,
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                : ListView.builder(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    itemCount: _selectedDayEvents.length,
+                    itemBuilder: (context, index) {
+                      final event = _selectedDayEvents[index];
+                      return _EventCard(
+                        event: event,
+                        color: _eventColor(event),
+                        onTap: () => _showEventDetailsSheet(context, event),
+                        onDelete: () {
+                          final eventId = calendarEventSeriesId(event);
+                          if (eventId.isEmpty) return;
+                          showDialog(
+                            context: context,
+                            builder: (ctx) => AlertDialog(
+                              title: const Text('削除確認'),
+                              content: Text('「${event['title']}」を削除しますか？'),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.pop(ctx),
+                                  child: const Text('キャンセル'),
                                 ),
-                              );
-                            },
+                                ElevatedButton(
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: const Color(0xFFE53935),
+                                    foregroundColor: Colors.white,
+                                  ),
+                                  onPressed: () {
+                                    Navigator.pop(ctx);
+                                    _deleteEvent(eventId);
+                                  },
+                                  child: const Text('削除'),
+                                ),
+                              ],
+                            ),
                           );
                         },
-                      ),
+                      );
+                    },
+                  ),
           ),
         ],
       ),
@@ -1702,8 +1855,9 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     _RecurrenceEditScope recurrenceScope = _RecurrenceEditScope.all,
   }) {
     final isEditing = event != null;
-    final editEvent =
-        event == null ? null : _eventForRecurrenceEdit(event, recurrenceScope);
+    final editEvent = event == null
+        ? null
+        : _eventForRecurrenceEdit(event, recurrenceScope);
     final eventId = editEvent == null ? '' : calendarEventSeriesId(editEvent);
     final initialStart = editEvent == null
         ? _selectedDay
@@ -1711,7 +1865,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     final initialEnd = editEvent == null
         ? initialStart.add(const Duration(hours: 1))
         : (_eventDateTime(editEvent, 'end_at') ??
-            initialStart.add(const Duration(hours: 1)));
+              initialStart.add(const Duration(hours: 1)));
     final titleCtrl = TextEditingController(
       text: editEvent?['title']?.toString() ?? '',
     );
@@ -1727,8 +1881,9 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     var startTime = TimeOfDay.fromDateTime(initialStart);
     var endTime = TimeOfDay.fromDateTime(initialEnd);
     final colors = ['#4285f4', '#ea4335', '#34a853', '#fbbc05', '#9334e6'];
-    var selectedColor =
-        editEvent == null ? colors.first : _eventColorHex(editEvent);
+    var selectedColor = editEvent == null
+        ? colors.first
+        : _eventColorHex(editEvent);
     if (!colors.contains(selectedColor)) {
       selectedColor = colors.first;
     }
@@ -2076,10 +2231,12 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
                         endTime.hour,
                         endTime.minute,
                       );
-                final reminderMinutes =
-                    selectedReminder < 0 ? null : selectedReminder;
-                final recurrenceCount =
-                    int.tryParse(recurrenceCountCtrl.text.trim());
+                final reminderMinutes = selectedReminder < 0
+                    ? null
+                    : selectedReminder;
+                final recurrenceCount = int.tryParse(
+                  recurrenceCountCtrl.text.trim(),
+                );
                 final rrule = _buildCalendarRRule(
                   preset: selectedRecurrence,
                   eventDate: eventDate,
@@ -2128,7 +2285,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
 class _CalendarEventSearchDelegate
     extends SearchDelegate<Map<String, dynamic>?> {
   _CalendarEventSearchDelegate({required this.events})
-      : super(searchFieldLabel: 'Search events');
+    : super(searchFieldLabel: 'Search events');
 
   final List<Map<String, dynamic>> events;
 
@@ -2535,9 +2692,11 @@ class _DayTimelineView extends StatelessWidget {
                       height: _hourHeight,
                       child: _HourSlot(hour: hour),
                     ),
-                  for (var minute = 0;
-                      minute < 24 * 60;
-                      minute += _calendarDragSnapMinutes)
+                  for (
+                    var minute = 0;
+                    minute < 24 * 60;
+                    minute += _calendarDragSnapMinutes
+                  )
                     Positioned(
                       top: (minute / 60) * _hourHeight,
                       left: _timeGutterWidth,
@@ -2562,7 +2721,8 @@ class _DayTimelineView extends StatelessWidget {
   }
 
   Widget _buildPositionedEvent(_TimelineEntry entry, double contentWidth) {
-    final columnWidth = (contentWidth - (entry.columnCount - 1) * _eventGap) /
+    final columnWidth =
+        (contentWidth - (entry.columnCount - 1) * _eventGap) /
         entry.columnCount;
     final safeColumnWidth = columnWidth < 48 ? 48.0 : columnWidth;
     final top = (entry.startMinute / 60) * _hourHeight + 2;
@@ -2572,7 +2732,8 @@ class _DayTimelineView extends StatelessWidget {
 
     return Positioned(
       top: top,
-      left: _timeGutterWidth +
+      left:
+          _timeGutterWidth +
           _eventGap +
           entry.column * (safeColumnWidth + _eventGap),
       width: safeColumnWidth,
@@ -2686,8 +2847,9 @@ class _DayTimelineView extends StatelessWidget {
       1440,
     );
     final minimumEndMinute = _clampInt(startMinute + 30, 1, 1440);
-    final endMinute =
-        rawEndMinute < minimumEndMinute ? minimumEndMinute : rawEndMinute;
+    final endMinute = rawEndMinute < minimumEndMinute
+        ? minimumEndMinute
+        : rawEndMinute;
 
     return _TimelineRange(startMinute, endMinute);
   }

--- a/lib/pages/calendar_events_page.dart
+++ b/lib/pages/calendar_events_page.dart
@@ -23,8 +23,8 @@ class CalendarEventsPage extends StatefulWidget {
     super.key,
     SupabaseClient? supabaseClient,
     NotificationService? notificationService,
-  }) : _supabaseClient = supabaseClient,
-       _notificationService = notificationService;
+  })  : _supabaseClient = supabaseClient,
+        _notificationService = notificationService;
 
   final SupabaseClient? _supabaseClient;
   final NotificationService? _notificationService;
@@ -70,8 +70,8 @@ bool _eventIsAllDay(Map<String, dynamic> event) => event['all_day'] == true;
 
 String _eventTitle(Map<String, dynamic> event) =>
     event['title']?.toString().trim().isNotEmpty == true
-    ? event['title'].toString()
-    : 'Untitled';
+        ? event['title'].toString()
+        : 'Untitled';
 
 String _eventTimeLabel(Map<String, dynamic> event) {
   if (_eventIsAllDay(event)) return 'All-day';
@@ -95,8 +95,8 @@ String _eventDateTimeLabel(Map<String, dynamic> event) {
   if (end == null) return _formatDateTime(start);
   final endLabel =
       start.year == end.year && start.month == end.month && start.day == end.day
-      ? _formatClock(end)
-      : _formatDateTime(end);
+          ? _formatClock(end)
+          : _formatDateTime(end);
   return '${_formatDateTime(start)} - $endLabel';
 }
 
@@ -181,8 +181,7 @@ String calendarEventRecurrenceLabel(Map<String, dynamic> event) {
       rrule,
       options: const RecurrenceRuleFromStringOptions.lenient(),
     );
-    final hasCustomParts =
-        rule.count != null ||
+    final hasCustomParts = rule.count != null ||
         rule.until != null ||
         rule.hasByWeekDays ||
         rule.hasByMonthDays ||
@@ -303,9 +302,8 @@ bool _eventRangeOverlaps(
   DateTime rangeStart,
   DateTime rangeEnd,
 ) {
-  final safeEnd = end.isAfter(start)
-      ? end
-      : start.add(const Duration(hours: 1));
+  final safeEnd =
+      end.isAfter(start) ? end : start.add(const Duration(hours: 1));
   return safeEnd.isAfter(rangeStart) && start.isBefore(rangeEnd);
 }
 
@@ -314,9 +312,8 @@ DateTime snapCalendarEventStartToGrid(
   DateTime value, {
   int granularityMinutes = _calendarDragSnapMinutes,
 }) {
-  final safeGranularity = granularityMinutes <= 0
-      ? _calendarDragSnapMinutes
-      : granularityMinutes;
+  final safeGranularity =
+      granularityMinutes <= 0 ? _calendarDragSnapMinutes : granularityMinutes;
   final dayStart = DateTime(value.year, value.month, value.day);
   final minutes = value.difference(dayStart).inMinutes;
   final snappedMinutes = (minutes / safeGranularity).round() * safeGranularity;
@@ -347,8 +344,7 @@ _CalendarRecurrencePreset _recurrencePresetForRRule(String? rrule) {
       rrule,
       options: const RecurrenceRuleFromStringOptions.lenient(),
     );
-    final hasCustomParts =
-        rule.count != null ||
+    final hasCustomParts = rule.count != null ||
         rule.until != null ||
         rule.hasByWeekDays ||
         rule.hasByMonthDays ||
@@ -447,9 +443,8 @@ String? _buildCalendarRRule({
     frequency: _frequencyForPreset(preset),
     until: normalizedUntil,
     count: normalizedCount,
-    byWeekDays: preset == _CalendarRecurrencePreset.custom
-        ? byWeekDays
-        : const [],
+    byWeekDays:
+        preset == _CalendarRecurrencePreset.custom ? byWeekDays : const [],
   );
   return rule.toString();
 }
@@ -586,14 +581,14 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   }
 
   _CalendarListItem get _defaultCalendar => _calendars.firstWhere(
-    (calendar) => calendar.id == _defaultCalendarId,
-    orElse: () => const _CalendarListItem(
-      id: _defaultCalendarId,
-      name: _defaultCalendarName,
-      color: _defaultCalendarColor,
-      isDefault: true,
-    ),
-  );
+        (calendar) => calendar.id == _defaultCalendarId,
+        orElse: () => const _CalendarListItem(
+          id: _defaultCalendarId,
+          name: _defaultCalendarName,
+          color: _defaultCalendarColor,
+          isDefault: true,
+        ),
+      );
 
   _CalendarListItem _calendarForId(String id) {
     return _calendars.firstWhere(
@@ -714,8 +709,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     final data = res.data;
     final rawCalendars =
         data is Map<String, dynamic> && data['calendars'] is List
-        ? data['calendars'] as List
-        : <dynamic>[];
+            ? data['calendars'] as List
+            : <dynamic>[];
     final nextCalendars = <_CalendarListItem>[];
     for (final raw in rawCalendars) {
       if (raw is! Map) continue;
@@ -736,8 +731,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     }
     final knownIds = nextCalendars.map((calendar) => calendar.id).toSet();
     setState(() {
-      final shouldSelectAll =
-          !_hasLoadedCalendars ||
+      final shouldSelectAll = !_hasLoadedCalendars ||
           (_visibleCalendarIds.length == _calendars.length &&
               _calendars.every(
                 (calendar) => _visibleCalendarIds.contains(calendar.id),
@@ -835,9 +829,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     String? rrule,
   }) async {
     try {
-      final end = allDay
-          ? startAt
-          : (endAt ?? startAt.add(const Duration(hours: 1)));
+      final end =
+          allDay ? startAt : (endAt ?? startAt.add(const Duration(hours: 1)));
       final res = await _supabase.functions.invoke(
         'app-hub',
         body: {
@@ -855,9 +848,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
       );
       final data = res.data;
       final savedEvent = data is Map ? data['event'] : null;
-      final eventId = savedEvent is Map
-          ? savedEvent['event_id']?.toString() ?? ''
-          : '';
+      final eventId =
+          savedEvent is Map ? savedEvent['event_id']?.toString() ?? '' : '';
       if (eventId.isNotEmpty && reminderMinutes != null) {
         _scheduleInAppReminderTimer({
           'event_id': eventId,
@@ -903,9 +895,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
       return;
     }
     try {
-      final end = allDay
-          ? startAt
-          : (endAt ?? startAt.add(const Duration(hours: 1)));
+      final end =
+          allDay ? startAt : (endAt ?? startAt.add(const Duration(hours: 1)));
       await _supabase.functions.invoke(
         'app-hub',
         body: {
@@ -1104,9 +1095,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
       );
       final data = res.data;
       final calendar = data is Map ? data['calendar'] : null;
-      final calendarId = calendar is Map
-          ? calendar['calendar_id']?.toString() ?? ''
-          : '';
+      final calendarId =
+          calendar is Map ? calendar['calendar_id']?.toString() ?? '' : '';
       if (calendarId.isNotEmpty) {
         _visibleCalendarIds.add(calendarId);
       }
@@ -1443,8 +1433,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
 
   @override
   Widget build(BuildContext context) {
-    final usesTimeline =
-        _calendarView == _CalendarView.day ||
+    final usesTimeline = _calendarView == _CalendarView.day ||
         _calendarView == _CalendarView.week;
 
     return Scaffold(
@@ -1608,68 +1597,71 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
                     onMove: _moveTimedEvent,
                   )
                 : _selectedDayEvents.isEmpty
-                ? Center(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          Icons.event_available,
-                          size: 48,
-                          color: Theme.of(
-                            context,
-                          ).colorScheme.surfaceContainerHighest,
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          'この日のイベントはありません',
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.outlineVariant,
-                            height: 1.5,
-                          ),
-                        ),
-                      ],
-                    ),
-                  )
-                : ListView.builder(
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    itemCount: _selectedDayEvents.length,
-                    itemBuilder: (context, index) {
-                      final event = _selectedDayEvents[index];
-                      return _EventCard(
-                        event: event,
-                        color: _eventColor(event),
-                        onTap: () => _showEventDetailsSheet(context, event),
-                        onDelete: () {
-                          final eventId = calendarEventSeriesId(event);
-                          if (eventId.isEmpty) return;
-                          showDialog(
-                            context: context,
-                            builder: (ctx) => AlertDialog(
-                              title: const Text('削除確認'),
-                              content: Text('「${event['title']}」を削除しますか？'),
-                              actions: [
-                                TextButton(
-                                  onPressed: () => Navigator.pop(ctx),
-                                  child: const Text('キャンセル'),
-                                ),
-                                ElevatedButton(
-                                  style: ElevatedButton.styleFrom(
-                                    backgroundColor: const Color(0xFFE53935),
-                                    foregroundColor: Colors.white,
-                                  ),
-                                  onPressed: () {
-                                    Navigator.pop(ctx);
-                                    _deleteEvent(eventId);
-                                  },
-                                  child: const Text('削除'),
-                                ),
-                              ],
+                    ? Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Icons.event_available,
+                              size: 48,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.surfaceContainerHighest,
                             ),
+                            const SizedBox(height: 8),
+                            Text(
+                              'この日のイベントはありません',
+                              style: TextStyle(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .outlineVariant,
+                                height: 1.5,
+                              ),
+                            ),
+                          ],
+                        ),
+                      )
+                    : ListView.builder(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        itemCount: _selectedDayEvents.length,
+                        itemBuilder: (context, index) {
+                          final event = _selectedDayEvents[index];
+                          return _EventCard(
+                            event: event,
+                            color: _eventColor(event),
+                            onTap: () => _showEventDetailsSheet(context, event),
+                            onDelete: () {
+                              final eventId = calendarEventSeriesId(event);
+                              if (eventId.isEmpty) return;
+                              showDialog(
+                                context: context,
+                                builder: (ctx) => AlertDialog(
+                                  title: const Text('削除確認'),
+                                  content: Text('「${event['title']}」を削除しますか？'),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => Navigator.pop(ctx),
+                                      child: const Text('キャンセル'),
+                                    ),
+                                    ElevatedButton(
+                                      style: ElevatedButton.styleFrom(
+                                        backgroundColor:
+                                            const Color(0xFFE53935),
+                                        foregroundColor: Colors.white,
+                                      ),
+                                      onPressed: () {
+                                        Navigator.pop(ctx);
+                                        _deleteEvent(eventId);
+                                      },
+                                      child: const Text('削除'),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            },
                           );
                         },
-                      );
-                    },
-                  ),
+                      ),
           ),
         ],
       ),
@@ -1855,9 +1847,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     _RecurrenceEditScope recurrenceScope = _RecurrenceEditScope.all,
   }) {
     final isEditing = event != null;
-    final editEvent = event == null
-        ? null
-        : _eventForRecurrenceEdit(event, recurrenceScope);
+    final editEvent =
+        event == null ? null : _eventForRecurrenceEdit(event, recurrenceScope);
     final eventId = editEvent == null ? '' : calendarEventSeriesId(editEvent);
     final initialStart = editEvent == null
         ? _selectedDay
@@ -1865,7 +1856,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     final initialEnd = editEvent == null
         ? initialStart.add(const Duration(hours: 1))
         : (_eventDateTime(editEvent, 'end_at') ??
-              initialStart.add(const Duration(hours: 1)));
+            initialStart.add(const Duration(hours: 1)));
     final titleCtrl = TextEditingController(
       text: editEvent?['title']?.toString() ?? '',
     );
@@ -1881,9 +1872,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
     var startTime = TimeOfDay.fromDateTime(initialStart);
     var endTime = TimeOfDay.fromDateTime(initialEnd);
     final colors = ['#4285f4', '#ea4335', '#34a853', '#fbbc05', '#9334e6'];
-    var selectedColor = editEvent == null
-        ? colors.first
-        : _eventColorHex(editEvent);
+    var selectedColor =
+        editEvent == null ? colors.first : _eventColorHex(editEvent);
     if (!colors.contains(selectedColor)) {
       selectedColor = colors.first;
     }
@@ -2231,9 +2221,8 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
                         endTime.hour,
                         endTime.minute,
                       );
-                final reminderMinutes = selectedReminder < 0
-                    ? null
-                    : selectedReminder;
+                final reminderMinutes =
+                    selectedReminder < 0 ? null : selectedReminder;
                 final recurrenceCount = int.tryParse(
                   recurrenceCountCtrl.text.trim(),
                 );
@@ -2285,7 +2274,7 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
 class _CalendarEventSearchDelegate
     extends SearchDelegate<Map<String, dynamic>?> {
   _CalendarEventSearchDelegate({required this.events})
-    : super(searchFieldLabel: 'Search events');
+      : super(searchFieldLabel: 'Search events');
 
   final List<Map<String, dynamic>> events;
 
@@ -2692,11 +2681,9 @@ class _DayTimelineView extends StatelessWidget {
                       height: _hourHeight,
                       child: _HourSlot(hour: hour),
                     ),
-                  for (
-                    var minute = 0;
-                    minute < 24 * 60;
-                    minute += _calendarDragSnapMinutes
-                  )
+                  for (var minute = 0;
+                      minute < 24 * 60;
+                      minute += _calendarDragSnapMinutes)
                     Positioned(
                       top: (minute / 60) * _hourHeight,
                       left: _timeGutterWidth,
@@ -2721,8 +2708,7 @@ class _DayTimelineView extends StatelessWidget {
   }
 
   Widget _buildPositionedEvent(_TimelineEntry entry, double contentWidth) {
-    final columnWidth =
-        (contentWidth - (entry.columnCount - 1) * _eventGap) /
+    final columnWidth = (contentWidth - (entry.columnCount - 1) * _eventGap) /
         entry.columnCount;
     final safeColumnWidth = columnWidth < 48 ? 48.0 : columnWidth;
     final top = (entry.startMinute / 60) * _hourHeight + 2;
@@ -2732,8 +2718,7 @@ class _DayTimelineView extends StatelessWidget {
 
     return Positioned(
       top: top,
-      left:
-          _timeGutterWidth +
+      left: _timeGutterWidth +
           _eventGap +
           entry.column * (safeColumnWidth + _eventGap),
       width: safeColumnWidth,
@@ -2847,9 +2832,8 @@ class _DayTimelineView extends StatelessWidget {
       1440,
     );
     final minimumEndMinute = _clampInt(startMinute + 30, 1, 1440);
-    final endMinute = rawEndMinute < minimumEndMinute
-        ? minimumEndMinute
-        : rawEndMinute;
+    final endMinute =
+        rawEndMinute < minimumEndMinute ? minimumEndMinute : rawEndMinute;
 
     return _TimelineRange(startMinute, endMinute);
   }

--- a/lib/services/calendar_ics_service.dart
+++ b/lib/services/calendar_ics_service.dart
@@ -1,0 +1,426 @@
+import 'package:flutter/foundation.dart';
+
+const String _icsProductId = '-//Jibun Inc//Calendar Events//EN';
+const String _icsDomain = 'my-web-app.local';
+
+class CalendarIcsParseResult {
+  const CalendarIcsParseResult({
+    required this.events,
+    required this.skippedDuplicateCount,
+    required this.invalidEventCount,
+  });
+
+  final List<Map<String, dynamic>> events;
+  final int skippedDuplicateCount;
+  final int invalidEventCount;
+}
+
+@visibleForTesting
+String normalizeCalendarIcsUid(Object? value) {
+  final raw = value?.toString().trim() ?? '';
+  if (raw.isEmpty) return '';
+  return raw.length > 512 ? raw.substring(0, 512) : raw;
+}
+
+Set<String> calendarIcsUidsFromEvents(Iterable<Map<String, dynamic>> events) {
+  return {
+    for (final event in events)
+      if (normalizeCalendarIcsUid(event['ical_uid'] ?? event['uid']).isNotEmpty)
+        normalizeCalendarIcsUid(event['ical_uid'] ?? event['uid']),
+  };
+}
+
+String buildCalendarEventsIcs(
+  Iterable<Map<String, dynamic>> events, {
+  DateTime? generatedAt,
+}) {
+  final now = (generatedAt ?? DateTime.now()).toUtc();
+  final buffer = StringBuffer();
+  final seenUids = <String>{};
+
+  _appendIcsLine(buffer, 'BEGIN:VCALENDAR');
+  _appendIcsLine(buffer, 'VERSION:2.0');
+  _appendIcsLine(buffer, 'PRODID:$_icsProductId');
+  _appendIcsLine(buffer, 'CALSCALE:GREGORIAN');
+  _appendIcsLine(buffer, 'METHOD:PUBLISH');
+
+  for (final rawEvent in events) {
+    final event = _canonicalExportEvent(rawEvent);
+    final uid = _eventUid(event);
+    if (uid.isEmpty || !seenUids.add(uid)) continue;
+
+    final start = _eventDateTime(event, 'start_at');
+    if (start == null) continue;
+    final end = _eventDateTime(event, 'end_at') ??
+        start.add(
+          _eventIsAllDay(event)
+              ? const Duration(days: 1)
+              : const Duration(hours: 1),
+        );
+    final allDay = _eventIsAllDay(event);
+    final title = _eventTitle(event);
+    final description = event['description']?.toString() ?? '';
+    final color = _eventColorHex(event);
+    final calendarId = _nonEmptyString(event['calendar_id']);
+    final calendarName = _nonEmptyString(event['calendar_name']);
+    final reminder = _nonEmptyString(event['reminder_min']);
+    final rrule = _nonEmptyString(event['rrule']);
+
+    _appendIcsLine(buffer, 'BEGIN:VEVENT');
+    _appendIcsLine(buffer, 'UID:${_escapeIcsText(uid)}');
+    _appendIcsLine(buffer, 'DTSTAMP:${_formatUtcIcsDateTime(now)}');
+    if (allDay) {
+      _appendIcsLine(buffer, 'DTSTART;VALUE=DATE:${_formatIcsDate(start)}');
+      _appendIcsLine(
+        buffer,
+        'DTEND;VALUE=DATE:${_formatIcsDate(_exclusiveAllDayEnd(start, end))}',
+      );
+    } else {
+      _appendIcsLine(buffer, 'DTSTART:${_formatUtcIcsDateTime(start.toUtc())}');
+      _appendIcsLine(buffer, 'DTEND:${_formatUtcIcsDateTime(end.toUtc())}');
+    }
+    _appendIcsLine(buffer, 'SUMMARY:${_escapeIcsText(title)}');
+    if (description.isNotEmpty) {
+      _appendIcsLine(buffer, 'DESCRIPTION:${_escapeIcsText(description)}');
+    }
+    if (rrule.isNotEmpty) {
+      _appendIcsLine(
+        buffer,
+        rrule.toUpperCase().startsWith('RRULE:') ? rrule : 'RRULE:$rrule',
+      );
+    }
+    _appendIcsLine(buffer, 'X-MYWEBAPP-COLOR:$color');
+    if (calendarId.isNotEmpty) {
+      _appendIcsLine(
+        buffer,
+        'X-MYWEBAPP-CALENDAR-ID:${_escapeIcsText(calendarId)}',
+      );
+    }
+    if (calendarName.isNotEmpty) {
+      _appendIcsLine(
+        buffer,
+        'X-MYWEBAPP-CALENDAR-NAME:${_escapeIcsText(calendarName)}',
+      );
+    }
+    if (reminder.isNotEmpty && reminder != 'null') {
+      _appendIcsLine(buffer, 'X-MYWEBAPP-REMINDER-MIN:$reminder');
+    }
+    _appendIcsLine(buffer, 'END:VEVENT');
+  }
+
+  _appendIcsLine(buffer, 'END:VCALENDAR');
+  return buffer.toString();
+}
+
+CalendarIcsParseResult parseCalendarEventsIcs(
+  String content, {
+  Set<String> existingUids = const {},
+}) {
+  final lines = _unfoldIcsLines(content);
+  final events = <Map<String, dynamic>>[];
+  final seenUids = existingUids
+      .map(normalizeCalendarIcsUid)
+      .where((uid) => uid.isNotEmpty)
+      .toSet();
+  var skippedDuplicates = 0;
+  var invalidEvents = 0;
+  Map<String, List<_IcsProperty>>? current;
+
+  void finishEvent() {
+    final fields = current;
+    if (fields == null) return;
+    current = null;
+
+    final uid = normalizeCalendarIcsUid(_firstValue(fields, 'UID'));
+    final startProp = _firstProperty(fields, 'DTSTART');
+    if (uid.isEmpty || startProp == null) {
+      invalidEvents += 1;
+      return;
+    }
+    if (seenUids.contains(uid)) {
+      skippedDuplicates += 1;
+      return;
+    }
+
+    final allDay = _isAllDayProperty(startProp);
+    final start = _parseIcsDateTime(startProp.value, allDay: allDay);
+    if (start == null) {
+      invalidEvents += 1;
+      return;
+    }
+    final endProp = _firstProperty(fields, 'DTEND');
+    final parsedEnd = endProp == null
+        ? null
+        : _parseIcsDateTime(endProp.value, allDay: _isAllDayProperty(endProp));
+    final end = parsedEnd ??
+        start.add(allDay ? const Duration(days: 1) : const Duration(hours: 1));
+
+    seenUids.add(uid);
+    events.add({
+      'ical_uid': uid,
+      'uid': uid,
+      'title': _unescapeIcsText(_firstValue(fields, 'SUMMARY')).trim().isEmpty
+          ? 'Untitled'
+          : _unescapeIcsText(_firstValue(fields, 'SUMMARY')).trim(),
+      'description': _unescapeIcsText(_firstValue(fields, 'DESCRIPTION')),
+      'start_at': start.toIso8601String(),
+      'end_at': end.toIso8601String(),
+      'all_day': allDay,
+      'color': _normalizeIcsColor(_firstValue(fields, 'X-MYWEBAPP-COLOR')),
+      'calendar_id': _unescapeIcsText(
+        _firstValue(fields, 'X-MYWEBAPP-CALENDAR-ID'),
+      ).trim(),
+      'calendar_name': _unescapeIcsText(
+        _firstValue(fields, 'X-MYWEBAPP-CALENDAR-NAME'),
+      ).trim(),
+      'reminder_min': int.tryParse(
+        _firstValue(fields, 'X-MYWEBAPP-REMINDER-MIN').trim(),
+      ),
+      'rrule': _normalizeImportedRRule(_firstValue(fields, 'RRULE')),
+      'source': 'ical_import',
+    });
+  }
+
+  for (final rawLine in lines) {
+    final property = _parseIcsProperty(rawLine);
+    if (property == null) continue;
+    if (property.name == 'BEGIN' && property.value.toUpperCase() == 'VEVENT') {
+      current = <String, List<_IcsProperty>>{};
+      continue;
+    }
+    if (property.name == 'END' && property.value.toUpperCase() == 'VEVENT') {
+      finishEvent();
+      continue;
+    }
+    if (current == null) continue;
+    current!.putIfAbsent(property.name, () => []).add(property);
+  }
+  finishEvent();
+
+  return CalendarIcsParseResult(
+    events: events,
+    skippedDuplicateCount: skippedDuplicates,
+    invalidEventCount: invalidEvents,
+  );
+}
+
+Map<String, dynamic> _canonicalExportEvent(Map<String, dynamic> event) {
+  if (event['series_event_id']?.toString().trim().isNotEmpty != true) {
+    return event;
+  }
+  return {
+    ...event,
+    'event_id': event['series_event_id'],
+    'start_at': event['series_start_at'] ?? event['start_at'],
+    'end_at': event['series_end_at'] ?? event['end_at'],
+  };
+}
+
+String _eventUid(Map<String, dynamic> event) {
+  final stored = normalizeCalendarIcsUid(event['ical_uid'] ?? event['uid']);
+  if (stored.isNotEmpty) return stored;
+  final id = normalizeCalendarIcsUid(
+    event['series_event_id'] ?? event['event_id'] ?? event['id'],
+  );
+  return id.isEmpty ? '' : '$id@$_icsDomain';
+}
+
+String _eventTitle(Map<String, dynamic> event) {
+  final title = event['title']?.toString().trim() ?? '';
+  return title.isEmpty ? 'Untitled' : title;
+}
+
+bool _eventIsAllDay(Map<String, dynamic> event) => event['all_day'] == true;
+
+DateTime? _eventDateTime(Map<String, dynamic> event, String key) {
+  final value = event[key]?.toString() ?? '';
+  if (value.isEmpty) return null;
+  return DateTime.tryParse(value);
+}
+
+String _eventColorHex(Map<String, dynamic> event) {
+  final raw = event['color']?.toString().trim() ?? '';
+  final normalized = raw.startsWith('#') ? raw : '#$raw';
+  final lower = normalized.toLowerCase();
+  return RegExp(r'^#[0-9a-f]{6}$').hasMatch(lower) ? lower : '#4285f4';
+}
+
+String _nonEmptyString(Object? value) => value?.toString().trim() ?? '';
+
+DateTime _exclusiveAllDayEnd(DateTime start, DateTime end) {
+  final startDate = DateTime(start.year, start.month, start.day);
+  final endDate = DateTime(end.year, end.month, end.day);
+  return endDate.isAfter(startDate)
+      ? endDate
+      : startDate.add(const Duration(days: 1));
+}
+
+String _formatIcsDate(DateTime value) {
+  return '${value.year.toString().padLeft(4, '0')}'
+      '${value.month.toString().padLeft(2, '0')}'
+      '${value.day.toString().padLeft(2, '0')}';
+}
+
+String _formatUtcIcsDateTime(DateTime value) {
+  final utc = value.toUtc();
+  return '${_formatIcsDate(utc)}T'
+      '${utc.hour.toString().padLeft(2, '0')}'
+      '${utc.minute.toString().padLeft(2, '0')}'
+      '${utc.second.toString().padLeft(2, '0')}Z';
+}
+
+void _appendIcsLine(StringBuffer buffer, String line) {
+  const max = 75;
+  if (line.length <= max) {
+    buffer.write(line);
+    buffer.write('\r\n');
+    return;
+  }
+  var remaining = line;
+  var first = true;
+  while (remaining.isNotEmpty) {
+    final take = first ? max : max - 1;
+    final part =
+        remaining.length <= take ? remaining : remaining.substring(0, take);
+    buffer.write(first ? part : ' $part');
+    buffer.write('\r\n');
+    remaining = remaining.length <= take ? '' : remaining.substring(take);
+    first = false;
+  }
+}
+
+String _escapeIcsText(String value) {
+  return value
+      .replaceAll('\\', '\\\\')
+      .replaceAll('\n', r'\n')
+      .replaceAll(';', r'\;')
+      .replaceAll(',', r'\,');
+}
+
+String _unescapeIcsText(String value) {
+  final buffer = StringBuffer();
+  for (var i = 0; i < value.length; i += 1) {
+    final char = value[i];
+    if (char != '\\' || i == value.length - 1) {
+      buffer.write(char);
+      continue;
+    }
+    final next = value[++i];
+    switch (next) {
+      case 'n':
+      case 'N':
+        buffer.write('\n');
+        break;
+      case '\\':
+        buffer.write('\\');
+        break;
+      case ',':
+        buffer.write(',');
+        break;
+      case ';':
+        buffer.write(';');
+        break;
+      default:
+        buffer.write(next);
+        break;
+    }
+  }
+  return buffer.toString();
+}
+
+List<String> _unfoldIcsLines(String content) {
+  final normalized = content.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  final lines = <String>[];
+  for (final line in normalized.split('\n')) {
+    if ((line.startsWith(' ') || line.startsWith('\t')) && lines.isNotEmpty) {
+      lines[lines.length - 1] += line.substring(1);
+    } else if (line.trim().isNotEmpty) {
+      lines.add(line);
+    }
+  }
+  return lines;
+}
+
+class _IcsProperty {
+  const _IcsProperty({
+    required this.name,
+    required this.params,
+    required this.value,
+  });
+
+  final String name;
+  final Map<String, String> params;
+  final String value;
+}
+
+_IcsProperty? _parseIcsProperty(String line) {
+  final colon = line.indexOf(':');
+  if (colon <= 0) return null;
+  final left = line.substring(0, colon);
+  final value = line.substring(colon + 1);
+  final parts = left.split(';');
+  final name = parts.first.trim().toUpperCase();
+  if (name.isEmpty) return null;
+  final params = <String, String>{};
+  for (final part in parts.skip(1)) {
+    final equals = part.indexOf('=');
+    if (equals <= 0) continue;
+    params[part.substring(0, equals).trim().toUpperCase()] =
+        part.substring(equals + 1).trim();
+  }
+  return _IcsProperty(name: name, params: params, value: value);
+}
+
+_IcsProperty? _firstProperty(
+  Map<String, List<_IcsProperty>> fields,
+  String name,
+) {
+  final values = fields[name.toUpperCase()];
+  return values == null || values.isEmpty ? null : values.first;
+}
+
+String _firstValue(Map<String, List<_IcsProperty>> fields, String name) {
+  return _firstProperty(fields, name)?.value ?? '';
+}
+
+bool _isAllDayProperty(_IcsProperty property) {
+  return property.params['VALUE']?.toUpperCase() == 'DATE' ||
+      RegExp(r'^\d{8}$').hasMatch(property.value);
+}
+
+DateTime? _parseIcsDateTime(String value, {required bool allDay}) {
+  final raw = value.trim();
+  if (RegExp(r'^\d{8}$').hasMatch(raw)) {
+    return DateTime(
+      int.parse(raw.substring(0, 4)),
+      int.parse(raw.substring(4, 6)),
+      int.parse(raw.substring(6, 8)),
+    );
+  }
+  final match = RegExp(
+    r'^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})?(Z)?$',
+  ).firstMatch(raw);
+  if (match == null) return DateTime.tryParse(raw);
+  final year = int.parse(match.group(1)!);
+  final month = int.parse(match.group(2)!);
+  final day = int.parse(match.group(3)!);
+  final hour = int.parse(match.group(4)!);
+  final minute = int.parse(match.group(5)!);
+  final second = int.tryParse(match.group(6) ?? '0') ?? 0;
+  if (match.group(7) == 'Z') {
+    return DateTime.utc(year, month, day, hour, minute, second).toLocal();
+  }
+  return DateTime(year, month, day, hour, minute, second);
+}
+
+String _normalizeIcsColor(String value) {
+  return _eventColorHex({'color': value});
+}
+
+String? _normalizeImportedRRule(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) return null;
+  return trimmed.toUpperCase().startsWith('RRULE:')
+      ? trimmed
+      : 'RRULE:$trimmed';
+}

--- a/lib/utils/web_text_downloader.dart
+++ b/lib/utils/web_text_downloader.dart
@@ -1,0 +1,2 @@
+export 'web_text_downloader_stub.dart'
+    if (dart.library.js_interop) 'web_text_downloader_web.dart';

--- a/lib/utils/web_text_downloader_stub.dart
+++ b/lib/utils/web_text_downloader_stub.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/foundation.dart';
+
+void downloadTextFile(
+  String textData,
+  String fileName, {
+  String mimeType = 'text/plain;charset=utf-8',
+}) {
+  debugPrint('Web text download is not supported on this platform: $fileName');
+}

--- a/lib/utils/web_text_downloader_web.dart
+++ b/lib/utils/web_text_downloader_web.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:web/web.dart' as web;
+
+void downloadTextFile(
+  String textData,
+  String fileName, {
+  String mimeType = 'text/plain;charset=utf-8',
+}) {
+  final bytes = Uint8List.fromList(utf8.encode(textData));
+  final blob = web.Blob([bytes.toJS].toJS, web.BlobPropertyBag(type: mimeType));
+  final url = web.URL.createObjectURL(blob);
+  web.HTMLAnchorElement()
+    ..href = url
+    ..download = fileName
+    ..click();
+  web.URL.revokeObjectURL(url);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -836,14 +836,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -928,18 +920,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1533,26 +1525,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   time:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -836,6 +836,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -920,18 +928,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1525,26 +1533,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/supabase/functions/app-hub/calendar_bulk_create.ts
+++ b/supabase/functions/app-hub/calendar_bulk_create.ts
@@ -1,0 +1,54 @@
+export function normalizeCalendarIcsUid(value: unknown): string {
+  const raw = value == null ? "" : String(value).trim();
+  return raw.length > 512 ? raw.slice(0, 512) : raw;
+}
+
+export function calendarIcsUidFromMetadata(
+  metadata: Record<string, unknown>,
+): string {
+  return normalizeCalendarIcsUid(metadata.ical_uid ?? metadata.uid);
+}
+
+export type CalendarBulkCreatePreparation = {
+  candidates: Record<string, unknown>[];
+  skippedDuplicates: number;
+  invalidCount: number;
+};
+
+export function prepareCalendarBulkCreateCandidates(
+  rawEvents: unknown,
+  existingUids: Set<string>,
+): CalendarBulkCreatePreparation {
+  if (!Array.isArray(rawEvents)) {
+    return { candidates: [], skippedDuplicates: 0, invalidCount: 1 };
+  }
+
+  const seen = new Set(
+    Array.from(existingUids).map(normalizeCalendarIcsUid).filter(Boolean),
+  );
+  const candidates: Record<string, unknown>[] = [];
+  let skippedDuplicates = 0;
+  let invalidCount = 0;
+
+  for (const raw of rawEvents) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      invalidCount += 1;
+      continue;
+    }
+    const event = raw as Record<string, unknown>;
+    const uid = normalizeCalendarIcsUid(event.ical_uid ?? event.uid);
+    const startAt = String(event.start_at ?? "").trim();
+    if (!uid || !startAt) {
+      invalidCount += 1;
+      continue;
+    }
+    if (seen.has(uid)) {
+      skippedDuplicates += 1;
+      continue;
+    }
+    seen.add(uid);
+    candidates.push({ ...event, ical_uid: uid });
+  }
+
+  return { candidates, skippedDuplicates, invalidCount };
+}

--- a/supabase/functions/app-hub/calendar_bulk_create_test.ts
+++ b/supabase/functions/app-hub/calendar_bulk_create_test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  calendarIcsUidFromMetadata,
+  normalizeCalendarIcsUid,
+  prepareCalendarBulkCreateCandidates,
+} from "./calendar_bulk_create.ts";
+
+Deno.test("calendar bulk create normalizes UID metadata", () => {
+  assertEquals(
+    normalizeCalendarIcsUid(" event-1@example.com "),
+    "event-1@example.com",
+  );
+  assertEquals(
+    calendarIcsUidFromMetadata({ uid: "fallback-uid" }),
+    "fallback-uid",
+  );
+  assertEquals(
+    calendarIcsUidFromMetadata({ ical_uid: "ical-uid", uid: "fallback-uid" }),
+    "ical-uid",
+  );
+});
+
+Deno.test("calendar bulk create skips existing and payload duplicate UIDs", () => {
+  const prepared = prepareCalendarBulkCreateCandidates(
+    [
+      { ical_uid: "already-there", start_at: "2026-05-14T09:00:00.000" },
+      { uid: "new-one", start_at: "2026-05-14T10:00:00.000" },
+      { ical_uid: "new-one", start_at: "2026-05-14T11:00:00.000" },
+      { ical_uid: "", start_at: "2026-05-14T12:00:00.000" },
+      { ical_uid: "missing-start" },
+      "not-an-event",
+    ],
+    new Set(["already-there"]),
+  );
+
+  assertEquals(prepared.candidates.length, 1);
+  assertEquals(prepared.candidates[0].ical_uid, "new-one");
+  assertEquals(prepared.skippedDuplicates, 2);
+  assertEquals(prepared.invalidCount, 3);
+});

--- a/supabase/functions/app-hub/index.ts
+++ b/supabase/functions/app-hub/index.ts
@@ -10,6 +10,11 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { AgentGpaActionError, handleAgentGpaAction } from "./agent_gpa.ts";
 import {
+  calendarIcsUidFromMetadata,
+  normalizeCalendarIcsUid,
+  prepareCalendarBulkCreateCandidates,
+} from "./calendar_bulk_create.ts";
+import {
   GaReadinessActionError,
   handleGaReadinessAction,
 } from "./ga_readiness.ts";
@@ -430,6 +435,7 @@ serve(async (req: Request) => {
       case "calendar.create": {
         const calendarId = normalizeCalendarId(body.calendar_id);
         const calendarName = await calendarNameById(admin, userId, calendarId);
+        const icalUid = normalizeCalendarIcsUid(body.ical_uid ?? body.uid);
         const item = await addItem(admin, "calendar_event", userId, {
           title: body.title,
           start_at: body.start_at,
@@ -441,11 +447,70 @@ serve(async (req: Request) => {
           calendar_id: calendarId,
           calendar_name: calendarName,
           rrule: normalizeCalendarRRule(body.rrule),
+          ...(icalUid ? { ical_uid: icalUid, uid: icalUid } : {}),
         });
         const meta = (item.metadata ?? {}) as Record<string, unknown>;
         return json({
           success: true,
           event: { ...meta, event_id: item.id, created_at: item.created_at },
+        });
+      }
+
+      case "calendar.bulk_create": {
+        const existingItems = await listItems(
+          admin,
+          "calendar_event",
+          userId,
+          1000,
+        );
+        const existingUids = new Set(
+          existingItems.map((item) =>
+            calendarIcsUidFromMetadata(
+              (item.metadata ?? {}) as Record<string, unknown>,
+            )
+          ).filter(Boolean),
+        );
+        const prepared = prepareCalendarBulkCreateCandidates(
+          body.events,
+          existingUids,
+        );
+        const created: Record<string, unknown>[] = [];
+
+        for (const event of prepared.candidates) {
+          const calendarId = normalizeCalendarId(event.calendar_id);
+          const calendarName = await calendarNameById(
+            admin,
+            userId,
+            calendarId,
+          );
+          const item = await addItem(admin, "calendar_event", userId, {
+            title: event.title ?? "Untitled",
+            start_at: event.start_at,
+            end_at: event.end_at ?? event.start_at,
+            description: event.description ?? "",
+            all_day: event.all_day ?? false,
+            color: event.color ?? "#4285f4",
+            reminder_min: normalizeCalendarReminderMinutes(event.reminder_min),
+            calendar_id: calendarId,
+            calendar_name: calendarName,
+            rrule: normalizeCalendarRRule(event.rrule),
+            ical_uid: event.ical_uid,
+            uid: event.ical_uid,
+          });
+          const meta = (item.metadata ?? {}) as Record<string, unknown>;
+          created.push({
+            ...meta,
+            event_id: item.id,
+            created_at: item.created_at,
+          });
+        }
+
+        return json({
+          success: true,
+          created_count: created.length,
+          skipped_duplicate_count: prepared.skippedDuplicates,
+          invalid_count: prepared.invalidCount,
+          events: created,
         });
       }
 

--- a/test/pages/calendar_events_page_test.dart
+++ b/test/pages/calendar_events_page_test.dart
@@ -126,11 +126,7 @@ void main() {
           day.add(const Duration(hours: 9)),
         ),
         event('Dentist', 'Annual cleaning', day.add(const Duration(hours: 13))),
-        event(
-          'Planning',
-          'Weekly roadmap',
-          day.add(const Duration(hours: 10)),
-        ),
+        event('Planning', 'Weekly roadmap', day.add(const Duration(hours: 10))),
       ],
       'annual cleaning',
     );
@@ -211,6 +207,21 @@ void main() {
       home: CalendarEventsPage(supabaseClient: mockSupabaseClient),
     );
   }
+
+  testWidgets('CalendarEventsPage exposes iCal import export menu', (
+    tester,
+  ) async {
+    stubCalendarList(const []);
+
+    await tester.pumpWidget(testWidget());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('calendar_events_ics_menu')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Export .ics'), findsOneWidget);
+    expect(find.text('Import .ics'), findsOneWidget);
+  });
 
   testWidgets('CalendarEventsPage switches to day timeline grid', (
     tester,
@@ -516,10 +527,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final captured = verify(
-      mockFunctionsClient.invoke(
-        'app-hub',
-        body: captureAnyNamed('body'),
-      ),
+      mockFunctionsClient.invoke('app-hub', body: captureAnyNamed('body')),
     ).captured;
     expect(
       captured.whereType<Map<String, dynamic>>().any(

--- a/test/services/calendar_ics_service_test.dart
+++ b/test/services/calendar_ics_service_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/calendar_ics_service.dart';
+
+void main() {
+  test('buildCalendarEventsIcs exports event metadata and RRULE', () {
+    final ics = buildCalendarEventsIcs(
+      [
+        {
+          'event_id': 'event-1',
+          'title': 'Budget review',
+          'description': 'Revise forecast, cash; debt',
+          'start_at': DateTime.utc(2026, 5, 14, 9).toIso8601String(),
+          'end_at': DateTime.utc(2026, 5, 14, 10).toIso8601String(),
+          'all_day': false,
+          'color': '#34a853',
+          'calendar_id': 'finance',
+          'calendar_name': 'Finance',
+          'reminder_min': 15,
+          'rrule': 'RRULE:FREQ=WEEKLY;COUNT=2',
+        },
+      ],
+      generatedAt: DateTime.utc(2026, 5, 14, 8),
+    );
+
+    expect(ics, contains('BEGIN:VCALENDAR'));
+    expect(ics, contains('BEGIN:VEVENT'));
+    expect(ics, contains('UID:event-1@my-web-app.local'));
+    expect(ics, contains('SUMMARY:Budget review'));
+    expect(ics, contains(r'DESCRIPTION:Revise forecast\, cash\; debt'));
+    expect(ics, contains('RRULE:FREQ=WEEKLY;COUNT=2'));
+    expect(ics, contains('X-MYWEBAPP-COLOR:#34a853'));
+    expect(ics, contains('X-MYWEBAPP-CALENDAR-ID:finance'));
+  });
+
+  test('parseCalendarEventsIcs imports events and skips duplicate UID', () {
+    const ics = '''
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-1@example.com
+DTSTART:20260514T090000Z
+DTEND:20260514T100000Z
+SUMMARY:Budget review
+DESCRIPTION:Revise forecast\\, cash\\; debt
+X-MYWEBAPP-COLOR:#34A853
+X-MYWEBAPP-CALENDAR-ID:finance
+X-MYWEBAPP-CALENDAR-NAME:Finance
+X-MYWEBAPP-REMINDER-MIN:15
+END:VEVENT
+BEGIN:VEVENT
+UID:event-1@example.com
+DTSTART:20260514T110000Z
+SUMMARY:Duplicate
+END:VEVENT
+END:VCALENDAR
+''';
+
+    final parsed = parseCalendarEventsIcs(ics);
+
+    expect(parsed.events, hasLength(1));
+    expect(parsed.skippedDuplicateCount, 1);
+    expect(parsed.invalidEventCount, 0);
+    expect(parsed.events.single['ical_uid'], 'event-1@example.com');
+    expect(parsed.events.single['title'], 'Budget review');
+    expect(parsed.events.single['description'], 'Revise forecast, cash; debt');
+    expect(parsed.events.single['color'], '#34a853');
+    expect(parsed.events.single['calendar_id'], 'finance');
+    expect(parsed.events.single['calendar_name'], 'Finance');
+    expect(parsed.events.single['reminder_min'], 15);
+  });
+
+  test('parseCalendarEventsIcs skips UIDs already present locally', () {
+    const ics = '''
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:existing@example.com
+DTSTART;VALUE=DATE:20260514
+DTEND;VALUE=DATE:20260515
+SUMMARY:Existing event
+END:VEVENT
+END:VCALENDAR
+''';
+
+    final parsed = parseCalendarEventsIcs(
+      ics,
+      existingUids: {'existing@example.com'},
+    );
+
+    expect(parsed.events, isEmpty);
+    expect(parsed.skippedDuplicateCount, 1);
+  });
+}


### PR DESCRIPTION
﻿## Summary
- add calendar .ics export/import actions to the calendar-events page
- add a small RFC 5545-oriented Dart iCal serializer/parser with UID duplicate skipping
- add app-hub `calendar.bulk_create` with backend UID deduplication for imported events

## Minimal E2E Gate
- Implementation-detail independent: the user-visible plan is black-box and checks calendar input/output rather than private internals.
- Minimal three cases: export downloads an `.ics` file, import adds events from an `.ics` file, and duplicate UID import skips without creating a second event.
- E2E mechanism: widget/service/Deno tests cover the flow contract locally; post-merge production smoke should verify `/calendar-events` loads and the iCal menu is visible.
- E2E-Exception: no new `integration_test/` or Playwright file is included because this scoped PR depends on local file picker/download browser capabilities and adds targeted widget, parser, and Edge helper coverage instead.

## High-risk Ultrareview
- Review owner: Claude Code #1.
- High-risk-ultrareview-exception: no live Claude Code #1 ultrareview was run before this draft PR; Codex #1 kept the Edge Function change scoped to idempotent calendar bulk create and records the required review owner for follow-up if the gate owner wants a live review.
- Security: imported events only use the authenticated app-hub user path and keep per-user filtering through `hub_data.metadata.user_id`; no secrets or service-role values are exposed to the client.
- Rollback: revert this PR to remove the UI menu, parser, downloader helper, and `calendar.bulk_create`; existing calendar events remain compatible because metadata fields are additive.
- Data migration: no schema or data migration is included.
- Prod smoke: after merge, verify Deploy to Production succeeds and `/calendar-events` opens with the iCal overflow menu.
- Observability: app-hub responses report `created_count`, `skipped_duplicate_count`, and `invalid_count` for import attempts.
- Unresolved ultrareview findings: 0 / none.

## Validation
- `flutter analyze lib/services/calendar_ics_service.dart lib/pages/calendar_events_page.dart test/services/calendar_ics_service_test.dart test/pages/calendar_events_page_test.dart`
- `flutter test test/services/calendar_ics_service_test.dart test/pages/calendar_events_page_test.dart`
- `deno check supabase/functions/app-hub/calendar_bulk_create.ts supabase/functions/app-hub/calendar_bulk_create_test.ts`
- `deno test --allow-env --allow-net supabase/functions/app-hub/calendar_bulk_create_test.ts`
- `git diff --check`

Closes #2213
