### PR TITLE
fix(share): Xでシェアが真っ白になる問題を修正 (x.com→twitter.com intent)

### DIFF
--- a/lib/services/grow_together_share.dart
+++ b/lib/services/grow_together_share.dart
@@ -33,10 +33,15 @@ class GrowTogetherShare {
 
   /// X の投稿 intent URL を生成する純関数。
   ///
+  /// host は `twitter.com` を使う（ログイン済みなら x.com の作成画面へ
+  /// リダイレクトされる）。`x.com/intent/tweet` を直接開くと作成画面が
+  /// 描画されず真っ白になる事象が報告されているため、従来から安定して
+  /// 動作する `twitter.com/intent/tweet` を採用する。
+  ///
   /// `text`（本文）と `url`（リンク）を分けて渡すことで、X が URL を自動で
   /// t.co 短縮し、本文の文字数超過を避ける。副作用を持たないためテスト容易。
   static Uri buildXIntentUrl() {
-    return Uri.https('x.com', '/intent/tweet', <String, String>{
+    return Uri.https('twitter.com', '/intent/tweet', <String, String>{
       'text': shareText,
       'url': appUrl,
     });

--- a/test/services/grow_together_share_test.dart
+++ b/test/services/grow_together_share_test.dart
@@ -33,7 +33,7 @@ void main() {
       final uri = GrowTogetherShare.buildXIntentUrl();
 
       expect(uri.scheme, 'https');
-      expect(uri.host, 'x.com');
+      expect(uri.host, 'twitter.com');
       expect(uri.path, '/intent/tweet');
       expect(uri.queryParameters['text'], GrowTogetherShare.shareText);
       expect(uri.queryParameters['url'], GrowTogetherShare.appUrl);
@@ -44,7 +44,7 @@ void main() {
       // 混入していないことを確認する（intent URL として壊れないこと）。
       final encoded = GrowTogetherShare.buildXIntentUrl().toString();
 
-      expect(encoded.startsWith('https://x.com/intent/tweet?'), isTrue);
+      expect(encoded.startsWith('https://twitter.com/intent/tweet?'), isTrue);
       expect(encoded.contains('\n'), isFalse);
       expect(encoded.contains('text='), isTrue);
       expect(encoded.contains('url='), isTrue);


### PR DESCRIPTION
## 概要

実機報告: ホームの「Xでシェア」ボタンを押すと、X の画面が真っ白で表示されるだけでシェアできない。

## 原因

`GrowTogetherShare.buildXIntentUrl` が intent host に `x.com/intent/tweet` を使っていた。`x.com/intent/*` は作成画面（composer）が描画されず真っ白になる事象が知られている（ログインリダイレクトや SPA のハイドレーション失敗）。本リポジトリの他の共有導線（`app_share_service.dart` / `viral_ad_generator_page.dart`）は従来から安定して動く `twitter.com/intent/tweet` を使っている。

## 修正

- `buildXIntentUrl` の host を `x.com` → `twitter.com` に変更（ログイン済みなら x.com の作成画面へリダイレクトされる）。
- 純関数テストの host / encoded-URL アサーションを更新。

## Minimal E2E Gate

- 本変更のテストは実装詳細に依存しない入出力契約（black-box）であり、入力（なし）→ 出力（intent URL の host / path / クエリ）を最小限の代表3ケース（host=twitter.com・改行/日本語の percent-encoding・text/url パラメータ）で検証する。
- E2E機構: 外部サイト（X）への遷移を伴うため integration_test / playwright のエンドツーエンド（e2e）テストは追加せず、純関数の単体テストで URL 生成を担保する。
- E2E例外: X の投稿画面描画は外部サービス依存のため自動E2E不可。URL 生成を純関数テストで検証し、実機目視で確認する。
