### PR TITLE
[codex] Show disposable balance breakdown tooltips

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -6722,11 +6722,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   label: '固定費',
                   value: '-${_formatYen(balance.fixedTotal)}',
                   color: const Color(0xFFB45309),
+                  tooltipMessage: _buildDisposableBalanceFixedTooltip(balance),
                 ),
                 _buildFlowPriorityMetric(
                   label: '返済',
                   value: '-${_formatYen(balance.debtTotal)}',
                   color: const Color(0xFFB91C1C),
+                  tooltipMessage: _buildDisposableBalanceDebtTooltip(balance),
                 ),
                 _buildFlowPriorityMetric(
                   label: '使える残高',
@@ -6814,6 +6816,58 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       ),
     );
+  }
+
+  String _buildDisposableBalanceFixedTooltip(DisposableBalanceResult balance) {
+    final rows = List<DisposableBalanceRecurringExpense>.from(
+      balance.recurringExpenses,
+    )..sort((a, b) {
+        final day = a.dayOfMonth.compareTo(b.dayOfMonth);
+        if (day != 0) return day;
+        return b.amount.compareTo(a.amount);
+      });
+    return _buildDisposableBalanceBreakdownTooltip(
+      title: '固定費内訳',
+      totalLabel: '固定費合計',
+      total: balance.fixedTotal,
+      lines: [
+        for (final row in rows)
+          '${row.dayOfMonth}日 ${row.name.trim().isEmpty ? '固定費' : row.name.trim()} ${_formatYen(row.amount)}',
+      ],
+    );
+  }
+
+  String _buildDisposableBalanceDebtTooltip(DisposableBalanceResult balance) {
+    final rows = List<DisposableBalanceDebt>.from(balance.debts)
+      ..sort((a, b) {
+        final day = (a.dayOfMonth ?? 99).compareTo(b.dayOfMonth ?? 99);
+        if (day != 0) return day;
+        return b.monthlyPayment.compareTo(a.monthlyPayment);
+      });
+    return _buildDisposableBalanceBreakdownTooltip(
+      title: '返済内訳',
+      totalLabel: '返済合計',
+      total: balance.debtTotal,
+      lines: [
+        for (final row in rows)
+          '${row.dayOfMonth == null ? '' : '${row.dayOfMonth}日 '}'
+              '${row.name.trim().isEmpty ? '返済' : row.name.trim()} ${_formatYen(row.monthlyPayment)}'
+              '${row.principal > 0 ? ' / 残高 ${_formatYen(row.principal)}' : ''}',
+      ],
+    );
+  }
+
+  String _buildDisposableBalanceBreakdownTooltip({
+    required String title,
+    required String totalLabel,
+    required double total,
+    required List<String> lines,
+  }) {
+    return <String>[
+      title,
+      if (lines.isEmpty) '対象なし' else ...lines,
+      '$totalLabel ${_formatYen(total)}',
+    ].join('\n');
   }
 
   Widget _buildDisposableBalanceActionRow({
@@ -7454,8 +7508,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     required String label,
     required String value,
     required Color color,
+    String? tooltipMessage,
   }) {
-    return Container(
+    final metric = Container(
       constraints: const BoxConstraints(minWidth: 108),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
@@ -7485,6 +7540,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
         ],
       ),
+    );
+    if (tooltipMessage == null || tooltipMessage.trim().isEmpty) {
+      return metric;
+    }
+    return Tooltip(
+      message: tooltipMessage,
+      waitDuration: const Duration(milliseconds: 250),
+      showDuration: const Duration(seconds: 12),
+      preferBelow: false,
+      child: metric,
     );
   }
 

--- a/lib/services/disposable_balance_asset_liability_adapter.dart
+++ b/lib/services/disposable_balance_asset_liability_adapter.dart
@@ -55,6 +55,7 @@ class DisposableBalanceAssetLiabilityAdapter {
           principal: row.balance.abs(),
           monthlyPayment: row.scheduledPaymentAmount,
           interestRate: row.annualRate,
+          dayOfMonth: row.paymentDay?.clamp(1, 31).toInt(),
           lastUpdated: lastUpdatedForDebt?.call(row),
         ),
       );

--- a/lib/services/disposable_balance_service.dart
+++ b/lib/services/disposable_balance_service.dart
@@ -35,6 +35,7 @@ class DisposableBalanceDebt {
     this.principal = 0,
     this.interestRate = 0,
     this.lender = '',
+    this.dayOfMonth,
     this.lastUpdated,
     this.pausedAt,
   });
@@ -44,6 +45,7 @@ class DisposableBalanceDebt {
   final double monthlyPayment;
   final double interestRate;
   final String lender;
+  final int? dayOfMonth;
   final DateTime? lastUpdated;
   final DateTime? pausedAt;
 }
@@ -79,6 +81,8 @@ class DisposableBalanceResult {
     required this.debtTotal,
     required this.disposable,
     required this.dailyPace,
+    required this.recurringExpenses,
+    required this.debts,
     required this.requiredActions,
   });
 
@@ -91,6 +95,8 @@ class DisposableBalanceResult {
   final double debtTotal;
   final double disposable;
   final double dailyPace;
+  final List<DisposableBalanceRecurringExpense> recurringExpenses;
+  final List<DisposableBalanceDebt> debts;
   final List<DisposableBalanceActionRecommendation> requiredActions;
 }
 
@@ -167,6 +173,10 @@ class DisposableBalanceService {
       debtTotal: debtTotal,
       disposable: disposable,
       dailyPace: dailyPace,
+      recurringExpenses: List<DisposableBalanceRecurringExpense>.unmodifiable(
+        activeRecurring,
+      ),
+      debts: List<DisposableBalanceDebt>.unmodifiable(activeDebts),
       requiredActions: List<DisposableBalanceActionRecommendation>.unmodifiable(
         actions,
       ),

--- a/test/services/disposable_balance_asset_liability_adapter_test.dart
+++ b/test/services/disposable_balance_asset_liability_adapter_test.dart
@@ -65,6 +65,10 @@ void main() {
         result.debts.map((debt) => debt.name),
         contains('PayPayカード'),
       );
+      final payPayDebt = result.debts.singleWhere(
+        (debt) => debt.monthlyPayment == 17229,
+      );
+      expect(payPayDebt.dayOfMonth, 27);
     });
   });
 }

--- a/test/services/disposable_balance_service_test.dart
+++ b/test/services/disposable_balance_service_test.dart
@@ -38,6 +38,12 @@ void main() {
       expect(result.daysRemaining, 30);
       expect(result.disposable, 314708);
       expect(result.dailyPace.round(), 10490);
+      expect(result.recurringExpenses, hasLength(1));
+      expect(result.recurringExpenses.single.name, 'Rent');
+      expect(result.recurringExpenses.single.amount, 92400);
+      expect(result.debts, hasLength(1));
+      expect(result.debts.single.name, 'student loan');
+      expect(result.debts.single.monthlyPayment, 58000);
       expect(
         result.requiredActions.single.actionKey,
         'refresh_debt_student_loan',
@@ -67,6 +73,7 @@ void main() {
 
       expect(result.nextPayday, DateTime(2026, 6, 25));
       expect(result.fixedTotal, 63000);
+      expect(result.recurringExpenses.single.dayOfMonth, 25);
       expect(result.disposable, 389815);
       expect(
         result.requiredActions.map((action) => action.actionKey),


### PR DESCRIPTION
## Summary
- Expose the exact recurring expense and repayment rows used by `DisposableBalanceResult` totals.
- Add hover tooltips to the `固定費` and `返済` chips in `給料日までの可処分残高` so each reflected item and total can be checked.
- Carry payment-day metadata from the asset/liability cashflow adapter into repayment tooltip rows when available.

## Validation
- `flutter test test/services/disposable_balance_service_test.dart test/services/disposable_balance_asset_liability_adapter_test.dart`
- `flutter analyze lib/pages/asset_management_page.dart lib/services/disposable_balance_service.dart lib/services/disposable_balance_asset_liability_adapter.dart test/services/disposable_balance_service_test.dart test/services/disposable_balance_asset_liability_adapter_test.dart`
- `git diff --check`

## Minimal E2E Gate
- Scope: UI-only tooltip follow-up on the already-deployed disposable balance totals.
- Plan: after merge/deploy, open `/asset-management`, hover `固定費` and `返済`, and confirm the tooltip lists every reflected row plus the displayed total.
- E2E exception: no new navigation, persistence, or API write path; deterministic service tests cover the totals and exposed detail rows.

## High-Risk Ultrareview
- Review owner: Codex #1 scoped fix for financial display transparency.
- Security: no secrets, auth changes, database writes, or migrations.
- Financial correctness: totals still come from the same active recurring expense/debt rows; the UI now displays those rows rather than recalculating separately.
- Rollback: revert this commit to remove the tooltip detail exposure without changing ingestion or cashflow aggregation.
- Observability: production smoke should verify the tooltip content against the visible支払日別資金繰り rows.
- Unresolved ultrareview findings: none.