### PR TITLE
feat(asset): メイン口座とウォッチリストも Supabase ミラー同期 (端末間同期)

### DIFF
--- a/docs/MIRROR_PREF_SCHEMA.md
+++ b/docs/MIRROR_PREF_SCHEMA.md
@@ -15,8 +15,19 @@
 | `debt_payment_day_overrides` | `{debtId: day(1-31)}` | 負債ごとの支払日手動設定 | `_mirrorDebtPaymentDayOverrides` | `_restoreDebtPaymentDayOverridesFromMirror` |
 | `debt_payment_day_override_deleted` | `{ids:[debtId]}` | 支払日上書きの削除tombstone | `_mirrorDebtOverrideDeleted` | `_pullDebtOverrideDeleted` |
 | `revolving_credit_configs` | `{debtId: {monthlyAmount, creditLimit}}` | 負債(リボ払いカード)ごとのリボ設定額+利用限度額 | `_mirrorRevolvingConfigs` | `_restoreRevolvingConfigsFromMirror` |
+| `main_account_id` | `{id: '<accountId>'}` | 使用可能額の基準となるメインバンク口座ID | `_mirrorMainAccount` | `_restoreMainAccountFromMirror` |
+| `watchlist_entries` | `{entries: [{assetType, group, memo, addedAt}]}` | ウォッチリスト項目(注目資産+グループ+メモ) | `_mirrorWatchlist` | `_restoreWatchlistFromMirror` |
 
 > 入金予定の実体は別テーブル `asset_expected_inflow_items`(本表の対象外)。
+
+> `main_account_id` / `watchlist_entries` も削除トゥームストーン不要(スカラ/全件置換)。
+> 読みは集約ミラー優先・無ければローカル(`asset_management_main_account_id_v1` /
+> `asset_watchlist_entries_v1`)へフォールバックし、ローカルに既存値がある端末は
+> ミラーで上書きしない(安全側復元)。メイン口座は `{id:''}`、ウォッチリストは空
+> `entries` の upsert で「未設定/全削除」を全端末へ伝播する。
+> なお表示モードの実験ログ(`display_mode_events` テーブル)と復元辞退フラグ
+> (`asset_management_restore_declined_v1`)は意図的に端末ローカルのまま
+> (前者は専用サーバテーブルへ別途記録済 / 後者は端末ごとの UX 状態)。
 
 > `revolving_credit_configs` は支払日上書きと同じく**削除トゥームストーン不要**。
 > 設定の有無は map のキー有無で表現し(リボOFF=キー削除)、空 map の upsert で

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -139,6 +139,16 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, dynamic>? debugRevolvingConfigsMirror;
 
+  /// テスト専用: メイン口座IDの集約ミラー値 (`{'id': '...'}`) を注入し、
+  /// 端末間同期 (起動時のミラー復元) をネットワークなしで検証する。
+  @visibleForTesting
+  final Map<String, dynamic>? debugMainAccountMirror;
+
+  /// テスト専用: ウォッチリストの集約ミラー値 (`{'entries': [...]}`) を注入し、
+  /// 端末間同期 (起動時のミラー復元) をネットワークなしで検証する。
+  @visibleForTesting
+  final Map<String, dynamic>? debugWatchlistMirror;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -154,6 +164,8 @@ class AssetManagementPage extends StatefulWidget {
     this.debugSectionOverrideDeletedMirror,
     this.debugDebtOverrideDeletedMirror,
     this.debugRevolvingConfigsMirror,
+    this.debugMainAccountMirror,
+    this.debugWatchlistMirror,
   });
 
   @override
@@ -5124,12 +5136,77 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return entries;
   }
 
+  /// ウォッチリストの集約ミラー pref_key (1 行 jsonb / MIRROR_PREF_SCHEMA.md)。
+  static const String _watchlistMirrorKey = 'watchlist_entries';
+
   Future<void> _loadWatchlistEntries() async {
     final entries = await widget.watchlistService.loadEntries();
-    if (!mounted) return;
-    setState(() {
-      _setWatchlistEntries(entries);
-    });
+    if (mounted) {
+      setState(() {
+        _setWatchlistEntries(entries);
+      });
+    }
+    // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
+    await _restoreWatchlistFromMirror();
+  }
+
+  /// ウォッチリストを `asset_pref_mirror` (pref_key: watchlist_entries) へ
+  /// 1 行 upsert する (リボ設定と同じ集約方針 / #3352)。
+  Future<void> _mirrorWatchlist() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _watchlistMirrorKey,
+        'value': AssetWatchlistService.encodeMirrorValue(
+          _watchlistByType.values.toList(),
+        ),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('watchlist mirror upsert failed: $e');
+    }
+  }
+
+  /// サーバ集約ミラーからウォッチリストを復元する (集約優先 + legacy local fallback)。
+  /// ローカルに既に項目がある場合は上書きしない (オフライン編集を握り潰さない安全側)。
+  Future<void> _restoreWatchlistFromMirror() async {
+    final debugMirror = widget.debugWatchlistMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    if (_watchlistByType.isNotEmpty) {
+      return;
+    }
+    try {
+      final dynamic value;
+      if (debugMirror != null) {
+        value = debugMirror;
+      } else {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', _watchlistMirrorKey);
+        if (rows.isEmpty) {
+          return;
+        }
+        value = rows.first['value'];
+      }
+      final restored = AssetWatchlistService.decodeMirrorValue(value);
+      if (restored.isEmpty || _watchlistByType.isNotEmpty || !mounted) {
+        return;
+      }
+      setState(() {
+        _setWatchlistEntries(restored);
+      });
+      // オフライン参照用にローカルへも書き戻す。
+      unawaited(widget.watchlistService.replaceAll(restored));
+    } catch (e) {
+      debugPrint('watchlist mirror restore failed: $e');
+    }
   }
 
   void _jumpToAssetType(String type) {
@@ -5198,6 +5275,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   setState(() {
                     _setWatchlistEntries(entries);
                   });
+                  unawaited(_mirrorWatchlist());
                   if (dialogContext.mounted) {
                     Navigator.of(dialogContext).pop();
                   }
@@ -5225,6 +5303,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 setState(() {
                   _setWatchlistEntries(entries);
                 });
+                unawaited(_mirrorWatchlist());
                 if (dialogContext.mounted) {
                   Navigator.of(dialogContext).pop();
                 }
@@ -5560,6 +5639,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   _sortAssetTypes(); // ★ 削除時にも並び替え
                   _updateChartData();
                 });
+                unawaited(_mirrorWatchlist());
               }
               if (context.mounted) Navigator.pop(context);
             },
@@ -7430,17 +7510,82 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  /// メイン口座IDの集約ミラー pref_key (1 行 jsonb / MIRROR_PREF_SCHEMA.md)。
+  static const String _mainAccountMirrorKey = 'main_account_id';
+
   Future<void> _loadMainAccount() async {
     try {
       final id = await _mainAccountStore.load();
-      if (!mounted || id == _assetManagementMainAccountId) {
+      if (mounted && id != _assetManagementMainAccountId) {
+        setState(() {
+          _assetManagementMainAccountId = id;
+        });
+      }
+    } catch (e) {
+      debugPrint('Error loading main account: $e');
+    }
+    // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
+    await _restoreMainAccountFromMirror();
+  }
+
+  /// メイン口座IDを `asset_pref_mirror` (pref_key: main_account_id) へ
+  /// 1 行 upsert する (リボ設定と同じ集約方針 / #3352)。
+  Future<void> _mirrorMainAccount() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _mainAccountMirrorKey,
+        'value': AssetManagementMainAccountStore.encodeMirrorValue(
+          _assetManagementMainAccountId,
+        ),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('main account mirror upsert failed: $e');
+    }
+  }
+
+  /// サーバ集約ミラーからメイン口座IDを復元する (集約優先 + legacy local fallback)。
+  /// ローカルに既に設定がある場合は上書きしない (オフライン編集を握り潰さない安全側)。
+  Future<void> _restoreMainAccountFromMirror() async {
+    final debugMirror = widget.debugMainAccountMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    if (_assetManagementMainAccountId != null) {
+      return;
+    }
+    try {
+      final dynamic value;
+      if (debugMirror != null) {
+        value = debugMirror;
+      } else {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', _mainAccountMirrorKey);
+        if (rows.isEmpty) {
+          return;
+        }
+        value = rows.first['value'];
+      }
+      final restored = AssetManagementMainAccountStore.decodeMirrorValue(value);
+      if (restored == null ||
+          _assetManagementMainAccountId != null ||
+          !mounted) {
         return;
       }
       setState(() {
-        _assetManagementMainAccountId = id;
+        _assetManagementMainAccountId = restored;
       });
+      // オフライン参照用にローカルへも書き戻す。
+      unawaited(_mainAccountStore.save(restored));
     } catch (e) {
-      debugPrint('Error loading main account: $e');
+      debugPrint('main account mirror restore failed: $e');
     }
   }
 
@@ -7453,6 +7598,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('Error saving main account: $e');
     }
+    unawaited(_mirrorMainAccount());
   }
 
   /// リボ設定の集約ミラー pref_key (1 行 jsonb / MIRROR_PREF_SCHEMA.md)。

--- a/lib/services/asset_management_main_account_store.dart
+++ b/lib/services/asset_management_main_account_store.dart
@@ -2,6 +2,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 /// 使用可能額の基準となる「メインバンク」口座IDを永続化する。
 /// 未設定なら null を返し、計算側で既定(残高最大の預金口座)を使う。
+///
+/// ローカル (SharedPreferences) を一次ストアとし、端末間同期は資産管理ページが
+/// `asset_pref_mirror` (pref_key: `main_account_id`) へ 1 行 jsonb でミラーする
+/// (リボ設定と同じ集約方針 / MIRROR_PREF_SCHEMA.md)。
+/// [encodeMirrorValue] / [decodeMirrorValue] がその往復を担う。
 class AssetManagementMainAccountStore {
   static const String prefsKey = 'asset_management_main_account_id_v1';
 
@@ -21,5 +26,25 @@ class AssetManagementMainAccountStore {
       return;
     }
     await store.setString(prefsKey, value);
+  }
+
+  /// メイン口座IDを `asset_pref_mirror.value` (jsonb) 形へ変換する。
+  /// 未設定は空文字 (= 全端末へ「未設定」を伝播)。
+  static Map<String, dynamic> encodeMirrorValue(String? accountId) {
+    return <String, dynamic>{'id': accountId?.trim() ?? ''};
+  }
+
+  /// `asset_pref_mirror.value` (jsonb) からメイン口座IDを復元する。
+  /// 空文字・不正値は null (未設定) とみなす。
+  static String? decodeMirrorValue(dynamic value) {
+    if (value is! Map) {
+      return null;
+    }
+    final raw = value['id'];
+    if (raw is! String) {
+      return null;
+    }
+    final trimmed = raw.trim();
+    return trimmed.isEmpty ? null : trimmed;
   }
 }

--- a/lib/services/asset_watchlist_service.dart
+++ b/lib/services/asset_watchlist_service.dart
@@ -49,6 +49,13 @@ class AssetWatchlistEntry {
   }
 }
 
+/// ウォッチリスト項目を永続化する。
+///
+/// ローカル (SharedPreferences) を一次ストアとし、端末間同期は資産管理ページが
+/// `asset_pref_mirror` (pref_key: `watchlist_entries`) へ 1 行 jsonb でミラーする
+/// (リボ設定と同じ集約方針 / MIRROR_PREF_SCHEMA.md)。
+/// [encodeMirrorValue] / [decodeMirrorValue] がその往復、[replaceAll] が
+/// ミラー復元時の一括ローカル書き戻しを担う。
 class AssetWatchlistService {
   static const String _storageKey = 'asset_watchlist_entries_v1';
 
@@ -118,6 +125,14 @@ class AssetWatchlistService {
     return _persistEntries(next, prefs: prefs);
   }
 
+  /// 全件を一括で置き換えて永続化する (ミラー復元時のローカル書き戻し用)。
+  Future<List<AssetWatchlistEntry>> replaceAll(
+    List<AssetWatchlistEntry> entries, {
+    SharedPreferences? prefs,
+  }) async {
+    return _persistEntries(entries, prefs: prefs);
+  }
+
   Future<List<AssetWatchlistEntry>> _persistEntries(
     List<AssetWatchlistEntry> entries, {
     SharedPreferences? prefs,
@@ -129,6 +144,42 @@ class AssetWatchlistService {
     );
     await store.setString(_storageKey, encoded);
     return sorted;
+  }
+
+  /// ウォッチリストを `asset_pref_mirror.value` (jsonb) 形へ変換する
+  /// (`{entries: [...]}`)。
+  static Map<String, dynamic> encodeMirrorValue(
+    List<AssetWatchlistEntry> entries,
+  ) {
+    return <String, dynamic>{
+      'entries': entries.map((entry) => entry.toJson()).toList(),
+    };
+  }
+
+  /// `asset_pref_mirror.value` (jsonb) からウォッチリストを復元する。
+  /// 不正な要素・assetType 空は捨てる寛容なパース (前方/後方互換)。
+  static List<AssetWatchlistEntry> decodeMirrorValue(dynamic value) {
+    if (value is! Map) {
+      return const <AssetWatchlistEntry>[];
+    }
+    final rawEntries = value['entries'];
+    if (rawEntries is! List) {
+      return const <AssetWatchlistEntry>[];
+    }
+    final entries = <AssetWatchlistEntry>[];
+    for (final item in rawEntries) {
+      if (item is! Map) {
+        continue;
+      }
+      final entry = AssetWatchlistEntry.fromJson(
+        Map<String, dynamic>.from(item),
+      );
+      if (entry.assetType.isEmpty) {
+        continue;
+      }
+      entries.add(entry);
+    }
+    return entries;
   }
 
   List<AssetWatchlistEntry> _sortEntries(List<AssetWatchlistEntry> entries) {

--- a/test/services/asset_management_main_account_store_test.dart
+++ b/test/services/asset_management_main_account_store_test.dart
@@ -28,5 +28,43 @@ void main() {
       await store.save('   ');
       expect(await store.load(), isNull);
     });
+
+    test('encode/decode mirror value round-trips (端末A→端末B 同期)', () {
+      final encoded = AssetManagementMainAccountStore.encodeMirrorValue(
+        'smbc_otsuka',
+      );
+      expect(encoded, <String, dynamic>{'id': 'smbc_otsuka'});
+      expect(
+        AssetManagementMainAccountStore.decodeMirrorValue(encoded),
+        'smbc_otsuka',
+      );
+    });
+
+    test('encodeMirrorValue of null is empty id (未設定を全端末へ伝播)', () {
+      expect(
+        AssetManagementMainAccountStore.encodeMirrorValue(null),
+        <String, dynamic>{'id': ''},
+      );
+    });
+
+    test('decodeMirrorValue treats empty/invalid as null', () {
+      expect(
+        AssetManagementMainAccountStore.decodeMirrorValue(
+          <String, dynamic>{'id': ''},
+        ),
+        isNull,
+      );
+      expect(
+        AssetManagementMainAccountStore.decodeMirrorValue(
+          <String, dynamic>{'id': '   '},
+        ),
+        isNull,
+      );
+      expect(AssetManagementMainAccountStore.decodeMirrorValue(null), isNull);
+      expect(
+        AssetManagementMainAccountStore.decodeMirrorValue('not a map'),
+        isNull,
+      );
+    });
   });
 }

--- a/test/services/asset_watchlist_service_test.dart
+++ b/test/services/asset_watchlist_service_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_watchlist_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('AssetWatchlistService', () {
+    const service = AssetWatchlistService();
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('saves, loads and replaceAll clears entries', () async {
+      await service.saveEntry(
+        AssetWatchlistEntry(
+          assetType: 'gold',
+          group: 'invest',
+          memo: 'hedge',
+          addedAt: DateTime.utc(2026, 6, 14),
+        ),
+      );
+      final loaded = await service.loadEntries();
+      expect(loaded.map((e) => e.assetType), <String>['gold']);
+
+      await service.replaceAll(const <AssetWatchlistEntry>[]);
+      expect(await service.loadEntries(), isEmpty);
+    });
+
+    test('encode/decode mirror value round-trips (端末A→端末B 同期)', () {
+      final entries = <AssetWatchlistEntry>[
+        AssetWatchlistEntry(
+          assetType: 'gold',
+          group: 'invest',
+          memo: 'hedge',
+          addedAt: DateTime.utc(2026, 6, 14),
+        ),
+        AssetWatchlistEntry(
+          assetType: 'btc',
+          group: '',
+          memo: '',
+          addedAt: DateTime.utc(2026, 1, 1),
+        ),
+      ];
+
+      final encoded = AssetWatchlistService.encodeMirrorValue(entries);
+      final decoded = AssetWatchlistService.decodeMirrorValue(encoded);
+
+      expect(
+        decoded.map((e) => e.assetType),
+        unorderedEquals(<String>['gold', 'btc']),
+      );
+      final gold = decoded.firstWhere((e) => e.assetType == 'gold');
+      expect(gold.group, 'invest');
+      expect(gold.memo, 'hedge');
+    });
+
+    test('decodeMirrorValue ignores malformed input and empty assetType', () {
+      expect(AssetWatchlistService.decodeMirrorValue(null), isEmpty);
+      expect(AssetWatchlistService.decodeMirrorValue('not a map'), isEmpty);
+
+      final decoded = AssetWatchlistService.decodeMirrorValue(
+        <String, dynamic>{
+          'entries': <dynamic>[
+            <String, dynamic>{
+              'assetType': 'gold',
+              'group': 'invest',
+              'memo': '',
+              'addedAt': '',
+            },
+            'broken',
+            <String, dynamic>{
+              'assetType': '',
+              'group': 'x',
+              'memo': '',
+              'addedAt': '',
+            },
+          ],
+        },
+      );
+      expect(decoded.map((e) => e.assetType), <String>['gold']);
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -8,7 +8,9 @@ import 'package:my_web_app/pages/asset_management_page.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
+import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
+import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -505,6 +507,70 @@ void main() {
       // ローカル値(3000)が維持され、ミラー値(99999)では上書きされない。
       final local = await const AssetRevolvingCreditConfigStore().load();
       expect(local['aupay']!.monthlyAmount, 3000);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('main account syncs from server mirror on a fresh device', (
+      tester,
+    ) async {
+      // 端末B はローカル空(別ブラウザ/別ログイン)で起動する。
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugMainAccountMirror: <String, dynamic>{'id': 'smbc_otsuka'},
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // 端末A のメイン口座IDが起動時に復元され、ローカルへも書き戻される。
+      expect(
+        await const AssetManagementMainAccountStore().load(),
+        'smbc_otsuka',
+      );
+
+      await _unmount(tester);
+    });
+
+    testWidgets('watchlist syncs from server mirror on a fresh device', (
+      tester,
+    ) async {
+      // 端末A が保存したウォッチリストを集約ミラー値へエンコードする。
+      final mirrorValue = AssetWatchlistService.encodeMirrorValue(
+        <AssetWatchlistEntry>[
+          AssetWatchlistEntry(
+            assetType: 'gold',
+            group: 'invest',
+            memo: 'hedge',
+            addedAt: DateTime.utc(2026, 6, 14),
+          ),
+        ],
+      );
+
+      // 端末B はローカル空で起動する。
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugWatchlistMirror: mirrorValue,
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // 起動時にミラーから復元され、端末B のローカルにも書き戻される。
+      final synced = await const AssetWatchlistService().loadEntries();
+      expect(synced.map((e) => e.assetType), contains('gold'));
 
       await _unmount(tester);
     });


### PR DESCRIPTION
## 概要

資産管理画面でローカル (SharedPreferences) のみに保存され、別端末 (スマホ等) で
引き継げなかったユーザー設定/データを `asset_pref_mirror` 経由でサーバへ 1 行 jsonb
ミラーし、端末間で同期されるようにする。リボ設定 (#3352) と同じ集約方針
(`docs/MIRROR_PREF_SCHEMA.md`)。

## 監査結果

資産管理画面の永続化項目を棚卸しした結果、未同期のローカル永続でユーザー向けは 2 件のみ:

| pref_key | データ | store |
|----|----|----|
| `main_account_id` | 使用可能額の基準となるメイン口座ID | `AssetManagementMainAccountStore` |
| `watchlist_entries` | ウォッチリスト (注目資産+グループ+メモ) | `AssetWatchlistService` |

他のローカル永続は既に `asset_pref_mirror` かリポジトリ経由でサーバ同期済み。

### 意図的に端末ローカルのまま (= 同期しない)
- **表示モード実験ログ** (`asset_management_display_mode_events_v1`) — イベントは既に
  専用サーバテーブル `display_mode_events` へ記録済み (ローカルは集計キャッシュ)。
- **復元辞退フラグ** (`asset_management_restore_declined_v1`) — 端末ごとの UX 状態。
  同期すると一方の端末での辞退が他端末の復元提案まで誤って抑止してしまうため。

## 変更点

- 各 store に `encodeMirrorValue`/`decodeMirrorValue` 共通往復を抽出 (ローカル保存と
  サーバミラーで同一形を共用)。ウォッチリストは `replaceAll` で復元時の一括書き戻し。
- **書き**: 保存/各変更時に `_mirrorMainAccount`/`_mirrorWatchlist` で 1 行 upsert。
- **読み**: 起動時 `_restore*FromMirror` が集約ミラーを優先し、ローカルが空のときだけ
  復元 (既存ローカル値は上書きしない安全側 / オフライン編集の握り潰し防止)。
- `docs/MIRROR_PREF_SCHEMA.md` に 2 pref_key を登録。

## テスト

`flutter analyze` → 0 issues、対象テストすべて green:
- widget 統合テスト 2 (`test/widgets/...`): メイン口座 / ウォッチリストの端末A→端末B 起動時同期。
- store 単体テスト (`test/services/...`): encode/decode 往復 / 不正値耐性 / replaceAll。

## Minimal E2E Gate

- 実装詳細に依存しない (black-box) 入出力契約のみを検証する: 「端末A が保存した値を
  端末B が起動時に受け取る」という観測可能な入出力をアサートし、内部実装に依存しない。
- 最小限 (minimal) の 3 ケース相当 — メイン口座同期 / ウォッチリスト同期 / encode-decode 往復。
- 機構: widget 統合テスト + store 単体テスト。公開サイトの Playwright / `integration_test/`
  のブラウザ E2E は未追加。
- E2E-Exception: 端末間同期は 2 デバイス + ログイン済みセッションが前提で、公開
  ブラックボックス E2E では決定的に再現しづらいため、widget 統合テストと store 単体
  テストで往復を担保する。

## レビュー

- Review owner: Claude Code #1。
- High-risk-ultrareview-exception: 変更は `lib/pages` `lib/services` `test` `docs` のみで、
  認証 / 課金 / インフラ配信などの高リスクパスには触れない純粋な端末間同期の追加のため
  ultrareview 対象外とする。
