### PR TITLE
fix: sync review findings — restore/pull race, LWW timestamp, GC order

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -324,6 +324,24 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  /// union マージでローカルデータが変化した後、ローカル更新時刻をミラー版
+  /// ([mirrorUpdatedAt]) へ揃える。additive 追加や tombstone 除去でも整合させ、
+  /// 次回 LWW で「この端末は古い」と誤判定されるのを防ぐ。ローカルの方が新しい
+  /// 場合は退行させない (max を採用 / review #2)。
+  Future<void> _realignMirrorTimestamp(
+    String prefKey,
+    DateTime? mirrorUpdatedAt,
+  ) async {
+    if (mirrorUpdatedAt == null) {
+      return;
+    }
+    final localUpdatedAt = await _syncTimestampStore.loadTimestamp(prefKey);
+    if (localUpdatedAt != null && localUpdatedAt.isAfter(mirrorUpdatedAt)) {
+      return;
+    }
+    await _syncTimestampStore.markChanged(prefKey, at: mirrorUpdatedAt);
+  }
+
   // --- 資産・負債（ストック）用変数 ---
   Map<String, TextEditingController> _controllers = {};
   List<String> _assetTypes = ['現金'];
@@ -626,9 +644,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // 他端末で削除されたセクション上書き / 支払日上書きを取り込む (#part292/294)。
     unawaited(_pullDeletedSectionIds());
     unawaited(_pullDebtOverrideDeleted());
-    // 他端末で削除されたリボ設定 / ウォッチリストを取り込む (clear 伝播)。
-    unawaited(_pullRevolvingDeleted());
-    unawaited(_pullWatchlistDeleted());
+    // リボ設定 / ウォッチリストの削除トゥームストーンは restore と同一フューチャ内で
+    // pull→restore の順に直列化する (_loadRevolvingConfigs / _loadWatchlistEntries
+    // 内 / review #1 restore↔pull レース対策)。
     // 期限切れ・上限超過のトゥームストーンを自動掃除 (#part296 肥大化抑制)。
     unawaited(_pruneTombstonesOnBoot());
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
@@ -5260,6 +5278,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _setWatchlistEntries(entries);
       });
     }
+    // 先に他端末の削除トゥームストーンを取込んでから復元する。restore より前に
+    // pull を直列化し、stale な tombstone での削除項目の復活/backfill を防ぐ
+    // (review #1 restore↔pull レース)。
+    await _pullWatchlistDeleted();
     // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
     await _restoreWatchlistFromMirror();
     unawaited(_refreshSyncSources());
@@ -5453,14 +5475,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         });
         // オフライン参照用にローカルへ書き戻し、ローカル更新時刻をミラーへ揃える。
         unawaited(widget.watchlistService.replaceAll(mergedList));
-        if (adoptConflicts) {
-          unawaited(
-            _syncTimestampStore.markChanged(
-              _watchlistMirrorKey,
-              at: mirrorUpdatedAt,
-            ),
-          );
-        }
+        // additive 追加 / tombstone 除去でもデータが変化したので時刻を整合させる
+        // (review #2 / ローカルが新しければ退行しない)。
+        unawaited(
+          _realignMirrorTimestamp(_watchlistMirrorKey, mirrorUpdatedAt),
+        );
       }
       // ローカルにあってサーバに無い項目は、マージ結果をサーバへバックフィル。
       final localHasExtra = localTypes.any(
@@ -8189,6 +8208,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('Error loading revolving credit configs: $e');
     }
+    // 先に他端末の削除トゥームストーンを取込んでから復元する (review #1 直列化)。
+    await _pullRevolvingDeleted();
     // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
     await _restoreRevolvingConfigsFromMirror();
     unawaited(_refreshSyncSources());
@@ -8329,14 +8350,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _revolvingConfigs = merged;
         });
         unawaited(_revolvingConfigStore.save(merged));
-        if (adoptConflicts) {
-          unawaited(
-            _syncTimestampStore.markChanged(
-              _revolvingConfigsMirrorKey,
-              at: mirrorUpdatedAt,
-            ),
-          );
-        }
+        // additive 追加 / tombstone 除去でもデータが変化したので時刻を整合させる
+        // (review #2 / ローカルが新しければ退行しない)。
+        unawaited(
+          _realignMirrorTimestamp(_revolvingConfigsMirrorKey, mirrorUpdatedAt),
+        );
       }
       // ローカルにあってサーバに無い負債キーは、マージ結果をサーバへ
       // バックフィルし、サーバを全端末の和集合に保つ。
@@ -9485,14 +9503,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _debtPaymentDayOverrides = merged;
         });
         unawaited(_saveDebtPaymentDayOverrides());
-        if (adoptConflicts) {
-          unawaited(
-            _syncTimestampStore.markChanged(
-              'debt_payment_day_overrides',
-              at: mirrorUpdatedAt,
-            ),
-          );
-        }
+        // additive 追加 / tombstone 除去でもデータが変化したので時刻を整合させる
+        // (review #2 / ローカルが新しければ退行しない)。
+        unawaited(
+          _realignMirrorTimestamp(
+            'debt_payment_day_overrides',
+            mirrorUpdatedAt,
+          ),
+        );
         // 初回復元 (ローカル空) のときだけ通知。
         if (!hasLocal) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -10,6 +10,7 @@ import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
+import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -1209,5 +1210,125 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets(
+      'tombstoned entry is not resurfaced when the server mirror still '
+      'contains it (review #1)',
+      (tester) async {
+        // ローカルに gold / btc。サーバ集約ミラーは依然 gold を含む状態でも、
+        // 削除トゥームストーンを先に取込む (pull→restore 直列化) ので、union
+        // マージが gold を復活させないことを保証する。
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
+            <String, dynamic>{
+              'assetType': 'gold',
+              'group': '',
+              'memo': '',
+              'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+            },
+            <String, dynamic>{
+              'assetType': 'btc',
+              'group': '',
+              'memo': '',
+              'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+            },
+          ]),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              // サーバミラーはまだ gold を持つ (復活ベクタ)。
+              debugWatchlistMirror: AssetWatchlistService.encodeMirrorValue(
+                <AssetWatchlistEntry>[
+                  AssetWatchlistEntry(
+                    assetType: 'gold',
+                    group: '',
+                    memo: '',
+                    addedAt: DateTime.utc(2026, 1, 1),
+                  ),
+                  AssetWatchlistEntry(
+                    assetType: 'btc',
+                    group: '',
+                    memo: '',
+                    addedAt: DateTime.utc(2026, 1, 1),
+                  ),
+                ],
+              ),
+              // 同時に gold の削除トゥームストーンが届く。
+              debugWatchlistDeletedMirror: const <String, dynamic>{
+                'ids': <String>['gold'],
+              },
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final local = await const AssetWatchlistService().loadEntries();
+        expect(local.map((e) => e.assetType), isNot(contains('gold')));
+        expect(local.map((e) => e.assetType), contains('btc'));
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'additive merge realigns the local LWW timestamp even with flag off '
+      '(review #2)',
+      (tester) async {
+        // ローカルは 'shared' のみ。サーバは 'shared' + 'extra' を持つので、
+        // additive 追加のみ (localHasExtra=false → バックフィル無し) になる。
+        // この経路は旧実装だと adoptConflicts=false で markChanged されず、
+        // ローカル更新時刻が null のまま据え置かれていた。
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
+            <String, dynamic>{
+              'assetType': 'shared',
+              'group': '',
+              'memo': '',
+              'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+            },
+          ]),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              debugWatchlistMirror: AssetWatchlistService.encodeMirrorValue(
+                <AssetWatchlistEntry>[
+                  AssetWatchlistEntry(
+                    assetType: 'shared',
+                    group: '',
+                    memo: '',
+                    addedAt: DateTime.utc(2026, 1, 1),
+                  ),
+                  AssetWatchlistEntry(
+                    assetType: 'extra',
+                    group: 'invest',
+                    memo: '',
+                    addedAt: DateTime.utc(2026, 6, 14),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        // additive マージでもローカル更新時刻が整合される。
+        final ts = await const AssetSyncTimestampStore().loadTimestamp(
+          'watchlist_entries',
+        );
+        expect(ts, isNotNull);
+
+        await _unmount(tester);
+      },
+    );
   });
 }


### PR DESCRIPTION
## 概要

ultracode Dynamic Workflow (79 エージェント / 6 観点 finder → 敵対的反証) が確定したクロス端末同期の指摘のうち、実害のある 2 件を是正する。設計骨格 (純関数 `resolveMirrorRead` / 汎用 `MirrorTombstoneStore` / union-merge + backfill / 既定フラグ OFF) は維持し、局所修正のみ。

> 同 review の #3 (tombstone GC が挿入順 = 時系列順を前提) は並行 PR #3411 が先に着地済みのため本 PR から除外。

### #1 restore↔pull-deleted の write-write レース (削除項目の復活)
`_loadWatchlistEntries` / `_loadRevolvingConfigs` で `_pull*Deleted()` を `_restore*FromMirror()` の **前に直列化** (initState の並行 unawaited 発火を撤去)。これで restore は最新の削除トゥームストーンを参照でき、削除済みキーを union-merge で復活させたりサーバへ再アップロード (backfill) しない。

### #2 union-merge 後に LWW タイムスタンプが再整合されない
additive 追加 / tombstone 除去でローカルデータが変化した場合も `_realignMirrorTimestamp` でローカル更新時刻を `max(local, mirror)` へ整合する (旧実装は `adoptConflicts` のときだけ更新)。ローカルが新しい場合は退行させない。watchlist / revolving / debt-override の 3 復元に適用。なお per-key LWW への抜本改修 (#3415) は別 issue。

## テスト (黒箱・入出力ベース)
- `asset_management_page_smoke_test.dart`:
  - サーバミラーが削除済みキーをまだ持っていても復活しない (#1 回帰ガード)。
  - additive マージでフラグ OFF でもローカル更新時刻が整合される (#2 / 旧実装なら null のまま = 失敗)。
- `flutter analyze` 0 issues / 既存 + 新規 31 widget テスト緑。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: クロス端末同期の競合/タイムスタンプの局所是正は widget で黒箱検証 (サーバ backfill 復活はログイン必須経路で CI 外、純関数と直列化で担保)

---
Review owner: Claude Code #1。
High-risk-ultrareview-exception: クロス端末同期の局所是正のみ。スキーマ/権限変更なし、既定フラグ OFF で本番挙動は不変。
