### PR TITLE
fix(home): 業務メニューの機能起動を user_feature_usage に記録（最近使った/よく使われる機能を実働化）

### DIFF
--- a/lib/pages/work_menu_page.dart
+++ b/lib/pages/work_menu_page.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../data/home_tool_catalog.dart';
 import '../services/home_tool_usage_service.dart';
+import '../utils/feature_tap_logger.dart';
 
 class WorkMenuPage extends StatefulWidget {
   const WorkMenuPage({
@@ -88,6 +91,11 @@ class _WorkMenuPageState extends State<WorkMenuPage> {
       return;
     }
     await HomeToolUsageService.recordToolUse(entry.id);
+    // ホームの「最近使った機能 / よく使われる機能」は user_feature_usage を参照する。
+    // 業務メニューが主要な起動口なので、ローカル recent とは別に DB へも記録する。
+    final usageRoute = entry.routePath ??
+        (entry.id.startsWith('/') ? entry.id : '/${entry.id}');
+    unawaited(recordFeatureTap(usageRoute, entry.title));
     if (!mounted) return;
     await entry.onOpen(context);
     if (!mounted) return;


### PR DESCRIPTION
## 概要

スマホ実機 UAT の追加報告(build 4462 でも「最近使った機能 / よく使われる機能」がサイト案内AIしか出ない)への対応。

## 根本原因

ホームの「最近使った機能」(`RecentFeaturesList`)と「よく使われる機能」(`PopularFeaturesList`)は Supabase の `user_feature_usage` テーブルを参照する。しかし**主要な機能起動口である業務メニュー**(`work_menu_page._openEntry`)は、ローカルの `HomeToolUsageService`(SharedPreferences)にしか記録しておらず、`user_feature_usage` には一切書いていなかった。そのため両セクションには、`recordFeatureTap` を呼ぶ一部導線(サイト案内AI 等)のデータしか溜まらず、実質機能していなかった。

## 修正

`_openEntry` で `recordFeatureTap(route, title)` を fire-and-forget 追加。route 正規化は `home_page` の `_runTrackedAction` と同一ロジック(`entry.routePath ?? '/<id>'`)。これにより業務メニュー経由の全機能起動が DB に記録され、両セクションが多様な利用実績で埋まるようになる。

## Minimal E2E Gate

- 本変更は **実装詳細に依存しない**(implementation-detail independent / black-box)観測点として「業務メニューでの機能タップ → `user_feature_usage` への 1 行 insert(user_id / feature_route / feature_label)」という入出力契約を持つ。検証は最小限の **3ケース** を想定: ① ルート指定ありの entry → routePath で記録、② ルート指定なし entry → `/<id>` に正規化して記録、③ 未ログイン時は記録せず遷移のみ(`recordFeatureTap` の早期 return)。
- 既存の Playwright E2E (`test/e2e/public_smoke.spec.ts`) が public ルートの smoke を本 PR の CI でも実行する。
- E2E-Exception: 業務メニューからの機能起動と利用記録は **認証 + Supabase 書き込みを伴う**ため、public Playwright E2E では到達不可。authenticated E2E fixture が現基盤に存在しないため、`flutter analyze` + 既存 widget テスト(業務メニュー描画)+ 上記入出力契約のレビューで代替担保する。

## 検証

- `flutter analyze lib/pages/work_menu_page.dart`(Flutter 3.38.10 = CI 同一版): **No issues found**
- `dart format --set-exit-if-changed`: 差分なし

https://claude.ai/code/session_01GHDwMz29SRggnphStwvxzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHDwMz29SRggnphStwvxzj)_