### PR TITLE
ci: dependabot に composite action 監視を追加 — Node 20 取り残し再発防止 (cache v4→v5 は #3202 先行)

### DIFF
--- a/.github/actions/setup-flutter-sdk/action.yml
+++ b/.github/actions/setup-flutter-sdk/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "flutter-root=${RUNNER_TEMP}/flutter-${ref}" >> "$GITHUB_OUTPUT"
 
     - name: Cache Flutter SDK
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.resolve.outputs.flutter-root }}
         key: flutter-sdk-${{ runner.os }}-${{ steps.resolve.outputs.ref }}-v1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # "/" は .github/workflows のみ対象。composite action は明示列挙が必要
+    # (actions/cache@v4 が Node 20 deprecation まで放置された根本原因)
+    directories:
+      - "/"
+      - "/.github/actions/setup-flutter-sdk"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
> **⚠️ スコープ更新 (2026-06-10 22:4x JST)**: 本 PR 起票とほぼ同時刻に並行セッション (part 264) が同一の cache v4→v5 修正を [#3202](https://github.com/kanta13jp1/my_web_app/pull/3202) で先行 merge (13:35 UTC)。本 PR の `action.yml` 変更は main と同一内容のため実質 no-op となり、**残スコープ = dependabot の composite action 監視追加 (再発防止) のみ**。update-branch 済みで Files 表示は `dependabot.yml` 1 ファイル。

## 概要

GitHub Actions が **2026-06-16 から Node.js 20 action を強制的に Node.js 24 で実行** (2026-09-16 に Node 20 はランナーから削除) する変更への対応 — の**再発防止レイヤー**。

deploy-prod.yml run [27277677955](https://github.com/kanta13jp1/my_web_app/actions/runs/27277677955) (2026-06-10) の annotation:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20: actions/cache@v4.

発生源は composite action `.github/actions/setup-flutter-sdk/action.yml` 内の `actions/cache@v4`。**workflows 直下は dependabot が checkout@v6 / cache@v5 (ci.yml) 等へ bump 済みだったのに composite action だけ v4 で取り残された** — 原因は dependabot の github-actions ecosystem が `directory: "/"` 指定だと `.github/workflows/` しか見ず、`.github/actions/` 配下が監視外だったこと。

## 監査結果 (`.github/workflows/` + `.github/actions/` 全 grep + 公式 repo runtime 確認)

| Action | runtime | 判定 |
|---|---|---|
| actions/cache@v4 (setup-flutter-sdk 内) | node20 | ✅ [#3202](https://github.com/kanta13jp1/my_web_app/pull/3202) で v5 へ bump 済 (merged 13:35 UTC) |
| actions/cache@v5 (ci.yml:65) | node24 | ✅ |
| checkout@v6 / setup-node@v6 / setup-python@v6 / setup-java@v5 / upload-artifact@v7 / download-artifact@v7,v8 / github-script@v9 | node24 | ✅ |
| denoland/setup-deno@v2 / softprops/action-gh-release@v3 / slackapi/slack-github-action@v3.0.3 / hashicorp/setup-terraform@v4 | node24 | ✅ |
| subosito/flutter-action@v2 / supabase/setup-cli@v2 | composite (nested node20 なし) | ✅ |

公式 [actions/cache releases](https://github.com/actions/cache/releases): v4 系に Node 24 patch なし / v5.0.0 (2025-12-11) 以降が node24 (最新 v5.0.5)。

**動作実証 (per-要素 verify)**: 本 PR の CI run [27279882368](https://github.com/kanta13jp1/my_web_app/actions/runs/27279882368) は cache@v5 構成の setup-flutter-sdk で `Lint, Format, and Test` 6m17s green + **Node.js 20 annotation 0 件** (修正前 run は同 job で 1 件)。

## 変更内容 (本 PR の実 diff = 1 ファイル)

- `.github/dependabot.yml` — github-actions ecosystem を `directory: "/"` → `directories: ["/", "/.github/actions/setup-flutter-sdk"]` へ。composite action を dependabot 監視下に入れ、次の major deprecation (cache v6 等) での同種取り残しを自動検出可能にする。

(コミット履歴上の `action.yml` v4→v5 は #3202 と同一内容のため merge で no-op。)

## 既存 Issue との関係

- [#3175](https://github.com/kanta13jp1/my_web_app/issues/3175) (ci-cd-cost-audit): 提案 3 が cache@v4 追加の出所。cache 戦略は有効なので維持し version のみ更新済 (#3202)。本 PR は監視ギャップを閉じる補完。コメント済み。
- [#1508](https://github.com/kanta13jp1/my_web_app/issues/1508) (CLOSED): 過去の Node 20 一掃。今回は composite action 内の新規 regression だった。

## Minimal E2E Gate

- 本 PR は dependabot 設定のみの変更で、Flutter アプリコードに変更なし → `no-e2e-needed` ラベル付与。
- 検証は実装詳細に依存しない入出力 (dependabot の PR 生成挙動 / workflow 成否) で確認する。最小限の 3ケース:
  1. dependabot.yml が schema valid (GitHub が次回 weekly run で parse 成功)
  2. 次回 monday 09:00 JST の dependabot run で `.github/actions/setup-flutter-sdk` がスキャン対象に含まれる
  3. 既存 workflows 直下の監視 (`"/"`) が従来どおり機能する
- e2e (Playwright / flutter integration test / integration_test) はアプリ挙動に変更がないため対象外。

## High-risk gate

- レビュー owner: Claude Code #1
- high-risk-ultrareview-exception: dependabot 設定 1 ファイルの監視範囲追加のみで、アプリ/deploy 実行ロジックに変更なし。`directories` キーは dependabot v2 の GA 構文で、失敗しても dependabot run が skip されるだけで CI/deploy を阻害しないため ultrareview 省略。

## 期限

GitHub の強制移行 2026-06-16 より前対応: 実体 fix は #3202 で着地済み。本 PR (再発防止) も同日 merge。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
