### PR TITLE
feat: a11y semantics for the cashflow forecast and budget cards

### DIFF
--- a/lib/widgets/asset_cashflow_forecast_card.dart
+++ b/lib/widgets/asset_cashflow_forecast_card.dart
@@ -94,9 +94,15 @@ class AssetCashflowForecastCard extends StatelessWidget {
               SizedBox(
                 height: 160,
                 width: double.infinity,
-                child: CustomPaint(
-                  key: const Key('asset_cashflow_forecast_chart'),
-                  painter: _ForecastChartPainter(forecast: forecast),
+                child: Semantics(
+                  label: '将来残高予測グラフ',
+                  value: _chartA11yValue(),
+                  child: ExcludeSemantics(
+                    child: CustomPaint(
+                      key: const Key('asset_cashflow_forecast_chart'),
+                      painter: _ForecastChartPainter(forecast: forecast),
+                    ),
+                  ),
                 ),
               ),
               const SizedBox(height: 10),
@@ -106,6 +112,26 @@ class AssetCashflowForecastCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  /// スクリーンリーダー向けにグラフ内容を文章化する(視覚に依らない要約)。
+  String _chartA11yValue() {
+    final months = forecast.months;
+    final last = months.isEmpty ? null : months.last;
+    final buffer = StringBuffer('今後${months.length}ヶ月の月末残高見込み。');
+    if (last != null) {
+      buffer.write('${_monthLabel(last.month)}末は${_yen(last.closingBalance)}。');
+    }
+    buffer.write('最小見込み残高は${_yen(forecast.worstBalance)}。');
+    final shortfallDate = forecast.firstShortfallDate;
+    if (shortfallDate != null) {
+      buffer.write('${shortfallDate.month}月${shortfallDate.day}日頃に残高不足の見込み。');
+    } else if (forecast.safetyShortfallAmount > 0) {
+      buffer.write('安全余裕を割り込む時期があります。');
+    } else {
+      buffer.write('残高不足の見込みはありません。');
+    }
+    return buffer.toString();
   }
 
   Widget _buildHorizonSelector() {
@@ -207,31 +233,36 @@ class AssetCashflowForecastCard extends StatelessWidget {
     required IconData icon,
     required String message,
   }) {
-    return Container(
-      key: alertKey,
-      width: double.infinity,
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(icon, color: color, size: 18),
-          const SizedBox(width: 6),
-          Expanded(
-            child: Text(
-              message,
-              style: TextStyle(
-                fontSize: 12,
-                height: 1.5,
-                color: color,
-                fontWeight: FontWeight.w700,
+    // liveRegion: 警告の出現/変化をスクリーンリーダーが読み上げる。
+    return Semantics(
+      liveRegion: true,
+      container: true,
+      child: Container(
+        key: alertKey,
+        width: double.infinity,
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: color, size: 18),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Text(
+                message,
+                style: TextStyle(
+                  fontSize: 12,
+                  height: 1.5,
+                  color: color,
+                  fontWeight: FontWeight.w700,
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/asset_category_budget_card.dart
+++ b/lib/widgets/asset_category_budget_card.dart
@@ -104,58 +104,65 @@ class AssetCategoryBudgetCard extends StatelessWidget {
     final value = report.totalBudget > 0
         ? (report.totalActual / report.totalBudget).clamp(0.0, 1.0).toDouble()
         : 0.0;
-    return Container(
-      key: const Key('asset_category_budget_total'),
-      width: double.infinity,
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: (over ? _danger : _accent).withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
+    return Semantics(
+      container: true,
+      liveRegion: over,
+      child: MergeSemantics(
+        child: Container(
+          key: const Key('asset_category_budget_total'),
+          width: double.infinity,
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: (over ? _danger : _accent).withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Expanded(
-                child: Text(
-                  '合計',
-                  style: TextStyle(fontSize: 13, fontWeight: FontWeight.w700),
+              Row(
+                children: [
+                  const Expanded(
+                    child: Text(
+                      '合計',
+                      style:
+                          TextStyle(fontSize: 13, fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                  Text(
+                    '${_yen(report.totalActual)} / ${_yen(report.totalBudget)}',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: over ? _danger : null,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: value,
+                  minHeight: 8,
+                  backgroundColor: _track,
+                  color: over ? _danger : _accent,
                 ),
               ),
+              const SizedBox(height: 4),
               Text(
-                '${_yen(report.totalActual)} / ${_yen(report.totalBudget)}',
+                over
+                    ? '予算を ${_yen(report.totalActual - report.totalBudget)} 超過しています'
+                    : '残り予算 ${_yen(report.totalRemaining)}',
                 style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w700,
-                  color: over ? _danger : null,
+                  fontSize: 12,
+                  height: 1.4,
+                  color: over ? _danger : _muted,
+                  fontWeight: FontWeight.w600,
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 6),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: LinearProgressIndicator(
-              value: value,
-              minHeight: 8,
-              backgroundColor: _track,
-              color: over ? _danger : _accent,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            over
-                ? '予算を ${_yen(report.totalActual - report.totalBudget)} 超過しています'
-                : '残り予算 ${_yen(report.totalRemaining)}',
-            style: TextStyle(
-              fontSize: 12,
-              height: 1.4,
-              color: over ? _danger : _muted,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }
@@ -163,62 +170,64 @@ class AssetCategoryBudgetCard extends StatelessWidget {
   Widget _buildCategoryRow(CategoryBudgetRow row) {
     final ratio = row.ratio;
     final over = row.isOver;
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 10),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              if (over) ...[
-                const Icon(Icons.warning_amber, color: _danger, size: 14),
-                const SizedBox(width: 3),
-              ],
-              Expanded(
-                child: Text(
-                  row.category,
-                  style: const TextStyle(
-                    fontSize: 13,
-                    fontWeight: FontWeight.w700,
+    return MergeSemantics(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                if (over) ...[
+                  const Icon(Icons.warning_amber, color: _danger, size: 14),
+                  const SizedBox(width: 3),
+                ],
+                Expanded(
+                  child: Text(
+                    row.category,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
                 ),
+                Text(
+                  row.hasBudget
+                      ? '${_yen(row.actual)} / ${_yen(row.budget)}'
+                      : '${_yen(row.actual)}(予算未設定)',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: over ? _danger : _muted,
+                  ),
+                ),
+              ],
+            ),
+            if (ratio != null) ...[
+              const SizedBox(height: 4),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: ratio.clamp(0.0, 1.0).toDouble(),
+                  minHeight: 6,
+                  backgroundColor: _track,
+                  color: over ? _danger : _accent,
+                ),
               ),
+              const SizedBox(height: 2),
               Text(
-                row.hasBudget
-                    ? '${_yen(row.actual)} / ${_yen(row.budget)}'
-                    : '${_yen(row.actual)}(予算未設定)',
+                over
+                    ? '予算を ${_yen(-row.remaining)} 超過'
+                    : '残り ${_yen(row.remaining)}',
                 style: TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
+                  fontSize: 11,
+                  height: 1.4,
                   color: over ? _danger : _muted,
                 ),
               ),
             ],
-          ),
-          if (ratio != null) ...[
-            const SizedBox(height: 4),
-            ClipRRect(
-              borderRadius: BorderRadius.circular(4),
-              child: LinearProgressIndicator(
-                value: ratio.clamp(0.0, 1.0).toDouble(),
-                minHeight: 6,
-                backgroundColor: _track,
-                color: over ? _danger : _accent,
-              ),
-            ),
-            const SizedBox(height: 2),
-            Text(
-              over
-                  ? '予算を ${_yen(-row.remaining)} 超過'
-                  : '残り ${_yen(row.remaining)}',
-              style: TextStyle(
-                fontSize: 11,
-                height: 1.4,
-                color: over ? _danger : _muted,
-              ),
-            ),
           ],
-        ],
+        ),
       ),
     );
   }

--- a/test/widgets/asset_cashflow_forecast_card_test.dart
+++ b/test/widgets/asset_cashflow_forecast_card_test.dart
@@ -175,5 +175,28 @@ void main() {
 
       expect(tapped, isTrue);
     });
+
+    testWidgets('exposes a live-region alert and a labelled chart for a11y', (
+      tester,
+    ) async {
+      await _pump(tester, _shortfallForecast());
+
+      // 警告は liveRegion(出現/変化をスクリーンリーダーが読み上げる)。
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics && (widget.properties.liveRegion ?? false),
+        ),
+        findsWidgets,
+      );
+      // グラフは視覚に依らない label/value を持つ。
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics && widget.properties.label == '将来残高予測グラフ',
+        ),
+        findsOneWidget,
+      );
+    });
   });
 }

--- a/test/widgets/asset_category_budget_card_test.dart
+++ b/test/widgets/asset_category_budget_card_test.dart
@@ -79,5 +79,27 @@ void main() {
 
       expect(tapped, isTrue);
     });
+
+    testWidgets('marks the over-budget total as a live region for a11y', (
+      tester,
+    ) async {
+      final report = AssetCategoryBudgetService.build(
+        actualByCategory: <String, double>{'食費': 60000},
+        budgets: <String, double>{'食費': 50000},
+      );
+
+      await _pump(tester, report);
+
+      // 予算超過の合計は liveRegion(変化をスクリーンリーダーが読み上げる)。
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics && (widget.properties.liveRegion ?? false),
+        ),
+        findsWidgets,
+      );
+      // 各行は MergeSemantics で1ノードに統合(断片的な読み上げを防ぐ)。
+      expect(find.byType(MergeSemantics), findsWidgets);
+    });
   });
 }


### PR DESCRIPTION
## What & why

Extends the automated accessibility coverage to the two new asset cards
(cashflow forecast, category budget) so the manual screen-reader surface in
`docs/ACCESSIBILITY_QA_CHECKLIST.md` is smaller. Same Semantics contract the
CFO experiment graphs already use. The real screen-reader walkthrough still
needs a human; this only widens the automated contract.

## Changes

- Forecast card: the shortfall / safety-breach alert is wrapped in a live
  region, and the chart gets a non-visual Semantics label + value.
- Budget card: the over-budget total is a live region; each total / category
  row is merged into one Semantics node for a single clean announcement.
- Widget tests assert the live region and chart label via Semantics predicates.

## Minimal E2E Gate

- Implementation-detail independent: the tests assert user-visible a11y output
  (a live region exists, the chart exposes a label), not private internals.
- Minimal scope: about 3 cases (live-region alert present, chart label present,
  merged row nodes present).
- E2E: covered black-box via widget tests; no page-level integration_test /
  Playwright e2e is added here (see exception).
- E2E-Exception: the cards are exercised by widget tests; the full page is
  auth-gated, and a real screen-reader pass is an inherently manual check.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: a11y-only widget change (Semantics live
  region + labels) with widget tests; no high-risk path touched, review owned
  by Claude Code #1.
