### PR TITLE
feat(asset): うどん縛りチャレンジ — 完済までの獄中食コミットメント (part 267)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -39,6 +39,7 @@ import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
 import 'package:my_web_app/services/disposable_balance_asset_liability_adapter.dart';
 import 'package:my_web_app/services/disposable_balance_service.dart';
+import 'package:my_web_app/services/konbini_udon_challenge_service.dart';
 import 'package:my_web_app/services/profile_service.dart';
 import 'package:my_web_app/services/salary_spending_breakdown_service.dart';
 import 'package:my_web_app/services/smbc_csv_import_service.dart';
@@ -320,6 +321,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   DebtLockdownSnapshot? _debtLockdownSnapshot;
   bool _isLoadingDebtLockdown = false;
   double? _debtLockdownLoadedForDebt;
+  final KonbiniUdonChallengeService _konbiniUdonChallengeService =
+      const KonbiniUdonChallengeService();
+  KonbiniUdonChallengeSnapshot? _konbiniUdonSnapshot;
+  bool _isLoadingKonbiniUdon = false;
+  double? _konbiniUdonLoadedForDebt;
   Future<AssetWasteTrainingAiReview>? _wasteTrainingAiReviewFuture;
   String? _wasteTrainingAiReviewKey;
   bool _isGeneratingAssetManagementAiSummary = false;
@@ -3608,6 +3614,374 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } finally {
       noteController.dispose();
       amountController.dispose();
+    }
+  }
+
+  void _ensureKonbiniUdonSnapshotLoaded(double remainingDebt) {
+    final loadedForDebt = _konbiniUdonLoadedForDebt;
+    if (_isLoadingKonbiniUdon) {
+      return;
+    }
+    if (loadedForDebt != null && (loadedForDebt - remainingDebt).abs() < 1) {
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _isLoadingKonbiniUdon) {
+        return;
+      }
+      final latestLoadedDebt = _konbiniUdonLoadedForDebt;
+      if (latestLoadedDebt != null &&
+          (latestLoadedDebt - remainingDebt).abs() < 1) {
+        return;
+      }
+      _loadKonbiniUdonSnapshot(remainingDebt);
+    });
+  }
+
+  Future<void> _loadKonbiniUdonSnapshot(double remainingDebt) async {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isLoadingKonbiniUdon = true;
+    });
+
+    try {
+      final snapshot = await _konbiniUdonChallengeService.loadSnapshot(
+        remainingDebt: remainingDebt,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _konbiniUdonSnapshot = snapshot;
+        _konbiniUdonLoadedForDebt = remainingDebt;
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingKonbiniUdon = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _setKonbiniUdonEnabled(
+    bool enabled,
+    double remainingDebt,
+  ) async {
+    final snapshot = await _konbiniUdonChallengeService.setEnabled(
+      enabled,
+      remainingDebt: remainingDebt,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _konbiniUdonSnapshot = snapshot;
+      _konbiniUdonLoadedForDebt = remainingDebt;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          enabled ? 'うどん縛りを開始しました。完済の日まで。' : 'うどん縛りを中断しました',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmKonbiniUdonPledge(double remainingDebt) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('うどん縛りの誓い'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                KonbiniUdonChallengeService.pledgeText,
+                style: TextStyle(fontWeight: FontWeight.w700, height: 1.6),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                KonbiniUdonChallengeService.healthDisclaimer,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(dialogContext).colorScheme.onSurfaceVariant,
+                  height: 1.6,
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('やめておく'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('誓う'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) {
+      return;
+    }
+    await _setKonbiniUdonEnabled(true, remainingDebt);
+  }
+
+  Future<void> _toggleKonbiniUdonMeal(
+    KonbiniUdonMealSlot slot,
+    bool ateUdon,
+    double remainingDebt,
+  ) async {
+    final snapshot = await _konbiniUdonChallengeService.toggleMealSlot(
+      slot,
+      ateUdon,
+      remainingDebt: remainingDebt,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _konbiniUdonSnapshot = snapshot;
+      _konbiniUdonLoadedForDebt = remainingDebt;
+    });
+  }
+
+  Future<void> _recordKonbiniUdonViolation({
+    required String note,
+    required double amount,
+    KonbiniUdonMealSlot? slot,
+    required double remainingDebt,
+  }) async {
+    final snapshot = await _konbiniUdonChallengeService.recordViolation(
+      note: note,
+      amount: amount,
+      slot: slot,
+      remainingDebt: remainingDebt,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _konbiniUdonSnapshot = snapshot;
+      _konbiniUdonLoadedForDebt = remainingDebt;
+    });
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(
+        const SnackBar(content: Text('うどん以外の食事を記録しました。明日また縛り直しです。')));
+  }
+
+  Future<void> _showKonbiniUdonViolationDialog(double remainingDebt) async {
+    KonbiniUdonMealSlot? selectedSlot;
+    final noteController = TextEditingController();
+    final amountController = TextEditingController();
+
+    try {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => StatefulBuilder(
+          builder: (dialogContext, setDialogState) => AlertDialog(
+            title: const Text('うどん以外を食べた記録'),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  DropdownButtonFormField<KonbiniUdonMealSlot?>(
+                    initialValue: selectedSlot,
+                    decoration: const InputDecoration(
+                      labelText: 'どの食事か',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    items: [
+                      for (final slot in KonbiniUdonMealSlot.values)
+                        DropdownMenuItem<KonbiniUdonMealSlot?>(
+                          value: slot,
+                          child: Text('${slot.label}食'),
+                        ),
+                      const DropdownMenuItem<KonbiniUdonMealSlot?>(
+                        value: null,
+                        child: Text('間食・その他'),
+                      ),
+                    ],
+                    onChanged: (value) {
+                      setDialogState(() {
+                        selectedSlot = value;
+                      });
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: noteController,
+                    minLines: 2,
+                    maxLines: 4,
+                    decoration: const InputDecoration(
+                      labelText: '何を食べたか',
+                      hintText: '例: 我慢できずに牛丼を食べた',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: amountController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(
+                      labelText: '支払額（任意）',
+                      hintText: '0',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext, false),
+                child: const Text('キャンセル'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(dialogContext, true),
+                child: const Text('記録'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      if (confirmed != true) {
+        return;
+      }
+
+      final note = noteController.text.trim();
+      if (note.isEmpty) {
+        if (!mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('何を食べたか入力してください')));
+        return;
+      }
+
+      final amount =
+          double.tryParse(amountController.text.replaceAll(',', '').trim()) ??
+              0;
+      await _recordKonbiniUdonViolation(
+        note: note,
+        amount: amount,
+        slot: selectedSlot,
+        remainingDebt: remainingDebt,
+      );
+    } finally {
+      noteController.dispose();
+      amountController.dispose();
+    }
+  }
+
+  Future<void> _showKonbiniUdonConfigDialog(double remainingDebt) async {
+    final config =
+        _konbiniUdonSnapshot?.config ?? KonbiniUdonChallengeConfig.defaults;
+    final priceController = TextEditingController(
+      text: config.udonUnitPrice.round().toString(),
+    );
+    final baselineController = TextEditingController(
+      text: config.baselineMonthlyFoodCost.round().toString(),
+    );
+
+    try {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('うどん縛りの前提を調整'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: priceController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: 'コンビニうどん1食の価格（円）',
+                    helperText: 'トッピング込みの実勢価格に合わせて調整',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: baselineController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: '縛りなしの月間食費（円）',
+                    helperText: '目安: 総務省家計調査の単身世帯食料費 約45,000円',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('キャンセル'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: const Text('保存'),
+            ),
+          ],
+        ),
+      );
+
+      if (confirmed != true) {
+        return;
+      }
+
+      final price = double.tryParse(
+        priceController.text.replaceAll(',', '').trim(),
+      );
+      final baseline = double.tryParse(
+        baselineController.text.replaceAll(',', '').trim(),
+      );
+      if (price == null || baseline == null) {
+        if (!mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('数値で入力してください')));
+        return;
+      }
+
+      final snapshot = await _konbiniUdonChallengeService.updateConfig(
+        udonUnitPrice: price,
+        baselineMonthlyFoodCost: baseline,
+        remainingDebt: remainingDebt,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _konbiniUdonSnapshot = snapshot;
+        _konbiniUdonLoadedForDebt = remainingDebt;
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('うどん縛りの前提を更新しました')));
+    } finally {
+      priceController.dispose();
+      baselineController.dispose();
     }
   }
 
@@ -8848,6 +9222,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           );
     _ensureDebtLockdownSnapshotLoaded(totalDebt);
+    _ensureKonbiniUdonSnapshotLoaded(totalDebt);
 
     return Card(
       elevation: 2,
@@ -8903,6 +9278,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               const SizedBox(height: 12),
             ],
             _buildDebtLockdownPanel(totalDebt),
+            const SizedBox(height: 12),
+            _buildKonbiniUdonChallengePanel(totalDebt, workbook),
             const SizedBox(height: 12),
             _isCompact
                 ? Column(
@@ -9531,6 +9908,434 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 ),
               );
             }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildKonbiniUdonChallengePanel(
+    double remainingDebt,
+    AssetLiabilityWorkbook? workbook,
+  ) {
+    final snapshot = _konbiniUdonSnapshot;
+    final isReleased = remainingDebt <= 0;
+    final isEnabled = snapshot?.isActive == true && !isReleased;
+    final config = snapshot?.config ?? KonbiniUdonChallengeConfig.defaults;
+    final savings = KonbiniUdonChallengeService.estimateSavings(config);
+    final udonSlots = snapshot?.todayUdonSlots ?? const <KonbiniUdonMealSlot>{};
+    final recentViolations =
+        snapshot?.recentViolations ?? const <KonbiniUdonViolation>[];
+    final streakDays = snapshot?.currentStreakDays ?? 0;
+    final totalCompliantDays = snapshot?.totalCompliantDays ?? 0;
+    final cumulativeSavings = snapshot?.cumulativeSavings ?? 0;
+    final advisory = KonbiniUdonChallengeService.healthAdvisoryFor(streakDays);
+    final statusLabel = isReleased
+        ? '釈放'
+        : isEnabled
+            ? '縛り中'
+            : '未開始';
+    final statusColor = isReleased
+        ? const Color(0xFF0D9488)
+        : isEnabled
+            ? const Color(0xFFB45309)
+            : const Color(0xFF475569);
+
+    int? payoffMonthsWithUdon;
+    int? monthsSaved;
+    double? interestSaved;
+    var baselineNeverFinishes = false;
+    if (workbook != null && savings.hasSavings) {
+      final simulation =
+          _assetLiabilityRepaymentSimulationService.buildComparison(
+        workbook: workbook,
+        extraMonthlyPayment: savings.monthlySavings,
+      );
+      if (simulation.hasEligibleDebt) {
+        final udonPlan = simulation.planFor(
+          AssetLiabilityRepaymentSimulationStrategy.interestRate,
+        );
+        final baselinePlan = simulation.baselinePlanFor(
+          AssetLiabilityRepaymentSimulationStrategy.interestRate,
+        );
+        final udonMonths = udonPlan?.estimatedPayoffMonths;
+        final baselineMonths = baselinePlan?.estimatedPayoffMonths;
+        payoffMonthsWithUdon = udonMonths;
+        if (udonPlan != null && baselinePlan != null && udonMonths != null) {
+          if (baselineMonths != null) {
+            monthsSaved = baselineMonths - udonMonths;
+          } else {
+            baselineNeverFinishes = true;
+          }
+          interestSaved = baselinePlan.estimatedInterestTotal -
+              udonPlan.estimatedInterestTotal;
+        }
+      }
+    }
+
+    final advisoryIsWarning =
+        advisory.level == KonbiniUdonHealthAdvisoryLevel.warning;
+    final advisoryIsDanger =
+        advisory.level == KonbiniUdonHealthAdvisoryLevel.danger;
+    final advisoryBg = advisoryIsDanger
+        ? const Color(0xFFFEF2F2)
+        : advisoryIsWarning
+            ? const Color(0xFFFFF7ED)
+            : const Color(0xFFEFF6FF);
+    final advisoryBorder = advisoryIsDanger
+        ? const Color(0xFFFECACA)
+        : advisoryIsWarning
+            ? const Color(0xFFFED7AA)
+            : const Color(0xFFBFDBFE);
+    final advisoryFg = advisoryIsDanger
+        ? const Color(0xFFB91C1C)
+        : advisoryIsWarning
+            ? const Color(0xFFC05621)
+            : const Color(0xFF1D4ED8);
+    final advisoryIcon = advisoryIsDanger
+        ? Icons.medical_services_outlined
+        : advisoryIsWarning
+            ? Icons.warning_amber_rounded
+            : Icons.restaurant;
+
+    return Container(
+      key: const Key('konbini_udon_challenge_panel'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isReleased ? const Color(0xFFF0FDFA) : const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isReleased ? const Color(0xFF99F6E4) : const Color(0xFFFCD34D),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.ramen_dining, color: statusColor),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  'うどん縛り — 完済までの獄中食',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              IconButton(
+                key: const Key('konbini_udon_config_button'),
+                tooltip: '節約前提を調整',
+                icon: const Icon(Icons.tune, size: 18),
+                onPressed: () => _showKonbiniUdonConfigDialog(remainingDebt),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            isReleased
+                ? KonbiniUdonChallengeService.releaseMessage
+                : '借金を完済するまで、食事はコンビニのうどんのみ。浮いた食費(月 ${_formatYen(savings.monthlySavings)} 想定)は全額返済へ回します。',
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.onSurface,
+              height: 1.5,
+            ),
+          ),
+          if (_isLoadingKonbiniUdon && snapshot == null) ...[
+            const SizedBox(height: 10),
+            const LinearProgressIndicator(minHeight: 3),
+          ],
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildOverviewStatChip(
+                label: '状態',
+                value: statusLabel,
+                color: statusColor,
+              ),
+              _buildOverviewStatChip(
+                label: '連続遵守',
+                value: '$streakDays日',
+                color: const Color(0xFF6366F1),
+              ),
+              _buildOverviewStatChip(
+                label: '通算遵守',
+                value: '$totalCompliantDays日',
+                color: const Color(0xFF0D9488),
+              ),
+              _buildOverviewStatChip(
+                label: '累計節約(概算)',
+                value: _formatYen(cumulativeSavings),
+                color: const Color(0xFFB45309),
+              ),
+            ],
+          ),
+          if (snapshot?.startedAt != null && !isReleased) ...[
+            const SizedBox(height: 8),
+            Text(
+              '誓約日: ${DateFormat('yyyy/MM/dd').format(snapshot!.startedAt!)}',
+              style: TextStyle(
+                fontSize: 11,
+                color: Theme.of(context).colorScheme.onSurface,
+                height: 1.5,
+              ),
+            ),
+          ],
+          if (isReleased && totalCompliantDays > 0) ...[
+            const SizedBox(height: 8),
+            Text(
+              '通算遵守 $totalCompliantDays日 / 概算節約 ${_formatYen(cumulativeSavings)}。よく耐えました。',
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: Color(0xFF0D9488),
+                height: 1.5,
+              ),
+            ),
+          ],
+          if (!isReleased) ...[
+            const SizedBox(height: 10),
+            if (savings.hasSavings)
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _buildRepaymentSimulationMetric(
+                    label: '月間節約見込み',
+                    value: _formatYen(savings.monthlySavings),
+                  ),
+                  if (payoffMonthsWithUdon != null)
+                    _buildRepaymentSimulationMetric(
+                      label: '縛り継続時の完済まで',
+                      value: '$payoffMonthsWithUdonヶ月',
+                    ),
+                  if (monthsSaved != null && monthsSaved > 0)
+                    _buildRepaymentSimulationMetric(
+                      label: '完済前倒し',
+                      value: '$monthsSavedヶ月',
+                    ),
+                  if (baselineNeverFinishes)
+                    _buildRepaymentSimulationMetric(
+                      label: '完済前倒し',
+                      value: '360ヶ月+ → 完済可能に',
+                    ),
+                  if (interestSaved != null && interestSaved > 0)
+                    _buildRepaymentSimulationMetric(
+                      label: '利息圧縮',
+                      value: _formatYen(interestSaved),
+                    ),
+                ],
+              )
+            else
+              Text(
+                '今の前提ではうどん縛りの節約が出ません。右上の調整ボタンから、うどん単価と月間食費の前提を見直してください。',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  height: 1.5,
+                ),
+              ),
+            const SizedBox(height: 12),
+            _isCompact
+                ? Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      ElevatedButton.icon(
+                        key: const Key('konbini_udon_toggle_button'),
+                        onPressed: isEnabled
+                            ? () => _setKonbiniUdonEnabled(false, remainingDebt)
+                            : () => _confirmKonbiniUdonPledge(remainingDebt),
+                        icon: Icon(
+                          isEnabled ? Icons.pause_circle : Icons.ramen_dining,
+                        ),
+                        label: Text(isEnabled ? 'うどん縛りを中断' : 'うどん縛りを誓う'),
+                      ),
+                      const SizedBox(height: 8),
+                      OutlinedButton.icon(
+                        onPressed: isEnabled
+                            ? () =>
+                                _showKonbiniUdonViolationDialog(remainingDebt)
+                            : null,
+                        icon: const Icon(Icons.no_food),
+                        label: const Text('うどん以外を食べた'),
+                      ),
+                    ],
+                  )
+                : Row(
+                    children: [
+                      Expanded(
+                        child: ElevatedButton.icon(
+                          key: const Key('konbini_udon_toggle_button'),
+                          onPressed: isEnabled
+                              ? () =>
+                                  _setKonbiniUdonEnabled(false, remainingDebt)
+                              : () => _confirmKonbiniUdonPledge(remainingDebt),
+                          icon: Icon(
+                            isEnabled ? Icons.pause_circle : Icons.ramen_dining,
+                          ),
+                          label: Text(isEnabled ? 'うどん縛りを中断' : 'うどん縛りを誓う'),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      OutlinedButton.icon(
+                        onPressed: isEnabled
+                            ? () =>
+                                _showKonbiniUdonViolationDialog(remainingDebt)
+                            : null,
+                        icon: const Icon(Icons.no_food),
+                        label: const Text('うどん以外を食べた'),
+                      ),
+                    ],
+                  ),
+            const SizedBox(height: 12),
+            const Text(
+              '今日の三食(うどんで完走)',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final slot in KonbiniUdonMealSlot.values)
+                  FilterChip(
+                    key: Key('konbini_udon_slot_${slot.storageId}'),
+                    selected: udonSlots.contains(slot),
+                    onSelected: isEnabled
+                        ? (value) =>
+                            _toggleKonbiniUdonMeal(slot, value, remainingDebt)
+                        : null,
+                    avatar: Icon(
+                      Icons.ramen_dining,
+                      size: 16,
+                      color: udonSlots.contains(slot)
+                          ? Colors.white
+                          : Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                    selectedColor: const Color(0xFFB45309),
+                    labelStyle: TextStyle(
+                      color: udonSlots.contains(slot)
+                          ? Colors.white
+                          : Theme.of(context).colorScheme.onSurface,
+                      fontWeight: FontWeight.w700,
+                      height: 1.5,
+                    ),
+                    label: Text('${slot.label}うどん'),
+                  ),
+              ],
+            ),
+            if (snapshot?.isTodayCompliant == true) ...[
+              const SizedBox(height: 6),
+              const Text(
+                '今日は三食うどんで完走。完済が一歩近づきました。',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: Color(0xFF0D9488),
+                  height: 1.5,
+                ),
+              ),
+            ],
+            if (advisory.level != KonbiniUdonHealthAdvisoryLevel.none) ...[
+              const SizedBox(height: 10),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: advisoryBg,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: advisoryBorder),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(advisoryIcon, size: 16, color: advisoryFg),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            advisory.title,
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w800,
+                              color: advisoryFg,
+                              height: 1.4,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      advisory.body,
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: Theme.of(context).colorScheme.onSurface,
+                        height: 1.6,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+            const SizedBox(height: 8),
+            const Text(
+              '最近のうどん違反',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 6),
+            if (recentViolations.isEmpty)
+              Text(
+                isEnabled
+                    ? 'まだ違反はありません。今日もうどんで生き延びます。'
+                    : '誓いを立てると、ここにうどん以外の食事ログが溜まります。',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(context).colorScheme.onSurface,
+                  height: 1.5,
+                ),
+              )
+            else
+              ...recentViolations.take(3).map((violation) {
+                final amountLabel = violation.amount > 0
+                    ? ' / ${_formatYen(violation.amount)}'
+                    : '';
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 6),
+                  child: Text(
+                    '${DateFormat('MM/dd HH:mm').format(violation.createdAt)}  ${violation.mealSlotLabel}$amountLabel  ${violation.note}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.onSurface,
+                      height: 1.5,
+                    ),
+                  ),
+                );
+              }),
+          ],
+          const SizedBox(height: 8),
+          Text(
+            KonbiniUdonChallengeService.healthDisclaimer,
+            style: TextStyle(
+              fontSize: 10,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              height: 1.5,
+            ),
+          ),
         ],
       ),
     );

--- a/lib/services/konbini_udon_challenge_service.dart
+++ b/lib/services/konbini_udon_challenge_service.dart
@@ -1,0 +1,565 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 1日の食事スロット。うどん縛りは3食すべてをコンビニうどんで通すと
+/// その日が「遵守日」になる。
+enum KonbiniUdonMealSlot { breakfast, lunch, dinner }
+
+extension KonbiniUdonMealSlotLabel on KonbiniUdonMealSlot {
+  String get label {
+    switch (this) {
+      case KonbiniUdonMealSlot.breakfast:
+        return '朝';
+      case KonbiniUdonMealSlot.lunch:
+        return '昼';
+      case KonbiniUdonMealSlot.dinner:
+        return '夜';
+    }
+  }
+
+  String get storageId => name;
+}
+
+/// うどん以外を食べてしまった記録。金額は「うどんとの差額」ではなく
+/// 実際に払った額をそのまま入れる(振り返り用の事実記録)。
+class KonbiniUdonViolation {
+  const KonbiniUdonViolation({
+    required this.id,
+    required this.mealSlot,
+    required this.note,
+    required this.amount,
+    required this.createdAt,
+  });
+
+  final String id;
+  final KonbiniUdonMealSlot? mealSlot;
+  final String note;
+  final double amount;
+  final DateTime createdAt;
+
+  String get mealSlotLabel => mealSlot?.label ?? 'その他';
+
+  factory KonbiniUdonViolation.fromJson(Map<String, dynamic> json) {
+    final rawSlot = json['meal_slot']?.toString();
+    KonbiniUdonMealSlot? slot;
+    for (final candidate in KonbiniUdonMealSlot.values) {
+      if (candidate.storageId == rawSlot) {
+        slot = candidate;
+      }
+    }
+    return KonbiniUdonViolation(
+      id: json['id']?.toString() ?? '',
+      mealSlot: slot,
+      note: json['note']?.toString() ?? '',
+      amount: (json['amount'] as num?)?.toDouble() ?? 0,
+      createdAt:
+          DateTime.tryParse(json['created_at']?.toString() ?? '')?.toLocal() ??
+              DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'meal_slot': mealSlot?.storageId,
+      'note': note,
+      'amount': amount,
+      'created_at': createdAt.toUtc().toIso8601String(),
+    };
+  }
+}
+
+/// 節約計算の前提値。うどん単価と「縛りなしの場合の月間食費」は
+/// 利用者が自分の実態に合わせて上書きできる。
+class KonbiniUdonChallengeConfig {
+  const KonbiniUdonChallengeConfig({
+    required this.udonUnitPrice,
+    required this.baselineMonthlyFoodCost,
+  });
+
+  /// コンビニうどん1食あたりの想定価格(円)。
+  final double udonUnitPrice;
+
+  /// 縛りをしない場合の月間食費の目安(円)。
+  /// 初期値は総務省家計調査の単身世帯食料費を参考にした概算。
+  final double baselineMonthlyFoodCost;
+
+  static const KonbiniUdonChallengeConfig defaults = KonbiniUdonChallengeConfig(
+    udonUnitPrice: KonbiniUdonChallengeService.defaultUdonUnitPrice,
+    baselineMonthlyFoodCost:
+        KonbiniUdonChallengeService.defaultBaselineMonthlyFoodCost,
+  );
+
+  factory KonbiniUdonChallengeConfig.fromJson(Map<String, dynamic> json) {
+    return KonbiniUdonChallengeConfig(
+      udonUnitPrice: max(
+        0.0,
+        (json['udon_unit_price'] as num?)?.toDouble() ??
+            KonbiniUdonChallengeService.defaultUdonUnitPrice,
+      ),
+      baselineMonthlyFoodCost: max(
+        0.0,
+        (json['baseline_monthly_food_cost'] as num?)?.toDouble() ??
+            KonbiniUdonChallengeService.defaultBaselineMonthlyFoodCost,
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'udon_unit_price': udonUnitPrice,
+      'baseline_monthly_food_cost': baselineMonthlyFoodCost,
+    };
+  }
+}
+
+/// うどん縛りによる食費圧縮の試算。月間節約額は返済シミュレーションの
+/// extraMonthlyPayment にそのまま渡せる。
+class KonbiniUdonSavingsEstimate {
+  const KonbiniUdonSavingsEstimate({
+    required this.monthlyUdonCost,
+    required this.monthlyBaselineFoodCost,
+    required this.monthlySavings,
+  });
+
+  final double monthlyUdonCost;
+  final double monthlyBaselineFoodCost;
+  final double monthlySavings;
+
+  double get dailySavings =>
+      monthlySavings / KonbiniUdonChallengeService.averageDaysPerMonth;
+
+  bool get hasSavings => monthlySavings > 0;
+}
+
+enum KonbiniUdonHealthAdvisoryLevel { none, info, warning, danger }
+
+/// 連続日数に応じた健康ガードレール。節約は健康を犠牲にした瞬間に
+/// 医療費として跳ね返り、返済計画そのものを壊す。
+class KonbiniUdonHealthAdvisory {
+  const KonbiniUdonHealthAdvisory({
+    required this.level,
+    required this.title,
+    required this.body,
+  });
+
+  final KonbiniUdonHealthAdvisoryLevel level;
+  final String title;
+  final String body;
+}
+
+class KonbiniUdonChallengeSnapshot {
+  const KonbiniUdonChallengeSnapshot({
+    required this.remainingDebt,
+    required this.isEnabled,
+    required this.isReleased,
+    required this.startedAt,
+    required this.config,
+    required this.todayUdonSlots,
+    required this.todayViolations,
+    required this.currentStreakDays,
+    required this.totalCompliantDays,
+    required this.recentViolations,
+  });
+
+  final double remainingDebt;
+  final bool isEnabled;
+  final bool isReleased;
+  final DateTime? startedAt;
+  final KonbiniUdonChallengeConfig config;
+  final Set<KonbiniUdonMealSlot> todayUdonSlots;
+  final List<KonbiniUdonViolation> todayViolations;
+  final int currentStreakDays;
+  final int totalCompliantDays;
+  final List<KonbiniUdonViolation> recentViolations;
+
+  bool get isActive => isEnabled && !isReleased;
+
+  bool get isTodayCompliant =>
+      todayViolations.isEmpty &&
+      todayUdonSlots.length >= KonbiniUdonMealSlot.values.length;
+
+  KonbiniUdonSavingsEstimate get savings =>
+      KonbiniUdonChallengeService.estimateSavings(config);
+
+  /// 遵守日数 × 1日あたり節約額の概算累計。
+  double get cumulativeSavings => totalCompliantDays * savings.dailySavings;
+
+  KonbiniUdonHealthAdvisory get healthAdvisory =>
+      KonbiniUdonChallengeService.healthAdvisoryFor(currentStreakDays);
+}
+
+/// 「借金を完済するまで、コンビニのうどんしか食ってはいけない」縛りの
+/// 記録・節約試算・健康ガードレールを担うサービス。
+///
+/// 完済(残債0)で自動的に釈放される。記録は端末ローカル
+/// (SharedPreferences)のみで、ネットワークやDBには書き込まない。
+class KonbiniUdonChallengeService {
+  const KonbiniUdonChallengeService({this.nowProvider});
+
+  static const double defaultUdonUnitPrice = 200;
+  static const double defaultBaselineMonthlyFoodCost = 45000;
+  static const double averageDaysPerMonth = 30.4;
+
+  static const int infoStreakThresholdDays = 3;
+  static const int warningStreakThresholdDays = 7;
+  static const int dangerStreakThresholdDays = 14;
+
+  static const String pledgeText = '借金を完済するまで、食事はコンビニのうどんしか食わない。浮いた食費は全額返済に回す。';
+
+  static const String healthDisclaimer = '本機能は自己規律のためのゲームであり、医学・栄養学上の助言ではありません。'
+      '単一食の継続は栄養が偏ります。卵・わかめ・ねぎ等のトッピングで補い、'
+      '体調に異変を感じたら直ちに縛りを中断してください。';
+
+  static const String releaseMessage =
+      '完済おめでとうございます。うどん縛りは解除されました。最初の一食は、好きなものを。';
+
+  static const String _enabledKey = 'konbini_udon_challenge_enabled_v1';
+  static const String _startedAtKey = 'konbini_udon_challenge_started_at_v1';
+  static const String _historyKey = 'konbini_udon_challenge_history_v1';
+  static const String _configKey = 'konbini_udon_challenge_config_v1';
+
+  final DateTime Function()? nowProvider;
+
+  DateTime _now() => nowProvider?.call() ?? DateTime.now();
+
+  static KonbiniUdonSavingsEstimate estimateSavings(
+    KonbiniUdonChallengeConfig config,
+  ) {
+    final monthlyUdonCost = max(0.0, config.udonUnitPrice) *
+        KonbiniUdonMealSlot.values.length *
+        averageDaysPerMonth;
+    final baseline = max(0.0, config.baselineMonthlyFoodCost);
+    return KonbiniUdonSavingsEstimate(
+      monthlyUdonCost: monthlyUdonCost,
+      monthlyBaselineFoodCost: baseline,
+      monthlySavings: max(0.0, baseline - monthlyUdonCost),
+    );
+  }
+
+  static KonbiniUdonHealthAdvisory healthAdvisoryFor(int consecutiveDays) {
+    if (consecutiveDays >= dangerStreakThresholdDays) {
+      return const KonbiniUdonHealthAdvisory(
+        level: KonbiniUdonHealthAdvisoryLevel.danger,
+        title: '健康最優先: 縛りの緩和を強く推奨します',
+        body: '単一食が14日以上続いています。ここから先は健康リスクが節約メリットを上回ります。'
+            '野菜とタンパク質を含む食事へ切り替え、体調不良があれば医療機関の受診を検討してください。'
+            '健康を損なうと医療費と収入減で、返済計画そのものが崩れます。',
+      );
+    }
+    if (consecutiveDays >= warningStreakThresholdDays) {
+      return const KonbiniUdonHealthAdvisory(
+        level: KonbiniUdonHealthAdvisoryLevel.warning,
+        title: '栄養不足リスクが高まっています',
+        body: 'うどん縛りが7日以上続いています。タンパク質・ビタミン・食物繊維が不足しがちです。'
+            '卵・サラダチキン・わかめのトッピングを必須にして、疲労感や集中力低下を感じたら'
+            '縛りを緩めてください。',
+      );
+    }
+    if (consecutiveDays >= infoStreakThresholdDays) {
+      return const KonbiniUdonHealthAdvisory(
+        level: KonbiniUdonHealthAdvisoryLevel.info,
+        title: 'トッピングで栄養を補ってください',
+        body: '連続遵守おつかれさまです。卵・わかめ・ねぎ・サラダチキンのトッピングは'
+            '「うどんの範囲内」です。価格を抑えたままタンパク質とミネラルを補えます。',
+      );
+    }
+    return const KonbiniUdonHealthAdvisory(
+      level: KonbiniUdonHealthAdvisoryLevel.none,
+      title: '',
+      body: '',
+    );
+  }
+
+  Future<KonbiniUdonChallengeSnapshot> loadSnapshot({
+    required double remainingDebt,
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final now = _now();
+    final history = _readHistory(store.getString(_historyKey));
+    final isReleased = remainingDebt <= 0;
+    final storedEnabled = store.getBool(_enabledKey) ?? false;
+
+    if (isReleased && storedEnabled) {
+      await store.setBool(_enabledKey, false);
+    }
+
+    final todayRecord = history[_dateKey(now)] ?? _emptyDayRecord();
+
+    return KonbiniUdonChallengeSnapshot(
+      remainingDebt: remainingDebt,
+      isEnabled: !isReleased && storedEnabled,
+      isReleased: isReleased,
+      startedAt: _parseDate(store.getString(_startedAtKey)),
+      config: _readConfig(store.getString(_configKey)),
+      todayUdonSlots: _readUdonSlots(todayRecord),
+      todayViolations: _sortViolations(_readViolations(todayRecord)),
+      currentStreakDays: _calculateStreak(history, now: now),
+      totalCompliantDays: _countCompliantDays(history),
+      recentViolations: _recentViolations(history),
+    );
+  }
+
+  Future<KonbiniUdonChallengeSnapshot> setEnabled(
+    bool enabled, {
+    required double remainingDebt,
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    if (enabled && remainingDebt <= 0) {
+      await store.setBool(_enabledKey, false);
+      return loadSnapshot(remainingDebt: remainingDebt, prefs: store);
+    }
+
+    await store.setBool(_enabledKey, enabled);
+    if (enabled && (store.getString(_startedAtKey) ?? '').isEmpty) {
+      await store.setString(_startedAtKey, _now().toUtc().toIso8601String());
+    }
+    return loadSnapshot(remainingDebt: remainingDebt, prefs: store);
+  }
+
+  Future<KonbiniUdonChallengeSnapshot> toggleMealSlot(
+    KonbiniUdonMealSlot slot,
+    bool ateUdon, {
+    required double remainingDebt,
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final history = _readHistory(store.getString(_historyKey));
+    final todayKey = _dateKey(_now());
+    final todayRecord = Map<String, dynamic>.from(
+      history[todayKey] ?? _emptyDayRecord(),
+    );
+    final slots = _readUdonSlots(todayRecord);
+
+    if (ateUdon) {
+      slots.add(slot);
+    } else {
+      slots.remove(slot);
+    }
+
+    todayRecord['udon_slots'] = slots.map((entry) => entry.storageId).toList()
+      ..sort();
+    todayRecord['updated_at'] = _now().toUtc().toIso8601String();
+    history[todayKey] = todayRecord;
+
+    await _saveHistory(store, history);
+    return loadSnapshot(remainingDebt: remainingDebt, prefs: store);
+  }
+
+  Future<KonbiniUdonChallengeSnapshot> recordViolation({
+    required String note,
+    required double amount,
+    KonbiniUdonMealSlot? slot,
+    required double remainingDebt,
+    SharedPreferences? prefs,
+  }) async {
+    final trimmedNote = note.trim();
+    if (trimmedNote.isEmpty) {
+      throw ArgumentError('note must not be empty');
+    }
+
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final now = _now();
+    final history = _readHistory(store.getString(_historyKey));
+    final todayKey = _dateKey(now);
+    final todayRecord = Map<String, dynamic>.from(
+      history[todayKey] ?? _emptyDayRecord(),
+    );
+    final violations = _readViolations(todayRecord);
+
+    violations.add(
+      KonbiniUdonViolation(
+        id: 'konbini_udon_${now.microsecondsSinceEpoch}_${violations.length}',
+        mealSlot: slot,
+        note: trimmedNote,
+        amount: amount,
+        createdAt: now,
+      ),
+    );
+
+    // うどん以外を食べたスロットは遵守チェックからも外す。
+    final slots = _readUdonSlots(todayRecord);
+    if (slot != null) {
+      slots.remove(slot);
+    }
+
+    todayRecord['udon_slots'] = slots.map((entry) => entry.storageId).toList()
+      ..sort();
+    todayRecord['violations'] =
+        violations.map((entry) => entry.toJson()).toList();
+    todayRecord['updated_at'] = now.toUtc().toIso8601String();
+    history[todayKey] = todayRecord;
+
+    await _saveHistory(store, history);
+    return loadSnapshot(remainingDebt: remainingDebt, prefs: store);
+  }
+
+  Future<KonbiniUdonChallengeSnapshot> updateConfig({
+    required double udonUnitPrice,
+    required double baselineMonthlyFoodCost,
+    required double remainingDebt,
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final config = KonbiniUdonChallengeConfig(
+      udonUnitPrice: max(0.0, udonUnitPrice),
+      baselineMonthlyFoodCost: max(0.0, baselineMonthlyFoodCost),
+    );
+    await store.setString(_configKey, jsonEncode(config.toJson()));
+    return loadSnapshot(remainingDebt: remainingDebt, prefs: store);
+  }
+
+  Future<void> _saveHistory(
+    SharedPreferences store,
+    Map<String, Map<String, dynamic>> history,
+  ) async {
+    await store.setString(_historyKey, jsonEncode(history));
+  }
+
+  KonbiniUdonChallengeConfig _readConfig(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return KonbiniUdonChallengeConfig.defaults;
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        return KonbiniUdonChallengeConfig.defaults;
+      }
+      return KonbiniUdonChallengeConfig.fromJson(
+        Map<String, dynamic>.from(decoded),
+      );
+    } catch (_) {
+      return KonbiniUdonChallengeConfig.defaults;
+    }
+  }
+
+  Map<String, Map<String, dynamic>> _readHistory(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return <String, Map<String, dynamic>>{};
+    }
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        return <String, Map<String, dynamic>>{};
+      }
+
+      final history = <String, Map<String, dynamic>>{};
+      decoded.forEach((key, value) {
+        if (key is! String || value is! Map) {
+          return;
+        }
+        history[key] = Map<String, dynamic>.from(value);
+      });
+      return history;
+    } catch (_) {
+      return <String, Map<String, dynamic>>{};
+    }
+  }
+
+  Map<String, dynamic> _emptyDayRecord() {
+    return <String, dynamic>{
+      'udon_slots': <String>[],
+      'violations': <Map<String, dynamic>>[],
+    };
+  }
+
+  Set<KonbiniUdonMealSlot> _readUdonSlots(Map<String, dynamic> record) {
+    final rawSlots = ((record['udon_slots'] as List<dynamic>?) ?? const [])
+        .map((entry) => entry.toString())
+        .toSet();
+    return KonbiniUdonMealSlot.values
+        .where((slot) => rawSlots.contains(slot.storageId))
+        .toSet();
+  }
+
+  List<KonbiniUdonViolation> _readViolations(Map<String, dynamic> record) {
+    return ((record['violations'] as List<dynamic>?) ?? const [])
+        .whereType<Map>()
+        .map(
+          (entry) =>
+              KonbiniUdonViolation.fromJson(Map<String, dynamic>.from(entry)),
+        )
+        .toList();
+  }
+
+  List<KonbiniUdonViolation> _sortViolations(
+    List<KonbiniUdonViolation> values,
+  ) {
+    final sorted = List<KonbiniUdonViolation>.from(values);
+    sorted.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return sorted;
+  }
+
+  List<KonbiniUdonViolation> _recentViolations(
+    Map<String, Map<String, dynamic>> history,
+  ) {
+    final values =
+        history.values.expand(_readViolations).toList(growable: false);
+    final sorted = _sortViolations(values);
+    if (sorted.length <= 5) {
+      return sorted;
+    }
+    return sorted.take(5).toList(growable: false);
+  }
+
+  bool _isCompliantRecord(Map<String, dynamic> record) {
+    return _readViolations(record).isEmpty &&
+        _readUdonSlots(record).length >= KonbiniUdonMealSlot.values.length;
+  }
+
+  int _countCompliantDays(Map<String, Map<String, dynamic>> history) {
+    return history.values.where(_isCompliantRecord).length;
+  }
+
+  /// 連続遵守日数。今日が未完了(違反なし・3食未記録)の場合は昨日から
+  /// 遡って数える。今日すでに違反があるなら連続は0。
+  int _calculateStreak(
+    Map<String, Map<String, dynamic>> history, {
+    required DateTime now,
+  }) {
+    var current = DateTime(now.year, now.month, now.day);
+    final todayRecord = history[_dateKey(current)];
+
+    if (todayRecord != null) {
+      if (_readViolations(todayRecord).isNotEmpty) {
+        return 0;
+      }
+      if (!_isCompliantRecord(todayRecord)) {
+        current = current.subtract(const Duration(days: 1));
+      }
+    } else {
+      current = current.subtract(const Duration(days: 1));
+    }
+
+    var streak = 0;
+    while (true) {
+      final record = history[_dateKey(current)];
+      if (record == null || !_isCompliantRecord(record)) {
+        break;
+      }
+      streak += 1;
+      current = current.subtract(const Duration(days: 1));
+    }
+
+    return streak;
+  }
+
+  DateTime? _parseDate(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    return DateTime.tryParse(raw)?.toLocal();
+  }
+
+  String _dateKey(DateTime value) {
+    final year = value.year.toString().padLeft(4, '0');
+    final month = value.month.toString().padLeft(2, '0');
+    final day = value.day.toString().padLeft(2, '0');
+    return '$year-$month-$day';
+  }
+}

--- a/test/services/konbini_udon_challenge_service_test.dart
+++ b/test/services/konbini_udon_challenge_service_test.dart
@@ -1,0 +1,208 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/konbini_udon_challenge_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('KonbiniUdonChallengeService', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('can enable the challenge and complete all three meals', () async {
+      final now = DateTime(2026, 6, 11, 8, 0);
+      final service = KonbiniUdonChallengeService(nowProvider: () => now);
+
+      var snapshot = await service.setEnabled(true, remainingDebt: 300000);
+
+      expect(snapshot.isEnabled, isTrue);
+      expect(snapshot.isReleased, isFalse);
+      expect(snapshot.startedAt, isNotNull);
+      expect(snapshot.isTodayCompliant, isFalse);
+
+      for (final slot in KonbiniUdonMealSlot.values) {
+        snapshot = await service.toggleMealSlot(
+          slot,
+          true,
+          remainingDebt: 300000,
+        );
+      }
+
+      expect(snapshot.todayUdonSlots, hasLength(3));
+      expect(snapshot.isTodayCompliant, isTrue);
+      expect(snapshot.currentStreakDays, 1);
+      expect(snapshot.totalCompliantDays, 1);
+    });
+
+    test('a violation breaks today compliance and clears its meal slot',
+        () async {
+      final now = DateTime(2026, 6, 11, 12, 30);
+      final service = KonbiniUdonChallengeService(nowProvider: () => now);
+
+      await service.setEnabled(true, remainingDebt: 300000);
+      for (final slot in KonbiniUdonMealSlot.values) {
+        await service.toggleMealSlot(slot, true, remainingDebt: 300000);
+      }
+
+      final snapshot = await service.recordViolation(
+        note: '牛丼を食べてしまった',
+        amount: 580,
+        slot: KonbiniUdonMealSlot.lunch,
+        remainingDebt: 300000,
+      );
+
+      expect(snapshot.todayViolations, hasLength(1));
+      expect(
+        snapshot.todayViolations.first.mealSlot,
+        KonbiniUdonMealSlot.lunch,
+      );
+      expect(snapshot.todayViolations.first.amount, 580);
+      expect(
+        snapshot.todayUdonSlots.contains(KonbiniUdonMealSlot.lunch),
+        isFalse,
+      );
+      expect(snapshot.isTodayCompliant, isFalse);
+      expect(snapshot.currentStreakDays, 0);
+      expect(snapshot.recentViolations.first.note, '牛丼を食べてしまった');
+    });
+
+    test('releases the challenge automatically when debt reaches zero',
+        () async {
+      final service = KonbiniUdonChallengeService(
+        nowProvider: () => DateTime(2026, 6, 11, 9, 0),
+      );
+
+      await service.setEnabled(true, remainingDebt: 120000);
+      final snapshot = await service.loadSnapshot(remainingDebt: 0);
+
+      expect(snapshot.isReleased, isTrue);
+      expect(snapshot.isEnabled, isFalse);
+      expect(snapshot.isActive, isFalse);
+    });
+
+    test('counts streak across consecutive fully compliant days', () async {
+      var now = DateTime(2026, 6, 9, 7, 0);
+      final service = KonbiniUdonChallengeService(nowProvider: () => now);
+
+      await service.setEnabled(true, remainingDebt: 200000);
+      for (final slot in KonbiniUdonMealSlot.values) {
+        await service.toggleMealSlot(slot, true, remainingDebt: 200000);
+      }
+
+      now = now.add(const Duration(days: 1));
+      for (final slot in KonbiniUdonMealSlot.values) {
+        await service.toggleMealSlot(slot, true, remainingDebt: 200000);
+      }
+
+      var snapshot = await service.loadSnapshot(remainingDebt: 200000);
+      expect(snapshot.currentStreakDays, 2);
+      expect(snapshot.totalCompliantDays, 2);
+
+      // 翌日まだ何も記録していない朝の時点では、昨日までの連続を保持する。
+      now = now.add(const Duration(days: 1));
+      snapshot = await service.loadSnapshot(remainingDebt: 200000);
+      expect(snapshot.currentStreakDays, 2);
+    });
+
+    test('estimates monthly savings from config defaults', () {
+      const estimate = KonbiniUdonSavingsEstimate(
+        monthlyUdonCost: 0,
+        monthlyBaselineFoodCost: 0,
+        monthlySavings: 0,
+      );
+      expect(estimate.hasSavings, isFalse);
+
+      final computed = KonbiniUdonChallengeService.estimateSavings(
+        KonbiniUdonChallengeConfig.defaults,
+      );
+
+      // 200円 × 3食 × 30.4日 = 18,240円 / 月。
+      expect(computed.monthlyUdonCost, closeTo(18240, 0.01));
+      expect(computed.monthlyBaselineFoodCost, 45000);
+      expect(computed.monthlySavings, closeTo(26760, 0.01));
+      expect(computed.hasSavings, isTrue);
+      expect(computed.dailySavings, closeTo(26760 / 30.4, 0.01));
+    });
+
+    test('clamps savings to zero when udon costs exceed the baseline', () {
+      final computed = KonbiniUdonChallengeService.estimateSavings(
+        const KonbiniUdonChallengeConfig(
+          udonUnitPrice: 800,
+          baselineMonthlyFoodCost: 30000,
+        ),
+      );
+
+      expect(computed.monthlySavings, 0);
+      expect(computed.hasSavings, isFalse);
+    });
+
+    test('escalates health advisory with consecutive days', () {
+      expect(
+        KonbiniUdonChallengeService.healthAdvisoryFor(2).level,
+        KonbiniUdonHealthAdvisoryLevel.none,
+      );
+      expect(
+        KonbiniUdonChallengeService.healthAdvisoryFor(3).level,
+        KonbiniUdonHealthAdvisoryLevel.info,
+      );
+      expect(
+        KonbiniUdonChallengeService.healthAdvisoryFor(7).level,
+        KonbiniUdonHealthAdvisoryLevel.warning,
+      );
+      expect(
+        KonbiniUdonChallengeService.healthAdvisoryFor(14).level,
+        KonbiniUdonHealthAdvisoryLevel.danger,
+      );
+    });
+
+    test('persists config updates and clamps negative values', () async {
+      final service = KonbiniUdonChallengeService(
+        nowProvider: () => DateTime(2026, 6, 11, 10, 0),
+      );
+
+      final snapshot = await service.updateConfig(
+        udonUnitPrice: 250,
+        baselineMonthlyFoodCost: -100,
+        remainingDebt: 50000,
+      );
+
+      expect(snapshot.config.udonUnitPrice, 250);
+      expect(snapshot.config.baselineMonthlyFoodCost, 0);
+      expect(snapshot.savings.monthlySavings, 0);
+    });
+
+    test('tolerates corrupted history payloads', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'konbini_udon_challenge_history_v1': '{broken json',
+        'konbini_udon_challenge_config_v1': '[]',
+      });
+      final service = KonbiniUdonChallengeService(
+        nowProvider: () => DateTime(2026, 6, 11, 11, 0),
+      );
+
+      final snapshot = await service.loadSnapshot(remainingDebt: 80000);
+
+      expect(snapshot.todayUdonSlots, isEmpty);
+      expect(snapshot.todayViolations, isEmpty);
+      expect(snapshot.currentStreakDays, 0);
+      expect(
+        snapshot.config.udonUnitPrice,
+        KonbiniUdonChallengeService.defaultUdonUnitPrice,
+      );
+    });
+
+    test('rejects an empty violation note', () async {
+      final service = KonbiniUdonChallengeService(
+        nowProvider: () => DateTime(2026, 6, 11, 12, 0),
+      );
+
+      await expectLater(
+        service.recordViolation(
+          note: '   ',
+          amount: 100,
+          remainingDebt: 10000,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

「**借金を完済するまで、コンビニのうどんしか食ってはいけない**」縛り(うどん縛り)を資産管理ページの借金返済プランへ実装する。MoneyForward 系の家計簿が持たない**コミットメント・デバイス層**(行動変容)の第1弾。記録するだけのツールから、完済へ向けて行動を縛るツールへ。

## 実装

- `lib/services/konbini_udon_challenge_service.dart` (新規 / 648行級の DebtLockdownService と同型パターン)
  - 朝/昼/夜の3食うどんチェック、連続・通算遵守日数、違反ログ(何を食べたか+支払額)
  - 節約試算: うどん単価×3食×30.4日 vs 月間食費基準(初期値: うどん200円 / 食費45,000円=総務省家計調査 単身世帯目安、ともに調整可)
  - 健康ガードレール: 連続 3日=info(トッピング推奨) / 7日=warning(栄養不足リスク) / 14日=danger(縛り緩和強推奨+受診検討)。医学的助言でない旨の免責を常時表示
  - 完済(残債0)で自動釈放。SharedPreferences ローカル保存のみ・ネットワーク/DB 書き込みなし
- `lib/pages/asset_management_page.dart`
  - 収監モードパネル直下に「うどん縛り — 完済までの獄中食」パネル
  - 誓約ダイアログ(健康免責明記)/ 違反記録ダイアログ / 節約前提調整ダイアログ
  - 返済シミュレーション連携: 節約額を `extraMonthlyPayment` として `AssetLiabilityRepaymentSimulationService.buildComparison` に注入 → **完済前倒しヶ月数・利息圧縮額**を表示
- `test/services/konbini_udon_challenge_service_test.dart` (新規): 10 テスト

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) 誓約→3食チェック→遵守日カウント (2) 違反記録→当日遵守破棄+該当食スロット解除 (3) 残債0→自動釈放。加えて節約算定・健康 advisory 閾値・破損 JSON 耐性・設定永続化まで計 10 ケース。
- E2E例外: 本機能は端末ローカル SharedPreferences 完結(ネットワーク・DB・Edge Function 変更なし)のため、エンドツーエンド(integration_test)の追加は行わず、service 単体テストで入出力契約を担保する。
- 検証状況: `dart format` ローカル PASS。`flutter analyze` / `flutter test` はローカル dart toolchain のハング(既知の zombie daemon 環境問題)により実行不能 → CI の analyze/test を正とする。

## 健康・法務ガードレール (ライフプランナー/FP/弁護士視点)

- 単一食継続の栄養リスクは段階警告で明示し、「健康を損なうと医療費と収入減で返済計画そのものが崩れる」というFP観点を danger 文言に組込み
- 既存の利息制限法/出資法上限・貸付自粛制度・違法業者警告(`DebtLockdownService`)は変更なしで併存

🤖 Generated with [Claude Code](https://claude.com/claude-code)
