### PR TITLE
fix(home): 最近使った機能で多用機能が他を押し出す表示窓バグを修正

### DIFF
--- a/lib/widgets/home_tier/recent_features_list.dart
+++ b/lib/widgets/home_tier/recent_features_list.dart
@@ -26,17 +26,22 @@ class _RecentFeaturesListState extends State<RecentFeaturesList> {
       return;
     }
     try {
+      // dedup 前に十分な履歴を取得する。limit を dedup より先に効かせると、
+      // 多用機能(例: サイト案内AI)の連続タップが直近行を占有し、たまにしか
+      // 使わない機能(例: 統一地方選必達管理室)が窓から押し出されて
+      // 「最近使った機能」に出てこない。多めに取得してから distinct 上位を採る。
       final rows = await Supabase.instance.client
           .from('user_feature_usage')
           .select('feature_route, feature_label, tapped_at')
           .eq('user_id', user.id)
           .order('tapped_at', ascending: false)
-          .limit(8);
+          .limit(200);
       final seen = <String>{};
       final deduped = <Map<String, dynamic>>[];
       for (final row in rows) {
         final route = row['feature_route'] as String? ?? '';
         if (route.isNotEmpty && seen.add(route)) deduped.add(row);
+        if (deduped.length >= 10) break;
       }
       if (mounted) {
         setState(() {


### PR DESCRIPTION
## 背景

スマホ実機 UAT (build 4470) で「統一地方選必達管理室にアクセスしても『最近使った機能』に反映されない」と報告 (IMG_4540)。

## 調査

- 機能起動の記録自体は #3306(`onGenerateRoute` を全 named route の一元記録点に)/ #3315(カタログ起動の単一チョークポイント記録)で網羅済みで、build 4470 に反映されている。
- 真因は **表示側** `lib/widgets/home_tier/recent_features_list.dart`。`user_feature_usage` を `.limit(8)` で取得してから重複排除していたため、サイト案内AI など多用機能の連続タップが直近8行を占有し、たまにしか使わない機能(統一地方選必達管理室など)は記録済みでも窓から押し出されて表示されなかった。
- 補足: 「よく使われる機能(ユーザー全体)」を返す `ai-hub` `home.popular` は全ユーザー集計(`user_id` 非依存)のため、個人の記録有無の判断材料にはならない。

## 修正

- `recent_features_list.dart`: 重複排除前の取得を `limit(200)` に拡大し、distinct 上位10件を採用。直近に使った「異なる」機能を網羅表示する。

## 効果

多用機能の繰り返しタップに関係なく、直近に使った異なる機能(統一地方選必達管理室を含む)が「最近使った機能」に正しく並ぶ。

## Minimal E2E Gate

- 検証は実装詳細に依存しない入出力 (I/O) 契約で行う(履歴行の並び → 表示される distinct 機能集合)。
- 最小限の3ケース(入出力):
  1. 多用機能が直近を占有しても、別機能が直近200行内にあれば表示される
  2. 同一機能の重複は1チップに集約される
  3. 履歴ゼロなら空状態の文言を表示
- E2E mechanism: integration_test を想定。
- E2E-Exception: 本変更は表示クエリの取得件数と重複排除の順序調整のみで、業務ロジックや記録経路は変更しない。記録経路は #3306 / #3315 で対応済みのため、重い integration_test は本 PR では不要と判断。

---

🤖 関連: #3306 #3315

https://claude.ai/code/session_0196MXKcH5U1x6nDhNp2dk2h

---
_Generated by [Claude Code](https://claude.ai/code/session_0196MXKcH5U1x6nDhNp2dk2h)_