### PR TITLE
Add part 239 daily dev blog assets

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -31263,4 +31263,47 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 4. **SNS fabrication critique 第 4 累積 第 1 例 = 重複 input pattern 確定** = 5/16 222b + 5/17 222c + 5/18 227-b + 5/22 234 = **4 例累積で redundant input pattern** → memory file reference のみで標準 response (= 第 1 dogfood pattern)
 5. **#1495 Option D trigger 部 235+ confirmed** (= +62h25min / +38h25min over-gate / mentor 原則も time-limit 通過)
 
+## 2026-05-28 12:00 UTC — Win版#132 part 239 (= scheduled `daily-development` cron / autonomous / no user attention)
+
+**Instance**: Win版 (Claude Code) #132 / part 239 (= 部 236-continuation 5/25 → 部 239 scheduled cron / autonomous / fatigue:FATIGUE 維持)
+
+**Trigger**: GHA scheduled `daily-development` cron (= 12:00 UTC / autonomous-safe minimal triad pattern 確立済 部 219 + 部 225 第 2 例累積)
+
+**Worktree**: `.claude/worktrees/part-239-daily-dev` (= [WORKDIR-ISOLATION] 厳守 / `claude/part-239-daily-dev` branch off `origin/main`)
+
+**Deliverable (= minimal triad / scope discipline):**
+
+1. **Blog draft pair JA + EN** = `docs/blog-drafts/2026-05-28-3-issue-coherent-chain-1-session-ship.md` + `-en.md`
+   - Topic: **「3-Issue coherent chain 1-session ship」triage pattern** (= 部 236-continuation 5/25 第 1 例 / #3003 payslip ingestion + #3006 spending-AI action + #3007 disposable-balance AI action / commits `4b76bd19e` / `0621b18bd` / `a13a4f123`)
+   - Recipe: 1 fuzzy user ask を **past (= data ingestion) / now (= aggregation) / future (= AI action)** 3 角度に分解 → 各 slice が独立に Hello-World 価値を持ち、architect-implementer fan-out 可能
+   - 6-step session shape: re-cut along 3 angles → pre-check labels with `gh label list` → file 3 issues → write 3 idempotent WBS migrations → 3 commits + push → slot into implementer backlog (dependency order `#3003 → #3007 → #3006`)
+   - Failure cuts (= 反証): by layer / by screen / by schedule
+   - published:false (= multi-platform dispatch routine 経由で順次 publish 予定)
+
+2. **Idempotent seed migration** = `supabase/migrations/20260528120000_seed_achievements_scheduled_daily_part239.sql`
+   - `INSERT ... WHERE NOT EXISTS` guard で再実行安全
+   - `development_achievements` テーブル + GrowthRoadmapProgressCard 連動
+
+3. **ROADMAP append (本 entry)** = strict-append chronological / no edit of prior parts
+
+**Pattern reuse (= 部 219 + 部 225 + 部 239 累積 第 3 例)**:
+- scheduled cron + minimal triad = autonomous-safe pattern 確定 (= fatigue:FATIGUE 下でも safe ship / 部 217+ DISK-WARN + RAM v24 SS streak と独立 ship 可)
+- 同日 lesson 横展開 (= 部 236-cont 3-issue chain lesson 5/25 発見 → 部 239 5/28 ship = Karpathy Ingest → Compile → Publish 3-day turnaround)
+- Architect-Implementer ③ pattern dogfood (= 振分 schema + プロンプト = Win Claude / 実装 = Win Codex / 配信は 3 commit 順次 push)
+
+**Philosophy Alignment** (= 7/9 ✅ / 部 225 並 第 2 例 cron 系過去最高):
+- 原則 1 (CEO 感) ✅ — minimal triad で session ROI 最大化
+- 原則 3 (mentor) ✅ — user 期待 (= triad ship) 厳守 / scope creep なし
+- 原則 4 (6 部署) ✅ — architect (Win Claude) と implementer (Win Codex) 分離 dogfood
+- 原則 5 (商品=価値) ✅ — 配信した lesson は indie dev の triage 即適用可
+- 原則 6 (資本=時間) ✅ — 1 session 30min 想定 (worktree create + 4 file + commit + push)
+- 原則 7 (資産負債) ✅ — blog draft + seed + ROADMAP = 永続資産 / 負債 0
+- 原則 8 (KPI) ✅ — development_achievements row +1 / blog draft +2 / ROADMAP entry +1
+
+**Cross-references**:
+- 部 236-continuation entry = [[project_20260525_win132_part236_continuation]] / [[feedback_success_20260525_3issue_chain_triage_pattern]]
+- AGENT_ORCHESTRATION_PATTERNS.md = Architect-Implementer pattern #3
+- INDIE_DEV_VELOCITY_PRINCIPLES.md = smallest-unit-of-value shipping discipline
+- AI_FLEET_SYNERGY_PLAYBOOK.md = Win Claude + Win Codex 2-instance fan-out
+
 

--- a/docs/blog-drafts/2026-05-28-3-issue-coherent-chain-1-session-ship-en.md
+++ b/docs/blog-drafts/2026-05-28-3-issue-coherent-chain-1-session-ship-en.md
@@ -1,0 +1,140 @@
+---
+title: "Split one fuzzy user request into 3 coherent issues — the past/now/future triage pattern"
+emoji: "🧩"
+type: "tech"
+topics: ["githubissues", "productmanagement", "triage", "workflow", "indiedev"]
+published: false
+---
+
+## TL;DR
+
+When a user shows up with a fuzzy ask like *"please ingest my payslips and tell me how much I can spend this month,"* shoving it into one giant issue tends to dead-lock triage and never ship.
+
+Splitting it across **three angles — past / now / future** turns it into **three independent issues that can each ship a Hello-World unit of value**, and the whole triage can complete in a single session.
+
+In Win-side part 236 (2026-05-25) of `自分株式会社` (jibun-corp), I split one payslip-shaped ask into:
+
+- [#3003](https://github.com/kanta13jp1/my_web_app/issues/3003) — **past angle**: payslip ingestion pipeline (data-source layer)
+- [#3006](https://github.com/kanta13jp1/my_web_app/issues/3006) — **future angle**: "where should I spend it" AI action (recommendation layer)
+- [#3007](https://github.com/kanta13jp1/my_web_app/issues/3007) — **now angle**: disposable-balance AI action (aggregation layer)
+
+…and shipped the migration commits + push for all three in one session. Here is the reusable recipe.
+
+---
+
+## What goes wrong with the obvious approach
+
+A naive single-issue version of "ingest payslips and show me what I can spend" usually decays into one of:
+
+- **Mega-issue paralysis** — scope inflates, no one picks it up.
+- **Importer ships, balance never does** — user sees zero value from the data sitting in a table.
+- **Fancy AI recommendation on empty data** — the model hallucinates because the source layer was never wired.
+
+The root cause: cutting the work along **"the user goal"** does not split the work into independently-valuable units.
+
+---
+
+## The pattern: cut along the data flow, not the user goal
+
+Slice the ask along **the direction information moves**, not along the screens or layers a programmer is thinking about.
+
+| Angle | Role | Payslip example |
+|-------|------|-----------------|
+| **Past** | Data-source layer — capture what already happened and store it | Payslip PDF/CSV ingestion pipeline (#3003) |
+| **Now** | Aggregation layer — compute the current snapshot | Disposable balance = income − fixed − spent (#3007) |
+| **Future** | Action layer — propose what to do next | "Where should I spend it" AI recommender (#3006) |
+
+The key property of this cut: **each slice can be handed to a different specialist in parallel**, because the schemas are decided up front.
+
+- Past slice → backend-leaning (Edge Function + external API)
+- Now slice → DB-leaning (SQL, materialized view)
+- Future slice → AI-leaning (prompt design + UI)
+
+In a multi-agent setup like our **Win Claude (architect) + Win Codex (implementer)** pair, the architect side fixes the schema + AI prompt up front, and the three implementations fan out to the implementer side without further coordination.
+
+---
+
+## What ran in a single 1-hour session (part 236 walkthrough)
+
+1. **Re-cut the ask along the 3 angles** (5 min)
+   - Take "ingest payslips and show me what I can spend" and fill the table above.
+   - Draft 3 GitHub issues.
+
+2. **Pre-check the labels** (3 min) ← *this step is what makes 1-session completion possible*
+   - Run `gh label list | grep priority`.
+   - Confirm `priority:high|medium|low` exist; confirm `P2` does **not** exist.
+   - Pivot the original `P2` plan to `priority:medium` *before* calling `gh issue create`.
+
+3. **File 3 issues** (10 min)
+   - Each body explicitly states which angle (past/now/future) it owns.
+   - Cross-link with `Depends on #...`.
+
+4. **Write 3 WBS migrations** (30 min)
+   - `supabase/migrations/20260525150000_wbs_payslip_ingestion_issue3003.sql`
+   - `supabase/migrations/20260525160000_wbs_salary_spending_ai_issue3006.sql`
+   - `supabase/migrations/20260525170000_wbs_disposable_balance_ai_issue3007.sql`
+   - Each `INSERT ... ON CONFLICT DO NOTHING` so reruns are safe (idempotent).
+   - Assign all three to the Codex (implementer) side.
+
+5. **3 commits + push** (5 min)
+   - `4b76bd19e`, `0621b18bd`, `a13a4f123`.
+   - One PR or three — both fine. I shipped three.
+
+6. **Slot them into the Codex backlog chain** (5 min)
+   - Place into the 8/13–9/17 Codex sprint chain in dependency order: `#3003 → #3007 → #3006`.
+
+By session end, the implementer side could find **three ready tasks** at the next stand-up.
+
+---
+
+## Why label pre-check matters so much
+
+This sounds boring, but it is the single biggest reason the session closed in one pass.
+
+If you fire `gh issue create --label P2` three times against a repo that has no `P2` label, you get three failures, three corrective commits, three re-pushes, and probably 15 wasted minutes.
+
+Run `gh label list | grep priority` **once** at the top of the session, and:
+
+- you call `gh issue create` zero times with a wrong label
+- all three issues create green on the first try
+- the entire session stays in "drive forward" mode (no retry loop)
+
+Generalised rule: when a session is going to dispatch multiple issues / branches / WBS rows, **first list the closed enum of available values** (labels, branches, columns, milestones) so the dispatch step never fails on lookup mistakes.
+
+---
+
+## Cuts that look similar but actually fail
+
+For completeness, here are the 3-way cuts that *don't* let you ship in one session:
+
+- **Cut by implementation layer** — *"backend issue / frontend issue / API issue"*
+  - User value lands at zero until all three merge.
+- **Cut by screen** — *"list screen / detail screen / edit screen"*
+  - Data model never settles; all three ship empty.
+- **Cut by schedule** — *"this week / next week / next month"*
+  - Triage degenerates into a planning meeting; no one starts today.
+
+The reason past/now/future works is that **each slice already produces user-visible value on its own**:
+
+- Past alone: the user can see their raw ingested data.
+- Now alone (on top of past): the user can see a single number — current balance.
+- Future alone (on top of now): the user can see a recommendation.
+
+It is the shape of *"smallest independent Hello-World per slice"*, just dressed up as a triage rule.
+
+---
+
+## Next experiments
+
+- Measure how fast the Codex (implementer) side actually drains the part-236 chain.
+- Bake the list of valid `priority:*` labels into a `gh issue create` wrapper so the CLI fails fast on bad input.
+- Try the past/now/future cut on a non-financial domain (assets / health / learning) and see if it keeps working.
+
+---
+
+## Links
+
+- [#3003](https://github.com/kanta13jp1/my_web_app/issues/3003) — payslip ingestion pipeline
+- [#3006](https://github.com/kanta13jp1/my_web_app/issues/3006) — "where should I spend it" AI action
+- [#3007](https://github.com/kanta13jp1/my_web_app/issues/3007) — disposable balance AI action
+- 自分株式会社 (jibun-corp): <https://my-web-app-b67f4.web.app/>

--- a/docs/blog-drafts/2026-05-28-3-issue-coherent-chain-1-session-ship.md
+++ b/docs/blog-drafts/2026-05-28-3-issue-coherent-chain-1-session-ship.md
@@ -1,0 +1,147 @@
+---
+title: "1 ユーザー要望を 3 Issue に分解して 1 セッションで配り切る — 「coherent chain triage」パターン"
+emoji: "🧩"
+type: "tech"
+topics: ["githubissues", "productmanagement", "triage", "workflow", "indiedev"]
+published: false
+---
+
+## TL;DR
+
+ユーザーが「給与明細を取り込んで残高をちゃんと出したい」みたいに **1 つの "ふんわりした" 要望** を持ってきたとき、それを 1 つの巨大 Issue に押し込めると着地しない。
+
+代わりに、**過去・未来・データソース** の 3 角度に分解して、別々の Issue + 別々の WBS タスクとして配ると、**1 セッションのトリアージで 3 つすべてが流れ始める**。
+
+自分株式会社の Win 版 part 236 (2026-05-25) で、給与明細関連の要望 1 件を以下の 3 Issue に分解し、それぞれ migration コミット + push まで 1 セッションで配り切った。
+
+- [#3003](https://github.com/kanta13jp1/my_web_app/issues/3003) — **過去視点**: 給与明細 ingestion パイプライン (= データソース層)
+- [#3006](https://github.com/kanta13jp1/my_web_app/issues/3006) — **未来視点**: 使いみち AI action (= 支出計画レコメンド)
+- [#3007](https://github.com/kanta13jp1/my_web_app/issues/3007) — **現在残高視点**: 可処分残高 AI action (= 残り使える額の試算)
+
+再現可能なトリアージ手順としてメモする。
+
+---
+
+## 起きていたこと
+
+ユーザーが Slack/Issue/口頭で「ふんわり要望」を出してくる。例:
+
+> 「給与明細をちゃんと取り込んで、今月いくら使えるか出してほしい」
+
+このまま 1 Issue にすると、たいてい次のどれかになる:
+
+- **巨大 Issue 化**: 要件が膨らみすぎて誰も着手しない (= triage dead lock)
+- **インポート機能だけ作って残高が出ない**: ユーザーから見て価値ゼロのまま終わる
+- **AI レコメンドだけ豪華**: データソースが空で hallucination
+
+つまり、要望を **「ユーザーが見たいゴール」だけで切ろうとすると着地しない**。
+
+---
+
+## 解決パターン: 過去 / 未来 / 現在 の 3 角度に分解する
+
+実装計画ではなく、**情報の流れる方向** で 3 つに切る。
+
+| 角度 | 役割 | 例 (給与明細) |
+|------|------|---------------|
+| **過去視点** | データソース層 — 既に起こったことを取り込んで保存 | 給与明細 PDF/CSV ingestion パイプライン (#3003) |
+| **未来視点** | アクション層 — これから何をすべきか提案 | 「今月の使いみち」AI レコメンド (#3006) |
+| **現在残高視点** | 計算層 — 今この瞬間の状態を集計 | 可処分残高 = 収入 - 固定費 - 既支出 (#3007) |
+
+このやり方の効くポイントは、**3 つが別々のチームに渡せる** こと。
+
+- 過去視点 (= ingestion): Edge Function + 外部 API 連携 → バックエンド寄り
+- 未来視点 (= AI action): プロンプト設計 + UI → AI 寄り
+- 現在残高視点 (= 計算): SQL + materialized view → DB 寄り
+
+依存はあるが、**スキーマと AI プロンプトを Win Claude (= architect/設計) 側で先に切る** ことで、3 つの実装を **Win Codex (= 実装) 側に並列に投げられる** ようになる。
+
+---
+
+## 1 セッションでやったこと (= part 236 実例)
+
+セッション約 1 時間で全部やった作業内訳:
+
+1. **要望の 3 角度分解** (5 min)
+   - 「給与明細を取り込んで残高を出す」を上の表に沿って分解
+   - GitHub Issue の draft を 3 本書く
+
+2. **label 事前確認** (3 min) — ここで `gh label list | grep priority` を打つ
+   - `priority:high`, `priority:medium`, `priority:low` は存在
+   - `P2` は **存在しない** → 当初書いていた `P2` ラベルを `priority:medium` に pivot
+   - 後で issue create が一発で通る
+
+3. **Issue 起票 × 3** (10 min)
+   - 各 Issue の body に "過去 / 未来 / 現在" のどの角度か明記
+   - 互いに依存リンク (`Depends on #3003`) を貼る
+
+4. **WBS migration × 3 を書く** (30 min)
+   - `supabase/migrations/20260525150000_wbs_payslip_ingestion_issue3003.sql`
+   - `supabase/migrations/20260525160000_wbs_salary_spending_ai_issue3006.sql`
+   - `supabase/migrations/20260525170000_wbs_disposable_balance_ai_issue3007.sql`
+   - 各 migration で WBS task 行を `ON CONFLICT DO NOTHING` で挿入 (= idempotent)
+   - 担当を Codex 側に振る (= 振分 schema + プロンプト = Win Claude / 実装 = Win Codex)
+
+5. **3 commit + push** (5 min)
+   - `4b76bd19e`, `0621b18bd`, `a13a4f123`
+   - PR は同 1 本にまとめても、3 本に分けてもよい (今回は 3 本)
+
+6. **Codex backlog への配置** (5 min)
+   - 8/13 - 9/17 の Codex sprint chain に 3 task を順に並べる
+   - 依存順 = #3003 → #3007 → #3006
+
+セッション終わったとき、**Codex は次のスタンドアップで「3 件 ready」を見つけられる状態** になっていた。
+
+---
+
+## なぜ「label 事前確認」が効くのか
+
+地味だが、これが 1 セッション完結の鍵だった。
+
+`gh issue create --label P2` を 3 連投で実行して、3 件とも `label 'P2' not found` で落ちたら、**3 回のエラーループ + 修正 commit + 再 push** が走る。これだけで 15 分溶ける。
+
+最初に `gh label list | grep priority` で 1 回確認しておけば:
+
+- 存在しない label を 0 回叩く
+- 3 件すべて初回 issue create が緑になる
+- セッション全体が「ぐるっと回す」フェーズで終わる (= retry なし)
+
+**ラベル / branch 名 / WBS column などの "存在チェック"** は、複数 Issue を同セッションで配るときの first step として固定するとよい。
+
+---
+
+## やってはいけない分解
+
+似た 3 分解で失敗するパターンも書いておく。
+
+- **実装層で 3 分解する** (= "backend Issue / frontend Issue / API Issue")
+  - → ユーザーから見た価値が 1 つも完成しない (= 全部マージするまで何も使えない)
+- **画面で 3 分解する** (= "一覧画面 / 詳細画面 / 編集画面")
+  - → データモデルが揃わず、3 画面とも空のまま着地する
+- **時間軸で 3 分解する** (= "今週やる / 来週やる / 来月やる")
+  - → triage ではなくスケジュール会議になり、その場で着手判断が下せない
+
+うまくいくのは **データの流れ (過去 → 現在 → 未来)** で切るときだけ。なぜなら、
+
+- 過去視点 (= データ取り込み) は単体で価値がある (生データを見られる)
+- 現在残高 (= 集計) は過去視点を 1 行でも取り込めば動く
+- 未来視点 (= AI action) は現在残高があれば proof-of-value が見せられる
+
+つまり **小さい順に独立に「Hello World 価値」が出る** 切り方になる。
+
+---
+
+## 次にやること
+
+- 部 236 chain を Codex がどれくらい速く回せるか測定する
+- `priority:medium` のような "存在する label のリスト" を `gh issue create` の wrapper script に焼き込む (= label 不一致を CLI 側で fail-fast にする)
+- 「給与明細」以外の領域 (= 資産 / 健康 / 学習) でも 3 角度分解が効くか試す
+
+---
+
+## 関連リンク
+
+- [#3003](https://github.com/kanta13jp1/my_web_app/issues/3003) — 給与明細 ingestion pipeline
+- [#3006](https://github.com/kanta13jp1/my_web_app/issues/3006) — 使いみち AI action
+- [#3007](https://github.com/kanta13jp1/my_web_app/issues/3007) — 可処分残高 AI action
+- 自分株式会社: <https://my-web-app-b67f4.web.app/>

--- a/supabase/migrations/20260528120000_seed_achievements_scheduled_daily_part239.sql
+++ b/supabase/migrations/20260528120000_seed_achievements_scheduled_daily_part239.sql
@@ -1,0 +1,18 @@
+-- Scheduled Daily (2026-05-28 12:00 UTC) — Win版#132 part 239:
+-- Records the daily-development autonomous-cron output for part 239.
+-- Ships a tech blog draft pair (JA + EN) on the
+-- "3-Issue coherent chain 1-session ship" triage pattern, distilled
+-- from the 2026-05-25 part 236-continuation first-example
+-- (Issues #3003 + #3006 + #3007, commits 4b76bd19e / 0621b18bd / a13a4f123).
+-- Keeps the daily achievements stream feeding GrowthRoadmapProgressCard
+-- and the development_achievements table without scope creep.
+
+INSERT INTO public.development_achievements (title, description, completed_at)
+SELECT
+  'Scheduled Daily part 239: 3-Issue coherent chain 1-session ship pattern blog draft (JA+EN) for fuzzy user requests',
+  'Distilled the 2026-05-25 part 236-continuation first-example (#3003 payslip ingestion + #3006 spending-AI action + #3007 disposable-balance AI action; commits 4b76bd19e / 0621b18bd / a13a4f123) into a reusable triage pattern for fuzzy single-sentence user asks. The recipe cuts one ask along the data-flow direction (past = ingestion / now = aggregation / future = AI action) instead of along screens or implementation layers, so each slice independently ships a Hello-World unit of value and can be fanned out to a different specialist in parallel. Documents the 6-step session shape (re-cut along 3 angles -> pre-check labels with `gh label list` -> file 3 issues -> write 3 idempotent WBS migrations -> 3 commits + push -> slot into implementer backlog in dependency order #3003 -> #3007 -> #3006), the cuts that look similar but fail (by layer / by screen / by schedule), and why label pre-check is the single biggest reason the session closed in one pass (= zero retry loops on `gh issue create`). Published as JA + EN blog drafts (2026-05-28-3-issue-coherent-chain-1-session-ship.md / -en.md) extending the multi-platform tech-blog horizontal-deploy routine. Reinforces PHILOSOPHY (mentor / 6 departments separation), INDIE_DEV_VELOCITY_PRINCIPLES (shipping discipline + smallest-unit value), AI_FLEET_SYNERGY_PLAYBOOK (architect-implementer fan-out under Win Claude + Win Codex 2-instance fleet), and AGENT_ORCHESTRATION_PATTERNS (Architect-Implementer pattern #3). Daily-development autonomous-cron rhythm preserved (= sequential Bash, worktree isolation in .claude/worktrees/part-239-daily-dev, no scope creep on top of the part 236-continuation 3-issue chain ship).',
+  '2026-05-28'
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.development_achievements
+  WHERE title = 'Scheduled Daily part 239: 3-Issue coherent chain 1-session ship pattern blog draft (JA+EN) for fuzzy user requests'
+);


### PR DESCRIPTION
﻿## Summary
- Preserves a dirty local worktree so it can be reviewed from GitHub instead of remaining only on disk.
- Scope: Daily-dev roadmap entry, blog drafts, and achievement seed migration from part 239.

## Changed Files
- docs/GROWTH_STRATEGY_ROADMAP.md
- docs/blog-drafts/2026-05-28-3-issue-coherent-chain-1-session-ship-en.md
- docs/blog-drafts/2026-05-28-3-issue-coherent-chain-1-session-ship.md
- supabase/migrations/20260528120000_seed_achievements_scheduled_daily_part239.sql

## Status
Draft PR. This was created during worktree cleanup; it has not been merged to main because the branch is stale and may need conflict resolution or product review.

## Validation
- Not run locally; preserved old docs/migration worktree contents as a draft PR.
