### PR TITLE
fix(asset): 家賃など全額支払い固定費を利率確認の対象外にする

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -257,6 +257,9 @@ class AssetLiabilityDebtRow {
   final bool billingConfirmed;
   final bool paid;
 
+  /// 家賃・通信費など毎月全額を支払う固定費型の負債。利率の概念を持たない。
+  final bool fullPaymentEstimate;
+
   const AssetLiabilityDebtRow({
     required this.id,
     required this.name,
@@ -285,6 +288,7 @@ class AssetLiabilityDebtRow {
     required this.paymentAmountEstimated,
     required this.billingConfirmed,
     required this.paid,
+    this.fullPaymentEstimate = false,
   });
 
   bool get isDirectCashflowTarget =>

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -17544,6 +17544,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Widget _buildAnnualRateInputWithEvidence(AssetLiabilityDebtRow row) {
+    if (row.fullPaymentEstimate) {
+      return _buildTextStatusChip(
+        label: '固定費（利率なし）',
+        color: const Color(0xFF475569),
+      );
+    }
     final controller = _annualRateControllerFor(row);
     final hasOverride = _annualRateOverrides.containsKey(row.id);
     final evidence = _annualRateEvidences[row.id];

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -624,6 +624,7 @@ class AssetLiabilityPlanningService {
           liabilityTotal == 0 ? 0 : principal / liabilityTotal.abs(),
       priorityLabel: _priorityLabel(annualRate),
       paymentAmountEstimated: manualPayment == null,
+      fullPaymentEstimate: account.fullPaymentEstimate,
       billingConfirmed: _containsAccountKey(
         billingConfirmedAccountIds,
         account,

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -952,6 +952,10 @@ class AssetManagementInsightService {
     if (row.annualRate > 0) {
       return false;
     }
+    // 家賃・通信費など全額支払い型の固定費は利率の概念がないため対象外。
+    if (row.fullPaymentEstimate) {
+      return false;
+    }
     return switch (row.kind) {
       AssetLiabilityAccountKind.cardLoan ||
       AssetLiabilityAccountKind.shoppingDebt ||

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1425,5 +1425,27 @@ void main() {
       );
       expect(row.paymentDay, isNull);
     });
+
+    test('marks full-payment fixed costs on debt rows', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: const <String, double>{'cash': 50000, 'モビット': -100000},
+        baseDate: DateTime(2026, 5, 12),
+        includeDefaultFixedPayments: true,
+      );
+
+      final rent = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.rentAccountId,
+      );
+      final kddi = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.kddiProviderAccountId,
+      );
+      final mobit = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == 'mobit',
+      );
+
+      expect(rent.fullPaymentEstimate, isTrue);
+      expect(kddi.fullPaymentEstimate, isTrue);
+      expect(mobit.fullPaymentEstimate, isFalse);
+    });
   });
 }

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -77,6 +77,36 @@ void main() {
       );
     });
 
+    test('does not require annual rate for full-payment fixed costs', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 50000},
+        baseDate: DateTime(2026, 5, 1),
+        includeDefaultFixedPayments: true,
+      );
+
+      final report = service.buildReport(
+        workbook: workbook,
+        userProfile: _userProfile(),
+      );
+
+      expect(
+        workbook.debtMasterRows.any(
+          (row) =>
+              row.id == AssetLiabilityPlanningService.rentAccountId &&
+              row.fullPaymentEstimate &&
+              row.annualRate == 0,
+        ),
+        true,
+      );
+      expect(
+        report.actionItems.any(
+          (item) =>
+              item.type == AssetManagementInsightActionType.missingAnnualRate,
+        ),
+        false,
+      );
+    });
+
     test('marks missing payment source as an action item', () {
       final workbook = planner.buildWorkbook(
         latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},


### PR DESCRIPTION
## 概要

アクションアイテムに「家賃の利率を確認」と表示される問題への対応（PR #3244 / #3248 の続編）。家賃はローンではなく固定費のため利率は存在しません。

家賃・通信費（KDDI）のような毎月全額を支払う固定費型負債は、分類時に `fullPaymentEstimate: true` が付与されています。このフラグを `AssetLiabilityDebtRow` へ伝搬し、利率確認の対象から除外しました（「0を許容」だと実ローンの利率未入力警告まで消えてしまうため、固定費だけを対象外にする方式を採用）。

### 変更内容

- `AssetLiabilityDebtRow` に `fullPaymentEstimate` フィールドを追加（既定 false）し、planner の `_buildDebtRow` で口座から伝搬
- インサイト `_needsAnnualRate` で `fullPaymentEstimate` の行を早期除外 →「家賃の利率を確認」が出なくなる
- 負債マスタカードの「年利と証跡」入力欄は、固定費では「固定費（利率なし）」チップ表示に置き換え（利率の入力自体を求めない）
- カードローン・クレカ等の実ローンに対する利率未入力警告（missingAnnualRate）は従来どおり

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. 家賃（固定費・利率0）→「利率を確認」アクションアイテムが出ない
  2. カードローン（利率0）→ 従来どおり「利率を確認」が出る
  3. 負債マスタの家賃カード → 年利入力欄の代わりに「固定費（利率なし）」表示
- 上記と同じ入出力契約をサービス層の単体テスト（新規2件、対象2ファイル計56件 PASS）で検証済み
- E2E-Exception: 資産管理ページは認証済みユーザーの資産データ前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。サービス層の単体テストで入出力契約を担保し、UI表示は本番反映後に手動確認する。

## 検証

- `flutter test`（planning / insight の2ファイル・56件）: All tests passed
- `flutter analyze`: No issues found（並行マージ #3250 反映後の最新 main 基準で再検証済み）
- `dart format --set-exit-if-changed`（変更6ファイル）: 0 changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
