### PR TITLE
feat(asset): 収支カードを暦月から給料サイクル(先月25日〜今月24日)集計へ

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -9713,9 +9713,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // 給料サイクル (先月25日〜今月24日) で集計する。暦月だと給料日前は
     // 収入0で赤字に見えてしまうため (給料日=25日基準)。
     final cycleStart = AssetLiabilityMonthlyStateStore.salaryCycleStart(_now);
-    final cycleEndInclusive = AssetLiabilityMonthlyStateStore
-        .salaryCycleEndExclusive(_now)
-        .subtract(const Duration(days: 1));
+    final cycleEndInclusive =
+        AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(_now)
+            .subtract(const Duration(days: 1));
     final cycleLabel =
         '${cycleStart.month}/${cycleStart.day}〜${cycleEndInclusive.month}/${cycleEndInclusive.day}';
     final flows = _flowsForSalaryCycle(_now);

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -768,6 +768,26 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }).toList();
   }
 
+  /// 給料サイクル (先月25日〜今月24日) の期間に発生したフローを返す。
+  /// 「収支を最優先で把握」カードは暦月ではなくこのサイクルで集計する
+  /// (給料日前は収入0で赤字に見えてしまうのを避けるため)。
+  List<Map<String, dynamic>> _flowsForSalaryCycle(DateTime reference) {
+    final start = AssetLiabilityMonthlyStateStore.salaryCycleStart(reference);
+    final endExclusive =
+        AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(reference);
+    return _recentFlows.where((flow) {
+      final occurredAtRaw = flow['occurred_at']?.toString();
+      if (occurredAtRaw == null || occurredAtRaw.isEmpty) {
+        return false;
+      }
+      final occurredAt = DateTime.tryParse(occurredAtRaw)?.toLocal();
+      if (occurredAt == null) {
+        return false;
+      }
+      return !occurredAt.isBefore(start) && occurredAt.isBefore(endExclusive);
+    }).toList();
+  }
+
   Future<void> _pickFlowHistoryMonth() async {
     final now = DateTime.now();
     final picked = await showDatePicker(
@@ -9690,9 +9710,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // -------------------------
 
   Widget _buildMonthlyFlowFirstCard() {
-    final currentMonth = DateTime(_now.year, _now.month, 1);
-    final monthLabel = _flowMonthLabel(currentMonth);
-    final flows = _flowsForMonth(currentMonth);
+    // 給料サイクル (先月25日〜今月24日) で集計する。暦月だと給料日前は
+    // 収入0で赤字に見えてしまうため (給料日=25日基準)。
+    final cycleStart = AssetLiabilityMonthlyStateStore.salaryCycleStart(_now);
+    final cycleEndInclusive = AssetLiabilityMonthlyStateStore
+        .salaryCycleEndExclusive(_now)
+        .subtract(const Duration(days: 1));
+    final cycleLabel =
+        '${cycleStart.month}/${cycleStart.day}〜${cycleEndInclusive.month}/${cycleEndInclusive.day}';
+    final flows = _flowsForSalaryCycle(_now);
     var totalIncome = 0;
     var totalExpense = 0;
 
@@ -9708,8 +9734,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
     final net = totalIncome - totalExpense;
     final statusText = flows.isEmpty
-        ? 'まだ今月の収支が未記録です。まず収入と支出を入れて全体像を把握してください。'
-        : '今月の収支差額は ${NumberFormat('#,###').format(net.abs())}円 ${net >= 0 ? '黒字' : '赤字'} です。まずここを基準に残りの判断を進めます。';
+        ? 'まだこの給料サイクル ($cycleLabel) の収支が未記録です。まず収入と支出を入れて全体像を把握してください。'
+        : 'この給料サイクル ($cycleLabel) の収支差額は ${NumberFormat('#,###').format(net.abs())}円 ${net >= 0 ? '黒字' : '赤字'} です。まずここを基準に残りの判断を進めます。';
 
     return Card(
       key: const Key('asset_monthly_flow_priority_card'),
@@ -9749,7 +9775,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        '$monthLabelの収支を最優先で把握',
+                        '給料サイクル ($cycleLabel) の収支を最優先で把握',
                         style: const TextStyle(
                           fontSize: 18,
                           fontWeight: FontWeight.w800,

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -454,6 +454,21 @@ class AssetLiabilityMonthlyStateStore {
     return formatMonthKey(salaryCycleMonthFor(date, salaryDay: salaryDay));
   }
 
+  /// 給料サイクルの開始日 (= 当該サイクルの給料日)。
+  /// 例: salaryDay=25 で 6/13 を渡すと 5/25 を返す (5/25〜6/24 サイクル)。
+  static DateTime salaryCycleStart(DateTime date, {int salaryDay = 25}) {
+    final cycleMonth = salaryCycleMonthFor(date, salaryDay: salaryDay);
+    final normalizedSalaryDay = salaryDay.clamp(1, 28).toInt();
+    return DateTime(cycleMonth.year, cycleMonth.month, normalizedSalaryDay);
+  }
+
+  /// 給料サイクルの終了 (排他: 次サイクルの開始日)。
+  /// 例: salaryDay=25 で 6/13 を渡すと 6/25 を返す ([5/25, 6/25) = 5/25〜6/24)。
+  static DateTime salaryCycleEndExclusive(DateTime date, {int salaryDay = 25}) {
+    final start = salaryCycleStart(date, salaryDay: salaryDay);
+    return DateTime(start.year, start.month + 1, start.day);
+  }
+
   static AssetLiabilityMonthlyState copyPreviousMonthState({
     required AssetLiabilityMonthlyState previousState,
     required DateTime targetMonth,

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -43,6 +43,36 @@ void main() {
       );
     });
 
+    test('salaryCycleStart / EndExclusive give the 25th-to-24th window', () {
+      // 6/13 (給料日前) は 5/25〜6/24 サイクル。
+      expect(
+        AssetLiabilityMonthlyStateStore.salaryCycleStart(DateTime(2026, 6, 13)),
+        DateTime(2026, 5, 25),
+      );
+      expect(
+        AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(
+          DateTime(2026, 6, 13),
+        ),
+        DateTime(2026, 6, 25),
+      );
+      // 6/25 (給料日当日) は 6/25〜7/24 サイクルへ切替。
+      expect(
+        AssetLiabilityMonthlyStateStore.salaryCycleStart(DateTime(2026, 6, 25)),
+        DateTime(2026, 6, 25),
+      );
+      expect(
+        AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(
+          DateTime(2026, 6, 25),
+        ),
+        DateTime(2026, 7, 25),
+      );
+      // 1月始端の前サイクルは前年12/25。
+      expect(
+        AssetLiabilityMonthlyStateStore.salaryCycleStart(DateTime(2026, 1, 5)),
+        DateTime(2025, 12, 25),
+      );
+    });
+
     test('saves and restores monthly paid statuses', () async {
       await store.saveMonth(
         month: DateTime(2026, 5, 13),


### PR DESCRIPTION
## 概要

ユーザー報告: 「収支を最優先で把握」カードが暦月（1日〜末日）で集計しているため、給料日（25日）前は収入が0のままで大半の期間が赤字に見えてしまう。集計期間を**給料サイクル（先月25日〜今月24日）**へ変更したい。

### 変更内容

1. `AssetLiabilityMonthlyStateStore` に給料サイクルの境界ヘルパーを追加（既存 `salaryCycleMonthFor` と同じ salaryDay=25 基準）:
   - `salaryCycleStart(date)` — そのサイクルの給料日（6/13 → 5/25）
   - `salaryCycleEndExclusive(date)` — 次サイクル開始日＝排他終端（6/13 → 6/25）。窓は `[5/25, 6/25)` = 5/25〜6/24
2. ページに `_flowsForSalaryCycle(reference)` を追加し、`_recentFlows` を給料サイクル窓で絞り込み
3. 「収支を最優先で把握」カードを暦月集計 → 給料サイクル集計へ変更。見出しを「給料サイクル (5/25〜6/24) の収支を最優先で把握」、状況文も同期間表示に更新

`_flowsForMonth`（暦月）は他の多くの箇所で共用されているため変更せず、本カードのみ給料サイクルへ切り替え（影響範囲を限定）。

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. 6/13（給料日前）→ サイクル開始 5/25・終端排他 6/25（窓 = 5/25〜6/24）
  2. 6/25（給料日当日）→ サイクル開始 6/25・終端排他 7/25 へ切替
  3. 1/5 → 前サイクル開始は前年 12/25（年跨ぎ）
- 上記をサイクル境界の純関数（`salaryCycleStart`/`salaryCycleEndExclusive`）単体テスト（新規 / store テスト計20件 PASS）で検証
- E2E-Exception: 資産管理ページは認証済みユーザーのフロー履歴前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。集計窓の境界ロジックを純関数で単体テスト化して担保し、カード表示は本番反映後に手動確認する。

## 検証

- `flutter test`（monthly_state_store 20件）: All tests passed
- `dart analyze`: No issues found
- 並行セッションで base が複数回進行したため最新 origin/main に取り込み直して再適用（diff: page +32/-6・store +15・test +30、逆 revert ゼロ確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
