### PR TITLE
feat(asset): ミラー復元 + 週次トレンド + 移動効果プレビュー (part 277)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -7351,6 +7351,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _expectedInflows = entries;
       _expectedInflowRules = rules;
     });
+    if (entries.isEmpty && rules.isEmpty) {
+      unawaited(_restoreInflowsFromMirror());
+    }
   }
 
   Future<void> _removeExpectedInflowRule(String id) async {
@@ -7676,9 +7679,29 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final rate = standardInitial == 0
           ? '-'
           : '${(retained * 100 / standardInitial).round()}%';
+      final weekly = data['weekly'];
+      var trendLabel = '';
+      if (weekly is List && weekly.isNotEmpty) {
+        final parts = <String>[];
+        for (final raw in weekly.take(4)) {
+          if (raw is! Map) {
+            continue;
+          }
+          final week = Map<String, dynamic>.from(raw);
+          final start = week['week_start']?.toString() ?? '';
+          final label = start.length >= 10 ? start.substring(5, 10) : start;
+          final initials = (week['initials'] as num?)?.toInt() ?? 0;
+          final std = (week['initial_standard'] as num?)?.toInt() ?? 0;
+          final switches = (week['switches'] as num?)?.toInt() ?? 0;
+          parts.add('$label: 初期$initials(std$std)/切替$switches');
+        }
+        if (parts.isNotEmpty) {
+          trendLabel = ' | 週次 ${parts.join(' → ')}';
+        }
+      }
       setState(() {
         _experimentServerSummary =
-            '全体: 初期 min ${countOf('initial_minimum')} / std $standardInitial / full ${countOf('initial_full')}・標準維持率 $rate・切替 ${countOf('switch_total')}回';
+            '全体: 初期 min ${countOf('initial_minimum')} / std $standardInitial / full ${countOf('initial_full')}・標準維持率 $rate・切替 ${countOf('switch_total')}回$trendLabel';
       });
     } catch (e) {
       debugPrint('experiment summary fetch failed: $e');
@@ -7739,6 +7762,73 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       ),
     );
+  }
+
+  String _shiftPreviewLabel({
+    required AssetCalendarEvent event,
+    required AssetPaymentCalendarMonth calendar,
+    required List<AssetCalendarDebtInput> debts,
+    required List<Map<String, dynamic>> subscriptions,
+    required List<AssetCalendarInflowInput> inflows,
+    required double? startingCashBalance,
+  }) {
+    const newDay = _salarySpendingSalaryDay + 1;
+    final shifted = AssetPaymentCalendarService.buildMonth(
+      month: _calendarMonth,
+      flows: _recentFlows,
+      subscriptions: subscriptions,
+      debts: [
+        for (final debt in debts)
+          if (debt.id == event.sourceId)
+            AssetCalendarDebtInput(
+              id: debt.id,
+              name: debt.name,
+              balance: debt.balance,
+              paymentDay: newDay,
+              scheduledPaymentAmount: debt.scheduledPaymentAmount,
+              isDirectCashflowTarget: debt.isDirectCashflowTarget,
+            )
+          else
+            debt,
+      ],
+      salaryDay: _salarySpendingSalaryDay,
+      startingCashBalance: startingCashBalance,
+      expectedInflows: inflows,
+    );
+    final shiftedShortfall = shifted.firstShortfallDate;
+    if (shiftedShortfall == null) {
+      return '(回避できます)';
+    }
+    final currentShortfall = calendar.firstShortfallDate;
+    if (currentShortfall != null &&
+        shiftedShortfall.isAfter(currentShortfall)) {
+      return '(${DateFormat('M/d').format(shiftedShortfall)}へ後退)';
+    }
+    return '(単独では回避不可)';
+  }
+
+  Future<void> _restoreInflowsFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase.from('asset_expected_inflow_items').select();
+      final restored = await _expectedInflowStore.restoreFromMirrorRows(
+        List<Map<String, dynamic>>.from(rows),
+      );
+      if (!restored || !mounted) {
+        return;
+      }
+      await _loadExpectedInflows();
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('入金予定をサーバのバックアップから復元しました')),
+      );
+    } catch (e) {
+      debugPrint('inflow mirror restore failed: $e');
+    }
   }
 
   Future<void> _showInflowRulesDialog() async {
@@ -8013,31 +8103,34 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       rules: _expectedInflowRules,
       month: _calendarMonth,
     );
+    final monthSubscriptions = _subscriptionsForMonth(_calendarMonth);
+    final debtInputs = <AssetCalendarDebtInput>[
+      for (final row in debtRows)
+        AssetCalendarDebtInput(
+          id: row.id,
+          name: row.name,
+          balance: row.balance,
+          paymentDay: row.paymentDay,
+          scheduledPaymentAmount: row.scheduledPaymentAmount,
+          isDirectCashflowTarget: row.isDirectCashflowTarget,
+        ),
+    ];
+    final inflowInputs = <AssetCalendarInflowInput>[
+      for (final inflow in monthInflowEntries)
+        AssetCalendarInflowInput(
+          date: inflow.date,
+          amount: inflow.amount,
+          label: inflow.label,
+        ),
+    ];
     final calendar = AssetPaymentCalendarService.buildMonth(
       month: _calendarMonth,
       flows: _recentFlows,
-      subscriptions: _subscriptionsForMonth(_calendarMonth),
-      debts: [
-        for (final row in debtRows)
-          AssetCalendarDebtInput(
-            id: row.id,
-            name: row.name,
-            balance: row.balance,
-            paymentDay: row.paymentDay,
-            scheduledPaymentAmount: row.scheduledPaymentAmount,
-            isDirectCashflowTarget: row.isDirectCashflowTarget,
-          ),
-      ],
+      subscriptions: monthSubscriptions,
+      debts: debtInputs,
       salaryDay: _salarySpendingSalaryDay,
       startingCashBalance: startingCashBalance,
-      expectedInflows: [
-        for (final inflow in monthInflowEntries)
-          AssetCalendarInflowInput(
-            date: inflow.date,
-            amount: inflow.amount,
-            label: inflow.label,
-          ),
-      ],
+      expectedInflows: inflowInputs,
     );
     final selectedDate = _calendarSelectedDate;
     final selectedDay =
@@ -8052,6 +8145,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           (event) =>
               event.kind == AssetCalendarEventKind.debtPayment &&
               event.sourceId != null,
+        ),
+    ];
+    final shiftCandidates = <MapEntry<AssetCalendarEvent, String>>[
+      for (final event in shortfallDebtEvents)
+        MapEntry(
+          event,
+          _shiftPreviewLabel(
+            event: event,
+            calendar: calendar,
+            debts: debtInputs,
+            subscriptions: monthSubscriptions,
+            inflows: inflowInputs,
+            startingCashBalance: startingCashBalance,
+          ),
         ),
     ];
     const weekdayLabels = ['日', '月', '火', '水', '木', '金', '土'];
@@ -8208,21 +8315,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         spacing: 8,
                         runSpacing: 6,
                         children: [
-                          for (final event in shortfallDebtEvents)
+                          for (final entry in shiftCandidates)
                             OutlinedButton.icon(
                               key: Key(
-                                'asset_shift_payment_${event.sourceId}',
+                                'asset_shift_payment_${entry.key.sourceId}',
                               ),
                               onPressed: () => _shiftDebtPaymentAfterSalary(
                                 workbook,
-                                event.sourceId!,
+                                entry.key.sourceId!,
                               ),
                               icon: const Icon(
                                 Icons.schedule_send,
                                 size: 14,
                               ),
                               label: Text(
-                                '${event.label}を26日へ',
+                                '${entry.key.label}を26日へ${entry.value}',
                                 style: const TextStyle(fontSize: 11),
                               ),
                             ),

--- a/lib/services/asset_expected_inflow_store.dart
+++ b/lib/services/asset_expected_inflow_store.dart
@@ -208,6 +208,64 @@ class AssetExpectedInflowStore {
     }
   }
 
+  /// サーバミラー行からの復元 (#3246 v1)。安全側に倒し、ローカルが
+  /// 完全に空の場合のみ全置換する(既存ローカルがあれば何もしない)。
+  Future<bool> restoreFromMirrorRows(
+    List<Map<String, dynamic>> rows, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final localItems = _decode(store.getString(_key));
+    final localRules = _decodeRules(store.getString(_rulesKey));
+    if (localItems.isNotEmpty || localRules.isNotEmpty || rows.isEmpty) {
+      return false;
+    }
+    final items = <AssetExpectedInflow>[];
+    final rules = <AssetExpectedInflowRule>[];
+    for (final row in rows) {
+      final id = row['id']?.toString() ?? '';
+      final amount = (row['amount'] as num?)?.toDouble() ?? 0;
+      final label = row['label']?.toString() ?? '';
+      if (id.isEmpty || amount <= 0) {
+        continue;
+      }
+      if (row['kind']?.toString() == 'rule') {
+        final day = (row['day_of_month'] as num?)?.toInt() ?? 0;
+        if (day >= 1 && day <= 31) {
+          rules.add(
+            AssetExpectedInflowRule(
+              id: id,
+              dayOfMonth: day,
+              amount: amount,
+              label: label,
+            ),
+          );
+        }
+      } else {
+        final date =
+            DateTime.tryParse(row['date']?.toString() ?? '')?.toLocal();
+        if (date != null) {
+          items.add(
+            AssetExpectedInflow(
+              id: id,
+              date: DateTime(date.year, date.month, date.day),
+              amount: amount,
+              label: label,
+            ),
+          );
+        }
+      }
+    }
+    if (items.isEmpty && rules.isEmpty) {
+      return false;
+    }
+    items.sort((a, b) => a.date.compareTo(b.date));
+    rules.sort((a, b) => a.dayOfMonth.compareTo(b.dayOfMonth));
+    await _save(store, items);
+    await _saveRules(store, rules);
+    return true;
+  }
+
   Future<List<AssetExpectedInflow>> loadAll({SharedPreferences? prefs}) async {
     final store = prefs ?? await SharedPreferences.getInstance();
     return _decode(store.getString(_key));

--- a/supabase/migrations/20260612210000_display_mode_weekly_trend.sql
+++ b/supabase/migrations/20260612210000_display_mode_weekly_trend.sql
@@ -1,0 +1,59 @@
+-- 表示モード実験集計の時系列トレンド化 (週次バケット / 個人情報なし)。
+-- display_mode_events は append-only なので追加テーブル不要で導出できる。
+create or replace function public.display_mode_experiment_summary()
+returns jsonb
+language sql
+security definer
+set search_path = public
+as $$
+  select jsonb_build_object(
+    'initial_minimum',
+      count(*) filter (where event_type = 'initial' and mode = 'minimum'),
+    'initial_standard',
+      count(*) filter (where event_type = 'initial' and mode = 'standard'),
+    'initial_full',
+      count(*) filter (where event_type = 'initial' and mode = 'full'),
+    'switch_total', count(*) filter (where event_type = 'switch'),
+    'standard_retained', (
+      select count(*)
+      from display_mode_events i
+      where i.event_type = 'initial' and i.mode = 'standard'
+        and not exists (
+          select 1 from display_mode_events s
+          where s.user_id = i.user_id
+            and s.event_type = 'switch'
+            and s.created_at > i.created_at
+        )
+    ),
+    'weekly', (
+      select coalesce(
+        jsonb_agg(week_row order by week_start desc),
+        '[]'::jsonb
+      )
+      from (
+        select
+          date_trunc('week', created_at)::date as week_start,
+          jsonb_build_object(
+            'week_start', date_trunc('week', created_at)::date,
+            'initials',
+              count(*) filter (where event_type = 'initial'),
+            'initial_standard',
+              count(*) filter (
+                where event_type = 'initial' and mode = 'standard'
+              ),
+            'switches', count(*) filter (where event_type = 'switch')
+          ) as week_row
+        from display_mode_events
+        group by 1
+        order by 1 desc
+        limit 8
+      ) weeks
+    )
+  )
+  from display_mode_events;
+$$;
+
+revoke all on function public.display_mode_experiment_summary() from public;
+revoke all on function public.display_mode_experiment_summary() from anon;
+grant execute on function public.display_mode_experiment_summary()
+  to authenticated;

--- a/test/services/asset_expected_inflow_store_test.dart
+++ b/test/services/asset_expected_inflow_store_test.dart
@@ -143,5 +143,56 @@ void main() {
       expect(entries.last.sourceRuleId, 'r1');
       expect(entries.last.id, 'rule_r1_202602');
     });
+
+    test('restores mirror rows only into an empty local store', () async {
+      const store = AssetExpectedInflowStore();
+      final rows = <Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': 'inflow_a',
+          'kind': 'one_time',
+          'date': '2026-06-20',
+          'amount': 5000,
+          'label': '振込',
+        },
+        <String, dynamic>{
+          'id': 'rule_b',
+          'kind': 'rule',
+          'day_of_month': 25,
+          'amount': 280000,
+          'label': '給料',
+        },
+        <String, dynamic>{'id': '', 'kind': 'one_time', 'amount': 1},
+      ];
+
+      final restored = await store.restoreFromMirrorRows(rows);
+
+      expect(restored, isTrue);
+      final items = await store.loadAll();
+      final rules = await store.loadRules();
+      expect(items.single.id, 'inflow_a');
+      expect(items.single.date, DateTime(2026, 6, 20));
+      expect(rules.single.dayOfMonth, 25);
+    });
+
+    test('refuses mirror restore when local data already exists', () async {
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+      await store.add(date: DateTime(2026, 6, 1), amount: 100, label: 'x');
+
+      final restored = await store.restoreFromMirrorRows(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': 'inflow_remote',
+          'kind': 'one_time',
+          'date': '2026-06-21',
+          'amount': 999,
+          'label': 'remote',
+        },
+      ]);
+
+      expect(restored, isFalse);
+      final items = await store.loadAll();
+      expect(items.single.label, 'x');
+    });
   });
 }


### PR DESCRIPTION
## 概要

1. **#3246 復元側 v1** — 起動時にローカルの入金予定が完全に空の場合のみ、`asset_expected_inflow_items` ミラーから全置換復元(機種変更・再インストール時のリカバリ)。既存ローカルがあれば何もしない安全側設計(マージ戦略の高度化は #3246 に残課題として継続)。
2. **全体集計の週次トレンド化** — `display_mode_experiment_summary()` を週次バケット付きへ replace(追加テーブルなし、append-only イベントから導出)。「全体集計」表示に直近4週の「初期N(stdM)/切替S」推移を追記。
3. **移動ボタンの効果プレビュー** — ショート日の各支払について「26日へ移した場合」の月を事前再計算し、ボタンラベルに「**(回避できます)**/(M/dへ後退)/(単独では回避不可)」を表示。押す前に効果が分かります。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) 空ローカルへのミラー復元(one_time/rule 振り分け+不正行スキップ) (2) 既存ローカルがある場合の復元拒否 (3) 既存28ケースの回帰なし。計 30 ケース。
- E2E例外: クライアントは表示層+ローカル保存+読み取り専用の select/rpc のみ、サーバは既存集計関数の replace 1本(スキーマ変更なし)のため、エンドツーエンド(integration_test)追加は行わず service 単体テストで入出力契約を担保する。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `flutter test` **30/30 PASS**。

## High-risk gate

- High-risk-ultrareview-exception: 既存の集計関数(security definer / 集計値のみ返却)の replace のみで、テーブル・RLS・認証・課金・Edge Function に変更なし。返却内容は引き続き個人特定情報を含まない集計値。レビュー所有者: Claude Code #1。
- 自己点検メモ: security = 関数は jsonb 集計のみ・anon revoke 継続・weekly も件数のみ / rollback = 前版 SQL の re-apply で即復旧(part 276 migration に全文あり) / data migration = なし / prod smoke = 本PRの DB + Edge smoke green / observability = 取得失敗は debugPrint + 「取得できませんでした」表示でユーザー影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
