### PR TITLE
Persist debt master settings

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -79,6 +79,7 @@ class AssetLiabilityMonthlyStatePayload {
   final Map<String, double> paymentOverrides;
   final Map<String, double> actualPaymentAmounts;
   final Map<String, String> paymentDifferenceReasons;
+  final Map<String, double> annualRateOverrides;
   final Set<String> paidAccountIds;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
@@ -89,6 +90,7 @@ class AssetLiabilityMonthlyStatePayload {
     required this.paymentOverrides,
     required this.actualPaymentAmounts,
     required this.paymentDifferenceReasons,
+    required this.annualRateOverrides,
     required this.paidAccountIds,
     required this.paymentSourceAccountIds,
     required this.cardBillingAccountIds,
@@ -107,6 +109,9 @@ class AssetLiabilityMonthlyStatePayload {
       ),
       paymentDifferenceReasons: Map<String, String>.from(
         state.paymentDifferenceReasons,
+      ),
+      annualRateOverrides: Map<String, double>.from(
+        state.annualRateOverrides,
       ),
       paidAccountIds: Set<String>.from(state.paidAccountNames),
       paymentSourceAccountIds: Map<String, String>.from(
@@ -136,6 +141,9 @@ class AssetLiabilityMonthlyStatePayload {
           _readStringMap(json, 'payment_difference_reasons') ??
               _readStringMap(json, 'paymentDifferenceReasons') ??
               const <String, String>{},
+      annualRateOverrides: _readDoubleMap(json, 'annual_rate_overrides') ??
+          _readDoubleMap(json, 'annualRateOverrides') ??
+          const <String, double>{},
       paidAccountIds: _readStringSet(json, 'paid_account_ids') ??
           _readStringSet(json, 'paidAccountIds') ??
           const <String>{},
@@ -159,6 +167,7 @@ class AssetLiabilityMonthlyStatePayload {
       paymentDifferenceReasons: Map<String, String>.from(
         paymentDifferenceReasons,
       ),
+      annualRateOverrides: Map<String, double>.from(annualRateOverrides),
       paidAccountNames: Set<String>.from(paidAccountIds),
       paymentSourceAccountIds: Map<String, String>.from(
         paymentSourceAccountIds,
@@ -183,6 +192,7 @@ class AssetLiabilityMonthlyStatePayload {
       'payment_difference_reasons': Map<String, String>.from(
         paymentDifferenceReasons,
       ),
+      'annual_rate_overrides': Map<String, double>.from(annualRateOverrides),
       'paid_account_ids': (paidAccountIds.toList()..sort()),
       'payment_source_account_ids': Map<String, String>.from(
         paymentSourceAccountIds,

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -111,6 +111,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, double> _monthlyPaymentOverrides = <String, double>{};
   Map<String, double> _actualPaymentAmounts = <String, double>{};
   Map<String, String> _paymentDifferenceReasons = <String, String>{};
+  Map<String, double> _annualRateOverrides = <String, double>{};
   Set<String> _monthlyPaidAccountNames = <String>{};
   Map<String, String> _paymentSourceAccountIds = <String, String>{};
   Map<String, String> _cardBillingAccountIds = <String, String>{};
@@ -142,6 +143,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final Map<String, TextEditingController> _actualPaymentControllers =
       <String, TextEditingController>{};
   final Map<String, TextEditingController> _paymentDifferenceReasonControllers =
+      <String, TextEditingController>{};
+  final Map<String, TextEditingController> _annualRateControllers =
       <String, TextEditingController>{};
 
   // --- グラフデータ ---
@@ -288,6 +291,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _paymentDifferenceReasonControllers.forEach(
       (_, controller) => controller.dispose(),
     );
+    _annualRateControllers.forEach((_, controller) => controller.dispose());
     _flowMemoController.dispose();
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
@@ -848,6 +852,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _paymentDifferenceReasons = Map<String, String>.from(
           state.paymentDifferenceReasons,
         );
+        _annualRateOverrides = Map<String, double>.from(
+          state.annualRateOverrides,
+        );
         _monthlyPaidAccountNames = Set<String>.from(state.paidAccountNames);
         _paymentSourceAccountIds = Map<String, String>.from(
           state.paymentSourceAccountIds,
@@ -906,6 +913,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         paymentDifferenceReasons: Map<String, String>.from(
           _paymentDifferenceReasons,
         ),
+        annualRateOverrides: Map<String, double>.from(_annualRateOverrides),
         paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
@@ -1222,6 +1230,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         paymentDifferenceReasons: Map<String, String>.from(
           _paymentDifferenceReasons,
         ),
+        annualRateOverrides: Map<String, double>.from(_annualRateOverrides),
         paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
@@ -1245,6 +1254,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _paymentDifferenceReasons,
           migrated.paymentDifferenceReasons,
         ) &&
+        _sameDoubleMap(_annualRateOverrides, migrated.annualRateOverrides) &&
         _sameStringSet(_monthlyPaidAccountNames, migrated.paidAccountNames) &&
         _sameStringMap(
           _paymentSourceAccountIds,
@@ -1276,6 +1286,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
         _paymentDifferenceReasons = Map<String, String>.from(
           migrated.paymentDifferenceReasons,
+        );
+        _annualRateOverrides = Map<String, double>.from(
+          migrated.annualRateOverrides,
         );
         _monthlyPaidAccountNames = Set<String>.from(migrated.paidAccountNames);
         _paymentSourceAccountIds = Map<String, String>.from(
@@ -1346,6 +1359,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _syncMonthlyPaymentControllers();
     _syncActualPaymentControllers();
     _syncPaymentDifferenceReasonControllers();
+    _syncAnnualRateControllers();
   }
 
   void _syncMonthlyPaymentControllers() {
@@ -1374,6 +1388,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   void _syncPaymentDifferenceReasonControllers() {
     for (final entry in _paymentDifferenceReasonControllers.entries) {
       final text = _paymentDifferenceReasons[entry.key] ?? '';
+      if (entry.value.text != text) {
+        entry.value.text = text;
+      }
+    }
+  }
+
+  void _syncAnnualRateControllers() {
+    for (final entry in _annualRateControllers.entries) {
+      final hasOverride = _annualRateOverrides.containsKey(entry.key);
+      final rate = _annualRateOverrides[entry.key];
+      final text = hasOverride && rate != null ? _formatRateInput(rate) : '';
       if (entry.value.text != text) {
         entry.value.text = text;
       }
@@ -1413,6 +1438,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       row.id,
       () => TextEditingController(text: row.paymentDifferenceReason ?? ''),
     );
+  }
+
+  TextEditingController _annualRateControllerFor(AssetLiabilityDebtRow row) {
+    return _annualRateControllers.putIfAbsent(
+      row.id,
+      () => TextEditingController(
+        text: _annualRateOverrides.containsKey(row.id)
+            ? _formatRateInput(_annualRateOverrides[row.id]!)
+            : '',
+      ),
+    );
+  }
+
+  String _formatRateInput(double rate) {
+    final percent = rate * 100;
+    if (percent == percent.roundToDouble()) {
+      return percent.round().toString();
+    }
+    return percent.toStringAsFixed(2).replaceFirst(RegExp(r'\.?0+$'), '');
   }
 
   void _updateMonthlyPaymentOverride(String accountId, String rawValue) {
@@ -1457,6 +1501,27 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       } else {
         _paymentDifferenceReasons[accountId] = reason;
       }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _updateAnnualRateOverride(String accountId, String rawValue) {
+    final normalized = rawValue.replaceAll('%', '').replaceAll(',', '').trim();
+    final parsed = normalized.isEmpty ? null : double.tryParse(normalized);
+    setState(() {
+      if (parsed == null || parsed < 0) {
+        _annualRateOverrides.remove(accountId);
+      } else {
+        _annualRateOverrides[accountId] = parsed > 1 ? parsed / 100 : parsed;
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _clearAnnualRateOverride(String accountId) {
+    _annualRateControllers[accountId]?.clear();
+    setState(() {
+      _annualRateOverrides.remove(accountId);
     });
     unawaited(_saveAssetLiabilityMonthlyState());
   }
@@ -6775,6 +6840,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       monthlyPaymentOverrides: _monthlyPaymentOverrides,
       actualPaymentAmounts: _actualPaymentAmounts,
       paymentDifferenceReasons: _paymentDifferenceReasons,
+      annualRateOverrides: _annualRateOverrides,
       paidAccountNames: _monthlyPaidAccountNames,
       paymentSourceAccountIds: _paymentSourceAccountIds,
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
@@ -9819,7 +9885,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return const SizedBox.shrink();
     }
 
-    final rows = workbook.debtMasterRows.take(10).toList();
+    final rows = List<AssetLiabilityDebtRow>.from(
+      workbook.debtMasterRows,
+    )..sort(_compareDebtRowsByPaymentDay);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -9828,6 +9896,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
         ),
         const SizedBox(height: 8),
+        const Text(
+          '支払日順で表示しています。',
+          style: TextStyle(fontSize: 12, height: 1.4),
+        ),
+        const SizedBox(height: 4),
         Text(
           '画面に収まらない場合は、表を横にスクロールして支払済み・年利・月利息まで確認できます。支払済みチェックは当月の状態として保存されます。',
           style: TextStyle(
@@ -9890,7 +9963,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                       DataCell(_buildMonthlyPaymentInput(row)),
                       DataCell(_buildPaymentAmountSourceChip(row)),
                       DataCell(_buildPaidCheckbox(row)),
-                      DataCell(Text(_formatManagementPercent(row.annualRate))),
+                      DataCell(_buildAnnualRateInput(row)),
                       DataCell(
                         Text(_formatManagementYen(row.monthlyInterestEstimate)),
                       ),
@@ -9905,6 +9978,23 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       ],
     );
+  }
+
+  int _compareDebtRowsByPaymentDay(
+    AssetLiabilityDebtRow a,
+    AssetLiabilityDebtRow b,
+  ) {
+    final dayA = a.paymentDay ?? 99;
+    final dayB = b.paymentDay ?? 99;
+    final day = dayA.compareTo(dayB);
+    if (day != 0) {
+      return day;
+    }
+    final balance = b.balance.abs().compareTo(a.balance.abs());
+    if (balance != 0) {
+      return balance;
+    }
+    return a.name.compareTo(b.name);
   }
 
   Widget _buildPaymentMethodDropdown(
@@ -10137,6 +10227,35 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       onChanged: (value) {
         unawaited(_toggleMonthlyPaymentPaid(row, value ?? false));
       },
+    );
+  }
+
+  Widget _buildAnnualRateInput(AssetLiabilityDebtRow row) {
+    final controller = _annualRateControllerFor(row);
+    final hasOverride = _annualRateOverrides.containsKey(row.id);
+    return SizedBox(
+      width: 120,
+      child: TextField(
+        controller: controller,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        inputFormatters: [
+          FilteringTextInputFormatter.allow(RegExp(r'[0-9.,%]')),
+        ],
+        onChanged: (value) => _updateAnnualRateOverride(row.id, value),
+        decoration: InputDecoration(
+          isDense: true,
+          hintText: _formatRateInput(row.annualRate),
+          helperText: hasOverride ? '保存済み' : '未入力時は既定',
+          suffixText: '%',
+          suffixIcon: hasOverride
+              ? IconButton(
+                  tooltip: '年利上書きをクリア',
+                  icon: const Icon(Icons.clear, size: 16),
+                  onPressed: () => _clearAnnualRateOverride(row.id),
+                )
+              : null,
+        ),
+      ),
     );
   }
 

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -10,6 +10,7 @@ class AssetLiabilityMonthlyState {
   final Map<String, double> paymentOverrides;
   final Map<String, double> actualPaymentAmounts;
   final Map<String, String> paymentDifferenceReasons;
+  final Map<String, double> annualRateOverrides;
   final Set<String> paidAccountNames;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
@@ -19,6 +20,7 @@ class AssetLiabilityMonthlyState {
     this.paymentOverrides = const <String, double>{},
     this.actualPaymentAmounts = const <String, double>{},
     this.paymentDifferenceReasons = const <String, String>{},
+    this.annualRateOverrides = const <String, double>{},
     this.paidAccountNames = const <String>{},
     this.paymentSourceAccountIds = const <String, String>{},
     this.cardBillingAccountIds = const <String, String>{},
@@ -29,6 +31,7 @@ class AssetLiabilityMonthlyState {
       paymentOverrides.isEmpty &&
       actualPaymentAmounts.isEmpty &&
       paymentDifferenceReasons.isEmpty &&
+      annualRateOverrides.isEmpty &&
       paidAccountNames.isEmpty &&
       paymentSourceAccountIds.isEmpty &&
       cardBillingAccountIds.isEmpty &&
@@ -42,6 +45,8 @@ class AssetLiabilityMonthlyStateStore {
       'asset_liability_monthly_actual_payments_v1';
   static const String paymentDifferenceReasonPrefsKey =
       'asset_liability_monthly_payment_difference_reasons_v1';
+  static const String annualRatePrefsKey =
+      'asset_liability_monthly_annual_rate_overrides_v1';
   static const String paidPrefsKey = 'asset_liability_paid_accounts_v1';
   static const String paymentSourcePrefsKey =
       'asset_liability_payment_source_accounts_v1';
@@ -76,6 +81,10 @@ class AssetLiabilityMonthlyStateStore {
       ),
       paymentDifferenceReasons: paymentDifferenceReasonsForMonth(
         prefs.getString(paymentDifferenceReasonPrefsKey),
+        monthKey,
+      ),
+      annualRateOverrides: annualRateOverridesForMonth(
+        prefs.getString(annualRatePrefsKey),
         monthKey,
       ),
       paidAccountNames: paidAccountsForMonth(
@@ -148,6 +157,19 @@ class AssetLiabilityMonthlyStateStore {
       paymentDifferenceReasonPrefsKey,
       jsonEncode(allPaymentDifferenceReasons),
     );
+
+    final allAnnualRates = decodePaymentOverrides(
+      prefs.getString(annualRatePrefsKey),
+    );
+    if (state.annualRateOverrides.isEmpty) {
+      allAnnualRates.remove(monthKey);
+    } else {
+      allAnnualRates[monthKey] = Map<String, double>.from(
+        state.annualRateOverrides,
+      );
+    }
+    await prefs.setString(annualRatePrefsKey, jsonEncode(allAnnualRates));
+
     await prefs.setString(
       paidPrefsKey,
       jsonEncode(_encodePaid(allPaidAccounts)),
@@ -328,6 +350,9 @@ class AssetLiabilityMonthlyStateStore {
     return AssetLiabilityMonthlyState(
       paymentOverrides: Map<String, double>.from(
         previousState.paymentOverrides,
+      ),
+      annualRateOverrides: Map<String, double>.from(
+        previousState.annualRateOverrides,
       ),
       paymentSourceAccountIds: Map<String, String>.from(
         previousState.paymentSourceAccountIds,
@@ -737,6 +762,15 @@ class AssetLiabilityMonthlyStateStore {
     );
   }
 
+  static Map<String, double> annualRateOverridesForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return Map<String, double>.from(
+      decodePaymentOverrides(raw)[monthKey] ?? const <String, double>{},
+    );
+  }
+
   static Map<String, String> paymentDifferenceReasonsForMonth(
     String? raw,
     String monthKey,
@@ -809,6 +843,16 @@ class AssetLiabilityMonthlyStateStore {
       migratedDifferenceReasons[migratedKey] = entry.value;
     }
 
+    final migratedAnnualRates = <String, double>{};
+    for (final entry in state.annualRateOverrides.entries) {
+      final migratedKey = legacyKeyToAccountId[entry.key] ?? entry.key;
+      if (legacyKeyToAccountId.containsKey(entry.key)) {
+        migratedAnnualRates.putIfAbsent(migratedKey, () => entry.value);
+      } else {
+        migratedAnnualRates[migratedKey] = entry.value;
+      }
+    }
+
     final migratedPaidAccounts = <String>{};
     for (final accountKey in state.paidAccountNames) {
       migratedPaidAccounts.add(legacyKeyToAccountId[accountKey] ?? accountKey);
@@ -832,6 +876,7 @@ class AssetLiabilityMonthlyStateStore {
       paymentOverrides: migratedPayments,
       actualPaymentAmounts: migratedActualPayments,
       paymentDifferenceReasons: migratedDifferenceReasons,
+      annualRateOverrides: migratedAnnualRates,
       paidAccountNames: migratedPaidAccounts,
       paymentSourceAccountIds: migratedPaymentSources,
       cardBillingAccountIds: migratedCardBillingAccounts,

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -50,6 +50,7 @@ class AssetLiabilityPlanningService {
     Map<String, double> monthlyPaymentOverrides = const <String, double>{},
     Map<String, double> actualPaymentAmounts = const <String, double>{},
     Map<String, String> paymentDifferenceReasons = const <String, String>{},
+    Map<String, double> annualRateOverrides = const <String, double>{},
     Set<String> paidAccountNames = const <String>{},
     Map<String, String> paymentSourceAccountIds = const <String, String>{},
     Map<String, String> defaultPaymentSourceAccountIds =
@@ -120,6 +121,7 @@ class AssetLiabilityPlanningService {
             monthlyPaymentOverrides: effectiveMonthlyPaymentOverrides,
             actualPaymentAmounts: actualPaymentAmounts,
             paymentDifferenceReasons: paymentDifferenceReasons,
+            annualRateOverrides: annualRateOverrides,
             paidAccountNames: paidAccountNames,
             paymentSourceAccountIds: effectivePaymentSourceAccountIds,
             defaultCardBillingAccountIds: defaultCardBillingAccountIds,
@@ -444,6 +446,7 @@ class AssetLiabilityPlanningService {
     required Map<String, double> monthlyPaymentOverrides,
     required Map<String, double> actualPaymentAmounts,
     required Map<String, String> paymentDifferenceReasons,
+    required Map<String, double> annualRateOverrides,
     required Set<String> paidAccountNames,
     required Map<String, String> paymentSourceAccountIds,
     required Map<String, String> defaultCardBillingAccountIds,
@@ -451,7 +454,11 @@ class AssetLiabilityPlanningService {
     required Map<String, AssetLiabilityAccount> accountsById,
   }) {
     final principal = account.liabilityBalance;
-    final interest = principal * account.annualRate / 12;
+    final annualRate = _annualRateFor(
+      account: account,
+      annualRateOverrides: annualRateOverrides,
+    );
+    final interest = principal * annualRate / 12;
     final minimumPayment = account.fullPaymentEstimate
         ? principal + interest
         : min(
@@ -501,7 +508,7 @@ class AssetLiabilityPlanningService {
       billingAccountId: paymentRouting.billingAccountId,
       billingAccountName: paymentRouting.billingAccountName,
       includedInBillingAccount: paymentRouting.includedInBillingAccount,
-      annualRate: account.annualRate,
+      annualRate: annualRate,
       minimumPaymentEstimate: minimumPayment,
       manualPaymentAmount: manualPayment,
       scheduledPaymentAmount: scheduledPayment,
@@ -512,12 +519,31 @@ class AssetLiabilityPlanningService {
       balanceAfterPaymentEstimate: afterPayment,
       liabilityShare:
           liabilityTotal == 0 ? 0 : principal / liabilityTotal.abs(),
-      priorityLabel: _priorityLabel(account.annualRate),
+      priorityLabel: _priorityLabel(annualRate),
       paymentAmountEstimated: manualPayment == null,
       paid: paidAccountNames.contains(account.id) ||
           paidAccountNames.contains(account.name.trim()) ||
           paidAccountNames.contains(account.name),
     );
+  }
+
+  double _annualRateFor({
+    required AssetLiabilityAccount account,
+    required Map<String, double> annualRateOverrides,
+  }) {
+    final byId = annualRateOverrides[account.id];
+    if (byId != null && byId >= 0) {
+      return byId;
+    }
+    final byTrimmedName = annualRateOverrides[account.name.trim()];
+    if (byTrimmedName != null && byTrimmedName >= 0) {
+      return byTrimmedName;
+    }
+    final byName = annualRateOverrides[account.name];
+    if (byName != null && byName >= 0) {
+      return byName;
+    }
+    return account.annualRate;
   }
 
   _AssetLiabilityPaymentRouting _paymentRoutingFor({

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1407,6 +1407,18 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
     AssetLiabilityMonthlyState remote,
   ) {
     return _doubleMapEquals(local.paymentOverrides, remote.paymentOverrides) &&
+        _doubleMapEquals(
+          local.actualPaymentAmounts,
+          remote.actualPaymentAmounts,
+        ) &&
+        _stringMapEquals(
+          local.paymentDifferenceReasons,
+          remote.paymentDifferenceReasons,
+        ) &&
+        _doubleMapEquals(
+          local.annualRateOverrides,
+          remote.annualRateOverrides,
+        ) &&
         _stringSetEquals(local.paidAccountNames, remote.paidAccountNames) &&
         _stringMapEquals(
           local.paymentSourceAccountIds,
@@ -1632,6 +1644,9 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
       monthKey: monthKey,
       payload: <String, Object?>{
         'payment_overrides': row['payment_overrides'],
+        'actual_payment_amounts': row['actual_payment_amounts'],
+        'payment_difference_reasons': row['payment_difference_reasons'],
+        'annual_rate_overrides': row['annual_rate_overrides'],
         'paid_account_ids': row['paid_account_ids'],
         'payment_source_account_ids': row['payment_source_account_ids'],
         'card_billing_account_ids': row['card_billing_account_ids'],

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -22,6 +22,7 @@ void main() {
           paymentDifferenceReasons: const <String, String>{
             'aupay_card': 'late fee',
           },
+          annualRateOverrides: const <String, double>{'mobit': 0.175},
           paymentSourceAccountIds: const <String, String>{
             'mobit': 'custom_bank',
           },
@@ -47,12 +48,14 @@ void main() {
       expect(loadedMay.paidAccountNames, contains('auPayカード'));
       expect(loadedMay.actualPaymentAmounts['aupay_card'], 6200);
       expect(loadedMay.paymentDifferenceReasons['aupay_card'], 'late fee');
+      expect(loadedMay.annualRateOverrides['mobit'], 0.175);
       expect(loadedMay.paymentSourceAccountIds['mobit'], 'custom_bank');
       expect(loadedMay.cardBillingAccountIds['au'], 'aupay_card');
       expect(loadedMay.incomePlans.single.name, 'Salary');
       expect(loadedJune.paymentOverrides, isEmpty);
       expect(loadedJune.actualPaymentAmounts, isEmpty);
       expect(loadedJune.paymentDifferenceReasons, isEmpty);
+      expect(loadedJune.annualRateOverrides, isEmpty);
       expect(loadedJune.paidAccountNames, isEmpty);
       expect(loadedJune.paymentSourceAccountIds, isEmpty);
       expect(loadedJune.cardBillingAccountIds, isEmpty);
@@ -163,6 +166,7 @@ void main() {
           paymentDifferenceReasons: <String, String>{
             'Legacy card': 'late fee',
           },
+          annualRateOverrides: <String, double>{'Legacy card': 0.145},
         ),
         legacyKeyToAccountId: const <String, String>{
           'Legacy card': 'aupay_card',
@@ -175,6 +179,9 @@ void main() {
       expect(migrated.paymentDifferenceReasons, <String, String>{
         'aupay_card': 'late fee',
       });
+      expect(migrated.annualRateOverrides, <String, double>{
+        'aupay_card': 0.145,
+      });
     });
 
     test(
@@ -184,6 +191,7 @@ void main() {
           month: DateTime(2026, 5, 13),
           state: AssetLiabilityMonthlyState(
             paymentOverrides: const <String, double>{'mobit': 70000},
+            annualRateOverrides: const <String, double>{'mobit': 0.175},
             paidAccountNames: const <String>{'mobit'},
             paymentSourceAccountIds: const <String, String>{
               'mobit': 'custom_bank',
@@ -211,6 +219,7 @@ void main() {
         final loaded = await store.loadMonth(DateTime(2026, 6, 20));
 
         expect(copied.paymentOverrides, <String, double>{'mobit': 70000});
+        expect(copied.annualRateOverrides, <String, double>{'mobit': 0.175});
         expect(copied.paymentSourceAccountIds, <String, String>{
           'mobit': 'custom_bank',
         });
@@ -221,6 +230,7 @@ void main() {
         expect(copied.incomePlans.single.date, DateTime(2026, 6, 30));
         expect(copied.incomePlans.single.received, isFalse);
         expect(loaded.paidAccountNames, isEmpty);
+        expect(loaded.annualRateOverrides, <String, double>{'mobit': 0.175});
         expect(loaded.cardBillingAccountIds, <String, String>{
           'kddi_provider': 'paypay_card',
         });

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -114,6 +114,25 @@ void main() {
       );
     });
 
+    test('uses annual rate overrides for interest and priority signals', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+        annualRateOverrides: const <String, double>{'mobit': 0.12},
+      );
+
+      final mobit = workbook.debtMasterRows.firstWhere(
+        (row) => row.name == 'モビット',
+      );
+
+      expect(mobit.annualRate, 0.12);
+      expect(
+        mobit.monthlyInterestEstimate,
+        closeTo(mobit.balance.abs() * 0.12 / 12, 0.001),
+      );
+      expect(mobit.priorityLabel, isNotEmpty);
+    });
+
     test('uses the estimated minimum payment when manual input is absent', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: snapshot,

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -1122,6 +1122,7 @@ void main() {
         paymentDifferenceReasons: const <String, String>{
           'mobit': 'fee adjustment',
         },
+        annualRateOverrides: const <String, double>{'mobit': 0.175},
         paidAccountNames: const <String>{'kddi_provider'},
         paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
         cardBillingAccountIds: const <String, String>{
@@ -1157,6 +1158,7 @@ void main() {
       expect(restored.paymentOverrides['mobit'], 70000);
       expect(restored.actualPaymentAmounts['mobit'], 71000);
       expect(restored.paymentDifferenceReasons['mobit'], 'fee adjustment');
+      expect(restored.annualRateOverrides['mobit'], 0.175);
       expect(restored.paidAccountNames, contains('kddi_provider'));
       expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
       expect(restored.cardBillingAccountIds['kddi_provider'], 'paypay_card');
@@ -1543,6 +1545,7 @@ AssetLiabilityMonthlyState _sampleMonthlyState() {
     paymentDifferenceReasons: const <String, String>{
       'kddi_provider': 'confirmed bill',
     },
+    annualRateOverrides: const <String, double>{'mobit': 0.175},
     paidAccountNames: const <String>{'kddi_provider'},
     paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
     cardBillingAccountIds: const <String, String>{


### PR DESCRIPTION
﻿## 概要

負債マスタの運用情報をより確実に保存・確認できるようにしました。

- 支払済み/実支払額/差分理由に加えて、年利上書きも月次状態として保存します
- Supabase monthly state payload に実支払額・差分理由・年利上書きを含め、production write 有効時に永続化されるようにします
- 負債マスタを支払日順に表示します
- 年利を負債マスタ上で編集できる入力欄に変更し、月利息・返済優先度へ反映します

## 主な変更

- `AssetLiabilityMonthlyState` に `annualRateOverrides` を追加
- `AssetLiabilityMonthlyStatePayload` に `annual_rate_overrides` を追加
- Supabase remote store の `saveMonth` で以下も保存するように修正
  - `actual_payment_amounts`
  - `payment_difference_reasons`
  - `annual_rate_overrides`
- 同期プレビュー/競合判定で、実支払額・差分理由・年利上書きも比較対象に追加
- `AssetLiabilityPlanningService` が年利上書きを使って月利息・優先度を計算するように変更
- 資産管理ページの負債マスタを支払日順にソート
- 負債マスタの年利列を編集可能な入力欄に変更
- 月次コピー時は年利上書きを引き継ぎ、支払済み・実支払額は引き継がない既存方針を維持
- 関連テストを追加/更新

## Minimal E2E Declaration

- Case 1: 負債マスタで支払済み・実支払額・差分理由・年利を保存し、月次状態として復元できること
- Case 2: 負債マスタが支払日順に並び、年利上書きが月利息と返済優先度に反映されること
- Case 3: Supabase production write 有効時の monthly state payload に支払済み周辺情報と年利上書きが含まれること
- E2E mechanism: Dart/Flutter service tests and GitHub Actions gates. These checks are implementation-detail independent: they validate persisted behavior, calculated outputs, and payload contents rather than private helper structure. UI behavior is covered by deterministic service/payload tests plus CI smoke.
- E2E-Exception: ローカルWeb HTTP 200確認は、現在のローカル `pubspec.lock` と `flutter pub get --enforce-lockfile` の不整合により未完了です。GitHub ActionsのPublic E2E stability smokeで補完します。

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- Scope: 資産/負債ボードの月次状態永続化、Supabase payload、負債マスタUI表示順、年利編集
- Risk notes:
  - 金額計算はDart側の決定的ロジックのみで行い、外部AIには委譲していません
  - Supabaseへ直接UIから書かず、既存Repository経由の保存経路を維持しています
  - 既存のSharedPreferences保存を維持し、Supabase保存失敗時もローカル保存を壊さない既存方針を維持しています
- Security/privacy: 新規テーブル・migration・RLS変更なし。既存monthly state payloadの項目追加のみです。
- Rollback: このPRをrevertすると、年利上書きと追加payload保存だけが外れ、既存ローカル保存/表示に戻ります。
- High-Risk-Ultrareview-Exception: 外部ultrareviewは実施せず、deterministic tests/analyze/CI gatesで確認します。
- Unresolved findings: none

## 検証

最新 `origin/main` へ rebase 後、以下を確認済みです。

- `dart format --output=none --set-exit-if-changed ...`: OK
- `dart analyze ...`: No issues found
- 関連 `flutter test --no-pub ...`: 79 tests passed
- 全体 `flutter test --no-pub --reporter expanded`: 487 tests passed
- `git diff --check`: OK

補足:
- `flutter pub get --enforce-lockfile` は現在のローカルFlutter/Dart resolverと既存 `pubspec.lock` の不整合で失敗します。検証用に通常 `flutter pub get` を実行後、scope外の `pubspec.lock` / platform generated files は戻しています。
- ローカルWeb HTTP 200確認は上記lock不整合に伴うWeb compile依存解決問題で未完了です。CIのWeb/E2E gateで確認します。
- ローカルの `lefthook` 未導入警告は出ていますが、commit/push自体は成功しています。

