### PR TITLE
[CI/CD自動最適化] deploy-dev/staging npm cache 追加 2026-06-16

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -111,6 +111,12 @@ jobs:
           echo "Build successful!"
           ls -la build/web
 
+      - name: Setup Node for Firebase CLI
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
       # Deploy to Firebase Hosting (CLI) - サフィックスを抽出
       - name: Deploy to Firebase Hosting (CLI)
         id: firebase_cli_deploy

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -117,6 +117,12 @@ jobs:
           echo "Build successful!"
           ls -la build/web
 
+      - name: Setup Node for Firebase CLI
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
       # Deploy to Firebase Hosting (CLI) - サフィックスを抽出するロジックに統一
       - name: Deploy to Firebase Hosting (CLI)
         id: firebase_cli_deploy

--- a/docs/ci-cd-audit/2026-06-16.md
+++ b/docs/ci-cd-audit/2026-06-16.md
@@ -1,0 +1,124 @@
+# CI/CD コスト監査 2026-06-16
+
+自動生成: Claude Schedule エージェント
+
+---
+
+## サマリ
+
+| 指標 | 値 |
+|------|-----|
+| 総ワークフロー数 | 106本 |
+| schedule トリガー | 67本 |
+| 推定月間 cron 実行回数 | 5,346 runs/月 |
+| 主要コスト源 TOP3 | health-monitor / notion-sync / cs-check (各 360 runs/月) |
+| 本日自動適用 | 2ファイル (deploy-dev / deploy-staging npm cache 追加) |
+
+---
+
+## ワークフロー別コスト表 (TOP20 schedule)
+
+| ワークフロー | 頻度 | 推定 runs/月 | トリガー |
+|-------------|------|-------------|---------|
+| ai-university-update.yml | 2h | 360 | schedule |
+| cs-check.yml | 2h | 360 | schedule |
+| health-monitor.yml | 2h | 360 | schedule |
+| horse-racing-update.yml | 2h | 360 | schedule |
+| infra-health-check.yml | 2h | 360 | schedule |
+| issue-to-wbs.yml | 2h | 360 | schedule |
+| mcp-audit-anomaly-cron.yml | 2h | 360 | schedule |
+| memory-search-sync.yml | 2h | 360 | schedule |
+| notion-sync.yml | 2h | 360 | schedule |
+| wbs-ai-review.yml | 2h | 360 | schedule |
+| edge-function-audit.yml | 4h | 180 | schedule |
+| feature-review.yml | 4h | 180 | schedule |
+| schedule-resilience-watch.yml | 4h | 180 | schedule |
+| blog-publish-orphan-cleanup.yml | 6h | 120 | schedule |
+| tools-hub-mcp-smoke.yml | 6h | 120 | schedule |
+| ai-tool-watch.yml | daily | 30 | schedule |
+| blog-draft.yml | daily | 30 | schedule |
+| daily-report.yml | daily | 30 | schedule |
+| session-residuals-sync.yml | daily | 30 | schedule |
+| deploy-prod.yml | push/main | ~varies | push |
+
+---
+
+## 検出した冗長フロー
+
+### E: cache 未使用 ★本日対応
+
+| 優先度 | ワークフロー | 問題 | 推定削減 |
+|--------|------------|------|---------|
+| **HIGH** | `deploy-dev.yml` | `npm install -g firebase-tools` に npm cache なし | ~2〜3 分/run (firebase-tools DL) |
+| **HIGH** | `deploy-staging.yml` | 同上 | ~2〜3 分/run |
+| med | `deploy-prod.yml` | `flutter pub get` に pub cache なし (setup-flutter-sdk は SDK のみキャッシュ) | ~1〜2 分/run |
+| med | `claude-agent-review.yml` | `npm install -g` に cache なし | ~1 分/run |
+
+### F: 失敗率が高いワークフロー (要確認)
+
+| ワークフロー | 直近状況 | 推定コスト |
+|------------|---------|---------|
+| `minimal-e2e-gate.yml` | 前回監査時 100% failure (Chromium playwright install 問題) | ~120 s/PR × 失敗回数 |
+| `tools-hub-mcp-smoke.yml` | 前回 6h ごとに failure 継続報告 | ~100 s/日 |
+
+### D: cron 集中リスク
+
+- `0 */2 * * *` が複数 (health-monitor, horse-racing-update, ai-university-update) 同一スロット
+- GHA キュー遅延が起きやすい。5〜15 分ずらすと分散効果あり
+- 推定影響: 実際の遅延次第 (low)
+
+### 前回バッチ (6件) 適用確認
+
+前回 Issue #3175 で提案した以下 6件は **全て適用済み**:
+- ai-bench-source-recheck.yml → cancel-in-progress: true ✅
+- codex-backlog-check.yml → cancel-in-progress: true ✅
+- daily-report-freshness-monitor.yml → cancel-in-progress: true ✅
+- kg-indexer-nightly.yml → cancel-in-progress: true ✅
+- managed-mcp-policy.yml → cancel-in-progress: (PR条件付き) ✅
+- release-notes-data.yml → cancel-in-progress: (PR条件付き) ✅
+
+---
+
+## 改善提案
+
+### 推定削減効果付き
+
+| 提案 | 対象 | 推定削減 | 優先度 |
+|------|------|---------|--------|
+| npm cache 追加 (setup-node@v6) | deploy-dev.yml | ~2〜3 分/run × deploy 回数/月 | HIGH |
+| npm cache 追加 (setup-node@v6) | deploy-staging.yml | 同上 | HIGH |
+| pub cache 追加 | deploy-prod.yml | ~1〜2 分/run × main push 数/月 | MED |
+| npm cache 追加 | claude-agent-review.yml | ~1 分/PR | MED |
+| `minimal-e2e-gate.yml` Chromium 依存修正 | minimal-e2e-gate.yml | PR ごとの無駄 120s 排除 | MED |
+| `tools-hub-mcp-smoke.yml` failure 原因修正または schedule 停止 | tools-hub-mcp-smoke.yml | ~100 s/日削除 | MED |
+| cron スロット分散 (0 */2 同一グループ) | health-monitor, horse-racing, ai-univ | GHA queue 遅延防止 | LOW |
+
+---
+
+## 自動適用した変更 (本実行 2026-06-16)
+
+| ファイル | 変更内容 | 推定削減効果 |
+|---------|---------|-------------|
+| `.github/workflows/deploy-dev.yml` | `actions/setup-node@v6 cache: npm` ステップ追加 (firebase CLI 前) | ~2〜3 分/run |
+| `.github/workflows/deploy-staging.yml` | 同上 | ~2〜3 分/run |
+
+---
+
+## 削除候補 (Issue 提案のみ・即削除しない)
+
+現時点で削除候補は特定されていない。`tools-hub-mcp-smoke.yml` は failure が継続している場合、schedule 停止を検討。
+
+---
+
+## 累積改善サマリー (2026-06-04〜2026-06-16)
+
+| 適用日 | 内容 | 削減効果 |
+|--------|------|---------|
+| 06-04 | ci.yml pub cache 追加 | ~2 min/PR |
+| 06-04 | memory-search-sync.yml concurrency 追加 | エラー回避 |
+| 06-06 | health-monitor.yml cron 30分→1時間→2時間 | ~720 runs/月削減 |
+| 06-08 | feature-review.yml cron 毎時→毎4時間 | ~22.8 分/日 |
+| 06-08 | edge-function-audit.yml cron 毎時→毎4時間 | ~9 分/日 |
+| 06-09 | blog-publish-orphan-cleanup + stale-ef-completeness-check concurrency 追加 | git 競合エラー回避 |
+| 06-10〜15 | notion-sync / cs-check 等 毎時→2時間 (複数 workflow) | 推定 3,600 runs/月削減 |
+| **06-16** | **deploy-dev + deploy-staging npm cache 追加** | **~4〜6 min/deploy-dev/staging run** |


### PR DESCRIPTION
## 変更概要

`deploy-dev.yml` / `deploy-staging.yml` で `npm install -g firebase-tools` 前に `actions/setup-node@v6 (cache: npm)` ステップを追加。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `.github/workflows/deploy-dev.yml` | `Setup Node for Firebase CLI` ステップ追加 (node 24 / cache: npm) |
| `.github/workflows/deploy-staging.yml` | 同上 |

## 推定削減効果

- `npm install -g firebase-tools` は初回 ~2〜3 分 → キャッシュヒット後は ~5〜10 秒
- `deploy-dev` / `deploy-staging` 共に毎 develop/staging push で実行されるため累積削減が大きい
- `deploy-prod` はすでに同パターン (`setup-node@v6 + npx`) 採用済 → 3環境で統一

## 安全性

- 純粋に `setup-node` ステップを追加するだけ (削除・変更なし)
- `npm install -g firebase-tools` のロジックは無変更 (キャッシュ有効化のみ)
- YAML 構文検証 OK (python yaml.safe_load 全106ファイル通過)

## 関連

- 監査レポート: `docs/ci-cd-audit/2026-06-16.md`
- Issue: #3175 [CI/CD監査] 冗長フロー削減提案 2026-06-09

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyuLthRBVLD29p4U23CHLY)_