### PR TITLE
feat: ガス代を毎月の固定費として既定計上

### DIFF
--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -62,6 +62,12 @@ class AssetLiabilityPlanningService {
   static const String waterBillAccountName = '\u6c34\u9053\u4ee3';
   static const double waterBillBimonthlyPaymentAmount = 2400;
   static const int waterBillPaymentDay = 22;
+  // ガス代: 毎月12日 / 三井住友銀行大塚支店から口座振替。使用量で変動するため
+  // 概算4,500円(3,000〜6,000円の中央値 / 今月支払予定額の手入力で上書き可)。
+  static const String gasBillAccountId = 'gas_bill';
+  static const String gasBillAccountName = 'ガス代';
+  static const double gasBillMonthlyPaymentAmount = 4500;
+  static const int gasBillPaymentDay = 12;
   static const String acomShoppingAccountId = 'acom_shopping';
   static const String anthropicAcomShoppingPaymentId =
       'anthropic_acom_shopping_repayment';
@@ -113,14 +119,19 @@ class AssetLiabilityPlanningService {
     final shouldIncludeDefaultWaterBill = includeDefaultFixedPayments &&
         baseDate.month.isEven &&
         !_hasWaterBill(latestSnapshot);
+    // ガス代は毎月12日。未計上時のみ既定で計上する。
+    final shouldIncludeDefaultGasBill =
+        includeDefaultFixedPayments && !_hasGasBill(latestSnapshot);
     final effectiveSnapshot = shouldIncludeDefaultKddiProvider ||
             shouldIncludeDefaultRent ||
-            shouldIncludeDefaultWaterBill
+            shouldIncludeDefaultWaterBill ||
+            shouldIncludeDefaultGasBill
         ? _withDefaultFixedPayments(
             latestSnapshot,
             includeKddiProvider: shouldIncludeDefaultKddiProvider,
             includeRent: shouldIncludeDefaultRent,
             includeWaterBill: shouldIncludeDefaultWaterBill,
+            includeGasBill: shouldIncludeDefaultGasBill,
           )
         : latestSnapshot;
     final effectiveMonthlyPaymentOverrides = _withDefaultFixedPaymentOverrides(
@@ -128,6 +139,7 @@ class AssetLiabilityPlanningService {
       includeDefaultKddiProvider: shouldIncludeDefaultKddiProvider,
       includeDefaultRent: shouldIncludeDefaultRent,
       includeDefaultWaterBill: shouldIncludeDefaultWaterBill,
+      includeDefaultGasBill: shouldIncludeDefaultGasBill,
     );
     final accounts = effectiveSnapshot.entries
         .where((entry) => entry.key.trim().isNotEmpty && entry.value != 0)
@@ -160,9 +172,11 @@ class AssetLiabilityPlanningService {
       accountsById: accountsById,
     );
     final effectivePaymentSourceAccountIds = <String, String>{
-      // 水道代の既定振替元は三井住友銀行大塚支店(ユーザー設定があれば下で上書き)。
+      // 水道代・ガス代の既定振替元は三井住友銀行大塚支店(ユーザー設定があれば下で上書き)。
       if (shouldIncludeDefaultWaterBill)
         waterBillAccountId: smbcOtsukaBranchAccountId,
+      if (shouldIncludeDefaultGasBill)
+        gasBillAccountId: smbcOtsukaBranchAccountId,
       ...defaultPaymentSourceAccountIds,
       ...paymentSourceAccountIds,
     };
@@ -448,6 +462,18 @@ class AssetLiabilityPlanningService {
         balance: balance,
         kind: AssetLiabilityAccountKind.utility,
         paymentDay: waterBillPaymentDay,
+        annualRate: 0,
+        minimumPaymentRate: 1,
+        minimumPaymentFloor: balance.abs(),
+        fullPaymentEstimate: true,
+      );
+    }
+    if (_accountIdForName(name) == gasBillAccountId) {
+      return _liability(
+        name: name,
+        balance: balance,
+        kind: AssetLiabilityAccountKind.utility,
+        paymentDay: gasBillPaymentDay,
         annualRate: 0,
         minimumPaymentRate: 1,
         minimumPaymentFloor: balance.abs(),
@@ -1708,6 +1734,9 @@ class AssetLiabilityPlanningService {
     if (_containsAny(key, const <String>['水道', 'すいどう', 'water'])) {
       return waterBillAccountId;
     }
+    if (_containsAny(key, const <String>['ガス', 'gas'])) {
+      return gasBillAccountId;
+    }
     if (key == 'au' || _containsAny(key, const <String>['通信', '携帯'])) {
       return 'au';
     }
@@ -1732,6 +1761,7 @@ class AssetLiabilityPlanningService {
     required bool includeKddiProvider,
     required bool includeRent,
     required bool includeWaterBill,
+    required bool includeGasBill,
   }) {
     final result = Map<String, double>.from(latestSnapshot);
     if (includeKddiProvider && !_hasKddiProvider(result)) {
@@ -1743,6 +1773,9 @@ class AssetLiabilityPlanningService {
     if (includeWaterBill && !_hasWaterBill(result)) {
       result[waterBillAccountName] = -waterBillBimonthlyPaymentAmount;
     }
+    if (includeGasBill && !_hasGasBill(result)) {
+      result[gasBillAccountName] = -gasBillMonthlyPaymentAmount;
+    }
     return result;
   }
 
@@ -1751,6 +1784,7 @@ class AssetLiabilityPlanningService {
     required bool includeDefaultKddiProvider,
     required bool includeDefaultRent,
     required bool includeDefaultWaterBill,
+    required bool includeDefaultGasBill,
   }) {
     final result = <String, double>{...monthlyPaymentOverrides};
     if (includeDefaultKddiProvider &&
@@ -1767,6 +1801,11 @@ class AssetLiabilityPlanningService {
         !result.containsKey(waterBillAccountId) &&
         !result.containsKey(waterBillAccountName)) {
       result[waterBillAccountId] = waterBillBimonthlyPaymentAmount;
+    }
+    if (includeDefaultGasBill &&
+        !result.containsKey(gasBillAccountId) &&
+        !result.containsKey(gasBillAccountName)) {
+      result[gasBillAccountId] = gasBillMonthlyPaymentAmount;
     }
     return result;
   }
@@ -1786,6 +1825,12 @@ class AssetLiabilityPlanningService {
   bool _hasWaterBill(Map<String, double> snapshot) {
     return snapshot.keys.any(
       (name) => _accountIdForName(name) == waterBillAccountId,
+    );
+  }
+
+  bool _hasGasBill(Map<String, double> snapshot) {
+    return snapshot.keys.any(
+      (name) => _accountIdForName(name) == gasBillAccountId,
     );
   }
 

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1377,6 +1377,9 @@ void main() {
       final rent = workbook.debtMasterRows.firstWhere(
         (row) => row.id == AssetLiabilityPlanningService.rentAccountId,
       );
+      final gas = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.gasBillAccountId,
+      );
       final kddiCashflow = workbook.cashflowRows.firstWhere(
         (row) =>
             row.accountId ==
@@ -1428,7 +1431,9 @@ void main() {
       expect(
         workbook.monthlyUnpaidPaymentTotal,
         closeTo(
-          kddi.scheduledPaymentAmount + rent.scheduledPaymentAmount,
+          kddi.scheduledPaymentAmount +
+              rent.scheduledPaymentAmount +
+              gas.scheduledPaymentAmount,
           0.001,
         ),
       );
@@ -1466,6 +1471,47 @@ void main() {
       );
     });
 
+    test('adds the monthly gas bill every month including odd months', () {
+      AssetLiabilityDebtRow gasRowFor(int month) {
+        final workbook = service.buildWorkbook(
+          latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 63539},
+          baseDate: DateTime(2026, month, 14),
+          includeDefaultFixedPayments: true,
+        );
+        return workbook.debtMasterRows.firstWhere(
+          (row) => row.id == AssetLiabilityPlanningService.gasBillAccountId,
+        );
+      }
+
+      // 偶数月(6月)・奇数月(7月)いずれもガス代を計上する。
+      for (final month in const <int>[6, 7]) {
+        final gas = gasRowFor(month);
+        expect(gas.name, AssetLiabilityPlanningService.gasBillAccountName);
+        expect(gas.kind, AssetLiabilityAccountKind.utility);
+        expect(gas.paymentDay, 12);
+        expect(gas.scheduledPaymentAmount, 4500);
+        expect(
+          gas.paymentSourceAccountId,
+          AssetLiabilityPlanningService.smbcOtsukaBranchAccountId,
+        );
+      }
+    });
+
+    test('lets a manual override replace the default monthly gas bill', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 63539},
+        baseDate: DateTime(2026, 7, 14),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.gasBillAccountId: 5800,
+        },
+        includeDefaultFixedPayments: true,
+      );
+      final gas = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.gasBillAccountId,
+      );
+      expect(gas.scheduledPaymentAmount, 5800);
+    });
+
     test('treats paid KDDI provider payment as reflected in cashflow', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: <String, double>{'cash': 50000, 'au': -32152},
@@ -1483,6 +1529,9 @@ void main() {
       final rent = workbook.debtMasterRows.firstWhere(
         (row) => row.id == AssetLiabilityPlanningService.rentAccountId,
       );
+      final gas = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.gasBillAccountId,
+      );
       final kddiCashflow = workbook.cashflowRows.firstWhere(
         (row) =>
             row.accountId ==
@@ -1493,7 +1542,13 @@ void main() {
       expect(kddi.paid, isTrue);
       expect(kddiCashflow.paid, isTrue);
       expect(kddiCashflow.cashBeforePayment, kddiCashflow.cashAfterPayment);
-      expect(workbook.monthlyUnpaidPaymentTotal, rent.scheduledPaymentAmount);
+      expect(
+        workbook.monthlyUnpaidPaymentTotal,
+        closeTo(
+          rent.scheduledPaymentAmount + gas.scheduledPaymentAmount,
+          0.001,
+        ),
+      );
     });
 
     test('applies manual payment day override to unknown cards', () {


### PR DESCRIPTION
## 概要

ガス代を「毎月12日／三井住友銀行大塚支店からの口座振替」の固定費として既定計上します。資産管理画面の月次キャッシュフローに、未登録時でも自動で反映されます。

- 振替日: 毎月12日（水道代の隔月とは異なり毎月）
- 概算額: 4,500円（使用量で3,000〜6,000円の中央値。今月分の手入力で上書き可）
- 振替元: 三井住友銀行大塚支店（既定。ユーザー設定があれば上書き）
- 口座名に「ガス／gas」を含む既存口座があれば二重計上しない

水道代（隔月・偶数月）と同型の実装ですが、ガスは毎月のため `baseDate.month.isEven` ガードを持ちません。

## テスト

純粋なサービス層の既定値追加のため、`AssetLiabilityPlanningService` の単体テストで入出力契約を検証します。実装詳細に依存しない最小限の約3ケースです。

- 偶数月・奇数月いずれでもガス代行（12日・4,500円・振替元=三井住友銀行大塚支店）が現れる
- 手入力の月次上書きが既定4,500円を置き換える
- 既存の固定費合計テスト2件をガス代込みに更新

UI を伴わない純粋関数の変更のため、integration_test / Playwright のエンドツーエンドは追加しません。

E2E例外: 純粋関数のサービス層既定値追加でUI経路なし、単体テストで入出力を網羅

---
Review owner: Claude Code #1
High-risk-ultrareview-exception: 純粋関数の固定費既定値追加で高リスクパスや外部通信を含まない
