### PR TITLE
Fix WBS list pagination and duplicate task rows

### DIFF
--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -33,6 +33,11 @@ import {
   type McpMyWebAppToolName,
   mcpRequestedScopes,
 } from "../_shared/mcp_my_web_app_tools.ts";
+import {
+  dedupeWbsTasksById,
+  normalizeWbsListPagination,
+  paginateWbsTasks,
+} from "./wbs_list_tasks.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -6204,11 +6209,11 @@ serve(async (req) => {
           // body: { instance?: 'all'|'claude'|'codex'|'user'|'automation' (legacy lanes are still accepted),
           //        status?: 'pending'|'in_progress'|'completed'|'blocked',
           //        updated_since?: 'YYYY-MM-DDTHH:MM:SSZ' (ISO-8601),
-          //        limit?: 50 }
+          //        limit?: 50, offset?: 0 }
           const inst = body.instance as string | undefined;
           const status = body.status as string | undefined;
           const updatedSince = body.updated_since as string | undefined;
-          const limit = Math.min(Number(body.limit ?? 50), 200);
+          const pagination = normalizeWbsListPagination(body);
           const taskSelect =
             "id, category, category_icon, category_order, title, description, instance, owner_instance, status, progress, start_date, end_date, planned_start_date, planned_end_date, milestone_code, priority, remaining_work, updated_at, github_issue_number, github_issue_url, github_issue_state, github_issue_labels, github_issue_synced_at";
           const pageSize = 1000;
@@ -6227,24 +6232,27 @@ serve(async (req) => {
             allTasks.push(...rows);
             if (rows.length < pageSize) break;
           }
-          const filteredTasks = allTasks.filter((task) =>
+          const dedupedTasks = dedupeWbsTasksById(allTasks);
+          const filteredTasks = dedupedTasks.tasks.filter((task) =>
             wbsTaskMatchesInstanceFilter(
               task,
               inst ?? "all",
             )
           );
-          const sortedTasks = filteredTasks.sort(compareWbsTasks).slice(
-            0,
-            limit,
-          );
+          const sortedTasks = filteredTasks.sort(compareWbsTasks);
+          const pagedTasks = paginateWbsTasks(sortedTasks, pagination);
           // milestone 情報も同時取得
           const { data: milestones } = await admin.from("wbs_milestones")
             .select("code, name, target_date, goal_users, color");
           return json({
             success: true,
-            tasks: sortedTasks,
+            tasks: pagedTasks,
             milestones: milestones ?? [],
             total: filteredTasks.length,
+            limit: pagination.limit,
+            offset: pagination.offset,
+            returned: pagedTasks.length,
+            duplicate_rows_removed: dedupedTasks.duplicateRowsRemoved,
           });
         }
         case "wbs.update_progress": {

--- a/supabase/functions/tools-hub/wbs_list_tasks.ts
+++ b/supabase/functions/tools-hub/wbs_list_tasks.ts
@@ -1,0 +1,59 @@
+export type WbsListPagination = {
+  limit: number;
+  offset: number;
+};
+
+export type WbsTaskDedupeResult = {
+  tasks: Array<Record<string, unknown>>;
+  duplicateRowsRemoved: number;
+};
+
+function boundedInteger(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const parsed = Math.trunc(Number(value));
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+export function normalizeWbsListPagination(
+  body: Record<string, unknown>,
+): WbsListPagination {
+  return {
+    limit: boundedInteger(body.limit, 50, 1, 200),
+    offset: boundedInteger(body.offset, 0, 0, 100_000),
+  };
+}
+
+export function dedupeWbsTasksById(
+  tasks: Array<Record<string, unknown>>,
+): WbsTaskDedupeResult {
+  const seen = new Set<string>();
+  const deduped: Array<Record<string, unknown>> = [];
+
+  for (const task of tasks) {
+    const id = String(task.id ?? "").trim();
+    if (!id) {
+      deduped.push(task);
+      continue;
+    }
+    if (seen.has(id)) continue;
+    seen.add(id);
+    deduped.push(task);
+  }
+
+  return {
+    tasks: deduped,
+    duplicateRowsRemoved: tasks.length - deduped.length,
+  };
+}
+
+export function paginateWbsTasks(
+  tasks: Array<Record<string, unknown>>,
+  pagination: WbsListPagination,
+): Array<Record<string, unknown>> {
+  return tasks.slice(pagination.offset, pagination.offset + pagination.limit);
+}

--- a/supabase/functions/tools-hub/wbs_list_tasks_test.ts
+++ b/supabase/functions/tools-hub/wbs_list_tasks_test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  dedupeWbsTasksById,
+  normalizeWbsListPagination,
+  paginateWbsTasks,
+} from "./wbs_list_tasks.ts";
+
+Deno.test("normalizeWbsListPagination clamps limit and offset", () => {
+  assertEquals(normalizeWbsListPagination({}), { limit: 50, offset: 0 });
+  assertEquals(normalizeWbsListPagination({ limit: 500, offset: -10 }), {
+    limit: 200,
+    offset: 0,
+  });
+  assertEquals(normalizeWbsListPagination({ limit: "25", offset: "75" }), {
+    limit: 25,
+    offset: 75,
+  });
+});
+
+Deno.test("dedupeWbsTasksById preserves first row per id", () => {
+  const result = dedupeWbsTasksById([
+    { id: "task-a", title: "first" },
+    { id: "task-b", title: "middle" },
+    { id: "task-a", title: "duplicate" },
+  ]);
+
+  assertEquals(result.duplicateRowsRemoved, 1);
+  assertEquals(result.tasks, [
+    { id: "task-a", title: "first" },
+    { id: "task-b", title: "middle" },
+  ]);
+});
+
+Deno.test("paginateWbsTasks applies offset after sorting/filtering", () => {
+  const rows = Array.from({ length: 6 }, (_, index) => ({
+    id: `task-${index + 1}`,
+  }));
+
+  assertEquals(paginateWbsTasks(rows, { limit: 2, offset: 0 }), [
+    { id: "task-1" },
+    { id: "task-2" },
+  ]);
+  assertEquals(paginateWbsTasks(rows, { limit: 2, offset: 2 }), [
+    { id: "task-3" },
+    { id: "task-4" },
+  ]);
+});


### PR DESCRIPTION
﻿## Overview

Fixes #2517 by making `wbs.list_tasks` pagination deterministic and defensive against repeated task rows.

The action now normalizes `limit` and `offset`, de-duplicates fetched rows by `id` before filtering/sorting, applies pagination after the final sort, and returns pagination/debug metadata.

## Changes

- Add `offset` support to `wbs.list_tasks`.
- Add defensive same-ID de-duplication before WBS instance filtering.
- Return `limit`, `offset`, `returned`, and `duplicate_rows_removed` in the response.
- Add focused Deno tests for pagination normalization, de-duplication, and offset slicing.

## Issue

Closes #2517

## Minimal E2E Declaration

No browser UI behavior is changed in this PR. This is an Edge Function API behavior fix.

- Implementation-detail independent black-box I/O contract: callers receive stable WBS task rows after filtering, sorting, and pagination without depending on internal query shape.
- Minimal 3 cases: normalize invalid pagination input, de-duplicate repeated task IDs, and apply offset after deterministic sorting.
- E2E: Public E2E stability smoke via Playwright remains the browser-level guard; targeted Deno tests cover this Edge Function API behavior.
- E2E-Exception: Edge Function API-only pagination/dedupe change with no browser route, selector, or user flow change, so no new integration_test or test/e2e file is added.

## High-risk Ultrareview

Claude Code #1 is the review owner for this Edge Function review.

- Security: no secrets, auth scopes, RLS policies, or service-role access paths are changed.
- Rollback: revert this PR to restore the previous `wbs.list_tasks` response behavior.
- Data migration: none; no database rows or schema are changed.
- Prod smoke: CI `DB + Edge smoke` is required before merge.
- Observability: response metadata includes `limit`, `offset`, `returned`, and `duplicate_rows_removed` so duplicate suppression is visible to callers.

Unresolved findings: 0. No unresolved ultrareview findings remain.

## Verification

- `deno fmt --check supabase/functions/tools-hub/index.ts supabase/functions/tools-hub/wbs_list_tasks.ts supabase/functions/tools-hub/wbs_list_tasks_test.ts`: OK
- `deno lint supabase/functions/tools-hub/index.ts supabase/functions/tools-hub/wbs_list_tasks.ts supabase/functions/tools-hub/wbs_list_tasks_test.ts`: OK
- `deno test --allow-env supabase/functions/tools-hub/wbs_list_tasks_test.ts`: 3 passed
- `git diff --check`: OK

Note: local `deno check supabase/functions/tools-hub/index.ts` was not completed because this worktree does not have local `node_modules` for `npm:@supabase/supabase-js@2`. I avoided dependency install to reduce disk pressure and left full Edge Function compile/smoke validation to CI.

## Resource Hygiene

- Work was done in a fresh worktree: `my_web_app-wbs-list-pagination-fix`.
- No root dirty files were touched.
- No dependency install was run because local memory/disk pressure is already elevated.
