### PR TITLE
Batch abstinence calendar snapshot loads

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1279,6 +1279,17 @@ class _HomePageState extends State<HomePage> {
     try {
       final prefs = await SharedPreferences.getInstance();
       final today = _startOfDay(_now());
+      final calendarRange = _calendarVisibleRange();
+      final abstinenceStart = today.isBefore(calendarRange.startDay)
+          ? today
+          : calendarRange.startDay;
+      final abstinenceEnd =
+          today.isAfter(calendarRange.endDay) ? today : calendarRange.endDay;
+      final abstinenceSnapshotsByDate =
+          await AbstinenceGuardStore.loadSnapshotsByDate(
+        startDate: abstinenceStart,
+        endDate: abstinenceEnd,
+      );
       final monthlyCashflowSummary = await _loadMonthlyCashflowSummary(
         prefs: prefs,
         month: today,
@@ -1292,14 +1303,18 @@ class _HomePageState extends State<HomePage> {
       );
       final todayStatus =
           homeDailyMap[_statusDateKey(today)] ?? const _HomeDailyStatusRecord();
-      final abstinenceSnapshot = await AbstinenceGuardStore.loadSnapshot(
-        now: today,
-      );
+      final abstinenceSnapshot =
+          abstinenceSnapshotsByDate[_statusDateKey(today)] ??
+              _emptyAbstinenceSnapshot();
       final completionGoalSnapshot = await _loadDailyCompletionGoalSnapshot(
         now: today,
       );
       final primaryInterference = abstinenceSnapshot.primaryInterference;
-      final calendarDays = await _loadCalendarDays(prefs: prefs);
+      final calendarDays = await _loadCalendarDays(
+        prefs: prefs,
+        calendarRange: calendarRange,
+        abstinenceSnapshotsByDate: abstinenceSnapshotsByDate,
+      );
 
       return _HomeOpsSnapshot(
         morningBriefingDone: todayStatus.morningBriefingDone,
@@ -1334,10 +1349,21 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  Future<List<_HomeCalendarDay>> _loadCalendarDays({
-    required SharedPreferences prefs,
-  }) async {
-    final now = _now();
+  AbstinenceGuardSnapshot _emptyAbstinenceSnapshot() {
+    return AbstinenceGuardSnapshot(
+      states: AbstinenceGuardStore.items
+          .map(
+            (item) => AbstinenceGuardState(
+              item: item,
+              isEnabled: false,
+              slipCount: 0,
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+
+  _HomeCalendarVisibleRange _calendarVisibleRange() {
     final monthAnchor = _calendarAnchorMonth();
     final firstDayOfMonth = DateTime(monthAnchor.year, monthAnchor.month, 1);
     final lastDayOfMonth = DateTime(monthAnchor.year, monthAnchor.month + 1, 0);
@@ -1345,6 +1371,24 @@ class _HomePageState extends State<HomePage> {
     final startDay = firstDayOfMonth.subtract(Duration(days: startOffset));
     final endOffset = 6 - (lastDayOfMonth.weekday % 7);
     final endDay = lastDayOfMonth.add(Duration(days: endOffset));
+
+    return _HomeCalendarVisibleRange(
+      monthAnchor: monthAnchor,
+      startDay: startDay,
+      endDay: endDay,
+    );
+  }
+
+  Future<List<_HomeCalendarDay>> _loadCalendarDays({
+    required SharedPreferences prefs,
+    _HomeCalendarVisibleRange? calendarRange,
+    Map<String, AbstinenceGuardSnapshot>? abstinenceSnapshotsByDate,
+  }) async {
+    final now = _now();
+    final range = calendarRange ?? _calendarVisibleRange();
+    final monthAnchor = range.monthAnchor;
+    final startDay = range.startDay;
+    final endDay = range.endDay;
     final homeDailyMap = await _loadHomeDailyStatusMap(
       prefs: prefs,
       startDate: startDay,
@@ -1362,15 +1406,19 @@ class _HomePageState extends State<HomePage> {
       startDate: startDay,
       endDate: endDay,
     );
+    final abstinenceByDate = abstinenceSnapshotsByDate ??
+        await AbstinenceGuardStore.loadSnapshotsByDate(
+          startDate: startDay,
+          endDate: endDay,
+        );
 
     final days = <_HomeCalendarDay>[];
     for (DateTime day = startDay;
         !day.isAfter(endDay);
         day = day.add(const Duration(days: 1))) {
       final dateKey = _statusDateKey(day);
-      final abstinence = await AbstinenceGuardStore.loadSnapshot(
-        now: day,
-      );
+      final abstinence =
+          abstinenceByDate[dateKey] ?? _emptyAbstinenceSnapshot();
       final isCurrentMonth =
           day.year == monthAnchor.year && day.month == monthAnchor.month;
       final isToday =
@@ -9146,6 +9194,18 @@ class _HomeDailyStatusRecord {
   const _HomeDailyStatusRecord({
     this.morningBriefingDone = false,
     this.balanceCheckDone = false,
+  });
+}
+
+class _HomeCalendarVisibleRange {
+  final DateTime monthAnchor;
+  final DateTime startDay;
+  final DateTime endDay;
+
+  const _HomeCalendarVisibleRange({
+    required this.monthAnchor,
+    required this.startDay,
+    required this.endDay,
   });
 }
 

--- a/lib/services/abstinence_guard_store.dart
+++ b/lib/services/abstinence_guard_store.dart
@@ -543,6 +543,33 @@ class AbstinenceGuardStore {
     );
   }
 
+  static Future<Map<String, AbstinenceGuardSnapshot>> loadSnapshotsByDate({
+    required DateTime startDate,
+    required DateTime endDate,
+    SharedPreferences? prefs,
+  }) async {
+    final start = _startOfDay(startDate);
+    final end = _startOfDay(endDate);
+    final rangeStart = start.isAfter(end) ? end : start;
+    final rangeEnd = start.isAfter(end) ? start : end;
+    final protocolPrefs = prefs ?? await SharedPreferences.getInstance();
+    final statesByDate = await _loadStatesForDateRange(
+      startDate: rangeStart,
+      endDate: rangeEnd,
+      prefs: prefs,
+    );
+
+    return <String, AbstinenceGuardSnapshot>{
+      for (final date in _dateRange(startDate: rangeStart, endDate: rangeEnd))
+        todayKey(date): _buildSnapshotFromStoredStates(
+          date: date,
+          storedStates: statesByDate[todayKey(date)] ??
+              const <String, _StoredAbstinenceState>{},
+          prefs: protocolPrefs,
+        ),
+    };
+  }
+
   static Future<AbstinenceGuardSnapshotWithSlipCounts>
       loadSnapshotWithSlipCounts({
     required String itemId,

--- a/test/pages/home_calendar_abstinence_batch_test.dart
+++ b/test/pages/home_calendar_abstinence_batch_test.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Home calendar batches abstinence daily status reads', () {
+    final source = File('lib/pages/home_page.dart').readAsStringSync();
+    final loaderStart = source.indexOf(
+      'Future<List<_HomeCalendarDay>> _loadCalendarDays',
+    );
+    final loaderEnd = source.indexOf(
+      'String _buildRelapsePreventionAction',
+      loaderStart,
+    );
+
+    expect(loaderStart, greaterThanOrEqualTo(0));
+    expect(loaderEnd, greaterThan(loaderStart));
+
+    final loaderSource = source.substring(loaderStart, loaderEnd);
+    expect(loaderSource, contains('AbstinenceGuardStore.loadSnapshotsByDate'));
+    expect(loaderSource, isNot(contains('AbstinenceGuardStore.loadSnapshot(')));
+  });
+}

--- a/test/services/abstinence_guard_store_test.dart
+++ b/test/services/abstinence_guard_store_test.dart
@@ -140,6 +140,56 @@ void main() {
     expect(lockedAlcoholProtocol.isLockedForToday, isTrue);
   });
 
+  test('loadSnapshotsByDate returns keyed snapshots for a date range',
+      () async {
+    final prefs = await SharedPreferences.getInstance();
+    final start = DateTime(2026, 3, 19, 9);
+    final middle = DateTime(2026, 3, 20, 9);
+    final end = DateTime(2026, 3, 21, 9);
+
+    await AbstinenceGuardStore.setEnabled(
+      itemId: 'sns',
+      isEnabled: true,
+      prefs: prefs,
+      now: start,
+    );
+    await AbstinenceGuardStore.incrementSlip(
+      itemId: 'sns',
+      prefs: prefs,
+      now: start,
+    );
+    await AbstinenceGuardStore.recordDisciplineRep(
+      categoryId: 'no_buy',
+      moneySaved: 1200,
+      timeSavedMinutes: 10,
+      prefs: prefs,
+      now: middle,
+    );
+    await AbstinenceGuardStore.setEnabled(
+      itemId: 'touch_hair',
+      isEnabled: true,
+      prefs: prefs,
+      now: end,
+    );
+
+    final snapshots = await AbstinenceGuardStore.loadSnapshotsByDate(
+      startDate: start,
+      endDate: end,
+      prefs: prefs,
+    );
+
+    expect(
+      snapshots.keys,
+      <String>['2026-03-19', '2026-03-20', '2026-03-21'],
+    );
+    expect(snapshots['2026-03-19']?.primaryInterference?.item.id, 'sns');
+    expect(snapshots['2026-03-20']?.disciplineSnapshot.totalRepCount, 1);
+    expect(
+      snapshots['2026-03-21']?.enabledStates.map((state) => state.item.id),
+      contains('touch_hair'),
+    );
+  });
+
   test('loadSnapshot includes discipline training totals and streak', () async {
     final prefs = await SharedPreferences.getInstance();
     final previousDay = DateTime(2026, 3, 20, 21);


### PR DESCRIPTION
﻿## Summary
- Batch-load abstinence guard snapshots for the visible home calendar range instead of reading each day one by one.
- Reuse the batched snapshots for today's home snapshot and add coverage for the range loader plus calendar source contract.

## Minimal E2E Gate
- The E2E plan is implementation-detail independent / black-box: verify the Home calendar renders abstinence status from stored input and does not depend on private loader internals.
- Minimal three cases: no stored abstinence state, one enabled blocker on a visible day, and one slipped blocker reflected on the visible calendar day.
- E2E mechanism: Playwright or Flutter integration_test can cover this through the Home calendar UI.
- E2E-Exception: this PR is a narrow data-loading performance change with focused Flutter tests for the new batch loader and calendar contract; a new integration_test file would duplicate existing Home calendar smoke coverage.

## Validation
- flutter test test\services\abstinence_guard_store_test.dart test\pages\home_calendar_abstinence_batch_test.dart
- flutter analyze lib\services\abstinence_guard_store.dart lib\pages\home_page.dart test\services\abstinence_guard_store_test.dart test\pages\home_calendar_abstinence_batch_test.dart
