### PR TITLE
feat(asset): Phase B - pref ミラー読みを Supabase 正本化 (LWW / 既定OFFフラグ)

### DIFF
--- a/docs/LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md
+++ b/docs/LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md
@@ -22,10 +22,15 @@ Supabase はバックアップ/同期先。これを **Supabase 正本・ロー�
   全体バナー＋未同期バッジで可視化。撤去作業の前提となる「どこがローカル由来か」を
   ユーザーと開発者の双方が確認できる状態にする (`lib/services/asset_sync_status.dart` /
   `_refreshSyncSources`)。
-- **Phase B — 読み優先度の反転**: ログイン＆オンライン時は **Supabase 優先・ローカル fallback**
-  へ。pref 系は `_restore*FromMirror` を「ローカル空時のみ」→「サーバ行があれば採用 (競合は
-  `updated_at` で解決)」へ見直す。月次state系は既存 `syncMonth`/競合解決を既定経路化し、
-  資産残高 (cfo_assets) の既存パターンに揃える。
+- **Phase B — 読み優先度の反転 (pref系4ドメインをフラグ裏で実装済 / 既定 OFF)**:
+  pref 系の `main_account_id` / `watchlist_entries` / `revolving_credit_configs` /
+  `debt_payment_day_overrides` の `_restore*FromMirror` を「ローカル空時のみ」→
+  **last-write-wins** (`resolveMirrorRead` / `lib/services/asset_mirror_read_policy.dart`) へ。
+  ローカル最終変更時刻 (`AssetSyncTimestampStore` / `asset_sync_timestamps_v1`) と
+  `asset_pref_mirror.updated_at` を比較し、新しい方を採用 (オフライン未同期のローカル編集は
+  保持)。フラグ `ASSET_MIRROR_READS_AUTHORITATIVE` (`bool.fromEnvironment` / 既定 false) で
+  ゲートし、**本番は無変更**。残り (入金 items / 月次state) と clear 伝播は Phase B.2。
+  月次state系は既存 `syncMonth`/競合解決を既定経路化、資産残高 (cfo_assets) は既存パターンに揃える。
 - **Phase C — legacy mirror 行の読み撤去**: 既存
   [`MIRROR_PREF_AGGREGATION_MIGRATION.md`](MIRROR_PREF_AGGREGATION_MIGRATION.md) Phase 3
   (per-key legacy 行の読みフォールバック撤去) を、撤去条件 (リリース後4週間＋SQL で残存ゼロ確認)
@@ -33,6 +38,40 @@ Supabase はバックアップ/同期先。これを **Supabase 正本・ロー�
 - **Phase D — ローカルをキャッシュ専用へ降格**: ローカル書き込みは write-through に限定し、
   クロス端末の真実源にしない。未ログイン/オフライン時はキャッシュ表示＋「未同期」明示
   (Phase A の指標がそのまま機能)。
+
+## Phase B 有効化手順 (本番)
+
+1. **データ分布を確認** (Supabase SQL Editor)。集約行とローカルの整合が前提:
+   ```sql
+   -- pref_key ごとの行数 / ユーザー数 / 最終更新。
+   select pref_key, count(*) as rows, count(distinct user_id) as users,
+          max(updated_at) as latest
+   from asset_pref_mirror
+   where pref_key in (
+     'main_account_id', 'watchlist_entries',
+     'revolving_credit_configs', 'debt_payment_day_overrides'
+   )
+   group by pref_key
+   order by rows desc;
+
+   -- updated_at が NULL の行が無いこと (LWW 比較の前提)。NULL は安全側でローカル維持になる。
+   select pref_key, count(*) as null_updated_at
+   from asset_pref_mirror
+   where updated_at is null
+     and pref_key in (
+       'main_account_id', 'watchlist_entries',
+       'revolving_credit_configs', 'debt_payment_day_overrides'
+     )
+   group by pref_key;
+   ```
+2. 問題なければ `deploy-staging.yml` で `--dart-define=ASSET_MIRROR_READS_AUTHORITATIVE=true`
+   を有効化し、複数端末で「端末A 変更 → 端末B 起動で反映」を確認。
+3. 本番 (`deploy-prod.yml`) も同 dart-define を追加。**ロールバックはフラグを外すだけ** (即時)。
+
+> LWW の安全性: ローカル変更時に `asset_sync_timestamps_v1` へ時刻記録、ミラー upsert も
+> `updated_at` 更新。新しい方が勝つため、オフラインの未同期ローカル編集が古いサーバ値に
+> 上書きされることはない。タイムスタンプ未記録の legacy ローカルは「サーバ採用」側に倒す
+> (= その端末自身の write-through 結果であり正本化方針に沿う)。clear (空化) の伝播は未対応 (Phase B.2)。
 
 ## 注記
 

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -40,7 +40,9 @@ import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
+import 'package:my_web_app/services/asset_mirror_read_policy.dart';
 import 'package:my_web_app/services/asset_sync_status.dart';
+import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
 import 'package:my_web_app/services/asset_unknown_expense_rule_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
@@ -150,6 +152,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, dynamic>? debugWatchlistMirror;
 
+  /// テスト専用: ミラー読み取りを Supabase 正本化 (LWW) する Phase B フラグを上書きする。
+  /// null なら [AssetMirrorReadPolicy.authoritative] (ビルド時フラグ / 既定 false)。
+  @visibleForTesting
+  final bool? debugMirrorReadsAuthoritative;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -167,6 +174,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugRevolvingConfigsMirror,
     this.debugMainAccountMirror,
     this.debugWatchlistMirror,
+    this.debugMirrorReadsAuthoritative,
   });
 
   @override
@@ -232,6 +240,35 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         loggedIn: _supabase.auth.currentUser != null,
         sources: _syncSources,
       );
+
+  /// 集約 pref ドメインのローカル最終変更時刻 (LWW 判定用 / Phase B)。
+  final AssetSyncTimestampStore _syncTimestampStore =
+      const AssetSyncTimestampStore();
+
+  /// ミラー読み取りを Supabase 正本化 (LWW) するか。テスト注入優先・既定はビルド時フラグ。
+  bool get _mirrorReadsAuthoritative =>
+      widget.debugMirrorReadsAuthoritative ??
+      AssetMirrorReadPolicy.authoritative;
+
+  /// 集約 pref ミラー行を採用すべきか判定する。フラグ ON 時は last-write-wins
+  /// (ローカル最終変更 vs ミラー `updated_at`)、OFF 時は従来「ローカル空のときだけ」。
+  Future<bool> _shouldAdoptMirror({
+    required String prefKey,
+    required bool hasLocal,
+    required DateTime? mirrorUpdatedAt,
+  }) async {
+    if (!_mirrorReadsAuthoritative) {
+      return !hasLocal;
+    }
+    final localUpdatedAt = await _syncTimestampStore.loadTimestamp(prefKey);
+    return resolveMirrorRead(
+          hasLocal: hasLocal,
+          hasMirror: true,
+          localUpdatedAt: localUpdatedAt,
+          mirrorUpdatedAt: mirrorUpdatedAt,
+        ) ==
+        AssetMirrorAdoption.adoptMirror;
+  }
 
   // --- 資産・負債（ストック）用変数 ---
   Map<String, TextEditingController> _controllers = {};
@@ -5170,6 +5207,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// ウォッチリストを `asset_pref_mirror` (pref_key: watchlist_entries) へ
   /// 1 行 upsert する (リボ設定と同じ集約方針 / #3352)。
   Future<void> _mirrorWatchlist() async {
+    unawaited(_syncTimestampStore.markChanged(_watchlistMirrorKey));
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
       return;
@@ -5196,13 +5234,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (debugMirror == null && _supabase.auth.currentUser == null) {
       return;
     }
-    if (_watchlistByType.isNotEmpty) {
+    final hasLocal = _watchlistByType.isNotEmpty;
+    if (!_mirrorReadsAuthoritative && hasLocal && debugMirror == null) {
       return;
     }
     try {
       final dynamic value;
+      final DateTime? mirrorUpdatedAt;
       if (debugMirror != null) {
         value = debugMirror;
+        mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
         final rows = await _supabase
             .from('asset_pref_mirror')
@@ -5212,16 +5253,33 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           return;
         }
         value = rows.first['value'];
+        mirrorUpdatedAt = DateTime.tryParse(
+          rows.first['updated_at']?.toString() ?? '',
+        );
       }
       final restored = AssetWatchlistService.decodeMirrorValue(value);
-      if (restored.isEmpty || _watchlistByType.isNotEmpty || !mounted) {
+      if (restored.isEmpty || !mounted) {
+        return;
+      }
+      final adopt = await _shouldAdoptMirror(
+        prefKey: _watchlistMirrorKey,
+        hasLocal: hasLocal,
+        mirrorUpdatedAt: mirrorUpdatedAt,
+      );
+      if (!adopt || !mounted) {
         return;
       }
       setState(() {
         _setWatchlistEntries(restored);
       });
-      // オフライン参照用にローカルへも書き戻す。
+      // オフライン参照用にローカルへ書き戻し、ローカル更新時刻をミラーへ揃える。
       unawaited(widget.watchlistService.replaceAll(restored));
+      unawaited(
+        _syncTimestampStore.markChanged(
+          _watchlistMirrorKey,
+          at: mirrorUpdatedAt,
+        ),
+      );
     } catch (e) {
       debugPrint('watchlist mirror restore failed: $e');
     }
@@ -7712,6 +7770,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// メイン口座IDを `asset_pref_mirror` (pref_key: main_account_id) へ
   /// 1 行 upsert する (リボ設定と同じ集約方針 / #3352)。
   Future<void> _mirrorMainAccount() async {
+    unawaited(_syncTimestampStore.markChanged(_mainAccountMirrorKey));
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
       return;
@@ -7738,13 +7797,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (debugMirror == null && _supabase.auth.currentUser == null) {
       return;
     }
-    if (_assetManagementMainAccountId != null) {
+    final hasLocal = _assetManagementMainAccountId != null;
+    // フラグ OFF かつローカルに値がある場合は従来どおり何もしない (ネットワーク省略)。
+    if (!_mirrorReadsAuthoritative && hasLocal && debugMirror == null) {
       return;
     }
     try {
       final dynamic value;
+      final DateTime? mirrorUpdatedAt;
       if (debugMirror != null) {
         value = debugMirror;
+        mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
         final rows = await _supabase
             .from('asset_pref_mirror')
@@ -7754,18 +7817,33 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           return;
         }
         value = rows.first['value'];
+        mirrorUpdatedAt = DateTime.tryParse(
+          rows.first['updated_at']?.toString() ?? '',
+        );
       }
       final restored = AssetManagementMainAccountStore.decodeMirrorValue(value);
-      if (restored == null ||
-          _assetManagementMainAccountId != null ||
-          !mounted) {
+      if (restored == null || !mounted) {
+        return;
+      }
+      final adopt = await _shouldAdoptMirror(
+        prefKey: _mainAccountMirrorKey,
+        hasLocal: hasLocal,
+        mirrorUpdatedAt: mirrorUpdatedAt,
+      );
+      if (!adopt || !mounted) {
         return;
       }
       setState(() {
         _assetManagementMainAccountId = restored;
       });
-      // オフライン参照用にローカルへも書き戻す。
+      // オフライン参照用にローカルへ書き戻し、ローカル更新時刻をミラーへ揃える。
       unawaited(_mainAccountStore.save(restored));
+      unawaited(
+        _syncTimestampStore.markChanged(
+          _mainAccountMirrorKey,
+          at: mirrorUpdatedAt,
+        ),
+      );
     } catch (e) {
       debugPrint('main account mirror restore failed: $e');
     }
@@ -7923,6 +8001,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// リボ設定を `asset_pref_mirror` (pref_key: revolving_credit_configs) へ
   /// 1 行 upsert する (支払日上書きと同じ集約方針 / #part293-295)。
   Future<void> _mirrorRevolvingConfigs() async {
+    unawaited(_syncTimestampStore.markChanged(_revolvingConfigsMirrorKey));
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
       return;
@@ -7951,12 +8030,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (debugMirror == null && _supabase.auth.currentUser == null) {
       return;
     }
+    final hasLocal = _revolvingConfigs.isNotEmpty;
+    if (!_mirrorReadsAuthoritative && hasLocal && debugMirror == null) {
+      return;
+    }
     try {
       final Map<String, AssetLiabilityRevolvingCreditConfig> restored;
+      final DateTime? mirrorUpdatedAt;
       if (debugMirror != null) {
         restored = AssetRevolvingCreditConfigStore.decodeMirrorValue(
           debugMirror,
         );
+        mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
         final rows = await _supabase
             .from('asset_pref_mirror')
@@ -7968,15 +8053,32 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         restored = AssetRevolvingCreditConfigStore.decodeMirrorValue(
           rows.first['value'],
         );
+        mirrorUpdatedAt = DateTime.tryParse(
+          rows.first['updated_at']?.toString() ?? '',
+        );
       }
-      if (restored.isEmpty || _revolvingConfigs.isNotEmpty || !mounted) {
+      if (restored.isEmpty || !mounted) {
+        return;
+      }
+      final adopt = await _shouldAdoptMirror(
+        prefKey: _revolvingConfigsMirrorKey,
+        hasLocal: hasLocal,
+        mirrorUpdatedAt: mirrorUpdatedAt,
+      );
+      if (!adopt || !mounted) {
         return;
       }
       setState(() {
         _revolvingConfigs = restored;
       });
-      // オフライン参照用にローカルへも書き戻す。
+      // オフライン参照用にローカルへ書き戻し、ローカル更新時刻をミラーへ揃える。
       unawaited(_revolvingConfigStore.save(_revolvingConfigs));
+      unawaited(
+        _syncTimestampStore.markChanged(
+          _revolvingConfigsMirrorKey,
+          at: mirrorUpdatedAt,
+        ),
+      );
     } catch (e) {
       debugPrint('revolving config mirror restore failed: $e');
     }
@@ -8927,6 +9029,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _mirrorDebtPaymentDayOverrides(
     Map<String, int> overrides,
   ) async {
+    unawaited(_syncTimestampStore.markChanged('debt_payment_day_overrides'));
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
       return;
@@ -8947,6 +9050,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (_supabase.auth.currentUser == null) {
       return;
     }
+    final hasLocal = _debtPaymentDayOverrides.isNotEmpty;
+    if (!_mirrorReadsAuthoritative && hasLocal) {
+      return;
+    }
     try {
       final rows = await _supabase
           .from('asset_pref_mirror')
@@ -8959,6 +9066,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (value is! Map) {
         return;
       }
+      final mirrorUpdatedAt = DateTime.tryParse(
+        rows.first['updated_at']?.toString() ?? '',
+      );
       // 削除トゥームストーン済みの支払日上書きは復元しない (#part293 3例目)。
       final tombstoned = _debtOverrideTombstones.activeIds(
         await SharedPreferences.getInstance(),
@@ -8974,16 +9084,33 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           restored[key] = day;
         }
       });
-      if (restored.isEmpty || _debtPaymentDayOverrides.isNotEmpty || !mounted) {
+      if (restored.isEmpty || !mounted) {
+        return;
+      }
+      final adopt = await _shouldAdoptMirror(
+        prefKey: 'debt_payment_day_overrides',
+        hasLocal: hasLocal,
+        mirrorUpdatedAt: mirrorUpdatedAt,
+      );
+      if (!adopt || !mounted) {
         return;
       }
       setState(() {
         _debtPaymentDayOverrides = restored;
       });
       unawaited(_saveDebtPaymentDayOverrides());
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('支払日設定をサーバのバックアップから復元しました')),
+      unawaited(
+        _syncTimestampStore.markChanged(
+          'debt_payment_day_overrides',
+          at: mirrorUpdatedAt,
+        ),
       );
+      // 初回復元 (ローカル空) のときだけ通知。LWW での更新時は通知しない。
+      if (!hasLocal) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('支払日設定をサーバのバックアップから復元しました')),
+        );
+      }
     } catch (e) {
       debugPrint('pref mirror restore failed: $e');
     }

--- a/lib/services/asset_mirror_read_policy.dart
+++ b/lib/services/asset_mirror_read_policy.dart
@@ -1,0 +1,54 @@
+/// 集約 pref ミラー (`asset_pref_mirror`) の読み取りポリシー。
+///
+/// 既定 (フラグ OFF) は従来の「ローカル優先・ミラーはローカルが空のときだけ復元」。
+/// フラグ ON で「Supabase 正本化 Phase B」= サーバ行があれば last-write-wins で採用
+/// (詳細は docs/LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md)。
+///
+/// 本番有効化は dart-define で行い、無効化は即時ロールバック可能
+/// (リポジトリの `supabaseWritesEnabled` と同じ feature-flag パターン)。
+class AssetMirrorReadPolicy {
+  const AssetMirrorReadPolicy._();
+
+  static const String flagName = 'ASSET_MIRROR_READS_AUTHORITATIVE';
+
+  /// ビルド時フラグ。既定 false (= 現行挙動を維持。プロダクションは無変更)。
+  static const bool authoritative = bool.fromEnvironment(
+    flagName,
+    defaultValue: false,
+  );
+}
+
+/// LWW 解決の結果: サーバ行を採用するか、ローカルを維持するか。
+enum AssetMirrorAdoption { adoptMirror, keepLocal }
+
+/// 集約 pref ミラーの採否を last-write-wins で判定する純関数。
+///
+/// - ミラー無し → ローカル維持。
+/// - ローカル無し → ミラー採用。
+/// - 両方あり → `updated_at` が新しい方を採用 (同時刻はローカル維持で安定)。
+///   - ローカルの timestamp が null (= タイムスタンプ導入前の legacy ローカル) の場合は
+///     **ミラー採用**。ミラーはその端末自身の write-through 結果であり、サーバ正本化の
+///     方針上もサーバを優先するのが妥当なため (本番データ分布を確認したうえで有効化する)。
+///   - ミラーの timestamp が null (想定外) の場合は安全側でローカル維持。
+AssetMirrorAdoption resolveMirrorRead({
+  required bool hasLocal,
+  required bool hasMirror,
+  required DateTime? localUpdatedAt,
+  required DateTime? mirrorUpdatedAt,
+}) {
+  if (!hasMirror) {
+    return AssetMirrorAdoption.keepLocal;
+  }
+  if (!hasLocal) {
+    return AssetMirrorAdoption.adoptMirror;
+  }
+  if (localUpdatedAt == null) {
+    return AssetMirrorAdoption.adoptMirror;
+  }
+  if (mirrorUpdatedAt == null) {
+    return AssetMirrorAdoption.keepLocal;
+  }
+  return mirrorUpdatedAt.isAfter(localUpdatedAt)
+      ? AssetMirrorAdoption.adoptMirror
+      : AssetMirrorAdoption.keepLocal;
+}

--- a/lib/services/asset_sync_timestamp_store.dart
+++ b/lib/services/asset_sync_timestamp_store.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 集約 pref ドメインのローカル最終変更時刻 (`updated_at`) を pref_key ごとに
+/// 1 つの SharedPreferences キーへ集約保存する。
+///
+/// Supabase 正本化 Phase B の last-write-wins 判定で、ローカル変更とサーバ
+/// `asset_pref_mirror.updated_at` を比較するために使う
+/// ([AssetMirrorReadPolicy] / resolveMirrorRead)。
+class AssetSyncTimestampStore {
+  static const String prefsKey = 'asset_sync_timestamps_v1';
+
+  const AssetSyncTimestampStore();
+
+  Future<Map<String, DateTime>> loadAll({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getString(prefsKey);
+    if (raw == null || raw.isEmpty) {
+      return <String, DateTime>{};
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        return <String, DateTime>{};
+      }
+      final result = <String, DateTime>{};
+      decoded.forEach((key, value) {
+        if (key is String && value is String) {
+          final parsed = DateTime.tryParse(value);
+          if (parsed != null) {
+            result[key] = parsed;
+          }
+        }
+      });
+      return result;
+    } catch (_) {
+      return <String, DateTime>{};
+    }
+  }
+
+  Future<DateTime?> loadTimestamp(String prefKey,
+      {SharedPreferences? prefs}) async {
+    final all = await loadAll(prefs: prefs);
+    return all[prefKey];
+  }
+
+  /// [prefKey] のローカル変更時刻を [at] (既定は現在時刻) で記録する。
+  Future<void> markChanged(
+    String prefKey, {
+    DateTime? at,
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final all = await loadAll(prefs: store);
+    all[prefKey] = (at ?? DateTime.now()).toUtc();
+    final encoded = jsonEncode(<String, String>{
+      for (final entry in all.entries)
+        entry.key: entry.value.toUtc().toIso8601String(),
+    });
+    await store.setString(prefsKey, encoded);
+  }
+}

--- a/lib/services/asset_sync_timestamp_store.dart
+++ b/lib/services/asset_sync_timestamp_store.dart
@@ -39,8 +39,10 @@ class AssetSyncTimestampStore {
     }
   }
 
-  Future<DateTime?> loadTimestamp(String prefKey,
-      {SharedPreferences? prefs}) async {
+  Future<DateTime?> loadTimestamp(
+    String prefKey, {
+    SharedPreferences? prefs,
+  }) async {
     final all = await loadAll(prefs: prefs);
     return all[prefKey];
   }

--- a/test/services/asset_mirror_read_policy_test.dart
+++ b/test/services/asset_mirror_read_policy_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_mirror_read_policy.dart';
+
+void main() {
+  group('resolveMirrorRead (last-write-wins)', () {
+    final t1 = DateTime.utc(2026, 6, 14, 10, 0, 0);
+    final t2 = DateTime.utc(2026, 6, 14, 11, 0, 0);
+
+    test('no mirror → keep local', () {
+      expect(
+        resolveMirrorRead(
+          hasLocal: true,
+          hasMirror: false,
+          localUpdatedAt: t1,
+          mirrorUpdatedAt: null,
+        ),
+        AssetMirrorAdoption.keepLocal,
+      );
+    });
+
+    test('no local → adopt mirror', () {
+      expect(
+        resolveMirrorRead(
+          hasLocal: false,
+          hasMirror: true,
+          localUpdatedAt: null,
+          mirrorUpdatedAt: t1,
+        ),
+        AssetMirrorAdoption.adoptMirror,
+      );
+    });
+
+    test('both present, mirror newer → adopt mirror', () {
+      expect(
+        resolveMirrorRead(
+          hasLocal: true,
+          hasMirror: true,
+          localUpdatedAt: t1,
+          mirrorUpdatedAt: t2,
+        ),
+        AssetMirrorAdoption.adoptMirror,
+      );
+    });
+
+    test('both present, local newer → keep local (offline edit preserved)', () {
+      expect(
+        resolveMirrorRead(
+          hasLocal: true,
+          hasMirror: true,
+          localUpdatedAt: t2,
+          mirrorUpdatedAt: t1,
+        ),
+        AssetMirrorAdoption.keepLocal,
+      );
+    });
+
+    test('both present, equal timestamps → keep local (stable tie)', () {
+      expect(
+        resolveMirrorRead(
+          hasLocal: true,
+          hasMirror: true,
+          localUpdatedAt: t1,
+          mirrorUpdatedAt: t1,
+        ),
+        AssetMirrorAdoption.keepLocal,
+      );
+    });
+
+    test('both present, local timestamp null (legacy) → adopt mirror', () {
+      expect(
+        resolveMirrorRead(
+          hasLocal: true,
+          hasMirror: true,
+          localUpdatedAt: null,
+          mirrorUpdatedAt: t1,
+        ),
+        AssetMirrorAdoption.adoptMirror,
+      );
+    });
+
+    test('both present, mirror timestamp null → keep local (safe side)', () {
+      expect(
+        resolveMirrorRead(
+          hasLocal: true,
+          hasMirror: true,
+          localUpdatedAt: t1,
+          mirrorUpdatedAt: null,
+        ),
+        AssetMirrorAdoption.keepLocal,
+      );
+    });
+
+    test('flag default is OFF (production unchanged)', () {
+      expect(AssetMirrorReadPolicy.authoritative, isFalse);
+    });
+  });
+}

--- a/test/services/asset_sync_timestamp_store_test.dart
+++ b/test/services/asset_sync_timestamp_store_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AssetSyncTimestampStore', () {
+    const store = AssetSyncTimestampStore();
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('returns null when no timestamp stored', () async {
+      expect(await store.loadTimestamp('watchlist_entries'), isNull);
+    });
+
+    test('marks and reads back a per-key timestamp', () async {
+      final at = DateTime.utc(2026, 6, 14, 9, 30);
+      await store.markChanged('main_account_id', at: at);
+      expect(await store.loadTimestamp('main_account_id'), at);
+      // 別キーは独立。
+      expect(await store.loadTimestamp('watchlist_entries'), isNull);
+    });
+
+    test('keeps multiple keys independently and overwrites in place', () async {
+      final a = DateTime.utc(2026, 6, 14, 9, 0);
+      final b = DateTime.utc(2026, 6, 14, 10, 0);
+      final c = DateTime.utc(2026, 6, 14, 11, 0);
+      await store.markChanged('main_account_id', at: a);
+      await store.markChanged('watchlist_entries', at: b);
+      await store.markChanged('main_account_id', at: c);
+
+      expect(await store.loadTimestamp('main_account_id'), c);
+      expect(await store.loadTimestamp('watchlist_entries'), b);
+      expect((await store.loadAll()).length, 2);
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -909,5 +909,94 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets('Phase B flag on: mirror overrides non-empty local (LWW)', (
+      tester,
+    ) async {
+      // 端末B はローカルに古いウォッチリストを持つ (タイムスタンプ未記録 = legacy)。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'assetType': 'old_local',
+            'group': '',
+            'memo': '',
+            'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugMirrorReadsAuthoritative: true,
+            debugWatchlistMirror: AssetWatchlistService.encodeMirrorValue(
+              <AssetWatchlistEntry>[
+                AssetWatchlistEntry(
+                  assetType: 'server_new',
+                  group: 'invest',
+                  memo: '',
+                  addedAt: DateTime.utc(2026, 6, 14),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // フラグ ON の LWW でサーバ値が採用され、ローカルへ書き戻される。
+      final synced = await const AssetWatchlistService().loadEntries();
+      expect(synced.map((e) => e.assetType), contains('server_new'));
+      expect(synced.map((e) => e.assetType), isNot(contains('old_local')));
+
+      await _unmount(tester);
+    });
+
+    testWidgets('Phase B flag off (default): mirror does not clobber local', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'assetType': 'kept_local',
+            'group': '',
+            'memo': '',
+            'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            // debugMirrorReadsAuthoritative 未指定 = 既定 OFF。
+            debugWatchlistMirror: AssetWatchlistService.encodeMirrorValue(
+              <AssetWatchlistEntry>[
+                AssetWatchlistEntry(
+                  assetType: 'server_value',
+                  group: '',
+                  memo: '',
+                  addedAt: DateTime.utc(2026, 6, 14),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // フラグ OFF なので非空ローカルは維持される (従来挙動)。
+      final local = await const AssetWatchlistService().loadEntries();
+      expect(local.map((e) => e.assetType), contains('kept_local'));
+      expect(local.map((e) => e.assetType), isNot(contains('server_value')));
+
+      await _unmount(tester);
+    });
   });
 }


### PR DESCRIPTION
## 概要

ローカル永続の段階的縮退ロードマップ **Phase B** (`docs/LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md`)。
集約 pref 4ドメイン (`main_account_id` / `watchlist_entries` / `revolving_credit_configs` /
`debt_payment_day_overrides`) のミラー読みを「ローカル空のときだけ復元」→ **last-write-wins**
へ反転し、Supabase を正本に寄せる。**既定 OFF フラグの裏で実装するため本番挙動は無変更**。

## 変更点

- 純関数 `resolveMirrorRead` + フラグ `AssetMirrorReadPolicy.authoritative`
  (`bool.fromEnvironment('ASSET_MIRROR_READS_AUTHORITATIVE')` / 既定 false) を
  `lib/services/asset_mirror_read_policy.dart` に新規。
- ローカル最終変更時刻を `asset_sync_timestamps_v1` の 1 キーへ集約する
  `AssetSyncTimestampStore` を新規 (`lib/services/asset_sync_timestamp_store.dart`)。
- ページ: `_shouldAdoptMirror` 共通判定 + 4 つの `_restore*FromMirror` を LWW 化。
  ローカル変更時刻と `asset_pref_mirror.updated_at` を比較し新しい方を採用。採用時は
  ローカルへ書き戻し、時刻をミラーに揃えて収束。各 `_mirror*` で変更時刻を記録。
- 安全性: オフライン未同期のローカル編集は (ローカルが新しいため) 保持される。
  タイムスタンプ未記録の legacy ローカルはサーバ採用側に倒す (その端末自身の write-through 結果)。
- 残り (入金 items / 月次 state / clear 伝播) は Phase B.2。

## テスト

`flutter analyze` → 0 issues、対象テスト green:
- 純関数 `resolveMirrorRead` の全分岐 (ミラー無 / ローカル無 / 新旧 / 同時刻 / legacy / null)。
- `AssetSyncTimestampStore` の記録・読み戻し。
- widget 2: フラグ ON で非空ローカルにミラーが LWW 採用される / フラグ OFF (既定) で非クロバー。

## 有効化

`docs/LOCAL_PERSISTENCE_RETIREMENT_ROADMAP.md` に手順を記載: ① データ分布 SQL 確認 →
② staging で `--dart-define=ASSET_MIRROR_READS_AUTHORITATIVE=true` → ③ 本番。
ロールバックはフラグを外すだけ (即時)。

## Minimal E2E Gate

- 実装詳細に依存しない (black-box) 入出力契約のみ検証: 「ローカル値 + サーバ値 + フラグ」という
  入力に対し「採用結果 (どちらの値が残るか)」という観測可能な出力をアサートし、内部実装に
  依存しない。
- 最小限 (minimal) の 3 ケース相当 — フラグ ON 採用 / フラグ OFF 維持 / 純関数の新旧判定。
- 機構: 純関数テスト + widget テスト。公開サイトの Playwright / `integration_test/` の
  ブラウザ E2E は未追加。
- E2E-Exception: LWW はログイン状態・サーバ updated_at・ビルドフラグに依存し、公開
  ブラックボックス E2E では決定的に再現しづらいため、純関数テストと widget テストで担保する。

## レビュー

- Review owner: Claude Code #1。
- High-risk-ultrareview-exception: 変更は `lib/pages` `lib/services` `test` `docs` のみで、
  既定 OFF フラグの裏の実装 (本番無変更)、認証 / 課金 / インフラ配信などの高リスクパスに
  触れないため ultrareview 対象外とする。
