### PR TITLE
[codex] Map cashflow fixed payments to disposable balance

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -34,6 +34,7 @@ import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
+import 'package:my_web_app/services/disposable_balance_asset_liability_adapter.dart';
 import 'package:my_web_app/services/disposable_balance_service.dart';
 import 'package:my_web_app/services/salary_spending_breakdown_service.dart';
 import 'package:my_web_app/services/smbc_csv_import_service.dart';
@@ -266,6 +267,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const SalarySpendingBreakdownService();
   final DisposableBalanceService _disposableBalanceService =
       const DisposableBalanceService();
+  final DisposableBalanceAssetLiabilityAdapter
+      _disposableBalanceAssetLiabilityAdapter =
+      const DisposableBalanceAssetLiabilityAdapter();
   final DebtLockdownService _debtLockdownService = const DebtLockdownService();
   final DebtRepaymentPlannerService _debtRepaymentPlanner =
       const DebtRepaymentPlannerService();
@@ -6540,6 +6544,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       cycleStart.day,
     );
     final recurringExpenses = <DisposableBalanceRecurringExpense>[];
+    final recurringExpenseKeys = <String>{};
+    void addRecurringExpense(DisposableBalanceRecurringExpense expense) {
+      if (expense.amount <= 0) {
+        return;
+      }
+      final normalizedName = expense.name.trim().toLowerCase();
+      final key =
+          '$normalizedName|${expense.dayOfMonth}|${expense.amount.round()}';
+      if (!recurringExpenseKeys.add(key)) {
+        return;
+      }
+      recurringExpenses.add(expense);
+    }
+
     for (final row in _subscriptionsThreeMonths) {
       final dueDate = DateTime.tryParse(row['due_date']?.toString() ?? '');
       if (dueDate == null) {
@@ -6554,7 +6572,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (amount <= 0) {
         continue;
       }
-      recurringExpenses.add(
+      addRecurringExpense(
         DisposableBalanceRecurringExpense(
           name: row['name']?.toString() ?? 'サブスク',
           amount: amount,
@@ -6584,20 +6602,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         transferTasks: _transferTasks,
         includeDefaultFixedPayments: true,
       );
-      for (final row in workbook.debtMasterRows) {
-        if (!row.isDirectCashflowTarget || row.scheduledPaymentAmount <= 0) {
-          continue;
-        }
-        debts.add(
-          DisposableBalanceDebt(
-            name: row.name,
-            principal: row.balance.abs(),
-            monthlyPayment: row.scheduledPaymentAmount,
-            interestRate: row.annualRate,
-            lastUpdated: DateTime.tryParse(_lastUpdatedDates[row.name] ?? ''),
-          ),
-        );
+      final assetLiabilityInputs =
+          _disposableBalanceAssetLiabilityAdapter.build(
+        workbook: workbook,
+        cycleStart: cycleStartOnly,
+        nextPayday: nextPayday,
+        lastUpdatedForDebt: (row) {
+          return DateTime.tryParse(_lastUpdatedDates[row.name] ?? '');
+        },
+      );
+      for (final expense in assetLiabilityInputs.recurringExpenses) {
+        addRecurringExpense(expense);
       }
+      debts.addAll(assetLiabilityInputs.debts);
     }
 
     return _disposableBalanceService.build(

--- a/lib/services/disposable_balance_asset_liability_adapter.dart
+++ b/lib/services/disposable_balance_asset_liability_adapter.dart
@@ -1,0 +1,118 @@
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+import 'package:my_web_app/services/disposable_balance_service.dart';
+
+class DisposableBalanceAssetLiabilityInputs {
+  const DisposableBalanceAssetLiabilityInputs({
+    required this.recurringExpenses,
+    required this.debts,
+  });
+
+  final List<DisposableBalanceRecurringExpense> recurringExpenses;
+  final List<DisposableBalanceDebt> debts;
+}
+
+class DisposableBalanceAssetLiabilityAdapter {
+  const DisposableBalanceAssetLiabilityAdapter();
+
+  DisposableBalanceAssetLiabilityInputs build({
+    required AssetLiabilityWorkbook workbook,
+    required DateTime cycleStart,
+    required DateTime nextPayday,
+    DateTime? Function(AssetLiabilityDebtRow row)? lastUpdatedForDebt,
+  }) {
+    final debtRowsById = <String, AssetLiabilityDebtRow>{
+      for (final row in workbook.debtMasterRows) row.id: row,
+    };
+    final recurringExpenses = <DisposableBalanceRecurringExpense>[];
+
+    for (final row in workbook.cashflowRows) {
+      final debtRow = debtRowsById[row.accountId];
+      if (!_isFixedCashflowRow(row, debtRow) ||
+          !_isWithinCycle(row.paymentDate, cycleStart, nextPayday)) {
+        continue;
+      }
+      recurringExpenses.add(
+        DisposableBalanceRecurringExpense(
+          name: row.accountName,
+          amount: row.paymentAmount,
+          dayOfMonth: row.paymentDate.day.clamp(1, 28).toInt(),
+          category: _fixedExpenseCategoryFor(debtRow),
+        ),
+      );
+    }
+
+    final debts = <DisposableBalanceDebt>[];
+    for (final row in workbook.debtMasterRows) {
+      if (!row.isDirectCashflowTarget ||
+          row.scheduledPaymentAmount <= 0 ||
+          _isFixedDebtRow(row)) {
+        continue;
+      }
+      debts.add(
+        DisposableBalanceDebt(
+          name: row.name,
+          principal: row.balance.abs(),
+          monthlyPayment: row.scheduledPaymentAmount,
+          interestRate: row.annualRate,
+          lastUpdated: lastUpdatedForDebt?.call(row),
+        ),
+      );
+    }
+
+    return DisposableBalanceAssetLiabilityInputs(
+      recurringExpenses: List<DisposableBalanceRecurringExpense>.unmodifiable(
+        recurringExpenses,
+      ),
+      debts: List<DisposableBalanceDebt>.unmodifiable(debts),
+    );
+  }
+
+  bool _isFixedCashflowRow(
+    AssetLiabilityCashflowRow row,
+    AssetLiabilityDebtRow? debtRow,
+  ) {
+    return row.isPayment &&
+        row.isDirectCashflowTarget &&
+        row.paymentAmount > 0 &&
+        debtRow != null &&
+        _isFixedDebtRow(debtRow);
+  }
+
+  bool _isFixedDebtRow(AssetLiabilityDebtRow row) {
+    return row.kind == AssetLiabilityAccountKind.utility ||
+        row.id == AssetLiabilityPlanningService.rentAccountId ||
+        row.id == AssetLiabilityPlanningService.kddiProviderAccountId;
+  }
+
+  String _fixedExpenseCategoryFor(AssetLiabilityDebtRow? row) {
+    if (row?.id == AssetLiabilityPlanningService.rentAccountId) {
+      return 'housing';
+    }
+    if (row?.kind == AssetLiabilityAccountKind.utility ||
+        row?.id == AssetLiabilityPlanningService.kddiProviderAccountId) {
+      return 'utility';
+    }
+    return 'cashflow_fixed';
+  }
+
+  bool _isWithinCycle(
+    DateTime date,
+    DateTime cycleStart,
+    DateTime nextPayday,
+  ) {
+    final normalizedDate = DateTime(date.year, date.month, date.day);
+    final normalizedStart = DateTime(
+      cycleStart.year,
+      cycleStart.month,
+      cycleStart.day,
+    );
+    final normalizedEnd = DateTime(
+      nextPayday.year,
+      nextPayday.month,
+      nextPayday.day,
+    );
+    return !normalizedDate.isBefore(normalizedStart) &&
+        normalizedDate.isBefore(normalizedEnd);
+  }
+}

--- a/test/services/disposable_balance_asset_liability_adapter_test.dart
+++ b/test/services/disposable_balance_asset_liability_adapter_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+import 'package:my_web_app/services/disposable_balance_asset_liability_adapter.dart';
+import 'package:my_web_app/services/disposable_balance_service.dart';
+
+void main() {
+  group('DisposableBalanceAssetLiabilityAdapter', () {
+    const planner = AssetLiabilityPlanningService();
+    const adapter = DisposableBalanceAssetLiabilityAdapter();
+    const disposableBalance = DisposableBalanceService();
+
+    test('routes cashflow fixed payments into fixed expenses, not debts', () {
+      final asOfDate = DateTime(2026, 5, 26);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'cash': 464568,
+          'au': -32152,
+          'PayPayカード': -487324,
+        },
+        baseDate: asOfDate,
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.rentAccountName: 63000,
+          AssetLiabilityPlanningService.kddiProviderAccountName: 5764,
+          'PayPayカード': 17229,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.rentAccountId: 'cash',
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'cash',
+          'paypay_card': 'cash',
+        },
+        includeDefaultFixedPayments: true,
+      );
+      final nextPayday = disposableBalance.nextPaydayFor(
+        asOfDate: asOfDate,
+      );
+      final cycleStart = disposableBalance.salaryCycleStartFor(
+        asOfDate: asOfDate,
+      );
+
+      final result = adapter.build(
+        workbook: workbook,
+        cycleStart: cycleStart,
+        nextPayday: nextPayday,
+      );
+
+      expect(
+        result.recurringExpenses.map((expense) => expense.name),
+        containsAll(<String>[
+          AssetLiabilityPlanningService.rentAccountName,
+          AssetLiabilityPlanningService.kddiProviderAccountName,
+        ]),
+      );
+      expect(
+        result.recurringExpenses
+            .fold<double>(0, (sum, expense) => sum + expense.amount),
+        68764,
+      );
+      expect(
+        result.debts.map((debt) => debt.name),
+        isNot(
+          contains(AssetLiabilityPlanningService.rentAccountName),
+        ),
+      );
+      expect(
+        result.debts.map((debt) => debt.name),
+        contains('PayPayカード'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Route fixed-payment rows from `AssetLiabilityWorkbook.cashflowRows` into the disposable-balance fixed-expense bucket.
- Keep loan/card payment rows in the repayment bucket so rent/KDDI are not double counted as debt repayments.
- Add adapter coverage proving salary-cycle cashflow fixed payments such as 2026-05-25 rent are fixed expenses.

## Root Cause
The disposable-balance card only used subscription rows for fixed expenses and treated all direct asset-liability payment rows as repayments. Rent and KDDI were visible in the payment-day cashflow table, but they were bucketed under repayment, leaving fixed expenses at 0 yen.

## Validation
- `flutter analyze lib/pages/asset_management_page.dart lib/services/disposable_balance_asset_liability_adapter.dart lib/services/disposable_balance_service.dart test/services/disposable_balance_asset_liability_adapter_test.dart`
- `flutter test test/services/disposable_balance_asset_liability_adapter_test.dart test/services/disposable_balance_service_test.dart`
- `git diff --cached --check`

## Minimal E2E Gate
- Plan: black-box cases for the asset-management disposable-balance card and payment-day cashflow table.
- Cases: a payment-day cashflow rent row due on 2026-05-25 appears in fixed expenses; KDDI utility payment is fixed; PayPay card remains a repayment; total obligations are not double counted.
- E2E-Exception: no new `integration_test/` or `test/e2e/` file was added because this is a scoped calculation adapter with deterministic unit coverage and will also run the public E2E stability smoke.

## High-Risk Ultrareview
- Review owner: Claude Code #1.
- Claude ultrareview exception reason: scoped frontend/service calculation fix only; no schema, auth, Edge Function, payment execution, or deployment path changed.
- Security: no auth boundary, secret handling, or permission model changed.
- Rollback: revert this PR's squash merge.
- Data migration: none.
- Prod smoke: after merge, verify `/asset-management` shows fixed expenses from payment-day cashflow rows, including 25日 家賃 63,000円.
- Observability: no new telemetry required; the fixed/repayment chips and required-action state expose the behavior.
- Unresolved ultrareview findings: none / 0.