### PR TITLE
feat(asset): track planned actual payment differences (#2450)

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -77,6 +77,8 @@ class AssetLiabilityPersistenceSnapshot {
 class AssetLiabilityMonthlyStatePayload {
   final String monthKey;
   final Map<String, double> paymentOverrides;
+  final Map<String, double> actualPaymentAmounts;
+  final Map<String, String> paymentDifferenceReasons;
   final Set<String> paidAccountIds;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
@@ -85,6 +87,8 @@ class AssetLiabilityMonthlyStatePayload {
   const AssetLiabilityMonthlyStatePayload({
     required this.monthKey,
     required this.paymentOverrides,
+    required this.actualPaymentAmounts,
+    required this.paymentDifferenceReasons,
     required this.paidAccountIds,
     required this.paymentSourceAccountIds,
     required this.cardBillingAccountIds,
@@ -98,6 +102,12 @@ class AssetLiabilityMonthlyStatePayload {
     return AssetLiabilityMonthlyStatePayload(
       monthKey: monthKey,
       paymentOverrides: Map<String, double>.from(state.paymentOverrides),
+      actualPaymentAmounts: Map<String, double>.from(
+        state.actualPaymentAmounts,
+      ),
+      paymentDifferenceReasons: Map<String, String>.from(
+        state.paymentDifferenceReasons,
+      ),
       paidAccountIds: Set<String>.from(state.paidAccountNames),
       paymentSourceAccountIds: Map<String, String>.from(
         state.paymentSourceAccountIds,
@@ -119,6 +129,13 @@ class AssetLiabilityMonthlyStatePayload {
       paymentOverrides: _readDoubleMap(json, 'payment_overrides') ??
           _readDoubleMap(json, 'paymentOverrides') ??
           const <String, double>{},
+      actualPaymentAmounts: _readDoubleMap(json, 'actual_payment_amounts') ??
+          _readDoubleMap(json, 'actualPaymentAmounts') ??
+          const <String, double>{},
+      paymentDifferenceReasons:
+          _readStringMap(json, 'payment_difference_reasons') ??
+              _readStringMap(json, 'paymentDifferenceReasons') ??
+              const <String, String>{},
       paidAccountIds: _readStringSet(json, 'paid_account_ids') ??
           _readStringSet(json, 'paidAccountIds') ??
           const <String>{},
@@ -138,6 +155,10 @@ class AssetLiabilityMonthlyStatePayload {
   AssetLiabilityMonthlyState toState() {
     return AssetLiabilityMonthlyState(
       paymentOverrides: Map<String, double>.from(paymentOverrides),
+      actualPaymentAmounts: Map<String, double>.from(actualPaymentAmounts),
+      paymentDifferenceReasons: Map<String, String>.from(
+        paymentDifferenceReasons,
+      ),
       paidAccountNames: Set<String>.from(paidAccountIds),
       paymentSourceAccountIds: Map<String, String>.from(
         paymentSourceAccountIds,
@@ -156,6 +177,12 @@ class AssetLiabilityMonthlyStatePayload {
       'user_id': userId,
       'month_key': monthKey,
       'payment_overrides': Map<String, double>.from(paymentOverrides),
+      'actual_payment_amounts': Map<String, double>.from(
+        actualPaymentAmounts,
+      ),
+      'payment_difference_reasons': Map<String, String>.from(
+        paymentDifferenceReasons,
+      ),
       'paid_account_ids': (paidAccountIds.toList()..sort()),
       'payment_source_account_ids': Map<String, String>.from(
         paymentSourceAccountIds,
@@ -262,6 +289,16 @@ class AssetLiabilityMonthlySnapshotPayload {
             _readDouble(json, 'monthly_unpaid_payment_total') ??
                 _readDouble(json, 'monthlyUnpaidPaymentTotal') ??
                 0,
+        monthlyActualPaymentTotal:
+            _readDouble(json, 'monthly_actual_payment_total') ??
+                _readDouble(json, 'monthlyActualPaymentTotal') ??
+                _readDouble(json, 'monthly_paid_payment_total') ??
+                _readDouble(json, 'monthlyPaidPaymentTotal') ??
+                0,
+        monthlyPaymentDifferenceTotal:
+            _readDouble(json, 'monthly_payment_difference_total') ??
+                _readDouble(json, 'monthlyPaymentDifferenceTotal') ??
+                0,
         overduePaymentCount: _readInt(json, 'overdue_payment_count') ??
             _readInt(json, 'overduePaymentCount') ??
             0,
@@ -285,6 +322,9 @@ class AssetLiabilityMonthlySnapshotPayload {
       'monthly_scheduled_payment_total': snapshot.monthlyScheduledPaymentTotal,
       'monthly_paid_payment_total': snapshot.monthlyPaidPaymentTotal,
       'monthly_unpaid_payment_total': snapshot.monthlyUnpaidPaymentTotal,
+      'monthly_actual_payment_total': snapshot.monthlyActualPaymentTotal,
+      'monthly_payment_difference_total':
+          snapshot.monthlyPaymentDifferenceTotal,
       'overdue_payment_count': snapshot.overduePaymentCount,
       if (timestamp != null) 'updated_at': timestamp,
     };

--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -79,6 +79,8 @@ class AssetLiabilityDebtRow {
   final double minimumPaymentEstimate;
   final double? manualPaymentAmount;
   final double scheduledPaymentAmount;
+  final double? actualPaymentAmount;
+  final String? paymentDifferenceReason;
   final double monthlyInterestEstimate;
   final double principalPaymentEstimate;
   final double balanceAfterPaymentEstimate;
@@ -105,6 +107,8 @@ class AssetLiabilityDebtRow {
     required this.minimumPaymentEstimate,
     required this.manualPaymentAmount,
     required this.scheduledPaymentAmount,
+    this.actualPaymentAmount,
+    this.paymentDifferenceReason,
     required this.monthlyInterestEstimate,
     required this.principalPaymentEstimate,
     required this.balanceAfterPaymentEstimate,
@@ -117,6 +121,16 @@ class AssetLiabilityDebtRow {
   bool get isDirectCashflowTarget =>
       !includedInBillingAccount &&
       paymentMethod == AssetLiabilityPaymentMethod.direct;
+
+  double get effectivePaidPaymentAmount =>
+      paid ? actualPaymentAmount ?? scheduledPaymentAmount : 0;
+
+  double? get paymentDifferenceAmount {
+    if (!paid || actualPaymentAmount == null) {
+      return null;
+    }
+    return actualPaymentAmount! - scheduledPaymentAmount;
+  }
 }
 
 class AssetLiabilityPaymentDayRisk {
@@ -212,6 +226,9 @@ class AssetLiabilityCashflowRow {
   final String? billingAccountName;
   final bool includedInBillingAccount;
   final double paymentAmount;
+  final double? actualPaymentAmount;
+  final double? paymentDifferenceAmount;
+  final String? paymentDifferenceReason;
   final bool paymentAmountEstimated;
   final bool paid;
   final bool received;
@@ -237,6 +254,9 @@ class AssetLiabilityCashflowRow {
     required this.billingAccountName,
     required this.includedInBillingAccount,
     required this.paymentAmount,
+    this.actualPaymentAmount,
+    this.paymentDifferenceAmount,
+    this.paymentDifferenceReason,
     required this.paymentAmountEstimated,
     required this.paid,
     required this.received,
@@ -304,6 +324,8 @@ class AssetLiabilityMonthlySnapshot {
   final double monthlyScheduledPaymentTotal;
   final double monthlyPaidPaymentTotal;
   final double monthlyUnpaidPaymentTotal;
+  final double monthlyActualPaymentTotal;
+  final double monthlyPaymentDifferenceTotal;
   final int overduePaymentCount;
 
   const AssetLiabilityMonthlySnapshot({
@@ -316,6 +338,8 @@ class AssetLiabilityMonthlySnapshot {
     required this.monthlyScheduledPaymentTotal,
     required this.monthlyPaidPaymentTotal,
     required this.monthlyUnpaidPaymentTotal,
+    this.monthlyActualPaymentTotal = 0,
+    this.monthlyPaymentDifferenceTotal = 0,
     required this.overduePaymentCount,
   });
 }
@@ -493,6 +517,8 @@ class AssetLiabilityWorkbook {
   final double netWorth;
   final double monthlyMinimumPaymentEstimateTotal;
   final double monthlyScheduledPaymentTotal;
+  final double monthlyActualPaymentTotal;
+  final double monthlyPaymentDifferenceTotal;
   final double monthlyUnpaidPaymentTotal;
   final double monthlyUnreceivedIncomeTotal;
   final double cashAfterMinimumPayments;
@@ -520,6 +546,8 @@ class AssetLiabilityWorkbook {
     required this.netWorth,
     required this.monthlyMinimumPaymentEstimateTotal,
     required this.monthlyScheduledPaymentTotal,
+    required this.monthlyActualPaymentTotal,
+    required this.monthlyPaymentDifferenceTotal,
     required this.monthlyUnpaidPaymentTotal,
     required this.monthlyUnreceivedIncomeTotal,
     required this.cashAfterMinimumPayments,

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -109,6 +109,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, AssetWatchlistEntry> _watchlistByType = {};
   final Map<String, GlobalKey> _assetRowKeys = <String, GlobalKey>{};
   Map<String, double> _monthlyPaymentOverrides = <String, double>{};
+  Map<String, double> _actualPaymentAmounts = <String, double>{};
+  Map<String, String> _paymentDifferenceReasons = <String, String>{};
   Set<String> _monthlyPaidAccountNames = <String>{};
   Map<String, String> _paymentSourceAccountIds = <String, String>{};
   Map<String, String> _cardBillingAccountIds = <String, String>{};
@@ -136,6 +138,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   List<AssetLiabilitySyncAuditLog> _assetLiabilitySyncAuditLogs =
       <AssetLiabilitySyncAuditLog>[];
   final Map<String, TextEditingController> _monthlyPaymentControllers =
+      <String, TextEditingController>{};
+  final Map<String, TextEditingController> _actualPaymentControllers =
+      <String, TextEditingController>{};
+  final Map<String, TextEditingController> _paymentDifferenceReasonControllers =
       <String, TextEditingController>{};
 
   // --- グラフデータ ---
@@ -278,6 +284,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   void dispose() {
     _controllers.forEach((_, controller) => controller.dispose());
     _monthlyPaymentControllers.forEach((_, controller) => controller.dispose());
+    _actualPaymentControllers.forEach((_, controller) => controller.dispose());
+    _paymentDifferenceReasonControllers.forEach(
+      (_, controller) => controller.dispose(),
+    );
     _flowMemoController.dispose();
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
@@ -832,6 +842,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _monthlyPaymentOverrides = Map<String, double>.from(
           state.paymentOverrides,
         );
+        _actualPaymentAmounts = Map<String, double>.from(
+          state.actualPaymentAmounts,
+        );
+        _paymentDifferenceReasons = Map<String, String>.from(
+          state.paymentDifferenceReasons,
+        );
         _monthlyPaidAccountNames = Set<String>.from(state.paidAccountNames);
         _paymentSourceAccountIds = Map<String, String>.from(
           state.paymentSourceAccountIds,
@@ -857,7 +873,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           syncAuditLogs,
         );
         _loadedAssetLiabilityMonthKey = monthKey;
-        _syncMonthlyPaymentControllers();
+        _syncPaymentStateControllers();
       });
       if (generatedTemplatePlans) {
         unawaited(_saveAssetLiabilityMonthlyState());
@@ -886,6 +902,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       month: _now,
       state: AssetLiabilityMonthlyState(
         paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
+        actualPaymentAmounts: Map<String, double>.from(_actualPaymentAmounts),
+        paymentDifferenceReasons: Map<String, String>.from(
+          _paymentDifferenceReasons,
+        ),
         paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
@@ -1198,6 +1218,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final migrated = AssetLiabilityMonthlyStateStore.migrateLegacyKeys(
       state: AssetLiabilityMonthlyState(
         paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
+        actualPaymentAmounts: Map<String, double>.from(_actualPaymentAmounts),
+        paymentDifferenceReasons: Map<String, String>.from(
+          _paymentDifferenceReasons,
+        ),
         paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
@@ -1216,6 +1240,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       legacyKeyToAccountId,
     );
     if (_sameDoubleMap(_monthlyPaymentOverrides, migrated.paymentOverrides) &&
+        _sameDoubleMap(_actualPaymentAmounts, migrated.actualPaymentAmounts) &&
+        _sameStringMap(
+          _paymentDifferenceReasons,
+          migrated.paymentDifferenceReasons,
+        ) &&
         _sameStringSet(_monthlyPaidAccountNames, migrated.paidAccountNames) &&
         _sameStringMap(
           _paymentSourceAccountIds,
@@ -1242,6 +1271,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _monthlyPaymentOverrides = Map<String, double>.from(
           migrated.paymentOverrides,
         );
+        _actualPaymentAmounts = Map<String, double>.from(
+          migrated.actualPaymentAmounts,
+        );
+        _paymentDifferenceReasons = Map<String, String>.from(
+          migrated.paymentDifferenceReasons,
+        );
         _monthlyPaidAccountNames = Set<String>.from(migrated.paidAccountNames);
         _paymentSourceAccountIds = Map<String, String>.from(
           migrated.paymentSourceAccountIds,
@@ -1255,7 +1290,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _defaultCardBillingAccountIds = Map<String, String>.from(
           migratedDefaultCardBillingAccounts,
         );
-        _syncMonthlyPaymentControllers();
+        _syncPaymentStateControllers();
       });
       unawaited(_saveAssetLiabilityMonthlyState());
       unawaited(_saveDefaultPaymentSources());
@@ -1307,12 +1342,38 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return true;
   }
 
+  void _syncPaymentStateControllers() {
+    _syncMonthlyPaymentControllers();
+    _syncActualPaymentControllers();
+    _syncPaymentDifferenceReasonControllers();
+  }
+
   void _syncMonthlyPaymentControllers() {
     for (final entry in _monthlyPaymentControllers.entries) {
       final hasOverride = _monthlyPaymentOverrides.containsKey(entry.key);
       final amount = _monthlyPaymentOverrides[entry.key];
       final text =
           hasOverride && amount != null ? amount.round().toString() : '';
+      if (entry.value.text != text) {
+        entry.value.text = text;
+      }
+    }
+  }
+
+  void _syncActualPaymentControllers() {
+    for (final entry in _actualPaymentControllers.entries) {
+      final hasAmount = _actualPaymentAmounts.containsKey(entry.key);
+      final amount = _actualPaymentAmounts[entry.key];
+      final text = hasAmount && amount != null ? amount.round().toString() : '';
+      if (entry.value.text != text) {
+        entry.value.text = text;
+      }
+    }
+  }
+
+  void _syncPaymentDifferenceReasonControllers() {
+    for (final entry in _paymentDifferenceReasonControllers.entries) {
+      final text = _paymentDifferenceReasons[entry.key] ?? '';
       if (entry.value.text != text) {
         entry.value.text = text;
       }
@@ -1329,6 +1390,28 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ? ''
             : row.manualPaymentAmount!.round().toString(),
       ),
+    );
+  }
+
+  TextEditingController _actualPaymentControllerFor(
+    AssetLiabilityDebtRow row,
+  ) {
+    return _actualPaymentControllers.putIfAbsent(
+      row.id,
+      () => TextEditingController(
+        text: row.actualPaymentAmount == null
+            ? ''
+            : row.actualPaymentAmount!.round().toString(),
+      ),
+    );
+  }
+
+  TextEditingController _paymentDifferenceReasonControllerFor(
+    AssetLiabilityDebtRow row,
+  ) {
+    return _paymentDifferenceReasonControllers.putIfAbsent(
+      row.id,
+      () => TextEditingController(text: row.paymentDifferenceReason ?? ''),
     );
   }
 
@@ -1353,13 +1436,50 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_saveAssetLiabilityMonthlyState());
   }
 
-  Future<void> _toggleMonthlyPaymentPaid(String accountId, bool paid) async {
+  void _updateActualPaymentAmount(String accountId, String rawValue) {
+    final normalized = rawValue.replaceAll(',', '').trim();
+    final amount = normalized.isEmpty ? null : double.tryParse(normalized);
+    setState(() {
+      if (amount == null || amount < 0) {
+        _actualPaymentAmounts.remove(accountId);
+      } else {
+        _actualPaymentAmounts[accountId] = amount;
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _updatePaymentDifferenceReason(String accountId, String rawValue) {
+    final reason = rawValue.trim();
+    setState(() {
+      if (reason.isEmpty) {
+        _paymentDifferenceReasons.remove(accountId);
+      } else {
+        _paymentDifferenceReasons[accountId] = reason;
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  Future<void> _toggleMonthlyPaymentPaid(
+    AssetLiabilityDebtRow row,
+    bool paid,
+  ) async {
     final previousPaidAccountNames = Set<String>.from(_monthlyPaidAccountNames);
+    final previousActualPaymentAmounts = Map<String, double>.from(
+      _actualPaymentAmounts,
+    );
     setState(() {
       if (paid) {
-        _monthlyPaidAccountNames.add(accountId);
+        _monthlyPaidAccountNames.add(row.id);
+        _actualPaymentAmounts.putIfAbsent(
+          row.id,
+          () => row.scheduledPaymentAmount,
+        );
+        _actualPaymentControllers[row.id]?.text =
+            _actualPaymentAmounts[row.id]!.round().toString();
       } else {
-        _monthlyPaidAccountNames.remove(accountId);
+        _monthlyPaidAccountNames.remove(row.id);
       }
     });
     try {
@@ -1369,6 +1489,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (!mounted) return;
       setState(() {
         _monthlyPaidAccountNames = previousPaidAccountNames;
+        _actualPaymentAmounts = previousActualPaymentAmounts;
+        _syncActualPaymentControllers();
       });
       ScaffoldMessenger.of(
         context,
@@ -1515,6 +1637,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _monthlyPaymentOverrides = Map<String, double>.from(
         copied.paymentOverrides,
       );
+      _actualPaymentAmounts = <String, double>{};
+      _paymentDifferenceReasons = <String, String>{};
       _monthlyPaidAccountNames = <String>{};
       _paymentSourceAccountIds = Map<String, String>.from(
         copied.paymentSourceAccountIds,
@@ -1523,7 +1647,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         copied.cardBillingAccountIds,
       );
       _monthlyIncomePlans = incomePlansWithTemplates;
-      _syncMonthlyPaymentControllers();
+      _syncPaymentStateControllers();
     });
     unawaited(_saveAssetLiabilityMonthlyState());
     ScaffoldMessenger.of(context).showSnackBar(
@@ -6649,6 +6773,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       latestSnapshot: latestSnapshot,
       baseDate: _now,
       monthlyPaymentOverrides: _monthlyPaymentOverrides,
+      actualPaymentAmounts: _actualPaymentAmounts,
+      paymentDifferenceReasons: _paymentDifferenceReasons,
       paidAccountNames: _monthlyPaidAccountNames,
       paymentSourceAccountIds: _paymentSourceAccountIds,
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
@@ -9537,6 +9663,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   DataColumn(label: Text('実支払済み'), numeric: true),
                   DataColumn(label: Text('未払い'), numeric: true),
                   DataColumn(label: Text('期限超過'), numeric: true),
+                  DataColumn(label: Text('actual paid'), numeric: true),
+                  DataColumn(label: Text('planned/actual diff'), numeric: true),
                 ],
                 rows: [
                   for (final comparison in comparisons)
@@ -9611,6 +9739,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                           Text(
                             _formatManagementYen(
                               comparison.snapshot.monthlyUnpaidPaymentTotal,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementYen(
+                              comparison.snapshot.monthlyActualPaymentTotal,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            _formatManagementYen(
+                              comparison.snapshot.monthlyPaymentDifferenceTotal,
                             ),
                           ),
                         ),
@@ -9706,6 +9848,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               dataRowMinHeight: 60,
               dataRowMaxHeight: 76,
               columns: const [
+                DataColumn(label: Text('actual payment'), numeric: true),
+                DataColumn(label: Text('difference'), numeric: true),
+                DataColumn(label: Text('difference reason')),
                 DataColumn(
                   label: Text('\u8a2d\u5b9a\u5143/\u4fdd\u5b58\u5148'),
                 ),
@@ -9726,6 +9871,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 for (final row in rows)
                   DataRow(
                     cells: [
+                      DataCell(_buildActualPaymentInput(row)),
+                      DataCell(_buildPaymentDifferenceCell(row)),
+                      DataCell(_buildPaymentDifferenceReasonInput(row)),
                       DataCell(_buildPaymentMethodScopeControl(row)),
                       DataCell(_buildPaymentMethodDropdown(row, workbook)),
                       DataCell(Text(row.name)),
@@ -9873,6 +10021,81 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  Widget _buildActualPaymentInput(AssetLiabilityDebtRow row) {
+    if (row.includedInBillingAccount) {
+      return _buildTextStatusChip(
+        label: AssetLiabilityPlanningService.cardBillingIncludedLabel,
+        color: const Color(0xFF2563EB),
+      );
+    }
+    final controller = _actualPaymentControllerFor(row);
+    return SizedBox(
+      width: 140,
+      child: TextField(
+        controller: controller,
+        enabled: row.paid,
+        keyboardType: TextInputType.number,
+        inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9,]'))],
+        onChanged: (value) => _updateActualPaymentAmount(row.id, value),
+        decoration: InputDecoration(
+          isDense: true,
+          hintText: row.paid
+              ? _formatManagementYen(row.scheduledPaymentAmount)
+              : 'paid only',
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPaymentDifferenceCell(AssetLiabilityDebtRow row) {
+    if (row.includedInBillingAccount) {
+      return const Text('-');
+    }
+    final difference = row.paymentDifferenceAmount;
+    if (difference == null) {
+      return Text(
+        row.paid ? _formatManagementYen(0) : '-',
+        style: TextStyle(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+          fontSize: 12,
+        ),
+      );
+    }
+    final color = difference == 0
+        ? const Color(0xFF64748B)
+        : difference > 0
+            ? const Color(0xFFDC2626)
+            : const Color(0xFF0D9488);
+    final prefix = difference > 0 ? '+' : '';
+    return Text(
+      '$prefix${_formatManagementYen(difference)}',
+      style: TextStyle(
+        color: color,
+        fontWeight: FontWeight.bold,
+        fontSize: 12,
+      ),
+    );
+  }
+
+  Widget _buildPaymentDifferenceReasonInput(AssetLiabilityDebtRow row) {
+    if (row.includedInBillingAccount) {
+      return const Text('-');
+    }
+    final controller = _paymentDifferenceReasonControllerFor(row);
+    return SizedBox(
+      width: 190,
+      child: TextField(
+        controller: controller,
+        enabled: row.paid,
+        onChanged: (value) => _updatePaymentDifferenceReason(row.id, value),
+        decoration: const InputDecoration(
+          isDense: true,
+          hintText: 'reason',
+        ),
+      ),
+    );
+  }
+
   Widget _buildPaymentAmountSourceChip(AssetLiabilityDebtRow row) {
     if (row.includedInBillingAccount) {
       return _buildTextStatusChip(
@@ -9912,7 +10135,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return Checkbox(
       value: row.paid,
       onChanged: (value) {
-        unawaited(_toggleMonthlyPaymentPaid(row.id, value ?? false));
+        unawaited(_toggleMonthlyPaymentPaid(row, value ?? false));
       },
     );
   }

--- a/lib/services/asset_liability_history_service.dart
+++ b/lib/services/asset_liability_history_service.dart
@@ -14,7 +14,13 @@ class AssetLiabilityHistoryService {
     final paidPaymentTotal = workbook.debtMasterRows.fold<double>(
       0,
       (sum, row) => row.isDirectCashflowTarget && row.paid
-          ? sum + row.scheduledPaymentAmount
+          ? sum + row.effectivePaidPaymentAmount
+          : sum,
+    );
+    final paymentDifferenceTotal = workbook.debtMasterRows.fold<double>(
+      0,
+      (sum, row) => row.isDirectCashflowTarget
+          ? sum + (row.paymentDifferenceAmount ?? 0)
           : sum,
     );
     final overduePaymentCount = workbook.cashflowRows
@@ -31,6 +37,8 @@ class AssetLiabilityHistoryService {
       monthlyScheduledPaymentTotal: workbook.monthlyScheduledPaymentTotal,
       monthlyPaidPaymentTotal: paidPaymentTotal,
       monthlyUnpaidPaymentTotal: workbook.monthlyUnpaidPaymentTotal,
+      monthlyActualPaymentTotal: workbook.monthlyActualPaymentTotal,
+      monthlyPaymentDifferenceTotal: paymentDifferenceTotal,
       overduePaymentCount: overduePaymentCount,
     );
   }
@@ -157,6 +165,8 @@ class AssetLiabilityHistoryService {
         '実支払済み総額',
         '未払い総額',
         '期限超過件数',
+        'actual_paid_payment_total',
+        'payment_difference_total',
       ],
       for (final snapshot in sorted)
         <Object?>[
@@ -170,6 +180,8 @@ class AssetLiabilityHistoryService {
           snapshot.monthlyPaidPaymentTotal,
           snapshot.monthlyUnpaidPaymentTotal,
           snapshot.overduePaymentCount,
+          snapshot.monthlyActualPaymentTotal,
+          snapshot.monthlyPaymentDifferenceTotal,
         ],
     ]);
   }
@@ -200,6 +212,9 @@ class AssetLiabilityHistoryService {
         '支払済み',
         '期限超過',
         '支払後手元資金',
+        'actual_payment_amount',
+        'payment_difference_amount',
+        'payment_difference_reason',
       ],
       for (final row in rows)
         <Object?>[
@@ -229,6 +244,9 @@ class AssetLiabilityHistoryService {
               : (row.paid ? '済' : '未済'),
           row.overdue ? '期限超過' : '',
           row.cashAfterPayment,
+          row.actualPaymentAmount ?? '',
+          row.paymentDifferenceAmount ?? '',
+          row.paymentDifferenceReason ?? '',
         ],
     ]);
   }

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -8,6 +8,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class AssetLiabilityMonthlyState {
   final Map<String, double> paymentOverrides;
+  final Map<String, double> actualPaymentAmounts;
+  final Map<String, String> paymentDifferenceReasons;
   final Set<String> paidAccountNames;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
@@ -15,6 +17,8 @@ class AssetLiabilityMonthlyState {
 
   const AssetLiabilityMonthlyState({
     this.paymentOverrides = const <String, double>{},
+    this.actualPaymentAmounts = const <String, double>{},
+    this.paymentDifferenceReasons = const <String, String>{},
     this.paidAccountNames = const <String>{},
     this.paymentSourceAccountIds = const <String, String>{},
     this.cardBillingAccountIds = const <String, String>{},
@@ -23,6 +27,8 @@ class AssetLiabilityMonthlyState {
 
   bool get isEmpty =>
       paymentOverrides.isEmpty &&
+      actualPaymentAmounts.isEmpty &&
+      paymentDifferenceReasons.isEmpty &&
       paidAccountNames.isEmpty &&
       paymentSourceAccountIds.isEmpty &&
       cardBillingAccountIds.isEmpty &&
@@ -32,6 +38,10 @@ class AssetLiabilityMonthlyState {
 class AssetLiabilityMonthlyStateStore {
   static const String paymentPrefsKey =
       'asset_liability_monthly_payment_overrides_v1';
+  static const String actualPaymentPrefsKey =
+      'asset_liability_monthly_actual_payments_v1';
+  static const String paymentDifferenceReasonPrefsKey =
+      'asset_liability_monthly_payment_difference_reasons_v1';
   static const String paidPrefsKey = 'asset_liability_paid_accounts_v1';
   static const String paymentSourcePrefsKey =
       'asset_liability_payment_source_accounts_v1';
@@ -58,6 +68,14 @@ class AssetLiabilityMonthlyStateStore {
     return AssetLiabilityMonthlyState(
       paymentOverrides: paymentOverridesForMonth(
         prefs.getString(paymentPrefsKey),
+        monthKey,
+      ),
+      actualPaymentAmounts: actualPaymentAmountsForMonth(
+        prefs.getString(actualPaymentPrefsKey),
+        monthKey,
+      ),
+      paymentDifferenceReasons: paymentDifferenceReasonsForMonth(
+        prefs.getString(paymentDifferenceReasonPrefsKey),
         monthKey,
       ),
       paidAccountNames: paidAccountsForMonth(
@@ -95,6 +113,28 @@ class AssetLiabilityMonthlyStateStore {
       allPayments[monthKey] = Map<String, double>.from(state.paymentOverrides);
     }
 
+    final allActualPayments = decodePaymentOverrides(
+      prefs.getString(actualPaymentPrefsKey),
+    );
+    if (state.actualPaymentAmounts.isEmpty) {
+      allActualPayments.remove(monthKey);
+    } else {
+      allActualPayments[monthKey] = Map<String, double>.from(
+        state.actualPaymentAmounts,
+      );
+    }
+
+    final allPaymentDifferenceReasons = decodePaymentDifferenceReasons(
+      prefs.getString(paymentDifferenceReasonPrefsKey),
+    );
+    if (state.paymentDifferenceReasons.isEmpty) {
+      allPaymentDifferenceReasons.remove(monthKey);
+    } else {
+      allPaymentDifferenceReasons[monthKey] = Map<String, String>.from(
+        state.paymentDifferenceReasons,
+      );
+    }
+
     final allPaidAccounts = decodePaidAccounts(prefs.getString(paidPrefsKey));
     if (state.paidAccountNames.isEmpty) {
       allPaidAccounts.remove(monthKey);
@@ -103,6 +143,11 @@ class AssetLiabilityMonthlyStateStore {
     }
 
     await prefs.setString(paymentPrefsKey, jsonEncode(allPayments));
+    await prefs.setString(actualPaymentPrefsKey, jsonEncode(allActualPayments));
+    await prefs.setString(
+      paymentDifferenceReasonPrefsKey,
+      jsonEncode(allPaymentDifferenceReasons),
+    );
     await prefs.setString(
       paidPrefsKey,
       jsonEncode(_encodePaid(allPaidAccounts)),
@@ -373,6 +418,32 @@ class AssetLiabilityMonthlyStateStore {
     });
   }
 
+  static Map<String, Map<String, String>> decodePaymentDifferenceReasons(
+    String? raw,
+  ) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, Map<String, String>>{};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return <String, Map<String, String>>{};
+    }
+
+    return decoded.map<String, Map<String, String>>((month, values) {
+      final monthKey = month.toString();
+      final reasons = <String, String>{};
+      if (values is Map) {
+        for (final entry in values.entries) {
+          final reason = entry.value.toString().trim();
+          if (reason.isNotEmpty) {
+            reasons[entry.key.toString()] = reason;
+          }
+        }
+      }
+      return MapEntry(monthKey, reasons);
+    });
+  }
+
   static Map<String, Set<String>> decodePaidAccounts(String? raw) {
     if (raw == null || raw.trim().isEmpty) {
       return <String, Set<String>>{};
@@ -578,6 +649,12 @@ class AssetLiabilityMonthlyStateStore {
       final monthlyUnpaidPaymentTotal = _parseNonNullDouble(
         rawSnapshot['monthlyUnpaidPaymentTotal'],
       );
+      final monthlyActualPaymentTotal = _parseNonNullDouble(
+        rawSnapshot['monthlyActualPaymentTotal'],
+      );
+      final monthlyPaymentDifferenceTotal = _parseNonNullDouble(
+        rawSnapshot['monthlyPaymentDifferenceTotal'],
+      );
       final overduePaymentCount = _parseNonNullInt(
         rawSnapshot['overduePaymentCount'],
       );
@@ -605,6 +682,9 @@ class AssetLiabilityMonthlyStateStore {
           monthlyScheduledPaymentTotal: monthlyScheduledPaymentTotal,
           monthlyPaidPaymentTotal: monthlyPaidPaymentTotal,
           monthlyUnpaidPaymentTotal: monthlyUnpaidPaymentTotal,
+          monthlyActualPaymentTotal:
+              monthlyActualPaymentTotal ?? monthlyPaidPaymentTotal,
+          monthlyPaymentDifferenceTotal: monthlyPaymentDifferenceTotal ?? 0,
           overduePaymentCount: overduePaymentCount,
         ),
       );
@@ -645,6 +725,24 @@ class AssetLiabilityMonthlyStateStore {
   ) {
     return Map<String, double>.from(
       decodePaymentOverrides(raw)[monthKey] ?? const <String, double>{},
+    );
+  }
+
+  static Map<String, double> actualPaymentAmountsForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return Map<String, double>.from(
+      decodePaymentOverrides(raw)[monthKey] ?? const <String, double>{},
+    );
+  }
+
+  static Map<String, String> paymentDifferenceReasonsForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return Map<String, String>.from(
+      decodePaymentDifferenceReasons(raw)[monthKey] ?? const <String, String>{},
     );
   }
 
@@ -695,6 +793,22 @@ class AssetLiabilityMonthlyStateStore {
       }
     }
 
+    final migratedActualPayments = <String, double>{};
+    for (final entry in state.actualPaymentAmounts.entries) {
+      final migratedKey = legacyKeyToAccountId[entry.key] ?? entry.key;
+      if (legacyKeyToAccountId.containsKey(entry.key)) {
+        migratedActualPayments.putIfAbsent(migratedKey, () => entry.value);
+      } else {
+        migratedActualPayments[migratedKey] = entry.value;
+      }
+    }
+
+    final migratedDifferenceReasons = <String, String>{};
+    for (final entry in state.paymentDifferenceReasons.entries) {
+      final migratedKey = legacyKeyToAccountId[entry.key] ?? entry.key;
+      migratedDifferenceReasons[migratedKey] = entry.value;
+    }
+
     final migratedPaidAccounts = <String>{};
     for (final accountKey in state.paidAccountNames) {
       migratedPaidAccounts.add(legacyKeyToAccountId[accountKey] ?? accountKey);
@@ -716,6 +830,8 @@ class AssetLiabilityMonthlyStateStore {
 
     return AssetLiabilityMonthlyState(
       paymentOverrides: migratedPayments,
+      actualPaymentAmounts: migratedActualPayments,
+      paymentDifferenceReasons: migratedDifferenceReasons,
       paidAccountNames: migratedPaidAccounts,
       paymentSourceAccountIds: migratedPaymentSources,
       cardBillingAccountIds: migratedCardBillingAccounts,
@@ -773,6 +889,9 @@ class AssetLiabilityMonthlyStateStore {
           'monthlyScheduledPaymentTotal': snapshot.monthlyScheduledPaymentTotal,
           'monthlyPaidPaymentTotal': snapshot.monthlyPaidPaymentTotal,
           'monthlyUnpaidPaymentTotal': snapshot.monthlyUnpaidPaymentTotal,
+          'monthlyActualPaymentTotal': snapshot.monthlyActualPaymentTotal,
+          'monthlyPaymentDifferenceTotal':
+              snapshot.monthlyPaymentDifferenceTotal,
           'overduePaymentCount': snapshot.overduePaymentCount,
         },
     ];

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -48,6 +48,8 @@ class AssetLiabilityPlanningService {
     required Map<String, double> latestSnapshot,
     required DateTime baseDate,
     Map<String, double> monthlyPaymentOverrides = const <String, double>{},
+    Map<String, double> actualPaymentAmounts = const <String, double>{},
+    Map<String, String> paymentDifferenceReasons = const <String, String>{},
     Set<String> paidAccountNames = const <String>{},
     Map<String, String> paymentSourceAccountIds = const <String, String>{},
     Map<String, String> defaultPaymentSourceAccountIds =
@@ -116,6 +118,8 @@ class AssetLiabilityPlanningService {
             account: account,
             liabilityTotal: liabilityTotal,
             monthlyPaymentOverrides: effectiveMonthlyPaymentOverrides,
+            actualPaymentAmounts: actualPaymentAmounts,
+            paymentDifferenceReasons: paymentDifferenceReasons,
             paidAccountNames: paidAccountNames,
             paymentSourceAccountIds: effectivePaymentSourceAccountIds,
             defaultCardBillingAccountIds: defaultCardBillingAccountIds,
@@ -168,6 +172,14 @@ class AssetLiabilityPlanningService {
       0,
       (sum, row) => row.paid ? sum : sum + row.scheduledPaymentAmount,
     );
+    final monthlyActualPaymentTotal = directDebtRows.fold<double>(
+      0,
+      (sum, row) => sum + row.effectivePaidPaymentAmount,
+    );
+    final monthlyPaymentDifferenceTotal = directDebtRows.fold<double>(
+      0,
+      (sum, row) => sum + (row.paymentDifferenceAmount ?? 0),
+    );
     final monthlyUnreceivedIncomeTotal = resolvedIncomePlans.fold<double>(
       0,
       (sum, plan) => plan.received ? sum : sum + plan.amount,
@@ -202,6 +214,8 @@ class AssetLiabilityPlanningService {
       monthlyMinimumPaymentEstimateTotal: monthlyMinimumPaymentEstimateTotal,
       monthlyScheduledPaymentTotal: monthlyScheduledPaymentTotal,
       monthlyUnpaidPaymentTotal: monthlyUnpaidPaymentTotal,
+      monthlyActualPaymentTotal: monthlyActualPaymentTotal,
+      monthlyPaymentDifferenceTotal: monthlyPaymentDifferenceTotal,
       monthlyUnreceivedIncomeTotal: monthlyUnreceivedIncomeTotal,
       cashAfterMinimumPayments: cashAfterScheduledPayments,
       cashAfterScheduledPayments: cashAfterScheduledPayments,
@@ -428,6 +442,8 @@ class AssetLiabilityPlanningService {
     required AssetLiabilityAccount account,
     required double liabilityTotal,
     required Map<String, double> monthlyPaymentOverrides,
+    required Map<String, double> actualPaymentAmounts,
+    required Map<String, String> paymentDifferenceReasons,
     required Set<String> paidAccountNames,
     required Map<String, String> paymentSourceAccountIds,
     required Map<String, String> defaultCardBillingAccountIds,
@@ -450,6 +466,14 @@ class AssetLiabilityPlanningService {
       monthlyPaymentOverrides: monthlyPaymentOverrides,
     );
     final scheduledPayment = manualPayment ?? minimumPayment;
+    final actualPayment = _actualPaymentAmountFor(
+      account: account,
+      actualPaymentAmounts: actualPaymentAmounts,
+    );
+    final paymentDifferenceReason = _paymentDifferenceReasonFor(
+      account: account,
+      paymentDifferenceReasons: paymentDifferenceReasons,
+    );
     final principalPayment = max(0.0, scheduledPayment - interest);
     final afterPayment = -max(0.0, principal + interest - scheduledPayment);
     final paymentSourceAccountId = paymentSourceAccountIds[account.id];
@@ -481,6 +505,8 @@ class AssetLiabilityPlanningService {
       minimumPaymentEstimate: minimumPayment,
       manualPaymentAmount: manualPayment,
       scheduledPaymentAmount: scheduledPayment,
+      actualPaymentAmount: actualPayment,
+      paymentDifferenceReason: paymentDifferenceReason,
       monthlyInterestEstimate: interest,
       principalPaymentEstimate: principalPayment,
       balanceAfterPaymentEstimate: afterPayment,
@@ -846,6 +872,9 @@ class AssetLiabilityPlanningService {
           billingAccountName: null,
           includedInBillingAccount: false,
           paymentAmount: plan.amount,
+          actualPaymentAmount: null,
+          paymentDifferenceAmount: null,
+          paymentDifferenceReason: null,
           paymentAmountEstimated: false,
           paid: false,
           received: plan.received,
@@ -884,6 +913,9 @@ class AssetLiabilityPlanningService {
           billingAccountName: row.billingAccountName,
           includedInBillingAccount: row.includedInBillingAccount,
           paymentAmount: row.scheduledPaymentAmount,
+          actualPaymentAmount: row.actualPaymentAmount,
+          paymentDifferenceAmount: row.paymentDifferenceAmount,
+          paymentDifferenceReason: row.paymentDifferenceReason,
           paymentAmountEstimated: row.paymentAmountEstimated,
           paid: row.paid,
           received: false,
@@ -935,6 +967,9 @@ class AssetLiabilityPlanningService {
             billingAccountName: row.billingAccountName,
             includedInBillingAccount: row.includedInBillingAccount,
             paymentAmount: row.paymentAmount,
+            actualPaymentAmount: row.actualPaymentAmount,
+            paymentDifferenceAmount: row.paymentDifferenceAmount,
+            paymentDifferenceReason: row.paymentDifferenceReason,
             paymentAmountEstimated: row.paymentAmountEstimated,
             paid: row.paid,
             received: row.received,
@@ -1233,6 +1268,32 @@ class AssetLiabilityPlanningService {
       return null;
     }
     return amount;
+  }
+
+  double? _actualPaymentAmountFor({
+    required AssetLiabilityAccount account,
+    required Map<String, double> actualPaymentAmounts,
+  }) {
+    final trimmedName = account.name.trim();
+    final amount = actualPaymentAmounts[account.id] ??
+        actualPaymentAmounts[trimmedName] ??
+        actualPaymentAmounts[account.name];
+    if (amount == null || amount < 0) {
+      return null;
+    }
+    return amount;
+  }
+
+  String? _paymentDifferenceReasonFor({
+    required AssetLiabilityAccount account,
+    required Map<String, String> paymentDifferenceReasons,
+  }) {
+    final trimmedName = account.name.trim();
+    final reason = paymentDifferenceReasons[account.id] ??
+        paymentDifferenceReasons[trimmedName] ??
+        paymentDifferenceReasons[account.name];
+    final trimmed = reason?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
   }
 
   String _priorityLabel(double annualRate) {

--- a/test/services/asset_liability_history_service_test.dart
+++ b/test/services/asset_liability_history_service_test.dart
@@ -20,6 +20,7 @@ void main() {
           'mobit': 10000,
           'aupay_card': 5000,
         },
+        actualPaymentAmounts: const <String, double>{'aupay_card': 6200},
         paidAccountNames: const <String>{'aupay_card'},
       );
 
@@ -31,7 +32,9 @@ void main() {
 
       expect(snapshot.monthKey, '2026-05');
       expect(snapshot.monthlyScheduledPaymentTotal, 15000);
-      expect(snapshot.monthlyPaidPaymentTotal, 5000);
+      expect(snapshot.monthlyPaidPaymentTotal, 6200);
+      expect(snapshot.monthlyActualPaymentTotal, 6200);
+      expect(snapshot.monthlyPaymentDifferenceTotal, 1200);
       expect(snapshot.monthlyUnpaidPaymentTotal, 10000);
       expect(snapshot.overduePaymentCount, 1);
     });
@@ -189,6 +192,8 @@ void main() {
             monthlyScheduledPaymentTotal: 20000,
             monthlyPaidPaymentTotal: 0,
             monthlyUnpaidPaymentTotal: 20000,
+            monthlyActualPaymentTotal: 21000,
+            monthlyPaymentDifferenceTotal: 1000,
             overduePaymentCount: 0,
           ),
         ],
@@ -197,6 +202,9 @@ void main() {
 
       expect(bundle.monthlyHistoryCsv, contains('対象月,保存日時,資産合計'));
       expect(bundle.monthlyHistoryCsv, contains('2026-05'));
+      expect(bundle.monthlyHistoryCsv, contains('actual_paid_payment_total'));
+      expect(bundle.monthlyHistoryCsv, contains('payment_difference_total'));
+      expect(bundle.monthlyHistoryCsv, contains('21000'));
       expect(bundle.paymentScheduleCsv, contains('支払先'));
       expect(bundle.paymentScheduleCsv, contains('モビット'));
       expect(bundle.paymentScheduleCsv, contains('KDDI'));
@@ -204,6 +212,31 @@ void main() {
       expect(bundle.incomePlansCsv, contains('"Bonus, side income"'));
       expect(bundle.accountCashflowCsv, contains('口座,現在残高'));
       expect(bundle.accountCashflowCsv, contains('bank'));
+    });
+
+    test('exports actual payment difference metadata to payment CSV', () {
+      final workbook = planningService.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'aupay': -10000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'aupay_card': 5000},
+        actualPaymentAmounts: const <String, double>{'aupay_card': 6200},
+        paymentDifferenceReasons: const <String, String>{
+          'aupay_card': 'late fee',
+        },
+        paidAccountNames: const <String>{'aupay_card'},
+      );
+
+      final csv = historyService.buildPaymentScheduleCsv(workbook);
+
+      expect(csv, contains('actual_payment_amount'));
+      expect(csv, contains('payment_difference_amount'));
+      expect(csv, contains('payment_difference_reason'));
+      expect(csv, contains('6200'));
+      expect(csv, contains('1200'));
+      expect(csv, contains('late fee'));
     });
 
     test('exports au card-billed payment metadata to payment CSV', () {

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -18,6 +18,10 @@ void main() {
         state: AssetLiabilityMonthlyState(
           paymentOverrides: const <String, double>{'モビット': 70000},
           paidAccountNames: const <String>{'auPayカード'},
+          actualPaymentAmounts: const <String, double>{'aupay_card': 6200},
+          paymentDifferenceReasons: const <String, String>{
+            'aupay_card': 'late fee',
+          },
           paymentSourceAccountIds: const <String, String>{
             'mobit': 'custom_bank',
           },
@@ -41,10 +45,14 @@ void main() {
 
       expect(loadedMay.paymentOverrides['モビット'], 70000);
       expect(loadedMay.paidAccountNames, contains('auPayカード'));
+      expect(loadedMay.actualPaymentAmounts['aupay_card'], 6200);
+      expect(loadedMay.paymentDifferenceReasons['aupay_card'], 'late fee');
       expect(loadedMay.paymentSourceAccountIds['mobit'], 'custom_bank');
       expect(loadedMay.cardBillingAccountIds['au'], 'aupay_card');
       expect(loadedMay.incomePlans.single.name, 'Salary');
       expect(loadedJune.paymentOverrides, isEmpty);
+      expect(loadedJune.actualPaymentAmounts, isEmpty);
+      expect(loadedJune.paymentDifferenceReasons, isEmpty);
       expect(loadedJune.paidAccountNames, isEmpty);
       expect(loadedJune.paymentSourceAccountIds, isEmpty);
       expect(loadedJune.cardBillingAccountIds, isEmpty);
@@ -148,6 +156,27 @@ void main() {
       });
     });
 
+    test('migrates actual payment difference keys to stable account ids', () {
+      final migrated = AssetLiabilityMonthlyStateStore.migrateLegacyKeys(
+        state: const AssetLiabilityMonthlyState(
+          actualPaymentAmounts: <String, double>{'Legacy card': 6200},
+          paymentDifferenceReasons: <String, String>{
+            'Legacy card': 'late fee',
+          },
+        ),
+        legacyKeyToAccountId: const <String, String>{
+          'Legacy card': 'aupay_card',
+        },
+      );
+
+      expect(migrated.actualPaymentAmounts, <String, double>{
+        'aupay_card': 6200,
+      });
+      expect(migrated.paymentDifferenceReasons, <String, String>{
+        'aupay_card': 'late fee',
+      });
+    });
+
     test(
       'copies previous month settings without paid or received state',
       () async {
@@ -198,6 +227,33 @@ void main() {
         expect(loaded.incomePlans.single.received, isFalse);
       },
     );
+
+    test('does not copy actual payments or difference reasons', () async {
+      await store.saveMonth(
+        month: DateTime(2026, 5, 13),
+        state: const AssetLiabilityMonthlyState(
+          paymentOverrides: <String, double>{'mobit': 70000},
+          actualPaymentAmounts: <String, double>{'mobit': 71000},
+          paymentDifferenceReasons: <String, String>{
+            'mobit': 'fee adjustment',
+          },
+          paidAccountNames: <String>{'mobit'},
+        ),
+      );
+
+      final copied = await store.copyPreviousMonthToMonth(
+        DateTime(2026, 6, 10),
+      );
+      final loaded = await store.loadMonth(DateTime(2026, 6, 20));
+
+      expect(copied.paymentOverrides, <String, double>{'mobit': 70000});
+      expect(copied.actualPaymentAmounts, isEmpty);
+      expect(copied.paymentDifferenceReasons, isEmpty);
+      expect(copied.paidAccountNames, isEmpty);
+      expect(loaded.actualPaymentAmounts, isEmpty);
+      expect(loaded.paymentDifferenceReasons, isEmpty);
+      expect(loaded.paidAccountNames, isEmpty);
+    });
 
     test('saves and restores default payment source accounts', () async {
       await store.saveDefaultPaymentSources(const <String, String>{

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -211,6 +211,52 @@ void main() {
       );
     });
 
+    test('uses actual paid amount for paid rows and keeps unpaid planned', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'aupay': -10000,
+          'paypay': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'aupay_card': 5000,
+          'paypay_card': 8000,
+        },
+        actualPaymentAmounts: const <String, double>{
+          'aupay_card': 6200,
+          'paypay_card': 9000,
+        },
+        paymentDifferenceReasons: const <String, String>{
+          'aupay_card': 'late fee',
+        },
+        paidAccountNames: const <String>{'aupay_card'},
+      );
+
+      final auPay = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == 'aupay_card',
+      );
+      final payPay = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == 'paypay_card',
+      );
+      final auPayCashflow = workbook.cashflowRows.firstWhere(
+        (row) => row.accountId == 'aupay_card',
+      );
+
+      expect(auPay.scheduledPaymentAmount, 5000);
+      expect(auPay.actualPaymentAmount, 6200);
+      expect(auPay.effectivePaidPaymentAmount, 6200);
+      expect(auPay.paymentDifferenceAmount, 1200);
+      expect(auPay.paymentDifferenceReason, 'late fee');
+      expect(auPayCashflow.actualPaymentAmount, 6200);
+      expect(auPayCashflow.paymentDifferenceAmount, 1200);
+      expect(payPay.paid, isFalse);
+      expect(payPay.paymentDifferenceAmount, isNull);
+      expect(workbook.monthlyActualPaymentTotal, 6200);
+      expect(workbook.monthlyPaymentDifferenceTotal, 1200);
+      expect(workbook.monthlyUnpaidPaymentTotal, 8000);
+    });
+
     test(
       'treats au as auPay card-billed detail without direct subtraction',
       () {

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -23,6 +23,12 @@ void main() {
             'mobit': 70000,
             'kddi_provider': 5764,
           },
+          actualPaymentAmounts: const <String, double>{
+            'kddi_provider': 5764,
+          },
+          paymentDifferenceReasons: const <String, String>{
+            'kddi_provider': 'confirmed bill',
+          },
           paidAccountNames: const <String>{'kddi_provider'},
           paymentSourceAccountIds: const <String, String>{
             'mobit': 'smbc_otsuka',
@@ -48,6 +54,11 @@ void main() {
 
       expect(restored.paymentOverrides['mobit'], 70000);
       expect(restored.paymentOverrides['kddi_provider'], 5764);
+      expect(restored.actualPaymentAmounts['kddi_provider'], 5764);
+      expect(
+        restored.paymentDifferenceReasons['kddi_provider'],
+        'confirmed bill',
+      );
       expect(restored.paidAccountNames, contains('kddi_provider'));
       expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
       expect(restored.cardBillingAccountIds['kddi_provider'], 'paypay_card');
@@ -102,6 +113,8 @@ void main() {
         monthlyScheduledPaymentTotal: 180000,
         monthlyPaidPaymentTotal: 100000,
         monthlyUnpaidPaymentTotal: 80000,
+        monthlyActualPaymentTotal: 102000,
+        monthlyPaymentDifferenceTotal: 2000,
         overduePaymentCount: 1,
       );
 
@@ -1105,6 +1118,10 @@ void main() {
     test('round-trips monthly state payload', () {
       final state = AssetLiabilityMonthlyState(
         paymentOverrides: const <String, double>{'mobit': 70000},
+        actualPaymentAmounts: const <String, double>{'mobit': 71000},
+        paymentDifferenceReasons: const <String, String>{
+          'mobit': 'fee adjustment',
+        },
         paidAccountNames: const <String>{'kddi_provider'},
         paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
         cardBillingAccountIds: const <String, String>{
@@ -1138,6 +1155,8 @@ void main() {
       expect(row['user_id'], 'user-1');
       expect(row['month_key'], '2026-05');
       expect(restored.paymentOverrides['mobit'], 70000);
+      expect(restored.actualPaymentAmounts['mobit'], 71000);
+      expect(restored.paymentDifferenceReasons['mobit'], 'fee adjustment');
       expect(restored.paidAccountNames, contains('kddi_provider'));
       expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
       expect(restored.cardBillingAccountIds['kddi_provider'], 'paypay_card');
@@ -1187,6 +1206,8 @@ void main() {
         monthlyScheduledPaymentTotal: 180000,
         monthlyPaidPaymentTotal: 100000,
         monthlyUnpaidPaymentTotal: 80000,
+        monthlyActualPaymentTotal: 102000,
+        monthlyPaymentDifferenceTotal: 2000,
         overduePaymentCount: 1,
       );
       final snapshotRow = AssetLiabilityMonthlySnapshotPayload(
@@ -1200,6 +1221,8 @@ void main() {
       expect(snapshotRow['user_id'], 'user-1');
       expect(restoredSnapshot.monthKey, '2026-05');
       expect(restoredSnapshot.netWorth, -7080000);
+      expect(restoredSnapshot.monthlyActualPaymentTotal, 102000);
+      expect(restoredSnapshot.monthlyPaymentDifferenceTotal, 2000);
       expect(restoredSnapshot.overduePaymentCount, 1);
     });
 
@@ -1516,6 +1539,10 @@ class _RecordingAssetLiabilityRemoteStore extends AssetLiabilityRemoteStore {
 AssetLiabilityMonthlyState _sampleMonthlyState() {
   return AssetLiabilityMonthlyState(
     paymentOverrides: const <String, double>{'mobit': 70000},
+    actualPaymentAmounts: const <String, double>{'kddi_provider': 5764},
+    paymentDifferenceReasons: const <String, String>{
+      'kddi_provider': 'confirmed bill',
+    },
     paidAccountNames: const <String>{'kddi_provider'},
     paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
     cardBillingAccountIds: const <String, String>{

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -271,6 +271,8 @@ AssetLiabilityWorkbook _workbook({
     netWorth: 40000,
     monthlyMinimumPaymentEstimateTotal: 10000,
     monthlyScheduledPaymentTotal: 10000,
+    monthlyActualPaymentTotal: 0,
+    monthlyPaymentDifferenceTotal: 0,
     monthlyUnpaidPaymentTotal: 10000,
     monthlyUnreceivedIncomeTotal: 0,
     cashAfterMinimumPayments: 40000,


### PR DESCRIPTION
﻿## Summary
- Add monthly actual paid amount and planned/actual difference reason tracking to the asset/liability board.
- Propagate actual payment totals through planning, monthly snapshots, Supabase persistence payloads, and CSV exports.
- Add paid-row UI inputs for actual payment amount and difference reason, with the planned amount prefilled when a payment is marked paid.

## Validation
- `dart format lib/models/asset_liability_workbook.dart lib/models/asset_liability_persistence.dart lib/services/asset_liability_monthly_state_store.dart lib/services/asset_liability_planning_service.dart lib/services/asset_liability_history_service.dart lib/pages/asset_management_page.dart test/services/asset_liability_planning_service_test.dart test/services/asset_liability_monthly_state_store_test.dart test/services/asset_liability_history_service_test.dart test/services/asset_liability_repository_test.dart`: OK
- `dart analyze`: No issues found
- `flutter test --no-pub test/services/asset_liability_planning_service_test.dart test/services/asset_liability_monthly_state_store_test.dart test/services/asset_liability_history_service_test.dart test/services/asset_liability_repository_test.dart --reporter expanded`: 85 passed
- `flutter test --no-pub --reporter expanded`: 486 passed
- `git diff --check`: OK
- Local web smoke: `flutter run -d web-server --web-hostname 127.0.0.1 --web-port 8765 --no-pub` then `Invoke-WebRequest http://127.0.0.1:8765`: HTTP 200

## Minimal E2E Gate
- Implementation-detail independent: the black-box I/O contract is monthly payment input and paid status changes producing observable actual-payment totals, planned/actual differences, persisted monthly state, monthly history, and CSV output.
- Minimal: three cases cover the user-visible behavior:
  1. Happy path: mark a payment paid, store an actual paid amount, and see actual totals/difference reflected in planning rows and cashflow rows.
  2. Persistence path: save/load monthly state and Supabase payloads with actual payment amount and difference reason intact.
  3. Export/history path: monthly snapshot and CSV output include actual paid total, planned/actual difference, and difference reason.
- E2E mechanism: Flutter service and repository tests exercise the asset/liability persistence and calculation I/O boundary; local web smoke confirms the route still serves HTTP 200.
- E2E-Exception: no browser `integration_test/` or Playwright test was added because this PR extends an existing dense finance screen and deterministic service/store outputs; the risk is covered by targeted service/repository tests plus full Flutter tests and HTTP 200 smoke.

## Visual / UI QA Notes
- Changed surface: asset management page debt master and monthly history tables.
- Codex in-app browser evidence: not captured in this local worktree session; local web-server HTTP 200 smoke was completed.
- Generated imagery: none.

## Risk / Rollback
- Risk: payment/finance persistence is high-impact because incorrect totals could mislead monthly cashflow review.
- Rollback: revert this PR to remove actual-payment tracking and return to planned payment totals only. Existing saved planned amounts and paid checks remain compatible because new actual/difference fields default to empty/zero.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: scoped payment-difference persistence work; external ultrareview was not run in this Codex execution, and merge is gated by deterministic Dart/Flutter tests, local web smoke, and GitHub Actions.
- Perspectives covered: security, rollback, data migration, prod smoke, observability.
- Unresolved findings: none / 0.

## Scope Notes
- Scoped to #2450 planned vs actual payment difference management.
- Monetary calculations remain deterministic in Dart services; AI remains out of calculation authority.
- No Supabase migration, production write flag, secret, or external API behavior is changed.

Fixes #2450
