### PR TITLE
auto: issue #2869 [追加要望][P2][NotebookLM] bdec9ea5:2 Notion MCPを利用したGitHub Issuesと連携する仕様書・PRDの自動生成と動的更新

### DIFF
--- a/docs/issue-fix-plans/issue-2869.md
+++ b/docs/issue-fix-plans/issue-2869.md
@@ -1,0 +1,72 @@
+# Issue Fix Plan #2869
+
+- Issue: [[追加要望][P2][NotebookLM] bdec9ea5:2 Notion MCPを利用したGitHub Issuesと連携する仕様書・PRDの自動生成と動的更新](https://github.com/kanta13jp1/my_web_app/issues/2869)
+- Labels: enhancement,priority:medium,automation,追加要望,wbs,notebooklm
+- Workflow: `.github/workflows/github-issue-fix.yml`
+- CI repair pair: `.github/workflows/ci-auto-fix.yml`
+- Run: https://github.com/kanta13jp1/my_web_app/actions/runs/26670527851
+
+## Goal
+
+[追加要望][P2][NotebookLM] bdec9ea5:2 Notion MCPを利用したGitHub Issuesと連携する仕様書・PRDの自動生成と動的更新
+
+## Current Context
+
+```text
+<!-- notebooklm-requirement:bdec9ea5-c6f6-4c7d-923c-9bdf87d553d0:2 -->
+<!-- notebooklm-requirement-hash:39fc97fbe8cde92d -->
+
+## Source Notebook
+
+- Notebook ID: `bdec9ea5-c6f6-4c7d-923c-9bdf87d553d0`
+- Notebook title: AI Agent Revolution and The Future of Workflow Automation
+- Ownership: Owner
+- Created: `2026-04-30T09:00:08`
+- Requirement slot: `2/3`
+- Suggested priority: `P2`
+- Extracted at: `2026-05-18T15:32:00Z`
+
+## Additional Request
+
+Notion MCPを利用したGitHub Issuesと連携する仕様書・PRDの自動生成と動的更新
+
+## Rationale
+
+Notion MCPのAI最適化機能（高速なマークダウン処理やワークスペース横断検索）を活用し、Gi tHub IssuesやWBS上のタスク状況、調査データをもとに、最新のプロダクト要求仕様書（PRD ）やアーキテクチャドキュメントを自律的に構築・維持するナレッジ管理体制を実現す るため。
+
+## Acceptance Criteria
+
+- [ ] AIツールがNotion MCPサーバーへOAuth経由でセキュアに接続し、指定されたワークスペース・ページの読 み書きを実行できること
+- [ ] GitHub IssuesのWBS情報や設計変更のログから、Notion上にPRDや技術仕様書がマークダウン形 式で自動生成・更新されること
+- [ ] AIエージェントが過去のNotionコンテンツを横断検索し、プロジェクト全体で整 合性の取れたドキュメントの要約やインサイトを出力できること
+
+## Implementation Notes
+
+遅延や不要なトークン消費を防ぐため、Notion APIの直接利用ではなく最適化されたリモートNotion MCPエンドポイントを利用し、ドキュメント生成時のプロンプトインジェクションリスク を考慮した人間によるレビュープロセス（Human-in-the-loop）を組み込んでください。
+
+## Verification / Routing
+
+- [ ] NotebookLM 由来の外部事実は、実装前に公式または一次情報で確認する
+- [ ] 既存 GitHub Issues / WBS と重複しないことを確認する
+- [ ] Claude Code #1 + Codex #1 の top-level 2インスタンス制に沿って担当を決める
+- [ ] 完了時は GitHub Issues WBS Sync または `wbs-progress-update.yml` で進捗を同期する
+
+---
+
+
+```
+
+## Autonomous Repair Loop
+
+1. Reproduce the smallest failing path for this issue.
+2. Apply the minimum safe fix on this branch.
+3. Let normal CI run on the draft PR.
+4. If CI fails on mechanical issues, `ci-auto-fix.yml` attempts `dart fix --apply` and `deno fmt`.
+5. Merge only after CI is green and the issue scope is satisfied.
+
+## Checklist
+
+- [ ] Reproduction is clear
+- [ ] Smallest safe fix is implemented
+- [ ] Analyze/tests/CI are checked
+- [ ] PR notes explain the change and the remaining risk


### PR DESCRIPTION
## Summary

- bootstrap the autonomous repair lane for #2869
- create a dedicated fix branch and plan file
- pair this lane with `ci-auto-fix.yml` for small CI repair commits

Closes #2869

## Repair Loop

1. `github-issue-fix.yml` created branch `issue-fix/2869-bdec9ea5-2-notion-mcp-github-iss-26670527851`
2. make the smallest fix needed for the issue
3. let CI run normally
4. if CI fails on mechanical fixes, `ci-auto-fix.yml` will try `dart fix --apply` and `deno fmt`
5. merge after green CI and issue-scope confirmation

## Plan File

- `docs/issue-fix-plans/issue-2869.md`
