### PR TITLE
fix(asset): AI改善提案の本文再掲を遮断 — echo材料の削除と照合完了待ち

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -13661,6 +13661,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (!mounted || _assetManagementAiSummaryInFlightKey != key) {
       return;
     }
+    // 初回自動生成が既存Issue照合より先に走ると already_issued が
+    // 空のままAIへ渡り再掲抑止が効かないため、照合完了を待つ。
+    await _ensureExistingDeveloperIssuesLoaded(report.developerRequests);
+    if (!mounted || _assetManagementAiSummaryInFlightKey != key) {
+      return;
+    }
     final existingIssuesByTitle = <String, Map<String, dynamic>>{};
     for (final request in report.developerRequests) {
       final existing = _developerRequestExistingIssueResults[
@@ -13755,6 +13761,27 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _loadExistingDeveloperIssues(lookupKey: lookupKey, requests: payload),
       );
     });
+  }
+
+  /// 既存Issue照合の完了を待つ。未取得・取得中の場合はその場で照合を実行する。
+  /// AI要約生成前に already_issued 注釈を確実に揃えるために使う。
+  Future<void> _ensureExistingDeveloperIssuesLoaded(
+    List<AssetManagementDeveloperRequest> requests,
+  ) async {
+    if (_supabase.auth.currentUser == null || requests.isEmpty) {
+      return;
+    }
+    final payload = requests
+        .map(_developerRequestExistingIssuePayload)
+        .toList(growable: false);
+    final lookupKey = jsonEncode(payload);
+    if (_developerRequestExistingIssueLookupKey == lookupKey &&
+        !_isCheckingExistingDeveloperRequestIssues) {
+      return;
+    }
+    _developerRequestExistingIssueLookupKey = lookupKey;
+    _isCheckingExistingDeveloperRequestIssues = true;
+    await _loadExistingDeveloperIssues(lookupKey: lookupKey, requests: payload);
   }
 
   Map<String, String> _developerRequestExistingIssuePayload(

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -296,27 +296,25 @@ class AssetManagementAiSummaryService {
         ),
         'note': '定型生成の既知提案。already_issued=true は既にGitHub Issue起票済みで、'
             'AIはこれらを繰り返さず未起票の新規提案だけを返す。',
-        'items': report.developerRequests
-            .map(
-              (request) {
-                final existingIssue = _existingIssueSummary(
-                  existingDeveloperIssuesByTitle[request.title],
-                );
-                if (existingIssue != null) {
-                  // 起票済み提案は echo の材料にならないよう本文を渡さない。
-                  return <String, dynamic>{
-                    'title': request.title,
-                    'already_issued': true,
-                    'existing_github_issue': existingIssue,
-                    'note': '起票済み。本文・JSONブロックとも再掲禁止。',
-                  };
-                }
-                return _developerRequestToJson(request)
-                  ..['already_issued'] = false
-                  ..['existing_github_issue'] = null;
-              },
-            )
-            .toList(growable: false),
+        'items': report.developerRequests.map(
+          (request) {
+            final existingIssue = _existingIssueSummary(
+              existingDeveloperIssuesByTitle[request.title],
+            );
+            if (existingIssue != null) {
+              // 起票済み提案は echo の材料にならないよう本文を渡さない。
+              return <String, dynamic>{
+                'title': request.title,
+                'already_issued': true,
+                'existing_github_issue': existingIssue,
+                'note': '起票済み。本文・JSONブロックとも再掲禁止。',
+              };
+            }
+            return _developerRequestToJson(request)
+              ..['already_issued'] = false
+              ..['existing_github_issue'] = null;
+          },
+        ).toList(growable: false),
         'required_output_contract': const <String>[
           '現状の痛み',
           '根拠データ',

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -130,6 +130,7 @@ class AssetManagementAiSummaryService {
         report: report,
         payload: detailedPayload,
         previousAnalyses: previousAnalyses,
+        existingDeveloperIssuesByTitle: existingDeveloperIssuesByTitle,
       );
       final response = route.routingEnabled
           ? await _sendRoutedSummary(prompt: prompt, route: route)
@@ -297,12 +298,23 @@ class AssetManagementAiSummaryService {
             'AIはこれらを繰り返さず未起票の新規提案だけを返す。',
         'items': report.developerRequests
             .map(
-              (request) => _developerRequestToJson(request)
-                ..['already_issued'] =
-                    existingDeveloperIssuesByTitle.containsKey(request.title)
-                ..['existing_github_issue'] = _existingIssueSummary(
+              (request) {
+                final existingIssue = _existingIssueSummary(
                   existingDeveloperIssuesByTitle[request.title],
-                ),
+                );
+                if (existingIssue != null) {
+                  // 起票済み提案は echo の材料にならないよう本文を渡さない。
+                  return <String, dynamic>{
+                    'title': request.title,
+                    'already_issued': true,
+                    'existing_github_issue': existingIssue,
+                    'note': '起票済み。本文・JSONブロックとも再掲禁止。',
+                  };
+                }
+                return _developerRequestToJson(request)
+                  ..['already_issued'] = false
+                  ..['existing_github_issue'] = null;
+              },
             )
             .toList(growable: false),
         'required_output_contract': const <String>[
@@ -450,9 +462,14 @@ class AssetManagementAiSummaryService {
     required Map<String, dynamic> payload,
     List<AssetManagementAiAnalysisHistoryEntry> previousAnalyses =
         const <AssetManagementAiAnalysisHistoryEntry>[],
+    Map<String, Map<String, dynamic>> existingDeveloperIssuesByTitle =
+        const <String, Map<String, dynamic>>{},
   }) {
     return [
-      _promptBuilder.buildDetailedAdvicePrompt(report),
+      _promptBuilder.buildDetailedAdvicePrompt(
+        report,
+        existingDeveloperIssuesByTitle: existingDeveloperIssuesByTitle,
+      ),
       '',
       '## AIに渡す詳細ペイロード',
       jsonEncode(payload),
@@ -465,7 +482,7 @@ class AssetManagementAiSummaryService {
       '出力ルール: FlutterのMarkdownプレビューで表示します。必ずGitHub Flavored Markdownで、## 見出し、- 箇条書き、**強調**を使ってください。見出し、箇条書き、ラベル、本文はすべて自然な日本語にし、英語の見出しや英語ラベルは使わないでください。プロフィールの生年月日、性別、職業、年収、住所、学歴、職歴、趣味、飲酒、喫煙、好きな食べ物を生活背景として引用し、口座名、残高、支払日、推定最低支払額、今月支払予定額、年利、月利息、元金返済見込み、負債割合と結びつけて具体的に助言してください。金額はDart計算値を正として扱い、追加計算は概算と明記してください。細木数子を彷彿とさせる、厳しめで愛情のある断言口調にしてください。曖昧にせず、今日・今週・今月にやることを具体的に言い切ってください。飢える、水だけで耐える、食事を抜くといった健康を害する提案はしないでください。食費、住居、医療、支払先への連絡、公的・地域の緊急支援を優先してください。',
       '履歴利用ルール: previous_ai_analyses がある場合は、前回までの指摘をただ繰り返さず、今回の金額・支払状況・未解決アクションとの差分を明示してください。前回から改善した点、悪化した点、まだ放置されている点を分けて、次に同じ分析をしたときに進捗確認できる言葉で書いてください。',
       '完結性ルール: 途中で切れないよう、各章は最大3〜5個の短い箇条書きに圧縮してください。必ず「8. 最後にズバッと総評」まで書き切り、最後の行を「以上。今日やることは、支払い確認、生活費確保、余剰支出停止。この3つよ。」で締めてください。長くなりそうな場合は、負債明細は利息負担の大きい上位5件と合計に絞ってください。',
-      '開発者向け改善提案の出力ルール: implementation_context を読んで現状の機能を実際にレビューしてから提案してください。developer_requests は定型生成の既知提案一覧で、already_issued が true のものは既にGitHub Issue起票済みです。既知提案の再掲・言い換えは禁止し、items の title と同一または類似のタイトルも新規提案として出力しないでください。まだ起票されていない新規の改善提案だけを最大3件返してください。各提案は「現状できること（機能レビュー）」「現状の痛み」「根拠データ」「変更ファイル」「実装手順」「受け入れ条件」「テスト/確認コマンド」「リスク」を必ず含め、実装者がそのままGitHub Issueとして着手できる粒度にしてください。現実装にない機能を断言せず、推測は「追加調査」と明記してください。',
+      '開発者向け改善提案の出力ルール: implementation_context を読んで現状の機能を実際にレビューしてから提案してください。developer_requests は定型生成の既知提案一覧で、already_issued が true のものは既にGitHub Issue起票済みです。本文の「7. 開発者向け改善提案」にも既知提案・起票済み提案やその言い換えを書かないでください。items の title と同一または類似のタイトルは本文にもJSONにも出力禁止です。まだ起票されていない新規の改善提案だけを最大3件返し、新規提案が1件も無い場合は本文には「新規提案なし（既知の提案はすべて起票済みです）」と1行だけ書いてください。各提案は「現状できること（機能レビュー）」「現状の痛み」「根拠データ」「変更ファイル」「実装手順」「受け入れ条件」「テスト/確認コマンド」「リスク」を必ず含め、実装者がそのままGitHub Issueとして着手できる粒度にしてください。現実装にない機能を断言せず、推測は「追加調査」と明記してください。',
       '新規改善提案の機械可読出力ルール: 応答の最後にコードブロックを1つだけ出力してください。コードブロックの開始行は必ず「```json ai-new-proposals」の1行とし、ai-new-proposals を次の行に分けないでください。中身は本文の「7. 開発者向け改善提案」と同じ新規提案を {"title","description","evidence":[],"implementation_steps":[],"acceptance_criteria":[],"source_references":[]} の配列で返し、evidence・implementation_steps・acceptance_criteria・source_references も本文と同じ内容で必ず埋めてください。タイトルは既存Issueと区別できる具体的な日本語にしてください。新規提案がない場合は空配列 [] だけを出力してください。',
     ].join('\n');
   }

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -1119,7 +1119,11 @@ class AssetManagementInsightPromptBuilder {
     return buildDetailedAdvicePrompt(report);
   }
 
-  String buildDetailedAdvicePrompt(AssetManagementInsightReport report) {
+  String buildDetailedAdvicePrompt(
+    AssetManagementInsightReport report, {
+    Map<String, Map<String, dynamic>> existingDeveloperIssuesByTitle =
+        const <String, Map<String, dynamic>>{},
+  }) {
     final severityCounts = _countBy(
       report.actionItems.map((item) => item.severity.name),
     );
@@ -1234,7 +1238,12 @@ class AssetManagementInsightPromptBuilder {
       ..writeln('## 開発者向け改善提案候補')
       ..writeln('- 合計: ${report.developerRequests.length}')
       ..writeln('- 重要度別: ${_formatCounts(developerCounts)}')
-      ..write(_developerRequestLines(report.developerRequests));
+      ..write(
+        _developerRequestLines(
+          report.developerRequests,
+          existingDeveloperIssuesByTitle: existingDeveloperIssuesByTitle,
+        ),
+      );
     return buffer.toString();
   }
 
@@ -1511,13 +1520,25 @@ class AssetManagementInsightPromptBuilder {
   }
 
   String _developerRequestLines(
-    List<AssetManagementDeveloperRequest> requests,
-  ) {
+    List<AssetManagementDeveloperRequest> requests, {
+    Map<String, Map<String, dynamic>> existingDeveloperIssuesByTitle =
+        const <String, Map<String, dynamic>>{},
+  }) {
     if (requests.isEmpty) {
       return '- 開発者向け改善提案候補はありません。\n';
     }
     final buffer = StringBuffer();
     for (final request in requests) {
+      final existingIssue = existingDeveloperIssuesByTitle[request.title];
+      if (existingIssue != null) {
+        // 起票済み候補は echo の材料を渡さず、再掲禁止だけ伝える。
+        buffer.writeln(
+          '- ${request.title}'
+          '（起票済み GitHub Issue #${existingIssue['number'] ?? '-'}。'
+          '本文・JSONとも再掲禁止）',
+        );
+        continue;
+      }
       buffer
         ..writeln('- ${request.title}')
         ..writeln('  - 重要度: ${request.severity.name}')

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -449,8 +449,19 @@ void main() {
       expect(message.contains('"already_issued":true'), true);
       expect(message.contains('"number":3064'), true);
       expect(message.contains('既にGitHub Issue起票済み'), true);
-      expect(message.contains('既知提案の再掲・言い換えは禁止'), true);
+      expect(message.contains('本文にもJSONにも出力禁止'), true);
+      expect(
+        message.contains('新規提案なし（既知の提案はすべて起票済みです）'),
+        true,
+      );
+      expect(message.contains('起票済み。本文・JSONブロックとも再掲禁止。'), true);
       expect(message.contains('ai-new-proposals'), true);
+      // 起票済みテンプレートの本文 (echo の材料) はプロンプトへ渡さない。
+      expect(
+        message.contains(report.developerRequests.first.description),
+        false,
+      );
+      expect(message.contains('本文・JSONとも再掲禁止'), true);
     });
 
     test('extracts ai proposal block into issueable requests', () async {


### PR DESCRIPTION
## 概要

PR #3265 後の本番2回目生成でも §7 本文に起票済みテンプレート（「支払原資口座の未設定レビュー」「口座間移動タスク管理」= いずれも定型テンプレと同名・根拠データ文言もテンプレそのまま）が再掲された問題への対応（part 271 シリーズ第8弾）。

### 根本原因（3つ）

1. **echo 材料が2箇所に全文残存**: 既起票テンプレートの本文が ① PromptBuilder の「開発者向け改善提案候補」節（マークダウン）と ② detailed payload の `developer_requests.items`（JSON）の両方で LLM に渡っており、「再掲禁止」指示より材料の引力が勝っていた
2. **レース**: 初回自動生成が既存Issue照合（Edge Function）の完了**前**に走るため、`already_issued` 注釈が空のままプロンプトが組まれていた
3. 新規提案ゼロの場合の本文の書き方が未定義だった

### 変更内容

1. PromptBuilder: 起票済み候補は「タイトル（起票済み GitHub Issue #N。本文・JSONとも再掲禁止）」の1行のみ出力（本文・手順・根拠を渡さない）
2. detailed payload: 起票済み items は title + already_issued + existing_github_issue + 再掲禁止 note のみ
3. ページ: AI要約生成前に `_ensureExistingDeveloperIssuesLoaded` を await（照合結果が揃ってから生成）
4. プロンプト: 既知タイトルは本文にも出力禁止を明記 / 新規ゼロ時は「新規提案なし（既知の提案はすべて起票済みです）」と1行だけ書く

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. 起票済みテンプレートあり → プロンプトに本文（現状の痛み等）が含まれず、再掲禁止の1行注釈と Issue 番号だけが渡る
  2. 未起票テンプレート → 従来どおり全文が渡る（提案材料として有効）
  3. 新規提案ゼロの応答 → 本文は「新規提案なし」1行の指示が含まれる
- 上記はサービス層単体テスト（ai_summary 18件 + insight 13件 PASS）で検証済み
- E2E-Exception: 資産管理ページは認証済みユーザーのデータと ai-hub 応答前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。LLM 実応答の §7 本文品質は本番反映後に AI 要約を再生成して手動確認する。

## 検証

- `flutter test`（ai_summary + insight 計31件）: All tests passed
- `dart analyze`: No issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
