### PR TITLE
feat: リボ払いカードの請求額モデルを追加 (auPAY 三重不一致を解消)

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -228,6 +228,67 @@ class AssetLiabilityAccount {
   }
 }
 
+/// リボ払いカードの設定。
+///
+/// 請求額 = [monthlyAmount] + max(0, リボ残高 − [creditLimit])。
+/// auPAY カードの「あらかじめリボ」などで、毎月の請求額が利用明細合計ではなく
+/// 設定額 + 限度額超過分で決まるカードを表す。
+class AssetLiabilityRevolvingCreditConfig {
+  /// リボ設定額 (毎月固定で請求される最低額)。
+  final double monthlyAmount;
+
+  /// 利用限度額。これを超えたリボ残高は当月に一括で上乗せ請求される。
+  final double creditLimit;
+
+  const AssetLiabilityRevolvingCreditConfig({
+    required this.monthlyAmount,
+    required this.creditLimit,
+  });
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'monthlyAmount': monthlyAmount,
+        'creditLimit': creditLimit,
+      };
+
+  factory AssetLiabilityRevolvingCreditConfig.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return AssetLiabilityRevolvingCreditConfig(
+      monthlyAmount: (json['monthlyAmount'] as num?)?.toDouble() ?? 0,
+      creditLimit: (json['creditLimit'] as num?)?.toDouble() ?? 0,
+    );
+  }
+}
+
+/// リボ残高に対して算出した今月の請求内訳。
+class AssetLiabilityRevolvingCreditBilling {
+  /// リボ残高 (= 当月時点の負債残高)。
+  final double balance;
+
+  /// 利用限度額。
+  final double creditLimit;
+
+  /// リボ設定額。
+  final double monthlyAmount;
+
+  /// 限度額超過分 = max(0, [balance] − [creditLimit])。
+  final double overLimitAmount;
+
+  /// 今月請求額 = [monthlyAmount] + [overLimitAmount]。
+  final double billedAmount;
+
+  const AssetLiabilityRevolvingCreditBilling({
+    required this.balance,
+    required this.creditLimit,
+    required this.monthlyAmount,
+    required this.overLimitAmount,
+    required this.billedAmount,
+  });
+
+  /// 限度額を超過しているか (= 設定額に上乗せ請求が発生しているか)。
+  bool get isOverLimit => overLimitAmount > 0;
+}
+
 class AssetLiabilityDebtRow {
   final String id;
   final String name;
@@ -260,6 +321,10 @@ class AssetLiabilityDebtRow {
   /// 家賃・通信費など毎月全額を支払う固定費型の負債。利率の概念を持たない。
   final bool fullPaymentEstimate;
 
+  /// リボ払いカードの場合の今月請求内訳 (= 設定額 + 限度額超過分)。
+  /// null なら通常の負債 (請求額は手入力 or 推定)。
+  final AssetLiabilityRevolvingCreditBilling? revolvingBilling;
+
   const AssetLiabilityDebtRow({
     required this.id,
     required this.name,
@@ -289,7 +354,11 @@ class AssetLiabilityDebtRow {
     required this.billingConfirmed,
     required this.paid,
     this.fullPaymentEstimate = false,
+    this.revolvingBilling,
   });
+
+  /// リボ払いカードか (= 請求額が設定額 + 限度額超過分で決まるか)。
+  bool get isRevolving => revolvingBilling != null;
 
   bool get isDirectCashflowTarget =>
       !includedInBillingAccount &&
@@ -793,6 +862,10 @@ class AssetLiabilityCardStatementReconciliationGroup {
   final List<AssetLiabilityCardStatementLine> statementLines;
   final List<String> alerts;
 
+  /// リボ払いカードの場合の今月請求内訳。null なら通常の一括払いカード。
+  /// リボ払いでは 請求額 ≠ 明細合計 が正常なため、不一致アラートは抑止する。
+  final AssetLiabilityRevolvingCreditBilling? revolvingBilling;
+
   const AssetLiabilityCardStatementReconciliationGroup({
     required this.billingAccountId,
     required this.billingAccountName,
@@ -802,12 +875,16 @@ class AssetLiabilityCardStatementReconciliationGroup {
     required this.configuredItems,
     required this.statementLines,
     required this.alerts,
+    this.revolvingBilling,
   });
 
   double get statementDifference => statementLineTotal - billedAmount;
   double get configuredDifference => configuredDetailTotal - billedAmount;
   bool get hasStatementLines => statementLines.isNotEmpty;
   bool get needsReview => alerts.isNotEmpty;
+
+  /// リボ払いカードか。
+  bool get isRevolving => revolvingBilling != null;
 }
 
 class AssetLiabilityCardStatementReconciliationData {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -37,6 +37,7 @@ import 'package:my_web_app/services/asset_management_ai_summary_refresh.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
+import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
 import 'package:my_web_app/services/asset_unknown_expense_rule_service.dart';
@@ -211,6 +212,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, String> _paymentDifferenceReasons = <String, String>{};
   Map<String, double> _annualRateOverrides = <String, double>{};
   Map<String, int> _debtPaymentDayOverrides = <String, int>{};
+  // リボ払いカードの設定 (負債IDごと)。v1 はローカル永続化のみ。
+  Map<String, AssetLiabilityRevolvingCreditConfig> _revolvingConfigs =
+      <String, AssetLiabilityRevolvingCreditConfig>{};
   final Map<String, GlobalKey> _debtMasterCardKeys = <String, GlobalKey>{};
   Map<String, AssetLiabilityAnnualRateEvidence> _annualRateEvidences =
       <String, AssetLiabilityAnnualRateEvidence>{};
@@ -381,6 +385,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetManagementDisplayModeStore.defaultMode;
   final AssetManagementMainAccountStore _mainAccountStore =
       const AssetManagementMainAccountStore();
+  final AssetRevolvingCreditConfigStore _revolvingConfigStore =
+      const AssetRevolvingCreditConfigStore();
   // 使用可能額の基準となるメインバンク口座ID。null は既定(最大預金口座)。
   String? _assetManagementMainAccountId;
   Map<AssetManagementSectionId, AssetManagementSectionVisibilityOverride>
@@ -484,6 +490,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _fetchMustTasks();
     _loadDisplayMode();
     _loadMainAccount();
+    unawaited(_loadRevolvingConfigs());
     _loadExpectedInflows();
     // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
     unawaited(_initTombstoneGcAndPull());
@@ -4294,6 +4301,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
       defaultCardBillingAccountIds: _defaultCardBillingAccountIds,
       cardBillingAccountIds: _cardBillingAccountIds,
+      revolvingConfigs: _revolvingConfigs,
       incomePlans: _monthlyIncomePlans,
       cardStatementLines: _cardStatementLines,
       transferTasks: _transferTasks,
@@ -7306,6 +7314,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
       defaultCardBillingAccountIds: _defaultCardBillingAccountIds,
       cardBillingAccountIds: _cardBillingAccountIds,
+      revolvingConfigs: _revolvingConfigs,
       incomePlans: _monthlyIncomePlans,
       cardStatementLines: _cardStatementLines,
       transferTasks: _transferTasks,
@@ -7437,6 +7446,83 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('Error saving main account: $e');
     }
+  }
+
+  Future<void> _loadRevolvingConfigs() async {
+    try {
+      final configs = await _revolvingConfigStore.load();
+      if (!mounted || configs.isEmpty) {
+        return;
+      }
+      setState(() {
+        _revolvingConfigs = configs;
+      });
+    } catch (e) {
+      debugPrint('Error loading revolving credit configs: $e');
+    }
+  }
+
+  void _persistRevolvingConfig(
+    String debtId,
+    AssetLiabilityRevolvingCreditConfig? config,
+  ) {
+    setState(() {
+      final next = Map<String, AssetLiabilityRevolvingCreditConfig>.from(
+        _revolvingConfigs,
+      );
+      if (config == null) {
+        next.remove(debtId);
+      } else {
+        next[debtId] = config;
+      }
+      _revolvingConfigs = next;
+    });
+    unawaited(_revolvingConfigStore.save(_revolvingConfigs));
+  }
+
+  void _toggleRevolving(AssetLiabilityDebtRow row, bool enabled) {
+    if (!enabled) {
+      _persistRevolvingConfig(row.id, null);
+      return;
+    }
+    _persistRevolvingConfig(
+      row.id,
+      _revolvingConfigs[row.id] ??
+          const AssetLiabilityRevolvingCreditConfig(
+            monthlyAmount: 0,
+            creditLimit: 0,
+          ),
+    );
+  }
+
+  void _updateRevolvingMonthlyAmount(String debtId, double amount) {
+    final existing = _revolvingConfigs[debtId] ??
+        const AssetLiabilityRevolvingCreditConfig(
+          monthlyAmount: 0,
+          creditLimit: 0,
+        );
+    _persistRevolvingConfig(
+      debtId,
+      AssetLiabilityRevolvingCreditConfig(
+        monthlyAmount: amount < 0 ? 0 : amount,
+        creditLimit: existing.creditLimit,
+      ),
+    );
+  }
+
+  void _updateRevolvingCreditLimit(String debtId, double amount) {
+    final existing = _revolvingConfigs[debtId] ??
+        const AssetLiabilityRevolvingCreditConfig(
+          monthlyAmount: 0,
+          creditLimit: 0,
+        );
+    _persistRevolvingConfig(
+      debtId,
+      AssetLiabilityRevolvingCreditConfig(
+        monthlyAmount: existing.monthlyAmount,
+        creditLimit: amount < 0 ? 0 : amount,
+      ),
+    );
   }
 
   Future<void> _loadDisplayMode() async {
@@ -10180,6 +10266,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
         defaultCardBillingAccountIds: _defaultCardBillingAccountIds,
         cardBillingAccountIds: _cardBillingAccountIds,
+        revolvingConfigs: _revolvingConfigs,
         incomePlans: _monthlyIncomePlans,
         cardStatementLines: _cardStatementLines,
         transferTasks: _transferTasks,
@@ -16328,6 +16415,23 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  /// 照合行の「確認事項」表示文。リボ払いカードは不一致アラートの代わりに
+  /// 請求内訳 (設定額 + 限度超過分) を説明し、明細合計との不一致が正常である旨を示す。
+  String _cardReconciliationNote(
+    AssetLiabilityCardStatementReconciliationGroup group,
+  ) {
+    final billing = group.revolvingBilling;
+    if (billing != null) {
+      return 'リボ払い: 設定額 ${_formatManagementYen(billing.monthlyAmount)}'
+          ' ＋ 限度超過 ${_formatManagementYen(billing.overLimitAmount)}'
+          ' ＝ 請求 ${_formatManagementYen(billing.billedAmount)}'
+          '（残高 ${_formatManagementYen(billing.balance)}'
+          ' / 限度額 ${_formatManagementYen(billing.creditLimit)}）。'
+          '明細合計は今月の新規利用のため請求額と一致しません。';
+    }
+    return group.alerts.isEmpty ? 'OK' : group.alerts.join(' / ');
+  }
+
   Widget _buildCardStatementReconciliationTable(
     AssetLiabilityCardStatementReconciliationData reconciliation,
   ) {
@@ -16368,15 +16472,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   Text(_formatManagementYen(group.configuredDetailTotal)),
                 ),
                 DataCell(
-                  Text(
-                    _formatManagementYen(group.statementDifference),
-                    style: TextStyle(
-                      color: group.needsReview
-                          ? const Color(0xFFD97706)
-                          : const Color(0xFF0D9488),
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
+                  group.isRevolving
+                      ? const Text('—')
+                      : Text(
+                          _formatManagementYen(group.statementDifference),
+                          style: TextStyle(
+                            color: group.needsReview
+                                ? const Color(0xFFD97706)
+                                : const Color(0xFF0D9488),
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
                 ),
                 DataCell(
                   ConstrainedBox(
@@ -16384,7 +16490,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     child: Padding(
                       padding: const EdgeInsets.symmetric(vertical: 6),
                       child: Text(
-                        group.alerts.isEmpty ? 'OK' : group.alerts.join(' / '),
+                        _cardReconciliationNote(group),
                         softWrap: true,
                         style: const TextStyle(height: 1.4),
                       ),
@@ -19414,6 +19520,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 child: _buildMonthlyPaymentInput(row),
               ),
               _buildDebtMasterControl(
+                label: 'リボ払い設定',
+                child: _buildRevolvingControl(row),
+                maxWidth: 260,
+              ),
+              _buildDebtMasterControl(
                 label: '支払額区分',
                 child: _buildPaymentAmountSourceChip(row),
                 maxWidth: 150,
@@ -19624,6 +19735,27 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Widget _buildMonthlyPaymentInput(AssetLiabilityDebtRow row) {
+    if (row.isRevolving) {
+      // リボ払いは請求額を式から自動算出するため手入力欄は出さない。
+      final billing = row.revolvingBilling!;
+      return SizedBox(
+        width: 150,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              _formatManagementYen(billing.billedAmount),
+              style: const TextStyle(fontWeight: FontWeight.bold, height: 1.3),
+            ),
+            const Text(
+              'リボ自動算出',
+              style: TextStyle(fontSize: 11, height: 1.3),
+            ),
+          ],
+        ),
+      );
+    }
     final controller = _monthlyPaymentControllerFor(row);
     return SizedBox(
       width: 150,
@@ -19645,6 +19777,105 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 ),
         ),
       ),
+    );
+  }
+
+  Widget _buildRevolvingControl(AssetLiabilityDebtRow row) {
+    final config = _revolvingConfigs[row.id];
+    final enabled = config != null;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 24,
+              height: 24,
+              child: Checkbox(
+                value: enabled,
+                onChanged: (value) => _toggleRevolving(row, value ?? false),
+              ),
+            ),
+            const SizedBox(width: 4),
+            const Flexible(
+              child: Text(
+                'リボ払い (請求=設定額+限度超過分)',
+                style: TextStyle(fontSize: 11, height: 1.3),
+              ),
+            ),
+          ],
+        ),
+        if (config != null) ...[
+          const SizedBox(height: 6),
+          _buildRevolvingField(
+            row: row,
+            label: 'リボ設定額',
+            hint: '例: 10000',
+            value: config.monthlyAmount,
+            onChanged: (amount) =>
+                _updateRevolvingMonthlyAmount(row.id, amount),
+          ),
+          const SizedBox(height: 6),
+          _buildRevolvingField(
+            row: row,
+            label: '利用限度額',
+            hint: '例: 500000',
+            value: config.creditLimit,
+            onChanged: (amount) => _updateRevolvingCreditLimit(row.id, amount),
+          ),
+          if (row.revolvingBilling != null) ...[
+            const SizedBox(height: 6),
+            Text(
+              '今月請求 ${_formatManagementYen(row.revolvingBilling!.billedAmount)}',
+              style: const TextStyle(
+                fontSize: 11,
+                height: 1.3,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ],
+      ],
+    );
+  }
+
+  Widget _buildRevolvingField({
+    required AssetLiabilityDebtRow row,
+    required String label,
+    required String hint,
+    required double value,
+    required ValueChanged<double> onChanged,
+  }) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 64,
+          child: Text(
+            label,
+            style: const TextStyle(fontSize: 11, height: 1.3),
+          ),
+        ),
+        Expanded(
+          child: TextFormField(
+            key: ValueKey('revolving:${row.id}:$label'),
+            initialValue: value > 0 ? value.toStringAsFixed(0) : '',
+            keyboardType: TextInputType.number,
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9,]')),
+            ],
+            style: const TextStyle(fontSize: 12),
+            decoration: InputDecoration(isDense: true, hintText: hint),
+            onChanged: (text) {
+              final normalized = text.replaceAll(',', '').trim();
+              final parsed =
+                  normalized.isEmpty ? 0.0 : double.tryParse(normalized) ?? 0.0;
+              onChanged(parsed);
+            },
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:my_web_app/services/debt_lockdown_service.dart';
+import 'package:my_web_app/services/asset_revolving_credit_service.dart';
 
 import '../models/asset_liability_workbook.dart';
 
@@ -88,6 +89,8 @@ class AssetLiabilityPlanningService {
         const <String, String>{},
     Map<String, String> defaultCardBillingAccountIds = const <String, String>{},
     Map<String, String> cardBillingAccountIds = const <String, String>{},
+    Map<String, AssetLiabilityRevolvingCreditConfig> revolvingConfigs =
+        const <String, AssetLiabilityRevolvingCreditConfig>{},
     List<AssetLiabilityIncomePlan> incomePlans =
         const <AssetLiabilityIncomePlan>[],
     List<AssetLiabilityTransferTask> transferTasks =
@@ -183,6 +186,7 @@ class AssetLiabilityPlanningService {
             paymentSourceAccountIds: effectivePaymentSourceAccountIds,
             defaultCardBillingAccountIds: defaultCardBillingAccountIds,
             cardBillingAccountIds: cardBillingAccountIds,
+            revolvingConfigs: revolvingConfigs,
             accountsById: accountsById,
           ),
         )
@@ -554,6 +558,7 @@ class AssetLiabilityPlanningService {
     required Map<String, String> paymentSourceAccountIds,
     required Map<String, String> defaultCardBillingAccountIds,
     required Map<String, String> cardBillingAccountIds,
+    required Map<String, AssetLiabilityRevolvingCreditConfig> revolvingConfigs,
     required Map<String, AssetLiabilityAccount> accountsById,
   }) {
     final principal = account.liabilityBalance;
@@ -575,7 +580,20 @@ class AssetLiabilityPlanningService {
       account: account,
       monthlyPaymentOverrides: monthlyPaymentOverrides,
     );
-    final scheduledPayment = manualPayment ?? minimumPayment;
+    // リボ払いカードは 請求額 = 設定額 + max(0, リボ残高 − 利用限度額) で確定する。
+    // リボ残高は負債残高 (principal) を用い、手入力/推定額より優先する。
+    final revolvingConfig = _revolvingConfigFor(
+      account: account,
+      revolvingConfigs: revolvingConfigs,
+    );
+    final revolvingBilling = revolvingConfig == null
+        ? null
+        : const AssetRevolvingCreditService().computeBilling(
+            balance: principal,
+            config: revolvingConfig,
+          );
+    final scheduledPayment =
+        revolvingBilling?.billedAmount ?? manualPayment ?? minimumPayment;
     final actualPayment = _actualPaymentAmountFor(
       account: account,
       actualPaymentAmounts: actualPaymentAmounts,
@@ -623,8 +641,9 @@ class AssetLiabilityPlanningService {
       liabilityShare:
           liabilityTotal == 0 ? 0 : principal / liabilityTotal.abs(),
       priorityLabel: _priorityLabel(annualRate),
-      paymentAmountEstimated: manualPayment == null,
+      paymentAmountEstimated: revolvingBilling == null && manualPayment == null,
       fullPaymentEstimate: account.fullPaymentEstimate,
+      revolvingBilling: revolvingBilling,
       billingConfirmed: _containsAccountKey(
         billingConfirmedAccountIds,
         account,
@@ -984,6 +1003,11 @@ class AssetLiabilityPlanningService {
         0,
         (sum, line) => sum + line.amount,
       );
+      // リボ払いカードは 請求額 = 設定額 + 限度額超過分 で決まり、利用明細(新規利用)は
+      // リボ残高に積み増されるだけなので「明細合計 ≠ 請求額」が正常。一括払い前提の
+      // 不一致アラートは抑止し、内訳は revolvingBilling で表示する。
+      final revolvingBilling = billingRow?.revolvingBilling;
+      final isRevolving = revolvingBilling != null;
       final alerts = <String>[];
 
       if (billingRow == null) {
@@ -992,15 +1016,19 @@ class AssetLiabilityPlanningService {
       if (lines.isEmpty && group != null) {
         alerts.add(cardStatementMissingImportAlert);
       }
-      if (lines.isNotEmpty && _moneyDiffers(statementLineTotal, billedAmount)) {
+      if (!isRevolving &&
+          lines.isNotEmpty &&
+          _moneyDiffers(statementLineTotal, billedAmount)) {
         alerts.add(cardStatementAmountMismatchAlert);
       }
-      if (group != null &&
+      if (!isRevolving &&
+          group != null &&
           billingRow != null &&
           _moneyDiffers(configuredDetailTotal, billedAmount)) {
         alerts.add(cardStatementConfiguredMismatchAlert);
       }
-      if (lines.isNotEmpty &&
+      if (!isRevolving &&
+          lines.isNotEmpty &&
           group != null &&
           _moneyDiffers(statementLineTotal, configuredDetailTotal)) {
         alerts.add(cardStatementImportedConfiguredMismatchAlert);
@@ -1017,6 +1045,7 @@ class AssetLiabilityPlanningService {
               group?.items ?? const <AssetLiabilityCardBillingReviewItem>[],
           statementLines: lines,
           alerts: alerts,
+          revolvingBilling: revolvingBilling,
         ),
       );
     }
@@ -1748,6 +1777,19 @@ class AssetLiabilityPlanningService {
       return null;
     }
     return amount;
+  }
+
+  AssetLiabilityRevolvingCreditConfig? _revolvingConfigFor({
+    required AssetLiabilityAccount account,
+    required Map<String, AssetLiabilityRevolvingCreditConfig> revolvingConfigs,
+  }) {
+    if (revolvingConfigs.isEmpty) {
+      return null;
+    }
+    final trimmedName = account.name.trim();
+    return revolvingConfigs[account.id] ??
+        revolvingConfigs[trimmedName] ??
+        revolvingConfigs[account.name];
   }
 
   double? _actualPaymentAmountFor({

--- a/lib/services/asset_revolving_credit_config_store.dart
+++ b/lib/services/asset_revolving_credit_config_store.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/asset_liability_workbook.dart';
+
+/// リボ払いカードの設定 (リボ設定額・利用限度額) を負債IDごとに永続化する。
+///
+/// v1 はローカル (SharedPreferences) のみ。複数端末同期は支払日上書きと同じく
+/// 段階的に進めるため、Supabase ミラー化は将来の別 Issue で扱う。
+class AssetRevolvingCreditConfigStore {
+  static const String prefsKey = 'asset_revolving_credit_configs_v1';
+
+  const AssetRevolvingCreditConfigStore();
+
+  Future<Map<String, AssetLiabilityRevolvingCreditConfig>> load({
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getString(prefsKey);
+    if (raw == null || raw.isEmpty) {
+      return <String, AssetLiabilityRevolvingCreditConfig>{};
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        return <String, AssetLiabilityRevolvingCreditConfig>{};
+      }
+      final result = <String, AssetLiabilityRevolvingCreditConfig>{};
+      decoded.forEach((key, value) {
+        if (key is String && value is Map) {
+          result[key] = AssetLiabilityRevolvingCreditConfig.fromJson(
+            Map<String, dynamic>.from(value),
+          );
+        }
+      });
+      return result;
+    } catch (_) {
+      return <String, AssetLiabilityRevolvingCreditConfig>{};
+    }
+  }
+
+  Future<void> save(
+    Map<String, AssetLiabilityRevolvingCreditConfig> configs, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    if (configs.isEmpty) {
+      await store.remove(prefsKey);
+      return;
+    }
+    final encoded = jsonEncode(<String, dynamic>{
+      for (final entry in configs.entries) entry.key: entry.value.toJson(),
+    });
+    await store.setString(prefsKey, encoded);
+  }
+}

--- a/lib/services/asset_revolving_credit_service.dart
+++ b/lib/services/asset_revolving_credit_service.dart
@@ -1,0 +1,35 @@
+import '../models/asset_liability_workbook.dart';
+
+/// リボ払いカードの今月請求額を算出する純関数サービス。
+///
+/// auPAY カードなどの「あらかじめリボ」方式では、毎月の請求額は利用明細の
+/// 合計ではなく次の式で決まる:
+///
+///   請求額 = リボ設定額 + max(0, リボ残高 − 利用限度額)
+///
+/// 利用限度額の範囲内ならリボ設定額のみが請求され、限度額を超えた分だけが
+/// その月に一括で上乗せ請求される。利用明細(新規利用)はリボ残高に積み増され、
+/// その月の請求額とは直接対応しない(= 明細合計 ≠ 請求額 が正常)。
+class AssetRevolvingCreditService {
+  const AssetRevolvingCreditService();
+
+  /// [config] と現在の [balance] (リボ残高) から今月の請求内訳を算出する。
+  AssetLiabilityRevolvingCreditBilling computeBilling({
+    required double balance,
+    required AssetLiabilityRevolvingCreditConfig config,
+  }) {
+    final normalizedBalance = balance > 0 ? balance : 0.0;
+    // 利用限度額が未設定 (0以下) なら上乗せ請求なしとして設定額のみ請求する。
+    // リボ設定の入力途中で請求額が残高全額へ跳ねるのを防ぐ安全側の扱い。
+    final hasLimit = config.creditLimit > 0;
+    final overLimit = hasLimit ? normalizedBalance - config.creditLimit : 0.0;
+    final overLimitAmount = overLimit > 0 ? overLimit : 0.0;
+    return AssetLiabilityRevolvingCreditBilling(
+      balance: normalizedBalance,
+      creditLimit: config.creditLimit,
+      monthlyAmount: config.monthlyAmount,
+      overLimitAmount: overLimitAmount,
+      billedAmount: config.monthlyAmount + overLimitAmount,
+    );
+  }
+}

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -690,6 +690,66 @@ void main() {
       expect(workbook.cardBillingReview.hasDoubleCountingRisk, isFalse);
     });
 
+    test('リボ払いカードは請求額を式から算出し不一致アラートを抑止する', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'auPayカード': -530163,
+        },
+        baseDate: DateTime(2026, 6, 1),
+        revolvingConfigs: const <String, AssetLiabilityRevolvingCreditConfig>{
+          'aupay_card': AssetLiabilityRevolvingCreditConfig(
+            monthlyAmount: 10000,
+            creditLimit: 500000,
+          ),
+        },
+        cardStatementLines: const <AssetLiabilityCardStatementLine>[
+          AssetLiabilityCardStatementLine(
+            id: 'line_lemon',
+            billingAccountId: 'aupay_card',
+            billingAccountName: 'auPayカード',
+            postedAt: null,
+            description: 'レモンガス',
+            amount: 8066,
+          ),
+          AssetLiabilityCardStatementLine(
+            id: 'line_au',
+            billingAccountId: 'aupay_card',
+            billingAccountName: 'auPayカード',
+            postedAt: null,
+            description: 'au電話',
+            amount: 15116,
+          ),
+        ],
+      );
+
+      final debtRow = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == 'aupay_card',
+      );
+      // 請求額 = 設定額10000 + max(0, 530163 − 500000) = 40163。
+      expect(debtRow.scheduledPaymentAmount, 40163);
+      expect(debtRow.isRevolving, isTrue);
+      expect(debtRow.revolvingBilling!.overLimitAmount, 30163);
+      expect(debtRow.paymentAmountEstimated, isFalse);
+
+      final group = workbook.cardStatementReconciliation.groups.singleWhere(
+        (group) => group.billingAccountId == 'aupay_card',
+      );
+      expect(group.isRevolving, isTrue);
+      expect(group.billedAmount, 40163);
+      // 明細合計(新規利用) 8066 + 15116 = 23182 は請求額と一致しないが正常。
+      expect(group.statementLineTotal, 23182);
+      expect(
+        group.alerts,
+        isNot(
+          contains(
+            AssetLiabilityPlanningService.cardStatementAmountMismatchAlert,
+          ),
+        ),
+      );
+      expect(group.revolvingBilling!.billedAmount, 40163);
+    });
+
     test(
       'marks monthly and default setting sources in card billing review',
       () {

--- a/test/services/asset_revolving_credit_config_store_test.dart
+++ b/test/services/asset_revolving_credit_config_store_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AssetRevolvingCreditConfigStore', () {
+    const store = AssetRevolvingCreditConfigStore();
+
+    test('round-trips configs through SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      await store.save(
+        <String, AssetLiabilityRevolvingCreditConfig>{
+          'aupay': const AssetLiabilityRevolvingCreditConfig(
+            monthlyAmount: 10000,
+            creditLimit: 500000,
+          ),
+        },
+        prefs: prefs,
+      );
+
+      final loaded = await store.load(prefs: prefs);
+      expect(loaded.keys, ['aupay']);
+      expect(loaded['aupay']!.monthlyAmount, 10000);
+      expect(loaded['aupay']!.creditLimit, 500000);
+    });
+
+    test('returns empty map when nothing stored', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      final loaded = await store.load(prefs: prefs);
+      expect(loaded, isEmpty);
+    });
+
+    test('save with empty map clears the key', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      await store.save(
+        <String, AssetLiabilityRevolvingCreditConfig>{
+          'aupay': const AssetLiabilityRevolvingCreditConfig(
+            monthlyAmount: 10000,
+            creditLimit: 500000,
+          ),
+        },
+        prefs: prefs,
+      );
+      await store.save(
+        const <String, AssetLiabilityRevolvingCreditConfig>{},
+        prefs: prefs,
+      );
+      final loaded = await store.load(prefs: prefs);
+      expect(loaded, isEmpty);
+    });
+  });
+}

--- a/test/services/asset_revolving_credit_service_test.dart
+++ b/test/services/asset_revolving_credit_service_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_revolving_credit_service.dart';
+
+void main() {
+  group('AssetRevolvingCreditService', () {
+    const service = AssetRevolvingCreditService();
+    const config = AssetLiabilityRevolvingCreditConfig(
+      monthlyAmount: 10000,
+      creditLimit: 500000,
+    );
+
+    test('5月: 残高が限度額以内ならリボ設定額のみ請求', () {
+      final billing = service.computeBilling(balance: 459329, config: config);
+      expect(billing.overLimitAmount, 0);
+      expect(billing.billedAmount, 10000);
+      expect(billing.isOverLimit, isFalse);
+    });
+
+    test('6月: 限度額超過分が設定額に上乗せされる', () {
+      final billing = service.computeBilling(balance: 530163, config: config);
+      expect(billing.overLimitAmount, 30163);
+      expect(billing.billedAmount, 40163);
+      expect(billing.isOverLimit, isTrue);
+    });
+
+    test('7月: 別の残高でも式どおり一括上乗せ', () {
+      final billing = service.computeBilling(balance: 519843, config: config);
+      expect(billing.overLimitAmount, 19843);
+      expect(billing.billedAmount, 29843);
+    });
+
+    test('残高が限度額ちょうどなら設定額のみ', () {
+      final billing = service.computeBilling(balance: 500000, config: config);
+      expect(billing.overLimitAmount, 0);
+      expect(billing.billedAmount, 10000);
+    });
+
+    test('残高が負/ゼロでも設定額を下回らない', () {
+      final billing = service.computeBilling(balance: -1000, config: config);
+      expect(billing.balance, 0);
+      expect(billing.billedAmount, 10000);
+    });
+
+    test('利用限度額が未設定(0)なら上乗せせず設定額のみ請求', () {
+      final billing = service.computeBilling(
+        balance: 530163,
+        config: const AssetLiabilityRevolvingCreditConfig(
+          monthlyAmount: 10000,
+          creditLimit: 0,
+        ),
+      );
+      expect(billing.overLimitAmount, 0);
+      expect(billing.billedAmount, 10000);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

リボ払いカード (auPAY「あらかじめリボ」等) の今月請求額を正しくモデル化し、`資産管理闘争` ページのカード明細照合で誤発火していた「請求額・設定内訳・明細合計の三重不一致」アラートを解消します。

### 背景
auPAY カードはリボ払いで、毎月の請求額は利用明細の合計ではなく次の式で決まります:

`請求額 = リボ設定額 + max(0, リボ残高 − 利用限度額)`

- 5月: 残高 459,329 (限度額 500,000 以内) → 請求 **10,000** (設定額のみ)
- 6月: 残高 530,163 → 10,000 + (530,163−500,000) = **40,163**
- 7月: 残高 519,843 → 10,000 + (519,843−500,000) = **29,843**

従来の照合は「請求額 == 明細合計 == 設定内訳」を前提 (一括払いモデル) としていたため、リボ払いでは常に不一致アラートが誤発火していました。

### 変更点
- **`AssetRevolvingCreditService`** (新規): 請求額算出の純関数。
- **`AssetRevolvingCreditConfigStore`** (新規): リボ設定のローカル永続化 (v1)。
- **モデル**: `AssetLiabilityRevolvingCreditConfig` と `AssetLiabilityRevolvingCreditBilling` を追加し、`DebtRow` と照合グループへ請求内訳を伝搬。
- **負債マスタ UI**: 「リボ払い」トグル + リボ設定額/利用限度額の入力欄。今月支払予定額はリボ時に式から自動算出し、手入力欄を非表示。
- **カード明細照合**: リボ払いは「明細合計 ≠ 請求額」が正常なため、一括払い前提の不一致アラート3種を抑止し、請求内訳 (設定額 + 限度超過分 / 残高 / 限度額) を確認事項欄に表示。差額欄は「—」表示。

### 使い方
負債マスタで auPAY カードの「リボ払い」を ON にし、リボ設定額 (例: 10,000) と利用限度額 (例: 500,000) を入力すると、請求額が自動で 40,163 と算出され、三重不一致アラートが消えます。

Supabase 同期は支払日上書きと同じく段階導入とし、将来の別 Issue で対応します (v1 はローカル永続化)。

## Minimal E2E Gate

- **実装詳細に依存しない (black-box / 入出力)**: 請求額の算出は入出力 (残高・設定額・限度額 → 請求額) で検証し、内部実装に依存しません。
- **最小限の約3ケース (3 cases / minimal / 3件)**: 5月 (限度内=設定額のみ) / 6月 (超過=40,163) / 7月 (別残高=29,843) の3代表ケース + 限度額未設定の安全側ケース。
- **E2E メカニズム**: 公開ブラウザ E2E (Playwright / エンドツーエンド) ではなく flutter のユニット・統合・ウィジェットテストで入出力を検証。
- E2E-Exception: 内部の財務計算ロジックとフォーム入力のみで、新規ネットワーク経路やルートを追加しないため公開ブラウザ E2E は対象外。純関数単体 + 照合統合 + ページ widget smoke の計69件で入出力を担保済み。

## テスト
- `dart analyze` (変更5ファイル): No issues found。
- `flutter test test/services/`: 559 passed (リボ算出5件 + 設定永続化3件 + 照合統合1件を含む)。
- `flutter test test/widgets/asset_management_page_smoke_test.dart`: 15 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
