### PR TITLE
ci: add audit workflow concurrency batch

### DIFF
--- a/.github/workflows/ai-model-telemetry-review.yml
+++ b/.github/workflows/ai-model-telemetry-review.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "23 21 1 * *"
 
+concurrency:
+  group: ai-model-telemetry-review-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/wbs-staleness-audit.yml
+++ b/.github/workflows/wbs-staleness-audit.yml
@@ -11,6 +11,10 @@ on:
     - cron: '0 21 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: wbs-staleness-audit-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/docs/ci-cd-audit/2026-06-10.md
+++ b/docs/ci-cd-audit/2026-06-10.md
@@ -14,6 +14,12 @@ Issue: #3175
 | `kg-indexer-nightly.yml` | Added workflow concurrency | Prevents overlapping knowledge-graph indexer runs |
 | `managed-mcp-policy.yml` | Added PR-aware workflow concurrency | Cancels superseded PR audit runs |
 | `release-notes-data.yml` | Added PR-aware workflow concurrency | Cancels superseded release-note drift checks |
+| `ai-model-telemetry-review.yml` | Added workflow concurrency | Prevents stacked monthly/manual telemetry reviews |
+| `wbs-staleness-audit.yml` | Added workflow concurrency | Prevents overlapping daily/manual WBS escalation PR creation |
+
+## Follow-up notes
+
+- `horse-racing-update.yml` was rechecked before applying the cache proposal. Current `scripts/fetch_horse_racing.py` uses only Python standard-library modules and the workflow has no `pip install` step, so `actions/setup-python` `cache: pip` would not reduce runner time in the current implementation. Keep the hourly cadence unchanged because the workflow branches on JST time internally.
 
 ## Already present on main
 


### PR DESCRIPTION
## Summary
- add top-level concurrency to `ai-model-telemetry-review.yml`
- add top-level concurrency to `wbs-staleness-audit.yml`
- update the #3175 audit note with this batch and record why `horse-racing-update.yml` pip cache was skipped

## Root cause / context
#3175 tracks scheduled workflow cost and overlap reduction. The latest main branch already had concurrency on several earlier candidates, but these two scheduled/manual workflows still lacked top-level concurrency.

Refs #3175

## Minimal E2E Gate
- E2E-Exception: CI/workflow scheduling-only change; no application runtime path, UI route, or user-visible behavior changes.
- The validation is implementation-detail independent / black-box: observe GitHub Actions scheduling/check outcomes rather than internals of Flutter or Supabase code.
- Minimal 3 cases covered conceptually: monthly telemetry schedule/manual dispatch, daily WBS staleness schedule/manual dispatch, and superseded same-ref run cancellation.
- E2E mechanism: the existing Minimal E2E Gate Playwright public smoke remains unchanged and runs on the PR.

## Validation
- `python scripts/codex_session_check.py`
- `python scripts/ai_tool_watch.py --print-only`
- YAML parse check for changed workflows
- `python scripts/check_github_actions_node_runtime.py`
- `python scripts/check_cicd_path_filters.py`
- `git diff --check`