### PR TITLE
docs(notebooklm): 2アカウント分離運用確立 NOTEBOOKLM_HOME + use ID prefix是正 (part 266b)

### DIFF
--- a/.claude/commands/wrap-up.md
+++ b/.claude/commands/wrap-up.md
@@ -78,8 +78,12 @@ notebooklm status
 認証済みの場合、Step 2 で保存したメモリファイルを Master Brain ノートブックにソースとして追加する:
 
 ```bash
-# Master Brain ノートブックに切り替え（部分ID可）
-notebooklm use jibun-master-brain
+# Master Brain ノートブックに切り替え
+# 注意: use は notebook **ID prefix のみ** マッチ (title 不可 / CLI v0.3.4 実測)。
+# ea6cff25... = jibun-master-brain (kanta13jp@gmail.com 側 / NOTEBOOKLM_HOME は
+# .claude/settings.json env で gmail home に自動適用済み)
+notebooklm use ea6cff25
+notebooklm status   # Title = jibun-master-brain を verify してから add (誤着地防止)
 
 # 今セッションで作成したメモリファイルをすべてソース追加
 # (該当ファイルのみ実行。存在しないファイルはスキップ)
@@ -90,7 +94,7 @@ notebooklm source add "C:/Users/kanta/.claude/projects/C--Users-kanta-GitHub-my-
 
 これにより:
 - 複数セッションにまたがる学習がファイル単位で蓄積される
-- 次回 `/deep-research` で `notebooklm use jibun-master-brain && notebooklm ask "..."` で過去の知見を横断検索できる
+- 次回 `/deep-research` で `notebooklm use ea6cff25 && notebooklm ask "..."` で過去の知見を横断検索できる
 - NotebookLM の Gemini が全セッション履歴から関連情報を自動抽出する
 
 **認証未完了・cookie 期限切れの場合はスキップ**し、`notebooklm login` で再認証を促す（ローカルの memory/ 保存は必ず実行）。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,8 @@
   "env": {
     "MCP_TIMEOUT": "60000",
     "MAX_MCP_OUTPUT_TOKENS": "50000",
-    "ENABLE_MCP_TOOL_SEARCH": "true"
+    "ENABLE_MCP_TOOL_SEARCH": "true",
+    "NOTEBOOKLM_HOME": "C:\\Users\\kanta\\.notebooklm-gmail"
   },
   "statusLine": {
     "type": "command",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@
 
 ## Session ritual
 
-- **開始**: `~/.claude/projects/.../memory/MEMORY.md` 参照 + `notebooklm use jibun-master-brain` で過去判断確認
+- **開始**: `~/.claude/projects/.../memory/MEMORY.md` 参照 + `notebooklm use ea6cff25` (= jibun-master-brain / use は ID prefix のみ) で過去判断確認 (= NotebookLM は **kanta13jp@gmail.com 側** / `NOTEBOOKLM_HOME=~/.notebooklm-gmail` を settings.json env で自動適用。default `~/.notebooklm` = ml-mightylink 側 / 他プロジェクト用。詳細 [`docs/NOTEBOOKLM_GUIDE.md`](docs/NOTEBOOKLM_GUIDE.md))
 - **終了**: `/wrap-up` skill (= memory + NotebookLM 蓄積 + 次回 candidate 3-5 件 必須)
 - **手動 skill**: `/session-start-check` `/rule17-wf-health` `/blog-publish-cleanup` `/wrap-up`
 - **自動化**: 5 daily cron (= ai-tool-watch / safety / residuals / crosscheck / wiki-compile) + 30+ workflow

--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -32330,3 +32330,23 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 - Philosophy Alignment: 原則 4 (mentor = deploy lane の単一 flaky 依存を先回り根絶) / 6 (資本=時間: 503 一発で rerun 人手対応するコストの削減) / 7 (deploy skip = migration 滞留という隠れ負債の検出と回復) / 8 (deploy-prod 成功率100%維持 KPI) / 9 (無人 main push 運用の信頼性)。7+/9 ✅。
 - commit hash: (PR merge 後に追記 / part 265 = 407cdc9e4)。
 ---
+
+### 2026-06-11 Win版#132 part 266b — NotebookLM 2 アカウント分離運用 (NOTEBOOKLM_HOME / user 訂正起点)
+
+**Summary**:
+- part 266 wrap-up の「jibun-master-brain 不存在 = CLAUDE.md stale」誤結論を **user が訂正** — 真因 = CLI login アカウント違い (CLI = k-umezawa@ml-mightylink.com / jibun-master-brain は kanta13jp@gmail.com 側に実在)。誤着地 source は `source delete -y` で除去し、memory を是正 (feedback_correction_20260611_notebooklm_account_mismatch)。
+- user 要件「両アカウント併用 (本プロジェクト = gmail / 他プロジェクト = ml-mightylink)」に対し、CLI `paths.py` を verify-first で読み **`NOTEBOOKLM_HOME` env による丸ごと分離** (storage_state.json + context.json + browser_profile) を採用。`--storage` 単独は context.json が共有され cross-contamination footgun のため不採用。
+- 構成: default `~/.notebooklm` = ml-mightylink (**無傷で維持** / env 未設定の他プロジェクトは自動的にこちら) / 新設 `~/.notebooklm-gmail` = gmail (`.claude/settings.json` env で本プロジェクトに自動適用)。
+- 実測で判明した CLI の罠 2 件を GUIDE に正本化: ① `status`/`auth check` とも login アカウント非表示 → 「notebook 不存在」はまず account 指紋 (`list`) を疑う ② `use` fail 後の `source add` は現行 context へ着地 → use 成功 verify 必須。
+
+**Changes**:
+- `.claude/settings.json` — env に `NOTEBOOKLM_HOME` 追加 (本プロジェクトの全セッションへ ambient 適用 / skill 群は無修正で済む)。
+- `CLAUDE.md` — Session ritual 行にアカウント注記 + GUIDE への pointer。
+- `docs/NOTEBOOKLM_GUIDE.md` — 「アカウント運用 — 2 アカウント分離」節新設 (分離表 + 罠 2 件 + GHA `NOTEBOOKLM_AUTH_JSON` secret の account 監査は別タスクと明記)。
+
+**Validation focus**:
+- merge 前実測: gmail home で `list` に jibun-master-brain 実在 → `use` 成功 → part 266 memory source add 成功 / default home の context (ml-mightylink notebook) 無傷。
+- 初回 login の教訓: 対話式 login (browser → ENTER) を background 実行中に hard-kill すると session 未 flush で消失 → **auto-ENTER 遅延窓 (sleep N; echo) 方式**で CLI 自身に保存させる。
+- Philosophy Alignment: 原則 3 (mentor = user 訂正の即時反映と仕組み化) / 6 (資本=時間: account 誤認 triage の再発防止) / 7 (誤着地 source = 負債の即時除去) / 8 (儀式の信頼性 KPI)。7+/9 ✅。
+- commit hash: (PR merge 後に追記 / part 266 = b2a9cf648)。
+---

--- a/docs/NOTEBOOKLM_GUIDE.md
+++ b/docs/NOTEBOOKLM_GUIDE.md
@@ -17,6 +17,24 @@
 
 ---
 
+## アカウント運用 — 2 アカウント分離 (= part 266b 2026-06-11 確立)
+
+NotebookLM は Google アカウント単位で notebook が分かれる。CLI は `NOTEBOOKLM_HOME` 環境変数で
+認証・context・browser_profile を**丸ごとディレクトリ分離**できる (CLI `paths.py` 正本 / `--storage` 単独は context.json が共有されるため不可):
+
+| 用途 | アカウント | NOTEBOOKLM_HOME | 主な notebook |
+| --- | --- | --- | --- |
+| **本プロジェクト (my_web_app)** | kanta13jp@gmail.com | `C:\Users\kanta\.notebooklm-gmail` (= `.claude/settings.json` env で自動適用) | `jibun-master-brain` (= ID `ea6cff25...` / Shared) |
+| 他プロジェクト | k-umezawa@ml-mightylink.com | default `~/.notebooklm` (= env 未設定時) | Mighty Skill-Bridge / Mighty-Link 系 |
+
+- **初回 setup**: `NOTEBOOKLM_HOME=C:\Users\kanta\.notebooklm-gmail notebooklm login` (browser OAuth = user 操作)。
+- **罠 1**: CLI は login 中アカウントを表示しない (`status` / `auth check` とも cookie domain のみ) → 「notebook 不存在」はまず**アカウント違い**を疑い、`notebooklm list` の notebook 群で指紋確認。
+- **罠 2**: `use <name>` が fail しても後続 `source add` は現行 context の notebook へ着地する → `use` 成功を verify してから add (part 266 で誤着地→`source delete -y` 削除の実例)。
+- **罠 3**: `use` の解決は **notebook ID prefix のみ** (title マッチ不可 / CLI v0.3.4 `helpers.py` 実測) → `notebooklm use ea6cff25` のように ID 先頭で指定する。
+- **未監査**: GHA 側 (notebooklm-video-pipeline 等) は `NOTEBOOKLM_AUTH_JSON` secret 経由 — どちらのアカウントで生成された secret かの監査は別タスク。
+
+---
+
 ## セッション開始 ritual (= Master Brain 参照)
 
 セッション冒頭で必ず以下を確認:
@@ -30,7 +48,7 @@
 **アーキテクチャ・意思決定・好みの質問には必ず Master Brain に問い合わせる**:
 
 ```bash
-notebooklm use jibun-master-brain
+notebooklm use ea6cff25   # = jibun-master-brain (use は ID prefix のみマッチ / title 不可 v0.3.4 実測)
 notebooklm ask "過去の意思決定: [質問内容]"
 ```
 


### PR DESCRIPTION
## 概要 (Win版#132 part 266b)

NotebookLM の **2 アカウント分離運用**を確立 (user 訂正起点)。part 266 wrap-up で「jibun-master-brain 不存在 = CLAUDE.md stale」と誤結論したが、真因は CLI の login アカウント違い (CLI = k-umezawa@ml-mightylink.com / jibun-master-brain = kanta13jp@gmail.com 側に実在) と user が訂正。

## 設計 (verify-first: CLI paths.py / helpers.py 読解)

- **`NOTEBOOKLM_HOME` env で丸ごと分離** (storage_state.json + context.json + browser_profile)。`--storage` 単独は context.json が共有され cross-contamination するため不採用。
- default `~/.notebooklm` = **ml-mightylink (無傷)** — 他プロジェクトは env 未設定で自動的にこちら (user 要件)。
- 新設 `~/.notebooklm-gmail` = **gmail** — `.claude/settings.json` の env で本プロジェクト全セッションに ambient 適用。
- 追加発見: `notebooklm use` は **notebook ID prefix のみマッチ** (title 不可 / v0.3.4 `helpers.py:336` 実測) → 儀式の `use jibun-master-brain` は元々解決不能だった。`use ea6cff25` (ID) 形式へ全 docs を是正。

## Changes

- `.claude/settings.json` — env に `NOTEBOOKLM_HOME` 追加
- `CLAUDE.md` — Session ritual 行を `use ea6cff25` (ID) + アカウント注記へ更新
- `.claude/commands/wrap-up.md` — Step 3 を ID 指定 + use 成功 verify 手順へ更新
- `docs/NOTEBOOKLM_GUIDE.md` — 「アカウント運用 — 2 アカウント分離」節 (分離表 + 実測罠 3 件 + GHA secret 監査は別タスク) + ritual の ID 化
- `docs/GROWTH_STRATEGY_ROADMAP.md` — part 266b エントリ

## 検証 (merge 前実測済み)

1. gmail home (`NOTEBOOKLM_HOME=~/.notebooklm-gmail`) で login 保存成功 (user の対話 ENTER 方式) → `list` に jibun-master-brain (ID `ea6cff25` / Shared) 実在
2. `use ea6cff25` 成功 → part 266 memory 2 ファイルの `source add` 成功 (source `d399bbb1` / `49dc291b`)
3. default home (env 未設定) の context = ml-mightylink notebook (`cd44c4ef`) **無傷**を確認

## High-risk ultrareview gate

- Review owner: Claude Code #1 (Win L3 / part 266b)
- high-risk-ultrareview-exception: 変更は .claude 設定ファイルと docs のみで実行コードの変更ゼロ。gate trigger の「secret」言及は GHA NOTEBOOKLM_AUTH_JSON secret の監査を別タスクとして明記した記述であり、本 PR 自体は secret/credential/auth コードに一切触れない。

## Minimal E2E Gate

- 変更は `.claude/` + `*.md` (docs) のみ = app-code 非該当 (lib/ / supabase/functions/ 変更なし)
- E2E 方針: 検証は実装詳細に依存しない black-box の入出力 (I/O) 確認で、最小限の 3ケース — ① gmail home で jibun-master-brain が list/use 可能 ② source add が正しい notebook へ着地 ③ default home (ml-mightylink) の context 無傷。Playwright スイートや integration_test への追加は不要 (上記「検証」で 3 ケースとも実測 PASS)
- Minimal E2E Exception: 設定 + docs のみの変更で UI 挙動変化が一切ないため、新規 E2E ファイル追加は不要
- label: `no-e2e-needed` (close+reopen で event payload へ反映)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
