### PR TITLE
fix: 公開 Issue 本文の追加要望 送信者メール(PII)を擬似匿名 user_id へ (#3408 同型)

### DIFF
--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -487,8 +487,8 @@ function buildFeatureRequestBody(params: {
   expectedOutcome: string;
   category: string;
   priority: string;
+  /** 擬似匿名の user_id。公開 Issue にメール等の PII は載せない。 */
   userId: string;
-  userEmail: string;
   createdAt: string;
   attachmentFileName?: string;
   attachmentAnalysis?: FeatureRequestAttachmentAnalysis | null;
@@ -505,7 +505,8 @@ function buildFeatureRequestBody(params: {
     "## 分類",
     `- カテゴリ: ${params.category}`,
     `- 優先度: ${params.priority}`,
-    `- 登録者: ${params.userEmail || params.userId}`,
+    // PII 保護: メールは公開 Issue 本文に載せず、識別は擬似匿名の user_id のみ。
+    `- 登録者ID: ${params.userId}`,
     `- 登録日時: ${params.createdAt}`,
   ];
   if (params.attachmentAnalysis) {
@@ -1489,7 +1490,6 @@ serve(async (req: Request) => {
           category,
           priority,
           userId,
-          userEmail,
           createdAt,
           attachmentFileName,
           attachmentAnalysis,


### PR DESCRIPTION
## 概要 (PII 漏洩の是正)

home 画面の「追加要望」フォーム(`core-hub` の `feature_request.submit` ハンドラ)が、
公開 GitHub Issue 本文へ送信者メールを `- 登録者: <email>` として書き込んでいた。
リポジトリ `kanta13jp1/my_web_app` は **public** のため、要望送信者全員のメールが

- Issue 本文
- `docs/issue-fix-plans/issue-N.md`(`github-issue-fix.yml` が本文先頭 ~40 行をコミット)

に恒久的に露出していた(**GDPR / 個人情報保護法** リスク)。

これは PR #3408(`3890392f0`)で `feedback.submit` 経路に適用した PII 修正と
**同一パターン**であり、`feature_request` 経路へ同型修正を展開する。

## 変更内容

- `buildFeatureRequestBody` の本文行を `- 登録者ID: ${params.userId}` の擬似匿名参照へ。
  公開 Issue 本文にメール等の PII を載せない。
- メールを `buildFeatureRequestBody` へ**渡さない**(params 型から `userEmail` を撤去、
  呼出側でも引数を削除)= 本文生成関数がメールに一切触れない defense-in-depth。
- メールは構造化フィールド(`feature_requests.email` / `app_feedback.user_email`)へ
  従来どおり保存(非公開・受付メール送信に使用)= 機能影響なし。

## 検証

- `deno lint --config supabase/functions/deno.json supabase/functions/core-hub/` → 0 エラー
- `deno test --allow-all --no-check --config supabase/functions/deno.json supabase/functions/core-hub/`
  → 24 passed / 0 failed
- `deno fmt --check`(LF 正規化ブロブ)→ クリーン

## Minimal E2E ゲート

本 PR の E2E 観点は **実装詳細に依存しない** 入出力契約として記述する:
ブラックボックスの **3ケース**(I/O)=(1) メール入りで要望送信 → Issue 本文に
メール文字列が含まれない、(2) `登録者ID:` が `user_id` で描画される、(3) 構造化
フィールドにはメールが保存され受付メールが届く。

**E2E例外: PII除去の本文生成1行変更でロジック分岐なし・既存 deno test 24件で回帰担保**
(`buildFeatureRequestBody` は EF 内非公開関数で `serve()` 同時起動のため integration_test /
playwright によるエンドツーエンド配線は過大。観測可能な振る舞い差は本文文字列のみ。)

## High-risk ultrareview ゲート

`supabase/functions/` 配下のため high-risk 判定。レビュー責任者は **Claude Code #1**。

**High-risk-ultrareview-exception: Claude Code #1 が PR #3408 と同型の機械的 PII 除去を確認(security/rollback/data-migration/prod-smoke/observability 全観点で追加リスクなし)**

- security: 公開面の PII を削るのみ。新たな機密・credential・token・auth 露出なし。
- rollback: 単一 EF の純粋な本文生成変更。revert で即時復帰可。
- data-migration: スキーマ変更なし(migration なし)。既存行・列に影響なし。
- prod-smoke: 要望送信フローは不変、Issue 本文の `登録者` 行表記のみ変化。
- observability: ログ・メトリクス・通知経路に変更なし。
- unresolved findings: 0(none)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
