### PR TITLE
fix(asset): ウォッチリスト/支払日設定の他端末同期を union マージ化

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -157,6 +157,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final bool? debugMirrorReadsAuthoritative;
 
+  /// テスト専用: 支払日上書きの集約ミラー値 (`{debtId: day}`) を注入し、端末間同期
+  /// (union マージ) をネットワークなしで検証する。
+  @visibleForTesting
+  final Map<String, dynamic>? debugDebtOverridesMirror;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -175,6 +180,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugMainAccountMirror,
     this.debugWatchlistMirror,
     this.debugMirrorReadsAuthoritative,
+    this.debugDebtOverridesMirror,
   });
 
   @override
@@ -1275,9 +1281,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
         );
       }
-      if (debtPaymentDayOverrides.isEmpty) {
-        unawaited(_restoreDebtPaymentDayOverridesFromMirror());
-      }
       final templates =
           await _assetLiabilityRepository.loadRecurringIncomeTemplates();
       final monthlySnapshots =
@@ -1358,6 +1361,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _syncPaymentStateControllers();
       });
       unawaited(_refreshSyncSources());
+      // ローカル(_debtPaymentDayOverrides)反映後に呼ぶ。空でなくても union
+      // マージ/バックフィルするため常に実行する。
+      unawaited(_restoreDebtPaymentDayOverridesFromMirror());
       if (generatedTemplatePlans) {
         unawaited(_saveAssetLiabilityMonthlyState());
       }
@@ -5278,6 +5284,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             .select()
             .eq('pref_key', _watchlistMirrorKey);
         if (rows.isEmpty) {
+          // サーバ行が無い: ローカルにあれば初回バックフィル。
+          if (hasLocal) {
+            unawaited(_mirrorWatchlist());
+          }
           return;
         }
         value = rows.first['value'];
@@ -5285,29 +5295,50 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           rows.first['updated_at']?.toString() ?? '',
         );
       }
-      final restored = AssetWatchlistService.decodeMirrorValue(value);
-      if (restored.isEmpty || !mounted) {
+      final serverEntries = AssetWatchlistService.decodeMirrorValue(value);
+      if (serverEntries.isEmpty || !mounted) {
         return;
       }
-      final adopt = await _shouldAdoptMirror(
+      final adoptConflicts = await _shouldAdoptMirror(
         prefKey: _watchlistMirrorKey,
         hasLocal: hasLocal,
         mirrorUpdatedAt: mirrorUpdatedAt,
       );
-      if (!adopt || !mounted) {
-        return;
+      // union マージ: ローカルに無い assetType はサーバから追加 (他の項目は維持)。
+      final localTypes = _watchlistByType.keys.toSet();
+      final merged = Map<String, AssetWatchlistEntry>.from(_watchlistByType);
+      final serverTypes = <String>{};
+      var changed = false;
+      for (final entry in serverEntries) {
+        serverTypes.add(entry.assetType);
+        if (!merged.containsKey(entry.assetType) || adoptConflicts) {
+          merged[entry.assetType] = entry;
+          changed = true;
+        }
       }
-      setState(() {
-        _setWatchlistEntries(restored);
-      });
-      // オフライン参照用にローカルへ書き戻し、ローカル更新時刻をミラーへ揃える。
-      unawaited(widget.watchlistService.replaceAll(restored));
-      unawaited(
-        _syncTimestampStore.markChanged(
-          _watchlistMirrorKey,
-          at: mirrorUpdatedAt,
-        ),
+      if (changed && mounted) {
+        final mergedList = merged.values.toList();
+        setState(() {
+          _setWatchlistEntries(mergedList);
+        });
+        // オフライン参照用にローカルへ書き戻し、ローカル更新時刻をミラーへ揃える。
+        unawaited(widget.watchlistService.replaceAll(mergedList));
+        if (adoptConflicts) {
+          unawaited(
+            _syncTimestampStore.markChanged(
+              _watchlistMirrorKey,
+              at: mirrorUpdatedAt,
+            ),
+          );
+        }
+      }
+      // ローカルにあってサーバに無い項目は、マージ結果をサーバへバックフィル。
+      final localHasExtra = localTypes.any(
+        (type) => !serverTypes.contains(type),
       );
+      if (localHasExtra && debugMirror == null) {
+        unawaited(_mirrorWatchlist());
+      }
     } catch (e) {
       debugPrint('watchlist mirror restore failed: $e');
     }
@@ -9105,12 +9136,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Future<void> _restoreDebtPaymentDayOverridesFromMirror() async {
-    if (_supabase.auth.currentUser == null) {
+    final debugMirror = widget.debugDebtOverridesMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
       return;
     }
     final hasLocal = _debtPaymentDayOverrides.isNotEmpty;
     // フラグ OFF + ローカル値あり: サーバに無ければ初回バックフィルして終了。
-    if (!_mirrorReadsAuthoritative && hasLocal) {
+    if (!_mirrorReadsAuthoritative && hasLocal && debugMirror == null) {
       unawaited(
         _backfillPrefIfServerMissing(
           'debt_payment_day_overrides',
@@ -9120,25 +9152,36 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     try {
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select()
-          .eq('pref_key', 'debt_payment_day_overrides');
-      if (rows.isEmpty || !mounted) {
+      final dynamic value;
+      final DateTime? mirrorUpdatedAt;
+      if (debugMirror != null) {
+        value = debugMirror;
+        mirrorUpdatedAt = DateTime.now().toUtc();
+      } else {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', 'debt_payment_day_overrides');
+        if (rows.isEmpty) {
+          // サーバ行が無い: ローカルにあれば初回バックフィル。
+          if (hasLocal) {
+            unawaited(_mirrorDebtPaymentDayOverrides(_debtPaymentDayOverrides));
+          }
+          return;
+        }
+        value = rows.first['value'];
+        mirrorUpdatedAt = DateTime.tryParse(
+          rows.first['updated_at']?.toString() ?? '',
+        );
+      }
+      if (value is! Map || !mounted) {
         return;
       }
-      final value = rows.first['value'];
-      if (value is! Map) {
-        return;
-      }
-      final mirrorUpdatedAt = DateTime.tryParse(
-        rows.first['updated_at']?.toString() ?? '',
-      );
       // 削除トゥームストーン済みの支払日上書きは復元しない (#part293 3例目)。
       final tombstoned = _debtOverrideTombstones.activeIds(
         await SharedPreferences.getInstance(),
       );
-      final restored = <String, int>{};
+      final serverOverrides = <String, int>{};
       value.forEach((key, dynamic raw) {
         final day = (raw as num?)?.toInt();
         if (key is String &&
@@ -9146,35 +9189,53 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             day >= 1 &&
             day <= 31 &&
             !tombstoned.contains(key)) {
-          restored[key] = day;
+          serverOverrides[key] = day;
         }
       });
-      if (restored.isEmpty || !mounted) {
+      if (serverOverrides.isEmpty || !mounted) {
         return;
       }
-      final adopt = await _shouldAdoptMirror(
+      final adoptConflicts = await _shouldAdoptMirror(
         prefKey: 'debt_payment_day_overrides',
         hasLocal: hasLocal,
         mirrorUpdatedAt: mirrorUpdatedAt,
       );
-      if (!adopt || !mounted) {
-        return;
-      }
-      setState(() {
-        _debtPaymentDayOverrides = restored;
+      // union マージ: ローカルに無い負債キーはサーバから追加 (他の上書きは維持)。
+      final localKeys = _debtPaymentDayOverrides.keys.toSet();
+      final merged = Map<String, int>.from(_debtPaymentDayOverrides);
+      var changed = false;
+      serverOverrides.forEach((key, day) {
+        if (!merged.containsKey(key) || adoptConflicts) {
+          merged[key] = day;
+          changed = true;
+        }
       });
-      unawaited(_saveDebtPaymentDayOverrides());
-      unawaited(
-        _syncTimestampStore.markChanged(
-          'debt_payment_day_overrides',
-          at: mirrorUpdatedAt,
-        ),
+      if (changed && mounted) {
+        setState(() {
+          _debtPaymentDayOverrides = merged;
+        });
+        unawaited(_saveDebtPaymentDayOverrides());
+        if (adoptConflicts) {
+          unawaited(
+            _syncTimestampStore.markChanged(
+              'debt_payment_day_overrides',
+              at: mirrorUpdatedAt,
+            ),
+          );
+        }
+        // 初回復元 (ローカル空) のときだけ通知。
+        if (!hasLocal) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('支払日設定をサーバのバックアップから復元しました')),
+          );
+        }
+      }
+      // ローカルにあってサーバに無い負債キーは、マージ結果をサーバへバックフィル。
+      final localHasExtra = localKeys.any(
+        (key) => !serverOverrides.containsKey(key),
       );
-      // 初回復元 (ローカル空) のときだけ通知。LWW での更新時は通知しない。
-      if (!hasLocal) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('支払日設定をサーバのバックアップから復元しました')),
-        );
+      if (localHasExtra && debugMirror == null) {
+        unawaited(_mirrorDebtPaymentDayOverrides(_debtPaymentDayOverrides));
       }
     } catch (e) {
       debugPrint('pref mirror restore failed: $e');

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -910,15 +910,16 @@ void main() {
       await _unmount(tester);
     });
 
-    testWidgets('Phase B flag on: mirror overrides non-empty local (LWW)', (
+    testWidgets('Phase B flag on: same-key conflict adopts server (LWW)', (
       tester,
     ) async {
-      // 端末B はローカルに古いウォッチリストを持つ (タイムスタンプ未記録 = legacy)。
+      // ローカルに gold(group=old / タイムスタンプ未記録) があり、サーバに同じ
+      // gold(group=new) がある衝突状態。union マージでは衝突キーの採否のみフラグで変わる。
       SharedPreferences.setMockInitialValues(<String, Object>{
         'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
           <String, dynamic>{
-            'assetType': 'old_local',
-            'group': '',
+            'assetType': 'gold',
+            'group': 'old',
             'memo': '',
             'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
           },
@@ -934,8 +935,8 @@ void main() {
             debugWatchlistMirror: AssetWatchlistService.encodeMirrorValue(
               <AssetWatchlistEntry>[
                 AssetWatchlistEntry(
-                  assetType: 'server_new',
-                  group: 'invest',
+                  assetType: 'gold',
+                  group: 'new',
                   memo: '',
                   addedAt: DateTime.utc(2026, 6, 14),
                 ),
@@ -947,22 +948,22 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
       await tester.pump(const Duration(milliseconds: 300));
 
-      // フラグ ON の LWW でサーバ値が採用され、ローカルへ書き戻される。
+      // フラグ ON: 衝突キー gold はサーバ値 (group=new) が採用される。
       final synced = await const AssetWatchlistService().loadEntries();
-      expect(synced.map((e) => e.assetType), contains('server_new'));
-      expect(synced.map((e) => e.assetType), isNot(contains('old_local')));
+      final gold = synced.firstWhere((e) => e.assetType == 'gold');
+      expect(gold.group, 'new');
 
       await _unmount(tester);
     });
 
-    testWidgets('Phase B flag off (default): mirror does not clobber local', (
+    testWidgets('Phase B flag off (default): same-key conflict keeps local', (
       tester,
     ) async {
       SharedPreferences.setMockInitialValues(<String, Object>{
         'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
           <String, dynamic>{
-            'assetType': 'kept_local',
-            'group': '',
+            'assetType': 'gold',
+            'group': 'old',
             'memo': '',
             'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
           },
@@ -978,8 +979,8 @@ void main() {
             debugWatchlistMirror: AssetWatchlistService.encodeMirrorValue(
               <AssetWatchlistEntry>[
                 AssetWatchlistEntry(
-                  assetType: 'server_value',
-                  group: '',
+                  assetType: 'gold',
+                  group: 'new',
                   memo: '',
                   addedAt: DateTime.utc(2026, 6, 14),
                 ),
@@ -991,10 +992,10 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
       await tester.pump(const Duration(milliseconds: 300));
 
-      // フラグ OFF なので非空ローカルは維持される (従来挙動)。
+      // フラグ OFF: 衝突キー gold はローカル値 (group=old) を維持。
       final local = await const AssetWatchlistService().loadEntries();
-      expect(local.map((e) => e.assetType), contains('kept_local'));
-      expect(local.map((e) => e.assetType), isNot(contains('server_value')));
+      final gold = local.firstWhere((e) => e.assetType == 'gold');
+      expect(gold.group, 'old');
 
       await _unmount(tester);
     });

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1047,5 +1047,78 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets('watchlist union-merge: server entry fills in, local kept', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'assetType': 'local_only',
+            'group': '',
+            'memo': '',
+            'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugWatchlistMirror: AssetWatchlistService.encodeMirrorValue(
+              <AssetWatchlistEntry>[
+                AssetWatchlistEntry(
+                  assetType: 'server_only',
+                  group: 'invest',
+                  memo: '',
+                  addedAt: DateTime.utc(2026, 6, 14),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final merged = await const AssetWatchlistService().loadEntries();
+      expect(
+        merged.map((e) => e.assetType),
+        containsAll(<String>['local_only', 'server_only']),
+      );
+
+      await _unmount(tester);
+    });
+
+    testWidgets('debt-override union-merge: server day fills in, local kept', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // ローカルは debt_a の支払日上書きを持ち、サーバは debt_b を持つ状態。
+      final repo = _FakeDebtOverrideRepository(<String, int>{'debt_a': 27});
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            assetLiabilityRepository: repo,
+            debugDebtOverridesMirror: const <String, dynamic>{'debt_b': 5},
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // union マージ: ローカルの debt_a を維持しつつサーバの debt_b を取り込み、repo へ保存。
+      expect(repo.savedDebtOverrides, isNotNull);
+      expect(repo.savedDebtOverrides!['debt_a'], 27);
+      expect(repo.savedDebtOverrides!['debt_b'], 5);
+
+      await _unmount(tester);
+    });
   });
 }


### PR DESCRIPTION
## 概要

リボ払い設定で確認できた他端末同期の不具合修正 ([#3381](https://github.com/kanta13jp1/my_web_app/pull/3381)) と
同じ「ローカルが空のときだけマップ全体を置換」の穴が、**ウォッチリスト**と**支払日設定
(支払日上書き)** にも残っていたため、同じ union マージ + バックフィルを適用する。

## 原因 (リボと同型)

`_restoreWatchlistFromMirror` / `_restoreDebtPaymentDayOverridesFromMirror` が
「ローカルが空のときだけ全置換」だったため、スマホ側に**別の項目がローカルにある**と
復元ごとスキップされ、他端末で追加した項目が取り込まれない。支払日側は呼び出しも
「ローカル空時のみ」にゲートされていた。

## 修正

- **ウォッチリスト**: `assetType` ごとの union マージ (サーバの新規項目を追加し、ローカルの
  既存項目は維持)。サーバに無いローカル項目はバックフィル。
- **支払日上書き**: `debtId` ごとの union マージ (削除トゥームストーン除外を維持、初回復元時
  のみ通知)。バックフィルを追加。テスト用 `debugDebtOverridesMirror` 注入を追加。
- 支払日復元の呼び出しを「ローカル空時のみ」→ **ローカル反映 (setState) 後の無条件呼び出し**へ
  移動 (union マージ/バックフィルを常に実行できるよう、フィールド設定後に呼ぶ競合も修正)。
- いずれも additive・条件付きアップロードで、既存のサーバ値を上書きしない安全な変更。
  衝突キーは従来どおりローカル維持 (Phase B フラグ ON のときのみサーバ採用)。

## テスト

`flutter analyze` → 0 issues、対象テスト green:
- 追加 widget テスト 2 件: ウォッチリスト/支払日それぞれで、ローカルに別項目がある状態で
  サーバの項目が union マージで反映され、ローカルの既存項目も維持されることを検証。

## Minimal E2E Gate

- 実装詳細に依存しない (black-box) 入出力契約のみ検証: 「ローカル項目 + サーバ項目」という
  入力に対し「マージ後の項目集合」という観測可能な出力をアサートし、内部実装に依存しない。
- 最小限 (minimal) の 3 ケース相当 — サーバ項目追加 / ローカル項目維持 / 値の一致。
- 機構: widget テスト。公開サイトの Playwright / `integration_test/` のブラウザ E2E は未追加。
- E2E-Exception: 端末間同期はログイン状態と Supabase 上のデータに依存し、公開
  ブラックボックス E2E では決定的に再現しづらいため、widget テストで担保する。

## レビュー

- Review owner: Claude Code #1。
- High-risk-ultrareview-exception: 変更は `lib/pages` `test` のみで、認証 / 課金 /
  インフラ配信などの高リスクパスに触れない、additive な不具合修正のため ultrareview 対象外とする。
