### PR TITLE
fix(ai-hub): Gemini の thinking budget を上限化し MAX_TOKENS 途中終了を防止

### DIFF
--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -66,6 +66,7 @@ import {
   MarketPriceActionError,
   type MarketPriceDb,
 } from "./market_price.ts";
+import { applyProviderGenerationOptions } from "./provider_generation_options.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -592,62 +593,6 @@ function normalizeMaxTokens(value: unknown): number | undefined {
   const raw = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(raw) || raw <= 0) return undefined;
   return Math.max(64, Math.min(8192, Math.round(raw)));
-}
-
-function applyProviderGenerationOptions(
-  providerId: string,
-  requestBody: Record<string, unknown>,
-  options?: ProviderCallOptions,
-): Record<string, unknown> {
-  const maxTokens = options?.maxTokens;
-
-  if (providerId === "openai") {
-    // OpenAI の新世代モデル (gpt-5 / o系) は max_tokens パラメータ自体を
-    // 拒否するため、ベース body (OPENAI_COMPAT_BODY) の max_tokens: 512 を
-    // 取り除いた上で max_completion_tokens へ載せ替える。
-    // groq / deepinfra 等の OpenAI 互換プロバイダーは従来どおり max_tokens。
-    const body: Record<string, unknown> = { ...requestBody };
-    const legacyMaxTokens = body.max_tokens;
-    delete body.max_tokens;
-    const model = String(body.model ?? "");
-    if (model.startsWith("gpt-5") || /^o\d/.test(model)) {
-      // reasoning モデルは温度指定を拒否する (既定値のみ許容)。
-      delete body.temperature;
-      // reasoning_effort を下げないと、推論トークンが max_completion_tokens を
-      // 使い切り本文が 0 トークンになる (gpt-5 が text:"" を返す原因)。
-      // 金額計算は Dart 側で完了済みなので低 effort で十分。
-      if (body.reasoning_effort == null) {
-        body.reasoning_effort = "low";
-      }
-    }
-    const budget = maxTokens ??
-      (typeof legacyMaxTokens === "number" ? legacyMaxTokens : undefined);
-    if (budget != null) {
-      body.max_completion_tokens = budget;
-    }
-    return body;
-  }
-
-  if (!maxTokens) return requestBody;
-
-  if (providerId === "google" || providerId === "google_flash_lite") {
-    const generationConfig = requestBody.generationConfig &&
-        typeof requestBody.generationConfig === "object"
-      ? requestBody.generationConfig as Record<string, unknown>
-      : {};
-    return {
-      ...requestBody,
-      generationConfig: {
-        ...generationConfig,
-        maxOutputTokens: maxTokens,
-      },
-    };
-  }
-
-  return {
-    ...requestBody,
-    max_tokens: maxTokens,
-  };
 }
 
 function providerFinishReason(data: unknown): string | null {

--- a/supabase/functions/ai-hub/provider_generation_options.ts
+++ b/supabase/functions/ai-hub/provider_generation_options.ts
@@ -1,0 +1,76 @@
+// プロバイダーごとの出力トークン (max_tokens / maxOutputTokens / thinking budget)
+// 適用ロジック。index.ts の serve 副作用を避けて単体テストできるよう分離している。
+
+// Gemini の thinking トークンは maxOutputTokens を本文と共有して消費するため、
+// 上限を設けないと thinking が枠を食い切り、本文出力前に MAX_TOKENS で途中終了する
+// (細木数子風の長文資産要約で実際に発生し provider フォールバックが多発した)。
+// 本文用にこのトークン数を確保し、残りを thinkingBudget で上限化する。
+export const GEMINI_OUTPUT_TOKEN_RESERVE = 8000;
+
+export function applyProviderGenerationOptions(
+  providerId: string,
+  requestBody: Record<string, unknown>,
+  options?: { maxTokens?: number },
+): Record<string, unknown> {
+  const maxTokens = options?.maxTokens;
+
+  if (providerId === "openai") {
+    // OpenAI の新世代モデル (gpt-5 / o系) は max_tokens パラメータ自体を
+    // 拒否するため、ベース body (OPENAI_COMPAT_BODY) の max_tokens: 512 を
+    // 取り除いた上で max_completion_tokens へ載せ替える。
+    // groq / deepinfra 等の OpenAI 互換プロバイダーは従来どおり max_tokens。
+    const body: Record<string, unknown> = { ...requestBody };
+    const legacyMaxTokens = body.max_tokens;
+    delete body.max_tokens;
+    const model = String(body.model ?? "");
+    if (model.startsWith("gpt-5") || /^o\d/.test(model)) {
+      // reasoning モデルは温度指定を拒否する (既定値のみ許容)。
+      delete body.temperature;
+      // reasoning_effort を下げないと、推論トークンが max_completion_tokens を
+      // 使い切り本文が 0 トークンになる (gpt-5 が text:"" を返す原因)。
+      // 金額計算は Dart 側で完了済みなので低 effort で十分。
+      if (body.reasoning_effort == null) {
+        body.reasoning_effort = "low";
+      }
+    }
+    const budget = maxTokens ??
+      (typeof legacyMaxTokens === "number" ? legacyMaxTokens : undefined);
+    if (budget != null) {
+      body.max_completion_tokens = budget;
+    }
+    return body;
+  }
+
+  if (!maxTokens) return requestBody;
+
+  if (providerId === "google" || providerId === "google_flash_lite") {
+    const generationConfig = requestBody.generationConfig &&
+        typeof requestBody.generationConfig === "object"
+      ? requestBody.generationConfig as Record<string, unknown>
+      : {};
+    const nextGenerationConfig: Record<string, unknown> = {
+      ...generationConfig,
+      maxOutputTokens: maxTokens,
+    };
+    // 呼び出し側が thinkingConfig を明示していない & 本文確保枠より大きい予算のときだけ
+    // thinking を上限化する。残り (maxTokens - reserve) を thinking に割り当て、
+    // 本文用に最低 GEMINI_OUTPUT_TOKEN_RESERVE を必ず残す。
+    if (
+      generationConfig.thinkingConfig == null &&
+      maxTokens > GEMINI_OUTPUT_TOKEN_RESERVE
+    ) {
+      nextGenerationConfig.thinkingConfig = {
+        thinkingBudget: maxTokens - GEMINI_OUTPUT_TOKEN_RESERVE,
+      };
+    }
+    return {
+      ...requestBody,
+      generationConfig: nextGenerationConfig,
+    };
+  }
+
+  return {
+    ...requestBody,
+    max_tokens: maxTokens,
+  };
+}

--- a/supabase/functions/ai-hub/provider_generation_options_test.ts
+++ b/supabase/functions/ai-hub/provider_generation_options_test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  applyProviderGenerationOptions,
+  GEMINI_OUTPUT_TOKEN_RESERVE,
+} from "./provider_generation_options.ts";
+
+Deno.test("gemini caps thinking budget so output tokens are reserved", () => {
+  const body = applyProviderGenerationOptions(
+    "google",
+    { contents: [] },
+    { maxTokens: 24000 },
+  );
+  const generationConfig = body.generationConfig as Record<string, unknown>;
+  assertEquals(generationConfig.maxOutputTokens, 24000);
+  const thinkingConfig = generationConfig.thinkingConfig as Record<
+    string,
+    unknown
+  >;
+  assertEquals(
+    thinkingConfig.thinkingBudget,
+    24000 - GEMINI_OUTPUT_TOKEN_RESERVE,
+  );
+});
+
+Deno.test("gemini flash-lite also gets a thinking budget", () => {
+  const body = applyProviderGenerationOptions(
+    "google_flash_lite",
+    { contents: [] },
+    { maxTokens: 20000 },
+  );
+  const generationConfig = body.generationConfig as Record<string, unknown>;
+  const thinkingConfig = generationConfig.thinkingConfig as Record<
+    string,
+    unknown
+  >;
+  assertEquals(
+    thinkingConfig.thinkingBudget,
+    20000 - GEMINI_OUTPUT_TOKEN_RESERVE,
+  );
+});
+
+Deno.test("gemini does not set a thinking budget for small max tokens", () => {
+  const body = applyProviderGenerationOptions(
+    "google",
+    { contents: [] },
+    { maxTokens: GEMINI_OUTPUT_TOKEN_RESERVE },
+  );
+  const generationConfig = body.generationConfig as Record<string, unknown>;
+  assertEquals(generationConfig.maxOutputTokens, GEMINI_OUTPUT_TOKEN_RESERVE);
+  assertEquals(generationConfig.thinkingConfig, undefined);
+});
+
+Deno.test("gemini respects a caller-provided thinkingConfig", () => {
+  const body = applyProviderGenerationOptions(
+    "google",
+    {
+      contents: [],
+      generationConfig: { thinkingConfig: { thinkingBudget: 1234 } },
+    },
+    { maxTokens: 24000 },
+  );
+  const generationConfig = body.generationConfig as Record<string, unknown>;
+  const thinkingConfig = generationConfig.thinkingConfig as Record<
+    string,
+    unknown
+  >;
+  // 明示指定は上書きしない。
+  assertEquals(thinkingConfig.thinkingBudget, 1234);
+  assertEquals(generationConfig.maxOutputTokens, 24000);
+});
+
+Deno.test("openai uses max_completion_tokens and never a thinking budget", () => {
+  const body = applyProviderGenerationOptions(
+    "openai",
+    { model: "gpt-5", max_tokens: 512 },
+    { maxTokens: 24000 },
+  );
+  assertEquals(body.max_completion_tokens, 24000);
+  assertEquals(body.max_tokens, undefined);
+  assertEquals(body.generationConfig, undefined);
+});
+
+Deno.test("non-gemini providers fall back to max_tokens", () => {
+  const body = applyProviderGenerationOptions(
+    "groq",
+    { model: "llama" },
+    { maxTokens: 2048 },
+  );
+  assertEquals(body.max_tokens, 2048);
+  assertEquals(body.generationConfig, undefined);
+});


### PR DESCRIPTION
## 概要

AI資産要約で Gemini が `MAX_TOKENS`（outputLengthLimited）により本文出力前に途中終了し、
プロバイダーフォールバックの churn（Claude→gpt-5→gemini→…）が多発していた問題を是正する。

## 原因

Gemini の **thinking トークンは `maxOutputTokens` を本文と共有して消費**する。上限を設けないと
thinking が枠（24,000）を食い切り、本文を1トークンも出す前に `MAX_TOKENS` で打ち切られる
（細木数子風の長文要約で実際に発生）。

## 修正

- `applyProviderGenerationOptions`（ai-hub）で google / google_flash_lite のとき
  `generationConfig.thinkingConfig.thinkingBudget = maxTokens − GEMINI_OUTPUT_TOKEN_RESERVE(8000)`
  を設定し、**本文用に最低 8,000 トークンを必ず確保**する。
- 呼び出し側が `thinkingConfig` を明示した場合、または `maxTokens` が確保枠以下の場合は適用しない。
- `serve` の副作用を避けて単体テストできるよう、関数を `provider_generation_options.ts` へ抽出
  （index.ts は import 化のみ・挙動不変）。

## 検証

- `deno test provider_generation_options_test.ts`（6件 green: thinking上限 / flash-lite /
  小maxTokensスキップ / 明示thinkingConfig尊重 / openai は max_completion_tokens / groq は max_tokens）
- `deno fmt` / `deno lint`（3ファイル clean）
- `deno check` はローカルの npm 依存未インストールで未実行（抽出モジュールは test の型チェックで検証済み・挙動不変リファクタ）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: ai-hub の provider リクエスト整形は deno 単体テスト6件で検証。LLMプロバイダ呼び出しはE2Eで再現困難なため

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: supabase/functions/ai-hub のみ変更。挙動不変の純関数抽出 + Gemini generationConfig への additive な thinkingBudget 追加で、deno 単体テスト6件で担保。RLS/migration/auth は不変
