### PR TITLE
feat: 給料日を設定可能に (月次サイクル統一 Phase 1)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -41,6 +41,7 @@ import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_recurring_suggestion_ignore_store.dart';
+import 'package:my_web_app/services/asset_salary_day_store.dart';
 import 'package:my_web_app/services/asset_recurring_transaction_detector.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_inputs.dart';
@@ -241,7 +242,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       '1WZlHr6YWG8ZbT9r-wXtYPEdPT5E4b47PSpNSNl8A1MM';
   static const String _smbcSheetGid = '0';
   static const List<String> _jibunCandidateSheetGids = <String>['0'];
-  static const int _salarySpendingSalaryDay = 25;
+  // 給料日(資産管理の月次サイクル基準日 / 設定で変更可 / clamp 1-28)。
+  // AssetSalaryDayStore で永続化 + asset_pref_mirror(salary_day)で端末間同期。
+  int _salaryDay = AssetSalaryDayStore.defaultSalaryDay;
   static const List<Color> _salarySpendingChartColors = <Color>[
     Color(0xFF0F766E),
     Color(0xFF2563EB),
@@ -604,6 +607,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetManagementDisplayModeStore.defaultMode;
   final AssetManagementMainAccountStore _mainAccountStore =
       const AssetManagementMainAccountStore();
+  final AssetSalaryDayStore _salaryDayStore = const AssetSalaryDayStore();
+  static const String _salaryDayMirrorKey = 'salary_day';
   final AssetRevolvingCreditConfigStore _revolvingConfigStore =
       const AssetRevolvingCreditConfigStore();
   final AssetRecurringFixedCostStore _recurringFixedCostStore =
@@ -733,6 +738,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _fetchMustTasks();
     _loadDisplayMode();
     _loadMainAccount();
+    unawaited(_loadSalaryDay());
     unawaited(_loadRevolvingConfigs());
     unawaited(_loadCategoryBudgets());
     unawaited(_loadRecurringFixedCosts());
@@ -893,7 +899,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   DateTime _assetLiabilityStateMonth(DateTime dt) {
     return AssetLiabilityMonthlyStateStore.salaryCycleMonthFor(
       dt,
-      salaryDay: _salarySpendingSalaryDay,
+      salaryDay: _salaryDay,
     );
   }
 
@@ -6477,7 +6483,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         body: <String, dynamic>{
           'action': 'asset.disposable_balance.compute',
           'as_of_date': _dateOnly(_now),
-          'salary_day': _salarySpendingSalaryDay,
+          'salary_day': _salaryDay,
           'enable_ai_actions': enableAiActions,
           'trace_id': 'asset-disposable-balance',
         },
@@ -8023,6 +8029,148 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     // ローカル読込後にサーバ集約ミラーから復元する (端末間同期 / 集約優先)。
     await _restoreMainAccountFromMirror();
     unawaited(_refreshSyncSources());
+  }
+
+  /// 給料日(月次サイクル基準日)を起動時にローカルから読み、サーバミラーで上書きする。
+  Future<void> _loadSalaryDay() async {
+    try {
+      final day = await _salaryDayStore.load();
+      if (mounted && day != _salaryDay) {
+        setState(() => _salaryDay = day);
+      }
+    } catch (e) {
+      debugPrint('Error loading salary day: $e');
+    }
+    await _restoreSalaryDayFromMirror();
+  }
+
+  /// サーバミラー (pref_key: salary_day) があれば採用する(設定は稀更新 +
+  /// AI 計算へは毎回 payload で渡すため scalar は集約優先で実害小)。
+  Future<void> _restoreSalaryDayFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', _salaryDayMirrorKey);
+      if (rows.isEmpty) {
+        return;
+      }
+      final restored = AssetSalaryDayStore.decodeMirrorValue(
+        rows.first['value'],
+      );
+      if (!mounted || restored == _salaryDay) {
+        return;
+      }
+      setState(() => _salaryDay = restored);
+      _persistInBackground(
+        _salaryDayStore.save(restored),
+        'salary day restore save',
+      );
+      // サイクル基準が変わるため月次stateを読み直す。
+      unawaited(_loadAssetLiabilityMonthlyState());
+    } catch (e) {
+      debugPrint('salary day mirror restore failed: $e');
+    }
+  }
+
+  /// 給料日を `asset_pref_mirror` (pref_key: salary_day) へ 1 行 upsert する。
+  Future<void> _mirrorSalaryDay() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _salaryDayMirrorKey,
+        'value': AssetSalaryDayStore.encodeMirrorValue(_salaryDay),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('salary day mirror upsert failed: $e');
+    }
+  }
+
+  /// 給料日を更新して永続化 + ミラー + 月次state再読込(サイクル基準が変わる)。
+  Future<void> _setSalaryDay(int day) async {
+    final clamped = AssetSalaryDayStore.clampDay(day);
+    if (clamped == _salaryDay) {
+      return;
+    }
+    setState(() => _salaryDay = clamped);
+    _persistInBackground(_salaryDayStore.save(clamped), 'salary day save');
+    unawaited(_mirrorSalaryDay());
+    unawaited(_loadAssetLiabilityMonthlyState());
+  }
+
+  /// 給料日(月次サイクル基準日)を設定するダイアログ。
+  Future<void> _showSalaryDayDialog() async {
+    final controller = TextEditingController(text: _salaryDay.toString());
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        String? errorText;
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              title: const Text('給料日(月次サイクル基準)'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '資産管理は給料日から翌給料日の前日までを1サイクルとして集計します'
+                    '(支払済みチェックもこのサイクルで自動リセット)。',
+                    style: TextStyle(fontSize: 12, height: 1.5),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: controller,
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    decoration: InputDecoration(
+                      labelText: '給料日 (1〜28)',
+                      errorText: errorText,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    '※ 給料日を変えると当月の支払済みチェックが新しいサイクル基準で'
+                    '読み直されます。',
+                    style: TextStyle(fontSize: 11, height: 1.4),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                FilledButton(
+                  onPressed: () {
+                    final day = int.tryParse(controller.text.trim());
+                    if (day == null ||
+                        day < AssetSalaryDayStore.minSalaryDay ||
+                        day > AssetSalaryDayStore.maxSalaryDay) {
+                      setDialogState(
+                        () => errorText = '1〜28 の日付を入力してください',
+                      );
+                      return;
+                    }
+                    Navigator.of(dialogContext).pop();
+                    unawaited(_setSalaryDay(day));
+                  },
+                  child: const Text('保存'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
   }
 
   /// メイン口座IDを `asset_pref_mirror` (pref_key: main_account_id) へ
@@ -9890,11 +10038,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   DateTime _nextSalaryDate() {
     final now = DateTime.now();
-    final thisMonth = DateTime(now.year, now.month, _salarySpendingSalaryDay);
+    final thisMonth = DateTime(now.year, now.month, _salaryDay);
     if (!now.isAfter(thisMonth)) {
       return thisMonth;
     }
-    return DateTime(now.year, now.month + 1, _salarySpendingSalaryDay);
+    return DateTime(now.year, now.month + 1, _salaryDay);
   }
 
   Future<void> _sendDisplayModeEvent({
@@ -10259,7 +10407,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (target == null) {
       return;
     }
-    const newDay = _salarySpendingSalaryDay + 1;
+    final newDay = _salaryDay + 1;
     _setDebtPaymentDayOverride(target, newDay);
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -10278,7 +10426,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     required List<AssetCalendarInflowInput> inflows,
     required double? startingCashBalance,
   }) {
-    const newDay = _salarySpendingSalaryDay + 1;
+    final newDay = _salaryDay + 1;
     final shifted = AssetPaymentCalendarService.buildMonth(
       month: _calendarMonth,
       flows: _recentFlows,
@@ -10297,7 +10445,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           else
             debt,
       ],
-      salaryDay: _salarySpendingSalaryDay,
+      salaryDay: _salaryDay,
       startingCashBalance: startingCashBalance,
       expectedInflows: inflows,
     );
@@ -10899,7 +11047,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     AssetLiabilityWorkbook? workbook,
     List<String> debtRowIds,
   ) {
-    const newDay = _salarySpendingSalaryDay + 1;
+    final newDay = _salaryDay + 1;
     var shiftedCount = 0;
     for (final id in debtRowIds) {
       final target = _debtRowById(workbook, id);
@@ -11497,7 +11645,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       flows: _recentFlows,
       subscriptions: monthSubscriptions,
       debts: debtInputs,
-      salaryDay: _salarySpendingSalaryDay,
+      salaryDay: _salaryDay,
       startingCashBalance: startingCashBalance,
       expectedInflows: inflowInputs,
     );
@@ -11544,8 +11692,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             subscriptions: monthSubscriptions,
             debts: debtInputs,
             candidateIds: comboIds,
-            shiftToDay: _salarySpendingSalaryDay + 1,
-            salaryDay: _salarySpendingSalaryDay,
+            shiftToDay: _salaryDay + 1,
+            salaryDay: _salaryDay,
             startingCashBalance: startingCashBalance,
             expectedInflows: inflowInputs,
           )
@@ -12278,7 +12426,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       referenceDate: _now,
       expenses: entries.expenses,
       incomes: entries.incomes,
-      salaryDay: _salarySpendingSalaryDay,
+      salaryDay: _salaryDay,
     );
   }
 
@@ -12308,11 +12456,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
     final nextPayday = _disposableBalanceService.nextPaydayFor(
       asOfDate: _now,
-      salaryDay: _salarySpendingSalaryDay,
+      salaryDay: _salaryDay,
     );
     final cycleStart = _disposableBalanceService.salaryCycleStartFor(
       asOfDate: _now,
-      salaryDay: _salarySpendingSalaryDay,
+      salaryDay: _salaryDay,
     );
     final cycleStartOnly = DateTime(
       cycleStart.year,
@@ -12402,7 +12550,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       payslips: payslips,
       recurringExpenses: recurringExpenses,
       debts: debts,
-      salaryDay: _salarySpendingSalaryDay,
+      salaryDay: _salaryDay,
     );
   }
 
@@ -19940,6 +20088,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 runSpacing: 4,
                 alignment: WrapAlignment.end,
                 children: [
+                  TextButton.icon(
+                    onPressed: () => unawaited(_showSalaryDayDialog()),
+                    icon: const Icon(Icons.event_available_outlined),
+                    label: Text('給料日 $_salaryDay日'),
+                  ),
                   TextButton.icon(
                     onPressed: _copyPreviousMonthSettings,
                     icon: const Icon(Icons.copy_all_outlined),

--- a/lib/services/asset_salary_day_store.dart
+++ b/lib/services/asset_salary_day_store.dart
@@ -1,0 +1,47 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 給料日(資産管理の月次サイクル基準日)を永続化する。
+///
+/// 月次 state(支払済みフラグ等)・給与内訳・予実は給料日サイクル
+/// (`salaryDay` 〜 翌 `salaryDay`-1)で集計されるため、この値がサイクルの基準になる。
+/// ローカル (SharedPreferences) を一次ストアとし、端末間同期は資産管理ページが
+/// `asset_pref_mirror` (pref_key: `salary_day`) へ 1 行 jsonb (`{day: N}`) でミラーする。
+/// 値は [minSalaryDay]〜[maxSalaryDay] にクランプ(月末差異を避けるため 28 が上限)。
+class AssetSalaryDayStore {
+  static const String prefsKey = 'asset_salary_day_v1';
+  static const int defaultSalaryDay = 25;
+  static const int minSalaryDay = 1;
+  static const int maxSalaryDay = 28;
+
+  const AssetSalaryDayStore();
+
+  static int clampDay(int day) => day.clamp(minSalaryDay, maxSalaryDay);
+
+  Future<int> load({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getInt(prefsKey);
+    if (raw == null) {
+      return defaultSalaryDay;
+    }
+    return clampDay(raw);
+  }
+
+  Future<void> save(int day, {SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    await store.setInt(prefsKey, clampDay(day));
+  }
+
+  /// `asset_pref_mirror.value` (jsonb) 用に `{day: N}` へ変換する。
+  static Map<String, dynamic> encodeMirrorValue(int day) {
+    return <String, dynamic>{'day': clampDay(day)};
+  }
+
+  /// `asset_pref_mirror.value` (jsonb) から給料日を復元する。
+  /// 不正値は既定(25)。
+  static int decodeMirrorValue(dynamic value) {
+    if (value is Map && value['day'] is num) {
+      return clampDay((value['day'] as num).toInt());
+    }
+    return defaultSalaryDay;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -836,6 +836,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -920,26 +928,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1525,26 +1533,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/test/services/asset_salary_day_store_test.dart
+++ b/test/services/asset_salary_day_store_test.dart
@@ -40,10 +40,14 @@ void main() {
   });
 
   test('decodeMirrorValue parses, clamps, and falls back to default', () {
-    expect(AssetSalaryDayStore.decodeMirrorValue(<String, dynamic>{'day': 10}),
-        10);
-    expect(AssetSalaryDayStore.decodeMirrorValue(<String, dynamic>{'day': 99}),
-        28);
+    expect(
+      AssetSalaryDayStore.decodeMirrorValue(<String, dynamic>{'day': 10}),
+      10,
+    );
+    expect(
+      AssetSalaryDayStore.decodeMirrorValue(<String, dynamic>{'day': 99}),
+      28,
+    );
     expect(
       AssetSalaryDayStore.decodeMirrorValue('nope'),
       AssetSalaryDayStore.defaultSalaryDay,

--- a/test/services/asset_salary_day_store_test.dart
+++ b/test/services/asset_salary_day_store_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_salary_day_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const store = AssetSalaryDayStore();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  test('load returns the default when unset', () async {
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      await store.load(prefs: prefs),
+      AssetSalaryDayStore.defaultSalaryDay,
+    );
+  });
+
+  test('save then load round-trips a valid day', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.save(15, prefs: prefs);
+    expect(await store.load(prefs: prefs), 15);
+  });
+
+  test('save clamps out-of-range days to 1..28', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.save(40, prefs: prefs);
+    expect(await store.load(prefs: prefs), 28);
+    await store.save(0, prefs: prefs);
+    expect(await store.load(prefs: prefs), 1);
+  });
+
+  test('encodeMirrorValue clamps and wraps as {day: N}', () {
+    expect(AssetSalaryDayStore.encodeMirrorValue(15), <String, dynamic>{
+      'day': 15,
+    });
+    expect(AssetSalaryDayStore.encodeMirrorValue(99), <String, dynamic>{
+      'day': 28,
+    });
+  });
+
+  test('decodeMirrorValue parses, clamps, and falls back to default', () {
+    expect(AssetSalaryDayStore.decodeMirrorValue(<String, dynamic>{'day': 10}),
+        10);
+    expect(AssetSalaryDayStore.decodeMirrorValue(<String, dynamic>{'day': 99}),
+        28);
+    expect(
+      AssetSalaryDayStore.decodeMirrorValue('nope'),
+      AssetSalaryDayStore.defaultSalaryDay,
+    );
+    expect(
+      AssetSalaryDayStore.decodeMirrorValue(<String, dynamic>{}),
+      AssetSalaryDayStore.defaultSalaryDay,
+    );
+  });
+}


### PR DESCRIPTION
## 概要

月次サイクル統一(給料日サイクル)の **Phase 1**。給料日(月次サイクルの基準日)をハードコード(25日)から**ユーザー設定可能**にし、永続化 + 端末間ミラー + 設定UIを追加します。これは後続フェーズ(資金繰り/未払い/期限超過/分析を給料日サイクルへ統一)の基盤です。

## 背景

支払済みフラグ・給与内訳・予実は給料日サイクル(25日→翌24日)基準だが給料日が `_salarySpendingSalaryDay = 25` でハードコードだった。本 PR で設定化し、ユーザーの実際の給料日に合わせて paid 自動リセット・給与内訳が揃うようにする。資金繰り/未払いの暦月→サイクル統一は Phase 2 で対応(本 PR では挙動変更なし)。

## 変更点

- 新ストア `AssetSalaryDayStore`(`asset_salary_day_v1` / mirror `salary_day` / clamp 1-28 / 既定25)。
- ページ: `static const int _salarySpendingSalaryDay = 25` を **field `int _salaryDay`** へ置換(全32参照 / `const newDay = ...+1` 3箇所は `final` 化)。起動時ロード + サーバミラー復元 + 変更時 save/upsert + 月次state再読込。
- 設定UI: 収入セクションに「給料日 N日」ボタン → 1-28 の数値ダイアログ(サイクル基準・リセット注記つき)。
- 既存のサイクル消費者(`_assetLiabilityStateMonth` / 給与内訳 / AI可処分残高payload `salary_day`)へ設定値が自動伝播。

## 互換性 / リスク

- 既定25のとき**挙動不変**。資金繰り/未払い(暦月)は本 PR では未変更。設定変更時のみサイクル基準が動く(月次stateを再読込 / ダイアログに注記)。
- ミラーはサーバ採用優先のシンプル方式(設定は稀更新 + AI計算へは per-request payload で渡るため scalar は実害小)。

## テスト

- `asset_salary_day_store_test`: 既定 / save→load round-trip / clamp(0→1, 40→28)/ encode・decode mirror(clamp + 既定フォールバック)。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 設定値の永続化(既定で挙動不変)。store unitテストで担保。E2E基盤未整備のため対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/services・lib/pages・test のみ(設定値の追加)。supabase/workflow/auth系の高リスクパスは未変更
