### PR TITLE
固定費の既定計上をデータ駆動化 (家賃/KDDI/水道/ガスのハードコード重複を撤去)

### DIFF
--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -5,6 +5,39 @@ import 'package:my_web_app/services/asset_revolving_credit_service.dart';
 
 import '../models/asset_liability_workbook.dart';
 
+/// ハードコードされた既定固定費 (家賃/KDDI/水道/ガス) をデータ駆動で表す内部記述子。
+///
+/// 金額/口座ID/名称は [AssetLiabilityPlanningService] の `static const` を単一の
+/// 真実源として参照する。kind と既定の支払日 (25/25/22/12) は引き続き
+/// `_classifyAccount` 側に置く (ユーザー手入力の同名口座も同じ経路で分類するため)。
+class _BuiltInRecurringFixedCost {
+  final String accountId;
+  final String accountName;
+  final double monthlyAmount;
+  final AssetRecurringFixedCostCadence cadence;
+  final String? sourceAccountId;
+
+  const _BuiltInRecurringFixedCost({
+    required this.accountId,
+    required this.accountName,
+    required this.monthlyAmount,
+    this.cadence = AssetRecurringFixedCostCadence.monthly,
+    this.sourceAccountId,
+  });
+
+  /// 指定した月 (1-12) にこの既定固定費が発生するか (隔月は偶数/奇数月のみ)。
+  bool appliesToMonth(int month) {
+    switch (cadence) {
+      case AssetRecurringFixedCostCadence.monthly:
+        return true;
+      case AssetRecurringFixedCostCadence.bimonthlyEvenMonth:
+        return month.isEven;
+      case AssetRecurringFixedCostCadence.bimonthlyOddMonth:
+        return month.isOdd;
+    }
+  }
+}
+
 class AssetLiabilityPlanningService {
   static const String directPaymentMethodId = 'direct';
   static const String directPaymentLabel = '直接支払い';
@@ -84,6 +117,36 @@ class AssetLiabilityPlanningService {
   static const int auPayCardFundingTransferDay = 26;
   static const double auPayCardFundingTransferAmount = 80000;
 
+  /// ハードコードされた既定固定費 (家賃/KDDI/水道/ガス) のデータ駆動定義。
+  /// `buildWorkbook(includeDefaultFixedPayments: true)` で当月該当かつ未計上の
+  /// ものだけを既定計上する。各値は上の `static const` を参照 (重複記述なし)。
+  static const List<_BuiltInRecurringFixedCost> _builtInRecurringFixedCosts =
+      <_BuiltInRecurringFixedCost>[
+    _BuiltInRecurringFixedCost(
+      accountId: kddiProviderAccountId,
+      accountName: kddiProviderAccountName,
+      monthlyAmount: kddiProviderMonthlyPaymentAmount,
+    ),
+    _BuiltInRecurringFixedCost(
+      accountId: rentAccountId,
+      accountName: rentAccountName,
+      monthlyAmount: rentMonthlyPaymentAmount,
+    ),
+    _BuiltInRecurringFixedCost(
+      accountId: waterBillAccountId,
+      accountName: waterBillAccountName,
+      monthlyAmount: waterBillBimonthlyPaymentAmount,
+      cadence: AssetRecurringFixedCostCadence.bimonthlyEvenMonth,
+      sourceAccountId: smbcOtsukaBranchAccountId,
+    ),
+    _BuiltInRecurringFixedCost(
+      accountId: gasBillAccountId,
+      accountName: gasBillAccountName,
+      monthlyAmount: gasBillMonthlyPaymentAmount,
+      sourceAccountId: smbcOtsukaBranchAccountId,
+    ),
+  ];
+
   const AssetLiabilityPlanningService();
 
   AssetLiabilityWorkbook buildWorkbook({
@@ -113,35 +176,27 @@ class AssetLiabilityPlanningService {
         const <AssetRecurringFixedCost>[],
     bool includeDefaultFixedPayments = false,
   }) {
-    final shouldIncludeDefaultKddiProvider =
-        includeDefaultFixedPayments && !_hasKddiProvider(latestSnapshot);
-    final shouldIncludeDefaultRent =
-        includeDefaultFixedPayments && !_hasRent(latestSnapshot);
-    // 水道代は2ヶ月に1回(偶数月の22日)。偶数月のみ既定で計上する。
-    final shouldIncludeDefaultWaterBill = includeDefaultFixedPayments &&
-        baseDate.month.isEven &&
-        !_hasWaterBill(latestSnapshot);
-    // ガス代は毎月12日。未計上時のみ既定で計上する。
-    final shouldIncludeDefaultGasBill =
-        includeDefaultFixedPayments && !_hasGasBill(latestSnapshot);
-    final effectiveSnapshot = shouldIncludeDefaultKddiProvider ||
-            shouldIncludeDefaultRent ||
-            shouldIncludeDefaultWaterBill ||
-            shouldIncludeDefaultGasBill
-        ? _withDefaultFixedPayments(
+    // 既定固定費 (家賃/KDDI/水道/ガス) を当月該当の周期かつ未計上 (残高<0 の同 ID
+    // 負債が無い) のものだけ抽出する。残高<0 限定の判定で正残高の同名資産
+    // (家賃保証金/KDDIポイント/ガスト 等) が既定を誤抑止しないようにする。
+    final applicableDefaultFixedCosts = includeDefaultFixedPayments
+        ? _builtInRecurringFixedCosts
+            .where(
+              (cost) =>
+                  cost.appliesToMonth(baseDate.month) &&
+                  !_hasLiabilityAccountFor(latestSnapshot, cost.accountId),
+            )
+            .toList(growable: false)
+        : const <_BuiltInRecurringFixedCost>[];
+    final effectiveSnapshot = applicableDefaultFixedCosts.isEmpty
+        ? latestSnapshot
+        : _withDefaultFixedPayments(
             latestSnapshot,
-            includeKddiProvider: shouldIncludeDefaultKddiProvider,
-            includeRent: shouldIncludeDefaultRent,
-            includeWaterBill: shouldIncludeDefaultWaterBill,
-            includeGasBill: shouldIncludeDefaultGasBill,
-          )
-        : latestSnapshot;
+            applicableDefaultFixedCosts,
+          );
     final effectiveMonthlyPaymentOverrides = _withDefaultFixedPaymentOverrides(
       monthlyPaymentOverrides: monthlyPaymentOverrides,
-      includeDefaultKddiProvider: shouldIncludeDefaultKddiProvider,
-      includeDefaultRent: shouldIncludeDefaultRent,
-      includeDefaultWaterBill: shouldIncludeDefaultWaterBill,
-      includeDefaultGasBill: shouldIncludeDefaultGasBill,
+      applicableDefaults: applicableDefaultFixedCosts,
     );
     final accounts = effectiveSnapshot.entries
         .where((entry) => entry.key.trim().isNotEmpty && entry.value != 0)
@@ -195,11 +250,9 @@ class AssetLiabilityPlanningService {
       accountsById: accountsById,
     );
     final effectivePaymentSourceAccountIds = <String, String>{
-      // 水道代・ガス代の既定振替元は三井住友銀行大塚支店(ユーザー設定があれば下で上書き)。
-      if (shouldIncludeDefaultWaterBill)
-        waterBillAccountId: smbcOtsukaBranchAccountId,
-      if (shouldIncludeDefaultGasBill)
-        gasBillAccountId: smbcOtsukaBranchAccountId,
+      // 既定固定費 (水道/ガス) の既定振替元は三井住友銀行大塚支店(ユーザー設定があれば下で上書き)。
+      for (final cost in applicableDefaultFixedCosts)
+        if (cost.sourceAccountId != null) cost.accountId: cost.sourceAccountId!,
       // UI 登録の定期固定費の振替元 (任意 / ユーザー個別設定があれば下で上書き)。
       for (final injected in injectedFixedCosts)
         if (injected.sourceAccountId != null &&
@@ -1838,55 +1891,28 @@ class AssetLiabilityPlanningService {
   }
 
   Map<String, double> _withDefaultFixedPayments(
-    Map<String, double> latestSnapshot, {
-    required bool includeKddiProvider,
-    required bool includeRent,
-    required bool includeWaterBill,
-    required bool includeGasBill,
-  }) {
+    Map<String, double> latestSnapshot,
+    List<_BuiltInRecurringFixedCost> applicableDefaults,
+  ) {
     final result = Map<String, double>.from(latestSnapshot);
-    if (includeKddiProvider && !_hasKddiProvider(result)) {
-      result[kddiProviderAccountName] = -kddiProviderMonthlyPaymentAmount;
-    }
-    if (includeRent && !_hasRent(result)) {
-      result[rentAccountName] = -rentMonthlyPaymentAmount;
-    }
-    if (includeWaterBill && !_hasWaterBill(result)) {
-      result[waterBillAccountName] = -waterBillBimonthlyPaymentAmount;
-    }
-    if (includeGasBill && !_hasGasBill(result)) {
-      result[gasBillAccountName] = -gasBillMonthlyPaymentAmount;
+    for (final cost in applicableDefaults) {
+      result[cost.accountName] = -cost.monthlyAmount;
     }
     return result;
   }
 
   Map<String, double> _withDefaultFixedPaymentOverrides({
     required Map<String, double> monthlyPaymentOverrides,
-    required bool includeDefaultKddiProvider,
-    required bool includeDefaultRent,
-    required bool includeDefaultWaterBill,
-    required bool includeDefaultGasBill,
+    required List<_BuiltInRecurringFixedCost> applicableDefaults,
   }) {
     final result = <String, double>{...monthlyPaymentOverrides};
-    if (includeDefaultKddiProvider &&
-        !result.containsKey(kddiProviderAccountId) &&
-        !result.containsKey(kddiProviderAccountName)) {
-      result[kddiProviderAccountId] = kddiProviderMonthlyPaymentAmount;
-    }
-    if (includeDefaultRent &&
-        !result.containsKey(rentAccountId) &&
-        !result.containsKey(rentAccountName)) {
-      result[rentAccountId] = rentMonthlyPaymentAmount;
-    }
-    if (includeDefaultWaterBill &&
-        !result.containsKey(waterBillAccountId) &&
-        !result.containsKey(waterBillAccountName)) {
-      result[waterBillAccountId] = waterBillBimonthlyPaymentAmount;
-    }
-    if (includeDefaultGasBill &&
-        !result.containsKey(gasBillAccountId) &&
-        !result.containsKey(gasBillAccountName)) {
-      result[gasBillAccountId] = gasBillMonthlyPaymentAmount;
+    for (final cost in applicableDefaults) {
+      // ID キーでも名称キーでもユーザー上書きが無いときだけ既定額を補う
+      // (名称キー上書きを既定額で shadow しないための両キーガード)。
+      if (!result.containsKey(cost.accountId) &&
+          !result.containsKey(cost.accountName)) {
+        result[cost.accountId] = cost.monthlyAmount;
+      }
     }
     return result;
   }
@@ -1899,22 +1925,6 @@ class AssetLiabilityPlanningService {
     return snapshot.entries.any(
       (entry) => entry.value < 0 && _accountIdForName(entry.key) == accountId,
     );
-  }
-
-  bool _hasKddiProvider(Map<String, double> snapshot) {
-    return _hasLiabilityAccountFor(snapshot, kddiProviderAccountId);
-  }
-
-  bool _hasRent(Map<String, double> snapshot) {
-    return _hasLiabilityAccountFor(snapshot, rentAccountId);
-  }
-
-  bool _hasWaterBill(Map<String, double> snapshot) {
-    return _hasLiabilityAccountFor(snapshot, waterBillAccountId);
-  }
-
-  bool _hasGasBill(Map<String, double> snapshot) {
-    return _hasLiabilityAccountFor(snapshot, gasBillAccountId);
   }
 
   String _fallbackAccountId(String name) {

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1553,6 +1553,24 @@ void main() {
       expect(gas.scheduledPaymentAmount, 5800);
     });
 
+    test('honors a name-keyed override for a default fixed cost', () {
+      // 名称キー (口座ID ではなく口座名) の今月上書きでも既定額で shadow せず
+      // ユーザー額を採用する。データ駆動化後も両キーガードを保つ回帰ピン。
+      final workbook = service.buildWorkbook(
+        latestSnapshot: const <String, double>{'メインバンク': 200000},
+        baseDate: DateTime(2026, 6, 14),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.rentAccountName: 70000,
+        },
+        includeDefaultFixedPayments: true,
+      );
+      final rent = workbook.debtMasterRows.firstWhere(
+        (row) => row.id == AssetLiabilityPlanningService.rentAccountId,
+      );
+      expect(rent.scheduledPaymentAmount, 70000);
+      expect(rent.paymentAmountEstimated, isFalse);
+    });
+
     test(
       'positive-balance accounts sharing a substring do not suppress defaults',
       () {


### PR DESCRIPTION
## 概要
資産管理の既定固定費 (家賃/KDDI/水道/ガス) の計上ロジックは `asset_liability_planning_service.dart` に
4 件 × 複数サイトでハードコード重複していた。本 PR は**挙動を一切変えずに**、これらを内部記述子
`_BuiltInRecurringFixedCost` の `const` リスト 1 本へ畳み、`buildWorkbook` の 4 分岐・ヘルパ 2 本・
振替元ブロックをリスト走査へ置換した (Claude Code #1)。

- 金額/口座 ID/名称は既存の `static const` を参照 (重複記述なし=単一の真実源)。
- kind と既定支払日 (25/25/22/12) は従来どおり `_classifyAccount` 側に残し、snapshot 経路を維持。
- ハンドオフ当初案の「`_buildRecurringFixedCostInjections` へ畳む」は実コード検証でリグレッションと判明
  (同名の正残高資産が既定を誤抑止/家賃の kind 変化) したため、挙動保存のデータ駆動化を採用。

## 挙動ゼロ変更の根拠
- dedup は `_hasLiabilityAccountFor` (残高<0 限定) を維持 → 正残高の同名資産 (家賃保証金/KDDI ポイント/ガスト) は既定を抑止しない。
- 家賃の kind=otherLiability・各既定支払日を維持。水道は偶数月のみ (bimonthlyEvenMonth)。
- 今月上書きは口座 ID キー・名称キー両対応の両キーガードを維持 (名称キー上書きを既定額で shadow しない)。

## テスト
- `dart format --language-version=3.4` / `flutter analyze` クリーン。
- `flutter test test/services/` = 664 件 green (既定 4 件の計上・偶数月水道・毎月ガス・両キー上書き・
  #3409 同名資産非抑止・実負債抑止を含む)。
- 名称キー上書きを既定額で shadow しない回帰ピンを 1 件追加。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数サービスの挙動保存リファクタで、unit テスト 664 件が入出力等価を担保 (UI/E2E 不変)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 純関数の挙動保存リファクタ・高リスクパス不触 (lib/services のみ)・本番フラグ不変。
