### PR TITLE
feat: 自動振替の引落確認待ちカードで見込み残高の二重控除を解消

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -21,6 +21,7 @@ import 'package:my_web_app/models/debt_repayment_plan.dart';
 import 'package:my_web_app/models/kgi_csf_kpi.dart';
 import 'package:my_web_app/models/user_profile.dart';
 import 'package:my_web_app/pages/profile_settings_page.dart';
+import 'package:my_web_app/services/asset_auto_debit_confirmation_service.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
 import 'package:my_web_app/services/asset_liability_annual_rate_evidence_service.dart';
 import 'package:my_web_app/services/asset_liability_card_statement_import_service.dart';
@@ -7922,6 +7923,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ],
             _buildSyncStatusBanner(),
             _buildUnsyncedBadgeRow(),
+            _buildAutoDebitConfirmationCard(assetLiabilityWorkbook),
             const SizedBox(height: 12),
             _buildDisplayModeSwitcher(),
             const SizedBox(height: 12),
@@ -10483,6 +10485,119 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   /// 現金・預金を起点に、繰り返し収入・固定費・返済予定を毎月積み上げた
   /// 今後の残高見込みカード。登録データが無ければ非表示。
+  // 支払日を過ぎた自動振替・固定費の「引落確認待ち」カード。引落済みなら
+  // ユーザーが確認 → 支払済み(現在残高に反映済み)扱いにし、見込み残高の
+  // 二重控除を防ぐ。引落失敗の可能性があるため自動では支払済みにしない。
+  Widget _buildAutoDebitConfirmationCard(AssetLiabilityWorkbook? workbook) {
+    if (workbook == null) {
+      return const SizedBox.shrink();
+    }
+    final pending = const AssetAutoDebitConfirmationService()
+        .pendingConfirmations(workbook);
+    final entries =
+        <MapEntry<AssetLiabilityCashflowRow, AssetLiabilityDebtRow>>[];
+    for (final row in pending) {
+      for (final debt in workbook.debtMasterRows) {
+        if (debt.id == row.accountId) {
+          entries.add(MapEntry(row, debt));
+          break;
+        }
+      }
+    }
+    if (entries.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Card(
+        color: scheme.tertiaryContainer,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.help_outline, color: scheme.onTertiaryContainer),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '引落の確認待ち (${entries.length}件)',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: scheme.onTertiaryContainer,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '支払日を過ぎた自動振替・固定費です。引落が完了していれば「引落済み」を'
+                '押してください。現在の口座残高に反映済みとして扱い、見込み残高の'
+                '二重控除を防ぎます。引落が失敗している場合は押さないでください。',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onTertiaryContainer,
+                ),
+              ),
+              const SizedBox(height: 12),
+              for (final entry in entries)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              entry.key.accountName,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: scheme.onTertiaryContainer,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            Text(
+                              _autoDebitConfirmationSubtitle(entry.key),
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: scheme.onTertiaryContainer,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      FilledButton.tonal(
+                        onPressed: () {
+                          unawaited(
+                            _toggleMonthlyPaymentPaid(entry.value, true),
+                          );
+                        },
+                        child: const Text('引落済み'),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _autoDebitConfirmationSubtitle(AssetLiabilityCashflowRow row) {
+    final buffer = StringBuffer(
+      '${row.paymentDay}日 / ${_formatManagementYen(row.paymentAmount)}',
+    );
+    final source = row.paymentSourceAccountName;
+    if (source != null && source.isNotEmpty) {
+      buffer.write(' / $source');
+    }
+    return buffer.toString();
+  }
+
   Widget _buildCashflowForecastCard(AssetLiabilityWorkbook? workbook) {
     if (workbook == null) {
       return const SizedBox.shrink();

--- a/lib/services/asset_auto_debit_confirmation_service.dart
+++ b/lib/services/asset_auto_debit_confirmation_service.dart
@@ -1,0 +1,43 @@
+import '../models/asset_liability_workbook.dart';
+
+/// 「支払日を過ぎたが、まだ支払済み確認をしていない直接支払い(口座振替など)」を
+/// 抽出する純関数サービス。
+///
+/// これらの支払いは未払い扱いのまま見込み残高から差し引かれる。実際には自動
+/// 口座振替で既に引落済みのことが多く、その場合は現在の口座残高に既に反映されて
+/// いるため、二重に差し引かれて残高予測が過度に悲観的になる。一方で、残高不足で
+/// 引落が失敗している可能性もあるため、自動的に「支払済み」にはせず、ユーザーに
+/// 「引落されましたか?」と確認させて確定する(確認したら現在残高に反映済みとして扱う)。
+class AssetAutoDebitConfirmationService {
+  const AssetAutoDebitConfirmationService();
+
+  /// 確認待ちの支払い行(支払日が baseDate より前=厳密に過去・直接支払い対象・未払い)。
+  ///
+  /// `overdue` フラグ自体が「直接支払い対象 かつ 未払い かつ 支払日<=本日」を表すため、
+  /// それに「本日より前(本日分は引落が未確定なので除外)」の条件を重ねる。
+  /// 金額の大きい順に並べる。
+  List<AssetLiabilityCashflowRow> pendingConfirmations(
+    AssetLiabilityWorkbook workbook,
+  ) {
+    final today = DateTime(
+      workbook.baseDate.year,
+      workbook.baseDate.month,
+      workbook.baseDate.day,
+    );
+    final rows = workbook.cashflowRows
+        .where(
+          (row) =>
+              row.isPayment && row.overdue && row.paymentDate.isBefore(today),
+        )
+        .toList();
+    rows.sort((a, b) => b.paymentAmount.compareTo(a.paymentAmount));
+    return List<AssetLiabilityCashflowRow>.unmodifiable(rows);
+  }
+
+  /// 確認待ち支払いの合計額(見込み残高から二重控除され得る金額)。
+  double pendingTotal(AssetLiabilityWorkbook workbook) {
+    return pendingConfirmations(
+      workbook,
+    ).fold<double>(0, (sum, row) => sum + row.paymentAmount);
+  }
+}

--- a/test/services/asset_auto_debit_confirmation_service_test.dart
+++ b/test/services/asset_auto_debit_confirmation_service_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_auto_debit_confirmation_service.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  const service = AssetAutoDebitConfirmationService();
+  const planning = AssetLiabilityPlanningService();
+
+  group('AssetAutoDebitConfirmationService', () {
+    test('lists direct payments whose date has already passed this month', () {
+      // 6/15 時点。ガス(12日)は過去、水道(22日)・家賃/KDDI(25日)は未来。
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 63539},
+        baseDate: DateTime(2026, 6, 15),
+        includeDefaultFixedPayments: true,
+      );
+      final pending = service.pendingConfirmations(workbook);
+      final ids = pending.map((row) => row.accountId).toSet();
+
+      expect(ids, contains(AssetLiabilityPlanningService.gasBillAccountId));
+      expect(
+        ids,
+        isNot(contains(AssetLiabilityPlanningService.waterBillAccountId)),
+      );
+      expect(ids, isNot(contains(AssetLiabilityPlanningService.rentAccountId)));
+
+      for (final row in pending) {
+        expect(row.isPayment, isTrue);
+        expect(row.overdue, isTrue);
+        expect(row.paymentDate.isBefore(DateTime(2026, 6, 15)), isTrue);
+      }
+    });
+
+    test('excludes payments due exactly today (debit not yet certain)', () {
+      // 6/12 = ガスの振替日当日。本日分は引落未確定なので確認待ちに含めない。
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 63539},
+        baseDate: DateTime(2026, 6, 12),
+        includeDefaultFixedPayments: true,
+      );
+      final ids = service
+          .pendingConfirmations(workbook)
+          .map((row) => row.accountId)
+          .toSet();
+      expect(
+        ids,
+        isNot(contains(AssetLiabilityPlanningService.gasBillAccountId)),
+      );
+    });
+
+    test('excludes payments already confirmed as paid', () {
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 63539},
+        baseDate: DateTime(2026, 6, 15),
+        includeDefaultFixedPayments: true,
+        paidAccountNames: <String>{
+          AssetLiabilityPlanningService.gasBillAccountId,
+        },
+      );
+      final ids = service
+          .pendingConfirmations(workbook)
+          .map((row) => row.accountId)
+          .toSet();
+      expect(
+        ids,
+        isNot(contains(AssetLiabilityPlanningService.gasBillAccountId)),
+      );
+      expect(service.pendingTotal(workbook), 0);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

支払日を過ぎた自動振替・固定費の「引落確認待ち」カードを資産管理画面の上部に追加します。引落済みなら[引落済み]ボタンで確認 → 支払済み(現在残高に反映済み)扱いにし、見込み残高の二重控除を解消します。

**背景**: 自動口座振替(ガス/水道/家賃/KDDI等)は振替日に銀行が自動引落するが、本アプリは「支払済み」をユーザーが手動マークした時だけ計上する。そのため振替日を過ぎると未払い扱いのまま見込み残高から差し引かれ、実際は引落済み=現残高に反映済みなのに二重控除されて残高予測が過度に悲観的になっていた。

**設計判断**: 自動で「支払済み」にはしない。残高不足で引落が失敗している可能性があり、自動確定すると失敗を隠してしまうため、ユーザーに「引落されましたか?」と確認させる方式。

- 純関数 `AssetAutoDebitConfirmationService.pendingConfirmations`: 支払日が本日より前(厳密に過去)・直接支払い対象・未払いの行を抽出。本日分は引落未確定なので除外。
- カードは確認待ちが無ければ非表示(`SizedBox.shrink`)。確認操作は既存の `_toggleMonthlyPaymentPaid` を再利用。

## テスト

`AssetAutoDebitConfirmationService` の単体テストで入出力契約を検証。実装詳細に依存しない最小限の3ケース。

- 支払日が過去(ガス12日@6/15)の直接支払いを抽出し、未来(水道22日・家賃/KDDI25日)は除外
- 本日が振替日の支払い(ガス@6/12)は除外(引落未確定)
- 確認済みの支払いは除外(pendingTotal=0)

ページ smoke テスト33件green(カード挿入でページビルドが壊れないことを確認)。

UIカードは純関数の抽出結果を描画し確認ボタンは既存トグルを再利用するため、integration_test / Playwright のエンドツーエンドは追加しません。

E2E例外: 抽出ロジックは純関数で単体網羅、UIは既存トグル再利用で新規ロジックなし

---
Review owner: Claude Code #1
High-risk-ultrareview-exception: 純関数の抽出と既存トグル再利用のUI追加で高リスクパスや外部通信を含まない
