### PR TITLE
feat(asset): 監査initState拡張 + CFOグラフ拡大 + 差分プレビュー + 2クライアント統合テスト (part 284)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -7417,13 +7417,61 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           content: const Text('他端末で表示設定が更新されています'),
           action: SnackBarAction(
             label: '取り込む',
-            onPressed: () =>
-                unawaited(_applyDisplayPrefs(diff.mode, diff.overrides)),
+            onPressed: () => unawaited(_showMirrorDiffPreview(diff)),
           ),
         ),
       );
     } catch (e) {
       debugPrint('display pref mirror check failed: $e');
+    }
+  }
+
+  /// 取り込み前に「旧 → 新」を見せて確定させる差分プレビュー。
+  Future<void> _showMirrorDiffPreview(AssetMirrorPrefsDiff diff) async {
+    if (!mounted) {
+      return;
+    }
+    final lines = AssetManagementDisplayModeStore.describeMirrorPrefsDiff(
+      currentMode: _displayMode,
+      currentOverrides: _sectionOverrides,
+      diff: diff,
+    );
+    if (lines.isEmpty) {
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('表示設定の取り込みプレビュー'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (final line in lines)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(
+                  line,
+                  style: const TextStyle(fontSize: 12, height: 1.5),
+                ),
+              ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            key: const Key('asset_mirror_diff_apply'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('適用する'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      await _applyDisplayPrefs(diff.mode, diff.overrides);
     }
   }
 

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -321,6 +321,39 @@ class AssetManagementDisplayModeStore {
     return AssetMirrorPrefsDiff(mode: newerMode, overrides: newerOverrides);
   }
 
+  /// 取り込み前プレビュー用の「旧 → 新」差分行を組み立てる。
+  static List<String> describeMirrorPrefsDiff({
+    required AssetManagementDisplayMode currentMode,
+    required AssetManagementSectionOverrides currentOverrides,
+    required AssetMirrorPrefsDiff diff,
+  }) {
+    final lines = <String>[];
+    final newMode = diff.mode;
+    if (newMode != null && newMode != currentMode) {
+      lines.add('表示モード: ${currentMode.label} → ${newMode.label}');
+    }
+    final newOverrides = diff.overrides;
+    if (newOverrides != null) {
+      final keys = <AssetManagementSectionId>{
+        ...currentOverrides.keys,
+        ...newOverrides.keys,
+      };
+      for (final section in AssetManagementSectionId.values) {
+        if (!keys.contains(section)) {
+          continue;
+        }
+        final before = currentOverrides[section] ??
+            AssetManagementSectionVisibilityOverride.auto;
+        final after = newOverrides[section] ??
+            AssetManagementSectionVisibilityOverride.auto;
+        if (before != after) {
+          lines.add('${section.label}: ${before.label} → ${after.label}');
+        }
+      }
+    }
+    return lines;
+  }
+
   /// サーババックアップからの表示設定復元をユーザーが辞退したか。
   Future<bool> isRestoreDeclined({SharedPreferences? prefs}) async {
     final store = prefs ?? await SharedPreferences.getInstance();

--- a/lib/widgets/display_mode_experiment_card.dart
+++ b/lib/widgets/display_mode_experiment_card.dart
@@ -104,6 +104,85 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
     return parts.isEmpty ? null : parts.join('・');
   }
 
+  /// タップ拡大: 大きいグラフ+週次の数値表を出す。
+  Future<void> _showExpandedCharts() async {
+    final retentionByWeek = <String, dynamic>{
+      for (final week in _weeklyRetention)
+        week['week_start']?.toString() ?? '': week['rate'],
+    };
+    String cell(Object? value) => value?.toString() ?? '-';
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('表示モード実験 詳細グラフ'),
+        content: SizedBox(
+          width: 460,
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (_weeklyRetention.isNotEmpty) ...[
+                  const Text(
+                    '標準維持率%の推移(週末時点)',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  _RetentionBars(retention: _weeklyRetention, expanded: true),
+                  const SizedBox(height: 12),
+                ],
+                if (_weekly.isNotEmpty) ...[
+                  const Text(
+                    '週次イベント(初期解決=藍 / 切替=橙)',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  _TrendBars(weekly: _weekly, expanded: true),
+                  const SizedBox(height: 12),
+                  const Text(
+                    '週次の数値',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  for (final week in _weekly)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 3),
+                      child: Text(
+                        '${cell(week['week_start'])}週: '
+                        '初期${cell(week['initials'])}'
+                        '(std${cell(week['initial_standard'])}) / '
+                        '切替${cell(week['switches'])} / '
+                        '維持率${cell(retentionByWeek[week['week_start']?.toString() ?? ''])}%',
+                        style: const TextStyle(fontSize: 11, height: 1.5),
+                      ),
+                    ),
+                ],
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('閉じる'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Card(
@@ -126,6 +205,14 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
                       height: 1.4,
                     ),
                   ),
+                ),
+                IconButton(
+                  key: const Key('display_mode_experiment_expand'),
+                  tooltip: 'グラフを拡大',
+                  icon: const Icon(Icons.zoom_out_map, size: 18),
+                  onPressed: _weekly.isEmpty && _weeklyRetention.isEmpty
+                      ? null
+                      : _showExpandedCharts,
                 ),
                 IconButton(
                   key: const Key('display_mode_experiment_refresh'),
@@ -201,9 +288,10 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
 }
 
 class _TrendBars extends StatelessWidget {
-  const _TrendBars({required this.weekly});
+  const _TrendBars({required this.weekly, this.expanded = false});
 
   final List<Map<String, dynamic>> weekly;
+  final bool expanded;
 
   @override
   Widget build(BuildContext context) {
@@ -216,8 +304,9 @@ class _TrendBars extends StatelessWidget {
         maxTotal = initials + switches;
       }
     }
+    final barScale = expanded ? 100.0 : 30.0;
     return SizedBox(
-      height: 60,
+      height: expanded ? 160 : 60,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
@@ -234,7 +323,7 @@ class _TrendBars extends StatelessWidget {
                     ),
                     Container(
                       height: 2 +
-                          30 *
+                          barScale *
                               ((week['switches'] as num?)?.toInt() ?? 0) /
                               maxTotal,
                       decoration: BoxDecoration(
@@ -245,7 +334,7 @@ class _TrendBars extends StatelessWidget {
                     const SizedBox(height: 1),
                     Container(
                       height: 2 +
-                          30 *
+                          barScale *
                               ((week['initials'] as num?)?.toInt() ?? 0) /
                               maxTotal,
                       decoration: BoxDecoration(
@@ -271,15 +360,17 @@ class _TrendBars extends StatelessWidget {
 }
 
 class _RetentionBars extends StatelessWidget {
-  const _RetentionBars({required this.retention});
+  const _RetentionBars({required this.retention, this.expanded = false});
 
   final List<Map<String, dynamic>> retention;
+  final bool expanded;
 
   @override
   Widget build(BuildContext context) {
     final weeks = retention.reversed.toList(growable: false);
+    final barScale = expanded ? 110.0 : 30.0;
     return SizedBox(
-      height: 56,
+      height: expanded ? 170 : 56,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
@@ -298,7 +389,9 @@ class _RetentionBars extends StatelessWidget {
                     ),
                     Container(
                       height: 2 +
-                          30 * ((week['rate'] as num?)?.toDouble() ?? 0) / 100,
+                          barScale *
+                              ((week['rate'] as num?)?.toDouble() ?? 0) /
+                              100,
                       decoration: BoxDecoration(
                         color: const Color(0xFF0D9488),
                         borderRadius: BorderRadius.circular(2),

--- a/scripts/check_duplicate_dispose.py
+++ b/scripts/check_duplicate_dispose.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Detect duplicated cleanup statements inside Flutter dispose() bodies.
+"""Detect duplicated top-level statements in Flutter lifecycle bodies.
 
 part 280 の本番バグ (_annualRateControllers の二重 dispose → dispose 中断 →
-Timer 未解放 → defunct setState) の再発防止ゲート。lib/ 配下の全 dispose()
-ボディを brace バランスで抽出し、同一文の重複を検出したら exit 1。
+Timer 未解放 → defunct setState) の再発防止ゲート。lib/ 配下の全 dispose() /
+initState() ボディを brace バランスで抽出し、**トップレベル文** (コールバック
+内部は対象外) を `;` 区切りで再構成して同一文の重複を検出したら exit 1。
+二重 dispose のほか、二重 addListener / 二重フェッチ起動も同型として捕捉する。
 
 Usage: python scripts/check_duplicate_dispose.py [root]
 """
@@ -15,11 +17,12 @@ import pathlib
 import re
 import sys
 
-DISPOSE_RE = re.compile(r"void\s+dispose\(\)\s*\{")
+LIFECYCLE_RE = re.compile(r"void\s+(dispose|initState)\(\)\s*\{")
+LINE_COMMENT_RE = re.compile(r"(?<!:)//[^\n]*")
 
 
-def dispose_bodies(source: str):
-    for match in DISPOSE_RE.finditer(source):
+def lifecycle_bodies(source: str):
+    for match in LIFECYCLE_RE.finditer(source):
         index = match.end()
         depth = 1
         while index < len(source) and depth > 0:
@@ -30,25 +33,51 @@ def dispose_bodies(source: str):
                 depth -= 1
             index += 1
         line = source[: match.start()].count("\n") + 1
-        yield line, source[match.end() : index - 1]
+        yield match.group(1), line, source[match.end() : index - 1]
+
+
+def top_level_statements(body: str):
+    """コールバック内部 (brace 深度>0) を除いた文を `;` 区切りで返す。"""
+    statements = []
+    current = []
+    brace = 0
+    paren = 0
+    for char in body:
+        if char == "{":
+            brace += 1
+        elif char == "}":
+            brace -= 1
+        elif char == "(":
+            paren += 1
+        elif char == ")":
+            paren -= 1
+        if brace == 0:
+            current.append(char)
+            if char == ";" and paren == 0:
+                statement = re.sub(r"\s+", " ", "".join(current)).strip(" ;")
+                if statement:
+                    statements.append(statement)
+                current = []
+        elif current and brace > 0:
+            # トップレベル文の途中でコールバックへ潜った (例: addListener(() {
+            # ...})) — 文としては継続中なのでプレースホルダだけ残す。
+            if current[-1] != "\x00":
+                current.append("\x00")
+    return statements
 
 
 def find_duplicates(root: pathlib.Path):
     hits = []
     for path in sorted(root.glob("lib/**/*.dart")):
-        source = path.read_text(encoding="utf-8", errors="replace")
-        for line, body in dispose_bodies(source):
-            statements = [
-                stripped
-                for raw in body.splitlines()
-                if (stripped := raw.strip()).endswith(";")
-                and not stripped.startswith("//")
-            ]
-            for statement, count in collections.Counter(statements).items():
+        source = LINE_COMMENT_RE.sub(
+            "", path.read_text(encoding="utf-8", errors="replace")
+        )
+        for kind, line, body in lifecycle_bodies(source):
+            counter = collections.Counter(top_level_statements(body))
+            for statement, count in counter.items():
                 if count > 1:
-                    hits.append(
-                        f"{path.as_posix()}:{line} x{count}: {statement[:100]}"
-                    )
+                    shown = statement.replace("\x00", "{...}")[:100]
+                    hits.append(f"{path.as_posix()}:{line} {kind} x{count}: {shown}")
     return hits
 
 
@@ -56,15 +85,18 @@ def main() -> int:
     root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else ".")
     hits = find_duplicates(root)
     if hits:
-        print("Duplicate statements found in dispose() bodies:")
+        print("Duplicate top-level statements found in lifecycle bodies:")
         for hit in hits:
             print(f"- {hit}")
         print(
-            "二重 dispose は dispose 中断→リソース未解放を招きます"
-            " (part 280 実例)。重複行を削除してください。"
+            "二重 dispose / 二重リスナー登録は dispose 中断やコールバック"
+            "多重発火を招きます (part 280 実例)。重複行を削除してください。"
         )
         return 1
-    print("check_duplicate_dispose: CLEAN (no duplicated dispose statements)")
+    print(
+        "check_duplicate_dispose: CLEAN"
+        " (no duplicated top-level statements in dispose/initState)"
+    )
     return 0
 
 

--- a/test/services/asset_management_display_mode_store_test.dart
+++ b/test/services/asset_management_display_mode_store_test.dart
@@ -344,5 +344,50 @@ void main() {
 
       expect(diff.isEmpty, isTrue);
     });
+
+    test('describeMirrorPrefsDiff renders old → new lines', () {
+      const diff = AssetMirrorPrefsDiff(
+        mode: AssetManagementDisplayMode.standard,
+        overrides: <AssetManagementSectionId,
+            AssetManagementSectionVisibilityOverride>{
+          AssetManagementSectionId.chart:
+              AssetManagementSectionVisibilityOverride.pinned,
+        },
+      );
+
+      final lines = AssetManagementDisplayModeStore.describeMirrorPrefsDiff(
+        currentMode: AssetManagementDisplayMode.minimum,
+        currentOverrides: const <AssetManagementSectionId,
+            AssetManagementSectionVisibilityOverride>{
+          AssetManagementSectionId.calendar:
+              AssetManagementSectionVisibilityOverride.pinned,
+        },
+        diff: diff,
+      );
+
+      expect(lines, contains('表示モード: ミニマム → 標準'));
+      expect(lines, contains('グラフ: 自動 → 常に表示'));
+      expect(lines, contains('マネーカレンダー: 常に表示 → 自動'));
+      expect(lines, hasLength(3));
+    });
+
+    test('describeMirrorPrefsDiff returns empty when nothing differs', () {
+      const overrides =
+          <AssetManagementSectionId, AssetManagementSectionVisibilityOverride>{
+        AssetManagementSectionId.chart:
+            AssetManagementSectionVisibilityOverride.pinned,
+      };
+
+      final lines = AssetManagementDisplayModeStore.describeMirrorPrefsDiff(
+        currentMode: AssetManagementDisplayMode.standard,
+        currentOverrides: overrides,
+        diff: const AssetMirrorPrefsDiff(
+          mode: AssetManagementDisplayMode.standard,
+          overrides: overrides,
+        ),
+      );
+
+      expect(lines, isEmpty);
+    });
   });
 }

--- a/test/services/mirror_two_client_scenario_test.dart
+++ b/test/services/mirror_two_client_scenario_test.dart
@@ -1,0 +1,241 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_expected_inflow_store.dart';
+import 'package:my_web_app/services/asset_management_display_mode_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// ミラー系 (入金予定 / 表示設定) の「端末A → サーバ → 端末B」統合シナリオ。
+///
+/// サーバは asset_pref_mirror / inflow ミラーの行リスト (List<Map>) として
+/// 模擬し、端末の切替は SharedPreferences のモック初期値を差し替えて表現する
+/// (切替後は旧ハンドルへ触らない逐次シミュレーション)。supabase クライアント
+/// 本体の fake 化は auth セッション偽装が必要になるため採らない (part 283 判断)。
+
+const String _inflowItemsKey = 'asset_expected_inflows_v1';
+
+Future<SharedPreferences> _switchClient([
+  Map<String, Object> seed = const <String, Object>{},
+]) async {
+  SharedPreferences.setMockInitialValues(seed);
+  return SharedPreferences.getInstance();
+}
+
+/// ページの upsert と同じ shape でローカル状態をサーバ行へ展開する。
+List<Map<String, dynamic>> _uploadInflows(
+  List<AssetExpectedInflow> items,
+  List<AssetExpectedInflowRule> rules,
+) {
+  return <Map<String, dynamic>>[
+    for (final rule in rules)
+      <String, dynamic>{
+        'id': rule.id,
+        'kind': 'rule',
+        'day_of_month': rule.dayOfMonth,
+        'amount': rule.amount,
+        'label': rule.label,
+      },
+    for (final item in items)
+      <String, dynamic>{
+        'id': item.id,
+        'kind': 'one_time',
+        'date': item.date.toUtc().toIso8601String(),
+        'amount': item.amount,
+        'label': item.label,
+      },
+  ];
+}
+
+void main() {
+  group('mirror two-client scenarios', () {
+    test('client A uploads inflows and empty client B restores identically',
+        () async {
+      final prefsA = await _switchClient();
+      final storeA = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 13, 9),
+      );
+      await storeA.add(
+        date: DateTime(2026, 6, 25),
+        amount: 280000,
+        label: '給料',
+        prefs: prefsA,
+      );
+      await storeA.add(
+        date: DateTime(2026, 6, 30),
+        amount: 12000,
+        label: 'フリマ売上',
+        prefs: prefsA,
+      );
+      await storeA.addRule(
+        dayOfMonth: 15,
+        amount: 30000,
+        label: '副業振込',
+        prefs: prefsA,
+      );
+      final itemsA = await storeA.loadAll(prefs: prefsA);
+      final rulesA = await storeA.loadRules(prefs: prefsA);
+      final serverRows = _uploadInflows(itemsA, rulesA);
+
+      final prefsB = await _switchClient();
+      final storeB = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 13, 10),
+      );
+      final restored = await storeB.restoreFromMirrorRows(
+        serverRows,
+        prefs: prefsB,
+      );
+
+      expect(restored, isTrue);
+      final itemsB = await storeB.loadAll(prefs: prefsB);
+      final rulesB = await storeB.loadRules(prefs: prefsB);
+      expect(
+        itemsB.map((item) => '${item.id}|${item.date}|${item.amount}'),
+        itemsA.map((item) => '${item.id}|${item.date}|${item.amount}'),
+      );
+      expect(rulesB.single.id, rulesA.single.id);
+      expect(rulesB.single.dayOfMonth, 15);
+
+      // 既にローカルがある端末では復元は no-op (上書き事故防止)。
+      expect(
+        await storeB.restoreFromMirrorRows(serverRows, prefs: prefsB),
+        isFalse,
+      );
+    });
+
+    test(
+        'client B addition merges into client A as union '
+        '(local deletion resurrects without tombstones)', () async {
+      // 端末A: 2件登録してサーバへ反映。
+      final prefsA1 = await _switchClient();
+      final storeA = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 13, 9),
+      );
+      await storeA.add(
+        date: DateTime(2026, 6, 25),
+        amount: 280000,
+        label: '給料',
+        prefs: prefsA1,
+      );
+      await storeA.add(
+        date: DateTime(2026, 6, 30),
+        amount: 12000,
+        label: 'フリマ売上',
+        prefs: prefsA1,
+      );
+      var serverRows = _uploadInflows(
+        await storeA.loadAll(prefs: prefsA1),
+        const <AssetExpectedInflowRule>[],
+      );
+      final snapshotA = <String, Object>{
+        _inflowItemsKey: prefsA1.getString(_inflowItemsKey)!,
+      };
+
+      // 端末B: 復元後に1件追加してサーバへ反映。
+      final prefsB = await _switchClient();
+      final storeB = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 14, 9),
+      );
+      await storeB.restoreFromMirrorRows(serverRows, prefs: prefsB);
+      await storeB.add(
+        date: DateTime(2026, 7, 10),
+        amount: 50000,
+        label: 'ボーナス',
+        prefs: prefsB,
+      );
+      serverRows = _uploadInflows(
+        await storeB.loadAll(prefs: prefsB),
+        const <AssetExpectedInflowRule>[],
+      );
+      expect(serverRows, hasLength(3));
+
+      // 端末Aへ戻り、フリマ売上をローカル削除してから手動統合する。
+      final prefsA2 = await _switchClient(snapshotA);
+      final removedId = (await storeA.loadAll(prefs: prefsA2))
+          .firstWhere((item) => item.label == 'フリマ売上')
+          .id;
+      await storeA.remove(removedId, prefs: prefsA2);
+
+      final added = await storeA.mergeFromMirrorRows(
+        serverRows,
+        prefs: prefsA2,
+      );
+      final merged = await storeA.loadAll(prefs: prefsA2);
+
+      // 和集合マージ: B の追加分に加え、トゥームストーンが無いため
+      // ローカル削除済みの ID もサーバ残存分から復活する (仕様の明文化)。
+      expect(added, 2);
+      expect(merged, hasLength(3));
+      expect(merged.map((item) => item.label), contains('ボーナス'));
+      expect(merged.map((item) => item.id), contains(removedId));
+    });
+
+    test('client B applies display prefs diff from client A rows', () async {
+      // 端末A: 標準モード + グラフ常時表示を保存しサーバ行へ展開。
+      final prefsA = await _switchClient();
+      const displayStore = AssetManagementDisplayModeStore();
+      await displayStore.save(
+        AssetManagementDisplayMode.standard,
+        prefs: prefsA,
+        recordEvent: false,
+      );
+      await displayStore.saveOverride(
+        AssetManagementSectionId.chart,
+        AssetManagementSectionVisibilityOverride.pinned,
+        prefs: prefsA,
+      );
+      final modeA = await displayStore.load(prefs: prefsA);
+      final overridesA = await displayStore.loadOverrides(prefs: prefsA);
+      final updatedAt = DateTime(2026, 6, 13, 12).toUtc().toIso8601String();
+      final serverRows = <Map<String, dynamic>>[
+        <String, dynamic>{
+          'pref_key': 'display_mode',
+          'value': <String, dynamic>{'mode': modeA.storageId},
+          'updated_at': updatedAt,
+        },
+        <String, dynamic>{
+          'pref_key': 'section_overrides',
+          'value': <String, dynamic>{
+            for (final entry in overridesA.entries)
+              entry.key.storageId: entry.value.storageId,
+          },
+          'updated_at': updatedAt,
+        },
+      ];
+
+      // 端末B: ミニマム運用中。通知判定 → 差分プレビュー → 適用。
+      final prefsB = await _switchClient(<String, Object>{
+        'asset_management_display_mode_v1': 'minimum',
+      });
+      final modeB = await displayStore.load(prefs: prefsB);
+      final overridesB = await displayStore.loadOverrides(prefs: prefsB);
+      final diff = AssetManagementDisplayModeStore.evaluateMirrorPrefRows(
+        rows: serverRows,
+        currentMode: modeB,
+        currentOverrides: overridesB,
+        localChangedAt: DateTime(2026, 6, 13, 8),
+      );
+
+      expect(diff.mode, AssetManagementDisplayMode.standard);
+      final preview = AssetManagementDisplayModeStore.describeMirrorPrefsDiff(
+        currentMode: modeB,
+        currentOverrides: overridesB,
+        diff: diff,
+      );
+      expect(preview, contains('表示モード: ミニマム → 標準'));
+      expect(preview, contains('グラフ: 自動 → 常に表示'));
+
+      final newMode = diff.mode;
+      if (newMode != null) {
+        await displayStore.save(newMode, prefs: prefsB, recordEvent: false);
+      }
+      for (final entry in (diff.overrides ?? overridesB).entries) {
+        await displayStore.saveOverride(
+          entry.key,
+          entry.value,
+          prefs: prefsB,
+        );
+      }
+
+      expect(await displayStore.load(prefs: prefsB), modeA);
+      expect(await displayStore.loadOverrides(prefs: prefsB), overridesA);
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -373,6 +373,20 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200));
       await tester.pump(const Duration(milliseconds: 200));
 
+      // 取り込み前に「旧 → 新」差分プレビューで確認させる。
+      expect(find.text('表示設定の取り込みプレビュー'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('表示モード: ミニマム → 標準'),
+        ),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const Key('asset_mirror_diff_apply')));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
       expect(
         tester
             .widget<ChoiceChip>(


### PR DESCRIPTION
## 概要

1. **監査スクリプトの対象拡張** — `scripts/check_duplicate_dispose.py` を dispose() + initState() 対応へ書き換え。素朴な行比較では `);` や複数コールバック内の同形行が false positive になるため、brace/paren 深度でトップレベル文を再構成しコールバック内部(`{...}` プレースホルダ化)を除外する方式に変更。合成重複ファイル(二重 dispose / 二重 addListener)で検出力を自己検証(exit 1 確認)済み。lib/ 全走査は CLEAN。
2. **CFO グラフのタップ拡大** — 実験カードへ拡大ボタン(`zoom_out_map` / データ無し時は無効)を追加し、大型版グラフ(維持率推移・週次イベント 2 色バー)+「週次の数値」一覧をダイアログ表示。バー描画は `expanded` パラメータでスケール切替(小: 高さ60 / 大: 160)。
3. **反映通知に取り込み前の差分プレビュー** — 「取り込む」タップで即適用せず、`describeMirrorPrefsDiff`(store 静的関数)が組み立てる「旧 → 新」行(表示モード/セクション別 pin・hide)を AlertDialog で提示し、「適用する」確定後にのみ反映。他端末設定の不意の上書きをもう一段防ぐ。
4. **ミラー系の 2 クライアント同時シナリオ統合テスト** — サーバを行リストで模擬し SharedPreferences 差し替えで端末 A/B を逐次シミュレーション。(a) A 登録 → 空端末 B 復元で完全一致+非空端末では no-op、(b) B 追加・A ローカル削除 → 手動統合で和集合+トゥームストーン無しの復活挙動を仕様として明文化、(c) 表示設定 A 行 → B の evaluate→describe→apply で最終状態一致。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核は次の 3ケース: (1) 空端末復元の完全一致 (2) 和集合マージと削除復活の明文化 (3) 差分プレビュー経由の取り込みフロー(SnackBar→プレビュー→適用→ChoiceChip.selected)。今回追加・更新分は service 5 + widget 1、全体では flutter test 680 ケース。
- E2E例外: 変更はクライアント+テスト+CI 静的スクリプトのみでサーバ・スキーマ変更なし。widget pump がエンドツーエンド相当の UI 検証(通知→プレビュー→適用)を担い、本番疎通は既存 Playwright smoke で補完する。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `python scripts/check_duplicate_dispose.py` **CLEAN** / `flutter test` **680/680 PASS**。compare diff-stat ゲート確認済み(+538 -32 / 7 files / 想定外削除なし)。

## High-risk gate

- High-risk-ultrareview-exception: migration・RLS・認証・課金・Edge Function への変更は一切なし(クライアント UI + テスト + 監査スクリプトの精度向上のみ)。監査スクリプトは読み取り専用の静的チェックで、検出時に対象行を列挙して exit 1。レビュー所有者: Claude Code #1。
- 自己点検メモ: rollback = 本 PR revert のみで完結(データ・スキーマ影響ゼロ)/ 差分プレビューはキャンセルで従来どおり何も変更しない安全側設計 / 2 クライアントテストは仕様(復活挙動)の回帰検知を兼ねる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
