### PR TITLE
fix(asset): AssetSyncDirtyKeysStore の static write-lock を testWidgets zone-orphan から防御

### DIFF
--- a/lib/services/asset_sync_dirty_keys_store.dart
+++ b/lib/services/asset_sync_dirty_keys_store.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// 集約 pref ドメインごとに「ローカルで編集したがまだサーバへ同期できていない
@@ -26,7 +27,32 @@ class AssetSyncDirtyKeysStore {
   /// 全ての write (markDirty / clearDomain) を直列化する process-wide ロック。
   /// 単一 pref blob への read-modify-write が並行 (= 各サイト unawaited) で
   /// 交錯し、別ドメイン/別キーの dirty マークを取りこぼす lost-update を防ぐ。
+  /// 姉妹の MirrorTombstoneStore と異なり本ストアは read↔write 間に
+  /// `await _loadAll` を挟む (= RMW が原子的でない) ため、このロックは
+  /// production では必須であり撤去できない。
+  ///
+  /// 🔴 testWidgets での注意 (= FakeAsync zone-orphan): production は単一の
+  /// root zone で走るため static でも正しく直列化されるが、`testWidgets` は
+  /// 各テストを個別の FakeAsync zone で実行する。あるテスト (zone A) の write が
+  /// `_writeLock` に未完了 future を残したまま zone A が破棄されると、次のテスト
+  /// (zone B) の `_writeLock.then(...)` は死んだ zone A の future に連結されて
+  /// 永久に完了せず hang する (= 単体 pass / 全 suite fail という cross-test
+  /// static state の典型症状。MirrorTombstoneStore へ同型ロックを移植した際に
+  /// 実証済み)。よって write 経路を踏む widget テストは setUp で
+  /// [resetWriteLockForTest] を呼び lock を現在の zone で再初期化すること。
+  ///
+  /// 現状の資産管理 page smoke は未ログイン (`auth.currentUser == null`) で
+  /// mirror upsert が早期 return し write 経路 (markDirty/clearDomain) を踏まない
+  /// ため dormant (= 安全) だが、将来ログイン状態の編集 smoke を足す場合に備え
+  /// 既に smoke の setUp で reset 済み。
   static Future<void> _writeLock = Future<void>.value();
+
+  /// [_writeLock] を現在の zone の完了済み future に再初期化する (テスト専用)。
+  /// FakeAsync zone を跨いだ static future の orphan-hang を防ぐ (上記参照)。
+  @visibleForTesting
+  static void resetWriteLockForTest() {
+    _writeLock = Future<void>.value();
+  }
 
   /// [action] を前の write 完了後に直列実行する。action の結果/例外は戻り値の
   /// future へ伝播するが、ロック鎖は失敗で途切れさせない。

--- a/test/services/asset_sync_dirty_keys_store_test.dart
+++ b/test/services/asset_sync_dirty_keys_store_test.dart
@@ -66,5 +66,29 @@ void main() {
       ]);
       expect(await store.loadDirty('keep', prefs: sp), <String>{'k1', 'k2'});
     });
+
+    test('resetWriteLockForTest leaves the lock usable for a fresh write',
+        () async {
+      final sp = await prefs();
+      // FakeAsync zone 跨ぎ対策の reset hook。reset 後も write が完了し読み戻せる
+      // (= lock を壊さない) ことを担保する。
+      AssetSyncDirtyKeysStore.resetWriteLockForTest();
+      await store.markDirty('domA', 'k1', prefs: sp);
+      expect(await store.loadDirty('domA', prefs: sp), <String>{'k1'});
+    });
+
+    test('serialization invariant holds after resetWriteLockForTest', () async {
+      final sp = await prefs();
+      AssetSyncDirtyKeysStore.resetWriteLockForTest();
+      // reset 直後でも並行 unawaited write が交錯せず全マークが残る。
+      await Future.wait(<Future<void>>[
+        store.markDirty('domA', 'a', prefs: sp),
+        store.markDirty('domB', 'b', prefs: sp),
+        store.markDirty('domC', 'c', prefs: sp),
+      ]);
+      expect(await store.loadDirty('domA', prefs: sp), <String>{'a'});
+      expect(await store.loadDirty('domB', prefs: sp), <String>{'b'});
+      expect(await store.loadDirty('domC', prefs: sp), <String>{'c'});
+    });
   });
 }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -11,6 +11,7 @@ import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
+import 'package:my_web_app/services/asset_sync_dirty_keys_store.dart';
 import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
@@ -89,6 +90,10 @@ void main() {
 
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
+    // 各テストを個別の FakeAsync zone で開始するため、前テストが残し得る
+    // static write-lock future を現在の zone の完了済み future へ再初期化する
+    // (= 将来ログイン状態の編集 smoke が write 経路を踏んでも orphan-hang しない)。
+    AssetSyncDirtyKeysStore.resetWriteLockForTest();
   });
 
   group('AssetManagementPage smoke', () {


### PR DESCRIPTION
## 背景 (#1 候補 / 前 part304 派生)

前セッションで `MirrorTombstoneStore` へ static write-lock を移植した際、`testWidgets` の FakeAsync zone を跨いで static future が orphan 化し smoke 10 件が赤化した（撤回済 / #3495）。本 PR はその姉妹である `AssetSyncDirtyKeysStore` に同型の latent trap が残っていないか棚卸しし、恒久ガードを入れる。

### 棚卸し結論: trap は実在するが現状 dormant
- `AssetSyncDirtyKeysStore` は page の 8 サイト（markDirty×4 / clearDomain×4）で使われ、smoke が `asset_sync_dirty_keys_v1` を seed する。
- ただし smoke は**未ログイン**（ログインユーザー不在）で mirror upsert が早期 return → `clearDomain` 不実行・`markDirty` は `unawaited` かつ UI 未タップ → **write 経路（lock 使用）を踏まない**（read=loadDirty のみ・lock 不使用）。よって現状は安全。
- 将来ログイン状態の編集 smoke を足すと zone-orphan が顕在化し得る潜在リスク。
- lock 自体は `MirrorTombstoneStore` と異なり read↔write 間に `await _loadAll` を挟む（RMW が非原子）ため **撤去不可**。production は単一 root zone なので static lock は正しく機能する。問題は test zone のみ。

## 変更
- `@visibleForTesting static void resetWriteLockForTest()` を追加（`_writeLock` を現在 zone の完了済み future へ再初期化）。
- クラス doc に zone-orphan caveat + dormant 理由を明記（`MirrorTombstoneStore` の並行安全性 doc と対）。
- 資産管理 page smoke の `setUp` で `resetWriteLockForTest()` を呼び、将来の write 経路 smoke への保険を先回りで敷く。
- unit test 2 件追加（reset 後も lock が使用可能 / 並行 write の直列性維持）。

## 検証
- `flutter test test/services/asset_sync_dirty_keys_store_test.dart` → 7/7 green。
- `flutter test test/widgets/asset_management_page_smoke_test.dart` → 40/40 green（全 suite で cross-test static state の赤化なし）。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: text-pattern false positive: the gate flags a documentation reference to the unauthenticated smoke path; this PR changes no auth/billing/payment code, only a test-only static write-lock reset hook plus docs and unit tests

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: test-only defensive hardening of a sync store's static write-lock; no user-facing flow changes, guarded by the existing asset page widget smoke suite (40 cases) plus the store unit tests.