### PR TITLE
Fix asset debt master scrolling and paid persistence

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -79,6 +79,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   // --- 今日18:00締切のためのチェックリスト ---
   final ScrollController _scrollController = ScrollController();
+  final ScrollController _debtMasterHorizontalScrollController =
+      ScrollController();
   final _keyStock = GlobalKey();
   final _keyFlow = GlobalKey();
   final _keySubs = GlobalKey();
@@ -280,6 +282,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
     _scrollController.dispose();
+    _debtMasterHorizontalScrollController.dispose();
     super.dispose();
   }
 
@@ -878,22 +881,24 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  Future<void> _persistAssetLiabilityMonthlyState() async {
+    await _assetLiabilityRepository.saveMonth(
+      month: _now,
+      state: AssetLiabilityMonthlyState(
+        paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
+        paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
+        paymentSourceAccountIds: Map<String, String>.from(
+          _paymentSourceAccountIds,
+        ),
+        cardBillingAccountIds: Map<String, String>.from(_cardBillingAccountIds),
+        incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
+      ),
+    );
+  }
+
   Future<void> _saveAssetLiabilityMonthlyState() async {
     try {
-      await _assetLiabilityRepository.saveMonth(
-        month: _now,
-        state: AssetLiabilityMonthlyState(
-          paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
-          paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
-          paymentSourceAccountIds: Map<String, String>.from(
-            _paymentSourceAccountIds,
-          ),
-          cardBillingAccountIds: Map<String, String>.from(
-            _cardBillingAccountIds,
-          ),
-          incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
-        ),
-      );
+      await _persistAssetLiabilityMonthlyState();
     } catch (e) {
       debugPrint('Error saving asset liability monthly state: $e');
     }
@@ -1348,7 +1353,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_saveAssetLiabilityMonthlyState());
   }
 
-  void _toggleMonthlyPaymentPaid(String accountId, bool paid) {
+  Future<void> _toggleMonthlyPaymentPaid(String accountId, bool paid) async {
+    final previousPaidAccountNames = Set<String>.from(_monthlyPaidAccountNames);
     setState(() {
       if (paid) {
         _monthlyPaidAccountNames.add(accountId);
@@ -1356,7 +1362,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _monthlyPaidAccountNames.remove(accountId);
       }
     });
-    unawaited(_saveAssetLiabilityMonthlyState());
+    try {
+      await _persistAssetLiabilityMonthlyState();
+    } catch (e) {
+      debugPrint('Error saving paid status: $e');
+      if (!mounted) return;
+      setState(() {
+        _monthlyPaidAccountNames = previousPaidAccountNames;
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('支払済み状態を保存できませんでした。')));
+    }
   }
 
   void _updatePaymentSourceAccount(
@@ -9669,57 +9686,73 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
         ),
         const SizedBox(height: 8),
-        SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: DataTable(
-            headingRowHeight: 36,
-            dataRowMinHeight: 60,
-            dataRowMaxHeight: 76,
-            columns: const [
-              DataColumn(label: Text('\u8a2d\u5b9a\u5143/\u4fdd\u5b58\u5148')),
-              DataColumn(label: Text('支払い方式')),
-              DataColumn(label: Text('項目')),
-              DataColumn(label: Text('種別')),
-              DataColumn(label: Text('残高'), numeric: true),
-              DataColumn(label: Text('支払日'), numeric: true),
-              DataColumn(label: Text('推定最低支払額'), numeric: true),
-              DataColumn(label: Text('今月支払予定額'), numeric: true),
-              DataColumn(label: Text('区分')),
-              DataColumn(label: Text('支払済み')),
-              DataColumn(label: Text('年利'), numeric: true),
-              DataColumn(label: Text('月利息'), numeric: true),
-              DataColumn(label: Text('負債割合'), numeric: true),
-            ],
-            rows: [
-              for (final row in rows)
-                DataRow(
-                  cells: [
-                    DataCell(_buildPaymentMethodScopeControl(row)),
-                    DataCell(_buildPaymentMethodDropdown(row, workbook)),
-                    DataCell(Text(row.name)),
-                    DataCell(Text(_assetKindLabel(row.kind))),
-                    DataCell(Text(_formatManagementYen(row.balance))),
-                    DataCell(
-                      Text(
-                        row.paymentDay == null ? '未設定' : '${row.paymentDay}日',
-                      ),
-                    ),
-                    DataCell(
-                      Text(_formatManagementYen(row.minimumPaymentEstimate)),
-                    ),
-                    DataCell(_buildMonthlyPaymentInput(row)),
-                    DataCell(_buildPaymentAmountSourceChip(row)),
-                    DataCell(_buildPaidCheckbox(row)),
-                    DataCell(Text(_formatManagementPercent(row.annualRate))),
-                    DataCell(
-                      Text(_formatManagementYen(row.monthlyInterestEstimate)),
-                    ),
-                    DataCell(
-                      Text(_formatManagementPercent(row.liabilityShare)),
-                    ),
-                  ],
+        Text(
+          '画面に収まらない場合は、表を横にスクロールして支払済み・年利・月利息まで確認できます。支払済みチェックは当月の状態として保存されます。',
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            fontSize: 12,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Scrollbar(
+          controller: _debtMasterHorizontalScrollController,
+          thumbVisibility: true,
+          child: SingleChildScrollView(
+            controller: _debtMasterHorizontalScrollController,
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              headingRowHeight: 36,
+              dataRowMinHeight: 60,
+              dataRowMaxHeight: 76,
+              columns: const [
+                DataColumn(
+                  label: Text('\u8a2d\u5b9a\u5143/\u4fdd\u5b58\u5148'),
                 ),
-            ],
+                DataColumn(label: Text('支払い方式')),
+                DataColumn(label: Text('項目')),
+                DataColumn(label: Text('種別')),
+                DataColumn(label: Text('残高'), numeric: true),
+                DataColumn(label: Text('支払日'), numeric: true),
+                DataColumn(label: Text('推定最低支払額'), numeric: true),
+                DataColumn(label: Text('今月支払予定額'), numeric: true),
+                DataColumn(label: Text('区分')),
+                DataColumn(label: Text('支払済み')),
+                DataColumn(label: Text('年利'), numeric: true),
+                DataColumn(label: Text('月利息'), numeric: true),
+                DataColumn(label: Text('負債割合'), numeric: true),
+              ],
+              rows: [
+                for (final row in rows)
+                  DataRow(
+                    cells: [
+                      DataCell(_buildPaymentMethodScopeControl(row)),
+                      DataCell(_buildPaymentMethodDropdown(row, workbook)),
+                      DataCell(Text(row.name)),
+                      DataCell(Text(_assetKindLabel(row.kind))),
+                      DataCell(Text(_formatManagementYen(row.balance))),
+                      DataCell(
+                        Text(
+                          row.paymentDay == null ? '未設定' : '${row.paymentDay}日',
+                        ),
+                      ),
+                      DataCell(
+                        Text(_formatManagementYen(row.minimumPaymentEstimate)),
+                      ),
+                      DataCell(_buildMonthlyPaymentInput(row)),
+                      DataCell(_buildPaymentAmountSourceChip(row)),
+                      DataCell(_buildPaidCheckbox(row)),
+                      DataCell(Text(_formatManagementPercent(row.annualRate))),
+                      DataCell(
+                        Text(_formatManagementYen(row.monthlyInterestEstimate)),
+                      ),
+                      DataCell(
+                        Text(_formatManagementPercent(row.liabilityShare)),
+                      ),
+                    ],
+                  ),
+              ],
+            ),
           ),
         ),
       ],
@@ -9878,7 +9911,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     return Checkbox(
       value: row.paid,
-      onChanged: (value) => _toggleMonthlyPaymentPaid(row.id, value ?? false),
+      onChanged: (value) {
+        unawaited(_toggleMonthlyPaymentPaid(row.id, value ?? false));
+      },
     );
   }
 

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -51,6 +51,26 @@ void main() {
       expect(loadedJune.incomePlans, isEmpty);
     });
 
+    test('clears monthly paid status after unchecked state is saved', () async {
+      await store.saveMonth(
+        month: DateTime(2026, 5, 13),
+        state: const AssetLiabilityMonthlyState(
+          paidAccountNames: <String>{'acom_card_loan'},
+        ),
+      );
+
+      final checked = await store.loadMonth(DateTime(2026, 5, 13));
+      expect(checked.paidAccountNames, contains('acom_card_loan'));
+
+      await store.saveMonth(
+        month: DateTime(2026, 5, 13),
+        state: const AssetLiabilityMonthlyState(),
+      );
+
+      final unchecked = await store.loadMonth(DateTime(2026, 5, 13));
+      expect(unchecked.paidAccountNames, isEmpty);
+    });
+
     test('keeps zero yen as a valid manual payment amount', () {
       const raw = '{"2026-05":{"PayPayカード":0,"モビット":"70,000"}}';
 


### PR DESCRIPTION
﻿## 概要

資産管理ページの負債マスタについて、画面幅が狭い場合でも右側の列を確認できるように横スクロールの導線を明示しました。

あわせて、支払済みチェックの保存処理をチェック操作時に待機し、保存失敗時は状態を元に戻して通知するようにしました。

## 主な変更

- 負債マスタに常時表示の横スクロールバーを追加
- 負債マスタに「横スクロールで支払済み・年利・月利息まで確認できる」説明を追加
- 支払済みチェックを当月状態として保存する説明を追加
- 支払済みチェック変更時は保存完了を待つように変更
- 支払済み状態の保存失敗時に元の状態へ戻し、SnackBarで通知
- 支払済み状態を解除した場合に月次保存から消えることをテスト追加

## Minimal E2E Declaration

- E2E mechanism: Playwright / integration_test 相当の black-box E2E は今回は追加していません。
- E2E-Exception: 今回は既存画面の横スクロール導線と月次保存の失敗時復旧だけを修正する小規模UI/永続化修正で、既存のサービス層テストとWeb build smokeで確認します。
- Implementation-detail independent: E2E観点は実装詳細ではなく、入力/出力として「負債マスタが横スクロールで右端列まで確認できる」「支払済みチェックが当月状態として保持される」「保存失敗時にユーザーへ通知される」を確認対象にします。
- Minimal three I/O cases:
  1. 狭い画面幅で負債マスタを開き、横スクロールにより支払済み・年利・月利息列が確認できる。
  2. 支払済みチェックをON/OFFし、当月の月次状態として保存/解除される。
  3. 保存失敗時はチェック状態が元に戻り、エラー通知が表示される。
- Local smoke: `flutter build web --no-pub` 後にローカルHTTP配信で `HTTP 200` を確認済みです。

## High-risk Ultrareview

- Review owner: Claude Code #1
- security: 金額・支払状態の保存経路は既存Repositoryのままで、secret / auth / Supabase direct write 変更はありません。
- rollback: UI表示と支払済み保存待機の小差分なので、問題時はこのPRのsquash commitをrevertすれば戻せます。
- data migration: migration / RLS / schema / 保存キー変更はありません。
- prod smoke: `flutter build web --no-pub` とローカルHTTP 200でproduction smoke相当のWeb起動確認済みです。
- observability: 保存失敗時は `debugPrint('Error saving paid status: ...')` とSnackBarで非ブロッカー通知します。
- No unresolved ultrareview findings remain. Unresolved findings: 0

## 検証

最新 `origin/main` に rebase 後、以下を確認済みです。

- `dart format --output=none --set-exit-if-changed lib/pages/asset_management_page.dart test/services/asset_liability_monthly_state_store_test.dart`: OK
- `dart analyze`: No issues found
- `flutter test --no-pub test/services/asset_liability_monthly_state_store_test.dart --reporter expanded`: 11 tests passed
- `flutter test --no-pub --reporter expanded`: 477 tests passed
- `git diff --check`: OK
- `flutter build web --no-pub`: OK
- ローカルHTTP確認: HTTP 200

## 補足

ローカル検証のため `flutter pub get` を実行した際に lockfile / platform generated files が一時的に更新されましたが、今回の修正範囲外のため差分から除外済みです。

