### PR TITLE
feat(asset): add monthly report UI (#2463)

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -98,9 +98,7 @@ class AssetLiabilityAnnualRateEvidence {
     };
   }
 
-  static AssetLiabilityAnnualRateEvidence? fromJson(
-    Map<String, Object?> json,
-  ) {
+  static AssetLiabilityAnnualRateEvidence? fromJson(Map<String, Object?> json) {
     final accountId = json['accountId']?.toString().trim() ??
         json['account_id']?.toString().trim();
     final fileName = json['fileName']?.toString().trim() ??
@@ -541,6 +539,26 @@ class AssetLiabilityMonthlySnapshot {
     this.monthlyActualPaymentTotal = 0,
     this.monthlyPaymentDifferenceTotal = 0,
     required this.overduePaymentCount,
+  });
+}
+
+class AssetLiabilityMonthlyReport {
+  final String monthKey;
+  final DateTime generatedAt;
+  final double totalAssets;
+  final double totalLiabilities;
+  final double netWorth;
+  final String aiSummary;
+  final String aiModel;
+
+  const AssetLiabilityMonthlyReport({
+    required this.monthKey,
+    required this.generatedAt,
+    required this.totalAssets,
+    required this.totalLiabilities,
+    required this.netWorth,
+    required this.aiSummary,
+    required this.aiModel,
   });
 }
 

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -22,6 +22,7 @@ import 'package:my_web_app/services/asset_liability_annual_rate_evidence_service
 import 'package:my_web_app/services/asset_liability_card_statement_import_service.dart';
 import 'package:my_web_app/services/asset_liability_csv_restore_service.dart';
 import 'package:my_web_app/services/asset_liability_history_service.dart';
+import 'package:my_web_app/services/asset_liability_monthly_report_service.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 import 'package:my_web_app/services/asset_liability_payment_reminder_service.dart';
 import 'package:my_web_app/services/asset_liability_planning_service.dart';
@@ -137,6 +138,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       <AssetLiabilityRecurringIncomeTemplate>[];
   List<AssetLiabilityMonthlySnapshot> _monthlySnapshots =
       <AssetLiabilityMonthlySnapshot>[];
+  List<AssetLiabilityMonthlyReport> _monthlyReports =
+      <AssetLiabilityMonthlyReport>[];
+  String? _selectedMonthlyReportMonthKey;
+  bool _isRefreshingMonthlyReports = false;
+  String? _monthlyReportMessage;
   String? _loadedAssetLiabilityMonthKey;
   bool _isSavingAssetLiabilitySnapshot = false;
   bool _isRunningAssetLiabilitySync = false;
@@ -235,6 +241,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetLiabilityAnnualRateEvidenceService();
   final AssetLiabilityHistoryService _assetLiabilityHistoryService =
       const AssetLiabilityHistoryService();
+  final AssetLiabilityMonthlyReportService _assetLiabilityMonthlyReportService =
+      const AssetLiabilityMonthlyReportService();
   final AssetManagementInsightService _assetManagementInsightService =
       const AssetManagementInsightService();
   final AssetManagementAiSummaryService _assetManagementAiSummaryService =
@@ -887,6 +895,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           await _assetLiabilityRepository.loadRecurringIncomeTemplates();
       final monthlySnapshots =
           await _assetLiabilityRepository.loadMonthlySnapshots();
+      final monthlyReports = await _assetLiabilityRepository.loadMonthlyReports(
+        limit: 24,
+      );
       final syncAuditLogs = await _assetLiabilityRepository.loadSyncAuditLogs(
         limit: 12,
       );
@@ -943,6 +954,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _monthlySnapshots = List<AssetLiabilityMonthlySnapshot>.from(
           monthlySnapshots,
         );
+        _monthlyReports = List<AssetLiabilityMonthlyReport>.from(
+          monthlyReports,
+        );
+        _monthlyReportMessage = null;
         _assetLiabilitySyncAuditLogs = List<AssetLiabilitySyncAuditLog>.from(
           syncAuditLogs,
         );
@@ -968,6 +983,37 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       });
     } catch (e) {
       debugPrint('Error loading asset liability sync audit logs: $e');
+    }
+  }
+
+  Future<void> _refreshMonthlyAssetReports() async {
+    setState(() {
+      _isRefreshingMonthlyReports = true;
+      _monthlyReportMessage = null;
+    });
+    try {
+      final reports = await _assetLiabilityRepository.loadMonthlyReports(
+        limit: 24,
+      );
+      if (!mounted) return;
+      setState(() {
+        _monthlyReports = List<AssetLiabilityMonthlyReport>.from(reports);
+        _monthlyReportMessage = reports.isEmpty
+            ? 'No generated monthly AI reports were found. Local snapshots remain available.'
+            : 'Monthly reports refreshed.';
+      });
+    } catch (e) {
+      debugPrint('Error loading monthly asset reports: $e');
+      if (!mounted) return;
+      setState(() {
+        _monthlyReportMessage = 'Monthly report refresh failed: $e';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isRefreshingMonthlyReports = false;
+        });
+      }
     }
   }
 
@@ -7670,6 +7716,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             const SizedBox(height: 16),
             _buildMonthlySnapshotSection(workbook),
             const SizedBox(height: 16),
+            _buildMonthlyReportSection(),
+            const SizedBox(height: 16),
             _buildTransferSuggestionSection(workbook),
             const SizedBox(height: 16),
             _buildAssetWorkbookDebtTable(workbook),
@@ -11160,6 +11208,407 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  Widget _buildMonthlyReportSection() {
+    final theme = Theme.of(context);
+    final reportViews = _assetLiabilityMonthlyReportService.buildReportViews(
+      snapshots: _monthlySnapshots,
+      reports: _monthlyReports,
+    );
+    AssetLiabilityMonthlyReportView? selectedReport;
+    for (final view in reportViews) {
+      if (view.monthKey == _selectedMonthlyReportMonthKey) {
+        selectedReport = view;
+        break;
+      }
+    }
+    selectedReport ??= reportViews.isEmpty ? null : reportViews.first;
+    final selectedIndex = selectedReport == null
+        ? -1
+        : reportViews.indexWhere(
+            (view) => view.monthKey == selectedReport!.monthKey,
+          );
+
+    return Container(
+      key: const Key('asset_monthly_report_section'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.summarize_outlined, size: 20),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  'Monthly asset reports',
+                  style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+                ),
+              ),
+              IconButton(
+                tooltip: 'Refresh monthly reports',
+                onPressed: _isRefreshingMonthlyReports
+                    ? null
+                    : _refreshMonthlyAssetReports,
+                icon: _isRefreshingMonthlyReports
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.refresh),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'AI summaries are read-only; KPI values come from deterministic monthly snapshots.',
+            style: TextStyle(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          if (_monthlyReportMessage != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _monthlyReportMessage!,
+              style: TextStyle(
+                color: theme.colorScheme.onSurfaceVariant,
+                fontSize: 12,
+                height: 1.5,
+              ),
+            ),
+          ],
+          const SizedBox(height: 12),
+          if (reportViews.isEmpty)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surface,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: theme.colorScheme.outlineVariant),
+              ),
+              child: Text(
+                'No monthly reports yet. Save a monthly snapshot or run the month-end report job first.',
+                style: TextStyle(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontSize: 12,
+                  height: 1.5,
+                ),
+              ),
+            )
+          else
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final narrow = _isCompact || constraints.maxWidth < 760;
+                final monthList = Column(
+                  key: const Key('asset_monthly_report_list'),
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    for (final view in reportViews)
+                      _buildMonthlyReportMonthTile(
+                        view: view,
+                        selected: view.monthKey == selectedReport!.monthKey,
+                      ),
+                  ],
+                );
+                final detail = _buildMonthlyReportDetail(
+                  selectedReport!,
+                  selectedIndex: selectedIndex,
+                  reportViews: reportViews,
+                );
+                if (narrow) {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [monthList, const SizedBox(height: 12), detail],
+                  );
+                }
+                return Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(width: 220, child: monthList),
+                    const SizedBox(width: 12),
+                    Expanded(child: detail),
+                  ],
+                );
+              },
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMonthlyReportMonthTile({
+    required AssetLiabilityMonthlyReportView view,
+    required bool selected,
+  }) {
+    final theme = Theme.of(context);
+    final color =
+        selected ? const Color(0xFF0D9488) : theme.colorScheme.outlineVariant;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        key: Key('asset_monthly_report_item_${view.monthKey}'),
+        borderRadius: BorderRadius.circular(8),
+        onTap: () {
+          setState(() {
+            _selectedMonthlyReportMonthKey = view.monthKey;
+          });
+        },
+        child: Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color:
+                selected ? const Color(0xFFECFDF5) : theme.colorScheme.surface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: color),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                view.monthKey,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w800,
+                  color: selected ? const Color(0xFF0F766E) : null,
+                  height: 1.4,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                view.hasAiReport ? 'AI summary' : 'Local snapshot',
+                style: TextStyle(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontSize: 11,
+                  height: 1.4,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMonthlyReportDetail(
+    AssetLiabilityMonthlyReportView report, {
+    required int selectedIndex,
+    required List<AssetLiabilityMonthlyReportView> reportViews,
+  }) {
+    final theme = Theme.of(context);
+    final canSelectNewer = selectedIndex > 0;
+    final canSelectOlder =
+        selectedIndex >= 0 && selectedIndex < reportViews.length - 1;
+    return Container(
+      key: const Key('asset_monthly_report_detail'),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  report.monthKey,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              IconButton(
+                tooltip: 'Newer month',
+                onPressed: canSelectNewer
+                    ? () => _selectMonthlyReportAt(
+                          reportViews[selectedIndex - 1].monthKey,
+                        )
+                    : null,
+                icon: const Icon(Icons.chevron_left),
+              ),
+              IconButton(
+                tooltip: 'Older month',
+                onPressed: canSelectOlder
+                    ? () => _selectMonthlyReportAt(
+                          reportViews[selectedIndex + 1].monthKey,
+                        )
+                    : null,
+                icon: const Icon(Icons.chevron_right),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildMonthlyReportStatTile(
+                label: 'Assets',
+                value: _formatManagementYen(report.totalAssets),
+                color: const Color(0xFF0D9488),
+              ),
+              _buildMonthlyReportStatTile(
+                label: 'Liabilities',
+                value: _formatManagementYen(report.totalLiabilities),
+                color: const Color(0xFFB91C1C),
+              ),
+              _buildMonthlyReportStatTile(
+                label: 'Net worth',
+                value: _formatManagementYen(report.netWorth),
+                color: report.netWorth < 0
+                    ? const Color(0xFFB91C1C)
+                    : const Color(0xFF0D9488),
+              ),
+              _buildMonthlyReportStatTile(
+                label: 'MoM net worth',
+                value: _formatManagementDeltaYen(report.netWorthDelta),
+                color: const Color(0xFF4F46E5),
+              ),
+              _buildMonthlyReportStatTile(
+                label: 'Cash-like',
+                value: _formatManagementYen(report.cashLikeTotal),
+                color: const Color(0xFF0891B2),
+              ),
+              _buildMonthlyReportStatTile(
+                label: 'Planned payments',
+                value: _formatManagementYen(
+                  report.monthlyScheduledPaymentTotal,
+                ),
+                color: const Color(0xFF7C3AED),
+              ),
+              _buildMonthlyReportStatTile(
+                label: 'Actual paid',
+                value: _formatManagementYen(report.monthlyActualPaymentTotal),
+                color: const Color(0xFF2563EB),
+              ),
+              _buildMonthlyReportStatTile(
+                label: 'Planned/actual diff',
+                value: _formatManagementYen(
+                  report.monthlyPaymentDifferenceTotal,
+                ),
+                color: const Color(0xFFD97706),
+              ),
+              _buildMonthlyReportStatTile(
+                label: 'Overdue',
+                value: '${report.overduePaymentCount}',
+                color: const Color(0xFFB91C1C),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: report.hasAiReport
+                  ? const Color(0xFFEEF2FF)
+                  : const Color(0xFFF8FAFC),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: report.hasAiReport
+                    ? const Color(0xFFC7D2FE)
+                    : theme.colorScheme.outlineVariant,
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  report.hasAiReport ? 'AI summary' : 'Deterministic summary',
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  report.summary,
+                  style: const TextStyle(fontSize: 12, height: 1.5),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '${report.aiModel} / ${_formatMonthlyReportGeneratedAt(report.generatedAt)}',
+            style: TextStyle(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontSize: 11,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMonthlyReportStatTile({
+    required String label,
+    required String value,
+    required Color color,
+  }) {
+    return Container(
+      constraints: const BoxConstraints(minWidth: 132),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.22)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 10,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.w800,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _selectMonthlyReportAt(String monthKey) {
+    setState(() {
+      _selectedMonthlyReportMonthKey = monthKey;
+    });
+  }
+
+  String _formatMonthlyReportGeneratedAt(DateTime? value) {
+    if (value == null) {
+      return 'not generated';
+    }
+    return DateFormat('yyyy/MM/dd HH:mm').format(value.toLocal());
+  }
+
   Widget _buildTransferSuggestionSection(AssetLiabilityWorkbook workbook) {
     if (workbook.transferSuggestions.isEmpty && _transferTasks.isEmpty) {
       return const SizedBox.shrink();
@@ -11815,9 +12264,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
-  Widget _buildAssetRepaymentSimulationPanel(
-    AssetLiabilityWorkbook workbook,
-  ) {
+  Widget _buildAssetRepaymentSimulationPanel(AssetLiabilityWorkbook workbook) {
     final extraMonthlyPayment = _parseRepaymentSimulationExtraPayment();
     final simulation =
         _assetLiabilityRepaymentSimulationService.buildComparison(
@@ -11830,8 +12277,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
     final selectedPlan = simulation.planFor(_repaymentSimulationStrategy) ??
         simulation.plans.first;
-    final baselinePlan =
-        simulation.baselinePlanFor(_repaymentSimulationStrategy);
+    final baselinePlan = simulation.baselinePlanFor(
+      _repaymentSimulationStrategy,
+    );
     final firstMonth = selectedPlan.monthSnapshots.isEmpty
         ? null
         : selectedPlan.monthSnapshots.first;
@@ -11930,8 +12378,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
               _buildRepaymentSimulationMetric(
                 label: 'Interest estimate',
-                value:
-                    _formatManagementYen(selectedPlan.estimatedInterestTotal),
+                value: _formatManagementYen(
+                  selectedPlan.estimatedInterestTotal,
+                ),
               ),
             ],
           ),

--- a/lib/services/asset_liability_monthly_report_service.dart
+++ b/lib/services/asset_liability_monthly_report_service.dart
@@ -1,0 +1,143 @@
+import 'package:intl/intl.dart';
+
+import '../models/asset_liability_workbook.dart';
+
+class AssetLiabilityMonthlyReportView {
+  final String monthKey;
+  final AssetLiabilityMonthlySnapshot? snapshot;
+  final AssetLiabilityMonthlySnapshot? previousSnapshot;
+  final AssetLiabilityMonthlyReport? report;
+  final String fallbackSummary;
+
+  const AssetLiabilityMonthlyReportView({
+    required this.monthKey,
+    required this.snapshot,
+    required this.previousSnapshot,
+    required this.report,
+    required this.fallbackSummary,
+  });
+
+  bool get hasAiReport => report != null && report!.aiSummary.trim().isNotEmpty;
+
+  DateTime? get generatedAt => report?.generatedAt ?? snapshot?.savedAt;
+
+  String get aiModel {
+    final model = report?.aiModel.trim();
+    if (model != null && model.isNotEmpty) {
+      return model;
+    }
+    return 'deterministic-local-snapshot';
+  }
+
+  String get summary {
+    final aiSummary = report?.aiSummary.trim();
+    if (aiSummary != null && aiSummary.isNotEmpty) {
+      return aiSummary;
+    }
+    return fallbackSummary;
+  }
+
+  double get totalAssets =>
+      report?.totalAssets ?? snapshot?.positiveAssetTotal ?? 0;
+
+  double get totalLiabilities =>
+      report?.totalLiabilities ?? snapshot?.liabilityTotal ?? 0;
+
+  double get netWorth => report?.netWorth ?? snapshot?.netWorth ?? 0;
+
+  double? get netWorthDelta {
+    if (snapshot == null || previousSnapshot == null) {
+      return null;
+    }
+    return snapshot!.netWorth - previousSnapshot!.netWorth;
+  }
+
+  double get cashLikeTotal => snapshot?.cashLikeTotal ?? 0;
+
+  double get monthlyScheduledPaymentTotal =>
+      snapshot?.monthlyScheduledPaymentTotal ?? 0;
+
+  double get monthlyPaidPaymentTotal => snapshot?.monthlyPaidPaymentTotal ?? 0;
+
+  double get monthlyUnpaidPaymentTotal =>
+      snapshot?.monthlyUnpaidPaymentTotal ?? 0;
+
+  double get monthlyActualPaymentTotal =>
+      snapshot?.monthlyActualPaymentTotal ?? 0;
+
+  double get monthlyPaymentDifferenceTotal =>
+      snapshot?.monthlyPaymentDifferenceTotal ?? 0;
+
+  int get overduePaymentCount => snapshot?.overduePaymentCount ?? 0;
+}
+
+class AssetLiabilityMonthlyReportService {
+  const AssetLiabilityMonthlyReportService();
+
+  List<AssetLiabilityMonthlyReportView> buildReportViews({
+    required List<AssetLiabilityMonthlySnapshot> snapshots,
+    required List<AssetLiabilityMonthlyReport> reports,
+    int limit = 24,
+  }) {
+    final snapshotsByMonth = <String, AssetLiabilityMonthlySnapshot>{
+      for (final snapshot in snapshots) snapshot.monthKey: snapshot,
+    };
+    final reportsByMonth = <String, AssetLiabilityMonthlyReport>{
+      for (final report in reports) report.monthKey: report,
+    };
+    final monthKeys = <String>{
+      ...snapshotsByMonth.keys,
+      ...reportsByMonth.keys,
+    }.toList()
+      ..sort((a, b) => b.compareTo(a));
+    final previousByMonth = _previousSnapshotsByMonth(snapshotsByMonth.values);
+
+    return [
+      for (final monthKey in monthKeys.take(limit < 0 ? 0 : limit))
+        AssetLiabilityMonthlyReportView(
+          monthKey: monthKey,
+          snapshot: snapshotsByMonth[monthKey],
+          previousSnapshot: previousByMonth[monthKey],
+          report: reportsByMonth[monthKey],
+          fallbackSummary: buildDeterministicSummary(
+            monthKey: monthKey,
+            snapshot: snapshotsByMonth[monthKey],
+          ),
+        ),
+    ];
+  }
+
+  String buildDeterministicSummary({
+    required String monthKey,
+    required AssetLiabilityMonthlySnapshot? snapshot,
+  }) {
+    if (snapshot == null) {
+      return '$monthKey report is available, but the KPI snapshot has not been synced locally yet.';
+    }
+    final paidRate = snapshot.monthlyScheduledPaymentTotal <= 0
+        ? 0.0
+        : snapshot.monthlyPaidPaymentTotal /
+            snapshot.monthlyScheduledPaymentTotal;
+    final formatter = NumberFormat('#,###');
+    return [
+      '$monthKey monthly asset report.',
+      'Net worth: JPY ${formatter.format(snapshot.netWorth.round())}; '
+          'cash-like assets: JPY ${formatter.format(snapshot.cashLikeTotal.round())}.',
+      'Scheduled payments: JPY ${formatter.format(snapshot.monthlyScheduledPaymentTotal.round())}; '
+          'paid ${(paidRate * 100).clamp(0, 999).toStringAsFixed(0)}%.',
+      'Actual payment difference: JPY ${formatter.format(snapshot.monthlyPaymentDifferenceTotal.round())}; '
+          'overdue payments: ${snapshot.overduePaymentCount}.',
+    ].join(' ');
+  }
+
+  Map<String, AssetLiabilityMonthlySnapshot?> _previousSnapshotsByMonth(
+    Iterable<AssetLiabilityMonthlySnapshot> snapshots,
+  ) {
+    final sorted = List<AssetLiabilityMonthlySnapshot>.from(snapshots)
+      ..sort((a, b) => a.monthKey.compareTo(b.monthKey));
+    return <String, AssetLiabilityMonthlySnapshot?>{
+      for (var index = 0; index < sorted.length; index++)
+        sorted[index].monthKey: index == 0 ? null : sorted[index - 1],
+    };
+  }
+}

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -318,6 +318,12 @@ abstract class AssetLiabilityRepository {
 
   Future<void> saveMonthlySnapshot(AssetLiabilityMonthlySnapshot snapshot);
 
+  Future<List<AssetLiabilityMonthlyReport>> loadMonthlyReports({
+    int limit = 24,
+  }) async {
+    return const <AssetLiabilityMonthlyReport>[];
+  }
+
   Future<List<AssetLiabilitySyncAuditLog>> loadSyncAuditLogs({
     int limit = 20,
   }) async {
@@ -404,6 +410,11 @@ abstract class AssetLiabilityRemoteStore {
   Future<void> saveMonthlySnapshot({
     required String userId,
     required AssetLiabilityMonthlySnapshot snapshot,
+  });
+
+  Future<List<AssetLiabilityMonthlyReport>?> loadMonthlyReports({
+    required String userId,
+    int limit = 24,
   });
 }
 
@@ -712,6 +723,26 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
     }
 
     return local;
+  }
+
+  @override
+  Future<List<AssetLiabilityMonthlyReport>> loadMonthlyReports({
+    int limit = 24,
+  }) async {
+    final remote = _remoteOrNull();
+    final userId = _userIdOrNull();
+    if (remote == null || userId == null) {
+      return const <AssetLiabilityMonthlyReport>[];
+    }
+    final remoteReports = await _tryRemote(
+      () => remote.loadMonthlyReports(userId: userId, limit: limit),
+    );
+    if (remoteReports == null || remoteReports.isEmpty) {
+      return const <AssetLiabilityMonthlyReport>[];
+    }
+    final sorted = List<AssetLiabilityMonthlyReport>.from(remoteReports)
+      ..sort((a, b) => b.monthKey.compareTo(a.monthKey));
+    return sorted.take(limit < 0 ? 0 : limit).toList(growable: false);
   }
 
   @override
@@ -1911,6 +1942,43 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
     );
   }
 
+  @override
+  Future<List<AssetLiabilityMonthlyReport>?> loadMonthlyReports({
+    required String userId,
+    int limit = 24,
+  }) async {
+    final response = await client
+        .from('monthly_asset_reports')
+        .select(
+          'year_month,total_assets,total_liabilities,net_worth,ai_summary,ai_model,generated_at',
+        )
+        .eq('user_id', userId)
+        .order('year_month', ascending: false)
+        .limit(limit < 0 ? 0 : limit);
+
+    final reports = <AssetLiabilityMonthlyReport>[];
+    for (final item in response) {
+      final monthKey = _monthKeyFromReportValue(item['year_month']);
+      final generatedAt = _dateTimeFromReportValue(item['generated_at']);
+      if (monthKey == null || generatedAt == null) {
+        continue;
+      }
+      reports.add(
+        AssetLiabilityMonthlyReport(
+          monthKey: monthKey,
+          generatedAt: generatedAt,
+          totalAssets: _doubleFromReportValue(item['total_assets']),
+          totalLiabilities: _doubleFromReportValue(item['total_liabilities']),
+          netWorth: _doubleFromReportValue(item['net_worth']),
+          aiSummary: item['ai_summary']?.toString() ?? '',
+          aiModel: item['ai_model']?.toString() ?? '',
+        ),
+      );
+    }
+    reports.sort((a, b) => b.monthKey.compareTo(a.monthKey));
+    return reports;
+  }
+
   Future<Map<String, Object?>?> _loadPayloadRow(
     String table, {
     required String userId,
@@ -1969,6 +2037,43 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
       );
     }
     return null;
+  }
+
+  String? _monthKeyFromReportValue(Object? value) {
+    final text = value?.toString().trim();
+    if (text == null || text.isEmpty) {
+      return null;
+    }
+    final direct = RegExp(r'^(\d{4})-(\d{2})').firstMatch(text);
+    if (direct != null) {
+      final month = int.tryParse(direct.group(2)!);
+      if (month != null && month >= 1 && month <= 12) {
+        return '${direct.group(1)}-${direct.group(2)}';
+      }
+    }
+    final parsed = DateTime.tryParse(text);
+    if (parsed == null) {
+      return null;
+    }
+    return AssetLiabilityMonthlyStateStore.formatMonthKey(parsed);
+  }
+
+  DateTime? _dateTimeFromReportValue(Object? value) {
+    final text = value?.toString().trim();
+    if (text == null || text.isEmpty) {
+      return null;
+    }
+    return DateTime.tryParse(text);
+  }
+
+  double _doubleFromReportValue(Object? value) {
+    if (value is num) {
+      return value.toDouble();
+    }
+    if (value is String) {
+      return double.tryParse(value.trim()) ?? 0;
+    }
+    return 0;
   }
 }
 

--- a/test/services/asset_liability_monthly_report_service_test.dart
+++ b/test/services/asset_liability_monthly_report_service_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_monthly_report_service.dart';
+
+void main() {
+  group('AssetLiabilityMonthlyReportService', () {
+    const service = AssetLiabilityMonthlyReportService();
+
+    test('merges generated reports with local KPI snapshots by month', () {
+      final views = service.buildReportViews(
+        snapshots: <AssetLiabilityMonthlySnapshot>[
+          _snapshot('2026-05', netWorth: -7000000),
+          _snapshot('2026-06', netWorth: -6500000),
+        ],
+        reports: <AssetLiabilityMonthlyReport>[
+          AssetLiabilityMonthlyReport(
+            monthKey: '2026-06',
+            generatedAt: DateTime.utc(2026, 7, 1),
+            totalAssets: 180000,
+            totalLiabilities: -6680000,
+            netWorth: -6500000,
+            aiSummary: 'AI summary for June',
+            aiModel: 'claude-opus-4-7',
+          ),
+        ],
+      );
+
+      expect(views.map((view) => view.monthKey), <String>[
+        '2026-06',
+        '2026-05',
+      ]);
+      expect(views.first.hasAiReport, isTrue);
+      expect(views.first.summary, 'AI summary for June');
+      expect(views.first.aiModel, 'claude-opus-4-7');
+      expect(views.first.netWorthDelta, 500000);
+      expect(views.last.hasAiReport, isFalse);
+      expect(views.last.summary, contains('2026-05 monthly asset report'));
+    });
+
+    test('keeps remote-only reports visible until snapshots are synced', () {
+      final views = service.buildReportViews(
+        snapshots: const <AssetLiabilityMonthlySnapshot>[],
+        reports: <AssetLiabilityMonthlyReport>[
+          AssetLiabilityMonthlyReport(
+            monthKey: '2026-07',
+            generatedAt: DateTime.utc(2026, 8, 1),
+            totalAssets: 100000,
+            totalLiabilities: -600000,
+            netWorth: -500000,
+            aiSummary: '',
+            aiModel: '',
+          ),
+        ],
+      );
+
+      expect(views.single.monthKey, '2026-07');
+      expect(views.single.totalAssets, 100000);
+      expect(
+        views.single.summary,
+        contains('KPI snapshot has not been synced'),
+      );
+      expect(views.single.aiModel, 'deterministic-local-snapshot');
+    });
+
+    test('applies limit after descending month sort', () {
+      final views = service.buildReportViews(
+        snapshots: <AssetLiabilityMonthlySnapshot>[
+          _snapshot('2026-05', netWorth: -7000000),
+          _snapshot('2026-06', netWorth: -6500000),
+          _snapshot('2026-07', netWorth: -6400000),
+        ],
+        reports: const <AssetLiabilityMonthlyReport>[],
+        limit: 2,
+      );
+
+      expect(views.map((view) => view.monthKey), <String>[
+        '2026-07',
+        '2026-06',
+      ]);
+    });
+  });
+}
+
+AssetLiabilityMonthlySnapshot _snapshot(
+  String monthKey, {
+  required double netWorth,
+}) {
+  return AssetLiabilityMonthlySnapshot(
+    monthKey: monthKey,
+    savedAt: DateTime.utc(
+      int.parse(monthKey.substring(0, 4)),
+      int.parse(monthKey.substring(5, 7)),
+      28,
+    ),
+    positiveAssetTotal: 100000,
+    liabilityTotal: netWorth - 100000,
+    netWorth: netWorth,
+    cashLikeTotal: 50000,
+    monthlyScheduledPaymentTotal: 120000,
+    monthlyPaidPaymentTotal: 60000,
+    monthlyUnpaidPaymentTotal: 60000,
+    monthlyActualPaymentTotal: 61000,
+    monthlyPaymentDifferenceTotal: 1000,
+    overduePaymentCount: 1,
+  );
+}

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -1104,6 +1104,44 @@ void main() {
       },
     );
 
+    test('loads generated monthly reports from remote store', () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore()
+        ..seedMonthlyReports(<AssetLiabilityMonthlyReport>[
+          AssetLiabilityMonthlyReport(
+            monthKey: '2026-06',
+            generatedAt: DateTime.utc(2026, 7, 1),
+            totalAssets: 160000,
+            totalLiabilities: -6800000,
+            netWorth: -6640000,
+            aiSummary: 'June summary',
+            aiModel: 'deterministic-fallback',
+          ),
+          AssetLiabilityMonthlyReport(
+            monthKey: '2026-05',
+            generatedAt: DateTime.utc(2026, 6, 1),
+            totalAssets: 120000,
+            totalLiabilities: -7000000,
+            netWorth: -6880000,
+            aiSummary: 'May summary',
+            aiModel: 'claude-opus-4-7',
+          ),
+        ]);
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+
+      final reports = await repository.loadMonthlyReports(limit: 1);
+
+      expect(reports, hasLength(1));
+      expect(reports.single.monthKey, '2026-06');
+      expect(reports.single.aiSummary, 'June summary');
+      expect(remote.calls, contains('loadMonthlyReports:user-1:1'));
+    });
+
     test(
       'keeps local repository usable when no Supabase user is available',
       () async {
@@ -1406,11 +1444,14 @@ class _RecordingAssetLiabilityRemoteStore extends AssetLiabilityRemoteStore {
       <AssetLiabilityRecurringIncomeTemplate>[];
   final List<AssetLiabilityMonthlySnapshot> _monthlySnapshots =
       <AssetLiabilityMonthlySnapshot>[];
+  final List<AssetLiabilityMonthlyReport> _monthlyReports =
+      <AssetLiabilityMonthlyReport>[];
 
   bool _hasDefaultPaymentSources = false;
   bool _hasDefaultCardBillingAccounts = false;
   bool _hasRecurringIncomeTemplates = false;
   bool _hasMonthlySnapshots = false;
+  bool _hasMonthlyReports = false;
   bool failSaves = false;
 
   Map<String, String> get defaultPaymentSources =>
@@ -1426,6 +1467,9 @@ class _RecordingAssetLiabilityRemoteStore extends AssetLiabilityRemoteStore {
 
   List<AssetLiabilityMonthlySnapshot> get monthlySnapshots =>
       List<AssetLiabilityMonthlySnapshot>.from(_monthlySnapshots);
+
+  List<AssetLiabilityMonthlyReport> get monthlyReports =>
+      List<AssetLiabilityMonthlyReport>.from(_monthlyReports);
 
   AssetLiabilityMonthlyState? monthState(String monthKey) => _states[monthKey];
 
@@ -1462,6 +1506,14 @@ class _RecordingAssetLiabilityRemoteStore extends AssetLiabilityRemoteStore {
       ..clear()
       ..addAll(snapshots)
       ..sort((a, b) => a.monthKey.compareTo(b.monthKey));
+  }
+
+  void seedMonthlyReports(List<AssetLiabilityMonthlyReport> reports) {
+    _hasMonthlyReports = true;
+    _monthlyReports
+      ..clear()
+      ..addAll(reports)
+      ..sort((a, b) => b.monthKey.compareTo(a.monthKey));
   }
 
   @override
@@ -1583,6 +1635,20 @@ class _RecordingAssetLiabilityRemoteStore extends AssetLiabilityRemoteStore {
     );
     _monthlySnapshots.add(snapshot);
     _monthlySnapshots.sort((a, b) => a.monthKey.compareTo(b.monthKey));
+  }
+
+  @override
+  Future<List<AssetLiabilityMonthlyReport>?> loadMonthlyReports({
+    required String userId,
+    int limit = 24,
+  }) async {
+    calls.add('loadMonthlyReports:$userId:$limit');
+    if (!_hasMonthlyReports) {
+      return null;
+    }
+    return List<AssetLiabilityMonthlyReport>.from(
+      _monthlyReports.take(limit < 0 ? 0 : limit),
+    );
   }
 
   void _throwIfSavingFails() {


### PR DESCRIPTION
﻿## Summary
- Adds a monthly asset report section to the asset management page with month list, detail view, KPI tiles, AI summary fallback, and month navigation.
- Reads generated `monthly_asset_reports` rows through the asset liability repository while keeping local snapshots visible when generated reports are absent.
- Adds deterministic monthly report view aggregation and repository tests for Supabase-free validation.

Closes #2463

## Scope / Risk
- Lead owner: Codex #1 (Windows app).
- Review owner: Claude Code #1 for the high-risk ultrareview gate contract.
- Guarded subagent orchestration: not used; no child worker was launched.
- Data writes: none. This slice is read-only UI + remote read path for generated monthly reports.
- High-risk-ultrareview-exception: read-only monthly asset report UI/repository read path; no schema migration, production write enablement, deploy config, secret, token, credential, or external side effect changed. Security, data migration, prod smoke, observability, and rollback were reviewed; no unresolved findings: 0.
- Rollback: revert this PR; existing monthly snapshot and report cron paths remain independent.

## Minimal E2E Declaration
Implementation-detail independent black-box I/O plan:
- Input: local monthly snapshots and optional generated monthly report rows for multiple month keys.
- Output: month list sorted newest-first, detail panel with AI summary or deterministic fallback, KPI tiles, and safe empty state.
- Boundary: no production Supabase write, no live provider call, no user secrets required.

Minimal 3 cases:
1. Generated report + local KPI snapshot merge shows AI summary and month-over-month net-worth delta.
2. Remote-only generated report remains visible with fallback summary until a KPI snapshot is synced.
3. Multiple months sort descending and honor the 24-month display limit.

E2E mechanism:
- Service-level black-box tests cover the report view contract.
- Repository tests cover feature-flagged remote monthly report reads without production writes.
- Full Flutter analyze covers the integrated asset management page.

E2E-Exception: no `integration_test/` or `test/e2e/` file is added because this slice is deterministic read-only UI/read-model plumbing with no production write, browser-only side effect, live provider call, or external secret dependency; the black-box inputs/outputs above are covered by service and repository tests plus full Flutter analyze.

## Validation
- `flutter analyze`
- `flutter test test/services/asset_liability_monthly_report_service_test.dart test/services/asset_liability_repository_test.dart`
- `dart format --output=none --set-exit-if-changed .` was run locally; on Windows it rewrote `lib/services/asset_liability_repository.dart` due local line-ending behavior, then `flutter analyze` and targeted tests passed.

## Memory / HDD Hygiene
- Preflight C: free space checked (~27GB during implementation).
- Safe worktree cleanup dry-run returned 0 removable candidates.
- `pub get` temporarily restored Pub cache for validation; commit excludes lockfile/generated plugin churn.
