### PR TITLE
ci: add video pipeline secret readiness (#1724)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,6 +15,7 @@
 | **Release Readiness Gate** | `release-readiness.yml` | deploy-prod success / daily 06:40 JST / manual | #1556 alpha gate: migration + EF import + Deno lint + readiness hub Deno check + Flutter build + production route + tools-hub/schedule-hub + Notion + Slack + WBS update |
 | **Blog News Production Smoke** | `blog-news-prod-smoke.yml` | deploy-prod success / manual | #1950 blog/news E2E guard: `/blog`, `/blog/compose`, `/news-rss`, optional `/blog/post?id=<postId>`, RSS Edge Function, and read-only `blog_posts` queue state |
 | **Mobile Distribution Readiness** | `mobile-distribution-readiness.yml` | mobile release PR / mobile-release-build success / manual | #1495 iOS/Android distribution gate: metadata, signing placeholders, docs, workflow wiring, and boolean-only signing/store secret presence report |
+| **Video Pipeline Secret Readiness** | `video-pipeline-secret-readiness.yml` | video pipeline PR / manual | #1724 NotebookLM video-pipeline gate: boolean-only presence report for `GITHUB_PAT`, `NOTEBOOKLM_STORAGE_STATE_JSON`, `ELEVENLABS_API_KEY`, `YOUTUBE_CLIENT_SECRET_JSON`, and `YOUTUBE_TOKEN_JSON` |
 | **Daily Report** | `daily-report.yml` | 毎日 07:30 JST / 手動 | 日次レポート生成 + X投稿 + 競合モニタリング + schedule_task_runs記録 + Job Summary |
 | **CS Check** | `cs-check.yml` | 毎時 07分 / 手動 | CS自動対応 + PR自動レビュー + schedule_task_runs記録 + Job Summary |
 | **Edge Function Audit** | `edge-function-audit.yml` | 毎時 47分 / 手動 | EF UI導線カバレッジチェック + schedule_task_runs記録 + Job Summary |

--- a/.github/workflows/notebooklm-video-pipeline.yml
+++ b/.github/workflows/notebooklm-video-pipeline.yml
@@ -70,12 +70,33 @@ jobs:
       ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
       YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET_JSON }}
       YOUTUBE_TOKEN: ${{ secrets.YOUTUBE_TOKEN_JSON }}
+      HAS_GITHUB_PAT: ${{ secrets.GITHUB_PAT != '' }}
+      HAS_NOTEBOOKLM_STORAGE_STATE_JSON: ${{ secrets.NOTEBOOKLM_STORAGE_STATE_JSON != '' }}
+      HAS_ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY != '' }}
+      HAS_YOUTUBE_CLIENT_SECRET_JSON: ${{ secrets.YOUTUBE_CLIENT_SECRET_JSON != '' }}
+      HAS_YOUTUBE_TOKEN_JSON: ${{ secrets.YOUTUBE_TOKEN_JSON != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_PAT }}
+          token: ${{ secrets.GITHUB_PAT || github.token }}
           fetch-depth: 100  # Step 0 dedup needs ≥1h of history (default depth=1 hides past bot commits)
+
+      - name: Check required video pipeline secrets
+        run: |
+          mkdir -p tmp/video-pipeline-secret-readiness
+          python scripts/check_video_pipeline_secret_readiness.py \
+            --require-secrets \
+            --report tmp/video-pipeline-secret-readiness/report.json
+
+      - name: Upload video pipeline secret readiness report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: video-pipeline-secret-readiness-report
+          path: tmp/video-pipeline-secret-readiness/report.json
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Setup Python 3.12
         uses: actions/setup-python@v6

--- a/.github/workflows/video-pipeline-secret-readiness.yml
+++ b/.github/workflows/video-pipeline-secret-readiness.yml
@@ -1,0 +1,60 @@
+name: Video Pipeline Secret Readiness
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/notebooklm-video-pipeline.yml'
+      - '.github/workflows/video-pipeline-secret-readiness.yml'
+      - 'scripts/check_video_pipeline_secret_readiness.py'
+      - 'test/scripts/test_video_pipeline_secret_readiness.py'
+      - 'docs/GA_LAUNCH_READINESS_GATE_SPEC.md'
+      - 'docs/AI_VIDEO_PRINCIPLES.md'
+  workflow_dispatch:
+    inputs:
+      require_video_pipeline_secrets:
+        description: 'Fail if the five NotebookLM video-pipeline secrets are missing'
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: video-pipeline-secret-readiness-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  readiness:
+    name: Video Pipeline Secret Readiness
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      REQUIRE_VIDEO_PIPELINE_SECRETS: ${{ github.event_name == 'workflow_dispatch' && inputs.require_video_pipeline_secrets || 'false' }}
+      HAS_GITHUB_PAT: ${{ secrets.GITHUB_PAT != '' }}
+      HAS_NOTEBOOKLM_STORAGE_STATE_JSON: ${{ secrets.NOTEBOOKLM_STORAGE_STATE_JSON != '' }}
+      HAS_ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY != '' }}
+      HAS_YOUTUBE_CLIENT_SECRET_JSON: ${{ secrets.YOUTUBE_CLIENT_SECRET_JSON != '' }}
+      HAS_YOUTUBE_TOKEN_JSON: ${{ secrets.YOUTUBE_TOKEN_JSON != '' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check video pipeline secret readiness
+        shell: bash
+        run: |
+          mkdir -p tmp/video-pipeline-secret-readiness
+          args=(--report tmp/video-pipeline-secret-readiness/report.json)
+          if [ "$REQUIRE_VIDEO_PIPELINE_SECRETS" = "true" ]; then
+            args+=(--require-secrets)
+          fi
+          python scripts/check_video_pipeline_secret_readiness.py "${args[@]}"
+
+      - name: Upload video pipeline secret readiness report
+        uses: actions/upload-artifact@v7
+        with:
+          name: video-pipeline-secret-readiness-report
+          path: tmp/video-pipeline-secret-readiness/report.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/video-pipeline-test.yml
+++ b/.github/workflows/video-pipeline-test.yml
@@ -12,17 +12,22 @@ on:
   pull_request:
     paths:
       - 'scripts/video/**'
+      - 'scripts/check_video_pipeline_secret_readiness.py'
       - 'scripts/embed_video_in_philosophy.py'
       - '.github/workflows/notebooklm-video-pipeline.yml'
+      - '.github/workflows/video-pipeline-secret-readiness.yml'
       - '.github/workflows/video-pipeline-test.yml'
+      - 'test/scripts/test_video_pipeline_secret_readiness.py'
   push:
     branches:
       - staging
       - develop
     paths:
       - 'scripts/video/**'
+      - 'scripts/check_video_pipeline_secret_readiness.py'
       - 'scripts/embed_video_in_philosophy.py'
       - '.github/workflows/notebooklm-video-pipeline.yml'
+      - '.github/workflows/video-pipeline-secret-readiness.yml'
   workflow_dispatch:
 
 concurrency:
@@ -56,3 +61,8 @@ jobs:
         env:
           PYTHONUTF8: '1'
         run: python scripts/video/_smoke_test.py
+
+      - name: Run video pipeline secret readiness tests
+        env:
+          PYTHONUTF8: '1'
+        run: python -m unittest discover -s test/scripts -p "test_video_pipeline_secret_readiness.py"

--- a/docs/AI_VIDEO_PRINCIPLES.md
+++ b/docs/AI_VIDEO_PRINCIPLES.md
@@ -273,6 +273,12 @@ D-ID の事例 = 顔認識「**防御**」技術から AI アバター「**生�
 - [#1724](https://github.com/kanta13jp1/my_web_app/issues/1724) (= P1 / 5 secrets 設定): F6 publish 公開化の前提
 - [#1788](https://github.com/kanta13jp1/my_web_app/issues/1788) (= P3 / D-ID + Hedra アバター): Phase 3 リアルタイム presence への bridge
 
+2026-05-16 Codex #1 readiness update:
+
+- `video-pipeline-secret-readiness.yml` can be run manually before dispatching the heavy NotebookLM pipeline.
+- `notebooklm-video-pipeline.yml` performs an early boolean-only secret preflight for `GITHUB_PAT`, `NOTEBOOKLM_STORAGE_STATE_JSON`, `ELEVENLABS_API_KEY`, `YOUTUBE_CLIENT_SECRET_JSON`, and `YOUTUBE_TOKEN_JSON`.
+- The preflight is side-effect free: no secret values are printed, no NotebookLM download starts, and no YouTube quota is consumed when a required secret is missing.
+
 ### Philosophy / Principle Alignment
 
 - **PHILOSOPHY-22** = 9/9 ✅ (= 商品=価値 / 資本=時間 / KPI=昨日の自分 で月次本数 KPI 化)

--- a/docs/GA_LAUNCH_READINESS_GATE_SPEC.md
+++ b/docs/GA_LAUNCH_READINESS_GATE_SPEC.md
@@ -120,6 +120,13 @@ f9c7fd37... Seed 投資家リスト    → axis F (= future)
 
 ### 5.2 登録手順 (= user 1 step)
 
+Codex #1 deterministic readiness layer (2026-05-16):
+
+- `video-pipeline-secret-readiness.yml` reports boolean-only presence for the five required secrets.
+- `notebooklm-video-pipeline.yml` runs `check_video_pipeline_secret_readiness.py --require-secrets` before any NotebookLM download, ElevenLabs transcription, YouTube upload, or quota-consuming work.
+- The checker never prints secret values; it records only `present: true/false` and uploads `video-pipeline-secret-readiness-report`.
+- This does not replace the user-owned secret registration step. It changes the old opaque `Input required and not supplied: token` failure into a deterministic readiness report.
+
 ```bash
 # secret 5 件登録 (= user local PC 上)
 gh secret set GITHUB_PAT --body "ghp_..."

--- a/scripts/check_video_pipeline_secret_readiness.py
+++ b/scripts/check_video_pipeline_secret_readiness.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Validate NotebookLM video-pipeline secret readiness without exposing values."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_SECRETS = (
+    "GITHUB_PAT",
+    "NOTEBOOKLM_STORAGE_STATE_JSON",
+    "ELEVENLABS_API_KEY",
+    "YOUTUBE_CLIENT_SECRET_JSON",
+    "YOUTUBE_TOKEN_JSON",
+)
+
+SECRET_DESCRIPTIONS = {
+    "GITHUB_PAT": "checkout/push token for the auto-embed commit",
+    "NOTEBOOKLM_STORAGE_STATE_JSON": "NotebookLM CLI storage_state.json payload",
+    "ELEVENLABS_API_KEY": "ElevenLabs Scribe transcription API key",
+    "YOUTUBE_CLIENT_SECRET_JSON": "YouTube OAuth client secret JSON",
+    "YOUTUBE_TOKEN_JSON": "YouTube OAuth refresh token JSON",
+}
+
+PIPELINE_WORKFLOW_MARKERS = (
+    "NotebookLM Video Pipeline",
+    "Check required video pipeline secrets",
+    "HAS_GITHUB_PAT",
+    "secrets.GITHUB_PAT || github.token",
+    "check_video_pipeline_secret_readiness.py",
+)
+
+READINESS_WORKFLOW_MARKERS = (
+    "Video Pipeline Secret Readiness",
+    "check_video_pipeline_secret_readiness.py",
+    "--require-secrets",
+    "actions/upload-artifact@v7",
+)
+
+DOC_MARKERS: dict[str, tuple[str, ...]] = {
+    "docs/GA_LAUNCH_READINESS_GATE_SPEC.md": REQUIRED_SECRETS,
+    "docs/AI_VIDEO_PRINCIPLES.md": ("#1724", "YOUTUBE_TOKEN_JSON", "NOTEBOOKLM_STORAGE_STATE_JSON"),
+}
+
+
+def add_check(
+    checks: list[dict[str, str]],
+    name: str,
+    ok: bool,
+    detail: str,
+    *,
+    warn: bool = False,
+) -> None:
+    status = "pass" if ok else ("warn" if warn else "fail")
+    checks.append({"name": name, "status": status, "detail": detail})
+
+
+def secret_present(name: str, env: Mapping[str, str]) -> bool:
+    flag_names = (f"HAS_{name}", f"VIDEO_PIPELINE_SECRET_{name}")
+    truthy = {"1", "true", "yes", "present", "set"}
+    falsy = {"", "0", "false", "no", "missing", "unset"}
+
+    for flag_name in flag_names:
+        if flag_name in env:
+            value = env[flag_name].strip().lower()
+            if value in truthy:
+                return True
+            if value in falsy:
+                return False
+
+    return bool(env.get(name, "").strip())
+
+
+def check_file_contains(
+    root: Path,
+    relative: str,
+    markers: tuple[str, ...],
+    checks: list[dict[str, str]],
+    name: str,
+) -> None:
+    path = root / relative
+    if not path.exists():
+        add_check(checks, name, False, f"{relative} is missing.")
+        return
+
+    content = path.read_text(encoding="utf-8")
+    missing = [marker for marker in markers if marker not in content]
+    add_check(
+        checks,
+        name,
+        not missing,
+        "all markers present" if not missing else f"missing markers: {', '.join(missing)}",
+    )
+
+
+def evaluate(
+    *,
+    root: Path,
+    require_secrets: bool,
+    env: Mapping[str, str],
+) -> dict[str, object]:
+    checks: list[dict[str, str]] = []
+    secrets: list[dict[str, object]] = []
+
+    check_file_contains(
+        root,
+        ".github/workflows/notebooklm-video-pipeline.yml",
+        PIPELINE_WORKFLOW_MARKERS,
+        checks,
+        "notebooklm video pipeline preflight",
+    )
+    check_file_contains(
+        root,
+        ".github/workflows/video-pipeline-secret-readiness.yml",
+        READINESS_WORKFLOW_MARKERS,
+        checks,
+        "video pipeline secret readiness workflow",
+    )
+    for relative, markers in DOC_MARKERS.items():
+        check_file_contains(root, relative, markers, checks, f"doc markers: {relative}")
+
+    missing_secrets: list[str] = []
+    for secret in REQUIRED_SECRETS:
+        present = secret_present(secret, env)
+        secrets.append(
+            {
+                "name": secret,
+                "present": present,
+                "description": SECRET_DESCRIPTIONS[secret],
+            }
+        )
+        if not present:
+            missing_secrets.append(secret)
+
+    if missing_secrets:
+        add_check(
+            checks,
+            "video pipeline secrets",
+            False,
+            f"missing: {', '.join(missing_secrets)}",
+            warn=not require_secrets,
+        )
+    else:
+        add_check(
+            checks,
+            "video pipeline secrets",
+            True,
+            "all required video pipeline secret flags are present",
+        )
+
+    has_failures = any(check["status"] == "fail" for check in checks)
+    has_warnings = any(check["status"] == "warn" for check in checks)
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": "fail" if has_failures else ("warn" if has_warnings else "pass"),
+        "require_secrets": require_secrets,
+        "checks": checks,
+        "secrets": secrets,
+        "missing_secrets": missing_secrets,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--require-secrets", action="store_true")
+    parser.add_argument("--report", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = evaluate(
+        root=args.root.resolve(),
+        require_secrets=args.require_secrets,
+        env=os.environ,
+    )
+
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 1 if report["status"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/supabase/migrations/20260516093000_update_wbs_progress_video_pipeline_secret_readiness_codex1.sql
+++ b/supabase/migrations/20260516093000_update_wbs_progress_video_pipeline_secret_readiness_codex1.sql
@@ -1,0 +1,27 @@
+-- Codex #1: Issue #1724 video-pipeline secret readiness slice.
+--
+-- This records the deterministic preflight/report that turns missing video
+-- pipeline secrets into an explicit readiness artifact without exposing values
+-- or triggering NotebookLM/ElevenLabs/YouTube side effects.
+
+UPDATE public.wbs_tasks
+SET status = 'in_progress',
+    progress = GREATEST(progress, 35),
+    recovery_plan = COALESCE(
+      NULLIF(trim(recovery_plan), ''),
+      'Codex #1 added a video-pipeline secret readiness gate. Remaining work: user registers the five required secrets, runs the strict readiness workflow, dispatches notebooklm-video-pipeline.yml, and then replaces the temporary MP4 embed after YouTube upload succeeds.'
+    ),
+    recovery_planned_at = COALESCE(recovery_planned_at, NOW()),
+    description = COALESCE(description, '') ||
+      E'\n\n[Codex #1 / 2026-05-16] Issue #1724 advanced: NotebookLM video pipeline now has a boolean-only secret readiness workflow/report and an early required-secret preflight before any download, transcription, upload, or quota-consuming work.'
+WHERE github_issue_number = 1724;
+
+INSERT INTO public.development_achievements (title, description, completed_at)
+SELECT
+  'Codex #1: video pipeline secret readiness gate (#1724)',
+  'Added a deterministic GitHub Actions readiness report and early NotebookLM video-pipeline preflight for the five required secrets without printing values or running external video side effects.',
+  '2026-05-16'
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.development_achievements
+  WHERE title = 'Codex #1: video pipeline secret readiness gate (#1724)'
+);

--- a/test/scripts/test_video_pipeline_secret_readiness.py
+++ b/test/scripts/test_video_pipeline_secret_readiness.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Tests for the NotebookLM video-pipeline secret readiness gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/check_video_pipeline_secret_readiness.py"
+SPEC = importlib.util.spec_from_file_location("video_pipeline_secret_readiness", SCRIPT)
+assert SPEC and SPEC.loader
+video_pipeline_secret_readiness = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(video_pipeline_secret_readiness)
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class VideoPipelineSecretReadinessTest(unittest.TestCase):
+    def make_root(self) -> tempfile.TemporaryDirectory[str]:
+        temp = tempfile.TemporaryDirectory()
+        root = Path(temp.name)
+        write(
+            root / ".github/workflows/notebooklm-video-pipeline.yml",
+            "\n".join(
+                (
+                    "name: NotebookLM Video Pipeline",
+                    "run: python scripts/check_video_pipeline_secret_readiness.py",
+                    "name: Check required video pipeline secrets",
+                    "HAS_GITHUB_PAT: true",
+                    "token: ${{ secrets.GITHUB_PAT || github.token }}",
+                )
+            ),
+        )
+        write(
+            root / ".github/workflows/video-pipeline-secret-readiness.yml",
+            "\n".join(
+                (
+                    "name: Video Pipeline Secret Readiness",
+                    "run: python scripts/check_video_pipeline_secret_readiness.py --require-secrets",
+                    "uses: actions/upload-artifact@v7",
+                )
+            ),
+        )
+        write(
+            root / "docs/GA_LAUNCH_READINESS_GATE_SPEC.md",
+            "GITHUB_PAT NOTEBOOKLM_STORAGE_STATE_JSON ELEVENLABS_API_KEY "
+            "YOUTUBE_CLIENT_SECRET_JSON YOUTUBE_TOKEN_JSON",
+        )
+        write(
+            root / "docs/AI_VIDEO_PRINCIPLES.md",
+            "#1724 YOUTUBE_TOKEN_JSON NOTEBOOKLM_STORAGE_STATE_JSON",
+        )
+        return temp
+
+    def test_missing_secrets_warn_without_strict_mode(self) -> None:
+        with self.make_root() as temp:
+            report = video_pipeline_secret_readiness.evaluate(
+                root=Path(temp),
+                require_secrets=False,
+                env={},
+            )
+
+        self.assertEqual(report["status"], "warn")
+        self.assertTrue(report["missing_secrets"])
+
+    def test_missing_secrets_fail_with_strict_mode(self) -> None:
+        with self.make_root() as temp:
+            report = video_pipeline_secret_readiness.evaluate(
+                root=Path(temp),
+                require_secrets=True,
+                env={},
+            )
+
+        self.assertEqual(report["status"], "fail")
+        self.assertIn("GITHUB_PAT", report["missing_secrets"])
+        self.assertIn("YOUTUBE_TOKEN_JSON", report["missing_secrets"])
+
+    def test_secret_flags_pass_strict_mode(self) -> None:
+        env = {f"HAS_{name}": "true" for name in video_pipeline_secret_readiness.REQUIRED_SECRETS}
+        with self.make_root() as temp:
+            report = video_pipeline_secret_readiness.evaluate(
+                root=Path(temp),
+                require_secrets=True,
+                env=env,
+            )
+
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["missing_secrets"], [])
+
+    def test_missing_workflow_marker_fails(self) -> None:
+        with self.make_root() as temp:
+            root = Path(temp)
+            write(root / ".github/workflows/notebooklm-video-pipeline.yml", "name: NotebookLM Video Pipeline")
+            env = {f"HAS_{name}": "true" for name in video_pipeline_secret_readiness.REQUIRED_SECRETS}
+            report = video_pipeline_secret_readiness.evaluate(
+                root=root,
+                require_secrets=True,
+                env=env,
+            )
+
+        failed = {check["name"] for check in report["checks"] if check["status"] == "fail"}
+        self.assertIn("notebooklm video pipeline preflight", failed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

- Add a boolean-only `scripts/check_video_pipeline_secret_readiness.py` gate for the five #1724 NotebookLM video-pipeline secrets.
- Add `video-pipeline-secret-readiness.yml` for PR/manual readiness reports and wire the existing Video Pipeline Smoke Test workflow to run the new unit tests.
- Add an early required-secret preflight to `notebooklm-video-pipeline.yml` before NotebookLM download, ElevenLabs transcription, YouTube upload, or quota-consuming work.
- Document the readiness path and record WBS progress for the Codex #1 scoped slice.

## Scope / remaining work

Refs #1724. This PR does not register secrets, does not run the heavy video pipeline, does not upload to YouTube, and does not remove the temporary MP4 embed. The issue should remain open until the user registers the five required secrets, the strict readiness workflow passes, `notebooklm-video-pipeline.yml` succeeds, and the post-upload embed cleanup is accepted.

## Minimal E2E Gate

- Black-box contract: secret readiness is evaluated from boolean presence flags (`HAS_*`) and workflow/doc wiring markers, never from secret values.
- Minimal cases: missing secrets warn in non-strict mode, missing secrets fail in strict mode, all five flags pass strict mode, and missing workflow markers fail.
- Existing video smoke coverage remains in `video-pipeline-test.yml`; the PR adds the readiness unit test to that existing workflow so PR checks cover both the video scripts and the secret gate.
- E2E-Exception: no live NotebookLM, ElevenLabs, or YouTube calls are executed in this PR because those require user-owned secrets and public/external side effects.

## High-risk Ultrareview Gate

- Risk reason: GitHub Actions + secret readiness flow.
- Claude Code #1 review owner: requested for policy concerns before closing #1724; this PR is the deterministic Codex #1 implementation slice under the two-instance policy.
- High-risk-ultrareview-exception: no secret value is printed or read into reports, no external upload is triggered, and the workflow fails before side-effecting work when a required secret is missing.
- Rollback: revert this PR to remove the readiness workflow, checker, preflight step, docs, tests, and WBS metadata migration.
- Data migration: metadata-only WBS progress/achievement update for #1724; no schema, RLS, or production data contract change.
- Observability: Actions artifact `video-pipeline-secret-readiness-report` contains the boolean-only JSON report.

## Validation

- `python -m unittest discover -s test\scripts -p "test_video_pipeline_secret_readiness.py"`
- `python scripts\check_video_pipeline_secret_readiness.py --report tmp\video-pipeline-secret-readiness-local\report.json` (warns locally because secrets are absent by design)
- strict-mode simulation with all five `HAS_*` flags set
- `python scripts\video\_smoke_test.py`
- YAML parse for `notebooklm-video-pipeline.yml`, `video-pipeline-secret-readiness.yml`, and `video-pipeline-test.yml`
- `python scripts\check_migration_timestamps.py`
- `python scripts\check_github_actions_node_runtime.py`
- `git diff --cached --check`
