### PR TITLE
db: add investment assets schema (#2465)

### DIFF
--- a/supabase/migrations/20260522020000_create_investment_assets.sql
+++ b/supabase/migrations/20260522020000_create_investment_assets.sql
@@ -1,0 +1,97 @@
+-- Asset management phase 2B: investment asset schema.
+-- Issue #2465. This migration adds storage only; price fetch, UI, and
+-- production sync behavior stay in later scoped issues.
+
+begin;
+
+create table if not exists public.investment_assets (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  asset_type text not null,
+  ticker text not null,
+  quantity numeric(28, 8) not null,
+  buy_price_jpy numeric(20, 4) not null default 0,
+  buy_date date,
+  current_price_jpy numeric(20, 4),
+  last_priced_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint investment_assets_asset_type_check
+    check (asset_type in ('stock', 'crypto', 'reit', 'etf')),
+  constraint investment_assets_ticker_not_blank
+    check (length(btrim(ticker)) > 0),
+  constraint investment_assets_quantity_positive
+    check (quantity > 0),
+  constraint investment_assets_buy_price_non_negative
+    check (buy_price_jpy >= 0),
+  constraint investment_assets_current_price_non_negative
+    check (current_price_jpy is null or current_price_jpy >= 0),
+  constraint investment_assets_last_price_requires_price
+    check (last_priced_at is null or current_price_jpy is not null)
+);
+
+create index if not exists investment_assets_user_type_ticker_idx
+  on public.investment_assets (user_id, asset_type, ticker);
+
+create index if not exists investment_assets_user_last_priced_idx
+  on public.investment_assets (user_id, last_priced_at desc nulls last);
+
+comment on table public.investment_assets is
+  'Asset management phase 2B investment holdings for stocks, crypto, REITs, and ETFs. Issue #2465.';
+comment on column public.investment_assets.quantity is
+  'Decimal quantity so fractional shares and crypto holdings can be stored deterministically.';
+comment on column public.investment_assets.current_price_jpy is
+  'Latest cached JPY unit price. Populated by later market-price fetch work; nullable until priced.';
+
+alter table public.investment_assets enable row level security;
+
+drop policy if exists investment_assets_select_own
+  on public.investment_assets;
+create policy investment_assets_select_own
+on public.investment_assets
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists investment_assets_insert_own
+  on public.investment_assets;
+create policy investment_assets_insert_own
+on public.investment_assets
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists investment_assets_update_own
+  on public.investment_assets;
+create policy investment_assets_update_own
+on public.investment_assets
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists investment_assets_delete_own
+  on public.investment_assets;
+create policy investment_assets_delete_own
+on public.investment_assets
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+create or replace function public.set_investment_assets_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists investment_assets_updated_at
+  on public.investment_assets;
+create trigger investment_assets_updated_at
+before update on public.investment_assets
+for each row execute function public.set_investment_assets_updated_at();
+
+commit;

--- a/test/services/investment_assets_schema_test.dart
+++ b/test/services/investment_assets_schema_test.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260522020000_create_investment_assets.sql';
+
+void main() {
+  group('investment assets schema migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(_migrationPath).readAsStringSync().replaceAll('\r\n', '\n');
+    });
+
+    test('defines investment holdings with deterministic numeric fields', () {
+      final block = _createTableBlock(sql, 'investment_assets');
+
+      expect(block, contains('id uuid primary key default gen_random_uuid()'));
+      expect(
+        block,
+        contains('user_id uuid not null references auth.users(id)'),
+      );
+      expect(block, contains('asset_type text not null'));
+      expect(block, contains('ticker text not null'));
+      expect(block, contains('quantity numeric(28, 8) not null'));
+      expect(block, contains('buy_price_jpy numeric(20, 4) not null'));
+      expect(block, contains('buy_date date'));
+      expect(block, contains('current_price_jpy numeric(20, 4)'));
+      expect(block, contains('last_priced_at timestamptz'));
+    });
+
+    test('enforces asset type, positive quantity, and price guards', () {
+      final block = _createTableBlock(sql, 'investment_assets');
+
+      expect(
+        block,
+        contains("check (asset_type in ('stock', 'crypto', 'reit', 'etf'))"),
+      );
+      expect(block, contains('check (length(btrim(ticker)) > 0)'));
+      expect(block, contains('check (quantity > 0)'));
+      expect(block, contains('check (buy_price_jpy >= 0)'));
+      expect(
+        block,
+        contains('check (current_price_jpy is null or current_price_jpy >= 0)'),
+      );
+      expect(
+        block,
+        contains(
+          'check (last_priced_at is null or current_price_jpy is not null)',
+        ),
+      );
+    });
+
+    test('adds lookup indexes for user scoped portfolio reads', () {
+      expect(
+        sql,
+        contains(
+          'create index if not exists investment_assets_user_type_ticker_idx',
+        ),
+      );
+      expect(
+        sql,
+        contains('on public.investment_assets (user_id, asset_type, ticker)'),
+      );
+      expect(
+        sql,
+        contains(
+          'create index if not exists investment_assets_user_last_priced_idx',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'on public.investment_assets (user_id, last_priced_at desc nulls last)',
+        ),
+      );
+    });
+
+    test('enables owner-only RLS for authenticated users', () {
+      expect(
+        sql,
+        contains(
+          'alter table public.investment_assets enable row level security;',
+        ),
+      );
+
+      for (final operation in ['select', 'insert', 'update', 'delete']) {
+        expect(
+          sql,
+          contains('create policy investment_assets_${operation}_own'),
+        );
+        expect(sql, contains('for $operation\nto authenticated'));
+      }
+
+      expect(sql, contains('using (auth.uid() = user_id)'));
+      expect(sql, contains('with check (auth.uid() = user_id)'));
+    });
+
+    test('touches updated_at through a table-specific trigger', () {
+      expect(
+        sql,
+        contains(
+          'create or replace function public.set_investment_assets_updated_at()',
+        ),
+      );
+      expect(sql, contains('create trigger investment_assets_updated_at'));
+      expect(
+        sql,
+        contains(
+          'for each row execute function public.set_investment_assets_updated_at();',
+        ),
+      );
+    });
+  });
+}
+
+String _createTableBlock(String sql, String table) {
+  final start = sql.indexOf('create table if not exists public.$table');
+  expect(start, isNonNegative, reason: 'missing create table for $table');
+
+  final end = sql.indexOf('\n);', start);
+  expect(
+    end,
+    isNonNegative,
+    reason: 'missing create table terminator for $table',
+  );
+
+  return sql.substring(start, end);
+}


### PR DESCRIPTION
﻿## Summary
- Add the `public.investment_assets` table for asset-management phase 2B / Issue #2465.
- Store stocks, crypto, REITs, and ETFs with decimal quantity, JPY cost/price fields, owner-only RLS, user/ticker lookup indexes, and an `updated_at` trigger.
- Keep price fetching, UI, and production sync behavior out of scope for later #2466-#2469 slices.

Closes #2465

## Validation
- `C:\app\flutter\bin\dart.bat format test\services\investment_assets_schema_test.dart`
- `C:\app\flutter\bin\flutter.bat test test\services\investment_assets_schema_test.dart`
- `C:\app\flutter\bin\flutter.bat analyze test\services\investment_assets_schema_test.dart`
- `git diff --check` (exit 0; CRLF warnings only)
- SQL sanity: one `begin;`, one `commit;`, migration references `investment_assets`

## Minimal E2E Gate
- Plan is implementation-detail independent / black-box for this scoped DB slice: migration text -> expected table contract, constraints, indexes, RLS, and trigger.
- Minimal cases covered by static migration tests: schema fields and numeric guards, owner-only RLS across CRUD, and updated_at trigger wiring.
- E2E mechanism: Flutter test reads the migration as the artifact that will be deployed; no browser/UI flow exists in this schema-only PR.
- E2E-Exception: no Flutter UI, Edge Function behavior, provider call, or production data write is introduced.

## High-risk Ultrareview Gate
- Review owner: Claude Code #1.
- high-risk-ultrareview-exception: Codex #1 scoped schema-only migration with no data backfill, no live market/provider API calls, no secret changes, and no app production write enablement.
- Security: owner-only RLS is enabled for authenticated CRUD via `auth.uid() = user_id`; service-role bypass behavior is unchanged.
- Rollback: revert this migration before deploy, or follow a later rollback migration to drop `public.investment_assets` before downstream #2466-#2471 depend on it.
- Data migration: none; this creates an empty table only.
- Prod smoke: PR CI green, then post-merge Deploy to Production and GitHub Issues WBS Sync will be verified.
- Observability: table includes `last_priced_at` for later stale-price reporting and `updated_at` trigger for change tracking.
- Unresolved ultrareview findings: 0.

## Two-instance / subagent note
- Lead owner: Codex #1 Windows app.
- Guarded subagents: not used.
- Old Codex #2/#3 and PS lane: not used.
- Scope: #2465 investment asset DB schema only.
