### PR TITLE
feat(social-commerce-hub): 多段承認ワークフロー (discount/privilege/free-offer) — Closes #2919

### DIFF
--- a/docs/AGENT_TOOL_POLICY.md
+++ b/docs/AGENT_TOOL_POLICY.md
@@ -69,6 +69,14 @@ reaches the threshold, the decision resets execution to the safe default
 (`read`/`suggest`) and returns an `ai_tool_monitoring` event payload for the AI
 tool monitoring dashboard or notification pipeline.
 
+`multi_step_approval_workflow.ts` adds the multi-step approval contract for
+NotebookLM Issue #2919. `social-commerce-hub:discount_approval.request` now
+stores a workflow with manager, finance, legal, and CEO steps as required by
+discount size, free offers, or privilege grants. Transactions stay
+`held_for_approval` until all steps pass, each decision appends audit events,
+and the request payload includes an `admin_approval_requests` notification event
+for dashboard or notification delivery.
+
 This follows the Harness Engineering direction from NotebookLM
 `bc58b50b-5fc4-4840-9a62-b397d6d3b65a`: Claude Code, Codex, and external AI
 agents should operate inside explicit scopes, approval gates, and audit logs.

--- a/supabase/functions/_shared/multi_step_approval_workflow.ts
+++ b/supabase/functions/_shared/multi_step_approval_workflow.ts
@@ -1,0 +1,320 @@
+export type ApprovalActionType =
+  | "discount_apply"
+  | "privilege_grant"
+  | "free_offer";
+
+export type ApprovalDecisionValue = "approved" | "rejected";
+export type ApprovalWorkflowStatus =
+  | "not_required"
+  | "pending"
+  | "approved"
+  | "rejected";
+export type ApprovalStepStatus = "pending" | "approved" | "rejected";
+
+export interface ApprovalWorkflowInput {
+  actionType: ApprovalActionType;
+  requestedByRole?: string | null;
+  amountJpy?: number | null;
+  discountPct?: number | null;
+  freeOffer?: boolean | null;
+  privilegeGrant?: boolean | null;
+  requestedAt?: string | null;
+}
+
+export interface ApprovalStep {
+  id: string;
+  label: string;
+  allowedRoles: string[];
+  status: ApprovalStepStatus;
+  approvedBy?: string | null;
+  approvedByRole?: string | null;
+  decidedAt?: string | null;
+  comment?: string | null;
+}
+
+export interface ApprovalWorkflowNotificationEvent {
+  channel: "admin_approval_requests";
+  eventType: "multi_step_approval.requested";
+  severity: "medium" | "high" | "critical";
+  title: string;
+  message: string;
+  targetRoles: string[];
+  payload: Record<string, unknown>;
+}
+
+export interface MultiStepApprovalWorkflow {
+  required: boolean;
+  status: ApprovalWorkflowStatus;
+  transactionStatus:
+    | "approval_not_required"
+    | "held_for_approval"
+    | "approval_completed"
+    | "approval_rejected";
+  actionType: ApprovalActionType;
+  currentStepId: string | null;
+  steps: ApprovalStep[];
+  notificationEvent: ApprovalWorkflowNotificationEvent | null;
+  auditEvents: Record<string, unknown>[];
+}
+
+export interface ApprovalStepDecisionInput {
+  decision: ApprovalDecisionValue;
+  approverRole: string;
+  approverId: string;
+  stepId?: string | null;
+  comment?: string | null;
+  decidedAt?: string | null;
+}
+
+export interface ApprovalStepDecisionResult {
+  accepted: boolean;
+  error: string | null;
+  workflow: MultiStepApprovalWorkflow;
+  auditEvents: Record<string, unknown>[];
+}
+
+const DISCOUNT_PCT_THRESHOLD = 20;
+const HIGH_DISCOUNT_PCT_THRESHOLD = 50;
+const DISCOUNT_AMOUNT_THRESHOLD_JPY = 5000;
+
+function normalizeRole(value: string | null | undefined): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function uniqueRoles(steps: readonly ApprovalStep[]): string[] {
+  return [...new Set(steps.flatMap((step) => step.allowedRoles))];
+}
+
+function normalizeNumber(value: number | null | undefined): number {
+  return Number.isFinite(value) ? Number(value) : 0;
+}
+
+function buildStep(
+  id: string,
+  label: string,
+  allowedRoles: readonly string[],
+): ApprovalStep {
+  return {
+    id,
+    label,
+    allowedRoles: [...allowedRoles],
+    status: "pending",
+  };
+}
+
+function requiredSteps(input: ApprovalWorkflowInput): ApprovalStep[] {
+  const discountPct = normalizeNumber(input.discountPct);
+  const amountJpy = normalizeNumber(input.amountJpy);
+  const freeOffer = input.freeOffer === true ||
+    input.actionType === "free_offer";
+  const privilegeGrant = input.privilegeGrant === true ||
+    input.actionType === "privilege_grant";
+  const steps: ApprovalStep[] = [];
+
+  if (
+    freeOffer || privilegeGrant || discountPct >= DISCOUNT_PCT_THRESHOLD ||
+    amountJpy >= DISCOUNT_AMOUNT_THRESHOLD_JPY
+  ) {
+    steps.push(buildStep("manager_review", "Manager review", [
+      "manager",
+      "admin",
+      "owner",
+    ]));
+  }
+
+  if (
+    freeOffer || discountPct >= DISCOUNT_PCT_THRESHOLD ||
+    amountJpy >= DISCOUNT_AMOUNT_THRESHOLD_JPY
+  ) {
+    steps.push(buildStep("finance_review", "Finance review", [
+      "cfo",
+      "admin",
+      "owner",
+    ]));
+  }
+
+  if (freeOffer || privilegeGrant) {
+    steps.push(buildStep("legal_review", "Legal review", [
+      "legal",
+      "admin",
+      "owner",
+    ]));
+  }
+
+  if (
+    freeOffer || privilegeGrant || discountPct >= HIGH_DISCOUNT_PCT_THRESHOLD
+  ) {
+    steps.push(buildStep("ceo_approval", "CEO approval", [
+      "ceo",
+      "admin",
+      "owner",
+    ]));
+  }
+
+  return steps;
+}
+
+function severityFor(
+  input: ApprovalWorkflowInput,
+): "medium" | "high" | "critical" {
+  if (
+    input.freeOffer === true || input.privilegeGrant === true ||
+    normalizeNumber(input.discountPct) >= HIGH_DISCOUNT_PCT_THRESHOLD
+  ) {
+    return "critical";
+  }
+  if (
+    normalizeNumber(input.discountPct) >= DISCOUNT_PCT_THRESHOLD ||
+    normalizeNumber(input.amountJpy) >= DISCOUNT_AMOUNT_THRESHOLD_JPY
+  ) {
+    return "high";
+  }
+  return "medium";
+}
+
+function currentStepId(steps: readonly ApprovalStep[]): string | null {
+  return steps.find((step) => step.status === "pending")?.id ?? null;
+}
+
+export function buildMultiStepApprovalWorkflow(
+  input: ApprovalWorkflowInput,
+): MultiStepApprovalWorkflow {
+  const steps = requiredSteps(input);
+  const required = steps.length > 0;
+  const requestedAt = input.requestedAt ?? new Date().toISOString();
+  const notificationEvent = required
+    ? {
+      channel: "admin_approval_requests" as const,
+      eventType: "multi_step_approval.requested" as const,
+      severity: severityFor(input),
+      title: "Approval required for high-risk AI action",
+      message:
+        "A discount, free offer, or privilege grant is held until all approval steps pass.",
+      targetRoles: uniqueRoles(steps),
+      payload: {
+        action_type: input.actionType,
+        requested_by_role: normalizeRole(input.requestedByRole),
+        amount_jpy: normalizeNumber(input.amountJpy),
+        discount_pct: normalizeNumber(input.discountPct),
+        free_offer: input.freeOffer === true,
+        privilege_grant: input.privilegeGrant === true,
+      },
+    }
+    : null;
+
+  return {
+    required,
+    status: required ? "pending" : "not_required",
+    transactionStatus: required ? "held_for_approval" : "approval_not_required",
+    actionType: input.actionType,
+    currentStepId: currentStepId(steps),
+    steps,
+    notificationEvent,
+    auditEvents: [{
+      event: "workflow_requested",
+      action_type: input.actionType,
+      approval_required: required,
+      at: requestedAt,
+      requested_by_role: normalizeRole(input.requestedByRole),
+    }],
+  };
+}
+
+export function applyApprovalStepDecision(
+  workflow: MultiStepApprovalWorkflow,
+  input: ApprovalStepDecisionInput,
+): ApprovalStepDecisionResult {
+  if (!workflow.required || workflow.status === "not_required") {
+    return {
+      accepted: false,
+      error: "approval_not_required",
+      workflow,
+      auditEvents: [],
+    };
+  }
+  if (workflow.status === "approved" || workflow.status === "rejected") {
+    return {
+      accepted: false,
+      error: `workflow_already_${workflow.status}`,
+      workflow,
+      auditEvents: [],
+    };
+  }
+
+  const stepId = input.stepId ?? workflow.currentStepId;
+  const stepIndex = workflow.steps.findIndex((step) => step.id === stepId);
+  if (stepIndex < 0) {
+    return {
+      accepted: false,
+      error: "approval_step_not_found",
+      workflow,
+      auditEvents: [],
+    };
+  }
+  if (workflow.steps[stepIndex].id !== workflow.currentStepId) {
+    return {
+      accepted: false,
+      error: "approval_step_out_of_order",
+      workflow,
+      auditEvents: [],
+    };
+  }
+
+  const approverRole = normalizeRole(input.approverRole);
+  const step = workflow.steps[stepIndex];
+  if (!step.allowedRoles.includes(approverRole)) {
+    return {
+      accepted: false,
+      error: "approver_role_not_allowed_for_step",
+      workflow,
+      auditEvents: [],
+    };
+  }
+
+  const decidedAt = input.decidedAt ?? new Date().toISOString();
+  const updatedSteps = workflow.steps.map((candidate, index) =>
+    index === stepIndex
+      ? {
+        ...candidate,
+        status: input.decision,
+        approvedBy: input.approverId,
+        approvedByRole: approverRole,
+        decidedAt,
+        comment: input.comment ?? "",
+      }
+      : candidate
+  );
+  const rejected = input.decision === "rejected";
+  const nextCurrentStepId = rejected ? null : currentStepId(updatedSteps);
+  const nextStatus: ApprovalWorkflowStatus = rejected
+    ? "rejected"
+    : nextCurrentStepId === null
+    ? "approved"
+    : "pending";
+  const nextTransactionStatus = nextStatus === "approved"
+    ? "approval_completed"
+    : nextStatus === "rejected"
+    ? "approval_rejected"
+    : "held_for_approval";
+  const auditEvent = {
+    event: `step_${input.decision}`,
+    step_id: step.id,
+    actor_id: input.approverId,
+    approver_role: approverRole,
+    comment: input.comment ?? "",
+    at: decidedAt,
+  };
+
+  return {
+    accepted: true,
+    error: null,
+    workflow: {
+      ...workflow,
+      status: nextStatus,
+      transactionStatus: nextTransactionStatus,
+      currentStepId: nextCurrentStepId,
+      steps: updatedSteps,
+    },
+    auditEvents: [auditEvent],
+  };
+}

--- a/supabase/functions/_shared/multi_step_approval_workflow_test.ts
+++ b/supabase/functions/_shared/multi_step_approval_workflow_test.ts
@@ -1,0 +1,137 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  applyApprovalStepDecision,
+  buildMultiStepApprovalWorkflow,
+} from "./multi_step_approval_workflow.ts";
+
+Deno.test("multi-step approval is not required for a small discount", () => {
+  const workflow = buildMultiStepApprovalWorkflow({
+    actionType: "discount_apply",
+    amountJpy: 1000,
+    discountPct: 5,
+    requestedByRole: "agent",
+    requestedAt: "2026-06-09T00:00:00Z",
+  });
+
+  assertEquals(workflow.required, false);
+  assertEquals(workflow.status, "not_required");
+  assertEquals(workflow.transactionStatus, "approval_not_required");
+  assertEquals(workflow.steps, []);
+  assertEquals(workflow.notificationEvent, null);
+});
+
+Deno.test("multi-step approval holds large discounts for manager and finance", () => {
+  const workflow = buildMultiStepApprovalWorkflow({
+    actionType: "discount_apply",
+    amountJpy: 8000,
+    discountPct: 25,
+    requestedByRole: "agent",
+    requestedAt: "2026-06-09T00:00:00Z",
+  });
+
+  assertEquals(workflow.required, true);
+  assertEquals(workflow.status, "pending");
+  assertEquals(workflow.transactionStatus, "held_for_approval");
+  assertEquals(workflow.currentStepId, "manager_review");
+  assertEquals(workflow.steps.map((step) => step.id), [
+    "manager_review",
+    "finance_review",
+  ]);
+  assertEquals(workflow.notificationEvent?.channel, "admin_approval_requests");
+  assertEquals(workflow.notificationEvent?.severity, "high");
+});
+
+Deno.test("free offers require manager finance legal and ceo approval", () => {
+  const workflow = buildMultiStepApprovalWorkflow({
+    actionType: "free_offer",
+    amountJpy: 50000,
+    discountPct: 100,
+    freeOffer: true,
+  });
+
+  assertEquals(workflow.steps.map((step) => step.id), [
+    "manager_review",
+    "finance_review",
+    "legal_review",
+    "ceo_approval",
+  ]);
+  assertEquals(workflow.notificationEvent?.severity, "critical");
+});
+
+Deno.test("approval decisions must follow step order and allowed roles", () => {
+  const workflow = buildMultiStepApprovalWorkflow({
+    actionType: "discount_apply",
+    amountJpy: 8000,
+    discountPct: 25,
+  });
+
+  const outOfOrder = applyApprovalStepDecision(workflow, {
+    stepId: "finance_review",
+    decision: "approved",
+    approverRole: "cfo",
+    approverId: "user-cfo",
+    decidedAt: "2026-06-09T00:05:00Z",
+  });
+  assertEquals(outOfOrder.accepted, false);
+  assertEquals(outOfOrder.error, "approval_step_out_of_order");
+
+  const wrongRole = applyApprovalStepDecision(workflow, {
+    decision: "approved",
+    approverRole: "cfo",
+    approverId: "user-cfo",
+    decidedAt: "2026-06-09T00:05:00Z",
+  });
+  assertEquals(wrongRole.accepted, false);
+  assertEquals(wrongRole.error, "approver_role_not_allowed_for_step");
+});
+
+Deno.test("approval workflow advances and completes with audit events", () => {
+  const workflow = buildMultiStepApprovalWorkflow({
+    actionType: "discount_apply",
+    amountJpy: 8000,
+    discountPct: 25,
+  });
+
+  const manager = applyApprovalStepDecision(workflow, {
+    decision: "approved",
+    approverRole: "manager",
+    approverId: "user-manager",
+    decidedAt: "2026-06-09T00:05:00Z",
+  });
+  assertEquals(manager.accepted, true);
+  assertEquals(manager.workflow.status, "pending");
+  assertEquals(manager.workflow.currentStepId, "finance_review");
+  assertEquals(manager.auditEvents[0].event, "step_approved");
+
+  const finance = applyApprovalStepDecision(manager.workflow, {
+    decision: "approved",
+    approverRole: "cfo",
+    approverId: "user-cfo",
+    decidedAt: "2026-06-09T00:10:00Z",
+  });
+  assertEquals(finance.accepted, true);
+  assertEquals(finance.workflow.status, "approved");
+  assertEquals(finance.workflow.transactionStatus, "approval_completed");
+  assertEquals(finance.workflow.currentStepId, null);
+});
+
+Deno.test("approval workflow rejection ends the held transaction", () => {
+  const workflow = buildMultiStepApprovalWorkflow({
+    actionType: "privilege_grant",
+    privilegeGrant: true,
+  });
+
+  const rejection = applyApprovalStepDecision(workflow, {
+    decision: "rejected",
+    approverRole: "manager",
+    approverId: "user-manager",
+    comment: "Not enough justification.",
+    decidedAt: "2026-06-09T00:05:00Z",
+  });
+
+  assertEquals(rejection.accepted, true);
+  assertEquals(rejection.workflow.status, "rejected");
+  assertEquals(rejection.workflow.transactionStatus, "approval_rejected");
+  assertEquals(rejection.workflow.currentStepId, null);
+  assertEquals(rejection.auditEvents[0].comment, "Not enough justification.");
+});

--- a/supabase/functions/social-commerce-hub/index.ts
+++ b/supabase/functions/social-commerce-hub/index.ts
@@ -11,6 +11,11 @@
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
+import {
+  applyApprovalStepDecision,
+  buildMultiStepApprovalWorkflow,
+  MultiStepApprovalWorkflow,
+} from "../_shared/multi_step_approval_workflow.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -110,6 +115,18 @@ function readAuditEvents(
       event !== null && typeof event === "object" && !Array.isArray(event)
     )
     : [];
+}
+
+function readApprovalWorkflow(
+  metadata: Record<string, unknown>,
+): MultiStepApprovalWorkflow | null {
+  const workflow = metadata.approval_workflow;
+  if (
+    workflow === null || typeof workflow !== "object" || Array.isArray(workflow)
+  ) {
+    return null;
+  }
+  return workflow as MultiStepApprovalWorkflow;
 }
 
 function evaluateDiscountHold(body: Record<string, unknown>) {
@@ -430,8 +447,30 @@ serve(async (req) => {
       case "discount_approval.request": {
         const now = new Date().toISOString();
         const gate = evaluateDiscountHold(body);
-        const status = gate.approvalRequired ? "pending" : "not_required";
-        const transactionStatus = gate.approvalRequired
+        const privilegeGrant = body.privilege_grant === true ||
+          body.special_privilege === true;
+        const actionType = privilegeGrant
+          ? "privilege_grant"
+          : gate.freeOffer
+          ? "free_offer"
+          : "discount_apply";
+        const workflow = buildMultiStepApprovalWorkflow({
+          actionType,
+          amountJpy: gate.discountAmount,
+          discountPct: gate.discountPct,
+          freeOffer: gate.freeOffer,
+          privilegeGrant,
+          requestedByRole: String(
+            body.requested_by_actor ?? body.actor_role ?? "system",
+          ),
+          requestedAt: now,
+        });
+        const approvalReasons = [
+          ...gate.reasons,
+          ...(privilegeGrant ? ["privilege_grant"] : []),
+        ];
+        const status = workflow.status;
+        const transactionStatus = workflow.required
           ? "held_for_approval"
           : "discount_clear";
         const item = await addItem(admin, DISCOUNT_APPROVAL_SOURCE, userId, {
@@ -450,26 +489,34 @@ serve(async (req) => {
           free_offer: gate.freeOffer,
           approval_threshold_pct: gate.thresholdPct,
           approval_amount_threshold: gate.amountThreshold,
-          approval_required: gate.approvalRequired,
-          approval_reasons: gate.reasons,
+          approval_required: workflow.required,
+          approval_reasons: approvalReasons,
+          approval_workflow: workflow,
+          current_approval_step: workflow.currentStepId,
+          approval_notification_event: workflow.notificationEvent,
           status,
           transaction_status: transactionStatus,
-          user_message: gate.approvalRequired
+          user_message: workflow.required
             ? "割引適用は管理者承認待ちです。承認後に処理を再開します。"
             : "この割引は承認不要の範囲です。",
-          audit_events: [{
-            event: "requested",
-            actor_id: userId,
-            at: now,
-            approval_required: gate.approvalRequired,
-            reasons: gate.reasons,
-          }],
+          audit_events: [
+            {
+              event: "requested",
+              actor_id: userId,
+              at: now,
+              approval_required: workflow.required,
+              reasons: approvalReasons,
+            },
+            ...workflow.auditEvents,
+          ],
         });
         return json({
           success: true,
-          approval_required: gate.approvalRequired,
+          approval_required: workflow.required,
           status,
           transaction_status: transactionStatus,
+          approval_workflow: workflow,
+          notification_event: workflow.notificationEvent,
           request: item,
         });
       }
@@ -539,28 +586,76 @@ serve(async (req) => {
         const now = new Date().toISOString();
         const metadata = (current.metadata ?? {}) as Record<string, unknown>;
         const auditEvents = readAuditEvents(metadata);
-        const nextMetadata = {
-          ...metadata,
-          status: decision,
-          transaction_status: decision === "approved"
-            ? "discount_approved"
-            : "discount_rejected",
-          decision,
-          decision_comment: body.comment ?? "",
-          decided_by: userId,
-          decided_by_role: approverRole,
-          decided_at: now,
-          audit_events: [
-            ...auditEvents,
-            {
-              event: decision,
-              actor_id: userId,
-              approver_role: approverRole,
-              comment: body.comment ?? "",
-              at: now,
-            },
-          ],
-        };
+        const approvalWorkflow = readApprovalWorkflow(metadata);
+        let nextMetadata: Record<string, unknown>;
+        if (approvalWorkflow) {
+          const stepResult = applyApprovalStepDecision(approvalWorkflow, {
+            decision: decision as "approved" | "rejected",
+            approverRole,
+            approverId: userId,
+            stepId: String(body.step_id ?? "") || null,
+            comment: String(body.comment ?? ""),
+            decidedAt: now,
+          });
+          if (!stepResult.accepted) {
+            return json({
+              success: false,
+              error: stepResult.error,
+              approval_workflow: stepResult.workflow,
+            }, 403);
+          }
+          const workflowDecision = stepResult.workflow.status === "approved"
+            ? "approved"
+            : stepResult.workflow.status === "rejected"
+            ? "rejected"
+            : "pending";
+          nextMetadata = {
+            ...metadata,
+            status: stepResult.workflow.status,
+            transaction_status: stepResult.workflow.transactionStatus,
+            decision: workflowDecision,
+            decision_comment: body.comment ?? "",
+            decided_by: stepResult.workflow.status === "pending"
+              ? null
+              : userId,
+            decided_by_role: stepResult.workflow.status === "pending"
+              ? null
+              : approverRole,
+            decided_at: stepResult.workflow.status === "pending" ? null : now,
+            last_decision_by: userId,
+            last_decision_by_role: approverRole,
+            last_decision_at: now,
+            approval_workflow: stepResult.workflow,
+            current_approval_step: stepResult.workflow.currentStepId,
+            audit_events: [
+              ...auditEvents,
+              ...stepResult.auditEvents,
+            ],
+          };
+        } else {
+          nextMetadata = {
+            ...metadata,
+            status: decision,
+            transaction_status: decision === "approved"
+              ? "discount_approved"
+              : "discount_rejected",
+            decision,
+            decision_comment: body.comment ?? "",
+            decided_by: userId,
+            decided_by_role: approverRole,
+            decided_at: now,
+            audit_events: [
+              ...auditEvents,
+              {
+                event: decision,
+                actor_id: userId,
+                approver_role: approverRole,
+                comment: body.comment ?? "",
+                at: now,
+              },
+            ],
+          };
+        }
         const { data: updated, error: updateErr } = await admin.from("hub_data")
           .update({ metadata: nextMetadata })
           .eq("id", id)
@@ -568,7 +663,12 @@ serve(async (req) => {
           .select("id, metadata, created_at")
           .single();
         if (updateErr) throw new Error(updateErr.message);
-        return json({ success: true, approval: updated });
+        return json({
+          success: true,
+          approval: updated,
+          approval_workflow: nextMetadata.approval_workflow ?? null,
+          current_approval_step: nextMetadata.current_approval_step ?? null,
+        });
       }
       case "discount_approval.audit": {
         const id = String(body.id ?? "");


### PR DESCRIPTION
## 概要 (Closes #2919)

割引適用・特別権限付与・無料オファー時の**多段承認ワークフロー**を `social-commerce-hub` Edge Function に実装。AI エージェントによる高リスクアクションを deny-by-default で承認ゲートに通す。

## 実装

| File | 内容 |
|------|------|
| `supabase/functions/_shared/multi_step_approval_workflow.ts` | 純粋関数モジュール (320L)。`buildMultiStepApprovalWorkflow` + `applyApprovalStepDecision` |
| `supabase/functions/_shared/multi_step_approval_workflow_test.ts` | deno test 6 ケース |
| `supabase/functions/social-commerce-hub/index.ts` | `discount_approval.request` / `.decision` への配線 + 後方互換フォールバック |
| `docs/AGENT_TOOL_POLICY.md` | ポリシー追記 |

### 承認ステップ (条件で段数が決まる)

- **Manager review** — 割引 ≥20% / 金額 ≥¥5,000 / 無料オファー / 権限付与
- **Finance review** — 割引 ≥20% / 金額 ≥¥5,000 / 無料オファー
- **Legal review** — 無料オファー / 権限付与
- **CEO approval** — 割引 ≥50% / 無料オファー / 権限付与

トランザクションは全ステップ通過まで `held_for_approval`。各決定は監査イベントを追記し、`admin_approval_requests` 通知イベントを発行。ステップ順序・許可ロールを検証 (out-of-order / wrong-role は 403)。

### 後方互換

`approval_workflow` を持たない既存リクエストは従来の単段 decision パスにフォールバック (`else` 分岐)。既存データ破壊なし。

## 検証

```
deno test  supabase/functions/_shared/multi_step_approval_workflow_test.ts  → 6 passed | 0 failed
deno lint  (workflow + test + index.ts)                                     → clean
deno check supabase/functions/social-commerce-hub/index.ts                  → clean
```

## Philosophy Alignment

- **[AI-DEV-23]** deny-by-default + 承認ゲート + 監査ログ (trace 可能な audit_events) → 4/7 直接該当 ✅
- **[MCP-AUTH-27]** 高リスク AI アクションを明示スコープ + approval gate に通す deny-by-default 設計 ✅
- **[PHILOSOPHY-22]** 原則 4 (mentor: 人間承認を介在) + 原則 8 (KPI: 監査可能性)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
