### PR TITLE
docs+test(asset): mirror pref 俯瞰 + Phase3確認SQL + 支払日tombstone e2e + a11y状況 (part 295)

### DIFF
--- a/docs/ACCESSIBILITY_QA_CHECKLIST.md
+++ b/docs/ACCESSIBILITY_QA_CHECKLIST.md
@@ -5,6 +5,14 @@ CFO 室「表示モード実験 詳細グラフ」(折れ線=標準維持率 / �
 (label / value / liveRegion)を検証するが、**実 AT (支援技術) の読み上げ挙動は
 実機確認が必要**(自動テストでは代替できない)。
 
+## 現在ステータス (2026-06-13 / part 295 時点)
+
+- **自動側 (Semantics 契約) は完了**: CI widget テストが label / value / liveRegion /
+  矢印キー移動を継続検証(下記)。
+- **残るは実機 AT の音声確認のみ**: NVDA / VoiceOver / TalkBack の実読み上げは
+  自動化できず、リポジトリ自動化では実行不可。**実機を持つ担当者**が「実機チェック」
+  節の手順で実施し、「記録」節の表へ PASS/FAIL を追記する。
+
 ## 自動テストでカバー済み (CI)
 
 - `test/widgets/display_mode_experiment_card_test.dart`

--- a/docs/MIRROR_PREF_AGGREGATION_MIGRATION.md
+++ b/docs/MIRROR_PREF_AGGREGATION_MIGRATION.md
@@ -31,6 +31,49 @@
    実質ゼロ (sql で `count(*) where pref_key in (...)` を確認)。
 3. 旧クライアント (集約行を書けないバージョン) のアクティブ利用がない。
 
+## Phase 3 着手前チェック: legacy 行残存ゼロ確認 (SQL/手順)
+
+撤去条件 2「legacy per-key 行の残存が実質ゼロ」を Supabase SQL Editor で確認する。
+
+```sql
+-- (1) legacy pref_key の残存件数 (ゼロが理想 / 全 0 なら撤去可)。
+select pref_key, count(*) as rows, count(distinct user_id) as users,
+       max(updated_at) as latest
+from asset_pref_mirror
+where pref_key in (
+  'display_mode', 'section_overrides', 'section_override_deleted',
+  'inflow_deleted_ids', 'inflow_tombstone_gc'
+)
+group by pref_key
+order by rows desc;
+
+-- (2) 直近 28 日以内に legacy 行が更新されていないこと (= 旧クライアント不在)。
+--     0 行なら「最近 legacy を書く端末はいない」。
+select count(*) as recent_legacy_writes
+from asset_pref_mirror
+where pref_key in (
+  'display_mode', 'section_overrides', 'section_override_deleted',
+  'inflow_deleted_ids', 'inflow_tombstone_gc'
+)
+  and updated_at > now() - interval '28 days';
+
+-- (3) 集約行の普及率 (分母=何らかの pref を持つ user / 分子=集約行を持つ user)。
+with users_any as (
+  select distinct user_id from asset_pref_mirror
+),
+users_aggregated as (
+  select distinct user_id from asset_pref_mirror
+  where pref_key in ('asset_display_prefs_v1', 'asset_inflow_prefs_v1')
+)
+select (select count(*) from users_aggregated) as aggregated_users,
+       (select count(*) from users_any) as total_users;
+```
+
+判定: (1) が全 pref_key で 0、(2) が 0、(3) で aggregated≒total を確認できたら
+Phase 3(読みフォールバック撤去)へ進む。残存があれば、最終クリーンアップとして
+管理者が `delete from asset_pref_mirror where pref_key in (...)` を 1 度実行してよい
+(集約行が真実のためデータ損失なし)。
+
 ## ロールバック
 
 - Phase 2 は revert で「legacy delete を止める」だけ。集約行・読みフォールバックは

--- a/docs/MIRROR_PREF_SCHEMA.md
+++ b/docs/MIRROR_PREF_SCHEMA.md
@@ -1,0 +1,40 @@
+# asset_pref_mirror pref_key スキーマ俯瞰
+
+資産管理ページが `asset_pref_mirror`(user_id ごと・pref_key ごとに 1 行の jsonb
+バックアップ。端末間同期/削除伝播に使用)へ書き込む全 pref_key の現行スキーマ。
+集約方針・移行は [`MIRROR_PREF_AGGREGATION_MIGRATION.md`](MIRROR_PREF_AGGREGATION_MIGRATION.md) 参照。
+
+行は `{ user_id, pref_key, value (jsonb), updated_at }`。下表は `value` の形。
+
+## 現行 (書き込み対象)
+
+| pref_key | value | 用途 | 書込 | 読出 |
+|----|----|----|----|----|
+| `asset_display_prefs_v1` | `{mode, section_overrides:{id:state}, section_override_deleted:[id]}` | 表示モード+セクション上書き+その削除tombstone(集約) | `_mirrorDisplayPrefs` | `_fetchDisplayPrefRows` / `_pullDeletedSectionIds` |
+| `asset_inflow_prefs_v1` | `{deleted_ids:{ids:[id]}, gc:{max_count,max_age_days}}` | 入金削除tombstone + GC設定(集約) | `_mirrorInflowPrefs` | `_pullInflowDeletedIds` / `_loadTombstoneGcConfig` |
+| `debt_payment_day_overrides` | `{debtId: day(1-31)}` | 負債ごとの支払日手動設定 | `_mirrorDebtPaymentDayOverrides` | `_restoreDebtPaymentDayOverridesFromMirror` |
+| `debt_payment_day_override_deleted` | `{ids:[debtId]}` | 支払日上書きの削除tombstone | `_mirrorDebtOverrideDeleted` | `_pullDebtOverrideDeleted` |
+
+> 入金予定の実体は別テーブル `asset_expected_inflow_items`(本表の対象外)。
+
+## Legacy (読みフォールバックのみ / 書き込み停止済 / 撤去予定)
+
+集約行へ移行済み。新クライアントは書かず、boot 時の集約 upsert と同時に
+best-effort delete される(Phase 2)。読みは集約行が無い場合のみ参照。
+
+| pref_key | 集約先 | サブキー |
+|----|----|----|
+| `display_mode` | `asset_display_prefs_v1` | `mode` |
+| `section_overrides` | 〃 | `section_overrides` |
+| `section_override_deleted` | 〃 | `section_override_deleted` |
+| `inflow_deleted_ids` | `asset_inflow_prefs_v1` | `deleted_ids` |
+| `inflow_tombstone_gc` | 〃 | `gc` |
+
+## tombstone (削除伝播) の構成
+
+「一度消したものを他端末/サーバ残存から復活させない」ため、削除 ID 集合を
+`MirrorTombstoneStore`(GC 付き)で管理し mirror 往復する。3 ドメイン:
+
+1. 入金予定削除 → `asset_inflow_prefs_v1.deleted_ids`
+2. セクション上書き削除 → `asset_display_prefs_v1.section_override_deleted`
+3. 支払日上書き削除 → `debt_payment_day_override_deleted`

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -1153,8 +1153,24 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           await _assetLiabilityRepository.loadDefaultPaymentSources();
       final defaultCardBillingAccounts =
           await _assetLiabilityRepository.loadDefaultCardBillingAccounts();
-      final debtPaymentDayOverrides =
+      // #part295: ロード時もトゥームストーン済み支払日上書きを除外する
+      // (pull とロードの順序に依らず「削除した上書き」を復活させない)。
+      final loadedDebtOverrides =
           await _assetLiabilityRepository.loadDebtPaymentDayOverrides();
+      final debtTombstones = _debtOverrideTombstones.activeIds(
+        await SharedPreferences.getInstance(),
+      );
+      final debtPaymentDayOverrides = <String, int>{
+        for (final entry in loadedDebtOverrides.entries)
+          if (!debtTombstones.contains(entry.key)) entry.key: entry.value,
+      };
+      if (debtPaymentDayOverrides.length != loadedDebtOverrides.length) {
+        unawaited(
+          _assetLiabilityRepository.saveDebtPaymentDayOverrides(
+            Map<String, int>.from(debtPaymentDayOverrides),
+          ),
+        );
+      }
       if (debtPaymentDayOverrides.isEmpty) {
         unawaited(_restoreDebtPaymentDayOverridesFromMirror());
       }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -5,9 +5,30 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:my_web_app/pages/asset_management_page.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
+import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// 支払日上書きだけ差し替え可能なテスト用 repo (#part295 fake repo 足場)。
+/// 他のロード/保存は SharedPreferences 実装に委譲(テストでは空)。
+class _FakeDebtOverrideRepository
+    extends SharedPreferencesAssetLiabilityRepository {
+  _FakeDebtOverrideRepository(this._seed);
+
+  final Map<String, int> _seed;
+  Map<String, int>? savedDebtOverrides;
+
+  @override
+  Future<Map<String, int>> loadDebtPaymentDayOverrides() async {
+    return Map<String, int>.from(_seed);
+  }
+
+  @override
+  Future<void> saveDebtPaymentDayOverrides(Map<String, int> overrides) async {
+    savedDebtOverrides = Map<String, int>.from(overrides);
+  }
+}
 
 /// 資産管理ページの widget スモーク足場 (#3260)。
 /// 未ログイン (auth.currentUser == null) では Supabase フェッチ群が
@@ -332,6 +353,41 @@ void main() {
         find.byKey(const Key('asset_section_override_chart')),
       );
       expect(dropdown.value, AssetManagementSectionVisibilityOverride.auto);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('remote debt-override tombstone removes it via fake repo', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // fake repo が debt_1/debt_2 の支払日上書きを返す。他端末が debt_1 を削除した
+      // 状態をミラー注入 → boot pull + ロード除外で debt_1 が消え、repo へ保存される。
+      final repo = _FakeDebtOverrideRepository(<String, int>{
+        'debt_1': 27,
+        'debt_2': 5,
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            assetLiabilityRepository: repo,
+            debugDebtOverrideDeletedMirror: const <String, dynamic>{
+              'ids': <String>['debt_1'],
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // 削除伝播の結果が repo へ保存される(debt_1 除外 / debt_2 維持)。
+      expect(repo.savedDebtOverrides, isNotNull);
+      expect(repo.savedDebtOverrides!.containsKey('debt_1'), isFalse);
+      expect(repo.savedDebtOverrides!['debt_2'], 5);
 
       await _unmount(tester);
     });


### PR DESCRIPTION
## 概要

part 294 の次回候補 4 件を実装(主に doc + テスト + 小修正でリスク低)。

1. **全 `asset_pref_mirror` pref_key 俯瞰 doc** — [docs/MIRROR_PREF_SCHEMA.md](docs/MIRROR_PREF_SCHEMA.md) を新規。集約 2 行(`asset_display_prefs_v1`/`asset_inflow_prefs_v1`)・debt 2 行・legacy 5 キー・tombstone 3 ドメインの value 形と読み書きメソッドを一覧化。
2. **移行 Phase 3 の「legacy 行残存ゼロ」確認 SQL/手順** — [MIRROR_PREF_AGGREGATION_MIGRATION.md](docs/MIRROR_PREF_AGGREGATION_MIGRATION.md) に SQL 3本(残存件数 / 直近28日更新 / 集約普及率)+ 判定基準 + 最終クリーンアップ手順を追記。
3. **支払日上書きの 2クライアント widget e2e(fake repo 注入足場)** — `SharedPreferencesAssetLiabilityRepository` を継承した `_FakeDebtOverrideRepository`(支払日上書きだけ差し替え/保存を記録)を足場化。他端末削除をミラー注入 → boot pull + **ロード時トゥームストーン除外**で `debt_1` 抜き保存を検証。あわせて**ロード経路がトゥームストーンを無視していた潜在問題を修正**(pull とロードの順序に依らず削除済みを復活させない)。
4. **a11y QA 実機=ユーザー実施項目を明示** — チェックリストに現在ステータス(自動 Semantics 契約は CI で完了 / 残るは実機 AT の音声確認のみで担当者待ち)を追記。実 AT は自動化不可のため正直に分離継続。

## Minimal E2E Gate

- テストは実装詳細に依存しない入出力(black-box)契約で記述。核となるケース: 支払日上書き削除のミラー伝播を fake repo 注入で widget e2e 検証(boot pull + ロード除外 → repo へ `debt_1` 抜きで保存 / `debt_2` 維持)。pull とロードの順序双方で同一結果になる設計。全体で flutter test 749 ケース。
- E2E例外: アプリコード変更は「ロード時にトゥームストーン除外」する +17 -1 のみ(サーバ・スキーマ変更なし)。他は doc + テスト。widget pump がエンドツーエンド相当(削除伝播→repo 保存)を担い、本番疎通は既存 Playwright smoke で補完。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** / `python scripts/check_duplicate_dispose.py` **CLEAN** / `flutter test` **749/749 PASS**。compare diff-stat ゲート確認済み(+164 -1 / 5 files / 想定外削除なし)。

## High-risk gate

- High-risk-ultrareview-exception: migration・RLS・認証・課金ロジックへの変更なし。SQL は doc 内の**確認用クエリ**(実行はマイグレーションではなく運用手順)。アプリ変更はローカルのトゥームストーン除外フィルタのみ。レビュー所有者: Claude Code #1。
- 自己点検メモ: rollback = 本 PR revert で完結(ロード除外フィルタは追加のみ・除外時のみ保存)。doc/SQL は参照用で本番に副作用なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
