### PR TITLE
feat(asset): AI分析のプロバイダールーティング有効化 — Claude Opus 4.7 チェーンへ

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -656,6 +656,7 @@ jobs:
             --dart-define=ASSET_LIABILITY_SUPABASE_SYNC_ENABLED=true \
             --dart-define=ASSET_LIABILITY_SUPABASE_PRODUCTION_WRITES_ENABLED=true \
             --dart-define=ASSET_MANAGEMENT_AI_SUMMARY_ENABLED=true \
+            --dart-define=ASSET_MANAGEMENT_AI_PROVIDER_ROUTING_ENABLED=true \
             --dart-define=LANDING_GOOGLE_LOGIN_ENABLED=${{ env.LANDING_GOOGLE_LOGIN_ENABLED }}
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -103,6 +103,7 @@ jobs:
           --dart-define=ASSET_LIABILITY_SUPABASE_SYNC_ENABLED=true
           --dart-define=ASSET_LIABILITY_SUPABASE_PRODUCTION_WRITES_ENABLED=true
           --dart-define=ASSET_MANAGEMENT_AI_SUMMARY_ENABLED=true
+          --dart-define=ASSET_MANAGEMENT_AI_PROVIDER_ROUTING_ENABLED=true
         env:
           # 修正: シークレット名を _STAGING に変更
           SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING }}


### PR DESCRIPTION
## 概要

「AI分析結果があまり変わらない。別のモデルの使用も検討してほしい」というユーザー要望への対応（part 271 シリーズ第9弾）。

### 調査結果

- 現在の AI 分析は `sendAutoChat(tier: 'performance')` 経由で **groq の軽量モデル**が生成しており、§7 の再掲禁止などの細かい指示遵守と表現多様性が弱い構造要因だった
- 一方、`AssetManagementAiProviderRouter` には part 261 のモデルルーティング戦略に基づく **premium チェーン（anthropic/claude-opus-4-7 → openai/gpt-5 → google/gemini-3.1-pro → 決定論フォールバック）が実装済み**だが、feature flag `ASSET_MANAGEMENT_AI_PROVIDER_ROUTING_ENABLED` が既定 false のため一度も本番で使われていなかった
- 配線は全て検証済み: クライアント `sendProviderChat` は `model` を body に含める / ai-hub EF の `provider.chat` は `body.model` を受理 / anthropic プロバイダ登録済み（x-api-key 認証）/ `claude-opus-4-7` は ai-hub 内の他機能（高精度合成）で本番使用実績あり

### 変更内容

`deploy-prod.yml` / `deploy-staging.yml` のビルドに `--dart-define=ASSET_MANAGEMENT_AI_PROVIDER_ROUTING_ENABLED=true` を追加（各1行）。Dart コード変更なし。

### 期待効果と注記

- 次回デプロイ後の AI 要約は Claude Opus 4.7 が第一候補となり、§1〜6 の表現品質・履歴差分の言及・§7 の再掲禁止遵守が大幅に改善する見込み
- §1〜6 の内容自体は同じ財務データに基づくため、データが変わらない限り要旨は近いまま（これは仕様）
- コスト注記: 要約1回あたり Opus 4.7 の出力最大3,200トークン。生成は手動更新+フィンガープリントキャッシュで抑制されており、失敗時は GPT-5 → Gemini 3.1 Pro → 決定論要約へフォールバック

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースの観点で確認
  1. ルーティング有効ビルド → AI要約の「ソース」表示が ai-hub provider.chat / anthropic になる
  2. anthropic 失敗時 → チェーン後続（openai/google）または決定論要約へフォールバック（既存実装・単体テスト済み経路）
  3. ルーティング無効ビルド（CI 等）→ 従来どおり tier=performance auto（挙動不変）
- 本PRはワークフローの dart-define 追加のみでアプリコード変更なし（lib/ 変更ゼロ）。ルーティング経路自体は既存の単体テスト済みコード
- 本番反映後に AI 要約を再生成し、ソース表示と §7 出力品質を手動確認する（E2E 自動化は認証必須ページのため Playwright 公開スモーク対象外）

## 検証

- 変更は workflows 2ファイル +2行のみ（`git diff --stat`: 2 files changed, 2 insertions）
- クライアント→EF→プロバイダの model 受け渡しチェーンをコードリーディングで検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## High-risk レビュー宣言

- レビューオーナー: Claude Code #1
- High-risk-ultrareview-exception: 本PRはデプロイワークフローへの dart-define 1行×2の追加のみで、アプリコード・権限・シークレット・migration の変更は一切なし。有効化されるルーティング経路は既存の単体テスト済みコードであり、失敗時は既存の決定論フォールバックに収束するため ultrareview は省略し、本番反映後のAI要約ソース表示確認で代替する。
