### PR TITLE
feat(asset): 支払日未入力警告から支払日入力欄へジャンプするリンクを追加

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -205,6 +205,27 @@ class AssetLiabilityAccount {
   bool get isAsset => balance > 0;
   bool get isLiability => balance < 0;
   double get liabilityBalance => isLiability ? balance.abs() : 0;
+
+  AssetLiabilityAccount copyWith({int? paymentDay}) {
+    return AssetLiabilityAccount(
+      id: id,
+      name: name,
+      kind: kind,
+      balance: balance,
+      paymentDay: paymentDay ?? this.paymentDay,
+      paymentSourceAccountName: paymentSourceAccountName,
+      paymentMethod: paymentMethod,
+      paymentMethodLabel: paymentMethodLabel,
+      paymentMethodSettingSource: paymentMethodSettingSource,
+      billingAccountId: billingAccountId,
+      billingAccountName: billingAccountName,
+      includedInBillingAccount: includedInBillingAccount,
+      annualRate: annualRate,
+      minimumPaymentRate: minimumPaymentRate,
+      minimumPaymentFloor: minimumPaymentFloor,
+      fullPaymentEstimate: fullPaymentEstimate,
+    );
+  }
 }
 
 class AssetLiabilityDebtRow {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -166,6 +166,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, double> _actualPaymentAmounts = <String, double>{};
   Map<String, String> _paymentDifferenceReasons = <String, String>{};
   Map<String, double> _annualRateOverrides = <String, double>{};
+  Map<String, int> _debtPaymentDayOverrides = <String, int>{};
+  final Map<String, GlobalKey> _debtMasterCardKeys = <String, GlobalKey>{};
   Map<String, AssetLiabilityAnnualRateEvidence> _annualRateEvidences =
       <String, AssetLiabilityAnnualRateEvidence>{};
   Set<String> _monthlyPaidAccountNames = <String>{};
@@ -1042,6 +1044,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           await _assetLiabilityRepository.loadDefaultPaymentSources();
       final defaultCardBillingAccounts =
           await _assetLiabilityRepository.loadDefaultCardBillingAccounts();
+      final debtPaymentDayOverrides =
+          await _assetLiabilityRepository.loadDebtPaymentDayOverrides();
       final templates =
           await _assetLiabilityRepository.loadRecurringIncomeTemplates();
       final monthlySnapshots =
@@ -1096,6 +1100,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
         _defaultCardBillingAccountIds = Map<String, String>.from(
           defaultCardBillingAccounts,
+        );
+        _debtPaymentDayOverrides = Map<String, int>.from(
+          debtPaymentDayOverrides,
         );
         _monthlyIncomePlans = List<AssetLiabilityIncomePlan>.from(
           incomePlansWithTemplates,
@@ -4157,6 +4164,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       actualPaymentAmounts: _actualPaymentAmounts,
       paymentDifferenceReasons: _paymentDifferenceReasons,
       annualRateOverrides: _annualRateOverrides,
+      paymentDayOverrides: _debtPaymentDayOverrides,
       paidAccountNames: _monthlyPaidAccountNames,
       paymentSourceAccountIds: _paymentSourceAccountIds,
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
@@ -7161,6 +7169,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       actualPaymentAmounts: _actualPaymentAmounts,
       paymentDifferenceReasons: _paymentDifferenceReasons,
       annualRateOverrides: _annualRateOverrides,
+      paymentDayOverrides: _debtPaymentDayOverrides,
       paidAccountNames: _monthlyPaidAccountNames,
       billingConfirmedAccountIds: _billingConfirmedAccountIds,
       paymentSourceAccountIds: _paymentSourceAccountIds,
@@ -8096,6 +8105,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         actualPaymentAmounts: _actualPaymentAmounts,
         paymentDifferenceReasons: _paymentDifferenceReasons,
         annualRateOverrides: _annualRateOverrides,
+        paymentDayOverrides: _debtPaymentDayOverrides,
         paidAccountNames: _monthlyPaidAccountNames,
         billingConfirmedAccountIds: _billingConfirmedAccountIds,
         paymentSourceAccountIds: _paymentSourceAccountIds,
@@ -12767,6 +12777,22 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  String? _assetManagementActionJumpLabel(
+    AssetManagementInsightActionItem item,
+  ) {
+    final accountId = item.relatedAccountId;
+    if (accountId == null || accountId.trim().isEmpty) {
+      return null;
+    }
+    return switch (item.type) {
+      AssetManagementInsightActionType.missingPaymentDay => '支払日を入力する',
+      AssetManagementInsightActionType.missingInput => '今月支払予定額を入力する',
+      AssetManagementInsightActionType.missingAnnualRate => '利率を入力する',
+      AssetManagementInsightActionType.missingPaymentSource => '支払原資口座を設定する',
+      _ => null,
+    };
+  }
+
   Widget _buildAssetManagementAssistantActionTile(
     AssetManagementInsightActionItem item,
   ) {
@@ -12774,6 +12800,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final dueLabel = item.dueDate == null
         ? (item.paymentDay == null ? null : '${item.paymentDay}日')
         : DateFormat('M/d').format(item.dueDate!);
+    final jumpLabel = _assetManagementActionJumpLabel(item);
 
     return Container(
       width: double.infinity,
@@ -12838,6 +12865,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   item.suggestedAction,
                   style: const TextStyle(fontSize: 12, height: 1.5),
                 ),
+                if (jumpLabel != null)
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton.icon(
+                      style: TextButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        foregroundColor: color,
+                      ),
+                      onPressed: () =>
+                          _jumpToDebtMasterCard(item.relatedAccountId!),
+                      icon: const Icon(Icons.arrow_downward, size: 16),
+                      label: Text(jumpLabel),
+                    ),
+                  ),
               ],
             ),
           ),
@@ -16709,6 +16751,94 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  GlobalKey _debtMasterCardKeyFor(String accountId) {
+    return _debtMasterCardKeys.putIfAbsent(
+      accountId,
+      () => GlobalKey(debugLabel: 'debt_master_card_$accountId'),
+    );
+  }
+
+  void _jumpToDebtMasterCard(String accountId) {
+    if (_debtMasterReviewFilter != _DebtMasterReviewFilter.all) {
+      setState(() {
+        _debtMasterReviewFilter = _DebtMasterReviewFilter.all;
+      });
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      final key = _debtMasterCardKeys[accountId];
+      if (key == null || key.currentContext == null) {
+        return;
+      }
+      _scrollTo(key);
+    });
+  }
+
+  void _setDebtPaymentDayOverride(AssetLiabilityDebtRow row, int? day) {
+    setState(() {
+      if (day == null) {
+        _debtPaymentDayOverrides.remove(row.id);
+      } else {
+        _debtPaymentDayOverrides[row.id] = day.clamp(1, 31).toInt();
+      }
+    });
+    unawaited(_saveDebtPaymentDayOverrides());
+  }
+
+  Future<void> _saveDebtPaymentDayOverrides() async {
+    try {
+      await _assetLiabilityRepository.saveDebtPaymentDayOverrides(
+        Map<String, int>.from(_debtPaymentDayOverrides),
+      );
+    } catch (e) {
+      debugPrint('Error saving debt payment day overrides: $e');
+    }
+  }
+
+  Widget _buildDebtPaymentDayInput(AssetLiabilityDebtRow row) {
+    final hasOverride = _debtPaymentDayOverrides.containsKey(row.id);
+    final statusLabel = hasOverride
+        ? '手動設定'
+        : row.paymentDay == null
+            ? '未設定'
+            : '自動推定';
+    final statusColor = hasOverride
+        ? const Color(0xFF7C3AED)
+        : row.paymentDay == null
+            ? const Color(0xFFD97706)
+            : const Color(0xFF475569);
+    return SizedBox(
+      width: 140,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildTextStatusChip(label: statusLabel, color: statusColor),
+          const SizedBox(height: 4),
+          DropdownButton<int?>(
+            value: row.paymentDay,
+            isExpanded: true,
+            isDense: true,
+            items: [
+              const DropdownMenuItem<int?>(
+                value: null,
+                child: Text('未設定'),
+              ),
+              for (var day = 1; day <= 31; day++)
+                DropdownMenuItem<int?>(
+                  value: day,
+                  child: Text('$day日'),
+                ),
+            ],
+            onChanged: (value) => _setDebtPaymentDayOverride(row, value),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildDebtMasterCard(
     AssetLiabilityDebtRow row,
     AssetLiabilityWorkbook workbook,
@@ -16723,6 +16853,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         row.paymentDay == null ? '支払日未設定' : '${row.paymentDay}日支払';
 
     return Container(
+      key: _debtMasterCardKeyFor(row.id),
       width: double.infinity,
       margin: const EdgeInsets.only(bottom: 10),
       padding: const EdgeInsets.all(12),
@@ -16814,6 +16945,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             runSpacing: 10,
             crossAxisAlignment: WrapCrossAlignment.start,
             children: [
+              _buildDebtMasterControl(
+                label: '支払日',
+                child: _buildDebtPaymentDayInput(row),
+                maxWidth: 150,
+              ),
               _buildDebtMasterControl(
                 label: '実支払額',
                 child: _buildActualPaymentInput(row),

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -79,6 +79,8 @@ class AssetLiabilityMonthlyStateStore {
       'asset_liability_default_payment_source_accounts_v1';
   static const String defaultCardBillingPrefsKey =
       'asset_liability_default_card_billing_accounts_v1';
+  static const String debtPaymentDayPrefsKey =
+      'asset_liability_debt_payment_day_overrides_v1';
   static const String recurringIncomeTemplatePrefsKey =
       'asset_liability_recurring_income_templates_v1';
   static const String monthlySnapshotPrefsKey =
@@ -343,6 +345,21 @@ class AssetLiabilityMonthlyStateStore {
     );
   }
 
+  Future<Map<String, int>> loadDebtPaymentDayOverrides() async {
+    final prefs = await SharedPreferences.getInstance();
+    return decodeDebtPaymentDayOverrides(
+      prefs.getString(debtPaymentDayPrefsKey),
+    );
+  }
+
+  Future<void> saveDebtPaymentDayOverrides(Map<String, int> overrides) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      debtPaymentDayPrefsKey,
+      jsonEncode(sanitizeDebtPaymentDayOverrides(overrides)),
+    );
+  }
+
   Future<List<AssetLiabilityRecurringIncomeTemplate>>
       loadRecurringIncomeTemplates() async {
     final prefs = await SharedPreferences.getInstance();
@@ -554,6 +571,39 @@ class AssetLiabilityMonthlyStateStore {
         (key, value) => MapEntry(key.toString(), value.toString()),
       ),
     );
+  }
+
+  static Map<String, int> decodeDebtPaymentDayOverrides(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, int>{};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return <String, int>{};
+    }
+
+    final overrides = <String, int>{};
+    for (final entry in decoded.entries) {
+      final key = entry.key.toString().trim();
+      final rawDay = entry.value;
+      final day = rawDay is num ? rawDay.toInt() : int.tryParse('$rawDay');
+      if (key.isNotEmpty && day != null && day >= 1 && day <= 31) {
+        overrides[key] = day;
+      }
+    }
+    return overrides;
+  }
+
+  static Map<String, int> sanitizeDebtPaymentDayOverrides(
+    Map<String, int> values,
+  ) {
+    return <String, int>{
+      for (final entry in values.entries)
+        if (entry.key.trim().isNotEmpty &&
+            entry.value >= 1 &&
+            entry.value <= 31)
+          entry.key.trim(): entry.value,
+    };
   }
 
   static Map<String, Map<String, double>> decodePaymentOverrides(String? raw) {

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -79,6 +79,7 @@ class AssetLiabilityPlanningService {
     Map<String, double> actualPaymentAmounts = const <String, double>{},
     Map<String, String> paymentDifferenceReasons = const <String, String>{},
     Map<String, double> annualRateOverrides = const <String, double>{},
+    Map<String, int> paymentDayOverrides = const <String, int>{},
     Set<String> paidAccountNames = const <String>{},
     Set<String> billingConfirmedAccountIds = const <String>{},
     Map<String, String> paymentSourceAccountIds = const <String, String>{},
@@ -114,9 +115,12 @@ class AssetLiabilityPlanningService {
     final accounts = effectiveSnapshot.entries
         .where((entry) => entry.key.trim().isNotEmpty && entry.value != 0)
         .map(
-          (entry) => _classifyAccount(
-            name: entry.key.trim(),
-            balance: entry.value,
+          (entry) => _applyPaymentDayOverride(
+            account: _classifyAccount(
+              name: entry.key.trim(),
+              balance: entry.value,
+            ),
+            paymentDayOverrides: paymentDayOverrides,
           ),
         )
         .toList()
@@ -298,6 +302,22 @@ class AssetLiabilityPlanningService {
       manualPaymentCount: manualPaymentCount,
       estimatedPaymentCount: estimatedPaymentCount,
     );
+  }
+
+  AssetLiabilityAccount _applyPaymentDayOverride({
+    required AssetLiabilityAccount account,
+    required Map<String, int> paymentDayOverrides,
+  }) {
+    if (!account.isLiability) {
+      return account;
+    }
+    final override = paymentDayOverrides[account.id] ??
+        paymentDayOverrides[account.name.trim()] ??
+        paymentDayOverrides[account.name];
+    if (override == null || override < 1 || override > 31) {
+      return account;
+    }
+    return account.copyWith(paymentDay: override);
   }
 
   AssetLiabilityAccount _classifyAccount({

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -303,6 +303,13 @@ abstract class AssetLiabilityRepository {
 
   Future<void> saveDefaultCardBillingAccounts(Map<String, String> accounts);
 
+  /// 負債ごとの支払日 (1-31) 手動設定。契約属性のため月をまたいで共有する。
+  Future<Map<String, int>> loadDebtPaymentDayOverrides() async {
+    return const <String, int>{};
+  }
+
+  Future<void> saveDebtPaymentDayOverrides(Map<String, int> overrides) async {}
+
   Future<List<AssetLiabilityRecurringIncomeTemplate>>
       loadRecurringIncomeTemplates();
 
@@ -623,6 +630,17 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
         ),
       );
     }
+  }
+
+  // 支払日手動設定はローカル保存のみ (リモート同期は将来対応)。
+  @override
+  Future<Map<String, int>> loadDebtPaymentDayOverrides() {
+    return localRepository.loadDebtPaymentDayOverrides();
+  }
+
+  @override
+  Future<void> saveDebtPaymentDayOverrides(Map<String, int> overrides) {
+    return localRepository.saveDebtPaymentDayOverrides(overrides);
   }
 
   @override
@@ -2127,6 +2145,16 @@ class SharedPreferencesAssetLiabilityRepository
   @override
   Future<void> saveDefaultCardBillingAccounts(Map<String, String> accounts) {
     return store.saveDefaultCardBillingAccounts(accounts);
+  }
+
+  @override
+  Future<Map<String, int>> loadDebtPaymentDayOverrides() {
+    return store.loadDebtPaymentDayOverrides();
+  }
+
+  @override
+  Future<void> saveDebtPaymentDayOverrides(Map<String, int> overrides) {
+    return store.saveDebtPaymentDayOverrides(overrides);
   }
 
   @override

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -359,7 +359,7 @@ class AssetManagementInsightService {
             relatedAccountId: row.id,
             dueDate: null,
             paymentDay: null,
-            suggestedAction: '契約画面または請求明細で支払日を確認して入力してください。',
+            suggestedAction: '契約画面または請求明細で支払日を確認し、負債マスタ（支払日順）の「支払日」欄に入力してください。',
           ),
         );
       }

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -611,5 +611,42 @@ void main() {
       expect(snapshots.single.monthlyPaidPaymentTotal, 130000);
       expect(snapshots.single.overduePaymentCount, 0);
     });
+
+    test('saves and restores debt payment day overrides', () async {
+      await store.saveDebtPaymentDayOverrides(const <String, int>{
+        'famima_card': 27,
+        'paypay_card': 15,
+      });
+
+      final overrides = await store.loadDebtPaymentDayOverrides();
+
+      expect(overrides, <String, int>{'famima_card': 27, 'paypay_card': 15});
+    });
+
+    test('drops invalid debt payment day overrides on save and load', () async {
+      await store.saveDebtPaymentDayOverrides(const <String, int>{
+        'famima_card': 27,
+        'too_small': 0,
+        'too_large': 32,
+        '': 10,
+      });
+
+      final overrides = await store.loadDebtPaymentDayOverrides();
+
+      expect(overrides, <String, int>{'famima_card': 27});
+
+      expect(
+        AssetLiabilityMonthlyStateStore.decodeDebtPaymentDayOverrides(
+          '{"famima_card": 27, "junk": "abc", "out_of_range": 99}',
+        ),
+        <String, int>{'famima_card': 27},
+      );
+      expect(
+        AssetLiabilityMonthlyStateStore.decodeDebtPaymentDayOverrides(
+          '[1, 2, 3]',
+        ),
+        isEmpty,
+      );
+    });
   });
 }

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1356,5 +1356,60 @@ void main() {
       expect(kddiCashflow.cashBeforePayment, kddiCashflow.cashAfterPayment);
       expect(workbook.monthlyUnpaidPaymentTotal, rent.scheduledPaymentAmount);
     });
+
+    test('applies manual payment day override to unknown cards', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'ファミマカード': -25000,
+        },
+        baseDate: DateTime(2026, 6, 1),
+        paymentDayOverrides: const <String, int>{'ファミマカード': 27},
+      );
+
+      final row = workbook.debtMasterRows.firstWhere(
+        (row) => row.name == 'ファミマカード',
+      );
+      expect(row.paymentDay, 27);
+      expect(
+        workbook.cashflowRows.any(
+          (cashflow) =>
+              cashflow.accountId == row.id && cashflow.paymentDate.day == 27,
+        ),
+        isTrue,
+      );
+    });
+
+    test('manual payment day override replaces the built-in default', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'PayPayカード': -30000,
+        },
+        baseDate: DateTime(2026, 6, 1),
+        paymentDayOverrides: const <String, int>{'paypay_card': 15},
+      );
+
+      final row = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == 'paypay_card',
+      );
+      expect(row.paymentDay, 15);
+    });
+
+    test('ignores out-of-range payment day overrides', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'ファミマカード': -25000,
+        },
+        baseDate: DateTime(2026, 6, 1),
+        paymentDayOverrides: const <String, int>{'ファミマカード': 45},
+      );
+
+      final row = workbook.debtMasterRows.firstWhere(
+        (row) => row.name == 'ファミマカード',
+      );
+      expect(row.paymentDay, isNull);
+    });
   });
 }

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -32,6 +32,30 @@ void main() {
       );
     });
 
+    test('clears missing payment day item once an override is entered', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'Custom Card': -10000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        paymentDayOverrides: const <String, int>{'Custom Card': 27},
+      );
+
+      final report = service.buildReport(
+        workbook: workbook,
+        userProfile: _userProfile(),
+      );
+
+      expect(
+        report.actionItems.any(
+          (item) =>
+              item.type == AssetManagementInsightActionType.missingPaymentDay,
+        ),
+        false,
+      );
+    });
+
     test('marks missing annual rate as an action item', () {
       final workbook = _workbook(
         debtRows: <AssetLiabilityDebtRow>[


### PR DESCRIPTION
## 概要

「ファミマカードの支払日が未入力です」等の警告から、支払日の入力欄へ直接飛べるリンクが欲しいというユーザー要望への対応です。

調査の結果、負債の支払日は口座名からの自動推定（ハードコード分類）のみで、**そもそもユーザーが入力できる欄が存在しない**ことが判明したため、入力欄の新設とジャンプリンクをセットで実装しました。

### 変更内容

- 負債マスタ（支払日順）カードに「支払日」ドロップダウン（未設定 / 1〜31日）を新設し、口座IDごとの手動設定を保存（新キー `asset_liability_debt_payment_day_overrides_v1`、契約属性のため月をまたいで共有・v1はローカル保存のみ）
- `AssetLiabilityPlanningService.buildWorkbook` に `paymentDayOverrides` を追加。分類後の負債口座に適用され、支払日順資金繰り・マネーカレンダー・支払日別リスク・リマインダーへ波及
- AI資産管理アシスタントのアクションアイテム（支払日・今月支払予定額・利率・支払原資口座の未設定）に、該当の負債マスタカードへスクロールするリンクを追加（フィルタ表示中はフィルタを解除してからジャンプ）
- インサイトの提案文言を新しい入力欄へ誘導する内容に更新
- 支払日を入力すると `missingPaymentDay` 警告自体が消える

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. 支払日未設定の負債（例: ファミマカード）→ 警告に「支払日を入力する」リンクが表示され、負債マスタの支払日欄は「未設定」
  2. 支払日に27日を設定 → 資金繰り表に27日の支払予定が出現し、支払日未入力警告が消える
  3. 範囲外の保存値（0 / 32 / 非数値）→ 無視され未設定のまま
- 上記3ケースと同じ入出力契約をサービス層の単体テスト（新規6件、対象3ファイル計71件 PASS）で検証済み
- E2E-Exception: 資産管理ページは認証済みユーザーの資産データ前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。サービス層の単体テストで入出力契約を担保し、UIリンクのスクロール挙動は本番反映後に手動確認する。

## 検証

- `flutter test`（planning / monthly_state_store / insight の3ファイル・71件）: All tests passed
- `flutter analyze`: No issues found
- `dart format --set-exit-if-changed`（変更9ファイル）: 0 changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
