### PR TITLE
refactor: 浪費トレーニング集計を純関数へ抽出 (巨大page健全化)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -54,6 +54,7 @@ import 'package:my_web_app/services/asset_sync_status.dart';
 import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
 import 'package:my_web_app/services/asset_unknown_expense_rule_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
+import 'package:my_web_app/services/asset_waste_training_snapshot_inputs.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
@@ -1141,52 +1142,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   AssetWasteTrainingSnapshot _buildWasteTrainingSnapshot() {
-    final currentMonth = _monthStart(_now);
-    final flows = _flowsForMonth(currentMonth);
-    var totalExpense = 0;
-    var wasteExpense = 0;
-    var expenseEntryCount = 0;
-    var wasteEntryCount = 0;
-    final wasteDateKeys = <String>{};
-
-    for (final item in flows) {
-      final actionType = item['action_type']?.toString() ?? '';
-      if (!_isExpenseActionType(actionType)) {
-        continue;
-      }
-      final amount = ((item['amount'] as num?)?.toDouble() ?? 0).abs().round();
-      totalExpense += amount;
-      expenseEntryCount += 1;
-
-      final description = item['description']?.toString() ?? '';
-      final parsed = _parseFlowDescription(description, actionType: actionType);
-      if (parsed.wasteCategory == null) {
-        continue;
-      }
-
-      wasteExpense += amount;
-      wasteEntryCount += 1;
-      final occurredAt = DateTime.tryParse(
-        item['occurred_at']?.toString() ?? '',
-      )?.toLocal();
-      if (occurredAt != null) {
-        wasteDateKeys.add(_dateOnly(occurredAt));
-      }
-    }
-
-    final elapsedDays = _isSameMonth(currentMonth, _now)
-        ? _now.day
-        : DateTime(currentMonth.year, currentMonth.month + 1, 0).day;
     final lockdown = _debtLockdownSnapshot;
-    return AssetWasteTrainingSnapshot(
-      month: currentMonth,
-      monitoredAt: _now,
-      totalExpense: totalExpense,
-      wasteExpense: wasteExpense,
-      expenseEntryCount: expenseEntryCount,
-      wasteEntryCount: wasteEntryCount,
-      noWasteDays: max(0, elapsedDays - wasteDateKeys.length),
-      elapsedDays: max(1, elapsedDays),
+    return AssetWasteTrainingSnapshotInputs.build(
+      monthFlows: _flowsForMonth(_monthStart(_now)),
+      now: _now,
+      isExpense: _isExpenseActionType,
+      wasteCategoryOf: (description, actionType) => _parseFlowDescription(
+        description,
+        actionType: actionType,
+      ).wasteCategory,
       ruleCompletedCount: lockdown?.completedRuleCount ?? 0,
       ruleTargetCount:
           lockdown?.rules.length ?? DebtLockdownService.builtinRules.length,

--- a/lib/services/asset_waste_training_snapshot_inputs.dart
+++ b/lib/services/asset_waste_training_snapshot_inputs.dart
@@ -1,0 +1,82 @@
+import 'dart:math';
+
+import 'asset_waste_training_ai_service.dart';
+
+/// `_buildWasteTrainingSnapshot` の純粋集計部分を切り出した純関数ビルダー。
+///
+/// description のパース(浪費カテゴリ判定)・支出判定・借金ロックダウンの集計値は
+/// ページから関数/値として注入する(深依存は注入 = 3 手法②)。月内フローと現在時刻
+/// から浪費トレーニング指標 [AssetWasteTrainingSnapshot] を組み立てる。スキーマ非依存・
+/// 完全テスト可。
+class AssetWasteTrainingSnapshotInputs {
+  const AssetWasteTrainingSnapshotInputs();
+
+  /// [monthFlows] は対象月に絞り込み済みの収支フロー。
+  static AssetWasteTrainingSnapshot build({
+    required List<Map<String, dynamic>> monthFlows,
+    required DateTime now,
+    required bool Function(String actionType) isExpense,
+    required String? Function(String description, String actionType)
+        wasteCategoryOf,
+    required int ruleCompletedCount,
+    required int ruleTargetCount,
+    required int todayViolationCount,
+    required int compliantStreakDays,
+    required bool lockdownActive,
+  }) {
+    final currentMonth = DateTime(now.year, now.month, 1);
+    var totalExpense = 0;
+    var wasteExpense = 0;
+    var expenseEntryCount = 0;
+    var wasteEntryCount = 0;
+    final wasteDateKeys = <String>{};
+
+    for (final item in monthFlows) {
+      final actionType = item['action_type']?.toString() ?? '';
+      if (!isExpense(actionType)) {
+        continue;
+      }
+      final amount = ((item['amount'] as num?)?.toDouble() ?? 0).abs().round();
+      totalExpense += amount;
+      expenseEntryCount += 1;
+
+      final description = item['description']?.toString() ?? '';
+      if (wasteCategoryOf(description, actionType) == null) {
+        continue;
+      }
+
+      wasteExpense += amount;
+      wasteEntryCount += 1;
+      final occurredAt = DateTime.tryParse(
+        item['occurred_at']?.toString() ?? '',
+      )?.toLocal();
+      if (occurredAt != null) {
+        wasteDateKeys.add(
+          '${occurredAt.year}-${occurredAt.month}-${occurredAt.day}',
+        );
+      }
+    }
+
+    final isCurrentMonth =
+        currentMonth.year == now.year && currentMonth.month == now.month;
+    final elapsedDays = isCurrentMonth
+        ? now.day
+        : DateTime(currentMonth.year, currentMonth.month + 1, 0).day;
+
+    return AssetWasteTrainingSnapshot(
+      month: currentMonth,
+      monitoredAt: now,
+      totalExpense: totalExpense,
+      wasteExpense: wasteExpense,
+      expenseEntryCount: expenseEntryCount,
+      wasteEntryCount: wasteEntryCount,
+      noWasteDays: max(0, elapsedDays - wasteDateKeys.length),
+      elapsedDays: max(1, elapsedDays),
+      ruleCompletedCount: ruleCompletedCount,
+      ruleTargetCount: ruleTargetCount,
+      todayViolationCount: todayViolationCount,
+      compliantStreakDays: compliantStreakDays,
+      lockdownActive: lockdownActive,
+    );
+  }
+}

--- a/test/services/asset_waste_training_snapshot_inputs_test.dart
+++ b/test/services/asset_waste_training_snapshot_inputs_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
+import 'package:my_web_app/services/asset_waste_training_snapshot_inputs.dart';
+
+void main() {
+  Map<String, dynamic> flow(
+    String actionType,
+    int amount, {
+    String description = '',
+    String? occurredAt,
+  }) {
+    return <String, dynamic>{
+      'action_type': actionType,
+      'amount': amount,
+      'description': description,
+      if (occurredAt != null) 'occurred_at': occurredAt,
+    };
+  }
+
+  // 浪費は description に「#浪費」を含むものとする(注入する判定関数)。
+  AssetWasteTrainingSnapshot build(
+    List<Map<String, dynamic>> flows, {
+    DateTime? now,
+    int ruleCompletedCount = 2,
+    int ruleTargetCount = 5,
+    int todayViolationCount = 1,
+  }) {
+    return AssetWasteTrainingSnapshotInputs.build(
+      monthFlows: flows,
+      now: now ?? DateTime(2026, 6, 15),
+      isExpense: (actionType) => actionType == 'expense',
+      wasteCategoryOf: (description, actionType) =>
+          description.contains('#浪費') ? '浪費' : null,
+      ruleCompletedCount: ruleCompletedCount,
+      ruleTargetCount: ruleTargetCount,
+      todayViolationCount: todayViolationCount,
+      compliantStreakDays: 3,
+      lockdownActive: true,
+    );
+  }
+
+  test('aggregates expenses and waste, ignoring income/transfer', () {
+    final snapshot = build([
+      flow('expense', 1000, description: 'ランチ'),
+      flow(
+        'expense',
+        2000,
+        description: 'ゲーム #浪費',
+        occurredAt: '2026-06-10T09:00:00',
+      ),
+      flow('income', 5000),
+      flow('transfer', 3000),
+    ]);
+
+    expect(snapshot.totalExpense, 3000);
+    expect(snapshot.expenseEntryCount, 2);
+    expect(snapshot.wasteExpense, 2000);
+    expect(snapshot.wasteEntryCount, 1);
+    expect(snapshot.month, DateTime(2026, 6, 1));
+    expect(snapshot.monitoredAt, DateTime(2026, 6, 15));
+    expect(snapshot.elapsedDays, 15); // 今月 → now.day
+  });
+
+  test('noWasteDays counts unique waste days', () {
+    final snapshot = build([
+      flow(
+        'expense',
+        1000,
+        description: 'A #浪費',
+        occurredAt: '2026-06-10T09:00:00',
+      ),
+      flow(
+        'expense',
+        1500,
+        description: 'B #浪費',
+        occurredAt: '2026-06-10T20:00:00',
+      ),
+      flow(
+        'expense',
+        800,
+        description: 'C #浪費',
+        occurredAt: '2026-06-12T12:00:00',
+      ),
+    ]);
+
+    // 浪費は2日 (10日・12日)。elapsedDays 15 → noWasteDays = 13。
+    expect(snapshot.wasteEntryCount, 3);
+    expect(snapshot.noWasteDays, 13);
+  });
+
+  test('passes through lockdown metrics and clamps elapsedDays to >= 1', () {
+    final snapshot = build(
+      const [],
+      now: DateTime(2026, 6, 1),
+      ruleCompletedCount: 4,
+      ruleTargetCount: 6,
+      todayViolationCount: 0,
+    );
+
+    expect(snapshot.totalExpense, 0);
+    expect(snapshot.elapsedDays, 1); // 1日 → max(1, 1)
+    expect(snapshot.noWasteDays, 1);
+    expect(snapshot.ruleCompletedCount, 4);
+    expect(snapshot.ruleTargetCount, 6);
+    expect(snapshot.todayViolationCount, 0);
+    expect(snapshot.lockdownActive, isTrue);
+  });
+}


### PR DESCRIPTION
## 概要

巨大ページ `asset_management_page.dart`(約25,000行)の継続的健全化。浪費トレーニング指標の純粋集計部分 `_buildWasteTrainingSnapshot` を純関数サービスへ抽出し、ページには薄いデリゲータだけ残します(振る舞い不変)。

## 変更点

- 新サービス `AssetWasteTrainingSnapshotInputs.build(...)`(`lib/services/`): 月内フロー・現在時刻・支出判定・浪費カテゴリ判定・ロックダウン集計値から `AssetWasteTrainingSnapshot` を組み立てる純関数。
- 深依存(`_parseFlowDescription` の浪費カテゴリ判定 / `_isExpenseActionType`)とロックダウン集計値は**関数/値として注入**(3 手法②)。
- ページの `_buildWasteTrainingSnapshot` は注入して呼ぶだけの薄いデリゲータに(net -36 行)。

## 互換性 / リスク

- **振る舞い不変**(同一ロジックの移設のみ)。抽出後も `_dateOnly`/`_isSameMonth`/`_monthStart`/`max` は他箇所で使用継続(unused なし)。
- 純関数化によりユニットテストで集計ロジックを単体検証可能に。

## テスト

- `asset_waste_training_snapshot_inputs_test`: 支出/浪費集計(収入・振替は除外)/ 浪費ユニーク日数による noWasteDays / ロックダウン値の透過と elapsedDays クランプ。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 振る舞い不変の純関数抽出。純関数unitテストで担保(E2E基盤未整備)

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/services・lib/pages・test のみの振る舞い不変リファクタ。supabase/workflow/auth系の高リスクパスは未変更
