### PR TITLE
Add direct Supabase attachment uploads

### DIFF
--- a/lib/services/attachment_service.dart
+++ b/lib/services/attachment_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:mime/mime.dart';
 import '../main.dart';
 import '../models/attachment.dart';
+import 'direct_storage_upload_service.dart';
 
 class AttachmentService {
   static const int maxFileSize = 5 * 1024 * 1024; // 5MB
@@ -93,50 +94,43 @@ class AttachmentService {
       // ファイル情報
       final mimeType = lookupMimeType(file.name) ?? 'application/octet-stream';
       final fileType = _getFileType(mimeType);
-      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final uploadService = DirectStorageUploadService.supabase(supabase);
 
       // ファイル名をURLセーフな形式にサニタイズ
-      final safeFileName = _sanitizeFileName(file.name);
-      final fileName = '${timestamp}_$safeFileName';
-      final filePath = '$userId/$noteId/$fileName';
+      final uploadResult = await uploadService.uploadAndInsertMetadata(
+        bucketId: 'attachments',
+        tableName: 'attachments',
+        userId: userId,
+        bytes: bytes,
+        originalFileName: file.name,
+        contentType: mimeType,
+        ownerPathSegments: <String>[noteId.toString()],
+        metadataBuilder: (final object) {
+          return <String, dynamic>{
+            'note_id': noteId,
+            'user_id': object.userId,
+            'file_name': file.name,
+            'file_path': object.storagePath,
+            'file_size': object.sizeBytes,
+            'file_type': fileType,
+            'mime_type': object.contentType,
+          };
+        },
+      );
 
       debugPrint(
         '📎 [AttachmentService] MIME type: $mimeType, file type: $fileType',
       );
-      debugPrint('📎 [AttachmentService] Upload path: $filePath');
-
-      // Supabase Storageにアップロード
-      debugPrint('📤 [AttachmentService] Uploading to Supabase Storage...');
-      await supabase.storage.from('attachments').uploadBinary(
-            filePath,
-            bytes,
-          );
-      debugPrint('✅ [AttachmentService] File uploaded to storage successfully');
-
-      // データベースに記録
       debugPrint(
-        '💾 [AttachmentService] Inserting attachment record to database...',
+        '📎 [AttachmentService] Upload path: ${uploadResult.storagePath}',
       );
-      final response = await supabase
-          .from('attachments')
-          .insert({
-            'note_id': noteId,
-            'user_id': userId,
-            'file_name': file.name,
-            'file_path': filePath,
-            'file_size': file.size,
-            'file_type': fileType,
-            'mime_type': mimeType,
-          })
-          .select()
-          .single();
 
       debugPrint(
         '✅ [AttachmentService] Attachment record inserted successfully',
       );
-      debugPrint('📎 [AttachmentService] Attachment ID: ${response['id']}');
+      debugPrint('📎 [AttachmentService] Attachment metadata inserted');
 
-      return Attachment.fromJson(response);
+      return Attachment.fromJson(uploadResult.metadataRow);
     } catch (e, stackTrace) {
       debugPrint('❌ [AttachmentService] Upload failed with error: $e');
       debugPrint('❌ [AttachmentService] Stack trace: $stackTrace');
@@ -161,28 +155,6 @@ class AttachmentService {
     } else {
       return 'other';
     }
-  }
-
-  // ファイル名をURLセーフな形式にサニタイズ
-  static String _sanitizeFileName(String fileName) {
-    // ファイル名から拡張子を分離
-    final lastDot = fileName.lastIndexOf('.');
-    final nameWithoutExt =
-        lastDot > 0 ? fileName.substring(0, lastDot) : fileName;
-    final extension = lastDot > 0 ? fileName.substring(lastDot) : '';
-
-    // 非ASCII文字と特殊文字をアンダースコアに置換
-    // ASCII文字、数字、ハイフン、ピリオドのみ許可
-    final sanitized = nameWithoutExt
-        .replaceAll(RegExp(r'[^\x00-\x7F]'), '_') // 非ASCII文字を置換
-        .replaceAll(RegExp(r'[^\w\-.]'), '_') // 英数字、ハイフン、ピリオド以外を置換
-        .replaceAll(RegExp(r'_+'), '_') // 連続するアンダースコアを1つに
-        .replaceAll(RegExp(r'^_|_$'), ''); // 先頭と末尾のアンダースコアを削除
-
-    // サニタイズ後のファイル名が空の場合は'file'を使用
-    final safeName = sanitized.isEmpty ? 'file' : sanitized;
-
-    return '$safeName$extension';
   }
 
 // getAttachments メソッドの引数を修正

--- a/lib/services/direct_storage_upload_service.dart
+++ b/lib/services/direct_storage_upload_service.dart
@@ -1,0 +1,250 @@
+import 'dart:typed_data';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+typedef DirectUploadMetadataBuilder = Map<String, dynamic> Function(
+  DirectStorageUploadObject object,
+);
+
+class DirectStorageUploadObject {
+  DirectStorageUploadObject({
+    required this.bucketId,
+    required this.userId,
+    required this.storagePath,
+    required this.originalFileName,
+    required this.contentType,
+    required this.sizeBytes,
+  });
+
+  final String bucketId;
+  final String userId;
+  final String storagePath;
+  final String originalFileName;
+  final String contentType;
+  final int sizeBytes;
+}
+
+class DirectStorageUploadResult {
+  DirectStorageUploadResult({
+    required this.object,
+    required this.metadataRow,
+  });
+
+  final DirectStorageUploadObject object;
+  final Map<String, dynamic> metadataRow;
+
+  String get bucketId => object.bucketId;
+  String get storagePath => object.storagePath;
+}
+
+abstract class DirectStorageUploadGateway {
+  Future<void> uploadBinary({
+    required final String bucketId,
+    required final String storagePath,
+    required final Uint8List bytes,
+    required final String contentType,
+    required final bool upsert,
+  });
+}
+
+abstract class DirectUploadMetadataStore {
+  Future<Map<String, dynamic>> insert({
+    required final String tableName,
+    required final Map<String, dynamic> values,
+  });
+}
+
+class SupabaseDirectStorageUploadGateway implements DirectStorageUploadGateway {
+  SupabaseDirectStorageUploadGateway(this._supabase);
+
+  final SupabaseClient _supabase;
+
+  @override
+  Future<void> uploadBinary({
+    required final String bucketId,
+    required final String storagePath,
+    required final Uint8List bytes,
+    required final String contentType,
+    required final bool upsert,
+  }) async {
+    await _supabase.storage.from(bucketId).uploadBinary(
+          storagePath,
+          bytes,
+          fileOptions: FileOptions(
+            contentType: contentType,
+            upsert: upsert,
+          ),
+        );
+  }
+}
+
+class SupabaseDirectUploadMetadataStore implements DirectUploadMetadataStore {
+  SupabaseDirectUploadMetadataStore(this._supabase);
+
+  final SupabaseClient _supabase;
+
+  @override
+  Future<Map<String, dynamic>> insert({
+    required final String tableName,
+    required final Map<String, dynamic> values,
+  }) async {
+    final response =
+        await _supabase.from(tableName).insert(values).select().single();
+    return Map<String, dynamic>.from(response as Map);
+  }
+}
+
+class DirectStorageUploadService {
+  DirectStorageUploadService({
+    required this.storage,
+    required this.metadataStore,
+  });
+
+  factory DirectStorageUploadService.supabase(final SupabaseClient client) {
+    return DirectStorageUploadService(
+      storage: SupabaseDirectStorageUploadGateway(client),
+      metadataStore: SupabaseDirectUploadMetadataStore(client),
+    );
+  }
+
+  final DirectStorageUploadGateway storage;
+  final DirectUploadMetadataStore metadataStore;
+
+  Future<DirectStorageUploadResult> uploadAndInsertMetadata({
+    required final String bucketId,
+    required final String tableName,
+    required final String userId,
+    required final Uint8List bytes,
+    required final String originalFileName,
+    required final String contentType,
+    required final DirectUploadMetadataBuilder metadataBuilder,
+    final Iterable<String> ownerPathSegments = const <String>[],
+    final DateTime? now,
+    final bool upsert = false,
+    final bool enforceUserIdColumn = true,
+  }) async {
+    if (bytes.isEmpty) {
+      throw ArgumentError.value(bytes.length, 'bytes', 'must not be empty');
+    }
+
+    final ownerId = _validateOwnerId(userId);
+    final storagePath = buildOwnerScopedPath(
+      userId: ownerId,
+      originalFileName: originalFileName,
+      ownerPathSegments: ownerPathSegments,
+      now: now,
+    );
+    final object = DirectStorageUploadObject(
+      bucketId: bucketId,
+      userId: ownerId,
+      storagePath: storagePath,
+      originalFileName: originalFileName,
+      contentType: contentType,
+      sizeBytes: bytes.length,
+    );
+    final metadataValues = metadataBuilder(object);
+    if (enforceUserIdColumn && metadataValues['user_id'] != ownerId) {
+      throw ArgumentError.value(
+        metadataValues['user_id'],
+        'metadataBuilder',
+        'must set user_id to the authenticated owner id',
+      );
+    }
+
+    await storage.uploadBinary(
+      bucketId: bucketId,
+      storagePath: storagePath,
+      bytes: bytes,
+      contentType: contentType,
+      upsert: upsert,
+    );
+    final metadataRow = await metadataStore.insert(
+      tableName: tableName,
+      values: metadataValues,
+    );
+
+    return DirectStorageUploadResult(
+      object: object,
+      metadataRow: metadataRow,
+    );
+  }
+
+  static String buildOwnerScopedPath({
+    required final String userId,
+    required final String originalFileName,
+    final Iterable<String> ownerPathSegments = const <String>[],
+    final DateTime? now,
+  }) {
+    final ownerId = _validateOwnerId(userId);
+    final safeFileName = sanitizeFileName(originalFileName);
+    final timestamp = (now ?? DateTime.now()).millisecondsSinceEpoch;
+    final segments = <String>[
+      ownerId,
+      ...ownerPathSegments.map(sanitizePathSegment),
+      '${timestamp}_$safeFileName',
+    ];
+
+    return segments.join('/');
+  }
+
+  static String sanitizeFileName(final String fileName) {
+    final baseName = _lastPathComponent(fileName);
+    final lastDot = baseName.lastIndexOf('.');
+    final nameWithoutExtension =
+        lastDot > 0 ? baseName.substring(0, lastDot) : baseName;
+    final rawExtension = lastDot > 0 ? baseName.substring(lastDot + 1) : '';
+    final safeName = _sanitizeToken(nameWithoutExtension, fallback: 'file');
+    final safeExtension =
+        rawExtension.replaceAll(RegExp(r'[^A-Za-z0-9]'), '').toLowerCase();
+
+    if (safeExtension.isEmpty) {
+      return safeName;
+    }
+    return '$safeName.$safeExtension';
+  }
+
+  static String sanitizePathSegment(final String value) {
+    return _sanitizeToken(value, fallback: 'segment');
+  }
+
+  static String _validateOwnerId(final String userId) {
+    final trimmed = userId.trim();
+    if (trimmed.isEmpty || trimmed.contains('/') || trimmed.contains('\\')) {
+      throw ArgumentError.value(
+        userId,
+        'userId',
+        'must be a non-empty owner id without path separators',
+      );
+    }
+    return trimmed;
+  }
+
+  static String _lastPathComponent(final String value) {
+    final normalized = value.replaceAll('\\', '/');
+    final parts = normalized
+        .split('/')
+        .where((final part) => part.trim().isNotEmpty)
+        .toList(growable: false);
+    if (parts.isEmpty) {
+      return '';
+    }
+    return parts.last;
+  }
+
+  static String _sanitizeToken(
+    final String value, {
+    required final String fallback,
+  }) {
+    final sanitized = value
+        .trim()
+        .replaceAll(RegExp(r'[^\x00-\x7F]'), '_')
+        .replaceAll(RegExp(r'[^\w\-.]'), '_')
+        .replaceAll(RegExp(r'_+'), '_')
+        .replaceAll(RegExp(r'^[_.-]+|[_.-]+$'), '');
+
+    if (sanitized.isEmpty || sanitized == '.' || sanitized == '..') {
+      return fallback;
+    }
+    return sanitized;
+  }
+}

--- a/supabase/migrations/20260606023000_harden_attachment_direct_upload.sql
+++ b/supabase/migrations/20260606023000_harden_attachment_direct_upload.sql
@@ -1,0 +1,89 @@
+-- Issue #2602: keep note attachments on a frontend direct-upload path.
+-- Uploads go directly to Supabase Storage under auth.uid()/... and metadata
+-- is recorded in public.attachments by the authenticated client.
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'attachments',
+  'attachments',
+  false,
+  5242880,
+  array['image/jpeg','image/jpg','image/png','image/gif','image/webp','application/pdf']::text[]
+)
+on conflict (id) do update
+set
+  public = false,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+alter table public.attachments enable row level security;
+
+drop policy if exists "Users can view their own attachments" on public.attachments;
+drop policy if exists "Users can insert their own attachments" on public.attachments;
+drop policy if exists "Users can update their own attachments" on public.attachments;
+drop policy if exists "Users can delete their own attachments" on public.attachments;
+
+create policy "Users can view their own attachments"
+  on public.attachments for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users can insert their own attachments"
+  on public.attachments for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users can update their own attachments"
+  on public.attachments for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users can delete their own attachments"
+  on public.attachments for delete
+  to authenticated
+  using (auth.uid() = user_id);
+
+drop policy if exists "Users can upload their own files" on storage.objects;
+drop policy if exists "Users can view their own files" on storage.objects;
+drop policy if exists "Users can update their own files" on storage.objects;
+drop policy if exists "Users can delete their own files" on storage.objects;
+
+create policy "Users can upload their own files"
+  on storage.objects for insert
+  to authenticated
+  with check (
+    bucket_id = 'attachments'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "Users can view their own files"
+  on storage.objects for select
+  to authenticated
+  using (
+    bucket_id = 'attachments'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "Users can update their own files"
+  on storage.objects for update
+  to authenticated
+  using (
+    bucket_id = 'attachments'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  )
+  with check (
+    bucket_id = 'attachments'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "Users can delete their own files"
+  on storage.objects for delete
+  to authenticated
+  using (
+    bucket_id = 'attachments'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+comment on table public.attachments is
+  'Owner-scoped metadata for files uploaded directly to Supabase Storage.';

--- a/test/services/direct_storage_upload_service_test.dart
+++ b/test/services/direct_storage_upload_service_test.dart
@@ -1,0 +1,228 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/direct_storage_upload_service.dart';
+
+void main() {
+  group('DirectStorageUploadService', () {
+    final fixedNow = DateTime.fromMillisecondsSinceEpoch(
+      1700000000000,
+      isUtc: true,
+    );
+
+    test('uploads owner-scoped bytes before inserting metadata', () async {
+      final events = <String>[];
+      final storage = _FakeStorageUploadGateway(events);
+      final metadataStore = _FakeDirectUploadMetadataStore(events);
+      final service = DirectStorageUploadService(
+        storage: storage,
+        metadataStore: metadataStore,
+      );
+
+      final result = await service.uploadAndInsertMetadata(
+        bucketId: 'attachments',
+        tableName: 'attachments',
+        userId: 'user-123',
+        bytes: Uint8List.fromList(<int>[1, 2, 3]),
+        originalFileName: '../Receipt June.PDF',
+        contentType: 'application/pdf',
+        ownerPathSegments: <String>['42'],
+        now: fixedNow,
+        metadataBuilder: (final object) {
+          return <String, dynamic>{
+            'note_id': 42,
+            'user_id': object.userId,
+            'file_name': object.originalFileName,
+            'file_path': object.storagePath,
+            'file_size': object.sizeBytes,
+            'mime_type': object.contentType,
+          };
+        },
+      );
+
+      const expectedPath = 'user-123/42/1700000000000_Receipt_June.pdf';
+      expect(events, <String>['upload:$expectedPath', 'metadata:attachments']);
+      expect(result.bucketId, 'attachments');
+      expect(result.storagePath, expectedPath);
+
+      final upload = storage.uploads.single;
+      expect(upload.bucketId, 'attachments');
+      expect(upload.storagePath, expectedPath);
+      expect(upload.contentType, 'application/pdf');
+      expect(upload.upsert, isFalse);
+      expect(upload.bytes, <int>[1, 2, 3]);
+
+      final insert = metadataStore.inserts.single;
+      expect(insert.tableName, 'attachments');
+      expect(insert.values['user_id'], 'user-123');
+      expect(insert.values['file_path'], expectedPath);
+      expect(insert.values['file_size'], 3);
+      expect(result.metadataRow['id'], 99);
+    });
+
+    test('rejects metadata that does not belong to the upload owner', () async {
+      final events = <String>[];
+      final storage = _FakeStorageUploadGateway(events);
+      final metadataStore = _FakeDirectUploadMetadataStore(events);
+      final service = DirectStorageUploadService(
+        storage: storage,
+        metadataStore: metadataStore,
+      );
+
+      await expectLater(
+        service.uploadAndInsertMetadata(
+          bucketId: 'attachments',
+          tableName: 'attachments',
+          userId: 'user-123',
+          bytes: Uint8List.fromList(<int>[1]),
+          originalFileName: 'receipt.pdf',
+          contentType: 'application/pdf',
+          now: fixedNow,
+          metadataBuilder: (final object) {
+            return <String, dynamic>{
+              'user_id': 'someone-else',
+              'file_path': object.storagePath,
+            };
+          },
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(storage.uploads, isEmpty);
+      expect(metadataStore.inserts, isEmpty);
+    });
+
+    test('rejects empty uploads before touching storage', () async {
+      final events = <String>[];
+      final storage = _FakeStorageUploadGateway(events);
+      final metadataStore = _FakeDirectUploadMetadataStore(events);
+      final service = DirectStorageUploadService(
+        storage: storage,
+        metadataStore: metadataStore,
+      );
+
+      await expectLater(
+        service.uploadAndInsertMetadata(
+          bucketId: 'attachments',
+          tableName: 'attachments',
+          userId: 'user-123',
+          bytes: Uint8List(0),
+          originalFileName: 'receipt.pdf',
+          contentType: 'application/pdf',
+          now: fixedNow,
+          metadataBuilder: (final object) {
+            return <String, dynamic>{
+              'user_id': object.userId,
+              'file_path': object.storagePath,
+            };
+          },
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(storage.uploads, isEmpty);
+      expect(metadataStore.inserts, isEmpty);
+    });
+
+    test('sanitizes path segments and rejects unsafe owner ids', () {
+      final storagePath = DirectStorageUploadService.buildOwnerScopedPath(
+        userId: 'user-123',
+        ownerPathSegments: <String>['../bad folder'],
+        originalFileName: r'..\..\receipt report 06.PDF',
+        now: fixedNow,
+      );
+
+      expect(
+        storagePath,
+        'user-123/bad_folder/1700000000000_receipt_report_06.pdf',
+      );
+      expect(
+        () => DirectStorageUploadService.buildOwnerScopedPath(
+          userId: 'user/123',
+          originalFileName: 'receipt.pdf',
+          now: fixedNow,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}
+
+class _UploadCall {
+  _UploadCall({
+    required this.bucketId,
+    required this.storagePath,
+    required this.bytes,
+    required this.contentType,
+    required this.upsert,
+  });
+
+  final String bucketId;
+  final String storagePath;
+  final Uint8List bytes;
+  final String contentType;
+  final bool upsert;
+}
+
+class _MetadataInsert {
+  _MetadataInsert({
+    required this.tableName,
+    required this.values,
+  });
+
+  final String tableName;
+  final Map<String, dynamic> values;
+}
+
+class _FakeStorageUploadGateway implements DirectStorageUploadGateway {
+  _FakeStorageUploadGateway(this.events);
+
+  final List<String> events;
+  final uploads = <_UploadCall>[];
+
+  @override
+  Future<void> uploadBinary({
+    required final String bucketId,
+    required final String storagePath,
+    required final Uint8List bytes,
+    required final String contentType,
+    required final bool upsert,
+  }) async {
+    uploads.add(
+      _UploadCall(
+        bucketId: bucketId,
+        storagePath: storagePath,
+        bytes: bytes,
+        contentType: contentType,
+        upsert: upsert,
+      ),
+    );
+    events.add('upload:$storagePath');
+  }
+}
+
+class _FakeDirectUploadMetadataStore implements DirectUploadMetadataStore {
+  _FakeDirectUploadMetadataStore(this.events);
+
+  final List<String> events;
+  final inserts = <_MetadataInsert>[];
+
+  @override
+  Future<Map<String, dynamic>> insert({
+    required final String tableName,
+    required final Map<String, dynamic> values,
+  }) async {
+    inserts.add(
+      _MetadataInsert(
+        tableName: tableName,
+        values: values,
+      ),
+    );
+    events.add('metadata:$tableName');
+    return <String, dynamic>{
+      ...values,
+      'id': 99,
+      'created_at': '2026-06-06T00:00:00Z',
+    };
+  }
+}

--- a/test/services/direct_upload_storage_schema_test.dart
+++ b/test/services/direct_upload_storage_schema_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _attachmentsSetupPath =
+    'supabase/migrations/20251108120000_attachments_complete_setup.sql';
+const _directUploadHardeningPath =
+    'supabase/migrations/20260606023000_harden_attachment_direct_upload.sql';
+
+void main() {
+  group('attachments direct upload schema', () {
+    late final String setupSql;
+    late final String hardeningSql;
+
+    setUpAll(() {
+      setupSql = _readSql(_attachmentsSetupPath);
+      hardeningSql = _readSql(_directUploadHardeningPath);
+    });
+
+    test('stores upload metadata needed after a direct Storage write', () {
+      final block = _createTableBlock(setupSql, 'attachments');
+
+      expect(block, contains('note_id bigint not null'));
+      expect(
+        block,
+        contains('user_id uuid not null references auth.users(id)'),
+      );
+      expect(block, contains('file_name text not null'));
+      expect(block, contains('file_path text not null unique'));
+      expect(block, contains('file_size bigint not null'));
+      expect(block, contains('mime_type text not null'));
+    });
+
+    test('keeps the attachments bucket private with upload limits', () {
+      expect(hardeningSql, contains('insert into storage.buckets'));
+      expect(hardeningSql, contains("'attachments'"));
+      expect(hardeningSql, contains('false'));
+      expect(hardeningSql, contains('5242880'));
+      expect(hardeningSql, contains("'application/pdf'"));
+      expect(hardeningSql, contains('on conflict (id) do update'));
+      expect(hardeningSql, contains('public = false'));
+      expect(
+        hardeningSql,
+        contains('file_size_limit = excluded.file_size_limit'),
+      );
+      expect(
+        hardeningSql,
+        contains('allowed_mime_types = excluded.allowed_mime_types'),
+      );
+    });
+
+    test('requires authenticated owner-only RLS for metadata rows', () {
+      expect(
+        hardeningSql,
+        contains('alter table public.attachments enable row level security;'),
+      );
+
+      for (final operation in <String>[
+        'select',
+        'insert',
+        'update',
+        'delete',
+      ]) {
+        expect(
+          hardeningSql,
+          contains('on public.attachments for $operation\n  to authenticated'),
+        );
+      }
+
+      expect(hardeningSql, contains('using (auth.uid() = user_id)'));
+      expect(hardeningSql, contains('with check (auth.uid() = user_id)'));
+    });
+
+    test('requires authenticated owner-scoped Storage object paths', () {
+      for (final operation in <String>[
+        'insert',
+        'select',
+        'update',
+        'delete',
+      ]) {
+        expect(
+          hardeningSql,
+          contains('on storage.objects for $operation\n  to authenticated'),
+        );
+      }
+
+      expect(hardeningSql, contains("bucket_id = 'attachments'"));
+      expect(
+        hardeningSql,
+        contains('(storage.foldername(name))[1] = auth.uid()::text'),
+      );
+    });
+  });
+}
+
+String _readSql(final String path) {
+  return File(path).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+}
+
+String _createTableBlock(final String sql, final String table) {
+  final start = sql.indexOf('create table public.$table');
+  expect(start, isNonNegative, reason: 'missing create table for $table');
+
+  final end = sql.indexOf('\n);', start);
+  expect(
+    end,
+    isNonNegative,
+    reason: 'missing create table terminator for $table',
+  );
+
+  return sql.substring(start, end);
+}


### PR DESCRIPTION
## Summary

- Adds a reusable `DirectStorageUploadService` for authenticated owner-scoped Supabase Storage uploads.
- Routes note attachment uploads through the direct Storage path before inserting metadata.
- Hardens the `attachments` bucket and `public.attachments`/`storage.objects` RLS policies for owner-only direct uploads.

Closes #2602.

## Validation

- `flutter test test\services\direct_storage_upload_service_test.dart test\services\direct_upload_storage_schema_test.dart`
- `flutter analyze lib\services\direct_storage_upload_service.dart`
- `flutter analyze lib\services\attachment_service.dart`

## Minimal E2E Gate

- black-box coverage: direct upload service tests verify owner-scoped upload, metadata insert ordering, empty upload rejection, and unsafe owner/path rejection.
- implementation-detail independent: schema tests validate required Storage/RLS behavior through migration SQL expectations.
- minimal three cases: success, wrong-owner rejection, empty upload rejection.
- Playwright: not run because this change is a service/storage-policy path without a local browser UI workflow.
- E2E-Exception: covered by focused Flutter service tests plus SQL schema tests instead of Playwright.

## High-risk Ultrareview Evidence

- Review owner: Claude Code #1
- Claude ultrareview evidence: storage/RLS/security impact reviewed against owner-scoped paths and authenticated-only metadata policies.
- Required perspectives: security, rollback, data migration, prod smoke, observability.
- Security: upload path starts with authenticated `auth.uid()` / user id and metadata insert enforces owner id.
- Rollback: revert this migration and service routing to restore the prior attachment upload path.
- Data migration: migration is additive/hardening for `attachments` bucket/policies and does not rewrite attachment rows.
- Prod smoke: upload one allowed attachment as an authenticated user and confirm metadata row plus private object path.
- Observability: existing debug logging still reports MIME type, path, and upload/metadata failure categories.
- unresolved findings: 0 / none.