### PR TITLE
[CI/CD自動最適化] 2026-06-07 — schedule cron 削減 (月1,260実行・14.7h削減)

### DIFF
--- a/.github/workflows/feature-review.yml
+++ b/.github/workflows/feature-review.yml
@@ -2,7 +2,7 @@ name: Feature Review
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 */4 * * *"  # ci-audit 2026-06-07: 毎時→4時間毎、月540実行削減
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -13,7 +13,7 @@ name: Health Monitor (統合ヘルスモニター)
 
 on:
   schedule:
-    - cron: "*/30 * * * *"  # 毎30分
+    - cron: "0 * * * *"  # 毎時 (ci-audit 2026-06-07: 30分→毎時、月720実行削減)
   workflow_dispatch:
 
 concurrency:

--- a/docs/ci-cd-audit/2026-06-07.md
+++ b/docs/ci-cd-audit/2026-06-07.md
@@ -1,0 +1,132 @@
+# CI/CD コスト監査 2026-06-07
+
+実行日: 2026-06-07 / エージェント: Claude Sonnet 4.6
+
+---
+
+## サマリ
+
+| 項目 | 値 |
+|---|---|
+| 総ワークフロー数 | 104 |
+| cron ワークフロー数 | 67 (64%) |
+| 毎時以上の高頻度 cron | 14 本 |
+| 30分毎実行 | 1 本 (health-monitor → 本実行で修正) |
+| cache 設定済み | ci.yml のみ (pub-cache) |
+| 前回監査から未マージ変更 | 2 件 (PR #3132 未確認) |
+| 既存 open CI監査 Issue | #3108 (2026-06-04) |
+
+**重要観察**: docs/ci-cd-audit/2026-06-06.md は `health-monitor.yml` と `feature-review.yml` の変更を「本実行で自動適用 (PR #3132)」と記録しているが、git log・実ファイル確認の結果、どちらも未適用のままであることが判明。本実行で改めて適用する。
+
+推定 billable 時間 (月次): 1,200+ 実行/月 (schedule のみ) × 平均 30〜870 秒
+
+**TOP3 コスト源:**
+1. `issue-to-wbs.yml` — 毎時 × 平均870s (14.5分) = 月 **174h** ※最大コスト源
+2. `health-monitor.yml` — 30分毎 × 24s = 月 9.6h (本実行で削減)
+3. `feature-review.yml` — 毎時 + Playwright/Chromium × 66s = 月 13.2h (本実行で削減)
+
+---
+
+## ワークフロー別コスト表 (高頻度 cron / 直近実績)
+
+| ワークフロー | cron | 月実行数 | 平均時間 | 失敗率 | 備考 |
+|---|---|---|---|---|---|
+| issue-to-wbs.yml | 毎時 | 720 | 870s | 0% | 最重要削減候補 |
+| health-monitor.yml | 30分毎 | 1,440 | 24s | 0% | **本実行: 毎時に変更** |
+| feature-review.yml | 毎時 | 720 | 66s | 0% | **本実行: 4時間毎に変更** |
+| horse-racing-update.yml | 毎時 | 720 | 310s | 0% | Deno + API 呼び出し |
+| notion-sync.yml | 毎時 | 720 | 196s | 0% | Deno |
+| cs-check.yml | 毎時 | 720 | ~60s | 0% | |
+| schedule-resilience-watch.yml | 毎時 | 720 | 15s | 0% | 軽量 |
+| mcp-audit-anomaly-cron.yml | 毎時 | 720 | 18s | 0% | 軽量 |
+| infra-health-check.yml | 毎時 | 720 | 20s | 0% | git push あり |
+| wbs-ai-review.yml | 毎時 | 720 | 10s | 0% | Gemini API |
+| edge-function-audit.yml | 毎時 | 720 | 16s | 0% | |
+| memory-search-sync.yml | 毎時 | 720 | 14s | 0% | concurrency済み |
+| tools-hub-mcp-smoke.yml | 6時間毎 | 120 | 19s | **100%** | 要修正 |
+| ai-university-update.yml | 2時間毎 | 360 | ~300s | 0% | |
+
+---
+
+## 検出した冗長フロー (A-G)
+
+### A. 過剰 cron 頻度 [HIGH]
+
+**A-1. `health-monitor.yml` — 30分毎は過剰** → 本実行で修正済み
+- 月 1,440 実行 → 720 実行へ削減 (節約: 720 × 24s = 4.8h/月)
+- `infra-health-check.yml` が毎時同等チェックをしており、30分頻度の実益は限定的
+
+**A-2. `feature-review.yml` — 毎時 Playwright は高コスト** → 本実行で修正済み
+- Playwright + Chromium インストールが毎時発生。540 実行/月削減
+- 節約: 540 × 66s ≈ 9.9h/月 runner 時間
+
+**A-3. `issue-to-wbs.yml` — 毎時 × 14.5分は最大コスト源** [HIGH / Issue 提案]
+- 月 720 実行 × 870s = 174h runner 時間 (※ 単独で全ワークフロー合計を超える可能性)
+- 推奨: `25 * * * *` → `25 */2 * * *` (2時間毎) で87h/月削減
+- issue/PR イベントでも起動するため実質的な遅延は軽微
+
+**A-4. `horse-racing-update.yml` — 毎時 × 5.2分** [med]
+- 月 720 × 310s ≈ 62h。`0 */2 * * *` に変更で31h削減可能
+
+**A-5. `notion-sync.yml` — 毎時 × 3.3分** [med]
+- 月 720 × 196s ≈ 39h。`10 */2 * * *` に変更で20h削減可能
+
+### B. 常時 100% 失敗ワークフロー [HIGH]
+
+**B-1. `tools-hub-mcp-smoke.yml`** — 6時間毎・100% failure (前回 #3108 から継続)
+- secret 未設定または EF 未稼働の可能性。schedule をコメントアウト推奨
+
+### C. cache 未使用 [HIGH]
+
+**C-1. `setup-flutter-sdk` custom action** — cache なしで毎回 `git clone flutter.git`
+- `ci.yml` と `deploy-prod.yml` が使用。2-3分/実行のオーバーヘッド
+- `.github/actions/setup-flutter-sdk/action.yml` に `actions/cache@v4` 追加で削減可能
+- 実装案: `path: ${{ runner.temp }}/flutter-sdk`, `key: flutter-sdk-${{ inputs.flutter-version }}-${{ runner.os }}-v1`
+
+### D. 重複目的ワークフロー [med]
+
+**D-1. `wbs-user-notify.yml` / `wbs-user-tasks-notify.yml`** — 同一 cron `0 0 * * *` (前回 #3108 で提案済み)
+
+### E. 前回レポート虚偽記録 [注意]
+
+- 2026-06-05 / 2026-06-06 のレポートが変更を「自動適用済み (PR #3132)」と記録しているが実際には未適用
+- git log に該当コミットなし・実ファイル確認で旧値のまま確認
+- 原因: PR 作成後に CI 失敗 or 未マージの可能性。本実行で改めて適用
+
+---
+
+## 改善提案 (削減効果順)
+
+| 優先度 | 対象 | 変更 | 推定削減 |
+|---|---|---|---|
+| HIGH | `issue-to-wbs.yml` | 毎時 → 2時間毎 | 87h/月 |
+| HIGH | `tools-hub-mcp-smoke.yml` | schedule 停止 | 0.6h/月 + failure noise 解消 |
+| HIGH | `setup-flutter-sdk` action | `actions/cache@v4` 追加 | 2-3分/Flutter ビルド |
+| med | `horse-racing-update.yml` | 毎時 → 2時間毎 | 31h/月 |
+| med | `notion-sync.yml` | 毎時 → 2時間毎 | 20h/月 |
+| med | `wbs-ai-review.yml` | 毎時 → 2時間毎 | 5h/月 |
+| low | `wbs-user-notify.yml` / `wbs-user-tasks-notify.yml` | 統合 | 365 実行/年 |
+
+---
+
+## 自動適用した変更 (本実行)
+
+| ファイル | 変更前 | 変更後 | 推定削減 |
+|---|---|---|---|
+| `health-monitor.yml` | `*/30 * * * *` (30分毎) | `0 * * * *` (毎時) | 720 実行/月 × 24s = **4.8h/月** |
+| `feature-review.yml` | `0 * * * *` (毎時) | `0 */4 * * *` (4時間毎) | 540 実行/月 × 66s = **9.9h/月** |
+
+**合計推定削減: 14.7h runner 時間/月 (≈ 1,260 実行削減/月)**
+
+---
+
+## 削除候補 (根拠付き・即削除しない)
+
+| ファイル | 根拠 |
+|---|---|
+| `cron-batch.yml` | `# DISABLED` コメント。secrets 未設定でエラー継続 (3 回連続指摘) |
+| `tools-hub-mcp-smoke.yml` の schedule | 100% failure 継続。secret/EF 修復まで schedule 停止推奨 |
+
+---
+
+*前回監査: docs/ci-cd-audit/2026-06-06.md | Issue: #3108*


### PR DESCRIPTION
## 変更概要

CI/CD コスト監査 2026-06-07 による自動最適化。前回 (2026-06-06) のレポートが「適用済み」と記録していたが実際には未適用だったことを確認し、本 PR で改めて適用する。

| ファイル | 変更前 | 変更後 | 推定削減 |
|---|---|---|---|
| `health-monitor.yml` | `*/30 * * * *` (30分毎) | `0 * * * *` (毎時) | 720 実行/月 × 24s = **4.8h/月** |
| `feature-review.yml` | `0 * * * *` (毎時) | `0 */4 * * *` (4時間毎) | 540 実行/月 × 66s = **9.9h/月** |

**合計: 月 1,260 実行削減 / 約 14.7h runner 時間削減**

## 変更の根拠

- `health-monitor.yml` (30分毎): `infra-health-check.yml` が毎時同等チェックを実施しており、30分頻度の実益は限定的。health-status.json の freshness が 30min → 60min に劣化するが許容範囲。
- `feature-review.yml` (毎時): Playwright + Chromium を毎時インストールするコストが高い。レビューの実効発火は数件/日程度であり、4時間毎で実用上の影響なし。

## 安全性

- ホワイトリスト該当変更 (schedule cron 頻度削減) のみ
- deploy 系 workflow は非対象
- YAML 構文検証済み (`python3 yaml.safe_load` 全104ファイル通過)
- `workflow_dispatch` は変更なし (手動即時実行は引き続き可能)

## 監査レポート

`docs/ci-cd-audit/2026-06-07.md` を同梱。次の高優先度 Issue 提案を含む:
- `issue-to-wbs.yml`: 毎時 × 870s → 2時間毎で月87h削減
- `setup-flutter-sdk` custom action: `actions/cache@v4` 追加で Flutter ビルド 2-3分削減
- `tools-hub-mcp-smoke.yml`: 100% failure 継続 → schedule 停止推奨

関連 Issue: #3108

---
_Generated by [Claude Code](https://claude.ai/code/session_012bNzWatPpUAKPNGNZ7Znja)_