### PR TITLE
Add lending self-exclusion safety guardrails

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -47,6 +47,7 @@ import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:web/web.dart' as web;
 
 enum AssetManagementInitialFocus {
@@ -2063,17 +2064,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_saveAssetLiabilityMonthlyState());
   }
 
-  void _updateAnnualRateOverride(String accountId, String rawValue) {
+  void _updateAnnualRateOverride(AssetLiabilityDebtRow row, String rawValue) {
     final parsed = _parseAnnualRateInput(rawValue);
     setState(() {
       if (parsed == null) {
-        _annualRateOverrides.remove(accountId);
-        _annualRateEvidences.remove(accountId);
+        _annualRateOverrides.remove(row.id);
+        _annualRateEvidences.remove(row.id);
+      } else if (_annualRateRiskFor(
+            accountName: row.name,
+            annualRate: parsed,
+            principal: row.balance.abs(),
+          )?.blocksRegistration ==
+          true) {
+        _annualRateOverrides.remove(row.id);
+        _annualRateEvidences.remove(row.id);
       } else {
-        final currentEvidence = _annualRateEvidences[accountId];
+        final currentEvidence = _annualRateEvidences[row.id];
         if (currentEvidence == null ||
             !currentEvidence.matchesAnnualRate(parsed)) {
-          _annualRateOverrides.remove(accountId);
+          _annualRateOverrides.remove(row.id);
         }
       }
     });
@@ -2087,6 +2096,34 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return null;
     }
     return parsed > 1 ? parsed / 100 : parsed;
+  }
+
+  DebtAnnualRateRisk? _annualRateRiskFor({
+    required String accountName,
+    required double annualRate,
+    required double principal,
+  }) {
+    return DebtLockdownService.evaluateAnnualRate(
+      accountName: accountName,
+      annualRate: annualRate,
+      principal: principal,
+    );
+  }
+
+  DebtAnnualRateRisk? _annualRateRiskForRow(AssetLiabilityDebtRow row) {
+    final rate = _parseAnnualRateInput(_annualRateControllerFor(row).text) ??
+        row.annualRate;
+    return _annualRateRiskFor(
+      accountName: row.name,
+      annualRate: rate,
+      principal: row.balance.abs(),
+    );
+  }
+
+  void _showAnnualRateBlockedSnackBar(DebtAnnualRateRisk risk) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(risk.detail)));
   }
 
   void _clearAnnualRateOverride(String accountId) {
@@ -2105,6 +2142,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('年利を入力してから証跡画像を提出してください')));
+      return;
+    }
+    final risk = _annualRateRiskFor(
+      accountName: row.name,
+      annualRate: rate,
+      principal: row.balance.abs(),
+    );
+    if (risk?.blocksRegistration == true) {
+      _showAnnualRateBlockedSnackBar(risk!);
       return;
     }
     final result = await FilePicker.pickFiles(
@@ -2134,6 +2180,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       ).showSnackBar(const SnackBar(content: Text('年利を入力してから証跡画像を貼り付けてください')));
       return;
     }
+    final risk = _annualRateRiskFor(
+      accountName: row.name,
+      annualRate: rate,
+      principal: row.balance.abs(),
+    );
+    if (risk?.blocksRegistration == true) {
+      _showAnnualRateBlockedSnackBar(risk!);
+      return;
+    }
     setState(() => _annualRateEvidencePasteTargetRow = row);
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -2156,6 +2211,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('年利を入力してから証跡画像を貼り付けてください')));
+      return;
+    }
+    final risk = _annualRateRiskFor(
+      accountName: row.name,
+      annualRate: rate,
+      principal: row.balance.abs(),
+    );
+    if (risk?.blocksRegistration == true) {
+      _showAnnualRateBlockedSnackBar(risk!);
       return;
     }
     if (bytes.isEmpty) {
@@ -2832,8 +2896,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
     final currentMonth = _assetLiabilityStateMonth(_now);
     final nextMonth = DateTime(currentMonth.year, currentMonth.month + 1);
-    final nextMonthKey =
-        AssetLiabilityMonthlyStateStore.formatMonthKey(nextMonth);
+    final nextMonthKey = AssetLiabilityMonthlyStateStore.formatMonthKey(
+      nextMonth,
+    );
     final lastDay = DateTime(nextMonth.year, nextMonth.month + 1, 0).day;
     final nextState = await _assetLiabilityRepository.loadMonth(nextMonth);
     final existingIds = nextState.transferTasks.map((task) => task.id).toSet();
@@ -2859,9 +2924,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     ];
     if (carriedTasks.isEmpty) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('繰り越し済みのため追加はありません。')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('繰り越し済みのため追加はありません。')));
       return;
     }
 
@@ -4791,9 +4856,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       }
       _controllers.forEach((_, controller) => controller.clear());
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(
+        ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
               autoRecordedCount > 0
@@ -5709,9 +5772,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     String? wasteCategory,
     bool isTransfer,
   }) _parseFlowDescription(String description, {String? actionType}) {
-    final normalizedDescription = _stripFlowMetadataMarkers(
-      description.trim(),
-    );
+    final normalizedDescription = _stripFlowMetadataMarkers(description.trim());
     final isExpense = _isExpenseActionType(actionType ?? '');
     final wasteCategory = isExpense
         ? WasteTrackingService.extractWasteCategory(normalizedDescription)
@@ -6643,9 +6704,35 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // ==========================================
   // UI構築 (エラーが起きていた箇所)
   // ==========================================
+  AssetLiabilityWorkbook? _buildCurrentAssetLiabilityWorkbook() {
+    final latestSnapshot = _latestSnapshotForDisplay();
+    if (latestSnapshot.isEmpty) {
+      return null;
+    }
+
+    return _assetLiabilityPlanner.buildWorkbook(
+      latestSnapshot: latestSnapshot,
+      baseDate: _now,
+      monthlyPaymentOverrides: _monthlyPaymentOverrides,
+      actualPaymentAmounts: _actualPaymentAmounts,
+      paymentDifferenceReasons: _paymentDifferenceReasons,
+      annualRateOverrides: _annualRateOverrides,
+      paidAccountNames: _monthlyPaidAccountNames,
+      paymentSourceAccountIds: _paymentSourceAccountIds,
+      defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
+      defaultCardBillingAccountIds: _defaultCardBillingAccountIds,
+      cardBillingAccountIds: _cardBillingAccountIds,
+      incomePlans: _monthlyIncomePlans,
+      cardStatementLines: _cardStatementLines,
+      transferTasks: _transferTasks,
+      includeDefaultFixedPayments: true,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isCompact = _isCompact;
+    final assetLiabilityWorkbook = _buildCurrentAssetLiabilityWorkbook();
     return Scaffold(
       appBar: AppBar(
         title: const Text('資産管理闘争'),
@@ -6678,9 +6765,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             const SizedBox(height: 16),
             _buildThreeMonthOverviewCard(), // 3ヶ月俯瞰
             const SizedBox(height: 16),
-            _buildDebtPlannerCard(), // 借金返済プラン
+            _buildDebtPlannerCard(assetLiabilityWorkbook), // 借金返済プラン
             const SizedBox(height: 16),
-            _buildAssetLiabilityWorkbookBoard(),
+            _buildAssetLiabilityWorkbookBoard(assetLiabilityWorkbook),
             const SizedBox(height: 16),
             Container(
               key: _keyStock,
@@ -7414,14 +7501,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   String _buildDisposableBalanceFixedBreakdown(
-      DisposableBalanceResult balance) {
-    final rows = List<DisposableBalanceRecurringExpense>.from(
-      balance.recurringExpenses,
-    )..sort((a, b) {
-        final day = a.dayOfMonth.compareTo(b.dayOfMonth);
-        if (day != 0) return day;
-        return b.amount.compareTo(a.amount);
-      });
+    DisposableBalanceResult balance,
+  ) {
+    final rows =
+        List<DisposableBalanceRecurringExpense>.from(balance.recurringExpenses)
+          ..sort((a, b) {
+            final day = a.dayOfMonth.compareTo(b.dayOfMonth);
+            if (day != 0) return day;
+            return b.amount.compareTo(a.amount);
+          });
     return _buildDisposableBalanceBreakdownText(
       title: '固定費内訳',
       totalLabel: '固定費合計',
@@ -8640,7 +8728,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   // 借金返済プランカード
-  Widget _buildDebtPlannerCard() {
+  Widget _buildDebtPlannerCard(AssetLiabilityWorkbook? workbook) {
     final latestSnapshot = _sortedDates.isEmpty
         ? const <String, double>{}
         : (_effectiveAssetDataByDate[_sortedDates.last] ??
@@ -8655,6 +8743,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       0,
       (sum, e) => sum + e.value.abs(),
     );
+    final debtSafetySnapshot = workbook == null
+        ? null
+        : DebtLockdownService.buildSafetySnapshot(
+            debts: workbook.debtMasterRows.map(
+              (row) => DebtSafetyDebtInput(
+                accountId: row.id,
+                accountName: row.name,
+                balance: row.balance.abs(),
+                annualRate: row.annualRate,
+              ),
+            ),
+          );
     _ensureDebtLockdownSnapshotLoaded(totalDebt);
 
     return Card(
@@ -8705,6 +8805,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ],
             ),
             const SizedBox(height: 12),
+            if (debtSafetySnapshot != null &&
+                debtSafetySnapshot.hasSignals) ...[
+              _buildDebtSafetyPanel(debtSafetySnapshot),
+              const SizedBox(height: 12),
+            ],
             _buildDebtLockdownPanel(totalDebt),
             const SizedBox(height: 12),
             _isCompact
@@ -8864,6 +8969,240 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       ),
     );
+  }
+
+  Widget _buildDebtSafetyPanel(DebtSafetySnapshot snapshot) {
+    final color = snapshot.hasBlockingAnnualRates
+        ? const Color(0xFFB91C1C)
+        : const Color(0xFFD97706);
+    final background = snapshot.hasBlockingAnnualRates
+        ? const Color(0xFFFEF2F2)
+        : const Color(0xFFFFFBEB);
+
+    return Container(
+      key: const Key('asset_debt_safety_panel'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.32)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.health_and_safety_outlined, color: color),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  '貸付自粛・違法業者ガード',
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w800,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '年利20%超は登録を保存しません。多重債務の兆候がある場合は貸付自粛制度と公的な相談窓口を自動で提示します。',
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.onSurface,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildOverviewStatChip(
+                label: '負債件数',
+                value: '${snapshot.debtCount}件',
+                color: const Color(0xFFB91C1C),
+              ),
+              _buildOverviewStatChip(
+                label: '対象残高',
+                value: _formatManagementYen(snapshot.totalDebt),
+                color: const Color(0xFFFF6B35),
+              ),
+              _buildOverviewStatChip(
+                label: '金利警告',
+                value: '${snapshot.annualRateRisks.length}件',
+                color: color,
+              ),
+              if (snapshot.shouldShowSelfExclusionGuidance)
+                _buildTextStatusChip(
+                  label: '貸付自粛制度を案内中',
+                  color: const Color(0xFF7C2D12),
+                ),
+            ],
+          ),
+          if (snapshot.annualRateRisks.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            for (final risk in snapshot.annualRateRisks.take(3))
+              _buildDebtSafetyWarningRow(risk),
+          ],
+          if (snapshot.guidanceCards.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            for (final guidance in snapshot.guidanceCards.take(4))
+              _buildDebtSafetyGuidanceRow(guidance),
+          ],
+          if (snapshot.educationNotices.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            const Text(
+              'アプリ内通知',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+                height: 1.4,
+              ),
+            ),
+            const SizedBox(height: 4),
+            for (final notice in snapshot.educationNotices)
+              _buildDebtEducationNoticeRow(notice),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDebtSafetyWarningRow(DebtAnnualRateRisk risk) {
+    final color = _debtSafetySeverityColor(risk.severity);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            risk.blocksRegistration
+                ? Icons.gpp_bad_outlined
+                : Icons.warning_amber_rounded,
+            size: 18,
+            color: color,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '${risk.title}: ${risk.detail}',
+              style: TextStyle(
+                fontSize: 12,
+                color: color,
+                fontWeight: FontWeight.w700,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDebtSafetyGuidanceRow(DebtSafetyGuidance guidance) {
+    final color = _debtSafetySeverityColor(guidance.severity);
+    return Container(
+      margin: const EdgeInsets.only(bottom: 6),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.64),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.open_in_new, size: 18, color: color),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  guidance.title,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: color,
+                    fontWeight: FontWeight.w800,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  guidance.body,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Theme.of(context).colorScheme.onSurface,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          TextButton.icon(
+            onPressed: () => _openDebtSafetyUrl(guidance.url),
+            icon: const Icon(Icons.open_in_new, size: 14),
+            label: Text(guidance.actionLabel),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDebtEducationNoticeRow(DebtEducationNotice notice) {
+    final color = _debtSafetySeverityColor(notice.severity);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.notifications_active_outlined, size: 18, color: color),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '${notice.title}: ${notice.body}',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurface,
+                height: 1.5,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          TextButton(
+            onPressed: () => _openDebtSafetyUrl(notice.url),
+            child: Text(notice.actionLabel),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _debtSafetySeverityColor(DebtSafetySeverity severity) {
+    return switch (severity) {
+      DebtSafetySeverity.info => const Color(0xFF2563EB),
+      DebtSafetySeverity.warning => const Color(0xFFD97706),
+      DebtSafetySeverity.danger => const Color(0xFFB91C1C),
+    };
+  }
+
+  Future<void> _openDebtSafetyUrl(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      return;
+    }
+    final opened = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!mounted || opened) {
+      return;
+    }
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('URLを開けませんでした: $url')));
   }
 
   Widget _buildDebtLockdownPanel(double remainingDebt) {
@@ -9404,29 +9743,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
-  Widget _buildAssetLiabilityWorkbookBoard() {
-    final latestSnapshot = _latestSnapshotForDisplay();
-    if (latestSnapshot.isEmpty) {
+  Widget _buildAssetLiabilityWorkbookBoard(AssetLiabilityWorkbook? workbook) {
+    if (workbook == null) {
       return const SizedBox.shrink();
     }
-
-    final workbook = _assetLiabilityPlanner.buildWorkbook(
-      latestSnapshot: latestSnapshot,
-      baseDate: _now,
-      monthlyPaymentOverrides: _monthlyPaymentOverrides,
-      actualPaymentAmounts: _actualPaymentAmounts,
-      paymentDifferenceReasons: _paymentDifferenceReasons,
-      annualRateOverrides: _annualRateOverrides,
-      paidAccountNames: _monthlyPaidAccountNames,
-      paymentSourceAccountIds: _paymentSourceAccountIds,
-      defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
-      defaultCardBillingAccountIds: _defaultCardBillingAccountIds,
-      cardBillingAccountIds: _cardBillingAccountIds,
-      incomePlans: _monthlyIncomePlans,
-      cardStatementLines: _cardStatementLines,
-      transferTasks: _transferTasks,
-      includeDefaultFixedPayments: true,
-    );
     _scheduleAssetLiabilityStateIdMigration(workbook);
     final insightReport = _assetManagementInsightService.buildReport(
       workbook: workbook,
@@ -10407,10 +10727,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
               OutlinedButton.icon(
                 onPressed: enabled && !_isGeneratingAssetManagementAiSummary
-                    ? () => _generateAssetManagementAiSummary(
-                          report,
-                          force: true,
-                        )
+                    ? () =>
+                        _generateAssetManagementAiSummary(report, force: true)
                     : null,
                 icon: _isGeneratingAssetManagementAiSummary
                     ? const SizedBox(
@@ -10419,9 +10737,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
                     : const Icon(Icons.auto_awesome_outlined, size: 16),
-                label: Text(
-                  enabled ? 'AI要約を更新' : 'AI要約は機能フラグで無効です',
-                ),
+                label: Text(enabled ? 'AI要約を更新' : 'AI要約は機能フラグで無効です'),
               ),
               if (report.developerRequests.isNotEmpty)
                 OutlinedButton.icon(
@@ -10486,13 +10802,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           h1: heading.copyWith(fontSize: 14),
           h2: heading,
           h3: heading.copyWith(fontSize: 12.5),
-          listBullet: base.copyWith(
-            color: color,
-            fontWeight: FontWeight.w700,
-          ),
-          blockquote: base.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
+          listBullet: base.copyWith(color: color, fontWeight: FontWeight.w700),
+          blockquote: base.copyWith(color: theme.colorScheme.onSurfaceVariant),
           blockquoteDecoration: BoxDecoration(
             border: Border(
               left: BorderSide(color: color.withValues(alpha: 0.45), width: 3),
@@ -10535,9 +10846,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (!mounted) {
       return;
     }
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('AI分析結果をコピーしました')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('AI分析結果をコピーしました')));
   }
 
   Future<void> _generateAssetManagementAiSummary(
@@ -10722,7 +11033,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         return false;
       }
       final result = _developerRequestIssueResults[issueKey];
-      final githubIssue = _assetManagementDynamicMap(result?['githubIssue']);
+      final githubIssue = _assetManagementDynamicMap(
+        result?['githubIssue'],
+      );
       return (githubIssue['html_url']?.toString() ?? '').isEmpty;
     }).toList(growable: false);
   }
@@ -10739,9 +11052,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
     final targets = _issueableDeveloperRequests(requests);
     if (targets.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('登録できる新規改善提案はありません')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('登録できる新規改善提案はありません')));
       return;
     }
 
@@ -10902,21 +11215,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       ..writeln('重要度: $severityLabel')
       ..writeln('画面: /asset-management');
     _appendDeveloperIssueSection(buffer, '根拠データ', request.evidence);
-    _appendDeveloperIssueSection(
-      buffer,
-      '変更候補ファイル',
-      request.sourceReferences,
-    );
-    _appendDeveloperIssueSection(
-      buffer,
-      '実装手順',
-      request.implementationSteps,
-    );
-    _appendDeveloperIssueSection(
-      buffer,
-      '受け入れ条件',
-      request.acceptanceCriteria,
-    );
+    _appendDeveloperIssueSection(buffer, '変更候補ファイル', request.sourceReferences);
+    _appendDeveloperIssueSection(buffer, '実装手順', request.implementationSteps);
+    _appendDeveloperIssueSection(buffer, '受け入れ条件', request.acceptanceCriteria);
     return buffer.toString().trim();
   }
 
@@ -12285,9 +12586,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 selected:
                     _debtMasterReviewFilter == _DebtMasterReviewFilter.all,
                 label: const Text('負債マスタ全件'),
-                onSelected: (_) => _setDebtMasterReviewFilter(
-                  _DebtMasterReviewFilter.all,
-                ),
+                onSelected: (_) =>
+                    _setDebtMasterReviewFilter(_DebtMasterReviewFilter.all),
               ),
               FilterChip(
                 selected: _debtMasterReviewFilter ==
@@ -12307,9 +12607,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
               if (billingRows.isNotEmpty)
                 OutlinedButton.icon(
-                  onPressed: () => _confirmAllEstimatedPaymentAmounts(
-                    billingRows,
-                  ),
+                  onPressed: () =>
+                      _confirmAllEstimatedPaymentAmounts(billingRows),
                   icon: const Icon(Icons.done_all, size: 18),
                   label: const Text('推定額を一括確定'),
                 ),
@@ -12393,8 +12692,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         )
         .toList(growable: false);
     rows.sort((a, b) {
-      final urgency = _consultationUrgencyRank(a, workbook.baseDate)
-          .compareTo(_consultationUrgencyRank(b, workbook.baseDate));
+      final urgency = _consultationUrgencyRank(
+        a,
+        workbook.baseDate,
+      ).compareTo(_consultationUrgencyRank(b, workbook.baseDate));
       if (urgency != 0) {
         return urgency;
       }
@@ -12402,8 +12703,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (rate != 0) {
         return rate;
       }
-      final amount =
-          b.scheduledPaymentAmount.compareTo(a.scheduledPaymentAmount);
+      final amount = b.scheduledPaymentAmount.compareTo(
+        a.scheduledPaymentAmount,
+      );
       if (amount != 0) {
         return amount;
       }
@@ -12412,10 +12714,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return rows;
   }
 
-  int _consultationUrgencyRank(
-    AssetLiabilityDebtRow row,
-    DateTime baseDate,
-  ) {
+  int _consultationUrgencyRank(AssetLiabilityDebtRow row, DateTime baseDate) {
     final dueDate = _debtRowPaymentDate(row, baseDate);
     if (dueDate == null) {
       return 4;
@@ -12434,10 +12733,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return 3;
   }
 
-  DateTime? _debtRowPaymentDate(
-    AssetLiabilityDebtRow row,
-    DateTime baseDate,
-  ) {
+  DateTime? _debtRowPaymentDate(AssetLiabilityDebtRow row, DateTime baseDate) {
     final paymentDay = row.paymentDay;
     if (paymentDay == null) {
       return null;
@@ -12472,9 +12768,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
           const SizedBox(width: 8),
           TextButton.icon(
-            onPressed: () => unawaited(
-              _copyPaymentConsultationText(row, workbook),
-            ),
+            onPressed: () =>
+                unawaited(_copyPaymentConsultationText(row, workbook)),
             icon: const Icon(Icons.content_copy, size: 16),
             label: const Text('相談文をコピー'),
           ),
@@ -12493,9 +12788,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (!mounted) {
       return;
     }
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('${row.name}への相談文をコピーしました。')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('${row.name}への相談文をコピーしました。')));
   }
 
   String _paymentConsultationText(
@@ -14718,10 +15013,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         List<AssetLiabilityDebtRow>.from(
           workbook.billingConfirmationPendingRows,
         ),
-      _DebtMasterReviewFilter.paymentSource =>
-        List<AssetLiabilityDebtRow>.from(workbook.paymentSourceMissingRows),
-      _DebtMasterReviewFilter.all =>
-        List<AssetLiabilityDebtRow>.from(workbook.debtMasterRows),
+      _DebtMasterReviewFilter.paymentSource => List<AssetLiabilityDebtRow>.from(
+          workbook.paymentSourceMissingRows,
+        ),
+      _DebtMasterReviewFilter.all => List<AssetLiabilityDebtRow>.from(
+          workbook.debtMasterRows,
+        ),
     };
   }
 
@@ -14956,6 +15253,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final hasOverride = _annualRateOverrides.containsKey(row.id);
     final evidence = _annualRateEvidences[row.id];
     final verified = evidence?.matchesAnnualRate(row.annualRate) ?? false;
+    final risk = _annualRateRiskForRow(row);
     return SizedBox(
       width: 220,
       child: Column(
@@ -14968,7 +15266,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             inputFormatters: [
               FilteringTextInputFormatter.allow(RegExp(r'[0-9.,%]')),
             ],
-            onChanged: (value) => _updateAnnualRateOverride(row.id, value),
+            onChanged: (value) => _updateAnnualRateOverride(row, value),
             decoration: InputDecoration(
               isDense: true,
               hintText: _formatRateInput(row.annualRate),
@@ -14985,8 +15283,34 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           ),
           const SizedBox(height: 4),
+          if (risk != null) ...[
+            _buildAnnualRateRiskWarning(risk),
+            const SizedBox(height: 4),
+          ],
           _buildAnnualRateEvidenceCell(row),
         ],
+      ),
+    );
+  }
+
+  Widget _buildAnnualRateRiskWarning(DebtAnnualRateRisk risk) {
+    final color = _debtSafetySeverityColor(risk.severity);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.24)),
+      ),
+      child: Text(
+        risk.blocksRegistration ? risk.title : risk.detail,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          height: 1.4,
+        ),
       ),
     );
   }
@@ -14998,6 +15322,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final requestedRate =
         _parseAnnualRateInput(_annualRateControllerFor(row).text) ??
             row.annualRate;
+    final risk = _annualRateRiskFor(
+      accountName: row.name,
+      annualRate: requestedRate,
+      principal: row.balance.abs(),
+    );
+    final blocked = risk?.blocksRegistration == true;
     final verified = evidence?.matchesAnnualRate(requestedRate) ?? false;
     final color = verified
         ? const Color(0xFF0D9488)
@@ -15015,7 +15345,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
         OutlinedButton.icon(
-          onPressed: isVerifying ? null : () => _submitAnnualRateEvidence(row),
+          onPressed: isVerifying || blocked
+              ? null
+              : () => _submitAnnualRateEvidence(row),
           icon: isVerifying
               ? const SizedBox(
                   width: 14,
@@ -15031,8 +15363,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
         ),
         OutlinedButton.icon(
-          onPressed:
-              isVerifying ? null : () => _startAnnualRateEvidencePaste(row),
+          onPressed: isVerifying || blocked
+              ? null
+              : () => _startAnnualRateEvidencePaste(row),
           icon: const Icon(Icons.content_paste, size: 14),
           label: const Text('貼付'),
           style: OutlinedButton.styleFrom(
@@ -15048,6 +15381,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _buildTextStatusChip(
             label: 'Ctrl+V待ち',
             color: const Color(0xFF2563EB),
+          ),
+        if (blocked)
+          _buildTextStatusChip(
+            label: '20%超は登録不可',
+            color: const Color(0xFFB91C1C),
           ),
         if (evidence != null)
           Tooltip(

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:intl/intl.dart';
 import 'package:my_web_app/models/asset_liability_sync_audit_log.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AssetLiabilityMonthlyState {
@@ -189,25 +190,26 @@ class AssetLiabilityMonthlyStateStore {
     final allAnnualRates = decodePaymentOverrides(
       prefs.getString(annualRatePrefsKey),
     );
-    if (state.annualRateOverrides.isEmpty) {
+    final sanitizedAnnualRateOverrides = sanitizeAnnualRateOverrides(
+      state.annualRateOverrides,
+    );
+    if (sanitizedAnnualRateOverrides.isEmpty) {
       allAnnualRates.remove(monthKey);
     } else {
-      allAnnualRates[monthKey] = Map<String, double>.from(
-        state.annualRateOverrides,
-      );
+      allAnnualRates[monthKey] = sanitizedAnnualRateOverrides;
     }
     await prefs.setString(annualRatePrefsKey, jsonEncode(allAnnualRates));
 
     final allAnnualRateEvidences = decodeAnnualRateEvidences(
       prefs.getString(annualRateEvidencePrefsKey),
     );
-    if (state.annualRateEvidences.isEmpty) {
+    final sanitizedAnnualRateEvidences = sanitizeAnnualRateEvidences(
+      state.annualRateEvidences,
+    );
+    if (sanitizedAnnualRateEvidences.isEmpty) {
       allAnnualRateEvidences.remove(monthKey);
     } else {
-      allAnnualRateEvidences[monthKey] =
-          Map<String, AssetLiabilityAnnualRateEvidence>.from(
-        state.annualRateEvidences,
-      );
+      allAnnualRateEvidences[monthKey] = sanitizedAnnualRateEvidences;
     }
     await prefs.setString(
       annualRateEvidencePrefsKey,
@@ -399,10 +401,7 @@ class AssetLiabilityMonthlyStateStore {
     return DateFormat('yyyy-MM').format(month);
   }
 
-  static DateTime salaryCycleMonthFor(
-    DateTime date, {
-    int salaryDay = 25,
-  }) {
+  static DateTime salaryCycleMonthFor(DateTime date, {int salaryDay = 25}) {
     final normalizedSalaryDay = salaryDay.clamp(1, 28).toInt();
     if (date.day >= normalizedSalaryDay) {
       return DateTime(date.year, date.month);
@@ -410,13 +409,8 @@ class AssetLiabilityMonthlyStateStore {
     return DateTime(date.year, date.month - 1);
   }
 
-  static String formatSalaryCycleMonthKey(
-    DateTime date, {
-    int salaryDay = 25,
-  }) {
-    return formatMonthKey(
-      salaryCycleMonthFor(date, salaryDay: salaryDay),
-    );
+  static String formatSalaryCycleMonthKey(DateTime date, {int salaryDay = 25}) {
+    return formatMonthKey(salaryCycleMonthFor(date, salaryDay: salaryDay));
   }
 
   static AssetLiabilityMonthlyState copyPreviousMonthState({
@@ -1082,20 +1076,48 @@ class AssetLiabilityMonthlyStateStore {
     String? raw,
     String monthKey,
   ) {
-    return Map<String, double>.from(
-      decodePaymentOverrides(raw)[monthKey] ?? const <String, double>{},
+    return sanitizeAnnualRateOverrides(
+      Map<String, double>.from(
+        decodePaymentOverrides(raw)[monthKey] ?? const <String, double>{},
+      ),
     );
   }
 
   static Map<String, AssetLiabilityAnnualRateEvidence>
-      annualRateEvidencesForMonth(
-    String? raw,
-    String monthKey,
-  ) {
-    return Map<String, AssetLiabilityAnnualRateEvidence>.from(
-      decodeAnnualRateEvidences(raw)[monthKey] ??
-          const <String, AssetLiabilityAnnualRateEvidence>{},
+      annualRateEvidencesForMonth(String? raw, String monthKey) {
+    return sanitizeAnnualRateEvidences(
+      Map<String, AssetLiabilityAnnualRateEvidence>.from(
+        decodeAnnualRateEvidences(raw)[monthKey] ??
+            const <String, AssetLiabilityAnnualRateEvidence>{},
+      ),
     );
+  }
+
+  static Map<String, double> sanitizeAnnualRateOverrides(
+    Map<String, double> values,
+  ) {
+    return <String, double>{
+      for (final entry in values.entries)
+        if (DebtLockdownService.isRegistrableAnnualRate(entry.value))
+          entry.key: entry.value,
+    };
+  }
+
+  static Map<String, AssetLiabilityAnnualRateEvidence>
+      sanitizeAnnualRateEvidences(
+    Map<String, AssetLiabilityAnnualRateEvidence> values,
+  ) {
+    return <String, AssetLiabilityAnnualRateEvidence>{
+      for (final entry in values.entries)
+        if (DebtLockdownService.isRegistrableAnnualRate(
+              entry.value.submittedAnnualRate,
+            ) &&
+            (entry.value.detectedAnnualRate == null ||
+                DebtLockdownService.isRegistrableAnnualRate(
+                  entry.value.detectedAnnualRate!,
+                )))
+          entry.key: entry.value,
+    };
   }
 
   static Map<String, String> paymentDifferenceReasonsForMonth(
@@ -1192,6 +1214,9 @@ class AssetLiabilityMonthlyStateStore {
 
     final migratedAnnualRates = <String, double>{};
     for (final entry in state.annualRateOverrides.entries) {
+      if (!DebtLockdownService.isRegistrableAnnualRate(entry.value)) {
+        continue;
+      }
       final migratedKey = legacyKeyToAccountId[entry.key] ?? entry.key;
       if (legacyKeyToAccountId.containsKey(entry.key)) {
         migratedAnnualRates.putIfAbsent(migratedKey, () => entry.value);
@@ -1203,9 +1228,19 @@ class AssetLiabilityMonthlyStateStore {
     final migratedAnnualRateEvidences =
         <String, AssetLiabilityAnnualRateEvidence>{};
     for (final entry in state.annualRateEvidences.entries) {
+      if (!DebtLockdownService.isRegistrableAnnualRate(
+            entry.value.submittedAnnualRate,
+          ) ||
+          (entry.value.detectedAnnualRate != null &&
+              !DebtLockdownService.isRegistrableAnnualRate(
+                entry.value.detectedAnnualRate!,
+              ))) {
+        continue;
+      }
       final migratedKey = legacyKeyToAccountId[entry.key] ?? entry.key;
-      migratedAnnualRateEvidences[migratedKey] =
-          entry.value.copyWith(accountId: migratedKey);
+      migratedAnnualRateEvidences[migratedKey] = entry.value.copyWith(
+        accountId: migratedKey,
+      );
     }
 
     final migratedPaidAccounts = <String>{};

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
 
+import 'package:my_web_app/services/debt_lockdown_service.dart';
+
 import '../models/asset_liability_workbook.dart';
 
 class AssetLiabilityPlanningService {
@@ -611,15 +613,16 @@ class AssetLiabilityPlanningService {
     required Map<String, double> annualRateOverrides,
   }) {
     final byId = annualRateOverrides[account.id];
-    if (byId != null && byId >= 0) {
+    if (byId != null && DebtLockdownService.isRegistrableAnnualRate(byId)) {
       return byId;
     }
     final byTrimmedName = annualRateOverrides[account.name.trim()];
-    if (byTrimmedName != null && byTrimmedName >= 0) {
+    if (byTrimmedName != null &&
+        DebtLockdownService.isRegistrableAnnualRate(byTrimmedName)) {
       return byTrimmedName;
     }
     final byName = annualRateOverrides[account.name];
-    if (byName != null && byName >= 0) {
+    if (byName != null && DebtLockdownService.isRegistrableAnnualRate(byName)) {
       return byName;
     }
     return account.annualRate;
@@ -1382,8 +1385,10 @@ class AssetLiabilityPlanningService {
       return transferTasks;
     }
 
-    final fromAccount =
-        _findCashLikeAccountById(accounts, smbcOtsukaBranchAccountId);
+    final fromAccount = _findCashLikeAccountById(
+      accounts,
+      smbcOtsukaBranchAccountId,
+    );
     final toAccount = _findCashLikeAccountById(accounts, jibunBankAccountId);
     if (fromAccount == null || toAccount == null) {
       return transferTasks;
@@ -1644,9 +1649,7 @@ class AssetLiabilityPlanningService {
     required bool includeDefaultKddiProvider,
     required bool includeDefaultRent,
   }) {
-    final result = <String, double>{
-      ...monthlyPaymentOverrides,
-    };
+    final result = <String, double>{...monthlyPaymentOverrides};
     if (includeDefaultKddiProvider &&
         !result.containsKey(kddiProviderAccountId) &&
         !result.containsKey(kddiProviderAccountName)) {
@@ -1667,8 +1670,9 @@ class AssetLiabilityPlanningService {
   }
 
   bool _hasRent(Map<String, double> snapshot) {
-    return snapshot.keys
-        .any((name) => _accountIdForName(name) == rentAccountId);
+    return snapshot.keys.any(
+      (name) => _accountIdForName(name) == rentAccountId,
+    );
   }
 
   String _fallbackAccountId(String name) {

--- a/lib/services/debt_lockdown_service.dart
+++ b/lib/services/debt_lockdown_service.dart
@@ -84,12 +84,137 @@ class DebtLockdownSnapshot {
   bool get allRulesCompletedToday => completedRuleIds.length >= rules.length;
 }
 
-class DebtLockdownService {
-  const DebtLockdownService({
-    this.nowProvider,
+enum DebtSafetySeverity { info, warning, danger }
+
+class DebtSafetyDebtInput {
+  const DebtSafetyDebtInput({
+    required this.accountId,
+    required this.accountName,
+    required this.balance,
+    required this.annualRate,
   });
 
+  final String accountId;
+  final String accountName;
+  final double balance;
+  final double annualRate;
+}
+
+class DebtAnnualRateRisk {
+  const DebtAnnualRateRisk({
+    required this.accountName,
+    required this.annualRate,
+    required this.principal,
+    required this.legalCapAnnualRate,
+    required this.blocksRegistration,
+  });
+
+  final String accountName;
+  final double annualRate;
+  final double principal;
+  final double legalCapAnnualRate;
+  final bool blocksRegistration;
+
+  DebtSafetySeverity get severity => blocksRegistration
+      ? DebtSafetySeverity.danger
+      : DebtSafetySeverity.warning;
+
+  String get title =>
+      blocksRegistration ? '年利20%超のため登録できません' : '元本別の上限金利を超える可能性があります';
+
+  String get detail {
+    final capLabel = DebtLockdownService.formatAnnualRate(legalCapAnnualRate);
+    final rateLabel = DebtLockdownService.formatAnnualRate(annualRate);
+    if (blocksRegistration) {
+      return '$accountName は年利 $rateLabel です。出資法の上限金利20%を超える可能性があるため、この条件は保存せず、登録貸金業者か確認してください。';
+    }
+    return '$accountName は年利 $rateLabel です。元本別の利息制限法上限 $capLabel を超える可能性があるため、契約条件を確認してください。';
+  }
+}
+
+class DebtSafetyGuidance {
+  const DebtSafetyGuidance({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.actionLabel,
+    required this.url,
+    required this.severity,
+  });
+
+  final String id;
+  final String title;
+  final String body;
+  final String actionLabel;
+  final String url;
+  final DebtSafetySeverity severity;
+}
+
+class DebtEducationNotice {
+  const DebtEducationNotice({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.actionLabel,
+    required this.url,
+    required this.severity,
+  });
+
+  final String id;
+  final String title;
+  final String body;
+  final String actionLabel;
+  final String url;
+  final DebtSafetySeverity severity;
+}
+
+class DebtSafetySnapshot {
+  const DebtSafetySnapshot({
+    required this.totalDebt,
+    required this.debtCount,
+    required this.annualRateRisks,
+    required this.guidanceCards,
+    required this.educationNotices,
+  });
+
+  final double totalDebt;
+  final int debtCount;
+  final List<DebtAnnualRateRisk> annualRateRisks;
+  final List<DebtSafetyGuidance> guidanceCards;
+  final List<DebtEducationNotice> educationNotices;
+
+  bool get hasBlockingAnnualRates =>
+      annualRateRisks.any((risk) => risk.blocksRegistration);
+
+  bool get shouldShowSelfExclusionGuidance =>
+      guidanceCards.any((guidance) => guidance.id == 'lending_self_exclusion');
+
+  bool get hasSignals =>
+      annualRateRisks.isNotEmpty ||
+      guidanceCards.isNotEmpty ||
+      educationNotices.isNotEmpty;
+}
+
+class DebtLockdownService {
+  const DebtLockdownService({this.nowProvider});
+
   static const String otherCategory = 'その他';
+  static const double statutoryBlockAnnualRate = 0.20;
+  static const double selfExclusionDebtTotalThreshold = 1000000;
+  static const int selfExclusionDebtCountThreshold = 5;
+
+  static const String selfExclusionGuidanceUrl =
+      'https://www.j-fsa.or.jp/personal/useful/question/selfcontrol.php';
+  static const String lendingConsultationUrl =
+      'https://www.j-fsa.or.jp/personal/borrowing/';
+  static const String registeredLenderSearchUrl =
+      'https://www.fsa.go.jp/ordinary/kensaku/index.html';
+  static const String illegalLenderWarningUrl =
+      'https://www.fsa.go.jp/ordinary/chuui/index.html';
+  static const String badContractorWarningUrl =
+      'https://www.j-fsa.or.jp/personal/bad_contractor/';
+  static const String youngFraudWarningUrl =
+      'https://www.j-fsa.or.jp/topics/association/for_young.php';
 
   static const List<DebtLockdownRule> builtinRules = <DebtLockdownRule>[
     DebtLockdownRule(
@@ -131,6 +256,156 @@ class DebtLockdownService {
         ...WasteTrackingService.categoryLabels,
         otherCategory,
       ];
+
+  static bool isRegistrableAnnualRate(double annualRate) =>
+      annualRate >= 0 && annualRate <= statutoryBlockAnnualRate;
+
+  static double legalAnnualRateCapForPrincipal(double principal) {
+    final amount = principal.abs();
+    if (amount >= 1000000) {
+      return 0.15;
+    }
+    if (amount >= 100000) {
+      return 0.18;
+    }
+    return statutoryBlockAnnualRate;
+  }
+
+  static String formatAnnualRate(double annualRate) {
+    final percent = annualRate * 100;
+    if (percent == percent.roundToDouble()) {
+      return '${percent.round()}%';
+    }
+    return '${percent.toStringAsFixed(2).replaceFirst(RegExp(r'\.?0+$'), '')}%';
+  }
+
+  static DebtAnnualRateRisk? evaluateAnnualRate({
+    required String accountName,
+    required double annualRate,
+    double? principal,
+  }) {
+    if (annualRate <= 0) {
+      return null;
+    }
+
+    final principalAmount = (principal ?? 0).abs();
+    final legalCap = legalAnnualRateCapForPrincipal(principalAmount);
+    final blocksRegistration = annualRate > statutoryBlockAnnualRate;
+    final exceedsPrincipalCap = annualRate > legalCap;
+    if (!blocksRegistration && !exceedsPrincipalCap) {
+      return null;
+    }
+
+    return DebtAnnualRateRisk(
+      accountName: accountName,
+      annualRate: annualRate,
+      principal: principalAmount,
+      legalCapAnnualRate: legalCap,
+      blocksRegistration: blocksRegistration,
+    );
+  }
+
+  static DebtSafetySnapshot buildSafetySnapshot({
+    required Iterable<DebtSafetyDebtInput> debts,
+  }) {
+    final activeDebts =
+        debts.where((debt) => debt.balance.abs() > 0).toList(growable: false);
+    final totalDebt = activeDebts.fold<double>(
+      0,
+      (sum, debt) => sum + debt.balance.abs(),
+    );
+    final annualRateRisks = activeDebts
+        .map(
+          (debt) => evaluateAnnualRate(
+            accountName: debt.accountName,
+            annualRate: debt.annualRate,
+            principal: debt.balance.abs(),
+          ),
+        )
+        .whereType<DebtAnnualRateRisk>()
+        .toList(growable: false);
+
+    final shouldShowSelfExclusion =
+        activeDebts.length >= selfExclusionDebtCountThreshold ||
+            totalDebt >= selfExclusionDebtTotalThreshold ||
+            annualRateRisks.any((risk) => risk.blocksRegistration);
+    final guidanceCards = <DebtSafetyGuidance>[
+      if (shouldShowSelfExclusion)
+        const DebtSafetyGuidance(
+          id: 'lending_self_exclusion',
+          title: '貸付自粛制度を確認',
+          body: '新たな借入れを自分の意思だけで止めにくい状態です。日本貸金業協会の貸付自粛制度と生活再建相談を確認してください。',
+          actionLabel: '制度を見る',
+          url: selfExclusionGuidanceUrl,
+          severity: DebtSafetySeverity.warning,
+        ),
+      if (shouldShowSelfExclusion)
+        const DebtSafetyGuidance(
+          id: 'lending_consultation',
+          title: '貸金業相談・紛争解決センター',
+          body: '返済や借入れで困っている場合は、早めに公的な相談窓口へつなげます。',
+          actionLabel: '相談窓口',
+          url: lendingConsultationUrl,
+          severity: DebtSafetySeverity.info,
+        ),
+      if (annualRateRisks.any((risk) => risk.blocksRegistration))
+        const DebtSafetyGuidance(
+          id: 'illegal_lender_warning',
+          title: '違法業者・高金利の疑い',
+          body: '年利20%を超える条件や登録確認できない業者からは借入れしないでください。',
+          actionLabel: '金融庁の注意',
+          url: illegalLenderWarningUrl,
+          severity: DebtSafetySeverity.danger,
+        ),
+      if (shouldShowSelfExclusion || annualRateRisks.isNotEmpty)
+        const DebtSafetyGuidance(
+          id: 'registered_lender_search',
+          title: '登録貸金業者を確認',
+          body: '新しい借入れや借換えを検討する前に、金融庁の登録貸金業者情報検索サービスで確認してください。',
+          actionLabel: '登録検索',
+          url: registeredLenderSearchUrl,
+          severity: DebtSafetySeverity.info,
+        ),
+    ];
+
+    final educationNotices =
+        shouldShowSelfExclusion || annualRateRisks.isNotEmpty
+            ? const <DebtEducationNotice>[
+                DebtEducationNotice(
+                  id: 'name_lending',
+                  title: '名義貸しに注意',
+                  body: '自分名義で借りて他人に渡す話は、返済義務だけが残る典型的なトラブルです。頼まれても登録しないでください。',
+                  actionLabel: '事例を見る',
+                  url: youngFraudWarningUrl,
+                  severity: DebtSafetySeverity.warning,
+                ),
+                DebtEducationNotice(
+                  id: 'credit_card_cashing',
+                  title: 'クレジットカード現金化に注意',
+                  body: 'ショッピング枠の現金化や後払い現金化は、手数料負担と規約違反のリスクが高い取引です。',
+                  actionLabel: '注意喚起',
+                  url: badContractorWarningUrl,
+                  severity: DebtSafetySeverity.warning,
+                ),
+                DebtEducationNotice(
+                  id: 'registered_lender_check',
+                  title: '借入先の登録確認',
+                  body: '業者名、電話番号、登録番号が確認できない場合は、連絡や申込みを止めて登録検索で確認してください。',
+                  actionLabel: '検索する',
+                  url: registeredLenderSearchUrl,
+                  severity: DebtSafetySeverity.info,
+                ),
+              ]
+            : const <DebtEducationNotice>[];
+
+    return DebtSafetySnapshot(
+      totalDebt: totalDebt,
+      debtCount: activeDebts.length,
+      annualRateRisks: annualRateRisks,
+      guidanceCards: guidanceCards,
+      educationNotices: educationNotices,
+    );
+  }
 
   Future<DebtLockdownSnapshot> loadSnapshot({
     required double remainingDebt,

--- a/supabase/migrations/20260606103000_create_debt_safety_guidance_master.sql
+++ b/supabase/migrations/20260606103000_create_debt_safety_guidance_master.sql
@@ -1,0 +1,186 @@
+-- Master guidance for debt safety guardrails. The Flutter client keeps a
+-- built-in fallback, while this table gives operations a single Supabase
+-- source for legal-rate warnings, lending self-exclusion links, and education
+-- notices.
+
+create table if not exists public.debt_safety_guidance_master (
+  guidance_key text primary key,
+  category text not null,
+  severity text not null,
+  title text not null,
+  body text not null,
+  action_label text not null,
+  url text not null,
+  source_url text not null,
+  active boolean not null default true,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint debt_safety_guidance_master_category_valid
+    check (
+      category in (
+        'legal_rate',
+        'self_exclusion',
+        'registered_lender',
+        'education'
+      )
+    ),
+  constraint debt_safety_guidance_master_severity_valid
+    check (severity in ('info', 'warning', 'danger')),
+  constraint debt_safety_guidance_master_title_not_blank
+    check (length(btrim(title)) > 0),
+  constraint debt_safety_guidance_master_body_not_blank
+    check (length(btrim(body)) > 0),
+  constraint debt_safety_guidance_master_action_not_blank
+    check (length(btrim(action_label)) > 0),
+  constraint debt_safety_guidance_master_https_url
+    check (url ~ '^https://'),
+  constraint debt_safety_guidance_master_https_source_url
+    check (source_url ~ '^https://')
+);
+
+create index if not exists debt_safety_guidance_master_category_idx
+  on public.debt_safety_guidance_master (
+    category,
+    active,
+    sort_order,
+    guidance_key
+  );
+
+alter table public.debt_safety_guidance_master enable row level security;
+
+drop policy if exists debt_safety_guidance_master_select_active
+  on public.debt_safety_guidance_master;
+create policy debt_safety_guidance_master_select_active
+on public.debt_safety_guidance_master
+for select
+to anon, authenticated
+using (active);
+
+create or replace function public.set_debt_safety_guidance_master_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists debt_safety_guidance_master_updated_at
+  on public.debt_safety_guidance_master;
+create trigger debt_safety_guidance_master_updated_at
+before update on public.debt_safety_guidance_master
+for each row execute function
+  public.set_debt_safety_guidance_master_updated_at();
+
+insert into public.debt_safety_guidance_master (
+  guidance_key,
+  category,
+  severity,
+  title,
+  body,
+  action_label,
+  url,
+  source_url,
+  active,
+  sort_order
+) values
+  (
+    'legal_rate_over_20_block',
+    'legal_rate',
+    'danger',
+    '年利20%超の登録ブロック',
+    '年利20%を超える条件は出資法違反となる可能性があるため、借入先と契約条件を確認してください。',
+    '金融庁の注意を見る',
+    'https://www.fsa.go.jp/ordinary/chuui/index.html',
+    'https://www.fsa.go.jp/ordinary/chuui/index.html',
+    true,
+    10
+  ),
+  (
+    'principal_based_interest_limit_warning',
+    'legal_rate',
+    'warning',
+    '元本別上限金利の確認',
+    '利息制限法の上限金利は元本に応じて15%から20%です。20%以下でも元本別の上限を超える場合は契約条件を確認してください。',
+    '上限金利を確認',
+    'https://www.j-fsa.or.jp/association/money_lending/law/maximum_interest_rate.php',
+    'https://www.j-fsa.or.jp/association/money_lending/law/maximum_interest_rate.php',
+    true,
+    20
+  ),
+  (
+    'lending_self_exclusion',
+    'self_exclusion',
+    'warning',
+    '貸付自粛制度',
+    '新たな借入れを自分の意思だけで止めにくい場合は、日本貸金業協会の貸付自粛制度を確認してください。',
+    '制度を見る',
+    'https://www.j-fsa.or.jp/personal/useful/question/selfcontrol.php',
+    'https://www.j-fsa.or.jp/personal/useful/question/selfcontrol.php',
+    true,
+    30
+  ),
+  (
+    'lending_consultation_center',
+    'self_exclusion',
+    'info',
+    '貸金業相談・紛争解決センター',
+    '返済や借入れの相談は、日本貸金業協会の相談窓口につなげます。',
+    '相談窓口',
+    'https://www.j-fsa.or.jp/personal/borrowing/',
+    'https://www.j-fsa.or.jp/personal/borrowing/',
+    true,
+    40
+  ),
+  (
+    'registered_lender_search',
+    'registered_lender',
+    'info',
+    '登録貸金業者情報検索サービス',
+    '借入れや借換えの前に、金融庁の登録貸金業者情報検索サービスで業者の登録を確認してください。',
+    '登録検索',
+    'https://www.fsa.go.jp/ordinary/kensaku/index.html',
+    'https://www.fsa.go.jp/ordinary/kensaku/index.html',
+    true,
+    50
+  ),
+  (
+    'name_lending_notice',
+    'education',
+    'warning',
+    '名義貸しに注意',
+    '自分名義で借りて他人に渡す話は、返済義務とトラブルだけが残る危険があります。',
+    '事例を見る',
+    'https://www.j-fsa.or.jp/topics/association/for_young.php',
+    'https://www.j-fsa.or.jp/topics/association/for_young.php',
+    true,
+    60
+  ),
+  (
+    'credit_card_cashing_notice',
+    'education',
+    'warning',
+    'クレジットカード現金化に注意',
+    'ショッピング枠の現金化や後払い現金化は、手数料負担と規約違反のリスクが高い取引です。',
+    '注意喚起',
+    'https://www.j-fsa.or.jp/personal/bad_contractor/',
+    'https://www.j-fsa.or.jp/personal/bad_contractor/',
+    true,
+    70
+  )
+on conflict (guidance_key) do update set
+  category = excluded.category,
+  severity = excluded.severity,
+  title = excluded.title,
+  body = excluded.body,
+  action_label = excluded.action_label,
+  url = excluded.url,
+  source_url = excluded.source_url,
+  active = excluded.active,
+  sort_order = excluded.sort_order,
+  updated_at = now();
+
+comment on table public.debt_safety_guidance_master is
+  'Master data for legal-rate guardrails, lending self-exclusion guidance, registered lender checks, and debt-trouble education notices.';

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -212,6 +212,58 @@ void main() {
     });
 
     test(
+      'drops annual rates above the 20 percent registration block',
+      () async {
+        await store.saveMonth(
+          month: DateTime(2026, 5, 13),
+          state: AssetLiabilityMonthlyState(
+            annualRateOverrides: const <String, double>{
+              'legal': 0.20,
+              'blocked': 0.205,
+            },
+            annualRateEvidences: <String, AssetLiabilityAnnualRateEvidence>{
+              'legal': AssetLiabilityAnnualRateEvidence(
+                accountId: 'legal',
+                fileName: 'legal.png',
+                mimeType: 'image/png',
+                submittedAt: DateTime(2026, 5, 13),
+                submittedAnnualRate: 0.20,
+                detectedAnnualRate: 0.20,
+                status: AssetLiabilityAnnualRateEvidenceStatus.verified,
+                summary: '20%',
+                source: 'test',
+              ),
+              'blocked': AssetLiabilityAnnualRateEvidence(
+                accountId: 'blocked',
+                fileName: 'blocked.png',
+                mimeType: 'image/png',
+                submittedAt: DateTime(2026, 5, 13),
+                submittedAnnualRate: 0.205,
+                detectedAnnualRate: 0.205,
+                status: AssetLiabilityAnnualRateEvidenceStatus.verified,
+                summary: '20.5%',
+                source: 'test',
+              ),
+            },
+          ),
+        );
+
+        final loaded = await store.loadMonth(DateTime(2026, 5, 13));
+        expect(loaded.annualRateOverrides, <String, double>{'legal': 0.20});
+        expect(loaded.annualRateEvidences.keys, contains('legal'));
+        expect(loaded.annualRateEvidences.keys, isNot(contains('blocked')));
+
+        const raw = '{"2026-05":{"legal":0.2,"blocked":0.205}}';
+        final decoded =
+            AssetLiabilityMonthlyStateStore.annualRateOverridesForMonth(
+          raw,
+          '2026-05',
+        );
+        expect(decoded, <String, double>{'legal': 0.2});
+      },
+    );
+
+    test(
       'falls back to estimated payment after manual amount is cleared',
       () async {
         await store.saveMonth(

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -133,6 +133,20 @@ void main() {
       expect(mobit.priorityLabel, isNotEmpty);
     });
 
+    test('ignores annual rate overrides above the 20 percent block line', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+        annualRateOverrides: const <String, double>{'mobit': 0.205},
+      );
+
+      final mobit = workbook.debtMasterRows.firstWhere(
+        (row) => row.name == 'モビット',
+      );
+
+      expect(mobit.annualRate, 0.18);
+    });
+
     test('uses the estimated minimum payment when manual input is absent', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: snapshot,
@@ -160,10 +174,7 @@ void main() {
 
     test('exposes debt control review targets and payment split totals', () {
       final workbook = service.buildWorkbook(
-        latestSnapshot: const <String, double>{
-          'bank': 50000,
-          'PayPay': -20000,
-        },
+        latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
         baseDate: DateTime(2026, 5, 1),
       );
 
@@ -186,14 +197,9 @@ void main() {
       );
 
       final reviewed = service.buildWorkbook(
-        latestSnapshot: const <String, double>{
-          'bank': 50000,
-          'PayPay': -20000,
-        },
+        latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
         baseDate: DateTime(2026, 5, 1),
-        monthlyPaymentOverrides: const <String, double>{
-          'paypay_card': 20000,
-        },
+        monthlyPaymentOverrides: const <String, double>{'paypay_card': 20000},
         paymentSourceAccountIds: const <String, String>{
           'paypay_card': 'custom_bank',
         },
@@ -859,10 +865,10 @@ void main() {
         anthropicPayment.destinationAccountId,
         AssetLiabilityPlanningService.acomShoppingAccountId,
       );
-      expect(
-        workbook.cashflowRows.map((row) => row.paymentDay).toList(),
-        <int>[8, 26],
-      );
+      expect(workbook.cashflowRows.map((row) => row.paymentDay).toList(), <int>[
+        8,
+        26,
+      ]);
       expect(workbook.monthlyScheduledPaymentTotal, 108000);
       expect(workbook.monthlyUnpaidPaymentTotal, 108000);
       expect(workbook.cashAfterScheduledPayments, -8000);

--- a/test/services/debt_lockdown_service_test.dart
+++ b/test/services/debt_lockdown_service_test.dart
@@ -37,38 +37,129 @@ void main() {
       expect(snapshot.recentViolations.first.amount, 280);
     });
 
-    test('marks snapshot as released when remaining debt reaches zero',
-        () async {
-      final service = DebtLockdownService(
-        nowProvider: () => DateTime(2026, 3, 23, 9, 0),
+    test(
+      'marks snapshot as released when remaining debt reaches zero',
+      () async {
+        final service = DebtLockdownService(
+          nowProvider: () => DateTime(2026, 3, 23, 9, 0),
+        );
+
+        await service.setEnabled(true, remainingDebt: 80000);
+        final snapshot = await service.loadSnapshot(remainingDebt: 0);
+
+        expect(snapshot.isReleased, isTrue);
+        expect(snapshot.isEnabled, isFalse);
+      },
+    );
+
+    test(
+      'counts compliant streak across consecutive fully completed days',
+      () async {
+        var now = DateTime(2026, 3, 23, 7, 0);
+        final service = DebtLockdownService(nowProvider: () => now);
+
+        await service.setEnabled(true, remainingDebt: 100000);
+        for (final rule in DebtLockdownService.builtinRules) {
+          await service.toggleRule(rule.id, true, remainingDebt: 100000);
+        }
+
+        now = now.add(const Duration(days: 1));
+        for (final rule in DebtLockdownService.builtinRules) {
+          await service.toggleRule(rule.id, true, remainingDebt: 100000);
+        }
+
+        final snapshot = await service.loadSnapshot(remainingDebt: 100000);
+
+        expect(snapshot.currentCompliantStreakDays, 2);
+        expect(snapshot.todayViolations, isEmpty);
+      },
+    );
+
+    test('blocks annual rates above the statutory 20 percent line', () {
+      final risk = DebtLockdownService.evaluateAnnualRate(
+        accountName: 'Unregistered lender',
+        annualRate: 0.205,
+        principal: 50000,
       );
 
-      await service.setEnabled(true, remainingDebt: 80000);
-      final snapshot = await service.loadSnapshot(remainingDebt: 0);
-
-      expect(snapshot.isReleased, isTrue);
-      expect(snapshot.isEnabled, isFalse);
+      expect(risk, isNotNull);
+      expect(risk!.blocksRegistration, isTrue);
+      expect(risk.legalCapAnnualRate, 0.20);
+      expect(risk.severity, DebtSafetySeverity.danger);
     });
 
-    test('counts compliant streak across consecutive fully completed days',
-        () async {
-      var now = DateTime(2026, 3, 23, 7, 0);
-      final service = DebtLockdownService(nowProvider: () => now);
+    test('warns when the principal based cap is exceeded below 20 percent', () {
+      final risk = DebtLockdownService.evaluateAnnualRate(
+        accountName: 'Large card loan',
+        annualRate: 0.17,
+        principal: 1200000,
+      );
 
-      await service.setEnabled(true, remainingDebt: 100000);
-      for (final rule in DebtLockdownService.builtinRules) {
-        await service.toggleRule(rule.id, true, remainingDebt: 100000);
-      }
+      expect(risk, isNotNull);
+      expect(risk!.blocksRegistration, isFalse);
+      expect(risk.legalCapAnnualRate, 0.15);
+      expect(risk.severity, DebtSafetySeverity.warning);
+    });
 
-      now = now.add(const Duration(days: 1));
-      for (final rule in DebtLockdownService.builtinRules) {
-        await service.toggleRule(rule.id, true, remainingDebt: 100000);
-      }
+    test(
+      'shows self-exclusion guidance and education notices at thresholds',
+      () {
+        final snapshot = DebtLockdownService.buildSafetySnapshot(
+          debts: List<DebtSafetyDebtInput>.generate(
+            5,
+            (index) => DebtSafetyDebtInput(
+              accountId: 'debt_$index',
+              accountName: 'Debt $index',
+              balance: 220000,
+              annualRate: 0.18,
+            ),
+          ),
+        );
 
-      final snapshot = await service.loadSnapshot(remainingDebt: 100000);
+        expect(snapshot.totalDebt, 1100000);
+        expect(snapshot.shouldShowSelfExclusionGuidance, isTrue);
+        expect(
+          snapshot.guidanceCards.map((guidance) => guidance.id),
+          containsAll(<String>[
+            'lending_self_exclusion',
+            'lending_consultation',
+            'registered_lender_search',
+          ]),
+        );
+        expect(
+          snapshot.educationNotices.map((notice) => notice.id),
+          containsAll(<String>[
+            'name_lending',
+            'credit_card_cashing',
+            'registered_lender_check',
+          ]),
+        );
+        expect(
+          snapshot.guidanceCards
+              .firstWhere((guidance) => guidance.id == 'lending_self_exclusion')
+              .url,
+          DebtLockdownService.selfExclusionGuidanceUrl,
+        );
+      },
+    );
 
-      expect(snapshot.currentCompliantStreakDays, 2);
-      expect(snapshot.todayViolations, isEmpty);
+    test('keeps quiet when legal-rate debts are below guidance thresholds', () {
+      final snapshot = DebtLockdownService.buildSafetySnapshot(
+        debts: const <DebtSafetyDebtInput>[
+          DebtSafetyDebtInput(
+            accountId: 'small',
+            accountName: 'Small balance',
+            balance: 50000,
+            annualRate: 0.18,
+          ),
+        ],
+      );
+
+      expect(snapshot.hasSignals, isFalse);
+      expect(snapshot.shouldShowSelfExclusionGuidance, isFalse);
+      expect(snapshot.annualRateRisks, isEmpty);
+      expect(snapshot.educationNotices, isEmpty);
+      expect(snapshot.guidanceCards, isEmpty);
     });
   });
 }

--- a/test/services/debt_safety_guidance_schema_test.dart
+++ b/test/services/debt_safety_guidance_schema_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260606103000_create_debt_safety_guidance_master.sql';
+
+void main() {
+  group('debt safety guidance master migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(_migrationPath).readAsStringSync().replaceAll('\r\n', '\n');
+    });
+
+    test('defines a selectable master table for debt safety content', () {
+      final block = _createTableBlock(sql, 'debt_safety_guidance_master');
+
+      expect(block, contains('guidance_key text primary key'));
+      expect(block, contains('category text not null'));
+      expect(block, contains('severity text not null'));
+      expect(block, contains('url text not null'));
+      expect(block, contains('source_url text not null'));
+      expect(block, contains('active boolean not null default true'));
+      expect(block, contains("check (url ~ '^https://')"));
+    });
+
+    test('locks categories and severities to known app values', () {
+      expect(sql, contains("'legal_rate'"));
+      expect(sql, contains("'self_exclusion'"));
+      expect(sql, contains("'registered_lender'"));
+      expect(sql, contains("'education'"));
+      expect(
+        sql,
+        contains("check (severity in ('info', 'warning', 'danger'))"),
+      );
+    });
+
+    test('enables active-row read policy for app clients', () {
+      expect(
+        sql,
+        contains(
+          'alter table public.debt_safety_guidance_master enable row level security;',
+        ),
+      );
+      expect(
+        sql,
+        contains('create policy debt_safety_guidance_master_select_active'),
+      );
+      expect(
+        sql,
+        contains('for select\nto anon, authenticated\nusing (active)'),
+      );
+    });
+
+    test('seeds official guidance and education links', () {
+      expect(sql, contains('legal_rate_over_20_block'));
+      expect(sql, contains('principal_based_interest_limit_warning'));
+      expect(sql, contains('lending_self_exclusion'));
+      expect(sql, contains('registered_lender_search'));
+      expect(sql, contains('name_lending_notice'));
+      expect(sql, contains('credit_card_cashing_notice'));
+      expect(
+        sql,
+        contains(
+          'https://www.j-fsa.or.jp/personal/useful/question/selfcontrol.php',
+        ),
+      );
+      expect(
+        sql,
+        contains('https://www.fsa.go.jp/ordinary/kensaku/index.html'),
+      );
+      expect(sql, contains('https://www.fsa.go.jp/ordinary/chuui/index.html'));
+    });
+  });
+}
+
+String _createTableBlock(String sql, String table) {
+  final start = sql.indexOf('create table if not exists public.$table');
+  expect(start, isNonNegative, reason: 'missing create table for $table');
+
+  final end = sql.indexOf('\n);', start);
+  expect(
+    end,
+    isNonNegative,
+    reason: 'missing create table terminator for $table',
+  );
+
+  return sql.substring(start, end);
+}


### PR DESCRIPTION
## Summary

- Adds debt safety guardrails for annual-rate inputs, including a hard block above 20% and warnings for principal-based interest-limit risk.
- Shows lending self-exclusion, consultation, registered-lender lookup, and education notices inside the asset/debt planning workflow when debt count, balance, or risky rates trigger them.
- Adds a Supabase guidance master table for official links and seeded debt-safety content.

Closes #2751.

## Official Source Check

- Financial Services Agency warning page confirms lending above the 20% annual cap can violate the Investment Deposit and Interest Rate Act: https://www.fsa.go.jp/ordinary/chuui/index.html
- Japan Financial Services Association explains the lending self-exclusion system: https://www.j-fsa.or.jp/personal/useful/question/selfcontrol.php
- Japan Financial Services Association explains principal-based 15%-20% interest limits: https://www.j-fsa.or.jp/association/money_lending/law/maximum_interest_rate.php

## Validation

- `dart format lib\pages\asset_management_page.dart lib\services\asset_liability_monthly_state_store.dart lib\services\asset_liability_planning_service.dart lib\services\debt_lockdown_service.dart test\services\asset_liability_monthly_state_store_test.dart test\services\asset_liability_planning_service_test.dart test\services\debt_lockdown_service_test.dart test\services\debt_safety_guidance_schema_test.dart`
- `flutter test test\services\debt_lockdown_service_test.dart test\services\asset_liability_monthly_state_store_test.dart test\services\asset_liability_planning_service_test.dart test\services\debt_safety_guidance_schema_test.dart`
- `flutter analyze lib\services\debt_lockdown_service.dart lib\services\asset_liability_monthly_state_store.dart lib\services\asset_liability_planning_service.dart test\services\debt_lockdown_service_test.dart test\services\asset_liability_monthly_state_store_test.dart test\services\asset_liability_planning_service_test.dart test\services\debt_safety_guidance_schema_test.dart`
- `flutter analyze lib\pages\asset_management_page.dart`

## Minimal E2E Gate

- black-box coverage: service tests verify annual-rate block/warning, self-exclusion guidance thresholds, quiet below-threshold behavior, and persisted annual-rate sanitization.
- implementation-detail independent: schema tests validate guidance table categories, severities, active-row read policy, and official seed links.
- minimal three cases: 20%+ block, principal-limit warning below 20%, self-exclusion guidance threshold.
- Playwright: not run because this change is covered by Flutter service/page analyzer checks and deterministic state/schema tests; no local seeded browser scenario was available in this cleanup pass.
- E2E-Exception: focused Flutter tests plus schema tests cover the risk logic without relying on browser automation.

## High-risk Ultrareview Evidence

- Review owner: Claude Code #1
- Claude ultrareview evidence: legal-rate guardrails, migration/RLS exposure, and rollback path reviewed for high-risk financial-safety behavior.
- Required perspectives: security, rollback, data migration, prod smoke, observability.
- Security: only active guidance rows are readable; client-side rate storage drops values above the 20% registration block.
- Rollback: revert this migration and UI/service routing to return to prior annual-rate behavior.
- Data migration: additive master-data table; no existing user debt rows are rewritten.
- Prod smoke: enter a 20.5% rate and confirm it is blocked, then enter threshold debt data and confirm guidance panel appears.
- Observability: user-visible warnings and guidance panel expose blocked/risky state directly in the asset workflow.
- unresolved findings: 0 / none.