### PR TITLE
fix: リボ払いカードの参考値をAI入力の比較対象から外す (#3347/#3351 後続)

### DIFF
--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -1021,16 +1021,60 @@ class AssetManagementAiSummaryService {
   Map<String, dynamic> _cardStatementReconciliationGroupToJson(
     AssetLiabilityCardStatementReconciliationGroup group,
   ) {
-    final json = <String, dynamic>{
+    final revolving = group.revolvingBilling;
+    if (revolving != null) {
+      // リボ払い: 請求額は revolving_billing.billed_amount で確定する。設定内訳合計や
+      // 取込明細合計は請求額と比較しても無意味なため top-level の比較対象から外し、
+      // 「請求額の構成要素ではない参考値」として明示ラベル付きで渡す。
+      // (生の合計を請求額の隣に置くと AI が自前で差を取り「不一致」と誤指摘するため)
+      return <String, dynamic>{
+        'billing_account_id': group.billingAccountId,
+        'billing_account_name': group.billingAccountName,
+        'billed_amount': group.billedAmount,
+        'is_revolving': true,
+        'has_statement_lines': group.hasStatementLines,
+        'needs_review': group.needsReview,
+        'alerts': group.alerts,
+        'reconciliation_status': 'ok_revolving_no_action_needed',
+        'revolving_billing': <String, dynamic>{
+          'monthly_amount': revolving.monthlyAmount,
+          'credit_limit': revolving.creditLimit,
+          'balance': revolving.balance,
+          'over_limit_amount': revolving.overLimitAmount,
+          'billed_amount': revolving.billedAmount,
+        },
+        'reference_only_not_billed': <String, dynamic>{
+          'new_usage_this_month_total': group.statementLineTotal,
+          'debts_routed_to_card_total': group.configuredDetailTotal,
+          'note': 'これらは請求額の構成要素ではない参考値。リボ払いの請求額は '
+              'revolving_billing.billed_amount のみで確定する。これらとの差を'
+              '「不一致」「ズレ」として判断・指摘しないこと。',
+        },
+        'reconciliation_note': 'リボ払いカード。請求額=リボ設定額+max(0,リボ残高-利用限度額)で確定する。'
+            '取込明細(今月の新規利用)はリボ残高へ積み増される参考値、設定内訳は紐づけ管理用の参考値で、'
+            'いずれも請求額とは一致しないのが正常。不一致・要修正として扱わず、照合は完了とみなすこと。',
+        'configured_items':
+            group.configuredItems.map(_cardReviewItemToJson).toList(
+                  growable: false,
+                ),
+        'statement_lines':
+            group.statementLines.map(_statementLineToJson).toList(
+                  growable: false,
+                ),
+      };
+    }
+    return <String, dynamic>{
       'billing_account_id': group.billingAccountId,
       'billing_account_name': group.billingAccountName,
       'billed_amount': group.billedAmount,
       'configured_detail_total': group.configuredDetailTotal,
       'statement_line_total': group.statementLineTotal,
+      'configured_difference': group.configuredDifference,
+      'statement_difference': group.statementDifference,
       'has_statement_lines': group.hasStatementLines,
       'needs_review': group.needsReview,
       'alerts': group.alerts,
-      'is_revolving': group.isRevolving,
+      'is_revolving': false,
       'configured_items':
           group.configuredItems.map(_cardReviewItemToJson).toList(
                 growable: false,
@@ -1039,25 +1083,6 @@ class AssetManagementAiSummaryService {
             growable: false,
           ),
     };
-    final revolving = group.revolvingBilling;
-    if (revolving != null) {
-      // リボ払いは 請求額 = 設定額 + 限度超過分 で確定し、明細合計との差は不一致ではない。
-      // 誤解を招く configured_difference/statement_difference は渡さず、内訳と注記を渡す。
-      json['revolving_billing'] = <String, dynamic>{
-        'monthly_amount': revolving.monthlyAmount,
-        'credit_limit': revolving.creditLimit,
-        'balance': revolving.balance,
-        'over_limit_amount': revolving.overLimitAmount,
-        'billed_amount': revolving.billedAmount,
-      };
-      json['reconciliation_note'] = 'リボ払いカード。請求額=リボ設定額+max(0,リボ残高-利用限度額)で確定する。'
-          '取込明細(今月の新規利用)はリボ残高に積み増されるだけで請求額とは一致しないのが正常。'
-          '設定内訳合計や明細合計との差は不一致ではなく、是正・指摘の対象外。';
-    } else {
-      json['configured_difference'] = group.configuredDifference;
-      json['statement_difference'] = group.statementDifference;
-    }
-    return json;
   }
 
   Map<String, dynamic> _statementLineToJson(

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -306,9 +306,14 @@ void main() {
       expect(encoded.contains('is_revolving'), true);
       expect(encoded.contains('revolving_billing'), true);
       expect(encoded.contains('reconciliation_note'), true);
-      // リボ払いでは明細合計との差は不一致ではないため、誤解を招く差分は渡さない。
+      expect(encoded.contains('reference_only_not_billed'), true);
+      expect(encoded.contains('ok_revolving_no_action_needed'), true);
+      // リボ払いでは比較対象になる生の合計・差分を top-level に置かない
+      // (AI が請求額の隣で差を取り「不一致」と誤指摘するのを防ぐ)。
       expect(encoded.contains('configured_difference'), false);
       expect(encoded.contains('statement_difference'), false);
+      expect(encoded.contains('configured_detail_total'), false);
+      expect(encoded.contains('statement_line_total'), false);
     });
 
     test('falls back to deterministic text when ai-hub fails', () async {


### PR DESCRIPTION
## 概要

[PR #3347](https://github.com/kanta13jp1/my_web_app/pull/3347) / [#3351](https://github.com/kanta13jp1/my_web_app/pull/3351) の後続(第3段)。リボ払いの auPAY カードについて、AI資産管理アシスタントが「請求14,727円なのに内包32,152円・取込明細23,182円でズレている」と誤って指摘し続ける問題を解消します。

### 背景
リボ払いの請求額は `リボ設定額 + max(0, リボ残高 − 利用限度額)` で確定し、設定内訳合計や取込明細合計とは一致しないのが正常です。#3351 で差分フィールドは外しましたが、**生の設定内訳合計(32,152)・取込明細合計(23,182)が請求額(14,727)の隣に残っていた**ため、AIが自前で差を取り「不一致」と指摘し続けていました。

### 変更点
- リボ払いグループは AI 入力の top-level から `configured_detail_total` / `statement_line_total` を外し、`reference_only_not_billed`(「請求額の構成要素ではない参考値」+「差を不一致と判断しない」注記)へ移動。
- `reconciliation_status: ok_revolving_no_action_needed` を追加。
- 単体テストを強化(生の合計が top-level に出ないことを検証)。

### 結果
auPAY をリボ払い設定にすれば、AI が照合不一致を指摘しなくなります。請求額(リボ確定額)のみが top-level に残り、参考値は明示ラベル下に分離されます。

## Minimal E2E Gate

- **実装詳細に依存しない (black-box / 入出力)**: AI へ渡す入出力(リボ払いグループ → 生の比較合計を top-level に含めず参考ラベル下へ)で検証。
- **最小限の約3ケース (3 cases / minimal / 3件)**: リボ=参考ラベルあり/比較合計なし、非リボ=従来どおり、の代表ケースを単体テストで担保。
- **E2E メカニズム**: 公開ブラウザ E2E (Playwright / エンドツーエンド) ではなく flutter のユニットテストで入出力を検証。
- E2E-Exception: AI へ渡すデータ構造の調整のみで画面遷移や新規ネットワーク経路を追加しないため公開ブラウザ E2E は対象外。ペイロード単体テストで入出力を担保済み。

## テスト
- `dart analyze`: No issues found。
- `flutter test test/services/asset_management_ai_summary_service_test.dart`: 19 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
