### PR TITLE
feat(asset): pump検証拡充 + 表示設定ミラー + 最小移動セット + 2色バー (part 279)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -7323,6 +7323,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _loadDisplayMode() async {
     final mode = await _displayModeStore.load();
     final overrides = await _displayModeStore.loadOverrides();
+    final hadStored = await _displayModeStore.hasStoredMode();
     if (!mounted) {
       return;
     }
@@ -7331,6 +7332,110 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _sectionOverrides = overrides;
     });
     unawaited(_refreshDisplayModeStats());
+    if (!hadStored && overrides.isEmpty) {
+      unawaited(_restoreDisplayPrefsFromMirror());
+    }
+  }
+
+  Future<void> _mirrorDisplayPrefs() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final now = DateTime.now().toUtc().toIso8601String();
+      await _supabase.from('asset_pref_mirror').upsert(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'user_id': userId,
+          'pref_key': 'display_mode',
+          'value': <String, dynamic>{'mode': _displayMode.storageId},
+          'updated_at': now,
+        },
+        <String, dynamic>{
+          'user_id': userId,
+          'pref_key': 'section_overrides',
+          'value': <String, String>{
+            for (final entry in _sectionOverrides.entries)
+              entry.key.storageId: entry.value.storageId,
+          },
+          'updated_at': now,
+        },
+      ]);
+    } catch (e) {
+      debugPrint('display pref mirror upsert failed: $e');
+    }
+  }
+
+  Future<void> _restoreDisplayPrefsFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .inFilter('pref_key', <String>['display_mode', 'section_overrides']);
+      if (rows.isEmpty || !mounted) {
+        return;
+      }
+      var restoredAny = false;
+      for (final row in rows) {
+        final value = row['value'];
+        if (value is! Map) {
+          continue;
+        }
+        if (row['pref_key'] == 'display_mode') {
+          final raw = value['mode']?.toString();
+          for (final mode in AssetManagementDisplayMode.values) {
+            if (mode.storageId == raw && mode != _displayMode) {
+              setState(() {
+                _displayMode = mode;
+              });
+              await _displayModeStore.save(mode, recordEvent: false);
+              restoredAny = true;
+            }
+          }
+        }
+        if (row['pref_key'] == 'section_overrides') {
+          for (final entry in value.entries) {
+            AssetManagementSectionId? section;
+            for (final candidate in AssetManagementSectionId.values) {
+              if (candidate.storageId == entry.key.toString()) {
+                section = candidate;
+              }
+            }
+            AssetManagementSectionVisibilityOverride? override;
+            for (final candidate
+                in AssetManagementSectionVisibilityOverride.values) {
+              if (candidate.storageId == entry.value.toString()) {
+                override = candidate;
+              }
+            }
+            if (section == null ||
+                override == null ||
+                override == AssetManagementSectionVisibilityOverride.auto) {
+              continue;
+            }
+            final overrides =
+                await _displayModeStore.saveOverride(section, override);
+            if (!mounted) {
+              return;
+            }
+            setState(() {
+              _sectionOverrides = overrides;
+            });
+            restoredAny = true;
+          }
+        }
+      }
+      if (restoredAny && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('表示設定をサーバのバックアップから復元しました')),
+        );
+      }
+    } catch (e) {
+      debugPrint('display pref mirror restore failed: $e');
+    }
   }
 
   Future<void> _refreshDisplayModeStats() async {
@@ -7627,6 +7732,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     });
     await _displayModeStore.save(mode);
     unawaited(_sendDisplayModeEvent(eventType: 'switch', mode: mode));
+    unawaited(_mirrorDisplayPrefs());
     await _refreshDisplayModeStats();
   }
 
@@ -7669,6 +7775,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     setState(() {
       _sectionOverrides = overrides;
     });
+    unawaited(_mirrorDisplayPrefs());
   }
 
   Future<void> _fetchExperimentSummary() async {
@@ -7966,7 +8073,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
-  String? _comboShiftPreviewLabel({
+  bool _shiftedMonthClears({
     required List<String> ids,
     required List<AssetCalendarDebtInput> debts,
     required List<Map<String, dynamic>> subscriptions,
@@ -7996,16 +8103,62 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       startingCashBalance: startingCashBalance,
       expectedInflows: inflows,
     );
-    return shifted.firstShortfallDate == null ? '(回避できます)' : null;
+    return shifted.firstShortfallDate == null;
+  }
+
+  /// ショート回避に必要な最小の移動セット(サイズ昇順で探索)。
+  /// 候補が7件以上の場合は組合せ爆発を避け全件移動のみ試す。
+  List<String>? _findMinimalShiftSet({
+    required List<String> ids,
+    required List<AssetCalendarDebtInput> debts,
+    required List<Map<String, dynamic>> subscriptions,
+    required List<AssetCalendarInflowInput> inflows,
+    required double? startingCashBalance,
+  }) {
+    bool clears(List<String> subset) => _shiftedMonthClears(
+          ids: subset,
+          debts: debts,
+          subscriptions: subscriptions,
+          inflows: inflows,
+          startingCashBalance: startingCashBalance,
+        );
+
+    if (ids.length > 6) {
+      return clears(ids) ? List<String>.from(ids) : null;
+    }
+    final maskLimit = 1 << ids.length;
+    for (var size = 2; size <= ids.length; size++) {
+      for (var mask = 1; mask < maskLimit; mask++) {
+        var bits = 0;
+        for (var i = 0; i < ids.length; i++) {
+          final bit = 1 << i;
+          if (mask & bit != 0) {
+            bits += 1;
+          }
+        }
+        if (bits != size) {
+          continue;
+        }
+        final subset = <String>[
+          for (var i = 0; i < ids.length; i++)
+            if (mask & 1 << i != 0) ids[i],
+        ];
+        if (clears(subset)) {
+          return subset;
+        }
+      }
+    }
+    return null;
   }
 
   Widget _buildExperimentTrendBars() {
     final weeks = _experimentWeekly.reversed.toList(growable: false);
-    var maxInitials = 1;
+    var maxTotal = 1;
     for (final week in weeks) {
       final initials = (week['initials'] as num?)?.toInt() ?? 0;
-      if (initials > maxInitials) {
-        maxInitials = initials;
+      final switches = (week['switches'] as num?)?.toInt() ?? 0;
+      if (initials + switches > maxTotal) {
+        maxTotal = initials + switches;
       }
     }
     return SizedBox(
@@ -8021,14 +8174,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     Text(
-                      '${(week['initials'] as num?)?.toInt() ?? 0}',
+                      '${(week['initials'] as num?)?.toInt() ?? 0}/${(week['switches'] as num?)?.toInt() ?? 0}',
                       style: const TextStyle(fontSize: 8, height: 1.2),
                     ),
                     Container(
-                      height: 4 +
-                          36 *
+                      height: 2 +
+                          30 *
+                              ((week['switches'] as num?)?.toInt() ?? 0) /
+                              maxTotal,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF97316),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 1),
+                    Container(
+                      height: 2 +
+                          30 *
                               ((week['initials'] as num?)?.toInt() ?? 0) /
-                              maxInitials,
+                              maxTotal,
                       decoration: BoxDecoration(
                         color: const Color(0xFF6366F1),
                         borderRadius: BorderRadius.circular(2),
@@ -8191,6 +8355,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   if (_experimentWeekly.isNotEmpty) ...[
                     const SizedBox(height: 4),
                     _buildExperimentTrendBars(),
+                    const SizedBox(height: 2),
+                    Wrap(
+                      spacing: 10,
+                      children: [
+                        _buildCalendarLegendItem(
+                          const Color(0xFF6366F1),
+                          '初期解決',
+                        ),
+                        _buildCalendarLegendItem(
+                          const Color(0xFFF97316),
+                          '切替',
+                        ),
+                      ],
+                    ),
                   ],
                   const SizedBox(height: 6),
                   Text(
@@ -8397,11 +8575,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       for (final event in shortfallDebtEvents)
         if (event.sourceId != null) event.sourceId!,
     ];
-    final comboPreview = comboIds.length >= 2 &&
+    final comboSuggestionIds = comboIds.length >= 2 &&
             shiftCandidates.every(
               (entry) => entry.value == '(単独では回避不可)',
             )
-        ? _comboShiftPreviewLabel(
+        ? _findMinimalShiftSet(
             ids: comboIds,
             debts: debtInputs,
             subscriptions: monthSubscriptions,
@@ -8409,6 +8587,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             startingCashBalance: startingCashBalance,
           )
         : null;
+    final comboSuggestionLabel = comboSuggestionIds == null
+        ? null
+        : shortfallDebtEvents
+            .where((event) => comboSuggestionIds.contains(event.sourceId))
+            .map((event) => event.label)
+            .join(' + ');
     const weekdayLabels = ['日', '月', '火', '水', '木', '金', '土'];
 
     return Card(
@@ -8584,17 +8768,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         ],
                       ),
                     ],
-                    if (comboPreview != null) ...[
+                    if (comboSuggestionIds != null) ...[
                       const SizedBox(height: 6),
                       OutlinedButton.icon(
                         key: const Key('asset_shift_payment_combo'),
                         onPressed: () => _shiftDebtPaymentsAfterSalaryCombo(
                           workbook,
-                          comboIds,
+                          comboSuggestionIds,
                         ),
                         icon: const Icon(Icons.double_arrow, size: 14),
                         label: Text(
-                          'まとめて26日へ移動$comboPreview',
+                          '$comboSuggestionLabelを26日へ(回避できます)',
                           style: const TextStyle(fontSize: 11),
                         ),
                       ),

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -223,12 +223,18 @@ class AssetManagementDisplayModeStore {
     return _storedMode(store) != null;
   }
 
+  /// [recordEvent] を false にするとミラー復元などの非ユーザー操作を
+  /// 実験ログ (switch 回数) に混入させずに保存できる。
   Future<void> save(
     AssetManagementDisplayMode mode, {
     SharedPreferences? prefs,
+    bool recordEvent = true,
   }) async {
     final store = prefs ?? await SharedPreferences.getInstance();
     await store.setString(_modeKey, mode.storageId);
+    if (!recordEvent) {
+      return;
+    }
     await _appendEvent(store, <String, dynamic>{
       'type': 'switch',
       'to': mode.storageId,

--- a/test/services/asset_management_display_mode_store_test.dart
+++ b/test/services/asset_management_display_mode_store_test.dart
@@ -212,5 +212,18 @@ void main() {
       await store.save(AssetManagementDisplayMode.full);
       expect(await store.hasStoredMode(), isTrue);
     });
+
+    test('save with recordEvent false keeps experiment stats untouched',
+        () async {
+      final store = AssetManagementDisplayModeStore(
+        nowProvider: () => DateTime(2026, 6, 12, 10, 0),
+      );
+
+      await store.save(AssetManagementDisplayMode.minimum, recordEvent: false);
+
+      final stats = await store.loadStats();
+      expect(stats.switchCount, 0);
+      expect(await store.load(), AssetManagementDisplayMode.minimum);
+    });
   });
 }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
@@ -101,6 +103,91 @@ void main() {
         find.byKey(const Key('asset_calendar_prefill_flow_button')),
         findsOneWidget,
       );
+
+      await _unmount(tester);
+    });
+
+    testWidgets('starts in stored minimum mode', (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_management_display_mode_v1': 'minimum',
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.textContaining('最重要のみ'), findsWidgets);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('seeded inflows surface as chips and managed rules', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      final monthKey = '${now.year}${now.month.toString().padLeft(2, '0')}';
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflows_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'seeded_one',
+            'date': DateTime(now.year, now.month, 10).toUtc().toIso8601String(),
+            'amount': 5000,
+            'label': '臨時収入',
+          },
+        ]),
+        'asset_expected_inflow_rules_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'seeded_rule',
+            'day_of_month': 25,
+            'amount': 280000,
+            'label': '給料',
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_inflow_chip_seeded_one')),
+      );
+      expect(
+        find.byKey(const Key('asset_inflow_chip_seeded_one')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(Key('asset_inflow_chip_rule_seeded_rule_$monthKey')),
+        findsOneWidget,
+      );
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_inflow_rules_button')),
+      );
+      await tester.tap(find.byKey(const Key('asset_inflow_rules_button')));
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.textContaining('毎月25日 給料'), findsOneWidget);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('hidden override removes an essential section', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_management_section_overrides_v1': jsonEncode(
+          <String, String>{'calendar': 'hidden'},
+        ),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.byKey(const Key('asset_calendar_prev_month')), findsNothing);
 
       await _unmount(tester);
     });


### PR DESCRIPTION
## 概要

1. **widget pump 検証の拡充(+3 → 計6本)** — SharedPreferences シード注入で (a) 保存済み「ミニマム」での起動 (b) シードした入金予定(単発+毎月ルール)がカレンダーチップとルール管理ダイアログに反映 (c) `hidden` 上書きで essential セクションが消える、を black-box 検証。※ショート警告の pump は口座スナップショットが Supabase フェッチ由来のため注入経路が未整備 — 調査結果付きで別 Issue 化。
2. **表示モード・pin/hide のサーバミラー同梱** — 既存 `asset_pref_mirror`(part 278)へ `display_mode` / `section_overrides` キーで保存時ミラー+未設定端末での復元。復元時は `save(recordEvent: false)` で**実験ログ(切替回数)を汚染しない**。
3. **組合せ移動の最小セット探索** — 全件一括から、サイズ昇順の部分集合探索へ。「**AローンとBカードを26日へ(回避できます)**」のように必要最小限だけ提案(7件超は組合せ爆発ガードで全件のみ)。
4. **トレンドバーの2色スタック化** — 週次バーを 初期解決(藍)+切替(橙)の積み上げ+凡例付きへ。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) シード入金予定→チップ/ルール管理ダイアログ表示 (2) hidden 上書き→essential 非表示 (3) recordEvent:false 保存が統計に乗らない。既存分含め計 38 ケース(widget 6 + service 32)。
- E2E例外: 変更はクライアント表示層とローカル保存+既存ミラーテーブルへの読み書きのみ(スキーマ・Edge Function 変更なし)。widget pump 検証を本PRで拡充済みのため、エンドツーエンド(integration_test)追加は行わず既存 Playwright 本番 smoke で補完する。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `flutter test` **38/38 PASS**。

## High-risk gate

- High-risk-ultrareview-exception: サーバ変更なし(既存 asset_pref_mirror への键追加のみ、スキーマ・認証・課金・Edge Function 不変)。payment 語は支払日表示設定の文脈で、決済処理への変更はない。レビュー所有者: Claude Code #1。
- 自己点検メモ: security = 既存 RLS(本人 for all)の範囲内 / rollback = クライアント revert のみで完結 / data migration = なし / prod smoke = 本PRの smoke green + widget 6本 / observability = ミラー失敗は debugPrint+ローカル継続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
