### PR TITLE
feat(asset): add CSV restore preview (#2455)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -20,6 +20,7 @@ import 'package:my_web_app/models/debt_repayment_plan.dart';
 import 'package:my_web_app/models/kgi_csf_kpi.dart';
 import 'package:my_web_app/services/asset_liability_annual_rate_evidence_service.dart';
 import 'package:my_web_app/services/asset_liability_card_statement_import_service.dart';
+import 'package:my_web_app/services/asset_liability_csv_restore_service.dart';
 import 'package:my_web_app/services/asset_liability_history_service.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 import 'package:my_web_app/services/asset_liability_payment_reminder_service.dart';
@@ -162,10 +163,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   AssetLiabilityDebtRow? _annualRateEvidencePasteTargetRow;
   final TextEditingController _cardStatementImportController =
       TextEditingController();
+  final TextEditingController _assetCsvRestoreController =
+      TextEditingController();
   final TextEditingController _repaymentSimulationExtraPaymentController =
       TextEditingController(text: '0');
   String? _selectedCardStatementBillingAccountId;
   String? _cardStatementImportMessage;
+  AssetLiabilityCsvRestorePreview? _assetCsvRestorePreview;
+  String? _assetCsvRestoreMessage;
+  bool _isApplyingAssetCsvRestore = false;
 
   // --- グラフデータ ---
   List<LineChartBarData> _lineChartBars = [];
@@ -223,6 +229,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetLiabilityRepaymentSimulationService();
   final AssetLiabilityCardStatementImportService _cardStatementImportService =
       const AssetLiabilityCardStatementImportService();
+  final AssetLiabilityCsvRestoreService _assetLiabilityCsvRestoreService =
+      const AssetLiabilityCsvRestoreService();
   final AssetLiabilityAnnualRateEvidenceService _annualRateEvidenceService =
       AssetLiabilityAnnualRateEvidenceService();
   final AssetLiabilityHistoryService _assetLiabilityHistoryService =
@@ -337,6 +345,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
     _annualRateControllers.forEach((_, controller) => controller.dispose());
     _cardStatementImportController.dispose();
+    _assetCsvRestoreController.dispose();
     _repaymentSimulationExtraPaymentController.dispose();
     _annualRateControllers.forEach((_, controller) => controller.dispose());
     _flowMemoController.dispose();
@@ -965,27 +974,31 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _persistAssetLiabilityMonthlyState() async {
     await _assetLiabilityRepository.saveMonth(
       month: _now,
-      state: AssetLiabilityMonthlyState(
-        paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
-        actualPaymentAmounts: Map<String, double>.from(_actualPaymentAmounts),
-        paymentDifferenceReasons: Map<String, String>.from(
-          _paymentDifferenceReasons,
-        ),
-        annualRateOverrides: Map<String, double>.from(_annualRateOverrides),
-        annualRateEvidences: Map<String, AssetLiabilityAnnualRateEvidence>.from(
-          _annualRateEvidences,
-        ),
-        paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
-        paymentSourceAccountIds: Map<String, String>.from(
-          _paymentSourceAccountIds,
-        ),
-        cardBillingAccountIds: Map<String, String>.from(_cardBillingAccountIds),
-        cardStatementLines: List<AssetLiabilityCardStatementLine>.from(
-          _cardStatementLines,
-        ),
-        incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
-        transferTasks: List<AssetLiabilityTransferTask>.from(_transferTasks),
+      state: _currentAssetLiabilityMonthlyState(),
+    );
+  }
+
+  AssetLiabilityMonthlyState _currentAssetLiabilityMonthlyState() {
+    return AssetLiabilityMonthlyState(
+      paymentOverrides: Map<String, double>.from(_monthlyPaymentOverrides),
+      actualPaymentAmounts: Map<String, double>.from(_actualPaymentAmounts),
+      paymentDifferenceReasons: Map<String, String>.from(
+        _paymentDifferenceReasons,
       ),
+      annualRateOverrides: Map<String, double>.from(_annualRateOverrides),
+      annualRateEvidences: Map<String, AssetLiabilityAnnualRateEvidence>.from(
+        _annualRateEvidences,
+      ),
+      paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
+      paymentSourceAccountIds: Map<String, String>.from(
+        _paymentSourceAccountIds,
+      ),
+      cardBillingAccountIds: Map<String, String>.from(_cardBillingAccountIds),
+      cardStatementLines: List<AssetLiabilityCardStatementLine>.from(
+        _cardStatementLines,
+      ),
+      incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
+      transferTasks: List<AssetLiabilityTransferTask>.from(_transferTasks),
     );
   }
 
@@ -994,6 +1007,185 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       await _persistAssetLiabilityMonthlyState();
     } catch (e) {
       debugPrint('Error saving asset liability monthly state: $e');
+    }
+  }
+
+  DateTime? _parseAssetLiabilityMonthKey(String monthKey) {
+    final parts = monthKey.split('-');
+    if (parts.length != 2) return null;
+    final year = int.tryParse(parts[0]);
+    final month = int.tryParse(parts[1]);
+    if (year == null || month == null || month < 1 || month > 12) {
+      return null;
+    }
+    return DateTime(year, month);
+  }
+
+  String _assetCsvRestoreSectionLabel(AssetLiabilityCsvRestoreSection section) {
+    switch (section) {
+      case AssetLiabilityCsvRestoreSection.monthlyHistory:
+        return 'monthly history';
+      case AssetLiabilityCsvRestoreSection.paymentSchedule:
+        return 'payment schedule';
+      case AssetLiabilityCsvRestoreSection.cardStatement:
+        return 'card statement';
+      case AssetLiabilityCsvRestoreSection.incomePlans:
+        return 'income plans';
+      case AssetLiabilityCsvRestoreSection.accountCashflow:
+        return 'account cashflow';
+      case AssetLiabilityCsvRestoreSection.unknown:
+        return 'unknown';
+    }
+  }
+
+  String _assetCsvRestorePreviewMessage(
+    AssetLiabilityCsvRestorePreview preview,
+  ) {
+    final sections =
+        preview.detectedSections.map(_assetCsvRestoreSectionLabel).join(', ');
+    final monthText = preview.affectedMonthKeys.isEmpty
+        ? '0 months'
+        : preview.affectedMonthKeys.join(', ');
+    return [
+      'Preview: ${sections.isEmpty ? 'unknown' : sections}',
+      'months: $monthText',
+      'payments: ${preview.restoredPaymentCount}',
+      'cards: ${preview.restoredCardStatementLineCount}',
+      'income: ${preview.restoredIncomeCount}',
+      'snapshots: ${preview.monthlySnapshots.length}',
+      'rejected: ${preview.rejectedRows.length}',
+    ].join(' / ');
+  }
+
+  void _previewAssetLiabilityCsvRestore() {
+    final rawText = _assetCsvRestoreController.text.trim();
+    if (rawText.isEmpty) {
+      setState(() {
+        _assetCsvRestorePreview = null;
+        _assetCsvRestoreMessage = 'Paste an exported CSV before preview.';
+      });
+      return;
+    }
+    final preview = _assetLiabilityCsvRestoreService.previewCsvText(rawText);
+    setState(() {
+      _assetCsvRestorePreview = preview;
+      _assetCsvRestoreMessage = _assetCsvRestorePreviewMessage(preview);
+    });
+  }
+
+  Future<void> _applyAssetLiabilityCsvRestore() async {
+    final preview = _assetCsvRestorePreview;
+    if (preview == null || !preview.hasRestorableRows) {
+      setState(() {
+        _assetCsvRestoreMessage = 'Preview a restorable CSV before apply.';
+      });
+      return;
+    }
+    setState(() {
+      _isApplyingAssetCsvRestore = true;
+      _assetCsvRestoreMessage = 'Applying append-only restore...';
+    });
+    try {
+      final existingStates = <String, AssetLiabilityMonthlyState>{};
+      final currentMonthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(
+        _now,
+      );
+      for (final monthKey in preview.monthlyStates.keys) {
+        if (monthKey == currentMonthKey) {
+          existingStates[monthKey] = _currentAssetLiabilityMonthlyState();
+          continue;
+        }
+        final month = _parseAssetLiabilityMonthKey(monthKey);
+        if (month == null) continue;
+        existingStates[monthKey] = await _assetLiabilityRepository.loadMonth(
+          month,
+        );
+      }
+
+      final mergeResult = _assetLiabilityCsvRestoreService.mergePreview(
+        preview: preview,
+        existingStates: existingStates,
+        existingSnapshots: _monthlySnapshots,
+        policy: AssetLiabilityCsvRestoreApplyPolicy.appendOnly,
+      );
+
+      for (final monthKey in preview.monthlyStates.keys) {
+        final month = _parseAssetLiabilityMonthKey(monthKey);
+        final state = mergeResult.monthlyStates[monthKey];
+        if (month == null || state == null) continue;
+        await _assetLiabilityRepository.saveMonth(month: month, state: state);
+      }
+
+      final importedSnapshotKeys =
+          preview.monthlySnapshots.map((snapshot) => snapshot.monthKey).toSet();
+      for (final snapshot in mergeResult.monthlySnapshots) {
+        if (!importedSnapshotKeys.contains(snapshot.monthKey)) continue;
+        await _assetLiabilityRepository.saveMonthlySnapshot(snapshot);
+      }
+
+      final refreshedSnapshots =
+          await _assetLiabilityRepository.loadMonthlySnapshots();
+      if (!mounted) return;
+      final currentState = mergeResult.monthlyStates[currentMonthKey];
+      setState(() {
+        if (currentState != null) {
+          _monthlyPaymentOverrides = Map<String, double>.from(
+            currentState.paymentOverrides,
+          );
+          _actualPaymentAmounts = Map<String, double>.from(
+            currentState.actualPaymentAmounts,
+          );
+          _paymentDifferenceReasons = Map<String, String>.from(
+            currentState.paymentDifferenceReasons,
+          );
+          _annualRateOverrides = Map<String, double>.from(
+            currentState.annualRateOverrides,
+          );
+          _annualRateEvidences =
+              Map<String, AssetLiabilityAnnualRateEvidence>.from(
+            currentState.annualRateEvidences,
+          );
+          _monthlyPaidAccountNames = Set<String>.from(
+            currentState.paidAccountNames,
+          );
+          _paymentSourceAccountIds = Map<String, String>.from(
+            currentState.paymentSourceAccountIds,
+          );
+          _cardBillingAccountIds = Map<String, String>.from(
+            currentState.cardBillingAccountIds,
+          );
+          _cardStatementLines = List<AssetLiabilityCardStatementLine>.from(
+            currentState.cardStatementLines,
+          );
+          _monthlyIncomePlans = List<AssetLiabilityIncomePlan>.from(
+            currentState.incomePlans,
+          );
+          _transferTasks = List<AssetLiabilityTransferTask>.from(
+            currentState.transferTasks,
+          );
+          _syncPaymentStateControllers();
+        }
+        _monthlySnapshots = List<AssetLiabilityMonthlySnapshot>.from(
+          refreshedSnapshots,
+        );
+        final warningText = mergeResult.warnings.isEmpty
+            ? ''
+            : ' Warnings: ${mergeResult.warnings.take(3).join(' ')}';
+        _assetCsvRestoreMessage =
+            'Applied append-only restore for ${preview.affectedMonthKeys.length} month(s).$warningText';
+      });
+    } catch (e) {
+      debugPrint('Error applying asset CSV restore: $e');
+      if (!mounted) return;
+      setState(() {
+        _assetCsvRestoreMessage = 'CSV restore failed: $e';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isApplyingAssetCsvRestore = false;
+        });
+      }
     }
   }
 
@@ -10676,6 +10868,96 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  Widget _buildAssetCsvRestorePanel() {
+    final preview = _assetCsvRestorePreview;
+    final theme = Theme.of(context);
+    final message = _assetCsvRestoreMessage;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Divider(height: 20),
+        const Text(
+          'CSV restore',
+          style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: _assetCsvRestoreController,
+          minLines: 3,
+          maxLines: 6,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: 'Exported CSV',
+            hintText: 'month_key,...',
+            isDense: true,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            OutlinedButton.icon(
+              onPressed: _previewAssetLiabilityCsvRestore,
+              icon: const Icon(Icons.visibility_outlined),
+              label: const Text('Preview'),
+            ),
+            FilledButton.icon(
+              onPressed: preview != null &&
+                      preview.hasRestorableRows &&
+                      !_isApplyingAssetCsvRestore
+                  ? _applyAssetLiabilityCsvRestore
+                  : null,
+              icon: _isApplyingAssetCsvRestore
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.restore_outlined),
+              label: const Text('Apply append-only'),
+            ),
+            if (message != null)
+              Text(
+                message,
+                style: TextStyle(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontSize: 12,
+                  height: 1.5,
+                ),
+              ),
+          ],
+        ),
+        if (preview != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            _assetCsvRestorePreviewMessage(preview),
+            style: TextStyle(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          if (preview.rejectedRows.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Text(
+              preview.rejectedRows
+                  .take(3)
+                  .map((row) => 'row ${row.rowNumber}: ${row.reason}')
+                  .join('\n'),
+              style: TextStyle(
+                color: theme.colorScheme.error,
+                fontSize: 12,
+                height: 1.5,
+              ),
+            ),
+          ],
+        ],
+      ],
+    );
+  }
+
   Widget _buildMonthlySnapshotSection(AssetLiabilityWorkbook workbook) {
     final comparisons = _assetLiabilityHistoryService.compareSnapshots(
       _monthlySnapshots,
@@ -10739,6 +11021,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           ),
           const SizedBox(height: 8),
+          _buildAssetCsvRestorePanel(),
+          const SizedBox(height: 12),
           _buildMonthlySnapshotChart(chartData),
           const SizedBox(height: 12),
           if (comparisons.isEmpty)

--- a/lib/services/asset_liability_csv_restore_service.dart
+++ b/lib/services/asset_liability_csv_restore_service.dart
@@ -1,0 +1,740 @@
+import 'package:intl/intl.dart';
+
+import '../models/asset_liability_workbook.dart';
+import 'asset_liability_monthly_state_store.dart';
+
+enum AssetLiabilityCsvRestoreApplyPolicy {
+  appendOnly,
+  overwriteImportedFields,
+  skipExistingMonths,
+}
+
+enum AssetLiabilityCsvRestoreSection {
+  monthlyHistory,
+  paymentSchedule,
+  cardStatement,
+  incomePlans,
+  accountCashflow,
+  unknown,
+}
+
+class AssetLiabilityCsvRestoreRejectedRow {
+  final AssetLiabilityCsvRestoreSection section;
+  final int rowNumber;
+  final String rawText;
+  final String reason;
+
+  const AssetLiabilityCsvRestoreRejectedRow({
+    required this.section,
+    required this.rowNumber,
+    required this.rawText,
+    required this.reason,
+  });
+}
+
+class AssetLiabilityCsvRestorePreview {
+  final Map<String, AssetLiabilityMonthlyState> monthlyStates;
+  final List<AssetLiabilityMonthlySnapshot> monthlySnapshots;
+  final List<AssetLiabilityCsvRestoreRejectedRow> rejectedRows;
+  final Set<AssetLiabilityCsvRestoreSection> detectedSections;
+
+  const AssetLiabilityCsvRestorePreview({
+    this.monthlyStates = const <String, AssetLiabilityMonthlyState>{},
+    this.monthlySnapshots = const <AssetLiabilityMonthlySnapshot>[],
+    this.rejectedRows = const <AssetLiabilityCsvRestoreRejectedRow>[],
+    this.detectedSections = const <AssetLiabilityCsvRestoreSection>{},
+  });
+
+  bool get hasRestorableRows =>
+      monthlyStates.isNotEmpty || monthlySnapshots.isNotEmpty;
+
+  int get restoredPaymentCount => monthlyStates.values.fold<int>(
+        0,
+        (sum, state) => sum + state.paymentOverrides.length,
+      );
+
+  int get restoredIncomeCount => monthlyStates.values.fold<int>(
+        0,
+        (sum, state) => sum + state.incomePlans.length,
+      );
+
+  int get restoredCardStatementLineCount => monthlyStates.values.fold<int>(
+        0,
+        (sum, state) => sum + state.cardStatementLines.length,
+      );
+
+  List<String> get affectedMonthKeys {
+    final keys = <String>{
+      ...monthlyStates.keys,
+      for (final snapshot in monthlySnapshots) snapshot.monthKey,
+    }.toList()
+      ..sort();
+    return keys;
+  }
+}
+
+class AssetLiabilityCsvRestoreMergeResult {
+  final Map<String, AssetLiabilityMonthlyState> monthlyStates;
+  final List<AssetLiabilityMonthlySnapshot> monthlySnapshots;
+  final List<String> warnings;
+
+  const AssetLiabilityCsvRestoreMergeResult({
+    required this.monthlyStates,
+    required this.monthlySnapshots,
+    this.warnings = const <String>[],
+  });
+}
+
+class AssetLiabilityCsvRestoreService {
+  const AssetLiabilityCsvRestoreService();
+
+  AssetLiabilityCsvRestorePreview previewCsvText(String rawText) {
+    final rows = _parseCsv(rawText);
+    if (rows.isEmpty) {
+      return const AssetLiabilityCsvRestorePreview(
+        rejectedRows: <AssetLiabilityCsvRestoreRejectedRow>[
+          AssetLiabilityCsvRestoreRejectedRow(
+            section: AssetLiabilityCsvRestoreSection.unknown,
+            rowNumber: 0,
+            rawText: '',
+            reason: 'CSV is empty',
+          ),
+        ],
+      );
+    }
+    final header = rows.first;
+    final section = _detectSection(header);
+    return previewCsvSections(<AssetLiabilityCsvRestoreSection, String>{
+      section: rawText,
+    });
+  }
+
+  AssetLiabilityCsvRestorePreview previewCsvSections(
+    Map<AssetLiabilityCsvRestoreSection, String> csvBySection,
+  ) {
+    final stateByMonth = <String, AssetLiabilityMonthlyState>{};
+    final snapshotsByMonth = <String, AssetLiabilityMonthlySnapshot>{};
+    final rejected = <AssetLiabilityCsvRestoreRejectedRow>[];
+    final detectedSections = <AssetLiabilityCsvRestoreSection>{};
+
+    void mergeState(String monthKey, AssetLiabilityMonthlyState patch) {
+      stateByMonth[monthKey] = _mergeStateAppendOnly(
+        stateByMonth[monthKey] ?? const AssetLiabilityMonthlyState(),
+        patch,
+      );
+    }
+
+    for (final entry in csvBySection.entries) {
+      final rows = _parseCsv(entry.value);
+      if (rows.isEmpty) {
+        rejected.add(
+          AssetLiabilityCsvRestoreRejectedRow(
+            section: entry.key,
+            rowNumber: 0,
+            rawText: '',
+            reason: 'CSV is empty',
+          ),
+        );
+        continue;
+      }
+      final detected = entry.key == AssetLiabilityCsvRestoreSection.unknown
+          ? _detectSection(rows.first)
+          : entry.key;
+      detectedSections.add(detected);
+      switch (detected) {
+        case AssetLiabilityCsvRestoreSection.monthlyHistory:
+          for (final parsed in _parseMonthlyHistory(rows, rejected)) {
+            snapshotsByMonth[parsed.monthKey] = parsed;
+          }
+          break;
+        case AssetLiabilityCsvRestoreSection.paymentSchedule:
+          for (final parsed in _parsePaymentSchedule(rows, rejected)) {
+            mergeState(parsed.monthKey, parsed.state);
+          }
+          break;
+        case AssetLiabilityCsvRestoreSection.cardStatement:
+          for (final parsed in _parseCardStatements(rows, rejected)) {
+            mergeState(parsed.monthKey, parsed.state);
+          }
+          break;
+        case AssetLiabilityCsvRestoreSection.incomePlans:
+          for (final parsed in _parseIncomePlans(rows, rejected)) {
+            mergeState(parsed.monthKey, parsed.state);
+          }
+          break;
+        case AssetLiabilityCsvRestoreSection.accountCashflow:
+          // Account cashflow exports are derived summaries; they are useful for
+          // human audit but do not restore mutable state.
+          break;
+        case AssetLiabilityCsvRestoreSection.unknown:
+          rejected.add(
+            AssetLiabilityCsvRestoreRejectedRow(
+              section: detected,
+              rowNumber: 1,
+              rawText: rows.first.join(','),
+              reason: 'CSV section could not be detected',
+            ),
+          );
+          break;
+      }
+    }
+
+    return AssetLiabilityCsvRestorePreview(
+      monthlyStates: Map<String, AssetLiabilityMonthlyState>.from(stateByMonth),
+      monthlySnapshots: snapshotsByMonth.values.toList(growable: false)
+        ..sort((a, b) => a.monthKey.compareTo(b.monthKey)),
+      rejectedRows: rejected,
+      detectedSections: detectedSections,
+    );
+  }
+
+  AssetLiabilityCsvRestoreMergeResult mergePreview({
+    required AssetLiabilityCsvRestorePreview preview,
+    required Map<String, AssetLiabilityMonthlyState> existingStates,
+    required List<AssetLiabilityMonthlySnapshot> existingSnapshots,
+    required AssetLiabilityCsvRestoreApplyPolicy policy,
+  }) {
+    if (!preview.hasRestorableRows) {
+      return AssetLiabilityCsvRestoreMergeResult(
+        monthlyStates: Map<String, AssetLiabilityMonthlyState>.from(
+          existingStates,
+        ),
+        monthlySnapshots: List<AssetLiabilityMonthlySnapshot>.from(
+          existingSnapshots,
+        ),
+        warnings: const <String>['No restorable rows were found.'],
+      );
+    }
+
+    final states = Map<String, AssetLiabilityMonthlyState>.from(existingStates);
+    final snapshotsByMonth = <String, AssetLiabilityMonthlySnapshot>{
+      for (final snapshot in existingSnapshots) snapshot.monthKey: snapshot,
+    };
+    final warnings = <String>[];
+
+    for (final entry in preview.monthlyStates.entries) {
+      final existing = states[entry.key];
+      if (policy == AssetLiabilityCsvRestoreApplyPolicy.skipExistingMonths &&
+          existing != null &&
+          !existing.isEmpty) {
+        warnings.add(
+          'Skipped ${entry.key}: existing monthly state is present.',
+        );
+        continue;
+      }
+      states[entry.key] = switch (policy) {
+        AssetLiabilityCsvRestoreApplyPolicy.appendOnly => _mergeStateAppendOnly(
+            existing ?? const AssetLiabilityMonthlyState(),
+            entry.value,
+          ),
+        AssetLiabilityCsvRestoreApplyPolicy.overwriteImportedFields =>
+          _mergeStateOverwriteImportedFields(
+            existing ?? const AssetLiabilityMonthlyState(),
+            entry.value,
+          ),
+        AssetLiabilityCsvRestoreApplyPolicy.skipExistingMonths => entry.value,
+      };
+    }
+
+    for (final snapshot in preview.monthlySnapshots) {
+      final existing = snapshotsByMonth[snapshot.monthKey];
+      if (policy == AssetLiabilityCsvRestoreApplyPolicy.skipExistingMonths &&
+          existing != null) {
+        warnings.add('Skipped ${snapshot.monthKey}: snapshot already exists.');
+        continue;
+      }
+      if (policy == AssetLiabilityCsvRestoreApplyPolicy.appendOnly &&
+          existing != null) {
+        warnings.add(
+          'Kept existing ${snapshot.monthKey}: append-only does not overwrite.',
+        );
+        continue;
+      }
+      snapshotsByMonth[snapshot.monthKey] = snapshot;
+    }
+
+    return AssetLiabilityCsvRestoreMergeResult(
+      monthlyStates: states,
+      monthlySnapshots: snapshotsByMonth.values.toList(growable: false)
+        ..sort((a, b) => a.monthKey.compareTo(b.monthKey)),
+      warnings: warnings,
+    );
+  }
+
+  AssetLiabilityCsvRestoreSection _detectSection(List<String> header) {
+    final normalized = header.map((cell) => cell.toLowerCase()).join(',');
+    if (normalized.contains('actual_paid_payment_total') ||
+        normalized.contains('payment_difference_total')) {
+      return AssetLiabilityCsvRestoreSection.monthlyHistory;
+    }
+    if (normalized.contains('payment_difference_reason') ||
+        normalized.contains('actual_payment_amount')) {
+      return AssetLiabilityCsvRestoreSection.paymentSchedule;
+    }
+    if (normalized.contains('statement_difference') ||
+        normalized.contains('billing_account_id')) {
+      return AssetLiabilityCsvRestoreSection.cardStatement;
+    }
+    if (normalized.contains('amount') && normalized.contains('received')) {
+      return AssetLiabilityCsvRestoreSection.incomePlans;
+    }
+    if (header.length == 5) {
+      return AssetLiabilityCsvRestoreSection.incomePlans;
+    }
+    if (header.length == 6) {
+      return AssetLiabilityCsvRestoreSection.accountCashflow;
+    }
+    return AssetLiabilityCsvRestoreSection.unknown;
+  }
+
+  List<AssetLiabilityMonthlySnapshot> _parseMonthlyHistory(
+    List<List<String>> rows,
+    List<AssetLiabilityCsvRestoreRejectedRow> rejected,
+  ) {
+    final snapshots = <AssetLiabilityMonthlySnapshot>[];
+    for (var i = 1; i < rows.length; i++) {
+      final row = rows[i];
+      if (row.every((cell) => cell.trim().isEmpty)) {
+        continue;
+      }
+      final monthKey = _cell(row, 0);
+      final savedAt = DateTime.tryParse(_cell(row, 1));
+      final positiveAssetTotal = _parseDouble(_cell(row, 2));
+      final liabilityTotal = _parseDouble(_cell(row, 3));
+      final netWorth = _parseDouble(_cell(row, 4));
+      final cashLikeTotal = _parseDouble(_cell(row, 5));
+      final scheduled = _parseDouble(_cell(row, 6));
+      final paid = _parseDouble(_cell(row, 7));
+      final unpaid = _parseDouble(_cell(row, 8));
+      final overdue = _parseInt(_cell(row, 9));
+      if (!_isMonthKey(monthKey) ||
+          savedAt == null ||
+          positiveAssetTotal == null ||
+          liabilityTotal == null ||
+          netWorth == null ||
+          cashLikeTotal == null ||
+          scheduled == null ||
+          paid == null ||
+          unpaid == null ||
+          overdue == null) {
+        rejected.add(
+          _rejected(
+            AssetLiabilityCsvRestoreSection.monthlyHistory,
+            i + 1,
+            row,
+            'monthly snapshot columns are invalid',
+          ),
+        );
+        continue;
+      }
+      snapshots.add(
+        AssetLiabilityMonthlySnapshot(
+          monthKey: monthKey,
+          savedAt: savedAt,
+          positiveAssetTotal: positiveAssetTotal,
+          liabilityTotal: liabilityTotal,
+          netWorth: netWorth,
+          cashLikeTotal: cashLikeTotal,
+          monthlyScheduledPaymentTotal: scheduled,
+          monthlyPaidPaymentTotal: paid,
+          monthlyUnpaidPaymentTotal: unpaid,
+          monthlyActualPaymentTotal: _parseDouble(_cell(row, 10)) ?? paid,
+          monthlyPaymentDifferenceTotal: _parseDouble(_cell(row, 11)) ?? 0,
+          overduePaymentCount: overdue,
+        ),
+      );
+    }
+    return snapshots;
+  }
+
+  List<_MonthlyStatePatch> _parsePaymentSchedule(
+    List<List<String>> rows,
+    List<AssetLiabilityCsvRestoreRejectedRow> rejected,
+  ) {
+    final patches = <_MonthlyStatePatch>[];
+    for (var i = 1; i < rows.length; i++) {
+      final row = rows[i];
+      final date = DateTime.tryParse(_cell(row, 5));
+      final accountName = _cell(row, 6);
+      final amount = _parseDouble(_cell(row, 11));
+      if (date == null || accountName.isEmpty || amount == null || amount < 0) {
+        rejected.add(
+          _rejected(
+            AssetLiabilityCsvRestoreSection.paymentSchedule,
+            i + 1,
+            row,
+            'payment date, account, or amount is invalid',
+          ),
+        );
+        continue;
+      }
+      final actual = _parseDouble(_cell(row, 16));
+      final differenceReason = _cell(row, 18);
+      final paid = actual != null || _looksPaid(_cell(row, 13));
+      patches.add(
+        _MonthlyStatePatch(
+          monthKey: AssetLiabilityMonthlyStateStore.formatMonthKey(date),
+          state: AssetLiabilityMonthlyState(
+            paymentOverrides: <String, double>{accountName: amount},
+            actualPaymentAmounts: actual == null
+                ? const <String, double>{}
+                : <String, double>{accountName: actual},
+            paymentDifferenceReasons: differenceReason.isEmpty
+                ? const <String, String>{}
+                : <String, String>{accountName: differenceReason},
+            paidAccountNames: paid ? <String>{accountName} : const <String>{},
+          ),
+        ),
+      );
+    }
+    return patches;
+  }
+
+  List<_MonthlyStatePatch> _parseIncomePlans(
+    List<List<String>> rows,
+    List<AssetLiabilityCsvRestoreRejectedRow> rejected,
+  ) {
+    final patches = <_MonthlyStatePatch>[];
+    for (var i = 1; i < rows.length; i++) {
+      final row = rows[i];
+      final date = DateTime.tryParse(_cell(row, 0));
+      final name = _cell(row, 1);
+      final amount = _parseDouble(_cell(row, 2));
+      if (date == null || name.isEmpty || amount == null || amount <= 0) {
+        rejected.add(
+          _rejected(
+            AssetLiabilityCsvRestoreSection.incomePlans,
+            i + 1,
+            row,
+            'income date, name, or amount is invalid',
+          ),
+        );
+        continue;
+      }
+      final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(date);
+      patches.add(
+        _MonthlyStatePatch(
+          monthKey: monthKey,
+          state: AssetLiabilityMonthlyState(
+            incomePlans: <AssetLiabilityIncomePlan>[
+              AssetLiabilityIncomePlan(
+                id: _stableId('income', monthKey, name, i),
+                date: date,
+                name: name,
+                amount: amount,
+                destinationAccountId: null,
+                destinationAccountName: _emptyToNull(_cell(row, 3)),
+                received: _looksPaid(_cell(row, 4)),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    return patches;
+  }
+
+  List<_MonthlyStatePatch> _parseCardStatements(
+    List<List<String>> rows,
+    List<AssetLiabilityCsvRestoreRejectedRow> rejected,
+  ) {
+    final header = rows.first.map((cell) => cell.toLowerCase()).toList();
+    final billingIndex = _indexOf(header, 'billing_account_id', fallback: 0);
+    final billingNameIndex = _indexOf(
+      header,
+      'billing_account_name',
+      fallback: 1,
+    );
+    final postedAtIndex = _indexOf(header, 'posted_at', fallback: 2);
+    final descriptionIndex = _indexOf(header, 'description', fallback: 3);
+    final amountIndex = _indexOf(header, 'amount', fallback: 4);
+    final patches = <_MonthlyStatePatch>[];
+    for (var i = 1; i < rows.length; i++) {
+      final row = rows[i];
+      final billingAccountId = _cell(row, billingIndex);
+      final description = _cell(row, descriptionIndex);
+      final amount = _parseDouble(_cell(row, amountIndex));
+      final postedAt = DateTime.tryParse(_cell(row, postedAtIndex));
+      if (billingAccountId.isEmpty || description.isEmpty || amount == null) {
+        rejected.add(
+          _rejected(
+            AssetLiabilityCsvRestoreSection.cardStatement,
+            i + 1,
+            row,
+            'card statement billing account, description, or amount is invalid',
+          ),
+        );
+        continue;
+      }
+      final month = postedAt ?? DateTime.now();
+      final monthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(month);
+      patches.add(
+        _MonthlyStatePatch(
+          monthKey: monthKey,
+          state: AssetLiabilityMonthlyState(
+            cardStatementLines: <AssetLiabilityCardStatementLine>[
+              AssetLiabilityCardStatementLine(
+                id: _stableId(
+                  'card',
+                  billingAccountId,
+                  '$description-${amount.toStringAsFixed(2)}',
+                  i,
+                ),
+                billingAccountId: billingAccountId,
+                billingAccountName: _emptyToNull(_cell(row, billingNameIndex)),
+                postedAt: postedAt,
+                description: description,
+                amount: amount,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    return patches;
+  }
+
+  AssetLiabilityMonthlyState _mergeStateAppendOnly(
+    AssetLiabilityMonthlyState existing,
+    AssetLiabilityMonthlyState patch,
+  ) {
+    return AssetLiabilityMonthlyState(
+      paymentOverrides: _appendMap(
+        existing.paymentOverrides,
+        patch.paymentOverrides,
+      ),
+      actualPaymentAmounts: _appendMap(
+        existing.actualPaymentAmounts,
+        patch.actualPaymentAmounts,
+      ),
+      paymentDifferenceReasons: _appendMap(
+        existing.paymentDifferenceReasons,
+        patch.paymentDifferenceReasons,
+      ),
+      annualRateOverrides: Map<String, double>.from(
+        existing.annualRateOverrides,
+      ),
+      annualRateEvidences: Map<String, AssetLiabilityAnnualRateEvidence>.from(
+        existing.annualRateEvidences,
+      ),
+      paidAccountNames: <String>{
+        ...existing.paidAccountNames,
+        ...patch.paidAccountNames,
+      },
+      paymentSourceAccountIds: Map<String, String>.from(
+        existing.paymentSourceAccountIds,
+      ),
+      cardBillingAccountIds: Map<String, String>.from(
+        existing.cardBillingAccountIds,
+      ),
+      cardStatementLines: _appendById(
+        existing.cardStatementLines,
+        patch.cardStatementLines,
+      ),
+      incomePlans: _appendById(existing.incomePlans, patch.incomePlans),
+      transferTasks: List<AssetLiabilityTransferTask>.from(
+        existing.transferTasks,
+      ),
+    );
+  }
+
+  AssetLiabilityMonthlyState _mergeStateOverwriteImportedFields(
+    AssetLiabilityMonthlyState existing,
+    AssetLiabilityMonthlyState patch,
+  ) {
+    return AssetLiabilityMonthlyState(
+      paymentOverrides: patch.paymentOverrides.isEmpty
+          ? Map<String, double>.from(existing.paymentOverrides)
+          : Map<String, double>.from(patch.paymentOverrides),
+      actualPaymentAmounts: patch.actualPaymentAmounts.isEmpty
+          ? Map<String, double>.from(existing.actualPaymentAmounts)
+          : Map<String, double>.from(patch.actualPaymentAmounts),
+      paymentDifferenceReasons: patch.paymentDifferenceReasons.isEmpty
+          ? Map<String, String>.from(existing.paymentDifferenceReasons)
+          : Map<String, String>.from(patch.paymentDifferenceReasons),
+      annualRateOverrides: Map<String, double>.from(
+        existing.annualRateOverrides,
+      ),
+      annualRateEvidences: Map<String, AssetLiabilityAnnualRateEvidence>.from(
+        existing.annualRateEvidences,
+      ),
+      paidAccountNames: patch.paidAccountNames.isEmpty
+          ? Set<String>.from(existing.paidAccountNames)
+          : Set<String>.from(patch.paidAccountNames),
+      paymentSourceAccountIds: Map<String, String>.from(
+        existing.paymentSourceAccountIds,
+      ),
+      cardBillingAccountIds: Map<String, String>.from(
+        existing.cardBillingAccountIds,
+      ),
+      cardStatementLines: patch.cardStatementLines.isEmpty
+          ? List<AssetLiabilityCardStatementLine>.from(
+              existing.cardStatementLines,
+            )
+          : List<AssetLiabilityCardStatementLine>.from(
+              patch.cardStatementLines,
+            ),
+      incomePlans: patch.incomePlans.isEmpty
+          ? List<AssetLiabilityIncomePlan>.from(existing.incomePlans)
+          : List<AssetLiabilityIncomePlan>.from(patch.incomePlans),
+      transferTasks: List<AssetLiabilityTransferTask>.from(
+        existing.transferTasks,
+      ),
+    );
+  }
+
+  Map<K, V> _appendMap<K, V>(Map<K, V> existing, Map<K, V> patch) {
+    return <K, V>{...patch, ...existing};
+  }
+
+  List<T> _appendById<T extends Object>(List<T> existing, List<T> patch) {
+    final result = <String, T>{};
+    for (final item in patch) {
+      result[_itemId(item)] = item;
+    }
+    for (final item in existing) {
+      result[_itemId(item)] = item;
+    }
+    return result.values.toList(growable: false);
+  }
+
+  String _itemId(Object item) {
+    if (item is AssetLiabilityIncomePlan) {
+      return item.id;
+    }
+    if (item is AssetLiabilityCardStatementLine) {
+      return item.id;
+    }
+    return item.hashCode.toString();
+  }
+
+  List<List<String>> _parseCsv(String rawText) {
+    final rows = <List<String>>[];
+    final currentRow = <String>[];
+    final currentCell = StringBuffer();
+    var inQuotes = false;
+
+    for (var i = 0; i < rawText.length; i++) {
+      final char = rawText[i];
+      if (char == '"') {
+        if (inQuotes && i + 1 < rawText.length && rawText[i + 1] == '"') {
+          currentCell.write('"');
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (char == ',' && !inQuotes) {
+        currentRow.add(currentCell.toString().trim());
+        currentCell.clear();
+      } else if ((char == '\n' || char == '\r') && !inQuotes) {
+        if (char == '\r' && i + 1 < rawText.length && rawText[i + 1] == '\n') {
+          i++;
+        }
+        currentRow.add(currentCell.toString().trim());
+        currentCell.clear();
+        if (currentRow.any((cell) => cell.isNotEmpty)) {
+          rows.add(List<String>.from(currentRow));
+        }
+        currentRow.clear();
+      } else {
+        currentCell.write(char);
+      }
+    }
+    currentRow.add(currentCell.toString().trim());
+    if (currentRow.any((cell) => cell.isNotEmpty)) {
+      rows.add(List<String>.from(currentRow));
+    }
+    return rows;
+  }
+
+  int _indexOf(List<String> header, String name, {required int fallback}) {
+    final index = header.indexOf(name);
+    return index < 0 ? fallback : index;
+  }
+
+  AssetLiabilityCsvRestoreRejectedRow _rejected(
+    AssetLiabilityCsvRestoreSection section,
+    int rowNumber,
+    List<String> row,
+    String reason,
+  ) {
+    return AssetLiabilityCsvRestoreRejectedRow(
+      section: section,
+      rowNumber: rowNumber,
+      rawText: row.map(_escapeCsvCell).join(','),
+      reason: reason,
+    );
+  }
+
+  String _cell(List<String> row, int index) {
+    if (index < 0 || index >= row.length) {
+      return '';
+    }
+    return row[index].trim();
+  }
+
+  bool _isMonthKey(String value) => RegExp(r'^\d{4}-\d{2}$').hasMatch(value);
+
+  double? _parseDouble(String raw) {
+    final normalized = raw
+        .replaceAll(',', '')
+        .replaceAll('\u00a5', '')
+        .replaceAll('\u5186', '')
+        .trim();
+    if (normalized.isEmpty) {
+      return null;
+    }
+    return double.tryParse(normalized);
+  }
+
+  int? _parseInt(String raw) {
+    final normalized = raw.replaceAll(',', '').trim();
+    if (normalized.isEmpty) {
+      return null;
+    }
+    return int.tryParse(normalized);
+  }
+
+  bool _looksPaid(String raw) {
+    final normalized = raw.toLowerCase().trim();
+    if (normalized.isEmpty) {
+      return false;
+    }
+    return normalized == 'true' ||
+        normalized == 'yes' ||
+        normalized == 'received' ||
+        normalized == 'paid' ||
+        normalized.contains('\u6e08') ||
+        normalized.contains('\u8c82');
+  }
+
+  String? _emptyToNull(String raw) {
+    final trimmed = raw.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
+  String _stableId(String prefix, String monthKey, String name, int rowNumber) {
+    final slug = '$prefix-$monthKey-$name-$rowNumber'
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '_')
+        .replaceAll(RegExp(r'_+'), '_')
+        .replaceAll(RegExp(r'^_|_$'), '');
+    return slug.isEmpty
+        ? '${prefix}_${DateFormat('yyyyMMddHHmmss').format(DateTime(1970))}_$rowNumber'
+        : slug;
+  }
+
+  String _escapeCsvCell(String value) {
+    if (value.contains(',') || value.contains('"') || value.contains('\n')) {
+      return '"${value.replaceAll('"', '""')}"';
+    }
+    return value;
+  }
+}
+
+class _MonthlyStatePatch {
+  final String monthKey;
+  final AssetLiabilityMonthlyState state;
+
+  const _MonthlyStatePatch({required this.monthKey, required this.state});
+}

--- a/test/services/asset_liability_csv_restore_service_test.dart
+++ b/test/services/asset_liability_csv_restore_service_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_csv_restore_service.dart';
+import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+
+void main() {
+  group('AssetLiabilityCsvRestoreService', () {
+    const service = AssetLiabilityCsvRestoreService();
+
+    test('previews monthly history, payment schedule, and income plans', () {
+      final preview =
+          service.previewCsvSections(<AssetLiabilityCsvRestoreSection, String>{
+        AssetLiabilityCsvRestoreSection.monthlyHistory: [
+          'month_key,saved_at,assets,liabilities,net_worth,cash,scheduled,paid,unpaid,overdue,actual_paid_payment_total,payment_difference_total',
+          '2026-05,2026-05-31 20:00:00,60000,-100000,-40000,50000,20000,6200,13800,1,6200,1200',
+        ].join('\n'),
+        AssetLiabilityCsvRestoreSection.paymentSchedule: [
+          'category,alerts,direct_target,source,billing_card,date,account,source_account,method,card_billed,direct_cashflow,amount,estimate_state,paid_state,overdue,cash_after,actual_payment_amount,payment_difference_amount,payment_difference_reason',
+          'direct,ok,target,manual,,2026-05-20,"auPay card",Bank,direct,direct,target,5000,actual,paid,,45000,6200,1200,"late fee, adjustment"',
+        ].join('\n'),
+        AssetLiabilityCsvRestoreSection.incomePlans: [
+          'date,name,amount,destination,received',
+          '2026-05-25,"副業,臨時収入",30000,main bank,yes',
+        ].join('\n'),
+      });
+
+      expect(preview.rejectedRows, isEmpty);
+      expect(preview.monthlySnapshots.single.monthKey, '2026-05');
+      expect(preview.monthlySnapshots.single.monthlyActualPaymentTotal, 6200);
+      expect(preview.affectedMonthKeys, <String>['2026-05']);
+
+      final mayState = preview.monthlyStates['2026-05']!;
+      expect(mayState.paymentOverrides['auPay card'], 5000);
+      expect(mayState.actualPaymentAmounts['auPay card'], 6200);
+      expect(
+        mayState.paymentDifferenceReasons['auPay card'],
+        'late fee, adjustment',
+      );
+      expect(mayState.paidAccountNames, contains('auPay card'));
+      expect(mayState.incomePlans.single.name, '副業,臨時収入');
+      expect(mayState.incomePlans.single.received, isTrue);
+    });
+
+    test('keeps existing state unless an explicit overwrite policy is used',
+        () {
+      final preview =
+          service.previewCsvSections(<AssetLiabilityCsvRestoreSection, String>{
+        AssetLiabilityCsvRestoreSection.paymentSchedule: [
+          'category,alerts,direct_target,source,billing_card,date,account,source_account,method,card_billed,direct_cashflow,amount,estimate_state,paid_state,overdue,cash_after,actual_payment_amount,payment_difference_amount,payment_difference_reason',
+          'direct,ok,target,manual,,2026-05-20,mobit,Bank,direct,direct,target,70000,actual,paid,,0,70000,0,',
+        ].join('\n'),
+      });
+      final existing = AssetLiabilityMonthlyState(
+        paymentOverrides: <String, double>{'mobit': 60000},
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'existing_salary',
+            date: DateTime(2026, 5, 25),
+            name: 'Salary',
+            amount: 250000,
+            destinationAccountId: 'bank',
+            destinationAccountName: 'Bank',
+            received: false,
+          ),
+        ],
+      );
+
+      final appendOnly = service.mergePreview(
+        preview: preview,
+        existingStates: <String, AssetLiabilityMonthlyState>{
+          '2026-05': existing,
+        },
+        existingSnapshots: const <AssetLiabilityMonthlySnapshot>[],
+        policy: AssetLiabilityCsvRestoreApplyPolicy.appendOnly,
+      );
+      expect(
+        appendOnly.monthlyStates['2026-05']!.paymentOverrides['mobit'],
+        60000,
+      );
+      expect(
+        appendOnly.monthlyStates['2026-05']!.incomePlans.single.name,
+        'Salary',
+      );
+
+      final overwrite = service.mergePreview(
+        preview: preview,
+        existingStates: <String, AssetLiabilityMonthlyState>{
+          '2026-05': existing,
+        },
+        existingSnapshots: const <AssetLiabilityMonthlySnapshot>[],
+        policy: AssetLiabilityCsvRestoreApplyPolicy.overwriteImportedFields,
+      );
+      expect(
+        overwrite.monthlyStates['2026-05']!.paymentOverrides['mobit'],
+        70000,
+      );
+      expect(
+        overwrite.monthlyStates['2026-05']!.incomePlans.single.name,
+        'Salary',
+      );
+    });
+
+    test('rejects malformed CSV rows without mutating existing data', () {
+      final preview =
+          service.previewCsvSections(<AssetLiabilityCsvRestoreSection, String>{
+        AssetLiabilityCsvRestoreSection.monthlyHistory: [
+          'month_key,saved_at,assets,liabilities,net_worth,cash,scheduled,paid,unpaid,overdue,actual_paid_payment_total,payment_difference_total',
+          'bad-month,not-date,invalid,-100000,-40000,50000,20000,6200,13800,1,6200,1200',
+        ].join('\n'),
+      });
+
+      expect(preview.hasRestorableRows, isFalse);
+      expect(preview.rejectedRows.single.reason, contains('invalid'));
+
+      const existing = AssetLiabilityMonthlyState(
+        paymentOverrides: <String, double>{'paypay_card': 12000},
+      );
+      final merged = service.mergePreview(
+        preview: preview,
+        existingStates: const <String, AssetLiabilityMonthlyState>{
+          '2026-05': existing,
+        },
+        existingSnapshots: const <AssetLiabilityMonthlySnapshot>[],
+        policy: AssetLiabilityCsvRestoreApplyPolicy.overwriteImportedFields,
+      );
+
+      expect(
+        merged.monthlyStates['2026-05']!.paymentOverrides['paypay_card'],
+        12000,
+      );
+      expect(merged.warnings.single, contains('No restorable rows'));
+    });
+
+    test('restores escaped card statement fields with Japanese text', () {
+      final preview =
+          service.previewCsvSections(<AssetLiabilityCsvRestoreSection, String>{
+        AssetLiabilityCsvRestoreSection.cardStatement: [
+          'billing_account_id,billing_account_name,posted_at,description,amount,billed_amount,statement_line_total,configured_detail_total,statement_difference,configured_difference,review_alerts',
+          'paypay_card,PayPay,2026-05-12,"通信費 ""家族,共有""",5764,10000,5764,5764,-4236,-4236,',
+        ].join('\n'),
+      });
+
+      expect(preview.rejectedRows, isEmpty);
+      final line = preview.monthlyStates['2026-05']!.cardStatementLines.single;
+      expect(line.billingAccountId, 'paypay_card');
+      expect(line.description, '通信費 "家族,共有"');
+      expect(line.amount, 5764);
+      expect(line.postedAt, DateTime(2026, 5, 12));
+    });
+  });
+}


### PR DESCRIPTION
﻿## Summary
- Add a CSV restore service for asset-liability monthly backups with section detection, quoted-field parsing, reject rows, and append-only/overwrite/skip merge policies.
- Add a compact CSV restore panel to the monthly snapshot section so imports must be previewed before the append-only apply action is enabled.
- Cover monthly history, payment schedule, income plan, and card statement restore paths with tests for malformed rows, escaping, and Japanese text.

## Validation
- `PUB_CACHE=C:\Users\kanta\GitHub\.pub-cache-codex1-2455 dart analyze --no-fatal-warnings lib\services\asset_liability_csv_restore_service.dart test\services\asset_liability_csv_restore_service_test.dart lib\pages\asset_management_page.dart`
- `PUB_CACHE=C:\Users\kanta\GitHub\.pub-cache-codex1-2455 flutter test --no-pub test\services\asset_liability_csv_restore_service_test.dart`
- `git diff --check HEAD~1..HEAD`
- CI: Lint/Format/Test, Security Check, GA readiness gate, Public E2E stability smoke passed on PR #2943 initial run.

## Minimal E2E Gate
- E2E-Exception: no browser/integration_test file was added because this slice is deterministic CSV parsing/merge plus a small existing-page control surface; focused service tests cover the behavior.
- The E2E review plan is implementation-detail independent / black-box and minimal: three I/O cases are checked by tests and reviewer inspection.
- Three cases: valid exported CSV restores preview rows, invalid CSV is rejected without mutating existing data, and escaped Japanese fields round-trip through preview/merge.
- E2E mechanism noted for the gate: no Playwright or flutter integration_test was needed; Public E2E stability smoke still runs as the repository-level smoke.

## High-risk Ultrareview Gate
- Claude Code #1 review owner: Claude Code #1 is named as the high-risk review owner for the gate contract.
- High-risk-ultrareview-exception: no Claude ultrareview was requested because the PR has no auth/payment provider changes, no production deploy workflow changes, no Supabase migration, and no external side effects; the title/body only mention payment-domain CSV data.
- Coverage considered: security is local append-only only, rollback is branch revert, data migration is none, prod smoke is repository Public E2E stability smoke, and observability is unchanged.
- Unresolved ultrareview findings: 0/none.

## Risk / cleanup notes
- Apply is user-triggered, local repository scoped, append-only by default, and does not expose destructive overwrite from the UI.
- 2-instance policy: Codex #1 lead only; no subagents were spawned for this PR.
- Local verification used a temporary PUB_CACHE because the normal Pub cache was being reclaimed by hygiene cleanup during validation.

Closes #2455
