### PR TITLE
docs(adr): ADR 運用の確立 + 主要設計判断 3 件 backfill (WBS 2e41ebca 完了)

### DIFF
--- a/docs/DIRECTORY_STRUCTURE.md
+++ b/docs/DIRECTORY_STRUCTURE.md
@@ -31,6 +31,7 @@ docs/
   concepts/              # wiki_compile.py が生成する Karpathy Compile 出力 (part 132)
   INDEX.md               # wiki_compile.py が生成するマスターインデックス
   cross-instance-prs/    # instance 間 task 依頼 / 規律拡散
+  adr/                   # Architecture Decision Records (= 設計判断ログ / docs/adr/README.md)
 scripts/
   wiki_compile.py        # Karpathy Compile cycle (part 132)
   memory_ingest.py       # Karpathy Ingest cycle (part 111)
@@ -60,4 +61,5 @@ web/
 - [`docs/EDGE_FUNCTION_LIST.md`](EDGE_FUNCTION_LIST.md) — EF 一覧
 - [`docs/DEVELOPMENT_ACHIEVEMENTS_FORMAT.md`](DEVELOPMENT_ACHIEVEMENTS_FORMAT.md) — migration 命名 + seed 形式
 - [`docs/SCHEDULE_TASKS.md`](SCHEDULE_TASKS.md) — cron 詳細
+- [`docs/adr/README.md`](adr/README.md) — ADR (設計判断ログ) 運用ガイド + Index
 - [`CLAUDE.md`](../CLAUDE.md) — pointer hub

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -31576,3 +31576,23 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 - Migration is additive and idempotent.
 - Content remains educational, source-linked, politically neutral, and contains no party/candidate recommendation or legislator scoring.
 - Production verification target: `select name_ja from public.university_faculties where faculty_code = 'civics';` and `select count(*) from public.university_departments d join public.university_faculties f on d.faculty_id = f.id where f.faculty_code = 'civics';`.
+
+---
+
+## 2026-06-05 - Win Claude part 241: ADR (設計判断ログ) 運用の確立
+
+**Scope**: WBS 設計タスク `2e41ebca-36bd-4c47-a87f-90b7b5948ece`「アーキテクチャ判断ログ運用 (ADR)」を完了 (/loop dynamic mode, Win Claude architect lane)。
+
+**Changes**:
+- `docs/adr/README.md` を新設 — いつ ADR を書くか / 命名 (`YYYY-MM-DD-kebab.md`) / Status ライフサイクル (Proposed→Accepted→Deprecated/Superseded) / WBS・Issue・NotebookLM への紐づけ / 原則 docs との関係 / Index 表。
+- `docs/adr/TEMPLATE.md` を新設 — 新規 ADR のコピー元。
+- 主要設計判断 3 件を backfill ADR 化: Flutter Web+Supabase+Firebase スタック / Edge-Function-first (EF-FIRST・EF-CAP-50) / 2-instance fleet (Architect+Implementer)。
+- `docs/DIRECTORY_STRUCTURE.md` に `docs/adr/` への pointer を追記。
+- migration `20260605140000_wbs_complete_adr_operating_process.sql` で WBS task を completed (progress=100 / ai_review_status=approved) 化 + `development_achievements` 追記。
+
+**Validation focus**:
+- docs-only + WBS 完了 migration のみ (コード/EF/スキーマ変更なし)。
+- migration は idempotent (固定値 UPDATE / description LIKE guard / achievement NOT EXISTS guard)。
+- `ai_review_status='approved'` を同一 UPDATE で設定し `wbs_request_ai_review` trigger の in_progress 差し戻しを回避。
+- Philosophy Alignment: 原則 2 ミッション / 4 mentor / 8 KPI (= 設計判断の追跡可能性) + [BRAIN-32] PKM。
+- commit hash: (PR merge 後に追記)。

--- a/docs/adr/2026-06-05-edge-function-first-architecture.md
+++ b/docs/adr/2026-06-05-edge-function-first-architecture.md
@@ -1,0 +1,45 @@
+# ADR: Edge-Function-first アーキテクチャ (EF-FIRST / EF-CAP-50)
+
+Date: 2026-06-05
+Status: Accepted
+
+> 注: 運用ルール [EF-FIRST] / [EF-CAP-50] として既に毎ターン inject されている判断を、
+> ADR 運用開始 (part 241) にあわせて根拠つきで backfill 記録したもの。
+
+## Context
+
+ビジネスロジックを「Flutter クライアント側」と「サーバー (Edge Function) 側」のどちらに置くかは
+繰り返し発生する設計判断。クライアント側に複雑ロジックを置くと:
+
+- シークレット / API キーがクライアントに露出する
+- 信頼境界がクライアントに移り、検証不能な入力を信じることになる
+- Web とモバイルでロジックが二重実装される
+
+一方で Edge Function を無制限に増やすと、deploy-prod のビルド/デプロイ時間とデプロイ面が肥大し、
+依存解決の失敗面 (= 先行 ADR [EF dependency resolution](2026-04-30-edge-function-dependency-resolution.md))
+も増える。
+
+## Decision
+
+- **EF-FIRST**: 複雑ロジックは Supabase Edge Function に置く。Flutter widget は **表示 + 操作のみ**。
+- **既存 hub への action 追加を最優先**: 新機能はまず既存 hub EF (core-hub / enterprise-hub 等) に
+  action を 1 つ足す形で実装する。新規 EF 作成は最後の手段。
+- **EF-CAP-50**: deploy-prod の EF 数 ≤ 50 を上限とする。超えそうなら hub 統合を先に行う。
+- **認可は deny-by-default**: EF は認証・認可を明示的に通す ([`../AI_DEV_PRINCIPLES.md`](../AI_DEV_PRINCIPLES.md))。
+- **依存は `npm:` specifier**: Supabase JS は `npm:@supabase/supabase-js@2` で import
+  (= 先行 ADR の決定を継承)。
+
+## Consequences
+
+- シークレットとビジネスロジックがサーバー側に留まり、Web/モバイルで単一ロジックパスを共有できる。
+- hub パターンにより EF 数が抑制され、デプロイ面と依存解決リスクが bounded に保たれる。
+- 「ついで実装」でクライアントにロジックが漏れるのを構造的に防ぐ ([NO-SCOPE-CREEP] と整合)。
+- トレードオフ: 単純な表示専用機能でも「まず hub action」を検討するため、ごく軽量な処理には
+  わずかにオーバーヘッドが乗る。判断に迷う場合は EF-CAP-50 を超えないことを優先する。
+
+## Links
+
+- 運用ルール: [EF-FIRST] / [EF-CAP-50] (= `~/.claude/hooks/inject-rules.txt`)
+- EF 一覧: [`../EDGE_FUNCTION_LIST.md`](../EDGE_FUNCTION_LIST.md)
+- 先行 ADR: [Supabase Edge Function Dependency Resolution](2026-04-30-edge-function-dependency-resolution.md)
+- 関連 ADR: [スタック選定](2026-06-05-flutter-web-supabase-firebase-stack.md)

--- a/docs/adr/2026-06-05-flutter-web-supabase-firebase-stack.md
+++ b/docs/adr/2026-06-05-flutter-web-supabase-firebase-stack.md
@@ -1,0 +1,45 @@
+# ADR: Flutter Web + Supabase + Firebase Hosting スタック選定
+
+Date: 2026-06-05
+Status: Accepted
+
+> 注: これは 2026-06-05 に新規に下した判断ではなく、本プロジェクト発足時から運用されてきた
+> 基盤判断を ADR 運用開始 (part 241) にあわせて backfill 記録したもの。
+
+## Context
+
+「自分株式会社」は少人数 (実質ソロ + AI fleet) で運用する個人プロダクトであり、専任の
+インフラ / 運用チームを持たない。次の制約下でスタックを選ぶ必要があった:
+
+- UI / バックエンドを通して言語・思考コストを最小化したい (= 文脈切替の削減)
+- 認証・DB・サーバーロジック・ストレージをマネージドで揃え、ops 負荷をほぼ 0 にしたい
+- ホスティングは低コスト (実質無料枠) + CDN + 独自ドメイン対応
+- 将来モバイル (iOS/Android) へ展開する可能性がある (= GitHub Issue #1495)
+- CI/CD は無料で回せること
+
+## Decision
+
+以下を標準スタックとする:
+
+- **フロントエンド**: Flutter Web (Dart) による単一コードベースの SPA。
+- **バックエンド**: Supabase = PostgreSQL + Edge Functions (Deno) + Auth + Storage。
+  データアクセス境界は **RLS (Row Level Security)** を一次防御線とする。
+- **ホスティング**: Firebase Hosting (静的配信 + CDN)。本番 = <https://my-web-app-b67f4.web.app/>。
+- **CI/CD**: GitHub Actions (deploy-prod / dev / staging)。
+
+## Consequences
+
+- Dart 単一言語で Web を構築でき、同一コードベースでモバイル展開の余地が残る。
+- サーバーロジックの置き場所は Edge Function に寄せる (= 別 ADR
+  [Edge-Function-first](2026-06-05-edge-function-first-architecture.md) で具体化)。
+- Supabase + Firebase の **2 ベンダー混在** を受け入れる (DB/認証/EF は Supabase、配信は Firebase)。
+  各々の無料/低額枠の良いとこ取りだが、障害切り分けは 2 系統を見る必要がある。
+- セキュリティの主境界が RLS / EF 認可になるため、新機能では deny-by-default を徹底する
+  (= [`../AI_DEV_PRINCIPLES.md`](../AI_DEV_PRINCIPLES.md))。
+- Dart 編集は `dart format` + `flutter analyze` 0 を push 前ゲートにする ([DART-FORMAT])。
+
+## Links
+
+- 原則 docs: [`../PHILOSOPHY.md`](../PHILOSOPHY.md) / [`../AI_DEV_PRINCIPLES.md`](../AI_DEV_PRINCIPLES.md)
+- 関連 ADR: [Edge-Function-first](2026-06-05-edge-function-first-architecture.md)
+- CLAUDE.md `Facts` セクション (= 技術スタックの正本)

--- a/docs/adr/2026-06-05-two-instance-fleet-architect-implementer.md
+++ b/docs/adr/2026-06-05-two-instance-fleet-architect-implementer.md
@@ -1,0 +1,49 @@
+# ADR: 2-instance fleet — Architect + Implementer 役割分担
+
+Date: 2026-06-05
+Status: Accepted
+
+> 注: 12→2 instance 移行 ([`../FLEET_2_INSTANCE_TRANSITION.md`](../FLEET_2_INSTANCE_TRANSITION.md))
+> で確定済の運用判断を、ADR 運用開始 (part 241) にあわせて backfill 記録したもの。
+
+## Context
+
+複数の AI コーディングツール (Claude Code / Codex / Gemini / Copilot 等) が利用可能だが、
+かつての 12-instance 体制 (PS#1-6 / VSCode / WEB / mobile / Codex 複数) は:
+
+- 担当の重複と作業衝突 (= 同一 file / migration / EF の並行編集)
+- merge コンフリクトと「誰が何を持っているか」の不透明化
+- 通信・調整オーバーヘッドの増大
+
+を生んでいた。明確なオーナーシップで衝突を減らす必要があった。
+
+## Decision
+
+アクティブ instance を **2 つ** に絞り、役割を分ける ([INSTANCE-ROLES]):
+
+- **Win Claude (Architect / L3)**: 設計・docs・memory・UI design・triage・AI 大学・競合分析・
+  mobile UAT・動画。**本 ADR 運用自体もこのレーンの成果物**。
+- **Win Codex (Implementer / L2)**: 実装・修正 PR・SQL・Edge Function (Deno)・GHA・
+  T-1 dispatch・競馬・Karpathy Compile/Lint。
+
+振り分けは 5 質問マトリクス (`docs/CODEX_WORKFLOW.md` §6) で判定: **1 つでも YES → Win Claude /
+全 NO → Win Codex**。各 instance は別 worktree で作業し main 直接編集は禁止 ([WORKDIR-ISOLATION])。
+旧 12 instance は dormant。
+
+## Consequences
+
+- オーナーシップが明確になり、重複作業と clobber が構造的に減る。
+- Architect (設計/handoff) → Implementer (実装) の **Architect-Implementer パターン**
+  ([`../AGENT_ORCHESTRATION_PATTERNS.md`](../AGENT_ORCHESTRATION_PATTERNS.md) ③) が標準フローになる。
+- worktree 分離により並行 push でも互いの作業を壊さない ([REBASE] / [STASH-SAFETY] と整合)。
+- Claude Code quota 超過時は Codex CLI / Gemini / Copilot に fallback できる
+  ([`../AI_FALLBACK_RUNBOOK.md`](../AI_FALLBACK_RUNBOOK.md))。
+- トレードオフ: 2 instance に絞ったぶん、瞬間的な並列度は下がる。スループットより
+  「衝突しない・追える」を優先する判断。
+
+## Links
+
+- 運用 docs: [`../MULTI_INSTANCE_FLEET.md`](../MULTI_INSTANCE_FLEET.md) /
+  [`../FLEET_2_INSTANCE_TRANSITION.md`](../FLEET_2_INSTANCE_TRANSITION.md) /
+  [`../AI_DRIVEN_DEV_OPERATING_MODEL.md`](../AI_DRIVEN_DEV_OPERATING_MODEL.md)
+- 運用ルール: [INSTANCE] / [INSTANCE-ROLES] / [WORKDIR-ISOLATION] (= inject-rules.txt)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,82 @@
+# Architecture Decision Records (ADR) — 運用ガイド
+
+> Win版#132 part 241 (2026-06-05): WBS 設計タスク「アーキテクチャ判断ログ運用 (ADR)」着地。
+> 目的 = 主要な設計判断を ADR 化し、NotebookLM / WBS に紐づけて **後続実装が迷わない状態** を作る。
+
+ADR (Architecture Decision Record) は「いつ・なぜ・どの設計を選んだか」を 1 ファイル 1 判断で
+不変記録する仕組み。原則 docs (= 12 軸 / 恒常的な指針) と違い、ADR は **特定時点の具体判断**
+(= alternatives を比較して 1 つに decide した記録) を残す。
+
+## いつ ADR を書くか
+
+以下のいずれかに当てはまる判断は ADR 化する:
+
+- アーキテクチャ / 技術スタック / データモデルの選択 (= 後から覆すコストが高い)
+- 複数の妥当な選択肢があり、1 つを選んだ理由を残す価値がある
+- セキュリティ境界 / 認証方式 / 権限モデルの決定
+- 運用上の制約 (= EF 数上限 / instance 役割分担 等) を恒久ルール化するとき
+- 過去の incident を受けた再発防止の構造変更
+
+書かなくてよいもの: 自明な実装詳細 / 1 行修正 / 可逆な微調整 / 個別バグ fix。
+(= 原則 [NO-SCOPE-CREEP] と同じ精神。迷ったら「3 ヶ月後の自分/他 instance が理由を知りたいか」で判断)
+
+## ファイル命名
+
+```
+docs/adr/YYYY-MM-DD-kebab-case-title.md
+```
+
+- 日付プレフィックス = 時系列順に自然ソート (= fleet が高速に判断を積む本プロジェクトに適合)
+- 既存 [`2026-04-30-edge-function-dependency-resolution.md`](2026-04-30-edge-function-dependency-resolution.md) がこの形式の先行例
+- 1 判断 = 1 ファイル。後で覆す場合も既存 ADR は編集せず Status を `Superseded` にして新 ADR を追加 (= 不変記録)
+
+## Status ライフサイクル
+
+| Status | 意味 |
+|--------|------|
+| `Proposed` | 提案中。レビュー / 合意待ち |
+| `Accepted` | 採用。実装の前提として有効 |
+| `Deprecated` | 非推奨化。新規には使わないが履歴として残す |
+| `Superseded by <ファイル名>` | 別 ADR に置き換え。本文は不変のまま残す |
+
+Status を変えるときは本文を書き換えず、`Status:` 行と必要なら冒頭 1 行の注記のみ更新する。
+
+## 構造 (= テンプレート)
+
+新規 ADR は [`TEMPLATE.md`](TEMPLATE.md) をコピーして書く。最小セクション:
+
+1. **タイトル** (`# ADR: <判断の要約>`)
+2. **Date / Status**
+3. **Context** — なぜこの判断が必要だったか (制約 / 問題)
+4. **Decision** — 何を決めたか (具体的に / コード片や数値があれば含める)
+5. **Consequences** — 結果として何が起きるか (得たもの・トレードオフ・後続への影響)
+6. **Links** (任意) — 関連 WBS task id / GitHub Issue / 原則 docs / 先行 ADR
+
+## WBS / Issue / NotebookLM への紐づけ
+
+後続実装が迷わないために、ADR は単体で終わらせず接続する:
+
+- **WBS**: ADR が実装タスクを生むときは `Links` に WBS task id を記載。逆に WBS の設計タスク完了時は
+  成果として該当 ADR を参照する (= 本 README は WBS task `2e41ebca-36bd-4c47-a87f-90b7b5948ece` の成果物)。
+- **GitHub Issue**: incident / feature 起点の判断は Issue 番号を `Links` に残す ([ISSUE-PRECHECK] と整合)。
+- **NotebookLM (Karpathy 外部脳)**: `docs/adr/` は Compile サイクル (`scripts/wiki_compile.py`) と
+  NotebookLM ingest の対象。過去判断は `notebooklm` CLI / `/wiki-query` でゼロトークン検索できる
+  (= 詳細 [`../NOTEBOOKLM_GUIDE.md`](../NOTEBOOKLM_GUIDE.md))。設計判断前に既存 ADR を query するのが推奨儀式。
+
+## 原則 docs との関係
+
+- **原則 docs** (= [`../PHILOSOPHY.md`](../PHILOSOPHY.md) ほか 12 軸) = 恒常的な「どう判断すべきか」の指針。
+- **ADR** = その指針を特定状況に適用した「実際にこう判断した」記録。
+
+ADR は原則 docs を置き換えない。原則に沿って下した個別判断のログ。原則自体を変える提案は原則 docs の PR で行う。
+
+## ADR 一覧 (Index)
+
+| Date | ADR | Status |
+|------|-----|--------|
+| 2026-04-30 | [Supabase Edge Function Dependency Resolution](2026-04-30-edge-function-dependency-resolution.md) | Accepted |
+| 2026-06-05 | [Flutter Web + Supabase + Firebase Hosting スタック選定](2026-06-05-flutter-web-supabase-firebase-stack.md) | Accepted |
+| 2026-06-05 | [Edge-Function-first アーキテクチャ (EF-FIRST / EF-CAP-50)](2026-06-05-edge-function-first-architecture.md) | Accepted |
+| 2026-06-05 | [2-instance fleet: Architect + Implementer 役割分担](2026-06-05-two-instance-fleet-architect-implementer.md) | Accepted |
+
+> 新しい ADR を追加したら、この表に 1 行追記する (= Index を単一の入口に保つ)。

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,36 @@
+# ADR: <判断の 1 行要約>
+
+Date: YYYY-MM-DD
+Status: Proposed
+
+## Context
+
+<なぜこの判断が必要か。制約・問題・背景。複数の選択肢が存在する状況を簡潔に。>
+
+## Decision
+
+<何を決めたか。曖昧さを残さず具体的に。守るべきルール・数値・コード片があれば含める。>
+
+## Consequences
+
+- <得られるもの / 良い影響>
+- <トレードオフ / 諦めたもの>
+- <後続実装・他 instance への影響 (= 迷わないための注意点)>
+
+## Alternatives considered (任意)
+
+- <検討したが採用しなかった案と、却下した理由 (1 行ずつ)>
+
+## Links (任意)
+
+- WBS task: `<uuid>`
+- GitHub Issue: #<number>
+- 原則 docs: [`../<doc>.md`](../<doc>.md)
+- 関連 / 先行 ADR: [`<filename>.md`](<filename>.md)
+
+<!--
+運用メモ (= docs/adr/README.md 参照):
+- ファイル名: docs/adr/YYYY-MM-DD-kebab-case-title.md
+- 採用が決まったら Status を Accepted に更新し README の Index 表に 1 行追記
+- 既存 ADR を覆す場合は本文を編集せず Status を Superseded by <新ファイル> に
+-->

--- a/supabase/migrations/20260605140000_wbs_complete_adr_operating_process.sql
+++ b/supabase/migrations/20260605140000_wbs_complete_adr_operating_process.sql
@@ -1,0 +1,45 @@
+-- Win版#132 part 241 (2026-06-05 / Win Claude): Complete WBS 設計タスク
+-- 「アーキテクチャ判断ログ運用 (ADR)」 (task 2e41ebca-36bd-4c47-a87f-90b7b5948ece).
+--
+-- Deliverable (docs-only, no code/EF/schema change):
+--   - docs/adr/README.md        … ADR 運用ガイド (いつ書く/命名/Status/WBS+Issue+NotebookLM 紐づけ/Index)
+--   - docs/adr/TEMPLATE.md       … 新規 ADR テンプレート
+--   - docs/adr/2026-06-05-flutter-web-supabase-firebase-stack.md         … 基盤判断 backfill
+--   - docs/adr/2026-06-05-edge-function-first-architecture.md            … EF-FIRST/EF-CAP-50 backfill
+--   - docs/adr/2026-06-05-two-instance-fleet-architect-implementer.md    … 2-instance fleet backfill
+--   - docs/DIRECTORY_STRUCTURE.md … docs/adr/ への pointer 追記
+--
+-- ai_review_status='approved' を同一 UPDATE で設定するため、progress=100 への遷移でも
+-- wbs_request_ai_review trigger は発火しない (trigger 条件: NEW.ai_review_status='pending')。
+-- → status='completed' が確定する。
+--
+-- Idempotent: 値は固定セット / description append は LIKE guard / achievement は NOT EXISTS guard。
+
+UPDATE public.wbs_tasks
+SET
+  status            = 'completed',
+  progress          = 100,
+  ai_review_status  = 'approved',
+  ai_reviewed_at    = now(),
+  ai_review_notes   = 'Win Claude (architect lane) self-authored deliverable. docs/adr/ に ADR 運用ガイド + テンプレート + 主要設計判断 3 件の backfill ADR を整備。コード/スキーマ変更なしの docs-only。',
+  start_date        = COALESCE(start_date, DATE '2026-06-05'),
+  end_date          = DATE '2026-06-05',
+  remaining_work    = 'Completed by Win Claude (part 241). ADR 運用は docs/adr/README.md に確立。新規設計判断は TEMPLATE.md をコピーし Index に 1 行追記する運用。',
+  description       = CASE
+    WHEN COALESCE(description, '') LIKE '%Done 2026-06-05: ADR operating process established%'
+      THEN description
+    ELSE COALESCE(description, '') ||
+      E'\n\nDone 2026-06-05 (Win Claude part 241): ADR operating process established under docs/adr/. Added README.md (when-to-write / naming / status lifecycle / WBS+Issue+NotebookLM linkage / index), TEMPLATE.md, and 3 backfill ADRs for the foundational stack, Edge-Function-first, and 2-instance fleet decisions. Docs-only; no code/schema change.'
+  END,
+  updated_at        = now()
+WHERE id = '2e41ebca-36bd-4c47-a87f-90b7b5948ece';
+
+-- 開発実績ログ (development_achievements ページ反映 / 重複防止 = NOT EXISTS guard)
+INSERT INTO development_achievements (title, description, completed_at)
+SELECT
+  'ADR (設計判断ログ) 運用の確立',
+  'docs/adr/ にアーキテクチャ判断記録 (ADR) の運用を整備。README で「いつ書くか/命名規則/Status ライフサイクル/WBS・Issue・NotebookLM への紐づけ」を定義し、TEMPLATE を用意。基盤スタック・Edge-Function-first・2-instance fleet の主要設計判断 3 件を backfill ADR 化した。後続実装が過去判断の理由を辿れる状態を作る (Win版#132 part 241)。',
+  DATE '2026-06-05'
+WHERE NOT EXISTS (
+  SELECT 1 FROM development_achievements WHERE title = 'ADR (設計判断ログ) 運用の確立'
+);


### PR DESCRIPTION
## 概要
WBS 設計タスク `2e41ebca-36bd-4c47-a87f-90b7b5948ece`「[設計] アーキテクチャ判断ログ運用 (ADR)」を完了 (Win版#132 part 241 / /loop dynamic mode / Win Claude architect lane)。

`docs/adr/` には ADR が 1 件あるのみで template・index・運用ルールが未整備だった。本 PR で ADR 運用 (いつ書く / 命名 / Status / 紐づけ) を確立し、主要設計判断 3 件を backfill。

## 変更
- **`docs/adr/README.md`** (新規) — 運用ガイド: いつ ADR を書くか / 命名 `YYYY-MM-DD-kebab.md` / Status ライフサイクル / WBS・Issue・NotebookLM 紐づけ / 原則 docs との関係 / Index 表
- **`docs/adr/TEMPLATE.md`** (新規) — 新規 ADR コピー元
- **backfill ADR 3 件** (新規): Flutter Web+Supabase+Firebase スタック / Edge-Function-first (EF-FIRST・EF-CAP-50) / 2-instance fleet (Architect+Implementer)
- **`docs/DIRECTORY_STRUCTURE.md`** — `docs/adr/` への pointer 追記
- **`supabase/migrations/20260605140000_*.sql`** — WBS task を completed 化 (progress=100 / ai_review_status=approved) + `development_achievements` 追記

## 検証
- docs-only + data-only WBS 完了 migration (コード/EF/スキーマ変更なし)
- migration idempotent: 固定値 UPDATE / description LIKE guard / achievement NOT EXISTS guard
- `ai_review_status='approved'` を同一 UPDATE で設定 → `wbs_request_ai_review` trigger の in_progress 差し戻しを回避 → status='completed' 確定
- merge → deploy-prod が migration 適用 → /project-gantt 上で当該タスクが完了表示

## Gate Declarations
- Review owner: Claude Code #1 (architect lane / Win Claude).
- high-risk-ultrareview-exception: docs-only ADR set + data-only WBS-completion migration (status flip); no code/EF/schema/auth/secret change; risk surface = markdown text + one idempotent UPDATE.
- Minimal E2E: implementation-detail independent (black-box, I/O level). No application code under lib/ or supabase/functions/, so the minimal ~3 I/O E2E cases are not applicable and there is no runtime behavior to exercise end-to-end. E2E-Exception: docs + data-only WBS migration, no app-code path.

## Philosophy Alignment
原則 2 ミッション / 4 mentor / 8 KPI (設計判断の追跡可能性) + [BRAIN-32] PKM。

🤖 Generated with [Claude Code](https://claude.com/claude-code)