### PR TITLE
fix(asset): カード明細取り込みをauPAY形式(タブ区切り・日本語ヘッダ)に対応

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -16151,7 +16151,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
           const SizedBox(height: 6),
           Text(
-            'CSV行は「摘要,金額,日付」または「請求先ID,摘要,金額,日付」で貼り付けできます。取り込み合計をカード請求額と照合します。',
+            'CSV/TSV行は「摘要,金額,日付」または「請求先ID,摘要,金額,日付」で貼り付けできます。auPAY等の明細表（タブ区切り・「利用日/利用店名/利用金額」等の見出し付き）もそのまま貼り付け可能です。取り込み合計をカード請求額と照合します。',
             style: TextStyle(
               color: Theme.of(context).colorScheme.onSurfaceVariant,
               fontSize: 12,

--- a/lib/services/asset_liability_card_statement_import_service.dart
+++ b/lib/services/asset_liability_card_statement_import_service.dart
@@ -203,8 +203,7 @@ class AssetLiabilityCardStatementImportService {
               header.contains('description'))) {
         descriptionIndex = i;
       } else if (billingIndex == null &&
-          (header.contains('請求先id') ||
-              header.contains('billing_account'))) {
+          (header.contains('請求先id') || header.contains('billing_account'))) {
         billingIndex = i;
       }
     }

--- a/lib/services/asset_liability_card_statement_import_service.dart
+++ b/lib/services/asset_liability_card_statement_import_service.dart
@@ -14,23 +14,28 @@ class AssetLiabilityCardStatementImportService {
     final rejected = <AssetLiabilityCardStatementRejectedRow>[];
     final rows = rawText.split(RegExp(r'\r?\n'));
     var hasHeader = false;
+    _CardStatementColumnMap? columnMap;
 
     for (var i = 0; i < rows.length; i++) {
       final rawRow = rows[i].trim();
       if (rawRow.isEmpty) {
         continue;
       }
-      final cells = _splitCsvRow(rawRow).map((cell) => cell.trim()).toList();
+      final cells = _splitRow(rawRow).map((cell) => cell.trim()).toList();
       if (cells.isEmpty) {
         continue;
       }
       if (!hasHeader && _looksLikeHeader(cells)) {
         hasHeader = true;
+        // 各社 CSV/TSV のヘッダ列名から「日付・摘要・金額」の位置を学習し、
+        // 以降の行をその位置で読む (auPAY 等の列順差異を吸収)。
+        columnMap = _buildColumnMap(cells);
         continue;
       }
 
       final parsed = _parseRow(
         cells: cells,
+        columnMap: columnMap,
         rowNumber: i + 1,
         rawRow: rawRow,
         defaultBillingAccountId: defaultBillingAccountId,
@@ -51,6 +56,7 @@ class AssetLiabilityCardStatementImportService {
 
   _ParsedCardStatementRow _parseRow({
     required List<String> cells,
+    required _CardStatementColumnMap? columnMap,
     required int rowNumber,
     required String rawRow,
     required String? defaultBillingAccountId,
@@ -62,7 +68,21 @@ class AssetLiabilityCardStatementImportService {
     String? amountText;
     String? dateText;
 
-    if (cells.length >= 4) {
+    String? cellAt(int? index) =>
+        (index != null && index >= 0 && index < cells.length)
+            ? cells[index]
+            : null;
+
+    if (columnMap != null) {
+      // ヘッダ学習済み: 列名から得た位置で読む (auPAY 等の列順に対応)。
+      description = cellAt(columnMap.description);
+      amountText = cellAt(columnMap.amount);
+      dateText = cellAt(columnMap.date);
+      final billingFromColumn = cellAt(columnMap.billing);
+      if (billingFromColumn != null && billingFromColumn.trim().isNotEmpty) {
+        billingAccountId = billingFromColumn;
+      }
+    } else if (cells.length >= 4) {
       billingAccountId = cells[0];
       description = cells[1];
       amountText = cells[2];
@@ -91,7 +111,7 @@ class AssetLiabilityCardStatementImportService {
 
     billingAccountId = billingAccountId?.trim();
     billingAccountName = billingAccountName?.trim();
-    description = description.trim();
+    description = (description ?? '').trim();
     final amount = _parseAmount(amountText);
     final postedAt = _parseDate(dateText);
 
@@ -141,7 +161,80 @@ class AssetLiabilityCardStatementImportService {
     return normalized.contains('amount') ||
         normalized.contains('billing_account') ||
         normalized.contains('description') ||
-        normalized.contains('posted_at');
+        normalized.contains('posted_at') ||
+        // 日本語ヘッダ (auPAY / 各社カード明細 CSV/TSV)。データ行には現れない
+        // 列見出しの語で判定する。
+        normalized.contains('利用金額') ||
+        normalized.contains('利用日') ||
+        normalized.contains('利用店名') ||
+        normalized.contains('ご利用者') ||
+        normalized.contains('ご利用日') ||
+        normalized.contains('請求額') ||
+        normalized.contains('支払区分');
+  }
+
+  /// ヘッダ行から「日付・摘要・金額・請求先ID」の列位置を学習する。
+  /// 金額と摘要が特定できなければ null を返し、位置ベースの推定へ委ねる。
+  _CardStatementColumnMap? _buildColumnMap(List<String> headerCells) {
+    int? dateIndex;
+    int? descriptionIndex;
+    int? amountIndex;
+    int? billingIndex;
+    for (var i = 0; i < headerCells.length; i++) {
+      final header = headerCells[i].toLowerCase().trim();
+      if (amountIndex == null &&
+          (header.contains('利用金額') ||
+              header.contains('請求額') ||
+              header == '金額' ||
+              header.contains('amount'))) {
+        amountIndex = i;
+      } else if (dateIndex == null &&
+          (header.contains('利用日') ||
+              header.contains('ご利用日') ||
+              header.contains('日付') ||
+              header.contains('date') ||
+              header.contains('posted_at'))) {
+        dateIndex = i;
+      } else if (descriptionIndex == null &&
+          (header.contains('利用店名') ||
+              header.contains('店名') ||
+              header.contains('利用内容') ||
+              header.contains('ご利用先') ||
+              header.contains('description'))) {
+        descriptionIndex = i;
+      } else if (billingIndex == null &&
+          (header.contains('請求先id') ||
+              header.contains('billing_account'))) {
+        billingIndex = i;
+      }
+    }
+    // 店名列が無い明細は摘要列を摘要(=説明)として使う。
+    if (descriptionIndex == null) {
+      for (var i = 0; i < headerCells.length; i++) {
+        if (headerCells[i].toLowerCase().contains('摘要')) {
+          descriptionIndex = i;
+          break;
+        }
+      }
+    }
+    if (amountIndex == null || descriptionIndex == null) {
+      return null;
+    }
+    return _CardStatementColumnMap(
+      date: dateIndex,
+      description: descriptionIndex,
+      amount: amountIndex,
+      billing: billingIndex,
+    );
+  }
+
+  /// タブ区切り (表計算/明細サイトからの貼り付け) はタブで、それ以外は
+  /// カンマで分割する。
+  List<String> _splitRow(String row) {
+    if (row.contains('\t')) {
+      return row.split('\t');
+    }
+    return _splitCsvRow(row);
   }
 
   List<String> _splitCsvRow(String row) {
@@ -173,8 +266,9 @@ class AssetLiabilityCardStatementImportService {
     if (raw == null) {
       return null;
     }
-    final normalized = raw
+    final normalized = _normalizeFullWidthDigits(raw)
         .replaceAll(',', '')
+        .replaceAll('\uff0c', '') // \u5168\u89d2\u30ab\u30f3\u30de
         .replaceAll('\u5186', '')
         .replaceAll('\u00a5', '')
         .trim();
@@ -184,8 +278,21 @@ class AssetLiabilityCardStatementImportService {
     return double.tryParse(normalized);
   }
 
+  /// \u5168\u89d2\u6570\u5b57 (\uff10-\uff19) \u3092\u534a\u89d2\u3078\u5909\u63db\u3059\u308b\u3002\u660e\u7d30\u30b5\u30a4\u30c8\u306e\u30b3\u30d4\u30fc\u306f\u5168\u89d2\u6df7\u3058\u308a\u304c\u591a\u3044\u3002
+  String _normalizeFullWidthDigits(String input) {
+    final buffer = StringBuffer();
+    for (final rune in input.runes) {
+      if (rune >= 0xFF10 && rune <= 0xFF19) {
+        buffer.writeCharCode(rune - 0xFF10 + 0x30);
+      } else {
+        buffer.writeCharCode(rune);
+      }
+    }
+    return buffer.toString();
+  }
+
   DateTime? _parseDate(String? raw) {
-    final text = raw?.trim();
+    final text = raw == null ? null : _normalizeFullWidthDigits(raw).trim();
     if (text == null || text.isEmpty) {
       return null;
     }
@@ -226,6 +333,21 @@ class AssetLiabilityCardStatementImportService {
         .replaceAll(RegExp(r'^_|_$'), '');
     return slug.isEmpty ? 'card_statement_$rowNumber' : slug;
   }
+}
+
+/// ヘッダから学習したカード明細の列位置 (0始まり)。date/billing は任意。
+class _CardStatementColumnMap {
+  final int? date;
+  final int description;
+  final int amount;
+  final int? billing;
+
+  const _CardStatementColumnMap({
+    required this.date,
+    required this.description,
+    required this.amount,
+    required this.billing,
+  });
 }
 
 class _ParsedCardStatementRow {

--- a/test/services/asset_liability_card_statement_import_service_test.dart
+++ b/test/services/asset_liability_card_statement_import_service_test.dart
@@ -44,5 +44,58 @@ void main() {
       expect(result.rejectedRows, hasLength(2));
       expect(result.rejectedRows.first.rowNumber, 2);
     });
+
+    test('imports auPAY tab-separated statement with Japanese header', () {
+      final result = service.parse(
+        rawText: [
+          'ご利用者\t支払区分\t利用日\t利用店名\t利用金額\t摘要',
+          '本人(1034)\tリボ払い・「あらかじめリボ」\t2026/5/31\t'
+              'レモンガス（株）　東京支社\t8066\t',
+          '本人(1034)\tリボ払い・「あらかじめリボ」\t2026/6/11\t'
+              'ａｕ電話利用料\t15116\t０５月分',
+        ].join('\n'),
+        defaultBillingAccountId: 'aupay_card',
+        defaultBillingAccountName: 'auPAYカード',
+      );
+
+      expect(result.rejectedRows, isEmpty);
+      expect(result.lines, hasLength(2));
+      final first = result.lines.first;
+      expect(first.billingAccountId, 'aupay_card');
+      expect(first.description, 'レモンガス（株）　東京支社');
+      expect(first.amount, 8066);
+      expect(first.postedAt, DateTime(2026, 5, 31));
+      final second = result.lines[1];
+      expect(second.description, 'ａｕ電話利用料');
+      expect(second.amount, 15116);
+      expect(second.postedAt, DateTime(2026, 6, 11));
+    });
+
+    test('header-driven mapping uses 摘要 when no 利用店名 column', () {
+      final result = service.parse(
+        rawText: [
+          '利用日\t摘要\t利用金額',
+          '2026/05/10\tNetflix\t1,980',
+        ].join('\n'),
+        defaultBillingAccountId: 'paypay_card',
+      );
+
+      expect(result.rejectedRows, isEmpty);
+      expect(result.lines.single.description, 'Netflix');
+      expect(result.lines.single.amount, 1980);
+      expect(result.lines.single.postedAt, DateTime(2026, 5, 10));
+    });
+
+    test('normalizes full-width digits in amount and date', () {
+      final result = service.parse(
+        rawText: '利用日\t利用店名\t利用金額\n'
+            '２０２６/６/１１\tａｕ電話利用料\t１５１１６',
+        defaultBillingAccountId: 'aupay_card',
+      );
+
+      expect(result.rejectedRows, isEmpty);
+      expect(result.lines.single.amount, 15116);
+      expect(result.lines.single.postedAt, DateTime(2026, 6, 11));
+    });
   });
 }


### PR DESCRIPTION
## 概要

ユーザー報告: auPAYカードの明細を「カード明細取り込み・照合」に貼り付けても「No rows imported. First error: 摘要と金額が必要です」で0行しか取り込めない。

### 原因

`AssetLiabilityCardStatementImportService` が **カンマ区切り・固定列順（摘要,金額,日付 / 請求先ID,摘要,金額,日付）のみ**に対応していた。ユーザーが貼り付けた auPAY 形式は:
- **タブ区切り**（表/明細サイトからのコピー）→ `_splitCsvRow` がカンマのみ分割するため全体が1セル → 「摘要と金額が必要です」で reject
- **日本語ヘッダ**（ご利用者/支払区分/利用日/利用店名/利用金額/摘要）→ 英語ヘッダ判定に不一致
- **列順が異なる**（金額は5列目、日付は3列目、店名は4列目）

### 変更内容（`asset_liability_card_statement_import_service.dart` 中心・271g の許容パーサ方針）

1. **タブ区切り対応**: `_splitRow` がタブを含む行はタブで分割（それ以外は従来のCSVパーサ）
2. **日本語ヘッダ検出**: 利用金額/利用日/利用店名/ご利用者/支払区分 等のデータ行に現れない見出し語で判定
3. **ヘッダ駆動の列マッピング**: `_buildColumnMap` が見出し語から「日付・摘要・金額・請求先ID」の列位置を学習し、以降の行をその位置で読む（各社の列順差異を吸収）。店名列が無ければ摘要列を説明として使用
4. **全角数字の正規化**: 金額・日付の `０-９` を半角へ変換
5. 既存のカンマ区切り・位置ベース推定は後方互換で不変。UIヒント文を更新（タブ区切り・明細表も貼り付け可）

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の3ケースで行う
  1. auPAY形式（タブ区切り＋日本語ヘッダ＋利用者/支払区分/利用日/利用店名/利用金額/摘要）→ 2行とも取り込まれ、説明=利用店名・金額=利用金額・日付=利用日が正しくマップされる
  2. 利用店名列が無い明細（利用日/摘要/利用金額）→ 摘要を説明として取り込む
  3. 全角数字の金額・日付 → 半角に正規化して取り込む
- 上記をパーサの単体テスト（新規3件 / 計6件 PASS）で検証
- E2E-Exception: パース処理は純関数 `AssetLiabilityCardStatementImportService` で UI/Supabase 非依存。既存 Playwright 公開スモークの範囲外で、実画面の貼り付け→取り込みは本番反映後に手動確認する。

## 検証

- `flutter test`（card_statement_import 6件）: All tests passed
- `dart analyze`: No issues found
- 変更は service + test + page（ヒント文1行）。並行セッションとは領域独立（branch vs origin/main で逆revert ゼロ確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
