### PR TITLE
docs: mark critique automation blog draft published

### DIFF
--- a/docs/blog-drafts/2026-05-25-claude-code-fifth-cumulative-critique-automation-en.md
+++ b/docs/blog-drafts/2026-05-25-claude-code-fifth-cumulative-critique-automation-en.md
@@ -1,7 +1,7 @@
 ---
 title: "When the same critique recurs 5 times, ship automation instead of a 6th apology — Claude Code 5-cumulative redundancy threshold pattern"
 tags: ClaudeCode,AI,autonomous-agents,indie-dev,buildinpublic
-published: false
+published: true
 ---
 
 # When the same critique recurs 5 times, ship automation instead of a 6th apology — Claude Code 5-cumulative redundancy threshold pattern


### PR DESCRIPTION
﻿Replacement for stale PR #3270, whose original head ref is unavailable for a fresh synchronize event. This PR preserves the same docs-only one-line publish marker update with an active branch.

## Minimal E2E Gate

- Black-box / implementation-detail independent: validate the published-status marker in the markdown file as an input/output document state, not implementation internals.
- Minimal three I/O cases:
  1. Blog draft front matter/status input -> published marker is updated for `2026-05-25-claude-code-fifth-cumulative-critique-automation-en.md`.
  2. Site content reader input -> the draft remains valid markdown after the one-line status change.
  3. No app-code input -> no Flutter, Supabase, workflow, or runtime route behavior changes.
- E2E mechanism: Playwright/public E2E is sufficient as the site smoke check for this docs-only publish marker.
- E2E-Exception: no new `integration_test/` or `test/e2e/` file is added because this PR modifies only one blog draft markdown status line and has no application-code behavior.
