### PR TITLE
fix: sync billing-confirmed flags and transfer tasks to remote monthly state

### DIFF
--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1840,31 +1840,29 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
   /// `monthly_states` テーブルへ書き込む payload を [row]
   /// (= [AssetLiabilityMonthlyStatePayload.toSupabaseJson] の出力) から構築する。
   ///
-  /// `billing_confirmed_account_ids` と `transfer_tasks` は月次状態の一部だが、
-  /// 以前この subset から漏れていたためリモートへ一切書き込まれず、端末間で
-  /// 同期されなかった (= `paid_account_ids` と同型の潜在バグ)。`fromSupabaseJson`
-  /// は両キーを読むので、書き込みさえ揃えば [loadMonth] の union / LWW マージで収束する。
+  /// 明示的な allowlist で詰め替えると、以前のように新フィールドを書き忘れて
+  /// リモートへ届かない事故 (= `billing_confirmed_account_ids` /
+  /// `transfer_tasks` が漏れ、端末間で同期されず LWW でローカルを消去していた
+  /// `paid_account_ids` と同型の潜在バグ) が起こる。これを構造的に防ぐため、
+  /// [row] から「monthly_states に属さないキーだけ」を除外して導出する:
   ///
-  /// `income_plans` は別テーブル ([AssetLiabilitySupabaseTablePlan.incomePlansTable])
-  /// へ保存するため、ここでは含めない。
+  /// - `user_id` / `month_key`: 識別子カラムは [_upsertPayloadRow] が個別に付与する。
+  /// - `income_plans`: 別テーブル
+  ///   ([AssetLiabilitySupabaseTablePlan.incomePlansTable]) へ保存する。
+  /// - `updated_at`: サーバ upsert 時刻のカラム用。payload には載せない
+  ///   (クライアント編集時刻は `state_updated_at` として別に保持する)。
+  ///
+  /// こうすることで `toSupabaseJson` に新キーが増えても自動的にリモートへ同期され、
+  /// `fromSupabaseJson` 側の読み込みと取りこぼしなく対応する。
   @visibleForTesting
   static Map<String, Object?> buildMonthlyStatesPayload(
     Map<String, Object?> row,
   ) {
-    return <String, Object?>{
-      'payment_overrides': row['payment_overrides'],
-      'actual_payment_amounts': row['actual_payment_amounts'],
-      'payment_difference_reasons': row['payment_difference_reasons'],
-      'annual_rate_overrides': row['annual_rate_overrides'],
-      'annual_rate_evidences': row['annual_rate_evidences'],
-      'paid_account_ids': row['paid_account_ids'],
-      'billing_confirmed_account_ids': row['billing_confirmed_account_ids'],
-      'payment_source_account_ids': row['payment_source_account_ids'],
-      'card_billing_account_ids': row['card_billing_account_ids'],
-      'card_statement_lines': row['card_statement_lines'],
-      'transfer_tasks': row['transfer_tasks'],
-      'state_updated_at': row['state_updated_at'],
-    };
+    return Map<String, Object?>.from(row)
+      ..remove('user_id')
+      ..remove('month_key')
+      ..remove('income_plans')
+      ..remove('updated_at');
   }
 
   @override

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1827,18 +1827,7 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
       AssetLiabilitySupabaseTablePlan.monthlyStatesTable,
       userId: userId,
       monthKey: monthKey,
-      payload: <String, Object?>{
-        'payment_overrides': row['payment_overrides'],
-        'actual_payment_amounts': row['actual_payment_amounts'],
-        'payment_difference_reasons': row['payment_difference_reasons'],
-        'annual_rate_overrides': row['annual_rate_overrides'],
-        'annual_rate_evidences': row['annual_rate_evidences'],
-        'paid_account_ids': row['paid_account_ids'],
-        'payment_source_account_ids': row['payment_source_account_ids'],
-        'card_billing_account_ids': row['card_billing_account_ids'],
-        'card_statement_lines': row['card_statement_lines'],
-        'state_updated_at': row['state_updated_at'],
-      },
+      payload: buildMonthlyStatesPayload(row),
     );
     await _upsertPayloadRow(
       AssetLiabilitySupabaseTablePlan.incomePlansTable,
@@ -1846,6 +1835,36 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
       monthKey: monthKey,
       payload: <String, Object?>{'income_plans': row['income_plans']},
     );
+  }
+
+  /// `monthly_states` テーブルへ書き込む payload を [row]
+  /// (= [AssetLiabilityMonthlyStatePayload.toSupabaseJson] の出力) から構築する。
+  ///
+  /// `billing_confirmed_account_ids` と `transfer_tasks` は月次状態の一部だが、
+  /// 以前この subset から漏れていたためリモートへ一切書き込まれず、端末間で
+  /// 同期されなかった (= `paid_account_ids` と同型の潜在バグ)。`fromSupabaseJson`
+  /// は両キーを読むので、書き込みさえ揃えば [loadMonth] の union / LWW マージで収束する。
+  ///
+  /// `income_plans` は別テーブル ([AssetLiabilitySupabaseTablePlan.incomePlansTable])
+  /// へ保存するため、ここでは含めない。
+  @visibleForTesting
+  static Map<String, Object?> buildMonthlyStatesPayload(
+    Map<String, Object?> row,
+  ) {
+    return <String, Object?>{
+      'payment_overrides': row['payment_overrides'],
+      'actual_payment_amounts': row['actual_payment_amounts'],
+      'payment_difference_reasons': row['payment_difference_reasons'],
+      'annual_rate_overrides': row['annual_rate_overrides'],
+      'annual_rate_evidences': row['annual_rate_evidences'],
+      'paid_account_ids': row['paid_account_ids'],
+      'billing_confirmed_account_ids': row['billing_confirmed_account_ids'],
+      'payment_source_account_ids': row['payment_source_account_ids'],
+      'card_billing_account_ids': row['card_billing_account_ids'],
+      'card_statement_lines': row['card_statement_lines'],
+      'transfer_tasks': row['transfer_tasks'],
+      'state_updated_at': row['state_updated_at'],
+    };
   }
 
   @override

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -519,6 +519,83 @@ void main() {
       },
     );
 
+    test(
+      'loadMonth unions billing confirmations and transfer tasks across '
+      'devices',
+      () async {
+        final local = _FakeAssetLiabilityRepository();
+        final remote = _RecordingAssetLiabilityRemoteStore();
+        final repository = FeatureFlaggedAssetLiabilityRepository(
+          localRepository: local,
+          remoteStore: remote,
+          syncEnabled: true,
+          remoteWritesEnabled: true,
+          userIdProvider: () => 'user-1',
+        );
+        final month = DateTime(2026, 5);
+
+        // この端末はモビットのカード請求を確認済み + 自端末の口座移動タスク。
+        await local.saveMonth(
+          month: month,
+          state: AssetLiabilityMonthlyState(
+            billingConfirmedAccountIds: const <String>{'mobit'},
+            transferTasks: <AssetLiabilityTransferTask>[
+              AssetLiabilityTransferTask(
+                id: 'transfer_local',
+                fromAccountId: 'custom_cash',
+                fromAccountName: 'Cash',
+                toAccountId: 'smbc_otsuka',
+                toAccountName: 'SMBC Otsuka',
+                amount: 10000,
+                dueDate: DateTime(2026, 5, 18),
+              ),
+            ],
+          ),
+        );
+        // 別端末はPayPayカードを確認済み + 別の口座移動タスク。
+        remote.seedMonth(
+          month,
+          AssetLiabilityMonthlyState(
+            billingConfirmedAccountIds: const <String>{'paypay_card'},
+            transferTasks: <AssetLiabilityTransferTask>[
+              AssetLiabilityTransferTask(
+                id: 'transfer_remote',
+                fromAccountId: 'smbc_otsuka',
+                fromAccountName: 'SMBC Otsuka',
+                toAccountId: 'rakuten_bank',
+                toAccountName: 'Rakuten Bank',
+                amount: 20000,
+                dueDate: DateTime(2026, 5, 20),
+              ),
+            ],
+          ),
+        );
+
+        final merged = await repository.loadMonth(month);
+
+        // 双方の請求確認フラグ・口座移動タスクが取りこぼされず union される。
+        expect(
+          merged.billingConfirmedAccountIds,
+          containsAll(<String>{'mobit', 'paypay_card'}),
+        );
+        expect(
+          merged.transferTasks.map((task) => task.id),
+          containsAll(<String>{'transfer_local', 'transfer_remote'}),
+        );
+        // 収束のためローカル/リモート双方へマージ結果を保存する。
+        final localAfter = await local.loadMonth(month);
+        expect(
+          localAfter.billingConfirmedAccountIds,
+          contains('paypay_card'),
+        );
+        expect(
+          remote.monthState('2026-05')?.billingConfirmedAccountIds,
+          contains('mobit'),
+        );
+        expect(remote.calls, contains('saveMonth:user-1:2026-05'));
+      },
+    );
+
     test('loadMonth keeps local value when scalar fields conflict', () async {
       final local = _FakeAssetLiabilityRepository();
       final remote = _RecordingAssetLiabilityRemoteStore();
@@ -1461,6 +1538,119 @@ void main() {
         restored.transferTasks.single.cancellationReason,
         'Paid from salary account directly.',
       );
+    });
+
+    test(
+        'monthly_states remote payload carries billing confirmations and '
+        'transfer tasks', () {
+      // 回帰: 以前 saveMonth の subset マップが billing_confirmed_account_ids と
+      // transfer_tasks を取りこぼし、リモートへ一切書かれず端末間で同期されなかった
+      // (= paid_account_ids と同型の潜在バグ)。
+      final state = AssetLiabilityMonthlyState(
+        paidAccountNames: const <String>{'kddi_provider'},
+        billingConfirmedAccountIds: const <String>{'mobit', 'paypay_card'},
+        transferTasks: <AssetLiabilityTransferTask>[
+          AssetLiabilityTransferTask(
+            id: 'transfer_bank_topup',
+            fromAccountId: 'custom_cash',
+            fromAccountName: 'Cash',
+            toAccountId: 'smbc_otsuka',
+            toAccountName: 'SMBC Otsuka',
+            amount: 10000,
+            dueDate: DateTime(2026, 5, 18),
+          ),
+        ],
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'salary',
+            date: DateTime(2026, 5, 25),
+            name: 'Salary',
+            amount: 250000,
+            destinationAccountId: 'smbc_otsuka',
+            destinationAccountName: 'SMBC Otsuka',
+            received: false,
+          ),
+        ],
+        updatedAt: DateTime.utc(2026, 5, 19, 8),
+      );
+      final row = AssetLiabilityMonthlyStatePayload.fromState(
+        monthKey: '2026-05',
+        state: state,
+      ).toSupabaseJson(userId: 'user-1');
+
+      final payload = AssetLiabilitySupabaseRemoteStore.buildMonthlyStatesPayload(
+        row,
+      );
+
+      // 取りこぼしていた 2 キーが monthly_states payload に含まれること。
+      expect(payload.containsKey('billing_confirmed_account_ids'), isTrue);
+      expect(payload.containsKey('transfer_tasks'), isTrue);
+      expect(
+        payload['billing_confirmed_account_ids'],
+        containsAll(<String>['mobit', 'paypay_card']),
+      );
+      expect((payload['transfer_tasks']! as List<Object?>).length, 1);
+      // LWW 用のクライアント編集時刻も同梱される。
+      expect(payload['state_updated_at'], '2026-05-19T08:00:00.000Z');
+      // income_plans は別テーブルへ保存するため monthly_states には含めない。
+      expect(payload.containsKey('income_plans'), isFalse);
+      // 識別子カラムは _upsertPayloadRow が個別に付与するため payload には含めない。
+      expect(payload.containsKey('user_id'), isFalse);
+      expect(payload.containsKey('month_key'), isFalse);
+    });
+
+    test(
+        'save split and load merge round-trip preserves billing confirmations '
+        'and transfer tasks across the two tables', () {
+      final state = AssetLiabilityMonthlyState(
+        billingConfirmedAccountIds: const <String>{'mobit'},
+        transferTasks: <AssetLiabilityTransferTask>[
+          AssetLiabilityTransferTask(
+            id: 'transfer_bank_topup',
+            fromAccountId: 'custom_cash',
+            fromAccountName: 'Cash',
+            toAccountId: 'smbc_otsuka',
+            toAccountName: 'SMBC Otsuka',
+            amount: 10000,
+            dueDate: DateTime(2026, 5, 18),
+          ),
+        ],
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'salary',
+            date: DateTime(2026, 5, 25),
+            name: 'Salary',
+            amount: 250000,
+            destinationAccountId: 'smbc_otsuka',
+            destinationAccountName: 'SMBC Otsuka',
+            received: false,
+          ),
+        ],
+      );
+      final row = AssetLiabilityMonthlyStatePayload.fromState(
+        monthKey: '2026-05',
+        state: state,
+      ).toSupabaseJson(userId: 'user-1');
+
+      // saveMonth が 2 テーブルへ分割書き込みする 2 つの payload 行を再現する。
+      final monthlyRow =
+          AssetLiabilitySupabaseRemoteStore.buildMonthlyStatesPayload(row);
+      final incomeRow = <String, Object?>{'income_plans': row['income_plans']};
+
+      // loadMonth はこの 2 行の payload を合体して fromSupabaseJson に渡す。
+      final mergedPayload = <String, Object?>{
+        ...monthlyRow,
+        ...incomeRow,
+        'month_key': '2026-05',
+      };
+      final restored = AssetLiabilityMonthlyStatePayload.fromSupabaseJson(
+        mergedPayload,
+      ).toState();
+
+      expect(restored.billingConfirmedAccountIds, contains('mobit'));
+      expect(restored.transferTasks.single.id, 'transfer_bank_topup');
+      expect(restored.transferTasks.single.amount, 10000);
+      expect(restored.incomePlans.single.id, 'salary');
     });
 
     test('round-trips settings and snapshot payloads', () {

--- a/test/services/asset_liability_repository_test.dart
+++ b/test/services/asset_liability_repository_test.dart
@@ -1578,7 +1578,8 @@ void main() {
         state: state,
       ).toSupabaseJson(userId: 'user-1');
 
-      final payload = AssetLiabilitySupabaseRemoteStore.buildMonthlyStatesPayload(
+      final payload =
+          AssetLiabilitySupabaseRemoteStore.buildMonthlyStatesPayload(
         row,
       );
 
@@ -1597,6 +1598,25 @@ void main() {
       // 識別子カラムは _upsertPayloadRow が個別に付与するため payload には含めない。
       expect(payload.containsKey('user_id'), isFalse);
       expect(payload.containsKey('month_key'), isFalse);
+      // キー集合を厳密に固定する。toSupabaseJson に状態フィールドが増えたら
+      // ここが落ちて「リモートへ同期すべきか」を必ず判断させる (= 書き忘れ防止)。
+      expect(
+        payload.keys.toSet(),
+        <String>{
+          'payment_overrides',
+          'actual_payment_amounts',
+          'payment_difference_reasons',
+          'annual_rate_overrides',
+          'annual_rate_evidences',
+          'paid_account_ids',
+          'billing_confirmed_account_ids',
+          'payment_source_account_ids',
+          'card_billing_account_ids',
+          'card_statement_lines',
+          'transfer_tasks',
+          'state_updated_at',
+        },
+      );
     });
 
     test(


### PR DESCRIPTION
## 概要

月次状態のリモート同期で、`billing_confirmed_account_ids`（カード請求確認済みフラグ）と `transfer_tasks`（口座移動タスク）が **Supabase に一切書き込まれず、端末間で同期されない** 潜在バグを修正する。`paid` を `#3474`（union マージ）/`#3480`（LWW）で直したのと同型で、これらは同じ月次状態の一部でありながら remote payload から取りこぼされていた。

## 根本原因

`AssetLiabilitySupabaseRemoteStore.saveMonth` は `AssetLiabilityMonthlyStatePayload.toSupabaseJson(...)` の出力 `row`（全キーを含む）から、`monthly_states` テーブルへ書き込む payload を **allowlist で詰め替えていた**。この allowlist に `billing_confirmed_account_ids` と `transfer_tasks` が含まれておらず、両キーが remote に届かなかった。

- `toSupabaseJson` は両キーを出力する（出力側は正しい）。
- `fromSupabaseJson` は両キーを読む（読み込み側も正しい）。
- しかし `saveMonth` の allowlist が落としていたため、**書いていないので読んでも常に空**。

## 実害

1. **端末間で同期されない**: 各端末は自分の確認済みフラグ／移動タスクしか保持せず、別端末の入力が remote 経由で届かない。
2. **LWW でのデータ消失**: `loadMonth` の last-write-wins 分岐で remote の `state_updated_at` が新しい場合、ローカルを `remoteState` で丸ごと上書きする。`remoteState` の両フィールドは常に空のため、**ローカルで確認済みのカード請求フラグと口座移動タスクが空に上書き消去** される。

## 修正

`saveMonth` の payload 構築を `@visibleForTesting static buildMonthlyStatesPayload(row)` に抽出し、取りこぼしていた 2 キーを追加した（`income_plans` は別テーブル `incomePlansTable` のため引き続き除外）。挙動は「2 キー追加」のみで、抽出は **回帰テストを実コード（remote payload 構築）に到達させるため**（`SupabaseClient` の fake は非現実的なため、純粋なペイロード構築を切り出した）。

`#3474` の union マージと `#3480` の LWW は既にあるので、書き込みさえ揃えばマージで収束する。マイグレーション不要（payload は freeform JSONB）。

## テスト

`test/services/asset_liability_repository_test.dart` に 3 ケース追加（全 47 件 green / `flutter test`）:

1. **回帰**: `buildMonthlyStatesPayload` の出力に `billing_confirmed_account_ids` / `transfer_tasks` / `state_updated_at` が含まれ、`income_plans`・識別子カラムは含まれないことを検証。修正前のヘルパでは落ちることを確認済み（teeth あり）。
2. **save 分割 + load 合体の round-trip**: 2 テーブルへの分割書き込み → `loadMonth` の payload 合体 → `fromSupabaseJson` → `toState` で両フィールド + `income_plans` が保持されること。
3. **loadMonth 端末間 union**: 別端末の請求確認フラグ・移動タスクが union され取りこぼされないこと（収束のため双方へ再保存）。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Backend Supabase sync serialization fix (AssetLiabilitySupabaseRemoteStore monthly_states payload); no user-facing UI flow changed. Covered by unit/round-trip tests in test/services/asset_liability_repository_test.dart asserting billing_confirmed_account_ids and transfer_tasks reach the remote payload and round-trip through the load merge.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Gate fired on the words billing/transfer in the body text, not on a high-risk path. Change is limited to lib/services (Supabase monthly_states payload key allowlist) plus its test; no auth/billing/payments/migration/RLS path or secret touched. Reviewed by Claude Code #1 with a focused regression test proving the two dropped keys now persist.
