### PR TITLE
feat: 資金繰り/未払い/期限超過を給料日サイクルへ統一 (Phase 2)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -4536,6 +4536,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       incomePlans: _monthlyIncomePlans,
       cardStatementLines: _cardStatementLines,
       transferTasks: _transferTasks,
+      salaryDay: _salaryDay,
     );
     final liabilities = workbook.debtMasterRows;
     if (liabilities.isEmpty) {
@@ -7731,6 +7732,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       transferTasks: _transferTasks,
       recurringFixedCosts: _recurringFixedCosts,
       includeDefaultFixedPayments: true,
+      salaryDay: _salaryDay,
     );
   }
 
@@ -12529,6 +12531,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         transferTasks: _transferTasks,
         recurringFixedCosts: _recurringFixedCosts,
         includeDefaultFixedPayments: true,
+        salaryDay: _salaryDay,
       );
       final assetLiabilityInputs =
           _disposableBalanceAssetLiabilityAdapter.build(

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -17,10 +17,15 @@ class _BuiltInRecurringFixedCost {
   final AssetRecurringFixedCostCadence cadence;
   final String? sourceAccountId;
 
+  /// 支払日(_classifyAccount が付与する日と一致)。給料日サイクルでどの暦月に
+  /// 発生するかの判定(隔月の偶奇判定)に使う。毎月の固定費では実質影響しない。
+  final int paymentDay;
+
   const _BuiltInRecurringFixedCost({
     required this.accountId,
     required this.accountName,
     required this.monthlyAmount,
+    required this.paymentDay,
     this.cadence = AssetRecurringFixedCostCadence.monthly,
     this.sourceAccountId,
   });
@@ -126,16 +131,19 @@ class AssetLiabilityPlanningService {
       accountId: kddiProviderAccountId,
       accountName: kddiProviderAccountName,
       monthlyAmount: kddiProviderMonthlyPaymentAmount,
+      paymentDay: 25,
     ),
     _BuiltInRecurringFixedCost(
       accountId: rentAccountId,
       accountName: rentAccountName,
       monthlyAmount: rentMonthlyPaymentAmount,
+      paymentDay: 25,
     ),
     _BuiltInRecurringFixedCost(
       accountId: waterBillAccountId,
       accountName: waterBillAccountName,
       monthlyAmount: waterBillBimonthlyPaymentAmount,
+      paymentDay: waterBillPaymentDay,
       cadence: AssetRecurringFixedCostCadence.bimonthlyEvenMonth,
       sourceAccountId: smbcOtsukaBranchAccountId,
     ),
@@ -143,6 +151,7 @@ class AssetLiabilityPlanningService {
       accountId: gasBillAccountId,
       accountName: gasBillAccountName,
       monthlyAmount: gasBillMonthlyPaymentAmount,
+      paymentDay: gasBillPaymentDay,
       sourceAccountId: smbcOtsukaBranchAccountId,
     ),
   ];
@@ -175,6 +184,8 @@ class AssetLiabilityPlanningService {
     List<AssetRecurringFixedCost> recurringFixedCosts =
         const <AssetRecurringFixedCost>[],
     bool includeDefaultFixedPayments = false,
+    // 給料日サイクルの基準日。null のとき従来どおり baseDate の暦月で集計(後方互換)。
+    int? salaryDay,
   }) {
     // 既定固定費 (家賃/KDDI/水道/ガス) を当月該当の周期かつ未計上 (残高<0 の同 ID
     // 負債が無い) のものだけ抽出する。残高<0 限定の判定で正残高の同名資産
@@ -183,7 +194,9 @@ class AssetLiabilityPlanningService {
         ? _builtInRecurringFixedCosts
             .where(
               (cost) =>
-                  cost.appliesToMonth(baseDate.month) &&
+                  cost.appliesToMonth(
+                    _cycleTargetMonth(baseDate, salaryDay, cost.paymentDay),
+                  ) &&
                   !_hasLiabilityAccountFor(latestSnapshot, cost.accountId),
             )
             .toList(growable: false)
@@ -218,6 +231,7 @@ class AssetLiabilityPlanningService {
       recurringFixedCosts: recurringFixedCosts,
       existingAccounts: accounts,
       baseDate: baseDate,
+      salaryDay: salaryDay,
     );
     if (injectedFixedCosts.isNotEmpty) {
       accounts
@@ -243,6 +257,7 @@ class AssetLiabilityPlanningService {
       transferTasks: transferTasks,
       accounts: accounts,
       baseDate: baseDate,
+      salaryDay: salaryDay,
     );
     final resolvedTransferTasks = _resolveTransferTasks(
       transferTasks: effectiveTransferTasks,
@@ -314,11 +329,13 @@ class AssetLiabilityPlanningService {
     final paymentDayRisks = _buildPaymentDayRisks(
       rows: directDebtRows,
       baseDate: baseDate,
+      salaryDay: salaryDay,
     );
     final cashflowRows = _buildCashflowRows(
       rows: debtMasterRows,
       incomePlans: resolvedIncomePlans,
       baseDate: baseDate,
+      salaryDay: salaryDay,
       startingCash: cashLikeTotal,
       paidAccountNames: paidAccountNames,
       paymentSourceAccountIds: effectivePaymentSourceAccountIds,
@@ -1226,6 +1243,7 @@ class AssetLiabilityPlanningService {
   List<AssetLiabilityPaymentDayRisk> _buildPaymentDayRisks({
     required List<AssetLiabilityDebtRow> rows,
     required DateTime baseDate,
+    int? salaryDay,
   }) {
     final byDay = <int, List<AssetLiabilityDebtRow>>{};
     for (final row in rows) {
@@ -1245,9 +1263,7 @@ class AssetLiabilityPlanningService {
     final result = <AssetLiabilityPaymentDayRisk>[];
     for (final entry in byDay.entries) {
       final day = entry.key;
-      final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
-      final resolvedDay = day.clamp(1, lastDay).toInt();
-      final paymentDate = DateTime(baseDate.year, baseDate.month, resolvedDay);
+      final paymentDate = _resolveCyclePaymentDate(baseDate, salaryDay, day);
       final rowsForDay = entry.value
         ..sort((a, b) => b.balance.abs().compareTo(a.balance.abs()));
       result.add(
@@ -1297,8 +1313,8 @@ class AssetLiabilityPlanningService {
     required Set<String> paidAccountNames,
     required Map<String, String> paymentSourceAccountIds,
     required Map<String, AssetLiabilityAccount> accountsById,
+    int? salaryDay,
   }) {
-    final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
     final result = <AssetLiabilityCashflowRow>[];
     for (final plan in incomePlans) {
       final paymentDate = _dateOnly(plan.date);
@@ -1337,8 +1353,11 @@ class AssetLiabilityPlanningService {
 
     for (final row in rows.where((row) => row.paymentDay != null)) {
       final paymentDay = row.paymentDay!;
-      final resolvedDay = paymentDay.clamp(1, lastDay).toInt();
-      final paymentDate = DateTime(baseDate.year, baseDate.month, resolvedDay);
+      final paymentDate = _resolveCyclePaymentDate(
+        baseDate,
+        salaryDay,
+        paymentDay,
+      );
       final overdue = row.isDirectCashflowTarget &&
           !row.paid &&
           !paymentDate.isAfter(_dateOnly(baseDate));
@@ -1378,8 +1397,11 @@ class AssetLiabilityPlanningService {
     final acomShoppingRow = _findAcomShoppingDebtRow(rows);
     if (acomShoppingRow != null && acomShoppingRow.isDirectCashflowTarget) {
       const paymentDay = anthropicAcomShoppingPaymentDay;
-      final resolvedDay = paymentDay.clamp(1, lastDay).toInt();
-      final paymentDate = DateTime(baseDate.year, baseDate.month, resolvedDay);
+      final paymentDate = _resolveCyclePaymentDate(
+        baseDate,
+        salaryDay,
+        paymentDay,
+      );
       final paid = paidAccountNames.contains(anthropicAcomShoppingPaymentId) ||
           paidAccountNames.contains(anthropicAcomShoppingPaymentName);
       final sourceAccountId =
@@ -1586,6 +1608,7 @@ class AssetLiabilityPlanningService {
     required List<AssetLiabilityTransferTask> transferTasks,
     required List<AssetLiabilityAccount> accounts,
     required DateTime baseDate,
+    int? salaryDay,
   }) {
     if (transferTasks.any(
       (task) => task.id == auPayCardFundingTransferTaskId,
@@ -1602,8 +1625,6 @@ class AssetLiabilityPlanningService {
       return transferTasks;
     }
 
-    final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
-    final resolvedDay = auPayCardFundingTransferDay.clamp(1, lastDay).toInt();
     return <AssetLiabilityTransferTask>[
       ...transferTasks,
       AssetLiabilityTransferTask(
@@ -1613,7 +1634,11 @@ class AssetLiabilityPlanningService {
         toAccountId: toAccount.id,
         toAccountName: toAccount.name,
         amount: auPayCardFundingTransferAmount,
-        dueDate: DateTime(baseDate.year, baseDate.month, resolvedDay),
+        dueDate: _resolveCyclePaymentDate(
+          baseDate,
+          salaryDay,
+          auPayCardFundingTransferDay,
+        ),
       ),
     ];
   }
@@ -1853,6 +1878,7 @@ class AssetLiabilityPlanningService {
     required List<AssetRecurringFixedCost> recurringFixedCosts,
     required List<AssetLiabilityAccount> existingAccounts,
     required DateTime baseDate,
+    int? salaryDay,
   }) {
     if (recurringFixedCosts.isEmpty) {
       return const <({
@@ -1866,7 +1892,10 @@ class AssetLiabilityPlanningService {
     final result =
         <({AssetLiabilityAccount account, String? sourceAccountId})>[];
     for (final cost in recurringFixedCosts) {
-      if (cost.amount <= 0 || !cost.appliesToMonth(baseDate.month)) {
+      if (cost.amount <= 0 ||
+          !cost.appliesToMonth(
+            _cycleTargetMonth(baseDate, salaryDay, cost.paymentDay),
+          )) {
         continue;
       }
       final account = _liability(
@@ -2043,6 +2072,53 @@ class AssetLiabilityPlanningService {
 
   DateTime _dateOnly(DateTime source) {
     return DateTime(source.year, source.month, source.day);
+  }
+
+  /// 支払日 [dayOfMonth] の実日付を、[baseDate] を含む期間内で解決する。
+  ///
+  /// [salaryDay] が null のとき従来どおり [baseDate] の暦月で算出(後方互換)。
+  /// 指定時は給料日サイクル `[salaryDay 〜 翌salaryDay-1]` で算出する:
+  /// サイクルは 2 暦月にまたがり、支払日 >= salaryDay は第1暦月、未満は第2暦月に発生する
+  /// (例 salaryDay=25 のサイクル 5/25〜6/24: 27日→5/27、10日→6/10)。
+  /// 月末差異は対象暦月の末日にクランプする。
+  DateTime _resolveCyclePaymentDate(
+    DateTime baseDate,
+    int? salaryDay,
+    int dayOfMonth,
+  ) {
+    if (salaryDay == null) {
+      final lastDay = DateTime(baseDate.year, baseDate.month + 1, 0).day;
+      return DateTime(
+        baseDate.year,
+        baseDate.month,
+        dayOfMonth.clamp(1, lastDay).toInt(),
+      );
+    }
+    final anchor = salaryDay.clamp(1, 28).toInt();
+    // サイクルの第1暦月 (baseDate.day >= anchor なら当月、未満なら前月)。
+    final firstMonth = baseDate.day >= anchor
+        ? DateTime(baseDate.year, baseDate.month)
+        : DateTime(baseDate.year, baseDate.month - 1);
+    final monthOffset = dayOfMonth >= anchor ? 0 : 1;
+    final targetMonth = DateTime(
+      firstMonth.year,
+      firstMonth.month + monthOffset,
+    );
+    final lastDay = DateTime(targetMonth.year, targetMonth.month + 1, 0).day;
+    return DateTime(
+      targetMonth.year,
+      targetMonth.month,
+      dayOfMonth.clamp(1, lastDay).toInt(),
+    );
+  }
+
+  /// 支払日 [dayOfMonth] が発生する暦月 (1-12) を返す。隔月固定費の偶奇判定に使う。
+  /// [salaryDay] が null のとき [baseDate] の暦月。
+  int _cycleTargetMonth(DateTime baseDate, int? salaryDay, int dayOfMonth) {
+    if (salaryDay == null) {
+      return baseDate.month;
+    }
+    return _resolveCyclePaymentDate(baseDate, salaryDay, dayOfMonth).month;
   }
 }
 

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1757,12 +1757,11 @@ void main() {
         baseDate: DateTime(2026, 6, 26), // サイクル 6/25〜7/24
         salaryDay: 25,
       );
-      final payments = workbook.cashflowRows
-          .where((row) => row.isPayment && row.paymentDay != null)
-          .toList();
+      final payments =
+          workbook.cashflowRows.where((row) => row.isPayment).toList();
       expect(payments, isNotEmpty);
       for (final row in payments) {
-        final day = row.paymentDay!;
+        final day = row.paymentDay;
         expect(row.paymentDate.year, 2026);
         if (day >= 25) {
           expect(row.paymentDate.month, 6, reason: '${row.accountName} d=$day');
@@ -1789,7 +1788,7 @@ void main() {
           .where(
             (row) =>
                 row.isPayment &&
-                (row.paymentDay ?? 99) < 25 &&
+                row.paymentDay < 25 &&
                 row.isDirectCashflowTarget &&
                 !row.paid,
           )
@@ -1813,9 +1812,7 @@ void main() {
         latestSnapshot: snapshot,
         baseDate: DateTime(2026, 6, 26),
       );
-      for (final row in workbook.cashflowRows.where(
-        (row) => row.isPayment && row.paymentDay != null,
-      )) {
+      for (final row in workbook.cashflowRows.where((row) => row.isPayment)) {
         expect(row.paymentDate.month, 6, reason: row.accountName);
       }
     });

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1739,4 +1739,106 @@ void main() {
       expect(mobit.fullPaymentEstimate, isFalse);
     });
   });
+
+  group('AssetLiabilityPlanningService.buildWorkbook (salary cycle)', () {
+    const service = AssetLiabilityPlanningService();
+    final snapshot = <String, double>{
+      '三井住友銀行大塚支店': 25677,
+      'アコムショッピング': -2234106, // 支払日 8 / 特別行は 26
+      'モビット': -1553260, // 支払日 15 (直接対象)
+      '横浜銀行': -161437,
+    };
+
+    test(
+        'payment day >= salaryDay lands in the first cycle month, < in the '
+        'second', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 6, 26), // サイクル 6/25〜7/24
+        salaryDay: 25,
+      );
+      final payments = workbook.cashflowRows
+          .where((row) => row.isPayment && row.paymentDay != null)
+          .toList();
+      expect(payments, isNotEmpty);
+      for (final row in payments) {
+        final day = row.paymentDay!;
+        expect(row.paymentDate.year, 2026);
+        if (day >= 25) {
+          expect(row.paymentDate.month, 6, reason: '${row.accountName} d=$day');
+        } else {
+          expect(row.paymentDate.month, 7, reason: '${row.accountName} d=$day');
+        }
+      }
+    });
+
+    test(
+        'a pre-salaryDay payment is overdue under calendar but not under '
+        'the salary cycle (払ったのに未払い 逆戻りの根治)', () {
+      final base = DateTime(2026, 6, 26);
+      final calendar = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: base,
+      );
+      final cycle = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: base,
+        salaryDay: 25,
+      );
+      final calRows = calendar.cashflowRows
+          .where(
+            (row) =>
+                row.isPayment &&
+                (row.paymentDay ?? 99) < 25 &&
+                row.isDirectCashflowTarget &&
+                !row.paid,
+          )
+          .toList();
+      expect(calRows, isNotEmpty);
+      final calRow = calRows.first;
+      final cycRow = cycle.cashflowRows.firstWhere(
+        (row) => row.accountId == calRow.accountId,
+      );
+
+      // 暦月: 当月(6月)の支払日 <= 6/26 → 期限超過。
+      expect(calRow.paymentDate.month, 6);
+      expect(calRow.overdue, isTrue);
+      // サイクル: 第2暦月(7月)→ 6/26 より後 → 期限超過でない。
+      expect(cycRow.paymentDate.month, 7);
+      expect(cycRow.overdue, isFalse);
+    });
+
+    test('without salaryDay, payment dates stay in the calendar month', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 6, 26),
+      );
+      for (final row in workbook.cashflowRows.where(
+        (row) => row.isPayment && row.paymentDay != null,
+      )) {
+        expect(row.paymentDate.month, 6, reason: row.accountName);
+      }
+    });
+
+    test('bimonthly water bill applies based on its cycle calendar month', () {
+      // 水道代(22日/偶数月)。salaryDay 25, baseDate 6/10 → サイクル 5/25〜6/24、
+      // 22<25 → 第2暦月=6月(偶数)→ 計上。
+      final included = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 6, 10),
+        salaryDay: 25,
+        includeDefaultFixedPayments: true,
+      );
+      expect(included.accounts.any((a) => a.name.contains('水道')), isTrue);
+
+      // baseDate 6/26 → サイクル 6/25〜7/24、22<25 → 第2暦月=7月(奇数)→ 非計上。
+      final excluded = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 6, 26),
+        salaryDay: 25,
+        includeDefaultFixedPayments: true,
+      );
+      expect(excluded.accounts.any((a) => a.name.contains('水道')), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## 概要

月次サイクル統一の **Phase 2(コア)**。資金繰り/未払い/期限超過/ショート判定(`AssetLiabilityPlanningService.buildWorkbook`)の集計窓を**暦月 → 給料日サイクル**へ統一します。これにより「給料日を過ぎると前サイクルで支払済みにした項目が未払い・期限超過へ逆戻りして見える」不整合を根治します(支払済みフラグは Phase 0 から給料日サイクル基準)。

## 背景(逆戻りバグ)

支払済みフラグ等は給料日サイクル(salaryDay→翌salaryDay-1)で自動リセットされるのに、資金繰りは暦月(1日〜末)で支払日・期限超過を判定していた。例: 6/26(給料日後)に、前サイクルで支払済みにした6/10の項目が暦月6月のカレンダーに残り、サイクルリセットで未払い扱い→「払ったのに期限超過」に見える。Phase 1([#3500](https://github.com/kanta13jp1/my_web_app/pull/3500))で給料日を設定化済。

## 変更点

- `buildWorkbook` に **`int? salaryDay` を追加(任意 / null=従来の暦月=後方互換)**。ページは `_salaryDay` を渡す。
- サイクルヘルパー2種を追加:
  - `_resolveCyclePaymentDate(baseDate, salaryDay, dayOfMonth)`: 支払日 D が **D>=salaryDay→サイクル第1暦月 / D<salaryDay→第2暦月** に発生するよう実日付を算出(月末はクランプ)。
  - `_cycleTargetMonth(...)`: 隔月固定費の偶奇判定に使う対象暦月。
- 全 paymentDate 算出(債務行 / アコムショッピング特別行 / 支払日リスク / auPay振替)と固定費の `appliesToMonth`(既定 + UI登録)をサイクル基準へ。overdue/未払い合計/ショート累積は paymentDate 由来のため自動的にサイクル窓へ。
- `_BuiltInRecurringFixedCost` に `paymentDay` を追加(水道22/ガス12/KDDI25/家賃25。隔月=水道のみが gating に実質影響)。

## 互換性 / リスク

- **`salaryDay` 未指定で挙動完全不変**(既存テストは暦月のまま green)。本番ページのみサイクル化。
- 🔴 AI 分析の入力になる振る舞い変更。下記テストで月割当・overdue 逆戻り・隔月water・後方互換を検証。**実機確認は deploy 後にユーザー**(未確認として handoff 明記)。
- スコープ外: 支払カレンダー表示グリッド(`AssetPaymentCalendarService`)は暦月のまま(Phase 3 で検討)。

## テスト(planning service)

- 支払日 >= salaryDay → 第1暦月 / < → 第2暦月。
- **暦月では overdue だがサイクルでは overdue でない**(逆戻り根治の実証)。
- salaryDay 未指定で暦月維持(後方互換)。
- 隔月水道がサイクル暦月(偶数)で計上/非計上。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数 planning service の集計窓変更。service unitテストで月割当・overdue・隔月・後方互換を担保。E2E基盤未整備のため対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/services・lib/pages・test のみ。supabase/workflow/auth系の高リスクパスは未変更。後方互換(salaryDay任意)+ service unitテストで担保
