### PR TITLE
feat(asset): 繰り返し入金 + ショート逆算 + うどん転記 + #3253 サーバ集約 (part 275)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -341,6 +341,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final AssetExpectedInflowStore _expectedInflowStore =
       const AssetExpectedInflowStore();
   List<AssetExpectedInflow> _expectedInflows = <AssetExpectedInflow>[];
+  List<AssetExpectedInflowRule> _expectedInflowRules =
+      <AssetExpectedInflowRule>[];
   String? _displayModeStatsLabel;
   DateTime _calendarMonth = DateTime.now();
   DateTime? _calendarSelectedDate;
@@ -7321,12 +7323,54 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Future<void> _loadExpectedInflows() async {
     final entries = await _expectedInflowStore.loadAll();
+    final rules = await _expectedInflowStore.loadRules();
     if (!mounted) {
       return;
     }
     setState(() {
       _expectedInflows = entries;
+      _expectedInflowRules = rules;
     });
+  }
+
+  Future<void> _removeExpectedInflowRule(String id) async {
+    final rules = await _expectedInflowStore.removeRule(id);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _expectedInflowRules = rules;
+    });
+  }
+
+  DateTime _nextSalaryDate() {
+    final now = DateTime.now();
+    final thisMonth = DateTime(now.year, now.month, _salarySpendingSalaryDay);
+    if (!now.isAfter(thisMonth)) {
+      return thisMonth;
+    }
+    return DateTime(now.year, now.month + 1, _salarySpendingSalaryDay);
+  }
+
+  Future<void> _sendDisplayModeEvent({
+    required String eventType,
+    required AssetManagementDisplayMode mode,
+    bool? hasData,
+  }) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('display_mode_events').insert(<String, dynamic>{
+        'user_id': userId,
+        'event_type': eventType,
+        'mode': mode.storageId,
+        'has_data': hasData,
+      });
+    } catch (e) {
+      debugPrint('display_mode_events insert failed: $e');
+    }
   }
 
   Future<void> _removeExpectedInflow(String id) async {
@@ -7358,10 +7402,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
-  Future<void> _showAddExpectedInflowDialog(DateTime initialDate) async {
+  Future<void> _showAddExpectedInflowDialog(
+    DateTime initialDate, {
+    double? initialAmount,
+    String? initialLabel,
+  }) async {
     var selectedDate = initialDate;
-    final amountController = TextEditingController();
-    final labelController = TextEditingController();
+    var repeatMonthly = false;
+    final amountController = TextEditingController(
+      text: initialAmount != null && initialAmount > 0
+          ? initialAmount.round().toString()
+          : '',
+    );
+    final labelController = TextEditingController(text: initialLabel ?? '');
 
     try {
       final confirmed = await showDialog<bool>(
@@ -7421,6 +7474,23 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     isDense: true,
                   ),
                 ),
+                const SizedBox(height: 4),
+                CheckboxListTile(
+                  key: const Key('asset_inflow_repeat_checkbox'),
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                  controlAffinity: ListTileControlAffinity.leading,
+                  value: repeatMonthly,
+                  onChanged: (value) {
+                    setDialogState(() {
+                      repeatMonthly = value ?? false;
+                    });
+                  },
+                  title: const Text(
+                    '毎月この日に繰り返す(給料など)',
+                    style: TextStyle(fontSize: 12),
+                  ),
+                ),
               ],
             ),
             actions: [
@@ -7451,6 +7521,23 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ).showSnackBar(const SnackBar(content: Text('金額を1円以上で入力してください')));
         return;
       }
+      if (repeatMonthly) {
+        final rules = await _expectedInflowStore.addRule(
+          dayOfMonth: selectedDate.day,
+          amount: amount,
+          label: labelController.text,
+        );
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _expectedInflowRules = rules;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('毎月${selectedDate.day}日の入金予定を登録しました')),
+        );
+        return;
+      }
       final entries = await _expectedInflowStore.add(
         date: selectedDate,
         amount: amount,
@@ -7479,15 +7566,26 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _displayMode = mode;
     });
     await _displayModeStore.save(mode);
+    unawaited(_sendDisplayModeEvent(eventType: 'switch', mode: mode));
     await _refreshDisplayModeStats();
   }
 
   Future<void> _resolveInitialDisplayMode({
     required bool hasExistingData,
   }) async {
+    final hadStored = await _displayModeStore.hasStoredMode();
     final mode = await _displayModeStore.resolveInitialMode(
       hasExistingData: hasExistingData,
     );
+    if (!hadStored) {
+      unawaited(
+        _sendDisplayModeEvent(
+          eventType: 'initial',
+          mode: mode,
+          hasData: hasExistingData,
+        ),
+      );
+    }
     if (!mounted) {
       return;
     }
@@ -7700,6 +7798,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       }
       startingCashBalance = liquid;
     }
+    final monthInflowEntries = AssetExpectedInflowStore.materializeMonth(
+      oneTime: _expectedInflows,
+      rules: _expectedInflowRules,
+      month: _calendarMonth,
+    );
     final calendar = AssetPaymentCalendarService.buildMonth(
       month: _calendarMonth,
       flows: _recentFlows,
@@ -7717,10 +7820,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       salaryDay: _salarySpendingSalaryDay,
       startingCashBalance: startingCashBalance,
       expectedInflows: [
-        for (final inflow in AssetExpectedInflowStore.monthInflows(
-          _expectedInflows,
-          _calendarMonth,
-        ))
+        for (final inflow in monthInflowEntries)
           AssetCalendarInflowInput(
             date: inflow.date,
             amount: inflow.amount,
@@ -7851,11 +7951,22 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         height: 1.6,
                       ),
                     ),
+                    const SizedBox(height: 6),
+                    Text(
+                      '回避ライン: ショート日までに ${_formatYen(calendar.shortfallRecoveryAmount)} の入金、または月内支払の同額圧縮で黒字化します。',
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w800,
+                        color: Color(0xFFB91C1C),
+                        height: 1.5,
+                      ),
+                    ),
                     const SizedBox(height: 8),
                     ElevatedButton.icon(
                       key: const Key('asset_calendar_add_inflow_button'),
                       onPressed: () => _showAddExpectedInflowDialog(
                         calendar.firstShortfallDate!,
+                        initialAmount: calendar.shortfallRecoveryAmount,
                       ),
                       icon: const Icon(Icons.savings, size: 16),
                       label: const Text('入金予定を追加して再計算'),
@@ -7911,26 +8022,30 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 _buildCalendarLegendItem(const Color(0xFF0EA5E9), '入金予定'),
               ],
             ),
-            if (AssetExpectedInflowStore.monthInflows(
-              _expectedInflows,
-              _calendarMonth,
-            ).isNotEmpty) ...[
+            if (monthInflowEntries.isNotEmpty) ...[
               const SizedBox(height: 8),
               Wrap(
                 spacing: 6,
                 runSpacing: 6,
                 children: [
-                  for (final inflow in AssetExpectedInflowStore.monthInflows(
-                    _expectedInflows,
-                    _calendarMonth,
-                  ))
+                  for (final inflow in monthInflowEntries)
                     InputChip(
                       key: Key('asset_inflow_chip_${inflow.id}'),
+                      avatar: inflow.sourceRuleId != null
+                          ? const Icon(Icons.repeat, size: 14)
+                          : null,
                       label: Text(
                         '${DateFormat('M/d').format(inflow.date)} ${inflow.label} ${_formatYen(inflow.amount)}',
                         style: const TextStyle(fontSize: 11),
                       ),
-                      onDeleted: () => _removeExpectedInflow(inflow.id),
+                      onDeleted: () {
+                        final ruleId = inflow.sourceRuleId;
+                        if (ruleId != null) {
+                          _removeExpectedInflowRule(ruleId);
+                        } else {
+                          _removeExpectedInflow(inflow.id);
+                        }
+                      },
                     ),
                 ],
               ),
@@ -11063,6 +11178,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   height: 1.5,
                 ),
               ),
+            if (isEnabled && savings.hasSavings) ...[
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                key: const Key('konbini_udon_transfer_inflow_button'),
+                onPressed: () => _showAddExpectedInflowDialog(
+                  _nextSalaryDate(),
+                  initialAmount: savings.monthlySavings,
+                  initialLabel: 'うどん縛り節約分(返済原資)',
+                ),
+                icon: const Icon(Icons.savings, size: 16),
+                label: const Text('節約見込みを入金予定へ転記'),
+              ),
+            ],
             const SizedBox(height: 12),
             _isCompact
                 ? Column(

--- a/lib/services/asset_expected_inflow_store.dart
+++ b/lib/services/asset_expected_inflow_store.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:my_web_app/services/asset_payment_calendar_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// 入金予定(給料・振込など)。カレンダーの見込み残高に加算され、
@@ -10,12 +11,16 @@ class AssetExpectedInflow {
     required this.date,
     required this.amount,
     required this.label,
+    this.sourceRuleId,
   });
 
   final String id;
   final DateTime date;
   final double amount;
   final String label;
+
+  /// 繰り返しルール由来の場合、その元ルールID(実体は保存しない)。
+  final String? sourceRuleId;
 
   factory AssetExpectedInflow.fromJson(Map<String, dynamic> json) {
     return AssetExpectedInflow(
@@ -37,11 +42,45 @@ class AssetExpectedInflow {
   }
 }
 
+/// 毎月の繰り返し入金ルール(給料・固定振込など)。
+class AssetExpectedInflowRule {
+  const AssetExpectedInflowRule({
+    required this.id,
+    required this.dayOfMonth,
+    required this.amount,
+    required this.label,
+  });
+
+  final String id;
+  final int dayOfMonth;
+  final double amount;
+  final String label;
+
+  factory AssetExpectedInflowRule.fromJson(Map<String, dynamic> json) {
+    return AssetExpectedInflowRule(
+      id: json['id']?.toString() ?? '',
+      dayOfMonth: (json['day_of_month'] as num?)?.toInt() ?? 0,
+      amount: (json['amount'] as num?)?.toDouble() ?? 0,
+      label: json['label']?.toString() ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'day_of_month': dayOfMonth,
+      'amount': amount,
+      'label': label,
+    };
+  }
+}
+
 /// 入金予定の永続化ストア。
 class AssetExpectedInflowStore {
   const AssetExpectedInflowStore({this.nowProvider});
 
   static const String _key = 'asset_expected_inflows_v1';
+  static const String _rulesKey = 'asset_expected_inflow_rules_v1';
 
   final DateTime Function()? nowProvider;
 
@@ -57,6 +96,116 @@ class AssetExpectedInflowStore {
               entry.date.year == month.year && entry.date.month == month.month,
         )
         .toList(growable: false);
+  }
+
+  /// 単発の入金予定と繰り返しルールを、指定月の実体リストへ展開する。
+  /// 31日ルールは短い月では月末へ丸める。
+  static List<AssetExpectedInflow> materializeMonth({
+    required List<AssetExpectedInflow> oneTime,
+    required List<AssetExpectedInflowRule> rules,
+    required DateTime month,
+  }) {
+    final monthKey = '${month.year}${month.month.toString().padLeft(2, '0')}';
+    final entries = <AssetExpectedInflow>[
+      ...monthInflows(oneTime, month),
+      for (final rule in rules)
+        if (rule.dayOfMonth > 0 && rule.amount > 0)
+          AssetExpectedInflow(
+            id: 'rule_${rule.id}_$monthKey',
+            date: DateTime(
+              month.year,
+              month.month,
+              AssetPaymentCalendarService.clampDayToMonth(
+                rule.dayOfMonth,
+                month,
+              ),
+            ),
+            amount: rule.amount,
+            label: rule.label,
+            sourceRuleId: rule.id,
+          ),
+    ];
+    entries.sort((a, b) => a.date.compareTo(b.date));
+    return entries;
+  }
+
+  Future<List<AssetExpectedInflowRule>> loadRules({
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return _decodeRules(store.getString(_rulesKey));
+  }
+
+  Future<List<AssetExpectedInflowRule>> addRule({
+    required int dayOfMonth,
+    required double amount,
+    required String label,
+    SharedPreferences? prefs,
+  }) async {
+    if (dayOfMonth < 1 || dayOfMonth > 31) {
+      throw ArgumentError('dayOfMonth must be 1-31');
+    }
+    if (amount <= 0) {
+      throw ArgumentError('amount must be positive');
+    }
+    final trimmedLabel = label.trim();
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final rules = _decodeRules(store.getString(_rulesKey));
+    rules.add(
+      AssetExpectedInflowRule(
+        id: 'inflow_rule_${_now().microsecondsSinceEpoch}_${rules.length}',
+        dayOfMonth: dayOfMonth,
+        amount: amount,
+        label: trimmedLabel.isEmpty ? '毎月の入金' : trimmedLabel,
+      ),
+    );
+    rules.sort((a, b) => a.dayOfMonth.compareTo(b.dayOfMonth));
+    await _saveRules(store, rules);
+    return rules;
+  }
+
+  Future<List<AssetExpectedInflowRule>> removeRule(
+    String id, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final rules = _decodeRules(store.getString(_rulesKey))
+      ..removeWhere((rule) => rule.id == id);
+    await _saveRules(store, rules);
+    return rules;
+  }
+
+  Future<void> _saveRules(
+    SharedPreferences store,
+    List<AssetExpectedInflowRule> rules,
+  ) async {
+    await store.setString(
+      _rulesKey,
+      jsonEncode(rules.map((rule) => rule.toJson()).toList()),
+    );
+  }
+
+  List<AssetExpectedInflowRule> _decodeRules(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return <AssetExpectedInflowRule>[];
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) {
+        return <AssetExpectedInflowRule>[];
+      }
+      return decoded
+          .whereType<Map>()
+          .map(
+            (entry) => AssetExpectedInflowRule.fromJson(
+              Map<String, dynamic>.from(entry),
+            ),
+          )
+          .where((rule) => rule.id.isNotEmpty)
+          .toList();
+    } catch (_) {
+      return <AssetExpectedInflowRule>[];
+    }
   }
 
   Future<List<AssetExpectedInflow>> loadAll({SharedPreferences? prefs}) async {

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -217,6 +217,12 @@ class AssetManagementDisplayModeStore {
     return _storedMode(store) ?? defaultMode;
   }
 
+  /// 保存済みモードが存在するか(初期解決イベント送信の判定用)。
+  Future<bool> hasStoredMode({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return _storedMode(store) != null;
+  }
+
   Future<void> save(
     AssetManagementDisplayMode mode, {
     SharedPreferences? prefs,

--- a/lib/services/asset_payment_calendar_service.dart
+++ b/lib/services/asset_payment_calendar_service.dart
@@ -103,6 +103,7 @@ class AssetPaymentCalendarMonth {
     this.scheduledDebtPaymentTotal = 0,
     this.subscriptionTotal = 0,
     this.firstShortfallDate,
+    this.worstProjectedBalance,
   });
 
   final DateTime month;
@@ -117,6 +118,15 @@ class AssetPaymentCalendarMonth {
 
   /// 見込み残高が最初にマイナスへ落ちる日。資金リスクの早期警告。
   final DateTime? firstShortfallDate;
+
+  /// 月内の見込み残高の最小値(起点未指定なら null)。
+  final double? worstProjectedBalance;
+
+  /// ショート回避に必要な追加入金額(=最大不足幅)。ショートなしなら 0。
+  double get shortfallRecoveryAmount =>
+      worstProjectedBalance != null && worstProjectedBalance! < 0
+          ? -worstProjectedBalance!
+          : 0;
 
   double get scheduledOutflowTotal =>
       scheduledDebtPaymentTotal + subscriptionTotal;
@@ -291,6 +301,7 @@ class AssetPaymentCalendarService {
 
     var runningBalance = startingCashBalance;
     DateTime? firstShortfallDate;
+    double? worstProjectedBalance;
     final days = <AssetCalendarDaySummary>[];
     for (var day = 1; day <= lastDay; day++) {
       final outflow = outflowByDay[day] ?? 0;
@@ -303,6 +314,11 @@ class AssetPaymentCalendarService {
           runningBalance != null &&
           runningBalance < 0) {
         firstShortfallDate = date;
+      }
+      if (runningBalance != null &&
+          (worstProjectedBalance == null ||
+              runningBalance < worstProjectedBalance)) {
+        worstProjectedBalance = runningBalance;
       }
       days.add(
         AssetCalendarDaySummary(
@@ -323,6 +339,7 @@ class AssetPaymentCalendarService {
       scheduledDebtPaymentTotal: scheduledDebtPaymentTotal,
       subscriptionTotal: subscriptionTotal,
       firstShortfallDate: firstShortfallDate,
+      worstProjectedBalance: worstProjectedBalance,
     );
   }
 

--- a/supabase/migrations/20260612153000_create_display_mode_events.sql
+++ b/supabase/migrations/20260612153000_create_display_mode_events.sql
@@ -1,0 +1,54 @@
+-- 表示モード実験 (新規ユーザー=標準既定) のサーバ側集約 (Issue #3253)
+-- クライアント (asset_management_page) が初期解決とモード切替を非同期送信する。
+-- 送信失敗時はローカル (SharedPreferences) のみで継続する v1 設計。
+
+create table if not exists public.display_mode_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  event_type text not null check (event_type in ('initial', 'switch')),
+  mode text not null check (mode in ('minimum', 'standard', 'full')),
+  has_data boolean,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists display_mode_events_user_created_idx
+  on public.display_mode_events (user_id, created_at desc);
+
+alter table public.display_mode_events enable row level security;
+
+drop policy if exists "display_mode_events_insert_own"
+  on public.display_mode_events;
+create policy "display_mode_events_insert_own"
+  on public.display_mode_events
+  for insert to authenticated
+  with check (auth.uid() = user_id);
+
+drop policy if exists "display_mode_events_select_own"
+  on public.display_mode_events;
+create policy "display_mode_events_select_own"
+  on public.display_mode_events
+  for select to authenticated
+  using (auth.uid() = user_id);
+
+-- 集計クエリ例 (#3253 受入基準3 / service_role で実行する想定):
+--
+-- 1) 新規ユーザーの標準維持率 (初期=standard のうち、その後 switch していない割合)
+--   select
+--     count(*) filter (where not exists (
+--       select 1 from display_mode_events s
+--       where s.user_id = i.user_id and s.event_type = 'switch'
+--         and s.created_at > i.created_at
+--     ))::numeric / greatest(count(*), 1) as standard_retention_rate
+--   from display_mode_events i
+--   where i.event_type = 'initial' and i.mode = 'standard';
+--
+-- 2) 初期モード別の最終到達モード分布 (フル昇格率 / ミニマム降格率)
+--   select i.mode as initial_mode, last.mode as final_mode, count(*)
+--   from display_mode_events i
+--   join lateral (
+--     select mode from display_mode_events e
+--     where e.user_id = i.user_id
+--     order by e.created_at desc limit 1
+--   ) last on true
+--   where i.event_type = 'initial'
+--   group by 1, 2 order by 1, 3 desc;

--- a/test/services/asset_expected_inflow_store_test.dart
+++ b/test/services/asset_expected_inflow_store_test.dart
@@ -85,5 +85,63 @@ void main() {
         throwsArgumentError,
       );
     });
+
+    test('adds and removes monthly recurring rules', () async {
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+
+      final rules = await store.addRule(
+        dayOfMonth: 25,
+        amount: 280000,
+        label: '給料',
+      );
+      expect(rules.single.dayOfMonth, 25);
+      expect(await store.loadRules(), hasLength(1));
+
+      final cleared = await store.removeRule(rules.single.id);
+      expect(cleared, isEmpty);
+
+      await expectLater(
+        store.addRule(dayOfMonth: 0, amount: 100, label: 'x'),
+        throwsArgumentError,
+      );
+    });
+
+    test('materializes rules into a month with end-of-month clamping', () {
+      const rule = AssetExpectedInflowRule(
+        id: 'r1',
+        dayOfMonth: 31,
+        amount: 280000,
+        label: '給料',
+      );
+      final oneTime = <AssetExpectedInflow>[
+        AssetExpectedInflow(
+          id: 'a',
+          date: DateTime(2026, 2, 10),
+          amount: 5000,
+          label: '単発',
+        ),
+        AssetExpectedInflow(
+          id: 'b',
+          date: DateTime(2026, 3, 1),
+          amount: 9999,
+          label: '対象外',
+        ),
+      ];
+
+      final entries = AssetExpectedInflowStore.materializeMonth(
+        oneTime: oneTime,
+        rules: const <AssetExpectedInflowRule>[rule],
+        month: DateTime(2026, 2),
+      );
+
+      expect(entries, hasLength(2));
+      expect(entries.first.id, 'a');
+      expect(entries.first.sourceRuleId, isNull);
+      expect(entries.last.date, DateTime(2026, 2, 28));
+      expect(entries.last.sourceRuleId, 'r1');
+      expect(entries.last.id, 'rule_r1_202602');
+    });
   });
 }

--- a/test/services/asset_management_display_mode_store_test.dart
+++ b/test/services/asset_management_display_mode_store_test.dart
@@ -204,5 +204,13 @@ void main() {
       expect(stats.switchCount, 2);
       expect(stats.lastChangedAt, isNotNull);
     });
+
+    test('hasStoredMode distinguishes saved from default', () async {
+      const store = AssetManagementDisplayModeStore();
+
+      expect(await store.hasStoredMode(), isFalse);
+      await store.save(AssetManagementDisplayMode.full);
+      expect(await store.hasStoredMode(), isTrue);
+    });
   });
 }

--- a/test/services/asset_payment_calendar_service_test.dart
+++ b/test/services/asset_payment_calendar_service_test.dart
@@ -278,5 +278,45 @@ void main() {
       expect(calendar.firstShortfallDate, isNull);
       expect(calendar.dayFor(DateTime(2026, 6, 25))!.projectedBalance, 0);
     });
+
+    test('reports the worst dip as the shortfall recovery amount', () {
+      final calendar = AssetPaymentCalendarService.buildMonth(
+        month: DateTime(2026, 6),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[
+          AssetCalendarDebtInput(
+            name: 'ローンA',
+            balance: -100000,
+            paymentDay: 5,
+            scheduledPaymentAmount: 8000,
+          ),
+          AssetCalendarDebtInput(
+            name: 'ローンB',
+            balance: -100000,
+            paymentDay: 10,
+            scheduledPaymentAmount: 7000,
+          ),
+        ],
+        startingCashBalance: 10000,
+      );
+
+      expect(calendar.worstProjectedBalance, -5000);
+      expect(calendar.shortfallRecoveryAmount, 5000);
+      expect(calendar.firstShortfallDate, DateTime(2026, 6, 10));
+    });
+
+    test('recovery amount is zero when the month stays positive', () {
+      final calendar = AssetPaymentCalendarService.buildMonth(
+        month: DateTime(2026, 6),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[],
+        startingCashBalance: 1000,
+      );
+
+      expect(calendar.worstProjectedBalance, 1000);
+      expect(calendar.shortfallRecoveryAmount, 0);
+    });
   });
 }


### PR DESCRIPTION
## 概要

カレンダー資金繰りの完成度を上げる4機能(part 274 の続き)。

1. **#3253 サーバ集約** — `display_mode_events` テーブル migration(RLS: 本人 insert/select のみ + user/created 複合 index + service_role 用の集計クエリ例2本をコメント同梱)。ページが初期解決(`initial` + has_data)とモード切替(`switch`)を**非同期送信、失敗時はローカルのみで継続**(リトライなし v1)。初期解決イベントは `hasStoredMode()` 判定で**本当に初回の1件だけ**送信。
2. **入金予定の繰り返し設定** — ダイアログに「毎月この日に繰り返す」チェックボックス。ルールは月展開時に短い月へ月末丸め(31日→2月28日)。チップに 🔁 マーク、ルール由来チップの削除はルール自体を削除(全月へ反映)。
3. **ショート逆算サジェスト** — 月内見込み残高の最小値(worstProjectedBalance)から「**回避ライン: ショート日までに ¥X の入金、または同額の支払圧縮で黒字化**」を警告バナーに表示。「入金予定を追加して再計算」ボタンは**¥X を金額プリフィル**して開く。
4. **うどん縛り×資金繰り連携** — うどん縛りパネルに「節約見込みを入金予定へ転記」。次回給料日(25日)・節約月額・ラベル「うどん縛り節約分(返済原資)」をプリフィルした**確認ダイアログ経由**で登録(食費は残高プロジェクションの対象外のため、転記の妥当性判断をユーザーに委ねるサイレント追加なし設計)。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) 繰り返しルールの月展開と月末丸め・sourceRuleId 付与 (2) 最悪残高→回避ライン金額の算出(複数支払の累積不足) (3) hasStoredMode による初回判定。既存分含め計 28 ケース。
- E2E例外: クライアント変更は表示層とローカル保存のみ、サーバ変更は新規テーブル migration のみ(既存スキーマ・Edge Function 変更なし)のため、エンドツーエンド(integration_test)追加は行わず service 単体テスト+RLS ポリシー定義で入出力契約を担保する。
- 検証実績(ローカル worktree): `dart format` / `dart analyze` 対象7ファイル **No issues found** / `flutter test` **28/28 PASS**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3253

## High-risk gate

- High-risk-ultrareview-exception: 追加のみの新規テーブル (display_mode_events) で、既存スキーマ・認証・課金・Edge Function に変更なし。RLS は本人 insert/select 限定(update/delete ポリシーなし)。レビュー所有者: Claude Code #1。
- 自己点検メモ: security = RLS 本人限定 + 集計は service_role 想定 / rollback = `drop table` で完全可逆(他オブジェクト依存なし) / data migration = 既存データ移行なし / prod smoke = 本PRの DB + Edge smoke green / observability = クライアント送信失敗は debugPrint + ローカル継続でユーザー影響なし。
