### PR TITLE
[CI/CD自動最適化] cancel-in-progress: true 追加 2026-06-13

### DIFF
--- a/.github/workflows/claude-session-hygiene-cron.yml
+++ b/.github/workflows/claude-session-hygiene-cron.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: claude-session-hygiene-cron
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-06-13 ci-audit: Windows 42runs/日キュー積み上がり防止
 
 jobs:
   hygiene:

--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: health-monitor
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-06-13 ci-audit: 毎30分モニタリングのキュー積み防止
 
 permissions:
   contents: write

--- a/docs/ci-cd-audit/2026-06-13.md
+++ b/docs/ci-cd-audit/2026-06-13.md
@@ -1,0 +1,133 @@
+# CI/CD コスト監査 2026-06-13
+
+> 自動生成 by CI/CD コスト最適化エージェント
+
+---
+
+## サマリ
+
+| 項目 | 値 |
+|------|-----|
+| 総ワークフロー数 | 106 |
+| スケジュール(cron)実行ワークフロー | 67 (63.2%) |
+| 高コスト Runner (Windows) | 5 workflows |
+| cancel-in-progress: false 残存 (非deploy) | 73 workflows |
+| 前回監査比較 | 前回バッチ6件 (ai-bench, codex-backlog 等) は適用済み確認 ✅ |
+
+### TOP3 コスト源
+
+| 順位 | ワークフロー | 理由 | 月間概算コスト |
+|------|-----------|------|-------------|
+| 1 | `claude-session-hygiene-cron` | Windows×30分×42回/日 = ~12,600 ubuntu-equiv min/月 | **本実行で cancel-in-progress: true 追加** |
+| 2 | `health-monitor` | Ubuntu×30分×48回/日 = ~720 min/月 | **本実行で cancel-in-progress: true 追加** |
+| 3 | `ai-university-update` | Ubuntu×2時間毎×15分 = ~180 min/月 | cancel-in-progress: false 意図的 (コメント付き) ← 触らない |
+
+---
+
+## ワークフロー別コスト表 (高頻度・高コスト上位)
+
+| ワークフロー | 頻度 | cron | Runner | cancel-in-progress | 推定月間時間 |
+|------------|------|------|--------|-------------------|-----------|
+| claude-session-hygiene-cron | 30分×21h/日 | `*/30 21-23,0-17 * * *` | windows-latest (2x) | **→ true (本実行)** | ~12,600 ubuntu-equiv min |
+| health-monitor | 30分 | `*/30 * * * *` | ubuntu-latest | **→ true (本実行)** | ~720 min |
+| ai-university-update | 2時間毎 | `0 */2 * * *` | ubuntu-latest | false (意図的) | ~180 min |
+| horse-racing-update | 2時間毎 | `0 */2 * * *` | ubuntu-latest | false | ~150 min |
+| wbs-ai-review | 2時間毎 | `20 */2 * * *` | ubuntu-latest | false | ~120 min |
+| infra-health-check | 2時間毎 | `37 */2 * * *` | ubuntu-latest | false | ~60 min |
+| mcp-audit-anomaly-cron | 2時間毎 | `7 */2 * * *` | ubuntu-latest | false | ~60 min |
+| feature-review | 4時間毎 | `0 */4 * * *` | ubuntu-latest | false | ~60 min |
+| edge-function-audit | 4時間毎 | `47 */4 * * *` | ubuntu-latest | false | ~30 min |
+
+---
+
+## 検出した冗長フロー (A-G)
+
+### A. 重複トリガー — 優先度 low
+- `ci.yml` → deploy-prod/staging/dev は workflow_call で呼び出す設計済み ✅
+
+### B. cancel-in-progress 未設定 — 優先度 high
+- 非deploy で cancel-in-progress: false のまま: **73 workflows** (前回レポート記載の残余6件は修正済みだが、元来73件あった状態)
+- **本実行対象 2 件**: `claude-session-hygiene-cron.yml`、`health-monitor.yml` → true に変更
+- windows-latest で cancel-in-progress: false 残存: `dev-cache-cleanup-cron.yml` (週1)、`docs-rotate-cron.yml` (月1)、`worktree-cleanup-cron.yml` (週1) → 次回バッチ候補
+
+### C. paths フィルタ — 優先度 low
+- push/PR トリガー持ち workflow は paths/paths-ignore 設定済み ✅
+
+### D. 過剰 cron 頻度 — 優先度 med
+- `health-monitor`: 前回06-06監査で30分→60分改善の記録があるが現在30分に戻っている。意図的な再設定の可能性あり → Issue 提案のみ (自動変更せず)
+- `claude-session-hygiene-cron`: 前回06-12監査で30分→60分とレポートされたが現在は30分(`*/30`)のまま。同様に確認要
+
+### E. cache 未使用 — 優先度 med
+- cron-only ワークフローの大半は checkout のみで cache 不要
+- `e2e-smoke.yml` は `cache: true` (flutter-action) 設定済み ✅
+- `ci.yml` は actions/cache@v5 設定済み ✅
+
+### F. 高失敗率 — 優先度 low
+- 直近30実行の記録では `AI Agent PR Review` が 100% failure (1件のみ / PR 1件の sample)
+- 統計的に有意なサンプルなし。次回に継続監視
+
+### G. 廃止候補 — 優先度 low
+- `tools-hub-mcp-smoke.yml`: 前回監査 (06-09) で6日連続100% failure が報告されたが今回のサンプルでは未確認。Issue #3175 で追跡中
+
+---
+
+## 自動適用した変更 (本実行)
+
+| ファイル | 変更内容 | 効果 |
+|---------|---------|------|
+| `.github/workflows/claude-session-hygiene-cron.yml` | `cancel-in-progress: false` → `true` | windows-latest 42runs/日のキュー積み上がり防止。前回 run が遅延した場合の二重課金リスク軽減 |
+| `.github/workflows/health-monitor.yml` | `cancel-in-progress: false` → `true` | 毎30分のモニタリングキュー防止。スタレな health-status.json 書き込みの上書き競合リスク排除 |
+
+**推定削減効果**: 最大 ~2,100 ubuntu-equiv min/月 (キュー積み上がり時の二重実行防止)
+
+---
+
+## 改善提案 (Issue 提案のみ)
+
+### 🔴 優先度 HIGH
+
+**1. health-monitor / claude-session-hygiene-cron の cron 頻度再確認**
+- `health-monitor`: 前回06-06で30分→60分改善と記録されたが、現在 `*/30 * * * *` (30分) に戻っている
+- `claude-session-hygiene-cron`: 前回06-12で30分→60分改善と記録されたが、現在 `*/30 21-23,0-17 * * *` (30分) のまま
+- 推定: 意図的な再設定か、PRがマージされなかった可能性
+- アクション: オーナー確認後、本当に30分必要か検討。60分で十分なら再度変更
+
+**2. windows-latest 残存3件の cancel-in-progress 設定**
+- `dev-cache-cleanup-cron.yml` (週1 日曜 17:00 UTC)
+- `docs-rotate-cron.yml` (月1)
+- `worktree-cleanup-cron.yml` (週1)
+- 推定削減: 頻度低いが次回バッチで対応
+
+### 🟡 優先度 MED
+
+**3. midnight cron 集中 (0 0 * * *) 5件の分散**
+- `ai-university-reminder`, `codex-backlog-check`, `quota-monitor`, `wbs-user-notify`, `wbs-user-tasks-notify` が全て `0 0 * * *` で同時起動
+- GHA キュー遅延リスク。5分ずつずらす (0,5,10,15,20 分) を推奨
+
+**4. claude-session-hygiene-cron の 60分→毎時設定 (オーナー確認後)**
+- `*/30 21-23,0-17 * * *` (42回/日) → `0 21-23,0-17 * * *` (21回/日)
+- 削減効果: windows-latest ~6,300 ubuntu-equiv min/月
+
+---
+
+## 次回バッチ候補 (最大2ファイル)
+
+```
+dev-cache-cleanup-cron.yml    (windows-latest 週1 → cancel-in-progress: true)
+worktree-cleanup-cron.yml     (windows-latest 週1 → cancel-in-progress: true)
+```
+
+---
+
+## 累積改善サマリー (2026-06-04〜13)
+
+| 適用日 | 内容 | 削減効果 |
+|--------|------|---------| 
+| 06-04 | ci.yml pub cache 追加 | ~2 min/PR |
+| 06-04 | memory-search-sync.yml concurrency 追加 | エラー回避 |
+| 06-06 | health-monitor.yml cron 30分→1時間 (レポートのみ、要確認) | ~720 runs/月 |
+| 06-08 | feature-review.yml cron 毎時→毎4時間 | ~22.8 分/日 |
+| 06-08 | edge-function-audit.yml cron 毎時→毎4時間 | ~9 分/日 |
+| 06-09 | blog-publish-orphan-cleanup + stale-ef concurrency true | git 競合エラー回避 |
+| 06-12 | claude-session-hygiene-cron 30分→60分 (レポートのみ、要確認) | ~6,300 ubuntu-equiv min/月 |
+| **06-13** | **claude-session-hygiene-cron + health-monitor cancel-in-progress: true** | **キュー積み二重実行防止 ~2,100 ubuntu-equiv min/月** |


### PR DESCRIPTION
⚠️ このPRはブランチが古いローカルmainから作成されたため、無関係なファイルが大量にdiffに含まれていました。PR #3333 (ci/auto-optimize-20260613-clean) に差し替えてクローズします。