### PR TITLE
feat: add Discord secondary fallback notifications

### DIFF
--- a/docs/DISCORD_SECONDARY_WEBHOOK.md
+++ b/docs/DISCORD_SECONDARY_WEBHOOK.md
@@ -1,0 +1,46 @@
+# Discord Secondary Webhook
+
+Issue #1035 adds Discord as an optional secondary notification channel for the
+multi-AI fallback workflow. Slack remains the primary notification path.
+
+## Secret
+
+Set the Supabase Edge Function secret:
+
+```bash
+supabase secrets set DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+```
+
+## Mirror a Slack Notification
+
+Use the existing `core-hub` `slack.notify` action and opt in per payload:
+
+```json
+{
+  "action": "slack.notify",
+  "channel": "quota",
+  "text": "AI fallback quota alert",
+  "discord_secondary": true
+}
+```
+
+`discordSecondary: true`, `discord_backup: true`, and `discordBackup: true` are
+also accepted.
+
+If `DISCORD_WEBHOOK_URL` is missing or Discord returns an error, the Slack
+notification path still keeps its original success/failure behavior. The Discord
+result is included in the JSON response as `discord`.
+
+## Direct Smoke Test
+
+To send a test payload directly from the Edge Function path:
+
+```json
+{
+  "action": "discord.notify",
+  "text": "Discord fallback notification test"
+}
+```
+
+When the secret is missing, `discord.notify` returns a skipped result instead of
+failing deployment or Slack notification flows.

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -7,6 +7,10 @@ import {
   type MemoReactionAction,
 } from "./memo_reactions.ts";
 import {
+  sendDiscordWebhook,
+  wantsDiscordSecondary,
+} from "./notification_channels.ts";
+import {
   type ExistingFeatureRequestIssue,
   type FeatureRequestCandidate,
   featureRequestCandidateKey,
@@ -764,6 +768,7 @@ serve(async (req: Request) => {
       "notification.broadcast_release",
       "system.proactive_diagnostics",
       "slack.notify",
+      "discord.notify",
     ]);
     // Anonymous-allowed actions (no auth required / page-specific cache)
     const anonymousActions = new Set(["page.share_generate"]);
@@ -1089,15 +1094,61 @@ serve(async (req: Request) => {
 
         if (!resp.ok) {
           const errBody = await resp.text();
+          const discord = await sendDiscordWebhook({
+            enabled: wantsDiscordSecondary(body),
+            webhookUrl: Deno.env.get("DISCORD_WEBHOOK_URL") ?? "",
+            text: text || `Slack ${channel} notification failed.`,
+            username: body.discord_username ?? body.username,
+            channel,
+          });
           return json({
             error: `slack webhook failed: ${resp.status}`,
             detail: errBody.slice(0, 500),
             channel,
             envKey,
+            discord,
           }, 502);
         }
 
-        return json({ success: true, channel, envKey, status: resp.status });
+        const discord = await sendDiscordWebhook({
+          enabled: wantsDiscordSecondary(body),
+          webhookUrl: Deno.env.get("DISCORD_WEBHOOK_URL") ?? "",
+          text: text || `Slack ${channel} notification mirrored to Discord.`,
+          username: body.discord_username ?? body.username,
+          channel,
+        });
+
+        return json({
+          success: true,
+          channel,
+          envKey,
+          status: resp.status,
+          discord,
+        });
+      }
+
+      case "discord.notify": {
+        const text = typeof body.text === "string"
+          ? body.text.trim()
+          : typeof body.message === "string"
+          ? body.message.trim()
+          : "";
+        if (!text) {
+          return json({ error: "text or message required" }, 400);
+        }
+
+        const discord = await sendDiscordWebhook({
+          enabled: true,
+          webhookUrl: Deno.env.get("DISCORD_WEBHOOK_URL") ?? "",
+          text,
+          username: body.discord_username ?? body.username,
+          channel: typeof body.channel === "string" ? body.channel : undefined,
+        });
+
+        return json(
+          { success: discord.success, discord },
+          discord.success || discord.skipped ? 200 : 502,
+        );
       }
 
       // ---- User profile ----

--- a/supabase/functions/core-hub/notification_channels.ts
+++ b/supabase/functions/core-hub/notification_channels.ts
@@ -1,0 +1,119 @@
+export type DiscordNotifyResult = {
+  enabled: boolean;
+  configured: boolean;
+  success: boolean;
+  skipped: boolean;
+  status?: number;
+  error?: string;
+  detail?: string;
+};
+
+type Fetcher = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export function wantsDiscordSecondary(body: Record<string, unknown>): boolean {
+  const value = body.discord_secondary ?? body.discordSecondary ??
+    body.discord_backup ?? body.discordBackup;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "1" ||
+      normalized === "discord" || normalized === "secondary";
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => String(item).toLowerCase() === "discord");
+  }
+  return false;
+}
+
+export function buildDiscordWebhookPayload(input: {
+  text: string;
+  username?: unknown;
+  channel?: string;
+}): Record<string, unknown> {
+  const content = input.text.trim().slice(0, 2000) ||
+    "Slack notification mirrored to Discord.";
+  const username = typeof input.username === "string" &&
+      input.username.trim() !== ""
+    ? input.username.trim().slice(0, 80)
+    : "my_web_app fallback";
+  return {
+    content,
+    username,
+    allowed_mentions: { parse: [] },
+    embeds: input.channel
+      ? [{
+        title: "Fallback notification",
+        fields: [{ name: "Slack channel", value: input.channel }],
+      }]
+      : undefined,
+  };
+}
+
+export async function sendDiscordWebhook(input: {
+  enabled: boolean;
+  webhookUrl: string;
+  text: string;
+  username?: unknown;
+  channel?: string;
+  fetcher?: Fetcher;
+}): Promise<DiscordNotifyResult> {
+  if (!input.enabled) {
+    return {
+      enabled: false,
+      configured: false,
+      success: false,
+      skipped: true,
+      error: "discord secondary disabled",
+    };
+  }
+
+  const webhookUrl = input.webhookUrl.trim();
+  if (!webhookUrl) {
+    return {
+      enabled: true,
+      configured: false,
+      success: false,
+      skipped: true,
+      error: "DISCORD_WEBHOOK_URL not configured",
+    };
+  }
+
+  try {
+    const fetcher = input.fetcher ?? fetch;
+    const resp = await fetcher(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildDiscordWebhookPayload(input)),
+    });
+    if (!resp.ok) {
+      const detail = await resp.text();
+      return {
+        enabled: true,
+        configured: true,
+        success: false,
+        skipped: false,
+        status: resp.status,
+        error: `discord webhook failed: ${resp.status}`,
+        detail: detail.slice(0, 500),
+      };
+    }
+    return {
+      enabled: true,
+      configured: true,
+      success: true,
+      skipped: false,
+      status: resp.status,
+    };
+  } catch (error) {
+    return {
+      enabled: true,
+      configured: true,
+      success: false,
+      skipped: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/supabase/functions/core-hub/notification_channels_test.ts
+++ b/supabase/functions/core-hub/notification_channels_test.ts
@@ -1,0 +1,128 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildDiscordWebhookPayload,
+  sendDiscordWebhook,
+  wantsDiscordSecondary,
+} from "./notification_channels.ts";
+
+Deno.test("wantsDiscordSecondary accepts snake and camel case flags", () => {
+  assertEquals(wantsDiscordSecondary({ discord_secondary: true }), true);
+  assertEquals(wantsDiscordSecondary({ discordSecondary: "discord" }), true);
+  assertEquals(wantsDiscordSecondary({ discord_backup: ["discord"] }), true);
+  assertEquals(wantsDiscordSecondary({ discord_secondary: false }), false);
+  assertEquals(wantsDiscordSecondary({}), false);
+});
+
+Deno.test("buildDiscordWebhookPayload removes mentions and bounds content", () => {
+  const payload = buildDiscordWebhookPayload({
+    text: "hello",
+    username: "Fallback Bot",
+    channel: "quota",
+  });
+
+  assertEquals(payload.content, "hello");
+  assertEquals(payload.username, "Fallback Bot");
+  assertEquals(payload.allowed_mentions, { parse: [] });
+  assertEquals(Array.isArray(payload.embeds), true);
+});
+
+Deno.test("sendDiscordWebhook soft-skips when secondary is disabled", async () => {
+  const result = await sendDiscordWebhook({
+    enabled: false,
+    webhookUrl: "https://discord.example/webhook",
+    text: "quota alert",
+    fetcher: () => {
+      throw new Error("fetch should not run");
+    },
+  });
+
+  assertEquals(result, {
+    enabled: false,
+    configured: false,
+    success: false,
+    skipped: true,
+    error: "discord secondary disabled",
+  });
+});
+
+Deno.test("sendDiscordWebhook soft-skips missing secret", async () => {
+  const result = await sendDiscordWebhook({
+    enabled: true,
+    webhookUrl: "",
+    text: "quota alert",
+    fetcher: () => {
+      throw new Error("fetch should not run");
+    },
+  });
+
+  assertEquals(result, {
+    enabled: true,
+    configured: false,
+    success: false,
+    skipped: true,
+    error: "DISCORD_WEBHOOK_URL not configured",
+  });
+});
+
+Deno.test("sendDiscordWebhook posts a Discord payload when configured", async () => {
+  let postedBody = "";
+  const result = await sendDiscordWebhook({
+    enabled: true,
+    webhookUrl: "https://discord.example/webhook",
+    text: "quota alert",
+    username: "Ops",
+    channel: "quota",
+    fetcher: (_url, init) => {
+      postedBody = String(init?.body ?? "");
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    },
+  });
+
+  assertEquals(result, {
+    enabled: true,
+    configured: true,
+    success: true,
+    skipped: false,
+    status: 200,
+  });
+  const payload = JSON.parse(postedBody);
+  assertEquals(payload.content, "quota alert");
+  assertEquals(payload.username, "Ops");
+});
+
+Deno.test("sendDiscordWebhook reports webhook errors without throwing", async () => {
+  const result = await sendDiscordWebhook({
+    enabled: true,
+    webhookUrl: "https://discord.example/webhook",
+    text: "quota alert",
+    fetcher: () =>
+      Promise.resolve(new Response("bad webhook", { status: 500 })),
+  });
+
+  assertEquals(result, {
+    enabled: true,
+    configured: true,
+    success: false,
+    skipped: false,
+    status: 500,
+    error: "discord webhook failed: 500",
+    detail: "bad webhook",
+  });
+});
+
+Deno.test("sendDiscordWebhook catches fetch failures", async () => {
+  const result = await sendDiscordWebhook({
+    enabled: true,
+    webhookUrl: "https://discord.example/webhook",
+    text: "quota alert",
+    fetcher: () => Promise.reject(new Error("network down")),
+  });
+
+  assertEquals(result, {
+    enabled: true,
+    configured: true,
+    success: false,
+    skipped: false,
+    error: "network down",
+  });
+});


### PR DESCRIPTION
﻿## Summary
- Add optional Discord secondary mirroring to `core-hub:slack.notify` via `discord_secondary` / `discordSecondary` flags.
- Add `core-hub:discord.notify` for direct Discord smoke payloads using `DISCORD_WEBHOOK_URL`.
- Soft-skip missing Discord secrets and keep Slack as the primary notification path.
- Document setup and smoke payloads in `docs/DISCORD_SECONDARY_WEBHOOK.md`.

Closes #1035

## Validation
- PASS: `deno fmt --check supabase\functions\core-hub\index.ts supabase\functions\core-hub\notification_channels.ts supabase\functions\core-hub\notification_channels_test.ts docs\DISCORD_SECONDARY_WEBHOOK.md`
- PASS: `deno check --config supabase\functions\deno.json supabase\functions\core-hub\index.ts supabase\functions\core-hub\notification_channels.ts supabase\functions\core-hub\notification_channels_test.ts`
- PASS: `deno lint --config supabase\functions\deno.json supabase\functions\core-hub\index.ts supabase\functions\core-hub\notification_channels.ts supabase\functions\core-hub\notification_channels_test.ts`
- PASS: `deno test --config supabase\functions\deno.json supabase\functions\core-hub\_smoke_test.ts supabase\functions\core-hub\feature_request_dedupe_test.ts supabase\functions\core-hub\notification_channels_test.ts` (14 tests)
- PASS: `python scripts\check_migration_timestamps.py`
- PASS: `git diff --check origin/main...HEAD`

## Minimal E2E Gate
E2E mechanism: implementation-detail independent service-role Edge Function smoke against deployed `core-hub`.
Minimal plan: 1) call `slack.notify` with `discord_secondary: true` and both Slack/Discord secrets configured; 2) call `slack.notify` with Discord secret missing and confirm Slack still succeeds plus `discord.skipped`; 3) call `discord.notify` with a test message and confirm Discord receives it.
E2E-Exception: no live Discord webhook secret is available in this local Codex session, so validation is covered by deterministic helper tests and deployed smoke is documented for follow-up.

## High-Risk Ultrareview Gate
Review owner: Claude Code #1.
High-risk-ultrareview-exception: Claude Code #1 ultrareview has not run in this Codex-only PR; this PR is intentionally small and covered by deterministic tests plus CI gates.
Security coverage: Discord webhook URL is read only from `DISCORD_WEBHOOK_URL`; payloads disable Discord mentions with `allowed_mentions.parse=[]`; missing/failed Discord delivery cannot leak the Slack webhook URL.
Rollback coverage: revert this PR to remove `discord.notify`, the optional `slack.notify` mirror path, helper/tests, and docs; no persisted state or migration rollback is needed.
Data migration coverage: no database schema, RLS, or data migration changes.
Prod smoke coverage: service-role smoke should call `slack.notify` with `discord_secondary: true`, call it again without `DISCORD_WEBHOOK_URL`, and call `discord.notify` directly after deploy secrets are configured.
Observability coverage: `slack.notify` responses include a structured `discord` result with enabled/configured/skipped/status/error fields for audit and troubleshooting.
Unresolved ultrareview findings: none recorded in this Codex pass.
