### PR TITLE
fix(web): #3237 boot時ViewFocusレースの抑止フィルタをビルド非依存化 (part 281)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1035,32 +1035,25 @@
 
     // Flutter Web occasionally surfaces non-fatal framework focus/hover races
     // as window-level "Uncaught Error" entries after the app has recovered.
-    // Keep this filter narrow: it only matches minified Flutter framework
-    // stacks for FocusTraversal RenderBox geometry and InkResponse hover.
+    // Known case (#3237): the engine delivers the initial ViewFocusEvent
+    // before the first layout pass, so the reading-order focus sort reads
+    // FocusNode.rect on render boxes that are not laid out yet and throws
+    // "Bad state: RenderBox was not laid out". The same traversal succeeds
+    // once layout completes (verified by TAB refocus), so these escapes are
+    // noise. Match on the stable Dart exception text via String(error) --
+    // minified stack symbols rotate every build, which is how the previous
+    // signature-based filter went stale.
     window.addEventListener('error', function(event) {
       var error = event && event.error;
       var stack = String((error && error.stack) || '');
       var message = String((event && event.message) || (error && error.message) || '');
       var isMainBundle = stack.indexOf('main.dart.js') !== -1;
-      var isFocusTraversalRenderBoxV1 =
+      var text = '';
+      try { text = String(error || ''); } catch (ignored) {}
+      var isFocusGeometryRace =
         isMainBundle &&
-        stack.indexOf('.gN') !== -1 &&
-        stack.indexOf('.gn') !== -1 &&
-        stack.indexOf('Object.e') !== -1 &&
-        stack.indexOf('Object.dy') !== -1 &&
-        stack.indexOf('.ak') !== -1 &&
-        stack.indexOf('a7') !== -1;
-      var isFocusTraversalRenderBoxV2 =
-        isMainBundle &&
-        stack.indexOf('.gn') !== -1 &&
-        stack.indexOf('.ge') !== -1 &&
-        stack.indexOf('Object.e') !== -1 &&
-        stack.indexOf('Object.d') !== -1 &&
-        (stack.indexOf('.aF') !== -1 || stack.indexOf('.aG') !== -1) &&
-        (stack.indexOf('.aU') !== -1 || stack.indexOf('.aV') !== -1) &&
-        stack.indexOf('.at') !== -1;
-      var isFocusTraversalRenderBox =
-        isFocusTraversalRenderBoxV1 || isFocusTraversalRenderBoxV2;
+        (text.indexOf('RenderBox was not laid out') !== -1 ||
+          message.indexOf('RenderBox was not laid out') !== -1);
       var isInkResponseNull =
         message.indexOf('Null check operator used on a null value') !== -1 &&
         isMainBundle &&
@@ -1070,8 +1063,12 @@
           stack.indexOf('MouseTracker') !== -1
         );
 
-      if (isFocusTraversalRenderBox || isInkResponseNull) {
+      if (isFocusGeometryRace || isInkResponseNull) {
         event.preventDefault();
+        console.info(
+          '[known-race] suppressed non-fatal Flutter framework error (#3237):',
+          text || message
+        );
       }
     }, true);
   </script>


### PR DESCRIPTION
## 概要

[#3237](https://github.com/kanta13jp1/my_web_app/issues/3237) (全ページ共通 boot 時 Uncaught Error) の根本原因特定と恒久対処。

## 根本原因 (調査結果)

minified スタックの逆コンパイル + 本番ライブ実験で特定:

- エラー実体 = `Bad state: RenderBox was not laid out: minified:aDW#…` (`String(error)` のカスタム toString をページコンテキストで捕獲)
- スタック解読: `iR.geh` = `FocusNode.rect` (getTransformTo + paintBounds の 2 点変換) / `e4g`・`eF3` = `ReadingOrderTraversalPolicy` の全 FocusNode 読み順ソート / `bDk.aqP`・`aMs` = `findFirstFocus`/`findLastFocus` / `alY.b1x` = `FocusManager` の ViewFocusEvent ハンドラ (direction 3 分岐 + requestFocus) / `abj.az4` = binding の ViewFocusEvent ブロードキャスト
- **機序: エンジンが boot 直後にビューへ初回 ViewFocusEvent(focused, forward) を配送 → 初回レイアウト完了前なので全 RenderBox が未レイアウト → 読み順ソートが最初に測った Semantics box (`aDW` = `RenderSemanticsAnnotations`) で必ず throw**
- 決定実験: レイアウト完了後に TAB でビュー再フォーカス (同一ソート経路を再実行) → **エラーゼロ**。= 特定ウィジェットの問題ではなく boot 時タイミングレース (framework 由来 / アプリは自己回復済み)

## 変更 (web/index.html の既存抑止フィルタの恒久化)

index.html には本件用の抑止フィルタが既に存在したが、**minified シンボル断片 (`.gN`/`.gn`/`Object.dy` 等) でマッチする設計のためビルドごとに名前がローテートして bitrot** し、現行ビルドで素通りしていた。

- focus-geometry 判定を**安定した Dart 例外文言ベース** (`String(error)` に `RenderBox was not laid out`) へ置換 — ビルド非依存で再 bitrot しない
- 抑止時に `console.info('[known-race] suppressed … (#3237)')` で痕跡を残す (完全沈黙にしない / 観測可能性維持)
- InkResponse null 系ルールはスコープ拡大を避けるため現状維持
- Dart/Flutter コードは非接触 (index.html の error リスナーのみ)

## Minimal E2E (gate)

- E2E 検証は implementation-detail independent (black-box) — 本番 URL のブラウザ console 観測のみで判定し、内部実装に依存しない。
- minimal plan = 3 cases (3ケース):
  1. boot 時の console に Uncaught Error が 0 件になる
  2. 代わりに `[known-race] suppressed …` の console.info が記録される (抑止が機能した痕跡)
  3. TAB でビュー再フォーカスしてもエラーが出ない (レイアウト後経路の健全性)
- E2E-Exception: ブラウザ console 挙動の検証は playwright での本番観測が最適なため新規 integration_test ファイルは追加しない。merge → deploy 後に上記 3 ケースを playwright で実測し本 PR にコメントする。

## High-risk gate (review owner: Claude Code #1)

- Review owner: Claude Code #1 (Win Claude / L3)
- high-risk-ultrareview-exception: 本PRは index.html の error リスナー 1 ブロックの書き換えのみで auth / billing / RLS / data migration / Edge Function / Dart コードに非接触のため、課金 ultrareview は省略し Claude Code #1 によるセルフレビュー (下記 5 観点) で代替する。
- 5 観点 self-review:
  - security: 新規攻撃面なし (エラーリスナー内の文字列比較のみ / 外部送信なし)
  - rollback: 1 コミット revert で即時 rollback 可能
  - data migration: なし
  - prod smoke: deploy 後に production smoke として上記 3 ケースを playwright で実測し本 PR にコメントする
  - observability: 抑止を console.info 痕跡付きに変更 = 従来の無音 preventDefault より観測性は向上。実バグの "RenderBox was not laid out" も抑止対象になるトレードオフは info ログで追跡可能 (リスクは #3237 に明記)
- unresolved findings: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
