### PR TITLE
feat(asset): 入金予定×ショート対策 + 日タップ記録プリフィル + 実験ログ (part 274)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -20,6 +20,7 @@ import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/models/debt_repayment_plan.dart';
 import 'package:my_web_app/models/kgi_csf_kpi.dart';
 import 'package:my_web_app/models/user_profile.dart';
+import 'package:my_web_app/services/asset_expected_inflow_store.dart';
 import 'package:my_web_app/services/asset_liability_annual_rate_evidence_service.dart';
 import 'package:my_web_app/services/asset_liability_card_statement_import_service.dart';
 import 'package:my_web_app/services/asset_liability_csv_restore_service.dart';
@@ -337,6 +338,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetManagementDisplayModeStore.defaultMode;
   Map<AssetManagementSectionId, AssetManagementSectionVisibilityOverride>
       _sectionOverrides = {};
+  final AssetExpectedInflowStore _expectedInflowStore =
+      const AssetExpectedInflowStore();
+  List<AssetExpectedInflow> _expectedInflows = <AssetExpectedInflow>[];
+  String? _displayModeStatsLabel;
   DateTime _calendarMonth = DateTime.now();
   DateTime? _calendarSelectedDate;
   Future<AssetWasteTrainingAiReview>? _wasteTrainingAiReviewFuture;
@@ -416,6 +421,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _fetchSubscriptions();
     _fetchMustTasks();
     _loadDisplayMode();
+    _loadExpectedInflows();
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
       final previousMonthKey = _assetLiabilityStateMonthKey(_now);
@@ -7296,6 +7302,173 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _displayMode = mode;
       _sectionOverrides = overrides;
     });
+    unawaited(_refreshDisplayModeStats());
+  }
+
+  Future<void> _refreshDisplayModeStats() async {
+    final stats = await _displayModeStore.loadStats();
+    if (!mounted) {
+      return;
+    }
+    final hadData = stats.initialHadData == true ? '既存データあり' : '新規';
+    final initialLabel = stats.initialMode == null
+        ? '初期解決なし'
+        : '初期=${stats.initialMode}($hadData)';
+    setState(() {
+      _displayModeStatsLabel = '$initialLabel / 切替 ${stats.switchCount}回';
+    });
+  }
+
+  Future<void> _loadExpectedInflows() async {
+    final entries = await _expectedInflowStore.loadAll();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _expectedInflows = entries;
+    });
+  }
+
+  Future<void> _removeExpectedInflow(String id) async {
+    final entries = await _expectedInflowStore.remove(id);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _expectedInflows = entries;
+    });
+  }
+
+  void _prefillFlowDateFromCalendar(DateTime date) {
+    setState(() {
+      _selectedFlowDate = date;
+    });
+    final dateLabel = DateFormat('M月d日').format(date);
+    if (_isSectionShown(AssetManagementSectionId.flow)) {
+      _scrollTo(_keyFlow);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('$dateLabelを記録日にセットしました')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('$dateLabelを記録日にセットしました。収支セクション(標準/フル)で記録できます'),
+        ),
+      );
+    }
+  }
+
+  Future<void> _showAddExpectedInflowDialog(DateTime initialDate) async {
+    var selectedDate = initialDate;
+    final amountController = TextEditingController();
+    final labelController = TextEditingController();
+
+    try {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => StatefulBuilder(
+          builder: (dialogContext, setDialogState) => AlertDialog(
+            title: const Text('入金予定を追加'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        DateFormat('yyyy/MM/dd').format(selectedDate),
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w700,
+                          height: 1.4,
+                        ),
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: () async {
+                        final picked = await showDatePicker(
+                          context: dialogContext,
+                          initialDate: selectedDate,
+                          firstDate: DateTime(2020),
+                          lastDate: DateTime(2035),
+                        );
+                        if (picked == null) {
+                          return;
+                        }
+                        setDialogState(() {
+                          selectedDate = picked;
+                        });
+                      },
+                      child: const Text('日付変更'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: amountController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: '金額(円)',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: labelController,
+                  decoration: const InputDecoration(
+                    labelText: 'メモ(例: 給料、フリマ売上)',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext, false),
+                child: const Text('キャンセル'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(dialogContext, true),
+                child: const Text('追加'),
+              ),
+            ],
+          ),
+        ),
+      );
+      if (confirmed != true) {
+        return;
+      }
+      final amount = double.tryParse(
+        amountController.text.replaceAll(',', '').trim(),
+      );
+      if (amount == null || amount <= 0) {
+        if (!mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('金額を1円以上で入力してください')));
+        return;
+      }
+      final entries = await _expectedInflowStore.add(
+        date: selectedDate,
+        amount: amount,
+        label: labelController.text,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _expectedInflows = entries;
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('入金予定を追加しました。見込み残高に反映されます')));
+    } finally {
+      amountController.dispose();
+      labelController.dispose();
+    }
   }
 
   Future<void> _setDisplayMode(AssetManagementDisplayMode mode) async {
@@ -7306,6 +7479,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _displayMode = mode;
     });
     await _displayModeStore.save(mode);
+    await _refreshDisplayModeStats();
   }
 
   Future<void> _resolveInitialDisplayMode({
@@ -7314,7 +7488,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final mode = await _displayModeStore.resolveInitialMode(
       hasExistingData: hasExistingData,
     );
-    if (!mounted || mode == _displayMode) {
+    if (!mounted) {
+      return;
+    }
+    unawaited(_refreshDisplayModeStats());
+    if (mode == _displayMode) {
       return;
     }
     setState(() {
@@ -7374,6 +7552,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  if (_displayModeStatsLabel != null) ...[
+                    Text(
+                      '実験ログ: $_displayModeStatsLabel',
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                  ],
                   Text(
                     '「自動」は表示モード(ミニマム/標準/フル)に従います。「常に表示」「隠す」はモードより優先されます。',
                     style: TextStyle(
@@ -7527,6 +7716,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       ],
       salaryDay: _salarySpendingSalaryDay,
       startingCashBalance: startingCashBalance,
+      expectedInflows: [
+        for (final inflow in AssetExpectedInflowStore.monthInflows(
+          _expectedInflows,
+          _calendarMonth,
+        ))
+          AssetCalendarInflowInput(
+            date: inflow.date,
+            amount: inflow.amount,
+            label: inflow.label,
+          ),
+      ],
     );
     final selectedDate = _calendarSelectedDate;
     final selectedDay =
@@ -7644,11 +7844,29 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      '現金・預金 ${_formatYen(startingCashBalance ?? 0)} を起点に、返済予定と固定費だけを差し引いた保守的な見込みです。給料などの入金は含めていません。入金予定や返済日の調整を確認してください。',
+                      '現金・預金 ${_formatYen(startingCashBalance ?? 0)} と登録済み入金予定を起点に、返済予定と固定費を差し引いた見込みです。未登録の入金は含まれません。',
                       style: TextStyle(
                         fontSize: 11,
                         color: Theme.of(context).colorScheme.onSurface,
                         height: 1.6,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton.icon(
+                      key: const Key('asset_calendar_add_inflow_button'),
+                      onPressed: () => _showAddExpectedInflowDialog(
+                        calendar.firstShortfallDate!,
+                      ),
+                      icon: const Icon(Icons.savings, size: 16),
+                      label: const Text('入金予定を追加して再計算'),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '返済日の変更は「負債マスタ」の支払日設定から。給料日(25日)以降へ動かすとショートを避けやすくなります。',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        height: 1.5,
                       ),
                     ),
                   ],
@@ -7690,8 +7908,33 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 _buildCalendarLegendItem(const Color(0xFF9333EA), '固定費'),
                 _buildCalendarLegendItem(const Color(0xFF0D9488), '給料日'),
                 _buildCalendarLegendItem(const Color(0xFF2563EB), '収入'),
+                _buildCalendarLegendItem(const Color(0xFF0EA5E9), '入金予定'),
               ],
             ),
+            if (AssetExpectedInflowStore.monthInflows(
+              _expectedInflows,
+              _calendarMonth,
+            ).isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: [
+                  for (final inflow in AssetExpectedInflowStore.monthInflows(
+                    _expectedInflows,
+                    _calendarMonth,
+                  ))
+                    InputChip(
+                      key: Key('asset_inflow_chip_${inflow.id}'),
+                      label: Text(
+                        '${DateFormat('M/d').format(inflow.date)} ${inflow.label} ${_formatYen(inflow.amount)}',
+                        style: const TextStyle(fontSize: 11),
+                      ),
+                      onDeleted: () => _removeExpectedInflow(inflow.id),
+                    ),
+                ],
+              ),
+            ],
             if (selectedDay != null) ...[
               const SizedBox(height: 10),
               Text(
@@ -7701,6 +7944,27 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   fontWeight: FontWeight.w700,
                   height: 1.5,
                 ),
+              ),
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 8,
+                runSpacing: 6,
+                children: [
+                  OutlinedButton.icon(
+                    key: const Key('asset_calendar_prefill_flow_button'),
+                    onPressed: () =>
+                        _prefillFlowDateFromCalendar(selectedDay.date),
+                    icon: const Icon(Icons.edit_calendar, size: 16),
+                    label: const Text('この日に記録'),
+                  ),
+                  OutlinedButton.icon(
+                    key: const Key('asset_calendar_day_inflow_button'),
+                    onPressed: () =>
+                        _showAddExpectedInflowDialog(selectedDay.date),
+                    icon: const Icon(Icons.savings, size: 16),
+                    label: const Text('入金予定'),
+                  ),
+                ],
               ),
               const SizedBox(height: 6),
               if (!selectedDay.hasAnyEvent)
@@ -7775,6 +8039,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (day.hasDebtPayment) const Color(0xFFB91C1C),
       if (day.hasSubscription) const Color(0xFF9333EA),
       if (day.hasSalary) const Color(0xFF0D9488),
+      if (day.hasExpectedInflow) const Color(0xFF0EA5E9),
       if (day.hasIncome) const Color(0xFF2563EB),
     ];
 
@@ -7879,6 +8144,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     switch (kind) {
       case AssetCalendarEventKind.salary:
         return Icons.payments_outlined;
+      case AssetCalendarEventKind.expectedInflow:
+        return Icons.savings;
       case AssetCalendarEventKind.debtPayment:
         return Icons.account_balance_outlined;
       case AssetCalendarEventKind.subscription:
@@ -7894,6 +8161,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     switch (kind) {
       case AssetCalendarEventKind.salary:
         return const Color(0xFF0D9488);
+      case AssetCalendarEventKind.expectedInflow:
+        return const Color(0xFF0EA5E9);
       case AssetCalendarEventKind.debtPayment:
         return const Color(0xFFB91C1C);
       case AssetCalendarEventKind.subscription:

--- a/lib/services/asset_expected_inflow_store.dart
+++ b/lib/services/asset_expected_inflow_store.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 入金予定(給料・振込など)。カレンダーの見込み残高に加算され、
+/// 残高ショート警告の精度を上げる。端末ローカル保存のみ。
+class AssetExpectedInflow {
+  const AssetExpectedInflow({
+    required this.id,
+    required this.date,
+    required this.amount,
+    required this.label,
+  });
+
+  final String id;
+  final DateTime date;
+  final double amount;
+  final String label;
+
+  factory AssetExpectedInflow.fromJson(Map<String, dynamic> json) {
+    return AssetExpectedInflow(
+      id: json['id']?.toString() ?? '',
+      date: DateTime.tryParse(json['date']?.toString() ?? '')?.toLocal() ??
+          DateTime.now(),
+      amount: (json['amount'] as num?)?.toDouble() ?? 0,
+      label: json['label']?.toString() ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'date': date.toUtc().toIso8601String(),
+      'amount': amount,
+      'label': label,
+    };
+  }
+}
+
+/// 入金予定の永続化ストア。
+class AssetExpectedInflowStore {
+  const AssetExpectedInflowStore({this.nowProvider});
+
+  static const String _key = 'asset_expected_inflows_v1';
+
+  final DateTime Function()? nowProvider;
+
+  DateTime _now() => nowProvider?.call() ?? DateTime.now();
+
+  static List<AssetExpectedInflow> monthInflows(
+    List<AssetExpectedInflow> inflows,
+    DateTime month,
+  ) {
+    return inflows
+        .where(
+          (entry) =>
+              entry.date.year == month.year && entry.date.month == month.month,
+        )
+        .toList(growable: false);
+  }
+
+  Future<List<AssetExpectedInflow>> loadAll({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return _decode(store.getString(_key));
+  }
+
+  Future<List<AssetExpectedInflow>> add({
+    required DateTime date,
+    required double amount,
+    required String label,
+    SharedPreferences? prefs,
+  }) async {
+    final trimmedLabel = label.trim();
+    if (amount <= 0) {
+      throw ArgumentError('amount must be positive');
+    }
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final entries = _decode(store.getString(_key));
+    entries.add(
+      AssetExpectedInflow(
+        id: 'inflow_${_now().microsecondsSinceEpoch}_${entries.length}',
+        date: DateTime(date.year, date.month, date.day),
+        amount: amount,
+        label: trimmedLabel.isEmpty ? '入金予定' : trimmedLabel,
+      ),
+    );
+    entries.sort((a, b) => a.date.compareTo(b.date));
+    await _save(store, entries);
+    return entries;
+  }
+
+  Future<List<AssetExpectedInflow>> remove(
+    String id, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final entries = _decode(store.getString(_key))
+      ..removeWhere((entry) => entry.id == id);
+    await _save(store, entries);
+    return entries;
+  }
+
+  Future<void> _save(
+    SharedPreferences store,
+    List<AssetExpectedInflow> entries,
+  ) async {
+    await store.setString(
+      _key,
+      jsonEncode(entries.map((entry) => entry.toJson()).toList()),
+    );
+  }
+
+  List<AssetExpectedInflow> _decode(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return <AssetExpectedInflow>[];
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) {
+        return <AssetExpectedInflow>[];
+      }
+      return decoded
+          .whereType<Map>()
+          .map(
+            (entry) =>
+                AssetExpectedInflow.fromJson(Map<String, dynamic>.from(entry)),
+          )
+          .where((entry) => entry.id.isNotEmpty)
+          .toList();
+    } catch (_) {
+      return <AssetExpectedInflow>[];
+    }
+  }
+}

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -139,9 +139,34 @@ extension AssetManagementSectionVisibilityOverrideLabel
   }
 }
 
+/// 表示モード実験の観測値(ローカル計測)。
+class AssetDisplayModeStats {
+  const AssetDisplayModeStats({
+    required this.initialMode,
+    required this.initialHadData,
+    required this.switchCount,
+    required this.lastChangedAt,
+  });
+
+  /// 初回解決で保存されたモード(未解決なら null)。
+  final String? initialMode;
+
+  /// 初回解決時に既存データがあったか(=既存ユーザー判定)。
+  final bool? initialHadData;
+
+  /// ユーザーが手動でモードを切り替えた回数。
+  final int switchCount;
+
+  final DateTime? lastChangedAt;
+}
+
 /// 表示モード・セクション上書きの永続化と可視判定。
 class AssetManagementDisplayModeStore {
-  const AssetManagementDisplayModeStore();
+  const AssetManagementDisplayModeStore({this.nowProvider});
+
+  final DateTime Function()? nowProvider;
+
+  DateTime _now() => nowProvider?.call() ?? DateTime.now();
 
   /// 既存ユーザーの体験を変えないため、未設定時はフル表示。
   static const AssetManagementDisplayMode defaultMode =
@@ -153,6 +178,8 @@ class AssetManagementDisplayModeStore {
 
   static const String _modeKey = 'asset_management_display_mode_v1';
   static const String _overridesKey = 'asset_management_section_overrides_v1';
+  static const String _eventsKey = 'asset_management_display_mode_events_v1';
+  static const int _maxEvents = 50;
 
   static bool isTierVisible({
     required AssetManagementSectionTier tier,
@@ -196,6 +223,11 @@ class AssetManagementDisplayModeStore {
   }) async {
     final store = prefs ?? await SharedPreferences.getInstance();
     await store.setString(_modeKey, mode.storageId);
+    await _appendEvent(store, <String, dynamic>{
+      'type': 'switch',
+      'to': mode.storageId,
+      'at': _now().toUtc().toIso8601String(),
+    });
   }
 
   /// 初回起動時の既定モード解決。保存済みがあればそれを優先し、
@@ -211,7 +243,72 @@ class AssetManagementDisplayModeStore {
     }
     final resolved = hasExistingData ? defaultMode : newUserDefaultMode;
     await store.setString(_modeKey, resolved.storageId);
+    await _appendEvent(store, <String, dynamic>{
+      'type': 'initial',
+      'to': resolved.storageId,
+      'has_data': hasExistingData,
+      'at': _now().toUtc().toIso8601String(),
+    });
     return resolved;
+  }
+
+  /// 標準既定実験のローカル統計。サーバ集約は別 Issue で対応。
+  Future<AssetDisplayModeStats> loadStats({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final events = _decodeEvents(store.getString(_eventsKey));
+    String? initialMode;
+    bool? initialHadData;
+    var switchCount = 0;
+    DateTime? lastChangedAt;
+    for (final event in events) {
+      final type = event['type']?.toString();
+      if (type == 'initial' && initialMode == null) {
+        initialMode = event['to']?.toString();
+        initialHadData = event['has_data'] == true;
+      }
+      if (type == 'switch') {
+        switchCount += 1;
+      }
+      final at = DateTime.tryParse(event['at']?.toString() ?? '');
+      if (at != null) {
+        lastChangedAt = at.toLocal();
+      }
+    }
+    return AssetDisplayModeStats(
+      initialMode: initialMode,
+      initialHadData: initialHadData,
+      switchCount: switchCount,
+      lastChangedAt: lastChangedAt,
+    );
+  }
+
+  Future<void> _appendEvent(
+    SharedPreferences store,
+    Map<String, dynamic> event,
+  ) async {
+    final events = _decodeEvents(store.getString(_eventsKey))..add(event);
+    final trimmed = events.length <= _maxEvents
+        ? events
+        : events.sublist(events.length - _maxEvents);
+    await store.setString(_eventsKey, jsonEncode(trimmed));
+  }
+
+  List<Map<String, dynamic>> _decodeEvents(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return <Map<String, dynamic>>[];
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) {
+        return <Map<String, dynamic>>[];
+      }
+      return decoded
+          .whereType<Map>()
+          .map((entry) => Map<String, dynamic>.from(entry))
+          .toList();
+    } catch (_) {
+      return <Map<String, dynamic>>[];
+    }
   }
 
   Future<AssetManagementSectionOverrides> loadOverrides({

--- a/lib/services/asset_payment_calendar_service.dart
+++ b/lib/services/asset_payment_calendar_service.dart
@@ -20,10 +20,24 @@ class AssetCalendarDebtInput {
 /// カレンダーに載せる日次イベントの種別。
 enum AssetCalendarEventKind {
   salary,
+  expectedInflow,
   debtPayment,
   subscription,
   expense,
   income,
+}
+
+/// 入金予定の入力(ストアのモデルから必要項目だけ写す)。
+class AssetCalendarInflowInput {
+  const AssetCalendarInflowInput({
+    required this.date,
+    required this.amount,
+    required this.label,
+  });
+
+  final DateTime date;
+  final double amount;
+  final String label;
 }
 
 /// カレンダー1イベント。amount は不明な場合 null。
@@ -72,6 +86,8 @@ class AssetCalendarDaySummary {
   bool get hasDebtPayment => _has(AssetCalendarEventKind.debtPayment);
 
   bool get hasSubscription => _has(AssetCalendarEventKind.subscription);
+
+  bool get hasExpectedInflow => _has(AssetCalendarEventKind.expectedInflow);
 
   bool get hasIncome => incomeTotal > 0;
 
@@ -141,12 +157,15 @@ class AssetPaymentCalendarService {
     required List<AssetCalendarDebtInput> debts,
     int? salaryDay,
     double? startingCashBalance,
+    List<AssetCalendarInflowInput> expectedInflows =
+        const <AssetCalendarInflowInput>[],
   }) {
     final normalizedMonth = DateTime(month.year, month.month);
     final lastDay = DateTime(month.year, month.month + 1, 0).day;
     final expenseByDay = <int, double>{};
     final incomeByDay = <int, double>{};
     final outflowByDay = <int, double>{};
+    final inflowByDay = <int, double>{};
     final eventsByDay = <int, List<AssetCalendarEvent>>{};
     var scheduledDebtPaymentTotal = 0.0;
     var subscriptionTotal = 0.0;
@@ -161,6 +180,24 @@ class AssetPaymentCalendarService {
         const AssetCalendarEvent(
           kind: AssetCalendarEventKind.salary,
           label: '給料日',
+        ),
+      );
+    }
+
+    for (final inflow in expectedInflows) {
+      if (inflow.date.year != normalizedMonth.year ||
+          inflow.date.month != normalizedMonth.month ||
+          inflow.amount <= 0) {
+        continue;
+      }
+      inflowByDay[inflow.date.day] =
+          (inflowByDay[inflow.date.day] ?? 0) + inflow.amount;
+      addEvent(
+        inflow.date.day,
+        AssetCalendarEvent(
+          kind: AssetCalendarEventKind.expectedInflow,
+          label: inflow.label,
+          amount: inflow.amount,
         ),
       );
     }
@@ -257,8 +294,9 @@ class AssetPaymentCalendarService {
     final days = <AssetCalendarDaySummary>[];
     for (var day = 1; day <= lastDay; day++) {
       final outflow = outflowByDay[day] ?? 0;
+      final inflow = inflowByDay[day] ?? 0;
       if (runningBalance != null) {
-        runningBalance = runningBalance - outflow;
+        runningBalance = runningBalance + inflow - outflow;
       }
       final date = DateTime(normalizedMonth.year, normalizedMonth.month, day);
       if (firstShortfallDate == null &&

--- a/test/services/asset_expected_inflow_store_test.dart
+++ b/test/services/asset_expected_inflow_store_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_expected_inflow_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('AssetExpectedInflowStore', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('adds inflows sorted by date with sane defaults', () async {
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+
+      await store.add(date: DateTime(2026, 6, 25), amount: 280000, label: '給料');
+      final entries = await store.add(
+        date: DateTime(2026, 6, 10, 23, 59),
+        amount: 5000,
+        label: '   ',
+      );
+
+      expect(entries, hasLength(2));
+      expect(entries.first.date, DateTime(2026, 6, 10));
+      expect(entries.first.label, '入金予定');
+      expect(entries.last.amount, 280000);
+
+      final reloaded = await store.loadAll();
+      expect(reloaded, hasLength(2));
+    });
+
+    test('removes an inflow by id', () async {
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+      final entries = await store.add(
+        date: DateTime(2026, 6, 25),
+        amount: 1000,
+        label: '副収入',
+      );
+
+      final remaining = await store.remove(entries.single.id);
+
+      expect(remaining, isEmpty);
+      expect(await store.loadAll(), isEmpty);
+    });
+
+    test('filters inflows to a single month', () {
+      final inflows = <AssetExpectedInflow>[
+        AssetExpectedInflow(
+          id: 'a',
+          date: DateTime(2026, 6, 25),
+          amount: 1,
+          label: 'a',
+        ),
+        AssetExpectedInflow(
+          id: 'b',
+          date: DateTime(2026, 7, 1),
+          amount: 2,
+          label: 'b',
+        ),
+      ];
+
+      final june = AssetExpectedInflowStore.monthInflows(
+        inflows,
+        DateTime(2026, 6),
+      );
+
+      expect(june, hasLength(1));
+      expect(june.single.id, 'a');
+    });
+
+    test('rejects non-positive amounts and tolerates corrupt storage',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflows_v1': '{bad json',
+      });
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+
+      expect(await store.loadAll(), isEmpty);
+      await expectLater(
+        store.add(date: DateTime(2026, 6, 25), amount: 0, label: 'x'),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/services/asset_management_display_mode_store_test.dart
+++ b/test/services/asset_management_display_mode_store_test.dart
@@ -186,5 +186,23 @@ void main() {
         expect(storedWins, AssetManagementDisplayMode.minimum);
       },
     );
+
+    test('records initial resolution and mode switches as local stats',
+        () async {
+      final store = AssetManagementDisplayModeStore(
+        nowProvider: () => DateTime(2026, 6, 12, 10, 0),
+      );
+
+      await store.resolveInitialMode(hasExistingData: false);
+      await store.save(AssetManagementDisplayMode.full);
+      await store.save(AssetManagementDisplayMode.minimum);
+
+      final stats = await store.loadStats();
+
+      expect(stats.initialMode, 'standard');
+      expect(stats.initialHadData, isFalse);
+      expect(stats.switchCount, 2);
+      expect(stats.lastChangedAt, isNotNull);
+    });
   });
 }

--- a/test/services/asset_payment_calendar_service_test.dart
+++ b/test/services/asset_payment_calendar_service_test.dart
@@ -214,5 +214,69 @@ void main() {
       expect(day5.projectedBalance, isNull);
       expect(day5.isShortfall, isFalse);
     });
+
+    test('expected inflows lift the projection and clear shortfalls', () {
+      final calendar = AssetPaymentCalendarService.buildMonth(
+        month: DateTime(2026, 6),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[
+          AssetCalendarDebtInput(
+            name: 'ローン',
+            balance: -300000,
+            paymentDay: 5,
+            scheduledPaymentAmount: 15000,
+          ),
+        ],
+        startingCashBalance: 5000,
+        expectedInflows: <AssetCalendarInflowInput>[
+          AssetCalendarInflowInput(
+            date: DateTime(2026, 6, 3),
+            amount: 20000,
+            label: '振込',
+          ),
+          AssetCalendarInflowInput(
+            date: DateTime(2026, 7, 3),
+            amount: 99999,
+            label: '対象外の月',
+          ),
+        ],
+      );
+
+      expect(calendar.firstShortfallDate, isNull);
+      final day3 = calendar.dayFor(DateTime(2026, 6, 3))!;
+      expect(day3.hasExpectedInflow, isTrue);
+      expect(day3.projectedBalance, 25000);
+      final day5 = calendar.dayFor(DateTime(2026, 6, 5))!;
+      expect(day5.projectedBalance, 10000);
+      expect(day5.isShortfall, isFalse);
+    });
+
+    test('same-day inflow is applied before the payment', () {
+      final calendar = AssetPaymentCalendarService.buildMonth(
+        month: DateTime(2026, 6),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[
+          AssetCalendarDebtInput(
+            name: 'ローン',
+            balance: -300000,
+            paymentDay: 25,
+            scheduledPaymentAmount: 15000,
+          ),
+        ],
+        startingCashBalance: 0,
+        expectedInflows: <AssetCalendarInflowInput>[
+          AssetCalendarInflowInput(
+            date: DateTime(2026, 6, 25),
+            amount: 15000,
+            label: '給料',
+          ),
+        ],
+      );
+
+      expect(calendar.firstShortfallDate, isNull);
+      expect(calendar.dayFor(DateTime(2026, 6, 25))!.projectedBalance, 0);
+    });
   });
 }


### PR DESCRIPTION
## 概要

残高ショート警告を「見るだけ」から「**その場で対策する**」へ(3機能)。

1. **入金予定 × ショート対策** — 新設 `AssetExpectedInflowStore`(ローカル保存)。給料・振込などの入金予定を登録すると、カレンダーの見込み残高に日次で加算され、ショート警告が**その場で再計算**されます。警告バナーに「入金予定を追加して再計算」ボタンと、返済日変更(負債マスタの支払日設定)のヒントを併設。月内の入金予定はチップ一覧から削除可能。同日の入金と支払は**入金→支払の順**で適用(給料日返済の現実に整合)。
2. **日タップ→フロー記録プリフィル** — カレンダーの選択日詳細に「この日に記録」ボタン。既存フロー記録フォームの `_selectedFlowDate` に日付をセットし、収支セクションへ自動スクロール(非表示モード時は案内 SnackBar)。「入金予定」ボタンも併設し、その日付で即ダイアログ起動。
3. **標準既定実験のローカル計測** — 初期モード解決(新規=標準 / 既存=フル)とモード切替をイベントログ(上限50件)として記録し、カスタマイズダイアログに「実験ログ: 初期=standard(新規) / 切替 N回」を表示。サーバ側集約は別 Issue で分離。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) 入金予定がプロジェクションを押し上げショートを解消(同日適用順含む) (2) 入金予定ストアの追加/削除/月フィルタ/不正値拒否 (3) 初期解決+切替のイベント集計。既存分含め計 23 ケース。
- E2E例外: 本変更は表示層とローカル保存(SharedPreferences)のみでネットワーク・DB・Edge Function 変更なしのため、エンドツーエンド(integration_test)追加は行わず service 単体テストで入出力契約を担保する。
- 検証実績(ローカル worktree): `dart format` 差分 0 / `dart analyze` 対象7ファイル **No issues found** / `flutter test` **23/23 PASS**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
