### PR TITLE
feat: add multi-month cashflow balance forecast card

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -39,6 +39,7 @@ import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
+import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
 import 'package:my_web_app/services/asset_mirror_read_policy.dart';
 import 'package:my_web_app/services/asset_sync_status.dart';
@@ -59,6 +60,7 @@ import 'package:my_web_app/services/smbc_csv_import_service.dart';
 import 'package:my_web_app/services/waste_tracking_service.dart';
 import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
+import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -7751,6 +7753,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             if (_isSectionShown(AssetManagementSectionId.calendar)) ...[
               _buildAssetCalendarCard(assetLiabilityWorkbook),
               const SizedBox(height: 16),
+              _buildCashflowForecastCard(assetLiabilityWorkbook),
             ],
             if (_isSectionShown(AssetManagementSectionId.salaryBreakdown)) ...[
               _buildSalarySpendingBreakdownCard(),
@@ -10165,6 +10168,110 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       );
       _calendarSelectedDate = null;
     });
+  }
+
+  AssetCashflowRecurringEntry? _subscriptionRecurringEntry(
+    Map<String, dynamic> subscription,
+  ) {
+    final price = (subscription['price'] as num?)?.toDouble();
+    if (price == null || price <= 0) {
+      return null;
+    }
+    final dueDate = DateTime.tryParse(
+      subscription['due_date']?.toString() ?? '',
+    );
+    final name = subscription['service_name']?.toString().trim() ?? '';
+    return AssetCashflowRecurringEntry(
+      dayOfMonth: dueDate?.day ?? 1,
+      amount: price,
+      label: name.isEmpty ? '固定費' : name,
+    );
+  }
+
+  /// 現金・預金を起点に、繰り返し収入・固定費・返済予定を毎月積み上げた
+  /// 今後の残高見込みカード。登録データが無ければ非表示。
+  Widget _buildCashflowForecastCard(AssetLiabilityWorkbook? workbook) {
+    if (workbook == null) {
+      return const SizedBox.shrink();
+    }
+    var startingBalance = 0.0;
+    for (final account in workbook.accounts) {
+      final isLiquid = account.kind == AssetLiabilityAccountKind.cash ||
+          account.kind == AssetLiabilityAccountKind.deposit;
+      if (isLiquid && account.balance > 0) {
+        startingBalance += account.balance;
+      }
+    }
+
+    final recurringIncome = <AssetCashflowRecurringEntry>[
+      for (final template in _recurringIncomeTemplates)
+        if (template.dayOfMonth > 0 && template.amount > 0)
+          AssetCashflowRecurringEntry(
+            dayOfMonth: template.dayOfMonth,
+            amount: template.amount,
+            label: template.name,
+          ),
+      for (final rule in _expectedInflowRules)
+        if (rule.dayOfMonth > 0 && rule.amount > 0)
+          AssetCashflowRecurringEntry(
+            dayOfMonth: rule.dayOfMonth,
+            amount: rule.amount,
+            label: rule.label,
+          ),
+    ];
+
+    final subscriptionOutflow = <AssetCashflowRecurringEntry>[];
+    for (final subscription in _subscriptions) {
+      final entry = _subscriptionRecurringEntry(subscription);
+      if (entry != null) {
+        subscriptionOutflow.add(entry);
+      }
+    }
+    final recurringOutflow = <AssetCashflowRecurringEntry>[
+      for (final row in workbook.debtMasterRows)
+        if (row.isDirectCashflowTarget &&
+            row.balance < 0 &&
+            (row.paymentDay ?? 0) > 0 &&
+            row.scheduledPaymentAmount > 0)
+          AssetCashflowRecurringEntry(
+            dayOfMonth: row.paymentDay!,
+            amount: row.scheduledPaymentAmount,
+            label: row.name,
+          ),
+      ...subscriptionOutflow,
+    ];
+
+    final oneTimeIncome = <AssetCashflowDatedEntry>[
+      for (final inflow in _expectedInflows)
+        if (inflow.amount > 0)
+          AssetCashflowDatedEntry(
+            date: inflow.date,
+            amount: inflow.amount,
+            label: inflow.label,
+          ),
+    ];
+
+    if (recurringIncome.isEmpty &&
+        recurringOutflow.isEmpty &&
+        oneTimeIncome.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final forecast = AssetCashflowForecastService.project(
+      asOf: DateTime.now(),
+      startingBalance: startingBalance,
+      recurringIncome: recurringIncome,
+      recurringOutflow: recurringOutflow,
+      oneTimeIncome: oneTimeIncome,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: AssetCashflowForecastCard(
+        forecast: forecast,
+        currencyFormatter: _formatYen,
+      ),
+    );
   }
 
   Widget _buildAssetCalendarCard(AssetLiabilityWorkbook? workbook) {

--- a/lib/services/asset_cashflow_forecast_service.dart
+++ b/lib/services/asset_cashflow_forecast_service.dart
@@ -1,0 +1,223 @@
+import 'dart:math';
+
+/// 繰り返し(毎月)発生する収入・支出の1項目。
+/// [dayOfMonth] はその月の入金日 / 支払日(月末超過は丸める)。
+class AssetCashflowRecurringEntry {
+  const AssetCashflowRecurringEntry({
+    required this.dayOfMonth,
+    required this.amount,
+    this.label = '',
+  });
+
+  final int dayOfMonth;
+  final double amount;
+  final String label;
+}
+
+/// 特定日に1回だけ発生する収入・支出の1項目。
+class AssetCashflowDatedEntry {
+  const AssetCashflowDatedEntry({
+    required this.date,
+    required this.amount,
+    this.label = '',
+  });
+
+  final DateTime date;
+  final double amount;
+  final String label;
+}
+
+/// 予測1ヶ月分のサマリ。
+class AssetCashflowForecastMonth {
+  const AssetCashflowForecastMonth({
+    required this.month,
+    required this.openingBalance,
+    required this.closingBalance,
+    required this.worstBalance,
+    required this.incomeTotal,
+    required this.outflowTotal,
+    this.firstShortfallDate,
+  });
+
+  /// 対象月(1日0時)。
+  final DateTime month;
+
+  /// 月初(=前月末)の見込み残高。
+  final double openingBalance;
+
+  /// 月末の見込み残高。
+  final double closingBalance;
+
+  /// 月内の見込み残高の最小値。
+  final double worstBalance;
+
+  final double incomeTotal;
+  final double outflowTotal;
+
+  /// 月内で最初に残高が 0 未満へ落ちる日。なければ null。
+  final DateTime? firstShortfallDate;
+
+  bool get isShortfall => worstBalance < 0;
+
+  double get netChange => closingBalance - openingBalance;
+}
+
+/// 「今日起点・Nヶ月先」までの前方残高予測の結果。
+class AssetCashflowForecast {
+  const AssetCashflowForecast({
+    required this.asOf,
+    required this.startingBalance,
+    required this.months,
+    required this.worstBalance,
+    required this.safetyMargin,
+    this.firstShortfallDate,
+  });
+
+  final DateTime asOf;
+  final double startingBalance;
+  final List<AssetCashflowForecastMonth> months;
+
+  /// 全期間を通じた見込み残高の最小値。
+  final double worstBalance;
+
+  /// 安全余裕(見込み残高がこれを下回ると注意。0 なら 0 円ライン)。
+  final double safetyMargin;
+
+  /// 見込み残高が最初に 0 未満へ落ちる日。なければ null。
+  final DateTime? firstShortfallDate;
+
+  bool get isEmpty => months.isEmpty;
+
+  bool get hasShortfall => firstShortfallDate != null;
+
+  /// ショート回避に必要な追加資金(=最大不足幅)。ショートなしなら 0。
+  double get shortfallRecoveryAmount =>
+      worstBalance < 0 ? -worstBalance : 0;
+
+  /// 安全余裕を割り込む不足額(安全線維持に必要な額)。ショートなしでも > 0 になりうる。
+  double get safetyShortfallAmount =>
+      worstBalance < safetyMargin ? safetyMargin - worstBalance : 0;
+}
+
+/// 既存の単月 [AssetPaymentCalendarService.buildMonth] を「今日起点・Nヶ月先」
+/// の前方残高予測へ拡張する純関数サービス。
+///
+/// 各月で繰り返し収入/支出と一時収入/支出を日付順に積み上げ、月末残高を
+/// 翌月へ繰り越す。当月(m==0)は基準日より前の予定を二重計上しないよう
+/// 基準日以降のイベントのみ計上する。スキーマ非依存で完全にテスト可能。
+class AssetCashflowForecastService {
+  const AssetCashflowForecastService();
+
+  static const double _epsilon = 0.01;
+
+  /// 月の日数を超える日を月末へ丸める(2月の31日指定など)。
+  static int _clampDay(int day, DateTime month) {
+    final lastDay = DateTime(month.year, month.month + 1, 0).day;
+    return max(1, min(day, lastDay));
+  }
+
+  static bool _isSameDate(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  static AssetCashflowForecast project({
+    required DateTime asOf,
+    required double startingBalance,
+    int horizonMonths = 6,
+    List<AssetCashflowRecurringEntry> recurringIncome =
+        const <AssetCashflowRecurringEntry>[],
+    List<AssetCashflowRecurringEntry> recurringOutflow =
+        const <AssetCashflowRecurringEntry>[],
+    List<AssetCashflowDatedEntry> oneTimeIncome =
+        const <AssetCashflowDatedEntry>[],
+    List<AssetCashflowDatedEntry> oneTimeOutflow =
+        const <AssetCashflowDatedEntry>[],
+    double safetyMargin = 0,
+  }) {
+    final anchor = DateTime(asOf.year, asOf.month, asOf.day);
+    final horizon = max(1, horizonMonths);
+    var running = startingBalance;
+    var worstBalance = startingBalance;
+    DateTime? firstShortfallDate;
+    final months = <AssetCashflowForecastMonth>[];
+
+    for (var m = 0; m < horizon; m++) {
+      final monthStart = DateTime(asOf.year, asOf.month + m, 1);
+      final lastDay = DateTime(monthStart.year, monthStart.month + 1, 0).day;
+      final opening = running;
+      var incomeTotal = 0.0;
+      var outflowTotal = 0.0;
+      var worstInMonth = running;
+      DateTime? monthShortfall;
+
+      for (var day = 1; day <= lastDay; day++) {
+        final date = DateTime(monthStart.year, monthStart.month, day);
+        if (m == 0 && date.isBefore(anchor)) {
+          continue;
+        }
+        var dayIn = 0.0;
+        var dayOut = 0.0;
+        for (final entry in recurringIncome) {
+          if (entry.amount > _epsilon &&
+              _clampDay(entry.dayOfMonth, monthStart) == day) {
+            dayIn += entry.amount;
+          }
+        }
+        for (final entry in recurringOutflow) {
+          if (entry.amount > _epsilon &&
+              _clampDay(entry.dayOfMonth, monthStart) == day) {
+            dayOut += entry.amount;
+          }
+        }
+        for (final entry in oneTimeIncome) {
+          if (entry.amount > _epsilon && _isSameDate(entry.date, date)) {
+            dayIn += entry.amount;
+          }
+        }
+        for (final entry in oneTimeOutflow) {
+          if (entry.amount > _epsilon && _isSameDate(entry.date, date)) {
+            dayOut += entry.amount;
+          }
+        }
+        if (dayIn == 0 && dayOut == 0) {
+          continue;
+        }
+        running += dayIn - dayOut;
+        incomeTotal += dayIn;
+        outflowTotal += dayOut;
+        if (running < worstInMonth) {
+          worstInMonth = running;
+        }
+        if (running < worstBalance) {
+          worstBalance = running;
+        }
+        if (firstShortfallDate == null && running < 0) {
+          firstShortfallDate = date;
+        }
+        if (monthShortfall == null && running < 0) {
+          monthShortfall = date;
+        }
+      }
+
+      months.add(
+        AssetCashflowForecastMonth(
+          month: monthStart,
+          openingBalance: opening,
+          closingBalance: running,
+          worstBalance: worstInMonth,
+          incomeTotal: incomeTotal,
+          outflowTotal: outflowTotal,
+          firstShortfallDate: monthShortfall,
+        ),
+      );
+    }
+
+    return AssetCashflowForecast(
+      asOf: anchor,
+      startingBalance: startingBalance,
+      months: months,
+      worstBalance: worstBalance,
+      safetyMargin: safetyMargin,
+      firstShortfallDate: firstShortfallDate,
+    );
+  }
+}

--- a/lib/services/asset_cashflow_forecast_service.dart
+++ b/lib/services/asset_cashflow_forecast_service.dart
@@ -91,8 +91,7 @@ class AssetCashflowForecast {
   bool get hasShortfall => firstShortfallDate != null;
 
   /// ショート回避に必要な追加資金(=最大不足幅)。ショートなしなら 0。
-  double get shortfallRecoveryAmount =>
-      worstBalance < 0 ? -worstBalance : 0;
+  double get shortfallRecoveryAmount => worstBalance < 0 ? -worstBalance : 0;
 
   /// 安全余裕を割り込む不足額(安全線維持に必要な額)。ショートなしでも > 0 になりうる。
   double get safetyShortfallAmount =>

--- a/lib/widgets/asset_cashflow_forecast_card.dart
+++ b/lib/widgets/asset_cashflow_forecast_card.dart
@@ -242,9 +242,8 @@ class _ForecastChartPainter extends CustomPainter {
       final value = series[i];
       final isShortfall = i > 0 && forecast.months[i - 1].isShortfall;
       final pointPaint = Paint()
-        ..color = isShortfall
-            ? const Color(0xFFDC2626)
-            : const Color(0xFF4F46E5)
+        ..color =
+            isShortfall ? const Color(0xFFDC2626) : const Color(0xFF4F46E5)
         ..style = PaintingStyle.fill;
       canvas.drawCircle(Offset(xFor(i), yFor(value)), 3, pointPaint);
     }

--- a/lib/widgets/asset_cashflow_forecast_card.dart
+++ b/lib/widgets/asset_cashflow_forecast_card.dart
@@ -1,0 +1,256 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../services/asset_cashflow_forecast_service.dart';
+
+/// 将来 N ヶ月の月末残高予測カード。
+///
+/// 純関数 [AssetCashflowForecastService] の結果([AssetCashflowForecast])を
+/// 受け取り、残高カーブ + ショート警告 + 前提サマリを描画する自己完結ウィジェット。
+/// ページ状態へ依存しないためウィジェットテストで単体検証できる。
+class AssetCashflowForecastCard extends StatelessWidget {
+  const AssetCashflowForecastCard({
+    super.key,
+    required this.forecast,
+    this.currencyFormatter,
+  });
+
+  final AssetCashflowForecast forecast;
+
+  /// 金額整形(ページの `_formatYen` を渡す)。null なら簡易整形。
+  final String Function(double value)? currencyFormatter;
+
+  static const Color _accent = Color(0xFF4F46E5);
+  static const Color _danger = Color(0xFFDC2626);
+  static const Color _safe = Color(0xFF059669);
+
+  String _yen(double value) {
+    final formatter = currencyFormatter;
+    if (formatter != null) {
+      return formatter(value);
+    }
+    return '¥${value.round()}';
+  }
+
+  String _monthLabel(DateTime month) => '${month.month}月';
+
+  @override
+  Widget build(BuildContext context) {
+    final months = forecast.months;
+    return Card(
+      key: const Key('asset_cashflow_forecast_card'),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.timeline, color: _accent),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '将来残高予測(今後${months.length}ヶ月)',
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            if (forecast.isEmpty)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 12),
+                child: Text(
+                  '繰り返し収入・固定費・返済予定を登録すると、今後の残高見込みを表示します。',
+                  style: TextStyle(fontSize: 12, height: 1.5),
+                ),
+              )
+            else ...[
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 160,
+                width: double.infinity,
+                child: CustomPaint(
+                  key: const Key('asset_cashflow_forecast_chart'),
+                  painter: _ForecastChartPainter(forecast: forecast),
+                ),
+              ),
+              const SizedBox(height: 10),
+              _buildSummary(context),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSummary(BuildContext context) {
+    final shortfallDate = forecast.firstShortfallDate;
+    final last = forecast.months.isEmpty ? null : forecast.months.last;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (shortfallDate != null)
+          Container(
+            key: const Key('asset_cashflow_forecast_shortfall'),
+            width: double.infinity,
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: _danger.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Icon(Icons.warning_amber, color: _danger, size: 18),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    '${shortfallDate.month}/${shortfallDate.day} 頃に残高が不足する見込みです。'
+                    '回避には ${_yen(forecast.shortfallRecoveryAmount)} の追加資金が必要です。',
+                    style: const TextStyle(
+                      fontSize: 12,
+                      height: 1.5,
+                      color: _danger,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          )
+        else
+          Row(
+            children: [
+              const Icon(Icons.check_circle, color: _safe, size: 18),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  '今後${forecast.months.length}ヶ月は残高不足の見込みはありません'
+                  '(最小見込み残高 ${_yen(forecast.worstBalance)})。',
+                  style: const TextStyle(fontSize: 12, height: 1.5),
+                ),
+              ),
+            ],
+          ),
+        const SizedBox(height: 8),
+        if (last != null)
+          Text(
+            '${_monthLabel(last.month)}末の見込み残高: ${_yen(last.closingBalance)}',
+            style: const TextStyle(
+              fontSize: 12,
+              height: 1.5,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        const SizedBox(height: 2),
+        Text(
+          '現金・預金 ${_yen(forecast.startingBalance)} を起点に、繰り返し収入・固定費・返済予定を'
+          '毎月積み上げた見込みです。未登録の入出金は含まれません。',
+          style: TextStyle(
+            fontSize: 11,
+            height: 1.5,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ForecastChartPainter extends CustomPainter {
+  const _ForecastChartPainter({required this.forecast});
+
+  final AssetCashflowForecast forecast;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final closings = forecast.months
+        .map((month) => month.closingBalance)
+        .toList(growable: false);
+    final series = <double>[forecast.startingBalance, ...closings];
+    if (series.length < 2) {
+      return;
+    }
+
+    final reference = <double>[0, forecast.safetyMargin];
+    var minValue = [...series, ...reference].reduce(min);
+    var maxValue = [...series, ...reference].reduce(max);
+    if ((maxValue - minValue).abs() < 1) {
+      maxValue += 1;
+      minValue -= 1;
+    }
+    final range = maxValue - minValue;
+
+    const leftPad = 8.0;
+    const rightPad = 8.0;
+    const topPad = 8.0;
+    const bottomPad = 8.0;
+    final chartWidth = size.width - leftPad - rightPad;
+    final chartHeight = size.height - topPad - bottomPad;
+
+    double xFor(int index) =>
+        leftPad + chartWidth * index / (series.length - 1);
+    double yFor(double value) =>
+        topPad + chartHeight * (1 - (value - minValue) / range);
+
+    // 0 円ライン。
+    final zeroPaint = Paint()
+      ..color = const Color(0xFF9CA3AF)
+      ..strokeWidth = 1;
+    final zeroY = yFor(0);
+    canvas.drawLine(
+      Offset(leftPad, zeroY),
+      Offset(size.width - rightPad, zeroY),
+      zeroPaint,
+    );
+
+    // 安全線(0 と異なる場合のみ)。
+    if (forecast.safetyMargin.abs() >= 1) {
+      final safePaint = Paint()
+        ..color = const Color(0xFF059669)
+        ..strokeWidth = 1;
+      final safeY = yFor(forecast.safetyMargin);
+      for (double x = leftPad; x < size.width - rightPad; x += 8) {
+        canvas.drawLine(
+          Offset(x, safeY),
+          Offset(min(x + 4, size.width - rightPad), safeY),
+          safePaint,
+        );
+      }
+    }
+
+    // 残高ポリライン。
+    final linePaint = Paint()
+      ..color = const Color(0xFF4F46E5)
+      ..strokeWidth = 2
+      ..style = PaintingStyle.stroke;
+    final path = Path()..moveTo(xFor(0), yFor(series.first));
+    for (var i = 1; i < series.length; i++) {
+      path.lineTo(xFor(i), yFor(series[i]));
+    }
+    canvas.drawPath(path, linePaint);
+
+    // 各点(ショート月は赤)。
+    for (var i = 0; i < series.length; i++) {
+      final value = series[i];
+      final isShortfall = i > 0 && forecast.months[i - 1].isShortfall;
+      final pointPaint = Paint()
+        ..color = isShortfall
+            ? const Color(0xFFDC2626)
+            : const Color(0xFF4F46E5)
+        ..style = PaintingStyle.fill;
+      canvas.drawCircle(Offset(xFor(i), yFor(value)), 3, pointPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _ForecastChartPainter oldDelegate) =>
+      oldDelegate.forecast != forecast;
+}

--- a/test/services/asset_cashflow_forecast_service_test.dart
+++ b/test/services/asset_cashflow_forecast_service_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
+
+void main() {
+  group('AssetCashflowForecastService.project', () {
+    test('flat forecast when there are no recurring or dated entries', () {
+      final forecast = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 1),
+        startingBalance: 100000,
+        horizonMonths: 3,
+      );
+
+      expect(forecast.months, hasLength(3));
+      expect(forecast.hasShortfall, isFalse);
+      expect(forecast.worstBalance, 100000);
+      for (final month in forecast.months) {
+        expect(month.closingBalance, 100000);
+        expect(month.openingBalance, 100000);
+      }
+    });
+
+    test('surplus income grows the balance with no shortfall', () {
+      final forecast = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 1),
+        startingBalance: 500000,
+        horizonMonths: 2,
+        recurringIncome: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 25, amount: 300000),
+        ],
+        recurringOutflow: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 10, amount: 100000),
+        ],
+      );
+
+      expect(forecast.hasShortfall, isFalse);
+      expect(forecast.firstShortfallDate, isNull);
+      // 6月: 500000 -100000 +300000 = 700000。7月: +200000 = 900000。
+      expect(forecast.months[0].closingBalance, 700000);
+      expect(forecast.months[1].closingBalance, 900000);
+      expect(forecast.worstBalance, 400000);
+      expect(forecast.shortfallRecoveryAmount, 0);
+    });
+
+    test('detects the first shortfall date and recovery amount', () {
+      final forecast = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 1),
+        startingBalance: 100000,
+        horizonMonths: 3,
+        recurringIncome: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 25, amount: 200000),
+        ],
+        recurringOutflow: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 10, amount: 250000),
+        ],
+      );
+
+      expect(forecast.hasShortfall, isTrue);
+      expect(forecast.firstShortfallDate, DateTime(2026, 6, 10));
+      // 6月worst -150000, 7月worst -200000, 8月worst -250000。
+      expect(forecast.worstBalance, -250000);
+      expect(forecast.shortfallRecoveryAmount, 250000);
+      expect(forecast.months[0].isShortfall, isTrue);
+    });
+
+    test('closing balance of month N equals opening balance of month N+1', () {
+      final forecast = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 1),
+        startingBalance: 80000,
+        horizonMonths: 4,
+        recurringIncome: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 25, amount: 180000),
+        ],
+        recurringOutflow: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 5, amount: 60000),
+          AssetCashflowRecurringEntry(dayOfMonth: 27, amount: 90000),
+        ],
+      );
+
+      for (var i = 1; i < forecast.months.length; i++) {
+        expect(
+          forecast.months[i].openingBalance,
+          forecast.months[i - 1].closingBalance,
+        );
+      }
+    });
+
+    test('current month ignores entries dated before the anchor day', () {
+      final withEarlyAnchor = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 1),
+        startingBalance: 50000,
+        horizonMonths: 1,
+        recurringOutflow: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 10, amount: 100000),
+        ],
+      );
+      final withLateAnchor = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 15),
+        startingBalance: 50000,
+        horizonMonths: 1,
+        recurringOutflow: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 10, amount: 100000),
+        ],
+      );
+
+      // 1日基準なら10日の支払を計上してショート、15日基準なら計上しない。
+      expect(withEarlyAnchor.hasShortfall, isTrue);
+      expect(withLateAnchor.hasShortfall, isFalse);
+      expect(withLateAnchor.months[0].closingBalance, 50000);
+    });
+
+    test('one-time income only counts in its own month', () {
+      final forecast = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 1),
+        startingBalance: 0,
+        horizonMonths: 3,
+        oneTimeIncome: [
+          AssetCashflowDatedEntry(date: DateTime(2026, 7, 10), amount: 70000),
+        ],
+      );
+
+      expect(forecast.months[0].incomeTotal, 0);
+      expect(forecast.months[1].incomeTotal, 70000);
+      expect(forecast.months[2].incomeTotal, 0);
+      expect(forecast.months[2].closingBalance, 70000);
+    });
+
+    test('clamps a day-of-month beyond the month length to month end', () {
+      final forecast = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 2, 1),
+        startingBalance: 5000,
+        horizonMonths: 1,
+        recurringOutflow: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 31, amount: 6000),
+        ],
+      );
+
+      // 2026年2月は28日まで。31日指定は28日へ丸めて計上される。
+      expect(forecast.months[0].outflowTotal, 6000);
+      expect(forecast.months[0].closingBalance, -1000);
+      expect(forecast.firstShortfallDate, DateTime(2026, 2, 28));
+    });
+
+    test('safety margin surfaces a shortfall even above zero', () {
+      final forecast = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 1),
+        startingBalance: 30000,
+        horizonMonths: 1,
+        recurringOutflow: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 10, amount: 25000),
+        ],
+        safetyMargin: 10000,
+      );
+
+      // worst = 5000。0以上だがショートなし、安全余裕10000は割り込む。
+      expect(forecast.hasShortfall, isFalse);
+      expect(forecast.safetyShortfallAmount, 5000);
+    });
+  });
+}

--- a/test/widgets/asset_cashflow_forecast_card_test.dart
+++ b/test/widgets/asset_cashflow_forecast_card_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
+import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
+
+Future<void> _pump(WidgetTester tester, AssetCashflowForecast forecast) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: AssetCashflowForecastCard(
+            forecast: forecast,
+            currencyFormatter: (value) => '¥${value.round()}',
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('AssetCashflowForecastCard', () {
+    testWidgets('renders the chart and a shortfall warning', (tester) async {
+      final forecast = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 1),
+        startingBalance: 100000,
+        horizonMonths: 3,
+        recurringIncome: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 25, amount: 200000),
+        ],
+        recurringOutflow: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 10, amount: 250000),
+        ],
+      );
+
+      await _pump(tester, forecast);
+
+      expect(
+        find.byKey(const Key('asset_cashflow_forecast_card')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('asset_cashflow_forecast_chart')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('asset_cashflow_forecast_shortfall')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('残高が不足'), findsOneWidget);
+    });
+
+    testWidgets('shows a no-shortfall summary when balances stay positive', (
+      tester,
+    ) async {
+      final forecast = AssetCashflowForecastService.project(
+        asOf: DateTime(2026, 6, 1),
+        startingBalance: 500000,
+        horizonMonths: 2,
+        recurringIncome: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 25, amount: 300000),
+        ],
+        recurringOutflow: const [
+          AssetCashflowRecurringEntry(dayOfMonth: 10, amount: 100000),
+        ],
+      );
+
+      await _pump(tester, forecast);
+
+      expect(
+        find.byKey(const Key('asset_cashflow_forecast_card')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('asset_cashflow_forecast_chart')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('asset_cashflow_forecast_shortfall')),
+        findsNothing,
+      );
+      expect(
+        find.textContaining('残高不足の見込みはありません'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What & why

The asset management page already projects a running balance for the current
month (the money calendar). This extends that into a forward "今後Nヶ月"
balance forecast (default 6 months) so the user can see, well ahead of time,
when their balance is projected to dip below zero — the headline gap versus
spreadsheet-style trackers.

## Changes

- `lib/services/asset_cashflow_forecast_service.dart` (pure function): projects
  a running balance month by month from today, carrying each month's closing
  into the next. Inputs are recurring income (income templates + inflow rules),
  one-time income, and recurring outflows (fixed costs + scheduled debt
  outflows). It surfaces the first shortfall date and the recovery amount (the
  worst deficit). No schema change; it reuses existing in-memory models.
- `lib/widgets/asset_cashflow_forecast_card.dart` (self-contained widget):
  renders the balance curve (CustomPaint), a shortfall warning, and the
  assumptions summary. It depends only on the forecast result, so it is
  testable in isolation.
- `lib/pages/asset_management_page.dart`: derives the inputs from the same
  liquid balance / debts / recurring income already on the page and shows the
  card under the calendar section (one builder method + one insertion).
- Tests: unit tests for the projection and widget tests for the card.

## Minimal E2E Gate

- Implementation-detail independent: the tests assert user-visible input/output
  (a forecast result and the rendered curve / warning), not private internals.
- Minimal scope: about 3 cases (happy path with surplus, error path that hits a
  shortfall, recovery / empty-input state).
- E2E: the card is exercised black-box via widget tests; full page-level
  integration_test / Playwright e2e is not added here (see exception).
- E2E-Exception: the asset page is auth-gated and ~30k lines, so a black-box
  widget test of the new card is the minimal user-visible check; the pure
  service is covered by unit tests.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: docs/services/widget/test plus a small
  additive page change; no high-risk path touched, review owned by Claude Code #1.
