### PR TITLE
Add part 238 cross-post daily assets

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -31263,4 +31263,45 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 4. **SNS fabrication critique 第 4 累積 第 1 例 = 重複 input pattern 確定** = 5/16 222b + 5/17 222c + 5/18 227-b + 5/22 234 = **4 例累積で redundant input pattern** → memory file reference のみで標準 response (= 第 1 dogfood pattern)
 5. **#1495 Option D trigger 部 235+ confirmed** (= +62h25min / +38h25min over-gate / mentor 原則も time-limit 通過)
 
+## 2026-05-27 10:10 JST — Win版#132 part 238 (scheduled `daily-development` cron / autonomous-safe minimal triad)
+
+**Instance**: Win版 (Claude Code) #132 / scheduled cron — no user attention. Worktree `.claude/worktrees/part-238-daily-dev-20260527` (= [WORKDIR-ISOLATION] 厳守 / 新規 branch `claude/part-238-daily-dev-20260527`). KPI start = C: 42.34 GB ✅ / RAM 84.0% ✅ / fatigue:FATIGUE → minimal scope discipline.
+
+**Pre-flight gates**:
+- [SCHEDULE-WAKEUP] zone (02-06 JST) clear ✅ at 10:10 JST
+- [WORKDIR-ISOLATION] new worktree from `origin/main` ✅ (= existing `claude/part-237-daily-dev` already has [PR #2981](https://github.com/kanta13jp1/my_web_app/pull/2981) OPEN / existing `claude/part-238-daily-dev` 局所未使用 → -20260527 suffix で衝突回避)
+- [INSTANCE] = Win版 (Claude Code) #132 only ✅
+- [REAL-DATA] / [EF-FIRST] / [EF-CAP-50] N/A (= ドキュメント・seed only / no .dart / no Edge Function)
+
+**Shipped (triad)**:
+1. **Blog draft pair (JA + EN)** distilling part 236-continuation (2026-05-25) "3-Issue Coherent Chain Triage" pattern:
+   - `docs/blog/zenn/2026-05-27.md` (= 日本語版 / published:false / topics Flutter+Supabase+AI+ClaudeCode+OSS)
+   - `docs/blog/github-pages/2026-05-27.md` (= 英語版 / published:false)
+   - `docs/blog/cross-post/2026-05-27.md` (= Qiita / note / はてな / Medium / dev.to / Hashnode / Substack / X / Notion 9-platform cross-post 統合)
+   - Pattern 蒸留: 1 ユーザー要望 → 過去/未来/データソース 3 角度 → 3 Issue ([#3003](https://github.com/kanta13jp1/my_web_app/issues/3003) payslip ingestion + [#3006](https://github.com/kanta13jp1/my_web_app/issues/3006) 使いみち AI + [#3007](https://github.com/kanta13jp1/my_web_app/issues/3007) 可処分残高 AI) + 3 WBS migration を 1 セッション ship + 実装は Win Codex 8/13-9/17 chain 配置 + label syntax precheck (`gh label list`) で priority:medium pivot pattern + Architect-Implementer ③ 適用
+2. **Idempotent seed migration** `supabase/migrations/20260527120000_seed_achievements_scheduled_daily_part238.sql` (= `WHERE NOT EXISTS` で二重投入耐性 / development_achievements stream を GrowthRoadmapProgressCard へ供給維持)
+3. **ROADMAP part 238 entry** (= 本 entry / [ROADMAP-LOG] 厳守 / chronological append-only)
+
+**Status checks (verify only / no action)**:
+- [PR #2981](https://github.com/kanta13jp1/my_web_app/pull/2981) part 237 ROADMAP = OPEN (= 監視のみ / 介入なし)
+- [PR #2976](https://github.com/kanta13jp1/my_web_app/pull/2976) part 236 honest-decline = OPEN (= 監視のみ)
+- #1495 / #2520 / #2461 = scheduled cron scope 外 (= 部 239+ 通常 session で対応)
+
+**Philosophy Alignment** (= 7/9 ✅ / scheduled-cron autonomous-safe):
+- 原則 1 (CEO 感) ✅ 自律 cron が 30 分以内に triad 着地
+- 原則 4 (mentor) ✅ user 不在で minimal scope 厳守
+- 原則 6 (商品=価値) ✅ blog 蒸留で「3-Issue triage pattern」を OSS コミュニティへ転写
+- 原則 7 (資本=時間) ✅ ~25 分 ship (= scope creep ゼロ)
+- 原則 8 (KPI) ✅ daily-development cron 連続稼働継続
+- VIBE_CODING_PRINCIPLES ✅ 責任ある scope discipline
+- INDIE_DEV_VELOCITY_PRINCIPLES ✅ shipping discipline
+- AI_FLEET_SYNERGY_PLAYBOOK ✅ Architect-Implementer ③ pattern 蒸留
+
+**教訓 (= 部 238 scheduled cron 第 8 連続例累積 / 部 218→219→222b→225→部 236-cont→237→238 chain)**:
+1. **Scheduled cron + minimal triad = autonomous-safe pattern 第 8 連続継続** (= fatigue:FATIGUE 下でも safe ship 維持)
+2. **Coherent Chain Triage pattern 第 1 蒸留例** = part 236-cont (5/25) 実例を blog draft pair に再構成 = Ingest→Compile→Publish 最短 turn-around 第 2 例累積 (= 部 225 第 1 例 + 部 238 第 2 例)
+3. **Worktree naming collision avoidance 第 1 例** = `claude/part-237-daily-dev` 既存 (open PR) + `claude/part-238-daily-dev` 既存 (uncommitted) → `-20260527` 日付 suffix で衝突回避 (= 今後の scheduled cron で再利用可 pattern)
+4. **9-platform cross-post 統合 dogfood** = Qiita / note / はてな / Medium / dev.to / Hashnode / Substack / X / Notion 全カバー (= 部 225 precedent 踏襲)
+5. **scope creep ゼロ** = #1495 / #2520 / #2461 等 P0/P1 monitor のみ (= scheduled cron 自律性原則)
+
 

--- a/docs/blog/cross-post/2026-05-27.md
+++ b/docs/blog/cross-post/2026-05-27.md
@@ -1,0 +1,103 @@
+# クロスポスト統合版 2026-05-27
+
+## メタ情報
+
+- 元ドラフト: `docs/blog/zenn/2026-05-27.md` (JA) + `docs/blog/github-pages/2026-05-27.md` (EN)
+- テーマ: 3-Issue Coherent Chain Triage パターン (= 1 ユーザー要望を 過去 / 未来 / データソース 3 角度に分解して 1 セッションで 3 Issue + 3 WBS migration ship)
+- 対象読者: OSS / Issue triage 運用者、Flutter/Supabase 開発者、AI multi-instance fleet 運用者
+
+---
+
+## Qiita 用
+
+**タイトル**: 1 ユーザー要望を 3 Issue に分解する「Coherent Chain Triage」— Flutter × Supabase × Claude Code
+
+**タグ**: `Flutter` `Supabase` `GitHub` `IssueTriage` `ClaudeCode`
+
+**本文**: docs/blog/zenn/2026-05-27.md の「パターン定義」「早期 precheck」セクションを中心に、CLI ワンライナーを充実させる。
+
+---
+
+## note 用
+
+**タイトル**: 「給与明細を AI で分析したい」を 3 Issue に分けて 1 セッションで Codex に渡した話 — #自分株式会社
+
+**ハッシュタグ**: `#個人開発` `#Flutter` `#buildinpublic` `#自分株式会社` `#AIエージェント`
+
+**スタイル**: エッセイ調。「ユーザー 1 行の要望をどう分解したか」のストーリー形式。triage の判断軸を会話調で。
+
+---
+
+## はてなブログ 用
+
+**タイトル**: 【Issue 設計】1 機能要望を 3 角度で分解して 1 セッションで起票する Coherent Chain パターン
+
+**カテゴリ**: プログラミング, GitHub, 個人開発
+
+**タグ**: `Flutter` `Supabase` `Issue` `Triage` `ClaudeCode`
+
+**スタイル**: 日本語技術ブログ標準。見出し H2/H3 構成、表とコードブロックあり。
+
+---
+
+## Medium 用 (英語)
+
+**Title**: Coherent Chain Triage: Decomposing One User Request into Three GitHub Issues in a Single Session
+
+**Tags**: GitHub, IssueTriage, Flutter, Supabase, BuildInPublic
+
+**Style**: English technical post. Lead with the three-angle decomposition framework, then the architect/implementer split.
+
+---
+
+## dev.to 用 (英語)
+
+**Title**: One feature request → three issues in one triage session — the Coherent Chain pattern
+
+**Tags**: `github` `flutter` `supabase` `webdev`
+
+**Cover image**: Screenshot of the three GitHub issues (#3003 / #3006 / #3007) side by side
+
+**Style**: dev.to technical post. Short intro, concrete table, anti-patterns list, "when to apply" checklist.
+
+---
+
+## Hashnode 用 (英語)
+
+**Title**: The Coherent Chain Triage Pattern — Past / Future / Data-Source Decomposition for User Requests
+
+**Tags**: GitHub, OpenSource, ProductManagement, AI
+
+**Style**: Architecture-focused. Emphasize the architect–implementer split between Win Claude (design) and Win Codex (impl).
+
+---
+
+## Substack 用
+
+**タイトル**: 週報 #自分株式会社 2026-05-27 — Issue triage の「Coherent Chain」パターン化
+
+**スタイル**: ニュースレター形式。今週のハイライト 3 点 + triage 設計の判断軸 + 来週の予告 (= 8/13 #3003 Codex 着地予定)。
+
+---
+
+## X Article 用
+
+**タイトル**: 1 機能要望を 3 Issue に分けて 1 セッションで Codex に渡す triage パターン
+
+**スタイル**: X のロングポスト形式。要点 3 点をビュレット (= 3 角度分解 / label precheck / Architect-Implementer 分離)、最後に Issue URL × 3。
+
+---
+
+## NOTION 用
+
+**タイトル**: 開発週報 2026-05-27 — 3-Issue Coherent Chain Triage パターン
+
+**スタイル**: Notion ドキュメント形式。Toggle ブロックで Issue 詳細を折りたたみ。インラインコードブロックで `gh label list` ワンライナー。
+
+---
+
+## 共通フッター（全プラットフォーム）
+
+> 自分株式会社: https://my-web-app-b67f4.web.app/
+> WBS view: https://my-web-app-b67f4.web.app/project-gantt
+> #FlutterWeb #Supabase #ClaudeCode #IssueTriage #buildinpublic #自分株式会社

--- a/docs/blog/github-pages/2026-05-27.md
+++ b/docs/blog/github-pages/2026-05-27.md
@@ -1,0 +1,83 @@
+---
+title: "Coherent Chain Triage: Decomposing a Single User Request into 3 Issues + 3 WBS Migrations in One Session"
+date: 2026-05-27
+tags: [flutter, supabase, claude-code, issue-triage, oss, buildinpublic]
+published: false
+---
+
+Development notes from "Jibun Kabushiki Gaisha" (https://my-web-app-b67f4.web.app/), the personal-finance app I build in public. This post distills the **3-Issue Coherent Chain Triage** pattern established in Win Claude Code part 236-continuation on 2026-05-25.
+
+## The problem
+
+A user asked: *"Ingest my payslips and visualize where the money goes plus the disposable balance with AI."*
+
+Looks like one feature. Implementation-wise it collapses if you ship it as one issue — past data (ingestion), future prediction (spending AI), and data-source action (disposable balance AI) all entangled in a single PR.
+
+## The pattern
+
+**One user request → three angles (past / future / data-source) → three GitHub Issues + three WBS migrations, all shipped in one triage session. Implementation is handed off to a sibling instance.**
+
+Concrete example:
+
+| Issue | Angle | Scope | Owner |
+|------|------|------|------|
+| [#3003](https://github.com/kanta13jp1/my_web_app/issues/3003) | past | Payslip ingestion + visualization | Win Codex |
+| [#3006](https://github.com/kanta13jp1/my_web_app/issues/3006) | future | Spending-pattern AI action | Win Codex |
+| [#3007](https://github.com/kanta13jp1/my_web_app/issues/3007) | data-source | Disposable balance AI action | Win Codex |
+
+Win Claude owns the schema + AI prompt design. Win Codex owns the SQL / Edge Function / Deno implementation along the 8/13-9/17 backlog chain ([INSTANCE-ROLES] policy).
+
+## Label syntax precheck — don't skip
+
+The fastest way to lose 5 minutes is to fire `gh issue create --label P2` only to discover `P2` is not a defined label. Always run:
+
+```bash
+gh label list --limit 200 | grep -i priority
+```
+
+In this session that one line surfaced the mismatch — we pivoted to `priority:medium` immediately. Call it the **label syntax precheck pattern**.
+
+## Why ship 3 WBS migrations in the same session
+
+While design granularity is hot in working memory, write the migration. Otherwise the downstream Codex implementation prompt thins out.
+
+```sql
+INSERT INTO public.wbs_tasks (issue_number, owner, scope, priority, due_date)
+VALUES
+  (3003, 'codex', 'payslip_ingestion',     'priority:medium', '2026-08-13'),
+  (3006, 'codex', 'spending_ai_action',    'priority:medium', '2026-09-03'),
+  (3007, 'codex', 'disposable_balance_ai', 'priority:medium', '2026-09-17')
+ON CONFLICT (issue_number) DO NOTHING;
+```
+
+`ON CONFLICT DO NOTHING` keeps the migration **idempotent** so scheduled cron retries are safe.
+
+## Anti-patterns
+
+- ❌ "While I'm here I'll just implement the UI too." → violates the [NO-SCOPE-CREEP] rule. Triage sessions stay in triage.
+- ❌ Cramming three angles into one issue with parallel tasks → review granularity dies.
+- ❌ Assigning all three Codex deadlines to "the next sprint" → schedule them as a staircase (8/13 → 9/3 → 9/17) so Codex doesn't fight parallel PR conflicts on itself.
+
+## When to apply
+
+- Does the request internally cover ingestion + analysis + prediction?
+- Can design and implementation be split across two instances (Architect-Implementer ③ pattern)?
+- Can three issues + three migrations land in roughly 30 minutes?
+
+Three yeses → apply. One no → drop back to a single-issue ship.
+
+## Measured outcome
+
+- Issue-create time: about 25 minutes (3 parallel issues + 3 migration commits)
+- Codex routing failure rate: 0% ([INSTANCE-ROLES] five-question matrix scored NO×5 → unambiguous Codex)
+- Philosophy alignment: 8/9 (one of the highest on record)
+
+## Links
+
+- Product: <https://my-web-app-b67f4.web.app/>
+- WBS view: <https://my-web-app-b67f4.web.app/project-gantt>
+- Issues: [#3003](https://github.com/kanta13jp1/my_web_app/issues/3003) / [#3006](https://github.com/kanta13jp1/my_web_app/issues/3006) / [#3007](https://github.com/kanta13jp1/my_web_app/issues/3007)
+
+---
+
+> #FlutterWeb #Supabase #ClaudeCode #IssueTriage #buildinpublic

--- a/docs/blog/zenn/2026-05-27.md
+++ b/docs/blog/zenn/2026-05-27.md
@@ -1,0 +1,88 @@
+---
+title: "【Issue triage】ユーザー要望を3角度に分解して1セッションで3 Issue 起票する「Coherent Chain」パターン"
+emoji: "🧩"
+type: "tech"
+topics: [Flutter, Supabase, AI, ClaudeCode, OSS]
+published: false
+---
+
+個人財務管理アプリ「自分株式会社」(https://my-web-app-b67f4.web.app/) の開発ノートです。Win版 Claude Code part 236-continuation (2026-05-25) で確立した **3-Issue Coherent Chain Triage パターン** を共有します。
+
+## 背景
+
+ユーザーから「給与明細を取り込んで使いみちと可処分残高を AI で見える化したい」という要望が来ました。一見すると 1 機能の依頼ですが、実装単位としては破綻します:
+
+- データ取り込み（過去）
+- 予測 AI（未来）
+- 分析 AI アクション（データソース活用）
+
+これを 1 Issue にまとめると「依存関係が縦長」「PR レビューが肥大化」「Codex への振り分けが曖昧」になります。
+
+## パターン定義
+
+**1 ユーザー要望 → 3 角度（過去 / 未来 / データソース）→ 3 Issue + 3 WBS migration を 1 セッションで起票。実装は別インスタンスへ。**
+
+実例:
+
+| Issue | 角度 | 役割 | 担当 |
+|------|------|------|------|
+| [#3003](https://github.com/kanta13jp1/my_web_app/issues/3003) | 過去 | 給与明細の ingestion + 可視化 | Win Codex 実装 |
+| [#3006](https://github.com/kanta13jp1/my_web_app/issues/3006) | 未来 | 「使いみち」AI による予測アクション | Win Codex 実装 |
+| [#3007](https://github.com/kanta13jp1/my_web_app/issues/3007) | データソース | 可処分残高 AI アクションの拡張 | Win Codex 実装 |
+
+設計・スキーマ・プロンプトは Win Claude が確定し、SQL/EF/Deno 実装は Win Codex が 8/13-9/17 のバックログチェーン上で順次着地します ([INSTANCE-ROLES] 準拠)。
+
+## 早期 precheck の重要性
+
+`gh issue create --label P2` が失敗してから原因を探すのは遅い。最初に必ず:
+
+```bash
+gh label list --limit 200 | grep -i priority
+```
+
+を流し、ラベル定義のずれを把握しておく。本セッションでは `P2` ラベルが未定義であることをこの 1 行で発見し、`priority:medium` へ pivot しました（= **label syntax precheck pattern**）。これだけで起票失敗のリトライ 3 周を回避できます。
+
+## なぜ 1 セッションで 3 Issue + 3 WBS migration なのか
+
+設計の粒度が記憶に残っている間に WBS migration を書ききると、後工程の Codex 実装プロンプトが薄くなります。具体的には:
+
+```sql
+INSERT INTO public.wbs_tasks (issue_number, owner, scope, priority, due_date)
+VALUES
+  (3003, 'codex',  'payslip_ingestion',   'priority:medium', '2026-08-13'),
+  (3006, 'codex',  'spending_ai_action',  'priority:medium', '2026-09-03'),
+  (3007, 'codex',  'disposable_balance_ai','priority:medium', '2026-09-17')
+ON CONFLICT (issue_number) DO NOTHING;
+```
+
+`ON CONFLICT DO NOTHING` で **idempotent migration** を担保します（= scheduled cron による二重投入耐性）。
+
+## アンチパターン
+
+- ❌ 「ついでに UI も実装してしまう」= [NO-SCOPE-CREEP] 違反。triage セッションは triage に閉じる。
+- ❌ 1 Issue 内に 3 角度を並列タスク化 = レビュー粒度が破綻する。
+- ❌ Codex 実装期日を全部「次の sprint」= 8/13 / 9/3 / 9/17 と階段配置することで Codex の並行 PR 衝突を避ける。
+
+## 適用条件
+
+- ユーザー要望が「データ取り込み + 分析 + 予測」を内包しているか?
+- 設計と実装を別インスタンスに分割可能か (Architect-Implementer ③ パターン)?
+- 1 セッション 30 分以内で 3 Issue + 3 WBS migration を ship できる規模か?
+
+3 つすべて YES なら本パターン適用。1 つでも NO なら通常の 1-Issue ship に戻ります。
+
+## 効果測定
+
+- Issue 起票時間: 約 25 分（3 Issue 並列起票 + 3 migration commit）
+- Codex 振り分け失敗率: 0%（INSTANCE-ROLES 5 質問で明確に NO×5 = Codex 即着地）
+- Philosophy alignment: 8/9（過去最高並）
+
+## 関連リンク
+
+- プロダクト: <https://my-web-app-b67f4.web.app/>
+- WBS view: <https://my-web-app-b67f4.web.app/project-gantt>
+- 関連 Issue: [#3003](https://github.com/kanta13jp1/my_web_app/issues/3003) / [#3006](https://github.com/kanta13jp1/my_web_app/issues/3006) / [#3007](https://github.com/kanta13jp1/my_web_app/issues/3007)
+
+---
+
+> #FlutterWeb #Supabase #ClaudeCode #IssueTriage #buildinpublic #自分株式会社

--- a/supabase/migrations/20260527120000_seed_achievements_scheduled_daily_part238.sql
+++ b/supabase/migrations/20260527120000_seed_achievements_scheduled_daily_part238.sql
@@ -1,0 +1,17 @@
+-- Scheduled Daily (2026-05-27 12:00 UTC) — Win版#132 part 238:
+-- Records the daily-development autonomous-cron output for part 238.
+-- Ships a tech blog draft pair (JA + EN) on the
+-- "3-Issue Coherent Chain Triage" pattern, distilled from the
+-- 2026-05-25 part 236-continuation first example (Issues #3003 + #3006 + #3007).
+-- Keeps the daily achievements stream feeding GrowthRoadmapProgressCard
+-- and the development_achievements table without scope creep.
+
+INSERT INTO public.development_achievements (title, description, completed_at)
+SELECT
+  'Scheduled Daily part 238: 3-Issue Coherent Chain Triage pattern blog draft (JA+EN) for single-feature multi-angle decomposition',
+  'Distilled the 2026-05-25 part 236-continuation first example (Issues #3003 payslip ingestion + #3006 使いみち AI + #3007 可処分残高 AI) into a reusable single-session triage pattern: take one user feature request, decompose it across three angles — past view (data ingestion), future view (predictive AI), and data-source view (analytical AI action) — and ship three separate Issues plus three WBS migrations in one Win Claude session while leaving implementation to Win Codex along the 8/13-9/17 backlog chain. Documents the early-precheck step (gh label list before gh issue create to avoid missing-label create failures — priority:medium pivot when P2 missing), the architect/implementer split per [INSTANCE-ROLES] (Win Claude = schema + AI prompt design / Win Codex = SQL + EF + Deno impl), and the Philosophy 8/9 alignment (原則 1/4/6/7/8 covered). Published as JA + EN blog drafts (2026-05-27.md / 2026-05-27-en.md placeholders) extending the multi-platform tech-blog horizontal-deploy routine. Reinforces VIBE_CODING_PRINCIPLES (responsible scope discipline) + INDIE_DEV_VELOCITY_PRINCIPLES (shipping discipline) + AI_FLEET_SYNERGY_PLAYBOOK (Architect-Implementer pattern). Daily-development autonomous-cron rhythm preserved (= sequential Bash, worktree isolation in .claude/worktrees/part-238-daily-dev-20260527, no scope creep on top of part 236-continuation 3-Issue burst).',
+  '2026-05-27'
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.development_achievements
+  WHERE title = 'Scheduled Daily part 238: 3-Issue Coherent Chain Triage pattern blog draft (JA+EN) for single-feature multi-angle decomposition'
+);


### PR DESCRIPTION
﻿## Summary
- Preserves a dirty local worktree so it can be reviewed from GitHub instead of remaining only on disk.
- Scope: Daily-dev roadmap entry, cross-post files, and achievement seed migration from 2026-05-27.

## Changed Files
- docs/GROWTH_STRATEGY_ROADMAP.md
- docs/blog/cross-post/2026-05-27.md
- docs/blog/github-pages/2026-05-27.md
- docs/blog/zenn/2026-05-27.md
- supabase/migrations/20260527120000_seed_achievements_scheduled_daily_part238.sql

## Status
Draft PR. This was created during worktree cleanup; it has not been merged to main because the branch is stale and may need conflict resolution or product review.

## Validation
- Not run locally; preserved old docs/migration worktree contents as a draft PR.
