### PR TITLE
fix(home): カタログ機能起動を単一チョークポイントで利用記録（最近使った/よく使われる機能の網羅的実働化）

### DIFF
--- a/lib/data/home_tool_catalog.dart
+++ b/lib/data/home_tool_catalog.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/feature_tap_logger.dart';
 
 import '../pages/abstinence_guard_page.dart';
 import '../pages/admin_analytics_page.dart';
@@ -266,6 +270,16 @@ const List<HomeToolSection> homeToolSections = <HomeToolSection>[
 
 String? _pendingHomeToolRoutePath;
 
+// route -> 表示名 の遅延キャッシュ。カタログ全エントリの起動記録でラベル解決に使う。
+Map<String, String>? _routeTitleCache;
+Map<String, String> _routeTitleMap() {
+  return _routeTitleCache ??= <String, String>{
+    for (final entry in buildHomeToolCatalog())
+      if (entry.routePath != null && entry.routePath!.isNotEmpty)
+        entry.routePath!: entry.title,
+  };
+}
+
 HomeToolOpenCallback _wrapRouteAwareHomeToolOpen(
   HomeToolOpenCallback onOpen,
   String? routePath,
@@ -273,6 +287,14 @@ HomeToolOpenCallback _wrapRouteAwareHomeToolOpen(
   return (context) async {
     final previous = _pendingHomeToolRoutePath;
     _pendingHomeToolRoutePath = routePath;
+    // ホームの「最近使った機能 / よく使われる機能」は user_feature_usage を参照する。
+    // 業務メニュー・ホームタイルなどカタログ経由の全機能起動はこのラッパーを通るため、
+    // ここで DB へ記録する (個別の起動口での記録漏れを一掃する単一チョークポイント)。
+    if (routePath != null && routePath.isNotEmpty) {
+      final label = _routeTitleMap()[routePath] ??
+          routePath.substring(1).replaceAll('-', ' ');
+      unawaited(recordFeatureTap(routePath, label));
+    }
     try {
       await onOpen(context);
     } finally {

--- a/lib/pages/work_menu_page.dart
+++ b/lib/pages/work_menu_page.dart
@@ -1,10 +1,7 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import '../data/home_tool_catalog.dart';
 import '../services/home_tool_usage_service.dart';
-import '../utils/feature_tap_logger.dart';
 
 class WorkMenuPage extends StatefulWidget {
   const WorkMenuPage({
@@ -91,12 +88,8 @@ class _WorkMenuPageState extends State<WorkMenuPage> {
       return;
     }
     await HomeToolUsageService.recordToolUse(entry.id);
-    // ホームの「最近使った機能 / よく使われる機能」は user_feature_usage を参照する。
-    // 業務メニューが主要な起動口なので、ローカル recent とは別に DB へも記録する。
-    final usageRoute = entry.routePath ??
-        (entry.id.startsWith('/') ? entry.id : '/${entry.id}');
-    unawaited(recordFeatureTap(usageRoute, entry.title));
     if (!mounted) return;
+    // entry.onOpen はカタログラッパー経由で user_feature_usage に記録される。
     await entry.onOpen(context);
     if (!mounted) return;
     setState(() {


### PR DESCRIPTION
## 概要

スマホ実機 UAT の継続報告(build 4465 でも「最近使った機能 / よく使われる機能」がサイト案内AIしか出ない)への根本対応。

## 根本原因(前回 PR #3305 で取りこぼした範囲)

前回は業務メニュー `work_menu_page._openEntry` のみに利用記録を追加したが、機能を起動する導線は業務メニュー以外にも複数(ホームタイル、各種カード等)あり、それらが `user_feature_usage` に記録していなかった。結果、`_runTrackedAction` で記録される目立つサイト案内AIだけが突出し続けていた。

カタログ機能の起動は全て `_wrapRouteAwareHomeToolOpen`(全エントリの `onOpen` をラップする単一チョークポイント)を通る。ここを計装するのが最も網羅的。

## 修正

- `_wrapRouteAwareHomeToolOpen`(`home_tool_catalog.dart`)で `recordFeatureTap(routePath, label)` を fire-and-forget 実行。業務メニュー・ホームタイル等あらゆる起動口からのカタログ機能起動が `user_feature_usage` に記録される。
- ラベルは `routePath -> title` の遅延キャッシュ(`buildHomeToolCatalog()` から構築)で解決、無ければ route から導出。
- 前回 `work_menu_page._openEntry` に追加した明示記録は撤去(ラッパーが一元化するため二重計上を回避)。

## Minimal E2E Gate

- 本変更は **実装詳細に依存しない**(implementation-detail independent / black-box)観測点として「カタログ機能の起動 → `user_feature_usage` への 1 行 insert」という入出力契約を持つ。検証は最小限の **3ケース** を想定: ① routePath ありエントリ起動 → 当該 route で記録、② route から title 解決(キャッシュ命中)/ 未命中時は route 導出ラベル、③ 未ログイン時は記録せず遷移のみ(`recordFeatureTap` の早期 return)。
- 既存の Playwright E2E (`test/e2e/public_smoke.spec.ts`) が public ルートの smoke を本 PR の CI でも実行する。
- E2E-Exception: カタログ機能起動と利用記録は **認証 + Supabase 書き込みを伴う**ため public Playwright E2E では到達不可。authenticated E2E fixture が現基盤に存在しないため、`flutter analyze`(リポジトリ全体 No issues)+ 上記入出力契約のレビューで代替担保する。

## 検証

- `flutter analyze`(リポジトリ全体 / Flutter 3.38.10 = CI 同一版): **No issues found**
- `dart format --set-exit-if-changed`: 差分なし

https://claude.ai/code/session_01GHDwMz29SRggnphStwvxzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHDwMz29SRggnphStwvxzj)_