### PR TITLE
fix: tolerate missing PR merge refs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,18 @@ jobs:
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
             ref="refs/pull/${{ github.event.pull_request.number }}/merge"
+            if ! git fetch --depth=1 origin "+${ref}:refs/remotes/origin/checkout"; then
+              echo "::warning::PR merge ref ${ref} is unavailable; falling back to PR head SHA."
+              git fetch --depth=1 \
+                "https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git" \
+                "${{ github.event.pull_request.head.sha }}"
+              git checkout --force FETCH_HEAD
+              exit 0
+            fi
           else
             ref="${GITHUB_REF}"
+            git fetch --depth=1 origin "+${ref}:refs/remotes/origin/checkout"
           fi
-          git fetch --depth=1 origin "+${ref}:refs/remotes/origin/checkout"
           git checkout --force refs/remotes/origin/checkout
 
       - name: Setup Flutter
@@ -308,10 +316,18 @@ jobs:
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
             ref="refs/pull/${{ github.event.pull_request.number }}/merge"
+            if ! git fetch --depth=1 origin "+${ref}:refs/remotes/origin/checkout"; then
+              echo "::warning::PR merge ref ${ref} is unavailable; falling back to PR head SHA."
+              git fetch --depth=1 \
+                "https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git" \
+                "${{ github.event.pull_request.head.sha }}"
+              git checkout --force FETCH_HEAD
+              exit 0
+            fi
           else
             ref="${GITHUB_REF}"
+            git fetch --depth=1 origin "+${ref}:refs/remotes/origin/checkout"
           fi
-          git fetch --depth=1 origin "+${ref}:refs/remotes/origin/checkout"
           git checkout --force refs/remotes/origin/checkout
 
       - name: Run security audit


### PR DESCRIPTION
## Summary
- keep the normal PR merge-ref checkout path for CI
- fall back to the PR head SHA when a queued PR run loses `refs/pull/<number>/merge`
- apply the same fallback to both `Lint, Format, and Test` and `Security Check`

## Root cause
Plan-only PRs #3184 and #3182 were closed while queued `pull_request` CI runs were still starting. The workflow tried to fetch `refs/pull/3184/merge` / `refs/pull/3182/merge`, but those refs were already unavailable, so checkout failed before any repo checks ran.

Closes #3219
Closes #3220

## Minimal E2E Gate
- E2E-Exception: CI-only workflow checkout hardening; no application runtime path, UI route, or user-visible behavior changes.
- The validation is implementation-detail independent / black-box: observe GitHub Actions outcomes for a PR run rather than internals of Flutter or Supabase code.
- Minimal 3 cases covered conceptually: merge ref available, merge ref missing with PR head SHA available, and non-PR push/workflow_call refs.
- E2E mechanism: the existing Minimal E2E Gate Playwright public smoke remains unchanged and runs on the PR.

## Validation
- `python scripts/codex_session_check.py`
- `python scripts/ai_tool_watch.py --print-only`
- `python scripts/check_github_actions_node_runtime.py`
- `python scripts/check_cicd_path_filters.py`
- `python -` YAML parse check for `.github/workflows/ci.yml`
- `git diff --check`