### PR TITLE
fix: document MirrorTombstoneStore write atomicity instead of locking

### DIFF
--- a/lib/services/mirror_tombstone_store.dart
+++ b/lib/services/mirror_tombstone_store.dart
@@ -48,6 +48,24 @@ class AssetTombstoneGcConfig {
 /// 保存形式は `[{"id": ..., "at": <iso>}, ...]`。part 285 の旧プレーン配列
 /// (`["id", ...]`) も後方互換で読み込む。書き込み・読み出し時に期限切れ
 /// (gcConfig.maxAgeDays) と件数超過 (gcConfig.maxCount) を破棄する。
+///
+/// 並行安全性 (= write 直列化は不要): 各 write メソッド (addId / removeId /
+/// prune / mergeRemoteIds) は同期 `getString` で読み、計算し、`setString` で
+/// 書く。read と write の間に `await` は無く、legacy `SharedPreferences` は
+/// `setString` の呼び出し時点で in-memory cache を **同期更新** する
+/// (platform への永続化のみ非同期)。よって unawaited で連続発火しても各
+/// read-modify-write は同期区間内で原子的に完了し、後発の read は先発の cache
+/// 更新を必ず観測する → 単一 blob でも lost-update は起きない。姉妹
+/// [AssetSyncDirtyKeysStore] は `await _loadAll` を read↔write 間に挟むため
+/// process-wide ロックが要るが、本ストアは構造上不要。
+///
+/// 🔴 将来 RMW 間に `await` を入れる / `SharedPreferencesAsync` (同期 cache
+/// 無し) へ移行する場合は、この原子性が崩れるため write 直列化ロックが必須に
+/// なる。`const` コンストラクタを維持するならロックは `static` にせざるを得ず、
+/// その static future は `testWidgets` の FakeAsync zone を跨いで orphan 化し
+/// 既存の page smoke suite を壊す (検証済み) ので、その時はインスタンス設計と
+/// テスト戦略を併せて見直すこと。本不変条件は
+/// `test/services/mirror_tombstone_store_test.dart` の並行テストでガードする。
 class MirrorTombstoneStore {
   const MirrorTombstoneStore({
     required this.storageKey,
@@ -60,34 +78,6 @@ class MirrorTombstoneStore {
   final DateTime Function()? nowProvider;
 
   DateTime _now() => nowProvider?.call() ?? DateTime.now();
-
-  /// 全 write 系メソッド (addId / removeId / prune / mergeRemoteIds) の
-  /// read-modify-write を process-wide で直列化するロック。単一 pref blob への
-  /// RMW が並行 (= 各呼び出しサイトが unawaited で発火) で交錯すると、後発の
-  /// write が先発の `setString` 着地前に古い blob を読み、相手の変更を
-  /// 取りこぼす lost-update が起こり得る (= stale tombstone 残存 → 他端末へ
-  /// 誤伝播)。読み取り (`activeIds` / `decodeMirror`) はスナップショットで
-  /// 十分なためロック不要。
-  ///
-  /// 防御的ハードニング: 現行の legacy `SharedPreferences` は cache を
-  /// `setString` 内で同期更新し、本ストアの read→write 間に await を挟まない
-  /// ため back-to-back の発火では実際には取りこぼさない。だが
-  /// `SharedPreferencesAsync` への移行や read/write 間に await が入る将来の
-  /// 改修では race が顕在化する。同期レイヤの姉妹 [AssetSyncDirtyKeysStore]
-  /// (#3415) と同型のガードを横展開し、その回帰を構造的に封じる。
-  /// `const` コンストラクタとは両立する (static はインスタンス state でない)。
-  static Future<void> _writeLock = Future<void>.value();
-
-  /// [action] を前の write 完了後に直列実行し、その結果/例外を呼び出し元へ
-  /// 伝播する。ロック鎖自体は失敗で途切れさせない (onError で吸収)。
-  /// `catchError` は非 void future を null 完了させ TypeError になり得るため、
-  /// `prune` (Future<int>) / `mergeRemoteIds` (Future<Set>) にも対応できるよう
-  /// `then<void>((_) {}, onError:)` でロック鎖を void 化する。
-  Future<T> _runLocked<T>(Future<T> Function() action) {
-    final run = _writeLock.then((_) => action());
-    _writeLock = run.then<void>((_) {}, onError: (_) {});
-    return run;
-  }
 
   /// トゥームストーン ID 集合をミラー upsert 用の値へ変換する
   /// (`{'ids': [...]}`)。ページと統合テストで同一の形を共有する (#part287)。
@@ -124,74 +114,62 @@ class MirrorTombstoneStore {
   }
 
   /// ID を 1 件トゥームストーン化する (タイムスタンプ付きで追記し GC)。
-  /// read-modify-write を [_runLocked] で直列化する。
-  Future<void> addId(SharedPreferences store, String id) {
+  Future<void> addId(SharedPreferences store, String id) async {
     if (id.isEmpty) {
-      return Future<void>.value();
+      return;
     }
-    return _runLocked(() async {
-      final entries = _gcEntries(_readEntries(store.getString(storageKey)))
-        ..removeWhere((entry) => entry['id'] == id);
-      entries.add(<String, String>{
-        'id': id,
-        'at': _now().toUtc().toIso8601String(),
-      });
-      await _writeEntries(store, entries);
+    final entries = _gcEntries(_readEntries(store.getString(storageKey)))
+      ..removeWhere((entry) => entry['id'] == id);
+    entries.add(<String, String>{
+      'id': id,
+      'at': _now().toUtc().toIso8601String(),
     });
+    await _writeEntries(store, entries);
   }
 
   /// ID のトゥームストーンを解除する (再追加を許す / #part291)。
   /// 表示設定 override のように ID (= sectionId) が再利用されるドメイン向け。
-  /// read-modify-write を [_runLocked] で直列化する。
-  Future<void> removeId(SharedPreferences store, String id) {
-    return _runLocked(() async {
-      final entries = _gcEntries(_readEntries(store.getString(storageKey)));
-      final before = entries.length;
-      entries.removeWhere((entry) => entry['id'] == id);
-      if (entries.length != before) {
-        await _writeEntries(store, entries);
-      }
-    });
+  Future<void> removeId(SharedPreferences store, String id) async {
+    final entries = _gcEntries(_readEntries(store.getString(storageKey)));
+    final before = entries.length;
+    entries.removeWhere((entry) => entry['id'] == id);
+    if (entries.length != before) {
+      await _writeEntries(store, entries);
+    }
   }
 
   /// 期限切れ・上限超過のトゥームストーンを今すぐ掃除し、削除件数を返す
   /// (手動 GC / #part291)。読み出し時にも GC されるが、件数を見せる用途。
-  /// read-modify-write を [_runLocked] で直列化する。
-  Future<int> prune(SharedPreferences store) {
-    return _runLocked(() async {
-      final entries = _readEntries(store.getString(storageKey));
-      final kept = _gcEntries(entries);
-      final removed = entries.length - kept.length;
-      if (removed > 0) {
-        await _writeEntries(store, kept);
-      }
-      return removed;
-    });
+  Future<int> prune(SharedPreferences store) async {
+    final entries = _readEntries(store.getString(storageKey));
+    final kept = _gcEntries(entries);
+    final removed = entries.length - kept.length;
+    if (removed > 0) {
+      await _writeEntries(store, kept);
+    }
+    return removed;
   }
 
   /// 他端末由来の ID 群を取り込む。実際に取り込んだ (空でない) ID 集合を返す。
   /// ローカル項目の削除はドメイン側 (呼び出し元) が行う。
-  /// read-modify-write を [_runLocked] で直列化する。
   Future<Set<String>> mergeRemoteIds(
     SharedPreferences store,
     Iterable<String> remoteIds,
-  ) {
+  ) async {
     final incoming = remoteIds.where((id) => id.isNotEmpty).toSet();
     if (incoming.isEmpty) {
-      return Future<Set<String>>.value(incoming);
-    }
-    return _runLocked(() async {
-      final entries = _gcEntries(_readEntries(store.getString(storageKey)));
-      final existingIds = <String>{for (final entry in entries) entry['id']!};
-      final nowIso = _now().toUtc().toIso8601String();
-      for (final id in incoming) {
-        if (existingIds.add(id)) {
-          entries.add(<String, String>{'id': id, 'at': nowIso});
-        }
-      }
-      await _writeEntries(store, _gcEntries(entries));
       return incoming;
-    });
+    }
+    final entries = _gcEntries(_readEntries(store.getString(storageKey)));
+    final existingIds = <String>{for (final entry in entries) entry['id']!};
+    final nowIso = _now().toUtc().toIso8601String();
+    for (final id in incoming) {
+      if (existingIds.add(id)) {
+        entries.add(<String, String>{'id': id, 'at': nowIso});
+      }
+    }
+    await _writeEntries(store, _gcEntries(entries));
+    return incoming;
   }
 
   /// 後方互換読み込み: 旧形式 (["id",...]) と新形式 ([{"id","at"},...]) の
@@ -264,11 +242,6 @@ class MirrorTombstoneStore {
     return kept;
   }
 
-  /// 実際の blob 書き込みプリミティブ。呼び出しは必ず [_runLocked] のロック
-  /// 区間 *内* からのみ行うこと (= 各 write 系メソッド経由)。ここで再度
-  /// [_runLocked] を取得すると、外側のロック区間が本 write の完了を待ち、本
-  /// write が同じロック鎖の解放を待つ self-deadlock になるため、本メソッド
-  /// 自体はロックを取らない。
   Future<void> _writeEntries(
     SharedPreferences store,
     List<Map<String, String>> entries,

--- a/lib/services/mirror_tombstone_store.dart
+++ b/lib/services/mirror_tombstone_store.dart
@@ -61,6 +61,34 @@ class MirrorTombstoneStore {
 
   DateTime _now() => nowProvider?.call() ?? DateTime.now();
 
+  /// 全 write 系メソッド (addId / removeId / prune / mergeRemoteIds) の
+  /// read-modify-write を process-wide で直列化するロック。単一 pref blob への
+  /// RMW が並行 (= 各呼び出しサイトが unawaited で発火) で交錯すると、後発の
+  /// write が先発の `setString` 着地前に古い blob を読み、相手の変更を
+  /// 取りこぼす lost-update が起こり得る (= stale tombstone 残存 → 他端末へ
+  /// 誤伝播)。読み取り (`activeIds` / `decodeMirror`) はスナップショットで
+  /// 十分なためロック不要。
+  ///
+  /// 防御的ハードニング: 現行の legacy `SharedPreferences` は cache を
+  /// `setString` 内で同期更新し、本ストアの read→write 間に await を挟まない
+  /// ため back-to-back の発火では実際には取りこぼさない。だが
+  /// `SharedPreferencesAsync` への移行や read/write 間に await が入る将来の
+  /// 改修では race が顕在化する。同期レイヤの姉妹 [AssetSyncDirtyKeysStore]
+  /// (#3415) と同型のガードを横展開し、その回帰を構造的に封じる。
+  /// `const` コンストラクタとは両立する (static はインスタンス state でない)。
+  static Future<void> _writeLock = Future<void>.value();
+
+  /// [action] を前の write 完了後に直列実行し、その結果/例外を呼び出し元へ
+  /// 伝播する。ロック鎖自体は失敗で途切れさせない (onError で吸収)。
+  /// `catchError` は非 void future を null 完了させ TypeError になり得るため、
+  /// `prune` (Future<int>) / `mergeRemoteIds` (Future<Set>) にも対応できるよう
+  /// `then<void>((_) {}, onError:)` でロック鎖を void 化する。
+  Future<T> _runLocked<T>(Future<T> Function() action) {
+    final run = _writeLock.then((_) => action());
+    _writeLock = run.then<void>((_) {}, onError: (_) {});
+    return run;
+  }
+
   /// トゥームストーン ID 集合をミラー upsert 用の値へ変換する
   /// (`{'ids': [...]}`)。ページと統合テストで同一の形を共有する (#part287)。
   static Map<String, dynamic> encodeMirror(Iterable<String> ids) {
@@ -96,62 +124,74 @@ class MirrorTombstoneStore {
   }
 
   /// ID を 1 件トゥームストーン化する (タイムスタンプ付きで追記し GC)。
-  Future<void> addId(SharedPreferences store, String id) async {
+  /// read-modify-write を [_runLocked] で直列化する。
+  Future<void> addId(SharedPreferences store, String id) {
     if (id.isEmpty) {
-      return;
+      return Future<void>.value();
     }
-    final entries = _gcEntries(_readEntries(store.getString(storageKey)))
-      ..removeWhere((entry) => entry['id'] == id);
-    entries.add(<String, String>{
-      'id': id,
-      'at': _now().toUtc().toIso8601String(),
+    return _runLocked(() async {
+      final entries = _gcEntries(_readEntries(store.getString(storageKey)))
+        ..removeWhere((entry) => entry['id'] == id);
+      entries.add(<String, String>{
+        'id': id,
+        'at': _now().toUtc().toIso8601String(),
+      });
+      await _writeEntries(store, entries);
     });
-    await _writeEntries(store, entries);
   }
 
   /// ID のトゥームストーンを解除する (再追加を許す / #part291)。
   /// 表示設定 override のように ID (= sectionId) が再利用されるドメイン向け。
-  Future<void> removeId(SharedPreferences store, String id) async {
-    final entries = _gcEntries(_readEntries(store.getString(storageKey)));
-    final before = entries.length;
-    entries.removeWhere((entry) => entry['id'] == id);
-    if (entries.length != before) {
-      await _writeEntries(store, entries);
-    }
+  /// read-modify-write を [_runLocked] で直列化する。
+  Future<void> removeId(SharedPreferences store, String id) {
+    return _runLocked(() async {
+      final entries = _gcEntries(_readEntries(store.getString(storageKey)));
+      final before = entries.length;
+      entries.removeWhere((entry) => entry['id'] == id);
+      if (entries.length != before) {
+        await _writeEntries(store, entries);
+      }
+    });
   }
 
   /// 期限切れ・上限超過のトゥームストーンを今すぐ掃除し、削除件数を返す
   /// (手動 GC / #part291)。読み出し時にも GC されるが、件数を見せる用途。
-  Future<int> prune(SharedPreferences store) async {
-    final entries = _readEntries(store.getString(storageKey));
-    final kept = _gcEntries(entries);
-    final removed = entries.length - kept.length;
-    if (removed > 0) {
-      await _writeEntries(store, kept);
-    }
-    return removed;
+  /// read-modify-write を [_runLocked] で直列化する。
+  Future<int> prune(SharedPreferences store) {
+    return _runLocked(() async {
+      final entries = _readEntries(store.getString(storageKey));
+      final kept = _gcEntries(entries);
+      final removed = entries.length - kept.length;
+      if (removed > 0) {
+        await _writeEntries(store, kept);
+      }
+      return removed;
+    });
   }
 
   /// 他端末由来の ID 群を取り込む。実際に取り込んだ (空でない) ID 集合を返す。
   /// ローカル項目の削除はドメイン側 (呼び出し元) が行う。
+  /// read-modify-write を [_runLocked] で直列化する。
   Future<Set<String>> mergeRemoteIds(
     SharedPreferences store,
     Iterable<String> remoteIds,
-  ) async {
+  ) {
     final incoming = remoteIds.where((id) => id.isNotEmpty).toSet();
     if (incoming.isEmpty) {
-      return incoming;
+      return Future<Set<String>>.value(incoming);
     }
-    final entries = _gcEntries(_readEntries(store.getString(storageKey)));
-    final existingIds = <String>{for (final entry in entries) entry['id']!};
-    final nowIso = _now().toUtc().toIso8601String();
-    for (final id in incoming) {
-      if (existingIds.add(id)) {
-        entries.add(<String, String>{'id': id, 'at': nowIso});
+    return _runLocked(() async {
+      final entries = _gcEntries(_readEntries(store.getString(storageKey)));
+      final existingIds = <String>{for (final entry in entries) entry['id']!};
+      final nowIso = _now().toUtc().toIso8601String();
+      for (final id in incoming) {
+        if (existingIds.add(id)) {
+          entries.add(<String, String>{'id': id, 'at': nowIso});
+        }
       }
-    }
-    await _writeEntries(store, _gcEntries(entries));
-    return incoming;
+      await _writeEntries(store, _gcEntries(entries));
+      return incoming;
+    });
   }
 
   /// 後方互換読み込み: 旧形式 (["id",...]) と新形式 ([{"id","at"},...]) の
@@ -224,6 +264,11 @@ class MirrorTombstoneStore {
     return kept;
   }
 
+  /// 実際の blob 書き込みプリミティブ。呼び出しは必ず [_runLocked] のロック
+  /// 区間 *内* からのみ行うこと (= 各 write 系メソッド経由)。ここで再度
+  /// [_runLocked] を取得すると、外側のロック区間が本 write の完了を待ち、本
+  /// write が同じロック鎖の解放を待つ self-deadlock になるため、本メソッド
+  /// 自体はロックを取らない。
   Future<void> _writeEntries(
     SharedPreferences store,
     List<Map<String, String>> entries,

--- a/test/services/mirror_tombstone_store_test.dart
+++ b/test/services/mirror_tombstone_store_test.dart
@@ -159,17 +159,14 @@ void main() {
       expect(store.activeIds(sp), isNot(contains('debt_row_1')));
     });
 
-    test('serializes concurrent add/remove without losing effects', () async {
-      // 各削除/編集サイトと同様 await を挟まず並行発火する RMW。直列化ロックが
-      // あれば後発の write が先発の setString を踏み潰す lost-update が起きず、
-      // 全操作の効果 (追加された tombstone・解除された tombstone) が保たれる。
-      //
-      // 注: legacy SharedPreferences は cache を setString 内で同期更新し、本
-      // ストアは read→write 間に await が無いため、ロック未導入でも back-to-back
-      // 発火では実際には取りこぼさない。本テストはその不変条件の回帰ガードで、
-      // read/write 間に await が入る将来の改修や SharedPreferencesAsync 移行で
-      // race が顕在化した際に直列化の欠落を検出する (姉妹
-      // AssetSyncDirtyKeysStore の並行 write テストと同型)。
+    test('concurrent add/remove stays atomic (no lost update)', () async {
+      // 不変条件ガード: 各 write は同期 getString 読み→計算→setString 書きで
+      // read↔write 間に await が無く、legacy SharedPreferences は setString 時
+      // 点で cache を同期更新する。よって await を挟まず並行発火 (= 各削除/編集
+      // サイトの unawaited パターン) しても各 RMW は同期区間で原子的に完了し、
+      // 先発の効果を後発が踏み潰す lost-update は起きない (= 書き込み直列化ロック
+      // 不要)。read↔write 間に await が入る将来の改修や SharedPreferencesAsync
+      // (同期 cache 無し) 移行でこの原子性が崩れたら本テストが落ちる。
       final store = MirrorTombstoneStore(
         storageKey: 'revolving_credit_deleted_v1',
         nowProvider: () => DateTime(2026, 6, 19, 9),
@@ -190,12 +187,11 @@ void main() {
       expect(store.activeIds(sp), <String>{'rev_a', 'rev_b'});
     });
 
-    test('serializes concurrent non-void writes and propagates results',
+    test('concurrent non-void writes stay atomic and return correct results',
         () async {
-      // generic _runLocked は非 void 戻り値 (prune=Future<int> /
-      // mergeRemoteIds=Future<Set>) も直列化しつつ、各結果/例外を呼び出し元へ
-      // 正しく伝播する (= catchError でなく then<void>((_) {}, onError:) を
-      // 使う理由)。3 操作を await を挟まず同時にロック鎖へ投入する。
+      // 非 void 戻り値 (prune=Future<int> / mergeRemoteIds=Future<Set>) も
+      // 同じ同期原子性ガード下にある: 並行発火しても取りこぼさず、各呼び出し元へ
+      // 正しい結果が返る。3 操作を await を挟まず同時に発火する。
       final store = MirrorTombstoneStore(
         storageKey: 'watchlist_entries_deleted_v1',
         nowProvider: () => DateTime(2026, 6, 19, 9),
@@ -212,7 +208,7 @@ void main() {
 
       expect(merged, <String>{'w_remote'}); // 取り込んだ非空 ID 集合
       expect(pruned, 0); // 期限内・上限内なので掃除ゼロ
-      // 全 tombstone が直列化され取りこぼし無し。
+      // 全 tombstone が取りこぼされず残る。
       expect(store.activeIds(sp), <String>{'w_seed', 'w_new', 'w_remote'});
     });
   });

--- a/test/services/mirror_tombstone_store_test.dart
+++ b/test/services/mirror_tombstone_store_test.dart
@@ -158,5 +158,62 @@ void main() {
       await store.removeId(sp, 'debt_row_1');
       expect(store.activeIds(sp), isNot(contains('debt_row_1')));
     });
+
+    test('serializes concurrent add/remove without losing effects', () async {
+      // 各削除/編集サイトと同様 await を挟まず並行発火する RMW。直列化ロックが
+      // あれば後発の write が先発の setString を踏み潰す lost-update が起きず、
+      // 全操作の効果 (追加された tombstone・解除された tombstone) が保たれる。
+      //
+      // 注: legacy SharedPreferences は cache を setString 内で同期更新し、本
+      // ストアは read→write 間に await が無いため、ロック未導入でも back-to-back
+      // 発火では実際には取りこぼさない。本テストはその不変条件の回帰ガードで、
+      // read/write 間に await が入る将来の改修や SharedPreferencesAsync 移行で
+      // race が顕在化した際に直列化の欠落を検出する (姉妹
+      // AssetSyncDirtyKeysStore の並行 write テストと同型)。
+      final store = MirrorTombstoneStore(
+        storageKey: 'revolving_credit_deleted_v1',
+        nowProvider: () => DateTime(2026, 6, 19, 9),
+      );
+      final sp = await prefs();
+      await store.addId(sp, 'keep'); // 既存トゥームストーン
+
+      // delete→addId と edit→removeId を別 future で同時発火する
+      // (asset_management_page の _recordRevolvingTombstone /
+      // _recordWatchlistTombstone と同じ unawaited パターン)。
+      await Future.wait(<Future<void>>[
+        store.addId(sp, 'rev_a'),
+        store.addId(sp, 'rev_b'),
+        store.removeId(sp, 'keep'),
+      ]);
+
+      // 'keep' は解除され 'rev_a'/'rev_b' は両方残る (= 取りこぼし無し)。
+      expect(store.activeIds(sp), <String>{'rev_a', 'rev_b'});
+    });
+
+    test('serializes concurrent non-void writes and propagates results',
+        () async {
+      // generic _runLocked は非 void 戻り値 (prune=Future<int> /
+      // mergeRemoteIds=Future<Set>) も直列化しつつ、各結果/例外を呼び出し元へ
+      // 正しく伝播する (= catchError でなく then<void>((_) {}, onError:) を
+      // 使う理由)。3 操作を await を挟まず同時にロック鎖へ投入する。
+      final store = MirrorTombstoneStore(
+        storageKey: 'watchlist_entries_deleted_v1',
+        nowProvider: () => DateTime(2026, 6, 19, 9),
+      );
+      final sp = await prefs();
+      await store.addId(sp, 'w_seed');
+
+      final addFuture = store.addId(sp, 'w_new');
+      final mergeFuture = store.mergeRemoteIds(sp, <String>['w_remote', '']);
+      final pruneFuture = store.prune(sp);
+      await addFuture;
+      final merged = await mergeFuture;
+      final pruned = await pruneFuture;
+
+      expect(merged, <String>{'w_remote'}); // 取り込んだ非空 ID 集合
+      expect(pruned, 0); // 期限内・上限内なので掃除ゼロ
+      // 全 tombstone が直列化され取りこぼし無し。
+      expect(store.activeIds(sp), <String>{'w_seed', 'w_new', 'w_remote'});
+    });
   });
 }


### PR DESCRIPTION
## Summary

This branch originally added a process-wide write-lock to `MirrorTombstoneStore`
(porting the `AssetSyncDirtyKeysStore` pattern). Adversarial verification plus a
direct experiment showed that was the wrong fix, so this PR instead **documents
the synchronous write-atomicity invariant** and keeps two concurrency guard
tests. No runtime behavior change.

## Why not the lock

- **The race is not reproducible** on the pinned legacy `SharedPreferences`
  backend: each write does a synchronous `getString` read, computes, then
  `setString`, with no `await` between read and write, and legacy
  `SharedPreferences` updates its in-memory cache synchronously inside
  `setString`. So back-to-back unawaited writes each complete their
  read-modify-write atomically within a synchronous section — no lost update.
  (Verified by reverting to unlocked code: the concurrency test still passes.)
- **The lock broke the build.** The `const` constructor forces the lock to be
  `static`; that static future is carried across `testWidgets` FakeAsync zones
  and orphans in later tests, so chained tombstone writes silently never run —
  10 tombstone smoke tests across all domains went red. The sibling store
  tolerates the same pattern only because its tests are plain `test()` units
  that fully await each op, and it is inherently async (`await _loadAll` between
  read and write) — which is also why its race is real and this one's is not.

## What this PR does

- Documents the write-atomicity invariant on `MirrorTombstoneStore`, including
  what *would* require a real lock (an `await` inserted into the
  read-modify-write path, or a `SharedPreferencesAsync` migration that drops the
  synchronous cache).
- Adds two concurrency tests that pass today and fail if that invariant is ever
  broken.

## Tests

`dart format --language-version=3.4` clean · `flutter analyze` (store + test)
clean · `flutter test test/services/mirror_tombstone_store_test.dart` 11/11 ·
`flutter test test/widgets/asset_management_page_smoke_test.dart` 40/40 (the
suite the lock had broken).

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output,
  not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty
  state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Docs comment plus unit-level concurrency guard tests; no
  user-facing flow changed.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Removes a runtime lock in favor of a
  documented invariant and guard tests; verified by adversarial review with no
  behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
