### PR TITLE
refactor: extract salary spending entry assembly into a pure service

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -61,6 +61,7 @@ import 'package:my_web_app/services/drink_challenge_service.dart';
 import 'package:my_web_app/services/drink_challenge_store.dart';
 import 'package:my_web_app/services/konbini_udon_challenge_service.dart';
 import 'package:my_web_app/services/profile_service.dart';
+import 'package:my_web_app/services/asset_salary_spending_entries.dart';
 import 'package:my_web_app/services/salary_spending_breakdown_service.dart';
 import 'package:my_web_app/services/smbc_csv_import_service.dart';
 import 'package:my_web_app/services/waste_tracking_service.dart';
@@ -11703,138 +11704,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   SalarySpendingBreakdown _buildSalarySpendingBreakdown() {
-    final expenses = <SalarySpendingEntry>[];
-    final incomes = <SalaryIncomeEntry>[];
-    final cardBillingMarkers = <String>{};
-
-    bool hasIncomeEntry(DateTime date, double amount) {
-      final rowKey = '${_dateOnly(date)}:${amount.round()}';
-      return incomes.any(
-        (entry) => '${_dateOnly(entry.date)}:${entry.amount.round()}' == rowKey,
-      );
-    }
-
-    void addIncomeEntry({
-      required DateTime date,
-      required double amount,
-      required String description,
-    }) {
-      if (amount <= 0 || hasIncomeEntry(date, amount)) {
-        return;
-      }
-      incomes.add(
-        SalaryIncomeEntry(
-          date: date,
-          amount: amount,
-          description: description.trim().isEmpty ? '収入' : description.trim(),
-        ),
-      );
-    }
-
-    for (final line in _cardStatementLines) {
-      final postedAt = line.postedAt;
-      if (postedAt == null) {
-        continue;
-      }
-      final billingName = line.billingAccountName?.trim();
-      if (billingName != null && billingName.isNotEmpty) {
-        cardBillingMarkers.add(billingName.toLowerCase());
-      }
-      cardBillingMarkers.add(line.billingAccountId.toLowerCase());
-      final billingLabel = billingName != null && billingName.isNotEmpty
-          ? billingName
-          : line.billingAccountId;
-      expenses.add(
-        SalarySpendingEntry(
-          date: postedAt,
-          amount: line.amount,
-          description: line.description,
-          sourceLabel: billingLabel,
-        ),
-      );
-    }
-
-    for (final flow in _recentFlows) {
-      final actionType = flow['action_type']?.toString() ?? '';
-      if (_isTransferActionType(actionType)) {
-        continue;
-      }
-      final occurredAt = DateTime.tryParse(
-        flow['occurred_at']?.toString() ?? '',
-      )?.toLocal();
-      final amount = (flow['amount'] as num?)?.toDouble() ?? 0;
-      if (occurredAt == null || amount <= 0) {
-        continue;
-      }
-      final description = flow['description']?.toString() ?? '';
-      final displayTitle = _flowDisplayTitle(flow);
-      if (_isExpenseActionType(actionType)) {
-        final lowerDescription = description.toLowerCase();
-        final representedByCardDetail = cardBillingMarkers.any(
-          (marker) => marker.isNotEmpty && lowerDescription.contains(marker),
-        );
-        if (representedByCardDetail) {
-          continue;
-        }
-        expenses.add(
-          SalarySpendingEntry(
-            date: occurredAt,
-            amount: amount,
-            description: displayTitle.isEmpty ? description : displayTitle,
-            sourceLabel: _actionTypeToFlowLabel(actionType),
-          ),
-        );
-      } else if (_isIncomeActionType(actionType)) {
-        incomes.add(
-          SalaryIncomeEntry(
-            date: occurredAt,
-            amount: amount,
-            description: displayTitle.isEmpty ? description : displayTitle,
-          ),
-        );
-      }
-    }
-
-    for (final plan in _monthlyIncomePlans) {
-      addIncomeEntry(
-        date: plan.date,
-        amount: plan.amount,
-        description: plan.name,
-      );
-    }
-
-    for (final row in _payslipSalaryIncomes) {
-      final payDate = DateTime.tryParse(row['pay_date']?.toString() ?? '');
-      final amount = _numberFromDynamic(row['amount']);
-      if (payDate == null || amount <= 0) {
-        continue;
-      }
-      final description = row['description']?.toString().trim() ?? '';
-      addIncomeEntry(
-        date: payDate,
-        amount: amount,
-        description: description.isEmpty ? '給与明細' : '給与明細: $description',
-      );
-    }
-
-    for (final row in _payslipRows) {
-      final payDate = DateTime.tryParse(row['pay_date']?.toString() ?? '');
-      final amount = _numberFromDynamic(row['net_amount']);
-      if (payDate == null || amount <= 0) {
-        continue;
-      }
-      final companyName = row['company_name']?.toString().trim() ?? '';
-      addIncomeEntry(
-        date: payDate,
-        amount: amount,
-        description: companyName.isEmpty ? '給与明細' : '給与明細: $companyName',
-      );
-    }
-
+    final entries = AssetSalarySpendingEntries.build(
+      cardStatementLines: _cardStatementLines,
+      recentFlows: _recentFlows,
+      monthlyIncomePlans: _monthlyIncomePlans,
+      payslipSalaryIncomes: _payslipSalaryIncomes,
+      payslipRows: _payslipRows,
+      flowDisplayTitle: _flowDisplayTitle,
+    );
     return _salarySpendingBreakdownService.build(
       referenceDate: _now,
-      expenses: expenses,
-      incomes: incomes,
+      expenses: entries.expenses,
+      incomes: entries.incomes,
       salaryDay: _salarySpendingSalaryDay,
     );
   }

--- a/lib/services/asset_salary_spending_entries.dart
+++ b/lib/services/asset_salary_spending_entries.dart
@@ -1,0 +1,196 @@
+import '../models/asset_liability_workbook.dart';
+import 'salary_spending_breakdown_service.dart';
+
+/// 資産管理ページのフロー(カード明細・収支履歴・収入計画・給与明細)から
+/// [SalarySpendingBreakdownService] へ渡す [SalarySpendingEntry] /
+/// [SalaryIncomeEntry] を組み立てる純関数の置き場。
+///
+/// 元々ページの `_buildSalarySpendingBreakdown` 内にインライン化されていた集計
+/// ロジックを抽出し、build から切り離してユニットテスト可能にしたもの(振る舞いは
+/// 不変)。表示タイトルの導出だけはページ依存(`_flowDisplayTitle` → 説明パース)の
+/// ため、関数として注入する。
+class AssetSalarySpendingEntries {
+  const AssetSalarySpendingEntries({
+    required this.expenses,
+    required this.incomes,
+  });
+
+  final List<SalarySpendingEntry> expenses;
+  final List<SalaryIncomeEntry> incomes;
+
+  /// 各種フローから支出/収入エントリを組み立てる。
+  ///
+  /// - カード明細 = すべて支出。billing 名/ID を「カード明細マーカー」に記録。
+  /// - 収支履歴(recentFlows)= 振替は除外。支出はカード明細マーカーに含まれる
+  ///   説明なら二重計上回避で除外。収入(conquer)は収入へ。
+  /// - 収入計画・給与明細 = 同日同額の重複を排除して収入へ。
+  static AssetSalarySpendingEntries build({
+    required List<AssetLiabilityCardStatementLine> cardStatementLines,
+    required List<Map<String, dynamic>> recentFlows,
+    required List<AssetLiabilityIncomePlan> monthlyIncomePlans,
+    required List<Map<String, dynamic>> payslipSalaryIncomes,
+    required List<Map<String, dynamic>> payslipRows,
+    required String Function(Map<String, dynamic> flow) flowDisplayTitle,
+  }) {
+    final expenses = <SalarySpendingEntry>[];
+    final incomes = <SalaryIncomeEntry>[];
+    final cardBillingMarkers = <String>{};
+
+    bool hasIncomeEntry(DateTime date, double amount) {
+      final rowKey = '${_dateKey(date)}:${amount.round()}';
+      return incomes.any(
+        (entry) => '${_dateKey(entry.date)}:${entry.amount.round()}' == rowKey,
+      );
+    }
+
+    void addIncomeEntry({
+      required DateTime date,
+      required double amount,
+      required String description,
+    }) {
+      if (amount <= 0 || hasIncomeEntry(date, amount)) {
+        return;
+      }
+      incomes.add(
+        SalaryIncomeEntry(
+          date: date,
+          amount: amount,
+          description: description.trim().isEmpty ? '収入' : description.trim(),
+        ),
+      );
+    }
+
+    for (final line in cardStatementLines) {
+      final postedAt = line.postedAt;
+      if (postedAt == null) {
+        continue;
+      }
+      final billingName = line.billingAccountName?.trim();
+      if (billingName != null && billingName.isNotEmpty) {
+        cardBillingMarkers.add(billingName.toLowerCase());
+      }
+      cardBillingMarkers.add(line.billingAccountId.toLowerCase());
+      final billingLabel = billingName != null && billingName.isNotEmpty
+          ? billingName
+          : line.billingAccountId;
+      expenses.add(
+        SalarySpendingEntry(
+          date: postedAt,
+          amount: line.amount,
+          description: line.description,
+          sourceLabel: billingLabel,
+        ),
+      );
+    }
+
+    for (final flow in recentFlows) {
+      final actionType = flow['action_type']?.toString() ?? '';
+      if (actionType == 'transfer') {
+        continue;
+      }
+      final occurredAt = DateTime.tryParse(
+        flow['occurred_at']?.toString() ?? '',
+      )?.toLocal();
+      final amount = (flow['amount'] as num?)?.toDouble() ?? 0;
+      if (occurredAt == null || amount <= 0) {
+        continue;
+      }
+      final description = flow['description']?.toString() ?? '';
+      final displayTitle = flowDisplayTitle(flow);
+      if (actionType == 'expense') {
+        final lowerDescription = description.toLowerCase();
+        final representedByCardDetail = cardBillingMarkers.any(
+          (marker) => marker.isNotEmpty && lowerDescription.contains(marker),
+        );
+        if (representedByCardDetail) {
+          continue;
+        }
+        expenses.add(
+          SalarySpendingEntry(
+            date: occurredAt,
+            amount: amount,
+            description: displayTitle.isEmpty ? description : displayTitle,
+            sourceLabel: _flowLabel(actionType),
+          ),
+        );
+      } else if (actionType == 'conquer') {
+        incomes.add(
+          SalaryIncomeEntry(
+            date: occurredAt,
+            amount: amount,
+            description: displayTitle.isEmpty ? description : displayTitle,
+          ),
+        );
+      }
+    }
+
+    for (final plan in monthlyIncomePlans) {
+      addIncomeEntry(
+        date: plan.date,
+        amount: plan.amount,
+        description: plan.name,
+      );
+    }
+
+    for (final row in payslipSalaryIncomes) {
+      final payDate = DateTime.tryParse(row['pay_date']?.toString() ?? '');
+      final amount = _num(row['amount']);
+      if (payDate == null || amount <= 0) {
+        continue;
+      }
+      final description = row['description']?.toString().trim() ?? '';
+      addIncomeEntry(
+        date: payDate,
+        amount: amount,
+        description: description.isEmpty ? '給与明細' : '給与明細: $description',
+      );
+    }
+
+    for (final row in payslipRows) {
+      final payDate = DateTime.tryParse(row['pay_date']?.toString() ?? '');
+      final amount = _num(row['net_amount']);
+      if (payDate == null || amount <= 0) {
+        continue;
+      }
+      final companyName = row['company_name']?.toString().trim() ?? '';
+      addIncomeEntry(
+        date: payDate,
+        amount: amount,
+        description: companyName.isEmpty ? '給与明細' : '給与明細: $companyName',
+      );
+    }
+
+    return AssetSalarySpendingEntries(expenses: expenses, incomes: incomes);
+  }
+
+  /// action_type のラベル(支出の sourceLabel 用)。
+  static String _flowLabel(String actionType) {
+    switch (actionType) {
+      case 'conquer':
+        return '収入';
+      case 'transfer':
+        return '振替';
+      default:
+        return '支出';
+    }
+  }
+
+  /// 文字列/数値混在の金額を double へ寛容に変換する。
+  static double _num(Object? value) {
+    if (value is num) {
+      return value.toDouble();
+    }
+    if (value == null) {
+      return 0;
+    }
+    return double.tryParse(value.toString().replaceAll(',', '').trim()) ?? 0;
+  }
+
+  /// 同日同額の収入重複排除に使う日付キー(yyyy-MM-dd)。
+  static String _dateKey(DateTime dt) {
+    final y = dt.year.toString().padLeft(4, '0');
+    final m = dt.month.toString().padLeft(2, '0');
+    final d = dt.day.toString().padLeft(2, '0');
+    return '$y-$m-$d';
+  }
+}

--- a/test/services/asset_salary_spending_entries_test.dart
+++ b/test/services/asset_salary_spending_entries_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_salary_spending_entries.dart';
+
+String _title(Map<String, dynamic> flow) =>
+    flow['description']?.toString() ?? '';
+
+AssetLiabilityIncomePlan _plan(String name, DateTime date, double amount) {
+  return AssetLiabilityIncomePlan(
+    id: name,
+    date: date,
+    name: name,
+    amount: amount,
+    destinationAccountId: null,
+    destinationAccountName: null,
+    received: false,
+  );
+}
+
+void main() {
+  group('AssetSalarySpendingEntries.build', () {
+    test('splits recent flows into expense/income and drops transfers', () {
+      final result = AssetSalarySpendingEntries.build(
+        cardStatementLines: const [],
+        recentFlows: [
+          <String, dynamic>{
+            'action_type': 'expense',
+            'amount': 3000,
+            'occurred_at': '2026-06-10',
+            'description': 'ランチ',
+          },
+          <String, dynamic>{
+            'action_type': 'conquer',
+            'amount': 5000,
+            'occurred_at': '2026-06-11',
+            'description': 'メルカリ売上',
+          },
+          <String, dynamic>{
+            'action_type': 'transfer',
+            'amount': 10000,
+            'occurred_at': '2026-06-12',
+            'description': '口座移動',
+          },
+        ],
+        monthlyIncomePlans: const [],
+        payslipSalaryIncomes: const [],
+        payslipRows: const [],
+        flowDisplayTitle: _title,
+      );
+
+      expect(result.expenses, hasLength(1));
+      expect(result.expenses.single.description, 'ランチ');
+      expect(result.expenses.single.sourceLabel, '支出');
+      expect(result.incomes, hasLength(1));
+      expect(result.incomes.single.description, 'メルカリ売上');
+    });
+
+    test('card lines are expenses and dedupe flows that match the marker', () {
+      final result = AssetSalarySpendingEntries.build(
+        cardStatementLines: [
+          AssetLiabilityCardStatementLine(
+            id: 'c1',
+            billingAccountId: 'rakuten',
+            billingAccountName: '楽天カード',
+            postedAt: DateTime(2026, 6, 5),
+            description: 'Amazon',
+            amount: 2000,
+          ),
+        ],
+        recentFlows: [
+          <String, dynamic>{
+            'action_type': 'expense',
+            'amount': 2000,
+            'occurred_at': '2026-06-05',
+            'description': '楽天カード引き落とし',
+          },
+          <String, dynamic>{
+            'action_type': 'expense',
+            'amount': 500,
+            'occurred_at': '2026-06-06',
+            'description': 'コンビニ',
+          },
+        ],
+        monthlyIncomePlans: const [],
+        payslipSalaryIncomes: const [],
+        payslipRows: const [],
+        flowDisplayTitle: _title,
+      );
+
+      expect(result.expenses, hasLength(2));
+      expect(
+        result.expenses.map((e) => e.description),
+        containsAll(<String>['Amazon', 'コンビニ']),
+      );
+      expect(
+        result.expenses.where((e) => e.description.contains('楽天カード')),
+        isEmpty,
+      );
+    });
+
+    test('income plans dedupe by same date and amount', () {
+      final result = AssetSalarySpendingEntries.build(
+        cardStatementLines: const [],
+        recentFlows: const [],
+        monthlyIncomePlans: [
+          _plan('給料', DateTime(2026, 6, 25), 300000),
+          _plan('給料(重複)', DateTime(2026, 6, 25), 300000),
+          _plan('副収入', DateTime(2026, 6, 20), 20000),
+        ],
+        payslipSalaryIncomes: const [],
+        payslipRows: const [],
+        flowDisplayTitle: _title,
+      );
+
+      expect(result.incomes, hasLength(2));
+    });
+
+    test('payslip rows add net amounts as income, skipping non-positive', () {
+      final result = AssetSalarySpendingEntries.build(
+        cardStatementLines: const [],
+        recentFlows: const [],
+        monthlyIncomePlans: const [],
+        payslipSalaryIncomes: const [],
+        payslipRows: const [
+          <String, dynamic>{
+            'pay_date': '2026-06-25',
+            'net_amount': 280000,
+            'company_name': '自分株式会社',
+          },
+          <String, dynamic>{'pay_date': '2026-06-26', 'net_amount': 0},
+        ],
+        flowDisplayTitle: _title,
+      );
+
+      expect(result.incomes, hasLength(1));
+      expect(result.incomes.single.description, '給与明細: 自分株式会社');
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Page-health refactor (follows #3459). `_buildSalarySpendingBreakdown` inlined
~130 lines that assemble expense / income entries from card statement lines,
flow history, income plans and payslips before calling the breakdown service.
This moves the assembly verbatim into a pure function, behavior unchanged.

## Changes

- New `lib/services/asset_salary_spending_entries.dart`:
  `AssetSalarySpendingEntries.build(...)` returns the expense / income entry
  lists. The trivial `action_type` classifiers and number/date helpers are
  inlined; the only page-coupled piece (the flow display title, which parses
  descriptions) is injected as a function parameter.
- Page: `_buildSalarySpendingBreakdown` now calls `build()` and forwards the
  result to `SalarySpendingBreakdownService` (net -119 lines on the page). The
  classifier helpers stay (still used elsewhere).
- Unit tests for the transfer filter, the card-billing-marker dedupe, the
  income dedupe, and payslip income, previously untestable inside the page.

## Minimal E2E Gate

- Implementation-detail independent: the tests assert the assembly's
  input/output (which entries are produced from each flow source), not private
  internals.
- Minimal scope: about 3 cases (flow split + transfer drop, marker dedupe,
  income dedupe / payslip income).
- E2E: covered by the new unit tests in `test/services/`; the salary breakdown
  card is exercised by existing tests; no new integration_test / Playwright e2e
  (see exception).
- E2E-Exception: behavior-preserving refactor (no user-visible change) verified
  by the new unit tests; the page is reachable only after login.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: behavior-preserving pure-function extraction
  with unit tests; no high-risk path touched, review owned by Claude Code #1.
