### PR TITLE
fix(asset): 「収支を最優先で把握」カードを給料日サイクル集計へ

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -221,6 +221,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, dynamic>? debugSubscriptionAuditMirror;
 
+  /// テスト専用: 収支フロー履歴 (`wealth_struggles` 行相当) の初期リストを注入し、
+  /// 給料日サイクル集計を Supabase なしで検証する。null なら通常のフェッチのみ。
+  @visibleForTesting
+  final List<Map<String, dynamic>>? debugInitialRecentFlows;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -246,6 +251,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugRecurringFixedCostsMirror,
     this.debugRecurringFixedCostsDeletedMirror,
     this.debugSubscriptionAuditMirror,
+    this.debugInitialRecentFlows,
   });
 
   @override
@@ -760,6 +766,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (debugRecurring != null) {
       _recurringFixedCosts = List<AssetRecurringFixedCost>.from(debugRecurring);
     }
+    final debugFlows = widget.debugInitialRecentFlows;
+    if (debugFlows != null) {
+      _recentFlows = <Map<String, dynamic>>[
+        for (final flow in debugFlows) Map<String, dynamic>.from(flow),
+      ];
+    }
     _assetLiabilityRepository = widget.assetLiabilityRepository ??
         AssetLiabilityRepositoryFactory.createDefault(
           supabaseClient: _supabase,
@@ -1121,6 +1133,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       }
       return !occurredAt.isBefore(start) && occurredAt.isBefore(endExclusive);
     }).toList();
+  }
+
+  /// 給料日サイクルの期間ラベル (例: "5/25〜6/24")。
+  String _salaryCycleRangeLabel(DateTime reference) {
+    final start = AssetLiabilityMonthlyStateStore.salaryCycleStart(
+      reference,
+      salaryDay: _salaryDay,
+    );
+    final endInclusive =
+        AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(
+      reference,
+      salaryDay: _salaryDay,
+    ).subtract(const Duration(days: 1));
+    return '${start.month}/${start.day}〜${endInclusive.month}/${endInclusive.day}';
   }
 
   Future<void> _pickFlowHistoryMonth() async {
@@ -4624,7 +4650,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
 
-    final currentMonthFlows = _flowsForMonth(DateTime.now());
+    final currentMonthFlows = _flowsForCycle(DateTime.now());
     int monthlyIncome = 0;
     int monthlyExpense = 0;
     for (final f in currentMonthFlows) {
@@ -4981,7 +5007,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
     final subsOk = _subscriptions.isNotEmpty;
 
-    final currentMonthFlows = _flowsForMonth(DateTime.now());
+    final currentMonthFlows = _flowsForCycle(DateTime.now());
     final incomeCount =
         currentMonthFlows.where((r) => r['action_type'] == 'conquer').length;
     final expenseCount =
@@ -5046,7 +5072,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       totalFixed += (s['price'] as num?)?.toInt() ?? 0;
     }
 
-    final currentMonthFlows = _flowsForMonth(now);
+    final currentMonthFlows = _flowsForCycle(now);
     int totalIncome = 0;
     int totalExpense = 0;
     int totalTransfer = 0;
@@ -5058,6 +5084,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
 
     final monthLabel = '${now.year}/${now.month.toString().padLeft(2, '0')}';
+    final flowCycleLabel = _salaryCycleRangeLabel(now);
     final mustThisMonth = _mustTasks.where((t) {
       final d = DateTime.parse(t['deadline']).toLocal();
       return d.year == now.year && d.month == now.month;
@@ -5113,7 +5140,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     buf.writeln('');
 
-    buf.writeln('### ④ 収支（$monthLabel）');
+    buf.writeln('### ④ 収支（給料サイクル $flowCycleLabel）');
     buf.writeln('- 収入合計: ¥${NumberFormat('#,###').format(totalIncome)}');
     buf.writeln('- 支出合計: ¥${NumberFormat('#,###').format(totalExpense)}');
     buf.writeln('- 振替合計: ¥${NumberFormat('#,###').format(totalTransfer)}');
@@ -12792,9 +12819,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // -------------------------
 
   Widget _buildMonthlyFlowFirstCard() {
-    final currentMonth = DateTime(_now.year, _now.month, 1);
-    final monthLabel = _flowMonthLabel(currentMonth);
-    final flows = _flowsForMonth(currentMonth);
+    final cycleRangeLabel = _salaryCycleRangeLabel(_now);
+    final flows = _flowsForCycle(_now);
     var totalIncome = 0;
     var totalExpense = 0;
 
@@ -12810,8 +12836,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
     final net = totalIncome - totalExpense;
     final statusText = flows.isEmpty
-        ? 'まだ今月の収支が未記録です。まず収入と支出を入れて全体像を把握してください。'
-        : '今月の収支差額は ${NumberFormat('#,###').format(net.abs())}円 ${net >= 0 ? '黒字' : '赤字'} です。まずここを基準に残りの判断を進めます。';
+        ? 'まだこのサイクルの収支が未記録です。まず収入と支出を入れて全体像を把握してください。'
+        : 'このサイクルの収支差額は ${NumberFormat('#,###').format(net.abs())}円 ${net >= 0 ? '黒字' : '赤字'} です。まずここを基準に残りの判断を進めます。';
 
     return Card(
       key: const Key('asset_monthly_flow_priority_card'),
@@ -12851,7 +12877,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        '$monthLabelの収支を最優先で把握',
+                        '給料サイクル($cycleRangeLabel)の収支を最優先で把握',
                         style: const TextStyle(
                           fontSize: 18,
                           fontWeight: FontWeight.w800,

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -6,11 +6,13 @@ import 'package:intl/intl.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/pages/asset_management_page.dart';
 import 'package:my_web_app/services/asset_expected_inflow_store.dart';
+import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
+import 'package:my_web_app/services/asset_salary_day_store.dart';
 import 'package:my_web_app/services/asset_subscription_audit_store.dart';
 import 'package:my_web_app/services/asset_sync_dirty_keys_store.dart';
 import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
@@ -142,6 +144,95 @@ void main() {
 
       await _unmount(tester);
     });
+
+    testWidgets(
+      'monthly flow card aggregates over the salary cycle, not the month',
+      (tester) async {
+        // 暦月だと給料日(25日)受給分が翌月の窓から外れ収入0=赤字になる回帰を防ぐ。
+        // 当サイクル [給料日, 翌給料日) の窓で収入/支出を集計することを検証する。
+        final now = DateTime.now();
+        final cycleStart = AssetLiabilityMonthlyStateStore.salaryCycleStart(
+          now,
+          salaryDay: AssetSalaryDayStore.defaultSalaryDay,
+        );
+        // 当サイクル開始日(=給料日)に受け取った給料。暦月窓では外れるが、
+        // サイクル窓では収入として計上される。
+        final cycleSalary = DateTime(
+          cycleStart.year,
+          cycleStart.month,
+          cycleStart.day,
+          12,
+        );
+        // 前サイクル(給料日の前日)の収入。当サイクル窓では除外される。
+        final previousCycleIncome = cycleSalary.subtract(
+          const Duration(days: 1),
+        );
+        // 当サイクル内(本日)の支出。
+        final cycleExpense = DateTime(now.year, now.month, now.day, 12);
+
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              debugInitialRecentFlows: <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'action_type': 'conquer',
+                  'amount': 280000,
+                  'description': '給料',
+                  'occurred_at': cycleSalary.toIso8601String(),
+                },
+                <String, dynamic>{
+                  'action_type': 'expense',
+                  'amount': 50000,
+                  'description': '食費',
+                  'occurred_at': cycleExpense.toIso8601String(),
+                },
+                <String, dynamic>{
+                  'action_type': 'conquer',
+                  'amount': 999999,
+                  'description': '前サイクル収入',
+                  'occurred_at': previousCycleIncome.toIso8601String(),
+                },
+              ],
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 200));
+
+        final card = find.byKey(
+          const Key('asset_monthly_flow_priority_card'),
+        );
+        expect(card, findsOneWidget);
+
+        // 当サイクルの給料(280,000)が収入として計上される。
+        expect(
+          find.descendant(of: card, matching: find.text('¥280,000')),
+          findsOneWidget,
+        );
+        // 当サイクルの支出(50,000)も計上される。
+        expect(
+          find.descendant(of: card, matching: find.text('¥50,000')),
+          findsOneWidget,
+        );
+        // 前サイクルの収入(999,999)は窓外なので除外される。
+        expect(
+          find.descendant(of: card, matching: find.textContaining('999,999')),
+          findsNothing,
+        );
+        // 見出しは暦月ラベルではなく給料サイクルの期間ラベルになっている。
+        expect(
+          find.descendant(
+            of: card,
+            matching: find.textContaining('給料サイクル('),
+          ),
+          findsOneWidget,
+        );
+
+        await _unmount(tester);
+      },
+    );
 
     testWidgets('tapping a day reveals the prefill action', (tester) async {
       await tester.binding.setSurfaceSize(const Size(1200, 2400));


### PR DESCRIPTION
## 概要

「2026/06の収支を最優先で把握」カード (`_buildMonthlyFlowFirstCard`) が **暦月 (月初〜月末) で収支を集計**していたため、給料日 (例: 25日) に受け取った給料が暦月の窓から外れ、**収入 0 = ほぼ常に赤字**に見える問題を修正します。

実機 (2026/06/20) では `収入 ¥0 / 支出 ¥211,314 / 差額 -¥211,314` と表示されていました (= 5/25 受給の給料が暦6月窓の外、支出だけ6月に乗る)。

給料日サイクル統一の Phase 1/2 (#3500 / #3504) は「支払済み/未払い/資金繰り」を給料日サイクル化しましたが、この収支サマリーカードは対象外で暦月のままでした。本 PR でこのカードと、同じ暦月集計を使う「今サイクルの収入/支出」集計を給料日サイクル `[給料日, 翌給料日)` 窓へ統一します。

## 変更点

- `_flowsForSalaryCycle(referenceDate)` / `_salaryCycleRangeLabel(referenceDate)` ヘルパーを追加 (窓は既存の `AssetLiabilityMonthlyStateStore.salaryCycleStart / salaryCycleEndExclusive` を流用)。
- 「収支を最優先で把握」カード: 窓をサイクルへ + 見出しを暦月ラベルから**給料サイクル範囲ラベル** (例: `給料サイクル(5/25〜6/24)の収支を最優先で把握`) へ。本文も「今月」→「このサイクル」。
- 同じ暦月集計を使っていた以下もサイクル窓へ統一: 借金返済プラン入力 (`monthlyIncome/Expense`)、起動時自動チェック (`flowsOk`)、日次サマリーコピー (④収支セクション。③固定費/⑤必須タスクは暦月のまま)。
- テスト容易化のため `debugInitialRecentFlows` 注入経路を追加 (`debugInitialAssetData` と同型) + サイクル境界の widget test を追加。

## スコープ外 (意図的)

- 履歴ブラウザ (`_flowsForMonth` + 月ピッカー): ユーザーが月を明示選択するUIなので暦月のまま。
- 浪費トレーニングスナップショット (`_buildWasteTrainingSnapshot`): `elapsedDays` が暦月に結合しており、サイクル化には別途分母の修正が必要 (Phase 3 / 浪費検出系)。収入を含まず本件の赤字バイアスとは別。

## 検証

- `flutter test test/widgets/asset_management_page_smoke_test.dart` → 41/41 green (新規: 当サイクル収入計上 / 前サイクル収入除外 / サイクルラベル)。
- `flutter analyze lib/pages/asset_management_page.dart test/widgets/asset_management_page_smoke_test.dart` → No issues found.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 給料日サイクル窓への変更は集計範囲とラベルの修正で、widget smoke test (test/widgets/asset_management_page_smoke_test.dart) が当サイクル収入計上・前サイクル除外・サイクルラベルの3観点を検証するため integration_test は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
