### PR TITLE
Add feature-flagged asset management AI summaries

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -21,6 +21,7 @@ import 'package:my_web_app/services/asset_liability_history_service.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 import 'package:my_web_app/services/asset_liability_planning_service.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
+import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
@@ -184,6 +185,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetLiabilityHistoryService();
   final AssetManagementInsightService _assetManagementInsightService =
       const AssetManagementInsightService();
+  final AssetManagementAiSummaryService _assetManagementAiSummaryService =
+      AssetManagementAiSummaryService();
   final DebtLockdownService _debtLockdownService = const DebtLockdownService();
   final DebtRepaymentPlannerService _debtRepaymentPlanner =
       const DebtRepaymentPlannerService();
@@ -201,6 +204,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   double? _debtLockdownLoadedForDebt;
   Future<AssetWasteTrainingAiReview>? _wasteTrainingAiReviewFuture;
   String? _wasteTrainingAiReviewKey;
+  bool _isGeneratingAssetManagementAiSummary = false;
+  AssetManagementAiSummaryResult? _assetManagementAiSummaryResult;
 
   final List<Color> _colors = [
     const Color(0xFF6366F1),
@@ -6997,6 +7002,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           ),
           const SizedBox(height: 10),
+          _buildAssetManagementAiSummaryPanel(report),
+          const SizedBox(height: 10),
           Wrap(
             spacing: 8,
             runSpacing: 8,
@@ -7019,6 +7026,126 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ],
       ),
     );
+  }
+
+  Widget _buildAssetManagementAiSummaryPanel(
+    AssetManagementInsightReport report,
+  ) {
+    final result = _assetManagementAiSummaryResult ??
+        _assetManagementAiSummaryService.buildDisabledResult(report);
+    final enabled = _assetManagementAiSummaryService.aiEnabled;
+    final color = switch (result.status) {
+      AssetManagementAiSummaryStatus.aiGenerated => const Color(0xFF0D9488),
+      AssetManagementAiSummaryStatus.fallback => const Color(0xFFD97706),
+      AssetManagementAiSummaryStatus.disabled => const Color(0xFF475569),
+    };
+    final statusLabel = switch (result.status) {
+      AssetManagementAiSummaryStatus.aiGenerated => 'AI summary',
+      AssetManagementAiSummaryStatus.fallback => 'Fallback',
+      AssetManagementAiSummaryStatus.disabled => 'Feature flag OFF',
+    };
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.24)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.psychology_alt_outlined, color: color, size: 18),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  result.text,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    height: 1.5,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (result.errorMessage != null) ...[
+            const SizedBox(height: 6),
+            Text(
+              result.errorMessage!,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.error,
+                fontSize: 11,
+                height: 1.4,
+              ),
+            ),
+          ],
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              _buildAssetLiabilitySyncChip(
+                label: 'AI',
+                value: statusLabel,
+                color: color,
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: 'source',
+                value: result.source,
+                color: color,
+              ),
+              OutlinedButton.icon(
+                onPressed: enabled && !_isGeneratingAssetManagementAiSummary
+                    ? () => _generateAssetManagementAiSummary(report)
+                    : null,
+                icon: _isGeneratingAssetManagementAiSummary
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.auto_awesome_outlined, size: 16),
+                label: Text(
+                  enabled
+                      ? 'AI summary'
+                      : 'AI summary disabled by feature flag',
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'AI receives only calculated insight payloads. Amount calculation stays in Dart.',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 11,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _generateAssetManagementAiSummary(
+    AssetManagementInsightReport report,
+  ) async {
+    setState(() => _isGeneratingAssetManagementAiSummary = true);
+    final result = await _assetManagementAiSummaryService.generateSummary(
+      report: report,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _assetManagementAiSummaryResult = result;
+      _isGeneratingAssetManagementAiSummary = false;
+    });
   }
 
   Widget _buildAssetManagementAvailableCard(

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -1,0 +1,234 @@
+import 'dart:convert';
+
+import 'ai_hub_chat_service.dart';
+import 'asset_management_insight_service.dart';
+
+class AssetManagementAiSummaryFeatureFlag {
+  static const String dartDefineName = 'ASSET_MANAGEMENT_AI_SUMMARY_ENABLED';
+
+  static const bool enabled = bool.fromEnvironment(
+    dartDefineName,
+    defaultValue: false,
+  );
+
+  const AssetManagementAiSummaryFeatureFlag._();
+}
+
+enum AssetManagementAiSummaryStatus { disabled, aiGenerated, fallback }
+
+class AssetManagementAiSummaryResult {
+  final AssetManagementAiSummaryStatus status;
+  final String text;
+  final String source;
+  final String? errorMessage;
+  final DateTime generatedAt;
+  final Map<String, dynamic> payload;
+
+  const AssetManagementAiSummaryResult({
+    required this.status,
+    required this.text,
+    required this.source,
+    required this.errorMessage,
+    required this.generatedAt,
+    required this.payload,
+  });
+
+  bool get usedExternalAi =>
+      status == AssetManagementAiSummaryStatus.aiGenerated;
+}
+
+class AssetManagementAiSummaryService {
+  final bool _aiEnabled;
+  final AiHubChatService _chatService;
+  final AssetManagementInsightPromptBuilder _promptBuilder;
+  final DateTime Function() _now;
+  final String _provider;
+
+  AssetManagementAiSummaryService({
+    bool aiEnabled = AssetManagementAiSummaryFeatureFlag.enabled,
+    AiHubChatService chatService = const AiHubChatService(),
+    AssetManagementInsightPromptBuilder promptBuilder =
+        const AssetManagementInsightPromptBuilder(),
+    DateTime Function()? now,
+    String provider = 'deepinfra',
+  })  : _aiEnabled = aiEnabled,
+        _chatService = chatService,
+        _promptBuilder = promptBuilder,
+        _now = now ?? DateTime.now,
+        _provider = provider;
+
+  bool get aiEnabled => _aiEnabled;
+
+  Future<AssetManagementAiSummaryResult> generateSummary({
+    required AssetManagementInsightReport report,
+  }) async {
+    final payload = buildPayload(report);
+    final fallback = buildDeterministicSummary(report);
+    if (!_aiEnabled) {
+      return AssetManagementAiSummaryResult(
+        status: AssetManagementAiSummaryStatus.disabled,
+        text: fallback,
+        source: 'deterministic fallback / feature flag off',
+        errorMessage: null,
+        generatedAt: _now(),
+        payload: payload,
+      );
+    }
+
+    try {
+      final prompt = _buildPrompt(report: report, payload: payload);
+      final response = await _chatService.sendProviderChat(
+        message: prompt,
+        provider: _provider,
+        traceId: 'asset-management-ai-summary',
+      );
+      return AssetManagementAiSummaryResult(
+        status: AssetManagementAiSummaryStatus.aiGenerated,
+        text: response.text,
+        source: response.source,
+        errorMessage: null,
+        generatedAt: _now(),
+        payload: payload,
+      );
+    } catch (error) {
+      return AssetManagementAiSummaryResult(
+        status: AssetManagementAiSummaryStatus.fallback,
+        text: fallback,
+        source: 'deterministic fallback / ai-hub failed',
+        errorMessage: error.toString(),
+        generatedAt: _now(),
+        payload: payload,
+      );
+    }
+  }
+
+  AssetManagementAiSummaryResult buildDisabledResult(
+    AssetManagementInsightReport report,
+  ) {
+    final payload = buildPayload(report);
+    return AssetManagementAiSummaryResult(
+      status: AssetManagementAiSummaryStatus.disabled,
+      text: buildDeterministicSummary(report),
+      source: 'deterministic fallback / feature flag off',
+      errorMessage: null,
+      generatedAt: _now(),
+      payload: payload,
+    );
+  }
+
+  Map<String, dynamic> buildPayload(AssetManagementInsightReport report) {
+    return <String, dynamic>{
+      'available_money': <String, dynamic>{
+        'today': _availableToJson(report.todayAvailable),
+        'week': _availableToJson(report.weekAvailable),
+        'month': _availableToJson(report.monthAvailable),
+      },
+      'action_items': report.actionItems
+          .map(
+            (item) => <String, dynamic>{
+              'type': item.type.name,
+              'severity': item.severity.name,
+              'title': item.title,
+              'description': item.description,
+              'related_account_id': item.relatedAccountId,
+              'due_date': item.dueDate?.toIso8601String(),
+              'payment_day': item.paymentDay,
+              'suggested_action': item.suggestedAction,
+            },
+          )
+          .toList(growable: false),
+      'movement_suggestions': report.movementSuggestions
+          .map(
+            (suggestion) => <String, dynamic>{
+              'from_account_id': suggestion.fromAccountId,
+              'from_account_name': suggestion.fromAccountName,
+              'to_account_id': suggestion.toAccountId,
+              'to_account_name': suggestion.toAccountName,
+              'amount': suggestion.amount,
+              'needed_by': suggestion.neededBy?.toIso8601String(),
+              'reason': suggestion.reason,
+            },
+          )
+          .toList(growable: false),
+      'developer_requests': report.developerRequests
+          .map(
+            (request) => <String, dynamic>{
+              'title': request.title,
+              'description': request.description,
+              'severity': request.severity.name,
+            },
+          )
+          .toList(growable: false),
+      'guardrails': const <String, dynamic>{
+        'calculation_owner': 'dart_service',
+        'external_ai_may_summarize_only': true,
+        'external_ai_may_recalculate_amounts': false,
+      },
+    };
+  }
+
+  String buildDeterministicSummary(AssetManagementInsightReport report) {
+    final critical = report.criticalActions.length;
+    final actionCount = report.actionItems.length;
+    final today = _formatYen(report.todayAvailable.availableAmount);
+    final week = _formatYen(report.weekAvailable.availableAmount);
+    final month = _formatYen(report.monthAvailable.availableAmount);
+    final movement = report.movementSuggestions.isEmpty
+        ? 'No account movement suggestion is currently required.'
+        : 'Review ${report.movementSuggestions.length} account movement suggestion(s).';
+    final status = critical > 0
+        ? 'Critical cashflow items need attention.'
+        : 'No critical cashflow item was detected.';
+    return [
+      status,
+      'Action items: $actionCount, critical: $critical.',
+      'Available money: today $today, week $week, month $month.',
+      movement,
+      'Amounts are calculated by Dart rules; AI summary is optional.',
+    ].join(' ');
+  }
+
+  String _buildPrompt({
+    required AssetManagementInsightReport report,
+    required Map<String, dynamic> payload,
+  }) {
+    return [
+      _promptBuilder.buildPrompt(report),
+      '',
+      '## Computed insight payload',
+      jsonEncode(payload),
+      '',
+      'Rules: summarize only. Do not recalculate amounts. Do not provide legal, investment, or credit advice. Keep the response concise and action-oriented.',
+    ].join('\n');
+  }
+
+  Map<String, dynamic> _availableToJson(
+    AssetManagementAvailableMoneyInsight insight,
+  ) {
+    return <String, dynamic>{
+      'window': insight.window.name,
+      'start_date': insight.startDate.toIso8601String(),
+      'end_date': insight.endDate.toIso8601String(),
+      'cash_like_total': insight.cashLikeTotal,
+      'unpaid_payment_total': insight.unpaidPaymentTotal,
+      'unreceived_income_total': insight.unreceivedIncomeTotal,
+      'minimum_safety_balance': insight.minimumSafetyBalance,
+      'available_amount': insight.availableAmount,
+      'summary': insight.summary,
+    };
+  }
+
+  String _formatYen(double amount) {
+    final sign = amount < 0 ? '-' : '';
+    final digits = amount.abs().round().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i += 1) {
+      final remaining = digits.length - i;
+      buffer.write(digits[i]);
+      if (remaining > 1 && remaining % 3 == 1) {
+        buffer.write(',');
+      }
+    }
+    return '$sign$buffer円';
+  }
+}

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/ai_hub_chat_service.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
+import 'package:my_web_app/services/asset_management_insight_service.dart';
+
+void main() {
+  group('AssetManagementAiSummaryService', () {
+    test('does not call ai-hub when feature flag is off', () async {
+      var calls = 0;
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: false,
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            calls += 1;
+            return <String, dynamic>{'success': true, 'text': 'should not run'};
+          },
+        ),
+        now: () => DateTime(2026, 5, 1, 12),
+      );
+
+      final result = await service.generateSummary(report: _report());
+
+      expect(calls, 0);
+      expect(result.status, AssetManagementAiSummaryStatus.disabled);
+      expect(result.usedExternalAi, false);
+      expect(result.source.contains('feature flag off'), true);
+      expect(
+        result.text.contains('Amounts are calculated by Dart rules'),
+        true,
+      );
+    });
+
+    test('calls ai-hub provider.chat when feature flag is on', () async {
+      Map<String, dynamic>? capturedBody;
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            capturedBody = body;
+            return <String, dynamic>{
+              'success': true,
+              'text': 'AI generated summary',
+              'provider': 'deepinfra',
+            };
+          },
+        ),
+        now: () => DateTime(2026, 5, 1, 12),
+      );
+
+      final result = await service.generateSummary(report: _report());
+
+      expect(result.status, AssetManagementAiSummaryStatus.aiGenerated);
+      expect(result.usedExternalAi, true);
+      expect(result.text, 'AI generated summary');
+      expect(capturedBody?['action'], 'provider.chat');
+      expect(capturedBody?['provider'], 'deepinfra');
+      expect(capturedBody?['trace_id'], 'asset-management-ai-summary');
+      expect(
+        capturedBody?['message'].toString().contains(
+              'Computed insight payload',
+            ),
+        true,
+      );
+      expect(
+        capturedBody?['message'].toString().contains(
+              '"external_ai_may_recalculate_amounts":false',
+            ),
+        true,
+      );
+    });
+
+    test('falls back to deterministic text when ai-hub fails', () async {
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        chatService: AiHubChatService(
+          invoker: (body) async => throw const AiHubChatException('boom'),
+        ),
+        now: () => DateTime(2026, 5, 1, 12),
+      );
+
+      final result = await service.generateSummary(report: _report());
+
+      expect(result.status, AssetManagementAiSummaryStatus.fallback);
+      expect(result.usedExternalAi, false);
+      expect(result.errorMessage?.contains('boom'), true);
+      expect(
+        result.text.contains('Amounts are calculated by Dart rules'),
+        true,
+      );
+    });
+
+    test('builds payload from calculated insights only', () {
+      final report = _report();
+      final service = AssetManagementAiSummaryService(
+        now: () => DateTime(2026, 5, 1, 12),
+      );
+
+      final payload = service.buildPayload(report);
+      final available = payload['available_money'] as Map<String, dynamic>;
+      final today = available['today'] as Map<String, dynamic>;
+      final guardrails = payload['guardrails'] as Map<String, dynamic>;
+
+      expect(payload.containsKey('workbook'), false);
+      expect(today['available_amount'], report.todayAvailable.availableAmount);
+      expect(payload['action_items'] is List<dynamic>, true);
+      expect(payload['movement_suggestions'] is List<dynamic>, true);
+      expect(payload['developer_requests'] is List<dynamic>, true);
+      expect(guardrails['calculation_owner'], 'dart_service');
+      expect(guardrails['external_ai_may_summarize_only'], true);
+      expect(guardrails['external_ai_may_recalculate_amounts'], false);
+    });
+  });
+}
+
+AssetManagementInsightReport _report() {
+  const planner = AssetLiabilityPlanningService();
+  const insight = AssetManagementInsightService();
+  final workbook = planner.buildWorkbook(
+    latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
+    baseDate: DateTime(2026, 5, 1),
+    monthlyPaymentOverrides: const <String, double>{'paypay_card': 20000},
+    paymentSourceAccountIds: const <String, String>{'paypay_card': 'bank'},
+  );
+  return insight.buildReport(workbook: workbook, minimumSafetyBalance: 10000);
+}


### PR DESCRIPTION
﻿## 概要

資産管理ページの AI 資産管理アシスタントに、LLM要約連携の土台を feature flag 付きで追加します。

金額計算は引き続き Dart 側の `AssetManagementInsightService` で完結させ、外部AIには計算済みインサイトpayloadだけを渡します。feature flag はデフォルトOFFで、OFF時は ai-hub/provider.chat を呼ばず deterministic summary を表示します。

Closes #2446

## 主な変更

- `AssetManagementAiSummaryService` を追加
  - `ASSET_MANAGEMENT_AI_SUMMARY_ENABLED` dart-define feature flagを追加
  - OFF時は外部AIを呼ばず deterministic fallback を返す
  - ON時のみ `AiHubChatService.sendProviderChat` 経由で `ai-hub provider.chat` を呼ぶ
  - AI失敗時も deterministic fallback に戻す
- AIに渡すpayloadを計算済みインサイトに限定
  - 本日/今週/今月の使用可能額
  - アクションアイテム
  - 口座移動候補
  - 開発者向け改善提案
  - guardrails
- 資産管理ページにAI要約パネルを追加
  - デフォルトは `Feature flag OFF`
  - ON時のみ手動ボタンでAI要約生成
- サービス層テストを追加

## 補足

このPRでは外部AI API呼び出しをデフォルト有効化しません。production write、migration/RLS、Supabase保存変更、金額再計算のAI委譲は含みません。

## Minimal E2E Declaration

- E2E plan is implementation-detail independent / black-box: users should see deterministic asset-management summary by default and should not trigger external AI while the flag is OFF.
- Minimal 3 cases: asset management page renders the AI summary panel, feature flag OFF keeps the AI summary button disabled/no external call path, and service fallback preserves deterministic text when ai-hub fails.
- E2E mechanism: existing CI plus service tests cover the branch logic; a future Playwright check can toggle dart-define builds, but no new browser E2E is required because the default behavior is non-network and non-mutating.
- E2E-Exception: No new browser E2E is added in this PR because the default user-visible behavior is feature-flag OFF, non-network, non-mutating, and covered by service tests for disabled, enabled, and fallback paths. Existing CI remains the merge gate.

## High-risk Ultrareview

Claude Code #1 review owner: Claude Code #1

high-risk-ultrareview-exception: This PR touches AI/payment-domain UI text, but it does not change authentication, RLS, migrations, production write, payment provider integration, secrets, or deterministic amount calculations. External AI is feature-flagged OFF by default and can only summarize precomputed payloads.

Manual risk notes:

- security: no secrets or auth changes.
- rollback: revert PR to remove the service/UI panel.
- data migration: none.
- prod smoke: asset management page should render with `Feature flag OFF` summary panel.
- observability: result source/status is shown in the panel.
- unresolved: 0

## 検証

Local:

- `dart format lib/services/asset_management_ai_summary_service.dart test/services/asset_management_ai_summary_service_test.dart`: OK
- `dart analyze lib/services/asset_management_ai_summary_service.dart test/services/asset_management_ai_summary_service_test.dart`: No issues found
- `git diff --check`: OK

Local note:

- `flutter pub get --enforce-lockfile` failed on this Windows SDK because it wanted to update lockfile-resolved transitive versions.
- `flutter test --no-pub test/services/asset_management_ai_summary_service_test.dart` was attempted after local cache repair, but the local Pub cache is missing transitive package directories. CI runs in a clean dependency environment and is the merge gate for full Flutter validation.
