### PR TITLE
fix(asset): 改善提案Issues登録ボタンの無効理由を可視化（既存Issueリンク表示）

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -12979,9 +12979,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         )
                       : const Icon(Icons.add_task_outlined, size: 16),
                   label: Text(
-                    _isSubmittingAllDeveloperIssues
-                        ? 'Issues登録中'
-                        : '改善提案をIssues登録',
+                    _developerIssuesBulkButtonLabel(
+                      issueableDeveloperRequests,
+                    ),
                   ),
                 ),
             ],
@@ -13833,6 +13833,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
             )
             .toList(growable: false);
+    final existingIssueEntries =
+        <MapEntry<AssetManagementDeveloperRequest, Map<String, dynamic>>>[];
+    if (!_isCheckingExistingDeveloperRequestIssues) {
+      for (final request in requests) {
+        final issueKey = _developerRequestIssueKey(request);
+        final existing = _developerRequestExistingIssueResults[issueKey];
+        if (existing != null) {
+          existingIssueEntries.add(MapEntry(request, existing));
+        }
+      }
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -13841,6 +13852,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
         ),
         const SizedBox(height: 6),
+        if (_isCheckingExistingDeveloperRequestIssues)
+          Text(
+            '既存のGitHub Issueを確認しています...',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
         for (final request in visibleRequests.take(4))
           Padding(
             padding: const EdgeInsets.only(bottom: 6),
@@ -13900,7 +13920,61 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
             ),
           ),
+        if (existingIssueEntries.isNotEmpty) ...[
+          Text(
+            '登録済みの改善提案（既存Issueがあるため新規登録対象外）',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              height: 1.4,
+            ),
+          ),
+          for (final entry in existingIssueEntries)
+            _buildExistingDeveloperIssueLink(entry.key, entry.value),
+        ],
       ],
+    );
+  }
+
+  String _developerIssuesBulkButtonLabel(
+    List<AssetManagementDeveloperRequest> issueableRequests,
+  ) {
+    if (_isSubmittingAllDeveloperIssues) {
+      return 'Issues登録中';
+    }
+    if (_isCheckingExistingDeveloperRequestIssues) {
+      return '既存Issue確認中';
+    }
+    if (issueableRequests.isEmpty) {
+      return '改善提案はIssue登録済み';
+    }
+    return '改善提案をIssues登録';
+  }
+
+  Widget _buildExistingDeveloperIssueLink(
+    AssetManagementDeveloperRequest request,
+    Map<String, dynamic> existingIssue,
+  ) {
+    final issueUrl = existingIssue['html_url']?.toString() ?? '';
+    final issueNumber = existingIssue['number']?.toString() ?? '-';
+    final issueState = existingIssue['state']?.toString() ?? '-';
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: TextButton.icon(
+        style: TextButton.styleFrom(
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+        ),
+        onPressed: issueUrl.isEmpty
+            ? null
+            : () => web.window.open(issueUrl, '_blank'),
+        icon: const Icon(Icons.open_in_new, size: 14),
+        label: Text(
+          '${request.title}: 既存Issue #$issueNumber（$issueState）を開く',
+          style: const TextStyle(fontSize: 12, height: 1.4),
+        ),
+      ),
     );
   }
 

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -13966,9 +13966,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           visualDensity: VisualDensity.compact,
           padding: const EdgeInsets.symmetric(horizontal: 8),
         ),
-        onPressed: issueUrl.isEmpty
-            ? null
-            : () => web.window.open(issueUrl, '_blank'),
+        onPressed:
+            issueUrl.isEmpty ? null : () => web.window.open(issueUrl, '_blank'),
         icon: const Icon(Icons.open_in_new, size: 14),
         label: Text(
           '${request.title}: 既存Issue #$issueNumber（$issueState）を開く',


### PR DESCRIPTION
## 概要

「改善提案をIssues登録」ボタンが有効にならないというユーザー報告の対応（part 271 シリーズ第5弾）。

### 調査結果: ボタン無効は故障ではなく重複防止の正常動作

- ボタンは `feature_request.existing_issues`（core-hub EF）で各提案の既存 GitHub Issue を照合し、**全提案に既存 Issue がある場合に無効化**される設計
- 今回のケースでは両提案とも既存 Issue が実在:
  - 「請求確定額と推定額の差分レビュー導線」→ #3064（closed）
  - 「口座間移動タスク管理」→ #2452 / #2941 / #2948 / #2955（いずれも closed・過去の重複登録がこの抑止機能の導入理由）
- ただし**無効の理由が UI にまったく表示されず**、既存 Issue がある提案はリストから黙って消えるため、ユーザーには「ボタンが壊れている」ように見えていた

### 変更内容（UIのみ・透明化）

1. ボタンラベルを状態別に変更: `既存Issue確認中` →（全件既存なら）`改善提案はIssue登録済み` / （登録対象があれば従来どおり）`改善提案をIssues登録`
2. 開発者向け改善提案リストで、既存 Issue がある提案を非表示にせず「**提案タイトル: 既存Issue #N（state）を開く**」リンクとして表示
3. 既存 Issue 確認中は「既存のGitHub Issueを確認しています...」を表示
4. 重複 Issue を防ぐ挙動自体は変更しない（強制登録は追加しない）

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. 全提案に既存 Issue あり → ボタンが「改善提案はIssue登録済み」表示で無効、リストに既存 Issue リンクが出る
  2. 既存 Issue がない提案あり → ボタンが「改善提案をIssues登録」で有効
  3. 既存 Issue 照合中 → 「既存Issue確認中」表示で無効
- 本変更は表示ロジックのみで、判定（_issueableDeveloperRequests）・登録処理は不変
- E2E-Exception: 資産管理ページは認証済みユーザーの資産データと Edge Function 応答前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。表示分岐は既存 state の参照のみの薄いUI層であり、本番反映後に上記3ケースを手動確認する。

## 検証

- `flutter analyze`: No issues found
- 並行マージ反映後の最新 main 基準で検証（dart format は本ファイルが CI 側新フォーマッタ整形済みのためローカル旧フォーマッタでは検証不能 — 追加コードは既存スタイル踏襲、CI の Format ジョブで最終確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
