### PR TITLE
feat: 定期固定費のデータ駆動モデルと資金繰り計上を追加 (UI登録の土台)

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -260,6 +260,138 @@ class AssetLiabilityRevolvingCreditConfig {
   }
 }
 
+/// 定期固定費の発生周期。
+enum AssetRecurringFixedCostCadence {
+  /// 毎月。
+  monthly,
+
+  /// 隔月 (偶数月のみ / 例: 水道代)。
+  bimonthlyEvenMonth,
+
+  /// 隔月 (奇数月のみ)。
+  bimonthlyOddMonth,
+}
+
+/// UI から登録できる定期固定費 (家賃・光熱費・通信費など毎月/隔月の口座振替)。
+///
+/// ハードコードされた既定固定費 (家賃/KDDI/水道/ガス) と同様に、資金繰りへ
+/// 「全額支払いの負債 (utility)」として計上される。`buildWorkbook` の
+/// `recurringFixedCosts` で渡し、`asset_pref_mirror` で端末間同期する。
+/// 保存形は `{id: {name, amount, paymentDay, cadence, sourceAccountId}}`。
+class AssetRecurringFixedCost {
+  /// 安定した一意 ID (編集・削除のキー)。
+  final String id;
+
+  /// 表示名 (例: 電気代)。
+  final String name;
+
+  /// 月額の概算 (今月分は手入力の支払額上書きで変更可)。
+  final double amount;
+
+  /// 振替日 (1-31)。
+  final int paymentDay;
+
+  /// 発生周期 (毎月 / 隔月偶数月 / 隔月奇数月)。
+  final AssetRecurringFixedCostCadence cadence;
+
+  /// 引落の振替元口座 ID (任意)。
+  final String? sourceAccountId;
+
+  const AssetRecurringFixedCost({
+    required this.id,
+    required this.name,
+    required this.amount,
+    required this.paymentDay,
+    this.cadence = AssetRecurringFixedCostCadence.monthly,
+    this.sourceAccountId,
+  });
+
+  /// 指定した月 (1-12) にこの固定費が発生するか (隔月は偶数/奇数月のみ計上)。
+  bool appliesToMonth(int month) {
+    switch (cadence) {
+      case AssetRecurringFixedCostCadence.monthly:
+        return true;
+      case AssetRecurringFixedCostCadence.bimonthlyEvenMonth:
+        return month.isEven;
+      case AssetRecurringFixedCostCadence.bimonthlyOddMonth:
+        return month.isOdd;
+    }
+  }
+
+  AssetRecurringFixedCost copyWith({
+    String? id,
+    String? name,
+    double? amount,
+    int? paymentDay,
+    AssetRecurringFixedCostCadence? cadence,
+    String? sourceAccountId,
+    bool clearSourceAccountId = false,
+  }) {
+    return AssetRecurringFixedCost(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      amount: amount ?? this.amount,
+      paymentDay: paymentDay ?? this.paymentDay,
+      cadence: cadence ?? this.cadence,
+      sourceAccountId: clearSourceAccountId
+          ? null
+          : (sourceAccountId ?? this.sourceAccountId),
+    );
+  }
+
+  /// ID をキーにする保存形のため、JSON には id を含めない。
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'name': name,
+      'amount': amount,
+      'paymentDay': paymentDay,
+      'cadence': cadence.name,
+      if (sourceAccountId != null && sourceAccountId!.isNotEmpty)
+        'sourceAccountId': sourceAccountId,
+    };
+  }
+
+  /// 不正な値 (空名 / 金額<=0 / 振替日範囲外) は null を返す寛容なパース。
+  static AssetRecurringFixedCost? fromJson(
+    String id,
+    Map<String, dynamic> json,
+  ) {
+    final trimmedId = id.trim();
+    if (trimmedId.isEmpty) {
+      return null;
+    }
+    final name = json['name']?.toString().trim() ?? '';
+    if (name.isEmpty) {
+      return null;
+    }
+    final amount = (json['amount'] as num?)?.toDouble() ??
+        double.tryParse(json['amount']?.toString() ?? '');
+    if (amount == null || amount <= 0) {
+      return null;
+    }
+    final paymentDay = (json['paymentDay'] as num?)?.toInt() ??
+        int.tryParse(json['paymentDay']?.toString() ?? '');
+    if (paymentDay == null || paymentDay < 1 || paymentDay > 31) {
+      return null;
+    }
+    final cadenceName = json['cadence']?.toString();
+    final cadence = AssetRecurringFixedCostCadence.values.firstWhere(
+      (value) => value.name == cadenceName,
+      orElse: () => AssetRecurringFixedCostCadence.monthly,
+    );
+    final rawSource = json['sourceAccountId']?.toString().trim();
+    return AssetRecurringFixedCost(
+      id: trimmedId,
+      name: name,
+      amount: amount,
+      paymentDay: paymentDay,
+      cadence: cadence,
+      sourceAccountId:
+          rawSource == null || rawSource.isEmpty ? null : rawSource,
+    );
+  }
+}
+
 /// リボ残高に対して算出した今月の請求内訳。
 class AssetLiabilityRevolvingCreditBilling {
   /// リボ残高 (= 当月時点の負債残高)。

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -109,6 +109,8 @@ class AssetLiabilityPlanningService {
         const <AssetLiabilityTransferTask>[],
     List<AssetLiabilityCardStatementLine> cardStatementLines =
         const <AssetLiabilityCardStatementLine>[],
+    List<AssetRecurringFixedCost> recurringFixedCosts =
+        const <AssetRecurringFixedCost>[],
     bool includeDefaultFixedPayments = false,
   }) {
     final shouldIncludeDefaultKddiProvider =
@@ -154,6 +156,27 @@ class AssetLiabilityPlanningService {
         )
         .toList()
       ..sort(_compareAccounts);
+    // UI 登録の定期固定費を負債 (全額支払いの utility) として計上する。既定固定費
+    // (家賃/KDDI/水道/ガス) と同じ扱いで、当月に該当する周期かつ同名/同IDの口座が
+    // まだ無いものだけを追加する (手動計上や既定との二重計上を防ぐ)。
+    final injectedFixedCosts = _buildRecurringFixedCostInjections(
+      recurringFixedCosts: recurringFixedCosts,
+      existingAccounts: accounts,
+      baseDate: baseDate,
+    );
+    if (injectedFixedCosts.isNotEmpty) {
+      accounts
+        ..addAll(injectedFixedCosts.map((injected) => injected.account))
+        ..sort(_compareAccounts);
+      // 利用者が金額を入力済み = 推定ではない (請求確認待ちにしない)。今月の手入力
+      // 上書きがある場合はそれを優先する。
+      for (final injected in injectedFixedCosts) {
+        effectiveMonthlyPaymentOverrides.putIfAbsent(
+          injected.account.id,
+          () => injected.account.balance.abs(),
+        );
+      }
+    }
     final accountsById = <String, AssetLiabilityAccount>{
       for (final account in accounts) account.id: account,
     };
@@ -177,6 +200,11 @@ class AssetLiabilityPlanningService {
         waterBillAccountId: smbcOtsukaBranchAccountId,
       if (shouldIncludeDefaultGasBill)
         gasBillAccountId: smbcOtsukaBranchAccountId,
+      // UI 登録の定期固定費の振替元 (任意 / ユーザー個別設定があれば下で上書き)。
+      for (final injected in injectedFixedCosts)
+        if (injected.sourceAccountId != null &&
+            injected.sourceAccountId!.isNotEmpty)
+          injected.account.id: injected.sourceAccountId!,
       ...defaultPaymentSourceAccountIds,
       ...paymentSourceAccountIds,
     };
@@ -1760,6 +1788,53 @@ class AssetLiabilityPlanningService {
     }
 
     return _fallbackAccountId(name);
+  }
+
+  /// UI 登録の定期固定費を、計上対象の負債口座 (+ 振替元口座 ID) へ変換する。
+  ///
+  /// 当月に該当する周期 (毎月/隔月) かつ金額>0 で、まだ同名/同IDの口座が無いものだけ
+  /// を返す。`_liability` 経由で既定固定費 (水道/ガス) と同じ全額支払いの utility 負債
+  /// として作る。振替元は呼び出し側で `effectivePaymentSourceAccountIds` に反映する。
+  List<({AssetLiabilityAccount account, String? sourceAccountId})>
+      _buildRecurringFixedCostInjections({
+    required List<AssetRecurringFixedCost> recurringFixedCosts,
+    required List<AssetLiabilityAccount> existingAccounts,
+    required DateTime baseDate,
+  }) {
+    if (recurringFixedCosts.isEmpty) {
+      return const <({
+        AssetLiabilityAccount account,
+        String? sourceAccountId
+      })>[];
+    }
+    final takenIds = existingAccounts.map((account) => account.id).toSet();
+    final takenNames =
+        existingAccounts.map((account) => _normalize(account.name)).toSet();
+    final result =
+        <({AssetLiabilityAccount account, String? sourceAccountId})>[];
+    for (final cost in recurringFixedCosts) {
+      if (cost.amount <= 0 || !cost.appliesToMonth(baseDate.month)) {
+        continue;
+      }
+      final account = _liability(
+        name: cost.name,
+        balance: -cost.amount,
+        kind: AssetLiabilityAccountKind.utility,
+        paymentDay: cost.paymentDay,
+        annualRate: 0,
+        minimumPaymentRate: 1,
+        minimumPaymentFloor: cost.amount,
+        fullPaymentEstimate: true,
+      );
+      if (takenIds.contains(account.id) ||
+          takenNames.contains(_normalize(account.name))) {
+        continue;
+      }
+      takenIds.add(account.id);
+      takenNames.add(_normalize(account.name));
+      result.add((account: account, sourceAccountId: cost.sourceAccountId));
+    }
+    return result;
   }
 
   Map<String, double> _withDefaultFixedPayments(

--- a/lib/services/asset_recurring_fixed_cost_store.dart
+++ b/lib/services/asset_recurring_fixed_cost_store.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/asset_liability_workbook.dart';
+
+/// UI から登録した定期固定費 (家賃・光熱費・通信費など) を永続化する。
+///
+/// ローカル (SharedPreferences) を一次ストアとし、端末間同期は資産管理ページが
+/// `asset_pref_mirror` (pref_key: `recurring_fixed_costs`) へ 1 行 jsonb で
+/// ミラーする (リボ払い設定と同じ集約方針 / MIRROR_PREF_SCHEMA.md)。
+/// [encodeMirrorValue] / [decodeMirrorValue] がローカルとミラー双方で使う
+/// 共通の往復ロジックで、保存形は `{id: {name, amount, paymentDay, cadence,
+/// sourceAccountId}}`。読み出しは振替日昇順 (同日は名前順) に整える。
+class AssetRecurringFixedCostStore {
+  static const String prefsKey = 'asset_recurring_fixed_costs_v1';
+
+  const AssetRecurringFixedCostStore();
+
+  Future<List<AssetRecurringFixedCost>> load({
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getString(prefsKey);
+    if (raw == null || raw.isEmpty) {
+      return const <AssetRecurringFixedCost>[];
+    }
+    try {
+      return decodeMirrorValue(jsonDecode(raw));
+    } catch (_) {
+      return const <AssetRecurringFixedCost>[];
+    }
+  }
+
+  Future<void> save(
+    List<AssetRecurringFixedCost> costs, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    if (costs.isEmpty) {
+      await store.remove(prefsKey);
+      return;
+    }
+    await store.setString(prefsKey, jsonEncode(encodeMirrorValue(costs)));
+  }
+
+  /// リストを `asset_pref_mirror.value` (jsonb) 形 `{id: {...}}` へ変換する。
+  /// ローカル永続化とサーバミラーで同一形を使う。
+  static Map<String, dynamic> encodeMirrorValue(
+    List<AssetRecurringFixedCost> costs,
+  ) {
+    return <String, dynamic>{
+      for (final cost in costs) cost.id: cost.toJson(),
+    };
+  }
+
+  /// `asset_pref_mirror.value` (jsonb) または保存済み JSON からリストへ復元する。
+  /// 不正なキー/値は黙って捨てる寛容なパース (前方/後方互換)。
+  /// 並びは振替日昇順 → 名前順で安定化する。
+  static List<AssetRecurringFixedCost> decodeMirrorValue(dynamic value) {
+    final result = <AssetRecurringFixedCost>[];
+    if (value is! Map) {
+      return result;
+    }
+    value.forEach((dynamic key, dynamic raw) {
+      if (key is String && raw is Map) {
+        final cost = AssetRecurringFixedCost.fromJson(
+          key,
+          Map<String, dynamic>.from(raw),
+        );
+        if (cost != null) {
+          result.add(cost);
+        }
+      }
+    });
+    result.sort((a, b) {
+      final byDay = a.paymentDay.compareTo(b.paymentDay);
+      if (byDay != 0) {
+        return byDay;
+      }
+      return a.name.compareTo(b.name);
+    });
+    return result;
+  }
+}

--- a/test/services/asset_recurring_fixed_cost_injection_test.dart
+++ b/test/services/asset_recurring_fixed_cost_injection_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  const planning = AssetLiabilityPlanningService();
+
+  AssetLiabilityDebtRow? debtRowByName(
+    AssetLiabilityWorkbook workbook,
+    String name,
+  ) {
+    for (final row in workbook.debtMasterRows) {
+      if (row.name == name) {
+        return row;
+      }
+    }
+    return null;
+  }
+
+  group('buildWorkbook recurringFixedCosts injection', () {
+    test('monthly fixed cost is counted as a full-payment direct liability',
+        () {
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'みずほ銀行': 100000},
+        baseDate: DateTime(2026, 6, 15),
+        recurringFixedCosts: const <AssetRecurringFixedCost>[
+          AssetRecurringFixedCost(
+            id: 'fc_denki',
+            name: '電気代',
+            amount: 8000,
+            paymentDay: 27,
+          ),
+        ],
+      );
+
+      final row = debtRowByName(workbook, '電気代');
+      expect(row, isNotNull);
+      expect(row!.kind, AssetLiabilityAccountKind.utility);
+      expect(row.scheduledPaymentAmount, 8000);
+      expect(row.paymentDay, 27);
+      expect(row.isDirectCashflowTarget, isTrue);
+      expect(row.fullPaymentEstimate, isTrue);
+      // 金額を入力済み = 推定ではない → 請求確認待ちにならない。
+      expect(row.paymentAmountEstimated, isFalse);
+      expect(workbook.liabilityTotal, -8000);
+      expect(
+        workbook.hasBillingConfirmationPendingRows,
+        isFalse,
+      );
+    });
+
+    test('empty list leaves the workbook unchanged', () {
+      const snapshot = <String, double>{'みずほ銀行': 100000, '楽天カード': -30000};
+      final baseline = planning.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 6, 15),
+      );
+      final withEmpty = planning.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 6, 15),
+        recurringFixedCosts: const <AssetRecurringFixedCost>[],
+      );
+      expect(withEmpty.liabilityTotal, baseline.liabilityTotal);
+      expect(
+        withEmpty.debtMasterRows.length,
+        baseline.debtMasterRows.length,
+      );
+    });
+
+    test('bimonthly cost only appears in matching months', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'fc_chonaikai',
+        name: '町内会費',
+        amount: 1000,
+        paymentDay: 10,
+        cadence: AssetRecurringFixedCostCadence.bimonthlyEvenMonth,
+      );
+      final june = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'みずほ銀行': 100000},
+        baseDate: DateTime(2026, 6, 15),
+        recurringFixedCosts: const <AssetRecurringFixedCost>[cost],
+      );
+      final july = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'みずほ銀行': 100000},
+        baseDate: DateTime(2026, 7, 15),
+        recurringFixedCosts: const <AssetRecurringFixedCost>[cost],
+      );
+
+      expect(debtRowByName(june, '町内会費'), isNotNull);
+      expect(debtRowByName(july, '町内会費'), isNull);
+    });
+
+    test('does not double-count when a same-named liability already exists',
+        () {
+      final workbook = planning.buildWorkbook(
+        // ユーザーが既に「電気代」を負債として手動計上している。
+        latestSnapshot: const <String, double>{
+          'みずほ銀行': 100000,
+          '電気代': -5000,
+        },
+        baseDate: DateTime(2026, 6, 15),
+        recurringFixedCosts: const <AssetRecurringFixedCost>[
+          AssetRecurringFixedCost(
+            id: 'fc_denki',
+            name: '電気代',
+            amount: 8000,
+            paymentDay: 27,
+          ),
+        ],
+      );
+
+      final denki =
+          workbook.debtMasterRows.where((row) => row.name == '電気代').toList();
+      expect(denki.length, 1);
+      // 既存の手動計上 (-5000) が優先され、固定費 (8000) は二重計上されない。
+      expect(workbook.liabilityTotal, -5000);
+    });
+
+    test('source account id flows to the debt row', () {
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'みずほ銀行': 100000},
+        baseDate: DateTime(2026, 6, 15),
+        recurringFixedCosts: const <AssetRecurringFixedCost>[
+          AssetRecurringFixedCost(
+            id: 'fc_denki',
+            name: '電気代',
+            amount: 8000,
+            paymentDay: 27,
+            sourceAccountId: 'smbc_otsuka_branch',
+          ),
+        ],
+      );
+
+      final row = debtRowByName(workbook, '電気代');
+      expect(row, isNotNull);
+      expect(row!.paymentSourceAccountId, 'smbc_otsuka_branch');
+    });
+  });
+}

--- a/test/services/asset_recurring_fixed_cost_store_test.dart
+++ b/test/services/asset_recurring_fixed_cost_store_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AssetRecurringFixedCost model', () {
+    test('appliesToMonth respects cadence', () {
+      const monthly = AssetRecurringFixedCost(
+        id: 'a',
+        name: '電気代',
+        amount: 8000,
+        paymentDay: 27,
+      );
+      const evenMonth = AssetRecurringFixedCost(
+        id: 'b',
+        name: '町内会費',
+        amount: 1000,
+        paymentDay: 10,
+        cadence: AssetRecurringFixedCostCadence.bimonthlyEvenMonth,
+      );
+      const oddMonth = AssetRecurringFixedCost(
+        id: 'c',
+        name: '雑誌購読',
+        amount: 1200,
+        paymentDay: 5,
+        cadence: AssetRecurringFixedCostCadence.bimonthlyOddMonth,
+      );
+
+      expect(monthly.appliesToMonth(6), isTrue);
+      expect(monthly.appliesToMonth(7), isTrue);
+      expect(evenMonth.appliesToMonth(6), isTrue);
+      expect(evenMonth.appliesToMonth(7), isFalse);
+      expect(oddMonth.appliesToMonth(6), isFalse);
+      expect(oddMonth.appliesToMonth(7), isTrue);
+    });
+
+    test('fromJson rejects invalid values (lenient)', () {
+      expect(AssetRecurringFixedCost.fromJson('', _validJson()), isNull);
+      expect(
+        AssetRecurringFixedCost.fromJson('x', {..._validJson(), 'name': ' '}),
+        isNull,
+      );
+      expect(
+        AssetRecurringFixedCost.fromJson('x', {..._validJson(), 'amount': 0}),
+        isNull,
+      );
+      expect(
+        AssetRecurringFixedCost.fromJson(
+          'x',
+          {..._validJson(), 'paymentDay': 32},
+        ),
+        isNull,
+      );
+      // 未知の cadence は monthly にフォールバック。
+      final fallback = AssetRecurringFixedCost.fromJson(
+        'x',
+        {..._validJson(), 'cadence': 'weird'},
+      );
+      expect(fallback, isNotNull);
+      expect(fallback!.cadence, AssetRecurringFixedCostCadence.monthly);
+    });
+  });
+
+  group('AssetRecurringFixedCostStore', () {
+    const store = AssetRecurringFixedCostStore();
+
+    test('round-trips a list through SharedPreferences sorted by day',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      await store.save(
+        const <AssetRecurringFixedCost>[
+          AssetRecurringFixedCost(
+            id: 'fc_denki',
+            name: '電気代',
+            amount: 8000,
+            paymentDay: 27,
+            sourceAccountId: 'smbc_otsuka_branch',
+          ),
+          AssetRecurringFixedCost(
+            id: 'fc_nhk',
+            name: 'NHK受信料',
+            amount: 1300,
+            paymentDay: 10,
+            cadence: AssetRecurringFixedCostCadence.bimonthlyEvenMonth,
+          ),
+        ],
+        prefs: prefs,
+      );
+
+      final loaded = await store.load(prefs: prefs);
+      // 振替日昇順 (10 → 27)。
+      expect(loaded.map((c) => c.id), ['fc_nhk', 'fc_denki']);
+      expect(loaded[1].name, '電気代');
+      expect(loaded[1].amount, 8000);
+      expect(loaded[1].sourceAccountId, 'smbc_otsuka_branch');
+      expect(
+        loaded[0].cadence,
+        AssetRecurringFixedCostCadence.bimonthlyEvenMonth,
+      );
+    });
+
+    test('returns empty list when nothing stored', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      expect(await store.load(prefs: prefs), isEmpty);
+    });
+
+    test('save with empty list clears the key', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      await store.save(
+        const <AssetRecurringFixedCost>[
+          AssetRecurringFixedCost(
+            id: 'fc_denki',
+            name: '電気代',
+            amount: 8000,
+            paymentDay: 27,
+          ),
+        ],
+        prefs: prefs,
+      );
+      await store.save(const <AssetRecurringFixedCost>[], prefs: prefs);
+      expect(await store.load(prefs: prefs), isEmpty);
+    });
+
+    test('encode/decode mirror value round-trips (端末A→端末B 同期)', () {
+      const costs = <AssetRecurringFixedCost>[
+        AssetRecurringFixedCost(
+          id: 'fc_denki',
+          name: '電気代',
+          amount: 8000,
+          paymentDay: 27,
+        ),
+      ];
+      final encoded = AssetRecurringFixedCostStore.encodeMirrorValue(costs);
+      final decoded = AssetRecurringFixedCostStore.decodeMirrorValue(encoded);
+      expect(decoded.length, 1);
+      expect(decoded.first.id, 'fc_denki');
+      expect(decoded.first.amount, 8000);
+    });
+
+    test('decodeMirrorValue drops malformed entries', () {
+      expect(AssetRecurringFixedCostStore.decodeMirrorValue(null), isEmpty);
+      expect(
+        AssetRecurringFixedCostStore.decodeMirrorValue('not a map'),
+        isEmpty,
+      );
+      final decoded = AssetRecurringFixedCostStore.decodeMirrorValue(
+        <String, dynamic>{
+          'fc_denki': <String, dynamic>{
+            'name': '電気代',
+            'amount': 8000,
+            'paymentDay': 27,
+          },
+          'fc_bad': <String, dynamic>{
+            'name': '',
+            'amount': 0,
+            'paymentDay': 99,
+          },
+          'fc_broken': 'oops',
+        },
+      );
+      expect(decoded.map((c) => c.id), ['fc_denki']);
+    });
+  });
+}
+
+Map<String, dynamic> _validJson() {
+  return <String, dynamic>{
+    'name': '電気代',
+    'amount': 8000,
+    'paymentDay': 27,
+    'cadence': 'monthly',
+  };
+}


### PR DESCRIPTION
## 概要

固定費はこれまで4件（家賃・KDDI・水道・ガス）が `asset_liability_planning_service.dart` に1件あたり約8箇所ハードコードされていた。これを **UIで登録できる定期固定費モデルへ汎用化する第1段（データ駆動の土台）**。本PRはモデル・永続化・資金繰りへの計上ロジックと単体テストのみで、**既定固定費4件・既存挙動は一切変更しない**（新パラメータは既定空）。UIと端末間同期の配線は後続PRで追加する。

## 変更

- モデル `AssetRecurringFixedCost`（id/名称/金額/振替日/周期[毎月・隔月偶数月・隔月奇数月]/振替元口座id）+ `appliesToMonth` + 寛容な `fromJson`（空名/金額≤0/振替日範囲外は破棄）。
- `AssetRecurringFixedCostStore`（`asset_recurring_fixed_costs_v1` / `asset_pref_mirror` ミラー同型 / encode・decode・load・save・振替日昇順整列）。リボ払い設定ストアと同じパターン。
- `buildWorkbook(recurringFixedCosts:)` を追加。当月に該当する周期かつ同名/同IDの口座が無いものだけを「全額支払いの utility 負債」として計上（既定固定費 水道/ガスと同じ `_liability` 経由）。金額入力済み＝推定でない（請求確認待ちにしない）。振替元は `effectivePaymentSourceAccountIds` へ反映。**同名口座があれば二重計上しない**。
- 単体テスト：モデル/ストア（往復・整列・寛容パース）+ 計上ロジック（毎月計上・空リストで不変・隔月・二重計上防止・振替元伝播）。

## テスト

- `flutter analyze`（変更5ファイル／プロジェクト lint）= No issues found
- `flutter test`（新規2ファイル + 既存 `asset_liability_planning_service_test.dart` で回帰なし）= green

担当: Claude Code #1

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数モデル・ストア・計上ロジックの追加で UI 配線は含まない。入出力（登録した固定費→資金繰りへの計上）を単体テストで網羅し、実装詳細に依存しないため integration_test は不要。

High-risk-ultrareview-exception: 純粋なモデル・ストア・計上ロジックの追加のみで、認証・課金・決済などの高リスク経路や本番設定には触れない。
