### PR TITLE
Add AI insight foundation for asset management page

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -21,6 +21,7 @@ import 'package:my_web_app/services/asset_liability_history_service.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 import 'package:my_web_app/services/asset_liability_planning_service.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
+import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
@@ -181,6 +182,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetLiabilityPlanningService();
   final AssetLiabilityHistoryService _assetLiabilityHistoryService =
       const AssetLiabilityHistoryService();
+  final AssetManagementInsightService _assetManagementInsightService =
+      const AssetManagementInsightService();
   final DebtLockdownService _debtLockdownService = const DebtLockdownService();
   final DebtRepaymentPlannerService _debtRepaymentPlanner =
       const DebtRepaymentPlannerService();
@@ -6492,6 +6495,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       includeDefaultFixedPayments: true,
     );
     _scheduleAssetLiabilityStateIdMigration(workbook);
+    final insightReport = _assetManagementInsightService.buildReport(
+      workbook: workbook,
+    );
     final warningColor = workbook.cashAfterScheduledPayments < 0
         ? const Color(0xFFB91C1C)
         : const Color(0xFF0D9488);
@@ -6529,6 +6535,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
             const SizedBox(height: 12),
             _buildAssetLiabilitySyncPanel(),
+            const SizedBox(height: 12),
+            _buildAssetManagementAiAssistantSection(insightReport),
             const SizedBox(height: 12),
             Wrap(
               spacing: 8,
@@ -6942,6 +6950,392 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       ),
     );
+  }
+
+  Widget _buildAssetManagementAiAssistantSection(
+    AssetManagementInsightReport report,
+  ) {
+    final criticalCount = report.criticalActions.length;
+    final statusColor =
+        criticalCount > 0 ? const Color(0xFFB91C1C) : const Color(0xFF0D9488);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: statusColor.withValues(alpha: 0.24)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.auto_awesome_outlined, color: statusColor, size: 20),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  'AI資産管理アシスタント',
+                  style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+                ),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: '要対応',
+                value: '${report.actionItems.length}件',
+                color: statusColor,
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '金額は資産/負債ボードの計算結果を使い、外部AI APIは呼び出さずに安全なルールベースで確認しています。',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildAssetManagementAvailableCard(report.todayAvailable),
+              _buildAssetManagementAvailableCard(report.weekAvailable),
+              _buildAssetManagementAvailableCard(report.monthAvailable),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _buildAssetManagementAssistantActionList(report.actionItems),
+          if (report.movementSuggestions.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            _buildAssetManagementMovementSuggestionList(
+              report.movementSuggestions,
+            ),
+          ],
+          const SizedBox(height: 12),
+          _buildAssetManagementDeveloperRequestList(report.developerRequests),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetManagementAvailableCard(
+    AssetManagementAvailableMoneyInsight insight,
+  ) {
+    final color = insight.availableAmount < 0
+        ? const Color(0xFFB91C1C)
+        : const Color(0xFF0D9488);
+    final subtitle =
+        '支払 ${_formatManagementYen(insight.unpaidPaymentTotal)} / 入金 ${_formatManagementYen(insight.unreceivedIncomeTotal)} / 安全残高 ${_formatManagementYen(insight.minimumSafetyBalance)}';
+
+    return Container(
+      constraints: const BoxConstraints(minWidth: 210, maxWidth: 320),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.24)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            _assetManagementInsightWindowLabel(insight.window),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurface,
+              fontSize: 12,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 3),
+          Text(
+            _formatManagementYen(insight.availableAmount),
+            style: TextStyle(
+              color: color,
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              height: 1.3,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            subtitle,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 11,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetManagementAssistantActionList(
+    List<AssetManagementInsightActionItem> actionItems,
+  ) {
+    if (actionItems.isEmpty) {
+      return Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: const Color(0xFFECFDF5),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: const Color(0xFF0D9488).withValues(alpha: 0.24),
+          ),
+        ),
+        child: const Text(
+          '今日すぐ確認すべき資金繰りアクションはありません。',
+          style: TextStyle(fontWeight: FontWeight.w700, height: 1.4),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'アクションアイテム',
+          style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+        ),
+        const SizedBox(height: 6),
+        for (final item in actionItems.take(8))
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: _buildAssetManagementAssistantActionTile(item),
+          ),
+        if (actionItems.length > 8)
+          Text(
+            'ほか ${actionItems.length - 8}件',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildAssetManagementAssistantActionTile(
+    AssetManagementInsightActionItem item,
+  ) {
+    final color = _assetManagementInsightSeverityColor(item.severity);
+    final dueLabel = item.dueDate == null
+        ? (item.paymentDay == null ? null : '${item.paymentDay}日')
+        : DateFormat('M/d').format(item.dueDate!);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.24)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            _assetManagementInsightActionIcon(item.type),
+            color: color,
+            size: 18,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 6,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    Text(
+                      item.title,
+                      style: TextStyle(
+                        color: color,
+                        fontWeight: FontWeight.bold,
+                        height: 1.4,
+                      ),
+                    ),
+                    _buildAssetLiabilitySyncChip(
+                      label: '重要度',
+                      value: _assetManagementInsightSeverityLabel(
+                        item.severity,
+                      ),
+                      color: color,
+                    ),
+                    if (dueLabel != null)
+                      _buildAssetLiabilitySyncChip(
+                        label: '期日',
+                        value: dueLabel,
+                        color: const Color(0xFF475569),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  item.description,
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    fontSize: 12,
+                    height: 1.5,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  item.suggestedAction,
+                  style: const TextStyle(fontSize: 12, height: 1.5),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetManagementMovementSuggestionList(
+    List<AssetManagementMovementSuggestion> suggestions,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '口座移動/出金提案',
+          style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+        ),
+        const SizedBox(height: 6),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final suggestion in suggestions)
+              Chip(
+                avatar: const Icon(
+                  Icons.account_balance_wallet_outlined,
+                  size: 16,
+                ),
+                label: Text(
+                  '${suggestion.fromAccountName}から ${_formatManagementYen(suggestion.amount)}'
+                  '${suggestion.toAccountName == null ? ' 出金/移動' : ' → ${suggestion.toAccountName}'}',
+                ),
+                backgroundColor: const Color(0xFFFFF7ED),
+                side: const BorderSide(color: Color(0xFFF97316)),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAssetManagementDeveloperRequestList(
+    List<AssetManagementDeveloperRequest> requests,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '開発者向け改善提案',
+          style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+        ),
+        const SizedBox(height: 6),
+        for (final request in requests.take(4))
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surface,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    request.title,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    request.description,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      fontSize: 12,
+                      height: 1.5,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  String _assetManagementInsightWindowLabel(
+    AssetManagementInsightWindow window,
+  ) {
+    return switch (window) {
+      AssetManagementInsightWindow.today => '本日使用可能額',
+      AssetManagementInsightWindow.week => '今週使用可能額',
+      AssetManagementInsightWindow.month => '今月使用可能額',
+    };
+  }
+
+  String _assetManagementInsightSeverityLabel(
+    AssetManagementInsightSeverity severity,
+  ) {
+    return switch (severity) {
+      AssetManagementInsightSeverity.info => '確認',
+      AssetManagementInsightSeverity.warning => '警戒',
+      AssetManagementInsightSeverity.critical => '至急',
+    };
+  }
+
+  Color _assetManagementInsightSeverityColor(
+    AssetManagementInsightSeverity severity,
+  ) {
+    return switch (severity) {
+      AssetManagementInsightSeverity.info => const Color(0xFF2563EB),
+      AssetManagementInsightSeverity.warning => const Color(0xFFD97706),
+      AssetManagementInsightSeverity.critical => const Color(0xFFB91C1C),
+    };
+  }
+
+  IconData _assetManagementInsightActionIcon(
+    AssetManagementInsightActionType type,
+  ) {
+    return switch (type) {
+      AssetManagementInsightActionType.missingInput => Icons.edit_note_outlined,
+      AssetManagementInsightActionType.missingPaymentDay =>
+        Icons.event_busy_outlined,
+      AssetManagementInsightActionType.missingAnnualRate =>
+        Icons.percent_outlined,
+      AssetManagementInsightActionType.missingPaymentSource =>
+        Icons.account_balance_outlined,
+      AssetManagementInsightActionType.overduePayment =>
+        Icons.priority_high_rounded,
+      AssetManagementInsightActionType.upcomingPayment =>
+        Icons.event_available_outlined,
+      AssetManagementInsightActionType.cashShortageRisk =>
+        Icons.warning_amber_rounded,
+      AssetManagementInsightActionType.cardBillingConfiguration =>
+        Icons.credit_card_off_outlined,
+      AssetManagementInsightActionType.doubleCountingRisk =>
+        Icons.difference_outlined,
+    };
   }
 
   String _assetLiabilityManualSyncStatusLabel(

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -1,0 +1,698 @@
+import '../models/asset_liability_workbook.dart';
+
+enum AssetManagementInsightActionType {
+  missingInput,
+  missingPaymentDay,
+  missingAnnualRate,
+  missingPaymentSource,
+  overduePayment,
+  upcomingPayment,
+  cashShortageRisk,
+  cardBillingConfiguration,
+  doubleCountingRisk,
+}
+
+enum AssetManagementInsightSeverity { info, warning, critical }
+
+enum AssetManagementInsightWindow { today, week, month }
+
+class AssetManagementInsightActionItem {
+  final AssetManagementInsightActionType type;
+  final AssetManagementInsightSeverity severity;
+  final String title;
+  final String description;
+  final String? relatedAccountId;
+  final DateTime? dueDate;
+  final int? paymentDay;
+  final String suggestedAction;
+
+  const AssetManagementInsightActionItem({
+    required this.type,
+    required this.severity,
+    required this.title,
+    required this.description,
+    required this.relatedAccountId,
+    required this.dueDate,
+    required this.paymentDay,
+    required this.suggestedAction,
+  });
+}
+
+class AssetManagementAvailableMoneyInsight {
+  final AssetManagementInsightWindow window;
+  final DateTime startDate;
+  final DateTime endDate;
+  final double cashLikeTotal;
+  final double unpaidPaymentTotal;
+  final double unreceivedIncomeTotal;
+  final double minimumSafetyBalance;
+  final double availableAmount;
+  final String summary;
+
+  const AssetManagementAvailableMoneyInsight({
+    required this.window,
+    required this.startDate,
+    required this.endDate,
+    required this.cashLikeTotal,
+    required this.unpaidPaymentTotal,
+    required this.unreceivedIncomeTotal,
+    required this.minimumSafetyBalance,
+    required this.availableAmount,
+    required this.summary,
+  });
+}
+
+class AssetManagementMovementSuggestion {
+  final String fromAccountId;
+  final String fromAccountName;
+  final String? toAccountId;
+  final String? toAccountName;
+  final double amount;
+  final DateTime? neededBy;
+  final String reason;
+
+  const AssetManagementMovementSuggestion({
+    required this.fromAccountId,
+    required this.fromAccountName,
+    required this.toAccountId,
+    required this.toAccountName,
+    required this.amount,
+    required this.neededBy,
+    required this.reason,
+  });
+}
+
+class AssetManagementDeveloperRequest {
+  final String title;
+  final String description;
+  final AssetManagementInsightSeverity severity;
+
+  const AssetManagementDeveloperRequest({
+    required this.title,
+    required this.description,
+    required this.severity,
+  });
+}
+
+class AssetManagementInsightReport {
+  final List<AssetManagementInsightActionItem> actionItems;
+  final AssetManagementAvailableMoneyInsight todayAvailable;
+  final AssetManagementAvailableMoneyInsight weekAvailable;
+  final AssetManagementAvailableMoneyInsight monthAvailable;
+  final List<AssetManagementMovementSuggestion> movementSuggestions;
+  final List<AssetManagementDeveloperRequest> developerRequests;
+
+  const AssetManagementInsightReport({
+    required this.actionItems,
+    required this.todayAvailable,
+    required this.weekAvailable,
+    required this.monthAvailable,
+    required this.movementSuggestions,
+    required this.developerRequests,
+  });
+
+  bool get hasCriticalActions {
+    return actionItems.any(
+      (item) => item.severity == AssetManagementInsightSeverity.critical,
+    );
+  }
+
+  List<AssetManagementInsightActionItem> get criticalActions {
+    return actionItems
+        .where(
+          (item) => item.severity == AssetManagementInsightSeverity.critical,
+        )
+        .toList(growable: false);
+  }
+}
+
+class AssetManagementInsightService {
+  static const double defaultMinimumSafetyBalance = 10000;
+  static const int defaultUpcomingPaymentWarningDays = 3;
+
+  const AssetManagementInsightService();
+
+  AssetManagementInsightReport buildReport({
+    required AssetLiabilityWorkbook workbook,
+    double minimumSafetyBalance = defaultMinimumSafetyBalance,
+    int upcomingPaymentWarningDays = defaultUpcomingPaymentWarningDays,
+  }) {
+    final actions = _buildActionItems(
+      workbook: workbook,
+      upcomingPaymentWarningDays: upcomingPaymentWarningDays,
+    )..sort(_compareActionItems);
+    final today = _buildAvailableMoneyInsight(
+      workbook: workbook,
+      window: AssetManagementInsightWindow.today,
+      startDate: _dateOnly(workbook.baseDate),
+      endDate: _dateOnly(workbook.baseDate),
+      minimumSafetyBalance: minimumSafetyBalance,
+    );
+    final week = _buildAvailableMoneyInsight(
+      workbook: workbook,
+      window: AssetManagementInsightWindow.week,
+      startDate: _dateOnly(workbook.baseDate),
+      endDate: _dateOnly(workbook.baseDate).add(const Duration(days: 6)),
+      minimumSafetyBalance: minimumSafetyBalance,
+    );
+    final month = _buildAvailableMoneyInsight(
+      workbook: workbook,
+      window: AssetManagementInsightWindow.month,
+      startDate: DateTime(workbook.baseDate.year, workbook.baseDate.month),
+      endDate: DateTime(workbook.baseDate.year, workbook.baseDate.month + 1, 0),
+      minimumSafetyBalance: minimumSafetyBalance,
+    );
+    final movementSuggestions = _buildMovementSuggestions(
+      workbook: workbook,
+      windows: <AssetManagementAvailableMoneyInsight>[today, week, month],
+      minimumSafetyBalance: minimumSafetyBalance,
+    );
+    final developerRequests = _buildDeveloperRequests(
+      workbook: workbook,
+      actions: actions,
+      movementSuggestions: movementSuggestions,
+    );
+
+    return AssetManagementInsightReport(
+      actionItems: actions,
+      todayAvailable: today,
+      weekAvailable: week,
+      monthAvailable: month,
+      movementSuggestions: movementSuggestions,
+      developerRequests: developerRequests,
+    );
+  }
+
+  List<AssetManagementInsightActionItem> _buildActionItems({
+    required AssetLiabilityWorkbook workbook,
+    required int upcomingPaymentWarningDays,
+  }) {
+    final actions = <AssetManagementInsightActionItem>[];
+    final today = _dateOnly(workbook.baseDate);
+    final upcomingLimit = today.add(Duration(days: upcomingPaymentWarningDays));
+
+    for (final row in workbook.debtMasterRows) {
+      if (row.paymentAmountEstimated && row.isDirectCashflowTarget) {
+        actions.add(
+          AssetManagementInsightActionItem(
+            type: AssetManagementInsightActionType.missingInput,
+            severity: AssetManagementInsightSeverity.info,
+            title: '${row.name}の今月支払予定額を確認',
+            description: '実請求額が未入力のため、推定最低支払額で資金繰りに入っています。',
+            relatedAccountId: row.id,
+            dueDate: _paymentDateFor(row, workbook.baseDate),
+            paymentDay: row.paymentDay,
+            suggestedAction: '請求確定後に今月支払予定額を入力してください。',
+          ),
+        );
+      }
+      if (row.paymentDay == null) {
+        actions.add(
+          AssetManagementInsightActionItem(
+            type: AssetManagementInsightActionType.missingPaymentDay,
+            severity: AssetManagementInsightSeverity.warning,
+            title: '${row.name}の支払日が未入力です',
+            description: '支払日がないため、支払日順資金繰りで正しい危険日を判断しにくい状態です。',
+            relatedAccountId: row.id,
+            dueDate: null,
+            paymentDay: null,
+            suggestedAction: '契約画面または請求明細で支払日を確認して入力してください。',
+          ),
+        );
+      }
+      if (_needsAnnualRate(row)) {
+        actions.add(
+          AssetManagementInsightActionItem(
+            type: AssetManagementInsightActionType.missingAnnualRate,
+            severity: AssetManagementInsightSeverity.warning,
+            title: '${row.name}の利率を確認',
+            description: 'カードローン・カード系の金利が未入力のため、返済優先度の判断精度が落ちます。',
+            relatedAccountId: row.id,
+            dueDate: _paymentDateFor(row, workbook.baseDate),
+            paymentDay: row.paymentDay,
+            suggestedAction: '契約中の年利を確認し、負債マスタへ入力してください。',
+          ),
+        );
+      }
+      if (row.isDirectCashflowTarget &&
+          !row.paid &&
+          (row.paymentSourceAccountId == null ||
+              row.paymentSourceAccountId!.trim().isEmpty)) {
+        actions.add(
+          AssetManagementInsightActionItem(
+            type: AssetManagementInsightActionType.missingPaymentSource,
+            severity: AssetManagementInsightSeverity.warning,
+            title: '${row.name}の支払原資口座が未設定です',
+            description: 'どの口座から引き落とすか未設定のため、口座別資金繰りに反映しにくい状態です。',
+            relatedAccountId: row.id,
+            dueDate: _paymentDateFor(row, workbook.baseDate),
+            paymentDay: row.paymentDay,
+            suggestedAction: '通常使う引落口座をデフォルト、または今月だけ上書きで設定してください。',
+          ),
+        );
+      }
+    }
+
+    for (final row in workbook.cashflowRows.where((row) => row.isPayment)) {
+      if (!row.isDirectCashflowTarget || row.paid) {
+        continue;
+      }
+      if (row.overdue) {
+        actions.add(
+          AssetManagementInsightActionItem(
+            type: AssetManagementInsightActionType.overduePayment,
+            severity: AssetManagementInsightSeverity.critical,
+            title: '${row.accountName}が期限超過です',
+            description: '支払日を過ぎた未払い予定があります。',
+            relatedAccountId: row.accountId,
+            dueDate: row.paymentDate,
+            paymentDay: row.paymentDay,
+            suggestedAction: '残高と引落状況を確認し、支払済みならチェックを更新してください。',
+          ),
+        );
+      } else if (!row.paymentDate.isBefore(today) &&
+          !row.paymentDate.isAfter(upcomingLimit)) {
+        actions.add(
+          AssetManagementInsightActionItem(
+            type: AssetManagementInsightActionType.upcomingPayment,
+            severity: AssetManagementInsightSeverity.warning,
+            title: '${row.accountName}の支払日が近づいています',
+            description: '${_formatYen(row.paymentAmount)}の支払いが近づいています。',
+            relatedAccountId: row.accountId,
+            dueDate: row.paymentDate,
+            paymentDay: row.paymentDay,
+            suggestedAction: '支払原資口座の残高を確認してください。',
+          ),
+        );
+      }
+      if (row.riskLevel == AssetLiabilityCashRiskLevel.short) {
+        actions.add(
+          AssetManagementInsightActionItem(
+            type: AssetManagementInsightActionType.cashShortageRisk,
+            severity: AssetManagementInsightSeverity.critical,
+            title: '${row.accountName}支払い後に資金ショートします',
+            description: '支払後手元資金が${_formatYen(row.cashAfterPayment)}になります。',
+            relatedAccountId: row.accountId,
+            dueDate: row.paymentDate,
+            paymentDay: row.paymentDay,
+            suggestedAction: '支払い前に口座移動または出金を行ってください。',
+          ),
+        );
+      }
+    }
+
+    for (final item in workbook.cardBillingReview.needsReviewItems) {
+      actions.add(
+        AssetManagementInsightActionItem(
+          type: AssetManagementInsightActionType.cardBillingConfiguration,
+          severity: AssetManagementInsightSeverity.warning,
+          title: '${item.accountName}のカード請求設定を確認',
+          description: item.alerts.join(' / '),
+          relatedAccountId: item.accountId,
+          dueDate: item.paymentDay == null
+              ? null
+              : _paymentDateFromDay(workbook.baseDate, item.paymentDay!),
+          paymentDay: item.paymentDay,
+          suggestedAction: 'カード請求に含める設定と請求先カードを確認してください。',
+        ),
+      );
+    }
+
+    for (final item in workbook.cardBillingReview.doubleCountingRiskItems) {
+      actions.add(
+        AssetManagementInsightActionItem(
+          type: AssetManagementInsightActionType.doubleCountingRisk,
+          severity: AssetManagementInsightSeverity.critical,
+          title: '${item.accountName}に二重計上リスクがあります',
+          description: '直接支払いとカード請求内訳の両方で計算される可能性があります。',
+          relatedAccountId: item.accountId,
+          dueDate: item.paymentDay == null
+              ? null
+              : _paymentDateFromDay(workbook.baseDate, item.paymentDay!),
+          paymentDay: item.paymentDay,
+          suggestedAction: '支払い方式を直接支払いまたはカード請求に含めるのどちらかへ整理してください。',
+        ),
+      );
+    }
+
+    return actions;
+  }
+
+  AssetManagementAvailableMoneyInsight _buildAvailableMoneyInsight({
+    required AssetLiabilityWorkbook workbook,
+    required AssetManagementInsightWindow window,
+    required DateTime startDate,
+    required DateTime endDate,
+    required double minimumSafetyBalance,
+  }) {
+    final payments = _paymentTotalForWindow(
+      workbook: workbook,
+      startDate: startDate,
+      endDate: endDate,
+    );
+    final income = _incomeTotalForWindow(
+      workbook: workbook,
+      startDate: startDate,
+      endDate: endDate,
+    );
+    final available =
+        workbook.cashLikeTotal + income - payments - minimumSafetyBalance;
+    return AssetManagementAvailableMoneyInsight(
+      window: window,
+      startDate: startDate,
+      endDate: endDate,
+      cashLikeTotal: workbook.cashLikeTotal,
+      unpaidPaymentTotal: payments,
+      unreceivedIncomeTotal: income,
+      minimumSafetyBalance: minimumSafetyBalance,
+      availableAmount: available,
+      summary: _availableSummary(window, available),
+    );
+  }
+
+  List<AssetManagementMovementSuggestion> _buildMovementSuggestions({
+    required AssetLiabilityWorkbook workbook,
+    required List<AssetManagementAvailableMoneyInsight> windows,
+    required double minimumSafetyBalance,
+  }) {
+    final suggestions = <AssetManagementMovementSuggestion>[
+      for (final suggestion in workbook.transferSuggestions)
+        AssetManagementMovementSuggestion(
+          fromAccountId: suggestion.fromAccountId,
+          fromAccountName: suggestion.fromAccountName,
+          toAccountId: suggestion.toAccountId,
+          toAccountName: suggestion.toAccountName,
+          amount: suggestion.amount,
+          neededBy: suggestion.neededBy,
+          reason: '口座別資金繰りで不足が見込まれています。',
+        ),
+    ];
+
+    final worstWindow = windows
+        .where((window) => window.availableAmount < 0)
+        .toList()
+      ..sort((a, b) => a.availableAmount.compareTo(b.availableAmount));
+    if (worstWindow.isEmpty) {
+      return _dedupeSuggestions(suggestions);
+    }
+
+    var needed = worstWindow.first.availableAmount.abs();
+    final donors = workbook.accounts
+        .where(
+          (account) =>
+              account.balance > minimumSafetyBalance &&
+              (account.kind == AssetLiabilityAccountKind.cash ||
+                  account.kind == AssetLiabilityAccountKind.deposit ||
+                  account.kind == AssetLiabilityAccountKind.otherAsset),
+        )
+        .toList()
+      ..sort((a, b) => b.balance.compareTo(a.balance));
+
+    for (final donor in donors) {
+      if (needed <= 0) {
+        break;
+      }
+      final surplus = donor.balance - minimumSafetyBalance;
+      if (surplus <= 0) {
+        continue;
+      }
+      final amount = surplus < needed ? surplus : needed;
+      if (amount <= 0) {
+        continue;
+      }
+      suggestions.add(
+        AssetManagementMovementSuggestion(
+          fromAccountId: donor.id,
+          fromAccountName: donor.name,
+          toAccountId: null,
+          toAccountName: null,
+          amount: amount,
+          neededBy: worstWindow.first.endDate,
+          reason: '${_windowLabel(worstWindow.first.window)}の使用可能額が不足しています。',
+        ),
+      );
+      needed -= amount;
+    }
+
+    return _dedupeSuggestions(suggestions);
+  }
+
+  List<AssetManagementDeveloperRequest> _buildDeveloperRequests({
+    required AssetLiabilityWorkbook workbook,
+    required List<AssetManagementInsightActionItem> actions,
+    required List<AssetManagementMovementSuggestion> movementSuggestions,
+  }) {
+    final requests = <AssetManagementDeveloperRequest>[];
+    if (workbook.debtMasterRows.any((row) => row.paymentAmountEstimated)) {
+      requests.add(
+        const AssetManagementDeveloperRequest(
+          title: '実支払額と推定額の差分管理',
+          description:
+              '現状では推定最低支払額と実際の引落額の差分を月次で記録しにくいです。カード請求内訳の実績差分管理機能を追加してください。',
+          severity: AssetManagementInsightSeverity.info,
+        ),
+      );
+    }
+    if (actions.any(
+      (action) =>
+          action.type == AssetManagementInsightActionType.missingPaymentSource,
+    )) {
+      requests.add(
+        const AssetManagementDeveloperRequest(
+          title: '支払原資口座の未設定レビュー',
+          description:
+              '現状では支払原資口座が未設定のままでも運用できてしまいます。未設定項目を一括で確認・設定できる機能を追加してください。',
+          severity: AssetManagementInsightSeverity.warning,
+        ),
+      );
+    }
+    if (workbook.cardBillingReview.hasNeedsReviewItems) {
+      requests.add(
+        const AssetManagementDeveloperRequest(
+          title: 'カード請求内訳の設定監査',
+          description:
+              '現状ではカード請求に含める項目の請求先不整合を手動確認する必要があります。請求先カード未設定や削除済みカードを月次レビューで修正できる機能を強化してください。',
+          severity: AssetManagementInsightSeverity.warning,
+        ),
+      );
+    }
+    if (movementSuggestions.isNotEmpty || workbook.hasAccountShortage) {
+      requests.add(
+        const AssetManagementDeveloperRequest(
+          title: '口座間移動タスク管理',
+          description:
+              '現状では口座間移動の提案を完了タスクとして保存できません。移動候補をタスク化し、実行済み管理できる機能を追加してください。',
+          severity: AssetManagementInsightSeverity.warning,
+        ),
+      );
+    }
+    if (requests.isEmpty) {
+      requests.add(
+        const AssetManagementDeveloperRequest(
+          title: '月次レビュー履歴の強化',
+          description:
+              '現状ではAI資産管理アシスタントの確認結果を月次履歴へ保存していません。レビュー完了ログと改善メモを保存できる機能を追加してください。',
+          severity: AssetManagementInsightSeverity.info,
+        ),
+      );
+    }
+    return requests;
+  }
+
+  double _paymentTotalForWindow({
+    required AssetLiabilityWorkbook workbook,
+    required DateTime startDate,
+    required DateTime endDate,
+  }) {
+    return workbook.cashflowRows.fold<double>(0, (sum, row) {
+      if (!row.isPayment ||
+          !row.isDirectCashflowTarget ||
+          row.paid ||
+          row.paymentAmount <= 0) {
+        return sum;
+      }
+      final date = _dateOnly(row.paymentDate);
+      final inWindow = !date.isBefore(startDate) && !date.isAfter(endDate);
+      final overdueForWindow =
+          row.overdue && !endDate.isBefore(_dateOnly(workbook.baseDate));
+      return inWindow || overdueForWindow ? sum + row.paymentAmount : sum;
+    });
+  }
+
+  double _incomeTotalForWindow({
+    required AssetLiabilityWorkbook workbook,
+    required DateTime startDate,
+    required DateTime endDate,
+  }) {
+    return workbook.cashflowRows.fold<double>(0, (sum, row) {
+      if (!row.isIncome || row.received || row.paymentAmount <= 0) {
+        return sum;
+      }
+      final date = _dateOnly(row.paymentDate);
+      return !date.isBefore(startDate) && !date.isAfter(endDate)
+          ? sum + row.paymentAmount
+          : sum;
+    });
+  }
+
+  bool _needsAnnualRate(AssetLiabilityDebtRow row) {
+    if (row.annualRate > 0) {
+      return false;
+    }
+    return switch (row.kind) {
+      AssetLiabilityAccountKind.cardLoan ||
+      AssetLiabilityAccountKind.shoppingDebt ||
+      AssetLiabilityAccountKind.creditCard ||
+      AssetLiabilityAccountKind.otherLiability =>
+        true,
+      _ => false,
+    };
+  }
+
+  List<AssetManagementMovementSuggestion> _dedupeSuggestions(
+    List<AssetManagementMovementSuggestion> suggestions,
+  ) {
+    final seen = <String>{};
+    final result = <AssetManagementMovementSuggestion>[];
+    for (final suggestion in suggestions) {
+      final key =
+          '${suggestion.fromAccountId}|${suggestion.toAccountId}|${suggestion.amount.round()}';
+      if (seen.add(key)) {
+        result.add(suggestion);
+      }
+    }
+    return result;
+  }
+
+  int _compareActionItems(
+    AssetManagementInsightActionItem a,
+    AssetManagementInsightActionItem b,
+  ) {
+    final severity = _severityRank(
+      b.severity,
+    ).compareTo(_severityRank(a.severity));
+    if (severity != 0) {
+      return severity;
+    }
+    final aDate = a.dueDate ?? DateTime(9999);
+    final bDate = b.dueDate ?? DateTime(9999);
+    final date = aDate.compareTo(bDate);
+    if (date != 0) {
+      return date;
+    }
+    return a.title.compareTo(b.title);
+  }
+
+  int _severityRank(AssetManagementInsightSeverity severity) {
+    return switch (severity) {
+      AssetManagementInsightSeverity.critical => 3,
+      AssetManagementInsightSeverity.warning => 2,
+      AssetManagementInsightSeverity.info => 1,
+    };
+  }
+
+  DateTime? _paymentDateFor(AssetLiabilityDebtRow row, DateTime baseDate) {
+    if (row.paymentDay == null) {
+      return null;
+    }
+    return _paymentDateFromDay(baseDate, row.paymentDay!);
+  }
+
+  DateTime _paymentDateFromDay(DateTime baseDate, int day) {
+    final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
+    return DateTime(baseDate.year, baseDate.month, day.clamp(1, lastDay));
+  }
+
+  DateTime _dateOnly(DateTime value) {
+    return DateTime(value.year, value.month, value.day);
+  }
+
+  String _availableSummary(AssetManagementInsightWindow window, double amount) {
+    final label = _windowLabel(window);
+    if (amount < 0) {
+      return '$labelの使用可能額は${_formatYen(amount)}です。支払い前に資金移動を確認してください。';
+    }
+    return '$labelの使用可能額は${_formatYen(amount)}です。';
+  }
+
+  String _windowLabel(AssetManagementInsightWindow window) {
+    return switch (window) {
+      AssetManagementInsightWindow.today => '本日',
+      AssetManagementInsightWindow.week => '今週',
+      AssetManagementInsightWindow.month => '今月',
+    };
+  }
+
+  String _formatYen(double amount) {
+    final sign = amount < 0 ? '-' : '';
+    final digits = amount.abs().round().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i += 1) {
+      final remaining = digits.length - i;
+      buffer.write(digits[i]);
+      if (remaining > 1 && remaining % 3 == 1) {
+        buffer.write(',');
+      }
+    }
+    return '$sign$buffer円';
+  }
+}
+
+class AssetManagementInsightPromptBuilder {
+  const AssetManagementInsightPromptBuilder();
+
+  String buildPrompt(AssetManagementInsightReport report) {
+    final buffer = StringBuffer()
+      ..writeln('あなたは資産管理AIアシスタントです。')
+      ..writeln('重要: 金額計算はDart側で計算済みです。数値を再計算せず、説明と優先順位付けだけ行ってください。')
+      ..writeln()
+      ..writeln('## 使用可能額')
+      ..writeln('- 本日: ${_formatAmount(report.todayAvailable.availableAmount)}')
+      ..writeln('- 今週: ${_formatAmount(report.weekAvailable.availableAmount)}')
+      ..writeln('- 今月: ${_formatAmount(report.monthAvailable.availableAmount)}')
+      ..writeln()
+      ..writeln('## アクションアイテム');
+    if (report.actionItems.isEmpty) {
+      buffer.writeln('- 重要なアクションはありません。');
+    } else {
+      for (final item in report.actionItems.take(12)) {
+        buffer.writeln(
+          '- [${item.severity.name}] ${item.title}: ${item.suggestedAction}',
+        );
+      }
+    }
+    buffer
+      ..writeln()
+      ..writeln('## 口座移動/出金提案');
+    if (report.movementSuggestions.isEmpty) {
+      buffer.writeln('- 現時点で提案はありません。');
+    } else {
+      for (final suggestion in report.movementSuggestions.take(8)) {
+        buffer.writeln(
+          '- ${suggestion.fromAccountName}から${_formatAmount(suggestion.amount)}: ${suggestion.reason}',
+        );
+      }
+    }
+    buffer
+      ..writeln()
+      ..writeln('## 開発者向け改善提案');
+    for (final request in report.developerRequests.take(8)) {
+      buffer.writeln('- ${request.title}: ${request.description}');
+    }
+    return buffer.toString();
+  }
+
+  String _formatAmount(double amount) {
+    final sign = amount < 0 ? '-' : '';
+    final digits = amount.abs().round().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i += 1) {
+      final remaining = digits.length - i;
+      buffer.write(digits[i]);
+      if (remaining > 1 && remaining % 3 == 1) {
+        buffer.write(',');
+      }
+    }
+    return '$sign$buffer円';
+  }
+}

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -1,0 +1,274 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+import 'package:my_web_app/services/asset_management_insight_service.dart';
+
+void main() {
+  group('AssetManagementInsightService', () {
+    const service = AssetManagementInsightService();
+    const planner = AssetLiabilityPlanningService();
+
+    test('marks missing payment day as an action item', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'Custom Card': -10000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      expect(
+        report.actionItems.any(
+          (item) =>
+              item.type == AssetManagementInsightActionType.missingPaymentDay,
+        ),
+        true,
+      );
+    });
+
+    test('marks missing annual rate as an action item', () {
+      final workbook = _workbook(
+        debtRows: <AssetLiabilityDebtRow>[
+          _debtRow(annualRate: 0, kind: AssetLiabilityAccountKind.cardLoan),
+        ],
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      expect(
+        report.actionItems.any(
+          (item) =>
+              item.type == AssetManagementInsightActionType.missingAnnualRate,
+        ),
+        true,
+      );
+    });
+
+    test('marks missing payment source as an action item', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'paypay_card': 20000},
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      expect(
+        report.actionItems.any(
+          (item) =>
+              item.type ==
+              AssetManagementInsightActionType.missingPaymentSource,
+        ),
+        true,
+      );
+    });
+
+    test('marks overdue payments as critical', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'auPayカード': -10000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.auPayCardAccountId: 10000,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.auPayCardAccountId: 'bank',
+        },
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      final overdue = report.actionItems.where(
+        (item) => item.type == AssetManagementInsightActionType.overduePayment,
+      );
+      expect(overdue.isNotEmpty, true);
+      expect(overdue.first.severity, AssetManagementInsightSeverity.critical);
+    });
+
+    test('calculates today, week, and month available amounts', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'paypay_card': 20000},
+        paymentSourceAccountIds: const <String, String>{'paypay_card': 'bank'},
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'salary',
+            date: DateTime(2026, 5, 2),
+            name: 'salary',
+            amount: 5000,
+            destinationAccountId: 'bank',
+            destinationAccountName: 'bank',
+            received: false,
+          ),
+        ],
+      );
+
+      final report = service.buildReport(
+        workbook: workbook,
+        minimumSafetyBalance: 10000,
+      );
+
+      expect(report.todayAvailable.availableAmount, 40000);
+      expect(report.weekAvailable.availableAmount, 45000);
+      expect(report.monthAvailable.availableAmount, 25000);
+    });
+
+    test('generates movement suggestions from accounts with surplus', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -45000},
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'paypay_card': 45000},
+        paymentSourceAccountIds: const <String, String>{'paypay_card': 'bank'},
+      );
+
+      final report = service.buildReport(
+        workbook: workbook,
+        minimumSafetyBalance: 10000,
+      );
+
+      expect(report.monthAvailable.availableAmount, -5000);
+      expect(report.movementSuggestions.isNotEmpty, true);
+      expect(report.movementSuggestions.first.fromAccountId, 'custom_bank');
+      expect(report.movementSuggestions.first.amount, 5000);
+    });
+
+    test('generates developer improvement requests', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
+        baseDate: DateTime(2026, 5, 1),
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      expect(report.developerRequests.isNotEmpty, true);
+      expect(report.developerRequests.first.description.contains('現状では'), true);
+    });
+
+    test('detects card billing configuration action items', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 50000, 'KDDI': -5764},
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+        },
+        cardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'missing_card',
+        },
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      expect(
+        report.actionItems.any(
+          (item) =>
+              item.type ==
+              AssetManagementInsightActionType.cardBillingConfiguration,
+        ),
+        true,
+      );
+    });
+
+    test('builds prompt with deterministic calculated values', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'Custom Card': -10000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+      );
+      final report = service.buildReport(workbook: workbook);
+
+      final prompt = const AssetManagementInsightPromptBuilder().buildPrompt(
+        report,
+      );
+
+      expect(prompt.contains('Dart側で計算済み'), true);
+      expect(prompt.contains('本日'), true);
+      expect(prompt.contains('アクションアイテム'), true);
+      expect(prompt.contains(report.actionItems.first.title), true);
+    });
+  });
+}
+
+AssetLiabilityWorkbook _workbook({
+  required List<AssetLiabilityDebtRow> debtRows,
+}) {
+  return AssetLiabilityWorkbook(
+    baseDate: DateTime(2026, 5, 1),
+    accounts: const <AssetLiabilityAccount>[
+      AssetLiabilityAccount(
+        id: 'bank',
+        name: 'bank',
+        kind: AssetLiabilityAccountKind.deposit,
+        balance: 50000,
+      ),
+    ],
+    debtMasterRows: debtRows,
+    repaymentPriorityRows: debtRows,
+    paymentDayRisks: const <AssetLiabilityPaymentDayRisk>[],
+    cashflowRows: const <AssetLiabilityCashflowRow>[],
+    incomePlans: const <AssetLiabilityIncomePlan>[],
+    accountCashflowSummaries: const <AssetLiabilityAccountCashflowSummary>[],
+    transferSuggestions: const <AssetLiabilityTransferSuggestion>[],
+    cardBillingReview: const AssetLiabilityCardBillingReviewData(
+      directPaymentItems: <AssetLiabilityCardBillingReviewItem>[],
+      cardBillingGroups: <AssetLiabilityCardBillingGroup>[],
+      missingBillingAccountItems: <AssetLiabilityCardBillingReviewItem>[],
+      needsReviewItems: <AssetLiabilityCardBillingReviewItem>[],
+      doubleCountingRiskItems: <AssetLiabilityCardBillingReviewItem>[],
+    ),
+    cashLikeTotal: 50000,
+    securitiesTotal: 0,
+    positiveAssetTotal: 50000,
+    liabilityTotal: -10000,
+    netWorth: 40000,
+    monthlyMinimumPaymentEstimateTotal: 10000,
+    monthlyScheduledPaymentTotal: 10000,
+    monthlyUnpaidPaymentTotal: 10000,
+    monthlyUnreceivedIncomeTotal: 0,
+    cashAfterMinimumPayments: 40000,
+    cashAfterScheduledPayments: 40000,
+    debtToAssetRatio: 0.2,
+    topFourDebtShare: 1,
+    manualPaymentCount: 1,
+    estimatedPaymentCount: 0,
+  );
+}
+
+AssetLiabilityDebtRow _debtRow({
+  required double annualRate,
+  required AssetLiabilityAccountKind kind,
+}) {
+  return AssetLiabilityDebtRow(
+    id: 'loan',
+    name: 'loan',
+    kind: kind,
+    balance: -10000,
+    paymentDay: 15,
+    paymentSourceAccountId: 'bank',
+    paymentSourceAccountName: 'bank',
+    paymentMethod: AssetLiabilityPaymentMethod.direct,
+    paymentMethodLabel: '直接支払い',
+    paymentMethodSettingSource:
+        AssetLiabilityPaymentMethodSettingSource.builtInDefault,
+    billingAccountId: null,
+    billingAccountName: null,
+    includedInBillingAccount: false,
+    annualRate: annualRate,
+    minimumPaymentEstimate: 10000,
+    manualPaymentAmount: 10000,
+    scheduledPaymentAmount: 10000,
+    monthlyInterestEstimate: 0,
+    principalPaymentEstimate: 10000,
+    balanceAfterPaymentEstimate: 0,
+    liabilityShare: 1,
+    priorityLabel: 'test',
+    paymentAmountEstimated: false,
+    paid: false,
+  );
+}


### PR DESCRIPTION
﻿## 概要

資産管理ページに「AI資産管理アシスタント」の土台を追加しました。

金額計算は外部AIに任せず、既存の資産/負債ボードの計算結果を `AssetManagementInsightService` でルールベース分析し、今日/今週/今月の使用可能額、アクションアイテム、口座移動/出金候補、開発者向け改善提案を表示します。

## 主な変更

- `AssetManagementInsightService` を追加
  - 未入力、支払日未入力、利率未入力、支払原資口座未設定、期限超過、期限接近、資金ショート、カード請求内訳の設定漏れ、二重計上リスクを検出
  - 本日/今週/今月の使用可能額を計算
  - 口座移動/出金候補を生成
  - 開発者向け改善提案を生成
- `AssetManagementInsightPromptBuilder` を追加
  - 将来のAI要約用プロンプトを生成
  - プロンプトへ渡す数値はDart側で計算済み
  - 今回は外部AI API呼び出しなし
- 資産管理ページに「AI資産管理アシスタント」セクションを追加
  - アクションアイテム
  - 本日/今週/今月使用可能額
  - 口座移動/出金候補
  - 開発者向け改善提案
- サービス層テストを追加

## 補足

このPRはAI連携の土台作りです。外部AI API呼び出し、Supabase production write、migration/RLS、認証、決済連携、実DB書き込みは含みません。

## Minimal E2E Declaration

- This PR is implementation-detail independent at the behavior contract level: the user should see rule-based asset management insights derived from existing board data, regardless of the internal service split.
- Minimal black-box/input-output coverage is three cases: overdue payment produces a critical action, future cashflow produces today/week/month available money, and card-billing configuration issues produce an action item without direct double counting.
- E2E mechanism considered: Playwright or Flutter `integration_test` can open the asset management page and verify the assistant section renders with those data states.
- E2E-Exception: no new browser E2E file is added in this PR because the change is a deterministic service plus existing-page section with no new navigation, auth, backend write, or external AI call; coverage is provided by service tests and full Flutter tests.

## High-risk Ultrareview Gate

- Review owner: Claude Code #1
- High-Risk-Ultrareview-Exception: this PR mentions payment/card-billing domain text, but the scope is deterministic local insight rendering only; it has no security, auth, rollback-sensitive migration, production smoke, observability, deployment, Supabase production write, secrets, or payment provider integration changes.

## 検証

最新 `origin/main` へ rebase 後、以下を確認済みです。

- `dart format --output=none --set-exit-if-changed ...`: OK
- `dart analyze`: No issues found
- 資産/負債関連 `flutter test --no-pub ...`: 80 tests passed
- 全体 `flutter test --no-pub --reporter compact`: 461 tests passed
- `git diff --check HEAD~1..HEAD`: OK
- ローカルWeb確認: HTTP 200
