### PR TITLE
[CI/CD自動最適化] 2026-06-14: edge-function-audit リグレッション修正 + monthly-asset-report 削減

### DIFF
--- a/.github/workflows/edge-function-audit.yml
+++ b/.github/workflows/edge-function-audit.yml
@@ -1,14 +1,14 @@
 name: Edge Function UI Audit (UI導線チェック)
 
-# 毎時47分 + 手動実行
+# 毎4時間47分 + 手動実行 (ci-cost-audit 2026-06-08: 毎時→毎4時間, 2026-06-14: リグレッション再修正)
 on:
   schedule:
-    - cron: "47 * * * *"
+    - cron: "47 */4 * * *"
   workflow_dispatch:
 
 concurrency:
   group: edge-function-audit
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/monthly-asset-report.yml
+++ b/.github/workflows/monthly-asset-report.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     # Month-end 24:00 JST is 15:00 UTC. The script gates daily runs to
     # the JST month rollover because GitHub cron has no last-day syntax.
-    - cron: "0 15 * * *"
+    # ci-cost-audit 2026-06-14: 毎日→月末4日のみ (days 28-31), ~89% 削減 (~324 runs/年)
+    - cron: "0 15 28-31 * *"
   workflow_dispatch:
     inputs:
       year_month:

--- a/docs/ci-cd-audit/2026-06-14.md
+++ b/docs/ci-cd-audit/2026-06-14.md
@@ -1,0 +1,138 @@
+# CI/CD コスト監査 2026-06-14
+
+自動生成 by CI/CD コスト最適化エージェント (claude-schedule)
+
+---
+
+## サマリ
+
+| 項目 | 値 |
+|------|---|
+| 総ワークフロー数 | 106 件 |
+| cron 定義数 | 66 件 |
+| 推定 billable 時間 (schedule only, 月換算) | ~220 min/日 × 30 = 6,600 min/月 |
+| 本日自動適用した変更 | 2 ファイル |
+| 今回推定削減 | 324 runs/年 (5.4 h/年) |
+
+### 前回からの継続改善サマリー (Issue #3175)
+
+| 適用日 | 内容 | 削減効果 |
+|--------|------|---------|
+| 06-04 | ci.yml pub cache 追加 | ~2 min/PR |
+| 06-04 | memory-search-sync.yml concurrency 追加 | エラー回避 |
+| 06-06 | health-monitor.yml cron 30分→1時間 | ~720 runs/月削減 |
+| 06-08 | feature-review.yml cron 毎時→毎4時間 | ~22.8 min/日 |
+| 06-08 | edge-function-audit.yml cron 毎時→毎4時間 | ~9 min/日 |
+| 06-09 | blog-publish-orphan-cleanup + stale-ef-completeness-check concurrency 追加 | git 競合回避 |
+| 06-10 | cs-check.yml 毎時→2時間 | ~360 runs/月削減 |
+| 06-11 | memory-search-sync.yml 毎時→2時間 | ~360 runs/月削減 |
+| **06-14** | **monthly-asset-report.yml cron 毎日→月末4日** | **~324 runs/年削減 (89%)** |
+| **06-14** | **edge-function-audit.yml cancel-in-progress: true 追加** | 手動実行競合防止 |
+
+---
+
+## ワークフロー別コスト表 (TOP 高頻度)
+
+| ワークフロー名 | 頻度 | 平均時間 | runner | トリガー |
+|--------------|------|---------|--------|---------|
+| claude-session-hygiene-cron | 21x/日 (0-17, 21-23 UTC) | ~0.6 min | **windows-latest** | schedule |
+| health-monitor | 24x/日 | ~0.4 min | ubuntu | schedule |
+| ai-university-update | 12x/日 | ~1.0 min | ubuntu | schedule |
+| horse-racing-update | 12x/日 | ~5.5 min | ubuntu | schedule |
+| cs-check | 12x/日 | ~0.3 min | ubuntu | schedule |
+| mcp-audit-anomaly-cron | 12x/日 | ~0.4 min | ubuntu | schedule |
+| wbs-ai-review | 12x/日 | ~0.3 min | ubuntu | schedule |
+| issue-to-wbs | 12x/日 + issues event | ~3.9 min | ubuntu | schedule+events |
+| notion-sync | 12x/日 | ~3.1 min | ubuntu | schedule |
+| infra-health-check | 12x/日 | ~0.5 min | ubuntu | schedule |
+| edge-function-audit | 6x/日 | ~0.2 min | ubuntu | schedule |
+| feature-review | 6x/日 | ~0.9 min | ubuntu | schedule |
+| schedule-resilience-watch | 6x/日 | ~0.4 min | ubuntu | schedule |
+| tools-hub-mcp-smoke | 4x/日 | ~0.1 min | ubuntu | schedule |
+| blog-publish | 1x/日 | ~0.4 min | ubuntu | schedule |
+| daily-report | 1x/日 | - | ubuntu | schedule |
+| **monthly-asset-report** | **1x/日→月末4日のみ** | ~1 min | ubuntu | schedule |
+
+---
+
+## 検出した冗長フロー (パターン A–G)
+
+### 🔴 HIGH
+
+#### D-1. `monthly-asset-report.yml` — 毎日実行だが実質月末1回のみ
+- **現状**: `cron: "0 15 * * *"` = 365 runs/年
+- **問題**: スクリプト内部で「今日が JST 月末か？」をチェックして早期終了。毎日 runner を起動しているが実効実行は月末のみ
+- **修正**: `cron: "0 15 28-31 * *"` (月の 28〜31 日のみ実行) = ~41 runs/年
+- **推定削減**: **~324 runs/年、~324 min/年 (89% 削減)**
+- **リスク**: 極低 — 内部の月末チェックは維持されるため 2月/31日なし月も正常動作
+
+### 🟡 MED
+
+#### B-1. `edge-function-audit.yml` — cancel-in-progress: false (4h cron)
+- **現状**: 6x/日、`cancel-in-progress: false`
+- **問題**: workflow_dispatch 実行中に schedule が重なった場合、キューに積まれ両者が完走する。audit は冪等 (Supabase upsert) なので重複実行は無駄
+- **修正**: `cancel-in-progress: true` 追加
+- **推定削減**: 手動実行競合時 ~0.2 min/回 × 年数回 = 微量だが runner 清潔化
+- **リスク**: 極低 — 純粋な audit、Supabase upsert は冪等
+
+#### B-2. `youtube-analysis.yml` — cancel-in-progress: false (daily)
+- **現状**: 1x/日 20 min timeout、`cancel-in-progress: false`
+- **問題**: 手動実行と schedule が重なると 20 min の重複実行
+- **提案**: `cancel-in-progress: true` 追加 (次回バッチ候補)
+- **リスク**: 低 — contents: write / PR 作成あり、cancel 中断で孤立 PR が残る可能性
+- **アクション**: 今回は Issue 提案のみ
+
+#### D-2. `claude-session-hygiene-cron.yml` — windows-latest で 21x/日 (Issue提案のみ)
+- **現状**: `windows-latest` (billable: ubuntu の 2x コスト) で毎時 21h 帯実行
+- **問題**: windows runner の一般化メトリクス取得のみなら ubuntu でも代替可能。ただし「Windows ランナー実機 C: ドライブ状態」チェックが目的であれば必須
+- **提案**: スクリプト内の OS 依存チェックを確認し、ubuntu 移行可否を判断
+- **推定削減**: 21x/日 × 1x コスト差 × 0.6 min = **~12.6 min/日追加等価削減**
+- **アクション**: 本実行は Issue 提案のみ (環境依存のため自動変更せず)
+
+#### F-1. `GitHub Issues WBS Sync` — cancel=true で 75% キャンセル率
+- **観測**: sample 8 runs 中 6 cancel (75%) — issues event の高頻度発火でキャンセルが連鎖
+- **評価**: cancel-in-progress: true は**正しい設定** (重複 WBS 同期を防ぐ)。45 min timeout で並列起動されると深刻なため現状維持
+- **監視継続**: cancel 率が 90% を超えたら issues event trigger の見直しを検討
+
+### 🟢 LOW
+
+#### G-1. `cron-batch.yml` — schedule 無効化済み・workflow_dispatch のみ
+- **現状**: コメントに「schedule は SUPABASE_SERVICE_ROLE_KEY 設定後に戻す」と記載。事実上休眠状態
+- **提案**: 廃止または secrets 整備後の復活計画策定
+- **アクション**: Issue 提案のみ
+
+---
+
+## 改善提案 (未適用分)
+
+| # | 対象 | 提案 | 推定削減効果 | 優先度 |
+|---|------|------|------------|-------|
+| 1 | `youtube-analysis.yml` | `cancel-in-progress: true` | 稀な重複 20 min 回避 | MED |
+| 2 | `claude-session-hygiene-cron.yml` | Ubuntu 移行可否確認 | ~12.6 min/日 (相当) | MED |
+| 3 | `cron-batch.yml` | secrets 整備または廃止 | 運用コスト削減 | LOW |
+| 4 | `horse-racing-update.yml` | 12x/日 → 6x/日 検討 (2h→4h) | ~30 min/日 | LOW |
+
+---
+
+## 自動適用した変更 (本実行で main へ入れた分)
+
+| ファイル | 変更内容 | 推定削減効果 |
+|---------|---------|------------|
+| `monthly-asset-report.yml` | cron `0 15 * * *` → `0 15 28-31 * *` | ~324 runs/年削減 (89%) |
+| `edge-function-audit.yml` | `cancel-in-progress: false` → `true` | 手動実行競合防止 |
+
+---
+
+## 削除候補 (根拠付き・即削除しない)
+
+| ワークフロー | 根拠 | 推奨アクション |
+|------------|------|-------------|
+| `cron-batch.yml` | schedule 無効・secrets 未設定で事実上停止中 | secrets 整備か削除を Issue で確認 |
+
+---
+
+## 次回バッチ候補 (2026-06-15 以降)
+
+1. `youtube-analysis.yml` — cancel-in-progress: true 追加
+2. `claude-session-hygiene-cron.yml` — ubuntu 移行可否確認・Issue 作成
+3. `horse-racing-update.yml` — 12x/日 → 6x/日 cron 頻度削減


### PR DESCRIPTION
## 変更概要

本 PR は CI/CD コスト最適化エージェント (claude-schedule) による自動最適化です。

### 変更ファイル (2件)

| ファイル | 変更内容 | 推定削減効果 |
|---------|---------|------------|
| `edge-function-audit.yml` | cron `47 * * * *` → `47 */4 * * *` + `cancel-in-progress: true` 追加 | **~432 runs/月削減** (リグレッション修正) |
| `monthly-asset-report.yml` | cron `0 15 * * *` → `0 15 28-31 * *` | **~324 runs/年削減 (89%)** |

### edge-function-audit リグレッション

- 2026-06-08 の ci-cost-audit で毎時→毎4時間 に削減済みだったが、その後の変更で `47 * * * *` (毎時) に戻っていた
- 再適用: `47 */4 * * *` (毎4時間)
- 合わせて `cancel-in-progress: true` を追加 (manual dispatch と schedule の競合防止、audit は冪等)

### monthly-asset-report cron 最適化

- スクリプト内部で「今日が JST 月末か？」を確認し、月末でなければ早期終了する設計
- にもかかわらず毎日 runner を起動していた (365 runs/年)
- `0 15 28-31 * *` (月の 28〜31 日のみ) に変更で ~41 runs/年 → **89% 削減**
- 2 月末 (28 日) も含まれるため全月カバー

## 監査レポート

`docs/ci-cd-audit/2026-06-14.md` (本 PR に含む)

Issue #3175 に追記済み。

## リスク評価

- **破壊的変更なし** — cron 変更は可逆、cancel=true は audit(idempotent) のみ適用
- **deploy 系は無変更** — deploy-prod/dev/staging は対象外

https://github.com/kanta13jp1/my_web_app/issues/3175

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJqKyMG6BhNK3inSLmrFub)_