### PR TITLE
feat(asset): add salary cycle spending chart (#1368)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -6144,10 +6144,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         cardBillingMarkers.add(billingName.toLowerCase());
       }
       cardBillingMarkers.add(line.billingAccountId.toLowerCase());
-      final billingLabel =
-          billingName != null && billingName.isNotEmpty
-              ? billingName
-              : line.billingAccountId;
+      final billingLabel = billingName != null && billingName.isNotEmpty
+          ? billingName
+          : line.billingAccountId;
       expenses.add(
         SalarySpendingEntry(
           date: postedAt,
@@ -6218,8 +6217,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Widget _buildSalarySpendingBreakdownCard() {
     final breakdown = _buildSalarySpendingBreakdown();
-    final periodLabel =
-        '${DateFormat('M/d').format(breakdown.periodStart)}〜'
+    final periodLabel = '${DateFormat('M/d').format(breakdown.periodStart)}〜'
         '${DateFormat('M/d').format(breakdown.periodEndInclusive)}';
     final remaining = breakdown.remainingAfterExpense;
     final topSection = breakdown.topSection;
@@ -6299,9 +6297,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 ),
                 _buildFlowPriorityMetric(
                   label: '残り目安',
-                  value: remaining == null
-                      ? '未計算'
-                      : _formatSignedYen(remaining),
+                  value:
+                      remaining == null ? '未計算' : _formatSignedYen(remaining),
                   color: remaining == null || remaining >= 0
                       ? const Color(0xFF065F46)
                       : const Color(0xFF7F1D1D),

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -34,6 +34,7 @@ import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
+import 'package:my_web_app/services/salary_spending_breakdown_service.dart';
 import 'package:my_web_app/services/smbc_csv_import_service.dart';
 import 'package:my_web_app/services/waste_tracking_service.dart';
 import 'package:my_web_app/utils/note_image_clipboard.dart';
@@ -81,6 +82,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       '1WZlHr6YWG8ZbT9r-wXtYPEdPT5E4b47PSpNSNl8A1MM';
   static const String _smbcSheetGid = '0';
   static const List<String> _jibunCandidateSheetGids = <String>['0'];
+  static const int _salarySpendingSalaryDay = 25;
+  static const List<Color> _salarySpendingChartColors = <Color>[
+    Color(0xFF0F766E),
+    Color(0xFF2563EB),
+    Color(0xFFF97316),
+    Color(0xFF9333EA),
+    Color(0xFFDC2626),
+    Color(0xFF0891B2),
+    Color(0xFF65A30D),
+    Color(0xFF7C3AED),
+    Color(0xFFB45309),
+    Color(0xFF475569),
+  ];
 
   final _supabase = Supabase.instance.client;
 
@@ -247,6 +261,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetManagementInsightService();
   final AssetManagementAiSummaryService _assetManagementAiSummaryService =
       AssetManagementAiSummaryService();
+  final SalarySpendingBreakdownService _salarySpendingBreakdownService =
+      const SalarySpendingBreakdownService();
   final DebtLockdownService _debtLockdownService = const DebtLockdownService();
   final DebtRepaymentPlannerService _debtRepaymentPlanner =
       const DebtRepaymentPlannerService();
@@ -5881,6 +5897,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ],
             _buildMonthlyFlowFirstCard(),
             const SizedBox(height: 16),
+            _buildSalarySpendingBreakdownCard(),
+            const SizedBox(height: 16),
             _buildMonthlyFlowPrimaryActionBar(),
             const SizedBox(height: 16),
             _buildWasteTrainingAiCard(),
@@ -6107,6 +6125,332 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  SalarySpendingBreakdown _buildSalarySpendingBreakdown() {
+    final expenses = <SalarySpendingEntry>[];
+    final incomes = <SalaryIncomeEntry>[];
+    final cardBillingMarkers = <String>{};
+
+    for (final line in _cardStatementLines) {
+      final postedAt = line.postedAt;
+      if (postedAt == null) {
+        continue;
+      }
+      final billingName = line.billingAccountName?.trim();
+      if (billingName != null && billingName.isNotEmpty) {
+        cardBillingMarkers.add(billingName.toLowerCase());
+      }
+      cardBillingMarkers.add(line.billingAccountId.toLowerCase());
+      final billingLabel =
+          billingName != null && billingName.isNotEmpty
+              ? billingName
+              : line.billingAccountId;
+      expenses.add(
+        SalarySpendingEntry(
+          date: postedAt,
+          amount: line.amount,
+          description: line.description,
+          sourceLabel: billingLabel,
+        ),
+      );
+    }
+
+    for (final flow in _recentFlows) {
+      final actionType = flow['action_type']?.toString() ?? '';
+      if (_isTransferActionType(actionType)) {
+        continue;
+      }
+      final occurredAt =
+          DateTime.tryParse(flow['occurred_at']?.toString() ?? '')?.toLocal();
+      final amount = (flow['amount'] as num?)?.toDouble() ?? 0;
+      if (occurredAt == null || amount <= 0) {
+        continue;
+      }
+      final description = flow['description']?.toString() ?? '';
+      final displayTitle = _flowDisplayTitle(flow);
+      if (_isExpenseActionType(actionType)) {
+        final lowerDescription = description.toLowerCase();
+        final representedByCardDetail = cardBillingMarkers.any(
+          (marker) => marker.isNotEmpty && lowerDescription.contains(marker),
+        );
+        if (representedByCardDetail) {
+          continue;
+        }
+        expenses.add(
+          SalarySpendingEntry(
+            date: occurredAt,
+            amount: amount,
+            description: displayTitle.isEmpty ? description : displayTitle,
+            sourceLabel: _actionTypeToFlowLabel(actionType),
+          ),
+        );
+      } else if (_isIncomeActionType(actionType)) {
+        incomes.add(
+          SalaryIncomeEntry(
+            date: occurredAt,
+            amount: amount,
+            description: displayTitle.isEmpty ? description : displayTitle,
+          ),
+        );
+      }
+    }
+
+    for (final plan in _monthlyIncomePlans) {
+      incomes.add(
+        SalaryIncomeEntry(
+          date: plan.date,
+          amount: plan.amount,
+          description: plan.name,
+        ),
+      );
+    }
+
+    return _salarySpendingBreakdownService.build(
+      referenceDate: _now,
+      expenses: expenses,
+      incomes: incomes,
+      salaryDay: _salarySpendingSalaryDay,
+    );
+  }
+
+  Widget _buildSalarySpendingBreakdownCard() {
+    final breakdown = _buildSalarySpendingBreakdown();
+    final periodLabel =
+        '${DateFormat('M/d').format(breakdown.periodStart)}〜'
+        '${DateFormat('M/d').format(breakdown.periodEndInclusive)}';
+    final remaining = breakdown.remainingAfterExpense;
+    final topSection = breakdown.topSection;
+    final chartSections = breakdown.sections.take(8).toList(growable: false);
+
+    return Card(
+      key: const Key('asset_salary_spending_breakdown_card'),
+      elevation: 3,
+      color: Theme.of(context).colorScheme.surfaceContainerLow,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(18),
+        side: const BorderSide(color: Color(0xFFDBEAFE)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF2563EB).withValues(alpha: 0.12),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.pie_chart_outline,
+                    color: Color(0xFF2563EB),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '前回給料の使いみち',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w800,
+                          height: 1.5,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        '給料日${breakdown.salaryDay}日基準の $periodLabel を集計。支出カテゴリ別に、前回給料が何へ消えたかを見ます。',
+                        style: TextStyle(
+                          fontSize: 12,
+                          height: 1.5,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 14),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                _buildFlowPriorityMetric(
+                  label: '期間支出',
+                  value: _formatYen(breakdown.totalExpense),
+                  color: const Color(0xFFB91C1C),
+                ),
+                _buildFlowPriorityMetric(
+                  label: '給料収入',
+                  value: breakdown.salaryIncomeTotal > 0
+                      ? _formatYen(breakdown.salaryIncomeTotal)
+                      : '未記録',
+                  color: const Color(0xFF0F766E),
+                ),
+                _buildFlowPriorityMetric(
+                  label: '残り目安',
+                  value: remaining == null
+                      ? '未計算'
+                      : _formatSignedYen(remaining),
+                  color: remaining == null || remaining >= 0
+                      ? const Color(0xFF065F46)
+                      : const Color(0xFF7F1D1D),
+                ),
+                _buildFlowPriorityMetric(
+                  label: '最大カテゴリ',
+                  value: topSection == null
+                      ? '未記録'
+                      : '${topSection.category} ${(topSection.ratio * 100).round()}%',
+                  color: const Color(0xFF2563EB),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (breakdown.sections.isEmpty)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFEFF6FF),
+                  borderRadius: BorderRadius.circular(14),
+                  border: Border.all(color: const Color(0xFFBFDBFE)),
+                ),
+                child: const Text(
+                  'この給与サイクルの支出がまだありません。収支入力またはカード明細取込を行うと円グラフが表示されます。',
+                  style: TextStyle(
+                    color: Color(0xFF1E3A8A),
+                    height: 1.5,
+                  ),
+                ),
+              )
+            else
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  final compact = constraints.maxWidth < 620;
+                  final chart = SizedBox(
+                    height: compact ? 210 : 240,
+                    width: compact ? double.infinity : 260,
+                    child: PieChart(
+                      PieChartData(
+                        sectionsSpace: 2,
+                        centerSpaceRadius: compact ? 42 : 50,
+                        sections: [
+                          for (var i = 0; i < chartSections.length; i++)
+                            PieChartSectionData(
+                              color: _salarySpendingChartColors[
+                                  i % _salarySpendingChartColors.length],
+                              value: chartSections[i].amount,
+                              title:
+                                  '${(chartSections[i].ratio * 100).round()}%',
+                              radius: compact ? 72 : 82,
+                              titleStyle: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  );
+                  final legend = Column(
+                    children: [
+                      for (var i = 0; i < chartSections.length; i++)
+                        _buildSalarySpendingLegendRow(
+                          section: chartSections[i],
+                          color: _salarySpendingChartColors[
+                              i % _salarySpendingChartColors.length],
+                        ),
+                    ],
+                  );
+                  if (compact) {
+                    return Column(
+                      children: [
+                        chart,
+                        const SizedBox(height: 12),
+                        legend,
+                      ],
+                    );
+                  }
+                  return Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      chart,
+                      const SizedBox(width: 18),
+                      Expanded(child: legend),
+                    ],
+                  );
+                },
+              ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: OutlinedButton.icon(
+                onPressed: () => _scrollTo(_keyFlow),
+                icon: const Icon(Icons.add_chart),
+                label: const Text('支出を追加して内訳を更新'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSalarySpendingLegendRow({
+    required SalarySpendingCategorySlice section,
+    required Color color,
+  }) {
+    final samples = section.sampleDescriptions
+        .where((sample) => sample.trim().isNotEmpty)
+        .take(2)
+        .join(' / ');
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 12,
+            height: 12,
+            margin: const EdgeInsets.only(top: 4),
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${section.category} ${_formatYen(section.amount)}',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    height: 1.4,
+                  ),
+                ),
+                Text(
+                  '${(section.ratio * 100).toStringAsFixed(1)}% / ${section.entryCount}件'
+                  '${samples.isEmpty ? '' : ' / $samples'}',
+                  style: const TextStyle(
+                    fontSize: 11,
+                    color: Color(0xFF64748B),
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/services/salary_spending_breakdown_service.dart
+++ b/lib/services/salary_spending_breakdown_service.dart
@@ -1,0 +1,346 @@
+class SalarySpendingEntry {
+  const SalarySpendingEntry({
+    required this.date,
+    required this.amount,
+    required this.description,
+    required this.sourceLabel,
+  });
+
+  final DateTime date;
+  final double amount;
+  final String description;
+  final String sourceLabel;
+}
+
+class SalaryIncomeEntry {
+  const SalaryIncomeEntry({
+    required this.date,
+    required this.amount,
+    required this.description,
+  });
+
+  final DateTime date;
+  final double amount;
+  final String description;
+}
+
+class SalarySpendingCategorySlice {
+  const SalarySpendingCategorySlice({
+    required this.category,
+    required this.amount,
+    required this.entryCount,
+    required this.ratio,
+    required this.sampleDescriptions,
+  });
+
+  final String category;
+  final double amount;
+  final int entryCount;
+  final double ratio;
+  final List<String> sampleDescriptions;
+}
+
+class SalarySpendingBreakdown {
+  const SalarySpendingBreakdown({
+    required this.salaryDay,
+    required this.periodStart,
+    required this.periodEndExclusive,
+    required this.totalExpense,
+    required this.salaryIncomeTotal,
+    required this.expenseEntryCount,
+    required this.sections,
+  });
+
+  final int salaryDay;
+  final DateTime periodStart;
+  final DateTime periodEndExclusive;
+  final double totalExpense;
+  final double salaryIncomeTotal;
+  final int expenseEntryCount;
+  final List<SalarySpendingCategorySlice> sections;
+
+  DateTime get periodEndInclusive =>
+      periodEndExclusive.subtract(const Duration(days: 1));
+
+  double? get remainingAfterExpense =>
+      salaryIncomeTotal > 0 ? salaryIncomeTotal - totalExpense : null;
+
+  SalarySpendingCategorySlice? get topSection =>
+      sections.isEmpty ? null : sections.first;
+}
+
+class SalarySpendingBreakdownService {
+  const SalarySpendingBreakdownService();
+
+  static const int defaultSalaryDay = 25;
+
+  SalarySpendingBreakdown build({
+    required DateTime referenceDate,
+    Iterable<SalarySpendingEntry> expenses = const <SalarySpendingEntry>[],
+    Iterable<SalaryIncomeEntry> incomes = const <SalaryIncomeEntry>[],
+    int salaryDay = defaultSalaryDay,
+  }) {
+    final normalizedSalaryDay = salaryDay.clamp(1, 28).toInt();
+    final periodStart = salaryPeriodStartFor(
+      referenceDate: referenceDate,
+      salaryDay: normalizedSalaryDay,
+    );
+    final periodEndExclusive = _safeDate(
+      periodStart.year,
+      periodStart.month + 1,
+      normalizedSalaryDay,
+    );
+
+    final totalsByCategory = <String, double>{};
+    final countsByCategory = <String, int>{};
+    final samplesByCategory = <String, List<String>>{};
+    var totalExpense = 0.0;
+    var expenseEntryCount = 0;
+
+    for (final entry in expenses) {
+      if (!_isInRange(entry.date, periodStart, periodEndExclusive)) {
+        continue;
+      }
+      final amount = entry.amount.abs();
+      if (amount <= 0) {
+        continue;
+      }
+      final category = categorize(entry.description);
+      totalsByCategory[category] = (totalsByCategory[category] ?? 0) + amount;
+      countsByCategory[category] = (countsByCategory[category] ?? 0) + 1;
+      samplesByCategory.putIfAbsent(category, () => <String>[]);
+      if (samplesByCategory[category]!.length < 2) {
+        final sample = entry.description.trim().isEmpty
+            ? entry.sourceLabel
+            : entry.description.trim();
+        samplesByCategory[category]!.add(sample);
+      }
+      totalExpense += amount;
+      expenseEntryCount += 1;
+    }
+
+    final incomeEntries = incomes.toList(growable: false);
+    var salaryIncomeTotal = 0.0;
+    for (final entry in incomeEntries) {
+      if (!_isInRange(entry.date, periodStart, periodEndExclusive)) {
+        continue;
+      }
+      if (_looksLikeSalary(entry.description) || incomeEntries.length == 1) {
+        salaryIncomeTotal += entry.amount.abs();
+      }
+    }
+
+    final sections = totalsByCategory.entries
+        .map(
+          (entry) => SalarySpendingCategorySlice(
+            category: entry.key,
+            amount: entry.value,
+            entryCount: countsByCategory[entry.key] ?? 0,
+            ratio: totalExpense > 0 ? entry.value / totalExpense : 0,
+            sampleDescriptions: List<String>.unmodifiable(
+              samplesByCategory[entry.key] ?? const <String>[],
+            ),
+          ),
+        )
+        .toList()
+      ..sort((a, b) => b.amount.compareTo(a.amount));
+
+    return SalarySpendingBreakdown(
+      salaryDay: normalizedSalaryDay,
+      periodStart: periodStart,
+      periodEndExclusive: periodEndExclusive,
+      totalExpense: totalExpense,
+      salaryIncomeTotal: salaryIncomeTotal,
+      expenseEntryCount: expenseEntryCount,
+      sections: List<SalarySpendingCategorySlice>.unmodifiable(sections),
+    );
+  }
+
+  DateTime salaryPeriodStartFor({
+    required DateTime referenceDate,
+    int salaryDay = defaultSalaryDay,
+  }) {
+    final normalizedSalaryDay = salaryDay.clamp(1, 28).toInt();
+    final today = DateTime(
+      referenceDate.year,
+      referenceDate.month,
+      referenceDate.day,
+    );
+    final currentMonthSalaryDay = _safeDate(
+      referenceDate.year,
+      referenceDate.month,
+      normalizedSalaryDay,
+    );
+    if (today.isBefore(currentMonthSalaryDay)) {
+      return _safeDate(
+        referenceDate.year,
+        referenceDate.month - 1,
+        normalizedSalaryDay,
+      );
+    }
+    return currentMonthSalaryDay;
+  }
+
+  String categorize(String description) {
+    final text = description.toLowerCase();
+    for (final rule in _categoryRules) {
+      for (final keyword in rule.keywords) {
+        if (text.contains(keyword.toLowerCase())) {
+          return rule.label;
+        }
+      }
+    }
+    return 'その他';
+  }
+
+  static bool _isInRange(DateTime date, DateTime start, DateTime endExclusive) {
+    final normalized = DateTime(date.year, date.month, date.day);
+    return !normalized.isBefore(start) && normalized.isBefore(endExclusive);
+  }
+
+  static DateTime _safeDate(int year, int month, int day) {
+    final firstOfMonth = DateTime(year, month, 1);
+    final lastDay = DateTime(firstOfMonth.year, firstOfMonth.month + 1, 0).day;
+    final safeDay = day.clamp(1, lastDay).toInt();
+    return DateTime(firstOfMonth.year, firstOfMonth.month, safeDay);
+  }
+
+  static bool _looksLikeSalary(String description) {
+    final text = description.toLowerCase();
+    return text.contains('給料') ||
+        text.contains('給与') ||
+        text.contains('salary') ||
+        text.contains('payroll') ||
+        text.contains('賞与') ||
+        text.contains('収入');
+  }
+}
+
+class _SalarySpendingCategoryRule {
+  const _SalarySpendingCategoryRule(this.label, this.keywords);
+
+  final String label;
+  final List<String> keywords;
+}
+
+const List<_SalarySpendingCategoryRule> _categoryRules =
+    <_SalarySpendingCategoryRule>[
+  _SalarySpendingCategoryRule('住居', <String>[
+    '家賃',
+    '住宅',
+    '管理費',
+    'rent',
+    'housing',
+  ]),
+  _SalarySpendingCategoryRule('借入返済', <String>[
+    '返済',
+    'ローン',
+    'loan',
+    'リボ',
+    '借入',
+    'mobit',
+    'acom',
+    'promise',
+    'カードローン',
+  ]),
+  _SalarySpendingCategoryRule('食費', <String>[
+    '食費',
+    'スーパー',
+    'コンビニ',
+    'セブン',
+    'ローソン',
+    'ファミマ',
+    'restaurant',
+    'lunch',
+    'dinner',
+    'cafe',
+    'coffee',
+    'grocery',
+    'food',
+    'starbucks',
+  ]),
+  _SalarySpendingCategoryRule('通信', <String>[
+    '通信',
+    '携帯',
+    'スマホ',
+    'mobile',
+    'docomo',
+    'softbank',
+    'internet',
+    'wifi',
+    'sim',
+  ]),
+  _SalarySpendingCategoryRule('光熱費', <String>[
+    '電気',
+    'ガス',
+    '水道',
+    'utility',
+    'utilities',
+  ]),
+  _SalarySpendingCategoryRule('交通', <String>[
+    '交通',
+    '電車',
+    'バス',
+    'タクシー',
+    'suica',
+    'pasmo',
+    'taxi',
+    'uber',
+    'parking',
+  ]),
+  _SalarySpendingCategoryRule('サブスク', <String>[
+    'サブスク',
+    'subscription',
+    'netflix',
+    'spotify',
+    'youtube',
+    'amazon prime',
+    'apple',
+    'google',
+    'openai',
+    'claude',
+  ]),
+  _SalarySpendingCategoryRule('投資・貯蓄', <String>[
+    '投資',
+    '証券',
+    'nisa',
+    '積立',
+    '株',
+    'crypto',
+    'coincheck',
+    'bitflyer',
+    'reit',
+  ]),
+  _SalarySpendingCategoryRule('医療', <String>[
+    '医療',
+    '病院',
+    '薬',
+    '薬局',
+    'pharmacy',
+    'clinic',
+  ]),
+  _SalarySpendingCategoryRule('日用品', <String>[
+    '日用品',
+    'ドラッグ',
+    'amazon',
+    '楽天',
+    'shopping',
+    'store',
+  ]),
+  _SalarySpendingCategoryRule('娯楽・浪費', <String>[
+    '飲み',
+    '酒',
+    'bar',
+    'game',
+    'steam',
+    'パチンコ',
+    'ギャンブル',
+    'casino',
+  ]),
+  _SalarySpendingCategoryRule('手数料・税金', <String>[
+    '手数料',
+    '税',
+    'fee',
+    'tax',
+  ]),
+];

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -836,6 +836,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -920,18 +928,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1525,26 +1533,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/test/services/salary_spending_breakdown_service_test.dart
+++ b/test/services/salary_spending_breakdown_service_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/salary_spending_breakdown_service.dart';
+
+void main() {
+  group('SalarySpendingBreakdownService', () {
+    const service = SalarySpendingBreakdownService();
+
+    test('uses the 25th as the salary-cycle boundary before payday', () {
+      final breakdown = service.build(
+        referenceDate: DateTime(2026, 5, 23),
+        expenses: <SalarySpendingEntry>[
+          SalarySpendingEntry(
+            date: DateTime(2026, 4, 24),
+            amount: 9999,
+            description: 'outside previous cycle',
+            sourceLabel: 'flow',
+          ),
+          SalarySpendingEntry(
+            date: DateTime(2026, 4, 25),
+            amount: 120000,
+            description: '家賃',
+            sourceLabel: 'flow',
+          ),
+          SalarySpendingEntry(
+            date: DateTime(2026, 5, 24),
+            amount: 5000,
+            description: 'スーパー',
+            sourceLabel: 'flow',
+          ),
+          SalarySpendingEntry(
+            date: DateTime(2026, 5, 25),
+            amount: 3000,
+            description: 'next salary cycle',
+            sourceLabel: 'flow',
+          ),
+        ],
+        incomes: <SalaryIncomeEntry>[
+          SalaryIncomeEntry(
+            date: DateTime(2026, 4, 25),
+            amount: 245000,
+            description: '給与',
+          ),
+        ],
+      );
+
+      expect(breakdown.periodStart, DateTime(2026, 4, 25));
+      expect(breakdown.periodEndExclusive, DateTime(2026, 5, 25));
+      expect(breakdown.totalExpense, 125000);
+      expect(breakdown.salaryIncomeTotal, 245000);
+      expect(breakdown.remainingAfterExpense, 120000);
+    });
+
+    test('groups expenses by category and sorts by amount', () {
+      final breakdown = service.build(
+        referenceDate: DateTime(2026, 5, 26),
+        expenses: <SalarySpendingEntry>[
+          SalarySpendingEntry(
+            date: DateTime(2026, 5, 25),
+            amount: 10000,
+            description: 'Netflix subscription',
+            sourceLabel: 'card',
+          ),
+          SalarySpendingEntry(
+            date: DateTime(2026, 5, 26),
+            amount: 30000,
+            description: 'カードローン返済',
+            sourceLabel: 'flow',
+          ),
+          SalarySpendingEntry(
+            date: DateTime(2026, 5, 26),
+            amount: 2000,
+            description: '用途未分類',
+            sourceLabel: 'flow',
+          ),
+        ],
+      );
+
+      expect(breakdown.sections.map((section) => section.category), <String>[
+        '借入返済',
+        'サブスク',
+        'その他',
+      ]);
+      expect(breakdown.sections.first.amount, 30000);
+      expect(breakdown.sections.first.ratio, closeTo(30000 / 42000, 0.0001));
+      expect(breakdown.expenseEntryCount, 3);
+    });
+
+    test('falls back to single income entry even without salary keywords', () {
+      final breakdown = service.build(
+        referenceDate: DateTime(2026, 5, 23),
+        incomes: <SalaryIncomeEntry>[
+          SalaryIncomeEntry(
+            date: DateTime(2026, 4, 25),
+            amount: 180000,
+            description: 'main income',
+          ),
+        ],
+      );
+
+      expect(breakdown.salaryIncomeTotal, 180000);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add a salary-cycle spending breakdown service keyed to payday 25, including category grouping and salary-income matching.
- Surface 「前回給料の使いみち」 on `/asset-management` with KPI chips, pie chart, and category legend.
- Add service tests for the 25th boundary, category sorting, and single-income fallback.

## Validation
- `git diff --check`
- Pure Dart smoke for `SalarySpendingBreakdownService` passed.
- GitHub auto-fix applied Dart formatting on the PR branch.
- Local `dart format` and `flutter test test/services/salary_spending_breakdown_service_test.dart --no-pub --reporter compact` timed out in this Windows session, so the hosted check is the full Flutter toolchain verdict.

## Minimal E2E Gate
- The E2E plan is implementation-detail independent / black-box: verify the visible salary-cycle card output from seeded income and expense inputs.
- The plan is minimal, about three I/O cases: before-payday cycle, after-payday cycle, and empty-period state.
- Mechanism: Playwright or `integration_test` can exercise `/asset-management` once a deterministic asset workbook fixture is available.
- E2E-Exception: this scoped slice adds deterministic service coverage and visible UI wiring only; no stable seeded browser fixture exists yet for the local workbook-backed asset page.

## Ops notes
- Issue: #1368 (existing canonical spending classification / chart request; no duplicate issue created)
- Top-level owner: Codex #1
- Subagents: none used
- External APIs / live writes: none