### PR TITLE
feat(asset): boot自動tombstone prune + items削除伝播の整理 (part 296)

### DIFF
--- a/docs/MIRROR_PREF_SCHEMA.md
+++ b/docs/MIRROR_PREF_SCHEMA.md
@@ -38,3 +38,23 @@ best-effort delete される(Phase 2)。読みは集約行が無い場合のみ�
 1. 入金予定削除 → `asset_inflow_prefs_v1.deleted_ids`
 2. セクション上書き削除 → `asset_display_prefs_v1.section_override_deleted`
 3. 支払日上書き削除 → `debt_payment_day_override_deleted`
+
+## 入金予定実体 (`asset_expected_inflow_items` テーブル) の削除伝播 — 整理 (part 296)
+
+入金予定の**実体行**は別テーブル `asset_expected_inflow_items` にあるが、その
+**削除伝播は上記 tombstone #1 が既にカバーしている**ため、items 専用の追加
+ラウンドトリップは不要(結論)。具体的な流れ:
+
+- 端末A で削除 → `_deleteInflowMirror(id)` がサーバ行を削除 **かつ**
+  `_mirrorInflowPrefs` が `deleted_ids` に id を追加 (tombstone をミラー)。
+- 端末B の boot → `_pullInflowDeletedIds` が tombstone を取り込み
+  `applyRemoteDeletedIds` で**ローカルの該当 item を削除**(復活防止)。
+- `mergeFromMirrorRows` / `restoreFromMirrorRows` は tombstone 済み id を除外。
+
+`restoreFromMirrorRows` が「ローカル空のときだけ全復元」なのは安全側の初期復元
+専用であり、削除伝播はあくまで tombstone 経路で成立している(= 「復元のみ」では
+ない)。よって items に新規の削除ミラーは追加しない。
+
+> 強いて残る差分: items は `_mirrorInflowToSupabase` で**行ごと upsert** する一方、
+> tombstone は集約 1 行。行ごと upsert の集約化は別テーマ (実体データのため本 doc の
+> pref 集約とはスコープが異なる)。

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -490,6 +490,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // 他端末で削除されたセクション上書き / 支払日上書きを取り込む (#part292/294)。
     unawaited(_pullDeletedSectionIds());
     unawaited(_pullDebtOverrideDeleted());
+    // 期限切れ・上限超過のトゥームストーンを自動掃除 (#part296 肥大化抑制)。
+    unawaited(_pruneTombstonesOnBoot());
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
       final previousMonthKey = _assetLiabilityStateMonthKey(_now);
@@ -8549,19 +8551,34 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// GC 設定 (上限/期限) の編集ダイアログ。保存でローカル+ミラーへ反映する。
   /// 手動 GC: 期限切れ・上限超過の削除記録を今すぐ掃除し、件数を SnackBar 表示。
   Future<void> _pruneTombstonesNow() async {
-    // 入金予定 + 表示設定 override の両トゥームストーンを一括掃除 (#part292)。
-    final removedInflow = await _expectedInflowStore.pruneDeletedIds();
-    final removedOverride = await _displayModeStore.pruneDeletedSectionIds();
+    // 入金予定 + 表示設定 override + 支払日上書きの全トゥームストーンを一括掃除
+    // (#part292/296)。
+    final removed = await _pruneAllTombstones();
     if (!mounted) {
       return;
     }
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          '古い削除記録を${removedInflow + removedOverride}件 掃除しました',
-        ),
-      ),
+      SnackBar(content: Text('古い削除記録を$removed件 掃除しました')),
     );
+  }
+
+  /// 3 ドメインのトゥームストーンを掃除し、合算した削除件数を返す。
+  Future<int> _pruneAllTombstones() async {
+    final store = await SharedPreferences.getInstance();
+    final removedInflow = await _expectedInflowStore.pruneDeletedIds();
+    final removedOverride = await _displayModeStore.pruneDeletedSectionIds();
+    final removedDebt = await _debtOverrideTombstones.prune(store);
+    return removedInflow + removedOverride + removedDebt;
+  }
+
+  /// boot 時に期限切れ・上限超過のトゥームストーンを自動で掃除する
+  /// (SharedPreferences 肥大化の自動抑制 / #part296)。UI 通知はしない。
+  Future<void> _pruneTombstonesOnBoot() async {
+    try {
+      await _pruneAllTombstones();
+    } catch (e) {
+      debugPrint('boot tombstone prune failed: $e');
+    }
   }
 
   Future<void> _showTombstoneGcSettings(

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -311,8 +311,42 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200));
       await tester.pump(const Duration(milliseconds: 200));
 
-      // inflow(1) + override(1) = 2 件を一括掃除。
-      expect(find.textContaining('古い削除記録を2件 掃除しました'), findsOneWidget);
+      // ボタン→prune→SnackBar の配線を検証 (件数は boot 自動 prune が先に
+      // 期限切れを掃除するため非依存にする / #part296)。実際の物理削除は
+      // 「boot auto-prune」テストと store 単体テストで担保。
+      expect(find.textContaining('件 掃除しました'), findsOneWidget);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('boot auto-prune physically drops expired tombstones', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        // 期限切れ(2020) + 期限内(現在) を混在させる。
+        'asset_expected_inflow_deleted_ids_v1':
+            jsonEncode(<Map<String, String>>[
+          <String, String>{'id': 'old1', 'at': '2020-01-01T00:00:00.000Z'},
+          <String, String>{
+            'id': 'recent',
+            'at': now.toUtc().toIso8601String(),
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // boot 自動 prune が期限切れ(old1)を物理削除し、期限内(recent)は残す。
+      final raw = (await SharedPreferences.getInstance())
+          .getString('asset_expected_inflow_deleted_ids_v1');
+      expect(raw, isNotNull);
+      expect(raw!.contains('old1'), isFalse);
+      expect(raw.contains('recent'), isTrue);
 
       await _unmount(tester);
     });


### PR DESCRIPTION
## 概要

part 295 の次回候補 4 件のうち、安全に実施できる 2 件を実装。残り 2 件は前提未達/
自動化不可のため**本 PR では実施せず理由を明記**(下記)。

### 実施した 2 件

1. **入金予定実体 `asset_expected_inflow_items` の削除伝播 — 整理(doc)** — 結論: items の
   削除伝播は**既存の inflow tombstone(`asset_inflow_prefs_v1.deleted_ids`)でカバー済み**
   (端末A削除→サーバ行delete+tombstone / 端末B boot pull→`applyRemoteDeletedIds` で
   ローカル item 削除)。`restoreFromMirrorRows` の「ローカル空のみ全復元」は初期復元
   専用で、削除伝播は tombstone 経路で成立。items 専用の追加ラウンドトリップは不要、と
   [MIRROR_PREF_SCHEMA.md](docs/MIRROR_PREF_SCHEMA.md) に明文化。
3. **`MirrorTombstoneStore.prune` を boot 時に自動実行** — boot で 3 ドメイン(入金/表示
   override/支払日 override)のトゥームストーンを自動 prune(期限切れ・上限超過を物理削除)
   し SharedPreferences 肥大化を自動抑制(`_pruneTombstonesOnBoot`)。手動「今すぐ掃除」も
   debt を含む全 3 ドメイン一括へ統一(`_pruneAllTombstones`)。物理削除を widget テストで検証。

### 本 PR で実施しなかった 2 件(理由)

2. **Phase 3(legacy 読みフォールバック撤去)** — 前提未達のため**見送り**。撤去条件は
   「Phase 2 着地から 28 日経過 + 本番で legacy 行残存ゼロ確認」。Phase 2 は本日(part 294)
   着地で 28 日未経過、かつ残存確認 SQL は本番 DB へのオペレータ実行が必要。早期撤去は
   旧クライアントのデータを読めなくするため実施しない(条件・SQL は migration doc に記載済)。
4. **a11y 実機 AT(NVDA/VoiceOver/TalkBack)** — 実読み上げ音声の確認は自動化できず、
   リポジトリ自動化では実行不可。担当者の実機実施待ち(手順・合否基準・記入欄は整備済)。

## Minimal E2E Gate

- テストは black-box 契約で記述。核となるケース: boot 自動 prune が期限切れ tombstone を
  **物理削除**(SharedPreferences の生値から消える)し期限内は残す。手動 prune は boot が
  先に掃除するため件数非依存で配線(ボタン→prune→SnackBar)を検証。全体で flutter test 750 ケース。
- E2E例外: アプリ変更は boot 自動 prune の配線 + 手動 prune の debt 統合のみ(サーバ・スキーマ
  変更なし)。残りは doc + テスト。本番疎通は既存 Playwright smoke で補完。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** /
  `python scripts/check_duplicate_dispose.py` **CLEAN** / `flutter test` **750/750 PASS**。
  compare diff-stat ゲート確認済み(+81 -10 / 3 files / 想定外削除なし)。

## High-risk gate

- High-risk-ultrareview-exception: migration・RLS・認証・課金ロジックへの変更なし。boot 自動
  prune は SharedPreferences ローカルの期限切れ削除記録の掃除のみ(サーバ未接続)。レビュー所有者:
  Claude Code #1。
- 自己点検メモ: rollback = 本 PR revert で完結(boot prune は追加のみ・期限切れ/上限超過のみ削除で
  有効な tombstone は不変)。Phase 3 は意図的に未実施でデータ後方互換を維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
