### PR TITLE
fix(asset): 月次stateの端末間マージで支払済みチェックが消える問題を是正

### DIFF
--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -50,6 +50,101 @@ class AssetLiabilityMonthlyState {
       cardStatementLines.isEmpty &&
       incomePlans.isEmpty &&
       transferTasks.isEmpty;
+
+  /// マップ/セット/リストの総エントリ数 (= 端末間マージで「増えたか」判定に使う)。
+  int get totalEntryCount =>
+      paymentOverrides.length +
+      actualPaymentAmounts.length +
+      paymentDifferenceReasons.length +
+      annualRateOverrides.length +
+      annualRateEvidences.length +
+      paidAccountNames.length +
+      billingConfirmedAccountIds.length +
+      paymentSourceAccountIds.length +
+      cardBillingAccountIds.length +
+      cardStatementLines.length +
+      incomePlans.length +
+      transferTasks.length;
+
+  /// 端末間同期の競合解決: ローカルと [other] (別端末で保存された状態) の入力を
+  /// 両方保持する union マージ。スカラ値の衝突は this(ローカル) を優先し、
+  /// [other] にしか無いキー/要素 (= 別端末で付けた支払済み等) を補完する。
+  ///
+  /// 旧実装は競合時に無条件でローカルを返し、別端末で付けた「支払済み」を取りこぼした上、
+  /// それをサーバへ保存し直して上書き消去していた。union は monotonic (追加のみ) なので
+  /// データ消失や重複が無く、並行マージしても収束する。
+  ///
+  /// 注意: 削除 (支払済みのチェック解除) の伝播はしない。removal の端末間伝播は
+  /// 既存の tombstone パターン (リボ/ウォッチリスト等で実績) を別途適用する将来課題。
+  AssetLiabilityMonthlyState mergeWith(AssetLiabilityMonthlyState other) {
+    return AssetLiabilityMonthlyState(
+      paymentOverrides: <String, double>{
+        ...other.paymentOverrides,
+        ...paymentOverrides,
+      },
+      actualPaymentAmounts: <String, double>{
+        ...other.actualPaymentAmounts,
+        ...actualPaymentAmounts,
+      },
+      paymentDifferenceReasons: <String, String>{
+        ...other.paymentDifferenceReasons,
+        ...paymentDifferenceReasons,
+      },
+      annualRateOverrides: <String, double>{
+        ...other.annualRateOverrides,
+        ...annualRateOverrides,
+      },
+      annualRateEvidences: <String, AssetLiabilityAnnualRateEvidence>{
+        ...other.annualRateEvidences,
+        ...annualRateEvidences,
+      },
+      paidAccountNames: <String>{
+        ...other.paidAccountNames,
+        ...paidAccountNames,
+      },
+      billingConfirmedAccountIds: <String>{
+        ...other.billingConfirmedAccountIds,
+        ...billingConfirmedAccountIds,
+      },
+      paymentSourceAccountIds: <String, String>{
+        ...other.paymentSourceAccountIds,
+        ...paymentSourceAccountIds,
+      },
+      cardBillingAccountIds: <String, String>{
+        ...other.cardBillingAccountIds,
+        ...cardBillingAccountIds,
+      },
+      cardStatementLines: _mergeById(
+        cardStatementLines,
+        other.cardStatementLines,
+        (line) => line.id,
+      ),
+      incomePlans: _mergeById(
+        incomePlans,
+        other.incomePlans,
+        (plan) => plan.id,
+      ),
+      transferTasks: _mergeById(
+        transferTasks,
+        other.transferTasks,
+        (task) => task.id,
+      ),
+    );
+  }
+
+  /// ローカルの要素を保持しつつ、[remote] のうちローカルに無い id の要素だけ追加する
+  /// (id による重複排除付き union)。
+  static List<T> _mergeById<T>(
+    List<T> local,
+    List<T> remote,
+    String Function(T) idOf,
+  ) {
+    final localIds = local.map(idOf).toSet();
+    return <T>[
+      ...local,
+      ...remote.where((element) => !localIds.contains(idOf(element))),
+    ];
+  }
 }
 
 class AssetLiabilityMonthlyStateStore {

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -513,7 +513,21 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       return remoteState;
     }
 
-    return local;
+    // 双方に入力がある場合は union マージする。旧実装は無条件に local を返し、
+    // 別端末で付けた「支払済み」等を無視した上に、その local をサーバへ保存し直して
+    // リモートの入力を上書き消去していた (= PC で支払済みにしてもスマホで未払いに戻る)。
+    // union は monotonic なので、両端末の入力を取りこぼさず収束する。
+    final merged = local.mergeWith(remoteState);
+    if (merged.totalEntryCount > local.totalEntryCount) {
+      await localRepository.saveMonth(month: month, state: merged);
+    }
+    if (supabaseWritesEnabled &&
+        merged.totalEntryCount > remoteState.totalEntryCount) {
+      await _tryRemote(
+        () => remote.saveMonth(userId: userId, month: month, state: merged),
+      );
+    }
+    return merged;
   }
 
   @override

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -679,4 +679,82 @@ void main() {
       );
     });
   });
+
+  group('AssetLiabilityMonthlyState.mergeWith', () {
+    test('unions paid sets and fills gaps from the other device', () {
+      const local = AssetLiabilityMonthlyState(
+        paidAccountNames: <String>{'mobit'},
+        actualPaymentAmounts: <String, double>{'mobit': 61024},
+      );
+      const remote = AssetLiabilityMonthlyState(
+        paidAccountNames: <String>{'yokohama_bank'},
+        actualPaymentAmounts: <String, double>{'yokohama_bank': 4846},
+      );
+
+      final merged = local.mergeWith(remote);
+
+      expect(
+        merged.paidAccountNames,
+        containsAll(<String>{'mobit', 'yokohama_bank'}),
+      );
+      expect(merged.actualPaymentAmounts['mobit'], 61024);
+      expect(merged.actualPaymentAmounts['yokohama_bank'], 4846);
+    });
+
+    test('keeps local value when a scalar key conflicts', () {
+      const local = AssetLiabilityMonthlyState(
+        paymentOverrides: <String, double>{'mobit': 70000},
+      );
+      const remote = AssetLiabilityMonthlyState(
+        paymentOverrides: <String, double>{'mobit': 60000},
+      );
+
+      expect(local.mergeWith(remote).paymentOverrides['mobit'], 70000);
+    });
+
+    test('unions list entries by id without duplicating shared ids', () {
+      final local = AssetLiabilityMonthlyState(
+        transferTasks: <AssetLiabilityTransferTask>[
+          AssetLiabilityTransferTask(
+            id: 'shared',
+            fromAccountId: 'a',
+            fromAccountName: 'A',
+            toAccountId: 'b',
+            toAccountName: 'B',
+            amount: 1000,
+            dueDate: DateTime(2026, 5, 18),
+          ),
+        ],
+      );
+      final remote = AssetLiabilityMonthlyState(
+        transferTasks: <AssetLiabilityTransferTask>[
+          AssetLiabilityTransferTask(
+            id: 'shared',
+            fromAccountId: 'a',
+            fromAccountName: 'A',
+            toAccountId: 'b',
+            toAccountName: 'B',
+            amount: 1000,
+            dueDate: DateTime(2026, 5, 18),
+          ),
+          AssetLiabilityTransferTask(
+            id: 'remote_only',
+            fromAccountId: 'c',
+            fromAccountName: 'C',
+            toAccountId: 'd',
+            toAccountName: 'D',
+            amount: 2000,
+            dueDate: DateTime(2026, 5, 20),
+          ),
+        ],
+      );
+
+      final merged = local.mergeWith(remote);
+
+      expect(merged.transferTasks.map((task) => task.id), <String>[
+        'shared',
+        'remote_only',
+      ]);
+    });
+  });
 }

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -471,6 +471,85 @@ void main() {
     });
 
     test(
+      'loadMonth unions local and remote so cross-device paid is not lost',
+      () async {
+        final local = _FakeAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore();
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          remoteWritesEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
+
+        // この端末(ローカル)はモビットだけ支払済み。
+        await local.saveMonth(
+          month: month,
+          state: const AssetLiabilityMonthlyState(
+            paidAccountNames: <String>{'mobit'},
+          ),
+        );
+        // 別端末(リモート)は横浜銀行を支払済み(実支払額付き)。
+        remote.seedMonth(
+          month,
+          const AssetLiabilityMonthlyState(
+            paidAccountNames: <String>{'yokohama_bank'},
+            actualPaymentAmounts: <String, double>{'yokohama_bank': 4846},
+          ),
+        );
+
+        final merged = await repository.loadMonth(month);
+
+        // 双方の支払済みが取りこぼされず union される (= 端末間で paid が消えない)。
+        expect(
+          merged.paidAccountNames,
+          containsAll(<String>{'mobit', 'yokohama_bank'}),
+        );
+        expect(merged.actualPaymentAmounts['yokohama_bank'], 4846);
+        // 収束のためローカル/リモート双方へマージ結果を保存する。
+        final localAfter = await local.loadMonth(month);
+        expect(localAfter.paidAccountNames, contains('yokohama_bank'));
+        expect(
+          remote.monthState('2026-05')?.paidAccountNames,
+          contains('mobit'),
+        );
+        expect(remote.calls, contains('saveMonth:user-1:2026-05'));
+      },
+    );
+
+    test('loadMonth keeps local value when scalar fields conflict', () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore();
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        remoteWritesEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+      await local.saveMonth(
+        month: month,
+        state: const AssetLiabilityMonthlyState(
+          paymentOverrides: <String, double>{'mobit': 70000},
+        ),
+      );
+      remote.seedMonth(
+        month,
+        const AssetLiabilityMonthlyState(
+          paymentOverrides: <String, double>{'mobit': 60000},
+        ),
+      );
+
+      final merged = await repository.loadMonth(month);
+
+      // 同一キーの衝突は this(ローカル) を優先する。
+      expect(merged.paymentOverrides['mobit'], 70000);
+    });
+
+    test(
       'sync on keeps production writes disabled unless write flag is enabled',
       () async {
         final local = _FakeAssetLiabilityRepository();


### PR DESCRIPTION
## 概要

PC で「支払済み」にチェックしても、別端末（スマホ）や再読み込み後に未払いへ戻り、AI分析が
「期限超過で未払い」と指摘し続ける**根本原因**を是正する。これまでの #3445 / #3463 は AI 文面という
下流の症状だった。真因は月次stateの端末間マージにある。

## 原因

月次state（支払済みチェック・実支払額等を含む）を1個の blob で Supabase 同期しているが、
`FeatureFlaggedAssetLiabilityRepository.loadMonth` が**ローカルとリモートの両方に入力があると
無条件でローカルを返し**、別端末で付けた `paid` を無視。さらにその（paid を含まない）ローカルを
サーバへ保存し直して**リモートの入力を上書き消去（lost update）**していた。

memory が他4ドメイン（リボ／ウォッチリスト／メイン口座／支払日上書き）で潰してきた
「ローカル空時のみ復元」アンチパターンの、月次state版の取り残し。

## 修正

- `AssetLiabilityMonthlyState.mergeWith`: union マージ（マップ／セット／リストを両端末分保持。
  リスト要素は id で重複排除。スカラ値の衝突はローカル優先。monotonic なのでデータ消失・重複が無く、
  並行マージしても収束）。
- `loadMonth`: 双方非空時の `return local` を **union マージ＋収束保存** へ置換。
- 削除（チェック解除）の端末間伝播は union では不可。removal 伝播は既存の tombstone パターンを
  別途適用する将来課題として明記（本PRは「付けた paid が消えない」を解消）。

## 検証

- `flutter test`（repo 64件 green）: loadMonth union 伝播 / スカラ衝突=ローカル優先 の2件追加
- model `mergeWith` 3件（paid union＋gap-fill / スカラ衝突 / リスト id union）
- `flutter analyze`（4ファイル No issues）/ `dart format --language-version=3.4`（差分なし）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 端末間マージは純関数+リポジトリfakeの単体テスト5件で検証。認証付き多端末同期はUI/E2Eで再現困難なため

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: lib/services のみ変更で高リスクパス(auth/billing/supabase functions/migrations/RLS)に未接触。同期マージの純関数化と単体テストで担保
