### PR TITLE
feat: add auPay card funding transfer

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -2508,21 +2508,39 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     bool completed,
   ) {
     setState(() {
+      var found = false;
+      final completedAt = completed ? DateTime.now() : null;
       _transferTasks = [
         for (final current in _transferTasks)
-          current.id == task.id
-              ? AssetLiabilityTransferTask(
-                  id: current.id,
-                  fromAccountId: current.fromAccountId,
-                  fromAccountName: current.fromAccountName,
-                  toAccountId: current.toAccountId,
-                  toAccountName: current.toAccountName,
-                  amount: current.amount,
-                  dueDate: current.dueDate,
-                  completed: completed,
-                  completedAt: completed ? DateTime.now() : null,
-                )
-              : current,
+          if (current.id == task.id)
+            () {
+              found = true;
+              return AssetLiabilityTransferTask(
+                id: current.id,
+                fromAccountId: current.fromAccountId,
+                fromAccountName: current.fromAccountName,
+                toAccountId: current.toAccountId,
+                toAccountName: current.toAccountName,
+                amount: current.amount,
+                dueDate: current.dueDate,
+                completed: completed,
+                completedAt: completedAt,
+              );
+            }()
+          else
+            current,
+        if (!found)
+          AssetLiabilityTransferTask(
+            id: task.id,
+            fromAccountId: task.fromAccountId,
+            fromAccountName: task.fromAccountName,
+            toAccountId: task.toAccountId,
+            toAccountName: task.toAccountName,
+            amount: task.amount,
+            dueDate: task.dueDate,
+            completed: completed,
+            completedAt: completedAt,
+          ),
       ]..sort(_compareTransferTasksByDueDate);
     });
     unawaited(_saveAssetLiabilityMonthlyState());
@@ -2536,6 +2554,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     });
     unawaited(_saveAssetLiabilityMonthlyState());
   }
+
+  bool _isBuiltInTransferTask(AssetLiabilityTransferTask task) =>
+      task.id == AssetLiabilityPlanningService.auPayCardFundingTransferTaskId;
 
   void _deleteRecurringIncomeTemplate(String templateId) {
     final currentMonthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(
@@ -12942,20 +12963,22 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Widget _buildTransferSuggestionSection(AssetLiabilityWorkbook workbook) {
-    if (workbook.transferSuggestions.isEmpty && _transferTasks.isEmpty) {
+    if (workbook.transferSuggestions.isEmpty &&
+        workbook.transferTasks.isEmpty) {
       return const SizedBox.shrink();
     }
 
-    final activeTasks = _transferTasks
+    final activeTasks = workbook.transferTasks
         .where((task) => !task.completed)
         .toList(growable: false)
       ..sort(_compareTransferTasksByDueDate);
-    final completedTasks = _transferTasks
+    final completedTasks = workbook.transferTasks
         .where((task) => task.completed)
         .toList(growable: false)
       ..sort(_compareTransferTasksByDueDate);
 
     Widget buildTaskRow(AssetLiabilityTransferTask task) {
+      final isBuiltIn = _isBuiltInTransferTask(task);
       final dueLabel = task.dueDate == null
           ? 'No due date'
           : DateFormat('M/d').format(task.dueDate!);
@@ -12985,9 +13008,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
             ),
             IconButton(
-              tooltip: 'Delete transfer task',
+              tooltip: isBuiltIn ? '定例振替' : '振替タスクを削除',
               icon: const Icon(Icons.delete_outline, size: 18),
-              onPressed: () => _deleteTransferTask(task.id),
+              onPressed: isBuiltIn ? null : () => _deleteTransferTask(task.id),
             ),
           ],
         ),

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -63,6 +63,12 @@ class AssetLiabilityPlanningService {
       '\u8fd4\u6e08\uff09';
   static const int anthropicAcomShoppingPaymentDay = 26;
   static const double anthropicAcomShoppingPaymentAmount = 40000;
+  static const String smbcOtsukaBranchAccountId = 'smbc_otsuka_branch';
+  static const String jibunBankAccountId = 'jibun_bank_card_loan';
+  static const String auPayCardFundingTransferTaskId =
+      'transfer_smbc_otsuka_to_jibun_aupay_card_funding';
+  static const int auPayCardFundingTransferDay = 26;
+  static const double auPayCardFundingTransferAmount = 80000;
 
   const AssetLiabilityPlanningService();
 
@@ -121,8 +127,14 @@ class AssetLiabilityPlanningService {
       incomePlans: incomePlans,
       accountsById: accountsById,
     );
-    final resolvedTransferTasks = _resolveTransferTasks(
+    final effectiveTransferTasks = _withDefaultAuPayCardFundingTransfer(
       transferTasks: transferTasks,
+      accounts: accounts,
+      baseDate: baseDate,
+    );
+    final resolvedTransferTasks = _resolveTransferTasks(
+      transferTasks: effectiveTransferTasks,
+      accounts: accounts,
       accountsById: accountsById,
     );
     final effectivePaymentSourceAccountIds = <String, String>{
@@ -1306,6 +1318,7 @@ class AssetLiabilityPlanningService {
 
   List<AssetLiabilityTransferTask> _resolveTransferTasks({
     required List<AssetLiabilityTransferTask> transferTasks,
+    required List<AssetLiabilityAccount> accounts,
     required Map<String, AssetLiabilityAccount> accountsById,
   }) {
     final result = <AssetLiabilityTransferTask>[];
@@ -1317,8 +1330,11 @@ class AssetLiabilityPlanningService {
           task.amount <= 0) {
         continue;
       }
-      final fromAccount = accountsById[task.fromAccountId];
-      final toAccount = accountsById[task.toAccountId];
+      final fromAccount =
+          _findCashLikeAccountById(accounts, task.fromAccountId) ??
+              accountsById[task.fromAccountId];
+      final toAccount = _findCashLikeAccountById(accounts, task.toAccountId) ??
+          accountsById[task.toAccountId];
       result.add(
         AssetLiabilityTransferTask(
           id: task.id,
@@ -1349,6 +1365,52 @@ class AssetLiabilityPlanningService {
       return a.id.compareTo(b.id);
     });
     return result;
+  }
+
+  List<AssetLiabilityTransferTask> _withDefaultAuPayCardFundingTransfer({
+    required List<AssetLiabilityTransferTask> transferTasks,
+    required List<AssetLiabilityAccount> accounts,
+    required DateTime baseDate,
+  }) {
+    if (transferTasks.any(
+      (task) => task.id == auPayCardFundingTransferTaskId,
+    )) {
+      return transferTasks;
+    }
+
+    final fromAccount =
+        _findCashLikeAccountById(accounts, smbcOtsukaBranchAccountId);
+    final toAccount = _findCashLikeAccountById(accounts, jibunBankAccountId);
+    if (fromAccount == null || toAccount == null) {
+      return transferTasks;
+    }
+
+    final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
+    final resolvedDay = auPayCardFundingTransferDay.clamp(1, lastDay).toInt();
+    return <AssetLiabilityTransferTask>[
+      ...transferTasks,
+      AssetLiabilityTransferTask(
+        id: auPayCardFundingTransferTaskId,
+        fromAccountId: fromAccount.id,
+        fromAccountName: fromAccount.name,
+        toAccountId: toAccount.id,
+        toAccountName: toAccount.name,
+        amount: auPayCardFundingTransferAmount,
+        dueDate: DateTime(baseDate.year, baseDate.month, resolvedDay),
+      ),
+    ];
+  }
+
+  AssetLiabilityAccount? _findCashLikeAccountById(
+    List<AssetLiabilityAccount> accounts,
+    String accountId,
+  ) {
+    for (final account in accounts) {
+      if (account.id == accountId && _isCashLike(account)) {
+        return account;
+      }
+    }
+    return null;
   }
 
   List<AssetLiabilityAccountCashflowSummary> _buildAccountCashflowSummaries({

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -952,6 +952,111 @@ void main() {
       expect(workbook.transferSuggestions, isEmpty);
     });
 
+    test('adds monthly auPay card funding transfer to Jibun bank', () {
+      const smbcOtsukaName =
+          '\u4e09\u4e95\u4f4f\u53cb\u9280\u884c\u5927\u585a\u652f\u5e97';
+      const jibunBankName = '\u3058\u3076\u3093\u9280\u884c';
+      const auPayCardName = 'auPay\u30ab\u30fc\u30c9';
+      final workbook = service.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          smbcOtsukaName: 200000,
+          jibunBankName: 10000,
+          auPayCardName: -80000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.auPayCardAccountId: 80000,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.auPayCardAccountId:
+              AssetLiabilityPlanningService.jibunBankAccountId,
+        },
+      );
+
+      final transfer = workbook.transferTasks.singleWhere(
+        (task) =>
+            task.id ==
+            AssetLiabilityPlanningService.auPayCardFundingTransferTaskId,
+      );
+      final smbcSummary = workbook.accountCashflowSummaries.singleWhere(
+        (summary) =>
+            summary.accountId ==
+            AssetLiabilityPlanningService.smbcOtsukaBranchAccountId,
+      );
+      final jibunSummary = workbook.accountCashflowSummaries.singleWhere(
+        (summary) =>
+            summary.accountId ==
+            AssetLiabilityPlanningService.jibunBankAccountId,
+      );
+
+      expect(
+        transfer.fromAccountId,
+        AssetLiabilityPlanningService.smbcOtsukaBranchAccountId,
+      );
+      expect(
+        transfer.toAccountId,
+        AssetLiabilityPlanningService.jibunBankAccountId,
+      );
+      expect(
+        transfer.amount,
+        AssetLiabilityPlanningService.auPayCardFundingTransferAmount,
+      );
+      expect(transfer.dueDate, DateTime(2026, 5, 26));
+      expect(smbcSummary.pendingTransferOut, 80000);
+      expect(smbcSummary.projectedBalance, 120000);
+      expect(jibunSummary.upcomingPayments, 80000);
+      expect(jibunSummary.pendingTransferIn, 80000);
+      expect(jibunSummary.projectedBalance, 10000);
+    });
+
+    test('does not duplicate completed built-in auPay funding transfer', () {
+      const smbcOtsukaName =
+          '\u4e09\u4e95\u4f4f\u53cb\u9280\u884c\u5927\u585a\u652f\u5e97';
+      const jibunBankName = '\u3058\u3076\u3093\u9280\u884c';
+      final workbook = service.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          smbcOtsukaName: 200000,
+          jibunBankName: 10000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        transferTasks: <AssetLiabilityTransferTask>[
+          AssetLiabilityTransferTask(
+            id: AssetLiabilityPlanningService.auPayCardFundingTransferTaskId,
+            fromAccountId:
+                AssetLiabilityPlanningService.smbcOtsukaBranchAccountId,
+            fromAccountName: smbcOtsukaName,
+            toAccountId: AssetLiabilityPlanningService.jibunBankAccountId,
+            toAccountName: jibunBankName,
+            amount:
+                AssetLiabilityPlanningService.auPayCardFundingTransferAmount,
+            dueDate: DateTime(2026, 5, 26),
+            completed: true,
+            completedAt: DateTime(2026, 5, 26, 8),
+          ),
+        ],
+      );
+
+      final transfer = workbook.transferTasks.singleWhere(
+        (task) =>
+            task.id ==
+            AssetLiabilityPlanningService.auPayCardFundingTransferTaskId,
+      );
+      final smbcSummary = workbook.accountCashflowSummaries.singleWhere(
+        (summary) =>
+            summary.accountId ==
+            AssetLiabilityPlanningService.smbcOtsukaBranchAccountId,
+      );
+      final jibunSummary = workbook.accountCashflowSummaries.singleWhere(
+        (summary) =>
+            summary.accountId ==
+            AssetLiabilityPlanningService.jibunBankAccountId,
+      );
+
+      expect(transfer.completed, isTrue);
+      expect(smbcSummary.pendingTransferOut, 0);
+      expect(jibunSummary.pendingTransferIn, 0);
+    });
+
     test('does not double count completed transfer tasks', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: <String, double>{


### PR DESCRIPTION
﻿## Summary
- Add a monthly 26th transfer task from SMBC Otsuka branch to Jibun Bank for JPY 80,000.
- Include the recurring transfer in account-level projected balances without reducing total cash as an expense.
- Show generated workbook transfer tasks in the transfer section and let the recurring task be marked completed for the month.

## Validation
- dart analyze lib/services/asset_liability_planning_service.dart lib/pages/asset_management_page.dart test/services/asset_liability_planning_service_test.dart
- flutter test --no-pub test/services/asset_liability_planning_service_test.dart

## High-Risk Review Contract
Claude Code #1 is the review owner for this high-risk-keyword PR.
High-risk-ultrareview-exception: scoped deterministic asset-liability calculation/UI display change only; no auth, billing provider, Stripe, token, credential, RLS, Supabase migration, data migration, production config, or deploy workflow change.
Security: no secrets or authorization paths changed.
Rollback: revert this PR if the generated transfer task needs to be removed.
Data migration: none.
Prod smoke: target is `/asset-management` showing the 26th SMBC Otsuka -> Jibun Bank transfer when both accounts exist.
Observability: existing transfer task section and account-level projected balances expose the row; tests assert the transfer and completed-state behavior.
Unresolved findings: 0.

## Minimal E2E Gate
The E2E approach is implementation-detail independent / black-box and would use Playwright against `/asset-management`.
Minimal plan: three I/O cases: both accounts present adds the 26th JPY 80,000 transfer, completing the recurring transfer removes pending in/out impact for that month, and account-level projections reflect SMBC outflow plus Jibun Bank inflow.
E2E-Exception: not adding a new Playwright file because this is covered by deterministic service tests plus the existing route-level production smoke in CI.
