### PR TITLE
fix: 同名資産口座による既定固定費の誤抑止を修正

### DIFF
--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -1810,28 +1810,30 @@ class AssetLiabilityPlanningService {
     return result;
   }
 
-  bool _hasKddiProvider(Map<String, double> snapshot) {
-    return snapshot.keys.any(
-      (name) => _accountIdForName(name) == kddiProviderAccountId,
+  // 同名の資産口座(例: 「家賃保証金」「KDDIポイント」「ガスト」)が既定固定費を
+  // 誤って抑止しないよう、実際に負債(残高<0)の口座だけを「既存の請求あり」とみなす。
+  // _accountIdForName の名寄せは部分一致で語境界を持たないため、残高の符号で
+  // 本物の請求口座に限定する。既定固定費(家賃/KDDI/水道/ガス)は負債として計上される。
+  bool _hasLiabilityAccountFor(Map<String, double> snapshot, String accountId) {
+    return snapshot.entries.any(
+      (entry) => entry.value < 0 && _accountIdForName(entry.key) == accountId,
     );
+  }
+
+  bool _hasKddiProvider(Map<String, double> snapshot) {
+    return _hasLiabilityAccountFor(snapshot, kddiProviderAccountId);
   }
 
   bool _hasRent(Map<String, double> snapshot) {
-    return snapshot.keys.any(
-      (name) => _accountIdForName(name) == rentAccountId,
-    );
+    return _hasLiabilityAccountFor(snapshot, rentAccountId);
   }
 
   bool _hasWaterBill(Map<String, double> snapshot) {
-    return snapshot.keys.any(
-      (name) => _accountIdForName(name) == waterBillAccountId,
-    );
+    return _hasLiabilityAccountFor(snapshot, waterBillAccountId);
   }
 
   bool _hasGasBill(Map<String, double> snapshot) {
-    return snapshot.keys.any(
-      (name) => _accountIdForName(name) == gasBillAccountId,
-    );
+    return _hasLiabilityAccountFor(snapshot, gasBillAccountId);
   }
 
   String _fallbackAccountId(String name) {

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1512,6 +1512,58 @@ void main() {
       expect(gas.scheduledPaymentAmount, 5800);
     });
 
+    test(
+      'positive-balance accounts sharing a substring do not suppress defaults',
+      () {
+        // 「家賃保証金」「KDDIポイント」「ガスト」は名前に家賃/kddi/ガスを含むが
+        // 資産(正残高)であり、既定固定費(家賃/KDDI/ガス)を抑止してはならない。
+        final workbook = service.buildWorkbook(
+          latestSnapshot: const <String, double>{
+            'メインバンク': 200000,
+            '家賃保証金': 500000,
+            'KDDIポイント': 1200,
+            'ガスト': 3000,
+          },
+          baseDate: DateTime(2026, 6, 14),
+          includeDefaultFixedPayments: true,
+        );
+        bool hasDefault(String id) =>
+            workbook.debtMasterRows.any((row) => row.id == id);
+        expect(hasDefault(AssetLiabilityPlanningService.rentAccountId), isTrue);
+        expect(
+          hasDefault(AssetLiabilityPlanningService.kddiProviderAccountId),
+          isTrue,
+        );
+        expect(
+          hasDefault(AssetLiabilityPlanningService.gasBillAccountId),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'a real liability sharing the rent id still suppresses the default rent',
+      () {
+        // ユーザーが実際の家賃を負債として登録している場合は二重計上せず、
+        // 既定63,000円ではなくユーザーの実額を優先する。
+        final workbook = service.buildWorkbook(
+          latestSnapshot: const <String, double>{
+            'メインバンク': 200000,
+            '家賃': -58000,
+          },
+          baseDate: DateTime(2026, 6, 14),
+          includeDefaultFixedPayments: true,
+        );
+        final rentRows = workbook.debtMasterRows
+            .where(
+              (row) => row.id == AssetLiabilityPlanningService.rentAccountId,
+            )
+            .toList();
+        expect(rentRows.length, 1);
+        expect(rentRows.first.balance, -58000);
+      },
+    );
+
     test('treats paid KDDI provider payment as reflected in cashflow', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: <String, double>{'cash': 50000, 'au': -32152},


### PR DESCRIPTION
## 概要

既定固定費(家賃/KDDI/水道/ガス)の自動計上が、名前に同じ部分文字列を含むだけの無関係な「資産」口座の存在で誤って抑止される不具合を修正します。多次元監査(Dynamic Workflow / 39エージェント・3レンズ敵対的検証)で確定したHIGH 2件の根本原因です。

- 根本原因: `_accountIdForName` の名寄せが部分一致(語境界なし)。「家賃保証金」「KDDIポイント」「ガスト」等が rent/kddi/gas に解決され、`_hasX` が true を返して既定固定費を抑止 → 月次の支出が過小表示(楽観方向)。
- 影響額の例: 家賃が抑止されると月63,000円・年756,000円が欠落し、資金繰り判定を大きく狂わせる。
- 修正: `_hasX` 判定を「マッチした口座が実際に負債(残高<0)の場合のみ既存とみなす」へ変更(共通ヘルパ `_hasLiabilityAccountFor`)。資産系の同名口座では抑止されない。`_accountIdForName` のマッチ語は変更しない(既定口座名が「家賃」「ガス代」等の素の語に依存しており、語を絞ると既定自体が壊れるため)。

先日追加した水道・ガスを含む4固定費すべてに同時適用。

## テスト

`AssetLiabilityPlanningService` の単体テストで入出力契約を検証します。実装詳細に依存しない最小限の約3ケースです。

- 「家賃保証金」「KDDIポイント」「ガスト」(いずれも正残高=資産)があっても家賃/KDDI/ガスの既定が計上される
- 実際の負債「家賃」(-58,000)がある場合は二重計上せず、ユーザー実額を優先(既定63,000で上書きしない)
- 既存71件 + 新規2件 = 73件 green(回帰なし)

UI を伴わない純粋なサービス層の判定ロジック修正のため、integration_test / Playwright のエンドツーエンドは追加しません。

E2E例外: 純粋なサービス層の判定ロジック修正でUI経路なし、単体テストで入出力を網羅

---
Review owner: Claude Code #1
High-risk-ultrareview-exception: 純関数の名寄せ抑止判定の修正で高リスクパスや外部通信を含まない
