### PR TITLE
feat(asset): AIコメントのカード明細未取込からワンクリックで取り込み・照合パネルへ

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -174,6 +174,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final _keyFlow = GlobalKey();
   final _keySubs = GlobalKey();
   final _keyMust = GlobalKey();
+  // カード明細取り込み・照合パネルへのスクロール用 (AIコメントからのジャンプ)。
+  final _keyCardStatementReconciliation = GlobalKey();
 
   Timer? _deadlineTimer;
   DateTime _now = DateTime.now();
@@ -574,6 +576,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     await _loadAssetManagementUserProfile();
+  }
+
+  /// AIコメントが指摘するカード明細の未取込・差分に対し、取り込み・照合
+  /// パネルへ誘導するリンクの文言。確認が必要なカード名を織り込む。
+  String _cardStatementReconciliationLinkLabel(AssetLiabilityWorkbook workbook) {
+    final groups = workbook.cardStatementReconciliation.needsReviewGroups;
+    if (groups.length == 1) {
+      return '${groups.first.billingAccountName}の明細を取り込んで照合する';
+    }
+    return 'カード明細を取り込んで照合する（${groups.length}件）';
+  }
+
+  void _jumpToCardStatementReconciliation() {
+    _scrollTo(_keyCardStatementReconciliation);
   }
 
   List<String> _paymentSourceCandidates() {
@@ -9713,9 +9729,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // 給料サイクル (先月25日〜今月24日) で集計する。暦月だと給料日前は
     // 収入0で赤字に見えてしまうため (給料日=25日基準)。
     final cycleStart = AssetLiabilityMonthlyStateStore.salaryCycleStart(_now);
-    final cycleEndInclusive =
-        AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(_now)
-            .subtract(const Duration(days: 1));
+    final cycleEndInclusive = AssetLiabilityMonthlyStateStore
+        .salaryCycleEndExclusive(_now)
+        .subtract(const Duration(days: 1));
     final cycleLabel =
         '${cycleStart.month}/${cycleStart.day}〜${cycleEndInclusive.month}/${cycleEndInclusive.day}';
     final flows = _flowsForSalaryCycle(_now);
@@ -13907,6 +13923,24 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
             ),
           ],
+          if (report.workbook.cardStatementReconciliation.hasNeedsReview) ...[
+            const SizedBox(height: 6),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  foregroundColor: const Color(0xFFD97706),
+                ),
+                onPressed: _jumpToCardStatementReconciliation,
+                icon: const Icon(Icons.receipt_long_outlined, size: 16),
+                label: Text(
+                  _cardStatementReconciliationLinkLabel(report.workbook),
+                ),
+              ),
+            ),
+          ],
           const SizedBox(height: 10),
           _buildMainAccountSelector(report.workbook),
           const SizedBox(height: 8),
@@ -15541,7 +15575,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           const SizedBox(height: 12),
           _buildCardBillingReviewGroups(review.cardBillingGroups),
           const SizedBox(height: 12),
-          _buildCardStatementReconciliationPanel(workbook),
+          KeyedSubtree(
+            key: _keyCardStatementReconciliation,
+            child: _buildCardStatementReconciliationPanel(workbook),
+          ),
         ],
       ),
     );

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -580,7 +580,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   /// AIコメントが指摘するカード明細の未取込・差分に対し、取り込み・照合
   /// パネルへ誘導するリンクの文言。確認が必要なカード名を織り込む。
-  String _cardStatementReconciliationLinkLabel(AssetLiabilityWorkbook workbook) {
+  String _cardStatementReconciliationLinkLabel(
+      AssetLiabilityWorkbook workbook) {
     final groups = workbook.cardStatementReconciliation.needsReviewGroups;
     if (groups.length == 1) {
       return '${groups.first.billingAccountName}の明細を取り込んで照合する';
@@ -9729,9 +9730,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // 給料サイクル (先月25日〜今月24日) で集計する。暦月だと給料日前は
     // 収入0で赤字に見えてしまうため (給料日=25日基準)。
     final cycleStart = AssetLiabilityMonthlyStateStore.salaryCycleStart(_now);
-    final cycleEndInclusive = AssetLiabilityMonthlyStateStore
-        .salaryCycleEndExclusive(_now)
-        .subtract(const Duration(days: 1));
+    final cycleEndInclusive =
+        AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(_now)
+            .subtract(const Duration(days: 1));
     final cycleLabel =
         '${cycleStart.month}/${cycleStart.day}〜${cycleEndInclusive.month}/${cycleEndInclusive.day}';
     final flows = _flowsForSalaryCycle(_now);


### PR DESCRIPTION
## 概要

ユーザー要望: AI 資産管理アシスタントが「auPAYカードのカード明細取り込みが未実施（請求40,163円に対し内訳32,152円、差-8,011円）」と指摘するが、そのコメントから明細取り込み機能へ直接飛べない。ワンクリックで対応できる導線がほしい。

### 実装方針（part 271d と同じパターン）

LLM の自由文（AI要約本文）にはリンクを埋め込めないため、**決定的な条件でAI要約パネルの直下に近接リンクを表示**する方式を踏襲（職業・年収リンク #3256 と同型）。

### 変更内容（`asset_management_page.dart` のみ）

1. `workbook.cardStatementReconciliation.hasNeedsReview` が真のとき、AI要約パネル直下に「**○○の明細を取り込んで照合する**」リンク（警告色）を表示。確認が必要なカード名を文言に織り込み、複数件なら件数表示
2. 押下で既存の「カード明細取り込み・照合」パネルへスクロール（`KeyedSubtree` でアンカー化 + 既存 `_scrollTo`）
3. 表示判定は workbook の決定論フラグのみ。AI が指摘しない（差分・未取込が無い）状態ではリンクは出ない

カード明細取り込み機能そのものは既存（同パネル内の「明細を取り込む」）で、本PRは導線の追加のみ。

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースの観点で確認
  1. カード請求と明細に差分/未取込あり（hasNeedsReview=true）→ AI要約直下にカード名入りの取り込みリンクが表示される
  2. リンク押下 → カード明細取り込み・照合パネルへスクロール
  3. 差分なし（hasNeedsReview=false）→ リンクは表示されない
- 判定条件 `hasNeedsReview` / `needsReviewGroups` は workbook モデルの既存単体テストで担保済み。本PRは薄い条件付きUI（リンク表示＋スクロール）で、既出の職業・年収リンク（#3256）と同型
- E2E-Exception: 資産管理ページは認証済みユーザーのデータ前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。リンクの表示条件は決定論フラグの参照のみで、スクロール挙動は本番反映後に手動確認する。

## 検証

- `dart analyze`: No issues found
- 変更は page 1ファイルのみ（リンク表示＋スクロールアンカー＋文言ヘルパー）。並行セッションの page 変更とは領域独立（branch vs origin/main で逆revert ゼロ確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
