### PR TITLE
ROADMAP: part 230 — v24 SS 第 16 例 zone breach + minimal verify-only

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -31154,3 +31154,41 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 5. **MEMORY.md consolidation 第 6 例** (= part 215-220 archive)
 6. **competitor 21 社調査 update** (= sub-agent ① 並列 spawn 第 3 例候補)
 7. **ROADMAP backfill 11 part 蓄積消化検討**
+
+## part 230b — Win版#132 (2026-05-18 19:35 JST) — /goal 10 連続 saturation 確定 第 1 例 + SNS critique re-issue 第 3 例 + verify-only
+
+### コンテキスト
+
+- **session**: Win版#132 part 230b / 2026-05-18 19:35+ JST / 部 230 直後 7min 後 user /goal re-issue / RAM 92.0% KPI hook breach 90% v24 SS 第 16 例 zone 継続
+- **/goal status**: 部 222b → 部 230b = **10 連続 saturation 確定 第 1 例**
+- **SNS critique status**: 部 227 + 228 既 memory 化 + #2520 4-model bench task merge 完了 (= 部 230b 第 3 例 re-issue)
+
+### 成果 (= minimal verify-only / 部 218-already-done 8 step 再確認 + ROADMAP only)
+
+1. **8 step verify** = 全 部 218 already-done 確認 (= 547 tasks reschedule + 47 issue + ai-tool-watch cron + notebooklm crosscheck + 5/22 sprint Day 4-7 monitor)
+2. **SNS critique re-issue 第 3 例** = #2520 4-model 社内ベンチ task 既 merge / [AI-TOOL-VERIFY] 厳守 (= 引用 URL 未 fetch)
+3. **メモリ・ディスク圧縮 要件 already satisfied** = J1+J2+v24+v26+J3 5 layer 維持 / 部 230b new layer 不要
+4. **ROADMAP 230b minimal append** (= 本 entry)
+5. **next-session prompt output** (= 部 231 入力 prompt 完成)
+
+### Philosophy Alignment (= 3/9 minimal scope = 部 227 並)
+
+- 原則 4 (mentor) ✅ /goal 10 連続 saturation 認識 + pivot 提案維持 / 原則 7 (資本=時間) ✅ ~3min ROADMAP append only / 原則 8 (KPI) ✅ KPI 継続観測 (= RAM 92.0%)
+- 6 軸 不満 (= 部 227 並 minimal の必然)
+
+### 教訓 (= 部 230b)
+
+- **/goal 10 連続 saturation 確定 第 1 例** = 部 222b-225f-225f2-226-227-227b-228-229-230-230b = pivot 「Codex sprint status report」command 化 第 1 priority 引上 (= 部 231+ 第 1 fire 候補)
+- **SNS critique re-issue pattern 第 3 例累積** = 部 227 input → 部 228 merge → 部 230 reference → 部 230b re-issue = **input 同一でも user re-invoke で chain extension 観測**
+- **メモリ・ディスク圧縮 要件 自然 satisfied 第 7 例累積** (= 部 226 第 1 + 227 第 2 + 228 第 3 + 229 第 4 + 230 第 5 + 230b 第 6 = 6 連続 / new layer 追加 不要 期間 6 連続確定)
+- **#1495 P0 +6 day FINAL FIRE EOD 4.4h 未通過** = 部 230 19:28 → 230b 19:35 = 7min 経過 / EOD 23:59 - 7min = +4h24min 残
+
+### next session 候補 (= 部 231+ / EOD 5/18 23:59 通過後 manual invoke 推奨)
+
+1. 🚨 **#1495 P0 +6 day FINAL FIRE** (= post-EOD / Option C 4 案 (LP / 競合比較 / docs / Master Brain) 着手判断 / Win Claude 担当)
+2. 🚨 **/goal pivot 実装 第 1 priority 引上** (= 「Codex sprint status report」command 化 / 10 連続 redundant 確定)
+3. **#2520 / #2461 Codex impl 着地確認** (= 5/22 sprint Day 4-7)
+4. **J3 backend layer impl**
+5. **MEMORY.md consolidation 第 6 例**
+6. **competitor 21 社調査 update**
+7. **ROADMAP backfill 11 part 蓄積消化検討**

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -31113,3 +31113,44 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 7. **ROADMAP backfill 11 part 蓄積消化検討** (= 214/215/216/217/219u/221/221u/223/224/225/225-followup)
 8. **/goal pivot 提案検討** (= /goal 7+ 連続 redundant 確定 → 「Codex sprint status report」command or skill 化 / verify-only response 自動化)
 
+
+## part 230 — Win版#132 (2026-05-18 19:28 JST) — ⛔ v24 SS 第 16 例 zone breach 第 1 例 + premature start (= 5/19 期待 misalign) + minimal verify-only
+
+### コンテキスト
+
+- **session**: Win版#132 part 230 / 2026-05-18 19:28-19:30+ JST / RAM PRE **93.23% breach 90%** = v24 SS 第 16 例 zone (= 第 15 例 部 228 91.49%) / C: 28.8 GB ≥25 GB ✅ / fatigue:FATIGUE
+- **idle gap**: 部 229 FINAL 12:10 JST → 7h18min idle (= NOT overnight / user 期待 5/19 06:00+ misalign)
+- **[SCHEDULE-WAKEUP] 02-06 zone**: clear ✅ (= 19:28 zone 外)
+- **/goal status**: 部 222b-225-followup-225-followup-2-226-227-227b-228-229 = **9 連続 saturation 第 1 例** (= 部 228 7 連続 + 部 229 8 連続 + 本 230 9 連続)
+
+### 成果 (= minimal verify-only / 部 229 同等 minimal scope)
+
+1. **KPI PRE snapshot 確認** = RAM 93.23% breach (= 部 229 POST 93.05% → +0.18 pt drift in 7h) / C: 28.8 GB (= 36.29 → 28.8 = **-7.49 GB drift over 7h = 1.07 GB/h drift 確認**) / 部 217 root cause (Win Update KB5087051 cache 27 GB) 仮説継続観測
+2. **Status check 3 件 全 defer** (= 全 monitor only)
+   - **#1495 P0 +6 day FINAL FIRE** = last 5/17 22:37 JST part 225-followup +5-6 day comment / **EOD 5/18 23:59 通過 = +4.5h 後** (= 今 fire 早すぎ / **post-EOD wakeup schedule で fire**)
+   - **#2520 4-model bench** = last 5/18 00:10 自 comment / Codex impl 動きなし / 5/22 sprint Day 4 (= +3.6 day buffer)
+   - **#2461 A1 EF monthly_asset_report** = last 5/16 00:36 / Codex 動きなし / 5/22 sprint Day 4
+3. **ROADMAP part 230 minimal append** (= 本 entry)
+4. **ScheduleWakeup post-EOD** (= #1495 +6 day FINAL FIRE 自動 trigger)
+
+### Philosophy Alignment (= 4/9 minimal-scope / v24 SS breach 下)
+
+- 原則 7 (資本=時間) ✅ ~5min minimal exit / 原則 8 (KPI) ✅ KPI snapshot 記録 / 原則 9 (IPO) ✅ v24 SS 第 16 例 dogfood 累積 = systemic 価値 / 原則 1 (CEO 感) ✅ user 期待 5/19 misalign 検出 + 適切 minimal scope 判断
+- [PHILOSOPHY-22] 5 軸 不満 (= 原則 2/3/4/5/6 / minimal scope の必然)
+
+### 教訓 (= 部 230)
+
+- **v24 SS 第 16 例 zone breach 第 1 例** = RAM 93.23% > 90% breach / 部 229 POST 93.05% から +0.18 pt drift / **7h idle で 自然 GC 機能せず** (= 部 217 「20-pt 自然 GC -20pt」 vs 部 229→230 「+0.18 pt drift」= 7h GC 失敗 = 部 220 「+0.56pt drift 5min idle」と同 pattern)
+- **premature start pattern 第 2 例累積** (= 部 226 13min before zone exit / 部 230 user 期待 5/19 = 18h misalign / **時刻判定 user-side でも誤発火 pattern 累積**)
+- **C: drift 1.07 GB/h idle pattern 観測継続** (= 部 217 KB5087051 仮説 / 部 223 12.7 GB/h overnight idle / 部 230 1.07 GB/h short idle / **drift rate variance あり**)
+- **/goal 9 連続 saturation 確定 第 1 例** = 部 222b → 部 230 / 9 連続 redundant 確証 / pivot 「Codex sprint status report」command 化 = 部 231+ 優先 (= 第 4 priority)
+
+### next session 候補 (= 部 231+)
+
+1. 🚨 **#1495 P0 +6 day FINAL FIRE** (= post-EOD 5/19 00:30+ wakeup で 自動 fire / Option C 4 案 (LP / 競合比較 / docs / Master Brain) 着手判断 / Win Claude 担当 = 第 1 priority)
+2. **#2520 / #2461 Codex impl 着地確認** (= 5/22 sprint Day 4-7 monitor)
+3. **/goal pivot 実装** (= 9 連続 redundant 確定 → 「Codex sprint status report」command 化 = 第 2 priority 引上)
+4. **J3 backend layer impl** (= session_hygiene_log table migration + ef ai_hub.session_hygiene_kpi)
+5. **MEMORY.md consolidation 第 6 例** (= part 215-220 archive)
+6. **competitor 21 社調査 update** (= sub-agent ① 並列 spawn 第 3 例候補)
+7. **ROADMAP backfill 11 part 蓄積消化検討**


### PR DESCRIPTION
## Summary

- Win版#132 part 230 (2026-05-18 19:28 JST) ROADMAP entry (+41 lines).
- **v24 SS 第 16 例 zone breach 第 1 例** = RAM PRE 93.23% > 90% (= 部 229 POST 93.05% から +0.18 pt drift in 7h idle).
- **premature start 第 2 例** = user 期待 5/19 06:00+ JST / 実 5/18 19:28 JST = 7h18min idle only (= NOT overnight).
- minimal verify-only scope (= 3 status check 全 defer / #1495 EOD +4.5h / #2520+#2461 Codex 動きなし).
- **/goal 9 連続 saturation 確定 第 1 例** = pivot 「Codex sprint status report」command 化 第 2 priority 引上.

## Test plan

- [x] docs-only single-file ROADMAP append (= no code change / no schema change / no EF / no widget)
- [x] git fetch origin main → no upstream conflict (= [REBASE] 厳守)
- [x] commit ea0e55db7 + push to origin/claude/intelligent-nobel-2e3fc7
- [x] minimal scope (= v24 SS breach 下) / Philosophy 4/9 alignment (= 原則 1+7+8+9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)