### PR TITLE
fix(ai-hub): gpt-5 の空出力を解消 (reasoning_effort=low) + 空応答を失敗扱いに

### DIFF
--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -611,8 +611,14 @@ function applyProviderGenerationOptions(
     delete body.max_tokens;
     const model = String(body.model ?? "");
     if (model.startsWith("gpt-5") || /^o\d/.test(model)) {
-      // reasoning モデルは温度指定も拒否する (既定値のみ許容)。
+      // reasoning モデルは温度指定を拒否する (既定値のみ許容)。
       delete body.temperature;
+      // reasoning_effort を下げないと、推論トークンが max_completion_tokens を
+      // 使い切り本文が 0 トークンになる (gpt-5 が text:"" を返す原因)。
+      // 金額計算は Dart 側で完了済みなので低 effort で十分。
+      if (body.reasoning_effort == null) {
+        body.reasoning_effort = "low";
+      }
     }
     const budget = maxTokens ??
       (typeof legacyMaxTokens === "number" ? legacyMaxTokens : undefined);
@@ -4775,22 +4781,30 @@ serve(async (req: Request) => {
           const modelUsed = pick(data, "model");
           const outputChars = content.length;
           const usedModel = String(modelUsed ?? requestedModel);
-          if (content && isProviderOutputLengthLimited(finishReason)) {
+          // 本文が空のレスポンスは成功扱いにしない。reasoning モデルが
+          // 推論で予算を使い切ると finish_reason=length かつ本文が空になり、
+          // 旧コードは success:true(空文字)で返してフォールバック連鎖を
+          // 止め、無駄なコストだけ計上していた。
+          const lengthLimited = isProviderOutputLengthLimited(finishReason);
+          if (!content.trim() || lengthLimited) {
+            const failureStatus = !content.trim()
+              ? "emptyOutput"
+              : "outputLengthLimited";
             await logProviderChat({
               success: false,
               statusCode: 502,
               model: usedModel,
               outputChars,
-              errorMessage: `outputLengthLimited: ${finishReason}`,
+              errorMessage: `${failureStatus}: ${finishReason ?? "no-content"}`,
             });
             return json({
               success: false,
-              status: "outputLengthLimited",
+              status: failureStatus,
               provider: providerId,
               model: usedModel,
               finish_reason: finishReason,
               message:
-                "AI応答が出力上限で途中終了しました。max_tokens を増やすか、別プロバイダーを試してください。",
+                "AI応答が空、または出力上限で途中終了しました。max_tokens を増やすか、別プロバイダーを試してください。",
             }, 502);
           }
           const estimatedCost = calculateApiCost(


### PR DESCRIPTION
## 概要

PR #3281（gpt-5 のパラメータ修正）後の本番再生成ログで判明した2つの問題の追従修正（part 271 シリーズ第12弾）。Gemini 3.1 Pro は引き続き高品質に動作（履歴差分「前回も同じ指摘を受けたはず」まで言及・§7「新規提案なし」も正常）。

### 観測された問題

1. **gpt-5 が空出力**: `success:true` だが `text:""`（output_chars:0）でコスト約 $0.034 だけ発生。チェーンは空を失敗とみなし Gemini へ継続するため利用者の表示は正常だが、毎回 gpt-5 の呼び出しが無駄になっていた
2. **真因**: gpt-5 は reasoning モデルで、`max_completion_tokens`（8000）に**推論トークンと出力トークンの両方**が含まれる。複雑なプロンプト（入力約34Kトークン）で推論が予算を使い切り、本文出力が 0 トークンになっていた
3. **EF の判定バグ**: 成功パスの `if (content && isProviderOutputLengthLimited(...))` は**本文が空だと条件を満たさず**、`success:true`（空文字）で返してフォールバック連鎖を止め、コストだけ計上していた

### 変更内容（`supabase/functions/ai-hub/index.ts` のみ）

1. **根本原因**: gpt-5 / o系モデルに `reasoning_effort: "low"` を付与（金額計算は Dart 側で完了済みのため低 effort で十分、本文用に予算を確保）。呼び出し側が明示指定していれば尊重
2. **防御**: 成功パスで「本文 trim 後が空」または「出力上限による途中終了」を failure（`emptyOutput` / `outputLengthLimited`、502）として返し、次プロバイダーへ正しく継続。空応答を二度と success 扱いしない

gpt-4o 系・groq 等の互換プロバイダー・他プロバイダーの挙動は不変。

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースの観点で確認
  1. openai + gpt-5 → body に `reasoning_effort: "low"` が載り、本文を出力して `success:true`
  2. 本文が空のプロバイダー応答 → `success:false`（emptyOutput, 502）でチェーンが次へ継続
  3. groq / gemini / anthropic → 従来どおりの body・成功判定（変更なし）
- 純粋関数の分岐追加＋成功パスの条件修正のみ。DB+Edge smoke（EF 変更で自動実行）と本番反映後の実ログで検証
- E2E-Exception: ai-hub は実プロバイダー API キー前提のため Playwright 公開スモークでは検証不可。本番反映後に AI 要約を再生成し、gpt-5 の本文出力（または空時の正しいフォールバック）を実ログで確認する

## 検証

- `git diff --stat`: 1 file changed（applyProviderGenerationOptions と provider.chat 成功パスのみ）
- CI の deno lint / fmt / DB+Edge smoke で静的・疎通検証

## High-risk レビュー宣言

- レビューオーナー: Claude Code #1
- High-risk-ultrareview-exception: 本PRは ai-hub EF 内の生成パラメータ整形と空応答判定の修正のみで、権限・シークレット・migration・課金ロジックの変更なし。失敗時も既存のプロバイダーチェーン→決定論フォールバックに収束するため ultrareview は省略し、DB+Edge smoke と本番反映後の実ログ確認で代替する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
