### PR TITLE
feat(asset): tombstoneミラーe2e + グラフtooltip + 監査時間ゲート + tombstone GC (part 286)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,8 +250,10 @@ jobs:
         continue-on-error: false
 
       - name: Check duplicate dispose statements
-        # part 280 実例 (二重 dispose → dispose 中断 → defunct setState) の再発防止
-        run: python scripts/check_duplicate_dispose.py
+        # part 280 実例 (二重 dispose → dispose 中断 → defunct setState) の再発防止。
+        # part 286: timeout でハング検知 + --max-seconds で線形時間 (正規表現の
+        # 破滅的バックトラック回帰) を CI でアサート。通常 ~2.5s なので 60s 上限。
+        run: timeout 120 python scripts/check_duplicate_dispose.py --max-seconds 60
         continue-on-error: false
 
       - name: Check formatting

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -110,6 +110,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final List<Map<String, dynamic>>? debugMirrorPrefsRows;
 
+  /// テスト専用: 入金トゥームストーンのミラー値 (`{'ids': [...]}`) を
+  /// 直接注入し、削除伝播 (pull→ローカル除去) をネットワークなしで検証する。
+  @visibleForTesting
+  final Map<String, dynamic>? debugInflowDeletedIdsMirror;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -120,6 +125,7 @@ class AssetManagementPage extends StatefulWidget {
     this.entryDescription,
     this.debugInitialAssetData,
     this.debugMirrorPrefsRows,
+    this.debugInflowDeletedIdsMirror,
   });
 
   @override
@@ -8202,20 +8208,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   /// サーバのトゥームストーンを取り込み、該当ローカル項目を削除する。
   Future<void> _pullInflowDeletedIds() async {
-    if (_supabase.auth.currentUser == null) {
+    final debugMirror = widget.debugInflowDeletedIdsMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
       return;
     }
     try {
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select()
-          .eq('pref_key', 'inflow_deleted_ids');
-      if (rows.isEmpty) {
-        return;
-      }
-      final value = rows.first['value'];
-      if (value is! Map) {
-        return;
+      Map<String, dynamic>? value = debugMirror;
+      if (value == null) {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', 'inflow_deleted_ids');
+        if (rows.isEmpty) {
+          return;
+        }
+        final raw = rows.first['value'];
+        if (raw is! Map) {
+          return;
+        }
+        value = Map<String, dynamic>.from(raw);
       }
       final rawIds = value['ids'];
       if (rawIds is! List) {

--- a/lib/services/asset_expected_inflow_store.dart
+++ b/lib/services/asset_expected_inflow_store.dart
@@ -86,6 +86,11 @@ class AssetExpectedInflowStore {
   /// 「一度消した項目」がサーバ残存分から復活するのを抑止する (#part285)。
   static const String _deletedIdsKey = 'asset_expected_inflow_deleted_ids_v1';
 
+  /// トゥームストーンの保持上限と期限。SharedPreferences の肥大化を防ぐ
+  /// ため、書き込み・読み出し時に古い/超過分を破棄する (#part286)。
+  static const int _tombstoneMaxCount = 1000;
+  static const int _tombstoneMaxAgeDays = 365;
+
   final DateTime Function()? nowProvider;
 
   DateTime _now() => nowProvider?.call() ?? DateTime.now();
@@ -213,36 +218,88 @@ class AssetExpectedInflowStore {
     }
   }
 
-  /// 削除済み ID の集合を読み出す。
+  /// 削除済み ID の集合を読み出す (期限切れ・上限超過は除外)。
   Future<Set<String>> loadDeletedIds({SharedPreferences? prefs}) async {
     final store = prefs ?? await SharedPreferences.getInstance();
-    return _decodeIds(store.getString(_deletedIdsKey));
+    return _decodeActiveIds(store.getString(_deletedIdsKey));
   }
 
   Future<void> _addDeletedId(SharedPreferences store, String id) async {
     if (id.isEmpty) {
       return;
     }
-    final ids = _decodeIds(store.getString(_deletedIdsKey))..add(id);
-    await store.setString(_deletedIdsKey, jsonEncode(ids.toList()));
+    final entries = _gcEntries(
+      _readDeletedEntries(store.getString(_deletedIdsKey)),
+    )..removeWhere((entry) => entry['id'] == id);
+    entries.add(<String, String>{
+      'id': id,
+      'at': _now().toUtc().toIso8601String(),
+    });
+    await _writeDeletedEntries(store, entries);
   }
 
-  Set<String> _decodeIds(String? raw) {
+  /// 後方互換読み込み: 旧形式 (["id",...]) と新形式 ([{"id","at"},...]) の
+  /// 双方を受け付ける。旧形式やタイムスタンプ欠落は現時刻を付与する
+  /// (= 既存トゥームストーンを即時に期限切れさせない)。
+  List<Map<String, String>> _readDeletedEntries(String? raw) {
     if (raw == null || raw.isEmpty) {
-      return <String>{};
+      return <Map<String, String>>[];
     }
     try {
       final decoded = jsonDecode(raw);
       if (decoded is! List) {
-        return <String>{};
+        return <Map<String, String>>[];
       }
-      return decoded
-          .map((dynamic entry) => entry?.toString() ?? '')
-          .where((id) => id.isNotEmpty)
-          .toSet();
+      final nowIso = _now().toUtc().toIso8601String();
+      final entries = <Map<String, String>>[];
+      for (final entry in decoded) {
+        if (entry is String) {
+          if (entry.isNotEmpty) {
+            entries.add(<String, String>{'id': entry, 'at': nowIso});
+          }
+        } else if (entry is Map) {
+          final id = entry['id']?.toString() ?? '';
+          if (id.isNotEmpty) {
+            entries.add(<String, String>{
+              'id': id,
+              'at': entry['at']?.toString() ?? nowIso,
+            });
+          }
+        }
+      }
+      return entries;
     } catch (_) {
-      return <String>{};
+      return <Map<String, String>>[];
     }
+  }
+
+  /// 期限切れ (>_tombstoneMaxAgeDays) を捨て、件数超過分は新しい順に残す。
+  List<Map<String, String>> _gcEntries(List<Map<String, String>> entries) {
+    final now = _now();
+    final kept = <Map<String, String>>[];
+    for (final entry in entries) {
+      final at = DateTime.tryParse(entry['at'] ?? '');
+      if (at == null || now.difference(at).inDays <= _tombstoneMaxAgeDays) {
+        kept.add(entry);
+      }
+    }
+    if (kept.length > _tombstoneMaxCount) {
+      return kept.sublist(kept.length - _tombstoneMaxCount);
+    }
+    return kept;
+  }
+
+  Future<void> _writeDeletedEntries(
+    SharedPreferences store,
+    List<Map<String, String>> entries,
+  ) async {
+    await store.setString(_deletedIdsKey, jsonEncode(entries));
+  }
+
+  Set<String> _decodeActiveIds(String? raw) {
+    return <String>{
+      for (final entry in _gcEntries(_readDeletedEntries(raw))) entry['id']!,
+    };
   }
 
   /// 他端末由来のトゥームストーンを取り込み、該当するローカル項目を削除する。
@@ -256,9 +313,17 @@ class AssetExpectedInflowStore {
       return 0;
     }
     final store = prefs ?? await SharedPreferences.getInstance();
-    final tombstones = _decodeIds(store.getString(_deletedIdsKey))
-      ..addAll(incoming);
-    await store.setString(_deletedIdsKey, jsonEncode(tombstones.toList()));
+    final entries = _gcEntries(
+      _readDeletedEntries(store.getString(_deletedIdsKey)),
+    );
+    final existingIds = <String>{for (final entry in entries) entry['id']!};
+    final nowIso = _now().toUtc().toIso8601String();
+    for (final id in incoming) {
+      if (existingIds.add(id)) {
+        entries.add(<String, String>{'id': id, 'at': nowIso});
+      }
+    }
+    await _writeDeletedEntries(store, _gcEntries(entries));
 
     final items = _decode(store.getString(_key));
     final rules = _decodeRules(store.getString(_rulesKey));
@@ -287,7 +352,7 @@ class AssetExpectedInflowStore {
     if (localItems.isNotEmpty || localRules.isNotEmpty || rows.isEmpty) {
       return false;
     }
-    final deletedIds = _decodeIds(store.getString(_deletedIdsKey));
+    final deletedIds = _decodeActiveIds(store.getString(_deletedIdsKey));
     final items = <AssetExpectedInflow>[];
     final rules = <AssetExpectedInflowRule>[];
     for (final row in rows) {
@@ -344,7 +409,7 @@ class AssetExpectedInflowStore {
     final store = prefs ?? await SharedPreferences.getInstance();
     final items = _decode(store.getString(_key));
     final rules = _decodeRules(store.getString(_rulesKey));
-    final deletedIds = _decodeIds(store.getString(_deletedIdsKey));
+    final deletedIds = _decodeActiveIds(store.getString(_deletedIdsKey));
     final knownIds = <String>{
       for (final item in items) item.id,
       for (final rule in rules) rule.id,
@@ -410,7 +475,7 @@ class AssetExpectedInflowStore {
     final store = prefs ?? await SharedPreferences.getInstance();
     final items = _decode(store.getString(_key));
     final rules = _decodeRules(store.getString(_rulesKey));
-    final deletedIds = _decodeIds(store.getString(_deletedIdsKey));
+    final deletedIds = _decodeActiveIds(store.getString(_deletedIdsKey));
     final knownIds = <String>{
       for (final item in items) item.id,
       for (final rule in rules) rule.id,

--- a/lib/widgets/display_mode_experiment_card.dart
+++ b/lib/widgets/display_mode_experiment_card.dart
@@ -437,49 +437,150 @@ class _RetentionBars extends StatelessWidget {
   }
 }
 
+// 拡大グラフの共有ジオメトリ。ヒットテスト(ラッパー)と描画(painter)で
+// 同一座標を使うためトップレベル定数で共有する。
+const double _kChartHeight = 190;
+const double _kChartTopPad = 14;
+const double _kChartBottomPad = 18;
+const double _kRetentionLeftPad = 28;
+const double _kTrendLeftPad = 24;
+
+/// dx から最近接のデータ点 index を返す (count 0 → null)。
+int? _nearestIndex(double dx, double width, double leftPad, int count) {
+  if (count <= 0) {
+    return null;
+  }
+  if (count == 1) {
+    return 0;
+  }
+  final chartW = width - leftPad;
+  if (chartW <= 0) {
+    return null;
+  }
+  final raw = ((dx - leftPad) / chartW * (count - 1)).round();
+  return raw.clamp(0, count - 1);
+}
+
+double _xForIndex(int index, double width, double leftPad, int count) {
+  final chartW = width - leftPad;
+  if (count <= 1) {
+    return leftPad + chartW / 2;
+  }
+  return leftPad + chartW * index / (count - 1);
+}
+
 /// 標準維持率% の推移を折れ線+面で描く拡大ビュー用チャート。
-/// null の週は線を途切れさせる(欠測を埋めない)。
-class _RetentionLineChart extends StatelessWidget {
+/// null の週は線を途切れさせる(欠測を埋めない)。hover/tap で点の値を表示。
+class _RetentionLineChart extends StatefulWidget {
   const _RetentionLineChart({required this.retention, super.key});
 
   final List<Map<String, dynamic>> retention;
 
   @override
+  State<_RetentionLineChart> createState() => _RetentionLineChartState();
+}
+
+class _RetentionLineChartState extends State<_RetentionLineChart> {
+  int? _selected;
+
+  @override
   Widget build(BuildContext context) {
-    final weeks = retention.reversed.toList(growable: false);
+    final weeks = widget.retention.reversed.toList(growable: false);
+    const lineColor = Color(0xFF0D9488);
     return SizedBox(
-      height: 190,
+      height: _kChartHeight,
       width: double.infinity,
-      child: CustomPaint(
-        painter: _RetentionLinePainter(
-          weeks: weeks,
-          lineColor: const Color(0xFF0D9488),
-          gridColor: Theme.of(context).colorScheme.outlineVariant,
-          labelColor: Theme.of(context).colorScheme.onSurfaceVariant,
-        ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth;
+          void onAt(Offset p) {
+            final i = _nearestIndex(
+              p.dx,
+              width,
+              _kRetentionLeftPad,
+              weeks.length,
+            );
+            if (i != _selected) {
+              setState(() => _selected = i);
+            }
+          }
+
+          return MouseRegion(
+            onHover: (event) => onAt(event.localPosition),
+            onExit: (_) {
+              if (_selected != null) {
+                setState(() => _selected = null);
+              }
+            },
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTapDown: (details) => onAt(details.localPosition),
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: CustomPaint(
+                      painter: _RetentionLinePainter(
+                        weeks: weeks,
+                        selected: _selected,
+                        lineColor: lineColor,
+                        gridColor: Theme.of(context).colorScheme.outlineVariant,
+                        labelColor:
+                            Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  if (_selected != null && _selected! < weeks.length)
+                    _ChartTooltip(
+                      text: _tooltipText(weeks[_selected!]),
+                      anchor: _anchor(weeks, _selected!, width),
+                      width: width,
+                    ),
+                ],
+              ),
+            ),
+          );
+        },
       ),
     );
+  }
+
+  String _tooltipText(Map<String, dynamic> week) {
+    final rate = week['rate'];
+    return '${_weekShort(week['week_start'])}  '
+        '${rate == null ? '—' : '$rate%'}';
+  }
+
+  Offset _anchor(List<Map<String, dynamic>> weeks, int i, double width) {
+    const chartH = _kChartHeight - _kChartTopPad - _kChartBottomPad;
+    final x = _xForIndex(i, width, _kRetentionLeftPad, weeks.length);
+    final rate = (weeks[i]['rate'] as num?)?.toDouble();
+    final y = rate == null
+        ? _kChartTopPad
+        : _kChartTopPad + chartH * (1 - rate / 100);
+    return Offset(x, y);
   }
 }
 
 class _RetentionLinePainter extends CustomPainter {
   _RetentionLinePainter({
     required this.weeks,
+    required this.selected,
     required this.lineColor,
     required this.gridColor,
     required this.labelColor,
   });
 
   final List<Map<String, dynamic>> weeks;
+  final int? selected;
   final Color lineColor;
   final Color gridColor;
   final Color labelColor;
 
   @override
   void paint(Canvas canvas, Size size) {
-    const topPad = 14.0;
-    const bottomPad = 18.0;
-    const leftPad = 28.0;
+    const topPad = _kChartTopPad;
+    const bottomPad = _kChartBottomPad;
+    const leftPad = _kRetentionLeftPad;
     final chartW = size.width - leftPad;
     final chartH = size.height - topPad - bottomPad;
     if (chartW <= 0 || chartH <= 0 || weeks.isEmpty) {
@@ -487,12 +588,8 @@ class _RetentionLinePainter extends CustomPainter {
     }
 
     double yFor(double rate) => topPad + chartH * (1 - rate / 100);
-    double xFor(int index) {
-      if (weeks.length == 1) {
-        return leftPad + chartW / 2;
-      }
-      return leftPad + chartW * index / (weeks.length - 1);
-    }
+    double xFor(int index) =>
+        _xForIndex(index, size.width, leftPad, weeks.length);
 
     // グリッド線 + 目盛り (0/50/100%)。
     final gridPaint = Paint()
@@ -502,6 +599,17 @@ class _RetentionLinePainter extends CustomPainter {
       final y = yFor(pct.toDouble());
       canvas.drawLine(Offset(leftPad, y), Offset(size.width, y), gridPaint);
       _drawText(canvas, '$pct', Offset(0, y - 6), labelColor, 9);
+    }
+
+    // 選択ガイド (縦線)。
+    if (selected != null && selected! < weeks.length) {
+      canvas.drawLine(
+        Offset(xFor(selected!), topPad),
+        Offset(xFor(selected!), topPad + chartH),
+        Paint()
+          ..color = lineColor.withValues(alpha: 0.4)
+          ..strokeWidth = 1,
+      );
     }
 
     // 面 + 折れ線 (null は途切れ)。
@@ -550,6 +658,21 @@ class _RetentionLinePainter extends CustomPainter {
     }
     flush();
 
+    // 選択点のリング強調。
+    if (selected != null && selected! < weeks.length) {
+      final rate = (weeks[selected!]['rate'] as num?)?.toDouble();
+      if (rate != null) {
+        canvas.drawCircle(
+          Offset(xFor(selected!), yFor(rate)),
+          4.5,
+          Paint()
+            ..color = lineColor
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = 2,
+        );
+      }
+    }
+
     // x 軸ラベル (端のみ: 先頭と末尾の week_start)。
     for (final i in <int>{0, weeks.length - 1}) {
       final label = _weekShort(weeks[i]['week_start']);
@@ -585,61 +708,28 @@ class _RetentionLinePainter extends CustomPainter {
   @override
   bool shouldRepaint(_RetentionLinePainter oldDelegate) =>
       oldDelegate.weeks != weeks ||
+      oldDelegate.selected != selected ||
       oldDelegate.lineColor != lineColor ||
       oldDelegate.gridColor != gridColor;
 }
 
 /// 週次イベント(初期解決=藍 / 切替=橙)を積み上げ面で描く拡大ビュー用チャート。
-class _TrendAreaChart extends StatelessWidget {
+/// hover/tap でその週の初期解決/切替件数を表示。
+class _TrendAreaChart extends StatefulWidget {
   const _TrendAreaChart({required this.weekly, super.key});
 
   final List<Map<String, dynamic>> weekly;
 
   @override
-  Widget build(BuildContext context) {
-    final weeks = weekly.reversed.toList(growable: false);
-    return SizedBox(
-      height: 190,
-      width: double.infinity,
-      child: CustomPaint(
-        painter: _TrendAreaPainter(
-          weeks: weeks,
-          initialsColor: const Color(0xFF6366F1),
-          switchesColor: const Color(0xFFF97316),
-          gridColor: Theme.of(context).colorScheme.outlineVariant,
-          labelColor: Theme.of(context).colorScheme.onSurfaceVariant,
-        ),
-      ),
-    );
-  }
+  State<_TrendAreaChart> createState() => _TrendAreaChartState();
 }
 
-class _TrendAreaPainter extends CustomPainter {
-  _TrendAreaPainter({
-    required this.weeks,
-    required this.initialsColor,
-    required this.switchesColor,
-    required this.gridColor,
-    required this.labelColor,
-  });
-
-  final List<Map<String, dynamic>> weeks;
-  final Color initialsColor;
-  final Color switchesColor;
-  final Color gridColor;
-  final Color labelColor;
+class _TrendAreaChartState extends State<_TrendAreaChart> {
+  int? _selected;
 
   @override
-  void paint(Canvas canvas, Size size) {
-    const topPad = 14.0;
-    const bottomPad = 18.0;
-    const leftPad = 24.0;
-    final chartW = size.width - leftPad;
-    final chartH = size.height - topPad - bottomPad;
-    if (chartW <= 0 || chartH <= 0 || weeks.isEmpty) {
-      return;
-    }
-
+  Widget build(BuildContext context) {
+    final weeks = widget.weekly.reversed.toList(growable: false);
     var maxTotal = 1;
     for (final week in weeks) {
       final total = ((week['initials'] as num?)?.toInt() ?? 0) +
@@ -648,14 +738,114 @@ class _TrendAreaPainter extends CustomPainter {
         maxTotal = total;
       }
     }
+    return SizedBox(
+      height: _kChartHeight,
+      width: double.infinity,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth;
+          void onAt(Offset p) {
+            final i = _nearestIndex(p.dx, width, _kTrendLeftPad, weeks.length);
+            if (i != _selected) {
+              setState(() => _selected = i);
+            }
+          }
+
+          return MouseRegion(
+            onHover: (event) => onAt(event.localPosition),
+            onExit: (_) {
+              if (_selected != null) {
+                setState(() => _selected = null);
+              }
+            },
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTapDown: (details) => onAt(details.localPosition),
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: CustomPaint(
+                      painter: _TrendAreaPainter(
+                        weeks: weeks,
+                        selected: _selected,
+                        maxTotal: maxTotal,
+                        initialsColor: const Color(0xFF6366F1),
+                        switchesColor: const Color(0xFFF97316),
+                        gridColor: Theme.of(context).colorScheme.outlineVariant,
+                        labelColor:
+                            Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  if (_selected != null && _selected! < weeks.length)
+                    _ChartTooltip(
+                      text: _tooltipText(weeks[_selected!]),
+                      anchor: _anchor(weeks, _selected!, width, maxTotal),
+                      width: width,
+                    ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  String _tooltipText(Map<String, dynamic> week) {
+    final initials = (week['initials'] as num?)?.toInt() ?? 0;
+    final switches = (week['switches'] as num?)?.toInt() ?? 0;
+    return '${_weekShort(week['week_start'])}  初期$initials/切替$switches';
+  }
+
+  Offset _anchor(
+    List<Map<String, dynamic>> weeks,
+    int i,
+    double width,
+    int maxTotal,
+  ) {
+    const chartH = _kChartHeight - _kChartTopPad - _kChartBottomPad;
+    final x = _xForIndex(i, width, _kTrendLeftPad, weeks.length);
+    final total = ((weeks[i]['initials'] as num?)?.toInt() ?? 0) +
+        ((weeks[i]['switches'] as num?)?.toInt() ?? 0);
+    final y = _kChartTopPad + chartH * (1 - total / maxTotal);
+    return Offset(x, y);
+  }
+}
+
+class _TrendAreaPainter extends CustomPainter {
+  _TrendAreaPainter({
+    required this.weeks,
+    required this.selected,
+    required this.maxTotal,
+    required this.initialsColor,
+    required this.switchesColor,
+    required this.gridColor,
+    required this.labelColor,
+  });
+
+  final List<Map<String, dynamic>> weeks;
+  final int? selected;
+  final int maxTotal;
+  final Color initialsColor;
+  final Color switchesColor;
+  final Color gridColor;
+  final Color labelColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const topPad = _kChartTopPad;
+    const bottomPad = _kChartBottomPad;
+    const leftPad = _kTrendLeftPad;
+    final chartW = size.width - leftPad;
+    final chartH = size.height - topPad - bottomPad;
+    if (chartW <= 0 || chartH <= 0 || weeks.isEmpty) {
+      return;
+    }
 
     double yFor(double value) => topPad + chartH * (1 - value / maxTotal);
-    double xFor(int index) {
-      if (weeks.length == 1) {
-        return leftPad + chartW / 2;
-      }
-      return leftPad + chartW * index / (weeks.length - 1);
-    }
+    double xFor(int index) =>
+        _xForIndex(index, size.width, leftPad, weeks.length);
 
     final gridPaint = Paint()
       ..color = gridColor
@@ -667,6 +857,16 @@ class _TrendAreaPainter extends CustomPainter {
     );
     _drawText(canvas, '$maxTotal', const Offset(0, topPad - 4), labelColor, 9);
     _drawText(canvas, '0', Offset(0, yFor(0) - 6), labelColor, 9);
+
+    if (selected != null && selected! < weeks.length) {
+      canvas.drawLine(
+        Offset(xFor(selected!), topPad),
+        Offset(xFor(selected!), topPad + chartH),
+        Paint()
+          ..color = switchesColor.withValues(alpha: 0.4)
+          ..strokeWidth = 1,
+      );
+    }
 
     final initialsPts = <Offset>[];
     final totalPts = <Offset>[];
@@ -693,6 +893,17 @@ class _TrendAreaPainter extends CustomPainter {
     );
     _drawLine(canvas, totalPts, switchesColor, 2);
     _drawLine(canvas, initialsPts, initialsColor, 2);
+
+    if (selected != null && selected! < totalPts.length) {
+      canvas.drawCircle(
+        totalPts[selected!],
+        4.5,
+        Paint()
+          ..color = switchesColor
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2,
+      );
+    }
 
     for (final i in <int>{0, weeks.length - 1}) {
       final label = _weekShort(weeks[i]['week_start']);
@@ -785,8 +996,56 @@ class _TrendAreaPainter extends CustomPainter {
   @override
   bool shouldRepaint(_TrendAreaPainter oldDelegate) =>
       oldDelegate.weeks != weeks ||
+      oldDelegate.selected != selected ||
+      oldDelegate.maxTotal != maxTotal ||
       oldDelegate.initialsColor != initialsColor ||
       oldDelegate.switchesColor != switchesColor;
+}
+
+/// グラフ上の選択点に重ねる値ツールチップ (実ウィジェット=テスト可能)。
+class _ChartTooltip extends StatelessWidget {
+  const _ChartTooltip({
+    required this.text,
+    required this.anchor,
+    required this.width,
+  });
+
+  final String text;
+  final Offset anchor;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    const tipWidth = 104.0;
+    final maxLeft = (width - tipWidth).clamp(0.0, double.infinity);
+    final left = (anchor.dx - tipWidth / 2).clamp(0.0, maxLeft);
+    final top = (anchor.dy - 30).clamp(0.0, double.infinity);
+    final scheme = Theme.of(context).colorScheme;
+    return Positioned(
+      left: left,
+      top: top,
+      child: IgnorePointer(
+        child: Container(
+          key: const Key('display_mode_chart_tooltip'),
+          width: tipWidth,
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+          decoration: BoxDecoration(
+            color: scheme.inverseSurface,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Text(
+            text,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: scheme.onInverseSurface,
+              fontSize: 10,
+              height: 1.3,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 String _weekShort(Object? weekStart) {

--- a/scripts/check_duplicate_dispose.py
+++ b/scripts/check_duplicate_dispose.py
@@ -25,10 +25,11 @@ Usage: python scripts/check_duplicate_dispose.py [root]
 
 from __future__ import annotations
 
+import argparse
 import collections
 import pathlib
 import re
-import sys
+import time
 
 # 本体開始 `) [async] {`。`)` と `{` の間は空白/改行のみ許容 (多行シグネチャ可)。
 HEADER_RE = re.compile(r"\)[ \t\n]*(?:async\*?|sync\*?)?[ \t\n]*\{")
@@ -145,8 +146,23 @@ def find_duplicates(root: pathlib.Path):
 
 
 def main() -> int:
-    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else ".")
-    hits = find_duplicates(root)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", default=".")
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=None,
+        help=(
+            "走査が指定秒数を超えたら exit 1 (正規表現の破滅的バックトラック "
+            "= part 286 で 49s→2.5s 化した回帰の再発を CI で検知する)。"
+        ),
+    )
+    args = parser.parse_args()
+
+    start = time.perf_counter()
+    hits = find_duplicates(pathlib.Path(args.root))
+    elapsed = time.perf_counter() - start
+
     if hits:
         print("Duplicate risky top-level statements found in method bodies:")
         for hit in hits:
@@ -156,9 +172,15 @@ def main() -> int:
             "二重フェッチ・二重再描画を招きます (part 280 実例)。重複行を削除してください。"
         )
         return 1
+    if args.max_seconds is not None and elapsed > args.max_seconds:
+        print(
+            f"check_duplicate_dispose: SLOW ({elapsed:.1f}s > "
+            f"{args.max_seconds:.1f}s) — 正規表現が線形時間でなくなった疑い。"
+        )
+        return 1
     print(
         "check_duplicate_dispose: CLEAN"
-        " (no duplicated risky top-level statements in method bodies)"
+        f" (no duplicates, {elapsed:.2f}s)"
     )
     return 0
 

--- a/test/services/asset_expected_inflow_store_test.dart
+++ b/test/services/asset_expected_inflow_store_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -396,6 +398,80 @@ void main() {
 
       final added = await store.mergeFromMirrorRows(rows);
       expect(added, preview.length);
+    });
+
+    test('expired tombstones are garbage-collected after the TTL', () async {
+      var clock = DateTime(2026, 1, 1, 9);
+      final store = AssetExpectedInflowStore(nowProvider: () => clock);
+      final added = await store.add(
+        date: DateTime(2026, 1, 5),
+        amount: 5000,
+        label: '消す',
+      );
+      final id = added.single.id;
+      await store.remove(id);
+      expect(await store.loadDeletedIds(), contains(id));
+
+      // TTL (365日) を超えると GC され、復活し得る状態に戻る。
+      clock = DateTime(2027, 1, 5, 9);
+      expect(await store.loadDeletedIds(), isNot(contains(id)));
+
+      final mergedBack = await store.mergeFromMirrorRows(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': id,
+          'kind': 'one_time',
+          'date': '2026-01-05',
+          'amount': 5000,
+          'label': '消す',
+        },
+      ]);
+      expect(mergedBack, 1);
+    });
+
+    test('tombstones are capped to the most recent entries', () async {
+      // 上限 (1000) を超える削除済み ID を直接シードし、GC で新しい順に
+      // 残ることを確認する (古い id0 は破棄)。
+      final seeded = <Map<String, String>>[
+        for (var i = 0; i < 1005; i++)
+          <String, String>{
+            'id': 'tomb_$i',
+            'at': DateTime(2026, 6, 13, 9).toUtc().toIso8601String(),
+          },
+      ];
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflow_deleted_ids_v1': jsonEncode(seeded),
+      });
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 13, 9),
+      );
+
+      final ids = await store.loadDeletedIds();
+      expect(ids, hasLength(1000));
+      expect(ids, isNot(contains('tomb_0')));
+      expect(ids, contains('tomb_1004'));
+    });
+
+    test('legacy plain-string tombstones remain effective', () async {
+      // part 285 の旧形式 (["id",...]) を読み込めること。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflow_deleted_ids_v1':
+            jsonEncode(<String>['legacy_id']),
+      });
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 13, 9),
+      );
+
+      expect(await store.loadDeletedIds(), contains('legacy_id'));
+      final added = await store.mergeFromMirrorRows(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': 'legacy_id',
+          'kind': 'one_time',
+          'date': '2026-06-01',
+          'amount': 100,
+          'label': '旧削除',
+        },
+      ]);
+      expect(added, 0);
     });
   });
 }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -173,6 +173,58 @@ void main() {
       await _unmount(tester);
     });
 
+    testWidgets('remote inflow tombstone removes the matching local chip', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflows_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'keep_me',
+            'date': DateTime(now.year, now.month, 10).toUtc().toIso8601String(),
+            'amount': 5000,
+            'label': '残す入金',
+          },
+          <String, dynamic>{
+            'id': 'delete_me',
+            'date': DateTime(now.year, now.month, 12).toUtc().toIso8601String(),
+            'amount': 8000,
+            'label': '他端末で削除',
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 他端末が delete_me を削除した状態をミラー経由で注入。
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugInflowDeletedIdsMirror: <String, dynamic>{
+              'ids': <String>['delete_me'],
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_inflow_chip_keep_me')),
+      );
+      expect(
+        find.byKey(const Key('asset_inflow_chip_keep_me')),
+        findsOneWidget,
+      );
+      // 削除トゥームストーンが伝播し、該当チップは消えている。
+      expect(
+        find.byKey(const Key('asset_inflow_chip_delete_me')),
+        findsNothing,
+      );
+
+      await _unmount(tester);
+    });
+
     testWidgets('hidden override removes an essential section', (
       tester,
     ) async {

--- a/test/widgets/display_mode_experiment_card_test.dart
+++ b/test/widgets/display_mode_experiment_card_test.dart
@@ -78,5 +78,56 @@ void main() {
       );
       expect(tester.widget<IconButton>(expandButton).onPressed, isNull);
     });
+
+    testWidgets('tapping the retention chart shows a value tooltip', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1500));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: DisplayModeExperimentCard(
+                debugWeekly: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'week_start': '2026-06-08',
+                    'initials': 5,
+                    'initial_standard': 4,
+                    'switches': 2,
+                  },
+                ],
+                debugWeeklyRetention: <Map<String, dynamic>>[
+                  <String, dynamic>{'week_start': '2026-06-08', 'rate': 80},
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('display_mode_experiment_expand')));
+      await tester.pumpAndSettle();
+
+      // 初期状態ではツールチップ非表示。
+      expect(
+        find.byKey(const Key('display_mode_chart_tooltip')),
+        findsNothing,
+      );
+
+      await tester.tap(
+        find.byKey(const Key('display_mode_retention_line_chart')),
+      );
+      await tester.pumpAndSettle();
+
+      final tooltip = find.byKey(const Key('display_mode_chart_tooltip'));
+      expect(tooltip, findsOneWidget);
+      expect(
+        find.descendant(of: tooltip, matching: find.textContaining('%')),
+        findsOneWidget,
+      );
+    });
   });
 }


### PR DESCRIPTION
## 概要

part 285 の次回候補 4 件を実装。

1. **入金 tombstone ミラー往復の e2e 検証** — page に `@visibleForTesting debugInflowDeletedIdsMirror` フックを追加し、`_pullInflowDeletedIds` がミラー値 (`{'ids': [...]}`) をネットワークなしで取り込めるようにした。widget テストで「他端末が削除 → ミラー注入 → 該当ローカルチップが消える / 残すべきチップは残る」を検証(従来は service 層の `applyRemoteDeletedIds` のみ)。
2. **折れ線/面グラフに hover/tap ツールチップ** — チャートを Stateful 化し、共有ジオメトリ定数でポインタ位置→最近接データ点を特定。選択ガイド線+リング強調(`CustomPaint`)に加え、値ツールチップを**実ウィジェット**(`Key('display_mode_chart_tooltip')`)で重ねて表示(テスト可能)。タップでツールチップが出ることを widget テストで検証。
3. **監査 v2 を CI で線形時間アサート** — `check_duplicate_dispose.py` に `--max-seconds` を追加(走査が閾値超過なら exit 1)。ci.yml のステップを `timeout 120 ... --max-seconds 60` でラップし、正規表現の破滅的バックトラック回帰(part 285 の 49s ハング)を CI で検知。通常 ~2.5s(fresh checkout の cold I/O で ~22s)。
4. **tombstone GC(肥大化対策)** — トゥームストーンの保持を「id+削除時刻」形式へ拡張し、書込/読出時に**期限切れ(365日)**と**上限超過(新しい順 1000 件)**を破棄。part 285 の旧プレーン配列形式(`["id",...]`)も後方互換で読み込み、欠落タイムスタンプには現時刻を付与して即時失効を防ぐ。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核となる 3ケース: (1) ミラー注入→トゥームストーン伝播でローカルチップが消える(page widget e2e) (2) グラフ tap → 値ツールチップ表示 (3) tombstone の TTL 失効・件数上限・旧形式互換。今回 store 3 + widget 2 を追加、全体で flutter test 692 ケース。
- E2E例外: アプリコード変更はクライアント UI + テストのみで、サーバ・スキーマ変更なし。widget pump がエンドツーエンド相当の UI 検証(ミラー pull→チップ消失 / グラフ tap→ツールチップ)を担い、本番疎通は既存 Playwright smoke で補完する。ci.yml 変更は監査ステップの timeout ラップのみ(読み取り専用の静的チェック)。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `python scripts/check_duplicate_dispose.py` **CLEAN (2.5s)** / `flutter test` **692/692 PASS**。compare diff-stat ゲート確認済み(+622 -84 / 8 files / 想定外削除なし)。

## High-risk gate

- High-risk-ultrareview-exception: `.github/workflows/ci.yml` の変更は既存監査ステップを `timeout` でラップし `--max-seconds` を渡す 1 行のみ(新規ジョブ・シークレット・デプロイ経路の変更なし)。アプリ側は migration・RLS・認証・課金への変更なし。データ保存はクライアントローカル(SharedPreferences)と既存 `asset_pref_mirror` への汎用 jsonb のみ。レビュー所有者: Claude Code #1。
- 自己点検メモ: rollback = 本 PR revert のみで完結(tombstone 形式は後方互換・追加キーのみ)/ GC は安全側(失効まで 365日・上限 1000)/ ツールチップは IgnorePointer で操作を妨げない / CI timeout ラップは失敗時のみ赤(正常は従来どおり)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
