### PR TITLE
feat(asset): 提案カードを専用 proposals セクションへ分離 (給与内訳相乗りの解消)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -7935,14 +7935,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               const SizedBox(height: 16),
               _buildCashflowForecastCard(assetLiabilityWorkbook),
             ],
+            // 提案カード(定期取引/定期収入の自動検出)は給与内訳に相乗りせず専用
+            // セクションへ。salaryBreakdown を隠しても提案だけ独立表示できる。
+            if (_isSectionShown(AssetManagementSectionId.proposals)) ...[
+              _buildRecurringTransactionSuggestionCard(assetLiabilityWorkbook),
+              const SizedBox(height: 16),
+              _buildRecurringIncomeSuggestionCard(assetLiabilityWorkbook),
+              const SizedBox(height: 16),
+            ],
             if (_isSectionShown(AssetManagementSectionId.salaryBreakdown)) ...[
               _buildSalarySpendingBreakdownCard(),
               const SizedBox(height: 16),
               _buildCategoryBudgetCard(),
-              const SizedBox(height: 16),
-              _buildRecurringTransactionSuggestionCard(assetLiabilityWorkbook),
-              const SizedBox(height: 16),
-              _buildRecurringIncomeSuggestionCard(assetLiabilityWorkbook),
             ],
             if (_isSectionShown(
                 AssetManagementSectionId.recurringFixedCost)) ...[

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -14,6 +14,7 @@ enum AssetManagementSectionTier { essential, standard, full }
 enum AssetManagementSectionId {
   monthlyFlow,
   calendar,
+  proposals,
   salaryBreakdown,
   recurringFixedCost,
   disposable,
@@ -72,6 +73,8 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
         return '当月収支の概観';
       case AssetManagementSectionId.calendar:
         return 'マネーカレンダー';
+      case AssetManagementSectionId.proposals:
+        return '提案カード';
       case AssetManagementSectionId.salaryBreakdown:
         return '給与消費内訳';
       case AssetManagementSectionId.recurringFixedCost:
@@ -111,6 +114,7 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
       case AssetManagementSectionId.quickActions:
       case AssetManagementSectionId.debtPlanner:
         return AssetManagementSectionTier.essential;
+      case AssetManagementSectionId.proposals:
       case AssetManagementSectionId.salaryBreakdown:
       case AssetManagementSectionId.recurringFixedCost:
       case AssetManagementSectionId.deadlines:

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -13,6 +13,7 @@ import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
+import 'package:my_web_app/widgets/asset_recurring_transaction_suggestion_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -1589,6 +1590,38 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
 
         expect(find.byType(RecurringFixedCostCard), findsOneWidget);
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'proposal cards survive hiding the salary-breakdown section',
+      (tester) async {
+        // 給与内訳セクションを hidden にしても、定期取引/定期収入の自動検出
+        // (提案カード) は専用 proposals セクションとして残る (相乗り解消 = 候補#2)。
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'asset_management_display_mode_v1':
+              AssetManagementDisplayMode.standard.storageId,
+          'asset_management_section_overrides_v1': jsonEncode(<String, String>{
+            AssetManagementSectionId.salaryBreakdown.storageId:
+                AssetManagementSectionVisibilityOverride.hidden.storageId,
+          }),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          const MaterialApp(home: AssetManagementPage()),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        // 検出データが無くてもカード widget 自体は構築される (内部で shrink)。
+        expect(
+          find.byType(AssetRecurringTransactionSuggestionCard),
+          findsWidgets,
+        );
 
         await _unmount(tester);
       },


### PR DESCRIPTION
## 背景 (#2 候補 / part301-302 繰越)

定期取引/定期収入の自動検出カード(提案カード)が **給与消費内訳(salaryBreakdown)セクションに相乗り**しており、給与内訳を hidden にすると提案カードも一緒に消えていた。前回 `recurringFixedCost` を専用セクション化した(#3497)のと同型で、提案カードを独立した専用 `proposals` セクションへ移し、可視性を給与内訳から切り離す。

## 変更
- `AssetManagementSectionId.proposals` を追加(label="提案カード" / `defaultTier`=standard / exhaustive switch の `label`・`defaultTier` 双方に case 追加)。
- `asset_management_page.dart` の `build()` で `salaryBreakdown` spread から 2 カード(`_buildRecurringTransactionSuggestionCard` / `_buildRecurringIncomeSuggestionCard`)を除去し、**calendar 直後**に `proposals` セクションを新設して移設。
- セクション順は build() ハードコードだが可視性/設定 UI は `AssetManagementSectionId.values` 走査なので、enum 追加だけで設定画面に独立 pin/hide 項目として自動出現。
- **auto-debit 確認カードは top に残置**(常時 ON の重要警告。tier-gate される proposals に入れると hidden 時に引落確認が消えるため)。

### 振る舞い変化(意図的)
- 提案カードが `salaryBreakdown` と独立可視に。standard/full モードで既定表示(tier=standard で従来同等のモード可視性を維持)、ユーザーが給与内訳を隠しても提案だけ独立表示・その逆も可。
- 既存 stored override に `proposals` キーが無くても auto/defaultTier へ fallback = 後方互換。

## 検証
- `flutter test test/widgets/asset_management_page_smoke_test.dart test/services/asset_management_display_mode_store_test.dart` → 69/69 green。
- 新規 smoke「proposal cards survive hiding the salary-breakdown section」で給与内訳 hidden 時も提案カードが残ることを担保。
- 提案カード単体 widget テストは page 非依存のため不変。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: section-reorganization of an existing Flutter page; behavior is covered by the asset page widget smoke suite (69 cases) including a new case asserting the proposal cards survive hiding the salary-breakdown section.