### PR TITLE
fix(asset): AIサマリーが初回生成以降データ変化を反映しない desync を修正

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -33,6 +33,7 @@ import 'package:my_web_app/services/asset_liability_planning_service.dart';
 import 'package:my_web_app/services/asset_liability_repayment_simulation_service.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_ai_analysis_history_service.dart';
+import 'package:my_web_app/services/asset_management_ai_summary_refresh.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
@@ -369,7 +370,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   AssetManagementAiSummaryResult? _assetManagementAiSummaryResult;
   String? _assetManagementAiSummaryRequestKey;
   String? _assetManagementAiSummaryInFlightKey;
-  final Set<String> _assetManagementAiSummaryAutoRequestedKeys = <String>{};
+  // 表示中サマリーが生成された時点のフィンガープリント。これと現在の
+  // レポートキーがずれたら自動再生成する (支払済みチェック等の反映)。
+  String? _assetManagementAiSummaryResultKey;
   List<AssetManagementAiAnalysisHistoryEntry>
       _assetManagementAiSummaryReferencedHistory =
       const <AssetManagementAiAnalysisHistoryEntry>[];
@@ -515,6 +518,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _isLoadingAssetManagementUserProfile = false;
         _assetManagementAiSummaryRequestKey = null;
         _assetManagementAiSummaryResult = null;
+        _assetManagementAiSummaryResultKey = null;
       });
     } catch (_) {
       if (!mounted) {
@@ -13844,9 +13848,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     if (!force &&
-        _assetManagementAiSummaryAutoRequestedKeys.contains(key) &&
-        _assetManagementAiSummaryRequestKey == key &&
-        _assetManagementAiSummaryResult != null) {
+        !AssetManagementAiSummaryRefresh.isStale(
+          currentKey: key,
+          resultKey: _assetManagementAiSummaryResultKey,
+          hasResult: _assetManagementAiSummaryResult != null,
+        )) {
       return;
     }
     setState(() {
@@ -13903,6 +13909,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     setState(() {
       _assetManagementAiSummaryResult = result;
+      _assetManagementAiSummaryResultKey = key;
       _assetManagementAiSummaryReferencedHistory = previousAnalyses;
       _isGeneratingAssetManagementAiSummary = false;
       _assetManagementAiSummaryInFlightKey = null;
@@ -13919,12 +13926,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     final key = _assetManagementAiSummaryKey(report);
     if (_assetManagementAiSummaryRequestKey == key ||
-        _assetManagementAiSummaryInFlightKey == key ||
-        _assetManagementAiSummaryAutoRequestedKeys.contains(key)) {
+        _assetManagementAiSummaryInFlightKey == key) {
+      return;
+    }
+    if (!AssetManagementAiSummaryRefresh.isStale(
+      currentKey: key,
+      resultKey: _assetManagementAiSummaryResultKey,
+      hasResult: _assetManagementAiSummaryResult != null,
+    )) {
       return;
     }
     _assetManagementAiSummaryRequestKey = key;
-    _assetManagementAiSummaryAutoRequestedKeys.add(key);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted ||
           !_assetManagementAiSummaryService.aiEnabled ||

--- a/lib/services/asset_management_ai_summary_refresh.dart
+++ b/lib/services/asset_management_ai_summary_refresh.dart
@@ -1,0 +1,27 @@
+/// 資産管理AIサマリーの自動再生成判定。
+///
+/// 旧実装は「結果が存在するか (result != null)」を再生成不要の条件に使い、
+/// かつ要求キーを生成前に設定していたため、初回生成以降はデータ
+/// (支払済みチェック等) が変わっても自動再生成が永久に抑止されていた。
+/// ここでは「表示中の結果が現在のレポートキーで生成されたものか」を
+/// 唯一の基準にし、キーが変われば必ず再生成が走るようにする。
+class AssetManagementAiSummaryRefresh {
+  const AssetManagementAiSummaryRefresh._();
+
+  /// 表示中のサマリーが現在のレポートキーに対して古い (= 再生成が必要) か。
+  ///
+  /// - 結果が無い: 古い (初回生成が必要)。
+  /// - 結果はあるが、生成時のキー [resultKey] が現在の [currentKey] と
+  ///   異なる: 古い (データが変わったので再生成が必要)。
+  /// - 結果があり、生成時のキーが現在のキーと一致: 最新 (再生成不要)。
+  static bool isStale({
+    required String currentKey,
+    required String? resultKey,
+    required bool hasResult,
+  }) {
+    if (!hasResult) {
+      return true;
+    }
+    return resultKey != currentKey;
+  }
+}

--- a/test/services/asset_management_ai_summary_refresh_test.dart
+++ b/test/services/asset_management_ai_summary_refresh_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_management_ai_summary_refresh.dart';
+
+void main() {
+  group('AssetManagementAiSummaryRefresh.isStale', () {
+    test('is stale when there is no result yet (needs first generation)', () {
+      expect(
+        AssetManagementAiSummaryRefresh.isStale(
+          currentKey: 'sha256:abc',
+          resultKey: null,
+          hasResult: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('is fresh when the result was generated for the current key', () {
+      expect(
+        AssetManagementAiSummaryRefresh.isStale(
+          currentKey: 'sha256:abc',
+          resultKey: 'sha256:abc',
+          hasResult: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'is stale when data changed (current key differs from result key)',
+      () {
+        // 支払済みチェックを入れるとフィンガープリントが変わる。旧バグでは
+        // ここで再生成が走らず古い「未払い」サマリーが残り続けた。
+        expect(
+          AssetManagementAiSummaryRefresh.isStale(
+            currentKey: 'sha256:paid',
+            resultKey: 'sha256:unpaid',
+            hasResult: true,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('is stale when a result key is unexpectedly missing', () {
+      expect(
+        AssetManagementAiSummaryRefresh.isStale(
+          currentKey: 'sha256:abc',
+          resultKey: null,
+          hasResult: true,
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

ユーザー報告: 負債の「支払状態」をチェックし実支払額も入力済みなのに、AI 資産分析が「今月実支払0円・アコム期限超過・未払い」のまま変わらない。スクリーンショットで **UI=支払済み / AI レポート=未払い** の乖離を確認した、本物の desync バグの修正。

### 真因（再生成の永久抑止）

- ページは表示用ボードと AI レポートで**同一の workbook/report** を使うため、本来チェックは即反映されるはず。フィンガープリント（再生成キャッシュキー）も `monthly_actual_payment_total` 等を含むので支払状態でキーは変わる。
- しかし `_generateAssetManagementAiSummary` の早期 return ガードが「**結果が存在する（`result != null`）**」を再生成不要の条件に使い、`_requestAssetManagementAiSummaryIfNeeded` が**生成前に** `requestKey` と `autoRequestedKeys` へキーを登録していた。
- そのため postFrame が呼ぶ generate() のガードが「`autoRequestedKeys.contains(key)` ∧ `requestKey == key` ∧ `result != null`」で**初回生成後は常に真 → bail**。結果、**初回生成以降はデータが変わっても自動再生成が永久に抑止**され、手動「再生成」（force）だけが反映する状態だった。

### 修正

- 再生成の要否を「**表示中の結果が現在のレポートキーで生成されたものか**」だけで判定するよう統一。新フィールド `_assetManagementAiSummaryResultKey`（生成完了時に設定）を導入し、`requestKey`（生成前に設定される）との混同を解消。
- 判定ロジックを純関数 `AssetManagementAiSummaryRefresh.isStale(currentKey, resultKey, hasResult)` に抽出し単体テスト化。
- 誤動作の原因だった `_assetManagementAiSummaryAutoRequestedKeys`（poison-set）を撤去。生成中・生成済み・スケジュール済みは `inFlightKey` / `resultKey` / `requestKey` の3キーで正しく重複抑止。
- プロフィール再読込でサマリーを破棄する箇所でも `resultKey` を null リセット。

これで支払済みチェック後の rebuild で「stale」と判定され自動再生成が走り、AI レポートに支払済みが反映される（トグルを戻した場合も反映）。

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. 結果なし → stale=true（初回生成が必要）
  2. 結果ありで生成時キー==現在キー → stale=false（再生成しない）
  3. 結果ありだが生成時キー≠現在キー（支払済みチェックでデータ変化）→ stale=true（**バグの中核ケース・再生成する**）
- 上記を純関数 `AssetManagementAiSummaryRefresh.isStale` の単体テスト（新規4件 PASS）で検証
- E2E-Exception: 資産管理ページは認証済みユーザーのデータと ai-hub 応答前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。再生成判定ロジックを純関数に抽出して単体テストで担保し、UI反映は本番反映後に支払済みチェック→AIレポート更新を手動確認する。

## 検証

- `flutter test`（refresh 4件）: All tests passed
- `flutter analyze` / `dart analyze`: No issues found
- 並行 part 285 (`a9a3ed9c2`) が同 page を変更済みのため、最新 origin/main に取り込み直して再適用・再検証（diff-stat で逆 revert を防止、最終差分は page +19/-7 + 新規2ファイルのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
