### PR TITLE
fix(share): Xシェアの本文が空欄になる問題を修正 (単一textパラメータ化)

### DIFF
--- a/lib/services/grow_together_share.dart
+++ b/lib/services/grow_together_share.dart
@@ -33,17 +33,17 @@ class GrowTogetherShare {
 
   /// X の投稿 intent URL を生成する純関数。
   ///
-  /// host は `twitter.com` を使う（ログイン済みなら x.com の作成画面へ
-  /// リダイレクトされる）。`x.com/intent/tweet` を直接開くと作成画面が
-  /// 描画されず真っ白になる事象が報告されているため、従来から安定して
-  /// 動作する `twitter.com/intent/tweet` を採用する。
+  /// host は `twitter.com`（ログイン済みなら x.com の作成画面へリダイレクト）。
+  /// `x.com/intent/tweet` を直接開くと作成画面が真っ白になる事象がある。
   ///
-  /// `text`（本文）と `url`（リンク）を分けて渡すことで、X が URL を自動で
-  /// t.co 短縮し、本文の文字数超過を避ける。副作用を持たないためテスト容易。
+  /// URL は **`text` パラメータ内に本文と一緒に含める**（別の `url` パラメータは
+  /// 使わない）。`text`+`url` の2パラメータ構成だと、X が full app の作成画面へ
+  /// リダイレクトする際に本文が反映されず空欄になる事象が実機で確認された。
+  /// 本リポジトリの他の共有導線(app_share_service / viral_ad_generator)と同じく
+  /// 単一 `text` 構成にすることで本文が確実に prefill される。
   static Uri buildXIntentUrl() {
     return Uri.https('twitter.com', '/intent/tweet', <String, String>{
-      'text': shareText,
-      'url': appUrl,
+      'text': fullShareMessage,
     });
   }
 

--- a/test/services/grow_together_share_test.dart
+++ b/test/services/grow_together_share_test.dart
@@ -28,8 +28,7 @@ void main() {
       );
     });
 
-    test('buildXIntentUrl puts the full message (incl URL) in a single text '
-        'param', () {
+    test('buildXIntentUrl embeds the URL in a single text param', () {
       final uri = GrowTogetherShare.buildXIntentUrl();
 
       expect(uri.scheme, 'https');
@@ -39,10 +38,7 @@ void main() {
       // リダイレクトで本文が空欄になる事象を避けるため）。
       expect(uri.queryParameters['text'], GrowTogetherShare.fullShareMessage);
       expect(uri.queryParameters.containsKey('url'), isFalse);
-      expect(
-        uri.queryParameters['text'],
-        contains(GrowTogetherShare.appUrl),
-      );
+      expect(uri.queryParameters['text'], contains(GrowTogetherShare.appUrl));
     });
 
     test('buildXIntentUrl percent-encodes newlines and Japanese text', () {

--- a/test/services/grow_together_share_test.dart
+++ b/test/services/grow_together_share_test.dart
@@ -28,15 +28,21 @@ void main() {
       );
     });
 
-    test('buildXIntentUrl targets the X tweet intent with text + url params',
-        () {
+    test('buildXIntentUrl puts the full message (incl URL) in a single text '
+        'param', () {
       final uri = GrowTogetherShare.buildXIntentUrl();
 
       expect(uri.scheme, 'https');
       expect(uri.host, 'twitter.com');
       expect(uri.path, '/intent/tweet');
-      expect(uri.queryParameters['text'], GrowTogetherShare.shareText);
-      expect(uri.queryParameters['url'], GrowTogetherShare.appUrl);
+      // URL は text 内に含める。別の url パラメータは使わない（full app への
+      // リダイレクトで本文が空欄になる事象を避けるため）。
+      expect(uri.queryParameters['text'], GrowTogetherShare.fullShareMessage);
+      expect(uri.queryParameters.containsKey('url'), isFalse);
+      expect(
+        uri.queryParameters['text'],
+        contains(GrowTogetherShare.appUrl),
+      );
     });
 
     test('buildXIntentUrl percent-encodes newlines and Japanese text', () {
@@ -47,7 +53,6 @@ void main() {
       expect(encoded.startsWith('https://twitter.com/intent/tweet?'), isTrue);
       expect(encoded.contains('\n'), isFalse);
       expect(encoded.contains('text='), isTrue);
-      expect(encoded.contains('url='), isTrue);
     });
   });
 }


### PR DESCRIPTION
## 概要

実機報告: 「Xでシェア」を押すと X の作成画面は開くが**本文が空欄**だった。

## 原因 & 検証

直前の修正で host を `twitter.com` にして作成画面は開くようになったが、`text` と `url` を**別パラメータ**で渡していたため、X が full app の作成画面（x.com/intent/post）へリダイレクトする際に本文が反映されず空欄になっていた。本文（URL を末尾に同梱）を**単一の `text` パラメータ**で渡す構成（本リポジトリの `app_share_service` / `viral_ad_generator` と同じ実績ある形）に変更したところ、実機で本文＋URL＋リンクカードが正しく prefill されることを確認済み。

## 修正

- `buildXIntentUrl` を `text`+`url` の2パラメータから、`fullShareMessage`（本文＋改行＋URL）を渡す**単一 `text` パラメータ**へ変更。
- 純関数テストを、url パラメータ非使用・text に URL 同梱を検証する形へ更新。

## Minimal E2E Gate

- 本変更のテストは実装詳細に依存しない入出力契約（black-box）であり、入力（なし）→ 出力（intent URL の host=twitter.com / path / 単一 text パラメータに本文＋URL が含まれること）を最小限の代表3ケースで検証する。
- E2E機構: 外部サイト（X）への遷移を伴うため integration_test / playwright のエンドツーエンド（e2e）テストは追加せず、純関数の単体テストで URL 生成を担保する。
- E2E例外: X の作成画面 prefill は外部サービス依存のため自動E2E不可。URL 生成を純関数テストで検証し、実機目視で確認済み。
