### PR TITLE
feat: Xシェア機能 + フィードバックをAI自動対応パイプラインに接続

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -21,6 +21,7 @@ import '../services/feature_strategy_ai_review_service.dart';
 import '../services/feature_strategy_focus_action_service.dart';
 import '../services/feature_strategy_monitor_service.dart';
 import '../services/feature_strategy_report_snapshot_service.dart';
+import '../services/grow_together_share.dart';
 import '../services/home_tool_usage_service.dart';
 import '../services/life_waste_elimination_service.dart';
 import '../services/personality_test_service.dart';
@@ -53,6 +54,7 @@ import '../widgets/ga_readiness_gate_panel.dart';
 import '../widgets/ai_university_home_card.dart';
 import '../widgets/api_key_status_banner.dart';
 import '../widgets/feature_strategy_monitor_panel.dart';
+import '../widgets/grow_together_share_card.dart';
 import '../widgets/kgi_csf_kpi_panel.dart';
 import '../widgets/life_waste_elimination_panel.dart';
 import '../widgets/referral_share_card.dart';
@@ -6693,7 +6695,7 @@ abstinence_slip_details: $slipDetailsText
       );
     }
 
-    return Card(
+    final formCard = Card(
       elevation: 0,
       color: isDark ? const Color(0xFF111827) : Colors.white,
       shape: RoundedRectangleBorder(
@@ -6896,6 +6898,56 @@ abstinence_slip_details: $slipDetailsText
                           label: const Text('Issue URLコピー'),
                         ),
                       ],
+                      const SizedBox(height: 10),
+                      const Divider(height: 1, color: Color(0x33047857)),
+                      const SizedBox(height: 10),
+                      const Text(
+                        '要望をありがとうございます。あなたの一言がそのまま開発タスクになります。'
+                        'この仕組みをXで広めて、一緒にアプリを育てる仲間を増やしませんか？',
+                        style: TextStyle(
+                          color: Color(0xFF065F46),
+                          fontSize: 12,
+                          height: 1.6,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: FilledButton.icon(
+                          key: const Key(
+                            'feature_request_share_x_button',
+                          ),
+                          onPressed: () async {
+                            final messenger = ScaffoldMessenger.of(context);
+                            final opened =
+                                await GrowTogetherShare.launchXShare();
+                            if (!mounted || opened) return;
+                            messenger.showSnackBar(
+                              const SnackBar(
+                                content: Text(
+                                  'Xの投稿画面を開けませんでした。本文をコピーして共有してください。',
+                                ),
+                              ),
+                            );
+                          },
+                          style: FilledButton.styleFrom(
+                            backgroundColor: const Color(0xFF000000),
+                            foregroundColor: Colors.white,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          icon: const Text(
+                            '𝕏',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          label: const Text('Xでシェアして仲間を増やす'),
+                        ),
+                      ),
                     ],
                   ),
                 ),
@@ -6904,6 +6956,15 @@ abstinence_slip_details: $slipDetailsText
           ),
         ),
       ),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        formCard,
+        const SizedBox(height: 16),
+        GrowTogetherShareCard(isDark: isDark, isCompact: isCompact),
+      ],
     );
   }
 

--- a/lib/services/grow_together_share.dart
+++ b/lib/services/grow_together_share.dart
@@ -23,7 +23,9 @@ class GrowTogetherShare {
       '自分株式会社';
 
   /// クリップボードへコピーする用の、URL を含む完全な共有文。
-  static String get fullShareMessage => '$shareText\n$appUrl';
+  /// `shareText` と `appUrl` がともに const のため、これ自体も const にできる
+  /// （const ClipboardData などの const コンテキストで利用するため）。
+  static const String fullShareMessage = '$shareText\n$appUrl';
 
   /// X の投稿 intent URL を生成する純関数。
   ///

--- a/lib/services/grow_together_share.dart
+++ b/lib/services/grow_together_share.dart
@@ -17,8 +17,7 @@ class GrowTogetherShare {
 
   /// X 投稿の本文。URL は intent の `url` パラメータで別途付与するため含めない
   /// （X 側が t.co 短縮し、本文の文字数を圧迫しないようにするため）。
-  static const String shareText =
-      'ユーザーが機能追加要望や改善要望、不具合報告をすると、'
+  static const String shareText = 'ユーザーが機能追加要望や改善要望、不具合報告をすると、'
       'AIが勝手にそれに対応してくれるアプリを作りました。\n\n'
       '使ってみてください。みんなでアプリを育てられます。\n\n'
       '自分株式会社';

--- a/lib/services/grow_together_share.dart
+++ b/lib/services/grow_together_share.dart
@@ -1,0 +1,54 @@
+import 'package:url_launcher/url_launcher.dart';
+
+/// 「みんなでアプリを育てる」X (旧 Twitter) シェア用の正本テキストとリンク生成。
+///
+/// 自分株式会社は、ユーザーが機能追加要望・改善要望・不具合報告を送ると、
+/// それを自動で GitHub Issue 化し、`github-issue-fix` レーン (draft PR 自動起票)
+/// と Claude / Codex の AI 開発フリートが対応に着手する仕組みを備えている。
+/// この文言はその「みんなで育てるアプリ」という体験を共有するためのもの。
+///
+/// 副作用を持たない純関数 ([buildXIntentUrl] / [fullShareMessage]) を中心に置き、
+/// 文字列・URL 生成を単体テストできるようにしている。
+class GrowTogetherShare {
+  const GrowTogetherShare._();
+
+  /// 本番サイト URL（X intent の `url` パラメータにも使用）。
+  static const String appUrl = 'https://my-web-app-b67f4.web.app/';
+
+  /// X 投稿の本文。URL は intent の `url` パラメータで別途付与するため含めない
+  /// （X 側が t.co 短縮し、本文の文字数を圧迫しないようにするため）。
+  static const String shareText =
+      'ユーザーが機能追加要望や改善要望、不具合報告をすると、'
+      'AIが勝手にそれに対応してくれるアプリを作りました。\n\n'
+      '使ってみてください。みんなでアプリを育てられます。\n\n'
+      '自分株式会社';
+
+  /// クリップボードへコピーする用の、URL を含む完全な共有文。
+  static String get fullShareMessage => '$shareText\n$appUrl';
+
+  /// X の投稿 intent URL を生成する純関数。
+  ///
+  /// `text`（本文）と `url`（リンク）を分けて渡すことで、X が URL を自動で
+  /// t.co 短縮し、本文の文字数超過を避ける。副作用を持たないためテスト容易。
+  static Uri buildXIntentUrl() {
+    return Uri.https('x.com', '/intent/tweet', <String, String>{
+      'text': shareText,
+      'url': appUrl,
+    });
+  }
+
+  /// X の投稿画面を開く。Web では別タブ、その他では外部アプリで開く。
+  ///
+  /// 成功可否を返す（ポップアップブロック等で開けなかった場合は false）。
+  static Future<bool> launchXShare() async {
+    final uri = buildXIntentUrl();
+    if (!await canLaunchUrl(uri)) {
+      return false;
+    }
+    return launchUrl(
+      uri,
+      mode: LaunchMode.externalApplication,
+      webOnlyWindowName: '_blank',
+    );
+  }
+}

--- a/lib/widgets/grow_together_share_card.dart
+++ b/lib/widgets/grow_together_share_card.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../services/grow_together_share.dart';
+
+/// 「みんなでアプリを育てる」を X (旧 Twitter) で共有するためのカード。
+///
+/// 自分株式会社の体験 — ユーザーが要望・不具合を送ると AI が自動で
+/// 対応に着手する — を広めるための共有導線。本文は [GrowTogetherShare] に
+/// 正本として置き、ここでは表示と起動のみを担う。
+///
+/// テスト時に外部リンクを実際に開かないよう、[onShareToX] / [onCopyMessage]
+/// を差し替え可能にしている。
+class GrowTogetherShareCard extends StatelessWidget {
+  const GrowTogetherShareCard({
+    super.key,
+    this.isDark = false,
+    this.isCompact = false,
+    this.onShareToX,
+    this.onCopyMessage,
+  });
+
+  final bool isDark;
+  final bool isCompact;
+
+  /// X 共有のフック。未指定時は実際に X の投稿画面を開く。
+  final Future<bool> Function()? onShareToX;
+
+  /// クリップボードコピーのフック。未指定時は本文をコピーする。
+  final Future<void> Function()? onCopyMessage;
+
+  Future<void> _handleShare(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final opened = await (onShareToX ?? GrowTogetherShare.launchXShare)();
+    if (!context.mounted) return;
+    if (!opened) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Xの投稿画面を開けませんでした。本文をコピーして共有してください。'),
+        ),
+      );
+    }
+  }
+
+  Future<void> _handleCopy(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final copy = onCopyMessage ??
+        () => Clipboard.setData(
+              const ClipboardData(text: GrowTogetherShare.fullShareMessage),
+            );
+    await copy();
+    if (!context.mounted) return;
+    messenger.showSnackBar(
+      const SnackBar(content: Text('共有用の本文をコピーしました')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      key: const Key('grow_together_share_card'),
+      elevation: 0,
+      color: isDark ? const Color(0xFF0B1220) : const Color(0xFFF8FAFF),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(
+          color: isDark
+              ? Colors.white.withValues(alpha: 0.14)
+              : const Color(0xFFD7DEF5),
+        ),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(isCompact ? 14 : 18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF000000),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const Center(
+                    child: Text(
+                      '𝕏',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 20,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'みんなでアプリを育てる',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w800,
+                          height: 1.4,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '要望・不具合を送るとAIが自動で対応に着手します。'
+                        'この仕組みをXで広めて、一緒に育てる仲間を増やしましょう。',
+                        style: theme.textTheme.bodySmall?.copyWith(height: 1.5),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 14),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: isDark
+                    ? const Color(0xFF0F172A)
+                    : Colors.white.withValues(alpha: 0.7),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: isDark
+                      ? Colors.white.withValues(alpha: 0.08)
+                      : const Color(0xFFE2E8F0),
+                ),
+              ),
+              child: Text(
+                GrowTogetherShare.fullShareMessage,
+                style: theme.textTheme.bodySmall?.copyWith(height: 1.6),
+              ),
+            ),
+            const SizedBox(height: 14),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                FilledButton.icon(
+                  key: const Key('grow_together_share_x_button'),
+                  onPressed: () => _handleShare(context),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: const Color(0xFF000000),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  icon: const Text(
+                    '𝕏',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  label: const Text('Xでシェア'),
+                ),
+                OutlinedButton.icon(
+                  key: const Key('grow_together_copy_button'),
+                  onPressed: () => _handleCopy(context),
+                  icon: const Icon(Icons.copy_outlined, size: 16),
+                  label: const Text('本文をコピー'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/supabase/functions/core-hub/feedback_issue.ts
+++ b/supabase/functions/core-hub/feedback_issue.ts
@@ -1,0 +1,108 @@
+// feedback_issue.ts — 「ご意見・ご要望」フォームの投稿を GitHub Issue 化するための
+// 純粋なタイトル/本文/ラベル生成ロジック。
+//
+// ユーザーの要望・不具合報告を `github-issue-fix` レーン (draft PR 自動起票 +
+// AI フリート対応) に確実に載せるため、カテゴリごとに正しいラベルを付与する。
+// 副作用を持たないため Deno test で網羅検証する。
+
+export interface FeedbackIssueDraft {
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+interface FeedbackCategoryConfig {
+  /** タイトル接頭辞。 */
+  prefix: string;
+  /** 人間可読なカテゴリ名。 */
+  label: string;
+  /**
+   * Issue ラベル。`github-issue-fix.yml` は
+   * bug / enhancement / feature / user-feedback のいずれかを対象に拾う。
+   */
+  labels: string[];
+}
+
+const FEEDBACK_CATEGORY_CONFIGS: Record<string, FeedbackCategoryConfig> = {
+  feature: {
+    prefix: "[追加要望]",
+    label: "機能改善・追加要望",
+    labels: ["enhancement", "追加要望", "user-feedback", "wbs"],
+  },
+  bug: {
+    prefix: "[不具合]",
+    label: "不具合・動作不良",
+    labels: ["bug", "user-feedback", "wbs"],
+  },
+  other: {
+    prefix: "[ご意見]",
+    label: "その他のご意見",
+    labels: ["user-feedback", "wbs"],
+  },
+};
+
+/** カテゴリ設定を取得する（未知のカテゴリは other 扱い）。 */
+export function feedbackCategoryConfig(
+  category: string,
+): FeedbackCategoryConfig {
+  return FEEDBACK_CATEGORY_CONFIGS[category] ?? FEEDBACK_CATEGORY_CONFIGS.other;
+}
+
+/** 本文の先頭行から Issue タイトルの要約を作る。 */
+export function buildFeedbackIssueTitle(
+  category: string,
+  message: string,
+): string {
+  const { prefix } = feedbackCategoryConfig(category);
+  const firstLine = message
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0) ?? "";
+  const summary = firstLine.length > 60
+    ? `${firstLine.slice(0, 57)}...`
+    : firstLine;
+  const safeSummary = summary.length > 0
+    ? summary
+    : "ユーザーからのフィードバック";
+  return `${prefix} ${safeSummary}`;
+}
+
+/** フィードバック投稿から GitHub Issue の下書きを生成する。 */
+export function buildFeedbackIssue(params: {
+  category: string;
+  message: string;
+  userEmail?: string;
+  createdAt?: string;
+}): FeedbackIssueDraft {
+  const config = feedbackCategoryConfig(params.category);
+  const title = buildFeedbackIssueTitle(params.category, params.message);
+  const trimmedMessage = params.message.trim();
+
+  const lines: string[] = [
+    `## ${config.label}`,
+    "",
+    "### 内容",
+    "",
+    trimmedMessage.length > 0 ? trimmedMessage : "(本文なし)",
+    "",
+    "### メタデータ",
+    "",
+    `- 種別: ${config.label} (${params.category})`,
+    `- 送信者: ${
+      params.userEmail && params.userEmail.length > 0
+        ? params.userEmail
+        : "(不明)"
+    }`,
+  ];
+  if (params.createdAt && params.createdAt.length > 0) {
+    lines.push(`- 受付: ${params.createdAt}`);
+  }
+  lines.push(
+    "",
+    "---",
+    "このIssueは自分株式会社アプリの「ご意見・ご要望」フォームから自動起票されました。",
+    "`github-issue-fix` レーンが draft PR を起票し、Claude / Codex の AI フリートが対応に着手します。",
+  );
+
+  return { title, body: lines.join("\n"), labels: config.labels };
+}

--- a/supabase/functions/core-hub/feedback_issue_test.ts
+++ b/supabase/functions/core-hub/feedback_issue_test.ts
@@ -1,0 +1,76 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildFeedbackIssue,
+  buildFeedbackIssueTitle,
+  feedbackCategoryConfig,
+} from "./feedback_issue.ts";
+
+Deno.test("bug feedback maps to the bug label so github-issue-fix picks it up", () => {
+  const config = feedbackCategoryConfig("bug");
+  assert(config.labels.includes("bug"));
+  assert(config.labels.includes("user-feedback"));
+  assertEquals(config.prefix, "[不具合]");
+});
+
+Deno.test("feature feedback maps to enhancement + user-feedback labels", () => {
+  const config = feedbackCategoryConfig("feature");
+  assert(config.labels.includes("enhancement"));
+  assert(config.labels.includes("user-feedback"));
+});
+
+Deno.test("unknown category falls back to other (still tracked as user-feedback)", () => {
+  const config = feedbackCategoryConfig("totally-unknown");
+  assertEquals(config.prefix, "[ご意見]");
+  assert(config.labels.includes("user-feedback"));
+});
+
+Deno.test("issue title summarizes the first non-empty line and truncates", () => {
+  assertEquals(
+    buildFeedbackIssueTitle("bug", "カレンダーが固まる\n再現手順は..."),
+    "[不具合] カレンダーが固まる",
+  );
+
+  const long = "あ".repeat(80);
+  const title = buildFeedbackIssueTitle("feature", long);
+  assert(title.startsWith("[追加要望] "));
+  assert(title.endsWith("..."));
+  // prefix (8 chars) + 57 chars + "..." (3)
+  assert(title.length <= 8 + 57 + 3);
+});
+
+Deno.test("blank message still produces a safe title", () => {
+  assertEquals(
+    buildFeedbackIssueTitle("other", "   \n  "),
+    "[ご意見] ユーザーからのフィードバック",
+  );
+});
+
+Deno.test("buildFeedbackIssue embeds category, content, and submitter", () => {
+  const draft = buildFeedbackIssue({
+    category: "bug",
+    message: "保存ボタンが反応しない",
+    userEmail: "user@example.com",
+    createdAt: "2026-06-14T00:00:00.000Z",
+  });
+
+  assertEquals(draft.title, "[不具合] 保存ボタンが反応しない");
+  assert(draft.labels.includes("bug"));
+  assert(draft.body.includes("不具合・動作不良"));
+  assert(draft.body.includes("保存ボタンが反応しない"));
+  assert(draft.body.includes("user@example.com"));
+  assert(draft.body.includes("2026-06-14T00:00:00.000Z"));
+  assert(draft.body.includes("github-issue-fix"));
+});
+
+Deno.test("buildFeedbackIssue handles missing email gracefully", () => {
+  const draft = buildFeedbackIssue({
+    category: "other",
+    message: "もっと色を選びたい",
+  });
+
+  assert(draft.body.includes("送信者: (不明)"));
+  assert(!draft.body.includes("受付:"));
+});

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -21,6 +21,7 @@ import {
   type FeatureRequestIssueLike,
   matchExistingFeatureRequestIssues,
 } from "./feature_request_dedupe.ts";
+import { buildFeedbackIssue } from "./feedback_issue.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -542,6 +543,10 @@ function buildFeatureRequestBody(params: {
 async function createGitHubIssue(params: {
   title: string;
   body: string;
+  /** タイトル接頭辞。既定は追加要望フォーム互換の "[追加要望] "。 */
+  titlePrefix?: string;
+  /** Issue ラベル。既定は追加要望フォーム互換。 */
+  labels?: string[];
 }): Promise<Record<string, unknown>> {
   const token = Deno.env.get("GITHUB_PAT") ??
     Deno.env.get("GITHUB_TOKEN") ??
@@ -558,6 +563,9 @@ async function createGitHubIssue(params: {
     };
   }
 
+  const titlePrefix = params.titlePrefix ?? "[追加要望] ";
+  const labels = params.labels ?? ["enhancement", "追加要望", "wbs"];
+
   const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
     method: "POST",
     headers: {
@@ -568,9 +576,9 @@ async function createGitHubIssue(params: {
       "User-Agent": "jibun-app-feature-request-form",
     },
     body: JSON.stringify({
-      title: `[追加要望] ${params.title}`,
+      title: `${titlePrefix}${params.title}`,
       body: params.body,
-      labels: ["enhancement", "追加要望", "wbs"],
+      labels,
     }),
   });
   const data = await res.json().catch(() => ({}));
@@ -1586,12 +1594,80 @@ serve(async (req: Request) => {
 
       // ---- User feedback ----
       case "feedback.submit": {
+        const category = textValue(body.category, 80) || "other";
+        const message = textValue(body.message, 4000);
+        const createdAt = new Date().toISOString();
+
+        // 受付記録は従来どおり hub_data に残す。
         const item = await addItem(admin, "user_feedback", userId, {
-          message: body.message,
-          category: body.category ?? "general",
+          message,
+          category,
           rating: body.rating,
+          created_at: createdAt,
         });
-        return json({ success: true, item });
+
+        // フィードバックを GitHub Issue 化し、github-issue-fix レーン
+        // (draft PR 自動起票 → AI フリート対応) に確実に載せる。
+        let githubIssue: Record<string, unknown> = {
+          skipped: true,
+          reason: "message_too_short",
+        };
+        if (message.trim().length >= 3) {
+          const userEmail = await getUserEmail(admin, userId);
+          const draft = buildFeedbackIssue({
+            category,
+            message,
+            userEmail,
+            createdAt,
+          });
+          githubIssue = await createGitHubIssue({
+            title: draft.title,
+            titlePrefix: "",
+            body: draft.body,
+            labels: draft.labels,
+          });
+
+          // 投稿ありがとうメール (best-effort: 失敗しても投稿は成功扱い)。
+          const resendKey = Deno.env.get("RESEND_API_KEY") ?? "";
+          const issueNumber = typeof githubIssue.number === "number"
+            ? githubIssue.number
+            : null;
+          if (resendKey && userEmail) {
+            try {
+              await fetch("https://api.resend.com/emails", {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${resendKey}`,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  from: "noreply@jibun.app",
+                  to: userEmail,
+                  subject: "【自分株式会社】ご意見・ご要望を受け付けました",
+                  html: [
+                    "<p>ご投稿ありがとうございます。内容を確認しました。</p>",
+                    issueNumber
+                      ? `<p>GitHub Issue #${issueNumber} として登録し、AIが対応に着手します。</p>`
+                      : "<p>GitHub Issue として登録し、AIが対応に着手します。</p>",
+                    "<p>進捗は対応完了時にあらためてお知らせします。</p>",
+                  ].join(""),
+                }),
+              });
+            } catch (_emailError) {
+              // 通知失敗は致命的ではないため握りつぶす。
+            }
+          }
+        }
+
+        const issueNumber = Number(githubIssue.number ?? 0) || null;
+        const issueUrl = textValue(githubIssue.html_url, 400);
+        return json({
+          success: true,
+          item,
+          githubIssue: issueNumber
+            ? { number: issueNumber, html_url: issueUrl }
+            : githubIssue,
+        });
       }
 
       // ---- Notify feature (email via Resend) ----

--- a/test/services/grow_together_share_test.dart
+++ b/test/services/grow_together_share_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/grow_together_share.dart';
+
+void main() {
+  group('GrowTogetherShare', () {
+    test('shareText keeps the canonical message verbatim', () {
+      expect(
+        GrowTogetherShare.shareText,
+        'ユーザーが機能追加要望や改善要望、不具合報告をすると、'
+        'AIが勝手にそれに対応してくれるアプリを作りました。\n\n'
+        '使ってみてください。みんなでアプリを育てられます。\n\n'
+        '自分株式会社',
+      );
+      // 本文に URL を二重で含めない（intent の url パラメータ側で付与する）。
+      expect(GrowTogetherShare.shareText.contains('http'), isFalse);
+    });
+
+    test('fullShareMessage appends the production URL for clipboard use', () {
+      expect(
+        GrowTogetherShare.fullShareMessage,
+        '${GrowTogetherShare.shareText}\n${GrowTogetherShare.appUrl}',
+      );
+      expect(
+        GrowTogetherShare.fullShareMessage,
+        contains('https://my-web-app-b67f4.web.app/'),
+      );
+    });
+
+    test('buildXIntentUrl targets the X tweet intent with text + url params',
+        () {
+      final uri = GrowTogetherShare.buildXIntentUrl();
+
+      expect(uri.scheme, 'https');
+      expect(uri.host, 'x.com');
+      expect(uri.path, '/intent/tweet');
+      expect(uri.queryParameters['text'], GrowTogetherShare.shareText);
+      expect(uri.queryParameters['url'], GrowTogetherShare.appUrl);
+    });
+
+    test('buildXIntentUrl percent-encodes newlines and Japanese text', () {
+      // toString() はクエリをエンコード済みで返すため、生の改行や日本語が
+      // 混入していないことを確認する（intent URL として壊れないこと）。
+      final encoded = GrowTogetherShare.buildXIntentUrl().toString();
+
+      expect(encoded.startsWith('https://x.com/intent/tweet?'), isTrue);
+      expect(encoded.contains('\n'), isFalse);
+      expect(encoded.contains('text='), isTrue);
+      expect(encoded.contains('url='), isTrue);
+    });
+  });
+}

--- a/test/widgets/grow_together_share_card_test.dart
+++ b/test/widgets/grow_together_share_card_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/grow_together_share.dart';
+import 'package:my_web_app/widgets/grow_together_share_card.dart';
+
+void main() {
+  group('GrowTogetherShareCard', () {
+    testWidgets('renders the canonical message and share controls',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: GrowTogetherShareCard(),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const Key('grow_together_share_card')), findsOneWidget);
+      expect(
+        find.text(GrowTogetherShare.fullShareMessage),
+        findsOneWidget,
+      );
+      expect(find.text('Xでシェア'), findsOneWidget);
+      expect(find.text('本文をコピー'), findsOneWidget);
+    });
+
+    testWidgets('tapping share invokes the injected share callback',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      var shareCalls = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: GrowTogetherShareCard(
+                onShareToX: () async {
+                  shareCalls++;
+                  return true;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('grow_together_share_x_button')));
+      await tester.pump();
+
+      expect(shareCalls, 1);
+    });
+
+    testWidgets('tapping copy invokes the injected copy callback',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      var copyCalls = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: GrowTogetherShareCard(
+                onCopyMessage: () async => copyCalls++,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('grow_together_copy_button')));
+      await tester.pump();
+
+      expect(copyCalls, 1);
+    });
+
+    testWidgets('shows a fallback snackbar when X cannot be opened',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: GrowTogetherShareCard(
+                onShareToX: () async => false,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('grow_together_share_x_button')));
+      await tester.pump();
+
+      expect(
+        find.textContaining('本文をコピーして共有してください'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

Xにアプリを共有する機能を追加し、共有文言「ユーザーが機能追加要望・改善要望・不具合報告をすると、AIが勝手に対応してくれる」が嘘にならないよう、フィードバック導線を実際のAI自動対応パイプラインに接続しました。

### 1. Xシェア機能 (フロント)
- `lib/services/grow_together_share.dart`: 正本の共有文言と X intent URL を生成する純関数 (`buildXIntentUrl`) + `launchXShare`。
- `lib/widgets/grow_together_share_card.dart`: 「みんなでアプリを育てる」共有カード (Xでシェア / 本文をコピー)。
- `lib/pages/home_page.dart`: 追加要望フォーム直下に常設の共有カード + 要望登録完了ボックスに文脈シェアボタンを追加。

### 2. 文言を真実にする改善 (バックエンド)
- これまで `feedback.submit` は `hub_data` に保存するだけで、「ご意見・ご要望」画面の「GitHub Issueに登録し github-issue-fix キューで対応を追跡します」という約束が実態と乖離していた。
- `supabase/functions/core-hub/feedback_issue.ts` (純関数) を新設し、カテゴリ→ラベル (不具合→`bug` / 要望→`enhancement`+`user-feedback`) でIssue下書きを生成。
- `feedback.submit` が実際に GitHub Issue を起票し、`github-issue-fix` レーン (draft PR 自動起票 → Claude/Codex フリート対応) + 受付ありがとうメール (best-effort) に接続。
- ホームの追加要望フォーム (`feature_request.submit`) は従来どおり全カテゴリでIssue化済みのため挙動不変。`createGitHubIssue` はデフォルト引数で後方互換。

## テスト
- `test/services/grow_together_share_test.dart`: 共有文言の正本一致 / URL生成 (4ケース)。
- `test/widgets/grow_together_share_card_test.dart`: カード描画 + シェア/コピー/フォールバック (4ケース)。
- `supabase/functions/core-hub/feedback_issue_test.ts`: カテゴリ→ラベル/タイトル生成 (7ケース、`deno test` green)。
- `deno lint` PASS / `flutter analyze` + `flutter test` green。

## Minimal E2E Gate
- 本PRのテストは実装詳細に依存しない入出力契約 (black-box) であり、入力 (カテゴリ/本文) → 出力 (ラベル/タイトル/intent URL) を最小限の代表3ケースで検証する。
- E2E機構: integration_test / playwright によるエンドツーエンド (e2e) テストは本PRでは追加せず、純関数の単体テストと widget テストで境界を担保。
- E2E例外: 外部リンク起動 (`launchUrl`) と Edge Function の GitHub API 呼び出しはネットワーク副作用のため、純関数・widget・Deno test で境界のみを検証する。

## High-risk review
- レビュー担当: Claude Code #1。
- 変更は `supabase/functions/` を含むため high-risk 判定。フロント + 純関数中心で、既存ヘルパ (`createGitHubIssue` / Resend) を再利用し、既存の `feature_request.submit` 経路のデフォルト挙動は不変。
- High-risk-ultrareview-exception: フロントと純関数中心の小規模変更で、単体・widget・Deno test により境界を検証済み。本番デプロイは既存 core-hub 経路を流用し新規インフラ追加なし。
