### PR TITLE
feat: 定期取引検出 v4 (収入候補の無視を永続化)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -416,8 +416,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // UI 登録の定期固定費 (家賃・光熱費など)。振替日昇順で保持する。
   List<AssetRecurringFixedCost> _recurringFixedCosts =
       <AssetRecurringFixedCost>[];
-  // 定期取引の自動検出で「無視」した正規化ラベル(再提案しない)。
+  // 定期取引の自動検出で「無視」した正規化ラベル(再提案しない / 支出側)。
   Set<String> _ignoredRecurringLabels = <String>{};
+  // 定期入金の自動検出で「無視」した正規化ラベル(再提案しない / 収入側)。
+  Set<String> _ignoredRecurringIncomeLabels = <String>{};
   // カテゴリ別 月次予算 (category -> 金額)。予算/カテゴリ予実カードで使用。
   Map<String, double> _categoryBudgets = <String, double>{};
   final Map<String, GlobalKey> _debtMasterCardKeys = <String, GlobalKey>{};
@@ -599,6 +601,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetRecurringSuggestionIgnoreStore();
   static const String _recurringIgnoredMirrorKey =
       'recurring_suggestion_ignored';
+  final AssetRecurringSuggestionIgnoreStore _recurringIncomeIgnoreStore =
+      const AssetRecurringSuggestionIgnoreStore(
+    prefsKey: 'asset_recurring_income_ignored_v1',
+  );
+  static const String _recurringIncomeIgnoredMirrorKey =
+      'recurring_income_suggestion_ignored';
   final AssetCategoryBudgetStore _categoryBudgetStore =
       const AssetCategoryBudgetStore();
   // 禁酒で借金完済チャレンジの記録(日付→我慢/飲んだ)。v1 はローカル永続化のみ。
@@ -715,6 +723,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_loadCategoryBudgets());
     unawaited(_loadRecurringFixedCosts());
     unawaited(_loadRecurringIgnored());
+    unawaited(_loadRecurringIncomeIgnored());
     unawaited(_loadDrinkChallenge());
     _loadExpectedInflows();
     // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
@@ -8477,6 +8486,96 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_mirrorRecurringIgnored());
   }
 
+  /// 起動時に収入の「無視」集合をローカルから読み、サーバミラーと union する。
+  Future<void> _loadRecurringIncomeIgnored() async {
+    try {
+      final ignored = await _recurringIncomeIgnoreStore.load();
+      if (mounted && ignored.isNotEmpty) {
+        setState(() => _ignoredRecurringIncomeLabels = ignored);
+      }
+    } catch (e) {
+      debugPrint('Error loading recurring income ignored: $e');
+    }
+    await _restoreRecurringIncomeIgnoredFromMirror();
+  }
+
+  /// サーバミラー (pref_key: recurring_income_suggestion_ignored) を取り込み、
+  /// ローカル集合と union する(無視は単調増加なので union が安全)。
+  Future<void> _restoreRecurringIncomeIgnoredFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', _recurringIncomeIgnoredMirrorKey);
+      if (rows.isEmpty) {
+        return;
+      }
+      final serverIgnored =
+          AssetRecurringSuggestionIgnoreStore.decodeMirrorValue(
+        rows.first['value'],
+      );
+      if (!mounted || serverIgnored.isEmpty) {
+        return;
+      }
+      final merged = <String>{
+        ..._ignoredRecurringIncomeLabels,
+        ...serverIgnored,
+      };
+      if (merged.length == _ignoredRecurringIncomeLabels.length) {
+        return; // サーバに新規無視なし。
+      }
+      setState(() => _ignoredRecurringIncomeLabels = merged);
+      _persistInBackground(
+        _recurringIncomeIgnoreStore.save(merged),
+        'recurring income ignored restore save',
+      );
+    } catch (e) {
+      debugPrint('recurring income ignored mirror restore failed: $e');
+    }
+  }
+
+  /// 収入の「無視」集合の全量を `asset_pref_mirror` へ 1 行 upsert する。
+  Future<void> _mirrorRecurringIncomeIgnored() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _recurringIncomeIgnoredMirrorKey,
+        'value': AssetRecurringSuggestionIgnoreStore.encodeMirrorValue(
+          _ignoredRecurringIncomeLabels,
+        ),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('recurring income ignored mirror upsert failed: $e');
+    }
+  }
+
+  /// 検出された定期入金を「無視」集合へ追加して再提案を止める(永続化 + ミラー)。
+  void _ignoreDetectedRecurringIncome(DetectedRecurringTransaction detected) {
+    final label = _normalizeRecurringLabel(detected.label);
+    if (label.isEmpty || _ignoredRecurringIncomeLabels.contains(label)) {
+      return;
+    }
+    setState(() {
+      _ignoredRecurringIncomeLabels = <String>{
+        ..._ignoredRecurringIncomeLabels,
+        label,
+      };
+    });
+    _persistInBackground(
+      _recurringIncomeIgnoreStore.save(_ignoredRecurringIncomeLabels),
+      'recurring income ignored save',
+    );
+    unawaited(_mirrorRecurringIncomeIgnored());
+  }
+
   void _saveRecurringFixedCost(AssetRecurringFixedCost cost) {
     setState(() {
       final next = List<AssetRecurringFixedCost>.from(_recurringFixedCosts);
@@ -8769,6 +8868,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (label.isEmpty) {
         return true;
       }
+      if (_ignoredRecurringIncomeLabels.contains(label)) {
+        return false;
+      }
       for (final name in registered) {
         if (label.contains(name) || name.contains(label)) {
           return false;
@@ -8821,6 +8923,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       onRegister: (detected) => unawaited(
         _registerDetectedRecurringIncome(detected, workbook),
       ),
+      onIgnore: _ignoreDetectedRecurringIncome,
     );
   }
 

--- a/lib/services/asset_recurring_suggestion_ignore_store.dart
+++ b/lib/services/asset_recurring_suggestion_ignore_store.dart
@@ -5,13 +5,17 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// 定期取引の自動検出で「この候補を無視」したラベル(正規化済み)を永続化する。
 ///
 /// ローカル (SharedPreferences) を一次ストアとし、端末間同期は資産管理ページが
-/// `asset_pref_mirror` (pref_key: `recurring_suggestion_ignored`) へ 1 行 jsonb
-/// 配列でミラーする。無視集合は単調増加(union)前提のため tombstone は不要
-/// (再表示はローカル操作で対応)。保存形は文字列の JSON 配列。
+/// `asset_pref_mirror` へ 1 行 jsonb 配列でミラーする。無視集合は単調増加(union)
+/// 前提のため tombstone は不要(再表示はローカル操作で対応)。保存形は文字列の JSON 配列。
+///
+/// [prefsKey] を差し替えることで支出用・収入用など複数の無視集合を別々に永続化できる
+/// (既定は支出側の `asset_recurring_ignored_v1`)。
 class AssetRecurringSuggestionIgnoreStore {
-  static const String prefsKey = 'asset_recurring_ignored_v1';
+  const AssetRecurringSuggestionIgnoreStore({
+    this.prefsKey = 'asset_recurring_ignored_v1',
+  });
 
-  const AssetRecurringSuggestionIgnoreStore();
+  final String prefsKey;
 
   Future<Set<String>> load({SharedPreferences? prefs}) async {
     final store = prefs ?? await SharedPreferences.getInstance();

--- a/test/services/asset_recurring_suggestion_ignore_store_test.dart
+++ b/test/services/asset_recurring_suggestion_ignore_store_test.dart
@@ -21,6 +21,19 @@ void main() {
     expect(await store.load(prefs: prefs), isEmpty);
   });
 
+  test('distinct prefsKey isolates expense and income ignore sets', () async {
+    final prefs = await SharedPreferences.getInstance();
+    const incomeStore = AssetRecurringSuggestionIgnoreStore(
+      prefsKey: 'asset_recurring_income_ignored_v1',
+    );
+
+    await store.save(<String>{'電気代'}, prefs: prefs);
+    await incomeStore.save(<String>{'給料'}, prefs: prefs);
+
+    expect(await store.load(prefs: prefs), <String>{'電気代'});
+    expect(await incomeStore.load(prefs: prefs), <String>{'給料'});
+  });
+
   test('encodeMirrorValue sorts and drops blank labels', () {
     expect(
       AssetRecurringSuggestionIgnoreStore.encodeMirrorValue(<String>{


### PR DESCRIPTION
## 概要

定期取引検出 v4 = **収入候補の「無視」永続化**。支出側(v2b / [#3479](https://github.com/kanta13jp1/my_web_app/pull/3479))に続き、定期収入の自動検出([#3490](https://github.com/kanta13jp1/my_web_app/pull/3490))にも「この候補を無視」を追加。誤検出や不要な定期入金候補を非表示にして再提案を止められます。

## 変更点

- ignore ストア `AssetRecurringSuggestionIgnoreStore` を `prefsKey` 引数で汎用化(既定は支出側キーで後方互換)。収入は別キー `asset_recurring_income_ignored_v1` で別集合を永続化(支出・収入のラベル衝突を回避)。
- ページに収入の無視集合 `_ignoredRecurringIncomeLabels` を配線: 起動時にローカル + サーバミラー(pref_key `recurring_income_suggestion_ignored`)を union 取込、「無視」操作でローカル保存 + ミラー upsert(無視は単調増加=union 安全 / tombstone 不要)。検出フィルタに ignore を追加。
- 収入検出カードに `onIgnore` を配線(汎用化済みカードの「無視」ボタンが表示される)。

## 互換性 / リスク

- 既存挙動はゼロ変更(ストアは既定キーで後方互換 / 収入無視集合が空なら従来どおり)。支出側の無視とは別キーで完全分離。

## テスト

- store: 異なる `prefsKey` で支出・収入の無視集合が分離されること(相互に干渉しない)を追加検証。既存の round-trip / 空クリア / encode・decode テストは不変。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数unit+widgetテストで担保。E2E基盤未整備のため対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/services・lib/pages・test のみ。supabase/workflow/auth系の高リスクパスは未変更。純関数unitテストで担保
