### PR TITLE
Require APR evidence and add rent payment to asset board

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -80,6 +80,7 @@ class AssetLiabilityMonthlyStatePayload {
   final Map<String, double> actualPaymentAmounts;
   final Map<String, String> paymentDifferenceReasons;
   final Map<String, double> annualRateOverrides;
+  final Map<String, AssetLiabilityAnnualRateEvidence> annualRateEvidences;
   final Set<String> paidAccountIds;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
@@ -93,6 +94,7 @@ class AssetLiabilityMonthlyStatePayload {
     required this.actualPaymentAmounts,
     required this.paymentDifferenceReasons,
     required this.annualRateOverrides,
+    required this.annualRateEvidences,
     required this.paidAccountIds,
     required this.paymentSourceAccountIds,
     required this.cardBillingAccountIds,
@@ -115,6 +117,9 @@ class AssetLiabilityMonthlyStatePayload {
         state.paymentDifferenceReasons,
       ),
       annualRateOverrides: Map<String, double>.from(state.annualRateOverrides),
+      annualRateEvidences: Map<String, AssetLiabilityAnnualRateEvidence>.from(
+        state.annualRateEvidences,
+      ),
       paidAccountIds: Set<String>.from(state.paidAccountNames),
       paymentSourceAccountIds: Map<String, String>.from(
         state.paymentSourceAccountIds,
@@ -150,6 +155,10 @@ class AssetLiabilityMonthlyStatePayload {
       annualRateOverrides: _readDoubleMap(json, 'annual_rate_overrides') ??
           _readDoubleMap(json, 'annualRateOverrides') ??
           const <String, double>{},
+      annualRateEvidences:
+          _readAnnualRateEvidences(json, 'annual_rate_evidences') ??
+              _readAnnualRateEvidences(json, 'annualRateEvidences') ??
+              const <String, AssetLiabilityAnnualRateEvidence>{},
       paidAccountIds: _readStringSet(json, 'paid_account_ids') ??
           _readStringSet(json, 'paidAccountIds') ??
           const <String>{},
@@ -181,6 +190,9 @@ class AssetLiabilityMonthlyStatePayload {
         paymentDifferenceReasons,
       ),
       annualRateOverrides: Map<String, double>.from(annualRateOverrides),
+      annualRateEvidences: Map<String, AssetLiabilityAnnualRateEvidence>.from(
+        annualRateEvidences,
+      ),
       paidAccountNames: Set<String>.from(paidAccountIds),
       paymentSourceAccountIds: Map<String, String>.from(
         paymentSourceAccountIds,
@@ -208,6 +220,10 @@ class AssetLiabilityMonthlyStatePayload {
         paymentDifferenceReasons,
       ),
       'annual_rate_overrides': Map<String, double>.from(annualRateOverrides),
+      'annual_rate_evidences': {
+        for (final entry in annualRateEvidences.entries)
+          entry.key: entry.value.toJson(),
+      },
       'paid_account_ids': (paidAccountIds.toList()..sort()),
       'payment_source_account_ids': Map<String, String>.from(
         paymentSourceAccountIds,
@@ -652,6 +668,33 @@ List<AssetLiabilityTransferTask>? _readTransferTasks(
     return a.id.compareTo(b.id);
   });
   return tasks;
+}
+
+Map<String, AssetLiabilityAnnualRateEvidence>? _readAnnualRateEvidences(
+  Map<String, Object?> json,
+  String key,
+) {
+  final source = json[key];
+  if (source is! Map) {
+    return null;
+  }
+  final result = <String, AssetLiabilityAnnualRateEvidence>{};
+  for (final entry in source.entries) {
+    if (entry.value is! Map) {
+      continue;
+    }
+    final evidence = AssetLiabilityAnnualRateEvidence.fromJson(
+      Map<String, Object?>.from(
+        (entry.value as Map).map(
+          (key, value) => MapEntry(key.toString(), value),
+        ),
+      ),
+    );
+    if (evidence != null) {
+      result[entry.key.toString()] = evidence;
+    }
+  }
+  return result;
 }
 
 Map<String, double>? _readDoubleMap(Map<String, Object?> json, String key) {

--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -18,6 +18,154 @@ enum AssetLiabilityPaymentMethodSettingSource {
   monthlyOverride,
 }
 
+enum AssetLiabilityAnnualRateEvidenceStatus {
+  verified,
+  rejected,
+  needsReview,
+  failed,
+}
+
+class AssetLiabilityAnnualRateEvidence {
+  final String accountId;
+  final String fileName;
+  final String mimeType;
+  final DateTime submittedAt;
+  final double submittedAnnualRate;
+  final double? detectedAnnualRate;
+  final AssetLiabilityAnnualRateEvidenceStatus status;
+  final String summary;
+  final String source;
+  final String? errorMessage;
+
+  const AssetLiabilityAnnualRateEvidence({
+    required this.accountId,
+    required this.fileName,
+    required this.mimeType,
+    required this.submittedAt,
+    required this.submittedAnnualRate,
+    required this.detectedAnnualRate,
+    required this.status,
+    required this.summary,
+    required this.source,
+    this.errorMessage,
+  });
+
+  bool get verified =>
+      status == AssetLiabilityAnnualRateEvidenceStatus.verified;
+
+  bool matchesAnnualRate(double annualRate) {
+    return verified && (submittedAnnualRate - annualRate).abs() < 0.0001;
+  }
+
+  AssetLiabilityAnnualRateEvidence copyWith({
+    String? accountId,
+    String? fileName,
+    String? mimeType,
+    DateTime? submittedAt,
+    double? submittedAnnualRate,
+    double? detectedAnnualRate,
+    AssetLiabilityAnnualRateEvidenceStatus? status,
+    String? summary,
+    String? source,
+    String? errorMessage,
+  }) {
+    return AssetLiabilityAnnualRateEvidence(
+      accountId: accountId ?? this.accountId,
+      fileName: fileName ?? this.fileName,
+      mimeType: mimeType ?? this.mimeType,
+      submittedAt: submittedAt ?? this.submittedAt,
+      submittedAnnualRate: submittedAnnualRate ?? this.submittedAnnualRate,
+      detectedAnnualRate: detectedAnnualRate ?? this.detectedAnnualRate,
+      status: status ?? this.status,
+      summary: summary ?? this.summary,
+      source: source ?? this.source,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'accountId': accountId,
+      'fileName': fileName,
+      'mimeType': mimeType,
+      'submittedAt': submittedAt.toUtc().toIso8601String(),
+      'submittedAnnualRate': submittedAnnualRate,
+      'detectedAnnualRate': detectedAnnualRate,
+      'status': status.name,
+      'summary': summary,
+      'source': source,
+      'errorMessage': errorMessage,
+    };
+  }
+
+  static AssetLiabilityAnnualRateEvidence? fromJson(
+    Map<String, Object?> json,
+  ) {
+    final accountId = json['accountId']?.toString().trim() ??
+        json['account_id']?.toString().trim();
+    final fileName = json['fileName']?.toString().trim() ??
+        json['file_name']?.toString().trim();
+    final mimeType = json['mimeType']?.toString().trim() ??
+        json['mime_type']?.toString().trim();
+    final submittedAtText =
+        json['submittedAt']?.toString() ?? json['submitted_at']?.toString();
+    final submittedAt =
+        submittedAtText == null ? null : DateTime.tryParse(submittedAtText);
+    final submittedAnnualRate = _parseEvidenceDouble(
+          json['submittedAnnualRate'] ?? json['submitted_annual_rate'],
+        ) ??
+        -1;
+    final detectedAnnualRate = _parseEvidenceDouble(
+      json['detectedAnnualRate'] ?? json['detected_annual_rate'],
+    );
+    final rawStatus = json['status']?.toString().trim();
+    AssetLiabilityAnnualRateEvidenceStatus? status;
+    for (final value in AssetLiabilityAnnualRateEvidenceStatus.values) {
+      if (value.name == rawStatus) {
+        status = value;
+        break;
+      }
+    }
+    if (accountId == null ||
+        accountId.isEmpty ||
+        fileName == null ||
+        fileName.isEmpty ||
+        mimeType == null ||
+        mimeType.isEmpty ||
+        submittedAt == null ||
+        submittedAnnualRate < 0 ||
+        status == null) {
+      return null;
+    }
+    final rawError =
+        json['errorMessage']?.toString() ?? json['error_message']?.toString();
+    final error =
+        rawError == null || rawError.trim().isEmpty ? null : rawError.trim();
+    return AssetLiabilityAnnualRateEvidence(
+      accountId: accountId,
+      fileName: fileName,
+      mimeType: mimeType,
+      submittedAt: submittedAt,
+      submittedAnnualRate: submittedAnnualRate,
+      detectedAnnualRate: detectedAnnualRate,
+      status: status,
+      summary: json['summary']?.toString().trim() ?? '',
+      source: json['source']?.toString().trim() ?? '',
+      errorMessage: error,
+    );
+  }
+}
+
+double? _parseEvidenceDouble(Object? value) {
+  if (value is num) {
+    return value.toDouble();
+  }
+  if (value == null) {
+    return null;
+  }
+  return double.tryParse(value.toString().replaceAll(',', '').trim());
+}
+
 class AssetLiabilityAccount {
   final String id;
   final String name;

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -18,6 +18,7 @@ import 'package:my_web_app/models/asset_liability_sync_audit_log.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/models/debt_repayment_plan.dart';
 import 'package:my_web_app/models/kgi_csf_kpi.dart';
+import 'package:my_web_app/services/asset_liability_annual_rate_evidence_service.dart';
 import 'package:my_web_app/services/asset_liability_card_statement_import_service.dart';
 import 'package:my_web_app/services/asset_liability_history_service.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
@@ -113,6 +114,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, double> _actualPaymentAmounts = <String, double>{};
   Map<String, String> _paymentDifferenceReasons = <String, String>{};
   Map<String, double> _annualRateOverrides = <String, double>{};
+  Map<String, AssetLiabilityAnnualRateEvidence> _annualRateEvidences =
+      <String, AssetLiabilityAnnualRateEvidence>{};
   Set<String> _monthlyPaidAccountNames = <String>{};
   Map<String, String> _paymentSourceAccountIds = <String, String>{};
   Map<String, String> _cardBillingAccountIds = <String, String>{};
@@ -151,6 +154,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       <String, TextEditingController>{};
   final Map<String, TextEditingController> _annualRateControllers =
       <String, TextEditingController>{};
+  final Set<String> _verifyingAnnualRateEvidenceAccountIds = <String>{};
   final TextEditingController _cardStatementImportController =
       TextEditingController();
   String? _selectedCardStatementBillingAccountId;
@@ -207,6 +211,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetLiabilityPlanningService();
   final AssetLiabilityCardStatementImportService _cardStatementImportService =
       const AssetLiabilityCardStatementImportService();
+  final AssetLiabilityAnnualRateEvidenceService _annualRateEvidenceService =
+      AssetLiabilityAnnualRateEvidenceService();
   final AssetLiabilityHistoryService _assetLiabilityHistoryService =
       const AssetLiabilityHistoryService();
   final AssetManagementInsightService _assetManagementInsightService =
@@ -869,6 +875,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _annualRateOverrides = Map<String, double>.from(
           state.annualRateOverrides,
         );
+        _annualRateEvidences =
+            Map<String, AssetLiabilityAnnualRateEvidence>.from(
+          state.annualRateEvidences,
+        );
         _monthlyPaidAccountNames = Set<String>.from(state.paidAccountNames);
         _paymentSourceAccountIds = Map<String, String>.from(
           state.paymentSourceAccountIds,
@@ -934,6 +944,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _paymentDifferenceReasons,
         ),
         annualRateOverrides: Map<String, double>.from(_annualRateOverrides),
+        annualRateEvidences: Map<String, AssetLiabilityAnnualRateEvidence>.from(
+          _annualRateEvidences,
+        ),
         paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
@@ -1261,6 +1274,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _paymentDifferenceReasons,
         ),
         annualRateOverrides: Map<String, double>.from(_annualRateOverrides),
+        annualRateEvidences: Map<String, AssetLiabilityAnnualRateEvidence>.from(
+          _annualRateEvidences,
+        ),
         paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
@@ -1289,6 +1305,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           migrated.paymentDifferenceReasons,
         ) &&
         _sameDoubleMap(_annualRateOverrides, migrated.annualRateOverrides) &&
+        _sameAnnualRateEvidences(
+          _annualRateEvidences,
+          migrated.annualRateEvidences,
+        ) &&
         _sameStringSet(_monthlyPaidAccountNames, migrated.paidAccountNames) &&
         _sameStringMap(
           _paymentSourceAccountIds,
@@ -1328,6 +1348,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
         _annualRateOverrides = Map<String, double>.from(
           migrated.annualRateOverrides,
+        );
+        _annualRateEvidences =
+            Map<String, AssetLiabilityAnnualRateEvidence>.from(
+          migrated.annualRateEvidences,
         );
         _monthlyPaidAccountNames = Set<String>.from(migrated.paidAccountNames);
         _paymentSourceAccountIds = Map<String, String>.from(
@@ -1394,6 +1418,34 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     for (final entry in a.entries) {
       if (b[entry.key] != entry.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _sameAnnualRateEvidences(
+    Map<String, AssetLiabilityAnnualRateEvidence> a,
+    Map<String, AssetLiabilityAnnualRateEvidence> b,
+  ) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final entry in a.entries) {
+      final other = b[entry.key];
+      final current = entry.value;
+      if (other == null ||
+          other.accountId != current.accountId ||
+          other.fileName != current.fileName ||
+          other.mimeType != current.mimeType ||
+          other.submittedAt.toIso8601String() !=
+              current.submittedAt.toIso8601String() ||
+          other.submittedAnnualRate != current.submittedAnnualRate ||
+          other.detectedAnnualRate != current.detectedAnnualRate ||
+          other.status != current.status ||
+          other.summary != current.summary ||
+          other.source != current.source ||
+          other.errorMessage != current.errorMessage) {
         return false;
       }
     }
@@ -1598,24 +1650,103 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   void _updateAnnualRateOverride(String accountId, String rawValue) {
-    final normalized = rawValue.replaceAll('%', '').replaceAll(',', '').trim();
-    final parsed = normalized.isEmpty ? null : double.tryParse(normalized);
+    final parsed = _parseAnnualRateInput(rawValue);
     setState(() {
-      if (parsed == null || parsed < 0) {
+      if (parsed == null) {
         _annualRateOverrides.remove(accountId);
+        _annualRateEvidences.remove(accountId);
       } else {
-        _annualRateOverrides[accountId] = parsed > 1 ? parsed / 100 : parsed;
+        final currentEvidence = _annualRateEvidences[accountId];
+        if (currentEvidence == null ||
+            !currentEvidence.matchesAnnualRate(parsed)) {
+          _annualRateOverrides.remove(accountId);
+        }
       }
     });
     unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  double? _parseAnnualRateInput(String rawValue) {
+    final normalized = rawValue.replaceAll('%', '').replaceAll(',', '').trim();
+    final parsed = normalized.isEmpty ? null : double.tryParse(normalized);
+    if (parsed == null || parsed < 0) {
+      return null;
+    }
+    return parsed > 1 ? parsed / 100 : parsed;
   }
 
   void _clearAnnualRateOverride(String accountId) {
     _annualRateControllers[accountId]?.clear();
     setState(() {
       _annualRateOverrides.remove(accountId);
+      _annualRateEvidences.remove(accountId);
     });
     unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  Future<void> _submitAnnualRateEvidence(AssetLiabilityDebtRow row) async {
+    final controller = _annualRateControllerFor(row);
+    final rate = _parseAnnualRateInput(controller.text);
+    if (rate == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('年利を入力してから証跡画像を提出してください')),
+      );
+      return;
+    }
+    final result = await FilePicker.pickFiles(
+      type: FileType.image,
+      withData: true,
+    );
+    final file = result?.files.single;
+    final bytes = file?.bytes;
+    if (file == null || bytes == null || bytes.isEmpty) {
+      return;
+    }
+    final mimeType = _mimeTypeForAnnualRateEvidence(file);
+    setState(() {
+      _verifyingAnnualRateEvidenceAccountIds.add(row.id);
+    });
+    final evidence = await _annualRateEvidenceService.verifyEvidence(
+      accountId: row.id,
+      accountName: row.name,
+      annualRate: rate,
+      imageBase64: base64Encode(bytes),
+      mimeType: mimeType,
+      fileName: file.name,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _verifyingAnnualRateEvidenceAccountIds.remove(row.id);
+      _annualRateEvidences[row.id] = evidence;
+      if (evidence.matchesAnnualRate(rate)) {
+        _annualRateOverrides[row.id] = rate;
+      } else {
+        _annualRateOverrides.remove(row.id);
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          evidence.verified
+              ? 'AIが年利証跡を確認しました'
+              : 'AIが年利証跡を確認できませんでした。画面キャプチャを確認してください',
+        ),
+      ),
+    );
+  }
+
+  String _mimeTypeForAnnualRateEvidence(PlatformFile file) {
+    final extension = (file.extension ?? '').toLowerCase();
+    return switch (extension) {
+      'png' => 'image/png',
+      'webp' => 'image/webp',
+      'gif' => 'image/gif',
+      'jpg' || 'jpeg' => 'image/jpeg',
+      _ => 'image/jpeg',
+    };
   }
 
   Future<void> _toggleMonthlyPaymentPaid(
@@ -10491,8 +10622,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             scrollDirection: Axis.horizontal,
             child: DataTable(
               headingRowHeight: 36,
-              dataRowMinHeight: 60,
-              dataRowMaxHeight: 76,
+              dataRowMinHeight: 64,
+              dataRowMaxHeight: 96,
               columns: const [
                 DataColumn(label: Text('actual payment'), numeric: true),
                 DataColumn(label: Text('difference'), numeric: true),
@@ -10536,7 +10667,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                       DataCell(_buildMonthlyPaymentInput(row)),
                       DataCell(_buildPaymentAmountSourceChip(row)),
                       DataCell(_buildPaidCheckbox(row)),
-                      DataCell(_buildAnnualRateInput(row)),
+                      DataCell(_buildAnnualRateInputWithEvidence(row)),
                       DataCell(
                         Text(_formatManagementYen(row.monthlyInterestEstimate)),
                       ),
@@ -10796,32 +10927,95 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
-  Widget _buildAnnualRateInput(AssetLiabilityDebtRow row) {
+  Widget _buildAnnualRateInputWithEvidence(AssetLiabilityDebtRow row) {
     final controller = _annualRateControllerFor(row);
     final hasOverride = _annualRateOverrides.containsKey(row.id);
+    final evidence = _annualRateEvidences[row.id];
+    final verified = evidence?.matchesAnnualRate(row.annualRate) ?? false;
     return SizedBox(
-      width: 120,
-      child: TextField(
-        controller: controller,
-        keyboardType: const TextInputType.numberWithOptions(decimal: true),
-        inputFormatters: [
-          FilteringTextInputFormatter.allow(RegExp(r'[0-9.,%]')),
+      width: 220,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: controller,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9.,%]')),
+            ],
+            onChanged: (value) => _updateAnnualRateOverride(row.id, value),
+            decoration: InputDecoration(
+              isDense: true,
+              hintText: _formatRateInput(row.annualRate),
+              helperText:
+                  hasOverride ? (verified ? 'AI確認済み' : '証跡確認が必要') : '年利変更は証跡必須',
+              suffixText: '%',
+              suffixIcon: hasOverride
+                  ? IconButton(
+                      tooltip: '年利上書きをクリア',
+                      icon: const Icon(Icons.clear, size: 16),
+                      onPressed: () => _clearAnnualRateOverride(row.id),
+                    )
+                  : null,
+            ),
+          ),
+          const SizedBox(height: 4),
+          _buildAnnualRateEvidenceCell(row),
         ],
-        onChanged: (value) => _updateAnnualRateOverride(row.id, value),
-        decoration: InputDecoration(
-          isDense: true,
-          hintText: _formatRateInput(row.annualRate),
-          helperText: hasOverride ? '保存済み' : '未入力時は既定',
-          suffixText: '%',
-          suffixIcon: hasOverride
-              ? IconButton(
-                  tooltip: '年利上書きをクリア',
-                  icon: const Icon(Icons.clear, size: 16),
-                  onPressed: () => _clearAnnualRateOverride(row.id),
-                )
-              : null,
-        ),
       ),
+    );
+  }
+
+  Widget _buildAnnualRateEvidenceCell(AssetLiabilityDebtRow row) {
+    final evidence = _annualRateEvidences[row.id];
+    final isVerifying = _verifyingAnnualRateEvidenceAccountIds.contains(row.id);
+    final requestedRate =
+        _parseAnnualRateInput(_annualRateControllerFor(row).text) ??
+            row.annualRate;
+    final verified = evidence?.matchesAnnualRate(requestedRate) ?? false;
+    final color = verified
+        ? const Color(0xFF0D9488)
+        : evidence == null
+            ? const Color(0xFFDC2626)
+            : const Color(0xFFD97706);
+    final label = verified
+        ? 'AI証跡OK'
+        : evidence == null
+            ? '証跡提出'
+            : '再提出';
+    return Wrap(
+      spacing: 6,
+      runSpacing: 4,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        OutlinedButton.icon(
+          onPressed: isVerifying ? null : () => _submitAnnualRateEvidence(row),
+          icon: isVerifying
+              ? const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.upload_file, size: 14),
+          label: Text(label),
+          style: OutlinedButton.styleFrom(
+            foregroundColor: color,
+            side: BorderSide(color: color.withValues(alpha: 0.5)),
+            visualDensity: VisualDensity.compact,
+          ),
+        ),
+        if (evidence != null)
+          Tooltip(
+            message: evidence.summary.isEmpty
+                ? evidence.fileName
+                : '${evidence.fileName}\n${evidence.summary}',
+            child: _buildTextStatusChip(
+              label: verified ? '確認済' : '要確認',
+              color: color,
+            ),
+          ),
+      ],
     );
   }
 

--- a/lib/services/ai_hub_chat_service.dart
+++ b/lib/services/ai_hub_chat_service.dart
@@ -107,6 +107,22 @@ class AiHubChatResponse {
   });
 }
 
+class AiHubAnnualRateEvidenceResponse {
+  final bool verified;
+  final String status;
+  final double? detectedAnnualRate;
+  final String summary;
+  final String source;
+
+  const AiHubAnnualRateEvidenceResponse({
+    required this.verified,
+    required this.status,
+    required this.detectedAnnualRate,
+    required this.summary,
+    required this.source,
+  });
+}
+
 class AiHubChatException implements Exception {
   final String message;
 
@@ -219,6 +235,58 @@ class AiHubChatService {
         );
       }
       throw const AiHubChatException('AI response was empty');
+    } catch (error) {
+      final message = error.toString();
+      if (RegExp(r'429|quota|rate.?limit', caseSensitive: false)
+          .hasMatch(message)) {
+        AiHubChatQuotaGuard.markQuotaExceeded();
+      }
+      if (error is AiHubChatException) {
+        rethrow;
+      }
+      throw AiHubChatException(message);
+    }
+  }
+
+  Future<AiHubAnnualRateEvidenceResponse> verifyAnnualRateEvidence({
+    required String accountName,
+    required double submittedAnnualRate,
+    required String imageBase64,
+    required String mimeType,
+    String? imageName,
+    String? traceId,
+  }) async {
+    if (AiHubChatQuotaGuard.isCoolingDown) {
+      throw const AiHubChatException('AI quota cooldown');
+    }
+
+    try {
+      final data = await _invoke(
+        await _withOfflinePolicy({
+          'action': 'asset_liability.verify_annual_rate_evidence',
+          'accountName': accountName,
+          'submittedAnnualRate': submittedAnnualRate,
+          'imageBase64': imageBase64,
+          'mimeType': mimeType,
+          if (imageName != null && imageName.trim().isNotEmpty)
+            'imageName': imageName.trim(),
+          if (traceId != null && traceId.trim().isNotEmpty)
+            'trace_id': traceId.trim(),
+        }),
+      );
+      if (data['success'] == true) {
+        return AiHubAnnualRateEvidenceResponse(
+          verified: data['verified'] == true,
+          status: data['status']?.toString() ?? 'unknown',
+          detectedAnnualRate: _asDouble(data['detected_annual_rate']),
+          summary: (data['summary'] ?? data['message'] ?? '').toString(),
+          source: 'ai-hub asset_liability.verify_annual_rate_evidence',
+        );
+      }
+      throw AiHubChatException(
+        (data['message'] ?? data['error'] ?? 'AI evidence check failed')
+            .toString(),
+      );
     } catch (error) {
       final message = error.toString();
       if (RegExp(r'429|quota|rate.?limit', caseSensitive: false)

--- a/lib/services/asset_liability_annual_rate_evidence_service.dart
+++ b/lib/services/asset_liability_annual_rate_evidence_service.dart
@@ -1,0 +1,60 @@
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+
+import 'ai_hub_chat_service.dart';
+
+class AssetLiabilityAnnualRateEvidenceService {
+  final AiHubChatService _chatService;
+  final DateTime Function() _now;
+
+  AssetLiabilityAnnualRateEvidenceService({
+    AiHubChatService chatService = const AiHubChatService(),
+    DateTime Function()? now,
+  })  : _chatService = chatService,
+        _now = now ?? DateTime.now;
+
+  Future<AssetLiabilityAnnualRateEvidence> verifyEvidence({
+    required String accountId,
+    required String accountName,
+    required double annualRate,
+    required String imageBase64,
+    required String mimeType,
+    required String fileName,
+  }) async {
+    try {
+      final response = await _chatService.verifyAnnualRateEvidence(
+        accountName: accountName,
+        submittedAnnualRate: annualRate,
+        imageBase64: imageBase64,
+        mimeType: mimeType,
+        imageName: fileName,
+        traceId: 'asset-liability-annual-rate-evidence',
+      );
+      return AssetLiabilityAnnualRateEvidence(
+        accountId: accountId,
+        fileName: fileName,
+        mimeType: mimeType,
+        submittedAt: _now(),
+        submittedAnnualRate: annualRate,
+        detectedAnnualRate: response.detectedAnnualRate,
+        status: response.verified
+            ? AssetLiabilityAnnualRateEvidenceStatus.verified
+            : AssetLiabilityAnnualRateEvidenceStatus.needsReview,
+        summary: response.summary,
+        source: response.source,
+      );
+    } catch (error) {
+      return AssetLiabilityAnnualRateEvidence(
+        accountId: accountId,
+        fileName: fileName,
+        mimeType: mimeType,
+        submittedAt: _now(),
+        submittedAnnualRate: annualRate,
+        detectedAnnualRate: null,
+        status: AssetLiabilityAnnualRateEvidenceStatus.failed,
+        summary: 'AI could not verify the annual rate evidence.',
+        source: 'ai-hub asset_liability.verify_annual_rate_evidence',
+        errorMessage: error.toString(),
+      );
+    }
+  }
+}

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -11,6 +11,7 @@ class AssetLiabilityMonthlyState {
   final Map<String, double> actualPaymentAmounts;
   final Map<String, String> paymentDifferenceReasons;
   final Map<String, double> annualRateOverrides;
+  final Map<String, AssetLiabilityAnnualRateEvidence> annualRateEvidences;
   final Set<String> paidAccountNames;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
@@ -23,6 +24,8 @@ class AssetLiabilityMonthlyState {
     this.actualPaymentAmounts = const <String, double>{},
     this.paymentDifferenceReasons = const <String, String>{},
     this.annualRateOverrides = const <String, double>{},
+    this.annualRateEvidences =
+        const <String, AssetLiabilityAnnualRateEvidence>{},
     this.paidAccountNames = const <String>{},
     this.paymentSourceAccountIds = const <String, String>{},
     this.cardBillingAccountIds = const <String, String>{},
@@ -36,6 +39,7 @@ class AssetLiabilityMonthlyState {
       actualPaymentAmounts.isEmpty &&
       paymentDifferenceReasons.isEmpty &&
       annualRateOverrides.isEmpty &&
+      annualRateEvidences.isEmpty &&
       paidAccountNames.isEmpty &&
       paymentSourceAccountIds.isEmpty &&
       cardBillingAccountIds.isEmpty &&
@@ -53,6 +57,8 @@ class AssetLiabilityMonthlyStateStore {
       'asset_liability_monthly_payment_difference_reasons_v1';
   static const String annualRatePrefsKey =
       'asset_liability_monthly_annual_rate_overrides_v1';
+  static const String annualRateEvidencePrefsKey =
+      'asset_liability_monthly_annual_rate_evidences_v1';
   static const String paidPrefsKey = 'asset_liability_paid_accounts_v1';
   static const String paymentSourcePrefsKey =
       'asset_liability_payment_source_accounts_v1';
@@ -95,6 +101,10 @@ class AssetLiabilityMonthlyStateStore {
       ),
       annualRateOverrides: annualRateOverridesForMonth(
         prefs.getString(annualRatePrefsKey),
+        monthKey,
+      ),
+      annualRateEvidences: annualRateEvidencesForMonth(
+        prefs.getString(annualRateEvidencePrefsKey),
         monthKey,
       ),
       paidAccountNames: paidAccountsForMonth(
@@ -187,6 +197,22 @@ class AssetLiabilityMonthlyStateStore {
       );
     }
     await prefs.setString(annualRatePrefsKey, jsonEncode(allAnnualRates));
+
+    final allAnnualRateEvidences = decodeAnnualRateEvidences(
+      prefs.getString(annualRateEvidencePrefsKey),
+    );
+    if (state.annualRateEvidences.isEmpty) {
+      allAnnualRateEvidences.remove(monthKey);
+    } else {
+      allAnnualRateEvidences[monthKey] =
+          Map<String, AssetLiabilityAnnualRateEvidence>.from(
+        state.annualRateEvidences,
+      );
+    }
+    await prefs.setString(
+      annualRateEvidencePrefsKey,
+      jsonEncode(_encodeAnnualRateEvidences(allAnnualRateEvidences)),
+    );
 
     await prefs.setString(
       paidPrefsKey,
@@ -401,6 +427,9 @@ class AssetLiabilityMonthlyStateStore {
       annualRateOverrides: Map<String, double>.from(
         previousState.annualRateOverrides,
       ),
+      annualRateEvidences: Map<String, AssetLiabilityAnnualRateEvidence>.from(
+        previousState.annualRateEvidences,
+      ),
       paymentSourceAccountIds: Map<String, String>.from(
         previousState.paymentSourceAccountIds,
       ),
@@ -487,6 +516,44 @@ class AssetLiabilityMonthlyStateStore {
         }
       }
       return MapEntry(monthKey, payments);
+    });
+  }
+
+  static Map<String, Map<String, AssetLiabilityAnnualRateEvidence>>
+      decodeAnnualRateEvidences(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, Map<String, AssetLiabilityAnnualRateEvidence>>{};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return <String, Map<String, AssetLiabilityAnnualRateEvidence>>{};
+    }
+
+    return decoded.map<String, Map<String, AssetLiabilityAnnualRateEvidence>>((
+      month,
+      values,
+    ) {
+      final monthKey = month.toString();
+      final evidences = <String, AssetLiabilityAnnualRateEvidence>{};
+      if (values is Map) {
+        for (final entry in values.entries) {
+          if (entry.value is! Map) {
+            continue;
+          }
+          final rawEvidence = Map<String, Object?>.from(
+            (entry.value as Map).map(
+              (key, value) => MapEntry(key.toString(), value),
+            ),
+          );
+          final evidence = AssetLiabilityAnnualRateEvidence.fromJson(
+            rawEvidence,
+          );
+          if (evidence != null) {
+            evidences[entry.key.toString()] = evidence;
+          }
+        }
+      }
+      return MapEntry(monthKey, evidences);
     });
   }
 
@@ -952,6 +1019,17 @@ class AssetLiabilityMonthlyStateStore {
     );
   }
 
+  static Map<String, AssetLiabilityAnnualRateEvidence>
+      annualRateEvidencesForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return Map<String, AssetLiabilityAnnualRateEvidence>.from(
+      decodeAnnualRateEvidences(raw)[monthKey] ??
+          const <String, AssetLiabilityAnnualRateEvidence>{},
+    );
+  }
+
   static Map<String, String> paymentDifferenceReasonsForMonth(
     String? raw,
     String monthKey,
@@ -1054,6 +1132,14 @@ class AssetLiabilityMonthlyStateStore {
       }
     }
 
+    final migratedAnnualRateEvidences =
+        <String, AssetLiabilityAnnualRateEvidence>{};
+    for (final entry in state.annualRateEvidences.entries) {
+      final migratedKey = legacyKeyToAccountId[entry.key] ?? entry.key;
+      migratedAnnualRateEvidences[migratedKey] =
+          entry.value.copyWith(accountId: migratedKey);
+    }
+
     final migratedPaidAccounts = <String>{};
     for (final accountKey in state.paidAccountNames) {
       migratedPaidAccounts.add(legacyKeyToAccountId[accountKey] ?? accountKey);
@@ -1111,6 +1197,7 @@ class AssetLiabilityMonthlyStateStore {
       actualPaymentAmounts: migratedActualPayments,
       paymentDifferenceReasons: migratedDifferenceReasons,
       annualRateOverrides: migratedAnnualRates,
+      annualRateEvidences: migratedAnnualRateEvidences,
       paidAccountNames: migratedPaidAccounts,
       paymentSourceAccountIds: migratedPaymentSources,
       cardBillingAccountIds: migratedCardBillingAccounts,
@@ -1126,6 +1213,17 @@ class AssetLiabilityMonthlyStateStore {
     return source.map((month, accounts) {
       final sorted = accounts.toList()..sort();
       return MapEntry(month, sorted);
+    });
+  }
+
+  static Map<String, Map<String, Object?>> _encodeAnnualRateEvidences(
+    Map<String, Map<String, AssetLiabilityAnnualRateEvidence>> source,
+  ) {
+    return source.map((month, evidences) {
+      final sortedKeys = evidences.keys.toList()..sort();
+      return MapEntry(month, <String, Object?>{
+        for (final key in sortedKeys) key: evidences[key]!.toJson(),
+      });
     });
   }
 

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -51,6 +51,9 @@ class AssetLiabilityPlanningService {
   static const String kddiProviderAccountId = 'kddi_provider';
   static const String kddiProviderAccountName = 'KDDI';
   static const double kddiProviderMonthlyPaymentAmount = 5764;
+  static const String rentAccountId = 'rent';
+  static const String rentAccountName = '\u5bb6\u8cc3';
+  static const double rentMonthlyPaymentAmount = 63000;
 
   const AssetLiabilityPlanningService();
 
@@ -77,12 +80,20 @@ class AssetLiabilityPlanningService {
   }) {
     final shouldIncludeDefaultKddiProvider =
         includeDefaultFixedPayments && !_hasKddiProvider(latestSnapshot);
-    final effectiveSnapshot = shouldIncludeDefaultKddiProvider
-        ? _withDefaultFixedPayments(latestSnapshot)
-        : latestSnapshot;
+    final shouldIncludeDefaultRent =
+        includeDefaultFixedPayments && !_hasRent(latestSnapshot);
+    final effectiveSnapshot =
+        shouldIncludeDefaultKddiProvider || shouldIncludeDefaultRent
+            ? _withDefaultFixedPayments(
+                latestSnapshot,
+                includeKddiProvider: shouldIncludeDefaultKddiProvider,
+                includeRent: shouldIncludeDefaultRent,
+              )
+            : latestSnapshot;
     final effectiveMonthlyPaymentOverrides = _withDefaultFixedPaymentOverrides(
       monthlyPaymentOverrides: monthlyPaymentOverrides,
       includeDefaultKddiProvider: shouldIncludeDefaultKddiProvider,
+      includeDefaultRent: shouldIncludeDefaultRent,
     );
     final accounts = effectiveSnapshot.entries
         .where((entry) => entry.key.trim().isNotEmpty && entry.value != 0)
@@ -340,6 +351,18 @@ class AssetLiabilityPlanningService {
         name: name,
         balance: balance,
         kind: AssetLiabilityAccountKind.utility,
+        paymentDay: 25,
+        annualRate: 0,
+        minimumPaymentRate: 1,
+        minimumPaymentFloor: balance.abs(),
+        fullPaymentEstimate: true,
+      );
+    }
+    if (_accountIdForName(name) == rentAccountId) {
+      return _liability(
+        name: name,
+        balance: balance,
+        kind: AssetLiabilityAccountKind.otherLiability,
         paymentDay: 25,
         annualRate: 0,
         minimumPaymentRate: 1,
@@ -1432,6 +1455,9 @@ class AssetLiabilityPlanningService {
     if (_containsAny(key, const <String>['kddi'])) {
       return kddiProviderAccountId;
     }
+    if (key == 'rent' || _containsAny(key, const <String>['家賃'])) {
+      return rentAccountId;
+    }
     if (key == 'au' || _containsAny(key, const <String>['通信', '携帯'])) {
       return 'au';
     }
@@ -1452,11 +1478,16 @@ class AssetLiabilityPlanningService {
   }
 
   Map<String, double> _withDefaultFixedPayments(
-    Map<String, double> latestSnapshot,
-  ) {
+    Map<String, double> latestSnapshot, {
+    required bool includeKddiProvider,
+    required bool includeRent,
+  }) {
     final result = Map<String, double>.from(latestSnapshot);
-    if (!_hasKddiProvider(result)) {
+    if (includeKddiProvider && !_hasKddiProvider(result)) {
       result[kddiProviderAccountName] = -kddiProviderMonthlyPaymentAmount;
+    }
+    if (includeRent && !_hasRent(result)) {
+      result[rentAccountName] = -rentMonthlyPaymentAmount;
     }
     return result;
   }
@@ -1464,22 +1495,33 @@ class AssetLiabilityPlanningService {
   Map<String, double> _withDefaultFixedPaymentOverrides({
     required Map<String, double> monthlyPaymentOverrides,
     required bool includeDefaultKddiProvider,
+    required bool includeDefaultRent,
   }) {
-    if (!includeDefaultKddiProvider ||
-        monthlyPaymentOverrides.containsKey(kddiProviderAccountId) ||
-        monthlyPaymentOverrides.containsKey(kddiProviderAccountName)) {
-      return monthlyPaymentOverrides;
-    }
-    return <String, double>{
-      kddiProviderAccountId: kddiProviderMonthlyPaymentAmount,
+    final result = <String, double>{
       ...monthlyPaymentOverrides,
     };
+    if (includeDefaultKddiProvider &&
+        !result.containsKey(kddiProviderAccountId) &&
+        !result.containsKey(kddiProviderAccountName)) {
+      result[kddiProviderAccountId] = kddiProviderMonthlyPaymentAmount;
+    }
+    if (includeDefaultRent &&
+        !result.containsKey(rentAccountId) &&
+        !result.containsKey(rentAccountName)) {
+      result[rentAccountId] = rentMonthlyPaymentAmount;
+    }
+    return result;
   }
 
   bool _hasKddiProvider(Map<String, double> snapshot) {
     return snapshot.keys.any(
       (name) => _accountIdForName(name) == kddiProviderAccountId,
     );
+  }
+
+  bool _hasRent(Map<String, double> snapshot) {
+    return snapshot.keys
+        .any((name) => _accountIdForName(name) == rentAccountId);
   }
 
   String _fallbackAccountId(String name) {

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1419,6 +1419,10 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
           local.annualRateOverrides,
           remote.annualRateOverrides,
         ) &&
+        _annualRateEvidencesEqual(
+          local.annualRateEvidences,
+          remote.annualRateEvidences,
+        ) &&
         _stringSetEquals(local.paidAccountNames, remote.paidAccountNames) &&
         _stringMapEquals(
           local.paymentSourceAccountIds,
@@ -1454,6 +1458,33 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
     }
     for (final entry in a.entries) {
       if (b[entry.key] != entry.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _annualRateEvidencesEqual(
+    Map<String, AssetLiabilityAnnualRateEvidence> a,
+    Map<String, AssetLiabilityAnnualRateEvidence> b,
+  ) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final entry in a.entries) {
+      final other = b[entry.key];
+      final current = entry.value;
+      if (other == null ||
+          other.accountId != current.accountId ||
+          other.fileName != current.fileName ||
+          other.mimeType != current.mimeType ||
+          other.submittedAt.toUtc() != current.submittedAt.toUtc() ||
+          other.submittedAnnualRate != current.submittedAnnualRate ||
+          other.detectedAnnualRate != current.detectedAnnualRate ||
+          other.status != current.status ||
+          other.summary != current.summary ||
+          other.source != current.source ||
+          other.errorMessage != current.errorMessage) {
         return false;
       }
     }
@@ -1707,6 +1738,7 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
         'actual_payment_amounts': row['actual_payment_amounts'],
         'payment_difference_reasons': row['payment_difference_reasons'],
         'annual_rate_overrides': row['annual_rate_overrides'],
+        'annual_rate_evidences': row['annual_rate_evidences'],
         'paid_account_ids': row['paid_account_ids'],
         'payment_source_account_ids': row['payment_source_account_ids'],
         'card_billing_account_ids': row['card_billing_account_ids'],

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -42,7 +42,7 @@ class AssetManagementAiSummaryService {
   final AiHubChatService _chatService;
   final AssetManagementInsightPromptBuilder _promptBuilder;
   final DateTime Function() _now;
-  final String _provider;
+  final String? _provider;
 
   AssetManagementAiSummaryService({
     bool aiEnabled = AssetManagementAiSummaryFeatureFlag.enabled,
@@ -50,7 +50,7 @@ class AssetManagementAiSummaryService {
     AssetManagementInsightPromptBuilder promptBuilder =
         const AssetManagementInsightPromptBuilder(),
     DateTime Function()? now,
-    String provider = 'deepinfra',
+    String? provider,
   })  : _aiEnabled = aiEnabled,
         _chatService = chatService,
         _promptBuilder = promptBuilder,
@@ -77,11 +77,17 @@ class AssetManagementAiSummaryService {
 
     try {
       final prompt = _buildPrompt(report: report, payload: payload);
-      final response = await _chatService.sendProviderChat(
-        message: prompt,
-        provider: _provider,
-        traceId: 'asset-management-ai-summary',
-      );
+      final response = _provider == null || _provider == 'auto'
+          ? await _chatService.sendAutoChat(
+              message: prompt,
+              tier: 'cheap',
+              traceId: 'asset-management-ai-summary',
+            )
+          : await _chatService.sendProviderChat(
+              message: prompt,
+              provider: _provider,
+              traceId: 'asset-management-ai-summary',
+            );
       return AssetManagementAiSummaryResult(
         status: AssetManagementAiSummaryStatus.aiGenerated,
         text: response.text,

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -4063,6 +4063,90 @@ serve(async (req: Request) => {
       }
 
       // ── AI大学 v2: Voice ─────────────────────────────────────────────────
+      case "asset_liability.verify_annual_rate_evidence": {
+        const parsedImage = parseInlineImage(body);
+        if (parsedImage.error) {
+          return json({ error: parsedImage.error }, parsedImage.status ?? 400);
+        }
+        const image = parsedImage.image;
+        if (!image) {
+          return json({ error: "imageBase64 required" }, 400);
+        }
+        const accountName = asString(body.accountName) || "unknown account";
+        const submittedAnnualRate = asNumber(
+          body.submittedAnnualRate,
+          Number.NaN,
+        );
+        if (!Number.isFinite(submittedAnnualRate) || submittedAnnualRate < 0) {
+          return json({ error: "submittedAnnualRate required" }, 400);
+        }
+        const offlinePolicy = parseOfflineSecureModePolicy(body);
+        if (shouldBlockExternalProviderCall(offlinePolicy)) {
+          return json(
+            buildOfflineBlockedResponseBody(offlinePolicy, {
+              action: "asset_liability.verify_annual_rate_evidence",
+              provider: "google",
+            }),
+            409,
+          );
+        }
+        const geminiKey = Deno.env.get("GEMINI_API_KEY") ?? "";
+        if (!geminiKey) {
+          return json({
+            success: false,
+            status: "apiKeyRequired",
+            secret_needed: "GEMINI_API_KEY",
+            message: "Supabase Secret GEMINI_API_KEY is required.",
+          });
+        }
+
+        const submittedPercent = submittedAnnualRate * 100;
+        const prompt = [
+          "You are verifying annual interest rate evidence for a personal finance board.",
+          "Inspect the attached screenshot. It must visibly contain the annual interest rate/APR for the named account.",
+          `Account name: ${accountName}`,
+          `User-entered annual rate: ${submittedPercent.toFixed(4)}%`,
+          "Return JSON only with keys: verified, detected_annual_rate_percent, confidence, summary, reason.",
+          "Set verified=true only when the screenshot clearly shows the same annual rate for this account. Do not infer missing rates.",
+          "If the screenshot is unreadable, unrelated, or the rate differs, set verified=false.",
+        ].join("\n");
+        const raw = await callGemini(prompt, geminiKey, image);
+        let parsed: Record<string, unknown> = {};
+        try {
+          parsed = JSON.parse(stripMarkdownCodeFence(raw)) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          parsed = { summary: raw, verified: false };
+        }
+        const detectedPercent = asNumber(
+          parsed.detected_annual_rate_percent,
+          Number.NaN,
+        );
+        const detectedAnnualRate = Number.isFinite(detectedPercent)
+          ? detectedPercent / 100
+          : null;
+        const rateMatches = detectedAnnualRate !== null &&
+          Math.abs(detectedAnnualRate - submittedAnnualRate) <= 0.001;
+        const verified = parsed.verified === true && rateMatches;
+        const summary = asString(parsed.summary) ||
+          asString(parsed.reason) ||
+          (verified
+            ? "Annual rate evidence matches the entered value."
+            : "Annual rate evidence could not be verified.");
+        return json({
+          success: true,
+          provider: "google",
+          status: verified ? "verified" : "needs_review",
+          verified,
+          detected_annual_rate: detectedAnnualRate,
+          detected_annual_rate_percent: detectedPercent,
+          summary,
+          confidence: asNumber(parsed.confidence, 0),
+        });
+      }
+
       case "provider.chat": {
         // 汎用プロバイダー呼び出し (AI大学150社の実装済みAIに統一インターフェースで話しかける)
         // 対応: OpenAI互換 8社 (openai/xai/deepseek/groq/sambanova/openrouter/fireworks/together/arcee_ai)

--- a/test/services/ai_hub_chat_service_test.dart
+++ b/test/services/ai_hub_chat_service_test.dart
@@ -111,4 +111,39 @@ void main() {
 
     expect(response.text, 'blocked before provider fetch in ai-hub');
   });
+
+  test('verifyAnnualRateEvidence calls ai-hub vision verifier', () async {
+    final service = AiHubChatService(
+      invoker: (body) async {
+        expect(
+          body['action'],
+          'asset_liability.verify_annual_rate_evidence',
+        );
+        expect(body['accountName'], 'Mobit');
+        expect(body['submittedAnnualRate'], 0.18);
+        expect(body['imageBase64'], 'abc123');
+        expect(body['mimeType'], 'image/png');
+        expect(body['imageName'], 'apr.png');
+        return <String, dynamic>{
+          'success': true,
+          'verified': true,
+          'status': 'verified',
+          'detected_annual_rate': 0.18,
+          'summary': '18.0% APR is visible.',
+        };
+      },
+    );
+
+    final response = await service.verifyAnnualRateEvidence(
+      accountName: 'Mobit',
+      submittedAnnualRate: 0.18,
+      imageBase64: 'abc123',
+      mimeType: 'image/png',
+      imageName: 'apr.png',
+    );
+
+    expect(response.verified, isTrue);
+    expect(response.detectedAnnualRate, 0.18);
+    expect(response.summary, contains('18.0%'));
+  });
 }

--- a/test/services/asset_liability_annual_rate_evidence_service_test.dart
+++ b/test/services/asset_liability_annual_rate_evidence_service_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/ai_hub_chat_service.dart';
+import 'package:my_web_app/services/asset_liability_annual_rate_evidence_service.dart';
+
+void main() {
+  group('AssetLiabilityAnnualRateEvidenceService', () {
+    test('stores verified AI evidence for matching annual rate', () async {
+      final service = AssetLiabilityAnnualRateEvidenceService(
+        now: () => DateTime(2026, 5, 17, 12),
+        chatService: AiHubChatService(
+          invoker: (_) async => <String, dynamic>{
+            'success': true,
+            'verified': true,
+            'status': 'verified',
+            'detected_annual_rate': 0.18,
+            'summary': 'The screenshot shows 18.0% annual rate.',
+          },
+        ),
+      );
+
+      final evidence = await service.verifyEvidence(
+        accountId: 'mobit',
+        accountName: 'Mobit',
+        annualRate: 0.18,
+        imageBase64: 'abc',
+        mimeType: 'image/png',
+        fileName: 'mobit_apr.png',
+      );
+
+      expect(evidence.status, AssetLiabilityAnnualRateEvidenceStatus.verified);
+      expect(evidence.verified, isTrue);
+      expect(evidence.matchesAnnualRate(0.18), isTrue);
+      expect(evidence.fileName, 'mobit_apr.png');
+    });
+
+    test('keeps failed evidence without approving annual rate', () async {
+      final service = AssetLiabilityAnnualRateEvidenceService(
+        now: () => DateTime(2026, 5, 17, 12),
+        chatService: AiHubChatService(
+          invoker: (_) async => throw const AiHubChatException('vision down'),
+        ),
+      );
+
+      final evidence = await service.verifyEvidence(
+        accountId: 'mobit',
+        accountName: 'Mobit',
+        annualRate: 0.18,
+        imageBase64: 'abc',
+        mimeType: 'image/png',
+        fileName: 'mobit_apr.png',
+      );
+
+      expect(evidence.status, AssetLiabilityAnnualRateEvidenceStatus.failed);
+      expect(evidence.verified, isFalse);
+      expect(evidence.matchesAnnualRate(0.18), isFalse);
+      expect(evidence.errorMessage, contains('vision down'));
+    });
+  });
+}

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -23,6 +23,19 @@ void main() {
             'aupay_card': 'late fee',
           },
           annualRateOverrides: const <String, double>{'mobit': 0.175},
+          annualRateEvidences: <String, AssetLiabilityAnnualRateEvidence>{
+            'mobit': AssetLiabilityAnnualRateEvidence(
+              accountId: 'mobit',
+              fileName: 'mobit_apr.png',
+              mimeType: 'image/png',
+              submittedAt: DateTime(2026, 5, 13, 9),
+              submittedAnnualRate: 0.175,
+              detectedAnnualRate: 0.175,
+              status: AssetLiabilityAnnualRateEvidenceStatus.verified,
+              summary: '17.5% is visible.',
+              source: 'ai-hub',
+            ),
+          },
           paymentSourceAccountIds: const <String, String>{
             'mobit': 'custom_bank',
           },
@@ -70,6 +83,8 @@ void main() {
       expect(loadedMay.actualPaymentAmounts['aupay_card'], 6200);
       expect(loadedMay.paymentDifferenceReasons['aupay_card'], 'late fee');
       expect(loadedMay.annualRateOverrides['mobit'], 0.175);
+      expect(loadedMay.annualRateEvidences['mobit']?.verified, isTrue);
+      expect(loadedMay.annualRateEvidences['mobit']?.fileName, 'mobit_apr.png');
       expect(loadedMay.paymentSourceAccountIds['mobit'], 'custom_bank');
       expect(loadedMay.cardBillingAccountIds['au'], 'aupay_card');
       expect(loadedMay.cardStatementLines.single.amount, 6200);
@@ -81,6 +96,7 @@ void main() {
       expect(loadedJune.actualPaymentAmounts, isEmpty);
       expect(loadedJune.paymentDifferenceReasons, isEmpty);
       expect(loadedJune.annualRateOverrides, isEmpty);
+      expect(loadedJune.annualRateEvidences, isEmpty);
       expect(loadedJune.paidAccountNames, isEmpty);
       expect(loadedJune.paymentSourceAccountIds, isEmpty);
       expect(loadedJune.cardBillingAccountIds, isEmpty);
@@ -188,10 +204,25 @@ void main() {
 
     test('migrates actual payment difference keys to stable account ids', () {
       final migrated = AssetLiabilityMonthlyStateStore.migrateLegacyKeys(
-        state: const AssetLiabilityMonthlyState(
+        state: AssetLiabilityMonthlyState(
           actualPaymentAmounts: <String, double>{'Legacy card': 6200},
-          paymentDifferenceReasons: <String, String>{'Legacy card': 'late fee'},
-          annualRateOverrides: <String, double>{'Legacy card': 0.145},
+          paymentDifferenceReasons: const <String, String>{
+            'Legacy card': 'late fee',
+          },
+          annualRateOverrides: const <String, double>{'Legacy card': 0.145},
+          annualRateEvidences: <String, AssetLiabilityAnnualRateEvidence>{
+            'Legacy card': AssetLiabilityAnnualRateEvidence(
+              accountId: 'Legacy card',
+              fileName: 'apr.png',
+              mimeType: 'image/png',
+              submittedAt: DateTime(2026, 5, 13),
+              submittedAnnualRate: 0.145,
+              detectedAnnualRate: 0.145,
+              status: AssetLiabilityAnnualRateEvidenceStatus.verified,
+              summary: '14.5%',
+              source: 'ai-hub',
+            ),
+          },
         ),
         legacyKeyToAccountId: const <String, String>{
           'Legacy card': 'aupay_card',
@@ -207,6 +238,10 @@ void main() {
       expect(migrated.annualRateOverrides, <String, double>{
         'aupay_card': 0.145,
       });
+      expect(
+        migrated.annualRateEvidences['aupay_card']?.accountId,
+        'aupay_card',
+      );
     });
 
     test(

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -999,7 +999,7 @@ void main() {
       expect(workbook.cashAfterScheduledPayments, 5000);
     });
 
-    test('adds KDDI provider as a separate day 25 fixed payment', () {
+    test('adds KDDI provider and rent as separate fixed payments', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: <String, double>{'cash': 50000, 'au': -32152},
         baseDate: DateTime(2026, 5, 1),
@@ -1012,6 +1012,9 @@ void main() {
       final au = workbook.debtMasterRows.firstWhere((row) => row.id == 'au');
       final kddi = workbook.debtMasterRows.firstWhere(
         (row) => row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
+      );
+      final rent = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.rentAccountId,
       );
       final kddiCashflow = workbook.cashflowRows.firstWhere(
         (row) =>
@@ -1049,6 +1052,10 @@ void main() {
         AssetLiabilityPlanningService.kddiProviderMonthlyPaymentAmount,
       );
       expect(kddiCashflow.paid, isFalse);
+      expect(rent.name, AssetLiabilityPlanningService.rentAccountName);
+      expect(rent.paymentDay, 25);
+      expect(rent.scheduledPaymentAmount, 63000);
+      expect(rent.isDirectCashflowTarget, isTrue);
       expect(
         kddiCashflow.cashAfterPayment,
         closeTo(
@@ -1059,7 +1066,10 @@ void main() {
       );
       expect(
         workbook.monthlyUnpaidPaymentTotal,
-        closeTo(kddi.scheduledPaymentAmount, 0.001),
+        closeTo(
+          kddi.scheduledPaymentAmount + rent.scheduledPaymentAmount,
+          0.001,
+        ),
       );
     });
 
@@ -1077,6 +1087,9 @@ void main() {
       final kddi = workbook.debtMasterRows.firstWhere(
         (row) => row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
       );
+      final rent = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.rentAccountId,
+      );
       final kddiCashflow = workbook.cashflowRows.firstWhere(
         (row) =>
             row.accountId ==
@@ -1087,7 +1100,7 @@ void main() {
       expect(kddi.paid, isTrue);
       expect(kddiCashflow.paid, isTrue);
       expect(kddiCashflow.cashBeforePayment, kddiCashflow.cashAfterPayment);
-      expect(workbook.monthlyUnpaidPaymentTotal, 0);
+      expect(workbook.monthlyUnpaidPaymentTotal, rent.scheduledPaymentAmount);
     });
   });
 }

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -1136,6 +1136,19 @@ void main() {
           'mobit': 'fee adjustment',
         },
         annualRateOverrides: const <String, double>{'mobit': 0.175},
+        annualRateEvidences: <String, AssetLiabilityAnnualRateEvidence>{
+          'mobit': AssetLiabilityAnnualRateEvidence(
+            accountId: 'mobit',
+            fileName: 'mobit_apr.png',
+            mimeType: 'image/png',
+            submittedAt: DateTime(2026, 5, 14, 9),
+            submittedAnnualRate: 0.175,
+            detectedAnnualRate: 0.175,
+            status: AssetLiabilityAnnualRateEvidenceStatus.verified,
+            summary: '17.5% APR visible',
+            source: 'ai-hub',
+          ),
+        },
         paidAccountNames: const <String>{'kddi_provider'},
         paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
         cardBillingAccountIds: const <String, String>{
@@ -1193,6 +1206,8 @@ void main() {
       expect(restored.actualPaymentAmounts['mobit'], 71000);
       expect(restored.paymentDifferenceReasons['mobit'], 'fee adjustment');
       expect(restored.annualRateOverrides['mobit'], 0.175);
+      expect(restored.annualRateEvidences['mobit']?.verified, isTrue);
+      expect(row['annual_rate_evidences'], isA<Map<String, Object?>>());
       expect(restored.paidAccountNames, contains('kddi_provider'));
       expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
       expect(restored.cardBillingAccountIds['kddi_provider'], 'paypay_card');
@@ -1585,6 +1600,19 @@ AssetLiabilityMonthlyState _sampleMonthlyState() {
       'kddi_provider': 'confirmed bill',
     },
     annualRateOverrides: const <String, double>{'mobit': 0.175},
+    annualRateEvidences: <String, AssetLiabilityAnnualRateEvidence>{
+      'mobit': AssetLiabilityAnnualRateEvidence(
+        accountId: 'mobit',
+        fileName: 'mobit_apr.png',
+        mimeType: 'image/png',
+        submittedAt: DateTime(2026, 5, 14, 9),
+        submittedAnnualRate: 0.175,
+        detectedAnnualRate: 0.175,
+        status: AssetLiabilityAnnualRateEvidenceStatus.verified,
+        summary: '17.5% APR visible',
+        source: 'ai-hub',
+      ),
+    },
     paidAccountNames: const <String>{'kddi_provider'},
     paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
     cardBillingAccountIds: const <String, String>{

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -31,7 +31,7 @@ void main() {
       );
     });
 
-    test('calls ai-hub provider.chat when feature flag is on', () async {
+    test('calls ai-hub auto chat when feature flag is on', () async {
       Map<String, dynamic>? capturedBody;
       final service = AssetManagementAiSummaryService(
         aiEnabled: true,
@@ -41,7 +41,7 @@ void main() {
             return <String, dynamic>{
               'success': true,
               'text': 'AI generated summary',
-              'provider': 'deepinfra',
+              'provider': 'groq',
             };
           },
         ),
@@ -53,8 +53,8 @@ void main() {
       expect(result.status, AssetManagementAiSummaryStatus.aiGenerated);
       expect(result.usedExternalAi, true);
       expect(result.text, 'AI generated summary');
-      expect(capturedBody?['action'], 'provider.chat');
-      expect(capturedBody?['provider'], 'deepinfra');
+      expect(capturedBody?['action'], 'provider.chat_auto');
+      expect(capturedBody?['tier'], 'cheap');
       expect(capturedBody?['trace_id'], 'asset-management-ai-summary');
       expect(
         capturedBody?['message'].toString().contains(


### PR DESCRIPTION
﻿## Overview

Adds the next asset/liability board safety layer:

- Adds rent as a fixed payment item: `rent` / ?? / 25? / ?63,000.
- Routes the AI asset-management summary through ai-hub auto provider routing when the feature flag is enabled, instead of a fixed provider path.
- Requires annual-rate overrides to be backed by screenshot evidence.
- Adds an ai-hub vision verifier action, `asset_liability.verify_annual_rate_evidence`, which checks the submitted APR screenshot through Gemini via Supabase Edge Function.
- Stores annual-rate evidence metadata/results in monthly state, repository payloads, and Supabase payloads without storing the raw screenshot.

## User Impact

- Rent appears in the debt/payment master and cashflow as a direct day-25 fixed payment.
- A user can no longer silently change an APR override without submitting evidence.
- The UI can upload an APR screenshot, ask AI to verify the visible annual rate, and only apply the override when the AI result matches the entered rate.
- External AI calls remain server-side through `ai-hub`; no provider secrets are added to the Flutter client.

## Safety Notes

- Amount calculations still stay in Dart/service logic.
- AI is used only to summarize calculated insights and verify screenshot evidence.
- Screenshot bytes are sent for verification but only metadata/result fields are persisted.
- If evidence verification fails, the APR override is not applied.

## Minimal E2E Gate

Plan is minimal and black-box / implementation-detail independent: reviewers should verify about 3 input/output cases, not internal classes.

1. Input: open asset management board with fixed-payment defaults. Output: ?? appears as a 25? direct payment for ?63,000 and is included in cashflow totals.
2. Input: enter an APR override without evidence. Output: the override is not applied and the UI asks for a screenshot evidence submission.
3. Input: submit an APR screenshot through the evidence flow. Output: ai-hub receives the vision verification request and a matching AI result applies the APR override; a rejected result leaves the override unapplied.

E2E mechanism: local web smoke was performed on `/cfo-office`; a future Playwright or integration_test case can automate the same 3 black-box I/O checks.
E2E-Exception: this PR uses service/API-boundary tests plus local web smoke instead of adding a new integration_test file because the file-picker screenshot path needs browser fixture plumbing and provider-key stubbing.

## Claude Ultrareview

Review owner: Claude Code #1.

- security: provider keys remain server-side in Supabase Edge Function secrets; raw evidence images are not persisted.
- rollback: disable `ASSET_MANAGEMENT_AI_SUMMARY_ENABLED` or revert this PR; existing deterministic fallback and default APRs remain available.
- data migration: no SQL migration is included; existing monthly payloads default `annual_rate_evidences` to empty when absent.
- prod smoke: after deploy, open `/cfo-office`, verify HTTP 200, confirm ?? appears on day 25, and confirm APR evidence upload calls ai-hub without client-side secrets.
- observability: ai-hub action returns structured `status`, `provider`, `summary`, `confidence`, and failure states for UI/log inspection.

Unresolved findings: 0. No unresolved findings.

## Validation

- `dart format ...`: OK
- `dart analyze`: No issues found
- Related `flutter test --no-pub ...`: 96 tests passed
- Full `flutter test --no-pub`: 499 tests passed
- `git diff --check`: OK
- Local web smoke: HTTP 200

## Notes

- `deno check supabase/functions/ai-hub/index.ts` could not run locally because Deno reported missing `npm:@supabase/supabase-js@2` in `node_modules`; this is an environment dependency setup issue, not a TypeScript syntax result.
- Local git hook warning `Can't find lefthook in PATH` appeared, but commit/push completed and local validation passed.
