### PR TITLE
fix(asset): AI新規提案ブロックのパース許容化と既知タイトルの決定論的除外

### DIFF
--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -154,6 +154,15 @@ class AssetManagementAiSummaryService {
         throw const AiHubChatException('AI要約が日本語ではありませんでした');
       }
       final proposals = extractAiDeveloperProposals(response.text);
+      // LLMの再掲禁止は確率的にしか守られないため、既知テンプレート・
+      // 起票済みIssueと同名の提案は決定論的に除外する。
+      final knownTitles = <String>{
+        for (final request in report.developerRequests) request.title.trim(),
+        for (final title in existingDeveloperIssuesByTitle.keys) title.trim(),
+      };
+      final novelRequests = proposals.requests
+          .where((request) => !knownTitles.contains(request.title.trim()))
+          .toList(growable: false);
       return AssetManagementAiSummaryResult(
         status: AssetManagementAiSummaryStatus.aiGenerated,
         text: proposals.displayText.trim(),
@@ -163,7 +172,7 @@ class AssetManagementAiSummaryService {
         payload: payload,
         providerRoute: route.toLogPayload(),
         providerChoiceReason: route.providerChoiceReason,
-        aiDeveloperRequests: proposals.requests,
+        aiDeveloperRequests: novelRequests,
       );
     } catch (error) {
       return AssetManagementAiSummaryResult(
@@ -456,33 +465,52 @@ class AssetManagementAiSummaryService {
       '出力ルール: FlutterのMarkdownプレビューで表示します。必ずGitHub Flavored Markdownで、## 見出し、- 箇条書き、**強調**を使ってください。見出し、箇条書き、ラベル、本文はすべて自然な日本語にし、英語の見出しや英語ラベルは使わないでください。プロフィールの生年月日、性別、職業、年収、住所、学歴、職歴、趣味、飲酒、喫煙、好きな食べ物を生活背景として引用し、口座名、残高、支払日、推定最低支払額、今月支払予定額、年利、月利息、元金返済見込み、負債割合と結びつけて具体的に助言してください。金額はDart計算値を正として扱い、追加計算は概算と明記してください。細木数子を彷彿とさせる、厳しめで愛情のある断言口調にしてください。曖昧にせず、今日・今週・今月にやることを具体的に言い切ってください。飢える、水だけで耐える、食事を抜くといった健康を害する提案はしないでください。食費、住居、医療、支払先への連絡、公的・地域の緊急支援を優先してください。',
       '履歴利用ルール: previous_ai_analyses がある場合は、前回までの指摘をただ繰り返さず、今回の金額・支払状況・未解決アクションとの差分を明示してください。前回から改善した点、悪化した点、まだ放置されている点を分けて、次に同じ分析をしたときに進捗確認できる言葉で書いてください。',
       '完結性ルール: 途中で切れないよう、各章は最大3〜5個の短い箇条書きに圧縮してください。必ず「8. 最後にズバッと総評」まで書き切り、最後の行を「以上。今日やることは、支払い確認、生活費確保、余剰支出停止。この3つよ。」で締めてください。長くなりそうな場合は、負債明細は利息負担の大きい上位5件と合計に絞ってください。',
-      '開発者向け改善提案の出力ルール: implementation_context を読んで現状の機能を実際にレビューしてから提案してください。developer_requests は定型生成の既知提案一覧で、already_issued が true のものは既にGitHub Issue起票済みです。既知提案の再掲・言い換えは禁止し、まだ起票されていない新規の改善提案だけを最大3件返してください。各提案は「現状できること（機能レビュー）」「現状の痛み」「根拠データ」「変更ファイル」「実装手順」「受け入れ条件」「テスト/確認コマンド」「リスク」を必ず含め、実装者がそのままGitHub Issueとして着手できる粒度にしてください。現実装にない機能を断言せず、推測は「追加調査」と明記してください。',
-      '新規改善提案の機械可読出力ルール: 応答の最後に「```json ai-new-proposals」で始まり「```」で終わるコードブロックを1つだけ出力し、本文の「7. 開発者向け改善提案」と同じ新規提案を {"title","description","evidence":[],"implementation_steps":[],"acceptance_criteria":[],"source_references":[]} の配列として返してください。タイトルは既存Issueと区別できる具体的な日本語にしてください。新規提案がない場合は空配列 [] だけを出力してください。',
+      '開発者向け改善提案の出力ルール: implementation_context を読んで現状の機能を実際にレビューしてから提案してください。developer_requests は定型生成の既知提案一覧で、already_issued が true のものは既にGitHub Issue起票済みです。既知提案の再掲・言い換えは禁止し、items の title と同一または類似のタイトルも新規提案として出力しないでください。まだ起票されていない新規の改善提案だけを最大3件返してください。各提案は「現状できること（機能レビュー）」「現状の痛み」「根拠データ」「変更ファイル」「実装手順」「受け入れ条件」「テスト/確認コマンド」「リスク」を必ず含め、実装者がそのままGitHub Issueとして着手できる粒度にしてください。現実装にない機能を断言せず、推測は「追加調査」と明記してください。',
+      '新規改善提案の機械可読出力ルール: 応答の最後にコードブロックを1つだけ出力してください。コードブロックの開始行は必ず「```json ai-new-proposals」の1行とし、ai-new-proposals を次の行に分けないでください。中身は本文の「7. 開発者向け改善提案」と同じ新規提案を {"title","description","evidence":[],"implementation_steps":[],"acceptance_criteria":[],"source_references":[]} の配列で返し、evidence・implementation_steps・acceptance_criteria・source_references も本文と同じ内容で必ず埋めてください。タイトルは既存Issueと区別できる具体的な日本語にしてください。新規提案がない場合は空配列 [] だけを出力してください。',
     ].join('\n');
   }
 
+  static const String aiProposalsMarker = 'ai-new-proposals';
   static const String aiProposalsFenceHeader = '```json ai-new-proposals';
 
   /// 応答末尾の機械可読ブロックを取り出し、表示用テキストからは取り除く。
+  /// LLMはマーカーをフェンスと同じ行に書かないことがあるため、
+  /// 「```json」または「```」の直後にマーカーが続く変形も受け付ける。
   /// ブロックが無い・JSONが壊れている場合は提案なしとして扱う。
   static AssetManagementAiProposalExtraction extractAiDeveloperProposals(
     String text,
   ) {
-    final startIndex = text.indexOf(aiProposalsFenceHeader);
-    if (startIndex < 0) {
+    final markerIndex = text.lastIndexOf(aiProposalsMarker);
+    if (markerIndex < 0) {
       return AssetManagementAiProposalExtraction(
         displayText: text,
         requests: const <AssetManagementDeveloperRequest>[],
       );
     }
-    final bodyStart = startIndex + aiProposalsFenceHeader.length;
+    final fenceStart = text.lastIndexOf('```', markerIndex);
+    if (fenceStart < 0) {
+      return AssetManagementAiProposalExtraction(
+        displayText: text,
+        requests: const <AssetManagementDeveloperRequest>[],
+      );
+    }
+    final betweenFenceAndMarker =
+        text.substring(fenceStart + 3, markerIndex).trim();
+    if (betweenFenceAndMarker.isNotEmpty && betweenFenceAndMarker != 'json') {
+      // マーカーが本文中の言及で、機械可読ブロックではないケース。
+      return AssetManagementAiProposalExtraction(
+        displayText: text,
+        requests: const <AssetManagementDeveloperRequest>[],
+      );
+    }
+    final bodyStart = markerIndex + aiProposalsMarker.length;
     final closeIndex = text.indexOf('```', bodyStart);
     final rawJson = closeIndex < 0
         ? text.substring(bodyStart)
         : text.substring(bodyStart, closeIndex);
     final blockEnd = closeIndex < 0 ? text.length : closeIndex + 3;
     final displayText =
-        (text.substring(0, startIndex) + text.substring(blockEnd)).trim();
+        (text.substring(0, fenceStart) + text.substring(blockEnd)).trim();
     return AssetManagementAiProposalExtraction(
       displayText: displayText,
       requests: _parseAiProposals(rawJson),

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -529,6 +529,103 @@ void main() {
       expect(result.text.contains('ai-new-proposals'), false);
       expect(result.text.contains('## 8. 最後にズバッと総評'), true);
     });
+
+    test('parses marker on the line after the fence', () async {
+      final response = [
+        '## 7. 開発者向け改善提案',
+        '- 新規提案: サンプル',
+        '',
+        '```json',
+        'ai-new-proposals',
+        '[{"title":"サンプル新規提案","description":"説明です。"}]',
+        '```',
+        '',
+        '## 8. 最後にズバッと総評',
+        '以上。',
+      ].join('\n');
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            return <String, dynamic>{
+              'success': true,
+              'text': response,
+              'provider': 'groq',
+            };
+          },
+        ),
+        now: () => DateTime(2026, 6, 12, 12),
+      );
+
+      final result = await service.generateSummary(report: _report());
+
+      expect(result.aiDeveloperRequests, hasLength(1));
+      expect(result.aiDeveloperRequests.single.title, 'サンプル新規提案');
+      expect(result.text.contains('ai-new-proposals'), false);
+      expect(result.text.contains('```json'), false);
+      expect(result.text.contains('## 8. 最後にズバッと総評'), true);
+    });
+
+    test('filters proposals that repeat known template titles', () async {
+      final report = _reportWithDeveloperRequests();
+      expect(report.developerRequests, isNotEmpty);
+      final knownTitle = report.developerRequests.first.title;
+      final response = [
+        '## 7. 開発者向け改善提案',
+        '提案本文です。',
+        '```json ai-new-proposals',
+        '[{"title":"$knownTitle","description":"既知提案の再掲です。"},'
+            '{"title":"全く新しい改善提案","description":"新規の提案です。"}]',
+        '```',
+        '## 8. 最後にズバッと総評',
+        '以上。',
+      ].join('\n');
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            return <String, dynamic>{
+              'success': true,
+              'text': response,
+              'provider': 'groq',
+            };
+          },
+        ),
+        now: () => DateTime(2026, 6, 12, 12),
+      );
+
+      final result = await service.generateSummary(report: report);
+
+      expect(result.aiDeveloperRequests, hasLength(1));
+      expect(result.aiDeveloperRequests.single.title, '全く新しい改善提案');
+    });
+
+    test('ignores prose mention of the marker without a block', () async {
+      final response = [
+        '## 7. 開発者向け改善提案',
+        '今回は ai-new-proposals に該当する新規提案はありません。',
+        '## 8. 最後にズバッと総評',
+        '以上。',
+      ].join('\n');
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        chatService: AiHubChatService(
+          invoker: (body) async {
+            return <String, dynamic>{
+              'success': true,
+              'text': response,
+              'provider': 'groq',
+            };
+          },
+        ),
+        now: () => DateTime(2026, 6, 12, 12),
+      );
+
+      final result = await service.generateSummary(report: _report());
+
+      expect(result.aiDeveloperRequests, isEmpty);
+      expect(result.text, response);
+    });
   });
 }
 


### PR DESCRIPTION
## 概要

PR #3264（AI改善提案の未起票新規生成）の本番初回生成で確認された2つの実害への追従修正（part 271 シリーズ第7弾）。

### 本番初回生成で観測された問題

1. **JSONブロックが画面に生表示**: LLM が `ai-new-proposals` マーカーをフェンス開始行ではなく**次の行**に出力（` ```json` ↵ `ai-new-proposals` ↵ `[...]`）。`'```json ai-new-proposals'` の完全一致でパースしていたため、除去もパースもされず利用者に生のJSONが見えた
2. **起票済み提案の再掲**: already_issued 注釈と再掲禁止指示にもかかわらず「口座間移動タスク管理」（#2452 起票済み）が新規提案として返された — LLM の指示遵守は確率的

### 変更内容

1. **パーサ許容化**: マーカー位置を起点に直前のフェンスを探索し、`「```json」`/`「```」` 直後にマーカーが続く変形も受理。フェンスを伴わない本文中の言及のみは機械可読ブロックとして扱わない
2. **決定論的除外**: パース後、既知テンプレート（developer_requests）・起票済みIssueと同名タイトルの提案を service 層で除外（プロンプト遵守に依存しない2層目）
3. **プロンプト強化**: フェンス開始行の厳密指定（マーカーを次の行に分けない）、配列フィールド（evidence 等）の記入必須化、既知 title と同一・類似タイトルの出力禁止

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. マーカーがフェンスの次の行にある応答（本番で観測された変形）→ パースされ、表示テキストからブロックが消える
  2. 既知テンプレートと同名の提案を含む応答 → 同名分だけ除外され新規のみ残る
  3. 本文中にマーカーの言及だけがある応答 → ブロック扱いせず本文を変更しない
- 上記3ケースはサービス層単体テスト（新規3件、対象ファイル計18件 PASS）で検証済み
- E2E-Exception: 資産管理ページは認証済みユーザーのデータと ai-hub 応答前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。修正は service 層のみで UI 変更なし。本番反映後に AI 要約を再生成してブロック非表示を手動確認する。

## 検証

- `flutter test`（ai_summary 18件）: All tests passed
- `dart analyze`: No issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
