### PR TITLE
feat(header): リリースノートをポップアップ表示に

### DIFF
--- a/lib/pages/release_notes_page.dart
+++ b/lib/pages/release_notes_page.dart
@@ -127,12 +127,39 @@ class ReleaseNotesDocument {
   }
 }
 
+/// リリースノートをポップアップ(ダイアログ)で表示する。
+///
+/// ヘッダーのバージョンバッジ等、フルページ遷移より軽い確認に使う。[context] は
+/// アプリ直下の Navigator を含むもの(ヘッダーは Navigator より上にあるため呼び出し
+/// 側で `navigatorKey.currentContext` を渡すこと)。
+Future<void> showReleaseNotesDialog(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    builder: (dialogContext) {
+      return Dialog(
+        clipBehavior: Clip.antiAlias,
+        insetPadding: const EdgeInsets.all(24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 560, maxHeight: 680),
+          child: ReleaseNotesPage(
+            onClose: () => Navigator.of(dialogContext).pop(),
+          ),
+        ),
+      );
+    },
+  );
+}
+
 class ReleaseNotesPage extends StatefulWidget {
   final ReleaseNotesDocument? initialDocument;
+
+  /// 非 null のときダイアログ表示とみなし、AppBar に閉じるボタンを出す。
+  final VoidCallback? onClose;
 
   const ReleaseNotesPage({
     super.key,
     this.initialDocument,
+    this.onClose,
   });
 
   @override
@@ -211,6 +238,15 @@ class _ReleaseNotesPageState extends State<ReleaseNotesPage> {
 
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: widget.onClose == null,
+        leading: widget.onClose != null
+            ? IconButton(
+                key: const Key('release_notes_close_button'),
+                tooltip: '閉じる',
+                icon: const Icon(Icons.close),
+                onPressed: widget.onClose,
+              )
+            : null,
         title: const Text('Release Notes'),
         actions: [
           IconButton(

--- a/lib/widgets/global_header_clock_bar.dart
+++ b/lib/widgets/global_header_clock_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../core/app_version.dart';
+import '../pages/release_notes_page.dart';
 
 class GlobalHeaderClockShell extends StatelessWidget {
   final Widget child;
@@ -78,9 +79,13 @@ class _GlobalHeaderClockBarState extends State<GlobalHeaderClockBar> {
   /// 例外)を避け、アプリ直下の [GlobalHeaderClockBar.navigatorKey] を優先して使う。
   /// key 未指定時のみ `Navigator.maybeOf`(無ければ no-op)へフォールバック。
   void _openReleaseNotes() {
-    final navigator =
-        widget.navigatorKey?.currentState ?? Navigator.maybeOf(context);
-    navigator?.pushNamed('/release-notes');
+    // 本バーは Navigator より上(MaterialApp.builder)にあるため、ダイアログは
+    // アプリ直下 Navigator を含む navigatorKey の context 上で開く。未指定時のみ
+    // ローカル context へフォールバック(Navigator が無ければ何もしない)。
+    final dialogContext = widget.navigatorKey?.currentContext ??
+        (Navigator.maybeOf(context) != null ? context : null);
+    if (dialogContext == null) return;
+    showReleaseNotesDialog(dialogContext);
   }
 
   @override

--- a/test/widgets/global_header_clock_bar_test.dart
+++ b/test/widgets/global_header_clock_bar_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/release_notes_page.dart';
 import 'package:my_web_app/widgets/global_header_clock_bar.dart';
 
 void main() {
@@ -22,26 +23,18 @@ void main() {
   });
 
   testWidgets(
-    'version badge opens release notes via navigatorKey when the header is '
-    'mounted above the Navigator (MaterialApp.builder)',
+    'version badge opens the release notes dialog via navigatorKey when the '
+    'header is mounted above the Navigator (MaterialApp.builder)',
     (WidgetTester tester) async {
       final navigatorKey = GlobalKey<NavigatorState>();
       await tester.pumpWidget(
         MaterialApp(
           navigatorKey: navigatorKey,
-          onGenerateRoute: (settings) {
-            if (settings.name == '/release-notes') {
-              return MaterialPageRoute<void>(
-                builder: (_) => const Scaffold(body: Text('RELEASE_NOTES')),
-              );
-            }
-            return MaterialPageRoute<void>(
-              builder: (_) => const Scaffold(body: Text('HOME')),
-            );
-          },
+          home: const Scaffold(body: Text('HOME')),
           // 本番(main.dart)と同じく Navigator(child)より上にヘッダーを置く。
           // このとき `Navigator.of(context)` は祖先 Navigator を見つけられず
-          // release ビルドで null-check 例外になる(修正前の不具合)。
+          // release ビルドで null-check 例外になる(#3511)。ダイアログは
+          // navigatorKey の context 上で開くことで回避する。
           builder: (context, child) {
             return Column(
               children: [
@@ -54,14 +47,18 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text('HOME'), findsOneWidget);
-      expect(find.text('RELEASE_NOTES'), findsNothing);
+      expect(find.byType(ReleaseNotesPage), findsNothing);
 
       await tester.tap(find.byKey(const Key('global_header_version_badge')));
-      await tester.pump(); // ルート push 開始
-      await tester.pump(const Duration(milliseconds: 400)); // 遷移完了
+      await tester.pump(); // ダイアログ route push
+      await tester.pump(const Duration(milliseconds: 300)); // フェード遷移
 
-      expect(find.text('RELEASE_NOTES'), findsOneWidget);
+      // リリースノートがポップアップ(ダイアログ)で開き、閉じるボタンを備える。
+      expect(find.byType(ReleaseNotesPage), findsOneWidget);
+      expect(
+        find.byKey(const Key('release_notes_close_button')),
+        findsOneWidget,
+      );
 
       // 周期タイマー(時計)を止めるため後始末でアンマウントする。
       await tester.pumpWidget(const SizedBox());


### PR DESCRIPTION
## 概要

ヘッダーのバージョンバッジをタップしたとき、リリースノートを**フルページ遷移ではなくポップアップ(ダイアログ)**で表示します(ユーザー要望「本来はリリースノートのポップアップを表示させたい」)。クラッシュ修正 #3511 の後続 UX 改善。

## 変更点

- `release_notes_page.dart`:
  - トップレベル関数 `showReleaseNotesDialog(context)` を追加。`Dialog`(最大幅560/高さ680)に `ReleaseNotesPage` を内包して表示。
  - `ReleaseNotesPage` に任意 `onClose` を追加。非 null(=ダイアログ表示)時のみ AppBar に閉じるボタンを出す(`automaticallyImplyLeading: false`)。フルページ遷移(`/release-notes` ルート)時は従来どおり戻るボタン(後方互換)。
- `global_header_clock_bar.dart`: `_openReleaseNotes` を `pushNamed` から `showReleaseNotesDialog` へ変更。ダイアログはアプリ直下 Navigator を含む `navigatorKey.currentContext` 上で開く(#3511 と同じく Navigator より上配置に対応)。

## 互換性

- `/release-notes` 名前付きルート(`main.dart`)は不変=他からのフルページ遷移は維持。ダイアログは追加経路。フェッチ・表示内容は既存のまま。

## テスト

- `global_header_clock_bar_test`: Navigator より上にヘッダーを置いた構成でバッジ tap → **ダイアログで `ReleaseNotesPage` が開き閉じるボタンを備える**ことを検証(#3511 のナビゲーション検証をダイアログ検証へ更新)。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: ヘッダーからのダイアログ表示(UI経路)。widgetテストでダイアログ表示+閉じるボタンを担保。E2E基盤未整備のため対象外

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: BEHIND誤発火対策の予防同梱: 変更は lib/pages・lib/widgets・test のみ(リリースノートのダイアログ表示化)。auth/billing/supabase/workflow 等の高リスクパスは未変更
