### PR TITLE
fix: harden sync restore — backfill auth-switch guard + non-silent save failures

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -315,7 +315,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     String prefKey,
     Future<void> Function() uploadLocal,
   ) async {
-    if (_supabase.auth.currentUser == null) {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
       return;
     }
     try {
@@ -324,6 +325,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           .select('pref_key')
           .eq('pref_key', prefKey)
           .limit(1);
+      // select の間にログアウト/別アカウントへ切替わっていないか再確認する。
+      // 前アカウントのローカル値を新しい user_id で誤アップロードしない (review medium)。
+      if (_supabase.auth.currentUser?.id != userId) {
+        return;
+      }
       if (rows.isEmpty) {
         await uploadLocal();
       }
@@ -343,11 +349,29 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (mirrorUpdatedAt == null) {
       return;
     }
-    final localUpdatedAt = await _syncTimestampStore.loadTimestamp(prefKey);
-    if (localUpdatedAt != null && localUpdatedAt.isAfter(mirrorUpdatedAt)) {
-      return;
+    try {
+      final localUpdatedAt = await _syncTimestampStore.loadTimestamp(prefKey);
+      if (localUpdatedAt != null && localUpdatedAt.isAfter(mirrorUpdatedAt)) {
+        return;
+      }
+      await _syncTimestampStore.markChanged(prefKey, at: mirrorUpdatedAt);
+    } catch (e) {
+      // 時刻整合の失敗は致命的でないが、無音にせずログする (review medium)。
+      debugPrint('mirror timestamp realign failed ($prefKey): $e');
     }
-    await _syncTimestampStore.markChanged(prefKey, at: mirrorUpdatedAt);
+  }
+
+  /// unawaited な保存 future の失敗を握り潰さずログする。setState 後の
+  /// SharedPreferences 永続化が落ちても無音にならないようにする (review medium)。
+  /// 戻り値型に依存しないよう then(onError:) で受ける (catchError だと非 void
+  /// future を null で完了させ TypeError になるため)。
+  void _persistInBackground<T>(Future<T> future, String label) {
+    unawaited(
+      future.then<void>(
+        (_) {},
+        onError: (Object e) => debugPrint('$label failed: $e'),
+      ),
+    );
   }
 
   // --- 資産・負債（ストック）用変数 ---
@@ -5399,7 +5423,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       setState(() {
         _setWatchlistEntries(mergedList);
       });
-      unawaited(widget.watchlistService.replaceAll(mergedList));
+      _persistInBackground(
+        widget.watchlistService.replaceAll(mergedList),
+        'watchlist pull save',
+      );
     } catch (e) {
       debugPrint('watchlist tombstone pull failed: $e');
     }
@@ -5487,7 +5514,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           _setWatchlistEntries(mergedList);
         });
         // オフライン参照用にローカルへ書き戻し、ローカル更新時刻をミラーへ揃える。
-        unawaited(widget.watchlistService.replaceAll(mergedList));
+        _persistInBackground(
+          widget.watchlistService.replaceAll(mergedList),
+          'watchlist restore save',
+        );
         // additive 追加 / tombstone 除去でもデータが変化したので時刻を整合させる
         // (review #2 / ローカルが新しければ退行しない)。
         unawaited(
@@ -8069,12 +8099,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _assetManagementMainAccountId = restored;
       });
       // オフライン参照用にローカルへ書き戻し、ローカル更新時刻をミラーへ揃える。
-      unawaited(_mainAccountStore.save(restored));
-      unawaited(
+      _persistInBackground(
+        _mainAccountStore.save(restored),
+        'main account restore save',
+      );
+      _persistInBackground(
         _syncTimestampStore.markChanged(
           _mainAccountMirrorKey,
           at: mirrorUpdatedAt,
         ),
+        'main account timestamp',
       );
     } catch (e) {
       debugPrint('main account mirror restore failed: $e');
@@ -8445,7 +8479,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         setState(() {
           _revolvingConfigs = merged;
         });
-        unawaited(_revolvingConfigStore.save(merged));
+        _persistInBackground(
+          _revolvingConfigStore.save(merged),
+          'revolving restore save',
+        );
         // additive 追加 / tombstone 除去でもデータが変化したので時刻を整合させる
         // (review #2 / ローカルが新しければ退行しない)。
         unawaited(
@@ -9606,7 +9643,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         setState(() {
           _debtPaymentDayOverrides = merged;
         });
-        unawaited(_saveDebtPaymentDayOverrides());
+        _persistInBackground(
+          _saveDebtPaymentDayOverrides(),
+          'debt override restore save',
+        );
         // additive 追加 / tombstone 除去でもデータが変化したので時刻を整合させる
         // (review #2 / ローカルが新しければ退行しない)。
         unawaited(

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -35,6 +35,30 @@ class _FakeDebtOverrideRepository
   }
 }
 
+/// ローカル保存 (replaceAll) が必ず失敗するウォッチリストサービス。
+/// 復元時の保存失敗が無音にならず (catchError でログ)、かつページを
+/// クラッシュさせないことを検証する (review medium / silent save)。
+class _ThrowingWatchlistService extends AssetWatchlistService {
+  _ThrowingWatchlistService(this._seed);
+
+  final List<AssetWatchlistEntry> _seed;
+
+  @override
+  Future<List<AssetWatchlistEntry>> loadEntries({
+    SharedPreferences? prefs,
+  }) async {
+    return List<AssetWatchlistEntry>.from(_seed);
+  }
+
+  @override
+  Future<List<AssetWatchlistEntry>> replaceAll(
+    List<AssetWatchlistEntry> entries, {
+    SharedPreferences? prefs,
+  }) async {
+    throw Exception('simulated disk failure');
+  }
+}
+
 /// 資産管理ページの widget スモーク足場 (#3260)。
 /// 未ログイン (auth.currentUser == null) では Supabase フェッチ群が
 /// 早期 return する性質を利用し、ネットワークなしで UI 契約だけを検証する。
@@ -1363,6 +1387,57 @@ void main() {
           'watchlist_entries',
         );
         expect(ts, isNotNull);
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'restore tolerates a failing local save without crashing (review medium)',
+      (tester) async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        // ローカルは 'gold' のみ。サーバは 'gold' + 'extra' なので additive
+        // マージ → replaceAll 保存が走るが、その保存を必ず失敗させる。
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              watchlistService: _ThrowingWatchlistService(
+                <AssetWatchlistEntry>[
+                  AssetWatchlistEntry(
+                    assetType: 'gold',
+                    group: '',
+                    memo: '',
+                    addedAt: DateTime.utc(2026, 1, 1),
+                  ),
+                ],
+              ),
+              debugWatchlistMirror: AssetWatchlistService.encodeMirrorValue(
+                <AssetWatchlistEntry>[
+                  AssetWatchlistEntry(
+                    assetType: 'gold',
+                    group: '',
+                    memo: '',
+                    addedAt: DateTime.utc(2026, 1, 1),
+                  ),
+                  AssetWatchlistEntry(
+                    assetType: 'extra',
+                    group: 'invest',
+                    memo: '',
+                    addedAt: DateTime.utc(2026, 6, 14),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        // 保存 future の失敗は catchError でログのみ → 未捕捉例外でクラッシュしない。
+        expect(tester.takeException(), isNull);
 
         await _unmount(tester);
       },


### PR DESCRIPTION
## 概要

ultracode Dynamic Workflow レビューの medium 指摘（同期復元の堅牢化）をまとめて是正。挙動は本番据え置き（フラグ OFF / 既存経路）で、防御的ガードとログ追加のみ。

### A. backfill が auth 切替を跨いで前アカウントのローカルを誤アップロード
`_backfillPrefIfServerMissing` で開始時に `user_id` を捕捉し、`select` 後・`uploadLocal()` 前に `currentUser?.id` が変わっていないか再確認。ログアウト→別アカウントログインの最中に in-flight な backfill が前アカウントの値を新 `user_id` で上げるのを防ぐ。

### B. unawaited な保存失敗が silent
復元経路の `unawaited(save)` を `_persistInBackground` 経由にし、SharedPreferences I/O 失敗を握り潰さずログする（watchlist / main account / revolving / debt の各 restore save + watchlist pull save + main account timestamp）。`_realignMirrorTimestamp` も try/catch でガード。
- 🔴 ヘルパは `then(onError:)` で受ける。`catchError` だと非 void future（`replaceAll` は `Future<List>` を返す）を null で完了させ **TypeError** になる（テストが検出 → 修正）。

### テスト (黒箱・入出力ベース)
- `asset_management_page_smoke_test.dart`: 復元時の `replaceAll` 保存を必ず失敗させても、未捕捉例外でクラッシュしない（`tester.takeException()` が null）。
- `flutter analyze` 0 issues / 33 widget テスト緑。

> auth 切替ガード (A) はログイン必須経路のため widget では再現不可（純関数的な再確認で担保）。catchError (B) は throwing fake で黒箱検証。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 同期復元の防御的ハードニング (auth 再確認 + save 失敗ログ) は widget で save 失敗時の非クラッシュを黒箱検証、ログイン必須経路は CI 外で再確認ロジックで担保

---
Review owner: Claude Code #1。
High-risk-ultrareview-exception: 同期復元の局所ハードニングのみ。スキーマ/権限変更なし、挙動は本番据え置きでガード/ログ追加に限定。
