### PR TITLE
fix(wbs): backfill business seed recovery plan (#2494)

### DIFF
--- a/supabase/migrations/20260425170000_business_wbs_phase1.sql
+++ b/supabase/migrations/20260425170000_business_wbs_phase1.sql
@@ -116,6 +116,21 @@ ALTER TABLE public.wbs_tasks ADD CONSTRAINT wbs_tasks_instance_check
     'user', 'gemini', 'copilot'
   )) NOT VALID;
 
+-- Deploy-prod intentionally repairs/re-runs this historical seed. Newer
+-- databases already enforce recovery_plan for overdue tasks, so pause that
+-- trigger around the bulk seed and backfill recovery metadata immediately after.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'wbs_enforce_recovery_plan_trg'
+      AND tgrelid = 'public.wbs_tasks'::regclass
+  ) THEN
+    EXECUTE 'ALTER TABLE public.wbs_tasks DISABLE TRIGGER wbs_enforce_recovery_plan_trg';
+  END IF;
+END $$;
+
 INSERT INTO public.wbs_tasks
   (category, category_icon, category_order, title, description, instance, status, progress,
    start_date, end_date, milestone_code, priority, ai_review_status, stale_threshold_hours)
@@ -247,6 +262,29 @@ VALUES
 ON CONFLICT DO NOTHING;
 -- 注: wbs_tasks に UNIQUE 制約は title + category にないため初回のみ INSERT。
 -- 重複起動した場合は何もしない (idempotent)。
+
+UPDATE public.wbs_tasks
+SET recovery_plan = COALESCE(
+      NULLIF(trim(recovery_plan), ''),
+      'business WBS phase1 seed re-run: review with the current realistic schedule and assign owner follow-up before resuming.'
+    ),
+    recovery_planned_at = COALESCE(recovery_planned_at, NOW())
+WHERE category LIKE 'business-%'
+  AND status <> 'completed'
+  AND COALESCE(planned_end_date, end_date) < CURRENT_DATE
+  AND (recovery_plan IS NULL OR length(trim(recovery_plan)) = 0);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'wbs_enforce_recovery_plan_trg'
+      AND tgrelid = 'public.wbs_tasks'::regclass
+  ) THEN
+    EXECUTE 'ALTER TABLE public.wbs_tasks ENABLE TRIGGER wbs_enforce_recovery_plan_trg';
+  END IF;
+END $$;
 
 -- Derive owner_instance: 'all' tasks owned by 'win' (architect), specific instance tasks own themselves
 UPDATE public.wbs_tasks


### PR DESCRIPTION
## Summary
- Fix deploy-prod failure #2494 by making the historical business WBS Phase 1 seed safe to repair/re-run.
- Temporarily pauses the existing overdue recovery_plan trigger around the bulk seed, then backfills recovery_plan metadata before later WBS updates run.
- Keeps the change scoped to the failing migration file; no app behavior changes.

## Validation
- `git diff --check`
- `python scripts/check_migration_timestamps.py`
- PR checks: DB + Edge smoke, migration timestamp collision check, time-relative CHECK guard, lint/format/test, and public E2E stability smoke are green.

## Minimal E2E declaration
Implementation-detail independent: deploy-prod can re-run the repaired historical WBS seed after migration repair without SQLSTATE 23514.

I/O cases:
1. Given an overdue business WBS seed row with no recovery_plan, when the seed reruns, then recovery_plan is populated before normal triggers resume.
2. Given a future-dated business WBS seed row, when the seed reruns, then it remains insert/update safe without unnecessary recovery metadata.
3. Given the deploy-prod migration repair list reverts 20260425170000, when Supabase migrations run, then the business seed reaches owner_instance derivation instead of failing on recovery_plan enforcement.

## High-risk ultrareview
Review owner: Claude Code #1.
Claude ultrareview evidence:
- security: no secrets, credentials, RLS policy, or service-role values are changed; scope is one historical SQL seed migration.
- rollback: revert PR #2510 or repair migration 20260425170000 back to applied/reverted as needed; no runtime app code changes.
- data migration: the hotfix only backfills recovery_plan/recovery_planned_at for overdue `business-%` WBS rows that are still missing recovery metadata.
- prod smoke: deploy-prod must rerun green after merge, specifically the Supabase migration step that failed in run 25948250304.
- observability: GitHub Actions deploy-prod logs and Issue #2494 remain the verification trail.
Unresolved findings: 0.

Fixes #2494