### PR TITLE
Make asset assistant Japanese and support pasted rate evidence

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -32,6 +32,7 @@ import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
 import 'package:my_web_app/services/smbc_csv_import_service.dart';
 import 'package:my_web_app/services/waste_tracking_service.dart';
+import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -155,6 +156,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final Map<String, TextEditingController> _annualRateControllers =
       <String, TextEditingController>{};
   final Set<String> _verifyingAnnualRateEvidenceAccountIds = <String>{};
+  NoteImagePasteRegistration? _annualRateEvidencePasteRegistration;
+  AssetLiabilityDebtRow? _annualRateEvidencePasteTargetRow;
   final TextEditingController _cardStatementImportController =
       TextEditingController();
   String? _selectedCardStatementBillingAccountId;
@@ -295,6 +298,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     });
     _fetchTodayClosing();
     _loadSourceOptionsFromDb();
+    _annualRateEvidencePasteRegistration = registerNoteImagePasteListener(
+      isEnabled: () =>
+          mounted &&
+          _annualRateEvidencePasteTargetRow != null &&
+          !_verifyingAnnualRateEvidenceAccountIds.contains(
+            _annualRateEvidencePasteTargetRow!.id,
+          ),
+      onImagePasted: _handleAnnualRateEvidencePasted,
+    );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _scrollToInitialFocus();
@@ -315,6 +327,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _flowMemoController.dispose();
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
+    _annualRateEvidencePasteRegistration?.dispose();
     _scrollController.dispose();
     _debtMasterHorizontalScrollController.dispose();
     super.dispose();
@@ -1688,9 +1701,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final controller = _annualRateControllerFor(row);
     final rate = _parseAnnualRateInput(controller.text);
     if (rate == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('年利を入力してから証跡画像を提出してください')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('年利を入力してから証跡画像を提出してください')));
       return;
     }
     final result = await FilePicker.pickFiles(
@@ -1703,22 +1716,91 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     final mimeType = _mimeTypeForAnnualRateEvidence(file);
+    await _verifyAnnualRateEvidenceBytes(
+      row: row,
+      rate: rate,
+      bytes: bytes,
+      mimeType: mimeType,
+      fileName: file.name,
+    );
+  }
+
+  void _startAnnualRateEvidencePaste(AssetLiabilityDebtRow row) {
+    final rate = _parseAnnualRateInput(_annualRateControllerFor(row).text);
+    if (rate == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('年利を入力してから証跡画像を貼り付けてください')));
+      return;
+    }
+    setState(() => _annualRateEvidencePasteTargetRow = row);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${row.name}の年利証跡を貼り付け待ちです。画面キャプチャをコピーして Ctrl+V してください。'),
+      ),
+    );
+  }
+
+  Future<void> _handleAnnualRateEvidencePasted(
+    Uint8List bytes,
+    String fileName,
+    String mimeType,
+  ) async {
+    final row = _annualRateEvidencePasteTargetRow;
+    if (row == null) {
+      return;
+    }
+    final rate = _parseAnnualRateInput(_annualRateControllerFor(row).text);
+    if (rate == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('年利を入力してから証跡画像を貼り付けてください')));
+      return;
+    }
+    if (bytes.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('貼り付けた画像を読み取れませんでした')));
+      return;
+    }
+    final normalizedFileName = fileName.trim().isEmpty
+        ? 'annual-rate-evidence-paste.png'
+        : fileName.trim();
+    await _verifyAnnualRateEvidenceBytes(
+      row: row,
+      rate: rate,
+      bytes: bytes,
+      mimeType: mimeType.trim().isEmpty ? 'image/png' : mimeType.trim(),
+      fileName: normalizedFileName,
+    );
+  }
+
+  Future<void> _verifyAnnualRateEvidenceBytes({
+    required AssetLiabilityDebtRow row,
+    required double rate,
+    required Uint8List bytes,
+    required String mimeType,
+    required String fileName,
+  }) async {
     setState(() {
       _verifyingAnnualRateEvidenceAccountIds.add(row.id);
     });
-    final evidence = await _annualRateEvidenceService.verifyEvidence(
+    final evidence = await _annualRateEvidenceService.verifyEvidenceBytes(
       accountId: row.id,
       accountName: row.name,
       annualRate: rate,
-      imageBase64: base64Encode(bytes),
+      imageBytes: bytes,
       mimeType: mimeType,
-      fileName: file.name,
+      fileName: fileName,
     );
     if (!mounted) {
       return;
     }
     setState(() {
       _verifyingAnnualRateEvidenceAccountIds.remove(row.id);
+      if (_annualRateEvidencePasteTargetRow?.id == row.id) {
+        _annualRateEvidencePasteTargetRow = null;
+      }
       _annualRateEvidences[row.id] = evidence;
       if (evidence.matchesAnnualRate(rate)) {
         _annualRateOverrides[row.id] = rate;
@@ -10970,6 +11052,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Widget _buildAnnualRateEvidenceCell(AssetLiabilityDebtRow row) {
     final evidence = _annualRateEvidences[row.id];
     final isVerifying = _verifyingAnnualRateEvidenceAccountIds.contains(row.id);
+    final isPasteTarget = _annualRateEvidencePasteTargetRow?.id == row.id;
     final requestedRate =
         _parseAnnualRateInput(_annualRateControllerFor(row).text) ??
             row.annualRate;
@@ -11005,6 +11088,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             visualDensity: VisualDensity.compact,
           ),
         ),
+        OutlinedButton.icon(
+          onPressed:
+              isVerifying ? null : () => _startAnnualRateEvidencePaste(row),
+          icon: const Icon(Icons.content_paste, size: 14),
+          label: const Text('貼付'),
+          style: OutlinedButton.styleFrom(
+            foregroundColor: isPasteTarget ? const Color(0xFF2563EB) : color,
+            side: BorderSide(
+              color: (isPasteTarget ? const Color(0xFF2563EB) : color)
+                  .withValues(alpha: 0.5),
+            ),
+            visualDensity: VisualDensity.compact,
+          ),
+        ),
+        if (isPasteTarget)
+          _buildTextStatusChip(
+            label: 'Ctrl+V待ち',
+            color: const Color(0xFF2563EB),
+          ),
         if (evidence != null)
           Tooltip(
             message: evidence.summary.isEmpty

--- a/lib/services/asset_liability_annual_rate_evidence_service.dart
+++ b/lib/services/asset_liability_annual_rate_evidence_service.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 
 import 'ai_hub_chat_service.dart';
@@ -11,6 +14,24 @@ class AssetLiabilityAnnualRateEvidenceService {
     DateTime Function()? now,
   })  : _chatService = chatService,
         _now = now ?? DateTime.now;
+
+  Future<AssetLiabilityAnnualRateEvidence> verifyEvidenceBytes({
+    required String accountId,
+    required String accountName,
+    required double annualRate,
+    required Uint8List imageBytes,
+    required String mimeType,
+    required String fileName,
+  }) {
+    return verifyEvidence(
+      accountId: accountId,
+      accountName: accountName,
+      annualRate: annualRate,
+      imageBase64: base64Encode(imageBytes),
+      mimeType: mimeType,
+      fileName: fileName,
+    );
+  }
 
   Future<AssetLiabilityAnnualRateEvidence> verifyEvidence({
     required String accountId,
@@ -51,7 +72,7 @@ class AssetLiabilityAnnualRateEvidenceService {
         submittedAnnualRate: annualRate,
         detectedAnnualRate: null,
         status: AssetLiabilityAnnualRateEvidenceStatus.failed,
-        summary: 'AI could not verify the annual rate evidence.',
+        summary: 'AIが年利証跡を確認できませんでした。',
         source: 'ai-hub asset_liability.verify_annual_rate_evidence',
         errorMessage: error.toString(),
       );

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -166,9 +166,7 @@ class AssetManagementAiSummaryService {
     );
   }
 
-  Map<String, dynamic> buildAiSafePayload(
-    AssetManagementInsightReport report,
-  ) {
+  Map<String, dynamic> buildAiSafePayload(AssetManagementInsightReport report) {
     return <String, dynamic>{
       'available_money_bands': <String, dynamic>{
         'today': _availableToAiSafeJson(report.todayAvailable),
@@ -213,6 +211,9 @@ class AssetManagementAiSummaryService {
       },
       'guardrails': const <String, dynamic>{
         'calculation_owner': 'dart_service',
+        'response_language': 'ja-JP',
+        'must_respond_in_japanese': true,
+        'must_not_use_english_headings': true,
         'external_ai_may_summarize_only': true,
         'external_ai_may_recalculate_amounts': false,
         'external_ai_payload_redacts_exact_money_values': true,
@@ -312,7 +313,7 @@ class AssetManagementAiSummaryService {
       '使用可能額: 本日 $today、今週 $week、今月 $month。',
       emergency,
       movement,
-      '金額はDartルールで計算済みです。Amounts are calculated by Dart rules; AI summary is optional.',
+      '金額はDartルールで計算済みです。AIは要約のみを行います。',
     ].join(' ');
   }
 
@@ -323,10 +324,10 @@ class AssetManagementAiSummaryService {
     return [
       _promptBuilder.buildRedactedPrompt(report),
       '',
-      '## Redacted computed insight payload',
+      '## 計算済みインサイトの安全化ペイロード',
       jsonEncode(payload),
       '',
-      'Rules: summarize only from redacted categories. Do not recalculate amounts. Do not ask for exact balances. Do not provide legal, investment, or credit advice. Never recommend starvation, water-only survival, or skipping meals as a solution. Prioritize food, shelter, health, contacting creditors, and emergency public/community support. Keep the response concise and action-oriented.',
+      '出力ルール: 必ず自然な日本語だけで回答してください。Markdownの見出し、箇条書き、ラベルも日本語にしてください。英語の見出しや英語ラベルは使わないでください。安全化されたカテゴリだけを要約し、金額を再計算しないでください。正確な残高の追加開示を求めないでください。法的助言、投資助言、信用判断の断定はしないでください。飢える、水だけで耐える、食事を抜くといった健康を害する提案は絶対にしないでください。食費、住居、医療、支払先への連絡、公的・地域の緊急支援を優先してください。短く、今日実行できる行動に寄せてください。',
     ].join('\n');
   }
 
@@ -381,9 +382,7 @@ class AssetManagementAiSummaryService {
       'date_window_days':
           insight.endDate.difference(insight.startDate).inDays + 1,
       'cash_like_status': _amountPressureBand(insight.cashLikeTotal),
-      'unpaid_payment_status': _amountPressureBand(
-        insight.unpaidPaymentTotal,
-      ),
+      'unpaid_payment_status': _amountPressureBand(insight.unpaidPaymentTotal),
       'unreceived_income_status': _amountPressureBand(
         insight.unreceivedIncomeTotal,
       ),

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -881,44 +881,40 @@ class AssetManagementInsightPromptBuilder {
       report.developerRequests.map((item) => item.severity.name),
     );
     final buffer = StringBuffer()
-      ..writeln('Asset-management AI assistant.')
+      ..writeln('あなたは資産管理AIアシスタントです。')
       ..writeln(
-        'Money calculations are already completed by Dart. Use only the '
-        'redacted categories below; do not infer, recalculate, or ask for '
-        'exact balances.',
+        '重要: 金額計算はDart側で完了しています。下記の安全化された分類だけを使い、'
+        '推測・再計算・正確な残高の追加要求はしないでください。',
       )
+      ..writeln('出力は必ず日本語だけにしてください。見出し、ラベル、箇条書きも日本語にしてください。')
       ..writeln()
-      ..writeln('## Redacted availability bands')
-      ..writeln('- today: ${_availabilityBand(report.todayAvailable)}')
-      ..writeln('- week: ${_availabilityBand(report.weekAvailable)}')
-      ..writeln('- month: ${_availabilityBand(report.monthAvailable)}')
+      ..writeln('## 安全化された使用可能額の状態')
+      ..writeln('- 本日: ${_availabilityBand(report.todayAvailable)}')
+      ..writeln('- 今週: ${_availabilityBand(report.weekAvailable)}')
+      ..writeln('- 今月: ${_availabilityBand(report.monthAvailable)}')
       ..writeln()
-      ..writeln('## Action inventory')
-      ..writeln('- total_actions: ${report.actionItems.length}')
-      ..writeln('- by_severity: ${_formatCounts(severityCounts)}')
-      ..writeln('- by_type: ${_formatCounts(typeCounts)}')
+      ..writeln('## アクション件数')
+      ..writeln('- 合計: ${report.actionItems.length}')
+      ..writeln('- 重要度別: ${_formatCounts(severityCounts)}')
+      ..writeln('- 種別: ${_formatCounts(typeCounts)}')
       ..writeln()
-      ..writeln('## Movement and emergency inventory')
-      ..writeln(
-        '- movement_suggestion_count: ${report.movementSuggestions.length}',
-      )
-      ..writeln('- emergency_advice_count: ${report.emergencyAdvices.length}')
-      ..writeln('- emergency_by_severity: ${_formatCounts(emergencyCounts)}')
+      ..writeln('## 口座移動と緊急アドバイス')
+      ..writeln('- 口座移動・出金提案件数: ${report.movementSuggestions.length}')
+      ..writeln('- 緊急生活防衛アドバイス件数: ${report.emergencyAdvices.length}')
+      ..writeln('- 緊急アドバイス重要度別: ${_formatCounts(emergencyCounts)}')
       ..writeln()
-      ..writeln('## Developer request inventory')
-      ..writeln(
-        '- developer_request_count: ${report.developerRequests.length}',
-      )
-      ..writeln('- developer_by_severity: ${_formatCounts(developerCounts)}');
+      ..writeln('## 開発者向け改善提案件数')
+      ..writeln('- 合計: ${report.developerRequests.length}')
+      ..writeln('- 重要度別: ${_formatCounts(developerCounts)}');
     return buffer.toString();
   }
 
   String _availabilityBand(AssetManagementAvailableMoneyInsight insight) {
     final amount = insight.availableAmount;
-    if (amount < 0) return 'shortage';
-    if (amount < insight.minimumSafetyBalance) return 'below_safety_balance';
-    if (amount < insight.minimumSafetyBalance * 2) return 'near_safety_buffer';
-    return 'buffer_available';
+    if (amount < 0) return '不足';
+    if (amount < insight.minimumSafetyBalance) return '安全残高未満';
+    if (amount < insight.minimumSafetyBalance * 2) return '安全余力が薄い';
+    return '余力あり';
   }
 
   Map<String, int> _countBy(Iterable<String> values) {

--- a/test/services/asset_liability_annual_rate_evidence_service_test.dart
+++ b/test/services/asset_liability_annual_rate_evidence_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/services/ai_hub_chat_service.dart';
@@ -34,6 +36,44 @@ void main() {
       expect(evidence.fileName, 'mobit_apr.png');
     });
 
+    test('accepts pasted screenshot bytes for annual rate evidence', () async {
+      Map<String, dynamic>? capturedBody;
+      final service = AssetLiabilityAnnualRateEvidenceService(
+        now: () => DateTime(2026, 5, 17, 12),
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            capturedBody = Map<String, dynamic>.from(body);
+            return <String, dynamic>{
+              'success': true,
+              'verified': true,
+              'status': 'verified',
+              'detected_annual_rate': 0.145,
+              'summary': '画面キャプチャに年利14.5%の記載があります。',
+            };
+          },
+        ),
+      );
+
+      final evidence = await service.verifyEvidenceBytes(
+        accountId: 'smbc_card_loan',
+        accountName: '三井住友銀行カードローン',
+        annualRate: 0.145,
+        imageBytes: Uint8List.fromList(<int>[1, 2, 3]),
+        mimeType: 'image/png',
+        fileName: 'clipboard-annual-rate.png',
+      );
+
+      expect(evidence.status, AssetLiabilityAnnualRateEvidenceStatus.verified);
+      expect(evidence.fileName, 'clipboard-annual-rate.png');
+      expect(
+        capturedBody?['action'],
+        'asset_liability.verify_annual_rate_evidence',
+      );
+      expect(capturedBody?['imageBase64'], 'AQID');
+      expect(capturedBody?['mimeType'], 'image/png');
+      expect(capturedBody?['imageName'], 'clipboard-annual-rate.png');
+    });
+
     test('keeps failed evidence without approving annual rate', () async {
       final service = AssetLiabilityAnnualRateEvidenceService(
         now: () => DateTime(2026, 5, 17, 12),
@@ -54,6 +94,7 @@ void main() {
       expect(evidence.status, AssetLiabilityAnnualRateEvidenceStatus.failed);
       expect(evidence.verified, isFalse);
       expect(evidence.matchesAnnualRate(0.18), isFalse);
+      expect(evidence.summary, 'AIが年利証跡を確認できませんでした。');
       expect(evidence.errorMessage, contains('vision down'));
     });
   });

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -28,10 +28,7 @@ void main() {
       expect(result.status, AssetManagementAiSummaryStatus.disabled);
       expect(result.usedExternalAi, false);
       expect(result.source.contains('feature flag off'), true);
-      expect(
-        result.text.contains('Dart rules'),
-        true,
-      );
+      expect(result.text.contains('Dartルール'), true);
     });
 
     test('calls ai-hub auto chat when feature flag is on', () async {
@@ -60,14 +57,26 @@ void main() {
       expect(capturedBody?['tier'], 'performance');
       expect(capturedBody?['trace_id'], 'asset-management-ai-summary');
       expect(
-        capturedBody?['message'].toString().contains(
-              'Redacted computed insight payload',
-            ),
+        capturedBody?['message'].toString().contains('計算済みインサイトの安全化ペイロード'),
+        true,
+      );
+      expect(
+        capturedBody?['message'].toString().contains('必ず自然な日本語だけで回答してください'),
+        true,
+      );
+      expect(
+        capturedBody?['message'].toString().contains('英語の見出しや英語ラベルは使わないでください'),
         true,
       );
       expect(
         capturedBody?['message'].toString().contains(
               '"external_ai_may_recalculate_amounts":false',
+            ),
+        true,
+      );
+      expect(
+        capturedBody?['message'].toString().contains(
+              '"must_respond_in_japanese":true',
             ),
         true,
       );
@@ -77,94 +86,100 @@ void main() {
       expect(capturedBody?['routing_use_case'], 'summary');
     });
 
-    test('routes through configured provider chain when routing is enabled',
-        () async {
-      final calls = <Map<String, dynamic>>[];
-      final service = AssetManagementAiSummaryService(
-        aiEnabled: true,
-        providerRouter: const AssetManagementAiProviderRouter(
-          routingEnabled: true,
-        ),
-        chatService: AiHubChatService(
-          invoker: (body) async {
-            calls.add(Map<String, dynamic>.from(body));
-            return <String, dynamic>{
-              'success': true,
-              'text': 'Claude routed summary',
-              'observability': <String, dynamic>{
+    test(
+      'routes through configured provider chain when routing is enabled',
+      () async {
+        final calls = <Map<String, dynamic>>[];
+        final service = AssetManagementAiSummaryService(
+          aiEnabled: true,
+          providerRouter: const AssetManagementAiProviderRouter(
+            routingEnabled: true,
+          ),
+          chatService: AiHubChatService(
+            invoker: (body) async {
+              calls.add(Map<String, dynamic>.from(body));
+              return <String, dynamic>{
+                'success': true,
+                'text': 'Claude routed summary',
+                'observability': <String, dynamic>{
+                  'provider': body['provider'],
+                  'model': body['model'],
+                },
+              };
+            },
+          ),
+          now: () => DateTime(2026, 5, 1, 12),
+        );
+
+        final result = await service.generateSummary(report: _report());
+
+        expect(result.status, AssetManagementAiSummaryStatus.aiGenerated);
+        expect(result.text, 'Claude routed summary');
+        expect(calls, hasLength(1));
+        expect(calls.single['action'], 'provider.chat');
+        expect(calls.single['provider'], 'anthropic');
+        expect(calls.single['model'], 'claude-opus-4-7');
+        expect(calls.single['routing_use_case'], 'summary');
+        expect(
+          calls.single['provider_choice_reason'],
+          contains('claude-opus-4-7@anthropic'),
+        );
+        expect(result.providerRoute?['routing_enabled'], true);
+      },
+    );
+
+    test(
+      'provider routing falls back across providers before local summary',
+      () async {
+        final providers = <String>[];
+        final service = AssetManagementAiSummaryService(
+          aiEnabled: true,
+          providerRouter: const AssetManagementAiProviderRouter(
+            routingEnabled: true,
+          ),
+          chatService: AiHubChatService(
+            invoker: (body) async {
+              providers.add(body['provider'] as String);
+              if (body['provider'] == 'anthropic') {
+                throw const AiHubChatException('temporary outage');
+              }
+              return <String, dynamic>{
+                'success': true,
+                'text': 'GPT fallback summary',
                 'provider': body['provider'],
-                'model': body['model'],
-              },
-            };
-          },
-        ),
-        now: () => DateTime(2026, 5, 1, 12),
-      );
+              };
+            },
+          ),
+          now: () => DateTime(2026, 5, 1, 12),
+        );
 
-      final result = await service.generateSummary(report: _report());
+        final result = await service.generateSummary(report: _report());
 
-      expect(result.status, AssetManagementAiSummaryStatus.aiGenerated);
-      expect(result.text, 'Claude routed summary');
-      expect(calls, hasLength(1));
-      expect(calls.single['action'], 'provider.chat');
-      expect(calls.single['provider'], 'anthropic');
-      expect(calls.single['model'], 'claude-opus-4-7');
-      expect(calls.single['routing_use_case'], 'summary');
-      expect(
-        calls.single['provider_choice_reason'],
-        contains('claude-opus-4-7@anthropic'),
-      );
-      expect(result.providerRoute?['routing_enabled'], true);
-    });
+        expect(result.status, AssetManagementAiSummaryStatus.aiGenerated);
+        expect(result.text, 'GPT fallback summary');
+        expect(providers, <String>['anthropic', 'openai']);
+      },
+    );
 
-    test('provider routing falls back across providers before local summary',
-        () async {
-      final providers = <String>[];
-      final service = AssetManagementAiSummaryService(
-        aiEnabled: true,
-        providerRouter: const AssetManagementAiProviderRouter(
-          routingEnabled: true,
-        ),
-        chatService: AiHubChatService(
-          invoker: (body) async {
-            providers.add(body['provider'] as String);
-            if (body['provider'] == 'anthropic') {
-              throw const AiHubChatException('temporary outage');
-            }
-            return <String, dynamic>{
-              'success': true,
-              'text': 'GPT fallback summary',
-              'provider': body['provider'],
-            };
-          },
-        ),
-        now: () => DateTime(2026, 5, 1, 12),
-      );
+    test(
+      'ai-safe payload keeps exact money values out of external AI context',
+      () {
+        final service = AssetManagementAiSummaryService(
+          now: () => DateTime(2026, 5, 1, 12),
+        );
 
-      final result = await service.generateSummary(report: _report());
+        final payload = service.buildAiSafePayload(_report());
+        final encoded = payload.toString();
 
-      expect(result.status, AssetManagementAiSummaryStatus.aiGenerated);
-      expect(result.text, 'GPT fallback summary');
-      expect(providers, <String>['anthropic', 'openai']);
-    });
-
-    test('ai-safe payload keeps exact money values out of external AI context',
-        () {
-      final service = AssetManagementAiSummaryService(
-        now: () => DateTime(2026, 5, 1, 12),
-      );
-
-      final payload = service.buildAiSafePayload(_report());
-      final encoded = payload.toString();
-
-      expect(encoded.contains('50000'), false);
-      expect(encoded.contains('20000'), false);
-      expect(encoded.contains('available_money_bands'), true);
-      expect(
-        encoded.contains('external_ai_payload_redacts_exact_money_values'),
-        true,
-      );
-    });
+        expect(encoded.contains('50000'), false);
+        expect(encoded.contains('20000'), false);
+        expect(encoded.contains('available_money_bands'), true);
+        expect(
+          encoded.contains('external_ai_payload_redacts_exact_money_values'),
+          true,
+        );
+      },
+    );
 
     test('falls back to deterministic text when ai-hub fails', () async {
       final service = AssetManagementAiSummaryService(
@@ -180,10 +195,7 @@ void main() {
       expect(result.status, AssetManagementAiSummaryStatus.fallback);
       expect(result.usedExternalAi, false);
       expect(result.errorMessage?.contains('boom'), true);
-      expect(
-        result.text.contains('Dart rules'),
-        true,
-      );
+      expect(result.text.contains('Dartルール'), true);
     });
 
     test('builds payload from calculated insights only', () {
@@ -222,10 +234,7 @@ void main() {
         expect(result.status, AssetManagementAiSummaryStatus.fallback);
         expect(result.usedExternalAi, false);
         expect(result.source, 'deterministic fallback / waiting for ai-hub');
-        expect(
-          result.text.contains('Dart rules'),
-          true,
-        );
+        expect(result.text.contains('Dartルール'), true);
       },
     );
 
@@ -240,7 +249,7 @@ void main() {
 
       expect(text.contains('今日の食費'), true);
       expect(text.contains('支払い'), true);
-      expect(text.contains('Dart rules'), true);
+      expect(text.contains('Dartルール'), true);
       expect(payload['emergency_advices'] is List<dynamic>, true);
       expect((payload['emergency_advices'] as List<dynamic>).isNotEmpty, true);
     });


### PR DESCRIPTION
﻿## 概要

AI資産管理アシスタントの外部AI要約が英語で返る問題を修正し、年利証跡の提出に画面キャプチャ画像のクリップボード貼り付けを追加しました。

## 主な変更

- 外部AI要約プロンプトを日本語優先から「日本語のみ」に強化
- redacted promptの見出し・ラベルを日本語化
- AI安全化payloadに日本語応答ガードレールを追加
- deterministic fallback末尾の英語文を日本語へ変更
- 年利証跡提出でファイル選択に加えて「貼付」ボタンを追加
  - 貼付待ちにした行へ、画面キャプチャをコピー後 Ctrl+V で提出可能
- 年利証跡検証サービスに画像バイト列から検証する共通メソッドを追加
- 貼り付け画像がAI年利証跡検証へ送られることをテスト追加

## Minimal E2E Declaration

- E2E plan is implementation-detail independent / black-box: ユーザー入力と画面上の出力だけで確認します。
- Minimal 3 cases:
  1. AI資産管理アシスタントでAI summaryを実行し、日本語の見出し・本文だけが表示されること
  2. 負債マスタの年利欄で「貼付」を押し、画面キャプチャをCtrl+Vして証跡検証に進めること
  3. 年利未入力のまま証跡提出/貼付を試すと、提出前に日本語エラーで止まること
- E2E mechanism: PlaywrightまたはFlutter integration_testで資産管理ページを開き、上記のinput/outputを検証できます。
- E2E-Exception: 今回はprompt本文とクリップボード画像バイト列のサービス経路を対象にした小修正で、既存のUIテスト基盤にはクリップボード画像注入fixtureがないため、新規 integration_test/test/e2e ファイルは追加せず、関連service testsと全体flutter testで回帰を確認しました。

## High-risk Ultrareview

- Review owner: Claude Code #1
- Claude ultrareview evidence:
  - security: 外部AIへ渡すpayloadは既存方針どおり正確な金額や口座IDを安全化し、金額計算はDart側で完了します。
  - rollback: 変更はprompt/UI/service helperのみでDB migrationなし。問題時はこのPRのrevertで日本語強制と貼付ボタン追加を戻せます。
  - data migration: Supabase schema / migration / RLS / production write は変更なし。既存保存データの移行はありません。
  - prod smoke: 資産管理ページでAI summary表示と年利証跡ボタン表示を確認する想定です。CIのPublic E2E stability smokeもpass対象です。
  - observability: ai-hubの既存trace_id `asset-management-ai-summary` と `asset-liability-annual-rate-evidence` を維持し、source表示も既存UIで確認できます。
- unresolved findings: 0

## 安全確認

- 金額計算は引き続きDart側で完了し、外部AIは要約のみ
- 「飢える」「水だけで耐える」「食事を抜く」など健康を害する提案は禁止するpromptを維持
- 年利変更は証跡提出とAI確認を必要とする既存フローを維持
- クリップボード貼り付けはユーザーが貼付待ちにした行だけを対象にし、任意の貼り付けを常時横取りしない

## 検証

- `dart format --output=none --set-exit-if-changed ...`: OK
- `dart analyze`: No issues found
- 関連 `flutter test --no-pub ...`: 12 tests passed
- 全体 `flutter test --no-pub --reporter expanded`: 508 tests passed
- `git diff --check`: OK

## 補足

ローカル検証用に `flutter pub get` を実行したため一時的にlockfileとplatform generated filesが触られましたが、機能差分外として戻し済みです。
