### PR TITLE
refactor: フロー説明文パースを純関数サービスへ移設 (巨大page健全化)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -6790,53 +6790,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return WasteTrackingService.attachWasteCategory(description, wasteCategory);
   }
 
-  ({
-    String source,
-    String destination,
-    String memo,
-    String? wasteCategory,
-    bool isTransfer,
-  }) _parseFlowDescription(String description, {String? actionType}) {
+  FlowDescriptionParts _parseFlowDescription(
+    String description, {
+    String? actionType,
+  }) {
+    // メタデータマーカー除去だけページ固有正規表現に依存するため残し、
+    // パース本体は純関数サービスへ委譲する(振る舞い不変)。
     final normalizedDescription = _stripFlowMetadataMarkers(description.trim());
-    final isExpense = _isExpenseActionType(actionType ?? '');
-    final wasteCategory = isExpense
-        ? WasteTrackingService.extractWasteCategory(normalizedDescription)
-        : null;
-    final normalized = isExpense
-        ? WasteTrackingService.stripWasteMarker(normalizedDescription)
-        : normalizedDescription;
-    if (_isTransferActionType(actionType ?? '')) {
-      final transferMatch = RegExp(
-        r'^(\[[^\]]+\])\s*->\s*(\[[^\]]+\])(?:\s+(.*))?$',
-      ).firstMatch(normalized);
-      if (transferMatch != null) {
-        return (
-          source: transferMatch.group(1)?.trim() ?? '',
-          destination: transferMatch.group(2)?.trim() ?? '',
-          memo: transferMatch.group(3)?.trim() ?? '',
-          wasteCategory: wasteCategory,
-          isTransfer: true,
-        );
-      }
-    }
-
-    final match = RegExp(r'^(\[[^\]]+\])\s*(.*)$').firstMatch(normalized);
-    if (match != null) {
-      return (
-        source: match.group(1)?.trim() ?? '',
-        destination: '',
-        memo: match.group(2)?.trim() ?? '',
-        wasteCategory: wasteCategory,
-        isTransfer: _isTransferActionType(actionType ?? ''),
-      );
-    }
-
-    return (
-      source: '',
-      destination: '',
-      memo: normalized,
-      wasteCategory: wasteCategory,
-      isTransfer: _isTransferActionType(actionType ?? ''),
+    return AssetFlowDescriptionService.parse(
+      normalizedDescription,
+      actionType: actionType,
     );
   }
 

--- a/lib/services/asset_flow_description_service.dart
+++ b/lib/services/asset_flow_description_service.dart
@@ -1,3 +1,5 @@
+import 'waste_tracking_service.dart';
+
 /// 収支フローの説明文パース結果(`_parseFlowDescription` の戻り値レコード)。
 typedef FlowDescriptionParts = ({
   String source,
@@ -7,14 +9,69 @@ typedef FlowDescriptionParts = ({
   bool isTransfer,
 });
 
-/// 収支フローの説明文から表示用ラベル/タイトルを組み立てる純関数の置き場。
+/// 収支フローの説明文をパースし、表示用ラベル/タイトルを組み立てる純関数の置き場。
 ///
-/// 元々ページの `_sourceLabel` / `_flowDisplayTitle` にあった表示ロジックを抽出し、
-/// パース([FlowDescriptionParts])の結果から視覚表現を導く部分をテスト可能に
-/// したもの(振る舞いは不変)。パース本体(正規表現・浪費マーカー除去)は依存が
-/// 重いためページ側に残す。
+/// パース本体([parse])= 浪費マーカー抽出/除去 + `[口座名]` 正規表現の純関数。
+/// インポートメタデータ(取込/自動資産差分マーカー)の除去だけはページ固有の
+/// 正規表現に依存するためページ側に残し、除去済み文字列を [parse] へ渡す。
+/// 振る舞いは不変でユニットテスト可能。
 class AssetFlowDescriptionService {
   const AssetFlowDescriptionService._();
+
+  static final RegExp _transferPattern = RegExp(
+    r'^(\[[^\]]+\])\s*->\s*(\[[^\]]+\])(?:\s+(.*))?$',
+  );
+  static final RegExp _sourcePattern = RegExp(r'^(\[[^\]]+\])\s*(.*)$');
+
+  /// メタデータ除去済みの説明文を [FlowDescriptionParts] へパースする。
+  /// [actionType] が `expense` のときのみ浪費カテゴリを抽出し、マーカーを除去する。
+  /// `transfer` は「移動元 -> 移動先 メモ」、それ以外は「[口座名] メモ」を解釈する。
+  static FlowDescriptionParts parse(
+    String metadataStrippedDescription, {
+    String? actionType,
+  }) {
+    final type = actionType ?? '';
+    final isExpense = type == 'expense';
+    final isTransfer = type == 'transfer';
+    final wasteCategory = isExpense
+        ? WasteTrackingService.extractWasteCategory(metadataStrippedDescription)
+        : null;
+    final normalized = isExpense
+        ? WasteTrackingService.stripWasteMarker(metadataStrippedDescription)
+        : metadataStrippedDescription;
+
+    if (isTransfer) {
+      final transferMatch = _transferPattern.firstMatch(normalized);
+      if (transferMatch != null) {
+        return (
+          source: transferMatch.group(1)?.trim() ?? '',
+          destination: transferMatch.group(2)?.trim() ?? '',
+          memo: transferMatch.group(3)?.trim() ?? '',
+          wasteCategory: wasteCategory,
+          isTransfer: true,
+        );
+      }
+    }
+
+    final match = _sourcePattern.firstMatch(normalized);
+    if (match != null) {
+      return (
+        source: match.group(1)?.trim() ?? '',
+        destination: '',
+        memo: match.group(2)?.trim() ?? '',
+        wasteCategory: wasteCategory,
+        isTransfer: isTransfer,
+      );
+    }
+
+    return (
+      source: '',
+      destination: '',
+      memo: normalized,
+      wasteCategory: wasteCategory,
+      isTransfer: isTransfer,
+    );
+  }
 
   /// `[口座名]` のような source ラベルから囲み括弧を除いた表示名を返す。
   static String sourceLabel(String source) =>

--- a/test/services/asset_flow_description_service_test.dart
+++ b/test/services/asset_flow_description_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/asset_flow_description_service.dart';
+import 'package:my_web_app/services/waste_tracking_service.dart';
 
 FlowDescriptionParts _parts({
   String source = '',
@@ -60,6 +61,62 @@ void main() {
         AssetFlowDescriptionService.displayTitle(_parts(memo: 'コンビニ')),
         'コンビニ',
       );
+    });
+  });
+
+  group('AssetFlowDescriptionService.parse', () {
+    test('parses an expense with source and memo', () {
+      final parts = AssetFlowDescriptionService.parse(
+        '[財布] ランチ',
+        actionType: 'expense',
+      );
+      expect(parts.source, '[財布]');
+      expect(parts.memo, 'ランチ');
+      expect(parts.isTransfer, isFalse);
+    });
+
+    test('parses a transfer route with memo', () {
+      final parts = AssetFlowDescriptionService.parse(
+        '[A] -> [B] 引越し資金',
+        actionType: 'transfer',
+      );
+      expect(parts.source, '[A]');
+      expect(parts.destination, '[B]');
+      expect(parts.memo, '引越し資金');
+      expect(parts.isTransfer, isTrue);
+    });
+
+    test('falls back to memo-only when there is no bracket', () {
+      final parts = AssetFlowDescriptionService.parse(
+        '給料',
+        actionType: 'income',
+      );
+      expect(parts.source, '');
+      expect(parts.memo, '給料');
+      expect(parts.isTransfer, isFalse);
+    });
+
+    test('extracts and strips the waste marker only for expenses', () {
+      final category = WasteTrackingService.categoryLabels.first;
+      final described = WasteTrackingService.attachWasteCategory(
+        '[セブン] コーヒー',
+        category,
+      );
+
+      final expense = AssetFlowDescriptionService.parse(
+        described,
+        actionType: 'expense',
+      );
+      expect(expense.source, '[セブン]');
+      expect(expense.memo, 'コーヒー'); // 浪費マーカーは除去
+      expect(expense.wasteCategory, category);
+
+      final income = AssetFlowDescriptionService.parse(
+        described,
+        actionType: 'income',
+      );
+      expect(income.wasteCategory, isNull);
+      expect(income.memo, contains('[浪費:')); // 非支出はマーカー保持
     });
   });
 }


### PR DESCRIPTION
## 概要

巨大ページ `asset_management_page.dart` の継続的健全化。フロー説明文のパース本体 `_parseFlowDescription`(浪費マーカー抽出/除去 + `[口座名]` 正規表現)を純関数サービス `AssetFlowDescriptionService.parse` へ移設し、ページにはメタデータ除去のデリゲータだけ残します(振る舞い不変)。

## 変更点

- `AssetFlowDescriptionService.parse(metadataStrippedDescription, {actionType})`: 浪費カテゴリ抽出/除去(`WasteTrackingService`)+ 振替/口座ラベルの正規表現パースを純関数化。`actionType` の expense/transfer 判定は inline。正規表現は static field 化。
- ページの `_parseFlowDescription`: ページ固有正規表現に依存する `_stripFlowMetadataMarkers` だけ残し、除去済み文字列を `parse` へ委譲(戻り型 `FlowDescriptionParts`)。net -37 行。
- 表示系(`sourceLabel`/`displayTitle`)は既存のまま。

## 互換性 / リスク

- **振る舞い不変**(同一ロジックの移設のみ / 正規表現・順序を保持)。`WasteTrackingService`/`_isExpenseActionType`/`_isTransferActionType` は他箇所で使用継続(unused なし)。

## テスト

- `asset_flow_description_service_test`: `parse` の expense(source+memo)/ transfer(route+memo)/ 括弧なし(memo-only)/ 浪費マーカーの抽出・除去が **expense のみ**で起きること(非支出は保持)を追加検証。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 振る舞い不変の純関数抽出。純関数unitテストで担保(E2E基盤未整備)

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/services・lib/pages・test のみの振る舞い不変リファクタ。supabase/workflow/auth系の高リスクパスは未変更
