### PR TITLE
fix: make the forecast chart and alert reliably readable by screen readers

### DIFF
--- a/lib/widgets/asset_cashflow_forecast_card.dart
+++ b/lib/widgets/asset_cashflow_forecast_card.dart
@@ -94,9 +94,12 @@ class AssetCashflowForecastCard extends StatelessWidget {
               SizedBox(
                 height: 160,
                 width: double.infinity,
+                // image + container + 単一 label で graphic として確実に読ませる
+                // (Flutter Web の role=img の alt として全文を読み上げ)。
                 child: Semantics(
-                  label: '将来残高予測グラフ',
-                  value: _chartA11yValue(),
+                  container: true,
+                  image: true,
+                  label: '将来残高予測グラフ。${_chartA11yValue()}',
                   child: ExcludeSemantics(
                     child: CustomPaint(
                       key: const Key('asset_cashflow_forecast_chart'),
@@ -233,35 +236,39 @@ class AssetCashflowForecastCard extends StatelessWidget {
     required IconData icon,
     required String message,
   }) {
-    // liveRegion: 警告の出現/変化をスクリーンリーダーが読み上げる。
+    // liveRegion + 明示 label: 警告の出現/変化を本文そのままで読み上げる
+    // (内側 Text は ExcludeSemantics で重複排除し、アナウンス内容を固定)。
     return Semantics(
       liveRegion: true,
       container: true,
-      child: Container(
-        key: alertKey,
-        width: double.infinity,
-        padding: const EdgeInsets.all(10),
-        decoration: BoxDecoration(
-          color: color.withValues(alpha: 0.08),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(icon, color: color, size: 18),
-            const SizedBox(width: 6),
-            Expanded(
-              child: Text(
-                message,
-                style: TextStyle(
-                  fontSize: 12,
-                  height: 1.5,
-                  color: color,
-                  fontWeight: FontWeight.w700,
+      label: message,
+      child: ExcludeSemantics(
+        child: Container(
+          key: alertKey,
+          width: double.infinity,
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.08),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(icon, color: color, size: 18),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  message,
+                  style: TextStyle(
+                    fontSize: 12,
+                    height: 1.5,
+                    color: color,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/test/widgets/asset_cashflow_forecast_card_test.dart
+++ b/test/widgets/asset_cashflow_forecast_card_test.dart
@@ -181,19 +181,23 @@ void main() {
     ) async {
       await _pump(tester, _shortfallForecast());
 
-      // 警告は liveRegion(出現/変化をスクリーンリーダーが読み上げる)。
+      // 警告は liveRegion かつ本文を label に持つ(出現/変化を読み上げる)。
       expect(
         find.byWidgetPredicate(
           (widget) =>
-              widget is Semantics && (widget.properties.liveRegion ?? false),
+              widget is Semantics &&
+              (widget.properties.liveRegion ?? false) &&
+              (widget.properties.label ?? '').contains('残高が不足'),
         ),
-        findsWidgets,
+        findsOneWidget,
       );
-      // グラフは視覚に依らない label/value を持つ。
+      // グラフは graphic(image)ロール + 要約を含む単一 label を持つ。
       expect(
         find.byWidgetPredicate(
           (widget) =>
-              widget is Semantics && widget.properties.label == '将来残高予測グラフ',
+              widget is Semantics &&
+              (widget.properties.image ?? false) &&
+              (widget.properties.label ?? '').startsWith('将来残高予測グラフ'),
         ),
         findsOneWidget,
       );


### PR DESCRIPTION
## What & why

Real-device NVDA testing of the cashflow forecast card found the chart was not
announced. A bare `Semantics(label, value)` over a `CustomPaint` can collapse on
Flutter web, and a live region that relies on a child `Text` is not reliably
announced. This makes both robust.

## Changes

- Chart: give the Semantics a graphic role (`image: true`) + `container: true`
  and fold the summary into a single `label`, so Flutter web exposes it as a
  role=img element whose alt text NVDA reads in browse mode.
- Alert: put the message on the Semantics `label` and `ExcludeSemantics` the
  inner `Text`, so the live region announces the exact warning text on
  appear/change.
- Widget test updated to assert the image role + label prefix and the
  live-region label.

The budget card rows keep the existing MergeSemantics pattern (reads the visible
text); this change is scoped to the chart/alert that real testing flagged.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible a11y output
  (a graphic-role labelled chart, a live-region labelled alert), not internals.
- Minimal scope: about 3 cases (chart role+label, live-region label, no
  regression of the existing card content).
- E2E: covered black-box via widget tests; the full page is behind login and a
  real screen-reader pass is an inherently manual check (see exception).
- E2E-Exception: a11y-only widget refinement covered by widget tests; the real
  AT voice check is a documented manual step.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: a11y-only widget change (Semantics roles /
  labels) with widget tests; no high-risk path touched, review owned by Claude
  Code #1.
