### PR TITLE
feat(asset): ショート警告pump完成 + 復元確認UI + 金額最小化 + CFOカード (part 280)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -100,6 +100,11 @@ class AssetManagementPage extends StatefulWidget {
   final String? entryLabel;
   final String? entryDescription;
 
+  /// テスト専用: 口座スナップショット ({yyyy-MM-dd: {口座名: 残高}}) を
+  /// 直接注入する (#3267)。null なら通常の Supabase 読込のみ。
+  @visibleForTesting
+  final Map<String, Map<String, double>>? debugInitialAssetData;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -108,6 +113,7 @@ class AssetManagementPage extends StatefulWidget {
     this.assetLiabilityRepository,
     this.entryLabel,
     this.entryDescription,
+    this.debugInitialAssetData,
   });
 
   @override
@@ -415,6 +421,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   @override
   void initState() {
     super.initState();
+    final debugAssetData = widget.debugInitialAssetData;
+    if (debugAssetData != null) {
+      _assetData = <String, Map<String, double>>{
+        for (final entry in debugAssetData.entries)
+          entry.key: Map<String, double>.from(entry.value),
+      };
+    }
     _assetLiabilityRepository = widget.assetLiabilityRepository ??
         AssetLiabilityRepositoryFactory.createDefault(
           supabaseClient: _supabase,
@@ -469,7 +482,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _cardStatementImportController.dispose();
     _assetCsvRestoreController.dispose();
     _repaymentSimulationExtraPaymentController.dispose();
-    _annualRateControllers.forEach((_, controller) => controller.dispose());
     _flowMemoController.dispose();
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
@@ -7370,6 +7382,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (_supabase.auth.currentUser == null) {
       return;
     }
+    if (await _displayModeStore.isRestoreDeclined()) {
+      return;
+    }
     try {
       final rows = await _supabase
           .from('asset_pref_mirror')
@@ -7378,7 +7393,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (rows.isEmpty || !mounted) {
         return;
       }
-      var restoredAny = false;
+
+      AssetManagementDisplayMode? pendingMode;
+      final pendingOverrides = <AssetManagementSectionId,
+          AssetManagementSectionVisibilityOverride>{};
       for (final row in rows) {
         final value = row['value'];
         if (value is! Map) {
@@ -7388,11 +7406,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           final raw = value['mode']?.toString();
           for (final mode in AssetManagementDisplayMode.values) {
             if (mode.storageId == raw && mode != _displayMode) {
-              setState(() {
-                _displayMode = mode;
-              });
-              await _displayModeStore.save(mode, recordEvent: false);
-              restoredAny = true;
+              pendingMode = mode;
             }
           }
         }
@@ -7416,19 +7430,68 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 override == AssetManagementSectionVisibilityOverride.auto) {
               continue;
             }
-            final overrides =
-                await _displayModeStore.saveOverride(section, override);
-            if (!mounted) {
-              return;
-            }
-            setState(() {
-              _sectionOverrides = overrides;
-            });
-            restoredAny = true;
+            pendingOverrides[section] = override;
           }
         }
       }
-      if (restoredAny && mounted) {
+      if (pendingMode == null && pendingOverrides.isEmpty) {
+        return;
+      }
+      if (!mounted) {
+        return;
+      }
+
+      // 他端末の設定で不意に上書きしないよう、適用前に必ず確認する。
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('表示設定のバックアップ'),
+          content: Text(
+            'サーバに表示設定のバックアップがあります'
+            '${pendingMode == null ? '' : '(表示モード: ${pendingMode.label})'}。'
+            'この端末に適用しますか?適用しない場合、次回以降は確認しません。',
+          ),
+          actions: [
+            TextButton(
+              key: const Key('asset_display_restore_decline'),
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('適用しない'),
+            ),
+            ElevatedButton(
+              key: const Key('asset_display_restore_accept'),
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: const Text('適用する'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) {
+        await _displayModeStore.markRestoreDeclined();
+        return;
+      }
+      if (!mounted) {
+        return;
+      }
+
+      if (pendingMode != null) {
+        setState(() {
+          _displayMode = pendingMode!;
+        });
+        await _displayModeStore.save(pendingMode, recordEvent: false);
+      }
+      for (final entry in pendingOverrides.entries) {
+        final overrides = await _displayModeStore.saveOverride(
+          entry.key,
+          entry.value,
+        );
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _sectionOverrides = overrides;
+        });
+      }
+      if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('表示設定をサーバのバックアップから復元しました')),
         );
@@ -7786,38 +7849,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         return;
       }
       final data = Map<String, dynamic>.from(result);
-      int countOf(String key) => (data[key] as num?)?.toInt() ?? 0;
-      final standardInitial = countOf('initial_standard');
-      final retained = countOf('standard_retained');
-      final rate = standardInitial == 0
-          ? '-'
-          : '${(retained * 100 / standardInitial).round()}%';
-      final weekly = data['weekly'];
-      var trendLabel = '';
-      final weeklyMaps = <Map<String, dynamic>>[];
-      if (weekly is List && weekly.isNotEmpty) {
-        final parts = <String>[];
-        for (final raw in weekly.take(4)) {
-          if (raw is! Map) {
-            continue;
-          }
-          final week = Map<String, dynamic>.from(raw);
-          weeklyMaps.add(week);
-          final start = week['week_start']?.toString() ?? '';
-          final label = start.length >= 10 ? start.substring(5, 10) : start;
-          final initials = (week['initials'] as num?)?.toInt() ?? 0;
-          final std = (week['initial_standard'] as num?)?.toInt() ?? 0;
-          final switches = (week['switches'] as num?)?.toInt() ?? 0;
-          parts.add('$label: 初期$initials(std$std)/切替$switches');
-        }
-        if (parts.isNotEmpty) {
-          trendLabel = ' | 週次 ${parts.join(' → ')}';
-        }
-      }
+      final parsed = AssetManagementDisplayModeStore.parseServerSummary(data);
       setState(() {
-        _experimentServerSummary =
-            '全体: 初期 min ${countOf('initial_minimum')} / std $standardInitial / full ${countOf('initial_full')}・標準維持率 $rate・切替 ${countOf('switch_total')}回$trendLabel';
-        _experimentWeekly = weeklyMaps;
+        _experimentServerSummary = parsed.summaryLabel;
+        _experimentWeekly = parsed.weekly;
       });
     } catch (e) {
       debugPrint('experiment summary fetch failed: $e');
@@ -8071,84 +8106,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       ),
     );
-  }
-
-  bool _shiftedMonthClears({
-    required List<String> ids,
-    required List<AssetCalendarDebtInput> debts,
-    required List<Map<String, dynamic>> subscriptions,
-    required List<AssetCalendarInflowInput> inflows,
-    required double? startingCashBalance,
-  }) {
-    const newDay = _salarySpendingSalaryDay + 1;
-    final shifted = AssetPaymentCalendarService.buildMonth(
-      month: _calendarMonth,
-      flows: _recentFlows,
-      subscriptions: subscriptions,
-      debts: [
-        for (final debt in debts)
-          if (ids.contains(debt.id))
-            AssetCalendarDebtInput(
-              id: debt.id,
-              name: debt.name,
-              balance: debt.balance,
-              paymentDay: newDay,
-              scheduledPaymentAmount: debt.scheduledPaymentAmount,
-              isDirectCashflowTarget: debt.isDirectCashflowTarget,
-            )
-          else
-            debt,
-      ],
-      salaryDay: _salarySpendingSalaryDay,
-      startingCashBalance: startingCashBalance,
-      expectedInflows: inflows,
-    );
-    return shifted.firstShortfallDate == null;
-  }
-
-  /// ショート回避に必要な最小の移動セット(サイズ昇順で探索)。
-  /// 候補が7件以上の場合は組合せ爆発を避け全件移動のみ試す。
-  List<String>? _findMinimalShiftSet({
-    required List<String> ids,
-    required List<AssetCalendarDebtInput> debts,
-    required List<Map<String, dynamic>> subscriptions,
-    required List<AssetCalendarInflowInput> inflows,
-    required double? startingCashBalance,
-  }) {
-    bool clears(List<String> subset) => _shiftedMonthClears(
-          ids: subset,
-          debts: debts,
-          subscriptions: subscriptions,
-          inflows: inflows,
-          startingCashBalance: startingCashBalance,
-        );
-
-    if (ids.length > 6) {
-      return clears(ids) ? List<String>.from(ids) : null;
-    }
-    final maskLimit = 1 << ids.length;
-    for (var size = 2; size <= ids.length; size++) {
-      for (var mask = 1; mask < maskLimit; mask++) {
-        var bits = 0;
-        for (var i = 0; i < ids.length; i++) {
-          final bit = 1 << i;
-          if (mask & bit != 0) {
-            bits += 1;
-          }
-        }
-        if (bits != size) {
-          continue;
-        }
-        final subset = <String>[
-          for (var i = 0; i < ids.length; i++)
-            if (mask & 1 << i != 0) ids[i],
-        ];
-        if (clears(subset)) {
-          return subset;
-        }
-      }
-    }
-    return null;
   }
 
   Widget _buildExperimentTrendBars() {
@@ -8579,12 +8536,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             shiftCandidates.every(
               (entry) => entry.value == '(単独では回避不可)',
             )
-        ? _findMinimalShiftSet(
-            ids: comboIds,
-            debts: debtInputs,
+        ? AssetPaymentCalendarService.findMinimalShiftSet(
+            month: _calendarMonth,
+            flows: _recentFlows,
             subscriptions: monthSubscriptions,
-            inflows: inflowInputs,
+            debts: debtInputs,
+            candidateIds: comboIds,
+            shiftToDay: _salarySpendingSalaryDay + 1,
+            salaryDay: _salarySpendingSalaryDay,
             startingCashBalance: startingCashBalance,
+            expectedInflows: inflowInputs,
           )
         : null;
     final comboSuggestionLabel = comboSuggestionIds == null

--- a/lib/pages/cfo_office_page.dart
+++ b/lib/pages/cfo_office_page.dart
@@ -8,6 +8,7 @@ import 'package:my_web_app/pages/payment_channel_ledger_page.dart';
 import '../models/agent_task.dart';
 import '../services/agent_org_service.dart';
 import '../widgets/agent_workspace_panel.dart';
+import '../widgets/display_mode_experiment_card.dart';
 
 class CfoOfficePage extends StatefulWidget {
   const CfoOfficePage({super.key});
@@ -85,6 +86,8 @@ class _CfoOfficePageState extends State<CfoOfficePage> {
               workspace: _workspace,
               onProcessTask: _processTask,
             ),
+            const SizedBox(height: 16),
+            const DisplayModeExperimentCard(),
             const SizedBox(height: 16),
             _buildMenuCard(
               context,

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -139,6 +139,17 @@ extension AssetManagementSectionVisibilityOverrideLabel
   }
 }
 
+/// サーバ全体集計 (display_mode_experiment_summary rpc) の整形結果。
+class AssetDisplayModeServerSummary {
+  const AssetDisplayModeServerSummary({
+    required this.summaryLabel,
+    required this.weekly,
+  });
+
+  final String summaryLabel;
+  final List<Map<String, dynamic>> weekly;
+}
+
 /// 表示モード実験の観測値(ローカル計測)。
 class AssetDisplayModeStats {
   const AssetDisplayModeStats({
@@ -176,6 +187,59 @@ class AssetManagementDisplayModeStore {
   static const AssetManagementDisplayMode newUserDefaultMode =
       AssetManagementDisplayMode.standard;
 
+  /// rpc 戻り値 (jsonb) を表示用ラベルと週次リストへ整形する。
+  /// asset_management_page と CFO 室カードで共用。
+  static AssetDisplayModeServerSummary parseServerSummary(
+    Map<String, dynamic> data,
+  ) {
+    int countOf(String key) => (data[key] as num?)?.toInt() ?? 0;
+    final standardInitial = countOf('initial_standard');
+    final retained = countOf('standard_retained');
+    final rate = standardInitial == 0
+        ? '-'
+        : '${(retained * 100 / standardInitial).round()}%';
+    final weekly = data['weekly'];
+    var trendLabel = '';
+    final weeklyMaps = <Map<String, dynamic>>[];
+    if (weekly is List && weekly.isNotEmpty) {
+      final parts = <String>[];
+      for (final raw in weekly.take(4)) {
+        if (raw is! Map) {
+          continue;
+        }
+        final week = Map<String, dynamic>.from(raw);
+        weeklyMaps.add(week);
+        final start = week['week_start']?.toString() ?? '';
+        final label = start.length >= 10 ? start.substring(5, 10) : start;
+        final initials = (week['initials'] as num?)?.toInt() ?? 0;
+        final std = (week['initial_standard'] as num?)?.toInt() ?? 0;
+        final switches = (week['switches'] as num?)?.toInt() ?? 0;
+        parts.add('$label: 初期$initials(std$std)/切替$switches');
+      }
+      if (parts.isNotEmpty) {
+        trendLabel = ' | 週次 ${parts.join(' → ')}';
+      }
+    }
+    return AssetDisplayModeServerSummary(
+      summaryLabel:
+          '全体: 初期 min ${countOf('initial_minimum')} / std $standardInitial / full ${countOf('initial_full')}・標準維持率 $rate・切替 ${countOf('switch_total')}回$trendLabel',
+      weekly: weeklyMaps,
+    );
+  }
+
+  /// サーババックアップからの表示設定復元をユーザーが辞退したか。
+  Future<bool> isRestoreDeclined({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return store.getBool(_restoreDeclinedKey) ?? false;
+  }
+
+  Future<void> markRestoreDeclined({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    await store.setBool(_restoreDeclinedKey, true);
+  }
+
+  static const String _restoreDeclinedKey =
+      'asset_management_display_restore_declined_v1';
   static const String _modeKey = 'asset_management_display_mode_v1';
   static const String _overridesKey = 'asset_management_section_overrides_v1';
   static const String _eventsKey = 'asset_management_display_mode_events_v1';

--- a/lib/services/asset_payment_calendar_service.dart
+++ b/lib/services/asset_payment_calendar_service.dart
@@ -351,6 +351,96 @@ class AssetPaymentCalendarService {
     );
   }
 
+  /// [candidateIds] のうち、支払日を [shiftToDay] へ移すことでショートが
+  /// 解消する最小の部分集合を返す。同サイズ候補が複数ある場合は
+  /// **移動する予定支払額の合計が最小**の組合せを優先する。
+  /// 候補7件以上は組合せ爆発を避け全件移動のみ判定する。
+  static List<String>? findMinimalShiftSet({
+    required DateTime month,
+    required List<Map<String, dynamic>> flows,
+    required List<Map<String, dynamic>> subscriptions,
+    required List<AssetCalendarDebtInput> debts,
+    required List<String> candidateIds,
+    required int shiftToDay,
+    int? salaryDay,
+    double? startingCashBalance,
+    List<AssetCalendarInflowInput> expectedInflows =
+        const <AssetCalendarInflowInput>[],
+  }) {
+    bool clears(List<String> subset) {
+      final shifted = buildMonth(
+        month: month,
+        flows: flows,
+        subscriptions: subscriptions,
+        debts: [
+          for (final debt in debts)
+            if (subset.contains(debt.id))
+              AssetCalendarDebtInput(
+                id: debt.id,
+                name: debt.name,
+                balance: debt.balance,
+                paymentDay: shiftToDay,
+                scheduledPaymentAmount: debt.scheduledPaymentAmount,
+                isDirectCashflowTarget: debt.isDirectCashflowTarget,
+              )
+            else
+              debt,
+        ],
+        salaryDay: salaryDay,
+        startingCashBalance: startingCashBalance,
+        expectedInflows: expectedInflows,
+      );
+      return shifted.firstShortfallDate == null;
+    }
+
+    double subsetAmount(List<String> subset) {
+      var total = 0.0;
+      for (final debt in debts) {
+        if (subset.contains(debt.id)) {
+          total += debt.scheduledPaymentAmount;
+        }
+      }
+      return total;
+    }
+
+    if (candidateIds.length > 6) {
+      return clears(candidateIds) ? List<String>.from(candidateIds) : null;
+    }
+    final maskLimit = 1 << candidateIds.length;
+    for (var size = 2; size <= candidateIds.length; size++) {
+      List<String>? best;
+      var bestAmount = double.infinity;
+      for (var mask = 1; mask < maskLimit; mask++) {
+        var bits = 0;
+        for (var i = 0; i < candidateIds.length; i++) {
+          final bit = 1 << i;
+          if (mask & bit != 0) {
+            bits += 1;
+          }
+        }
+        if (bits != size) {
+          continue;
+        }
+        final subset = <String>[
+          for (var i = 0; i < candidateIds.length; i++)
+            if (mask & 1 << i != 0) candidateIds[i],
+        ];
+        if (!clears(subset)) {
+          continue;
+        }
+        final amount = subsetAmount(subset);
+        if (amount < bestAmount) {
+          best = subset;
+          bestAmount = amount;
+        }
+      }
+      if (best != null) {
+        return best;
+      }
+    }
+    return null;
+  }
+
   static List<AssetCalendarEvent> _sortEvents(List<AssetCalendarEvent> events) {
     final sorted = List<AssetCalendarEvent>.from(events);
     sorted.sort((a, b) => a.kind.index.compareTo(b.kind.index));

--- a/lib/widgets/display_mode_experiment_card.dart
+++ b/lib/widgets/display_mode_experiment_card.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:my_web_app/services/asset_management_display_mode_store.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// 表示モード実験(新規=標準既定)の全体集計カード。CFO 室向け。
+/// rpc display_mode_experiment_summary を取得し、標準維持率と
+/// 週次トレンド(初期解決=藍 / 切替=橙)を表示する。
+class DisplayModeExperimentCard extends StatefulWidget {
+  const DisplayModeExperimentCard({super.key});
+
+  @override
+  State<DisplayModeExperimentCard> createState() =>
+      _DisplayModeExperimentCardState();
+}
+
+class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
+  String? _summaryLabel;
+  List<Map<String, dynamic>> _weekly = const <Map<String, dynamic>>[];
+  bool _loading = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetch();
+  }
+
+  Future<void> _fetch() async {
+    if (Supabase.instance.client.auth.currentUser == null) {
+      setState(() {
+        _error = 'ログインすると全体集計を表示できます';
+      });
+      return;
+    }
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final dynamic result = await Supabase.instance.client.rpc(
+        'display_mode_experiment_summary',
+      );
+      if (!mounted || result is! Map) {
+        return;
+      }
+      final parsed = AssetManagementDisplayModeStore.parseServerSummary(
+        Map<String, dynamic>.from(result),
+      );
+      setState(() {
+        _summaryLabel = parsed.summaryLabel;
+        _weekly = parsed.weekly;
+      });
+    } catch (e) {
+      debugPrint('experiment card fetch failed: $e');
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = '取得に失敗しました(再試行できます)';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.science_outlined, color: Color(0xFF6366F1)),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    '表示モード実験(標準既定)',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  key: const Key('display_mode_experiment_refresh'),
+                  tooltip: '再取得',
+                  icon: const Icon(Icons.refresh, size: 18),
+                  onPressed: _loading ? null : _fetch,
+                ),
+              ],
+            ),
+            if (_loading) ...[
+              const SizedBox(height: 8),
+              const LinearProgressIndicator(minHeight: 3),
+            ],
+            if (_error != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                _error!,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  height: 1.5,
+                ),
+              ),
+            ],
+            if (_summaryLabel != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                _summaryLabel!,
+                style: const TextStyle(fontSize: 12, height: 1.6),
+              ),
+            ],
+            if (_weekly.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              _TrendBars(weekly: _weekly),
+              const SizedBox(height: 4),
+              const Wrap(
+                spacing: 10,
+                children: [
+                  _LegendDot(color: Color(0xFF6366F1), label: '初期解決'),
+                  _LegendDot(color: Color(0xFFF97316), label: '切替'),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TrendBars extends StatelessWidget {
+  const _TrendBars({required this.weekly});
+
+  final List<Map<String, dynamic>> weekly;
+
+  @override
+  Widget build(BuildContext context) {
+    final weeks = weekly.reversed.toList(growable: false);
+    var maxTotal = 1;
+    for (final week in weeks) {
+      final initials = (week['initials'] as num?)?.toInt() ?? 0;
+      final switches = (week['switches'] as num?)?.toInt() ?? 0;
+      if (initials + switches > maxTotal) {
+        maxTotal = initials + switches;
+      }
+    }
+    return SizedBox(
+      height: 60,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          for (final week in weeks)
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 2),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Text(
+                      '${(week['initials'] as num?)?.toInt() ?? 0}/${(week['switches'] as num?)?.toInt() ?? 0}',
+                      style: const TextStyle(fontSize: 8, height: 1.2),
+                    ),
+                    Container(
+                      height: 2 +
+                          30 *
+                              ((week['switches'] as num?)?.toInt() ?? 0) /
+                              maxTotal,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF97316),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 1),
+                    Container(
+                      height: 2 +
+                          30 *
+                              ((week['initials'] as num?)?.toInt() ?? 0) /
+                              maxTotal,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF6366F1),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      (week['week_start']?.toString() ?? '').length >= 10
+                          ? week['week_start'].toString().substring(5, 10)
+                          : '',
+                      style: const TextStyle(fontSize: 7, height: 1.2),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LegendDot extends StatelessWidget {
+  const _LegendDot({required this.color, required this.label});
+
+  final Color color;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 7,
+          height: 7,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 4),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 10,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            height: 1.4,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/services/asset_management_display_mode_store_test.dart
+++ b/test/services/asset_management_display_mode_store_test.dart
@@ -225,5 +225,37 @@ void main() {
       expect(stats.switchCount, 0);
       expect(await store.load(), AssetManagementDisplayMode.minimum);
     });
+
+    test('parseServerSummary builds label and weekly list', () {
+      final parsed = AssetManagementDisplayModeStore.parseServerSummary(
+        <String, dynamic>{
+          'initial_minimum': 1,
+          'initial_standard': 4,
+          'initial_full': 2,
+          'switch_total': 3,
+          'standard_retained': 3,
+          'weekly': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'week_start': '2026-06-08',
+              'initials': 5,
+              'initial_standard': 4,
+              'switches': 2,
+            },
+          ],
+        },
+      );
+
+      expect(parsed.summaryLabel, contains('標準維持率 75%'));
+      expect(parsed.summaryLabel, contains('06-08'));
+      expect(parsed.weekly, hasLength(1));
+    });
+
+    test('restore decline flag persists', () async {
+      const store = AssetManagementDisplayModeStore();
+
+      expect(await store.isRestoreDeclined(), isFalse);
+      await store.markRestoreDeclined();
+      expect(await store.isRestoreDeclined(), isTrue);
+    });
   });
 }

--- a/test/services/asset_payment_calendar_service_test.dart
+++ b/test/services/asset_payment_calendar_service_test.dart
@@ -320,5 +320,86 @@ void main() {
       expect(calendar.worstProjectedBalance, 1000);
       expect(calendar.shortfallRecoveryAmount, 0);
     });
+
+    test('findMinimalShiftSet prefers the smallest total shifted amount', () {
+      const debts = <AssetCalendarDebtInput>[
+        AssetCalendarDebtInput(
+          id: 'a',
+          name: 'A',
+          balance: -100000,
+          paymentDay: 5,
+          scheduledPaymentAmount: 100,
+        ),
+        AssetCalendarDebtInput(
+          id: 'b',
+          name: 'B',
+          balance: -100000,
+          paymentDay: 5,
+          scheduledPaymentAmount: 50,
+        ),
+        AssetCalendarDebtInput(
+          id: 'c',
+          name: 'C',
+          balance: -100000,
+          paymentDay: 5,
+          scheduledPaymentAmount: 60,
+        ),
+      ];
+      final inflows = <AssetCalendarInflowInput>[
+        AssetCalendarInflowInput(
+          date: DateTime(2026, 6, 10),
+          amount: 120,
+          label: '入金',
+        ),
+      ];
+
+      final minimal = AssetPaymentCalendarService.findMinimalShiftSet(
+        month: DateTime(2026, 6),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: debts,
+        candidateIds: const <String>['a', 'b', 'c'],
+        shiftToDay: 26,
+        startingCashBalance: 100,
+        expectedInflows: inflows,
+      );
+
+      // 単独移動では5日の残額が現金100を超えるため不可。ペアでは
+      // {b,c}(残A=100)・{a,b}(残C=60)・{a,c}(残B=50)が全て成立し、
+      // 移動額合計が最小の {b,c}=110 が選ばれる。
+      expect(minimal, isNotNull);
+      expect(minimal!.toSet(), <String>{'b', 'c'});
+    });
+
+    test('findMinimalShiftSet returns null when no subset clears', () {
+      const debts = <AssetCalendarDebtInput>[
+        AssetCalendarDebtInput(
+          id: 'a',
+          name: 'A',
+          balance: -100000,
+          paymentDay: 5,
+          scheduledPaymentAmount: 500,
+        ),
+        AssetCalendarDebtInput(
+          id: 'b',
+          name: 'B',
+          balance: -100000,
+          paymentDay: 5,
+          scheduledPaymentAmount: 500,
+        ),
+      ];
+
+      final minimal = AssetPaymentCalendarService.findMinimalShiftSet(
+        month: DateTime(2026, 6),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: debts,
+        candidateIds: const <String>['a', 'b'],
+        shiftToDay: 26,
+        startingCashBalance: 100,
+      );
+
+      expect(minimal, isNull);
+    });
   });
 }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -191,5 +191,59 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets('shortfall warning appears and clears via expected inflow', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 10000,
+                'モビット': -300000,
+              },
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // モビット既定支払日15日の予定額が現金1万を超え、ショート警告が出る。
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_calendar_add_inflow_button')),
+      );
+      expect(find.textContaining('回避ライン'), findsOneWidget);
+      expect(
+        find.byKey(const Key('asset_shift_payment_mobit')),
+        findsOneWidget,
+      );
+
+      // 回避ライン額がプリフィルされた入金予定を登録すると警告が消える。
+      await tester.tap(
+        find.byKey(const Key('asset_calendar_add_inflow_button')),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('追加'),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.byKey(const Key('asset_calendar_add_inflow_button')),
+        findsNothing,
+      );
+      expect(find.textContaining('回避ライン'), findsNothing);
+
+      await _unmount(tester);
+    });
   });
 }


### PR DESCRIPTION
## 概要

1. **#3267 完遂: ショート警告の pump 検証** — `AssetManagementPage` に `@visibleForTesting debugInitialAssetData`(日付→{口座名: 残高})を追加。planning service の名称カタログ(例: 「モビット」= 既定支払日15日の消費者金融、「財布(現金)」= 現金口座)を利用し、**現金1万+ローン残▲30万のシードでショート警告→回避ライン表示→移動ボタン→プリフィル入金予定の登録で警告解消**までを widget で black-box 検証(widget 計8本)。
2. **テストが暴いた既存バグの修正** — dispose 内で `_annualRateControllers` を**二重 dispose**しており、workbook が存在する実利用条件では dispose が throw → `_deadlineTimer` 未解放 → defunct 要素への setState という潜在不具合(origin/main にも存在)を確認し重複行を削除。
3. **表示設定復元の確認ダイアログ化** — 他端末バックアップの**不意の上書きを防止**。「適用しない」を選ぶと記憶して再確認せず、適用時も `recordEvent: false` で実験ログを汚染しない。
4. **最小セット探索の金額最小化** — `findMinimalShiftSet` を service へ移設し、同サイズ候補では**移動予定額合計が最小**の組合せを返す(単体テストで {b,c}=110 が {a,b}=150 / {a,c}=160 より優先されることを検証)。
5. **実験ダッシュボードの CFO 室昇格** — 共有 `parseServerSummary` + 2色トレンドバーの `DisplayModeExperimentCard` を新設し CFO 室に常設(再取得ボタン付き)。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) シード口座→ショート警告→入金予定登録→警告解消の一連 (2) 金額最小の移動セット選択 (3) 復元辞退フラグの永続化。既存分含め計 43 ケース(widget 8 + service 35)。
- E2E例外: 変更はクライアントのみ(スキーマ・Edge Function 変更なし)。本PRの widget pump がエンドツーエンド相当の UI 検証を担い、本番疎通は既存 Playwright smoke で補完する。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `flutter test` **43/43 PASS**。並行 [#3268](https://github.com/kanta13jp1/my_web_app/pull/3268) のページ変更は着地前に取込み、compare diff-stat で逆 revert なし(page +91/-130 は全て意図的削除)を確認済み。

## High-risk gate

- High-risk-ultrareview-exception: サーバ変更なしのクライアント限定 PR(既存テーブルへの読み書きのみ)。payment 語は支払日表示・テストシナリオの文脈で、決済・課金処理への変更はない。レビュー所有者: Claude Code #1。
- 自己点検メモ: security = 既存 RLS の範囲内・新規権限なし / rollback = クライアント revert のみで完結 / data migration = なし / prod smoke = 既存 smoke green + widget 8本 / observability = 取得失敗は debugPrint + 再試行ボタン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3267
