### PR TITLE
feat: 自動振替の引落確認カードに振替元残高不足の早期警告を追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -10532,14 +10532,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (workbook == null) {
       return const SizedBox.shrink();
     }
-    final pending = const AssetAutoDebitConfirmationService()
-        .pendingConfirmations(workbook);
+    final details = const AssetAutoDebitConfirmationService()
+        .pendingConfirmationDetails(workbook);
     final entries =
-        <MapEntry<AssetLiabilityCashflowRow, AssetLiabilityDebtRow>>[];
-    for (final row in pending) {
+        <MapEntry<AssetAutoDebitConfirmation, AssetLiabilityDebtRow>>[];
+    for (final detail in details) {
       for (final debt in workbook.debtMasterRows) {
-        if (debt.id == row.accountId) {
-          entries.add(MapEntry(row, debt));
+        if (debt.id == detail.row.accountId) {
+          entries.add(MapEntry(detail, debt));
           break;
         }
       }
@@ -10593,18 +10593,46 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              entry.key.accountName,
+                              entry.key.row.accountName,
                               style: theme.textTheme.bodyMedium?.copyWith(
                                 color: scheme.onTertiaryContainer,
                                 fontWeight: FontWeight.w600,
                               ),
                             ),
                             Text(
-                              _autoDebitConfirmationSubtitle(entry.key),
+                              _autoDebitConfirmationSubtitle(entry.key.row),
                               style: theme.textTheme.bodySmall?.copyWith(
                                 color: scheme.onTertiaryContainer,
                               ),
                             ),
+                            if (entry.key.sourceBalanceInsufficient)
+                              Padding(
+                                padding: const EdgeInsets.only(top: 4),
+                                child: Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Icon(
+                                      Icons.warning_amber_rounded,
+                                      size: 16,
+                                      color: scheme.error,
+                                    ),
+                                    const SizedBox(width: 4),
+                                    Expanded(
+                                      child: Text(
+                                        '振替元の残高'
+                                        '(${_formatManagementYen(entry.key.sourceAccountBalance!)})'
+                                        'が支払額を下回っています。引落が失敗している'
+                                        '可能性があるため、残高をご確認のうえ操作してください。',
+                                        style:
+                                            theme.textTheme.bodySmall?.copyWith(
+                                          color: scheme.error,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
                           ],
                         ),
                       ),

--- a/lib/services/asset_auto_debit_confirmation_service.dart
+++ b/lib/services/asset_auto_debit_confirmation_service.dart
@@ -1,5 +1,31 @@
 import '../models/asset_liability_workbook.dart';
 
+/// 確認待ちの支払いと、その引落の振替元口座の残高状況。
+///
+/// 振替元の現在残高が支払額を下回っている場合、引落が失敗している(残高不足で
+/// 弾かれた)可能性があるため、ユーザーに早期に気付かせるためのフラグを持つ。
+class AssetAutoDebitConfirmation {
+  /// 確認待ちの支払い行。
+  final AssetLiabilityCashflowRow row;
+
+  /// 引落の振替元口座の現在残高。振替元が未設定、またはスナップショットに
+  /// 該当口座が無く残高を特定できない場合は null。
+  final double? sourceAccountBalance;
+
+  const AssetAutoDebitConfirmation({
+    required this.row,
+    required this.sourceAccountBalance,
+  });
+
+  /// 振替元残高が判明しており、かつ支払額を下回っている = 引落が失敗している可能性。
+  ///
+  /// 残高を特定できない (null) 場合は判定できないため false を返す (過剰警告を避ける)。
+  /// なお現在残高は引落成功後の減算を反映していることもあるため、これは「失敗の確証」
+  /// ではなく「要確認」のヒントであり、UI でもその旨を断定せずに案内する。
+  bool get sourceBalanceInsufficient =>
+      sourceAccountBalance != null && sourceAccountBalance! < row.paymentAmount;
+}
+
 /// 「支払日を過ぎたが、まだ支払済み確認をしていない直接支払い(口座振替など)」を
 /// 抽出する純関数サービス。
 ///
@@ -39,5 +65,36 @@ class AssetAutoDebitConfirmationService {
     return pendingConfirmations(
       workbook,
     ).fold<double>(0, (sum, row) => sum + row.paymentAmount);
+  }
+
+  /// 確認待ち支払いそれぞれに、引落の振替元口座の残高状況を添えて返す。
+  ///
+  /// 振替元口座は `paymentSourceAccountId` でワークブックの口座一覧を引いて残高を
+  /// 特定する。振替元が未設定、または該当口座がスナップショットに無い場合は残高を
+  /// null とし、引落失敗の判定は行わない (= 警告を出さない安全側)。
+  /// 並び順は [pendingConfirmations] と同じ (金額の大きい順)。
+  List<AssetAutoDebitConfirmation> pendingConfirmationDetails(
+    AssetLiabilityWorkbook workbook,
+  ) {
+    final balanceByAccountId = <String, double>{
+      for (final account in workbook.accounts) account.id: account.balance,
+    };
+    final details = pendingConfirmations(workbook).map((row) {
+      final sourceAccountId = row.paymentSourceAccountId;
+      return AssetAutoDebitConfirmation(
+        row: row,
+        sourceAccountBalance: sourceAccountId == null
+            ? null
+            : balanceByAccountId[sourceAccountId],
+      );
+    }).toList();
+    return List<AssetAutoDebitConfirmation>.unmodifiable(details);
+  }
+
+  /// 振替元残高が支払額を下回っている (= 引落が失敗している可能性がある) 確認待ちの件数。
+  int insufficientSourceCount(AssetLiabilityWorkbook workbook) {
+    return pendingConfirmationDetails(
+      workbook,
+    ).where((detail) => detail.sourceBalanceInsufficient).length;
   }
 }

--- a/test/services/asset_auto_debit_confirmation_service_test.dart
+++ b/test/services/asset_auto_debit_confirmation_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/services/asset_auto_debit_confirmation_service.dart';
 import 'package:my_web_app/services/asset_liability_planning_service.dart';
 
@@ -66,6 +67,157 @@ void main() {
         isNot(contains(AssetLiabilityPlanningService.gasBillAccountId)),
       );
       expect(service.pendingTotal(workbook), 0);
+    });
+  });
+
+  group('AssetAutoDebitConfirmationService source balance', () {
+    AssetLiabilityCashflowRow gasDetailRow(
+      List<AssetAutoDebitConfirmation> details,
+    ) {
+      return details
+          .firstWhere(
+            (detail) =>
+                detail.row.accountId ==
+                AssetLiabilityPlanningService.gasBillAccountId,
+          )
+          .row;
+    }
+
+    test('flags pending confirmation when source balance is below amount', () {
+      // 振替元(三井住友銀行大塚支店)残高 3,000 < ガス支払額 4,500 → 引落失敗の可能性。
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 3000},
+        baseDate: DateTime(2026, 6, 15),
+        includeDefaultFixedPayments: true,
+      );
+      final details = service.pendingConfirmationDetails(workbook);
+      final gas = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.gasBillAccountId,
+      );
+
+      expect(gas.sourceAccountBalance, 3000);
+      expect(gas.sourceBalanceInsufficient, isTrue);
+      expect(service.insufficientSourceCount(workbook), 1);
+    });
+
+    test('does not flag when source balance covers the amount', () {
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 63539},
+        baseDate: DateTime(2026, 6, 15),
+        includeDefaultFixedPayments: true,
+      );
+      final details = service.pendingConfirmationDetails(workbook);
+      final gas = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.gasBillAccountId,
+      );
+
+      expect(gas.sourceAccountBalance, 63539);
+      expect(gas.sourceBalanceInsufficient, isFalse);
+      expect(service.insufficientSourceCount(workbook), 0);
+    });
+
+    test('does not flag when source account balance is unknown', () {
+      // 振替元を実在しない口座へ上書き → 残高を特定できないので警告しない(安全側)。
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 3000},
+        baseDate: DateTime(2026, 6, 15),
+        includeDefaultFixedPayments: true,
+        paymentSourceAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.gasBillAccountId: 'ghost_account',
+        },
+      );
+      final details = service.pendingConfirmationDetails(workbook);
+      final gas = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.gasBillAccountId,
+      );
+
+      expect(gas.sourceAccountBalance, isNull);
+      expect(gas.sourceBalanceInsufficient, isFalse);
+      expect(service.insufficientSourceCount(workbook), 0);
+    });
+
+    test('details cover the same rows as pendingConfirmations in order', () {
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 63539},
+        baseDate: DateTime(2026, 6, 15),
+        includeDefaultFixedPayments: true,
+      );
+      final rows = service.pendingConfirmations(workbook);
+      final details = service.pendingConfirmationDetails(workbook);
+
+      expect(details.length, rows.length);
+      for (var i = 0; i < rows.length; i++) {
+        expect(details[i].row.accountId, rows[i].accountId);
+      }
+      expect(
+        gasDetailRow(details).accountId,
+        AssetLiabilityPlanningService.gasBillAccountId,
+      );
+    });
+
+    test('does not flag when source balance equals the amount (strict <)', () {
+      // 残高 4,500 == ガス支払額 4,500 → ちょうど引落できる想定なので警告しない。
+      // sourceBalanceInsufficient が < で定義されている境界を固定する。
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 4500},
+        baseDate: DateTime(2026, 6, 15),
+        includeDefaultFixedPayments: true,
+      );
+      final details = service.pendingConfirmationDetails(workbook);
+      final gas = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.gasBillAccountId,
+      );
+
+      expect(gas.row.paymentAmount, 4500);
+      expect(gas.sourceAccountBalance, 4500);
+      expect(gas.sourceBalanceInsufficient, isFalse);
+      expect(service.insufficientSourceCount(workbook), 0);
+    });
+
+    test('flags only rows whose own source is short among multiple pending',
+        () {
+      // 6/25 時点でガス(12日/4,500/振替元=大塚) と 水道(22日/2,400/振替元=神田へ上書き)
+      // が確認待ち。大塚 3,000 < ガス 4,500 → ガスのみ警告。神田 50,000 >= 水道 2,400 →
+      // 水道は警告しない。各行が「自分の振替元の残高」で判定され、件数がフィルタ後の数
+      // (=1, リストの長さ 2 ではない) であることを担保する。
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '三井住友銀行大塚支店': 3000,
+          '三井住友銀行神田支店': 50000,
+        },
+        baseDate: DateTime(2026, 6, 25),
+        includeDefaultFixedPayments: true,
+        paymentSourceAccountIds: const <String, String>{
+          // '三井住友銀行神田支店' の口座 ID (= 既定の大塚とは別口座)。
+          AssetLiabilityPlanningService.waterBillAccountId: 'smbc_kanda_branch',
+        },
+      );
+      final details = service.pendingConfirmationDetails(workbook);
+      final gas = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.gasBillAccountId,
+      );
+      final water = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.waterBillAccountId,
+      );
+
+      expect(gas.sourceAccountBalance, 3000);
+      expect(gas.sourceBalanceInsufficient, isTrue);
+      // 水道は自分の振替元(神田 50,000)で判定される = 大塚の 3,000 を流用しない。
+      expect(water.sourceAccountBalance, 50000);
+      expect(water.sourceBalanceInsufficient, isFalse);
+      expect(service.insufficientSourceCount(workbook), 1);
     });
   });
 }


### PR DESCRIPTION
## 概要

#3429 で追加した「引落の確認待ち」カードに、**振替元口座の現在残高が支払額を下回っている**確認待ちへ早期警告を表示する。現状は引落の成否を区別せず未払い計上のままで、残高不足で自動振替が失敗していても気付けない。

## 変更

- 純関数 `AssetAutoDebitConfirmation`（`sourceBalanceInsufficient`）と `AssetAutoDebitConfirmationService.pendingConfirmationDetails` / `insufficientSourceCount` を追加。振替元残高は `paymentSourceAccountId` でワークブックの口座一覧から特定する。
- 振替元が不明（未設定／スナップショットに無い）の場合は判定せず警告を出さない安全側。現在残高は引落成功後の減算を反映していることもあるため断定はせず「要確認」のヒントとして案内する。
- 確認カードに振替元残高不足の警告行（⚠ アイコン + 残高 + 案内文）をエントリ単位で表示。
- 単体テスト4件追加（不足で警告／充足で非警告／振替元不明で非警告／並び一致）。

## テスト

- `flutter analyze`（変更3ファイル／プロジェクト lint）= No issues found
- `flutter test test/services/asset_auto_debit_confirmation_service_test.dart` = 7 件 green（既存3 + 新規4）

担当: Claude Code #1

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数とカード描画の追加のみ。振替元残高 < 支払額の警告判定は単体テスト4件（不足／充足／不明／並び）で網羅し、実装詳細に依存しない入出力で検証済みのため integration_test は不要。

High-risk-ultrareview-exception: 純関数とUIカード描画の追加のみで、認証・課金・決済などの高リスク経路や本番設定には触れない。
