### PR TITLE
fix(ai-hub): OPENAI_COMPAT_BODY 残留の max_tokens を除去し gpt-5 を実働化

### DIFF
--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -600,6 +600,28 @@ function applyProviderGenerationOptions(
   options?: ProviderCallOptions,
 ): Record<string, unknown> {
   const maxTokens = options?.maxTokens;
+
+  if (providerId === "openai") {
+    // OpenAI の新世代モデル (gpt-5 / o系) は max_tokens パラメータ自体を
+    // 拒否するため、ベース body (OPENAI_COMPAT_BODY) の max_tokens: 512 を
+    // 取り除いた上で max_completion_tokens へ載せ替える。
+    // groq / deepinfra 等の OpenAI 互換プロバイダーは従来どおり max_tokens。
+    const body: Record<string, unknown> = { ...requestBody };
+    const legacyMaxTokens = body.max_tokens;
+    delete body.max_tokens;
+    const model = String(body.model ?? "");
+    if (model.startsWith("gpt-5") || /^o\d/.test(model)) {
+      // reasoning モデルは温度指定も拒否する (既定値のみ許容)。
+      delete body.temperature;
+    }
+    const budget = maxTokens ??
+      (typeof legacyMaxTokens === "number" ? legacyMaxTokens : undefined);
+    if (budget != null) {
+      body.max_completion_tokens = budget;
+    }
+    return body;
+  }
+
   if (!maxTokens) return requestBody;
 
   if (providerId === "google" || providerId === "google_flash_lite") {
@@ -613,16 +635,6 @@ function applyProviderGenerationOptions(
         ...generationConfig,
         maxOutputTokens: maxTokens,
       },
-    };
-  }
-
-  if (providerId === "openai") {
-    // OpenAI の新世代モデル (gpt-5 / o系) は max_tokens を拒否するため
-    // max_completion_tokens を使う (gpt-4o 系も同パラメータを受理する)。
-    // groq / deepinfra 等の OpenAI 互換プロバイダーは従来どおり max_tokens。
-    return {
-      ...requestBody,
-      max_completion_tokens: maxTokens,
     };
   }
 


### PR DESCRIPTION
## 概要

PR #3277 後の本番再生成で premium チェーンが実働し Gemini 3.1 Pro が高品質な分析を返すことを確認（§7「新規提案なし」も正常）。一方、**OpenAI (gpt-5) だけが修正前と同じ `max_tokens` 400 を返し続けた**問題の追従修正（part 271 シリーズ第11弾）。

### 真因

`OPENAI_COMPAT_BODY`（プロバイダー登録のベース body ビルダー）が `max_tokens: 512` を**焼き込んで**おり、#3277 の修正は `max_completion_tokens` を spread で**追加**しただけで、**残留した `max_tokens` キーがそのまま送信されていた**。gpt-5 はパラメータの存在自体を拒否するためエラーが継続した。

### 変更内容（`applyProviderGenerationOptions` のみ）

1. openai 分岐を `if (!maxTokens) return` の**早期 return より前**へ移動（explicit maxTokens が無い呼び出しでもベースの 512 を変換して引き継ぐ）
2. `max_tokens` キーを**削除**してから `max_completion_tokens` へ載せ替え
3. gpt-5 / o系 reasoning モデルは `temperature` 指定も拒否するため同時に除去（次に出るはずだった 400 の先回り。gpt-4o 系・groq 等互換プロバイダーの挙動は不変）

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースの観点で確認
  1. openai + gpt-5 + maxTokens 指定 → body に max_tokens が存在せず max_completion_tokens が載る
  2. openai + maxTokens 未指定 → ベースの 512 が max_completion_tokens に変換される
  3. groq / google / anthropic → 従来どおりの body（変更なし）
- 純粋関数1つの分岐変更のみ。DB+Edge smoke（EF 変更で自動実行）と本番反映後の AI 要約再生成で検証する
- E2E-Exception: ai-hub は実プロバイダー API キー前提のため Playwright 公開スモークでは検証不可。本番反映後に AI 要約を再生成し、openai 成功（またはチェーン継続）を実ログで確認する。

## 検証

- `git diff --stat`: 1 file changed（applyProviderGenerationOptions のみ）
- CI の deno lint / fmt / DB+Edge smoke で静的・疎通検証

## High-risk レビュー宣言

- レビューオーナー: Claude Code #1
- High-risk-ultrareview-exception: 本PRは ai-hub EF 内の純粋関数 applyProviderGenerationOptions の openai 分岐修正のみで、権限・シークレット・migration・課金ロジックの変更なし。失敗時も既存のプロバイダーチェーン→決定論フォールバックに収束するため ultrareview は省略し、DB+Edge smoke と本番反映後の実ログ確認で代替する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
