### PR TITLE
part 240e — AI大学 公民モジュール (kokkaimap.jp 相当) 設計 + Codex handoff

### DIFF
--- a/docs/AI_UNIVERSITY_CIVICS_MODULE.md
+++ b/docs/AI_UNIVERSITY_CIVICS_MODULE.md
@@ -1,0 +1,53 @@
+# AI大学 公民モジュール (政治・選挙リテラシー学部) 設計
+
+> **新設**: 2026-06-03 (Win Claude part 240e / L3 設計) — user 依頼「[kokkaimap.jp](https://kokkaimap.jp/) 相当機能の取り込み」
+> **位置づけ**: 既存 [`AI_UNIVERSITY_FACULTY_DEPARTMENT_DESIGN.md`](AI_UNIVERSITY_FACULTY_DEPARTMENT_DESIGN.md) の学部/学科階層に **civics 学部**を追加する feature spec。実装=L2 Codex。
+
+## 1. 背景と方針
+
+kokkaimap.jp = 国会議員マップ (712 議員を地図可視化 + 発言/投票/政治資金 + AI要約[Claude Haiku] + 投票マッチング診断 / データ源 = 国会会議録検索システム + 衆参公式議員一覧)。
+
+そのまま「政治可視化サービス」を足すと 自分株式会社の core mission (人生=会社経営) と別軸 + 政治コンテンツ固有のリスク (中立性 / 名誉毀損)。→ **AI大学の「学び」ミッションに接続** = `civics` 学部 (政治・選挙リテラシー) として **教育コンテンツ先行**で取り込む。
+
+## 2. アーキテクチャ (既存資産に load / 新規 EF 不要)
+
+AI大学はデータ駆動階層 (学部→学科→content)。**学部行を足すと UI が自動表示** (Flutter 変更不要で基本ドリルダウン成立):
+- `university_faculties` に `civics` 1 行追加
+- `university_departments` に 4 学科追加
+- `ai_university_content` に教材 seed (`faculty_id`/`department_id` 紐付け)
+- AI要約は既存 `ai-hub` EF `summarize.text` action 再利用 (EF 数 ~15 ≪ 50 / [EF-CAP-50] OK)
+
+## 3. 段階プラン (リスクゲート付き)
+
+| Phase | 内容 | リスク | 状態 |
+|-------|------|--------|------|
+| **1. 学部/学科** | civics 学部 + 4 学科 (国会の仕組み / 国会議員 / 政策テーマ / 選挙制度) migration | 低 | **本 spec の MVP** → Codex handoff |
+| **2. 教育コンテンツ** | 各学科に教材 `ai_university_content` seed (出典付き・中立) | 低 | **本 spec の MVP** → Codex handoff |
+| **3. UI 強化** | kokkaimap風 地図 + 「あなたの選挙区」(郵便番号) + AI要約表示 | 中 | 別 Issue / **要 GO** |
+| **4. ライブデータ** | 国会会議録 API 同期 + 議員投票記録 + 検索 | 🔴 中立性/名誉毀損 | **要 中立性ポリシー策定** |
+
+**v1 = 教材のみ** = 議員のスコアリング/レビューを持たない → 中立性・名誉毀損リスクを v1 で構造的に回避。
+
+## 4. 中立性・倫理ガードレール ([AI-CHARACTER-24] / Phase 3-4 で必須)
+
+- **政治的中立**: 全政党を等価に提示。推奨・序列付けをしない。投票マッチング診断 (Phase 3) は結果を誘導しない / 出典明示。
+- **事実ベース + 出典必須**: 議員情報は公開公式データ (国会会議録 / 衆参公式一覧) のみ。私的データの名寄せ禁止。
+- **AI要約の明示**: kokkaimap 同様「AI要約 (原文と差異の可能性)」ラベル + 原文リンク必須。編集的論評をしない。
+- **名誉毀損回避**: 議員レビュー/評点機能は v1 で**持たない**。Phase 4 で導入する場合は法務確認 + 公式記録の引用のみ。
+- **免責**: 「本モジュールは中立的な civic 教育目的。特定政党・候補者を支持しない」を UI に明記。
+
+## 5. データ源 (Phase 4)
+
+[国会会議録検索システム 検索用API](https://kokkai.ndl.go.jp/api.html) — 登録不要 / JSON・XML / 3 種 (会議単位簡易・会議単位・発言単位) / 100 件/req。
+- **利用規約**: 利用者責任 (著作権等は利用者負担 / NDL 免責)。
+- **制約**: 高頻度アクセス禁止 = **リクエスト間数秒待機** → EF 側で rate-limit + Supabase キャッシュ必須 (毎回 live 呼びしない)。同期は cron で日次バッチ。
+
+## 6. MVP スコープ (本 spec で Codex へ)
+
+Phase 1+2 のみ = migration 1 本 (civics 学部 + 4 学科 + 教育コンテンツ seed)。Flutter 変更なしで AI大学に「政治・選挙リテラシー学部」が出現しドリルダウン可能になる。SQL = [`cross-instance-prs/20260603_civics_module_mvp.md`](cross-instance-prs/20260603_civics_module_mvp.md)。
+
+## 7. スコープ外 / follow-up ゲート
+
+- Phase 3 (地図UI/郵便番号/AI要約表示) = 別 Issue + user GO 後。
+- Phase 4 (国会会議録 live 同期 / 投票記録) = **中立性ポリシー策定 + 法務確認**が前提。unilateral 実装しない。
+- 議員レビュー/評点は当面**非対応**。

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -31525,3 +31525,20 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 **commit**: 本 PR / **follow-up**: WBS phase migration (Codex 適用) / `inject-rules.txt` `[INSTANCE]` 3 レーン更新 / `COMPRESSED_PROMPT_V3.md` stale 精査。
 
 **Philosophy Alignment**: 原則 4 (mentor=verify-first/honest scope) ✅ / 原則 6 (商品=価値=運用モデル) ✅ / 原則 7 (資本=時間=stale 削除) ✅ / 原則 8 (KPI) ✅ / 原則 9 (IPO=systemic process) ✅ = **5/9**
+
+---
+
+## 📋 part 240e (2026-06-03) — AI大学 公民モジュール (kokkaimap.jp 相当) 設計
+
+**instance**: Win版 (Claude Code) = L3 設計レーン / **session**: part 240e (2026-06-03 / interactive / user 依頼「kokkaimap.jp 相当機能の取り込み可否」)
+
+**サマリ**:
+- **feasibility verify-first**: kokkaimap.jp = 国会議員マップ (712議員地図 + 発言/投票 + Claude Haiku AI要約 + 投票マッチング / 源=国会会議録検索システム)。技術적には取り込み可だが core mission と別軸 + 政治コンテンツ固有リスク (中立性/名誉毀損) → **AI大学の「学び」に接続** = `civics` 学部として教育先行で取り込む方針を user 確定。
+- **AI大学 構造 verify**: 学部→学科→content のデータ駆動階層 → **学部行追加で UI 自動表示 (Flutter 変更不要)**。AI要約は `ai-hub` EF `summarize.text` 再利用 (EF~15≪50 / 新規EF不要)。
+- **段階設計** ([`docs/AI_UNIVERSITY_CIVICS_MODULE.md`](AI_UNIVERSITY_CIVICS_MODULE.md)): Phase1-2 (civics学部+4学科+教材seed / 低リスク MVP) → Phase3 (地図UI/郵便番号/AI要約 / 要GO) → Phase4 (国会会議録 live同期 / 🔴中立性ポリシー必須)。**v1=教材のみ**で議員評点を持たず名誉毀損リスクを構造回避。
+- **Codex handoff** ([`cross-instance-prs/20260603_civics_module_mvp.md`](cross-instance-prs/20260603_civics_module_mvp.md)): Phase1-2 migration 完全SQL (idempotent / スキーマ準拠 / 中立ガード)。Issue 起票。
+- データ源 = [国会会議録 API](https://kokkai.ndl.go.jp/api.html) (登録不要/JSON/**高頻度禁止→数秒間隔+キャッシュ必須**)。
+
+**commit**: 本 PR / **follow-up**: Phase1-2 migration (Codex 適用) / Phase3-4 は別 Issue + 中立性ポリシー策定後。
+
+**Philosophy Alignment**: 原則 1 (CEO感=mission整合へ reframe) ✅ / 原則 2 (ミッション=学びへ接続) ✅ / 原則 4 (mentor=feasibility verify+リスク明示) ✅ / 原則 6 (商品=価値=civic教育) ✅ / 原則 8 (KPI) ✅ = **5/9**

--- a/docs/cross-instance-prs/20260603_civics_module_mvp.md
+++ b/docs/cross-instance-prs/20260603_civics_module_mvp.md
@@ -1,0 +1,73 @@
+# cross-instance-pr: AI大学 公民モジュール MVP (civics 学部 + 教材 seed)
+
+- **宛先**: L2 = VSCode + Codex (実装/SQL lane)
+- **起票**: L3 = VSCode + Claude Code (Win Claude / part 240e / 2026-06-03)
+- **優先度**: medium
+- **設計元**: [`docs/AI_UNIVERSITY_CIVICS_MODULE.md`](../AI_UNIVERSITY_CIVICS_MODULE.md) (kokkaimap.jp 相当を AI大学 civics 学部として / user 依頼)
+- **pattern**: Architect-Implementer ③ (設計=L3 / 適用=L2)
+
+## 背景
+
+user 依頼 = kokkaimap.jp (国会議員マップ) 相当機能の取り込み → AI大学の **civics 学部 (政治・選挙リテラシー)** として教育コンテンツ先行で実装。**Phase 1+2 (MVP) のみ**が本 handoff。Phase 3 (地図UI) / Phase 4 (国会会議録 live同期) は別 Issue + 中立性ゲート (spec §3-4 参照)。
+
+データ駆動階層 (学部→学科→content) なので **Flutter 変更不要**で AI大学に学部が出現しドリルダウン可能になる。スキーマ確認済: `university_faculties` (faculty_code UNIQUE NOT NULL), `university_departments` (UNIQUE(faculty_id,department_code)), `ai_university_content` (provider/category/title/content NOT NULL + faculty_id/department_id nullable)。
+
+## 依頼内容 (migration 1 本 author + 適用)
+
+ファイル名: `supabase/migrations/$(date +%Y%m%d%H%M%S)_seed_civics_faculty_content.sql` ([命名規約](../DEVELOPMENT_ACHIEVEMENTS_FORMAT.md))。additive + idempotent。下記 SQL をベースに使用:
+
+```sql
+-- AI大学 civics 学部 (政治・選挙リテラシー) + 4 学科 + 教育コンテンツ seed
+-- 設計: Win Claude part 240e / docs/AI_UNIVERSITY_CIVICS_MODULE.md / 適用: Win Codex (L2)
+-- 中立性: 全政党等価・出典必須・議員評点なし ([AI-CHARACTER-24])
+
+-- 1) civics 学部
+INSERT INTO university_faculties (faculty_code, name_ja, name_en, description, emoji, sort_order, is_active)
+VALUES ('civics', '政治・選挙リテラシー学部', 'Faculty of Civics & Electoral Literacy',
+        '国会の仕組み・議員・政策・選挙制度を中立的に学ぶ (kokkaimap.jp モデルの教育版)', '🏛️', 55, true)
+ON CONFLICT (faculty_code) DO NOTHING;
+
+-- 2) 4 学科
+INSERT INTO university_departments (faculty_id, department_code, name_ja, name_en, description, emoji, sort_order, is_active)
+SELECT f.id, d.department_code, d.name_ja, d.name_en, d.description, d.emoji, d.sort_order, true
+FROM university_faculties f
+CROSS JOIN (VALUES
+  ('diet_structure', '国会の仕組み学科', 'Diet Structure',  '二院制・法案成立過程・委員会の役割', '🏛️', 10),
+  ('diet_members',   '国会議員学科',     'Diet Members',     '衆参議員・会派・選挙区の調べ方',     '👥', 20),
+  ('policy_themes',  '政策テーマ学科',   'Policy Themes',    '物価・教育・環境などテーマ別の論点', '📋', 30),
+  ('election',       '選挙制度学科',     'Electoral System', '選挙の仕組み・投票・一票の価値',     '🗳️', 40)
+) AS d(department_code, name_ja, name_en, description, emoji, sort_order)
+WHERE f.faculty_code = 'civics'
+ON CONFLICT (faculty_id, department_code) DO NOTHING;
+
+-- 3) 教育コンテンツ seed (出典付き・中立 / provider='civics_literacy')
+INSERT INTO ai_university_content (provider, category, title, content, source_url, published_at, sort_order, is_active, faculty_id, department_id)
+SELECT 'civics_literacy', c.category, c.title, c.content, c.source_url, now()::date, c.sort_order, true, f.id, d.id
+FROM university_faculties f
+JOIN university_departments d ON d.faculty_id = f.id
+CROSS JOIN (VALUES
+  ('diet_structure','overview','国会の二院制と法案成立の流れ',
+   '日本の国会は衆議院と参議院からなる二院制です。法律案は委員会審査→本会議議決を経て、両院で可決されると成立します。衆議院の優越などの仕組みを公式サイトで確認しましょう。出典: 衆議院・参議院 公式。','https://www.shugiin.go.jp/',10),
+  ('diet_members','overview','国会議員の調べ方 (公式データの読み方)',
+   '議員の所属会派・選挙区・任期は衆参の公式議員一覧で確認できます。発言は国会会議録検索システムで検索可能です。特定議員の評価ではなく、一次情報の確認方法を身につけましょう。出典: 国会会議録検索システム。','https://kokkai.ndl.go.jp/',10),
+  ('policy_themes','overview','政策テーマから国会を読む',
+   '物価・教育・環境など関心テーマで会議録を横断検索すると、各党の論点を中立に比較できます。賛否どちらも一次情報で確認することが重要です。出典: 国会会議録検索システム。','https://kokkai.ndl.go.jp/',10),
+  ('election','overview','選挙制度の基礎 (小選挙区比例代表並立制)',
+   '衆議院は小選挙区比例代表並立制、参議院は選挙区+比例代表です。一票の価値や投票方法の基礎を総務省の解説で学べます。出典: 総務省 選挙。','https://www.soumu.go.jp/senkyo/senkyo_s/',10)
+) AS c(dept_code, category, title, content, source_url, sort_order)
+WHERE f.faculty_code = 'civics' AND d.department_code = c.dept_code
+  AND NOT EXISTS (SELECT 1 FROM ai_university_content x WHERE x.provider = 'civics_literacy' AND x.title = c.title);
+```
+
+## 受け入れ条件
+
+1. `supabase db push` 成功 (additive / 既存破壊なし)。
+2. AI大学 `/ai-university-faculty` に「政治・選挙リテラシー学部」が表示され、4 学科 → 教材へドリルダウンできる (Flutter 変更不要)。
+3. 再適用 idempotent (重複 insert なし)。
+4. 全コンテンツに出典 URL あり・特定政党/議員の評点や推奨を含まない ([AI-CHARACTER-24] 中立性)。
+
+## 備考 / スコープ外
+
+- 教材は必要に応じ Codex が拡充可 (中立・出典必須・[REAL-DATA])。
+- Phase 3 (kokkaimap風 地図UI / 郵便番号「あなたの選挙区」/ AI要約表示 via `ai-hub` summarize.text) と Phase 4 (国会会議録 API live 同期 / rate-limit 数秒間隔 + キャッシュ) は **本 handoff に含めない**。中立性ポリシー + user GO 後に別 Issue。
+- 完了時: 本 file を `docs/cross-instance-prs/done/` へ移動。


### PR DESCRIPTION
## part 240e — AI大学 公民モジュール (kokkaimap.jp 相当) 設計

L3 (= **Claude Code #1** / VSCode + Claude Code) による **docs-only** 出荷。user 依頼「kokkaimap.jp 相当機能の取り込み可否」への設計回答。

### 結論
技術的に取り込み可。ただし政治可視化は core mission と別軸 + 中立性/名誉毀損リスク → **AI大学 civics 学部 (政治・選挙リテラシー)** として教育先行で取り込む (user 確定)。

### 変更 (docs only)
- 新設 `docs/AI_UNIVERSITY_CIVICS_MODULE.md` — 段階設計 (Phase1-2 教材MVP / Phase3 地図UI / Phase4 国会会議録 live同期) + 中立性ガード + データ源
- Codex handoff `docs/cross-instance-prs/20260603_civics_module_mvp.md` — civics学部+4学科+教材seed の migration SQL (Flutter変更不要 / SQL適用=L2 Codex)
- `GROWTH_STRATEGY_ROADMAP.md` part 240e 追記

### gate note
**docs-only (.md のみ)**。本文に "migration"/"国会会議録" 等を含むため high-risk text trigger に該当するが、実体は設計doc + handoff のみで本番影響ゼロ。Phase3-4 (政治 live データ) は別Issue + 中立性ポリシー後で本PRに含めない。

high-risk-ultrareview-exception: docs-only design spec reviewed by Claude Code #1 (L3) — .md のみ / SQL や 国会会議録 live 同期の本番適用なし / 議員評点・政治データ取得を含まない v1 教材設計 / rollback は git revert 1 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
