### PR TITLE
feat: Phase 3 Layer-1 flag to retire legacy pref read fallback

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -8876,13 +8876,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<List<Map<String, dynamic>>> _fetchDisplayPrefRows() async {
     final rows = List<Map<String, dynamic>>.from(
       await _supabase.from('asset_pref_mirror').select().inFilter(
-        'pref_key',
-        <String>[
-          _displayPrefsAggregatedKey,
-          'display_mode',
-          'section_overrides',
-        ],
-      ),
+            'pref_key',
+            AssetMirrorReadPolicy.readPrefKeys(
+              aggregatedKey: _displayPrefsAggregatedKey,
+              legacyKeys: const <String>['display_mode', 'section_overrides'],
+            ),
+          ),
     );
     for (final row in rows) {
       if (row['pref_key'] == _displayPrefsAggregatedKey) {
@@ -8915,9 +8914,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         // 集約行 (asset_display_prefs_v1) を優先、無ければ legacy 行。
         final rows =
             await _supabase.from('asset_pref_mirror').select().inFilter(
-          'pref_key',
-          <String>[_displayPrefsAggregatedKey, 'section_override_deleted'],
-        );
+                  'pref_key',
+                  AssetMirrorReadPolicy.readPrefKeys(
+                    aggregatedKey: _displayPrefsAggregatedKey,
+                    legacyKeys: const <String>['section_override_deleted'],
+                  ),
+                );
         Map<String, dynamic>? aggregated;
         Map<String, dynamic>? legacy;
         for (final row in rows) {
@@ -9786,9 +9788,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         // 集約行 (asset_inflow_prefs_v1) を優先、無ければ legacy 行。
         final rows =
             await _supabase.from('asset_pref_mirror').select().inFilter(
-          'pref_key',
-          <String>[_inflowPrefsAggregatedKey, 'inflow_deleted_ids'],
-        );
+                  'pref_key',
+                  AssetMirrorReadPolicy.readPrefKeys(
+                    aggregatedKey: _inflowPrefsAggregatedKey,
+                    legacyKeys: const <String>['inflow_deleted_ids'],
+                  ),
+                );
         Map<String, dynamic>? aggregated;
         Map<String, dynamic>? legacy;
         for (final row in rows) {
@@ -9852,9 +9857,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     try {
       // 集約行 (asset_inflow_prefs_v1) を優先、無ければ legacy 行。
       final rows = await _supabase.from('asset_pref_mirror').select().inFilter(
-        'pref_key',
-        <String>[_inflowPrefsAggregatedKey, 'inflow_tombstone_gc'],
-      );
+            'pref_key',
+            AssetMirrorReadPolicy.readPrefKeys(
+              aggregatedKey: _inflowPrefsAggregatedKey,
+              legacyKeys: const <String>['inflow_tombstone_gc'],
+            ),
+          );
       Map<String, dynamic>? aggregated;
       Map<String, dynamic>? legacy;
       for (final row in rows) {

--- a/lib/services/asset_mirror_read_policy.dart
+++ b/lib/services/asset_mirror_read_policy.dart
@@ -16,6 +16,39 @@ class AssetMirrorReadPolicy {
     flagName,
     defaultValue: false,
   );
+
+  /// Phase 3: legacy per-key 行の読みフォールバックを撤去するビルド時フラグ。
+  ///
+  /// 既定 false (= legacy 行も読む現行挙動 / プロダクション無変更)。true で
+  /// `asset_pref_mirror` の読みを集約行のみに絞る。本番有効化は dart-define で行い、
+  /// 既定 false なので削除するだけで即時ロールバックできる。
+  ///
+  /// **有効化の前提**: docs/PHASE3_LEGACY_ZERO_DRYRUN.md の dry-run が全 PASS
+  /// (legacy 残存ゼロ + 旧クライアント不在) を確認できた後にのみ true にする。
+  static const String legacyReadDisabledFlag =
+      'ASSET_LEGACY_PREF_READ_DISABLED';
+
+  static const bool legacyReadDisabled = bool.fromEnvironment(
+    legacyReadDisabledFlag,
+    defaultValue: false,
+  );
+
+  /// `asset_pref_mirror` 読みの `inFilter('pref_key', ...)` に渡すキー一覧を返す
+  /// 純関数。[legacyReadDisabled] が true なら集約キーのみ(legacy フォールバック
+  /// 撤去)、false なら集約 + legacy キー(現行)。
+  ///
+  /// [legacyDisabled] はテスト用の上書き。省略時はビルド時フラグを使う。
+  static List<String> readPrefKeys({
+    required String aggregatedKey,
+    required List<String> legacyKeys,
+    bool? legacyDisabled,
+  }) {
+    final disabled = legacyDisabled ?? legacyReadDisabled;
+    if (disabled) {
+      return <String>[aggregatedKey];
+    }
+    return <String>[aggregatedKey, ...legacyKeys];
+  }
 }
 
 /// LWW 解決の結果: サーバ行を採用するか、ローカルを維持するか。

--- a/test/services/asset_mirror_read_policy_test.dart
+++ b/test/services/asset_mirror_read_policy_test.dart
@@ -94,4 +94,32 @@ void main() {
       expect(AssetMirrorReadPolicy.authoritative, isFalse);
     });
   });
+
+  group('readPrefKeys (Phase 3 legacy fallback flag)', () {
+    test('legacy enabled (default) → aggregated + legacy keys', () {
+      expect(
+        AssetMirrorReadPolicy.readPrefKeys(
+          aggregatedKey: 'asset_display_prefs_v1',
+          legacyKeys: const <String>['display_mode', 'section_overrides'],
+          legacyDisabled: false,
+        ),
+        <String>['asset_display_prefs_v1', 'display_mode', 'section_overrides'],
+      );
+    });
+
+    test('legacy disabled → aggregated key only (fallback retired)', () {
+      expect(
+        AssetMirrorReadPolicy.readPrefKeys(
+          aggregatedKey: 'asset_inflow_prefs_v1',
+          legacyKeys: const <String>['inflow_deleted_ids'],
+          legacyDisabled: true,
+        ),
+        <String>['asset_inflow_prefs_v1'],
+      );
+    });
+
+    test('the Phase 3 build flag defaults to OFF (production unchanged)', () {
+      expect(AssetMirrorReadPolicy.legacyReadDisabled, isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## What & why

Lands the cutover **Layer-1** infrastructure for the `asset_pref_mirror`
Phase 3 (retiring the legacy per-key read fallback), per
`docs/PHASE3_LEGACY_ZERO_DRYRUN.md` section 6.B. It is gated behind a build-time
flag that defaults **OFF**, so this PR changes no runtime behavior; it only
makes the cutover a one-line dart-define flip once the dry-run passes
(>= 2026-07-12). Shipping the infra now disperses the cutover risk.

## Changes

- `AssetMirrorReadPolicy.legacyReadDisabled` (flag `ASSET_LEGACY_PREF_READ_DISABLED`,
  default false) + a pure `readPrefKeys()` helper: returns the aggregated key
  alone when the flag is on, or aggregated + legacy keys (current) when off.
- Route the four read-fallback sites (`_fetchDisplayPrefRows`,
  `_pullDeletedSectionIds`, `_pullInflowDeletedIds`, `_loadTombstoneGcConfig`)
  through `readPrefKeys()`. With the flag OFF the inFilter key lists are
  byte-identical to before — verified by reading the diff.
- Unit tests for `readPrefKeys` (on/off) and the default-off guard.

## Minimal E2E Gate

- Implementation-detail independent: the unit tests assert the helper's
  input/output (which pref_keys are requested for each flag state), not private
  internals.
- Minimal scope: about 3 cases (flag off, flag on, default-off guard).
- E2E: covered by unit tests in `test/services/`; no page-level
  integration_test / Playwright e2e is added (see exception).
- E2E-Exception: behavior is behind a default-off build flag (zero runtime
  change), and the page read paths are auth-gated; the pure helper is unit
  tested.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: default-off feature flag with no runtime
  behavior change (inFilter key lists byte-identical when off); no high-risk
  path changed; review owned by Claude Code #1.
