### PR TITLE
ci: add AI bench provider manifest (#2520)

### DIFF
--- a/docs/ai-bench/v1_spec.md
+++ b/docs/ai-bench/v1_spec.md
@@ -86,3 +86,18 @@ python scripts/internal_ai_bench.py `
 
 The Markdown report must be attached to `#2520` or a follow-up issue before any
 `#2521` routing default changes are made.
+
+Prepare provider execution without making live API calls:
+
+```powershell
+python scripts/internal_ai_bench_provider_manifest.py `
+  --input docs/ai-bench/results/template.json `
+  --output-json docs/ai-bench/results/provider_manifest.json `
+  --output-md docs/ai-bench/results/provider_manifest.md `
+  --strict
+```
+
+The provider manifest is a dry-run runbook only. It records eligible verified
+model slots, official sources, required environment variable names, and
+synthetic-input rules. Live provider calls remain gated by explicit operator
+approval, current official source rechecks, and a scored bench report.

--- a/docs/ai-bench/verdict.md
+++ b/docs/ai-bench/verdict.md
@@ -1,0 +1,40 @@
+# Internal AI Model Bench Verdict
+
+Last updated: 2026-05-18
+
+## Current State
+
+No live provider run has been recorded yet. The project therefore has no
+task-specific winner and no fixed strongest-model conclusion.
+
+## Routing Rule
+
+- `#2521` routing defaults must cite a scored `scripts/internal_ai_bench.py`
+  report, or remain behind a feature flag.
+- Provider live runs require explicit operator approval because they may use
+  paid APIs and provider credentials.
+- SNS-only model claims stay unranked until an official or primary source is
+  attached to the bench input.
+
+## Next Evidence Needed
+
+1. Generate a dry-run provider manifest:
+
+   ```powershell
+   python scripts/internal_ai_bench_provider_manifest.py `
+     --input docs/ai-bench/results/template.json `
+     --output-json docs/ai-bench/results/provider_manifest.json `
+     --output-md docs/ai-bench/results/provider_manifest.md `
+     --strict
+   ```
+
+2. Recheck official model ids, pricing, context limits, and thinking/tool-use
+   parameters immediately before any live provider execution.
+3. Run B1/B2/B3/R1 against synthetic repository fixtures only.
+4. Normalize results with `scripts/internal_ai_bench.py` and attach the Markdown
+   report to `#2520`.
+
+## Interim Verdict
+
+Keep the existing asset-management AI routing conservative. Evidence collection
+is ready, but live scoring and production routing changes are not complete.

--- a/scripts/internal_ai_bench_provider_manifest.py
+++ b/scripts/internal_ai_bench_provider_manifest.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Build a dry-run provider execution manifest for the internal AI bench.
+
+This script intentionally does not call provider APIs. It converts the
+official-source bench template into a runbook that names the model slots, tasks,
+expected environment variables, and safety notes needed before a live run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import internal_ai_bench
+
+
+PROVIDER_CONFIGS: dict[str, dict[str, Any]] = {
+    "openai": {
+        "required_env": ["OPENAI_API_KEY"],
+        "live_calls_supported": False,
+        "operator_note": "Use Responses API-compatible prompts after official model availability is rechecked.",
+    },
+    "anthropic": {
+        "required_env": ["ANTHROPIC_API_KEY"],
+        "live_calls_supported": False,
+        "operator_note": "Use extended-thinking settings only when official docs and cost limits are attached.",
+    },
+    "google": {
+        "required_env": ["GOOGLE_AI_API_KEY"],
+        "live_calls_supported": False,
+        "operator_note": "Resolve the exact Gemini model id from official docs at run time.",
+    },
+    "moonshot": {
+        "required_env": ["MOONSHOT_API_KEY"],
+        "live_calls_supported": False,
+        "operator_note": "Treat Kimi candidates as unavailable until the official API model list is confirmed.",
+    },
+    "deepseek": {
+        "required_env": ["DEEPSEEK_API_KEY"],
+        "live_calls_supported": False,
+        "operator_note": "Attach current pricing docs before scoring cost.",
+    },
+    "xai": {
+        "required_env": ["XAI_API_KEY"],
+        "live_calls_supported": False,
+        "operator_note": "Use only documented model ids from xAI developer docs.",
+    },
+}
+
+
+SYNTHETIC_INPUT_POLICY = (
+    "Use synthetic repository fixtures only. Do not include asset balances, "
+    "account ids, API keys, customer data, or live external-site credentials."
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def task_ids(report: dict[str, Any], selected_tasks: list[str] | None) -> list[str]:
+    tasks = report.get("tasks") if isinstance(report.get("tasks"), dict) else internal_ai_bench.TASKS
+    available = list(tasks)
+    if not selected_tasks:
+        return available
+    return [task for task in selected_tasks if task in tasks]
+
+
+def selected_model_entries(
+    report: dict[str, Any],
+    providers: list[str] | None,
+    include_partial: bool,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    provider_filter = {provider.lower() for provider in providers or []}
+    runnable: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+
+    for entry in internal_ai_bench.iter_model_entries(report):
+        provider = str(entry.get("provider", "")).lower()
+        label = internal_ai_bench.model_label(entry)
+        status = str(entry.get("verification_status", "unverified")).lower()
+        sources = internal_ai_bench.source_list(entry)
+
+        if provider_filter and provider not in provider_filter:
+            skipped.append(
+                {
+                    "label": label,
+                    "verification_status": status,
+                    "reason": "provider filter excluded this model",
+                    "official_sources": sources,
+                }
+            )
+            continue
+
+        if status != internal_ai_bench.RANKABLE_STATUS and not (
+            include_partial and status == "partial"
+        ):
+            skipped.append(
+                {
+                    "label": label,
+                    "verification_status": status,
+                    "reason": "not eligible for dry-run execution manifest",
+                    "official_sources": sources,
+                }
+            )
+            continue
+
+        if not sources:
+            skipped.append(
+                {
+                    "label": label,
+                    "verification_status": status,
+                    "reason": "official_sources are required",
+                }
+            )
+            continue
+
+        if provider not in PROVIDER_CONFIGS:
+            skipped.append(
+                {
+                    "label": label,
+                    "verification_status": status,
+                    "reason": "provider config is not defined yet",
+                    "official_sources": sources,
+                }
+            )
+            continue
+
+        runnable.append(entry)
+
+    return runnable, skipped
+
+
+def prompt_package(task_id: str, task: dict[str, Any], axes: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "task_id": task_id,
+        "track": task.get("track", "unknown"),
+        "title": task.get("title", "unknown"),
+        "required_proof": task.get("proof", ""),
+        "instructions": [
+            "Follow the repository patterns already present in the target files.",
+            "Keep the diff small and explain any skipped requirement explicitly.",
+            "Do not perform live deploys, external postings, or account changes.",
+            "Return implementation notes, changed files, validation commands, and risk notes.",
+        ],
+        "scoring_axes": list(axes),
+        "input_policy": SYNTHETIC_INPUT_POLICY,
+    }
+
+
+def build_manifest(
+    report: dict[str, Any],
+    selected_tasks: list[str] | None = None,
+    providers: list[str] | None = None,
+    include_partial: bool = False,
+) -> dict[str, Any]:
+    tasks = report.get("tasks") if isinstance(report.get("tasks"), dict) else internal_ai_bench.TASKS
+    axes = report.get("axes") if isinstance(report.get("axes"), dict) else internal_ai_bench.AXES
+    task_list = task_ids(report, selected_tasks)
+    runnable, skipped = selected_model_entries(report, providers, include_partial)
+
+    runs: list[dict[str, Any]] = []
+    for entry in runnable:
+        provider = str(entry.get("provider", "")).lower()
+        config = PROVIDER_CONFIGS[provider]
+        for task_id in task_list:
+            task = tasks[task_id]
+            runs.append(
+                {
+                    "run_id": f"{task_id}-{provider}-{entry.get('model')}",
+                    "task_id": task_id,
+                    "provider": provider,
+                    "model": entry.get("model"),
+                    "verification_status": entry.get("verification_status"),
+                    "official_sources": internal_ai_bench.source_list(entry),
+                    "required_env": config["required_env"],
+                    "live_calls_supported": config["live_calls_supported"],
+                    "operator_note": config["operator_note"],
+                    "prompt_package": prompt_package(task_id, task, axes),
+                }
+            )
+
+    return {
+        "schema_version": 1,
+        "generated_at": utc_now(),
+        "issue": report.get("issue", "#2520"),
+        "bench_id": report.get("bench_id", "template"),
+        "mode": "dry_run_manifest",
+        "live_provider_calls": False,
+        "operator_approval_required_for_live": True,
+        "policy": {
+            "rank_only_verified_models": True,
+            "fixed_strongest_model": "forbidden",
+            "input_policy": SYNTHETIC_INPUT_POLICY,
+            "routing_default_rule": (
+                "#2521 routing defaults must cite scored bench results or remain feature-flagged."
+            ),
+        },
+        "tasks": {task_id: prompt_package(task_id, tasks[task_id], axes) for task_id in task_list},
+        "runs": runs,
+        "skipped_models": skipped,
+        "warnings": internal_ai_bench.validate_report(report),
+    }
+
+
+def render_sources(sources: list[str]) -> str:
+    return "<br>".join(sources) if sources else "none"
+
+
+def render_markdown(manifest: dict[str, Any]) -> str:
+    lines: list[str] = [
+        "# Internal AI Bench Provider Dry-Run Manifest",
+        "",
+        f"- Issue: `{manifest.get('issue', '#2520')}`",
+        f"- Bench ID: `{manifest.get('bench_id', 'template')}`",
+        f"- Generated at: `{manifest.get('generated_at')}`",
+        "- Live provider calls: disabled",
+        "- Operator approval required before any live API call",
+        "",
+        "This manifest prepares provider execution. It does not rank models and it does not call APIs.",
+        "",
+        "## Runnable Matrix",
+        "",
+        "| Run ID | Task | Provider | Model | Env | Sources |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+
+    runs = manifest.get("runs", [])
+    if runs:
+        for run in runs:
+            lines.append(
+                "| {run_id} | `{task}` | `{provider}` | `{model}` | `{env}` | {sources} |".format(
+                    run_id=run["run_id"],
+                    task=run["task_id"],
+                    provider=run["provider"],
+                    model=run["model"],
+                    env=", ".join(run["required_env"]),
+                    sources=render_sources(run["official_sources"]),
+                )
+            )
+    else:
+        lines.append("| - | - | - | - | - | No eligible provider runs. |")
+
+    lines.extend(
+        [
+            "",
+            "## Skipped Models",
+            "",
+            "| Model | Verification | Reason | Sources |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    skipped = manifest.get("skipped_models", [])
+    if skipped:
+        for entry in skipped:
+            lines.append(
+                "| `{label}` | `{status}` | {reason} | {sources} |".format(
+                    label=entry["label"],
+                    status=entry.get("verification_status", "unknown"),
+                    reason=entry.get("reason", ""),
+                    sources=render_sources(entry.get("official_sources", [])),
+                )
+            )
+    else:
+        lines.append("| - | - | None | - |")
+
+    lines.extend(
+        [
+            "",
+            "## Operator Rules",
+            "",
+            f"- {SYNTHETIC_INPUT_POLICY}",
+            "- Keep #2521 routing defaults feature-flagged until a scored bench report is attached.",
+            "- Recheck official model ids, pricing, and thinking/tool-use parameters immediately before live runs.",
+            "- Record latency, cost, and validation evidence in the normalized bench report, not in this manifest.",
+            "",
+            "## Warnings",
+            "",
+        ]
+    )
+    warnings = manifest.get("warnings", [])
+    if warnings:
+        lines.extend(f"- {warning}" for warning in warnings)
+    else:
+        lines.append("- None.")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, help="Input benchmark JSON.")
+    parser.add_argument("--output-json", type=Path, help="Write dry-run manifest JSON.")
+    parser.add_argument("--output-md", type=Path, help="Write dry-run manifest Markdown.")
+    parser.add_argument("--task", action="append", help="Limit manifest to a task id such as B1.")
+    parser.add_argument("--provider", action="append", help="Limit manifest to a provider key.")
+    parser.add_argument(
+        "--include-partial",
+        action="store_true",
+        help="Include partial verification rows in the dry-run manifest.",
+    )
+    parser.add_argument("--print-markdown", action="store_true", help="Print Markdown to stdout.")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero when warnings exist.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    report = internal_ai_bench.load_report(args.input)
+    manifest = build_manifest(
+        report,
+        selected_tasks=args.task,
+        providers=args.provider,
+        include_partial=args.include_partial,
+    )
+    markdown = render_markdown(manifest)
+
+    if args.output_json:
+        write_json(args.output_json, manifest)
+    if args.output_md:
+        write_text(args.output_md, markdown + "\n")
+    if args.print_markdown:
+        print(markdown)
+
+    if args.strict and manifest["warnings"]:
+        for warning in manifest["warnings"]:
+            print(f"WARN: {warning}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/test_internal_ai_bench_provider_manifest.py
+++ b/test/scripts/test_internal_ai_bench_provider_manifest.py
@@ -1,0 +1,85 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts import internal_ai_bench
+from scripts import internal_ai_bench_provider_manifest
+
+
+class InternalAiBenchProviderManifestTest(unittest.TestCase):
+    def test_default_manifest_excludes_partial_and_unverified_models(self) -> None:
+        manifest = internal_ai_bench_provider_manifest.build_manifest(
+            internal_ai_bench.default_report()
+        )
+
+        labels = {
+            f"{run['provider']}/{run['model']}"
+            for run in manifest["runs"]
+        }
+        skipped = {entry["label"] for entry in manifest["skipped_models"]}
+
+        self.assertIn("openai/gpt-5.5", labels)
+        self.assertIn("anthropic/claude-opus-4-7", labels)
+        self.assertNotIn("bytedance/seedance-2.0", labels)
+        self.assertIn("bytedance/seedance-2.0", skipped)
+        self.assertIn("mimo/mimo-v2.5-pro", skipped)
+        self.assertFalse(manifest["live_provider_calls"])
+
+    def test_manifest_run_contains_source_env_and_prompt_package(self) -> None:
+        manifest = internal_ai_bench_provider_manifest.build_manifest(
+            internal_ai_bench.default_report(),
+            selected_tasks=["B1"],
+            providers=["anthropic"],
+        )
+
+        self.assertEqual(len(manifest["runs"]), 1)
+        run = manifest["runs"][0]
+        self.assertEqual(run["task_id"], "B1")
+        self.assertEqual(run["required_env"], ["ANTHROPIC_API_KEY"])
+        self.assertIn("https://www.anthropic.com/news/claude-opus-4-7", run["official_sources"])
+        self.assertIn("thinking_budget", run["prompt_package"]["scoring_axes"])
+        self.assertIn("synthetic", run["prompt_package"]["input_policy"].lower())
+
+    def test_cli_writes_manifest_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report_path = root / "template.json"
+            out_json = root / "manifest.json"
+            out_md = root / "manifest.md"
+            report_path.write_text(
+                json.dumps(internal_ai_bench.default_report()),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                internal_ai_bench_provider_manifest.main(
+                    [
+                        "--input",
+                        str(report_path),
+                        "--task",
+                        "R1",
+                        "--provider",
+                        "openai",
+                        "--output-json",
+                        str(out_json),
+                        "--output-md",
+                        str(out_md),
+                        "--strict",
+                    ]
+                ),
+                0,
+            )
+
+            manifest = json.loads(out_json.read_text(encoding="utf-8"))
+            self.assertEqual(manifest["runs"][0]["run_id"], "R1-openai-gpt-5.5")
+            markdown = out_md.read_text(encoding="utf-8")
+            self.assertIn("Live provider calls: disabled", markdown)
+            self.assertIn("OPENAI_API_KEY", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

- Add a dry-run provider execution manifest generator for #2520.
- Add an initial `docs/ai-bench/verdict.md` that keeps #2521 routing conservative until scored bench evidence exists.
- Document the dry-run manifest command in the AI bench spec and cover it with Python unit tests.

## Scope and Safety

This PR does not call provider APIs, does not read provider credentials, and does not change production routing defaults. It only emits a dry-run runbook that names eligible verified model slots from the bench input, official sources, required environment variable names, synthetic-input rules, and operator gates.

## High-Risk Ultrareview

- Review owner: Claude Code #1 policy owner; Codex #1 scoped implementation.
- Claude ultrareview evidence: deterministic docs/Python CLI only; no runtime app path, deploy logic, data migration, or live provider execution.
- Security: manifest records env var names only and explicitly blocks asset balances, account ids, API keys, customer data, and external-site credentials in bench prompts.
- Rollback: revert this PR to remove the dry-run manifest helper and verdict scaffold.
- Data migration: none.
- Prod smoke: no production runtime path changed; the PR Public E2E stability smoke check covers the public surface.
- Observability: generated manifest records issue, bench id, official sources, provider env names, skipped models, and validation warnings for review.
- No unresolved ultrareview findings: 0.

## Minimal E2E Gate

- The E2E plan is implementation-detail independent / black-box: verify CLI input/output behavior rather than internal functions.
- Minimal, about three I/O cases: default manifest excludes partial/unverified models; Anthropic B1 manifest includes source/env/prompt package; CLI writes JSON and Markdown outputs.
- E2E mechanism: Playwright is not required for this docs/Python CLI-only PR; the equivalent black-box mechanism is the strict CLI invocation plus Python unit tests listed below.
- E2E-Exception: no application-code path changed, so no new integration_test or Playwright file is needed.

## Validation

- `python test/scripts/test_internal_ai_bench.py`
- `python test/scripts/test_internal_ai_bench_provider_manifest.py`
- `python -m py_compile scripts/internal_ai_bench.py scripts/internal_ai_bench_provider_manifest.py`
- `python scripts/internal_ai_bench_provider_manifest.py --input docs/ai-bench/results/template.json --output-json $env:TEMP\ai-bench-provider-manifest.json --output-md $env:TEMP\ai-bench-provider-manifest.md --strict`
- `npx --yes markdownlint-cli@0.45.0 --dot docs/ai-bench/v1_spec.md docs/ai-bench/verdict.md`
- `git diff --check`

Guarded subagent orchestration: none used. Lead owner: Codex #1. Child worker cleanup evidence: no child workers were started.

Closes scoped follow-up for #2520 provider manifest / verdict scaffold; keep #2520 open if live provider scoring still remains.
