### PR TITLE
ci: Setup Deno retry+backoff で deno.land 一時503による deploy-prod fail を恒久解消 + WBS保守タスク追加+完了 (part 266)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,28 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL https://deno.land/install.sh | sh
+          # deno.land は一時的な 5xx を返すことがあり、素の curl|sh だと main の
+          # deploy-prod ごと fail する (2026-06-10 run 27293741687 = 503 → exit 22 /
+          # Issue #3215)。deploy-prod.yml の deploy_function と同じ retry+backoff
+          # idiom で吸収する。一時ファイル経由にする理由: stdout パイプ直結だと
+          # curl --retry が rewind できず、切断時に途中までのスクリプトが sh に
+          # 流れる危険があるため。installer 内部の DL 失敗は外側 loop が拾う。
+          # 持続障害 (3 回 fail) は rerun に委ねる。
+          installer="$(mktemp)"
+          trap 'rm -f "$installer"' EXIT
+          for attempt in 1 2 3; do
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+                 -o "$installer" https://deno.land/install.sh \
+               && sh "$installer"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Deno install failed after ${attempt} attempts (deno.land transient error)"
+              exit 1
+            fi
+            echo "::warning::Deno install attempt ${attempt} failed; retrying in $((attempt * 20))s"
+            sleep $((attempt * 20))
+          done
           echo "$HOME/.deno/bin" >> "$GITHUB_PATH"
           "$HOME/.deno/bin/deno" --version
 

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -32309,3 +32309,24 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 - Philosophy Alignment: 原則 4 (mentor = 週次ノイズ源の根絶を先回り) / 6 (資本=時間: 毎週の workflow-failure triage コスト削減) / 7 (壊れ bump の放置 = 負債) / 8 (CI 健全性 KPI) / 9 (無人 dependabot 運用の信頼性)。7+/9 ✅。
 - commit hash: (PR merge 後に追記 / part 264 = 7773200e4)。
 ---
+
+### 2026-06-11 Win版#132 part 266 — CI Setup Deno の deno.land 一時503耐性化 (retry+backoff / 保守 WBS 追加→同一セッション完了 第 3 例)
+
+**Summary**:
+- user 標準プロンプト再起動 (part 265 終了 02:40 JST の直後 / 02:50 JST)。session-start fetch 儀式 (part 265 教訓) 適用後、**新規流入 Issue #3215 ([workflow-failure] Deploy to Production (main) deno-lint)** を triage — part 265 で確立した「補充源 = 新規 workflow-failure Issue 流入」の第 2 連続発火。
+- **誤分類を実ログで是正**: handler の「deno-lint」分類に対し、run 27293741687 (part 265 merge commit `407cdc9e4`) の job 80620889988 log 確証 = `curl: (22) The requested URL returned error: 503` → 真因は ci.yml「Setup Deno」の素の `curl -fsSL https://deno.land/install.sh | sh` が deno.land 一時 503 で fail (lint エラー不在 / 直前 commit `da667bc5d` の deploy は success)。reusable ci.yml fail → deploy job skip → **part 265 の WBS migration 本番未適用が滞留**、まで波及確認。
+- **2 段対応**: ① 即時復旧 = `gh run rerun 27293741687 --failed` (一時障害仮説の検証込み / green 化で handler recovery rule が #3215 自動 close + part 265 migration 適用回復) ② 恒久対応 = Setup Deno へ retry+backoff (3 attempts / 20s,40s / curl --retry 併用)。installer を一時ファイル経由に変更し、stdout パイプ直結で curl --retry が rewind 不能 → truncated script が sh に流れる潜在ハザードも同時解消。
+- **公式 docs verify-first**: 代替案 denoland/setup-deno@v2 の action.yml (main) で `runs.using: node24` を確認 (part 264 の Node20 廃止 sweep と矛盾しない) — ただし真因 (一時 503) には retry が strict superset の最小修正であり、deploy lane への新規依存追加を避けて defer (月 2 回以上再発で L2 移行検討 / WBS remaining_work に正本化)。
+
+**Changes**:
+- `.github/workflows/ci.yml` — Setup Deno step に retry+backoff loop (deploy-prod.yml `deploy_function` と同一 repo idiom) + 一時ファイル経由インストール。
+- migration `20260611030000_wbs_add_complete_ci_deno_retry.sql` — 保守 WBS タスク INSERT (completed / win / インフラ・CI/CD / alpha) + development_achievements (idempotent)。症状チケット #3215 は handler recovery rule 管理のため WBS 化せず (part 265 委譲準拠)。
+- ROADMAP part 266 エントリ (本欄 / part 265 merge hash `407cdc9e4` 補記)。
+
+**Validation focus**:
+- 「耐性化」の範囲: 一時障害 (数十秒〜分オーダー) は CI 内で自己回復 / 持続障害 (3 attempts 超) は fail して rerun に委ねる — 無限 retry で障害を隠蔽しない。
+- SDLC 7 工程 gap 監査: part 254 方法論 + part 265 結論を再確認 — 全工程 open 実在 / 今回の不足 = 保守工程の本タスク 1 件 (追加→同一セッション完了)。stale docs 棚卸しは part 265 (<24h 前) の「削除 0 件が正答」維持。
+- 両 gate push 前 local script 確証 + no-e2e-needed label + close+reopen 先制 (recipe 第 22 連続狙い / .github+migration+docs = 非 app-code)。
+- Philosophy Alignment: 原則 4 (mentor = deploy lane の単一 flaky 依存を先回り根絶) / 6 (資本=時間: 503 一発で rerun 人手対応するコストの削減) / 7 (deploy skip = migration 滞留という隠れ負債の検出と回復) / 8 (deploy-prod 成功率100%維持 KPI) / 9 (無人 main push 運用の信頼性)。7+/9 ✅。
+- commit hash: (PR merge 後に追記 / part 265 = 407cdc9e4)。
+---

--- a/supabase/migrations/20260611030000_wbs_add_complete_ci_deno_retry.sql
+++ b/supabase/migrations/20260611030000_wbs_add_complete_ci_deno_retry.sql
@@ -1,0 +1,66 @@
+-- Win版#132 part 266 (2026-06-11 / Win Claude): Add + Complete WBS 保守タスク
+-- 「CI Setup Deno の deno.land 一時503耐性化 (retry+backoff)」
+--
+-- 背景 (= workflow-failure Issue #3215 / 2026-06-11 02:30 JST 検出):
+--   main への push (part 265 merge commit 407cdc9e4) で deploy-prod が fail。
+--   workflow-failure-handler の分類は「deno-lint」だったが誤分類で、実ログ
+--   (run 27293741687 / job 80620889988) の確証は
+--     curl: (22) The requested URL returned error: 503
+--   = ci.yml「Setup Deno」step の `curl -fsSL https://deno.land/install.sh | sh`
+--   が deno.land の一時 503 で fail → reusable ci.yml の Lint, Format, and Test
+--   ごと fail → deploy job skip。lint エラーは一切発生していない。
+--   副作用: deploy job skip により part 265 の WBS migration (20260611021500) が
+--   本番 DB 未適用のまま滞留 (失敗 run の rerun で回復)。
+--
+-- 対応 (2 段):
+--   1. 即時復旧 = `gh run rerun 27293741687 --failed` (同 commit / 一時障害仮説の検証込み)。
+--      green 化で handler の recovery rule により Issue #3215 は自動 close。
+--   2. 恒久対応 = ci.yml Setup Deno へ retry+backoff (3 attempts / 20s,40s) を追加。
+--      deploy-prod.yml の deploy_function と同じ repo 既存 idiom。installer は
+--      一時ファイル経由に変更 (stdout パイプ直結だと curl --retry が rewind 不能で、
+--      切断時に truncated script が sh へ流れるハザードがあるため)。
+--
+-- 代替案 (検討の上 defer): denoland/setup-deno@v2 公式 action への移行。
+--   action.yml (main) で runs.using = node24 を verify 済 (2026-06-11 / Node20
+--   廃止問題なし) + deno-version pin / cache / tool-cache retry 内蔵。ただし
+--   インストール機構の置換は deploy lane への新規依存追加であり、今回の真因
+--   (一時 503) には retry が strict superset の最小修正のため defer。月 2 回以上
+--   再発するなら L2 で移行を検討 (remaining_work に正本化)。
+--
+-- WBS 取り扱い: user 標準指示「企画〜保守の全工程で不足タスクをゼロに (不足があれば追加)」
+--   に基づき、保守工程の恒久対応タスクとして追加し、同一セッション内で完了 (part 264 型
+--   第 3 例)。症状チケット #3215 は workflow-failure handler 管理 (recovery rule で
+--   自動 close) のため本 migration では WBS 化しない (part 265 の Issue close 委譲準拠)。
+--
+-- Idempotent: INSERT は NOT EXISTS (title) guard / achievement も NOT EXISTS guard。
+
+INSERT INTO public.wbs_tasks
+  (category, category_icon, category_order, title, description, instance, owner_instance,
+   status, progress, start_date, end_date, milestone_code, priority,
+   ai_review_status, ai_review_notes, ai_reviewed_at, remaining_work, stale_threshold_hours)
+SELECT
+  'インフラ・CI/CD', '⚙️', 1,
+  '[保守] CI Setup Deno の deno.land 一時503耐性化 (retry+backoff)',
+  'ci.yml「Setup Deno」が deno.land インストーラを素の curl|sh で取得しており、deno.land の一時 503 で main の deploy-prod ごと fail した (2026-06-10 17:30 UTC run 27293741687 / Issue #3215 / 実ログ確証 = curl: (22) The requested URL returned error: 503)。handler の deno-lint 分類は誤分類で lint エラーは不在。恒久対応として retry+backoff (3 attempts / 20s,40s / curl --retry 併用 / 一時ファイル経由で truncated-script ハザードも解消) を追加 — deploy-prod.yml の deploy_function と同じ repo 既存 idiom。即時復旧は failed jobs rerun (同 commit) で実施し、green 化により part 265 migration の本番適用も回復。Done 2026-06-11 (Win Claude part 266): SDLC 保守工程の不足タスクとして追加し、同一セッションで完了。',
+  'win', 'win',
+  'completed', 100, DATE '2026-06-11', DATE '2026-06-11', 'alpha', 'high',
+  'approved',
+  'Win Claude (L3 / part 266) self-authored maintenance. 根拠 = job 80620889988 log の curl exit 22 (HTTP 503) 全文 + deploy-prod run 履歴 (直前 da667bc5d は success = コード起因でない)。denoland/setup-deno@v2 代替は action.yml で node24 確認の上、最小修正原則 (deploy lane へ新規依存を足さない) で defer。',
+  now(),
+  'Completed by Win Claude (part 266). ci.yml retry 追加済 + run 27293741687 rerun 実施。followup: deno.land 起因の Setup Deno fail が月 2 回以上再発する場合は denoland/setup-deno@v2 (node24 / deno-version 2.x pin / cache 内蔵) への移行を L2 lane で検討。',
+  24
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.wbs_tasks
+  WHERE title = '[保守] CI Setup Deno の deno.land 一時503耐性化 (retry+backoff)'
+);
+
+-- 開発実績ログ (development_achievements ページ反映 / 重複防止 = NOT EXISTS guard)
+INSERT INTO public.development_achievements (title, description, completed_at)
+SELECT
+  'CI Setup Deno の deno.land 一時503耐性化 (retry+backoff)',
+  'main push の deploy-prod が deno.land の一時 503 (curl exit 22) で fail し本番デプロイ + migration 適用が滞留する問題 (2026-06-10 run 27293741687 / Issue #3215) を恒久解消。workflow-failure handler の「deno-lint」誤分類を実ログで是正し、ci.yml Setup Deno へ deploy_function と同一 idiom の retry+backoff を追加 (一時ファイル経由化で curl|sh の truncated-script ハザードも解消)。SDLC 保守工程の不足タスクを WBS へ追加→同一セッション完了の第 3 例。',
+  now()
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.development_achievements
+  WHERE title = 'CI Setup Deno の deno.land 一時503耐性化 (retry+backoff)'
+);


### PR DESCRIPTION
## 概要 (Win版#132 part 266)  main push (part 265 merge `407cdc9e4`) の deploy-prod fail = Issue #3215 の root-cause 対応。  ## Root cause (handler 分類「deno-lint」は誤分類)  - 実ログ確証 (run [27293741687](https://github.com/kanta13jp1/my_web_app/actions/runs/27293741687) / job 80620889988): `curl: (22) The requested URL returned error: 503` - ci.yml「Setup Deno」の素の `curl -fsSL https://deno.land/install.sh | sh` が deno.land の一時 503 で fail → reusable CI (Lint, Format, and Test) fail → deploy job skip。lint エラーは不在 (直前 commit `da667bc5d` の deploy は success = コード起因でない) - 副作用: part 265 の WBS migration (`20260611021500`) が本番未適用のまま滞留 (deploy job skip のため)  ## 対応 (2 段)  1. **即時復旧**: `gh run rerun 27293741687 --failed` 実施済み — green 化で workflow-failure handler の recovery rule が #3215 を自動 close し、part 265 migration の適用も回復 2. **恒久対応 (本 PR)**: Setup Deno へ retry+backoff (3 attempts / 20s,40s / `curl --retry 3 --retry-all-errors` 併用)。installer を一時ファイル経由に変更 — stdout パイプ直結だと `curl --retry` が rewind 不能で、切断時に truncated script が sh へ流れる潜在ハザードも同時解消。deploy-prod.yml `deploy_function` と同一の repo 既存 retry idiom。持続障害は 3 回で fail し rerun に委ねる (無限 retry で障害を隠蔽しない)  ## 代替案 (公式 docs verify の上 defer)  denoland/setup-deno@v2 公式 action — action.yml (main) で `runs.using: node24` を verify 済み (2026-06-11 / part 264 の Node20 廃止 sweep と矛盾なし) + deno-version pin / cache 内蔵。ただし今回の真因 (一時 503) には retry が strict superset の最小修正であり、deploy lane への新規依存追加を避けて defer。月 2 回以上再発で L2 移行検討 (WBS remaining_work に正本化済み)。  ## WBS / SDLC  - migration `20260611030000_wbs_add_complete_ci_deno_retry.sql`: 保守工程の不足タスクを追加 + 同一セッション completed (part 264 型第 3 例 / idempotent NOT EXISTS guard) - 症状チケット #3215 は handler recovery rule 管理のため WBS 化せず (part 265 委譲準拠) - SDLC 7 工程 gap 監査: part 254 方法論で再確認 — 全工程 open 実在 / 今回の不足 = 本保守タスク 1 件のみ  ## Minimal E2E Gate  - 変更は `.github/workflows/` + `supabase/migrations/` + `docs/` のみ = app-code 非該当 (lib/ / supabase/functions/ 変更なし) - E2E 方針: 検証は実装詳細に依存しない black-box の入出力 (I/O) 確認で、最小限の 3ケース — ① 本 PR の CI が Setup Deno を通過し green ② merge 後 main の deploy-prod green ③ rerun green により #3215 auto-close。Playwright スイートや integration_test への追加は不要 - Minimal E2E Exception: workflow + migration + docs のみの変更で UI 挙動変化が一切ないため、新規 E2E ファイル追加は不要 - label: `no-e2e-needed` (close+reopen で event payload へ反映)  🤖 Generated with [Claude Code](https://claude.com/claude-code)  
## High-risk Ultrareview Gate

- Review owner: Claude Code #1.
- high-risk-ultrareview-exception: workflow retry hardening plus idempotent WBS migration only; Claude Code #1 triaged the transient deno.land 503 failure, and formal ultrareview is deferred because this is a minimal deploy-unblocker patch with no auth, secret, Edge Function, or app-code behavior change. 
