### PR TITLE
feat(asset): AI改善提案を定型再掲から未起票の新規提案生成へ

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -12957,7 +12957,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           ],
           const SizedBox(height: 12),
-          _buildAssetManagementDeveloperRequestList(report.developerRequests),
+          _buildAssetManagementDeveloperRequestList(
+            _combinedDeveloperRequests(report),
+          ),
         ],
       ),
     );
@@ -12970,7 +12972,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (enabled) {
       _requestAssetManagementAiSummaryIfNeeded(report);
     }
-    _requestExistingDeveloperIssuesIfNeeded(report.developerRequests);
+    final developerRequests = _combinedDeveloperRequests(report);
+    _requestExistingDeveloperIssuesIfNeeded(developerRequests);
     final result = _assetManagementAiSummaryResult ??
         (enabled
             ? _assetManagementAiSummaryService.buildWaitingForAiResult(report)
@@ -12986,7 +12989,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetManagementAiSummaryStatus.disabled => 'AI無効',
     };
     final issueableDeveloperRequests = _issueableDeveloperRequests(
-      report.developerRequests,
+      developerRequests,
     );
     final canCopySummary = result.text.trim().isNotEmpty;
 
@@ -13069,14 +13072,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     : const Icon(Icons.auto_awesome_outlined, size: 16),
                 label: Text(enabled ? 'AI要約を更新' : 'AI要約は機能フラグで無効です'),
               ),
-              if (report.developerRequests.isNotEmpty)
+              if (developerRequests.isNotEmpty)
                 OutlinedButton.icon(
                   onPressed: _isSubmittingAllDeveloperIssues ||
                           _isCheckingExistingDeveloperRequestIssues ||
                           issueableDeveloperRequests.isEmpty
                       ? null
                       : () => _submitAssetManagementDeveloperIssues(
-                            report.developerRequests,
+                            developerRequests,
                           ),
                   icon: _isSubmittingAllDeveloperIssues
                       ? const SizedBox(
@@ -13211,9 +13214,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (!mounted || _assetManagementAiSummaryInFlightKey != key) {
       return;
     }
+    final existingIssuesByTitle = <String, Map<String, dynamic>>{};
+    for (final request in report.developerRequests) {
+      final existing = _developerRequestExistingIssueResults[
+          _developerRequestIssueKey(request)];
+      if (existing != null) {
+        existingIssuesByTitle[request.title] =
+            Map<String, dynamic>.from(existing);
+      }
+    }
     final result = await _assetManagementAiSummaryService.generateSummary(
       report: report,
       previousAnalyses: previousAnalyses,
+      existingDeveloperIssuesByTitle: existingIssuesByTitle,
     );
     if (result.usedExternalAi) {
       try {
@@ -13352,6 +13365,38 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _isCheckingExistingDeveloperRequestIssues = false;
       });
     }
+  }
+
+  /// 定型生成の改善提案に、AI要約が返した未起票の新規提案を合流させる。
+  List<AssetManagementDeveloperRequest> _combinedDeveloperRequests(
+    AssetManagementInsightReport report,
+  ) {
+    final aiRequests = _assetManagementAiSummaryResult?.aiDeveloperRequests ??
+        const <AssetManagementDeveloperRequest>[];
+    if (aiRequests.isEmpty) {
+      return report.developerRequests;
+    }
+    final knownKeys =
+        report.developerRequests.map(_developerRequestIssueKey).toSet();
+    return <AssetManagementDeveloperRequest>[
+      ...report.developerRequests,
+      for (final request in aiRequests)
+        if (knownKeys.add(_developerRequestIssueKey(request))) request,
+    ];
+  }
+
+  bool _isAiGeneratedDeveloperRequest(
+    AssetManagementDeveloperRequest request,
+  ) {
+    final aiRequests = _assetManagementAiSummaryResult?.aiDeveloperRequests ??
+        const <AssetManagementDeveloperRequest>[];
+    if (aiRequests.isEmpty) {
+      return false;
+    }
+    final key = _developerRequestIssueKey(request);
+    return aiRequests.any(
+      (candidate) => _developerRequestIssueKey(candidate) == key,
+    );
   }
 
   List<AssetManagementDeveloperRequest> _issueableDeveloperRequests(
@@ -13968,7 +14013,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               height: 1.5,
             ),
           ),
-        for (final request in visibleRequests.take(4))
+        for (final request in visibleRequests.take(6))
           Padding(
             padding: const EdgeInsets.only(bottom: 6),
             child: Container(
@@ -13991,6 +14036,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                       height: 1.4,
                     ),
                   ),
+                  if (_isAiGeneratedDeveloperRequest(request)) ...[
+                    const SizedBox(height: 4),
+                    _buildTextStatusChip(
+                      label: 'AI新規提案（未起票のみ登録可）',
+                      color: const Color(0xFF7C3AED),
+                    ),
+                  ],
                   const SizedBox(height: 3),
                   Text(
                     request.description,

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -32,6 +32,10 @@ class AssetManagementAiSummaryResult {
   final Map<String, dynamic>? providerRoute;
   final String? providerChoiceReason;
 
+  /// AIが応答末尾の機械可読ブロックで返した、既知テンプレートと重複しない
+  /// 新規改善提案。Issue登録フローへ合流させる。
+  final List<AssetManagementDeveloperRequest> aiDeveloperRequests;
+
   const AssetManagementAiSummaryResult({
     required this.status,
     required this.text,
@@ -41,10 +45,21 @@ class AssetManagementAiSummaryResult {
     required this.payload,
     this.providerRoute,
     this.providerChoiceReason,
+    this.aiDeveloperRequests = const <AssetManagementDeveloperRequest>[],
   });
 
   bool get usedExternalAi =>
       status == AssetManagementAiSummaryStatus.aiGenerated;
+}
+
+class AssetManagementAiProposalExtraction {
+  final String displayText;
+  final List<AssetManagementDeveloperRequest> requests;
+
+  const AssetManagementAiProposalExtraction({
+    required this.displayText,
+    required this.requests,
+  });
 }
 
 class AssetManagementAiSummaryService {
@@ -83,6 +98,8 @@ class AssetManagementAiSummaryService {
     required AssetManagementInsightReport report,
     List<AssetManagementAiAnalysisHistoryEntry> previousAnalyses =
         const <AssetManagementAiAnalysisHistoryEntry>[],
+    Map<String, Map<String, dynamic>> existingDeveloperIssuesByTitle =
+        const <String, Map<String, dynamic>>{},
   }) async {
     final payload = buildPayload(report);
     final route = _providerRouter.routeFor(
@@ -107,6 +124,7 @@ class AssetManagementAiSummaryService {
       final detailedPayload = buildAiDetailedPayload(
         report,
         previousAnalyses: previousAnalyses,
+        existingDeveloperIssuesByTitle: existingDeveloperIssuesByTitle,
       );
       final prompt = _buildPrompt(
         report: report,
@@ -135,15 +153,17 @@ class AssetManagementAiSummaryService {
       if (!_containsJapaneseText(response.text)) {
         throw const AiHubChatException('AI要約が日本語ではありませんでした');
       }
+      final proposals = extractAiDeveloperProposals(response.text);
       return AssetManagementAiSummaryResult(
         status: AssetManagementAiSummaryStatus.aiGenerated,
-        text: response.text.trim(),
+        text: proposals.displayText.trim(),
         source: response.source,
         errorMessage: null,
         generatedAt: _now(),
         payload: payload,
         providerRoute: route.toLogPayload(),
         providerChoiceReason: route.providerChoiceReason,
+        aiDeveloperRequests: proposals.requests,
       );
     } catch (error) {
       return AssetManagementAiSummaryResult(
@@ -195,6 +215,8 @@ class AssetManagementAiSummaryService {
     AssetManagementInsightReport report, {
     List<AssetManagementAiAnalysisHistoryEntry> previousAnalyses =
         const <AssetManagementAiAnalysisHistoryEntry>[],
+    Map<String, Map<String, dynamic>> existingDeveloperIssuesByTitle =
+        const <String, Map<String, dynamic>>{},
   }) {
     final workbook = report.workbook;
     return <String, dynamic>{
@@ -262,8 +284,17 @@ class AssetManagementAiSummaryService {
         'by_severity': _countBy(
           report.developerRequests.map((request) => request.severity.name),
         ),
+        'note': '定型生成の既知提案。already_issued=true は既にGitHub Issue起票済みで、'
+            'AIはこれらを繰り返さず未起票の新規提案だけを返す。',
         'items': report.developerRequests
-            .map(_developerRequestToJson)
+            .map(
+              (request) => _developerRequestToJson(request)
+                ..['already_issued'] =
+                    existingDeveloperIssuesByTitle.containsKey(request.title)
+                ..['existing_github_issue'] = _existingIssueSummary(
+                  existingDeveloperIssuesByTitle[request.title],
+                ),
+            )
             .toList(growable: false),
         'required_output_contract': const <String>[
           '現状の痛み',
@@ -425,8 +456,99 @@ class AssetManagementAiSummaryService {
       '出力ルール: FlutterのMarkdownプレビューで表示します。必ずGitHub Flavored Markdownで、## 見出し、- 箇条書き、**強調**を使ってください。見出し、箇条書き、ラベル、本文はすべて自然な日本語にし、英語の見出しや英語ラベルは使わないでください。プロフィールの生年月日、性別、職業、年収、住所、学歴、職歴、趣味、飲酒、喫煙、好きな食べ物を生活背景として引用し、口座名、残高、支払日、推定最低支払額、今月支払予定額、年利、月利息、元金返済見込み、負債割合と結びつけて具体的に助言してください。金額はDart計算値を正として扱い、追加計算は概算と明記してください。細木数子を彷彿とさせる、厳しめで愛情のある断言口調にしてください。曖昧にせず、今日・今週・今月にやることを具体的に言い切ってください。飢える、水だけで耐える、食事を抜くといった健康を害する提案はしないでください。食費、住居、医療、支払先への連絡、公的・地域の緊急支援を優先してください。',
       '履歴利用ルール: previous_ai_analyses がある場合は、前回までの指摘をただ繰り返さず、今回の金額・支払状況・未解決アクションとの差分を明示してください。前回から改善した点、悪化した点、まだ放置されている点を分けて、次に同じ分析をしたときに進捗確認できる言葉で書いてください。',
       '完結性ルール: 途中で切れないよう、各章は最大3〜5個の短い箇条書きに圧縮してください。必ず「8. 最後にズバッと総評」まで書き切り、最後の行を「以上。今日やることは、支払い確認、生活費確保、余剰支出停止。この3つよ。」で締めてください。長くなりそうな場合は、負債明細は利息負担の大きい上位5件と合計に絞ってください。',
-      '開発者向け改善提案の出力ルール: implementation_context と developer_requests を根拠にしてください。各提案は「現状の痛み」「根拠データ」「変更ファイル」「実装手順」「受け入れ条件」「テスト/確認コマンド」「リスク」を必ず含め、実装者がそのままGitHub Issueとして着手できる粒度にしてください。現実装にない機能を断言せず、推測は「追加調査」と明記してください。',
+      '開発者向け改善提案の出力ルール: implementation_context を読んで現状の機能を実際にレビューしてから提案してください。developer_requests は定型生成の既知提案一覧で、already_issued が true のものは既にGitHub Issue起票済みです。既知提案の再掲・言い換えは禁止し、まだ起票されていない新規の改善提案だけを最大3件返してください。各提案は「現状できること（機能レビュー）」「現状の痛み」「根拠データ」「変更ファイル」「実装手順」「受け入れ条件」「テスト/確認コマンド」「リスク」を必ず含め、実装者がそのままGitHub Issueとして着手できる粒度にしてください。現実装にない機能を断言せず、推測は「追加調査」と明記してください。',
+      '新規改善提案の機械可読出力ルール: 応答の最後に「```json ai-new-proposals」で始まり「```」で終わるコードブロックを1つだけ出力し、本文の「7. 開発者向け改善提案」と同じ新規提案を {"title","description","evidence":[],"implementation_steps":[],"acceptance_criteria":[],"source_references":[]} の配列として返してください。タイトルは既存Issueと区別できる具体的な日本語にしてください。新規提案がない場合は空配列 [] だけを出力してください。',
     ].join('\n');
+  }
+
+  static const String aiProposalsFenceHeader = '```json ai-new-proposals';
+
+  /// 応答末尾の機械可読ブロックを取り出し、表示用テキストからは取り除く。
+  /// ブロックが無い・JSONが壊れている場合は提案なしとして扱う。
+  static AssetManagementAiProposalExtraction extractAiDeveloperProposals(
+    String text,
+  ) {
+    final startIndex = text.indexOf(aiProposalsFenceHeader);
+    if (startIndex < 0) {
+      return AssetManagementAiProposalExtraction(
+        displayText: text,
+        requests: const <AssetManagementDeveloperRequest>[],
+      );
+    }
+    final bodyStart = startIndex + aiProposalsFenceHeader.length;
+    final closeIndex = text.indexOf('```', bodyStart);
+    final rawJson = closeIndex < 0
+        ? text.substring(bodyStart)
+        : text.substring(bodyStart, closeIndex);
+    final blockEnd = closeIndex < 0 ? text.length : closeIndex + 3;
+    final displayText =
+        (text.substring(0, startIndex) + text.substring(blockEnd)).trim();
+    return AssetManagementAiProposalExtraction(
+      displayText: displayText,
+      requests: _parseAiProposals(rawJson),
+    );
+  }
+
+  static List<AssetManagementDeveloperRequest> _parseAiProposals(
+    String rawJson,
+  ) {
+    try {
+      final decoded = jsonDecode(rawJson.trim());
+      if (decoded is! List) {
+        return const <AssetManagementDeveloperRequest>[];
+      }
+      final requests = <AssetManagementDeveloperRequest>[];
+      for (final item in decoded.take(3)) {
+        if (item is! Map) {
+          continue;
+        }
+        final title = item['title']?.toString().trim() ?? '';
+        final description = item['description']?.toString().trim() ?? '';
+        if (title.isEmpty || description.isEmpty) {
+          continue;
+        }
+        requests.add(
+          AssetManagementDeveloperRequest(
+            title: title,
+            description: description,
+            severity: AssetManagementInsightSeverity.info,
+            evidence: _stringListOf(item['evidence']),
+            implementationSteps: _stringListOf(item['implementation_steps']),
+            acceptanceCriteria: _stringListOf(item['acceptance_criteria']),
+            sourceReferences: _stringListOf(item['source_references']),
+          ),
+        );
+      }
+      return requests;
+    } catch (_) {
+      return const <AssetManagementDeveloperRequest>[];
+    }
+  }
+
+  static List<String> _stringListOf(Object? source) {
+    if (source is! List) {
+      return const <String>[];
+    }
+    final values = <String>[];
+    for (final item in source.take(6)) {
+      final value = item.toString().trim();
+      if (value.isNotEmpty) {
+        values.add(value);
+      }
+    }
+    return values;
+  }
+
+  Map<String, dynamic>? _existingIssueSummary(Map<String, dynamic>? issue) {
+    if (issue == null) {
+      return null;
+    }
+    return <String, dynamic>{
+      'number': issue['number'],
+      'state': issue['state'],
+      'title': issue['title'],
+      'html_url': issue['html_url'],
+    };
   }
 
   Future<AiHubChatResponse> _sendRoutedSummary({

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -411,7 +411,139 @@ void main() {
       expect(payload['emergency_advices'] is List<dynamic>, true);
       expect((payload['emergency_advices'] as List<dynamic>).isNotEmpty, true);
     });
+
+    test('annotates issued requests and demands novel proposals', () async {
+      final report = _reportWithDeveloperRequests();
+      expect(report.developerRequests, isNotEmpty);
+      final issuedTitle = report.developerRequests.first.title;
+
+      Map<String, dynamic>? capturedBody;
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            capturedBody = body;
+            return <String, dynamic>{
+              'success': true,
+              'text': 'AIが生成した日本語要約です。',
+              'provider': 'groq',
+            };
+          },
+        ),
+        now: () => DateTime(2026, 6, 12, 12),
+      );
+
+      await service.generateSummary(
+        report: report,
+        existingDeveloperIssuesByTitle: <String, Map<String, dynamic>>{
+          issuedTitle: <String, dynamic>{
+            'number': 3064,
+            'state': 'closed',
+            'title': issuedTitle,
+            'html_url': 'https://github.com/example/repo/issues/3064',
+          },
+        },
+      );
+
+      final message = capturedBody?['message'].toString() ?? '';
+      expect(message.contains('"already_issued":true'), true);
+      expect(message.contains('"number":3064'), true);
+      expect(message.contains('既にGitHub Issue起票済み'), true);
+      expect(message.contains('既知提案の再掲・言い換えは禁止'), true);
+      expect(message.contains('ai-new-proposals'), true);
+    });
+
+    test('extracts ai proposal block into issueable requests', () async {
+      final response = [
+        '## 7. 開発者向け改善提案',
+        '- 新規提案: 負債マスタの一括編集モード',
+        '',
+        '```json ai-new-proposals',
+        '[{"title":"負債マスタの一括編集モード",'
+            '"description":"請求確定待ちの負債をまとめて編集できるようにする。",'
+            '"evidence":["推定額の負債行: 2件"],'
+            '"implementation_steps":["一括編集UIを追加"],'
+            '"acceptance_criteria":["複数行を同時に保存できる"],'
+            '"source_references":["lib/pages/asset_management_page.dart"]}]',
+        '```',
+        '',
+        '## 8. 最後にズバッと総評',
+        '以上。',
+      ].join('\n');
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            return <String, dynamic>{
+              'success': true,
+              'text': response,
+              'provider': 'groq',
+            };
+          },
+        ),
+        now: () => DateTime(2026, 6, 12, 12),
+      );
+
+      final result = await service.generateSummary(report: _report());
+
+      expect(result.aiDeveloperRequests, hasLength(1));
+      final request = result.aiDeveloperRequests.single;
+      expect(request.title, '負債マスタの一括編集モード');
+      expect(request.acceptanceCriteria, contains('複数行を同時に保存できる'));
+      expect(
+        request.sourceReferences,
+        contains('lib/pages/asset_management_page.dart'),
+      );
+      expect(result.text.contains('ai-new-proposals'), false);
+      expect(result.text.contains('一括編集UIを追加'), false);
+      expect(result.text.contains('## 8. 最後にズバッと総評'), true);
+    });
+
+    test('drops broken ai proposal block safely', () async {
+      final response = [
+        '## 7. 開発者向け改善提案',
+        '提案本文です。',
+        '```json ai-new-proposals',
+        'これはJSONではありません',
+        '```',
+        '## 8. 最後にズバッと総評',
+        '以上。',
+      ].join('\n');
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            return <String, dynamic>{
+              'success': true,
+              'text': response,
+              'provider': 'groq',
+            };
+          },
+        ),
+        now: () => DateTime(2026, 6, 12, 12),
+      );
+
+      final result = await service.generateSummary(report: _report());
+
+      expect(result.aiDeveloperRequests, isEmpty);
+      expect(result.text.contains('ai-new-proposals'), false);
+      expect(result.text.contains('## 8. 最後にズバッと総評'), true);
+    });
   });
+}
+
+AssetManagementInsightReport _reportWithDeveloperRequests() {
+  const planner = AssetLiabilityPlanningService();
+  const insight = AssetManagementInsightService();
+  final workbook = planner.buildWorkbook(
+    latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},
+    baseDate: DateTime(2026, 6, 1),
+  );
+  return insight.buildReport(
+    workbook: workbook,
+    userProfile: _userProfile(),
+    minimumSafetyBalance: 10000,
+  );
 }
 
 AssetManagementInsightReport _report({DateTime? baseDate}) {


### PR DESCRIPTION
## 概要

「AIに投げるプロンプトを修正し、固定の提案ではなく、実際に機能をレビューしたうえで、Issuesとして起票されていない改善提案を返してほしい」というユーザー要望への対応（part 271 シリーズ第6弾）。

### 原因

従来のプロンプトは「developer_requests（定型生成テンプレート）を根拠にせよ」と指示していたため、AI は §7 でテンプレートをそのまま再掲していた。テンプレートは実装済み・起票済みでも出続ける（#3261 で判明した構造）。

### 変更内容

1. **プロンプト変更**: implementation_context（現実装のソース/ドキュメント文脈）を読んで現状機能をレビューすることを必須化。developer_requests は「既知提案一覧（already_issued 注釈付き）」として渡し、再掲・言い換えを禁止、**未起票の新規提案のみ最大3件**返すよう指示。推測は「追加調査」と明記させる
2. **既存Issue情報の伝達**: ページが保持する既存Issue照合結果（number/state/html_url）をタイトル単位でペイロードに注釈（`already_issued` / `existing_github_issue`）
3. **機械可読出力**: 応答末尾に ```json ai-new-proposals ブロックを要求し、パースして `AssetManagementDeveloperRequest` として既存の Issue 登録フローへ合流。**AI新規提案にも既存Issue照合（重複防止）と登録ボタンがそのまま適用**され、起票済みなら #3261 の既存Issueリンク表示になる
4. ブロックは表示テキストから除去。JSONが壊れていれば提案なしとして安全に無視（要約表示は維持）
5. AI新規提案カードに「AI新規提案（未起票のみ登録可）」チップ、リスト表示上限 4→6件

### 「未起票」の保証について

LLM はリポジトリ全Issueを把握できないため、最終的な未起票保証はプロンプトではなく**登録時の既存Issue照合（core-hub `feature_request.existing_issues`）**が担う2段構え。プロンプト側は既知の起票済み提案を明示して重複を減らす役割。

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. 起票済みテンプレートあり → プロンプトに already_issued=true と Issue 番号が注釈され、再掲禁止ルールが含まれる
  2. 応答に ai-new-proposals ブロックあり → パースされて登録可能な提案になり、表示テキストからブロックが消える
  3. ブロックのJSONが壊れている → 提案なし・要約表示は維持
- 上記3ケースはサービス層単体テスト（新規3件、対象ファイル15件 PASS）で検証済み
- E2E-Exception: 資産管理ページは認証済みユーザーのデータと ai-hub 応答前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。LLM実応答の品質（新規性）は本番反映後にAI要約を再生成して手動確認する。

## 検証

- `flutter test`（ai_summary 15件）: All tests passed
- `flutter analyze`: No issues found
- page の追加コードはスタイル非依存の書き方（メソッド抽出）。CI Format で最終確認（fail 時は ci-auto-fix → close/reopen で再走）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
