### PR TITLE
docs: authoritative mirror reads の多キー巻き添え上書きにガードコメント (#3415)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -274,6 +274,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   /// 集約 pref ミラー行を採用すべきか判定する。フラグ ON 時は last-write-wins
   /// (ローカル最終変更 vs ミラー `updated_at`)、OFF 時は従来「ローカル空のときだけ」。
+  ///
+  /// ⚠️ 既知の制限 (#3415 / authoritative reads を有効化する前に per-key LWW 必須):
+  /// 戻り値はドメイン全体の単一タイムスタンプ比較に基づく bool。複数キーの Map
+  /// ドメイン (revolving_credit_configs / watchlist_entries /
+  /// debt_payment_day_overrides) では、別キーの編集でミラーの updated_at が新しく
+  /// なると、ローカルで新しく編集した別キーまで巻き添えでサーバ値に上書きされ、
+  /// 無音のデータ喪失が起こり得る。フラグ OFF (本番既定) では発火しない。有効化前に
+  /// 各衝突キーを resolveMirrorRead で個別解決する per-key LWW へ要改修。
   Future<bool> _shouldAdoptMirror({
     required String prefKey,
     required bool hasLocal,
@@ -5431,6 +5439,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         if (tombstoned.contains(entry.assetType)) {
           continue;
         }
+        // ⚠️ #3415: adoptConflicts はドメイン全体 ts 由来。authoritative reads
+        // (フラグ ON) 時のみ多キー巻き添え上書きの恐れ。per-key LWW へ要改修。
         if (!merged.containsKey(entry.assetType) || adoptConflicts) {
           merged[entry.assetType] = entry;
           changed = true;
@@ -8307,6 +8317,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         if (tombstoned.contains(key)) {
           return;
         }
+        // ⚠️ #3415: adoptConflicts はドメイン全体 ts 由来。authoritative reads
+        // (フラグ ON) 時のみ多キー巻き添え上書きの恐れ。per-key LWW へ要改修。
         if (!merged.containsKey(key) || adoptConflicts) {
           merged[key] = config;
           changed = true;
@@ -9461,6 +9473,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final merged = Map<String, int>.from(_debtPaymentDayOverrides);
       var changed = false;
       serverOverrides.forEach((key, day) {
+        // ⚠️ #3415: adoptConflicts はドメイン全体 ts 由来。authoritative reads
+        // (フラグ ON) 時のみ多キー巻き添え上書きの恐れ。per-key LWW へ要改修。
         if (!merged.containsKey(key) || adoptConflicts) {
           merged[key] = day;
           changed = true;


### PR DESCRIPTION
## 概要

authoritative mirror reads(`ASSET_MIRROR_READS_AUTHORITATIVE` / 既定OFF・dormant)の多キーマージにおける既知の制限をコードに明示するガードコメントのみの変更です(挙動変更なし)。

- `_shouldAdoptMirror` と3マージ箇所(revolving / watchlist / debt)に、ドメイン全体タイムスタンプの last-write-wins が多キーで個別編集を巻き添え上書きし得る旨と、authoritative reads 有効化前に per-key LWW が必須である旨を記載。
- 完全修正の計画は #3415 に起票済み。
- 多次元監査(Dynamic Workflow / mirror-sync 再監査)で確定した dormant な制限の明示化。フラグ OFF の本番では発火しない。

## テスト

コメントのみの変更で挙動・出力に変化なし。`flutter analyze` で構文健全性を確認(No issues)。実装詳細に依存しない最小限の確認で、新規ロジックがないため単体/E2Eテストの追加対象はありません。

integration_test / Playwright のエンドツーエンドは追加しません(挙動変更なし)。

E2E例外: コメントのみの変更で挙動・出力に変化なく、テスト対象の新規ロジックなし

---
Review owner: Claude Code #1
High-risk-ultrareview-exception: コメント追加のみで挙動変更や高リスクパス・外部通信を含まない
