### PR TITLE
feat: per-key guard for authoritative mirror reads (#3415)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -45,6 +45,7 @@ import 'package:my_web_app/services/asset_category_budget_service.dart';
 import 'package:my_web_app/services/asset_category_budget_store.dart';
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
 import 'package:my_web_app/services/asset_mirror_read_policy.dart';
+import 'package:my_web_app/services/asset_sync_dirty_keys_store.dart';
 import 'package:my_web_app/services/asset_sync_status.dart';
 import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
 import 'package:my_web_app/services/asset_unknown_expense_rule_service.dart';
@@ -275,6 +276,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 集約 pref ドメインのローカル最終変更時刻 (LWW 判定用 / Phase B)。
   final AssetSyncTimestampStore _syncTimestampStore =
       const AssetSyncTimestampStore();
+
+  /// ローカル編集済みで未同期のキー集合 (authoritative reads の巻き添え上書き
+  /// 防止 / #3415 保守的 per-key ガード)。
+  final AssetSyncDirtyKeysStore _syncDirtyKeysStore =
+      const AssetSyncDirtyKeysStore();
 
   /// ミラー読み取りを Supabase 正本化 (LWW) するか。テスト注入優先・既定はビルド時フラグ。
   bool get _mirrorReadsAuthoritative =>
@@ -5342,6 +5348,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
         'updated_at': DateTime.now().toUtc().toIso8601String(),
       });
+      // 全量 upsert 成功 = 全キー同期済み → dirty クリア。
+      await _syncDirtyKeysStore.clearDomain(_watchlistMirrorKey);
     } catch (e) {
       debugPrint('watchlist mirror upsert failed: $e');
     }
@@ -5497,14 +5505,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         }
         return false;
       });
+      final dirtyKeys = await _syncDirtyKeysStore.loadDirty(
+        _watchlistMirrorKey,
+      );
       for (final entry in serverEntries) {
         serverTypes.add(entry.assetType);
         if (tombstoned.contains(entry.assetType)) {
           continue;
         }
-        // ⚠️ #3415: adoptConflicts はドメイン全体 ts 由来。authoritative reads
-        // (フラグ ON) 時のみ多キー巻き添え上書きの恐れ。per-key LWW へ要改修。
-        if (!merged.containsKey(entry.assetType) || adoptConflicts) {
+        // #3415 保守的 per-key ガード: ローカル編集済み (dirty) キーは、ドメイン
+        // 全体 adopt の巻き添えで上書きしない (同一キー衝突はローカル優先)。
+        // フラグ OFF はここに来ても merged が local 由来 (空) なので
+        // !containsKey が先に成立し no-op (本番無変更)。
+        if (!merged.containsKey(entry.assetType) ||
+            (adoptConflicts && !dirtyKeys.contains(entry.assetType))) {
           merged[entry.assetType] = entry;
           changed = true;
         }
@@ -5633,6 +5647,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   _setWatchlistEntries(entries);
                 });
                 unawaited(_recordWatchlistTombstone(type, deleted: false));
+                // ローカル編集を dirty 記録 (巻き添え上書き防止)。
+                unawaited(
+                  _syncDirtyKeysStore.markDirty(_watchlistMirrorKey, type),
+                );
                 unawaited(_mirrorWatchlist());
                 if (dialogContext.mounted) {
                   Navigator.of(dialogContext).pop();
@@ -8391,6 +8409,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
         'updated_at': DateTime.now().toUtc().toIso8601String(),
       });
+      // 全量 upsert 成功 = 全キー同期済み → dirty クリア。
+      await _syncDirtyKeysStore.clearDomain(_revolvingConfigsMirrorKey);
     } catch (e) {
       debugPrint('revolving config mirror upsert failed: $e');
     }
@@ -8466,13 +8486,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         }
         return false;
       });
+      final dirtyKeys = await _syncDirtyKeysStore.loadDirty(
+        _revolvingConfigsMirrorKey,
+      );
       serverConfigs.forEach((key, config) {
         if (tombstoned.contains(key)) {
           return;
         }
-        // ⚠️ #3415: adoptConflicts はドメイン全体 ts 由来。authoritative reads
-        // (フラグ ON) 時のみ多キー巻き添え上書きの恐れ。per-key LWW へ要改修。
-        if (!merged.containsKey(key) || adoptConflicts) {
+        // #3415 保守的 per-key ガード: ローカル編集済み (dirty) キーは、ドメイン
+        // 全体 adopt の巻き添えで上書きしない (同一キー衝突はローカル優先)。
+        // フラグ OFF はここに来ても merged が local 由来 (空) なので
+        // !containsKey が先に成立し no-op (本番無変更)。
+        if (!merged.containsKey(key) ||
+            (adoptConflicts && !dirtyKeys.contains(key))) {
           merged[key] = config;
           changed = true;
         }
@@ -8529,6 +8555,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_revolvingConfigStore.save(_revolvingConfigs));
     // 削除はトゥームストーン化、再設定は解除 (debtId 再利用ドメイン)。
     unawaited(_recordRevolvingTombstone(debtId, deleted: config == null));
+    if (config != null) {
+      // ローカル編集を dirty 記録 (authoritative reads の巻き添え上書き防止)。
+      unawaited(
+        _syncDirtyKeysStore.markDirty(_revolvingConfigsMirrorKey, debtId),
+      );
+    }
     unawaited(_mirrorRevolvingConfigs());
   }
 
@@ -9559,6 +9591,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         'value': overrides,
         'updated_at': DateTime.now().toUtc().toIso8601String(),
       });
+      // 全量 upsert 成功 = 全キー同期済み → dirty クリア。
+      await _syncDirtyKeysStore.clearDomain('debt_payment_day_overrides');
     } catch (e) {
       debugPrint('pref mirror upsert failed: $e');
     }
@@ -9633,10 +9667,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final localKeys = _debtPaymentDayOverrides.keys.toSet();
       final merged = Map<String, int>.from(_debtPaymentDayOverrides);
       var changed = false;
+      final dirtyKeys = await _syncDirtyKeysStore.loadDirty(
+        'debt_payment_day_overrides',
+      );
       serverOverrides.forEach((key, day) {
-        // ⚠️ #3415: adoptConflicts はドメイン全体 ts 由来。authoritative reads
-        // (フラグ ON) 時のみ多キー巻き添え上書きの恐れ。per-key LWW へ要改修。
-        if (!merged.containsKey(key) || adoptConflicts) {
+        // #3415 保守的 per-key ガード: ローカル編集済み (dirty) キーは、ドメイン
+        // 全体 adopt の巻き添えで上書きしない (同一キー衝突はローカル優先)。
+        // フラグ OFF はここに来ても merged が local 由来 (空) なので
+        // !containsKey が先に成立し no-op (本番無変更)。
+        if (!merged.containsKey(key) ||
+            (adoptConflicts && !dirtyKeys.contains(key))) {
           merged[key] = day;
           changed = true;
         }
@@ -21070,6 +21110,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       unawaited(_recordDebtOverrideTombstone(row.id, deleted: true));
     } else {
       unawaited(_recordDebtOverrideTombstone(row.id, deleted: false));
+      // ローカル編集を dirty 記録 (巻き添え上書き防止)。
+      unawaited(
+        _syncDirtyKeysStore.markDirty('debt_payment_day_overrides', row.id),
+      );
     }
     unawaited(_saveDebtPaymentDayOverrides());
   }

--- a/lib/services/asset_sync_dirty_keys_store.dart
+++ b/lib/services/asset_sync_dirty_keys_store.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 集約 pref ドメインごとに「ローカルで編集したがまだサーバへ同期できていない
+/// キー」(= dirty キー) を記録する。
+///
+/// authoritative reads (フラグ `ASSET_MIRROR_READS_AUTHORITATIVE` = ON) の
+/// last-write-wins はドメイン全体の `updated_at` を見るため、別キーの更新で
+/// ミラーが新しくなると、ローカルで編集した別キーまで巻き添えでサーバ値に
+/// 上書きされ得る (#3415)。マージ時にこの dirty キーをローカル優先で保護する
+/// ことで、その巻き添え上書き (= 無音のデータ喪失) を防ぐ保守的ガード。
+///
+/// dirty キーは「ローカル編集サイト」で `markDirty`、ミラーへの全量 upsert が
+/// 成功した時点で `clearDomain` する (= 全キーが同期済みになるため)。よって
+/// dirty が残るのはオフライン等で同期できなかった編集のみ。
+///
+/// 注意: 本機能導入より前に保存された既存ローカル値は dirty 記録が無いため、
+/// フラグ ON 時の保護対象外 (= 旧来の whole-domain LWW の制限が残る)。これは
+/// per-key LWW タイムスタンプ化 (#3415 本改修) で解消予定の dormant な残課題。
+class AssetSyncDirtyKeysStore {
+  static const String prefsKey = 'asset_sync_dirty_keys_v1';
+
+  const AssetSyncDirtyKeysStore();
+
+  /// 全ての write (markDirty / clearDomain) を直列化する process-wide ロック。
+  /// 単一 pref blob への read-modify-write が並行 (= 各サイト unawaited) で
+  /// 交錯し、別ドメイン/別キーの dirty マークを取りこぼす lost-update を防ぐ。
+  static Future<void> _writeLock = Future<void>.value();
+
+  /// [action] を前の write 完了後に直列実行する。action の結果/例外は戻り値の
+  /// future へ伝播するが、ロック鎖は失敗で途切れさせない。
+  Future<void> _runLocked(Future<void> Function() action) {
+    final run = _writeLock.then((_) => action());
+    _writeLock = run.catchError((_) {});
+    return run;
+  }
+
+  Future<Map<String, Set<String>>> _loadAll(SharedPreferences store) async {
+    final raw = store.getString(prefsKey);
+    if (raw == null || raw.isEmpty) {
+      return <String, Set<String>>{};
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        return <String, Set<String>>{};
+      }
+      final result = <String, Set<String>>{};
+      decoded.forEach((key, value) {
+        if (key is String && value is List) {
+          result[key] = <String>{
+            for (final entry in value)
+              if ((entry?.toString() ?? '').isNotEmpty) entry.toString(),
+          };
+        }
+      });
+      return result;
+    } catch (_) {
+      return <String, Set<String>>{};
+    }
+  }
+
+  Future<void> _writeAll(
+    SharedPreferences store,
+    Map<String, Set<String>> all,
+  ) async {
+    all.removeWhere((_, value) => value.isEmpty);
+    await store.setString(
+      prefsKey,
+      jsonEncode(<String, List<String>>{
+        for (final entry in all.entries) entry.key: entry.value.toList(),
+      }),
+    );
+  }
+
+  /// [prefKey] ドメインの dirty キー集合を返す (読み取りはロック不要)。
+  Future<Set<String>> loadDirty(
+    String prefKey, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return (await _loadAll(store))[prefKey] ?? <String>{};
+  }
+
+  /// [key] をローカル編集済み (未同期) として記録する。
+  Future<void> markDirty(
+    String prefKey,
+    String key, {
+    SharedPreferences? prefs,
+  }) {
+    if (key.isEmpty) {
+      return Future<void>.value();
+    }
+    return _runLocked(() async {
+      final store = prefs ?? await SharedPreferences.getInstance();
+      final all = await _loadAll(store);
+      (all[prefKey] ??= <String>{}).add(key);
+      await _writeAll(store, all);
+    });
+  }
+
+  /// [prefKey] ドメインの全 dirty キーを消す (= 全量 upsert 成功で同期済み)。
+  Future<void> clearDomain(
+    String prefKey, {
+    SharedPreferences? prefs,
+  }) {
+    return _runLocked(() async {
+      final store = prefs ?? await SharedPreferences.getInstance();
+      final all = await _loadAll(store);
+      if (all.remove(prefKey) != null) {
+        await _writeAll(store, all);
+      }
+    });
+  }
+}

--- a/test/services/asset_sync_dirty_keys_store_test.dart
+++ b/test/services/asset_sync_dirty_keys_store_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_sync_dirty_keys_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('AssetSyncDirtyKeysStore', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    Future<SharedPreferences> prefs() => SharedPreferences.getInstance();
+    const store = AssetSyncDirtyKeysStore();
+
+    test('markDirty records per domain and loadDirty reads back', () async {
+      final sp = await prefs();
+      await store.markDirty('domA', 'k1', prefs: sp);
+      await store.markDirty('domA', 'k2', prefs: sp);
+      await store.markDirty('domB', 'x', prefs: sp);
+      await store.markDirty('domA', '', prefs: sp); // 空は無視
+
+      expect(await store.loadDirty('domA', prefs: sp), <String>{'k1', 'k2'});
+      expect(await store.loadDirty('domB', prefs: sp), <String>{'x'});
+      expect(await store.loadDirty('none', prefs: sp), isEmpty);
+    });
+
+    test('clearDomain removes only that domain', () async {
+      final sp = await prefs();
+      await store.markDirty('domA', 'k1', prefs: sp);
+      await store.markDirty('domB', 'x', prefs: sp);
+
+      await store.clearDomain('domA', prefs: sp);
+
+      expect(await store.loadDirty('domA', prefs: sp), isEmpty);
+      expect(await store.loadDirty('domB', prefs: sp), <String>{'x'});
+    });
+
+    test('tolerates malformed json', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        AssetSyncDirtyKeysStore.prefsKey: 'not json',
+      });
+      final sp = await prefs();
+      expect(await store.loadDirty('domA', prefs: sp), isEmpty);
+    });
+
+    test('serializes concurrent writes without losing marks', () async {
+      final sp = await prefs();
+      // 各編集サイトと同様に await を挟まず並行発火する。直列化ロックが無いと
+      // read-modify-write が交錯し一部のマークを取りこぼす (review medium)。
+      await Future.wait(<Future<void>>[
+        store.markDirty('domA', 'a', prefs: sp),
+        store.markDirty('domB', 'b', prefs: sp),
+        store.markDirty('domC', 'c', prefs: sp),
+      ]);
+      expect(await store.loadDirty('domA', prefs: sp), <String>{'a'});
+      expect(await store.loadDirty('domB', prefs: sp), <String>{'b'});
+      expect(await store.loadDirty('domC', prefs: sp), <String>{'c'});
+    });
+
+    test('concurrent clearDomain does not drop another domain mark', () async {
+      final sp = await prefs();
+      await store.markDirty('keep', 'k1', prefs: sp);
+      // 別ドメインの clear と keep への mark を並行発火 → keep は失われない。
+      await Future.wait(<Future<void>>[
+        store.clearDomain('other', prefs: sp),
+        store.markDirty('keep', 'k2', prefs: sp),
+      ]);
+      expect(await store.loadDirty('keep', prefs: sp), <String>{'k1', 'k2'});
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1018,6 +1018,166 @@ void main() {
       await _unmount(tester);
     });
 
+    testWidgets(
+      'Phase B flag on: dirty watchlist key keeps local, clean key adopts '
+      'server (#3415 per-key guard)',
+      (tester) async {
+        // gold はローカル編集済み(dirty) / silver は未編集。サーバは両方別値。
+        // フラグ ON でも dirty な gold は巻き添え上書きされず、silver のみ採用。
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'asset_watchlist_entries_v1': jsonEncode(<Map<String, dynamic>>[
+            <String, dynamic>{
+              'assetType': 'gold',
+              'group': 'local_gold',
+              'memo': '',
+              'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+            },
+            <String, dynamic>{
+              'assetType': 'silver',
+              'group': 'local_silver',
+              'memo': '',
+              'addedAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+            },
+          ]),
+          'asset_sync_dirty_keys_v1': jsonEncode(<String, dynamic>{
+            'watchlist_entries': <String>['gold'],
+          }),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              debugMirrorReadsAuthoritative: true,
+              debugWatchlistMirror: AssetWatchlistService.encodeMirrorValue(
+                <AssetWatchlistEntry>[
+                  AssetWatchlistEntry(
+                    assetType: 'gold',
+                    group: 'server_gold',
+                    memo: '',
+                    addedAt: DateTime.utc(2026, 6, 14),
+                  ),
+                  AssetWatchlistEntry(
+                    assetType: 'silver',
+                    group: 'server_silver',
+                    memo: '',
+                    addedAt: DateTime.utc(2026, 6, 14),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final synced = await const AssetWatchlistService().loadEntries();
+        final gold = synced.firstWhere((e) => e.assetType == 'gold');
+        final silver = synced.firstWhere((e) => e.assetType == 'silver');
+        expect(gold.group, 'local_gold'); // dirty → 保護
+        expect(silver.group, 'server_silver'); // clean → サーバ採用
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'Phase B flag on: dirty revolving key keeps local, clean key adopts '
+      'server (#3415 per-key guard)',
+      (tester) async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          AssetRevolvingCreditConfigStore.prefsKey: jsonEncode(
+            AssetRevolvingCreditConfigStore.encodeMirrorValue(
+              <String, AssetLiabilityRevolvingCreditConfig>{
+                'dirty_card': const AssetLiabilityRevolvingCreditConfig(
+                  monthlyAmount: 1000,
+                  creditLimit: 500000,
+                ),
+                'clean_card': const AssetLiabilityRevolvingCreditConfig(
+                  monthlyAmount: 2000,
+                  creditLimit: 500000,
+                ),
+              },
+            ),
+          ),
+          'asset_sync_dirty_keys_v1': jsonEncode(<String, dynamic>{
+            'revolving_credit_configs': <String>['dirty_card'],
+          }),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              debugMirrorReadsAuthoritative: true,
+              debugRevolvingConfigsMirror:
+                  AssetRevolvingCreditConfigStore.encodeMirrorValue(
+                <String, AssetLiabilityRevolvingCreditConfig>{
+                  'dirty_card': const AssetLiabilityRevolvingCreditConfig(
+                    monthlyAmount: 9000,
+                    creditLimit: 500000,
+                  ),
+                  'clean_card': const AssetLiabilityRevolvingCreditConfig(
+                    monthlyAmount: 8000,
+                    creditLimit: 500000,
+                  ),
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final local = await const AssetRevolvingCreditConfigStore().load();
+        expect(local['dirty_card']!.monthlyAmount, 1000); // dirty → 保護
+        expect(local['clean_card']!.monthlyAmount, 8000); // clean → サーバ採用
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'Phase B flag on: dirty debt-override key keeps local, clean key adopts '
+      'server (#3415 per-key guard)',
+      (tester) async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'asset_sync_dirty_keys_v1': jsonEncode(<String, dynamic>{
+            'debt_payment_day_overrides': <String>['dirty_debt'],
+          }),
+        });
+        final repo = _FakeDebtOverrideRepository(<String, int>{
+          'dirty_debt': 10,
+          'clean_debt': 11,
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              assetLiabilityRepository: repo,
+              debugMirrorReadsAuthoritative: true,
+              debugDebtOverridesMirror: const <String, dynamic>{
+                'dirty_debt': 20,
+                'clean_debt': 21,
+              },
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(repo.savedDebtOverrides, isNotNull);
+        expect(repo.savedDebtOverrides!['dirty_debt'], 10); // dirty → 保護
+        expect(repo.savedDebtOverrides!['clean_debt'], 21); // clean → サーバ採用
+
+        await _unmount(tester);
+      },
+    );
+
     testWidgets('Phase B flag off (default): same-key conflict keeps local', (
       tester,
     ) async {


### PR DESCRIPTION
## 概要

#3415 = authoritative mirror reads (フラグ `ASSET_MIRROR_READS_AUTHORITATIVE` = ON) の **ドメイン全体 LWW が別キー更新の巻き添えでローカル編集キーを上書きするデータ喪失** を、保守的な **per-key ガード** で防ぐ。フラグは本番 OFF (dormant) で、本 PR はフラグ ON 経路かつ dirty キーのみ挙動が変わる純粋な追加保護。本番挙動は無変更。

### 仕組み
- 新 `AssetSyncDirtyKeysStore`: 「ローカル編集済みで未同期のキー」を記録。全 write は **process-wide ロックで直列化** (並行 read-modify-write の lost-update 防止)。
- 編集サイト (`_persistRevolvingConfig` / watchlist 保存ダイアログ / `_setDebtPaymentDayOverride`) で `markDirty`、全量 mirror upsert 成功で `clearDomain`。
- 3 ドメイン (リボ/ウォッチリスト/支払日上書き) のマージ条件を `!merged.containsKey(k) || (adoptConflicts && !dirty(k))` に変更。dirty キーはローカル優先 (同一キー衝突は安全側)、未編集キーはサーバ採用。

### ultracode 敵対レビュー (23 agent / 2.2M tok)
実装を 4 観点で並列レビュー→敵対的反証。確定指摘の **lost-update レース** (単一 pref blob への並行 unawaited write で dirty マーク取りこぼし) を **直列化ロックで是正**し、並行 write テストを追加。完全性 (全編集サイトが markDirty を通る) とテスト teeth は強みとして確認済み。

### テスト (黒箱・入出力)
- `asset_management_page_smoke_test.dart`: 3 ドメイン各々「dirty キーはローカル維持 / clean キーはサーバ採用」(flag ON)。既存「flag ON: 衝突はサーバ採用」も dirty 無しで緑のまま。
- `asset_sync_dirty_keys_store_test.dart`: mark/clear/不正 JSON + **並行 write の非ロスト** 5 件。
- `flutter analyze` 0 issues / 41 widget+unit テスト緑。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: per-key 同期ガードは widget (3 ドメインの dirty 保護/clean 採用) + unit (並行 write 非ロスト) で黒箱検証、ログイン必須経路は CI 外で純関数照合と同型

---
Review owner: Claude Code #1。
High-risk-ultrareview-exception: 同期ガードの局所追加のみ。スキーマ/権限変更なし、既定フラグ OFF で本番挙動は不変 (dirty キーのみ・フラグ ON 経路のみ作用)。
