### PR TITLE
feat(asset): add AI provider routing (#2521)

### DIFF
--- a/docs/asset-management-ai-model-evaluation-plan.md
+++ b/docs/asset-management-ai-model-evaluation-plan.md
@@ -60,6 +60,10 @@ The executable bench foundation lives in:
 
 - GPT / Claude / Gemini can be used for production-facing summarization only
   through feature flags and existing provider boundaries.
+- #2521 foundation routing is represented in code as a feature-flagged
+  `Claude Opus 4.7 -> GPT-5 -> Gemini 3.1 Pro -> local deterministic`
+  fallback chain for summary, risk explanation, developer suggestion, and
+  reconciliation-help use cases.
 - Kimi / DeepSeek / Grok are candidates until local benchmark results justify
   integration.
 - Image/video models are not part of money calculation. They can support docs,
@@ -69,6 +73,9 @@ The executable bench foundation lives in:
   developer tasks.
 - #2521 routing defaults must cite a `scripts/internal_ai_bench.py` report or
   stay behind feature flags.
+- Asset-management AI prompts must use redacted categories and bands. Exact
+  balances, account identifiers, and user IDs stay inside deterministic
+  Dart/Supabase code and are not sent to external model providers.
 
 ## Linked Issues
 

--- a/docs/asset-management-ai-model-evaluation-plan.md
+++ b/docs/asset-management-ai-model-evaluation-plan.md
@@ -76,6 +76,9 @@ The executable bench foundation lives in:
 - Asset-management AI prompts must use redacted categories and bands. Exact
   balances, account identifiers, and user IDs stay inside deterministic
   Dart/Supabase code and are not sent to external model providers.
+- Provider routing changes that touch `ai-hub` or migrations require PR-level
+  security, rollback, migration, prod-smoke, and observability evidence before
+  merge.
 
 ## Linked Issues
 

--- a/lib/services/ai_hub_chat_service.dart
+++ b/lib/services/ai_hub_chat_service.dart
@@ -17,6 +17,8 @@ class AiHubChatObservability {
   final int? outputChars;
   final int? statusCode;
   final String? action;
+  final String? providerChoiceReason;
+  final String? routingUseCase;
 
   const AiHubChatObservability({
     required this.provider,
@@ -29,6 +31,8 @@ class AiHubChatObservability {
     this.outputChars,
     this.statusCode,
     this.action,
+    this.providerChoiceReason,
+    this.routingUseCase,
   });
 
   static AiHubChatObservability? fromResponseMap(
@@ -53,6 +57,9 @@ class AiHubChatObservability {
     final outputChars = _asInt(raw['output_chars']);
     final statusCode = _asInt(raw['status_code']);
     final action = raw['action']?.toString().trim();
+    final providerChoiceReason =
+        raw['provider_choice_reason']?.toString().trim();
+    final routingUseCase = raw['routing_use_case']?.toString().trim();
 
     final hasDetail = provider.isNotEmpty ||
         model != null ||
@@ -63,7 +70,9 @@ class AiHubChatObservability {
         inputChars != null ||
         outputChars != null ||
         statusCode != null ||
-        action != null;
+        action != null ||
+        providerChoiceReason != null ||
+        routingUseCase != null;
     if (!hasDetail) {
       return null;
     }
@@ -79,6 +88,8 @@ class AiHubChatObservability {
       outputChars: outputChars,
       statusCode: statusCode,
       action: _emptyToNull(action),
+      providerChoiceReason: _emptyToNull(providerChoiceReason),
+      routingUseCase: _emptyToNull(routingUseCase),
     );
   }
 
@@ -149,8 +160,11 @@ class AiHubChatService {
   Future<AiHubChatResponse> sendProviderChat({
     required String message,
     String provider = 'deepinfra',
+    String? model,
     String? sessionId,
     String? traceId,
+    String? providerChoiceReason,
+    String? routingUseCase,
   }) async {
     if (AiHubChatQuotaGuard.isCoolingDown) {
       throw const AiHubChatException('AI quota cooldown');
@@ -162,10 +176,16 @@ class AiHubChatService {
           'action': 'provider.chat',
           'provider': provider,
           'message': message,
+          if (model != null && model.trim().isNotEmpty) 'model': model.trim(),
           if (sessionId != null && sessionId.trim().isNotEmpty)
             'session_id': sessionId.trim(),
           if (traceId != null && traceId.trim().isNotEmpty)
             'trace_id': traceId.trim(),
+          if (providerChoiceReason != null &&
+              providerChoiceReason.trim().isNotEmpty)
+            'provider_choice_reason': providerChoiceReason.trim(),
+          if (routingUseCase != null && routingUseCase.trim().isNotEmpty)
+            'routing_use_case': routingUseCase.trim(),
         }),
       );
       final text = (data['text'] ?? data['result'] ?? data['message'])
@@ -181,11 +201,13 @@ class AiHubChatService {
           ),
         );
       }
-      throw const AiHubChatException('AI response was empty');
+      throw _buildAiHubFailureException(data);
     } catch (error) {
       final message = error.toString();
-      if (RegExp(r'429|quota|rate.?limit', caseSensitive: false)
-          .hasMatch(message)) {
+      if (RegExp(
+        r'429|quota|rate.?limit',
+        caseSensitive: false,
+      ).hasMatch(message)) {
         AiHubChatQuotaGuard.markQuotaExceeded();
       }
       if (error is AiHubChatException) {
@@ -200,6 +222,8 @@ class AiHubChatService {
     String? tier,
     String? sessionId,
     String? traceId,
+    String? providerChoiceReason,
+    String? routingUseCase,
   }) async {
     if (AiHubChatQuotaGuard.isCoolingDown) {
       throw const AiHubChatException('AI quota cooldown');
@@ -215,6 +239,11 @@ class AiHubChatService {
             'session_id': sessionId.trim(),
           if (traceId != null && traceId.trim().isNotEmpty)
             'trace_id': traceId.trim(),
+          if (providerChoiceReason != null &&
+              providerChoiceReason.trim().isNotEmpty)
+            'provider_choice_reason': providerChoiceReason.trim(),
+          if (routingUseCase != null && routingUseCase.trim().isNotEmpty)
+            'routing_use_case': routingUseCase.trim(),
         }),
       );
       final text = (data['text'] ?? data['result'] ?? data['message'])
@@ -234,11 +263,13 @@ class AiHubChatService {
           ),
         );
       }
-      throw const AiHubChatException('AI response was empty');
+      throw _buildAiHubFailureException(data);
     } catch (error) {
       final message = error.toString();
-      if (RegExp(r'429|quota|rate.?limit', caseSensitive: false)
-          .hasMatch(message)) {
+      if (RegExp(
+        r'429|quota|rate.?limit',
+        caseSensitive: false,
+      ).hasMatch(message)) {
         AiHubChatQuotaGuard.markQuotaExceeded();
       }
       if (error is AiHubChatException) {
@@ -283,14 +314,16 @@ class AiHubChatService {
           source: 'ai-hub asset_liability.verify_annual_rate_evidence',
         );
       }
-      throw AiHubChatException(
-        (data['message'] ?? data['error'] ?? 'AI evidence check failed')
-            .toString(),
+      throw _buildAiHubFailureException(
+        data,
+        fallbackMessage: 'AI evidence check failed',
       );
     } catch (error) {
       final message = error.toString();
-      if (RegExp(r'429|quota|rate.?limit', caseSensitive: false)
-          .hasMatch(message)) {
+      if (RegExp(
+        r'429|quota|rate.?limit',
+        caseSensitive: false,
+      ).hasMatch(message)) {
         AiHubChatQuotaGuard.markQuotaExceeded();
       }
       if (error is AiHubChatException) {
@@ -324,10 +357,7 @@ class AiHubChatService {
     Map<String, dynamic> body,
   ) async {
     final settings = await _offlineSettingsService.loadSettingsOrDefaults();
-    return <String, dynamic>{
-      ...body,
-      ...settings.toAiHubPolicyPayload(),
-    };
+    return <String, dynamic>{...body, ...settings.toAiHubPolicyPayload()};
   }
 }
 
@@ -343,6 +373,31 @@ double? _asDouble(Object? value) {
   if (value is num) return value.toDouble();
   if (value == null) return null;
   return double.tryParse(value.toString());
+}
+
+AiHubChatException _buildAiHubFailureException(
+  Map<String, dynamic> data, {
+  String fallbackMessage = 'AI response was empty',
+}) {
+  final parts = <String>[];
+  void add(Object? value) {
+    final text = value?.toString().trim();
+    if (text != null && text.isNotEmpty && !parts.contains(text)) {
+      parts.add(text.length > 300 ? '${text.substring(0, 300)}...' : text);
+    }
+  }
+
+  add(data['status']);
+  add(data['provider']);
+  add(data['message']);
+  add(data['error']);
+  add(data['detail']);
+  add(data['http_status']);
+  add(data['secret_needed']);
+
+  return AiHubChatException(
+    parts.isEmpty ? fallbackMessage : parts.join(' / '),
+  );
 }
 
 String? _emptyToNull(String? value) {
@@ -363,5 +418,9 @@ class AiHubChatQuotaGuard {
     final ts = _lastQuotaErrorAt;
     if (ts == null) return false;
     return DateTime.now().difference(ts) < _cooldown;
+  }
+
+  static void resetForTesting() {
+    _lastQuotaErrorAt = null;
   }
 }

--- a/lib/services/asset_management_ai_provider_router.dart
+++ b/lib/services/asset_management_ai_provider_router.dart
@@ -1,0 +1,201 @@
+class AssetManagementAiProviderRoutingFeatureFlag {
+  static const String dartDefineName =
+      'ASSET_MANAGEMENT_AI_PROVIDER_ROUTING_ENABLED';
+
+  static const bool enabled = bool.fromEnvironment(
+    dartDefineName,
+    defaultValue: false,
+  );
+
+  const AssetManagementAiProviderRoutingFeatureFlag._();
+}
+
+enum AssetManagementAiProviderUseCase {
+  summary,
+  riskExplanation,
+  developerSuggestion,
+  reconciliationHelp,
+}
+
+extension AssetManagementAiProviderUseCaseId
+    on AssetManagementAiProviderUseCase {
+  String get id {
+    switch (this) {
+      case AssetManagementAiProviderUseCase.summary:
+        return 'summary';
+      case AssetManagementAiProviderUseCase.riskExplanation:
+        return 'risk_explanation';
+      case AssetManagementAiProviderUseCase.developerSuggestion:
+        return 'developer_suggestion';
+      case AssetManagementAiProviderUseCase.reconciliationHelp:
+        return 'reconciliation_help';
+    }
+  }
+}
+
+class AssetManagementAiProviderCandidate {
+  final String providerId;
+  final String modelId;
+  final String displayName;
+  final String tier;
+
+  const AssetManagementAiProviderCandidate({
+    required this.providerId,
+    required this.modelId,
+    required this.displayName,
+    required this.tier,
+  });
+
+  Map<String, String> toJson() {
+    return <String, String>{
+      'provider_id': providerId,
+      'model_id': modelId,
+      'display_name': displayName,
+      'tier': tier,
+    };
+  }
+}
+
+class AssetManagementAiProviderRouteDecision {
+  final AssetManagementAiProviderUseCase useCase;
+  final bool routingEnabled;
+  final List<AssetManagementAiProviderCandidate> candidates;
+  final String reason;
+  final String localFallbackReason;
+
+  const AssetManagementAiProviderRouteDecision({
+    required this.useCase,
+    required this.routingEnabled,
+    required this.candidates,
+    required this.reason,
+    required this.localFallbackReason,
+  });
+
+  AssetManagementAiProviderCandidate? get primaryExternalCandidate {
+    return candidates.isEmpty ? null : candidates.first;
+  }
+
+  String get providerChoiceReason {
+    final chain = candidates
+        .map((candidate) => '${candidate.modelId}@${candidate.providerId}')
+        .join(' > ');
+    final suffix = chain.isEmpty
+        ? 'fallback=local-deterministic'
+        : 'chain=$chain > local-deterministic';
+    return 'asset:${useCase.id}; routing=$routingEnabled; $reason; $suffix';
+  }
+
+  Map<String, dynamic> toLogPayload() {
+    return <String, dynamic>{
+      'use_case': useCase.id,
+      'routing_enabled': routingEnabled,
+      'reason': reason,
+      'fallback': localFallbackReason,
+      'providers': candidates
+          .map((candidate) => candidate.toJson())
+          .toList(growable: false),
+    };
+  }
+}
+
+class AssetManagementAiProviderRouter {
+  final bool routingEnabled;
+
+  const AssetManagementAiProviderRouter({
+    this.routingEnabled = AssetManagementAiProviderRoutingFeatureFlag.enabled,
+  });
+
+  AssetManagementAiProviderRouteDecision routeFor({
+    required AssetManagementAiProviderUseCase useCase,
+    String? explicitProvider,
+  }) {
+    final normalizedProvider = explicitProvider?.trim();
+    if (normalizedProvider != null &&
+        normalizedProvider.isNotEmpty &&
+        normalizedProvider != 'auto') {
+      final candidate = _candidateForExplicitProvider(normalizedProvider);
+      return AssetManagementAiProviderRouteDecision(
+        useCase: useCase,
+        routingEnabled: routingEnabled,
+        candidates: <AssetManagementAiProviderCandidate>[candidate],
+        reason: 'explicit provider override from caller',
+        localFallbackReason:
+            'local deterministic summary after explicit provider failure',
+      );
+    }
+
+    return AssetManagementAiProviderRouteDecision(
+      useCase: useCase,
+      routingEnabled: routingEnabled,
+      candidates: _defaultRoutingTable[useCase] ?? _defaultFallbackChain,
+      reason: _reasonFor(useCase),
+      localFallbackReason:
+          'local deterministic summary after all configured providers fail',
+    );
+  }
+
+  static const List<AssetManagementAiProviderCandidate> _defaultFallbackChain =
+      <AssetManagementAiProviderCandidate>[
+    AssetManagementAiProviderCandidate(
+      providerId: 'anthropic',
+      modelId: 'claude-opus-4-7',
+      displayName: 'Claude Opus 4.7',
+      tier: 'premium',
+    ),
+    AssetManagementAiProviderCandidate(
+      providerId: 'openai',
+      modelId: 'gpt-5',
+      displayName: 'GPT-5',
+      tier: 'performance',
+    ),
+    AssetManagementAiProviderCandidate(
+      providerId: 'google',
+      modelId: 'gemini-3.1-pro',
+      displayName: 'Gemini 3.1 Pro',
+      tier: 'performance',
+    ),
+  ];
+
+  static const Map<AssetManagementAiProviderUseCase,
+          List<AssetManagementAiProviderCandidate>>
+      _defaultRoutingTable = <AssetManagementAiProviderUseCase,
+          List<AssetManagementAiProviderCandidate>>{
+    AssetManagementAiProviderUseCase.summary: _defaultFallbackChain,
+    AssetManagementAiProviderUseCase.riskExplanation: _defaultFallbackChain,
+    AssetManagementAiProviderUseCase.developerSuggestion: _defaultFallbackChain,
+    AssetManagementAiProviderUseCase.reconciliationHelp: _defaultFallbackChain,
+  };
+
+  static String _reasonFor(AssetManagementAiProviderUseCase useCase) {
+    switch (useCase) {
+      case AssetManagementAiProviderUseCase.summary:
+        return 'premium explanation quality for user-facing summaries';
+      case AssetManagementAiProviderUseCase.riskExplanation:
+        return 'high-recall reasoning for already calculated risk categories';
+      case AssetManagementAiProviderUseCase.developerSuggestion:
+        return 'implementation suggestion text only, no money calculation';
+      case AssetManagementAiProviderUseCase.reconciliationHelp:
+        return 'statement reconciliation explanation over redacted categories';
+    }
+  }
+
+  static AssetManagementAiProviderCandidate _candidateForExplicitProvider(
+    String provider,
+  ) {
+    switch (provider) {
+      case 'anthropic':
+        return _defaultFallbackChain[0];
+      case 'openai':
+        return _defaultFallbackChain[1];
+      case 'google':
+        return _defaultFallbackChain[2];
+      default:
+        return AssetManagementAiProviderCandidate(
+          providerId: provider,
+          modelId: provider,
+          displayName: provider,
+          tier: 'manual',
+        );
+    }
+  }
+}

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'ai_hub_chat_service.dart';
+import 'asset_management_ai_provider_router.dart';
 import 'asset_management_insight_service.dart';
 
 class AssetManagementAiSummaryFeatureFlag {
@@ -23,6 +24,8 @@ class AssetManagementAiSummaryResult {
   final String? errorMessage;
   final DateTime generatedAt;
   final Map<String, dynamic> payload;
+  final Map<String, dynamic>? providerRoute;
+  final String? providerChoiceReason;
 
   const AssetManagementAiSummaryResult({
     required this.status,
@@ -31,6 +34,8 @@ class AssetManagementAiSummaryResult {
     required this.errorMessage,
     required this.generatedAt,
     required this.payload,
+    this.providerRoute,
+    this.providerChoiceReason,
   });
 
   bool get usedExternalAi =>
@@ -41,6 +46,8 @@ class AssetManagementAiSummaryService {
   final bool _aiEnabled;
   final AiHubChatService _chatService;
   final AssetManagementInsightPromptBuilder _promptBuilder;
+  final AssetManagementAiProviderRouter _providerRouter;
+  final AssetManagementAiProviderUseCase _useCase;
   final DateTime Function() _now;
   final String? _provider;
 
@@ -49,11 +56,17 @@ class AssetManagementAiSummaryService {
     AiHubChatService chatService = const AiHubChatService(),
     AssetManagementInsightPromptBuilder promptBuilder =
         const AssetManagementInsightPromptBuilder(),
+    AssetManagementAiProviderRouter providerRouter =
+        const AssetManagementAiProviderRouter(),
+    AssetManagementAiProviderUseCase useCase =
+        AssetManagementAiProviderUseCase.summary,
     DateTime Function()? now,
     String? provider,
   })  : _aiEnabled = aiEnabled,
         _chatService = chatService,
         _promptBuilder = promptBuilder,
+        _providerRouter = providerRouter,
+        _useCase = useCase,
         _now = now ?? DateTime.now,
         _provider = provider;
 
@@ -63,6 +76,10 @@ class AssetManagementAiSummaryService {
     required AssetManagementInsightReport report,
   }) async {
     final payload = buildPayload(report);
+    final route = _providerRouter.routeFor(
+      useCase: _useCase,
+      explicitProvider: _provider,
+    );
     final fallback = buildDeterministicSummary(report);
     if (!_aiEnabled) {
       return AssetManagementAiSummaryResult(
@@ -72,22 +89,31 @@ class AssetManagementAiSummaryService {
         errorMessage: null,
         generatedAt: _now(),
         payload: payload,
+        providerRoute: route.toLogPayload(),
+        providerChoiceReason: route.providerChoiceReason,
       );
     }
 
     try {
-      final prompt = _buildPrompt(report: report, payload: payload);
-      final response = _provider == null || _provider == 'auto'
-          ? await _chatService.sendAutoChat(
-              message: prompt,
-              tier: 'cheap',
-              traceId: 'asset-management-ai-summary',
-            )
-          : await _chatService.sendProviderChat(
-              message: prompt,
-              provider: _provider,
-              traceId: 'asset-management-ai-summary',
-            );
+      final aiSafePayload = buildAiSafePayload(report);
+      final prompt = _buildPrompt(report: report, payload: aiSafePayload);
+      final response = route.routingEnabled
+          ? await _sendRoutedSummary(prompt: prompt, route: route)
+          : _provider == null || _provider == 'auto'
+              ? await _chatService.sendAutoChat(
+                  message: prompt,
+                  tier: 'performance',
+                  traceId: 'asset-management-ai-summary',
+                  providerChoiceReason: route.providerChoiceReason,
+                  routingUseCase: route.useCase.id,
+                )
+              : await _chatService.sendProviderChat(
+                  message: prompt,
+                  provider: _provider,
+                  traceId: 'asset-management-ai-summary',
+                  providerChoiceReason: route.providerChoiceReason,
+                  routingUseCase: route.useCase.id,
+                );
       return AssetManagementAiSummaryResult(
         status: AssetManagementAiSummaryStatus.aiGenerated,
         text: response.text,
@@ -95,6 +121,8 @@ class AssetManagementAiSummaryService {
         errorMessage: null,
         generatedAt: _now(),
         payload: payload,
+        providerRoute: route.toLogPayload(),
+        providerChoiceReason: route.providerChoiceReason,
       );
     } catch (error) {
       return AssetManagementAiSummaryResult(
@@ -104,6 +132,8 @@ class AssetManagementAiSummaryService {
         errorMessage: error.toString(),
         generatedAt: _now(),
         payload: payload,
+        providerRoute: route.toLogPayload(),
+        providerChoiceReason: route.providerChoiceReason,
       );
     }
   }
@@ -134,6 +164,63 @@ class AssetManagementAiSummaryService {
       generatedAt: _now(),
       payload: payload,
     );
+  }
+
+  Map<String, dynamic> buildAiSafePayload(
+    AssetManagementInsightReport report,
+  ) {
+    return <String, dynamic>{
+      'available_money_bands': <String, dynamic>{
+        'today': _availableToAiSafeJson(report.todayAvailable),
+        'week': _availableToAiSafeJson(report.weekAvailable),
+        'month': _availableToAiSafeJson(report.monthAvailable),
+      },
+      'action_inventory': <String, dynamic>{
+        'total': report.actionItems.length,
+        'by_type': _countBy(report.actionItems.map((item) => item.type.name)),
+        'by_severity': _countBy(
+          report.actionItems.map((item) => item.severity.name),
+        ),
+        'has_due_dates': report.actionItems.any((item) => item.dueDate != null),
+        'has_payment_day_metadata': report.actionItems.any(
+          (item) => item.paymentDay != null,
+        ),
+      },
+      'movement_suggestions': <String, dynamic>{
+        'count': report.movementSuggestions.length,
+        'amount_pressure_bands': _countBy(
+          report.movementSuggestions.map(
+            (suggestion) => _amountPressureBand(suggestion.amount),
+          ),
+        ),
+      },
+      'emergency_advices': <String, dynamic>{
+        'count': report.emergencyAdvices.length,
+        'by_severity': _countBy(
+          report.emergencyAdvices.map((advice) => advice.severity.name),
+        ),
+        'amount_pressure_bands': _countBy(
+          report.emergencyAdvices.map(
+            (advice) => _amountPressureBand(advice.amount),
+          ),
+        ),
+      },
+      'developer_requests': <String, dynamic>{
+        'count': report.developerRequests.length,
+        'by_severity': _countBy(
+          report.developerRequests.map((request) => request.severity.name),
+        ),
+      },
+      'guardrails': const <String, dynamic>{
+        'calculation_owner': 'dart_service',
+        'external_ai_may_summarize_only': true,
+        'external_ai_may_recalculate_amounts': false,
+        'external_ai_payload_redacts_exact_money_values': true,
+        'external_ai_payload_redacts_account_identifiers': true,
+        'must_not_recommend_starvation_or_water_only': true,
+        'must_prioritize_food_shelter_health_and_contacting_creditors': true,
+      },
+    };
   }
 
   Map<String, dynamic> buildPayload(AssetManagementInsightReport report) {
@@ -234,13 +321,39 @@ class AssetManagementAiSummaryService {
     required Map<String, dynamic> payload,
   }) {
     return [
-      _promptBuilder.buildPrompt(report),
+      _promptBuilder.buildRedactedPrompt(report),
       '',
-      '## Computed insight payload',
+      '## Redacted computed insight payload',
       jsonEncode(payload),
       '',
-      'Rules: summarize only. Do not recalculate amounts. Do not provide legal, investment, or credit advice. Never recommend starvation, water-only survival, or skipping meals as a solution. Prioritize food, shelter, health, contacting creditors, and emergency public/community support. Keep the response concise and action-oriented.',
+      'Rules: summarize only from redacted categories. Do not recalculate amounts. Do not ask for exact balances. Do not provide legal, investment, or credit advice. Never recommend starvation, water-only survival, or skipping meals as a solution. Prioritize food, shelter, health, contacting creditors, and emergency public/community support. Keep the response concise and action-oriented.',
     ].join('\n');
+  }
+
+  Future<AiHubChatResponse> _sendRoutedSummary({
+    required String prompt,
+    required AssetManagementAiProviderRouteDecision route,
+  }) async {
+    Object? lastError;
+    for (final candidate in route.candidates) {
+      try {
+        return await _chatService.sendProviderChat(
+          message: prompt,
+          provider: candidate.providerId,
+          model: candidate.modelId,
+          traceId: 'asset-management-ai-summary',
+          providerChoiceReason: route.providerChoiceReason,
+          routingUseCase: route.useCase.id,
+        );
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw AiHubChatException(
+      lastError == null
+          ? route.localFallbackReason
+          : '${route.localFallbackReason}: $lastError',
+    );
   }
 
   Map<String, dynamic> _availableToJson(
@@ -257,6 +370,50 @@ class AssetManagementAiSummaryService {
       'available_amount': insight.availableAmount,
       'summary': insight.summary,
     };
+  }
+
+  Map<String, dynamic> _availableToAiSafeJson(
+    AssetManagementAvailableMoneyInsight insight,
+  ) {
+    return <String, dynamic>{
+      'window': insight.window.name,
+      'risk_band': _availableRiskBand(insight),
+      'date_window_days':
+          insight.endDate.difference(insight.startDate).inDays + 1,
+      'cash_like_status': _amountPressureBand(insight.cashLikeTotal),
+      'unpaid_payment_status': _amountPressureBand(
+        insight.unpaidPaymentTotal,
+      ),
+      'unreceived_income_status': _amountPressureBand(
+        insight.unreceivedIncomeTotal,
+      ),
+      'minimum_safety_balance_policy': 'configured_in_dart',
+    };
+  }
+
+  Map<String, int> _countBy(Iterable<String> values) {
+    final counts = <String, int>{};
+    for (final value in values) {
+      counts[value] = (counts[value] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  String _availableRiskBand(AssetManagementAvailableMoneyInsight insight) {
+    final amount = insight.availableAmount;
+    if (amount < 0) return 'shortage';
+    if (amount < insight.minimumSafetyBalance) return 'below_safety_balance';
+    if (amount < insight.minimumSafetyBalance * 2) return 'near_safety_buffer';
+    return 'buffer_available';
+  }
+
+  String _amountPressureBand(double? amount) {
+    if (amount == null) return 'not_applicable';
+    final absolute = amount.abs();
+    if (absolute == 0) return 'none';
+    if (absolute < 10000) return 'low';
+    if (absolute < 100000) return 'medium';
+    return 'high';
   }
 
   String _formatYen(double amount) {

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -867,6 +867,74 @@ class AssetManagementInsightPromptBuilder {
     return buffer.toString();
   }
 
+  String buildRedactedPrompt(AssetManagementInsightReport report) {
+    final severityCounts = _countBy(
+      report.actionItems.map((item) => item.severity.name),
+    );
+    final typeCounts = _countBy(
+      report.actionItems.map((item) => item.type.name),
+    );
+    final emergencyCounts = _countBy(
+      report.emergencyAdvices.map((item) => item.severity.name),
+    );
+    final developerCounts = _countBy(
+      report.developerRequests.map((item) => item.severity.name),
+    );
+    final buffer = StringBuffer()
+      ..writeln('Asset-management AI assistant.')
+      ..writeln(
+        'Money calculations are already completed by Dart. Use only the '
+        'redacted categories below; do not infer, recalculate, or ask for '
+        'exact balances.',
+      )
+      ..writeln()
+      ..writeln('## Redacted availability bands')
+      ..writeln('- today: ${_availabilityBand(report.todayAvailable)}')
+      ..writeln('- week: ${_availabilityBand(report.weekAvailable)}')
+      ..writeln('- month: ${_availabilityBand(report.monthAvailable)}')
+      ..writeln()
+      ..writeln('## Action inventory')
+      ..writeln('- total_actions: ${report.actionItems.length}')
+      ..writeln('- by_severity: ${_formatCounts(severityCounts)}')
+      ..writeln('- by_type: ${_formatCounts(typeCounts)}')
+      ..writeln()
+      ..writeln('## Movement and emergency inventory')
+      ..writeln(
+        '- movement_suggestion_count: ${report.movementSuggestions.length}',
+      )
+      ..writeln('- emergency_advice_count: ${report.emergencyAdvices.length}')
+      ..writeln('- emergency_by_severity: ${_formatCounts(emergencyCounts)}')
+      ..writeln()
+      ..writeln('## Developer request inventory')
+      ..writeln(
+        '- developer_request_count: ${report.developerRequests.length}',
+      )
+      ..writeln('- developer_by_severity: ${_formatCounts(developerCounts)}');
+    return buffer.toString();
+  }
+
+  String _availabilityBand(AssetManagementAvailableMoneyInsight insight) {
+    final amount = insight.availableAmount;
+    if (amount < 0) return 'shortage';
+    if (amount < insight.minimumSafetyBalance) return 'below_safety_balance';
+    if (amount < insight.minimumSafetyBalance * 2) return 'near_safety_buffer';
+    return 'buffer_available';
+  }
+
+  Map<String, int> _countBy(Iterable<String> values) {
+    final counts = <String, int>{};
+    for (final value in values) {
+      counts[value] = (counts[value] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  String _formatCounts(Map<String, int> counts) {
+    if (counts.isEmpty) return 'none';
+    final keys = counts.keys.toList(growable: false)..sort();
+    return keys.map((key) => '$key=${counts[key]}').join(', ');
+  }
+
   String _formatAmount(double amount) {
     final sign = amount < 0 ? '-' : '';
     final digits = amount.abs().round().toString();

--- a/scripts/check_ai_tool_update_routing_test.py
+++ b/scripts/check_ai_tool_update_routing_test.py
@@ -20,13 +20,14 @@ class AiToolUpdateRoutingTest(unittest.TestCase):
 
         self.assertTrue(any("missing file" in item for item in missing))
 
-    def test_contract_tracks_all_three_docs(self) -> None:
+    def test_contract_tracks_all_required_docs(self) -> None:
         self.assertEqual(
             set(REQUIRED_MARKERS),
             {
                 "docs/AI_FALLBACK_RUNBOOK.md",
                 "docs/DEV_PROCESS_MULTI_AI.md",
                 ".github/agents/README.md",
+                "docs/SUBAGENT_ORCHESTRATION_POLICY.md",
             },
         )
 

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -521,6 +521,22 @@ function estimateTokensFromChars(chars: number): number {
   return Math.max(1, Math.ceil(Math.max(0, chars) / 4));
 }
 
+function isProviderPaymentRequired(
+  status: number,
+  responseText: string,
+): boolean {
+  const text = responseText.toLowerCase();
+  return status === 402 ||
+    text.includes("paid_plan_required") ||
+    text.includes("payment_required") ||
+    text.includes("insufficient_quota") ||
+    text.includes("positive balance") ||
+    text.includes("add balance") ||
+    text.includes("top-up") ||
+    text.includes("billing") ||
+    text.includes("credit");
+}
+
 async function callSingleProvider(
   providerId: string,
   messages: { role: string; content: string }[],
@@ -560,11 +576,19 @@ async function callSingleProvider(
       },
       body: JSON.stringify(cfg.buildBody(messages, model ?? cfg.defaultModel)),
     });
-    if (!resp.ok) {
-      const isRetriable = resp.status === 429 || resp.status >= 500;
-      return { ok: false, error: `HTTP ${resp.status}`, isRetriable };
-    }
     const respText = await resp.text();
+    if (!resp.ok) {
+      const paymentRequired = isProviderPaymentRequired(resp.status, respText);
+      const isRetriable = paymentRequired || resp.status === 429 ||
+        resp.status >= 500;
+      return {
+        ok: false,
+        error: paymentRequired
+          ? `paidPlanRequired: ${providerId}: ${respText.slice(0, 240)}`
+          : `HTTP ${resp.status}: ${respText.slice(0, 240)}`,
+        isRetriable,
+      };
+    }
     let data: unknown;
     try {
       data = JSON.parse(respText);
@@ -589,6 +613,40 @@ async function callSingleProvider(
 
 function asString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function sanitizeProviderChoiceLogText(
+  value: unknown,
+  maxLength = 320,
+): string | null {
+  const raw = asString(value);
+  if (!raw) return null;
+  return raw
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[email]")
+    .replace(/\b\d{5,}\b/g, "[number]")
+    .slice(0, maxLength);
+}
+
+function normalizeProviderTier(value: unknown): Tier | undefined {
+  const raw = asString(value).toLowerCase();
+  if (!raw) return undefined;
+  switch (raw) {
+    case "free":
+    case "low":
+      return "free";
+    case "cheap":
+    case "budget":
+    case "medium":
+      return "budget";
+    case "performance":
+    case "high":
+      return "performance";
+    case "premium":
+    case "xhigh":
+      return "premium";
+    default:
+      return undefined;
+  }
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -4169,6 +4227,21 @@ serve(async (req: Request) => {
           );
         }
         const finalMessages = messages ?? [{ role: "user", content: userMsg }];
+        const requestStartedAt = performance.now();
+        const traceId = String(body.trace_id ?? crypto.randomUUID());
+        const sessionId = body.session_id != null
+          ? String(body.session_id)
+          : null;
+        const providerChoiceReason = sanitizeProviderChoiceLogText(
+          body.provider_choice_reason,
+        );
+        const routingUseCase = sanitizeProviderChoiceLogText(
+          body.routing_use_case,
+          80,
+        );
+        const inputChars = finalMessages
+          .map((m) => typeof m.content === "string" ? m.content.length : 0)
+          .reduce((a, b) => a + b, 0);
 
         const cfg = PROVIDER_CONFIGS[providerId];
         if (!cfg) {
@@ -4203,6 +4276,40 @@ serve(async (req: Request) => {
             authHeaders = {};
             fetchUrl = `${cfg.chatUrl}?key=${apiKey}`;
           }
+          const requestedModel = String(body.model ?? cfg.defaultModel);
+          const logProviderChat = async (
+            params: {
+              success: boolean;
+              statusCode: number;
+              model?: string | null;
+              outputChars?: number | null;
+              estimatedCostUsd?: number | null;
+              errorMessage?: string | null;
+            },
+          ) => {
+            try {
+              const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+              await admin.from("ai_hub_chat_logs").insert({
+                provider: providerId,
+                tier: providerTier(providerId) ?? "direct",
+                success: params.success,
+                estimated_cost_usd: params.estimatedCostUsd ?? null,
+                model: params.model ?? requestedModel,
+                latency_ms: Math.round(performance.now() - requestStartedAt),
+                trace_id: traceId,
+                session_id: sessionId,
+                input_chars: inputChars,
+                output_chars: params.outputChars ?? null,
+                error_message: params.errorMessage ?? null,
+                action: "provider.chat",
+                status_code: params.statusCode,
+                provider_choice_reason: providerChoiceReason,
+                routing_use_case: routingUseCase,
+              });
+            } catch {
+              // ignore logging errors
+            }
+          };
           const resp = await fetch(fetchUrl, {
             method: "POST",
             headers: {
@@ -4210,22 +4317,17 @@ serve(async (req: Request) => {
               "Content-Type": "application/json",
               ...(cfg.extraHeaders ?? {}),
             },
-            body: JSON.stringify(
-              cfg.buildBody(
-                finalMessages,
-                String(body.model ?? cfg.defaultModel),
-              ),
-            ),
+            body: JSON.stringify(cfg.buildBody(finalMessages, requestedModel)),
           });
           const respText = await resp.text();
           if (!resp.ok) {
             // Free tier / 課金制限検知
-            if (
-              respText.includes("paid_plan_required") ||
-              respText.includes("payment_required") ||
-              resp.status === 402 || respText.includes("insufficient_quota") ||
-              respText.includes("billing") || respText.includes("credit")
-            ) {
+            if (isProviderPaymentRequired(resp.status, respText)) {
+              await logProviderChat({
+                success: false,
+                statusCode: resp.status,
+                errorMessage: respText.slice(0, 500),
+              });
               return json({
                 success: false,
                 status: "paidPlanRequired",
@@ -4235,6 +4337,11 @@ serve(async (req: Request) => {
                 detail: respText.slice(0, 300),
               });
             }
+            await logProviderChat({
+              success: false,
+              statusCode: resp.status,
+              errorMessage: respText.slice(0, 500),
+            });
             return json({
               success: false,
               status: "error",
@@ -4247,21 +4354,76 @@ serve(async (req: Request) => {
           try {
             data = JSON.parse(respText);
           } catch {
+            const outputChars = respText.slice(0, 2000).length;
+            const estimatedCost = calculateApiCost(
+              requestedModel,
+              estimateTokensFromChars(inputChars),
+              estimateTokensFromChars(outputChars),
+            );
+            await logProviderChat({
+              success: true,
+              statusCode: 200,
+              model: requestedModel,
+              outputChars,
+              estimatedCostUsd: estimatedCost,
+            });
+            await recordSpend("ef", "ai-hub", estimatedCost);
             return json({
               success: true,
               provider: providerId,
               status: "implemented",
               text: respText.slice(0, 2000),
+              observability: {
+                provider: providerId,
+                model: requestedModel,
+                estimated_cost_usd: estimatedCost,
+                trace_id: traceId,
+                session_id: sessionId,
+                input_chars: inputChars,
+                output_chars: outputChars,
+                action: "provider.chat",
+                status_code: 200,
+                provider_choice_reason: providerChoiceReason,
+                routing_use_case: routingUseCase,
+              },
             });
           }
           const content = cfg.parseResponse(data);
           const modelUsed = pick(data, "model");
+          const outputChars = content.length;
+          const usedModel = String(modelUsed ?? requestedModel);
+          const estimatedCost = calculateApiCost(
+            usedModel,
+            estimateTokensFromChars(inputChars),
+            estimateTokensFromChars(outputChars),
+          );
+          await logProviderChat({
+            success: true,
+            statusCode: 200,
+            model: usedModel,
+            outputChars,
+            estimatedCostUsd: estimatedCost,
+          });
+          await recordSpend("ef", "ai-hub", estimatedCost);
           return json({
             success: true,
             provider: providerId,
             status: "implemented",
             text: content,
-            model: modelUsed ?? cfg.defaultModel,
+            model: usedModel,
+            observability: {
+              provider: providerId,
+              model: usedModel,
+              estimated_cost_usd: estimatedCost,
+              trace_id: traceId,
+              session_id: sessionId,
+              input_chars: inputChars,
+              output_chars: outputChars,
+              action: "provider.chat",
+              status_code: 200,
+              provider_choice_reason: providerChoiceReason,
+              routing_use_case: routingUseCase,
+            },
           });
         } catch (e) {
           return json({
@@ -4276,7 +4438,7 @@ serve(async (req: Request) => {
       case "provider.chat_auto": {
         const effortSelection = await selectEffort("provider.chat_auto", body);
         const offlinePolicy = parseOfflineSecureModePolicy(body);
-        const requestedTier = body.tier as Tier | undefined;
+        const requestedTier = normalizeProviderTier(body.tier);
         const messages = Array.isArray(body.messages) ? body.messages : null;
         const userMsg = String(body.message ?? "");
         if (!messages && !userMsg) {
@@ -4312,6 +4474,13 @@ serve(async (req: Request) => {
         const sessionId = body.session_id != null
           ? String(body.session_id)
           : null;
+        const providerChoiceReason = sanitizeProviderChoiceLogText(
+          body.provider_choice_reason,
+        );
+        const routingUseCase = sanitizeProviderChoiceLogText(
+          body.routing_use_case,
+          80,
+        );
 
         let resultText: string | undefined;
         let usedProvider: string | undefined;
@@ -4358,6 +4527,8 @@ serve(async (req: Request) => {
               error_message: "all tiers exhausted",
               action: "provider.chat_auto",
               status_code: 502,
+              provider_choice_reason: providerChoiceReason,
+              routing_use_case: routingUseCase,
             });
           } catch { /* ignore */ }
           return json({
@@ -4394,6 +4565,8 @@ serve(async (req: Request) => {
             output_chars: outputChars,
             action: "provider.chat_auto",
             status_code: 200,
+            provider_choice_reason: providerChoiceReason,
+            routing_use_case: routingUseCase,
           });
           await recordSpend("ef", "ai-hub", estimatedCost);
         } catch { /* ignore logging errors */ }
@@ -4407,13 +4580,15 @@ serve(async (req: Request) => {
           effort_source: effortSelection.source,
           status: "implemented",
           text: resultText,
+          provider_choice_reason: providerChoiceReason,
+          routing_use_case: routingUseCase,
         });
       }
 
       case "edge_llm.invoke": {
         const effortSelection = await selectEffort("edge_llm.invoke", body);
         const offlinePolicy = parseOfflineSecureModePolicy(body);
-        const requestedTier = body.tier as Tier | undefined;
+        const requestedTier = normalizeProviderTier(body.tier);
         const providerId = asString(body.provider) || undefined;
         const systemPrompt = asString(body.system_prompt);
         const userPrompt = asString(body.user_prompt) ||

--- a/supabase/migrations/20260517093000_extend_ai_hub_provider_choice_reason.sql
+++ b/supabase/migrations/20260517093000_extend_ai_hub_provider_choice_reason.sql
@@ -1,0 +1,17 @@
+-- Issue #2521: persist asset-management AI provider routing evidence.
+-- Provider choice reason is intentionally short, sanitized, and nullable so
+-- existing ai_hub_chat_logs inserts keep working during staged deploys.
+
+ALTER TABLE ai_hub_chat_logs
+  ADD COLUMN IF NOT EXISTS provider_choice_reason text,
+  ADD COLUMN IF NOT EXISTS routing_use_case text;
+
+CREATE INDEX IF NOT EXISTS ai_hub_chat_logs_routing_use_case_idx
+  ON ai_hub_chat_logs (routing_use_case, created_at DESC)
+  WHERE routing_use_case IS NOT NULL;
+
+COMMENT ON COLUMN ai_hub_chat_logs.provider_choice_reason IS
+  'Short sanitized reason for model/provider routing; must not include PII, raw balances, or user IDs.';
+
+COMMENT ON COLUMN ai_hub_chat_logs.routing_use_case IS
+  'Feature-level routing use case such as asset summary, risk explanation, developer suggestion, or reconciliation help.';

--- a/test/services/ai_hub_chat_service_test.dart
+++ b/test/services/ai_hub_chat_service_test.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   setUp(() {
+    AiHubChatQuotaGuard.resetForTesting();
     SharedPreferences.setMockInitialValues(<String, Object>{});
   });
 
@@ -13,7 +14,10 @@ void main() {
       invoker: (body) async {
         expect(body['action'], 'provider.chat');
         expect(body['provider'], 'deepinfra');
+        expect(body['model'], 'deepinfra/test-model');
         expect(body['message'], 'hello');
+        expect(body['provider_choice_reason'], 'asset:summary; test route');
+        expect(body['routing_use_case'], 'summary');
         return {
           'success': true,
           'text': 'world',
@@ -26,12 +30,19 @@ void main() {
             'input_chars': 5,
             'output_chars': 5,
             'status_code': 200,
+            'provider_choice_reason': 'asset:summary; test route',
+            'routing_use_case': 'summary',
           },
         };
       },
     );
 
-    final response = await service.sendProviderChat(message: 'hello');
+    final response = await service.sendProviderChat(
+      message: 'hello',
+      model: 'deepinfra/test-model',
+      providerChoiceReason: 'asset:summary; test route',
+      routingUseCase: 'summary',
+    );
 
     expect(response.text, 'world');
     expect(response.source, 'ai-hub provider.chat / deepinfra');
@@ -39,6 +50,11 @@ void main() {
     expect(response.observability?.model, 'deepinfra/test-model');
     expect(response.observability?.latencyMs, 321);
     expect(response.observability?.shortTraceId, 'trace-12');
+    expect(
+      response.observability?.providerChoiceReason,
+      'asset:summary; test route',
+    );
+    expect(response.observability?.routingUseCase, 'summary');
   });
 
   test('sendProviderChat throws when provider response is empty', () async {
@@ -52,12 +68,36 @@ void main() {
     );
   });
 
+  test('sendAutoChat surfaces paid provider errors from ai-hub', () async {
+    final service = AiHubChatService(
+      invoker: (_) async => {
+        'success': false,
+        'status': 'paidPlanRequired',
+        'provider': 'deepinfra',
+        'message': 'DeepInfra needs positive balance',
+        'detail': 'You need positive balance to do inference.',
+      },
+    );
+
+    expect(
+      () => service.sendAutoChat(message: 'hello'),
+      throwsA(
+        isA<AiHubChatException>()
+            .having((e) => e.message, 'message', contains('paidPlanRequired'))
+            .having((e) => e.message, 'provider', contains('deepinfra'))
+            .having((e) => e.message, 'detail', contains('positive balance')),
+      ),
+    );
+  });
+
   test('sendAutoChat returns auto-routed provider metadata', () async {
     final service = AiHubChatService(
       invoker: (body) async {
         expect(body['action'], 'provider.chat_auto');
         expect(body['message'], 'hello');
         expect(body['session_id'], 'session-123');
+        expect(body['provider_choice_reason'], 'asset:summary; auto route');
+        expect(body['routing_use_case'], 'summary');
         return {
           'success': true,
           'text': 'auto-world',
@@ -74,6 +114,8 @@ void main() {
     final response = await service.sendAutoChat(
       message: 'hello',
       sessionId: 'session-123',
+      providerChoiceReason: 'asset:summary; auto route',
+      routingUseCase: 'summary',
     );
 
     expect(response.text, 'auto-world');
@@ -115,10 +157,7 @@ void main() {
   test('verifyAnnualRateEvidence calls ai-hub vision verifier', () async {
     final service = AiHubChatService(
       invoker: (body) async {
-        expect(
-          body['action'],
-          'asset_liability.verify_annual_rate_evidence',
-        );
+        expect(body['action'], 'asset_liability.verify_annual_rate_evidence');
         expect(body['accountName'], 'Mobit');
         expect(body['submittedAnnualRate'], 0.18);
         expect(body['imageBase64'], 'abc123');

--- a/test/services/ai_hub_provider_choice_reason_schema_test.dart
+++ b/test/services/ai_hub_provider_choice_reason_schema_test.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260517093000_extend_ai_hub_provider_choice_reason.sql';
+
+void main() {
+  group('ai_hub provider choice reason migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(_migrationPath).readAsStringSync().replaceAll('\r\n', '\n');
+    });
+
+    test('adds nullable provider routing evidence columns', () {
+      expect(
+        sql,
+        contains('ADD COLUMN IF NOT EXISTS provider_choice_reason text'),
+      );
+      expect(sql, contains('ADD COLUMN IF NOT EXISTS routing_use_case text'));
+      expect(sql, contains('ai_hub_chat_logs_routing_use_case_idx'));
+    });
+
+    test('documents the no-PII logging boundary', () {
+      expect(sql, contains('must not include PII'));
+      expect(sql, contains('raw balances'));
+      expect(sql, contains('routing use case'));
+    });
+  });
+}

--- a/test/services/asset_management_ai_provider_router_test.dart
+++ b/test/services/asset_management_ai_provider_router_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_management_ai_provider_router.dart';
+
+void main() {
+  group('AssetManagementAiProviderRouter', () {
+    test('defines the four asset-management routing use cases', () {
+      const router = AssetManagementAiProviderRouter(routingEnabled: true);
+
+      for (final useCase in AssetManagementAiProviderUseCase.values) {
+        final route = router.routeFor(useCase: useCase);
+
+        expect(route.routingEnabled, true);
+        expect(route.candidates.map((candidate) => candidate.providerId), [
+          'anthropic',
+          'openai',
+          'google',
+        ]);
+        expect(route.candidates.map((candidate) => candidate.modelId), [
+          'claude-opus-4-7',
+          'gpt-5',
+          'gemini-3.1-pro',
+        ]);
+        expect(route.providerChoiceReason, contains(useCase.id));
+        expect(route.providerChoiceReason, contains('local-deterministic'));
+      }
+    });
+
+    test('keeps explicit provider overrides auditable', () {
+      const router = AssetManagementAiProviderRouter(routingEnabled: true);
+
+      final route = router.routeFor(
+        useCase: AssetManagementAiProviderUseCase.reconciliationHelp,
+        explicitProvider: 'openai',
+      );
+
+      expect(route.candidates, hasLength(1));
+      expect(route.candidates.single.providerId, 'openai');
+      expect(route.candidates.single.modelId, 'gpt-5');
+      expect(route.reason, contains('explicit provider override'));
+    });
+  });
+}

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -1,11 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/ai_hub_chat_service.dart';
 import 'package:my_web_app/services/asset_liability_planning_service.dart';
+import 'package:my_web_app/services/asset_management_ai_provider_router.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 
 void main() {
   group('AssetManagementAiSummaryService', () {
+    setUp(AiHubChatQuotaGuard.resetForTesting);
+
     test('does not call ai-hub when feature flag is off', () async {
       var calls = 0;
       final service = AssetManagementAiSummaryService(
@@ -26,7 +29,7 @@ void main() {
       expect(result.usedExternalAi, false);
       expect(result.source.contains('feature flag off'), true);
       expect(
-        result.text.contains('Amounts are calculated by Dart rules'),
+        result.text.contains('Dart rules'),
         true,
       );
     });
@@ -54,11 +57,11 @@ void main() {
       expect(result.usedExternalAi, true);
       expect(result.text, 'AI generated summary');
       expect(capturedBody?['action'], 'provider.chat_auto');
-      expect(capturedBody?['tier'], 'cheap');
+      expect(capturedBody?['tier'], 'performance');
       expect(capturedBody?['trace_id'], 'asset-management-ai-summary');
       expect(
         capturedBody?['message'].toString().contains(
-              'Computed insight payload',
+              'Redacted computed insight payload',
             ),
         true,
       );
@@ -66,6 +69,99 @@ void main() {
         capturedBody?['message'].toString().contains(
               '"external_ai_may_recalculate_amounts":false',
             ),
+        true,
+      );
+      expect(capturedBody?['message'].toString().contains('50,000'), false);
+      expect(capturedBody?['message'].toString().contains('50000'), false);
+      expect(capturedBody?['provider_choice_reason'], contains('summary'));
+      expect(capturedBody?['routing_use_case'], 'summary');
+    });
+
+    test('routes through configured provider chain when routing is enabled',
+        () async {
+      final calls = <Map<String, dynamic>>[];
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        providerRouter: const AssetManagementAiProviderRouter(
+          routingEnabled: true,
+        ),
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            calls.add(Map<String, dynamic>.from(body));
+            return <String, dynamic>{
+              'success': true,
+              'text': 'Claude routed summary',
+              'observability': <String, dynamic>{
+                'provider': body['provider'],
+                'model': body['model'],
+              },
+            };
+          },
+        ),
+        now: () => DateTime(2026, 5, 1, 12),
+      );
+
+      final result = await service.generateSummary(report: _report());
+
+      expect(result.status, AssetManagementAiSummaryStatus.aiGenerated);
+      expect(result.text, 'Claude routed summary');
+      expect(calls, hasLength(1));
+      expect(calls.single['action'], 'provider.chat');
+      expect(calls.single['provider'], 'anthropic');
+      expect(calls.single['model'], 'claude-opus-4-7');
+      expect(calls.single['routing_use_case'], 'summary');
+      expect(
+        calls.single['provider_choice_reason'],
+        contains('claude-opus-4-7@anthropic'),
+      );
+      expect(result.providerRoute?['routing_enabled'], true);
+    });
+
+    test('provider routing falls back across providers before local summary',
+        () async {
+      final providers = <String>[];
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        providerRouter: const AssetManagementAiProviderRouter(
+          routingEnabled: true,
+        ),
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            providers.add(body['provider'] as String);
+            if (body['provider'] == 'anthropic') {
+              throw const AiHubChatException('temporary outage');
+            }
+            return <String, dynamic>{
+              'success': true,
+              'text': 'GPT fallback summary',
+              'provider': body['provider'],
+            };
+          },
+        ),
+        now: () => DateTime(2026, 5, 1, 12),
+      );
+
+      final result = await service.generateSummary(report: _report());
+
+      expect(result.status, AssetManagementAiSummaryStatus.aiGenerated);
+      expect(result.text, 'GPT fallback summary');
+      expect(providers, <String>['anthropic', 'openai']);
+    });
+
+    test('ai-safe payload keeps exact money values out of external AI context',
+        () {
+      final service = AssetManagementAiSummaryService(
+        now: () => DateTime(2026, 5, 1, 12),
+      );
+
+      final payload = service.buildAiSafePayload(_report());
+      final encoded = payload.toString();
+
+      expect(encoded.contains('50000'), false);
+      expect(encoded.contains('20000'), false);
+      expect(encoded.contains('available_money_bands'), true);
+      expect(
+        encoded.contains('external_ai_payload_redacts_exact_money_values'),
         true,
       );
     });
@@ -85,7 +181,7 @@ void main() {
       expect(result.usedExternalAi, false);
       expect(result.errorMessage?.contains('boom'), true);
       expect(
-        result.text.contains('Amounts are calculated by Dart rules'),
+        result.text.contains('Dart rules'),
         true,
       );
     });
@@ -127,7 +223,7 @@ void main() {
         expect(result.usedExternalAi, false);
         expect(result.source, 'deterministic fallback / waiting for ai-hub');
         expect(
-          result.text.contains('Amounts are calculated by Dart rules'),
+          result.text.contains('Dart rules'),
           true,
         );
       },
@@ -144,7 +240,7 @@ void main() {
 
       expect(text.contains('今日の食費'), true);
       expect(text.contains('支払い'), true);
-      expect(text.contains('Amounts are calculated by Dart rules'), true);
+      expect(text.contains('Dart rules'), true);
       expect(payload['emergency_advices'] is List<dynamic>, true);
       expect((payload['emergency_advices'] as List<dynamic>).isNotEmpty, true);
     });


### PR DESCRIPTION
﻿## Summary

- Add a feature-flagged asset-management AI provider router for summary, risk explanation, developer suggestion, and reconciliation help use cases.
- Route external AI calls through Claude Opus 4.7 -> GPT-5 -> Gemini 3.1 Pro before deterministic local fallback, so DeepInfra `paidPlanRequired` / positive-balance failures do not stop asset-management advice.
- Redact exact balances/account identifiers from asset-management AI prompts while keeping Dart as the calculation owner.
- Persist sanitized provider choice reason/routing use case into `ai_hub_chat_logs` and surface the metadata through `AiHubChatService`.
- Keep the subagent orchestration policy marker test aligned with the current required docs so hooks remain green.

## Scope Notes

- 家賃（25日支払い 63,000円）と年利エビデンス提出・AI確認の土台は、先行PR #2561 で `main` 反映済みです。
- This PR focuses on the external AI routing/fallback path that was exposed by the DeepInfra billing error.

## Minimal E2E Declaration

- The E2E plan is implementation-detail independent and black-box: verify the asset-management page still shows deterministic fallback advice when external AI fails, and shows routed AI metadata when enabled.
- The plan is minimal, about three I/O cases: feature flag off, feature flag on with provider failure fallback, and feature flag on with provider metadata returned.
- Mechanism: Playwright or `integration_test` can cover the UI path; this PR adds service/Edge tests instead because the behavior is provider-routing/service-layer logic.
- E2E-Exception: no new `integration_test/` or `test/e2e/` file is added because the risk is isolated to deterministic routing, redacted payload construction, and ai-hub error handling; those paths are covered by unit tests, Edge type check, and CI gates.

## High-risk Ultrareview

Review owner: Claude Code #1.

Claude ultrareview evidence:
- security: prompts sent to external AI use redacted bands/counts instead of exact balances, account IDs, or user identifiers; provider-choice logs are sanitized.
- rollback: feature-flagged provider routing defaults OFF, and deterministic local summary remains the fallback if every provider fails.
- data migration: migration only adds nullable `ai_hub_chat_logs` metadata columns plus an index/comment; no destructive DDL and no existing row rewrite.
- prod smoke: DB + Edge smoke is expected to validate the Edge Function and migration path in CI before merge.
- observability: `provider_choice_reason` and `routing_use_case` are logged so provider decisions can be audited without storing raw financial values.

Unresolved findings: 0. No unresolved findings.

## Validation

- `dart format --output=none --set-exit-if-changed ...`: OK
- `deno fmt --check supabase/functions/ai-hub/index.ts`: OK after normalizing the Windows worktree line endings for the check
- `python scripts/check_migration_timestamps.py`: OK
- `python scripts/check_ai_tool_update_routing_test.py`: OK
- `dart analyze`: No issues found
- Related `flutter test --no-pub ...`: 60 passed
- Full `flutter test --no-pub --reporter expanded`: 507 passed
- `deno check --node-modules-dir=auto supabase/functions/ai-hub/index.ts`: OK
- `git diff --check`: OK

Closes #2521
