### PR TITLE
refactor: extract flow display-title logic into a pure service

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -61,6 +61,7 @@ import 'package:my_web_app/services/drink_challenge_service.dart';
 import 'package:my_web_app/services/drink_challenge_store.dart';
 import 'package:my_web_app/services/konbini_udon_challenge_service.dart';
 import 'package:my_web_app/services/profile_service.dart';
+import 'package:my_web_app/services/asset_flow_description_service.dart';
 import 'package:my_web_app/services/asset_salary_spending_entries.dart';
 import 'package:my_web_app/services/salary_spending_breakdown_service.dart';
 import 'package:my_web_app/services/smbc_csv_import_service.dart';
@@ -923,7 +924,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       '${description.trim()} [auto_asset_delta:$importKey]';
 
   String _sourceLabel(String source) =>
-      source.replaceAll('[', '').replaceAll(']', '').trim();
+      AssetFlowDescriptionService.sourceLabel(source);
 
   List<String> _transferDestinationOptions(String source, {String? include}) {
     final options = [
@@ -6864,36 +6865,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   String _flowDisplayTitle(Map<String, dynamic> flow) {
-    final actionType = flow['action_type']?.toString() ?? '';
-    final parsed = _parseFlowDescription(
-      flow['description']?.toString() ?? '',
-      actionType: actionType,
+    return AssetFlowDescriptionService.displayTitle(
+      _parseFlowDescription(
+        flow['description']?.toString() ?? '',
+        actionType: flow['action_type']?.toString() ?? '',
+      ),
     );
-    if (parsed.isTransfer) {
-      final fromLabel = _sourceLabel(parsed.source);
-      final toLabel = _sourceLabel(parsed.destination);
-      final routeParts = [
-        fromLabel,
-        toLabel,
-      ].where((part) => part.trim().isNotEmpty).toList();
-      final routeLabel = routeParts.join(' → ');
-      if (routeLabel.isEmpty) {
-        return parsed.memo;
-      }
-      if (parsed.memo.isEmpty) {
-        return routeLabel;
-      }
-      return '$routeLabel ・ ${parsed.memo}';
-    }
-
-    final sourceLabel = _sourceLabel(parsed.source);
-    if (sourceLabel.isEmpty) {
-      return parsed.memo;
-    }
-    if (parsed.memo.isEmpty) {
-      return sourceLabel;
-    }
-    return '$sourceLabel ・ ${parsed.memo}';
   }
 
   String _flowLabelToActionType(String label) {

--- a/lib/services/asset_flow_description_service.dart
+++ b/lib/services/asset_flow_description_service.dart
@@ -1,0 +1,52 @@
+/// 収支フローの説明文パース結果(`_parseFlowDescription` の戻り値レコード)。
+typedef FlowDescriptionParts = ({
+  String source,
+  String destination,
+  String memo,
+  String? wasteCategory,
+  bool isTransfer,
+});
+
+/// 収支フローの説明文から表示用ラベル/タイトルを組み立てる純関数の置き場。
+///
+/// 元々ページの `_sourceLabel` / `_flowDisplayTitle` にあった表示ロジックを抽出し、
+/// パース([FlowDescriptionParts])の結果から視覚表現を導く部分をテスト可能に
+/// したもの(振る舞いは不変)。パース本体(正規表現・浪費マーカー除去)は依存が
+/// 重いためページ側に残す。
+class AssetFlowDescriptionService {
+  const AssetFlowDescriptionService._();
+
+  /// `[口座名]` のような source ラベルから囲み括弧を除いた表示名を返す。
+  static String sourceLabel(String source) =>
+      source.replaceAll('[', '').replaceAll(']', '').trim();
+
+  /// パース結果から1行の表示タイトルを組み立てる。
+  /// 振替は「移動元 → 移動先 ・ メモ」、それ以外は「source ・ メモ」。
+  static String displayTitle(FlowDescriptionParts parsed) {
+    if (parsed.isTransfer) {
+      final fromLabel = sourceLabel(parsed.source);
+      final toLabel = sourceLabel(parsed.destination);
+      final routeParts = [
+        fromLabel,
+        toLabel,
+      ].where((part) => part.trim().isNotEmpty).toList();
+      final routeLabel = routeParts.join(' → ');
+      if (routeLabel.isEmpty) {
+        return parsed.memo;
+      }
+      if (parsed.memo.isEmpty) {
+        return routeLabel;
+      }
+      return '$routeLabel ・ ${parsed.memo}';
+    }
+
+    final label = sourceLabel(parsed.source);
+    if (label.isEmpty) {
+      return parsed.memo;
+    }
+    if (parsed.memo.isEmpty) {
+      return label;
+    }
+    return '$label ・ ${parsed.memo}';
+  }
+}

--- a/test/services/asset_flow_description_service_test.dart
+++ b/test/services/asset_flow_description_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_flow_description_service.dart';
+
+FlowDescriptionParts _parts({
+  String source = '',
+  String destination = '',
+  String memo = '',
+  bool isTransfer = false,
+}) {
+  return (
+    source: source,
+    destination: destination,
+    memo: memo,
+    wasteCategory: null,
+    isTransfer: isTransfer,
+  );
+}
+
+void main() {
+  group('AssetFlowDescriptionService', () {
+    test('sourceLabel strips bracket markers', () {
+      expect(AssetFlowDescriptionService.sourceLabel('[楽天カード]'), '楽天カード');
+      expect(AssetFlowDescriptionService.sourceLabel(''), '');
+    });
+
+    test('displayTitle joins a transfer route and memo', () {
+      expect(
+        AssetFlowDescriptionService.displayTitle(
+          _parts(
+            source: '[A]',
+            destination: '[B]',
+            memo: 'メモ',
+            isTransfer: true,
+          ),
+        ),
+        'A → B ・ メモ',
+      );
+    });
+
+    test('displayTitle for a transfer without memo shows the route only', () {
+      expect(
+        AssetFlowDescriptionService.displayTitle(
+          _parts(source: '[A]', destination: '[B]', isTransfer: true),
+        ),
+        'A → B',
+      );
+    });
+
+    test('displayTitle joins source and memo for a non-transfer', () {
+      expect(
+        AssetFlowDescriptionService.displayTitle(
+          _parts(source: '[財布]', memo: 'ランチ'),
+        ),
+        '財布 ・ ランチ',
+      );
+    });
+
+    test('displayTitle falls back to memo when there is no source', () {
+      expect(
+        AssetFlowDescriptionService.displayTitle(_parts(memo: 'コンビニ')),
+        'コンビニ',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Continues the `asset_management_page.dart` health pass. The flow display-title
logic is moved into a pure, unit-testable service while the page keeps thin
delegators, so no call site changes (zero churn).

## Changes

- New `AssetFlowDescriptionService.sourceLabel` / `displayTitle` (pure), with a
  shared `FlowDescriptionParts` record typedef.
- `_sourceLabel` / `_flowDisplayTitle` become one-line delegators; all existing
  call sites are unchanged.
- The regex / waste-marker parse (`_parseFlowDescription`) stays in the page
  (heavier dependencies), so this is a behavior-preserving move.
- Unit tests for the transfer / non-transfer / empty title cases.

## Minimal E2E Gate

- Implementation-detail independent: the tests assert the user-visible title
  string for given parsed parts (input/output), not internals.
- Minimal scope: about 3 cases (transfer route, source+memo, memo-only fallback).
- E2E: covered by unit tests in `test/services/`; no integration_test /
  Playwright e2e is added for a pure-refactor move (see exception).
- E2E-Exception: behavior-preserving extraction (page keeps delegators, no call
  site changes); the moved logic is unit tested and the page is auth-gated.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: behavior-preserving refactor (logic moved to
  a pure service, page keeps delegators) with unit tests; no high-risk path
  touched, review owned by Claude Code #1.
