### PR TITLE
Add asset liability sync conflict resolution UI

### DIFF
--- a/lib/models/asset_liability_sync_audit_log.dart
+++ b/lib/models/asset_liability_sync_audit_log.dart
@@ -4,6 +4,7 @@ enum AssetLiabilitySyncAuditType {
   uploadCandidate('upload_candidate'),
   downloadCandidate('download_candidate'),
   conflictDetected('conflict_detected'),
+  conflictResolved('conflict_resolved'),
   failed('failed'),
   success('success');
 

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -124,6 +124,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   bool _isSavingAssetLiabilitySnapshot = false;
   bool _isRunningAssetLiabilitySync = false;
   bool _isPreviewingAssetLiabilitySync = false;
+  bool _isResolvingAssetLiabilityConflict = false;
   AssetLiabilityManualSyncStatus _assetLiabilitySyncStatus =
       AssetLiabilityManualSyncStatus.notRun;
   DateTime? _lastAssetLiabilitySyncAt;
@@ -1002,6 +1003,115 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (mounted) {
         setState(() {
           _isPreviewingAssetLiabilitySync = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _refreshAssetLiabilitySyncPreviewSilently() async {
+    if (!_assetLiabilityRepository.supabaseSyncEnabled) {
+      return;
+    }
+    try {
+      final result = await _assetLiabilityRepository.previewSyncMonth(_now);
+      if (!mounted) return;
+      setState(() {
+        _assetLiabilitySyncPreview = result;
+        _assetLiabilitySyncConflicts = List<String>.from(
+          result.conflictTargets,
+        );
+      });
+      await _refreshAssetLiabilitySyncAuditLogs();
+    } catch (e) {
+      debugPrint('Error refreshing asset liability sync preview: $e');
+      await _refreshAssetLiabilitySyncAuditLogs();
+    }
+  }
+
+  Future<void> _resolveAssetLiabilitySyncConflict({
+    required AssetLiabilitySyncPreviewItem item,
+    required AssetLiabilityConflictResolutionChoice choice,
+  }) async {
+    if (!_assetLiabilityRepository.supabaseSyncEnabled) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Supabase同期は無効です')));
+      return;
+    }
+
+    if (choice == AssetLiabilityConflictResolutionChoice.supabaseWins) {
+      final confirmed = await showDialog<bool>(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: const Text('Supabase側の値で上書きしますか？'),
+              content: Text(
+                '${item.targetName} のローカル保存をSupabase側の値で置き換えます。'
+                'この操作は明示確認後のみ実行します。',
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text('キャンセル'),
+                ),
+                FilledButton(
+                  onPressed: () => Navigator.of(context).pop(true),
+                  child: const Text('Supabase優先で解決'),
+                ),
+              ],
+            ),
+          ) ??
+          false;
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    setState(() {
+      _isResolvingAssetLiabilityConflict = true;
+    });
+    try {
+      final result = await _assetLiabilityRepository.resolveSyncConflicts(
+        month: _now,
+        resolutions: <AssetLiabilityConflictResolution>[
+          AssetLiabilityConflictResolution(target: item.target, choice: choice),
+        ],
+      );
+      if (!mounted) return;
+      setState(() {
+        _assetLiabilitySyncStatus = result.isSuccess
+            ? (result.resolvedTargets.isEmpty &&
+                    result.skippedTargets.isNotEmpty
+                ? AssetLiabilityManualSyncStatus.conflict
+                : AssetLiabilityManualSyncStatus.success)
+            : AssetLiabilityManualSyncStatus.failure;
+        _lastAssetLiabilitySyncAt = result.completedAt;
+        _assetLiabilitySyncMessage = result.message;
+      });
+      if (result.isSuccess) {
+        await _loadAssetLiabilityMonthlyState();
+      }
+      await _refreshAssetLiabilitySyncPreviewSilently();
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(result.message)));
+    } catch (e) {
+      debugPrint('Error resolving asset liability sync conflict: $e');
+      if (!mounted) return;
+      setState(() {
+        _assetLiabilitySyncStatus = AssetLiabilityManualSyncStatus.failure;
+        _lastAssetLiabilitySyncAt = DateTime.now();
+        _assetLiabilitySyncMessage = '競合解決に失敗しました: $e';
+      });
+      await _refreshAssetLiabilitySyncAuditLogs();
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('競合解決に失敗しました: $e')));
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isResolvingAssetLiabilityConflict = false;
         });
       }
     }
@@ -6794,6 +6904,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           if (_assetLiabilitySyncPreview != null) ...[
             const SizedBox(height: 8),
             _buildAssetLiabilitySyncPreviewDetails(_assetLiabilitySyncPreview!),
+            if (_assetLiabilitySyncPreview!.hasConflict) ...[
+              const SizedBox(height: 8),
+              _buildAssetLiabilityConflictResolutionSection(
+                _assetLiabilitySyncPreview!,
+              ),
+            ],
           ],
           const SizedBox(height: 8),
           _buildAssetLiabilitySyncAuditLogSection(syncEnabled),
@@ -6963,6 +7079,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         return 'download';
       case AssetLiabilitySyncAuditType.conflictDetected:
         return 'conflict';
+      case AssetLiabilitySyncAuditType.conflictResolved:
+        return 'resolved';
       case AssetLiabilitySyncAuditType.failed:
         return 'failed';
       case AssetLiabilitySyncAuditType.success:
@@ -6976,6 +7094,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     if (log.isConflict) {
       return const Color(0xFFD97706);
+    }
+    if (log.type == AssetLiabilitySyncAuditType.conflictResolved) {
+      return const Color(0xFF0D9488);
     }
     if (log.type == AssetLiabilitySyncAuditType.success) {
       return const Color(0xFF0D9488);
@@ -7102,6 +7223,152 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ],
             ),
           ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetLiabilityConflictResolutionSection(
+    AssetLiabilitySyncPreviewResult preview,
+  ) {
+    final conflictItems =
+        preview.items.where((item) => item.conflict).toList(growable: false);
+    if (conflictItems.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFF59E0B).withValues(alpha: 0.35),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.rule_folder_outlined,
+                size: 16,
+                color: Color(0xFFD97706),
+              ),
+              const SizedBox(width: 6),
+              const Expanded(
+                child: Text(
+                  '同期競合の解決',
+                  style: TextStyle(fontWeight: FontWeight.w700, height: 1.4),
+                ),
+              ),
+              if (_isResolvingAssetLiabilityConflict)
+                const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'ローカルとSupabaseの両方にデータがある項目は自動上書きしません。'
+            'どちらを優先するか明示的に選んだ項目だけRepository経由で反映します。',
+            style: TextStyle(fontSize: 12, height: 1.5),
+          ),
+          const SizedBox(height: 8),
+          for (final item in conflictItems) ...[
+            _buildAssetLiabilityConflictResolutionTile(item),
+            if (item != conflictItems.last) const SizedBox(height: 8),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetLiabilityConflictResolutionTile(
+    AssetLiabilitySyncPreviewItem item,
+  ) {
+    final disabled = _isResolvingAssetLiabilityConflict ||
+        _isRunningAssetLiabilitySync ||
+        _isPreviewingAssetLiabilitySync;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFF59E0B).withValues(alpha: 0.28),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              _buildAssetLiabilitySyncChip(
+                label: '対象',
+                value: item.targetName,
+                color: const Color(0xFFD97706),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: 'ローカル',
+                value: '${item.localCount}件',
+                color: const Color(0xFF475569),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: 'Supabase',
+                value: '${item.remoteCount}件',
+                color: const Color(0xFF475569),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              OutlinedButton.icon(
+                onPressed: disabled
+                    ? null
+                    : () => _resolveAssetLiabilitySyncConflict(
+                          item: item,
+                          choice:
+                              AssetLiabilityConflictResolutionChoice.localWins,
+                        ),
+                icon: const Icon(Icons.upload_file_outlined),
+                label: const Text('ローカル優先'),
+              ),
+              OutlinedButton.icon(
+                onPressed: disabled
+                    ? null
+                    : () => _resolveAssetLiabilitySyncConflict(
+                          item: item,
+                          choice: AssetLiabilityConflictResolutionChoice
+                              .supabaseWins,
+                        ),
+                icon: const Icon(Icons.cloud_download_outlined),
+                label: const Text('Supabase優先'),
+              ),
+              TextButton.icon(
+                onPressed: disabled
+                    ? null
+                    : () => _resolveAssetLiabilitySyncConflict(
+                          item: item,
+                          choice: AssetLiabilityConflictResolutionChoice.skip,
+                        ),
+                icon: const Icon(Icons.block_outlined),
+                label: const Text('今回はスキップ'),
+              ),
+            ],
+          ),
         ],
       ),
     );

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -19,6 +19,111 @@ enum AssetLiabilityManualSyncStatus {
   conflict,
 }
 
+enum AssetLiabilitySyncTarget {
+  monthlyState('monthly_state', '月次状態'),
+  paymentSourceSettings('payment_source_settings', '支払原資口座設定'),
+  cardBillingDefaults('card_billing_defaults', 'カード請求デフォルト'),
+  recurringIncomeTemplates('recurring_income_templates', '定期収入テンプレート'),
+  monthlySnapshots('monthly_snapshots', '月次スナップショット');
+
+  final String storageKey;
+  final String label;
+
+  const AssetLiabilitySyncTarget(this.storageKey, this.label);
+
+  static AssetLiabilitySyncTarget? fromStorageKey(String value) {
+    final normalized = value.trim();
+    for (final target in values) {
+      if (target.storageKey == normalized) {
+        return target;
+      }
+    }
+    return null;
+  }
+}
+
+enum AssetLiabilityConflictResolutionChoice {
+  localWins('local_wins', 'ローカル優先'),
+  supabaseWins('supabase_wins', 'Supabase優先'),
+  skip('skip', 'スキップ');
+
+  final String storageKey;
+  final String label;
+
+  const AssetLiabilityConflictResolutionChoice(this.storageKey, this.label);
+}
+
+enum AssetLiabilityConflictResolutionStatus { disabled, success, failure }
+
+class AssetLiabilityConflictResolution {
+  final AssetLiabilitySyncTarget target;
+  final AssetLiabilityConflictResolutionChoice choice;
+
+  const AssetLiabilityConflictResolution({
+    required this.target,
+    required this.choice,
+  });
+}
+
+class AssetLiabilityConflictResolutionResult {
+  final AssetLiabilityConflictResolutionStatus status;
+  final DateTime completedAt;
+  final String message;
+  final List<AssetLiabilitySyncTarget> resolvedTargets;
+  final List<AssetLiabilitySyncTarget> skippedTargets;
+
+  const AssetLiabilityConflictResolutionResult({
+    required this.status,
+    required this.completedAt,
+    required this.message,
+    this.resolvedTargets = const <AssetLiabilitySyncTarget>[],
+    this.skippedTargets = const <AssetLiabilitySyncTarget>[],
+  });
+
+  factory AssetLiabilityConflictResolutionResult.disabled({
+    DateTime? completedAt,
+  }) {
+    return AssetLiabilityConflictResolutionResult(
+      status: AssetLiabilityConflictResolutionStatus.disabled,
+      completedAt: completedAt ?? DateTime.now(),
+      message: 'Supabase同期は無効です',
+    );
+  }
+
+  factory AssetLiabilityConflictResolutionResult.success({
+    required String message,
+    required List<AssetLiabilitySyncTarget> resolvedTargets,
+    required List<AssetLiabilitySyncTarget> skippedTargets,
+    DateTime? completedAt,
+  }) {
+    return AssetLiabilityConflictResolutionResult(
+      status: AssetLiabilityConflictResolutionStatus.success,
+      completedAt: completedAt ?? DateTime.now(),
+      message: message,
+      resolvedTargets: List<AssetLiabilitySyncTarget>.unmodifiable(
+        resolvedTargets,
+      ),
+      skippedTargets: List<AssetLiabilitySyncTarget>.unmodifiable(
+        skippedTargets,
+      ),
+    );
+  }
+
+  factory AssetLiabilityConflictResolutionResult.failure({
+    required String message,
+    DateTime? completedAt,
+  }) {
+    return AssetLiabilityConflictResolutionResult(
+      status: AssetLiabilityConflictResolutionStatus.failure,
+      completedAt: completedAt ?? DateTime.now(),
+      message: message,
+    );
+  }
+
+  bool get isSuccess =>
+      status == AssetLiabilityConflictResolutionStatus.success;
+}
+
 class AssetLiabilityManualSyncResult {
   final AssetLiabilityManualSyncStatus status;
   final DateTime completedAt;
@@ -80,23 +185,27 @@ class AssetLiabilityManualSyncResult {
 }
 
 class AssetLiabilitySyncPreviewItem {
-  final String targetName;
+  final AssetLiabilitySyncTarget target;
   final bool localHasData;
   final bool remoteHasData;
   final int localCount;
   final int remoteCount;
+  final bool dataMatches;
 
   const AssetLiabilitySyncPreviewItem({
-    required this.targetName,
+    required this.target,
     required this.localHasData,
     required this.remoteHasData,
     required this.localCount,
     required this.remoteCount,
+    this.dataMatches = false,
   });
 
+  String get targetName => target.label;
+  String get targetDataType => target.storageKey;
   bool get uploadCandidate => localHasData && !remoteHasData;
   bool get downloadCandidate => !localHasData && remoteHasData;
-  bool get conflict => localHasData && remoteHasData;
+  bool get conflict => localHasData && remoteHasData && !dataMatches;
 }
 
 class AssetLiabilitySyncPreviewResult {
@@ -165,6 +274,11 @@ class AssetLiabilitySyncPreviewResult {
         for (final item in items)
           if (item.conflict) item.targetName,
       ];
+  List<AssetLiabilitySyncTarget> get conflictTargetTypes =>
+      <AssetLiabilitySyncTarget>[
+        for (final item in items)
+          if (item.conflict) item.target,
+      ];
 }
 
 abstract class AssetLiabilityRepository {
@@ -218,6 +332,13 @@ abstract class AssetLiabilityRepository {
     DateTime month,
   ) async {
     return AssetLiabilitySyncPreviewResult.disabled();
+  }
+
+  Future<AssetLiabilityConflictResolutionResult> resolveSyncConflicts({
+    required DateTime month,
+    required List<AssetLiabilityConflictResolution> resolutions,
+  }) async {
+    return AssetLiabilityConflictResolutionResult.disabled();
   }
 
   Future<AssetLiabilityPersistenceSnapshot> loadPersistenceSnapshot(
@@ -633,7 +754,9 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
         await _recordAuditLog(
           month: month,
           type: AssetLiabilitySyncAuditType.conflictDetected,
-          targetDataType: preview.conflictTargets.join(','),
+          targetDataType: preview.conflictTargetTypes
+              .map((target) => target.storageKey)
+              .join(','),
           count: preview.conflictCount,
           result: 'conflict_non_destructive_stop',
           errorMessage: 'Both local and Supabase data exist; no overwrite.',
@@ -804,6 +927,233 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
     }
   }
 
+  @override
+  Future<AssetLiabilityConflictResolutionResult> resolveSyncConflicts({
+    required DateTime month,
+    required List<AssetLiabilityConflictResolution> resolutions,
+  }) async {
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null) {
+      return AssetLiabilityConflictResolutionResult.disabled();
+    }
+    if (userId == null) {
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.failed,
+        targetDataType: 'conflict_resolution',
+        count: 0,
+        result: 'missing_supabase_user',
+        errorMessage: 'Supabase user is not available.',
+      );
+      return AssetLiabilityConflictResolutionResult.failure(
+        message: 'Supabaseユーザーが確認できません',
+      );
+    }
+    if (resolutions.isEmpty) {
+      return AssetLiabilityConflictResolutionResult.success(
+        message: '競合解決の対象がありません',
+        resolvedTargets: const <AssetLiabilitySyncTarget>[],
+        skippedTargets: const <AssetLiabilitySyncTarget>[],
+      );
+    }
+
+    try {
+      final syncData = await _loadSyncData(
+        month: month,
+        remote: remote,
+        userId: userId,
+      );
+      final preview = _buildSyncPreview(syncData);
+      final conflictTargets = preview.conflictTargetTypes.toSet();
+      final resolved = <AssetLiabilitySyncTarget>[];
+      final skipped = <AssetLiabilitySyncTarget>[];
+      var affectedCount = 0;
+
+      for (final resolution in resolutions) {
+        if (!conflictTargets.contains(resolution.target)) {
+          skipped.add(resolution.target);
+          continue;
+        }
+        switch (resolution.choice) {
+          case AssetLiabilityConflictResolutionChoice.localWins:
+            final count = await _uploadLocalTarget(
+              target: resolution.target,
+              data: syncData,
+              remote: remote,
+              userId: userId,
+              month: month,
+            );
+            affectedCount += count;
+            if (count > 0) {
+              resolved.add(resolution.target);
+            } else {
+              skipped.add(resolution.target);
+            }
+          case AssetLiabilityConflictResolutionChoice.supabaseWins:
+            final count = await _restoreRemoteTarget(
+              target: resolution.target,
+              data: syncData,
+              month: month,
+            );
+            affectedCount += count;
+            if (count > 0) {
+              resolved.add(resolution.target);
+            } else {
+              skipped.add(resolution.target);
+            }
+          case AssetLiabilityConflictResolutionChoice.skip:
+            skipped.add(resolution.target);
+        }
+      }
+
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.conflictResolved,
+        targetDataType: resolutions
+            .map(
+              (resolution) =>
+                  '${resolution.target.storageKey}:${resolution.choice.storageKey}',
+            )
+            .join(','),
+        count: affectedCount,
+        result: resolved.isEmpty ? 'skipped' : 'resolved_explicitly',
+      );
+
+      final resolvedLabel = resolved.map((target) => target.label).join('、');
+      final skippedLabel = skipped.map((target) => target.label).join('、');
+      final message = resolved.isNotEmpty
+          ? '競合を解決しました: $resolvedLabel'
+          : skipped.isNotEmpty
+              ? '競合解決をスキップしました: $skippedLabel'
+              : '競合解決の対象がありません';
+
+      return AssetLiabilityConflictResolutionResult.success(
+        message: message,
+        resolvedTargets: resolved,
+        skippedTargets: skipped,
+      );
+    } catch (error, stackTrace) {
+      if (onSyncError != null) {
+        onSyncError!(error, stackTrace);
+      } else {
+        debugPrint('Asset liability conflict resolution failed: $error');
+      }
+      await _recordAuditLog(
+        month: month,
+        type: AssetLiabilitySyncAuditType.failed,
+        targetDataType: 'conflict_resolution',
+        count: 0,
+        result: 'failed',
+        errorMessage: error.toString(),
+      );
+      return AssetLiabilityConflictResolutionResult.failure(
+        message: '競合解決に失敗しました: $error',
+      );
+    }
+  }
+
+  Future<int> _uploadLocalTarget({
+    required AssetLiabilitySyncTarget target,
+    required _AssetLiabilitySyncData data,
+    required AssetLiabilityRemoteStore remote,
+    required String userId,
+    required DateTime month,
+  }) async {
+    switch (target) {
+      case AssetLiabilitySyncTarget.monthlyState:
+        if (data.localMonth.isEmpty) {
+          return 0;
+        }
+        await remote.saveMonth(
+          userId: userId,
+          month: month,
+          state: data.localMonth,
+        );
+        return 1;
+      case AssetLiabilitySyncTarget.paymentSourceSettings:
+        if (data.localSources.isEmpty) {
+          return 0;
+        }
+        await remote.saveDefaultPaymentSources(
+          userId: userId,
+          sources: data.localSources,
+        );
+        return data.localSources.length;
+      case AssetLiabilitySyncTarget.cardBillingDefaults:
+        if (data.localDefaultCardBillingAccounts.isEmpty) {
+          return 0;
+        }
+        await remote.saveDefaultCardBillingAccounts(
+          userId: userId,
+          accounts: data.localDefaultCardBillingAccounts,
+        );
+        return data.localDefaultCardBillingAccounts.length;
+      case AssetLiabilitySyncTarget.recurringIncomeTemplates:
+        if (data.localTemplates.isEmpty) {
+          return 0;
+        }
+        await remote.saveRecurringIncomeTemplates(
+          userId: userId,
+          templates: data.localTemplates,
+        );
+        return data.localTemplates.length;
+      case AssetLiabilitySyncTarget.monthlySnapshots:
+        if (data.localSnapshots.isEmpty) {
+          return 0;
+        }
+        for (final snapshot in data.localSnapshots) {
+          await remote.saveMonthlySnapshot(userId: userId, snapshot: snapshot);
+        }
+        return data.localSnapshots.length;
+    }
+  }
+
+  Future<int> _restoreRemoteTarget({
+    required AssetLiabilitySyncTarget target,
+    required _AssetLiabilitySyncData data,
+    required DateTime month,
+  }) async {
+    switch (target) {
+      case AssetLiabilitySyncTarget.monthlyState:
+        if (_remoteMonthIsEmpty(data.remoteMonth)) {
+          return 0;
+        }
+        await localRepository.saveMonth(month: month, state: data.remoteMonth!);
+        return 1;
+      case AssetLiabilitySyncTarget.paymentSourceSettings:
+        if (data.remoteSources?.isNotEmpty != true) {
+          return 0;
+        }
+        await localRepository.saveDefaultPaymentSources(data.remoteSources!);
+        return data.remoteSources!.length;
+      case AssetLiabilitySyncTarget.cardBillingDefaults:
+        if (data.remoteDefaultCardBillingAccounts?.isNotEmpty != true) {
+          return 0;
+        }
+        await localRepository.saveDefaultCardBillingAccounts(
+          data.remoteDefaultCardBillingAccounts!,
+        );
+        return data.remoteDefaultCardBillingAccounts!.length;
+      case AssetLiabilitySyncTarget.recurringIncomeTemplates:
+        if (data.remoteTemplates?.isNotEmpty != true) {
+          return 0;
+        }
+        await localRepository.saveRecurringIncomeTemplates(
+          data.remoteTemplates!,
+        );
+        return data.remoteTemplates!.length;
+      case AssetLiabilitySyncTarget.monthlySnapshots:
+        if (data.remoteSnapshots?.isNotEmpty != true) {
+          return 0;
+        }
+        for (final snapshot in data.remoteSnapshots!) {
+          await localRepository.saveMonthlySnapshot(snapshot);
+        }
+        return data.remoteSnapshots!.length;
+    }
+  }
+
   Future<void> _recordPreviewAuditLogs({
     required DateTime month,
     required AssetLiabilitySyncPreviewResult preview,
@@ -837,7 +1187,9 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       await _recordAuditLog(
         month: month,
         type: AssetLiabilitySyncAuditType.conflictDetected,
-        targetDataType: preview.conflictTargets.join(','),
+        targetDataType: preview.conflictTargetTypes
+            .map((target) => target.storageKey)
+            .join(','),
         count: preview.conflictCount,
         result: 'conflict_non_destructive_stop',
         errorMessage: 'Both local and Supabase data exist; no overwrite.',
@@ -905,43 +1257,196 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
   ) {
     final items = <AssetLiabilitySyncPreviewItem>[
       AssetLiabilitySyncPreviewItem(
-        targetName: '月次状態',
+        target: AssetLiabilitySyncTarget.monthlyState,
         localHasData: !data.localMonth.isEmpty,
         remoteHasData: !_remoteMonthIsEmpty(data.remoteMonth),
         localCount: data.localMonth.isEmpty ? 0 : 1,
         remoteCount: _remoteMonthIsEmpty(data.remoteMonth) ? 0 : 1,
+        dataMatches: !data.localMonth.isEmpty &&
+            !_remoteMonthIsEmpty(data.remoteMonth) &&
+            _monthlyStatesEqual(data.localMonth, data.remoteMonth!),
       ),
       AssetLiabilitySyncPreviewItem(
-        targetName: '支払原資口座設定',
+        target: AssetLiabilitySyncTarget.paymentSourceSettings,
         localHasData: data.localSources.isNotEmpty,
         remoteHasData: data.remoteSources?.isNotEmpty ?? false,
         localCount: data.localSources.length,
         remoteCount: data.remoteSources?.length ?? 0,
+        dataMatches: data.localSources.isNotEmpty &&
+            (data.remoteSources?.isNotEmpty ?? false) &&
+            _stringMapEquals(data.localSources, data.remoteSources!),
       ),
       AssetLiabilitySyncPreviewItem(
-        targetName: 'card billing defaults',
+        target: AssetLiabilitySyncTarget.cardBillingDefaults,
         localHasData: data.localDefaultCardBillingAccounts.isNotEmpty,
         remoteHasData:
             data.remoteDefaultCardBillingAccounts?.isNotEmpty ?? false,
         localCount: data.localDefaultCardBillingAccounts.length,
         remoteCount: data.remoteDefaultCardBillingAccounts?.length ?? 0,
+        dataMatches: data.localDefaultCardBillingAccounts.isNotEmpty &&
+            (data.remoteDefaultCardBillingAccounts?.isNotEmpty ?? false) &&
+            _stringMapEquals(
+              data.localDefaultCardBillingAccounts,
+              data.remoteDefaultCardBillingAccounts!,
+            ),
       ),
       AssetLiabilitySyncPreviewItem(
-        targetName: '定期収入テンプレート',
+        target: AssetLiabilitySyncTarget.recurringIncomeTemplates,
         localHasData: data.localTemplates.isNotEmpty,
         remoteHasData: data.remoteTemplates?.isNotEmpty ?? false,
         localCount: data.localTemplates.length,
         remoteCount: data.remoteTemplates?.length ?? 0,
+        dataMatches: data.localTemplates.isNotEmpty &&
+            (data.remoteTemplates?.isNotEmpty ?? false) &&
+            _recurringTemplatesEqual(
+              data.localTemplates,
+              data.remoteTemplates!,
+            ),
       ),
       AssetLiabilitySyncPreviewItem(
-        targetName: '月次スナップショット',
+        target: AssetLiabilitySyncTarget.monthlySnapshots,
         localHasData: data.localSnapshots.isNotEmpty,
         remoteHasData: data.remoteSnapshots?.isNotEmpty ?? false,
         localCount: data.localSnapshots.length,
         remoteCount: data.remoteSnapshots?.length ?? 0,
+        dataMatches: data.localSnapshots.isNotEmpty &&
+            (data.remoteSnapshots?.isNotEmpty ?? false) &&
+            _monthlySnapshotsEqual(data.localSnapshots, data.remoteSnapshots!),
       ),
     ];
     return AssetLiabilitySyncPreviewResult.ready(items: items);
+  }
+
+  bool _monthlyStatesEqual(
+    AssetLiabilityMonthlyState local,
+    AssetLiabilityMonthlyState remote,
+  ) {
+    return _doubleMapEquals(local.paymentOverrides, remote.paymentOverrides) &&
+        _stringSetEquals(local.paidAccountNames, remote.paidAccountNames) &&
+        _stringMapEquals(
+          local.paymentSourceAccountIds,
+          remote.paymentSourceAccountIds,
+        ) &&
+        _stringMapEquals(
+          local.cardBillingAccountIds,
+          remote.cardBillingAccountIds,
+        ) &&
+        _incomePlansEqual(local.incomePlans, remote.incomePlans);
+  }
+
+  bool _doubleMapEquals(Map<String, double> a, Map<String, double> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final entry in a.entries) {
+      if (b[entry.key] != entry.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _stringMapEquals(Map<String, String> a, Map<String, String> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final entry in a.entries) {
+      if (b[entry.key] != entry.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _stringSetEquals(Set<String> a, Set<String> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    return a.every(b.contains);
+  }
+
+  bool _incomePlansEqual(
+    List<AssetLiabilityIncomePlan> a,
+    List<AssetLiabilityIncomePlan> b,
+  ) {
+    final first = List<AssetLiabilityIncomePlan>.from(a)
+      ..sort((left, right) => left.id.compareTo(right.id));
+    final second = List<AssetLiabilityIncomePlan>.from(b)
+      ..sort((left, right) => left.id.compareTo(right.id));
+    if (first.length != second.length) {
+      return false;
+    }
+    for (var i = 0; i < first.length; i++) {
+      final left = first[i];
+      final right = second[i];
+      if (left.id != right.id ||
+          left.date != right.date ||
+          left.name != right.name ||
+          left.amount != right.amount ||
+          left.destinationAccountId != right.destinationAccountId ||
+          left.destinationAccountName != right.destinationAccountName ||
+          left.received != right.received) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _recurringTemplatesEqual(
+    List<AssetLiabilityRecurringIncomeTemplate> a,
+    List<AssetLiabilityRecurringIncomeTemplate> b,
+  ) {
+    final first = List<AssetLiabilityRecurringIncomeTemplate>.from(a)
+      ..sort((left, right) => left.id.compareTo(right.id));
+    final second = List<AssetLiabilityRecurringIncomeTemplate>.from(b)
+      ..sort((left, right) => left.id.compareTo(right.id));
+    if (first.length != second.length) {
+      return false;
+    }
+    for (var i = 0; i < first.length; i++) {
+      final left = first[i];
+      final right = second[i];
+      if (left.id != right.id ||
+          left.dayOfMonth != right.dayOfMonth ||
+          left.name != right.name ||
+          left.amount != right.amount ||
+          left.destinationAccountId != right.destinationAccountId ||
+          left.destinationAccountName != right.destinationAccountName) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _monthlySnapshotsEqual(
+    List<AssetLiabilityMonthlySnapshot> a,
+    List<AssetLiabilityMonthlySnapshot> b,
+  ) {
+    final first = List<AssetLiabilityMonthlySnapshot>.from(a)
+      ..sort((left, right) => left.monthKey.compareTo(right.monthKey));
+    final second = List<AssetLiabilityMonthlySnapshot>.from(b)
+      ..sort((left, right) => left.monthKey.compareTo(right.monthKey));
+    if (first.length != second.length) {
+      return false;
+    }
+    for (var i = 0; i < first.length; i++) {
+      final left = first[i];
+      final right = second[i];
+      if (left.monthKey != right.monthKey ||
+          left.savedAt != right.savedAt ||
+          left.positiveAssetTotal != right.positiveAssetTotal ||
+          left.liabilityTotal != right.liabilityTotal ||
+          left.netWorth != right.netWorth ||
+          left.cashLikeTotal != right.cashLikeTotal ||
+          left.monthlyScheduledPaymentTotal !=
+              right.monthlyScheduledPaymentTotal ||
+          left.monthlyPaidPaymentTotal != right.monthlyPaidPaymentTotal ||
+          left.monthlyUnpaidPaymentTotal != right.monthlyUnpaidPaymentTotal ||
+          left.overduePaymentCount != right.overduePaymentCount) {
+        return false;
+      }
+    }
+    return true;
   }
 
   String? _userIdOrNull() {

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -652,6 +652,154 @@ void main() {
     });
 
     test(
+      'resolves a monthly state conflict with explicit local wins',
+      () async {
+        const local = SharedPreferencesAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore()
+          ..seedMonth(
+            DateTime(2026, 5),
+            const AssetLiabilityMonthlyState(
+              paymentOverrides: <String, double>{'remote_only': 1000},
+            ),
+          );
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
+        await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+        final before = await repository.previewSyncMonth(month);
+        final result = await repository.resolveSyncConflicts(
+          month: month,
+          resolutions: const <AssetLiabilityConflictResolution>[
+            AssetLiabilityConflictResolution(
+              target: AssetLiabilitySyncTarget.monthlyState,
+              choice: AssetLiabilityConflictResolutionChoice.localWins,
+            ),
+          ],
+        );
+        final after = await repository.previewSyncMonth(month);
+        final logs = await repository.loadSyncAuditLogs();
+
+        expect(before.conflictCount, 1);
+        expect(result.isSuccess, isTrue);
+        expect(
+          result.resolvedTargets,
+          contains(AssetLiabilitySyncTarget.monthlyState),
+        );
+        expect(remote.monthState('2026-05')?.paymentOverrides['mobit'], 70000);
+        expect((await local.loadMonth(month)).paymentOverrides['mobit'], 70000);
+        expect(after.conflictCount, 0);
+        expect(
+          logs.map((log) => log.type),
+          contains(AssetLiabilitySyncAuditType.conflictResolved),
+        );
+      },
+    );
+
+    test(
+      'resolves a monthly state conflict with explicit Supabase wins',
+      () async {
+        const local = SharedPreferencesAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore()
+          ..seedMonth(
+            DateTime(2026, 5),
+            const AssetLiabilityMonthlyState(
+              paymentOverrides: <String, double>{'remote_only': 1000},
+            ),
+          );
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
+        await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+        final result = await repository.resolveSyncConflicts(
+          month: month,
+          resolutions: const <AssetLiabilityConflictResolution>[
+            AssetLiabilityConflictResolution(
+              target: AssetLiabilitySyncTarget.monthlyState,
+              choice: AssetLiabilityConflictResolutionChoice.supabaseWins,
+            ),
+          ],
+        );
+        final restored = await local.loadMonth(month);
+        final after = await repository.previewSyncMonth(month);
+
+        expect(result.isSuccess, isTrue);
+        expect(restored.paymentOverrides['remote_only'], 1000);
+        expect(restored.paymentOverrides.containsKey('mobit'), isFalse);
+        expect(
+          remote.monthState('2026-05')?.paymentOverrides['remote_only'],
+          1000,
+        );
+        expect(after.conflictCount, 0);
+      },
+    );
+
+    test(
+      'skips a conflict without overwriting either side and records the choice',
+      () async {
+        const local = SharedPreferencesAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore()
+          ..seedMonth(
+            DateTime(2026, 5),
+            const AssetLiabilityMonthlyState(
+              paymentOverrides: <String, double>{'remote_only': 1000},
+            ),
+          );
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
+        await local.saveMonth(month: month, state: _sampleMonthlyState());
+
+        final result = await repository.resolveSyncConflicts(
+          month: month,
+          resolutions: const <AssetLiabilityConflictResolution>[
+            AssetLiabilityConflictResolution(
+              target: AssetLiabilitySyncTarget.monthlyState,
+              choice: AssetLiabilityConflictResolutionChoice.skip,
+            ),
+          ],
+        );
+        final after = await repository.previewSyncMonth(month);
+        final logs = await repository.loadSyncAuditLogs();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.resolvedTargets, isEmpty);
+        expect(
+          result.skippedTargets,
+          contains(AssetLiabilitySyncTarget.monthlyState),
+        );
+        expect((await local.loadMonth(month)).paymentOverrides['mobit'], 70000);
+        expect(
+          remote.monthState('2026-05')?.paymentOverrides['remote_only'],
+          1000,
+        );
+        expect(after.conflictCount, 1);
+        expect(
+          logs
+              .firstWhere(
+                (log) =>
+                    log.type == AssetLiabilitySyncAuditType.conflictResolved,
+              )
+              .result,
+          'skipped',
+        );
+      },
+    );
+
+    test(
       'feature flag off does not call Supabase or create audit logs',
       () async {
         const local = SharedPreferencesAssetLiabilityRepository();


### PR DESCRIPTION
﻿## Overview

Adds an explicit conflict-resolution UI for asset/liability Supabase sync conflicts.

When both local SharedPreferences data and Supabase data exist for the same sync target, the board already stops non-destructively. This PR lets the user resolve each detected conflict by choosing local wins, Supabase wins, or skip. The actual write decision stays in `AssetLiabilityRepository`; the UI does not call Supabase directly.

Closes #2448

## Changes

- Add stable sync target metadata for monthly state, payment source settings, card billing defaults, recurring income templates, and monthly snapshots.
- Add repository-level conflict resolution choices:
  - local wins: upload local target to Supabase
  - Supabase wins: restore remote target to local storage after explicit confirmation
  - skip: record the decision without overwriting either side
- Treat matching local/remote payloads as non-conflicting after an explicit resolution.
- Add a conflict-resolution panel under the sync preview.
- Record explicit conflict-resolution decisions in the sync audit log.
- Add repository tests for local wins, Supabase wins, and skip.

## Safety Notes

- Feature flag behavior is unchanged.
- Supabase sync remains OFF by default.
- Feature flag OFF does not call Supabase.
- Conflict detection still stops automatic sync non-destructively.
- Supabase wins requires an explicit UI confirmation before local data is overwritten.
- No production migration or RLS change is included.

## Minimal E2E Declaration

This E2E declaration is implementation-detail independent: it describes user-visible sync outcomes rather than internal method names.

Minimal user-facing cases covered by deterministic tests and local web smoke:

1. A local/Supabase monthly-state conflict is detected without overwriting either side.
2. Selecting local wins resolves the conflict by uploading local data through the repository.
3. Selecting Supabase wins restores remote data only through the repository path; the UI includes an explicit confirmation.
4. Selecting skip records the decision and keeps both sides unchanged.
5. The asset management page still serves locally over web with HTTP 200.

E2E-Exception: no new browser E2E was added because the critical behavior is repository-mediated conflict handling and is covered by service tests; UI verification was limited to compile/analyze plus local web smoke.

## High-risk Ultrareview

- Risk area: asset/liability financial state persistence and Supabase sync conflict handling.
- Review owner: Claude Code #1.
- Implementation owner: Codex #1 implementation lane.
- Data safety: no automatic overwrite; explicit resolution only; Supabase wins is confirmed in UI.
- Security: no new secrets, no direct UI Supabase writes, no RLS/migration changes.
- Rollback: revert this PR to remove the conflict-resolution UI and repository method while keeping existing preview/manual sync behavior.
- Observability: conflict-resolution decisions are written to the existing local sync audit log.
- Prod smoke: not run against production; CI Public E2E stability smoke passed, and local web smoke returned HTTP 200.
- Unresolved findings: none (0). Unresolved ultrareview findings: none.

## Validation

- `dart format --output=none --set-exit-if-changed lib/models/asset_liability_sync_audit_log.dart lib/services/asset_liability_repository.dart lib/pages/asset_management_page.dart test/services/asset_liability_repository_test.dart`: OK
- `dart analyze`: No issues found
- Related asset/liability tests: 88 passed
- Full `flutter test --no-pub`: 474 passed
- `git diff --check`: OK
- Local web smoke: HTTP 200 on `http://127.0.0.1:55248`

## Notes

`flutter pub get --enforce-lockfile` could not be used in this fresh worktree because the current local Flutter/Dart SDK wanted to update `pubspec.lock`. I ran `flutter pub get` only to restore `.dart_tool/package_config.json`, then reverted generated platform files and lockfile changes. No lockfile or generated platform file is included in this PR.

