### PR TITLE
feat: 更新バナーを起動直後と前面復帰時にも確認して反映漏れを防止

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -443,7 +443,7 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
   final _navigatorKey = GlobalKey<NavigatorState>();
   final _versionCheckService = VersionCheckService();
@@ -452,13 +452,23 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _versionCheckService.startPolling(() {
       if (mounted) setState(() => _showUpdateBanner = true);
     });
   }
 
   @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // 背面のタブに復帰した時に再確認 (バックグラウンド中にデプロイされた場合を検知)。
+    if (state == AppLifecycleState.resumed) {
+      unawaited(_versionCheckService.checkNow());
+    }
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _versionCheckService.dispose();
     super.dispose();
   }

--- a/lib/services/version_check_service.dart
+++ b/lib/services/version_check_service.dart
@@ -9,6 +9,8 @@ import '../core/app_version.dart';
 class VersionCheckService {
   static const Duration _pollInterval = Duration(minutes: 30);
   Timer? _timer;
+  VoidCallback? _onOutdated;
+  bool _checking = false;
 
   Future<String?> fetchLatestVersion() async {
     final uri = Uri.parse(
@@ -38,17 +40,38 @@ class VersionCheckService {
     return false;
   }
 
-  void startPolling(VoidCallback onOutdated) {
-    if (!kIsWeb) return;
-    _timer = Timer.periodic(_pollInterval, (_) async {
+  /// 最新バージョンを一度だけ確認し、現在より新しければ [onOutdated] を呼ぶ。
+  ///
+  /// [onOutdated] を省略すると [startPolling] で登録したコールバックを使う。
+  /// アプリ起動直後や前面復帰時に呼び、デプロイ直後に開いた場合や旧バンドルが
+  /// HTTP キャッシュから配信された場合 (= 起動時点で既に古い) を即座に検知する。
+  /// 30 分間隔のポーリングを待たずに更新を促せる。
+  Future<void> checkNow([VoidCallback? onOutdated]) async {
+    if (!kIsWeb || AppVersion.isDev) return;
+    final callback = onOutdated ?? _onOutdated;
+    if (callback == null || _checking) return;
+    _checking = true;
+    try {
       final latest = await fetchLatestVersion();
-      if (latest != null &&
-          !AppVersion.isDev &&
-          isOutdated(AppVersion.value, latest)) {
-        onOutdated();
+      if (latest != null && isOutdated(AppVersion.value, latest)) {
+        callback();
       }
-    });
+    } finally {
+      _checking = false;
+    }
   }
 
-  void dispose() => _timer?.cancel();
+  void startPolling(VoidCallback onOutdated) {
+    if (!kIsWeb) return;
+    _onOutdated = onOutdated;
+    // 起動直後に一度確認 (デプロイ直後に開いた / 旧バンドルが配信された場合を即検知)。
+    unawaited(checkNow(onOutdated));
+    _timer = Timer.periodic(_pollInterval, (_) => unawaited(checkNow()));
+  }
+
+  void dispose() {
+    _timer?.cancel();
+    _timer = null;
+    _onOutdated = null;
+  }
 }

--- a/test/services/version_check_service_test.dart
+++ b/test/services/version_check_service_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/version_check_service.dart';
+
+void main() {
+  final service = VersionCheckService();
+
+  group('VersionCheckService.isOutdated', () {
+    test('newer patch version is outdated', () {
+      expect(service.isOutdated('1.0.1728', '1.0.1729'), isTrue);
+    });
+
+    test('identical version is not outdated', () {
+      expect(service.isOutdated('1.0.1728', '1.0.1728'), isFalse);
+    });
+
+    test('older latest is not outdated (no downgrade prompt)', () {
+      expect(service.isOutdated('1.0.1729', '1.0.1728'), isFalse);
+    });
+
+    test('newer minor or major is outdated', () {
+      expect(service.isOutdated('1.0.9', '1.1.0'), isTrue);
+      expect(service.isOutdated('1.9.9', '2.0.0'), isTrue);
+    });
+
+    test('higher major dominates a much higher patch', () {
+      // current major 2 > latest major 1, so not outdated despite latest patch.
+      expect(service.isOutdated('2.0.0', '1.0.9999'), isFalse);
+    });
+
+    test('missing trailing segment is treated as zero', () {
+      expect(service.isOutdated('1.0', '1.0.1'), isTrue);
+      expect(service.isOutdated('1.0.1', '1.0'), isFalse);
+    });
+
+    test('non-numeric segment is treated as zero without crashing', () {
+      expect(service.isOutdated('1.0.x', '1.0.1'), isTrue);
+      expect(service.isOutdated('1.0.1', '1.0.x'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

既存の更新バナー（`UpdateBanner` + `VersionCheckService`）は **30分間隔のポーリングのみ** で確認していたため、リリース直後にアプリを開いた場合や、旧バンドルが HTTP キャッシュから配信された場合に、最大30分間「更新あり」を検知できず stale な画面が表示されていた（先日のガス代が反映されなかった主因）。**起動直後と前面復帰時にも確認**するよう拡張する。

## 変更

- `VersionCheckService.checkNow([onOutdated])` を追加（一度だけ確認・多重実行ガード `_checking`・`kIsWeb`/`isDev` ガード）。`startPolling` は登録コールバックを保持し、**起動直後に即時 `checkNow` を実行**してから30分ポーリングを開始。
- `main.dart` の `_MyAppState` を `WidgetsBindingObserver` 化し、`AppLifecycleState.resumed`（タブ復帰）で `checkNow` を再実行。`dispose` で observer を解除。
- `isOutdated` の単体テスト7件を新規追加（semver 比較／等値・降格なし・桁不足・非数値）。

## テスト

- `flutter analyze`（変更3ファイル／プロジェクト lint）= No issues found
- `flutter test test/services/version_check_service_test.dart` = 7 件 green

担当: Claude Code #1

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 既存バナーの確認契機を起動時／復帰時へ広げる変更で、判定ロジック isOutdated を単体テスト7件で網羅。バナー UI 自体は既存・無変更。実装詳細に依存しない入出力で検証済みのため integration_test は不要。

High-risk-ultrareview-exception: 純粋なバージョン比較とライフサイクル配線の追加のみで、認証・課金・決済などの高リスク経路や本番設定には触れない。
