### PR TITLE
feat: 定期取引検出 v3 (収入側の定期検出 + 定期収入テンプレ prefill)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -3560,16 +3560,24 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _showRecurringIncomeTemplateDialog(
     AssetLiabilityWorkbook workbook, {
     AssetLiabilityRecurringIncomeTemplate? existing,
+    AssetLiabilityRecurringIncomeTemplate? prefill,
   }) async {
-    final nameController = TextEditingController(text: existing?.name ?? '');
+    // existing(編集)優先。なければ prefill(検出結果からの追加)を初期値に使う。
+    final initial = existing ?? prefill;
+    final nameController = TextEditingController(text: initial?.name ?? '');
     final amountController = TextEditingController(
-      text: existing == null ? '' : existing.amount.round().toString(),
+      text: initial == null ? '' : initial.amount.round().toString(),
     );
     final dayController = TextEditingController(
-      text: existing == null ? '' : existing.dayOfMonth.toString(),
+      text: initial == null ? '' : initial.dayOfMonth.toString(),
     );
-    var selectedDestinationId = existing?.destinationAccountId;
     final destinationOptions = _paymentSourceAccountOptions(workbook);
+    // 候補に無い入金先IDは保持しない(Dropdown の値整合を保つ)。
+    final destinationIds = destinationOptions.map((a) => a.id).toSet();
+    var selectedDestinationId =
+        destinationIds.contains(initial?.destinationAccountId)
+            ? initial?.destinationAccountId
+            : null;
 
     await showDialog<void>(
       context: context,
@@ -7904,6 +7912,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _buildRecurringFixedCostCard(assetLiabilityWorkbook),
               const SizedBox(height: 16),
               _buildRecurringTransactionSuggestionCard(assetLiabilityWorkbook),
+              const SizedBox(height: 16),
+              _buildRecurringIncomeSuggestionCard(assetLiabilityWorkbook),
             ],
             if (_isSectionShown(AssetManagementSectionId.disposable)) ...[
               _buildDisposableBalanceCard(),
@@ -8694,6 +8704,123 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       ),
       onIgnore: _ignoreDetectedRecurringTransaction,
+    );
+  }
+
+  /// `_recentFlows` の入金(action_type == 'conquer')を定期取引検出用の観測列にする。
+  List<RecurringTransactionObservation> _buildRecurringIncomeObservations() {
+    final observations = <RecurringTransactionObservation>[];
+    for (final flow in _recentFlows) {
+      final actionType = flow['action_type']?.toString() ?? '';
+      if (!_isIncomeActionType(actionType)) {
+        continue;
+      }
+      final occurredAt = DateTime.tryParse(
+        flow['occurred_at']?.toString() ?? '',
+      )?.toLocal();
+      if (occurredAt == null) {
+        continue;
+      }
+      final amount = ((flow['amount'] as num?)?.toDouble() ?? 0).abs().round();
+      if (amount <= 0) {
+        continue;
+      }
+      final parsed = _parseFlowDescription(
+        flow['description']?.toString() ?? '',
+        actionType: actionType,
+      );
+      final label = AssetRecurringTransactionDetector.buildLabel(
+        source: parsed.source,
+        memo: parsed.memo,
+      );
+      if (label.isEmpty) {
+        continue;
+      }
+      observations.add(
+        RecurringTransactionObservation(
+          label: label,
+          amount: amount,
+          occurredAt: occurredAt,
+          // 入金の `[口座名]` は入金先口座 → destination prefill に使う。
+          sourceName: AssetRecurringTransactionDetector.stripAccountBrackets(
+            parsed.source,
+          ),
+        ),
+      );
+    }
+    return observations;
+  }
+
+  /// 定期入金を検出し、登録済みの定期収入テンプレと一致するものは除外する。
+  List<DetectedRecurringTransaction> _detectRecurringIncome() {
+    final detected = AssetRecurringTransactionDetector.detect(
+      observations: _buildRecurringIncomeObservations(),
+      asOf: _now,
+    );
+    if (detected.isEmpty) {
+      return detected;
+    }
+    final registered = <String>{
+      for (final template in _recurringIncomeTemplates)
+        _normalizeRecurringLabel(template.name),
+    }..removeWhere((name) => name.isEmpty);
+    return detected.where((item) {
+      final label = _normalizeRecurringLabel(item.label);
+      if (label.isEmpty) {
+        return true;
+      }
+      for (final name in registered) {
+        if (label.contains(name) || name.contains(label)) {
+          return false;
+        }
+      }
+      return true;
+    }).toList();
+  }
+
+  /// 検出された定期入金を `prefill` として定期収入テンプレ追加ダイアログを開く。
+  /// 最頻の入金先口座を destination に反映する。
+  Future<void> _registerDetectedRecurringIncome(
+    DetectedRecurringTransaction detected,
+    AssetLiabilityWorkbook workbook,
+  ) {
+    final suggestedSource = detected.suggestedSourceName;
+    String? destinationAccountId;
+    String? destinationAccountName;
+    if (suggestedSource != null) {
+      for (final account in _paymentSourceAccountOptions(workbook)) {
+        if (account.name == suggestedSource) {
+          destinationAccountId = account.id;
+          destinationAccountName = account.name;
+          break;
+        }
+      }
+    }
+    final draft = AssetLiabilityRecurringIncomeTemplate(
+      id: 'income_template_suggestion',
+      dayOfMonth: detected.typicalPaymentDay,
+      name: detected.label,
+      amount: detected.typicalAmount.toDouble(),
+      destinationAccountId: destinationAccountId,
+      destinationAccountName: destinationAccountName,
+    );
+    return _showRecurringIncomeTemplateDialog(workbook, prefill: draft);
+  }
+
+  Widget _buildRecurringIncomeSuggestionCard(AssetLiabilityWorkbook? workbook) {
+    if (workbook == null) {
+      return const SizedBox.shrink();
+    }
+    return AssetRecurringTransactionSuggestionCard(
+      keyPrefix: 'asset_recurring_income',
+      title: '定期収入の自動検出',
+      description: '過去の入金から繰り返しを検出しました。定期収入に登録すると将来予測に反映されます。',
+      registerLabel: '定期収入に登録',
+      suggestions: _detectRecurringIncome(),
+      currencyFormatter: _formatYen,
+      onRegister: (detected) => unawaited(
+        _registerDetectedRecurringIncome(detected, workbook),
+      ),
     );
   }
 

--- a/lib/widgets/asset_recurring_transaction_suggestion_card.dart
+++ b/lib/widgets/asset_recurring_transaction_suggestion_card.dart
@@ -3,32 +3,51 @@ import 'package:flutter/material.dart';
 import '../services/asset_recurring_transaction_detector.dart';
 import 'recurring_fixed_cost_card.dart';
 
-/// 定期取引の自動検出カード。
+/// 定期取引(支出/収入)の自動検出カード。
 ///
 /// 純関数 [AssetRecurringTransactionDetector] が検出した
 /// [DetectedRecurringTransaction] 列を受け取り、「毎月◯日頃に約◯円」の
-/// 繰り返し支出を一覧表示する。各行の「固定費に登録」ボタンで [onRegister] を呼び、
-/// part 299 の固定費登録ダイアログへ pre-fill する。ページ状態に依存しないため
+/// 繰り返し取引を一覧表示する。各行の登録ボタンで [onRegister] を呼び、
+/// 固定費/定期収入の登録ダイアログへ pre-fill する。支出・収入の双方で再利用できるよう
+/// [title] / [description] / [registerLabel] / [keyPrefix] を差し替え可能にしている。
+/// [onIgnore] が null のときは「無視」ボタンを出さない。ページ状態に依存しないため
 /// ウィジェットテストで単体検証できる。検出ゼロなら `SizedBox.shrink()`。
 class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
   const AssetRecurringTransactionSuggestionCard({
     super.key,
     required this.suggestions,
     required this.onRegister,
-    required this.onIgnore,
+    this.onIgnore,
     this.currencyFormatter,
+    this.title = '定期取引の自動検出',
+    this.description = '過去の支出から繰り返しを検出しました。固定費に登録すると将来予測に反映されます。',
+    this.registerLabel = '固定費に登録',
+    this.keyPrefix = 'asset_recurring',
   });
 
   final List<DetectedRecurringTransaction> suggestions;
 
-  /// 「固定費に登録」押下時のコールバック。
+  /// 登録ボタン押下時のコールバック。
   final void Function(DetectedRecurringTransaction detected) onRegister;
 
   /// 「無視」押下時のコールバック(検出結果から除外して永続化する)。
-  final void Function(DetectedRecurringTransaction detected) onIgnore;
+  /// null のとき「無視」ボタンを描画しない。
+  final void Function(DetectedRecurringTransaction detected)? onIgnore;
 
   /// 金額整形(ページの `_formatYen` を渡す)。null なら簡易整形。
   final String Function(double value)? currencyFormatter;
+
+  /// カード見出し。
+  final String title;
+
+  /// 見出し下の説明文。
+  final String description;
+
+  /// 各行の登録ボタンの文言。
+  final String registerLabel;
+
+  /// key の接頭辞(支出/収入カードを別インスタンスで共存させるため衝突回避に使う)。
+  final String keyPrefix;
 
   static const Color _accent = Color(0xFF4F46E5);
   static const Color _high = Color(0xFF059669);
@@ -49,21 +68,21 @@ class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
       return const SizedBox.shrink();
     }
     return Card(
-      key: const Key('asset_recurring_transaction_suggestion_card'),
+      key: Key('${keyPrefix}_transaction_suggestion_card'),
       elevation: 2,
       child: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Row(
+            Row(
               children: [
-                Icon(Icons.autorenew, color: _accent),
-                SizedBox(width: 8),
+                const Icon(Icons.autorenew, color: _accent),
+                const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    '定期取引の自動検出',
-                    style: TextStyle(
+                    title,
+                    style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
                       height: 1.4,
@@ -73,9 +92,9 @@ class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 4),
-            const Text(
-              '過去の支出から繰り返しを検出しました。固定費に登録すると将来予測に反映されます。',
-              style: TextStyle(fontSize: 12, color: _muted, height: 1.5),
+            Text(
+              description,
+              style: const TextStyle(fontSize: 12, color: _muted, height: 1.5),
             ),
             const SizedBox(height: 8),
             for (var i = 0; i < suggestions.length; i++)
@@ -96,8 +115,9 @@ class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
     final summary = '${detected.label}、$scheduleLabel、約'
         '${_yen(detected.typicalAmount)}、$confidenceLabel、'
         '直近${detected.monthsObserved}ヶ月分を検出';
+    final ignore = onIgnore;
     return Padding(
-      key: Key('asset_recurring_suggestion_$index'),
+      key: Key('${keyPrefix}_suggestion_$index'),
       padding: const EdgeInsets.only(bottom: 10),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -176,17 +196,19 @@ class AssetRecurringTransactionSuggestionCard extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
+              if (ignore != null) ...[
+                TextButton(
+                  key: Key('${keyPrefix}_suggestion_ignore_$index'),
+                  onPressed: () => ignore(detected),
+                  style: TextButton.styleFrom(foregroundColor: _muted),
+                  child: const Text('無視'),
+                ),
+                const SizedBox(width: 4),
+              ],
               TextButton(
-                key: Key('asset_recurring_suggestion_ignore_$index'),
-                onPressed: () => onIgnore(detected),
-                style: TextButton.styleFrom(foregroundColor: _muted),
-                child: const Text('無視'),
-              ),
-              const SizedBox(width: 4),
-              TextButton(
-                key: Key('asset_recurring_suggestion_register_$index'),
+                key: Key('${keyPrefix}_suggestion_register_$index'),
                 onPressed: () => onRegister(detected),
-                child: const Text('固定費に登録'),
+                child: Text(registerLabel),
               ),
             ],
           ),

--- a/test/services/asset_recurring_transaction_detector_test.dart
+++ b/test/services/asset_recurring_transaction_detector_test.dart
@@ -189,6 +189,27 @@ void main() {
     });
   });
 
+  group('AssetRecurringTransactionDetector.detect (income usage)', () {
+    test('detects a stable monthly salary with its destination account', () {
+      final result = AssetRecurringTransactionDetector.detect(
+        observations: [
+          for (var m = 1; m <= 6; m++)
+            obs('給料', 280000, m, day: 25, sourceName: '給与口座'),
+        ],
+        asOf: asOf,
+      );
+
+      expect(result.length, 1);
+      final detected = result.single;
+      expect(detected.label, '給料');
+      expect(detected.cadence, AssetRecurringFixedCostCadence.monthly);
+      expect(detected.typicalAmount, 280000);
+      expect(detected.typicalPaymentDay, 25);
+      expect(detected.confidence, RecurringTransactionConfidence.high);
+      expect(detected.suggestedSourceName, '給与口座');
+    });
+  });
+
   group('AssetRecurringTransactionDetector.buildLabel', () {
     test('strips date and number fragments from the memo', () {
       expect(

--- a/test/widgets/asset_recurring_transaction_suggestion_card_test.dart
+++ b/test/widgets/asset_recurring_transaction_suggestion_card_test.dart
@@ -100,6 +100,42 @@ void main() {
     expect(ignored!.label, '家賃');
   });
 
+  testWidgets('income mode: custom labels, no ignore button, distinct keys', (
+    tester,
+  ) async {
+    DetectedRecurringTransaction? registered;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AssetRecurringTransactionSuggestionCard(
+            keyPrefix: 'asset_recurring_income',
+            title: '定期収入の自動検出',
+            description: '過去の入金から繰り返しを検出しました。',
+            registerLabel: '定期収入に登録',
+            suggestions: [make('給料')],
+            onRegister: (detected) => registered = detected,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('定期収入の自動検出'), findsOneWidget);
+    expect(find.text('定期収入に登録'), findsOneWidget);
+    expect(find.text('無視'), findsNothing); // onIgnore 未指定 → 非表示
+    final incomeCard = find.byKey(
+      const Key('asset_recurring_income_transaction_suggestion_card'),
+    );
+    expect(incomeCard, findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const Key('asset_recurring_income_suggestion_register_0')),
+    );
+    await tester.pump();
+
+    expect(registered, isNotNull);
+    expect(registered!.label, '給料');
+  });
+
   testWidgets('shows the cadence label (monthly vs bimonthly)', (tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## 概要

定期取引の自動検出 v3 = **収入側の定期検出**。支出側(v1/v2)に続き、過去の入金履歴(`_recentFlows` の `action_type == 'conquer'`)から「毎月◯日頃に約◯円」の繰り返し入金(給料・定期入金等)を自動検出し、未登録のものを既存の**定期収入テンプレ**(`AssetLiabilityRecurringIncomeTemplate`)へワンタップ pre-fill 登録します。定期収入は将来CF予測に投入されるため、登録で予測精度が上がります。

## 変更点

- 検出器 `AssetRecurringTransactionDetector` は支出/収入非依存のため**そのまま再利用**(変更なし)。
- カード `AssetRecurringTransactionSuggestionCard` を後方互換で汎用化: `onIgnore` を nullable 化(null で「無視」ボタン非表示)+ `title`/`description`/`registerLabel`/`keyPrefix`(支出・収入カードの key 衝突回避)を追加。既存の支出カード呼び出しは挙動不変。
- 収入ダイアログ `_showRecurringIncomeTemplateDialog` に `prefill` 経路を additive 追加(`existing ?? prefill` 初期化 / 保存時は新規 id 採番=「追加」)。候補に無い入金先IDは保持しない整合ガードも追加。
- ページ統合: `conquer` 入金の observation 構築 → 検出 → 登録済みテンプレ名と一致するものを除外 → 最頻入金先口座を destination prefill → 収入検出カードを支出検出カードの隣に配置。

## 互換性 / リスク

- 既存挙動はゼロ変更(汎用化は全て後方互換のデフォルト引数 / ダイアログは任意引数追加)。新カードはデータが無ければ非表示。

## テスト

- card: 収入モード(custom title/registerLabel 表示 / `onIgnore` 未指定で「無視」非表示 / keyPrefix で distinct key / 登録コールバック)。既存の支出モードテストは不変。
- detector: 収入(給料)の月次安定検出 + 入金先 source の代表ケースを追加。

## スコープ外(fast-follow)

- 収入候補の「無視」永続化(支出は実装済 / 収入は別キーの ignore ストアが要るため見送り。登録済み除外で主要ケースはカバー)。
- 検出感度の実データチューニングは本番フローデータ非アクセスで不可(既定値流用)。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数unit+widgetテストで担保。E2E基盤未整備のため対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/widgets・lib/pages・test のみ。supabase/workflow/auth系の高リスクパスは未変更。純関数unit+widgetテストで担保
