### PR TITLE
feat: 定期取引検出 v2b (候補の無視を永続化 + ミラー同期)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -40,6 +40,7 @@ import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
+import 'package:my_web_app/services/asset_recurring_suggestion_ignore_store.dart';
 import 'package:my_web_app/services/asset_recurring_transaction_detector.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_inputs.dart';
@@ -414,6 +415,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // UI 登録の定期固定費 (家賃・光熱費など)。振替日昇順で保持する。
   List<AssetRecurringFixedCost> _recurringFixedCosts =
       <AssetRecurringFixedCost>[];
+  // 定期取引の自動検出で「無視」した正規化ラベル(再提案しない)。
+  Set<String> _ignoredRecurringLabels = <String>{};
   // カテゴリ別 月次予算 (category -> 金額)。予算/カテゴリ予実カードで使用。
   Map<String, double> _categoryBudgets = <String, double>{};
   final Map<String, GlobalKey> _debtMasterCardKeys = <String, GlobalKey>{};
@@ -591,6 +594,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final AssetRecurringFixedCostStore _recurringFixedCostStore =
       const AssetRecurringFixedCostStore();
   static const String _recurringFixedCostsMirrorKey = 'recurring_fixed_costs';
+  final AssetRecurringSuggestionIgnoreStore _recurringIgnoreStore =
+      const AssetRecurringSuggestionIgnoreStore();
+  static const String _recurringIgnoredMirrorKey =
+      'recurring_suggestion_ignored';
   final AssetCategoryBudgetStore _categoryBudgetStore =
       const AssetCategoryBudgetStore();
   // 禁酒で借金完済チャレンジの記録(日付→我慢/飲んだ)。v1 はローカル永続化のみ。
@@ -706,6 +713,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_loadRevolvingConfigs());
     unawaited(_loadCategoryBudgets());
     unawaited(_loadRecurringFixedCosts());
+    unawaited(_loadRecurringIgnored());
     unawaited(_loadDrinkChallenge());
     _loadExpectedInflows();
     // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
@@ -8444,6 +8452,92 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  /// 起動時に「無視」集合をローカルから読み、サーバミラーと union する。
+  Future<void> _loadRecurringIgnored() async {
+    try {
+      final ignored = await _recurringIgnoreStore.load();
+      if (mounted && ignored.isNotEmpty) {
+        setState(() => _ignoredRecurringLabels = ignored);
+      }
+    } catch (e) {
+      debugPrint('Error loading recurring ignored: $e');
+    }
+    await _restoreRecurringIgnoredFromMirror();
+  }
+
+  /// サーバミラー (pref_key: recurring_suggestion_ignored) を取り込み、ローカル集合と
+  /// union する(無視は単調増加なので union が安全)。
+  Future<void> _restoreRecurringIgnoredFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', _recurringIgnoredMirrorKey);
+      if (rows.isEmpty) {
+        return;
+      }
+      final serverIgnored =
+          AssetRecurringSuggestionIgnoreStore.decodeMirrorValue(
+        rows.first['value'],
+      );
+      if (!mounted || serverIgnored.isEmpty) {
+        return;
+      }
+      final merged = <String>{..._ignoredRecurringLabels, ...serverIgnored};
+      if (merged.length == _ignoredRecurringLabels.length) {
+        return; // サーバに新規無視なし。
+      }
+      setState(() => _ignoredRecurringLabels = merged);
+      _persistInBackground(
+        _recurringIgnoreStore.save(merged),
+        'recurring ignored restore save',
+      );
+    } catch (e) {
+      debugPrint('recurring ignored mirror restore failed: $e');
+    }
+  }
+
+  /// 「無視」集合の全量を `asset_pref_mirror` へ 1 行 upsert する。
+  Future<void> _mirrorRecurringIgnored() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _recurringIgnoredMirrorKey,
+        'value': AssetRecurringSuggestionIgnoreStore.encodeMirrorValue(
+          _ignoredRecurringLabels,
+        ),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('recurring ignored mirror upsert failed: $e');
+    }
+  }
+
+  /// 検出候補を「無視」集合へ追加して再提案を止める(永続化 + ミラー)。
+  void _ignoreDetectedRecurringTransaction(
+    DetectedRecurringTransaction detected,
+  ) {
+    final label = _normalizeRecurringLabel(detected.label);
+    if (label.isEmpty || _ignoredRecurringLabels.contains(label)) {
+      return;
+    }
+    setState(() {
+      _ignoredRecurringLabels = <String>{..._ignoredRecurringLabels, label};
+    });
+    _persistInBackground(
+      _recurringIgnoreStore.save(_ignoredRecurringLabels),
+      'recurring ignored save',
+    );
+    unawaited(_mirrorRecurringIgnored());
+  }
+
   void _saveRecurringFixedCost(AssetRecurringFixedCost cost) {
     setState(() {
       final next = List<AssetRecurringFixedCost>.from(_recurringFixedCosts);
@@ -8590,13 +8684,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return observations;
   }
 
-  /// 定期取引を検出し、すでに固定費登録済みのものは除外する。
+  /// 定期取引を検出し、登録済み固定費と「無視」した候補を除外する。
   List<DetectedRecurringTransaction> _detectRecurringTransactions() {
     final detected = AssetRecurringTransactionDetector.detect(
       observations: _buildRecurringTransactionObservations(),
       asOf: _now,
     );
-    if (detected.isEmpty || _recurringFixedCosts.isEmpty) {
+    if (detected.isEmpty) {
       return detected;
     }
     final registered = <String>{
@@ -8607,6 +8701,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final label = _normalizeRecurringLabel(item.label);
       if (label.isEmpty) {
         return true;
+      }
+      if (_ignoredRecurringLabels.contains(label)) {
+        return false;
       }
       for (final name in registered) {
         if (label.contains(name) || name.contains(label)) {
@@ -8667,6 +8764,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           sourceOptions: sourceOptions,
         ),
       ),
+      onIgnore: _ignoreDetectedRecurringTransaction,
     );
   }
 

--- a/lib/services/asset_recurring_suggestion_ignore_store.dart
+++ b/lib/services/asset_recurring_suggestion_ignore_store.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 定期取引の自動検出で「この候補を無視」したラベル(正規化済み)を永続化する。
+///
+/// ローカル (SharedPreferences) を一次ストアとし、端末間同期は資産管理ページが
+/// `asset_pref_mirror` (pref_key: `recurring_suggestion_ignored`) へ 1 行 jsonb
+/// 配列でミラーする。無視集合は単調増加(union)前提のため tombstone は不要
+/// (再表示はローカル操作で対応)。保存形は文字列の JSON 配列。
+class AssetRecurringSuggestionIgnoreStore {
+  static const String prefsKey = 'asset_recurring_ignored_v1';
+
+  const AssetRecurringSuggestionIgnoreStore();
+
+  Future<Set<String>> load({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getString(prefsKey);
+    if (raw == null || raw.isEmpty) {
+      return <String>{};
+    }
+    try {
+      return decodeMirrorValue(jsonDecode(raw));
+    } catch (_) {
+      return <String>{};
+    }
+  }
+
+  Future<void> save(Set<String> labels, {SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final encoded = encodeMirrorValue(labels);
+    if (encoded.isEmpty) {
+      await store.remove(prefsKey);
+      return;
+    }
+    await store.setString(prefsKey, jsonEncode(encoded));
+  }
+
+  /// 集合を `asset_pref_mirror.value` (jsonb) 用の安定ソート済み配列へ変換する。
+  /// 空白のみのラベルは捨てる。
+  static List<String> encodeMirrorValue(Set<String> labels) {
+    final cleaned = <String>{
+      for (final label in labels)
+        if (label.trim().isNotEmpty) label.trim(),
+    }.toList()
+      ..sort();
+    return cleaned;
+  }
+
+  /// `asset_pref_mirror.value` (jsonb 配列) または保存済み JSON から集合へ復元する。
+  /// 配列でなければ空集合(寛容なパース)。
+  static Set<String> decodeMirrorValue(dynamic value) {
+    if (value is! List) {
+      return <String>{};
+    }
+    final result = <String>{};
+    for (final item in value) {
+      final label = item?.toString().trim() ?? '';
+      if (label.isNotEmpty) {
+        result.add(label);
+      }
+    }
+    return result;
+  }
+}

--- a/lib/widgets/asset_recurring_transaction_suggestion_card.dart
+++ b/lib/widgets/asset_recurring_transaction_suggestion_card.dart
@@ -15,6 +15,7 @@ class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
     super.key,
     required this.suggestions,
     required this.onRegister,
+    required this.onIgnore,
     this.currencyFormatter,
   });
 
@@ -22,6 +23,9 @@ class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
 
   /// 「固定費に登録」押下時のコールバック。
   final void Function(DetectedRecurringTransaction detected) onRegister;
+
+  /// 「無視」押下時のコールバック(検出結果から除外して永続化する)。
+  final void Function(DetectedRecurringTransaction detected) onIgnore;
 
   /// 金額整形(ページの `_formatYen` を渡す)。null なら簡易整形。
   final String Function(double value)? currencyFormatter;
@@ -92,83 +96,101 @@ class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
     final summary = '${detected.label}、$scheduleLabel、約'
         '${_yen(detected.typicalAmount)}、$confidenceLabel、'
         '直近${detected.monthsObserved}ヶ月分を検出';
-    return Semantics(
-      container: true,
-      label: summary,
-      child: MergeSemantics(
-        child: Padding(
-          key: Key('asset_recurring_suggestion_$index'),
-          padding: const EdgeInsets.only(bottom: 10),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
+    return Padding(
+      key: Key('asset_recurring_suggestion_$index'),
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 情報部分は 1 ノードへまとめて読み上げる。操作ボタンは別ノードに分離。
+          Semantics(
+            container: true,
+            label: summary,
+            child: MergeSemantics(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Expanded(
-                    child: Text(
-                      detected.label,
-                      style: const TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w700,
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          detected.label,
+                          style: const TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
                       ),
-                    ),
+                      Text(
+                        scheduleLabel,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: _muted,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
                   ),
-                  Text(
-                    scheduleLabel,
-                    style: const TextStyle(
-                      fontSize: 12,
-                      color: _muted,
-                      fontWeight: FontWeight.w600,
-                    ),
+                  const SizedBox(height: 2),
+                  Row(
+                    children: [
+                      Text(
+                        '約${_yen(detected.typicalAmount)}',
+                        style: const TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: 2,
+                        ),
+                        decoration: BoxDecoration(
+                          color: confidenceColor.withValues(alpha: 0.12),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text(
+                          confidenceLabel,
+                          style: TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w700,
+                            color: confidenceColor,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          '直近${detected.monthsObserved}ヶ月分',
+                          style: const TextStyle(fontSize: 11, color: _muted),
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),
-              const SizedBox(height: 2),
-              Row(
-                children: [
-                  Text(
-                    '約${_yen(detected.typicalAmount)}',
-                    style: const TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 6,
-                      vertical: 2,
-                    ),
-                    decoration: BoxDecoration(
-                      color: confidenceColor.withValues(alpha: 0.12),
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: Text(
-                      confidenceLabel,
-                      style: TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w700,
-                        color: confidenceColor,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      '直近${detected.monthsObserved}ヶ月分',
-                      style: const TextStyle(fontSize: 11, color: _muted),
-                    ),
-                  ),
-                  TextButton(
-                    key: Key('asset_recurring_suggestion_register_$index'),
-                    onPressed: () => onRegister(detected),
-                    child: const Text('固定費に登録'),
-                  ),
-                ],
+            ),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                key: Key('asset_recurring_suggestion_ignore_$index'),
+                onPressed: () => onIgnore(detected),
+                style: TextButton.styleFrom(foregroundColor: _muted),
+                child: const Text('無視'),
+              ),
+              const SizedBox(width: 4),
+              TextButton(
+                key: Key('asset_recurring_suggestion_register_$index'),
+                onPressed: () => onRegister(detected),
+                child: const Text('固定費に登録'),
               ),
             ],
           ),
-        ),
+        ],
       ),
     );
   }

--- a/test/services/asset_recurring_suggestion_ignore_store_test.dart
+++ b/test/services/asset_recurring_suggestion_ignore_store_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_recurring_suggestion_ignore_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const store = AssetRecurringSuggestionIgnoreStore();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  test('save then load round-trips the set', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.save(<String>{'電気代', 'netflix'}, prefs: prefs);
+    expect(await store.load(prefs: prefs), <String>{'電気代', 'netflix'});
+  });
+
+  test('saving an empty set clears the key', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.save(<String>{'x'}, prefs: prefs);
+    await store.save(<String>{}, prefs: prefs);
+    expect(await store.load(prefs: prefs), isEmpty);
+  });
+
+  test('encodeMirrorValue sorts and drops blank labels', () {
+    expect(
+      AssetRecurringSuggestionIgnoreStore.encodeMirrorValue(<String>{
+        'b',
+        '  ',
+        'a',
+        ' c ',
+      }),
+      <String>['a', 'b', 'c'],
+    );
+  });
+
+  test('decodeMirrorValue tolerates non-list and trims entries', () {
+    expect(
+      AssetRecurringSuggestionIgnoreStore.decodeMirrorValue('nope'),
+      isEmpty,
+    );
+    expect(
+      AssetRecurringSuggestionIgnoreStore.decodeMirrorValue(<dynamic>[
+        ' a ',
+        '',
+        'b',
+      ]),
+      <String>{'a', 'b'},
+    );
+  });
+}

--- a/test/widgets/asset_recurring_transaction_suggestion_card_test.dart
+++ b/test/widgets/asset_recurring_transaction_suggestion_card_test.dart
@@ -31,6 +31,7 @@ void main() {
           body: AssetRecurringTransactionSuggestionCard(
             suggestions: const [],
             onRegister: (_) {},
+            onIgnore: (_) {},
           ),
         ),
       ),
@@ -50,6 +51,7 @@ void main() {
           body: AssetRecurringTransactionSuggestionCard(
             suggestions: [make('電気代'), make('家賃')],
             onRegister: (detected) => tapped = detected,
+            onIgnore: (_) {},
           ),
         ),
       ),
@@ -72,6 +74,32 @@ void main() {
     expect(tapped!.label, '電気代');
   });
 
+  testWidgets('fires onIgnore when the ignore button is tapped',
+      (tester) async {
+    DetectedRecurringTransaction? ignored;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AssetRecurringTransactionSuggestionCard(
+            suggestions: [make('電気代'), make('家賃')],
+            onRegister: (_) {},
+            onIgnore: (detected) => ignored = detected,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('無視'), findsNWidgets(2));
+
+    await tester.tap(
+      find.byKey(const Key('asset_recurring_suggestion_ignore_1')),
+    );
+    await tester.pump();
+
+    expect(ignored, isNotNull);
+    expect(ignored!.label, '家賃');
+  });
+
   testWidgets('shows the cadence label (monthly vs bimonthly)', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -85,6 +113,7 @@ void main() {
               ),
             ],
             onRegister: (_) {},
+            onIgnore: (_) {},
           ),
         ),
       ),
@@ -101,6 +130,7 @@ void main() {
           body: AssetRecurringTransactionSuggestionCard(
             suggestions: [make('電気代')],
             onRegister: (_) {},
+            onIgnore: (_) {},
           ),
         ),
       ),


### PR DESCRIPTION
## 概要

定期取引の自動検出 v2b。誤検出や不要な候補を「無視」して再提案を止められるようにします([#3475](https://github.com/kanta13jp1/my_web_app/pull/3475) / [#3478](https://github.com/kanta13jp1/my_web_app/pull/3478) の続き)。

## 変更点

- 新ストア `AssetRecurringSuggestionIgnoreStore`(SharedPreferences `asset_recurring_ignored_v1` / 正規化ラベルの集合を JSON 配列で永続化 / encode・decode 共通)。
- 検出カードの各候補に「無視」ボタンを追加(`onIgnore`)。押すと検出結果から除外し永続化。
- ページ配線: `_ignoredRecurringLabels` を起動時にローカル+サーバミラー(pref_key `recurring_suggestion_ignored`)から union 取込(無視は単調増加=union が安全 / tombstone 不要)。「無視」操作でローカル保存+ミラー upsert。検出フィルタに ignore を追加。
- a11y 改善: 操作ボタン(無視/固定費に登録)を `MergeSemantics` の外へ出し、各ボタンを独立した semantics ノードに(情報部分のみ 1 ノードへ集約)。

## 互換性 / リスク

- 既存挙動はゼロ変更(無視集合が空なら従来どおり)。ストアは寛容なパースで前方/後方互換。

## テスト

- store: save/load 往復 / 空集合でキー削除 / encodeMirrorValue ソート・空白除去 / decodeMirrorValue 寛容パース。
- card: 「無視」ボタンが onIgnore を発火(対象候補を渡す)。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数unit+widgetテストで担保。E2E基盤未整備のため対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/services・lib/widgets・lib/pages・test のみ。supabase/workflow/auth系の高リスクパスは未変更。純関数unit+widgetテストで担保
