### PR TITLE
feat(asset): manage account transfer tasks (#2452)

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -85,6 +85,7 @@ class AssetLiabilityMonthlyStatePayload {
   final Map<String, String> cardBillingAccountIds;
   final List<AssetLiabilityCardStatementLine> cardStatementLines;
   final List<AssetLiabilityIncomePlan> incomePlans;
+  final List<AssetLiabilityTransferTask> transferTasks;
 
   const AssetLiabilityMonthlyStatePayload({
     required this.monthKey,
@@ -97,6 +98,7 @@ class AssetLiabilityMonthlyStatePayload {
     required this.cardBillingAccountIds,
     required this.cardStatementLines,
     required this.incomePlans,
+    required this.transferTasks,
   });
 
   factory AssetLiabilityMonthlyStatePayload.fromState({
@@ -112,9 +114,7 @@ class AssetLiabilityMonthlyStatePayload {
       paymentDifferenceReasons: Map<String, String>.from(
         state.paymentDifferenceReasons,
       ),
-      annualRateOverrides: Map<String, double>.from(
-        state.annualRateOverrides,
-      ),
+      annualRateOverrides: Map<String, double>.from(state.annualRateOverrides),
       paidAccountIds: Set<String>.from(state.paidAccountNames),
       paymentSourceAccountIds: Map<String, String>.from(
         state.paymentSourceAccountIds,
@@ -126,6 +126,7 @@ class AssetLiabilityMonthlyStatePayload {
         state.cardStatementLines,
       ),
       incomePlans: List<AssetLiabilityIncomePlan>.from(state.incomePlans),
+      transferTasks: List<AssetLiabilityTransferTask>.from(state.transferTasks),
     );
   }
 
@@ -166,6 +167,9 @@ class AssetLiabilityMonthlyStatePayload {
       incomePlans: _readIncomePlans(json, 'income_plans') ??
           _readIncomePlans(json, 'incomePlans') ??
           const <AssetLiabilityIncomePlan>[],
+      transferTasks: _readTransferTasks(json, 'transfer_tasks') ??
+          _readTransferTasks(json, 'transferTasks') ??
+          const <AssetLiabilityTransferTask>[],
     );
   }
 
@@ -186,6 +190,7 @@ class AssetLiabilityMonthlyStatePayload {
         cardStatementLines,
       ),
       incomePlans: List<AssetLiabilityIncomePlan>.from(incomePlans),
+      transferTasks: List<AssetLiabilityTransferTask>.from(transferTasks),
     );
   }
 
@@ -214,6 +219,9 @@ class AssetLiabilityMonthlyStatePayload {
         for (final line in cardStatementLines) _encodeCardStatementLine(line),
       ],
       'income_plans': [for (final plan in incomePlans) _encodeIncomePlan(plan)],
+      'transfer_tasks': [
+        for (final task in transferTasks) _encodeTransferTask(task),
+      ],
       if (timestamp != null) 'updated_at': timestamp,
     };
   }
@@ -392,6 +400,20 @@ Map<String, Object?> _encodeCardStatementLine(
   };
 }
 
+Map<String, Object?> _encodeTransferTask(AssetLiabilityTransferTask task) {
+  return <String, Object?>{
+    'id': task.id,
+    'fromAccountId': task.fromAccountId,
+    'fromAccountName': task.fromAccountName,
+    'toAccountId': task.toAccountId,
+    'toAccountName': task.toAccountName,
+    'amount': task.amount,
+    'dueDate': task.dueDate == null ? null : _dateOnly(task.dueDate!),
+    'completed': task.completed,
+    'completedAt': task.completedAt?.toUtc().toIso8601String(),
+  };
+}
+
 AssetLiabilityIncomePlan? _decodeIncomePlan(Object? source) {
   if (source is! Map) {
     return null;
@@ -476,6 +498,48 @@ AssetLiabilityCardStatementLine? _decodeCardStatementLine(Object? source) {
   );
 }
 
+AssetLiabilityTransferTask? _decodeTransferTask(Object? source) {
+  if (source is! Map) {
+    return null;
+  }
+  final id = _cleanString(source['id']);
+  final fromAccountId = _cleanString(source['fromAccountId']) ??
+      _cleanString(source['from_account_id']);
+  final toAccountId = _cleanString(source['toAccountId']) ??
+      _cleanString(source['to_account_id']);
+  final amount = _parseDouble(source['amount']);
+  final dueDateText =
+      _cleanString(source['dueDate']) ?? _cleanString(source['due_date']);
+  final completedAtText = _cleanString(source['completedAt']) ??
+      _cleanString(source['completed_at']);
+  final dueDate = dueDateText == null ? null : DateTime.tryParse(dueDateText);
+  final completedAt =
+      completedAtText == null ? null : DateTime.tryParse(completedAtText);
+  if (id == null ||
+      fromAccountId == null ||
+      toAccountId == null ||
+      fromAccountId == toAccountId ||
+      amount == null ||
+      amount <= 0) {
+    return null;
+  }
+  return AssetLiabilityTransferTask(
+    id: id,
+    fromAccountId: fromAccountId,
+    fromAccountName: _cleanString(source['fromAccountName']) ??
+        _cleanString(source['from_account_name']) ??
+        fromAccountId,
+    toAccountId: toAccountId,
+    toAccountName: _cleanString(source['toAccountName']) ??
+        _cleanString(source['to_account_name']) ??
+        toAccountId,
+    amount: amount,
+    dueDate: dueDate,
+    completed: source['completed'] == true,
+    completedAt: completedAt,
+  );
+}
+
 List<AssetLiabilityIncomePlan>? _readIncomePlans(
   Map<String, Object?> json,
   String key,
@@ -555,6 +619,39 @@ List<AssetLiabilityCardStatementLine>? _readCardStatementLines(
     return a.description.compareTo(b.description);
   });
   return lines;
+}
+
+List<AssetLiabilityTransferTask>? _readTransferTasks(
+  Map<String, Object?> json,
+  String key,
+) {
+  final source = json[key];
+  if (source is! Iterable) {
+    return null;
+  }
+  final tasks = <AssetLiabilityTransferTask>[];
+  for (final value in source) {
+    final task = _decodeTransferTask(value);
+    if (task != null) {
+      tasks.add(task);
+    }
+  }
+  tasks.sort((a, b) {
+    final aDue = a.dueDate;
+    final bDue = b.dueDate;
+    if (aDue != null && bDue != null) {
+      final date = aDue.compareTo(bDue);
+      if (date != 0) {
+        return date;
+      }
+    } else if (aDue != null) {
+      return -1;
+    } else if (bDue != null) {
+      return 1;
+    }
+    return a.id.compareTo(b.id);
+  });
+  return tasks;
 }
 
 Map<String, double>? _readDoubleMap(Map<String, Object?> json, String key) {

--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -279,6 +279,8 @@ class AssetLiabilityAccountCashflowSummary {
   final double currentBalance;
   final double upcomingPayments;
   final double upcomingIncome;
+  final double pendingTransferIn;
+  final double pendingTransferOut;
   final double projectedBalance;
   final AssetLiabilityCashRiskLevel riskLevel;
 
@@ -288,6 +290,8 @@ class AssetLiabilityAccountCashflowSummary {
     required this.currentBalance,
     required this.upcomingPayments,
     required this.upcomingIncome,
+    this.pendingTransferIn = 0,
+    this.pendingTransferOut = 0,
     required this.projectedBalance,
     required this.riskLevel,
   });
@@ -312,6 +316,54 @@ class AssetLiabilityTransferSuggestion {
     required this.amount,
     required this.neededBy,
   });
+}
+
+class AssetLiabilityTransferTask {
+  final String id;
+  final String fromAccountId;
+  final String fromAccountName;
+  final String toAccountId;
+  final String toAccountName;
+  final double amount;
+  final DateTime? dueDate;
+  final bool completed;
+  final DateTime? completedAt;
+
+  const AssetLiabilityTransferTask({
+    required this.id,
+    required this.fromAccountId,
+    required this.fromAccountName,
+    required this.toAccountId,
+    required this.toAccountName,
+    required this.amount,
+    required this.dueDate,
+    this.completed = false,
+    this.completedAt,
+  });
+
+  AssetLiabilityTransferTask copyWith({
+    String? id,
+    String? fromAccountId,
+    String? fromAccountName,
+    String? toAccountId,
+    String? toAccountName,
+    double? amount,
+    DateTime? dueDate,
+    bool? completed,
+    DateTime? completedAt,
+  }) {
+    return AssetLiabilityTransferTask(
+      id: id ?? this.id,
+      fromAccountId: fromAccountId ?? this.fromAccountId,
+      fromAccountName: fromAccountName ?? this.fromAccountName,
+      toAccountId: toAccountId ?? this.toAccountId,
+      toAccountName: toAccountName ?? this.toAccountName,
+      amount: amount ?? this.amount,
+      dueDate: dueDate ?? this.dueDate,
+      completed: completed ?? this.completed,
+      completedAt: completedAt ?? this.completedAt,
+    );
+  }
 }
 
 class AssetLiabilityMonthlySnapshot {
@@ -632,6 +684,7 @@ class AssetLiabilityWorkbook {
   final List<AssetLiabilityPaymentDayRisk> paymentDayRisks;
   final List<AssetLiabilityCashflowRow> cashflowRows;
   final List<AssetLiabilityIncomePlan> incomePlans;
+  final List<AssetLiabilityTransferTask> transferTasks;
   final List<AssetLiabilityAccountCashflowSummary> accountCashflowSummaries;
   final List<AssetLiabilityTransferSuggestion> transferSuggestions;
   final AssetLiabilityCardBillingReviewData cardBillingReview;
@@ -663,6 +716,7 @@ class AssetLiabilityWorkbook {
     required this.paymentDayRisks,
     required this.cashflowRows,
     required this.incomePlans,
+    required this.transferTasks,
     required this.accountCashflowSummaries,
     required this.transferSuggestions,
     required this.cardBillingReview,

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -124,6 +124,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       <String, _CardBillingSaveScope>{};
   List<AssetLiabilityIncomePlan> _monthlyIncomePlans =
       <AssetLiabilityIncomePlan>[];
+  List<AssetLiabilityTransferTask> _transferTasks =
+      <AssetLiabilityTransferTask>[];
   List<AssetLiabilityRecurringIncomeTemplate> _recurringIncomeTemplates =
       <AssetLiabilityRecurringIncomeTemplate>[];
   List<AssetLiabilityMonthlySnapshot> _monthlySnapshots =
@@ -885,6 +887,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _monthlyIncomePlans = List<AssetLiabilityIncomePlan>.from(
           incomePlansWithTemplates,
         );
+        _transferTasks = List<AssetLiabilityTransferTask>.from(
+          state.transferTasks,
+        );
         _recurringIncomeTemplates =
             List<AssetLiabilityRecurringIncomeTemplate>.from(templates);
         _monthlySnapshots = List<AssetLiabilityMonthlySnapshot>.from(
@@ -937,6 +942,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _cardStatementLines,
         ),
         incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
+        transferTasks: List<AssetLiabilityTransferTask>.from(_transferTasks),
       ),
     );
   }
@@ -1231,9 +1237,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       bundle.accountCashflowCsv,
       'asset_liability_account_cashflow_${monthKey}_$stamp.csv',
     );
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(
+    ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(
         content: Text('Asset liability CSV bundle exported (5 files)'),
       ),
@@ -1265,6 +1269,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _cardStatementLines,
         ),
         incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
+        transferTasks: List<AssetLiabilityTransferTask>.from(_transferTasks),
       ),
       legacyKeyToAccountId: legacyKeyToAccountId,
     );
@@ -1303,7 +1308,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _sameCardStatementLines(
           _cardStatementLines,
           migrated.cardStatementLines,
-        )) {
+        ) &&
+        _sameTransferTasks(_transferTasks, migrated.transferTasks)) {
       return;
     }
 
@@ -1331,6 +1337,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
         _cardStatementLines = List<AssetLiabilityCardStatementLine>.from(
           migrated.cardStatementLines,
+        );
+        _transferTasks = List<AssetLiabilityTransferTask>.from(
+          migrated.transferTasks,
         );
         _defaultPaymentSourceAccountIds = Map<String, String>.from(
           migratedDefaultSources,
@@ -1407,6 +1416,32 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               right.postedAt?.toIso8601String() ||
           left.description != right.description ||
           left.amount != right.amount) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _sameTransferTasks(
+    List<AssetLiabilityTransferTask> a,
+    List<AssetLiabilityTransferTask> b,
+  ) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (var i = 0; i < a.length; i++) {
+      final left = a[i];
+      final right = b[i];
+      if (left.id != right.id ||
+          left.fromAccountId != right.fromAccountId ||
+          left.fromAccountName != right.fromAccountName ||
+          left.toAccountId != right.toAccountId ||
+          left.toAccountName != right.toAccountName ||
+          left.amount != right.amount ||
+          left.dueDate?.toIso8601String() != right.dueDate?.toIso8601String() ||
+          left.completed != right.completed ||
+          left.completedAt?.toIso8601String() !=
+              right.completedAt?.toIso8601String()) {
         return false;
       }
     }
@@ -1825,6 +1860,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       );
       _cardStatementLines = <AssetLiabilityCardStatementLine>[];
       _monthlyIncomePlans = incomePlansWithTemplates;
+      _transferTasks = <AssetLiabilityTransferTask>[];
       _syncPaymentStateControllers();
     });
     unawaited(_saveAssetLiabilityMonthlyState());
@@ -1885,6 +1921,107 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     setState(() {
       _monthlyIncomePlans = _monthlyIncomePlans
           .where((plan) => plan.id != incomeId)
+          .toList(growable: false);
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  int _compareTransferTasksByDueDate(
+    AssetLiabilityTransferTask a,
+    AssetLiabilityTransferTask b,
+  ) {
+    final aDue = a.dueDate;
+    final bDue = b.dueDate;
+    if (aDue != null && bDue != null) {
+      final date = aDue.compareTo(bDue);
+      if (date != 0) {
+        return date;
+      }
+    } else if (aDue != null) {
+      return -1;
+    } else if (bDue != null) {
+      return 1;
+    }
+    return a.id.compareTo(b.id);
+  }
+
+  void _createTransferTaskFromSuggestion(
+    AssetLiabilityTransferSuggestion suggestion,
+  ) {
+    final dueDate = suggestion.neededBy == null
+        ? null
+        : DateTime(
+            suggestion.neededBy!.year,
+            suggestion.neededBy!.month,
+            suggestion.neededBy!.day,
+          );
+    final duplicate = _transferTasks.any(
+      (task) =>
+          !task.completed &&
+          task.fromAccountId == suggestion.fromAccountId &&
+          task.toAccountId == suggestion.toAccountId &&
+          task.amount == suggestion.amount &&
+          task.dueDate?.toIso8601String() == dueDate?.toIso8601String(),
+    );
+    if (duplicate) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Transfer task already exists.')),
+      );
+      return;
+    }
+
+    final now = DateTime.now();
+    final nextTasks = List<AssetLiabilityTransferTask>.from(_transferTasks)
+      ..add(
+        AssetLiabilityTransferTask(
+          id: 'transfer_${now.microsecondsSinceEpoch}',
+          fromAccountId: suggestion.fromAccountId,
+          fromAccountName: suggestion.fromAccountName,
+          toAccountId: suggestion.toAccountId,
+          toAccountName: suggestion.toAccountName,
+          amount: suggestion.amount,
+          dueDate: dueDate,
+        ),
+      )
+      ..sort(_compareTransferTasksByDueDate);
+    setState(() {
+      _transferTasks = nextTasks;
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Transfer task created.')));
+  }
+
+  void _toggleTransferTaskCompleted(
+    AssetLiabilityTransferTask task,
+    bool completed,
+  ) {
+    setState(() {
+      _transferTasks = [
+        for (final current in _transferTasks)
+          current.id == task.id
+              ? AssetLiabilityTransferTask(
+                  id: current.id,
+                  fromAccountId: current.fromAccountId,
+                  fromAccountName: current.fromAccountName,
+                  toAccountId: current.toAccountId,
+                  toAccountName: current.toAccountName,
+                  amount: current.amount,
+                  dueDate: current.dueDate,
+                  completed: completed,
+                  completedAt: completed ? DateTime.now() : null,
+                )
+              : current,
+      ]..sort(_compareTransferTasksByDueDate);
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _deleteTransferTask(String taskId) {
+    setState(() {
+      _transferTasks = _transferTasks
+          .where((task) => task.id != taskId)
           .toList(growable: false);
     });
     unawaited(_saveAssetLiabilityMonthlyState());
@@ -6961,6 +7098,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       cardBillingAccountIds: _cardBillingAccountIds,
       incomePlans: _monthlyIncomePlans,
       cardStatementLines: _cardStatementLines,
+      transferTasks: _transferTasks,
       includeDefaultFixedPayments: true,
     );
     _scheduleAssetLiabilityStateIdMigration(workbook);
@@ -10137,8 +10275,56 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Widget _buildTransferSuggestionSection(AssetLiabilityWorkbook workbook) {
-    if (workbook.transferSuggestions.isEmpty) {
+    if (workbook.transferSuggestions.isEmpty && _transferTasks.isEmpty) {
       return const SizedBox.shrink();
+    }
+
+    final activeTasks = _transferTasks
+        .where((task) => !task.completed)
+        .toList(growable: false)
+      ..sort(_compareTransferTasksByDueDate);
+    final completedTasks = _transferTasks
+        .where((task) => task.completed)
+        .toList(growable: false)
+      ..sort(_compareTransferTasksByDueDate);
+
+    Widget buildTaskRow(AssetLiabilityTransferTask task) {
+      final dueLabel = task.dueDate == null
+          ? 'No due date'
+          : DateFormat('M/d').format(task.dueDate!);
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 6),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Checkbox(
+              value: task.completed,
+              onChanged: (value) =>
+                  _toggleTransferTaskCompleted(task, value ?? false),
+            ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.only(top: 10),
+                child: Text(
+                  '${task.fromAccountName} -> ${task.toAccountName} / '
+                  '${_formatManagementYen(task.amount)} / $dueLabel',
+                  style: TextStyle(
+                    fontSize: 12,
+                    height: 1.5,
+                    decoration:
+                        task.completed ? TextDecoration.lineThrough : null,
+                  ),
+                ),
+              ),
+            ),
+            IconButton(
+              tooltip: 'Delete transfer task',
+              icon: const Icon(Icons.delete_outline, size: 18),
+              onPressed: () => _deleteTransferTask(task.id),
+            ),
+          ],
+        ),
+      );
     }
 
     return Container(
@@ -10168,6 +10354,54 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           ),
           const SizedBox(height: 8),
+          Text(
+            'Pending transfer tasks are included in account-level projected '
+            'balances. Completed tasks are treated as already reflected in '
+            'the current balance, so they are not counted twice.',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          if (activeTasks.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            const Text(
+              'Open transfer tasks',
+              style: TextStyle(fontWeight: FontWeight.w600, fontSize: 12),
+            ),
+            const SizedBox(height: 4),
+            for (final task in activeTasks) buildTaskRow(task),
+          ],
+          if (completedTasks.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            const Text(
+              'Completed transfer tasks',
+              style: TextStyle(fontWeight: FontWeight.w600, fontSize: 12),
+            ),
+            const SizedBox(height: 4),
+            for (final task in completedTasks) buildTaskRow(task),
+          ],
+          if (workbook.transferSuggestions.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            const Text(
+              'Suggestions',
+              style: TextStyle(fontWeight: FontWeight.w600, fontSize: 12),
+            ),
+            const SizedBox(height: 4),
+          ],
+          for (final suggestion in workbook.transferSuggestions)
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                icon: const Icon(Icons.add_task, size: 16),
+                label: Text(
+                  'Create task: ${suggestion.fromAccountName} -> '
+                  '${suggestion.toAccountName}',
+                ),
+                onPressed: () => _createTransferTaskFromSuggestion(suggestion),
+              ),
+            ),
           for (final suggestion in workbook.transferSuggestions)
             Padding(
               padding: const EdgeInsets.only(bottom: 6),
@@ -10186,9 +10420,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return const SizedBox.shrink();
     }
 
-    final rows = List<AssetLiabilityDebtRow>.from(
-      workbook.debtMasterRows,
-    )..sort(_compareDebtRowsByPaymentDay);
+    final rows = List<AssetLiabilityDebtRow>.from(workbook.debtMasterRows)
+      ..sort(_compareDebtRowsByPaymentDay);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -16,6 +16,7 @@ class AssetLiabilityMonthlyState {
   final Map<String, String> cardBillingAccountIds;
   final List<AssetLiabilityCardStatementLine> cardStatementLines;
   final List<AssetLiabilityIncomePlan> incomePlans;
+  final List<AssetLiabilityTransferTask> transferTasks;
 
   const AssetLiabilityMonthlyState({
     this.paymentOverrides = const <String, double>{},
@@ -27,6 +28,7 @@ class AssetLiabilityMonthlyState {
     this.cardBillingAccountIds = const <String, String>{},
     this.cardStatementLines = const <AssetLiabilityCardStatementLine>[],
     this.incomePlans = const <AssetLiabilityIncomePlan>[],
+    this.transferTasks = const <AssetLiabilityTransferTask>[],
   });
 
   bool get isEmpty =>
@@ -38,7 +40,8 @@ class AssetLiabilityMonthlyState {
       paymentSourceAccountIds.isEmpty &&
       cardBillingAccountIds.isEmpty &&
       cardStatementLines.isEmpty &&
-      incomePlans.isEmpty;
+      incomePlans.isEmpty &&
+      transferTasks.isEmpty;
 }
 
 class AssetLiabilityMonthlyStateStore {
@@ -58,6 +61,8 @@ class AssetLiabilityMonthlyStateStore {
   static const String cardStatementPrefsKey =
       'asset_liability_card_statement_lines_v1';
   static const String incomePrefsKey = 'asset_liability_income_plans_v1';
+  static const String transferTaskPrefsKey =
+      'asset_liability_transfer_tasks_v1';
   static const String defaultPaymentSourcePrefsKey =
       'asset_liability_default_payment_source_accounts_v1';
   static const String defaultCardBillingPrefsKey =
@@ -110,6 +115,10 @@ class AssetLiabilityMonthlyStateStore {
       ),
       incomePlans: incomePlansForMonth(
         prefs.getString(incomePrefsKey),
+        monthKey,
+      ),
+      transferTasks: transferTasksForMonth(
+        prefs.getString(transferTaskPrefsKey),
         monthKey,
       ),
     );
@@ -236,6 +245,21 @@ class AssetLiabilityMonthlyStateStore {
     await prefs.setString(
       incomePrefsKey,
       jsonEncode(_encodeIncomePlans(allIncomePlans)),
+    );
+
+    final allTransferTasks = decodeTransferTasks(
+      prefs.getString(transferTaskPrefsKey),
+    );
+    if (state.transferTasks.isEmpty) {
+      allTransferTasks.remove(monthKey);
+    } else {
+      allTransferTasks[monthKey] = List<AssetLiabilityTransferTask>.from(
+        state.transferTasks,
+      );
+    }
+    await prefs.setString(
+      transferTaskPrefsKey,
+      jsonEncode(_encodeTransferTasks(allTransferTasks)),
     );
   }
 
@@ -664,6 +688,80 @@ class AssetLiabilityMonthlyStateStore {
     });
   }
 
+  static Map<String, List<AssetLiabilityTransferTask>> decodeTransferTasks(
+    String? raw,
+  ) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, List<AssetLiabilityTransferTask>>{};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return <String, List<AssetLiabilityTransferTask>>{};
+    }
+
+    return decoded.map<String, List<AssetLiabilityTransferTask>>((
+      month,
+      values,
+    ) {
+      final monthKey = month.toString();
+      final tasks = <AssetLiabilityTransferTask>[];
+      if (values is Iterable) {
+        for (final rawTask in values) {
+          if (rawTask is! Map) {
+            continue;
+          }
+          final id = rawTask['id']?.toString().trim();
+          final fromAccountId = rawTask['fromAccountId']?.toString().trim() ??
+              rawTask['from_account_id']?.toString().trim();
+          final toAccountId = rawTask['toAccountId']?.toString().trim() ??
+              rawTask['to_account_id']?.toString().trim();
+          final amount = _parseNonNullDouble(rawTask['amount']);
+          final dueDateText =
+              rawTask['dueDate']?.toString() ?? rawTask['due_date']?.toString();
+          final completedAtText = rawTask['completedAt']?.toString() ??
+              rawTask['completed_at']?.toString();
+          final dueDate =
+              dueDateText == null ? null : DateTime.tryParse(dueDateText);
+          final completedAt = completedAtText == null
+              ? null
+              : DateTime.tryParse(completedAtText);
+          if (id == null ||
+              id.isEmpty ||
+              fromAccountId == null ||
+              fromAccountId.isEmpty ||
+              toAccountId == null ||
+              toAccountId.isEmpty ||
+              fromAccountId == toAccountId ||
+              amount == null ||
+              amount <= 0) {
+            continue;
+          }
+          tasks.add(
+            AssetLiabilityTransferTask(
+              id: id,
+              fromAccountId: fromAccountId,
+              fromAccountName: _cleanNullableString(
+                    rawTask['fromAccountName'] ?? rawTask['from_account_name'],
+                  ) ??
+                  fromAccountId,
+              toAccountId: toAccountId,
+              toAccountName: _cleanNullableString(
+                    rawTask['toAccountName'] ?? rawTask['to_account_name'],
+                  ) ??
+                  toAccountId,
+              amount: amount,
+              dueDate: dueDate,
+              completed: rawTask['completed'] == true,
+              completedAt: completedAt,
+            ),
+          );
+        }
+      }
+      tasks.sort(_compareTransferTasks);
+      return MapEntry(monthKey, tasks);
+    });
+  }
+
   static List<AssetLiabilityRecurringIncomeTemplate>
       decodeRecurringIncomeTemplates(String? raw) {
     if (raw == null || raw.trim().isEmpty) {
@@ -906,6 +1004,16 @@ class AssetLiabilityMonthlyStateStore {
     );
   }
 
+  static List<AssetLiabilityTransferTask> transferTasksForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return List<AssetLiabilityTransferTask>.from(
+      decodeTransferTasks(raw)[monthKey] ??
+          const <AssetLiabilityTransferTask>[],
+    );
+  }
+
   static AssetLiabilityMonthlyState migrateLegacyKeys({
     required AssetLiabilityMonthlyState state,
     required Map<String, String> legacyKeyToAccountId,
@@ -977,6 +1085,27 @@ class AssetLiabilityMonthlyStateStore {
         ),
     ];
 
+    final migratedTransferTasks = <AssetLiabilityTransferTask>[
+      for (final task in state.transferTasks)
+        AssetLiabilityTransferTask(
+          id: task.id,
+          fromAccountId:
+              legacyKeyToAccountId[task.fromAccountId] ?? task.fromAccountId,
+          fromAccountName: legacyKeyToAccountId.containsKey(task.fromAccountId)
+              ? task.fromAccountId
+              : task.fromAccountName,
+          toAccountId:
+              legacyKeyToAccountId[task.toAccountId] ?? task.toAccountId,
+          toAccountName: legacyKeyToAccountId.containsKey(task.toAccountId)
+              ? task.toAccountId
+              : task.toAccountName,
+          amount: task.amount,
+          dueDate: task.dueDate,
+          completed: task.completed,
+          completedAt: task.completedAt,
+        ),
+    ];
+
     return AssetLiabilityMonthlyState(
       paymentOverrides: migratedPayments,
       actualPaymentAmounts: migratedActualPayments,
@@ -987,6 +1116,7 @@ class AssetLiabilityMonthlyStateStore {
       cardBillingAccountIds: migratedCardBillingAccounts,
       cardStatementLines: migratedCardStatementLines,
       incomePlans: state.incomePlans,
+      transferTasks: migratedTransferTasks,
     );
   }
 
@@ -1077,6 +1207,31 @@ class AssetLiabilityMonthlyStateStore {
     });
   }
 
+  static Map<String, List<Map<String, Object?>>> _encodeTransferTasks(
+    Map<String, List<AssetLiabilityTransferTask>> source,
+  ) {
+    return source.map((month, tasks) {
+      final sorted = List<AssetLiabilityTransferTask>.from(tasks)
+        ..sort(_compareTransferTasks);
+      return MapEntry(month, [
+        for (final task in sorted)
+          <String, Object?>{
+            'id': task.id,
+            'fromAccountId': task.fromAccountId,
+            'fromAccountName': task.fromAccountName,
+            'toAccountId': task.toAccountId,
+            'toAccountName': task.toAccountName,
+            'amount': task.amount,
+            'dueDate': task.dueDate == null
+                ? null
+                : DateFormat('yyyy-MM-dd').format(task.dueDate!),
+            'completed': task.completed,
+            'completedAt': task.completedAt?.toIso8601String(),
+          },
+      ]);
+    });
+  }
+
   static Map<String, List<Map<String, Object?>>> _encodeCardStatementLines(
     Map<String, List<AssetLiabilityCardStatementLine>> source,
   ) {
@@ -1118,6 +1273,25 @@ class AssetLiabilityMonthlyStateStore {
       return 1;
     }
     return a.description.compareTo(b.description);
+  }
+
+  static int _compareTransferTasks(
+    AssetLiabilityTransferTask a,
+    AssetLiabilityTransferTask b,
+  ) {
+    final aDue = a.dueDate;
+    final bDue = b.dueDate;
+    if (aDue != null && bDue != null) {
+      final date = aDue.compareTo(bDue);
+      if (date != 0) {
+        return date;
+      }
+    } else if (aDue != null) {
+      return -1;
+    } else if (bDue != null) {
+      return 1;
+    }
+    return a.id.compareTo(b.id);
   }
 
   static Map<String, String> _cleanStringMap(Map<String, String> source) {

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -69,6 +69,8 @@ class AssetLiabilityPlanningService {
     Map<String, String> cardBillingAccountIds = const <String, String>{},
     List<AssetLiabilityIncomePlan> incomePlans =
         const <AssetLiabilityIncomePlan>[],
+    List<AssetLiabilityTransferTask> transferTasks =
+        const <AssetLiabilityTransferTask>[],
     List<AssetLiabilityCardStatementLine> cardStatementLines =
         const <AssetLiabilityCardStatementLine>[],
     bool includeDefaultFixedPayments = false,
@@ -97,6 +99,10 @@ class AssetLiabilityPlanningService {
     };
     final resolvedIncomePlans = _resolveIncomePlans(
       incomePlans: incomePlans,
+      accountsById: accountsById,
+    );
+    final resolvedTransferTasks = _resolveTransferTasks(
+      transferTasks: transferTasks,
       accountsById: accountsById,
     );
     final effectivePaymentSourceAccountIds = <String, String>{
@@ -164,6 +170,7 @@ class AssetLiabilityPlanningService {
     final accountCashflowSummaries = _buildAccountCashflowSummaries(
       accounts: accounts,
       cashflowRows: cashflowRows,
+      transferTasks: resolvedTransferTasks,
     );
     final transferSuggestions = _buildTransferSuggestions(
       summaries: accountCashflowSummaries,
@@ -223,6 +230,7 @@ class AssetLiabilityPlanningService {
       paymentDayRisks: paymentDayRisks,
       cashflowRows: cashflowRows,
       incomePlans: resolvedIncomePlans,
+      transferTasks: resolvedTransferTasks,
       accountCashflowSummaries: accountCashflowSummaries,
       transferSuggestions: transferSuggestions,
       cardBillingReview: cardBillingReview,
@@ -1196,9 +1204,57 @@ class AssetLiabilityPlanningService {
     return result;
   }
 
+  List<AssetLiabilityTransferTask> _resolveTransferTasks({
+    required List<AssetLiabilityTransferTask> transferTasks,
+    required Map<String, AssetLiabilityAccount> accountsById,
+  }) {
+    final result = <AssetLiabilityTransferTask>[];
+    for (final task in transferTasks) {
+      if (task.id.trim().isEmpty ||
+          task.fromAccountId.trim().isEmpty ||
+          task.toAccountId.trim().isEmpty ||
+          task.fromAccountId == task.toAccountId ||
+          task.amount <= 0) {
+        continue;
+      }
+      final fromAccount = accountsById[task.fromAccountId];
+      final toAccount = accountsById[task.toAccountId];
+      result.add(
+        AssetLiabilityTransferTask(
+          id: task.id,
+          fromAccountId: task.fromAccountId,
+          fromAccountName: fromAccount?.name ?? task.fromAccountName,
+          toAccountId: task.toAccountId,
+          toAccountName: toAccount?.name ?? task.toAccountName,
+          amount: task.amount,
+          dueDate: task.dueDate == null ? null : _dateOnly(task.dueDate!),
+          completed: task.completed,
+          completedAt: task.completedAt,
+        ),
+      );
+    }
+    result.sort((a, b) {
+      final aDate = a.dueDate;
+      final bDate = b.dueDate;
+      if (aDate != null && bDate != null) {
+        final date = aDate.compareTo(bDate);
+        if (date != 0) {
+          return date;
+        }
+      } else if (aDate != null) {
+        return -1;
+      } else if (bDate != null) {
+        return 1;
+      }
+      return a.id.compareTo(b.id);
+    });
+    return result;
+  }
+
   List<AssetLiabilityAccountCashflowSummary> _buildAccountCashflowSummaries({
     required List<AssetLiabilityAccount> accounts,
     required List<AssetLiabilityCashflowRow> cashflowRows,
+    required List<AssetLiabilityTransferTask> transferTasks,
   }) {
     final cashLikeAccounts = accounts.where(_isCashLike).toList()
       ..sort((a, b) => b.balance.compareTo(a.balance));
@@ -1222,13 +1278,31 @@ class AssetLiabilityPlanningService {
                 ? sum + row.paymentAmount
                 : sum,
           );
-          final projected = account.balance - payments + income;
+          final pendingTransferIn = transferTasks.fold<double>(
+            0,
+            (sum, task) => !task.completed && task.toAccountId == account.id
+                ? sum + task.amount
+                : sum,
+          );
+          final pendingTransferOut = transferTasks.fold<double>(
+            0,
+            (sum, task) => !task.completed && task.fromAccountId == account.id
+                ? sum + task.amount
+                : sum,
+          );
+          final projected = account.balance -
+              payments +
+              income +
+              pendingTransferIn -
+              pendingTransferOut;
           return AssetLiabilityAccountCashflowSummary(
             accountId: account.id,
             accountName: account.name,
             currentBalance: account.balance,
             upcomingPayments: payments,
             upcomingIncome: income,
+            pendingTransferIn: pendingTransferIn,
+            pendingTransferOut: pendingTransferOut,
             projectedBalance: projected,
             riskLevel: _cashRiskLevel(projected),
           );

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1432,7 +1432,8 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
           local.cardStatementLines,
           remote.cardStatementLines,
         ) &&
-        _incomePlansEqual(local.incomePlans, remote.incomePlans);
+        _incomePlansEqual(local.incomePlans, remote.incomePlans) &&
+        _transferTasksEqual(local.transferTasks, remote.transferTasks);
   }
 
   bool _doubleMapEquals(Map<String, double> a, Map<String, double> b) {
@@ -1513,6 +1514,35 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
           left.postedAt != right.postedAt ||
           left.description != right.description ||
           left.amount != right.amount) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _transferTasksEqual(
+    List<AssetLiabilityTransferTask> a,
+    List<AssetLiabilityTransferTask> b,
+  ) {
+    final first = List<AssetLiabilityTransferTask>.from(a)
+      ..sort((left, right) => left.id.compareTo(right.id));
+    final second = List<AssetLiabilityTransferTask>.from(b)
+      ..sort((left, right) => left.id.compareTo(right.id));
+    if (first.length != second.length) {
+      return false;
+    }
+    for (var i = 0; i < first.length; i++) {
+      final left = first[i];
+      final right = second[i];
+      if (left.id != right.id ||
+          left.fromAccountId != right.fromAccountId ||
+          left.fromAccountName != right.fromAccountName ||
+          left.toAccountId != right.toAccountId ||
+          left.toAccountName != right.toAccountName ||
+          left.amount != right.amount ||
+          left.dueDate != right.dueDate ||
+          left.completed != right.completed ||
+          left.completedAt != right.completedAt) {
         return false;
       }
     }

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -48,6 +48,17 @@ void main() {
               received: false,
             ),
           ],
+          transferTasks: <AssetLiabilityTransferTask>[
+            AssetLiabilityTransferTask(
+              id: 'transfer_bank_topup',
+              fromAccountId: 'custom_cash',
+              fromAccountName: 'Cash',
+              toAccountId: 'custom_bank',
+              toAccountName: 'Bank',
+              amount: 10000,
+              dueDate: DateTime(2026, 5, 18),
+            ),
+          ],
         ),
       );
 
@@ -64,6 +75,8 @@ void main() {
       expect(loadedMay.cardStatementLines.single.amount, 6200);
       expect(loadedMay.cardStatementLines.single.description, 'mobile');
       expect(loadedMay.incomePlans.single.name, 'Salary');
+      expect(loadedMay.transferTasks.single.id, 'transfer_bank_topup');
+      expect(loadedMay.transferTasks.single.amount, 10000);
       expect(loadedJune.paymentOverrides, isEmpty);
       expect(loadedJune.actualPaymentAmounts, isEmpty);
       expect(loadedJune.paymentDifferenceReasons, isEmpty);
@@ -73,6 +86,7 @@ void main() {
       expect(loadedJune.cardBillingAccountIds, isEmpty);
       expect(loadedJune.cardStatementLines, isEmpty);
       expect(loadedJune.incomePlans, isEmpty);
+      expect(loadedJune.transferTasks, isEmpty);
     });
 
     test('clears monthly paid status after unchecked state is saved', () async {
@@ -176,9 +190,7 @@ void main() {
       final migrated = AssetLiabilityMonthlyStateStore.migrateLegacyKeys(
         state: const AssetLiabilityMonthlyState(
           actualPaymentAmounts: <String, double>{'Legacy card': 6200},
-          paymentDifferenceReasons: <String, String>{
-            'Legacy card': 'late fee',
-          },
+          paymentDifferenceReasons: <String, String>{'Legacy card': 'late fee'},
           annualRateOverrides: <String, double>{'Legacy card': 0.145},
         ),
         legacyKeyToAccountId: const <String, String>{
@@ -223,6 +235,17 @@ void main() {
                 received: true,
               ),
             ],
+            transferTasks: <AssetLiabilityTransferTask>[
+              AssetLiabilityTransferTask(
+                id: 'transfer_may',
+                fromAccountId: 'custom_cash',
+                fromAccountName: 'Cash',
+                toAccountId: 'custom_bank',
+                toAccountName: 'Bank',
+                amount: 10000,
+                dueDate: DateTime(2026, 5, 20),
+              ),
+            ],
           ),
         );
 
@@ -240,6 +263,7 @@ void main() {
           'kddi_provider': 'paypay_card',
         });
         expect(copied.paidAccountNames, isEmpty);
+        expect(copied.transferTasks, isEmpty);
         expect(copied.incomePlans.single.date, DateTime(2026, 6, 30));
         expect(copied.incomePlans.single.received, isFalse);
         expect(loaded.paidAccountNames, isEmpty);
@@ -248,6 +272,7 @@ void main() {
           'kddi_provider': 'paypay_card',
         });
         expect(loaded.incomePlans.single.received, isFalse);
+        expect(loaded.transferTasks, isEmpty);
       },
     );
 

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -868,6 +868,77 @@ void main() {
       expect(workbook.transferSuggestions.single.toAccountId, 'custom_bank');
     });
 
+    test('applies pending transfer tasks to account-level cashflow', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'bank': 10000,
+          'mobit': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 20000},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'custom_bank'},
+        transferTasks: <AssetLiabilityTransferTask>[
+          AssetLiabilityTransferTask(
+            id: 'transfer_bank_topup',
+            fromAccountId: 'custom_cash',
+            fromAccountName: 'cash',
+            toAccountId: 'custom_bank',
+            toAccountName: 'bank',
+            amount: 10000,
+            dueDate: DateTime(2026, 5, 8),
+          ),
+        ],
+      );
+
+      final cashSummary = workbook.accountCashflowSummaries.firstWhere(
+        (summary) => summary.accountId == 'custom_cash',
+      );
+      final bankSummary = workbook.accountCashflowSummaries.firstWhere(
+        (summary) => summary.accountId == 'custom_bank',
+      );
+
+      expect(cashSummary.pendingTransferOut, 10000);
+      expect(cashSummary.projectedBalance, 40000);
+      expect(bankSummary.pendingTransferIn, 10000);
+      expect(bankSummary.projectedBalance, 0);
+      expect(workbook.transferSuggestions, isEmpty);
+    });
+
+    test('does not double count completed transfer tasks', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'bank': 10000,
+          'mobit': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 20000},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'custom_bank'},
+        transferTasks: <AssetLiabilityTransferTask>[
+          AssetLiabilityTransferTask(
+            id: 'transfer_done',
+            fromAccountId: 'custom_cash',
+            fromAccountName: 'cash',
+            toAccountId: 'custom_bank',
+            toAccountName: 'bank',
+            amount: 10000,
+            dueDate: DateTime(2026, 5, 8),
+            completed: true,
+            completedAt: DateTime(2026, 5, 8, 9),
+          ),
+        ],
+      );
+
+      final bankSummary = workbook.accountCashflowSummaries.firstWhere(
+        (summary) => summary.accountId == 'custom_bank',
+      );
+
+      expect(bankSummary.pendingTransferIn, 0);
+      expect(bankSummary.projectedBalance, -10000);
+      expect(workbook.transferSuggestions.single.amount, 10000);
+    });
+
     test('applies default payment source to unset monthly items', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: <String, double>{

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -1162,6 +1162,17 @@ void main() {
             received: true,
           ),
         ],
+        transferTasks: <AssetLiabilityTransferTask>[
+          AssetLiabilityTransferTask(
+            id: 'transfer_bank_topup',
+            fromAccountId: 'custom_cash',
+            fromAccountName: 'Cash',
+            toAccountId: 'smbc_otsuka',
+            toAccountName: 'SMBC Otsuka',
+            amount: 10000,
+            dueDate: DateTime(2026, 5, 18),
+          ),
+        ],
       );
 
       final payload = AssetLiabilityMonthlyStatePayload.fromState(
@@ -1188,6 +1199,9 @@ void main() {
       expect(restored.cardStatementLines.single.description, 'KDDI');
       expect(restored.cardStatementLines.single.amount, 5764);
       expect(restored.incomePlans.single.received, isTrue);
+      expect(row['transfer_tasks'], isA<List<Object?>>());
+      expect(restored.transferTasks.single.toAccountId, 'smbc_otsuka');
+      expect(restored.transferTasks.single.amount, 10000);
     });
 
     test('round-trips settings and snapshot payloads', () {
@@ -1595,6 +1609,17 @@ AssetLiabilityMonthlyState _sampleMonthlyState() {
         destinationAccountId: 'smbc_otsuka',
         destinationAccountName: 'SMBC Otsuka',
         received: false,
+      ),
+    ],
+    transferTasks: <AssetLiabilityTransferTask>[
+      AssetLiabilityTransferTask(
+        id: 'transfer_bank_topup',
+        fromAccountId: 'custom_cash',
+        fromAccountName: 'Cash',
+        toAccountId: 'smbc_otsuka',
+        toAccountName: 'SMBC Otsuka',
+        amount: 10000,
+        dueDate: DateTime(2026, 5, 18),
       ),
     ],
   );

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -255,6 +255,7 @@ AssetLiabilityWorkbook _workbook({
     paymentDayRisks: const <AssetLiabilityPaymentDayRisk>[],
     cashflowRows: const <AssetLiabilityCashflowRow>[],
     incomePlans: const <AssetLiabilityIncomePlan>[],
+    transferTasks: const <AssetLiabilityTransferTask>[],
     accountCashflowSummaries: const <AssetLiabilityAccountCashflowSummary>[],
     transferSuggestions: const <AssetLiabilityTransferSuggestion>[],
     cardBillingReview: const AssetLiabilityCardBillingReviewData(


### PR DESCRIPTION
## Summary
- add persisted account transfer tasks to asset/liability monthly state and Supabase payloads
- apply pending transfers to account-level projected balances while excluding completed transfers to avoid double counting
- surface transfer task creation, completion, and deletion from the asset management transfer suggestions UI

## Validation
- dart format --output=none --set-exit-if-changed .
- flutter analyze --no-pub
- flutter test --no-pub test/services/asset_liability_planning_service_test.dart test/services/asset_liability_monthly_state_store_test.dart test/services/asset_liability_repository_test.dart test/services/asset_management_insight_service_test.dart

## Minimal E2E Gate
- The E2E plan is implementation-detail independent / black-box and focuses on user-visible account transfer task behavior.
- Minimal plan: three I/O cases: create a transfer task from a suggestion, mark it complete without double-counting projected balance, and delete a transfer task.
- E2E mechanism: Playwright or Flutter integration_test can cover the same black-box UI contract when this asset-management flow receives a browser fixture.
- E2E-Exception reason: this scoped PR adds model/state/repository plumbing plus covered service tests; adding a new browser fixture here would be larger than the #2452 slice and risk unrelated asset-page churn.

## Guarded subagent orchestration
- Lead owner: Codex #1 Windows app
- Child workers: none used
- Scope/risk: single scoped #2452 asset-management slice, no persistent extra lane
- Cleanup evidence: formatter/test Dart processes stopped after local validation

Closes #2452