### PR TITLE
Add asset billing source review workflow

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -82,6 +82,7 @@ class AssetLiabilityMonthlyStatePayload {
   final Map<String, double> annualRateOverrides;
   final Map<String, AssetLiabilityAnnualRateEvidence> annualRateEvidences;
   final Set<String> paidAccountIds;
+  final Set<String> billingConfirmedAccountIds;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
   final List<AssetLiabilityCardStatementLine> cardStatementLines;
@@ -96,6 +97,7 @@ class AssetLiabilityMonthlyStatePayload {
     required this.annualRateOverrides,
     required this.annualRateEvidences,
     required this.paidAccountIds,
+    required this.billingConfirmedAccountIds,
     required this.paymentSourceAccountIds,
     required this.cardBillingAccountIds,
     required this.cardStatementLines,
@@ -121,6 +123,9 @@ class AssetLiabilityMonthlyStatePayload {
         state.annualRateEvidences,
       ),
       paidAccountIds: Set<String>.from(state.paidAccountNames),
+      billingConfirmedAccountIds: Set<String>.from(
+        state.billingConfirmedAccountIds,
+      ),
       paymentSourceAccountIds: Map<String, String>.from(
         state.paymentSourceAccountIds,
       ),
@@ -162,6 +167,10 @@ class AssetLiabilityMonthlyStatePayload {
       paidAccountIds: _readStringSet(json, 'paid_account_ids') ??
           _readStringSet(json, 'paidAccountIds') ??
           const <String>{},
+      billingConfirmedAccountIds:
+          _readStringSet(json, 'billing_confirmed_account_ids') ??
+              _readStringSet(json, 'billingConfirmedAccountIds') ??
+              const <String>{},
       paymentSourceAccountIds:
           _readStringMap(json, 'payment_source_account_ids') ??
               _readStringMap(json, 'paymentSourceAccountIds') ??
@@ -194,6 +203,7 @@ class AssetLiabilityMonthlyStatePayload {
         annualRateEvidences,
       ),
       paidAccountNames: Set<String>.from(paidAccountIds),
+      billingConfirmedAccountIds: Set<String>.from(billingConfirmedAccountIds),
       paymentSourceAccountIds: Map<String, String>.from(
         paymentSourceAccountIds,
       ),
@@ -225,6 +235,8 @@ class AssetLiabilityMonthlyStatePayload {
           entry.key: entry.value.toJson(),
       },
       'paid_account_ids': (paidAccountIds.toList()..sort()),
+      'billing_confirmed_account_ids': (billingConfirmedAccountIds.toList()
+        ..sort()),
       'payment_source_account_ids': Map<String, String>.from(
         paymentSourceAccountIds,
       ),

--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -233,6 +233,7 @@ class AssetLiabilityDebtRow {
   final double liabilityShare;
   final String priorityLabel;
   final bool paymentAmountEstimated;
+  final bool billingConfirmed;
   final bool paid;
 
   const AssetLiabilityDebtRow({
@@ -261,6 +262,7 @@ class AssetLiabilityDebtRow {
     required this.liabilityShare,
     required this.priorityLabel,
     required this.paymentAmountEstimated,
+    required this.billingConfirmed,
     required this.paid,
   });
 
@@ -952,6 +954,7 @@ class AssetLiabilityWorkbook {
           (row) =>
               row.isDirectCashflowTarget &&
               row.paymentAmountEstimated &&
+              !row.billingConfirmed &&
               row.scheduledPaymentAmount > 0 &&
               !row.paid,
         )

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -62,7 +62,25 @@ enum AssetDebtPlannerMode { ask, code }
 
 enum _CardBillingSaveScope { defaultSetting, monthlyOverride }
 
+enum _PaymentSourceSaveScope { monthlyOverride, defaultSetting }
+
 enum _DebtMasterReviewFilter { all, billingConfirmation, paymentSource }
+
+class _PaymentSourceCandidate {
+  final AssetLiabilityAccount account;
+  final double currentBalance;
+  final double projectedBeforePayment;
+  final double projectedAfterPayment;
+  final double safetyBalanceDelta;
+
+  const _PaymentSourceCandidate({
+    required this.account,
+    required this.currentBalance,
+    required this.projectedBeforePayment,
+    required this.projectedAfterPayment,
+    required this.safetyBalanceDelta,
+  });
+}
 
 class AssetManagementPage extends StatefulWidget {
   final AssetManagementInitialFocus initialFocus;
@@ -112,6 +130,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final ScrollController _scrollController = ScrollController();
   final ScrollController _debtMasterHorizontalScrollController =
       ScrollController();
+  static const double _paymentSourceSafetyBalance = 30000;
   final _keyStock = GlobalKey();
   final _keyFlow = GlobalKey();
   final _keySubs = GlobalKey();
@@ -146,6 +165,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, AssetLiabilityAnnualRateEvidence> _annualRateEvidences =
       <String, AssetLiabilityAnnualRateEvidence>{};
   Set<String> _monthlyPaidAccountNames = <String>{};
+  Set<String> _billingConfirmedAccountIds = <String>{};
   Map<String, String> _paymentSourceAccountIds = <String, String>{};
   Map<String, String> _cardBillingAccountIds = <String, String>{};
   List<AssetLiabilityCardStatementLine> _cardStatementLines =
@@ -1046,6 +1066,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           state.annualRateEvidences,
         );
         _monthlyPaidAccountNames = Set<String>.from(state.paidAccountNames);
+        _billingConfirmedAccountIds = Set<String>.from(
+          state.billingConfirmedAccountIds,
+        );
         _paymentSourceAccountIds = Map<String, String>.from(
           state.paymentSourceAccountIds,
         );
@@ -1154,6 +1177,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _annualRateEvidences,
       ),
       paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
+      billingConfirmedAccountIds: Set<String>.from(_billingConfirmedAccountIds),
       paymentSourceAccountIds: Map<String, String>.from(
         _paymentSourceAccountIds,
       ),
@@ -1309,6 +1333,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           );
           _monthlyPaidAccountNames = Set<String>.from(
             currentState.paidAccountNames,
+          );
+          _billingConfirmedAccountIds = Set<String>.from(
+            currentState.billingConfirmedAccountIds,
           );
           _paymentSourceAccountIds = Map<String, String>.from(
             currentState.paymentSourceAccountIds,
@@ -1666,6 +1693,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _annualRateEvidences,
         ),
         paidAccountNames: Set<String>.from(_monthlyPaidAccountNames),
+        billingConfirmedAccountIds: Set<String>.from(
+          _billingConfirmedAccountIds,
+        ),
         paymentSourceAccountIds: Map<String, String>.from(
           _paymentSourceAccountIds,
         ),
@@ -1698,6 +1728,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           migrated.annualRateEvidences,
         ) &&
         _sameStringSet(_monthlyPaidAccountNames, migrated.paidAccountNames) &&
+        _sameStringSet(
+          _billingConfirmedAccountIds,
+          migrated.billingConfirmedAccountIds,
+        ) &&
         _sameStringMap(
           _paymentSourceAccountIds,
           migrated.paymentSourceAccountIds,
@@ -1742,6 +1776,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           migrated.annualRateEvidences,
         );
         _monthlyPaidAccountNames = Set<String>.from(migrated.paidAccountNames);
+        _billingConfirmedAccountIds = Set<String>.from(
+          migrated.billingConfirmedAccountIds,
+        );
         _paymentSourceAccountIds = Map<String, String>.from(
           migrated.paymentSourceAccountIds,
         );
@@ -1998,8 +2035,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     setState(() {
       if (amount == null || amount < 0) {
         _monthlyPaymentOverrides.remove(accountId);
+        _billingConfirmedAccountIds.remove(accountId);
       } else {
         _monthlyPaymentOverrides[accountId] = amount;
+        _billingConfirmedAccountIds.add(accountId);
       }
     });
     unawaited(_saveAssetLiabilityMonthlyState());
@@ -2009,6 +2048,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _monthlyPaymentControllers[accountId]?.clear();
     setState(() {
       _monthlyPaymentOverrides.remove(accountId);
+      _billingConfirmedAccountIds.remove(accountId);
     });
     unawaited(_saveAssetLiabilityMonthlyState());
   }
@@ -2018,6 +2058,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _monthlyPaymentControllers[row.id]?.text = amount.toString();
     setState(() {
       _monthlyPaymentOverrides[row.id] = amount.toDouble();
+      _billingConfirmedAccountIds.add(row.id);
     });
     unawaited(_saveAssetLiabilityMonthlyState());
   }
@@ -2033,7 +2074,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       for (final row in targets) {
         final amount = row.scheduledPaymentAmount.round();
         _monthlyPaymentOverrides[row.id] = amount.toDouble();
+        _billingConfirmedAccountIds.add(row.id);
         _monthlyPaymentControllers[row.id]?.text = amount.toString();
+      }
+    });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _toggleBillingConfirmed(String accountId, bool confirmed) {
+    setState(() {
+      if (confirmed) {
+        _billingConfirmedAccountIds.add(accountId);
+      } else {
+        _billingConfirmedAccountIds.remove(accountId);
       }
     });
     unawaited(_saveAssetLiabilityMonthlyState());
@@ -2301,12 +2354,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     bool paid,
   ) async {
     final previousPaidAccountNames = Set<String>.from(_monthlyPaidAccountNames);
+    final previousBillingConfirmedAccountIds = Set<String>.from(
+      _billingConfirmedAccountIds,
+    );
     final previousActualPaymentAmounts = Map<String, double>.from(
       _actualPaymentAmounts,
     );
     setState(() {
       if (paid) {
         _monthlyPaidAccountNames.add(row.id);
+        _billingConfirmedAccountIds.add(row.id);
         _actualPaymentAmounts.putIfAbsent(
           row.id,
           () => row.scheduledPaymentAmount,
@@ -2324,6 +2381,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (!mounted) return;
       setState(() {
         _monthlyPaidAccountNames = previousPaidAccountNames;
+        _billingConfirmedAccountIds = previousBillingConfirmedAccountIds;
         _actualPaymentAmounts = previousActualPaymentAmounts;
         _syncActualPaymentControllers();
       });
@@ -2344,6 +2402,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _paymentSourceAccountIds[liabilityId] = sourceAccountId;
       }
     });
+    unawaited(_saveAssetLiabilityMonthlyState());
+  }
+
+  void _savePaymentSourceReviewChoice({
+    required String liabilityId,
+    required String sourceAccountId,
+    required _PaymentSourceSaveScope scope,
+  }) {
+    setState(() {
+      if (scope == _PaymentSourceSaveScope.defaultSetting) {
+        _defaultPaymentSourceAccountIds[liabilityId] = sourceAccountId;
+        _paymentSourceAccountIds.remove(liabilityId);
+      } else {
+        _paymentSourceAccountIds[liabilityId] = sourceAccountId;
+      }
+    });
+    if (scope == _PaymentSourceSaveScope.defaultSetting) {
+      unawaited(_saveDefaultPaymentSources());
+    }
     unawaited(_saveAssetLiabilityMonthlyState());
   }
 
@@ -2532,6 +2609,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _actualPaymentAmounts = <String, double>{};
       _paymentDifferenceReasons = <String, String>{};
       _monthlyPaidAccountNames = <String>{};
+      _billingConfirmedAccountIds = <String>{};
       _paymentSourceAccountIds = Map<String, String>.from(
         copied.paymentSourceAccountIds,
       );
@@ -6718,6 +6796,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       paymentDifferenceReasons: _paymentDifferenceReasons,
       annualRateOverrides: _annualRateOverrides,
       paidAccountNames: _monthlyPaidAccountNames,
+      billingConfirmedAccountIds: _billingConfirmedAccountIds,
       paymentSourceAccountIds: _paymentSourceAccountIds,
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
       defaultCardBillingAccountIds: _defaultCardBillingAccountIds,
@@ -7211,6 +7290,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         paymentDifferenceReasons: _paymentDifferenceReasons,
         annualRateOverrides: _annualRateOverrides,
         paidAccountNames: _monthlyPaidAccountNames,
+        billingConfirmedAccountIds: _billingConfirmedAccountIds,
         paymentSourceAccountIds: _paymentSourceAccountIds,
         defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
         defaultCardBillingAccountIds: _defaultCardBillingAccountIds,
@@ -12533,6 +12613,28 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           ),
           const SizedBox(height: 10),
+          if (billingRows.isNotEmpty) ...[
+            Text(
+              '請求確定待ち対象: ${_debtReviewNamesLabel(billingRows)}',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 4),
+          ],
+          if (sourceRows.isNotEmpty) ...[
+            Text(
+              '原資未設定対象: ${_debtReviewNamesLabel(sourceRows)}',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
           Wrap(
             spacing: 8,
             runSpacing: 8,
@@ -12714,6 +12816,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return rows;
   }
 
+  String _debtReviewNamesLabel(List<AssetLiabilityDebtRow> rows) {
+    return rows.map((row) => row.name).join(' / ');
+  }
+
   int _consultationUrgencyRank(AssetLiabilityDebtRow row, DateTime baseDate) {
     final dueDate = _debtRowPaymentDate(row, baseDate);
     if (dueDate == null) {
@@ -12848,26 +12954,178 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     AssetLiabilityDebtRow row,
     AssetLiabilityWorkbook workbook,
   ) {
+    final candidates = _paymentSourceCandidatesForRow(row, workbook);
     return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: Row(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          const Icon(Icons.account_balance_outlined, size: 18),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              '${row.name} / 支払日 ${row.paymentDay ?? '-'}日 / '
-              '予定 ${_formatManagementYen(row.scheduledPaymentAmount)} / '
-              '支払後手元を口座別に再計算します。',
-              style: const TextStyle(fontSize: 12, height: 1.5),
-            ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const Icon(Icons.account_balance_outlined, size: 18),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '${row.name} / 支払日 ${row.paymentDay ?? '-'}日 / '
+                  '予定 ${_formatManagementYen(row.scheduledPaymentAmount)}',
+                  style: const TextStyle(fontSize: 12, height: 1.5),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _buildPaymentSourceDebtDropdown(row, workbook),
+            ],
           ),
-          const SizedBox(width: 8),
-          _buildPaymentSourceDebtDropdown(row, workbook),
+          if (candidates.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final candidate in candidates)
+                    _buildPaymentSourceCandidateChoice(row, candidate),
+                ],
+              ),
+            ),
+          ],
         ],
       ),
     );
+  }
+
+  List<_PaymentSourceCandidate> _paymentSourceCandidatesForRow(
+    AssetLiabilityDebtRow row,
+    AssetLiabilityWorkbook workbook,
+  ) {
+    final summariesById = <String, AssetLiabilityAccountCashflowSummary>{
+      for (final summary in workbook.accountCashflowSummaries)
+        summary.accountId: summary,
+    };
+    final candidates = <_PaymentSourceCandidate>[];
+    for (final account in _paymentSourceAccountOptions(workbook)) {
+      final summary = summariesById[account.id];
+      final projectedBefore = summary?.projectedBalance ?? account.balance;
+      final projectedAfter = projectedBefore - row.scheduledPaymentAmount;
+      candidates.add(
+        _PaymentSourceCandidate(
+          account: account,
+          currentBalance: account.balance,
+          projectedBeforePayment: projectedBefore,
+          projectedAfterPayment: projectedAfter,
+          safetyBalanceDelta: projectedAfter - _paymentSourceSafetyBalance,
+        ),
+      );
+    }
+    candidates.sort(
+      (a, b) => b.projectedAfterPayment.compareTo(a.projectedAfterPayment),
+    );
+    return candidates;
+  }
+
+  Widget _buildPaymentSourceCandidateChoice(
+    AssetLiabilityDebtRow row,
+    _PaymentSourceCandidate candidate,
+  ) {
+    final selected = _paymentSourceAccountIds[row.id] ??
+        _defaultPaymentSourceAccountIds[row.id] ??
+        row.paymentSourceAccountId;
+    final isSelected = selected == candidate.account.id;
+    final riskLevel = _paymentSourceRiskLevel(candidate.projectedAfterPayment);
+    final color = _cashRiskColor(riskLevel);
+    return Container(
+      width: 280,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: isSelected
+            ? const Color(0xFFECFDF5)
+            : Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: isSelected
+              ? const Color(0xFF0D9488)
+              : Theme.of(context).colorScheme.outlineVariant,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  candidate.account.name,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 12,
+                    height: 1.3,
+                  ),
+                ),
+              ),
+              _buildTextStatusChip(
+                label: _cashRiskLabel(riskLevel),
+                color: color,
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '現在 ${_formatManagementYen(candidate.currentBalance)} / '
+            '支払前見込み ${_formatManagementYen(candidate.projectedBeforePayment)}',
+            style: const TextStyle(fontSize: 11, height: 1.4),
+          ),
+          Text(
+            '支払後見込み ${_formatManagementYen(candidate.projectedAfterPayment)} / '
+            '安全残高差 ${_formatSignedManagementYen(candidate.safetyBalanceDelta)}',
+            style: TextStyle(
+              color: color,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: [
+              OutlinedButton(
+                onPressed: () => _savePaymentSourceReviewChoice(
+                  liabilityId: row.id,
+                  sourceAccountId: candidate.account.id,
+                  scope: _PaymentSourceSaveScope.monthlyOverride,
+                ),
+                child: const Text('今月'),
+              ),
+              OutlinedButton(
+                onPressed: () => _savePaymentSourceReviewChoice(
+                  liabilityId: row.id,
+                  sourceAccountId: candidate.account.id,
+                  scope: _PaymentSourceSaveScope.defaultSetting,
+                ),
+                child: const Text('既定'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  AssetLiabilityCashRiskLevel _paymentSourceRiskLevel(double balance) {
+    if (balance < 0) {
+      return AssetLiabilityCashRiskLevel.short;
+    }
+    if (balance < 10000) {
+      return AssetLiabilityCashRiskLevel.caution;
+    }
+    if (balance < _paymentSourceSafetyBalance) {
+      return AssetLiabilityCashRiskLevel.watch;
+    }
+    return AssetLiabilityCashRiskLevel.normal;
   }
 
   Widget _buildPaymentSourceDebtDropdown(
@@ -14943,6 +15201,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 DataColumn(label: Text('推定最低支払額'), numeric: true),
                 DataColumn(label: Text('今月支払予定額'), numeric: true),
                 DataColumn(label: Text('区分')),
+                DataColumn(label: Text('請求確認')),
                 DataColumn(label: Text('支払済み')),
                 DataColumn(label: Text('年利'), numeric: true),
                 DataColumn(label: Text('月利息'), numeric: true),
@@ -14970,6 +15229,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                       ),
                       DataCell(_buildMonthlyPaymentInput(row)),
                       DataCell(_buildPaymentAmountSourceChip(row)),
+                      DataCell(_buildBillingConfirmedCell(row)),
                       DataCell(_buildPaidCheckbox(row)),
                       DataCell(_buildAnnualRateInputWithEvidence(row)),
                       DataCell(
@@ -15229,6 +15489,38 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           fontWeight: FontWeight.bold,
           height: 1.2,
         ),
+      ),
+    );
+  }
+
+  Widget _buildBillingConfirmedCell(AssetLiabilityDebtRow row) {
+    if (row.includedInBillingAccount) {
+      return _buildTextStatusChip(
+        label: AssetLiabilityPlanningService.cardBillingIncludedLabel,
+        color: const Color(0xFF2563EB),
+      );
+    }
+    final effectiveConfirmed =
+        row.billingConfirmed || !row.paymentAmountEstimated || row.paid;
+    final canToggle = row.paymentAmountEstimated && !row.paid;
+    return SizedBox(
+      width: 160,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Checkbox(
+            value: effectiveConfirmed,
+            onChanged: canToggle
+                ? (value) => _toggleBillingConfirmed(row.id, value ?? false)
+                : null,
+          ),
+          _buildTextStatusChip(
+            label: effectiveConfirmed ? '確認済み' : '未確認',
+            color: effectiveConfirmed
+                ? const Color(0xFF0D9488)
+                : const Color(0xFFD97706),
+          ),
+        ],
       ),
     );
   }
@@ -15771,6 +16063,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   String _formatManagementYen(num value) {
     final sign = value < 0 ? '-' : '';
+    return '$sign¥${NumberFormat('#,###').format(value.abs().round())}';
+  }
+
+  String _formatSignedManagementYen(num value) {
+    if (value == 0) {
+      return '±¥0';
+    }
+    final sign = value > 0 ? '+' : '-';
     return '$sign¥${NumberFormat('#,###').format(value.abs().round())}';
   }
 

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -14,6 +14,7 @@ class AssetLiabilityMonthlyState {
   final Map<String, double> annualRateOverrides;
   final Map<String, AssetLiabilityAnnualRateEvidence> annualRateEvidences;
   final Set<String> paidAccountNames;
+  final Set<String> billingConfirmedAccountIds;
   final Map<String, String> paymentSourceAccountIds;
   final Map<String, String> cardBillingAccountIds;
   final List<AssetLiabilityCardStatementLine> cardStatementLines;
@@ -28,6 +29,7 @@ class AssetLiabilityMonthlyState {
     this.annualRateEvidences =
         const <String, AssetLiabilityAnnualRateEvidence>{},
     this.paidAccountNames = const <String>{},
+    this.billingConfirmedAccountIds = const <String>{},
     this.paymentSourceAccountIds = const <String, String>{},
     this.cardBillingAccountIds = const <String, String>{},
     this.cardStatementLines = const <AssetLiabilityCardStatementLine>[],
@@ -42,6 +44,7 @@ class AssetLiabilityMonthlyState {
       annualRateOverrides.isEmpty &&
       annualRateEvidences.isEmpty &&
       paidAccountNames.isEmpty &&
+      billingConfirmedAccountIds.isEmpty &&
       paymentSourceAccountIds.isEmpty &&
       cardBillingAccountIds.isEmpty &&
       cardStatementLines.isEmpty &&
@@ -61,6 +64,8 @@ class AssetLiabilityMonthlyStateStore {
   static const String annualRateEvidencePrefsKey =
       'asset_liability_monthly_annual_rate_evidences_v1';
   static const String paidPrefsKey = 'asset_liability_paid_accounts_v1';
+  static const String billingConfirmedPrefsKey =
+      'asset_liability_billing_confirmed_accounts_v1';
   static const String paymentSourcePrefsKey =
       'asset_liability_payment_source_accounts_v1';
   static const String cardBillingPrefsKey =
@@ -110,6 +115,10 @@ class AssetLiabilityMonthlyStateStore {
       ),
       paidAccountNames: paidAccountsForMonth(
         prefs.getString(paidPrefsKey),
+        monthKey,
+      ),
+      billingConfirmedAccountIds: billingConfirmedAccountsForMonth(
+        prefs.getString(billingConfirmedPrefsKey),
         monthKey,
       ),
       paymentSourceAccountIds: paymentSourceAccountsForMonth(
@@ -219,6 +228,21 @@ class AssetLiabilityMonthlyStateStore {
     await prefs.setString(
       paidPrefsKey,
       jsonEncode(_encodePaid(allPaidAccounts)),
+    );
+
+    final allBillingConfirmedAccounts = decodePaidAccounts(
+      prefs.getString(billingConfirmedPrefsKey),
+    );
+    if (state.billingConfirmedAccountIds.isEmpty) {
+      allBillingConfirmedAccounts.remove(monthKey);
+    } else {
+      allBillingConfirmedAccounts[monthKey] = Set<String>.from(
+        state.billingConfirmedAccountIds,
+      );
+    }
+    await prefs.setString(
+      billingConfirmedPrefsKey,
+      jsonEncode(_encodePaid(allBillingConfirmedAccounts)),
     );
 
     final allPaymentSources = decodePaymentSourceAccounts(
@@ -1135,6 +1159,15 @@ class AssetLiabilityMonthlyStateStore {
     );
   }
 
+  static Set<String> billingConfirmedAccountsForMonth(
+    String? raw,
+    String monthKey,
+  ) {
+    return Set<String>.from(
+      decodePaidAccounts(raw)[monthKey] ?? const <String>{},
+    );
+  }
+
   static Map<String, String> paymentSourceAccountsForMonth(
     String? raw,
     String monthKey,
@@ -1248,6 +1281,13 @@ class AssetLiabilityMonthlyStateStore {
       migratedPaidAccounts.add(legacyKeyToAccountId[accountKey] ?? accountKey);
     }
 
+    final migratedBillingConfirmedAccounts = <String>{};
+    for (final accountKey in state.billingConfirmedAccountIds) {
+      migratedBillingConfirmedAccounts.add(
+        legacyKeyToAccountId[accountKey] ?? accountKey,
+      );
+    }
+
     final migratedPaymentSources = <String, String>{};
     for (final entry in state.paymentSourceAccountIds.entries) {
       final liabilityId = legacyKeyToAccountId[entry.key] ?? entry.key;
@@ -1306,6 +1346,7 @@ class AssetLiabilityMonthlyStateStore {
       annualRateOverrides: migratedAnnualRates,
       annualRateEvidences: migratedAnnualRateEvidences,
       paidAccountNames: migratedPaidAccounts,
+      billingConfirmedAccountIds: migratedBillingConfirmedAccounts,
       paymentSourceAccountIds: migratedPaymentSources,
       cardBillingAccountIds: migratedCardBillingAccounts,
       cardStatementLines: migratedCardStatementLines,

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -82,6 +82,7 @@ class AssetLiabilityPlanningService {
     Map<String, String> paymentDifferenceReasons = const <String, String>{},
     Map<String, double> annualRateOverrides = const <String, double>{},
     Set<String> paidAccountNames = const <String>{},
+    Set<String> billingConfirmedAccountIds = const <String>{},
     Map<String, String> paymentSourceAccountIds = const <String, String>{},
     Map<String, String> defaultPaymentSourceAccountIds =
         const <String, String>{},
@@ -175,6 +176,7 @@ class AssetLiabilityPlanningService {
             paymentDifferenceReasons: paymentDifferenceReasons,
             annualRateOverrides: annualRateOverrides,
             paidAccountNames: paidAccountNames,
+            billingConfirmedAccountIds: billingConfirmedAccountIds,
             paymentSourceAccountIds: effectivePaymentSourceAccountIds,
             defaultCardBillingAccountIds: defaultCardBillingAccountIds,
             cardBillingAccountIds: cardBillingAccountIds,
@@ -529,6 +531,7 @@ class AssetLiabilityPlanningService {
     required Map<String, String> paymentDifferenceReasons,
     required Map<String, double> annualRateOverrides,
     required Set<String> paidAccountNames,
+    required Set<String> billingConfirmedAccountIds,
     required Map<String, String> paymentSourceAccountIds,
     required Map<String, String> defaultCardBillingAccountIds,
     required Map<String, String> cardBillingAccountIds,
@@ -602,10 +605,23 @@ class AssetLiabilityPlanningService {
           liabilityTotal == 0 ? 0 : principal / liabilityTotal.abs(),
       priorityLabel: _priorityLabel(annualRate),
       paymentAmountEstimated: manualPayment == null,
+      billingConfirmed: _containsAccountKey(
+        billingConfirmedAccountIds,
+        account,
+      ),
       paid: paidAccountNames.contains(account.id) ||
           paidAccountNames.contains(account.name.trim()) ||
           paidAccountNames.contains(account.name),
     );
+  }
+
+  bool _containsAccountKey(
+    Set<String> accountKeys,
+    AssetLiabilityAccount account,
+  ) {
+    return accountKeys.contains(account.id) ||
+        accountKeys.contains(account.name.trim()) ||
+        accountKeys.contains(account.name);
   }
 
   double _annualRateFor({

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1458,6 +1458,10 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
           remote.annualRateEvidences,
         ) &&
         _stringSetEquals(local.paidAccountNames, remote.paidAccountNames) &&
+        _stringSetEquals(
+          local.billingConfirmedAccountIds,
+          remote.billingConfirmedAccountIds,
+        ) &&
         _stringMapEquals(
           local.paymentSourceAccountIds,
           remote.paymentSourceAccountIds,

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -49,6 +49,7 @@ void main() {
         state: AssetLiabilityMonthlyState(
           paymentOverrides: const <String, double>{'モビット': 70000},
           paidAccountNames: const <String>{'auPayカード'},
+          billingConfirmedAccountIds: const <String>{'paypay_card'},
           actualPaymentAmounts: const <String, double>{'aupay_card': 6200},
           paymentDifferenceReasons: const <String, String>{
             'aupay_card': 'late fee',
@@ -114,6 +115,7 @@ void main() {
 
       expect(loadedMay.paymentOverrides['モビット'], 70000);
       expect(loadedMay.paidAccountNames, contains('auPayカード'));
+      expect(loadedMay.billingConfirmedAccountIds, contains('paypay_card'));
       expect(loadedMay.actualPaymentAmounts['aupay_card'], 6200);
       expect(loadedMay.paymentDifferenceReasons['aupay_card'], 'late fee');
       expect(loadedMay.annualRateOverrides['mobit'], 0.175);
@@ -141,6 +143,7 @@ void main() {
       expect(loadedJune.annualRateOverrides, isEmpty);
       expect(loadedJune.annualRateEvidences, isEmpty);
       expect(loadedJune.paidAccountNames, isEmpty);
+      expect(loadedJune.billingConfirmedAccountIds, isEmpty);
       expect(loadedJune.paymentSourceAccountIds, isEmpty);
       expect(loadedJune.cardBillingAccountIds, isEmpty);
       expect(loadedJune.cardStatementLines, isEmpty);

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -196,6 +196,16 @@ void main() {
         closeTo(workbook.monthlyScheduledPaymentTotal, 0.001),
       );
 
+      final billingConfirmed = service.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
+        baseDate: DateTime(2026, 5, 1),
+        billingConfirmedAccountIds: const <String>{'paypay_card'},
+      );
+
+      expect(billingConfirmed.debtMasterRows.single.billingConfirmed, isTrue);
+      expect(billingConfirmed.billingConfirmationPendingRows, isEmpty);
+      expect(billingConfirmed.paymentSourceMissingRows.length, 1);
+
       final reviewed = service.buildWorkbook(
         latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
         baseDate: DateTime(2026, 5, 1),

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -1188,6 +1188,7 @@ void main() {
           ),
         },
         paidAccountNames: const <String>{'kddi_provider'},
+        billingConfirmedAccountIds: const <String>{'mobit'},
         paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
         cardBillingAccountIds: const <String, String>{
           'kddi_provider': 'paypay_card',
@@ -1250,6 +1251,7 @@ void main() {
       expect(restored.annualRateEvidences['mobit']?.verified, isTrue);
       expect(row['annual_rate_evidences'], isA<Map<String, Object?>>());
       expect(restored.paidAccountNames, contains('kddi_provider'));
+      expect(restored.billingConfirmedAccountIds, contains('mobit'));
       expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
       expect(restored.cardBillingAccountIds['kddi_provider'], 'paypay_card');
       expect(restored.cardStatementLines.single.description, 'KDDI');

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -347,6 +347,7 @@ AssetLiabilityDebtRow _debtRow({
     liabilityShare: 1,
     priorityLabel: 'test',
     paymentAmountEstimated: false,
+    billingConfirmed: true,
     paid: false,
   );
 }


### PR DESCRIPTION
## Summary

- Adds billing-confirmation state for estimated debt payment rows so confirmed estimates stop showing as pending review.
- Adds payment-source review candidates with projected balances, safety-balance signals, and one-click monthly/default save actions.
- Persists billing-confirmed account ids through local state and Supabase payloads, and carries them through account-id migration.

## Validation

- `dart format lib\models\asset_liability_persistence.dart lib\models\asset_liability_workbook.dart lib\pages\asset_management_page.dart lib\services\asset_liability_monthly_state_store.dart lib\services\asset_liability_planning_service.dart lib\services\asset_liability_repository.dart test\services\asset_liability_monthly_state_store_test.dart test\services\asset_liability_planning_service_test.dart test\services\asset_liability_repository_test.dart test\services\asset_management_insight_service_test.dart`
- `flutter test test\services\asset_liability_monthly_state_store_test.dart test\services\asset_liability_planning_service_test.dart test\services\asset_liability_repository_test.dart test\services\asset_management_insight_service_test.dart`
- `flutter analyze lib\models\asset_liability_persistence.dart lib\models\asset_liability_workbook.dart lib\services\asset_liability_monthly_state_store.dart lib\services\asset_liability_planning_service.dart lib\services\asset_liability_repository.dart test\services\asset_liability_monthly_state_store_test.dart test\services\asset_liability_planning_service_test.dart test\services\asset_liability_repository_test.dart test\services\asset_management_insight_service_test.dart`
- `flutter analyze lib\pages\asset_management_page.dart`

## Minimal E2E Gate

- black-box coverage: workbook tests verify pending billing confirmation, payment source missing totals, confirmed billing removal, and reviewed rows after source selection.
- implementation-detail independent: repository/payload tests verify persisted billing-confirmed ids through local and Supabase payload round trips.
- minimal three cases: pending estimate, billing-confirmed estimate, source-selected reviewed row.
- Playwright: not run because this cleanup pass validated the deterministic state/workbook/persistence paths and page analyzer; no local seeded browser flow was available.
- E2E-Exception: focused Flutter tests cover the state transitions without browser automation.

## High-risk Ultrareview Evidence

- Review owner: Claude Code #1
- Claude ultrareview evidence: payment review state, persistence compatibility, and rollback path reviewed for cashflow accuracy risk.
- Required perspectives: security, rollback, data migration, prod smoke, observability.
- Security: no new privileged writes; saved source choices stay in existing local/Supabase asset-liability state payloads.
- Rollback: revert this commit to remove billing-confirmation state and candidate source review UI.
- Data migration: additive payload field with default empty set; existing monthly state remains readable.
- Prod smoke: open debt master review, filter to confirmation/source review rows, confirm an estimate, then save a monthly/default payment source.
- Observability: review counts and row chips expose pending/confirmed/source state directly in the asset workflow.
- unresolved findings: 0 / none.