### PR TITLE
fix(home): 全 named route 遷移を利用履歴に記録し最近使った/よく使われるの機能不全を解消

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:my_web_app/data/home_tool_catalog.dart';
+import 'package:my_web_app/utils/feature_route_labels.dart';
 import 'package:my_web_app/models/site_guide_catalog_item.dart';
 import 'package:my_web_app/pages/abstinence_guard_page.dart';
 import 'package:my_web_app/pages/self_touch_tracker_page.dart';
@@ -512,6 +513,10 @@ class _MyAppState extends State<MyApp> {
       ],
       onGenerateRoute: (settings) {
         final uri = Uri.parse(settings.name ?? '/');
+        // 全ての named route 遷移を利用履歴に記録する単一チョークポイント。
+        // 主要導線の直叩き pushNamed が記録されず、最近使った / よく使われる
+        // 機能が「サイト案内AI」しか並ばなかった機能不全 (#3279) を解消する。
+        recordFeatureRouteNavigation(settings.name);
 
         switch (uri.path) {
           case '/':

--- a/lib/utils/feature_route_labels.dart
+++ b/lib/utils/feature_route_labels.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import '../data/home_system_fixed.dart';
-import '../data/home_tool_catalog.dart';
 import 'feature_tap_logger.dart';
 
 /// 「最近使った機能 / よく使われる機能」に集計しないルート。
@@ -15,32 +14,20 @@ const Set<String> _nonFeatureRoutes = <String>{
 };
 
 Map<String, String>? _labelCache;
-bool _catalogLoaded = false;
 
-/// route -> ラベルの参照表。
-/// `kHomeSystemFixed` と home ツールカタログから構築し、カタログ構築に
-/// 成功した時点でキャッシュする（Supabase 未初期化時は次回再試行）。
+/// route -> ラベルの参照表。`kHomeSystemFixed`(主要固定機能)から構築する。
+///
+/// home ツールカタログ由来の機能は `_runTrackedAction` 側が日本語タイトルで
+/// 既に利用記録しており、かつ `Navigator.push`(= `onGenerateRoute` を通らない)
+/// ため、ここでカタログを import する必要はない。重いページ群の import を避ける
+/// ことで VM テストでも安全に評価できる。
 Map<String, String> _featureRouteLabels() {
-  if (_catalogLoaded && _labelCache != null) return _labelCache!;
-  final map = <String, String>{
+  return _labelCache ??= <String, String>{
     for (final f in kHomeSystemFixed) f.route: f.label,
   };
-  try {
-    for (final entry in buildHomeToolCatalog()) {
-      final route = entry.routePath;
-      if (route != null && route.isNotEmpty) {
-        map.putIfAbsent(route, () => entry.title);
-      }
-    }
-    _catalogLoaded = true;
-  } catch (_) {
-    // カタログ構築失敗時は system-fixed 分とフォールバックで継続する。
-  }
-  _labelCache = map;
-  return map;
 }
 
-/// route からラベルを解決する。カタログに無ければ slug を整形して返す。
+/// route からラベルを解決する。固定機能に無ければ slug を整形して返す。
 String featureLabelForRoute(String route) {
   return _featureRouteLabels()[route] ?? _titleFromRoute(route);
 }

--- a/lib/utils/feature_route_labels.dart
+++ b/lib/utils/feature_route_labels.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import '../data/home_system_fixed.dart';
+import '../data/home_tool_catalog.dart';
+import 'feature_tap_logger.dart';
+
+/// 「最近使った機能 / よく使われる機能」に集計しないルート。
+/// 認証・アプリシェル・ホーム自体など、機能チップとして並べる対象外の導線。
+const Set<String> _nonFeatureRoutes = <String>{
+  '/',
+  '/login',
+  '/home',
+  '/landing',
+  '/maintenance',
+};
+
+Map<String, String>? _labelCache;
+bool _catalogLoaded = false;
+
+/// route -> ラベルの参照表。
+/// `kHomeSystemFixed` と home ツールカタログから構築し、カタログ構築に
+/// 成功した時点でキャッシュする（Supabase 未初期化時は次回再試行）。
+Map<String, String> _featureRouteLabels() {
+  if (_catalogLoaded && _labelCache != null) return _labelCache!;
+  final map = <String, String>{
+    for (final f in kHomeSystemFixed) f.route: f.label,
+  };
+  try {
+    for (final entry in buildHomeToolCatalog()) {
+      final route = entry.routePath;
+      if (route != null && route.isNotEmpty) {
+        map.putIfAbsent(route, () => entry.title);
+      }
+    }
+    _catalogLoaded = true;
+  } catch (_) {
+    // カタログ構築失敗時は system-fixed 分とフォールバックで継続する。
+  }
+  _labelCache = map;
+  return map;
+}
+
+/// route からラベルを解決する。カタログに無ければ slug を整形して返す。
+String featureLabelForRoute(String route) {
+  return _featureRouteLabels()[route] ?? _titleFromRoute(route);
+}
+
+String _titleFromRoute(String route) {
+  final segments = route.split('/').where((part) => part.isNotEmpty).toList();
+  if (segments.isEmpty) return route;
+  return segments.last
+      .split('-')
+      .where((part) => part.isNotEmpty)
+      .map((part) => part[0].toUpperCase() + part.substring(1))
+      .join(' ');
+}
+
+/// named route 遷移を利用履歴 (`user_feature_usage`) に記録する共通フック。
+///
+/// `MaterialApp.onGenerateRoute` から全ての `Navigator.pushNamed` 遷移に対して
+/// 呼ばれ、トップページの 5-tier（最近使った / よく使われる）へ反映される。
+/// これまで home tier チップ等の一部導線でしか記録されず、主要導線の
+/// 直叩き `pushNamed` が履歴に残らなかった機能不全を解消する。
+void recordFeatureRouteNavigation(String? routeName) {
+  if (routeName == null || routeName.isEmpty) return;
+  final path = Uri.tryParse(routeName)?.path ?? routeName;
+  if (path.isEmpty || _nonFeatureRoutes.contains(path)) return;
+  unawaited(recordFeatureTap(path, featureLabelForRoute(path)));
+}

--- a/lib/utils/feature_tap_logger.dart
+++ b/lib/utils/feature_tap_logger.dart
@@ -1,15 +1,16 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 Future<void> recordFeatureTap(String route, String label) async {
-  final user = Supabase.instance.client.auth.currentUser;
-  if (user == null) return;
   try {
+    final user = Supabase.instance.client.auth.currentUser;
+    if (user == null) return;
     await Supabase.instance.client.from('user_feature_usage').insert({
       'user_id': user.id,
       'feature_route': route,
       'feature_label': label,
     });
   } catch (_) {
-    // fire-and-forget; don't block navigation on failure
+    // fire-and-forget; Supabase 未初期化やネットワーク失敗でも遷移を妨げない。
+    // onGenerateRoute から全遷移で呼ばれるため、ここで必ず例外を吸収する。
   }
 }

--- a/lib/utils/home_feature_actions.dart
+++ b/lib/utils/home_feature_actions.dart
@@ -1,17 +1,14 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-
-import 'feature_tap_logger.dart';
 
 /// ピン留めが変化したら increment され、お気に入りセクションが再読込する。
 final ValueNotifier<int> homePinnedFeaturesRevision = ValueNotifier<int>(0);
 
 /// home tier チップ/リスト共通の遷移処理。
-/// 利用履歴 (user_feature_usage) に記録してから named route へ遷移する。
+/// 利用履歴 (user_feature_usage) への記録は `MaterialApp.onGenerateRoute` の
+/// `recordFeatureRouteNavigation` が全 named route 遷移に対して一元的に行うため、
+/// ここでは named route へ遷移するだけでよい（二重計上を避ける）。
 Future<void> openHomeFeature(BuildContext context, String route, String label) {
-  unawaited(recordFeatureTap(route, label));
   return Navigator.pushNamed(context, route);
 }
 

--- a/test/utils/feature_route_labels_test.dart
+++ b/test/utils/feature_route_labels_test.dart
@@ -11,8 +11,10 @@ void main() {
     });
 
     test('未知ルートは slug を Title Case に整形してフォールバックする', () {
-      expect(featureLabelForRoute('/guitar-recording-studio'),
-          'Guitar Recording Studio');
+      expect(
+        featureLabelForRoute('/guitar-recording-studio'),
+        'Guitar Recording Studio',
+      );
       expect(featureLabelForRoute('/personality-test'), 'Personality Test');
     });
 

--- a/test/utils/feature_route_labels_test.dart
+++ b/test/utils/feature_route_labels_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/utils/feature_route_labels.dart';
+
+void main() {
+  group('featureLabelForRoute', () {
+    test('system-fixed なルートは日本語ラベルを返す', () {
+      // kHomeSystemFixed 由来。Supabase 未初期化でも参照できる。
+      expect(featureLabelForRoute('/site-guide-ai'), 'サイト案内AI');
+      expect(featureLabelForRoute('/ai-university'), 'AI大学');
+      expect(featureLabelForRoute('/release-notes'), 'Release Notes');
+    });
+
+    test('未知ルートは slug を Title Case に整形してフォールバックする', () {
+      expect(featureLabelForRoute('/guitar-recording-studio'),
+          'Guitar Recording Studio');
+      expect(featureLabelForRoute('/personality-test'), 'Personality Test');
+    });
+
+    test('クエリ付きでも path 部分のラベルになる', () {
+      expect(featureLabelForRoute('/release-notes'), 'Release Notes');
+    });
+  });
+}


### PR DESCRIPTION
## 背景

スマホ実機 UAT で「トップページが build 4462 でも直っていない」と報告(IMG_4536)。「最近使った機能」「よく使われる機能」に `サイト案内AI` しか並ばない症状が継続していた。

### 調査

- build 4462 には #3279 の修正自体は含まれていた(リリース履歴で確認)。よって単なる再配信では直らない。
- 根本原因: #3279 / PR #3280 の修正は home tier チップ等の一部導線にしか利用記録を仕込んでおらず、アプリ全体に散在する主要導線(大カード・メニュー・各種ボタン)の生の `Navigator.pushNamed` は `user_feature_usage` に記録されなかった。チップは「表示専用」でデータを生まないため、普段使いでは `site-guide-ai`(専用導線)しか溜まらなかった。

## 修正

`Navigator.pushNamed` は全て `MaterialApp.onGenerateRoute` を通るため、ここを単一の記録チョークポイントにした。

- `lib/utils/feature_route_labels.dart`(新規): 全 named route 遷移を `user_feature_usage` へ一元記録 + ラベル解決(`kHomeSystemFixed` の主要固定機能は日本語ラベル、未知ルートは slug を Title Case にフォールバック)。`/`, `/login`, `/home`, `/landing`, `/maintenance` は集計対象外。カタログ導線は既存の `_runTrackedAction` が日本語タイトルで記録しており、かつ `Navigator.push`(= `onGenerateRoute` を通らない)ため二重記録にならない。
- `lib/main.dart`: `onGenerateRoute` 冒頭で記録フックを呼び全 `pushNamed` を捕捉
- `lib/utils/home_feature_actions.dart`: `openHomeFeature` の重複記録を削除(一元記録との二重計上を回避)
- `lib/utils/feature_tap_logger.dart`: `recordFeatureTap` 全体を try/catch で保護(全遷移から呼ばれるため、Supabase 未初期化やネットワーク失敗でも遷移を妨げない)
- `test/utils/feature_route_labels_test.dart`: ラベル解決の単体テスト追加

## 効果

どの導線から機能を開いても利用が記録され、「最近使った機能 / よく使われる機能」が正しく埋まる。

## Minimal E2E Gate

- 検証は実装詳細に依存しない入出力 (I/O) 契約で行う(ルート名 → 記録ラベルの対応)。
- 最小限の3ケース(入出力)を想定:
  1. 既知ルート(`/site-guide-ai`)→ 日本語ラベル `サイト案内AI` で記録
  2. 未知ルート(`/guitar-recording-studio`)→ Title Case フォールバックで記録
  3. 非機能ルート(`/`, `/login` 等)→ 記録しない
- E2E mechanism: integration_test を想定。
- E2E-Exception: 本変更は利用履歴記録の配線のみで業務ロジックの分岐を持たず、記録は fire-and-forget のため失敗しても画面遷移に影響しない。中核のラベル解決ロジックは単体テスト済みであり、重い integration_test は本 PR では不要と判断。

---

🤖 関連: #3279

https://claude.ai/code/session_0196MXKcH5U1x6nDhNp2dk2h