### PR TITLE
feat(asset): 双方向往復統合テスト + グラフキーボードa11y + 監査並列化 + GC設定リモート化 (part 287)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -360,7 +360,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetManagementDisplayModeStore.defaultMode;
   Map<AssetManagementSectionId, AssetManagementSectionVisibilityOverride>
       _sectionOverrides = {};
-  final AssetExpectedInflowStore _expectedInflowStore =
+  // GC 設定をサーバから取得したら差し替えるため非 final (#part287)。
+  AssetExpectedInflowStore _expectedInflowStore =
       const AssetExpectedInflowStore();
   List<AssetExpectedInflow> _expectedInflows = <AssetExpectedInflow>[];
   List<AssetExpectedInflowRule> _expectedInflowRules =
@@ -457,7 +458,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _fetchMustTasks();
     _loadDisplayMode();
     _loadExpectedInflows();
-    unawaited(_pullInflowDeletedIds());
+    // GC 設定をサーバから取得してから削除トゥームストーンを取り込む。
+    unawaited(
+      _loadTombstoneGcConfig().then((_) => _pullInflowDeletedIds()),
+    );
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
       final previousMonthKey = _assetLiabilityStateMonthKey(_now);
@@ -8202,7 +8206,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
         'user_id': userId,
         'pref_key': 'inflow_deleted_ids',
-        'value': <String, dynamic>{'ids': ids.toList()},
+        'value': AssetExpectedInflowStore.encodeDeletedIdsMirror(ids),
         'updated_at': DateTime.now().toUtc().toIso8601String(),
       });
     } catch (e) {
@@ -8232,18 +8236,38 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         }
         value = Map<String, dynamic>.from(raw);
       }
-      final rawIds = value['ids'];
-      if (rawIds is! List) {
+      final ids = AssetExpectedInflowStore.decodeDeletedIdsMirror(value);
+      if (ids.isEmpty) {
         return;
       }
-      final removed = await _expectedInflowStore.applyRemoteDeletedIds(
-        rawIds.map((dynamic id) => id?.toString() ?? ''),
-      );
+      final removed = await _expectedInflowStore.applyRemoteDeletedIds(ids);
       if (removed > 0 && mounted) {
         await _loadExpectedInflows();
       }
     } catch (e) {
       debugPrint('inflow tombstone pull failed: $e');
+    }
+  }
+
+  /// トゥームストーン GC の上限/期限をサーバ (asset_pref_mirror) から取得し、
+  /// ストアへ反映する (#part287 リモート調整)。未設定なら既定のまま。
+  Future<void> _loadTombstoneGcConfig() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', 'inflow_tombstone_gc');
+      if (rows.isEmpty) {
+        return;
+      }
+      _expectedInflowStore = AssetExpectedInflowStore(
+        gcConfig: AssetTombstoneGcConfig.fromMirrorValue(rows.first['value']),
+      );
+    } catch (e) {
+      debugPrint('tombstone gc config fetch failed: $e');
     }
   }
 

--- a/lib/services/asset_expected_inflow_store.dart
+++ b/lib/services/asset_expected_inflow_store.dart
@@ -75,9 +75,45 @@ class AssetExpectedInflowRule {
   }
 }
 
+/// トゥームストーン GC の上限/期限。既定はローカル定数だが、サーバ
+/// (asset_pref_mirror) から取得した値で上書きできる (#part287 リモート調整)。
+class AssetTombstoneGcConfig {
+  const AssetTombstoneGcConfig({
+    this.maxCount = 1000,
+    this.maxAgeDays = 365,
+  });
+
+  final int maxCount;
+  final int maxAgeDays;
+
+  /// ミラー値 (`{'max_count': N, 'max_age_days': M}`) から構築する。
+  /// 欠落/不正値は既定を維持し、正の範囲にクランプする。
+  factory AssetTombstoneGcConfig.fromMirrorValue(Object? value) {
+    const fallback = AssetTombstoneGcConfig();
+    if (value is! Map) {
+      return fallback;
+    }
+    int pick(String key, int fallbackValue, int min, int max) {
+      final raw = (value[key] as num?)?.toInt();
+      if (raw == null) {
+        return fallbackValue;
+      }
+      return raw.clamp(min, max);
+    }
+
+    return AssetTombstoneGcConfig(
+      maxCount: pick('max_count', fallback.maxCount, 1, 100000),
+      maxAgeDays: pick('max_age_days', fallback.maxAgeDays, 1, 36500),
+    );
+  }
+}
+
 /// 入金予定の永続化ストア。
 class AssetExpectedInflowStore {
-  const AssetExpectedInflowStore({this.nowProvider});
+  const AssetExpectedInflowStore({
+    this.nowProvider,
+    this.gcConfig = const AssetTombstoneGcConfig(),
+  });
 
   static const String _key = 'asset_expected_inflows_v1';
   static const String _rulesKey = 'asset_expected_inflow_rules_v1';
@@ -86,10 +122,8 @@ class AssetExpectedInflowStore {
   /// 「一度消した項目」がサーバ残存分から復活するのを抑止する (#part285)。
   static const String _deletedIdsKey = 'asset_expected_inflow_deleted_ids_v1';
 
-  /// トゥームストーンの保持上限と期限。SharedPreferences の肥大化を防ぐ
-  /// ため、書き込み・読み出し時に古い/超過分を破棄する (#part286)。
-  static const int _tombstoneMaxCount = 1000;
-  static const int _tombstoneMaxAgeDays = 365;
+  /// トゥームストーンの保持上限/期限 (#part286 GC / #part287 リモート調整可)。
+  final AssetTombstoneGcConfig gcConfig;
 
   final DateTime Function()? nowProvider;
 
@@ -224,6 +258,32 @@ class AssetExpectedInflowStore {
     return _decodeActiveIds(store.getString(_deletedIdsKey));
   }
 
+  /// トゥームストーン ID 集合をミラー upsert 用の値へ変換する
+  /// (`{'ids': [...]}`)。ページと統合テストで同一の形を共有する (#part287)。
+  static Map<String, dynamic> encodeDeletedIdsMirror(Iterable<String> ids) {
+    return <String, dynamic>{
+      'ids': [
+        for (final id in ids)
+          if (id.isNotEmpty) id,
+      ],
+    };
+  }
+
+  /// ミラー値 (`{'ids': [...]}`) から ID リストを取り出す。形が不正なら空。
+  static List<String> decodeDeletedIdsMirror(Object? value) {
+    if (value is! Map) {
+      return const <String>[];
+    }
+    final rawIds = value['ids'];
+    if (rawIds is! List) {
+      return const <String>[];
+    }
+    return <String>[
+      for (final id in rawIds)
+        if ((id?.toString() ?? '').isNotEmpty) id.toString(),
+    ];
+  }
+
   Future<void> _addDeletedId(SharedPreferences store, String id) async {
     if (id.isEmpty) {
       return;
@@ -273,18 +333,19 @@ class AssetExpectedInflowStore {
     }
   }
 
-  /// 期限切れ (>_tombstoneMaxAgeDays) を捨て、件数超過分は新しい順に残す。
+  /// 期限切れ (>gcConfig.maxAgeDays) を捨て、件数超過分は新しい順に残す。
   List<Map<String, String>> _gcEntries(List<Map<String, String>> entries) {
     final now = _now();
+    final maxAgeDays = gcConfig.maxAgeDays;
     final kept = <Map<String, String>>[];
     for (final entry in entries) {
       final at = DateTime.tryParse(entry['at'] ?? '');
-      if (at == null || now.difference(at).inDays <= _tombstoneMaxAgeDays) {
+      if (at == null || now.difference(at).inDays <= maxAgeDays) {
         kept.add(entry);
       }
     }
-    if (kept.length > _tombstoneMaxCount) {
-      return kept.sublist(kept.length - _tombstoneMaxCount);
+    if (kept.length > gcConfig.maxCount) {
+      return kept.sublist(kept.length - gcConfig.maxCount);
     }
     return kept;
   }

--- a/lib/widgets/display_mode_experiment_card.dart
+++ b/lib/widgets/display_mode_experiment_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -469,73 +470,130 @@ double _xForIndex(int index, double width, double leftPad, int count) {
   return leftPad + chartW * index / (count - 1);
 }
 
-/// 標準維持率% の推移を折れ線+面で描く拡大ビュー用チャート。
-/// null の週は線を途切れさせる(欠測を埋めない)。hover/tap で点の値を表示。
-class _RetentionLineChart extends StatefulWidget {
-  const _RetentionLineChart({required this.retention, super.key});
+/// グラフ共通の操作レイヤ: hover/tap で最近接点を選択し、フォーカス時は
+/// 矢印キーで点を移動できる (アクセシビリティ #part287)。描画と
+/// ツールチップは呼び出し側のビルダーへ委譲する。
+class _InteractiveChart extends StatefulWidget {
+  const _InteractiveChart({
+    required this.count,
+    required this.leftPad,
+    required this.semanticLabel,
+    required this.painterBuilder,
+    required this.tooltipBuilder,
+  });
 
-  final List<Map<String, dynamic>> retention;
+  final int count;
+  final double leftPad;
+  final String semanticLabel;
+  final CustomPainter Function(int? selected) painterBuilder;
+  final Widget Function(int selected, double width) tooltipBuilder;
 
   @override
-  State<_RetentionLineChart> createState() => _RetentionLineChartState();
+  State<_InteractiveChart> createState() => _InteractiveChartState();
 }
 
-class _RetentionLineChartState extends State<_RetentionLineChart> {
+class _InteractiveChartState extends State<_InteractiveChart> {
   int? _selected;
+  late final FocusNode _focusNode = FocusNode(debugLabel: 'experiment_chart');
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _select(int? i) {
+    if (i != _selected) {
+      setState(() => _selected = i);
+    }
+  }
+
+  void _move(int delta) {
+    if (widget.count == 0) {
+      return;
+    }
+    final base = _selected ?? (delta > 0 ? -1 : widget.count);
+    _select((base + delta).clamp(0, widget.count - 1));
+  }
+
+  KeyEventResult _onKey(FocusNode node, KeyEvent event) {
+    if (event is KeyUpEvent) {
+      return KeyEventResult.ignored;
+    }
+    final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.arrowRight ||
+        key == LogicalKeyboardKey.arrowUp) {
+      _move(1);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowLeft ||
+        key == LogicalKeyboardKey.arrowDown) {
+      _move(-1);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.escape) {
+      _select(null);
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
 
   @override
   Widget build(BuildContext context) {
-    final weeks = widget.retention.reversed.toList(growable: false);
-    const lineColor = Color(0xFF0D9488);
     return SizedBox(
       height: _kChartHeight,
       width: double.infinity,
       child: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
-          void onAt(Offset p) {
-            final i = _nearestIndex(
-              p.dx,
-              width,
-              _kRetentionLeftPad,
-              weeks.length,
-            );
-            if (i != _selected) {
-              setState(() => _selected = i);
-            }
-          }
-
-          return MouseRegion(
-            onHover: (event) => onAt(event.localPosition),
-            onExit: (_) {
-              if (_selected != null) {
-                setState(() => _selected = null);
-              }
-            },
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTapDown: (details) => onAt(details.localPosition),
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: CustomPaint(
-                      painter: _RetentionLinePainter(
-                        weeks: weeks,
-                        selected: _selected,
-                        lineColor: lineColor,
-                        gridColor: Theme.of(context).colorScheme.outlineVariant,
-                        labelColor:
-                            Theme.of(context).colorScheme.onSurfaceVariant,
+          int? indexAt(double dx) =>
+              _nearestIndex(dx, width, widget.leftPad, widget.count);
+          return Focus(
+            focusNode: _focusNode,
+            onKeyEvent: _onKey,
+            child: Semantics(
+              label: widget.semanticLabel,
+              child: MouseRegion(
+                onHover: (event) => _select(indexAt(event.localPosition.dx)),
+                onExit: (_) {
+                  if (!_focusNode.hasFocus) {
+                    _select(null);
+                  }
+                },
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTapDown: (details) {
+                    _focusNode.requestFocus();
+                    _select(indexAt(details.localPosition.dx));
+                  },
+                  child: AnimatedBuilder(
+                    animation: _focusNode,
+                    builder: (context, _) => DecoratedBox(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(4),
+                        border: _focusNode.hasFocus
+                            ? Border.all(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .primary
+                                    .withValues(alpha: 0.5),
+                              )
+                            : null,
+                      ),
+                      child: Stack(
+                        children: [
+                          Positioned.fill(
+                            child: CustomPaint(
+                              painter: widget.painterBuilder(_selected),
+                            ),
+                          ),
+                          if (_selected != null && _selected! < widget.count)
+                            widget.tooltipBuilder(_selected!, width),
+                        ],
                       ),
                     ),
                   ),
-                  if (_selected != null && _selected! < weeks.length)
-                    _ChartTooltip(
-                      text: _tooltipText(weeks[_selected!]),
-                      anchor: _anchor(weeks, _selected!, width),
-                      width: width,
-                    ),
-                ],
+                ),
               ),
             ),
           );
@@ -543,22 +601,58 @@ class _RetentionLineChartState extends State<_RetentionLineChart> {
       ),
     );
   }
+}
 
-  String _tooltipText(Map<String, dynamic> week) {
-    final rate = week['rate'];
-    return '${_weekShort(week['week_start'])}  '
-        '${rate == null ? '—' : '$rate%'}';
-  }
+/// 標準維持率% の推移を折れ線+面で描く拡大ビュー用チャート。
+/// null の週は線を途切れさせる(欠測を埋めない)。hover/tap/矢印キーで値を表示。
+class _RetentionLineChart extends StatelessWidget {
+  const _RetentionLineChart({required this.retention, super.key});
 
-  Offset _anchor(List<Map<String, dynamic>> weeks, int i, double width) {
-    const chartH = _kChartHeight - _kChartTopPad - _kChartBottomPad;
-    final x = _xForIndex(i, width, _kRetentionLeftPad, weeks.length);
-    final rate = (weeks[i]['rate'] as num?)?.toDouble();
-    final y = rate == null
-        ? _kChartTopPad
-        : _kChartTopPad + chartH * (1 - rate / 100);
-    return Offset(x, y);
+  final List<Map<String, dynamic>> retention;
+
+  @override
+  Widget build(BuildContext context) {
+    final weeks = retention.reversed.toList(growable: false);
+    final gridColor = Theme.of(context).colorScheme.outlineVariant;
+    final labelColor = Theme.of(context).colorScheme.onSurfaceVariant;
+    const lineColor = Color(0xFF0D9488);
+    return _InteractiveChart(
+      count: weeks.length,
+      leftPad: _kRetentionLeftPad,
+      semanticLabel: '標準維持率の推移グラフ。矢印キーで週を移動します。',
+      painterBuilder: (selected) => _RetentionLinePainter(
+        weeks: weeks,
+        selected: selected,
+        lineColor: lineColor,
+        gridColor: gridColor,
+        labelColor: labelColor,
+      ),
+      tooltipBuilder: (selected, width) => _ChartTooltip(
+        text: _retentionTooltipText(weeks[selected]),
+        anchor: _retentionAnchor(weeks, selected, width),
+        width: width,
+      ),
+    );
   }
+}
+
+String _retentionTooltipText(Map<String, dynamic> week) {
+  final rate = week['rate'];
+  return '${_weekShort(week['week_start'])}  '
+      '${rate == null ? '—' : '$rate%'}';
+}
+
+Offset _retentionAnchor(
+  List<Map<String, dynamic>> weeks,
+  int i,
+  double width,
+) {
+  const chartH = _kChartHeight - _kChartTopPad - _kChartBottomPad;
+  final x = _xForIndex(i, width, _kRetentionLeftPad, weeks.length);
+  final rate = (weeks[i]['rate'] as num?)?.toDouble();
+  final y =
+      rate == null ? _kChartTopPad : _kChartTopPad + chartH * (1 - rate / 100);
+  return Offset(x, y);
 }
 
 class _RetentionLinePainter extends CustomPainter {
@@ -715,21 +809,14 @@ class _RetentionLinePainter extends CustomPainter {
 
 /// 週次イベント(初期解決=藍 / 切替=橙)を積み上げ面で描く拡大ビュー用チャート。
 /// hover/tap でその週の初期解決/切替件数を表示。
-class _TrendAreaChart extends StatefulWidget {
+class _TrendAreaChart extends StatelessWidget {
   const _TrendAreaChart({required this.weekly, super.key});
 
   final List<Map<String, dynamic>> weekly;
 
   @override
-  State<_TrendAreaChart> createState() => _TrendAreaChartState();
-}
-
-class _TrendAreaChartState extends State<_TrendAreaChart> {
-  int? _selected;
-
-  @override
   Widget build(BuildContext context) {
-    final weeks = widget.weekly.reversed.toList(growable: false);
+    final weeks = weekly.reversed.toList(growable: false);
     var maxTotal = 1;
     for (final week in weeks) {
       final total = ((week['initials'] as num?)?.toInt() ?? 0) +
@@ -738,79 +825,48 @@ class _TrendAreaChartState extends State<_TrendAreaChart> {
         maxTotal = total;
       }
     }
-    return SizedBox(
-      height: _kChartHeight,
-      width: double.infinity,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final width = constraints.maxWidth;
-          void onAt(Offset p) {
-            final i = _nearestIndex(p.dx, width, _kTrendLeftPad, weeks.length);
-            if (i != _selected) {
-              setState(() => _selected = i);
-            }
-          }
-
-          return MouseRegion(
-            onHover: (event) => onAt(event.localPosition),
-            onExit: (_) {
-              if (_selected != null) {
-                setState(() => _selected = null);
-              }
-            },
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTapDown: (details) => onAt(details.localPosition),
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: CustomPaint(
-                      painter: _TrendAreaPainter(
-                        weeks: weeks,
-                        selected: _selected,
-                        maxTotal: maxTotal,
-                        initialsColor: const Color(0xFF6366F1),
-                        switchesColor: const Color(0xFFF97316),
-                        gridColor: Theme.of(context).colorScheme.outlineVariant,
-                        labelColor:
-                            Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ),
-                  if (_selected != null && _selected! < weeks.length)
-                    _ChartTooltip(
-                      text: _tooltipText(weeks[_selected!]),
-                      anchor: _anchor(weeks, _selected!, width, maxTotal),
-                      width: width,
-                    ),
-                ],
-              ),
-            ),
-          );
-        },
+    final gridColor = Theme.of(context).colorScheme.outlineVariant;
+    final labelColor = Theme.of(context).colorScheme.onSurfaceVariant;
+    return _InteractiveChart(
+      count: weeks.length,
+      leftPad: _kTrendLeftPad,
+      semanticLabel: '週次イベントの推移グラフ。矢印キーで週を移動します。',
+      painterBuilder: (selected) => _TrendAreaPainter(
+        weeks: weeks,
+        selected: selected,
+        maxTotal: maxTotal,
+        initialsColor: const Color(0xFF6366F1),
+        switchesColor: const Color(0xFFF97316),
+        gridColor: gridColor,
+        labelColor: labelColor,
+      ),
+      tooltipBuilder: (selected, width) => _ChartTooltip(
+        text: _trendTooltipText(weeks[selected]),
+        anchor: _trendAnchor(weeks, selected, width, maxTotal),
+        width: width,
       ),
     );
   }
+}
 
-  String _tooltipText(Map<String, dynamic> week) {
-    final initials = (week['initials'] as num?)?.toInt() ?? 0;
-    final switches = (week['switches'] as num?)?.toInt() ?? 0;
-    return '${_weekShort(week['week_start'])}  初期$initials/切替$switches';
-  }
+String _trendTooltipText(Map<String, dynamic> week) {
+  final initials = (week['initials'] as num?)?.toInt() ?? 0;
+  final switches = (week['switches'] as num?)?.toInt() ?? 0;
+  return '${_weekShort(week['week_start'])}  初期$initials/切替$switches';
+}
 
-  Offset _anchor(
-    List<Map<String, dynamic>> weeks,
-    int i,
-    double width,
-    int maxTotal,
-  ) {
-    const chartH = _kChartHeight - _kChartTopPad - _kChartBottomPad;
-    final x = _xForIndex(i, width, _kTrendLeftPad, weeks.length);
-    final total = ((weeks[i]['initials'] as num?)?.toInt() ?? 0) +
-        ((weeks[i]['switches'] as num?)?.toInt() ?? 0);
-    final y = _kChartTopPad + chartH * (1 - total / maxTotal);
-    return Offset(x, y);
-  }
+Offset _trendAnchor(
+  List<Map<String, dynamic>> weeks,
+  int i,
+  double width,
+  int maxTotal,
+) {
+  const chartH = _kChartHeight - _kChartTopPad - _kChartBottomPad;
+  final x = _xForIndex(i, width, _kTrendLeftPad, weeks.length);
+  final total = ((weeks[i]['initials'] as num?)?.toInt() ?? 0) +
+      ((weeks[i]['switches'] as num?)?.toInt() ?? 0);
+  final y = _kChartTopPad + chartH * (1 - total / maxTotal);
+  return Offset(x, y);
 }
 
 class _TrendAreaPainter extends CustomPainter {

--- a/scripts/check_duplicate_dispose.py
+++ b/scripts/check_duplicate_dispose.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import argparse
 import collections
+import concurrent.futures
+import os
 import pathlib
 import re
 import time
@@ -125,23 +127,38 @@ def top_level_statements(body: str):
     return statements
 
 
-def find_duplicates(root: pathlib.Path):
+def scan_file(path: pathlib.Path):
+    """1 ファイルを走査して重複ヒット行のリストを返す (並列ワーカー単位)。"""
     hits = []
-    for path in sorted(root.glob("lib/**/*.dart")):
-        source = LINE_COMMENT_RE.sub(
-            "", path.read_text(encoding="utf-8", errors="replace")
-        )
-        for name, start_index, body in method_bodies(source):
-            counter = collections.Counter(top_level_statements(body))
-            lifecycle = name in LIFECYCLE_NAMES
-            for statement, count in counter.items():
-                if count <= 1:
-                    continue
-                if not lifecycle and not RISKY_RE.search(statement):
-                    continue
-                line = source.count("\n", 0, start_index) + 1
-                shown = statement[:100]
-                hits.append(f"{path.as_posix()}:{line} {name}() x{count}: {shown}")
+    source = LINE_COMMENT_RE.sub(
+        "", path.read_text(encoding="utf-8", errors="replace")
+    )
+    for name, start_index, body in method_bodies(source):
+        counter = collections.Counter(top_level_statements(body))
+        lifecycle = name in LIFECYCLE_NAMES
+        for statement, count in counter.items():
+            if count <= 1:
+                continue
+            if not lifecycle and not RISKY_RE.search(statement):
+                continue
+            line = source.count("\n", 0, start_index) + 1
+            shown = statement[:100]
+            hits.append(f"{path.as_posix()}:{line} {name}() x{count}: {shown}")
+    return hits
+
+
+def find_duplicates(root: pathlib.Path):
+    # cold disk I/O 律速 (fresh checkout で全 lib 読込) を ThreadPoolExecutor で
+    # 並列化する (#part287)。ファイル読込は GIL を解放するため I/O 待ちが重なる。
+    # executor.map は入力順を保つので、出力はパス順で決定的なまま。
+    paths = sorted(root.glob("lib/**/*.dart"))
+    if not paths:
+        return []
+    workers = min(16, (os.cpu_count() or 4) * 2)
+    hits = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        for file_hits in executor.map(scan_file, paths):
+            hits.extend(file_hits)
     return hits
 
 

--- a/test/services/asset_expected_inflow_store_test.dart
+++ b/test/services/asset_expected_inflow_store_test.dart
@@ -473,5 +473,76 @@ void main() {
       ]);
       expect(added, 0);
     });
+
+    test('encode/decode deleted-ids mirror round-trips', () {
+      final mirror = AssetExpectedInflowStore.encodeDeletedIdsMirror(
+        <String>['a', '', 'b'],
+      );
+      expect(mirror, <String, dynamic>{
+        'ids': <String>['a', 'b'],
+      });
+      expect(
+        AssetExpectedInflowStore.decodeDeletedIdsMirror(mirror),
+        <String>['a', 'b'],
+      );
+      // 不正な形は空に倒す。
+      expect(
+        AssetExpectedInflowStore.decodeDeletedIdsMirror('nope'),
+        isEmpty,
+      );
+      expect(
+        AssetExpectedInflowStore.decodeDeletedIdsMirror(
+          <String, dynamic>{'ids': 'x'},
+        ),
+        isEmpty,
+      );
+    });
+
+    test('remote gc config tightens the cap and TTL', () async {
+      var clock = DateTime(2026, 1, 1, 9);
+      final store = AssetExpectedInflowStore(
+        nowProvider: () => clock,
+        gcConfig: const AssetTombstoneGcConfig(maxCount: 2, maxAgeDays: 10),
+      );
+
+      // 3件削除 → 上限2で古い1件が破棄される。
+      // クロックを毎回進めて id 衝突 (同一 microsecond) を避ける。
+      for (var i = 0; i < 3; i++) {
+        clock = DateTime(2026, 1, 1, 9, 0, i);
+        final added = await store.add(
+          date: DateTime(2026, 1, 2 + i),
+          amount: 1000.0 + i,
+          label: 'x$i',
+        );
+        await store.remove(added.firstWhere((e) => e.label == 'x$i').id);
+      }
+      final ids = await store.loadDeletedIds();
+      expect(ids, hasLength(2));
+
+      // TTL=10日を超えると全て失効。
+      clock = DateTime(2026, 2, 1, 9);
+      expect(await store.loadDeletedIds(), isEmpty);
+    });
+
+    test('AssetTombstoneGcConfig.fromMirrorValue parses and clamps', () {
+      const fallback = AssetTombstoneGcConfig();
+      expect(
+        AssetTombstoneGcConfig.fromMirrorValue(null).maxCount,
+        fallback.maxCount,
+      );
+
+      final parsed = AssetTombstoneGcConfig.fromMirrorValue(
+        <String, dynamic>{'max_count': 50, 'max_age_days': 30},
+      );
+      expect(parsed.maxCount, 50);
+      expect(parsed.maxAgeDays, 30);
+
+      // 0 以下は最小1へクランプ。
+      final clamped = AssetTombstoneGcConfig.fromMirrorValue(
+        <String, dynamic>{'max_count': 0, 'max_age_days': -5},
+      );
+      expect(clamped.maxCount, 1);
+      expect(clamped.maxAgeDays, 1);
+    });
   });
 }

--- a/test/services/mirror_two_client_scenario_test.dart
+++ b/test/services/mirror_two_client_scenario_test.dart
@@ -11,6 +11,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// 本体の fake 化は auth セッション偽装が必要になるため採らない (part 283 判断)。
 
 const String _inflowItemsKey = 'asset_expected_inflows_v1';
+const String _inflowDeletedIdsKey = 'asset_expected_inflow_deleted_ids_v1';
 
 Future<SharedPreferences> _switchClient([
   Map<String, Object> seed = const <String, Object>{},
@@ -287,6 +288,87 @@ void main() {
 
       expect(await displayStore.load(prefs: prefsB), modeA);
       expect(await displayStore.loadOverrides(prefs: prefsB), overridesA);
+    });
+
+    test(
+        'full round trip: A deletes → server → B reflects → B re-uploads → '
+        'A keeps deletion', () async {
+      // 端末A: I1(給料)+I2(フリマ) を登録しサーバ行へ。
+      final prefsA1 = await _switchClient();
+      final storeA = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 13, 9),
+      );
+      await storeA.add(
+        date: DateTime(2026, 6, 25),
+        amount: 280000,
+        label: '給料',
+        prefs: prefsA1,
+      );
+      await storeA.add(
+        date: DateTime(2026, 6, 30),
+        amount: 12000,
+        label: 'フリマ売上',
+        prefs: prefsA1,
+      );
+      final serverInitial = _uploadInflows(
+        await storeA.loadAll(prefs: prefsA1),
+        const <AssetExpectedInflowRule>[],
+      );
+      final removedId = serverInitial
+          .firstWhere((row) => row['label'] == 'フリマ売上')['id']
+          .toString();
+
+      // 端末A: I2 をローカル削除 → トゥームストーンをミラー値 (encode) へ。
+      await storeA.remove(removedId, prefs: prefsA1);
+      final tombstoneMirror = AssetExpectedInflowStore.encodeDeletedIdsMirror(
+        await storeA.loadDeletedIds(prefs: prefsA1),
+      );
+      // A の削除後スナップショット (items + tombstone) を控える。
+      final aSnapshot = <String, Object>{
+        _inflowItemsKey: prefsA1.getString(_inflowItemsKey)!,
+        _inflowDeletedIdsKey: prefsA1.getString(_inflowDeletedIdsKey)!,
+      };
+
+      // 端末B: 削除前にサーバ同期済 (I1,I2) の状態を作る。
+      final prefsB = await _switchClient();
+      final storeB = AssetExpectedInflowStore(
+        nowProvider: () => DateTime(2026, 6, 14, 9),
+      );
+      await storeB.restoreFromMirrorRows(serverInitial, prefs: prefsB);
+      expect(await storeB.loadAll(prefs: prefsB), hasLength(2));
+
+      // 端末B: A のトゥームストーンミラーを decode→適用 → I2 が消える。
+      final incoming = AssetExpectedInflowStore.decodeDeletedIdsMirror(
+        tombstoneMirror,
+      );
+      final removedOnB = await storeB.applyRemoteDeletedIds(
+        incoming,
+        prefs: prefsB,
+      );
+      expect(removedOnB, 1);
+
+      // 端末B: I4(臨時) を追加して再アップロード。
+      await storeB.add(
+        date: DateTime(2026, 7, 5),
+        amount: 30000,
+        label: '臨時収入',
+        prefs: prefsB,
+      );
+      final serverFromB = _uploadInflows(
+        await storeB.loadAll(prefs: prefsB),
+        const <AssetExpectedInflowRule>[],
+      );
+      expect(serverFromB.map((row) => row['label']), isNot(contains('フリマ売上')));
+
+      // 端末Aへ戻り、B 由来のサーバ行をマージ → I2 は復活せず I4 が増える。
+      final prefsA2 = await _switchClient(aSnapshot);
+      final added =
+          await storeA.mergeFromMirrorRows(serverFromB, prefs: prefsA2);
+      final mergedA = await storeA.loadAll(prefs: prefsA2);
+
+      expect(added, 1); // I4 のみ (I1 は既知 / I2 はトゥームストーン)
+      expect(mergedA.map((e) => e.label), containsAll(<String>['給料', '臨時収入']));
+      expect(mergedA.map((e) => e.id), isNot(contains(removedId)));
     });
   });
 }

--- a/test/widgets/display_mode_experiment_card_test.dart
+++ b/test/widgets/display_mode_experiment_card_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/widgets/display_mode_experiment_card.dart';
 
@@ -126,6 +127,79 @@ void main() {
       expect(tooltip, findsOneWidget);
       expect(
         find.descendant(of: tooltip, matching: find.textContaining('%')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('arrow keys move the selected point (keyboard a11y)', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1500));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: DisplayModeExperimentCard(
+                debugWeekly: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'week_start': '2026-06-15',
+                    'initials': 6,
+                    'initial_standard': 5,
+                    'switches': 3,
+                  },
+                  <String, dynamic>{
+                    'week_start': '2026-06-08',
+                    'initials': 5,
+                    'initial_standard': 4,
+                    'switches': 2,
+                  },
+                  <String, dynamic>{
+                    'week_start': '2026-06-01',
+                    'initials': 3,
+                    'initial_standard': 1,
+                    'switches': 1,
+                  },
+                ],
+                debugWeeklyRetention: <Map<String, dynamic>>[
+                  <String, dynamic>{'week_start': '2026-06-15', 'rate': 90},
+                  <String, dynamic>{'week_start': '2026-06-08', 'rate': 80},
+                  <String, dynamic>{'week_start': '2026-06-01', 'rate': 70},
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('display_mode_experiment_expand')));
+      await tester.pumpAndSettle();
+
+      // タップでフォーカス+選択。週は時系列昇順 (06-01,06-08,06-15)。
+      await tester.tap(
+        find.byKey(const Key('display_mode_retention_line_chart')),
+      );
+      await tester.pumpAndSettle();
+
+      // 右矢印2回で必ず末尾 (06-15 / 90%) に到達する (clamp)。
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+
+      final tooltip = find.byKey(const Key('display_mode_chart_tooltip'));
+      expect(
+        find.descendant(of: tooltip, matching: find.textContaining('90%')),
+        findsOneWidget,
+      );
+
+      // 左矢印2回で先頭 (06-01 / 70%) へ。
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();
+      expect(
+        find.descendant(of: tooltip, matching: find.textContaining('70%')),
         findsOneWidget,
       );
     });


### PR DESCRIPTION
## 概要

part 286 の次回候補 4 件を実装。

1. **tombstone ミラーの双方向往復を 1 統合テストで通し検証** — 「A 削除 → サーバ → B 反映 → B 再 upload → A 維持」の全周を `mirror_two_client_scenario_test.dart` の単一テストで検証。ミラー値の形 (`{'ids': [...]}`) を `encodeDeletedIdsMirror` / `decodeDeletedIdsMirror`(store 静的関数)へ抽出してページと共有し、encode→decode 往復の単体テストも追加。
2. **グラフツールチップのキーボード/フォーカス対応** — 折れ線/面チャートの操作レイヤを共通 `_InteractiveChart` へ集約。hover/tap に加え、フォーカス時に**矢印キーで点を移動**(↑→ 進む / ↓← 戻る / Esc 解除)、フォーカス枠の表示、`Semantics` ラベル付与でアクセシビリティ対応。
3. **監査スクリプトの cold I/O を並列化** — `check_duplicate_dispose.py` のファイル走査を `ThreadPoolExecutor` で並列化(ファイル読込が GIL を解放)。fresh checkout の全 lib 読込が **~22s → ~2.6s**。`executor.map` で出力はパス順のまま決定的。
4. **tombstone GC の上限/TTL をサーバ設定可能に** — GC パラメータを `AssetTombstoneGcConfig` へ外出しし、`asset_pref_mirror`(pref_key `inflow_tombstone_gc`)から取得した値(`max_count` / `max_age_days`、範囲クランプ付)で上書き可能に。ページは boot 時に設定を取得してからトゥームストーンを取り込む。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核となる 3ケース: (1) 双方向往復で A の削除が B へ伝播し、B の追加が A へ統合され、削除済みは復活しない (2) 矢印キーで選択点が移動しツールチップ値が変わる (3) リモート GC 設定で cap/TTL が縮まる。今回 service 4 + widget 1 を追加、全体で flutter test 701 ケース。
- E2E例外: 変更はクライアント + テスト + CI 監査スクリプトのみでサーバ・スキーマ変更なし(設定/トゥームストーンは既存 `asset_pref_mirror` の汎用 jsonb)。widget pump がエンドツーエンド相当(キーボード操作→ツールチップ)を、service 統合テストが端末間往復を担い、本番疎通は既存 Playwright smoke で補完する。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `python scripts/check_duplicate_dispose.py` **CLEAN (2.6s)** / `flutter test` **701/701 PASS**。compare diff-stat ゲート確認済み(+556 -171 / 7 files / widget -139 はチャート2重実装の共通化分、想定外削除なし)。

## High-risk gate

- High-risk-ultrareview-exception: migration・RLS・認証・課金ロジックへの変更は一切なし。設定/トゥームストーンの保存は既存 `asset_pref_mirror` テーブルへの汎用 jsonb upsert のみで、新テーブル・新ポリシーなし。監査スクリプトは読み取り専用の静的チェック。レビュー所有者: Claude Code #1。
- 自己点検メモ: rollback = 本 PR revert のみで完結(GC 設定は欠落時に既定へフォールバック / mirror ヘルパは形不正で空に倒す安全側)/ キーボード対応は IgnorePointer のツールチップで操作を妨げない / 並列監査は executor.map で順序保証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
