### PR TITLE
fix: バージョンバッジのリリースノート遷移クラッシュ修正 (navigatorKey)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -496,6 +496,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           : themeService.getFlutterThemeMode(),
       builder: (context, child) {
         return GlobalHeaderClockShell(
+          navigatorKey: _navigatorKey,
           child: UniversalAiShareShell(
             navigatorKey: _navigatorKey,
             child: MaintenanceShell(

--- a/lib/widgets/global_header_clock_bar.dart
+++ b/lib/widgets/global_header_clock_bar.dart
@@ -8,9 +8,16 @@ import '../core/app_version.dart';
 class GlobalHeaderClockShell extends StatelessWidget {
   final Widget child;
 
+  /// アプリ直下の Navigator を指す key。本シェルは `MaterialApp.builder` で
+  /// Navigator より上に置かれるため、`Navigator.of(context)` は祖先 Navigator を
+  /// 見つけられず release ビルドで null-check 例外になる。バージョンバッジ等の
+  /// 遷移はこの key を使う。
+  final GlobalKey<NavigatorState>? navigatorKey;
+
   const GlobalHeaderClockShell({
     super.key,
     required this.child,
+    this.navigatorKey,
   });
 
   @override
@@ -19,7 +26,7 @@ class GlobalHeaderClockShell extends StatelessWidget {
       color: Theme.of(context).scaffoldBackgroundColor,
       child: Column(
         children: [
-          const GlobalHeaderClockBar(),
+          GlobalHeaderClockBar(navigatorKey: navigatorKey),
           Expanded(
             child: MediaQuery.removePadding(
               context: context,
@@ -34,7 +41,10 @@ class GlobalHeaderClockShell extends StatelessWidget {
 }
 
 class GlobalHeaderClockBar extends StatefulWidget {
-  const GlobalHeaderClockBar({super.key});
+  const GlobalHeaderClockBar({super.key, this.navigatorKey});
+
+  /// アプリ直下の Navigator を指す key(リリースノート等の遷移に使う)。
+  final GlobalKey<NavigatorState>? navigatorKey;
 
   @override
   State<GlobalHeaderClockBar> createState() => _GlobalHeaderClockBarState();
@@ -61,6 +71,16 @@ class _GlobalHeaderClockBarState extends State<GlobalHeaderClockBar> {
   void dispose() {
     _timer?.cancel();
     super.dispose();
+  }
+
+  /// リリースノート画面へ遷移する。本バーは `MaterialApp.builder` で Navigator より
+  /// 上に置かれるため、`Navigator.of(context)`(release で `navigator!` の null-check
+  /// 例外)を避け、アプリ直下の [GlobalHeaderClockBar.navigatorKey] を優先して使う。
+  /// key 未指定時のみ `Navigator.maybeOf`(無ければ no-op)へフォールバック。
+  void _openReleaseNotes() {
+    final navigator =
+        widget.navigatorKey?.currentState ?? Navigator.maybeOf(context);
+    navigator?.pushNamed('/release-notes');
   }
 
   @override
@@ -142,8 +162,7 @@ class _GlobalHeaderClockBarState extends State<GlobalHeaderClockBar> {
                           child: InkWell(
                             key: const Key('global_header_version_badge'),
                             borderRadius: BorderRadius.circular(10),
-                            onTap: () => Navigator.of(context)
-                                .pushNamed('/release-notes'),
+                            onTap: _openReleaseNotes,
                             child: Container(
                               padding: const EdgeInsets.symmetric(
                                 horizontal: 8,

--- a/test/widgets/global_header_clock_bar_test.dart
+++ b/test/widgets/global_header_clock_bar_test.dart
@@ -20,4 +20,51 @@ void main() {
     expect(find.byKey(const Key('global_header_clock_text')), findsOneWidget);
     expect(find.text('dummy page'), findsOneWidget);
   });
+
+  testWidgets(
+    'version badge opens release notes via navigatorKey when the header is '
+    'mounted above the Navigator (MaterialApp.builder)',
+    (WidgetTester tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigatorKey,
+          onGenerateRoute: (settings) {
+            if (settings.name == '/release-notes') {
+              return MaterialPageRoute<void>(
+                builder: (_) => const Scaffold(body: Text('RELEASE_NOTES')),
+              );
+            }
+            return MaterialPageRoute<void>(
+              builder: (_) => const Scaffold(body: Text('HOME')),
+            );
+          },
+          // 本番(main.dart)と同じく Navigator(child)より上にヘッダーを置く。
+          // このとき `Navigator.of(context)` は祖先 Navigator を見つけられず
+          // release ビルドで null-check 例外になる(修正前の不具合)。
+          builder: (context, child) {
+            return Column(
+              children: [
+                GlobalHeaderClockBar(navigatorKey: navigatorKey),
+                Expanded(child: child ?? const SizedBox.shrink()),
+              ],
+            );
+          },
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('HOME'), findsOneWidget);
+      expect(find.text('RELEASE_NOTES'), findsNothing);
+
+      await tester.tap(find.byKey(const Key('global_header_version_badge')));
+      await tester.pump(); // ルート push 開始
+      await tester.pump(const Duration(milliseconds: 400)); // 遷移完了
+
+      expect(find.text('RELEASE_NOTES'), findsOneWidget);
+
+      // 周期タイマー(時計)を止めるため後始末でアンマウントする。
+      await tester.pumpWidget(const SizedBox());
+    },
+  );
 }


### PR DESCRIPTION
## 概要

実機で**ヘッダーのバージョンバッジをクリックするとリリースノートが開かず「Null check operator used on a null value」でクラッシュ**する不具合を修正します(P1/P2 とは無関係の既存バグ)。

## 真因

`GlobalHeaderClockBar`(バージョンバッジ)は `MaterialApp.builder` 内=**アプリ直下の Navigator より上**に配置されている(`GlobalHeaderClockShell` 経由)。バッジの onTap は `Navigator.of(context).pushNamed('/release-notes')` を呼ぶが、祖先に Navigator が無いため `Navigator.of` 内部の `navigator!` が **release ビルドで null-check 例外**になる(debug の assert はメッセージ表示だが release では strip され `Null check operator used on a null value`)。

## 変更点

- `GlobalHeaderClockShell` / `GlobalHeaderClockBar` に `navigatorKey`(アプリ直下 Navigator の key / 任意)を追加。隣接の `UniversalAiShareShell` が既に同 key を受け取るのと同じ手法。
- onTap を `_openReleaseNotes()` 化: `navigatorKey?.currentState ?? Navigator.maybeOf(context)` で遷移(key 優先 / 無ければ maybeOf=null安全フォールバック)。`Navigator.of` の生 `!` を排除。
- `main.dart` の `MaterialApp.builder` で `GlobalHeaderClockShell(navigatorKey: _navigatorKey, ...)` を配線。

## 互換性 / リスク

- 表示は不変。遷移先(既存 `ReleaseNotesPage` / `/release-notes` ルート)も不変=**クラッシュせずリリースノートが開く**ようになるだけ。`navigatorKey` は任意引数(後方互換)。

## テスト

- `global_header_clock_bar_test`: 本番同様に**ヘッダーを Navigator(child)より上**に置き、バッジ tap → navigatorKey 経由で `/release-notes` へ遷移することを検証(修正前はこの構成で null-check クラッシュ)。

## 補足

- リリースノートは現状フルページ遷移(`ReleaseNotesPage`)。ご要望の「ポップアップ表示」にする場合は別途 UX 変更(`showDialog` 化)を follow-up で対応可能です。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: ヘッダー上配置からの遷移クラッシュ修正。widgetテストで遷移成立を担保。E2E基盤未整備のため対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/widgets・lib/main.dart・test のみ(遷移経路の修正)。supabase/workflow/auth系の高リスクパスは未変更
