### PR TITLE
feat(asset): 負債マスタを給料日サイクル順に並べ替え

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -21843,7 +21843,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
         const SizedBox(height: 4),
         Text(
-          '支払済みチェックは給料日25日基準のサイクルで保存されます。入力欄は画面幅に合わせて折り返します。',
+          '支払済みチェックは給料日$_salaryDay日基準のサイクルで保存されます。'
+          'カードも給料日起点の支払日順に並びます。入力欄は画面幅に合わせて折り返します。',
           style: TextStyle(
             color: Theme.of(context).colorScheme.onSurfaceVariant,
             fontSize: 12,
@@ -22270,9 +22271,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     AssetLiabilityDebtRow a,
     AssetLiabilityDebtRow b,
   ) {
-    final dayA = a.paymentDay ?? 99;
-    final dayB = b.paymentDay ?? 99;
-    final day = dayA.compareTo(dayB);
+    // 給料日サイクル順 (給料日起点) に並べる。salaryDay=25 なら
+    // 25,26…31,1…24 の順。未設定 (null) は末尾。
+    final rankA = AssetLiabilityMonthlyStateStore.salaryCyclePaymentDayRank(
+      a.paymentDay,
+      salaryDay: _salaryDay,
+    );
+    final rankB = AssetLiabilityMonthlyStateStore.salaryCyclePaymentDayRank(
+      b.paymentDay,
+      salaryDay: _salaryDay,
+    );
+    final day = rankA.compareTo(rankB);
     if (day != 0) {
       return day;
     }

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -628,6 +628,19 @@ class AssetLiabilityMonthlyStateStore {
     return DateTime(start.year, start.month + 1, start.day);
   }
 
+  /// 支払日 [paymentDay] を給料日サイクル内の並び順 (0 起点) へ写像する。
+  /// salaryDay を起点に「給料日以降→翌給料日前日」を 0..30 で表すので、
+  /// salaryDay=25 なら 25 日→0, 31 日→6, 1 日→7, 24 日→30 の順になる。
+  /// null (未設定) は末尾へ送るため十分大きい値を返す。
+  static int salaryCyclePaymentDayRank(int? paymentDay, {int salaryDay = 25}) {
+    if (paymentDay == null) {
+      return 1000;
+    }
+    final anchor = salaryDay.clamp(1, 28).toInt();
+    final day = paymentDay.clamp(1, 31).toInt();
+    return day >= anchor ? day - anchor : day - anchor + 31;
+  }
+
   static AssetLiabilityMonthlyState copyPreviousMonthState({
     required AssetLiabilityMonthlyState previousState,
     required DateTime targetMonth,

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -73,6 +73,35 @@ void main() {
       );
     });
 
+    test('salaryCyclePaymentDayRank orders days from the salary day', () {
+      int rank(int? day, {int salaryDay = 25}) =>
+          AssetLiabilityMonthlyStateStore.salaryCyclePaymentDayRank(
+            day,
+            salaryDay: salaryDay,
+          );
+      // salaryDay=25: 25→0, 26→1, 31→6, 1→7, 24→30 の順 (給料日起点)。
+      expect(rank(25), 0);
+      expect(rank(26), 1);
+      expect(rank(31), 6);
+      expect(rank(1), 7);
+      expect(rank(24), 30);
+      // 給料日以降が必ず給料日前より前に来る (連続・単調)。
+      final ordered = [for (var d = 1; d <= 31; d++) d]
+        ..sort((a, b) => rank(a).compareTo(rank(b)));
+      expect(ordered.first, 25);
+      expect(ordered.last, 24);
+      // 未設定は末尾。
+      expect(rank(null), greaterThan(rank(24)));
+      // salaryDay を変えると起点も動く。
+      expect(rank(1, salaryDay: 1), 0);
+      expect(rank(28, salaryDay: 1), 27);
+      expect(rank(10, salaryDay: 10), 0);
+      expect(rank(9, salaryDay: 10), 30);
+      // clamp 境界 (paymentDay 0/32 は 1/31 扱い)。
+      expect(rank(0), rank(1));
+      expect(rank(32), rank(31));
+    });
+
     test('saves and restores monthly paid statuses', () async {
       await store.saveMonth(
         month: DateTime(2026, 5, 13),


### PR DESCRIPTION
## 概要

資産管理画面「負債マスタ（支払日順）」の並びを、単純な支払日数値順(1→31)から
**給料日を起点とした給料日サイクル順**へ変更します。給料日=25日なら
`25,26…31,1…24` の順になり、支払済みチェックの保存サイクル（給料日サイクル）と
カードの表示順が一致します。給料日サイクル統一 #3500 / #3504 の続きです。

## 変更点

- `AssetLiabilityMonthlyStateStore.salaryCyclePaymentDayRank` を追加
  （支払日 → サイクル内 0 起点順位へ写像。`null` は末尾、clamp 境界対応）
- `_compareDebtRowsByPaymentDay` を rank 比較へ置換（第2/第3キー=残高降順・名前は不変）
- 説明文の「給料日25日基準」ハードコードを `_salaryDay` 反映へ修正
- rank の単体テストを追加（順序・null・salaryDay 変動・clamp 境界）

## テスト

- `flutter test test/services/asset_liability_monthly_state_store_test.dart` → 26 件 green
- `flutter analyze`（変更2ファイル）→ No issues

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純粋関数 salaryCyclePaymentDayRank の単体テストで順序を網羅済み。UI は既存負債マスタの並び順のみ変更で新規フロー無し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
