### PR TITLE
ci: make AI bench source recheck report-only (#2520)

### DIFF
--- a/.github/workflows/ai-bench-source-recheck.yml
+++ b/.github/workflows/ai-bench-source-recheck.yml
@@ -28,8 +28,8 @@ jobs:
           python scripts/internal_ai_bench_source_recheck.py \
             --input docs/ai-bench/results/template.json \
             --output-json ai-bench-source-recheck.json \
-            --output-md ai-bench-source-recheck.md \
-            --strict
+            --output-md ai-bench-source-recheck.md
+          cat ai-bench-source-recheck.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload source recheck artifact
         uses: actions/upload-artifact@v6

--- a/docs/ai-bench/v1_spec.md
+++ b/docs/ai-bench/v1_spec.md
@@ -81,7 +81,9 @@ python scripts/internal_ai_bench_source_recheck.py `
 
 The source recheck is also available as the `AI Bench Source Recheck` workflow.
 It performs public HTTP reads only; it does not call paid model APIs and does
-not change routing defaults.
+not change routing defaults. The workflow is report-only because some official
+sites may serve different content or bot-block GitHub hosted runners; use the
+CLI `--strict` flag for operator-gated live-run readiness checks.
 
 Create a template:
 

--- a/docs/ai-bench/verdict.md
+++ b/docs/ai-bench/verdict.md
@@ -32,7 +32,8 @@ Latest source-only evidence snapshot:
    ```
 
    This step is also available as the `AI Bench Source Recheck` workflow. It is
-   source-only and does not use provider API keys.
+   source-only and does not use provider API keys. The workflow is report-only;
+   use the CLI `--strict` mode before approving any live provider execution.
 
 2. Generate a dry-run provider manifest:
 


### PR DESCRIPTION
﻿## Summary

- Make the new `AI Bench Source Recheck` workflow report-only so official-site runner blocking creates an artifact/warning instead of a failing scheduled/manual workflow.
- Keep `scripts/internal_ai_bench_source_recheck.py --strict` as the operator gate before any live provider execution.
- Clarify the report-only workflow behavior in the AI bench spec and verdict docs.

## Validation

- `python scripts\check_github_actions_node_runtime.py`
- `python test\scripts\test_internal_ai_bench_source_recheck.py`
- `npx --yes markdownlint-cli@0.45.0 --dot docs\ai-bench\v1_spec.md docs\ai-bench\verdict.md`
- `git diff --check`

## Minimal E2E Gate

- Plan is implementation-detail independent and black-box at the workflow/report boundary.
- Minimal three I/O cases are covered by the existing source-recheck test suite; this PR changes workflow failure behavior only.
- E2E mechanism: no Flutter integration_test or Playwright run is needed because this is a workflow/docs-only hotfix.
- E2E-Exception: report-only workflow fix; no app-code, data, route, or provider API execution change.

## High-risk Ultrareview Gate

- Claude Code #1 is the review owner for high-risk review follow-up.
- Claude ultrareview evidence / exception: High-risk-ultrareview-exception: workflow/docs-only hotfix after GitHub hosted runner source blocking; no secrets, auth, billing, migrations, deploy workflow, Supabase writes, or production routing defaults changed.
- Security: no new secrets or provider API calls; public HTTP report remains artifact-only.
- Rollback: revert this hotfix to restore strict workflow failure behavior.
- Data migration: none.
- Prod smoke: not required for workflow/docs-only change; Deploy to Production will still be verified after merge.
- Observability: workflow writes the report to job summary and artifact.
- Unresolved findings: none / 0.

## Guarded subagent orchestration

- Lead owner: Codex #1
- Child workers: none used
- Cleanup evidence: no child worker/process cleanup required

Follow-up to PR #2820 / #2520.
