### PR TITLE
fix(wbs): preserve realistic reschedule plan (#2528)

### DIFF
--- a/supabase/functions/tools-hub/index.ts
+++ b/supabase/functions/tools-hub/index.ts
@@ -38,6 +38,10 @@ import {
   normalizeWbsListPagination,
   paginateWbsTasks,
 } from "./wbs_list_tasks.ts";
+import {
+  ASSET_MANAGEMENT_PINNED_ISSUE_SCHEDULE,
+  buildWbsReschedulePlan,
+} from "./wbs_reschedule_realistic.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -6671,74 +6675,6 @@ serve(async (req) => {
           // 対象: status != 'completed' AND github_issue_state != 'CLOSED'
           // skip: 上記完了系
           const dryRun = body.dry_run !== false; // default true
-          const offsetIn =
-            (body.priority_offset_days as Record<string, number>) ?? {};
-          const durIn = (body.duration_days as Record<string, number>) ?? {};
-          const parIn = (body.parallel_capacity as Record<string, number>) ??
-            {};
-          const featureRequestOffsetDays = Math.max(
-            0,
-            Number(body.feature_request_offset_days ?? 0),
-          );
-          const featureRequestDurationDays = Math.max(
-            0,
-            Number(body.feature_request_duration_days ?? 0),
-          );
-          const featureRequestParallelCapacity = Math.max(
-            1,
-            Number(body.feature_request_parallel_capacity ?? 1000),
-          );
-          const githubIssueOffsetDays = Math.max(
-            0,
-            Number(body.github_issue_offset_days ?? 0),
-          );
-          const githubIssueDurationDays = Math.max(
-            0,
-            Number(body.github_issue_duration_days ?? 3),
-          );
-          const githubIssueParallelCapacity = Math.max(
-            1,
-            Number(body.github_issue_parallel_capacity ?? 1000),
-          );
-          const offset = {
-            high: Number(offsetIn.high ?? 7),
-            medium: Number(offsetIn.medium ?? 30),
-            low: Number(offsetIn.low ?? 90),
-          };
-          const duration = {
-            high: Number(durIn.high ?? 3),
-            medium: Number(durIn.medium ?? 7),
-            low: Number(durIn.low ?? 14),
-          };
-          const parallel = {
-            high: Math.max(1, Number(parIn.high ?? 4)),
-            medium: Math.max(1, Number(parIn.medium ?? 8)),
-            low: Math.max(1, Number(parIn.low ?? 12)),
-          };
-          const rescheduleParams = {
-            offset,
-            duration,
-            parallel,
-            feature_request: {
-              offset_days: featureRequestOffsetDays,
-              duration_days: featureRequestDurationDays,
-              parallel_capacity: featureRequestParallelCapacity,
-            },
-            github_issue: {
-              offset_days: githubIssueOffsetDays,
-              duration_days: githubIssueDurationDays,
-              parallel_capacity: githubIssueParallelCapacity,
-            },
-          };
-
-          const today = new Date();
-          today.setUTCHours(0, 0, 0, 0);
-          const fmt = (d: Date) => d.toISOString().slice(0, 10);
-          const addDays = (base: Date, days: number) => {
-            const d = new Date(base);
-            d.setUTCDate(d.getUTCDate() + days);
-            return d;
-          };
 
           // 全 open タスクを取得 (完了系 skip / Supabase 1000 row cap 回避にページネーション)
           const selectCols =
@@ -6780,167 +6716,24 @@ serve(async (req) => {
               );
             }
           }
-          const open = all.filter(
-            (r) => String(r.github_issue_state ?? "") !== "CLOSED",
+          const plan = buildWbsReschedulePlan(
+            all,
+            body as Record<string, unknown>,
+            new Date(),
           );
-          const featureRequestTasks = open.filter(isFeatureRequestTask);
-          const githubIssueTasks = open.filter((task) =>
-            !isFeatureRequestTask(task) && isGithubIssueLinkedTask(task)
-          );
-          const regularTasks = open.filter((task) =>
-            !isFeatureRequestTask(task) && !isGithubIssueLinkedTask(task)
-          );
-
-          // priority bucket 別 queue index を category_order, id で安定 sort
-          const buckets: Record<string, Array<Record<string, unknown>>> = {
-            high: [],
-            medium: [],
-            low: [],
-          };
-          for (const r of regularTasks) {
-            const p = String(r.priority ?? "medium").toLowerCase();
-            const tier = p === "high" || p === "urgent"
-              ? "high"
-              : p === "low"
-              ? "low"
-              : "medium";
-            buckets[tier].push(r);
-          }
-          for (const tier of Object.keys(buckets)) {
-            buckets[tier].sort((a, b) => {
-              const oa = Number(a.category_order ?? 999);
-              const ob = Number(b.category_order ?? 999);
-              if (oa !== ob) return oa - ob;
-              return String(a.id).localeCompare(String(b.id));
-            });
-          }
-          featureRequestTasks.sort((a, b) =>
-            wbsPriorityRank(b.priority) - wbsPriorityRank(a.priority) ||
-            Number(a.category_order ?? 999) - Number(b.category_order ?? 999) ||
-            String(a.id).localeCompare(String(b.id))
-          );
-          githubIssueTasks.sort((a, b) =>
-            wbsPriorityRank(b.priority) - wbsPriorityRank(a.priority) ||
-            Number(a.category_order ?? 999) - Number(b.category_order ?? 999) ||
-            String(a.id).localeCompare(String(b.id))
-          );
-          const featureRequestWindowDays = featureRequestTasks.length === 0
-            ? 0
-            : featureRequestOffsetDays +
-              Math.floor(
-                (featureRequestTasks.length - 1) /
-                  featureRequestParallelCapacity,
-              ) +
-              featureRequestDurationDays +
-              1;
-          const githubIssueStartOffsetDays = Math.max(
-            githubIssueOffsetDays,
-            featureRequestWindowDays,
-          );
-          const githubIssueWindowDays = githubIssueTasks.length === 0
-            ? featureRequestWindowDays
-            : githubIssueStartOffsetDays +
-              Math.floor(
-                (githubIssueTasks.length - 1) /
-                  githubIssueParallelCapacity,
-              ) +
-              githubIssueDurationDays +
-              1;
-
-          // queue index に基づき stagger 配置
-          const updates: Array<{
-            id: string;
-            start_date: string;
-            end_date: string;
-            tier:
-              | "feature_request"
-              | "github_issue"
-              | "high"
-              | "medium"
-              | "low";
-            stagger_days: number;
-          }> = [];
-          for (let i = 0; i < featureRequestTasks.length; i++) {
-            const t = featureRequestTasks[i];
-            const stagger = Math.floor(i / featureRequestParallelCapacity);
-            const start = addDays(
-              today,
-              featureRequestOffsetDays + stagger,
-            );
-            const end = addDays(start, featureRequestDurationDays);
-            updates.push({
-              id: String(t.id),
-              start_date: fmt(start),
-              end_date: fmt(end),
-              tier: "feature_request",
-              stagger_days: stagger,
-            });
-          }
-          for (let i = 0; i < githubIssueTasks.length; i++) {
-            const t = githubIssueTasks[i];
-            const stagger = Math.floor(i / githubIssueParallelCapacity);
-            const start = addDays(
-              today,
-              githubIssueStartOffsetDays + stagger,
-            );
-            const end = addDays(start, githubIssueDurationDays);
-            updates.push({
-              id: String(t.id),
-              start_date: fmt(start),
-              end_date: fmt(end),
-              tier: "github_issue",
-              stagger_days: stagger,
-            });
-          }
-          for (const tier of ["high", "medium", "low"] as const) {
-            const tasks = buckets[tier];
-            const offDays = Math.max(offset[tier], githubIssueWindowDays);
-            const durDays = duration[tier];
-            const par = parallel[tier];
-            for (let i = 0; i < tasks.length; i++) {
-              const t = tasks[i];
-              const stagger = Math.floor(i / par); // par 件並列、par 超で 1 日ずらす
-              const start = addDays(today, offDays + stagger);
-              const end = addDays(start, durDays);
-              updates.push({
-                id: String(t.id),
-                start_date: fmt(start),
-                end_date: fmt(end),
-                tier,
-                stagger_days: stagger,
-              });
-            }
-          }
-
-          // by_priority サマリ + sample 構築
-          const byPrio: Record<
-            string,
-            { count: number; first_start: string; last_end: string }
-          > = {};
-          for (const u of updates) {
-            const cur = byPrio[u.tier] ?? {
-              count: 0,
-              first_start: u.start_date,
-              last_end: u.end_date,
-            };
-            cur.count += 1;
-            if (u.start_date < cur.first_start) cur.first_start = u.start_date;
-            if (u.end_date > cur.last_end) cur.last_end = u.end_date;
-            byPrio[u.tier] = cur;
-          }
-          const sample = updates.slice(0, 10);
+          const updates = plan.updates;
 
           if (dryRun) {
             return json({
               success: true,
               dry_run: true,
-              total_open: open.length,
-              total_skipped_completed: all.length - open.length,
+              total_open: plan.totalOpen,
+              total_skipped_completed: plan.totalSkippedCompleted,
               would_update: updates.length,
-              by_priority: byPrio,
-              sample,
-              today: fmt(today),
-              params: rescheduleParams,
+              by_priority: plan.byPriority,
+              sample: plan.sample,
+              today: plan.today,
+              params: plan.params,
             });
           }
 
@@ -6978,12 +6771,12 @@ serve(async (req) => {
               event_type: "wbs.reschedule_realistic",
               severity: errors.length > 0 ? "warning" : "info",
               metadata: {
-                total_open: open.length,
+                total_open: plan.totalOpen,
                 updated,
                 errors: errors.length,
-                by_priority: byPrio,
-                params: rescheduleParams,
-                today: fmt(today),
+                by_priority: plan.byPriority,
+                params: plan.params,
+                today: plan.today,
               },
             });
           } catch (_) {
@@ -6993,14 +6786,14 @@ serve(async (req) => {
           return json({
             success: errors.length === 0,
             dry_run: false,
-            total_open: open.length,
+            total_open: plan.totalOpen,
             updated,
             errors_count: errors.length,
             errors: errors.slice(0, 10),
-            by_priority: byPrio,
-            sample,
-            today: fmt(today),
-            params: rescheduleParams,
+            by_priority: plan.byPriority,
+            sample: plan.sample,
+            today: plan.today,
+            params: plan.params,
           });
         }
         case "wbs.bulk_update": {
@@ -7463,6 +7256,12 @@ serve(async (req) => {
                 ? additionalRequestStartDate(now)
                 : githubIssueStartDate(now);
               const syncedEndDate = githubIssueDueDate(labels, now, issueTitle);
+              const pinnedSchedule =
+                ASSET_MANAGEMENT_PINNED_ISSUE_SCHEDULE[issueNumber];
+              const issueScheduleStartDate = pinnedSchedule?.start_date ??
+                syncedStartDate;
+              const issueScheduleEndDate = pinnedSchedule?.end_date ??
+                syncedEndDate;
               const payload: Record<string, unknown> = {
                 category: githubIssueCategory(labels),
                 category_icon: githubIssueCategoryIcon(labels),
@@ -7475,17 +7274,17 @@ serve(async (req) => {
                 progress: nextProgress,
                 priority: githubIssuePriority(labels),
                 start_date: prioritizeIssueSchedule
-                  ? syncedStartDate
+                  ? issueScheduleStartDate
                   : keeper?.start_date ?? syncedStartDate,
                 end_date: prioritizeIssueSchedule
-                  ? syncedEndDate
+                  ? issueScheduleEndDate
                   : keeper?.end_date ?? syncedEndDate,
                 planned_start_date: prioritizeIssueSchedule
-                  ? syncedStartDate
+                  ? issueScheduleStartDate
                   : keeper?.planned_start_date ?? keeper?.start_date ??
                     syncedStartDate,
                 planned_end_date: prioritizeIssueSchedule
-                  ? syncedEndDate
+                  ? issueScheduleEndDate
                   : keeper?.planned_end_date ?? keeper?.end_date ??
                     syncedEndDate,
                 remaining_work: isClosed

--- a/supabase/functions/tools-hub/wbs_reschedule_realistic.ts
+++ b/supabase/functions/tools-hub/wbs_reschedule_realistic.ts
@@ -1,0 +1,433 @@
+export type WbsRescheduleTier =
+  | "pinned"
+  | "github_issue"
+  | "feature_request"
+  | "high"
+  | "medium"
+  | "low";
+
+export type WbsTaskRecord = Record<string, unknown>;
+
+export interface WbsScheduleUpdate {
+  id: string;
+  start_date: string;
+  end_date: string;
+  tier: WbsRescheduleTier;
+  stagger_days: number;
+  github_issue_number?: number;
+  schedule_source: "pinned" | "computed";
+}
+
+interface QueueConfig {
+  offset_days: number;
+  duration_days: number;
+  parallel_capacity: number;
+}
+
+export interface WbsRescheduleParams {
+  high: QueueConfig;
+  medium: QueueConfig;
+  low: QueueConfig;
+  feature_request: QueueConfig;
+  github_issue: QueueConfig;
+  pinned_issue_numbers: number[];
+}
+
+export interface WbsReschedulePlan {
+  totalOpen: number;
+  totalSkippedCompleted: number;
+  updates: WbsScheduleUpdate[];
+  byPriority: Record<string, {
+    count: number;
+    first_start: string;
+    last_end: string;
+  }>;
+  sample: WbsScheduleUpdate[];
+  today: string;
+  params: WbsRescheduleParams;
+}
+
+interface PinnedIssueSchedule {
+  start_date: string;
+  end_date: string;
+}
+
+const ADDITIONAL_REQUEST_TEXT = "\u8ffd\u52a0\u8981\u671b";
+const USER_REQUEST_CATEGORY_TEXT = "\u30e6\u30fc\u30b6\u30fc\u8981\u671b";
+
+export const ASSET_MANAGEMENT_PINNED_ISSUE_SCHEDULE: Record<
+  number,
+  PinnedIssueSchedule
+> = {
+  2448: { start_date: "2026-05-17", end_date: "2026-05-18" },
+  2449: { start_date: "2026-05-19", end_date: "2026-05-21" },
+  2450: { start_date: "2026-05-22", end_date: "2026-05-23" },
+  2451: { start_date: "2026-05-24", end_date: "2026-05-26" },
+  2452: { start_date: "2026-05-27", end_date: "2026-05-28" },
+  2453: { start_date: "2026-05-29", end_date: "2026-05-30" },
+  2454: { start_date: "2026-05-31", end_date: "2026-06-02" },
+  2455: { start_date: "2026-06-03", end_date: "2026-06-04" },
+  2456: { start_date: "2026-06-05", end_date: "2026-06-05" },
+  2520: { start_date: "2026-06-06", end_date: "2026-06-07" },
+  2521: { start_date: "2026-06-08", end_date: "2026-06-09" },
+  2522: { start_date: "2026-06-10", end_date: "2026-06-11" },
+  2460: { start_date: "2026-06-12", end_date: "2026-06-12" },
+  2461: { start_date: "2026-06-13", end_date: "2026-06-14" },
+  2462: { start_date: "2026-06-15", end_date: "2026-06-15" },
+  2463: { start_date: "2026-06-16", end_date: "2026-06-17" },
+  2464: { start_date: "2026-06-18", end_date: "2026-06-18" },
+  2465: { start_date: "2026-06-19", end_date: "2026-06-19" },
+  2466: { start_date: "2026-06-20", end_date: "2026-06-21" },
+  2467: { start_date: "2026-06-22", end_date: "2026-06-22" },
+  2468: { start_date: "2026-06-23", end_date: "2026-06-24" },
+  2469: { start_date: "2026-06-25", end_date: "2026-06-26" },
+  2470: { start_date: "2026-06-27", end_date: "2026-06-28" },
+  2471: { start_date: "2026-06-29", end_date: "2026-06-29" },
+  2472: { start_date: "2026-06-30", end_date: "2026-07-01" },
+  2473: { start_date: "2026-07-02", end_date: "2026-07-02" },
+  2474: { start_date: "2026-07-03", end_date: "2026-07-03" },
+  2475: { start_date: "2026-07-04", end_date: "2026-07-04" },
+  2476: { start_date: "2026-07-05", end_date: "2026-07-05" },
+  2477: { start_date: "2026-07-06", end_date: "2026-07-07" },
+  2478: { start_date: "2026-07-08", end_date: "2026-07-08" },
+  2479: { start_date: "2026-07-09", end_date: "2026-07-10" },
+  2480: { start_date: "2026-07-11", end_date: "2026-07-11" },
+  2481: { start_date: "2026-07-12", end_date: "2026-07-13" },
+  2482: { start_date: "2026-07-14", end_date: "2026-07-14" },
+  2483: { start_date: "2026-07-15", end_date: "2026-07-15" },
+  2484: { start_date: "2026-07-16", end_date: "2026-07-16" },
+  2485: { start_date: "2026-07-17", end_date: "2026-07-18" },
+  2486: { start_date: "2026-07-19", end_date: "2026-07-20" },
+  2487: { start_date: "2026-07-21", end_date: "2026-07-21" },
+  2488: { start_date: "2026-07-22", end_date: "2026-07-22" },
+  2489: { start_date: "2026-07-23", end_date: "2026-07-23" },
+  2490: { start_date: "2026-07-24", end_date: "2026-07-24" },
+  2491: { start_date: "2026-07-25", end_date: "2026-07-25" },
+  2492: { start_date: "2026-07-26", end_date: "2026-07-27" },
+  2493: { start_date: "2026-07-28", end_date: "2026-07-28" },
+  2496: { start_date: "2026-07-29", end_date: "2026-07-29" },
+  2497: { start_date: "2026-07-30", end_date: "2026-07-31" },
+  2498: { start_date: "2026-08-01", end_date: "2026-08-01" },
+  2499: { start_date: "2026-08-02", end_date: "2026-08-02" },
+  2500: { start_date: "2026-08-03", end_date: "2026-08-03" },
+  2501: { start_date: "2026-08-04", end_date: "2026-08-04" },
+  2502: { start_date: "2026-08-05", end_date: "2026-08-06" },
+  2503: { start_date: "2026-08-07", end_date: "2026-08-07" },
+  2504: { start_date: "2026-08-08", end_date: "2026-08-08" },
+  2505: { start_date: "2026-08-09", end_date: "2026-08-09" },
+  2508: { start_date: "2026-08-10", end_date: "2026-08-11" },
+};
+
+function numberFromBody(
+  body: Record<string, unknown>,
+  key: string,
+  defaultValue: number,
+): number {
+  const value = Number(body[key] ?? defaultValue);
+  return Number.isFinite(value) ? value : defaultValue;
+}
+
+function queueConfig(
+  offsetDays: number,
+  durationDays: number,
+  parallelCapacity: number,
+): QueueConfig {
+  return {
+    offset_days: Math.max(0, offsetDays),
+    duration_days: Math.max(0, durationDays),
+    parallel_capacity: Math.max(1, parallelCapacity),
+  };
+}
+
+function nestedNumber(
+  value: unknown,
+  key: string,
+  defaultValue: number,
+): number {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return defaultValue;
+  }
+  const raw = (value as Record<string, unknown>)[key];
+  const num = Number(raw ?? defaultValue);
+  return Number.isFinite(num) ? num : defaultValue;
+}
+
+export function resolveWbsRescheduleParams(
+  body: Record<string, unknown> = {},
+): WbsRescheduleParams {
+  const offsetIn = body.priority_offset_days;
+  const durIn = body.duration_days;
+  const parIn = body.parallel_capacity;
+  return {
+    high: queueConfig(
+      nestedNumber(offsetIn, "high", 7),
+      nestedNumber(durIn, "high", 3),
+      nestedNumber(parIn, "high", 2),
+    ),
+    medium: queueConfig(
+      nestedNumber(offsetIn, "medium", 30),
+      nestedNumber(durIn, "medium", 7),
+      nestedNumber(parIn, "medium", 2),
+    ),
+    low: queueConfig(
+      nestedNumber(offsetIn, "low", 90),
+      nestedNumber(durIn, "low", 14),
+      nestedNumber(parIn, "low", 2),
+    ),
+    feature_request: queueConfig(
+      numberFromBody(body, "feature_request_offset_days", 30),
+      numberFromBody(body, "feature_request_duration_days", 1),
+      numberFromBody(body, "feature_request_parallel_capacity", 2),
+    ),
+    github_issue: queueConfig(
+      numberFromBody(body, "github_issue_offset_days", 0),
+      numberFromBody(body, "github_issue_duration_days", 2),
+      numberFromBody(body, "github_issue_parallel_capacity", 2),
+    ),
+    pinned_issue_numbers: Object.keys(ASSET_MANAGEMENT_PINNED_ISSUE_SCHEDULE)
+      .map((issue) => Number(issue))
+      .sort((a, b) => a - b),
+  };
+}
+
+function dateOnlyUtc(date: Date): Date {
+  const copy = new Date(date);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
+}
+
+function formatIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function addDays(base: Date, days: number): Date {
+  const d = new Date(base);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d;
+}
+
+function daysBetween(base: Date, dateText: string): number {
+  const target = new Date(`${dateText}T00:00:00.000Z`);
+  return Math.floor((target.getTime() - base.getTime()) / 86400000);
+}
+
+function githubIssueNumberFromTask(task: WbsTaskRecord): number | null {
+  const raw = task.github_issue_number;
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return Math.trunc(raw);
+  }
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return Math.trunc(parsed);
+  return null;
+}
+
+function hasAdditionalRequestText(value: unknown): boolean {
+  return String(value ?? "").includes(ADDITIONAL_REQUEST_TEXT);
+}
+
+function isFeatureRequestTask(task: WbsTaskRecord): boolean {
+  const category = String(task.category ?? "");
+  const title = String(task.title ?? "");
+  return category === USER_REQUEST_CATEGORY_TEXT ||
+    hasAdditionalRequestText(category) ||
+    hasAdditionalRequestText(title);
+}
+
+function isGithubIssueLinkedTask(task: WbsTaskRecord): boolean {
+  return githubIssueNumberFromTask(task) !== null ||
+    String(task.github_issue_state ?? "").trim() !== "";
+}
+
+function isOpenTask(task: WbsTaskRecord): boolean {
+  return String(task.status ?? "") !== "completed" &&
+    String(task.github_issue_state ?? "").toUpperCase() !== "CLOSED";
+}
+
+function wbsPriorityRank(priority: unknown): number {
+  const value = String(priority ?? "").toLowerCase();
+  if (value === "urgent") return 4;
+  if (value === "high") return 3;
+  if (value === "medium") return 2;
+  if (value === "low") return 1;
+  return 0;
+}
+
+function sortTasks(a: WbsTaskRecord, b: WbsTaskRecord): number {
+  return wbsPriorityRank(b.priority) - wbsPriorityRank(a.priority) ||
+    Number(a.category_order ?? 999) - Number(b.category_order ?? 999) ||
+    String(a.id).localeCompare(String(b.id));
+}
+
+function scheduleQueue(
+  updates: WbsScheduleUpdate[],
+  tasks: WbsTaskRecord[],
+  tier: WbsRescheduleTier,
+  config: QueueConfig,
+  today: Date,
+  earliestOffsetDays: number,
+): number {
+  const startOffset = Math.max(config.offset_days, earliestOffsetDays);
+  const sorted = [...tasks].sort(sortTasks);
+  for (let i = 0; i < sorted.length; i++) {
+    const task = sorted[i];
+    const stagger = Math.floor(i / config.parallel_capacity);
+    const start = addDays(today, startOffset + stagger);
+    const end = addDays(start, config.duration_days);
+    const issueNumber = githubIssueNumberFromTask(task);
+    updates.push({
+      id: String(task.id),
+      start_date: formatIsoDate(start),
+      end_date: formatIsoDate(end),
+      tier,
+      stagger_days: stagger,
+      github_issue_number: issueNumber ?? undefined,
+      schedule_source: "computed",
+    });
+  }
+  if (sorted.length === 0) return earliestOffsetDays;
+  return startOffset +
+    Math.floor((sorted.length - 1) / config.parallel_capacity) +
+    config.duration_days +
+    1;
+}
+
+function buildSummary(
+  updates: WbsScheduleUpdate[],
+): Record<string, { count: number; first_start: string; last_end: string }> {
+  const summary: Record<string, {
+    count: number;
+    first_start: string;
+    last_end: string;
+  }> = {};
+  for (const update of updates) {
+    const current = summary[update.tier] ?? {
+      count: 0,
+      first_start: update.start_date,
+      last_end: update.end_date,
+    };
+    current.count += 1;
+    if (update.start_date < current.first_start) {
+      current.first_start = update.start_date;
+    }
+    if (update.end_date > current.last_end) current.last_end = update.end_date;
+    summary[update.tier] = current;
+  }
+  return summary;
+}
+
+export function buildWbsReschedulePlan(
+  tasks: WbsTaskRecord[],
+  body: Record<string, unknown> = {},
+  now = new Date(),
+): WbsReschedulePlan {
+  const today = dateOnlyUtc(now);
+  const params = resolveWbsRescheduleParams(body);
+  const open = tasks.filter(isOpenTask);
+  const updates: WbsScheduleUpdate[] = [];
+  const scheduledIds = new Set<string>();
+  let pinnedEndOffsetExclusive = 0;
+
+  for (const task of open) {
+    const issueNumber = githubIssueNumberFromTask(task);
+    if (!issueNumber) continue;
+    const pinned = ASSET_MANAGEMENT_PINNED_ISSUE_SCHEDULE[issueNumber];
+    if (!pinned) continue;
+    const id = String(task.id);
+    scheduledIds.add(id);
+    updates.push({
+      id,
+      start_date: pinned.start_date,
+      end_date: pinned.end_date,
+      tier: "pinned",
+      stagger_days: 0,
+      github_issue_number: issueNumber,
+      schedule_source: "pinned",
+    });
+    pinnedEndOffsetExclusive = Math.max(
+      pinnedEndOffsetExclusive,
+      daysBetween(today, pinned.end_date) + 1,
+    );
+  }
+
+  const remaining = open.filter((task) => !scheduledIds.has(String(task.id)));
+  const githubIssueTasks = remaining.filter(isGithubIssueLinkedTask);
+  const featureRequestTasks = remaining.filter((task) =>
+    !isGithubIssueLinkedTask(task) && isFeatureRequestTask(task)
+  );
+  const regularTasks = remaining.filter((task) =>
+    !isGithubIssueLinkedTask(task) && !isFeatureRequestTask(task)
+  );
+  const regularBuckets: Record<"high" | "medium" | "low", WbsTaskRecord[]> = {
+    high: [],
+    medium: [],
+    low: [],
+  };
+  for (const task of regularTasks) {
+    const priority = String(task.priority ?? "medium").toLowerCase();
+    const tier = priority === "high" || priority === "urgent"
+      ? "high"
+      : priority === "low"
+      ? "low"
+      : "medium";
+    regularBuckets[tier].push(task);
+  }
+
+  const afterPinned = Math.max(0, pinnedEndOffsetExclusive);
+  const afterGithubIssues = scheduleQueue(
+    updates,
+    githubIssueTasks,
+    "github_issue",
+    params.github_issue,
+    today,
+    afterPinned,
+  );
+  const afterHigh = scheduleQueue(
+    updates,
+    regularBuckets.high,
+    "high",
+    params.high,
+    today,
+    afterPinned,
+  );
+  const afterMedium = scheduleQueue(
+    updates,
+    regularBuckets.medium,
+    "medium",
+    params.medium,
+    today,
+    Math.max(afterPinned, afterHigh),
+  );
+  scheduleQueue(
+    updates,
+    featureRequestTasks,
+    "feature_request",
+    params.feature_request,
+    today,
+    Math.max(afterPinned, afterGithubIssues, afterMedium),
+  );
+  scheduleQueue(
+    updates,
+    regularBuckets.low,
+    "low",
+    params.low,
+    today,
+    afterPinned,
+  );
+
+  const orderedUpdates = updates.sort((a, b) =>
+    a.start_date.localeCompare(b.start_date) ||
+    a.end_date.localeCompare(b.end_date) ||
+    a.tier.localeCompare(b.tier) ||
+    a.id.localeCompare(b.id)
+  );
+
+  return {
+    totalOpen: open.length,
+    totalSkippedCompleted: tasks.length - open.length,
+    updates: orderedUpdates,
+    byPriority: buildSummary(orderedUpdates),
+    sample: orderedUpdates.slice(0, 10),
+    today: formatIsoDate(today),
+    params,
+  };
+}

--- a/supabase/functions/tools-hub/wbs_reschedule_realistic_test.ts
+++ b/supabase/functions/tools-hub/wbs_reschedule_realistic_test.ts
@@ -1,0 +1,134 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { buildWbsReschedulePlan } from "./wbs_reschedule_realistic.ts";
+
+const today = new Date("2026-05-16T00:00:00.000Z");
+
+function task(
+  id: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id,
+    category: "Backlog",
+    title: `Task ${id}`,
+    status: "pending",
+    priority: "medium",
+    category_order: 10,
+    ...overrides,
+  };
+}
+
+Deno.test("keeps pinned asset-management issue schedule after issue sync", () => {
+  const plan = buildWbsReschedulePlan(
+    [
+      task("asset-2448", {
+        title:
+          "[Issue #2448] [\u8ffd\u52a0\u8981\u671b] Supabase sync conflict UI",
+        github_issue_number: 2448,
+        github_issue_state: "OPEN",
+        priority: "high",
+      }),
+    ],
+    {},
+    today,
+  );
+
+  assertEquals(plan.updates.length, 1);
+  assertEquals(plan.updates[0].tier, "pinned");
+  assertEquals(plan.updates[0].schedule_source, "pinned");
+  assertEquals(plan.updates[0].start_date, "2026-05-17");
+  assertEquals(plan.updates[0].end_date, "2026-05-18");
+});
+
+Deno.test("does not place a large feature-request queue on one day", () => {
+  const tasks = Array.from(
+    { length: 5 },
+    (_, index) =>
+      task(`feature-${index}`, {
+        category: "\u30e6\u30fc\u30b6\u30fc\u8981\u671b",
+        title: `\u8ffd\u52a0\u8981\u671b ${index}`,
+      }),
+  );
+  const plan = buildWbsReschedulePlan(tasks, {
+    feature_request_offset_days: 0,
+    feature_request_duration_days: 0,
+    feature_request_parallel_capacity: 2,
+  }, today);
+
+  const startCounts = new Map<string, number>();
+  for (const update of plan.updates) {
+    startCounts.set(
+      update.start_date,
+      (startCounts.get(update.start_date) ?? 0) + 1,
+    );
+  }
+
+  assertEquals(plan.byPriority.feature_request.count, 5);
+  assert(startCounts.size > 1);
+  assert([...startCounts.values()].every((count) => count <= 2));
+});
+
+Deno.test("schedules unpinned backlog after the pinned roadmap window", () => {
+  const plan = buildWbsReschedulePlan([
+    task("asset-2508", {
+      title: "[Issue #2508] Memory/disk hygiene KPI dashboard",
+      github_issue_number: 2508,
+      github_issue_state: "OPEN",
+    }),
+    task("feature-after-pinned", {
+      category: "\u30e6\u30fc\u30b6\u30fc\u8981\u671b",
+      title: "\u8ffd\u52a0\u8981\u671b later feature",
+    }),
+  ], {
+    feature_request_offset_days: 0,
+    feature_request_duration_days: 0,
+    feature_request_parallel_capacity: 2,
+  }, today);
+
+  const feature = plan.updates.find((update) =>
+    update.id === "feature-after-pinned"
+  );
+  assert(feature);
+  assertEquals(feature.start_date, "2026-08-12");
+});
+
+Deno.test("spreads unpinned GitHub issues with realistic default capacity", () => {
+  const tasks = Array.from({ length: 5 }, (_, index) =>
+    task(`issue-${index}`, {
+      title: `[Issue #30${index}] ordinary issue`,
+      github_issue_number: 300 + index,
+      github_issue_state: "OPEN",
+    }));
+  const plan = buildWbsReschedulePlan(tasks, {}, today);
+
+  const githubUpdates = plan.updates.filter((update) =>
+    update.tier === "github_issue"
+  );
+  assertEquals(githubUpdates.length, 5);
+  assertEquals(githubUpdates[0].start_date, "2026-05-16");
+  assertEquals(githubUpdates[2].start_date, "2026-05-17");
+  assertEquals(plan.params.github_issue.parallel_capacity, 2);
+});
+
+Deno.test("issue-backed feature requests use the GitHub issue lane", () => {
+  const plan = buildWbsReschedulePlan(
+    [
+      task("issue-feature-2528", {
+        title:
+          "[Issue #2528] [\u8ffd\u52a0\u8981\u671b] Keep WBS schedule realistic after issue sync",
+        github_issue_number: 2528,
+        github_issue_state: "OPEN",
+        category: "\u30e6\u30fc\u30b6\u30fc\u8981\u671b",
+      }),
+    ],
+    {},
+    today,
+  );
+
+  assertEquals(plan.updates.length, 1);
+  assertEquals(plan.updates[0].tier, "github_issue");
+  assertEquals(plan.byPriority.feature_request, undefined);
+});


### PR DESCRIPTION
## Summary
- Extract `wbs.reschedule_realistic` planning into a tested helper.
- Reapply the pinned asset-management WBS roadmap (#2448-#2508, #2520-#2522) instead of collapsing feature requests onto the current day.
- Preserve pinned schedule dates during GitHub Issue sync for those roadmap issues.

## Verification
- `deno fmt --check supabase\functions\tools-hub\wbs_reschedule_realistic.ts supabase\functions\tools-hub\wbs_reschedule_realistic_test.ts supabase\functions\tools-hub\index.ts`
- `deno test --allow-env --allow-net supabase\functions\tools-hub\wbs_reschedule_realistic_test.ts supabase\functions\tools-hub\wbs_list_tasks_test.ts`
- `deno check supabase\functions\tools-hub\wbs_reschedule_realistic.ts supabase\functions\tools-hub\wbs_reschedule_realistic_test.ts`

## High-Risk Review Gate
- Claude Code #1 review owner: Claude Code #1.
- High-risk-ultrareview-exception: no production apply, secret, auth, RLS, schema, or data migration change is included in this PR; it only changes deterministic WBS scheduling code and tests. The live WBS apply remains gated by a post-deploy dry-run before any apply run.
- Security: no credential or service-role behavior changes.
- Rollback: revert this PR to restore the prior `wbs.reschedule_realistic` planner.
- Data migration: none in this PR.
- Prod smoke: post-merge Deploy to Production plus WBS Auto Reschedule dry-run before apply.
- Observability: existing `monitoring_events` write and workflow artifact summary remain in place.
- Unresolved ultrareview findings: none.

## Minimal E2E Gate
- The verification plan is implementation-detail independent / black-box: inspect `wbs.reschedule_realistic` input-output scheduling behavior rather than helper internals.
- Minimal 3 cases: pinned roadmap issue remains pinned, a feature-request queue spreads across days, unpinned GitHub issues use realistic capacity.
- E2E mechanism considered: Playwright / test/e2e is not a good fit because this is a Supabase Edge scheduling action with no browser UI surface.
- E2E-Exception: no browser or user-facing route changes; behavior is covered by deterministic Deno unit tests, DB + Edge smoke, and post-deploy WBS Auto Reschedule dry-run.

## Notes
- Full `deno check supabase/functions/tools-hub/index.ts` is blocked locally by the existing missing `npm:@supabase/supabase-js@2` node_modules setup; PR CI validates the deployed function environment.
- Refs #2528. After merge/deploy, run WBS Auto Reschedule dry-run first and record the result before any apply run.