### PR TITLE
refactor: extract cashflow forecast input derivation into a pure service

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -41,6 +41,7 @@ import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
+import 'package:my_web_app/services/asset_cashflow_forecast_inputs.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
 import 'package:my_web_app/services/asset_category_budget_service.dart';
 import 'package:my_web_app/services/asset_category_budget_store.dart';
@@ -10708,26 +10709,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     });
   }
 
-  AssetCashflowRecurringEntry? _subscriptionRecurringEntry(
-    Map<String, dynamic> subscription,
-  ) {
-    final price = (subscription['price'] as num?)?.toDouble();
-    if (price == null || price <= 0) {
-      return null;
-    }
-    final dueDate = DateTime.tryParse(
-      subscription['due_date']?.toString() ?? '',
-    );
-    final name = subscription['service_name']?.toString().trim() ?? '';
-    return AssetCashflowRecurringEntry(
-      dayOfMonth: dueDate?.day ?? 1,
-      amount: price,
-      label: name.isEmpty ? '固定費' : name,
-    );
-  }
-
-  /// 現金・預金を起点に、繰り返し収入・固定費・返済予定を毎月積み上げた
-  /// 今後の残高見込みカード。登録データが無ければ非表示。
   // 支払日を過ぎた自動振替・固定費の「引落確認待ち」カード。引落済みなら
   // ユーザーが確認 → 支払済み(現在残高に反映済み)扱いにし、見込み残高の
   // 二重控除を防ぐ。引落失敗の可能性があるため自動では支払済みにしない。
@@ -10873,76 +10854,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (workbook == null) {
       return const SizedBox.shrink();
     }
-    var startingBalance = 0.0;
-    for (final account in workbook.accounts) {
-      final isLiquid = account.kind == AssetLiabilityAccountKind.cash ||
-          account.kind == AssetLiabilityAccountKind.deposit;
-      if (isLiquid && account.balance > 0) {
-        startingBalance += account.balance;
-      }
-    }
-
-    final recurringIncome = <AssetCashflowRecurringEntry>[
-      for (final template in _recurringIncomeTemplates)
-        if (template.dayOfMonth > 0 && template.amount > 0)
-          AssetCashflowRecurringEntry(
-            dayOfMonth: template.dayOfMonth,
-            amount: template.amount,
-            label: template.name,
-          ),
-      for (final rule in _expectedInflowRules)
-        if (rule.dayOfMonth > 0 && rule.amount > 0)
-          AssetCashflowRecurringEntry(
-            dayOfMonth: rule.dayOfMonth,
-            amount: rule.amount,
-            label: rule.label,
-          ),
-    ];
-
-    final subscriptionOutflow = <AssetCashflowRecurringEntry>[];
-    for (final subscription in _subscriptions) {
-      final entry = _subscriptionRecurringEntry(subscription);
-      if (entry != null) {
-        subscriptionOutflow.add(entry);
-      }
-    }
-    final recurringOutflow = <AssetCashflowRecurringEntry>[
-      for (final row in workbook.debtMasterRows)
-        if (row.isDirectCashflowTarget &&
-            row.balance < 0 &&
-            (row.paymentDay ?? 0) > 0 &&
-            row.scheduledPaymentAmount > 0)
-          AssetCashflowRecurringEntry(
-            dayOfMonth: row.paymentDay!,
-            amount: row.scheduledPaymentAmount,
-            label: row.name,
-          ),
-      ...subscriptionOutflow,
-    ];
-
-    final oneTimeIncome = <AssetCashflowDatedEntry>[
-      for (final inflow in _expectedInflows)
-        if (inflow.amount > 0)
-          AssetCashflowDatedEntry(
-            date: inflow.date,
-            amount: inflow.amount,
-            label: inflow.label,
-          ),
-    ];
-
-    if (recurringIncome.isEmpty &&
-        recurringOutflow.isEmpty &&
-        oneTimeIncome.isEmpty) {
+    final inputs = AssetCashflowForecastInputs.fromAssetData(
+      accounts: workbook.accounts,
+      debtRows: workbook.debtMasterRows,
+      recurringIncomeTemplates: _recurringIncomeTemplates,
+      inflowRules: _expectedInflowRules,
+      oneTimeInflows: _expectedInflows,
+      subscriptions: _subscriptions,
+    );
+    if (!inputs.hasData) {
       return const SizedBox.shrink();
     }
 
     final forecast = AssetCashflowForecastService.project(
       asOf: DateTime.now(),
-      startingBalance: startingBalance,
+      startingBalance: inputs.startingBalance,
       horizonMonths: _forecastHorizonMonths,
-      recurringIncome: recurringIncome,
-      recurringOutflow: recurringOutflow,
-      oneTimeIncome: oneTimeIncome,
+      recurringIncome: inputs.recurringIncome,
+      recurringOutflow: inputs.recurringOutflow,
+      oneTimeIncome: inputs.oneTimeIncome,
       safetyMargin: _assetForecastSafetyMargin,
     );
 

--- a/lib/services/asset_cashflow_forecast_inputs.dart
+++ b/lib/services/asset_cashflow_forecast_inputs.dart
@@ -1,0 +1,129 @@
+import '../models/asset_liability_workbook.dart';
+import 'asset_cashflow_forecast_service.dart';
+import 'asset_expected_inflow_store.dart';
+
+/// 資産管理ページの状態(口座・負債・繰り返し収入テンプレ・入金ルール・固定費)から
+/// [AssetCashflowForecastService.project] へ渡す入力を導出する純関数の置き場。
+///
+/// 元々ページの `_buildCashflowForecastCard` 内にインラインで書かれていたロジックを
+/// 抽出し、build メソッドから切り離してユニットテスト可能にしたもの(振る舞いは不変)。
+class AssetCashflowForecastInputs {
+  const AssetCashflowForecastInputs({
+    required this.startingBalance,
+    required this.recurringIncome,
+    required this.recurringOutflow,
+    required this.oneTimeIncome,
+  });
+
+  /// 現金・預金(残高がプラスの流動資産)の合計。予測の起点残高。
+  final double startingBalance;
+
+  final List<AssetCashflowRecurringEntry> recurringIncome;
+  final List<AssetCashflowRecurringEntry> recurringOutflow;
+  final List<AssetCashflowDatedEntry> oneTimeIncome;
+
+  /// いずれかの入力があるか(なければカードを出さない判定に使う)。
+  bool get hasData =>
+      recurringIncome.isNotEmpty ||
+      recurringOutflow.isNotEmpty ||
+      oneTimeIncome.isNotEmpty;
+
+  /// ページ状態から予測入力を導出する。
+  ///
+  /// - 起点残高 = 現金・預金口座(`cash`/`deposit` かつ残高 > 0)の合計。
+  /// - 繰り返し収入 = 繰り返し収入テンプレ + 入金ルール(日付・金額が正のもの)。
+  /// - 繰り返し支出 = 直接キャッシュフロー対象の負債(残高 < 0・支払日・予定額あり)
+  ///   + 固定費(subscription)。
+  /// - 一時収入 = 登録済みの入金予定(金額が正のもの)。
+  static AssetCashflowForecastInputs fromAssetData({
+    required List<AssetLiabilityAccount> accounts,
+    required List<AssetLiabilityDebtRow> debtRows,
+    required List<AssetLiabilityRecurringIncomeTemplate>
+        recurringIncomeTemplates,
+    required List<AssetExpectedInflowRule> inflowRules,
+    required List<AssetExpectedInflow> oneTimeInflows,
+    required List<Map<String, dynamic>> subscriptions,
+  }) {
+    var startingBalance = 0.0;
+    for (final account in accounts) {
+      final isLiquid = account.kind == AssetLiabilityAccountKind.cash ||
+          account.kind == AssetLiabilityAccountKind.deposit;
+      if (isLiquid && account.balance > 0) {
+        startingBalance += account.balance;
+      }
+    }
+
+    final recurringIncome = <AssetCashflowRecurringEntry>[
+      for (final template in recurringIncomeTemplates)
+        if (template.dayOfMonth > 0 && template.amount > 0)
+          AssetCashflowRecurringEntry(
+            dayOfMonth: template.dayOfMonth,
+            amount: template.amount,
+            label: template.name,
+          ),
+      for (final rule in inflowRules)
+        if (rule.dayOfMonth > 0 && rule.amount > 0)
+          AssetCashflowRecurringEntry(
+            dayOfMonth: rule.dayOfMonth,
+            amount: rule.amount,
+            label: rule.label,
+          ),
+    ];
+
+    final recurringOutflow = <AssetCashflowRecurringEntry>[
+      for (final row in debtRows)
+        if (row.isDirectCashflowTarget &&
+            row.balance < 0 &&
+            (row.paymentDay ?? 0) > 0 &&
+            row.scheduledPaymentAmount > 0)
+          AssetCashflowRecurringEntry(
+            dayOfMonth: row.paymentDay!,
+            amount: row.scheduledPaymentAmount,
+            label: row.name,
+          ),
+    ];
+    for (final subscription in subscriptions) {
+      final entry = subscriptionRecurringEntry(subscription);
+      if (entry != null) {
+        recurringOutflow.add(entry);
+      }
+    }
+
+    final oneTimeIncome = <AssetCashflowDatedEntry>[
+      for (final inflow in oneTimeInflows)
+        if (inflow.amount > 0)
+          AssetCashflowDatedEntry(
+            date: inflow.date,
+            amount: inflow.amount,
+            label: inflow.label,
+          ),
+    ];
+
+    return AssetCashflowForecastInputs(
+      startingBalance: startingBalance,
+      recurringIncome: recurringIncome,
+      recurringOutflow: recurringOutflow,
+      oneTimeIncome: oneTimeIncome,
+    );
+  }
+
+  /// 固定費(subscription)1 件を繰り返し支出エントリへ変換する。
+  /// 価格が無効(null/非正)なら null。支払日は due_date の日、名前が空なら「固定費」。
+  static AssetCashflowRecurringEntry? subscriptionRecurringEntry(
+    Map<String, dynamic> subscription,
+  ) {
+    final price = (subscription['price'] as num?)?.toDouble();
+    if (price == null || price <= 0) {
+      return null;
+    }
+    final dueDate = DateTime.tryParse(
+      subscription['due_date']?.toString() ?? '',
+    );
+    final name = subscription['service_name']?.toString().trim() ?? '';
+    return AssetCashflowRecurringEntry(
+      dayOfMonth: dueDate?.day ?? 1,
+      amount: price,
+      label: name.isEmpty ? '固定費' : name,
+    );
+  }
+}

--- a/test/services/asset_cashflow_forecast_inputs_test.dart
+++ b/test/services/asset_cashflow_forecast_inputs_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_cashflow_forecast_inputs.dart';
+import 'package:my_web_app/services/asset_expected_inflow_store.dart';
+
+AssetLiabilityAccount _account(
+  String name,
+  AssetLiabilityAccountKind kind,
+  double balance,
+) {
+  return AssetLiabilityAccount(
+    id: name,
+    name: name,
+    kind: kind,
+    balance: balance,
+  );
+}
+
+void main() {
+  group('AssetCashflowForecastInputs.subscriptionRecurringEntry', () {
+    test('maps a valid subscription to a recurring entry', () {
+      final entry = AssetCashflowForecastInputs.subscriptionRecurringEntry(
+        <String, dynamic>{
+          'service_name': 'Netflix',
+          'price': 1500,
+          'due_date': '2026-06-10',
+        },
+      );
+
+      expect(entry, isNotNull);
+      expect(entry!.dayOfMonth, 10);
+      expect(entry.amount, 1500);
+      expect(entry.label, 'Netflix');
+    });
+
+    test('returns null for a non-positive or missing price', () {
+      expect(
+        AssetCashflowForecastInputs.subscriptionRecurringEntry(
+          <String, dynamic>{'price': 0},
+        ),
+        isNull,
+      );
+      expect(
+        AssetCashflowForecastInputs.subscriptionRecurringEntry(
+          <String, dynamic>{'foo': 'bar'},
+        ),
+        isNull,
+      );
+    });
+
+    test('falls back to day 1 and 固定費 label when fields are missing', () {
+      final entry = AssetCashflowForecastInputs.subscriptionRecurringEntry(
+        <String, dynamic>{'price': 980},
+      );
+
+      expect(entry!.dayOfMonth, 1);
+      expect(entry.label, '固定費');
+    });
+  });
+
+  group('AssetCashflowForecastInputs.fromAssetData', () {
+    test('sums only positive cash/deposit balances into startingBalance', () {
+      final inputs = AssetCashflowForecastInputs.fromAssetData(
+        accounts: [
+          _account('財布', AssetLiabilityAccountKind.cash, 11000),
+          _account('普通預金', AssetLiabilityAccountKind.deposit, 50000),
+          _account('当座マイナス', AssetLiabilityAccountKind.deposit, -3000),
+          _account('証券', AssetLiabilityAccountKind.securities, 99999),
+        ],
+        debtRows: const [],
+        recurringIncomeTemplates: const [],
+        inflowRules: const [],
+        oneTimeInflows: const [],
+        subscriptions: const [],
+      );
+
+      expect(inputs.startingBalance, 61000);
+      expect(inputs.hasData, isFalse);
+    });
+
+    test('derives recurring income from templates and inflow rules', () {
+      final inputs = AssetCashflowForecastInputs.fromAssetData(
+        accounts: const [],
+        debtRows: const [],
+        recurringIncomeTemplates: const [
+          AssetLiabilityRecurringIncomeTemplate(
+            id: 't1',
+            dayOfMonth: 25,
+            name: '給料',
+            amount: 300000,
+            destinationAccountId: null,
+            destinationAccountName: null,
+          ),
+          AssetLiabilityRecurringIncomeTemplate(
+            id: 't0',
+            dayOfMonth: 0,
+            name: 'invalid-day',
+            amount: 1,
+            destinationAccountId: null,
+            destinationAccountName: null,
+          ),
+        ],
+        inflowRules: const [
+          AssetExpectedInflowRule(
+            id: 'r1',
+            dayOfMonth: 10,
+            amount: 20000,
+            label: '副業',
+          ),
+        ],
+        oneTimeInflows: const [],
+        subscriptions: const [],
+      );
+
+      expect(inputs.recurringIncome, hasLength(2));
+      expect(
+        inputs.recurringIncome.map((e) => e.label),
+        containsAll(<String>['給料', '副業']),
+      );
+      expect(inputs.hasData, isTrue);
+    });
+
+    test('subscriptions → recurring outflow; one-time inflows → dated income',
+        () {
+      final inputs = AssetCashflowForecastInputs.fromAssetData(
+        accounts: const [],
+        debtRows: const [],
+        recurringIncomeTemplates: const [],
+        inflowRules: const [],
+        oneTimeInflows: [
+          AssetExpectedInflow(
+            id: 'i1',
+            date: DateTime(2026, 7, 5),
+            amount: 50000,
+            label: '臨時',
+          ),
+          AssetExpectedInflow(
+            id: 'i0',
+            date: DateTime(2026, 7, 6),
+            amount: 0,
+            label: 'zero',
+          ),
+        ],
+        subscriptions: [
+          <String, dynamic>{
+            'service_name': 'Spotify',
+            'price': 980,
+            'due_date': '2026-06-15',
+          },
+          <String, dynamic>{'service_name': 'bad', 'price': 0},
+        ],
+      );
+
+      expect(inputs.recurringOutflow, hasLength(1));
+      expect(inputs.recurringOutflow.single.label, 'Spotify');
+      expect(inputs.recurringOutflow.single.dayOfMonth, 15);
+      expect(inputs.oneTimeIncome, hasLength(1));
+      expect(inputs.oneTimeIncome.single.amount, 50000);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Page-health refactor: the cashflow forecast input derivation (starting balance,
recurring income, recurring outflow, one-time income) was inlined in
`_buildCashflowForecastCard`, untested and adding ~70 lines to the 25k-line
asset page. This moves it verbatim into a pure function, behavior unchanged.

## Changes

- New `lib/services/asset_cashflow_forecast_inputs.dart`:
  `AssetCashflowForecastInputs.fromAssetData(...)` derives the forecast inputs
  from accounts / debt rows / income templates / inflow rules / one-time
  inflows / subscriptions. Same logic and ordering (debts then subscriptions).
- Page: `_buildCashflowForecastCard` now calls it and checks `hasData`; the
  inline derivation and `_subscriptionRecurringEntry` are removed (net -70
  lines on the page).
- Unit tests for the derivation and the subscription mapper, which were
  previously untestable inside a build method.

## Minimal E2E Gate

- Implementation-detail independent: the tests assert the derivation's
  user-relevant input/output (which entries are produced from page data), not
  private internals.
- Minimal scope: about 3 cases (starting balance, recurring income, one-time +
  subscription mapping).
- E2E: covered by the new unit tests in `test/services/`; the forecast card
  itself is exercised by existing widget tests; no new integration_test /
  Playwright e2e (see exception).
- E2E-Exception: behavior-preserving refactor (no user-visible change) verified
  by the new unit tests plus the existing forecast widget tests; the page is
  auth-gated.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: behavior-preserving refactor (pure-function
  extraction) with unit tests; no high-risk path touched, review owned by
  Claude Code #1.
