### PR TITLE
Add monthly review for card-billed asset liability items

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -383,6 +383,84 @@ class AssetLiabilityMonthlyChartData {
   bool get hasEnoughData => monthKeys.length >= 2;
 }
 
+class AssetLiabilityCardBillingReviewItem {
+  final String accountId;
+  final String accountName;
+  final double amount;
+  final int? paymentDay;
+  final AssetLiabilityPaymentMethod paymentMethod;
+  final String paymentMethodLabel;
+  final AssetLiabilityPaymentMethodSettingSource paymentMethodSettingSource;
+  final String? billingAccountId;
+  final String? billingAccountName;
+  final bool includedInBillingAccount;
+  final bool directCashflowTarget;
+  final List<String> alerts;
+
+  const AssetLiabilityCardBillingReviewItem({
+    required this.accountId,
+    required this.accountName,
+    required this.amount,
+    required this.paymentDay,
+    required this.paymentMethod,
+    required this.paymentMethodLabel,
+    required this.paymentMethodSettingSource,
+    required this.billingAccountId,
+    required this.billingAccountName,
+    required this.includedInBillingAccount,
+    required this.directCashflowTarget,
+    this.alerts = const <String>[],
+  });
+
+  bool get needsReview => alerts.isNotEmpty;
+  bool get hasMissingBillingAccount =>
+      includedInBillingAccount &&
+      (billingAccountId == null || billingAccountId!.trim().isEmpty);
+  bool get excludedFromDirectCashflow => includedInBillingAccount;
+}
+
+class AssetLiabilityCardBillingGroup {
+  final String billingAccountId;
+  final String billingAccountName;
+  final List<AssetLiabilityCardBillingReviewItem> items;
+
+  const AssetLiabilityCardBillingGroup({
+    required this.billingAccountId,
+    required this.billingAccountName,
+    required this.items,
+  });
+
+  double get totalAmount {
+    return items.fold<double>(0, (sum, item) => sum + item.amount);
+  }
+}
+
+class AssetLiabilityCardBillingReviewData {
+  final List<AssetLiabilityCardBillingReviewItem> directPaymentItems;
+  final List<AssetLiabilityCardBillingGroup> cardBillingGroups;
+  final List<AssetLiabilityCardBillingReviewItem> missingBillingAccountItems;
+  final List<AssetLiabilityCardBillingReviewItem> needsReviewItems;
+  final List<AssetLiabilityCardBillingReviewItem> doubleCountingRiskItems;
+
+  const AssetLiabilityCardBillingReviewData({
+    required this.directPaymentItems,
+    required this.cardBillingGroups,
+    required this.missingBillingAccountItems,
+    required this.needsReviewItems,
+    required this.doubleCountingRiskItems,
+  });
+
+  bool get hasDoubleCountingRisk => doubleCountingRiskItems.isNotEmpty;
+  bool get hasNeedsReviewItems => needsReviewItems.isNotEmpty;
+  bool get hasMissingBillingAccounts => missingBillingAccountItems.isNotEmpty;
+  int get cardBilledItemCount {
+    return cardBillingGroups.fold<int>(
+      0,
+      (sum, group) => sum + group.items.length,
+    );
+  }
+}
+
 class AssetLiabilityCsvExportBundle {
   final String monthlyHistoryCsv;
   final String paymentScheduleCsv;
@@ -407,6 +485,7 @@ class AssetLiabilityWorkbook {
   final List<AssetLiabilityIncomePlan> incomePlans;
   final List<AssetLiabilityAccountCashflowSummary> accountCashflowSummaries;
   final List<AssetLiabilityTransferSuggestion> transferSuggestions;
+  final AssetLiabilityCardBillingReviewData cardBillingReview;
   final double cashLikeTotal;
   final double securitiesTotal;
   final double positiveAssetTotal;
@@ -433,6 +512,7 @@ class AssetLiabilityWorkbook {
     required this.incomePlans,
     required this.accountCashflowSummaries,
     required this.transferSuggestions,
+    required this.cardBillingReview,
     required this.cashLikeTotal,
     required this.securitiesTotal,
     required this.positiveAssetTotal,

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -6613,6 +6613,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               const SizedBox(height: 8),
               _buildAssetWorkbookCardBillingNotice(workbook),
             ],
+            const SizedBox(height: 16),
+            _buildCardBillingReviewSection(workbook),
             if (workbook.hasOverduePayments) ...[
               const SizedBox(height: 8),
               _buildAssetWorkbookOverdueWarning(workbook),
@@ -7052,6 +7054,305 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildCardBillingReviewSection(AssetLiabilityWorkbook workbook) {
+    final review = workbook.cardBillingReview;
+    if (workbook.debtMasterRows.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Row(
+            children: [
+              Icon(Icons.fact_check_outlined, color: Color(0xFF2563EB)),
+              SizedBox(width: 8),
+              Text(
+                'カード請求内訳レビュー',
+                style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '今月の支払い方式を、直接支払い・カード請求内訳・設定確認が必要な項目に分けて確認します。',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildTextStatusChip(
+                label: '直接支払い ${review.directPaymentItems.length}件',
+                color: const Color(0xFF0D9488),
+              ),
+              _buildTextStatusChip(
+                label: 'カード請求内訳 ${review.cardBilledItemCount}件',
+                color: const Color(0xFF2563EB),
+              ),
+              _buildTextStatusChip(
+                label: '請求先未設定 ${review.missingBillingAccountItems.length}件',
+                color: review.hasMissingBillingAccounts
+                    ? const Color(0xFFB91C1C)
+                    : const Color(0xFF475569),
+              ),
+              _buildTextStatusChip(
+                label: '設定確認 ${review.needsReviewItems.length}件',
+                color: review.hasNeedsReviewItems
+                    ? const Color(0xFFD97706)
+                    : const Color(0xFF475569),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          _buildCardBillingReviewRiskNotice(review),
+          if (review.hasNeedsReviewItems) ...[
+            const SizedBox(height: 8),
+            _buildCardBillingReviewAlertList(review.needsReviewItems),
+          ],
+          const SizedBox(height: 12),
+          _buildCardBillingReviewDirectPayments(review.directPaymentItems),
+          const SizedBox(height: 12),
+          _buildCardBillingReviewGroups(review.cardBillingGroups),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCardBillingReviewRiskNotice(
+    AssetLiabilityCardBillingReviewData review,
+  ) {
+    final hasRisk = review.hasDoubleCountingRisk;
+    final color = hasRisk ? const Color(0xFFB91C1C) : const Color(0xFF0D9488);
+    final message = hasRisk
+        ? '${AssetLiabilityPlanningService.cardBillingReviewDoubleCountRiskLabel}: '
+            '${review.doubleCountingRiskItems.map((item) => item.accountName).join(' / ')}'
+        : AssetLiabilityPlanningService.cardBillingReviewNoDoubleCountRiskLabel;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            hasRisk ? Icons.warning_amber_outlined : Icons.verified_outlined,
+            color: color,
+            size: 18,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(color: color, fontSize: 12, height: 1.5),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCardBillingReviewAlertList(
+    List<AssetLiabilityCardBillingReviewItem> items,
+  ) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFD97706).withValues(alpha: 0.25),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '設定確認が必要な項目',
+            style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+          ),
+          const SizedBox(height: 6),
+          for (final item in items)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Text(
+                '${item.accountName}: ${item.alerts.join(' / ')}',
+                style: const TextStyle(fontSize: 12, height: 1.5),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCardBillingReviewDirectPayments(
+    List<AssetLiabilityCardBillingReviewItem> items,
+  ) {
+    return _buildCardBillingReviewItemTable(
+      title: '直接支払い',
+      items: items,
+      emptyMessage: '直接支払いの項目はありません',
+    );
+  }
+
+  Widget _buildCardBillingReviewGroups(
+    List<AssetLiabilityCardBillingGroup> groups,
+  ) {
+    if (groups.isEmpty) {
+      return _buildCardBillingReviewItemTable(
+        title: 'カード請求に含める項目',
+        items: const <AssetLiabilityCardBillingReviewItem>[],
+        emptyMessage: 'カード請求に含める項目はありません',
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'カード請求に含める項目',
+          style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+        ),
+        const SizedBox(height: 8),
+        for (final group in groups) ...[
+          Row(
+            children: [
+              const Icon(Icons.credit_card_outlined, size: 16),
+              const SizedBox(width: 6),
+              Text(
+                '${group.billingAccountName} '
+                '(${group.items.length}件 / ${_formatManagementYen(group.totalAmount)})',
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          _buildCardBillingReviewItemTable(
+            title: null,
+            items: group.items,
+            emptyMessage: '',
+          ),
+          const SizedBox(height: 10),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildCardBillingReviewItemTable({
+    required String? title,
+    required List<AssetLiabilityCardBillingReviewItem> items,
+    required String emptyMessage,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (title != null) ...[
+          Text(
+            title,
+            style: const TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+          ),
+          const SizedBox(height: 6),
+        ],
+        if (items.isEmpty)
+          Text(
+            emptyMessage,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          )
+        else
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              headingRowHeight: 34,
+              dataRowMinHeight: 46,
+              dataRowMaxHeight: 58,
+              columns: const [
+                DataColumn(label: Text('支払い項目')),
+                DataColumn(label: Text('金額'), numeric: true),
+                DataColumn(label: Text('支払日'), numeric: true),
+                DataColumn(label: Text('支払い方式')),
+                DataColumn(label: Text('請求先カード')),
+                DataColumn(label: Text('設定元')),
+                DataColumn(label: Text('資金繰り')),
+                DataColumn(label: Text('確認事項')),
+              ],
+              rows: [
+                for (final item in items)
+                  DataRow(
+                    cells: [
+                      DataCell(Text(item.accountName)),
+                      DataCell(Text(_formatManagementYen(item.amount))),
+                      DataCell(
+                        Text(
+                          item.paymentDay == null
+                              ? '未設定'
+                              : '${item.paymentDay}日',
+                        ),
+                      ),
+                      DataCell(Text(item.paymentMethodLabel)),
+                      DataCell(
+                        Text(
+                          item.billingAccountName ??
+                              item.billingAccountId ??
+                              'なし',
+                        ),
+                      ),
+                      DataCell(
+                        Text(
+                          AssetLiabilityPlanningService
+                              .paymentMethodSettingSourceLabel(
+                            item.paymentMethodSettingSource,
+                          ),
+                        ),
+                      ),
+                      DataCell(
+                        _buildTextStatusChip(
+                          label: item.excludedFromDirectCashflow
+                              ? AssetLiabilityPlanningService
+                                  .cardBillingReviewExcludedFromDirectCashflowLabel
+                              : AssetLiabilityPlanningService
+                                  .cardBillingReviewDirectCashflowTargetLabel,
+                          color: item.excludedFromDirectCashflow
+                              ? const Color(0xFF2563EB)
+                              : const Color(0xFF0D9488),
+                        ),
+                      ),
+                      DataCell(
+                        Text(
+                          item.alerts.isEmpty
+                              ? '問題なし'
+                              : item.alerts.join(' / '),
+                        ),
+                      ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+      ],
     );
   }
 

--- a/lib/services/asset_liability_history_service.dart
+++ b/lib/services/asset_liability_history_service.dart
@@ -176,8 +176,17 @@ class AssetLiabilityHistoryService {
 
   String buildPaymentScheduleCsv(AssetLiabilityWorkbook workbook) {
     final rows = workbook.cashflowRows.where((row) => row.isPayment).toList();
+    final reviewItemsById = <String, AssetLiabilityCardBillingReviewItem>{
+      for (final item in workbook.cardBillingReview.directPaymentItems)
+        item.accountId: item,
+      for (final group in workbook.cardBillingReview.cardBillingGroups)
+        for (final item in group.items) item.accountId: item,
+    };
     return _csv([
       const <Object?>[
+        'レビュー区分',
+        '確認事項',
+        '二重計上対象外',
         '\u8a2d\u5b9a\u5143',
         '請求先カード',
         '日付',
@@ -194,6 +203,13 @@ class AssetLiabilityHistoryService {
       ],
       for (final row in rows)
         <Object?>[
+          _paymentReviewCategoryLabel(reviewItemsById[row.accountId]),
+          _paymentReviewAlertLabel(reviewItemsById[row.accountId]),
+          row.includedInBillingAccount
+              ? AssetLiabilityPlanningService
+                  .cardBillingReviewExcludedFromDirectCashflowLabel
+              : AssetLiabilityPlanningService
+                  .cardBillingReviewDirectCashflowTargetLabel,
           AssetLiabilityPlanningService.paymentMethodSettingSourceLabel(
             row.paymentMethodSettingSource,
           ),
@@ -215,6 +231,24 @@ class AssetLiabilityHistoryService {
           row.cashAfterPayment,
         ],
     ]);
+  }
+
+  String _paymentReviewCategoryLabel(
+    AssetLiabilityCardBillingReviewItem? item,
+  ) {
+    if (item == null) {
+      return '';
+    }
+    return item.includedInBillingAccount
+        ? AssetLiabilityPlanningService.cardBillingReviewIncludedLabel
+        : AssetLiabilityPlanningService.cardBillingReviewDirectLabel;
+  }
+
+  String _paymentReviewAlertLabel(AssetLiabilityCardBillingReviewItem? item) {
+    if (item == null) {
+      return '';
+    }
+    return item.alerts.isEmpty ? '問題なし' : item.alerts.join(' / ');
   }
 
   String buildIncomePlansCsv(AssetLiabilityWorkbook workbook) {

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -21,6 +21,21 @@ class AssetLiabilityPlanningService {
       '\u30c7\u30d5\u30a9\u30eb\u30c8\u3068\u3057\u3066\u4fdd\u5b58';
   static const String saveAsMonthlyPaymentMethodLabel =
       '\u4eca\u6708\u3060\u3051\u4e0a\u66f8\u304d';
+  static const String cardBillingReviewDirectLabel = '直接支払い';
+  static const String cardBillingReviewIncludedLabel = 'カード請求に含める';
+  static const String cardBillingReviewUnsetLabel = '請求先カード未設定';
+  static const String cardBillingReviewNeedsReviewLabel = '設定確認が必要';
+  static const String cardBillingReviewNoDoubleCountRiskLabel =
+      '二重計上リスクは検出されていません';
+  static const String cardBillingReviewDoubleCountRiskLabel = '二重計上リスクあり';
+  static const String cardBillingReviewExcludedFromDirectCashflowLabel =
+      '二重計上対象外';
+  static const String cardBillingReviewDirectCashflowTargetLabel = '直接差し引き対象';
+  static const String cardBillingReviewMissingBillingAccountAlert =
+      '請求先カードが未設定です';
+  static const String cardBillingReviewRemovedBillingAccountAlert =
+      '請求先カードが見つかりません';
+  static const String cardBillingReviewZeroAmountAlert = '金額が0円のため確認してください';
   static const String auCardBillingNotice =
       'auはauPayカード払いのため、資金繰りではauPayカード請求に含めて扱います。';
   static const String kddiProviderAccountId = 'kddi_provider';
@@ -136,6 +151,10 @@ class AssetLiabilityPlanningService {
       summaries: accountCashflowSummaries,
       cashflowRows: cashflowRows,
     );
+    final cardBillingReview = _buildCardBillingReview(
+      rows: debtMasterRows,
+      accountsById: accountsById,
+    );
 
     final monthlyMinimumPaymentEstimateTotal = directDebtRows.fold<double>(
       0,
@@ -174,6 +193,7 @@ class AssetLiabilityPlanningService {
       incomePlans: resolvedIncomePlans,
       accountCashflowSummaries: accountCashflowSummaries,
       transferSuggestions: transferSuggestions,
+      cardBillingReview: cardBillingReview,
       cashLikeTotal: cashLikeTotal,
       securitiesTotal: securitiesTotal,
       positiveAssetTotal: positiveAssetTotal,
@@ -596,6 +616,145 @@ class AssetLiabilityPlanningService {
       'famipay_card' => 'ファミペイカード',
       _ => null,
     };
+  }
+
+  AssetLiabilityCardBillingReviewData _buildCardBillingReview({
+    required List<AssetLiabilityDebtRow> rows,
+    required Map<String, AssetLiabilityAccount> accountsById,
+  }) {
+    final creditCardAccountIds = accountsById.values
+        .where(
+          (account) => account.kind == AssetLiabilityAccountKind.creditCard,
+        )
+        .map((account) => account.id)
+        .toSet();
+    final items = [
+      for (final row in rows)
+        _cardBillingReviewItemFor(
+          row: row,
+          creditCardAccountIds: creditCardAccountIds,
+        ),
+    ]..sort(_compareCardBillingReviewItems);
+
+    final directPaymentItems = items
+        .where((item) => item.directCashflowTarget)
+        .toList(growable: false);
+    final missingBillingAccountItems = items
+        .where((item) => item.hasMissingBillingAccount)
+        .toList(growable: false);
+    final needsReviewItems =
+        items.where((item) => item.needsReview).toList(growable: false);
+    final cardBillingGroups = _cardBillingReviewGroups(items);
+    final doubleCountingRiskItems = _doubleCountingRiskItems(items);
+
+    return AssetLiabilityCardBillingReviewData(
+      directPaymentItems: directPaymentItems,
+      cardBillingGroups: cardBillingGroups,
+      missingBillingAccountItems: missingBillingAccountItems,
+      needsReviewItems: needsReviewItems,
+      doubleCountingRiskItems: doubleCountingRiskItems,
+    );
+  }
+
+  AssetLiabilityCardBillingReviewItem _cardBillingReviewItemFor({
+    required AssetLiabilityDebtRow row,
+    required Set<String> creditCardAccountIds,
+  }) {
+    final alerts = <String>[];
+    if (row.includedInBillingAccount) {
+      final billingAccountId = row.billingAccountId?.trim();
+      if (billingAccountId == null || billingAccountId.isEmpty) {
+        alerts.add(cardBillingReviewMissingBillingAccountAlert);
+      } else if (!creditCardAccountIds.contains(billingAccountId)) {
+        alerts.add(cardBillingReviewRemovedBillingAccountAlert);
+      }
+    }
+    if (row.scheduledPaymentAmount <= 0) {
+      alerts.add(cardBillingReviewZeroAmountAlert);
+    }
+
+    return AssetLiabilityCardBillingReviewItem(
+      accountId: row.id,
+      accountName: row.name,
+      amount: row.scheduledPaymentAmount,
+      paymentDay: row.paymentDay,
+      paymentMethod: row.paymentMethod,
+      paymentMethodLabel: row.includedInBillingAccount
+          ? (row.paymentMethodLabel ?? cardBillingReviewIncludedLabel)
+          : directPaymentLabel,
+      paymentMethodSettingSource: row.paymentMethodSettingSource,
+      billingAccountId: row.billingAccountId,
+      billingAccountName: row.billingAccountName,
+      includedInBillingAccount: row.includedInBillingAccount,
+      directCashflowTarget: row.isDirectCashflowTarget,
+      alerts: alerts,
+    );
+  }
+
+  List<AssetLiabilityCardBillingGroup> _cardBillingReviewGroups(
+    List<AssetLiabilityCardBillingReviewItem> items,
+  ) {
+    final grouped = <String, List<AssetLiabilityCardBillingReviewItem>>{};
+    for (final item in items.where((item) => item.includedInBillingAccount)) {
+      final key = item.billingAccountId?.trim().isNotEmpty ?? false
+          ? item.billingAccountId!.trim()
+          : cardBillingReviewUnsetLabel;
+      grouped
+          .putIfAbsent(key, () => <AssetLiabilityCardBillingReviewItem>[])
+          .add(item);
+    }
+
+    final groups = [
+      for (final entry in grouped.entries)
+        AssetLiabilityCardBillingGroup(
+          billingAccountId:
+              entry.key == cardBillingReviewUnsetLabel ? '' : entry.key,
+          billingAccountName: entry.value.first.billingAccountName ??
+              cardBillingReviewUnsetLabel,
+          items: entry.value..sort(_compareCardBillingReviewItems),
+        ),
+    ];
+    groups.sort((a, b) => a.billingAccountName.compareTo(b.billingAccountName));
+    return groups;
+  }
+
+  List<AssetLiabilityCardBillingReviewItem> _doubleCountingRiskItems(
+    List<AssetLiabilityCardBillingReviewItem> items,
+  ) {
+    final itemsByAccountId =
+        <String, List<AssetLiabilityCardBillingReviewItem>>{};
+    for (final item in items) {
+      itemsByAccountId
+          .putIfAbsent(
+            item.accountId,
+            () => <AssetLiabilityCardBillingReviewItem>[],
+          )
+          .add(item);
+    }
+
+    final result = <AssetLiabilityCardBillingReviewItem>[];
+    for (final accountItems in itemsByAccountId.values) {
+      final hasDirect = accountItems.any((item) => item.directCashflowTarget);
+      final hasCardBilled = accountItems.any(
+        (item) => item.includedInBillingAccount,
+      );
+      if (hasDirect && hasCardBilled) {
+        result.addAll(accountItems);
+      }
+    }
+    result.sort(_compareCardBillingReviewItems);
+    return result;
+  }
+
+  int _compareCardBillingReviewItems(
+    AssetLiabilityCardBillingReviewItem a,
+    AssetLiabilityCardBillingReviewItem b,
+  ) {
+    final day = (a.paymentDay ?? 99).compareTo(b.paymentDay ?? 99);
+    if (day != 0) {
+      return day;
+    }
+    return b.amount.compareTo(a.amount);
   }
 
   List<AssetLiabilityPaymentDayRisk> _buildPaymentDayRisks({

--- a/test/services/asset_liability_history_service_test.dart
+++ b/test/services/asset_liability_history_service_test.dart
@@ -221,6 +221,21 @@ void main() {
 
       final csv = historyService.buildPaymentScheduleCsv(workbook);
 
+      expect(csv, contains('レビュー区分'));
+      expect(csv, contains('確認事項'));
+      expect(csv, contains('二重計上対象外'));
+      expect(
+        csv,
+        contains(AssetLiabilityPlanningService.cardBillingReviewIncludedLabel),
+      );
+      expect(
+        csv,
+        contains(
+          AssetLiabilityPlanningService
+              .cardBillingReviewExcludedFromDirectCashflowLabel,
+        ),
+      );
+
       expect(csv, contains('支払い方法'));
       expect(
         csv,

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -386,6 +386,150 @@ void main() {
       expect(workbook.monthlyUnpaidPaymentTotal, 25764);
     });
 
+    test('builds monthly card billing review direct payment group', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'KDDI': -5764,
+          'PayPay': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+          'paypay_card': 20000,
+        },
+      );
+
+      final review = workbook.cardBillingReview;
+      final directIds =
+          review.directPaymentItems.map((item) => item.accountId).toSet();
+
+      expect(
+        directIds,
+        contains(AssetLiabilityPlanningService.kddiProviderAccountId),
+      );
+      expect(directIds, contains('paypay_card'));
+      expect(review.hasDoubleCountingRisk, isFalse);
+      expect(workbook.monthlyUnpaidPaymentTotal, 25764);
+    });
+
+    test('groups card-billed review items by billing card', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'KDDI': -5764,
+          'PayPay': -20000,
+          'au': -32152,
+          'auPayカード': -10000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+          'paypay_card': 20000,
+          AssetLiabilityPlanningService.auPayCardAccountId: 10000,
+        },
+        cardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'paypay_card',
+        },
+      );
+
+      final review = workbook.cardBillingReview;
+      final auPayGroup = review.cardBillingGroups.firstWhere(
+        (group) =>
+            group.billingAccountId ==
+            AssetLiabilityPlanningService.auPayCardAccountId,
+      );
+      final payPayGroup = review.cardBillingGroups.firstWhere(
+        (group) => group.billingAccountId == 'paypay_card',
+      );
+
+      expect(
+        auPayGroup.items.map((item) => item.accountId),
+        contains(AssetLiabilityPlanningService.auAccountId),
+      );
+      expect(
+        payPayGroup.items.map((item) => item.accountId),
+        contains(AssetLiabilityPlanningService.kddiProviderAccountId),
+      );
+      expect(review.hasDoubleCountingRisk, isFalse);
+    });
+
+    test(
+      'marks monthly and default setting sources in card billing review',
+      () {
+        final workbook = service.buildWorkbook(
+          latestSnapshot: <String, double>{
+            'cash': 50000,
+            'KDDI': -5764,
+            'PayPay': -20000,
+            'ファミペイカード': -3000,
+          },
+          baseDate: DateTime(2026, 5, 1),
+          monthlyPaymentOverrides: const <String, double>{
+            AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+            'paypay_card': 20000,
+            'famipay_card': 3000,
+          },
+          defaultCardBillingAccountIds: const <String, String>{
+            AssetLiabilityPlanningService.kddiProviderAccountId: 'paypay_card',
+          },
+          cardBillingAccountIds: const <String, String>{
+            'paypay_card': 'famipay_card',
+          },
+        );
+
+        final items = [
+          for (final group in workbook.cardBillingReview.cardBillingGroups)
+            ...group.items,
+        ];
+        final kddi = items.firstWhere(
+          (item) =>
+              item.accountId ==
+              AssetLiabilityPlanningService.kddiProviderAccountId,
+        );
+        final payPay = items.firstWhere(
+          (item) => item.accountId == 'paypay_card',
+        );
+
+        expect(
+          kddi.paymentMethodSettingSource,
+          AssetLiabilityPaymentMethodSettingSource.defaultSetting,
+        );
+        expect(
+          payPay.paymentMethodSettingSource,
+          AssetLiabilityPaymentMethodSettingSource.monthlyOverride,
+        );
+      },
+    );
+
+    test('alerts when card billing target card is missing', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{'cash': 50000, 'KDDI': -5764},
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+        },
+        cardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'missing_card',
+        },
+      );
+
+      final item = workbook.cardBillingReview.needsReviewItems.firstWhere(
+        (item) =>
+            item.accountId ==
+            AssetLiabilityPlanningService.kddiProviderAccountId,
+      );
+
+      expect(
+        item.alerts,
+        contains(
+          AssetLiabilityPlanningService
+              .cardBillingReviewRemovedBillingAccountAlert,
+        ),
+      );
+      expect(workbook.cardBillingReview.hasDoubleCountingRisk, isFalse);
+    });
+
     test('restores monthly state by stable id after display name changes', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: <String, double>{'財布': 50000, 'SMBCカードローン': -100000},


### PR DESCRIPTION
﻿## 概要

資産/負債ボードに「カード請求内訳レビュー」セクションを追加しました。

月ごとに、直接支払い・カード請求に含める項目・請求先カード未設定・設定確認が必要な項目を確認できるようにし、二重計上や設定漏れを見つけやすくしています。

## 主な変更

- カード請求内訳レビュー用の model / group / review data を追加
- `AssetLiabilityPlanningService` にレビュー分類・請求先カード別グルーピング・設定漏れ/確認アラート・二重計上リスク判定を追加
- 資産/負債ボードに「カード請求内訳レビュー」セクションを追加
- 直接支払い、カード請求内訳、請求先未設定、設定確認件数のサマリを表示
- カード請求内訳を請求先カードごとに表示
- au は既定どおり auPayカード配下に表示
- CSV支払予定にレビュー区分、確認事項、二重計上対象外情報を追加
- レビュー分類・設定元・アラート・CSV出力のテストを追加

## Minimal E2E Gate

- Implementation-detail independent: ユーザー視点で「資産/負債ボードでカード請求内訳レビューを見て、直接支払い/カード請求/設定漏れが判別できる」ことを確認する black-box / input/output 観点です。
- Minimal scope: 3 cases only.
  1. Happy path: au が auPayカード配下に表示され、二重計上リスクなしが表示される。
  2. Error path: 請求先カード未設定/存在しないカードIDが設定確認アラートになる。
  3. Recovery/empty-ish path: direct 支払いは直接支払いグループに残り、既存の資金繰り計算が変わらない。
- E2E mechanism: Playwright or Flutter integration_test would verify the route visually; this PR uses service tests plus local web HTTP smoke because the asset/liability page has existing broad UI surface and this change is review-section additive.
- E2E-Exception: no new integration_test/test/e2e file was added; manual/local verification covered `dart analyze`, targeted service tests, full `flutter test`, `git diff --check`, and local Web HTTP 200.

## Visual E2E Evidence

- Codex in-app browser: not used; local Web server smoke returned HTTP 200 for `http://127.0.0.1:5086`.
- Playwright artifacts: not captured for this scoped additive section.
- Console/page errors: not inspected beyond HTTP smoke in this local validation.
- Generated imagery: No generated image was used.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: scoped asset/liability card billing review UI and service classification only; no auth, secrets, production write, Supabase migration/RLS, Edge Functions, deploy workflow, or external payment provider integration changes. Deterministic validation is listed below and unresolved findings are none.

## 検証

- `dart format --output=none --set-exit-if-changed ...`: OK
- `dart analyze`: No issues found
- 資産/負債関連 `flutter test --no-pub ...`: 32 tests passed
- 全体 `flutter test --no-pub`: 452 tests passed
- `git diff --check`: OK
- ローカルWeb確認: HTTP 200

## Files changed

- `lib/models/asset_liability_workbook.dart`
- `lib/services/asset_liability_planning_service.dart`
- `lib/services/asset_liability_history_service.dart`
- `lib/pages/asset_management_page.dart`
- `test/services/asset_liability_planning_service_test.dart`
- `test/services/asset_liability_history_service_test.dart`
