### PR TITLE
docs: add paste-able Minimal E2E gate snippet helper

### DIFF
--- a/docs/MINIMAL_E2E_ISSUE_GATE.md
+++ b/docs/MINIMAL_E2E_ISSUE_GATE.md
@@ -19,6 +19,37 @@ Recommended cases:
 - Error path: invalid input, missing auth, or unavailable service is handled.
 - Recovery path: retry, empty state, or fallback keeps the user moving.
 
+## Ready-to-paste snippet
+
+AI authors create PR bodies with `gh pr create --body`, which bypasses
+`.github/PULL_REQUEST_TEMPLATE.md`, so the three commitment phrases are easy to
+forget. A forgotten phrase fails the gate, and because editing a PR body does
+not re-run the check, the usual recovery is a wasteful close/reopen. To avoid
+that, emit the canonical block straight from the checker and paste it verbatim:
+
+```bash
+# Docs/tooling change, or any PR that ships an integration_test/ or test/e2e/ file:
+python scripts/check_minimal_e2e_gate.py --emit-snippet
+
+# App-code change with no E2E file (>= 8 chars of reason after the label):
+python scripts/check_minimal_e2e_gate.py --emit-snippet \
+  --exception "manual verification: <what you checked and how>"
+```
+
+The emitted wording lives in `passing_snippet()` next to the pattern tables it
+must satisfy, and a round-trip test in `check_minimal_e2e_gate_test.py` pins it
+so it can never drift out of sync with the validator. When a local pre-flight
+check (`--body-file`) FAILs, the same block is printed under a
+`snippet start/end` banner so the fix is one copy away.
+
+Always pre-flight the body locally before opening the PR:
+
+```bash
+python scripts/check_minimal_e2e_gate.py \
+  --body-file pr-body.md \
+  --changed-files <(git diff --name-only origin/main...HEAD)
+```
+
 ## Automation
 
 `.github/workflows/minimal-e2e-gate.yml` runs on pull requests and provides two

--- a/scripts/check_minimal_e2e_gate.py
+++ b/scripts/check_minimal_e2e_gate.py
@@ -75,6 +75,39 @@ EXCEPTION_PATTERNS = (
     r"e2e例外",
 )
 
+# Minimum length the cleaned E2E-Exception reason must reach to count as visible.
+# Mirrors the threshold enforced in has_visible_exception_reason().
+EXCEPTION_REASON_MIN_LENGTH = 8
+
+
+def passing_snippet(exception_reason: str | None = None) -> str:
+    """Return a Minimal E2E Gate block that is guaranteed to pass validate().
+
+    Paste the output verbatim into a PR body (or `gh pr create --body`) so the
+    three required body commitments are always present, instead of rediscovering
+    the exact phrasing and re-editing the PR after a gate FAIL. The wording here
+    is the single source of truth that the round-trip test pins against the
+    pattern tables above, so it can never silently drift out of sync.
+
+    When the PR changes application code but ships no integration_test/ or
+    test/e2e/ file, pass an ``exception_reason`` (at least
+    EXCEPTION_REASON_MIN_LENGTH characters once the label is stripped) so the
+    E2E-Exception line is emitted as well.
+    """
+    lines = [
+        "## Minimal E2E Gate",
+        "",
+        "- Implementation-detail independent: the test asserts user-visible "
+        "input/output, not private internals.",
+        "- Minimal scope: about 3 cases (happy path, error path, recovery or "
+        "empty state).",
+        "- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.",
+    ]
+    reason = (exception_reason or "").strip()
+    if reason:
+        lines.append(f"- E2E-Exception: {reason}")
+    return "\n".join(lines) + "\n"
+
 
 def normalize_path(path: str) -> str:
     return path.replace("\ufeff", "").replace("\\", "/").lstrip("./")
@@ -191,11 +224,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--event", help="GitHub event JSON path")
     parser.add_argument("--body-file", help="Local markdown file to validate")
     parser.add_argument("--changed-files", help="Newline-separated changed file list")
+    parser.add_argument(
+        "--emit-snippet",
+        action="store_true",
+        help="Print a ready-to-paste Minimal E2E Gate block that passes the gate, then exit.",
+    )
+    parser.add_argument(
+        "--exception",
+        metavar="REASON",
+        help="With --emit-snippet (or on FAIL), include an E2E-Exception line carrying this reason.",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
+
+    if args.emit_snippet:
+        print(passing_snippet(args.exception), end="")
+        return 0
+
     payload = event_payload(args.event)
     body = pr_body(payload, args.body_file)
     changed_files = read_changed_files(args.changed_files)
@@ -208,6 +256,18 @@ def main(argv: list[str]) -> int:
         print(f"Changed files inspected: {len(changed_files)}")
     for message in messages:
         print(f"- {message}")
+    if not ok:
+        print()
+        print("Paste this Minimal E2E Gate block into the PR body to satisfy the contract:")
+        print("---8<--- snippet start ---8<---")
+        print(passing_snippet(args.exception), end="")
+        print("---8<--- snippet end ---8<---")
+        if app_change and not args.exception:
+            print(
+                "If this PR changes app code without an integration_test/ or test/e2e/ file, "
+                "re-run with --exception \"<reason, >= "
+                f"{EXCEPTION_REASON_MIN_LENGTH} chars>\" to add an E2E-Exception line."
+            )
     return 0 if ok else 1
 
 

--- a/scripts/check_minimal_e2e_gate_test.py
+++ b/scripts/check_minimal_e2e_gate_test.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import unittest
 
-from check_minimal_e2e_gate import validate
+from check_minimal_e2e_gate import (
+    EXCEPTION_REASON_MIN_LENGTH,
+    has_visible_exception_reason,
+    passing_snippet,
+    validate,
+)
 
 
 GOOD_BODY = """
@@ -78,6 +83,70 @@ class MinimalE2EGateTest(unittest.TestCase):
 
         self.assertTrue(ok, messages)
         self.assertFalse(app_change)
+
+
+class PassingSnippetTest(unittest.TestCase):
+    """The canonical paste-able snippet must always satisfy validate().
+
+    These round-trip tests are the guard against drift: if anyone edits the
+    snippet wording or the pattern tables in a way that breaks the contract,
+    CI fails here instead of in a developer's PR.
+    """
+
+    def test_snippet_passes_for_non_app_change(self) -> None:
+        ok, messages, app_change = validate(
+            passing_snippet(),
+            ["docs/MINIMAL_E2E_ISSUE_GATE.md", "scripts/check_minimal_e2e_gate.py"],
+            set(),
+        )
+
+        self.assertTrue(ok, messages)
+        self.assertFalse(app_change)
+
+    def test_snippet_with_exception_passes_for_app_change_without_e2e_file(self) -> None:
+        body = passing_snippet("docs and scripts only; no app runtime code changed")
+        ok, messages, app_change = validate(
+            body,
+            ["lib/pages/foo.dart"],
+            set(),
+        )
+
+        self.assertTrue(ok, messages)
+        self.assertTrue(app_change)
+        self.assertTrue(has_visible_exception_reason(body))
+
+    def test_snippet_without_exception_fails_for_app_change_without_e2e_file(self) -> None:
+        # Proves the exception line is what carries an E2E-less app PR: the body
+        # commitments alone are present, but the missing E2E file is still caught.
+        ok, messages, app_change = validate(
+            passing_snippet(),
+            ["lib/pages/foo.dart"],
+            set(),
+        )
+
+        self.assertFalse(ok)
+        self.assertTrue(app_change)
+        self.assertTrue(any("Application-code PRs" in item for item in messages))
+
+    def test_emit_snippet_cli_prints_passing_block(self) -> None:
+        import contextlib
+        import io
+
+        from check_minimal_e2e_gate import main
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            exit_code = main(["--emit-snippet"])
+
+        self.assertEqual(exit_code, 0)
+        ok, _, _ = validate(buffer.getvalue(), ["docs/x.md"], set())
+        self.assertTrue(ok)
+
+    def test_min_length_constant_is_consistent(self) -> None:
+        short = "x" * (EXCEPTION_REASON_MIN_LENGTH - 1)
+        long = "x" * EXCEPTION_REASON_MIN_LENGTH
+        self.assertFalse(has_visible_exception_reason(f"E2E-Exception: {short}"))
+        self.assertTrue(has_visible_exception_reason(f"E2E-Exception: {long}"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

AI authors write PR bodies with `gh pr create --body`, which bypasses
`.github/PULL_REQUEST_TEMPLATE.md`, so the three Minimal E2E Gate commitment
phrases are easy to forget. A forgotten phrase fails the gate, and because
editing a PR body does not re-run the check, the usual recovery is a wasteful
close/reopen cycle.

This adds a paste-able snippet helper so the canonical phrasing is one command
away — emit it from the checker itself and paste it verbatim.

## Changes

- `scripts/check_minimal_e2e_gate.py`: new `passing_snippet()` (single source of
  truth, sitting next to the pattern tables it must satisfy) plus
  `--emit-snippet` / `--exception` CLI. On a local pre-flight FAIL the same
  block is printed under a snippet banner so the fix is one copy away.
- `scripts/check_minimal_e2e_gate_test.py`: round-trip tests pin the snippet to
  the validator so it can never silently drift out of sync (wired via
  `quality_gate.py`).
- `docs/MINIMAL_E2E_ISSUE_GATE.md`: documents the helper and the local
  pre-flight command.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

This PR changes docs and tooling only (no app runtime code), so no
`integration_test/` or `test/e2e/` file is required; the round-trip unit tests
in `check_minimal_e2e_gate_test.py` cover the new behavior.

## Review owner

Claude Code #1.
