### PR TITLE
fix(asset): 「同額」簡易更新を前回記録ベースに緩和 (part 270c)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -517,9 +517,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   String _todayDateKey() => _dateOnly(DateTime.now());
 
-  String _yesterdayDateKey() =>
-      _dateOnly(DateTime.now().subtract(const Duration(days: 1)));
-
   DateTime _monthStart(DateTime dt) => DateTime(dt.year, dt.month, 1);
 
   DateTime _assetLiabilityStateMonth(DateTime dt) {
@@ -5209,13 +5206,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _quickUpdateAssetData(String type) async {
     final today = _todayDateKey();
     final lastDate = _lastUpdatedDates[type];
-    if (lastDate == null ||
-        lastDate == today ||
-        lastDate != _yesterdayDateKey()) {
+    if (lastDate == null || lastDate == today) {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('$type は昨日の記録がある場合のみ簡易更新できます')));
+      ).showSnackBar(SnackBar(content: Text('$type は過去の記録がある場合のみ簡易更新できます')));
       return;
     }
 
@@ -5231,7 +5226,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     await _recordAssetAmountForToday(
       type,
       lastAmount,
-      successMessage: '✅ $type を昨日と同額で簡易更新しました',
+      successMessage: '✅ $type を前回と同額で簡易更新しました',
     );
   }
 
@@ -18451,9 +18446,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       lastAmount = _assetData[lastDate]?[type];
     }
     final isLiability = (lastAmount ?? 0) < 0;
-    final canQuickUpdate = lastAmount != null &&
-        !isUpdatedToday &&
-        lastDate == _yesterdayDateKey();
+    final canQuickUpdate = lastAmount != null && !isUpdatedToday;
 
     final accentColor =
         isLiability ? const Color(0xFFDC2626) : const Color(0xFF0D9488);
@@ -18670,7 +18663,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           if (canQuickUpdate) ...[
             const SizedBox(height: 8),
             const Text(
-              '昨日と同額なら「同額」で素早く更新できます。',
+              '残高が変わっていなければ「同額」で前回と同じ額をすぐ記録できます。',
               style: TextStyle(
                 fontSize: 11,
                 color: Color(0xFF64748B),


### PR DESCRIPTION
## 概要

user 報告 (2026-06-12 未明): 「残高が変わらないときに昨日と同じ額で更新済みとするボタンが消えました」。

調査の結果、「同額」簡易更新ボタンは**最終記録がちょうど昨日のときだけ**表示される設計 (初期実装 c2f97359d 由来 / 近時 PR による退行ではない) で、日付が変わった瞬間や記録を 1 日空けただけで消える。残高が動いていない日が続くほどワンタップ更新が欲しいのに、その時こそ使えなくなる非対称があった。

## 変更 (「昨日と同額」→「前回と同額」セマンティクス)

- 表示条件 `canQuickUpdate` から「最終記録 == 昨日」要件を撤去 — **前回記録があり・今日未記録なら常に表示**
- `_quickUpdateAssetData` のガードも同様に緩和 (未記録 / 本日記録済みのみ拒否)
- 文言更新: スナックバー「✅ ○○ を前回と同額で簡易更新しました」/ ヘルパー「残高が変わっていなければ『同額』で前回と同じ額をすぐ記録できます。」
- これにより未使用化した `_yesterdayDateKey` を削除 (analyze unused_element 対策)

記録自体は既存の `_recordAssetAmountForToday` を再利用 — 同額記録は減少幅 0 のため使途不明金の自動追加は発生しない (#3241 のルールと整合)。

## Minimal E2E (gate)

- E2E 検証は implementation-detail independent (black-box) — 入出力 (最終記録日/今日の記録有無 → ボタン表示・記録結果) のみで判定し、内部実装に依存しない。
- minimal plan = 3 cases (3ケース):
  1. 最終記録が 2 日以上前のタイプでも「同額」ボタンが表示され、タップで今日の残高が前回額で記録される
  2. 今日すでに記録済みのタイプではボタンが表示されない
  3. 同額記録では使途不明金の自動追加が発生しない (減少幅 0)
- E2E-Exception: 表示条件 1 行 + ガード緩和 + 文言のみの UI 変更で、記録処理は既存経路を再利用しているため新規 integration_test / playwright ファイルは追加しない。対象 UI はログイン必須のため、merge 後にログイン実機で上記 3 ケースを確認する。

## High-risk gate (review owner: Claude Code #1)

- Review owner: Claude Code #1 (Win Claude / L3)
- high-risk-ultrareview-exception: 本PRはボタン表示条件の緩和 + 文言変更のみで auth / billing / RLS / data migration / Edge Function に非接触のため、課金 ultrareview は省略し Claude Code #1 によるセルフレビュー (下記 5 観点) で代替する。
- 5 観点 self-review:
  - security: 新規攻撃面なし (クライアント内表示条件と文言のみ / 書込経路は既存 `_recordAssetAmountForToday` 不変)
  - rollback: 1 コミット revert で即時 rollback 可能 (依存変更なし)
  - data migration: なし (DB / スキーマ / migration 非接触)
  - prod smoke: merge 後に production smoke として上記 3 ケースをログイン実機で確認し本 PR にコメントする
  - observability: 簡易更新は通常記録と同一経路のため既存の記録履歴 (最終更新日表示) で確認可能
- unresolved findings: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
