### PR TITLE
chore: ignore local hygiene logs (#2507)

### DIFF
--- a/memory/.gitignore
+++ b/memory/.gitignore
@@ -1,0 +1,3 @@
+# Local Claude/Codex session hygiene logs
+/session_hygiene_log.csv
+/claude-hygiene-tasks/


### PR DESCRIPTION
﻿## Summary
- Ignore local session hygiene logs created by the #2507 Windows Task Scheduler installer.
- Keep `memory/session_hygiene_log.csv` and `memory/claude-hygiene-tasks/` out of future commits when the local scheduled tasks are installed.

## Why
The #2507 installer intentionally writes local operation and hygiene logs. Those logs should stay machine-local so the installer does not dirty the main worktree after merge.

## Validation
- `git check-ignore -v memory/session_hygiene_log.csv`
- `git check-ignore -v memory/claude-hygiene-tasks/install-test.json`
- `git diff --check`

## Minimal E2E declaration
This is implementation-detail independent and black-box validated through Git ignore behavior. About three I/O cases are covered: the CSV log path, the task log directory path, and whitespace validation. Playwright is not required because this PR has no browser UI surface.

Follow-up for #2507
