### PR TITLE
feat(asset): add market price cache (#2466)

### DIFF
--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -42,6 +42,12 @@ import {
   type MonthlyAssetReportDb,
   normalizeMonthlyAssetReportProvider,
 } from "./monthly_asset_report.ts";
+import {
+  handleMarketPriceAction,
+  isMarketPriceLiveFetchEnabled,
+  MarketPriceActionError,
+  type MarketPriceDb,
+} from "./market_price.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -2836,6 +2842,9 @@ serve(async (req: Request) => {
       "quiz.evaluate",
       "quiz.explain",
       "kpi.monthly_summary",
+      "asset.market_price.fetch",
+      "asset.investment.market_price.fetch",
+      "ai_hub.fetch_market_price",
       "asset.monthly_report.generate",
       "asset_liability.monthly_report.generate",
       "voice.tts",
@@ -4214,6 +4223,18 @@ serve(async (req: Request) => {
         });
       }
 
+      case "asset.market_price.fetch":
+      case "asset.investment.market_price.fetch":
+      case "ai_hub.fetch_market_price": {
+        const result = await handleMarketPriceAction({
+          db: admin as unknown as MarketPriceDb,
+          body,
+          userId: userId ?? "",
+          liveFetchEnabled: isMarketPriceLiveFetchEnabled(body),
+        });
+        return json({ success: true, ...result });
+      }
+
       case "asset.monthly_report.generate":
       case "asset_liability.monthly_report.generate": {
         const aiSummaryEnabled = isMonthlyAssetReportAiSummaryEnabled(body);
@@ -5347,6 +5368,9 @@ serve(async (req: Request) => {
       return json({ error: err.message }, err.status);
     }
     if (err instanceof MonthlyAssetReportActionError) {
+      return json({ error: err.message }, err.status);
+    }
+    if (err instanceof MarketPriceActionError) {
       return json({ error: err.message }, err.status);
     }
     const message = err instanceof Error ? err.message : String(err);

--- a/supabase/functions/ai-hub/market_price.ts
+++ b/supabase/functions/ai-hub/market_price.ts
@@ -1,0 +1,627 @@
+type UnknownRecord = Record<string, unknown>;
+
+type QueryResult = {
+  data?: unknown[] | null;
+  error?: { message?: string } | null;
+};
+
+type SingleResult = {
+  data?: unknown | null;
+  error?: { message?: string } | null;
+};
+
+export type MarketPriceDbQuery = {
+  select(columns?: string): MarketPriceDbQuery;
+  eq(column: string, value: string): MarketPriceDbQuery;
+  order(
+    column: string,
+    options?: { ascending?: boolean },
+  ): MarketPriceDbQuery;
+  limit(count: number): Promise<QueryResult>;
+  update(value: UnknownRecord): MarketPriceDbQuery;
+  upsert(
+    value: UnknownRecord,
+    options?: { onConflict?: string },
+  ): {
+    select(columns?: string): {
+      single(): Promise<SingleResult>;
+    };
+  };
+};
+
+export type MarketPriceDb = {
+  from(table: string): MarketPriceDbQuery;
+};
+
+export type MarketPriceFetchRequest = {
+  assetType: MarketPriceAssetType;
+  ticker: string;
+  currency: string;
+  provider: string;
+  body: UnknownRecord;
+};
+
+export type MarketPriceFetchResult = {
+  ok: boolean;
+  priceJpy?: number;
+  provider?: string;
+  fetchedAt?: string;
+  payload?: UnknownRecord;
+  error?: string;
+  rateLimited?: boolean;
+};
+
+export type MarketPriceFetcher = (
+  request: MarketPriceFetchRequest,
+) => Promise<MarketPriceFetchResult>;
+
+export type MarketPriceAssetType = "stock" | "crypto" | "reit" | "etf";
+
+export type MarketPriceInput = {
+  assetType: MarketPriceAssetType;
+  ticker: string;
+  currency: string;
+  provider: string;
+  cacheMinutes: number;
+  forceRefresh: boolean;
+  dryRun: boolean;
+};
+
+type MarketPriceCacheRow = {
+  asset_type: MarketPriceAssetType;
+  ticker: string;
+  currency: string;
+  provider: string;
+  price_jpy: number;
+  fetched_at: string;
+  expires_at: string;
+  source_payload?: UnknownRecord;
+};
+
+export type MarketPriceActionResult = {
+  status:
+    | "cache_hit"
+    | "cache_write"
+    | "stale_cache_fallback"
+    | "external_fetch_disabled"
+    | "provider_rate_limited"
+    | "provider_error";
+  asset_type: MarketPriceAssetType;
+  ticker: string;
+  currency: string;
+  provider: string;
+  price_jpy: number | null;
+  fetched_at: string | null;
+  expires_at: string | null;
+  source: "cache" | "provider" | "none";
+  cache_age_minutes: number | null;
+  cache_ttl_minutes: number;
+  dry_run: boolean;
+  updated_holding_count: number;
+  warnings: string[];
+};
+
+export class MarketPriceActionError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "MarketPriceActionError";
+    this.status = status;
+  }
+}
+
+const ASSET_TYPES = new Set(["stock", "crypto", "reit", "etf"]);
+const MARKET_PRICE_ACTIONS = new Set([
+  "asset.market_price.fetch",
+  "asset.investment.market_price.fetch",
+  "ai_hub.fetch_market_price",
+]);
+const COMMON_COINGECKO_IDS: Record<string, string> = {
+  btc: "bitcoin",
+  bitcoin: "bitcoin",
+  eth: "ethereum",
+  ethereum: "ethereum",
+  sol: "solana",
+  solana: "solana",
+  xrp: "ripple",
+  ripple: "ripple",
+  doge: "dogecoin",
+  dogecoin: "dogecoin",
+  ada: "cardano",
+  cardano: "cardano",
+};
+
+export function isMarketPriceAction(action: string): boolean {
+  return MARKET_PRICE_ACTIONS.has(action);
+}
+
+export function isMarketPriceLiveFetchEnabled(body: UnknownRecord): boolean {
+  return body.live_fetch_enabled === true ||
+    body.enable_live_fetch === true ||
+    Deno.env.get("ASSET_MARKET_PRICE_LIVE_FETCH_ENABLED") === "true";
+}
+
+export function normalizeMarketPriceInput(
+  body: UnknownRecord,
+): MarketPriceInput {
+  const assetType = normalizeAssetType(body.asset_type ?? body.assetType);
+  const ticker = normalizeTicker(body.ticker ?? body.symbol);
+  const currency = normalizeCurrency(body.currency);
+  const provider = normalizeMarketPriceProvider(
+    body.provider,
+    assetType,
+  );
+  const cacheMinutes = clampNumber(
+    readOptionalNumber(body, ["cache_minutes", "cacheMinutes"]) ?? 30,
+    5,
+    24 * 60,
+  );
+  return {
+    assetType,
+    ticker,
+    currency,
+    provider,
+    cacheMinutes,
+    forceRefresh: body.force_refresh === true ||
+      body.forceRefresh === true,
+    dryRun: body.dry_run === true || body.dryRun === true,
+  };
+}
+
+export async function handleMarketPriceAction(options: {
+  db: MarketPriceDb;
+  body: UnknownRecord;
+  userId: string;
+  fetcher?: MarketPriceFetcher;
+  liveFetchEnabled?: boolean;
+  now?: Date;
+}): Promise<MarketPriceActionResult> {
+  const input = normalizeMarketPriceInput(options.body);
+  const now = options.now ?? new Date();
+  const liveFetchEnabled = options.liveFetchEnabled ??
+    isMarketPriceLiveFetchEnabled(options.body);
+  const warnings: string[] = [];
+  const cached = await readMarketPriceCache(options.db, input, warnings);
+  if (cached && !input.forceRefresh && isFresh(cached, now)) {
+    return resultFromCache({
+      status: "cache_hit",
+      input,
+      cached,
+      now,
+      warnings,
+      updatedHoldingCount: 0,
+    });
+  }
+
+  if (!liveFetchEnabled) {
+    if (cached) {
+      warnings.push("Live market price fetch is disabled; using stale cache.");
+      return resultFromCache({
+        status: "stale_cache_fallback",
+        input,
+        cached,
+        now,
+        warnings,
+        updatedHoldingCount: 0,
+      });
+    }
+    warnings.push("Live market price fetch is disabled and no cache exists.");
+    return emptyResult("external_fetch_disabled", input, warnings);
+  }
+
+  const fetcher = options.fetcher ?? fetchConfiguredMarketPrice;
+  const providerResult = await fetcher({
+    assetType: input.assetType,
+    ticker: input.ticker,
+    currency: input.currency,
+    provider: input.provider,
+    body: options.body,
+  });
+  if (!providerResult.ok || !isPositivePrice(providerResult.priceJpy)) {
+    const status = providerResult.rateLimited
+      ? "provider_rate_limited"
+      : "provider_error";
+    warnings.push(
+      providerResult.error ?? "Provider returned no usable JPY price.",
+    );
+    if (cached) {
+      warnings.push("Using last cached market price as fallback.");
+      return resultFromCache({
+        status: "stale_cache_fallback",
+        input,
+        cached,
+        now,
+        warnings,
+        updatedHoldingCount: 0,
+      });
+    }
+    return emptyResult(status, input, warnings);
+  }
+
+  const fetchedAt = providerResult.fetchedAt ?? now.toISOString();
+  const expiresAt = new Date(
+    new Date(fetchedAt).getTime() + input.cacheMinutes * 60 * 1000,
+  ).toISOString();
+  const cachePayload: UnknownRecord = {
+    asset_type: input.assetType,
+    ticker: input.ticker,
+    currency: input.currency,
+    provider: providerResult.provider ?? input.provider,
+    price_jpy: roundPrice(providerResult.priceJpy),
+    fetched_at: fetchedAt,
+    expires_at: expiresAt,
+    source_payload: providerResult.payload ?? {},
+  };
+
+  let updatedHoldingCount = 0;
+  if (!input.dryRun) {
+    const { error } = await options.db.from("investment_market_price_cache")
+      .upsert(cachePayload, { onConflict: "asset_type,ticker,currency" })
+      .select(
+        "asset_type,ticker,currency,provider,price_jpy,fetched_at,expires_at,source_payload",
+      )
+      .single();
+    if (error) {
+      throw new MarketPriceActionError(
+        `investment_market_price_cache upsert failed: ${
+          error.message ?? "unknown"
+        }`,
+        500,
+      );
+    }
+    updatedHoldingCount = await updateInvestmentAssetPrices({
+      db: options.db,
+      userId: options.userId,
+      input,
+      priceJpy: roundPrice(providerResult.priceJpy),
+      fetchedAt,
+      warnings,
+    });
+  }
+
+  return {
+    status: "cache_write",
+    asset_type: input.assetType,
+    ticker: input.ticker,
+    currency: input.currency,
+    provider: providerResult.provider ?? input.provider,
+    price_jpy: roundPrice(providerResult.priceJpy),
+    fetched_at: fetchedAt,
+    expires_at: expiresAt,
+    source: "provider",
+    cache_age_minutes: 0,
+    cache_ttl_minutes: input.cacheMinutes,
+    dry_run: input.dryRun,
+    updated_holding_count: updatedHoldingCount,
+    warnings,
+  };
+}
+
+export function fetchConfiguredMarketPrice(
+  request: MarketPriceFetchRequest,
+): Promise<MarketPriceFetchResult> {
+  if (request.assetType === "crypto") {
+    return fetchCoinGeckoCryptoPrice(request);
+  }
+  return fetchAlphaVantageMarketPrice(request);
+}
+
+async function fetchCoinGeckoCryptoPrice(
+  request: MarketPriceFetchRequest,
+): Promise<MarketPriceFetchResult> {
+  const id = readString(request.body.coingecko_id) ||
+    COMMON_COINGECKO_IDS[request.ticker.toLowerCase()];
+  if (!id) {
+    return {
+      ok: false,
+      error: "coingecko_id required for crypto tickers not in the common map",
+      rateLimited: false,
+    };
+  }
+  const vsCurrency = request.currency.toLowerCase();
+  const url = new URL("https://api.coingecko.com/api/v3/simple/price");
+  url.searchParams.set("ids", id);
+  url.searchParams.set("vs_currencies", vsCurrency);
+  const response = await fetch(url);
+  const rawText = await response.text();
+  const parsed = parseJsonRecord(rawText);
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: `coingecko:${response.status}:${rawText.slice(0, 240)}`,
+      rateLimited: response.status === 429,
+    };
+  }
+  const price = readOptionalNumber(asRecord(parsed[id]) ?? {}, [vsCurrency]);
+  return {
+    ok: isPositivePrice(price),
+    priceJpy: price,
+    provider: "coingecko",
+    payload: parsed,
+    error: isPositivePrice(price) ? undefined : "coingecko price missing",
+  };
+}
+
+async function fetchAlphaVantageMarketPrice(
+  request: MarketPriceFetchRequest,
+): Promise<MarketPriceFetchResult> {
+  const apiKey = Deno.env.get("ALPHA_VANTAGE_API_KEY") ?? "";
+  if (!apiKey) {
+    return {
+      ok: false,
+      error: "ALPHA_VANTAGE_API_KEY required for stock/ETF/REIT prices",
+      rateLimited: false,
+    };
+  }
+  const url = new URL("https://www.alphavantage.co/query");
+  url.searchParams.set("function", "GLOBAL_QUOTE");
+  url.searchParams.set("symbol", request.ticker);
+  url.searchParams.set("apikey", apiKey);
+  const response = await fetch(url);
+  const rawText = await response.text();
+  const parsed = parseJsonRecord(rawText);
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: `alpha_vantage:${response.status}:${rawText.slice(0, 240)}`,
+      rateLimited: response.status === 429,
+    };
+  }
+  const quote = asRecord(parsed["Global Quote"]) ?? {};
+  const rateLimited = readString(parsed.Note).length > 0 ||
+    readString(parsed.Information).toLowerCase().includes("rate limit");
+  const price = readOptionalNumber(quote, ["05. price", "price"]);
+  return {
+    ok: isPositivePrice(price) && !rateLimited,
+    priceJpy: price,
+    provider: "alpha_vantage",
+    payload: parsed,
+    error: rateLimited
+      ? "alpha_vantage rate limit"
+      : isPositivePrice(price)
+      ? undefined
+      : "alpha_vantage price missing",
+    rateLimited,
+  };
+}
+
+async function readMarketPriceCache(
+  db: MarketPriceDb,
+  input: MarketPriceInput,
+  warnings: string[],
+): Promise<MarketPriceCacheRow | null> {
+  try {
+    const { data, error } = await db.from("investment_market_price_cache")
+      .select(
+        "asset_type,ticker,currency,provider,price_jpy,fetched_at,expires_at,source_payload",
+      )
+      .eq("asset_type", input.assetType)
+      .eq("ticker", input.ticker)
+      .eq("currency", input.currency)
+      .order("expires_at", { ascending: false })
+      .limit(1);
+    if (error) {
+      warnings.push(`price cache read skipped: ${error.message ?? "unknown"}`);
+      return null;
+    }
+    const row = firstRecord(data);
+    return row ? normalizeCacheRow(row) : null;
+  } catch (error) {
+    warnings.push(`price cache read skipped: ${String(error)}`);
+    return null;
+  }
+}
+
+async function updateInvestmentAssetPrices(options: {
+  db: MarketPriceDb;
+  userId: string;
+  input: MarketPriceInput;
+  priceJpy: number;
+  fetchedAt: string;
+  warnings: string[];
+}): Promise<number> {
+  if (!options.userId) return 0;
+  try {
+    const { data, error } = await options.db.from("investment_assets")
+      .update({
+        current_price_jpy: options.priceJpy,
+        last_priced_at: options.fetchedAt,
+      })
+      .eq("user_id", options.userId)
+      .eq("asset_type", options.input.assetType)
+      .eq("ticker", options.input.ticker)
+      .select("id")
+      .limit(1000);
+    if (error) {
+      options.warnings.push(
+        `investment_assets update skipped: ${error.message ?? "unknown"}`,
+      );
+      return 0;
+    }
+    return toRecords(data).length;
+  } catch (error) {
+    options.warnings.push(`investment_assets update skipped: ${String(error)}`);
+    return 0;
+  }
+}
+
+function resultFromCache(options: {
+  status: "cache_hit" | "stale_cache_fallback";
+  input: MarketPriceInput;
+  cached: MarketPriceCacheRow;
+  now: Date;
+  warnings: string[];
+  updatedHoldingCount: number;
+}): MarketPriceActionResult {
+  return {
+    status: options.status,
+    asset_type: options.input.assetType,
+    ticker: options.input.ticker,
+    currency: options.input.currency,
+    provider: options.cached.provider,
+    price_jpy: options.cached.price_jpy,
+    fetched_at: options.cached.fetched_at,
+    expires_at: options.cached.expires_at,
+    source: "cache",
+    cache_age_minutes: cacheAgeMinutes(options.cached, options.now),
+    cache_ttl_minutes: options.input.cacheMinutes,
+    dry_run: options.input.dryRun,
+    updated_holding_count: options.updatedHoldingCount,
+    warnings: options.warnings,
+  };
+}
+
+function emptyResult(
+  status:
+    | "external_fetch_disabled"
+    | "provider_rate_limited"
+    | "provider_error",
+  input: MarketPriceInput,
+  warnings: string[],
+): MarketPriceActionResult {
+  return {
+    status,
+    asset_type: input.assetType,
+    ticker: input.ticker,
+    currency: input.currency,
+    provider: input.provider,
+    price_jpy: null,
+    fetched_at: null,
+    expires_at: null,
+    source: "none",
+    cache_age_minutes: null,
+    cache_ttl_minutes: input.cacheMinutes,
+    dry_run: input.dryRun,
+    updated_holding_count: 0,
+    warnings,
+  };
+}
+
+function normalizeCacheRow(row: UnknownRecord): MarketPriceCacheRow {
+  return {
+    asset_type: normalizeAssetType(row.asset_type),
+    ticker: normalizeTicker(row.ticker),
+    currency: normalizeCurrency(row.currency),
+    provider: readString(row.provider) || "unknown",
+    price_jpy: roundPrice(
+      readOptionalNumber(row, ["price_jpy", "priceJpy"]) ?? 0,
+    ),
+    fetched_at: readString(row.fetched_at),
+    expires_at: readString(row.expires_at),
+    source_payload: asRecord(row.source_payload) ?? {},
+  };
+}
+
+function normalizeAssetType(value: unknown): MarketPriceAssetType {
+  const key = readString(value).toLowerCase();
+  if (ASSET_TYPES.has(key)) return key as MarketPriceAssetType;
+  throw new MarketPriceActionError(
+    "asset_type must be one of stock, crypto, reit, etf",
+    400,
+  );
+}
+
+function normalizeTicker(value: unknown): string {
+  const ticker = readString(value).toUpperCase();
+  if (!ticker) {
+    throw new MarketPriceActionError("ticker is required", 400);
+  }
+  if (!/^[A-Z0-9._:-]{1,32}$/.test(ticker)) {
+    throw new MarketPriceActionError(
+      "ticker must be 1-32 chars of A-Z, 0-9, dot, underscore, colon, or hyphen",
+      400,
+    );
+  }
+  return ticker;
+}
+
+function normalizeCurrency(value: unknown): string {
+  const currency = readString(value).toUpperCase() || "JPY";
+  if (!/^[A-Z]{3}$/.test(currency)) {
+    throw new MarketPriceActionError("currency must be a 3-letter code", 400);
+  }
+  if (currency !== "JPY") {
+    throw new MarketPriceActionError(
+      "Only JPY market price cache is supported in this phase",
+      400,
+    );
+  }
+  return currency;
+}
+
+function normalizeMarketPriceProvider(
+  value: unknown,
+  assetType: MarketPriceAssetType,
+): string {
+  const provider = readString(value).toLowerCase();
+  if (provider) return provider;
+  return assetType === "crypto" ? "coingecko" : "alpha_vantage";
+}
+
+function isFresh(row: MarketPriceCacheRow, now: Date): boolean {
+  const expiresAt = Date.parse(row.expires_at);
+  return Number.isFinite(expiresAt) && expiresAt > now.getTime();
+}
+
+function cacheAgeMinutes(row: MarketPriceCacheRow, now: Date): number | null {
+  const fetchedAt = Date.parse(row.fetched_at);
+  if (!Number.isFinite(fetchedAt)) return null;
+  return Math.max(0, Math.round((now.getTime() - fetchedAt) / 60000));
+}
+
+function isPositivePrice(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function roundPrice(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+function readOptionalNumber(
+  record: UnknownRecord,
+  keys: string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value.replace(/,/g, ""));
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseJsonRecord(text: string): UnknownRecord {
+  try {
+    return asRecord(JSON.parse(text)) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as UnknownRecord
+    : null;
+}
+
+function firstRecord(value: unknown): UnknownRecord | null {
+  return toRecords(value)[0] ?? null;
+}
+
+function toRecords(value: unknown): UnknownRecord[] {
+  return Array.isArray(value)
+    ? value.map(asRecord).filter((row): row is UnknownRecord => row !== null)
+    : [];
+}

--- a/supabase/functions/ai-hub/market_price_test.ts
+++ b/supabase/functions/ai-hub/market_price_test.ts
@@ -1,0 +1,245 @@
+import {
+  handleMarketPriceAction,
+  isMarketPriceAction,
+  type MarketPriceDb,
+  type MarketPriceDbQuery,
+  normalizeMarketPriceInput,
+} from "./market_price.ts";
+
+Deno.test("market price actions and inputs are normalized", () => {
+  assertEquals(isMarketPriceAction("asset.market_price.fetch"), true);
+  assertEquals(isMarketPriceAction("ai_hub.fetch_market_price"), true);
+  assertEquals(isMarketPriceAction("provider.chat"), false);
+
+  const input = normalizeMarketPriceInput({
+    asset_type: "crypto",
+    ticker: "btc",
+    cache_minutes: 2,
+  });
+  assertEquals(input.assetType, "crypto");
+  assertEquals(input.ticker, "BTC");
+  assertEquals(input.currency, "JPY");
+  assertEquals(input.provider, "coingecko");
+  assertEquals(input.cacheMinutes, 5);
+});
+
+Deno.test("handleMarketPriceAction returns fresh cache without live fetch", async () => {
+  const db = new FakeDb({
+    investment_market_price_cache: [
+      priceCacheRow({
+        ticker: "BTC",
+        fetched_at: "2026-06-20T00:20:00.000Z",
+        expires_at: "2026-06-20T00:50:00.000Z",
+      }),
+    ],
+  });
+
+  const result = await handleMarketPriceAction({
+    db,
+    userId: "user-1",
+    body: { asset_type: "crypto", ticker: "btc" },
+    liveFetchEnabled: false,
+    now: new Date("2026-06-20T00:30:00.000Z"),
+    fetcher: () => {
+      throw new Error("fetcher should not be called for fresh cache");
+    },
+  });
+
+  assertEquals(result.status, "cache_hit");
+  assertEquals(result.price_jpy, 10500000);
+  assertEquals(result.source, "cache");
+  assertEquals(result.cache_age_minutes, 10);
+  assertEquals(db.upserts.length, 0);
+});
+
+Deno.test("handleMarketPriceAction falls back to stale cache when live fetch is off", async () => {
+  const db = new FakeDb({
+    investment_market_price_cache: [
+      priceCacheRow({
+        ticker: "BTC",
+        fetched_at: "2026-06-20T00:00:00.000Z",
+        expires_at: "2026-06-20T00:30:00.000Z",
+      }),
+    ],
+  });
+
+  const result = await handleMarketPriceAction({
+    db,
+    userId: "user-1",
+    body: { asset_type: "crypto", ticker: "btc" },
+    liveFetchEnabled: false,
+    now: new Date("2026-06-20T01:00:00.000Z"),
+  });
+
+  assertEquals(result.status, "stale_cache_fallback");
+  assertEquals(result.price_jpy, 10500000);
+  assertStringIncludes(result.warnings.join(" "), "disabled");
+});
+
+Deno.test("handleMarketPriceAction writes provider cache and updates holdings", async () => {
+  const db = new FakeDb({
+    investment_assets: [
+      {
+        id: "asset-1",
+        user_id: "user-1",
+        asset_type: "crypto",
+        ticker: "BTC",
+      },
+      {
+        id: "asset-2",
+        user_id: "other-user",
+        asset_type: "crypto",
+        ticker: "BTC",
+      },
+    ],
+  });
+
+  const result = await handleMarketPriceAction({
+    db,
+    userId: "user-1",
+    body: { asset_type: "crypto", ticker: "btc", live_fetch_enabled: true },
+    liveFetchEnabled: true,
+    now: new Date("2026-06-20T00:00:00.000Z"),
+    fetcher: (request) => {
+      assertEquals(request.provider, "coingecko");
+      assertEquals(request.ticker, "BTC");
+      return Promise.resolve({
+        ok: true,
+        priceJpy: 10600000.12345,
+        provider: "coingecko",
+        fetchedAt: "2026-06-20T00:00:00.000Z",
+        payload: { bitcoin: { jpy: 10600000.12345 } },
+      });
+    },
+  });
+
+  assertEquals(result.status, "cache_write");
+  assertEquals(result.price_jpy, 10600000.1235);
+  assertEquals(result.updated_holding_count, 1);
+  assertEquals(db.upserts[0].table, "investment_market_price_cache");
+  assertEquals(db.upserts[0].value.expires_at, "2026-06-20T00:30:00.000Z");
+  assertEquals(
+    db.rows.investment_assets[0].current_price_jpy,
+    10600000.1235,
+  );
+  assertEquals(db.rows.investment_assets[1].current_price_jpy, undefined);
+});
+
+Deno.test("handleMarketPriceAction reports provider errors without cache", async () => {
+  const db = new FakeDb();
+
+  const result = await handleMarketPriceAction({
+    db,
+    userId: "user-1",
+    body: { asset_type: "stock", ticker: "7203.T", live_fetch_enabled: true },
+    liveFetchEnabled: true,
+    fetcher: () =>
+      Promise.resolve({
+        ok: false,
+        error: "rate limit",
+        rateLimited: true,
+      }),
+  });
+
+  assertEquals(result.status, "provider_rate_limited");
+  assertEquals(result.price_jpy, null);
+  assertStringIncludes(result.warnings.join(" "), "rate limit");
+});
+
+function priceCacheRow(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    asset_type: "crypto",
+    ticker: "BTC",
+    currency: "JPY",
+    provider: "coingecko",
+    price_jpy: 10500000,
+    fetched_at: "2026-06-20T00:00:00.000Z",
+    expires_at: "2026-06-20T00:30:00.000Z",
+    source_payload: {},
+    ...overrides,
+  };
+}
+
+function assertEquals(actual: unknown, expected: unknown) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `Assertion failed:\nactual:   ${JSON.stringify(actual)}\nexpected: ${
+        JSON.stringify(expected)
+      }`,
+    );
+  }
+}
+
+function assertStringIncludes(actual: string, expected: string) {
+  if (!actual.includes(expected)) {
+    throw new Error(
+      `Assertion failed: expected ${JSON.stringify(actual)} to include ${
+        JSON.stringify(expected)
+      }`,
+    );
+  }
+}
+
+class FakeDb implements MarketPriceDb {
+  rows: Record<string, Record<string, unknown>[]>;
+  upserts: { table: string; value: Record<string, unknown> }[] = [];
+
+  constructor(rows: Record<string, Record<string, unknown>[]> = {}) {
+    this.rows = rows;
+  }
+
+  from(table: string): MarketPriceDbQuery {
+    this.rows[table] ??= [];
+    return new FakeQuery(table, this);
+  }
+}
+
+class FakeQuery implements MarketPriceDbQuery {
+  private filters: { column: string; value: string }[] = [];
+  private updateValue: Record<string, unknown> | null = null;
+
+  constructor(
+    private readonly table: string,
+    private readonly db: FakeDb,
+  ) {}
+
+  select(): MarketPriceDbQuery {
+    return this;
+  }
+
+  eq(column: string, value: string): MarketPriceDbQuery {
+    this.filters.push({ column, value });
+    return this;
+  }
+
+  order(): MarketPriceDbQuery {
+    return this;
+  }
+
+  update(value: Record<string, unknown>): MarketPriceDbQuery {
+    this.updateValue = value;
+    return this;
+  }
+
+  limit(count: number): Promise<{ data: unknown[]; error: null }> {
+    let rows = this.db.rows[this.table].filter((row) =>
+      this.filters.every((filter) => row[filter.column] === filter.value)
+    );
+    if (this.updateValue) {
+      rows = rows.map((row) => Object.assign(row, this.updateValue));
+    }
+    return Promise.resolve({ data: rows.slice(0, count), error: null });
+  }
+
+  upsert(value: Record<string, unknown>) {
+    this.db.upserts.push({ table: this.table, value });
+    this.db.rows[this.table].push(value);
+    return {
+      select: () => ({
+        single: () => Promise.resolve({ data: value, error: null }),
+      }),
+    };
+  }
+}

--- a/supabase/migrations/20260523090000_create_investment_market_price_cache.sql
+++ b/supabase/migrations/20260523090000_create_investment_market_price_cache.sql
@@ -1,0 +1,72 @@
+-- Asset management phase 2B: market price cache.
+-- Issue #2466. External market data fetches are opt-in at the Edge Function;
+-- this table stores the deterministic cache used by investment_assets pricing.
+
+begin;
+
+create table if not exists public.investment_market_price_cache (
+  id uuid primary key default gen_random_uuid(),
+  asset_type text not null,
+  ticker text not null,
+  currency text not null default 'JPY',
+  provider text not null,
+  price_jpy numeric(20, 4) not null,
+  fetched_at timestamptz not null,
+  expires_at timestamptz not null,
+  source_payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint investment_market_price_cache_asset_type_check
+    check (asset_type in ('stock', 'crypto', 'reit', 'etf')),
+  constraint investment_market_price_cache_ticker_not_blank
+    check (length(btrim(ticker)) > 0),
+  constraint investment_market_price_cache_currency_not_blank
+    check (length(btrim(currency)) > 0),
+  constraint investment_market_price_cache_provider_not_blank
+    check (length(btrim(provider)) > 0),
+  constraint investment_market_price_cache_price_non_negative
+    check (price_jpy >= 0),
+  constraint investment_market_price_cache_expires_after_fetch
+    check (expires_at > fetched_at),
+  constraint investment_market_price_cache_unique_key
+    unique (asset_type, ticker, currency)
+);
+
+create index if not exists investment_market_price_cache_freshness_idx
+  on public.investment_market_price_cache (asset_type, ticker, currency, expires_at desc);
+
+comment on table public.investment_market_price_cache is
+  'Cache for opt-in investment market price fetches. Issue #2466.';
+comment on column public.investment_market_price_cache.price_jpy is
+  'Cached unit price in JPY. External fetches are feature-flagged off by default.';
+comment on column public.investment_market_price_cache.expires_at is
+  'Default cache expiry is 30 minutes after fetched_at; stale rows are used only as graceful fallback.';
+
+alter table public.investment_market_price_cache enable row level security;
+
+drop policy if exists investment_market_price_cache_service_role_all
+  on public.investment_market_price_cache;
+create policy investment_market_price_cache_service_role_all
+on public.investment_market_price_cache
+for all
+to service_role
+using (true)
+with check (true);
+
+create or replace function public.set_investment_market_price_cache_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists investment_market_price_cache_updated_at
+  on public.investment_market_price_cache;
+create trigger investment_market_price_cache_updated_at
+before update on public.investment_market_price_cache
+for each row execute function public.set_investment_market_price_cache_updated_at();
+
+commit;

--- a/test/services/investment_market_price_cache_schema_test.dart
+++ b/test/services/investment_market_price_cache_schema_test.dart
@@ -1,0 +1,109 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260523090000_create_investment_market_price_cache.sql';
+
+void main() {
+  group('investment market price cache schema migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(_migrationPath).readAsStringSync().replaceAll('\r\n', '\n');
+    });
+
+    test('defines cache rows with provider and JPY price fields', () {
+      final block = _createTableBlock(sql, 'investment_market_price_cache');
+
+      expect(block, contains('id uuid primary key default gen_random_uuid()'));
+      expect(block, contains('asset_type text not null'));
+      expect(block, contains('ticker text not null'));
+      expect(block, contains("currency text not null default 'JPY'"));
+      expect(block, contains('provider text not null'));
+      expect(block, contains('price_jpy numeric(20, 4) not null'));
+      expect(block, contains('fetched_at timestamptz not null'));
+      expect(block, contains('expires_at timestamptz not null'));
+      expect(
+        block,
+        contains("source_payload jsonb not null default '{}'::jsonb"),
+      );
+    });
+
+    test('enforces asset type, nonblank keys, price, and expiry guards', () {
+      final block = _createTableBlock(sql, 'investment_market_price_cache');
+
+      expect(
+        block,
+        contains("check (asset_type in ('stock', 'crypto', 'reit', 'etf'))"),
+      );
+      expect(block, contains('check (length(btrim(ticker)) > 0)'));
+      expect(block, contains('check (length(btrim(currency)) > 0)'));
+      expect(block, contains('check (length(btrim(provider)) > 0)'));
+      expect(block, contains('check (price_jpy >= 0)'));
+      expect(block, contains('check (expires_at > fetched_at)'));
+      expect(block, contains('unique (asset_type, ticker, currency)'));
+    });
+
+    test('adds freshness index and service-role-only RLS policy', () {
+      expect(
+        sql,
+        contains(
+          'create index if not exists investment_market_price_cache_freshness_idx',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'on public.investment_market_price_cache (asset_type, ticker, currency, expires_at desc)',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'alter table public.investment_market_price_cache enable row level security;',
+        ),
+      );
+      expect(
+        sql,
+        contains('create policy investment_market_price_cache_service_role_all'),
+      );
+      expect(sql, contains('to service_role'));
+      expect(sql, contains('using (true)'));
+      expect(sql, contains('with check (true)'));
+    });
+
+    test('touches updated_at through a table-specific trigger', () {
+      expect(
+        sql,
+        contains(
+          'create or replace function public.set_investment_market_price_cache_updated_at()',
+        ),
+      );
+      expect(
+        sql,
+        contains('create trigger investment_market_price_cache_updated_at'),
+      );
+      expect(
+        sql,
+        contains(
+          'for each row execute function public.set_investment_market_price_cache_updated_at();',
+        ),
+      );
+    });
+  });
+}
+
+String _createTableBlock(String sql, String table) {
+  final start = sql.indexOf('create table if not exists public.$table');
+  expect(start, isNonNegative, reason: 'missing create table for $table');
+
+  final end = sql.indexOf('\n);', start);
+  expect(
+    end,
+    isNonNegative,
+    reason: 'missing create table terminator for $table',
+  );
+
+  return sql.substring(start, end);
+}

--- a/test/services/investment_market_price_cache_schema_test.dart
+++ b/test/services/investment_market_price_cache_schema_test.dart
@@ -68,7 +68,8 @@ void main() {
       expect(
         sql,
         contains(
-            'create policy investment_market_price_cache_service_role_all'),
+          'create policy investment_market_price_cache_service_role_all',
+        ),
       );
       expect(sql, contains('to service_role'));
       expect(sql, contains('using (true)'));

--- a/test/services/investment_market_price_cache_schema_test.dart
+++ b/test/services/investment_market_price_cache_schema_test.dart
@@ -66,7 +66,8 @@ void main() {
       );
       expect(
         sql,
-        contains('create policy investment_market_price_cache_service_role_all'),
+        contains(
+            'create policy investment_market_price_cache_service_role_all'),
       );
       expect(sql, contains('to service_role'));
       expect(sql, contains('using (true)'));

--- a/test/services/investment_market_price_cache_schema_test.dart
+++ b/test/services/investment_market_price_cache_schema_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+// Keeps the market-price cache migration contract pinned without live providers.
 const _migrationPath =
     'supabase/migrations/20260523090000_create_investment_market_price_cache.sql';
 

--- a/test/services/investment_market_price_cache_schema_test.dart
+++ b/test/services/investment_market_price_cache_schema_test.dart
@@ -66,8 +66,7 @@ void main() {
       );
       expect(
         sql,
-        contains(
-            'create policy investment_market_price_cache_service_role_all'),
+        contains('create policy investment_market_price_cache_service_role_all'),
       );
       expect(sql, contains('to service_role'));
       expect(sql, contains('using (true)'));


### PR DESCRIPTION
Summary: Adds #2466 market-price cache slice: investment_market_price_cache schema, cache-first ai-hub market price actions, opt-in live fetch guard, stale-cache fallback, and Deno coverage. Validation: deno test market_price_test; deno check ai-hub index; deno lint market_price files; schema smoke. Minimal E2E Gate: implementation-detail independent / black-box I/O plan is minimal three cases: fresh cache hit, stale cache fallback, provider write plus holding update. E2E mechanism: integration_test or Playwright is not the right mechanism for this Edge-only cache contract. E2E-Exception: no UI/browser E2E file added because behavior is an authenticated Edge Function cache contract covered by deterministic Deno I/O tests. High-risk review owner: Claude Code #1. high-risk-ultrareview-exception: Claude Code #1 remains review owner, but no separate live Claude ultrareview was run in this Codex-only session; risk is bounded by OFF-default live fetch, service-role-only cache RLS, no default external calls, rollback by reverting one migration plus one Edge action, deploy/prod-smoke covered by existing Deploy to Production and DB + Edge smoke, observability via returned warnings/status and existing ai-hub logs path if live calls are later enabled. Unresolved ultrareview findings: none. Closes #2466