### PR TITLE
[codex] 可処分残高に固定費・返済の内訳表示を追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -300,6 +300,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   bool _isComputingDisposableBalance = false;
   Map<String, dynamic>? _serverDisposableBalanceResult;
   String? _disposableBalanceMessage;
+  String? _disposableBalanceBreakdownKey;
   final Set<String> _developerRequestIssueSubmissionKeys = <String>{};
   final Map<String, Map<String, dynamic>> _developerRequestIssueResults =
       <String, Map<String, dynamic>>{};
@@ -6652,6 +6653,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
     final periodLabel = '${DateFormat('yyyy/MM/dd').format(balance.asOfDate)}〜'
         '${DateFormat('yyyy/MM/dd').format(balance.nextPayday.subtract(const Duration(days: 1)))}';
+    final breakdownMessage = switch (_disposableBalanceBreakdownKey) {
+      'fixed' => _buildDisposableBalanceFixedBreakdown(balance),
+      'debt' => _buildDisposableBalanceDebtBreakdown(balance),
+      _ => null,
+    };
 
     return Card(
       key: const Key('asset_disposable_balance_card'),
@@ -6722,11 +6728,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   label: '固定費',
                   value: '-${_formatYen(balance.fixedTotal)}',
                   color: const Color(0xFFB45309),
+                  isSelected: _disposableBalanceBreakdownKey == 'fixed',
+                  onHoverStart: () => _setDisposableBalanceBreakdown('fixed'),
+                  onHoverEnd: () => _clearDisposableBalanceBreakdown('fixed'),
                 ),
                 _buildFlowPriorityMetric(
                   label: '返済',
                   value: '-${_formatYen(balance.debtTotal)}',
                   color: const Color(0xFFB91C1C),
+                  isSelected: _disposableBalanceBreakdownKey == 'debt',
+                  onHoverStart: () => _setDisposableBalanceBreakdown('debt'),
+                  onHoverEnd: () => _clearDisposableBalanceBreakdown('debt'),
                 ),
                 _buildFlowPriorityMetric(
                   label: '使える残高',
@@ -6742,6 +6754,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 ),
               ],
             ),
+            if (breakdownMessage != null) ...[
+              const SizedBox(height: 10),
+              _buildDisposableBalanceBreakdownPanel(breakdownMessage),
+            ],
             const SizedBox(height: 14),
             Wrap(
               spacing: 8,
@@ -6812,6 +6828,113 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
           ],
         ),
+      ),
+    );
+  }
+
+  String _buildDisposableBalanceFixedBreakdown(
+      DisposableBalanceResult balance) {
+    final rows = List<DisposableBalanceRecurringExpense>.from(
+      balance.recurringExpenses,
+    )..sort((a, b) {
+        final day = a.dayOfMonth.compareTo(b.dayOfMonth);
+        if (day != 0) return day;
+        return b.amount.compareTo(a.amount);
+      });
+    return _buildDisposableBalanceBreakdownText(
+      title: '固定費内訳',
+      totalLabel: '固定費合計',
+      total: balance.fixedTotal,
+      lines: [
+        for (final row in rows)
+          '${row.dayOfMonth}日 ${row.name.trim().isEmpty ? '固定費' : row.name.trim()} ${_formatYen(row.amount)}',
+      ],
+    );
+  }
+
+  String _buildDisposableBalanceDebtBreakdown(DisposableBalanceResult balance) {
+    final rows = List<DisposableBalanceDebt>.from(balance.debts)
+      ..sort((a, b) {
+        final day = (a.dayOfMonth ?? 99).compareTo(b.dayOfMonth ?? 99);
+        if (day != 0) return day;
+        return b.monthlyPayment.compareTo(a.monthlyPayment);
+      });
+    return _buildDisposableBalanceBreakdownText(
+      title: '返済内訳',
+      totalLabel: '返済合計',
+      total: balance.debtTotal,
+      lines: [
+        for (final row in rows)
+          '${row.dayOfMonth == null ? '' : '${row.dayOfMonth}日 '}'
+              '${row.name.trim().isEmpty ? '返済' : row.name.trim()} ${_formatYen(row.monthlyPayment)}'
+              '${row.principal > 0 ? ' / 残高 ${_formatYen(row.principal)}' : ''}',
+      ],
+    );
+  }
+
+  String _buildDisposableBalanceBreakdownText({
+    required String title,
+    required String totalLabel,
+    required double total,
+    required List<String> lines,
+  }) {
+    return <String>[
+      title,
+      if (lines.isEmpty) '対象なし' else ...lines,
+      '$totalLabel ${_formatYen(total)}',
+    ].join('\n');
+  }
+
+  void _setDisposableBalanceBreakdown(String key) {
+    if (_disposableBalanceBreakdownKey == key) {
+      return;
+    }
+    setState(() => _disposableBalanceBreakdownKey = key);
+  }
+
+  void _clearDisposableBalanceBreakdown(String key) {
+    if (_disposableBalanceBreakdownKey != key) {
+      return;
+    }
+    setState(() => _disposableBalanceBreakdownKey = null);
+  }
+
+  Widget _buildDisposableBalanceBreakdownPanel(String message) {
+    final lines = message.split('\n');
+    final title = lines.isEmpty ? '内訳' : lines.first;
+    final detailLines =
+        lines.length <= 1 ? const <String>[] : lines.skip(1).toList();
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFECFDF5),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFA7F3D0)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w800,
+              color: Color(0xFF047857),
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 4),
+          for (final line in detailLines)
+            Text(
+              line,
+              style: const TextStyle(
+                fontSize: 12,
+                color: Color(0xFF0F172A),
+                height: 1.5,
+              ),
+            ),
+        ],
       ),
     );
   }
@@ -7454,13 +7577,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     required String label,
     required String value,
     required Color color,
+    bool isSelected = false,
+    VoidCallback? onHoverStart,
+    VoidCallback? onHoverEnd,
   }) {
-    return Container(
+    final metric = Container(
       constraints: const BoxConstraints(minWidth: 108),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.08),
         borderRadius: BorderRadius.circular(14),
+        border: isSelected ? Border.all(color: color, width: 1.2) : null,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -7484,6 +7611,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           ),
         ],
+      ),
+    );
+    if (onHoverStart == null && onHoverEnd == null) {
+      return metric;
+    }
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => onHoverStart?.call(),
+      onExit: (_) => onHoverEnd?.call(),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onHoverStart,
+        child: metric,
       ),
     );
   }

--- a/lib/services/disposable_balance_asset_liability_adapter.dart
+++ b/lib/services/disposable_balance_asset_liability_adapter.dart
@@ -55,6 +55,7 @@ class DisposableBalanceAssetLiabilityAdapter {
           principal: row.balance.abs(),
           monthlyPayment: row.scheduledPaymentAmount,
           interestRate: row.annualRate,
+          dayOfMonth: row.paymentDay?.clamp(1, 31).toInt(),
           lastUpdated: lastUpdatedForDebt?.call(row),
         ),
       );

--- a/lib/services/disposable_balance_service.dart
+++ b/lib/services/disposable_balance_service.dart
@@ -35,6 +35,7 @@ class DisposableBalanceDebt {
     this.principal = 0,
     this.interestRate = 0,
     this.lender = '',
+    this.dayOfMonth,
     this.lastUpdated,
     this.pausedAt,
   });
@@ -44,6 +45,7 @@ class DisposableBalanceDebt {
   final double monthlyPayment;
   final double interestRate;
   final String lender;
+  final int? dayOfMonth;
   final DateTime? lastUpdated;
   final DateTime? pausedAt;
 }
@@ -79,6 +81,8 @@ class DisposableBalanceResult {
     required this.debtTotal,
     required this.disposable,
     required this.dailyPace,
+    required this.recurringExpenses,
+    required this.debts,
     required this.requiredActions,
   });
 
@@ -91,6 +95,8 @@ class DisposableBalanceResult {
   final double debtTotal;
   final double disposable;
   final double dailyPace;
+  final List<DisposableBalanceRecurringExpense> recurringExpenses;
+  final List<DisposableBalanceDebt> debts;
   final List<DisposableBalanceActionRecommendation> requiredActions;
 }
 
@@ -167,6 +173,10 @@ class DisposableBalanceService {
       debtTotal: debtTotal,
       disposable: disposable,
       dailyPace: dailyPace,
+      recurringExpenses: List<DisposableBalanceRecurringExpense>.unmodifiable(
+        activeRecurring,
+      ),
+      debts: List<DisposableBalanceDebt>.unmodifiable(activeDebts),
       requiredActions: List<DisposableBalanceActionRecommendation>.unmodifiable(
         actions,
       ),

--- a/test/services/disposable_balance_asset_liability_adapter_test.dart
+++ b/test/services/disposable_balance_asset_liability_adapter_test.dart
@@ -65,6 +65,10 @@ void main() {
         result.debts.map((debt) => debt.name),
         contains('PayPayカード'),
       );
+      final payPayDebt = result.debts.singleWhere(
+        (debt) => debt.monthlyPayment == 17229,
+      );
+      expect(payPayDebt.dayOfMonth, 27);
     });
   });
 }

--- a/test/services/disposable_balance_service_test.dart
+++ b/test/services/disposable_balance_service_test.dart
@@ -38,6 +38,12 @@ void main() {
       expect(result.daysRemaining, 30);
       expect(result.disposable, 314708);
       expect(result.dailyPace.round(), 10490);
+      expect(result.recurringExpenses, hasLength(1));
+      expect(result.recurringExpenses.single.name, 'Rent');
+      expect(result.recurringExpenses.single.amount, 92400);
+      expect(result.debts, hasLength(1));
+      expect(result.debts.single.name, 'student loan');
+      expect(result.debts.single.monthlyPayment, 58000);
       expect(
         result.requiredActions.single.actionKey,
         'refresh_debt_student_loan',
@@ -67,6 +73,7 @@ void main() {
 
       expect(result.nextPayday, DateTime(2026, 6, 25));
       expect(result.fixedTotal, 63000);
+      expect(result.recurringExpenses.single.dayOfMonth, 25);
       expect(result.disposable, 389815);
       expect(
         result.requiredActions.map((action) => action.actionKey),


### PR DESCRIPTION
## 変更内容
- 給料日までの可処分残高カードで、固定費・返済のチップにマウスオーバーするとカード内に内訳を表示します。
- Flutter 標準 Tooltip のオーバーレイは使わず、カード内インライン表示にして前回の表示崩れリスクを避けました。
- 可処分残高の集計に使った固定費・返済リストを `DisposableBalanceResult` に保持し、表示金額と内訳のデータ元を揃えました。
- 返済側にも支払日を渡し、支払日順に確認できるようにしました。

## 検証
- `%TEMP%\flutter_3.38.10\bin\flutter.bat analyze lib/pages/asset_management_page.dart lib/services/disposable_balance_service.dart lib/services/disposable_balance_asset_liability_adapter.dart test/services/disposable_balance_service_test.dart test/services/disposable_balance_asset_liability_adapter_test.dart`
- `%TEMP%\flutter_3.38.10\bin\flutter.bat test test/services/disposable_balance_service_test.dart test/services/disposable_balance_asset_liability_adapter_test.dart`
- `git diff --check`

## デプロイ注意
- 前回の Windows 手動デプロイで本番表示が壊れたため、このPRでは手元から Firebase Hosting へ直接デプロイしません。
- main マージ後は GitHub Actions/Linux 経由の通常デプロイで確認します。