### PR TITLE
feat(asset): 現金のマイナス残高でも減少分を使途不明金として自動記録 (part 270b)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -35,6 +35,7 @@ import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
+import 'package:my_web_app/services/asset_unknown_expense_rule_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
@@ -6126,31 +6127,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     ].join(':');
   }
 
-  bool _shouldAutoRecordUnknownExpenseFromAssetDrop({
-    required String assetType,
-    required double previousAmount,
-    required double currentAmount,
-  }) {
-    final drop = previousAmount - currentAmount;
-    if (previousAmount <= 0 || drop < 1) {
-      return false;
-    }
-    final key = assetType.toLowerCase();
-    final looksLikeInvestment = key.contains('証券') ||
-        key.contains('株') ||
-        key.contains('投資') ||
-        key.contains('nisa') ||
-        key.contains('securities') ||
-        key.contains('stock') ||
-        key.contains('crypto') ||
-        key.contains('coincheck') ||
-        key.contains('bitflyer');
-    if (looksLikeInvestment) {
-      return false;
-    }
-    return true;
-  }
-
   Future<bool> _autoRecordUnknownExpenseFromAssetDrop({
     required String assetType,
     required String dateKey,
@@ -6159,7 +6135,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }) async {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null ||
-        !_shouldAutoRecordUnknownExpenseFromAssetDrop(
+        !AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
           assetType: assetType,
           previousAmount: previousAmount,
           currentAmount: currentAmount,

--- a/lib/services/asset_unknown_expense_rule_service.dart
+++ b/lib/services/asset_unknown_expense_rule_service.dart
@@ -1,0 +1,48 @@
+/// 資産記録時の残高減少を「使途不明金」支出として自動記録するかの判定ルール。
+/// asset_management_page から切り出した pure logic (UI / Supabase 非依存)。
+class AssetUnknownExpenseRuleService {
+  const AssetUnknownExpenseRuleService._();
+
+  /// 現金系タイプ。マイナス残高(立替・前借り等)でも減少分を支出として扱う。
+  static bool isCashLikeType(String assetType) {
+    final key = assetType.toLowerCase();
+    return key.contains('現金') || key.contains('cash');
+  }
+
+  /// 投資系タイプ。減少が評価損か出金か区別できないため自動記録の対象外。
+  static bool isInvestmentLikeType(String assetType) {
+    final key = assetType.toLowerCase();
+    return key.contains('証券') ||
+        key.contains('株') ||
+        key.contains('投資') ||
+        key.contains('nisa') ||
+        key.contains('securities') ||
+        key.contains('stock') ||
+        key.contains('crypto') ||
+        key.contains('coincheck') ||
+        key.contains('bitflyer');
+  }
+
+  /// 自動記録の条件:
+  /// - 減少幅が 1 円以上
+  /// - 投資系タイプは対象外
+  /// - 残高がマイナス圏 (previousAmount <= 0) のときは現金系のみ対象。
+  ///   負の値で記録する負債系タイプの残高悪化を使途不明金と誤認しないため。
+  static bool shouldAutoRecordFromAssetDrop({
+    required String assetType,
+    required double previousAmount,
+    required double currentAmount,
+  }) {
+    final drop = previousAmount - currentAmount;
+    if (drop < 1) {
+      return false;
+    }
+    if (previousAmount <= 0 && !isCashLikeType(assetType)) {
+      return false;
+    }
+    if (isInvestmentLikeType(assetType)) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/test/services/asset_unknown_expense_rule_service_test.dart
+++ b/test/services/asset_unknown_expense_rule_service_test.dart
@@ -137,11 +137,17 @@ void main() {
 
     test('isInvestmentLikeType', () {
       expect(
-          AssetUnknownExpenseRuleService.isInvestmentLikeType('証券口座'), isTrue);
+        AssetUnknownExpenseRuleService.isInvestmentLikeType('証券口座'),
+        isTrue,
+      );
       expect(
-          AssetUnknownExpenseRuleService.isInvestmentLikeType('NISA'), isTrue);
+        AssetUnknownExpenseRuleService.isInvestmentLikeType('NISA'),
+        isTrue,
+      );
       expect(
-          AssetUnknownExpenseRuleService.isInvestmentLikeType('現金'), isFalse);
+        AssetUnknownExpenseRuleService.isInvestmentLikeType('現金'),
+        isFalse,
+      );
     });
   });
 }

--- a/test/services/asset_unknown_expense_rule_service_test.dart
+++ b/test/services/asset_unknown_expense_rule_service_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_unknown_expense_rule_service.dart';
+
+void main() {
+  group('AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop', () {
+    test('プラス残高からの減少は対象 (従来動作)', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: 'みずほ銀行',
+          previousAmount: 50000,
+          currentAmount: 48000,
+        ),
+        isTrue,
+      );
+    });
+
+    test('減少幅 1 円未満・増加は対象外', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: '現金',
+          previousAmount: 10000,
+          currentAmount: 10000,
+        ),
+        isFalse,
+      );
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: '現金',
+          previousAmount: 1000,
+          currentAmount: 5000,
+        ),
+        isFalse,
+      );
+    });
+
+    test('投資系タイプの減少は対象外 (評価損と区別できない)', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: '証券口座',
+          previousAmount: 100000,
+          currentAmount: 90000,
+        ),
+        isFalse,
+      );
+    });
+
+    test('現金: プラスからマイナスへ跨ぐ減少は対象 (従来動作)', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: '現金',
+          previousAmount: 500,
+          currentAmount: -200,
+        ),
+        isTrue,
+      );
+    });
+
+    test('現金: 残高 0 からマイナスへの減少も対象 (新規)', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: '現金',
+          previousAmount: 0,
+          currentAmount: -3000,
+        ),
+        isTrue,
+      );
+    });
+
+    test('現金: マイナス圏からさらに減少も対象 (新規)', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: '現金',
+          previousAmount: -3000,
+          currentAmount: -8000,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: '手元現金',
+          previousAmount: -100,
+          currentAmount: -1100,
+        ),
+        isTrue,
+      );
+    });
+
+    test('現金: マイナス圏での増加 (返済・補充) は対象外', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: '現金',
+          previousAmount: -8000,
+          currentAmount: -2000,
+        ),
+        isFalse,
+      );
+    });
+
+    test('現金以外: マイナス圏の減少は従来どおり対象外 (負債系の誤記録防止)', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: 'カード未払',
+          previousAmount: -50000,
+          currentAmount: -80000,
+        ),
+        isFalse,
+      );
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: '銀行口座',
+          previousAmount: 0,
+          currentAmount: -1000,
+        ),
+        isFalse,
+      );
+    });
+
+    test('英語表記 cash も現金系として扱う', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: 'Cash Wallet',
+          previousAmount: -100,
+          currentAmount: -200,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('type 判定ヘルパー', () {
+    test('isCashLikeType', () {
+      expect(AssetUnknownExpenseRuleService.isCashLikeType('現金'), isTrue);
+      expect(AssetUnknownExpenseRuleService.isCashLikeType('手元現金'), isTrue);
+      expect(AssetUnknownExpenseRuleService.isCashLikeType('Cash'), isTrue);
+      expect(AssetUnknownExpenseRuleService.isCashLikeType('みずほ銀行'), isFalse);
+    });
+
+    test('isInvestmentLikeType', () {
+      expect(
+          AssetUnknownExpenseRuleService.isInvestmentLikeType('証券口座'), isTrue);
+      expect(
+          AssetUnknownExpenseRuleService.isInvestmentLikeType('NISA'), isTrue);
+      expect(
+          AssetUnknownExpenseRuleService.isInvestmentLikeType('現金'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

user 要望「現金残高のマイナスも自動支出記録の対象としたい」への対応。

これまで資産記録時の「減少分を使途不明金として自動記録」は `previousAmount <= 0` で無効化されており、現金が一度 0 円・マイナス圏に入ると、そこからさらに減っても (例: 0 → -3,000 / -3,000 → -8,000) 使途不明金が記録されなかった。マイナス入力 UI (`_toggleMinusForType`) は正式サポート済みなのに自動記録だけ非対称だった。

## 変更

- 判定ロジックを `AssetUnknownExpenseRuleService` (pure logic / UI・DB 非依存) として `lib/services/` へ抽出
- **現金系タイプ (名前に「現金」or「cash」) はマイナス圏でも減少幅 1 円以上で自動記録**
- 現金以外 (負の値で記録する負債系タイプ等) は従来どおりマイナス圏では対象外 — 残高悪化を使途不明金と誤認しないため
- 投資系タイプの除外 (評価損と区別不能) は従来どおり維持
- `asset_management_page.dart` は service 委譲に置き換え (旧 private メソッド削除 / 挙動パリティはテストで担保)

## テスト

- 新規 `test/services/asset_unknown_expense_rule_service_test.dart` — 11 ケース
  - 新挙動: 現金 0→マイナス / マイナス→さらにマイナス / 英語 cash 表記
  - 従来パリティ: プラス残高からの減少・プラス→マイナス跨ぎ・増加/微減ガード・投資系除外・非現金のマイナス圏除外

## Minimal E2E (gate)

- E2E 検証は implementation-detail independent (black-box) — 入出力 (前回残高/今回残高/タイプ名 → 記録有無) のみで判定し、ウィジェット内部実装に依存しない。
- minimal plan = 3 cases (3ケース):
  1. 現金 0 → -3,000 を記録 → 使途不明金 3,000 円が収支履歴へ自動追加される
  2. 現金 -3,000 → -8,000 を記録 → 使途不明金 5,000 円が自動追加される
  3. 負債系タイプ (負値記録) の悪化では自動追加されない
- E2E-Exception: 判定を pure service に抽出し上記 3 ケースを含む unit test 11 件で I/O カバー済みのため、新規 integration_test / playwright ファイルは追加しない。記録系 UI 経路は認証必須でログイン後の手動確認が必要なため、merge 後に本番で上記 3 ケースを実機確認する。

## High-risk gate (review owner: Claude Code #1)

- Review owner: Claude Code #1 (Win Claude / L3)
- high-risk-ultrareview-exception: 本PRは支出自動記録の判定条件 1 点の限定解除 (現金系のみ) + pure service 抽出で、auth / billing / RLS / data migration / Edge Function に非接触のため、課金 ultrareview は省略し Claude Code #1 によるセルフレビュー (下記 5 観点) で代替する。
- 5 観点 self-review:
  - security: 新規攻撃面なし (クライアント内判定ロジックのみ / insert 先テーブル・権限・通信の変更なし)
  - rollback: service 委譲 1 コミットの revert で即時 rollback 可能 (依存変更なし)
  - data migration: なし (DB / スキーマ / migration 非接触。過去分の遡及記録もしない — 次回記録時から適用)
  - prod smoke: merge 後に production smoke として上記 3 ケースをログイン実機で確認し本 PR にコメントする
  - observability: 自動記録行は description マーカー (`残高差分から自動記録`) で履歴 UI から識別可能 — 誤記録時は収支履歴から個別削除可能
- unresolved findings: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
