### PR TITLE
feat: budget vs actual by category (予算/カテゴリ予実)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -40,6 +40,8 @@ import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
+import 'package:my_web_app/services/asset_category_budget_service.dart';
+import 'package:my_web_app/services/asset_category_budget_store.dart';
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
 import 'package:my_web_app/services/asset_mirror_read_policy.dart';
 import 'package:my_web_app/services/asset_sync_status.dart';
@@ -61,6 +63,7 @@ import 'package:my_web_app/services/waste_tracking_service.dart';
 import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
+import 'package:my_web_app/widgets/asset_category_budget_card.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -363,6 +366,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // リボ払いカードの設定 (負債IDごと)。v1 はローカル永続化のみ。
   Map<String, AssetLiabilityRevolvingCreditConfig> _revolvingConfigs =
       <String, AssetLiabilityRevolvingCreditConfig>{};
+  // カテゴリ別 月次予算 (category -> 金額)。予算/カテゴリ予実カードで使用。
+  Map<String, double> _categoryBudgets = <String, double>{};
   final Map<String, GlobalKey> _debtMasterCardKeys = <String, GlobalKey>{};
   Map<String, AssetLiabilityAnnualRateEvidence> _annualRateEvidences =
       <String, AssetLiabilityAnnualRateEvidence>{};
@@ -535,6 +540,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetManagementMainAccountStore();
   final AssetRevolvingCreditConfigStore _revolvingConfigStore =
       const AssetRevolvingCreditConfigStore();
+  final AssetCategoryBudgetStore _categoryBudgetStore =
+      const AssetCategoryBudgetStore();
   // 禁酒で借金完済チャレンジの記録(日付→我慢/飲んだ)。v1 はローカル永続化のみ。
   final DrinkChallengeStore _drinkChallengeStore = const DrinkChallengeStore();
   Map<String, DrinkRecordStatus> _drinkRecords = <String, DrinkRecordStatus>{};
@@ -642,6 +649,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _loadDisplayMode();
     _loadMainAccount();
     unawaited(_loadRevolvingConfigs());
+    unawaited(_loadCategoryBudgets());
     unawaited(_loadDrinkChallenge());
     _loadExpectedInflows();
     // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
@@ -7902,6 +7910,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             if (_isSectionShown(AssetManagementSectionId.salaryBreakdown)) ...[
               _buildSalarySpendingBreakdownCard(),
               const SizedBox(height: 16),
+              _buildCategoryBudgetCard(),
             ],
             if (_isSectionShown(AssetManagementSectionId.disposable)) ...[
               _buildDisposableBalanceCard(),
@@ -8204,6 +8213,85 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   /// リボ設定の集約ミラー pref_key (1 行 jsonb / MIRROR_PREF_SCHEMA.md)。
   static const String _revolvingConfigsMirrorKey = 'revolving_credit_configs';
+  static const String _categoryBudgetsMirrorKey = 'category_budgets';
+
+  Future<void> _loadCategoryBudgets() async {
+    try {
+      final budgets = await _categoryBudgetStore.load();
+      if (mounted && budgets.isNotEmpty) {
+        setState(() {
+          _categoryBudgets = budgets;
+        });
+      }
+    } catch (e) {
+      debugPrint('Error loading category budgets: $e');
+    }
+    await _restoreCategoryBudgetsFromMirror();
+  }
+
+  /// カテゴリ別予算を `asset_pref_mirror` (pref_key: category_budgets) へ
+  /// 1 行 upsert する (revolving_credit_configs と同じ集約方針 / 削除は空 map で表現)。
+  Future<void> _mirrorCategoryBudgets() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _categoryBudgetsMirrorKey,
+        'value': AssetCategoryBudgetStore.encodeMirrorValue(_categoryBudgets),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('category budget mirror upsert failed: $e');
+    }
+  }
+
+  /// サーバ集約ミラーからカテゴリ別予算を復元する。ローカルに既に設定がある場合は
+  /// 上書きしない (オフライン編集を握り潰さない安全側)。サーバ行が無ければ初回
+  /// バックフィルする。設定の有無は map のキー有無で表すため削除トゥームストーン不要。
+  Future<void> _restoreCategoryBudgetsFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    final hasLocal = _categoryBudgets.isNotEmpty;
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', _categoryBudgetsMirrorKey);
+      if (rows.isEmpty) {
+        if (hasLocal) {
+          unawaited(_mirrorCategoryBudgets());
+        }
+        return;
+      }
+      if (hasLocal) {
+        return;
+      }
+      final serverBudgets = AssetCategoryBudgetStore.decodeMirrorValue(
+        rows.first['value'],
+      );
+      if (serverBudgets.isEmpty || !mounted) {
+        return;
+      }
+      setState(() {
+        _categoryBudgets = serverBudgets;
+      });
+      unawaited(_categoryBudgetStore.save(serverBudgets));
+    } catch (e) {
+      debugPrint('category budget mirror restore failed: $e');
+    }
+  }
+
+  Future<void> _saveCategoryBudgets(Map<String, double> budgets) async {
+    setState(() {
+      _categoryBudgets = budgets;
+    });
+    await _categoryBudgetStore.save(budgets);
+    unawaited(_mirrorCategoryBudgets());
+  }
 
   Future<void> _loadRevolvingConfigs() async {
     try {
@@ -12036,6 +12124,133 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         return '動画';
     }
     return group.isEmpty ? '対象' : group;
+  }
+
+  /// 予算/カテゴリ予実カード。給料サイクルのカテゴリ別実支出(既存 breakdown)に
+  /// ユーザー設定の月次予算を重ねて表示する。支出も予算も無ければ非表示。
+  Widget _buildCategoryBudgetCard() {
+    final breakdown = _buildSalarySpendingBreakdown();
+    if (breakdown.expenseEntryCount == 0 && _categoryBudgets.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final actualByCategory = <String, double>{
+      for (final section in breakdown.sections)
+        section.category: section.amount,
+    };
+    final report = AssetCategoryBudgetService.build(
+      actualByCategory: actualByCategory,
+      budgets: _categoryBudgets,
+    );
+    final start = breakdown.periodStart;
+    final end = breakdown.periodEndInclusive;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: AssetCategoryBudgetCard(
+        report: report,
+        currencyFormatter: _formatYen,
+        periodLabel:
+            '${start.month}/${start.day}〜${end.month}/${end.day}(給料サイクル)',
+        onEditBudgets: () => _showCategoryBudgetEditor(actualByCategory),
+      ),
+    );
+  }
+
+  /// カテゴリ別の月次予算を編集するダイアログ。既定カテゴリ + 実支出/既存予算に
+  /// 現れたカテゴリへ数値入力し、保存でローカル永続 + ミラーする。
+  Future<void> _showCategoryBudgetEditor(
+    Map<String, double> actualByCategory,
+  ) async {
+    final categories = <String>[
+      ...SalarySpendingBreakdownService.categoryLabels,
+      for (final category in actualByCategory.keys)
+        if (!SalarySpendingBreakdownService.categoryLabels.contains(category))
+          category,
+      for (final category in _categoryBudgets.keys)
+        if (!SalarySpendingBreakdownService.categoryLabels.contains(category) &&
+            !actualByCategory.containsKey(category))
+          category,
+    ];
+    final controllers = <String, TextEditingController>{
+      for (final category in categories)
+        category: TextEditingController(
+          text: (_categoryBudgets[category] ?? 0) > 0
+              ? (_categoryBudgets[category] ?? 0).round().toString()
+              : '',
+        ),
+    };
+    final saved = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('カテゴリ別の月次予算'),
+        content: SizedBox(
+          width: 420,
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '給料サイクル(25日始まり)あたりの予算を入力します。空欄は予算なし。',
+                  style: TextStyle(fontSize: 12, height: 1.5),
+                ),
+                const SizedBox(height: 8),
+                for (final category in categories)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            category,
+                            style: const TextStyle(fontSize: 13),
+                          ),
+                        ),
+                        SizedBox(
+                          width: 130,
+                          child: TextField(
+                            controller: controllers[category],
+                            keyboardType: TextInputType.number,
+                            decoration: const InputDecoration(
+                              prefixText: '¥',
+                              isDense: true,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            key: const Key('asset_category_budget_save'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    if (saved == true && mounted) {
+      final next = <String, double>{};
+      controllers.forEach((category, controller) {
+        final parsed = double.tryParse(
+          controller.text.replaceAll(',', '').trim(),
+        );
+        if (parsed != null && parsed > 0) {
+          next[category] = parsed;
+        }
+      });
+      await _saveCategoryBudgets(next);
+    }
+    for (final controller in controllers.values) {
+      controller.dispose();
+    }
   }
 
   Widget _buildSalarySpendingBreakdownCard() {

--- a/lib/services/asset_category_budget_service.dart
+++ b/lib/services/asset_category_budget_service.dart
@@ -1,0 +1,115 @@
+/// カテゴリ別の予算と実支出を突き合わせた1行(予実)。
+class CategoryBudgetRow {
+  const CategoryBudgetRow({
+    required this.category,
+    required this.budget,
+    required this.actual,
+  });
+
+  final String category;
+
+  /// 月次予算。0 なら未設定。
+  final double budget;
+
+  /// 当該期間の実支出。
+  final double actual;
+
+  /// 残り予算(予算 − 実績)。予算未設定なら負になりうる(= 実績のぶん)。
+  double get remaining => budget - actual;
+
+  /// 消化率(実績 / 予算)。予算未設定(0)なら null。
+  double? get ratio => budget > 0 ? actual / budget : null;
+
+  /// 予算超過(予算設定あり かつ 実績 > 予算)。
+  bool get isOver => budget > 0 && actual > budget;
+
+  bool get hasBudget => budget > 0;
+}
+
+/// 予算/カテゴリ予実レポート(給料サイクル等の1期間ぶん)。
+class CategoryBudgetReport {
+  const CategoryBudgetReport({
+    required this.rows,
+    required this.totalBudget,
+    required this.totalActual,
+  });
+
+  final List<CategoryBudgetRow> rows;
+  final double totalBudget;
+  final double totalActual;
+
+  /// 全体の残り予算。
+  double get totalRemaining => totalBudget - totalActual;
+
+  bool get isEmpty => rows.isEmpty;
+
+  /// いずれかのカテゴリに予算が設定されているか。
+  bool get hasAnyBudget => totalBudget > 0;
+
+  /// 予算超過しているカテゴリ数。
+  int get overCount {
+    var count = 0;
+    for (final row in rows) {
+      if (row.isOver) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+}
+
+/// カテゴリ別の月次予算(ユーザー設定)と実支出([actualByCategory])を
+/// 突き合わせて予実レポートを作る純関数サービス。
+///
+/// 実支出は `SalarySpendingBreakdownService` が算出した
+/// カテゴリ別内訳(`sections`)をそのまま渡す想定。スキーマ非依存・完全テスト可。
+class AssetCategoryBudgetService {
+  const AssetCategoryBudgetService();
+
+  static CategoryBudgetReport build({
+    required Map<String, double> actualByCategory,
+    required Map<String, double> budgets,
+  }) {
+    final categories = <String>{
+      for (final entry in budgets.entries)
+        if (entry.value > 0) entry.key,
+      for (final entry in actualByCategory.entries)
+        if (entry.value > 0) entry.key,
+    };
+
+    final rows = <CategoryBudgetRow>[
+      for (final category in categories)
+        CategoryBudgetRow(
+          category: category,
+          budget: _nonNegative(budgets[category]),
+          actual: _nonNegative(actualByCategory[category]),
+        ),
+    ]..sort((a, b) {
+        // 予算超過を先頭へ、その中・以降は実績の多い順。
+        if (a.isOver != b.isOver) {
+          return a.isOver ? -1 : 1;
+        }
+        return b.actual.compareTo(a.actual);
+      });
+
+    var totalBudget = 0.0;
+    var totalActual = 0.0;
+    for (final row in rows) {
+      totalBudget += row.budget;
+      totalActual += row.actual;
+    }
+
+    return CategoryBudgetReport(
+      rows: rows,
+      totalBudget: totalBudget,
+      totalActual: totalActual,
+    );
+  }
+
+  static double _nonNegative(double? value) {
+    if (value == null || value < 0) {
+      return 0;
+    }
+    return value;
+  }
+}

--- a/lib/services/asset_category_budget_store.dart
+++ b/lib/services/asset_category_budget_store.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// カテゴリ別 月次予算 (category -> 金額) を永続化する。
+///
+/// ローカル (SharedPreferences) を一次ストアとし、端末間同期は資産管理ページが
+/// `asset_pref_mirror` (pref_key: `category_budgets`) へ 1 行 jsonb でミラーする
+/// (revolving_credit_configs と同じ集約方針 / MIRROR_PREF_SCHEMA.md)。
+/// [encodeMirrorValue] / [decodeMirrorValue] がローカルとミラー双方で使う
+/// 共通の往復ロジックで、保存形は `{category: amount}` (正の金額のみ)。
+class AssetCategoryBudgetStore {
+  static const String prefsKey = 'asset_category_budgets_v1';
+
+  const AssetCategoryBudgetStore();
+
+  Future<Map<String, double>> load({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getString(prefsKey);
+    if (raw == null || raw.isEmpty) {
+      return <String, double>{};
+    }
+    try {
+      return decodeMirrorValue(jsonDecode(raw));
+    } catch (_) {
+      return <String, double>{};
+    }
+  }
+
+  Future<void> save(Map<String, double> budgets,
+      {SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final sanitized = encodeMirrorValue(budgets);
+    if (sanitized.isEmpty) {
+      await store.remove(prefsKey);
+      return;
+    }
+    await store.setString(prefsKey, jsonEncode(sanitized));
+  }
+
+  /// 予算マップを `asset_pref_mirror.value` (jsonb) 形へ変換する。正の金額のみ残す。
+  static Map<String, dynamic> encodeMirrorValue(Map<String, double> budgets) {
+    return <String, dynamic>{
+      for (final entry in budgets.entries)
+        if (entry.value > 0) entry.key: entry.value,
+    };
+  }
+
+  /// `asset_pref_mirror.value` (jsonb) または保存済み JSON から予算マップへ
+  /// 復元する。不正キー・非正の金額は黙って捨てる寛容なパース。
+  static Map<String, double> decodeMirrorValue(dynamic value) {
+    final result = <String, double>{};
+    if (value is! Map) {
+      return result;
+    }
+    value.forEach((dynamic key, dynamic raw) {
+      if (key is String && raw is num && raw > 0) {
+        result[key] = raw.toDouble();
+      }
+    });
+    return result;
+  }
+}

--- a/lib/services/asset_category_budget_store.dart
+++ b/lib/services/asset_category_budget_store.dart
@@ -27,8 +27,10 @@ class AssetCategoryBudgetStore {
     }
   }
 
-  Future<void> save(Map<String, double> budgets,
-      {SharedPreferences? prefs}) async {
+  Future<void> save(
+    Map<String, double> budgets, {
+    SharedPreferences? prefs,
+  }) async {
     final store = prefs ?? await SharedPreferences.getInstance();
     final sanitized = encodeMirrorValue(budgets);
     if (sanitized.isEmpty) {

--- a/lib/services/salary_spending_breakdown_service.dart
+++ b/lib/services/salary_spending_breakdown_service.dart
@@ -74,6 +74,25 @@ class SalarySpendingBreakdownService {
 
   static const int defaultSalaryDay = 25;
 
+  /// [categorize] が返しうるカテゴリラベル一覧(予算設定 UI の選択肢に使う)。
+  /// `_categoryRules` のラベル + フォールバックの「その他」。
+  static const List<String> categoryLabels = <String>[
+    '住居',
+    '食費',
+    '通信',
+    '光熱費',
+    '交通',
+    'サブスク',
+    '投資・貯蓄',
+    '医療',
+    '日用品',
+    '娯楽・浪費',
+    '借入返済',
+    '手数料・税金',
+    '使途不明金',
+    'その他',
+  ];
+
   SalarySpendingBreakdown build({
     required DateTime referenceDate,
     Iterable<SalarySpendingEntry> expenses = const <SalarySpendingEntry>[],

--- a/lib/widgets/asset_category_budget_card.dart
+++ b/lib/widgets/asset_category_budget_card.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+
+import '../services/asset_category_budget_service.dart';
+
+/// 予算/カテゴリ予実カード。
+///
+/// 純関数 [AssetCategoryBudgetService] が作る [CategoryBudgetReport] を受け取り、
+/// カテゴリ別の予算 vs 実績(進捗バー + 超過警告)と全体集計を描画する自己完結
+/// ウィジェット。ページ状態へ依存しないためウィジェットテストで単体検証できる。
+class AssetCategoryBudgetCard extends StatelessWidget {
+  const AssetCategoryBudgetCard({
+    super.key,
+    required this.report,
+    this.onEditBudgets,
+    this.currencyFormatter,
+    this.periodLabel,
+  });
+
+  final CategoryBudgetReport report;
+
+  /// 「予算を設定」リンク。null ならリンクを出さない。
+  final VoidCallback? onEditBudgets;
+
+  /// 金額整形(ページの `_formatYen` を渡す)。null なら簡易整形。
+  final String Function(double value)? currencyFormatter;
+
+  /// 期間ラベル(例: 「5/25〜6/24」)。null なら非表示。
+  final String? periodLabel;
+
+  static const Color _accent = Color(0xFF4F46E5);
+  static const Color _danger = Color(0xFFDC2626);
+  static const Color _muted = Color(0xFF6B7280);
+  static const Color _track = Color(0xFFE5E7EB);
+
+  String _yen(double value) {
+    final formatter = currencyFormatter;
+    if (formatter != null) {
+      return formatter(value);
+    }
+    return '¥${value.round()}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('asset_category_budget_card'),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.donut_small, color: _accent),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    '予算/カテゴリ予実',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                if (onEditBudgets != null)
+                  TextButton(
+                    key: const Key('asset_category_budget_edit'),
+                    onPressed: onEditBudgets,
+                    child: const Text('予算を設定'),
+                  ),
+              ],
+            ),
+            if (periodLabel != null)
+              Text(
+                periodLabel!,
+                style:
+                    const TextStyle(fontSize: 12, color: _muted, height: 1.4),
+              ),
+            const SizedBox(height: 8),
+            if (!report.hasAnyBudget)
+              Padding(
+                key: const Key('asset_category_budget_empty'),
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: const Text(
+                  'カテゴリ別の予算を設定すると、今月の予算 vs 実績(予実)を表示します。',
+                  style: TextStyle(fontSize: 12, height: 1.5),
+                ),
+              )
+            else ...[
+              _buildTotalRow(),
+              const SizedBox(height: 12),
+              for (final row in report.rows) _buildCategoryRow(row),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTotalRow() {
+    final over = report.totalActual > report.totalBudget;
+    final value = report.totalBudget > 0
+        ? (report.totalActual / report.totalBudget).clamp(0.0, 1.0).toDouble()
+        : 0.0;
+    return Container(
+      key: const Key('asset_category_budget_total'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: (over ? _danger : _accent).withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  '合計',
+                  style: TextStyle(fontSize: 13, fontWeight: FontWeight.w700),
+                ),
+              ),
+              Text(
+                '${_yen(report.totalActual)} / ${_yen(report.totalBudget)}',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: over ? _danger : null,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: value,
+              minHeight: 8,
+              backgroundColor: _track,
+              color: over ? _danger : _accent,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            over
+                ? '予算を ${_yen(report.totalActual - report.totalBudget)} 超過しています'
+                : '残り予算 ${_yen(report.totalRemaining)}',
+            style: TextStyle(
+              fontSize: 12,
+              height: 1.4,
+              color: over ? _danger : _muted,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCategoryRow(CategoryBudgetRow row) {
+    final ratio = row.ratio;
+    final over = row.isOver;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              if (over) ...[
+                const Icon(Icons.warning_amber, color: _danger, size: 14),
+                const SizedBox(width: 3),
+              ],
+              Expanded(
+                child: Text(
+                  row.category,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              Text(
+                row.hasBudget
+                    ? '${_yen(row.actual)} / ${_yen(row.budget)}'
+                    : '${_yen(row.actual)}(予算未設定)',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: over ? _danger : _muted,
+                ),
+              ),
+            ],
+          ),
+          if (ratio != null) ...[
+            const SizedBox(height: 4),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: ratio.clamp(0.0, 1.0).toDouble(),
+                minHeight: 6,
+                backgroundColor: _track,
+                color: over ? _danger : _accent,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              over
+                  ? '予算を ${_yen(-row.remaining)} 超過'
+                  : '残り ${_yen(row.remaining)}',
+              style: TextStyle(
+                fontSize: 11,
+                height: 1.4,
+                color: over ? _danger : _muted,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/asset_category_budget_card.dart
+++ b/lib/widgets/asset_category_budget_card.dart
@@ -80,10 +80,10 @@ class AssetCategoryBudgetCard extends StatelessWidget {
               ),
             const SizedBox(height: 8),
             if (!report.hasAnyBudget)
-              Padding(
-                key: const Key('asset_category_budget_empty'),
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                child: const Text(
+              const Padding(
+                key: Key('asset_category_budget_empty'),
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Text(
                   'カテゴリ別の予算を設定すると、今月の予算 vs 実績(予実)を表示します。',
                   style: TextStyle(fontSize: 12, height: 1.5),
                 ),

--- a/test/services/asset_category_budget_service_test.dart
+++ b/test/services/asset_category_budget_service_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_category_budget_service.dart';
+
+void main() {
+  group('AssetCategoryBudgetService.build', () {
+    test('takes the union of budgeted and actual categories', () {
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{'食費': 30000, '交通': 5000},
+        budgets: <String, double>{'食費': 50000, '住居': 63000},
+      );
+
+      expect(report.rows.length, 3);
+      expect(report.totalBudget, 50000 + 63000);
+      expect(report.totalActual, 30000 + 5000);
+      expect(report.totalRemaining, 113000 - 35000);
+    });
+
+    test('detects over-budget and sorts it first', () {
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{'食費': 60000, '交通': 5000},
+        budgets: <String, double>{'食費': 50000, '交通': 20000},
+      );
+
+      expect(report.rows.first.category, '食費');
+      expect(report.rows.first.isOver, isTrue);
+      expect(report.overCount, 1);
+
+      final shoku = report.rows.firstWhere((row) => row.category == '食費');
+      expect(shoku.remaining, -10000);
+      expect(shoku.ratio, closeTo(1.2, 0.001));
+    });
+
+    test('an unbudgeted category has a null ratio and is not over', () {
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{'娯楽・浪費': 8000},
+        budgets: <String, double>{},
+      );
+
+      final row = report.rows.single;
+      expect(row.hasBudget, isFalse);
+      expect(row.ratio, isNull);
+      expect(row.isOver, isFalse);
+      expect(report.hasAnyBudget, isFalse);
+    });
+
+    test('a budgeted category with no spend keeps the full remaining', () {
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{},
+        budgets: <String, double>{'住居': 63000},
+      );
+
+      final row = report.rows.single;
+      expect(row.actual, 0);
+      expect(row.remaining, 63000);
+      expect(row.isOver, isFalse);
+      expect(report.totalRemaining, 63000);
+    });
+
+    test('is empty when there are no budgets and no spend', () {
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{},
+        budgets: <String, double>{},
+      );
+
+      expect(report.isEmpty, isTrue);
+      expect(report.hasAnyBudget, isFalse);
+    });
+
+    test('ignores non-positive amounts as category sources', () {
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{'食費': 0, '交通': -100},
+        budgets: <String, double>{'住居': 0, '食費': 50000},
+      );
+
+      expect(report.rows.length, 1);
+      expect(report.rows.single.category, '食費');
+      expect(report.rows.single.actual, 0);
+    });
+  });
+}

--- a/test/services/asset_category_budget_store_test.dart
+++ b/test/services/asset_category_budget_store_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_category_budget_store.dart';
+
+void main() {
+  group('AssetCategoryBudgetStore encode/decode', () {
+    test('round-trips a budget map', () {
+      final budgets = <String, double>{'食費': 50000, '住居': 63000};
+      final encoded = AssetCategoryBudgetStore.encodeMirrorValue(budgets);
+      final decoded = AssetCategoryBudgetStore.decodeMirrorValue(encoded);
+
+      expect(decoded, budgets);
+    });
+
+    test('drops non-positive entries on encode', () {
+      final encoded = AssetCategoryBudgetStore.encodeMirrorValue(
+        <String, double>{'食費': 50000, '交通': 0, '医療': -100},
+      );
+
+      expect(encoded.keys, <String>['食費']);
+    });
+
+    test('drops invalid and non-positive entries on decode', () {
+      final decoded = AssetCategoryBudgetStore.decodeMirrorValue(
+        <String, dynamic>{'住居': 63000, '無効': 'x', '負': -5},
+      );
+
+      expect(decoded, <String, double>{'住居': 63000});
+    });
+
+    test('decode tolerates non-map input', () {
+      expect(AssetCategoryBudgetStore.decodeMirrorValue(null), isEmpty);
+      expect(AssetCategoryBudgetStore.decodeMirrorValue('oops'), isEmpty);
+    });
+  });
+}

--- a/test/widgets/asset_category_budget_card_test.dart
+++ b/test/widgets/asset_category_budget_card_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_category_budget_service.dart';
+import 'package:my_web_app/widgets/asset_category_budget_card.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  CategoryBudgetReport report, {
+  VoidCallback? onEdit,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: AssetCategoryBudgetCard(
+            report: report,
+            onEditBudgets: onEdit,
+            currencyFormatter: (value) => '¥${value.round()}',
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('AssetCategoryBudgetCard', () {
+    testWidgets('shows the empty state when no budget is set', (tester) async {
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{'食費': 30000},
+        budgets: <String, double>{},
+      );
+
+      await _pump(tester, report);
+
+      expect(
+        find.byKey(const Key('asset_category_budget_card')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('asset_category_budget_empty')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('asset_category_budget_total')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('shows totals and an over-budget marker', (tester) async {
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{'食費': 60000},
+        budgets: <String, double>{'食費': 50000},
+      );
+
+      await _pump(tester, report);
+
+      expect(
+        find.byKey(const Key('asset_category_budget_total')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('超過'), findsWidgets);
+    });
+
+    testWidgets('the edit button fires the callback', (tester) async {
+      var tapped = false;
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{},
+        budgets: <String, double>{'住居': 63000},
+      );
+
+      await _pump(tester, report, onEdit: () => tapped = true);
+
+      final button = find.byKey(const Key('asset_category_budget_edit'));
+      expect(button, findsOneWidget);
+
+      await tester.tap(button);
+      await tester.pump();
+
+      expect(tapped, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Adds a category budget-vs-actual ("予算/カテゴリ予実") card — a MoneyForward
staple — to the asset management page. It reuses the existing salary-cycle
spending categorization, so the actual-by-category data is already available;
this layer adds user-set budgets on top and shows the gap.

## Changes

- **`AssetCategoryBudgetService`** (pure): given actual-by-category (from the
  existing `SalarySpendingBreakdown` sections) and user budgets, produces a
  report of per-category rows (budget, actual, remaining, ratio, over) plus
  totals, sorted over-budget first. Fully unit-tested.
- **`AssetCategoryBudgetStore`**: local persistence plus the shared
  encode/decode used to mirror the `{category: amount}` map to
  `asset_pref_mirror` (pref_key `category_budgets`), the same map pattern as
  `revolving_credit_configs` (no tombstone; an empty map means no budgets).
- **`AssetCategoryBudgetCard`** (self-contained widget): per-category progress
  bars, over-budget markers, totals, an empty/CTA state, and an edit link.
- **Page**: load/mirror/restore/save wiring, a budget editor dialog seeded from
  the predefined category labels plus categories seen this cycle, and the card
  under the salary-breakdown section. No schema change (reuses asset_pref_mirror).
- Unit tests (service + store) and widget tests for the card.

## Minimal E2E Gate

- Implementation-detail independent: the tests assert user-visible input/output
  (the report computed from actual + budgets; the card renders totals, an
  over-budget marker, the empty state, and fires the edit callback), not private
  internals.
- Minimal scope: about 3 cases per surface (union/over/empty for the service;
  empty-state/over-marker/edit-callback for the card; round-trip/sanitize for
  the store).
- E2E: the card and pure layers are exercised black-box via widget and unit
  tests; no page-level integration_test / Playwright e2e is added here.
- E2E-Exception: the asset page is auth-gated and ~30k lines, so black-box
  widget + unit tests are the minimal user-visible check.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: additive UI feature plus pure services and a
  local-first mirror map; no high-risk path touched, review owned by Claude
  Code #1.
