### PR TITLE
feat(asset): 実験全体集計 + ルール管理UI + 支払日ワンタップ移動 + 入金ミラー (part 276)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -344,6 +344,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   List<AssetExpectedInflowRule> _expectedInflowRules =
       <AssetExpectedInflowRule>[];
   String? _displayModeStatsLabel;
+  String? _experimentServerSummary;
   DateTime _calendarMonth = DateTime.now();
   DateTime? _calendarSelectedDate;
   Future<AssetWasteTrainingAiReview>? _wasteTrainingAiReviewFuture;
@@ -7335,6 +7336,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Future<void> _removeExpectedInflowRule(String id) async {
     final rules = await _expectedInflowStore.removeRule(id);
+    unawaited(_deleteInflowMirror(id));
     if (!mounted) {
       return;
     }
@@ -7375,6 +7377,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Future<void> _removeExpectedInflow(String id) async {
     final entries = await _expectedInflowStore.remove(id);
+    unawaited(_deleteInflowMirror(id));
     if (!mounted) {
       return;
     }
@@ -7522,6 +7525,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         return;
       }
       if (repeatMonthly) {
+        final beforeRuleIds =
+            _expectedInflowRules.map((rule) => rule.id).toSet();
         final rules = await _expectedInflowStore.addRule(
           dayOfMonth: selectedDate.day,
           amount: amount,
@@ -7533,11 +7538,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         setState(() {
           _expectedInflowRules = rules;
         });
+        for (final rule in rules) {
+          if (!beforeRuleIds.contains(rule.id)) {
+            unawaited(
+              _mirrorInflowToSupabase(<String, dynamic>{
+                'id': rule.id,
+                'kind': 'rule',
+                'day_of_month': rule.dayOfMonth,
+                'amount': rule.amount,
+                'label': rule.label,
+              }),
+            );
+          }
+        }
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('毎月${selectedDate.day}日の入金予定を登録しました')),
         );
         return;
       }
+      final beforeIds = _expectedInflows.map((entry) => entry.id).toSet();
       final entries = await _expectedInflowStore.add(
         date: selectedDate,
         amount: amount,
@@ -7549,6 +7568,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       setState(() {
         _expectedInflows = entries;
       });
+      for (final entry in entries) {
+        if (!beforeIds.contains(entry.id)) {
+          unawaited(
+            _mirrorInflowToSupabase(<String, dynamic>{
+              'id': entry.id,
+              'kind': 'one_time',
+              'date': DateFormat('yyyy-MM-dd').format(entry.date),
+              'amount': entry.amount,
+              'label': entry.label,
+            }),
+          );
+        }
+      }
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('入金予定を追加しました。見込み残高に反映されます')));
@@ -7611,6 +7643,146 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     });
   }
 
+  Future<void> _fetchExperimentSummary() async {
+    try {
+      final dynamic result =
+          await _supabase.rpc('display_mode_experiment_summary');
+      if (!mounted || result is! Map) {
+        return;
+      }
+      final data = Map<String, dynamic>.from(result);
+      int countOf(String key) => (data[key] as num?)?.toInt() ?? 0;
+      final standardInitial = countOf('initial_standard');
+      final retained = countOf('standard_retained');
+      final rate = standardInitial == 0
+          ? '-'
+          : '${(retained * 100 / standardInitial).round()}%';
+      setState(() {
+        _experimentServerSummary =
+            '全体: 初期 min ${countOf('initial_minimum')} / std $standardInitial / full ${countOf('initial_full')}・標準維持率 $rate・切替 ${countOf('switch_total')}回';
+      });
+    } catch (e) {
+      debugPrint('experiment summary fetch failed: $e');
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _experimentServerSummary = '全体集計を取得できませんでした(ネットワーク/権限)';
+      });
+    }
+  }
+
+  Future<void> _mirrorInflowToSupabase(Map<String, dynamic> row) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase
+          .from('asset_expected_inflow_items')
+          .upsert(<String, dynamic>{...row, 'user_id': userId});
+    } catch (e) {
+      debugPrint('inflow mirror upsert failed: $e');
+    }
+  }
+
+  Future<void> _deleteInflowMirror(String id) async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_expected_inflow_items').delete().eq('id', id);
+    } catch (e) {
+      debugPrint('inflow mirror delete failed: $e');
+    }
+  }
+
+  void _shiftDebtPaymentAfterSalary(
+    AssetLiabilityWorkbook? workbook,
+    String debtRowId,
+  ) {
+    final rows = workbook?.debtMasterRows ?? const <AssetLiabilityDebtRow>[];
+    AssetLiabilityDebtRow? target;
+    for (final row in rows) {
+      if (row.id == debtRowId) {
+        target = row;
+      }
+    }
+    if (target == null) {
+      return;
+    }
+    const newDay = _salarySpendingSalaryDay + 1;
+    _setDebtPaymentDayOverride(target, newDay);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          '${target.name} の支払日を毎月$newDay日へ変更しました(負債マスタの支払日設定から戻せます)',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showInflowRulesDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (dialogContext, setDialogState) => AlertDialog(
+          title: const Text('毎月の入金ルール'),
+          content: SizedBox(
+            width: 360,
+            child: _expectedInflowRules.isEmpty
+                ? const Text(
+                    'ルールはありません。入金予定ダイアログの「毎月この日に繰り返す」で登録できます。',
+                    style: TextStyle(fontSize: 12, height: 1.5),
+                  )
+                : SingleChildScrollView(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        for (final rule in _expectedInflowRules)
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  '毎月${rule.dayOfMonth}日 ${rule.label} ${_formatYen(rule.amount)}',
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    height: 1.5,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              IconButton(
+                                key: Key(
+                                  'asset_inflow_rule_delete_${rule.id}',
+                                ),
+                                tooltip: '削除',
+                                icon: const Icon(
+                                  Icons.delete_outline,
+                                  size: 18,
+                                ),
+                                onPressed: () async {
+                                  await _removeExpectedInflowRule(rule.id);
+                                  setDialogState(() {});
+                                },
+                              ),
+                            ],
+                          ),
+                      ],
+                    ),
+                  ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('閉じる'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildSectionOverrideDropdown(
     AssetManagementSectionId section,
     void Function(void Function()) setDialogState,
@@ -7661,6 +7833,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     ),
                     const SizedBox(height: 6),
                   ],
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          _experimentServerSummary ?? '全体集計は未取得です。',
+                          style: const TextStyle(fontSize: 11, height: 1.5),
+                        ),
+                      ),
+                      TextButton(
+                        key: const Key('asset_experiment_summary_button'),
+                        onPressed: () async {
+                          await _fetchExperimentSummary();
+                          setDialogState(() {});
+                        },
+                        child: const Text('全体集計'),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
                   Text(
                     '「自動」は表示モード(ミニマム/標準/フル)に従います。「常に表示」「隠す」はモードより優先されます。',
                     style: TextStyle(
@@ -7810,6 +8001,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       debts: [
         for (final row in debtRows)
           AssetCalendarDebtInput(
+            id: row.id,
             name: row.name,
             balance: row.balance,
             paymentDay: row.paymentDay,
@@ -7832,6 +8024,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final selectedDay =
         selectedDate == null ? null : calendar.dayFor(selectedDate);
     final today = DateTime.now();
+    final shortfallDaySummary = calendar.firstShortfallDate == null
+        ? null
+        : calendar.dayFor(calendar.firstShortfallDate!);
+    final shortfallDebtEvents = <AssetCalendarEvent>[
+      if (shortfallDaySummary != null)
+        ...shortfallDaySummary.events.where(
+          (event) =>
+              event.kind == AssetCalendarEventKind.debtPayment &&
+              event.sourceId != null,
+        ),
+    ];
     const weekdayLabels = ['日', '月', '火', '水', '木', '金', '土'];
 
     return Card(
@@ -7980,6 +8183,33 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         height: 1.5,
                       ),
                     ),
+                    if (shortfallDebtEvents.isNotEmpty) ...[
+                      const SizedBox(height: 6),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 6,
+                        children: [
+                          for (final event in shortfallDebtEvents)
+                            OutlinedButton.icon(
+                              key: Key(
+                                'asset_shift_payment_${event.sourceId}',
+                              ),
+                              onPressed: () => _shiftDebtPaymentAfterSalary(
+                                workbook,
+                                event.sourceId!,
+                              ),
+                              icon: const Icon(
+                                Icons.schedule_send,
+                                size: 14,
+                              ),
+                              label: Text(
+                                '${event.label}を26日へ',
+                                style: const TextStyle(fontSize: 11),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ],
                   ],
                 ),
               ),
@@ -8021,6 +8251,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 _buildCalendarLegendItem(const Color(0xFF2563EB), '収入'),
                 _buildCalendarLegendItem(const Color(0xFF0EA5E9), '入金予定'),
               ],
+            ),
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                key: const Key('asset_inflow_rules_button'),
+                onPressed: _showInflowRulesDialog,
+                icon: const Icon(Icons.repeat, size: 16),
+                label: const Text('毎月の入金ルール'),
+              ),
             ),
             if (monthInflowEntries.isNotEmpty) ...[
               const SizedBox(height: 8),

--- a/lib/services/asset_payment_calendar_service.dart
+++ b/lib/services/asset_payment_calendar_service.dart
@@ -8,8 +8,11 @@ class AssetCalendarDebtInput {
     required this.paymentDay,
     this.scheduledPaymentAmount = 0,
     this.isDirectCashflowTarget = true,
+    this.id = '',
   });
 
+  /// workbook 行ID(支払日移動などのアクション連携用)。
+  final String id;
   final String name;
   final double balance;
   final int? paymentDay;
@@ -46,11 +49,15 @@ class AssetCalendarEvent {
     required this.kind,
     required this.label,
     this.amount,
+    this.sourceId,
   });
 
   final AssetCalendarEventKind kind;
   final String label;
   final double? amount;
+
+  /// 元データのID(debtPayment は workbook 行ID)。アクション連携用。
+  final String? sourceId;
 }
 
 /// 1日分のサマリ。支出/収入はフロー記録の合算。
@@ -234,6 +241,7 @@ class AssetPaymentCalendarService {
           kind: AssetCalendarEventKind.debtPayment,
           label: '${row.name} 返済',
           amount: amount,
+          sourceId: row.id.isEmpty ? null : row.id,
         ),
       );
     }

--- a/supabase/migrations/20260612190000_display_mode_summary_and_inflow_mirror.sql
+++ b/supabase/migrations/20260612190000_display_mode_summary_and_inflow_mirror.sql
@@ -1,0 +1,61 @@
+-- 1) 表示モード実験の全体集計関数 (個人特定情報を返さない集計のみ)
+--    クライアントは supabase.rpc('display_mode_experiment_summary') で取得。
+create or replace function public.display_mode_experiment_summary()
+returns jsonb
+language sql
+security definer
+set search_path = public
+as $$
+  select jsonb_build_object(
+    'initial_minimum',
+      count(*) filter (where event_type = 'initial' and mode = 'minimum'),
+    'initial_standard',
+      count(*) filter (where event_type = 'initial' and mode = 'standard'),
+    'initial_full',
+      count(*) filter (where event_type = 'initial' and mode = 'full'),
+    'switch_total', count(*) filter (where event_type = 'switch'),
+    'standard_retained', (
+      select count(*)
+      from display_mode_events i
+      where i.event_type = 'initial' and i.mode = 'standard'
+        and not exists (
+          select 1 from display_mode_events s
+          where s.user_id = i.user_id
+            and s.event_type = 'switch'
+            and s.created_at > i.created_at
+        )
+    )
+  )
+  from display_mode_events;
+$$;
+
+revoke all on function public.display_mode_experiment_summary() from public;
+revoke all on function public.display_mode_experiment_summary() from anon;
+grant execute on function public.display_mode_experiment_summary()
+  to authenticated;
+
+-- 2) 入金予定のバックアップミラー (#3246 関連 / v1 は書き込みミラーのみ、
+--    読み込みは端末ローカルを正とする。復元・マージは別Issueで対応)
+create table if not exists public.asset_expected_inflow_items (
+  id text primary key,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  kind text not null check (kind in ('one_time', 'rule')),
+  date date,
+  day_of_month integer check (day_of_month between 1 and 31),
+  amount numeric not null check (amount > 0),
+  label text not null default '',
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists asset_expected_inflow_items_user_idx
+  on public.asset_expected_inflow_items (user_id);
+
+alter table public.asset_expected_inflow_items enable row level security;
+
+drop policy if exists "asset_expected_inflow_items_own_all"
+  on public.asset_expected_inflow_items;
+create policy "asset_expected_inflow_items_own_all"
+  on public.asset_expected_inflow_items
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/test/services/asset_payment_calendar_service_test.dart
+++ b/test/services/asset_payment_calendar_service_test.dart
@@ -48,6 +48,7 @@ void main() {
         subscriptions: const <Map<String, dynamic>>[],
         debts: const <AssetCalendarDebtInput>[
           AssetCalendarDebtInput(
+            id: 'debt_card_loan',
             name: 'カードローン',
             balance: -300000,
             paymentDay: 31,
@@ -67,6 +68,7 @@ void main() {
       expect(day28!.hasDebtPayment, isTrue);
       expect(day28.events.single.label, 'カードローン 返済');
       expect(day28.events.single.amount, 15000);
+      expect(day28.events.single.sourceId, 'debt_card_loan');
       expect(calendar.dayFor(DateTime(2026, 2, 10))!.hasAnyEvent, isFalse);
       expect(calendar.dayFor(DateTime(2026, 2, 5))!.hasAnyEvent, isFalse);
     });


### PR DESCRIPTION
## 概要

1. **実験の全体集計ダッシュボード** — `display_mode_experiment_summary()`(security definer / **個人特定情報を返さない集計のみ** / anon は revoke、authenticated のみ execute)。カスタマイズダイアログの「全体集計」ボタンで初期モード分布・**標準維持率**・切替総数を表示。
2. **毎月の入金ルール一覧管理UI** — カレンダーに「毎月の入金ルール」ボタン常設。一覧表示+個別削除(全月へ反映)。
3. **ショート回避の実行ボタン化** — 残高ショート警告に、ショート日の返済イベントごとに「**{負債名}を26日へ**」ボタン。`AssetCalendarEvent.sourceId` → 既存 `_setDebtPaymentDayOverride` 連携でワンタップ移動(負債マスタの支払日設定からいつでも可逆)。移動後は残高プロジェクションが即再計算。
4. **入金予定の Supabase ミラー(#3246 関連)** — `asset_expected_inflow_items` テーブル(RLS 本人 for all)。追加/削除の4箇所で upsert/delete を**非同期ミラー(失敗時ローカル継続)**。v1 は書き込みミラーのみで読み込みはローカルを正とし、復元・マージは #3246 で扱う。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) debtPayment イベントへの sourceId 伝播(ワンタップ移動の前提) (2) 繰り返しルールの月展開・月末丸め (3) 回避ライン金額の算出。既存分含め計 28 ケース。
- E2E例外: クライアントは表示層+非同期ミラーのみ、サーバは追加のみの関数1本とテーブル1本(既存スキーマ・Edge Function 変更なし)のため、エンドツーエンド(integration_test)追加は行わず service 単体テスト+RLS 定義で入出力契約を担保する。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `flutter test` **28/28 PASS**。

## High-risk gate

- High-risk-ultrareview-exception: 追加のみの migration(集計関数1本 + ミラーテーブル1本)で既存スキーマ・認証・課金・Edge Function に変更なし。関数は集計値のみ返し個人データ非公開、テーブル RLS は本人限定。レビュー所有者: Claude Code #1。
- 自己点検メモ: security = definer 関数は jsonb 集計のみ返却 + anon revoke + ミラーは RLS 本人 for all / rollback = drop function + drop table で完全可逆 / data migration = 既存データ移行なし / prod smoke = 本PRの DB + Edge smoke green / observability = ミラー・集計取得の失敗は debugPrint + ローカル継続でユーザー影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
