### PR TITLE
ci: add monthly asset report cron (#2462)

### DIFF
--- a/.github/workflows/monthly-asset-report.yml
+++ b/.github/workflows/monthly-asset-report.yml
@@ -1,0 +1,98 @@
+name: Monthly Asset Report
+
+on:
+  schedule:
+    # Month-end 24:00 JST is 15:00 UTC. The script gates daily runs to
+    # the JST month rollover because GitHub cron has no last-day syntax.
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+    inputs:
+      year_month:
+        description: "Optional target month (YYYY-MM). Defaults to the previous JST month."
+        required: false
+        default: ""
+      force:
+        description: "Run even when today is not the JST month rollover."
+        required: false
+        default: "false"
+      dry_run:
+        description: "Call the EF with dry_run=true."
+        required: false
+        default: "true"
+      enable_ai_summary:
+        description: "Enable LLM summary generation. Default keeps #2461 AI flag off."
+        required: false
+        default: "false"
+      provider:
+        description: "Provider preference for AI summary when enabled."
+        required: false
+        default: "google"
+      strict_secrets:
+        description: "Fail instead of skip when required auth secrets are missing."
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: monthly-asset-report
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    name: Generate month-end asset report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD || 'https://smmkxxavexumewbfaqpy.supabase.co' }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_PROD || secrets.SUPABASE_ANON_KEY }}
+      ASSET_MONTHLY_REPORT_USER_JWT: ${{ secrets.ASSET_MONTHLY_REPORT_USER_JWT }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      CRON_ENABLED: ${{ github.event_name == 'workflow_dispatch' && 'true' || vars.ASSET_MONTHLY_REPORT_CRON_ENABLED || 'false' }}
+      YEAR_MONTH: ${{ github.event_name == 'workflow_dispatch' && inputs.year_month || '' }}
+      FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force || 'false' }}
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || vars.ASSET_MONTHLY_REPORT_DRY_RUN || 'false' }}
+      ENABLE_AI_SUMMARY: ${{ github.event_name == 'workflow_dispatch' && inputs.enable_ai_summary || 'false' }}
+      PROVIDER: ${{ github.event_name == 'workflow_dispatch' && inputs.provider || vars.ASSET_MONTHLY_REPORT_PROVIDER || 'google' }}
+      STRICT_SECRETS: ${{ github.event_name == 'workflow_dispatch' && inputs.strict_secrets || 'false' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Call monthly asset report EF
+        run: |
+          mkdir -p tmp/monthly-asset-report
+          python scripts/monthly_asset_report_cron.py \
+            --supabase-url "$SUPABASE_URL" \
+            --anon-key "$SUPABASE_ANON_KEY" \
+            --user-jwt "$ASSET_MONTHLY_REPORT_USER_JWT" \
+            --cron-enabled "$CRON_ENABLED" \
+            --manual-run "${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}" \
+            --force "$FORCE" \
+            --dry-run "$DRY_RUN" \
+            --enable-ai-summary "$ENABLE_AI_SUMMARY" \
+            --strict-secrets "$STRICT_SECRETS" \
+            --year-month "$YEAR_MONTH" \
+            --provider "$PROVIDER" \
+            --slack-webhook-url "$SLACK_WEBHOOK_URL" \
+            --discord-webhook-url "$DISCORD_WEBHOOK_URL" \
+            --report tmp/monthly-asset-report/report.json \
+            --summary-md tmp/monthly-asset-report/summary.md
+          cat tmp/monthly-asset-report/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload monthly asset report artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: monthly-asset-report
+          path: tmp/monthly-asset-report
+          if-no-files-found: ignore

--- a/scripts/monthly_asset_report_cron.py
+++ b/scripts/monthly_asset_report_cron.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Run the month-end asset report Edge Function from GitHub Actions.
+
+The workflow is intentionally staged:
+- scheduled runs are disabled until ASSET_MONTHLY_REPORT_CRON_ENABLED=true,
+- user JWT auth must be supplied via ASSET_MONTHLY_REPORT_USER_JWT,
+- AI summaries stay off unless explicitly enabled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from zoneinfo import ZoneInfo
+
+
+DEFAULT_SUPABASE_URL = "https://smmkxxavexumewbfaqpy.supabase.co"
+ISSUE = "#2462"
+JST = ZoneInfo("Asia/Tokyo")
+YEAR_MONTH_PATTERN = re.compile(r"^\d{4}-\d{2}$")
+
+
+@dataclass(frozen=True)
+class CronConfig:
+    supabase_url: str
+    anon_key: str
+    user_jwt: str
+    cron_enabled: bool
+    manual_run: bool
+    force: bool
+    dry_run: bool
+    enable_ai_summary: bool
+    strict_secrets: bool
+    year_month: str
+    provider: str
+    timeout: int
+    slack_webhook_url: str
+    discord_webhook_url: str
+
+
+class MonthlyAssetReportCronError(RuntimeError):
+    pass
+
+
+def parse_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", ""}:
+        return False
+    return default
+
+
+def month_rollover_jst(now: datetime) -> bool:
+    now_jst = now.astimezone(JST)
+    return now_jst.day == 1
+
+
+def previous_month_key(now: datetime) -> str:
+    now_jst = now.astimezone(JST)
+    year = now_jst.year
+    month = now_jst.month - 1
+    if month == 0:
+        year -= 1
+        month = 12
+    return f"{year:04d}-{month:02d}"
+
+
+def normalize_year_month(value: str, now: datetime) -> str:
+    text = value.strip()
+    if not text:
+        return previous_month_key(now)
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", text):
+        text = text[:7]
+    if not YEAR_MONTH_PATTERN.match(text):
+        raise MonthlyAssetReportCronError("year_month must be YYYY-MM or YYYY-MM-DD")
+    month = int(text[5:7])
+    if month < 1 or month > 12:
+        raise MonthlyAssetReportCronError("year_month month is invalid")
+    return text
+
+
+def normalize_base_url(value: str) -> str:
+    return (value or DEFAULT_SUPABASE_URL).rstrip("/")
+
+
+def build_payload(config: CronConfig, target_month: str, run_id: str) -> dict[str, Any]:
+    return {
+        "action": "asset.monthly_report.generate",
+        "year_month": target_month,
+        "dry_run": config.dry_run,
+        "enable_ai_summary": config.enable_ai_summary,
+        "provider_preference": config.provider or "google",
+        "routing_use_case": "asset_monthly_report_cron",
+        "provider_choice_reason": "month-end scheduled asset report cron (#2462)",
+        "trace_id": run_id,
+    }
+
+
+def request_json(
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    timeout: int,
+) -> tuple[int, dict[str, Any]]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        body = response.read().decode("utf-8", errors="replace")
+        parsed = json.loads(body) if body.strip() else {}
+        if not isinstance(parsed, dict):
+            raise MonthlyAssetReportCronError("Edge Function response must be a JSON object")
+        return int(response.status), parsed
+
+
+def post_json(url: str, payload: dict[str, Any], timeout: int) -> None:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        response.read()
+
+
+def build_failure_text(report: dict[str, Any]) -> str:
+    reason = report.get("reason") or report.get("error") or "unknown"
+    target_month = report.get("target_month", "unknown")
+    return (
+        f"Monthly asset report cron failed ({ISSUE})\n"
+        f"- target_month: {target_month}\n"
+        f"- reason: {reason}"
+    )
+
+
+def notify_failure(
+    config: CronConfig,
+    report: dict[str, Any],
+    *,
+    poster: Callable[[str, dict[str, Any], int], None] = post_json,
+) -> list[str]:
+    delivered: list[str] = []
+    text = build_failure_text(report)
+    if config.slack_webhook_url:
+        try:
+            poster(config.slack_webhook_url, {"text": text}, min(config.timeout, 10))
+            delivered.append("slack")
+        except Exception as exc:  # pragma: no cover - transport failures vary.
+            delivered.append(f"slack_error:{exc}")
+    if config.discord_webhook_url:
+        try:
+            poster(config.discord_webhook_url, {"content": text}, min(config.timeout, 10))
+            delivered.append("discord")
+        except Exception as exc:  # pragma: no cover - transport failures vary.
+            delivered.append(f"discord_error:{exc}")
+    return delivered
+
+
+def build_report(
+    config: CronConfig,
+    *,
+    now: datetime | None = None,
+    requester: Callable[[str, dict[str, Any], dict[str, str], int], tuple[int, dict[str, Any]]] = request_json,
+) -> dict[str, Any]:
+    current = now or datetime.now(timezone.utc)
+    target_month = normalize_year_month(config.year_month, current)
+    run_id = f"asset-monthly-report-{target_month}-{int(current.timestamp())}"
+
+    if not config.manual_run and not config.cron_enabled:
+        return {
+            "status": "skipped",
+            "reason": "feature_flag_off",
+            "issue": ISSUE,
+            "target_month": target_month,
+            "dry_run": config.dry_run,
+        }
+
+    if (
+        not config.manual_run and not config.force and not config.year_month and
+        not month_rollover_jst(current)
+    ):
+        return {
+            "status": "skipped",
+            "reason": "not_month_rollover_jst",
+            "issue": ISSUE,
+            "target_month": target_month,
+            "dry_run": config.dry_run,
+        }
+
+    if not config.user_jwt:
+        status = "fail" if (
+            config.strict_secrets or (config.cron_enabled and not config.manual_run)
+        ) else "skipped"
+        return {
+            "status": status,
+            "reason": "missing_ASSET_MONTHLY_REPORT_USER_JWT",
+            "issue": ISSUE,
+            "target_month": target_month,
+            "dry_run": config.dry_run,
+        }
+
+    endpoint = f"{normalize_base_url(config.supabase_url)}/functions/v1/ai-hub"
+    payload = build_payload(config, target_month, run_id)
+    api_key = config.anon_key or config.user_jwt
+    headers = {
+        "apikey": api_key,
+        "Authorization": f"Bearer {config.user_jwt}",
+        "Content-Type": "application/json",
+        "User-Agent": "my-web-app-monthly-asset-report-cron/1.0",
+    }
+
+    try:
+        http_status, response = requester(endpoint, payload, headers, config.timeout)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return {
+            "status": "fail",
+            "reason": f"http_{exc.code}",
+            "error": body[:1000],
+            "issue": ISSUE,
+            "target_month": target_month,
+            "dry_run": config.dry_run,
+            "payload": safe_payload(payload),
+        }
+    except Exception as exc:
+        return {
+            "status": "fail",
+            "reason": "request_error",
+            "error": str(exc),
+            "issue": ISSUE,
+            "target_month": target_month,
+            "dry_run": config.dry_run,
+            "payload": safe_payload(payload),
+        }
+
+    success = response.get("success") is True
+    return {
+        "status": "pass" if success else "fail",
+        "reason": "edge_function_success" if success else "edge_function_error",
+        "issue": ISSUE,
+        "target_month": target_month,
+        "dry_run": config.dry_run,
+        "http_status": http_status,
+        "payload": safe_payload(payload),
+        "response": response,
+    }
+
+
+def safe_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if key not in {"snapshot"}}
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Monthly Asset Report Cron",
+        "",
+        f"- Issue: `{report.get('issue', ISSUE)}`",
+        f"- Status: `{report.get('status', 'unknown')}`",
+        f"- Reason: `{report.get('reason', 'unknown')}`",
+        f"- Target month: `{report.get('target_month', 'unknown')}`",
+        f"- Dry run: `{str(report.get('dry_run', False)).lower()}`",
+    ]
+    response = report.get("response")
+    if isinstance(response, dict):
+        lines.extend(
+            [
+                f"- EF status: `{response.get('status', 'unknown')}`",
+                f"- AI enabled: `{str(response.get('ai_enabled', False)).lower()}`",
+                f"- AI model: `{response.get('ai_model', 'n/a')}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(report: dict[str, Any], report_path: str, summary_path: str) -> None:
+    if report_path:
+        path = Path(report_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    if summary_path:
+        path = Path(summary_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(render_markdown(report), encoding="utf-8", newline="\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--supabase-url", default=os.environ.get("SUPABASE_URL", DEFAULT_SUPABASE_URL))
+    parser.add_argument("--anon-key", default=os.environ.get("SUPABASE_ANON_KEY", ""))
+    parser.add_argument("--user-jwt", default=os.environ.get("ASSET_MONTHLY_REPORT_USER_JWT", ""))
+    parser.add_argument("--cron-enabled", default=os.environ.get("ASSET_MONTHLY_REPORT_CRON_ENABLED", "false"))
+    parser.add_argument("--manual-run", default=os.environ.get("ASSET_MONTHLY_REPORT_MANUAL_RUN", "false"))
+    parser.add_argument("--force", default=os.environ.get("ASSET_MONTHLY_REPORT_FORCE", "false"))
+    parser.add_argument("--dry-run", default=os.environ.get("ASSET_MONTHLY_REPORT_DRY_RUN", "false"))
+    parser.add_argument("--enable-ai-summary", default=os.environ.get("ASSET_MONTHLY_REPORT_AI_ENABLED", "false"))
+    parser.add_argument("--strict-secrets", default=os.environ.get("ASSET_MONTHLY_REPORT_STRICT_SECRETS", "false"))
+    parser.add_argument("--year-month", default=os.environ.get("ASSET_MONTHLY_REPORT_YEAR_MONTH", ""))
+    parser.add_argument("--provider", default=os.environ.get("ASSET_MONTHLY_REPORT_PROVIDER", "google"))
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--slack-webhook-url", default=os.environ.get("SLACK_WEBHOOK_URL", ""))
+    parser.add_argument("--discord-webhook-url", default=os.environ.get("DISCORD_WEBHOOK_URL", ""))
+    parser.add_argument("--report", default="")
+    parser.add_argument("--summary-md", default="")
+    return parser
+
+
+def config_from_args(args: argparse.Namespace) -> CronConfig:
+    return CronConfig(
+        supabase_url=args.supabase_url,
+        anon_key=args.anon_key.strip(),
+        user_jwt=args.user_jwt.strip(),
+        cron_enabled=parse_bool(args.cron_enabled),
+        manual_run=parse_bool(args.manual_run),
+        force=parse_bool(args.force),
+        dry_run=parse_bool(args.dry_run),
+        enable_ai_summary=parse_bool(args.enable_ai_summary),
+        strict_secrets=parse_bool(args.strict_secrets),
+        year_month=args.year_month.strip(),
+        provider=args.provider.strip() or "google",
+        timeout=args.timeout,
+        slack_webhook_url=args.slack_webhook_url.strip(),
+        discord_webhook_url=args.discord_webhook_url.strip(),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = config_from_args(args)
+    report = build_report(config)
+    if report["status"] == "fail":
+        report["notifications"] = notify_failure(config, report)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    write_outputs(report, args.report, args.summary_md)
+    return 1 if report["status"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/scripts/test_monthly_asset_report_cron.py
+++ b/test/scripts/test_monthly_asset_report_cron.py
@@ -1,0 +1,148 @@
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts import monthly_asset_report_cron
+
+
+def config(**overrides):
+    values = {
+        "supabase_url": "https://example.supabase.co",
+        "anon_key": "anon",
+        "user_jwt": "jwt",
+        "cron_enabled": True,
+        "manual_run": False,
+        "force": False,
+        "dry_run": False,
+        "enable_ai_summary": False,
+        "strict_secrets": False,
+        "year_month": "",
+        "provider": "google",
+        "timeout": 3,
+        "slack_webhook_url": "",
+        "discord_webhook_url": "",
+    }
+    values.update(overrides)
+    return monthly_asset_report_cron.CronConfig(**values)
+
+
+class MonthlyAssetReportCronTest(unittest.TestCase):
+    def test_month_rollover_and_previous_month_use_jst(self) -> None:
+        now = datetime(2026, 6, 30, 15, 0, tzinfo=timezone.utc)
+
+        self.assertTrue(monthly_asset_report_cron.month_rollover_jst(now))
+        self.assertEqual(monthly_asset_report_cron.previous_month_key(now), "2026-06")
+
+    def test_scheduled_run_skips_when_feature_flag_is_off(self) -> None:
+        report = monthly_asset_report_cron.build_report(
+            config(cron_enabled=False),
+            now=datetime(2026, 6, 30, 15, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(report["status"], "skipped")
+        self.assertEqual(report["reason"], "feature_flag_off")
+
+    def test_scheduled_run_skips_non_month_rollover(self) -> None:
+        report = monthly_asset_report_cron.build_report(
+            config(),
+            now=datetime(2026, 6, 29, 15, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(report["status"], "skipped")
+        self.assertEqual(report["reason"], "not_month_rollover_jst")
+
+    def test_missing_user_jwt_fails_when_cron_enabled(self) -> None:
+        report = monthly_asset_report_cron.build_report(
+            config(user_jwt=""),
+            now=datetime(2026, 6, 30, 15, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(report["status"], "fail")
+        self.assertEqual(report["reason"], "missing_ASSET_MONTHLY_REPORT_USER_JWT")
+
+    def test_payload_calls_ai_hub_with_guarded_defaults(self) -> None:
+        calls = []
+
+        def requester(url, payload, headers, timeout):
+            calls.append((url, payload, headers, timeout))
+            return 200, {
+                "success": True,
+                "status": "feature_flag_off",
+                "ai_enabled": False,
+                "ai_model": "deterministic-fallback",
+            }
+
+        report = monthly_asset_report_cron.build_report(
+            config(),
+            now=datetime(2026, 6, 30, 15, 0, tzinfo=timezone.utc),
+            requester=requester,
+        )
+
+        self.assertEqual(report["status"], "pass")
+        url, payload, headers, timeout = calls[0]
+        self.assertEqual(url, "https://example.supabase.co/functions/v1/ai-hub")
+        self.assertEqual(payload["action"], "asset.monthly_report.generate")
+        self.assertEqual(payload["year_month"], "2026-06")
+        self.assertFalse(payload["enable_ai_summary"])
+        self.assertFalse(payload["dry_run"])
+        self.assertEqual(headers["Authorization"], "Bearer jwt")
+        self.assertEqual(headers["apikey"], "anon")
+        self.assertEqual(timeout, 3)
+
+    def test_manual_run_allows_explicit_month_and_dry_run(self) -> None:
+        def requester(_url, payload, _headers, _timeout):
+            self.assertEqual(payload["year_month"], "2026-05")
+            self.assertTrue(payload["dry_run"])
+            return 200, {"success": True, "status": "feature_flag_off"}
+
+        report = monthly_asset_report_cron.build_report(
+            config(
+                cron_enabled=False,
+                manual_run=True,
+                year_month="2026-05",
+                dry_run=True,
+            ),
+            now=datetime(2026, 6, 10, 2, 0, tzinfo=timezone.utc),
+            requester=requester,
+        )
+
+        self.assertEqual(report["status"], "pass")
+
+    def test_manual_run_without_secret_skips_unless_strict(self) -> None:
+        report = monthly_asset_report_cron.build_report(
+            config(manual_run=True, user_jwt=""),
+            now=datetime(2026, 6, 10, 2, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(report["status"], "skipped")
+        self.assertEqual(report["reason"], "missing_ASSET_MONTHLY_REPORT_USER_JWT")
+
+    def test_cli_writes_report_and_summary_for_safe_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report_path = root / "report.json"
+            summary_path = root / "summary.md"
+            rc = monthly_asset_report_cron.main(
+                [
+                    "--cron-enabled",
+                    "false",
+                    "--report",
+                    str(report_path),
+                    "--summary-md",
+                    str(summary_path),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["status"], "skipped")
+            self.assertIn("Monthly Asset Report Cron", summary_path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- Adds a staged month-end GitHub Actions cron for #2462 that calls `ai-hub` with `asset.monthly_report.generate`.
- Adds a dependency-free Python harness with JST month-rollover gating, feature-flagged schedule enablement, user JWT auth checks, report artifacts, and best-effort Slack/Discord failure notification.
- Adds unit coverage for month rollover selection, safe skips, auth failure behavior, guarded payload defaults, and CLI artifact output.

## Safety / rollout
- Scheduled runs are inert until `ASSET_MONTHLY_REPORT_CRON_ENABLED=true` is configured.
- `ASSET_MONTHLY_REPORT_USER_JWT` is required for real EF calls; missing credentials skip manual dry-runs and fail enabled scheduled runs.
- AI summaries remain off by default; the workflow only enables them when `enable_ai_summary=true` is explicitly passed.
- No subagents were used for this implementation; guarded subagent orchestration evidence: lead owner Codex #1, no child workers spawned, cleanup handled locally.

## Validation
- `python test\scripts\test_monthly_asset_report_cron.py`
- `python -m py_compile scripts\monthly_asset_report_cron.py test\scripts\test_monthly_asset_report_cron.py`
- `python scripts\monthly_asset_report_cron.py --manual-run true --dry-run true --cron-enabled false --year-month 2026-06`
- `git diff --check`

## Minimal E2E Gate
- Implementation-detail independent black-box I/O plan.
- Minimal 3 cases: feature flag off scheduled skip, missing user JWT auth guard, successful EF payload construction.
- E2E mechanism: workflow_dispatch/manual cron dry-run plus Python harness artifact output; no Flutter Integration Test or Playwright file is added because this is workflow/scripts-only automation.
- E2E-Exception: workflow-only cron harness change; app runtime files are unchanged and production writes remain feature-flagged.

## High-risk Ultrareview Gate
- Review owner: Claude Code #1.
- High-risk-ultrareview-exception: workflow-only automation; production write path is feature-flagged, requires `ASSET_MONTHLY_REPORT_USER_JWT`, and has deterministic unit coverage.
- Security: user JWT is read only from GitHub Secrets, never logged, and missing credentials fail enabled scheduled runs or skip manual dry-runs.
- Data migration: none; this PR only calls the existing #2461 EF and does not alter schema or RLS.
- Prod smoke: local dry-run exercised the script path without credentials; post-merge workflow dispatch can run dry-run before enabling schedule writes.
- Observability: JSON/Markdown artifacts are uploaded and Slack/Discord failure notification is attempted when configured.
- Rollback: disable `ASSET_MONTHLY_REPORT_CRON_ENABLED`, or revert/remove `.github/workflows/monthly-asset-report.yml`.
- No unresolved findings.

Closes #2462
