### PR TITLE
feat: enable Flutter semantics at startup (no Enable-accessibility step)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -313,6 +313,12 @@ final GrowthPresenceNavigatorObserver _growthPresenceObserver =
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  // アクセシビリティを起動時から常時 ON にする。Flutter Web は既定で
+  // 「アクセシビリティを有効にする(Enable accessibility)」プレースホルダを
+  // 押すまでセマンティクスツリーを出さないため、スクリーンリーダー利用者は
+  // 最初から全要素を読める。返り値の SemanticsHandle は dispose しないので
+  // アプリ生存期間 ON を維持する(docs/ACCESSIBILITY_QA_CHECKLIST.md)。
+  WidgetsBinding.instance.ensureSemantics();
   GoogleFonts.config.allowRuntimeFetching = false;
   usePathUrlStrategy();
 


### PR DESCRIPTION
## What & why

Flutter Web does not expose the semantics tree to the browser until the hidden
"Enable accessibility" placeholder is activated, so screen-reader users hear
nothing until they find and press it. Real NVDA testing of the new asset cards
hit exactly this: even standard buttons were silent until the placeholder was
activated. This removes that step.

## Changes

- In `main()`, call `WidgetsBinding.instance.ensureSemantics()` right after
  binding init and keep the handle for the app lifetime, so semantics are always
  on and assistive tech reads every element from first load.
- Trade-off: the semantics tree is always built (a small, accepted cost for an
  accessibility-first app).

## Minimal E2E Gate

- Implementation-detail independent: the user-visible behavior is "a screen
  reader reads the UI from first load without a manual enable step".
- Minimal scope: about 3 cases (first-load read, no placeholder needed,
  no change to visual rendering).
- E2E: this is a one-line startup binding side-effect; a Flutter
  `integration_test` would only re-assert framework behavior, so none is added.
- E2E-Exception: startup semantics enablement is verified by a real-device NVDA
  pass on the asset cards (recorded in docs/ACCESSIBILITY_QA_CHECKLIST.md); no
  isolated unit test is meaningful for a binding-level side-effect.
