### PR TITLE
fix: sync inject rules guard count (#2568)

### DIFF
--- a/.claude/inject-rules.txt
+++ b/.claude/inject-rules.txt
@@ -70,4 +70,4 @@ RULES (毎ターン inject / pointer hub / 詳細展開 = docs/RULES_INDEX.md):
 
 [FLEET-OPS] 5 正本 (Issues/PR / WBS+Notion / NotebookLM / Slack / worktree+branch). 作業開始時: 担当重複 / file・schema・EF・workflow 競合 / 5 正本不一致 / 通知形骸化 / 他 AI 活用余地を確認.
 
-> 詳細展開 (= 全 38 rule の full body / 違反例 / 関連 docs link): docs/RULES_INDEX.md (= part 134 で新規)
+> 詳細展開 (= 全 39 rule の full body / 違反例 / 関連 docs link): docs/RULES_INDEX.md (= part 134 で新規)

--- a/.github/workflows/inject-rules-drift-cron.yml
+++ b/.github/workflows/inject-rules-drift-cron.yml
@@ -3,7 +3,7 @@ name: Inject Rules Drift Detection
 # Win版#132 part 135 (2026-05-05) — fleet 横断 inject-rules.txt 同期 mechanism
 # .claude/inject-rules.txt (= repo canonical) の integrity を weekly check.
 # - 行数 ≤ 80 (Karpathy KPI 維持)
-# - rule ID 数 = 37 (= 既知の 37 rule 揃ってるか)
+# - rule ID 数 = 39 (= 既知の 39 rule 揃ってるか)
 # - 各 critical rule 存在
 # - docs/RULES_INDEX.md との整合 (= 全 rule ID が docs に expand されてるか)
 #
@@ -51,6 +51,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Run sync_inject_rules unit test
+        run: python test/scripts/test_sync_inject_rules.py
+
       - name: Run sync_inject_rules --verify (canonical only)
         id: verify
         run: |
@@ -67,12 +70,12 @@ jobs:
           echo "rules=$RULES"       >> $GITHUB_OUTPUT
           echo "missing=$MISSING"   >> $GITHUB_OUTPUT
 
-      - name: Verify docs/RULES_INDEX.md mentions all 37 rules
+      - name: Verify docs/RULES_INDEX.md mentions all 39 rules
         id: docs_match
         run: |
           DOCS_RULE_COUNT=$(grep -cE "^### \`\[" docs/RULES_INDEX.md || echo 0)
           DOCS_TABLE_COUNT=$(grep -cE "^\| \`\[" docs/RULES_INDEX.md || echo 0)
-          # Section A (= ### form) + Section B (= table form) + Section C (= ### form) で 37 entry あるはず
+          # Section A (= ### form) + Section B (= table form) + Section C (= ### form) で 39 entry あるはず
           TOTAL=$((DOCS_RULE_COUNT + DOCS_TABLE_COUNT))
           echo "docs_rule_section=$DOCS_RULE_COUNT" >> $GITHUB_OUTPUT
           echo "docs_rule_table=$DOCS_TABLE_COUNT" >> $GITHUB_OUTPUT
@@ -102,7 +105,7 @@ jobs:
             echo ""
             echo "### KPI 詳細"
             echo "- 行数: ${{ steps.verify.outputs.lines }} (= 80 行上限)"
-            echo "- rule ID 数: ${{ steps.verify.outputs.rules }} (= 37 期待)"
+            echo "- rule ID 数: ${{ steps.verify.outputs.rules }} (= 39 期待)"
             echo "- 不足 critical rule: ${{ steps.verify.outputs.missing }}"
             echo ""
             echo "### 修復手順"

--- a/docs/INJECT_RULES_AUTO_SYNC.md
+++ b/docs/INJECT_RULES_AUTO_SYNC.md
@@ -4,7 +4,7 @@
 
 ## 全体像
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │ canonical: .claude/inject-rules.txt (= repo / git tracked)      │
 └──────────────┬──────────────────────────────────────────────────┘
@@ -54,6 +54,7 @@
 **仕組み**: Windows Task Scheduler が daily 03:30 JST (= GHA cron 30 分後) に local 実行.
 
 **Task 内容**:
+
 ```powershell
 cd <repo>
 git pull origin main
@@ -61,16 +62,19 @@ python scripts/sync_inject_rules.py --apply
 ```
 
 **Setup** (= 1 度だけ実行):
+
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File scripts/setup_inject_rules_auto_sync.ps1 -Install
 ```
 
 **確認**:
+
 ```powershell
 powershell -File scripts/setup_inject_rules_auto_sync.ps1 -Status
 ```
 
 **Uninstall**:
+
 ```powershell
 powershell -File scripts/setup_inject_rules_auto_sync.ps1 -Uninstall
 ```
@@ -88,7 +92,7 @@ powershell -File scripts/setup_inject_rules_auto_sync.ps1 -Uninstall
 
 **動作**:
 1. `scripts/sync_inject_rules.py --verify --json` で integrity check
-2. KPI 違反 (= 行数 > 80 / rule 数 ≠ 37 / critical rule 欠落) → Issue 自動作成 (`automation, priority:high`)
+2. KPI 違反 (= 行数 > 80 / rule 数 ≠ 39 / critical rule 欠落) → Issue 自動作成 (`automation, priority:high`)
 3. 直近 commit で canonical 更新検出 → tracking Issue [#1647](https://github.com/kanta13jp1/my_web_app/issues/1647) コメント
 4. コメント内容: 各 instance の手元 sync 推奨 (= `git pull && --apply`)
 
@@ -100,20 +104,24 @@ powershell -File scripts/setup_inject_rules_auto_sync.ps1 -Uninstall
 ## 設計 trade-off (= 採用判断の理由)
 
 ### 1. SessionStart vs PostToolUse vs UserPromptSubmit
+
 - **SessionStart 採用**: 1 セッション 1 回 / overhead 最小 / 確実に session 開始時 sync
 - PostToolUse: 過剰発火 (= 全 tool 後に走る)
 - UserPromptSubmit: 同様 / session 中 drift 発生は稀
 
 ### 2. Daily 03:30 JST トリガー
+
 - GHA cron (= 03:00 JST) の **30 分後**: GHA が canonical 更新を push しても local pull ↔ apply の余裕
 - 深夜帯 (= [SCHEDULE-WAKEUP] rule 02:00-06:00 と若干重複) → 03:30 が user 影響最小
 
 ### 3. silent failure 方針
+
 - Python 不在 / repo 未 pull / network 障害 → **session を block しない**
 - log 記録だけ残し次回再試行
 - block すると Claude Code 起動不能リスク
 
 ### 4. Tier 3 が Issue 起票でなく comment の理由
+
 - 全 user に通知すべき = noisy / 既存 Issue (= part 117 #1647 Codex Memory + Thread Automations) は rule infra tracking として既存
 - 新 Issue = noise 発生 / dedup 困難
 
@@ -146,7 +154,7 @@ Start-ScheduledTask -TaskName "JibunKK-InjectRulesAutoSync"
 
 ## 関連
 
-- [`docs/RULES_INDEX.md`](RULES_INDEX.md) — 全 37 rule full body (= part 134)
+- [`docs/RULES_INDEX.md`](RULES_INDEX.md) — 全 39 rule full body (= part 134)
 - [`docs/MULTI_INSTANCE_FLEET.md`](MULTI_INSTANCE_FLEET.md) — 2 instance fleet (= part 130)
 - [`scripts/sync_inject_rules.py`](../scripts/sync_inject_rules.py) — sync engine (= part 135)
 - [`scripts/setup_inject_rules_auto_sync.ps1`](../scripts/setup_inject_rules_auto_sync.ps1) — Tier 2 installer (= 本 part)

--- a/docs/RULES_INDEX.md
+++ b/docs/RULES_INDEX.md
@@ -1,4 +1,4 @@
-# inject-rules.txt 詳細 expand (= 37 rule full body)
+# inject-rules.txt 詳細 expand (= 39 rule full body)
 
 > **Win版#132 part 134 (2026-05-05)**: 旧 `~/.claude/hooks/inject-rules.txt` (= 344 行) の詳細を本ファイルに移行 (= Karpathy 80 行 KPI 達成 / inject-rules.txt は ≤ 80 行 pointer hub 化).
 > 詳細 body は本ファイル参照. 違反例 / 受領者 instance / 関連 docs link も保存.
@@ -72,6 +72,14 @@ git stash は同一 workdir の全 process に影響:
   → 1 つでも YES = Win Claude / 全部 NO = Win Codex
 - SLA: Issue 起票 → 24h 以内 Win Claude triage → severity ≤ normal は Win Codex / 重い設計判断は Win Claude
 
+### `[AI-TOOL-VERIFY]`
+
+AI tool / model / agent capability claims are verify-first. Check official sources via `scripts/check_versions.py --web` before adopting fleet-wide behavior, model routing, or automation changes. The top-level operating model remains Claude Code #1 for policy/review and Codex #1 for scoped PR/CI/cleanup.
+
+### `[SUBAGENT-GUARD]`
+
+Guarded child subagents are allowed only under Claude Code #1 or Codex #1 as short-lived workers. Record lead owner, role, scope, validation, risk, and cleanup evidence in PR/Issue/wrap-up. Old Codex #2/#3, PS, WEB, and mobile lanes stay dormant.
+
 ### `[CONCURRENCY]`
 
 (Win#109 修正) deploy-prod / dev / staging は `cancel-in-progress: false` 変更済. 並行 push でも全 commit が順次 deploy. 後発 push は最大 11min × 並行数 待機.
@@ -104,7 +112,7 @@ git stash は同一 workdir の全 process に影響:
 
 ---
 
-## C. Behavioral 1-line (= 15 rule)
+## C. Behavioral 1-line (= 14 rule)
 
 ### `[ROADMAP-LOG]`
 

--- a/scripts/sync_inject_rules.py
+++ b/scripts/sync_inject_rules.py
@@ -50,6 +50,7 @@ CRITICAL_RULES = [
     "[WBS-SYNC]",
     "[INSTANCE-ROLES]",
     "[AI-TOOL-VERIFY]",
+    "[SUBAGENT-GUARD]",
     "[CONCURRENCY]",
     "[AUTO-REPLY]",
     "[PHILOSOPHY-22]",
@@ -81,7 +82,7 @@ CRITICAL_RULES = [
     "[FLEET-OPS]",
 ]
 
-EXPECTED_RULE_COUNT = 38
+EXPECTED_RULE_COUNT = 39
 
 
 def read_text(path: Path) -> str | None:
@@ -143,6 +144,8 @@ def verify(text: str) -> dict:
     return {
         "lines": lines,
         "rule_count": rule_count,
+        "expected_rule_count": EXPECTED_RULE_COUNT,
+        "line_kpi": LINE_KPI,
         "missing_critical_rules": missing,
         "kpi_pass": len(issues) == 0,
         "issues": issues,

--- a/test/scripts/test_sync_inject_rules.py
+++ b/test/scripts/test_sync_inject_rules.py
@@ -1,0 +1,38 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts import sync_inject_rules
+
+
+class SyncInjectRulesTest(unittest.TestCase):
+    def test_canonical_rule_count_matches_expected_constant(self) -> None:
+        text = sync_inject_rules.read_text(sync_inject_rules.CANONICAL)
+        self.assertIsNotNone(text)
+
+        result = sync_inject_rules.verify(text or "")
+
+        self.assertEqual(result["rule_count"], sync_inject_rules.EXPECTED_RULE_COUNT)
+        self.assertEqual(result["expected_rule_count"], sync_inject_rules.EXPECTED_RULE_COUNT)
+        self.assertEqual(result["missing_critical_rules"], [])
+        self.assertTrue(result["kpi_pass"], result["issues"])
+
+    def test_rules_index_mentions_every_canonical_rule(self) -> None:
+        canonical = sync_inject_rules.read_text(sync_inject_rules.CANONICAL) or ""
+        docs = (sync_inject_rules.REPO_ROOT / "docs" / "RULES_INDEX.md").read_text(
+            encoding="utf-8",
+        )
+
+        missing = [
+            rule_id
+            for rule_id in sync_inject_rules.list_rule_ids(canonical)
+            if rule_id not in docs
+        ]
+
+        self.assertEqual(missing, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #2568 by bringing the inject-rules integrity guard back in sync with the repo canonical rule set.

Root cause: `[SUBAGENT-GUARD]` was added to `.claude/inject-rules.txt`, but `scripts/sync_inject_rules.py` still expected 38 rules and did not list the new guard in `CRITICAL_RULES`. `docs/RULES_INDEX.md` and the drift workflow text also still described the old 37/38-rule state.

## Changes

- Bump `EXPECTED_RULE_COUNT` to 39 and add `[SUBAGENT-GUARD]` to critical rule verification.
- Add the missing `[AI-TOOL-VERIFY]` and `[SUBAGENT-GUARD]` entries to `docs/RULES_INDEX.md`.
- Update drift cron / auto-sync docs to describe the current 39-rule invariant.
- Add `test/scripts/test_sync_inject_rules.py` so canonical count and RULES_INDEX coverage drift are caught before the weekly issue opens again.

## Minimal E2E Gate

This PR has no app-code path changes. The E2E contract remains implementation-detail independent and minimal, about three I/O cases: verify canonical rule integrity input/output, verify RULES_INDEX coverage input/output, and rely on the existing Playwright public E2E stability smoke for deployed app behavior. No `integration_test/` file is added because this is a script/docs/workflow integrity fix, not a user-facing app flow.

## High-Risk Review Gate

- Claude Code #1 review owner: Claude Code #1 owns policy/high-risk review if this docs/workflow guard needs human review before merge.
- High-risk-ultrareview-exception: deterministic inject-rules integrity counter/docs/workflow-only update; no secrets, credentials, token handling changes, data migration, auth path changes, or production writes.
- Security: no runtime secret access or permission expansion; the script remains local/stdlib verification only.
- Rollback: revert this PR to return to the prior 38-rule guard state, though that would re-open the known false-positive drift issue.
- Data migration: none.
- Prod smoke: existing Public E2E stability smoke and Deploy to Production after merge cover production smoke; this PR changes no app runtime surface.
- Observability: weekly inject-rules-drift-cron plus the new unit test cover future drift observability.
- Unresolved findings: none.

## Validation

- `python scripts\sync_inject_rules.py --verify --json`
- `python test\scripts\test_sync_inject_rules.py`
- `python -m py_compile scripts\sync_inject_rules.py`
- `npx --yes markdownlint-cli@0.45.0 --dot docs\RULES_INDEX.md docs\INJECT_RULES_AUTO_SYNC.md`
- `git diff --check HEAD~1..HEAD`

## Operations

- Lead owner: Codex #1
- Guarded subagent orchestration: none used
- Risk: scoped to inject-rules integrity docs/script/workflow; no production writes or secrets
- Cleanup evidence: no child workers; branch/worktree cleanup will run after merge