### PR TITLE
feat(asset): 反映通知widgetテスト + 維持率推移 + 監査CI常設 (part 283)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,11 @@ jobs:
         run: python scripts/check_github_actions_python_inline.py
         continue-on-error: false
 
+      - name: Check duplicate dispose statements
+        # part 280 実例 (二重 dispose → dispose 中断 → defunct setState) の再発防止
+        run: python scripts/check_duplicate_dispose.py
+        continue-on-error: false
+
       - name: Check formatting
         # #1372: treat Dart formatting as a required static-analysis gate.
         run: dart format --output=none --set-exit-if-changed .

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -105,6 +105,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, Map<String, double>>? debugInitialAssetData;
 
+  /// テスト専用: asset_pref_mirror 行を直接注入し、反映通知の判定を
+  /// ネットワークなしで検証する。null なら通常の select。
+  @visibleForTesting
+  final List<Map<String, dynamic>>? debugMirrorPrefsRows;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -114,6 +119,7 @@ class AssetManagementPage extends StatefulWidget {
     this.entryLabel,
     this.entryDescription,
     this.debugInitialAssetData,
+    this.debugMirrorPrefsRows,
   });
 
   @override
@@ -7351,18 +7357,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
-  bool _sameSectionOverrides(AssetManagementSectionOverrides candidate) {
-    if (candidate.length != _sectionOverrides.length) {
-      return false;
-    }
-    for (final entry in candidate.entries) {
-      if (_sectionOverrides[entry.key] != entry.value) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   Future<void> _applyDisplayPrefs(
     AssetManagementDisplayMode? mode,
     AssetManagementSectionOverrides? overrides,
@@ -7390,81 +7384,41 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   /// 他端末がミラーを更新していたら、自動適用せず通知して選ばせる。
-  /// 自端末の直近書き込み (lastChangedAt+10秒以内) は対象外。
+  /// 判定は AssetManagementDisplayModeStore.evaluateMirrorPrefRows に委譲。
   Future<void> _checkDisplayPrefsMirrorNewer() async {
-    if (_supabase.auth.currentUser == null) {
+    final debugRows = widget.debugMirrorPrefsRows;
+    if (_supabase.auth.currentUser == null && debugRows == null) {
       return;
     }
     try {
       final stats = await _displayModeStore.loadStats();
-      final localChangedAt = stats.lastChangedAt;
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select()
-          .inFilter('pref_key', <String>['display_mode', 'section_overrides']);
+      final rows = debugRows ??
+          List<Map<String, dynamic>>.from(
+            await _supabase.from('asset_pref_mirror').select().inFilter(
+              'pref_key',
+              <String>['display_mode', 'section_overrides'],
+            ),
+          );
       if (rows.isEmpty || !mounted) {
         return;
       }
-      AssetManagementDisplayMode? newerMode;
-      AssetManagementSectionOverrides? newerOverrides;
-      for (final row in rows) {
-        final updatedAt =
-            DateTime.tryParse(row['updated_at']?.toString() ?? '')?.toLocal();
-        if (updatedAt == null) {
-          continue;
-        }
-        if (localChangedAt != null &&
-            !updatedAt.isAfter(
-              localChangedAt.add(const Duration(seconds: 10)),
-            )) {
-          continue;
-        }
-        final value = row['value'];
-        if (value is! Map) {
-          continue;
-        }
-        if (row['pref_key'] == 'display_mode') {
-          final raw = value['mode']?.toString();
-          for (final mode in AssetManagementDisplayMode.values) {
-            if (mode.storageId == raw && mode != _displayMode) {
-              newerMode = mode;
-            }
-          }
-        }
-        if (row['pref_key'] == 'section_overrides') {
-          final candidate = <AssetManagementSectionId,
-              AssetManagementSectionVisibilityOverride>{};
-          for (final entry in value.entries) {
-            for (final section in AssetManagementSectionId.values) {
-              if (section.storageId != entry.key.toString()) {
-                continue;
-              }
-              for (final override
-                  in AssetManagementSectionVisibilityOverride.values) {
-                if (override.storageId == entry.value.toString() &&
-                    override != AssetManagementSectionVisibilityOverride.auto) {
-                  candidate[section] = override;
-                }
-              }
-            }
-          }
-          if (!_sameSectionOverrides(candidate)) {
-            newerOverrides = candidate;
-          }
-        }
-      }
-      if ((newerMode == null && newerOverrides == null) || !mounted) {
+      final diff = AssetManagementDisplayModeStore.evaluateMirrorPrefRows(
+        rows: rows,
+        currentMode: _displayMode,
+        currentOverrides: _sectionOverrides,
+        localChangedAt: stats.lastChangedAt,
+      );
+      if (diff.isEmpty || !mounted) {
         return;
       }
-      final mode = newerMode;
-      final overrides = newerOverrides;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           duration: const Duration(seconds: 8),
           content: const Text('他端末で表示設定が更新されています'),
           action: SnackBarAction(
             label: '取り込む',
-            onPressed: () => unawaited(_applyDisplayPrefs(mode, overrides)),
+            onPressed: () =>
+                unawaited(_applyDisplayPrefs(diff.mode, diff.overrides)),
           ),
         ),
       );

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -145,6 +145,7 @@ class AssetDisplayModeServerSummary {
     required this.summaryLabel,
     required this.weekly,
     this.firstEventAt,
+    this.weeklyRetention = const <Map<String, dynamic>>[],
   });
 
   final String summaryLabel;
@@ -152,6 +153,19 @@ class AssetDisplayModeServerSummary {
 
   /// 実験の最初のイベント時刻 (= 実験開始)。イベント0件なら null。
   final DateTime? firstEventAt;
+
+  /// 週末時点 as-of の標準維持率% ({week_start, rate})。rate は null 可。
+  final List<Map<String, dynamic>> weeklyRetention;
+}
+
+/// ミラー上の表示設定がローカルより新しい場合の差分。
+class AssetMirrorPrefsDiff {
+  const AssetMirrorPrefsDiff({this.mode, this.overrides});
+
+  final AssetManagementDisplayMode? mode;
+  final AssetManagementSectionOverrides? overrides;
+
+  bool get isEmpty => mode == null && overrides == null;
 }
 
 /// 表示モード実験の観測値(ローカル計測)。
@@ -230,7 +244,81 @@ class AssetManagementDisplayModeStore {
       weekly: weeklyMaps,
       firstEventAt: DateTime.tryParse(data['first_event_at']?.toString() ?? '')
           ?.toLocal(),
+      weeklyRetention: data['weekly_retention'] is List
+          ? <Map<String, dynamic>>[
+              for (final raw in data['weekly_retention'] as List)
+                if (raw is Map) Map<String, dynamic>.from(raw),
+            ]
+          : const <Map<String, dynamic>>[],
     );
+  }
+
+  /// ミラー行 (asset_pref_mirror) を評価し、ローカル設定より新しく
+  /// かつ内容が異なる差分だけを返す。自端末の直近書込みは
+  /// [selfWriteMargin] 以内の updated_at として除外する。
+  static AssetMirrorPrefsDiff evaluateMirrorPrefRows({
+    required List<Map<String, dynamic>> rows,
+    required AssetManagementDisplayMode currentMode,
+    required AssetManagementSectionOverrides currentOverrides,
+    DateTime? localChangedAt,
+    Duration selfWriteMargin = const Duration(seconds: 10),
+  }) {
+    AssetManagementDisplayMode? newerMode;
+    AssetManagementSectionOverrides? newerOverrides;
+    for (final row in rows) {
+      final updatedAt =
+          DateTime.tryParse(row['updated_at']?.toString() ?? '')?.toLocal();
+      if (updatedAt == null) {
+        continue;
+      }
+      if (localChangedAt != null &&
+          !updatedAt.isAfter(localChangedAt.add(selfWriteMargin))) {
+        continue;
+      }
+      final value = row['value'];
+      if (value is! Map) {
+        continue;
+      }
+      if (row['pref_key'] == 'display_mode') {
+        final raw = value['mode']?.toString();
+        for (final mode in AssetManagementDisplayMode.values) {
+          if (mode.storageId == raw && mode != currentMode) {
+            newerMode = mode;
+          }
+        }
+      }
+      if (row['pref_key'] == 'section_overrides') {
+        final candidate = <AssetManagementSectionId,
+            AssetManagementSectionVisibilityOverride>{};
+        for (final entry in value.entries) {
+          for (final section in AssetManagementSectionId.values) {
+            if (section.storageId != entry.key.toString()) {
+              continue;
+            }
+            for (final override
+                in AssetManagementSectionVisibilityOverride.values) {
+              if (override.storageId == entry.value.toString() &&
+                  override != AssetManagementSectionVisibilityOverride.auto) {
+                candidate[section] = override;
+              }
+            }
+          }
+        }
+        var same = candidate.length == currentOverrides.length;
+        if (same) {
+          for (final entry in candidate.entries) {
+            if (currentOverrides[entry.key] != entry.value) {
+              same = false;
+              break;
+            }
+          }
+        }
+        if (!same) {
+          newerOverrides = candidate;
+        }
+      }
+    }
+    return AssetMirrorPrefsDiff(mode: newerMode, overrides: newerOverrides);
   }
 
   /// サーババックアップからの表示設定復元をユーザーが辞退したか。

--- a/lib/widgets/display_mode_experiment_card.dart
+++ b/lib/widgets/display_mode_experiment_card.dart
@@ -17,6 +17,7 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
   String? _summaryLabel;
   String? _progressLabel;
   List<Map<String, dynamic>> _weekly = const <Map<String, dynamic>>[];
+  List<Map<String, dynamic>> _weeklyRetention = const <Map<String, dynamic>>[];
   bool _loading = false;
   String? _error;
 
@@ -50,6 +51,7 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
       setState(() {
         _summaryLabel = parsed.summaryLabel;
         _weekly = parsed.weekly;
+        _weeklyRetention = parsed.weeklyRetention;
         _progressLabel = _buildProgressLabel(parsed);
       });
     } catch (e) {
@@ -166,6 +168,19 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
                 style: const TextStyle(fontSize: 12, height: 1.6),
               ),
             ],
+            if (_weeklyRetention.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              const Text(
+                '標準維持率%の推移(週末時点)',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  height: 1.4,
+                ),
+              ),
+              const SizedBox(height: 4),
+              _RetentionBars(retention: _weeklyRetention),
+            ],
             if (_weekly.isNotEmpty) ...[
               const SizedBox(height: 8),
               _TrendBars(weekly: _weekly),
@@ -235,6 +250,57 @@ class _TrendBars extends StatelessWidget {
                               maxTotal,
                       decoration: BoxDecoration(
                         color: const Color(0xFF6366F1),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      (week['week_start']?.toString() ?? '').length >= 10
+                          ? week['week_start'].toString().substring(5, 10)
+                          : '',
+                      style: const TextStyle(fontSize: 7, height: 1.2),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RetentionBars extends StatelessWidget {
+  const _RetentionBars({required this.retention});
+
+  final List<Map<String, dynamic>> retention;
+
+  @override
+  Widget build(BuildContext context) {
+    final weeks = retention.reversed.toList(growable: false);
+    return SizedBox(
+      height: 56,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          for (final week in weeks)
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 2),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Text(
+                      week['rate'] == null
+                          ? '-'
+                          : '${(week['rate'] as num).toInt()}%',
+                      style: const TextStyle(fontSize: 8, height: 1.2),
+                    ),
+                    Container(
+                      height: 2 +
+                          30 * ((week['rate'] as num?)?.toDouble() ?? 0) / 100,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF0D9488),
                         borderRadius: BorderRadius.circular(2),
                       ),
                     ),

--- a/scripts/check_duplicate_dispose.py
+++ b/scripts/check_duplicate_dispose.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Detect duplicated cleanup statements inside Flutter dispose() bodies.
+
+part 280 の本番バグ (_annualRateControllers の二重 dispose → dispose 中断 →
+Timer 未解放 → defunct setState) の再発防止ゲート。lib/ 配下の全 dispose()
+ボディを brace バランスで抽出し、同一文の重複を検出したら exit 1。
+
+Usage: python scripts/check_duplicate_dispose.py [root]
+"""
+
+from __future__ import annotations
+
+import collections
+import pathlib
+import re
+import sys
+
+DISPOSE_RE = re.compile(r"void\s+dispose\(\)\s*\{")
+
+
+def dispose_bodies(source: str):
+    for match in DISPOSE_RE.finditer(source):
+        index = match.end()
+        depth = 1
+        while index < len(source) and depth > 0:
+            char = source[index]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            index += 1
+        line = source[: match.start()].count("\n") + 1
+        yield line, source[match.end() : index - 1]
+
+
+def find_duplicates(root: pathlib.Path):
+    hits = []
+    for path in sorted(root.glob("lib/**/*.dart")):
+        source = path.read_text(encoding="utf-8", errors="replace")
+        for line, body in dispose_bodies(source):
+            statements = [
+                stripped
+                for raw in body.splitlines()
+                if (stripped := raw.strip()).endswith(";")
+                and not stripped.startswith("//")
+            ]
+            for statement, count in collections.Counter(statements).items():
+                if count > 1:
+                    hits.append(
+                        f"{path.as_posix()}:{line} x{count}: {statement[:100]}"
+                    )
+    return hits
+
+
+def main() -> int:
+    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else ".")
+    hits = find_duplicates(root)
+    if hits:
+        print("Duplicate statements found in dispose() bodies:")
+        for hit in hits:
+            print(f"- {hit}")
+        print(
+            "二重 dispose は dispose 中断→リソース未解放を招きます"
+            " (part 280 実例)。重複行を削除してください。"
+        )
+        return 1
+    print("check_duplicate_dispose: CLEAN (no duplicated dispose statements)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/migrations/20260613150000_display_mode_weekly_retention.sql
+++ b/supabase/migrations/20260613150000_display_mode_weekly_retention.sql
@@ -1,0 +1,101 @@
+-- 標準維持率の推移 (週末時点 as-of) を集計へ追加。CFO カードの折れ線用。
+create or replace function public.display_mode_experiment_summary()
+returns jsonb
+language sql
+security definer
+set search_path = public
+as $$
+  select jsonb_build_object(
+    'initial_minimum',
+      count(*) filter (where event_type = 'initial' and mode = 'minimum'),
+    'initial_standard',
+      count(*) filter (where event_type = 'initial' and mode = 'standard'),
+    'initial_full',
+      count(*) filter (where event_type = 'initial' and mode = 'full'),
+    'switch_total', count(*) filter (where event_type = 'switch'),
+    'standard_retained', (
+      select count(*)
+      from display_mode_events i
+      where i.event_type = 'initial' and i.mode = 'standard'
+        and not exists (
+          select 1 from display_mode_events s
+          where s.user_id = i.user_id
+            and s.event_type = 'switch'
+            and s.created_at > i.created_at
+        )
+    ),
+    'first_event_at', (select min(created_at) from display_mode_events),
+    'weekly', (
+      select coalesce(
+        jsonb_agg(week_row order by week_start desc),
+        '[]'::jsonb
+      )
+      from (
+        select
+          date_trunc('week', created_at)::date as week_start,
+          jsonb_build_object(
+            'week_start', date_trunc('week', created_at)::date,
+            'initials',
+              count(*) filter (where event_type = 'initial'),
+            'initial_standard',
+              count(*) filter (
+                where event_type = 'initial' and mode = 'standard'
+              ),
+            'switches', count(*) filter (where event_type = 'switch')
+          ) as week_row
+        from display_mode_events
+        group by 1
+        order by 1 desc
+        limit 8
+      ) weeks
+    ),
+    'weekly_retention', (
+      select coalesce(
+        jsonb_agg(
+          jsonb_build_object('week_start', week_start, 'rate', rate)
+          order by week_start desc
+        ),
+        '[]'::jsonb
+      )
+      from (
+        select
+          w.week_start,
+          case
+            when totals.total = 0 then null
+            else round(100.0 * totals.kept / totals.total)
+          end as rate
+        from (
+          select distinct
+            date_trunc('week', created_at)::date as week_start,
+            date_trunc('week', created_at) + interval '7 days' as week_end
+          from display_mode_events
+          order by 1 desc
+          limit 8
+        ) w
+        cross join lateral (
+          select
+            count(*) as total,
+            count(*) filter (
+              where not exists (
+                select 1 from display_mode_events s
+                where s.user_id = i.user_id
+                  and s.event_type = 'switch'
+                  and s.created_at > i.created_at
+                  and s.created_at < w.week_end
+              )
+            ) as kept
+          from display_mode_events i
+          where i.event_type = 'initial'
+            and i.mode = 'standard'
+            and i.created_at < w.week_end
+        ) totals
+      ) rates
+    )
+  )
+  from display_mode_events;
+$$;
+
+revoke all on function public.display_mode_experiment_summary() from public;
+revoke all on function public.display_mode_experiment_summary() from anon;
+grant execute on function public.display_mode_experiment_summary()
+  to authenticated;

--- a/test/services/asset_management_display_mode_store_test.dart
+++ b/test/services/asset_management_display_mode_store_test.dart
@@ -271,5 +271,78 @@ void main() {
       await store.markRestoreDeclined();
       expect(await store.isRestoreDeclined(), isTrue);
     });
+
+    test('parseServerSummary reads weekly retention series', () {
+      final parsed = AssetManagementDisplayModeStore.parseServerSummary(
+        <String, dynamic>{
+          'initial_standard': 0,
+          'weekly_retention': <Map<String, dynamic>>[
+            <String, dynamic>{'week_start': '2026-06-08', 'rate': 75},
+            <String, dynamic>{'week_start': '2026-06-01', 'rate': null},
+          ],
+        },
+      );
+
+      expect(parsed.weeklyRetention, hasLength(2));
+      expect(parsed.weeklyRetention.first['rate'], 75);
+      expect(parsed.weeklyRetention.last['rate'], isNull);
+    });
+
+    test('evaluateMirrorPrefRows reports only newer differing prefs', () {
+      final local = DateTime(2026, 6, 13, 10, 0);
+      final rows = <Map<String, dynamic>>[
+        <String, dynamic>{
+          'pref_key': 'display_mode',
+          'value': <String, dynamic>{'mode': 'standard'},
+          'updated_at': DateTime(2026, 6, 13, 11, 0).toUtc().toIso8601String(),
+        },
+        <String, dynamic>{
+          'pref_key': 'section_overrides',
+          'value': <String, dynamic>{'chart': 'pinned'},
+          'updated_at': DateTime(2026, 6, 13, 11, 0).toUtc().toIso8601String(),
+        },
+      ];
+
+      final diff = AssetManagementDisplayModeStore.evaluateMirrorPrefRows(
+        rows: rows,
+        currentMode: AssetManagementDisplayMode.minimum,
+        currentOverrides: const <AssetManagementSectionId,
+            AssetManagementSectionVisibilityOverride>{},
+        localChangedAt: local,
+      );
+
+      expect(diff.mode, AssetManagementDisplayMode.standard);
+      expect(
+        diff.overrides?[AssetManagementSectionId.chart],
+        AssetManagementSectionVisibilityOverride.pinned,
+      );
+    });
+
+    test('evaluateMirrorPrefRows skips self-writes and same content', () {
+      final local = DateTime(2026, 6, 13, 10, 0);
+      final selfWrite = <String, dynamic>{
+        'pref_key': 'display_mode',
+        'value': <String, dynamic>{'mode': 'standard'},
+        'updated_at': DateTime(2026, 6, 13, 10, 0, 5).toUtc().toIso8601String(),
+      };
+      final sameContent = <String, dynamic>{
+        'pref_key': 'section_overrides',
+        'value': <String, dynamic>{'chart': 'pinned'},
+        'updated_at': DateTime(2026, 6, 13, 12, 0).toUtc().toIso8601String(),
+      };
+
+      final diff = AssetManagementDisplayModeStore.evaluateMirrorPrefRows(
+        rows: <Map<String, dynamic>>[selfWrite, sameContent],
+        currentMode: AssetManagementDisplayMode.minimum,
+        currentOverrides: const <AssetManagementSectionId,
+            AssetManagementSectionVisibilityOverride>{
+          AssetManagementSectionId.chart:
+              AssetManagementSectionVisibilityOverride.pinned,
+        },
+        localChangedAt: local,
+      );
+
+      expect(diff.isEmpty, isTrue);
+    });
   });
 }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -330,5 +330,59 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets('mirror update notice offers and applies remote prefs', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_management_display_mode_v1': 'minimum',
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugMirrorPrefsRows: <Map<String, dynamic>>[
+              <String, dynamic>{
+                'pref_key': 'display_mode',
+                'value': const <String, dynamic>{'mode': 'standard'},
+                'updated_at': DateTime.now()
+                    .add(const Duration(hours: 1))
+                    .toUtc()
+                    .toIso8601String(),
+              },
+            ],
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('他端末で表示設定が更新されています'), findsOneWidget);
+      expect(
+        tester
+            .widget<ChoiceChip>(
+              find.byKey(const Key('asset_display_mode_minimum')),
+            )
+            .selected,
+        isTrue,
+      );
+
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('取り込む'));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        tester
+            .widget<ChoiceChip>(
+              find.byKey(const Key('asset_display_mode_standard')),
+            )
+            .selected,
+        isTrue,
+      );
+
+      await _unmount(tester);
+    });
   });
 }


### PR DESCRIPTION
## 概要

1. **反映通知の widget テスト** — 判定ロジックを `evaluateMirrorPrefRows`(store 静的関数)へ抽出して単体テスト化(新しい差分のみ検出/自端末書込マージン/同一内容スキップ)。さらに `@visibleForTesting debugMirrorPrefsRows` でミラー行を直接注入し、**SnackBar 表示→「取り込む」タップ→モード適用(ChoiceChip.selected で検証)**まで pump で確認。※「supabase fake」案は auth セッション偽装まで必要になり費用対効果が悪いため、#3267 で実証済みの debug 注入方式を採用(判断根拠として記録)。
2. **標準維持率の推移グラフ** — rpc に `weekly_retention`(各週末時点 as-of の維持率%、lateral 集計・直近8週)を追加し、CFO カードに「標準維持率%の推移」棒グラフを表示(rate null 週は「-」)。
3. **既定固定費オフのテストフック → 不要と判断** — フィクスチャは実定数(家賃63,000+KDDI5,764@25日)を織り込む方が本番挙動に忠実で、本番コードにテスト分岐を増やすデメリットが上回る。part 282 で決定論シナリオが既に成立しており、必要になった時点で再検討(コード変更なし・判断の記録)。
4. **監査スクリプトの常設+CI 組込み** — `scripts/check_duplicate_dispose.py`(dispose() ボディの重複文検出・検出時 exit 1)を新設し、ci.yml の静的ゲート(既存の inline-Python 安全チェック直後)へ追加。part 280 の dispose 二重バグ系統の再発を CI で恒久防止。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) ミラー行注入→通知→取り込みでモード切替 (2) evaluateMirrorPrefRows の新旧/同一内容判定 (3) weekly_retention のパース。既存分含め計 50 ケース(widget 10 + service 40)。
- E2E例外: サーバ変更は既存集計関数の replace 1本(スキーマ変更なし)、ほかはクライアント+CI スクリプト。widget pump がエンドツーエンド相当の UI 検証を担い、本番疎通は既存 Playwright smoke で補完する。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `python scripts/check_duplicate_dispose.py` **CLEAN** / `flutter test` **50/50 PASS**。compare diff-stat ゲート確認済み(page -71 は判定ロジックの store 移設分)。

## High-risk gate

- High-risk-ultrareview-exception: 既存 security definer 集計関数への weekly_retention 1キー追加の replace のみで、テーブル・RLS・認証・課金・Edge Function に変更なし。ci.yml 追加は読み取り専用の静的チェック1ステップ。レビュー所有者: Claude Code #1。
- 自己点検メモ: security = 集計値のみ・anon revoke 継続 / rollback = 前版 SQL(part 282 migration に全文)re-apply + ci.yml 1ステップ削除で即復旧 / data migration = なし / prod smoke = 本PRの DB + Edge smoke green / observability = 監査スクリプトは検出時に対象行を列挙して exit 1。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
