### PR TITLE
feat(asset): ウォッチリスト項目の削除を他端末へ伝播 (clear propagation)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -169,6 +169,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, dynamic>? debugRevolvingDeletedMirror;
 
+  /// テスト専用: ウォッチリストの削除トゥームストーン値 (`{'ids': [...]}`) を注入し、
+  /// 削除伝播をネットワークなしで検証する。
+  @visibleForTesting
+  final Map<String, dynamic>? debugWatchlistDeletedMirror;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -189,6 +194,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugMirrorReadsAuthoritative,
     this.debugDebtOverridesMirror,
     this.debugRevolvingDeletedMirror,
+    this.debugWatchlistDeletedMirror,
   });
 
   @override
@@ -610,8 +616,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // 他端末で削除されたセクション上書き / 支払日上書きを取り込む (#part292/294)。
     unawaited(_pullDeletedSectionIds());
     unawaited(_pullDebtOverrideDeleted());
-    // 他端末で削除されたリボ設定を取り込む (clear 伝播)。
+    // 他端末で削除されたリボ設定 / ウォッチリストを取り込む (clear 伝播)。
     unawaited(_pullRevolvingDeleted());
+    unawaited(_pullWatchlistDeleted());
     // 期限切れ・上限超過のトゥームストーンを自動掃除 (#part296 肥大化抑制)。
     unawaited(_pruneTombstonesOnBoot());
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
@@ -5271,6 +5278,88 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_refreshSyncSources());
   }
 
+  /// 削除したウォッチリスト項目のトゥームストーン (clear 伝播 / 復活防止)。
+  static const MirrorTombstoneStore _watchlistTombstones = MirrorTombstoneStore(
+    storageKey: 'watchlist_entries_deleted_v1',
+  );
+
+  Future<void> _recordWatchlistTombstone(
+    String assetType, {
+    required bool deleted,
+  }) async {
+    final store = await SharedPreferences.getInstance();
+    if (deleted) {
+      await _watchlistTombstones.addId(store, assetType);
+    } else {
+      await _watchlistTombstones.removeId(store, assetType);
+    }
+    unawaited(_mirrorWatchlistDeleted());
+  }
+
+  /// ウォッチリストの削除トゥームストーンをサーバへ反映 (他端末伝播)。
+  Future<void> _mirrorWatchlistDeleted() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final store = await SharedPreferences.getInstance();
+      final ids = _watchlistTombstones.activeIds(store);
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': 'watchlist_entries_deleted',
+        'value': MirrorTombstoneStore.encodeMirror(ids),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('watchlist tombstone mirror upsert failed: $e');
+    }
+  }
+
+  /// 他端末で削除されたウォッチリスト項目を取り込み、ローカルからも除去する。
+  Future<void> _pullWatchlistDeleted() async {
+    final debugMirror = widget.debugWatchlistDeletedMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      Map<String, dynamic>? value = debugMirror;
+      if (value == null) {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', 'watchlist_entries_deleted');
+        if (rows.isEmpty) {
+          return;
+        }
+        final raw = rows.first['value'];
+        if (raw is! Map) {
+          return;
+        }
+        value = Map<String, dynamic>.from(raw);
+      }
+      final ids = MirrorTombstoneStore.decodeMirror(value);
+      if (ids.isEmpty) {
+        return;
+      }
+      final store = await SharedPreferences.getInstance();
+      final incoming = await _watchlistTombstones.mergeRemoteIds(store, ids);
+      final next = Map<String, AssetWatchlistEntry>.from(_watchlistByType);
+      final before = next.length;
+      next.removeWhere((key, _) => incoming.contains(key));
+      if (next.length == before || !mounted) {
+        return;
+      }
+      final mergedList = next.values.toList();
+      setState(() {
+        _setWatchlistEntries(mergedList);
+      });
+      unawaited(widget.watchlistService.replaceAll(mergedList));
+    } catch (e) {
+      debugPrint('watchlist tombstone pull failed: $e');
+    }
+  }
+
   /// サーバ集約ミラーからウォッチリストを復元する (集約優先 + legacy local fallback)。
   /// ローカルに既に項目がある場合は上書きしない (オフライン編集を握り潰さない安全側)。
   Future<void> _restoreWatchlistFromMirror() async {
@@ -5279,6 +5368,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     final hasLocal = _watchlistByType.isNotEmpty;
+    // 削除トゥームストーン: 復活させない / バックフィルしない。
+    final tombstoned = _watchlistTombstones.activeIds(
+      await SharedPreferences.getInstance(),
+    );
     // フラグ OFF + ローカル値あり: サーバに無ければ初回バックフィルして終了。
     if (!_mirrorReadsAuthoritative && hasLocal && debugMirror == null) {
       unawaited(
@@ -5323,8 +5416,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final merged = Map<String, AssetWatchlistEntry>.from(_watchlistByType);
       final serverTypes = <String>{};
       var changed = false;
+      // 削除トゥームストーン済み項目はローカルからも除く (clear 伝播 / 復活防止)。
+      merged.removeWhere((key, _) {
+        if (tombstoned.contains(key)) {
+          changed = true;
+          return true;
+        }
+        return false;
+      });
       for (final entry in serverEntries) {
         serverTypes.add(entry.assetType);
+        if (tombstoned.contains(entry.assetType)) {
+          continue;
+        }
         if (!merged.containsKey(entry.assetType) || adoptConflicts) {
           merged[entry.assetType] = entry;
           changed = true;
@@ -5348,7 +5452,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       }
       // ローカルにあってサーバに無い項目は、マージ結果をサーバへバックフィル。
       final localHasExtra = localTypes.any(
-        (type) => !serverTypes.contains(type),
+        (type) => !tombstoned.contains(type) && !serverTypes.contains(type),
       );
       if (localHasExtra && debugMirror == null) {
         unawaited(_mirrorWatchlist());
@@ -5424,6 +5528,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   setState(() {
                     _setWatchlistEntries(entries);
                   });
+                  unawaited(_recordWatchlistTombstone(type, deleted: true));
                   unawaited(_mirrorWatchlist());
                   if (dialogContext.mounted) {
                     Navigator.of(dialogContext).pop();
@@ -5452,6 +5557,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 setState(() {
                   _setWatchlistEntries(entries);
                 });
+                unawaited(_recordWatchlistTombstone(type, deleted: false));
                 unawaited(_mirrorWatchlist());
                 if (dialogContext.mounted) {
                   Navigator.of(dialogContext).pop();
@@ -5788,6 +5894,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   _sortAssetTypes(); // ★ 削除時にも並び替え
                   _updateChartData();
                 });
+                unawaited(_recordWatchlistTombstone(type, deleted: true));
                 unawaited(_mirrorWatchlist());
               }
               if (context.mounted) Navigator.pop(context);
@@ -9576,20 +9683,29 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
-  /// 3 ドメインのトゥームストーンを掃除し、ドメイン別の削除件数を返す。
-  Future<({int inflow, int override, int debt, int revolving, int total})>
-      _pruneAllTombstones() async {
+  /// 各ドメインのトゥームストーンを掃除し、ドメイン別の削除件数を返す。
+  Future<
+      ({
+        int inflow,
+        int override,
+        int debt,
+        int revolving,
+        int watchlist,
+        int total,
+      })> _pruneAllTombstones() async {
     final store = await SharedPreferences.getInstance();
     final inflow = await _expectedInflowStore.pruneDeletedIds();
     final override = await _displayModeStore.pruneDeletedSectionIds();
     final debt = await _debtOverrideTombstones.prune(store);
     final revolving = await _revolvingConfigTombstones.prune(store);
+    final watchlist = await _watchlistTombstones.prune(store);
     return (
       inflow: inflow,
       override: override,
       debt: debt,
       revolving: revolving,
-      total: inflow + override + debt + revolving,
+      watchlist: watchlist,
+      total: inflow + override + debt + revolving + watchlist,
     );
   }
 
@@ -9603,7 +9719,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         debugPrint(
           'boot tombstone prune: removed ${removed.total} '
           '(inflow=${removed.inflow} override=${removed.override} '
-          'debt=${removed.debt} revolving=${removed.revolving})',
+          'debt=${removed.debt} revolving=${removed.revolving} '
+          'watchlist=${removed.watchlist})',
         );
       }
     } catch (e) {

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1165,5 +1165,49 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets('watchlist deletion tombstone removes local entry', (
+      tester,
+    ) async {
+      // ローカルに gold / btc のウォッチリスト項目がある。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'assetType': 'gold',
+            'group': '',
+            'memo': '',
+            'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+          },
+          <String, dynamic>{
+            'assetType': 'btc',
+            'group': '',
+            'memo': '',
+            'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 他端末で gold を削除した状態を削除トゥームストーンで注入。
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugWatchlistDeletedMirror: <String, dynamic>{
+              'ids': <String>['gold'],
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // 削除が伝播し gold はローカルから消え、btc は残る。
+      final local = await const AssetWatchlistService().loadEntries();
+      expect(local.map((e) => e.assetType), isNot(contains('gold')));
+      expect(local.map((e) => e.assetType), contains('btc'));
+
+      await _unmount(tester);
+    });
   });
 }


### PR DESCRIPTION
## 概要

ウォッチリスト項目の**削除が他端末に伝播しない**問題を修正する (リボ #3400 の続き)。

## 原因

union マージ/backfill は追加・更新のみ同期するため、片端末で削除したウォッチリスト項目が
他端末に残り、backfill でサーバへ復活してしまう。

## 修正 (リボ #3400 と同じ削除トゥームストーン方式)

- `_watchlistTombstones` (`MirrorTombstoneStore`) を追加。削除 (`removeEntry` 3箇所) /
  再追加 (`saveEntry`) で `addId`/`removeId` し、`_mirrorWatchlistDeleted` が pref_key
  `watchlist_entries_deleted` へ upsert (他端末伝播)。
- boot で `_pullWatchlistDeleted`: 他端末の削除トゥームストーンを取り込みローカルから除去。
- union マージ復元は削除トゥームストーン済み assetType を除外 (復活・backfill しない)。
- GC prune に watchlist を追加。`debugWatchlistDeletedMirror` 注入を追加。

これでウォッチリスト + リボ + 支払日の全コレクション pref ドメインで削除が双方向に同期される。

## テスト

`flutter analyze` → 0 issues、`flutter test` (全 29 件) green:
- 追加 widget テスト: 他端末で gold を削除した状態 (削除トゥームストーン注入) →
  ローカルから gold が消え、btc は残ることを検証。

## Minimal E2E Gate

- 実装詳細に依存しない (black-box) 入出力契約のみ検証: 「ローカルの項目 + 削除トゥームストーン」
  という入力に対し「削除後のローカル項目」という観測可能な出力をアサート。
- 最小限 (minimal) の 3 ケース相当 — 削除キー除去 / 非削除キー維持 / 復活なし。
- 機構: widget テスト。公開サイトの Playwright / `integration_test/` のブラウザ E2E は未追加。
- E2E-Exception: 端末間の削除伝播はログイン状態と Supabase 上のトゥームストーンに依存し、
  公開ブラックボックス E2E では決定的に再現しづらいため、widget テストで担保する。

## レビュー

- Review owner: Claude Code #1。
- High-risk-ultrareview-exception: 変更は `lib/pages` `test` のみで、認証 / 課金 /
  インフラ配信などの高リスクパスに触れない、既存パターン踏襲の修正のため ultrareview 対象外とする。
