### PR TITLE
fix: AI要約のトークン上限を24,000へ引き上げ (Gemini thinking 枯渇対策)

### DIFF
--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -64,9 +64,11 @@ class AssetManagementAiProposalExtraction {
 
 class AssetManagementAiSummaryService {
   // GPT-5 の reasoning トークンや Gemini の thinking トークンも
-  // この上限を消費するため、本文 (約3,000トークン) に思考分の余裕を足す。
-  // 3,200 では Gemini 3.1 Pro が本文出力前に MAX_TOKENS で途中終了した。
-  static const int _summaryMaxTokens = 8000;
+  // この上限 (maxOutputTokens) を消費するため、本文 (約3,000-4,000トークン) に
+  // 思考分の余裕を大きく足す。3,200→8,000 でも Gemini 3.1 Pro が thinking で
+  // 食い切り、本文出力前に MAX_TOKENS (outputLengthLimited) で途中終了したため、
+  // 24,000 へ引き上げる (思考に約20,000確保しても本文が収まる)。
+  static const int _summaryMaxTokens = 24000;
 
   final bool _aiEnabled;
   final AiHubChatService _chatService;

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -58,7 +58,7 @@ void main() {
       expect(result.text, 'AIが生成した日本語要約です。');
       expect(capturedBody?['action'], 'provider.chat_auto');
       expect(capturedBody?['tier'], 'performance');
-      expect(capturedBody?['max_tokens'], 8000);
+      expect(capturedBody?['max_tokens'], 24000);
       expect(capturedBody?['trace_id'], 'asset-management-ai-summary');
       expect(
         capturedBody?['message'].toString().contains('AIに渡す詳細ペイロード'),
@@ -184,7 +184,7 @@ void main() {
         expect(calls.single['action'], 'provider.chat');
         expect(calls.single['provider'], 'anthropic');
         expect(calls.single['model'], 'claude-opus-4-7');
-        expect(calls.single['max_tokens'], 8000);
+        expect(calls.single['max_tokens'], 24000);
         expect(calls.single['routing_use_case'], 'summary');
         expect(
           calls.single['provider_choice_reason'],
@@ -331,6 +331,35 @@ void main() {
       expect(result.usedExternalAi, false);
       expect(result.errorMessage?.contains('boom'), true);
       expect(result.text.contains('Dartルール'), true);
+    });
+
+    test('routed summary passes a generous token budget for thinking models',
+        () async {
+      int? capturedMaxTokens;
+      final chatService = AiHubChatService(
+        invoker: (body) async {
+          capturedMaxTokens = body['max_tokens'] as int?;
+          return <String, dynamic>{
+            'success': true,
+            'text': 'これはAI要約のテスト本文です。',
+            'provider': 'anthropic',
+          };
+        },
+      );
+      final service = AssetManagementAiSummaryService(
+        aiEnabled: true,
+        chatService: chatService,
+        providerRouter: const AssetManagementAiProviderRouter(
+          routingEnabled: true,
+        ),
+        now: () => DateTime(2026, 6, 1, 12),
+      );
+
+      await service.generateSummary(report: _report());
+
+      // Gemini 3.1 Pro 等の thinking トークン + 長文要約に耐える予算であること。
+      expect(capturedMaxTokens, isNotNull);
+      expect(capturedMaxTokens! >= 16000, isTrue);
     });
 
     test('builds payload from calculated insights only', () {


### PR DESCRIPTION
## 概要

AI資産管理アシスタントが Gemini 3.1 Pro に到達しても「定型要約 / outputLengthLimited」になる問題を解消します([#3360](https://github.com/kanta13jp1/my_web_app/pull/3360) のプロバイダ・フォールバック復旧で Gemini へ到達できるようになった後に判明)。

### 原因
Gemini 3.1 Pro は thinking 分も `maxOutputTokens` を消費します。上限が 8,000 だったため、長文の8セクション要約を出力する前に thinking で枠を食い切り、`finish_reason: MAX_TOKENS`(本文が空)で途中終了していました。Edge Function は client の上限をそのまま Gemini の `maxOutputTokens` に渡すため、client 側の上限が効きます。

### 変更点
- `_summaryMaxTokens` を 8,000 → **24,000** へ引き上げ(thinking に約20,000確保しても本文約3,000-4,000が収まる)。
- 既存テストの期待値を更新 + 予算が provider 呼び出しへ伝播することを検証する単体テストを追加。

### 補足
上限引き上げは安全側(出力上限は大きくしても壊れない)で、Edge Function 改変なし。プロバイダ毎クールダウン(#3360)により、Gemini の `outputLengthLimited`(クォータ系ではない)は再試行をブロックしません。

## Minimal E2E Gate

- **実装詳細に依存しない (black-box / 入出力)**: 入力(要約生成)→出力(provider 呼び出しに渡る上限が thinking モデルに十分大きい)で検証。
- **最小限の約3ケース (3 cases / minimal / 3件)**: routed 経路で上限が伝播 / auto 経路で伝播 / 上限値が閾値以上、の代表ケースを単体テストで担保。
- **E2E メカニズム**: 公開ブラウザ E2E (Playwright / エンドツーエンド) ではなく flutter のユニットテストで入出力を検証。
- E2E-Exception: 出力上限値のチューニングと伝播確認のみで、画面遷移や新規ネットワーク経路を追加しないため公開ブラウザ E2E は対象外。単体テストで伝播を担保済み。

## テスト
- `dart analyze`: No issues found。
- `flutter test test/services/asset_management_ai_summary_service_test.dart`: 20 passed(伝播検証の新規テストを含む)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
