### PR TITLE
[CI/CD自動最適化] cron 頻度削減 2026-06-06

### DIFF
--- a/.github/workflows/feature-review.yml
+++ b/.github/workflows/feature-review.yml
@@ -2,7 +2,7 @@ name: Feature Review
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 */4 * * *"  # 4時間毎 (2026-06-06 ci-audit: 毎時→4時間, 540実行/月削減)
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -13,7 +13,7 @@ name: Health Monitor (統合ヘルスモニター)
 
 on:
   schedule:
-    - cron: "*/30 * * * *"  # 毎30分
+    - cron: "0 * * * *"  # 毎時 (2026-06-06 ci-audit: 30分→60分, 720実行/月削減)
   workflow_dispatch:
 
 concurrency:

--- a/docs/ci-cd-audit/2026-06-06.md
+++ b/docs/ci-cd-audit/2026-06-06.md
@@ -1,0 +1,122 @@
+# CI/CD コスト監査 2026-06-06
+
+実行日: 2026-06-06 / エージェント: Claude Sonnet 4.6
+
+---
+
+## サマリ
+
+| 項目 | 値 |
+|---|---|
+| 総ワークフロー数 | 104 |
+| cron ワークフロー数 | 72 (69%) |
+| 毎時以上の高頻度 cron | 13 本 |
+| 30分毎実行 | 1 本 (health-monitor) |
+| cache 設定済み | ci.yml (pub-cache のみ) |
+| 既存 open CI監査 Issue | #3108 (2026-06-04) |
+
+推定 billable 時間 (月次): 1,400+ 実行/月 × 平均 30〜870 秒
+
+**TOP3 コスト源:**
+1. `health-monitor.yml` — 30分毎 → 月 1,440 実行 × 24s = 9.6h/月
+2. `cs-check.yml` — 毎時 → 月 720 実行 × 推定 60s = 12h/月
+3. `feature-review.yml` — 毎時 + Playwright/Chromium → 月 720 実行
+
+---
+
+## ワークフロー別コスト表 (高頻度 cron 抜粋)
+
+| ワークフロー | cron | 推定月実行数 | 平均時間 | 失敗率 | 主トリガー |
+|---|---|---|---|---|---|
+| health-monitor.yml | `*/30 * * * *` | 1,440 | 24s | 0% | schedule |
+| cs-check.yml | `7 * * * *` | 720 | ~60s | 0% | schedule |
+| feature-review.yml | `0 * * * *` | 720 | 56s+ | 0% | schedule |
+| edge-function-audit.yml | `47 * * * *` | 720 | ~20s | 0% | schedule |
+| horse-racing-update.yml | `0 * * * *` | 720 | 275s | 0% | schedule |
+| infra-health-check.yml | `37 * * * *` | 720 | ~25s | 0% | schedule |
+| notion-sync.yml | `10 * * * *` | 720 | 178s | 0% | schedule |
+| schedule-resilience-watch.yml | `22 * * * *` | 720 | 15s | 0% | schedule |
+| issue-to-wbs.yml | `25 * * * *` | 720 | 870s | 0% | schedule |
+| wbs-ai-review.yml | `20 * * * *` | 720 | ~20s | 0% | schedule |
+| mcp-audit-anomaly-cron.yml | `7 * * * *` | 720 | ~20s | 0% | schedule |
+| ai-university-update.yml | `0 */2 * * *` | 360 | ~300s | 0% | schedule |
+| tools-hub-mcp-smoke.yml | `22 */6 * * *` | 120 | 19s | **100%** | schedule |
+
+---
+
+## 検出した冗長フロー
+
+### A. 過剰 cron 頻度 (優先度: HIGH)
+
+**A-1. `health-monitor.yml` — 30分毎は過剰** [HIGH]
+- `*/30 * * * *` → 月 1,440 実行。同データは `cs-check.yml` (毎時) でも取得しており、30分サイクルの実益は限定的。
+- 推定削減: 720 実行/月 × 24s = 4.8h runner 時間削減
+- **本実行で自動適用**: `0 * * * *` (毎時) に変更
+
+**A-2. `feature-review.yml` — 毎時 Playwright は高コスト** [HIGH]
+- Playwright + Chromium を毎時インストール。720 実行/月。実際のレビュー発火は数件/日程度と推定。
+- 推定削減: 540 実行/月 (75%削減) × 平均実時間
+- **本実行で自動適用**: `0 */4 * * *` (4時間毎) に変更
+
+**A-3. `issue-to-wbs.yml` — 毎時 870秒は最重量** [HIGH]
+- 月 720 実行 × 870s = 174h/月。最大の billable 要因。
+- 推定削減: `0 */2 * * *` (2時間毎) で 360 実行/月 → 87h/月 削減
+- **Issue 提案のみ** (データ更新系のため破壊的変更回避)
+
+**A-4. `notion-sync.yml` — 毎時 178秒** [med]
+- 月 720 × 178s = 35.6h/月。Notion API 連携。
+- 推定削減: 2時間毎に変更 → 17.8h/月 削減
+
+### B. 100% 失敗ワークフロー (優先度: HIGH)
+
+**B-1. `tools-hub-mcp-smoke.yml` — 継続失敗** [HIGH]
+- 前回監査 (2026-06-04) から継続して 100% failure。
+- `TOOLS_HUB_MCP_BEARER_TOKEN` secret 未設定か tools-hub EF が未デプロイの可能性。
+- 対応: secret 設定 or `on.schedule` を一時コメントアウト
+- **Issue 提案のみ**
+
+### C. cache 未設定 (優先度: med)
+
+**C-1. `horse-racing-update.yml`** — Deno ランタイム使用、cache なし。月 720 × 275s = 54.9h/月。  
+**C-2. `notion-sync.yml`** — Python/requests、pip cache なし。  
+**C-3. `wbs-ai-review.yml`** — Gemini API call、軽量だが Python cache 未設定。
+
+### D. deploy 以外で concurrency 未最適化 (優先度: low)
+
+- `wbs-ai-review.yml`, `edge-function-audit.yml` など: concurrency 設定なし → 並行積み上がりの可能性
+
+### E. 重複目的ワークフロー (優先度: low / Issue 提案のみ)
+
+- `wbs-user-notify.yml` と `wbs-user-tasks-notify.yml` が同一 cron で類似目的 (前回 #3108 で提案済み)
+
+---
+
+## 自動適用した変更 (本実行)
+
+| ファイル | 変更 | 推定削減 |
+|---|---|---|
+| `health-monitor.yml` | `*/30 * * * *` → `0 * * * *` (30分→60分) | 720 実行/月 × 24s ≈ 4.8h runner 削減 |
+| `feature-review.yml` | `0 * * * *` → `0 */4 * * *` (毎時→4時間毎) | 540 実行/月 削減 (75%減) |
+
+---
+
+## 削除候補 (根拠付き・即削除しない)
+
+| ファイル | 根拠 |
+|---|---|
+| `cron-batch.yml` | 前回 #3108 で指摘済み。`# DISABLED` コメント、secrets 未設定でエラー継続 |
+| `tools-hub-mcp-smoke.yml` の schedule | 100% failure が 2 監査連続。secret 未整備 or EF 未稼働 |
+
+---
+
+## 改善提案 (非自動・Issue 対応)
+
+1. **[HIGH] `issue-to-wbs.yml` cron 変更** `25 * * * *` → `25 */2 * * *` (月87h削減)
+2. **[HIGH] `tools-hub-mcp-smoke.yml` 修正** — secret 確認または schedule 一時停止
+3. **[med] `notion-sync.yml` cron 変更** `10 * * * *` → `10 */2 * * *` (月18h削減)
+4. **[med] `horse-racing-update.yml` に Deno cache 追加** — 月 54h 中のダウンロード分を削減
+5. **[med] `wbs-ai-review.yml` cron 変更** `20 * * * *` → `20 */2 * * *` (月10h削減)
+
+---
+
+*前回監査: docs/ci-cd-audit/2026-06-05.md | Issue: #3108*


### PR DESCRIPTION
## 変更概要

ホワイトリスト該当の cron 頻度削減 2 件を自動適用。

| ファイル | 変更 | 推定削減効果 |
|---|---|---|
| `health-monitor.yml` | `*/30 * * * *` → `0 * * * *` (30分→毎時) | 720 実行/月 × 24s ≈ **4.8h runner 削減/月** |
| `feature-review.yml` | `0 * * * *` → `0 */4 * * *` (毎時→4時間毎) | 540 実行/月 削減 (Playwright overhead **75%減**) |

## 安全性確認

- YAML 構文: 104 ファイル全て `python3 yaml.safe_load` パス
- deploy 系ワークフロー: 変更なし
- concurrency / cancel-in-progress: 変更なし
- secrets / permissions: 変更なし

## 監査レポート

`docs/ci-cd-audit/2026-06-06.md` — 本実行の全検出結果・削減提案を記載

前回監査 Issue: #3108

## 追加提案 (本 PR 対象外 / Issue #3108 に追記)

- `issue-to-wbs.yml` cron 変更 → 月 87h 削減 (HIGH)
- `tools-hub-mcp-smoke.yml` 100% failure 修正 (HIGH)
- `notion-sync.yml` cron 変更 → 月 18h 削減 (med)


---
_Generated by [Claude Code](https://claude.ai/code/session_016A4iLyy8WRFgFLD2kCrcAV)_