### PR TITLE
fix(asset): premium AIチェーンの実働化 — OpenAI param 修正と思考トークン予算

### DIFF
--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -63,7 +63,10 @@ class AssetManagementAiProposalExtraction {
 }
 
 class AssetManagementAiSummaryService {
-  static const int _summaryMaxTokens = 3200;
+  // GPT-5 の reasoning トークンや Gemini の thinking トークンも
+  // この上限を消費するため、本文 (約3,000トークン) に思考分の余裕を足す。
+  // 3,200 では Gemini 3.1 Pro が本文出力前に MAX_TOKENS で途中終了した。
+  static const int _summaryMaxTokens = 8000;
 
   final bool _aiEnabled;
   final AiHubChatService _chatService;

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -616,6 +616,16 @@ function applyProviderGenerationOptions(
     };
   }
 
+  if (providerId === "openai") {
+    // OpenAI の新世代モデル (gpt-5 / o系) は max_tokens を拒否するため
+    // max_completion_tokens を使う (gpt-4o 系も同パラメータを受理する)。
+    // groq / deepinfra 等の OpenAI 互換プロバイダーは従来どおり max_tokens。
+    return {
+      ...requestBody,
+      max_completion_tokens: maxTokens,
+    };
+  }
+
   return {
     ...requestBody,
     max_tokens: maxTokens,

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -57,7 +57,7 @@ void main() {
       expect(result.text, 'AIが生成した日本語要約です。');
       expect(capturedBody?['action'], 'provider.chat_auto');
       expect(capturedBody?['tier'], 'performance');
-      expect(capturedBody?['max_tokens'], 3200);
+      expect(capturedBody?['max_tokens'], 8000);
       expect(capturedBody?['trace_id'], 'asset-management-ai-summary');
       expect(
         capturedBody?['message'].toString().contains('AIに渡す詳細ペイロード'),
@@ -183,7 +183,7 @@ void main() {
         expect(calls.single['action'], 'provider.chat');
         expect(calls.single['provider'], 'anthropic');
         expect(calls.single['model'], 'claude-opus-4-7');
-        expect(calls.single['max_tokens'], 3200);
+        expect(calls.single['max_tokens'], 8000);
         expect(calls.single['routing_use_case'], 'summary');
         expect(
           calls.single['provider_choice_reason'],


### PR DESCRIPTION
## 概要

PR #3274 でプロバイダールーティングを有効化した後、本番初回呼び出しで premium チェーン3社が全滅し決定論フォールバックに落ちた問題への対応（part 271 シリーズ第10弾）。ユーザーが3社分の実エラーログを取得してくれたため原因が確定した。

### 3社の失敗原因と対処

| プロバイダー | 実エラー | 対処 |
|---|---|---|
| anthropic | `Your credit balance is too low to access the Anthropic API`（402系） | **コード対象外** — Anthropic API のクレジット購入が必要（プロバイダー側課金）。チェーンは fail-fast で次へ進む |
| openai | 400 `'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.` | ai-hub の `applyProviderGenerationOptions` で **openai プロバイダーのみ `max_completion_tokens`** を送る。gpt-4o 系も同パラメータを受理。groq/deepinfra 等の OpenAI 互換プロバイダーは従来どおり `max_tokens`（互換層が新パラメータ未対応の可能性があるため不変） |
| google | `finish_reason: MAX_TOKENS`（本文出力前に途中終了） | gemini-3.1-pro / gpt-5 は thinking・reasoning トークンが出力上限を消費するため、要約の `maxTokens` を 3,200 → **8,000** に引き上げ（上限はキャップであり課金は実出力分のみ） |

この2修正により、Anthropic 未課金の状態でも **GPT-5 が実働プライマリ**になる（anthropic fail-fast → openai 成功）。

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. openai 宛リクエスト → body に `max_completion_tokens` が入り `max_tokens` が入らない
  2. groq 等の互換プロバイダー宛 → 従来どおり `max_tokens`（回 regression なし）
  3. 要約呼び出し → `max_tokens: 8000` が送られる（既存単体テストのアサーション更新で担保）
- クライアント側はサービス単体テスト18件 PASS（上限アサーション更新含む）。EF 側の分岐は純関数 `applyProviderGenerationOptions` への1分岐追加
- E2E-Exception: ai-hub EF の実プロバイダー呼び出しは外部APIキーと課金前提のため自動E2E不可。本番反映後にAI要約を再生成し、ソース表示（openai）と完走を手動確認する。

## High-risk レビュー宣言

- レビューオーナー: Claude Code #1
- High-risk-ultrareview-exception: 変更は ai-hub EF の純関数 `applyProviderGenerationOptions` への openai 分岐1件（リクエストパラメータ名の修正のみ）と、クライアント定数 `_summaryMaxTokens` の引き上げ、対応するテストアサーション更新の計3ファイル+16/-3行。認証・RLS・migration・シークレットの変更なし。失敗時挙動は既存のチェーン fallback と決定論要約に収束するため ultrareview は省略し、本番反映後の実呼び出し確認で代替する。

## 検証

- `flutter test`（ai_summary 18件）: All tests passed
- `dart analyze`: No issues found
- `deno fmt --check`: 内容差分なし（行末はリポジトリ格納時に LF 正規化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
