### PR TITLE
feat: add Anthropic Acom repayment cashflow

### DIFF
--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -54,6 +54,15 @@ class AssetLiabilityPlanningService {
   static const String rentAccountId = 'rent';
   static const String rentAccountName = '\u5bb6\u8cc3';
   static const double rentMonthlyPaymentAmount = 63000;
+  static const String acomShoppingAccountId = 'acom_shopping';
+  static const String anthropicAcomShoppingPaymentId =
+      'anthropic_acom_shopping_repayment';
+  static const String anthropicAcomShoppingPaymentName =
+      'Anthropic\u30b5\u30d6\u30b9\u30af'
+      '\uff08\u30a2\u30b3\u30e0\u30b7\u30e7\u30c3\u30d4\u30f3\u30b0'
+      '\u8fd4\u6e08\uff09';
+  static const int anthropicAcomShoppingPaymentDay = 26;
+  static const double anthropicAcomShoppingPaymentAmount = 40000;
 
   const AssetLiabilityPlanningService();
 
@@ -177,6 +186,9 @@ class AssetLiabilityPlanningService {
       incomePlans: resolvedIncomePlans,
       baseDate: baseDate,
       startingCash: cashLikeTotal,
+      paidAccountNames: paidAccountNames,
+      paymentSourceAccountIds: effectivePaymentSourceAccountIds,
+      accountsById: accountsById,
     );
     final accountCashflowSummaries = _buildAccountCashflowSummaries(
       accounts: accounts,
@@ -202,19 +214,24 @@ class AssetLiabilityPlanningService {
       0,
       (sum, row) => sum + row.minimumPaymentEstimate,
     );
-    final monthlyScheduledPaymentTotal = directDebtRows.fold<double>(
+    final directPaymentCashflowRows = cashflowRows
+        .where((row) => row.isPayment && row.isDirectCashflowTarget)
+        .toList(growable: false);
+    final monthlyScheduledPaymentTotal = directPaymentCashflowRows.fold<double>(
       0,
-      (sum, row) => sum + row.scheduledPaymentAmount,
+      (sum, row) => sum + row.paymentAmount,
     );
-    final monthlyUnpaidPaymentTotal = directDebtRows.fold<double>(
+    final monthlyUnpaidPaymentTotal = directPaymentCashflowRows.fold<double>(
       0,
-      (sum, row) => row.paid ? sum : sum + row.scheduledPaymentAmount,
+      (sum, row) => row.paid ? sum : sum + row.paymentAmount,
     );
-    final monthlyActualPaymentTotal = directDebtRows.fold<double>(
+    final monthlyActualPaymentTotal = directPaymentCashflowRows.fold<double>(
       0,
-      (sum, row) => sum + row.effectivePaidPaymentAmount,
+      (sum, row) =>
+          row.paid ? sum + (row.actualPaymentAmount ?? row.paymentAmount) : sum,
     );
-    final monthlyPaymentDifferenceTotal = directDebtRows.fold<double>(
+    final monthlyPaymentDifferenceTotal =
+        directPaymentCashflowRows.fold<double>(
       0,
       (sum, row) => sum + (row.paymentDifferenceAmount ?? 0),
     );
@@ -1054,6 +1071,9 @@ class AssetLiabilityPlanningService {
     required List<AssetLiabilityIncomePlan> incomePlans,
     required DateTime baseDate,
     required double startingCash,
+    required Set<String> paidAccountNames,
+    required Map<String, String> paymentSourceAccountIds,
+    required Map<String, AssetLiabilityAccount> accountsById,
   }) {
     final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
     final result = <AssetLiabilityCashflowRow>[];
@@ -1132,6 +1152,52 @@ class AssetLiabilityPlanningService {
         ),
       );
     }
+    final acomShoppingRow = _findAcomShoppingDebtRow(rows);
+    if (acomShoppingRow != null && acomShoppingRow.isDirectCashflowTarget) {
+      const paymentDay = anthropicAcomShoppingPaymentDay;
+      final resolvedDay = paymentDay.clamp(1, lastDay).toInt();
+      final paymentDate = DateTime(baseDate.year, baseDate.month, resolvedDay);
+      final paid = paidAccountNames.contains(anthropicAcomShoppingPaymentId) ||
+          paidAccountNames.contains(anthropicAcomShoppingPaymentName);
+      final sourceAccountId =
+          paymentSourceAccountIds[anthropicAcomShoppingPaymentId] ??
+              acomShoppingRow.paymentSourceAccountId;
+      final sourceAccountName = sourceAccountId == null
+          ? acomShoppingRow.paymentSourceAccountName
+          : accountsById[sourceAccountId]?.name ??
+              acomShoppingRow.paymentSourceAccountName;
+      result.add(
+        AssetLiabilityCashflowRow(
+          eventType: AssetLiabilityCashflowEventType.payment,
+          accountId: anthropicAcomShoppingPaymentId,
+          accountName: anthropicAcomShoppingPaymentName,
+          paymentDay: paymentDay,
+          paymentDate: paymentDate,
+          paymentSourceAccountId: sourceAccountId,
+          paymentSourceAccountName: sourceAccountName,
+          destinationAccountId: acomShoppingRow.id,
+          destinationAccountName: acomShoppingRow.name,
+          paymentMethod: AssetLiabilityPaymentMethod.direct,
+          paymentMethodLabel: acomShoppingRow.paymentMethodLabel,
+          paymentMethodSettingSource:
+              AssetLiabilityPaymentMethodSettingSource.builtInDefault,
+          billingAccountId: null,
+          billingAccountName: null,
+          includedInBillingAccount: false,
+          paymentAmount: anthropicAcomShoppingPaymentAmount,
+          actualPaymentAmount: null,
+          paymentDifferenceAmount: null,
+          paymentDifferenceReason: null,
+          paymentAmountEstimated: false,
+          paid: paid,
+          received: false,
+          overdue: !paid && !paymentDate.isAfter(_dateOnly(baseDate)),
+          cashBeforePayment: 0,
+          cashAfterPayment: 0,
+          riskLevel: AssetLiabilityCashRiskLevel.normal,
+        ),
+      );
+    }
 
     result.sort((a, b) {
       final date = a.paymentDate.compareTo(b.paymentDate);
@@ -1186,6 +1252,17 @@ class AssetLiabilityPlanningService {
           );
         }(),
     ];
+  }
+
+  AssetLiabilityDebtRow? _findAcomShoppingDebtRow(
+    List<AssetLiabilityDebtRow> rows,
+  ) {
+    for (final row in rows) {
+      if (row.id == acomShoppingAccountId) {
+        return row;
+      }
+    }
+    return null;
   }
 
   AssetLiabilityCashRiskLevel _cashRiskLevel(double cashAfterPayment) {
@@ -1420,7 +1497,7 @@ class AssetLiabilityPlanningService {
     final key = _normalize(name);
 
     if (_containsAll(key, const <String>['アコム', 'ショッピング'])) {
-      return 'acom_shopping';
+      return acomShoppingAccountId;
     }
     if (_containsAll(key, const <String>['アコム', 'ローン'])) {
       return 'acom_card_loan';

--- a/lib/services/disposable_balance_asset_liability_adapter.dart
+++ b/lib/services/disposable_balance_asset_liability_adapter.dart
@@ -60,6 +60,22 @@ class DisposableBalanceAssetLiabilityAdapter {
         ),
       );
     }
+    for (final row in workbook.cashflowRows) {
+      if (!_isSupplementalDebtCashflowRow(row, debtRowsById) ||
+          !_isWithinCycle(row.paymentDate, cycleStart, nextPayday)) {
+        continue;
+      }
+      debts.add(
+        DisposableBalanceDebt(
+          name: row.accountName,
+          principal: 0,
+          monthlyPayment: row.paymentAmount,
+          interestRate: 0,
+          dayOfMonth: row.paymentDate.day.clamp(1, 31).toInt(),
+          lastUpdated: null,
+        ),
+      );
+    }
 
     return DisposableBalanceAssetLiabilityInputs(
       recurringExpenses: List<DisposableBalanceRecurringExpense>.unmodifiable(
@@ -84,6 +100,16 @@ class DisposableBalanceAssetLiabilityAdapter {
     return row.kind == AssetLiabilityAccountKind.utility ||
         row.id == AssetLiabilityPlanningService.rentAccountId ||
         row.id == AssetLiabilityPlanningService.kddiProviderAccountId;
+  }
+
+  bool _isSupplementalDebtCashflowRow(
+    AssetLiabilityCashflowRow row,
+    Map<String, AssetLiabilityDebtRow> debtRowsById,
+  ) {
+    return row.isPayment &&
+        row.isDirectCashflowTarget &&
+        row.paymentAmount > 0 &&
+        !debtRowsById.containsKey(row.accountId);
   }
 
   String _fixedExpenseCategoryFor(AssetLiabilityDebtRow? row) {

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -99,8 +99,8 @@ void main() {
       expect(
         workbook.monthlyScheduledPaymentTotal,
         closeTo(
-          baseline.monthlyMinimumPaymentEstimateTotal -
-              baselineMobit.minimumPaymentEstimate +
+          baseline.monthlyScheduledPaymentTotal -
+              baselineMobit.scheduledPaymentAmount +
               70000,
           0.001,
         ),
@@ -775,6 +775,53 @@ void main() {
         workbook.cashflowRows[2].riskLevel,
         AssetLiabilityCashRiskLevel.short,
       );
+    });
+
+    test('adds Anthropic Acom shopping repayment on the 26th', () {
+      const acomShoppingName =
+          '\u30a2\u30b3\u30e0\u30b7\u30e7\u30c3\u30d4\u30f3\u30b0';
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 100000,
+          acomShoppingName: -200000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.acomShoppingAccountId: 68000,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.acomShoppingAccountId: 'custom_cash',
+        },
+      );
+
+      final anthropicPayment = workbook.cashflowRows.singleWhere(
+        (row) =>
+            row.accountId ==
+            AssetLiabilityPlanningService.anthropicAcomShoppingPaymentId,
+      );
+
+      expect(
+        anthropicPayment.accountName,
+        AssetLiabilityPlanningService.anthropicAcomShoppingPaymentName,
+      );
+      expect(anthropicPayment.paymentDay, 26);
+      expect(
+        anthropicPayment.paymentAmount,
+        AssetLiabilityPlanningService.anthropicAcomShoppingPaymentAmount,
+      );
+      expect(anthropicPayment.paymentSourceAccountId, 'custom_cash');
+      expect(
+        anthropicPayment.destinationAccountId,
+        AssetLiabilityPlanningService.acomShoppingAccountId,
+      );
+      expect(
+        workbook.cashflowRows.map((row) => row.paymentDay).toList(),
+        <int>[8, 26],
+      );
+      expect(workbook.monthlyScheduledPaymentTotal, 108000);
+      expect(workbook.monthlyUnpaidPaymentTotal, 108000);
+      expect(workbook.cashAfterScheduledPayments, -8000);
+      expect(anthropicPayment.cashAfterPayment, -8000);
     });
 
     test('reflects unreceived income plans in chronological cashflow', () {

--- a/test/services/disposable_balance_asset_liability_adapter_test.dart
+++ b/test/services/disposable_balance_asset_liability_adapter_test.dart
@@ -70,5 +70,48 @@ void main() {
       );
       expect(payPayDebt.dayOfMonth, 27);
     });
+
+    test('routes supplemental Anthropic repayment into debts', () {
+      const acomShoppingName =
+          '\u30a2\u30b3\u30e0\u30b7\u30e7\u30c3\u30d4\u30f3\u30b0';
+      final asOfDate = DateTime(2026, 5, 26);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'cash': 150000,
+          acomShoppingName: -200000,
+        },
+        baseDate: asOfDate,
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.acomShoppingAccountId: 68000,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.acomShoppingAccountId: 'custom_cash',
+        },
+      );
+      final nextPayday = disposableBalance.nextPaydayFor(
+        asOfDate: asOfDate,
+      );
+      final cycleStart = disposableBalance.salaryCycleStartFor(
+        asOfDate: asOfDate,
+      );
+
+      final result = adapter.build(
+        workbook: workbook,
+        cycleStart: cycleStart,
+        nextPayday: nextPayday,
+      );
+
+      final anthropicDebt = result.debts.singleWhere(
+        (debt) =>
+            debt.name ==
+            AssetLiabilityPlanningService.anthropicAcomShoppingPaymentName,
+      );
+      expect(
+        anthropicDebt.monthlyPayment,
+        AssetLiabilityPlanningService.anthropicAcomShoppingPaymentAmount,
+      );
+      expect(anthropicDebt.dayOfMonth, 26);
+      expect(anthropicDebt.principal, 0);
+    });
   });
 }


### PR DESCRIPTION
﻿## Summary
- Add a recurring 26th cashflow row for Anthropic subscription repayment via Acom shopping.
- Include the supplemental repayment in cashflow running balance and monthly scheduled/unpaid totals.
- Surface supplemental direct cashflow rows as debts for disposable balance breakdowns.

## Validation
- dart analyze lib/services/asset_liability_planning_service.dart lib/services/disposable_balance_asset_liability_adapter.dart test/services/asset_liability_planning_service_test.dart test/services/disposable_balance_asset_liability_adapter_test.dart
- flutter test --no-pub test/services/asset_liability_planning_service_test.dart test/services/disposable_balance_asset_liability_adapter_test.dart
- GitHub Actions: Lint, Format, and Test passed; GA readiness gate passed; Public E2E stability smoke passed.

## High-Risk Review Contract
Claude Code #1 is the review owner for this high-risk-keyword PR.
High-risk-ultrareview-exception: scoped deterministic asset-liability calculation change only; no auth, billing provider, Stripe, token, credential, RLS, Supabase migration, data migration, production config, or deploy workflow change.
Security: no secrets or authorization paths changed.
Rollback: revert commit 0277836 if the generated repayment row needs to be removed.
Data migration: none.
Prod smoke: existing Public E2E stability smoke passed in GitHub Actions; manual target is `/asset-management` showing the 26th Anthropic repayment when Acom shopping exists.
Observability: existing cashflow and disposable-balance summaries expose the row through current UI and tests.
Unresolved findings: 0.

## Minimal E2E Gate
The E2E approach is implementation-detail independent / black-box and would use Playwright against `/asset-management`.
Minimal plan: three I/O cases: Acom shopping present adds the 26th Anthropic repayment, Acom shopping absent adds nothing, and disposable balance debt breakdown includes the supplemental repayment.
E2E-Exception: not adding a new Playwright file because this is covered by deterministic service tests plus the existing Public E2E stability smoke for the route.
