### PR TITLE
定期固定費カードを専用セクション化 (給与内訳の相乗りを解消)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -7932,11 +7932,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               const SizedBox(height: 16),
               _buildCategoryBudgetCard(),
               const SizedBox(height: 16),
-              _buildRecurringFixedCostCard(assetLiabilityWorkbook),
-              const SizedBox(height: 16),
               _buildRecurringTransactionSuggestionCard(assetLiabilityWorkbook),
               const SizedBox(height: 16),
               _buildRecurringIncomeSuggestionCard(assetLiabilityWorkbook),
+            ],
+            if (_isSectionShown(
+                AssetManagementSectionId.recurringFixedCost)) ...[
+              _buildRecurringFixedCostCard(assetLiabilityWorkbook),
+              const SizedBox(height: 16),
             ],
             if (_isSectionShown(AssetManagementSectionId.disposable)) ...[
               _buildDisposableBalanceCard(),

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -15,6 +15,7 @@ enum AssetManagementSectionId {
   monthlyFlow,
   calendar,
   salaryBreakdown,
+  recurringFixedCost,
   disposable,
   quickActions,
   wasteAi,
@@ -73,6 +74,8 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
         return 'マネーカレンダー';
       case AssetManagementSectionId.salaryBreakdown:
         return '給与消費内訳';
+      case AssetManagementSectionId.recurringFixedCost:
+        return '定期固定費';
       case AssetManagementSectionId.disposable:
         return '裁量余資金';
       case AssetManagementSectionId.quickActions:
@@ -109,6 +112,7 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
       case AssetManagementSectionId.debtPlanner:
         return AssetManagementSectionTier.essential;
       case AssetManagementSectionId.salaryBreakdown:
+      case AssetManagementSectionId.recurringFixedCost:
       case AssetManagementSectionId.deadlines:
       case AssetManagementSectionId.threeMonth:
       case AssetManagementSectionId.workbookBoard:

--- a/test/services/asset_management_display_mode_store_test.dart
+++ b/test/services/asset_management_display_mode_store_test.dart
@@ -129,6 +129,40 @@ void main() {
       );
     });
 
+    test('recurring fixed cost is a standard-tier dedicated section', () {
+      // 給与内訳と同じ standard tier = 標準/フルで表示・ミニマムで非表示。
+      expect(
+        AssetManagementDisplayModeStore.isSectionVisible(
+          section: AssetManagementSectionId.recurringFixedCost,
+          mode: AssetManagementDisplayMode.standard,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetManagementDisplayModeStore.isSectionVisible(
+          section: AssetManagementSectionId.recurringFixedCost,
+          mode: AssetManagementDisplayMode.full,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetManagementDisplayModeStore.isSectionVisible(
+          section: AssetManagementSectionId.recurringFixedCost,
+          mode: AssetManagementDisplayMode.minimum,
+        ),
+        isFalse,
+      );
+      // 給与内訳から独立して hidden 上書きできる (相乗り解消)。
+      expect(
+        AssetManagementDisplayModeStore.isSectionVisible(
+          section: AssetManagementSectionId.recurringFixedCost,
+          mode: AssetManagementDisplayMode.full,
+          override: AssetManagementSectionVisibilityOverride.hidden,
+        ),
+        isFalse,
+      );
+    });
+
     test('persists overrides and clears them when reset to auto', () async {
       const store = AssetManagementDisplayModeStore();
 

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -13,6 +13,7 @@ import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
+import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -1560,6 +1561,34 @@ void main() {
           local.map((c) => c.id),
           containsAll(<String>['fc_denki', 'fc_gym']),
         );
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'recurring fixed cost card survives hiding the salary-breakdown section',
+      (tester) async {
+        // 給与内訳セクションを hidden にしても、固定費カードは専用セクションとして
+        // 残る (salaryBreakdown 相乗りの解消 = 候補#5)。
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'asset_management_display_mode_v1':
+              AssetManagementDisplayMode.standard.storageId,
+          'asset_management_section_overrides_v1': jsonEncode(<String, String>{
+            AssetManagementSectionId.salaryBreakdown.storageId:
+                AssetManagementSectionVisibilityOverride.hidden.storageId,
+          }),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          const MaterialApp(home: AssetManagementPage()),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byType(RecurringFixedCostCard), findsOneWidget);
 
         await _unmount(tester);
       },


### PR DESCRIPTION
## 概要
定期固定費カード (`RecurringFixedCostCard`) は「給与消費内訳」セクションの gate 内に相乗りしており、
給与内訳を隠すと固定費カードも一緒に消えてしまっていた。本 PR は固定費カードに**専用の
`AssetManagementSectionId.recurringFixedCost` を与え**、独立した表示モード制御 / pin・hide を可能にする
(Claude Code #1)。

## 変更点
- `asset_management_display_mode_store.dart`: `AssetManagementSectionId` に `recurringFixedCost` を追加
  (label「定期固定費」/ tier=standard)。section 設定 UI は `.values` 走査なので pin/hide UI に自動で出現。
- `asset_management_page.dart`: 固定費カードを `salaryBreakdown` gate から独立した
  `if (_isSectionShown(recurringFixedCost))` セクションへ移設。
- tier=standard は給与内訳と同 tier のため**標準/フル表示での可視性は不変**(ミニマムで非表示も従来どおり)。
  既存の section override は storageId 名キーなので新セクション追加で破壊されない (既定 auto)。

## テスト
- `dart format --language-version=3.4` / `flutter analyze` クリーン。
- `flutter test test/services/asset_management_display_mode_store_test.dart test/widgets/asset_management_page_smoke_test.dart` green。
  新規: ①store=新セクションが standard tier (標準/フル可視・ミニマム非表示・hidden 上書き可) ②smoke=給与内訳を
  hidden にしても固定費カードが残る (相乗り解消の実証)。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 表示セクションの分離 UI 変更で、smoke harness の page pump + 表示モード store テストで入出力を検証 (専用 E2E 経路は不要)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: UI セクション分離のみ・高リスクパス不触 (lib/pages, lib/services)・可視性は同 tier 維持で挙動不変。
