### PR TITLE
feat(asset): override tombstoneミラー往復 + 一括prune + hooks全検証 + a11y記録 (part 292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,16 +256,28 @@ jobs:
         run: timeout 120 python scripts/check_duplicate_dispose.py --max-seconds 60
         continue-on-error: false
 
-      - name: Verify pre-commit hook stays healthy
-        # part 291: pre-commit hook の腐敗防止。構文 + 実行ビット + 監査スクリプト
-        # 参照を検証し、ローカル導入 (git config core.hooksPath .githooks) を促す。
+      - name: Verify git hooks stay healthy
+        # part 291: pre-commit hook の腐敗防止。part 292: .githooks/* 全体へ一般化
+        # (将来 hook を追加しても自動で対象 / *.md は除外)。構文 + 実行ビットを検証。
         run: |
-          bash -n .githooks/pre-commit
-          test -x .githooks/pre-commit || {
-            echo ".githooks/pre-commit must be executable (chmod +x)" >&2
+          shopt -s nullglob
+          found=0
+          for hook in .githooks/*; do
+            case "$hook" in
+              *.md) continue ;;
+            esac
+            found=$((found + 1))
+            echo "checking $hook"
+            bash -n "$hook"
+            test -x "$hook" || {
+              echo "$hook must be executable (chmod +x)" >&2
+              exit 1
+            }
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "no hooks found under .githooks/" >&2
             exit 1
-          }
-          grep -q 'check_duplicate_dispose.py' .githooks/pre-commit
+          fi
         continue-on-error: false
 
       - name: Check formatting

--- a/docs/ACCESSIBILITY_QA_CHECKLIST.md
+++ b/docs/ACCESSIBILITY_QA_CHECKLIST.md
@@ -39,7 +39,12 @@ CFO 室「表示モード実験 詳細グラフ」(折れ線=標準維持率 / �
 ## 記録
 
 確認したら下表に日付/AT/ブラウザ/結果を追記する。
+**自動 (CI widget test)** 行は機械検証済み。**実 AT 行**は読み上げ音声の確認が
+必要で自動テストでは代替できないため、実機を持つ担当者が実施して追記する。
 
 | 日付 | AT | ブラウザ | 結果 | 備考 |
 |------|----|---------|------|------|
-| (未実施) | NVDA | Chrome | - | リリース前に実施 |
+| 2026-06-13 | 自動 (CI widget test) | flutter test | ✅ | `display_mode_experiment_card_test.dart`: 折れ線/面の両方で `Semantics.value` + `flagsCollection.isLiveRegion` を検証。矢印キー移動で value 更新も検証。 |
+| (未実施・要実機) | NVDA | Chrome/Edge | - | リリース前に担当者が実施 → 結果追記 |
+| (未実施・要実機) | VoiceOver | Safari | - | 同上 |
+| (未実施・要実機) | TalkBack | Chrome (Android) | - | 同上 |

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -121,6 +121,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final AssetTombstoneGcConfig? debugTombstoneGcConfig;
 
+  /// テスト専用: section override 削除トゥームストーンのミラー値
+  /// (`{'ids': [...]}`) を注入し、削除伝播をネットワークなしで検証する (#part292)。
+  @visibleForTesting
+  final Map<String, dynamic>? debugSectionOverrideDeletedMirror;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -133,6 +138,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugMirrorPrefsRows,
     this.debugInflowDeletedIdsMirror,
     this.debugTombstoneGcConfig,
+    this.debugSectionOverrideDeletedMirror,
   });
 
   @override
@@ -472,6 +478,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _loadExpectedInflows();
     // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
     unawaited(_initTombstoneGcAndPull());
+    // 他端末で削除されたセクション上書きを取り込む (#part292)。
+    unawaited(_pullDeletedSectionIds());
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
       final previousMonthKey = _assetLiabilityStateMonthKey(_now);
@@ -7534,6 +7542,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     try {
       final now = DateTime.now().toUtc().toIso8601String();
+      final deletedMirror =
+          await _displayModeStore.encodeDeletedSectionIdsMirror();
       await _supabase.from('asset_pref_mirror').upsert(<Map<String, dynamic>>[
         <String, dynamic>{
           'user_id': userId,
@@ -7550,9 +7560,59 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           },
           'updated_at': now,
         },
+        <String, dynamic>{
+          'user_id': userId,
+          'pref_key': 'section_override_deleted',
+          'value': deletedMirror,
+          'updated_at': now,
+        },
       ]);
     } catch (e) {
       debugPrint('display pref mirror upsert failed: $e');
+    }
+  }
+
+  /// 他端末で「自動へ戻した(削除した)」セクション上書きを取り込み、
+  /// ローカルからも除去する (削除伝播 / #part292)。
+  Future<void> _pullDeletedSectionIds() async {
+    final debugMirror = widget.debugSectionOverrideDeletedMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      Map<String, dynamic>? value = debugMirror;
+      if (value == null) {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', 'section_override_deleted');
+        if (rows.isEmpty) {
+          return;
+        }
+        final raw = rows.first['value'];
+        if (raw is! Map) {
+          return;
+        }
+        value = Map<String, dynamic>.from(raw);
+      }
+      final ids = AssetManagementDisplayModeStore.decodeDeletedSectionIdsMirror(
+        value,
+      );
+      if (ids.isEmpty) {
+        return;
+      }
+      final removed = await _displayModeStore.applyRemoteDeletedSectionIds(ids);
+      if (removed > 0 && mounted) {
+        final overrides = await _displayModeStore.loadOverrides();
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _sectionOverrides = overrides;
+        });
+      }
+    } catch (e) {
+      debugPrint('section override tombstone pull failed: $e');
     }
   }
 
@@ -8340,12 +8400,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// GC 設定 (上限/期限) の編集ダイアログ。保存でローカル+ミラーへ反映する。
   /// 手動 GC: 期限切れ・上限超過の削除記録を今すぐ掃除し、件数を SnackBar 表示。
   Future<void> _pruneTombstonesNow() async {
-    final removed = await _expectedInflowStore.pruneDeletedIds();
+    // 入金予定 + 表示設定 override の両トゥームストーンを一括掃除 (#part292)。
+    final removedInflow = await _expectedInflowStore.pruneDeletedIds();
+    final removedOverride = await _displayModeStore.pruneDeletedSectionIds();
     if (!mounted) {
       return;
     }
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('古い削除記録を$removed件 掃除しました')),
+      SnackBar(
+        content: Text(
+          '古い削除記録を${removedInflow + removedOverride}件 掃除しました',
+        ),
+      ),
     );
   }
 

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -215,6 +215,49 @@ class AssetManagementDisplayModeStore {
     return _overrideTombstones.activeIds(store);
   }
 
+  /// 削除トゥームストーンをミラー upsert 用の値へ変換する (`{'ids': [...]}`)。
+  Future<Map<String, dynamic>> encodeDeletedSectionIdsMirror({
+    SharedPreferences? prefs,
+  }) async {
+    final ids = await loadDeletedSectionIds(prefs: prefs);
+    return MirrorTombstoneStore.encodeMirror(ids);
+  }
+
+  /// ミラー値 (`{'ids': [...]}`) から section storageId リストを取り出す。
+  static List<String> decodeDeletedSectionIdsMirror(Object? value) =>
+      MirrorTombstoneStore.decodeMirror(value);
+
+  /// 他端末由来の override 削除トゥームストーンを取り込み、該当するローカル
+  /// 上書きを削除する (端末間の削除伝播 / #part292)。削除した上書き数を返す。
+  Future<int> applyRemoteDeletedSectionIds(
+    Iterable<String> remoteIds, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final incoming = await _overrideTombstones.mergeRemoteIds(store, remoteIds);
+    if (incoming.isEmpty) {
+      return 0;
+    }
+    final current = await loadOverrides(prefs: store);
+    final before = current.length;
+    current.removeWhere((section, _) => incoming.contains(section.storageId));
+    final removed = before - current.length;
+    if (removed > 0) {
+      final encoded = <String, String>{
+        for (final entry in current.entries)
+          entry.key.storageId: entry.value.storageId,
+      };
+      await store.setString(_overridesKey, jsonEncode(encoded));
+    }
+    return removed;
+  }
+
+  /// 期限切れ・上限超過の override 削除トゥームストーンを掃除し件数を返す。
+  Future<int> pruneDeletedSectionIds({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return _overrideTombstones.prune(store);
+  }
+
   /// 既存ユーザーの体験を変えないため、未設定時はフル表示。
   static const AssetManagementDisplayMode defaultMode =
       AssetManagementDisplayMode.full;

--- a/test/services/asset_management_display_mode_store_test.dart
+++ b/test/services/asset_management_display_mode_store_test.dart
@@ -445,5 +445,82 @@ void main() {
         AssetManagementSectionVisibilityOverride.hidden,
       );
     });
+
+    test('encode/decode deleted section ids mirror round-trips', () async {
+      const store = AssetManagementDisplayModeStore();
+      await store.saveOverride(
+        AssetManagementSectionId.chart,
+        AssetManagementSectionVisibilityOverride.pinned,
+      );
+      await store.saveOverride(
+        AssetManagementSectionId.chart,
+        AssetManagementSectionVisibilityOverride.auto,
+      );
+
+      final mirror = await store.encodeDeletedSectionIdsMirror();
+      expect(
+        mirror['ids'],
+        contains(AssetManagementSectionId.chart.storageId),
+      );
+      expect(
+        AssetManagementDisplayModeStore.decodeDeletedSectionIdsMirror(mirror),
+        contains(AssetManagementSectionId.chart.storageId),
+      );
+    });
+
+    test('applyRemoteDeletedSectionIds removes matching local overrides',
+        () async {
+      const store = AssetManagementDisplayModeStore();
+      await store.saveOverride(
+        AssetManagementSectionId.chart,
+        AssetManagementSectionVisibilityOverride.hidden,
+      );
+      await store.saveOverride(
+        AssetManagementSectionId.flow,
+        AssetManagementSectionVisibilityOverride.pinned,
+      );
+
+      // 他端末で chart 上書きが削除された → ローカルからも消える。
+      final removed = await store.applyRemoteDeletedSectionIds(
+        <String>[AssetManagementSectionId.chart.storageId],
+      );
+      expect(removed, 1);
+      final overrides = await store.loadOverrides();
+      expect(overrides.containsKey(AssetManagementSectionId.chart), isFalse);
+      expect(
+        overrides[AssetManagementSectionId.flow],
+        AssetManagementSectionVisibilityOverride.pinned,
+      );
+      expect(
+        await store.loadDeletedSectionIds(),
+        contains(AssetManagementSectionId.chart.storageId),
+      );
+
+      // 二度目は対象なし。
+      expect(
+        await store.applyRemoteDeletedSectionIds(
+          <String>[AssetManagementSectionId.chart.storageId],
+        ),
+        0,
+      );
+    });
+
+    test('pruneDeletedSectionIds clears expired override tombstones', () async {
+      var clock = DateTime(2026, 1, 1, 9);
+      final store = AssetManagementDisplayModeStore(nowProvider: () => clock);
+      await store.saveOverride(
+        AssetManagementSectionId.chart,
+        AssetManagementSectionVisibilityOverride.pinned,
+      );
+      await store.saveOverride(
+        AssetManagementSectionId.chart,
+        AssetManagementSectionVisibilityOverride.auto,
+      );
+      expect(await store.pruneDeletedSectionIds(), 0); // 期限内
+
+      clock = DateTime(2027, 6, 1, 9); // 既定 TTL 365 日超過
+      expect(await store.pruneDeletedSectionIds(), 1);
+      expect(await store.loadDeletedSectionIds(), isEmpty);
+    });
   });
 }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:my_web_app/pages/asset_management_page.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
+import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -251,10 +252,15 @@ void main() {
             'label': '給料',
           },
         ]),
-        // 2020 年の古い削除記録 → maxAgeDays:10 で期限切れ。
+        // 2020 年の古い削除記録 → inflow は maxAgeDays:10、override は既定365日で
+        // どちらも期限切れ → 一括掃除で 2 件 (#part292)。
         'asset_expected_inflow_deleted_ids_v1':
             jsonEncode(<Map<String, String>>[
           <String, String>{'id': 'old1', 'at': '2020-01-01T00:00:00.000Z'},
+        ]),
+        'asset_management_section_override_deleted_v1':
+            jsonEncode(<Map<String, String>>[
+          <String, String>{'id': 'chart', 'at': '2020-01-01T00:00:00.000Z'},
         ]),
       });
       await tester.binding.setSurfaceSize(const Size(1200, 2400));
@@ -284,7 +290,48 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200));
       await tester.pump(const Duration(milliseconds: 200));
 
-      expect(find.textContaining('古い削除記録を1件 掃除しました'), findsOneWidget);
+      // inflow(1) + override(1) = 2 件を一括掃除。
+      expect(find.textContaining('古い削除記録を2件 掃除しました'), findsOneWidget);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('remote section-override tombstone removes local override', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_management_section_overrides_v1': jsonEncode(
+          <String, String>{'chart': 'hidden'},
+        ),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 他端末で chart の上書きを削除した状態をミラー注入。
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugSectionOverrideDeletedMirror: <String, dynamic>{
+              'ids': <String>['chart'],
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // カスタマイズダイアログを開き、chart の上書きが「自動」に戻ったことを確認。
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_section_customize_button')),
+      );
+      await tester.tap(find.byKey(const Key('asset_section_customize_button')));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final dropdown = tester
+          .widget<DropdownButton<AssetManagementSectionVisibilityOverride>>(
+        find.byKey(const Key('asset_section_override_chart')),
+      );
+      expect(dropdown.value, AssetManagementSectionVisibilityOverride.auto);
 
       await _unmount(tester);
     });


### PR DESCRIPTION
## 概要

part 291 の次回候補 4 件を実装(※ part 288/290 等を並行セッションが使用済のため part 292 として採番)。

1. **override 削除トゥームストーンをサーバ mirror へ往復(他端末伝播)** — `_mirrorDisplayPrefs` に pref_key `section_override_deleted` の upsert を追加し、boot で pull→`applyRemoteDeletedSectionIds` で他端末の「自動へ戻した(削除)」上書きをローカルへ伝播。`encode/decodeDeletedSectionIdsMirror` + debug 注入フックで検証。
2. **手動「今すぐ掃除」を全トゥームストーン一括へ拡張** — 入金予定 + 表示設定 override の両 prune 件数を合算して SnackBar 表示(`pruneDeletedSectionIds` 追加)。
3. **CI の hook 検証を `.githooks/*` 全体へ一般化** — pre-commit 固有チェックを廃し、`.githooks/*`(`*.md` 除外)を走査して構文(`bash -n`)+ 実行ビットを検証。将来 hook 追加にも自動追従。
4. **グラフ a11y の記録 + 実機 QA の正直な分離** — 自動 semantics 契約検証(折れ線/面の `value` + `liveRegion`)を QA チェックリストの結果表に**実施済みとして記録**。実 AT(NVDA/VoiceOver/TalkBack)の読み上げ音声確認は自動化できないため、**実機担当者の実施項目として明記**(未実施を実施済みと偽らない)。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核となる 3ケース: (1) `applyRemoteDeletedSectionIds` が他端末削除をローカル override から除去(+ page e2e で chart 上書きが「自動」へ戻る) (2) 一括 prune が inflow+override 合算件数を返す (3) override 削除トゥームストーンの encode/decode 往復。今回 service 3 + widget 2 を追加、全体で flutter test 738 ケース。
- E2E例外: アプリコード変更はクライアント + テストのみでサーバ・スキーマ変更なし(設定/トゥームストーンは既存 `asset_pref_mirror` 汎用 jsonb・ローカル prefs)。widget pump がエンドツーエンド相当(削除伝播→上書き解除 / 一括掃除)を担い、本番疎通は既存 Playwright smoke で補完する。ci.yml 変更は hook 検証ステップの一般化のみ。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `python scripts/check_duplicate_dispose.py` **CLEAN** / `flutter test` **738/738 PASS**。compare diff-stat ゲート確認済み(+263 -13 / 6 files / 想定外削除なし)。

## High-risk gate

- High-risk-ultrareview-exception: migration・RLS・認証・課金ロジックへの変更は一切なし。トゥームストーン同期は既存 `asset_pref_mirror`(汎用 jsonb)への pref_key 追加のみ。ci.yml 変更は読み取り専用の hook 健全性チェックの一般化。レビュー所有者: Claude Code #1。
- 自己点検メモ: rollback = 本 PR revert のみで完結(override tombstone は追加 pref_key・applyRemote は既定空で後方互換)。pull は削除のみ伝播(上書きの新規追加は従来の section_overrides 経路)。a11y は実 AT 未確認を doc で正直に区別。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
