### PR TITLE
docs: mark blog draft published 2026-05-22-claude-code-massive-goal-defer-mentor-pattern-en.md

### DIFF
--- a/docs/blog-drafts/2026-05-22-claude-code-massive-goal-defer-mentor-pattern-en.md
+++ b/docs/blog-drafts/2026-05-22-claude-code-massive-goal-defer-mentor-pattern-en.md
@@ -3,7 +3,7 @@ title: "When to defer massive /goal requests in Claude Code sessions — mentor 
 emoji: "🛑"
 type: "tech"
 topics: ["claudecode", "ai", "agents", "devops", "productivity"]
-published: false
+published: true
 ---
 
 ## TL;DR


### PR DESCRIPTION
Automated blog-publish status update. If auto-merge is unavailable, merge this PR manually.\n\n✅ 2026-05-30 cs-check WEB版: HEAD ブランチ削除済みのため直接 main に適用しクローズ (commit c39d46b8)