### PR TITLE
feat: add v27 disk compression guard (#1564)

### DIFF
--- a/.claude/hooks/session-end-auto-compress.ps1
+++ b/.claude/hooks/session-end-auto-compress.ps1
@@ -1,4 +1,5 @@
-# Issue #1564: v23 Layer LL SessionEnd/wrap-up auto-compress.
+# Issue #1564: v23 Layer LL SessionEnd/wrap-up auto-compress + v27
+# Layer DDD per-session disk quota contract.
 # Runs a deterministic wrap-up compression pass. It is advisory by default and
 # only fails closed when SESSION_COMPRESSION_WRAPUP_ENFORCE=1 is set.
 
@@ -42,6 +43,7 @@ $arguments = @(
     "--apply",
     "--banner",
     "--target-free-gb", "28",
+    "--min-reclaim-mb", "512",
     "--max-runtime-sec", "120"
 )
 

--- a/.claude/hooks/session-start-hard-gate.ps1
+++ b/.claude/hooks/session-start-hard-gate.ps1
@@ -1,4 +1,5 @@
-# Issue #1564: v23 Layer JJ SessionStart compression gate.
+# Issue #1564: v23 Layer JJ SessionStart compression gate + v27 Layer DDD
+# always-fire per-session disk quota contract.
 # Runs the repo-managed session compression guard and optionally enforces the
 # target when SESSION_COMPRESSION_FAIL_CLOSED=1 is set in the host environment.
 
@@ -40,9 +41,11 @@ $arguments = @(
     "--mode", "session-start",
     "--root", $projectDir,
     "--banner",
+    "--always-fire",
     "--max-runtime-sec", "120",
     "--min-free-gb", "26",
-    "--target-free-gb", "28"
+    "--target-free-gb", "28",
+    "--min-reclaim-mb", "512"
 )
 
 if ($env:SESSION_COMPRESSION_DRY_RUN -ne "1") {

--- a/.claude/hooks/smartcleanup-monthlydeep-guard.ps1
+++ b/.claude/hooks/smartcleanup-monthlydeep-guard.ps1
@@ -1,0 +1,64 @@
+# Issue #1564: v27 Layer GGG SmartCleanup_MonthlyDeep stuck guard.
+# Reports the 1999 LastRunTime / 267011 never-ran failure mode. It only starts
+# the task when SMARTCLEANUP_MONTHLYDEEP_FIX=1 is set.
+
+param()
+
+$ErrorActionPreference = "SilentlyContinue"
+
+function Resolve-PythonCommand {
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        return @($python.Source)
+    }
+
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($py) {
+        return @($py.Source, "-3")
+    }
+
+    return @()
+}
+
+$projectDir = $env:CLAUDE_PROJECT_DIR
+if (-not $projectDir) { $projectDir = (Get-Location).Path }
+
+$scriptPath = Join-Path $projectDir "scripts\smartcleanup_task_guard.py"
+if (-not (Test-Path $scriptPath)) {
+    Write-Output "[KPI] SmartCleanup guard missing: $scriptPath"
+    exit 0
+}
+
+$pythonCommand = @(Resolve-PythonCommand)
+if ($pythonCommand.Count -eq 0) {
+    Write-Output "[KPI] python unavailable; SmartCleanup guard skipped"
+    exit 0
+}
+
+$arguments = @(
+    $scriptPath,
+    "--task-name", "SmartCleanup_MonthlyDeep",
+    "--max-age-days", "35"
+)
+
+if ($env:SMARTCLEANUP_MONTHLYDEEP_FIX -eq "1") {
+    $arguments += "--fix"
+}
+if ($env:SMARTCLEANUP_MONTHLYDEEP_ENFORCE -eq "1") {
+    $arguments += "--enforce"
+}
+
+$command = $pythonCommand[0]
+$prefixArgs = @()
+if ($pythonCommand.Count -gt 1) {
+    $prefixArgs = $pythonCommand[1..($pythonCommand.Count - 1)]
+}
+
+& $command @prefixArgs @arguments
+$exitCode = $LASTEXITCODE
+
+if ($env:SMARTCLEANUP_MONTHLYDEEP_ENFORCE -eq "1" -and $exitCode -ne 0) {
+    exit $exitCode
+}
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -132,6 +132,10 @@
           },
           {
             "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/smartcleanup-monthlydeep-guard.ps1"
+          },
+          {
+            "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/session-start-state-check.ps1"
           }
         ]

--- a/.github/workflows/session-state-hooks.yml
+++ b/.github/workflows/session-state-hooks.yml
@@ -8,6 +8,7 @@ on:
       - ".claude/hooks/session-end-auto-compress.ps1"
       - ".claude/hooks/session-start-hard-gate.ps1"
       - ".claude/hooks/session-start-state-check.ps1"
+      - ".claude/hooks/smartcleanup-monthlydeep-guard.ps1"
       - ".claude/hooks/statusline.ps1"
       - ".claude/hooks/userprompt-idle-gap-fire.ps1"
       - ".claude/hooks/userprompt-kpi-banner.ps1"
@@ -19,6 +20,8 @@ on:
       - "scripts/codex_session_check.py"
       - "scripts/session_compression_guard.py"
       - "scripts/session_compression_guard_test.py"
+      - "scripts/smartcleanup_task_guard.py"
+      - "scripts/smartcleanup_task_guard_test.py"
   workflow_dispatch:
 
 permissions:
@@ -42,6 +45,9 @@ jobs:
 
       - name: Session compression guard unit tests
         run: python scripts/session_compression_guard_test.py
+
+      - name: SmartCleanup task guard unit tests
+        run: python scripts/smartcleanup_task_guard_test.py
 
       - name: Codex session check JSON smoke
         run: python scripts/codex_session_check.py --json > /tmp/codex-session-check.json

--- a/docs/CLAUDE_CODE_SETUP_RUNBOOK.md
+++ b/docs/CLAUDE_CODE_SETUP_RUNBOOK.md
@@ -107,6 +107,9 @@ Default behavior is safe for repo-managed hooks:
 
 - SessionStart applies `scripts/dev_cache_cleanup.py --apply` when C: free
   space is below 26 GB or the last cleanup fire is older than 4 hours.
+- SessionStart now passes `--always-fire --min-reclaim-mb 512` for the v27
+  Layer DDD contract. It still exits zero by default, but the per-fire quota
+  result is written to `~/.claude/logs/session-delta.csv`.
 - PreToolUse runs `.claude/hooks/pretooluse-compression-budget.ps1`, increments
   a local tool-use counter, records every 10th-tool KPI snapshot, and runs a
   capped 30-second cleanup only when C: free space is below 22 GB. The per-session
@@ -116,6 +119,14 @@ Default behavior is safe for repo-managed hooks:
 - Stop runs `.claude/hooks/session-end-auto-compress.ps1` as the repo-managed
   SessionEnd/wrap-up compression primitive. It is advisory unless
   `SESSION_COMPRESSION_WRAPUP_ENFORCE=1` is set.
+- Stop also records the v27 DDD 512 MB reclaim quota. Set
+  `SESSION_COMPRESSION_WRAPUP_ENFORCE=1` only after confirming local cleanup can
+  meet the quota without trapping the host shell.
+- SessionStart runs `.claude/hooks/smartcleanup-monthlydeep-guard.ps1` as the
+  v27 Layer GGG guard. It detects `SmartCleanup_MonthlyDeep` missing/stuck
+  states, including `LastTaskResult=267011` and 1999-era `LastRunTime` sentinel
+  values. It reports by default; set `SMARTCLEANUP_MONTHLYDEEP_FIX=1` to start
+  the task on demand, and `SMARTCLEANUP_MONTHLYDEEP_ENFORCE=1` to fail closed.
 - It exits zero by default so an unavailable Python runtime or a missed 28 GB
   target does not trap a user in a broken local shell.
 - Set `SESSION_COMPRESSION_FAIL_CLOSED=1` to enforce the 28 GB target and return
@@ -135,9 +146,11 @@ Manual verification examples:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File .claude\hooks\pretooluse-compression-budget.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude\hooks\smartcleanup-monthlydeep-guard.ps1
 powershell -NoProfile -ExecutionPolicy Bypass -File .claude\hooks\userprompt-idle-gap-fire.ps1
 powershell -NoProfile -ExecutionPolicy Bypass -File .claude\hooks\session-end-auto-compress.ps1
 python scripts\session_compression_guard_test.py
+python scripts\smartcleanup_task_guard_test.py
 python scripts\check_session_state_hooks.py --scan-transcripts
 ```
 

--- a/scripts/check_session_state_hooks.py
+++ b/scripts/check_session_state_hooks.py
@@ -21,6 +21,7 @@ REQUIRED_FILES = [
     ".claude/hooks/session-end-auto-compress.ps1",
     ".claude/hooks/session-start-hard-gate.ps1",
     ".claude/hooks/session-start-state-check.ps1",
+    ".claude/hooks/smartcleanup-monthlydeep-guard.ps1",
     ".claude/hooks/statusline.ps1",
     ".claude/hooks/userprompt-idle-gap-fire.ps1",
     ".claude/hooks/userprompt-kpi-banner.ps1",
@@ -31,6 +32,7 @@ REQUIRED_FILES = [
     "memory/transcripts/.gitignore",
     "memory/transcripts/.gitkeep",
     "scripts/session_compression_guard.py",
+    "scripts/smartcleanup_task_guard.py",
 ]
 
 SECRET_PATTERNS = [
@@ -77,6 +79,8 @@ def validate_settings(root: Path, errors: list[str]) -> None:
         errors.append("SessionStart must keep session-start-sync-rules.ps1")
     if not any("session-start-hard-gate.ps1" in command for command in commands):
         errors.append("SessionStart must run session-start-hard-gate.ps1")
+    if not any("smartcleanup-monthlydeep-guard.ps1" in command for command in commands):
+        errors.append("SessionStart must run smartcleanup-monthlydeep-guard.ps1")
     if not any("session-start-state-check.ps1" in command for command in commands):
         errors.append("SessionStart must run session-start-state-check.ps1")
 
@@ -172,6 +176,9 @@ def validate_session_compression(root: Path, errors: list[str]) -> None:
         "SESSION_START_PHASE",
         "PRETOOLUSE_PHASE",
         "WRAP_UP_PHASE",
+        "QuotaResult",
+        "always-fire disk quota contract",
+        "min_reclaim_mb",
     ]:
         require_contains(errors, guard_text, needle, guard_label)
 
@@ -193,6 +200,8 @@ def validate_session_compression(root: Path, errors: list[str]) -> None:
         "SESSION_COMPRESSION_DRY_RUN",
         "--mode\", \"session-start",
         "--apply",
+        "--always-fire",
+        "--min-reclaim-mb\", \"512",
         "session_compression_guard.py",
     ]:
         require_contains(errors, hard_gate_text, needle, hard_gate_label)
@@ -223,9 +232,32 @@ def validate_session_compression(root: Path, errors: list[str]) -> None:
         "SESSION_COMPRESSION_WRAPUP_ENFORCE",
         "--mode\", \"wrap-up",
         "--target-free-gb\", \"28",
+        "--min-reclaim-mb\", \"512",
         "session_compression_guard.py",
     ]:
         require_contains(errors, wrap_up_text, needle, wrap_up_label)
+
+    smartcleanup_text = read_text(root, ".claude/hooks/smartcleanup-monthlydeep-guard.ps1")
+    smartcleanup_label = "smartcleanup-monthlydeep-guard.ps1"
+    for needle in [
+        "SmartCleanup_MonthlyDeep",
+        "SMARTCLEANUP_MONTHLYDEEP_FIX",
+        "SMARTCLEANUP_MONTHLYDEEP_ENFORCE",
+        "smartcleanup_task_guard.py",
+    ]:
+        require_contains(errors, smartcleanup_text, needle, smartcleanup_label)
+
+    smartcleanup_guard = read_text(root, "scripts/smartcleanup_task_guard.py")
+    smartcleanup_guard_label = "smartcleanup_task_guard.py"
+    for needle in [
+        "TASK_NEVER_RAN_CODE = 267011",
+        "last_run_time sentinel year <= 1999",
+        "principal_user_id missing DOMAIN prefix",
+        "Set-ScheduledTask",
+        "Start-ScheduledTask",
+        "SmartCleanup_MonthlyDeep",
+    ]:
+        require_contains(errors, smartcleanup_guard, needle, smartcleanup_guard_label)
 
 
 def validate_statusline(root: Path, errors: list[str]) -> None:

--- a/scripts/session_compression_guard.py
+++ b/scripts/session_compression_guard.py
@@ -9,6 +9,7 @@ session compression contract for Issue #1564:
 - Layer LL: SessionEnd/wrap-up compression pass.
 - Layer MM: UserPromptSubmit idle-gap cleanup fire.
 - Layer NN: SessionStart/UserPromptSubmit KPI banner.
+- Layer DDD: Always-fire per-session disk quota contract.
 
 It writes state under the user's home directory by default so committed repo
 files stay clean. Tests can override every measured value and output path.
@@ -47,6 +48,14 @@ class CleanupResult:
 
 
 @dataclass
+class QuotaResult:
+    min_reclaim_mb: float = 0.0
+    actual_reclaim_mb: float = 0.0
+    passed: bool = True
+    reason: str = "disabled"
+
+
+@dataclass
 class GuardResult:
     mode: str
     phase: str
@@ -61,6 +70,7 @@ class GuardResult:
     fatigue: str
     banner: str
     cleanup: CleanupResult
+    quota: QuotaResult
     log_path: str
     state_path: str
 
@@ -181,6 +191,13 @@ def build_banner(
 
 
 def run_dev_cache_cleanup(args: argparse.Namespace) -> CleanupResult:
+    if args.sample_cleanup_reclaim_mb is not None:
+        return CleanupResult(
+            status="sampled",
+            returncode=0,
+            actual_reclaim_mb=round(max(0.0, args.sample_cleanup_reclaim_mb), 1),
+        )
+
     script = args.root / "scripts" / "dev_cache_cleanup.py"
     if not script.exists():
         return CleanupResult(status="missing_dev_cache_cleanup", stderr_tail=str(script))
@@ -256,6 +273,9 @@ def append_session_delta(path: Path, result: GuardResult) -> None:
                 "last_fire_age_min",
                 "fatigue",
                 "cleanup_status",
+                "quota_min_reclaim_mb",
+                "quota_pass",
+                "quota_reason",
             ],
         )
         if not exists:
@@ -274,8 +294,38 @@ def append_session_delta(path: Path, result: GuardResult) -> None:
                 "last_fire_age_min": result.last_fire_age_min,
                 "fatigue": result.fatigue,
                 "cleanup_status": result.cleanup.status,
+                "quota_min_reclaim_mb": result.quota.min_reclaim_mb,
+                "quota_pass": result.quota.passed,
+                "quota_reason": result.quota.reason,
             }
         )
+
+
+def build_quota_result(args: argparse.Namespace, cleanup: CleanupResult) -> QuotaResult:
+    min_reclaim = round(max(0.0, args.min_reclaim_mb), 1)
+    actual = round(max(0.0, cleanup.actual_reclaim_mb), 1)
+    if min_reclaim <= 0:
+        return QuotaResult(actual_reclaim_mb=actual)
+    if cleanup.status == "skipped":
+        return QuotaResult(
+            min_reclaim_mb=min_reclaim,
+            actual_reclaim_mb=actual,
+            passed=False,
+            reason="cleanup did not run",
+        )
+    if actual >= min_reclaim:
+        return QuotaResult(
+            min_reclaim_mb=min_reclaim,
+            actual_reclaim_mb=actual,
+            passed=True,
+            reason=f"reclaim {actual:.1f} MB >= {min_reclaim:.1f} MB",
+        )
+    return QuotaResult(
+        min_reclaim_mb=min_reclaim,
+        actual_reclaim_mb=actual,
+        passed=False,
+        reason=f"reclaim {actual:.1f} MB < {min_reclaim:.1f} MB",
+    )
 
 
 def decide_session_start(
@@ -359,12 +409,16 @@ def run_guard(args: argparse.Namespace) -> GuardResult:
 
     if args.mode == "session-start":
         phase = SESSION_START_PHASE
-        should_fire, reason = decide_session_start(
-            c_free_gb=c_free_before,
-            last_fire_age_min=last_fire_age_min,
-            min_free_gb=args.min_free_gb,
-            max_age_hours=args.max_age_hours,
-        )
+        if args.always_fire:
+            should_fire = True
+            reason = "always-fire disk quota contract"
+        else:
+            should_fire, reason = decide_session_start(
+                c_free_gb=c_free_before,
+                last_fire_age_min=last_fire_age_min,
+                min_free_gb=args.min_free_gb,
+                max_age_hours=args.max_age_hours,
+            )
         state["session_started_at"] = now.isoformat()
         state["tool_use_count_session"] = 0
         state["mid_fire_count_session"] = 0
@@ -431,6 +485,8 @@ def run_guard(args: argparse.Namespace) -> GuardResult:
     if args.apply and should_fire and not cleanup_required:
         cleanup = CleanupResult(status="snapshot_only")
 
+    quota = build_quota_result(args, cleanup)
+
     if args.apply and state_dirty:
         write_state(args.state_path, state)
 
@@ -456,6 +512,7 @@ def run_guard(args: argparse.Namespace) -> GuardResult:
         fatigue=fatigue,
         banner=banner,
         cleanup=cleanup,
+        quota=quota,
         log_path=str(args.log_path),
         state_path=str(args.state_path),
     )
@@ -482,6 +539,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--log-path", type=Path, default=home_log)
     parser.add_argument("--min-free-gb", type=float, default=26.0)
     parser.add_argument("--target-free-gb", type=float, default=28.0)
+    parser.add_argument("--min-reclaim-mb", type=float, default=0.0)
     parser.add_argument("--max-age-hours", type=float, default=4.0)
     parser.add_argument("--max-age-minutes", type=float, default=30.0)
     parser.add_argument("--cooldown-minutes", type=float, default=60.0)
@@ -490,6 +548,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--max-mid-fires", type=int, default=5)
     parser.add_argument("--max-runtime-sec", type=int, default=120)
     parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--always-fire", action="store_true")
     parser.add_argument("--tier18", action="store_true")
     parser.add_argument("--tier19", action="store_true")
     parser.add_argument("--enforce", action="store_true")
@@ -499,6 +558,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--log-dry-run", action="store_true")
     parser.add_argument("--sample-free-gb", type=float)
     parser.add_argument("--sample-free-gb-after", type=float)
+    parser.add_argument("--sample-cleanup-reclaim-mb", type=float)
     parser.add_argument("--sample-ram-pct", type=float)
     parser.add_argument("--sample-ram-pct-after", type=float)
     parser.add_argument("--sample-now")
@@ -524,6 +584,8 @@ def main(argv: list[str]) -> int:
         effective_free = result.c_free_gb_after if result.c_free_gb_after is not None else result.c_free_gb_before
         if effective_free < args.target_free_gb:
             return 2
+        if not result.quota.passed:
+            return 3
     return 0
 
 

--- a/scripts/session_compression_guard_test.py
+++ b/scripts/session_compression_guard_test.py
@@ -74,6 +74,29 @@ class SessionCompressionGuardTest(unittest.TestCase):
         self.assertFalse(result["should_fire"])
         self.assertEqual(result["decision"], "skip")
 
+    def test_session_start_always_fire_overrides_recent_capacity(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            state = tmp / "state.json"
+            state.write_text(
+                json.dumps({"last_fire_at": "2026-05-14T00:00:00+00:00", "fires": []}),
+                encoding="utf-8",
+            )
+            result = self.run_guard(
+                tmp,
+                "--mode",
+                "session-start",
+                "--always-fire",
+                "--sample-free-gb",
+                "29.0",
+                "--sample-now",
+                "2026-05-14T00:30:00+00:00",
+            )
+
+        self.assertTrue(result["should_fire"])
+        self.assertEqual(result["decision"], "due")
+        self.assertEqual(result["reason"], "always-fire disk quota contract")
+
     def test_userprompt_respects_hourly_cooldown(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             tmp = Path(raw)
@@ -141,6 +164,53 @@ class SessionCompressionGuardTest(unittest.TestCase):
         self.assertTrue(result["should_fire"])
         self.assertEqual(result["phase"], "wrap_up_post")
         self.assertEqual(result["reason"], "wrap-up compression required")
+
+    def test_min_reclaim_quota_records_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            result = self.run_guard(
+                tmp,
+                "--mode",
+                "wrap-up",
+                "--apply",
+                "--sample-free-gb",
+                "12.0",
+                "--sample-free-gb-after",
+                "12.7",
+                "--sample-cleanup-reclaim-mb",
+                "700",
+                "--min-reclaim-mb",
+                "512",
+                "--sample-now",
+                "2026-05-14T01:15:00+00:00",
+            )
+
+        self.assertEqual(result["cleanup"]["status"], "sampled")
+        self.assertTrue(result["quota"]["passed"])
+        self.assertIn(">= 512.0 MB", result["quota"]["reason"])
+
+    def test_min_reclaim_quota_records_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            result = self.run_guard(
+                tmp,
+                "--mode",
+                "wrap-up",
+                "--apply",
+                "--sample-free-gb",
+                "12.0",
+                "--sample-free-gb-after",
+                "12.1",
+                "--sample-cleanup-reclaim-mb",
+                "100",
+                "--min-reclaim-mb",
+                "512",
+                "--sample-now",
+                "2026-05-14T01:15:00+00:00",
+            )
+
+        self.assertFalse(result["quota"]["passed"])
+        self.assertIn("< 512.0 MB", result["quota"]["reason"])
 
     def test_fatigue_flag_uses_last_three_reclaim_values(self) -> None:
         with tempfile.TemporaryDirectory() as raw:

--- a/scripts/smartcleanup_task_guard.py
+++ b/scripts/smartcleanup_task_guard.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Detect and optionally repair a stuck SmartCleanup_MonthlyDeep task.
+
+Issue #1564 v27 Layer GGG calls out a local Windows Task Scheduler failure mode:
+`LastTaskResult = 267011` with a 1999-era `LastRunTime`, which means the monthly
+deep cleanup task never actually ran. This checker is safe by default: it only
+reports the task state unless `--fix` is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+TASK_NEVER_RAN_CODE = 267011
+
+
+@dataclass
+class SmartCleanupTaskResult:
+    task_name: str
+    installed: bool
+    status: str
+    stuck: bool
+    reasons: list[str]
+    last_run_time: str
+    last_task_result: int | None
+    next_run_time: str
+    state: str
+    principal_user_id: str
+    run_level: str
+    logon_type: str
+    fix_attempted: bool
+    fix_result: str
+
+
+def parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    cleaned = str(value).strip()
+    if not cleaned:
+        return None
+    for candidate in (cleaned, cleaned.replace("Z", "+00:00")):
+        try:
+            parsed = datetime.fromisoformat(candidate)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def normalize_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def load_sample(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def collect_task_info(task_name: str) -> dict[str, Any]:
+    if os.name != "nt":
+        return {
+            "installed": False,
+            "state": "unsupported",
+            "last_run_time": "",
+            "last_task_result": None,
+            "next_run_time": "",
+            "error": "Windows Task Scheduler is only available on Windows",
+        }
+
+    ps = rf"""
+$ErrorActionPreference = 'Stop'
+$task = Get-ScheduledTask -TaskName '{task_name}' -ErrorAction SilentlyContinue
+if (-not $task) {{
+  [pscustomobject]@{{
+    installed = $false
+    state = 'missing'
+    last_run_time = ''
+    last_task_result = $null
+    next_run_time = ''
+  }} | ConvertTo-Json -Compress
+  exit 0
+}}
+$info = Get-ScheduledTaskInfo -TaskName '{task_name}'
+[pscustomobject]@{{
+  installed = $true
+  state = [string]$task.State
+  principal_user_id = [string]$task.Principal.UserId
+  run_level = [string]$task.Principal.RunLevel
+  logon_type = [string]$task.Principal.LogonType
+  last_run_time = if ($info.LastRunTime) {{ $info.LastRunTime.ToString('o') }} else {{ '' }}
+  last_task_result = $info.LastTaskResult
+  next_run_time = if ($info.NextRunTime) {{ $info.NextRunTime.ToString('o') }} else {{ '' }}
+}} | ConvertTo-Json -Compress
+"""
+    proc = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=20,
+    )
+    if proc.returncode != 0:
+        return {
+            "installed": False,
+            "state": "error",
+            "last_run_time": "",
+            "last_task_result": None,
+            "next_run_time": "",
+            "error": proc.stderr.strip() or proc.stdout.strip(),
+        }
+    return json.loads(proc.stdout or "{}")
+
+
+def analyze_task(task_name: str, payload: dict[str, Any], max_age_days: float) -> SmartCleanupTaskResult:
+    installed = bool(payload.get("installed"))
+    state = str(payload.get("state") or "")
+    principal_user_id = str(payload.get("principal_user_id") or "")
+    run_level = str(payload.get("run_level") or "")
+    logon_type = str(payload.get("logon_type") or "")
+    last_run_time = str(payload.get("last_run_time") or "")
+    next_run_time = str(payload.get("next_run_time") or "")
+    last_task_result = normalize_int(payload.get("last_task_result"))
+    reasons: list[str] = []
+
+    parsed_last_run = parse_dt(last_run_time)
+    never_ran = parsed_last_run is None or parsed_last_run.year <= 1999 or last_task_result == TASK_NEVER_RAN_CODE
+
+    if not installed:
+        reasons.append("task missing")
+    elif never_ran and principal_user_id and "\\" not in principal_user_id and not principal_user_id.startswith("S-"):
+        reasons.append("principal_user_id missing DOMAIN prefix")
+
+    if installed and parsed_last_run is None:
+        reasons.append("last_run_time missing")
+    elif parsed_last_run is not None and parsed_last_run.year <= 1999:
+        reasons.append("last_run_time sentinel year <= 1999")
+
+    if last_task_result == TASK_NEVER_RAN_CODE:
+        reasons.append("last_task_result 267011 indicates task has not run")
+    elif last_task_result not in (None, 0, 267009):
+        reasons.append(f"last_task_result {last_task_result} is non-zero")
+
+    if parsed_last_run is not None and parsed_last_run.year > 1999:
+        age_days = (datetime.now(timezone.utc) - parsed_last_run).total_seconds() / 86400.0
+        if age_days > max_age_days:
+            reasons.append(f"last_run_age {age_days:.1f}d > {max_age_days:.1f}d")
+
+    stuck = bool(reasons)
+    status = "stuck" if stuck else "ok"
+    if not installed:
+        status = "missing"
+    return SmartCleanupTaskResult(
+        task_name=task_name,
+        installed=installed,
+        status=status,
+        stuck=stuck,
+        reasons=reasons,
+        last_run_time=last_run_time,
+        last_task_result=last_task_result,
+        next_run_time=next_run_time,
+        state=state,
+        principal_user_id=principal_user_id,
+        run_level=run_level,
+        logon_type=logon_type,
+        fix_attempted=False,
+        fix_result="not-requested",
+    )
+
+
+def start_task(task_name: str) -> str:
+    if os.name != "nt":
+        return "unsupported-non-windows"
+    proc = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", f"Start-ScheduledTask -TaskName '{task_name}'"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=20,
+    )
+    if proc.returncode == 0:
+        return "started"
+    return "failed: " + (proc.stderr.strip() or proc.stdout.strip())
+
+
+def repair_principal(task_name: str) -> str:
+    if os.name != "nt":
+        return "principal-repair-unsupported-non-windows"
+    ps = rf"""
+$ErrorActionPreference = 'Stop'
+$task = Get-ScheduledTask -TaskName '{task_name}' -ErrorAction Stop
+$userId = "$env:USERDOMAIN\$env:USERNAME"
+$principal = New-ScheduledTaskPrincipal -UserId $userId -LogonType Interactive -RunLevel Limited
+Set-ScheduledTask -TaskName '{task_name}' -Principal $principal -ErrorAction Stop | Out-Null
+$updated = Get-ScheduledTask -TaskName '{task_name}' -ErrorAction Stop
+$observed = [string]$updated.Principal.UserId
+$expectedShort = "$env:USERNAME"
+if ($observed -eq $userId) {{
+  Write-Output "principal-updated:$userId"
+}} elseif ($observed -eq $expectedShort) {{
+  Write-Output "principal-repair-accepted-observed-short:$observed requested:$userId"
+}} else {{
+  throw "principal verification failed: $observed != $userId"
+}}
+"""
+    proc = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=20,
+    )
+    if proc.returncode == 0:
+        return (proc.stdout.strip() or "principal-updated")
+    return "principal-repair-failed: " + (proc.stderr.strip() or proc.stdout.strip())
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task-name", default="SmartCleanup_MonthlyDeep")
+    parser.add_argument("--max-age-days", type=float, default=35.0)
+    parser.add_argument("--sample-json", type=Path)
+    parser.add_argument("--fix", action="store_true")
+    parser.add_argument("--enforce", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = load_sample(args.sample_json) if args.sample_json else collect_task_info(args.task_name)
+    result = analyze_task(args.task_name, payload, args.max_age_days)
+
+    if args.fix and result.installed and result.stuck:
+        result.fix_attempted = True
+        fixes: list[str] = []
+        if "principal_user_id missing DOMAIN prefix" in result.reasons:
+            fixes.append(repair_principal(args.task_name))
+        fixes.append(start_task(args.task_name))
+        result.fix_result = "; ".join(fixes)
+
+    if args.json:
+        print(json.dumps(asdict(result), ensure_ascii=False, indent=2))
+    else:
+        reason = "; ".join(result.reasons) if result.reasons else "healthy"
+        print(f"{result.task_name}: {result.status} ({reason})")
+        if result.fix_attempted:
+            print(f"fix: {result.fix_result}")
+
+    if args.enforce and result.stuck:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/smartcleanup_task_guard_test.py
+++ b/scripts/smartcleanup_task_guard_test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "smartcleanup_task_guard.py"
+
+
+class SmartCleanupTaskGuardTest(unittest.TestCase):
+    def run_guard(self, sample: dict) -> dict:
+        with tempfile.TemporaryDirectory() as raw:
+            sample_path = Path(raw) / "sample.json"
+            sample_path.write_text(json.dumps(sample), encoding="utf-8")
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--sample-json",
+                    str(sample_path),
+                    "--json",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        return json.loads(proc.stdout)
+
+    def test_detects_1999_never_run_sentinel(self) -> None:
+        result = self.run_guard(
+            {
+                "installed": True,
+                "state": "Ready",
+                "last_run_time": "1999-11-30T00:00:00+00:00",
+                "last_task_result": 267011,
+                "next_run_time": "2026-05-31T03:00:00+09:00",
+            }
+        )
+
+        self.assertEqual(result["status"], "stuck")
+        self.assertTrue(result["stuck"])
+        self.assertIn("last_run_time sentinel year <= 1999", result["reasons"])
+        self.assertIn("last_task_result 267011 indicates task has not run", result["reasons"])
+
+    def test_accepts_recent_successful_task(self) -> None:
+        result = self.run_guard(
+            {
+                "installed": True,
+                "state": "Ready",
+                "principal_user_id": "kanta",
+                "last_run_time": "2026-05-14T00:00:00+00:00",
+                "last_task_result": 0,
+                "next_run_time": "2026-06-01T03:00:00+09:00",
+            }
+        )
+
+        self.assertEqual(result["status"], "ok")
+        self.assertFalse(result["stuck"])
+        self.assertEqual(result["reasons"], [])
+
+    def test_short_principal_is_actionable_for_never_run_task(self) -> None:
+        result = self.run_guard(
+            {
+                "installed": True,
+                "state": "Ready",
+                "principal_user_id": "kanta",
+                "last_run_time": "1999-11-30T00:00:00+00:00",
+                "last_task_result": 267011,
+                "next_run_time": "2026-06-01T03:00:00+09:00",
+            }
+        )
+
+        self.assertEqual(result["status"], "stuck")
+        self.assertIn("principal_user_id missing DOMAIN prefix", result["reasons"])
+
+    def test_missing_task_is_actionable(self) -> None:
+        result = self.run_guard(
+            {
+                "installed": False,
+                "state": "missing",
+                "last_run_time": "",
+                "last_task_result": None,
+                "next_run_time": "",
+            }
+        )
+
+        self.assertEqual(result["status"], "missing")
+        self.assertTrue(result["stuck"])
+        self.assertIn("task missing", result["reasons"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add Issue #1564 v27 DDD per-session disk compression quota: SessionStart always fires the guard and requires at least 512 MB reclaimed when cleanup runs.
- Add v27 GGG SmartCleanup_MonthlyDeep guard for the Windows Task Scheduler 1999/267011 never-ran failure mode, report-only by default with explicit env-gated repair/start.
- Wire the new guard into SessionStart, CI hook validation, unit tests, and the Claude Code setup runbook.

## Risk / review
- This touches Claude hook startup behavior and local cleanup orchestration, so please keep this PR in the high-risk review lane for Claude Code #1 ultrareview before merge.
- The SmartCleanup task guard is report-only unless `SMARTCLEANUP_MONTHLYDEEP_FIX=1` is set; `SMARTCLEANUP_MONTHLYDEEP_ENFORCE=1` is also explicit.
- The quota behavior is implementation-detail independent: tests validate the observable contract instead of relying on a specific cache implementation.

## Minimal E2E / validation
- `python scripts\session_compression_guard_test.py`
- `python scripts\smartcleanup_task_guard_test.py`
- `python scripts\check_session_state_hooks.py --scan-transcripts`
- `git diff --check`
- `python scripts\session_compression_guard.py --mode session-start --always-fire --min-reclaim-mb 512 --sample-free-gb 10.2 --sample-cleanup-reclaim-mb 600 --sample-free-gb-after 10.8 --apply --json`
- `python scripts\smartcleanup_task_guard.py --json` against the local task after manual runaway stop: reports `LastTaskResult=267014`, task `Ready`, no leftover smart_cleanup process.

Closes scoped repo-managed v27 DDD/GGG slice of #1564; #1564 should remain open for any user-home / non-repo closure evidence still owned outside this PR.