### PR TITLE
ci: guard multiline inline Python in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,23 +212,27 @@ jobs:
           # bash quoting pattern '"'"' が SQL ファイルに混入すると SQLSTATE 42601 で deploy-prod が失敗する
           FOUND=$(grep -rl "'\"\\'\"'" supabase/migrations/ 2>/dev/null || true)
           # シングルクォートのアーティファクトパターン: ' + " + ' + " + '
-          FOUND2=$(python3 -c "
-          import os, sys
+          FOUND2=$(python3 <<'PY' 2>&1
+          import os
+          import sys
+
           found = []
-          mig_dir = 'supabase/migrations'
+          mig_dir = "supabase/migrations"
           if os.path.isdir(mig_dir):
-              for f in os.listdir(mig_dir):
-                  if f.endswith('.sql'):
-                      path = os.path.join(mig_dir, f)
-                      content = open(path, encoding='utf-8', errors='replace').read()
-                      if \"'\\\"'\\\"'\" in content:
+              for filename in os.listdir(mig_dir):
+                  if filename.endswith(".sql"):
+                      path = os.path.join(mig_dir, filename)
+                      content = open(path, encoding="utf-8", errors="replace").read()
+                      if "'\"'\"'" in content:
                           found.append(path)
+
           if found:
-              print('FOUND: ' + ', '.join(found))
+              print("FOUND: " + ", ".join(found))
               sys.exit(1)
-          else:
-              print('OK: no shell quoting artifacts in migrations')
-          " 2>&1)
+
+          print("OK: no shell quoting artifacts in migrations")
+          PY
+          )
           echo "$FOUND2"
           if echo "$FOUND2" | grep -q "^FOUND:"; then
             echo "❌ bash quoting artifact '\"'\"' detected in SQL migration files"
@@ -239,6 +243,10 @@ jobs:
 
       - name: Check GitHub Actions Node runtime floor
         run: python scripts/check_github_actions_node_runtime.py
+        continue-on-error: false
+
+      - name: Check GitHub Actions inline Python safety
+        run: python scripts/check_github_actions_python_inline.py
         continue-on-error: false
 
       - name: Check formatting

--- a/scripts/check_github_actions_python_inline.py
+++ b/scripts/check_github_actions_python_inline.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Reject multiline inline Python in GitHub Actions shell blocks."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+DEFAULT_ROOT = Path(".github/workflows")
+MULTILINE_INLINE_PYTHON = re.compile(r"\bpython3?\s+-c\s+(['\"])\s*(?:#.*)?$")
+
+
+def workflow_files(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return sorted([*root.glob("*.yml"), *root.glob("*.yaml")])
+
+
+def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
+    violations: list[tuple[Path, int, str]] = []
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            if MULTILINE_INLINE_PYTHON.search(line):
+                violations.append((path, line_number, line.strip()))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    args = parser.parse_args(argv)
+
+    if not args.root.exists():
+        print(f"workflow directory not found: {args.root}", file=sys.stderr)
+        return 1
+
+    files = workflow_files(args.root)
+    violations = find_violations(files)
+    if violations:
+        print("Multiline inline Python is not allowed in GitHub Actions workflows.")
+        print("Use a heredoc (`python3 <<'PY'`) or a single-line `python3 -c` command.")
+        for path, line_number, line in violations:
+            print(f"{path}:{line_number}: {line}")
+        return 1
+
+    print(f"OK: checked {len(files)} workflow files for multiline inline Python")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/test_check_github_actions_python_inline.py
+++ b/test/scripts/test_check_github_actions_python_inline.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_github_actions_python_inline import find_violations, workflow_files
+
+
+class CheckGithubActionsPythonInlineTest(unittest.TestCase):
+    def test_allows_single_line_inline_python(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workflows = Path(tmp) / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            path = workflows / "ci.yml"
+            path.write_text(
+                "jobs:\n"
+                "  test:\n"
+                "    steps:\n"
+                "      - run: python3 -c \"print(1)\"\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(find_violations(workflow_files(workflows)), [])
+
+    def test_rejects_multiline_inline_python_opening_quote(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workflows = Path(tmp) / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            path = workflows / "ci.yml"
+            path.write_text(
+                "jobs:\n"
+                "  test:\n"
+                "    steps:\n"
+                "      - run: |\n"
+                "          python3 -c \"\n"
+                "          print(1)\n"
+                "          \"\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                find_violations(workflow_files(workflows)),
+                [(path, 5, 'python3 -c "')],
+            )
+
+    def test_allows_heredoc_python(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workflows = Path(tmp) / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            path = workflows / "ci.yml"
+            path.write_text(
+                "jobs:\n"
+                "  test:\n"
+                "    steps:\n"
+                "      - run: |\n"
+                "          python3 <<'PY'\n"
+                "          print(1)\n"
+                "          PY\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(find_violations(workflow_files(workflows)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- Convert the SQL migration shell-quoting check from multiline `python3 -c` to a heredoc.
- Add a deterministic workflow guard that rejects multiline inline Python openings in GitHub Actions YAML.
- Add unit coverage for single-line inline Python, multiline inline Python rejection, and heredoc Python allowance.

## Validation
- `python scripts\check_github_actions_python_inline.py`
- `PYTHONPATH=. PYTHONDONTWRITEBYTECODE=1 python test\scripts\test_check_github_actions_python_inline.py`
- Parsed all 105 GitHub Actions workflow YAML files with PyYAML.
- `python scripts\check_github_actions_node_runtime.py`
- `git diff --check` (passed; Windows CRLF warning only)
- Local bash execution was skipped because `bash` resolves to WSL and no WSL distro is installed in this Windows session; GitHub Actions Ubuntu CI is the shell authority.

## Minimal E2E
- Implementation-detail independent: the guard scans committed workflow files and reports `path:line` for unsafe multiline inline Python openings.
- Black-box cases covered: single-line `python3 -c` remains allowed; multiline `python3 -c "` is rejected; heredoc `python3 <<'PY'` remains allowed.
- E2E mechanism: workflow-only static CI guard; app browser E2E is not applicable because no app runtime UI changes are included.

## High-Risk Ultrareview
Review owner: Claude Code #1.
high-risk-ultrareview-exception: workflow-only deterministic guard for issue #1928; no app runtime path, data migration, secret, auth, or production behavior change.
Security: no credential handling or secret access is added.
Rollback: revert this PR to remove the CI guard and heredoc conversion.
Data migration: none.
Prod smoke: GitHub Actions PR checks.
Observability: failing guard output lists the workflow path and line number.
Unresolved findings: none.

Closes #1928
