### PR TITLE
fix(asset): 支払済みチェック解除を端末間で伝播 (月次state last-write-wins)

### DIFF
--- a/lib/models/asset_liability_persistence.dart
+++ b/lib/models/asset_liability_persistence.dart
@@ -89,6 +89,11 @@ class AssetLiabilityMonthlyStatePayload {
   final List<AssetLiabilityIncomePlan> incomePlans;
   final List<AssetLiabilityTransferTask> transferTasks;
 
+  /// クライアントが編集時刻を刻む last-write-wins 用タイムスタンプ。
+  /// サーバ側の `updated_at` カラム (= upsert 時刻) とは別物で、payload jsonb に
+  /// `state_updated_at` として保存・復元する。
+  final DateTime? updatedAt;
+
   const AssetLiabilityMonthlyStatePayload({
     required this.monthKey,
     required this.paymentOverrides,
@@ -103,6 +108,7 @@ class AssetLiabilityMonthlyStatePayload {
     required this.cardStatementLines,
     required this.incomePlans,
     required this.transferTasks,
+    this.updatedAt,
   });
 
   factory AssetLiabilityMonthlyStatePayload.fromState({
@@ -137,6 +143,7 @@ class AssetLiabilityMonthlyStatePayload {
       ),
       incomePlans: List<AssetLiabilityIncomePlan>.from(state.incomePlans),
       transferTasks: List<AssetLiabilityTransferTask>.from(state.transferTasks),
+      updatedAt: state.updatedAt,
     );
   }
 
@@ -188,6 +195,8 @@ class AssetLiabilityMonthlyStatePayload {
       transferTasks: _readTransferTasks(json, 'transfer_tasks') ??
           _readTransferTasks(json, 'transferTasks') ??
           const <AssetLiabilityTransferTask>[],
+      updatedAt: _readDateTime(json, 'state_updated_at') ??
+          _readDateTime(json, 'stateUpdatedAt'),
     );
   }
 
@@ -213,6 +222,7 @@ class AssetLiabilityMonthlyStatePayload {
       ),
       incomePlans: List<AssetLiabilityIncomePlan>.from(incomePlans),
       transferTasks: List<AssetLiabilityTransferTask>.from(transferTasks),
+      updatedAt: updatedAt,
     );
   }
 
@@ -251,6 +261,10 @@ class AssetLiabilityMonthlyStatePayload {
         for (final task in transferTasks) _encodeTransferTask(task),
       ],
       if (timestamp != null) 'updated_at': timestamp,
+      // クライアント編集時刻 (LWW 用)。サーバ upsert 時刻の updated_at とは別に
+      // payload jsonb へ保存し、別端末ロード時の last-write-wins 判定に使う。
+      if (this.updatedAt != null)
+        'state_updated_at': this.updatedAt!.toUtc().toIso8601String(),
     };
   }
 }
@@ -777,6 +791,12 @@ Set<String>? _readStringSet(Map<String, Object?> json, String key) {
 
 String? _readString(Map<String, Object?> json, String key) {
   return _cleanString(json[key]);
+}
+
+DateTime? _readDateTime(Map<String, Object?> json, String key) {
+  final raw = _cleanString(json[key]);
+  if (raw == null || raw.isEmpty) return null;
+  return DateTime.tryParse(raw);
 }
 
 double? _readDouble(Map<String, Object?> json, String key) {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -1564,6 +1564,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       ),
       incomePlans: List<AssetLiabilityIncomePlan>.from(_monthlyIncomePlans),
       transferTasks: List<AssetLiabilityTransferTask>.from(_transferTasks),
+      // 端末間 last-write-wins 用に、保存(=編集)時刻を毎回刻む。
+      updatedAt: DateTime.now(),
     );
   }
 

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -21,6 +21,11 @@ class AssetLiabilityMonthlyState {
   final List<AssetLiabilityIncomePlan> incomePlans;
   final List<AssetLiabilityTransferTask> transferTasks;
 
+  /// この月次stateを最後に編集した時刻 (端末ローカルの wall-clock)。
+  /// 端末間マージで last-write-wins (新しい方の状態を採用) する基準。
+  /// null は timestamp 未記録 (= 旧データ) を意味し、その場合は union マージへ退避する。
+  final DateTime? updatedAt;
+
   const AssetLiabilityMonthlyState({
     this.paymentOverrides = const <String, double>{},
     this.actualPaymentAmounts = const <String, double>{},
@@ -35,6 +40,7 @@ class AssetLiabilityMonthlyState {
     this.cardStatementLines = const <AssetLiabilityCardStatementLine>[],
     this.incomePlans = const <AssetLiabilityIncomePlan>[],
     this.transferTasks = const <AssetLiabilityTransferTask>[],
+    this.updatedAt,
   });
 
   bool get isEmpty =>
@@ -129,7 +135,15 @@ class AssetLiabilityMonthlyState {
         other.transferTasks,
         (task) => task.id,
       ),
+      updatedAt: laterUpdatedAt(updatedAt, other.updatedAt),
     );
+  }
+
+  /// 2つの updatedAt のうち新しい方 (null は最古扱い) を返す。
+  static DateTime? laterUpdatedAt(DateTime? a, DateTime? b) {
+    if (a == null) return b;
+    if (b == null) return a;
+    return a.isAfter(b) ? a : b;
   }
 
   /// ローカルの要素を保持しつつ、[remote] のうちローカルに無い id の要素だけ追加する
@@ -182,9 +196,45 @@ class AssetLiabilityMonthlyStateStore {
       'asset_liability_monthly_snapshots_v1';
   static const String syncAuditLogPrefsKey =
       'asset_liability_sync_audit_logs_v1';
+  static const String stateUpdatedAtPrefsKey =
+      'asset_liability_state_updated_at_v1';
   static const int maxSyncAuditLogCount = 50;
 
   const AssetLiabilityMonthlyStateStore();
+
+  /// `{monthKey: ISO8601}` 形式の updatedAt マップから対象月の時刻を読む。
+  static DateTime? updatedAtForMonth(String? raw, String monthKey) {
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map) {
+        final value = decoded[monthKey];
+        if (value is String && value.isNotEmpty) {
+          return DateTime.tryParse(value);
+        }
+      }
+    } catch (_) {
+      // 破損データは無視 (timestamp 無し扱い → union マージへ退避)。
+    }
+    return null;
+  }
+
+  static Map<String, String> _decodeUpdatedAtMap(String? raw) {
+    if (raw == null || raw.isEmpty) return <String, String>{};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map) {
+        return <String, String>{
+          for (final entry in decoded.entries)
+            if (entry.value is String)
+              entry.key.toString(): entry.value as String,
+        };
+      }
+    } catch (_) {
+      // 破損は空扱い。
+    }
+    return <String, String>{};
+  }
 
   Future<AssetLiabilityMonthlyState> loadMonth(DateTime month) async {
     final prefs = await SharedPreferences.getInstance();
@@ -236,6 +286,10 @@ class AssetLiabilityMonthlyStateStore {
       ),
       transferTasks: transferTasksForMonth(
         prefs.getString(transferTaskPrefsKey),
+        monthKey,
+      ),
+      updatedAt: updatedAtForMonth(
+        prefs.getString(stateUpdatedAtPrefsKey),
         monthKey,
       ),
     );
@@ -410,6 +464,16 @@ class AssetLiabilityMonthlyStateStore {
       transferTaskPrefsKey,
       jsonEncode(_encodeTransferTasks(allTransferTasks)),
     );
+
+    final allUpdatedAt = _decodeUpdatedAtMap(
+      prefs.getString(stateUpdatedAtPrefsKey),
+    );
+    if (state.updatedAt == null) {
+      allUpdatedAt.remove(monthKey);
+    } else {
+      allUpdatedAt[monthKey] = state.updatedAt!.toUtc().toIso8601String();
+    }
+    await prefs.setString(stateUpdatedAtPrefsKey, jsonEncode(allUpdatedAt));
   }
 
   Future<Map<String, String>> loadDefaultPaymentSources() async {

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -513,9 +513,29 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       return remoteState;
     }
 
-    // 双方に入力がある場合は union マージする。旧実装は無条件に local を返し、
-    // 別端末で付けた「支払済み」等を無視した上に、その local をサーバへ保存し直して
-    // リモートの入力を上書き消去していた (= PC で支払済みにしてもスマホで未払いに戻る)。
+    // 双方に編集時刻 (updatedAt) があり差があるなら last-write-wins =
+    // 新しい方の状態全体を採用する。union と違い「支払済みのチェック解除 (削除)」も
+    // 新しい端末の状態として伝播する。
+    final localUpdatedAt = local.updatedAt;
+    final remoteUpdatedAt = remoteState.updatedAt;
+    if (localUpdatedAt != null &&
+        remoteUpdatedAt != null &&
+        !localUpdatedAt.isAtSameMomentAs(remoteUpdatedAt)) {
+      if (remoteUpdatedAt.isAfter(localUpdatedAt)) {
+        await localRepository.saveMonth(month: month, state: remoteState);
+        return remoteState;
+      }
+      if (supabaseWritesEnabled) {
+        await _tryRemote(
+          () => remote.saveMonth(userId: userId, month: month, state: local),
+        );
+      }
+      return local;
+    }
+
+    // timestamp が無い/同時刻 (旧データを含む) ときは union マージへ退避する。
+    // 旧実装は無条件に local を返し、別端末で付けた「支払済み」等を無視した上に、
+    // その local をサーバへ保存し直してリモートの入力を上書き消去していた。
     // union は monotonic なので、両端末の入力を取りこぼさず収束する。
     final merged = local.mergeWith(remoteState);
     if (merged.totalEntryCount > local.totalEntryCount) {
@@ -1817,6 +1837,7 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
         'payment_source_account_ids': row['payment_source_account_ids'],
         'card_billing_account_ids': row['card_billing_account_ids'],
         'card_statement_lines': row['card_statement_lines'],
+        'state_updated_at': row['state_updated_at'],
       },
     );
     await _upsertPayloadRow(

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -678,6 +678,23 @@ void main() {
         isEmpty,
       );
     });
+
+    test('saves and restores the updatedAt timestamp by month', () async {
+      final timestamp = DateTime.utc(2026, 5, 20, 10, 30);
+      await store.saveMonth(
+        month: DateTime(2026, 5),
+        state: AssetLiabilityMonthlyState(
+          paidAccountNames: const <String>{'mobit'},
+          updatedAt: timestamp,
+        ),
+      );
+
+      final restored = await store.loadMonth(DateTime(2026, 5));
+      expect(restored.updatedAt?.toUtc(), timestamp);
+      // 別月には漏れない。
+      final other = await store.loadMonth(DateTime(2026, 6));
+      expect(other.updatedAt, isNull);
+    });
   });
 
   group('AssetLiabilityMonthlyState.mergeWith', () {
@@ -710,6 +727,20 @@ void main() {
       );
 
       expect(local.mergeWith(remote).paymentOverrides['mobit'], 70000);
+    });
+
+    test('carries the later updatedAt into the merged result', () {
+      final older = AssetLiabilityMonthlyState(
+        paidAccountNames: const <String>{'mobit'},
+        updatedAt: DateTime(2026, 5, 20, 9),
+      );
+      final newer = AssetLiabilityMonthlyState(
+        paidAccountNames: const <String>{'yokohama_bank'},
+        updatedAt: DateTime(2026, 5, 20, 10),
+      );
+
+      expect(older.mergeWith(newer).updatedAt, DateTime(2026, 5, 20, 10));
+      expect(newer.mergeWith(older).updatedAt, DateTime(2026, 5, 20, 10));
     });
 
     test('unions list entries by id without duplicating shared ids', () {

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -550,6 +550,115 @@ void main() {
     });
 
     test(
+      'loadMonth adopts the newer state so a cross-device uncheck propagates',
+      () async {
+        final local = _FakeAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore();
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          remoteWritesEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
+
+        // この端末は古い時刻にモビットを支払済みにした。
+        await local.saveMonth(
+          month: month,
+          state: AssetLiabilityMonthlyState(
+            paidAccountNames: const <String>{'mobit'},
+            updatedAt: DateTime(2026, 5, 20, 9),
+          ),
+        );
+        // 別端末はより新しい時刻にチェックを外した (paid 空 / 状態は非空)。
+        remote.seedMonth(
+          month,
+          AssetLiabilityMonthlyState(
+            paymentOverrides: const <String, double>{'mobit': 1},
+            updatedAt: DateTime(2026, 5, 20, 10),
+          ),
+        );
+
+        final resolved = await repository.loadMonth(month);
+
+        // 新しい方 (= チェック解除) が採用され、union のように mobit を復活させない。
+        expect(resolved.paidAccountNames, isNot(contains('mobit')));
+        final localAfter = await local.loadMonth(month);
+        expect(localAfter.paidAccountNames, isNot(contains('mobit')));
+      },
+    );
+
+    test('loadMonth keeps the newer local state over an older remote',
+        () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore();
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        remoteWritesEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+
+      await local.saveMonth(
+        month: month,
+        state: AssetLiabilityMonthlyState(
+          paidAccountNames: const <String>{'mobit'},
+          updatedAt: DateTime(2026, 5, 20, 10),
+        ),
+      );
+      remote.seedMonth(
+        month,
+        AssetLiabilityMonthlyState(
+          paidAccountNames: const <String>{'yokohama_bank'},
+          updatedAt: DateTime(2026, 5, 20, 9),
+        ),
+      );
+
+      final resolved = await repository.loadMonth(month);
+
+      // 新しいローカルが状態全体として勝ち、古いリモートの paid は採用しない。
+      expect(resolved.paidAccountNames, contains('mobit'));
+      expect(resolved.paidAccountNames, isNot(contains('yokohama_bank')));
+    });
+
+    test('loadMonth falls back to union when timestamps are absent', () async {
+      final local = _FakeAssetLiabilityRepository();
+      final remote = _RecordingAssetLiabilityRemoteStore();
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        remoteWritesEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+      final month = DateTime(2026, 5);
+
+      // 旧データ (updatedAt 無し) 同士は union で取りこぼさない (#3474 の挙動)。
+      await local.saveMonth(
+        month: month,
+        state: const AssetLiabilityMonthlyState(
+          paidAccountNames: <String>{'mobit'},
+        ),
+      );
+      remote.seedMonth(
+        month,
+        const AssetLiabilityMonthlyState(
+          paidAccountNames: <String>{'yokohama_bank'},
+        ),
+      );
+
+      final resolved = await repository.loadMonth(month);
+
+      expect(
+        resolved.paidAccountNames,
+        containsAll(<String>{'mobit', 'yokohama_bank'}),
+      );
+    });
+
+    test(
       'sync on keeps production writes disabled unless write flag is enabled',
       () async {
         final local = _FakeAssetLiabilityRepository();
@@ -1307,6 +1416,7 @@ void main() {
             cancellationReason: 'Paid from salary account directly.',
           ),
         ],
+        updatedAt: DateTime.utc(2026, 5, 19, 8),
       );
 
       final payload = AssetLiabilityMonthlyStatePayload.fromState(
@@ -1330,6 +1440,9 @@ void main() {
       expect(restored.annualRateEvidences['mobit']?.verified, isTrue);
       expect(row['annual_rate_evidences'], isA<Map<String, Object?>>());
       expect(restored.paidAccountNames, contains('kddi_provider'));
+      // クライアント編集時刻 (LWW 用) が payload 経由で round-trip する。
+      expect(row['state_updated_at'], '2026-05-19T08:00:00.000Z');
+      expect(restored.updatedAt?.toUtc(), DateTime.utc(2026, 5, 19, 8));
       expect(restored.billingConfirmedAccountIds, contains('mobit'));
       expect(restored.paymentSourceAccountIds['mobit'], 'smbc_otsuka');
       expect(restored.cardBillingAccountIds['kddi_provider'], 'paypay_card');


### PR DESCRIPTION
## 概要

#3474（union マージ）の残課題だった**「支払済みチェックの解除（削除）が端末間で伝播しない」**を是正する。
union は追加（チェック）は伝播するが削除は伝播せず、別端末でチェックを外しても他端末では paid のまま残っていた。
月次stateにクライアント編集時刻を持たせ、**competing 時は新しい方の状態全体を採用する last-write-wins** へ拡張する
（チェック解除も「最後に編集した端末の状態」として伝播）。

## 原因

`AssetLiabilityMonthlyState` にタイムスタンプが無く、`loadMonth` は #3474 で union マージにしたが、
union は monotonic（追加のみ）なため**削除（uncheck）を表現できず**、別端末の古い paid が再合流して残っていた。

## 修正

- `AssetLiabilityMonthlyState.updatedAt` を追加。保存（編集）時に `DateTime.now()` を刻む。
- 永続化を両経路に通す: ローカルは prefs キー `asset_liability_state_updated_at_v1`、リモートは payload jsonb の
  `state_updated_at`（サーバ upsert 時刻の `updated_at` カラムとは別物）で round-trip。
- `loadMonth`: 双方に `updatedAt` があり差があれば**新しい方の状態全体を採用**（uncheck 伝播）。
  timestamp が無い/同時刻（旧データ含む）は #3474 の union へフォールバック（後方互換でリグレッション無し）。

## 検証

- `flutter test`（repo + store 69件 green）
  - LWW: cross-device uncheck 伝播 / local newer wins / legacy(no-ts) は union フォールバック の3件
  - store round-trip（updatedAt 月別保存・復元）/ mergeWith は newer updatedAt を継承 / payload round-trip（`state_updated_at`）
- `flutter analyze`（6ファイル No issues）/ `dart format --language-version=3.4`

## 既知の限界

- whole-state LWW のため、2端末を同期せずに**同時刻に別フィールドを編集**した場合は片方の編集が負ける（単一ユーザーの逐次利用では load→edit→save で解消）。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 端末間 LWW は純関数+リポジトリ/ストアfakeの単体テスト6件で検証。認証付き多端末同期はUI/E2Eで再現困難なため

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: lib/services・lib/models・lib/pages のみ変更で高リスクパス(auth/billing/supabase functions/migrations/RLS)に未接触。jsonb payload への additive フィールド追加(スキーマ migration 不要)+純関数LWWの単体テストで担保
