### PR TITLE
feat(asset): 入金実体upsertのバッチ化 + boot prune件数ログ (part 297)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -8220,19 +8220,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         setState(() {
           _expectedInflowRules = rules;
         });
-        for (final rule in rules) {
-          if (!beforeRuleIds.contains(rule.id)) {
-            unawaited(
-              _mirrorInflowToSupabase(<String, dynamic>{
-                'id': rule.id,
-                'kind': 'rule',
-                'day_of_month': rule.dayOfMonth,
-                'amount': rule.amount,
-                'label': rule.label,
-              }),
-            );
-          }
-        }
+        unawaited(
+          _mirrorInflowsToSupabase(<Map<String, dynamic>>[
+            for (final rule in rules)
+              if (!beforeRuleIds.contains(rule.id))
+                <String, dynamic>{
+                  'id': rule.id,
+                  'kind': 'rule',
+                  'day_of_month': rule.dayOfMonth,
+                  'amount': rule.amount,
+                  'label': rule.label,
+                },
+          ]),
+        );
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('毎月${selectedDate.day}日の入金予定を登録しました')),
         );
@@ -8250,19 +8250,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       setState(() {
         _expectedInflows = entries;
       });
-      for (final entry in entries) {
-        if (!beforeIds.contains(entry.id)) {
-          unawaited(
-            _mirrorInflowToSupabase(<String, dynamic>{
-              'id': entry.id,
-              'kind': 'one_time',
-              'date': DateFormat('yyyy-MM-dd').format(entry.date),
-              'amount': entry.amount,
-              'label': entry.label,
-            }),
-          );
-        }
-      }
+      unawaited(
+        _mirrorInflowsToSupabase(<Map<String, dynamic>>[
+          for (final entry in entries)
+            if (!beforeIds.contains(entry.id))
+              <String, dynamic>{
+                'id': entry.id,
+                'kind': 'one_time',
+                'date': DateFormat('yyyy-MM-dd').format(entry.date),
+                'amount': entry.amount,
+                'label': entry.label,
+              },
+        ]),
+      );
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('入金予定を追加しました。見込み残高に反映されます')));
@@ -8351,7 +8351,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
-  Future<void> _mirrorInflowToSupabase(Map<String, dynamic> row) async {
+  /// 複数の入金実体行を 1 回の upsert でまとめてミラーする (#part297 バッチ化)。
+  /// 行ごとに upsert を呼ぶと N 往復になるため、追加分はまとめて送る。
+  Future<void> _mirrorInflowsToSupabase(List<Map<String, dynamic>> rows) async {
+    if (rows.isEmpty) {
+      return;
+    }
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
       return;
@@ -8359,7 +8364,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     try {
       await _supabase
           .from('asset_expected_inflow_items')
-          .upsert(<String, dynamic>{...row, 'user_id': userId});
+          .upsert(<Map<String, dynamic>>[
+        for (final row in rows) <String, dynamic>{...row, 'user_id': userId},
+      ]);
     } catch (e) {
       debugPrint('inflow mirror upsert failed: $e');
     }
@@ -8717,24 +8724,38 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('古い削除記録を$removed件 掃除しました')),
+      SnackBar(content: Text('古い削除記録を${removed.total}件 掃除しました')),
     );
   }
 
-  /// 3 ドメインのトゥームストーンを掃除し、合算した削除件数を返す。
-  Future<int> _pruneAllTombstones() async {
+  /// 3 ドメインのトゥームストーンを掃除し、ドメイン別の削除件数を返す。
+  Future<({int inflow, int override, int debt, int total})>
+      _pruneAllTombstones() async {
     final store = await SharedPreferences.getInstance();
-    final removedInflow = await _expectedInflowStore.pruneDeletedIds();
-    final removedOverride = await _displayModeStore.pruneDeletedSectionIds();
-    final removedDebt = await _debtOverrideTombstones.prune(store);
-    return removedInflow + removedOverride + removedDebt;
+    final inflow = await _expectedInflowStore.pruneDeletedIds();
+    final override = await _displayModeStore.pruneDeletedSectionIds();
+    final debt = await _debtOverrideTombstones.prune(store);
+    return (
+      inflow: inflow,
+      override: override,
+      debt: debt,
+      total: inflow + override + debt,
+    );
   }
 
   /// boot 時に期限切れ・上限超過のトゥームストーンを自動で掃除する
-  /// (SharedPreferences 肥大化の自動抑制 / #part296)。UI 通知はしない。
+  /// (SharedPreferences 肥大化の自動抑制 / #part296)。UI 通知はせず、
+  /// 掃除件数を debug ログに出して肥大化を観測する (#part297)。
   Future<void> _pruneTombstonesOnBoot() async {
     try {
-      await _pruneAllTombstones();
+      final removed = await _pruneAllTombstones();
+      if (removed.total > 0) {
+        debugPrint(
+          'boot tombstone prune: removed ${removed.total} '
+          '(inflow=${removed.inflow} override=${removed.override} '
+          'debt=${removed.debt})',
+        );
+      }
     } catch (e) {
       debugPrint('boot tombstone prune failed: $e');
     }


### PR DESCRIPTION
## 概要

part 296 の次回候補 4 件のうち、安全に実施できる 2 件を実装。残り 2 件は前提未達/
自動化不可のため**本 PR では実施せず理由を明記**。

### 実施した 2 件

2. **入金実体 `asset_expected_inflow_items` の upsert バッチ化** — 入金予定/ルール追加時に
   新規行を**行ごと upsert(N 往復)**していたのを、追加分をまとめて **1 回の upsert**
   (`_mirrorInflowsToSupabase`)へ集約。単体 `_mirrorInflowToSupabase` は廃止し全呼び出しを
   バッチ経路へ統一(挙動は不変・送信回数のみ削減)。
3. **boot 自動 prune の削除件数を観測ログへ** — boot 自動 prune の結果を debug ログに出力
   (inflow / override / debt のドメイン別件数 + 合計)。`_pruneAllTombstones` をドメイン別件数を
   返す record へ変更し、手動「今すぐ掃除」と共用。肥大化の傾向を観測可能にした。

### 本 PR で実施しなかった 2 件(理由)

1. **Phase 3(legacy 読みフォールバック撤去)** — 前提未達のため**見送り**。撤去条件は
   「2026-07-11 以降 + 本番 legacy 行残存ゼロの SQL 確認」。本日は 2026-06-14 で日付未到来、
   かつ残存確認は本番 DB へのオペレータ実行が必要。早期撤去は旧クライアントのデータ不読を
   招くため実施しない(条件・SQL は migration doc 記載済)。
4. **a11y 実機 AT(NVDA/VoiceOver/TalkBack)** — 実読み上げ音声の確認は自動化不可・リポジトリ
   からは実行できない。担当者の実機実施待ち(手順・合否基準・記入欄は整備済)。

## Minimal E2E Gate

- テストは**実装詳細に依存しない入出力(black-box)契約**で記述。変更は入金実体ミラーの送信回数
  最適化(挙動不変)+ boot prune の観測ログのみで、UI 契約・保存内容・削除伝播の挙動は不変。
  既存の widget/サービステスト(削除伝播・boot prune 物理削除・入金チップ表示等)の I/O 契約が
  回帰なく通ることで担保。核は最小限の 3ケース相当(追加→1回upsert / boot prune 物理削除 /
  削除伝播)。全体で flutter test 768 ケース。
- E2E例外: 追加 UI なし。バッチ upsert は同一行を 1 回で送るだけ、prune ログは debug 出力のみ。
  本番疎通は既存 Playwright smoke で補完。
- 検証実績(ローカル worktree): `dart format` 差分0 / `dart analyze` **No issues found** /
  `python scripts/check_duplicate_dispose.py` **CLEAN** / `flutter test` **768/768 PASS**。
  compare diff-stat ゲート確認済み(+58 -37 / 1 file / 想定外削除なし=ループ→集約式の置換分)。

## High-risk gate

- High-risk-ultrareview-exception: migration・RLS・認証・課金ロジックへの変更なし。
  `asset_expected_inflow_items` への upsert は従来と同一行を 1 回にまとめるのみ(列・値は不変)。
  レビュー所有者: Claude Code #1。
- 自己点検メモ: rollback = 本 PR revert で完結(バッチ化は送信回数のみ・行内容不変 / prune ログは
  debugPrint のみ)。Phase 3 は意図的に未実施でデータ後方互換を維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
