### PR TITLE
feat(asset): 削除トゥームストーン + 入金取込プレビュー + CFO折れ線/面グラフ + 監査v2 (part 285)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -448,6 +448,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _fetchMustTasks();
     _loadDisplayMode();
     _loadExpectedInflows();
+    unawaited(_pullInflowDeletedIds());
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
       final previousMonthKey = _assetLiabilityStateMonthKey(_now);
@@ -7659,6 +7660,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _removeExpectedInflowRule(String id) async {
     final rules = await _expectedInflowStore.removeRule(id);
     unawaited(_deleteInflowMirror(id));
+    unawaited(_mirrorInflowDeletedIds());
     if (!mounted) {
       return;
     }
@@ -7700,6 +7702,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _removeExpectedInflow(String id) async {
     final entries = await _expectedInflowStore.remove(id);
     unawaited(_deleteInflowMirror(id));
+    unawaited(_mirrorInflowDeletedIds());
     if (!mounted) {
       return;
     }
@@ -8165,30 +8168,143 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  /// 入金予定のミラー取り込みプレビュー行を組み立てる。
+  String _inflowMergeRowLabel(Map<String, dynamic> row) {
+    final label = row['label']?.toString() ?? '入金予定';
+    final amount = (row['amount'] as num?)?.toDouble() ?? 0;
+    if (row['kind']?.toString() == 'rule') {
+      final day = (row['day_of_month'] as num?)?.toInt() ?? 0;
+      return '毎月$day日 $label  +${_formatYen(amount)}';
+    }
+    final date = DateTime.tryParse(row['date']?.toString() ?? '')?.toLocal();
+    final when = date == null ? '' : '${DateFormat('M/d').format(date)} ';
+    return '$when$label  +${_formatYen(amount)}';
+  }
+
+  /// 削除トゥームストーンをサーバへ反映 (他端末の削除伝播用 / #part285)。
+  Future<void> _mirrorInflowDeletedIds() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final ids = await _expectedInflowStore.loadDeletedIds();
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': 'inflow_deleted_ids',
+        'value': <String, dynamic>{'ids': ids.toList()},
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('inflow tombstone mirror upsert failed: $e');
+    }
+  }
+
+  /// サーバのトゥームストーンを取り込み、該当ローカル項目を削除する。
+  Future<void> _pullInflowDeletedIds() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', 'inflow_deleted_ids');
+      if (rows.isEmpty) {
+        return;
+      }
+      final value = rows.first['value'];
+      if (value is! Map) {
+        return;
+      }
+      final rawIds = value['ids'];
+      if (rawIds is! List) {
+        return;
+      }
+      final removed = await _expectedInflowStore.applyRemoteDeletedIds(
+        rawIds.map((dynamic id) => id?.toString() ?? ''),
+      );
+      if (removed > 0 && mounted) {
+        await _loadExpectedInflows();
+      }
+    } catch (e) {
+      debugPrint('inflow tombstone pull failed: $e');
+    }
+  }
+
   Future<void> _mergeInflowsFromMirror() async {
     if (_supabase.auth.currentUser == null) {
       return;
     }
     try {
-      final rows = await _supabase.from('asset_expected_inflow_items').select();
-      final added = await _expectedInflowStore.mergeFromMirrorRows(
-        List<Map<String, dynamic>>.from(rows),
+      // 先に他端末の削除を取り込み、復活候補から除外する。
+      await _pullInflowDeletedIds();
+      final rows = List<Map<String, dynamic>>.from(
+        await _supabase.from('asset_expected_inflow_items').select(),
       );
+      final additions = await _expectedInflowStore.previewMergeAdditions(rows);
       if (!mounted) {
         return;
       }
-      if (added > 0) {
+      if (additions.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('サーバとの差分はありませんでした')),
+        );
+        return;
+      }
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('サーバから取り込む入金予定'),
+          content: SizedBox(
+            width: 420,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '以下の${additions.length}件をローカルへ追加します(削除済みは復活しません)。',
+                    style: const TextStyle(fontSize: 12, height: 1.5),
+                  ),
+                  const SizedBox(height: 8),
+                  for (final row in additions)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Text(
+                        '・${_inflowMergeRowLabel(row)}',
+                        style: const TextStyle(fontSize: 12, height: 1.4),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('キャンセル'),
+            ),
+            ElevatedButton(
+              key: const Key('asset_inflow_merge_apply'),
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: const Text('取り込む'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) {
+        return;
+      }
+      final added = await _expectedInflowStore.mergeFromMirrorRows(rows);
+      if (added > 0 && mounted) {
         await _loadExpectedInflows();
       }
       if (!mounted) {
         return;
       }
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            added > 0 ? '$added件をサーバから統合しました' : 'サーバとの差分はありませんでした',
-          ),
-        ),
+        SnackBar(content: Text('$added件をサーバから統合しました')),
       );
     } catch (e) {
       debugPrint('inflow mirror merge failed: $e');

--- a/lib/services/asset_expected_inflow_store.dart
+++ b/lib/services/asset_expected_inflow_store.dart
@@ -82,6 +82,10 @@ class AssetExpectedInflowStore {
   static const String _key = 'asset_expected_inflows_v1';
   static const String _rulesKey = 'asset_expected_inflow_rules_v1';
 
+  /// 削除済み ID のトゥームストーン。和集合マージやサーバ復元で
+  /// 「一度消した項目」がサーバ残存分から復活するのを抑止する (#part285)。
+  static const String _deletedIdsKey = 'asset_expected_inflow_deleted_ids_v1';
+
   final DateTime Function()? nowProvider;
 
   DateTime _now() => nowProvider?.call() ?? DateTime.now();
@@ -172,6 +176,7 @@ class AssetExpectedInflowStore {
     final rules = _decodeRules(store.getString(_rulesKey))
       ..removeWhere((rule) => rule.id == id);
     await _saveRules(store, rules);
+    await _addDeletedId(store, id);
     return rules;
   }
 
@@ -208,8 +213,70 @@ class AssetExpectedInflowStore {
     }
   }
 
+  /// 削除済み ID の集合を読み出す。
+  Future<Set<String>> loadDeletedIds({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return _decodeIds(store.getString(_deletedIdsKey));
+  }
+
+  Future<void> _addDeletedId(SharedPreferences store, String id) async {
+    if (id.isEmpty) {
+      return;
+    }
+    final ids = _decodeIds(store.getString(_deletedIdsKey))..add(id);
+    await store.setString(_deletedIdsKey, jsonEncode(ids.toList()));
+  }
+
+  Set<String> _decodeIds(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return <String>{};
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) {
+        return <String>{};
+      }
+      return decoded
+          .map((dynamic entry) => entry?.toString() ?? '')
+          .where((id) => id.isNotEmpty)
+          .toSet();
+    } catch (_) {
+      return <String>{};
+    }
+  }
+
+  /// 他端末由来のトゥームストーンを取り込み、該当するローカル項目を削除する。
+  /// 端末Bでの削除を端末Aへ伝播させる用途。削除した件数を返す。
+  Future<int> applyRemoteDeletedIds(
+    Iterable<String> remoteIds, {
+    SharedPreferences? prefs,
+  }) async {
+    final incoming = remoteIds.where((id) => id.isNotEmpty).toSet();
+    if (incoming.isEmpty) {
+      return 0;
+    }
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final tombstones = _decodeIds(store.getString(_deletedIdsKey))
+      ..addAll(incoming);
+    await store.setString(_deletedIdsKey, jsonEncode(tombstones.toList()));
+
+    final items = _decode(store.getString(_key));
+    final rules = _decodeRules(store.getString(_rulesKey));
+    final beforeItems = items.length;
+    final beforeRules = rules.length;
+    items.removeWhere((item) => incoming.contains(item.id));
+    rules.removeWhere((rule) => incoming.contains(rule.id));
+    final removed = (beforeItems - items.length) + (beforeRules - rules.length);
+    if (removed > 0) {
+      await _save(store, items);
+      await _saveRules(store, rules);
+    }
+    return removed;
+  }
+
   /// サーバミラー行からの復元 (#3246 v1)。安全側に倒し、ローカルが
   /// 完全に空の場合のみ全置換する(既存ローカルがあれば何もしない)。
+  /// トゥームストーン済み ID は復元対象から除外する。
   Future<bool> restoreFromMirrorRows(
     List<Map<String, dynamic>> rows, {
     SharedPreferences? prefs,
@@ -220,13 +287,14 @@ class AssetExpectedInflowStore {
     if (localItems.isNotEmpty || localRules.isNotEmpty || rows.isEmpty) {
       return false;
     }
+    final deletedIds = _decodeIds(store.getString(_deletedIdsKey));
     final items = <AssetExpectedInflow>[];
     final rules = <AssetExpectedInflowRule>[];
     for (final row in rows) {
       final id = row['id']?.toString() ?? '';
       final amount = (row['amount'] as num?)?.toDouble() ?? 0;
       final label = row['label']?.toString() ?? '';
-      if (id.isEmpty || amount <= 0) {
+      if (id.isEmpty || amount <= 0 || deletedIds.contains(id)) {
         continue;
       }
       if (row['kind']?.toString() == 'rule') {
@@ -267,8 +335,8 @@ class AssetExpectedInflowStore {
   }
 
   /// ミラーとの手動統合: ローカルに無い ID のみ追加する和集合マージ。
-  /// 削除のトゥームストーンが無いため、ローカルで消した項目がサーバに
-  /// 残っていれば復活し得る(明示的なボタン操作でのみ実行する前提)。
+  /// トゥームストーン済み (ローカルで明示削除した) ID はスキップするため、
+  /// サーバに残っていても復活しない (#part285 本対策)。
   Future<int> mergeFromMirrorRows(
     List<Map<String, dynamic>> rows, {
     SharedPreferences? prefs,
@@ -276,6 +344,7 @@ class AssetExpectedInflowStore {
     final store = prefs ?? await SharedPreferences.getInstance();
     final items = _decode(store.getString(_key));
     final rules = _decodeRules(store.getString(_rulesKey));
+    final deletedIds = _decodeIds(store.getString(_deletedIdsKey));
     final knownIds = <String>{
       for (final item in items) item.id,
       for (final rule in rules) rule.id,
@@ -285,7 +354,10 @@ class AssetExpectedInflowStore {
       final id = row['id']?.toString() ?? '';
       final amount = (row['amount'] as num?)?.toDouble() ?? 0;
       final label = row['label']?.toString() ?? '';
-      if (id.isEmpty || amount <= 0 || knownIds.contains(id)) {
+      if (id.isEmpty ||
+          amount <= 0 ||
+          knownIds.contains(id) ||
+          deletedIds.contains(id)) {
         continue;
       }
       if (row['kind']?.toString() == 'rule') {
@@ -328,6 +400,44 @@ class AssetExpectedInflowStore {
     return added;
   }
 
+  /// 取り込み前プレビュー用: [mergeFromMirrorRows] と同じガード
+  /// (既知 ID / トゥームストーン / 不正値の除外) を通過して「実際に追加される」
+  /// 行だけを返す。保存はしない。件数は merge の戻り値と一致する。
+  Future<List<Map<String, dynamic>>> previewMergeAdditions(
+    List<Map<String, dynamic>> rows, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final items = _decode(store.getString(_key));
+    final rules = _decodeRules(store.getString(_rulesKey));
+    final deletedIds = _decodeIds(store.getString(_deletedIdsKey));
+    final knownIds = <String>{
+      for (final item in items) item.id,
+      for (final rule in rules) rule.id,
+    };
+    final additions = <Map<String, dynamic>>[];
+    for (final row in rows) {
+      final id = row['id']?.toString() ?? '';
+      final amount = (row['amount'] as num?)?.toDouble() ?? 0;
+      if (id.isEmpty ||
+          amount <= 0 ||
+          knownIds.contains(id) ||
+          deletedIds.contains(id)) {
+        continue;
+      }
+      if (row['kind']?.toString() == 'rule') {
+        final day = (row['day_of_month'] as num?)?.toInt() ?? 0;
+        if (day < 1 || day > 31) {
+          continue;
+        }
+      } else if (DateTime.tryParse(row['date']?.toString() ?? '') == null) {
+        continue;
+      }
+      additions.add(row);
+    }
+    return additions;
+  }
+
   Future<List<AssetExpectedInflow>> loadAll({SharedPreferences? prefs}) async {
     final store = prefs ?? await SharedPreferences.getInstance();
     return _decode(store.getString(_key));
@@ -366,6 +476,7 @@ class AssetExpectedInflowStore {
     final entries = _decode(store.getString(_key))
       ..removeWhere((entry) => entry.id == id);
     await _save(store, entries);
+    await _addDeletedId(store, id);
     return entries;
   }
 

--- a/lib/widgets/display_mode_experiment_card.dart
+++ b/lib/widgets/display_mode_experiment_card.dart
@@ -6,7 +6,19 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 /// rpc display_mode_experiment_summary を取得し、標準維持率と
 /// 週次トレンド(初期解決=藍 / 切替=橙)を表示する。
 class DisplayModeExperimentCard extends StatefulWidget {
-  const DisplayModeExperimentCard({super.key});
+  const DisplayModeExperimentCard({
+    super.key,
+    this.debugWeekly,
+    this.debugWeeklyRetention,
+  });
+
+  /// テスト専用: rpc を介さず週次データを直接注入する。
+  @visibleForTesting
+  final List<Map<String, dynamic>>? debugWeekly;
+
+  /// テスト専用: rpc を介さず維持率データを直接注入する。
+  @visibleForTesting
+  final List<Map<String, dynamic>>? debugWeeklyRetention;
 
   @override
   State<DisplayModeExperimentCard> createState() =>
@@ -24,6 +36,13 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
   @override
   void initState() {
     super.initState();
+    if (widget.debugWeekly != null || widget.debugWeeklyRetention != null) {
+      _weekly = widget.debugWeekly ?? const <Map<String, dynamic>>[];
+      _weeklyRetention =
+          widget.debugWeeklyRetention ?? const <Map<String, dynamic>>[];
+      _summaryLabel = 'テスト注入データ';
+      return;
+    }
     _fetch();
   }
 
@@ -132,7 +151,10 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
                     ),
                   ),
                   const SizedBox(height: 6),
-                  _RetentionBars(retention: _weeklyRetention, expanded: true),
+                  _RetentionLineChart(
+                    key: const Key('display_mode_retention_line_chart'),
+                    retention: _weeklyRetention,
+                  ),
                   const SizedBox(height: 12),
                 ],
                 if (_weekly.isNotEmpty) ...[
@@ -145,7 +167,10 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
                     ),
                   ),
                   const SizedBox(height: 6),
-                  _TrendBars(weekly: _weekly, expanded: true),
+                  _TrendAreaChart(
+                    key: const Key('display_mode_trend_area_chart'),
+                    weekly: _weekly,
+                  ),
                   const SizedBox(height: 12),
                   const Text(
                     '週次の数値',
@@ -288,10 +313,9 @@ class _DisplayModeExperimentCardState extends State<DisplayModeExperimentCard> {
 }
 
 class _TrendBars extends StatelessWidget {
-  const _TrendBars({required this.weekly, this.expanded = false});
+  const _TrendBars({required this.weekly});
 
   final List<Map<String, dynamic>> weekly;
-  final bool expanded;
 
   @override
   Widget build(BuildContext context) {
@@ -304,9 +328,9 @@ class _TrendBars extends StatelessWidget {
         maxTotal = initials + switches;
       }
     }
-    final barScale = expanded ? 100.0 : 30.0;
+    const barScale = 30.0;
     return SizedBox(
-      height: expanded ? 160 : 60,
+      height: 60,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
@@ -360,17 +384,16 @@ class _TrendBars extends StatelessWidget {
 }
 
 class _RetentionBars extends StatelessWidget {
-  const _RetentionBars({required this.retention, this.expanded = false});
+  const _RetentionBars({required this.retention});
 
   final List<Map<String, dynamic>> retention;
-  final bool expanded;
 
   @override
   Widget build(BuildContext context) {
     final weeks = retention.reversed.toList(growable: false);
-    final barScale = expanded ? 110.0 : 30.0;
+    const barScale = 30.0;
     return SizedBox(
-      height: expanded ? 170 : 56,
+      height: 56,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
@@ -412,6 +435,363 @@ class _RetentionBars extends StatelessWidget {
       ),
     );
   }
+}
+
+/// 標準維持率% の推移を折れ線+面で描く拡大ビュー用チャート。
+/// null の週は線を途切れさせる(欠測を埋めない)。
+class _RetentionLineChart extends StatelessWidget {
+  const _RetentionLineChart({required this.retention, super.key});
+
+  final List<Map<String, dynamic>> retention;
+
+  @override
+  Widget build(BuildContext context) {
+    final weeks = retention.reversed.toList(growable: false);
+    return SizedBox(
+      height: 190,
+      width: double.infinity,
+      child: CustomPaint(
+        painter: _RetentionLinePainter(
+          weeks: weeks,
+          lineColor: const Color(0xFF0D9488),
+          gridColor: Theme.of(context).colorScheme.outlineVariant,
+          labelColor: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _RetentionLinePainter extends CustomPainter {
+  _RetentionLinePainter({
+    required this.weeks,
+    required this.lineColor,
+    required this.gridColor,
+    required this.labelColor,
+  });
+
+  final List<Map<String, dynamic>> weeks;
+  final Color lineColor;
+  final Color gridColor;
+  final Color labelColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const topPad = 14.0;
+    const bottomPad = 18.0;
+    const leftPad = 28.0;
+    final chartW = size.width - leftPad;
+    final chartH = size.height - topPad - bottomPad;
+    if (chartW <= 0 || chartH <= 0 || weeks.isEmpty) {
+      return;
+    }
+
+    double yFor(double rate) => topPad + chartH * (1 - rate / 100);
+    double xFor(int index) {
+      if (weeks.length == 1) {
+        return leftPad + chartW / 2;
+      }
+      return leftPad + chartW * index / (weeks.length - 1);
+    }
+
+    // グリッド線 + 目盛り (0/50/100%)。
+    final gridPaint = Paint()
+      ..color = gridColor
+      ..strokeWidth = 1;
+    for (final pct in <int>[0, 50, 100]) {
+      final y = yFor(pct.toDouble());
+      canvas.drawLine(Offset(leftPad, y), Offset(size.width, y), gridPaint);
+      _drawText(canvas, '$pct', Offset(0, y - 6), labelColor, 9);
+    }
+
+    // 面 + 折れ線 (null は途切れ)。
+    final fillPaint = Paint()
+      ..color = lineColor.withValues(alpha: 0.15)
+      ..style = PaintingStyle.fill;
+    final linePaint = Paint()
+      ..color = lineColor
+      ..strokeWidth = 2
+      ..style = PaintingStyle.stroke
+      ..strokeJoin = StrokeJoin.round;
+    final dotPaint = Paint()..color = lineColor;
+
+    var segment = <Offset>[];
+    void flush() {
+      if (segment.length >= 2) {
+        final path = Path()..moveTo(segment.first.dx, segment.first.dy);
+        for (final p in segment.skip(1)) {
+          path.lineTo(p.dx, p.dy);
+        }
+        canvas.drawPath(path, linePaint);
+        final fill = Path()
+          ..moveTo(segment.first.dx, yFor(0))
+          ..lineTo(segment.first.dx, segment.first.dy);
+        for (final p in segment.skip(1)) {
+          fill.lineTo(p.dx, p.dy);
+        }
+        fill
+          ..lineTo(segment.last.dx, yFor(0))
+          ..close();
+        canvas.drawPath(fill, fillPaint);
+      }
+      for (final p in segment) {
+        canvas.drawCircle(p, 2.5, dotPaint);
+      }
+      segment = <Offset>[];
+    }
+
+    for (var i = 0; i < weeks.length; i++) {
+      final rate = (weeks[i]['rate'] as num?)?.toDouble();
+      if (rate == null) {
+        flush();
+        continue;
+      }
+      segment.add(Offset(xFor(i), yFor(rate)));
+    }
+    flush();
+
+    // x 軸ラベル (端のみ: 先頭と末尾の week_start)。
+    for (final i in <int>{0, weeks.length - 1}) {
+      final label = _weekShort(weeks[i]['week_start']);
+      if (label.isNotEmpty) {
+        _drawText(
+          canvas,
+          label,
+          Offset(xFor(i) - 14, size.height - bottomPad + 4),
+          labelColor,
+          8,
+        );
+      }
+    }
+  }
+
+  void _drawText(
+    Canvas canvas,
+    String text,
+    Offset offset,
+    Color color,
+    double fontSize,
+  ) {
+    final tp = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(color: color, fontSize: fontSize),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    tp.paint(canvas, offset);
+  }
+
+  @override
+  bool shouldRepaint(_RetentionLinePainter oldDelegate) =>
+      oldDelegate.weeks != weeks ||
+      oldDelegate.lineColor != lineColor ||
+      oldDelegate.gridColor != gridColor;
+}
+
+/// 週次イベント(初期解決=藍 / 切替=橙)を積み上げ面で描く拡大ビュー用チャート。
+class _TrendAreaChart extends StatelessWidget {
+  const _TrendAreaChart({required this.weekly, super.key});
+
+  final List<Map<String, dynamic>> weekly;
+
+  @override
+  Widget build(BuildContext context) {
+    final weeks = weekly.reversed.toList(growable: false);
+    return SizedBox(
+      height: 190,
+      width: double.infinity,
+      child: CustomPaint(
+        painter: _TrendAreaPainter(
+          weeks: weeks,
+          initialsColor: const Color(0xFF6366F1),
+          switchesColor: const Color(0xFFF97316),
+          gridColor: Theme.of(context).colorScheme.outlineVariant,
+          labelColor: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _TrendAreaPainter extends CustomPainter {
+  _TrendAreaPainter({
+    required this.weeks,
+    required this.initialsColor,
+    required this.switchesColor,
+    required this.gridColor,
+    required this.labelColor,
+  });
+
+  final List<Map<String, dynamic>> weeks;
+  final Color initialsColor;
+  final Color switchesColor;
+  final Color gridColor;
+  final Color labelColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const topPad = 14.0;
+    const bottomPad = 18.0;
+    const leftPad = 24.0;
+    final chartW = size.width - leftPad;
+    final chartH = size.height - topPad - bottomPad;
+    if (chartW <= 0 || chartH <= 0 || weeks.isEmpty) {
+      return;
+    }
+
+    var maxTotal = 1;
+    for (final week in weeks) {
+      final total = ((week['initials'] as num?)?.toInt() ?? 0) +
+          ((week['switches'] as num?)?.toInt() ?? 0);
+      if (total > maxTotal) {
+        maxTotal = total;
+      }
+    }
+
+    double yFor(double value) => topPad + chartH * (1 - value / maxTotal);
+    double xFor(int index) {
+      if (weeks.length == 1) {
+        return leftPad + chartW / 2;
+      }
+      return leftPad + chartW * index / (weeks.length - 1);
+    }
+
+    final gridPaint = Paint()
+      ..color = gridColor
+      ..strokeWidth = 1;
+    canvas.drawLine(
+      Offset(leftPad, yFor(0)),
+      Offset(size.width, yFor(0)),
+      gridPaint,
+    );
+    _drawText(canvas, '$maxTotal', const Offset(0, topPad - 4), labelColor, 9);
+    _drawText(canvas, '0', Offset(0, yFor(0) - 6), labelColor, 9);
+
+    final initialsPts = <Offset>[];
+    final totalPts = <Offset>[];
+    for (var i = 0; i < weeks.length; i++) {
+      final initials = (weeks[i]['initials'] as num?)?.toInt() ?? 0;
+      final switches = (weeks[i]['switches'] as num?)?.toInt() ?? 0;
+      initialsPts.add(Offset(xFor(i), yFor(initials.toDouble())));
+      totalPts.add(Offset(xFor(i), yFor((initials + switches).toDouble())));
+    }
+
+    // 下段(初期解決)の面。
+    _fillBand(
+      canvas,
+      initialsPts,
+      yFor(0),
+      initialsColor.withValues(alpha: 0.5),
+    );
+    // 上段(切替): initials 線と total 線の間。
+    _fillBetween(
+      canvas,
+      initialsPts,
+      totalPts,
+      switchesColor.withValues(alpha: 0.45),
+    );
+    _drawLine(canvas, totalPts, switchesColor, 2);
+    _drawLine(canvas, initialsPts, initialsColor, 2);
+
+    for (final i in <int>{0, weeks.length - 1}) {
+      final label = _weekShort(weeks[i]['week_start']);
+      if (label.isNotEmpty) {
+        _drawText(
+          canvas,
+          label,
+          Offset(xFor(i) - 14, size.height - bottomPad + 4),
+          labelColor,
+          8,
+        );
+      }
+    }
+  }
+
+  void _fillBand(Canvas canvas, List<Offset> top, double baseY, Color color) {
+    if (top.isEmpty) {
+      return;
+    }
+    final path = Path()
+      ..moveTo(top.first.dx, baseY)
+      ..lineTo(top.first.dx, top.first.dy);
+    for (final p in top.skip(1)) {
+      path.lineTo(p.dx, p.dy);
+    }
+    path
+      ..lineTo(top.last.dx, baseY)
+      ..close();
+    canvas.drawPath(path, Paint()..color = color);
+  }
+
+  void _fillBetween(
+    Canvas canvas,
+    List<Offset> lower,
+    List<Offset> upper,
+    Color color,
+  ) {
+    if (lower.length != upper.length || lower.isEmpty) {
+      return;
+    }
+    final path = Path()..moveTo(lower.first.dx, lower.first.dy);
+    for (final p in lower.skip(1)) {
+      path.lineTo(p.dx, p.dy);
+    }
+    for (final p in upper.reversed) {
+      path.lineTo(p.dx, p.dy);
+    }
+    path.close();
+    canvas.drawPath(path, Paint()..color = color);
+  }
+
+  void _drawLine(Canvas canvas, List<Offset> pts, Color color, double width) {
+    if (pts.length < 2) {
+      if (pts.length == 1) {
+        canvas.drawCircle(pts.first, 2.5, Paint()..color = color);
+      }
+      return;
+    }
+    final path = Path()..moveTo(pts.first.dx, pts.first.dy);
+    for (final p in pts.skip(1)) {
+      path.lineTo(p.dx, p.dy);
+    }
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = color
+        ..strokeWidth = width
+        ..style = PaintingStyle.stroke
+        ..strokeJoin = StrokeJoin.round,
+    );
+  }
+
+  void _drawText(
+    Canvas canvas,
+    String text,
+    Offset offset,
+    Color color,
+    double fontSize,
+  ) {
+    final tp = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(color: color, fontSize: fontSize),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    tp.paint(canvas, offset);
+  }
+
+  @override
+  bool shouldRepaint(_TrendAreaPainter oldDelegate) =>
+      oldDelegate.weeks != weeks ||
+      oldDelegate.initialsColor != initialsColor ||
+      oldDelegate.switchesColor != switchesColor;
+}
+
+String _weekShort(Object? weekStart) {
+  final value = weekStart?.toString() ?? '';
+  return value.length >= 10 ? value.substring(5, 10) : '';
 }
 
 class _LegendDot extends StatelessWidget {

--- a/scripts/check_duplicate_dispose.py
+++ b/scripts/check_duplicate_dispose.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
-"""Detect duplicated top-level statements in Flutter lifecycle bodies.
+"""Detect duplicated risky top-level statements in Flutter method bodies.
 
 part 280 の本番バグ (_annualRateControllers の二重 dispose → dispose 中断 →
-Timer 未解放 → defunct setState) の再発防止ゲート。lib/ 配下の全 dispose() /
-initState() ボディを brace バランスで抽出し、**トップレベル文** (コールバック
-内部は対象外) を `;` 区切りで再構成して同一文の重複を検出したら exit 1。
-二重 dispose のほか、二重 addListener / 二重フェッチ起動も同型として捕捉する。
+Timer 未解放 → defunct setState) の再発防止ゲート。part 285 で対象を
+dispose()/initState() から **全メソッドボディ** へ拡張した。
+
+検出方針 (2 ティア):
+- **ライフサイクル** (dispose / initState): トップレベル文の重複を**すべて**検出。
+  これらのボディでは同一文の繰り返しはほぼ確実にバグ。
+- **一般メソッド**: トップレベル文のうち `await` / `setState(` / `.dispose(` /
+  `.addListener(` 等の**副作用を伴う危険パターン**の重複のみ検出
+  (二重 await = 二重フェッチ、二重 setState = 二重再描画 等)。一般メソッドは
+  正当な同一文の繰り返しもあるため、危険パターンに限定して誤検出を抑える。
+
+メソッド検出は `){`(本体開始)を起点に対応する `(` まで後方走査し、その直前の
+語を名前として取る方式。制御構文 (if/for/...) と無名クロージャは名前条件で除外。
+巨大ファイル (= 80 万字の page) でも線形時間で走るよう、貪欲な前方マッチを避ける。
+
+トップレベル文は brace/paren 深度で `;` 区切りに分割し、コールバック本体も
+そのまま保持する (本体が異なる呼び出しを別物として扱い、完全一致だけ捕捉)。
 
 Usage: python scripts/check_duplicate_dispose.py [root]
 """
@@ -17,12 +30,61 @@ import pathlib
 import re
 import sys
 
-LIFECYCLE_RE = re.compile(r"void\s+(dispose|initState)\(\)\s*\{")
+# 本体開始 `) [async] {`。`)` と `{` の間は空白/改行のみ許容 (多行シグネチャ可)。
+HEADER_RE = re.compile(r"\)[ \t\n]*(?:async\*?|sync\*?)?[ \t\n]*\{")
+NAME_RE = re.compile(r"(\w+)\s*$")
+CONTROL_KEYWORDS = {
+    "if",
+    "for",
+    "while",
+    "switch",
+    "catch",
+    "else",
+    "do",
+    "return",
+}
+LIFECYCLE_NAMES = {"dispose", "initState"}
 LINE_COMMENT_RE = re.compile(r"(?<!:)//[^\n]*")
+# 副作用を伴う危険な呼び出し (重複すると二重実行になりやすい)。
+RISKY_RE = re.compile(
+    r"\bawait\b"
+    r"|\bsetState\s*\("
+    r"|\.dispose\s*\("
+    r"|\.cancel\s*\("
+    r"|\.addListener\s*\("
+    r"|\.removeListener\s*\("
+)
 
 
-def lifecycle_bodies(source: str):
-    for match in LIFECYCLE_RE.finditer(source):
+def _matching_open_paren(source: str, close_index: int) -> int:
+    """`close_index` の `)` に対応する `(` の位置を返す (無ければ -1)。"""
+    depth = 0
+    index = close_index
+    while index >= 0:
+        char = source[index]
+        if char == ")":
+            depth += 1
+        elif char == "(":
+            depth -= 1
+            if depth == 0:
+                return index
+        index -= 1
+    return -1
+
+
+def method_bodies(source: str):
+    """全メソッド/関数ボディを (name, start_index, body) で返す。"""
+    for match in HEADER_RE.finditer(source):
+        open_paren = _matching_open_paren(source, match.start())
+        if open_paren < 0:
+            continue
+        window = source[max(0, open_paren - 64):open_paren].rstrip()
+        name_match = NAME_RE.search(window)
+        if name_match is None:
+            continue
+        name = name_match.group(1)
+        if name in CONTROL_KEYWORDS:
+            continue
         index = match.end()
         depth = 1
         while index < len(source) and depth > 0:
@@ -32,17 +94,20 @@ def lifecycle_bodies(source: str):
             elif char == "}":
                 depth -= 1
             index += 1
-        line = source[: match.start()].count("\n") + 1
-        yield match.group(1), line, source[match.end() : index - 1]
+        yield name, match.start(), source[match.end() : index - 1]
 
 
 def top_level_statements(body: str):
-    """コールバック内部 (brace 深度>0) を除いた文を `;` 区切りで返す。"""
+    """brace/paren 深度 0 の `;` で区切ったトップレベル文を返す。
+
+    コールバック本体も保持するため、本体の異なる呼び出しは別文として扱う。
+    """
     statements = []
     current = []
     brace = 0
     paren = 0
     for char in body:
+        current.append(char)
         if char == "{":
             brace += 1
         elif char == "}":
@@ -51,18 +116,11 @@ def top_level_statements(body: str):
             paren += 1
         elif char == ")":
             paren -= 1
-        if brace == 0:
-            current.append(char)
-            if char == ";" and paren == 0:
-                statement = re.sub(r"\s+", " ", "".join(current)).strip(" ;")
-                if statement:
-                    statements.append(statement)
-                current = []
-        elif current and brace > 0:
-            # トップレベル文の途中でコールバックへ潜った (例: addListener(() {
-            # ...})) — 文としては継続中なのでプレースホルダだけ残す。
-            if current[-1] != "\x00":
-                current.append("\x00")
+        elif char == ";" and brace == 0 and paren == 0:
+            statement = re.sub(r"\s+", " ", "".join(current)).strip(" ;")
+            if statement:
+                statements.append(statement)
+            current = []
     return statements
 
 
@@ -72,12 +130,17 @@ def find_duplicates(root: pathlib.Path):
         source = LINE_COMMENT_RE.sub(
             "", path.read_text(encoding="utf-8", errors="replace")
         )
-        for kind, line, body in lifecycle_bodies(source):
+        for name, start_index, body in method_bodies(source):
             counter = collections.Counter(top_level_statements(body))
+            lifecycle = name in LIFECYCLE_NAMES
             for statement, count in counter.items():
-                if count > 1:
-                    shown = statement.replace("\x00", "{...}")[:100]
-                    hits.append(f"{path.as_posix()}:{line} {kind} x{count}: {shown}")
+                if count <= 1:
+                    continue
+                if not lifecycle and not RISKY_RE.search(statement):
+                    continue
+                line = source.count("\n", 0, start_index) + 1
+                shown = statement[:100]
+                hits.append(f"{path.as_posix()}:{line} {name}() x{count}: {shown}")
     return hits
 
 
@@ -85,17 +148,17 @@ def main() -> int:
     root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else ".")
     hits = find_duplicates(root)
     if hits:
-        print("Duplicate top-level statements found in lifecycle bodies:")
+        print("Duplicate risky top-level statements found in method bodies:")
         for hit in hits:
             print(f"- {hit}")
         print(
-            "二重 dispose / 二重リスナー登録は dispose 中断やコールバック"
-            "多重発火を招きます (part 280 実例)。重複行を削除してください。"
+            "二重 dispose / 二重 await / 二重 setState は dispose 中断・"
+            "二重フェッチ・二重再描画を招きます (part 280 実例)。重複行を削除してください。"
         )
         return 1
     print(
         "check_duplicate_dispose: CLEAN"
-        " (no duplicated top-level statements in dispose/initState)"
+        " (no duplicated risky top-level statements in method bodies)"
     )
     return 0
 

--- a/test/services/asset_expected_inflow_store_test.dart
+++ b/test/services/asset_expected_inflow_store_test.dart
@@ -238,5 +238,164 @@ void main() {
       );
       expect(secondRun, 0);
     });
+
+    test('records a tombstone on remove and never resurrects it on merge',
+        () async {
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+      final added = await store.add(
+        date: DateTime(2026, 6, 20),
+        amount: 5000,
+        label: '消す予定',
+      );
+      final removedId = added.single.id;
+      await store.remove(removedId);
+
+      expect(await store.loadDeletedIds(), contains(removedId));
+
+      // サーバにまだ残っている削除済み行を統合しても復活しない。
+      final mergedCount =
+          await store.mergeFromMirrorRows(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': removedId,
+          'kind': 'one_time',
+          'date': '2026-06-20',
+          'amount': 5000,
+          'label': '消す予定',
+        },
+        <String, dynamic>{
+          'id': 'inflow_fresh',
+          'kind': 'one_time',
+          'date': '2026-06-22',
+          'amount': 1200,
+          'label': '新規分',
+        },
+      ]);
+
+      expect(mergedCount, 1);
+      final items = await store.loadAll();
+      expect(items.single.id, 'inflow_fresh');
+      expect(items.map((e) => e.id), isNot(contains(removedId)));
+    });
+
+    test('tombstoned ids are excluded from empty-store restore too', () async {
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+      final added = await store.add(
+        date: DateTime(2026, 6, 20),
+        amount: 5000,
+        label: '消す',
+      );
+      final removedId = added.single.id;
+      await store.remove(removedId);
+      // ローカルは空に戻った状態。
+      expect(await store.loadAll(), isEmpty);
+
+      final restored = await store.restoreFromMirrorRows(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': removedId,
+          'kind': 'one_time',
+          'date': '2026-06-20',
+          'amount': 5000,
+          'label': '消す',
+        },
+        <String, dynamic>{
+          'id': 'inflow_keep',
+          'kind': 'one_time',
+          'date': '2026-06-21',
+          'amount': 800,
+          'label': '残す',
+        },
+      ]);
+
+      expect(restored, isTrue);
+      final items = await store.loadAll();
+      expect(items.single.id, 'inflow_keep');
+    });
+
+    test(
+        'applyRemoteDeletedIds removes matching local items and adds tombstones',
+        () async {
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+      final added = await store.add(
+        date: DateTime(2026, 6, 20),
+        amount: 5000,
+        label: '他端末で削除',
+      );
+      final id = added.single.id;
+
+      final removed = await store.applyRemoteDeletedIds(<String>[id, '']);
+
+      expect(removed, 1);
+      expect(await store.loadAll(), isEmpty);
+      expect(await store.loadDeletedIds(), contains(id));
+
+      // 二度目は対象が無いので 0。
+      expect(await store.applyRemoteDeletedIds(<String>[id]), 0);
+    });
+
+    test('previewMergeAdditions count matches mergeFromMirrorRows result',
+        () async {
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 12, 9, 0),
+      );
+      final local = await store.add(
+        date: DateTime(2026, 6, 1),
+        amount: 100,
+        label: 'local',
+      );
+      final removed = await store.add(
+        date: DateTime(2026, 6, 2),
+        amount: 200,
+        label: 'will-delete',
+      );
+      final removedId = removed.firstWhere((e) => e.label == 'will-delete').id;
+      await store.remove(removedId);
+
+      final rows = <Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': local.first.id,
+          'kind': 'one_time',
+          'date': '2026-06-01',
+          'amount': 100,
+          'label': 'local',
+        },
+        <String, dynamic>{
+          'id': removedId,
+          'kind': 'one_time',
+          'date': '2026-06-02',
+          'amount': 200,
+          'label': 'will-delete',
+        },
+        <String, dynamic>{
+          'id': 'inflow_new',
+          'kind': 'one_time',
+          'date': '2026-06-20',
+          'amount': 5000,
+          'label': '新規',
+        },
+        <String, dynamic>{
+          'id': 'rule_new',
+          'kind': 'rule',
+          'day_of_month': 25,
+          'amount': 280000,
+          'label': '給料',
+        },
+      ];
+
+      final preview = await store.previewMergeAdditions(rows);
+      // 既知(local)とトゥームストーン(will-delete)を除いた2件だけ。
+      expect(
+        preview.map((row) => row['id']),
+        <String>['inflow_new', 'rule_new'],
+      );
+
+      final added = await store.mergeFromMirrorRows(rows);
+      expect(added, preview.length);
+    });
   });
 }

--- a/test/services/mirror_two_client_scenario_test.dart
+++ b/test/services/mirror_two_client_scenario_test.dart
@@ -102,7 +102,7 @@ void main() {
 
     test(
         'client B addition merges into client A as union '
-        '(local deletion resurrects without tombstones)', () async {
+        '(tombstone prevents local-deletion resurrection)', () async {
       // 端末A: 2件登録してサーバへ反映。
       final prefsA1 = await _switchClient();
       final storeA = AssetExpectedInflowStore(
@@ -159,12 +159,63 @@ void main() {
       );
       final merged = await storeA.loadAll(prefs: prefsA2);
 
-      // 和集合マージ: B の追加分に加え、トゥームストーンが無いため
-      // ローカル削除済みの ID もサーバ残存分から復活する (仕様の明文化)。
-      expect(added, 2);
-      expect(merged, hasLength(3));
+      // 和集合マージ (#part285 本対策): B の追加分 (ボーナス) のみ取り込み、
+      // ローカル削除済みの ID はトゥームストーンにより復活しない。
+      expect(added, 1);
+      expect(merged, hasLength(2));
       expect(merged.map((item) => item.label), contains('ボーナス'));
-      expect(merged.map((item) => item.id), contains(removedId));
+      expect(merged.map((item) => item.id), isNot(contains(removedId)));
+    });
+
+    test('client A deletion propagates to client B via remote tombstones',
+        () async {
+      // 端末A: 2件登録 → サーバ行へ展開 (ID はサーバ行が保持する)。
+      final prefsA = await _switchClient();
+      final storeA = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 13, 9),
+      );
+      await storeA.add(
+        date: DateTime(2026, 6, 25),
+        amount: 280000,
+        label: '給料',
+        prefs: prefsA,
+      );
+      await storeA.add(
+        date: DateTime(2026, 6, 30),
+        amount: 12000,
+        label: 'フリマ売上',
+        prefs: prefsA,
+      );
+      final serverRows = _uploadInflows(
+        await storeA.loadAll(prefs: prefsA),
+        const <AssetExpectedInflowRule>[],
+      );
+      final removedId = serverRows
+          .firstWhere((row) => row['label'] == 'フリマ売上')['id']
+          .toString();
+      // 端末A でローカル削除 → トゥームストーン (= サーバへ上げる集合) を得る。
+      await storeA.remove(removedId, prefs: prefsA);
+      final tombstones = (await storeA.loadDeletedIds(prefs: prefsA)).toList();
+      expect(tombstones, contains(removedId));
+
+      // 端末B: サーバから復元すると A と同じ ID 集合を保持する。
+      final prefsB = await _switchClient();
+      final storeB = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 14, 9),
+      );
+      await storeB.restoreFromMirrorRows(serverRows, prefs: prefsB);
+      expect(await storeB.loadAll(prefs: prefsB), hasLength(2));
+
+      // 端末B がサーバ経由のトゥームストーンを取り込む → 同 ID が消える。
+      final removed = await storeB.applyRemoteDeletedIds(
+        tombstones,
+        prefs: prefsB,
+      );
+
+      expect(removed, 1);
+      final itemsB = await storeB.loadAll(prefs: prefsB);
+      expect(itemsB.single.label, '給料');
+      expect(itemsB.map((e) => e.id), isNot(contains(removedId)));
     });
 
     test('client B applies display prefs diff from client A rows', () async {

--- a/test/widgets/display_mode_experiment_card_test.dart
+++ b/test/widgets/display_mode_experiment_card_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/display_mode_experiment_card.dart';
+
+void main() {
+  group('DisplayModeExperimentCard', () {
+    testWidgets('expand opens dialog with line + area charts', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1500));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: DisplayModeExperimentCard(
+                debugWeekly: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'week_start': '2026-06-08',
+                    'initials': 5,
+                    'initial_standard': 4,
+                    'switches': 2,
+                  },
+                  <String, dynamic>{
+                    'week_start': '2026-06-01',
+                    'initials': 3,
+                    'initial_standard': 1,
+                    'switches': 1,
+                  },
+                ],
+                debugWeeklyRetention: <Map<String, dynamic>>[
+                  <String, dynamic>{'week_start': '2026-06-08', 'rate': 80},
+                  <String, dynamic>{'week_start': '2026-06-01', 'rate': null},
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expandButton = find.byKey(
+        const Key('display_mode_experiment_expand'),
+      );
+      expect(expandButton, findsOneWidget);
+      expect(tester.widget<IconButton>(expandButton).onPressed, isNotNull);
+
+      await tester.tap(expandButton);
+      await tester.pumpAndSettle();
+
+      expect(find.text('表示モード実験 詳細グラフ'), findsOneWidget);
+      expect(
+        find.byKey(const Key('display_mode_retention_line_chart')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('display_mode_trend_area_chart')),
+        findsOneWidget,
+      );
+      // 週次の数値表も併記される。
+      expect(find.textContaining('維持率'), findsWidgets);
+    });
+
+    testWidgets('expand button is disabled without data', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DisplayModeExperimentCard(
+              debugWeekly: <Map<String, dynamic>>[],
+              debugWeeklyRetention: <Map<String, dynamic>>[],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expandButton = find.byKey(
+        const Key('display_mode_experiment_expand'),
+      );
+      expect(tester.widget<IconButton>(expandButton).onPressed, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

part 284 の次回候補 4 件を実装。

1. **削除トゥームストーン (deleted_ids) 導入で復活を本対策** — `AssetExpectedInflowStore` に削除済み ID 集合を追加。`remove`/`removeRule` で記録し、`mergeFromMirrorRows` / `restoreFromMirrorRows` で除外することで「一度消した項目」がサーバ残存分から復活しなくなった(part 284 で仕様として明文化した挙動の本対策)。`applyRemoteDeletedIds` でサーバ経由のトゥームストーンを取り込み、他端末の削除をローカルへ伝播。page はローカル削除時に `asset_pref_mirror` (`inflow_deleted_ids`) へ upsert、boot 時に pull する。
2. **差分プレビューを入金予定 (inflow) 取込にも展開** — 「サーバと統合」を即適用せず、`previewMergeAdditions`(merge と同一ガードで「実際に追加される行」を返す)を使って取り込み内容を一覧するダイアログで確定式に変更。プレビュー件数と merge の追加件数が一致することをテストで担保(ロジック drift 防止)。
3. **CFO 拡大ダイアログのグラフを折れ線/面グラフ化** — 維持率% は折れ線+面(null 週は線を途切れ)、週次イベントは初期解決/切替の積み上げ面に刷新(`CustomPaint`)。カード本体の小型バーは従来どおり。`@visibleForTesting` の debug 注入フックを追加し、拡大→チャート描画を widget テストで検証。
4. **監査スクリプトを全メソッドへ拡張** — `check_duplicate_dispose.py` を dispose/initState 限定から全メソッドへ拡張。ライフサイクルは全重複、一般メソッドは `await`/`setState(`/`.dispose(`/`.addListener(` 等の**副作用パターンの重複のみ**検出(誤検出抑制)。80 万字の page でも線形(2.5s)で走るよう `){` を起点に対応 `(` を後方走査する方式へ再設計。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核となる 3ケース: (1) remove → tombstone 記録 → merge で復活しない (2) `previewMergeAdditions` 件数 == `mergeFromMirrorRows` 追加件数(プレビューと実行の一致) (3) 2クライアント同時シナリオ(A 削除 → サーバ tombstone → B へ伝播でローカルから消える)。今回 service 8 + widget 2 を追加・更新、全体で flutter test 687 ケース。
- E2E例外: 変更はクライアント + テスト + CI 監査スクリプトのみでサーバ・スキーマ変更なし(ミラー書込は既存 `asset_pref_mirror` テーブルへの汎用 jsonb upsert)。widget pump がエンドツーエンド相当の UI 検証(拡大→チャート / 通知→プレビュー)を担い、本番疎通は既存 Playwright smoke で補完する。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `python scripts/check_duplicate_dispose.py` **CLEAN**(合成重複ファイルで二重 dispose/await/setState の検出力を exit 1 で自己検証済み) / `flutter test` **687/687 PASS**。compare diff-stat ゲート確認済み(+1023 -61 / 7 files / 想定外削除なし)。

## High-risk gate

- High-risk-ultrareview-exception: migration・RLS・認証・課金ロジックへの変更は一切なし。データ保存はクライアントローカル(SharedPreferences)と既存 `asset_pref_mirror` への汎用 jsonb upsert のみで、新テーブル・新ポリシーなし。監査スクリプトは読み取り専用の静的チェック。レビュー所有者: Claude Code #1。
- 自己点検メモ: rollback = 本 PR revert のみで完結(スキーマ影響ゼロ / トゥームストーンは追加キーで後方互換)/ プレビューはキャンセルで何も変更しない安全側設計 / トゥームストーンと2クライアントテストは復活防止仕様の回帰検知を兼ねる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
