### PR TITLE
feat(asset): サブスク(AI/クラウド)を定期固定費として計上する仕組みを追加

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -272,6 +272,17 @@ enum AssetRecurringFixedCostCadence {
   bimonthlyOddMonth,
 }
 
+/// 定期固定費の区分。資金繰りへの計上は区分に依らず同じ (全額支払いの utility 負債)
+/// だが、UI 上の表示セクションと既定アイコンを切り替えるためだけに使う。
+enum AssetRecurringFixedCostCategory {
+  /// 家賃・光熱費・通信費など従来の定期固定費 (既定)。
+  utility,
+
+  /// AI/クラウド等の月額サブスク (Anthropic / OpenAI / Gemini / GCP / Supabase /
+  /// Notion など)。資金繰りでは固定費として同様に計上される。
+  subscription,
+}
+
 /// UI から登録できる定期固定費 (家賃・光熱費・通信費など毎月/隔月の口座振替)。
 ///
 /// ハードコードされた既定固定費 (家賃/KDDI/水道/ガス) と同様に、資金繰りへ
@@ -297,6 +308,9 @@ class AssetRecurringFixedCost {
   /// 引落の振替元口座 ID (任意)。
   final String? sourceAccountId;
 
+  /// 区分 (固定費 / サブスク)。既定は utility で、表示セクションの振り分けにのみ使う。
+  final AssetRecurringFixedCostCategory category;
+
   const AssetRecurringFixedCost({
     required this.id,
     required this.name,
@@ -304,6 +318,7 @@ class AssetRecurringFixedCost {
     required this.paymentDay,
     this.cadence = AssetRecurringFixedCostCadence.monthly,
     this.sourceAccountId,
+    this.category = AssetRecurringFixedCostCategory.utility,
   });
 
   /// 指定した月 (1-12) にこの固定費が発生するか (隔月は偶数/奇数月のみ計上)。
@@ -326,6 +341,7 @@ class AssetRecurringFixedCost {
     AssetRecurringFixedCostCadence? cadence,
     String? sourceAccountId,
     bool clearSourceAccountId = false,
+    AssetRecurringFixedCostCategory? category,
   }) {
     return AssetRecurringFixedCost(
       id: id ?? this.id,
@@ -336,10 +352,12 @@ class AssetRecurringFixedCost {
       sourceAccountId: clearSourceAccountId
           ? null
           : (sourceAccountId ?? this.sourceAccountId),
+      category: category ?? this.category,
     );
   }
 
   /// ID をキーにする保存形のため、JSON には id を含めない。
+  /// 区分は既定 (utility) のときは出力しない (既存ペイロードと互換を保つ)。
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'name': name,
@@ -348,6 +366,8 @@ class AssetRecurringFixedCost {
       'cadence': cadence.name,
       if (sourceAccountId != null && sourceAccountId!.isNotEmpty)
         'sourceAccountId': sourceAccountId,
+      if (category != AssetRecurringFixedCostCategory.utility)
+        'category': category.name,
     };
   }
 
@@ -380,6 +400,11 @@ class AssetRecurringFixedCost {
       orElse: () => AssetRecurringFixedCostCadence.monthly,
     );
     final rawSource = json['sourceAccountId']?.toString().trim();
+    final categoryName = json['category']?.toString();
+    final category = AssetRecurringFixedCostCategory.values.firstWhere(
+      (value) => value.name == categoryName,
+      orElse: () => AssetRecurringFixedCostCategory.utility,
+    );
     return AssetRecurringFixedCost(
       id: trimmedId,
       name: name,
@@ -388,6 +413,7 @@ class AssetRecurringFixedCost {
       cadence: cadence,
       sourceAccountId:
           rawSource == null || rawSource.isEmpty ? null : rawSource,
+      category: category,
     );
   }
 }

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -41,6 +41,7 @@ import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_recurring_suggestion_ignore_store.dart';
+import 'package:my_web_app/services/asset_subscription_catalog.dart';
 import 'package:my_web_app/services/asset_salary_day_store.dart';
 import 'package:my_web_app/services/asset_recurring_transaction_detector.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
@@ -76,6 +77,7 @@ import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
 import 'package:my_web_app/widgets/asset_category_budget_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
+import 'package:my_web_app/widgets/subscription_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/asset_recurring_transaction_suggestion_card.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -7989,6 +7991,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _buildRecurringFixedCostCard(assetLiabilityWorkbook),
               const SizedBox(height: 16),
             ],
+            if (_isSectionShown(
+                AssetManagementSectionId.subscriptionFixedCost)) ...[
+              _buildSubscriptionFixedCostCard(assetLiabilityWorkbook),
+              const SizedBox(height: 16),
+            ],
             if (_isSectionShown(AssetManagementSectionId.disposable)) ...[
               _buildDisposableBalanceCard(),
               const SizedBox(height: 16),
@@ -9002,12 +9009,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     AssetRecurringFixedCost? existing,
     AssetRecurringFixedCost? prefill,
     required List<RecurringFixedCostSourceOption> sourceOptions,
+    AssetRecurringFixedCostCategory category =
+        AssetRecurringFixedCostCategory.utility,
   }) async {
     final result = await showRecurringFixedCostEditor(
       context,
       existing: existing,
       prefill: prefill,
       sourceAccounts: sourceOptions,
+      category: category,
     );
     if (result != null) {
       _saveRecurringFixedCost(result);
@@ -9048,11 +9058,57 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final sourceNames = <String, String>{
       for (final account in accounts) account.id: account.name,
     };
+    // サブスク区分は専用カードに分離し、ここでは従来の固定費 (utility) だけ表示する。
+    final utilityCosts = <AssetRecurringFixedCost>[
+      for (final cost in _recurringFixedCosts)
+        if (cost.category == AssetRecurringFixedCostCategory.utility) cost,
+    ];
     return RecurringFixedCostCard(
-      costs: _recurringFixedCosts,
+      costs: utilityCosts,
       sourceAccountNames: sourceNames,
       onAdd: () => unawaited(
         _openRecurringFixedCostEditor(sourceOptions: sourceOptions),
+      ),
+      onEdit: (cost) => unawaited(
+        _openRecurringFixedCostEditor(
+          existing: cost,
+          sourceOptions: sourceOptions,
+        ),
+      ),
+      onDelete: (cost) => unawaited(_confirmDeleteRecurringFixedCost(cost)),
+    );
+  }
+
+  Widget _buildSubscriptionFixedCostCard(AssetLiabilityWorkbook? workbook) {
+    final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
+    final sourceOptions = <RecurringFixedCostSourceOption>[
+      for (final account in accounts)
+        if (account.balance > 0) (id: account.id, name: account.name),
+    ];
+    final sourceNames = <String, String>{
+      for (final account in accounts) account.id: account.name,
+    };
+    final subscriptionCosts = <AssetRecurringFixedCost>[
+      for (final cost in _recurringFixedCosts)
+        if (cost.category == AssetRecurringFixedCostCategory.subscription) cost,
+    ];
+    return SubscriptionFixedCostCard(
+      costs: subscriptionCosts,
+      sourceAccountNames: sourceNames,
+      onAddPreset: (preset) => unawaited(
+        _openRecurringFixedCostEditor(
+          prefill: preset.toPrefill(
+            paymentDay: AssetSubscriptionCatalog.defaultPaymentDay,
+          ),
+          sourceOptions: sourceOptions,
+          category: AssetRecurringFixedCostCategory.subscription,
+        ),
+      ),
+      onAddCustom: () => unawaited(
+        _openRecurringFixedCostEditor(
+          sourceOptions: sourceOptions,
+          category: AssetRecurringFixedCostCategory.subscription,
+        ),
       ),
       onEdit: (cost) => unawaited(
         _openRecurringFixedCostEditor(

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -17,6 +17,7 @@ enum AssetManagementSectionId {
   proposals,
   salaryBreakdown,
   recurringFixedCost,
+  subscriptionFixedCost,
   disposable,
   quickActions,
   wasteAi,
@@ -79,6 +80,8 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
         return '給与消費内訳';
       case AssetManagementSectionId.recurringFixedCost:
         return '定期固定費';
+      case AssetManagementSectionId.subscriptionFixedCost:
+        return 'サブスク (AI/クラウド)';
       case AssetManagementSectionId.disposable:
         return '裁量余資金';
       case AssetManagementSectionId.quickActions:
@@ -117,6 +120,7 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
       case AssetManagementSectionId.proposals:
       case AssetManagementSectionId.salaryBreakdown:
       case AssetManagementSectionId.recurringFixedCost:
+      case AssetManagementSectionId.subscriptionFixedCost:
       case AssetManagementSectionId.deadlines:
       case AssetManagementSectionId.threeMonth:
       case AssetManagementSectionId.workbookBoard:

--- a/lib/services/asset_subscription_catalog.dart
+++ b/lib/services/asset_subscription_catalog.dart
@@ -1,0 +1,123 @@
+import '../models/asset_liability_workbook.dart';
+
+/// サブスク (AI/クラウド SaaS) のテンプレート 1 件。
+///
+/// ユーザーが「Anthropic」「OpenAI」等をワンタップで定期固定費に登録できるよう、
+/// 代表的な月額サービスのプリセットを提供する。金額は概算 (円換算の目安) であり、
+/// 実際の請求額・請求日に合わせて登録ダイアログで調整する前提。
+class AssetSubscriptionPreset {
+  /// 安定した一意 ID (重複登録の判定・テスト用)。
+  final String id;
+
+  /// 表示名 (例: Anthropic (Claude))。
+  final String name;
+
+  /// 月額の概算 (円)。USD 課金のサービスはおおよその円換算。0 より大きい。
+  final double defaultMonthlyAmount;
+
+  /// 補足 (プラン名や「従量課金」など)。カードのサブタイトルに表示する。
+  final String note;
+
+  const AssetSubscriptionPreset({
+    required this.id,
+    required this.name,
+    required this.defaultMonthlyAmount,
+    this.note = '',
+  });
+
+  /// 登録ダイアログへ渡す prefill 用の [AssetRecurringFixedCost] を作る。
+  /// 区分は subscription 固定。[paymentDay] は呼び出し側で既定値を渡す
+  /// (請求日はユーザーがダイアログで調整する)。id は保存時に採番し直されるため
+  /// プレースホルダーで良い。
+  AssetRecurringFixedCost toPrefill({int paymentDay = 1}) {
+    return AssetRecurringFixedCost(
+      id: 'sub_preset_$id',
+      name: name,
+      amount: defaultMonthlyAmount,
+      paymentDay: paymentDay,
+      cadence: AssetRecurringFixedCostCadence.monthly,
+      category: AssetRecurringFixedCostCategory.subscription,
+    );
+  }
+}
+
+/// 代表的な AI/クラウド サブスクのプリセット集 (静的カタログ)。
+///
+/// あくまで登録を素早くするためのテンプレートで、金額は目安。ここに無いサービスは
+/// 「その他を追加」から手入力できる。
+class AssetSubscriptionCatalog {
+  const AssetSubscriptionCatalog._();
+
+  /// 登録時に請求日が未指定のときに使う既定の振替日 (ユーザーが調整する前提)。
+  static const int defaultPaymentDay = 1;
+
+  static const List<AssetSubscriptionPreset> presets =
+      <AssetSubscriptionPreset>[
+    AssetSubscriptionPreset(
+      id: 'anthropic',
+      name: 'Anthropic (Claude)',
+      defaultMonthlyAmount: 3000,
+      note: 'Claude Pro 目安 / 実際の請求額に調整',
+    ),
+    AssetSubscriptionPreset(
+      id: 'openai',
+      name: 'OpenAI (ChatGPT)',
+      defaultMonthlyAmount: 3000,
+      note: 'ChatGPT Plus 目安',
+    ),
+    AssetSubscriptionPreset(
+      id: 'gemini',
+      name: 'Google Gemini',
+      defaultMonthlyAmount: 2900,
+      note: 'Google AI Pro 目安',
+    ),
+    AssetSubscriptionPreset(
+      id: 'gcp',
+      name: 'Google Cloud (GCP)',
+      defaultMonthlyAmount: 1000,
+      note: '従量課金 / 平均額を入力',
+    ),
+    AssetSubscriptionPreset(
+      id: 'supabase',
+      name: 'Supabase',
+      defaultMonthlyAmount: 3800,
+      note: 'Pro プラン 目安',
+    ),
+    AssetSubscriptionPreset(
+      id: 'notion',
+      name: 'Notion',
+      defaultMonthlyAmount: 1650,
+      note: 'Plus プラン 目安',
+    ),
+    AssetSubscriptionPreset(
+      id: 'github',
+      name: 'GitHub',
+      defaultMonthlyAmount: 1500,
+      note: 'Copilot / Pro 目安',
+    ),
+    AssetSubscriptionPreset(
+      id: 'cursor',
+      name: 'Cursor',
+      defaultMonthlyAmount: 3000,
+      note: 'Pro プラン 目安',
+    ),
+    AssetSubscriptionPreset(
+      id: 'microsoft365',
+      name: 'Microsoft 365',
+      defaultMonthlyAmount: 1490,
+      note: 'Personal 目安',
+    ),
+    AssetSubscriptionPreset(
+      id: 'figma',
+      name: 'Figma',
+      defaultMonthlyAmount: 1800,
+      note: 'Professional 目安',
+    ),
+    AssetSubscriptionPreset(
+      id: 'vercel',
+      name: 'Vercel',
+      defaultMonthlyAmount: 3000,
+      note: 'Pro プラン 目安 (従量加算あり)',
+    ),
+  ];
+}

--- a/lib/widgets/recurring_fixed_cost_card.dart
+++ b/lib/widgets/recurring_fixed_cost_card.dart
@@ -39,7 +39,12 @@ class RecurringFixedCostCard extends StatelessWidget {
     }
   }
 
-  String _subtitle(AssetRecurringFixedCost cost) {
+  /// 「周期+振替日 / ¥金額 [/ 振替元: 口座]」のサブタイトル文字列を組み立てる。
+  /// 定期固定費カードとサブスクカードで同一表記を共有する (フォーマット drift 防止)。
+  static String subtitleFor(
+    AssetRecurringFixedCost cost,
+    Map<String, String> sourceAccountNames,
+  ) {
     final buffer = StringBuffer(
       '${cadenceLabel(cost.cadence)}${cost.paymentDay}日 / ¥${_yen.format(cost.amount)}',
     );
@@ -52,6 +57,9 @@ class RecurringFixedCostCard extends StatelessWidget {
     }
     return buffer.toString();
   }
+
+  String _subtitle(AssetRecurringFixedCost cost) =>
+      subtitleFor(cost, sourceAccountNames);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/recurring_fixed_cost_editor_dialog.dart
+++ b/lib/widgets/recurring_fixed_cost_editor_dialog.dart
@@ -19,6 +19,8 @@ Future<AssetRecurringFixedCost?> showRecurringFixedCostEditor(
   AssetRecurringFixedCost? prefill,
   List<RecurringFixedCostSourceOption> sourceAccounts =
       const <RecurringFixedCostSourceOption>[],
+  AssetRecurringFixedCostCategory category =
+      AssetRecurringFixedCostCategory.utility,
 }) {
   return showDialog<AssetRecurringFixedCost>(
     context: context,
@@ -26,6 +28,7 @@ Future<AssetRecurringFixedCost?> showRecurringFixedCostEditor(
       existing: existing,
       prefill: prefill,
       sourceAccounts: sourceAccounts,
+      category: category,
     ),
   );
 }
@@ -38,6 +41,7 @@ class RecurringFixedCostEditorDialog extends StatefulWidget {
     this.existing,
     this.prefill,
     this.sourceAccounts = const <RecurringFixedCostSourceOption>[],
+    this.category = AssetRecurringFixedCostCategory.utility,
   });
 
   final AssetRecurringFixedCost? existing;
@@ -45,6 +49,10 @@ class RecurringFixedCostEditorDialog extends StatefulWidget {
   /// 追加モードの初期値(検出結果からの登録用)。[existing] があれば無視される。
   final AssetRecurringFixedCost? prefill;
   final List<RecurringFixedCostSourceOption> sourceAccounts;
+
+  /// 区分の初期値 (固定費 / サブスク)。[existing]/[prefill] が区分を持つ場合は
+  /// そちらを優先する (サブスクカードから「その他を追加」する際の既定値)。
+  final AssetRecurringFixedCostCategory category;
 
   @override
   State<RecurringFixedCostEditorDialog> createState() =>
@@ -58,6 +66,7 @@ class _RecurringFixedCostEditorDialogState
   late final TextEditingController _amountController;
   late final TextEditingController _dayController;
   late AssetRecurringFixedCostCadence _cadence;
+  late AssetRecurringFixedCostCategory _category;
   String? _sourceAccountId;
 
   @override
@@ -65,6 +74,8 @@ class _RecurringFixedCostEditorDialogState
     super.initState();
     // existing(編集)優先。なければ prefill(検出結果からの追加)を初期値に使う。
     final initial = widget.existing ?? widget.prefill;
+    // 区分は initial が持つ値を最優先し、無ければ呼び出し側が指定した既定を使う。
+    _category = initial?.category ?? widget.category;
     _nameController = TextEditingController(text: initial?.name ?? '');
     _amountController = TextEditingController(
       text: initial == null ? '' : initial.amount.toStringAsFixed(0),
@@ -100,25 +111,56 @@ class _RecurringFixedCostEditorDialogState
       paymentDay: int.parse(_dayController.text.trim()),
       cadence: _cadence,
       sourceAccountId: _sourceAccountId,
+      category: _category,
     );
     Navigator.of(context).pop(cost);
   }
 
+  static String categoryLabel(AssetRecurringFixedCostCategory category) {
+    switch (category) {
+      case AssetRecurringFixedCostCategory.utility:
+        return '定期固定費';
+      case AssetRecurringFixedCostCategory.subscription:
+        return 'サブスク';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final label = categoryLabel(_category);
     return AlertDialog(
-      title: Text(widget.existing == null ? '定期固定費を追加' : '定期固定費を編集'),
+      title: Text(widget.existing == null ? '$labelを追加' : '$labelを編集'),
       content: SingleChildScrollView(
         child: Form(
           key: _formKey,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              DropdownButtonFormField<AssetRecurringFixedCostCategory>(
+                initialValue: _category,
+                decoration: const InputDecoration(labelText: '区分'),
+                items: [
+                  for (final category in AssetRecurringFixedCostCategory.values)
+                    DropdownMenuItem<AssetRecurringFixedCostCategory>(
+                      value: category,
+                      child: Text(categoryLabel(category)),
+                    ),
+                ],
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() => _category = value);
+                  }
+                },
+              ),
+              const SizedBox(height: 8),
               TextFormField(
                 controller: _nameController,
-                decoration: const InputDecoration(
+                decoration: InputDecoration(
                   labelText: '名称',
-                  hintText: '例: 電気代',
+                  hintText:
+                      _category == AssetRecurringFixedCostCategory.subscription
+                          ? '例: Anthropic (Claude)'
+                          : '例: 電気代',
                 ),
                 validator: (value) => (value == null || value.trim().isEmpty)
                     ? '名称を入力してください'

--- a/lib/widgets/subscription_fixed_cost_card.dart
+++ b/lib/widgets/subscription_fixed_cost_card.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+
+import '../models/asset_liability_workbook.dart';
+import '../services/asset_subscription_catalog.dart';
+import 'recurring_fixed_cost_card.dart';
+
+/// AI/クラウド等の月額サブスク (Anthropic / OpenAI / Gemini / GCP / Supabase /
+/// Notion など) を登録し、定期固定費 (= 資金繰り上の固定費) として計上するための
+/// 自己完結カード。状態・永続化・同期は資産管理ページが持ち、本ウィジェットは表示と
+/// コールバックのみを担う (定期固定費カードと同じ設計 / ページ本体を肥大化させない)。
+///
+/// 登録済みサブスクと未登録のプリセット (テンプレート) を分けて表示し、ワンタップで
+/// 追加できる。登録された値は定期固定費と同じパイプラインで資金繰りへ反映される。
+class SubscriptionFixedCostCard extends StatelessWidget {
+  const SubscriptionFixedCostCard({
+    super.key,
+    required this.costs,
+    required this.sourceAccountNames,
+    required this.onAddPreset,
+    required this.onAddCustom,
+    required this.onEdit,
+    required this.onDelete,
+    this.presets = AssetSubscriptionCatalog.presets,
+  });
+
+  /// 表示する登録済みサブスク (category == subscription / 振替日昇順で渡される想定)。
+  final List<AssetRecurringFixedCost> costs;
+
+  /// 振替元口座 ID → 表示名。サブタイトルの「振替元」表示に使う。
+  final Map<String, String> sourceAccountNames;
+
+  /// テンプレート一覧 (テスト差し替え用に注入可能)。
+  final List<AssetSubscriptionPreset> presets;
+
+  /// プリセットからの追加。
+  final void Function(AssetSubscriptionPreset preset) onAddPreset;
+
+  /// テンプレートに無いサブスクを手入力で追加。
+  final VoidCallback onAddCustom;
+  final void Function(AssetRecurringFixedCost cost) onEdit;
+  final void Function(AssetRecurringFixedCost cost) onDelete;
+
+  static String _normalize(String value) =>
+      value.replaceAll(RegExp(r'\s+'), '').toLowerCase();
+
+  /// サブタイトルは定期固定費カードと同じ表記を共有する。
+  String _subtitle(AssetRecurringFixedCost cost) =>
+      RecurringFixedCostCard.subtitleFor(cost, sourceAccountNames);
+
+  /// 既に登録済み (正規化した名前が一致) のプリセットは候補から除く。
+  ///
+  /// 名前ベースの簡易判定のため、ユーザーがダイアログでプリセット名を別名へ変更して
+  /// 保存した場合はこの一致が外れ、同じプリセットを再登録できてしまう (二重計上の余地)。
+  /// 重複は一覧から見える・削除できる低影響のため、現状は名前一致のみで許容する。
+  List<AssetSubscriptionPreset> _unregisteredPresets() {
+    final registered = costs.map((cost) => _normalize(cost.name)).toSet();
+    return [
+      for (final preset in presets)
+        if (!registered.contains(_normalize(preset.name))) preset,
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final availablePresets = _unregisteredPresets();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.subscriptions_outlined, color: scheme.primary),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'サブスク (AI/クラウド)',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  TextButton.icon(
+                    onPressed: onAddCustom,
+                    icon: const Icon(Icons.add),
+                    label: const Text('その他を追加'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Anthropic・OpenAI・Gemini・GCP・Supabase・Notion などの月額サブスクを'
+                '登録すると、定期固定費として資金繰り(見込み残高)に自動で反映されます。'
+                '金額・請求日は登録後に調整できます。',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+              ),
+              if (availablePresets.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                Text(
+                  'テンプレートから追加',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    for (final preset in availablePresets)
+                      ActionChip(
+                        avatar: const Icon(Icons.add, size: 18),
+                        label: Text(preset.name),
+                        tooltip: preset.note.isEmpty
+                            ? '${preset.name} を追加'
+                            : '${preset.name}（${preset.note}）を追加',
+                        onPressed: () => onAddPreset(preset),
+                      ),
+                  ],
+                ),
+              ],
+              const SizedBox(height: 8),
+              if (costs.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: Text(
+                    'まだ登録がありません。テンプレートか「その他を追加」から'
+                    'サブスクを登録できます。',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              else
+                for (final cost in costs)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          // 名称 + 内訳を 1 ノードへまとめて読み上げる。
+                          child: Semantics(
+                            container: true,
+                            label: '${cost.name}、${_subtitle(cost)}',
+                            child: MergeSemantics(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    cost.name,
+                                    style: theme.textTheme.bodyMedium?.copyWith(
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                  Text(
+                                    _subtitle(cost),
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color: scheme.onSurfaceVariant,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                        IconButton(
+                          tooltip: '${cost.name} を編集',
+                          icon: const Icon(Icons.edit_outlined),
+                          onPressed: () => onEdit(cost),
+                        ),
+                        IconButton(
+                          tooltip: '${cost.name} を削除',
+                          icon: const Icon(Icons.delete_outline),
+                          onPressed: () => onDelete(cost),
+                        ),
+                      ],
+                    ),
+                  ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/asset_recurring_fixed_cost_store_test.dart
+++ b/test/services/asset_recurring_fixed_cost_store_test.dart
@@ -62,6 +62,88 @@ void main() {
       expect(fallback, isNotNull);
       expect(fallback!.cadence, AssetRecurringFixedCostCadence.monthly);
     });
+
+    test('category defaults to utility and is omitted from json', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'a',
+        name: '電気代',
+        amount: 8000,
+        paymentDay: 27,
+      );
+      expect(cost.category, AssetRecurringFixedCostCategory.utility);
+      // 既定 (utility) のときは既存ペイロードと互換のため category を出力しない。
+      expect(cost.toJson().containsKey('category'), isFalse);
+    });
+
+    test('subscription category round-trips through json', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'sub_claude',
+        name: 'Anthropic (Claude)',
+        amount: 3000,
+        paymentDay: 1,
+        category: AssetRecurringFixedCostCategory.subscription,
+      );
+      final json = cost.toJson();
+      expect(json['category'], 'subscription');
+      final restored = AssetRecurringFixedCost.fromJson('sub_claude', json);
+      expect(restored, isNotNull);
+      expect(
+        restored!.category,
+        AssetRecurringFixedCostCategory.subscription,
+      );
+    });
+
+    test('fromJson without category defaults to utility (back-compat)', () {
+      // category キーが無い旧データ。
+      final restored = AssetRecurringFixedCost.fromJson('x', _validJson());
+      expect(restored, isNotNull);
+      expect(restored!.category, AssetRecurringFixedCostCategory.utility);
+    });
+
+    test('fromJson with unknown category falls back to utility', () {
+      final restored = AssetRecurringFixedCost.fromJson(
+        'x',
+        {..._validJson(), 'category': 'weird'},
+      );
+      expect(restored, isNotNull);
+      expect(restored!.category, AssetRecurringFixedCostCategory.utility);
+    });
+
+    test('copyWith updates category', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'a',
+        name: 'Notion',
+        amount: 1650,
+        paymentDay: 5,
+      );
+      final updated = cost.copyWith(
+        category: AssetRecurringFixedCostCategory.subscription,
+      );
+      expect(updated.category, AssetRecurringFixedCostCategory.subscription);
+      // 他フィールドは保持。
+      expect(updated.name, 'Notion');
+      expect(updated.amount, 1650);
+    });
+  });
+
+  group('AssetRecurringFixedCostStore category', () {
+    test('mirror value preserves subscription category', () {
+      const costs = <AssetRecurringFixedCost>[
+        AssetRecurringFixedCost(
+          id: 'sub_openai',
+          name: 'OpenAI (ChatGPT)',
+          amount: 3000,
+          paymentDay: 1,
+          category: AssetRecurringFixedCostCategory.subscription,
+        ),
+      ];
+      final encoded = AssetRecurringFixedCostStore.encodeMirrorValue(costs);
+      final decoded = AssetRecurringFixedCostStore.decodeMirrorValue(encoded);
+      expect(
+        decoded.single.category,
+        AssetRecurringFixedCostCategory.subscription,
+      );
+    });
   });
 
   group('AssetRecurringFixedCostStore', () {

--- a/test/services/asset_subscription_catalog_test.dart
+++ b/test/services/asset_subscription_catalog_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_subscription_catalog.dart';
+
+void main() {
+  group('AssetSubscriptionCatalog', () {
+    test('presets are non-empty with unique ids and positive amounts', () {
+      const presets = AssetSubscriptionCatalog.presets;
+      expect(presets, isNotEmpty);
+      final ids = presets.map((p) => p.id).toSet();
+      expect(ids.length, presets.length, reason: 'preset ids must be unique');
+      for (final preset in presets) {
+        expect(preset.id.trim(), isNotEmpty);
+        expect(preset.name.trim(), isNotEmpty);
+        expect(preset.defaultMonthlyAmount, greaterThan(0));
+      }
+    });
+
+    test('covers the headline AI/cloud providers', () {
+      final ids = AssetSubscriptionCatalog.presets.map((p) => p.id).toSet();
+      for (final required in const <String>[
+        'anthropic',
+        'openai',
+        'gemini',
+        'gcp',
+        'supabase',
+        'notion',
+      ]) {
+        expect(ids, contains(required), reason: 'missing preset: $required');
+      }
+    });
+
+    test('toPrefill produces a subscription-category recurring fixed cost', () {
+      final preset = AssetSubscriptionCatalog.presets
+          .firstWhere((p) => p.id == 'anthropic');
+      final draft = preset.toPrefill(paymentDay: 12);
+      expect(draft.category, AssetRecurringFixedCostCategory.subscription);
+      expect(draft.name, preset.name);
+      expect(draft.amount, preset.defaultMonthlyAmount);
+      expect(draft.paymentDay, 12);
+      expect(draft.cadence, AssetRecurringFixedCostCadence.monthly);
+    });
+
+    test('toPrefill default payment day falls back to catalog default', () {
+      final draft = AssetSubscriptionCatalog.presets.first.toPrefill();
+      expect(draft.paymentDay, AssetSubscriptionCatalog.defaultPaymentDay);
+      // 1〜31 の正当な振替日 (fromJson が受け付ける範囲)。
+      expect(draft.paymentDay, inInclusiveRange(1, 31));
+    });
+  });
+}

--- a/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
+++ b/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
@@ -57,4 +57,150 @@ void main() {
     expect(saved!.paymentDay, 15);
     expect(saved!.id, isNot('fc_suggestion')); // 新規 id を採番
   });
+
+  testWidgets('subscription prefill shows subscription title', (tester) async {
+    const subPrefill = AssetRecurringFixedCost(
+      id: 'sub_preset_anthropic',
+      name: 'Anthropic (Claude)',
+      amount: 3000,
+      paymentDay: 1,
+      category: AssetRecurringFixedCostCategory.subscription,
+    );
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: RecurringFixedCostEditorDialog(prefill: subPrefill),
+        ),
+      ),
+    );
+
+    expect(find.text('サブスクを追加'), findsOneWidget);
+    expect(
+      find.widgetWithText(TextFormField, 'Anthropic (Claude)'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('category param defaults the add form to subscription', (
+    tester,
+  ) async {
+    AssetRecurringFixedCost? saved;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                saved = await showRecurringFixedCostEditor(
+                  context,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('サブスクを追加'), findsOneWidget);
+
+    // 区分は DropdownButtonFormField のため TextFormField の並びは name/amount/day。
+    await tester.enterText(find.byType(TextFormField).at(0), 'Supabase');
+    await tester.enterText(find.byType(TextFormField).at(1), '3800');
+    await tester.enterText(find.byType(TextFormField).at(2), '5');
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+
+    expect(saved, isNotNull);
+    expect(saved!.name, 'Supabase');
+    expect(saved!.category, AssetRecurringFixedCostCategory.subscription);
+  });
+
+  testWidgets('editing an existing subscription preserves its category', (
+    tester,
+  ) async {
+    const existing = AssetRecurringFixedCost(
+      id: 'sub_existing',
+      name: 'Notion',
+      amount: 1650,
+      paymentDay: 5,
+      category: AssetRecurringFixedCostCategory.subscription,
+    );
+    AssetRecurringFixedCost? saved;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                saved = await showRecurringFixedCostEditor(
+                  context,
+                  existing: existing,
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('サブスクを編集'), findsOneWidget);
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+
+    expect(saved, isNotNull);
+    expect(saved!.id, 'sub_existing'); // 既存 id を保持
+    expect(saved!.category, AssetRecurringFixedCostCategory.subscription);
+  });
+
+  testWidgets('区分ドロップダウンで utility→subscription に切り替えて保存できる', (
+    tester,
+  ) async {
+    AssetRecurringFixedCost? saved;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                // 既定 (utility) の追加モードで開く。
+                saved = await showRecurringFixedCostEditor(context);
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('定期固定費を追加'), findsOneWidget);
+
+    // 区分ドロップダウンを開いて「サブスク」を選ぶ (onChanged→setState の配線を検証)。
+    await tester.tap(
+      find.byType(DropdownButtonFormField<AssetRecurringFixedCostCategory>),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('サブスク').last);
+    await tester.pumpAndSettle();
+    // タイトルが追従して切り替わる。
+    expect(find.text('サブスクを追加'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField).at(0), 'Cursor');
+    await tester.enterText(find.byType(TextFormField).at(1), '3000');
+    await tester.enterText(find.byType(TextFormField).at(2), '10');
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+
+    expect(saved, isNotNull);
+    expect(saved!.name, 'Cursor');
+    expect(saved!.category, AssetRecurringFixedCostCategory.subscription);
+  });
 }

--- a/test/widgets/subscription_fixed_cost_card_test.dart
+++ b/test/widgets/subscription_fixed_cost_card_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_subscription_catalog.dart';
+import 'package:my_web_app/widgets/subscription_fixed_cost_card.dart';
+
+void main() {
+  const presets = <AssetSubscriptionPreset>[
+    AssetSubscriptionPreset(
+      id: 'anthropic',
+      name: 'Anthropic (Claude)',
+      defaultMonthlyAmount: 3000,
+      note: 'Claude Pro 目安',
+    ),
+    AssetSubscriptionPreset(
+      id: 'notion',
+      name: 'Notion',
+      defaultMonthlyAmount: 1650,
+    ),
+  ];
+
+  group('SubscriptionFixedCostCard', () {
+    testWidgets('renders preset chips and fires onAddPreset', (tester) async {
+      AssetSubscriptionPreset? addedPreset;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SubscriptionFixedCostCard(
+              costs: const <AssetRecurringFixedCost>[],
+              sourceAccountNames: const <String, String>{},
+              presets: presets,
+              onAddPreset: (preset) => addedPreset = preset,
+              onAddCustom: () {},
+              onEdit: (_) {},
+              onDelete: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('サブスク (AI/クラウド)'), findsOneWidget);
+      expect(find.textContaining('まだ登録がありません'), findsOneWidget);
+      // 2 件のテンプレート chip。
+      expect(
+        find.widgetWithText(ActionChip, 'Anthropic (Claude)'),
+        findsOneWidget,
+      );
+      expect(find.widgetWithText(ActionChip, 'Notion'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(ActionChip, 'Notion'));
+      expect(addedPreset?.id, 'notion');
+    });
+
+    testWidgets('hides presets already registered (dedup by name)',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SubscriptionFixedCostCard(
+              costs: const <AssetRecurringFixedCost>[
+                AssetRecurringFixedCost(
+                  id: 'sub_notion',
+                  name: 'Notion',
+                  amount: 1650,
+                  paymentDay: 5,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                ),
+              ],
+              sourceAccountNames: const <String, String>{},
+              presets: presets,
+              onAddPreset: (_) {},
+              onAddCustom: () {},
+              onEdit: (_) {},
+              onDelete: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      // 登録済み Notion はリストに出るが、テンプレート chip からは消える。
+      expect(find.text('Notion'), findsOneWidget);
+      expect(find.widgetWithText(ActionChip, 'Notion'), findsNothing);
+      expect(
+        find.widgetWithText(ActionChip, 'Anthropic (Claude)'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders registered entries and fires edit/delete/custom-add',
+        (tester) async {
+      AssetRecurringFixedCost? edited;
+      AssetRecurringFixedCost? deleted;
+      var customPressed = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SubscriptionFixedCostCard(
+              costs: const <AssetRecurringFixedCost>[
+                AssetRecurringFixedCost(
+                  id: 'sub_claude',
+                  name: 'Anthropic (Claude)',
+                  amount: 3000,
+                  paymentDay: 1,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                  sourceAccountId: 'smbc',
+                ),
+              ],
+              sourceAccountNames: const <String, String>{
+                'smbc': '三井住友銀行',
+              },
+              presets: presets,
+              onAddPreset: (_) {},
+              onAddCustom: () => customPressed = true,
+              onEdit: (cost) => edited = cost,
+              onDelete: (cost) => deleted = cost,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Anthropic (Claude)'), findsWidgets);
+      expect(find.textContaining('毎月1日'), findsOneWidget);
+      expect(find.textContaining('¥3,000'), findsOneWidget);
+      expect(find.textContaining('振替元: 三井住友銀行'), findsOneWidget);
+
+      // 行ごとに 名称+内訳 を 1 つの semantics ラベルへまとめる。
+      final rowSemantics = find.byWidgetPredicate(
+        (widget) =>
+            widget is Semantics &&
+            (widget.properties.label?.contains('Anthropic (Claude)') ??
+                false) &&
+            (widget.properties.label?.contains('¥3,000') ?? false),
+      );
+      expect(rowSemantics, findsOneWidget);
+
+      await tester.tap(find.text('その他を追加'));
+      expect(customPressed, isTrue);
+      await tester.tap(find.byTooltip('Anthropic (Claude) を編集'));
+      expect(edited?.id, 'sub_claude');
+      await tester.tap(find.byTooltip('Anthropic (Claude) を削除'));
+      expect(deleted?.id, 'sub_claude');
+    });
+  });
+}


### PR DESCRIPTION
## 概要

Anthropic / OpenAI / Gemini / GCP / Supabase / Notion などの月額サブスク（SaaS）を登録し、**資金繰り（固定費）へ自動反映**できる仕組みを追加します。

サブスクは内部的には既存の「定期固定費（`AssetRecurringFixedCost`）」の一区分として扱い、**store・端末間同期・`buildWorkbook` の計上パイプラインを丸ごと共用**します。つまり「サブスクを固定費として計上する」中核ロジックは新設ではなく既存経路の再利用で、登録 UI とプリセットだけを追加しています。

## 変更点

- **モデル**: `AssetRecurringFixedCost` に `category(utility|subscription)` を追加（既定 `utility` / `utility` のときは JSON へ出力せず既存ペイロード・同期データと**完全後方互換**）。
- **カタログ**: `AssetSubscriptionCatalog` — 代表的な AI/クラウド SaaS のプリセット集（金額は編集可能な目安）。
- **UI**: 専用カード `SubscriptionFixedCostCard`（専用セクション `subscriptionFixedCost`）。テンプレートチップからワンタップ登録 + 「その他を追加」で手入力。
- **編集ダイアログ**: 「区分」セレクタを追加し `category` を往復（プリセット追加 / 手動追加 / 既存編集のいずれでも区分を保持）。
- **ページ配線**: 既存の定期固定費カードは `utility` のみ表示、サブスクは専用カードへ分離。`buildWorkbook` には従来どおり全件（両区分）を渡すため、サブスクも固定費として資金繰りに乗ります。

## 設計判断

- サブスクは「定期固定費の一カテゴリ」とし、**同期経路・計上経路を一本化**（並行システムを作らない）。既存データの挙動はゼロ変更。
- 金額は USD 課金サービスの円換算の**目安**。登録ダイアログで実際の請求額・請求日に調整する前提。

## レビュー（多エージェント敵対レビュー）

4 次元（correctness / 後方互換・同期 / UI・a11y / テスト網羅）の並列レビュー + 各指摘を懐疑エージェントで検証。確定 7 件を反映:

- **（高）stale-base による #3514/#3515 の巻き戻し** → 現 `origin/main` へ rebase 済み。差分は本機能 11 ファイルのみ（巻き戻しファイルは差分から消滅を確認）。
- **（低）サブスクカードとサブタイトル整形の重複** → `RecurringFixedCostCard.subtitleFor` を共有ヘルパー化し両カードで委譲。
- **（低）プリセット重複判定が名称一致のみ** → 制約をコードコメントで明記（重複は一覧表示・削除可で低影響）。
- **（低）区分ドロップダウン操作の未テスト** → utility→subscription 切替の widget テストを追加。
- ラベルの空白統一など軽微な polish。

## 検証

- `flutter analyze`（touched 7 ファイル）: **No issues found**。
- `flutter test`（model/store/catalog/injection/display-mode/editor/card 各 suite）: **全 63 ケース green**。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: UI card + model/catalog feature covered by widget+unit tests (63 cases); no new e2e route, reuses existing recurring-fixed-cost flow

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive UI/model feature under lib/services,lib/widgets (not lib/subscription); no auth/billing/RLS/deploy/migration touched; verified by analyze clean + 63 tests + 4-dimension adversarial review (0 unresolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
