### PR TITLE
Add audit log for asset liability Supabase sync

### DIFF
--- a/lib/models/asset_liability_sync_audit_log.dart
+++ b/lib/models/asset_liability_sync_audit_log.dart
@@ -1,0 +1,159 @@
+enum AssetLiabilitySyncAuditType {
+  preview('preview'),
+  manualSync('manual_sync'),
+  uploadCandidate('upload_candidate'),
+  downloadCandidate('download_candidate'),
+  conflictDetected('conflict_detected'),
+  failed('failed'),
+  success('success');
+
+  final String storageKey;
+
+  const AssetLiabilitySyncAuditType(this.storageKey);
+
+  static AssetLiabilitySyncAuditType fromStorageKey(String value) {
+    for (final type in values) {
+      if (type.storageKey == value) {
+        return type;
+      }
+    }
+    return AssetLiabilitySyncAuditType.preview;
+  }
+}
+
+class AssetLiabilitySyncAuditLog {
+  final String id;
+  final DateTime executedAt;
+  final AssetLiabilitySyncAuditType type;
+  final String monthKey;
+  final String targetDataType;
+  final int count;
+  final String result;
+  final String? errorMessage;
+
+  const AssetLiabilitySyncAuditLog({
+    required this.id,
+    required this.executedAt,
+    required this.type,
+    required this.monthKey,
+    required this.targetDataType,
+    required this.count,
+    required this.result,
+    this.errorMessage,
+  });
+
+  factory AssetLiabilitySyncAuditLog.create({
+    required AssetLiabilitySyncAuditType type,
+    required String monthKey,
+    required String targetDataType,
+    required int count,
+    required String result,
+    String? errorMessage,
+    DateTime? executedAt,
+  }) {
+    final timestamp = (executedAt ?? DateTime.now()).toUtc();
+    return AssetLiabilitySyncAuditLog(
+      id: '${timestamp.microsecondsSinceEpoch}_${type.storageKey}_$monthKey',
+      executedAt: timestamp,
+      type: type,
+      monthKey: monthKey,
+      targetDataType:
+          targetDataType.trim().isEmpty ? 'unknown' : targetDataType.trim(),
+      count: count < 0 ? 0 : count,
+      result: result.trim().isEmpty ? 'unknown' : result.trim(),
+      errorMessage: _cleanNullableString(errorMessage),
+    );
+  }
+
+  factory AssetLiabilitySyncAuditLog.fromJson(Map<String, Object?> json) {
+    final executedAt = DateTime.tryParse(
+          json['executedAt']?.toString() ??
+              json['executed_at']?.toString() ??
+              '',
+        ) ??
+        DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+    final type = AssetLiabilitySyncAuditType.fromStorageKey(
+      json['type']?.toString() ?? '',
+    );
+    return AssetLiabilitySyncAuditLog(
+      id: _cleanString(json['id']) ??
+          '${executedAt.microsecondsSinceEpoch}_${type.storageKey}',
+      executedAt: executedAt.toUtc(),
+      type: type,
+      monthKey: _cleanString(json['monthKey']) ??
+          _cleanString(json['month_key']) ??
+          '',
+      targetDataType: _cleanString(json['targetDataType']) ??
+          _cleanString(json['target_data_type']) ??
+          'unknown',
+      count: _parseInt(json['count']) ?? 0,
+      result: _cleanString(json['result']) ?? 'unknown',
+      errorMessage: _cleanNullableString(
+        json['errorMessage'] ?? json['error_message'],
+      ),
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'id': id,
+      'executedAt': executedAt.toUtc().toIso8601String(),
+      'type': type.storageKey,
+      'monthKey': monthKey,
+      'targetDataType': targetDataType,
+      'count': count,
+      'result': result,
+      if (errorMessage != null) 'errorMessage': errorMessage,
+    };
+  }
+
+  bool get isFailure => type == AssetLiabilitySyncAuditType.failed;
+
+  bool get isConflict =>
+      type == AssetLiabilitySyncAuditType.conflictDetected ||
+      result.contains('conflict');
+}
+
+class AssetLiabilitySyncAuditLogTablePlan {
+  static const String tableName = 'asset_liability_sync_audit_logs';
+
+  static const List<String> futureSupabaseColumns = <String>[
+    'id',
+    'user_id',
+    'month_key',
+    'executed_at',
+    'sync_type',
+    'target_data_type',
+    'target_count',
+    'result',
+    'error_message',
+    'payload',
+    'created_at',
+    'updated_at',
+  ];
+
+  const AssetLiabilitySyncAuditLogTablePlan._();
+}
+
+String? _cleanString(Object? source) {
+  final value = source?.toString().trim();
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  return value;
+}
+
+String? _cleanNullableString(Object? source) {
+  final value = _cleanString(source);
+  return value == null || value.isEmpty ? null : value;
+}
+
+int? _parseInt(Object? source) {
+  if (source is num) {
+    return source.toInt();
+  }
+  if (source == null) {
+    return null;
+  }
+  return int.tryParse(source.toString());
+}

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -14,6 +14,7 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
+import 'package:my_web_app/models/asset_liability_sync_audit_log.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/models/debt_repayment_plan.dart';
 import 'package:my_web_app/models/kgi_csf_kpi.dart';
@@ -129,6 +130,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   String? _assetLiabilitySyncMessage;
   List<String> _assetLiabilitySyncConflicts = <String>[];
   AssetLiabilitySyncPreviewResult? _assetLiabilitySyncPreview;
+  List<AssetLiabilitySyncAuditLog> _assetLiabilitySyncAuditLogs =
+      <AssetLiabilitySyncAuditLog>[];
   final Map<String, TextEditingController> _monthlyPaymentControllers =
       <String, TextEditingController>{};
 
@@ -809,6 +812,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           await _assetLiabilityRepository.loadRecurringIncomeTemplates();
       final monthlySnapshots =
           await _assetLiabilityRepository.loadMonthlySnapshots();
+      final syncAuditLogs = await _assetLiabilityRepository.loadSyncAuditLogs(
+        limit: 12,
+      );
       final incomePlansWithTemplates =
           AssetLiabilityMonthlyStateStore.applyRecurringIncomeTemplates(
         month: targetMonth,
@@ -843,6 +849,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _monthlySnapshots = List<AssetLiabilityMonthlySnapshot>.from(
           monthlySnapshots,
         );
+        _assetLiabilitySyncAuditLogs = List<AssetLiabilitySyncAuditLog>.from(
+          syncAuditLogs,
+        );
         _loadedAssetLiabilityMonthKey = monthKey;
         _syncMonthlyPaymentControllers();
       });
@@ -851,6 +860,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       }
     } catch (e) {
       debugPrint('Error loading asset liability monthly state: $e');
+    }
+  }
+
+  Future<void> _refreshAssetLiabilitySyncAuditLogs() async {
+    try {
+      final logs = await _assetLiabilityRepository.loadSyncAuditLogs(limit: 12);
+      if (!mounted) return;
+      setState(() {
+        _assetLiabilitySyncAuditLogs = List<AssetLiabilitySyncAuditLog>.from(
+          logs,
+        );
+      });
+    } catch (e) {
+      debugPrint('Error loading asset liability sync audit logs: $e');
     }
   }
 
@@ -905,6 +928,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       });
       if (result.isSuccess) {
         await _loadAssetLiabilityMonthlyState();
+      } else {
+        await _refreshAssetLiabilitySyncAuditLogs();
       }
       if (!mounted) return;
       ScaffoldMessenger.of(
@@ -919,6 +944,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _assetLiabilitySyncMessage = 'Supabase同期に失敗しました: $e';
         _assetLiabilitySyncConflicts = <String>[];
       });
+      await _refreshAssetLiabilitySyncAuditLogs();
+      if (!mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text('Supabase同期に失敗しました: $e')));
@@ -937,6 +964,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       setState(() {
         _assetLiabilitySyncPreview = result;
       });
+      await _refreshAssetLiabilitySyncAuditLogs();
+      if (!mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(result.message)));
@@ -952,6 +981,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       setState(() {
         _assetLiabilitySyncPreview = result;
       });
+      await _refreshAssetLiabilitySyncAuditLogs();
+      if (!mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(result.message)));
@@ -6764,6 +6795,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             const SizedBox(height: 8),
             _buildAssetLiabilitySyncPreviewDetails(_assetLiabilitySyncPreview!),
           ],
+          const SizedBox(height: 8),
+          _buildAssetLiabilitySyncAuditLogSection(syncEnabled),
           if (_assetLiabilitySyncConflicts.isNotEmpty) ...[
             const SizedBox(height: 8),
             Wrap(
@@ -6783,6 +6816,177 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ],
       ),
     );
+  }
+
+  Widget _buildAssetLiabilitySyncAuditLogSection(bool syncEnabled) {
+    final logs = _assetLiabilitySyncAuditLogs.take(8).toList(growable: false);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.receipt_long_outlined, size: 16),
+              const SizedBox(width: 6),
+              const Expanded(
+                child: Text(
+                  'Supabase同期監査ログ',
+                  style: TextStyle(fontWeight: FontWeight.w700, height: 1.4),
+                ),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: 'ログ',
+                value: syncEnabled ? '${logs.length}件' : 'OFF',
+                color: syncEnabled
+                    ? const Color(0xFF2563EB)
+                    : Theme.of(context).colorScheme.outline,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            syncEnabled
+                ? '同期プレビュー・手動同期・競合検出・失敗をローカルに記録します。'
+                : 'Supabase同期がOFFのため、同期検証ログは記録しません。',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          if (syncEnabled && logs.isEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              'まだ同期検証ログはありません。',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+              ),
+            ),
+          ],
+          if (syncEnabled && logs.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            for (final log in logs) _buildAssetLiabilitySyncAuditLogTile(log),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetLiabilitySyncAuditLogTile(AssetLiabilitySyncAuditLog log) {
+    final color = _assetLiabilitySyncAuditLogColor(log);
+    final executedAt = DateFormat(
+      'MM/dd HH:mm',
+    ).format(log.executedAt.toLocal());
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: color.withValues(alpha: 0.26)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                _buildAssetLiabilitySyncChip(
+                  label: '時刻',
+                  value: executedAt,
+                  color: color,
+                ),
+                _buildAssetLiabilitySyncChip(
+                  label: '種別',
+                  value: _assetLiabilitySyncAuditTypeLabel(log.type),
+                  color: color,
+                ),
+                _buildAssetLiabilitySyncChip(
+                  label: '対象月',
+                  value: log.monthKey,
+                  color: const Color(0xFF475569),
+                ),
+                _buildAssetLiabilitySyncChip(
+                  label: '件数',
+                  value: '${log.count}件',
+                  color: const Color(0xFF475569),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${log.targetDataType} / ${log.result}',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+                height: 1.4,
+              ),
+            ),
+            if (log.errorMessage != null) ...[
+              const SizedBox(height: 2),
+              Text(
+                log.errorMessage!,
+                style: const TextStyle(
+                  color: Color(0xFFB91C1C),
+                  fontSize: 12,
+                  height: 1.4,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _assetLiabilitySyncAuditTypeLabel(AssetLiabilitySyncAuditType type) {
+    switch (type) {
+      case AssetLiabilitySyncAuditType.preview:
+        return 'preview';
+      case AssetLiabilitySyncAuditType.manualSync:
+        return 'manual_sync';
+      case AssetLiabilitySyncAuditType.uploadCandidate:
+        return 'upload';
+      case AssetLiabilitySyncAuditType.downloadCandidate:
+        return 'download';
+      case AssetLiabilitySyncAuditType.conflictDetected:
+        return 'conflict';
+      case AssetLiabilitySyncAuditType.failed:
+        return 'failed';
+      case AssetLiabilitySyncAuditType.success:
+        return 'success';
+    }
+  }
+
+  Color _assetLiabilitySyncAuditLogColor(AssetLiabilitySyncAuditLog log) {
+    if (log.isFailure) {
+      return const Color(0xFFB91C1C);
+    }
+    if (log.isConflict) {
+      return const Color(0xFFD97706);
+    }
+    if (log.type == AssetLiabilitySyncAuditType.success) {
+      return const Color(0xFF0D9488);
+    }
+    if (log.type == AssetLiabilitySyncAuditType.downloadCandidate) {
+      return const Color(0xFF0D9488);
+    }
+    if (log.type == AssetLiabilitySyncAuditType.uploadCandidate) {
+      return const Color(0xFF2563EB);
+    }
+    return const Color(0xFF475569);
   }
 
   Widget _buildAssetLiabilitySyncPreviewDetails(

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:intl/intl.dart';
+import 'package:my_web_app/models/asset_liability_sync_audit_log.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -45,6 +46,9 @@ class AssetLiabilityMonthlyStateStore {
       'asset_liability_recurring_income_templates_v1';
   static const String monthlySnapshotPrefsKey =
       'asset_liability_monthly_snapshots_v1';
+  static const String syncAuditLogPrefsKey =
+      'asset_liability_sync_audit_logs_v1';
+  static const int maxSyncAuditLogCount = 50;
 
   const AssetLiabilityMonthlyStateStore();
 
@@ -224,6 +228,28 @@ class AssetLiabilityMonthlyStateStore {
     await prefs.setString(
       monthlySnapshotPrefsKey,
       jsonEncode(_encodeMonthlySnapshots(nextSnapshots)),
+    );
+  }
+
+  Future<List<AssetLiabilitySyncAuditLog>> loadSyncAuditLogs({
+    int limit = 20,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final logs = decodeSyncAuditLogs(prefs.getString(syncAuditLogPrefsKey));
+    return logs.take(limit < 0 ? 0 : limit).toList(growable: false);
+  }
+
+  Future<void> saveSyncAuditLog(AssetLiabilitySyncAuditLog log) async {
+    final prefs = await SharedPreferences.getInstance();
+    final logs = decodeSyncAuditLogs(prefs.getString(syncAuditLogPrefsKey));
+    final nextLogs = <AssetLiabilitySyncAuditLog>[
+      log,
+      for (final current in logs)
+        if (current.id != log.id) current,
+    ].take(maxSyncAuditLogCount).toList(growable: false);
+    await prefs.setString(
+      syncAuditLogPrefsKey,
+      jsonEncode(_encodeSyncAuditLogs(nextLogs)),
     );
   }
 
@@ -587,6 +613,32 @@ class AssetLiabilityMonthlyStateStore {
     return snapshots;
   }
 
+  static List<AssetLiabilitySyncAuditLog> decodeSyncAuditLogs(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <AssetLiabilitySyncAuditLog>[];
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Iterable) {
+      return <AssetLiabilitySyncAuditLog>[];
+    }
+
+    final logs = <AssetLiabilitySyncAuditLog>[];
+    for (final rawLog in decoded) {
+      if (rawLog is! Map) {
+        continue;
+      }
+      logs.add(
+        AssetLiabilitySyncAuditLog.fromJson(
+          rawLog.map<String, Object?>(
+            (key, value) => MapEntry(key.toString(), value),
+          ),
+        ),
+      );
+    }
+    logs.sort((a, b) => b.executedAt.compareTo(a.executedAt));
+    return logs;
+  }
+
   static Map<String, double> paymentOverridesForMonth(
     String? raw,
     String monthKey,
@@ -724,6 +776,14 @@ class AssetLiabilityMonthlyStateStore {
           'overduePaymentCount': snapshot.overduePaymentCount,
         },
     ];
+  }
+
+  static List<Map<String, Object?>> _encodeSyncAuditLogs(
+    List<AssetLiabilitySyncAuditLog> logs,
+  ) {
+    final sorted = List<AssetLiabilitySyncAuditLog>.from(logs)
+      ..sort((a, b) => b.executedAt.compareTo(a.executedAt));
+    return [for (final log in sorted) log.toJson()];
   }
 
   static Map<String, List<Map<String, Object?>>> _encodeIncomePlans(

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:my_web_app/models/asset_liability_persistence.dart';
+import 'package:my_web_app/models/asset_liability_sync_audit_log.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -200,6 +201,14 @@ abstract class AssetLiabilityRepository {
   Future<List<AssetLiabilityMonthlySnapshot>> loadMonthlySnapshots();
 
   Future<void> saveMonthlySnapshot(AssetLiabilityMonthlySnapshot snapshot);
+
+  Future<List<AssetLiabilitySyncAuditLog>> loadSyncAuditLogs({
+    int limit = 20,
+  }) async {
+    return const <AssetLiabilitySyncAuditLog>[];
+  }
+
+  Future<void> saveSyncAuditLog(AssetLiabilitySyncAuditLog log) async {}
 
   Future<AssetLiabilityManualSyncResult> syncMonth(DateTime month) async {
     return AssetLiabilityManualSyncResult.disabled();
@@ -576,6 +585,16 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
   }
 
   @override
+  Future<List<AssetLiabilitySyncAuditLog>> loadSyncAuditLogs({int limit = 20}) {
+    return localRepository.loadSyncAuditLogs(limit: limit);
+  }
+
+  @override
+  Future<void> saveSyncAuditLog(AssetLiabilitySyncAuditLog log) {
+    return localRepository.saveSyncAuditLog(log);
+  }
+
+  @override
   Future<AssetLiabilityManualSyncResult> syncMonth(DateTime month) async {
     final remote = _remoteOrNull();
     final userId = _userIdOrNull();
@@ -583,6 +602,14 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       return AssetLiabilityManualSyncResult.disabled();
     }
     if (userId == null) {
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.failed,
+        targetDataType: 'all_targets',
+        count: 0,
+        result: 'missing_supabase_user',
+        errorMessage: 'Supabase user is not available.',
+      );
       return AssetLiabilityManualSyncResult.failure(
         message: 'Supabaseユーザーが確認できません',
       );
@@ -596,6 +623,21 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       );
       final preview = _buildSyncPreview(syncData);
       if (preview.hasConflict) {
+        await _recordAuditLog(
+          month: month,
+          type: AssetLiabilitySyncAuditType.manualSync,
+          targetDataType: 'all_targets',
+          count: preview.targetCount,
+          result: 'conflict',
+        );
+        await _recordAuditLog(
+          month: month,
+          type: AssetLiabilitySyncAuditType.conflictDetected,
+          targetDataType: preview.conflictTargets.join(','),
+          count: preview.conflictCount,
+          result: 'conflict_non_destructive_stop',
+          errorMessage: 'Both local and Supabase data exist; no overwrite.',
+        );
         return AssetLiabilityManualSyncResult.conflict(
           targets: preview.conflictTargets,
         );
@@ -671,6 +713,22 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
         restored += syncData.remoteSnapshots!.length;
       }
 
+      final syncedCount = uploaded + restored;
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.manualSync,
+        targetDataType: 'all_targets',
+        count: syncedCount,
+        result: 'success',
+      );
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.success,
+        targetDataType: 'all_targets',
+        count: syncedCount,
+        result: 'success',
+      );
+
       return AssetLiabilityManualSyncResult.success(
         message: '同期完了（アップロード $uploaded 件 / 復元 $restored 件）',
       );
@@ -680,6 +738,14 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       } else {
         debugPrint('Asset liability manual Supabase sync failed: $error');
       }
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.failed,
+        targetDataType: 'all_targets',
+        count: 0,
+        result: 'failed',
+        errorMessage: error.toString(),
+      );
       return AssetLiabilityManualSyncResult.failure(
         message: 'Supabase同期に失敗しました: $error',
       );
@@ -696,6 +762,14 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       return AssetLiabilitySyncPreviewResult.disabled();
     }
     if (userId == null) {
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.failed,
+        targetDataType: 'preview',
+        count: 0,
+        result: 'missing_supabase_user',
+        errorMessage: 'Supabase user is not available.',
+      );
       return AssetLiabilitySyncPreviewResult.failure(
         message: 'Supabaseユーザーが確認できません',
       );
@@ -707,16 +781,91 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
         remote: remote,
         userId: userId,
       );
-      return _buildSyncPreview(syncData);
+      final preview = _buildSyncPreview(syncData);
+      await _recordPreviewAuditLogs(month: month, preview: preview);
+      return preview;
     } catch (error, stackTrace) {
       if (onSyncError != null) {
         onSyncError!(error, stackTrace);
       } else {
         debugPrint('Asset liability Supabase sync preview failed: $error');
       }
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.failed,
+        targetDataType: 'preview',
+        count: 0,
+        result: 'failed',
+        errorMessage: error.toString(),
+      );
       return AssetLiabilitySyncPreviewResult.failure(
         message: 'Supabase同期プレビューに失敗しました: $error',
       );
+    }
+  }
+
+  Future<void> _recordPreviewAuditLogs({
+    required DateTime month,
+    required AssetLiabilitySyncPreviewResult preview,
+  }) async {
+    await _recordAuditLog(
+      month: month,
+      type: AssetLiabilitySyncAuditType.preview,
+      targetDataType: 'all_targets',
+      count: preview.targetCount,
+      result: preview.hasConflict ? 'conflict' : 'success',
+    );
+    if (preview.uploadCandidateCount > 0) {
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.uploadCandidate,
+        targetDataType: 'upload_candidates',
+        count: preview.uploadCandidateCount,
+        result: 'detected',
+      );
+    }
+    if (preview.downloadCandidateCount > 0) {
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.downloadCandidate,
+        targetDataType: 'download_candidates',
+        count: preview.downloadCandidateCount,
+        result: 'detected',
+      );
+    }
+    if (preview.conflictCount > 0) {
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.conflictDetected,
+        targetDataType: preview.conflictTargets.join(','),
+        count: preview.conflictCount,
+        result: 'conflict_non_destructive_stop',
+        errorMessage: 'Both local and Supabase data exist; no overwrite.',
+      );
+    }
+  }
+
+  Future<void> _recordAuditLog({
+    required DateTime month,
+    required AssetLiabilitySyncAuditType type,
+    required String targetDataType,
+    required int count,
+    required String result,
+    String? errorMessage,
+  }) async {
+    try {
+      await localRepository.saveSyncAuditLog(
+        AssetLiabilitySyncAuditLog.create(
+          type: type,
+          monthKey: AssetLiabilityMonthlyStateStore.formatMonthKey(month),
+          targetDataType: targetDataType,
+          count: count,
+          result: result,
+          errorMessage: errorMessage,
+        ),
+      );
+    } catch (error) {
+      debugPrint('Asset liability sync audit log skipped: $error');
     }
   }
 
@@ -1194,5 +1343,15 @@ class SharedPreferencesAssetLiabilityRepository
   @override
   Future<void> saveMonthlySnapshot(AssetLiabilityMonthlySnapshot snapshot) {
     return store.saveMonthlySnapshot(snapshot);
+  }
+
+  @override
+  Future<List<AssetLiabilitySyncAuditLog>> loadSyncAuditLogs({int limit = 20}) {
+    return store.loadSyncAuditLogs(limit: limit);
+  }
+
+  @override
+  Future<void> saveSyncAuditLog(AssetLiabilitySyncAuditLog log) {
+    return store.saveSyncAuditLog(log);
   }
 }

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/models/asset_liability_persistence.dart';
+import 'package:my_web_app/models/asset_liability_sync_audit_log.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
@@ -113,6 +114,28 @@ void main() {
       expect(snapshots.single.monthlyUnpaidPaymentTotal, 80000);
     });
 
+    test('saves and restores sync audit logs through repository', () async {
+      const repository = SharedPreferencesAssetLiabilityRepository();
+
+      await repository.saveSyncAuditLog(
+        AssetLiabilitySyncAuditLog.create(
+          type: AssetLiabilitySyncAuditType.preview,
+          monthKey: '2026-05',
+          targetDataType: 'all_targets',
+          count: 5,
+          result: 'success',
+          executedAt: DateTime.utc(2026, 5, 14, 12),
+        ),
+      );
+
+      final logs = await repository.loadSyncAuditLogs();
+
+      expect(logs, hasLength(1));
+      expect(logs.single.type, AssetLiabilitySyncAuditType.preview);
+      expect(logs.single.monthKey, '2026-05');
+      expect(logs.single.count, 5);
+    });
+
     test('builds a full local persistence snapshot', () async {
       const repository = SharedPreferencesAssetLiabilityRepository();
       final month = DateTime(2026, 5, 1);
@@ -192,6 +215,10 @@ void main() {
   });
 
   group('FeatureFlaggedAssetLiabilityRepository', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
     test('factory keeps Supabase sync disabled by default', () {
       final local = _FakeAssetLiabilityRepository();
       final remote = _RecordingAssetLiabilityRemoteStore();
@@ -283,6 +310,35 @@ void main() {
       expect(remote.recurringIncomeTemplates, isEmpty);
       expect(remote.monthlySnapshots, isEmpty);
     });
+
+    test(
+      'sync preview records preview and upload candidate audit logs',
+      () async {
+        const local = SharedPreferencesAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore();
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
+        await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+        final result = await repository.previewSyncMonth(month);
+        final logs = await repository.loadSyncAuditLogs();
+
+        expect(result.status, AssetLiabilityManualSyncStatus.success);
+        expect(
+          logs.map((log) => log.type),
+          containsAll(<AssetLiabilitySyncAuditType>[
+            AssetLiabilitySyncAuditType.preview,
+            AssetLiabilitySyncAuditType.uploadCandidate,
+          ]),
+        );
+        expect(remote.calls, isNot(contains('saveMonth:user-1:2026-05')));
+      },
+    );
 
     test(
       'sync preview reports download candidates without restoring',
@@ -459,6 +515,28 @@ void main() {
       expect(remote.monthlySnapshots.single.monthKey, '2026-05');
     });
 
+    test('manual sync success records success audit log', () async {
+      const local = SharedPreferencesAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore();
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+      await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+      final result = await repository.syncMonth(month);
+      final logs = await repository.loadSyncAuditLogs();
+
+      expect(result.status, AssetLiabilityManualSyncStatus.success);
+      expect(
+        logs.map((log) => log.type),
+        contains(AssetLiabilitySyncAuditType.success),
+      );
+    });
+
     test('manual sync failure keeps local data intact', () async {
       final local = _FakeAssetLiabilityRepository();
       final remote = _RecordingAssetLiabilityRemoteStore()..failSaves = true;
@@ -477,6 +555,29 @@ void main() {
       expect(result.status, AssetLiabilityManualSyncStatus.failure);
       expect(restored.paymentOverrides['mobit'], 70000);
       expect(remote.calls, contains('saveMonth:user-1:2026-05'));
+    });
+
+    test('manual sync failure records failed audit log', () async {
+      const local = SharedPreferencesAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore()..failSaves = true;
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+      await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+      final result = await repository.syncMonth(month);
+      final logs = await repository.loadSyncAuditLogs();
+
+      expect(result.status, AssetLiabilityManualSyncStatus.failure);
+      expect(
+        logs.map((log) => log.type),
+        contains(AssetLiabilitySyncAuditType.failed),
+      );
+      expect((await local.loadMonth(month)).paymentOverrides['mobit'], 70000);
     });
 
     test(
@@ -511,6 +612,67 @@ void main() {
           1000,
         );
         expect(remote.calls, isNot(contains('saveMonth:user-1:2026-05')));
+      },
+    );
+
+    test('manual sync conflict records conflict audit log', () async {
+      const local = SharedPreferencesAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore()
+        ..seedMonth(
+          DateTime(2026, 5),
+          const AssetLiabilityMonthlyState(
+            paymentOverrides: <String, double>{'remote_only': 1000},
+          ),
+        );
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+      await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+      final result = await repository.syncMonth(month);
+      final logs = await repository.loadSyncAuditLogs();
+
+      expect(result.status, AssetLiabilityManualSyncStatus.conflict);
+      expect(
+        logs.map((log) => log.type),
+        contains(AssetLiabilitySyncAuditType.conflictDetected),
+      );
+      expect(
+        logs
+            .firstWhere(
+              (log) => log.type == AssetLiabilitySyncAuditType.conflictDetected,
+            )
+            .result,
+        'conflict_non_destructive_stop',
+      );
+    });
+
+    test(
+      'feature flag off does not call Supabase or create audit logs',
+      () async {
+        const local = SharedPreferencesAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore();
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: false,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
+        await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+        final result = await repository.previewSyncMonth(month);
+        final syncResult = await repository.syncMonth(month);
+        final logs = await repository.loadSyncAuditLogs();
+
+        expect(result.status, AssetLiabilityManualSyncStatus.disabled);
+        expect(syncResult.status, AssetLiabilityManualSyncStatus.disabled);
+        expect(remote.calls, isEmpty);
+        expect(logs, isEmpty);
       },
     );
 


### PR DESCRIPTION
﻿## 概要

資産/負債ボードの Supabase 同期に、ステージング検証向けの監査ログを追加します。

同期プレビュー・手動同期・候補検出・競合検出・失敗/成功をローカルに記録し、資産管理ページ上で最新ログを確認できるようにしました。feature flag は引き続きデフォルト OFF で、OFF 時は Supabase へアクセスせず、同期検証ログも生成しません。

Closes #2447

## 主な変更

- `AssetLiabilitySyncAuditLog` model を追加
  - sync type: `preview`, `manual_sync`, `upload_candidate`, `download_candidate`, `conflict_detected`, `failed`, `success`
  - executedAt / monthKey / targetDataType / count / result / errorMessage を保持
  - 将来 Supabase 保存するための table plan を併記
- `AssetLiabilityMonthlyStateStore` に同期監査ログのローカル保存/復元を追加
  - SharedPreferences 保存
  - 最新順で最大50件保持
- `FeatureFlaggedAssetLiabilityRepository` に同期監査ログ記録を追加
  - preview 成功時に preview / upload candidate / download candidate / conflict を記録
  - manual sync 成功時に manual_sync / success を記録
  - 失敗時に failed を記録
  - 競合時は自動上書きせず conflict_detected を記録
  - feature flag OFF 時は Supabase access なし、監査ログ生成なし
- 資産管理ページに「Supabase同期監査ログ」セクションを追加
  - 最新ログ一覧
  - 成功/失敗/競合を色で区別
  - feature flag OFF 時はログ機能が無効であることを表示
- Repository service tests を追加

## スコープ外

- Supabase への監査ログ production write
- migration / RLS 変更
- 自動競合解決
- feature flag のデフォルト ON 化
- UI からの直接 Supabase 呼び出し

## Minimal E2E Declaration

- E2E plan is implementation-detail independent / black-box: users should see a non-mutating Supabase sync audit log panel and should not trigger Supabase access or log generation while the sync feature flag is OFF.
- Minimal 3 cases: feature flag OFF shows the disabled audit-log state, sync preview records preview/candidate/conflict logs when enabled, and manual sync records success/failed outcomes without deleting local data.
- E2E mechanism: repository/service tests cover the sync/log branch behavior and CI remains the merge gate; a web build + HTTP 200 smoke was used locally to verify the page still serves.
- E2E-Exception: UI impact is limited to a deterministic local audit-log panel for an existing asset management sync section; verified by web build + HTTP 200 and service tests, with no browser automation required.

## High-risk Ultrareview

Claude Code #1 review owner: Claude Code #1

high-risk-ultrareview-exception: This PR touches money-management sync UI/repository flow, but it does not change authentication, RLS, migrations, production Supabase writes, payment integrations, secrets, or deterministic amount calculations. Supabase sync remains feature-flagged OFF by default, and audit logs are local-only.

Manual risk notes:

- security: no secrets, auth, RLS, or migration changes.
- rollback: revert PR to remove the audit-log model, repository logging, local store methods, and UI panel.
- data migration: none. Audit logs are local SharedPreferences records only.
- prod smoke: asset management page should render; with flag OFF the panel displays disabled state and does not access Supabase.
- observability: sync preview/manual sync now expose local success/failure/conflict logs.
- unresolved: 0

## 検証

Local:

- `dart format --output=none --set-exit-if-changed <changed files>`: OK, 0 changed
- `flutter analyze --no-pub <changed files>`: No issues found before local Pub cache instability
- `flutter test --no-pub test/services/asset_liability_repository_test.dart --reporter expanded`: 30 tests passed
- asset/liability related tests: 90 tests passed
- full `flutter test --no-pub --reporter compact`: 471 tests passed
- `flutter build web --no-pub`: OK
- local web smoke: HTTP 200
- `git diff --check`: OK

Local note:

- After the first successful validation pass, the local Windows Pub cache lost hosted package directories while attempting a final re-run. The branch itself remains clean, and GitHub Actions runs in a fresh dependency environment as the final validation gate.
