### PR TITLE
Add edit UI for card-billed asset liability items

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -58,6 +58,7 @@ class AssetLiabilityPersistenceSnapshot {
   final String monthKey;
   final AssetLiabilityMonthlyState monthlyState;
   final Map<String, String> defaultPaymentSourceAccountIds;
+  final Map<String, String> defaultCardBillingAccountIds;
   final List<AssetLiabilityRecurringIncomeTemplate> recurringIncomeTemplates;
   final List<AssetLiabilityMonthlySnapshot> monthlySnapshots;
 
@@ -65,6 +66,7 @@ class AssetLiabilityPersistenceSnapshot {
     required this.monthKey,
     required this.monthlyState,
     required this.defaultPaymentSourceAccountIds,
+    required this.defaultCardBillingAccountIds,
     required this.recurringIncomeTemplates,
     required this.monthlySnapshots,
   });
@@ -167,10 +169,12 @@ class AssetLiabilityMonthlyStatePayload {
 
 class AssetLiabilityUserSettingsPayload {
   final Map<String, String> defaultPaymentSourceAccountIds;
+  final Map<String, String> defaultCardBillingAccountIds;
   final List<AssetLiabilityRecurringIncomeTemplate> recurringIncomeTemplates;
 
   const AssetLiabilityUserSettingsPayload({
     required this.defaultPaymentSourceAccountIds,
+    required this.defaultCardBillingAccountIds,
     required this.recurringIncomeTemplates,
   });
 
@@ -181,6 +185,10 @@ class AssetLiabilityUserSettingsPayload {
       defaultPaymentSourceAccountIds:
           _readStringMap(json, 'default_payment_source_account_ids') ??
               _readStringMap(json, 'defaultPaymentSourceAccountIds') ??
+              const <String, String>{},
+      defaultCardBillingAccountIds:
+          _readStringMap(json, 'default_card_billing_account_ids') ??
+              _readStringMap(json, 'defaultCardBillingAccountIds') ??
               const <String, String>{},
       recurringIncomeTemplates:
           _readRecurringIncomeTemplates(json, 'recurring_income_templates') ??
@@ -198,6 +206,9 @@ class AssetLiabilityUserSettingsPayload {
       'user_id': userId,
       'default_payment_source_account_ids': Map<String, String>.from(
         defaultPaymentSourceAccountIds,
+      ),
+      'default_card_billing_account_ids': Map<String, String>.from(
+        defaultCardBillingAccountIds,
       ),
       'recurring_income_templates': [
         for (final template in recurringIncomeTemplates)

--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -12,6 +12,12 @@ enum AssetLiabilityAccountKind {
 
 enum AssetLiabilityPaymentMethod { direct, includedInCard }
 
+enum AssetLiabilityPaymentMethodSettingSource {
+  builtInDefault,
+  defaultSetting,
+  monthlyOverride,
+}
+
 class AssetLiabilityAccount {
   final String id;
   final String name;
@@ -21,6 +27,7 @@ class AssetLiabilityAccount {
   final String? paymentSourceAccountName;
   final AssetLiabilityPaymentMethod paymentMethod;
   final String? paymentMethodLabel;
+  final AssetLiabilityPaymentMethodSettingSource paymentMethodSettingSource;
   final String? billingAccountId;
   final String? billingAccountName;
   final bool includedInBillingAccount;
@@ -38,6 +45,8 @@ class AssetLiabilityAccount {
     this.paymentSourceAccountName,
     this.paymentMethod = AssetLiabilityPaymentMethod.direct,
     this.paymentMethodLabel,
+    this.paymentMethodSettingSource =
+        AssetLiabilityPaymentMethodSettingSource.builtInDefault,
     this.billingAccountId,
     this.billingAccountName,
     this.includedInBillingAccount = false,
@@ -62,6 +71,7 @@ class AssetLiabilityDebtRow {
   final String? paymentSourceAccountName;
   final AssetLiabilityPaymentMethod paymentMethod;
   final String? paymentMethodLabel;
+  final AssetLiabilityPaymentMethodSettingSource paymentMethodSettingSource;
   final String? billingAccountId;
   final String? billingAccountName;
   final bool includedInBillingAccount;
@@ -87,6 +97,7 @@ class AssetLiabilityDebtRow {
     required this.paymentSourceAccountName,
     required this.paymentMethod,
     required this.paymentMethodLabel,
+    required this.paymentMethodSettingSource,
     required this.billingAccountId,
     required this.billingAccountName,
     required this.includedInBillingAccount,
@@ -196,6 +207,7 @@ class AssetLiabilityCashflowRow {
   final String? destinationAccountName;
   final AssetLiabilityPaymentMethod paymentMethod;
   final String? paymentMethodLabel;
+  final AssetLiabilityPaymentMethodSettingSource paymentMethodSettingSource;
   final String? billingAccountId;
   final String? billingAccountName;
   final bool includedInBillingAccount;
@@ -220,6 +232,7 @@ class AssetLiabilityCashflowRow {
     required this.destinationAccountName,
     required this.paymentMethod,
     required this.paymentMethodLabel,
+    required this.paymentMethodSettingSource,
     required this.billingAccountId,
     required this.billingAccountName,
     required this.includedInBillingAccount,

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -42,6 +42,8 @@ enum AssetManagementInitialFocus {
 
 enum AssetDebtPlannerMode { ask, code }
 
+enum _CardBillingSaveScope { defaultSetting, monthlyOverride }
+
 class AssetManagementPage extends StatefulWidget {
   final AssetManagementInitialFocus initialFocus;
   final bool emphasizeMonthlyFlow;
@@ -106,6 +108,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, String> _paymentSourceAccountIds = <String, String>{};
   Map<String, String> _cardBillingAccountIds = <String, String>{};
   Map<String, String> _defaultPaymentSourceAccountIds = <String, String>{};
+  Map<String, String> _defaultCardBillingAccountIds = <String, String>{};
+  final Map<String, _CardBillingSaveScope> _cardBillingSaveScopes =
+      <String, _CardBillingSaveScope>{};
   List<AssetLiabilityIncomePlan> _monthlyIncomePlans =
       <AssetLiabilityIncomePlan>[];
   List<AssetLiabilityRecurringIncomeTemplate> _recurringIncomeTemplates =
@@ -790,6 +795,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final state = await _assetLiabilityRepository.loadMonth(targetMonth);
       final defaultSources =
           await _assetLiabilityRepository.loadDefaultPaymentSources();
+      final defaultCardBillingAccounts =
+          await _assetLiabilityRepository.loadDefaultCardBillingAccounts();
       final templates =
           await _assetLiabilityRepository.loadRecurringIncomeTemplates();
       final monthlySnapshots =
@@ -816,6 +823,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
         _defaultPaymentSourceAccountIds = Map<String, String>.from(
           defaultSources,
+        );
+        _defaultCardBillingAccountIds = Map<String, String>.from(
+          defaultCardBillingAccounts,
         );
         _monthlyIncomePlans = List<AssetLiabilityIncomePlan>.from(
           incomePlansWithTemplates,
@@ -865,9 +875,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _assetLiabilitySyncMessage = 'Supabase同期は無効です';
         _assetLiabilitySyncConflicts = <String>[];
       });
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Supabase同期は無効です')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Supabase同期は無効です')));
       return;
     }
 
@@ -881,16 +891,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _assetLiabilitySyncStatus = result.status;
         _lastAssetLiabilitySyncAt = result.completedAt;
         _assetLiabilitySyncMessage = result.message;
-        _assetLiabilitySyncConflicts =
-            List<String>.from(result.conflictTargets);
+        _assetLiabilitySyncConflicts = List<String>.from(
+          result.conflictTargets,
+        );
       });
       if (result.isSuccess) {
         await _loadAssetLiabilityMonthlyState();
       }
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(result.message)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(result.message)));
     } catch (e) {
       debugPrint('Error running asset liability manual sync: $e');
       if (!mounted) return;
@@ -900,9 +911,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _assetLiabilitySyncMessage = 'Supabase同期に失敗しました: $e';
         _assetLiabilitySyncConflicts = <String>[];
       });
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Supabase同期に失敗しました: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Supabase同期に失敗しました: $e')));
     } finally {
       if (mounted) {
         setState(() {
@@ -918,9 +929,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       setState(() {
         _assetLiabilitySyncPreview = result;
       });
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(result.message)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(result.message)));
       return;
     }
 
@@ -933,9 +944,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       setState(() {
         _assetLiabilitySyncPreview = result;
       });
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(result.message)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(result.message)));
     } catch (e) {
       debugPrint('Error previewing asset liability Supabase sync: $e');
       if (!mounted) return;
@@ -945,9 +956,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       setState(() {
         _assetLiabilitySyncPreview = result;
       });
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(result.message)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(result.message)));
     } finally {
       if (mounted) {
         setState(() {
@@ -1037,15 +1048,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
         ),
-        cardBillingAccountIds: Map<String, String>.from(
-          _cardBillingAccountIds,
-        ),
+        cardBillingAccountIds: Map<String, String>.from(_cardBillingAccountIds),
         incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
       ),
       legacyKeyToAccountId: legacyKeyToAccountId,
     );
     final migratedDefaultSources = _migrateStringMapKeysAndValues(
       _defaultPaymentSourceAccountIds,
+      legacyKeyToAccountId,
+    );
+    final migratedDefaultCardBillingAccounts = _migrateStringMapKeysAndValues(
+      _defaultCardBillingAccountIds,
       legacyKeyToAccountId,
     );
     if (_sameDoubleMap(_monthlyPaymentOverrides, migrated.paymentOverrides) &&
@@ -1061,6 +1074,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _sameStringMap(
           _defaultPaymentSourceAccountIds,
           migratedDefaultSources,
+        ) &&
+        _sameStringMap(
+          _defaultCardBillingAccountIds,
+          migratedDefaultCardBillingAccounts,
         )) {
       return;
     }
@@ -1081,10 +1098,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _defaultPaymentSourceAccountIds = Map<String, String>.from(
           migratedDefaultSources,
         );
+        _defaultCardBillingAccountIds = Map<String, String>.from(
+          migratedDefaultCardBillingAccounts,
+        );
         _syncMonthlyPaymentControllers();
       });
       unawaited(_saveAssetLiabilityMonthlyState());
       unawaited(_saveDefaultPaymentSources());
+      unawaited(_saveDefaultCardBillingAccounts());
     });
   }
 
@@ -1209,20 +1230,61 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   ) {
     final selected =
         billingAccountId ?? AssetLiabilityPlanningService.directPaymentMethodId;
+    final scope = _cardBillingSaveScopeFor(row);
     setState(() {
-      if (selected == AssetLiabilityPlanningService.directPaymentMethodId) {
-        if (row.includedInBillingAccount ||
-            _cardBillingAccountIds.containsKey(row.id)) {
-          _cardBillingAccountIds[row.id] =
-              AssetLiabilityPlanningService.directPaymentMethodId;
-        } else {
-          _cardBillingAccountIds.remove(row.id);
-        }
+      if (scope == _CardBillingSaveScope.defaultSetting) {
+        _applyCardBillingSelection(
+          target: _defaultCardBillingAccountIds,
+          row: row,
+          selected: selected,
+        );
+        _cardBillingAccountIds.remove(row.id);
       } else {
-        _cardBillingAccountIds[row.id] = selected;
+        _applyCardBillingSelection(
+          target: _cardBillingAccountIds,
+          row: row,
+          selected: selected,
+        );
       }
     });
-    unawaited(_saveAssetLiabilityMonthlyState());
+    if (scope == _CardBillingSaveScope.defaultSetting) {
+      unawaited(_saveDefaultCardBillingAccounts());
+      unawaited(_saveAssetLiabilityMonthlyState());
+    } else {
+      unawaited(_saveAssetLiabilityMonthlyState());
+    }
+  }
+
+  void _applyCardBillingSelection({
+    required Map<String, String> target,
+    required AssetLiabilityDebtRow row,
+    required String selected,
+  }) {
+    if (selected == AssetLiabilityPlanningService.directPaymentMethodId) {
+      if (row.includedInBillingAccount || target.containsKey(row.id)) {
+        target[row.id] = AssetLiabilityPlanningService.directPaymentMethodId;
+      } else {
+        target.remove(row.id);
+      }
+    } else {
+      target[row.id] = selected;
+    }
+  }
+
+  _CardBillingSaveScope _cardBillingSaveScopeFor(AssetLiabilityDebtRow row) {
+    return _cardBillingSaveScopes[row.id] ??
+        (_cardBillingAccountIds.containsKey(row.id)
+            ? _CardBillingSaveScope.monthlyOverride
+            : _CardBillingSaveScope.defaultSetting);
+  }
+
+  void _updateCardBillingSaveScope(
+    String liabilityId,
+    _CardBillingSaveScope scope,
+  ) {
+    setState(() {
+      _cardBillingSaveScopes[liabilityId] = scope;
+    });
   }
 
   Future<void> _saveDefaultPaymentSources() async {
@@ -1232,6 +1294,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       );
     } catch (e) {
       debugPrint('Error saving asset liability default sources: $e');
+    }
+  }
+
+  Future<void> _saveDefaultCardBillingAccounts() async {
+    try {
+      await _assetLiabilityRepository.saveDefaultCardBillingAccounts(
+        Map<String, String>.from(_defaultCardBillingAccountIds),
+      );
+    } catch (e) {
+      debugPrint('Error saving asset liability default card billing: $e');
     }
   }
 
@@ -1682,7 +1754,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   ) {
     return workbook.accounts
         .where(
-            (account) => account.kind == AssetLiabilityAccountKind.creditCard)
+          (account) => account.kind == AssetLiabilityAccountKind.creditCard,
+        )
         .toList()
       ..sort((a, b) => a.name.compareTo(b.name));
   }
@@ -6413,6 +6486,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       paidAccountNames: _monthlyPaidAccountNames,
       paymentSourceAccountIds: _paymentSourceAccountIds,
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
+      defaultCardBillingAccountIds: _defaultCardBillingAccountIds,
       cardBillingAccountIds: _cardBillingAccountIds,
       incomePlans: _monthlyIncomePlans,
       includeDefaultFixedPayments: true,
@@ -6533,8 +6607,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
             const SizedBox(height: 8),
             _buildAssetWorkbookEstimateNotice(workbook),
-            if (workbook.debtMasterRows
-                .any((row) => row.includedInBillingAccount)) ...[
+            if (workbook.debtMasterRows.any(
+              (row) => row.includedInBillingAccount,
+            )) ...[
               const SizedBox(height: 8),
               _buildAssetWorkbookCardBillingNotice(workbook),
             ],
@@ -6568,13 +6643,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Widget _buildAssetLiabilitySyncPanel() {
     final syncEnabled = _assetLiabilityRepository.supabaseSyncEnabled;
-    final statusColor =
-        _assetLiabilityManualSyncStatusColor(_assetLiabilitySyncStatus);
+    final statusColor = _assetLiabilityManualSyncStatusColor(
+      _assetLiabilitySyncStatus,
+    );
     final lastSyncedAt = _lastAssetLiabilitySyncAt == null
         ? '未実行'
-        : DateFormat('yyyy/MM/dd HH:mm').format(
-            _lastAssetLiabilitySyncAt!.toLocal(),
-          );
+        : DateFormat(
+            'yyyy/MM/dd HH:mm',
+          ).format(_lastAssetLiabilitySyncAt!.toLocal());
 
     return Container(
       width: double.infinity,
@@ -6582,9 +6658,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainerLow,
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outlineVariant,
-        ),
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -6673,9 +6747,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
           if (_assetLiabilitySyncPreview != null) ...[
             const SizedBox(height: 8),
-            _buildAssetLiabilitySyncPreviewDetails(
-              _assetLiabilitySyncPreview!,
-            ),
+            _buildAssetLiabilitySyncPreviewDetails(_assetLiabilitySyncPreview!),
           ],
           if (_assetLiabilitySyncConflicts.isNotEmpty) ...[
             const SizedBox(height: 8),
@@ -6713,9 +6785,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface,
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outlineVariant,
-        ),
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -6801,13 +6871,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                       '${_assetLiabilitySyncPreviewItemLabel(item)} '
                       '(ローカル${item.localCount} / Supabase${item.remoteCount})',
                     ),
-                    backgroundColor:
-                        _assetLiabilitySyncPreviewItemColor(item).withValues(
-                      alpha: 0.10,
-                    ),
+                    backgroundColor: _assetLiabilitySyncPreviewItemColor(
+                      item,
+                    ).withValues(alpha: 0.10),
                     side: BorderSide(
-                      color: _assetLiabilitySyncPreviewItemColor(item)
-                          .withValues(alpha: 0.35),
+                      color: _assetLiabilitySyncPreviewItemColor(
+                        item,
+                      ).withValues(alpha: 0.35),
                     ),
                   ),
               ],
@@ -6942,9 +7012,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
-  Widget _buildAssetWorkbookCardBillingNotice(
-    AssetLiabilityWorkbook workbook,
-  ) {
+  Widget _buildAssetWorkbookCardBillingNotice(AssetLiabilityWorkbook workbook) {
     final labels = workbook.debtMasterRows
         .where((row) => row.includedInBillingAccount)
         .map(
@@ -8216,6 +8284,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             dataRowMinHeight: 60,
             dataRowMaxHeight: 76,
             columns: const [
+              DataColumn(label: Text('\u8a2d\u5b9a\u5143/\u4fdd\u5b58\u5148')),
               DataColumn(label: Text('支払い方式')),
               DataColumn(label: Text('項目')),
               DataColumn(label: Text('種別')),
@@ -8233,6 +8302,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               for (final row in rows)
                 DataRow(
                   cells: [
+                    DataCell(_buildPaymentMethodScopeControl(row)),
                     DataCell(_buildPaymentMethodDropdown(row, workbook)),
                     DataCell(Text(row.name)),
                     DataCell(Text(_assetKindLabel(row.kind))),
@@ -8268,9 +8338,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     AssetLiabilityDebtRow row,
     AssetLiabilityWorkbook workbook,
   ) {
-    final cardOptions = _cardBillingAccountOptions(workbook)
-        .where((account) => account.id != row.id)
-        .toList(growable: false);
+    final cardOptions = _cardBillingAccountOptions(
+      workbook,
+    ).where((account) => account.id != row.id).toList(growable: false);
     final configured = _cardBillingAccountIds[row.id];
     final selected = configured ??
         (row.paymentMethod == AssetLiabilityPaymentMethod.includedInCard
@@ -8299,6 +8369,56 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
         ],
         onChanged: (value) => _updateCardBillingAccount(row, value),
+      ),
+    );
+  }
+
+  Widget _buildPaymentMethodScopeControl(AssetLiabilityDebtRow row) {
+    final selectedScope = _cardBillingSaveScopeFor(row);
+    final sourceLabel =
+        AssetLiabilityPlanningService.paymentMethodSettingSourceLabel(
+      row.paymentMethodSettingSource,
+    );
+
+    return SizedBox(
+      width: 180,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildTextStatusChip(
+            label: sourceLabel,
+            color: row.paymentMethodSettingSource ==
+                    AssetLiabilityPaymentMethodSettingSource.monthlyOverride
+                ? const Color(0xFF7C3AED)
+                : const Color(0xFF475569),
+          ),
+          const SizedBox(height: 4),
+          DropdownButton<_CardBillingSaveScope>(
+            value: selectedScope,
+            isExpanded: true,
+            items: const [
+              DropdownMenuItem<_CardBillingSaveScope>(
+                value: _CardBillingSaveScope.defaultSetting,
+                child: Text(
+                  AssetLiabilityPlanningService.saveAsDefaultPaymentMethodLabel,
+                ),
+              ),
+              DropdownMenuItem<_CardBillingSaveScope>(
+                value: _CardBillingSaveScope.monthlyOverride,
+                child: Text(
+                  AssetLiabilityPlanningService.saveAsMonthlyPaymentMethodLabel,
+                ),
+              ),
+            ],
+            onChanged: (value) {
+              if (value == null) {
+                return;
+              }
+              _updateCardBillingSaveScope(row.id, value);
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/services/asset_liability_history_service.dart
+++ b/lib/services/asset_liability_history_service.dart
@@ -178,6 +178,7 @@ class AssetLiabilityHistoryService {
     final rows = workbook.cashflowRows.where((row) => row.isPayment).toList();
     return _csv([
       const <Object?>[
+        '\u8a2d\u5b9a\u5143',
         '請求先カード',
         '日付',
         '支払先',
@@ -193,6 +194,9 @@ class AssetLiabilityHistoryService {
       ],
       for (final row in rows)
         <Object?>[
+          AssetLiabilityPlanningService.paymentMethodSettingSourceLabel(
+            row.paymentMethodSettingSource,
+          ),
           row.billingAccountName ?? row.billingAccountId ?? '',
           DateFormat('yyyy-MM-dd').format(row.paymentDate),
           row.accountName,

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -39,6 +39,8 @@ class AssetLiabilityMonthlyStateStore {
   static const String incomePrefsKey = 'asset_liability_income_plans_v1';
   static const String defaultPaymentSourcePrefsKey =
       'asset_liability_default_payment_source_accounts_v1';
+  static const String defaultCardBillingPrefsKey =
+      'asset_liability_default_card_billing_accounts_v1';
   static const String recurringIncomeTemplatePrefsKey =
       'asset_liability_recurring_income_templates_v1';
   static const String monthlySnapshotPrefsKey =
@@ -86,14 +88,10 @@ class AssetLiabilityMonthlyStateStore {
     if (state.paymentOverrides.isEmpty) {
       allPayments.remove(monthKey);
     } else {
-      allPayments[monthKey] = Map<String, double>.from(
-        state.paymentOverrides,
-      );
+      allPayments[monthKey] = Map<String, double>.from(state.paymentOverrides);
     }
 
-    final allPaidAccounts = decodePaidAccounts(
-      prefs.getString(paidPrefsKey),
-    );
+    final allPaidAccounts = decodePaidAccounts(prefs.getString(paidPrefsKey));
     if (state.paidAccountNames.isEmpty) {
       allPaidAccounts.remove(monthKey);
     } else {
@@ -116,10 +114,7 @@ class AssetLiabilityMonthlyStateStore {
         state.paymentSourceAccountIds,
       );
     }
-    await prefs.setString(
-      paymentSourcePrefsKey,
-      jsonEncode(allPaymentSources),
-    );
+    await prefs.setString(paymentSourcePrefsKey, jsonEncode(allPaymentSources));
 
     final allCardBillingAccounts = decodeCardBillingAccounts(
       prefs.getString(cardBillingPrefsKey),
@@ -136,9 +131,7 @@ class AssetLiabilityMonthlyStateStore {
       jsonEncode(allCardBillingAccounts),
     );
 
-    final allIncomePlans = decodeIncomePlans(
-      prefs.getString(incomePrefsKey),
-    );
+    final allIncomePlans = decodeIncomePlans(prefs.getString(incomePrefsKey));
     if (state.incomePlans.isEmpty) {
       allIncomePlans.remove(monthKey);
     } else {
@@ -157,13 +150,26 @@ class AssetLiabilityMonthlyStateStore {
     return decodeStringMap(prefs.getString(defaultPaymentSourcePrefsKey));
   }
 
-  Future<void> saveDefaultPaymentSources(
-    Map<String, String> sources,
-  ) async {
+  Future<void> saveDefaultPaymentSources(Map<String, String> sources) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(
       defaultPaymentSourcePrefsKey,
       jsonEncode(_cleanStringMap(sources)),
+    );
+  }
+
+  Future<Map<String, String>> loadDefaultCardBillingAccounts() async {
+    final prefs = await SharedPreferences.getInstance();
+    return decodeStringMap(prefs.getString(defaultCardBillingPrefsKey));
+  }
+
+  Future<void> saveDefaultCardBillingAccounts(
+    Map<String, String> accounts,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      defaultCardBillingPrefsKey,
+      jsonEncode(_cleanStringMap(accounts)),
     );
   }
 
@@ -492,10 +498,12 @@ class AssetLiabilityMonthlyStateStore {
           dayOfMonth: day.clamp(1, 31).toInt(),
           name: name,
           amount: amount,
-          destinationAccountId:
-              _cleanNullableString(rawTemplate['destinationAccountId']),
-          destinationAccountName:
-              _cleanNullableString(rawTemplate['destinationAccountName']),
+          destinationAccountId: _cleanNullableString(
+            rawTemplate['destinationAccountId'],
+          ),
+          destinationAccountName: _cleanNullableString(
+            rawTemplate['destinationAccountName'],
+          ),
         ),
       );
     }
@@ -529,19 +537,24 @@ class AssetLiabilityMonthlyStateStore {
       final savedAtText = rawSnapshot['savedAt']?.toString();
       final savedAt =
           savedAtText == null ? null : DateTime.tryParse(savedAtText);
-      final positiveAssetTotal =
-          _parseNonNullDouble(rawSnapshot['positiveAssetTotal']);
+      final positiveAssetTotal = _parseNonNullDouble(
+        rawSnapshot['positiveAssetTotal'],
+      );
       final liabilityTotal = _parseNonNullDouble(rawSnapshot['liabilityTotal']);
       final netWorth = _parseNonNullDouble(rawSnapshot['netWorth']);
       final cashLikeTotal = _parseNonNullDouble(rawSnapshot['cashLikeTotal']);
-      final monthlyScheduledPaymentTotal =
-          _parseNonNullDouble(rawSnapshot['monthlyScheduledPaymentTotal']);
-      final monthlyPaidPaymentTotal =
-          _parseNonNullDouble(rawSnapshot['monthlyPaidPaymentTotal']);
-      final monthlyUnpaidPaymentTotal =
-          _parseNonNullDouble(rawSnapshot['monthlyUnpaidPaymentTotal']);
-      final overduePaymentCount =
-          _parseNonNullInt(rawSnapshot['overduePaymentCount']);
+      final monthlyScheduledPaymentTotal = _parseNonNullDouble(
+        rawSnapshot['monthlyScheduledPaymentTotal'],
+      );
+      final monthlyPaidPaymentTotal = _parseNonNullDouble(
+        rawSnapshot['monthlyPaidPaymentTotal'],
+      );
+      final monthlyUnpaidPaymentTotal = _parseNonNullDouble(
+        rawSnapshot['monthlyUnpaidPaymentTotal'],
+      );
+      final overduePaymentCount = _parseNonNullInt(
+        rawSnapshot['overduePaymentCount'],
+      );
       if (monthKey == null ||
           monthKey.isEmpty ||
           savedAt == null ||
@@ -719,21 +732,18 @@ class AssetLiabilityMonthlyStateStore {
     return source.map((month, plans) {
       final sorted = List<AssetLiabilityIncomePlan>.from(plans)
         ..sort((a, b) => a.date.compareTo(b.date));
-      return MapEntry(
-        month,
-        [
-          for (final plan in sorted)
-            <String, Object?>{
-              'id': plan.id,
-              'date': DateFormat('yyyy-MM-dd').format(plan.date),
-              'name': plan.name,
-              'amount': plan.amount,
-              'destinationAccountId': plan.destinationAccountId,
-              'destinationAccountName': plan.destinationAccountName,
-              'received': plan.received,
-            },
-        ],
-      );
+      return MapEntry(month, [
+        for (final plan in sorted)
+          <String, Object?>{
+            'id': plan.id,
+            'date': DateFormat('yyyy-MM-dd').format(plan.date),
+            'name': plan.name,
+            'amount': plan.amount,
+            'destinationAccountId': plan.destinationAccountId,
+            'destinationAccountName': plan.destinationAccountName,
+            'received': plan.received,
+          },
+      ]);
     });
   }
 

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -12,6 +12,15 @@ class AssetLiabilityPlanningService {
   static const String auPayCardAccountName = 'auPayカード';
   static const String auPayCardPaymentMethodLabel = 'auPayカード払い';
   static const String cardBillingIncludedLabel = 'カード請求に含む';
+  static const String builtInPaymentMethodSettingLabel = '\u65e2\u5b9a\u5024';
+  static const String defaultPaymentMethodSettingLabel =
+      '\u30c7\u30d5\u30a9\u30eb\u30c8';
+  static const String monthlyPaymentMethodSettingLabel =
+      '\u4eca\u6708\u3060\u3051\u4e0a\u66f8\u304d';
+  static const String saveAsDefaultPaymentMethodLabel =
+      '\u30c7\u30d5\u30a9\u30eb\u30c8\u3068\u3057\u3066\u4fdd\u5b58';
+  static const String saveAsMonthlyPaymentMethodLabel =
+      '\u4eca\u6708\u3060\u3051\u4e0a\u66f8\u304d';
   static const String auCardBillingNotice =
       'auはauPayカード払いのため、資金繰りではauPayカード請求に含めて扱います。';
   static const String kddiProviderAccountId = 'kddi_provider';
@@ -28,6 +37,7 @@ class AssetLiabilityPlanningService {
     Map<String, String> paymentSourceAccountIds = const <String, String>{},
     Map<String, String> defaultPaymentSourceAccountIds =
         const <String, String>{},
+    Map<String, String> defaultCardBillingAccountIds = const <String, String>{},
     Map<String, String> cardBillingAccountIds = const <String, String>{},
     List<AssetLiabilityIncomePlan> incomePlans =
         const <AssetLiabilityIncomePlan>[],
@@ -93,6 +103,7 @@ class AssetLiabilityPlanningService {
             monthlyPaymentOverrides: effectiveMonthlyPaymentOverrides,
             paidAccountNames: paidAccountNames,
             paymentSourceAccountIds: effectivePaymentSourceAccountIds,
+            defaultCardBillingAccountIds: defaultCardBillingAccountIds,
             cardBillingAccountIds: cardBillingAccountIds,
             accountsById: accountsById,
           ),
@@ -142,10 +153,9 @@ class AssetLiabilityPlanningService {
       0,
       (sum, plan) => plan.received ? sum : sum + plan.amount,
     );
-    final topFourDebtTotal = debtMasterRows.take(4).fold<double>(
-          0,
-          (sum, row) => sum + row.balance.abs(),
-        );
+    final topFourDebtTotal = debtMasterRows
+        .take(4)
+        .fold<double>(0, (sum, row) => sum + row.balance.abs());
     final manualPaymentCount =
         directDebtRows.where((row) => !row.paymentAmountEstimated).length;
     final estimatedPaymentCount =
@@ -236,67 +246,31 @@ class AssetLiabilityPlanningService {
       );
     }
     if (_containsAll(key, const <String>['アコム', 'ローン'])) {
-      return _consumerFinance(
-        name: name,
-        balance: balance,
-        paymentDay: 8,
-      );
+      return _consumerFinance(name: name, balance: balance, paymentDay: 8);
     }
     if (_containsAny(key, const <String>['モビット', 'mobit'])) {
-      return _consumerFinance(
-        name: name,
-        balance: balance,
-        paymentDay: 15,
-      );
+      return _consumerFinance(name: name, balance: balance, paymentDay: 15);
     }
     if (_containsAny(key, const <String>['じぶん', 'jibun'])) {
-      return _bankLoan(
-        name: name,
-        balance: balance,
-        paymentDay: 27,
-      );
+      return _bankLoan(name: name, balance: balance, paymentDay: 27);
     }
     if (_accountIdForName(name) == 'smbc_card_loan') {
-      return _bankLoan(
-        name: name,
-        balance: balance,
-        paymentDay: 15,
-      );
+      return _bankLoan(name: name, balance: balance, paymentDay: 15);
     }
     if (_containsAll(key, const <String>['三井住友', 'cl'])) {
-      return _bankLoan(
-        name: name,
-        balance: balance,
-        paymentDay: 15,
-      );
+      return _bankLoan(name: name, balance: balance, paymentDay: 15);
     }
     if (_containsAny(key, const <String>['横浜銀行'])) {
-      return _bankLoan(
-        name: name,
-        balance: balance,
-        paymentDay: 15,
-      );
+      return _bankLoan(name: name, balance: balance, paymentDay: 15);
     }
     if (_containsAny(key, const <String>['aupay', 'aupayカード'])) {
-      return _creditCard(
-        name: name,
-        balance: balance,
-        paymentDay: 10,
-      );
+      return _creditCard(name: name, balance: balance, paymentDay: 10);
     }
     if (_containsAny(key, const <String>['paypay'])) {
-      return _creditCard(
-        name: name,
-        balance: balance,
-        paymentDay: 27,
-      );
+      return _creditCard(name: name, balance: balance, paymentDay: 27);
     }
     if (_containsAny(key, const <String>['ファミペイ', 'famipay'])) {
-      return _creditCard(
-        name: name,
-        balance: balance,
-        paymentDay: 27,
-      );
+      return _creditCard(name: name, balance: balance, paymentDay: 27);
     }
     if (_accountIdForName(name) == kddiProviderAccountId) {
       return _liability(
@@ -328,18 +302,10 @@ class AssetLiabilityPlanningService {
       );
     }
     if (_containsAny(key, const <String>['カード', 'card', 'クレカ'])) {
-      return _creditCard(
-        name: name,
-        balance: balance,
-        paymentDay: null,
-      );
+      return _creditCard(name: name, balance: balance, paymentDay: null);
     }
     if (_containsAny(key, const <String>['ローン', 'loan', '銀行'])) {
-      return _bankLoan(
-        name: name,
-        balance: balance,
-        paymentDay: null,
-      );
+      return _bankLoan(name: name, balance: balance, paymentDay: null);
     }
 
     return _liability(
@@ -409,6 +375,8 @@ class AssetLiabilityPlanningService {
     AssetLiabilityPaymentMethod paymentMethod =
         AssetLiabilityPaymentMethod.direct,
     String? paymentMethodLabel,
+    AssetLiabilityPaymentMethodSettingSource paymentMethodSettingSource =
+        AssetLiabilityPaymentMethodSettingSource.builtInDefault,
     String? billingAccountId,
     String? billingAccountName,
     bool includedInBillingAccount = false,
@@ -424,6 +392,7 @@ class AssetLiabilityPlanningService {
       paymentDay: paymentDay,
       paymentMethod: resolvedPaymentMethod,
       paymentMethodLabel: paymentMethodLabel,
+      paymentMethodSettingSource: paymentMethodSettingSource,
       billingAccountId: billingAccountId,
       billingAccountName: billingAccountName,
       includedInBillingAccount:
@@ -441,6 +410,7 @@ class AssetLiabilityPlanningService {
     required Map<String, double> monthlyPaymentOverrides,
     required Set<String> paidAccountNames,
     required Map<String, String> paymentSourceAccountIds,
+    required Map<String, String> defaultCardBillingAccountIds,
     required Map<String, String> cardBillingAccountIds,
     required Map<String, AssetLiabilityAccount> accountsById,
   }) {
@@ -468,6 +438,7 @@ class AssetLiabilityPlanningService {
         : accountsById[paymentSourceAccountId]?.name;
     final paymentRouting = _paymentRoutingFor(
       account: account,
+      defaultCardBillingAccountIds: defaultCardBillingAccountIds,
       cardBillingAccountIds: cardBillingAccountIds,
       accountsById: accountsById,
     );
@@ -482,6 +453,7 @@ class AssetLiabilityPlanningService {
       paymentSourceAccountName: paymentSourceAccountName,
       paymentMethod: paymentRouting.paymentMethod,
       paymentMethodLabel: paymentRouting.paymentMethodLabel,
+      paymentMethodSettingSource: paymentRouting.paymentMethodSettingSource,
       billingAccountId: paymentRouting.billingAccountId,
       billingAccountName: paymentRouting.billingAccountName,
       includedInBillingAccount: paymentRouting.includedInBillingAccount,
@@ -504,16 +476,21 @@ class AssetLiabilityPlanningService {
 
   _AssetLiabilityPaymentRouting _paymentRoutingFor({
     required AssetLiabilityAccount account,
+    required Map<String, String> defaultCardBillingAccountIds,
     required Map<String, String> cardBillingAccountIds,
     required Map<String, AssetLiabilityAccount> accountsById,
   }) {
-    final configuredBillingAccountId = _configuredBillingAccountIdFor(
+    final configuredBillingAccount = _configuredBillingAccountFor(
       account: account,
+      defaultCardBillingAccountIds: defaultCardBillingAccountIds,
       cardBillingAccountIds: cardBillingAccountIds,
     );
+    final configuredBillingAccountId = configuredBillingAccount?.accountId;
     if (configuredBillingAccountId == directPaymentMethodId) {
-      return const _AssetLiabilityPaymentRouting(
+      return _AssetLiabilityPaymentRouting(
         paymentMethod: AssetLiabilityPaymentMethod.direct,
+        paymentMethodSettingSource: configuredBillingAccount?.source ??
+            AssetLiabilityPaymentMethodSettingSource.builtInDefault,
       );
     }
 
@@ -538,9 +515,41 @@ class AssetLiabilityPlanningService {
     return _AssetLiabilityPaymentRouting(
       paymentMethod: AssetLiabilityPaymentMethod.includedInCard,
       paymentMethodLabel: paymentMethodLabel,
+      paymentMethodSettingSource: configuredBillingAccount?.source ??
+          AssetLiabilityPaymentMethodSettingSource.builtInDefault,
       billingAccountId: billingAccountId,
       billingAccountName: billingAccountName,
     );
+  }
+
+  _ConfiguredCardBillingAccount? _configuredBillingAccountFor({
+    required AssetLiabilityAccount account,
+    required Map<String, String> defaultCardBillingAccountIds,
+    required Map<String, String> cardBillingAccountIds,
+  }) {
+    final monthlyAccountId = _configuredBillingAccountIdFor(
+      account: account,
+      cardBillingAccountIds: cardBillingAccountIds,
+    );
+    if (monthlyAccountId != null) {
+      return _ConfiguredCardBillingAccount(
+        accountId: monthlyAccountId,
+        source: AssetLiabilityPaymentMethodSettingSource.monthlyOverride,
+      );
+    }
+
+    final defaultAccountId = _configuredBillingAccountIdFor(
+      account: account,
+      cardBillingAccountIds: defaultCardBillingAccountIds,
+    );
+    if (defaultAccountId != null) {
+      return _ConfiguredCardBillingAccount(
+        accountId: defaultAccountId,
+        source: AssetLiabilityPaymentMethodSettingSource.defaultSetting,
+      );
+    }
+
+    return null;
   }
 
   String? _configuredBillingAccountIdFor({
@@ -554,6 +563,19 @@ class AssetLiabilityPlanningService {
       }
     }
     return null;
+  }
+
+  static String paymentMethodSettingSourceLabel(
+    AssetLiabilityPaymentMethodSettingSource source,
+  ) {
+    return switch (source) {
+      AssetLiabilityPaymentMethodSettingSource.builtInDefault =>
+        builtInPaymentMethodSettingLabel,
+      AssetLiabilityPaymentMethodSettingSource.defaultSetting =>
+        defaultPaymentMethodSettingLabel,
+      AssetLiabilityPaymentMethodSettingSource.monthlyOverride =>
+        monthlyPaymentMethodSettingLabel,
+    };
   }
 
   String? _billingAccountNameFor({
@@ -594,11 +616,7 @@ class AssetLiabilityPlanningService {
       final day = entry.key;
       final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
       final resolvedDay = day.clamp(1, lastDay).toInt();
-      final paymentDate = DateTime(
-        baseDate.year,
-        baseDate.month,
-        resolvedDay,
-      );
+      final paymentDate = DateTime(baseDate.year, baseDate.month, resolvedDay);
       final rowsForDay = entry.value
         ..sort((a, b) => b.balance.abs().compareTo(a.balance.abs()));
       result.add(
@@ -663,6 +681,8 @@ class AssetLiabilityPlanningService {
           destinationAccountName: plan.destinationAccountName,
           paymentMethod: AssetLiabilityPaymentMethod.direct,
           paymentMethodLabel: null,
+          paymentMethodSettingSource:
+              AssetLiabilityPaymentMethodSettingSource.builtInDefault,
           billingAccountId: null,
           billingAccountName: null,
           includedInBillingAccount: false,
@@ -681,11 +701,7 @@ class AssetLiabilityPlanningService {
     for (final row in rows.where((row) => row.paymentDay != null)) {
       final paymentDay = row.paymentDay!;
       final resolvedDay = paymentDay.clamp(1, lastDay).toInt();
-      final paymentDate = DateTime(
-        baseDate.year,
-        baseDate.month,
-        resolvedDay,
-      );
+      final paymentDate = DateTime(baseDate.year, baseDate.month, resolvedDay);
       final overdue = row.isDirectCashflowTarget &&
           !row.paid &&
           !paymentDate.isAfter(_dateOnly(baseDate));
@@ -704,6 +720,7 @@ class AssetLiabilityPlanningService {
               : null,
           paymentMethod: row.paymentMethod,
           paymentMethodLabel: row.paymentMethodLabel,
+          paymentMethodSettingSource: row.paymentMethodSettingSource,
           billingAccountId: row.billingAccountId,
           billingAccountName: row.billingAccountName,
           includedInBillingAccount: row.includedInBillingAccount,
@@ -754,6 +771,7 @@ class AssetLiabilityPlanningService {
             destinationAccountName: row.destinationAccountName,
             paymentMethod: row.paymentMethod,
             paymentMethodLabel: row.paymentMethodLabel,
+            paymentMethodSettingSource: row.paymentMethodSettingSource,
             billingAccountId: row.billingAccountId,
             billingAccountName: row.billingAccountName,
             includedInBillingAccount: row.includedInBillingAccount,
@@ -917,20 +935,14 @@ class AssetLiabilityPlanningService {
     return null;
   }
 
-  int _compareAccounts(
-    AssetLiabilityAccount a,
-    AssetLiabilityAccount b,
-  ) {
+  int _compareAccounts(AssetLiabilityAccount a, AssetLiabilityAccount b) {
     if (a.isAsset != b.isAsset) {
       return a.isAsset ? -1 : 1;
     }
     return b.balance.abs().compareTo(a.balance.abs());
   }
 
-  int _compareDebtPriority(
-    AssetLiabilityDebtRow a,
-    AssetLiabilityDebtRow b,
-  ) {
+  int _compareDebtPriority(AssetLiabilityDebtRow a, AssetLiabilityDebtRow b) {
     final rate = b.annualRate.compareTo(a.annualRate);
     if (rate != 0) {
       return rate;
@@ -953,10 +965,11 @@ class AssetLiabilityPlanningService {
     if (_containsAny(key, const <String>['じぶん', 'jibun'])) {
       return 'jibun_bank_card_loan';
     }
-    if (_containsAny(
-          key,
-          const <String>['smbcカードローン', 'smbccardloan', 'smbccl'],
-        ) ||
+    if (_containsAny(key, const <String>[
+          'smbcカードローン',
+          'smbccardloan',
+          'smbccl',
+        ]) ||
         _containsAll(key, const <String>['三井住友', 'cl']) ||
         _containsAll(key, const <String>['三井住友', 'カードローン'])) {
       return 'smbc_card_loan';
@@ -1109,16 +1122,29 @@ class AssetLiabilityPlanningService {
 class _AssetLiabilityPaymentRouting {
   final AssetLiabilityPaymentMethod paymentMethod;
   final String? paymentMethodLabel;
+  final AssetLiabilityPaymentMethodSettingSource paymentMethodSettingSource;
   final String? billingAccountId;
   final String? billingAccountName;
 
   const _AssetLiabilityPaymentRouting({
     required this.paymentMethod,
     this.paymentMethodLabel,
+    this.paymentMethodSettingSource =
+        AssetLiabilityPaymentMethodSettingSource.builtInDefault,
     this.billingAccountId,
     this.billingAccountName,
   });
 
   bool get includedInBillingAccount =>
       paymentMethod == AssetLiabilityPaymentMethod.includedInCard;
+}
+
+class _ConfiguredCardBillingAccount {
+  final String accountId;
+  final AssetLiabilityPaymentMethodSettingSource source;
+
+  const _ConfiguredCardBillingAccount({
+    required this.accountId,
+    required this.source,
+  });
 }

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -182,6 +182,10 @@ abstract class AssetLiabilityRepository {
 
   Future<void> saveDefaultPaymentSources(Map<String, String> sources);
 
+  Future<Map<String, String>> loadDefaultCardBillingAccounts();
+
+  Future<void> saveDefaultCardBillingAccounts(Map<String, String> accounts);
+
   Future<List<AssetLiabilityRecurringIncomeTemplate>>
       loadRecurringIncomeTemplates();
 
@@ -214,6 +218,7 @@ abstract class AssetLiabilityRepository {
       monthKey: AssetLiabilityMonthlyStateStore.formatMonthKey(month),
       monthlyState: await loadMonth(month),
       defaultPaymentSourceAccountIds: await loadDefaultPaymentSources(),
+      defaultCardBillingAccountIds: await loadDefaultCardBillingAccounts(),
       recurringIncomeTemplates: await loadRecurringIncomeTemplates(),
       monthlySnapshots: await loadMonthlySnapshots(),
     );
@@ -241,6 +246,15 @@ abstract class AssetLiabilityRemoteStore {
   Future<void> saveDefaultPaymentSources({
     required String userId,
     required Map<String, String> sources,
+  });
+
+  Future<Map<String, String>?> loadDefaultCardBillingAccounts({
+    required String userId,
+  });
+
+  Future<void> saveDefaultCardBillingAccounts({
+    required String userId,
+    required Map<String, String> accounts,
   });
 
   Future<List<AssetLiabilityRecurringIncomeTemplate>?>
@@ -394,6 +408,56 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
     }
     await _tryRemote(
       () => remote.saveDefaultPaymentSources(userId: userId, sources: sources),
+    );
+  }
+
+  @override
+  Future<Map<String, String>> loadDefaultCardBillingAccounts() async {
+    final local = await localRepository.loadDefaultCardBillingAccounts();
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return local;
+    }
+
+    final remoteAccounts = await _tryRemote(
+      () => remote.loadDefaultCardBillingAccounts(userId: userId),
+    );
+    if (remoteAccounts == null || remoteAccounts.isEmpty) {
+      if (local.isNotEmpty) {
+        await _tryRemote(
+          () => remote.saveDefaultCardBillingAccounts(
+            userId: userId,
+            accounts: local,
+          ),
+        );
+      }
+      return local;
+    }
+
+    if (local.isEmpty) {
+      await localRepository.saveDefaultCardBillingAccounts(remoteAccounts);
+      return remoteAccounts;
+    }
+
+    return local;
+  }
+
+  @override
+  Future<void> saveDefaultCardBillingAccounts(
+    Map<String, String> accounts,
+  ) async {
+    await localRepository.saveDefaultCardBillingAccounts(accounts);
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return;
+    }
+    await _tryRemote(
+      () => remote.saveDefaultCardBillingAccounts(
+        userId: userId,
+        accounts: accounts,
+      ),
     );
   }
 
@@ -568,6 +632,20 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
         restored++;
       }
 
+      if (syncData.localDefaultCardBillingAccounts.isNotEmpty) {
+        await remote.saveDefaultCardBillingAccounts(
+          userId: userId,
+          accounts: syncData.localDefaultCardBillingAccounts,
+        );
+        uploaded++;
+      } else if (syncData.remoteDefaultCardBillingAccounts?.isNotEmpty ??
+          false) {
+        await localRepository.saveDefaultCardBillingAccounts(
+          syncData.remoteDefaultCardBillingAccounts!,
+        );
+        restored++;
+      }
+
       if (syncData.localTemplates.isNotEmpty) {
         await remote.saveRecurringIncomeTemplates(
           userId: userId,
@@ -658,10 +736,14 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
     return _AssetLiabilitySyncData(
       localMonth: await localRepository.loadMonth(month),
       localSources: await localRepository.loadDefaultPaymentSources(),
+      localDefaultCardBillingAccounts:
+          await localRepository.loadDefaultCardBillingAccounts(),
       localTemplates: await localRepository.loadRecurringIncomeTemplates(),
       localSnapshots: await localRepository.loadMonthlySnapshots(),
       remoteMonth: await remote.loadMonth(userId: userId, month: month),
       remoteSources: await remote.loadDefaultPaymentSources(userId: userId),
+      remoteDefaultCardBillingAccounts:
+          await remote.loadDefaultCardBillingAccounts(userId: userId),
       remoteTemplates: await remote.loadRecurringIncomeTemplates(
         userId: userId,
       ),
@@ -686,6 +768,14 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
         remoteHasData: data.remoteSources?.isNotEmpty ?? false,
         localCount: data.localSources.length,
         remoteCount: data.remoteSources?.length ?? 0,
+      ),
+      AssetLiabilitySyncPreviewItem(
+        targetName: 'card billing defaults',
+        localHasData: data.localDefaultCardBillingAccounts.isNotEmpty,
+        remoteHasData:
+            data.remoteDefaultCardBillingAccounts?.isNotEmpty ?? false,
+        localCount: data.localDefaultCardBillingAccounts.length,
+        remoteCount: data.remoteDefaultCardBillingAccounts?.length ?? 0,
       ),
       AssetLiabilitySyncPreviewItem(
         targetName: '定期収入テンプレート',
@@ -727,20 +817,24 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
 class _AssetLiabilitySyncData {
   final AssetLiabilityMonthlyState localMonth;
   final Map<String, String> localSources;
+  final Map<String, String> localDefaultCardBillingAccounts;
   final List<AssetLiabilityRecurringIncomeTemplate> localTemplates;
   final List<AssetLiabilityMonthlySnapshot> localSnapshots;
   final AssetLiabilityMonthlyState? remoteMonth;
   final Map<String, String>? remoteSources;
+  final Map<String, String>? remoteDefaultCardBillingAccounts;
   final List<AssetLiabilityRecurringIncomeTemplate>? remoteTemplates;
   final List<AssetLiabilityMonthlySnapshot>? remoteSnapshots;
 
   const _AssetLiabilitySyncData({
     required this.localMonth,
     required this.localSources,
+    required this.localDefaultCardBillingAccounts,
     required this.localTemplates,
     required this.localSnapshots,
     required this.remoteMonth,
     required this.remoteSources,
+    required this.remoteDefaultCardBillingAccounts,
     required this.remoteTemplates,
     required this.remoteSnapshots,
   });
@@ -801,6 +895,7 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
         'payment_overrides': row['payment_overrides'],
         'paid_account_ids': row['paid_account_ids'],
         'payment_source_account_ids': row['payment_source_account_ids'],
+        'card_billing_account_ids': row['card_billing_account_ids'],
       },
     );
     await _upsertPayloadRow(
@@ -835,15 +930,54 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
   }) async {
     final row = AssetLiabilityUserSettingsPayload(
       defaultPaymentSourceAccountIds: sources,
+      defaultCardBillingAccountIds: const <String, String>{},
       recurringIncomeTemplates: const <AssetLiabilityRecurringIncomeTemplate>[],
     ).toSupabaseJson(userId: userId);
-    await _upsertPayloadRow(
+    await _upsertMergedPayloadRow(
       AssetLiabilitySupabaseTablePlan.paymentSourceSettingsTable,
       userId: userId,
       monthKey: AssetLiabilitySupabaseTablePlan.globalMonthKey,
       payload: <String, Object?>{
         'default_payment_source_account_ids':
             row['default_payment_source_account_ids'],
+      },
+    );
+  }
+
+  @override
+  Future<Map<String, String>?> loadDefaultCardBillingAccounts({
+    required String userId,
+  }) async {
+    final payload = await _loadPayloadRow(
+      AssetLiabilitySupabaseTablePlan.paymentSourceSettingsTable,
+      userId: userId,
+      monthKey: AssetLiabilitySupabaseTablePlan.globalMonthKey,
+    );
+    if (payload == null) {
+      return null;
+    }
+    return AssetLiabilityUserSettingsPayload.fromSupabaseJson(
+      payload,
+    ).defaultCardBillingAccountIds;
+  }
+
+  @override
+  Future<void> saveDefaultCardBillingAccounts({
+    required String userId,
+    required Map<String, String> accounts,
+  }) async {
+    final row = AssetLiabilityUserSettingsPayload(
+      defaultPaymentSourceAccountIds: const <String, String>{},
+      defaultCardBillingAccountIds: accounts,
+      recurringIncomeTemplates: const <AssetLiabilityRecurringIncomeTemplate>[],
+    ).toSupabaseJson(userId: userId);
+    await _upsertMergedPayloadRow(
+      AssetLiabilitySupabaseTablePlan.paymentSourceSettingsTable,
+      userId: userId,
+      monthKey: AssetLiabilitySupabaseTablePlan.globalMonthKey,
+      payload: <String, Object?>{
+        'default_card_billing_account_ids':
+            row['default_card_billing_account_ids'],
       },
     );
   }
@@ -871,6 +1005,7 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
   }) async {
     final row = AssetLiabilityUserSettingsPayload(
       defaultPaymentSourceAccountIds: const <String, String>{},
+      defaultCardBillingAccountIds: const <String, String>{},
       recurringIncomeTemplates: templates,
     ).toSupabaseJson(userId: userId);
     await _upsertPayloadRow(
@@ -962,6 +1097,23 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
     );
   }
 
+  Future<void> _upsertMergedPayloadRow(
+    String table, {
+    required String userId,
+    required String monthKey,
+    required Map<String, Object?> payload,
+  }) async {
+    final current =
+        await _loadPayloadRow(table, userId: userId, monthKey: monthKey) ??
+            const <String, Object?>{};
+    await _upsertPayloadRow(
+      table,
+      userId: userId,
+      monthKey: monthKey,
+      payload: <String, Object?>{...current, ...payload},
+    );
+  }
+
   Map<String, Object?>? _payloadFromRow(Map<dynamic, dynamic> row) {
     final payload = row['payload'];
     if (payload is Map) {
@@ -1002,6 +1154,16 @@ class SharedPreferencesAssetLiabilityRepository
   @override
   Future<void> saveDefaultPaymentSources(Map<String, String> sources) {
     return store.saveDefaultPaymentSources(sources);
+  }
+
+  @override
+  Future<Map<String, String>> loadDefaultCardBillingAccounts() {
+    return store.loadDefaultCardBillingAccounts();
+  }
+
+  @override
+  Future<void> saveDefaultCardBillingAccounts(Map<String, String> accounts) {
+    return store.saveDefaultCardBillingAccounts(accounts);
   }
 
   @override

--- a/test/services/asset_liability_history_service_test.dart
+++ b/test/services/asset_liability_history_service_test.dart
@@ -226,13 +226,18 @@ void main() {
         csv,
         contains(AssetLiabilityPlanningService.auPayCardPaymentMethodLabel),
       );
-      expect(
-        csv,
-        contains(AssetLiabilityPlanningService.auPayCardAccountName),
-      );
+      expect(csv, contains(AssetLiabilityPlanningService.auPayCardAccountName));
       expect(
         csv,
         contains(AssetLiabilityPlanningService.cardBillingIncludedLabel),
+      );
+      expect(
+        csv,
+        contains(
+          AssetLiabilityPlanningService.paymentMethodSettingSourceLabel(
+            AssetLiabilityPaymentMethodSettingSource.builtInDefault,
+          ),
+        ),
       );
       expect(csv, contains('直接差し引き対象'));
     });

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -15,18 +16,12 @@ void main() {
       await store.saveMonth(
         month: DateTime(2026, 5, 13),
         state: AssetLiabilityMonthlyState(
-          paymentOverrides: const <String, double>{
-            'モビット': 70000,
-          },
-          paidAccountNames: const <String>{
-            'auPayカード',
-          },
+          paymentOverrides: const <String, double>{'モビット': 70000},
+          paidAccountNames: const <String>{'auPayカード'},
           paymentSourceAccountIds: const <String, String>{
             'mobit': 'custom_bank',
           },
-          cardBillingAccountIds: const <String, String>{
-            'au': 'aupay_card',
-          },
+          cardBillingAccountIds: const <String, String>{'au': 'aupay_card'},
           incomePlans: <AssetLiabilityIncomePlan>[
             AssetLiabilityIncomePlan(
               id: 'income_salary',
@@ -68,48 +63,38 @@ void main() {
       expect(decoded['モビット'], 70000);
     });
 
-    test('falls back to estimated payment after manual amount is cleared',
-        () async {
-      await store.saveMonth(
-        month: DateTime(2026, 5, 13),
-        state: const AssetLiabilityMonthlyState(
-          paymentOverrides: <String, double>{
-            'モビット': 70000,
-          },
-          paymentSourceAccountIds: <String, String>{
-            'mobit': 'custom_bank',
-          },
-          cardBillingAccountIds: <String, String>{
-            'au': 'aupay_card',
-          },
-        ),
-      );
-      await store.saveMonth(
-        month: DateTime(2026, 5, 13),
-        state: const AssetLiabilityMonthlyState(),
-      );
+    test(
+      'falls back to estimated payment after manual amount is cleared',
+      () async {
+        await store.saveMonth(
+          month: DateTime(2026, 5, 13),
+          state: const AssetLiabilityMonthlyState(
+            paymentOverrides: <String, double>{'モビット': 70000},
+            paymentSourceAccountIds: <String, String>{'mobit': 'custom_bank'},
+            cardBillingAccountIds: <String, String>{'au': 'aupay_card'},
+          ),
+        );
+        await store.saveMonth(
+          month: DateTime(2026, 5, 13),
+          state: const AssetLiabilityMonthlyState(),
+        );
 
-      final loaded = await store.loadMonth(DateTime(2026, 5, 13));
+        final loaded = await store.loadMonth(DateTime(2026, 5, 13));
 
-      expect(loaded.paymentOverrides, isEmpty);
-      expect(loaded.paidAccountNames, isEmpty);
-      expect(loaded.paymentSourceAccountIds, isEmpty);
-      expect(loaded.cardBillingAccountIds, isEmpty);
-      expect(loaded.incomePlans, isEmpty);
-    });
+        expect(loaded.paymentOverrides, isEmpty);
+        expect(loaded.paidAccountNames, isEmpty);
+        expect(loaded.paymentSourceAccountIds, isEmpty);
+        expect(loaded.cardBillingAccountIds, isEmpty);
+        expect(loaded.incomePlans, isEmpty);
+      },
+    );
 
     test('migrates legacy display-name keys to stable account ids', () {
       final migrated = AssetLiabilityMonthlyStateStore.migrateLegacyKeys(
         state: const AssetLiabilityMonthlyState(
-          paymentOverrides: <String, double>{
-            'モビット': 70000,
-          },
-          paidAccountNames: <String>{
-            'auPayカード',
-          },
-          paymentSourceAccountIds: <String, String>{
-            'モビット': '銀行口座',
-          },
+          paymentOverrides: <String, double>{'モビット': 70000},
+          paidAccountNames: <String>{'auPayカード'},
+          paymentSourceAccountIds: <String, String>{'モビット': '銀行口座'},
         ),
         legacyKeyToAccountId: const <String, String>{
           'モビット': 'mobit',
@@ -143,58 +128,56 @@ void main() {
       });
     });
 
-    test('copies previous month settings without paid or received state',
-        () async {
-      await store.saveMonth(
-        month: DateTime(2026, 5, 13),
-        state: AssetLiabilityMonthlyState(
-          paymentOverrides: const <String, double>{
-            'mobit': 70000,
-          },
-          paidAccountNames: const <String>{
-            'mobit',
-          },
-          paymentSourceAccountIds: const <String, String>{
-            'mobit': 'custom_bank',
-          },
-          cardBillingAccountIds: const <String, String>{
-            'kddi_provider': 'paypay_card',
-          },
-          incomePlans: <AssetLiabilityIncomePlan>[
-            AssetLiabilityIncomePlan(
-              id: 'salary',
-              date: DateTime(2026, 5, 31),
-              name: 'Salary',
-              amount: 250000,
-              destinationAccountId: 'custom_bank',
-              destinationAccountName: 'Bank',
-              received: true,
-            ),
-          ],
-        ),
-      );
+    test(
+      'copies previous month settings without paid or received state',
+      () async {
+        await store.saveMonth(
+          month: DateTime(2026, 5, 13),
+          state: AssetLiabilityMonthlyState(
+            paymentOverrides: const <String, double>{'mobit': 70000},
+            paidAccountNames: const <String>{'mobit'},
+            paymentSourceAccountIds: const <String, String>{
+              'mobit': 'custom_bank',
+            },
+            cardBillingAccountIds: const <String, String>{
+              'kddi_provider': 'paypay_card',
+            },
+            incomePlans: <AssetLiabilityIncomePlan>[
+              AssetLiabilityIncomePlan(
+                id: 'salary',
+                date: DateTime(2026, 5, 31),
+                name: 'Salary',
+                amount: 250000,
+                destinationAccountId: 'custom_bank',
+                destinationAccountName: 'Bank',
+                received: true,
+              ),
+            ],
+          ),
+        );
 
-      final copied = await store.copyPreviousMonthToMonth(
-        DateTime(2026, 6, 10),
-      );
-      final loaded = await store.loadMonth(DateTime(2026, 6, 20));
+        final copied = await store.copyPreviousMonthToMonth(
+          DateTime(2026, 6, 10),
+        );
+        final loaded = await store.loadMonth(DateTime(2026, 6, 20));
 
-      expect(copied.paymentOverrides, <String, double>{'mobit': 70000});
-      expect(copied.paymentSourceAccountIds, <String, String>{
-        'mobit': 'custom_bank',
-      });
-      expect(copied.cardBillingAccountIds, <String, String>{
-        'kddi_provider': 'paypay_card',
-      });
-      expect(copied.paidAccountNames, isEmpty);
-      expect(copied.incomePlans.single.date, DateTime(2026, 6, 30));
-      expect(copied.incomePlans.single.received, isFalse);
-      expect(loaded.paidAccountNames, isEmpty);
-      expect(loaded.cardBillingAccountIds, <String, String>{
-        'kddi_provider': 'paypay_card',
-      });
-      expect(loaded.incomePlans.single.received, isFalse);
-    });
+        expect(copied.paymentOverrides, <String, double>{'mobit': 70000});
+        expect(copied.paymentSourceAccountIds, <String, String>{
+          'mobit': 'custom_bank',
+        });
+        expect(copied.cardBillingAccountIds, <String, String>{
+          'kddi_provider': 'paypay_card',
+        });
+        expect(copied.paidAccountNames, isEmpty);
+        expect(copied.incomePlans.single.date, DateTime(2026, 6, 30));
+        expect(copied.incomePlans.single.received, isFalse);
+        expect(loaded.paidAccountNames, isEmpty);
+        expect(loaded.cardBillingAccountIds, <String, String>{
+          'kddi_provider': 'paypay_card',
+        });
+        expect(loaded.incomePlans.single.received, isFalse);
+      },
+    );
 
     test('saves and restores default payment source accounts', () async {
       await store.saveDefaultPaymentSources(const <String, String>{
@@ -207,6 +190,20 @@ void main() {
       expect(loaded, <String, String>{
         'mobit': 'custom_bank',
         'acom_card_loan': 'wallet_cash',
+      });
+    });
+
+    test('saves and restores default card billing accounts', () async {
+      await store.saveDefaultCardBillingAccounts(const <String, String>{
+        'kddi_provider': 'paypay_card',
+        'au': AssetLiabilityPlanningService.auPayCardAccountId,
+      });
+
+      final loaded = await store.loadDefaultCardBillingAccounts();
+
+      expect(loaded, <String, String>{
+        'kddi_provider': 'paypay_card',
+        'au': AssetLiabilityPlanningService.auPayCardAccountId,
       });
     });
 

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -87,9 +87,7 @@ void main() {
       final workbook = service.buildWorkbook(
         latestSnapshot: snapshot,
         baseDate: DateTime(2026, 5, 12),
-        monthlyPaymentOverrides: const <String, double>{
-          'モビット': 70000,
-        },
+        monthlyPaymentOverrides: const <String, double>{'モビット': 70000},
       );
       final mobit = workbook.debtMasterRows.firstWhere(
         (row) => row.name == 'モビット',
@@ -145,9 +143,7 @@ void main() {
       final workbook = service.buildWorkbook(
         latestSnapshot: snapshot,
         baseDate: DateTime(2026, 5, 12),
-        monthlyPaymentOverrides: const <String, double>{
-          'PayPayカード': 0,
-        },
+        monthlyPaymentOverrides: const <String, double>{'PayPayカード': 0},
       );
 
       final payPay = workbook.debtMasterRows.firstWhere(
@@ -163,9 +159,7 @@ void main() {
       final workbook = service.buildWorkbook(
         latestSnapshot: snapshot,
         baseDate: DateTime(2026, 5, 12),
-        monthlyPaymentOverrides: const <String, double>{
-          'モビット': 70000,
-        },
+        monthlyPaymentOverrides: const <String, double>{'モビット': 70000},
       );
 
       final risk15 = workbook.paymentDayRisks.firstWhere(
@@ -198,9 +192,7 @@ void main() {
           'モビット': -20000,
         },
         baseDate: DateTime(2026, 5, 1),
-        paidAccountNames: const <String>{
-          'auPayカード',
-        },
+        paidAccountNames: const <String>{'auPayカード'},
       );
 
       final auPay = workbook.debtMasterRows.firstWhere(
@@ -256,9 +248,10 @@ void main() {
           au.billingAccountId,
           AssetLiabilityPlanningService.auPayCardAccountId,
         );
+        expect(au.paymentMethod, AssetLiabilityPaymentMethod.includedInCard);
         expect(
-          au.paymentMethod,
-          AssetLiabilityPaymentMethod.includedInCard,
+          au.paymentMethodSettingSource,
+          AssetLiabilityPaymentMethodSettingSource.builtInDefault,
         );
         expect(au.includedInBillingAccount, isTrue);
         expect(au.isDirectCashflowTarget, isFalse);
@@ -281,65 +274,126 @@ void main() {
       },
     );
 
-    test(
-      'allows arbitrary payment items to be included in card billing',
-      () {
-        final workbook = service.buildWorkbook(
-          latestSnapshot: <String, double>{
-            'cash': 50000,
-            'KDDI': -5764,
-            'PayPay': -20000,
-          },
-          baseDate: DateTime(2026, 5, 1),
-          monthlyPaymentOverrides: const <String, double>{
-            AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
-            'paypay_card': 20000,
-          },
-          cardBillingAccountIds: const <String, String>{
-            AssetLiabilityPlanningService.kddiProviderAccountId: 'paypay_card',
-          },
-        );
+    test('allows arbitrary payment items to be included in card billing', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'KDDI': -5764,
+          'PayPay': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+          'paypay_card': 20000,
+        },
+        cardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'paypay_card',
+        },
+      );
 
-        final kddi = workbook.debtMasterRows.firstWhere(
-          (row) =>
-              row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
-        );
-        final payPay = workbook.debtMasterRows.firstWhere(
-          (row) => row.id == 'paypay_card',
-        );
-        final kddiCashflow = workbook.cashflowRows.firstWhere(
-          (row) =>
-              row.accountId ==
-              AssetLiabilityPlanningService.kddiProviderAccountId,
-        );
+      final kddi = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
+      );
+      final payPay = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == 'paypay_card',
+      );
+      final kddiCashflow = workbook.cashflowRows.firstWhere(
+        (row) =>
+            row.accountId ==
+            AssetLiabilityPlanningService.kddiProviderAccountId,
+      );
 
-        expect(kddi.paymentMethod, AssetLiabilityPaymentMethod.includedInCard);
-        expect(kddi.billingAccountId, 'paypay_card');
-        expect(kddi.isDirectCashflowTarget, isFalse);
-        expect(payPay.isDirectCashflowTarget, isTrue);
-        expect(
-          workbook.paymentDayRisks.any((risk) => risk.paymentDay == 25),
-          isFalse,
-        );
-        expect(kddiCashflow.cashAfterPayment, kddiCashflow.cashBeforePayment);
-        expect(workbook.monthlyUnpaidPaymentTotal, 20000);
-        expect(workbook.cashAfterScheduledPayments, 30000);
-      },
-    );
+      expect(kddi.paymentMethod, AssetLiabilityPaymentMethod.includedInCard);
+      expect(kddi.billingAccountId, 'paypay_card');
+      expect(
+        kddi.paymentMethodSettingSource,
+        AssetLiabilityPaymentMethodSettingSource.monthlyOverride,
+      );
+      expect(kddi.isDirectCashflowTarget, isFalse);
+      expect(payPay.isDirectCashflowTarget, isTrue);
+      expect(
+        workbook.paymentDayRisks.any((risk) => risk.paymentDay == 25),
+        isFalse,
+      );
+      expect(kddiCashflow.cashAfterPayment, kddiCashflow.cashBeforePayment);
+      expect(workbook.monthlyUnpaidPaymentTotal, 20000);
+      expect(workbook.cashAfterScheduledPayments, 30000);
+    });
+
+    test('applies default card billing settings before built-in defaults', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'KDDI': -5764,
+          'PayPay': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+          'paypay_card': 20000,
+        },
+        defaultCardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'paypay_card',
+        },
+      );
+
+      final kddi = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
+      );
+
+      expect(kddi.paymentMethod, AssetLiabilityPaymentMethod.includedInCard);
+      expect(kddi.billingAccountId, 'paypay_card');
+      expect(
+        kddi.paymentMethodSettingSource,
+        AssetLiabilityPaymentMethodSettingSource.defaultSetting,
+      );
+      expect(kddi.isDirectCashflowTarget, isFalse);
+      expect(workbook.monthlyUnpaidPaymentTotal, 20000);
+    });
+
+    test('monthly card billing overrides default card billing settings', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'KDDI': -5764,
+          'PayPay': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+          'paypay_card': 20000,
+        },
+        defaultCardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'paypay_card',
+        },
+        cardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId:
+              AssetLiabilityPlanningService.directPaymentMethodId,
+        },
+      );
+
+      final kddi = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
+      );
+
+      expect(kddi.paymentMethod, AssetLiabilityPaymentMethod.direct);
+      expect(kddi.billingAccountId, isNull);
+      expect(
+        kddi.paymentMethodSettingSource,
+        AssetLiabilityPaymentMethodSettingSource.monthlyOverride,
+      );
+      expect(kddi.isDirectCashflowTarget, isTrue);
+      expect(workbook.monthlyUnpaidPaymentTotal, 25764);
+    });
 
     test('restores monthly state by stable id after display name changes', () {
       final workbook = service.buildWorkbook(
-        latestSnapshot: <String, double>{
-          '財布': 50000,
-          'SMBCカードローン': -100000,
-        },
+        latestSnapshot: <String, double>{'財布': 50000, 'SMBCカードローン': -100000},
         baseDate: DateTime(2026, 5, 1),
         monthlyPaymentOverrides: const <String, double>{
           'smbc_card_loan': 12345,
         },
-        paidAccountNames: const <String>{
-          'smbc_card_loan',
-        },
+        paidAccountNames: const <String>{'smbc_card_loan'},
       );
 
       final row = workbook.debtMasterRows.single;
@@ -396,10 +450,11 @@ void main() {
         },
       );
 
-      expect(
-        workbook.cashflowRows.map((row) => row.paymentDay).toList(),
-        <int>[8, 10, 15],
-      );
+      expect(workbook.cashflowRows.map((row) => row.paymentDay).toList(), <int>[
+        8,
+        10,
+        15,
+      ]);
       expect(workbook.cashflowRows[0].cashAfterPayment, 15000);
       expect(
         workbook.cashflowRows[0].riskLevel,
@@ -419,14 +474,9 @@ void main() {
 
     test('reflects unreceived income plans in chronological cashflow', () {
       final workbook = service.buildWorkbook(
-        latestSnapshot: <String, double>{
-          'cash': 10000,
-          'mobit': -100000,
-        },
+        latestSnapshot: <String, double>{'cash': 10000, 'mobit': -100000},
         baseDate: DateTime(2026, 5, 1),
-        monthlyPaymentOverrides: const <String, double>{
-          'mobit': 20000,
-        },
+        monthlyPaymentOverrides: const <String, double>{'mobit': 20000},
         incomePlans: <AssetLiabilityIncomePlan>[
           AssetLiabilityIncomePlan(
             id: 'income_salary',
@@ -455,14 +505,9 @@ void main() {
 
     test('does not double count received income plans', () {
       final workbook = service.buildWorkbook(
-        latestSnapshot: <String, double>{
-          'cash': 10000,
-          'mobit': -100000,
-        },
+        latestSnapshot: <String, double>{'cash': 10000, 'mobit': -100000},
         baseDate: DateTime(2026, 5, 1),
-        monthlyPaymentOverrides: const <String, double>{
-          'mobit': 20000,
-        },
+        monthlyPaymentOverrides: const <String, double>{'mobit': 20000},
         incomePlans: <AssetLiabilityIncomePlan>[
           AssetLiabilityIncomePlan(
             id: 'income_received',
@@ -490,12 +535,8 @@ void main() {
           'mobit': -100000,
         },
         baseDate: DateTime(2026, 5, 1),
-        monthlyPaymentOverrides: const <String, double>{
-          'mobit': 20000,
-        },
-        paymentSourceAccountIds: const <String, String>{
-          'mobit': 'custom_bank',
-        },
+        monthlyPaymentOverrides: const <String, double>{'mobit': 20000},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'custom_bank'},
         incomePlans: <AssetLiabilityIncomePlan>[
           AssetLiabilityIncomePlan(
             id: 'income_bank',
@@ -530,9 +571,7 @@ void main() {
           'mobit': -100000,
         },
         baseDate: DateTime(2026, 5, 1),
-        monthlyPaymentOverrides: const <String, double>{
-          'mobit': 20000,
-        },
+        monthlyPaymentOverrides: const <String, double>{'mobit': 20000},
         defaultPaymentSourceAccountIds: const <String, String>{
           'mobit': 'custom_bank',
         },
@@ -553,14 +592,9 @@ void main() {
 
     test('keeps unassigned income out of account-level cashflow warnings', () {
       final workbook = service.buildWorkbook(
-        latestSnapshot: <String, double>{
-          'cash': 10000,
-          'mobit': -100000,
-        },
+        latestSnapshot: <String, double>{'cash': 10000, 'mobit': -100000},
         baseDate: DateTime(2026, 5, 1),
-        monthlyPaymentOverrides: const <String, double>{
-          'mobit': 20000,
-        },
+        monthlyPaymentOverrides: const <String, double>{'mobit': 20000},
         incomePlans: <AssetLiabilityIncomePlan>[
           AssetLiabilityIncomePlan(
             id: 'income_unassigned',
@@ -591,10 +625,7 @@ void main() {
 
     test('adds KDDI provider as a separate day 25 fixed payment', () {
       final workbook = service.buildWorkbook(
-        latestSnapshot: <String, double>{
-          'cash': 50000,
-          'au': -32152,
-        },
+        latestSnapshot: <String, double>{'cash': 50000, 'au': -32152},
         baseDate: DateTime(2026, 5, 1),
         defaultPaymentSourceAccountIds: const <String, String>{
           AssetLiabilityPlanningService.kddiProviderAccountId: 'custom_cash',
@@ -602,9 +633,7 @@ void main() {
         includeDefaultFixedPayments: true,
       );
 
-      final au = workbook.debtMasterRows.firstWhere(
-        (row) => row.id == 'au',
-      );
+      final au = workbook.debtMasterRows.firstWhere((row) => row.id == 'au');
       final kddi = workbook.debtMasterRows.firstWhere(
         (row) => row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
       );
@@ -660,10 +689,7 @@ void main() {
 
     test('treats paid KDDI provider payment as reflected in cashflow', () {
       final workbook = service.buildWorkbook(
-        latestSnapshot: <String, double>{
-          'cash': 50000,
-          'au': -32152,
-        },
+        latestSnapshot: <String, double>{'cash': 50000, 'au': -32152},
         baseDate: DateTime(2026, 5, 1),
         paidAccountNames: const <String>{
           AssetLiabilityPlanningService.kddiProviderAccountId,

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -62,6 +62,9 @@ void main() {
         await repository.saveDefaultPaymentSources(const <String, String>{
           'kddi_provider': 'smbc_otsuka',
         });
+        await repository.saveDefaultCardBillingAccounts(const <String, String>{
+          'kddi_provider': 'paypay_card',
+        });
         await repository.saveRecurringIncomeTemplates(
           const <AssetLiabilityRecurringIncomeTemplate>[
             AssetLiabilityRecurringIncomeTemplate(
@@ -76,9 +79,11 @@ void main() {
         );
 
         final defaults = await repository.loadDefaultPaymentSources();
+        final cardDefaults = await repository.loadDefaultCardBillingAccounts();
         final templates = await repository.loadRecurringIncomeTemplates();
 
         expect(defaults, <String, String>{'kddi_provider': 'smbc_otsuka'});
+        expect(cardDefaults, <String, String>{'kddi_provider': 'paypay_card'});
         expect(templates.single.id, 'salary');
         expect(templates.single.destinationAccountId, 'smbc_otsuka');
       },
@@ -121,6 +126,9 @@ void main() {
       await repository.saveDefaultPaymentSources(const <String, String>{
         'mobit': 'smbc_otsuka',
       });
+      await repository.saveDefaultCardBillingAccounts(const <String, String>{
+        'kddi_provider': 'paypay_card',
+      });
       await repository.saveMonthlySnapshot(
         AssetLiabilityMonthlySnapshot(
           monthKey: '2026-05',
@@ -141,6 +149,10 @@ void main() {
       expect(snapshot.monthKey, '2026-05');
       expect(snapshot.monthlyState.paymentOverrides['mobit'], 70000);
       expect(snapshot.defaultPaymentSourceAccountIds['mobit'], 'smbc_otsuka');
+      expect(
+        snapshot.defaultCardBillingAccountIds['kddi_provider'],
+        'paypay_card',
+      );
       expect(snapshot.monthlySnapshots.single.netWorth, -7080000);
     });
 
@@ -259,46 +271,45 @@ void main() {
       final result = await repository.previewSyncMonth(month);
 
       expect(result.status, AssetLiabilityManualSyncStatus.success);
-      expect(result.targetCount, 4);
+      expect(result.targetCount, 5);
       expect(result.localDataTargetCount, 4);
       expect(result.remoteDataTargetCount, 0);
       expect(result.uploadCandidateCount, 4);
       expect(result.downloadCandidateCount, 0);
       expect(result.conflictCount, 0);
       expect(remote.monthState('2026-05'), isNull);
-      expect(
-        remote.calls,
-        isNot(contains('saveMonth:user-1:2026-05')),
-      );
+      expect(remote.calls, isNot(contains('saveMonth:user-1:2026-05')));
       expect(remote.defaultPaymentSources, isEmpty);
       expect(remote.recurringIncomeTemplates, isEmpty);
       expect(remote.monthlySnapshots, isEmpty);
     });
 
-    test('sync preview reports download candidates without restoring',
-        () async {
-      final local = _FakeAssetLiabilityRepository();
-      final remote = _RecordingAssetLiabilityRemoteStore()
-        ..seedMonth(DateTime(2026, 5), _sampleMonthlyState());
-      final repository = FeatureFlaggedAssetLiabilityRepository(
-        localRepository: local,
-        remoteStore: remote,
-        syncEnabled: true,
-        userIdProvider: () => 'user-1',
-      );
-      final month = DateTime(2026, 5);
+    test(
+      'sync preview reports download candidates without restoring',
+      () async {
+        final local = _FakeAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore()
+          ..seedMonth(DateTime(2026, 5), _sampleMonthlyState());
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
 
-      final result = await repository.previewSyncMonth(month);
-      final localState = await local.loadMonth(month);
+        final result = await repository.previewSyncMonth(month);
+        final localState = await local.loadMonth(month);
 
-      expect(result.status, AssetLiabilityManualSyncStatus.success);
-      expect(result.localDataTargetCount, 0);
-      expect(result.remoteDataTargetCount, 1);
-      expect(result.uploadCandidateCount, 0);
-      expect(result.downloadCandidateCount, 1);
-      expect(result.conflictCount, 0);
-      expect(localState.isEmpty, isTrue);
-    });
+        expect(result.status, AssetLiabilityManualSyncStatus.success);
+        expect(result.localDataTargetCount, 0);
+        expect(result.remoteDataTargetCount, 1);
+        expect(result.uploadCandidateCount, 0);
+        expect(result.downloadCandidateCount, 1);
+        expect(result.conflictCount, 0);
+        expect(localState.isEmpty, isTrue);
+      },
+    );
 
     test('sync preview reports conflicts without overwriting data', () async {
       final local = _FakeAssetLiabilityRepository();
@@ -371,6 +382,9 @@ void main() {
         await repository.saveDefaultPaymentSources(const <String, String>{
           'mobit': 'smbc_otsuka',
         });
+        await repository.saveDefaultCardBillingAccounts(const <String, String>{
+          'kddi_provider': 'paypay_card',
+        });
         await repository.saveRecurringIncomeTemplates(
           <AssetLiabilityRecurringIncomeTemplate>[
             _sampleRecurringIncomeTemplate(),
@@ -380,6 +394,10 @@ void main() {
 
         expect(remote.monthState('2026-05')?.paymentOverrides['mobit'], 70000);
         expect(remote.defaultPaymentSources['mobit'], 'smbc_otsuka');
+        expect(
+          remote.defaultCardBillingAccounts['kddi_provider'],
+          'paypay_card',
+        );
         expect(remote.recurringIncomeTemplates.single.id, 'salary');
         expect(remote.monthlySnapshots.single.monthKey, '2026-05');
       },
@@ -420,6 +438,9 @@ void main() {
       await local.saveDefaultPaymentSources(const <String, String>{
         'mobit': 'smbc_otsuka',
       });
+      await local.saveDefaultCardBillingAccounts(const <String, String>{
+        'kddi_provider': 'paypay_card',
+      });
       await local.saveRecurringIncomeTemplates(
         <AssetLiabilityRecurringIncomeTemplate>[
           _sampleRecurringIncomeTemplate(),
@@ -433,6 +454,7 @@ void main() {
       expect(result.isSuccess, isTrue);
       expect(remote.monthState('2026-05')?.paymentOverrides['mobit'], 70000);
       expect(remote.defaultPaymentSources['mobit'], 'smbc_otsuka');
+      expect(remote.defaultCardBillingAccounts['kddi_provider'], 'paypay_card');
       expect(remote.recurringIncomeTemplates.single.id, 'salary');
       expect(remote.monthlySnapshots.single.monthKey, '2026-05');
     });
@@ -457,38 +479,40 @@ void main() {
       expect(remote.calls, contains('saveMonth:user-1:2026-05'));
     });
 
-    test('manual sync detects conflict without overwriting either side',
-        () async {
-      final local = _FakeAssetLiabilityRepository();
-      final remote = _RecordingAssetLiabilityRemoteStore()
-        ..seedMonth(
-          DateTime(2026, 5),
-          const AssetLiabilityMonthlyState(
-            paymentOverrides: <String, double>{'remote_only': 1000},
-          ),
+    test(
+      'manual sync detects conflict without overwriting either side',
+      () async {
+        final local = _FakeAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore()
+          ..seedMonth(
+            DateTime(2026, 5),
+            const AssetLiabilityMonthlyState(
+              paymentOverrides: <String, double>{'remote_only': 1000},
+            ),
+          );
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          userIdProvider: () => 'user-1',
         );
-      final repository = FeatureFlaggedAssetLiabilityRepository(
-        localRepository: local,
-        remoteStore: remote,
-        syncEnabled: true,
-        userIdProvider: () => 'user-1',
-      );
-      final month = DateTime(2026, 5);
-      await local.saveMonth(month: month, state: _sampleMonthlyState());
+        final month = DateTime(2026, 5);
+        await local.saveMonth(month: month, state: _sampleMonthlyState());
 
-      final result = await repository.syncMonth(month);
-      final localState = await local.loadMonth(month);
+        final result = await repository.syncMonth(month);
+        final localState = await local.loadMonth(month);
 
-      expect(result.status, AssetLiabilityManualSyncStatus.conflict);
-      expect(result.hasConflict, isTrue);
-      expect(result.conflictTargets, contains('月次状態'));
-      expect(localState.paymentOverrides['mobit'], 70000);
-      expect(
-        remote.monthState('2026-05')?.paymentOverrides['remote_only'],
-        1000,
-      );
-      expect(remote.calls, isNot(contains('saveMonth:user-1:2026-05')));
-    });
+        expect(result.status, AssetLiabilityManualSyncStatus.conflict);
+        expect(result.hasConflict, isTrue);
+        expect(result.conflictTargets, contains('月次状態'));
+        expect(localState.paymentOverrides['mobit'], 70000);
+        expect(
+          remote.monthState('2026-05')?.paymentOverrides['remote_only'],
+          1000,
+        );
+        expect(remote.calls, isNot(contains('saveMonth:user-1:2026-05')));
+      },
+    );
 
     test('uploads local monthly state when remote is empty', () async {
       final local = _FakeAssetLiabilityRepository();
@@ -527,37 +551,47 @@ void main() {
       expect(localState.paymentOverrides['mobit'], 70000);
     });
 
-    test('restores remote settings and snapshots when local is empty',
-        () async {
-      final local = _FakeAssetLiabilityRepository();
-      final remote = _RecordingAssetLiabilityRemoteStore()
-        ..seedDefaultPaymentSources(const <String, String>{
-          'mobit': 'smbc_otsuka',
-        })
-        ..seedRecurringIncomeTemplates(<AssetLiabilityRecurringIncomeTemplate>[
-          _sampleRecurringIncomeTemplate(),
-        ])
-        ..seedMonthlySnapshots(<AssetLiabilityMonthlySnapshot>[
-          _sampleSnapshot('2026-05'),
-        ]);
-      final repository = FeatureFlaggedAssetLiabilityRepository(
-        localRepository: local,
-        remoteStore: remote,
-        syncEnabled: true,
-        userIdProvider: () => 'user-1',
-      );
+    test(
+      'restores remote settings and snapshots when local is empty',
+      () async {
+        final local = _FakeAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore()
+          ..seedDefaultPaymentSources(const <String, String>{
+            'mobit': 'smbc_otsuka',
+          })
+          ..seedRecurringIncomeTemplates(
+            <AssetLiabilityRecurringIncomeTemplate>[
+              _sampleRecurringIncomeTemplate(),
+            ],
+          )
+          ..seedMonthlySnapshots(<AssetLiabilityMonthlySnapshot>[
+            _sampleSnapshot('2026-05'),
+          ]);
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
 
-      final sources = await repository.loadDefaultPaymentSources();
-      final templates = await repository.loadRecurringIncomeTemplates();
-      final snapshots = await repository.loadMonthlySnapshots();
+        final sources = await repository.loadDefaultPaymentSources();
+        final templates = await repository.loadRecurringIncomeTemplates();
+        final snapshots = await repository.loadMonthlySnapshots();
 
-      expect(sources['mobit'], 'smbc_otsuka');
-      expect(templates.single.id, 'salary');
-      expect(snapshots.single.monthKey, '2026-05');
-      expect((await local.loadDefaultPaymentSources())['mobit'], 'smbc_otsuka');
-      expect((await local.loadRecurringIncomeTemplates()).single.id, 'salary');
-      expect((await local.loadMonthlySnapshots()).single.monthKey, '2026-05');
-    });
+        expect(sources['mobit'], 'smbc_otsuka');
+        expect(templates.single.id, 'salary');
+        expect(snapshots.single.monthKey, '2026-05');
+        expect(
+          (await local.loadDefaultPaymentSources())['mobit'],
+          'smbc_otsuka',
+        );
+        expect(
+          (await local.loadRecurringIncomeTemplates()).single.id,
+          'salary',
+        );
+        expect((await local.loadMonthlySnapshots()).single.monthKey, '2026-05');
+      },
+    );
 
     test(
       'keeps local repository usable when no Supabase user is available',
@@ -629,6 +663,9 @@ void main() {
         defaultPaymentSourceAccountIds: <String, String>{
           'mobit': 'smbc_otsuka',
         },
+        defaultCardBillingAccountIds: <String, String>{
+          'kddi_provider': 'paypay_card',
+        },
         recurringIncomeTemplates: <AssetLiabilityRecurringIncomeTemplate>[
           AssetLiabilityRecurringIncomeTemplate(
             id: 'salary',
@@ -647,6 +684,10 @@ void main() {
       expect(
         restoredSettings.defaultPaymentSourceAccountIds['mobit'],
         'smbc_otsuka',
+      );
+      expect(
+        restoredSettings.defaultCardBillingAccountIds['kddi_provider'],
+        'paypay_card',
       );
       expect(restoredSettings.recurringIncomeTemplates.single.id, 'salary');
 
@@ -701,6 +742,7 @@ class _FakeAssetLiabilityRepository extends AssetLiabilityRepository {
   final Map<String, AssetLiabilityMonthlyState> _states =
       <String, AssetLiabilityMonthlyState>{};
   final Map<String, String> _defaultSources = <String, String>{};
+  final Map<String, String> _defaultCardBilling = <String, String>{};
   final List<AssetLiabilityRecurringIncomeTemplate> _templates =
       <AssetLiabilityRecurringIncomeTemplate>[];
   final List<AssetLiabilityMonthlySnapshot> _snapshots =
@@ -730,6 +772,20 @@ class _FakeAssetLiabilityRepository extends AssetLiabilityRepository {
     _defaultSources
       ..clear()
       ..addAll(sources);
+  }
+
+  @override
+  Future<Map<String, String>> loadDefaultCardBillingAccounts() async {
+    return Map<String, String>.from(_defaultCardBilling);
+  }
+
+  @override
+  Future<void> saveDefaultCardBillingAccounts(
+    Map<String, String> accounts,
+  ) async {
+    _defaultCardBilling
+      ..clear()
+      ..addAll(accounts);
   }
 
   @override
@@ -780,18 +836,23 @@ class _RecordingAssetLiabilityRemoteStore extends AssetLiabilityRemoteStore {
   final Map<String, AssetLiabilityMonthlyState> _states =
       <String, AssetLiabilityMonthlyState>{};
   final Map<String, String> _defaultPaymentSources = <String, String>{};
+  final Map<String, String> _defaultCardBillingAccounts = <String, String>{};
   final List<AssetLiabilityRecurringIncomeTemplate> _recurringIncomeTemplates =
       <AssetLiabilityRecurringIncomeTemplate>[];
   final List<AssetLiabilityMonthlySnapshot> _monthlySnapshots =
       <AssetLiabilityMonthlySnapshot>[];
 
   bool _hasDefaultPaymentSources = false;
+  bool _hasDefaultCardBillingAccounts = false;
   bool _hasRecurringIncomeTemplates = false;
   bool _hasMonthlySnapshots = false;
   bool failSaves = false;
 
   Map<String, String> get defaultPaymentSources =>
       Map<String, String>.from(_defaultPaymentSources);
+
+  Map<String, String> get defaultCardBillingAccounts =>
+      Map<String, String>.from(_defaultCardBillingAccounts);
 
   List<AssetLiabilityRecurringIncomeTemplate> get recurringIncomeTemplates =>
       List<AssetLiabilityRecurringIncomeTemplate>.from(
@@ -812,6 +873,13 @@ class _RecordingAssetLiabilityRemoteStore extends AssetLiabilityRemoteStore {
     _defaultPaymentSources
       ..clear()
       ..addAll(sources);
+  }
+
+  void seedDefaultCardBillingAccounts(Map<String, String> accounts) {
+    _hasDefaultCardBillingAccounts = true;
+    _defaultCardBillingAccounts
+      ..clear()
+      ..addAll(accounts);
   }
 
   void seedRecurringIncomeTemplates(
@@ -875,6 +943,30 @@ class _RecordingAssetLiabilityRemoteStore extends AssetLiabilityRemoteStore {
     _defaultPaymentSources
       ..clear()
       ..addAll(sources);
+  }
+
+  @override
+  Future<Map<String, String>?> loadDefaultCardBillingAccounts({
+    required String userId,
+  }) async {
+    calls.add('loadDefaultCardBillingAccounts:$userId');
+    if (!_hasDefaultCardBillingAccounts) {
+      return null;
+    }
+    return Map<String, String>.from(_defaultCardBillingAccounts);
+  }
+
+  @override
+  Future<void> saveDefaultCardBillingAccounts({
+    required String userId,
+    required Map<String, String> accounts,
+  }) async {
+    calls.add('saveDefaultCardBillingAccounts:$userId');
+    _throwIfSavingFails();
+    _hasDefaultCardBillingAccounts = true;
+    _defaultCardBillingAccounts
+      ..clear()
+      ..addAll(accounts);
   }
 
   @override


### PR DESCRIPTION
﻿## 概要

資産/負債ボードに、カード請求内訳の編集UIを追加しました。

#2432 で一般化した `direct` / `includedInCard` の支払い方式を、画面上で編集できるようにしています。基本はデフォルト設定を主とし、必要な月だけ月単位設定で上書きできるようにしました。

## 主な変更

- 負債マスタに支払い方式の編集UIを追加
  - 直接支払い
  - カード請求に含める
- 保存先を選べるUIを追加
  - デフォルトとして保存
  - 今月だけ上書き
- 支払い方式の解決順を追加
  - 月単位設定 > デフォルト設定 > 既定値
- 既存の au -> auPayカード請求の既定挙動を維持
- デフォルトカード請求設定を SharedPreferences / Repository / Supabase payload に追加
- Supabase同期プレビュー/手動同期の対象にデフォルトカード請求設定を追加
- CSVに支払い方式の設定元を追加
- 関連テストを追加・更新

## Minimal E2E Gate

- [x] Implementation-detail independent: the E2E plan checks user-visible payment routing behavior and persistence outcomes, not private implementation details.
- [x] Minimal scope: three cases only.
- [x] E2E mechanism: Flutter service/repository regression tests plus local web build and HTTP smoke for the finance board shell.
- [x] E2E-Exception: no new integration_test or Playwright file was added because this is a focused authenticated finance-board state/UI edit; behavior is covered by existing Flutter tests and local web smoke.

Minimal black-box cases:
1. User can save a card-billed setting as the default and future workbook calculation treats it as included in the card bill.
2. User can override that default for the current month, including switching back to direct payment, and the current month cashflow uses the override.
3. Existing au -> auPayカード behavior remains card-billed by default and does not double-count in unpaid total/cashflow.

## High-risk Ultrareview Gate

- Claude Code #1 review owner: Claude Code #1.
- High-risk Ultrareview Exception: this PR contains the word billing and touches local/Supabase asset-liability persistence payloads, but it does not change auth, RLS, migrations, secrets, payment processors, production writes, deployment, or external billing systems. The change is local finance-board routing/editing state only.
- Rollback: revert this squash commit; missing `default_card_billing_account_ids` defaults to an empty map and existing monthly/built-in routing continues to work.
- Data migration: no DB migration. SharedPreferences and Supabase JSON payloads tolerate missing `default_card_billing_account_ids` as an empty map.
- Prod smoke: CI public smoke plus local Flutter tests and web build are sufficient for this non-deploying UI/state change.
- Observability: no new runtime logging or external telemetry; failures remain covered by existing local persistence and repository error paths.
- Security: no secrets, credentials, RLS, service role, auth, or production write changes.
- Unresolved findings: 0.

## 検証

- `flutter pub get --enforce-lockfile`: failed because the local Flutter dependency resolver would update `pubspec.lock`; no lockfile/platform generated changes were kept.
- `dart format --output=none --set-exit-if-changed ...`: OK
- `dart analyze`: No issues found
- 資産/負債関連 `flutter test --no-pub ...`: 62 tests passed
- 全体 `flutter test --no-pub --reporter compact`: 446 tests passed
- `flutter build web --release --no-pub`: OK
- ローカルWeb確認: HTTP 200
- `git diff --check`: OK

## Files changed確認

想定どおり11件です。

- `lib/models/asset_liability_workbook.dart`
- `lib/models/asset_liability_persistence.dart`
- `lib/services/asset_liability_planning_service.dart`
- `lib/services/asset_liability_monthly_state_store.dart`
- `lib/services/asset_liability_repository.dart`
- `lib/services/asset_liability_history_service.dart`
- `lib/pages/asset_management_page.dart`
- `test/services/asset_liability_planning_service_test.dart`
- `test/services/asset_liability_monthly_state_store_test.dart`
- `test/services/asset_liability_repository_test.dart`
- `test/services/asset_liability_history_service_test.dart`

## 注意点

- Supabase migration / RLS / production write は含みません。
- lockfile / platform generated files は含みません。
