### PR TITLE
Add emergency living advice to asset assistant

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -7485,6 +7485,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ],
           ),
           const SizedBox(height: 12),
+          if (report.emergencyAdvices.isNotEmpty) ...[
+            _buildAssetManagementEmergencyAdviceList(report.emergencyAdvices),
+            const SizedBox(height: 12),
+          ],
           _buildAssetManagementAssistantActionList(report.actionItems),
           if (report.movementSuggestions.isNotEmpty) ...[
             const SizedBox(height: 12),
@@ -7667,6 +7671,99 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               height: 1.4,
             ),
           ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetManagementEmergencyAdviceList(
+    List<AssetManagementEmergencyAdvice> advices,
+  ) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF1F2),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFB91C1C).withValues(alpha: 0.28),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Row(
+            children: [
+              Icon(
+                Icons.health_and_safety_outlined,
+                color: Color(0xFFB91C1C),
+                size: 18,
+              ),
+              SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '緊急生活防衛アドバイス',
+                  style: TextStyle(
+                    color: Color(0xFFB91C1C),
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            '水だけで耐えるなど、健康を削る判断はしないでください。支払いより先に、食費・移動費・医療など最低限の生活費を守ります。',
+            style: TextStyle(fontSize: 12, height: 1.5),
+          ),
+          const SizedBox(height: 8),
+          for (final advice in advices.take(5))
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: _assetManagementInsightSeverityColor(
+                      advice.severity,
+                    ).withValues(alpha: 0.22),
+                  ),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      advice.title,
+                      style: TextStyle(
+                        color: _assetManagementInsightSeverityColor(
+                          advice.severity,
+                        ),
+                        fontWeight: FontWeight.bold,
+                        height: 1.4,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      advice.description,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        fontSize: 12,
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      advice.suggestedAction,
+                      style: const TextStyle(fontSize: 12, height: 1.5),
+                    ),
+                  ],
+                ),
+              ),
+            ),
         ],
       ),
     );
@@ -7929,6 +8026,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         Icons.event_available_outlined,
       AssetManagementInsightActionType.cashShortageRisk =>
         Icons.warning_amber_rounded,
+      AssetManagementInsightActionType.emergencyLivingExpense =>
+        Icons.health_and_safety_outlined,
       AssetManagementInsightActionType.cardBillingConfiguration =>
         Icons.credit_card_off_outlined,
       AssetManagementInsightActionType.doubleCountingRisk =>

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -198,9 +198,7 @@ class AssetManagementAiSummaryService {
                   '${advice.suggestedAction}',
             )
             .join(' ');
-    final status = critical > 0
-        ? '緊急の資金繰り項目があります。'
-        : '緊急度の高い資金繰り項目は検出されていません。';
+    final status = critical > 0 ? '緊急の資金繰り項目があります。' : '緊急度の高い資金繰り項目は検出されていません。';
     return [
       status,
       '要対応: $actionCount件、緊急: $critical件。',

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -150,6 +150,17 @@ class AssetManagementAiSummaryService {
             },
           )
           .toList(growable: false),
+      'emergency_advices': report.emergencyAdvices
+          .map(
+            (advice) => <String, dynamic>{
+              'severity': advice.severity.name,
+              'title': advice.title,
+              'description': advice.description,
+              'suggested_action': advice.suggestedAction,
+              'amount': advice.amount,
+            },
+          )
+          .toList(growable: false),
       'developer_requests': report.developerRequests
           .map(
             (request) => <String, dynamic>{
@@ -163,6 +174,8 @@ class AssetManagementAiSummaryService {
         'calculation_owner': 'dart_service',
         'external_ai_may_summarize_only': true,
         'external_ai_may_recalculate_amounts': false,
+        'must_not_recommend_starvation_or_water_only': true,
+        'must_prioritize_food_shelter_health_and_contacting_creditors': true,
       },
     };
   }
@@ -174,17 +187,27 @@ class AssetManagementAiSummaryService {
     final week = _formatYen(report.weekAvailable.availableAmount);
     final month = _formatYen(report.monthAvailable.availableAmount);
     final movement = report.movementSuggestions.isEmpty
-        ? 'No account movement suggestion is currently required.'
-        : 'Review ${report.movementSuggestions.length} account movement suggestion(s).';
+        ? '現時点で口座移動・出金提案はありません。'
+        : '口座移動・出金提案を${report.movementSuggestions.length}件確認してください。';
+    final emergency = report.emergencyAdvices.isEmpty
+        ? '緊急の生活費防衛アドバイスはありません。'
+        : report.emergencyAdvices
+            .take(3)
+            .map(
+              (advice) => '${advice.title}: ${advice.description} '
+                  '${advice.suggestedAction}',
+            )
+            .join(' ');
     final status = critical > 0
-        ? 'Critical cashflow items need attention.'
-        : 'No critical cashflow item was detected.';
+        ? '緊急の資金繰り項目があります。'
+        : '緊急度の高い資金繰り項目は検出されていません。';
     return [
       status,
-      'Action items: $actionCount, critical: $critical.',
-      'Available money: today $today, week $week, month $month.',
+      '要対応: $actionCount件、緊急: $critical件。',
+      '使用可能額: 本日 $today、今週 $week、今月 $month。',
+      emergency,
       movement,
-      'Amounts are calculated by Dart rules; AI summary is optional.',
+      '金額はDartルールで計算済みです。Amounts are calculated by Dart rules; AI summary is optional.',
     ].join(' ');
   }
 
@@ -198,7 +221,7 @@ class AssetManagementAiSummaryService {
       '## Computed insight payload',
       jsonEncode(payload),
       '',
-      'Rules: summarize only. Do not recalculate amounts. Do not provide legal, investment, or credit advice. Keep the response concise and action-oriented.',
+      'Rules: summarize only. Do not recalculate amounts. Do not provide legal, investment, or credit advice. Never recommend starvation, water-only survival, or skipping meals as a solution. Prioritize food, shelter, health, contacting creditors, and emergency public/community support. Keep the response concise and action-oriented.',
     ].join('\n');
   }
 

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -8,6 +8,7 @@ enum AssetManagementInsightActionType {
   overduePayment,
   upcomingPayment,
   cashShortageRisk,
+  emergencyLivingExpense,
   cardBillingConfiguration,
   doubleCountingRisk,
 }
@@ -94,12 +95,29 @@ class AssetManagementDeveloperRequest {
   });
 }
 
+class AssetManagementEmergencyAdvice {
+  final AssetManagementInsightSeverity severity;
+  final String title;
+  final String description;
+  final String suggestedAction;
+  final double? amount;
+
+  const AssetManagementEmergencyAdvice({
+    required this.severity,
+    required this.title,
+    required this.description,
+    required this.suggestedAction,
+    required this.amount,
+  });
+}
+
 class AssetManagementInsightReport {
   final List<AssetManagementInsightActionItem> actionItems;
   final AssetManagementAvailableMoneyInsight todayAvailable;
   final AssetManagementAvailableMoneyInsight weekAvailable;
   final AssetManagementAvailableMoneyInsight monthAvailable;
   final List<AssetManagementMovementSuggestion> movementSuggestions;
+  final List<AssetManagementEmergencyAdvice> emergencyAdvices;
   final List<AssetManagementDeveloperRequest> developerRequests;
 
   const AssetManagementInsightReport({
@@ -108,6 +126,7 @@ class AssetManagementInsightReport {
     required this.weekAvailable,
     required this.monthAvailable,
     required this.movementSuggestions,
+    required this.emergencyAdvices,
     required this.developerRequests,
   });
 
@@ -140,6 +159,7 @@ class AssetManagementInsightService {
     final actions = _buildActionItems(
       workbook: workbook,
       upcomingPaymentWarningDays: upcomingPaymentWarningDays,
+      minimumSafetyBalance: minimumSafetyBalance,
     )..sort(_compareActionItems);
     final today = _buildAvailableMoneyInsight(
       workbook: workbook,
@@ -167,6 +187,13 @@ class AssetManagementInsightService {
       windows: <AssetManagementAvailableMoneyInsight>[today, week, month],
       minimumSafetyBalance: minimumSafetyBalance,
     );
+    final emergencyAdvices = _buildEmergencyAdvices(
+      workbook: workbook,
+      today: today,
+      week: week,
+      month: month,
+      movementSuggestions: movementSuggestions,
+    );
     final developerRequests = _buildDeveloperRequests(
       workbook: workbook,
       actions: actions,
@@ -179,6 +206,7 @@ class AssetManagementInsightService {
       weekAvailable: week,
       monthAvailable: month,
       movementSuggestions: movementSuggestions,
+      emergencyAdvices: emergencyAdvices,
       developerRequests: developerRequests,
     );
   }
@@ -186,6 +214,7 @@ class AssetManagementInsightService {
   List<AssetManagementInsightActionItem> _buildActionItems({
     required AssetLiabilityWorkbook workbook,
     required int upcomingPaymentWarningDays,
+    required double minimumSafetyBalance,
   }) {
     final actions = <AssetManagementInsightActionItem>[];
     final today = _dateOnly(workbook.baseDate);
@@ -299,6 +328,30 @@ class AssetManagementInsightService {
           ),
         );
       }
+    }
+
+    final todayInsight = _buildAvailableMoneyInsight(
+      workbook: workbook,
+      window: AssetManagementInsightWindow.today,
+      startDate: today,
+      endDate: today,
+      minimumSafetyBalance: minimumSafetyBalance,
+    );
+    if (todayInsight.availableAmount < 0) {
+      actions.add(
+        AssetManagementInsightActionItem(
+          type: AssetManagementInsightActionType.emergencyLivingExpense,
+          severity: AssetManagementInsightSeverity.critical,
+          title: '本日の生活費が不足しています',
+          description:
+              '本日使用可能額が${_formatYen(todayInsight.availableAmount)}です。水だけで過ごすなど、健康を削る判断はしないでください。',
+          relatedAccountId: null,
+          dueDate: today,
+          paymentDay: today.day,
+          suggestedAction:
+              '支払いを実行する前に、今日の食費・移動費・医療など最低限の生活費を先に確保し、払えない支払いは支払先へ猶予または分割相談をしてください。',
+        ),
+      );
     }
 
     for (final item in workbook.cardBillingReview.needsReviewItems) {
@@ -435,6 +488,122 @@ class AssetManagementInsightService {
     }
 
     return _dedupeSuggestions(suggestions);
+  }
+
+  List<AssetManagementEmergencyAdvice> _buildEmergencyAdvices({
+    required AssetLiabilityWorkbook workbook,
+    required AssetManagementAvailableMoneyInsight today,
+    required AssetManagementAvailableMoneyInsight week,
+    required AssetManagementAvailableMoneyInsight month,
+    required List<AssetManagementMovementSuggestion> movementSuggestions,
+  }) {
+    final windows = <AssetManagementAvailableMoneyInsight>[today, week, month]
+      ..sort((a, b) => a.availableAmount.compareTo(b.availableAmount));
+    final worst = windows.first;
+    final hasShortage = windows.any((window) => window.availableAmount < 0);
+    if (!hasShortage) {
+      return const <AssetManagementEmergencyAdvice>[];
+    }
+
+    final nextIncome = _nextIncomePlan(workbook);
+    final shortfall =
+        worst.availableAmount < 0 ? worst.availableAmount.abs() : 0.0;
+    final advices = <AssetManagementEmergencyAdvice>[];
+
+    if (today.availableAmount < 0) {
+      advices.add(
+        AssetManagementEmergencyAdvice(
+          severity: AssetManagementInsightSeverity.critical,
+          title: '今日の食費を先に確保してください',
+          description:
+              '本日使用可能額が${_formatYen(today.availableAmount)}です。給料日まで水だけで耐える方針は危険です。支払いより先に、今日食べるためのお金を隔離してください。',
+          suggestedAction:
+              '財布または引落口座とは別の口座に、最低でも今日の食費1,000〜1,500円と移動費を残してください。残せない場合は、家族・知人・自治体窓口・フードバンクへ今日中に相談してください。',
+          amount: today.availableAmount.abs(),
+        ),
+      );
+    }
+
+    if (shortfall > 0) {
+      advices.add(
+        AssetManagementEmergencyAdvice(
+          severity: AssetManagementInsightSeverity.critical,
+          title: '払う順番を一度止めて組み替えてください',
+          description:
+              '${_windowLabel(worst.window)}の不足額は${_formatYen(shortfall)}です。全支払いを予定通り払う前提だと生活費が残りません。',
+          suggestedAction:
+              '優先順位は「食費・通勤・住居/公共料金の継続」→「期限超過の連絡」→「カード/ローンの猶予・分割相談」です。支払先へ、今日中に支払日変更・最低額変更・一時猶予を相談してください。',
+          amount: shortfall,
+        ),
+      );
+    }
+
+    if (movementSuggestions.isNotEmpty) {
+      final suggestion = movementSuggestions.first;
+      advices.add(
+        AssetManagementEmergencyAdvice(
+          severity: AssetManagementInsightSeverity.warning,
+          title: '口座移動または出金を先に実行してください',
+          description:
+              '${suggestion.fromAccountName}から${_formatYen(suggestion.amount)}を動かす候補があります。',
+          suggestedAction:
+              '支払い前にこの移動を実行し、生活費用の残高を確認してください。移動後も不足する場合は、その支払いは払う前に支払先へ連絡してください。',
+          amount: suggestion.amount,
+        ),
+      );
+    }
+
+    if (nextIncome == null) {
+      advices.add(
+        const AssetManagementEmergencyAdvice(
+          severity: AssetManagementInsightSeverity.warning,
+          title: '次の入金予定を登録してください',
+          description: '給料日や入金予定が未登録のため、何日分の生活費を守るべきか判断しにくい状態です。',
+          suggestedAction:
+              '給料日・金額・入金先口座を収入予定に入れてください。登録後、AIアシスタントが給料日までの不足額を再計算します。',
+          amount: null,
+        ),
+      );
+    } else {
+      advices.add(
+        AssetManagementEmergencyAdvice(
+          severity: AssetManagementInsightSeverity.info,
+          title: '次の入金日までの生活費を分けてください',
+          description:
+              '次の入金予定は${_formatDate(nextIncome.date)}の${nextIncome.name} ${_formatYen(nextIncome.amount)}です。',
+          suggestedAction:
+              'この入金日までに必要な食費を先に確保し、残額だけを支払いに回してください。入金前に資金が尽きる場合は支払い猶予の相談を優先してください。',
+          amount: nextIncome.amount,
+        ),
+      );
+    }
+
+    advices.add(
+      const AssetManagementEmergencyAdvice(
+        severity: AssetManagementInsightSeverity.info,
+        title: '公的・地域の緊急支援も候補に入れてください',
+        description: '食費が確保できない場合は、アプリ内の節約だけではなく外部支援を使う局面です。',
+        suggestedAction:
+            '自治体の生活困窮者自立支援窓口、社会福祉協議会、フードバンク、緊急小口資金の相談先を今日確認してください。',
+        amount: null,
+      ),
+    );
+
+    return advices;
+  }
+
+  AssetLiabilityIncomePlan? _nextIncomePlan(AssetLiabilityWorkbook workbook) {
+    final today = _dateOnly(workbook.baseDate);
+    final plans = workbook.incomePlans
+        .where(
+          (plan) =>
+              !plan.received &&
+              plan.amount > 0 &&
+              !_dateOnly(plan.date).isBefore(today),
+        )
+        .toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+    return plans.isEmpty ? null : plans.first;
   }
 
   List<AssetManagementDeveloperRequest> _buildDeveloperRequests({
@@ -636,6 +805,10 @@ class AssetManagementInsightService {
     }
     return '$sign$buffer円';
   }
+
+  String _formatDate(DateTime value) {
+    return '${value.month}/${value.day}';
+  }
 }
 
 class AssetManagementInsightPromptBuilder {
@@ -658,6 +831,18 @@ class AssetManagementInsightPromptBuilder {
       for (final item in report.actionItems.take(12)) {
         buffer.writeln(
           '- [${item.severity.name}] ${item.title}: ${item.suggestedAction}',
+        );
+      }
+    }
+    buffer
+      ..writeln()
+      ..writeln('## 緊急生活防衛アドバイス');
+    if (report.emergencyAdvices.isEmpty) {
+      buffer.writeln('- 緊急の生活費不足アドバイスはありません。');
+    } else {
+      for (final advice in report.emergencyAdvices.take(6)) {
+        buffer.writeln(
+          '- [${advice.severity.name}] ${advice.title}: ${advice.suggestedAction}',
         );
       }
     }

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -100,15 +100,34 @@ void main() {
       final available = payload['available_money'] as Map<String, dynamic>;
       final today = available['today'] as Map<String, dynamic>;
       final guardrails = payload['guardrails'] as Map<String, dynamic>;
+      final emergencyAdvices = payload['emergency_advices'] as List<dynamic>;
 
       expect(payload.containsKey('workbook'), false);
       expect(today['available_amount'], report.todayAvailable.availableAmount);
       expect(payload['action_items'] is List<dynamic>, true);
       expect(payload['movement_suggestions'] is List<dynamic>, true);
+      expect(emergencyAdvices.length, report.emergencyAdvices.length);
       expect(payload['developer_requests'] is List<dynamic>, true);
       expect(guardrails['calculation_owner'], 'dart_service');
       expect(guardrails['external_ai_may_summarize_only'], true);
       expect(guardrails['external_ai_may_recalculate_amounts'], false);
+      expect(guardrails['must_not_recommend_starvation_or_water_only'], true);
+    });
+
+    test('deterministic fallback gives concrete emergency living advice', () {
+      final report = _emergencyReport();
+      final service = AssetManagementAiSummaryService(
+        now: () => DateTime(2026, 5, 28, 12),
+      );
+
+      final text = service.buildDeterministicSummary(report);
+      final payload = service.buildPayload(report);
+
+      expect(text.contains('今日の食費'), true);
+      expect(text.contains('支払い'), true);
+      expect(text.contains('Amounts are calculated by Dart rules'), true);
+      expect(payload['emergency_advices'] is List<dynamic>, true);
+      expect((payload['emergency_advices'] as List<dynamic>).isNotEmpty, true);
     });
   });
 }
@@ -120,6 +139,18 @@ AssetManagementInsightReport _report() {
     latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
     baseDate: DateTime(2026, 5, 1),
     monthlyPaymentOverrides: const <String, double>{'paypay_card': 20000},
+    paymentSourceAccountIds: const <String, String>{'paypay_card': 'bank'},
+  );
+  return insight.buildReport(workbook: workbook, minimumSafetyBalance: 10000);
+}
+
+AssetManagementInsightReport _emergencyReport() {
+  const planner = AssetLiabilityPlanningService();
+  const insight = AssetManagementInsightService();
+  final workbook = planner.buildWorkbook(
+    latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -200000},
+    baseDate: DateTime(2026, 5, 28),
+    monthlyPaymentOverrides: const <String, double>{'paypay_card': 200000},
     paymentSourceAccountIds: const <String, String>{'paypay_card': 'bank'},
   );
   return insight.buildReport(workbook: workbook, minimumSafetyBalance: 10000);

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -137,6 +137,48 @@ void main() {
       expect(report.movementSuggestions.first.amount, 5000);
     });
 
+    test('generates emergency living advice for negative today cashflow', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'PayPay': -200000,
+        },
+        baseDate: DateTime(2026, 5, 28),
+        monthlyPaymentOverrides: const <String, double>{'paypay_card': 200000},
+        paymentSourceAccountIds: const <String, String>{'paypay_card': 'bank'},
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'salary',
+            date: DateTime(2026, 5, 31),
+            name: 'salary',
+            amount: 250000,
+            destinationAccountId: 'bank',
+            destinationAccountName: 'bank',
+            received: false,
+          ),
+        ],
+      );
+
+      final report = service.buildReport(
+        workbook: workbook,
+        minimumSafetyBalance: 10000,
+      );
+
+      expect(report.todayAvailable.availableAmount, -160000);
+      expect(report.emergencyAdvices.isNotEmpty, true);
+      expect(report.emergencyAdvices.first.title, contains('今日の食費'));
+      expect(report.emergencyAdvices.first.description, contains('水だけ'));
+      expect(report.emergencyAdvices.first.description, contains('危険'));
+      expect(
+        report.actionItems.any(
+          (item) =>
+              item.type ==
+              AssetManagementInsightActionType.emergencyLivingExpense,
+        ),
+        true,
+      );
+    });
+
     test('generates developer improvement requests', () {
       final workbook = planner.buildWorkbook(
         latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},


### PR DESCRIPTION
﻿## Overview

Adds emergency living-expense advice to the asset management AI assistant when the calculated available money is negative.

The assistant now gives concrete, safety-first guidance for cases like a negative `本日使用可能額`: protect food, transportation, medical, and other minimum living expenses first; do not try to survive on water only; contact payment destinations for deferment or installment changes; and consider family, local government, social welfare council, or food-bank support when food money cannot be secured.

## Changes

- Add `AssetManagementEmergencyAdvice` to the deterministic insight report.
- Add a critical action item when today's available money is below 0 yen.
- Add a red `緊急生活防衛アドバイス` panel to the AI asset management assistant.
- Include emergency advice in the AI summary payload and deterministic fallback summary.
- Add guardrails so external AI summarization must not recommend starvation, water-only survival, or skipping meals.
- Add emergency advice to the prompt-builder path used for future AI summaries.
- Add service tests for negative-cashflow emergency advice and AI summary payload/fallback behavior.

## Safety Notes

- Amount calculations remain in Dart rules only.
- External AI is still summary-only and may not recalculate amounts.
- The assistant explicitly avoids harmful advice such as water-only survival or skipping meals.
- The advice does not provide legal, investment, or credit advice; it suggests contacting creditors/payment destinations and emergency support channels.
- No Supabase, migration, RLS, or production write behavior is changed.

## Minimal E2E Declaration

This E2E declaration is implementation-detail independent: it describes user-visible assistant outcomes rather than internal method names.

Minimal user-facing cases covered by deterministic tests and PR CI:

1. When today's available money is negative, the assistant creates emergency living-expense advice.
2. The assistant warns against water-only survival and prioritizes food/living expense protection.
3. The AI summary payload includes emergency advice and guardrails for external summarization.
4. The deterministic fallback summary gives concrete Japanese emergency guidance even when the AI feature flag is OFF.
5. The asset management page renders a dedicated emergency living advice section when emergency advice exists.

E2E-Exception: no new browser E2E was added because this change is deterministic service/UI rendering logic and is covered by service tests plus existing CI gates.

## High-risk Ultrareview

- Risk area: personal finance guidance and emergency cashflow advice.
- Review owner: Claude Code #1.
- Implementation owner: Codex #1 implementation lane.
- Data safety: no persistence schema changes and no external write behavior changed.
- User safety: harmful food-deprivation advice is explicitly prohibited; advice prioritizes food, health, shelter/essential continuity, creditor contact, and public/community support.
- Security: no new secrets, no direct UI Supabase writes, no RLS/migration changes.
- Rollback: revert this PR to remove the emergency advice model, UI panel, payload field, and tests.
- Observability: existing assistant summary source/status display remains unchanged.
- Prod smoke: not run locally because Dart/Flutter CLI in this workstation timed out before package resolution; PR CI is the source of truth.
- Unresolved findings: none (0). Unresolved ultrareview findings: none.

## Validation

Local checks:

- `git diff --check`: OK
- `dart format`: local Dart formatter timed out before producing output in this workstation
- `flutter analyze`: local Flutter CLI timed out before package resolution in this fresh worktree
- `flutter test`: not run locally because package resolution/Flutter CLI timed out

CI/gates should validate:

- Lint, Format, and Test
- GA readiness gate
- PR minimal E2E declaration
- Public E2E stability smoke
- Security Check
- High-risk ultrareview gate

## Notes

The local root worktree remains dirty with pre-existing files outside this PR. This PR was built from a fresh worktree and includes only the five asset-management assistant files listed in Files changed.
