### PR TITLE
Enable asset management Supabase sync and AI summary

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -649,8 +649,9 @@ jobs:
             --dart-define=ENVIRONMENT=production \
             --dart-define=APP_VERSION=${{ steps.version.outputs.version }} \
             --dart-define=BUILD_NUMBER=${{ github.run_number }} \
-            --dart-define=ASSET_LIABILITY_SUPABASE_SYNC_ENABLED=false \
-            --dart-define=ASSET_LIABILITY_SUPABASE_PRODUCTION_WRITES_ENABLED=false \
+            --dart-define=ASSET_LIABILITY_SUPABASE_SYNC_ENABLED=true \
+            --dart-define=ASSET_LIABILITY_SUPABASE_PRODUCTION_WRITES_ENABLED=true \
+            --dart-define=ASSET_MANAGEMENT_AI_SUMMARY_ENABLED=true \
             --dart-define=LANDING_GOOGLE_LOGIN_ENABLED=${{ env.LANDING_GOOGLE_LOGIN_ENABLED }}
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -85,7 +85,12 @@ jobs:
 
       # Build Flutter Web
       - name: Build Flutter Web (Staging)
-        run: flutter build web --release --pwa-strategy=none --no-tree-shake-icons --dart-define=ENVIRONMENT=staging
+        run: >
+          flutter build web --release --pwa-strategy=none --no-tree-shake-icons
+          --dart-define=ENVIRONMENT=staging
+          --dart-define=ASSET_LIABILITY_SUPABASE_SYNC_ENABLED=true
+          --dart-define=ASSET_LIABILITY_SUPABASE_PRODUCTION_WRITES_ENABLED=true
+          --dart-define=ASSET_MANAGEMENT_AI_SUMMARY_ENABLED=true
         env:
           # 修正: シークレット名を _STAGING に変更
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING }}

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -232,6 +232,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   String? _wasteTrainingAiReviewKey;
   bool _isGeneratingAssetManagementAiSummary = false;
   AssetManagementAiSummaryResult? _assetManagementAiSummaryResult;
+  String? _assetManagementAiSummaryRequestKey;
 
   final List<Color> _colors = [
     const Color(0xFF6366F1),
@@ -7967,9 +7968,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Widget _buildAssetManagementAiSummaryPanel(
     AssetManagementInsightReport report,
   ) {
-    final result = _assetManagementAiSummaryResult ??
-        _assetManagementAiSummaryService.buildDisabledResult(report);
     final enabled = _assetManagementAiSummaryService.aiEnabled;
+    if (enabled) {
+      _requestAssetManagementAiSummaryIfNeeded(report);
+    }
+    final result = _assetManagementAiSummaryResult ??
+        (enabled
+            ? _assetManagementAiSummaryService.buildWaitingForAiResult(report)
+            : _assetManagementAiSummaryService.buildDisabledResult(report));
     final color = switch (result.status) {
       AssetManagementAiSummaryStatus.aiGenerated => const Color(0xFF0D9488),
       AssetManagementAiSummaryStatus.fallback => const Color(0xFFD97706),
@@ -8069,9 +8075,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Future<void> _generateAssetManagementAiSummary(
-    AssetManagementInsightReport report,
-  ) async {
-    setState(() => _isGeneratingAssetManagementAiSummary = true);
+    AssetManagementInsightReport report, {
+    String? requestKey,
+  }) async {
+    final key = requestKey ?? _assetManagementAiSummaryKey(report);
+    setState(() {
+      _isGeneratingAssetManagementAiSummary = true;
+      _assetManagementAiSummaryRequestKey = key;
+    });
     final result = await _assetManagementAiSummaryService.generateSummary(
       report: report,
     );
@@ -8081,7 +8092,35 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     setState(() {
       _assetManagementAiSummaryResult = result;
       _isGeneratingAssetManagementAiSummary = false;
+      _assetManagementAiSummaryRequestKey = key;
     });
+  }
+
+  void _requestAssetManagementAiSummaryIfNeeded(
+    AssetManagementInsightReport report,
+  ) {
+    if (!_assetManagementAiSummaryService.aiEnabled ||
+        _isGeneratingAssetManagementAiSummary) {
+      return;
+    }
+    final key = _assetManagementAiSummaryKey(report);
+    if (_assetManagementAiSummaryRequestKey == key) {
+      return;
+    }
+    _assetManagementAiSummaryRequestKey = key;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted ||
+          !_assetManagementAiSummaryService.aiEnabled ||
+          _isGeneratingAssetManagementAiSummary ||
+          _assetManagementAiSummaryRequestKey != key) {
+        return;
+      }
+      unawaited(_generateAssetManagementAiSummary(report, requestKey: key));
+    });
+  }
+
+  String _assetManagementAiSummaryKey(AssetManagementInsightReport report) {
+    return jsonEncode(_assetManagementAiSummaryService.buildPayload(report));
   }
 
   Widget _buildAssetManagementAvailableCard(

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -116,6 +116,20 @@ class AssetManagementAiSummaryService {
     );
   }
 
+  AssetManagementAiSummaryResult buildWaitingForAiResult(
+    AssetManagementInsightReport report,
+  ) {
+    final payload = buildPayload(report);
+    return AssetManagementAiSummaryResult(
+      status: AssetManagementAiSummaryStatus.fallback,
+      text: buildDeterministicSummary(report),
+      source: 'deterministic fallback / waiting for ai-hub',
+      errorMessage: null,
+      generatedAt: _now(),
+      payload: payload,
+    );
+  }
+
   Map<String, dynamic> buildPayload(AssetManagementInsightReport report) {
     return <String, dynamic>{
       'available_money': <String, dynamic>{

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -114,6 +114,25 @@ void main() {
       expect(guardrails['must_not_recommend_starvation_or_water_only'], true);
     });
 
+    test(
+      'waiting result keeps deterministic text before external AI returns',
+      () {
+        final service = AssetManagementAiSummaryService(
+          now: () => DateTime(2026, 5, 1, 12),
+        );
+
+        final result = service.buildWaitingForAiResult(_report());
+
+        expect(result.status, AssetManagementAiSummaryStatus.fallback);
+        expect(result.usedExternalAi, false);
+        expect(result.source, 'deterministic fallback / waiting for ai-hub');
+        expect(
+          result.text.contains('Amounts are calculated by Dart rules'),
+          true,
+        );
+      },
+    );
+
     test('deterministic fallback gives concrete emergency living advice', () {
       final report = _emergencyReport();
       final service = AssetManagementAiSummaryService(


### PR DESCRIPTION
﻿## 概要

資産/負債管理ボードで、Supabase同期とAI資産管理アシスタントの外部AI要約を本番/ステージングビルドで有効化します。

## 主な変更

- Production / Staging の Flutter Web build で以下の runtime flag を `true` に変更
  - `ASSET_LIABILITY_SUPABASE_SYNC_ENABLED`
  - `ASSET_LIABILITY_SUPABASE_PRODUCTION_WRITES_ENABLED`
  - `ASSET_MANAGEMENT_AI_SUMMARY_ENABLED`
- AI資産管理アシスタントが有効な場合、計算済み insight payload を `ai-hub provider.chat` へ自動要約依頼するように変更
- AI応答待ちの間はDart側の deterministic summary を表示し、金額計算は引き続きDart側だけで行う
- AI応答待ち用の結果生成メソッドとサービス層テストを追加

## Minimal E2E Declaration

This PR has an implementation-detail independent, black-box E2E plan with 3 cases:

1. Open the asset management page with runtime flags enabled and confirm the Supabase sync panel shows ON and manual sync/preview controls are available.
2. Open the AI asset management assistant with runtime flags enabled and confirm the AI summary path can call the external `ai-hub provider.chat` API while preserving the Dart-calculated amounts.
3. Disable the runtime flags in a local/dev build and confirm Supabase/AI calls stay disabled and the deterministic fallback remains visible.

E2E-Exception: no new integration_test file was added because this PR primarily changes production/staging dart-define runtime flags and a guarded UI auto-request path. Local web-server smoke with the flags enabled returned HTTP 200, and existing service tests cover the external AI call/fallback behavior.

## High-risk Ultrareview

Claude ultrareview evidence:

- Reviewer: Claude Code #1
- Scope: production/staging deploy workflow flags, Supabase production writes, and external AI API invocation through `ai-hub`
- Security: no secrets, tokens, service_role keys, or credentials are added; existing Supabase anon/env secret flow remains unchanged
- Rollback: set the three dart-defines back to `false` in deploy workflows or revert this PR; app-side fallback remains deterministic if `ai-hub` fails
- Data migration: no migration or schema change is included
- Prod smoke: local web-server smoke with all three flags enabled returned HTTP 200; GitHub Public E2E stability smoke will run on PR
- Observability: existing sync status/audit UI and AI source/status chips continue to show sync/AI state and fallback source
- No unresolved findings: 0

## 検証

- `dart format --output=none --set-exit-if-changed ...`: OK
- `dart analyze lib/pages/asset_management_page.dart lib/services/asset_management_ai_summary_service.dart test/services/asset_management_ai_summary_service_test.dart`: No issues found
- `flutter test --no-pub test/services/asset_management_ai_summary_service_test.dart --reporter expanded`: 6 passed
- `flutter test --no-pub --reporter expanded`: 494 passed
- `git diff --check`: OK
- deployment runtime flag check script: OK
- local Web smoke with flags enabled: HTTP 200

## 注意

`dart pub get --enforce-lockfile` は既存の lockfile 不整合により失敗します（Would change 7 dependencies）。検証用に一時的に `dart pub get` で `.dart_tool/package_config.json` を作成し、`pubspec.lock` はコミット前に復元済みです。
