### PR TITLE
feat(asset): 月次の負債トレンド検出と翌月アクション提示

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -1169,6 +1169,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (debtPaymentDayOverrides.isEmpty) {
         unawaited(_restoreDebtPaymentDayOverridesFromMirror());
       }
+      // 他端末の残高履歴を取り込み、負債トレンドの前月比を端末跨ぎで有効化。
+      unawaited(_restoreAssetBalanceHistoryFromMirror());
       final templates =
           await _assetLiabilityRepository.loadRecurringIncomeTemplates();
       final monthlySnapshots =
@@ -1990,6 +1992,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final prior =
           await _assetBalanceHistoryStore.priorMonthBalances(baseDate);
       await _assetBalanceHistoryStore.recordMonth(baseDate, balances);
+      // 記録した最新履歴を端末跨ぎミラーへ退避（ログイン時のみ実効）。
+      unawaited(_mirrorAssetBalanceHistory());
       if (!mounted) {
         return;
       }
@@ -8424,6 +8428,69 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       );
     } catch (e) {
       debugPrint('pref mirror restore failed: $e');
+    }
+  }
+
+  /// 口座別残高履歴を asset_pref_mirror へ丸ごと退避する（端末跨ぎ同期）。
+  ///
+  /// 汎用 jsonb ミラーの 1 pref_key を使うためマイグレーション不要。値は
+  /// `{monthKey: {accountId: 残高}}`。負債トレンドの前月比を別端末でも使える。
+  Future<void> _mirrorAssetBalanceHistory() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final history = await _assetBalanceHistoryStore.loadAll();
+      if (history.isEmpty) {
+        return;
+      }
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': 'account_balance_history',
+        'value': history,
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('balance history mirror upsert failed: $e');
+    }
+  }
+
+  /// 他端末の残高履歴をミラーから取り込み、ローカルへ和集合マージする。
+  ///
+  /// マージは非破壊（月キー・口座を消さない/巻き戻さない）。取り込みで前月残高が
+  /// 変わったら、当月基準の前月残高キャッシュを更新して負債トレンドを再評価する。
+  Future<void> _restoreAssetBalanceHistoryFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', 'account_balance_history');
+      if (rows.isEmpty) {
+        return;
+      }
+      final changed =
+          await _assetBalanceHistoryStore.mergeRemote(rows.first['value']);
+      if (!changed || !mounted) {
+        return;
+      }
+      final monthKey = AssetAccountBalanceHistoryStore.formatMonthKey(_now);
+      final prior = await _assetBalanceHistoryStore.priorMonthBalances(_now);
+      if (!mounted) {
+        return;
+      }
+      if (_assetDebtTrendPriorBalancesMonth != monthKey ||
+          !_sameDoubleMap(_assetDebtTrendPriorBalances, prior)) {
+        setState(() {
+          _assetDebtTrendPriorBalances = prior;
+          _assetDebtTrendPriorBalancesMonth = monthKey;
+        });
+      }
+    } catch (e) {
+      debugPrint('balance history mirror restore failed: $e');
     }
   }
 

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -20,6 +20,8 @@ import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/models/debt_repayment_plan.dart';
 import 'package:my_web_app/models/kgi_csf_kpi.dart';
 import 'package:my_web_app/models/user_profile.dart';
+import 'package:my_web_app/pages/profile_settings_page.dart';
+import 'package:my_web_app/services/asset_expected_inflow_store.dart';
 import 'package:my_web_app/services/asset_liability_annual_rate_evidence_service.dart';
 import 'package:my_web_app/services/asset_liability_card_statement_import_service.dart';
 import 'package:my_web_app/services/asset_liability_csv_restore_service.dart';
@@ -31,14 +33,22 @@ import 'package:my_web_app/services/asset_liability_planning_service.dart';
 import 'package:my_web_app/services/asset_liability_repayment_simulation_service.dart';
 import 'package:my_web_app/services/asset_liability_repository.dart';
 import 'package:my_web_app/services/asset_management_ai_analysis_history_service.dart';
+import 'package:my_web_app/services/asset_management_ai_summary_refresh.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
+import 'package:my_web_app/services/asset_management_display_mode_store.dart';
+import 'package:my_web_app/services/asset_account_balance_history_store.dart';
+import 'package:my_web_app/services/asset_debt_trend_analyzer.dart';
+import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
+import 'package:my_web_app/services/asset_payment_calendar_service.dart';
+import 'package:my_web_app/services/asset_unknown_expense_rule_service.dart';
 import 'package:my_web_app/services/asset_waste_training_ai_service.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
 import 'package:my_web_app/services/debt_lockdown_service.dart';
 import 'package:my_web_app/services/debt_repayment_planner_service.dart';
 import 'package:my_web_app/services/disposable_balance_asset_liability_adapter.dart';
 import 'package:my_web_app/services/disposable_balance_service.dart';
+import 'package:my_web_app/services/konbini_udon_challenge_service.dart';
 import 'package:my_web_app/services/profile_service.dart';
 import 'package:my_web_app/services/salary_spending_breakdown_service.dart';
 import 'package:my_web_app/services/smbc_csv_import_service.dart';
@@ -46,9 +56,12 @@ import 'package:my_web_app/services/waste_tracking_service.dart';
 import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:web/web.dart' as web;
+import 'package:web/web.dart'
+    // ignore: uri_does_not_exist
+    if (dart.library.io) 'package:my_web_app/utils/web_stub.dart' as web;
 
 enum AssetManagementInitialFocus {
   overview,
@@ -92,6 +105,35 @@ class AssetManagementPage extends StatefulWidget {
   final String? entryLabel;
   final String? entryDescription;
 
+  /// テスト専用: 口座スナップショット ({yyyy-MM-dd: {口座名: 残高}}) を
+  /// 直接注入する (#3267)。null なら通常の Supabase 読込のみ。
+  @visibleForTesting
+  final Map<String, Map<String, double>>? debugInitialAssetData;
+
+  /// テスト専用: asset_pref_mirror 行を直接注入し、反映通知の判定を
+  /// ネットワークなしで検証する。null なら通常の select。
+  @visibleForTesting
+  final List<Map<String, dynamic>>? debugMirrorPrefsRows;
+
+  /// テスト専用: 入金トゥームストーンのミラー値 (`{'ids': [...]}`) を
+  /// 直接注入し、削除伝播 (pull→ローカル除去) をネットワークなしで検証する。
+  @visibleForTesting
+  final Map<String, dynamic>? debugInflowDeletedIdsMirror;
+
+  /// テスト専用: トゥームストーン GC 設定の初期値を注入する (#part288)。
+  @visibleForTesting
+  final AssetTombstoneGcConfig? debugTombstoneGcConfig;
+
+  /// テスト専用: section override 削除トゥームストーンのミラー値
+  /// (`{'ids': [...]}`) を注入し、削除伝播をネットワークなしで検証する (#part292)。
+  @visibleForTesting
+  final Map<String, dynamic>? debugSectionOverrideDeletedMirror;
+
+  /// テスト専用: 支払日上書き削除トゥームストーンのミラー値
+  /// (`{'ids': [...]}`) を注入し、削除伝播をネットワークなしで検証する (#part294)。
+  @visibleForTesting
+  final Map<String, dynamic>? debugDebtOverrideDeletedMirror;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -100,6 +142,12 @@ class AssetManagementPage extends StatefulWidget {
     this.assetLiabilityRepository,
     this.entryLabel,
     this.entryDescription,
+    this.debugInitialAssetData,
+    this.debugMirrorPrefsRows,
+    this.debugInflowDeletedIdsMirror,
+    this.debugTombstoneGcConfig,
+    this.debugSectionOverrideDeletedMirror,
+    this.debugDebtOverrideDeletedMirror,
   });
 
   @override
@@ -135,6 +183,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final _keyFlow = GlobalKey();
   final _keySubs = GlobalKey();
   final _keyMust = GlobalKey();
+  // カード明細取り込み・照合パネルへのスクロール用 (AIコメントからのジャンプ)。
+  final _keyCardStatementReconciliation = GlobalKey();
 
   Timer? _deadlineTimer;
   DateTime _now = DateTime.now();
@@ -162,6 +212,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, double> _actualPaymentAmounts = <String, double>{};
   Map<String, String> _paymentDifferenceReasons = <String, String>{};
   Map<String, double> _annualRateOverrides = <String, double>{};
+  Map<String, int> _debtPaymentDayOverrides = <String, int>{};
+  final Map<String, GlobalKey> _debtMasterCardKeys = <String, GlobalKey>{};
   Map<String, AssetLiabilityAnnualRateEvidence> _annualRateEvidences =
       <String, AssetLiabilityAnnualRateEvidence>{};
   Set<String> _monthlyPaidAccountNames = <String>{};
@@ -320,13 +372,51 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   DebtLockdownSnapshot? _debtLockdownSnapshot;
   bool _isLoadingDebtLockdown = false;
   double? _debtLockdownLoadedForDebt;
+  final KonbiniUdonChallengeService _konbiniUdonChallengeService =
+      const KonbiniUdonChallengeService();
+  KonbiniUdonChallengeSnapshot? _konbiniUdonSnapshot;
+  bool _isLoadingKonbiniUdon = false;
+  double? _konbiniUdonLoadedForDebt;
+  final AssetManagementDisplayModeStore _displayModeStore =
+      const AssetManagementDisplayModeStore();
+  AssetManagementDisplayMode _displayMode =
+      AssetManagementDisplayModeStore.defaultMode;
+  final AssetManagementMainAccountStore _mainAccountStore =
+      const AssetManagementMainAccountStore();
+  // 使用可能額の基準となるメインバンク口座ID。null は既定(最大預金口座)。
+  String? _assetManagementMainAccountId;
+  // 月をまたいだ負債トレンド(リボ複利・残高増加)判定のための口座別残高履歴。
+  final AssetAccountBalanceHistoryStore _assetBalanceHistoryStore =
+      const AssetAccountBalanceHistoryStore();
+  // 前月末の口座別残高(accountId -> 残高絶対値)。非同期ロードでキャッシュする。
+  Map<String, double> _assetDebtTrendPriorBalances = const <String, double>{};
+  // 上記キャッシュが対象としている月キー(月ナビ/日跨ぎでの取り違え防止)。
+  String? _assetDebtTrendPriorBalancesMonth;
+  // 今月の残高記録の重複実行を防ぐシグネチャ(monthKey + 残高内容)。
+  String? _assetDebtTrendSyncedSignature;
+  Map<AssetManagementSectionId, AssetManagementSectionVisibilityOverride>
+      _sectionOverrides = {};
+  // GC 設定をサーバ/ローカルから取得したら差し替えるため非 final (#part287/288)。
+  AssetExpectedInflowStore _expectedInflowStore =
+      const AssetExpectedInflowStore();
+  AssetTombstoneGcConfig _tombstoneGcConfig = const AssetTombstoneGcConfig();
+  List<AssetExpectedInflow> _expectedInflows = <AssetExpectedInflow>[];
+  List<AssetExpectedInflowRule> _expectedInflowRules =
+      <AssetExpectedInflowRule>[];
+  String? _displayModeStatsLabel;
+  String? _experimentServerSummary;
+  List<Map<String, dynamic>> _experimentWeekly = const <Map<String, dynamic>>[];
+  DateTime _calendarMonth = DateTime.now();
+  DateTime? _calendarSelectedDate;
   Future<AssetWasteTrainingAiReview>? _wasteTrainingAiReviewFuture;
   String? _wasteTrainingAiReviewKey;
   bool _isGeneratingAssetManagementAiSummary = false;
   AssetManagementAiSummaryResult? _assetManagementAiSummaryResult;
   String? _assetManagementAiSummaryRequestKey;
   String? _assetManagementAiSummaryInFlightKey;
-  final Set<String> _assetManagementAiSummaryAutoRequestedKeys = <String>{};
+  // 表示中サマリーが生成された時点のフィンガープリント。これと現在の
+  // レポートキーがずれたら自動再生成する (支払済みチェック等の反映)。
+  String? _assetManagementAiSummaryResultKey;
   List<AssetManagementAiAnalysisHistoryEntry>
       _assetManagementAiSummaryReferencedHistory =
       const <AssetManagementAiAnalysisHistoryEntry>[];
@@ -384,6 +474,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   @override
   void initState() {
     super.initState();
+    final debugAssetData = widget.debugInitialAssetData;
+    if (debugAssetData != null) {
+      _assetData = <String, Map<String, double>>{
+        for (final entry in debugAssetData.entries)
+          entry.key: Map<String, double>.from(entry.value),
+      };
+    }
     _assetLiabilityRepository = widget.assetLiabilityRepository ??
         AssetLiabilityRepositoryFactory.createDefault(
           supabaseClient: _supabase,
@@ -396,6 +493,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _fetchRecentFlows();
     _fetchSubscriptions();
     _fetchMustTasks();
+    _loadDisplayMode();
+    _loadMainAccount();
+    _loadExpectedInflows();
+    // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
+    unawaited(_initTombstoneGcAndPull());
+    // 他端末で削除されたセクション上書き / 支払日上書きを取り込む (#part292/294)。
+    unawaited(_pullDeletedSectionIds());
+    unawaited(_pullDebtOverrideDeleted());
     _deadlineTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
       final previousMonthKey = _assetLiabilityStateMonthKey(_now);
@@ -436,7 +541,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _cardStatementImportController.dispose();
     _assetCsvRestoreController.dispose();
     _repaymentSimulationExtraPaymentController.dispose();
-    _annualRateControllers.forEach((_, controller) => controller.dispose());
     _flowMemoController.dispose();
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
@@ -463,6 +567,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _isLoadingAssetManagementUserProfile = false;
         _assetManagementAiSummaryRequestKey = null;
         _assetManagementAiSummaryResult = null;
+        _assetManagementAiSummaryResultKey = null;
       });
     } catch (_) {
       if (!mounted) {
@@ -472,6 +577,39 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _isLoadingAssetManagementUserProfile = false;
       });
     }
+  }
+
+  bool _assetManagementProfileBasicsMissing(UserProfile? profile) {
+    if (profile == null) {
+      return true;
+    }
+    final occupation = profile.occupation?.trim() ?? '';
+    return occupation.isEmpty || profile.annualIncome == null;
+  }
+
+  Future<void> _openProfileSettingsForAssetManagement() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (_) => const ProfileSettingsPage()),
+    );
+    if (!mounted) {
+      return;
+    }
+    await _loadAssetManagementUserProfile();
+  }
+
+  /// AIコメントが指摘するカード明細の未取込・差分に対し、取り込み・照合
+  /// パネルへ誘導するリンクの文言。確認が必要なカード名を織り込む。
+  String _cardStatementReconciliationLinkLabel(
+      AssetLiabilityWorkbook workbook) {
+    final groups = workbook.cardStatementReconciliation.needsReviewGroups;
+    if (groups.length == 1) {
+      return '${groups.first.billingAccountName}の明細を取り込んで照合する';
+    }
+    return 'カード明細を取り込んで照合する（${groups.length}件）';
+  }
+
+  void _jumpToCardStatementReconciliation() {
+    _scrollTo(_keyCardStatementReconciliation);
   }
 
   List<String> _paymentSourceCandidates() {
@@ -500,9 +638,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   String _todayDateKey() => _dateOnly(DateTime.now());
-
-  String _yesterdayDateKey() =>
-      _dateOnly(DateTime.now().subtract(const Duration(days: 1)));
 
   DateTime _monthStart(DateTime dt) => DateTime(dt.year, dt.month, 1);
 
@@ -1029,6 +1164,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           await _assetLiabilityRepository.loadDefaultPaymentSources();
       final defaultCardBillingAccounts =
           await _assetLiabilityRepository.loadDefaultCardBillingAccounts();
+      final debtPaymentDayOverrides =
+          await _assetLiabilityRepository.loadDebtPaymentDayOverrides();
+      if (debtPaymentDayOverrides.isEmpty) {
+        unawaited(_restoreDebtPaymentDayOverridesFromMirror());
+      }
       final templates =
           await _assetLiabilityRepository.loadRecurringIncomeTemplates();
       final monthlySnapshots =
@@ -1083,6 +1223,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
         _defaultCardBillingAccountIds = Map<String, String>.from(
           defaultCardBillingAccounts,
+        );
+        _debtPaymentDayOverrides = Map<String, int>.from(
+          debtPaymentDayOverrides,
         );
         _monthlyIncomePlans = List<AssetLiabilityIncomePlan>.from(
           incomePlansWithTemplates,
@@ -1803,6 +1946,66 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       unawaited(_saveDefaultPaymentSources());
       unawaited(_saveDefaultCardBillingAccounts());
     });
+  }
+
+  /// 今月の口座別負債残高を履歴へ記録し、前月末残高をロードして
+  /// 負債トレンド判定(リボ複利・残高増加)に供給する。
+  ///
+  /// 同期スナップショット(過去に LWW でのデータ消失あり)には触れず、
+  /// 独立した [AssetAccountBalanceHistoryStore] へ自動蓄積する。残高が変わった
+  /// ときだけ再記録し、前月残高が更新されたときだけ setState で再描画する。
+  void _scheduleAssetDebtTrendHistorySync(AssetLiabilityWorkbook workbook) {
+    final monthKey =
+        AssetAccountBalanceHistoryStore.formatMonthKey(workbook.baseDate);
+    final balances = <String, double>{
+      for (final row in workbook.debtMasterRows)
+        if (row.balance < 0) row.id: row.balance.abs(),
+    };
+    final signatureParts = balances.entries
+        .map((entry) => '${entry.key}:${entry.value.round()}')
+        .toList()
+      ..sort();
+    final signature = '$monthKey|${signatureParts.join(',')}';
+    if (_assetDebtTrendSyncedSignature == signature) {
+      return;
+    }
+    _assetDebtTrendSyncedSignature = signature;
+    unawaited(
+      _syncAssetDebtTrendHistory(
+        workbook.baseDate,
+        monthKey,
+        balances,
+        signature,
+      ),
+    );
+  }
+
+  Future<void> _syncAssetDebtTrendHistory(
+    DateTime baseDate,
+    String monthKey,
+    Map<String, double> balances,
+    String signature,
+  ) async {
+    try {
+      final prior =
+          await _assetBalanceHistoryStore.priorMonthBalances(baseDate);
+      await _assetBalanceHistoryStore.recordMonth(baseDate, balances);
+      if (!mounted) {
+        return;
+      }
+      if (_assetDebtTrendPriorBalancesMonth != monthKey ||
+          !_sameDoubleMap(_assetDebtTrendPriorBalances, prior)) {
+        setState(() {
+          _assetDebtTrendPriorBalances = prior;
+          _assetDebtTrendPriorBalancesMonth = monthKey;
+        });
+      }
+    } catch (_) {
+      // 失敗時はシグネチャを解除し、次のビルドで再試行できるようにする。
+      if (_assetDebtTrendSyncedSignature == signature) {
+        _assetDebtTrendSyncedSignature = null;
+      }
+    }
   }
 
   Map<String, String> _migrateStringMapKeysAndValues(
@@ -3611,6 +3814,371 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  void _ensureKonbiniUdonSnapshotLoaded(double remainingDebt) {
+    final loadedForDebt = _konbiniUdonLoadedForDebt;
+    if (_isLoadingKonbiniUdon) {
+      return;
+    }
+    if (loadedForDebt != null && (loadedForDebt - remainingDebt).abs() < 1) {
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _isLoadingKonbiniUdon) {
+        return;
+      }
+      final latestLoadedDebt = _konbiniUdonLoadedForDebt;
+      if (latestLoadedDebt != null &&
+          (latestLoadedDebt - remainingDebt).abs() < 1) {
+        return;
+      }
+      _loadKonbiniUdonSnapshot(remainingDebt);
+    });
+  }
+
+  Future<void> _loadKonbiniUdonSnapshot(double remainingDebt) async {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isLoadingKonbiniUdon = true;
+    });
+
+    try {
+      final snapshot = await _konbiniUdonChallengeService.loadSnapshot(
+        remainingDebt: remainingDebt,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _konbiniUdonSnapshot = snapshot;
+        _konbiniUdonLoadedForDebt = remainingDebt;
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingKonbiniUdon = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _setKonbiniUdonEnabled(
+    bool enabled,
+    double remainingDebt,
+  ) async {
+    final snapshot = await _konbiniUdonChallengeService.setEnabled(
+      enabled,
+      remainingDebt: remainingDebt,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _konbiniUdonSnapshot = snapshot;
+      _konbiniUdonLoadedForDebt = remainingDebt;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(enabled ? 'うどん縛りを開始しました。完済の日まで。' : 'うどん縛りを中断しました'),
+      ),
+    );
+  }
+
+  Future<void> _confirmKonbiniUdonPledge(double remainingDebt) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('うどん縛りの誓い'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                KonbiniUdonChallengeService.pledgeText,
+                style: TextStyle(fontWeight: FontWeight.w700, height: 1.6),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                KonbiniUdonChallengeService.healthDisclaimer,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(dialogContext).colorScheme.onSurfaceVariant,
+                  height: 1.6,
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('やめておく'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('誓う'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) {
+      return;
+    }
+    await _setKonbiniUdonEnabled(true, remainingDebt);
+  }
+
+  Future<void> _toggleKonbiniUdonMeal(
+    KonbiniUdonMealSlot slot,
+    bool ateUdon,
+    double remainingDebt,
+  ) async {
+    final snapshot = await _konbiniUdonChallengeService.toggleMealSlot(
+      slot,
+      ateUdon,
+      remainingDebt: remainingDebt,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _konbiniUdonSnapshot = snapshot;
+      _konbiniUdonLoadedForDebt = remainingDebt;
+    });
+  }
+
+  Future<void> _recordKonbiniUdonViolation({
+    required String note,
+    required double amount,
+    KonbiniUdonMealSlot? slot,
+    required double remainingDebt,
+  }) async {
+    final snapshot = await _konbiniUdonChallengeService.recordViolation(
+      note: note,
+      amount: amount,
+      slot: slot,
+      remainingDebt: remainingDebt,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _konbiniUdonSnapshot = snapshot;
+      _konbiniUdonLoadedForDebt = remainingDebt;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('うどん以外の食事を記録しました。明日また縛り直しです。')),
+    );
+  }
+
+  Future<void> _showKonbiniUdonViolationDialog(double remainingDebt) async {
+    KonbiniUdonMealSlot? selectedSlot;
+    final noteController = TextEditingController();
+    final amountController = TextEditingController();
+
+    try {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => StatefulBuilder(
+          builder: (dialogContext, setDialogState) => AlertDialog(
+            title: const Text('うどん以外を食べた記録'),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  DropdownButtonFormField<KonbiniUdonMealSlot?>(
+                    initialValue: selectedSlot,
+                    decoration: const InputDecoration(
+                      labelText: 'どの食事か',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    items: [
+                      for (final slot in KonbiniUdonMealSlot.values)
+                        DropdownMenuItem<KonbiniUdonMealSlot?>(
+                          value: slot,
+                          child: Text('${slot.label}食'),
+                        ),
+                      const DropdownMenuItem<KonbiniUdonMealSlot?>(
+                        value: null,
+                        child: Text('間食・その他'),
+                      ),
+                    ],
+                    onChanged: (value) {
+                      setDialogState(() {
+                        selectedSlot = value;
+                      });
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: noteController,
+                    minLines: 2,
+                    maxLines: 4,
+                    decoration: const InputDecoration(
+                      labelText: '何を食べたか',
+                      hintText: '例: 我慢できずに牛丼を食べた',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: amountController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(
+                      labelText: '支払額（任意）',
+                      hintText: '0',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext, false),
+                child: const Text('キャンセル'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(dialogContext, true),
+                child: const Text('記録'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      if (confirmed != true) {
+        return;
+      }
+
+      final note = noteController.text.trim();
+      if (note.isEmpty) {
+        if (!mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('何を食べたか入力してください')));
+        return;
+      }
+
+      final amount =
+          double.tryParse(amountController.text.replaceAll(',', '').trim()) ??
+              0;
+      await _recordKonbiniUdonViolation(
+        note: note,
+        amount: amount,
+        slot: selectedSlot,
+        remainingDebt: remainingDebt,
+      );
+    } finally {
+      noteController.dispose();
+      amountController.dispose();
+    }
+  }
+
+  Future<void> _showKonbiniUdonConfigDialog(double remainingDebt) async {
+    final config =
+        _konbiniUdonSnapshot?.config ?? KonbiniUdonChallengeConfig.defaults;
+    final priceController = TextEditingController(
+      text: config.udonUnitPrice.round().toString(),
+    );
+    final baselineController = TextEditingController(
+      text: config.baselineMonthlyFoodCost.round().toString(),
+    );
+
+    try {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('うどん縛りの前提を調整'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: priceController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: 'コンビニうどん1食の価格（円）',
+                    helperText: 'トッピング込みの実勢価格に合わせて調整',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: baselineController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: '縛りなしの月間食費（円）',
+                    helperText: '目安: 総務省家計調査の単身世帯食料費 約45,000円',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('キャンセル'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: const Text('保存'),
+            ),
+          ],
+        ),
+      );
+
+      if (confirmed != true) {
+        return;
+      }
+
+      final price = double.tryParse(
+        priceController.text.replaceAll(',', '').trim(),
+      );
+      final baseline = double.tryParse(
+        baselineController.text.replaceAll(',', '').trim(),
+      );
+      if (price == null || baseline == null) {
+        if (!mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('数値で入力してください')));
+        return;
+      }
+
+      final snapshot = await _konbiniUdonChallengeService.updateConfig(
+        udonUnitPrice: price,
+        baselineMonthlyFoodCost: baseline,
+        remainingDebt: remainingDebt,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _konbiniUdonSnapshot = snapshot;
+        _konbiniUdonLoadedForDebt = remainingDebt;
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('うどん縛りの前提を更新しました')));
+    } finally {
+      priceController.dispose();
+      baselineController.dispose();
+    }
+  }
+
   Future<void> _showDebtPlanDialog() async {
     final monthlyBudgetController = TextEditingController();
     final extraBudgetController = TextEditingController(text: '0');
@@ -3644,10 +4212,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         value: 'avalanche',
                         child: Text('高金利優先（アバランチ）'),
                       ),
-                      DropdownMenuItem(
-                        value: 'dueDate',
-                        child: Text('支払日順'),
-                      ),
+                      DropdownMenuItem(value: 'dueDate', child: Text('支払日順')),
                       DropdownMenuItem(
                         value: 'hybrid',
                         child: Text('ハイブリッド（高金利×少額）'),
@@ -3776,6 +4341,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       actualPaymentAmounts: _actualPaymentAmounts,
       paymentDifferenceReasons: _paymentDifferenceReasons,
       annualRateOverrides: _annualRateOverrides,
+      paymentDayOverrides: _debtPaymentDayOverrides,
       paidAccountNames: _monthlyPaidAccountNames,
       paymentSourceAccountIds: _paymentSourceAccountIds,
       defaultPaymentSourceAccountIds: _defaultPaymentSourceAccountIds,
@@ -4825,13 +5391,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _quickUpdateAssetData(String type) async {
     final today = _todayDateKey();
     final lastDate = _lastUpdatedDates[type];
-    if (lastDate == null ||
-        lastDate == today ||
-        lastDate != _yesterdayDateKey()) {
+    if (lastDate == null || lastDate == today) {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('$type は昨日の記録がある場合のみ簡易更新できます')));
+      ).showSnackBar(SnackBar(content: Text('$type は過去の記録がある場合のみ簡易更新できます')));
       return;
     }
 
@@ -4847,7 +5411,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     await _recordAssetAmountForToday(
       type,
       lastAmount,
-      successMessage: '✅ $type を昨日と同額で簡易更新しました',
+      successMessage: '✅ $type を前回と同額で簡易更新しました',
     );
   }
 
@@ -5543,6 +6107,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         setState(() {
           _recentFlows = List<Map<String, dynamic>>.from(data);
         });
+        unawaited(
+          _resolveInitialDisplayMode(
+            hasExistingData:
+                _recentFlows.isNotEmpty || _subscriptions.isNotEmpty,
+          ),
+        );
       }
     } catch (e) {
       debugPrint('Error fetching flows: $e');
@@ -5743,31 +6313,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     ].join(':');
   }
 
-  bool _shouldAutoRecordUnknownExpenseFromAssetDrop({
-    required String assetType,
-    required double previousAmount,
-    required double currentAmount,
-  }) {
-    final drop = previousAmount - currentAmount;
-    if (previousAmount <= 0 || drop < 1) {
-      return false;
-    }
-    final key = assetType.toLowerCase();
-    final looksLikeInvestment = key.contains('証券') ||
-        key.contains('株') ||
-        key.contains('投資') ||
-        key.contains('nisa') ||
-        key.contains('securities') ||
-        key.contains('stock') ||
-        key.contains('crypto') ||
-        key.contains('coincheck') ||
-        key.contains('bitflyer');
-    if (looksLikeInvestment) {
-      return false;
-    }
-    return true;
-  }
-
   Future<bool> _autoRecordUnknownExpenseFromAssetDrop({
     required String assetType,
     required String dateKey,
@@ -5776,7 +6321,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }) async {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null ||
-        !_shouldAutoRecordUnknownExpenseFromAssetDrop(
+        !AssetUnknownExpenseRuleService.shouldAutoRecordFromAssetDrop(
           assetType: assetType,
           previousAmount: previousAmount,
           currentAmount: currentAmount,
@@ -6807,6 +7352,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       actualPaymentAmounts: _actualPaymentAmounts,
       paymentDifferenceReasons: _paymentDifferenceReasons,
       annualRateOverrides: _annualRateOverrides,
+      paymentDayOverrides: _debtPaymentDayOverrides,
       paidAccountNames: _monthlyPaidAccountNames,
       billingConfirmedAccountIds: _billingConfirmedAccountIds,
       paymentSourceAccountIds: _paymentSourceAccountIds,
@@ -6842,40 +7388,2404 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _buildUnifiedEntryBanner(),
               const SizedBox(height: 16),
             ],
-            _buildMonthlyFlowFirstCard(),
-            const SizedBox(height: 16),
-            _buildSalarySpendingBreakdownCard(),
-            const SizedBox(height: 16),
-            _buildDisposableBalanceCard(),
-            const SizedBox(height: 16),
-            _buildMonthlyFlowPrimaryActionBar(),
-            const SizedBox(height: 16),
-            _buildWasteTrainingAiCard(),
-            const SizedBox(height: 24),
-            _buildDeadlineChecklistCard(), // 締切チェックリスト
-            const SizedBox(height: 16),
-            _buildThreeMonthOverviewCard(), // 3ヶ月俯瞰
-            const SizedBox(height: 16),
-            _buildDebtPlannerCard(assetLiabilityWorkbook), // 借金返済プラン
-            const SizedBox(height: 16),
-            _buildAssetLiabilityWorkbookBoard(assetLiabilityWorkbook),
-            const SizedBox(height: 16),
-            Container(
-              key: _keyStock,
-              child: _buildAssetLiabilityCard(),
-            ), // ①②資産負債
-            const SizedBox(height: 24),
-            Container(key: _keyFlow, child: _buildFlowCard()), // ④収支
-            const SizedBox(height: 24),
-            Container(key: _keySubs, child: _buildSubscriptionCard()), // ③固定費
-            const SizedBox(height: 24),
-            Container(key: _keyMust, child: _buildMustTasksCard()), // ⑤必須タスク
-            const SizedBox(height: 24),
-            _buildChartCard(), // グラフ
+            _buildDisplayModeSwitcher(),
+            const SizedBox(height: 12),
+            if (_isSectionShown(AssetManagementSectionId.monthlyFlow)) ...[
+              _buildMonthlyFlowFirstCard(),
+              const SizedBox(height: 16),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.calendar)) ...[
+              _buildAssetCalendarCard(assetLiabilityWorkbook),
+              const SizedBox(height: 16),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.salaryBreakdown)) ...[
+              _buildSalarySpendingBreakdownCard(),
+              const SizedBox(height: 16),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.disposable)) ...[
+              _buildDisposableBalanceCard(),
+              const SizedBox(height: 16),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.quickActions)) ...[
+              _buildMonthlyFlowPrimaryActionBar(),
+              const SizedBox(height: 16),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.wasteAi)) ...[
+              _buildWasteTrainingAiCard(),
+              const SizedBox(height: 24),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.deadlines)) ...[
+              _buildDeadlineChecklistCard(), // 締切チェックリスト
+              const SizedBox(height: 16),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.threeMonth)) ...[
+              _buildThreeMonthOverviewCard(), // 3ヶ月俯瞰
+              const SizedBox(height: 16),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.debtPlanner)) ...[
+              _buildDebtPlannerCard(assetLiabilityWorkbook), // 借金返済プラン
+              const SizedBox(height: 16),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.workbookBoard)) ...[
+              _buildAssetLiabilityWorkbookBoard(assetLiabilityWorkbook),
+              const SizedBox(height: 16),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.assetLiability)) ...[
+              Container(
+                key: _keyStock,
+                child: _buildAssetLiabilityCard(),
+              ), // ①②資産負債
+              const SizedBox(height: 24),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.flow)) ...[
+              Container(key: _keyFlow, child: _buildFlowCard()), // ④収支
+              const SizedBox(height: 24),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.subscriptions)) ...[
+              Container(key: _keySubs, child: _buildSubscriptionCard()), // ③固定費
+              const SizedBox(height: 24),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.mustTasks)) ...[
+              Container(key: _keyMust, child: _buildMustTasksCard()), // ⑤必須タスク
+              const SizedBox(height: 24),
+            ],
+            if (_isSectionShown(AssetManagementSectionId.chart))
+              _buildChartCard(), // グラフ
           ],
         ),
       ),
     );
+  }
+
+  bool _isSectionShown(AssetManagementSectionId section) {
+    final override = _sectionOverrides[section] ??
+        AssetManagementSectionVisibilityOverride.auto;
+    return AssetManagementDisplayModeStore.isSectionVisible(
+      section: section,
+      mode: _displayMode,
+      override: override,
+    );
+  }
+
+  Future<void> _loadMainAccount() async {
+    try {
+      final id = await _mainAccountStore.load();
+      if (!mounted || id == _assetManagementMainAccountId) {
+        return;
+      }
+      setState(() {
+        _assetManagementMainAccountId = id;
+      });
+    } catch (e) {
+      debugPrint('Error loading main account: $e');
+    }
+  }
+
+  Future<void> _setMainAccount(String? accountId) async {
+    setState(() {
+      _assetManagementMainAccountId = accountId;
+    });
+    try {
+      await _mainAccountStore.save(accountId);
+    } catch (e) {
+      debugPrint('Error saving main account: $e');
+    }
+  }
+
+  Future<void> _loadDisplayMode() async {
+    final mode = await _displayModeStore.load();
+    final overrides = await _displayModeStore.loadOverrides();
+    final hadStored = await _displayModeStore.hasStoredMode();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _displayMode = mode;
+      _sectionOverrides = overrides;
+    });
+    unawaited(_refreshDisplayModeStats());
+    if (!hadStored && overrides.isEmpty) {
+      unawaited(_restoreDisplayPrefsFromMirror());
+    } else {
+      unawaited(_checkDisplayPrefsMirrorNewer());
+    }
+  }
+
+  Future<void> _applyDisplayPrefs(
+    AssetManagementDisplayMode? mode,
+    AssetManagementSectionOverrides? overrides,
+  ) async {
+    if (mode != null && mode != _displayMode) {
+      setState(() {
+        _displayMode = mode;
+      });
+      await _displayModeStore.save(mode, recordEvent: false);
+    }
+    if (overrides != null) {
+      for (final entry in overrides.entries) {
+        final saved = await _displayModeStore.saveOverride(
+          entry.key,
+          entry.value,
+        );
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _sectionOverrides = saved;
+        });
+      }
+    }
+  }
+
+  /// 他端末がミラーを更新していたら、自動適用せず通知して選ばせる。
+  /// 判定は AssetManagementDisplayModeStore.evaluateMirrorPrefRows に委譲。
+  Future<void> _checkDisplayPrefsMirrorNewer() async {
+    final debugRows = widget.debugMirrorPrefsRows;
+    if (_supabase.auth.currentUser == null && debugRows == null) {
+      return;
+    }
+    try {
+      final stats = await _displayModeStore.loadStats();
+      final deletedSectionIds = await _displayModeStore.loadDeletedSectionIds();
+      final rows = debugRows ?? await _fetchDisplayPrefRows();
+      if (rows.isEmpty || !mounted) {
+        return;
+      }
+      final diff = AssetManagementDisplayModeStore.evaluateMirrorPrefRows(
+        rows: rows,
+        currentMode: _displayMode,
+        currentOverrides: _sectionOverrides,
+        localChangedAt: stats.lastChangedAt,
+        deletedSectionIds: deletedSectionIds,
+      );
+      if (diff.isEmpty || !mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          duration: const Duration(seconds: 8),
+          content: const Text('他端末で表示設定が更新されています'),
+          action: SnackBarAction(
+            label: '取り込む',
+            onPressed: () => unawaited(_showMirrorDiffPreview(diff)),
+          ),
+        ),
+      );
+    } catch (e) {
+      debugPrint('display pref mirror check failed: $e');
+    }
+  }
+
+  /// 取り込み前に「旧 → 新」を見せて確定させる差分プレビュー。
+  Future<void> _showMirrorDiffPreview(AssetMirrorPrefsDiff diff) async {
+    if (!mounted) {
+      return;
+    }
+    final lines = AssetManagementDisplayModeStore.describeMirrorPrefsDiff(
+      currentMode: _displayMode,
+      currentOverrides: _sectionOverrides,
+      diff: diff,
+    );
+    if (lines.isEmpty) {
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('表示設定の取り込みプレビュー'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (final line in lines)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(
+                  line,
+                  style: const TextStyle(fontSize: 12, height: 1.5),
+                ),
+              ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            key: const Key('asset_mirror_diff_apply'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('適用する'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      await _applyDisplayPrefs(diff.mode, diff.overrides);
+    }
+  }
+
+  /// 表示設定を集約する 1 行 jsonb の pref_key (#part293)。
+  static const String _displayPrefsAggregatedKey = 'asset_display_prefs_v1';
+
+  Future<void> _mirrorDisplayPrefs() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final now = DateTime.now().toUtc().toIso8601String();
+      // #part293: display_mode / section_overrides / section_override_deleted を
+      // 1 行 jsonb (asset_display_prefs_v1) へ集約し upsert を 1 回に削減。
+      final aggregated =
+          AssetManagementDisplayModeStore.buildAggregatedMirrorValue(
+        mode: _displayMode,
+        overrides: _sectionOverrides,
+        deletedIds: await _displayModeStore.loadDeletedSectionIds(),
+      );
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _displayPrefsAggregatedKey,
+        'value': aggregated,
+        'updated_at': now,
+      });
+      // #part294: 集約済みなので legacy per-key 行を best-effort で掃除する
+      // (移行完了後に読みフォールバックを撤去するための前段。詳細は
+      // docs/MIRROR_PREF_AGGREGATION_MIGRATION.md)。
+      unawaited(_cleanupLegacyDisplayPrefRows());
+    } catch (e) {
+      debugPrint('display pref mirror upsert failed: $e');
+    }
+  }
+
+  /// 集約行へ移行済みの legacy per-key 行を削除する (best-effort / #part294)。
+  Future<void> _cleanupLegacyDisplayPrefRows() async {
+    try {
+      await _supabase.from('asset_pref_mirror').delete().inFilter(
+        'pref_key',
+        <String>[
+          'display_mode',
+          'section_overrides',
+          'section_override_deleted'
+        ],
+      );
+    } catch (e) {
+      debugPrint('legacy display pref cleanup failed: $e');
+    }
+  }
+
+  /// 集約行を優先し、無ければ legacy per-key 行を per-key 形へ正規化して返す。
+  Future<List<Map<String, dynamic>>> _fetchDisplayPrefRows() async {
+    final rows = List<Map<String, dynamic>>.from(
+      await _supabase.from('asset_pref_mirror').select().inFilter(
+        'pref_key',
+        <String>[
+          _displayPrefsAggregatedKey,
+          'display_mode',
+          'section_overrides',
+        ],
+      ),
+    );
+    for (final row in rows) {
+      if (row['pref_key'] == _displayPrefsAggregatedKey) {
+        return AssetManagementDisplayModeStore.aggregatedMirrorToRows(
+          row['value'],
+          updatedAt: row['updated_at']?.toString() ??
+              DateTime.now().toUtc().toIso8601String(),
+        );
+      }
+    }
+    return rows
+        .where((row) => row['pref_key'] != _displayPrefsAggregatedKey)
+        .toList();
+  }
+
+  /// 他端末で「自動へ戻した(削除した)」セクション上書きを取り込み、
+  /// ローカルからも除去する (削除伝播 / #part292)。
+  Future<void> _pullDeletedSectionIds() async {
+    final debugMirror = widget.debugSectionOverrideDeletedMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final List<String> ids;
+      if (debugMirror != null) {
+        ids = AssetManagementDisplayModeStore.decodeDeletedSectionIdsMirror(
+          debugMirror,
+        );
+      } else {
+        // 集約行 (asset_display_prefs_v1) を優先、無ければ legacy 行。
+        final rows =
+            await _supabase.from('asset_pref_mirror').select().inFilter(
+          'pref_key',
+          <String>[_displayPrefsAggregatedKey, 'section_override_deleted'],
+        );
+        Map<String, dynamic>? aggregated;
+        Map<String, dynamic>? legacy;
+        for (final row in rows) {
+          if (row['pref_key'] == _displayPrefsAggregatedKey) {
+            aggregated = row;
+          } else if (row['pref_key'] == 'section_override_deleted') {
+            legacy = row;
+          }
+        }
+        if (aggregated != null) {
+          ids = AssetManagementDisplayModeStore.aggregatedDeletedSectionIds(
+            aggregated['value'],
+          );
+        } else if (legacy != null && legacy['value'] is Map) {
+          ids = AssetManagementDisplayModeStore.decodeDeletedSectionIdsMirror(
+            Map<String, dynamic>.from(legacy['value'] as Map),
+          );
+        } else {
+          return;
+        }
+      }
+      if (ids.isEmpty) {
+        return;
+      }
+      final removed = await _displayModeStore.applyRemoteDeletedSectionIds(ids);
+      if (removed > 0 && mounted) {
+        final overrides = await _displayModeStore.loadOverrides();
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _sectionOverrides = overrides;
+        });
+      }
+    } catch (e) {
+      debugPrint('section override tombstone pull failed: $e');
+    }
+  }
+
+  Future<void> _restoreDisplayPrefsFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    if (await _displayModeStore.isRestoreDeclined()) {
+      return;
+    }
+    try {
+      final rows = await _fetchDisplayPrefRows();
+      if (rows.isEmpty || !mounted) {
+        return;
+      }
+
+      AssetManagementDisplayMode? pendingMode;
+      final pendingOverrides = <AssetManagementSectionId,
+          AssetManagementSectionVisibilityOverride>{};
+      for (final row in rows) {
+        final value = row['value'];
+        if (value is! Map) {
+          continue;
+        }
+        if (row['pref_key'] == 'display_mode') {
+          final raw = value['mode']?.toString();
+          for (final mode in AssetManagementDisplayMode.values) {
+            if (mode.storageId == raw && mode != _displayMode) {
+              pendingMode = mode;
+            }
+          }
+        }
+        if (row['pref_key'] == 'section_overrides') {
+          for (final entry in value.entries) {
+            AssetManagementSectionId? section;
+            for (final candidate in AssetManagementSectionId.values) {
+              if (candidate.storageId == entry.key.toString()) {
+                section = candidate;
+              }
+            }
+            AssetManagementSectionVisibilityOverride? override;
+            for (final candidate
+                in AssetManagementSectionVisibilityOverride.values) {
+              if (candidate.storageId == entry.value.toString()) {
+                override = candidate;
+              }
+            }
+            if (section == null ||
+                override == null ||
+                override == AssetManagementSectionVisibilityOverride.auto) {
+              continue;
+            }
+            pendingOverrides[section] = override;
+          }
+        }
+      }
+      if (pendingMode == null && pendingOverrides.isEmpty) {
+        return;
+      }
+      if (!mounted) {
+        return;
+      }
+
+      // 他端末の設定で不意に上書きしないよう、適用前に必ず確認する。
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('表示設定のバックアップ'),
+          content: Text(
+            'サーバに表示設定のバックアップがあります'
+            '${pendingMode == null ? '' : '(表示モード: ${pendingMode.label})'}。'
+            'この端末に適用しますか?適用しない場合、次回以降は確認しません。',
+          ),
+          actions: [
+            TextButton(
+              key: const Key('asset_display_restore_decline'),
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('適用しない'),
+            ),
+            ElevatedButton(
+              key: const Key('asset_display_restore_accept'),
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: const Text('適用する'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) {
+        await _displayModeStore.markRestoreDeclined();
+        return;
+      }
+      if (!mounted) {
+        return;
+      }
+
+      if (pendingMode != null) {
+        setState(() {
+          _displayMode = pendingMode!;
+        });
+        await _displayModeStore.save(pendingMode, recordEvent: false);
+      }
+      for (final entry in pendingOverrides.entries) {
+        final overrides = await _displayModeStore.saveOverride(
+          entry.key,
+          entry.value,
+        );
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _sectionOverrides = overrides;
+        });
+      }
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('表示設定をサーバのバックアップから復元しました')),
+        );
+      }
+    } catch (e) {
+      debugPrint('display pref mirror restore failed: $e');
+    }
+  }
+
+  Future<void> _refreshDisplayModeStats() async {
+    final stats = await _displayModeStore.loadStats();
+    if (!mounted) {
+      return;
+    }
+    final hadData = stats.initialHadData == true ? '既存データあり' : '新規';
+    final initialLabel = stats.initialMode == null
+        ? '初期解決なし'
+        : '初期=${stats.initialMode}($hadData)';
+    setState(() {
+      _displayModeStatsLabel = '$initialLabel / 切替 ${stats.switchCount}回';
+    });
+  }
+
+  Future<void> _loadExpectedInflows() async {
+    final entries = await _expectedInflowStore.loadAll();
+    final rules = await _expectedInflowStore.loadRules();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _expectedInflows = entries;
+      _expectedInflowRules = rules;
+    });
+    if (entries.isEmpty && rules.isEmpty) {
+      unawaited(_restoreInflowsFromMirror());
+    }
+  }
+
+  Future<void> _removeExpectedInflowRule(String id) async {
+    final rules = await _expectedInflowStore.removeRule(id);
+    unawaited(_deleteInflowMirror(id));
+    unawaited(_mirrorInflowDeletedIds());
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _expectedInflowRules = rules;
+    });
+  }
+
+  DateTime _nextSalaryDate() {
+    final now = DateTime.now();
+    final thisMonth = DateTime(now.year, now.month, _salarySpendingSalaryDay);
+    if (!now.isAfter(thisMonth)) {
+      return thisMonth;
+    }
+    return DateTime(now.year, now.month + 1, _salarySpendingSalaryDay);
+  }
+
+  Future<void> _sendDisplayModeEvent({
+    required String eventType,
+    required AssetManagementDisplayMode mode,
+    bool? hasData,
+  }) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('display_mode_events').insert(<String, dynamic>{
+        'user_id': userId,
+        'event_type': eventType,
+        'mode': mode.storageId,
+        'has_data': hasData,
+      });
+    } catch (e) {
+      debugPrint('display_mode_events insert failed: $e');
+    }
+  }
+
+  Future<void> _removeExpectedInflow(String id) async {
+    final entries = await _expectedInflowStore.remove(id);
+    unawaited(_deleteInflowMirror(id));
+    unawaited(_mirrorInflowDeletedIds());
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _expectedInflows = entries;
+    });
+  }
+
+  void _prefillFlowDateFromCalendar(DateTime date) {
+    setState(() {
+      _selectedFlowDate = date;
+    });
+    final dateLabel = DateFormat('M月d日').format(date);
+    if (_isSectionShown(AssetManagementSectionId.flow)) {
+      _scrollTo(_keyFlow);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('$dateLabelを記録日にセットしました')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('$dateLabelを記録日にセットしました。収支セクション(標準/フル)で記録できます'),
+        ),
+      );
+    }
+  }
+
+  Future<void> _showAddExpectedInflowDialog(
+    DateTime initialDate, {
+    double? initialAmount,
+    String? initialLabel,
+  }) async {
+    var selectedDate = initialDate;
+    var repeatMonthly = false;
+    final amountController = TextEditingController(
+      text: initialAmount != null && initialAmount > 0
+          ? initialAmount.round().toString()
+          : '',
+    );
+    final labelController = TextEditingController(text: initialLabel ?? '');
+
+    try {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => StatefulBuilder(
+          builder: (dialogContext, setDialogState) => AlertDialog(
+            title: const Text('入金予定を追加'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        DateFormat('yyyy/MM/dd').format(selectedDate),
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w700,
+                          height: 1.4,
+                        ),
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: () async {
+                        final picked = await showDatePicker(
+                          context: dialogContext,
+                          initialDate: selectedDate,
+                          firstDate: DateTime(2020),
+                          lastDate: DateTime(2035),
+                        );
+                        if (picked == null) {
+                          return;
+                        }
+                        setDialogState(() {
+                          selectedDate = picked;
+                        });
+                      },
+                      child: const Text('日付変更'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: amountController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: '金額(円)',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: labelController,
+                  decoration: const InputDecoration(
+                    labelText: 'メモ(例: 給料、フリマ売上)',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                CheckboxListTile(
+                  key: const Key('asset_inflow_repeat_checkbox'),
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                  controlAffinity: ListTileControlAffinity.leading,
+                  value: repeatMonthly,
+                  onChanged: (value) {
+                    setDialogState(() {
+                      repeatMonthly = value ?? false;
+                    });
+                  },
+                  title: const Text(
+                    '毎月この日に繰り返す(給料など)',
+                    style: TextStyle(fontSize: 12),
+                  ),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext, false),
+                child: const Text('キャンセル'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(dialogContext, true),
+                child: const Text('追加'),
+              ),
+            ],
+          ),
+        ),
+      );
+      if (confirmed != true) {
+        return;
+      }
+      final amount = double.tryParse(
+        amountController.text.replaceAll(',', '').trim(),
+      );
+      if (amount == null || amount <= 0) {
+        if (!mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('金額を1円以上で入力してください')));
+        return;
+      }
+      if (repeatMonthly) {
+        final beforeRuleIds =
+            _expectedInflowRules.map((rule) => rule.id).toSet();
+        final rules = await _expectedInflowStore.addRule(
+          dayOfMonth: selectedDate.day,
+          amount: amount,
+          label: labelController.text,
+        );
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _expectedInflowRules = rules;
+        });
+        for (final rule in rules) {
+          if (!beforeRuleIds.contains(rule.id)) {
+            unawaited(
+              _mirrorInflowToSupabase(<String, dynamic>{
+                'id': rule.id,
+                'kind': 'rule',
+                'day_of_month': rule.dayOfMonth,
+                'amount': rule.amount,
+                'label': rule.label,
+              }),
+            );
+          }
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('毎月${selectedDate.day}日の入金予定を登録しました')),
+        );
+        return;
+      }
+      final beforeIds = _expectedInflows.map((entry) => entry.id).toSet();
+      final entries = await _expectedInflowStore.add(
+        date: selectedDate,
+        amount: amount,
+        label: labelController.text,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _expectedInflows = entries;
+      });
+      for (final entry in entries) {
+        if (!beforeIds.contains(entry.id)) {
+          unawaited(
+            _mirrorInflowToSupabase(<String, dynamic>{
+              'id': entry.id,
+              'kind': 'one_time',
+              'date': DateFormat('yyyy-MM-dd').format(entry.date),
+              'amount': entry.amount,
+              'label': entry.label,
+            }),
+          );
+        }
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('入金予定を追加しました。見込み残高に反映されます')));
+    } finally {
+      amountController.dispose();
+      labelController.dispose();
+    }
+  }
+
+  Future<void> _setDisplayMode(AssetManagementDisplayMode mode) async {
+    if (mode == _displayMode) {
+      return;
+    }
+    setState(() {
+      _displayMode = mode;
+    });
+    await _displayModeStore.save(mode);
+    unawaited(_sendDisplayModeEvent(eventType: 'switch', mode: mode));
+    unawaited(_mirrorDisplayPrefs());
+    await _refreshDisplayModeStats();
+  }
+
+  Future<void> _resolveInitialDisplayMode({
+    required bool hasExistingData,
+  }) async {
+    final hadStored = await _displayModeStore.hasStoredMode();
+    final mode = await _displayModeStore.resolveInitialMode(
+      hasExistingData: hasExistingData,
+    );
+    if (!hadStored) {
+      unawaited(
+        _sendDisplayModeEvent(
+          eventType: 'initial',
+          mode: mode,
+          hasData: hasExistingData,
+        ),
+      );
+    }
+    if (!mounted) {
+      return;
+    }
+    unawaited(_refreshDisplayModeStats());
+    if (mode == _displayMode) {
+      return;
+    }
+    setState(() {
+      _displayMode = mode;
+    });
+  }
+
+  Future<void> _setSectionOverride(
+    AssetManagementSectionId section,
+    AssetManagementSectionVisibilityOverride override,
+  ) async {
+    final overrides = await _displayModeStore.saveOverride(section, override);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _sectionOverrides = overrides;
+    });
+    unawaited(_mirrorDisplayPrefs());
+  }
+
+  Future<void> _fetchExperimentSummary() async {
+    try {
+      final dynamic result =
+          await _supabase.rpc('display_mode_experiment_summary');
+      if (!mounted || result is! Map) {
+        return;
+      }
+      final data = Map<String, dynamic>.from(result);
+      final parsed = AssetManagementDisplayModeStore.parseServerSummary(data);
+      setState(() {
+        _experimentServerSummary = parsed.summaryLabel;
+        _experimentWeekly = parsed.weekly;
+      });
+    } catch (e) {
+      debugPrint('experiment summary fetch failed: $e');
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _experimentServerSummary = '全体集計を取得できませんでした(ネットワーク/権限)';
+      });
+    }
+  }
+
+  Future<void> _mirrorInflowToSupabase(Map<String, dynamic> row) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase
+          .from('asset_expected_inflow_items')
+          .upsert(<String, dynamic>{...row, 'user_id': userId});
+    } catch (e) {
+      debugPrint('inflow mirror upsert failed: $e');
+    }
+  }
+
+  Future<void> _deleteInflowMirror(String id) async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_expected_inflow_items').delete().eq('id', id);
+    } catch (e) {
+      debugPrint('inflow mirror delete failed: $e');
+    }
+  }
+
+  void _shiftDebtPaymentAfterSalary(
+    AssetLiabilityWorkbook? workbook,
+    String debtRowId,
+  ) {
+    final rows = workbook?.debtMasterRows ?? const <AssetLiabilityDebtRow>[];
+    AssetLiabilityDebtRow? target;
+    for (final row in rows) {
+      if (row.id == debtRowId) {
+        target = row;
+      }
+    }
+    if (target == null) {
+      return;
+    }
+    const newDay = _salarySpendingSalaryDay + 1;
+    _setDebtPaymentDayOverride(target, newDay);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          '${target.name} の支払日を毎月$newDay日へ変更しました(負債マスタの支払日設定から戻せます)',
+        ),
+      ),
+    );
+  }
+
+  String _shiftPreviewLabel({
+    required AssetCalendarEvent event,
+    required AssetPaymentCalendarMonth calendar,
+    required List<AssetCalendarDebtInput> debts,
+    required List<Map<String, dynamic>> subscriptions,
+    required List<AssetCalendarInflowInput> inflows,
+    required double? startingCashBalance,
+  }) {
+    const newDay = _salarySpendingSalaryDay + 1;
+    final shifted = AssetPaymentCalendarService.buildMonth(
+      month: _calendarMonth,
+      flows: _recentFlows,
+      subscriptions: subscriptions,
+      debts: [
+        for (final debt in debts)
+          if (debt.id == event.sourceId)
+            AssetCalendarDebtInput(
+              id: debt.id,
+              name: debt.name,
+              balance: debt.balance,
+              paymentDay: newDay,
+              scheduledPaymentAmount: debt.scheduledPaymentAmount,
+              isDirectCashflowTarget: debt.isDirectCashflowTarget,
+            )
+          else
+            debt,
+      ],
+      salaryDay: _salarySpendingSalaryDay,
+      startingCashBalance: startingCashBalance,
+      expectedInflows: inflows,
+    );
+    final shiftedShortfall = shifted.firstShortfallDate;
+    if (shiftedShortfall == null) {
+      return '(回避できます)';
+    }
+    final currentShortfall = calendar.firstShortfallDate;
+    if (currentShortfall != null &&
+        shiftedShortfall.isAfter(currentShortfall)) {
+      return '(${DateFormat('M/d').format(shiftedShortfall)}へ後退)';
+    }
+    return '(単独では回避不可)';
+  }
+
+  Future<void> _restoreInflowsFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase.from('asset_expected_inflow_items').select();
+      final restored = await _expectedInflowStore.restoreFromMirrorRows(
+        List<Map<String, dynamic>>.from(rows),
+      );
+      if (!restored || !mounted) {
+        return;
+      }
+      await _loadExpectedInflows();
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('入金予定をサーバのバックアップから復元しました')),
+      );
+    } catch (e) {
+      debugPrint('inflow mirror restore failed: $e');
+    }
+  }
+
+  Future<void> _mirrorDebtPaymentDayOverrides(
+    Map<String, int> overrides,
+  ) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': 'debt_payment_day_overrides',
+        'value': overrides,
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('pref mirror upsert failed: $e');
+    }
+  }
+
+  Future<void> _restoreDebtPaymentDayOverridesFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', 'debt_payment_day_overrides');
+      if (rows.isEmpty || !mounted) {
+        return;
+      }
+      final value = rows.first['value'];
+      if (value is! Map) {
+        return;
+      }
+      // 削除トゥームストーン済みの支払日上書きは復元しない (#part293 3例目)。
+      final tombstoned = _debtOverrideTombstones.activeIds(
+        await SharedPreferences.getInstance(),
+      );
+      final restored = <String, int>{};
+      value.forEach((key, dynamic raw) {
+        final day = (raw as num?)?.toInt();
+        if (key is String &&
+            day != null &&
+            day >= 1 &&
+            day <= 31 &&
+            !tombstoned.contains(key)) {
+          restored[key] = day;
+        }
+      });
+      if (restored.isEmpty || _debtPaymentDayOverrides.isNotEmpty || !mounted) {
+        return;
+      }
+      setState(() {
+        _debtPaymentDayOverrides = restored;
+      });
+      unawaited(_saveDebtPaymentDayOverrides());
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('支払日設定をサーバのバックアップから復元しました')),
+      );
+    } catch (e) {
+      debugPrint('pref mirror restore failed: $e');
+    }
+  }
+
+  /// 入金予定のミラー取り込みプレビュー行を組み立てる。
+  String _inflowMergeRowLabel(Map<String, dynamic> row) {
+    final label = row['label']?.toString() ?? '入金予定';
+    final amount = (row['amount'] as num?)?.toDouble() ?? 0;
+    if (row['kind']?.toString() == 'rule') {
+      final day = (row['day_of_month'] as num?)?.toInt() ?? 0;
+      return '毎月$day日 $label  +${_formatYen(amount)}';
+    }
+    final date = DateTime.tryParse(row['date']?.toString() ?? '')?.toLocal();
+    final when = date == null ? '' : '${DateFormat('M/d').format(date)} ';
+    return '$when$label  +${_formatYen(amount)}';
+  }
+
+  /// 削除トゥームストーンをサーバへ反映 (他端末の削除伝播用 / #part285)。
+  /// 入金 pref を集約する 1 行 jsonb の pref_key (#part294)。
+  static const String _inflowPrefsAggregatedKey = 'asset_inflow_prefs_v1';
+
+  // 削除トゥームストーンと GC 設定の更新は同じ集約行へ書き込む (後方互換維持)。
+  Future<void> _mirrorInflowDeletedIds() => _mirrorInflowPrefs();
+
+  /// 入金 pref (削除トゥームストーン + GC 設定) を 1 行 jsonb へ集約 upsert
+  /// し、legacy per-key 行を best-effort で掃除する (#part294)。
+  Future<void> _mirrorInflowPrefs() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final ids = await _expectedInflowStore.loadDeletedIds();
+      final value = AssetExpectedInflowStore.buildAggregatedInflowMirrorValue(
+        deletedIds: ids,
+        gcConfig: _tombstoneGcConfig,
+      );
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _inflowPrefsAggregatedKey,
+        'value': value,
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+      unawaited(_cleanupLegacyInflowPrefRows());
+    } catch (e) {
+      debugPrint('inflow pref mirror upsert failed: $e');
+    }
+  }
+
+  Future<void> _cleanupLegacyInflowPrefRows() async {
+    try {
+      await _supabase.from('asset_pref_mirror').delete().inFilter(
+        'pref_key',
+        <String>['inflow_deleted_ids', 'inflow_tombstone_gc'],
+      );
+    } catch (e) {
+      debugPrint('legacy inflow pref cleanup failed: $e');
+    }
+  }
+
+  /// サーバのトゥームストーンを取り込み、該当ローカル項目を削除する。
+  Future<void> _pullInflowDeletedIds() async {
+    final debugMirror = widget.debugInflowDeletedIdsMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final List<String> ids;
+      if (debugMirror != null) {
+        ids = AssetExpectedInflowStore.decodeDeletedIdsMirror(debugMirror);
+      } else {
+        // 集約行 (asset_inflow_prefs_v1) を優先、無ければ legacy 行。
+        final rows =
+            await _supabase.from('asset_pref_mirror').select().inFilter(
+          'pref_key',
+          <String>[_inflowPrefsAggregatedKey, 'inflow_deleted_ids'],
+        );
+        Map<String, dynamic>? aggregated;
+        Map<String, dynamic>? legacy;
+        for (final row in rows) {
+          if (row['pref_key'] == _inflowPrefsAggregatedKey) {
+            aggregated = row;
+          } else if (row['pref_key'] == 'inflow_deleted_ids') {
+            legacy = row;
+          }
+        }
+        if (aggregated != null) {
+          ids = AssetExpectedInflowStore.aggregatedInflowDeletedIds(
+            aggregated['value'],
+          );
+        } else if (legacy != null && legacy['value'] is Map) {
+          ids = AssetExpectedInflowStore.decodeDeletedIdsMirror(
+            Map<String, dynamic>.from(legacy['value'] as Map),
+          );
+        } else {
+          return;
+        }
+      }
+      if (ids.isEmpty) {
+        return;
+      }
+      final removed = await _expectedInflowStore.applyRemoteDeletedIds(ids);
+      if (removed > 0 && mounted) {
+        await _loadExpectedInflows();
+      }
+    } catch (e) {
+      debugPrint('inflow tombstone pull failed: $e');
+    }
+  }
+
+  /// トゥームストーン GC の上限/期限をサーバ (asset_pref_mirror) から取得し、
+  /// ストアへ反映する (#part287 リモート調整)。未設定なら既定のまま。
+  Future<void> _initTombstoneGcAndPull() async {
+    await _applyLocalTombstoneGcConfig();
+    await _loadTombstoneGcConfig();
+    await _pullInflowDeletedIds();
+  }
+
+  /// ローカル保存 (またはテスト注入) の GC 設定をストアへ反映する。
+  Future<void> _applyLocalTombstoneGcConfig() async {
+    final config = widget.debugTombstoneGcConfig ??
+        await AssetExpectedInflowStore.loadGcConfig();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _tombstoneGcConfig = config;
+      _expectedInflowStore = AssetExpectedInflowStore(gcConfig: config);
+    });
+  }
+
+  Future<void> _loadTombstoneGcConfig() async {
+    // テスト注入時はサーバ取得を行わない (ネットワーク非依存)。
+    if (widget.debugTombstoneGcConfig != null ||
+        _supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      // 集約行 (asset_inflow_prefs_v1) を優先、無ければ legacy 行。
+      final rows = await _supabase.from('asset_pref_mirror').select().inFilter(
+        'pref_key',
+        <String>[_inflowPrefsAggregatedKey, 'inflow_tombstone_gc'],
+      );
+      Map<String, dynamic>? aggregated;
+      Map<String, dynamic>? legacy;
+      for (final row in rows) {
+        if (row['pref_key'] == _inflowPrefsAggregatedKey) {
+          aggregated = row;
+        } else if (row['pref_key'] == 'inflow_tombstone_gc') {
+          legacy = row;
+        }
+      }
+      final AssetTombstoneGcConfig config;
+      if (aggregated != null) {
+        config = AssetExpectedInflowStore.aggregatedInflowGcConfig(
+          aggregated['value'],
+        );
+      } else if (legacy != null) {
+        config = AssetTombstoneGcConfig.fromMirrorValue(legacy['value']);
+      } else {
+        return;
+      }
+      if (!mounted) {
+        return;
+      }
+      await AssetExpectedInflowStore.saveGcConfig(config);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _tombstoneGcConfig = config;
+        _expectedInflowStore = AssetExpectedInflowStore(gcConfig: config);
+      });
+    } catch (e) {
+      debugPrint('tombstone gc config fetch failed: $e');
+    }
+  }
+
+  /// GC 設定 (上限/期限) の編集ダイアログ。保存でローカル+ミラーへ反映する。
+  /// 手動 GC: 期限切れ・上限超過の削除記録を今すぐ掃除し、件数を SnackBar 表示。
+  Future<void> _pruneTombstonesNow() async {
+    // 入金予定 + 表示設定 override の両トゥームストーンを一括掃除 (#part292)。
+    final removedInflow = await _expectedInflowStore.pruneDeletedIds();
+    final removedOverride = await _displayModeStore.pruneDeletedSectionIds();
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          '古い削除記録を${removedInflow + removedOverride}件 掃除しました',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showTombstoneGcSettings(
+    void Function(void Function()) setOuterState,
+  ) async {
+    final countController = TextEditingController(
+      text: '${_tombstoneGcConfig.maxCount}',
+    );
+    final ageController = TextEditingController(
+      text: '${_tombstoneGcConfig.maxAgeDays}',
+    );
+    final saved = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('削除履歴の保持設定'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              '削除した入金予定の「復活防止」記録を、どれだけ保持するか。',
+              style: TextStyle(fontSize: 12, height: 1.5),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              key: const Key('asset_tombstone_gc_maxcount'),
+              controller: countController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '最大件数'),
+            ),
+            TextField(
+              key: const Key('asset_tombstone_gc_maxage'),
+              controller: ageController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '保持日数'),
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: OutlinedButton.icon(
+                key: const Key('asset_tombstone_gc_prune'),
+                onPressed: () => unawaited(_pruneTombstonesNow()),
+                icon: const Icon(Icons.auto_delete_outlined, size: 16),
+                label: const Text('今すぐ古い記録を掃除'),
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            key: const Key('asset_tombstone_gc_save'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    if (saved != true || !mounted) {
+      return;
+    }
+    final config = AssetTombstoneGcConfig.fromMirrorValue(<String, dynamic>{
+      'max_count': int.tryParse(countController.text.trim()),
+      'max_age_days': int.tryParse(ageController.text.trim()),
+    });
+    await AssetExpectedInflowStore.saveGcConfig(config);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _tombstoneGcConfig = config;
+      _expectedInflowStore = AssetExpectedInflowStore(gcConfig: config);
+    });
+    setOuterState(() {});
+    unawaited(_mirrorInflowPrefs());
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          '保持設定を更新しました(最大${config.maxCount}件 / ${config.maxAgeDays}日)',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _mergeInflowsFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      // 先に他端末の削除を取り込み、復活候補から除外する。
+      await _pullInflowDeletedIds();
+      final rows = List<Map<String, dynamic>>.from(
+        await _supabase.from('asset_expected_inflow_items').select(),
+      );
+      final additions = await _expectedInflowStore.previewMergeAdditions(rows);
+      if (!mounted) {
+        return;
+      }
+      if (additions.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('サーバとの差分はありませんでした')),
+        );
+        return;
+      }
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('サーバから取り込む入金予定'),
+          content: SizedBox(
+            width: 420,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '以下の${additions.length}件をローカルへ追加します(削除済みは復活しません)。',
+                    style: const TextStyle(fontSize: 12, height: 1.5),
+                  ),
+                  const SizedBox(height: 8),
+                  for (final row in additions)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Text(
+                        '・${_inflowMergeRowLabel(row)}',
+                        style: const TextStyle(fontSize: 12, height: 1.4),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('キャンセル'),
+            ),
+            ElevatedButton(
+              key: const Key('asset_inflow_merge_apply'),
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: const Text('取り込む'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) {
+        return;
+      }
+      final added = await _expectedInflowStore.mergeFromMirrorRows(rows);
+      if (added > 0 && mounted) {
+        await _loadExpectedInflows();
+      }
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('$added件をサーバから統合しました')),
+      );
+    } catch (e) {
+      debugPrint('inflow mirror merge failed: $e');
+    }
+  }
+
+  AssetLiabilityDebtRow? _debtRowById(
+    AssetLiabilityWorkbook? workbook,
+    String debtRowId,
+  ) {
+    final rows = workbook?.debtMasterRows ?? const <AssetLiabilityDebtRow>[];
+    for (final row in rows) {
+      if (row.id == debtRowId) {
+        return row;
+      }
+    }
+    return null;
+  }
+
+  void _shiftDebtPaymentsAfterSalaryCombo(
+    AssetLiabilityWorkbook? workbook,
+    List<String> debtRowIds,
+  ) {
+    const newDay = _salarySpendingSalaryDay + 1;
+    var shiftedCount = 0;
+    for (final id in debtRowIds) {
+      final target = _debtRowById(workbook, id);
+      if (target == null) {
+        continue;
+      }
+      _setDebtPaymentDayOverride(target, newDay);
+      shiftedCount += 1;
+    }
+    if (shiftedCount == 0) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          '$shiftedCount件の支払日を毎月$newDay日へまとめて変更しました(負債マスタから戻せます)',
+        ),
+      ),
+    );
+  }
+
+  Widget _buildExperimentTrendBars() {
+    final weeks = _experimentWeekly.reversed.toList(growable: false);
+    var maxTotal = 1;
+    for (final week in weeks) {
+      final initials = (week['initials'] as num?)?.toInt() ?? 0;
+      final switches = (week['switches'] as num?)?.toInt() ?? 0;
+      if (initials + switches > maxTotal) {
+        maxTotal = initials + switches;
+      }
+    }
+    return SizedBox(
+      height: 60,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          for (final week in weeks)
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 2),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Text(
+                      '${(week['initials'] as num?)?.toInt() ?? 0}/${(week['switches'] as num?)?.toInt() ?? 0}',
+                      style: const TextStyle(fontSize: 8, height: 1.2),
+                    ),
+                    Container(
+                      height: 2 +
+                          30 *
+                              ((week['switches'] as num?)?.toInt() ?? 0) /
+                              maxTotal,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF97316),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 1),
+                    Container(
+                      height: 2 +
+                          30 *
+                              ((week['initials'] as num?)?.toInt() ?? 0) /
+                              maxTotal,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF6366F1),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      (week['week_start']?.toString() ?? '').length >= 10
+                          ? week['week_start'].toString().substring(5, 10)
+                          : '',
+                      style: const TextStyle(fontSize: 7, height: 1.2),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showInflowRulesDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (dialogContext, setDialogState) => AlertDialog(
+          title: const Text('毎月の入金ルール'),
+          content: SizedBox(
+            width: 360,
+            child: _expectedInflowRules.isEmpty
+                ? const Text(
+                    'ルールはありません。入金予定ダイアログの「毎月この日に繰り返す」で登録できます。',
+                    style: TextStyle(fontSize: 12, height: 1.5),
+                  )
+                : SingleChildScrollView(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        for (final rule in _expectedInflowRules)
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  '毎月${rule.dayOfMonth}日 ${rule.label} ${_formatYen(rule.amount)}',
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    height: 1.5,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              IconButton(
+                                key: Key(
+                                  'asset_inflow_rule_delete_${rule.id}',
+                                ),
+                                tooltip: '削除',
+                                icon: const Icon(
+                                  Icons.delete_outline,
+                                  size: 18,
+                                ),
+                                onPressed: () async {
+                                  await _removeExpectedInflowRule(rule.id);
+                                  setDialogState(() {});
+                                },
+                              ),
+                            ],
+                          ),
+                      ],
+                    ),
+                  ),
+          ),
+          actions: [
+            TextButton.icon(
+              key: const Key('asset_tombstone_gc_edit'),
+              onPressed: () => _showTombstoneGcSettings(setDialogState),
+              icon: const Icon(Icons.cleaning_services_outlined, size: 16),
+              label: Text(
+                '保持設定 '
+                '(${_tombstoneGcConfig.maxCount}件/${_tombstoneGcConfig.maxAgeDays}日)',
+              ),
+            ),
+            TextButton.icon(
+              key: const Key('asset_inflow_merge_button'),
+              onPressed: () async {
+                await _mergeInflowsFromMirror();
+                setDialogState(() {});
+              },
+              icon: const Icon(Icons.cloud_sync, size: 16),
+              label: const Text('サーバと統合'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('閉じる'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionOverrideDropdown(
+    AssetManagementSectionId section,
+    void Function(void Function()) setDialogState,
+  ) {
+    final current = _sectionOverrides[section] ??
+        AssetManagementSectionVisibilityOverride.auto;
+    return DropdownButton<AssetManagementSectionVisibilityOverride>(
+      key: Key('asset_section_override_${section.storageId}'),
+      value: current,
+      isDense: true,
+      items: [
+        for (final option in AssetManagementSectionVisibilityOverride.values)
+          DropdownMenuItem(
+            value: option,
+            child: Text(option.label, style: const TextStyle(fontSize: 12)),
+          ),
+      ],
+      onChanged: (value) async {
+        if (value == null) {
+          return;
+        }
+        await _setSectionOverride(section, value);
+        setDialogState(() {});
+      },
+    );
+  }
+
+  Future<void> _showSectionCustomizeDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (dialogContext, setDialogState) => AlertDialog(
+          title: const Text('セクション表示のカスタマイズ'),
+          content: SizedBox(
+            width: 360,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (_displayModeStatsLabel != null) ...[
+                    Text(
+                      '実験ログ: $_displayModeStatsLabel',
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                  ],
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          _experimentServerSummary ?? '全体集計は未取得です。',
+                          style: const TextStyle(fontSize: 11, height: 1.5),
+                        ),
+                      ),
+                      TextButton(
+                        key: const Key('asset_experiment_summary_button'),
+                        onPressed: () async {
+                          await _fetchExperimentSummary();
+                          setDialogState(() {});
+                        },
+                        child: const Text('全体集計'),
+                      ),
+                    ],
+                  ),
+                  if (_experimentWeekly.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    _buildExperimentTrendBars(),
+                    const SizedBox(height: 2),
+                    Wrap(
+                      spacing: 10,
+                      children: [
+                        _buildCalendarLegendItem(
+                          const Color(0xFF6366F1),
+                          '初期解決',
+                        ),
+                        _buildCalendarLegendItem(
+                          const Color(0xFFF97316),
+                          '切替',
+                        ),
+                      ],
+                    ),
+                  ],
+                  const SizedBox(height: 6),
+                  Text(
+                    '「自動」は表示モード(ミニマム/標準/フル)に従います。「常に表示」「隠す」はモードより優先されます。',
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: Theme.of(
+                        dialogContext,
+                      ).colorScheme.onSurfaceVariant,
+                      height: 1.5,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  for (final section in AssetManagementSectionId.values)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 6),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              section.label,
+                              style: const TextStyle(fontSize: 12, height: 1.4),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          _buildSectionOverrideDropdown(
+                            section,
+                            setDialogState,
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('閉じる'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDisplayModeSwitcher() {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.tune, size: 18, color: Color(0xFF7C3AED)),
+                const SizedBox(width: 8),
+                const Text(
+                  '表示モード',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    _displayMode.description,
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                TextButton.icon(
+                  key: const Key('asset_section_customize_button'),
+                  onPressed: _showSectionCustomizeDialog,
+                  icon: const Icon(Icons.playlist_add_check, size: 16),
+                  label: const Text('カスタマイズ'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final mode in AssetManagementDisplayMode.values)
+                  ChoiceChip(
+                    key: Key('asset_display_mode_${mode.name}'),
+                    selected: _displayMode == mode,
+                    onSelected: (_) => _setDisplayMode(mode),
+                    selectedColor: const Color(0xFF7C3AED),
+                    labelStyle: TextStyle(
+                      color: _displayMode == mode
+                          ? Colors.white
+                          : Theme.of(context).colorScheme.onSurface,
+                      fontWeight: FontWeight.w700,
+                      height: 1.5,
+                    ),
+                    label: Text(mode.label),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _shiftCalendarMonth(int delta) {
+    setState(() {
+      _calendarMonth = DateTime(
+        _calendarMonth.year,
+        _calendarMonth.month + delta,
+      );
+      _calendarSelectedDate = null;
+    });
+  }
+
+  Widget _buildAssetCalendarCard(AssetLiabilityWorkbook? workbook) {
+    final debtRows =
+        workbook?.debtMasterRows ?? const <AssetLiabilityDebtRow>[];
+    double? startingCashBalance;
+    if (workbook != null) {
+      var liquid = 0.0;
+      for (final account in workbook.accounts) {
+        final isLiquid = account.kind == AssetLiabilityAccountKind.cash ||
+            account.kind == AssetLiabilityAccountKind.deposit;
+        if (isLiquid && account.balance > 0) {
+          liquid += account.balance;
+        }
+      }
+      startingCashBalance = liquid;
+    }
+    final monthInflowEntries = AssetExpectedInflowStore.materializeMonth(
+      oneTime: _expectedInflows,
+      rules: _expectedInflowRules,
+      month: _calendarMonth,
+    );
+    final monthSubscriptions = _subscriptionsForMonth(_calendarMonth);
+    final debtInputs = <AssetCalendarDebtInput>[
+      for (final row in debtRows)
+        AssetCalendarDebtInput(
+          id: row.id,
+          name: row.name,
+          balance: row.balance,
+          paymentDay: row.paymentDay,
+          scheduledPaymentAmount: row.scheduledPaymentAmount,
+          isDirectCashflowTarget: row.isDirectCashflowTarget,
+        ),
+    ];
+    final inflowInputs = <AssetCalendarInflowInput>[
+      for (final inflow in monthInflowEntries)
+        AssetCalendarInflowInput(
+          date: inflow.date,
+          amount: inflow.amount,
+          label: inflow.label,
+        ),
+    ];
+    final calendar = AssetPaymentCalendarService.buildMonth(
+      month: _calendarMonth,
+      flows: _recentFlows,
+      subscriptions: monthSubscriptions,
+      debts: debtInputs,
+      salaryDay: _salarySpendingSalaryDay,
+      startingCashBalance: startingCashBalance,
+      expectedInflows: inflowInputs,
+    );
+    final selectedDate = _calendarSelectedDate;
+    final selectedDay =
+        selectedDate == null ? null : calendar.dayFor(selectedDate);
+    final today = DateTime.now();
+    final shortfallDaySummary = calendar.firstShortfallDate == null
+        ? null
+        : calendar.dayFor(calendar.firstShortfallDate!);
+    final shortfallDebtEvents = <AssetCalendarEvent>[
+      if (shortfallDaySummary != null)
+        ...shortfallDaySummary.events.where(
+          (event) =>
+              event.kind == AssetCalendarEventKind.debtPayment &&
+              event.sourceId != null,
+        ),
+    ];
+    final shiftCandidates = <MapEntry<AssetCalendarEvent, String>>[
+      for (final event in shortfallDebtEvents)
+        MapEntry(
+          event,
+          _shiftPreviewLabel(
+            event: event,
+            calendar: calendar,
+            debts: debtInputs,
+            subscriptions: monthSubscriptions,
+            inflows: inflowInputs,
+            startingCashBalance: startingCashBalance,
+          ),
+        ),
+    ];
+    final comboIds = <String>[
+      for (final event in shortfallDebtEvents)
+        if (event.sourceId != null) event.sourceId!,
+    ];
+    final comboSuggestionIds = comboIds.length >= 2 &&
+            shiftCandidates.every(
+              (entry) => entry.value == '(単独では回避不可)',
+            )
+        ? AssetPaymentCalendarService.findMinimalShiftSet(
+            month: _calendarMonth,
+            flows: _recentFlows,
+            subscriptions: monthSubscriptions,
+            debts: debtInputs,
+            candidateIds: comboIds,
+            shiftToDay: _salarySpendingSalaryDay + 1,
+            salaryDay: _salarySpendingSalaryDay,
+            startingCashBalance: startingCashBalance,
+            expectedInflows: inflowInputs,
+          )
+        : null;
+    final comboSuggestionLabel = comboSuggestionIds == null
+        ? null
+        : shortfallDebtEvents
+            .where((event) => comboSuggestionIds.contains(event.sourceId))
+            .map((event) => event.label)
+            .join(' + ');
+    const weekdayLabels = ['日', '月', '火', '水', '木', '金', '土'];
+
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.calendar_month, color: Color(0xFF1D4ED8)),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    'マネーカレンダー',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  key: const Key('asset_calendar_prev_month'),
+                  tooltip: '前の月',
+                  icon: const Icon(Icons.chevron_left),
+                  onPressed: () => _shiftCalendarMonth(-1),
+                ),
+                Text(
+                  DateFormat('yyyy年M月').format(calendar.month),
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    height: 1.4,
+                  ),
+                ),
+                IconButton(
+                  key: const Key('asset_calendar_next_month'),
+                  tooltip: '次の月',
+                  icon: const Icon(Icons.chevron_right),
+                  onPressed: () => _shiftCalendarMonth(1),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '日ごとの支出と、返済日・固定費・給料日のイベントをまとめて見渡せます。',
+              style: TextStyle(
+                fontSize: 11,
+                color: Theme.of(context).colorScheme.onSurface,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _buildOverviewStatChip(
+                  label: '返済予定',
+                  value: _formatYen(calendar.scheduledDebtPaymentTotal),
+                  color: const Color(0xFFB91C1C),
+                ),
+                _buildOverviewStatChip(
+                  label: '固定費予定',
+                  value: _formatYen(calendar.subscriptionTotal),
+                  color: const Color(0xFF9333EA),
+                ),
+                _buildOverviewStatChip(
+                  label: '支払予定合計',
+                  value: _formatYen(calendar.scheduledOutflowTotal),
+                  color: const Color(0xFFC05621),
+                ),
+              ],
+            ),
+            if (calendar.firstShortfallDate != null) ...[
+              const SizedBox(height: 8),
+              Container(
+                key: const Key('asset_calendar_shortfall_warning'),
+                width: double.infinity,
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFFEF2F2),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: const Color(0xFFFECACA)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(
+                          Icons.warning_amber_rounded,
+                          size: 16,
+                          color: Color(0xFFB91C1C),
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            '${DateFormat('M月d日').format(calendar.firstShortfallDate!)} に残高ショート見込み',
+                            style: const TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w800,
+                              color: Color(0xFFB91C1C),
+                              height: 1.4,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '現金・預金 ${_formatYen(startingCashBalance ?? 0)} と登録済み入金予定を起点に、返済予定と固定費を差し引いた見込みです。未登録の入金は含まれません。',
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: Theme.of(context).colorScheme.onSurface,
+                        height: 1.6,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      '回避ライン: ショート日までに ${_formatYen(calendar.shortfallRecoveryAmount)} の入金、または月内支払の同額圧縮で黒字化します。',
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w800,
+                        color: Color(0xFFB91C1C),
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton.icon(
+                      key: const Key('asset_calendar_add_inflow_button'),
+                      onPressed: () => _showAddExpectedInflowDialog(
+                        calendar.firstShortfallDate!,
+                        initialAmount: calendar.shortfallRecoveryAmount,
+                      ),
+                      icon: const Icon(Icons.savings, size: 16),
+                      label: const Text('入金予定を追加して再計算'),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '返済日の変更は「負債マスタ」の支払日設定から。給料日(25日)以降へ動かすとショートを避けやすくなります。',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        height: 1.5,
+                      ),
+                    ),
+                    if (shortfallDebtEvents.isNotEmpty) ...[
+                      const SizedBox(height: 6),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 6,
+                        children: [
+                          for (final entry in shiftCandidates)
+                            OutlinedButton.icon(
+                              key: Key(
+                                'asset_shift_payment_${entry.key.sourceId}',
+                              ),
+                              onPressed: () => _shiftDebtPaymentAfterSalary(
+                                workbook,
+                                entry.key.sourceId!,
+                              ),
+                              icon: const Icon(
+                                Icons.schedule_send,
+                                size: 14,
+                              ),
+                              label: Text(
+                                '${entry.key.label}を26日へ${entry.value}',
+                                style: const TextStyle(fontSize: 11),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ],
+                    if (comboSuggestionIds != null) ...[
+                      const SizedBox(height: 6),
+                      OutlinedButton.icon(
+                        key: const Key('asset_shift_payment_combo'),
+                        onPressed: () => _shiftDebtPaymentsAfterSalaryCombo(
+                          workbook,
+                          comboSuggestionIds,
+                        ),
+                        icon: const Icon(Icons.double_arrow, size: 14),
+                        label: Text(
+                          '$comboSuggestionLabelを26日へ(回避できます)',
+                          style: const TextStyle(fontSize: 11),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                for (final weekday in weekdayLabels)
+                  Expanded(
+                    child: Text(
+                      weekday,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        height: 1.4,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            for (final week in calendar.weeks)
+              Row(
+                children: [
+                  for (final day in week)
+                    Expanded(child: _buildAssetCalendarCell(day, today)),
+                ],
+              ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 12,
+              runSpacing: 4,
+              children: [
+                _buildCalendarLegendItem(const Color(0xFFB91C1C), '返済日'),
+                _buildCalendarLegendItem(const Color(0xFF9333EA), '固定費'),
+                _buildCalendarLegendItem(const Color(0xFF0D9488), '給料日'),
+                _buildCalendarLegendItem(const Color(0xFF2563EB), '収入'),
+                _buildCalendarLegendItem(const Color(0xFF0EA5E9), '入金予定'),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                key: const Key('asset_inflow_rules_button'),
+                onPressed: _showInflowRulesDialog,
+                icon: const Icon(Icons.repeat, size: 16),
+                label: const Text('毎月の入金ルール'),
+              ),
+            ),
+            if (monthInflowEntries.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: [
+                  for (final inflow in monthInflowEntries)
+                    InputChip(
+                      key: Key('asset_inflow_chip_${inflow.id}'),
+                      avatar: inflow.sourceRuleId != null
+                          ? const Icon(Icons.repeat, size: 14)
+                          : null,
+                      label: Text(
+                        '${DateFormat('M/d').format(inflow.date)} ${inflow.label} ${_formatYen(inflow.amount)}',
+                        style: const TextStyle(fontSize: 11),
+                      ),
+                      onDeleted: () {
+                        final ruleId = inflow.sourceRuleId;
+                        if (ruleId != null) {
+                          _removeExpectedInflowRule(ruleId);
+                        } else {
+                          _removeExpectedInflow(inflow.id);
+                        }
+                      },
+                    ),
+                ],
+              ),
+            ],
+            if (selectedDay != null) ...[
+              const SizedBox(height: 10),
+              Text(
+                '${DateFormat('M月d日').format(selectedDay.date)} のイベント',
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 8,
+                runSpacing: 6,
+                children: [
+                  OutlinedButton.icon(
+                    key: const Key('asset_calendar_prefill_flow_button'),
+                    onPressed: () =>
+                        _prefillFlowDateFromCalendar(selectedDay.date),
+                    icon: const Icon(Icons.edit_calendar, size: 16),
+                    label: const Text('この日に記録'),
+                  ),
+                  OutlinedButton.icon(
+                    key: const Key('asset_calendar_day_inflow_button'),
+                    onPressed: () =>
+                        _showAddExpectedInflowDialog(selectedDay.date),
+                    icon: const Icon(Icons.savings, size: 16),
+                    label: const Text('入金予定'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              if (!selectedDay.hasAnyEvent)
+                Text(
+                  'この日のイベントはありません。',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    height: 1.5,
+                  ),
+                )
+              else
+                for (final event in selectedDay.events.take(10))
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Row(
+                      children: [
+                        Icon(
+                          _calendarEventIcon(event.kind),
+                          size: 14,
+                          color: _calendarEventColor(event.kind),
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            event.label,
+                            style: const TextStyle(fontSize: 12, height: 1.5),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        if (event.amount != null)
+                          Text(
+                            _formatYen(event.amount!),
+                            style: const TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w700,
+                              height: 1.5,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+            ],
+            const SizedBox(height: 4),
+            Text(
+              '支出・収入は記録済みフロー(直近取得分)に基づく概算、残高ショート見込みは入金を含めない保守的試算です。',
+              style: TextStyle(
+                fontSize: 10,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                height: 1.5,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAssetCalendarCell(AssetCalendarDaySummary? day, DateTime today) {
+    if (day == null) {
+      return const SizedBox(height: 54);
+    }
+    final isToday = day.date.year == today.year &&
+        day.date.month == today.month &&
+        day.date.day == today.day;
+    final selectedDate = _calendarSelectedDate;
+    final isSelected = selectedDate != null &&
+        day.date.year == selectedDate.year &&
+        day.date.month == selectedDate.month &&
+        day.date.day == selectedDate.day;
+    final markers = <Color>[
+      if (day.hasDebtPayment) const Color(0xFFB91C1C),
+      if (day.hasSubscription) const Color(0xFF9333EA),
+      if (day.hasSalary) const Color(0xFF0D9488),
+      if (day.hasExpectedInflow) const Color(0xFF0EA5E9),
+      if (day.hasIncome) const Color(0xFF2563EB),
+    ];
+
+    return InkWell(
+      key: Key('asset_calendar_day_${day.date.day}'),
+      borderRadius: BorderRadius.circular(6),
+      onTap: () {
+        setState(() {
+          _calendarSelectedDate = day.date;
+        });
+      },
+      child: Container(
+        height: 54,
+        margin: const EdgeInsets.all(1),
+        padding: const EdgeInsets.symmetric(vertical: 3),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? const Color(0xFF7C3AED).withValues(alpha: 0.14)
+              : day.isShortfall
+                  ? const Color(0xFFFEE2E2)
+                  : null,
+          borderRadius: BorderRadius.circular(6),
+          border: isToday
+              ? Border.all(color: const Color(0xFF7C3AED), width: 1.5)
+              : null,
+        ),
+        child: Column(
+          children: [
+            Text(
+              '${day.date.day}',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: isToday ? FontWeight.w800 : FontWeight.w600,
+                height: 1.2,
+              ),
+            ),
+            if (day.expenseTotal > 0)
+              Text(
+                _formatCalendarAmount(day.expenseTotal),
+                style: const TextStyle(
+                  fontSize: 9,
+                  color: Color(0xFFB91C1C),
+                  fontWeight: FontWeight.w700,
+                  height: 1.2,
+                ),
+              ),
+            const Spacer(),
+            if (markers.isNotEmpty)
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  for (final color in markers.take(4))
+                    Container(
+                      width: 5,
+                      height: 5,
+                      margin: const EdgeInsets.symmetric(horizontal: 1),
+                      decoration: BoxDecoration(
+                        color: color,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatCalendarAmount(double value) {
+    if (value >= 10000) {
+      final man = value / 10000;
+      final label = man >= 10 ? man.round().toString() : man.toStringAsFixed(1);
+      return '$label万';
+    }
+    return NumberFormat('#,###').format(value.round());
+  }
+
+  Widget _buildCalendarLegendItem(Color color, String label) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 7,
+          height: 7,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 4),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 10,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            height: 1.4,
+          ),
+        ),
+      ],
+    );
+  }
+
+  IconData _calendarEventIcon(AssetCalendarEventKind kind) {
+    switch (kind) {
+      case AssetCalendarEventKind.salary:
+        return Icons.payments_outlined;
+      case AssetCalendarEventKind.expectedInflow:
+        return Icons.savings;
+      case AssetCalendarEventKind.debtPayment:
+        return Icons.account_balance_outlined;
+      case AssetCalendarEventKind.subscription:
+        return Icons.autorenew;
+      case AssetCalendarEventKind.expense:
+        return Icons.remove_circle_outline;
+      case AssetCalendarEventKind.income:
+        return Icons.add_circle_outline;
+    }
+  }
+
+  Color _calendarEventColor(AssetCalendarEventKind kind) {
+    switch (kind) {
+      case AssetCalendarEventKind.salary:
+        return const Color(0xFF0D9488);
+      case AssetCalendarEventKind.expectedInflow:
+        return const Color(0xFF0EA5E9);
+      case AssetCalendarEventKind.debtPayment:
+        return const Color(0xFFB91C1C);
+      case AssetCalendarEventKind.subscription:
+        return const Color(0xFF9333EA);
+      case AssetCalendarEventKind.expense:
+        return const Color(0xFFC05621);
+      case AssetCalendarEventKind.income:
+        return const Color(0xFF2563EB);
+    }
   }
 
   Widget _buildUnifiedEntryBanner() {
@@ -7301,6 +10211,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         actualPaymentAmounts: _actualPaymentAmounts,
         paymentDifferenceReasons: _paymentDifferenceReasons,
         annualRateOverrides: _annualRateOverrides,
+        paymentDayOverrides: _debtPaymentDayOverrides,
         paidAccountNames: _monthlyPaidAccountNames,
         billingConfirmedAccountIds: _billingConfirmedAccountIds,
         paymentSourceAccountIds: _paymentSourceAccountIds,
@@ -8848,6 +11759,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           );
     _ensureDebtLockdownSnapshotLoaded(totalDebt);
+    _ensureKonbiniUdonSnapshotLoaded(totalDebt);
 
     return Card(
       elevation: 2,
@@ -8903,6 +11815,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               const SizedBox(height: 12),
             ],
             _buildDebtLockdownPanel(totalDebt),
+            const SizedBox(height: 12),
+            _buildKonbiniUdonChallengePanel(totalDebt, workbook),
             const SizedBox(height: 12),
             _isCompact
                 ? Column(
@@ -9536,6 +12450,447 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  Widget _buildKonbiniUdonChallengePanel(
+    double remainingDebt,
+    AssetLiabilityWorkbook? workbook,
+  ) {
+    final snapshot = _konbiniUdonSnapshot;
+    final isReleased = remainingDebt <= 0;
+    final isEnabled = snapshot?.isActive == true && !isReleased;
+    final config = snapshot?.config ?? KonbiniUdonChallengeConfig.defaults;
+    final savings = KonbiniUdonChallengeService.estimateSavings(config);
+    final udonSlots = snapshot?.todayUdonSlots ?? const <KonbiniUdonMealSlot>{};
+    final recentViolations =
+        snapshot?.recentViolations ?? const <KonbiniUdonViolation>[];
+    final streakDays = snapshot?.currentStreakDays ?? 0;
+    final totalCompliantDays = snapshot?.totalCompliantDays ?? 0;
+    final cumulativeSavings = snapshot?.cumulativeSavings ?? 0;
+    final advisory = KonbiniUdonChallengeService.healthAdvisoryFor(streakDays);
+    final statusLabel = isReleased
+        ? '釈放'
+        : isEnabled
+            ? '縛り中'
+            : '未開始';
+    final statusColor = isReleased
+        ? const Color(0xFF0D9488)
+        : isEnabled
+            ? const Color(0xFFB45309)
+            : const Color(0xFF475569);
+
+    int? payoffMonthsWithUdon;
+    int? monthsSaved;
+    double? interestSaved;
+    var baselineNeverFinishes = false;
+    if (workbook != null && savings.hasSavings) {
+      final simulation =
+          _assetLiabilityRepaymentSimulationService.buildComparison(
+        workbook: workbook,
+        extraMonthlyPayment: savings.monthlySavings,
+      );
+      if (simulation.hasEligibleDebt) {
+        final udonPlan = simulation.planFor(
+          AssetLiabilityRepaymentSimulationStrategy.interestRate,
+        );
+        final baselinePlan = simulation.baselinePlanFor(
+          AssetLiabilityRepaymentSimulationStrategy.interestRate,
+        );
+        final udonMonths = udonPlan?.estimatedPayoffMonths;
+        final baselineMonths = baselinePlan?.estimatedPayoffMonths;
+        payoffMonthsWithUdon = udonMonths;
+        if (udonPlan != null && baselinePlan != null && udonMonths != null) {
+          if (baselineMonths != null) {
+            monthsSaved = baselineMonths - udonMonths;
+          } else {
+            baselineNeverFinishes = true;
+          }
+          interestSaved = baselinePlan.estimatedInterestTotal -
+              udonPlan.estimatedInterestTotal;
+        }
+      }
+    }
+
+    final advisoryIsWarning =
+        advisory.level == KonbiniUdonHealthAdvisoryLevel.warning;
+    final advisoryIsDanger =
+        advisory.level == KonbiniUdonHealthAdvisoryLevel.danger;
+    final advisoryBg = advisoryIsDanger
+        ? const Color(0xFFFEF2F2)
+        : advisoryIsWarning
+            ? const Color(0xFFFFF7ED)
+            : const Color(0xFFEFF6FF);
+    final advisoryBorder = advisoryIsDanger
+        ? const Color(0xFFFECACA)
+        : advisoryIsWarning
+            ? const Color(0xFFFED7AA)
+            : const Color(0xFFBFDBFE);
+    final advisoryFg = advisoryIsDanger
+        ? const Color(0xFFB91C1C)
+        : advisoryIsWarning
+            ? const Color(0xFFC05621)
+            : const Color(0xFF1D4ED8);
+    final advisoryIcon = advisoryIsDanger
+        ? Icons.medical_services_outlined
+        : advisoryIsWarning
+            ? Icons.warning_amber_rounded
+            : Icons.restaurant;
+
+    return Container(
+      key: const Key('konbini_udon_challenge_panel'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isReleased ? const Color(0xFFF0FDFA) : const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isReleased ? const Color(0xFF99F6E4) : const Color(0xFFFCD34D),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.ramen_dining, color: statusColor),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  'うどん縛り — 完済までの獄中食',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              IconButton(
+                key: const Key('konbini_udon_config_button'),
+                tooltip: '節約前提を調整',
+                icon: const Icon(Icons.tune, size: 18),
+                onPressed: () => _showKonbiniUdonConfigDialog(remainingDebt),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            isReleased
+                ? KonbiniUdonChallengeService.releaseMessage
+                : '借金を完済するまで、食事はコンビニのうどんのみ。浮いた食費(月 ${_formatYen(savings.monthlySavings)} 想定)は全額返済へ回します。',
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.onSurface,
+              height: 1.5,
+            ),
+          ),
+          if (_isLoadingKonbiniUdon && snapshot == null) ...[
+            const SizedBox(height: 10),
+            const LinearProgressIndicator(minHeight: 3),
+          ],
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildOverviewStatChip(
+                label: '状態',
+                value: statusLabel,
+                color: statusColor,
+              ),
+              _buildOverviewStatChip(
+                label: '連続遵守',
+                value: '$streakDays日',
+                color: const Color(0xFF6366F1),
+              ),
+              _buildOverviewStatChip(
+                label: '通算遵守',
+                value: '$totalCompliantDays日',
+                color: const Color(0xFF0D9488),
+              ),
+              _buildOverviewStatChip(
+                label: '累計節約(概算)',
+                value: _formatYen(cumulativeSavings),
+                color: const Color(0xFFB45309),
+              ),
+            ],
+          ),
+          if (snapshot?.startedAt != null && !isReleased) ...[
+            const SizedBox(height: 8),
+            Text(
+              '誓約日: ${DateFormat('yyyy/MM/dd').format(snapshot!.startedAt!)}',
+              style: TextStyle(
+                fontSize: 11,
+                color: Theme.of(context).colorScheme.onSurface,
+                height: 1.5,
+              ),
+            ),
+          ],
+          if (isReleased && totalCompliantDays > 0) ...[
+            const SizedBox(height: 8),
+            Text(
+              '通算遵守 $totalCompliantDays日 / 概算節約 ${_formatYen(cumulativeSavings)}。よく耐えました。',
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: Color(0xFF0D9488),
+                height: 1.5,
+              ),
+            ),
+          ],
+          if (!isReleased) ...[
+            const SizedBox(height: 10),
+            if (savings.hasSavings)
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _buildRepaymentSimulationMetric(
+                    label: '月間節約見込み',
+                    value: _formatYen(savings.monthlySavings),
+                  ),
+                  if (payoffMonthsWithUdon != null)
+                    _buildRepaymentSimulationMetric(
+                      label: '縛り継続時の完済まで',
+                      value: '$payoffMonthsWithUdonヶ月',
+                    ),
+                  if (monthsSaved != null && monthsSaved > 0)
+                    _buildRepaymentSimulationMetric(
+                      label: '完済前倒し',
+                      value: '$monthsSavedヶ月',
+                    ),
+                  if (baselineNeverFinishes)
+                    _buildRepaymentSimulationMetric(
+                      label: '完済前倒し',
+                      value: '360ヶ月+ → 完済可能に',
+                    ),
+                  if (interestSaved != null && interestSaved > 0)
+                    _buildRepaymentSimulationMetric(
+                      label: '利息圧縮',
+                      value: _formatYen(interestSaved),
+                    ),
+                ],
+              )
+            else
+              Text(
+                '今の前提ではうどん縛りの節約が出ません。右上の調整ボタンから、うどん単価と月間食費の前提を見直してください。',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  height: 1.5,
+                ),
+              ),
+            if (isEnabled && savings.hasSavings) ...[
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                key: const Key('konbini_udon_transfer_inflow_button'),
+                onPressed: () => _showAddExpectedInflowDialog(
+                  _nextSalaryDate(),
+                  initialAmount: savings.monthlySavings,
+                  initialLabel: 'うどん縛り節約分(返済原資)',
+                ),
+                icon: const Icon(Icons.savings, size: 16),
+                label: const Text('節約見込みを入金予定へ転記'),
+              ),
+            ],
+            const SizedBox(height: 12),
+            _isCompact
+                ? Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      ElevatedButton.icon(
+                        key: const Key('konbini_udon_toggle_button'),
+                        onPressed: isEnabled
+                            ? () => _setKonbiniUdonEnabled(false, remainingDebt)
+                            : () => _confirmKonbiniUdonPledge(remainingDebt),
+                        icon: Icon(
+                          isEnabled ? Icons.pause_circle : Icons.ramen_dining,
+                        ),
+                        label: Text(isEnabled ? 'うどん縛りを中断' : 'うどん縛りを誓う'),
+                      ),
+                      const SizedBox(height: 8),
+                      OutlinedButton.icon(
+                        onPressed: isEnabled
+                            ? () =>
+                                _showKonbiniUdonViolationDialog(remainingDebt)
+                            : null,
+                        icon: const Icon(Icons.no_food),
+                        label: const Text('うどん以外を食べた'),
+                      ),
+                    ],
+                  )
+                : Row(
+                    children: [
+                      Expanded(
+                        child: ElevatedButton.icon(
+                          key: const Key('konbini_udon_toggle_button'),
+                          onPressed: isEnabled
+                              ? () =>
+                                  _setKonbiniUdonEnabled(false, remainingDebt)
+                              : () => _confirmKonbiniUdonPledge(remainingDebt),
+                          icon: Icon(
+                            isEnabled ? Icons.pause_circle : Icons.ramen_dining,
+                          ),
+                          label: Text(isEnabled ? 'うどん縛りを中断' : 'うどん縛りを誓う'),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      OutlinedButton.icon(
+                        onPressed: isEnabled
+                            ? () =>
+                                _showKonbiniUdonViolationDialog(remainingDebt)
+                            : null,
+                        icon: const Icon(Icons.no_food),
+                        label: const Text('うどん以外を食べた'),
+                      ),
+                    ],
+                  ),
+            const SizedBox(height: 12),
+            const Text(
+              '今日の三食(うどんで完走)',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final slot in KonbiniUdonMealSlot.values)
+                  FilterChip(
+                    key: Key('konbini_udon_slot_${slot.storageId}'),
+                    selected: udonSlots.contains(slot),
+                    onSelected: isEnabled
+                        ? (value) =>
+                            _toggleKonbiniUdonMeal(slot, value, remainingDebt)
+                        : null,
+                    avatar: Icon(
+                      Icons.ramen_dining,
+                      size: 16,
+                      color: udonSlots.contains(slot)
+                          ? Colors.white
+                          : Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                    selectedColor: const Color(0xFFB45309),
+                    labelStyle: TextStyle(
+                      color: udonSlots.contains(slot)
+                          ? Colors.white
+                          : Theme.of(context).colorScheme.onSurface,
+                      fontWeight: FontWeight.w700,
+                      height: 1.5,
+                    ),
+                    label: Text('${slot.label}うどん'),
+                  ),
+              ],
+            ),
+            if (snapshot?.isTodayCompliant == true) ...[
+              const SizedBox(height: 6),
+              const Text(
+                '今日は三食うどんで完走。完済が一歩近づきました。',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: Color(0xFF0D9488),
+                  height: 1.5,
+                ),
+              ),
+            ],
+            if (advisory.level != KonbiniUdonHealthAdvisoryLevel.none) ...[
+              const SizedBox(height: 10),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: advisoryBg,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: advisoryBorder),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(advisoryIcon, size: 16, color: advisoryFg),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            advisory.title,
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w800,
+                              color: advisoryFg,
+                              height: 1.4,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      advisory.body,
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: Theme.of(context).colorScheme.onSurface,
+                        height: 1.6,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+            const SizedBox(height: 8),
+            const Text(
+              '最近のうどん違反',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 6),
+            if (recentViolations.isEmpty)
+              Text(
+                isEnabled
+                    ? 'まだ違反はありません。今日もうどんで生き延びます。'
+                    : '誓いを立てると、ここにうどん以外の食事ログが溜まります。',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(context).colorScheme.onSurface,
+                  height: 1.5,
+                ),
+              )
+            else
+              ...recentViolations.take(3).map((violation) {
+                final amountLabel = violation.amount > 0
+                    ? ' / ${_formatYen(violation.amount)}'
+                    : '';
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 6),
+                  child: Text(
+                    '${DateFormat('MM/dd HH:mm').format(violation.createdAt)}  ${violation.mealSlotLabel}$amountLabel  ${violation.note}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.onSurface,
+                      height: 1.5,
+                    ),
+                  ),
+                );
+              }),
+          ],
+          const SizedBox(height: 8),
+          Text(
+            KonbiniUdonChallengeService.healthDisclaimer,
+            style: TextStyle(
+              fontSize: 10,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   IconData _debtExecutionTaskIcon(DebtExecutionTaskKind kind) {
     switch (kind) {
       case DebtExecutionTaskKind.focus:
@@ -9840,9 +13195,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return const SizedBox.shrink();
     }
     _scheduleAssetLiabilityStateIdMigration(workbook);
+    _scheduleAssetDebtTrendHistorySync(workbook);
+    final currentMonthKey =
+        AssetAccountBalanceHistoryStore.formatMonthKey(workbook.baseDate);
+    // キャッシュ済み前月残高が当月のものでない間は渡さない(取り違え防止)。
+    final priorMonthAccountBalances =
+        _assetDebtTrendPriorBalancesMonth == currentMonthKey
+            ? _assetDebtTrendPriorBalances
+            : const <String, double>{};
     final insightReport = _assetManagementInsightService.buildReport(
       workbook: workbook,
       userProfile: _assetManagementUserProfile,
+      mainAccountId: _assetManagementMainAccountId,
+      priorMonthAccountBalances: priorMonthAccountBalances,
     );
     final warningColor = workbook.cashAfterScheduledPayments < 0
         ? const Color(0xFFB91C1C)
@@ -10696,7 +14061,43 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
           const SizedBox(height: 10),
           _buildAssetManagementAiSummaryPanel(report),
+          if (_assetManagementProfileBasicsMissing(report.userProfile)) ...[
+            const SizedBox(height: 6),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                ),
+                onPressed: () =>
+                    unawaited(_openProfileSettingsForAssetManagement()),
+                icon: const Icon(Icons.badge_outlined, size: 16),
+                label: const Text('職業・年収をプロフィールに入力する'),
+              ),
+            ),
+          ],
+          if (report.workbook.cardStatementReconciliation.hasNeedsReview) ...[
+            const SizedBox(height: 6),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  foregroundColor: const Color(0xFFD97706),
+                ),
+                onPressed: _jumpToCardStatementReconciliation,
+                icon: const Icon(Icons.receipt_long_outlined, size: 16),
+                label: Text(
+                  _cardStatementReconciliationLinkLabel(report.workbook),
+                ),
+              ),
+            ),
+          ],
           const SizedBox(height: 10),
+          _buildMainAccountSelector(report.workbook),
+          const SizedBox(height: 8),
           Wrap(
             spacing: 8,
             runSpacing: 8,
@@ -10711,6 +14112,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             _buildAssetManagementEmergencyAdviceList(report.emergencyAdvices),
             const SizedBox(height: 12),
           ],
+          if (report.debtTrendInsights.isNotEmpty) ...[
+            _buildAssetManagementMonthlyDebtTrendList(report.debtTrendInsights),
+            const SizedBox(height: 12),
+          ],
           _buildAssetManagementAssistantActionList(report.actionItems),
           if (report.movementSuggestions.isNotEmpty) ...[
             const SizedBox(height: 12),
@@ -10719,7 +14124,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ),
           ],
           const SizedBox(height: 12),
-          _buildAssetManagementDeveloperRequestList(report.developerRequests),
+          _buildAssetManagementDeveloperRequestList(
+            _combinedDeveloperRequests(report),
+          ),
         ],
       ),
     );
@@ -10732,7 +14139,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (enabled) {
       _requestAssetManagementAiSummaryIfNeeded(report);
     }
-    _requestExistingDeveloperIssuesIfNeeded(report.developerRequests);
+    final developerRequests = _combinedDeveloperRequests(report);
+    _requestExistingDeveloperIssuesIfNeeded(developerRequests);
     final result = _assetManagementAiSummaryResult ??
         (enabled
             ? _assetManagementAiSummaryService.buildWaitingForAiResult(report)
@@ -10748,7 +14156,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetManagementAiSummaryStatus.disabled => 'AI無効',
     };
     final issueableDeveloperRequests = _issueableDeveloperRequests(
-      report.developerRequests,
+      developerRequests,
     );
     final canCopySummary = result.text.trim().isNotEmpty;
 
@@ -10831,14 +14239,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     : const Icon(Icons.auto_awesome_outlined, size: 16),
                 label: Text(enabled ? 'AI要約を更新' : 'AI要約は機能フラグで無効です'),
               ),
-              if (report.developerRequests.isNotEmpty)
+              if (developerRequests.isNotEmpty)
                 OutlinedButton.icon(
                   onPressed: _isSubmittingAllDeveloperIssues ||
                           _isCheckingExistingDeveloperRequestIssues ||
                           issueableDeveloperRequests.isEmpty
                       ? null
                       : () => _submitAssetManagementDeveloperIssues(
-                            report.developerRequests,
+                            developerRequests,
                           ),
                   icon: _isSubmittingAllDeveloperIssues
                       ? const SizedBox(
@@ -10848,9 +14256,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         )
                       : const Icon(Icons.add_task_outlined, size: 16),
                   label: Text(
-                    _isSubmittingAllDeveloperIssues
-                        ? 'Issues登録中'
-                        : '改善提案をIssues登録',
+                    _developerIssuesBulkButtonLabel(
+                      issueableDeveloperRequests,
+                    ),
                   ),
                 ),
             ],
@@ -10953,9 +14361,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     if (!force &&
-        _assetManagementAiSummaryAutoRequestedKeys.contains(key) &&
-        _assetManagementAiSummaryRequestKey == key &&
-        _assetManagementAiSummaryResult != null) {
+        !AssetManagementAiSummaryRefresh.isStale(
+          currentKey: key,
+          resultKey: _assetManagementAiSummaryResultKey,
+          hasResult: _assetManagementAiSummaryResult != null,
+        )) {
       return;
     }
     setState(() {
@@ -10973,9 +14383,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (!mounted || _assetManagementAiSummaryInFlightKey != key) {
       return;
     }
+    // 初回自動生成が既存Issue照合より先に走ると already_issued が
+    // 空のままAIへ渡り再掲抑止が効かないため、照合完了を待つ。
+    await _ensureExistingDeveloperIssuesLoaded(report.developerRequests);
+    if (!mounted || _assetManagementAiSummaryInFlightKey != key) {
+      return;
+    }
+    final existingIssuesByTitle = <String, Map<String, dynamic>>{};
+    for (final request in report.developerRequests) {
+      final existing = _developerRequestExistingIssueResults[
+          _developerRequestIssueKey(request)];
+      if (existing != null) {
+        existingIssuesByTitle[request.title] =
+            Map<String, dynamic>.from(existing);
+      }
+    }
     final result = await _assetManagementAiSummaryService.generateSummary(
       report: report,
       previousAnalyses: previousAnalyses,
+      existingDeveloperIssuesByTitle: existingIssuesByTitle,
     );
     if (result.usedExternalAi) {
       try {
@@ -10996,6 +14422,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     setState(() {
       _assetManagementAiSummaryResult = result;
+      _assetManagementAiSummaryResultKey = key;
       _assetManagementAiSummaryReferencedHistory = previousAnalyses;
       _isGeneratingAssetManagementAiSummary = false;
       _assetManagementAiSummaryInFlightKey = null;
@@ -11012,12 +14439,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     final key = _assetManagementAiSummaryKey(report);
     if (_assetManagementAiSummaryRequestKey == key ||
-        _assetManagementAiSummaryInFlightKey == key ||
-        _assetManagementAiSummaryAutoRequestedKeys.contains(key)) {
+        _assetManagementAiSummaryInFlightKey == key) {
+      return;
+    }
+    if (!AssetManagementAiSummaryRefresh.isStale(
+      currentKey: key,
+      resultKey: _assetManagementAiSummaryResultKey,
+      hasResult: _assetManagementAiSummaryResult != null,
+    )) {
       return;
     }
     _assetManagementAiSummaryRequestKey = key;
-    _assetManagementAiSummaryAutoRequestedKeys.add(key);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted ||
           !_assetManagementAiSummaryService.aiEnabled ||
@@ -11057,6 +14489,27 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _loadExistingDeveloperIssues(lookupKey: lookupKey, requests: payload),
       );
     });
+  }
+
+  /// 既存Issue照合の完了を待つ。未取得・取得中の場合はその場で照合を実行する。
+  /// AI要約生成前に already_issued 注釈を確実に揃えるために使う。
+  Future<void> _ensureExistingDeveloperIssuesLoaded(
+    List<AssetManagementDeveloperRequest> requests,
+  ) async {
+    if (_supabase.auth.currentUser == null || requests.isEmpty) {
+      return;
+    }
+    final payload = requests
+        .map(_developerRequestExistingIssuePayload)
+        .toList(growable: false);
+    final lookupKey = jsonEncode(payload);
+    if (_developerRequestExistingIssueLookupKey == lookupKey &&
+        !_isCheckingExistingDeveloperRequestIssues) {
+      return;
+    }
+    _developerRequestExistingIssueLookupKey = lookupKey;
+    _isCheckingExistingDeveloperRequestIssues = true;
+    await _loadExistingDeveloperIssues(lookupKey: lookupKey, requests: payload);
   }
 
   Map<String, String> _developerRequestExistingIssuePayload(
@@ -11114,6 +14567,38 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _isCheckingExistingDeveloperRequestIssues = false;
       });
     }
+  }
+
+  /// 定型生成の改善提案に、AI要約が返した未起票の新規提案を合流させる。
+  List<AssetManagementDeveloperRequest> _combinedDeveloperRequests(
+    AssetManagementInsightReport report,
+  ) {
+    final aiRequests = _assetManagementAiSummaryResult?.aiDeveloperRequests ??
+        const <AssetManagementDeveloperRequest>[];
+    if (aiRequests.isEmpty) {
+      return report.developerRequests;
+    }
+    final knownKeys =
+        report.developerRequests.map(_developerRequestIssueKey).toSet();
+    return <AssetManagementDeveloperRequest>[
+      ...report.developerRequests,
+      for (final request in aiRequests)
+        if (knownKeys.add(_developerRequestIssueKey(request))) request,
+    ];
+  }
+
+  bool _isAiGeneratedDeveloperRequest(
+    AssetManagementDeveloperRequest request,
+  ) {
+    final aiRequests = _assetManagementAiSummaryResult?.aiDeveloperRequests ??
+        const <AssetManagementDeveloperRequest>[];
+    if (aiRequests.isEmpty) {
+      return false;
+    }
+    final key = _developerRequestIssueKey(request);
+    return aiRequests.any(
+      (candidate) => _developerRequestIssueKey(candidate) == key,
+    );
   }
 
   List<AssetManagementDeveloperRequest> _issueableDeveloperRequests(
@@ -11349,6 +14834,69 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return const <String, dynamic>{};
   }
 
+  Widget _buildMainAccountSelector(AssetLiabilityWorkbook workbook) {
+    // メインバンク候補 = 現金以外の口座(預金・証券・その他資産)。
+    final candidates = workbook.accounts
+        .where(
+          (account) =>
+              account.kind != AssetLiabilityAccountKind.cash && account.isAsset,
+        )
+        .toList()
+      ..sort((a, b) => b.balance.compareTo(a.balance));
+    if (candidates.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final validSelected = candidates.any(
+      (account) => account.id == _assetManagementMainAccountId,
+    )
+        ? _assetManagementMainAccountId
+        : null;
+    return Row(
+      children: [
+        Icon(
+          Icons.account_balance_outlined,
+          size: 16,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(width: 6),
+        Text(
+          'メインバンク',
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            height: 1.3,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: DropdownButton<String?>(
+            value: validSelected,
+            isExpanded: true,
+            isDense: true,
+            hint: const Text('既定（残高最大の口座）', style: TextStyle(fontSize: 12)),
+            items: [
+              const DropdownMenuItem<String?>(
+                value: null,
+                child: Text('既定（残高最大の口座）', style: TextStyle(fontSize: 12)),
+              ),
+              for (final account in candidates)
+                DropdownMenuItem<String?>(
+                  value: account.id,
+                  child: Text(
+                    '${account.name}（${_formatManagementYen(account.balance)}）',
+                    style: const TextStyle(fontSize: 12),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+            ],
+            onChanged: (value) => unawaited(_setMainAccount(value)),
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _buildAssetManagementAvailableCard(
     AssetManagementAvailableMoneyInsight insight,
   ) {
@@ -11356,7 +14904,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ? const Color(0xFFB91C1C)
         : const Color(0xFF0D9488);
     final subtitle =
-        '支払 ${_formatManagementYen(insight.unpaidPaymentTotal)} / 入金 ${_formatManagementYen(insight.unreceivedIncomeTotal)} / 安全残高 ${_formatManagementYen(insight.minimumSafetyBalance)}';
+        '利用可能資産 ${_formatManagementYen(insight.cashLikeTotal)} / 給料日まで支払 ${_formatManagementYen(insight.unpaidPaymentTotal)} / 安全余裕 ${_formatManagementYen(insight.minimumSafetyBalance)}';
 
     return Container(
       constraints: const BoxConstraints(minWidth: 210, maxWidth: 320),
@@ -11396,6 +14944,182 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               fontSize: 11,
               height: 1.4,
             ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _assetDebtTrendSeverityColor(AssetDebtTrendSeverity severity) {
+    return switch (severity) {
+      AssetDebtTrendSeverity.info => const Color(0xFF2563EB),
+      AssetDebtTrendSeverity.warning => const Color(0xFFD97706),
+      AssetDebtTrendSeverity.critical => const Color(0xFFB91C1C),
+    };
+  }
+
+  String _assetDebtTrendCategoryLabel(AssetDebtTrendCategory category) {
+    return switch (category) {
+      AssetDebtTrendCategory.negativeAmortization => 'リボ複利・返済が利息以下',
+      AssetDebtTrendCategory.balanceIncreasing => '残高が先月より増加',
+      AssetDebtTrendCategory.slowPayoff => '完済まで超長期',
+    };
+  }
+
+  /// 今月の負債の問題点と「翌月こうしなさい」を、計算済みの具体額つきで描画する。
+  Widget _buildAssetManagementMonthlyDebtTrendList(
+    List<AssetDebtTrendInsight> insights,
+  ) {
+    final hasCritical = insights.any(
+      (insight) => insight.severity == AssetDebtTrendSeverity.critical,
+    );
+    final headerColor =
+        hasCritical ? const Color(0xFFB91C1C) : const Color(0xFFD97706);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF7ED),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: headerColor.withValues(alpha: 0.28)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.trending_up, color: headerColor, size: 18),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '今月の問題点と翌月の改善（負債トレンド）',
+                  style: TextStyle(
+                    color: headerColor,
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            'リボ払いで返済が利息に負けている／先月より残高が増えた負債を検出し、翌月の具体的な返済額を提示します。',
+            style: TextStyle(fontSize: 12, height: 1.5),
+          ),
+          const SizedBox(height: 8),
+          for (final insight in insights.take(5))
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _buildAssetManagementMonthlyDebtTrendTile(insight),
+            ),
+          if (insights.length > 5)
+            Text(
+              'ほか ${insights.length - 5}件',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetManagementMonthlyDebtTrendTile(
+    AssetDebtTrendInsight insight,
+  ) {
+    final color = _assetDebtTrendSeverityColor(insight.severity);
+    final payoffValue = insight.estimatedPayoffMonths == null
+        ? 'この返済額では完済不能'
+        : '約${insight.estimatedPayoffMonths}ヶ月';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.22)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${insight.accountName}（${_assetDebtTrendCategoryLabel(insight.category)}）',
+            style: TextStyle(
+              color: color,
+              fontWeight: FontWeight.bold,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            insight.problem,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.arrow_forward, color: color, size: 16),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    '翌月: ${insight.nextMonthAction}',
+                    style: const TextStyle(fontSize: 12, height: 1.5),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              _buildAssetLiabilitySyncChip(
+                label: '残高',
+                value: _formatManagementYen(insight.currentBalance),
+                color: color,
+              ),
+              if (insight.balanceDelta != null)
+                _buildAssetLiabilitySyncChip(
+                  label: '前月比',
+                  value: _formatManagementDeltaYen(insight.balanceDelta),
+                  color: color,
+                ),
+              _buildAssetLiabilitySyncChip(
+                label: '月利息',
+                value: _formatManagementYen(insight.monthlyInterest),
+                color: const Color(0xFF6B7280),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: '今月返済',
+                value: _formatManagementYen(insight.scheduledPayment),
+                color: const Color(0xFF6B7280),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: '24ヶ月完済ライン',
+                value: _formatManagementYen(insight.payoffIn24MonthsPayment),
+                color: const Color(0xFF0D9488),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: '完済見込み',
+                value: payoffValue,
+                color: const Color(0xFF6B7280),
+              ),
+            ],
           ),
         ],
       ),
@@ -11541,6 +15265,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  String? _assetManagementActionJumpLabel(
+    AssetManagementInsightActionItem item,
+  ) {
+    final accountId = item.relatedAccountId;
+    if (accountId == null || accountId.trim().isEmpty) {
+      return null;
+    }
+    return switch (item.type) {
+      AssetManagementInsightActionType.missingPaymentDay => '支払日を入力する',
+      AssetManagementInsightActionType.missingInput => '今月支払予定額を入力する',
+      AssetManagementInsightActionType.missingAnnualRate => '利率を入力する',
+      AssetManagementInsightActionType.missingPaymentSource => '支払原資口座を設定する',
+      AssetManagementInsightActionType.cardBillingConfiguration =>
+        '支払い方式と請求先カードを設定する',
+      AssetManagementInsightActionType.doubleCountingRisk => '支払い方式を整理する',
+      _ => null,
+    };
+  }
+
   Widget _buildAssetManagementAssistantActionTile(
     AssetManagementInsightActionItem item,
   ) {
@@ -11548,6 +15291,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final dueLabel = item.dueDate == null
         ? (item.paymentDay == null ? null : '${item.paymentDay}日')
         : DateFormat('M/d').format(item.dueDate!);
+    final jumpLabel = _assetManagementActionJumpLabel(item);
 
     return Container(
       width: double.infinity,
@@ -11612,6 +15356,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   item.suggestedAction,
                   style: const TextStyle(fontSize: 12, height: 1.5),
                 ),
+                if (jumpLabel != null)
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton.icon(
+                      style: TextButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        foregroundColor: color,
+                      ),
+                      onPressed: () =>
+                          _jumpToDebtMasterCard(item.relatedAccountId!),
+                      icon: const Icon(Icons.arrow_downward, size: 16),
+                      label: Text(jumpLabel),
+                    ),
+                  ),
               ],
             ),
           ),
@@ -11667,6 +15426,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
             )
             .toList(growable: false);
+    final existingIssueEntries =
+        <MapEntry<AssetManagementDeveloperRequest, Map<String, dynamic>>>[];
+    if (!_isCheckingExistingDeveloperRequestIssues) {
+      for (final request in requests) {
+        final issueKey = _developerRequestIssueKey(request);
+        final existing = _developerRequestExistingIssueResults[issueKey];
+        if (existing != null) {
+          existingIssueEntries.add(MapEntry(request, existing));
+        }
+      }
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -11675,7 +15445,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
         ),
         const SizedBox(height: 6),
-        for (final request in visibleRequests.take(4))
+        if (_isCheckingExistingDeveloperRequestIssues)
+          Text(
+            '既存のGitHub Issueを確認しています...',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+        for (final request in visibleRequests.take(6))
           Padding(
             padding: const EdgeInsets.only(bottom: 6),
             child: Container(
@@ -11698,6 +15477,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                       height: 1.4,
                     ),
                   ),
+                  if (_isAiGeneratedDeveloperRequest(request)) ...[
+                    const SizedBox(height: 4),
+                    _buildTextStatusChip(
+                      label: 'AI新規提案（未起票のみ登録可）',
+                      color: const Color(0xFF7C3AED),
+                    ),
+                  ],
                   const SizedBox(height: 3),
                   Text(
                     request.description,
@@ -11734,7 +15520,60 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
             ),
           ),
+        if (existingIssueEntries.isNotEmpty) ...[
+          Text(
+            '登録済みの改善提案（既存Issueがあるため新規登録対象外）',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              height: 1.4,
+            ),
+          ),
+          for (final entry in existingIssueEntries)
+            _buildExistingDeveloperIssueLink(entry.key, entry.value),
+        ],
       ],
+    );
+  }
+
+  String _developerIssuesBulkButtonLabel(
+    List<AssetManagementDeveloperRequest> issueableRequests,
+  ) {
+    if (_isSubmittingAllDeveloperIssues) {
+      return 'Issues登録中';
+    }
+    if (_isCheckingExistingDeveloperRequestIssues) {
+      return '既存Issue確認中';
+    }
+    if (issueableRequests.isEmpty) {
+      return '改善提案はIssue登録済み';
+    }
+    return '改善提案をIssues登録';
+  }
+
+  Widget _buildExistingDeveloperIssueLink(
+    AssetManagementDeveloperRequest request,
+    Map<String, dynamic> existingIssue,
+  ) {
+    final issueUrl = existingIssue['html_url']?.toString() ?? '';
+    final issueNumber = existingIssue['number']?.toString() ?? '-';
+    final issueState = existingIssue['state']?.toString() ?? '-';
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: TextButton.icon(
+        style: TextButton.styleFrom(
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+        ),
+        onPressed:
+            issueUrl.isEmpty ? null : () => web.window.open(issueUrl, '_blank'),
+        icon: const Icon(Icons.open_in_new, size: 14),
+        label: Text(
+          '${request.title}: 既存Issue #$issueNumber（$issueState）を開く',
+          style: const TextStyle(fontSize: 12, height: 1.4),
+        ),
+      ),
     );
   }
 
@@ -12070,7 +15909,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           const SizedBox(height: 12),
           _buildCardBillingReviewGroups(review.cardBillingGroups),
           const SizedBox(height: 12),
-          _buildCardStatementReconciliationPanel(workbook),
+          KeyedSubtree(
+            key: _keyCardStatementReconciliation,
+            child: _buildCardStatementReconciliationPanel(workbook),
+          ),
         ],
       ),
     );
@@ -12635,7 +16477,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ),
           const SizedBox(height: 6),
           Text(
-            'CSV行は「摘要,金額,日付」または「請求先ID,摘要,金額,日付」で貼り付けできます。取り込み合計をカード請求額と照合します。',
+            'CSV/TSV行は「摘要,金額,日付」または「請求先ID,摘要,金額,日付」で貼り付けできます。auPAY等の明細表（タブ区切り・「利用日/利用店名/利用金額」等の見出し付き）もそのまま貼り付け可能です。取り込み合計をカード請求額と照合します。',
             style: TextStyle(
               color: Theme.of(context).colorScheme.onSurfaceVariant,
               fontSize: 12,
@@ -12732,7 +16574,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       child: DataTable(
         headingRowHeight: 34,
         dataRowMinHeight: 46,
-        dataRowMaxHeight: 64,
+        // 確認事項は長文になり得るため行高さを可変にし、セル側で折り返す。
+        dataRowMaxHeight: double.infinity,
         columns: const [
           DataColumn(label: Text('請求先カード')),
           DataColumn(label: Text('請求額'), numeric: true),
@@ -12763,7 +16606,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   ),
                 ),
                 DataCell(
-                  Text(group.alerts.isEmpty ? 'OK' : group.alerts.join(' / ')),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 280),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: Text(
+                        group.alerts.isEmpty
+                            ? 'OK'
+                            : group.alerts.join(' / '),
+                        softWrap: true,
+                        style: const TextStyle(height: 1.4),
+                      ),
+                    ),
+                  ),
                 ),
               ],
             ),
@@ -15483,6 +19338,179 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  GlobalKey _debtMasterCardKeyFor(String accountId) {
+    return _debtMasterCardKeys.putIfAbsent(
+      accountId,
+      () => GlobalKey(debugLabel: 'debt_master_card_$accountId'),
+    );
+  }
+
+  void _jumpToDebtMasterCard(String accountId) {
+    if (_debtMasterReviewFilter != _DebtMasterReviewFilter.all) {
+      setState(() {
+        _debtMasterReviewFilter = _DebtMasterReviewFilter.all;
+      });
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      final key = _debtMasterCardKeys[accountId];
+      if (key == null || key.currentContext == null) {
+        return;
+      }
+      _scrollTo(key);
+    });
+  }
+
+  /// 削除した支払日上書きのトゥームストーン (#part293: MirrorTombstoneStore 3例目)。
+  /// ミラー復元で「自動へ戻した支払日」が復活するのを防ぐ。
+  static const MirrorTombstoneStore _debtOverrideTombstones =
+      MirrorTombstoneStore(
+    storageKey: 'debt_payment_day_override_deleted_v1',
+  );
+
+  void _setDebtPaymentDayOverride(AssetLiabilityDebtRow row, int? day) {
+    setState(() {
+      if (day == null) {
+        _debtPaymentDayOverrides.remove(row.id);
+      } else {
+        _debtPaymentDayOverrides[row.id] = day.clamp(1, 31).toInt();
+      }
+    });
+    if (day == null) {
+      // 削除はトゥームストーン化、再設定は解除 (ID 再利用ドメイン)。
+      unawaited(_recordDebtOverrideTombstone(row.id, deleted: true));
+    } else {
+      unawaited(_recordDebtOverrideTombstone(row.id, deleted: false));
+    }
+    unawaited(_saveDebtPaymentDayOverrides());
+  }
+
+  Future<void> _recordDebtOverrideTombstone(
+    String id, {
+    required bool deleted,
+  }) async {
+    final store = await SharedPreferences.getInstance();
+    if (deleted) {
+      await _debtOverrideTombstones.addId(store, id);
+    } else {
+      await _debtOverrideTombstones.removeId(store, id);
+    }
+    unawaited(_mirrorDebtOverrideDeleted());
+  }
+
+  /// 支払日上書きの削除トゥームストーンをサーバへ反映 (他端末伝播 / #part294)。
+  Future<void> _mirrorDebtOverrideDeleted() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final store = await SharedPreferences.getInstance();
+      final ids = _debtOverrideTombstones.activeIds(store);
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': 'debt_payment_day_override_deleted',
+        'value': MirrorTombstoneStore.encodeMirror(ids),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('debt override tombstone mirror upsert failed: $e');
+    }
+  }
+
+  /// 他端末で削除された支払日上書きを取り込み、ローカルからも除去する。
+  Future<void> _pullDebtOverrideDeleted() async {
+    final debugMirror = widget.debugDebtOverrideDeletedMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      Map<String, dynamic>? value = debugMirror;
+      if (value == null) {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', 'debt_payment_day_override_deleted');
+        if (rows.isEmpty) {
+          return;
+        }
+        final raw = rows.first['value'];
+        if (raw is! Map) {
+          return;
+        }
+        value = Map<String, dynamic>.from(raw);
+      }
+      final ids = MirrorTombstoneStore.decodeMirror(value);
+      if (ids.isEmpty) {
+        return;
+      }
+      final store = await SharedPreferences.getInstance();
+      final incoming = await _debtOverrideTombstones.mergeRemoteIds(store, ids);
+      final before = _debtPaymentDayOverrides.length;
+      _debtPaymentDayOverrides.removeWhere((key, _) => incoming.contains(key));
+      if (_debtPaymentDayOverrides.length == before || !mounted) {
+        return;
+      }
+      setState(() {});
+      unawaited(_saveDebtPaymentDayOverrides());
+    } catch (e) {
+      debugPrint('debt override tombstone pull failed: $e');
+    }
+  }
+
+  Future<void> _saveDebtPaymentDayOverrides() async {
+    try {
+      await _assetLiabilityRepository.saveDebtPaymentDayOverrides(
+        Map<String, int>.from(_debtPaymentDayOverrides),
+      );
+    } catch (e) {
+      debugPrint('Error saving debt payment day overrides: $e');
+    }
+    unawaited(
+      _mirrorDebtPaymentDayOverrides(
+        Map<String, int>.from(_debtPaymentDayOverrides),
+      ),
+    );
+  }
+
+  Widget _buildDebtPaymentDayInput(AssetLiabilityDebtRow row) {
+    final hasOverride = _debtPaymentDayOverrides.containsKey(row.id);
+    final statusLabel = hasOverride
+        ? '手動設定'
+        : row.paymentDay == null
+            ? '未設定'
+            : '自動推定';
+    final statusColor = hasOverride
+        ? const Color(0xFF7C3AED)
+        : row.paymentDay == null
+            ? const Color(0xFFD97706)
+            : const Color(0xFF475569);
+    return SizedBox(
+      width: 140,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildTextStatusChip(label: statusLabel, color: statusColor),
+          const SizedBox(height: 4),
+          DropdownButton<int?>(
+            value: row.paymentDay,
+            isExpanded: true,
+            isDense: true,
+            items: [
+              const DropdownMenuItem<int?>(value: null, child: Text('未設定')),
+              for (var day = 1; day <= 31; day++)
+                DropdownMenuItem<int?>(value: day, child: Text('$day日')),
+            ],
+            onChanged: (value) => _setDebtPaymentDayOverride(row, value),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildDebtMasterCard(
     AssetLiabilityDebtRow row,
     AssetLiabilityWorkbook workbook,
@@ -15497,6 +19525,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         row.paymentDay == null ? '支払日未設定' : '${row.paymentDay}日支払';
 
     return Container(
+      key: _debtMasterCardKeyFor(row.id),
       width: double.infinity,
       margin: const EdgeInsets.only(bottom: 10),
       padding: const EdgeInsets.all(12),
@@ -15588,6 +19617,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             runSpacing: 10,
             crossAxisAlignment: WrapCrossAlignment.start,
             children: [
+              _buildDebtMasterControl(
+                label: '支払日',
+                child: _buildDebtPaymentDayInput(row),
+                maxWidth: 150,
+              ),
               _buildDebtMasterControl(
                 label: '実支払額',
                 child: _buildActualPaymentInput(row),
@@ -15962,6 +19996,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Widget _buildAnnualRateInputWithEvidence(AssetLiabilityDebtRow row) {
+    if (row.fullPaymentEstimate) {
+      return _buildTextStatusChip(
+        label: '固定費（利率なし）',
+        color: const Color(0xFF475569),
+      );
+    }
     final controller = _annualRateControllerFor(row);
     final hasOverride = _annualRateOverrides.containsKey(row.id);
     final evidence = _annualRateEvidences[row.id];
@@ -17075,8 +21115,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     : spot.barIndex == 1
                         ? const Color(0xFF2563EB)
                         : const Color(0xFFDC2626);
-                final date =
-                    DateFormat('yyyy/MM/dd').format(DateTime.parse(point.date));
+                final date = DateFormat(
+                  'yyyy/MM/dd',
+                ).format(DateTime.parse(point.date));
                 final prefix = spot == spots.first ? '$date\n' : '';
                 return LineTooltipItem(
                   '$prefix$label: ${_formatYen(spot.y)}',
@@ -17128,8 +21169,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 if (index < 0 || index >= points.length) {
                   return const SizedBox.shrink();
                 }
-                final date = DateFormat('M/d')
-                    .format(DateTime.parse(points[index].date));
+                final date = DateFormat(
+                  'M/d',
+                ).format(DateTime.parse(points[index].date));
                 return SideTitleWidget(
                   meta: meta,
                   child: Text(
@@ -17144,10 +21186,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               },
             ),
           ),
-          topTitles:
-              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-          rightTitles:
-              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          topTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+          rightTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
         ),
         lineBarsData: [
           line(
@@ -17220,9 +21264,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       lastAmount = _assetData[lastDate]?[type];
     }
     final isLiability = (lastAmount ?? 0) < 0;
-    final canQuickUpdate = lastAmount != null &&
-        !isUpdatedToday &&
-        lastDate == _yesterdayDateKey();
+    final canQuickUpdate = lastAmount != null && !isUpdatedToday;
 
     final accentColor =
         isLiability ? const Color(0xFFDC2626) : const Color(0xFF0D9488);
@@ -17307,9 +21349,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           onPressed: () => _toggleMinusForType(type),
           icon: const Icon(Icons.exposure_neg_1),
         ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
           borderSide: const BorderSide(color: Color(0xFFCBD5E1)),
@@ -17362,10 +21402,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         if (type != '現金')
           IconButton(
             tooltip: '削除',
-            icon: const Icon(
-              Icons.delete_outline,
-              color: Color(0xFF94A3B8),
-            ),
+            icon: const Icon(Icons.delete_outline, color: Color(0xFF94A3B8)),
             onPressed: () => _showRemoveAssetDialog(type),
           ),
       ],
@@ -17439,7 +21476,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           if (canQuickUpdate) ...[
             const SizedBox(height: 8),
             const Text(
-              '昨日と同額なら「同額」で素早く更新できます。',
+              '残高が変わっていなければ「同額」で前回と同じ額をすぐ記録できます。',
               style: TextStyle(
                 fontSize: 11,
                 color: Color(0xFF64748B),
@@ -17714,401 +21751,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ],
           ),
         ],
-      ),
-    );
-  }
-
-  // ④ 今月の支出と収入
-  // ignore: unused_element
-  Widget _buildFlowCardLegacy() {
-    final visibleFlows = _flowsForMonth(_selectedFlowHistoryMonth);
-    final visibleMonthLabel = _flowMonthLabel(_selectedFlowHistoryMonth);
-    final canMoveForward = !_isSameMonth(
-      _selectedFlowHistoryMonth,
-      DateTime.now(),
-    );
-    int totalIncome = 0;
-    int totalExpense = 0;
-
-    for (var item in visibleFlows) {
-      final amount = (item['amount'] as num?)?.toInt() ?? 0;
-      final actionType = item['action_type'] as String? ?? '';
-      if (actionType == 'conquer') totalIncome += amount; // 収入
-      if (actionType == 'expense') totalExpense += amount; // 支出
-    }
-
-    return Card(
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Row(
-              children: [
-                Icon(Icons.receipt_long, color: Color(0xFF6366F1)),
-                SizedBox(width: 8),
-                Text(
-                  '④収支の記録',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                    height: 1.4,
-                  ),
-                ),
-              ],
-            ),
-            Text(
-              'お金の流れをすべてリスト化する。表示中: $visibleMonthLabel（過去月に切替可）',
-              style: const TextStyle(
-                fontSize: 11,
-                color: Color(0xFF9CA3AF),
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                Expanded(
-                  flex: 2,
-                  child: DropdownButtonFormField<String>(
-                    initialValue: _selectedFlowType,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 8,
-                      ),
-                    ),
-                    items: ['支出', '収入']
-                        .map(
-                          (String val) => DropdownMenuItem(
-                            value: val,
-                            child: Text(
-                              val,
-                              style: const TextStyle(fontSize: 13, height: 1.6),
-                            ),
-                          ),
-                        )
-                        .toList(),
-                    onChanged: (val) {
-                      if (val != null) setState(() => _selectedFlowType = val);
-                    },
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  flex: 3,
-                  child: InkWell(
-                    onTap: () async {
-                      final date = await showDatePicker(
-                        context: context,
-                        initialDate: _selectedFlowDate,
-                        firstDate: DateTime(2020),
-                        lastDate: DateTime.now(),
-                      );
-                      if (date != null) {
-                        setState(() => _selectedFlowDate = date);
-                      }
-                    },
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 10,
-                      ),
-                      decoration: BoxDecoration(
-                        border: Border.all(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                        borderRadius: BorderRadius.circular(4),
-                      ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(DateFormat('MM/dd').format(_selectedFlowDate)),
-                          Icon(
-                            Icons.calendar_today,
-                            size: 16,
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.onSurfaceVariant,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-              decoration: BoxDecoration(
-                color: const Color(0xFF64748B),
-                borderRadius: BorderRadius.circular(10),
-                border: Border.all(
-                  color: const Color(0xFF475569).withValues(alpha: 0.12),
-                ),
-              ),
-              child: Row(
-                children: [
-                  IconButton(
-                    tooltip: '前月',
-                    onPressed: () => _shiftFlowHistoryMonth(-1),
-                    icon: const Icon(Icons.chevron_left),
-                  ),
-                  Expanded(
-                    child: InkWell(
-                      onTap: _pickFlowHistoryMonth,
-                      borderRadius: BorderRadius.circular(8),
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 6),
-                        child: Column(
-                          children: [
-                            const Text(
-                              '履歴表示月',
-                              style: TextStyle(
-                                fontSize: 10,
-                                color: Color(0xFF9CA3AF),
-                                height: 1.5,
-                              ),
-                            ),
-                            const SizedBox(height: 2),
-                            Text(
-                              visibleMonthLabel,
-                              style: const TextStyle(
-                                fontWeight: FontWeight.w800,
-                                fontSize: 15,
-                                height: 1.5,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                  IconButton(
-                    tooltip: '翌月',
-                    onPressed:
-                        canMoveForward ? () => _shiftFlowHistoryMonth(1) : null,
-                    icon: const Icon(Icons.chevron_right),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 8),
-            Row(
-              children: [
-                Expanded(
-                  flex: 2,
-                  child: DropdownButtonFormField<String>(
-                    initialValue: _selectedSource,
-                    isExpanded: true,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 8,
-                      ),
-                    ),
-                    items: _sourceOptions
-                        .map(
-                          (String source) => DropdownMenuItem(
-                            value: source,
-                            child: Text(
-                              source.replaceAll('[', '').replaceAll(']', ''),
-                              style: const TextStyle(fontSize: 13, height: 1.6),
-                            ),
-                          ),
-                        )
-                        .toList(),
-                    onChanged: (val) {
-                      if (val != null) setState(() => _selectedSource = val);
-                    },
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  flex: 3,
-                  child: TextField(
-                    controller: _flowMemoController,
-                    decoration: const InputDecoration(
-                      labelText: '内容',
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _flowAmountController,
-                    keyboardType: TextInputType.number,
-                    decoration: const InputDecoration(
-                      labelText: '金額 (円)',
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                ElevatedButton(
-                  onPressed: _recordFlow,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF64748B),
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                  ),
-                  child: const Text('追加'),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: const Color(0xFF64748B),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: [
-                  Column(
-                    children: [
-                      Text(
-                        '$visibleMonthLabel 収入',
-                        style: const TextStyle(fontSize: 10, height: 1.5),
-                      ),
-                      Text(
-                        '¥${NumberFormat('#,###').format(totalIncome)}',
-                        style: const TextStyle(
-                          color: Color(0xFF065F46),
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          height: 1.5,
-                        ),
-                      ),
-                    ],
-                  ),
-                  Column(
-                    children: [
-                      Text(
-                        '$visibleMonthLabel 支出',
-                        style: const TextStyle(fontSize: 10, height: 1.5),
-                      ),
-                      Text(
-                        '¥${NumberFormat('#,###').format(totalExpense)}',
-                        style: const TextStyle(
-                          color: Color(0xFF991B1B),
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          height: 1.5,
-                        ),
-                      ),
-                    ],
-                  ),
-                  Column(
-                    children: [
-                      const Text(
-                        '収支差額',
-                        style: TextStyle(fontSize: 10, height: 1.5),
-                      ),
-                      Text(
-                        '¥${NumberFormat('#,###').format(totalIncome - totalExpense)}',
-                        style: TextStyle(
-                          color: (totalIncome - totalExpense) >= 0
-                              ? const Color(0xFF065F46)
-                              : const Color(0xFF991B1B),
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          height: 1.5,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 8),
-            visibleFlows.isEmpty
-                ? Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Center(child: Text('$visibleMonthLabel の記録はありません')),
-                  )
-                : ListView.builder(
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    itemCount: visibleFlows.length,
-                    itemBuilder: (context, index) {
-                      final item = visibleFlows[index];
-                      final isIncome =
-                          (item['action_type'] as String?) == 'conquer';
-                      final amount = (item['amount'] as num?)?.toInt() ?? 0;
-                      final desc = item['description']?.toString() ?? '';
-                      final date = DateTime.tryParse(
-                            item['occurred_at']?.toString() ?? '',
-                          )?.toLocal() ??
-                          _selectedFlowHistoryMonth;
-                      return ListTile(
-                        dense: true,
-                        contentPadding: EdgeInsets.zero,
-                        onTap: () => _editFlow(item),
-                        leading: Icon(
-                          isIncome ? Icons.add_circle : Icons.remove_circle,
-                          color: isIncome
-                              ? const Color(0xFF0D9488)
-                              : const Color(0xFFB91C1C),
-                          size: 20,
-                        ),
-                        title: Text(
-                          desc,
-                          style: const TextStyle(fontSize: 13, height: 1.6),
-                        ),
-                        subtitle: Text(
-                          '${DateFormat('MM/dd').format(date)} ・ タップで編集',
-                          style: const TextStyle(fontSize: 11, height: 1.5),
-                        ),
-                        trailing: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              '${isIncome ? '+' : '-'}¥${NumberFormat('#,###').format(amount)}',
-                              style: TextStyle(
-                                color: isIncome
-                                    ? const Color(0xFF0D9488)
-                                    : const Color(0xFFB91C1C),
-                                fontWeight: FontWeight.bold,
-                                height: 1.5,
-                              ),
-                            ),
-                            const SizedBox(width: 4),
-                            IconButton(
-                              tooltip: '編集',
-                              visualDensity: VisualDensity.compact,
-                              icon: const Icon(Icons.edit_outlined, size: 20),
-                              color: const Color(0xFF64748B),
-                              onPressed: () => _editFlow(item),
-                            ),
-                            IconButton(
-                              tooltip: '削除',
-                              visualDensity: VisualDensity.compact,
-                              icon: const Icon(Icons.delete_outline, size: 20),
-                              color: const Color(0xFFF87171),
-                              onPressed: () => _deleteFlow(item),
-                            ),
-                          ],
-                        ),
-                      );
-                    },
-                  ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/services/asset_account_balance_history_store.dart
+++ b/lib/services/asset_account_balance_history_store.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 口座（負債）ごとの月末残高を月キー単位で蓄積するローカルストア。
+///
+/// 既存の月次スナップショット同期（過去に LWW でのデータ消失バグあり）には触れず、
+/// 独立した SharedPreferences キーへ自動蓄積する。これにより
+/// [AssetDebtTrendAnalyzer] の「前月比で残高が増えたか」判定に必要な
+/// 前月末残高を、マイグレーションや edge deploy 無しで供給できる。
+///
+/// 保存形式: `{ "yyyy-MM": { accountId: balanceMagnitude(正の値) } }`。
+class AssetAccountBalanceHistoryStore {
+  static const String prefsKey = 'asset_account_balance_history_v1';
+
+  /// 保持する月数の上限（古い月から間引く）。
+  static const int maxMonths = 13;
+
+  const AssetAccountBalanceHistoryStore();
+
+  static String formatMonthKey(DateTime month) {
+    return '${month.year.toString().padLeft(4, '0')}-'
+        '${month.month.toString().padLeft(2, '0')}';
+  }
+
+  /// 指定月の口座別残高を保存（同じ月キーは上書き）。
+  ///
+  /// [balancesByAccountId] は accountId -> 利用残高の絶対額（正の値）。
+  Future<void> recordMonth(
+    DateTime month,
+    Map<String, double> balancesByAccountId, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final history = _decode(store.getString(prefsKey));
+    final monthKey = formatMonthKey(month);
+    final sanitized = <String, double>{
+      for (final entry in balancesByAccountId.entries)
+        if (entry.key.trim().isNotEmpty && entry.value.isFinite)
+          entry.key.trim(): entry.value.abs(),
+    };
+    if (sanitized.isEmpty) {
+      // 負債が無い月でも「空である」事実を残すと前月比が壊れるため、
+      // 空マップでも上書き記録する（負債が消えた=完済の検出にも使える）。
+      history[monthKey] = <String, double>{};
+    } else {
+      history[monthKey] = sanitized;
+    }
+    _pruneOldMonths(history);
+    await store.setString(prefsKey, jsonEncode(history));
+  }
+
+  /// 指定月より前で「残高データがある」最も新しい月の口座別残高を返す（無ければ空）。
+  ///
+  /// 負債ゼロの月は空マップで記録されるため、それを飛ばして実データのある
+  /// 直近の月まで遡る。これにより「先月は完済 → 今月新規借入」でも前月比を
+  /// 取りこぼさない（空マップを返すと残高増加検出が壊れるのを防ぐ）。
+  Future<Map<String, double>> priorMonthBalances(
+    DateTime month, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final history = _decode(store.getString(prefsKey));
+    final currentKey = formatMonthKey(month);
+    final priorKeys =
+        history.keys.where((key) => key.compareTo(currentKey) < 0).toList()
+          ..sort();
+    for (final key in priorKeys.reversed) {
+      final balances = history[key]!;
+      if (balances.isNotEmpty) {
+        return Map<String, double>.unmodifiable(balances);
+      }
+    }
+    return const <String, double>{};
+  }
+
+  /// 蓄積済みの全月キー（昇順）。デバッグ・テスト用。
+  Future<List<String>> recordedMonthKeys({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final history = _decode(store.getString(prefsKey));
+    return history.keys.toList()..sort();
+  }
+
+  void _pruneOldMonths(Map<String, Map<String, double>> history) {
+    if (history.length <= maxMonths) {
+      return;
+    }
+    final keys = history.keys.toList()..sort();
+    final removeCount = history.length - maxMonths;
+    for (var i = 0; i < removeCount; i++) {
+      history.remove(keys[i]);
+    }
+  }
+
+  Map<String, Map<String, double>> _decode(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, Map<String, double>>{};
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        return <String, Map<String, double>>{};
+      }
+      final result = <String, Map<String, double>>{};
+      decoded.forEach((monthKey, value) {
+        if (monthKey is! String || value is! Map) {
+          return;
+        }
+        final balances = <String, double>{};
+        value.forEach((accountId, balance) {
+          if (accountId is! String) {
+            return;
+          }
+          final parsed = balance is num
+              ? balance.toDouble()
+              : double.tryParse(balance.toString());
+          // 残高は絶対値（正の値）で保存する契約。負値は破損データとして拒否する。
+          if (parsed != null && parsed.isFinite && parsed >= 0) {
+            balances[accountId] = parsed;
+          }
+        });
+        result[monthKey] = balances;
+      });
+      return result;
+    } catch (_) {
+      return <String, Map<String, double>>{};
+    }
+  }
+}

--- a/lib/services/asset_account_balance_history_store.dart
+++ b/lib/services/asset_account_balance_history_store.dart
@@ -81,6 +81,51 @@ class AssetAccountBalanceHistoryStore {
     return history.keys.toList()..sort();
   }
 
+  /// 蓄積済みの全履歴（monthKey -> {accountId: 残高}）。端末跨ぎミラー同期用。
+  Future<Map<String, Map<String, double>>> loadAll({
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return _decode(store.getString(prefsKey));
+  }
+
+  /// 他端末由来のミラー値（jsonb 由来の Map）をローカル履歴へ和集合マージする。
+  ///
+  /// 月キー・口座とも非破壊（消さない・上書きしない）で、ローカルに無いものだけ
+  /// 補完する。競合する口座はローカル値を優先する（各端末は同期済みの残高から
+  /// 同値を導くため実害は小さく、月の取りこぼし/巻き戻しを防ぐことを優先）。
+  /// 変更があれば true を返す。
+  Future<bool> mergeRemote(Object? remoteValue, {SharedPreferences? prefs}) async {
+    final remote = remoteValue is Map
+        ? _decodeMap(remoteValue)
+        : const <String, Map<String, double>>{};
+    if (remote.isEmpty) {
+      return false;
+    }
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final local = _decode(store.getString(prefsKey));
+    var changed = false;
+    remote.forEach((monthKey, remoteBalances) {
+      final localBalances = local[monthKey];
+      if (localBalances == null) {
+        local[monthKey] = Map<String, double>.from(remoteBalances);
+        changed = true;
+        return;
+      }
+      remoteBalances.forEach((accountId, balance) {
+        if (!localBalances.containsKey(accountId)) {
+          localBalances[accountId] = balance;
+          changed = true;
+        }
+      });
+    });
+    if (changed) {
+      _pruneOldMonths(local);
+      await store.setString(prefsKey, jsonEncode(local));
+    }
+    return changed;
+  }
+
   void _pruneOldMonths(Map<String, Map<String, double>> history) {
     if (history.length <= maxMonths) {
       return;
@@ -98,32 +143,35 @@ class AssetAccountBalanceHistoryStore {
     }
     try {
       final decoded = jsonDecode(raw);
-      if (decoded is! Map) {
-        return <String, Map<String, double>>{};
-      }
-      final result = <String, Map<String, double>>{};
-      decoded.forEach((monthKey, value) {
-        if (monthKey is! String || value is! Map) {
-          return;
-        }
-        final balances = <String, double>{};
-        value.forEach((accountId, balance) {
-          if (accountId is! String) {
-            return;
-          }
-          final parsed = balance is num
-              ? balance.toDouble()
-              : double.tryParse(balance.toString());
-          // 残高は絶対値（正の値）で保存する契約。負値は破損データとして拒否する。
-          if (parsed != null && parsed.isFinite && parsed >= 0) {
-            balances[accountId] = parsed;
-          }
-        });
-        result[monthKey] = balances;
-      });
-      return result;
+      return decoded is Map
+          ? _decodeMap(decoded)
+          : <String, Map<String, double>>{};
     } catch (_) {
       return <String, Map<String, double>>{};
     }
+  }
+
+  Map<String, Map<String, double>> _decodeMap(Map decoded) {
+    final result = <String, Map<String, double>>{};
+    decoded.forEach((monthKey, value) {
+      if (monthKey is! String || value is! Map) {
+        return;
+      }
+      final balances = <String, double>{};
+      value.forEach((accountId, balance) {
+        if (accountId is! String) {
+          return;
+        }
+        final parsed = balance is num
+            ? balance.toDouble()
+            : double.tryParse(balance.toString());
+        // 残高は絶対値（正の値）で保存する契約。負値は破損データとして拒否する。
+        if (parsed != null && parsed.isFinite && parsed >= 0) {
+          balances[accountId] = parsed;
+        }
+      });
+      result[monthKey] = balances;
+    });
+    return result;
   }
 }

--- a/lib/services/asset_debt_trend_analyzer.dart
+++ b/lib/services/asset_debt_trend_analyzer.dart
@@ -1,0 +1,438 @@
+import 'dart:math';
+
+import '../models/asset_liability_workbook.dart';
+
+/// 今月の負債の「問題点」を分類するカテゴリ。
+///
+/// - [negativeAmortization]: 返済額が利息以下で、残高が永遠に減らない（リボ複利地獄）。
+/// - [balanceIncreasing]: 前月比で利用残高が増えており、新規利用が返済を上回っている。
+/// - [slowPayoff]: 元金は減るが、今のペースだと完済まで極端に長い。
+enum AssetDebtTrendCategory {
+  negativeAmortization,
+  balanceIncreasing,
+  slowPayoff,
+}
+
+/// 指摘の重要度。資金繰り系インサイトと同じ 3 段階に揃える。
+enum AssetDebtTrendSeverity { info, warning, critical }
+
+/// 1 件の負債に対する「今月の問題点」と「翌月の具体アクション」。
+///
+/// 金額はすべて Dart 側で計算済みで、AI には説明と優先順位付けのみを任せる
+/// （[AssetManagementInsightPromptBuilder] と同じ方針）。
+class AssetDebtTrendInsight {
+  final String accountId;
+  final String accountName;
+  final AssetLiabilityAccountKind kind;
+  final AssetDebtTrendCategory category;
+  final AssetDebtTrendSeverity severity;
+
+  /// 現在の利用残高（負債の絶対額・正の値）。
+  final double currentBalance;
+
+  /// 前月末の利用残高（履歴がある場合のみ・正の値）。
+  final double? priorBalance;
+
+  /// 前月比の残高変動（正 = 増加）。履歴がある場合のみ。
+  final double? balanceDelta;
+
+  /// 今月の月利息見込み。
+  final double monthlyInterest;
+
+  /// 今月の返済予定額。
+  final double scheduledPayment;
+
+  /// 残高を減らさずに済む「止血ライン」= 利息を 1 円でも上回る返済額。
+  final double interestBreakEvenPayment;
+
+  /// 24 ヶ月で完済するための目安返済額（年金現価式）。
+  final double payoffIn24MonthsPayment;
+
+  /// 今の返済額のままでの完済月数（null = この返済額では一生終わらない）。
+  final int? estimatedPayoffMonths;
+
+  /// 今の返済額のままでの総支払利息見込み（完済する場合のみ）。
+  final double? estimatedTotalInterest;
+
+  /// 画面・プロンプトに出す「今月の問題点」一文。
+  final String problem;
+
+  /// 画面・プロンプトに出す「翌月の具体アクション」一文。
+  final String nextMonthAction;
+
+  const AssetDebtTrendInsight({
+    required this.accountId,
+    required this.accountName,
+    required this.kind,
+    required this.category,
+    required this.severity,
+    required this.currentBalance,
+    required this.priorBalance,
+    required this.balanceDelta,
+    required this.monthlyInterest,
+    required this.scheduledPayment,
+    required this.interestBreakEvenPayment,
+    required this.payoffIn24MonthsPayment,
+    required this.estimatedPayoffMonths,
+    required this.estimatedTotalInterest,
+    required this.problem,
+    required this.nextMonthAction,
+  });
+}
+
+/// 固定額返済を続けたときの完済シミュレーション結果。
+class DebtPayoffEstimate {
+  /// 完済までの月数（null = [maxMonths] 以内に完済できない）。
+  final int? months;
+
+  /// 完済までに支払う利息の総額（完済できない場合は [maxMonths] までの累計）。
+  final double totalInterest;
+
+  /// この返済額で元金がいつか 0 になるか。
+  final bool everPaysOff;
+
+  const DebtPayoffEstimate({
+    required this.months,
+    required this.totalInterest,
+    required this.everPaysOff,
+  });
+}
+
+/// 月をまたいだ負債トレンドを決定論的に分析するサービス。
+///
+/// 既存の [AssetManagementInsightService] は「今〜給料日」の資金繰りに特化しており、
+/// 「先月より借金が増えていないか」「返済額が利息に負けていないか」を判定しない。
+/// 本サービスがその欠落を埋め、リボ複利・残高増加・超長期完済を検出して
+/// 翌月の具体アクションを生成する。
+class AssetDebtTrendAnalyzer {
+  const AssetDebtTrendAnalyzer({
+    this.balanceIncreaseThreshold = 5000,
+    this.slowPayoffMonthThreshold = 60,
+  });
+
+  /// 「残高が増えた」と見なす最小増加額（円）。小さなブレを問題化しない。
+  final double balanceIncreaseThreshold;
+
+  /// 「完済が遅すぎる」と見なす月数の閾値。
+  final int slowPayoffMonthThreshold;
+
+  static const double _epsilon = 1;
+
+  /// 利息を持ちうる（=リボ・分割が発生しうる）負債種別か。
+  ///
+  /// 家賃・通信費など [AssetLiabilityDebtRow.fullPaymentEstimate] の固定費は除外する
+  /// （毎月全額払いで残高が累積しないため）。
+  static bool isRevolvingLikeKind(AssetLiabilityAccountKind kind) {
+    return switch (kind) {
+      AssetLiabilityAccountKind.cardLoan ||
+      AssetLiabilityAccountKind.shoppingDebt ||
+      AssetLiabilityAccountKind.creditCard ||
+      AssetLiabilityAccountKind.otherLiability =>
+        true,
+      _ => false,
+    };
+  }
+
+  /// ワークブックと（あれば）前月末の口座別残高から負債トレンド指摘を生成する。
+  ///
+  /// [priorBalancesByAccountId] は accountId -> 前月末の利用残高（正の値）。
+  /// 空の場合でも、履歴の要らない①負の償却 ③超長期完済 は検出される。
+  List<AssetDebtTrendInsight> analyze({
+    required AssetLiabilityWorkbook workbook,
+    Map<String, double> priorBalancesByAccountId = const <String, double>{},
+  }) {
+    final insights = <AssetDebtTrendInsight>[];
+    for (final row in workbook.debtMasterRows) {
+      final insight = _analyzeRow(row, priorBalancesByAccountId);
+      if (insight != null) {
+        insights.add(insight);
+      }
+    }
+    insights.sort(_compare);
+    return List<AssetDebtTrendInsight>.unmodifiable(insights);
+  }
+
+  AssetDebtTrendInsight? _analyzeRow(
+    AssetLiabilityDebtRow row,
+    Map<String, double> priorBalances,
+  ) {
+    if (!isRevolvingLikeKind(row.kind) || row.fullPaymentEstimate) {
+      return null;
+    }
+    final balance = row.balance.abs();
+    if (balance <= _epsilon) {
+      return null;
+    }
+
+    final interest = max(0.0, row.monthlyInterestEstimate);
+    final payment = max(0.0, row.scheduledPaymentAmount);
+    final monthlyRate = row.annualRate / 12;
+    final priorBalance = priorBalances[row.id];
+    final delta = priorBalance == null ? null : balance - priorBalance;
+
+    final breakEven = interest + 1;
+    final payoff24 = _paymentToClearIn(balance, monthlyRate, 24);
+    final estimate = estimatePayoff(
+      balance: balance,
+      monthlyRate: monthlyRate,
+      monthlyPayment: payment,
+    );
+
+    final category = _classify(
+      row: row,
+      payment: payment,
+      delta: delta,
+      estimate: estimate,
+    );
+    if (category == null) {
+      return null;
+    }
+
+    final severity = _severityFor(
+      category: category,
+      payment: payment,
+      delta: delta,
+    );
+    final problem = _problemText(
+      category: category,
+      row: row,
+      balance: balance,
+      delta: delta,
+      interest: interest,
+      payment: payment,
+      estimate: estimate,
+    );
+    final action = _actionText(
+      category: category,
+      balance: balance,
+      delta: delta,
+      payment: payment,
+      breakEven: breakEven,
+      payoff24: payoff24,
+    );
+
+    return AssetDebtTrendInsight(
+      accountId: row.id,
+      accountName: row.name,
+      kind: row.kind,
+      category: category,
+      severity: severity,
+      currentBalance: balance,
+      priorBalance: priorBalance,
+      balanceDelta: delta,
+      monthlyInterest: interest,
+      scheduledPayment: payment,
+      interestBreakEvenPayment: breakEven,
+      payoffIn24MonthsPayment: payoff24,
+      estimatedPayoffMonths: estimate.months,
+      estimatedTotalInterest: estimate.everPaysOff ? estimate.totalInterest : null,
+      problem: problem,
+      nextMonthAction: action,
+    );
+  }
+
+  AssetDebtTrendCategory? _classify({
+    required AssetLiabilityDebtRow row,
+    required double payment,
+    required double? delta,
+    required DebtPayoffEstimate estimate,
+  }) {
+    // ① 返済額が利息以下 → 元金が 1 円も減らない（最優先で指摘）。
+    if (payment > 0 && row.principalPaymentEstimate < _epsilon) {
+      return AssetDebtTrendCategory.negativeAmortization;
+    }
+    // ② 前月比で残高が増加（新規利用が返済を侵食）。
+    if (delta != null && delta > balanceIncreaseThreshold) {
+      return AssetDebtTrendCategory.balanceIncreasing;
+    }
+    // ③ 元金は減るが完済まで極端に長い。
+    if (estimate.everPaysOff &&
+        estimate.months != null &&
+        estimate.months! > slowPayoffMonthThreshold) {
+      return AssetDebtTrendCategory.slowPayoff;
+    }
+    return null;
+  }
+
+  AssetDebtTrendSeverity _severityFor({
+    required AssetDebtTrendCategory category,
+    required double payment,
+    required double? delta,
+  }) {
+    switch (category) {
+      case AssetDebtTrendCategory.negativeAmortization:
+        return AssetDebtTrendSeverity.critical;
+      case AssetDebtTrendCategory.balanceIncreasing:
+        // 増加額が返済額を上回る = 払っても追いつかない → critical。
+        if (delta != null && delta > payment) {
+          return AssetDebtTrendSeverity.critical;
+        }
+        return AssetDebtTrendSeverity.warning;
+      case AssetDebtTrendCategory.slowPayoff:
+        return AssetDebtTrendSeverity.warning;
+    }
+  }
+
+  String _problemText({
+    required AssetDebtTrendCategory category,
+    required AssetLiabilityDebtRow row,
+    required double balance,
+    required double? delta,
+    required double interest,
+    required double payment,
+    required DebtPayoffEstimate estimate,
+  }) {
+    switch (category) {
+      case AssetDebtTrendCategory.negativeAmortization:
+        return '${row.name}は今月の返済予定額${_yen(payment)}が利息${_yen(interest)}以下です。'
+            'このままでは元金が1円も減らず、残高${_yen(balance)}は利息分だけ毎月膨らみ続けます。';
+      case AssetDebtTrendCategory.balanceIncreasing:
+        final increase = delta ?? 0;
+        final net = increase - payment;
+        final netClause = net > 0
+            ? '返済${_yen(payment)}を払っても純増${_yen(net)}で、借金は雪だるま式に増えています。'
+            : '返済${_yen(payment)}でかろうじて吸収していますが、新規利用が返済を圧迫しています。';
+        return '${row.name}の利用残高が先月比+${_yen(increase)}（${_yen(balance)}）に増えました。'
+            '$netClause';
+      case AssetDebtTrendCategory.slowPayoff:
+        final months = estimate.months;
+        final years = months == null ? null : (months / 12);
+        final yearsText =
+            years == null ? '' : '（約${years.toStringAsFixed(1)}年）';
+        final interestText = estimate.everPaysOff
+            ? '完済までに利息だけで${_yen(estimate.totalInterest)}を支払う計算です。'
+            : '';
+        return '${row.name}は今の返済額${_yen(payment)}だと完済まで約${months ?? '-'}ヶ月$yearsText。'
+            '$interestText';
+    }
+  }
+
+  String _actionText({
+    required AssetDebtTrendCategory category,
+    required double balance,
+    required double? delta,
+    required double payment,
+    required double breakEven,
+    required double payoff24,
+  }) {
+    switch (category) {
+      case AssetDebtTrendCategory.negativeAmortization:
+        return '①リボ払いを解除して一括返済する、'
+            '②または翌月から返済額を最低でも利息を上回る${_yen(breakEven)}（24ヶ月で完済するなら${_yen(payoff24)}）以上に引き上げてください。'
+            '元金を確実に減らすため、新規利用も止めるのが理想です。';
+      case AssetDebtTrendCategory.balanceIncreasing:
+        final increase = delta ?? 0;
+        return '翌月は新規利用を返済額${_yen(payment)}以下に抑えるか、'
+            '返済額を今月の増加分${_yen(increase)}以上に引き上げて残高を増やさないでください。'
+            '可能ならリボを解除して一括返済し、24ヶ月で完済するなら月${_yen(payoff24)}が目安です。';
+      case AssetDebtTrendCategory.slowPayoff:
+        return '返済額を月${_yen(payoff24)}まで引き上げると24ヶ月で完済でき、利息総額を大きく圧縮できます。'
+            '余力がある月は繰上返済を、新規利用は控えてください。';
+    }
+  }
+
+  int _compare(AssetDebtTrendInsight a, AssetDebtTrendInsight b) {
+    final severity = _severityRank(b.severity).compareTo(_severityRank(a.severity));
+    if (severity != 0) {
+      return severity;
+    }
+    // 重要度が同じなら、残高への影響が大きい順（増加額 → 残高）。
+    final aImpact = (a.balanceDelta ?? 0).abs();
+    final bImpact = (b.balanceDelta ?? 0).abs();
+    final impact = bImpact.compareTo(aImpact);
+    if (impact != 0) {
+      return impact;
+    }
+    final balance = b.currentBalance.compareTo(a.currentBalance);
+    if (balance != 0) {
+      return balance;
+    }
+    return a.accountName.compareTo(b.accountName);
+  }
+
+  int _severityRank(AssetDebtTrendSeverity severity) {
+    return switch (severity) {
+      AssetDebtTrendSeverity.critical => 3,
+      AssetDebtTrendSeverity.warning => 2,
+      AssetDebtTrendSeverity.info => 1,
+    };
+  }
+
+  /// 固定額返済を続けたときの完済シミュレーション。
+  ///
+  /// [monthlyPayment] が初月の利息以下なら元金が減らないため、
+  /// [DebtPayoffEstimate.everPaysOff] = false / [DebtPayoffEstimate.months] = null を返す。
+  static DebtPayoffEstimate estimatePayoff({
+    required double balance,
+    required double monthlyRate,
+    required double monthlyPayment,
+    int maxMonths = 600,
+  }) {
+    if (balance <= _epsilon) {
+      return const DebtPayoffEstimate(
+        months: 0,
+        totalInterest: 0,
+        everPaysOff: true,
+      );
+    }
+    final rate = max(0.0, monthlyRate);
+    final firstInterest = balance * rate;
+    if (monthlyPayment <= firstInterest + _epsilon) {
+      // 返済額が利息を超えない限り元金は減らない。
+      return DebtPayoffEstimate(
+        months: null,
+        totalInterest: firstInterest,
+        everPaysOff: false,
+      );
+    }
+    var remaining = balance;
+    var totalInterest = 0.0;
+    for (var month = 1; month <= maxMonths; month++) {
+      final interest = remaining * rate;
+      totalInterest += interest;
+      remaining = remaining + interest - monthlyPayment;
+      if (remaining <= _epsilon) {
+        return DebtPayoffEstimate(
+          months: month,
+          totalInterest: totalInterest,
+          everPaysOff: true,
+        );
+      }
+    }
+    return DebtPayoffEstimate(
+      months: null,
+      totalInterest: totalInterest,
+      everPaysOff: false,
+    );
+  }
+
+  /// [targetMonths] ヶ月で完済するために必要な毎月返済額（年金現価式）。
+  ///
+  /// 月利 0 のときは単純に balance / months。100 円単位へ切り上げる。
+  double _paymentToClearIn(double balance, double monthlyRate, int targetMonths) {
+    final months = max(1, targetMonths);
+    final rate = max(0.0, monthlyRate);
+    final double raw;
+    if (rate <= 0) {
+      raw = balance / months;
+    } else {
+      final factor = pow(1 + rate, months).toDouble();
+      raw = balance * rate * factor / (factor - 1);
+    }
+    return (raw / 100).ceilToDouble() * 100;
+  }
+
+  String _yen(double amount) {
+    final sign = amount < 0 ? '-' : '';
+    final digits = amount.abs().round().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      final remaining = digits.length - i;
+      buffer.write(digits[i]);
+      if (remaining > 1 && remaining % 3 == 1) {
+        buffer.write(',');
+      }
+    }
+    return '$sign$buffer円';
+  }
+}

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -1,5 +1,7 @@
 import '../models/asset_liability_workbook.dart';
 import '../models/user_profile.dart';
+import 'asset_debt_trend_analyzer.dart';
+import 'asset_management_available_money.dart';
 
 enum AssetManagementInsightActionType {
   missingInput,
@@ -224,6 +226,9 @@ class AssetManagementInsightReport {
   final List<AssetManagementDeveloperRequest> developerRequests;
   final List<AssetManagementImplementationContext> implementationContexts;
 
+  /// 月をまたいだ負債トレンド（リボ複利・残高増加・超長期完済）の指摘。
+  final List<AssetDebtTrendInsight> debtTrendInsights;
+
   const AssetManagementInsightReport({
     required this.workbook,
     this.userProfile,
@@ -236,7 +241,18 @@ class AssetManagementInsightReport {
     required this.developerRequests,
     this.implementationContexts =
         const <AssetManagementImplementationContext>[],
+    this.debtTrendInsights = const <AssetDebtTrendInsight>[],
   });
+
+  bool get hasDebtTrendInsights => debtTrendInsights.isNotEmpty;
+
+  List<AssetDebtTrendInsight> get criticalDebtTrendInsights {
+    return debtTrendInsights
+        .where(
+          (insight) => insight.severity == AssetDebtTrendSeverity.critical,
+        )
+        .toList(growable: false);
+  }
 
   bool get hasCriticalActions {
     return actionItems.any(
@@ -266,33 +282,36 @@ class AssetManagementInsightService {
         AssetManagementImplementationContext.defaultAssetManagementContexts,
     double minimumSafetyBalance = defaultMinimumSafetyBalance,
     int upcomingPaymentWarningDays = defaultUpcomingPaymentWarningDays,
+    String? mainAccountId,
+    Map<String, double> priorMonthAccountBalances = const <String, double>{},
+    AssetDebtTrendAnalyzer debtTrendAnalyzer = const AssetDebtTrendAnalyzer(),
   }) {
+    final breakdown = _availableMoneyBreakdown(
+      workbook: workbook,
+      mainAccountId: mainAccountId,
+      minimumSafetyBalance: minimumSafetyBalance,
+    );
+    final today = _availableInsightFromBreakdown(
+      AssetManagementInsightWindow.today,
+      breakdown,
+      workbook.baseDate,
+    );
+    final week = _availableInsightFromBreakdown(
+      AssetManagementInsightWindow.week,
+      breakdown,
+      workbook.baseDate,
+    );
+    final month = _availableInsightFromBreakdown(
+      AssetManagementInsightWindow.month,
+      breakdown,
+      workbook.baseDate,
+    );
     final actions = _buildActionItems(
       workbook: workbook,
       upcomingPaymentWarningDays: upcomingPaymentWarningDays,
       minimumSafetyBalance: minimumSafetyBalance,
+      todayInsight: today,
     )..sort(_compareActionItems);
-    final today = _buildAvailableMoneyInsight(
-      workbook: workbook,
-      window: AssetManagementInsightWindow.today,
-      startDate: _dateOnly(workbook.baseDate),
-      endDate: _dateOnly(workbook.baseDate),
-      minimumSafetyBalance: minimumSafetyBalance,
-    );
-    final week = _buildAvailableMoneyInsight(
-      workbook: workbook,
-      window: AssetManagementInsightWindow.week,
-      startDate: _dateOnly(workbook.baseDate),
-      endDate: _dateOnly(workbook.baseDate).add(const Duration(days: 6)),
-      minimumSafetyBalance: minimumSafetyBalance,
-    );
-    final month = _buildAvailableMoneyInsight(
-      workbook: workbook,
-      window: AssetManagementInsightWindow.month,
-      startDate: DateTime(workbook.baseDate.year, workbook.baseDate.month),
-      endDate: DateTime(workbook.baseDate.year, workbook.baseDate.month + 1, 0),
-      minimumSafetyBalance: minimumSafetyBalance,
-    );
     final movementSuggestions = _buildMovementSuggestions(
       workbook: workbook,
       windows: <AssetManagementAvailableMoneyInsight>[today, week, month],
@@ -310,6 +329,10 @@ class AssetManagementInsightService {
       actions: actions,
       movementSuggestions: movementSuggestions,
     );
+    final debtTrendInsights = debtTrendAnalyzer.analyze(
+      workbook: workbook,
+      priorBalancesByAccountId: priorMonthAccountBalances,
+    );
 
     return AssetManagementInsightReport(
       workbook: workbook,
@@ -322,6 +345,7 @@ class AssetManagementInsightService {
       emergencyAdvices: emergencyAdvices,
       developerRequests: developerRequests,
       implementationContexts: implementationContexts,
+      debtTrendInsights: debtTrendInsights,
     );
   }
 
@@ -329,6 +353,7 @@ class AssetManagementInsightService {
     required AssetLiabilityWorkbook workbook,
     required int upcomingPaymentWarningDays,
     required double minimumSafetyBalance,
+    required AssetManagementAvailableMoneyInsight todayInsight,
   }) {
     final actions = <AssetManagementInsightActionItem>[];
     final today = _dateOnly(workbook.baseDate);
@@ -359,7 +384,7 @@ class AssetManagementInsightService {
             relatedAccountId: row.id,
             dueDate: null,
             paymentDay: null,
-            suggestedAction: '契約画面または請求明細で支払日を確認して入力してください。',
+            suggestedAction: '契約画面または請求明細で支払日を確認し、負債マスタ（支払日順）の「支払日」欄に入力してください。',
           ),
         );
       }
@@ -444,13 +469,6 @@ class AssetManagementInsightService {
       }
     }
 
-    final todayInsight = _buildAvailableMoneyInsight(
-      workbook: workbook,
-      window: AssetManagementInsightWindow.today,
-      startDate: today,
-      endDate: today,
-      minimumSafetyBalance: minimumSafetyBalance,
-    );
     if (todayInsight.availableAmount < 0) {
       actions.add(
         AssetManagementInsightActionItem(
@@ -480,7 +498,8 @@ class AssetManagementInsightService {
               ? null
               : _paymentDateFromDay(workbook.baseDate, item.paymentDay!),
           paymentDay: item.paymentDay,
-          suggestedAction: 'カード請求に含める設定と請求先カードを確認してください。',
+          suggestedAction:
+              '負債マスタ（支払日順）の「支払い方式」でカード請求に含める設定と請求先カードを確認してください。請求額が0円の月は「今月支払予定額」に0を入力してください。',
         ),
       );
     }
@@ -505,35 +524,62 @@ class AssetManagementInsightService {
     return actions;
   }
 
-  AssetManagementAvailableMoneyInsight _buildAvailableMoneyInsight({
+  AssetManagementAvailableMoneyBreakdown _availableMoneyBreakdown({
     required AssetLiabilityWorkbook workbook,
-    required AssetManagementInsightWindow window,
-    required DateTime startDate,
-    required DateTime endDate,
+    required String? mainAccountId,
     required double minimumSafetyBalance,
   }) {
-    final payments = _paymentTotalForWindow(
-      workbook: workbook,
-      startDate: startDate,
-      endDate: endDate,
+    final today = _dateOnly(workbook.baseDate);
+    final payday = AssetManagementAvailableMoney.nextPayday(today);
+    final remainingDays =
+        AssetManagementAvailableMoney.remainingDaysToPayday(today, payday);
+    final daysThisWeek = AssetManagementAvailableMoney.daysUntilWeekEnd(
+      today,
+      remainingDays: remainingDays,
     );
-    final income = _incomeTotalForWindow(
-      workbook: workbook,
-      startDate: startDate,
-      endDate: endDate,
+    return AssetManagementAvailableMoneyBreakdown(
+      availableAssets: AssetManagementAvailableMoney.availableAssets(
+        accounts: workbook.accounts,
+        mainAccountId: mainAccountId,
+      ),
+      unpaidUntilPayday: AssetManagementAvailableMoney.unpaidUntilPayday(
+        cashflowRows: workbook.cashflowRows,
+        payday: payday,
+      ),
+      minimumSafetyBalance: minimumSafetyBalance,
+      remainingDaysToPayday: remainingDays,
+      daysThisWeek: daysThisWeek,
+      payday: payday,
     );
-    final available =
-        workbook.cashLikeTotal + income - payments - minimumSafetyBalance;
+  }
+
+  AssetManagementAvailableMoneyInsight _availableInsightFromBreakdown(
+    AssetManagementInsightWindow window,
+    AssetManagementAvailableMoneyBreakdown breakdown,
+    DateTime baseDate,
+  ) {
+    final start = _dateOnly(baseDate);
+    final amount = switch (window) {
+      AssetManagementInsightWindow.today => breakdown.todayAvailable,
+      AssetManagementInsightWindow.week => breakdown.weekAvailable,
+      AssetManagementInsightWindow.month => breakdown.monthAvailable,
+    };
+    final end = switch (window) {
+      AssetManagementInsightWindow.today => start,
+      AssetManagementInsightWindow.week =>
+        start.add(Duration(days: breakdown.daysThisWeek - 1)),
+      AssetManagementInsightWindow.month => breakdown.payday,
+    };
     return AssetManagementAvailableMoneyInsight(
       window: window,
-      startDate: startDate,
-      endDate: endDate,
-      cashLikeTotal: workbook.cashLikeTotal,
-      unpaidPaymentTotal: payments,
-      unreceivedIncomeTotal: income,
-      minimumSafetyBalance: minimumSafetyBalance,
-      availableAmount: available,
-      summary: _availableSummary(window, available),
+      startDate: start,
+      endDate: end,
+      cashLikeTotal: breakdown.availableAssets,
+      unpaidPaymentTotal: breakdown.unpaidUntilPayday,
+      unreceivedIncomeTotal: 0,
+      minimumSafetyBalance: breakdown.minimumSafetyBalance,
+      availableAmount: amount,
+      summary: _availableSummary(window, amount),
     );
   }
 
@@ -911,44 +957,12 @@ class AssetManagementInsightService {
         (rows.length > 6 ? ' ほか${rows.length - 6}件' : '');
   }
 
-  double _paymentTotalForWindow({
-    required AssetLiabilityWorkbook workbook,
-    required DateTime startDate,
-    required DateTime endDate,
-  }) {
-    return workbook.cashflowRows.fold<double>(0, (sum, row) {
-      if (!row.isPayment ||
-          !row.isDirectCashflowTarget ||
-          row.paid ||
-          row.paymentAmount <= 0) {
-        return sum;
-      }
-      final date = _dateOnly(row.paymentDate);
-      final inWindow = !date.isBefore(startDate) && !date.isAfter(endDate);
-      final overdueForWindow =
-          row.overdue && !endDate.isBefore(_dateOnly(workbook.baseDate));
-      return inWindow || overdueForWindow ? sum + row.paymentAmount : sum;
-    });
-  }
-
-  double _incomeTotalForWindow({
-    required AssetLiabilityWorkbook workbook,
-    required DateTime startDate,
-    required DateTime endDate,
-  }) {
-    return workbook.cashflowRows.fold<double>(0, (sum, row) {
-      if (!row.isIncome || row.received || row.paymentAmount <= 0) {
-        return sum;
-      }
-      final date = _dateOnly(row.paymentDate);
-      return !date.isBefore(startDate) && !date.isAfter(endDate)
-          ? sum + row.paymentAmount
-          : sum;
-    });
-  }
-
   bool _needsAnnualRate(AssetLiabilityDebtRow row) {
     if (row.annualRate > 0) {
+      return false;
+    }
+    // 家賃・通信費など全額支払い型の固定費は利率の概念がないため対象外。
+    if (row.fullPaymentEstimate) {
       return false;
     }
     return switch (row.kind) {
@@ -1114,7 +1128,11 @@ class AssetManagementInsightPromptBuilder {
     return buildDetailedAdvicePrompt(report);
   }
 
-  String buildDetailedAdvicePrompt(AssetManagementInsightReport report) {
+  String buildDetailedAdvicePrompt(
+    AssetManagementInsightReport report, {
+    Map<String, Map<String, dynamic>> existingDeveloperIssuesByTitle =
+        const <String, Map<String, dynamic>>{},
+  }) {
     final severityCounts = _countBy(
       report.actionItems.map((item) => item.severity.name),
     );
@@ -1155,6 +1173,12 @@ class AssetManagementInsightPromptBuilder {
       )
       ..writeln(
         '「7. 開発者向け改善提案」では、各提案ごとに「現状の痛み」「根拠データ」「変更ファイル」「実装手順」「受け入れ条件」「テスト/確認コマンド」「リスク」を必ず書いてください。',
+      )
+      ..writeln(
+        '「4. 今月の支払いと利息」と「5. 今後3〜5年の運気と借金圧縮」では、下記「今月の問題点と翌月の改善（負債トレンド）」を最優先で扱ってください。'
+        '特にリボ払いで返済額が利息以下の負債、前月比で利用残高が増えた負債は、'
+        '「今月いくら増えたか」「このままだと何年で完済か/一生終わらないか」「翌月いくら返済すべきか（具体額）」を断言してください。'
+        '該当データが無い月だけ、そのカテゴリには触れなくて構いません。',
       )
       ..writeln()
       ..writeln('## 総合サマリー')
@@ -1210,6 +1234,9 @@ class AssetManagementInsightPromptBuilder {
       ..writeln('## カード請求内訳と照合')
       ..write(_cardBillingLines(workbook))
       ..writeln()
+      ..writeln('## 今月の問題点と翌月の改善（負債トレンド）')
+      ..write(_debtTrendLines(report))
+      ..writeln()
       ..writeln('## アクション件数')
       ..writeln('- 合計: ${report.actionItems.length}')
       ..writeln('- 重要度別: ${_formatCounts(severityCounts)}')
@@ -1229,7 +1256,12 @@ class AssetManagementInsightPromptBuilder {
       ..writeln('## 開発者向け改善提案候補')
       ..writeln('- 合計: ${report.developerRequests.length}')
       ..writeln('- 重要度別: ${_formatCounts(developerCounts)}')
-      ..write(_developerRequestLines(report.developerRequests));
+      ..write(
+        _developerRequestLines(
+          report.developerRequests,
+          existingDeveloperIssuesByTitle: existingDeveloperIssuesByTitle,
+        ),
+      );
     return buffer.toString();
   }
 
@@ -1465,6 +1497,44 @@ class AssetManagementInsightPromptBuilder {
     return buffer.toString();
   }
 
+  String _debtTrendLines(AssetManagementInsightReport report) {
+    if (report.debtTrendInsights.isEmpty) {
+      return '- 月をまたいだ負債の悪化トレンドは検出されていません。'
+          '前月比のデータが無い場合は、来月以降の比較のために今月の残高を保存してください。\n';
+    }
+    final buffer = StringBuffer();
+    for (final insight in report.debtTrendInsights) {
+      final priorText = insight.priorBalance == null
+          ? '前月残高:履歴なし'
+          : '前月残高:${_formatAmount(insight.priorBalance!)} / '
+              '前月比:${_formatAmount(insight.balanceDelta ?? 0)}';
+      final payoffText = insight.estimatedPayoffMonths == null
+          ? '完済見込み:この返済額では完済不能'
+          : '完済見込み:約${insight.estimatedPayoffMonths}ヶ月';
+      buffer
+        ..writeln(
+          '- ${insight.accountName} / 区分:${_debtTrendCategoryLabel(insight.category)} / '
+          '重要度:${insight.severity.name} / 残高:${_formatAmount(insight.currentBalance)} / '
+          '$priorText / 月利息:${_formatAmount(insight.monthlyInterest)} / '
+          '今月返済:${_formatAmount(insight.scheduledPayment)} / '
+          '止血ライン(利息超え):${_formatAmount(insight.interestBreakEvenPayment)} / '
+          '24ヶ月完済ライン:${_formatAmount(insight.payoffIn24MonthsPayment)} / '
+          '$payoffText',
+        )
+        ..writeln('  - 問題点: ${insight.problem}')
+        ..writeln('  - 翌月アクション: ${insight.nextMonthAction}');
+    }
+    return buffer.toString();
+  }
+
+  String _debtTrendCategoryLabel(AssetDebtTrendCategory category) {
+    return switch (category) {
+      AssetDebtTrendCategory.negativeAmortization => 'リボ複利(返済が利息以下)',
+      AssetDebtTrendCategory.balanceIncreasing => '残高増加(新規利用過多)',
+      AssetDebtTrendCategory.slowPayoff => '超長期完済',
+    };
+  }
+
   String _redactedSituationCards(AssetManagementInsightReport report) {
     if (report.actionItems.isEmpty && report.emergencyAdvices.isEmpty) {
       return '- 目立つ個別リスクはありません。現状維持と入力精度の確認を優先してください。\n';
@@ -1506,13 +1576,25 @@ class AssetManagementInsightPromptBuilder {
   }
 
   String _developerRequestLines(
-    List<AssetManagementDeveloperRequest> requests,
-  ) {
+    List<AssetManagementDeveloperRequest> requests, {
+    Map<String, Map<String, dynamic>> existingDeveloperIssuesByTitle =
+        const <String, Map<String, dynamic>>{},
+  }) {
     if (requests.isEmpty) {
       return '- 開発者向け改善提案候補はありません。\n';
     }
     final buffer = StringBuffer();
     for (final request in requests) {
+      final existingIssue = existingDeveloperIssuesByTitle[request.title];
+      if (existingIssue != null) {
+        // 起票済み候補は echo の材料を渡さず、再掲禁止だけ伝える。
+        buffer.writeln(
+          '- ${request.title}'
+          '（起票済み GitHub Issue #${existingIssue['number'] ?? '-'}。'
+          '本文・JSONとも再掲禁止）',
+        );
+        continue;
+      }
       buffer
         ..writeln('- ${request.title}')
         ..writeln('  - 重要度: ${request.severity.name}')

--- a/test/services/asset_account_balance_history_store_test.dart
+++ b/test/services/asset_account_balance_history_store_test.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_account_balance_history_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const store = AssetAccountBalanceHistoryStore();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('records a month and reads it back from a later month', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{'famipay': 30000, 'mobit': -200000},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    // 負債残高は絶対値（正の値）で保存される。
+    expect(prior['famipay'], 30000);
+    expect(prior['mobit'], 200000);
+  });
+
+  test('prior month excludes the current month entry', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{'famipay': 30000},
+      prefs: prefs,
+    );
+    await store.recordMonth(
+      DateTime(2026, 6, 1),
+      <String, double>{'famipay': 100000},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    expect(prior['famipay'], 30000);
+  });
+
+  test('returns empty when no prior month exists', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.recordMonth(
+      DateTime(2026, 6, 1),
+      <String, double>{'famipay': 100000},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    expect(prior, isEmpty);
+  });
+
+  test('re-recording the same month overwrites it', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{'famipay': 30000},
+      prefs: prefs,
+    );
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{'famipay': 45000},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    expect(prior['famipay'], 45000);
+    expect(await store.recordedMonthKeys(prefs: prefs), <String>['2026-05']);
+  });
+
+  test('skips a debt-free (empty) month and returns the last month with debt',
+      () async {
+    final prefs = await SharedPreferences.getInstance();
+    // 4月に借金あり → 5月に完済(空) → 6月に新規借入。
+    await store.recordMonth(
+      DateTime(2026, 4, 1),
+      <String, double>{'famipay': 30000},
+      prefs: prefs,
+    );
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    // 空の5月を飛ばして4月の残高を前月比の基準にする。
+    expect(prior['famipay'], 30000);
+  });
+
+  test('rejects negative balances on read (corrupted data)', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'asset_account_balance_history_v1': jsonEncode(<String, dynamic>{
+        '2026-05': <String, dynamic>{'good': 100000, 'bad': -50000},
+      }),
+    });
+    final prefs = await SharedPreferences.getInstance();
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    expect(prior['good'], 100000);
+    expect(prior.containsKey('bad'), isFalse);
+  });
+
+  test('prunes history beyond the retention window', () async {
+    final prefs = await SharedPreferences.getInstance();
+    for (var i = 0; i < AssetAccountBalanceHistoryStore.maxMonths + 4; i++) {
+      final month = DateTime(2025, 1 + i, 1);
+      await store.recordMonth(
+        month,
+        <String, double>{'famipay': 1000.0 * i},
+        prefs: prefs,
+      );
+    }
+
+    final keys = await store.recordedMonthKeys(prefs: prefs);
+    expect(keys.length, AssetAccountBalanceHistoryStore.maxMonths);
+    // 最古の月から間引かれている。
+    expect(keys.first.compareTo(keys.last) < 0, isTrue);
+  });
+}

--- a/test/services/asset_account_balance_history_store_test.dart
+++ b/test/services/asset_account_balance_history_store_test.dart
@@ -131,6 +131,89 @@ void main() {
     expect(prior.containsKey('bad'), isFalse);
   });
 
+  group('mergeRemote (cross-device sync)', () {
+    test('adds a remote-only month (union, no data loss)', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await store.recordMonth(
+        DateTime(2026, 6, 1),
+        <String, double>{'famipay': 100000},
+        prefs: prefs,
+      );
+
+      final changed = await store.mergeRemote(
+        <String, dynamic>{
+          '2026-05': <String, dynamic>{'mobit': 200000},
+        },
+        prefs: prefs,
+      );
+
+      expect(changed, isTrue);
+      final all = await store.loadAll(prefs: prefs);
+      expect(all['2026-05']!['mobit'], 200000);
+      expect(all['2026-06']!['famipay'], 100000);
+    });
+
+    test('fills remote-only accounts but keeps local on conflict', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await store.recordMonth(
+        DateTime(2026, 6, 1),
+        <String, double>{'famipay': 100000},
+        prefs: prefs,
+      );
+
+      final changed = await store.mergeRemote(
+        <String, dynamic>{
+          '2026-06': <String, dynamic>{'famipay': 999999, 'mobit': 50000},
+        },
+        prefs: prefs,
+      );
+
+      expect(changed, isTrue);
+      final all = await store.loadAll(prefs: prefs);
+      // 共有口座はローカル値を優先、リモート限定口座だけ補完。
+      expect(all['2026-06']!['famipay'], 100000);
+      expect(all['2026-06']!['mobit'], 50000);
+    });
+
+    test('returns false and changes nothing for empty/invalid remote', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await store.recordMonth(
+        DateTime(2026, 6, 1),
+        <String, double>{'famipay': 100000},
+        prefs: prefs,
+      );
+
+      expect(await store.mergeRemote(null, prefs: prefs), isFalse);
+      expect(await store.mergeRemote(<String, dynamic>{}, prefs: prefs), isFalse);
+      expect(await store.mergeRemote('garbage', prefs: prefs), isFalse);
+
+      final all = await store.loadAll(prefs: prefs);
+      expect(all['2026-06']!['famipay'], 100000);
+    });
+
+    test('merged remote month becomes the prior-month basis', () async {
+      final prefs = await SharedPreferences.getInstance();
+      // 今月だけローカルにある状態へ、他端末の先月分をマージ。
+      await store.recordMonth(
+        DateTime(2026, 6, 1),
+        <String, double>{'famipay': 100000},
+        prefs: prefs,
+      );
+      await store.mergeRemote(
+        <String, dynamic>{
+          '2026-05': <String, dynamic>{'famipay': 30000},
+        },
+        prefs: prefs,
+      );
+
+      final prior = await store.priorMonthBalances(
+        DateTime(2026, 6, 1),
+        prefs: prefs,
+      );
+      expect(prior['famipay'], 30000);
+    });
+  });
+
   test('prunes history beyond the retention window', () async {
     final prefs = await SharedPreferences.getInstance();
     for (var i = 0; i < AssetAccountBalanceHistoryStore.maxMonths + 4; i++) {

--- a/test/services/asset_debt_trend_analyzer_test.dart
+++ b/test/services/asset_debt_trend_analyzer_test.dart
@@ -1,0 +1,192 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_debt_trend_analyzer.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  const planner = AssetLiabilityPlanningService();
+  const analyzer = AssetDebtTrendAnalyzer();
+  final baseDate = DateTime(2026, 6, 1);
+
+  String debtId(AssetLiabilityWorkbook workbook, String name) {
+    return workbook.debtMasterRows
+        .firstWhere((row) => row.name == name)
+        .id;
+  }
+
+  group('AssetDebtTrendAnalyzer.estimatePayoff', () {
+    test('returns null months when payment does not exceed interest', () {
+      // 30万円 @ 年15% → 月利息 3,750円。返済 3,000円では元金が減らない。
+      final estimate = AssetDebtTrendAnalyzer.estimatePayoff(
+        balance: 300000,
+        monthlyRate: 0.15 / 12,
+        monthlyPayment: 3000,
+      );
+      expect(estimate.everPaysOff, isFalse);
+      expect(estimate.months, isNull);
+    });
+
+    test('returns finite months when payment exceeds interest', () {
+      final estimate = AssetDebtTrendAnalyzer.estimatePayoff(
+        balance: 100000,
+        monthlyRate: 0.15 / 12,
+        monthlyPayment: 20000,
+      );
+      expect(estimate.everPaysOff, isTrue);
+      expect(estimate.months, isNotNull);
+      expect(estimate.months! > 0, isTrue);
+      expect(estimate.totalInterest > 0, isTrue);
+    });
+
+    test('returns zero months for a cleared balance', () {
+      final estimate = AssetDebtTrendAnalyzer.estimatePayoff(
+        balance: 0,
+        monthlyRate: 0.15 / 12,
+        monthlyPayment: 1000,
+      );
+      expect(estimate.months, 0);
+      expect(estimate.everPaysOff, isTrue);
+    });
+  });
+
+  group('AssetDebtTrendAnalyzer.analyze', () {
+    test('flags negative amortization when payment is below interest', () {
+      // 30万円 @ 15% / 返済 3,000円 → 月利息 3,750円 > 返済 → 元金が減らない。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'リボカード': -300000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'リボカード': 3000},
+      );
+
+      final insights = analyzer.analyze(workbook: workbook);
+
+      expect(insights, hasLength(1));
+      final insight = insights.single;
+      expect(insight.category, AssetDebtTrendCategory.negativeAmortization);
+      expect(insight.severity, AssetDebtTrendSeverity.critical);
+      expect(insight.estimatedPayoffMonths, isNull);
+      expect(insight.nextMonthAction.contains('一括返済'), isTrue);
+      expect(insight.nextMonthAction.contains('新規利用'), isTrue);
+      expect(insight.problem.contains('元金'), isTrue);
+    });
+
+    test('flags a revolving balance that grew month over month '
+        '(the FamiPay example)', () {
+      // 先月 3万円 → 今月 10万円 (+7万) なのに返済は 5,000円。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 80000,
+          'ファミペイ': -100000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'ファミペイ': 5000},
+      );
+      final famipayId = debtId(workbook, 'ファミペイ');
+
+      final insights = analyzer.analyze(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{famipayId: 30000},
+      );
+
+      expect(insights, hasLength(1));
+      final insight = insights.single;
+      expect(insight.category, AssetDebtTrendCategory.balanceIncreasing);
+      // 増加額 7万 > 返済 5,000 → 払っても追いつかない → critical。
+      expect(insight.severity, AssetDebtTrendSeverity.critical);
+      expect(insight.balanceDelta, 70000);
+      expect(insight.problem.contains('先月比+70,000円'), isTrue);
+      expect(insight.problem.contains('純増'), isTrue);
+      expect(insight.nextMonthAction.contains('新規利用'), isTrue);
+      expect(insight.nextMonthAction.contains('一括返済'), isTrue);
+    });
+
+    test('flags a very slow payoff even without history', () {
+      // 30万円 @ 15% / 返済 6,000円 → 元金は減るが完済まで 60ヶ月超。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'ショッピングカード': -300000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'ショッピングカード': 6000},
+      );
+
+      final insights = analyzer.analyze(workbook: workbook);
+
+      expect(insights, hasLength(1));
+      final insight = insights.single;
+      expect(insight.category, AssetDebtTrendCategory.slowPayoff);
+      expect(insight.estimatedPayoffMonths, isNotNull);
+      expect(insight.estimatedPayoffMonths! > 60, isTrue);
+      expect(insight.problem.contains('完済まで'), isTrue);
+    });
+
+    test('produces no insight for a healthy, shrinking revolving balance', () {
+      // 5万円 @ 15% / 返済 2万円 → すぐ完済。先月より残高は減少。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 200000,
+          '優等生カード': -50000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'優等生カード': 20000},
+      );
+      final cardId = debtId(workbook, '優等生カード');
+
+      final insights = analyzer.analyze(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{cardId: 80000},
+      );
+
+      expect(insights, isEmpty);
+    });
+
+    test('ignores non-revolving kinds', () {
+      expect(
+        AssetDebtTrendAnalyzer.isRevolvingLikeKind(
+          AssetLiabilityAccountKind.utility,
+        ),
+        isFalse,
+      );
+      expect(
+        AssetDebtTrendAnalyzer.isRevolvingLikeKind(
+          AssetLiabilityAccountKind.creditCard,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetDebtTrendAnalyzer.isRevolvingLikeKind(
+          AssetLiabilityAccountKind.cardLoan,
+        ),
+        isTrue,
+      );
+    });
+
+    test('prioritises critical insights first', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'リボカード': -300000, // payment < interest → negative amortization (critical)
+          'ショッピングカード': -300000, // slow payoff (warning)
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{
+          'リボカード': 3000,
+          'ショッピングカード': 6000,
+        },
+      );
+
+      final insights = analyzer.analyze(workbook: workbook);
+
+      expect(insights.length, 2);
+      expect(insights.first.severity, AssetDebtTrendSeverity.critical);
+      expect(
+        insights.first.category,
+        AssetDebtTrendCategory.negativeAmortization,
+      );
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1,0 +1,659 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:my_web_app/pages/asset_management_page.dart';
+import 'package:my_web_app/services/asset_expected_inflow_store.dart';
+import 'package:my_web_app/services/asset_management_display_mode_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// 資産管理ページの widget スモーク足場 (#3260)。
+/// 未ログイン (auth.currentUser == null) では Supabase フェッチ群が
+/// 早期 return する性質を利用し、ネットワークなしで UI 契約だけを検証する。
+Future<void> _pumpAssetPage(WidgetTester tester) async {
+  await tester.pumpWidget(
+    const MaterialApp(home: AssetManagementPage()),
+  );
+  await tester.pump(const Duration(milliseconds: 100));
+}
+
+Future<void> _unmount(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pump(const Duration(seconds: 2));
+}
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    await Supabase.initialize(
+      url: 'http://127.0.0.1:9999',
+      publishableKey: 'test-publishable-key',
+      authOptions: const FlutterAuthClientOptions(autoRefreshToken: false),
+    );
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('AssetManagementPage smoke', () {
+    testWidgets('display mode chips reduce visible sections', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+
+      expect(find.byKey(const Key('asset_display_mode_minimum')), findsOne);
+      final cardsInFull = tester.widgetList(find.byType(Card)).length;
+
+      await tester.tap(find.byKey(const Key('asset_display_mode_minimum')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      final cardsInMinimum = tester.widgetList(find.byType(Card)).length;
+      expect(cardsInMinimum, lessThan(cardsInFull));
+      expect(find.textContaining('最重要のみ'), findsWidgets);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('calendar month navigation updates the label', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+
+      final now = DateTime.now();
+      final current = DateFormat('yyyy年M月').format(now);
+      final next = DateFormat(
+        'yyyy年M月',
+      ).format(DateTime(now.year, now.month + 1));
+      expect(find.text(current), findsOneWidget);
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_calendar_next_month')),
+      );
+      await tester.tap(find.byKey(const Key('asset_calendar_next_month')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text(next), findsOneWidget);
+      expect(find.text(current), findsNothing);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('tapping a day reveals the prefill action', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+
+      expect(
+        find.byKey(const Key('asset_calendar_prefill_flow_button')),
+        findsNothing,
+      );
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_calendar_day_15')),
+      );
+      await tester.tap(find.byKey(const Key('asset_calendar_day_15')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        find.byKey(const Key('asset_calendar_prefill_flow_button')),
+        findsOneWidget,
+      );
+
+      await _unmount(tester);
+    });
+
+    testWidgets('starts in stored minimum mode', (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_management_display_mode_v1': 'minimum',
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.textContaining('最重要のみ'), findsWidgets);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('seeded inflows surface as chips and managed rules', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      final monthKey = '${now.year}${now.month.toString().padLeft(2, '0')}';
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflows_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'seeded_one',
+            'date': DateTime(now.year, now.month, 10).toUtc().toIso8601String(),
+            'amount': 5000,
+            'label': '臨時収入',
+          },
+        ]),
+        'asset_expected_inflow_rules_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'seeded_rule',
+            'day_of_month': 25,
+            'amount': 280000,
+            'label': '給料',
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_inflow_chip_seeded_one')),
+      );
+      expect(
+        find.byKey(const Key('asset_inflow_chip_seeded_one')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(Key('asset_inflow_chip_rule_seeded_rule_$monthKey')),
+        findsOneWidget,
+      );
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_inflow_rules_button')),
+      );
+      await tester.tap(find.byKey(const Key('asset_inflow_rules_button')));
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.textContaining('毎月25日 給料'), findsOneWidget);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('tombstone GC settings dialog edits and saves the config', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflow_rules_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'seeded_rule',
+            'day_of_month': 25,
+            'amount': 280000,
+            'label': '給料',
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugTombstoneGcConfig: AssetTombstoneGcConfig(
+              maxCount: 1000,
+              maxAgeDays: 365,
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_inflow_rules_button')),
+      );
+      await tester.tap(find.byKey(const Key('asset_inflow_rules_button')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // 現在値が保持設定ボタンに出ている。
+      expect(find.textContaining('保持設定 (1000件/365日)'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('asset_tombstone_gc_edit')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.enterText(
+        find.byKey(const Key('asset_tombstone_gc_maxcount')),
+        '50',
+      );
+      await tester.enterText(
+        find.byKey(const Key('asset_tombstone_gc_maxage')),
+        '90',
+      );
+      await tester.tap(find.byKey(const Key('asset_tombstone_gc_save')));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // SnackBar で更新を通知し、ボタンラベルも新値へ更新される。
+      expect(find.textContaining('最大50件 / 90日'), findsOneWidget);
+      expect(find.textContaining('保持設定 (50件/90日)'), findsOneWidget);
+
+      // ローカルにも保存される。
+      expect(
+        (await AssetExpectedInflowStore.loadGcConfig()).maxCount,
+        50,
+      );
+
+      await _unmount(tester);
+    });
+
+    testWidgets('manual prune button cleans expired tombstones', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflow_rules_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'seeded_rule',
+            'day_of_month': 25,
+            'amount': 280000,
+            'label': '給料',
+          },
+        ]),
+        // 2020 年の古い削除記録 → inflow は maxAgeDays:10、override は既定365日で
+        // どちらも期限切れ → 一括掃除で 2 件 (#part292)。
+        'asset_expected_inflow_deleted_ids_v1':
+            jsonEncode(<Map<String, String>>[
+          <String, String>{'id': 'old1', 'at': '2020-01-01T00:00:00.000Z'},
+        ]),
+        'asset_management_section_override_deleted_v1':
+            jsonEncode(<Map<String, String>>[
+          <String, String>{'id': 'chart', 'at': '2020-01-01T00:00:00.000Z'},
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugTombstoneGcConfig: AssetTombstoneGcConfig(
+              maxCount: 1000,
+              maxAgeDays: 10,
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_inflow_rules_button')),
+      );
+      await tester.tap(find.byKey(const Key('asset_inflow_rules_button')));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.byKey(const Key('asset_tombstone_gc_edit')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(find.byKey(const Key('asset_tombstone_gc_prune')));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // inflow(1) + override(1) = 2 件を一括掃除。
+      expect(find.textContaining('古い削除記録を2件 掃除しました'), findsOneWidget);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('remote section-override tombstone removes local override', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_management_section_overrides_v1': jsonEncode(
+          <String, String>{'chart': 'hidden'},
+        ),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 他端末で chart の上書きを削除した状態をミラー注入。
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugSectionOverrideDeletedMirror: <String, dynamic>{
+              'ids': <String>['chart'],
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // カスタマイズダイアログを開き、chart の上書きが「自動」に戻ったことを確認。
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_section_customize_button')),
+      );
+      await tester.tap(find.byKey(const Key('asset_section_customize_button')));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final dropdown = tester
+          .widget<DropdownButton<AssetManagementSectionVisibilityOverride>>(
+        find.byKey(const Key('asset_section_override_chart')),
+      );
+      expect(dropdown.value, AssetManagementSectionVisibilityOverride.auto);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('remote inflow tombstone removes the matching local chip', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflows_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'keep_me',
+            'date': DateTime(now.year, now.month, 10).toUtc().toIso8601String(),
+            'amount': 5000,
+            'label': '残す入金',
+          },
+          <String, dynamic>{
+            'id': 'delete_me',
+            'date': DateTime(now.year, now.month, 12).toUtc().toIso8601String(),
+            'amount': 8000,
+            'label': '他端末で削除',
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 他端末が delete_me を削除した状態をミラー経由で注入。
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AssetManagementPage(
+            debugInflowDeletedIdsMirror: <String, dynamic>{
+              'ids': <String>['delete_me'],
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_inflow_chip_keep_me')),
+      );
+      expect(
+        find.byKey(const Key('asset_inflow_chip_keep_me')),
+        findsOneWidget,
+      );
+      // 削除トゥームストーンが伝播し、該当チップは消えている。
+      expect(
+        find.byKey(const Key('asset_inflow_chip_delete_me')),
+        findsNothing,
+      );
+
+      await _unmount(tester);
+    });
+
+    testWidgets('hidden override removes an essential section', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_management_section_overrides_v1': jsonEncode(
+          <String, String>{'calendar': 'hidden'},
+        ),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpAssetPage(tester);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.byKey(const Key('asset_calendar_prev_month')), findsNothing);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('shortfall warning appears and clears via expected inflow', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 10000,
+                'モビット': -300000,
+              },
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // モビット既定支払日15日の予定額が現金1万を超え、ショート警告が出る。
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_calendar_add_inflow_button')),
+      );
+      expect(find.textContaining('回避ライン'), findsOneWidget);
+      expect(
+        find.byKey(const Key('asset_shift_payment_mobit')),
+        findsOneWidget,
+      );
+
+      // 回避ライン額がプリフィルされた入金予定を登録すると警告が消える。
+      await tester.tap(
+        find.byKey(const Key('asset_calendar_add_inflow_button')),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('追加'),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.byKey(const Key('asset_calendar_add_inflow_button')),
+        findsNothing,
+      );
+      expect(find.textContaining('回避ライン'), findsNothing);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('recurring inflow before payday prevents the shortfall', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflow_rules_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'r_cover',
+            'day_of_month': 14,
+            'amount': 100000,
+            'label': '給料前入金',
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 10000,
+                'モビット': -300000,
+              },
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // 14日の繰り返し入金が15日のモビット返済を覆い、警告は出ない。
+      expect(
+        find.byKey(const Key('asset_calendar_add_inflow_button')),
+        findsNothing,
+      );
+      expect(find.textContaining('回避ライン'), findsNothing);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('post-payday inflow keeps warning but shift previews clear', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_expected_inflow_rules_v1': jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'r_late',
+            'day_of_month': 20,
+            'amount': 100000,
+            'label': '後半入金',
+          },
+        ]),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 10000,
+                'モビット': -300000,
+              },
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // 入金が返済日(15日)より後ろなので警告は残る。
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_calendar_add_inflow_button')),
+      );
+      expect(find.textContaining('回避ライン'), findsOneWidget);
+      // ただし26日へ移せば20日の入金で賄えるため、事前判定が「回避できます」。
+      expect(find.textContaining('を26日へ(回避できます)'), findsOneWidget);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('revolving balance growth surfaces the monthly debt trend card',
+        (tester) async {
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      final priorMonth = DateTime(now.year, now.month - 1, 1);
+      final priorKey = '${priorMonth.year.toString().padLeft(4, '0')}-'
+          '${priorMonth.month.toString().padLeft(2, '0')}';
+      // 前月末のモビット残高 3 万円を履歴に仕込み、今月 30 万へ増加させる。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_account_balance_history_v1': jsonEncode(<String, dynamic>{
+          priorKey: <String, dynamic>{'mobit': 30000},
+        }),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 500000,
+                'モビット': -300000,
+              },
+            },
+          ),
+        ),
+      );
+      // 履歴の非同期ロード → setState → 再描画を待つ。
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.textContaining('今月の問題点と翌月の改善（負債トレンド）'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('残高が先月より増加'), findsWidgets);
+
+      await _unmount(tester);
+    });
+
+    testWidgets('mirror update notice offers and applies remote prefs', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_management_display_mode_v1': 'minimum',
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugMirrorPrefsRows: <Map<String, dynamic>>[
+              <String, dynamic>{
+                'pref_key': 'display_mode',
+                'value': const <String, dynamic>{'mode': 'standard'},
+                'updated_at': DateTime.now()
+                    .add(const Duration(hours: 1))
+                    .toUtc()
+                    .toIso8601String(),
+              },
+            ],
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('他端末で表示設定が更新されています'), findsOneWidget);
+      expect(
+        tester
+            .widget<ChoiceChip>(
+              find.byKey(const Key('asset_display_mode_minimum')),
+            )
+            .selected,
+        isTrue,
+      );
+
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('取り込む'));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // 取り込み前に「旧 → 新」差分プレビューで確認させる。
+      expect(find.text('表示設定の取り込みプレビュー'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('表示モード: ミニマム → 標準'),
+        ),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const Key('asset_mirror_diff_apply')));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        tester
+            .widget<ChoiceChip>(
+              find.byKey(const Key('asset_display_mode_standard')),
+            )
+            .selected,
+        isTrue,
+      );
+
+      await _unmount(tester);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

資産管理ページに **「今月の問題点と翌月の改善（負債トレンド）」** を追加。既存の資金繰り（今〜給料日）インサイトには無かった「月をまたいだ借金の増減トレンド」を決定論的に検出し、翌月の**具体的な返済額**を提示します。

例: 「ファミペイのリボ残高が先月比+10万、返済3,000円では純増。①リボ解除して一括返済、②または返済額を利息超え/24ヶ月完済ライン以上に」を自動生成。

## コミット構成（2件）

1. `feat(asset): 月次の負債トレンド検出と翌月アクション提示を追加` — 検出ロジック＋UI＋AIプロンプト
2. `feat(asset): 負債トレンドの口座別残高履歴を端末跨ぎ同期` — 前月比の端末跨ぎ対応

## 検出ロジック（3シグナル）

| 検出 | 条件 | 履歴要否 |
|---|---|---|
| リボ複利（負の償却） | 返済額 ≤ 利息（元金が減らない） | 不要（初月から動作） |
| 残高増加トレンド | 前月比で残高増（増加額>返済→critical） | 前月の口座別残高 |
| 超長期完済 | 完済まで60ヶ月超 | 不要 |

金額は Dart 側で計算済み。AIプロンプトには「再計算するな」契約を維持したまま数値を渡します。

## 端末跨ぎ同期（マイグレーション不要）

前月残高は当初ローカル限定でしたが、汎用 jsonb ミラー `asset_pref_mirror`（`pref_key='account_balance_history'`）で**端末跨ぎ同期**を追加。専用テーブル・SQLマイグレーション・edge deploy は**不要**。マージは月キー・口座を消さない**和集合・非破壊**（競合はローカル優先で巻き戻し/取りこぼしを防止）。

## 主な変更ファイル

- 🆕 `lib/services/asset_debt_trend_analyzer.dart` — 完済シミュレーション＋分類＋翌月アクション（純粋ロジック）
- 🆕 `lib/services/asset_account_balance_history_store.dart` — 前月残高の自動蓄積＋和集合マージ（同期スナップショット非干渉でLWWデータ消失を回避）
- `lib/services/asset_management_insight_service.dart` — `debtTrendInsights` 追加＋AIプロンプト節
- `lib/pages/asset_management_page.dart` — 専用カードUI＋月キーガード前月残高ロード＋ミラー upsert/restore

## テスト / 検証

- アナライザ9 / ストア11（うちマージ4）/ インサイト18 / スモーク（実機カード描画）**全緑**
- `dart analyze` 全変更ファイルでクリーン
- 26エージェントの敵対的レビュー確定4件を修正済み（空月スキップ/負残高拒否/月キーガード/符号付き差分）

## ⚠️ レビュー・CIに関する注意

- **CI**: このPRのベースは `codex/issue-1215-pre-debt-trend`（私の機能の直前tip）に調整済みで、**私の2コミットだけ**を差分表示します（main ベースだと branch の発散で CONFLICTING になり merge ref が作れず `pull_request` CI が起動しないため）。本ベースは main 系列外のため自動CIは走りません → **ローカルで全テスト緑＋analyzeクリーンを確認済み**。
- `+8525/-3035` の大半は**1コミット目に取り込まれた資産管理系の先行WIP**（作業ツリーに既存。2コミット目の同期分は +221 とクリーン）。
- 作業ツリーの他 約186 ファイルの未コミット変更は本PRに**含まれません**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)