### PR TITLE
feat: 定期取引検出 v2a (隔月検出 + 引落元口座の自動prefill)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -8581,6 +8581,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           label: label,
           amount: amount,
           occurredAt: occurredAt,
+          sourceName: AssetRecurringTransactionDetector.stripAccountBrackets(
+            parsed.source,
+          ),
         ),
       );
     }
@@ -8618,15 +8621,28 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       value.replaceAll(RegExp(r'\s+'), '').toLowerCase();
 
   /// 検出された定期取引を `prefill` として固定費登録ダイアログを開く。
+  /// 周期(毎月/隔月)と最頻の引落元口座も初期値に反映する。
   Future<void> _registerDetectedRecurringTransaction(
     DetectedRecurringTransaction detected, {
     required List<RecurringFixedCostSourceOption> sourceOptions,
   }) {
+    final suggestedSource = detected.suggestedSourceName;
+    String? sourceAccountId;
+    if (suggestedSource != null) {
+      for (final option in sourceOptions) {
+        if (option.name == suggestedSource) {
+          sourceAccountId = option.id;
+          break;
+        }
+      }
+    }
     final draft = AssetRecurringFixedCost(
       id: 'fc_suggestion',
       name: detected.label,
       amount: detected.typicalAmount.toDouble(),
       paymentDay: detected.typicalPaymentDay,
+      cadence: detected.cadence,
+      sourceAccountId: sourceAccountId,
     );
     return _openRecurringFixedCostEditor(
       prefill: draft,

--- a/lib/services/asset_recurring_transaction_detector.dart
+++ b/lib/services/asset_recurring_transaction_detector.dart
@@ -1,3 +1,5 @@
+import '../models/asset_liability_workbook.dart';
+
 /// 検出の信頼度。
 enum RecurringTransactionConfidence { high, medium }
 
@@ -5,16 +7,19 @@ enum RecurringTransactionConfidence { high, medium }
 ///
 /// [label] は `AssetRecurringTransactionDetector.buildLabel` 等で正規化した
 /// グルーピング用のキー。[amount] は円(正の整数)。[occurredAt] はローカル日時。
+/// [sourceName] は引落元口座の表示名(`[...]` を外したもの / 任意 / 振替元 prefill 用)。
 class RecurringTransactionObservation {
   const RecurringTransactionObservation({
     required this.label,
     required this.amount,
     required this.occurredAt,
+    this.sourceName = '',
   });
 
   final String label;
   final int amount;
   final DateTime occurredAt;
+  final String sourceName;
 }
 
 /// 検出された定期取引(= 固定費登録の候補)。
@@ -26,7 +31,9 @@ class DetectedRecurringTransaction {
     required this.occurrenceCount,
     required this.monthsObserved,
     required this.confidence,
+    required this.cadence,
     required this.lastSeen,
+    this.suggestedSourceName,
   });
 
   /// 表示名兼グルーピングキー(例: 電気代)。
@@ -46,30 +53,39 @@ class DetectedRecurringTransaction {
 
   final RecurringTransactionConfidence confidence;
 
+  /// 推定される発生周期(毎月 / 隔月偶数月 / 隔月奇数月)。
+  final AssetRecurringFixedCostCadence cadence;
+
   /// 直近の観測日時。
   final DateTime lastSeen;
+
+  /// 最頻の引落元口座名(振替元 prefill 用 / 不明なら null)。
+  final String? suggestedSourceName;
 }
 
-/// フロー履歴から「毎月◯日頃に約◯円」の繰り返し支出を検出する純関数サービス。
+/// フロー履歴から「毎月/隔月◯日頃に約◯円」の繰り返し支出を検出する純関数サービス。
 ///
 /// description のパース(口座名/使途/浪費マーカー除去)はページ側で行い、
 /// 正規化済みの [RecurringTransactionObservation] 列を渡す想定。スキーマ非依存・
-/// 完全テスト可。隔月(bimonthly)検出や収入側はスコープ外(将来候補)。
+/// 完全テスト可。収入側の定期検出はスコープ外(将来候補)。
 class AssetRecurringTransactionDetector {
   const AssetRecurringTransactionDetector();
 
   /// [observations] から定期支出を検出する。
   ///
   /// - 直近 [lookbackMonths] カレンダー月([asOf] 月を含む)に限定。
-  /// - [label] でグループ化し distinct 月数 >= [minMonthlyOccurrences] を候補に。
+  /// - [label] でグループ化し、毎月(distinct 月数 >= [minMonthlyOccurrences])または
+  ///   隔月(同パリティ月のみ・月間隔がすべて 2・distinct 月数 >= [minBimonthlyOccurrences])
+  ///   のいずれかを満たす候補を採用。
   /// - 全観測が中央値の ±[amountTolerance] に収まる(= 金額安定)候補のみ採用。
   /// - 中央値が [minTypicalAmount] 未満の小額ノイズは除外。
   /// - 金額(中央値)降順でソートして返す。
   static List<DetectedRecurringTransaction> detect({
     required List<RecurringTransactionObservation> observations,
     required DateTime asOf,
-    int lookbackMonths = 4,
-    int minMonthlyOccurrences = 3,
+    int lookbackMonths = 6,
+    int minMonthlyOccurrences = 4,
+    int minBimonthlyOccurrences = 3,
     int minTypicalAmount = 1000,
     double amountTolerance = 0.25,
   }) {
@@ -94,9 +110,6 @@ class AssetRecurringTransactionDetector {
     final detected = <DetectedRecurringTransaction>[];
     grouped.forEach((label, group) {
       final months = group.map((obs) => _monthIndex(obs.occurredAt)).toSet();
-      if (months.length < minMonthlyOccurrences) {
-        return;
-      }
 
       final amounts = <int>[for (final obs in group) obs.amount.abs()];
       final typicalAmount = _median(amounts);
@@ -107,16 +120,23 @@ class AssetRecurringTransactionDetector {
         return;
       }
 
+      final cadenceResult = _resolveCadence(
+        months: months,
+        windowStartIndex: windowStartIndex,
+        asOfIndex: asOfIndex,
+        minMonthlyOccurrences: minMonthlyOccurrences,
+        minBimonthlyOccurrences: minBimonthlyOccurrences,
+      );
+      if (cadenceResult == null) {
+        return;
+      }
+
       final days = <int>[for (final obs in group) obs.occurredAt.day];
       final typicalDay = _median(days).clamp(1, 31);
 
       final lastSeen = group
           .map((obs) => obs.occurredAt)
           .reduce((a, b) => a.isAfter(b) ? a : b);
-
-      final confidence = months.length >= lookbackMonths
-          ? RecurringTransactionConfidence.high
-          : RecurringTransactionConfidence.medium;
 
       detected.add(
         DetectedRecurringTransaction(
@@ -125,8 +145,12 @@ class AssetRecurringTransactionDetector {
           typicalPaymentDay: typicalDay,
           occurrenceCount: group.length,
           monthsObserved: months.length,
-          confidence: confidence,
+          confidence: cadenceResult.highCoverage
+              ? RecurringTransactionConfidence.high
+              : RecurringTransactionConfidence.medium,
+          cadence: cadenceResult.cadence,
           lastSeen: lastSeen,
+          suggestedSourceName: _dominantSourceName(group),
         ),
       );
     });
@@ -149,8 +173,86 @@ class AssetRecurringTransactionDetector {
     if (cleanedMemo.isNotEmpty) {
       return cleanedMemo;
     }
-    final cleanedSource = source.replaceAll(RegExp(r'[\[\]]'), '').trim();
-    return cleanedSource;
+    return stripAccountBrackets(source);
+  }
+
+  /// `[口座名]` から括弧を外して口座名だけにする。
+  static String stripAccountBrackets(String source) =>
+      source.replaceAll(RegExp(r'[\[\]]'), '').trim();
+
+  static _CadenceResult? _resolveCadence({
+    required Set<int> months,
+    required int windowStartIndex,
+    required int asOfIndex,
+    required int minMonthlyOccurrences,
+    required int minBimonthlyOccurrences,
+  }) {
+    if (months.length >= minMonthlyOccurrences) {
+      final lookback = asOfIndex - windowStartIndex + 1;
+      return _CadenceResult(
+        cadence: AssetRecurringFixedCostCadence.monthly,
+        highCoverage: months.length >= lookback,
+      );
+    }
+    if (months.length < minBimonthlyOccurrences) {
+      return null;
+    }
+    final sorted = months.toList()..sort();
+    for (var i = 1; i < sorted.length; i++) {
+      if (sorted[i] - sorted[i - 1] != 2) {
+        return null; // 毎月でも厳密隔月でもない(不規則)。
+      }
+    }
+    final monthOfYear = (sorted.first % 12) + 1;
+    final isEven = monthOfYear.isEven;
+    final sameParityInWindow = _sameParityMonthCount(
+      windowStartIndex: windowStartIndex,
+      asOfIndex: asOfIndex,
+      even: isEven,
+    );
+    return _CadenceResult(
+      cadence: isEven
+          ? AssetRecurringFixedCostCadence.bimonthlyEvenMonth
+          : AssetRecurringFixedCostCadence.bimonthlyOddMonth,
+      highCoverage: months.length >= sameParityInWindow,
+    );
+  }
+
+  static int _sameParityMonthCount({
+    required int windowStartIndex,
+    required int asOfIndex,
+    required bool even,
+  }) {
+    var count = 0;
+    for (var idx = windowStartIndex; idx <= asOfIndex; idx++) {
+      final monthOfYear = (idx % 12) + 1;
+      if (monthOfYear.isEven == even) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  static String? _dominantSourceName(
+    List<RecurringTransactionObservation> group,
+  ) {
+    final counts = <String, int>{};
+    for (final obs in group) {
+      final name = obs.sourceName.trim();
+      if (name.isEmpty) {
+        continue;
+      }
+      counts[name] = (counts[name] ?? 0) + 1;
+    }
+    if (counts.isEmpty) {
+      return null;
+    }
+    final sorted = counts.entries.toList()
+      ..sort((a, b) {
+        final byCount = b.value.compareTo(a.value);
+        return byCount != 0 ? byCount : a.key.compareTo(b.key);
+      });
+    return sorted.first.key;
   }
 
   static int _monthIndex(DateTime dt) => dt.year * 12 + (dt.month - 1);
@@ -213,4 +315,12 @@ class AssetRecurringTransactionDetector {
     }
     return buffer.toString();
   }
+}
+
+/// `_resolveCadence` の内部結果(周期 + 窓内フルカバレッジか)。
+class _CadenceResult {
+  const _CadenceResult({required this.cadence, required this.highCoverage});
+
+  final AssetRecurringFixedCostCadence cadence;
+  final bool highCoverage;
 }

--- a/lib/widgets/asset_recurring_transaction_suggestion_card.dart
+++ b/lib/widgets/asset_recurring_transaction_suggestion_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../services/asset_recurring_transaction_detector.dart';
+import 'recurring_fixed_cost_card.dart';
 
 /// 定期取引の自動検出カード。
 ///
@@ -85,7 +86,10 @@ class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
     final isHigh = detected.confidence == RecurringTransactionConfidence.high;
     final confidenceLabel = isHigh ? '確度 高' : '確度 中';
     final confidenceColor = isHigh ? _high : _medium;
-    final summary = '${detected.label}、毎月${detected.typicalPaymentDay}日頃、約'
+    final scheduleLabel =
+        '${RecurringFixedCostCard.cadenceLabel(detected.cadence)}'
+        '${detected.typicalPaymentDay}日頃';
+    final summary = '${detected.label}、$scheduleLabel、約'
         '${_yen(detected.typicalAmount)}、$confidenceLabel、'
         '直近${detected.monthsObserved}ヶ月分を検出';
     return Semantics(
@@ -110,7 +114,7 @@ class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
                     ),
                   ),
                   Text(
-                    '毎月${detected.typicalPaymentDay}日頃',
+                    scheduleLabel,
                     style: const TextStyle(
                       fontSize: 12,
                       color: _muted,

--- a/test/services/asset_recurring_transaction_detector_test.dart
+++ b/test/services/asset_recurring_transaction_detector_test.dart
@@ -1,138 +1,191 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/services/asset_recurring_transaction_detector.dart';
 
 void main() {
-  final asOf = DateTime(2026, 6, 15);
+  final asOf = DateTime(2026, 6, 15); // 窓 = 2026年 1〜6月 (lookback 6)
 
   RecurringTransactionObservation obs(
     String label,
     int amount,
-    int year,
-    int month,
-    int day,
-  ) {
+    int month, {
+    int day = 15,
+    int year = 2026,
+    String sourceName = '',
+  }) {
     return RecurringTransactionObservation(
       label: label,
       amount: amount,
       occurredAt: DateTime(year, month, day),
+      sourceName: sourceName,
     );
   }
 
-  group('AssetRecurringTransactionDetector.detect', () {
-    test('detects a stable monthly expense across recent months', () {
+  group('AssetRecurringTransactionDetector.detect (monthly)', () {
+    test('detects a stable monthly expense present every lookback month', () {
       final result = AssetRecurringTransactionDetector.detect(
-        observations: [
-          obs('電気代', 8000, 2026, 6, 15),
-          obs('電気代', 8200, 2026, 5, 15),
-          obs('電気代', 7800, 2026, 4, 14),
-          obs('電気代', 8100, 2026, 3, 15),
-        ],
+        observations: [for (var m = 1; m <= 6; m++) obs('電気代', 8000, m)],
         asOf: asOf,
       );
 
       expect(result.length, 1);
       final detected = result.single;
       expect(detected.label, '電気代');
-      expect(detected.monthsObserved, 4);
-      expect(detected.typicalPaymentDay, 15);
-      expect(detected.typicalAmount, 8050); // median of 7800/8000/8100/8200
+      expect(detected.cadence, AssetRecurringFixedCostCadence.monthly);
+      expect(detected.monthsObserved, 6);
       expect(detected.confidence, RecurringTransactionConfidence.high);
     });
 
-    test('ignores expenses seen in fewer than the minimum months', () {
+    test('marks medium confidence when present in only some months', () {
       final result = AssetRecurringTransactionDetector.detect(
         observations: [
-          obs('スポット', 5000, 2026, 6, 1),
-          obs('スポット', 5000, 2026, 5, 1),
+          obs('サブスク', 1500, 3),
+          obs('サブスク', 1500, 4),
+          obs('サブスク', 1500, 5),
+          obs('サブスク', 1500, 6),
         ],
         asOf: asOf,
       );
 
-      expect(result, isEmpty);
-    });
-
-    test('ignores expenses with unstable amounts (variable spend)', () {
-      final result = AssetRecurringTransactionDetector.detect(
-        observations: [
-          obs('コンビニ', 500, 2026, 6, 3),
-          obs('コンビニ', 3000, 2026, 5, 9),
-          obs('コンビニ', 12000, 2026, 4, 20),
-        ],
-        asOf: asOf,
-      );
-
-      expect(result, isEmpty);
-    });
-
-    test('marks medium confidence when absent in some lookback months', () {
-      final result = AssetRecurringTransactionDetector.detect(
-        observations: [
-          obs('サブスク', 1500, 2026, 6, 10),
-          obs('サブスク', 1500, 2026, 5, 10),
-          obs('サブスク', 1500, 2026, 4, 10),
-          // 3月は無し → 直近4ヶ月中3ヶ月。
-        ],
-        asOf: asOf,
-      );
-
-      expect(result.single.monthsObserved, 3);
+      expect(result.single.cadence, AssetRecurringFixedCostCadence.monthly);
+      expect(result.single.monthsObserved, 4);
       expect(result.single.confidence, RecurringTransactionConfidence.medium);
+    });
+
+    test('does not detect 3 consecutive months (ambiguous, not bimonthly)', () {
+      final result = AssetRecurringTransactionDetector.detect(
+        observations: [
+          obs('新規', 5000, 4),
+          obs('新規', 5000, 5),
+          obs('新規', 5000, 6),
+        ],
+        asOf: asOf,
+      );
+
+      expect(result, isEmpty);
+    });
+  });
+
+  group('AssetRecurringTransactionDetector.detect (bimonthly)', () {
+    test('detects an even-month bimonthly expense (water bill pattern)', () {
+      final result = AssetRecurringTransactionDetector.detect(
+        observations: [
+          obs('水道代', 6000, 2),
+          obs('水道代', 6200, 4),
+          obs('水道代', 5900, 6),
+        ],
+        asOf: asOf,
+      );
+
+      expect(result.length, 1);
+      final detected = result.single;
+      expect(
+        detected.cadence,
+        AssetRecurringFixedCostCadence.bimonthlyEvenMonth,
+      );
+      expect(detected.monthsObserved, 3);
+      expect(detected.confidence, RecurringTransactionConfidence.high);
+    });
+
+    test('detects an odd-month bimonthly expense', () {
+      final result = AssetRecurringTransactionDetector.detect(
+        observations: [
+          obs('隔月X', 4000, 1),
+          obs('隔月X', 4000, 3),
+          obs('隔月X', 4000, 5),
+        ],
+        asOf: asOf,
+      );
+
+      expect(
+        result.single.cadence,
+        AssetRecurringFixedCostCadence.bimonthlyOddMonth,
+      );
+    });
+
+    test('does not treat an irregular 2-of-6 pattern as bimonthly', () {
+      final result = AssetRecurringTransactionDetector.detect(
+        observations: [obs('不規則', 4000, 2), obs('不規則', 4000, 5)],
+        asOf: asOf,
+      );
+
+      expect(result, isEmpty);
+    });
+  });
+
+  group('AssetRecurringTransactionDetector.detect (filters)', () {
+    test('ignores expenses with unstable amounts', () {
+      final result = AssetRecurringTransactionDetector.detect(
+        observations: [
+          obs('コンビニ', 500, 3),
+          obs('コンビニ', 3000, 4),
+          obs('コンビニ', 12000, 5),
+          obs('コンビニ', 800, 6),
+        ],
+        asOf: asOf,
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('applies the minimum typical amount floor', () {
+      final result = AssetRecurringTransactionDetector.detect(
+        observations: [for (var m = 1; m <= 6; m++) obs('小額', 300, m)],
+        asOf: asOf,
+      );
+
+      expect(result, isEmpty);
     });
 
     test('excludes observations outside the lookback window', () {
       final result = AssetRecurringTransactionDetector.detect(
         observations: [
-          obs('家賃', 60000, 2026, 6, 27),
-          obs('家賃', 60000, 2026, 5, 27),
-          obs('家賃', 60000, 2026, 1, 27), // 窓外 (3月〜6月)
-          obs('家賃', 60000, 2025, 12, 27),
+          obs('家賃', 60000, 5),
+          obs('家賃', 60000, 6),
+          obs('家賃', 60000, 11, year: 2025),
+          obs('家賃', 60000, 12, year: 2025),
         ],
         asOf: asOf,
       );
 
-      expect(result, isEmpty); // 窓内は6月+5月の2ヶ月のみ
-    });
-
-    test('applies the minimum typical amount floor', () {
-      final result = AssetRecurringTransactionDetector.detect(
-        observations: [
-          obs('小額', 300, 2026, 6, 5),
-          obs('小額', 300, 2026, 5, 5),
-          obs('小額', 300, 2026, 4, 5),
-        ],
-        asOf: asOf,
-      );
-
-      expect(result, isEmpty);
+      expect(result, isEmpty); // 窓内は5月+6月の2ヶ月のみ
     });
 
     test('sorts detected transactions by typical amount descending', () {
       final result = AssetRecurringTransactionDetector.detect(
         observations: [
-          obs('通信', 4000, 2026, 6, 21),
-          obs('通信', 4000, 2026, 5, 21),
-          obs('通信', 4000, 2026, 4, 21),
-          obs('家賃', 60000, 2026, 6, 27),
-          obs('家賃', 60000, 2026, 5, 27),
-          obs('家賃', 60000, 2026, 4, 27),
+          for (var m = 1; m <= 6; m++) obs('通信', 4000, m),
+          for (var m = 1; m <= 6; m++) obs('家賃', 60000, m),
         ],
         asOf: asOf,
       );
 
       expect(result.map((d) => d.label).toList(), ['家賃', '通信']);
     });
+  });
 
-    test('skips observations with an empty label', () {
+  group('AssetRecurringTransactionDetector.detect (source)', () {
+    test('reports the most frequent source account name', () {
       final result = AssetRecurringTransactionDetector.detect(
         observations: [
-          obs('', 8000, 2026, 6, 15),
-          obs('', 8000, 2026, 5, 15),
-          obs('', 8000, 2026, 4, 15),
+          obs('電気代', 8000, 3, sourceName: '横浜銀行'),
+          obs('電気代', 8000, 4, sourceName: '横浜銀行'),
+          obs('電気代', 8000, 5, sourceName: '横浜銀行'),
+          obs('電気代', 8000, 6, sourceName: 'みずほ'),
         ],
         asOf: asOf,
       );
 
-      expect(result, isEmpty);
+      expect(result.single.suggestedSourceName, '横浜銀行');
+    });
+
+    test('leaves source null when no source name is present', () {
+      final result = AssetRecurringTransactionDetector.detect(
+        observations: [for (var m = 1; m <= 6; m++) obs('電気代', 8000, m)],
+        asOf: asOf,
+      );
+
+      expect(result.single.suggestedSourceName, isNull);
     });
   });
 

--- a/test/widgets/asset_recurring_transaction_suggestion_card_test.dart
+++ b/test/widgets/asset_recurring_transaction_suggestion_card_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/services/asset_recurring_transaction_detector.dart';
 import 'package:my_web_app/widgets/asset_recurring_transaction_suggestion_card.dart';
 
@@ -8,6 +9,8 @@ void main() {
     String label, {
     RecurringTransactionConfidence confidence =
         RecurringTransactionConfidence.high,
+    AssetRecurringFixedCostCadence cadence =
+        AssetRecurringFixedCostCadence.monthly,
   }) {
     return DetectedRecurringTransaction(
       label: label,
@@ -16,6 +19,7 @@ void main() {
       occurrenceCount: 4,
       monthsObserved: 4,
       confidence: confidence,
+      cadence: cadence,
       lastSeen: DateTime(2026, 6, 15),
     );
   }
@@ -66,6 +70,28 @@ void main() {
 
     expect(tapped, isNotNull);
     expect(tapped!.label, '電気代');
+  });
+
+  testWidgets('shows the cadence label (monthly vs bimonthly)', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AssetRecurringTransactionSuggestionCard(
+            suggestions: [
+              make('電気代'),
+              make(
+                '水道代',
+                cadence: AssetRecurringFixedCostCadence.bimonthlyEvenMonth,
+              ),
+            ],
+            onRegister: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('毎月15日頃'), findsOneWidget);
+    expect(find.text('隔月(偶数月)15日頃'), findsOneWidget);
   });
 
   testWidgets('exposes a semantics label per suggestion', (tester) async {


### PR DESCRIPTION
## 概要

定期取引の自動検出(part 301 / [#3475](https://github.com/kanta13jp1/my_web_app/pull/3475))の v2a。検出精度と登録体験を強化します。

## 変更点

- **隔月(bimonthly)cadence の検出**: 毎月だけでなく「同パリティ月のみ・月間隔がすべて2」の支出を隔月(偶数月/奇数月)として検出(水道代など)。検出窓を直近6ヶ月へ拡張(毎月=4ヶ月以上 / 隔月=3ヶ月以上)。
- **検出元口座の自動 prefill**: 観測に引落元口座名を付与し、最頻の口座を `suggestedSourceName` として返す。固定費登録ダイアログを開く際、周期(`cadence`)と振替元口座(`sourceAccountId`)も初期値に反映。
- カードは周期に応じて「毎月◯日頃 / 隔月(偶数月)◯日頃」を表示(既存 `RecurringFixedCostCard.cadenceLabel` を再利用)。

## 互換性 / リスク

- 純関数 + 自己完結カードで振る舞いをユニット/ウィジェットテストで検証。ページ変更は observation への source 付与と prefill 初期値の追加のみ。

## テスト

- detector: 毎月(全月=高/一部=中)/ 隔月(偶数・奇数)/ 3連続は非検出 / 不規則2点は非隔月 / 変動金額・小額・窓外の除外 / 最頻 source / ソート。
- card: 周期ラベル表示(毎月 vs 隔月)。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数unit+widgetテストで担保。E2E基盤未整備のため対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/services・lib/widgets・lib/pages・test のみ。supabase/workflow/auth系の高リスクパスは未変更。純関数unit+widgetテストで担保
