### PR TITLE
auto: issue #1807 [追加要望][P3][Win版] NotebookLM 47bd101a Managing Notion Database IDs — Notion統合改善

### DIFF
--- a/docs/issue-fix-plans/issue-1807.md
+++ b/docs/issue-fix-plans/issue-1807.md
@@ -1,0 +1,45 @@
+# Issue Fix Plan #1807
+
+- Issue: [[追加要望][P3][Win版] NotebookLM 47bd101a Managing Notion Database IDs — Notion統合改善](https://github.com/kanta13jp1/my_web_app/issues/1807)
+- Labels: enhancement,追加要望,notebooklm
+- Workflow: `.github/workflows/github-issue-fix.yml`
+- CI repair pair: `.github/workflows/ci-auto-fix.yml`
+- Run: https://github.com/kanta13jp1/my_web_app/actions/runs/26989790673
+
+## Goal
+
+[追加要望][P3][Win版] NotebookLM 47bd101a Managing Notion Database IDs — Notion統合改善
+
+## Current Context
+
+```text
+## 概要
+NotebookLM 47bd101a「Managing Notion Database IDs and API Page Properties」の内容をNotion統合に適用。
+
+## 適用内容
+- WBS/Notion の Database ID 管理を `docs/OPS_CHARTER.md` に文書化
+- Notion API Page Properties の型安全な取り扱いパターンをドキュメント化
+- `cross-instance-pr` テンプレートでの Notion タスク作成精度向上
+
+## 担当
+Win版 (docs + OPS統合)
+
+## 優先度
+P3
+
+```
+
+## Autonomous Repair Loop
+
+1. Reproduce the smallest failing path for this issue.
+2. Apply the minimum safe fix on this branch.
+3. Let normal CI run on the draft PR.
+4. If CI fails on mechanical issues, `ci-auto-fix.yml` attempts `dart fix --apply` and `deno fmt`.
+5. Merge only after CI is green and the issue scope is satisfied.
+
+## Checklist
+
+- [ ] Reproduction is clear
+- [ ] Smallest safe fix is implemented
+- [ ] Analyze/tests/CI are checked
+- [ ] PR notes explain the change and the remaining risk


### PR DESCRIPTION
## Summary

- bootstrap the autonomous repair lane for #1807
- create a dedicated fix branch and plan file
- pair this lane with `ci-auto-fix.yml` for small CI repair commits

Closes #1807

## Repair Loop

1. `github-issue-fix.yml` created branch `issue-fix/1807-notebooklm-47bd101a-managing-not-26989790673`
2. make the smallest fix needed for the issue
3. let CI run normally
4. if CI fails on mechanical fixes, `ci-auto-fix.yml` will try `dart fix --apply` and `deno fmt`
5. merge after green CI and issue-scope confirmation

## Plan File

- `docs/issue-fix-plans/issue-1807.md`
