### PR TITLE
fix(asset): カード請求設定の0円許容とアクションアイテムからの設定欄ジャンプ

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -12789,6 +12789,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetManagementInsightActionType.missingInput => '今月支払予定額を入力する',
       AssetManagementInsightActionType.missingAnnualRate => '利率を入力する',
       AssetManagementInsightActionType.missingPaymentSource => '支払原資口座を設定する',
+      AssetManagementInsightActionType.cardBillingConfiguration =>
+        '支払い方式と請求先カードを設定する',
+      AssetManagementInsightActionType.doubleCountingRisk => '支払い方式を整理する',
       _ => null,
     };
   }

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -37,7 +37,8 @@ class AssetLiabilityPlanningService {
       '請求先カードが未設定です';
   static const String cardBillingReviewRemovedBillingAccountAlert =
       '請求先カードが見つかりません';
-  static const String cardBillingReviewZeroAmountAlert = '金額が0円のため確認してください';
+  static const String cardBillingReviewZeroAmountAlert =
+      '金額が0円のため確認してください（請求が0円の月は今月支払予定額に0を入力すると確認対象外になります）';
   static const String cardStatementMissingImportAlert = 'カード明細の取り込みが未実施です';
   static const String cardStatementBillingAccountMissingAlert =
       '請求先カード口座が見つかりません';
@@ -837,7 +838,8 @@ class AssetLiabilityPlanningService {
         alerts.add(cardBillingReviewRemovedBillingAccountAlert);
       }
     }
-    if (row.scheduledPaymentAmount <= 0) {
+    // 手入力の0円 (請求なし月) は正常値として許容し、推定値が0以下の場合のみ確認を促す。
+    if (row.scheduledPaymentAmount <= 0 && row.paymentAmountEstimated) {
       alerts.add(cardBillingReviewZeroAmountAlert);
     }
 

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -480,7 +480,8 @@ class AssetManagementInsightService {
               ? null
               : _paymentDateFromDay(workbook.baseDate, item.paymentDay!),
           paymentDay: item.paymentDay,
-          suggestedAction: 'カード請求に含める設定と請求先カードを確認してください。',
+          suggestedAction:
+              '負債マスタ（支払日順）の「支払い方式」でカード請求に含める設定と請求先カードを確認してください。請求額が0円の月は「今月支払予定額」に0を入力してください。',
         ),
       );
     }

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -235,6 +235,20 @@ void main() {
       expect(payPay.paymentAmountEstimated, isFalse);
     });
 
+    test('manual zero yen does not trigger card billing review alert', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+        monthlyPaymentOverrides: const <String, double>{'PayPayカード': 0},
+      );
+
+      expect(
+        workbook.cardBillingReview.needsReviewItems
+            .where((item) => item.accountId == 'paypay_card'),
+        isEmpty,
+      );
+    });
+
     test('reflects manual and estimated sources in payment day risk', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: snapshot,

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -259,6 +259,25 @@ void main() {
       );
     });
 
+    test('accepts explicit zero yen billing without configuration item', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'paypay_card': 0},
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      expect(
+        report.actionItems.any(
+          (item) =>
+              item.type ==
+              AssetManagementInsightActionType.cardBillingConfiguration,
+        ),
+        false,
+      );
+    });
+
     test('builds prompt with deterministic calculated values', () {
       final workbook = planner.buildWorkbook(
         latestSnapshot: const <String, double>{


### PR DESCRIPTION
## 概要

PR #3244（支払日入力欄+ジャンプリンク）の続編。「ファミマカードのカード請求設定を確認」アクションアイテムに関する2つのユーザー要望に対応します。

1. **請求額0円の許容** — 今月の請求が0円のとき「今月支払予定額」に0を手入力しても、「金額が0円のため確認してください」アラートが出続けていた。手入力の0円（請求なし月）は正常値として許容し、推定値が0以下の場合のみ確認を促すよう `_cardBillingReviewItemFor` の条件を変更（`paymentAmountEstimated` で判定）。アラート文言にも0円入力の案内を追記。
2. **設定欄へのジャンプリンク** — 「カード請求に含める設定と請求先カードを確認してください」警告から設定欄へ飛べなかった。part 271 で導入したジャンプ機構を `cardBillingConfiguration`（→「支払い方式と請求先カードを設定する」）と `doubleCountingRisk`（→「支払い方式を整理する」）にも拡張。リンク先は該当負債マスタカード（「支払い方式」ドロップダウンで直接支払い/カード請求に含める+請求先カードを設定可能）。
3. インサイトの提案文言を、設定欄の場所（負債マスタの「支払い方式」）と0円入力手順を案内する内容に更新。

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. 今月支払予定額に0を手入力 → カード請求設定の確認アイテムが消える
  2. 請求先カードが見つからない負債 → 確認アイテムが表示され、「支払い方式と請求先カードを設定する」リンクで負債マスタカードへスクロール
  3. 手入力なし（推定額>0）の通常負債 → 0円アラートは出ない
- 上記と同じ入出力契約をサービス層の単体テスト（新規2件、対象2ファイル計54件 PASS）で検証済み
- E2E-Exception: 資産管理ページは認証済みユーザーの資産データ前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。サービス層の単体テストで入出力契約を担保し、UIリンクのスクロール挙動は本番反映後に手動確認する。

## 検証

- `flutter test`（planning / insight の2ファイル・54件）: All tests passed
- `flutter analyze`: No issues found
- `dart format --set-exit-if-changed`(変更5ファイル): 0 changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
