### PR TITLE
feat(asset): ローカル永続データの同期ステータス指標を追加

### DIFF
--- a/docs/LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md
+++ b/docs/LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md
@@ -1,0 +1,43 @@
+# 資産管理: ローカル永続の段階的縮退ロードマップ
+
+資産管理ページの読み取りは現在 **全ドメインがローカル (SharedPreferences) 優先** で、
+Supabase はバックアップ/同期先。これを **Supabase 正本・ローカルはオフライン用キャッシュ**
+へ段階的に移行する計画 (= 「ローカル永続を参照する処理を将来すべて減らす」要望の正本)。
+
+> 最終形は「ローカル永続の**完全撤去**」ではない。完全撤去するとオフライン/未ログインで
+> 資産画面が使えなくなるため、ローカルは **write-through キャッシュ**として残す
+> (真実の源 = Supabase、表示の即応性とオフライン耐性 = ローカル)。
+
+## 現状の2系統
+
+| 系統 | 対象 | 同期機構 | 読み |
+|----|----|----|----|
+| pref 系 | 表示設定 / 入金 / 支払日上書き / リボ / メイン口座 / ウォッチリスト | `asset_pref_mirror` (`_mirror*` / `_restore*FromMirror`) | ローカル優先・空時のみミラー復元 |
+| 月次state系 | 支払/カード請求/収入計画など12項目 | `AssetLiabilityRepository` (`syncMonth` / 競合解決 / sync audit log / `supabaseWritesEnabled`) | ローカル優先・リモート補完 |
+| 資産残高 | 口座残高スナップショット | `cfo_assets` テーブル直読み (`_loadDataFromSupabase`) | **既に Supabase 正本** |
+
+## フェーズ
+
+- **Phase A — 可視化 (本 PR / 完了)**: provenance を追跡し、未同期 (= この端末のみ) を
+  全体バナー＋未同期バッジで可視化。撤去作業の前提となる「どこがローカル由来か」を
+  ユーザーと開発者の双方が確認できる状態にする (`lib/services/asset_sync_status.dart` /
+  `_refreshSyncSources`)。
+- **Phase B — 読み優先度の反転**: ログイン＆オンライン時は **Supabase 優先・ローカル fallback**
+  へ。pref 系は `_restore*FromMirror` を「ローカル空時のみ」→「サーバ行があれば採用 (競合は
+  `updated_at` で解決)」へ見直す。月次state系は既存 `syncMonth`/競合解決を既定経路化し、
+  資産残高 (cfo_assets) の既存パターンに揃える。
+- **Phase C — legacy mirror 行の読み撤去**: 既存
+  [`MIRROR_PREF_AGGREGATION_MIGRATION.md`](MIRROR_PREF_AGGREGATION_MIGRATION.md) Phase 3
+  (per-key legacy 行の読みフォールバック撤去) を、撤去条件 (リリース後4週間＋SQL で残存ゼロ確認)
+  達成後に実施。
+- **Phase D — ローカルをキャッシュ専用へ降格**: ローカル書き込みは write-through に限定し、
+  クロス端末の真実源にしない。未ログイン/オフライン時はキャッシュ表示＋「未同期」明示
+  (Phase A の指標がそのまま機能)。
+
+## 注記
+
+- 各 Phase は独立 PR。Phase B 以降は本番データ分布 (Supabase SQL) と移行期間が前提のため、
+  着手前に分布確認を行う。
+- **意図的に端末ローカルのまま** (撤去対象外): 表示モード実験ログ (`display_mode_events`
+  テーブルへ別途記録済) / 復元辞退フラグ (端末ごとの UX 状態。同期すると他端末の復元提案を
+  誤抑止する)。

--- a/docs/MIRROR_PREF_SCHEMA.md
+++ b/docs/MIRROR_PREF_SCHEMA.md
@@ -76,3 +76,22 @@ best-effort delete される(Phase 2)。読みは集約行が無い場合のみ�
 > 強いて残る差分: items は `_mirrorInflowToSupabase` で**行ごと upsert** する一方、
 > tombstone は集約 1 行。行ごと upsert の集約化は別テーマ (実体データのため本 doc の
 > pref 集約とはスコープが異なる)。
+
+## 同期ステータス指標 (未同期 = この端末のみ の可視化)
+
+ローカル優先で読む構成のため「サーバ未同期 = 他端末に出ない」状態を画面で可視化する
+(`lib/services/asset_sync_status.dart` の `AssetSyncStatusSummary` / page の
+`_refreshSyncSources`)。各データ領域の出所 (`AssetSyncSource`: synced / localOnly / empty)
+を判定:
+
+- **pref 系** (`main_account_id` / `watchlist_entries` / `revolving_credit_configs` /
+  `debt_payment_day_overrides`): boot/保存時に `asset_pref_mirror` を 1 回 select し、
+  当該 pref_key 行があれば synced。
+- **入金** (`inflow`): `asset_expected_inflow_items` の存在で判定。
+- **月次state** (`monthlyState`): `AssetLiabilityRepository.supabaseWritesEnabled` ＋
+  `_assetLiabilitySyncStatus` から判定。
+- **未ログイン時**: 何も同期されないため、データのある領域はすべて localOnly。
+
+UI = 全体ステータスバナー (`Key('asset_sync_status_chip')`) ＋ 未同期バッジ列
+(`Key('asset_unsynced_badge_row')` / 各 `Key('asset_unsynced_badge_<domain>')`)。
+将来の正本化計画は [`LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md`](LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md)。

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -40,6 +40,7 @@ import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
+import 'package:my_web_app/services/asset_sync_status.dart';
 import 'package:my_web_app/services/asset_unknown_expense_rule_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
@@ -217,6 +218,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   bool _isFetchingSmbc = false;
   bool _isFetchingJibun = false;
   bool _isImportingSmbcCsv = false;
+
+  /// 各データ領域の同期出所 (provenance)。サーバ未同期 (= この端末のみ) を
+  /// 画面上で可視化するために保持する。`_refreshSyncSources` で更新。
+  final Map<AssetSyncDomain, AssetSyncSource> _syncSources =
+      <AssetSyncDomain, AssetSyncSource>{};
+
+  // 起動時の複数ロードからの同時呼び出しを 1 回に集約する再入ガード。
+  bool _syncRefreshInFlight = false;
+  bool _syncRefreshDirty = false;
+
+  AssetSyncStatusSummary get _syncSummary => AssetSyncStatusSummary(
+        loggedIn: _supabase.auth.currentUser != null,
+        sources: _syncSources,
+      );
 
   // --- 資産・負債（ストック）用変数 ---
   Map<String, TextEditingController> _controllers = {};
@@ -1281,6 +1296,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _loadedAssetLiabilityMonthKey = monthKey;
         _syncPaymentStateControllers();
       });
+      unawaited(_refreshSyncSources());
       if (generatedTemplatePlans) {
         unawaited(_saveAssetLiabilityMonthlyState());
       }
@@ -5148,6 +5164,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
     await _restoreWatchlistFromMirror();
+    unawaited(_refreshSyncSources());
   }
 
   /// ウォッチリストを `asset_pref_mirror` (pref_key: watchlist_entries) へ
@@ -5169,6 +5186,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('watchlist mirror upsert failed: $e');
     }
+    unawaited(_refreshSyncSources());
   }
 
   /// サーバ集約ミラーからウォッチリストを復元する (集約優先 + legacy local fallback)。
@@ -7409,6 +7427,165 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  /// 全体の同期ステータス バナー。未同期 (= この端末のみ) を可視化する。
+  /// タップで未同期データの一覧ダイアログを開く。
+  Widget _buildSyncStatusBanner() {
+    final summary = _syncSummary;
+    const warnBg = Color(0xFFFEF3C7);
+    const warnFg = Color(0xFF92400E);
+    const okBg = Color(0xFFDCFCE7);
+    const okFg = Color(0xFF166534);
+
+    late final Color background;
+    late final Color foreground;
+    late final IconData icon;
+    late final String text;
+    switch (summary.level) {
+      case AssetSyncLevel.loggedOut:
+        background = warnBg;
+        foreground = warnFg;
+        icon = Icons.cloud_off;
+        text = '未ログイン：データはこの端末にのみ保存（他端末に出ません）';
+      case AssetSyncLevel.partialLocal:
+        background = warnBg;
+        foreground = warnFg;
+        icon = Icons.sync_problem;
+        text = '未同期 ${summary.localOnlyCount} 項目（この端末のみ）';
+      case AssetSyncLevel.allSynced:
+        background = okBg;
+        foreground = okFg;
+        icon = Icons.cloud_done;
+        text = 'サーバ同期済み';
+    }
+    final tappable = summary.level != AssetSyncLevel.allSynced;
+    return InkWell(
+      key: const Key('asset_sync_status_chip'),
+      onTap: tappable ? _showSyncStatusDetails : null,
+      borderRadius: BorderRadius.circular(10),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: background,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: foreground),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, size: 18, color: foreground),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                text,
+                style: TextStyle(
+                  color: foreground,
+                  fontSize: 12.5,
+                  height: 1.3,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            if (tappable)
+              Icon(Icons.chevron_right, size: 18, color: foreground),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 未同期データ領域を示すバッジ列。localOnly の領域ごとに「<領域> 未同期」チップを
+  /// バナー直下に並べ、どのデータが他端末に出ないかを一目で分かるようにする。
+  Widget _buildUnsyncedBadgeRow() {
+    final domains = _syncSummary.localOnlyDomains;
+    if (domains.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      key: const Key('asset_unsynced_badge_row'),
+      padding: const EdgeInsets.only(top: 8),
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        children: <Widget>[
+          for (final domain in domains) _buildUnsyncedBadge(domain),
+        ],
+      ),
+    );
+  }
+
+  /// 1 領域分の「<領域> 未同期」チップ。
+  Widget _buildUnsyncedBadge(AssetSyncDomain domain) {
+    return Container(
+      key: Key('asset_unsynced_badge_${domain.name}'),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFEF3C7),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: const Color(0xFF92400E)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.cloud_off, size: 12, color: Color(0xFF92400E)),
+          const SizedBox(width: 4),
+          Text(
+            '${domain.label} 未同期',
+            style: const TextStyle(
+              fontSize: 10.5,
+              color: Color(0xFF92400E),
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showSyncStatusDetails() {
+    final summary = _syncSummary;
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('同期ステータス'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (summary.isLoggedOut)
+              const Text(
+                '未ログインのため、資産管理のデータはこの端末にのみ保存されます。\n'
+                'ログインするとサーバに同期され、スマホなど他の端末でも参照できます。',
+                style: TextStyle(fontSize: 13, height: 1.4),
+              )
+            else ...[
+              const Text(
+                '次のデータはまだサーバに同期されていません（この端末のみ）:',
+                style: TextStyle(fontSize: 13, height: 1.4),
+              ),
+              const SizedBox(height: 8),
+              for (final domain in summary.localOnlyDomains)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.cloud_off, size: 16),
+                      const SizedBox(width: 6),
+                      Text(domain.label),
+                    ],
+                  ),
+                ),
+            ],
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('閉じる'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isCompact = _isCompact;
@@ -7431,6 +7608,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _buildUnifiedEntryBanner(),
               const SizedBox(height: 16),
             ],
+            _buildSyncStatusBanner(),
+            _buildUnsyncedBadgeRow(),
+            const SizedBox(height: 12),
             _buildDisplayModeSwitcher(),
             const SizedBox(height: 12),
             if (_isSectionShown(AssetManagementSectionId.monthlyFlow)) ...[
@@ -7526,6 +7706,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
     await _restoreMainAccountFromMirror();
+    unawaited(_refreshSyncSources());
   }
 
   /// メイン口座IDを `asset_pref_mirror` (pref_key: main_account_id) へ
@@ -7547,6 +7728,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('main account mirror upsert failed: $e');
     }
+    unawaited(_refreshSyncSources());
   }
 
   /// サーバ集約ミラーからメイン口座IDを復元する (集約優先 + legacy local fallback)。
@@ -7589,6 +7771,124 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  /// 各データ領域の同期出所を再計算する。サーバに該当データがあれば synced、
+  /// ローカルのみなら localOnly、何も無ければ empty。未ログイン時は同期されない
+  /// ため、データのある領域はすべて localOnly になる。
+  ///
+  /// 起動時の複数ロードや保存後から繰り返し呼ばれるため、再入は 1 回に集約する。
+  Future<void> _refreshSyncSources() async {
+    if (_syncRefreshInFlight) {
+      _syncRefreshDirty = true;
+      return;
+    }
+    _syncRefreshInFlight = true;
+    try {
+      final user = _supabase.auth.currentUser;
+      final presentPrefKeys = <String>{};
+      var hasInflowOnServer = false;
+      if (user != null) {
+        try {
+          final rows = await _supabase
+              .from('asset_pref_mirror')
+              .select('pref_key')
+              .eq('user_id', user.id);
+          for (final row in rows) {
+            final key = row['pref_key'];
+            if (key is String) {
+              presentPrefKeys.add(key);
+            }
+          }
+        } catch (e) {
+          debugPrint('sync sources: pref mirror fetch failed: $e');
+        }
+        try {
+          final inflowRows = await _supabase
+              .from('asset_expected_inflow_items')
+              .select('id')
+              .eq('user_id', user.id)
+              .limit(1);
+          hasInflowOnServer = inflowRows.isNotEmpty;
+        } catch (e) {
+          debugPrint('sync sources: inflow items fetch failed: $e');
+        }
+      }
+
+      AssetSyncSource prefSource(String prefKey, {required bool hasLocal}) {
+        if (user != null && presentPrefKeys.contains(prefKey)) {
+          return AssetSyncSource.synced;
+        }
+        return hasLocal ? AssetSyncSource.localOnly : AssetSyncSource.empty;
+      }
+
+      final next = <AssetSyncDomain, AssetSyncSource>{
+        AssetSyncDomain.mainAccount: prefSource(
+          'main_account_id',
+          hasLocal: _assetManagementMainAccountId != null,
+        ),
+        AssetSyncDomain.watchlist: prefSource(
+          'watchlist_entries',
+          hasLocal: _watchlistByType.isNotEmpty,
+        ),
+        AssetSyncDomain.revolving: prefSource(
+          'revolving_credit_configs',
+          hasLocal: _revolvingConfigs.isNotEmpty,
+        ),
+        AssetSyncDomain.debtOverrides: prefSource(
+          'debt_payment_day_overrides',
+          hasLocal: _debtPaymentDayOverrides.isNotEmpty,
+        ),
+        AssetSyncDomain.inflow: _inflowSyncSource(
+          loggedIn: user != null,
+          hasInflowOnServer: hasInflowOnServer,
+        ),
+        AssetSyncDomain.monthlyState: _monthlyStateSyncSource(
+          loggedIn: user != null,
+        ),
+      };
+
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _syncSources
+          ..clear()
+          ..addAll(next);
+      });
+    } finally {
+      _syncRefreshInFlight = false;
+      if (_syncRefreshDirty) {
+        _syncRefreshDirty = false;
+        unawaited(_refreshSyncSources());
+      }
+    }
+  }
+
+  AssetSyncSource _inflowSyncSource({
+    required bool loggedIn,
+    required bool hasInflowOnServer,
+  }) {
+    final hasLocal =
+        _expectedInflows.isNotEmpty || _expectedInflowRules.isNotEmpty;
+    if (loggedIn && hasInflowOnServer) {
+      return AssetSyncSource.synced;
+    }
+    return hasLocal ? AssetSyncSource.localOnly : AssetSyncSource.empty;
+  }
+
+  AssetSyncSource _monthlyStateSyncSource({required bool loggedIn}) {
+    final hasLocal = !_currentAssetLiabilityMonthlyState().isEmpty;
+    if (!hasLocal) {
+      return AssetSyncSource.empty;
+    }
+    // リモート書込が無効 / 未ログイン / 直近同期が失敗ならローカルのみ。
+    if (!loggedIn ||
+        !_assetLiabilityRepository.supabaseWritesEnabled ||
+        _assetLiabilitySyncStatus == AssetLiabilityManualSyncStatus.failure) {
+      return AssetSyncSource.localOnly;
+    }
+    return AssetSyncSource.synced;
+  }
+
   Future<void> _setMainAccount(String? accountId) async {
     setState(() {
       _assetManagementMainAccountId = accountId;
@@ -7617,6 +7917,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
     await _restoreRevolvingConfigsFromMirror();
+    unawaited(_refreshSyncSources());
   }
 
   /// リボ設定を `asset_pref_mirror` (pref_key: revolving_credit_configs) へ
@@ -7638,6 +7939,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('revolving config mirror upsert failed: $e');
     }
+    unawaited(_refreshSyncSources());
   }
 
   /// サーバ集約ミラーからリボ設定を復元する (集約優先 + legacy local fallback)。
@@ -8158,6 +8460,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (entries.isEmpty && rules.isEmpty) {
       unawaited(_restoreInflowsFromMirror());
     }
+    unawaited(_refreshSyncSources());
   }
 
   Future<void> _removeExpectedInflowRule(String id) async {

--- a/lib/services/asset_sync_status.dart
+++ b/lib/services/asset_sync_status.dart
@@ -1,0 +1,109 @@
+/// 資産管理ページの各データ領域が「サーバ同期済み」か「この端末のみ (未同期)」かを
+/// 表す出所 (provenance)。
+///
+/// ローカル永続 (SharedPreferences) を一次ストアとし Supabase へミラーする構成のため、
+/// 「サーバにまだ無い = 他端末に出ない」状態を画面上で可視化するのに使う。
+enum AssetSyncSource {
+  /// Supabase に保存済み (他端末でも参照できる)。
+  synced,
+
+  /// この端末のローカルにのみ存在する (サーバ未同期 = 他端末に出ない)。
+  localOnly,
+
+  /// まだ何も保存されていない (同期対象なし)。
+  empty,
+}
+
+/// 同期ステータスを表示する資産管理データ領域。
+enum AssetSyncDomain {
+  mainAccount,
+  watchlist,
+  revolving,
+  debtOverrides,
+  inflow,
+  monthlyState,
+}
+
+extension AssetSyncDomainLabel on AssetSyncDomain {
+  /// 画面表示用の日本語ラベル。
+  String get label {
+    switch (this) {
+      case AssetSyncDomain.mainAccount:
+        return 'メイン口座';
+      case AssetSyncDomain.watchlist:
+        return 'ウォッチリスト';
+      case AssetSyncDomain.revolving:
+        return 'リボ払い設定';
+      case AssetSyncDomain.debtOverrides:
+        return '支払日設定';
+      case AssetSyncDomain.inflow:
+        return '入金予定';
+      case AssetSyncDomain.monthlyState:
+        return '資産・負債データ';
+    }
+  }
+}
+
+/// 全体の同期ステータスのレベル (チップの色/文言の決定に使う)。
+enum AssetSyncLevel {
+  /// 未ログイン: 何も同期されない (この端末のみ)。
+  loggedOut,
+
+  /// ログイン済みで未同期領域なし。
+  allSynced,
+
+  /// ログイン済みだが一部の領域がローカルのみ (未同期)。
+  partialLocal,
+}
+
+/// 各領域の出所から全体の同期ステータスを算出する純粋クラス (テスト可能)。
+class AssetSyncStatusSummary {
+  final bool loggedIn;
+  final Map<AssetSyncDomain, AssetSyncSource> sources;
+
+  const AssetSyncStatusSummary({
+    required this.loggedIn,
+    required this.sources,
+  });
+
+  bool get isLoggedOut => !loggedIn;
+
+  /// 未同期 (= localOnly) の領域一覧 (enum 宣言順で安定)。
+  List<AssetSyncDomain> get localOnlyDomains => <AssetSyncDomain>[
+        for (final domain in AssetSyncDomain.values)
+          if (sources[domain] == AssetSyncSource.localOnly) domain,
+      ];
+
+  /// 未同期領域の件数。
+  int get localOnlyCount => localOnlyDomains.length;
+
+  /// 同期対象 (synced か localOnly) のデータが1つでもあるか。
+  bool get hasAnyData =>
+      sources.values.any((source) => source != AssetSyncSource.empty);
+
+  AssetSyncLevel get level {
+    if (!loggedIn) {
+      return AssetSyncLevel.loggedOut;
+    }
+    if (localOnlyCount > 0) {
+      return AssetSyncLevel.partialLocal;
+    }
+    return AssetSyncLevel.allSynced;
+  }
+
+  /// 指定領域が画面上で「未同期」バッジを出すべきか。
+  bool isLocalOnly(AssetSyncDomain domain) =>
+      sources[domain] == AssetSyncSource.localOnly;
+
+  /// 全体ステータスチップの見出し文言。
+  String get headline {
+    switch (level) {
+      case AssetSyncLevel.loggedOut:
+        return '未ログイン：この端末にのみ保存';
+      case AssetSyncLevel.partialLocal:
+        return '未同期 $localOnlyCount 項目';
+      case AssetSyncLevel.allSynced:
+        return 'サーバ同期済み';
+    }
+  }
+}

--- a/test/services/asset_sync_status_test.dart
+++ b/test/services/asset_sync_status_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_sync_status.dart';
+
+void main() {
+  group('AssetSyncStatusSummary', () {
+    test('logged out → loggedOut level regardless of sources', () {
+      const summary = AssetSyncStatusSummary(
+        loggedIn: false,
+        sources: <AssetSyncDomain, AssetSyncSource>{
+          AssetSyncDomain.watchlist: AssetSyncSource.localOnly,
+          AssetSyncDomain.mainAccount: AssetSyncSource.synced,
+        },
+      );
+      expect(summary.level, AssetSyncLevel.loggedOut);
+      expect(summary.headline, '未ログイン：この端末にのみ保存');
+    });
+
+    test('logged in, all synced → allSynced level', () {
+      const summary = AssetSyncStatusSummary(
+        loggedIn: true,
+        sources: <AssetSyncDomain, AssetSyncSource>{
+          AssetSyncDomain.watchlist: AssetSyncSource.synced,
+          AssetSyncDomain.mainAccount: AssetSyncSource.synced,
+          AssetSyncDomain.revolving: AssetSyncSource.empty,
+        },
+      );
+      expect(summary.level, AssetSyncLevel.allSynced);
+      expect(summary.headline, 'サーバ同期済み');
+      expect(summary.localOnlyCount, 0);
+    });
+
+    test('logged in with some local-only → partialLocal + count + list', () {
+      const summary = AssetSyncStatusSummary(
+        loggedIn: true,
+        sources: <AssetSyncDomain, AssetSyncSource>{
+          AssetSyncDomain.mainAccount: AssetSyncSource.synced,
+          AssetSyncDomain.watchlist: AssetSyncSource.localOnly,
+          AssetSyncDomain.revolving: AssetSyncSource.localOnly,
+          AssetSyncDomain.inflow: AssetSyncSource.empty,
+        },
+      );
+      expect(summary.level, AssetSyncLevel.partialLocal);
+      expect(summary.localOnlyCount, 2);
+      expect(summary.headline, '未同期 2 項目');
+      // enum 宣言順で安定 (watchlist が revolving より先)。
+      expect(summary.localOnlyDomains, <AssetSyncDomain>[
+        AssetSyncDomain.watchlist,
+        AssetSyncDomain.revolving,
+      ]);
+      expect(summary.isLocalOnly(AssetSyncDomain.watchlist), isTrue);
+      expect(summary.isLocalOnly(AssetSyncDomain.mainAccount), isFalse);
+    });
+
+    test('empty sources → hasAnyData false, allSynced when logged in', () {
+      const summary = AssetSyncStatusSummary(
+        loggedIn: true,
+        sources: <AssetSyncDomain, AssetSyncSource>{
+          AssetSyncDomain.watchlist: AssetSyncSource.empty,
+        },
+      );
+      expect(summary.hasAnyData, isFalse);
+      expect(summary.level, AssetSyncLevel.allSynced);
+    });
+
+    test('domain labels are stable Japanese strings', () {
+      expect(AssetSyncDomain.mainAccount.label, 'メイン口座');
+      expect(AssetSyncDomain.monthlyState.label, '資産・負債データ');
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -852,5 +852,62 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets('sync status banner shows logged-out state', (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // 未ログイン (スモークは未認証) → 全体バナーが「この端末のみ」を明示。
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_sync_status_chip')),
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('asset_sync_status_chip')),
+          matching: find.textContaining('この端末にのみ保存'),
+        ),
+        findsOneWidget,
+      );
+
+      await _unmount(tester);
+    });
+
+    testWidgets('unsynced badge appears for local-only watchlist', (
+      tester,
+    ) async {
+      // ローカルにのみウォッチリストがある (未認証 = サーバ未同期) 状態。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'assetType': 'gold',
+            'group': 'invest',
+            'memo': 'hedge',
+            'addedAt': DateTime.utc(2026, 6, 14).toIso8601String(),
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // ウォッチリストが localOnly → 未同期バッジが出る。
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_unsynced_badge_row')),
+      );
+      expect(
+        find.byKey(const Key('asset_unsynced_badge_watchlist')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('ウォッチリスト 未同期'), findsOneWidget);
+
+      await _unmount(tester);
+    });
   });
 }


### PR DESCRIPTION
## 概要

資産管理ページで「サーバ未同期 = この端末のみ (他端末に出ない)」のデータを画面上で
可視化する。ローカル優先で読む構成のため、どのデータがまだサーバに無い (= スマホ等の
他端末で見えない) かを一目で分かるようにする。将来「ローカル永続の参照を Supabase 正本へ
寄せる」ための前提となる可視化。

## 監査で分かった現状

資産管理ページの読み取りは全ドメインがローカル (SharedPreferences) 優先で Supabase は
ミラー/同期先。資産残高 (`cfo_assets`) のみ既に Supabase 正本 (直読み) のため対象外。

## 変更点

- **純関数** `AssetSyncStatusSummary` (`lib/services/asset_sync_status.dart`): 各データ領域の
  出所 (`synced` / `localOnly` / `empty`) から全体ステータス (未ログイン / 全同期 / 未同期 N 項目)
  を算出。
- **provenance 追跡** (`_refreshSyncSources`): `asset_pref_mirror` を 1 回 select して
  pref 系 4 ドメイン、`asset_expected_inflow_items` で入金、リポジトリの書込フラグで月次 state を
  判定。未ログイン時はデータのある領域をすべて `localOnly`。起動・保存時に更新。
- **UI**: 全体ステータスバナー (`asset_sync_status_chip` / タップで未同期一覧ダイアログ) +
  未同期バッジ列 (各領域「○○ 未同期」)。
- **ロードマップ**: `docs/LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md` に Supabase 正本化の段階
  (A 可視化=本 PR / B 読み優先反転 / C legacy 撤去 / D キャッシュ降格) を明文化。

## テスト

`flutter analyze` → 0 issues、対象テストすべて green:
- 純関数単体テスト (`test/services/asset_sync_status_test.dart`): 未ログイン / 全同期 /
  未同期 N 項目 / 空 の全分岐。
- widget テスト 2 (`test/widgets/...`): 未ログイン時バナー / ローカルのみ領域の未同期バッジ。

## Minimal E2E Gate

- 実装詳細に依存しない (black-box) 入出力契約のみ検証: 「ログイン状態 + 各領域の出所」という
  入力に対し「バナー文言 / 未同期バッジの有無」という観測可能な出力をアサートし、内部実装に
  依存しない。
- 最小限 (minimal) の 3 ケース相当 — 未ログイン表示 / 未同期バッジ表示 / 全同期表示 (純関数)。
- 機構: 純関数単体テスト + widget テスト。公開サイトの Playwright / `integration_test/` の
  ブラウザ E2E は未追加。
- E2E-Exception: 同期ステータスはログイン状態と Supabase 上のデータ有無に依存し、公開
  ブラックボックス E2E では決定的に再現しづらいため、純関数テストと widget テストで担保する。

## レビュー

- Review owner: Claude Code #1。
- High-risk-ultrareview-exception: 変更は `lib/pages` `lib/services` `test` `docs` のみで、
  認証 / 課金 / インフラ配信などの高リスクパスに触れない、表示専用の可視化追加のため
  ultrareview 対象外とする。
