### PR TITLE
fix(asset): リボ設定が他端末に反映されない問題を修正 (union merge + backfill)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -270,6 +270,30 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         AssetMirrorAdoption.adoptMirror;
   }
 
+  /// サーバに当該 pref 行が無く、ローカルに値がある場合だけローカルをアップロード
+  /// する初回バックフィル。旧端末で mirror 化前に設定した値がサーバ未保存のまま
+  /// 他端末へ同期されない問題を解消する。
+  Future<void> _backfillPrefIfServerMissing(
+    String prefKey,
+    Future<void> Function() uploadLocal,
+  ) async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select('pref_key')
+          .eq('pref_key', prefKey)
+          .limit(1);
+      if (rows.isEmpty) {
+        await uploadLocal();
+      }
+    } catch (e) {
+      debugPrint('pref backfill check failed ($prefKey): $e');
+    }
+  }
+
   // --- 資産・負債（ストック）用変数 ---
   Map<String, TextEditingController> _controllers = {};
   List<String> _assetTypes = ['現金'];
@@ -5235,7 +5259,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     final hasLocal = _watchlistByType.isNotEmpty;
+    // フラグ OFF + ローカル値あり: サーバに無ければ初回バックフィルして終了。
     if (!_mirrorReadsAuthoritative && hasLocal && debugMirror == null) {
+      unawaited(
+        _backfillPrefIfServerMissing(_watchlistMirrorKey, _mirrorWatchlist),
+      );
       return;
     }
     try {
@@ -7798,8 +7826,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     final hasLocal = _assetManagementMainAccountId != null;
-    // フラグ OFF かつローカルに値がある場合は従来どおり何もしない (ネットワーク省略)。
+    // フラグ OFF + ローカル値あり: サーバに無ければ初回バックフィルして終了。
     if (!_mirrorReadsAuthoritative && hasLocal && debugMirror == null) {
+      unawaited(
+        _backfillPrefIfServerMissing(_mainAccountMirrorKey, _mirrorMainAccount),
+      );
       return;
     }
     try {
@@ -8030,15 +8061,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (debugMirror == null && _supabase.auth.currentUser == null) {
       return;
     }
-    final hasLocal = _revolvingConfigs.isNotEmpty;
-    if (!_mirrorReadsAuthoritative && hasLocal && debugMirror == null) {
-      return;
-    }
+    final localBefore = Map<String, AssetLiabilityRevolvingCreditConfig>.from(
+      _revolvingConfigs,
+    );
+    final hasLocal = localBefore.isNotEmpty;
     try {
-      final Map<String, AssetLiabilityRevolvingCreditConfig> restored;
+      final Map<String, AssetLiabilityRevolvingCreditConfig> serverConfigs;
       final DateTime? mirrorUpdatedAt;
       if (debugMirror != null) {
-        restored = AssetRevolvingCreditConfigStore.decodeMirrorValue(
+        serverConfigs = AssetRevolvingCreditConfigStore.decodeMirrorValue(
           debugMirror,
         );
         mirrorUpdatedAt = DateTime.now().toUtc();
@@ -8048,37 +8079,64 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             .select()
             .eq('pref_key', _revolvingConfigsMirrorKey);
         if (rows.isEmpty) {
+          // サーバ行が無い: ローカルにあれば初回バックフィル (旧端末で設定済みの
+          // リボ設定をサーバへ上げ、他端末へ同期させる)。
+          if (hasLocal) {
+            unawaited(_mirrorRevolvingConfigs());
+          }
           return;
         }
-        restored = AssetRevolvingCreditConfigStore.decodeMirrorValue(
+        serverConfigs = AssetRevolvingCreditConfigStore.decodeMirrorValue(
           rows.first['value'],
         );
         mirrorUpdatedAt = DateTime.tryParse(
           rows.first['updated_at']?.toString() ?? '',
         );
       }
-      if (restored.isEmpty || !mounted) {
+      if (!mounted) {
         return;
       }
-      final adopt = await _shouldAdoptMirror(
+      // 衝突キー (ローカルとサーバ両方にある負債) をサーバ採用するかは LWW
+      // (フラグ ON のみ。OFF はローカル維持)。
+      final adoptConflicts = await _shouldAdoptMirror(
         prefKey: _revolvingConfigsMirrorKey,
         hasLocal: hasLocal,
         mirrorUpdatedAt: mirrorUpdatedAt,
       );
-      if (!adopt || !mounted) {
-        return;
-      }
-      setState(() {
-        _revolvingConfigs = restored;
-      });
-      // オフライン参照用にローカルへ書き戻し、ローカル更新時刻をミラーへ揃える。
-      unawaited(_revolvingConfigStore.save(_revolvingConfigs));
-      unawaited(
-        _syncTimestampStore.markChanged(
-          _revolvingConfigsMirrorKey,
-          at: mirrorUpdatedAt,
-        ),
+      // union マージ: ローカルに無い負債キーはサーバから追加 (additive・安全)。
+      // これで「他端末で設定したカードのリボ設定」がこの端末にも反映される。
+      final merged = Map<String, AssetLiabilityRevolvingCreditConfig>.from(
+        localBefore,
       );
+      var changed = false;
+      serverConfigs.forEach((key, config) {
+        if (!merged.containsKey(key) || adoptConflicts) {
+          merged[key] = config;
+          changed = true;
+        }
+      });
+      if (changed && mounted) {
+        setState(() {
+          _revolvingConfigs = merged;
+        });
+        unawaited(_revolvingConfigStore.save(merged));
+        if (adoptConflicts) {
+          unawaited(
+            _syncTimestampStore.markChanged(
+              _revolvingConfigsMirrorKey,
+              at: mirrorUpdatedAt,
+            ),
+          );
+        }
+      }
+      // ローカルにあってサーバに無い負債キーは、マージ結果をサーバへ
+      // バックフィルし、サーバを全端末の和集合に保つ。
+      final localHasExtra = localBefore.keys.any(
+        (key) => !serverConfigs.containsKey(key),
+      );
+      if (localHasExtra && debugMirror == null) {
+        unawaited(_mirrorRevolvingConfigs());
+      }
     } catch (e) {
       debugPrint('revolving config mirror restore failed: $e');
     }
@@ -9051,7 +9109,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     final hasLocal = _debtPaymentDayOverrides.isNotEmpty;
+    // フラグ OFF + ローカル値あり: サーバに無ければ初回バックフィルして終了。
     if (!_mirrorReadsAuthoritative && hasLocal) {
+      unawaited(
+        _backfillPrefIfServerMissing(
+          'debt_payment_day_overrides',
+          () => _mirrorDebtPaymentDayOverrides(_debtPaymentDayOverrides),
+        ),
+      );
       return;
     }
     try {

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -998,5 +998,54 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets('revolving union-merge: server card fills in, local card kept',
+        (
+      tester,
+    ) async {
+      // 端末B はローカルに別カードのリボ設定だけ持つ (auPAY は未設定)。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        AssetRevolvingCreditConfigStore.prefsKey: jsonEncode(
+          AssetRevolvingCreditConfigStore.encodeMirrorValue(
+            <String, AssetLiabilityRevolvingCreditConfig>{
+              'other_card': const AssetLiabilityRevolvingCreditConfig(
+                monthlyAmount: 3000,
+                creditLimit: 100000,
+              ),
+            },
+          ),
+        ),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 端末A が auPAY のリボ設定をサーバへ保存済みの状態をミラー注入。
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugRevolvingConfigsMirror:
+                AssetRevolvingCreditConfigStore.encodeMirrorValue(
+              <String, AssetLiabilityRevolvingCreditConfig>{
+                'aupay_card': const AssetLiabilityRevolvingCreditConfig(
+                  monthlyAmount: 10000,
+                  creditLimit: 500000,
+                ),
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // union マージ: サーバの auPAY が反映され、かつローカルの別カードも維持。
+      final merged = await const AssetRevolvingCreditConfigStore().load();
+      expect(merged.keys, containsAll(<String>['other_card', 'aupay_card']));
+      expect(merged['aupay_card']!.monthlyAmount, 10000);
+      expect(merged['aupay_card']!.creditLimit, 500000);
+      expect(merged['other_card']!.monthlyAmount, 3000);
+
+      await _unmount(tester);
+    });
   });
 }


### PR DESCRIPTION
## 概要

PC で設定した auPAY カードのリボ払い設定がスマホに反映されない不具合を修正する。

## 原因

リボ設定のミラー復元 (`_restoreRevolvingConfigsFromMirror`) が「ローカルが空のときだけ
マップ全体を置換」だったため:

1. スマホ側に**別カードのリボ設定がローカルにある**と、マップ全体の復元がスキップされ、
   サーバの auPAY 設定が取り込まれない。
2. ミラー機能の導入**前に設定した既存のローカル設定**は、変更しない限りサーバへ上がらず
   (保存時のみ upsert)、他端末に同期されない。

## 修正

- **union マージ**: リボ復元を「サーバにあってローカルに無い負債キーは additive に追加」へ。
  他カードのローカル設定は維持し、衝突キーは従来どおりローカル維持 (LWW フラグ ON のときのみ
  サーバ採用)。これでスマホに auPAY 設定が入る。
- **バックフィル**: サーバ行が無く・ローカルに値がある場合はローカルをアップロードする
  `_backfillPrefIfServerMissing` を追加し、リボ / メイン口座 / ウォッチリスト / 支払日上書きの
  復元へ適用。旧端末の既存設定が初回ブートでサーバへ同期される。
- いずれも additive・条件付きアップロードで、既存のサーバ値を上書きしない安全な変更。

## テスト

`flutter analyze` → 0 issues、対象テスト green (25 件):
- 追加 widget テスト: ローカルに別カードのリボ設定がある状態でサーバの auPAY 設定が
  union マージで反映され、ローカルの別カードも維持されることを検証。

## Minimal E2E Gate

- 実装詳細に依存しない (black-box) 入出力契約のみ検証: 「ローカルのリボ設定 + サーバの
  リボ設定」という入力に対し「マージ後のローカル設定」という観測可能な出力をアサートし、
  内部実装に依存しない。
- 最小限 (minimal) の 3 ケース相当 — サーバキー追加 / ローカルキー維持 / 値の一致。
- 機構: widget テスト。公開サイトの Playwright / `integration_test/` のブラウザ E2E は未追加。
- E2E-Exception: 端末間同期はログイン状態と Supabase 上のデータに依存し、公開
  ブラックボックス E2E では決定的に再現しづらいため、widget テストで担保する。

## レビュー

- Review owner: Claude Code #1。
- High-risk-ultrareview-exception: 変更は `lib/pages` `test` のみで、認証 / 課金 /
  インフラ配信などの高リスクパスに触れない、additive・条件付きアップロードのみの不具合修正の
  ため ultrareview 対象外とする。
