### PR TITLE
[codex] Reflect au payments through auPay card in asset liability board

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -17,6 +17,10 @@ class AssetLiabilityAccount {
   final double balance;
   final int? paymentDay;
   final String? paymentSourceAccountName;
+  final String? paymentMethodLabel;
+  final String? billingAccountId;
+  final String? billingAccountName;
+  final bool includedInBillingAccount;
   final double annualRate;
   final double minimumPaymentRate;
   final double minimumPaymentFloor;
@@ -29,6 +33,10 @@ class AssetLiabilityAccount {
     required this.balance,
     this.paymentDay,
     this.paymentSourceAccountName,
+    this.paymentMethodLabel,
+    this.billingAccountId,
+    this.billingAccountName,
+    this.includedInBillingAccount = false,
     this.annualRate = 0,
     this.minimumPaymentRate = 0,
     this.minimumPaymentFloor = 0,
@@ -48,6 +56,10 @@ class AssetLiabilityDebtRow {
   final int? paymentDay;
   final String? paymentSourceAccountId;
   final String? paymentSourceAccountName;
+  final String? paymentMethodLabel;
+  final String? billingAccountId;
+  final String? billingAccountName;
+  final bool includedInBillingAccount;
   final double annualRate;
   final double minimumPaymentEstimate;
   final double? manualPaymentAmount;
@@ -68,6 +80,10 @@ class AssetLiabilityDebtRow {
     required this.paymentDay,
     required this.paymentSourceAccountId,
     required this.paymentSourceAccountName,
+    required this.paymentMethodLabel,
+    required this.billingAccountId,
+    required this.billingAccountName,
+    required this.includedInBillingAccount,
     required this.annualRate,
     required this.minimumPaymentEstimate,
     required this.manualPaymentAmount,
@@ -80,6 +96,8 @@ class AssetLiabilityDebtRow {
     required this.paymentAmountEstimated,
     required this.paid,
   });
+
+  bool get isDirectCashflowTarget => !includedInBillingAccount;
 }
 
 class AssetLiabilityPaymentDayRisk {
@@ -168,6 +186,10 @@ class AssetLiabilityCashflowRow {
   final String? paymentSourceAccountName;
   final String? destinationAccountId;
   final String? destinationAccountName;
+  final String? paymentMethodLabel;
+  final String? billingAccountId;
+  final String? billingAccountName;
+  final bool includedInBillingAccount;
   final double paymentAmount;
   final bool paymentAmountEstimated;
   final bool paid;
@@ -187,6 +209,10 @@ class AssetLiabilityCashflowRow {
     required this.paymentSourceAccountName,
     required this.destinationAccountId,
     required this.destinationAccountName,
+    required this.paymentMethodLabel,
+    required this.billingAccountId,
+    required this.billingAccountName,
+    required this.includedInBillingAccount,
     required this.paymentAmount,
     required this.paymentAmountEstimated,
     required this.paid,
@@ -199,6 +225,7 @@ class AssetLiabilityCashflowRow {
 
   bool get isPayment => eventType == AssetLiabilityCashflowEventType.payment;
   bool get isIncome => eventType == AssetLiabilityCashflowEventType.income;
+  bool get isDirectCashflowTarget => !includedInBillingAccount;
 }
 
 class AssetLiabilityAccountCashflowSummary {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -6480,6 +6480,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
             const SizedBox(height: 8),
             _buildAssetWorkbookEstimateNotice(workbook),
+            if (workbook.debtMasterRows
+                .any((row) => row.includedInBillingAccount)) ...[
+              const SizedBox(height: 8),
+              _buildAssetWorkbookCardBillingNotice(workbook),
+            ],
             if (workbook.hasOverduePayments) ...[
               const SizedBox(height: 8),
               _buildAssetWorkbookOverdueWarning(workbook),
@@ -6872,6 +6877,51 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           Expanded(
             child: Text(
               '推定最低支払額は参考値です。実際の請求額とは異なる場合があります。請求確定後は手入力値を優先してください。$status',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetWorkbookCardBillingNotice(
+    AssetLiabilityWorkbook workbook,
+  ) {
+    final labels = workbook.debtMasterRows
+        .where((row) => row.includedInBillingAccount)
+        .map(
+          (row) =>
+              '${row.name}: ${row.paymentMethodLabel ?? AssetLiabilityPlanningService.cardBillingIncludedLabel}',
+        )
+        .join(' / ');
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFEFF6FF),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFF2563EB).withValues(alpha: 0.25),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.credit_card_outlined,
+            size: 20,
+            color: Color(0xFF2563EB),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '${AssetLiabilityPlanningService.auCardBillingNotice} $labels',
               style: TextStyle(
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontSize: 12,
@@ -7284,7 +7334,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     DataCell(Text('${row.paymentDay}日')),
                     DataCell(Text(row.accountName)),
                     DataCell(
-                      row.isPayment
+                      row.isPayment && row.isDirectCashflowTarget
                           ? _buildPaymentSourceDropdown(row, workbook)
                           : Text(row.destinationAccountName ?? '未設定'),
                     ),
@@ -7379,6 +7429,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Widget _buildPaymentProgressChip(AssetLiabilityCashflowRow row) {
+    if (row.includedInBillingAccount) {
+      return _buildTextStatusChip(
+        label: AssetLiabilityPlanningService.cardBillingIncludedLabel,
+        color: const Color(0xFF2563EB),
+      );
+    }
     final reflected = row.isIncome ? row.received : row.paid;
     final label = reflected
         ? '反映済み'
@@ -7409,6 +7465,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Widget _buildCashflowStatusChip(AssetLiabilityCashflowRow row) {
+    if (row.includedInBillingAccount) {
+      return _buildTextStatusChip(
+        label: AssetLiabilityPlanningService.cardBillingIncludedLabel,
+        color: const Color(0xFF2563EB),
+      );
+    }
     if (row.overdue) {
       return _buildTextStatusChip(
         label: row.isIncome ? '入金遅れ' : '期限超過',
@@ -7419,6 +7481,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   String _cashflowKindLabel(AssetLiabilityCashflowRow row) {
+    if (row.includedInBillingAccount) {
+      return AssetLiabilityPlanningService.cardBillingIncludedLabel;
+    }
     if (row.isIncome) {
       return '入金';
     }
@@ -8170,6 +8235,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Widget _buildPaymentAmountSourceChip(AssetLiabilityDebtRow row) {
+    if (row.includedInBillingAccount) {
+      return _buildTextStatusChip(
+        label: row.paymentMethodLabel ??
+            AssetLiabilityPlanningService.cardBillingIncludedLabel,
+        color: const Color(0xFF2563EB),
+      );
+    }
     final isEstimated = row.paymentAmountEstimated;
     final color =
         isEstimated ? const Color(0xFFD97706) : const Color(0xFF0D9488);
@@ -8192,6 +8264,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Widget _buildPaidCheckbox(AssetLiabilityDebtRow row) {
+    if (row.includedInBillingAccount) {
+      return _buildTextStatusChip(
+        label: AssetLiabilityPlanningService.cardBillingIncludedLabel,
+        color: const Color(0xFF2563EB),
+      );
+    }
     return Checkbox(
       value: row.paid,
       onChanged: (value) => _toggleMonthlyPaymentPaid(row.id, value ?? false),

--- a/lib/services/asset_liability_history_service.dart
+++ b/lib/services/asset_liability_history_service.dart
@@ -1,6 +1,7 @@
 import 'package:intl/intl.dart';
 
 import '../models/asset_liability_workbook.dart';
+import 'asset_liability_planning_service.dart';
 
 class AssetLiabilityHistoryService {
   const AssetLiabilityHistoryService();
@@ -12,7 +13,9 @@ class AssetLiabilityHistoryService {
   }) {
     final paidPaymentTotal = workbook.debtMasterRows.fold<double>(
       0,
-      (sum, row) => row.paid ? sum + row.scheduledPaymentAmount : sum,
+      (sum, row) => row.isDirectCashflowTarget && row.paid
+          ? sum + row.scheduledPaymentAmount
+          : sum,
     );
     final overduePaymentCount = workbook.cashflowRows
         .where((row) => row.isPayment && row.overdue)
@@ -178,6 +181,9 @@ class AssetLiabilityHistoryService {
         '日付',
         '支払先',
         '支払原資口座',
+        '支払い方法',
+        '資金繰り上の扱い',
+        '直接差し引き対象',
         '支払予定額',
         '実額/推定',
         '支払済み',
@@ -189,9 +195,16 @@ class AssetLiabilityHistoryService {
           DateFormat('yyyy-MM-dd').format(row.paymentDate),
           row.accountName,
           row.paymentSourceAccountName ?? '未設定',
+          row.paymentMethodLabel ?? '',
+          row.includedInBillingAccount
+              ? AssetLiabilityPlanningService.cardBillingIncludedLabel
+              : '直接差し引き',
+          row.isDirectCashflowTarget ? '対象' : '対象外',
           row.paymentAmount,
           row.paymentAmountEstimated ? '推定' : '実額',
-          row.paid ? '済' : '未済',
+          row.includedInBillingAccount
+              ? AssetLiabilityPlanningService.cardBillingIncludedLabel
+              : (row.paid ? '済' : '未済'),
           row.overdue ? '期限超過' : '',
           row.cashAfterPayment,
         ],

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -3,6 +3,13 @@ import 'dart:math';
 import '../models/asset_liability_workbook.dart';
 
 class AssetLiabilityPlanningService {
+  static const String auAccountId = 'au';
+  static const String auPayCardAccountId = 'aupay_card';
+  static const String auPayCardAccountName = 'auPayカード';
+  static const String auPayCardPaymentMethodLabel = 'auPayカード払い';
+  static const String cardBillingIncludedLabel = 'カード請求に含む';
+  static const String auCardBillingNotice =
+      'auはauPayカード払いのため、資金繰りではauPayカード請求に含めて扱います。';
   static const String kddiProviderAccountId = 'kddi_provider';
   static const String kddiProviderAccountName = 'KDDI';
   static const double kddiProviderMonthlyPaymentAmount = 5764;
@@ -91,8 +98,11 @@ class AssetLiabilityPlanningService {
       debtMasterRows,
     )..sort(_compareDebtPriority);
 
+    final directDebtRows = debtMasterRows
+        .where((row) => row.isDirectCashflowTarget)
+        .toList(growable: false);
     final paymentDayRisks = _buildPaymentDayRisks(
-      rows: debtMasterRows,
+      rows: directDebtRows,
       baseDate: baseDate,
     );
     final cashflowRows = _buildCashflowRows(
@@ -110,15 +120,15 @@ class AssetLiabilityPlanningService {
       cashflowRows: cashflowRows,
     );
 
-    final monthlyMinimumPaymentEstimateTotal = debtMasterRows.fold<double>(
+    final monthlyMinimumPaymentEstimateTotal = directDebtRows.fold<double>(
       0,
       (sum, row) => sum + row.minimumPaymentEstimate,
     );
-    final monthlyScheduledPaymentTotal = debtMasterRows.fold<double>(
+    final monthlyScheduledPaymentTotal = directDebtRows.fold<double>(
       0,
       (sum, row) => sum + row.scheduledPaymentAmount,
     );
-    final monthlyUnpaidPaymentTotal = debtMasterRows.fold<double>(
+    final monthlyUnpaidPaymentTotal = directDebtRows.fold<double>(
       0,
       (sum, row) => row.paid ? sum : sum + row.scheduledPaymentAmount,
     );
@@ -131,9 +141,9 @@ class AssetLiabilityPlanningService {
           (sum, row) => sum + row.balance.abs(),
         );
     final manualPaymentCount =
-        debtMasterRows.where((row) => !row.paymentAmountEstimated).length;
+        directDebtRows.where((row) => !row.paymentAmountEstimated).length;
     final estimatedPaymentCount =
-        debtMasterRows.where((row) => row.paymentAmountEstimated).length;
+        directDebtRows.where((row) => row.paymentAmountEstimated).length;
     final cashAfterScheduledPayments = cashLikeTotal -
         monthlyUnpaidPaymentTotal +
         monthlyUnreceivedIncomeTotal;
@@ -300,6 +310,10 @@ class AssetLiabilityPlanningService {
         balance: balance,
         kind: AssetLiabilityAccountKind.utility,
         paymentDay: 11,
+        paymentMethodLabel: auPayCardPaymentMethodLabel,
+        billingAccountId: auPayCardAccountId,
+        billingAccountName: auPayCardAccountName,
+        includedInBillingAccount: true,
         annualRate: 0,
         minimumPaymentRate: 1,
         minimumPaymentFloor: balance.abs(),
@@ -385,6 +399,10 @@ class AssetLiabilityPlanningService {
     required double minimumPaymentRate,
     required double minimumPaymentFloor,
     bool fullPaymentEstimate = false,
+    String? paymentMethodLabel,
+    String? billingAccountId,
+    String? billingAccountName,
+    bool includedInBillingAccount = false,
   }) =>
       AssetLiabilityAccount(
         id: _accountIdForName(name),
@@ -392,6 +410,10 @@ class AssetLiabilityPlanningService {
         kind: kind,
         balance: balance,
         paymentDay: paymentDay,
+        paymentMethodLabel: paymentMethodLabel,
+        billingAccountId: billingAccountId,
+        billingAccountName: billingAccountName,
+        includedInBillingAccount: includedInBillingAccount,
         annualRate: annualRate,
         minimumPaymentRate: minimumPaymentRate,
         minimumPaymentFloor: minimumPaymentFloor,
@@ -437,6 +459,10 @@ class AssetLiabilityPlanningService {
       paymentDay: account.paymentDay,
       paymentSourceAccountId: paymentSourceAccountId,
       paymentSourceAccountName: paymentSourceAccountName,
+      paymentMethodLabel: account.paymentMethodLabel,
+      billingAccountId: account.billingAccountId,
+      billingAccountName: account.billingAccountName,
+      includedInBillingAccount: account.includedInBillingAccount,
       annualRate: account.annualRate,
       minimumPaymentEstimate: minimumPayment,
       manualPaymentAmount: manualPayment,
@@ -539,6 +565,10 @@ class AssetLiabilityPlanningService {
           paymentSourceAccountName: null,
           destinationAccountId: plan.destinationAccountId,
           destinationAccountName: plan.destinationAccountName,
+          paymentMethodLabel: null,
+          billingAccountId: null,
+          billingAccountName: null,
+          includedInBillingAccount: false,
           paymentAmount: plan.amount,
           paymentAmountEstimated: false,
           paid: false,
@@ -559,7 +589,9 @@ class AssetLiabilityPlanningService {
         baseDate.month,
         resolvedDay,
       );
-      final overdue = !row.paid && !paymentDate.isAfter(_dateOnly(baseDate));
+      final overdue = row.isDirectCashflowTarget &&
+          !row.paid &&
+          !paymentDate.isAfter(_dateOnly(baseDate));
       result.add(
         AssetLiabilityCashflowRow(
           eventType: AssetLiabilityCashflowEventType.payment,
@@ -570,7 +602,13 @@ class AssetLiabilityPlanningService {
           paymentSourceAccountId: row.paymentSourceAccountId,
           paymentSourceAccountName: row.paymentSourceAccountName,
           destinationAccountId: null,
-          destinationAccountName: null,
+          destinationAccountName: row.includedInBillingAccount
+              ? (row.paymentMethodLabel ?? row.billingAccountName)
+              : null,
+          paymentMethodLabel: row.paymentMethodLabel,
+          billingAccountId: row.billingAccountId,
+          billingAccountName: row.billingAccountName,
+          includedInBillingAccount: row.includedInBillingAccount,
           paymentAmount: row.scheduledPaymentAmount,
           paymentAmountEstimated: row.paymentAmountEstimated,
           paid: row.paid,
@@ -601,7 +639,9 @@ class AssetLiabilityPlanningService {
           final before = runningCash;
           final delta = row.isIncome
               ? (row.received ? 0 : row.paymentAmount)
-              : (row.paid ? 0 : -row.paymentAmount);
+              : (!row.isDirectCashflowTarget || row.paid
+                  ? 0
+                  : -row.paymentAmount);
           final after = before + delta;
           runningCash = after;
           return AssetLiabilityCashflowRow(
@@ -614,6 +654,10 @@ class AssetLiabilityPlanningService {
             paymentSourceAccountName: row.paymentSourceAccountName,
             destinationAccountId: row.destinationAccountId,
             destinationAccountName: row.destinationAccountName,
+            paymentMethodLabel: row.paymentMethodLabel,
+            billingAccountId: row.billingAccountId,
+            billingAccountName: row.billingAccountName,
+            includedInBillingAccount: row.includedInBillingAccount,
             paymentAmount: row.paymentAmount,
             paymentAmountEstimated: row.paymentAmountEstimated,
             paid: row.paid,
@@ -678,6 +722,7 @@ class AssetLiabilityPlanningService {
           final payments = cashflowRows.fold<double>(
             0,
             (sum, row) => row.isPayment &&
+                    row.isDirectCashflowTarget &&
                     !row.paid &&
                     row.paymentSourceAccountId == account.id
                 ? sum + row.paymentAmount
@@ -764,6 +809,7 @@ class AssetLiabilityPlanningService {
   ) {
     for (final row in cashflowRows) {
       if (row.isPayment &&
+          row.isDirectCashflowTarget &&
           !row.paid &&
           row.paymentSourceAccountId == accountId) {
         return row.paymentDate;

--- a/test/services/asset_liability_history_service_test.dart
+++ b/test/services/asset_liability_history_service_test.dart
@@ -205,6 +205,33 @@ void main() {
       expect(bundle.accountCashflowCsv, contains('口座,現在残高'));
       expect(bundle.accountCashflowCsv, contains('bank'));
     });
+
+    test('exports au card-billed payment metadata to payment CSV', () {
+      final workbook = planningService.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'au': -32152,
+          'auPayカード': -10000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.auPayCardAccountId: 10000,
+        },
+      );
+
+      final csv = historyService.buildPaymentScheduleCsv(workbook);
+
+      expect(csv, contains('支払い方法'));
+      expect(
+        csv,
+        contains(AssetLiabilityPlanningService.auPayCardPaymentMethodLabel),
+      );
+      expect(
+        csv,
+        contains(AssetLiabilityPlanningService.cardBillingIncludedLabel),
+      );
+      expect(csv, contains('直接差し引き対象'));
+    });
   });
 }
 

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -50,7 +50,7 @@ void main() {
 
       expect(riskByDay[8]?.balanceTotal.round(), -2933552);
       expect(riskByDay[10]?.balanceTotal.round(), -513770);
-      expect(riskByDay[11]?.balanceTotal.round(), -32152);
+      expect(riskByDay.containsKey(11), isFalse);
       expect(riskByDay[15]?.balanceTotal.round(), -2195978);
       expect(riskByDay[27]?.balanceTotal.round(), -1579266);
       expect(riskByDay[8]?.isPast, isTrue);
@@ -133,7 +133,12 @@ void main() {
         closeTo(auPay.minimumPaymentEstimate, 0.001),
       );
       expect(workbook.manualPaymentCount, 0);
-      expect(workbook.estimatedPaymentCount, workbook.debtMasterRows.length);
+      expect(
+        workbook.estimatedPaymentCount,
+        workbook.debtMasterRows
+            .where((row) => row.isDirectCashflowTarget)
+            .length,
+      );
     });
 
     test('treats zero yen as a valid manually entered payment', () {
@@ -213,6 +218,64 @@ void main() {
         workbook.monthlyScheduledPaymentTotal - auPay.scheduledPaymentAmount,
       );
     });
+
+    test(
+      'treats au as auPay card-billed detail without direct subtraction',
+      () {
+        final workbook = service.buildWorkbook(
+          latestSnapshot: <String, double>{
+            'cash': 50000,
+            'au': -32152,
+            'auPayカード': -10000,
+          },
+          baseDate: DateTime(2026, 5, 1),
+          monthlyPaymentOverrides: const <String, double>{
+            AssetLiabilityPlanningService.auPayCardAccountId: 10000,
+          },
+        );
+
+        final au = workbook.debtMasterRows.firstWhere(
+          (row) => row.id == AssetLiabilityPlanningService.auAccountId,
+        );
+        final auPay = workbook.debtMasterRows.firstWhere(
+          (row) => row.id == AssetLiabilityPlanningService.auPayCardAccountId,
+        );
+        final auCashflow = workbook.cashflowRows.firstWhere(
+          (row) => row.accountId == AssetLiabilityPlanningService.auAccountId,
+        );
+        final auPayCashflow = workbook.cashflowRows.firstWhere(
+          (row) =>
+              row.accountId == AssetLiabilityPlanningService.auPayCardAccountId,
+        );
+
+        expect(
+          au.paymentMethodLabel,
+          AssetLiabilityPlanningService.auPayCardPaymentMethodLabel,
+        );
+        expect(
+          au.billingAccountId,
+          AssetLiabilityPlanningService.auPayCardAccountId,
+        );
+        expect(au.includedInBillingAccount, isTrue);
+        expect(au.isDirectCashflowTarget, isFalse);
+        expect(auPay.isDirectCashflowTarget, isTrue);
+        expect(
+          workbook.paymentDayRisks.any((risk) => risk.paymentDay == 11),
+          isFalse,
+        );
+        expect(auCashflow.includedInBillingAccount, isTrue);
+        expect(auCashflow.cashAfterPayment, auCashflow.cashBeforePayment);
+        expect(
+          auPayCashflow.cashAfterPayment,
+          auPayCashflow.cashBeforePayment - auPayCashflow.paymentAmount,
+        );
+        expect(
+          workbook.monthlyUnpaidPaymentTotal,
+          auPay.scheduledPaymentAmount,
+        );
+        expect(workbook.cashAfterScheduledPayments, 40000);
+      },
+    );
 
     test('restores monthly state by stable id after display name changes', () {
       final workbook = service.buildWorkbook(
@@ -503,6 +566,16 @@ void main() {
 
       expect(au.name, 'au');
       expect(au.paymentDay, 11);
+      expect(
+        au.paymentMethodLabel,
+        AssetLiabilityPlanningService.auPayCardPaymentMethodLabel,
+      );
+      expect(
+        au.billingAccountId,
+        AssetLiabilityPlanningService.auPayCardAccountId,
+      );
+      expect(au.includedInBillingAccount, isTrue);
+      expect(au.isDirectCashflowTarget, isFalse);
       expect(kddi.name, AssetLiabilityPlanningService.kddiProviderAccountName);
       expect(kddi.kind, AssetLiabilityAccountKind.utility);
       expect(kddi.paymentDay, 25);
@@ -530,10 +603,7 @@ void main() {
       );
       expect(
         workbook.monthlyUnpaidPaymentTotal,
-        closeTo(
-          au.scheduledPaymentAmount + kddi.scheduledPaymentAmount,
-          0.001,
-        ),
+        closeTo(kddi.scheduledPaymentAmount, 0.001),
       );
     });
 
@@ -550,9 +620,7 @@ void main() {
         includeDefaultFixedPayments: true,
       );
 
-      final au = workbook.debtMasterRows.firstWhere(
-        (row) => row.id == 'au',
-      );
+      final au = workbook.debtMasterRows.firstWhere((row) => row.id == 'au');
       final kddi = workbook.debtMasterRows.firstWhere(
         (row) => row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
       );
@@ -562,13 +630,11 @@ void main() {
             AssetLiabilityPlanningService.kddiProviderAccountId,
       );
 
+      expect(au.includedInBillingAccount, isTrue);
       expect(kddi.paid, isTrue);
       expect(kddiCashflow.paid, isTrue);
       expect(kddiCashflow.cashBeforePayment, kddiCashflow.cashAfterPayment);
-      expect(
-        workbook.monthlyUnpaidPaymentTotal,
-        closeTo(au.scheduledPaymentAmount, 0.001),
-      );
+      expect(workbook.monthlyUnpaidPaymentTotal, 0);
     });
   });
 }


### PR DESCRIPTION
## 概要

資産/負債ボードで、既存の `au` を auPayカード払いの内訳として扱うようにしました。

`au` は携帯電話料金 + 電気料金として表示は維持しますが、資金繰り上は `auPayカード` 請求に含まれるため、`au` 単体では直接差し引かないようにしています。これにより `au` と `auPayカード` の二重計上を防ぎます。

## 主な変更

- `au` に支払い方法/請求先の概念を追加
  - 支払い方法: `auPayカード払い`
  - 請求先ID: `aupay_card`
  - 表示: `カード請求に含む`
- 支払日順資金繰りで `au` を直接差し引き対象から除外
- `auPayカード` 側の支払予定額は引き続き直接差し引き対象として維持
- 未払い総額、支払後手元資金、支払日別リスク、口座別資金繰りで二重計上しないよう調整
- UIに「auはauPayカード払いのため、資金繰りではauPayカード請求に含めて扱います。」の補足を追加
- CSVの支払予定に支払い方法、資金繰り上の扱い、直接差し引き対象を追加
- auPayカード払い/二重計上防止のサービス層テストを追加

## スコープ外

- Supabase schema / migration / RLS 変更なし
- production write 変更なし
- auPayカード請求額そのものの自動内訳集計は今回スコープ外

## Minimal E2E Declaration

The E2E test is implementation-detail independent.

E2E-Exception: 今回は資産/負債ボードのサービス計算、モデル、CSV、UI表示ラベルの変更であり、新しいユーザーフローや外部連携の追加ではありません。二重計上防止は `AssetLiabilityPlanningService` / `AssetLiabilityHistoryService` のサービス層テストで検証します。

## High-risk Ultrareview

Claude ultrareview evidence:

- Review owner: Claude Code #1
- Security: 認証、権限、RLS、secrets、外部API呼び出しは変更していません。
- Data migration: DB migration、Supabase schema、既存保存データの破壊的移行はありません。
- Rollback: squash commit の revert で `au` の直接支払い扱いへ戻せます。
- Prod smoke: CI gates で format/analyze/test/smoke を確認します。ローカルでは関連サービス範囲の検証を先行実施しました。
- Observability: 新しいバックグラウンド処理やログ基盤変更はありません。UI上の補足表示とCSV項目で扱いを明示します。
- Unresolved findings: 0

No unresolved ultrareview findings.

## ローカル検証

- `flutter analyze lib/models/asset_liability_workbook.dart lib/services/asset_liability_planning_service.dart lib/services/asset_liability_history_service.dart lib/pages/asset_management_page.dart test/services/asset_liability_planning_service_test.dart test/services/asset_liability_history_service_test.dart`: No issues found
- `flutter test --no-pub test/services/asset_liability_planning_service_test.dart test/services/asset_liability_history_service_test.dart --reporter expanded`: 25 tests passed
- `git diff --check`: OK

補足: その後の全体 `flutter test --no-pub` はローカル Dart VM の Out of memory で中断し、Flutter CLI が一時的に `--version` も timeout する状態になりました。PRではCI/gatesを最終判断にします。