### PR TITLE
Generalize card-billed items in asset liability board

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -75,6 +75,7 @@ class AssetLiabilityMonthlyStatePayload {
   final Map<String, double> paymentOverrides;
   final Set<String> paidAccountIds;
   final Map<String, String> paymentSourceAccountIds;
+  final Map<String, String> cardBillingAccountIds;
   final List<AssetLiabilityIncomePlan> incomePlans;
 
   const AssetLiabilityMonthlyStatePayload({
@@ -82,6 +83,7 @@ class AssetLiabilityMonthlyStatePayload {
     required this.paymentOverrides,
     required this.paidAccountIds,
     required this.paymentSourceAccountIds,
+    required this.cardBillingAccountIds,
     required this.incomePlans,
   });
 
@@ -95,6 +97,9 @@ class AssetLiabilityMonthlyStatePayload {
       paidAccountIds: Set<String>.from(state.paidAccountNames),
       paymentSourceAccountIds: Map<String, String>.from(
         state.paymentSourceAccountIds,
+      ),
+      cardBillingAccountIds: Map<String, String>.from(
+        state.cardBillingAccountIds,
       ),
       incomePlans: List<AssetLiabilityIncomePlan>.from(state.incomePlans),
     );
@@ -117,6 +122,9 @@ class AssetLiabilityMonthlyStatePayload {
           _readStringMap(json, 'payment_source_account_ids') ??
               _readStringMap(json, 'paymentSourceAccountIds') ??
               const <String, String>{},
+      cardBillingAccountIds: _readStringMap(json, 'card_billing_account_ids') ??
+          _readStringMap(json, 'cardBillingAccountIds') ??
+          const <String, String>{},
       incomePlans: _readIncomePlans(json, 'income_plans') ??
           _readIncomePlans(json, 'incomePlans') ??
           const <AssetLiabilityIncomePlan>[],
@@ -130,6 +138,7 @@ class AssetLiabilityMonthlyStatePayload {
       paymentSourceAccountIds: Map<String, String>.from(
         paymentSourceAccountIds,
       ),
+      cardBillingAccountIds: Map<String, String>.from(cardBillingAccountIds),
       incomePlans: List<AssetLiabilityIncomePlan>.from(incomePlans),
     );
   }
@@ -146,6 +155,9 @@ class AssetLiabilityMonthlyStatePayload {
       'paid_account_ids': (paidAccountIds.toList()..sort()),
       'payment_source_account_ids': Map<String, String>.from(
         paymentSourceAccountIds,
+      ),
+      'card_billing_account_ids': Map<String, String>.from(
+        cardBillingAccountIds,
       ),
       'income_plans': [for (final plan in incomePlans) _encodeIncomePlan(plan)],
       if (timestamp != null) 'updated_at': timestamp,

--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -10,6 +10,8 @@ enum AssetLiabilityAccountKind {
   otherLiability,
 }
 
+enum AssetLiabilityPaymentMethod { direct, includedInCard }
+
 class AssetLiabilityAccount {
   final String id;
   final String name;
@@ -17,6 +19,7 @@ class AssetLiabilityAccount {
   final double balance;
   final int? paymentDay;
   final String? paymentSourceAccountName;
+  final AssetLiabilityPaymentMethod paymentMethod;
   final String? paymentMethodLabel;
   final String? billingAccountId;
   final String? billingAccountName;
@@ -33,6 +36,7 @@ class AssetLiabilityAccount {
     required this.balance,
     this.paymentDay,
     this.paymentSourceAccountName,
+    this.paymentMethod = AssetLiabilityPaymentMethod.direct,
     this.paymentMethodLabel,
     this.billingAccountId,
     this.billingAccountName,
@@ -56,6 +60,7 @@ class AssetLiabilityDebtRow {
   final int? paymentDay;
   final String? paymentSourceAccountId;
   final String? paymentSourceAccountName;
+  final AssetLiabilityPaymentMethod paymentMethod;
   final String? paymentMethodLabel;
   final String? billingAccountId;
   final String? billingAccountName;
@@ -80,6 +85,7 @@ class AssetLiabilityDebtRow {
     required this.paymentDay,
     required this.paymentSourceAccountId,
     required this.paymentSourceAccountName,
+    required this.paymentMethod,
     required this.paymentMethodLabel,
     required this.billingAccountId,
     required this.billingAccountName,
@@ -97,7 +103,9 @@ class AssetLiabilityDebtRow {
     required this.paid,
   });
 
-  bool get isDirectCashflowTarget => !includedInBillingAccount;
+  bool get isDirectCashflowTarget =>
+      !includedInBillingAccount &&
+      paymentMethod == AssetLiabilityPaymentMethod.direct;
 }
 
 class AssetLiabilityPaymentDayRisk {
@@ -186,6 +194,7 @@ class AssetLiabilityCashflowRow {
   final String? paymentSourceAccountName;
   final String? destinationAccountId;
   final String? destinationAccountName;
+  final AssetLiabilityPaymentMethod paymentMethod;
   final String? paymentMethodLabel;
   final String? billingAccountId;
   final String? billingAccountName;
@@ -209,6 +218,7 @@ class AssetLiabilityCashflowRow {
     required this.paymentSourceAccountName,
     required this.destinationAccountId,
     required this.destinationAccountName,
+    required this.paymentMethod,
     required this.paymentMethodLabel,
     required this.billingAccountId,
     required this.billingAccountName,
@@ -225,7 +235,9 @@ class AssetLiabilityCashflowRow {
 
   bool get isPayment => eventType == AssetLiabilityCashflowEventType.payment;
   bool get isIncome => eventType == AssetLiabilityCashflowEventType.income;
-  bool get isDirectCashflowTarget => !includedInBillingAccount;
+  bool get isDirectCashflowTarget =>
+      !includedInBillingAccount &&
+      paymentMethod == AssetLiabilityPaymentMethod.direct;
 }
 
 class AssetLiabilityAccountCashflowSummary {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -104,6 +104,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, double> _monthlyPaymentOverrides = <String, double>{};
   Set<String> _monthlyPaidAccountNames = <String>{};
   Map<String, String> _paymentSourceAccountIds = <String, String>{};
+  Map<String, String> _cardBillingAccountIds = <String, String>{};
   Map<String, String> _defaultPaymentSourceAccountIds = <String, String>{};
   List<AssetLiabilityIncomePlan> _monthlyIncomePlans =
       <AssetLiabilityIncomePlan>[];
@@ -810,6 +811,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _paymentSourceAccountIds = Map<String, String>.from(
           state.paymentSourceAccountIds,
         );
+        _cardBillingAccountIds = Map<String, String>.from(
+          state.cardBillingAccountIds,
+        );
         _defaultPaymentSourceAccountIds = Map<String, String>.from(
           defaultSources,
         );
@@ -841,6 +845,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
           paymentSourceAccountIds: Map<String, String>.from(
             _paymentSourceAccountIds,
+          ),
+          cardBillingAccountIds: Map<String, String>.from(
+            _cardBillingAccountIds,
           ),
           incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
         ),
@@ -1030,6 +1037,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
         ),
+        cardBillingAccountIds: Map<String, String>.from(
+          _cardBillingAccountIds,
+        ),
         incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
       ),
       legacyKeyToAccountId: legacyKeyToAccountId,
@@ -1043,6 +1053,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _sameStringMap(
           _paymentSourceAccountIds,
           migrated.paymentSourceAccountIds,
+        ) &&
+        _sameStringMap(
+          _cardBillingAccountIds,
+          migrated.cardBillingAccountIds,
         ) &&
         _sameStringMap(
           _defaultPaymentSourceAccountIds,
@@ -1060,6 +1074,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _monthlyPaidAccountNames = Set<String>.from(migrated.paidAccountNames);
         _paymentSourceAccountIds = Map<String, String>.from(
           migrated.paymentSourceAccountIds,
+        );
+        _cardBillingAccountIds = Map<String, String>.from(
+          migrated.cardBillingAccountIds,
         );
         _defaultPaymentSourceAccountIds = Map<String, String>.from(
           migratedDefaultSources,
@@ -1186,6 +1203,28 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_saveAssetLiabilityMonthlyState());
   }
 
+  void _updateCardBillingAccount(
+    AssetLiabilityDebtRow row,
+    String? billingAccountId,
+  ) {
+    final selected =
+        billingAccountId ?? AssetLiabilityPlanningService.directPaymentMethodId;
+    setState(() {
+      if (selected == AssetLiabilityPlanningService.directPaymentMethodId) {
+        if (row.includedInBillingAccount ||
+            _cardBillingAccountIds.containsKey(row.id)) {
+          _cardBillingAccountIds[row.id] =
+              AssetLiabilityPlanningService.directPaymentMethodId;
+        } else {
+          _cardBillingAccountIds.remove(row.id);
+        }
+      } else {
+        _cardBillingAccountIds[row.id] = selected;
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
   Future<void> _saveDefaultPaymentSources() async {
     try {
       await _assetLiabilityRepository.saveDefaultPaymentSources(
@@ -1241,6 +1280,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _monthlyPaidAccountNames = <String>{};
       _paymentSourceAccountIds = Map<String, String>.from(
         copied.paymentSourceAccountIds,
+      );
+      _cardBillingAccountIds = Map<String, String>.from(
+        copied.cardBillingAccountIds,
       );
       _monthlyIncomePlans = incomePlansWithTemplates;
       _syncMonthlyPaymentControllers();
@@ -1633,6 +1675,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         )
         .toList()
       ..sort((a, b) => b.balance.compareTo(a.balance));
+  }
+
+  List<AssetLiabilityAccount> _cardBillingAccountOptions(
+    AssetLiabilityWorkbook workbook,
+  ) {
+    return workbook.accounts
+        .where(
+            (account) => account.kind == AssetLiabilityAccountKind.creditCard)
+        .toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
   }
 
   List<Map<String, dynamic>> _liabilitiesFromSnapshot(
@@ -6361,6 +6413,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       paidAccountNames: _monthlyPaidAccountNames,
       paymentSourceAccountIds: _paymentSourceAccountIds,
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
+      cardBillingAccountIds: _cardBillingAccountIds,
       incomePlans: _monthlyIncomePlans,
       includeDefaultFixedPayments: true,
     );
@@ -6921,7 +6974,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              '${AssetLiabilityPlanningService.auCardBillingNotice} $labels',
+              '${AssetLiabilityPlanningService.cardBillingNotice} $labels',
               style: TextStyle(
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontSize: 12,
@@ -8163,6 +8216,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             dataRowMinHeight: 60,
             dataRowMaxHeight: 76,
             columns: const [
+              DataColumn(label: Text('支払い方式')),
               DataColumn(label: Text('項目')),
               DataColumn(label: Text('種別')),
               DataColumn(label: Text('残高'), numeric: true),
@@ -8179,6 +8233,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               for (final row in rows)
                 DataRow(
                   cells: [
+                    DataCell(_buildPaymentMethodDropdown(row, workbook)),
                     DataCell(Text(row.name)),
                     DataCell(Text(_assetKindLabel(row.kind))),
                     DataCell(Text(_formatManagementYen(row.balance))),
@@ -8206,6 +8261,45 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildPaymentMethodDropdown(
+    AssetLiabilityDebtRow row,
+    AssetLiabilityWorkbook workbook,
+  ) {
+    final cardOptions = _cardBillingAccountOptions(workbook)
+        .where((account) => account.id != row.id)
+        .toList(growable: false);
+    final configured = _cardBillingAccountIds[row.id];
+    final selected = configured ??
+        (row.paymentMethod == AssetLiabilityPaymentMethod.includedInCard
+            ? row.billingAccountId
+            : AssetLiabilityPlanningService.directPaymentMethodId);
+    final validSelected =
+        selected == AssetLiabilityPlanningService.directPaymentMethodId ||
+            cardOptions.any((account) => account.id == selected);
+
+    return SizedBox(
+      width: 220,
+      child: DropdownButton<String>(
+        value: validSelected
+            ? selected
+            : AssetLiabilityPlanningService.directPaymentMethodId,
+        isExpanded: true,
+        items: [
+          const DropdownMenuItem<String>(
+            value: AssetLiabilityPlanningService.directPaymentMethodId,
+            child: Text(AssetLiabilityPlanningService.directPaymentLabel),
+          ),
+          for (final account in cardOptions)
+            DropdownMenuItem<String>(
+              value: account.id,
+              child: Text('${account.name}請求に含む'),
+            ),
+        ],
+        onChanged: (value) => _updateCardBillingAccount(row, value),
+      ),
     );
   }
 

--- a/lib/services/asset_liability_history_service.dart
+++ b/lib/services/asset_liability_history_service.dart
@@ -178,6 +178,7 @@ class AssetLiabilityHistoryService {
     final rows = workbook.cashflowRows.where((row) => row.isPayment).toList();
     return _csv([
       const <Object?>[
+        '請求先カード',
         '日付',
         '支払先',
         '支払原資口座',
@@ -192,6 +193,7 @@ class AssetLiabilityHistoryService {
       ],
       for (final row in rows)
         <Object?>[
+          row.billingAccountName ?? row.billingAccountId ?? '',
           DateFormat('yyyy-MM-dd').format(row.paymentDate),
           row.accountName,
           row.paymentSourceAccountName ?? '未設定',

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -9,12 +9,14 @@ class AssetLiabilityMonthlyState {
   final Map<String, double> paymentOverrides;
   final Set<String> paidAccountNames;
   final Map<String, String> paymentSourceAccountIds;
+  final Map<String, String> cardBillingAccountIds;
   final List<AssetLiabilityIncomePlan> incomePlans;
 
   const AssetLiabilityMonthlyState({
     this.paymentOverrides = const <String, double>{},
     this.paidAccountNames = const <String>{},
     this.paymentSourceAccountIds = const <String, String>{},
+    this.cardBillingAccountIds = const <String, String>{},
     this.incomePlans = const <AssetLiabilityIncomePlan>[],
   });
 
@@ -22,6 +24,7 @@ class AssetLiabilityMonthlyState {
       paymentOverrides.isEmpty &&
       paidAccountNames.isEmpty &&
       paymentSourceAccountIds.isEmpty &&
+      cardBillingAccountIds.isEmpty &&
       incomePlans.isEmpty;
 }
 
@@ -31,6 +34,8 @@ class AssetLiabilityMonthlyStateStore {
   static const String paidPrefsKey = 'asset_liability_paid_accounts_v1';
   static const String paymentSourcePrefsKey =
       'asset_liability_payment_source_accounts_v1';
+  static const String cardBillingPrefsKey =
+      'asset_liability_card_billing_accounts_v1';
   static const String incomePrefsKey = 'asset_liability_income_plans_v1';
   static const String defaultPaymentSourcePrefsKey =
       'asset_liability_default_payment_source_accounts_v1';
@@ -55,6 +60,10 @@ class AssetLiabilityMonthlyStateStore {
       ),
       paymentSourceAccountIds: paymentSourceAccountsForMonth(
         prefs.getString(paymentSourcePrefsKey),
+        monthKey,
+      ),
+      cardBillingAccountIds: cardBillingAccountsForMonth(
+        prefs.getString(cardBillingPrefsKey),
         monthKey,
       ),
       incomePlans: incomePlansForMonth(
@@ -110,6 +119,21 @@ class AssetLiabilityMonthlyStateStore {
     await prefs.setString(
       paymentSourcePrefsKey,
       jsonEncode(allPaymentSources),
+    );
+
+    final allCardBillingAccounts = decodeCardBillingAccounts(
+      prefs.getString(cardBillingPrefsKey),
+    );
+    if (state.cardBillingAccountIds.isEmpty) {
+      allCardBillingAccounts.remove(monthKey);
+    } else {
+      allCardBillingAccounts[monthKey] = Map<String, String>.from(
+        state.cardBillingAccountIds,
+      );
+    }
+    await prefs.setString(
+      cardBillingPrefsKey,
+      jsonEncode(allCardBillingAccounts),
     );
 
     final allIncomePlans = decodeIncomePlans(
@@ -230,6 +254,9 @@ class AssetLiabilityMonthlyStateStore {
       ),
       paymentSourceAccountIds: Map<String, String>.from(
         previousState.paymentSourceAccountIds,
+      ),
+      cardBillingAccountIds: Map<String, String>.from(
+        previousState.cardBillingAccountIds,
       ),
       incomePlans: copiedIncomePlans,
     );
@@ -362,6 +389,12 @@ class AssetLiabilityMonthlyStateStore {
       }
       return MapEntry(monthKey, sources);
     });
+  }
+
+  static Map<String, Map<String, String>> decodeCardBillingAccounts(
+    String? raw,
+  ) {
+    return decodePaymentSourceAccounts(raw);
   }
 
   static Map<String, List<AssetLiabilityIncomePlan>> decodeIncomePlans(
@@ -565,6 +598,15 @@ class AssetLiabilityMonthlyStateStore {
     );
   }
 
+  static Map<String, String> cardBillingAccountsForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return Map<String, String>.from(
+      decodeCardBillingAccounts(raw)[monthKey] ?? const <String, String>{},
+    );
+  }
+
   static List<AssetLiabilityIncomePlan> incomePlansForMonth(
     String? raw,
     String monthKey,
@@ -600,10 +642,18 @@ class AssetLiabilityMonthlyStateStore {
       migratedPaymentSources[liabilityId] = sourceId;
     }
 
+    final migratedCardBillingAccounts = <String, String>{};
+    for (final entry in state.cardBillingAccountIds.entries) {
+      final liabilityId = legacyKeyToAccountId[entry.key] ?? entry.key;
+      final cardId = legacyKeyToAccountId[entry.value] ?? entry.value;
+      migratedCardBillingAccounts[liabilityId] = cardId;
+    }
+
     return AssetLiabilityMonthlyState(
       paymentOverrides: migratedPayments,
       paidAccountNames: migratedPaidAccounts,
       paymentSourceAccountIds: migratedPaymentSources,
+      cardBillingAccountIds: migratedCardBillingAccounts,
       incomePlans: state.incomePlans,
     );
   }

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -3,6 +3,10 @@ import 'dart:math';
 import '../models/asset_liability_workbook.dart';
 
 class AssetLiabilityPlanningService {
+  static const String directPaymentMethodId = 'direct';
+  static const String directPaymentLabel = '直接支払い';
+  static const String cardBillingNotice =
+      'カード請求に含める支払いは、資金繰りでは請求先カード側だけを差し引きます。';
   static const String auAccountId = 'au';
   static const String auPayCardAccountId = 'aupay_card';
   static const String auPayCardAccountName = 'auPayカード';
@@ -24,6 +28,7 @@ class AssetLiabilityPlanningService {
     Map<String, String> paymentSourceAccountIds = const <String, String>{},
     Map<String, String> defaultPaymentSourceAccountIds =
         const <String, String>{},
+    Map<String, String> cardBillingAccountIds = const <String, String>{},
     List<AssetLiabilityIncomePlan> incomePlans =
         const <AssetLiabilityIncomePlan>[],
     bool includeDefaultFixedPayments = false,
@@ -88,6 +93,7 @@ class AssetLiabilityPlanningService {
             monthlyPaymentOverrides: effectiveMonthlyPaymentOverrides,
             paidAccountNames: paidAccountNames,
             paymentSourceAccountIds: effectivePaymentSourceAccountIds,
+            cardBillingAccountIds: cardBillingAccountIds,
             accountsById: accountsById,
           ),
         )
@@ -310,6 +316,7 @@ class AssetLiabilityPlanningService {
         balance: balance,
         kind: AssetLiabilityAccountKind.utility,
         paymentDay: 11,
+        paymentMethod: AssetLiabilityPaymentMethod.includedInCard,
         paymentMethodLabel: auPayCardPaymentMethodLabel,
         billingAccountId: auPayCardAccountId,
         billingAccountName: auPayCardAccountName,
@@ -399,26 +406,34 @@ class AssetLiabilityPlanningService {
     required double minimumPaymentRate,
     required double minimumPaymentFloor,
     bool fullPaymentEstimate = false,
+    AssetLiabilityPaymentMethod paymentMethod =
+        AssetLiabilityPaymentMethod.direct,
     String? paymentMethodLabel,
     String? billingAccountId,
     String? billingAccountName,
     bool includedInBillingAccount = false,
-  }) =>
-      AssetLiabilityAccount(
-        id: _accountIdForName(name),
-        name: name,
-        kind: kind,
-        balance: balance,
-        paymentDay: paymentDay,
-        paymentMethodLabel: paymentMethodLabel,
-        billingAccountId: billingAccountId,
-        billingAccountName: billingAccountName,
-        includedInBillingAccount: includedInBillingAccount,
-        annualRate: annualRate,
-        minimumPaymentRate: minimumPaymentRate,
-        minimumPaymentFloor: minimumPaymentFloor,
-        fullPaymentEstimate: fullPaymentEstimate,
-      );
+  }) {
+    final resolvedPaymentMethod = includedInBillingAccount
+        ? AssetLiabilityPaymentMethod.includedInCard
+        : paymentMethod;
+    return AssetLiabilityAccount(
+      id: _accountIdForName(name),
+      name: name,
+      kind: kind,
+      balance: balance,
+      paymentDay: paymentDay,
+      paymentMethod: resolvedPaymentMethod,
+      paymentMethodLabel: paymentMethodLabel,
+      billingAccountId: billingAccountId,
+      billingAccountName: billingAccountName,
+      includedInBillingAccount:
+          resolvedPaymentMethod == AssetLiabilityPaymentMethod.includedInCard,
+      annualRate: annualRate,
+      minimumPaymentRate: minimumPaymentRate,
+      minimumPaymentFloor: minimumPaymentFloor,
+      fullPaymentEstimate: fullPaymentEstimate,
+    );
+  }
 
   AssetLiabilityDebtRow _buildDebtRow({
     required AssetLiabilityAccount account,
@@ -426,6 +441,7 @@ class AssetLiabilityPlanningService {
     required Map<String, double> monthlyPaymentOverrides,
     required Set<String> paidAccountNames,
     required Map<String, String> paymentSourceAccountIds,
+    required Map<String, String> cardBillingAccountIds,
     required Map<String, AssetLiabilityAccount> accountsById,
   }) {
     final principal = account.liabilityBalance;
@@ -450,6 +466,11 @@ class AssetLiabilityPlanningService {
     final paymentSourceAccountName = paymentSourceAccountId == null
         ? null
         : accountsById[paymentSourceAccountId]?.name;
+    final paymentRouting = _paymentRoutingFor(
+      account: account,
+      cardBillingAccountIds: cardBillingAccountIds,
+      accountsById: accountsById,
+    );
 
     return AssetLiabilityDebtRow(
       id: account.id,
@@ -459,10 +480,11 @@ class AssetLiabilityPlanningService {
       paymentDay: account.paymentDay,
       paymentSourceAccountId: paymentSourceAccountId,
       paymentSourceAccountName: paymentSourceAccountName,
-      paymentMethodLabel: account.paymentMethodLabel,
-      billingAccountId: account.billingAccountId,
-      billingAccountName: account.billingAccountName,
-      includedInBillingAccount: account.includedInBillingAccount,
+      paymentMethod: paymentRouting.paymentMethod,
+      paymentMethodLabel: paymentRouting.paymentMethodLabel,
+      billingAccountId: paymentRouting.billingAccountId,
+      billingAccountName: paymentRouting.billingAccountName,
+      includedInBillingAccount: paymentRouting.includedInBillingAccount,
       annualRate: account.annualRate,
       minimumPaymentEstimate: minimumPayment,
       manualPaymentAmount: manualPayment,
@@ -478,6 +500,80 @@ class AssetLiabilityPlanningService {
           paidAccountNames.contains(account.name.trim()) ||
           paidAccountNames.contains(account.name),
     );
+  }
+
+  _AssetLiabilityPaymentRouting _paymentRoutingFor({
+    required AssetLiabilityAccount account,
+    required Map<String, String> cardBillingAccountIds,
+    required Map<String, AssetLiabilityAccount> accountsById,
+  }) {
+    final configuredBillingAccountId = _configuredBillingAccountIdFor(
+      account: account,
+      cardBillingAccountIds: cardBillingAccountIds,
+    );
+    if (configuredBillingAccountId == directPaymentMethodId) {
+      return const _AssetLiabilityPaymentRouting(
+        paymentMethod: AssetLiabilityPaymentMethod.direct,
+      );
+    }
+
+    final billingAccountId = configuredBillingAccountId ??
+        (account.paymentMethod == AssetLiabilityPaymentMethod.includedInCard
+            ? account.billingAccountId
+            : null);
+    if (billingAccountId == null || billingAccountId.trim().isEmpty) {
+      return const _AssetLiabilityPaymentRouting(
+        paymentMethod: AssetLiabilityPaymentMethod.direct,
+      );
+    }
+
+    final billingAccountName = _billingAccountNameFor(
+      billingAccountId: billingAccountId,
+      accountsById: accountsById,
+      fallbackName: account.billingAccountName,
+    );
+    final paymentMethodLabel = billingAccountId == auPayCardAccountId
+        ? auPayCardPaymentMethodLabel
+        : '${billingAccountName ?? billingAccountId}払い';
+    return _AssetLiabilityPaymentRouting(
+      paymentMethod: AssetLiabilityPaymentMethod.includedInCard,
+      paymentMethodLabel: paymentMethodLabel,
+      billingAccountId: billingAccountId,
+      billingAccountName: billingAccountName,
+    );
+  }
+
+  String? _configuredBillingAccountIdFor({
+    required AssetLiabilityAccount account,
+    required Map<String, String> cardBillingAccountIds,
+  }) {
+    for (final key in <String>[account.id, account.name.trim(), account.name]) {
+      final value = cardBillingAccountIds[key]?.trim();
+      if (value != null && value.isNotEmpty) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  String? _billingAccountNameFor({
+    required String billingAccountId,
+    required Map<String, AssetLiabilityAccount> accountsById,
+    String? fallbackName,
+  }) {
+    final accountName = accountsById[billingAccountId]?.name;
+    if (accountName != null && accountName.trim().isNotEmpty) {
+      return accountName;
+    }
+    if (fallbackName != null && fallbackName.trim().isNotEmpty) {
+      return fallbackName;
+    }
+    return switch (billingAccountId) {
+      auPayCardAccountId => auPayCardAccountName,
+      'paypay_card' => 'PayPayカード',
+      'famipay_card' => 'ファミペイカード',
+      _ => null,
+    };
   }
 
   List<AssetLiabilityPaymentDayRisk> _buildPaymentDayRisks({
@@ -565,6 +661,7 @@ class AssetLiabilityPlanningService {
           paymentSourceAccountName: null,
           destinationAccountId: plan.destinationAccountId,
           destinationAccountName: plan.destinationAccountName,
+          paymentMethod: AssetLiabilityPaymentMethod.direct,
           paymentMethodLabel: null,
           billingAccountId: null,
           billingAccountName: null,
@@ -605,6 +702,7 @@ class AssetLiabilityPlanningService {
           destinationAccountName: row.includedInBillingAccount
               ? (row.paymentMethodLabel ?? row.billingAccountName)
               : null,
+          paymentMethod: row.paymentMethod,
           paymentMethodLabel: row.paymentMethodLabel,
           billingAccountId: row.billingAccountId,
           billingAccountName: row.billingAccountName,
@@ -654,6 +752,7 @@ class AssetLiabilityPlanningService {
             paymentSourceAccountName: row.paymentSourceAccountName,
             destinationAccountId: row.destinationAccountId,
             destinationAccountName: row.destinationAccountName,
+            paymentMethod: row.paymentMethod,
             paymentMethodLabel: row.paymentMethodLabel,
             billingAccountId: row.billingAccountId,
             billingAccountName: row.billingAccountName,
@@ -1005,4 +1104,21 @@ class AssetLiabilityPlanningService {
   DateTime _dateOnly(DateTime source) {
     return DateTime(source.year, source.month, source.day);
   }
+}
+
+class _AssetLiabilityPaymentRouting {
+  final AssetLiabilityPaymentMethod paymentMethod;
+  final String? paymentMethodLabel;
+  final String? billingAccountId;
+  final String? billingAccountName;
+
+  const _AssetLiabilityPaymentRouting({
+    required this.paymentMethod,
+    this.paymentMethodLabel,
+    this.billingAccountId,
+    this.billingAccountName,
+  });
+
+  bool get includedInBillingAccount =>
+      paymentMethod == AssetLiabilityPaymentMethod.includedInCard;
 }

--- a/test/services/asset_liability_history_service_test.dart
+++ b/test/services/asset_liability_history_service_test.dart
@@ -228,6 +228,10 @@ void main() {
       );
       expect(
         csv,
+        contains(AssetLiabilityPlanningService.auPayCardAccountName),
+      );
+      expect(
+        csv,
         contains(AssetLiabilityPlanningService.cardBillingIncludedLabel),
       );
       expect(csv, contains('直接差し引き対象'));

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -24,6 +24,9 @@ void main() {
           paymentSourceAccountIds: const <String, String>{
             'mobit': 'custom_bank',
           },
+          cardBillingAccountIds: const <String, String>{
+            'au': 'aupay_card',
+          },
           incomePlans: <AssetLiabilityIncomePlan>[
             AssetLiabilityIncomePlan(
               id: 'income_salary',
@@ -44,10 +47,12 @@ void main() {
       expect(loadedMay.paymentOverrides['モビット'], 70000);
       expect(loadedMay.paidAccountNames, contains('auPayカード'));
       expect(loadedMay.paymentSourceAccountIds['mobit'], 'custom_bank');
+      expect(loadedMay.cardBillingAccountIds['au'], 'aupay_card');
       expect(loadedMay.incomePlans.single.name, 'Salary');
       expect(loadedJune.paymentOverrides, isEmpty);
       expect(loadedJune.paidAccountNames, isEmpty);
       expect(loadedJune.paymentSourceAccountIds, isEmpty);
+      expect(loadedJune.cardBillingAccountIds, isEmpty);
       expect(loadedJune.incomePlans, isEmpty);
     });
 
@@ -74,6 +79,9 @@ void main() {
           paymentSourceAccountIds: <String, String>{
             'mobit': 'custom_bank',
           },
+          cardBillingAccountIds: <String, String>{
+            'au': 'aupay_card',
+          },
         ),
       );
       await store.saveMonth(
@@ -86,6 +94,7 @@ void main() {
       expect(loaded.paymentOverrides, isEmpty);
       expect(loaded.paidAccountNames, isEmpty);
       expect(loaded.paymentSourceAccountIds, isEmpty);
+      expect(loaded.cardBillingAccountIds, isEmpty);
       expect(loaded.incomePlans, isEmpty);
     });
 
@@ -116,6 +125,24 @@ void main() {
       });
     });
 
+    test('migrates card billing routing keys to stable account ids', () {
+      final migrated = AssetLiabilityMonthlyStateStore.migrateLegacyKeys(
+        state: const AssetLiabilityMonthlyState(
+          cardBillingAccountIds: <String, String>{
+            'Legacy utility': 'Legacy card',
+          },
+        ),
+        legacyKeyToAccountId: const <String, String>{
+          'Legacy utility': 'custom_utility',
+          'Legacy card': 'paypay_card',
+        },
+      );
+
+      expect(migrated.cardBillingAccountIds, <String, String>{
+        'custom_utility': 'paypay_card',
+      });
+    });
+
     test('copies previous month settings without paid or received state',
         () async {
       await store.saveMonth(
@@ -129,6 +156,9 @@ void main() {
           },
           paymentSourceAccountIds: const <String, String>{
             'mobit': 'custom_bank',
+          },
+          cardBillingAccountIds: const <String, String>{
+            'kddi_provider': 'paypay_card',
           },
           incomePlans: <AssetLiabilityIncomePlan>[
             AssetLiabilityIncomePlan(
@@ -153,10 +183,16 @@ void main() {
       expect(copied.paymentSourceAccountIds, <String, String>{
         'mobit': 'custom_bank',
       });
+      expect(copied.cardBillingAccountIds, <String, String>{
+        'kddi_provider': 'paypay_card',
+      });
       expect(copied.paidAccountNames, isEmpty);
       expect(copied.incomePlans.single.date, DateTime(2026, 6, 30));
       expect(copied.incomePlans.single.received, isFalse);
       expect(loaded.paidAccountNames, isEmpty);
+      expect(loaded.cardBillingAccountIds, <String, String>{
+        'kddi_provider': 'paypay_card',
+      });
       expect(loaded.incomePlans.single.received, isFalse);
     });
 

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -256,6 +256,10 @@ void main() {
           au.billingAccountId,
           AssetLiabilityPlanningService.auPayCardAccountId,
         );
+        expect(
+          au.paymentMethod,
+          AssetLiabilityPaymentMethod.includedInCard,
+        );
         expect(au.includedInBillingAccount, isTrue);
         expect(au.isDirectCashflowTarget, isFalse);
         expect(auPay.isDirectCashflowTarget, isTrue);
@@ -274,6 +278,52 @@ void main() {
           auPay.scheduledPaymentAmount,
         );
         expect(workbook.cashAfterScheduledPayments, 40000);
+      },
+    );
+
+    test(
+      'allows arbitrary payment items to be included in card billing',
+      () {
+        final workbook = service.buildWorkbook(
+          latestSnapshot: <String, double>{
+            'cash': 50000,
+            'KDDI': -5764,
+            'PayPay': -20000,
+          },
+          baseDate: DateTime(2026, 5, 1),
+          monthlyPaymentOverrides: const <String, double>{
+            AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+            'paypay_card': 20000,
+          },
+          cardBillingAccountIds: const <String, String>{
+            AssetLiabilityPlanningService.kddiProviderAccountId: 'paypay_card',
+          },
+        );
+
+        final kddi = workbook.debtMasterRows.firstWhere(
+          (row) =>
+              row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
+        );
+        final payPay = workbook.debtMasterRows.firstWhere(
+          (row) => row.id == 'paypay_card',
+        );
+        final kddiCashflow = workbook.cashflowRows.firstWhere(
+          (row) =>
+              row.accountId ==
+              AssetLiabilityPlanningService.kddiProviderAccountId,
+        );
+
+        expect(kddi.paymentMethod, AssetLiabilityPaymentMethod.includedInCard);
+        expect(kddi.billingAccountId, 'paypay_card');
+        expect(kddi.isDirectCashflowTarget, isFalse);
+        expect(payPay.isDirectCashflowTarget, isTrue);
+        expect(
+          workbook.paymentDayRisks.any((risk) => risk.paymentDay == 25),
+          isFalse,
+        );
+        expect(kddiCashflow.cashAfterPayment, kddiCashflow.cashBeforePayment);
+        expect(workbook.monthlyUnpaidPaymentTotal, 20000);
+        expect(workbook.cashAfterScheduledPayments, 30000);
       },
     );
 
@@ -579,6 +629,7 @@ void main() {
       expect(kddi.name, AssetLiabilityPlanningService.kddiProviderAccountName);
       expect(kddi.kind, AssetLiabilityAccountKind.utility);
       expect(kddi.paymentDay, 25);
+      expect(kddi.paymentMethod, AssetLiabilityPaymentMethod.direct);
       expect(kddi.manualPaymentAmount, 5764);
       expect(kddi.paymentAmountEstimated, isFalse);
       expect(

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -26,6 +26,9 @@ void main() {
           paymentSourceAccountIds: const <String, String>{
             'mobit': 'smbc_otsuka',
           },
+          cardBillingAccountIds: const <String, String>{
+            'kddi_provider': 'paypay_card',
+          },
           incomePlans: <AssetLiabilityIncomePlan>[
             AssetLiabilityIncomePlan(
               id: 'salary',
@@ -46,6 +49,7 @@ void main() {
       expect(restored.paymentOverrides['kddi_provider'], 5764);
       expect(restored.paidAccountNames, contains('kddi_provider'));
       expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
+      expect(restored.cardBillingAccountIds['kddi_provider'], 'paypay_card');
       expect(restored.incomePlans.single.name, 'Salary');
       expect(restored.incomePlans.single.received, isFalse);
     });
@@ -583,6 +587,9 @@ void main() {
         paymentOverrides: const <String, double>{'mobit': 70000},
         paidAccountNames: const <String>{'kddi_provider'},
         paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
+        cardBillingAccountIds: const <String, String>{
+          'kddi_provider': 'paypay_card',
+        },
         incomePlans: <AssetLiabilityIncomePlan>[
           AssetLiabilityIncomePlan(
             id: 'salary',
@@ -613,6 +620,7 @@ void main() {
       expect(restored.paymentOverrides['mobit'], 70000);
       expect(restored.paidAccountNames, contains('kddi_provider'));
       expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
+      expect(restored.cardBillingAccountIds['kddi_provider'], 'paypay_card');
       expect(restored.incomePlans.single.received, isTrue);
     });
 
@@ -932,6 +940,9 @@ AssetLiabilityMonthlyState _sampleMonthlyState() {
     paymentOverrides: const <String, double>{'mobit': 70000},
     paidAccountNames: const <String>{'kddi_provider'},
     paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
+    cardBillingAccountIds: const <String, String>{
+      'kddi_provider': 'paypay_card',
+    },
     incomePlans: <AssetLiabilityIncomePlan>[
       AssetLiabilityIncomePlan(
         id: 'salary',


### PR DESCRIPTION
﻿## 概要

資産/負債ボードで、任意の支払い項目をカード請求内訳として扱えるようにしました。

これまで `au -> auPayカード` の個別対応だったものを、月次状態として保存できる支払い方式に一般化し、直接支払いとカード請求内訳を切り替えられるようにしています。

## 主な変更

- 支払い方式 `direct` / `includedInCard` をモデルに追加
- 任意の支払い項目に請求先カードIDを持てるように変更
- 資金繰り計算を一般化
  - direct は従来どおり差し引き対象
  - includedInCard は直接差し引かず、請求先カード側のみ差し引き対象
- au は一般化された `includedInCard` として auPayカード請求に含める扱いを維持
- 負債マスタに支払い方式の選択UIを追加
- 月次状態 / SharedPreferences / Repository payload にカード請求ルーティングを追加
- CSVに請求先カード情報を追加
- 関連テストを追加・更新

## Minimal E2E Gate

- [x] Implementation-detail independent: the E2E plan checks user-visible input/output, not private internals.
- [x] Minimal scope: three cases only.
- [x] E2E mechanism: Flutter widget/service regression tests plus manual browser smoke for the asset/liability board.
- [x] E2E-Exception: no new integration_test or Playwright file was added because this PR is a focused authenticated finance-board state/calculation change; verification is covered by existing Flutter test coverage and manual board smoke.

Minimal black-box cases:
1. User can mark a payment as direct and it remains a cashflow deduction.
2. User can mark a payment as included in a card bill and it no longer double-counts in unpaid total or cash-after-payment.
3. Existing au -> auPayカード behavior still displays as card-billed and only auPayカード is deducted.

## High-risk Ultrareview Gate

- Claude Code #1 review owner: Claude Code #1.
- High-risk Ultrareview Exception: this PR contains the word billing and touches local asset-liability persistence payloads, but it does not change auth, RLS, Supabase migrations, secrets, payment processors, production writes, deployment, or external billing systems. The change is local finance-board routing/state only.
- Rollback: revert this squash commit; existing local state remains backward-compatible because missing card billing routing defaults to direct except the existing au default.
- Data migration: no DB migration. SharedPreferences and Supabase JSON payloads tolerate missing `card_billing_account_ids` as an empty map.
- Prod smoke: CI public smoke plus local Flutter tests are sufficient for this non-deploying UI/state change.
- Observability: no new runtime logging or external telemetry; failures remain covered by existing local persistence and repository error paths.
- Security: no secrets, credentials, RLS, service role, auth, or production write changes.
- Unresolved findings: 0.

## 検証

- `flutter pub get --enforce-lockfile`: failed because the local Flutter dependency resolver would update `pubspec.lock`; no lockfile/platform generated changes were kept.
- `dart format --output=none --set-exit-if-changed ...`: OK
- `dart analyze`: No issues found
- 資産/負債関連 `flutter test --no-pub ...`: 59 tests passed
- 全体 `flutter test --no-pub --reporter compact`: 443 tests passed
- `git diff --check`: OK

## Files changed確認

想定どおり10件です。

- `lib/models/asset_liability_workbook.dart`
- `lib/models/asset_liability_persistence.dart`
- `lib/services/asset_liability_planning_service.dart`
- `lib/services/asset_liability_monthly_state_store.dart`
- `lib/services/asset_liability_history_service.dart`
- `lib/pages/asset_management_page.dart`
- `test/services/asset_liability_planning_service_test.dart`
- `test/services/asset_liability_monthly_state_store_test.dart`
- `test/services/asset_liability_history_service_test.dart`
- `test/services/asset_liability_repository_test.dart`

## 注意点

- Supabase migration / RLS / production write は含みません。
- lockfile / platform generated files は含みません。
