### PR TITLE
feat(asset): 表示モード(ミニマム/標準/フル) + マネーカレンダー (part 268)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -7398,9 +7398,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       salaryDay: _salarySpendingSalaryDay,
     );
     final selectedDate = _calendarSelectedDate;
-    final selectedDay = selectedDate == null
-        ? null
-        : calendar.dayFor(selectedDate);
+    final selectedDay =
+        selectedDate == null ? null : calendar.dayFor(selectedDate);
     final today = DateTime.now();
     const weekdayLabels = ['日', '月', '火', '水', '木', '金', '土'];
 
@@ -7646,9 +7645,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   String _formatCalendarAmount(double value) {
     if (value >= 10000) {
       final man = value / 10000;
-      final label = man >= 10
-          ? man.round().toString()
-          : man.toStringAsFixed(1);
+      final label = man >= 10 ? man.round().toString() : man.toStringAsFixed(1);
       return '$label万';
     }
     return NumberFormat('#,###').format(value.round());

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -32,7 +32,9 @@ import 'package:my_web_app/services/asset_liability_repayment_simulation_service
 import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_ai_analysis_history_service.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
+import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
+import 'package:my_web_app/services/asset_payment_calendar_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
@@ -326,6 +328,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   KonbiniUdonChallengeSnapshot? _konbiniUdonSnapshot;
   bool _isLoadingKonbiniUdon = false;
   double? _konbiniUdonLoadedForDebt;
+  final AssetManagementDisplayModeStore _displayModeStore =
+      const AssetManagementDisplayModeStore();
+  AssetManagementDisplayMode _displayMode =
+      AssetManagementDisplayModeStore.defaultMode;
+  DateTime _calendarMonth = DateTime.now();
+  DateTime? _calendarSelectedDate;
   Future<AssetWasteTrainingAiReview>? _wasteTrainingAiReviewFuture;
   String? _wasteTrainingAiReviewKey;
   bool _isGeneratingAssetManagementAiSummary = false;
@@ -402,6 +410,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _fetchRecentFlows();
     _fetchSubscriptions();
     _fetchMustTasks();
+    _loadDisplayMode();
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
       final previousMonthKey = _assetLiabilityStateMonthKey(_now);
@@ -7216,40 +7225,485 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _buildUnifiedEntryBanner(),
               const SizedBox(height: 16),
             ],
+            _buildDisplayModeSwitcher(),
+            const SizedBox(height: 12),
             _buildMonthlyFlowFirstCard(),
             const SizedBox(height: 16),
-            _buildSalarySpendingBreakdownCard(),
+            _buildAssetCalendarCard(assetLiabilityWorkbook),
             const SizedBox(height: 16),
+            if (_isTierVisible(AssetManagementSectionTier.standard)) ...[
+              _buildSalarySpendingBreakdownCard(),
+              const SizedBox(height: 16),
+            ],
             _buildDisposableBalanceCard(),
             const SizedBox(height: 16),
             _buildMonthlyFlowPrimaryActionBar(),
             const SizedBox(height: 16),
-            _buildWasteTrainingAiCard(),
-            const SizedBox(height: 24),
-            _buildDeadlineChecklistCard(), // 締切チェックリスト
-            const SizedBox(height: 16),
-            _buildThreeMonthOverviewCard(), // 3ヶ月俯瞰
-            const SizedBox(height: 16),
+            if (_isTierVisible(AssetManagementSectionTier.full)) ...[
+              _buildWasteTrainingAiCard(),
+              const SizedBox(height: 24),
+            ],
+            if (_isTierVisible(AssetManagementSectionTier.standard)) ...[
+              _buildDeadlineChecklistCard(), // 締切チェックリスト
+              const SizedBox(height: 16),
+              _buildThreeMonthOverviewCard(), // 3ヶ月俯瞰
+              const SizedBox(height: 16),
+            ],
             _buildDebtPlannerCard(assetLiabilityWorkbook), // 借金返済プラン
             const SizedBox(height: 16),
-            _buildAssetLiabilityWorkbookBoard(assetLiabilityWorkbook),
-            const SizedBox(height: 16),
-            Container(
-              key: _keyStock,
-              child: _buildAssetLiabilityCard(),
-            ), // ①②資産負債
-            const SizedBox(height: 24),
-            Container(key: _keyFlow, child: _buildFlowCard()), // ④収支
-            const SizedBox(height: 24),
-            Container(key: _keySubs, child: _buildSubscriptionCard()), // ③固定費
-            const SizedBox(height: 24),
-            Container(key: _keyMust, child: _buildMustTasksCard()), // ⑤必須タスク
-            const SizedBox(height: 24),
-            _buildChartCard(), // グラフ
+            if (_isTierVisible(AssetManagementSectionTier.standard)) ...[
+              _buildAssetLiabilityWorkbookBoard(assetLiabilityWorkbook),
+              const SizedBox(height: 16),
+              Container(
+                key: _keyStock,
+                child: _buildAssetLiabilityCard(),
+              ), // ①②資産負債
+              const SizedBox(height: 24),
+              Container(key: _keyFlow, child: _buildFlowCard()), // ④収支
+              const SizedBox(height: 24),
+              Container(
+                key: _keySubs,
+                child: _buildSubscriptionCard(),
+              ), // ③固定費
+              const SizedBox(height: 24),
+              Container(
+                key: _keyMust,
+                child: _buildMustTasksCard(),
+              ), // ⑤必須タスク
+              const SizedBox(height: 24),
+            ],
+            if (_isTierVisible(AssetManagementSectionTier.full))
+              _buildChartCard(), // グラフ
           ],
         ),
       ),
     );
+  }
+
+  bool _isTierVisible(AssetManagementSectionTier tier) {
+    return AssetManagementDisplayModeStore.isTierVisible(
+      tier: tier,
+      mode: _displayMode,
+    );
+  }
+
+  Future<void> _loadDisplayMode() async {
+    final mode = await _displayModeStore.load();
+    if (!mounted || mode == _displayMode) {
+      return;
+    }
+    setState(() {
+      _displayMode = mode;
+    });
+  }
+
+  Future<void> _setDisplayMode(AssetManagementDisplayMode mode) async {
+    if (mode == _displayMode) {
+      return;
+    }
+    setState(() {
+      _displayMode = mode;
+    });
+    await _displayModeStore.save(mode);
+  }
+
+  Widget _buildDisplayModeSwitcher() {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.tune, size: 18, color: Color(0xFF7C3AED)),
+                const SizedBox(width: 8),
+                const Text(
+                  '表示モード',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    _displayMode.description,
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final mode in AssetManagementDisplayMode.values)
+                  ChoiceChip(
+                    key: Key('asset_display_mode_${mode.name}'),
+                    selected: _displayMode == mode,
+                    onSelected: (_) => _setDisplayMode(mode),
+                    selectedColor: const Color(0xFF7C3AED),
+                    labelStyle: TextStyle(
+                      color: _displayMode == mode
+                          ? Colors.white
+                          : Theme.of(context).colorScheme.onSurface,
+                      fontWeight: FontWeight.w700,
+                      height: 1.5,
+                    ),
+                    label: Text(mode.label),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _shiftCalendarMonth(int delta) {
+    setState(() {
+      _calendarMonth = DateTime(
+        _calendarMonth.year,
+        _calendarMonth.month + delta,
+      );
+      _calendarSelectedDate = null;
+    });
+  }
+
+  Widget _buildAssetCalendarCard(AssetLiabilityWorkbook? workbook) {
+    final debtRows =
+        workbook?.debtMasterRows ?? const <AssetLiabilityDebtRow>[];
+    final calendar = AssetPaymentCalendarService.buildMonth(
+      month: _calendarMonth,
+      flows: _recentFlows,
+      subscriptions: _subscriptionsForMonth(_calendarMonth),
+      debts: [
+        for (final row in debtRows)
+          AssetCalendarDebtInput(
+            name: row.name,
+            balance: row.balance,
+            paymentDay: row.paymentDay,
+            scheduledPaymentAmount: row.scheduledPaymentAmount,
+            isDirectCashflowTarget: row.isDirectCashflowTarget,
+          ),
+      ],
+      salaryDay: _salarySpendingSalaryDay,
+    );
+    final selectedDate = _calendarSelectedDate;
+    final selectedDay = selectedDate == null
+        ? null
+        : calendar.dayFor(selectedDate);
+    final today = DateTime.now();
+    const weekdayLabels = ['日', '月', '火', '水', '木', '金', '土'];
+
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.calendar_month, color: Color(0xFF1D4ED8)),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    'マネーカレンダー',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  key: const Key('asset_calendar_prev_month'),
+                  tooltip: '前の月',
+                  icon: const Icon(Icons.chevron_left),
+                  onPressed: () => _shiftCalendarMonth(-1),
+                ),
+                Text(
+                  DateFormat('yyyy年M月').format(calendar.month),
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    height: 1.4,
+                  ),
+                ),
+                IconButton(
+                  key: const Key('asset_calendar_next_month'),
+                  tooltip: '次の月',
+                  icon: const Icon(Icons.chevron_right),
+                  onPressed: () => _shiftCalendarMonth(1),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '日ごとの支出と、返済日・固定費・給料日のイベントをまとめて見渡せます。',
+              style: TextStyle(
+                fontSize: 11,
+                color: Theme.of(context).colorScheme.onSurface,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                for (final weekday in weekdayLabels)
+                  Expanded(
+                    child: Text(
+                      weekday,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        height: 1.4,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            for (final week in calendar.weeks)
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  for (final day in week)
+                    Expanded(child: _buildAssetCalendarCell(day, today)),
+                ],
+              ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 12,
+              runSpacing: 4,
+              children: [
+                _buildCalendarLegendItem(const Color(0xFFB91C1C), '返済日'),
+                _buildCalendarLegendItem(const Color(0xFF9333EA), '固定費'),
+                _buildCalendarLegendItem(const Color(0xFF0D9488), '給料日'),
+                _buildCalendarLegendItem(const Color(0xFF2563EB), '収入'),
+              ],
+            ),
+            if (selectedDay != null) ...[
+              const SizedBox(height: 10),
+              Text(
+                '${DateFormat('M月d日').format(selectedDay.date)} のイベント',
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 6),
+              if (!selectedDay.hasAnyEvent)
+                Text(
+                  'この日のイベントはありません。',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    height: 1.5,
+                  ),
+                )
+              else
+                for (final event in selectedDay.events.take(10))
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Row(
+                      children: [
+                        Icon(
+                          _calendarEventIcon(event.kind),
+                          size: 14,
+                          color: _calendarEventColor(event.kind),
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            event.label,
+                            style: const TextStyle(fontSize: 12, height: 1.5),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        if (event.amount != null)
+                          Text(
+                            _formatYen(event.amount!),
+                            style: const TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w700,
+                              height: 1.5,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+            ],
+            const SizedBox(height: 4),
+            Text(
+              '支出・収入は記録済みフロー(直近取得分)に基づく概算です。',
+              style: TextStyle(
+                fontSize: 10,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                height: 1.5,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAssetCalendarCell(AssetCalendarDaySummary? day, DateTime today) {
+    if (day == null) {
+      return const SizedBox(height: 54);
+    }
+    final isToday = day.date.year == today.year &&
+        day.date.month == today.month &&
+        day.date.day == today.day;
+    final selectedDate = _calendarSelectedDate;
+    final isSelected = selectedDate != null &&
+        day.date.year == selectedDate.year &&
+        day.date.month == selectedDate.month &&
+        day.date.day == selectedDate.day;
+    final markers = <Color>[
+      if (day.hasDebtPayment) const Color(0xFFB91C1C),
+      if (day.hasSubscription) const Color(0xFF9333EA),
+      if (day.hasSalary) const Color(0xFF0D9488),
+      if (day.hasIncome) const Color(0xFF2563EB),
+    ];
+
+    return InkWell(
+      key: Key('asset_calendar_day_${day.date.day}'),
+      borderRadius: BorderRadius.circular(6),
+      onTap: () {
+        setState(() {
+          _calendarSelectedDate = day.date;
+        });
+      },
+      child: Container(
+        height: 54,
+        margin: const EdgeInsets.all(1),
+        padding: const EdgeInsets.symmetric(vertical: 3),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? const Color(0xFF7C3AED).withValues(alpha: 0.14)
+              : null,
+          borderRadius: BorderRadius.circular(6),
+          border: isToday
+              ? Border.all(color: const Color(0xFF7C3AED), width: 1.5)
+              : null,
+        ),
+        child: Column(
+          children: [
+            Text(
+              '${day.date.day}',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: isToday ? FontWeight.w800 : FontWeight.w600,
+                height: 1.2,
+              ),
+            ),
+            if (day.expenseTotal > 0)
+              Text(
+                _formatCalendarAmount(day.expenseTotal),
+                style: const TextStyle(
+                  fontSize: 9,
+                  color: Color(0xFFB91C1C),
+                  fontWeight: FontWeight.w700,
+                  height: 1.2,
+                ),
+              ),
+            const Spacer(),
+            if (markers.isNotEmpty)
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  for (final color in markers.take(4))
+                    Container(
+                      width: 5,
+                      height: 5,
+                      margin: const EdgeInsets.symmetric(horizontal: 1),
+                      decoration: BoxDecoration(
+                        color: color,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatCalendarAmount(double value) {
+    if (value >= 10000) {
+      final man = value / 10000;
+      final label = man >= 10
+          ? man.round().toString()
+          : man.toStringAsFixed(1);
+      return '$label万';
+    }
+    return NumberFormat('#,###').format(value.round());
+  }
+
+  Widget _buildCalendarLegendItem(Color color, String label) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 7,
+          height: 7,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 4),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 10,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            height: 1.4,
+          ),
+        ),
+      ],
+    );
+  }
+
+  IconData _calendarEventIcon(AssetCalendarEventKind kind) {
+    switch (kind) {
+      case AssetCalendarEventKind.salary:
+        return Icons.payments_outlined;
+      case AssetCalendarEventKind.debtPayment:
+        return Icons.account_balance_outlined;
+      case AssetCalendarEventKind.subscription:
+        return Icons.autorenew;
+      case AssetCalendarEventKind.expense:
+        return Icons.remove_circle_outline;
+      case AssetCalendarEventKind.income:
+        return Icons.add_circle_outline;
+    }
+  }
+
+  Color _calendarEventColor(AssetCalendarEventKind kind) {
+    switch (kind) {
+      case AssetCalendarEventKind.salary:
+        return const Color(0xFF0D9488);
+      case AssetCalendarEventKind.debtPayment:
+        return const Color(0xFFB91C1C);
+      case AssetCalendarEventKind.subscription:
+        return const Color(0xFF9333EA);
+      case AssetCalendarEventKind.expense:
+        return const Color(0xFFC05621);
+      case AssetCalendarEventKind.income:
+        return const Color(0xFF2563EB);
+    }
   }
 
   Widget _buildUnifiedEntryBanner() {

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -1,0 +1,78 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 資産管理ページの表示モード。情報量を段階的に開示する。
+enum AssetManagementDisplayMode { minimum, standard, full }
+
+/// 各セクションの重要度ティア。モードとの対応:
+/// minimum → essential のみ / standard → essential+standard / full → 全部。
+enum AssetManagementSectionTier { essential, standard, full }
+
+extension AssetManagementDisplayModeLabel on AssetManagementDisplayMode {
+  String get label {
+    switch (this) {
+      case AssetManagementDisplayMode.minimum:
+        return 'ミニマム';
+      case AssetManagementDisplayMode.standard:
+        return '標準';
+      case AssetManagementDisplayMode.full:
+        return 'フル';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case AssetManagementDisplayMode.minimum:
+        return '最重要のみ: 収支・残高・借金返済・カレンダー';
+      case AssetManagementDisplayMode.standard:
+        return '優先度の高い機能まで表示';
+      case AssetManagementDisplayMode.full:
+        return '全機能表示(従来どおり)';
+    }
+  }
+
+  String get storageId => name;
+}
+
+/// 表示モードの永続化と、ティア×モードの可視判定。
+class AssetManagementDisplayModeStore {
+  const AssetManagementDisplayModeStore();
+
+  /// 既存ユーザーの体験を変えないため、未設定時はフル表示。
+  static const AssetManagementDisplayMode defaultMode =
+      AssetManagementDisplayMode.full;
+
+  static const String _modeKey = 'asset_management_display_mode_v1';
+
+  static bool isTierVisible({
+    required AssetManagementSectionTier tier,
+    required AssetManagementDisplayMode mode,
+  }) {
+    switch (mode) {
+      case AssetManagementDisplayMode.minimum:
+        return tier == AssetManagementSectionTier.essential;
+      case AssetManagementDisplayMode.standard:
+        return tier != AssetManagementSectionTier.full;
+      case AssetManagementDisplayMode.full:
+        return true;
+    }
+  }
+
+  Future<AssetManagementDisplayMode> load({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getString(_modeKey);
+    for (final mode in AssetManagementDisplayMode.values) {
+      if (mode.storageId == raw) {
+        return mode;
+      }
+    }
+    return defaultMode;
+  }
+
+  Future<void> save(
+    AssetManagementDisplayMode mode, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    await store.setString(_modeKey, mode.storageId);
+  }
+}

--- a/lib/services/asset_payment_calendar_service.dart
+++ b/lib/services/asset_payment_calendar_service.dart
@@ -1,0 +1,253 @@
+import 'dart:math';
+
+/// カレンダー用の負債入力(重量級の workbook 行から必要項目だけ写す)。
+class AssetCalendarDebtInput {
+  const AssetCalendarDebtInput({
+    required this.name,
+    required this.balance,
+    required this.paymentDay,
+    this.scheduledPaymentAmount = 0,
+    this.isDirectCashflowTarget = true,
+  });
+
+  final String name;
+  final double balance;
+  final int? paymentDay;
+  final double scheduledPaymentAmount;
+  final bool isDirectCashflowTarget;
+}
+
+/// カレンダーに載せる日次イベントの種別。
+enum AssetCalendarEventKind {
+  salary,
+  debtPayment,
+  subscription,
+  expense,
+  income,
+}
+
+/// カレンダー1イベント。amount は不明な場合 null。
+class AssetCalendarEvent {
+  const AssetCalendarEvent({
+    required this.kind,
+    required this.label,
+    this.amount,
+  });
+
+  final AssetCalendarEventKind kind;
+  final String label;
+  final double? amount;
+}
+
+/// 1日分のサマリ。支出/収入はフロー記録の合算。
+class AssetCalendarDaySummary {
+  const AssetCalendarDaySummary({
+    required this.date,
+    required this.expenseTotal,
+    required this.incomeTotal,
+    required this.events,
+  });
+
+  final DateTime date;
+  final double expenseTotal;
+  final double incomeTotal;
+  final List<AssetCalendarEvent> events;
+
+  bool _has(AssetCalendarEventKind kind) =>
+      events.any((event) => event.kind == kind);
+
+  bool get hasSalary => _has(AssetCalendarEventKind.salary);
+
+  bool get hasDebtPayment => _has(AssetCalendarEventKind.debtPayment);
+
+  bool get hasSubscription => _has(AssetCalendarEventKind.subscription);
+
+  bool get hasIncome => incomeTotal > 0;
+
+  bool get hasAnyEvent => events.isNotEmpty;
+}
+
+/// 月単位のカレンダー。weeks は日曜始まり・null は空セル。
+class AssetPaymentCalendarMonth {
+  const AssetPaymentCalendarMonth({
+    required this.month,
+    required this.days,
+    required this.weeks,
+  });
+
+  final DateTime month;
+  final List<AssetCalendarDaySummary> days;
+  final List<List<AssetCalendarDaySummary?>> weeks;
+
+  AssetCalendarDaySummary? dayFor(DateTime date) {
+    for (final day in days) {
+      if (day.date.year == date.year &&
+          day.date.month == date.month &&
+          day.date.day == date.day) {
+        return day;
+      }
+    }
+    return null;
+  }
+}
+
+/// フロー記録・サブスク請求日・負債返済日・給料日を月カレンダーへ集約する。
+/// 入力はページが保持する生データ(Supabase row の Map)をそのまま受ける。
+class AssetPaymentCalendarService {
+  const AssetPaymentCalendarService();
+
+  /// wealth_struggles の action_type 分類(ページ実装と同一)。
+  static const Set<String> expenseActionTypes = <String>{'expense'};
+  static const Set<String> incomeActionTypes = <String>{'conquer'};
+
+  static const double _epsilon = 0.01;
+
+  /// 31日などが短い月に食い込む場合は月末日に丸める(2月の26日締め等)。
+  static int clampDayToMonth(int day, DateTime month) {
+    final lastDay = DateTime(month.year, month.month + 1, 0).day;
+    return max(1, min(day, lastDay));
+  }
+
+  static AssetPaymentCalendarMonth buildMonth({
+    required DateTime month,
+    required List<Map<String, dynamic>> flows,
+    required List<Map<String, dynamic>> subscriptions,
+    required List<AssetCalendarDebtInput> debts,
+    int? salaryDay,
+  }) {
+    final normalizedMonth = DateTime(month.year, month.month);
+    final lastDay = DateTime(month.year, month.month + 1, 0).day;
+    final expenseByDay = <int, double>{};
+    final incomeByDay = <int, double>{};
+    final eventsByDay = <int, List<AssetCalendarEvent>>{};
+
+    void addEvent(int day, AssetCalendarEvent event) {
+      eventsByDay.putIfAbsent(day, () => <AssetCalendarEvent>[]).add(event);
+    }
+
+    if (salaryDay != null && salaryDay > 0) {
+      addEvent(
+        clampDayToMonth(salaryDay, normalizedMonth),
+        const AssetCalendarEvent(
+          kind: AssetCalendarEventKind.salary,
+          label: '給料日',
+        ),
+      );
+    }
+
+    for (final row in debts) {
+      final paymentDay = row.paymentDay;
+      if (paymentDay == null || paymentDay <= 0) {
+        continue;
+      }
+      if (row.balance >= -_epsilon || !row.isDirectCashflowTarget) {
+        continue;
+      }
+      addEvent(
+        clampDayToMonth(paymentDay, normalizedMonth),
+        AssetCalendarEvent(
+          kind: AssetCalendarEventKind.debtPayment,
+          label: '${row.name} 返済',
+          amount: row.scheduledPaymentAmount > _epsilon
+              ? row.scheduledPaymentAmount
+              : null,
+        ),
+      );
+    }
+
+    for (final subscription in subscriptions) {
+      final dueDate =
+          DateTime.tryParse(subscription['due_date']?.toString() ?? '')
+              ?.toLocal();
+      if (dueDate == null ||
+          dueDate.year != normalizedMonth.year ||
+          dueDate.month != normalizedMonth.month) {
+        continue;
+      }
+      final name = subscription['service_name']?.toString().trim() ?? '';
+      addEvent(
+        dueDate.day,
+        AssetCalendarEvent(
+          kind: AssetCalendarEventKind.subscription,
+          label: name.isEmpty ? '固定費' : name,
+          amount: (subscription['price'] as num?)?.toDouble(),
+        ),
+      );
+    }
+
+    for (final flow in flows) {
+      final occurredAt =
+          DateTime.tryParse(flow['occurred_at']?.toString() ?? '')?.toLocal();
+      if (occurredAt == null ||
+          occurredAt.year != normalizedMonth.year ||
+          occurredAt.month != normalizedMonth.month) {
+        continue;
+      }
+      final amount = (flow['amount'] as num?)?.toDouble() ?? 0;
+      final actionType = flow['action_type']?.toString() ?? '';
+      final description = flow['description']?.toString().trim() ?? '';
+      final day = occurredAt.day;
+      if (expenseActionTypes.contains(actionType)) {
+        expenseByDay[day] = (expenseByDay[day] ?? 0) + amount.abs();
+        addEvent(
+          day,
+          AssetCalendarEvent(
+            kind: AssetCalendarEventKind.expense,
+            label: description.isEmpty ? '支出' : description,
+            amount: amount.abs(),
+          ),
+        );
+      } else if (incomeActionTypes.contains(actionType)) {
+        incomeByDay[day] = (incomeByDay[day] ?? 0) + amount.abs();
+        addEvent(
+          day,
+          AssetCalendarEvent(
+            kind: AssetCalendarEventKind.income,
+            label: description.isEmpty ? '収入' : description,
+            amount: amount.abs(),
+          ),
+        );
+      }
+    }
+
+    final days = <AssetCalendarDaySummary>[
+      for (var day = 1; day <= lastDay; day++)
+        AssetCalendarDaySummary(
+          date: DateTime(normalizedMonth.year, normalizedMonth.month, day),
+          expenseTotal: expenseByDay[day] ?? 0,
+          incomeTotal: incomeByDay[day] ?? 0,
+          events: _sortEvents(eventsByDay[day] ?? const <AssetCalendarEvent>[]),
+        ),
+    ];
+
+    return AssetPaymentCalendarMonth(
+      month: normalizedMonth,
+      days: days,
+      weeks: _buildWeeks(normalizedMonth, days),
+    );
+  }
+
+  static List<AssetCalendarEvent> _sortEvents(List<AssetCalendarEvent> events) {
+    final sorted = List<AssetCalendarEvent>.from(events);
+    sorted.sort((a, b) => a.kind.index.compareTo(b.kind.index));
+    return sorted;
+  }
+
+  /// 日曜始まりの週リストへ整形。月初までの空きと月末以降は null。
+  static List<List<AssetCalendarDaySummary?>> _buildWeeks(
+    DateTime month,
+    List<AssetCalendarDaySummary> days,
+  ) {
+    final leadingBlanks = DateTime(month.year, month.month, 1).weekday % 7;
+    final cells = <AssetCalendarDaySummary?>[
+      for (var i = 0; i < leadingBlanks; i++) null,
+      ...days,
+    ];
+    while (cells.length % 7 != 0) {
+      cells.add(null);
+    }
+    return <List<AssetCalendarDaySummary?>>[
+      for (var i = 0; i < cells.length; i += 7) cells.sublist(i, i + 7),
+    ];
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -836,6 +836,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -920,26 +928,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1525,26 +1533,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/test/services/asset_management_display_mode_store_test.dart
+++ b/test/services/asset_management_display_mode_store_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_management_display_mode_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('AssetManagementDisplayModeStore', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('minimum mode shows only essential sections', () {
+      expect(
+        AssetManagementDisplayModeStore.isTierVisible(
+          tier: AssetManagementSectionTier.essential,
+          mode: AssetManagementDisplayMode.minimum,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetManagementDisplayModeStore.isTierVisible(
+          tier: AssetManagementSectionTier.standard,
+          mode: AssetManagementDisplayMode.minimum,
+        ),
+        isFalse,
+      );
+      expect(
+        AssetManagementDisplayModeStore.isTierVisible(
+          tier: AssetManagementSectionTier.full,
+          mode: AssetManagementDisplayMode.minimum,
+        ),
+        isFalse,
+      );
+    });
+
+    test('standard mode hides only full-tier sections', () {
+      expect(
+        AssetManagementDisplayModeStore.isTierVisible(
+          tier: AssetManagementSectionTier.essential,
+          mode: AssetManagementDisplayMode.standard,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetManagementDisplayModeStore.isTierVisible(
+          tier: AssetManagementSectionTier.standard,
+          mode: AssetManagementDisplayMode.standard,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetManagementDisplayModeStore.isTierVisible(
+          tier: AssetManagementSectionTier.full,
+          mode: AssetManagementDisplayMode.standard,
+        ),
+        isFalse,
+      );
+    });
+
+    test('full mode shows every tier', () {
+      for (final tier in AssetManagementSectionTier.values) {
+        expect(
+          AssetManagementDisplayModeStore.isTierVisible(
+            tier: tier,
+            mode: AssetManagementDisplayMode.full,
+          ),
+          isTrue,
+        );
+      }
+    });
+
+    test('load falls back to full when nothing is stored', () async {
+      const store = AssetManagementDisplayModeStore();
+
+      final mode = await store.load();
+
+      expect(mode, AssetManagementDisplayMode.full);
+    });
+
+    test('save and load round-trips every mode', () async {
+      const store = AssetManagementDisplayModeStore();
+
+      for (final mode in AssetManagementDisplayMode.values) {
+        await store.save(mode);
+        expect(await store.load(), mode);
+      }
+    });
+
+    test('load tolerates an unknown stored value', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_management_display_mode_v1': 'galaxy',
+      });
+      const store = AssetManagementDisplayModeStore();
+
+      final mode = await store.load();
+
+      expect(mode, AssetManagementDisplayMode.full);
+    });
+  });
+}

--- a/test/services/asset_payment_calendar_service_test.dart
+++ b/test/services/asset_payment_calendar_service_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_payment_calendar_service.dart';
+
+void main() {
+  group('AssetPaymentCalendarService', () {
+    test('aggregates expenses and income per local day', () {
+      final calendar = AssetPaymentCalendarService.buildMonth(
+        month: DateTime(2026, 6),
+        flows: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'occurred_at': '2026-06-11T03:00:00Z',
+            'amount': 580,
+            'action_type': 'expense',
+            'description': '牛丼',
+          },
+          <String, dynamic>{
+            'occurred_at': '2026-06-11T09:30:00Z',
+            'amount': 200,
+            'action_type': 'expense',
+            'description': 'うどん',
+          },
+          <String, dynamic>{
+            'occurred_at': '2026-06-25T01:00:00Z',
+            'amount': 280000,
+            'action_type': 'conquer',
+            'description': '給与',
+          },
+          <String, dynamic>{'amount': 999, 'action_type': 'expense'},
+        ],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[],
+      );
+
+      final day11 = calendar.dayFor(DateTime(2026, 6, 11));
+      expect(day11, isNotNull);
+      expect(day11!.expenseTotal, 780);
+      expect(day11.events, hasLength(2));
+
+      final day25 = calendar.dayFor(DateTime(2026, 6, 25));
+      expect(day25!.incomeTotal, 280000);
+      expect(day25.hasIncome, isTrue);
+    });
+
+    test('clamps debt payment days into short months and skips paid rows', () {
+      final calendar = AssetPaymentCalendarService.buildMonth(
+        month: DateTime(2026, 2),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[
+          AssetCalendarDebtInput(
+            name: 'カードローン',
+            balance: -300000,
+            paymentDay: 31,
+            scheduledPaymentAmount: 15000,
+          ),
+          AssetCalendarDebtInput(
+            name: '完済済み',
+            balance: 0,
+            paymentDay: 10,
+          ),
+          AssetCalendarDebtInput(
+            name: 'カード合算',
+            balance: -5000,
+            paymentDay: 5,
+            isDirectCashflowTarget: false,
+          ),
+        ],
+      );
+
+      final day28 = calendar.dayFor(DateTime(2026, 2, 28));
+      expect(day28!.hasDebtPayment, isTrue);
+      expect(day28.events.single.label, 'カードローン 返済');
+      expect(day28.events.single.amount, 15000);
+      expect(calendar.dayFor(DateTime(2026, 2, 10))!.hasAnyEvent, isFalse);
+      expect(calendar.dayFor(DateTime(2026, 2, 5))!.hasAnyEvent, isFalse);
+    });
+
+    test('places subscriptions and salary on their days', () {
+      final calendar = AssetPaymentCalendarService.buildMonth(
+        month: DateTime(2026, 6),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'service_name': '家賃',
+            'price': 65000,
+            'due_date': '2026-06-27T00:00:00',
+          },
+          <String, dynamic>{
+            'service_name': '先月分',
+            'price': 1000,
+            'due_date': '2026-05-27T00:00:00',
+          },
+        ],
+        debts: const <AssetCalendarDebtInput>[],
+        salaryDay: 25,
+      );
+
+      final day27 = calendar.dayFor(DateTime(2026, 6, 27));
+      expect(day27!.hasSubscription, isTrue);
+      expect(day27.events.single.amount, 65000);
+      expect(calendar.dayFor(DateTime(2026, 6, 25))!.hasSalary, isTrue);
+      final withSubscription = calendar.days
+          .where((day) => day.hasSubscription)
+          .toList();
+      expect(withSubscription, hasLength(1));
+    });
+
+    test('builds sunday-first weeks with blank padding', () {
+      final calendar = AssetPaymentCalendarService.buildMonth(
+        month: DateTime(2026, 6),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[],
+      );
+
+      // 2026-06-01 は月曜 → 先頭の空きセルは1つ。
+      expect(calendar.weeks.first.first, isNull);
+      expect(calendar.weeks.first[1]!.date.day, 1);
+      expect(calendar.weeks.length, 5);
+      for (final week in calendar.weeks) {
+        expect(week, hasLength(7));
+      }
+    });
+
+    test('orders mixed events by kind priority', () {
+      final calendar = AssetPaymentCalendarService.buildMonth(
+        month: DateTime(2026, 6),
+        flows: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'occurred_at': '2026-06-25T05:00:00Z',
+            'amount': 1200,
+            'action_type': 'expense',
+            'description': '昼食',
+          },
+        ],
+        subscriptions: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'service_name': 'サブスク',
+            'price': 980,
+            'due_date': '2026-06-25T00:00:00',
+          },
+        ],
+        debts: const <AssetCalendarDebtInput>[
+          AssetCalendarDebtInput(
+            name: 'ローン',
+            balance: -100000,
+            paymentDay: 25,
+            scheduledPaymentAmount: 8000,
+          ),
+        ],
+        salaryDay: 25,
+      );
+
+      final day = calendar.dayFor(DateTime(2026, 6, 25))!;
+      expect(day.events, hasLength(4));
+      expect(day.events[0].kind, AssetCalendarEventKind.salary);
+      expect(day.events[1].kind, AssetCalendarEventKind.debtPayment);
+      expect(day.events[2].kind, AssetCalendarEventKind.subscription);
+      expect(day.events[3].kind, AssetCalendarEventKind.expense);
+    });
+  });
+}

--- a/test/services/asset_payment_calendar_service_test.dart
+++ b/test/services/asset_payment_calendar_service_test.dart
@@ -99,9 +99,8 @@ void main() {
       expect(day27!.hasSubscription, isTrue);
       expect(day27.events.single.amount, 65000);
       expect(calendar.dayFor(DateTime(2026, 6, 25))!.hasSalary, isTrue);
-      final withSubscription = calendar.days
-          .where((day) => day.hasSubscription)
-          .toList();
+      final withSubscription =
+          calendar.days.where((day) => day.hasSubscription).toList();
       expect(withSubscription, hasLength(1));
     });
 


### PR DESCRIPTION
## 概要

資産管理ページの**情報過多**を解消する2本柱。

1. **表示モード「ミニマム / 標準 / フル」** — 全15セクションを重要度ティア(essential / standard / full)に割当て、ユーザーがワンタップで情報量を切替。SharedPreferences 永続化。**既定はフル(既存ユーザーの画面は変わらない)**。
2. **マネーカレンダー** — 日ごとの支出合計と、返済日・固定費(サブスク)請求日・給料日を月グリッドで俯瞰。日タップでイベント詳細。31日設定の返済日は短い月では月末へ丸め(2月対応)。

## ティア割当て(= 重複機能の段階開示による統合)

| ティア | セクション |
|---|---|
| essential (ミニマム) | 表示モード切替 / 当月収支概観 / **マネーカレンダー(新規)** / 裁量余資金 / フロー記録ボタン / 借金返済プラン(収監・うどん縛り含む) |
| standard (+標準) | 給与消費内訳 / 締切チェックリスト / 3ヶ月俯瞰 / 資産負債ワークブックボード / ①②資産負債 / ④収支 / ③固定費 / ⑤必須タスク |
| full (フル) | 浪費訓練AI / グラフ |

**重複用途の対応表(段階開示で吸収、物理統合は follow-up)**:
- 借金返済プラン(essential) vs 返済シミュレーション(workbook board 内・standard) → 概要とディテールの2層として役割分離
- AIアシスタント(board 内) vs 浪費訓練AI(full) → full のみで併存表示
- `_buildFlowCardLegacy`(未使用 dead code 394行)→ 削除は専用ヘルパーの unused 連鎖を analyzer で確認できる環境での follow-up とする(本セッションは local toolchain 不能)

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) モード×ティア可視マトリクス (2) フロー/サブスク/返済日/給料日の日別集約と短い月への返済日丸め (3) 永続化 round-trip と不正値フォールバック。週グリッド整形・イベント種別順序まで計 11 ケース。
- E2E例外: 本変更は表示層の段階開示とローカル集計のみ(ネットワーク・DB・Edge Function 変更なし)のため、エンドツーエンド(integration_test)追加は行わず service 単体テストで入出力契約を担保する。
- 検証状況: local dart toolchain がハング継続(zombie daemon 環境問題)のため format/analyze/test は CI を正とする。スクロールアンカー(`_scrollTo`)は null ガード済みでミニマム時の initialFocus も安全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
