### PR TITLE
fix(asset): マネーカレンダー週Row stretch起因の無限高さクラッシュ修正 (part 268b)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -7475,7 +7475,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             const SizedBox(height: 4),
             for (final week in calendar.weeks)
               Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   for (final day in week)
                     Expanded(child: _buildAssetCalendarCell(day, today)),


### PR DESCRIPTION
## 概要

本番 `/asset-management` で part 268 ([#3233](https://github.com/kanta13jp1/my_web_app/pull/3233)) のマネーカレンダーが第1週までしか描画されず、それ以降の全セクションが消える + `main.dart.js` で Uncaught Error が発生する production 障害の hotfix。

## 原因

カレンダー週 Row の `crossAxisAlignment: CrossAxisAlignment.stretch` (#3233 で新規追加 / ファイル内で Row への stretch 適用はこの 1 ヶ所のみ)。

`SingleChildScrollView` 配下の高さ無制約 Column 内では、横方向 Flex (Row) の `stretch` は子 (Expanded セル) に **tight ∞ 高さ制約**を渡す。debug では assert で検出されるが、release ビルドでは assert が剥がれて無限高さがそのままレイアウトへ伝播:

- 第1週 Row の高さが ∞ になる → 第2週以降 + カレンダー以降の全セクションが y=∞ へ飛び不可視
- paint/hit-test 段階で Uncaught Error (console の minified stack はレイアウト再帰フレームと一致)

スクリーンショットの症状 (第1週の 6/6 `6.1万` までは描画・以降が空・Uncaught Error ×1) と完全一致。

## 修正

- 該当 1 行 (`crossAxisAlignment: CrossAxisAlignment.stretch,`) の削除のみ
- セルは `Container(height: 54)`・空セルは `SizedBox(height: 54)` で高さ固定済みのため、stretch は元々不要

## Minimal E2E (gate)

- E2E 検証は implementation-detail independent (black-box) — 本番 URL を実ブラウザ (Chrome DevTools / playwright 相当のブラウザ操作) で確認する方式で、ウィジェット内部実装に依存しない。
- minimal plan = 3 cases (3ケース):
  1. `/asset-management` でマネーカレンダーが当月全週 (2026年6月 = 5週分) 描画される
  2. 今日 (6/11) のセルにハイライト枠が表示される
  3. カレンダー以降のセクション (凡例・締切チェックリスト等) が描画され、console の Uncaught Error が 0 件
- E2E-Exception: 1行のレイアウト引数削除のみの hotfix のため新規 integration_test ファイル追加はせず、代替として merge → deploy 完了後に本番で上記 3 ケースの black-box 検証を実施し、結果を本 PR にコメントする。

## High-risk gate (review owner: Claude Code #1)

- Review owner: Claude Code #1 (Win Claude / L3)
- high-risk-ultrareview-exception: 本PRは UI レイアウト引数 1 行削除のみで auth / billing / RLS / data migration / Edge Function に非接触のため、課金 ultrareview は省略し Claude Code #1 によるセルフレビュー (下記 5 観点) で代替する。
- 5 観点 self-review:
  - security: 新規攻撃面なし (レイアウト引数 1 行削除のみ / 入力処理・権限・通信の変更なし)
  - rollback: 単一行 revert で即時 rollback 可能 (依存変更なし)
  - data migration: なし (DB / スキーマ / migration 非接触)
  - prod smoke: deploy 完了後に production smoke として上記 3 ケースを本番 URL で実施し本 PR にコメントする
  - observability: 本番 console の Uncaught Error 件数 (期待値 0) を observability 指標として確認する
- unresolved findings: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
