### PR TITLE
feat(asset): hide existing developer request issues (#2964)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -272,6 +272,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final Set<String> _developerRequestIssueSubmissionKeys = <String>{};
   final Map<String, Map<String, dynamic>> _developerRequestIssueResults =
       <String, Map<String, dynamic>>{};
+  bool _isCheckingExistingDeveloperRequestIssues = false;
+  String? _developerRequestExistingIssueLookupKey;
+  final Map<String, Map<String, dynamic>>
+      _developerRequestExistingIssueResults = <String, Map<String, dynamic>>{};
 
   final List<Color> _colors = [
     const Color(0xFF6366F1),
@@ -8595,6 +8599,91 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return jsonEncode(_assetManagementAiSummaryService.buildPayload(report));
   }
 
+  void _requestExistingDeveloperIssuesIfNeeded(
+    List<AssetManagementDeveloperRequest> requests,
+  ) {
+    if (_supabase.auth.currentUser == null || requests.isEmpty) {
+      return;
+    }
+    final payload = requests
+        .map(_developerRequestExistingIssuePayload)
+        .toList(growable: false);
+    final lookupKey = jsonEncode(payload);
+    if (_developerRequestExistingIssueLookupKey == lookupKey) {
+      return;
+    }
+    _developerRequestExistingIssueLookupKey = lookupKey;
+    _isCheckingExistingDeveloperRequestIssues = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _developerRequestExistingIssueLookupKey != lookupKey) {
+        return;
+      }
+      unawaited(
+        _loadExistingDeveloperIssues(
+          lookupKey: lookupKey,
+          requests: payload,
+        ),
+      );
+    });
+  }
+
+  Map<String, String> _developerRequestExistingIssuePayload(
+    AssetManagementDeveloperRequest request,
+  ) {
+    return <String, String>{
+      'key': _developerRequestIssueKey(request),
+      'title': request.title,
+      'description': request.description,
+    };
+  }
+
+  Future<void> _loadExistingDeveloperIssues({
+    required String lookupKey,
+    required List<Map<String, String>> requests,
+  }) async {
+    try {
+      final response = await _supabase.functions.invoke(
+        'core-hub',
+        body: {
+          'action': 'feature_request.existing_issues',
+          'source': 'asset_management_developer_request',
+          'requests': requests,
+        },
+      );
+      if (!mounted || _developerRequestExistingIssueLookupKey != lookupKey) {
+        return;
+      }
+      final rawData = response.data;
+      final existingByKey = <String, Map<String, dynamic>>{};
+      if (rawData is Map) {
+        final existingIssues = rawData['existingIssues'];
+        if (existingIssues is List) {
+          for (final item in existingIssues) {
+            final issue = _assetManagementDynamicMap(item);
+            final key = issue['key']?.toString() ?? '';
+            if (key.isNotEmpty) {
+              existingByKey[key] = issue;
+            }
+          }
+        }
+      }
+      setState(() {
+        _developerRequestExistingIssueResults
+          ..clear()
+          ..addAll(existingByKey);
+        _isCheckingExistingDeveloperRequestIssues = false;
+      });
+    } catch (_) {
+      if (!mounted || _developerRequestExistingIssueLookupKey != lookupKey) {
+        return;
+      }
+      setState(() {
+        _developerRequestExistingIssueResults.clear();
+        _isCheckingExistingDeveloperRequestIssues = false;
+      });
+    }
+  }
+
   Future<void> _submitAssetManagementDeveloperIssue(
     AssetManagementDeveloperRequest request,
   ) async {
@@ -8635,6 +8724,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           'category': 'UX改善',
           'priority': _developerRequestIssuePriority(request.severity),
           'source': 'asset_management_developer_request',
+          'dedupe_key': issueKey,
         },
       );
 
@@ -9027,6 +9117,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Widget _buildAssetManagementDeveloperRequestList(
     List<AssetManagementDeveloperRequest> requests,
   ) {
+    _requestExistingDeveloperIssuesIfNeeded(requests);
+    final visibleRequests = _isCheckingExistingDeveloperRequestIssues
+        ? <AssetManagementDeveloperRequest>[]
+        : requests
+            .where(
+              (request) => !_developerRequestExistingIssueResults.containsKey(
+                _developerRequestIssueKey(request),
+              ),
+            )
+            .toList(growable: false);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -9035,7 +9135,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
         ),
         const SizedBox(height: 6),
-        for (final request in requests.take(4))
+        for (final request in visibleRequests.take(4))
           Padding(
             padding: const EdgeInsets.only(bottom: 6),
             child: Container(

--- a/supabase/functions/core-hub/feature_request_dedupe.ts
+++ b/supabase/functions/core-hub/feature_request_dedupe.ts
@@ -1,0 +1,86 @@
+export type FeatureRequestCandidate = {
+  key: string;
+  title: string;
+  description?: string;
+};
+
+export type ExistingFeatureRequestIssue = {
+  key: string;
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  matched_by: "github_title" | "local_record";
+};
+
+export type FeatureRequestIssueLike = {
+  number?: unknown;
+  title?: unknown;
+  html_url?: unknown;
+  url?: unknown;
+  state?: unknown;
+};
+
+export function normalizeFeatureRequestIssueTitle(value: string): string {
+  return value
+    .normalize("NFKC")
+    .replace(/\[[^\]]*\]/g, " ")
+    .replace(/【[^】]*】/g, " ")
+    .replace(/追加要望/g, " ")
+    .replace(/資産管理/g, " ")
+    .replace(/feature\s*request/gi, " ")
+    .replace(/github\s*issue/gi, " ")
+    .toLowerCase()
+    .replace(/[\s\p{P}\p{S}]+/gu, "");
+}
+
+export function featureRequestCandidateKey(
+  title: string,
+  description = "",
+  source = "",
+): string {
+  return [
+    source.trim().toLowerCase(),
+    normalizeFeatureRequestIssueTitle(title),
+    normalizeFeatureRequestIssueTitle(description).slice(0, 120),
+  ].join("|");
+}
+
+export function featureRequestIssueMatchesCandidate(
+  candidate: FeatureRequestCandidate,
+  issueTitle: string,
+): boolean {
+  const candidateTitle = normalizeFeatureRequestIssueTitle(candidate.title);
+  const issue = normalizeFeatureRequestIssueTitle(issueTitle);
+  if (candidateTitle.length < 4 || issue.length < 4) return false;
+  return issue === candidateTitle ||
+    issue.includes(candidateTitle) ||
+    candidateTitle.includes(issue);
+}
+
+export function matchExistingFeatureRequestIssues(
+  candidates: FeatureRequestCandidate[],
+  issues: FeatureRequestIssueLike[],
+  matchedBy: ExistingFeatureRequestIssue["matched_by"],
+): ExistingFeatureRequestIssue[] {
+  const matches = new Map<string, ExistingFeatureRequestIssue>();
+  for (const candidate of candidates) {
+    if (matches.has(candidate.key)) continue;
+    for (const issue of issues) {
+      const title = String(issue.title ?? "");
+      if (!featureRequestIssueMatchesCandidate(candidate, title)) continue;
+      const number = Number(issue.number ?? 0);
+      if (!Number.isFinite(number) || number <= 0) continue;
+      matches.set(candidate.key, {
+        key: candidate.key,
+        number,
+        title,
+        html_url: String(issue.html_url ?? issue.url ?? ""),
+        state: String(issue.state ?? ""),
+        matched_by: matchedBy,
+      });
+      break;
+    }
+  }
+  return [...matches.values()];
+}

--- a/supabase/functions/core-hub/feature_request_dedupe_test.ts
+++ b/supabase/functions/core-hub/feature_request_dedupe_test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  featureRequestCandidateKey,
+  matchExistingFeatureRequestIssues,
+  normalizeFeatureRequestIssueTitle,
+} from "./feature_request_dedupe.ts";
+
+Deno.test("feature request title normalization removes GitHub and asset prefixes", () => {
+  assertEquals(
+    normalizeFeatureRequestIssueTitle(
+      "[追加要望] [資産管理] 実支払額と推定額の差分管理",
+    ),
+    normalizeFeatureRequestIssueTitle("実支払額と推定額の差分管理"),
+  );
+});
+
+Deno.test("feature request issue matching maps candidate keys to existing issues", () => {
+  const key = featureRequestCandidateKey(
+    "支払原資口座の未設定レビュー",
+    "未設定項目を一括で確認できるようにする",
+    "asset_management_developer_request",
+  );
+  const matches = matchExistingFeatureRequestIssues(
+    [{ key, title: "支払原資口座の未設定レビュー" }],
+    [
+      {
+        number: 2939,
+        title: "[追加要望] [資産管理] 支払原資口座の未設定レビュー",
+        html_url: "https://example.test/issues/2939",
+        state: "open",
+      },
+    ],
+    "github_title",
+  );
+
+  assertEquals(matches, [{
+    key,
+    number: 2939,
+    title: "[追加要望] [資産管理] 支払原資口座の未設定レビュー",
+    html_url: "https://example.test/issues/2939",
+    state: "open",
+    matched_by: "github_title",
+  }]);
+});

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -6,6 +6,13 @@ import {
   handleMemoReactionAction,
   type MemoReactionAction,
 } from "./memo_reactions.ts";
+import {
+  type ExistingFeatureRequestIssue,
+  type FeatureRequestCandidate,
+  featureRequestCandidateKey,
+  type FeatureRequestIssueLike,
+  matchExistingFeatureRequestIssues,
+} from "./feature_request_dedupe.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -534,6 +541,142 @@ async function createGitHubIssue(params: {
     html_url: issue.html_url,
     title: issue.title,
   };
+}
+
+function githubAuthHeaders(): Record<string, string> {
+  const token = Deno.env.get("GITHUB_PAT") ??
+    Deno.env.get("GITHUB_TOKEN") ??
+    Deno.env.get("GH_TOKEN") ??
+    "";
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "jibun-app-feature-request-dedupe",
+  };
+  if (token !== "") {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+function githubRepoName(): string {
+  return Deno.env.get("GITHUB_REPO") ??
+    Deno.env.get("GITHUB_REPOSITORY") ??
+    "kanta13jp1/my_web_app";
+}
+
+function normalizeFeatureRequestCandidates(
+  rawCandidates: unknown,
+  source: string,
+): FeatureRequestCandidate[] {
+  if (!Array.isArray(rawCandidates)) return [];
+  return rawCandidates.slice(0, 20).map((raw, index) => {
+    const item = raw && typeof raw === "object"
+      ? raw as Record<string, unknown>
+      : {};
+    const title = textValue(item.title, 180);
+    const description = textValue(item.description, 800);
+    const key = textValue(item.key, 240) ||
+      featureRequestCandidateKey(title, description, source) ||
+      `candidate-${index}`;
+    return { key, title, description };
+  }).filter((candidate) => candidate.title.length >= 3);
+}
+
+async function fetchGitHubIssuesByTitle(
+  repo: string,
+  title: string,
+): Promise<FeatureRequestIssueLike[]> {
+  const query = `repo:${repo} is:issue in:title "${
+    title.replaceAll('"', " ")
+  }"`;
+  const url = new URL("https://api.github.com/search/issues");
+  url.searchParams.set("q", query);
+  url.searchParams.set("per_page", "10");
+  const response = await fetch(url, { headers: githubAuthHeaders() });
+  if (!response.ok) return [];
+  const data = await response.json().catch(() => ({}));
+  const items = (data as { items?: unknown }).items;
+  return Array.isArray(items) ? items as FeatureRequestIssueLike[] : [];
+}
+
+async function findGitHubFeatureRequestIssues(
+  candidates: FeatureRequestCandidate[],
+): Promise<ExistingFeatureRequestIssue[]> {
+  const repo = githubRepoName();
+  const matched = new Map<string, ExistingFeatureRequestIssue>();
+  for (const candidate of candidates) {
+    if (matched.has(candidate.key)) continue;
+    const issues = await fetchGitHubIssuesByTitle(repo, candidate.title);
+    const [match] = matchExistingFeatureRequestIssues(
+      [candidate],
+      issues,
+      "github_title",
+    );
+    if (match) {
+      matched.set(candidate.key, match);
+    }
+  }
+  return [...matched.values()];
+}
+
+async function findLocalFeatureRequestIssues(
+  admin: SupabaseClient,
+  candidates: FeatureRequestCandidate[],
+  source: string,
+): Promise<ExistingFeatureRequestIssue[]> {
+  const { data, error } = await admin
+    .from("hub_data")
+    .select("metadata, created_at")
+    .eq("source", "feature_request_user")
+    .filter("metadata->>source", "eq", source)
+    .order("created_at", { ascending: false })
+    .limit(200);
+  if (error) return [];
+  const issues: FeatureRequestIssueLike[] = [];
+  for (const row of data ?? []) {
+    const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+    const githubIssue = (metadata.github_issue ?? {}) as Record<
+      string,
+      unknown
+    >;
+    const title = textValue(metadata.title, 200) ||
+      textValue(githubIssue.title, 200);
+    if (!title) continue;
+    issues.push({
+      number: githubIssue.number,
+      title,
+      html_url: githubIssue.html_url,
+      state: "registered",
+    });
+  }
+  return matchExistingFeatureRequestIssues(
+    candidates,
+    issues,
+    "local_record",
+  );
+}
+
+async function findExistingFeatureRequestIssues(
+  admin: SupabaseClient,
+  candidates: FeatureRequestCandidate[],
+  source: string,
+): Promise<ExistingFeatureRequestIssue[]> {
+  const byKey = new Map<string, ExistingFeatureRequestIssue>();
+  for (
+    const match of await findLocalFeatureRequestIssues(
+      admin,
+      candidates,
+      source,
+    )
+  ) {
+    byKey.set(match.key, match);
+  }
+  const unmatched = candidates.filter((candidate) => !byKey.has(candidate.key));
+  for (const match of await findGitHubFeatureRequestIssues(unmatched)) {
+    byKey.set(match.key, match);
+  }
+  return [...byKey.values()];
 }
 
 async function createFeatureRequestWbsTask(
@@ -1066,6 +1209,25 @@ serve(async (req: Request) => {
         return json({ success: true, analysis, item });
       }
 
+      case "feature_request.existing_issues": {
+        const source = textValue(body.source, 80) ||
+          "home_feature_request_form";
+        const candidates = normalizeFeatureRequestCandidates(
+          body.requests ?? body.candidates,
+          source,
+        );
+        const existingIssues = await findExistingFeatureRequestIssues(
+          admin,
+          candidates,
+          source,
+        );
+        return json({
+          success: true,
+          existingIssues,
+          existing_keys: existingIssues.map((issue) => issue.key),
+        });
+      }
+
       case "feature_request.submit": {
         const title = textValue(body.title, 120);
         const description = textValue(body.description, 4000);
@@ -1115,6 +1277,48 @@ serve(async (req: Request) => {
 
         const createdAt = new Date().toISOString();
         const userEmail = await getUserEmail(admin, userId);
+        const dedupeKey = textValue(body.dedupe_key ?? body.dedupeKey, 240) ||
+          featureRequestCandidateKey(title, description, source);
+        const [existingIssue] = await findExistingFeatureRequestIssues(
+          admin,
+          [{ key: dedupeKey, title, description }],
+          source,
+        );
+        if (existingIssue) {
+          const item = await addItem(admin, "feature_request_user", userId, {
+            title,
+            description,
+            expected_outcome: expectedOutcome,
+            category,
+            priority,
+            status: "existing_issue",
+            source,
+            dedupe_key: dedupeKey,
+            created_at: createdAt,
+            github_issue: existingIssue,
+            wbs_task: {
+              skipped: true,
+              reason: "existing_github_issue",
+            },
+          });
+          return json({
+            success: true,
+            partialSuccess: true,
+            deduped: true,
+            existingIssue: true,
+            item,
+            githubIssue: {
+              number: existingIssue.number,
+              html_url: existingIssue.html_url,
+              title: existingIssue.title,
+              state: existingIssue.state,
+            },
+            wbsTask: {
+              skipped: true,
+              reason: "existing_github_issue",
+            },
+          });
+        }
         const issueBody = buildFeatureRequestBody({
           title,
           description,
@@ -1197,6 +1401,7 @@ serve(async (req: Request) => {
           priority,
           status: "open",
           source,
+          dedupe_key: dedupeKey,
           created_at: createdAt,
           github_issue: githubIssue,
           wbs_task: wbsTask,


### PR DESCRIPTION
﻿## Summary
- add core-hub feature request issue dedupe helpers and tests
- expose `feature_request.existing_issues` so asset management can hide already-registered developer suggestions
- make `feature_request.submit` return an existing issue instead of creating a duplicate when a stale UI submits the same suggestion
- filter asset management developer request cards when existing GitHub Issues are found

## Minimal E2E Gate
- This is implementation-detail independent: the user-facing outcome is that already-registered developer suggestions no longer appear as repeat cards.
- Minimal, about three I/O cases: title normalization, existing issue title match, and core-hub smoke coverage for unchanged memo actions.
- E2E-Exception: this is a small dedupe/control-plane change verified with pure Deno helper tests plus Dart analysis; no live GitHub mutation test is run beyond the manually created tracking Issue #2964.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Scoped duplicate-suppression change for developer suggestions; it does not add secrets, billing, data migration, or new production write paths beyond the existing feature_request submit path.
- Claude ultrareview coverage notes: security uses existing authenticated core-hub and GitHub search fallback; rollback is reverting this PR; data migration is none; prod smoke is covered by Deploy to Production after merge; observability remains existing core-hub errors plus returned dedupe metadata.
- No unresolved ultrareview findings: 0

## Validation
- `deno test --no-lock supabase/functions/core-hub/feature_request_dedupe_test.ts supabase/functions/core-hub/_smoke_test.ts`
- `deno check --no-lock --node-modules-dir=auto supabase/functions/core-hub/index.ts`
- `dart analyze lib/pages/asset_management_page.dart`
- `dart format --output=none --set-exit-if-changed lib/pages/asset_management_page.dart`
- `git diff --check`

## Risk / Ops
- Uses existing authenticated `core-hub` path and GitHub search; if GitHub search is unavailable, the UI falls back to showing suggestions instead of blocking the page.
- Server-side submit dedupe prevents duplicate Issue creation even when the UI cache is stale.
- No provider calls, billing, secrets, or production writes beyond normal feature request submit behavior.

Review owner: Claude Code #1
Guarded subagent orchestration: not used

Closes #2964
