### PR TITLE
feat(asset): リボ払い設定を Supabase ミラー同期 (端末間同期)

### DIFF
--- a/docs/MIRROR_PREF_SCHEMA.md
+++ b/docs/MIRROR_PREF_SCHEMA.md
@@ -14,8 +14,15 @@
 | `asset_inflow_prefs_v1` | `{deleted_ids:{ids:[id]}, gc:{max_count,max_age_days}}` | 入金削除tombstone + GC設定(集約) | `_mirrorInflowPrefs` | `_pullInflowDeletedIds` / `_loadTombstoneGcConfig` |
 | `debt_payment_day_overrides` | `{debtId: day(1-31)}` | 負債ごとの支払日手動設定 | `_mirrorDebtPaymentDayOverrides` | `_restoreDebtPaymentDayOverridesFromMirror` |
 | `debt_payment_day_override_deleted` | `{ids:[debtId]}` | 支払日上書きの削除tombstone | `_mirrorDebtOverrideDeleted` | `_pullDebtOverrideDeleted` |
+| `revolving_credit_configs` | `{debtId: {monthlyAmount, creditLimit}}` | 負債(リボ払いカード)ごとのリボ設定額+利用限度額 | `_mirrorRevolvingConfigs` | `_restoreRevolvingConfigsFromMirror` |
 
 > 入金予定の実体は別テーブル `asset_expected_inflow_items`(本表の対象外)。
+
+> `revolving_credit_configs` は支払日上書きと同じく**削除トゥームストーン不要**。
+> 設定の有無は map のキー有無で表現し(リボOFF=キー削除)、空 map の upsert で
+> 全端末へ「設定なし」が伝播する。読みは集約ミラー優先・無ければローカル
+> (`asset_revolving_credit_configs_v1`)へフォールバックし、ローカルに既存設定が
+> ある端末はミラーで上書きしない(オフライン編集の握り潰し防止 / 安全側復元)。
 
 ## Legacy (読みフォールバックのみ / 書き込み停止済 / 撤去予定)
 

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -133,6 +133,12 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, dynamic>? debugDebtOverrideDeletedMirror;
 
+  /// テスト専用: リボ払い設定の集約ミラー値
+  /// (`{debtId: {monthlyAmount, creditLimit}}`) を注入し、端末間同期
+  /// (起動時のミラー復元) をネットワークなしで検証する。
+  @visibleForTesting
+  final Map<String, dynamic>? debugRevolvingConfigsMirror;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -147,6 +153,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugTombstoneGcConfig,
     this.debugSectionOverrideDeletedMirror,
     this.debugDebtOverrideDeletedMirror,
+    this.debugRevolvingConfigsMirror,
   });
 
   @override
@@ -7448,17 +7455,82 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  /// リボ設定の集約ミラー pref_key (1 行 jsonb / MIRROR_PREF_SCHEMA.md)。
+  static const String _revolvingConfigsMirrorKey = 'revolving_credit_configs';
+
   Future<void> _loadRevolvingConfigs() async {
     try {
       final configs = await _revolvingConfigStore.load();
-      if (!mounted || configs.isEmpty) {
+      if (mounted && configs.isNotEmpty) {
+        setState(() {
+          _revolvingConfigs = configs;
+        });
+      }
+    } catch (e) {
+      debugPrint('Error loading revolving credit configs: $e');
+    }
+    // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
+    await _restoreRevolvingConfigsFromMirror();
+  }
+
+  /// リボ設定を `asset_pref_mirror` (pref_key: revolving_credit_configs) へ
+  /// 1 行 upsert する (支払日上書きと同じ集約方針 / #part293-295)。
+  Future<void> _mirrorRevolvingConfigs() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _revolvingConfigsMirrorKey,
+        'value': AssetRevolvingCreditConfigStore.encodeMirrorValue(
+          _revolvingConfigs,
+        ),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('revolving config mirror upsert failed: $e');
+    }
+  }
+
+  /// サーバ集約ミラーからリボ設定を復元する (集約優先 + legacy local fallback)。
+  /// ローカルに既に設定がある場合は上書きしない (オフライン編集を握り潰さない
+  /// 安全側 / 支払日上書きの復元と同じ。削除トゥームストーンは設定の有無を
+  /// map のキー有無で表現するため不要)。
+  Future<void> _restoreRevolvingConfigsFromMirror() async {
+    final debugMirror = widget.debugRevolvingConfigsMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final Map<String, AssetLiabilityRevolvingCreditConfig> restored;
+      if (debugMirror != null) {
+        restored = AssetRevolvingCreditConfigStore.decodeMirrorValue(
+          debugMirror,
+        );
+      } else {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', _revolvingConfigsMirrorKey);
+        if (rows.isEmpty) {
+          return;
+        }
+        restored = AssetRevolvingCreditConfigStore.decodeMirrorValue(
+          rows.first['value'],
+        );
+      }
+      if (restored.isEmpty || _revolvingConfigs.isNotEmpty || !mounted) {
         return;
       }
       setState(() {
-        _revolvingConfigs = configs;
+        _revolvingConfigs = restored;
       });
+      // オフライン参照用にローカルへも書き戻す。
+      unawaited(_revolvingConfigStore.save(_revolvingConfigs));
     } catch (e) {
-      debugPrint('Error loading revolving credit configs: $e');
+      debugPrint('revolving config mirror restore failed: $e');
     }
   }
 
@@ -7478,6 +7550,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _revolvingConfigs = next;
     });
     unawaited(_revolvingConfigStore.save(_revolvingConfigs));
+    unawaited(_mirrorRevolvingConfigs());
   }
 
   void _toggleRevolving(AssetLiabilityDebtRow row, bool enabled) {

--- a/lib/services/asset_revolving_credit_config_store.dart
+++ b/lib/services/asset_revolving_credit_config_store.dart
@@ -6,8 +6,11 @@ import '../models/asset_liability_workbook.dart';
 
 /// リボ払いカードの設定 (リボ設定額・利用限度額) を負債IDごとに永続化する。
 ///
-/// v1 はローカル (SharedPreferences) のみ。複数端末同期は支払日上書きと同じく
-/// 段階的に進めるため、Supabase ミラー化は将来の別 Issue で扱う。
+/// ローカル (SharedPreferences) を一次ストアとし、端末間同期は資産管理ページが
+/// `asset_pref_mirror` (pref_key: `revolving_credit_configs`) へ 1 行 jsonb で
+/// ミラーする (支払日上書きと同じ集約方針 / MIRROR_PREF_SCHEMA.md)。
+/// [encodeMirrorValue] / [decodeMirrorValue] がローカルとミラー双方で使う
+/// 共通の往復ロジックで、保存形は `{debtId: {monthlyAmount, creditLimit}}`。
 class AssetRevolvingCreditConfigStore {
   static const String prefsKey = 'asset_revolving_credit_configs_v1';
 
@@ -22,19 +25,7 @@ class AssetRevolvingCreditConfigStore {
       return <String, AssetLiabilityRevolvingCreditConfig>{};
     }
     try {
-      final decoded = jsonDecode(raw);
-      if (decoded is! Map) {
-        return <String, AssetLiabilityRevolvingCreditConfig>{};
-      }
-      final result = <String, AssetLiabilityRevolvingCreditConfig>{};
-      decoded.forEach((key, value) {
-        if (key is String && value is Map) {
-          result[key] = AssetLiabilityRevolvingCreditConfig.fromJson(
-            Map<String, dynamic>.from(value),
-          );
-        }
-      });
-      return result;
+      return decodeMirrorValue(jsonDecode(raw));
     } catch (_) {
       return <String, AssetLiabilityRevolvingCreditConfig>{};
     }
@@ -49,9 +40,35 @@ class AssetRevolvingCreditConfigStore {
       await store.remove(prefsKey);
       return;
     }
-    final encoded = jsonEncode(<String, dynamic>{
+    await store.setString(prefsKey, jsonEncode(encodeMirrorValue(configs)));
+  }
+
+  /// 設定マップを `asset_pref_mirror.value` (jsonb) 形へ変換する。
+  /// ローカル永続化とサーバミラーで同一の `{debtId: {...}}` 形を使う。
+  static Map<String, dynamic> encodeMirrorValue(
+    Map<String, AssetLiabilityRevolvingCreditConfig> configs,
+  ) {
+    return <String, dynamic>{
       for (final entry in configs.entries) entry.key: entry.value.toJson(),
+    };
+  }
+
+  /// `asset_pref_mirror.value` (jsonb) または保存済み JSON から設定マップへ
+  /// 復元する。不正なキー/値は黙って捨てる寛容なパース (前方/後方互換)。
+  static Map<String, AssetLiabilityRevolvingCreditConfig> decodeMirrorValue(
+    dynamic value,
+  ) {
+    final result = <String, AssetLiabilityRevolvingCreditConfig>{};
+    if (value is! Map) {
+      return result;
+    }
+    value.forEach((dynamic key, dynamic raw) {
+      if (key is String && raw is Map) {
+        result[key] = AssetLiabilityRevolvingCreditConfig.fromJson(
+          Map<String, dynamic>.from(raw),
+        );
+      }
     });
-    await store.setString(prefsKey, encoded);
+    return result;
   }
 }

--- a/test/services/asset_revolving_credit_config_store_test.dart
+++ b/test/services/asset_revolving_credit_config_store_test.dart
@@ -54,5 +54,53 @@ void main() {
       final loaded = await store.load(prefs: prefs);
       expect(loaded, isEmpty);
     });
+
+    test('encode/decode mirror value round-trips (端末A→端末B 同期)', () {
+      final configs = <String, AssetLiabilityRevolvingCreditConfig>{
+        'aupay': const AssetLiabilityRevolvingCreditConfig(
+          monthlyAmount: 10000,
+          creditLimit: 500000,
+        ),
+        'rakuten': const AssetLiabilityRevolvingCreditConfig(
+          monthlyAmount: 5000,
+          creditLimit: 0,
+        ),
+      };
+
+      // encode (端末A の upload) → decode (端末B の boot 復元) で値が一致する。
+      final encoded =
+          AssetRevolvingCreditConfigStore.encodeMirrorValue(configs);
+      final decoded =
+          AssetRevolvingCreditConfigStore.decodeMirrorValue(encoded);
+
+      expect(decoded.keys, unorderedEquals(<String>['aupay', 'rakuten']));
+      expect(decoded['aupay']!.monthlyAmount, 10000);
+      expect(decoded['aupay']!.creditLimit, 500000);
+      expect(decoded['rakuten']!.monthlyAmount, 5000);
+      expect(decoded['rakuten']!.creditLimit, 0);
+    });
+
+    test('decodeMirrorValue ignores malformed input', () {
+      expect(
+        AssetRevolvingCreditConfigStore.decodeMirrorValue(null),
+        isEmpty,
+      );
+      expect(
+        AssetRevolvingCreditConfigStore.decodeMirrorValue('not a map'),
+        isEmpty,
+      );
+      // 不正な値 (Map でない) のエントリは捨て、正しいものだけ残す。
+      final decoded = AssetRevolvingCreditConfigStore.decodeMirrorValue(
+        <String, dynamic>{
+          'aupay': <String, dynamic>{
+            'monthlyAmount': 8000,
+            'creditLimit': 200000,
+          },
+          'broken': 'oops',
+        },
+      );
+      expect(decoded.keys, <String>['aupay']);
+      expect(decoded['aupay']!.monthlyAmount, 8000);
+    });
   });
 }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -3,10 +3,12 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/pages/asset_management_page.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
+import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -422,6 +424,87 @@ void main() {
       expect(repo.savedDebtOverrides, isNotNull);
       expect(repo.savedDebtOverrides!.containsKey('debt_1'), isFalse);
       expect(repo.savedDebtOverrides!['debt_2'], 5);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('revolving config syncs from server mirror on a fresh device', (
+      tester,
+    ) async {
+      // 端末A が保存したリボ設定を集約ミラー値へエンコードする(端末A の upload 相当)。
+      final mirrorValue = AssetRevolvingCreditConfigStore.encodeMirrorValue(
+        <String, AssetLiabilityRevolvingCreditConfig>{
+          'aupay': const AssetLiabilityRevolvingCreditConfig(
+            monthlyAmount: 10000,
+            creditLimit: 500000,
+          ),
+        },
+      );
+
+      // 端末B はローカル空(別ブラウザ/別ログイン)で起動する。
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugRevolvingConfigsMirror: mirrorValue,
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // 起動時にミラーから復元され、端末B のローカルにも書き戻される。
+      final synced = await const AssetRevolvingCreditConfigStore().load();
+      expect(synced.keys, contains('aupay'));
+      expect(synced['aupay']!.monthlyAmount, 10000);
+      expect(synced['aupay']!.creditLimit, 500000);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('local revolving config is not clobbered by the mirror', (
+      tester,
+    ) async {
+      // 端末B が既にローカル設定を持つ場合、ミラーは上書きしない(安全側)。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        AssetRevolvingCreditConfigStore.prefsKey: jsonEncode(
+          AssetRevolvingCreditConfigStore.encodeMirrorValue(
+            <String, AssetLiabilityRevolvingCreditConfig>{
+              'aupay': const AssetLiabilityRevolvingCreditConfig(
+                monthlyAmount: 3000,
+                creditLimit: 100000,
+              ),
+            },
+          ),
+        ),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugRevolvingConfigsMirror:
+                AssetRevolvingCreditConfigStore.encodeMirrorValue(
+              <String, AssetLiabilityRevolvingCreditConfig>{
+                'aupay': const AssetLiabilityRevolvingCreditConfig(
+                  monthlyAmount: 99999,
+                  creditLimit: 999999,
+                ),
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // ローカル値(3000)が維持され、ミラー値(99999)では上書きされない。
+      final local = await const AssetRevolvingCreditConfigStore().load();
+      expect(local['aupay']!.monthlyAmount, 3000);
 
       await _unmount(tester);
     });


### PR DESCRIPTION
## 概要

リボ払いカード設定 (リボ設定額・利用限度額) を `asset_pref_mirror` テーブル
(pref_key: `revolving_credit_configs`) 経由でサーバへ 1 行 jsonb ミラーし、別ブラウザ /
別ログインの複数端末で同期されるようにする。支払日上書き (`debt_payment_day_overrides`)
と同じ集約方針 (`docs/MIRROR_PREF_SCHEMA.md` / part293-295) に揃えた。

従来リボ設定は `AssetRevolvingCreditConfigStore` でローカル (SharedPreferences) のみに
保存され、他端末へ引き継がれなかった。

## 変更点

- **書き**: `_persistRevolvingConfig` 保存時に `_mirrorRevolvingConfigs` で 1 行 upsert。
- **読み**: 起動時 `_restoreRevolvingConfigsFromMirror` が集約ミラーを優先し、ローカルが
  空のときだけ復元する (既存ローカル設定は上書きしない安全側 / オフライン編集の握り潰し防止)。
- 削除トゥームストーンは不要 — 設定の有無は map のキー有無で表現 (リボ OFF = キー削除 → 空 map upsert)。
- `AssetRevolvingCreditConfigStore` に `encodeMirrorValue` / `decodeMirrorValue` 共通往復を抽出し、
  ローカル保存とサーバミラーで同一形 `{debtId: {monthlyAmount, creditLimit}}` を共用。
- `docs/MIRROR_PREF_SCHEMA.md` に pref_key を登録。

## テスト

ローカルで `flutter analyze` → 0 issues、対象テストすべて green:
- widget 統合テスト 2 件 (`test/widgets/asset_management_page_smoke_test.dart`):
  端末 A → 端末 B 起動時同期 / ローカル非上書き。
- store 単体テスト 2 件 (`test/services/asset_revolving_credit_config_store_test.dart`):
  encode / decode 往復 / 不正値耐性。

## Minimal E2E Gate

- 実装詳細に依存しない (black-box) 入出力契約のみを検証する: 「端末 A が保存した値を
  端末 B が起動時に受け取る」という観測可能な入出力をアサートし、内部実装には依存しない。
- 最小限 (minimal) の 3 ケース相当 — 起動時同期 / ローカル非上書き / encode-decode 往復。
- 機構: widget 統合テスト + store 単体テスト。公開サイトの Playwright / `integration_test/` の
  ブラウザ E2E は未追加。
- E2E-Exception: 端末間同期は 2 デバイス + ログイン済みセッションが前提で、公開ブラックボックス
  E2E では決定的に再現しづらいため、widget 統合テストと store 単体テストで往復を担保する。

## レビュー

- Review owner: Claude Code #1。
- High-risk-ultrareview-exception: 変更は `lib/pages` `lib/services` `test` `docs` のみで、
  認証 / 課金 / インフラ配信などの高リスクパスには触れない純粋な端末間同期の追加のため
  ultrareview 対象外とする。
