### PR TITLE
feat(asset): プリペイド残高(ファミペイ等)のマイナス深化も自動支出に計上

### DIFF
--- a/lib/services/asset_unknown_expense_rule_service.dart
+++ b/lib/services/asset_unknown_expense_rule_service.dart
@@ -9,6 +9,60 @@ class AssetUnknownExpenseRuleService {
     return key.contains('現金') || key.contains('cash');
   }
 
+  /// プリペイド/電子マネー/QR決済の残高タイプ。ファミペイのように
+  /// 残高がマイナス(あと払い・チャージ不足)へさらに進む=支出なので、
+  /// 現金系と同様にマイナス圏の減少も自動記録の対象にする。
+  /// ただしカード/ローン等の負債名は除外(残高悪化=借入で、カード請求側と
+  /// 二重計上になるため)。
+  static bool isPrepaidLikeType(String assetType) {
+    final key = assetType.toLowerCase();
+    if (key.contains('カード') ||
+        key.contains('card') ||
+        key.contains('ローン') ||
+        key.contains('loan') ||
+        key.contains('クレジット') ||
+        key.contains('credit')) {
+      return false;
+    }
+    const keywords = <String>[
+      'ファミペイ',
+      'famipay',
+      'paypay',
+      'ペイペイ',
+      'aupay',
+      'au pay',
+      '楽天ペイ',
+      'rakuten pay',
+      'd払い',
+      'linepay',
+      'line pay',
+      'ラインペイ',
+      'メルペイ',
+      'merpay',
+      'suica',
+      'スイカ',
+      'pasmo',
+      'パスモ',
+      'icoca',
+      'nanaco',
+      'ナナコ',
+      'waon',
+      'ワオン',
+      'edy',
+      'エディ',
+      '電子マネー',
+      'プリペイド',
+      'prepaid',
+      'スマホ決済',
+    ];
+    for (final keyword in keywords) {
+      if (key.contains(keyword)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /// 投資系タイプ。減少が評価損か出金か区別できないため自動記録の対象外。
   static bool isInvestmentLikeType(String assetType) {
     final key = assetType.toLowerCase();
@@ -26,8 +80,9 @@ class AssetUnknownExpenseRuleService {
   /// 自動記録の条件:
   /// - 減少幅が 1 円以上
   /// - 投資系タイプは対象外
-  /// - 残高がマイナス圏 (previousAmount <= 0) のときは現金系のみ対象。
-  ///   負の値で記録する負債系タイプの残高悪化を使途不明金と誤認しないため。
+  /// - 残高がマイナス圏 (previousAmount <= 0) のときは現金系・プリペイド系
+  ///   (ファミペイ等の電子マネー残高) のみ対象。負の値で記録する負債系
+  ///   タイプの残高悪化を使途不明金と誤認しないため。
   static bool shouldAutoRecordFromAssetDrop({
     required String assetType,
     required double previousAmount,
@@ -37,7 +92,9 @@ class AssetUnknownExpenseRuleService {
     if (drop < 1) {
       return false;
     }
-    if (previousAmount <= 0 && !isCashLikeType(assetType)) {
+    if (previousAmount <= 0 &&
+        !isCashLikeType(assetType) &&
+        !isPrepaidLikeType(assetType)) {
       return false;
     }
     if (isInvestmentLikeType(assetType)) {

--- a/test/services/asset_unknown_expense_rule_service_test.dart
+++ b/test/services/asset_unknown_expense_rule_service_test.dart
@@ -125,6 +125,58 @@ void main() {
         isTrue,
       );
     });
+
+    test('ファミペイ: マイナス圏からさらに減少も支出として記録 (新規)', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: 'ファミペイ',
+          previousAmount: -1000,
+          currentAmount: -3000,
+        ),
+        isTrue,
+      );
+    });
+
+    test('プリペイド: 0 からマイナスへの減少も対象', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: 'PayPay残高',
+          previousAmount: 0,
+          currentAmount: -500,
+        ),
+        isTrue,
+      );
+    });
+
+    test('ファミペイカード: 負債名はマイナス圏の減少を記録しない (二重計上防止)', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: 'ファミペイカード',
+          previousAmount: -1000,
+          currentAmount: -3000,
+        ),
+        isFalse,
+      );
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: 'auPAYカード',
+          previousAmount: -50000,
+          currentAmount: -90000,
+        ),
+        isFalse,
+      );
+    });
+
+    test('プリペイド: マイナス圏での増加 (チャージ) は対象外', () {
+      expect(
+        AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
+          assetType: 'ファミペイ',
+          previousAmount: -3000,
+          currentAmount: -500,
+        ),
+        isFalse,
+      );
+    });
   });
 
   group('type 判定ヘルパー', () {
@@ -146,6 +198,31 @@ void main() {
       );
       expect(
         AssetUnknownExpenseRuleService.isInvestmentLikeType('現金'),
+        isFalse,
+      );
+    });
+
+    test('isPrepaidLikeType', () {
+      expect(
+        AssetUnknownExpenseRuleService.isPrepaidLikeType('ファミペイ'),
+        isTrue,
+      );
+      expect(
+        AssetUnknownExpenseRuleService.isPrepaidLikeType('PayPay残高'),
+        isTrue,
+      );
+      expect(AssetUnknownExpenseRuleService.isPrepaidLikeType('Suica'), isTrue);
+      // カード/ローン等の負債名は除外。
+      expect(
+        AssetUnknownExpenseRuleService.isPrepaidLikeType('ファミペイカード'),
+        isFalse,
+      );
+      expect(
+        AssetUnknownExpenseRuleService.isPrepaidLikeType('PayPayカード'),
+        isFalse,
+      );
+      expect(
+        AssetUnknownExpenseRuleService.isPrepaidLikeType('三井住友銀行'),
         isFalse,
       );
     });


### PR DESCRIPTION
## 概要

ユーザー報告: 「ファミペイで支払いをするとファミペイ残高のマイナスが増えるが、これも支出として計上したい」。

### 現状の挙動

`AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop` は、残高がマイナス圏（`previousAmount <= 0`）のときは**現金系タイプのみ**を自動支出（使途不明金）の記録対象にしていた（負債系の残高悪化を誤計上しないためのガード）。ファミペイ残高は現金系判定（`現金`/`cash`）に該当しないため、マイナスがさらに深まっても記録されなかった。

### 変更内容（`asset_unknown_expense_rule_service.dart` のみ・純関数）

1. `isPrepaidLikeType` を追加 — ファミペイ/PayPay/auPay/楽天ペイ/d払い/LINE Pay/メルペイ/Suica/Pasmo/ICOCA/nanaco/WAON/Edy/電子マネー/プリペイド等のプリペイド・電子マネー残高タイプを判定
2. マイナス圏の減少判定を「現金系 **または** プリペイド系なら記録」へ拡張（ファミペイ残高がマイナスへ進む = 支出として計上）
3. **カード/ローン/クレジット名は除外** — 残高悪化＝借入であり、カード請求側との二重計上を防ぐ。`ファミペイ`（残高）= 対象 / `ファミペイカード`（負債）= 対象外

プラス残高からの減少・投資系除外・チャージ（増加）対象外などの既存挙動は不変。

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. ファミペイ残高 -1000 → -3000（マイナス深化）→ 記録対象（true）
  2. ファミペイカード -1000 → -3000（負債名）→ 対象外（false・二重計上防止）
  3. ファミペイ残高 -3000 → -500（チャージ=増加）→ 対象外（false）
- 上記を純関数の単体テスト（新規5件 / 計16件 PASS）で検証
- E2E-Exception: 本変更は純関数 `AssetUnknownExpenseRuleService` の判定ロジックのみで UI/Supabase 非依存。既存の widget/統合テストの範囲外であり、自動記録の実画面挙動は本番反映後にファミペイ残高を減らして手動確認する。

## 検証

- `flutter test`（unknown_expense 16件）: All tests passed
- `dart analyze`: No issues found
- 変更は service + test の2ファイルのみ（git index のローカルノイズは Git Data API 着地に影響なし・branch vs origin/main で逆 revert ゼロ確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
