### PR TITLE
fix: 表示設定 restore で削除済みセクション上書きを除外 (削除伝播)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -8799,17 +8799,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Future<void> _restoreDisplayPrefsFromMirror() async {
-    if (_supabase.auth.currentUser == null) {
+    final debugRows = widget.debugMirrorPrefsRows;
+    if (_supabase.auth.currentUser == null && debugRows == null) {
       return;
     }
     if (await _displayModeStore.isRestoreDeclined()) {
       return;
     }
     try {
-      final rows = await _fetchDisplayPrefRows();
+      final rows = debugRows ?? await _fetchDisplayPrefRows();
       if (rows.isEmpty || !mounted) {
         return;
       }
+      // 他端末で削除されたセクション上書きは復元候補から除外する (削除伝播)。
+      // 通知フロー (evaluateMirrorPrefRows) と同じく storageId 文字列で照合する。
+      final deletedSectionIds = await _displayModeStore.loadDeletedSectionIds();
 
       AssetManagementDisplayMode? pendingMode;
       final pendingOverrides = <AssetManagementSectionId,
@@ -8829,6 +8833,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         }
         if (row['pref_key'] == 'section_overrides') {
           for (final entry in value.entries) {
+            // 削除トゥームストーン済みのセクションは再提案しない (復活防止)。
+            if (deletedSectionIds.contains(entry.key.toString())) {
+              continue;
+            }
             AssetManagementSectionId? section;
             for (final candidate in AssetManagementSectionId.values) {
               if (candidate.storageId == entry.key.toString()) {

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -854,6 +854,43 @@ void main() {
       await _unmount(tester);
     });
 
+    testWidgets(
+      'display-prefs restore does not re-propose a deleted section override',
+      (tester) async {
+        // ローカルは表示設定なし (= restore 経路: !hadStored && overrides.isEmpty)
+        // だが、'chart' セクション上書きを過去に削除した削除トゥームストーンを持つ。
+        // サーバには 'chart' の上書きがまだ残っている状態を注入する。
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'asset_management_section_override_deleted_v1': jsonEncode(
+            <String>['chart'],
+          ),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: AssetManagementPage(
+              debugMirrorPrefsRows: <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'pref_key': 'section_overrides',
+                  'value': <String, dynamic>{'chart': 'hidden'},
+                },
+              ],
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        // 削除済みの上書きしか無いので、復元提案ダイアログは出ない
+        // (修正前はトゥームストーンを参照せず復活提案していた)。
+        expect(find.text('表示設定のバックアップ'), findsNothing);
+
+        await _unmount(tester);
+      },
+    );
+
     testWidgets('sync status banner shows logged-out state', (tester) async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
       await tester.binding.setSurfaceSize(const Size(1200, 2400));


### PR DESCRIPTION
## 概要

ultracode Dynamic Workflow レビューの確定 HIGH 指摘（削除伝播の最後の抜け穴）を是正。`_restoreDisplayPrefsFromMirror` だけ削除トゥームストーンを参照しておらず、他端末で削除したセクション上書きをサーバ残存分から**再提案**し得た（確認ダイアログ越しなので silent ではないが、リボ/ウォッチリスト/支払日と異なり非対称）。

### 修正
- `_restoreDisplayPrefsFromMirror` で `loadDeletedSectionIds()` を読み、`section_overrides` の復元候補から**削除済み section を除外**（通知フロー `evaluateMirrorPrefRows` と同じく storageId 文字列で照合）。
- テスト可能化のため、復元経路を既存の `debugMirrorPrefsRows` 注入フックに対応（通知フローと同一フック / 挙動は本番据え置き）。

### テスト (黒箱・入出力ベース)
- `asset_management_page_smoke_test.dart`: 削除トゥームストーン済みセクションの上書きしかサーバに無いとき、復元提案ダイアログが出ない（修正前はトゥームストーン非参照で復活提案 → ダイアログが出て失敗）。
- `flutter analyze` 0 issues / 32 widget テスト緑。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 表示設定の削除伝播の局所是正は widget で黒箱検証 (復元提案ダイアログの有無で判定、ログイン必須経路は CI 外で純関数照合と同型)

---
Review owner: Claude Code #1。
High-risk-ultrareview-exception: 表示設定 restore の局所是正のみ。スキーマ/権限変更なし、挙動は削除済み上書きの除外のみで本番影響は限定。
