### PR TITLE
fix(ai-hub): Gemini thinkingBudget を有効範囲にクランプ (400 invalid 修正)

### DIFF
--- a/supabase/functions/ai-hub/provider_generation_options.ts
+++ b/supabase/functions/ai-hub/provider_generation_options.ts
@@ -7,6 +7,15 @@
 // 本文用にこのトークン数を確保し、残りを thinkingBudget で上限化する。
 export const GEMINI_OUTPUT_TOKEN_RESERVE = 8000;
 
+// gemini-2.5-flash / flash-lite が受け付ける thinkingBudget の範囲。
+// 呼び出し側の maxTokens は index.ts の normalizeMaxTokens で 8192 上限に
+// クランプされるため、旧実装の (maxTokens - 8000) は本番で常に 192 となり、
+// Gemini の下限 512 を下回って 400 INVALID_ARGUMENT
+// ("thinking budget 192 is invalid. choose 512-24576") を返していた。
+// 算出値をこの範囲にクランプして回避する。
+export const GEMINI_MIN_THINKING_BUDGET = 512;
+export const GEMINI_MAX_THINKING_BUDGET = 24576;
+
 export function applyProviderGenerationOptions(
   providerId: string,
   requestBody: Record<string, unknown>,
@@ -52,15 +61,22 @@ export function applyProviderGenerationOptions(
       ...generationConfig,
       maxOutputTokens: maxTokens,
     };
-    // 呼び出し側が thinkingConfig を明示していない & 本文確保枠より大きい予算のときだけ
-    // thinking を上限化する。残り (maxTokens - reserve) を thinking に割り当て、
-    // 本文用に最低 GEMINI_OUTPUT_TOKEN_RESERVE を必ず残す。
+    // 呼び出し側が thinkingConfig を明示していないときだけ thinking を上限化する。
+    // 本文用に GEMINI_OUTPUT_TOKEN_RESERVE を確保した残りを thinking に割り当てるが、
+    // Gemini が許容する [GEMINI_MIN_THINKING_BUDGET, GEMINI_MAX_THINKING_BUDGET] に
+    // クランプする。maxTokens は 8192 上限のため実際は下限 512 になり、本文に 7680
+    // 以上を残しつつ 400 (192 invalid) を回避する。maxTokens が下限以下の極小
+    // リクエストでは thinking を設定せず Gemini 既定に委ねる。
     if (
       generationConfig.thinkingConfig == null &&
-      maxTokens > GEMINI_OUTPUT_TOKEN_RESERVE
+      maxTokens > GEMINI_MIN_THINKING_BUDGET
     ) {
+      const desiredBudget = maxTokens - GEMINI_OUTPUT_TOKEN_RESERVE;
       nextGenerationConfig.thinkingConfig = {
-        thinkingBudget: maxTokens - GEMINI_OUTPUT_TOKEN_RESERVE,
+        thinkingBudget: Math.min(
+          GEMINI_MAX_THINKING_BUDGET,
+          Math.max(GEMINI_MIN_THINKING_BUDGET, desiredBudget),
+        ),
       };
     }
     return {

--- a/supabase/functions/ai-hub/provider_generation_options_test.ts
+++ b/supabase/functions/ai-hub/provider_generation_options_test.ts
@@ -1,6 +1,8 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   applyProviderGenerationOptions,
+  GEMINI_MAX_THINKING_BUDGET,
+  GEMINI_MIN_THINKING_BUDGET,
   GEMINI_OUTPUT_TOKEN_RESERVE,
 } from "./provider_generation_options.ts";
 
@@ -39,14 +41,52 @@ Deno.test("gemini flash-lite also gets a thinking budget", () => {
   );
 });
 
-Deno.test("gemini does not set a thinking budget for small max tokens", () => {
+Deno.test(
+  "gemini clamps the thinking budget to the valid minimum for the 8192 cap " +
+    "(regression: production maxTokens=8192 produced 192 -> 400)",
+  () => {
+    // index.ts の normalizeMaxTokens は maxTokens を 8192 上限へクランプするため、
+    // 資産要約のような大きな要求は常に 8192 で届く。旧実装は 8192-8000=192 を
+    // thinkingBudget に渡し Gemini の 400 ("192 invalid, choose 512-24576") を招いた。
+    const body = applyProviderGenerationOptions(
+      "google_flash_lite",
+      { contents: [] },
+      { maxTokens: 8192 },
+    );
+    const generationConfig = body.generationConfig as Record<string, unknown>;
+    assertEquals(generationConfig.maxOutputTokens, 8192);
+    const thinkingConfig = generationConfig.thinkingConfig as Record<
+      string,
+      unknown
+    >;
+    assertEquals(thinkingConfig.thinkingBudget, GEMINI_MIN_THINKING_BUDGET);
+  },
+);
+
+Deno.test("gemini never exceeds the maximum thinking budget", () => {
   const body = applyProviderGenerationOptions(
     "google",
     { contents: [] },
-    { maxTokens: GEMINI_OUTPUT_TOKEN_RESERVE },
+    {
+      maxTokens: GEMINI_MAX_THINKING_BUDGET + GEMINI_OUTPUT_TOKEN_RESERVE + 100,
+    },
   );
   const generationConfig = body.generationConfig as Record<string, unknown>;
-  assertEquals(generationConfig.maxOutputTokens, GEMINI_OUTPUT_TOKEN_RESERVE);
+  const thinkingConfig = generationConfig.thinkingConfig as Record<
+    string,
+    unknown
+  >;
+  assertEquals(thinkingConfig.thinkingBudget, GEMINI_MAX_THINKING_BUDGET);
+});
+
+Deno.test("gemini does not set a thinking budget for tiny max tokens", () => {
+  const body = applyProviderGenerationOptions(
+    "google",
+    { contents: [] },
+    { maxTokens: GEMINI_MIN_THINKING_BUDGET },
+  );
+  const generationConfig = body.generationConfig as Record<string, unknown>;
+  assertEquals(generationConfig.maxOutputTokens, GEMINI_MIN_THINKING_BUDGET);
   assertEquals(generationConfig.thinkingConfig, undefined);
 });
 


### PR DESCRIPTION
## 概要

実機で AI 資産分析(細木数子風)が出ない原因の一つ、**Gemini フォールバックが必ず 400 で落ちる**バグを修正します。

```
{"provider":"google_flash_lite","http_status":400,
 "detail":"The thinking budget 192 is invalid. Please choose a value between 512 and 24576."}
```

## 真因

`applyProviderGenerationOptions` は本文枠確保のため `thinkingBudget = maxTokens − GEMINI_OUTPUT_TOKEN_RESERVE(8000)` を設定する(#3487)。だが呼び出し側の `maxTokens` は `index.ts` の `normalizeMaxTokens` で **8192 上限にクランプ**される。資産要約は大きい max_tokens を要求するため本番では常に `maxTokens = 8192` → `thinkingBudget = 8192 − 8000 = 192`。

Gemini(`google`=gemini-2.5-flash / `google_flash_lite`=gemini-2.5-flash-lite)の thinkingBudget 下限は **512** のため、**192 は常に 400 INVALID_ARGUMENT**。つまり Gemini 系プロバイダの thinking 上限化パスは本番で恒常的に壊れていた(`google` が 503 高需要のときフォールバックの flash-lite も 400 で連鎖失敗 → AI 分析が出ない)。

#3487 のテストは `maxTokens=24000/20000`(=8512 超)で書かれ通っていたが、**本番クランプ値 8192 を再現していなかった** test-vs-prod ミスマッチ。

## 変更点

- `GEMINI_MIN_THINKING_BUDGET = 512` / `GEMINI_MAX_THINKING_BUDGET = 24576` を追加。
- thinking 予算を算出後 **`[512, 24576]` にクランプ**。本番 8192 では 512 となり、本文に 7680 以上を残しつつ 400 を回避。`maxTokens` が下限(512)以下の極小リクエストでは thinking を設定せず Gemini 既定に委ねる。
- 振る舞い保存: 大きい maxTokens(24000 等)では従来同様 `maxTokens − 8000`(範囲内)。呼び出し側の明示 thinkingConfig は不変で尊重。

## テスト(`deno test` ローカル 8/8 green)

- **回帰テスト追加**: 本番クランプ値 `maxTokens=8192` → thinkingBudget が **512(旧 192 ではない)**。
- 上限クランプ(24576 超→24576)/ 極小(512 以下→未設定)テスト追加。既存 4 件(24000/20000/caller-provided/openai/groq)は不変で green。

## ⚠ デプロイ

- 🔴 **edge function は自動デプロイされません**。マージ後に手動 `supabase functions deploy ai-hub` が必要です(私の権限では実行不可)。
- `google` の **503(high demand)** は Google 側の一時的容量問題で本修正の対象外。ただし本修正でフォールバック(flash-lite)が正しく働くようになり、503 時の復旧性が上がります。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge function の純粋オプション整形ロジック。`deno test`(8件 green)で thinkingBudget クランプを担保。Flutter/Playwright E2E 対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: `supabase/functions/ai-hub/` の生成オプション整形のみ。auth/RLS/secrets 不変。thinkingBudget を Gemini 許容範囲にクランプする最小修正で deno test 全 green
