### PR TITLE
fix: tombstone GC を挿入位置順から削除時刻順へ (audit hardening)

### DIFF
--- a/lib/services/mirror_tombstone_store.dart
+++ b/lib/services/mirror_tombstone_store.dart
@@ -201,7 +201,20 @@ class MirrorTombstoneStore {
       }
     }
     if (kept.length > gcConfig.maxCount) {
-      return kept.sublist(kept.length - gcConfig.maxCount);
+      // 件数上限超過分は「挿入位置の末尾」ではなく実際の削除時刻('at')が
+      // 新しい順で残す。mergeRemoteIds はリモート ID を末尾に追記するため、
+      // 挿入順依存だと旧形式の混在やマージ順次第で新しいトゥームストーンを
+      // 取りこぼし得る(=削除済み項目が他端末から復活し得る)。'at' 降順で
+      // 決定的に最新側を残すことでこれを防ぐ。
+      final byNewest = List<Map<String, String>>.from(kept)
+        ..sort((a, b) {
+          final atA = DateTime.tryParse(a['at'] ?? '') ??
+              DateTime.fromMillisecondsSinceEpoch(0);
+          final atB = DateTime.tryParse(b['at'] ?? '') ??
+              DateTime.fromMillisecondsSinceEpoch(0);
+          return atB.compareTo(atA);
+        });
+      return byNewest.sublist(0, gcConfig.maxCount);
     }
     return kept;
   }

--- a/lib/services/mirror_tombstone_store.dart
+++ b/lib/services/mirror_tombstone_store.dart
@@ -201,20 +201,25 @@ class MirrorTombstoneStore {
       }
     }
     if (kept.length > gcConfig.maxCount) {
-      // 件数上限超過分は「挿入位置の末尾」ではなく実際の削除時刻('at')が
-      // 新しい順で残す。mergeRemoteIds はリモート ID を末尾に追記するため、
-      // 挿入順依存だと旧形式の混在やマージ順次第で新しいトゥームストーンを
-      // 取りこぼし得る(=削除済み項目が他端末から復活し得る)。'at' 降順で
-      // 決定的に最新側を残すことでこれを防ぐ。
-      final byNewest = List<Map<String, String>>.from(kept)
-        ..sort((a, b) {
-          final atA = DateTime.tryParse(a['at'] ?? '') ??
+      // 件数上限超過分は実際の削除時刻('at')が新しい順で残す。
+      // mergeRemoteIds はリモート ID を末尾に追記するため、純粋な挿入順依存
+      // (旧 sublist)だと旧形式の混在やマージ順次第で新しいトゥームストーンを
+      // 取りこぼし得る(=削除済み項目が他端末から復活し得る)。
+      // 同時刻('at' が等しい)場合は挿入が新しい方(末尾)を優先し、従来の
+      // 「最古の挿入を捨てる」挙動を保つ(固定クロック下での安定性)。
+      final order = <MapEntry<int, Map<String, String>>>[
+        for (var i = 0; i < kept.length; i++) MapEntry(i, kept[i]),
+      ]..sort((a, b) {
+          final atA = DateTime.tryParse(a.value['at'] ?? '') ??
               DateTime.fromMillisecondsSinceEpoch(0);
-          final atB = DateTime.tryParse(b['at'] ?? '') ??
+          final atB = DateTime.tryParse(b.value['at'] ?? '') ??
               DateTime.fromMillisecondsSinceEpoch(0);
-          return atB.compareTo(atA);
+          final byAt = atB.compareTo(atA);
+          return byAt != 0 ? byAt : b.key.compareTo(a.key);
         });
-      return byNewest.sublist(0, gcConfig.maxCount);
+      return <Map<String, String>>[
+        for (final entry in order.take(gcConfig.maxCount)) entry.value,
+      ];
     }
     return kept;
   }

--- a/test/services/mirror_tombstone_store_test.dart
+++ b/test/services/mirror_tombstone_store_test.dart
@@ -73,6 +73,31 @@ void main() {
       expect(store.activeIds(sp), isEmpty);
     });
 
+    test('GC keeps the newest by timestamp, not by list position', () async {
+      // 上限超過時は「末尾(挿入位置)」ではなく削除時刻('at')の新しい順で残す。
+      // 保存順では newer が先・older が後だが、上限1なら newer が残るべき。
+      // 旧挙動(tail keep)だと末尾の older を残し、新しい newer を取りこぼした。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'k': jsonEncode(<Map<String, String>>[
+          {
+            'id': 'newer',
+            'at': DateTime(2026, 6, 13, 12).toUtc().toIso8601String(),
+          },
+          {
+            'id': 'older',
+            'at': DateTime(2026, 6, 13, 9).toUtc().toIso8601String(),
+          },
+        ]),
+      });
+      final store = MirrorTombstoneStore(
+        storageKey: 'k',
+        gcConfig: const AssetTombstoneGcConfig(maxCount: 1, maxAgeDays: 3650),
+        nowProvider: () => DateTime(2026, 6, 14, 9),
+      );
+      final sp = await prefs();
+      expect(store.activeIds(sp), <String>{'newer'});
+    });
+
     test('reads legacy plain-string format', () async {
       SharedPreferences.setMockInitialValues(<String, Object>{
         'k': jsonEncode(<String>['legacy']),


### PR DESCRIPTION
## 概要

トゥームストーン GC(`MirrorTombstoneStore._gcEntries`)の件数上限超過時の退避を、**挿入位置の末尾**ではなく**削除時刻('at')の新しい順**へ変更します。多次元監査(mirror-sync 再監査)で挙がった項目の hardening です。

- 現状: `sublist(length - maxCount)` で挿入順の末尾を残す。`mergeRemoteIds` がリモートIDを末尾追記するため、旧形式の混在やマージ順次第で新しいトゥームストーンを取りこぼし得る(=削除済み項目が他端末から復活し得る)。
- 修正: 'at' 降順で決定的に最新側を残す。期限(maxAgeDays)フィルタは不変。
- 正直な評価: 通常運用ではリモートIDが取込時刻で付与されるため末尾退避≒最新退避で、実害は **件数上限(既定1000)超過 or 旧形式混在** という限定条件のみ。HIGH ではなく決定性・堅牢性の hardening。

## テスト

`MirrorTombstoneStore` の単体テストで入出力契約を検証します。実装詳細に依存しない最小限の追加1ケース(既存8件は不変)。

- 保存順では新しい項目が先・古い項目が後でも、上限1なら新しい項目が残る(旧挙動=末尾退避なら取りこぼしていた)
- 既存「GC honors maxCount」(最古を捨てる)も不変でPASS
- 合計9件green

純粋なローカル永続ロジックの変更でUI経路なし、integration_test / Playwright のエンドツーエンドは追加しません。

E2E例外: 純粋なローカルGCロジックの決定性修正でUI経路なし、単体テストで入出力を網羅

---
Review owner: Claude Code #1
High-risk-ultrareview-exception: ローカルGC順序の hardening で高リスクパスや外部通信を含まない
