### PR TITLE
feat(asset): widgetテスト足場 + overrides同期 + 統合/トレンド/組合せ移動 (part 278)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -303,15 +303,12 @@ import 'package:my_web_app/widgets/global_header_clock_bar.dart';
 import 'utils/app_logger.dart';
 import 'utils/error_reporter.dart';
 
-SupabaseClient? _testSupabaseClient;
+import 'services/supabase_client_provider.dart';
+
+export 'services/supabase_client_provider.dart';
+
 final GrowthPresenceNavigatorObserver _growthPresenceObserver =
     GrowthPresenceNavigatorObserver();
-
-@visibleForTesting
-set supabaseClientForTesting(SupabaseClient client) =>
-    _testSupabaseClient = client;
-
-SupabaseClient get supabase => _testSupabaseClient ?? Supabase.instance.client;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -54,7 +54,9 @@ import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:web/web.dart' as web;
+import 'package:web/web.dart'
+    // ignore: uri_does_not_exist
+    if (dart.library.io) 'package:my_web_app/utils/web_stub.dart' as web;
 
 enum AssetManagementInitialFocus {
   overview,
@@ -346,6 +348,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       <AssetExpectedInflowRule>[];
   String? _displayModeStatsLabel;
   String? _experimentServerSummary;
+  List<Map<String, dynamic>> _experimentWeekly = const <Map<String, dynamic>>[];
   DateTime _calendarMonth = DateTime.now();
   DateTime? _calendarSelectedDate;
   Future<AssetWasteTrainingAiReview>? _wasteTrainingAiReviewFuture;
@@ -1076,6 +1079,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           await _assetLiabilityRepository.loadDefaultCardBillingAccounts();
       final debtPaymentDayOverrides =
           await _assetLiabilityRepository.loadDebtPaymentDayOverrides();
+      if (debtPaymentDayOverrides.isEmpty) {
+        unawaited(_restoreDebtPaymentDayOverridesFromMirror());
+      }
       final templates =
           await _assetLiabilityRepository.loadRecurringIncomeTemplates();
       final monthlySnapshots =
@@ -7681,6 +7687,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           : '${(retained * 100 / standardInitial).round()}%';
       final weekly = data['weekly'];
       var trendLabel = '';
+      final weeklyMaps = <Map<String, dynamic>>[];
       if (weekly is List && weekly.isNotEmpty) {
         final parts = <String>[];
         for (final raw in weekly.take(4)) {
@@ -7688,6 +7695,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             continue;
           }
           final week = Map<String, dynamic>.from(raw);
+          weeklyMaps.add(week);
           final start = week['week_start']?.toString() ?? '';
           final label = start.length >= 10 ? start.substring(5, 10) : start;
           final initials = (week['initials'] as num?)?.toInt() ?? 0;
@@ -7702,6 +7710,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       setState(() {
         _experimentServerSummary =
             '全体: 初期 min ${countOf('initial_minimum')} / std $standardInitial / full ${countOf('initial_full')}・標準維持率 $rate・切替 ${countOf('switch_total')}回$trendLabel';
+        _experimentWeekly = weeklyMaps;
       });
     } catch (e) {
       debugPrint('experiment summary fetch failed: $e');
@@ -7831,6 +7840,216 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  Future<void> _mirrorDebtPaymentDayOverrides(
+    Map<String, int> overrides,
+  ) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': 'debt_payment_day_overrides',
+        'value': overrides,
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('pref mirror upsert failed: $e');
+    }
+  }
+
+  Future<void> _restoreDebtPaymentDayOverridesFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', 'debt_payment_day_overrides');
+      if (rows.isEmpty || !mounted) {
+        return;
+      }
+      final value = rows.first['value'];
+      if (value is! Map) {
+        return;
+      }
+      final restored = <String, int>{};
+      value.forEach((key, dynamic raw) {
+        final day = (raw as num?)?.toInt();
+        if (key is String && day != null && day >= 1 && day <= 31) {
+          restored[key] = day;
+        }
+      });
+      if (restored.isEmpty || _debtPaymentDayOverrides.isNotEmpty) {
+        return;
+      }
+      setState(() {
+        _debtPaymentDayOverrides = restored;
+      });
+      unawaited(_saveDebtPaymentDayOverrides());
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('支払日設定をサーバのバックアップから復元しました')),
+      );
+    } catch (e) {
+      debugPrint('pref mirror restore failed: $e');
+    }
+  }
+
+  Future<void> _mergeInflowsFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase.from('asset_expected_inflow_items').select();
+      final added = await _expectedInflowStore.mergeFromMirrorRows(
+        List<Map<String, dynamic>>.from(rows),
+      );
+      if (!mounted) {
+        return;
+      }
+      if (added > 0) {
+        await _loadExpectedInflows();
+      }
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            added > 0 ? '$added件をサーバから統合しました' : 'サーバとの差分はありませんでした',
+          ),
+        ),
+      );
+    } catch (e) {
+      debugPrint('inflow mirror merge failed: $e');
+    }
+  }
+
+  AssetLiabilityDebtRow? _debtRowById(
+    AssetLiabilityWorkbook? workbook,
+    String debtRowId,
+  ) {
+    final rows = workbook?.debtMasterRows ?? const <AssetLiabilityDebtRow>[];
+    for (final row in rows) {
+      if (row.id == debtRowId) {
+        return row;
+      }
+    }
+    return null;
+  }
+
+  void _shiftDebtPaymentsAfterSalaryCombo(
+    AssetLiabilityWorkbook? workbook,
+    List<String> debtRowIds,
+  ) {
+    const newDay = _salarySpendingSalaryDay + 1;
+    var shiftedCount = 0;
+    for (final id in debtRowIds) {
+      final target = _debtRowById(workbook, id);
+      if (target == null) {
+        continue;
+      }
+      _setDebtPaymentDayOverride(target, newDay);
+      shiftedCount += 1;
+    }
+    if (shiftedCount == 0) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          '$shiftedCount件の支払日を毎月$newDay日へまとめて変更しました(負債マスタから戻せます)',
+        ),
+      ),
+    );
+  }
+
+  String? _comboShiftPreviewLabel({
+    required List<String> ids,
+    required List<AssetCalendarDebtInput> debts,
+    required List<Map<String, dynamic>> subscriptions,
+    required List<AssetCalendarInflowInput> inflows,
+    required double? startingCashBalance,
+  }) {
+    const newDay = _salarySpendingSalaryDay + 1;
+    final shifted = AssetPaymentCalendarService.buildMonth(
+      month: _calendarMonth,
+      flows: _recentFlows,
+      subscriptions: subscriptions,
+      debts: [
+        for (final debt in debts)
+          if (ids.contains(debt.id))
+            AssetCalendarDebtInput(
+              id: debt.id,
+              name: debt.name,
+              balance: debt.balance,
+              paymentDay: newDay,
+              scheduledPaymentAmount: debt.scheduledPaymentAmount,
+              isDirectCashflowTarget: debt.isDirectCashflowTarget,
+            )
+          else
+            debt,
+      ],
+      salaryDay: _salarySpendingSalaryDay,
+      startingCashBalance: startingCashBalance,
+      expectedInflows: inflows,
+    );
+    return shifted.firstShortfallDate == null ? '(回避できます)' : null;
+  }
+
+  Widget _buildExperimentTrendBars() {
+    final weeks = _experimentWeekly.reversed.toList(growable: false);
+    var maxInitials = 1;
+    for (final week in weeks) {
+      final initials = (week['initials'] as num?)?.toInt() ?? 0;
+      if (initials > maxInitials) {
+        maxInitials = initials;
+      }
+    }
+    return SizedBox(
+      height: 60,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          for (final week in weeks)
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 2),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Text(
+                      '${(week['initials'] as num?)?.toInt() ?? 0}',
+                      style: const TextStyle(fontSize: 8, height: 1.2),
+                    ),
+                    Container(
+                      height: 4 +
+                          36 *
+                              ((week['initials'] as num?)?.toInt() ?? 0) /
+                              maxInitials,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF6366F1),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      (week['week_start']?.toString() ?? '').length >= 10
+                          ? week['week_start'].toString().substring(5, 10)
+                          : '',
+                      style: const TextStyle(fontSize: 7, height: 1.2),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
   Future<void> _showInflowRulesDialog() async {
     await showDialog<void>(
       context: context,
@@ -7882,6 +8101,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   ),
           ),
           actions: [
+            TextButton.icon(
+              key: const Key('asset_inflow_merge_button'),
+              onPressed: () async {
+                await _mergeInflowsFromMirror();
+                setDialogState(() {});
+              },
+              icon: const Icon(Icons.cloud_sync, size: 16),
+              label: const Text('サーバと統合'),
+            ),
             TextButton(
               onPressed: () => Navigator.pop(dialogContext),
               child: const Text('閉じる'),
@@ -7960,6 +8188,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                       ),
                     ],
                   ),
+                  if (_experimentWeekly.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    _buildExperimentTrendBars(),
+                  ],
                   const SizedBox(height: 6),
                   Text(
                     '「自動」は表示モード(ミニマム/標準/フル)に従います。「常に表示」「隠す」はモードより優先されます。',
@@ -8161,6 +8393,22 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
         ),
     ];
+    final comboIds = <String>[
+      for (final event in shortfallDebtEvents)
+        if (event.sourceId != null) event.sourceId!,
+    ];
+    final comboPreview = comboIds.length >= 2 &&
+            shiftCandidates.every(
+              (entry) => entry.value == '(単独では回避不可)',
+            )
+        ? _comboShiftPreviewLabel(
+            ids: comboIds,
+            debts: debtInputs,
+            subscriptions: monthSubscriptions,
+            inflows: inflowInputs,
+            startingCashBalance: startingCashBalance,
+          )
+        : null;
     const weekdayLabels = ['日', '月', '火', '水', '木', '金', '土'];
 
     return Card(
@@ -8334,6 +8582,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                               ),
                             ),
                         ],
+                      ),
+                    ],
+                    if (comboPreview != null) ...[
+                      const SizedBox(height: 6),
+                      OutlinedButton.icon(
+                        key: const Key('asset_shift_payment_combo'),
+                        onPressed: () => _shiftDebtPaymentsAfterSalaryCombo(
+                          workbook,
+                          comboIds,
+                        ),
+                        icon: const Icon(Icons.double_arrow, size: 14),
+                        label: Text(
+                          'まとめて26日へ移動$comboPreview',
+                          style: const TextStyle(fontSize: 11),
+                        ),
                       ),
                     ],
                   ],
@@ -17873,6 +18136,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('Error saving debt payment day overrides: $e');
     }
+    unawaited(
+      _mirrorDebtPaymentDayOverrides(
+        Map<String, int>.from(_debtPaymentDayOverrides),
+      ),
+    );
   }
 
   Widget _buildDebtPaymentDayInput(AssetLiabilityDebtRow row) {

--- a/lib/pages/profile_settings_page.dart
+++ b/lib/pages/profile_settings_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:file_picker/file_picker.dart'; // ファイル選択のために必要
 import 'package:mime/mime.dart';
-import '../main.dart';
+import 'package:my_web_app/services/supabase_client_provider.dart';
 import '../models/user_profile.dart';
 import '../services/profile_service.dart';
 

--- a/lib/services/asset_expected_inflow_store.dart
+++ b/lib/services/asset_expected_inflow_store.dart
@@ -266,6 +266,68 @@ class AssetExpectedInflowStore {
     return true;
   }
 
+  /// ミラーとの手動統合: ローカルに無い ID のみ追加する和集合マージ。
+  /// 削除のトゥームストーンが無いため、ローカルで消した項目がサーバに
+  /// 残っていれば復活し得る(明示的なボタン操作でのみ実行する前提)。
+  Future<int> mergeFromMirrorRows(
+    List<Map<String, dynamic>> rows, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final items = _decode(store.getString(_key));
+    final rules = _decodeRules(store.getString(_rulesKey));
+    final knownIds = <String>{
+      for (final item in items) item.id,
+      for (final rule in rules) rule.id,
+    };
+    var added = 0;
+    for (final row in rows) {
+      final id = row['id']?.toString() ?? '';
+      final amount = (row['amount'] as num?)?.toDouble() ?? 0;
+      final label = row['label']?.toString() ?? '';
+      if (id.isEmpty || amount <= 0 || knownIds.contains(id)) {
+        continue;
+      }
+      if (row['kind']?.toString() == 'rule') {
+        final day = (row['day_of_month'] as num?)?.toInt() ?? 0;
+        if (day < 1 || day > 31) {
+          continue;
+        }
+        rules.add(
+          AssetExpectedInflowRule(
+            id: id,
+            dayOfMonth: day,
+            amount: amount,
+            label: label,
+          ),
+        );
+      } else {
+        final date =
+            DateTime.tryParse(row['date']?.toString() ?? '')?.toLocal();
+        if (date == null) {
+          continue;
+        }
+        items.add(
+          AssetExpectedInflow(
+            id: id,
+            date: DateTime(date.year, date.month, date.day),
+            amount: amount,
+            label: label,
+          ),
+        );
+      }
+      added += 1;
+    }
+    if (added == 0) {
+      return 0;
+    }
+    items.sort((a, b) => a.date.compareTo(b.date));
+    rules.sort((a, b) => a.dayOfMonth.compareTo(b.dayOfMonth));
+    await _save(store, items);
+    await _saveRules(store, rules);
+    return added;
+  }
+
   Future<List<AssetExpectedInflow>> loadAll({SharedPreferences? prefs}) async {
     final store = prefs ?? await SharedPreferences.getInstance();
     return _decode(store.getString(_key));

--- a/lib/services/profile_service.dart
+++ b/lib/services/profile_service.dart
@@ -2,7 +2,7 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'dart:typed_data'; // 👈 Uint8Listのために必要
 import '../models/user_profile.dart';
-import '../main.dart';
+import 'package:my_web_app/services/supabase_client_provider.dart';
 import '../utils/app_logger.dart';
 
 /// ユーザープロフィール管理サービス

--- a/lib/services/supabase_client_provider.dart
+++ b/lib/services/supabase_client_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// アプリ共有の SupabaseClient 供給点 (main.dart から移設 / #3260)。
+/// main.dart 経由の import は全アプリのページグラフ (web 専用 page 含む) を
+/// 巻き込み VM テストをコンパイル不能にするため、独立ファイルに分離した。
+/// main.dart は本ファイルを export しており既存 import は影響を受けない。
+SupabaseClient? _testSupabaseClient;
+
+@visibleForTesting
+set supabaseClientForTesting(SupabaseClient client) =>
+    _testSupabaseClient = client;
+
+SupabaseClient get supabase => _testSupabaseClient ?? Supabase.instance.client;

--- a/lib/utils/web_stub.dart
+++ b/lib/utils/web_stub.dart
@@ -1,0 +1,21 @@
+/// VM (単体/widget テスト) 用の `package:web` 最小スタブ。
+/// Web ビルドでは条件付き import により本物の package:web が使われる。
+library;
+
+class TextDecoder {
+  const TextDecoder(this.encoding);
+
+  final String encoding;
+
+  String decode(Object? input) {
+    throw UnsupportedError('TextDecoder は Web ビルド専用です');
+  }
+}
+
+class Window {
+  const Window();
+
+  void open(String url, String target) {}
+}
+
+const Window window = Window();

--- a/supabase/migrations/20260612230000_asset_pref_mirror.sql
+++ b/supabase/migrations/20260612230000_asset_pref_mirror.sql
@@ -1,0 +1,19 @@
+-- 端末ローカル設定の汎用バックアップミラー (#3246: paymentDayOverrides 同期)。
+-- v1 は書き込みミラー + ローカル空時の復元のみ。キー単位の jsonb で将来の
+-- ローカル設定 (表示モード等) にも流用できる。
+create table if not exists public.asset_pref_mirror (
+  user_id uuid not null references auth.users (id) on delete cascade,
+  pref_key text not null,
+  value jsonb not null,
+  updated_at timestamptz not null default now(),
+  primary key (user_id, pref_key)
+);
+
+alter table public.asset_pref_mirror enable row level security;
+
+drop policy if exists "asset_pref_mirror_own_all" on public.asset_pref_mirror;
+create policy "asset_pref_mirror_own_all"
+  on public.asset_pref_mirror
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/test/services/asset_expected_inflow_store_test.dart
+++ b/test/services/asset_expected_inflow_store_test.dart
@@ -194,5 +194,49 @@ void main() {
       final items = await store.loadAll();
       expect(items.single.label, 'x');
     });
+
+    test('union-merges only mirror rows that are missing locally', () async {
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+      final local = await store.add(
+        date: DateTime(2026, 6, 1),
+        amount: 100,
+        label: 'local',
+      );
+
+      final added = await store.mergeFromMirrorRows(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': local.single.id,
+          'kind': 'one_time',
+          'date': '2026-06-01',
+          'amount': 100,
+          'label': 'local',
+        },
+        <String, dynamic>{
+          'id': 'inflow_remote_new',
+          'kind': 'one_time',
+          'date': '2026-06-20',
+          'amount': 5000,
+          'label': '別端末分',
+        },
+        <String, dynamic>{
+          'id': 'rule_remote_new',
+          'kind': 'rule',
+          'day_of_month': 25,
+          'amount': 280000,
+          'label': '給料',
+        },
+      ]);
+
+      expect(added, 2);
+      expect(await store.loadAll(), hasLength(2));
+      expect((await store.loadRules()).single.id, 'rule_remote_new');
+
+      final secondRun = await store.mergeFromMirrorRows(
+        const <Map<String, dynamic>>[],
+      );
+      expect(secondRun, 0);
+    });
   });
 }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:my_web_app/pages/asset_management_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// 資産管理ページの widget スモーク足場 (#3260)。
+/// 未ログイン (auth.currentUser == null) では Supabase フェッチ群が
+/// 早期 return する性質を利用し、ネットワークなしで UI 契約だけを検証する。
+Future<void> _pumpAssetPage(WidgetTester tester) async {
+  await tester.pumpWidget(
+    const MaterialApp(home: AssetManagementPage()),
+  );
+  await tester.pump(const Duration(milliseconds: 100));
+}
+
+Future<void> _unmount(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pump(const Duration(seconds: 2));
+}
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    await Supabase.initialize(
+      url: 'http://127.0.0.1:9999',
+      publishableKey: 'test-publishable-key',
+      authOptions: const FlutterAuthClientOptions(autoRefreshToken: false),
+    );
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('AssetManagementPage smoke', () {
+    testWidgets('display mode chips reduce visible sections', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+
+      expect(find.byKey(const Key('asset_display_mode_minimum')), findsOne);
+      final cardsInFull = tester.widgetList(find.byType(Card)).length;
+
+      await tester.tap(find.byKey(const Key('asset_display_mode_minimum')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      final cardsInMinimum = tester.widgetList(find.byType(Card)).length;
+      expect(cardsInMinimum, lessThan(cardsInFull));
+      expect(find.textContaining('最重要のみ'), findsWidgets);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('calendar month navigation updates the label', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+
+      final now = DateTime.now();
+      final current = DateFormat('yyyy年M月').format(now);
+      final next = DateFormat(
+        'yyyy年M月',
+      ).format(DateTime(now.year, now.month + 1));
+      expect(find.text(current), findsOneWidget);
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_calendar_next_month')),
+      );
+      await tester.tap(find.byKey(const Key('asset_calendar_next_month')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text(next), findsOneWidget);
+      expect(find.text(current), findsNothing);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('tapping a day reveals the prefill action', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+
+      expect(
+        find.byKey(const Key('asset_calendar_prefill_flow_button')),
+        findsNothing,
+      );
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_calendar_day_15')),
+      );
+      await tester.tap(find.byKey(const Key('asset_calendar_day_15')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        find.byKey(const Key('asset_calendar_prefill_flow_button')),
+        findsOneWidget,
+      );
+
+      await _unmount(tester);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

1. **#3260 widget テスト足場** — 資産管理ページ(~20k行)を VM で pump 可能にした。根本障害は2つ: (a) `package:web` の無条件 import → 条件付き import + 最小 `web_stub.dart`(TextDecoder/window.open のみ) (b) `supabase` getter が main.dart 在住で import すると全アプリページグラフ(web専用ページ含む)を巻き込む → `supabase_client_provider.dart` へ分離し **main.dart は re-export するため既存15ファイルの import は無変更**。profile_settings_page / profile_service の2箇所のみ provider 直 import へ差し替え。smoke 3テスト(モード切替でカード数減少・カレンダー月送り・日タップで記録ボタン出現)を `test/widgets/` に追加し CI の Test job で実行される。
2. **#3246 残り** — `asset_pref_mirror` 汎用 jsonb ミラーテーブル新設。paymentDayOverrides を保存時にミラー + ローカル空時に復元(snackbar 通知)。入金予定の非空マージは、復活リスク(削除トゥームストーン無し)を踏まえ**ルール管理ダイアログの「サーバと統合」ボタンによる明示的な ID 和集合マージ**として実装。
3. **トレンドのミニグラフ化** — 全体集計の下に直近週の初期解決数を手描きミニ棒グラフ表示(依存追加なし)。
4. **組合せ移動提案** — ショート日の支払が複数件かつ全てが「(単独では回避不可)」のとき、全件を26日へ移した月を事前計算し、回避できる場合のみ「**まとめて26日へ移動(回避できます)**」ボタンを提示。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) widget smoke: モード切替の表示セクション数変化/月送りラベル/日タップ→記録ボタン (2) ミラー和集合マージはローカル未知 ID のみ追加 (3) 既存31ケースの回帰なし。計 34 ケース(widget 3 + service 31)。
- E2E例外: 本PRで widget 層テストを新設しており(integration_test 相当の UI 検証の第一歩)、ネットワーク・認証フローはモック外のため Playwright 本番 smoke(既存CI)で担保する。新規サーバ変更は追加のみのミラーテーブル1本。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` 対象9ファイル **No issues found** / `flutter test` **34/34 PASS**。

## High-risk gate

- High-risk-ultrareview-exception: 追加のみの汎用ミラーテーブル1本(RLS 本人 for all)で、既存スキーマ・認証・課金・Edge Function に変更なし。main.dart の変更は getter の移設+re-export のみで挙動同一。レビュー所有者: Claude Code #1。
- 自己点検メモ: security = RLS 本人限定 + value は jsonb(クライアント検証済みの day 1-31 のみ採用) / rollback = drop table + getter 移設は re-export により import 互換(revert 容易) / data migration = なし / prod smoke = 本PRの DB + Edge smoke green + widget smoke 新設 / observability = ミラー失敗は debugPrint + ローカル継続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3260
