### PR TITLE
feat(asset): リボ設定の削除を他端末へ伝播 (clear propagation)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -164,6 +164,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, dynamic>? debugDebtOverridesMirror;
 
+  /// テスト専用: リボ設定の削除トゥームストーン値 (`{'ids': [...]}`) を注入し、
+  /// 削除伝播 (他端末で削除→ローカルから除去) をネットワークなしで検証する。
+  @visibleForTesting
+  final Map<String, dynamic>? debugRevolvingDeletedMirror;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -183,6 +188,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugWatchlistMirror,
     this.debugMirrorReadsAuthoritative,
     this.debugDebtOverridesMirror,
+    this.debugRevolvingDeletedMirror,
   });
 
   @override
@@ -604,6 +610,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // 他端末で削除されたセクション上書き / 支払日上書きを取り込む (#part292/294)。
     unawaited(_pullDeletedSectionIds());
     unawaited(_pullDebtOverrideDeleted());
+    // 他端末で削除されたリボ設定を取り込む (clear 伝播)。
+    unawaited(_pullRevolvingDeleted());
     // 期限切れ・上限超過のトゥームストーンを自動掃除 (#part296 肥大化抑制)。
     unawaited(_pruneTombstonesOnBoot());
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
@@ -8129,6 +8137,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _revolvingConfigs,
     );
     final hasLocal = localBefore.isNotEmpty;
+    // 削除トゥームストーン: 復活させない / バックフィルしない。
+    final tombstoned = _revolvingConfigTombstones.activeIds(
+      await SharedPreferences.getInstance(),
+    );
     try {
       final Map<String, AssetLiabilityRevolvingCreditConfig> serverConfigs;
       final DateTime? mirrorUpdatedAt;
@@ -8173,7 +8185,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         localBefore,
       );
       var changed = false;
+      // 削除トゥームストーン済みキーはローカルからも除く (clear 伝播 / 復活防止)。
+      merged.removeWhere((key, _) {
+        if (tombstoned.contains(key)) {
+          changed = true;
+          return true;
+        }
+        return false;
+      });
       serverConfigs.forEach((key, config) {
+        if (tombstoned.contains(key)) {
+          return;
+        }
         if (!merged.containsKey(key) || adoptConflicts) {
           merged[key] = config;
           changed = true;
@@ -8196,7 +8219,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       // ローカルにあってサーバに無い負債キーは、マージ結果をサーバへ
       // バックフィルし、サーバを全端末の和集合に保つ。
       final localHasExtra = localBefore.keys.any(
-        (key) => !serverConfigs.containsKey(key),
+        (key) => !tombstoned.contains(key) && !serverConfigs.containsKey(key),
       );
       if (localHasExtra && debugMirror == null) {
         unawaited(_mirrorRevolvingConfigs());
@@ -8205,6 +8228,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       debugPrint('revolving config mirror restore failed: $e');
     }
   }
+
+  /// 削除した (リボ OFF にした) リボ設定のトゥームストーン。union マージ/backfill
+  /// での復活を防ぎ、他端末へ削除を伝播する (debt 上書きと同じパターン)。
+  static const MirrorTombstoneStore _revolvingConfigTombstones =
+      MirrorTombstoneStore(
+    storageKey: 'revolving_credit_configs_deleted_v1',
+  );
 
   void _persistRevolvingConfig(
     String debtId,
@@ -8222,7 +8252,90 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _revolvingConfigs = next;
     });
     unawaited(_revolvingConfigStore.save(_revolvingConfigs));
+    // 削除はトゥームストーン化、再設定は解除 (debtId 再利用ドメイン)。
+    unawaited(_recordRevolvingTombstone(debtId, deleted: config == null));
     unawaited(_mirrorRevolvingConfigs());
+  }
+
+  Future<void> _recordRevolvingTombstone(
+    String id, {
+    required bool deleted,
+  }) async {
+    final store = await SharedPreferences.getInstance();
+    if (deleted) {
+      await _revolvingConfigTombstones.addId(store, id);
+    } else {
+      await _revolvingConfigTombstones.removeId(store, id);
+    }
+    unawaited(_mirrorRevolvingDeleted());
+  }
+
+  /// リボ設定の削除トゥームストーンをサーバへ反映 (他端末伝播)。
+  Future<void> _mirrorRevolvingDeleted() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final store = await SharedPreferences.getInstance();
+      final ids = _revolvingConfigTombstones.activeIds(store);
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': 'revolving_credit_configs_deleted',
+        'value': MirrorTombstoneStore.encodeMirror(ids),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('revolving tombstone mirror upsert failed: $e');
+    }
+  }
+
+  /// 他端末で削除されたリボ設定を取り込み、ローカルからも除去する。
+  Future<void> _pullRevolvingDeleted() async {
+    final debugMirror = widget.debugRevolvingDeletedMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      Map<String, dynamic>? value = debugMirror;
+      if (value == null) {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', 'revolving_credit_configs_deleted');
+        if (rows.isEmpty) {
+          return;
+        }
+        final raw = rows.first['value'];
+        if (raw is! Map) {
+          return;
+        }
+        value = Map<String, dynamic>.from(raw);
+      }
+      final ids = MirrorTombstoneStore.decodeMirror(value);
+      if (ids.isEmpty) {
+        return;
+      }
+      final store = await SharedPreferences.getInstance();
+      final incoming = await _revolvingConfigTombstones.mergeRemoteIds(
+        store,
+        ids,
+      );
+      final next = Map<String, AssetLiabilityRevolvingCreditConfig>.from(
+        _revolvingConfigs,
+      );
+      final before = next.length;
+      next.removeWhere((key, _) => incoming.contains(key));
+      if (next.length == before || !mounted) {
+        return;
+      }
+      setState(() {
+        _revolvingConfigs = next;
+      });
+      unawaited(_revolvingConfigStore.save(_revolvingConfigs));
+    } catch (e) {
+      debugPrint('revolving tombstone pull failed: $e');
+    }
   }
 
   void _toggleRevolving(AssetLiabilityDebtRow row, bool enabled) {
@@ -9464,17 +9577,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   /// 3 ドメインのトゥームストーンを掃除し、ドメイン別の削除件数を返す。
-  Future<({int inflow, int override, int debt, int total})>
+  Future<({int inflow, int override, int debt, int revolving, int total})>
       _pruneAllTombstones() async {
     final store = await SharedPreferences.getInstance();
     final inflow = await _expectedInflowStore.pruneDeletedIds();
     final override = await _displayModeStore.pruneDeletedSectionIds();
     final debt = await _debtOverrideTombstones.prune(store);
+    final revolving = await _revolvingConfigTombstones.prune(store);
     return (
       inflow: inflow,
       override: override,
       debt: debt,
-      total: inflow + override + debt,
+      revolving: revolving,
+      total: inflow + override + debt + revolving,
     );
   }
 
@@ -9488,7 +9603,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         debugPrint(
           'boot tombstone prune: removed ${removed.total} '
           '(inflow=${removed.inflow} override=${removed.override} '
-          'debt=${removed.debt})',
+          'debt=${removed.debt} revolving=${removed.revolving})',
         );
       }
     } catch (e) {

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1121,5 +1121,49 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets('revolving deletion tombstone removes local config', (
+      tester,
+    ) async {
+      // ローカルに aupay_card / keep_card のリボ設定がある。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        AssetRevolvingCreditConfigStore.prefsKey: jsonEncode(
+          AssetRevolvingCreditConfigStore.encodeMirrorValue(
+            <String, AssetLiabilityRevolvingCreditConfig>{
+              'aupay_card': const AssetLiabilityRevolvingCreditConfig(
+                monthlyAmount: 10000,
+                creditLimit: 500000,
+              ),
+              'keep_card': const AssetLiabilityRevolvingCreditConfig(
+                monthlyAmount: 3000,
+                creditLimit: 100000,
+              ),
+            },
+          ),
+        ),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 他端末で aupay_card を削除した状態を削除トゥームストーンで注入。
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugRevolvingDeletedMirror: <String, dynamic>{
+              'ids': <String>['aupay_card'],
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // 削除が伝播し aupay_card はローカルから消え、keep_card は残る。
+      final local = await const AssetRevolvingCreditConfigStore().load();
+      expect(local.keys, isNot(contains('aupay_card')));
+      expect(local.keys, contains('keep_card'));
+
+      await _unmount(tester);
+    });
   });
 }


### PR DESCRIPTION
## 概要

リボ払い設定の**削除（リボ OFF）が他端末に伝播しない**問題を修正する。

## 原因

直前にマージした union マージ/backfill（[#3381](https://github.com/kanta13jp1/my_web_app/pull/3381) /
[#3397](https://github.com/kanta13jp1/my_web_app/pull/3397)）は **追加・更新のみ**を同期する。
削除は additive マージでは表現できず、片端末で消したカードのリボ設定が他端末に残り、
さらに backfill で**サーバへ復活**してしまう。

## 修正（既存 debt 上書きと同じ削除トゥームストーン方式）

- `_revolvingConfigTombstones`（`MirrorTombstoneStore`）を追加。リボ OFF/再設定で
  `addId`/`removeId` し、`_mirrorRevolvingDeleted` が pref_key
  `revolving_credit_configs_deleted` へ upsert（他端末伝播）。
- boot で `_pullRevolvingDeleted`：他端末の削除トゥームストーンを取り込み、ローカルから除去。
- union マージ復元は削除トゥームストーン済みキーを **除外**（復活させない／backfill しない）。
- GC prune に revolving を追加（肥大化抑制）。`debugRevolvingDeletedMirror` 注入を追加。
- 残ドメイン（ウォッチリスト）の clear 伝播は後続 PR。

## テスト

`flutter analyze` → 0 issues、`flutter test`（全 28 件）green:
- 追加 widget テスト: 他端末で aupay_card を削除した状態（削除トゥームストーン注入）→
  ローカルから aupay_card が消え、keep_card は残ることを検証。

## Minimal E2E Gate

- 実装詳細に依存しない (black-box) 入出力契約のみ検証: 「ローカルのリボ設定 + 削除
  トゥームストーン」という入力に対し「削除後のローカル設定」という観測可能な出力をアサート。
- 最小限 (minimal) の 3 ケース相当 — 削除キー除去 / 非削除キー維持 / 復活なし。
- 機構: widget テスト。公開サイトの Playwright / `integration_test/` のブラウザ E2E は未追加。
- E2E-Exception: 端末間の削除伝播はログイン状態と Supabase 上のトゥームストーンに依存し、
  公開ブラックボックス E2E では決定的に再現しづらいため、widget テストで担保する。

## レビュー

- Review owner: Claude Code #1。
- High-risk-ultrareview-exception: 変更は `lib/pages` `test` のみで、認証 / 課金 /
  インフラ配信などの高リスクパスに触れない、既存パターン踏襲の不具合修正のため
  ultrareview 対象外とする。
