### PR TITLE
feat(asset): 浪費トレーニング集計を給料日サイクルへ (Phase 3)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -1059,6 +1059,31 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }).toList();
   }
 
+  /// [reference] が属する給料日サイクル `[salaryCycleStart, salaryCycleEndExclusive)`
+  /// に発生したフローを返す。資産管理の「今月 = 給料日サイクル」統一(Phase 3)用。
+  List<Map<String, dynamic>> _flowsForCycle(DateTime reference) {
+    final start = AssetLiabilityMonthlyStateStore.salaryCycleStart(
+      reference,
+      salaryDay: _salaryDay,
+    );
+    final endExclusive =
+        AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(
+      reference,
+      salaryDay: _salaryDay,
+    );
+    return _recentFlows.where((flow) {
+      final occurredAtRaw = flow['occurred_at']?.toString();
+      if (occurredAtRaw == null || occurredAtRaw.isEmpty) {
+        return false;
+      }
+      final occurredAt = DateTime.tryParse(occurredAtRaw)?.toLocal();
+      if (occurredAt == null) {
+        return false;
+      }
+      return !occurredAt.isBefore(start) && occurredAt.isBefore(endExclusive);
+    }).toList();
+  }
+
   Future<void> _pickFlowHistoryMonth() async {
     final now = DateTime.now();
     final picked = await showDatePicker(
@@ -1172,9 +1197,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   AssetWasteTrainingSnapshot _buildWasteTrainingSnapshot() {
     final lockdown = _debtLockdownSnapshot;
+    final cycleStart = AssetLiabilityMonthlyStateStore.salaryCycleStart(
+      _now,
+      salaryDay: _salaryDay,
+    );
+    final cycleEndExclusive =
+        AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(
+      _now,
+      salaryDay: _salaryDay,
+    );
     return AssetWasteTrainingSnapshotInputs.build(
-      monthFlows: _flowsForMonth(_monthStart(_now)),
+      monthFlows: _flowsForCycle(_now),
       now: _now,
+      cycleStart: cycleStart,
+      cycleEndExclusive: cycleEndExclusive,
       isExpense: _isExpenseActionType,
       wasteCategoryOf: (description, actionType) => _parseFlowDescription(
         description,

--- a/lib/services/asset_waste_training_snapshot_inputs.dart
+++ b/lib/services/asset_waste_training_snapshot_inputs.dart
@@ -11,7 +11,11 @@ import 'asset_waste_training_ai_service.dart';
 class AssetWasteTrainingSnapshotInputs {
   const AssetWasteTrainingSnapshotInputs();
 
-  /// [monthFlows] は対象月に絞り込み済みの収支フロー。
+  /// [monthFlows] は対象期間に絞り込み済みの収支フロー。
+  ///
+  /// [cycleStart] / [cycleEndExclusive] を両方渡すと、集計窓・経過日数を給料日
+  /// サイクル `[cycleStart, cycleEndExclusive)` で扱う(資産管理の「今月 = 給料日
+  /// サイクル」統一)。どちらか欠けると従来どおり [now] の暦月で扱う(後方互換)。
   static AssetWasteTrainingSnapshot build({
     required List<Map<String, dynamic>> monthFlows,
     required DateTime now,
@@ -23,8 +27,13 @@ class AssetWasteTrainingSnapshotInputs {
     required int todayViolationCount,
     required int compliantStreakDays,
     required bool lockdownActive,
+    DateTime? cycleStart,
+    DateTime? cycleEndExclusive,
   }) {
-    final currentMonth = DateTime(now.year, now.month, 1);
+    final usingCycle = cycleStart != null && cycleEndExclusive != null;
+    final periodStart = usingCycle
+        ? DateTime(cycleStart.year, cycleStart.month, cycleStart.day)
+        : DateTime(now.year, now.month, 1);
     var totalExpense = 0;
     var wasteExpense = 0;
     var expenseEntryCount = 0;
@@ -57,14 +66,25 @@ class AssetWasteTrainingSnapshotInputs {
       }
     }
 
-    final isCurrentMonth =
-        currentMonth.year == now.year && currentMonth.month == now.month;
-    final elapsedDays = isCurrentMonth
-        ? now.day
-        : DateTime(currentMonth.year, currentMonth.month + 1, 0).day;
+    final int elapsedDays;
+    if (usingCycle) {
+      // サイクル内なら開始日からの経過日数、終了済みサイクルなら全日数。
+      final nowWithinCycle =
+          !now.isBefore(cycleStart) && now.isBefore(cycleEndExclusive);
+      final fullCycleDays = cycleEndExclusive.difference(periodStart).inDays;
+      elapsedDays = nowWithinCycle
+          ? now.difference(periodStart).inDays + 1
+          : fullCycleDays;
+    } else {
+      final isCurrentMonth =
+          periodStart.year == now.year && periodStart.month == now.month;
+      elapsedDays = isCurrentMonth
+          ? now.day
+          : DateTime(periodStart.year, periodStart.month + 1, 0).day;
+    }
 
     return AssetWasteTrainingSnapshot(
-      month: currentMonth,
+      month: periodStart,
       monitoredAt: now,
       totalExpense: totalExpense,
       wasteExpense: wasteExpense,

--- a/test/services/asset_waste_training_snapshot_inputs_test.dart
+++ b/test/services/asset_waste_training_snapshot_inputs_test.dart
@@ -105,4 +105,69 @@ void main() {
     expect(snapshot.todayViolationCount, 0);
     expect(snapshot.lockdownActive, isTrue);
   });
+
+  // --- Phase 3: 給料日サイクル窓 ---
+
+  AssetWasteTrainingSnapshot buildCycle(
+    List<Map<String, dynamic>> flows, {
+    required DateTime now,
+    required DateTime cycleStart,
+    required DateTime cycleEndExclusive,
+  }) {
+    return AssetWasteTrainingSnapshotInputs.build(
+      monthFlows: flows,
+      now: now,
+      cycleStart: cycleStart,
+      cycleEndExclusive: cycleEndExclusive,
+      isExpense: (actionType) => actionType == 'expense',
+      wasteCategoryOf: (description, actionType) =>
+          description.contains('#浪費') ? '浪費' : null,
+      ruleCompletedCount: 2,
+      ruleTargetCount: 5,
+      todayViolationCount: 1,
+      compliantStreakDays: 3,
+      lockdownActive: true,
+    );
+  }
+
+  test('salary cycle: month=cycleStart and elapsedDays counts from cycle start',
+      () {
+    final snapshot = buildCycle(
+      [
+        flow(
+          'expense',
+          2000,
+          description: 'ゲーム #浪費',
+          occurredAt: '2026-05-27T09:00:00',
+        ),
+        flow(
+          'expense',
+          1000,
+          description: 'ランチ',
+          occurredAt: '2026-06-10T09:00:00',
+        ),
+      ],
+      now: DateTime(2026, 6, 15),
+      cycleStart: DateTime(2026, 5, 25),
+      cycleEndExclusive: DateTime(2026, 6, 25),
+    );
+
+    expect(snapshot.month, DateTime(2026, 5, 25));
+    expect(snapshot.totalExpense, 3000);
+    expect(snapshot.wasteExpense, 2000);
+    expect(snapshot.elapsedDays, 22); // 5/25→6/15 = 21日 + 1
+    expect(snapshot.noWasteDays, 21); // 浪費1日 (5/27)
+  });
+
+  test('ended salary cycle uses the full cycle length for elapsedDays', () {
+    final snapshot = buildCycle(
+      const [],
+      now: DateTime(2026, 7, 10), // サイクル終了後
+      cycleStart: DateTime(2026, 5, 25),
+      cycleEndExclusive: DateTime(2026, 6, 25),
+    );
+
+    expect(snapshot.elapsedDays, 31); // 5/25→6/25 = 31日
+    expect(snapshot.month, DateTime(2026, 5, 25));
+  });
 }


### PR DESCRIPTION
## 概要

月次サイクルの給料日サイクル統一 **Phase 3**(分析系)。浪費トレーニング集計を**給料日サイクル窓**に揃えます(Phase 1=給料日設定化 #3500 / Phase 2=資金繰り・未払い・期限超過のサイクル化 #3504 の続き)。

「今月の浪費 / 浪費しなかった日数」が、給料日(既定25日)を過ぎても暦月でリセットされず、**ユーザーの実サイクル**で集計されます。

## 変更点

- `AssetWasteTrainingSnapshotInputs.build` に任意引数 `cycleStart` / `cycleEndExclusive` を追加。両方指定時は集計窓・経過日数をサイクル `[cycleStart, cycleEndExclusive)` で扱う。どちらか欠ければ従来どおり暦月(**後方互換**)。
  - `elapsedDays`: サイクル内なら開始日からの経過日数、終了済みサイクルなら全日数。
  - `month` フィールド: サイクル開始日(非表示の内部値・下流は `elapsedDays`/`noWasteDays` のみ参照)。
- ページ: `_flowsForCycle(reference)` ヘルパー追加(`salaryCycleStart`〜`salaryCycleEndExclusive` で `_recentFlows` を絞り込み)。`_buildWasteTrainingSnapshot` がサイクル窓フロー + サイクル境界を渡すよう変更。`_salaryDay` 反映。

## スコープ判断(Phase 3 の意図的境界)

- 🔵 **定期取引検出は暦月バケット維持**: 検出は「毎月◯日頃に約◯円」= **日付パターン**で、暦月↔サイクルのバケット差は検出結果をほぼ変えない(月末境界の極稀なケースのみ)。一方で tested service の churn + 検出感度リスク(実データ調整したい点)があるため、価値<リスクと判断し変更しない。
- 🔵 **支払カレンダーグリッドは暦月維持**(Phase 2 スコープ外・計画通り)。

## テスト

- `asset_waste_training_snapshot_inputs_test`: サイクル窓で `month=cycleStart` / `elapsedDays` がサイクル開始からの経過日数になること / 終了済みサイクルは全日数になること を追加。既存の暦月テストは後方互換で不変。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数集計のサイクル窓化。unitテスト(サイクル/終了済み/後方互換)で担保。E2E基盤未整備のため対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/services・lib/pages・test のみ(浪費集計のサイクル窓化)。auth/billing/supabase/workflow 等の高リスクパスは未変更
