### PR TITLE
ci: skip NotebookLM canonical duplicates (#2931)

### DIFF
--- a/scripts/notebooklm_requirements_to_issues.py
+++ b/scripts/notebooklm_requirements_to_issues.py
@@ -37,6 +37,11 @@ MARKER_PREFIX = "notebooklm-requirement"
 MARKER_RE = re.compile(
     r"notebooklm-requirement:([0-9a-fA-F-]{8,36}):([0-9]+)"
 )
+ASCII_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_+#./-]{1,}", re.IGNORECASE)
+CJK_RUN_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff]+")
+CANONICAL_DUPLICATE_MIN_SCORE = 8
+CANONICAL_DUPLICATE_MIN_OVERLAP = 1
+LOW_SIGNAL_ASCII_TOKENS = {"ai", "api", "ci", "db", "ef", "gha", "gh", "pr", "ui"}
 
 
 @dataclass(frozen=True)
@@ -351,6 +356,118 @@ def existing_requirement_issues(
     return existing
 
 
+def existing_canonical_issues(
+    repo: str,
+    root: Path,
+    timeout: int,
+    *,
+    required: bool = False,
+) -> list[dict[str, Any]]:
+    result = run_command(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--limit",
+            "5000",
+            "--json",
+            "number,title,body,url,state",
+        ],
+        root,
+        timeout,
+    )
+    if result.code != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown gh issue list failure"
+        if required:
+            raise DedupFetchError(f"canonical issue dedup fetch failed: {message}")
+        print(f"[warn] canonical issue dedup fetch failed: {message}", file=sys.stderr)
+        return []
+    try:
+        issues = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        if required:
+            raise DedupFetchError("canonical issue dedup fetch returned invalid JSON") from exc
+        return []
+    return [issue for issue in issues if isinstance(issue, dict)]
+
+
+def text_tokens(text: str) -> set[str]:
+    normalized = str(text or "").lower()
+    tokens = {match.group(0) for match in ASCII_TOKEN_RE.finditer(normalized)}
+    for match in CJK_RUN_RE.finditer(normalized):
+        run = match.group(0)
+        for size in (2, 3):
+            if len(run) < size:
+                continue
+            tokens.update(run[index : index + size] for index in range(len(run) - size + 1))
+    return tokens
+
+
+def requirement_text(req: Requirement) -> str:
+    return "\n".join(
+        [
+            req.title,
+            req.rationale,
+            "\n".join(req.acceptance_criteria),
+            req.implementation_notes,
+        ]
+    )
+
+
+def issue_text(issue: dict[str, Any]) -> str:
+    return "\n".join([str(issue.get("title", "")), str(issue.get("body", ""))])
+
+
+def issue_references_notebook(issue: dict[str, Any], notebook_id: str) -> bool:
+    haystack = issue_text(issue).lower()
+    notebook_id = notebook_id.lower()
+    return notebook_id in haystack or notebook_id.split("-", 1)[0] in haystack
+
+
+def canonical_duplicate_score(req: Requirement, issue: dict[str, Any]) -> tuple[int, int]:
+    req_tokens = text_tokens(requirement_text(req))
+    issue_tokens = text_tokens(issue_text(issue))
+    if not req_tokens or not issue_tokens:
+        return (0, 0)
+    overlap = req_tokens.intersection(issue_tokens)
+    title_overlap = text_tokens(req.title).intersection(text_tokens(str(issue.get("title", ""))))
+    ascii_title_overlap = {
+        token
+        for token in title_overlap
+        if ASCII_TOKEN_RE.fullmatch(token) and token not in LOW_SIGNAL_ASCII_TOKENS
+    }
+    score = len(overlap) + (2 * len(title_overlap)) + (5 * len(ascii_title_overlap))
+    return (score, len(overlap))
+
+
+def find_canonical_duplicate(
+    req: Requirement,
+    issues: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    best_issue: dict[str, Any] | None = None
+    best_score = 0
+    best_overlap = 0
+    for issue in issues:
+        if not issue_references_notebook(issue, req.notebook_id):
+            continue
+        score, overlap = canonical_duplicate_score(req, issue)
+        if score > best_score:
+            best_issue = issue
+            best_score = score
+            best_overlap = overlap
+    if (
+        best_issue
+        and best_score >= CANONICAL_DUPLICATE_MIN_SCORE
+        and best_overlap >= CANONICAL_DUPLICATE_MIN_OVERLAP
+    ):
+        return best_issue
+    return None
+
+
 def extraction_prompt(count: int) -> str:
     return f"""
 You are reviewing one NotebookLM notebook for the repository `my_web_app`.
@@ -640,6 +757,7 @@ def render_report(
 ) -> str:
     created = [req for req in requirements if req.status == "created"]
     skipped = [req for req in requirements if req.status == "skipped_existing"]
+    canonical_skipped = [req for req in requirements if req.status == "skipped_canonical_duplicate"]
     capped = [req for req in requirements if req.status == "create_cap_reached"]
     failed = [req for req in requirements if req.status.endswith("failed")]
     lines = [
@@ -653,6 +771,7 @@ def render_report(
         f"- Issue creation cap: `{max_created_issues if max_created_issues else 'none'}`",
         f"- Issues created: `{len(created)}`",
         f"- Existing requirement Issues skipped: `{len(skipped)}`",
+        f"- Canonical duplicate Issues skipped: `{len(canonical_skipped)}`",
         f"- Requirements held by creation cap: `{len(capped)}`",
         f"- Failed requirements: `{len(failed)}`",
         f"- Notebook extraction errors: `{len(errors)}`",
@@ -673,6 +792,15 @@ def render_report(
             )
         if len(skipped) > 100:
             lines.append(f"- ... {len(skipped) - 100} more")
+        lines.append("")
+    if canonical_skipped:
+        lines.extend(["## Skipped Canonical Duplicates", ""])
+        for req in canonical_skipped[:100]:
+            lines.append(
+                f"- `{req.notebook_short_id}` slot {req.slot}: {req.title} ({req.issue_url or 'canonical duplicate'})"
+            )
+        if len(canonical_skipped) > 100:
+            lines.append(f"- ... {len(canonical_skipped) - 100} more")
         lines.append("")
     if capped:
         lines.extend(["## Held by Creation Cap", ""])
@@ -751,6 +879,12 @@ def main() -> int:
         args.timeout,
         required=args.create_issues,
     )
+    canonical_issues = existing_canonical_issues(
+        repo,
+        root,
+        args.timeout,
+        required=args.create_issues,
+    )
     if args.create_issues:
         ensure_labels(
             repo,
@@ -815,6 +949,21 @@ def main() -> int:
                 req.issue_url = str(issue.get("url", ""))
                 req.issue_number = int(issue["number"]) if issue.get("number") else None
                 requirements.append(req)
+                continue
+            canonical_issue = find_canonical_duplicate(req, canonical_issues)
+            if canonical_issue:
+                req.status = "skipped_canonical_duplicate"
+                req.issue_url = str(canonical_issue.get("url", ""))
+                req.issue_number = (
+                    int(canonical_issue["number"]) if canonical_issue.get("number") else None
+                )
+                req.error = f"canonical duplicate: {canonical_issue.get('title', '')}"
+                requirements.append(req)
+                print(
+                    f"[skip-canonical] {req.notebook_short_id}:{req.slot} -> #{req.issue_number}",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 continue
             if not args.create_issues:
                 req.status = "dry_run"

--- a/test/scripts/test_notebooklm_requirements_to_issues.py
+++ b/test/scripts/test_notebooklm_requirements_to_issues.py
@@ -78,6 +78,62 @@ class NotebookLmRequirementsToIssuesTest(unittest.TestCase):
             existing,
         )
 
+    def test_canonical_duplicate_matches_same_notebook_issue(self):
+        notebook_id = "9871b0b1-0748-4d7d-99bc-bd6aea2231f6"
+        requirement = reqs.Requirement(
+            notebook_id=notebook_id,
+            notebook_short_id="9871b0b1",
+            notebook_title="Claude Code and Obsidian: Building Your AI Second Brain",
+            notebook_created_at=None,
+            notebook_is_owner=True,
+            slot=3,
+            title="AI調査結果のQuery to Wiki直接保存機能の導入",
+            rationale="AIツールで得た比較表や構成案を使い捨てにせずナレッジベースに永続化する。",
+            acceptance_criteria=[
+                "AI出力をワンクリックで永続記憶として保存できる",
+                "保存データがSupabase検索対象に含まれる",
+                "元Issueとタイムスタンプをメタデータとして付与する",
+            ],
+            implementation_notes="Flutter WebにMarkdownプレビューと保存処理を追加する。",
+        )
+        issue = {
+            "number": 975,
+            "title": "[追加要望] Query to Wiki: AI回答を永続ナレッジ化する保存ワークフロー",
+            "url": "https://github.com/owner/repo/issues/975",
+            "state": "OPEN",
+            "body": (
+                f"Source: https://notebooklm.google.com/notebook/{notebook_id}\n"
+                "AI回答・診断結果・WBS手順・比較表などをMarkdownノートとして永続保存する。"
+                "保存時にタイトル、要約、タグ、関連Issue、関連ノート候補を生成する。"
+            ),
+        }
+
+        duplicate = reqs.find_canonical_duplicate(requirement, [issue])
+
+        self.assertIsNotNone(duplicate)
+        self.assertEqual(duplicate["number"], 975)
+
+    def test_canonical_duplicate_requires_same_notebook_reference(self):
+        requirement = reqs.Requirement(
+            notebook_id="9871b0b1-0748-4d7d-99bc-bd6aea2231f6",
+            notebook_short_id="9871b0b1",
+            notebook_title="Notebook",
+            notebook_created_at=None,
+            notebook_is_owner=True,
+            slot=2,
+            title="Knowledge Vault Lint",
+            rationale="Detect orphan notes and broken links.",
+        )
+        issue = {
+            "number": 976,
+            "title": "Knowledge Vault Lint",
+            "url": "https://github.com/owner/repo/issues/976",
+            "state": "CLOSED",
+            "body": "Same words, but it references a different notebook id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.",
+        }
+
+        self.assertIsNone(reqs.find_canonical_duplicate(requirement, [issue]))
+
     def test_report_surfaces_creation_cap(self):
         requirement = reqs.Requirement(
             notebook_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -103,6 +159,33 @@ class NotebookLmRequirementsToIssuesTest(unittest.TestCase):
 
         self.assertIn("Issue creation cap: `9`", report)
         self.assertIn("Held by Creation Cap", report)
+
+    def test_report_surfaces_canonical_duplicate_skip(self):
+        requirement = reqs.Requirement(
+            notebook_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            notebook_short_id="aaaaaaaa",
+            notebook_title="Example Notebook",
+            notebook_created_at=None,
+            notebook_is_owner=True,
+            slot=1,
+            title="Existing canonical requirement",
+            rationale="Reason",
+            status="skipped_canonical_duplicate",
+            issue_url="https://github.com/owner/repo/issues/974",
+        )
+
+        report = reqs.render_report(
+            "2026-05-18T00:00:00Z",
+            [],
+            [requirement],
+            [],
+            "owner/repo",
+            True,
+            9,
+        )
+
+        self.assertIn("Canonical duplicate Issues skipped: `1`", report)
+        self.assertIn("Skipped Canonical Duplicates", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## Summary
- Add canonical duplicate detection for NotebookLM requirement extraction when existing repo Issues reference the same NotebookLM notebook.
- Compare extracted requirement text against existing Issue title/body tokens before creating a new Issue.
- Surface canonical duplicate skips in the generated report so old NotebookLM slots can be routed to canonical Issues instead of reopening duplicates.

## Validation
- `PYTHONPATH=(Get-Location).Path; python test\scripts\test_notebooklm_requirements_to_issues.py`
- `python -m py_compile scripts\notebooklm_requirements_to_issues.py`
- Manual fixture check: #2931 -> #974, #2932 -> #976, #2933 -> #975

## Minimal E2E Declaration
- The E2E test is implementation-detail independent: it verifies observable input/output routing from extracted NotebookLM requirement text to an existing canonical Issue.
- The minimal E2E plan is about three I/O cases: #2931 maps to #974, #2932 maps to #976, and #2933 maps to #975.
- E2E mechanism: Python unittest plus a manual CLI fixture for this stdlib automation; Playwright/integration_test is not applicable because this PR has no Flutter UI or browser flow changes.

## High-risk Ultrareview Contract
- Claude Code #1 review owner: Claude Code #1.
- Claude ultrareview evidence / exception reason: exception requested because this is an automation-only dedup guard with no production data migration, no live NotebookLM auth use, no provider API calls, and no secret changes.
- Security: the change only reads existing Issue metadata through `gh issue list`; it does not log secrets or call external model/provider APIs.
- Rollback: revert this PR or rerun the workflow with `--no-skip-existing-before-ask` if canonical dedup needs to be bypassed during investigation.
- Data migration: none.
- Prod smoke: PR CI Lint/Format/Test and Public E2E stability smoke are expected to stay green; post-merge Deploy to Production and GitHub Issues WBS Sync will be verified.
- Observability: generated report now includes `Canonical duplicate Issues skipped`, and stderr emits `[skip-canonical]` with target Issue number.
- Unresolved ultrareview findings: 0/none. No unresolved findings: none.

## Two-instance / subagent note
- Lead owner: Codex #1
- Guarded subagents: not used
- Scope: NotebookLM requirements-to-Issues dedup guard only
- Risk: report/issue-creation automation only; no live NotebookLM auth or provider API calls

Refs #2931
Refs #2932
Refs #2933
Refs #975
