### PR TITLE
feat(asset): AIアシスタントから職業・年収のプロフィール入力へジャンプ

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -20,6 +20,7 @@ import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/models/debt_repayment_plan.dart';
 import 'package:my_web_app/models/kgi_csf_kpi.dart';
 import 'package:my_web_app/models/user_profile.dart';
+import 'package:my_web_app/pages/profile_settings_page.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
 import 'package:my_web_app/services/asset_liability_annual_rate_evidence_service.dart';
 import 'package:my_web_app/services/asset_liability_card_statement_import_service.dart';
@@ -500,6 +501,24 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _isLoadingAssetManagementUserProfile = false;
       });
     }
+  }
+
+  bool _assetManagementProfileBasicsMissing(UserProfile? profile) {
+    if (profile == null) {
+      return true;
+    }
+    final occupation = profile.occupation?.trim() ?? '';
+    return occupation.isEmpty || profile.annualIncome == null;
+  }
+
+  Future<void> _openProfileSettingsForAssetManagement() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (_) => const ProfileSettingsPage()),
+    );
+    if (!mounted) {
+      return;
+    }
+    await _loadAssetManagementUserProfile();
   }
 
   List<String> _paymentSourceCandidates() {
@@ -12552,6 +12571,22 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
           const SizedBox(height: 10),
           _buildAssetManagementAiSummaryPanel(report),
+          if (_assetManagementProfileBasicsMissing(report.userProfile)) ...[
+            const SizedBox(height: 6),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                ),
+                onPressed: () =>
+                    unawaited(_openProfileSettingsForAssetManagement()),
+                icon: const Icon(Icons.badge_outlined, size: 16),
+                label: const Text('職業・年収をプロフィールに入力する'),
+              ),
+            ),
+          ],
           const SizedBox(height: 10),
           Wrap(
             spacing: 8,


### PR DESCRIPTION
## 概要

AI資産管理アシスタントが「年収や職業がないのは危険信号」等のコメントを出した際に、そこから職業・年収の入力箇所へ飛べるリンクが欲しいというユーザー要望への対応（part 271 シリーズ第4弾）。

AIコメントは LLM 生成の自由文のため文中に直接リンクは埋め込めません。代わりに、コメントが表示される AIサマリーパネルの直下へ、**職業または年収が未入力のときだけ**「職業・年収をプロフィールに入力する」リンクを決定的に表示します。

### 変更内容（UIのみ・+35行）

- `_assetManagementProfileBasicsMissing`: プロフィール未連携 / 職業が空 / 年収が null のいずれかで true
- AIサマリーパネル直下に条件付き `TextButton.icon`（badge アイコン）を追加
- タップで `ProfileSettingsPage`（職業・年収の入力欄がある既存ページ）へ `MaterialPageRoute` 遷移
- 戻った際に `_loadAssetManagementUserProfile()` を再実行 — 既存実装によりAIサマリーのキャッシュも無効化されるため、入力後は新しいプロフィールでコメントが再生成される
- 入力済みになればリンクは自動的に消える

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. 職業・年収が未入力 → AIコメント下に「職業・年収をプロフィールに入力する」リンクが表示される
  2. リンクをタップ → プロフィール設定ページ（職業・年収欄）が開き、保存して戻るとリンクが消える
  3. 職業・年収が入力済み → リンクは表示されない
- 本変更はサービスロジックを変更しない UI のみの追加（既存の `UserProfile.occupation` / `annualIncome` と既存ページ遷移パターンを利用）
- E2E-Exception: 資産管理ページは認証済みユーザーの資産データ前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。条件分岐は null/空文字判定のみの薄いUI層であり、本番反映後に上記3ケースを手動確認する。

## 検証

- `flutter analyze`: No issues found
- `dart format --set-exit-if-changed`: 0 changed
- 並行マージ（#3254 ほか）反映後の最新 main (`d51ea9350`) 基準で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)
