### PR TITLE
feat(asset): add payment reminder candidates (#2453)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -22,6 +22,7 @@ import 'package:my_web_app/services/asset_liability_annual_rate_evidence_service
 import 'package:my_web_app/services/asset_liability_card_statement_import_service.dart';
 import 'package:my_web_app/services/asset_liability_history_service.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+import 'package:my_web_app/services/asset_liability_payment_reminder_service.dart';
 import 'package:my_web_app/services/asset_liability_planning_service.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
@@ -212,6 +213,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   late final AssetLiabilityRepository _assetLiabilityRepository;
   final AssetLiabilityPlanningService _assetLiabilityPlanner =
       const AssetLiabilityPlanningService();
+  final AssetLiabilityPaymentReminderService _assetLiabilityReminderService =
+      const AssetLiabilityPaymentReminderService();
   final AssetLiabilityCardStatementImportService _cardStatementImportService =
       const AssetLiabilityCardStatementImportService();
   final AssetLiabilityAnnualRateEvidenceService _annualRateEvidenceService =
@@ -7454,6 +7457,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             const SizedBox(height: 12),
             _buildAssetWorkbookWarning(workbook),
             const SizedBox(height: 16),
+            _buildAssetPaymentReminderPanel(workbook),
+            const SizedBox(height: 16),
             _buildAssetWorkbookPaymentList(workbook),
             const SizedBox(height: 16),
             _buildIncomePlanSection(workbook),
@@ -9628,6 +9633,151 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ],
       ),
     );
+  }
+
+  Widget _buildAssetPaymentReminderPanel(AssetLiabilityWorkbook workbook) {
+    final reminders = _assetLiabilityReminderService.buildCandidates(
+      workbook: workbook,
+      now: _now,
+    );
+    if (reminders.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFF59E0B).withValues(alpha: 0.32),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Row(
+            children: [
+              Icon(
+                Icons.notifications_active_outlined,
+                color: Color(0xFFD97706),
+              ),
+              SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '支払日前リマインダー候補',
+                  style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '通知基盤が未設定でも、支払日順資金繰りに沿って前日・当日・期限超過の未払いを確認できます。',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 10),
+          ...reminders.map(_buildAssetPaymentReminderRow),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetPaymentReminderRow(
+    AssetLiabilityPaymentReminderCandidate reminder,
+  ) {
+    final row = reminder.cashflowRow;
+    final color = _paymentReminderStatusColor(reminder);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 72,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              children: [
+                Text(
+                  DateFormat('M/d').format(row.paymentDate),
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: color,
+                    fontWeight: FontWeight.bold,
+                    height: 1.2,
+                  ),
+                ),
+                Text(
+                  _paymentReminderStatusLabel(reminder),
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 11,
+                    fontWeight: FontWeight.bold,
+                    height: 1.2,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  reminder.title,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w600,
+                    height: 1.4,
+                  ),
+                ),
+                Text(
+                  '${reminder.detail} / 支払予定 ${_formatManagementYen(row.paymentAmount)} / 支払後手元 ${_formatManagementYen(row.cashAfterPayment)}',
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    fontSize: 12,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _paymentReminderStatusColor(
+    AssetLiabilityPaymentReminderCandidate reminder,
+  ) {
+    if (reminder.hasShortageRisk ||
+        reminder.status == AssetLiabilityPaymentReminderStatus.overdue) {
+      return const Color(0xFFB91C1C);
+    }
+    if (reminder.status == AssetLiabilityPaymentReminderStatus.dueToday) {
+      return const Color(0xFFD97706);
+    }
+    return const Color(0xFF2563EB);
+  }
+
+  String _paymentReminderStatusLabel(
+    AssetLiabilityPaymentReminderCandidate reminder,
+  ) {
+    return switch (reminder.status) {
+      AssetLiabilityPaymentReminderStatus.overdue => '超過',
+      AssetLiabilityPaymentReminderStatus.dueToday => '今日',
+      AssetLiabilityPaymentReminderStatus.dueTomorrow => '明日',
+    };
   }
 
   Widget _buildAssetWorkbookPaymentList(AssetLiabilityWorkbook workbook) {

--- a/lib/services/asset_liability_payment_reminder_service.dart
+++ b/lib/services/asset_liability_payment_reminder_service.dart
@@ -1,0 +1,120 @@
+import '../models/asset_liability_workbook.dart';
+
+enum AssetLiabilityPaymentReminderStatus { overdue, dueToday, dueTomorrow }
+
+class AssetLiabilityPaymentReminderCandidate {
+  final AssetLiabilityCashflowRow cashflowRow;
+  final AssetLiabilityPaymentReminderStatus status;
+  final int daysUntilDue;
+  final bool hasShortageRisk;
+  final String title;
+  final String detail;
+
+  const AssetLiabilityPaymentReminderCandidate({
+    required this.cashflowRow,
+    required this.status,
+    required this.daysUntilDue,
+    required this.hasShortageRisk,
+    required this.title,
+    required this.detail,
+  });
+}
+
+class AssetLiabilityPaymentReminderService {
+  const AssetLiabilityPaymentReminderService();
+
+  List<AssetLiabilityPaymentReminderCandidate> buildCandidates({
+    required AssetLiabilityWorkbook workbook,
+    required DateTime now,
+    int lookAheadDays = 1,
+  }) {
+    final today = _dateOnly(now);
+    final candidates = <AssetLiabilityPaymentReminderCandidate>[];
+
+    for (final row in workbook.cashflowRows) {
+      if (!row.isPayment || !row.isDirectCashflowTarget || row.paid) {
+        continue;
+      }
+
+      final paymentDate = _dateOnly(row.paymentDate);
+      final daysUntilDue = paymentDate.difference(today).inDays;
+      if (daysUntilDue > lookAheadDays) {
+        continue;
+      }
+
+      final status = _statusFor(daysUntilDue);
+      final hasShortageRisk = row.cashAfterPayment < 0 ||
+          row.riskLevel == AssetLiabilityCashRiskLevel.short;
+      candidates.add(
+        AssetLiabilityPaymentReminderCandidate(
+          cashflowRow: row,
+          status: status,
+          daysUntilDue: daysUntilDue,
+          hasShortageRisk: hasShortageRisk,
+          title: _titleFor(row, status),
+          detail: _detailFor(row, status, hasShortageRisk),
+        ),
+      );
+    }
+
+    candidates.sort((a, b) {
+      final date = a.cashflowRow.paymentDate.compareTo(
+        b.cashflowRow.paymentDate,
+      );
+      if (date != 0) {
+        return date;
+      }
+      final amount = b.cashflowRow.paymentAmount.compareTo(
+        a.cashflowRow.paymentAmount,
+      );
+      if (amount != 0) {
+        return amount;
+      }
+      return a.cashflowRow.accountName.compareTo(b.cashflowRow.accountName);
+    });
+    return candidates;
+  }
+
+  AssetLiabilityPaymentReminderStatus _statusFor(int daysUntilDue) {
+    if (daysUntilDue < 0) {
+      return AssetLiabilityPaymentReminderStatus.overdue;
+    }
+    if (daysUntilDue == 0) {
+      return AssetLiabilityPaymentReminderStatus.dueToday;
+    }
+    return AssetLiabilityPaymentReminderStatus.dueTomorrow;
+  }
+
+  String _titleFor(
+    AssetLiabilityCashflowRow row,
+    AssetLiabilityPaymentReminderStatus status,
+  ) {
+    final prefix = switch (status) {
+      AssetLiabilityPaymentReminderStatus.overdue => '期限超過',
+      AssetLiabilityPaymentReminderStatus.dueToday => '本日支払日',
+      AssetLiabilityPaymentReminderStatus.dueTomorrow => '明日支払日',
+    };
+    return '$prefix: ${row.accountName}';
+  }
+
+  String _detailFor(
+    AssetLiabilityCashflowRow row,
+    AssetLiabilityPaymentReminderStatus status,
+    bool hasShortageRisk,
+  ) {
+    final statusDetail = switch (status) {
+      AssetLiabilityPaymentReminderStatus.overdue => '支払日を過ぎた未払いです。',
+      AssetLiabilityPaymentReminderStatus.dueToday => '今日中に支払い確認が必要です。',
+      AssetLiabilityPaymentReminderStatus.dueTomorrow => '明日の支払い準備を確認してください。',
+    };
+    final source = row.paymentSourceAccountName == null
+        ? '支払元口座未設定'
+        : '支払元: ${row.paymentSourceAccountName}';
+    final shortage = hasShortageRisk ? ' 支払後の手元資金が不足する見込みです。' : '';
+    return '$statusDetail $source。$shortage'.trim();
+  }
+
+  DateTime _dateOnly(DateTime value) {
+    return DateTime(value.year, value.month, value.day);
+  }
+}

--- a/test/services/asset_liability_payment_reminder_service_test.dart
+++ b/test/services/asset_liability_payment_reminder_service_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_liability_payment_reminder_service.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  group('AssetLiabilityPaymentReminderService.buildCandidates', () {
+    const planner = AssetLiabilityPlanningService();
+    const reminders = AssetLiabilityPaymentReminderService();
+
+    test('matches unpaid due rows from the chronological cashflow', () {
+      final now = DateTime(2026, 5, 14);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: <String, double>{
+          '財布': 25000,
+          'アコムカードローン': -100000,
+          'auPayカード': -10000,
+          'モビット': -100000,
+          'PayPayカード': -20000,
+        },
+        baseDate: now,
+        monthlyPaymentOverrides: const <String, double>{
+          'アコムカードローン': 5000,
+          'auPayカード': 8000,
+          'モビット': 9000,
+          'PayPayカード': 12000,
+        },
+      );
+
+      final candidates = reminders.buildCandidates(
+        workbook: workbook,
+        now: now,
+      );
+      final dueRows = workbook.cashflowRows.where((row) {
+        return row.isPayment &&
+            row.isDirectCashflowTarget &&
+            !row.paid &&
+            !row.paymentDate.isAfter(DateTime(2026, 5, 15));
+      });
+
+      expect(
+        candidates.map((candidate) => candidate.cashflowRow.accountId),
+        dueRows.map((row) => row.accountId),
+      );
+      expect(
+        candidates.map((candidate) => candidate.status),
+        <AssetLiabilityPaymentReminderStatus>[
+          AssetLiabilityPaymentReminderStatus.overdue,
+          AssetLiabilityPaymentReminderStatus.overdue,
+          AssetLiabilityPaymentReminderStatus.dueTomorrow,
+        ],
+      );
+    });
+
+    test('excludes already paid rows', () {
+      final now = DateTime(2026, 5, 15);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: <String, double>{'財布': 10000, 'モビット': -100000},
+        baseDate: now,
+        monthlyPaymentOverrides: const <String, double>{'モビット': 10000},
+        paidAccountNames: const <String>{'モビット'},
+      );
+
+      expect(reminders.buildCandidates(workbook: workbook, now: now), isEmpty);
+    });
+
+    test('adds shortage risk text without mutating cashflow data', () {
+      final now = DateTime(2026, 5, 15);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: <String, double>{'財布': 9000, 'モビット': -100000},
+        baseDate: now,
+        monthlyPaymentOverrides: const <String, double>{'モビット': 10000},
+      );
+      final before = workbook.cashflowRows
+          .map((row) => '${row.accountId}:${row.cashAfterPayment}:${row.paid}')
+          .toList();
+
+      final candidates = reminders.buildCandidates(
+        workbook: workbook,
+        now: now,
+      );
+      final after = workbook.cashflowRows
+          .map((row) => '${row.accountId}:${row.cashAfterPayment}:${row.paid}')
+          .toList();
+
+      expect(candidates, hasLength(1));
+      expect(
+        candidates.single.status,
+        AssetLiabilityPaymentReminderStatus.dueToday,
+      );
+      expect(candidates.single.hasShortageRisk, isTrue);
+      expect(candidates.single.detail, contains('不足'));
+      expect(after, before);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add a deterministic asset-liability payment reminder service that derives overdue, due-today, and due-tomorrow candidates from the chronological cashflow rows.
- Surface the candidates on the asset management board so the list remains usable even when notification delivery is not configured.
- Cover cashflow order alignment, paid-row exclusion, shortage-risk text, and read-only behavior with focused service tests.

## Validation
- `flutter test --no-pub test\services\asset_liability_payment_reminder_service_test.dart`
- `flutter test --no-pub test\services\asset_liability_planning_service_test.dart`
- `dart analyze --no-fatal-warnings lib\services\asset_liability_payment_reminder_service.dart test\services\asset_liability_payment_reminder_service_test.dart`
- `dart analyze --no-fatal-warnings lib\pages\asset_management_page.dart`
- Full `flutter analyze --no-pub` was attempted but timed out after 4 minutes; targeted analysis above completed cleanly.

## Minimal E2E Gate
- The E2E test is implementation-detail independent.
- Minimal plan: three I/O cases cover reminder derivation: overdue/today/tomorrow unpaid inputs produce sorted candidates, paid inputs produce no candidates, and shortage-risk inputs surface shortage copy without mutating cashflow.
- E2E mechanism: focused Flutter service tests plus the existing public E2E stability smoke cover this deterministic panel slice.
- Minimal E2E Exception: no new route, network boundary, auth state, or external side effect was introduced; the deterministic service I/O cases are the highest-signal coverage for this scoped change.

## High-Risk Ultrareview Gate
- Review owner: Claude Code #1.
- Ultrareview exception: high-risk detection is triggered by the word payment in the PR title/body, but this PR adds no auth, secrets, provider billing, data migration, deploy workflow, production write, or external notification side effect.

## Operations
- Guarded subagent orchestration: not used.

Closes #2453