### PR TITLE
Add annual interest rate overrides for liabilities (UI, persistence, planning)

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -75,6 +75,7 @@ class AssetLiabilityPersistenceSnapshot {
 class AssetLiabilityMonthlyStatePayload {
   final String monthKey;
   final Map<String, double> paymentOverrides;
+  final Map<String, double> annualRateOverrides;
   final Set<String> paidAccountIds;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
@@ -83,6 +84,7 @@ class AssetLiabilityMonthlyStatePayload {
   const AssetLiabilityMonthlyStatePayload({
     required this.monthKey,
     required this.paymentOverrides,
+    required this.annualRateOverrides,
     required this.paidAccountIds,
     required this.paymentSourceAccountIds,
     required this.cardBillingAccountIds,
@@ -96,6 +98,7 @@ class AssetLiabilityMonthlyStatePayload {
     return AssetLiabilityMonthlyStatePayload(
       monthKey: monthKey,
       paymentOverrides: Map<String, double>.from(state.paymentOverrides),
+      annualRateOverrides: Map<String, double>.from(state.annualRateOverrides),
       paidAccountIds: Set<String>.from(state.paidAccountNames),
       paymentSourceAccountIds: Map<String, String>.from(
         state.paymentSourceAccountIds,
@@ -117,6 +120,9 @@ class AssetLiabilityMonthlyStatePayload {
       paymentOverrides: _readDoubleMap(json, 'payment_overrides') ??
           _readDoubleMap(json, 'paymentOverrides') ??
           const <String, double>{},
+      annualRateOverrides: _readDoubleMap(json, 'annual_rate_overrides') ??
+          _readDoubleMap(json, 'annualRateOverrides') ??
+          const <String, double>{},
       paidAccountIds: _readStringSet(json, 'paid_account_ids') ??
           _readStringSet(json, 'paidAccountIds') ??
           const <String>{},
@@ -136,6 +142,7 @@ class AssetLiabilityMonthlyStatePayload {
   AssetLiabilityMonthlyState toState() {
     return AssetLiabilityMonthlyState(
       paymentOverrides: Map<String, double>.from(paymentOverrides),
+      annualRateOverrides: Map<String, double>.from(annualRateOverrides),
       paidAccountNames: Set<String>.from(paidAccountIds),
       paymentSourceAccountIds: Map<String, String>.from(
         paymentSourceAccountIds,
@@ -154,6 +161,7 @@ class AssetLiabilityMonthlyStatePayload {
       'user_id': userId,
       'month_key': monthKey,
       'payment_overrides': Map<String, double>.from(paymentOverrides),
+      'annual_rate_overrides': Map<String, double>.from(annualRateOverrides),
       'paid_account_ids': (paidAccountIds.toList()..sort()),
       'payment_source_account_ids': Map<String, String>.from(
         paymentSourceAccountIds,

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -107,6 +107,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, AssetWatchlistEntry> _watchlistByType = {};
   final Map<String, GlobalKey> _assetRowKeys = <String, GlobalKey>{};
   Map<String, double> _monthlyPaymentOverrides = <String, double>{};
+  Map<String, double> _annualRateOverrides = <String, double>{};
   Set<String> _monthlyPaidAccountNames = <String>{};
   Map<String, String> _paymentSourceAccountIds = <String, String>{};
   Map<String, String> _cardBillingAccountIds = <String, String>{};
@@ -134,6 +135,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   List<AssetLiabilitySyncAuditLog> _assetLiabilitySyncAuditLogs =
       <AssetLiabilitySyncAuditLog>[];
   final Map<String, TextEditingController> _monthlyPaymentControllers =
+      <String, TextEditingController>{};
+  final Map<String, TextEditingController> _annualRateControllers =
       <String, TextEditingController>{};
 
   // --- グラフデータ ---
@@ -276,6 +279,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   void dispose() {
     _controllers.forEach((_, controller) => controller.dispose());
     _monthlyPaymentControllers.forEach((_, controller) => controller.dispose());
+    _annualRateControllers.forEach((_, controller) => controller.dispose());
     _flowMemoController.dispose();
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
@@ -829,6 +833,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _monthlyPaymentOverrides = Map<String, double>.from(
           state.paymentOverrides,
         );
+        _annualRateOverrides = Map<String, double>.from(
+          state.annualRateOverrides,
+        );
         _monthlyPaidAccountNames = Set<String>.from(state.paidAccountNames);
         _paymentSourceAccountIds = Map<String, String>.from(
           state.paymentSourceAccountIds,
@@ -855,6 +862,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
         _loadedAssetLiabilityMonthKey = monthKey;
         _syncMonthlyPaymentControllers();
+        _syncAnnualRateControllers();
       });
       if (generatedTemplatePlans) {
         unawaited(_saveAssetLiabilityMonthlyState());
@@ -884,6 +892,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         month: _now,
         state: AssetLiabilityMonthlyState(
           paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
+          annualRateOverrides: Map<String, double>.from(_annualRateOverrides),
           paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
           paymentSourceAccountIds: Map<String, String>.from(
             _paymentSourceAccountIds,
@@ -1193,6 +1202,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final migrated = AssetLiabilityMonthlyStateStore.migrateLegacyKeys(
       state: AssetLiabilityMonthlyState(
         paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
+        annualRateOverrides: Map<String, double>.from(_annualRateOverrides),
         paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
@@ -1237,6 +1247,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _monthlyPaymentOverrides = Map<String, double>.from(
           migrated.paymentOverrides,
         );
+        _annualRateOverrides = Map<String, double>.from(
+          migrated.annualRateOverrides,
+        );
         _monthlyPaidAccountNames = Set<String>.from(migrated.paidAccountNames);
         _paymentSourceAccountIds = Map<String, String>.from(
           migrated.paymentSourceAccountIds,
@@ -1251,6 +1264,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           migratedDefaultCardBillingAccounts,
         );
         _syncMonthlyPaymentControllers();
+        _syncAnnualRateControllers();
       });
       unawaited(_saveAssetLiabilityMonthlyState());
       unawaited(_saveDefaultPaymentSources());
@@ -1314,6 +1328,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  void _syncAnnualRateControllers() {
+    for (final entry in _annualRateControllers.entries) {
+      final hasOverride = _annualRateOverrides.containsKey(entry.key);
+      final rate = _annualRateOverrides[entry.key];
+      final text = hasOverride && rate != null ? (rate * 100).toString() : '';
+      if (entry.value.text != text) {
+        entry.value.text = text;
+      }
+    }
+  }
+
   TextEditingController _monthlyPaymentControllerFor(
     AssetLiabilityDebtRow row,
   ) {
@@ -1323,6 +1348,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         text: row.manualPaymentAmount == null
             ? ''
             : row.manualPaymentAmount!.round().toString(),
+      ),
+    );
+  }
+
+  TextEditingController _annualRateControllerFor(AssetLiabilityDebtRow row) {
+    return _annualRateControllers.putIfAbsent(
+      row.id,
+      () => TextEditingController(
+        text: _annualRateOverrides[row.id] == null
+            ? ''
+            : (_annualRateOverrides[row.id]! * 100).toString(),
       ),
     );
   }
@@ -1340,10 +1376,31 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_saveAssetLiabilityMonthlyState());
   }
 
+  void _updateAnnualRateOverride(String accountId, String rawValue) {
+    final normalized = rawValue.trim();
+    final percent = normalized.isEmpty ? null : double.tryParse(normalized);
+    setState(() {
+      if (percent == null || percent < 0) {
+        _annualRateOverrides.remove(accountId);
+      } else {
+        _annualRateOverrides[accountId] = percent / 100;
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
   void _clearMonthlyPaymentOverride(String accountId) {
     _monthlyPaymentControllers[accountId]?.clear();
     setState(() {
       _monthlyPaymentOverrides.remove(accountId);
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _clearAnnualRateOverride(String accountId) {
+    _annualRateControllers[accountId]?.clear();
+    setState(() {
+      _annualRateOverrides.remove(accountId);
     });
     unawaited(_saveAssetLiabilityMonthlyState());
   }
@@ -1498,6 +1555,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _monthlyPaymentOverrides = Map<String, double>.from(
         copied.paymentOverrides,
       );
+      _annualRateOverrides = Map<String, double>.from(
+        copied.annualRateOverrides,
+      );
       _monthlyPaidAccountNames = <String>{};
       _paymentSourceAccountIds = Map<String, String>.from(
         copied.paymentSourceAccountIds,
@@ -1507,6 +1567,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       );
       _monthlyIncomePlans = incomePlansWithTemplates;
       _syncMonthlyPaymentControllers();
+      _syncAnnualRateControllers();
     });
     unawaited(_saveAssetLiabilityMonthlyState());
     ScaffoldMessenger.of(context).showSnackBar(
@@ -6632,6 +6693,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       latestSnapshot: latestSnapshot,
       baseDate: _now,
       monthlyPaymentOverrides: _monthlyPaymentOverrides,
+      annualRateOverrides: _annualRateOverrides,
       paidAccountNames: _monthlyPaidAccountNames,
       paymentSourceAccountIds: _paymentSourceAccountIds,
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
@@ -9710,7 +9772,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     DataCell(_buildMonthlyPaymentInput(row)),
                     DataCell(_buildPaymentAmountSourceChip(row)),
                     DataCell(_buildPaidCheckbox(row)),
-                    DataCell(Text(_formatManagementPercent(row.annualRate))),
+                    DataCell(_buildAnnualRateInput(row)),
                     DataCell(
                       Text(_formatManagementYen(row.monthlyInterestEstimate)),
                     ),
@@ -9835,6 +9897,34 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   icon: const Icon(Icons.clear, size: 16),
                   onPressed: () => _clearMonthlyPaymentOverride(row.id),
                 ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAnnualRateInput(AssetLiabilityDebtRow row) {
+    final controller = _annualRateControllerFor(row);
+    return SizedBox(
+      width: 120,
+      child: TextField(
+        controller: controller,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        inputFormatters: [
+          FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+        ],
+        onChanged: (value) => _updateAnnualRateOverride(row.id, value),
+        decoration: InputDecoration(
+          isDense: true,
+          suffixText: '%',
+          helperText:
+              _annualRateOverrides.containsKey(row.id) ? '手入力を優先' : '推定',
+          suffixIcon: _annualRateOverrides.containsKey(row.id)
+              ? IconButton(
+                  tooltip: '手入力値をクリア',
+                  icon: const Icon(Icons.clear, size: 16),
+                  onPressed: () => _clearAnnualRateOverride(row.id),
+                )
+              : null,
         ),
       ),
     );

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class AssetLiabilityMonthlyState {
   final Map<String, double> paymentOverrides;
+  final Map<String, double> annualRateOverrides;
   final Set<String> paidAccountNames;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
@@ -15,6 +16,7 @@ class AssetLiabilityMonthlyState {
 
   const AssetLiabilityMonthlyState({
     this.paymentOverrides = const <String, double>{},
+    this.annualRateOverrides = const <String, double>{},
     this.paidAccountNames = const <String>{},
     this.paymentSourceAccountIds = const <String, String>{},
     this.cardBillingAccountIds = const <String, String>{},
@@ -23,6 +25,7 @@ class AssetLiabilityMonthlyState {
 
   bool get isEmpty =>
       paymentOverrides.isEmpty &&
+      annualRateOverrides.isEmpty &&
       paidAccountNames.isEmpty &&
       paymentSourceAccountIds.isEmpty &&
       cardBillingAccountIds.isEmpty &&
@@ -32,6 +35,8 @@ class AssetLiabilityMonthlyState {
 class AssetLiabilityMonthlyStateStore {
   static const String paymentPrefsKey =
       'asset_liability_monthly_payment_overrides_v1';
+  static const String annualRatePrefsKey =
+      'asset_liability_monthly_annual_rate_overrides_v1';
   static const String paidPrefsKey = 'asset_liability_paid_accounts_v1';
   static const String paymentSourcePrefsKey =
       'asset_liability_payment_source_accounts_v1';
@@ -58,6 +63,10 @@ class AssetLiabilityMonthlyStateStore {
     return AssetLiabilityMonthlyState(
       paymentOverrides: paymentOverridesForMonth(
         prefs.getString(paymentPrefsKey),
+        monthKey,
+      ),
+      annualRateOverrides: annualRateOverridesForMonth(
+        prefs.getString(annualRatePrefsKey),
         monthKey,
       ),
       paidAccountNames: paidAccountsForMonth(
@@ -103,6 +112,18 @@ class AssetLiabilityMonthlyStateStore {
     }
 
     await prefs.setString(paymentPrefsKey, jsonEncode(allPayments));
+
+    final allAnnualRates = decodePaymentOverrides(
+      prefs.getString(annualRatePrefsKey),
+    );
+    if (state.annualRateOverrides.isEmpty) {
+      allAnnualRates.remove(monthKey);
+    } else {
+      allAnnualRates[monthKey] = Map<String, double>.from(
+        state.annualRateOverrides,
+      );
+    }
+    await prefs.setString(annualRatePrefsKey, jsonEncode(allAnnualRates));
     await prefs.setString(
       paidPrefsKey,
       jsonEncode(_encodePaid(allPaidAccounts)),
@@ -283,6 +304,9 @@ class AssetLiabilityMonthlyStateStore {
     return AssetLiabilityMonthlyState(
       paymentOverrides: Map<String, double>.from(
         previousState.paymentOverrides,
+      ),
+      annualRateOverrides: Map<String, double>.from(
+        previousState.annualRateOverrides,
       ),
       paymentSourceAccountIds: Map<String, String>.from(
         previousState.paymentSourceAccountIds,
@@ -648,6 +672,15 @@ class AssetLiabilityMonthlyStateStore {
     );
   }
 
+  static Map<String, double> annualRateOverridesForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return Map<String, double>.from(
+      decodePaymentOverrides(raw)[monthKey] ?? const <String, double>{},
+    );
+  }
+
   static Set<String> paidAccountsForMonth(String? raw, String monthKey) {
     return Set<String>.from(
       decodePaidAccounts(raw)[monthKey] ?? const <String>{},
@@ -695,6 +728,16 @@ class AssetLiabilityMonthlyStateStore {
       }
     }
 
+    final migratedAnnualRates = <String, double>{};
+    for (final entry in state.annualRateOverrides.entries) {
+      final migratedKey = legacyKeyToAccountId[entry.key] ?? entry.key;
+      if (legacyKeyToAccountId.containsKey(entry.key)) {
+        migratedAnnualRates.putIfAbsent(migratedKey, () => entry.value);
+      } else {
+        migratedAnnualRates[migratedKey] = entry.value;
+      }
+    }
+
     final migratedPaidAccounts = <String>{};
     for (final accountKey in state.paidAccountNames) {
       migratedPaidAccounts.add(legacyKeyToAccountId[accountKey] ?? accountKey);
@@ -716,6 +759,7 @@ class AssetLiabilityMonthlyStateStore {
 
     return AssetLiabilityMonthlyState(
       paymentOverrides: migratedPayments,
+      annualRateOverrides: migratedAnnualRates,
       paidAccountNames: migratedPaidAccounts,
       paymentSourceAccountIds: migratedPaymentSources,
       cardBillingAccountIds: migratedCardBillingAccounts,

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -48,6 +48,7 @@ class AssetLiabilityPlanningService {
     required Map<String, double> latestSnapshot,
     required DateTime baseDate,
     Map<String, double> monthlyPaymentOverrides = const <String, double>{},
+    Map<String, double> annualRateOverrides = const <String, double>{},
     Set<String> paidAccountNames = const <String>{},
     Map<String, String> paymentSourceAccountIds = const <String, String>{},
     Map<String, String> defaultPaymentSourceAccountIds =
@@ -73,6 +74,12 @@ class AssetLiabilityPlanningService {
           (entry) => _classifyAccount(
             name: entry.key.trim(),
             balance: entry.value,
+          ),
+        )
+        .map(
+          (account) => _withAnnualRateOverride(
+            account: account,
+            annualRateOverrides: annualRateOverrides,
           ),
         )
         .toList()
@@ -212,6 +219,34 @@ class AssetLiabilityPlanningService {
           liabilityTotal == 0 ? 0 : topFourDebtTotal / liabilityTotal.abs(),
       manualPaymentCount: manualPaymentCount,
       estimatedPaymentCount: estimatedPaymentCount,
+    );
+  }
+
+  AssetLiabilityAccount _withAnnualRateOverride({
+    required AssetLiabilityAccount account,
+    required Map<String, double> annualRateOverrides,
+  }) {
+    final overriddenRate = annualRateOverrides[account.id];
+    if (overriddenRate == null || overriddenRate < 0) {
+      return account;
+    }
+    return AssetLiabilityAccount(
+      id: account.id,
+      name: account.name,
+      kind: account.kind,
+      balance: account.balance,
+      paymentDay: account.paymentDay,
+      paymentSourceAccountName: account.paymentSourceAccountName,
+      paymentMethod: account.paymentMethod,
+      paymentMethodLabel: account.paymentMethodLabel,
+      paymentMethodSettingSource: account.paymentMethodSettingSource,
+      billingAccountId: account.billingAccountId,
+      billingAccountName: account.billingAccountName,
+      includedInBillingAccount: account.includedInBillingAccount,
+      annualRate: overriddenRate,
+      minimumPaymentRate: account.minimumPaymentRate,
+      minimumPaymentFloor: account.minimumPaymentFloor,
+      fullPaymentEstimate: account.fullPaymentEstimate,
     );
   }
 


### PR DESCRIPTION
### Motivation
- Allow users to override annual interest rates per liability so the workbook and calculations can use user-provided rates instead of estimates.
- Persist user-entered annual rate overrides across months and sync them with Supabase and local preferences.

### Description
- Add `annualRateOverrides` to `AssetLiabilityMonthlyState` and thread it through `AssetLiabilityMonthlyStateStore`, including a new prefs key `asset_liability_monthly_annual_rate_overrides_v1` and `annualRateOverridesForMonth` helper.
- Extend Supabase payloads in `asset_liability_persistence.dart` to read and write `annual_rate_overrides` and convert between payload/state.
- Update `AssetManagementPage` to store `_annualRateOverrides`, manage `_annualRateControllers`, sync controllers, provide `_annualRateControllerFor`, `_updateAnnualRateOverride`, `_clearAnnualRateOverride`, `_syncAnnualRateControllers`, integration with migration/copy/save/load flows, and render an annual rate input column with `_buildAnnualRateInput` in the liabilities table.
- Make the planning logic use overrides by passing `annualRateOverrides` into `AssetLiabilityPlanningService.buildWorkbook` and applying overrides to `AssetLiabilityAccount` via `_withAnnualRateOverride`.

### Testing
- Ran static analysis with `flutter analyze` and the existing test suite via `flutter test`; both completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0871e966208328888516ebd62934cd)