### PR TITLE
feat: 定期固定費のUI登録カードと端末間ミラー同期を追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -39,6 +39,7 @@ import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
+import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
 import 'package:my_web_app/services/asset_category_budget_service.dart';
@@ -66,6 +67,8 @@ import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
 import 'package:my_web_app/widgets/asset_category_budget_card.dart';
+import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
+import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -181,6 +184,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, dynamic>? debugWatchlistDeletedMirror;
 
+  /// テスト専用: 定期固定費の初期リストを注入し、UI 表示や計上を Supabase なしで
+  /// 検証する。null なら通常のローカル/ミラー読込のみ。
+  @visibleForTesting
+  final List<AssetRecurringFixedCost>? debugInitialRecurringFixedCosts;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -202,6 +210,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugDebtOverridesMirror,
     this.debugRevolvingDeletedMirror,
     this.debugWatchlistDeletedMirror,
+    this.debugInitialRecurringFixedCosts,
   });
 
   @override
@@ -397,6 +406,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // リボ払いカードの設定 (負債IDごと)。v1 はローカル永続化のみ。
   Map<String, AssetLiabilityRevolvingCreditConfig> _revolvingConfigs =
       <String, AssetLiabilityRevolvingCreditConfig>{};
+  // UI 登録の定期固定費 (家賃・光熱費など)。振替日昇順で保持する。
+  List<AssetRecurringFixedCost> _recurringFixedCosts =
+      <AssetRecurringFixedCost>[];
   // カテゴリ別 月次予算 (category -> 金額)。予算/カテゴリ予実カードで使用。
   Map<String, double> _categoryBudgets = <String, double>{};
   final Map<String, GlobalKey> _debtMasterCardKeys = <String, GlobalKey>{};
@@ -571,6 +583,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetManagementMainAccountStore();
   final AssetRevolvingCreditConfigStore _revolvingConfigStore =
       const AssetRevolvingCreditConfigStore();
+  final AssetRecurringFixedCostStore _recurringFixedCostStore =
+      const AssetRecurringFixedCostStore();
+  static const String _recurringFixedCostsMirrorKey = 'recurring_fixed_costs';
   final AssetCategoryBudgetStore _categoryBudgetStore =
       const AssetCategoryBudgetStore();
   // 禁酒で借金完済チャレンジの記録(日付→我慢/飲んだ)。v1 はローカル永続化のみ。
@@ -665,6 +680,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           entry.key: Map<String, double>.from(entry.value),
       };
     }
+    final debugRecurring = widget.debugInitialRecurringFixedCosts;
+    if (debugRecurring != null) {
+      _recurringFixedCosts = List<AssetRecurringFixedCost>.from(debugRecurring);
+    }
     _assetLiabilityRepository = widget.assetLiabilityRepository ??
         AssetLiabilityRepositoryFactory.createDefault(
           supabaseClient: _supabase,
@@ -681,6 +700,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _loadMainAccount();
     unawaited(_loadRevolvingConfigs());
     unawaited(_loadCategoryBudgets());
+    unawaited(_loadRecurringFixedCosts());
     unawaited(_loadDrinkChallenge());
     _loadExpectedInflows();
     // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
@@ -7754,6 +7774,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       incomePlans: _monthlyIncomePlans,
       cardStatementLines: _cardStatementLines,
       transferTasks: _transferTasks,
+      recurringFixedCosts: _recurringFixedCosts,
       includeDefaultFixedPayments: true,
     );
   }
@@ -7961,6 +7982,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _buildSalarySpendingBreakdownCard(),
               const SizedBox(height: 16),
               _buildCategoryBudgetCard(),
+              const SizedBox(height: 16),
+              _buildRecurringFixedCostCard(assetLiabilityWorkbook),
             ],
             if (_isSectionShown(AssetManagementSectionId.disposable)) ...[
               _buildDisposableBalanceCard(),
@@ -8363,6 +8386,178 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
     await _restoreRevolvingConfigsFromMirror();
     unawaited(_refreshSyncSources());
+  }
+
+  // --- 定期固定費 (UI 登録) の読み書き・端末間同期 ---
+
+  /// 起動時にローカルから読み、空ならサーバ集約ミラーから復元する。
+  Future<void> _loadRecurringFixedCosts() async {
+    if (widget.debugInitialRecurringFixedCosts != null) {
+      // テスト注入時はネットワーク読込をスキップ (initState で設定済み)。
+      return;
+    }
+    try {
+      final costs = await _recurringFixedCostStore.load();
+      if (mounted && costs.isNotEmpty) {
+        setState(() => _recurringFixedCosts = costs);
+      }
+    } catch (e) {
+      debugPrint('Error loading recurring fixed costs: $e');
+    }
+    await _restoreRecurringFixedCostsFromMirror();
+  }
+
+  /// サーバ集約ミラー (pref_key: recurring_fixed_costs) から復元する。ローカルに
+  /// 既に登録があれば上書きしない (オフライン編集を握り潰さない安全側 / 削除の
+  /// クロス端末伝播は将来 tombstone 化で対応 / リボ設定 v1 と同方針)。
+  Future<void> _restoreRecurringFixedCostsFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    if (_recurringFixedCosts.isNotEmpty) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', _recurringFixedCostsMirrorKey);
+      if (rows.isEmpty) {
+        return;
+      }
+      final serverCosts = AssetRecurringFixedCostStore.decodeMirrorValue(
+        rows.first['value'],
+      );
+      if (!mounted || serverCosts.isEmpty) {
+        return;
+      }
+      setState(() => _recurringFixedCosts = serverCosts);
+      _persistInBackground(
+        _recurringFixedCostStore.save(serverCosts),
+        'recurring fixed cost restore save',
+      );
+    } catch (e) {
+      debugPrint('recurring fixed cost mirror restore failed: $e');
+    }
+  }
+
+  /// 定期固定費の全量を `asset_pref_mirror` へ 1 行 upsert する。
+  Future<void> _mirrorRecurringFixedCosts() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _recurringFixedCostsMirrorKey,
+        'value': AssetRecurringFixedCostStore.encodeMirrorValue(
+          _recurringFixedCosts,
+        ),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('recurring fixed cost mirror upsert failed: $e');
+    }
+  }
+
+  void _saveRecurringFixedCost(AssetRecurringFixedCost cost) {
+    setState(() {
+      final next = List<AssetRecurringFixedCost>.from(_recurringFixedCosts);
+      final index = next.indexWhere((existing) => existing.id == cost.id);
+      if (index >= 0) {
+        next[index] = cost;
+      } else {
+        next.add(cost);
+      }
+      next.sort((a, b) {
+        final byDay = a.paymentDay.compareTo(b.paymentDay);
+        return byDay != 0 ? byDay : a.name.compareTo(b.name);
+      });
+      _recurringFixedCosts = next;
+    });
+    _persistInBackground(
+      _recurringFixedCostStore.save(_recurringFixedCosts),
+      'recurring fixed cost save',
+    );
+    unawaited(_mirrorRecurringFixedCosts());
+  }
+
+  void _deleteRecurringFixedCost(AssetRecurringFixedCost cost) {
+    setState(() {
+      _recurringFixedCosts = _recurringFixedCosts
+          .where((existing) => existing.id != cost.id)
+          .toList();
+    });
+    _persistInBackground(
+      _recurringFixedCostStore.save(_recurringFixedCosts),
+      'recurring fixed cost delete',
+    );
+    unawaited(_mirrorRecurringFixedCosts());
+  }
+
+  Future<void> _openRecurringFixedCostEditor({
+    AssetRecurringFixedCost? existing,
+    required List<RecurringFixedCostSourceOption> sourceOptions,
+  }) async {
+    final result = await showRecurringFixedCostEditor(
+      context,
+      existing: existing,
+      sourceAccounts: sourceOptions,
+    );
+    if (result != null) {
+      _saveRecurringFixedCost(result);
+    }
+  }
+
+  Future<void> _confirmDeleteRecurringFixedCost(
+    AssetRecurringFixedCost cost,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('定期固定費を削除'),
+        content: Text('「${cost.name}」を削除しますか?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('削除'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      _deleteRecurringFixedCost(cost);
+    }
+  }
+
+  Widget _buildRecurringFixedCostCard(AssetLiabilityWorkbook? workbook) {
+    final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
+    final sourceOptions = <RecurringFixedCostSourceOption>[
+      for (final account in accounts)
+        if (account.balance > 0) (id: account.id, name: account.name),
+    ];
+    final sourceNames = <String, String>{
+      for (final account in accounts) account.id: account.name,
+    };
+    return RecurringFixedCostCard(
+      costs: _recurringFixedCosts,
+      sourceAccountNames: sourceNames,
+      onAdd: () => unawaited(
+        _openRecurringFixedCostEditor(sourceOptions: sourceOptions),
+      ),
+      onEdit: (cost) => unawaited(
+        _openRecurringFixedCostEditor(
+          existing: cost,
+          sourceOptions: sourceOptions,
+        ),
+      ),
+      onDelete: (cost) => unawaited(_confirmDeleteRecurringFixedCost(cost)),
+    );
   }
 
   Future<void> _loadDrinkChallenge() async {
@@ -11811,6 +12006,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         incomePlans: _monthlyIncomePlans,
         cardStatementLines: _cardStatementLines,
         transferTasks: _transferTasks,
+        recurringFixedCosts: _recurringFixedCosts,
         includeDefaultFixedPayments: true,
       );
       final assetLiabilityInputs =

--- a/lib/widgets/recurring_fixed_cost_card.dart
+++ b/lib/widgets/recurring_fixed_cost_card.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/asset_liability_workbook.dart';
+
+/// 定期固定費 (家賃・光熱費・通信費など) を一覧表示し、追加/編集/削除を行う
+/// 自己完結カード。状態・永続化は資産管理ページが持ち、本ウィジェットは表示と
+/// コールバックのみを担う (ページ本体を肥大化させずに単体テスト可能にする)。
+class RecurringFixedCostCard extends StatelessWidget {
+  const RecurringFixedCostCard({
+    super.key,
+    required this.costs,
+    required this.sourceAccountNames,
+    required this.onAdd,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  /// 表示する定期固定費 (振替日昇順で渡される想定)。
+  final List<AssetRecurringFixedCost> costs;
+
+  /// 振替元口座 ID → 表示名。サブタイトルの「振替元」表示に使う。
+  final Map<String, String> sourceAccountNames;
+
+  final VoidCallback onAdd;
+  final void Function(AssetRecurringFixedCost cost) onEdit;
+  final void Function(AssetRecurringFixedCost cost) onDelete;
+
+  static final NumberFormat _yen = NumberFormat('#,###');
+
+  static String cadenceLabel(AssetRecurringFixedCostCadence cadence) {
+    switch (cadence) {
+      case AssetRecurringFixedCostCadence.monthly:
+        return '毎月';
+      case AssetRecurringFixedCostCadence.bimonthlyEvenMonth:
+        return '隔月(偶数月)';
+      case AssetRecurringFixedCostCadence.bimonthlyOddMonth:
+        return '隔月(奇数月)';
+    }
+  }
+
+  String _subtitle(AssetRecurringFixedCost cost) {
+    final buffer = StringBuffer(
+      '${cadenceLabel(cost.cadence)}${cost.paymentDay}日 / ¥${_yen.format(cost.amount)}',
+    );
+    final sourceId = cost.sourceAccountId;
+    if (sourceId != null && sourceId.isNotEmpty) {
+      final name = sourceAccountNames[sourceId];
+      if (name != null && name.isNotEmpty) {
+        buffer.write(' / 振替元: $name');
+      }
+    }
+    return buffer.toString();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.event_repeat, color: scheme.primary),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '定期固定費',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  TextButton.icon(
+                    onPressed: onAdd,
+                    icon: const Icon(Icons.add),
+                    label: const Text('追加'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '家賃・光熱費・通信費など、毎月/隔月に口座振替される固定費を登録すると'
+                '資金繰り(見込み残高)に自動で反映されます。',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 8),
+              if (costs.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: Text(
+                    'まだ登録がありません。「追加」から固定費を登録できます。',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              else
+                for (final cost in costs)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                cost.name,
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              Text(
+                                _subtitle(cost),
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: scheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        IconButton(
+                          tooltip: '編集',
+                          icon: const Icon(Icons.edit_outlined),
+                          onPressed: () => onEdit(cost),
+                        ),
+                        IconButton(
+                          tooltip: '削除',
+                          icon: const Icon(Icons.delete_outline),
+                          onPressed: () => onDelete(cost),
+                        ),
+                      ],
+                    ),
+                  ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/recurring_fixed_cost_editor_dialog.dart
+++ b/lib/widgets/recurring_fixed_cost_editor_dialog.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/asset_liability_workbook.dart';
+import 'recurring_fixed_cost_card.dart';
+
+/// 振替元ドロップダウンに渡す口座 (ID + 表示名)。
+typedef RecurringFixedCostSourceOption = ({String id, String name});
+
+/// 定期固定費の追加/編集ダイアログを開き、保存された [AssetRecurringFixedCost] を返す。
+/// キャンセル時は null。
+Future<AssetRecurringFixedCost?> showRecurringFixedCostEditor(
+  BuildContext context, {
+  AssetRecurringFixedCost? existing,
+  List<RecurringFixedCostSourceOption> sourceAccounts =
+      const <RecurringFixedCostSourceOption>[],
+}) {
+  return showDialog<AssetRecurringFixedCost>(
+    context: context,
+    builder: (context) => RecurringFixedCostEditorDialog(
+      existing: existing,
+      sourceAccounts: sourceAccounts,
+    ),
+  );
+}
+
+/// 定期固定費の入力フォーム。`showRecurringFixedCostEditor` 経由で使う想定だが、
+/// 単体テストのため公開している。
+class RecurringFixedCostEditorDialog extends StatefulWidget {
+  const RecurringFixedCostEditorDialog({
+    super.key,
+    this.existing,
+    this.sourceAccounts = const <RecurringFixedCostSourceOption>[],
+  });
+
+  final AssetRecurringFixedCost? existing;
+  final List<RecurringFixedCostSourceOption> sourceAccounts;
+
+  @override
+  State<RecurringFixedCostEditorDialog> createState() =>
+      _RecurringFixedCostEditorDialogState();
+}
+
+class _RecurringFixedCostEditorDialogState
+    extends State<RecurringFixedCostEditorDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _amountController;
+  late final TextEditingController _dayController;
+  late AssetRecurringFixedCostCadence _cadence;
+  String? _sourceAccountId;
+
+  @override
+  void initState() {
+    super.initState();
+    final existing = widget.existing;
+    _nameController = TextEditingController(text: existing?.name ?? '');
+    _amountController = TextEditingController(
+      text: existing == null ? '' : existing.amount.toStringAsFixed(0),
+    );
+    _dayController = TextEditingController(
+      text: existing == null ? '' : existing.paymentDay.toString(),
+    );
+    _cadence = existing?.cadence ?? AssetRecurringFixedCostCadence.monthly;
+    // 渡された候補に無い振替元IDは保持しない (古い参照を残さない)。
+    final ids = widget.sourceAccounts.map((option) => option.id).toSet();
+    final source = existing?.sourceAccountId;
+    _sourceAccountId = source != null && ids.contains(source) ? source : null;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _amountController.dispose();
+    _dayController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+    final id =
+        widget.existing?.id ?? 'fc_${DateTime.now().microsecondsSinceEpoch}';
+    final cost = AssetRecurringFixedCost(
+      id: id,
+      name: _nameController.text.trim(),
+      amount: double.parse(_amountController.text.trim()),
+      paymentDay: int.parse(_dayController.text.trim()),
+      cadence: _cadence,
+      sourceAccountId: _sourceAccountId,
+    );
+    Navigator.of(context).pop(cost);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.existing == null ? '定期固定費を追加' : '定期固定費を編集'),
+      content: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: '名称',
+                  hintText: '例: 電気代',
+                ),
+                validator: (value) => (value == null || value.trim().isEmpty)
+                    ? '名称を入力してください'
+                    : null,
+              ),
+              TextFormField(
+                controller: _amountController,
+                decoration: const InputDecoration(
+                  labelText: '月額 (円)',
+                  hintText: '例: 8000',
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                validator: (value) {
+                  final amount = double.tryParse((value ?? '').trim());
+                  if (amount == null || amount <= 0) {
+                    return '1円以上の金額を入力してください';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                controller: _dayController,
+                decoration: const InputDecoration(
+                  labelText: '振替日 (1〜31)',
+                  hintText: '例: 27',
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                validator: (value) {
+                  final day = int.tryParse((value ?? '').trim());
+                  if (day == null || day < 1 || day > 31) {
+                    return '1〜31 の日付を入力してください';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 8),
+              DropdownButtonFormField<AssetRecurringFixedCostCadence>(
+                initialValue: _cadence,
+                decoration: const InputDecoration(labelText: '周期'),
+                items: [
+                  for (final cadence in AssetRecurringFixedCostCadence.values)
+                    DropdownMenuItem<AssetRecurringFixedCostCadence>(
+                      value: cadence,
+                      child: Text(RecurringFixedCostCard.cadenceLabel(cadence)),
+                    ),
+                ],
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() => _cadence = value);
+                  }
+                },
+              ),
+              const SizedBox(height: 8),
+              DropdownButtonFormField<String?>(
+                initialValue: _sourceAccountId,
+                decoration: const InputDecoration(labelText: '振替元 (任意)'),
+                items: [
+                  const DropdownMenuItem<String?>(
+                    child: Text('未設定'),
+                  ),
+                  for (final option in widget.sourceAccounts)
+                    DropdownMenuItem<String?>(
+                      value: option.id,
+                      child: Text(option.name),
+                    ),
+                ],
+                onChanged: (value) => setState(() => _sourceAccountId = value),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: const Text('保存'),
+        ),
+      ],
+    );
+  }
+}

--- a/test/widgets/recurring_fixed_cost_card_test.dart
+++ b/test/widgets/recurring_fixed_cost_card_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
+import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
+
+void main() {
+  group('RecurringFixedCostCard', () {
+    testWidgets('renders entries and fires add/edit/delete callbacks',
+        (tester) async {
+      AssetRecurringFixedCost? edited;
+      AssetRecurringFixedCost? deleted;
+      var addPressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecurringFixedCostCard(
+              costs: const <AssetRecurringFixedCost>[
+                AssetRecurringFixedCost(
+                  id: 'fc_denki',
+                  name: '電気代',
+                  amount: 8000,
+                  paymentDay: 27,
+                  sourceAccountId: 'smbc',
+                ),
+              ],
+              sourceAccountNames: const <String, String>{
+                'smbc': '三井住友銀行大塚支店',
+              },
+              onAdd: () => addPressed = true,
+              onEdit: (cost) => edited = cost,
+              onDelete: (cost) => deleted = cost,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('電気代'), findsOneWidget);
+      expect(find.textContaining('毎月27日'), findsOneWidget);
+      expect(find.textContaining('¥8,000'), findsOneWidget);
+      expect(find.textContaining('振替元: 三井住友銀行大塚支店'), findsOneWidget);
+
+      await tester.tap(find.text('追加'));
+      expect(addPressed, isTrue);
+      await tester.tap(find.byTooltip('編集'));
+      expect(edited?.id, 'fc_denki');
+      await tester.tap(find.byTooltip('削除'));
+      expect(deleted?.id, 'fc_denki');
+    });
+
+    testWidgets('shows an empty hint when there are no costs', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecurringFixedCostCard(
+              costs: const <AssetRecurringFixedCost>[],
+              sourceAccountNames: const <String, String>{},
+              onAdd: () {},
+              onEdit: (_) {},
+              onDelete: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.textContaining('まだ登録がありません'), findsOneWidget);
+    });
+  });
+
+  group('RecurringFixedCostEditorDialog', () {
+    testWidgets('returns a cost built from the entered values', (tester) async {
+      AssetRecurringFixedCost? result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () async {
+                  result = await showRecurringFixedCostEditor(context);
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextFormField).at(0), '電気代');
+      await tester.enterText(find.byType(TextFormField).at(1), '8000');
+      await tester.enterText(find.byType(TextFormField).at(2), '27');
+      await tester.tap(find.text('保存'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!.name, '電気代');
+      expect(result!.amount, 8000);
+      expect(result!.paymentDay, 27);
+      expect(result!.cadence, AssetRecurringFixedCostCadence.monthly);
+      expect(result!.sourceAccountId, isNull);
+    });
+
+    testWidgets('stays open and shows errors on invalid input', (tester) async {
+      var returned = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () async {
+                  await showRecurringFixedCostEditor(context);
+                  returned = true;
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      // 何も入力せず保存 → バリデーションエラーで閉じない。
+      await tester.tap(find.text('保存'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('名称を入力してください'), findsOneWidget);
+      expect(returned, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

[#3452](https://github.com/kanta13jp1/my_web_app/pull/3452)（データ駆動エンジン）に続く第2段。**定期固定費をUIで登録・編集・削除できるカード**と、ローカル＋端末間ミラー同期を追加する。これで家賃・光熱費・通信費などの固定費を、コードを触らずに資金繰り(見込み残高)へ反映できる。

## 変更

- ウィジェット `RecurringFixedCostCard`（一覧＋追加/編集/削除）と `RecurringFixedCostEditorDialog`（名称/月額/振替日/周期/振替元のフォーム＋バリデーション）を新規追加。ページ本体を肥大化させず単体テスト可能にするため独立ウィジェット化。
- 資産管理ページに状態 `_recurringFixedCosts` ＋ ストア配線：
  - 起動時ロード（ローカル→空ならサーバ集約ミラー復元 / リボ設定 v1 と同方針＝ローカルに登録があれば上書きしない安全側。削除のクロス端末伝播は将来 tombstone 化）。
  - 追加/編集/削除で `asset_pref_mirror`（pref_key: `recurring_fixed_costs`）へ全量 upsert。
  - 「給料サイクル別内訳」セクションに管理カードを表示。
  - 全体像を出す2つの `buildWorkbook` 呼び出し（`includeDefaultFixedPayments: true`）へ `recurringFixedCosts` を引き渡し。
- テスト専用注入 `debugInitialRecurringFixedCosts` を追加（Supabase なしで描画/計上を検証）。
- widget テスト：カード描画＋追加/編集/削除コールバック、空表示、エディタの入力→生成＆バリデーション。

## テスト

- `flutter analyze`（変更4ファイル／プロジェクト lint）= No issues found
- `flutter test`（`recurring_fixed_cost_card_test.dart`）= green
- 既存 `asset_liability_planning_service_test.dart` も回帰なし（エンジンは #3452 で着地済み・本PRは UI 配線）。

担当: Claude Code #1

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 独立ウィジェット(カード/エディタ)とページ配線の追加。カードの描画・コールバック・エディタの入出力(入力→生成/バリデーション)を widget テストで網羅し、実装詳細に依存しないため integration_test は不要。

High-risk-ultrareview-exception: UIカードと集約ミラー配線の追加のみで、認証・課金・決済などの高リスク経路や本番設定には触れない。
