### PR TITLE
fix(asset): カード明細照合の「確認事項」欄を折り返して全文表示

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -16351,9 +16351,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     child: Padding(
                       padding: const EdgeInsets.symmetric(vertical: 6),
                       child: Text(
-                        group.alerts.isEmpty
-                            ? 'OK'
-                            : group.alerts.join(' / '),
+                        group.alerts.isEmpty ? 'OK' : group.alerts.join(' / '),
                         softWrap: true,
                         style: const TextStyle(height: 1.4),
                       ),

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -16314,7 +16314,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       child: DataTable(
         headingRowHeight: 34,
         dataRowMinHeight: 46,
-        dataRowMaxHeight: 64,
+        // 確認事項は長文になり得るため行高さを可変にし、セル側で折り返す。
+        dataRowMaxHeight: double.infinity,
         columns: const [
           DataColumn(label: Text('請求先カード')),
           DataColumn(label: Text('請求額'), numeric: true),
@@ -16345,7 +16346,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   ),
                 ),
                 DataCell(
-                  Text(group.alerts.isEmpty ? 'OK' : group.alerts.join(' / ')),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 280),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: Text(
+                        group.alerts.isEmpty
+                            ? 'OK'
+                            : group.alerts.join(' / '),
+                        softWrap: true,
+                        style: const TextStyle(height: 1.4),
+                      ),
+                    ),
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
## 概要

ユーザー報告: カード明細取り込み・照合テーブルの「確認事項」欄が途中までしか表示されない（例:「カード明細合計が請求額と一致しません / 設定済みカード内訳合計が…」で見切れる）。

### 原因

照合テーブル（`_buildCardStatementReconciliationTable`）の「確認事項」セルが `DataCell(Text(...))` で、長文が折り返さず横にはみ出していた。さらに `dataRowMaxHeight: 64` で行高さが制限されていたため、長いアラート文が途中で切れていた。

### 変更内容（`asset_management_page.dart` のみ）

1. `DataTable` の `dataRowMaxHeight` を `double.infinity` にして行高さを可変化（折り返した複数行が見えるように）
2. 「確認事項」セルを `maxWidth: 280` の `ConstrainedBox` + `softWrap: true` で複数行表示にし、全文が読めるようにした

表示のみの修正で、照合ロジック・データには変更なし。

## Minimal E2E Gate

- E2E方針: 実装詳細に依存しない入出力（ブラックボックス）検証を最小限の観点で確認
  1. 確認事項が長文（複数アラート）→ セル内で折り返して全文表示される
  2. 確認事項が短文（OK / 単一）→ 従来どおり1行で表示される
  3. 行高さがアラート文の行数に応じて伸びる
- 表示専用の薄い変更（セル幅制約＋折り返し＋行高さ可変）で、ロジック非依存
- E2E-Exception: 資産管理ページは認証済みユーザーのデータ前提のため、既存 Playwright 公開スモーク（test/e2e）では到達不可。レイアウト変更のため本番反映後に長文の確認事項が全文表示されることを手動確認する。

## 検証

- `dart analyze`: No issues found
- 変更は page 1ファイル（+15/-2、テーブルセルの折り返しと行高さ）。並行セッションとは領域独立（branch vs origin/main で逆revert ゼロ確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
