### PR TITLE
feat(asset): tombstone汎用化 + GC設定UI + グラフa11y強化 + pre-commit hook (part 289)

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,22 @@
+# .githooks
+
+ローカルの git hooks。リポジトリ追跡下に置き、各自が opt-in で有効化する。
+
+## 有効化
+
+```bash
+git config core.hooksPath .githooks
+```
+
+(無効化: `git config --unset core.hooksPath`)
+
+## pre-commit
+
+`scripts/check_duplicate_dispose.py` を実行し、**二重 dispose / 二重 await /
+二重 setState**(part 280 で本番障害になった系統)をコミット前に検知する。
+
+- `lib/**/*.dart` がステージされている時だけ走る(非 dart コミットは即通過)。
+- 監査本体は CI と同一スクリプト。通常 ~2.6s(`--max-seconds 60` で線形時間も担保)。
+- 同じゲートは [`ci.yml`](../.github/workflows/ci.yml) でも走るため、hook 未設定でも
+  CI で必ず検出される。hook は「手元での早期検知」用。
+- 緊急迂回は `git commit --no-verify`(非推奨)。

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# 二重 dispose / 二重 await / 二重 setState をコミット前に即検知する pre-commit hook。
+# 有効化: git config core.hooksPath .githooks
+#
+# lib/ 配下の .dart がステージされている時だけ監査を走らせる (非 dart コミットは即通過)。
+# 監査本体は CI と同じ scripts/check_duplicate_dispose.py (#part286 で線形時間化済)。
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+staged_dart="$(git diff --cached --name-only --diff-filter=ACM | grep -E '^lib/.*\.dart$' || true)"
+if [ -z "$staged_dart" ]; then
+  exit 0
+fi
+
+python_bin="python"
+command -v python >/dev/null 2>&1 || python_bin="python3"
+
+if ! "$python_bin" scripts/check_duplicate_dispose.py --max-seconds 60; then
+  echo "" >&2
+  echo "pre-commit: 重複した dispose/await/setState を検出しました。修正後に再コミットしてください。" >&2
+  echo "（緊急時は 'git commit --no-verify' で迂回できますが非推奨）" >&2
+  exit 1
+fi
+
+exit 0

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -117,6 +117,10 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, dynamic>? debugInflowDeletedIdsMirror;
 
+  /// テスト専用: トゥームストーン GC 設定の初期値を注入する (#part288)。
+  @visibleForTesting
+  final AssetTombstoneGcConfig? debugTombstoneGcConfig;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -128,6 +132,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugInitialAssetData,
     this.debugMirrorPrefsRows,
     this.debugInflowDeletedIdsMirror,
+    this.debugTombstoneGcConfig,
   });
 
   @override
@@ -365,9 +370,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   String? _assetManagementMainAccountId;
   Map<AssetManagementSectionId, AssetManagementSectionVisibilityOverride>
       _sectionOverrides = {};
-  // GC 設定をサーバから取得したら差し替えるため非 final (#part287)。
+  // GC 設定をサーバ/ローカルから取得したら差し替えるため非 final (#part287/288)。
   AssetExpectedInflowStore _expectedInflowStore =
       const AssetExpectedInflowStore();
+  AssetTombstoneGcConfig _tombstoneGcConfig = const AssetTombstoneGcConfig();
   List<AssetExpectedInflow> _expectedInflows = <AssetExpectedInflow>[];
   List<AssetExpectedInflowRule> _expectedInflowRules =
       <AssetExpectedInflowRule>[];
@@ -464,10 +470,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _loadDisplayMode();
     _loadMainAccount();
     _loadExpectedInflows();
-    // GC 設定をサーバから取得してから削除トゥームストーンを取り込む。
-    unawaited(
-      _loadTombstoneGcConfig().then((_) => _pullInflowDeletedIds()),
-    );
+    // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
+    unawaited(_initTombstoneGcAndPull());
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
       final previousMonthKey = _assetLiabilityStateMonthKey(_now);
@@ -8282,8 +8286,29 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   /// トゥームストーン GC の上限/期限をサーバ (asset_pref_mirror) から取得し、
   /// ストアへ反映する (#part287 リモート調整)。未設定なら既定のまま。
+  Future<void> _initTombstoneGcAndPull() async {
+    await _applyLocalTombstoneGcConfig();
+    await _loadTombstoneGcConfig();
+    await _pullInflowDeletedIds();
+  }
+
+  /// ローカル保存 (またはテスト注入) の GC 設定をストアへ反映する。
+  Future<void> _applyLocalTombstoneGcConfig() async {
+    final config = widget.debugTombstoneGcConfig ??
+        await AssetExpectedInflowStore.loadGcConfig();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _tombstoneGcConfig = config;
+      _expectedInflowStore = AssetExpectedInflowStore(gcConfig: config);
+    });
+  }
+
   Future<void> _loadTombstoneGcConfig() async {
-    if (_supabase.auth.currentUser == null) {
+    // テスト注入時はサーバ取得を行わない (ネットワーク非依存)。
+    if (widget.debugTombstoneGcConfig != null ||
+        _supabase.auth.currentUser == null) {
       return;
     }
     try {
@@ -8291,14 +8316,117 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           .from('asset_pref_mirror')
           .select()
           .eq('pref_key', 'inflow_tombstone_gc');
-      if (rows.isEmpty) {
+      if (rows.isEmpty || !mounted) {
         return;
       }
-      _expectedInflowStore = AssetExpectedInflowStore(
-        gcConfig: AssetTombstoneGcConfig.fromMirrorValue(rows.first['value']),
+      final config = AssetTombstoneGcConfig.fromMirrorValue(
+        rows.first['value'],
       );
+      await AssetExpectedInflowStore.saveGcConfig(config);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _tombstoneGcConfig = config;
+        _expectedInflowStore = AssetExpectedInflowStore(gcConfig: config);
+      });
     } catch (e) {
       debugPrint('tombstone gc config fetch failed: $e');
+    }
+  }
+
+  /// GC 設定 (上限/期限) の編集ダイアログ。保存でローカル+ミラーへ反映する。
+  Future<void> _showTombstoneGcSettings(
+    void Function(void Function()) setOuterState,
+  ) async {
+    final countController = TextEditingController(
+      text: '${_tombstoneGcConfig.maxCount}',
+    );
+    final ageController = TextEditingController(
+      text: '${_tombstoneGcConfig.maxAgeDays}',
+    );
+    final saved = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('削除履歴の保持設定'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              '削除した入金予定の「復活防止」記録を、どれだけ保持するか。',
+              style: TextStyle(fontSize: 12, height: 1.5),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              key: const Key('asset_tombstone_gc_maxcount'),
+              controller: countController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '最大件数'),
+            ),
+            TextField(
+              key: const Key('asset_tombstone_gc_maxage'),
+              controller: ageController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '保持日数'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            key: const Key('asset_tombstone_gc_save'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    if (saved != true || !mounted) {
+      return;
+    }
+    final config = AssetTombstoneGcConfig.fromMirrorValue(<String, dynamic>{
+      'max_count': int.tryParse(countController.text.trim()),
+      'max_age_days': int.tryParse(ageController.text.trim()),
+    });
+    await AssetExpectedInflowStore.saveGcConfig(config);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _tombstoneGcConfig = config;
+      _expectedInflowStore = AssetExpectedInflowStore(gcConfig: config);
+    });
+    setOuterState(() {});
+    unawaited(_mirrorTombstoneGcConfig(config));
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          '保持設定を更新しました(最大${config.maxCount}件 / ${config.maxAgeDays}日)',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _mirrorTombstoneGcConfig(AssetTombstoneGcConfig config) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': 'inflow_tombstone_gc',
+        'value': config.toMirrorValue(),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('tombstone gc config upsert failed: $e');
     }
   }
 
@@ -8534,6 +8662,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   ),
           ),
           actions: [
+            TextButton.icon(
+              key: const Key('asset_tombstone_gc_edit'),
+              onPressed: () => _showTombstoneGcSettings(setDialogState),
+              icon: const Icon(Icons.cleaning_services_outlined, size: 16),
+              label: Text(
+                '保持設定 '
+                '(${_tombstoneGcConfig.maxCount}件/${_tombstoneGcConfig.maxAgeDays}日)',
+              ),
+            ),
             TextButton.icon(
               key: const Key('asset_inflow_merge_button'),
               onPressed: () async {

--- a/lib/services/asset_expected_inflow_store.dart
+++ b/lib/services/asset_expected_inflow_store.dart
@@ -1,7 +1,13 @@
 import 'dart:convert';
 
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
+import 'package:my_web_app/services/mirror_tombstone_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+// GC 設定とトゥームストーン汎用ストアは mirror_tombstone_store.dart へ移設
+// (#part288)。既存 import (page 等) との後方互換のため再エクスポートする。
+export 'package:my_web_app/services/mirror_tombstone_store.dart'
+    show AssetTombstoneGcConfig, MirrorTombstoneStore;
 
 /// 入金予定(給料・振込など)。カレンダーの見込み残高に加算され、
 /// 残高ショート警告の精度を上げる。端末ローカル保存のみ。
@@ -75,39 +81,6 @@ class AssetExpectedInflowRule {
   }
 }
 
-/// トゥームストーン GC の上限/期限。既定はローカル定数だが、サーバ
-/// (asset_pref_mirror) から取得した値で上書きできる (#part287 リモート調整)。
-class AssetTombstoneGcConfig {
-  const AssetTombstoneGcConfig({
-    this.maxCount = 1000,
-    this.maxAgeDays = 365,
-  });
-
-  final int maxCount;
-  final int maxAgeDays;
-
-  /// ミラー値 (`{'max_count': N, 'max_age_days': M}`) から構築する。
-  /// 欠落/不正値は既定を維持し、正の範囲にクランプする。
-  factory AssetTombstoneGcConfig.fromMirrorValue(Object? value) {
-    const fallback = AssetTombstoneGcConfig();
-    if (value is! Map) {
-      return fallback;
-    }
-    int pick(String key, int fallbackValue, int min, int max) {
-      final raw = (value[key] as num?)?.toInt();
-      if (raw == null) {
-        return fallbackValue;
-      }
-      return raw.clamp(min, max);
-    }
-
-    return AssetTombstoneGcConfig(
-      maxCount: pick('max_count', fallback.maxCount, 1, 100000),
-      maxAgeDays: pick('max_age_days', fallback.maxAgeDays, 1, 36500),
-    );
-  }
-}
-
 /// 入金予定の永続化ストア。
 class AssetExpectedInflowStore {
   const AssetExpectedInflowStore({
@@ -122,12 +95,47 @@ class AssetExpectedInflowStore {
   /// 「一度消した項目」がサーバ残存分から復活するのを抑止する (#part285)。
   static const String _deletedIdsKey = 'asset_expected_inflow_deleted_ids_v1';
 
+  /// GC 設定 (上限/期限) のローカル保存キー (#part288 設定 UI)。
+  static const String _gcConfigKey = 'inflow_tombstone_gc_v1';
+
+  /// ローカル保存済みの GC 設定を読み出す。未保存なら既定。
+  static Future<AssetTombstoneGcConfig> loadGcConfig({
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getString(_gcConfigKey);
+    if (raw == null || raw.isEmpty) {
+      return const AssetTombstoneGcConfig();
+    }
+    try {
+      return AssetTombstoneGcConfig.fromMirrorValue(jsonDecode(raw));
+    } catch (_) {
+      return const AssetTombstoneGcConfig();
+    }
+  }
+
+  /// GC 設定をローカルへ保存する (mirror upsert はページ側が別途行う)。
+  static Future<void> saveGcConfig(
+    AssetTombstoneGcConfig config, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    await store.setString(_gcConfigKey, jsonEncode(config.toMirrorValue()));
+  }
+
   /// トゥームストーンの保持上限/期限 (#part286 GC / #part287 リモート調整可)。
   final AssetTombstoneGcConfig gcConfig;
 
   final DateTime Function()? nowProvider;
 
   DateTime _now() => nowProvider?.call() ?? DateTime.now();
+
+  /// 削除トゥームストーンの汎用ストア (#part288 で切り出し)。
+  MirrorTombstoneStore get _tombstones => MirrorTombstoneStore(
+        storageKey: _deletedIdsKey,
+        gcConfig: gcConfig,
+        nowProvider: nowProvider,
+      );
 
   static List<AssetExpectedInflow> monthInflows(
     List<AssetExpectedInflow> inflows,
@@ -215,7 +223,7 @@ class AssetExpectedInflowStore {
     final rules = _decodeRules(store.getString(_rulesKey))
       ..removeWhere((rule) => rule.id == id);
     await _saveRules(store, rules);
-    await _addDeletedId(store, id);
+    await _tombstones.addId(store, id);
     return rules;
   }
 
@@ -255,113 +263,17 @@ class AssetExpectedInflowStore {
   /// 削除済み ID の集合を読み出す (期限切れ・上限超過は除外)。
   Future<Set<String>> loadDeletedIds({SharedPreferences? prefs}) async {
     final store = prefs ?? await SharedPreferences.getInstance();
-    return _decodeActiveIds(store.getString(_deletedIdsKey));
+    return _tombstones.activeIds(store);
   }
 
   /// トゥームストーン ID 集合をミラー upsert 用の値へ変換する
   /// (`{'ids': [...]}`)。ページと統合テストで同一の形を共有する (#part287)。
-  static Map<String, dynamic> encodeDeletedIdsMirror(Iterable<String> ids) {
-    return <String, dynamic>{
-      'ids': [
-        for (final id in ids)
-          if (id.isNotEmpty) id,
-      ],
-    };
-  }
+  static Map<String, dynamic> encodeDeletedIdsMirror(Iterable<String> ids) =>
+      MirrorTombstoneStore.encodeMirror(ids);
 
   /// ミラー値 (`{'ids': [...]}`) から ID リストを取り出す。形が不正なら空。
-  static List<String> decodeDeletedIdsMirror(Object? value) {
-    if (value is! Map) {
-      return const <String>[];
-    }
-    final rawIds = value['ids'];
-    if (rawIds is! List) {
-      return const <String>[];
-    }
-    return <String>[
-      for (final id in rawIds)
-        if ((id?.toString() ?? '').isNotEmpty) id.toString(),
-    ];
-  }
-
-  Future<void> _addDeletedId(SharedPreferences store, String id) async {
-    if (id.isEmpty) {
-      return;
-    }
-    final entries = _gcEntries(
-      _readDeletedEntries(store.getString(_deletedIdsKey)),
-    )..removeWhere((entry) => entry['id'] == id);
-    entries.add(<String, String>{
-      'id': id,
-      'at': _now().toUtc().toIso8601String(),
-    });
-    await _writeDeletedEntries(store, entries);
-  }
-
-  /// 後方互換読み込み: 旧形式 (["id",...]) と新形式 ([{"id","at"},...]) の
-  /// 双方を受け付ける。旧形式やタイムスタンプ欠落は現時刻を付与する
-  /// (= 既存トゥームストーンを即時に期限切れさせない)。
-  List<Map<String, String>> _readDeletedEntries(String? raw) {
-    if (raw == null || raw.isEmpty) {
-      return <Map<String, String>>[];
-    }
-    try {
-      final decoded = jsonDecode(raw);
-      if (decoded is! List) {
-        return <Map<String, String>>[];
-      }
-      final nowIso = _now().toUtc().toIso8601String();
-      final entries = <Map<String, String>>[];
-      for (final entry in decoded) {
-        if (entry is String) {
-          if (entry.isNotEmpty) {
-            entries.add(<String, String>{'id': entry, 'at': nowIso});
-          }
-        } else if (entry is Map) {
-          final id = entry['id']?.toString() ?? '';
-          if (id.isNotEmpty) {
-            entries.add(<String, String>{
-              'id': id,
-              'at': entry['at']?.toString() ?? nowIso,
-            });
-          }
-        }
-      }
-      return entries;
-    } catch (_) {
-      return <Map<String, String>>[];
-    }
-  }
-
-  /// 期限切れ (>gcConfig.maxAgeDays) を捨て、件数超過分は新しい順に残す。
-  List<Map<String, String>> _gcEntries(List<Map<String, String>> entries) {
-    final now = _now();
-    final maxAgeDays = gcConfig.maxAgeDays;
-    final kept = <Map<String, String>>[];
-    for (final entry in entries) {
-      final at = DateTime.tryParse(entry['at'] ?? '');
-      if (at == null || now.difference(at).inDays <= maxAgeDays) {
-        kept.add(entry);
-      }
-    }
-    if (kept.length > gcConfig.maxCount) {
-      return kept.sublist(kept.length - gcConfig.maxCount);
-    }
-    return kept;
-  }
-
-  Future<void> _writeDeletedEntries(
-    SharedPreferences store,
-    List<Map<String, String>> entries,
-  ) async {
-    await store.setString(_deletedIdsKey, jsonEncode(entries));
-  }
-
-  Set<String> _decodeActiveIds(String? raw) {
-    return <String>{
-      for (final entry in _gcEntries(_readDeletedEntries(raw))) entry['id']!,
-    };
-  }
+  static List<String> decodeDeletedIdsMirror(Object? value) =>
+      MirrorTombstoneStore.decodeMirror(value);
 
   /// 他端末由来のトゥームストーンを取り込み、該当するローカル項目を削除する。
   /// 端末Bでの削除を端末Aへ伝播させる用途。削除した件数を返す。
@@ -369,22 +281,11 @@ class AssetExpectedInflowStore {
     Iterable<String> remoteIds, {
     SharedPreferences? prefs,
   }) async {
-    final incoming = remoteIds.where((id) => id.isNotEmpty).toSet();
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final incoming = await _tombstones.mergeRemoteIds(store, remoteIds);
     if (incoming.isEmpty) {
       return 0;
     }
-    final store = prefs ?? await SharedPreferences.getInstance();
-    final entries = _gcEntries(
-      _readDeletedEntries(store.getString(_deletedIdsKey)),
-    );
-    final existingIds = <String>{for (final entry in entries) entry['id']!};
-    final nowIso = _now().toUtc().toIso8601String();
-    for (final id in incoming) {
-      if (existingIds.add(id)) {
-        entries.add(<String, String>{'id': id, 'at': nowIso});
-      }
-    }
-    await _writeDeletedEntries(store, _gcEntries(entries));
 
     final items = _decode(store.getString(_key));
     final rules = _decodeRules(store.getString(_rulesKey));
@@ -413,7 +314,7 @@ class AssetExpectedInflowStore {
     if (localItems.isNotEmpty || localRules.isNotEmpty || rows.isEmpty) {
       return false;
     }
-    final deletedIds = _decodeActiveIds(store.getString(_deletedIdsKey));
+    final deletedIds = _tombstones.activeIds(store);
     final items = <AssetExpectedInflow>[];
     final rules = <AssetExpectedInflowRule>[];
     for (final row in rows) {
@@ -470,7 +371,7 @@ class AssetExpectedInflowStore {
     final store = prefs ?? await SharedPreferences.getInstance();
     final items = _decode(store.getString(_key));
     final rules = _decodeRules(store.getString(_rulesKey));
-    final deletedIds = _decodeActiveIds(store.getString(_deletedIdsKey));
+    final deletedIds = _tombstones.activeIds(store);
     final knownIds = <String>{
       for (final item in items) item.id,
       for (final rule in rules) rule.id,
@@ -536,7 +437,7 @@ class AssetExpectedInflowStore {
     final store = prefs ?? await SharedPreferences.getInstance();
     final items = _decode(store.getString(_key));
     final rules = _decodeRules(store.getString(_rulesKey));
-    final deletedIds = _decodeActiveIds(store.getString(_deletedIdsKey));
+    final deletedIds = _tombstones.activeIds(store);
     final knownIds = <String>{
       for (final item in items) item.id,
       for (final rule in rules) rule.id,
@@ -602,7 +503,7 @@ class AssetExpectedInflowStore {
     final entries = _decode(store.getString(_key))
       ..removeWhere((entry) => entry.id == id);
     await _save(store, entries);
-    await _addDeletedId(store, id);
+    await _tombstones.addId(store, id);
     return entries;
   }
 

--- a/lib/services/mirror_tombstone_store.dart
+++ b/lib/services/mirror_tombstone_store.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// トゥームストーン GC の上限/期限。既定はローカル定数だが、サーバ
+/// (asset_pref_mirror) から取得した値で上書きできる (#part287 リモート調整)。
+class AssetTombstoneGcConfig {
+  const AssetTombstoneGcConfig({this.maxCount = 1000, this.maxAgeDays = 365});
+
+  final int maxCount;
+  final int maxAgeDays;
+
+  /// ミラー値 (`{'max_count': N, 'max_age_days': M}`) から構築する。
+  /// 欠落/不正値は既定を維持し、正の範囲にクランプする。
+  factory AssetTombstoneGcConfig.fromMirrorValue(Object? value) {
+    const fallback = AssetTombstoneGcConfig();
+    if (value is! Map) {
+      return fallback;
+    }
+    int pick(String key, int fallbackValue, int min, int max) {
+      final raw = (value[key] as num?)?.toInt();
+      if (raw == null) {
+        return fallbackValue;
+      }
+      return raw.clamp(min, max);
+    }
+
+    return AssetTombstoneGcConfig(
+      maxCount: pick('max_count', fallback.maxCount, 1, 100000),
+      maxAgeDays: pick('max_age_days', fallback.maxAgeDays, 1, 36500),
+    );
+  }
+
+  /// mirror upsert / ローカル保存用の値へ変換する (#part288 設定 UI)。
+  Map<String, dynamic> toMirrorValue() {
+    return <String, dynamic>{
+      'max_count': maxCount,
+      'max_age_days': maxAgeDays,
+    };
+  }
+}
+
+/// 削除トゥームストーン(「一度消した ID」の集合)を 1 つの SharedPreferences
+/// キー上で管理する汎用ストア。和集合マージやサーバ復元での復活抑止、他端末
+/// 削除の伝播に使う。入金予定だけでなく表示設定など他のミラー pref でも
+/// 再利用できるよう、ドメイン非依存に切り出した (#part288 汎用化)。
+///
+/// 保存形式は `[{"id": ..., "at": <iso>}, ...]`。part 285 の旧プレーン配列
+/// (`["id", ...]`) も後方互換で読み込む。書き込み・読み出し時に期限切れ
+/// (gcConfig.maxAgeDays) と件数超過 (gcConfig.maxCount) を破棄する。
+class MirrorTombstoneStore {
+  const MirrorTombstoneStore({
+    required this.storageKey,
+    this.gcConfig = const AssetTombstoneGcConfig(),
+    this.nowProvider,
+  });
+
+  final String storageKey;
+  final AssetTombstoneGcConfig gcConfig;
+  final DateTime Function()? nowProvider;
+
+  DateTime _now() => nowProvider?.call() ?? DateTime.now();
+
+  /// トゥームストーン ID 集合をミラー upsert 用の値へ変換する
+  /// (`{'ids': [...]}`)。ページと統合テストで同一の形を共有する (#part287)。
+  static Map<String, dynamic> encodeMirror(Iterable<String> ids) {
+    return <String, dynamic>{
+      'ids': [
+        for (final id in ids)
+          if (id.isNotEmpty) id,
+      ],
+    };
+  }
+
+  /// ミラー値 (`{'ids': [...]}`) から ID リストを取り出す。形が不正なら空。
+  static List<String> decodeMirror(Object? value) {
+    if (value is! Map) {
+      return const <String>[];
+    }
+    final rawIds = value['ids'];
+    if (rawIds is! List) {
+      return const <String>[];
+    }
+    return <String>[
+      for (final id in rawIds)
+        if ((id?.toString() ?? '').isNotEmpty) id.toString(),
+    ];
+  }
+
+  /// 有効な (期限内・上限内の) 削除済み ID 集合を返す。
+  Set<String> activeIds(SharedPreferences store) {
+    return <String>{
+      for (final entry in _gcEntries(_readEntries(store.getString(storageKey))))
+        entry['id']!,
+    };
+  }
+
+  /// ID を 1 件トゥームストーン化する (タイムスタンプ付きで追記し GC)。
+  Future<void> addId(SharedPreferences store, String id) async {
+    if (id.isEmpty) {
+      return;
+    }
+    final entries = _gcEntries(_readEntries(store.getString(storageKey)))
+      ..removeWhere((entry) => entry['id'] == id);
+    entries.add(<String, String>{
+      'id': id,
+      'at': _now().toUtc().toIso8601String(),
+    });
+    await _writeEntries(store, entries);
+  }
+
+  /// 他端末由来の ID 群を取り込む。実際に取り込んだ (空でない) ID 集合を返す。
+  /// ローカル項目の削除はドメイン側 (呼び出し元) が行う。
+  Future<Set<String>> mergeRemoteIds(
+    SharedPreferences store,
+    Iterable<String> remoteIds,
+  ) async {
+    final incoming = remoteIds.where((id) => id.isNotEmpty).toSet();
+    if (incoming.isEmpty) {
+      return incoming;
+    }
+    final entries = _gcEntries(_readEntries(store.getString(storageKey)));
+    final existingIds = <String>{for (final entry in entries) entry['id']!};
+    final nowIso = _now().toUtc().toIso8601String();
+    for (final id in incoming) {
+      if (existingIds.add(id)) {
+        entries.add(<String, String>{'id': id, 'at': nowIso});
+      }
+    }
+    await _writeEntries(store, _gcEntries(entries));
+    return incoming;
+  }
+
+  /// 後方互換読み込み: 旧形式 (["id",...]) と新形式 ([{"id","at"},...]) の
+  /// 双方を受け付ける。旧形式やタイムスタンプ欠落は現時刻を付与する
+  /// (= 既存トゥームストーンを即時に期限切れさせない)。
+  List<Map<String, String>> _readEntries(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return <Map<String, String>>[];
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) {
+        return <Map<String, String>>[];
+      }
+      final nowIso = _now().toUtc().toIso8601String();
+      final entries = <Map<String, String>>[];
+      for (final entry in decoded) {
+        if (entry is String) {
+          if (entry.isNotEmpty) {
+            entries.add(<String, String>{'id': entry, 'at': nowIso});
+          }
+        } else if (entry is Map) {
+          final id = entry['id']?.toString() ?? '';
+          if (id.isNotEmpty) {
+            entries.add(<String, String>{
+              'id': id,
+              'at': entry['at']?.toString() ?? nowIso,
+            });
+          }
+        }
+      }
+      return entries;
+    } catch (_) {
+      return <Map<String, String>>[];
+    }
+  }
+
+  /// 期限切れ (>gcConfig.maxAgeDays) を捨て、件数超過分は新しい順に残す。
+  List<Map<String, String>> _gcEntries(List<Map<String, String>> entries) {
+    final now = _now();
+    final maxAgeDays = gcConfig.maxAgeDays;
+    final kept = <Map<String, String>>[];
+    for (final entry in entries) {
+      final at = DateTime.tryParse(entry['at'] ?? '');
+      if (at == null || now.difference(at).inDays <= maxAgeDays) {
+        kept.add(entry);
+      }
+    }
+    if (kept.length > gcConfig.maxCount) {
+      return kept.sublist(kept.length - gcConfig.maxCount);
+    }
+    return kept;
+  }
+
+  Future<void> _writeEntries(
+    SharedPreferences store,
+    List<Map<String, String>> entries,
+  ) async {
+    await store.setString(storageKey, jsonEncode(entries));
+  }
+}

--- a/lib/widgets/display_mode_experiment_card.dart
+++ b/lib/widgets/display_mode_experiment_card.dart
@@ -480,6 +480,7 @@ class _InteractiveChart extends StatefulWidget {
     required this.semanticLabel,
     required this.painterBuilder,
     required this.tooltipBuilder,
+    required this.valueBuilder,
   });
 
   final int count;
@@ -487,6 +488,10 @@ class _InteractiveChart extends StatefulWidget {
   final String semanticLabel;
   final CustomPainter Function(int? selected) painterBuilder;
   final Widget Function(int selected, double width) tooltipBuilder;
+
+  /// 選択中データ点の読み上げ文 (Semantics value)。スクリーンリーダーは
+  /// liveRegion により選択変更のたびに読み上げる (#part288 a11y)。
+  final String Function(int selected) valueBuilder;
 
   @override
   State<_InteractiveChart> createState() => _InteractiveChartState();
@@ -548,11 +553,16 @@ class _InteractiveChartState extends State<_InteractiveChart> {
           final width = constraints.maxWidth;
           int? indexAt(double dx) =>
               _nearestIndex(dx, width, widget.leftPad, widget.count);
+          final selectedValue = (_selected != null && _selected! < widget.count)
+              ? widget.valueBuilder(_selected!)
+              : null;
           return Focus(
             focusNode: _focusNode,
             onKeyEvent: _onKey,
             child: Semantics(
               label: widget.semanticLabel,
+              value: selectedValue,
+              liveRegion: selectedValue != null,
               child: MouseRegion(
                 onHover: (event) => _select(indexAt(event.localPosition.dx)),
                 onExit: (_) {
@@ -632,6 +642,12 @@ class _RetentionLineChart extends StatelessWidget {
         anchor: _retentionAnchor(weeks, selected, width),
         width: width,
       ),
+      valueBuilder: (selected) {
+        final week = weeks[selected];
+        final rate = week['rate'];
+        return '${_weekShort(week['week_start'])} の標準維持率 '
+            '${rate == null ? '記録なし' : '$rate パーセント'}';
+      },
     );
   }
 }
@@ -845,6 +861,13 @@ class _TrendAreaChart extends StatelessWidget {
         anchor: _trendAnchor(weeks, selected, width, maxTotal),
         width: width,
       ),
+      valueBuilder: (selected) {
+        final week = weeks[selected];
+        final initials = (week['initials'] as num?)?.toInt() ?? 0;
+        final switches = (week['switches'] as num?)?.toInt() ?? 0;
+        return '${_weekShort(week['week_start'])} '
+            '初期解決 $initials 件 切替 $switches 件';
+      },
     );
   }
 }

--- a/test/services/asset_expected_inflow_store_test.dart
+++ b/test/services/asset_expected_inflow_store_test.dart
@@ -544,5 +544,24 @@ void main() {
       expect(clamped.maxCount, 1);
       expect(clamped.maxAgeDays, 1);
     });
+
+    test('loadGcConfig/saveGcConfig round-trips local config', () async {
+      expect(
+        (await AssetExpectedInflowStore.loadGcConfig()).maxCount,
+        const AssetTombstoneGcConfig().maxCount,
+      );
+
+      await AssetExpectedInflowStore.saveGcConfig(
+        const AssetTombstoneGcConfig(maxCount: 42, maxAgeDays: 90),
+      );
+      final loaded = await AssetExpectedInflowStore.loadGcConfig();
+      expect(loaded.maxCount, 42);
+      expect(loaded.maxAgeDays, 90);
+      expect(
+        const AssetTombstoneGcConfig(maxCount: 42, maxAgeDays: 90)
+            .toMirrorValue(),
+        <String, dynamic>{'max_count': 42, 'max_age_days': 90},
+      );
+    });
   });
 }

--- a/test/services/mirror_tombstone_store_test.dart
+++ b/test/services/mirror_tombstone_store_test.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/mirror_tombstone_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('MirrorTombstoneStore (generic)', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    Future<SharedPreferences> prefs() => SharedPreferences.getInstance();
+
+    test('encode/decode mirror round-trips and rejects bad shapes', () {
+      final encoded = MirrorTombstoneStore.encodeMirror(<String>['a', '', 'b']);
+      expect(encoded, <String, dynamic>{
+        'ids': <String>['a', 'b'],
+      });
+      expect(MirrorTombstoneStore.decodeMirror(encoded), <String>['a', 'b']);
+      expect(MirrorTombstoneStore.decodeMirror('nope'), isEmpty);
+      expect(
+        MirrorTombstoneStore.decodeMirror(<String, dynamic>{'ids': 5}),
+        isEmpty,
+      );
+    });
+
+    test('addId records and activeIds reads back (any key)', () async {
+      final store = MirrorTombstoneStore(
+        storageKey: 'display_mode_section_deleted_v1',
+        nowProvider: () => DateTime(2026, 6, 13, 9),
+      );
+      final sp = await prefs();
+      await store.addId(sp, 'chart');
+      await store.addId(sp, 'flow');
+      await store.addId(sp, ''); // 空は無視される
+
+      expect(store.activeIds(sp), <String>{'chart', 'flow'});
+    });
+
+    test('mergeRemoteIds returns merged set and unions tombstones', () async {
+      final store = MirrorTombstoneStore(
+        storageKey: 'k',
+        nowProvider: () => DateTime(2026, 6, 13, 9),
+      );
+      final sp = await prefs();
+      await store.addId(sp, 'local');
+
+      final merged = await store.mergeRemoteIds(sp, <String>['remote', '']);
+      expect(merged, <String>{'remote'});
+      expect(store.activeIds(sp), <String>{'local', 'remote'});
+
+      // 空入力は no-op。
+      expect(await store.mergeRemoteIds(sp, <String>['']), isEmpty);
+    });
+
+    test('GC honors maxCount and maxAgeDays', () async {
+      var clock = DateTime(2026, 1, 1, 9);
+      final store = MirrorTombstoneStore(
+        storageKey: 'k',
+        gcConfig: const AssetTombstoneGcConfig(maxCount: 2, maxAgeDays: 10),
+        nowProvider: () => clock,
+      );
+      final sp = await prefs();
+      for (var i = 0; i < 3; i++) {
+        clock = DateTime(2026, 1, 1, 9, 0, i);
+        await store.addId(sp, 'id$i');
+      }
+      expect(store.activeIds(sp), hasLength(2));
+      expect(store.activeIds(sp), isNot(contains('id0')));
+
+      clock = DateTime(2026, 2, 1, 9);
+      expect(store.activeIds(sp), isEmpty);
+    });
+
+    test('reads legacy plain-string format', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'k': jsonEncode(<String>['legacy']),
+      });
+      final store = MirrorTombstoneStore(
+        storageKey: 'k',
+        nowProvider: () => DateTime(2026, 6, 13, 9),
+      );
+      final sp = await prefs();
+      expect(store.activeIds(sp), contains('legacy'));
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:my_web_app/pages/asset_management_page.dart';
+import 'package:my_web_app/services/asset_expected_inflow_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -169,6 +170,71 @@ void main() {
       await tester.tap(find.byKey(const Key('asset_inflow_rules_button')));
       await tester.pump(const Duration(milliseconds: 100));
       expect(find.textContaining('毎月25日 給料'), findsOneWidget);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('tombstone GC settings dialog edits and saves the config', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflow_rules_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'seeded_rule',
+            'day_of_month': 25,
+            'amount': 280000,
+            'label': '給料',
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugTombstoneGcConfig: AssetTombstoneGcConfig(
+              maxCount: 1000,
+              maxAgeDays: 365,
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_inflow_rules_button')),
+      );
+      await tester.tap(find.byKey(const Key('asset_inflow_rules_button')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // 現在値が保持設定ボタンに出ている。
+      expect(find.textContaining('保持設定 (1000件/365日)'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('asset_tombstone_gc_edit')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.enterText(
+        find.byKey(const Key('asset_tombstone_gc_maxcount')),
+        '50',
+      );
+      await tester.enterText(
+        find.byKey(const Key('asset_tombstone_gc_maxage')),
+        '90',
+      );
+      await tester.tap(find.byKey(const Key('asset_tombstone_gc_save')));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // SnackBar で更新を通知し、ボタンラベルも新値へ更新される。
+      expect(find.textContaining('最大50件 / 90日'), findsOneWidget);
+      expect(find.textContaining('保持設定 (50件/90日)'), findsOneWidget);
+
+      // ローカルにも保存される。
+      expect(
+        (await AssetExpectedInflowStore.loadGcConfig()).maxCount,
+        50,
+      );
 
       await _unmount(tester);
     });

--- a/test/widgets/display_mode_experiment_card_test.dart
+++ b/test/widgets/display_mode_experiment_card_test.dart
@@ -203,5 +203,51 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets('selected point is announced via Semantics value', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.binding.setSurfaceSize(const Size(900, 1500));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: DisplayModeExperimentCard(
+                debugWeekly: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'week_start': '2026-06-08',
+                    'initials': 5,
+                    'initial_standard': 4,
+                    'switches': 2,
+                  },
+                ],
+                debugWeeklyRetention: <Map<String, dynamic>>[
+                  <String, dynamic>{'week_start': '2026-06-08', 'rate': 80},
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('display_mode_experiment_expand')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const Key('display_mode_retention_line_chart')),
+      );
+      await tester.pumpAndSettle();
+
+      final node = tester.getSemantics(
+        find.bySemanticsLabel(RegExp('標準維持率の推移グラフ')),
+      );
+      expect(node.value, contains('パーセント'));
+
+      handle.dispose();
+    });
   });
 }


### PR DESCRIPTION
## 概要

part 287 の次回候補 4 件を実装(※ part 288 は並行セッションが使用済のため part 289 として番号採番)。

1. **tombstone 機構を汎用 `MirrorTombstoneStore` へ抽出** — 削除トゥームストーン(「一度消した ID」集合 + GC + encode/decode + 他端末取り込み)をドメイン非依存の `lib/services/mirror_tombstone_store.dart` へ切り出し、`AssetExpectedInflowStore` は委譲。`AssetTombstoneGcConfig` も移設し**再エクスポートで後方互換維持**。表示設定など他のミラー pref でも再利用できる汎用テスト付き。
2. **GC 設定の本番 UI** — 入金ルールダイアログに「保持設定(最大件数/保持日数)」を追加。編集 → **ローカル保存 + `asset_pref_mirror` upsert + ストア即時反映** + SnackBar 通知。boot は local→server の順で適用。`loadGcConfig`/`saveGcConfig`/`toMirrorValue` を追加。
3. **グラフ a11y の動的アナウンス** — 選択点を `Semantics(value:, liveRegion: true)` でスクリーンリーダーへ動的読み上げ(矢印キー/タップで「06-08 の標準維持率 80 パーセント」等)。
4. **監査スクリプトの pre-commit hook 化** — `.githooks/pre-commit` を追加。`lib/**/*.dart` ステージ時のみ `check_duplicate_dispose.py` を実行し、二重 dispose/await/setState をコミット前に検知。`git config core.hooksPath .githooks` で opt-in(README 同梱)。CI ゲートと同一スクリプトで二重防御。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核となる 3ケース: (1) `MirrorTombstoneStore` が任意キーで add/merge/GC/旧形式互換に動く (2) GC 設定ダイアログで編集→保存→ローカル反映+ラベル更新 (3) グラフ選択点が Semantics value で読み上げられる。今回 service 1 ファイル新規 + 各テスト追加、全体で flutter test 720 ケース。
- E2E例外: 変更はクライアント + テスト + ローカル git hook のみでサーバ・スキーマ変更なし(設定保存は既存 `asset_pref_mirror` の汎用 jsonb)。widget pump がエンドツーエンド相当(設定編集→反映 / 選択→読み上げ)を担い、本番疎通は既存 Playwright smoke で補完する。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `python scripts/check_duplicate_dispose.py` **CLEAN (2.5s)** / `flutter test` **720/720 PASS**。compare diff-stat ゲート確認済み(+682 -161 / 10 files / store -152 は MirrorTombstoneStore への移設分、想定外削除なし)。

## High-risk gate

- High-risk-ultrareview-exception: migration・RLS・認証・課金ロジックへの変更は一切なし。設定保存は既存 `asset_pref_mirror` テーブルへの汎用 jsonb upsert のみ。git hook はローカル opt-in の読み取り専用静的チェック(CI を置き換えない)。レビュー所有者: Claude Code #1。
- 自己点検メモ: rollback = 本 PR revert のみで完結(tombstone 抽出は挙動不変・既存テストで担保 / GC 設定は欠落時に既定フォールバック)/ a11y は IgnorePointer のツールチップで操作を妨げない / hook は --no-verify で迂回可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
