### PR TITLE
feat(asset): サブスク棚卸し (支払い元カバレッジ) を追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -41,6 +41,8 @@ import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_recurring_suggestion_ignore_store.dart';
+import 'package:my_web_app/services/asset_subscription_audit_catalog.dart';
+import 'package:my_web_app/services/asset_subscription_audit_store.dart';
 import 'package:my_web_app/services/asset_subscription_catalog.dart';
 import 'package:my_web_app/services/asset_salary_day_store.dart';
 import 'package:my_web_app/services/asset_recurring_transaction_detector.dart';
@@ -77,6 +79,7 @@ import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
 import 'package:my_web_app/widgets/asset_category_budget_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
+import 'package:my_web_app/widgets/subscription_audit_card.dart';
 import 'package:my_web_app/widgets/subscription_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/asset_recurring_transaction_suggestion_card.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
@@ -209,6 +212,11 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final Map<String, dynamic>? debugRecurringFixedCostsDeletedMirror;
 
+  /// テスト専用: サブスク棚卸しの確認状況ミラー値 (`{sourceId: iso8601}`) を注入し、
+  /// 端末間 MAX マージ復元をネットワークなしで検証する。
+  @visibleForTesting
+  final Map<String, dynamic>? debugSubscriptionAuditMirror;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -233,6 +241,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugInitialRecurringFixedCosts,
     this.debugRecurringFixedCostsMirror,
     this.debugRecurringFixedCostsDeletedMirror,
+    this.debugSubscriptionAuditMirror,
   });
 
   @override
@@ -433,6 +442,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // UI 登録の定期固定費 (家賃・光熱費など)。振替日昇順で保持する。
   List<AssetRecurringFixedCost> _recurringFixedCosts =
       <AssetRecurringFixedCost>[];
+  // サブスク棚卸し: 支払い元ごとの最終確認日時 (sourceId → UTC)。
+  Map<String, DateTime> _subscriptionAuditState = <String, DateTime>{};
   // 定期取引の自動検出で「無視」した正規化ラベル(再提案しない / 支出側)。
   Set<String> _ignoredRecurringLabels = <String>{};
   // 定期入金の自動検出で「無視」した正規化ラベル(再提案しない / 収入側)。
@@ -618,6 +629,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   static const String _recurringFixedCostsMirrorKey = 'recurring_fixed_costs';
   static const String _recurringFixedCostsDeletedMirrorKey =
       'recurring_fixed_costs_deleted';
+  final AssetSubscriptionAuditStore _subscriptionAuditStore =
+      const AssetSubscriptionAuditStore();
+  static const String _subscriptionAuditMirrorKey = 'subscription_audit_state';
   final AssetRecurringSuggestionIgnoreStore _recurringIgnoreStore =
       const AssetRecurringSuggestionIgnoreStore();
   static const String _recurringIgnoredMirrorKey =
@@ -744,6 +758,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_loadRevolvingConfigs());
     unawaited(_loadCategoryBudgets());
     unawaited(_loadRecurringFixedCosts());
+    unawaited(_loadSubscriptionAudit());
     unawaited(_loadRecurringIgnored());
     unawaited(_loadRecurringIncomeIgnored());
     unawaited(_loadDrinkChallenge());
@@ -7996,6 +8011,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _buildSubscriptionFixedCostCard(assetLiabilityWorkbook),
               const SizedBox(height: 16),
             ],
+            if (_isSectionShown(
+                AssetManagementSectionId.subscriptionAudit)) ...[
+              _buildSubscriptionAuditCard(assetLiabilityWorkbook),
+              const SizedBox(height: 16),
+            ],
             if (_isSectionShown(AssetManagementSectionId.disposable)) ...[
               _buildDisposableBalanceCard(),
               const SizedBox(height: 16),
@@ -8695,6 +8715,192 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('recurring fixed cost mirror upsert failed: $e');
     }
+  }
+
+  // --- サブスク棚卸し (支払い元ごとの確認状況) ---
+
+  Future<void> _loadSubscriptionAudit() async {
+    try {
+      final state = await _subscriptionAuditStore.load();
+      if (mounted && state.isNotEmpty) {
+        setState(() => _subscriptionAuditState = state);
+      }
+    } catch (e) {
+      debugPrint('Error loading subscription audit: $e');
+    }
+    await _restoreSubscriptionAuditFromMirror();
+  }
+
+  /// サーバ集約ミラー (pref_key: subscription_audit_state) から復元する。
+  /// 「確認した」は単調なので、tombstone/dirty/LWW ではなく MAX マージで統合する。
+  Future<void> _restoreSubscriptionAuditFromMirror() async {
+    final debugMirror = widget.debugSubscriptionAuditMirror;
+    if (debugMirror == null && _supabase.auth.currentUser == null) {
+      return;
+    }
+    final localBefore = Map<String, DateTime>.from(_subscriptionAuditState);
+    try {
+      final Map<String, DateTime> serverState;
+      final DateTime? mirrorUpdatedAt;
+      if (debugMirror != null) {
+        serverState =
+            AssetSubscriptionAuditStore.decodeMirrorValue(debugMirror);
+        mirrorUpdatedAt = DateTime.now().toUtc();
+      } else {
+        final rows = await _supabase
+            .from('asset_pref_mirror')
+            .select()
+            .eq('pref_key', _subscriptionAuditMirrorKey);
+        if (rows.isEmpty) {
+          // サーバ行無し: ローカルにあれば初回バックフィル。
+          if (localBefore.isNotEmpty) {
+            unawaited(_mirrorSubscriptionAudit());
+          }
+          return;
+        }
+        serverState = AssetSubscriptionAuditStore.decodeMirrorValue(
+          rows.first['value'],
+        );
+        mirrorUpdatedAt = DateTime.tryParse(
+          rows.first['updated_at']?.toString() ?? '',
+        );
+      }
+      if (!mounted) {
+        return;
+      }
+      // 取込み中に「確認した」が入っても失わないよう、localBefore ではなく現在の
+      // in-memory state とマージする (MAX は単調なので新しい確認を消さない)。
+      final current = _subscriptionAuditState;
+      final merged = AssetSubscriptionAuditStore.mergeMax(current, serverState);
+      if (!_sameSubscriptionAuditState(current, merged)) {
+        setState(() => _subscriptionAuditState = merged);
+        _persistInBackground(
+          _subscriptionAuditStore.save(merged),
+          'subscription audit restore save',
+        );
+        unawaited(
+          _realignMirrorTimestamp(_subscriptionAuditMirrorKey, mirrorUpdatedAt),
+        );
+      }
+      // ローカルにサーバより新しい確認があればサーバへ反映 (和集合維持)。
+      final localHasNewer = localBefore.entries.any((entry) {
+        final server = serverState[entry.key];
+        return server == null || entry.value.isAfter(server);
+      });
+      if (localHasNewer && debugMirror == null) {
+        unawaited(_mirrorSubscriptionAudit());
+      }
+    } catch (e) {
+      debugPrint('subscription audit mirror restore failed: $e');
+    }
+  }
+
+  bool _sameSubscriptionAuditState(
+    Map<String, DateTime> a,
+    Map<String, DateTime> b,
+  ) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final entry in a.entries) {
+      if (b[entry.key] != entry.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// 確認状況の全量を `asset_pref_mirror` へ 1 行 upsert する。
+  Future<void> _mirrorSubscriptionAudit() async {
+    unawaited(_syncTimestampStore.markChanged(_subscriptionAuditMirrorKey));
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _subscriptionAuditMirrorKey,
+        'value': AssetSubscriptionAuditStore.encodeMirrorValue(
+          _subscriptionAuditState,
+        ),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('subscription audit mirror upsert failed: $e');
+    }
+  }
+
+  void _markSubscriptionSourceChecked(SubscriptionAuditSource source) {
+    final next = Map<String, DateTime>.from(_subscriptionAuditState);
+    next[source.id] = DateTime.now().toUtc();
+    setState(() => _subscriptionAuditState = next);
+    _persistInBackground(
+      _subscriptionAuditStore.save(next),
+      'subscription audit save',
+    );
+    unawaited(_mirrorSubscriptionAudit());
+  }
+
+  /// 棚卸し対象の支払い元: manual (Apple/au/Google) + 銀行 + カード別 (口座から導出)。
+  List<SubscriptionAuditSource> _subscriptionAuditSources(
+    AssetLiabilityWorkbook? workbook,
+  ) {
+    final sources = <SubscriptionAuditSource>[
+      ...AssetSubscriptionAuditCatalog.manualSources,
+      AssetSubscriptionAuditCatalog.bankSource,
+    ];
+    if (workbook != null) {
+      for (final account in _cardBillingAccountOptions(workbook)) {
+        sources.add(
+          SubscriptionAuditSource(
+            id: AssetSubscriptionAuditCatalog.cardSourceId(account.id),
+            name: account.name,
+            kind: SubscriptionAuditSourceKind.autoAssisted,
+          ),
+        );
+      }
+    }
+    return sources;
+  }
+
+  /// 未登録の定期支出を支払い元 (sourceId) ごとに集計する。検出は登録済み・無視済みを
+  /// 減算済みの `_detectRecurringTransactions()` を流用 (提案カードと二重計上しない)。
+  Map<String, int> _unregisteredCountBySourceId(
+    AssetLiabilityWorkbook? workbook,
+  ) {
+    final detected = _detectRecurringTransactions();
+    if (detected.isEmpty) {
+      return const <String, int>{};
+    }
+    final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
+    return AssetSubscriptionAuditCatalog.bucketUnregisteredCounts(
+      accounts: accounts.map(
+        (account) => (id: account.id, name: account.name, kind: account.kind),
+      ),
+      suggestedSourceNames: detected.map((item) => item.suggestedSourceName),
+    );
+  }
+
+  Widget _buildSubscriptionAuditCard(AssetLiabilityWorkbook? workbook) {
+    final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
+    final sourceOptions = <RecurringFixedCostSourceOption>[
+      for (final account in accounts)
+        if (account.balance > 0) (id: account.id, name: account.name),
+    ];
+    return SubscriptionAuditCard(
+      sources: _subscriptionAuditSources(workbook),
+      lastCheckedAt: _subscriptionAuditState,
+      unregisteredCountBySourceId: _unregisteredCountBySourceId(workbook),
+      now: _now,
+      onMarkChecked: _markSubscriptionSourceChecked,
+      onRegisterSubscription: (source) => unawaited(
+        _openRecurringFixedCostEditor(
+          sourceOptions: sourceOptions,
+          category: AssetRecurringFixedCostCategory.subscription,
+        ),
+      ),
+    );
   }
 
   /// 削除した定期固定費のトゥームストーン。union マージ/backfill での復活を防ぎ、

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -18,6 +18,7 @@ enum AssetManagementSectionId {
   salaryBreakdown,
   recurringFixedCost,
   subscriptionFixedCost,
+  subscriptionAudit,
   disposable,
   quickActions,
   wasteAi,
@@ -82,6 +83,8 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
         return '定期固定費';
       case AssetManagementSectionId.subscriptionFixedCost:
         return 'サブスク (AI/クラウド)';
+      case AssetManagementSectionId.subscriptionAudit:
+        return 'サブスク棚卸し';
       case AssetManagementSectionId.disposable:
         return '裁量余資金';
       case AssetManagementSectionId.quickActions:
@@ -121,6 +124,7 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
       case AssetManagementSectionId.salaryBreakdown:
       case AssetManagementSectionId.recurringFixedCost:
       case AssetManagementSectionId.subscriptionFixedCost:
+      case AssetManagementSectionId.subscriptionAudit:
       case AssetManagementSectionId.deadlines:
       case AssetManagementSectionId.threeMonth:
       case AssetManagementSectionId.workbookBoard:

--- a/lib/services/asset_subscription_audit_catalog.dart
+++ b/lib/services/asset_subscription_audit_catalog.dart
@@ -1,0 +1,140 @@
+import '../models/asset_liability_workbook.dart';
+
+/// 集計入力用の口座 (id/表示名/種別) の最小ビュー。`AssetLiabilityAccount` 全体に
+/// 依存せず純関数 [AssetSubscriptionAuditCatalog.bucketUnregisteredCounts] を単体
+/// テスト可能にするための型。
+typedef SubscriptionAuditAccountView = ({
+  String id,
+  String name,
+  AssetLiabilityAccountKind kind,
+});
+
+/// サブスク棚卸しで確認する「支払い元(ソース)」の種別。
+enum SubscriptionAuditSourceKind {
+  /// アプリ側が個別サブスクを把握できない集約請求 (Apple/au/Google 等)。
+  /// 確認手順を提示し、ユーザーに手動確認を促す。
+  manualCheck,
+
+  /// 取引フロー (定期支出検出) からアプリが候補を提示できる支払い元
+  /// (銀行引き落とし・各クレジットカード)。
+  autoAssisted,
+}
+
+/// 棚卸し対象の支払い元 1 件 (静的定義)。確認状況 (最終確認日時) は本モデルには
+/// 持たせず、`AssetSubscriptionAuditStore` 側で sourceId をキーに永続化する。
+class SubscriptionAuditSource {
+  /// 安定した一意 ID。永続化キー (ミラー) になるためリネーム不可。
+  /// manual ソースは固定文字列、カード別ソースは `card_<accountId>`。
+  final String id;
+
+  /// 表示名 (例: Apple (iOS) サブスク)。
+  final String name;
+
+  /// 種別 (手動確認 / 自動補助)。
+  final SubscriptionAuditSourceKind kind;
+
+  /// 手動確認ソースに提示する確認手順 (順序付き)。autoAssisted では空でよい。
+  final List<String> checkSteps;
+
+  const SubscriptionAuditSource({
+    required this.id,
+    required this.name,
+    required this.kind,
+    this.checkSteps = const <String>[],
+  });
+}
+
+/// サブスク棚卸しの静的カタログ。
+///
+/// Apple/au/Google は「集約請求」で個別サブスクがアプリから不可視なため、確認手順を
+/// 提示してユーザーに棚卸しを促す (manualCheck)。銀行・各カードは取引フローから定期
+/// 支出を検出できるため候補を提示する (autoAssisted / カード別ソースは実行時に導出)。
+class AssetSubscriptionAuditCatalog {
+  const AssetSubscriptionAuditCatalog._();
+
+  /// 「要再確認」とみなす最終確認からの経過日数。
+  static const int staleDays = 30;
+
+  /// カード別ソースの ID 接頭辞 (口座 ID と連結して安定 ID にする)。
+  static const String cardSourceIdPrefix = 'card_';
+
+  /// 取引フローに記録される銀行引き落としをまとめる autoAssisted ソース ID。
+  static const String bankSourceId = 'bank_direct_debit';
+
+  /// アプリが個別サブスクを把握できない手動確認ソース (Apple/au/Google)。
+  static const List<SubscriptionAuditSource> manualSources =
+      <SubscriptionAuditSource>[
+    SubscriptionAuditSource(
+      id: 'apple_id',
+      name: 'Apple (iOS) サブスク',
+      kind: SubscriptionAuditSourceKind.manualCheck,
+      checkSteps: <String>[
+        'iPhone/iPad で「設定」アプリを開く',
+        '上部の自分の名前 (Apple Account) をタップ',
+        '「サブスクリプション」をタップ',
+        '有効なサブスクの更新日・金額を確認 (Mac は App Store > 名前 > アカウント設定)',
+      ],
+    ),
+    SubscriptionAuditSource(
+      id: 'au_kantan',
+      name: 'auかんたん決済',
+      kind: SubscriptionAuditSourceKind.manualCheck,
+      checkSteps: <String>[
+        'My au アプリ または My au (web) にログイン',
+        '「ご利用明細」→「auかんたん決済・au PAY」の利用履歴を確認',
+        'または「会員情報・各種設定」→「ご契約中の有料サービス」を確認',
+        '毎月課金されている定期サービスを洗い出す',
+      ],
+    ),
+    SubscriptionAuditSource(
+      id: 'google_play',
+      name: 'Google Play 定期購入',
+      kind: SubscriptionAuditSourceKind.manualCheck,
+      checkSteps: <String>[
+        'Google Play ストアアプリを開く',
+        '右上のプロフィールアイコン →「お支払いと定期購入」',
+        '「定期購入」をタップして有効な定期購入を確認',
+        'web は play.google.com/store/account/subscriptions',
+      ],
+    ),
+  ];
+
+  /// 取引フローから定期支出を検出できる「銀行引き落とし」ソース。
+  static const SubscriptionAuditSource bankSource = SubscriptionAuditSource(
+    id: bankSourceId,
+    name: '銀行引き落とし',
+    kind: SubscriptionAuditSourceKind.autoAssisted,
+  );
+
+  /// 口座 ID からカード別ソースの安定 ID を作る。
+  static String cardSourceId(String accountId) =>
+      '$cardSourceIdPrefix$accountId';
+
+  /// 検出した定期支出 ([suggestedSourceNames] = 各検出の引落元口座名) を支払い元
+  /// ソース ID ごとに集計する純関数。
+  ///
+  /// クレカ口座名は `card_<id>`、現金/預金口座名は銀行ソース、未知・不明 (null) は
+  /// 銀行ソースへ寄せる (取りこぼし防止)。検出器は口座名しか持たないため、同名口座が
+  /// 複数あると最後に走査した口座へ寄る (件数自体は失わない / 既存 register 経路と同仕様)。
+  static Map<String, int> bucketUnregisteredCounts({
+    required Iterable<SubscriptionAuditAccountView> accounts,
+    required Iterable<String?> suggestedSourceNames,
+  }) {
+    final nameToSourceId = <String, String>{};
+    for (final account in accounts) {
+      if (account.kind == AssetLiabilityAccountKind.creditCard) {
+        nameToSourceId[account.name] = cardSourceId(account.id);
+      } else if (account.kind == AssetLiabilityAccountKind.cash ||
+          account.kind == AssetLiabilityAccountKind.deposit) {
+        nameToSourceId[account.name] = bankSourceId;
+      }
+    }
+    final counts = <String, int>{};
+    for (final name in suggestedSourceNames) {
+      final sourceId =
+          (name != null ? nameToSourceId[name] : null) ?? bankSourceId;
+      counts[sourceId] = (counts[sourceId] ?? 0) + 1;
+    }
+    return counts;
+  }
+}

--- a/lib/services/asset_subscription_audit_store.dart
+++ b/lib/services/asset_subscription_audit_store.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// サブスク棚卸しの「支払い元ごとの最終確認日時」を永続化する。
+///
+/// ローカル (SharedPreferences) を一次ストアとし、資産管理ページが `asset_pref_mirror`
+/// (pref_key: `subscription_audit_state`) へ 1 行 jsonb でミラーする (定期固定費と同方針)。
+/// 保存形は `{sourceId: iso8601(UTC)}`。
+///
+/// 「確認した」は単調 (巻き戻らない) なので、端末間マージは **各 sourceId で最新時刻を
+/// 採用する MAX マージ** ([mergeMax]) で十分。tombstone / dirty-key / LWW は不要。
+class AssetSubscriptionAuditStore {
+  static const String prefsKey = 'asset_subscription_audit_state_v1';
+
+  const AssetSubscriptionAuditStore();
+
+  Future<Map<String, DateTime>> load({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getString(prefsKey);
+    if (raw == null || raw.isEmpty) {
+      return <String, DateTime>{};
+    }
+    try {
+      return decodeMirrorValue(jsonDecode(raw));
+    } catch (_) {
+      return <String, DateTime>{};
+    }
+  }
+
+  Future<void> save(
+    Map<String, DateTime> state, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    if (state.isEmpty) {
+      await store.remove(prefsKey);
+      return;
+    }
+    await store.setString(prefsKey, jsonEncode(encodeMirrorValue(state)));
+  }
+
+  /// `{sourceId: iso8601(UTC)}` へ変換する (ローカル保存とサーバミラー共通形)。
+  static Map<String, dynamic> encodeMirrorValue(Map<String, DateTime> state) {
+    return <String, dynamic>{
+      for (final entry in state.entries)
+        if (entry.key.trim().isNotEmpty)
+          entry.key: entry.value.toUtc().toIso8601String(),
+    };
+  }
+
+  /// `asset_pref_mirror.value` または保存済み JSON から復元する。
+  /// 非 String キー / パース不能な日時は黙って捨てる寛容なパース。時刻は UTC へ正規化。
+  static Map<String, DateTime> decodeMirrorValue(dynamic value) {
+    final result = <String, DateTime>{};
+    if (value is! Map) {
+      return result;
+    }
+    value.forEach((dynamic key, dynamic raw) {
+      if (key is! String || key.trim().isEmpty) {
+        return;
+      }
+      final parsed = DateTime.tryParse(raw?.toString() ?? '');
+      if (parsed != null) {
+        result[key] = parsed.toUtc();
+      }
+    });
+    return result;
+  }
+
+  /// 端末間マージ: キー和集合を取り、各 sourceId で **新しい方** の確認時刻を採用する。
+  /// 単調なので順序非依存・冪等 (確認を取り消さない限り情報を失わない)。
+  static Map<String, DateTime> mergeMax(
+    Map<String, DateTime> a,
+    Map<String, DateTime> b,
+  ) {
+    final result = <String, DateTime>{...a};
+    b.forEach((key, value) {
+      final existing = result[key];
+      if (existing == null || value.isAfter(existing)) {
+        result[key] = value;
+      }
+    });
+    return result;
+  }
+}

--- a/lib/widgets/subscription_audit_card.dart
+++ b/lib/widgets/subscription_audit_card.dart
@@ -1,0 +1,315 @@
+import 'package:flutter/material.dart';
+
+import '../services/asset_subscription_audit_catalog.dart';
+
+/// サブスク棚卸しの確認状況。
+enum SubscriptionAuditStatus {
+  /// 一度も確認していない。
+  unchecked,
+
+  /// 最近確認済み (staleDays 以内)。
+  recentlyChecked,
+
+  /// 前回確認から staleDays を超過 (要再確認)。
+  needsRecheck,
+}
+
+/// サブスクの支払い元 (銀行・各カード・Apple・auかんたん決済・Google) を一覧し、
+/// 「確認したか」を棚卸しする自己完結カード。
+///
+/// Apple/au/Google は個別サブスクがアプリから不可視なため確認手順を提示し、ユーザーが
+/// 確認したら「確認した」で最終確認日時を記録する。銀行・カードは取引フローから検出した
+/// 未登録の定期支出件数を提示する。状態・永続化・同期は資産管理ページが持ち、本ウィジェットは
+/// 表示とコールバックのみを担う (他の資産管理カードと同じ設計)。
+class SubscriptionAuditCard extends StatelessWidget {
+  const SubscriptionAuditCard({
+    super.key,
+    required this.sources,
+    required this.lastCheckedAt,
+    required this.now,
+    required this.onMarkChecked,
+    required this.onRegisterSubscription,
+    this.unregisteredCountBySourceId = const <String, int>{},
+    this.staleDays = AssetSubscriptionAuditCatalog.staleDays,
+  });
+
+  /// 表示する支払い元 (manual を先頭に、その後 autoAssisted の想定)。
+  final List<SubscriptionAuditSource> sources;
+
+  /// sourceId → 最終確認日時 (UTC 保存)。
+  final Map<String, DateTime> lastCheckedAt;
+
+  /// autoAssisted ソースの未登録定期支出件数 (情報表示用)。
+  final Map<String, int> unregisteredCountBySourceId;
+
+  /// ステータス判定の基準時刻 (テスト決定性のため注入)。
+  final DateTime now;
+
+  final int staleDays;
+
+  final void Function(SubscriptionAuditSource source) onMarkChecked;
+  final void Function(SubscriptionAuditSource source) onRegisterSubscription;
+
+  /// 最終確認日時と現在時刻からステータスを判定する (純関数)。
+  static SubscriptionAuditStatus statusFor(
+    DateTime? last,
+    DateTime now, {
+    int staleDays = AssetSubscriptionAuditCatalog.staleDays,
+  }) {
+    if (last == null) {
+      return SubscriptionAuditStatus.unchecked;
+    }
+    if (now.difference(last).inDays > staleDays) {
+      return SubscriptionAuditStatus.needsRecheck;
+    }
+    return SubscriptionAuditStatus.recentlyChecked;
+  }
+
+  String _statusLabel(SubscriptionAuditStatus status, DateTime? last) {
+    switch (status) {
+      case SubscriptionAuditStatus.unchecked:
+        return '未確認';
+      case SubscriptionAuditStatus.recentlyChecked:
+        return '確認済み (${_agoLabel(last!)})';
+      case SubscriptionAuditStatus.needsRecheck:
+        return '要再確認 (${_agoLabel(last!)})';
+    }
+  }
+
+  String _agoLabel(DateTime last) {
+    final days = now.difference(last).inDays;
+    if (days <= 0) {
+      return '今日';
+    }
+    return '$days日前';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final needsRecheckCount = sources
+        .where(
+          (s) =>
+              statusFor(lastCheckedAt[s.id], now, staleDays: staleDays) !=
+              SubscriptionAuditStatus.recentlyChecked,
+        )
+        .length;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.fact_check_outlined, color: scheme.primary),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'サブスク棚卸し',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  if (needsRecheckCount > 0)
+                    Semantics(
+                      label: '$needsRecheckCount件の支払い元が要確認',
+                      child: Chip(
+                        visualDensity: VisualDensity.compact,
+                        backgroundColor: scheme.errorContainer,
+                        label: Text(
+                          '要確認 $needsRecheckCount',
+                          style: theme.textTheme.labelMedium?.copyWith(
+                            color: scheme.onErrorContainer,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '銀行・各カードに加え、Apple(iOS)・auかんたん決済・Google など'
+                '内訳が見えない支払い元も含めて、サブスクの契約状況を定期的に確認しましょう。'
+                '確認できないものは手順に沿って確認し、見つけたサブスクを登録します。',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 8),
+              for (final source in sources)
+                _SourceTile(
+                  key: Key('asset_subscription_audit_${source.id}'),
+                  source: source,
+                  status: statusFor(
+                    lastCheckedAt[source.id],
+                    now,
+                    staleDays: staleDays,
+                  ),
+                  statusLabel: _statusLabel(
+                    statusFor(
+                      lastCheckedAt[source.id],
+                      now,
+                      staleDays: staleDays,
+                    ),
+                    lastCheckedAt[source.id],
+                  ),
+                  unregisteredCount:
+                      unregisteredCountBySourceId[source.id] ?? 0,
+                  onMarkChecked: () => onMarkChecked(source),
+                  onRegister: () => onRegisterSubscription(source),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SourceTile extends StatelessWidget {
+  const _SourceTile({
+    super.key,
+    required this.source,
+    required this.status,
+    required this.statusLabel,
+    required this.unregisteredCount,
+    required this.onMarkChecked,
+    required this.onRegister,
+  });
+
+  final SubscriptionAuditSource source;
+  final SubscriptionAuditStatus status;
+  final String statusLabel;
+  final int unregisteredCount;
+  final VoidCallback onMarkChecked;
+  final VoidCallback onRegister;
+
+  Color _statusColor(ColorScheme scheme) {
+    switch (status) {
+      case SubscriptionAuditStatus.unchecked:
+        return scheme.secondaryContainer;
+      case SubscriptionAuditStatus.recentlyChecked:
+        return scheme.primaryContainer;
+      case SubscriptionAuditStatus.needsRecheck:
+        return scheme.errorContainer;
+    }
+  }
+
+  Color _onStatusColor(ColorScheme scheme) {
+    switch (status) {
+      case SubscriptionAuditStatus.unchecked:
+        return scheme.onSecondaryContainer;
+      case SubscriptionAuditStatus.recentlyChecked:
+        return scheme.onPrimaryContainer;
+      case SubscriptionAuditStatus.needsRecheck:
+        return scheme.onErrorContainer;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final isManual = source.kind == SubscriptionAuditSourceKind.manualCheck;
+    final actions = Wrap(
+      spacing: 8,
+      children: [
+        TextButton.icon(
+          onPressed: onMarkChecked,
+          icon: const Icon(Icons.check, size: 18),
+          label: const Text('確認した'),
+        ),
+        TextButton.icon(
+          onPressed: onRegister,
+          icon: const Icon(Icons.add, size: 18),
+          label: const Text('サブスクを登録'),
+        ),
+      ],
+    );
+    final header = Row(
+      children: [
+        Expanded(
+          child: Text(
+            source.name,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        Semantics(
+          label: '${source.name}、$statusLabel',
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            decoration: BoxDecoration(
+              color: _statusColor(scheme),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              statusLabel,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: _onStatusColor(scheme),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          header,
+          if (isManual && source.checkSteps.isNotEmpty)
+            Theme(
+              // ExpansionTile の区切り線を消してリスト内に馴染ませる。
+              data: theme.copyWith(dividerColor: Colors.transparent),
+              child: ExpansionTile(
+                tilePadding: EdgeInsets.zero,
+                childrenPadding: const EdgeInsets.only(left: 8, bottom: 4),
+                expandedCrossAxisAlignment: CrossAxisAlignment.start,
+                title: Text(
+                  '確認手順',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: scheme.primary,
+                  ),
+                ),
+                children: [
+                  for (var i = 0; i < source.checkSteps.length; i++)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Text(
+                        '${i + 1}. ${source.checkSteps[i]}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: scheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            )
+          else if (!isManual)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                unregisteredCount > 0
+                    ? '未登録の定期支出 $unregisteredCount件 (提案カードから登録できます)'
+                    : '未登録の定期支出は検出されていません',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: unregisteredCount > 0
+                      ? scheme.error
+                      : scheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          Align(alignment: Alignment.centerRight, child: actions),
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/asset_subscription_audit_catalog_test.dart
+++ b/test/services/asset_subscription_audit_catalog_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_subscription_audit_catalog.dart';
+
+void main() {
+  SubscriptionAuditAccountView account(
+    String id,
+    String name,
+    AssetLiabilityAccountKind kind,
+  ) =>
+      (id: id, name: name, kind: kind);
+
+  group('AssetSubscriptionAuditCatalog', () {
+    test('manual sources cover Apple/au/Google with stable unique ids', () {
+      final ids =
+          AssetSubscriptionAuditCatalog.manualSources.map((s) => s.id).toList();
+      expect(
+        ids,
+        containsAll(<String>['apple_id', 'au_kantan', 'google_play']),
+      );
+      expect(ids.toSet().length, ids.length, reason: 'ids must be unique');
+    });
+
+    test('every manual source is manualCheck with at least one step', () {
+      for (final source in AssetSubscriptionAuditCatalog.manualSources) {
+        expect(source.kind, SubscriptionAuditSourceKind.manualCheck);
+        expect(source.name.trim(), isNotEmpty);
+        expect(source.checkSteps, isNotEmpty);
+        for (final step in source.checkSteps) {
+          expect(step.trim(), isNotEmpty);
+        }
+      }
+    });
+
+    test('bank source is autoAssisted and has the contract id', () {
+      expect(
+        AssetSubscriptionAuditCatalog.bankSource.kind,
+        SubscriptionAuditSourceKind.autoAssisted,
+      );
+      expect(
+        AssetSubscriptionAuditCatalog.bankSource.id,
+        AssetSubscriptionAuditCatalog.bankSourceId,
+      );
+    });
+
+    test('cardSourceId composes a stable prefixed id', () {
+      expect(
+        AssetSubscriptionAuditCatalog.cardSourceId('aupay_card'),
+        'card_aupay_card',
+      );
+    });
+  });
+
+  group('AssetSubscriptionAuditCatalog.bucketUnregisteredCounts', () {
+    final accounts = <SubscriptionAuditAccountView>[
+      account('aupay_card', 'auPayカード', AssetLiabilityAccountKind.creditCard),
+      account('smbc', '三井住友銀行', AssetLiabilityAccountKind.deposit),
+      account('wallet', '財布', AssetLiabilityAccountKind.cash),
+      account('rent', '家賃', AssetLiabilityAccountKind.otherLiability),
+    ];
+
+    test('routes card/bank names and folds unknown+null to bank', () {
+      final counts = AssetSubscriptionAuditCatalog.bucketUnregisteredCounts(
+        accounts: accounts,
+        suggestedSourceNames: <String?>[
+          'auPayカード', // → card
+          '三井住友銀行', // → bank (deposit)
+          '財布', // → bank (cash)
+          '謎サービス', // 未知 → bank
+          null, // 不明 → bank
+        ],
+      );
+      expect(counts['card_aupay_card'], 1);
+      expect(counts[AssetSubscriptionAuditCatalog.bankSourceId], 4);
+    });
+
+    test('non card/cash/deposit account name falls back to bank', () {
+      // 家賃 (otherLiability) は引落元マップに載らない → 銀行へフォールバック。
+      final counts = AssetSubscriptionAuditCatalog.bucketUnregisteredCounts(
+        accounts: accounts,
+        suggestedSourceNames: const <String?>['家賃'],
+      );
+      expect(counts[AssetSubscriptionAuditCatalog.bankSourceId], 1);
+      expect(counts.containsKey('card_rent'), isFalse);
+    });
+
+    test('same-named cards collapse onto the last scanned id (pinned)', () {
+      // 検出器は口座名しか持たないため、同名カードは最後に走査した id へ寄る。
+      final counts = AssetSubscriptionAuditCatalog.bucketUnregisteredCounts(
+        accounts: <SubscriptionAuditAccountView>[
+          account('card_a', '共通カード', AssetLiabilityAccountKind.creditCard),
+          account('card_b', '共通カード', AssetLiabilityAccountKind.creditCard),
+        ],
+        suggestedSourceNames: const <String?>['共通カード', '共通カード'],
+      );
+      // 件数は失わず (合計2)、後勝ちの card_card_b に集約される。
+      expect(counts['card_card_b'], 2);
+      expect(counts.containsKey('card_card_a'), isFalse);
+    });
+
+    test('empty detections yield an empty map', () {
+      expect(
+        AssetSubscriptionAuditCatalog.bucketUnregisteredCounts(
+          accounts: accounts,
+          suggestedSourceNames: const <String?>[],
+        ),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/test/services/asset_subscription_audit_store_test.dart
+++ b/test/services/asset_subscription_audit_store_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_subscription_audit_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  DateTime utc(int y, int m, int d) => DateTime.utc(y, m, d);
+
+  group('AssetSubscriptionAuditStore encode/decode', () {
+    test('round-trips state and normalizes to UTC', () {
+      final state = <String, DateTime>{
+        'apple_id': utc(2026, 6, 1),
+        'card_aupay_card': utc(2026, 5, 20),
+      };
+      final encoded = AssetSubscriptionAuditStore.encodeMirrorValue(state);
+      expect(encoded['apple_id'], '2026-06-01T00:00:00.000Z');
+      final decoded = AssetSubscriptionAuditStore.decodeMirrorValue(encoded);
+      expect(decoded['apple_id'], utc(2026, 6, 1));
+      expect(decoded['apple_id']!.isUtc, isTrue);
+      expect(decoded['card_aupay_card'], utc(2026, 5, 20));
+    });
+
+    test('decode drops non-string keys, blank keys and unparseable dates', () {
+      expect(AssetSubscriptionAuditStore.decodeMirrorValue(null), isEmpty);
+      expect(
+        AssetSubscriptionAuditStore.decodeMirrorValue('not a map'),
+        isEmpty,
+      );
+      final decoded = AssetSubscriptionAuditStore.decodeMirrorValue(
+        <dynamic, dynamic>{
+          'apple_id': '2026-06-01T00:00:00.000Z',
+          '  ': '2026-06-01T00:00:00.000Z',
+          'bad_date': 'not-a-date',
+          'au_kantan': 12345,
+        },
+      );
+      expect(decoded.keys, <String>{'apple_id'});
+    });
+
+    test('encode skips blank source ids', () {
+      final encoded = AssetSubscriptionAuditStore.encodeMirrorValue(
+        <String, DateTime>{
+          ' ': utc(2026, 6, 1),
+          'google_play': utc(2026, 6, 1),
+        },
+      );
+      expect(encoded.keys, <String>{'google_play'});
+    });
+  });
+
+  group('AssetSubscriptionAuditStore.mergeMax', () {
+    test('takes the later timestamp per source (both argument orders)', () {
+      final local = <String, DateTime>{'apple_id': utc(2026, 5, 1)};
+      final server = <String, DateTime>{'apple_id': utc(2026, 6, 1)};
+      expect(
+        AssetSubscriptionAuditStore.mergeMax(local, server)['apple_id'],
+        utc(2026, 6, 1),
+      );
+      // 逆順でも同じ結果 (順序非依存)。
+      expect(
+        AssetSubscriptionAuditStore.mergeMax(server, local)['apple_id'],
+        utc(2026, 6, 1),
+      );
+    });
+
+    test('unions disjoint keys', () {
+      final merged = AssetSubscriptionAuditStore.mergeMax(
+        <String, DateTime>{'apple_id': utc(2026, 6, 1)},
+        <String, DateTime>{'au_kantan': utc(2026, 6, 2)},
+      );
+      expect(merged.keys, <String>{'apple_id', 'au_kantan'});
+    });
+
+    test('empty is an identity element', () {
+      final state = <String, DateTime>{'apple_id': utc(2026, 6, 1)};
+      expect(
+        AssetSubscriptionAuditStore.mergeMax(state, const <String, DateTime>{}),
+        state,
+      );
+      expect(
+        AssetSubscriptionAuditStore.mergeMax(const <String, DateTime>{}, state),
+        state,
+      );
+    });
+  });
+
+  group('AssetSubscriptionAuditStore persistence', () {
+    const store = AssetSubscriptionAuditStore();
+
+    test('save/load round-trips through SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      await store.save(
+        <String, DateTime>{'apple_id': utc(2026, 6, 1)},
+        prefs: prefs,
+      );
+      final loaded = await store.load(prefs: prefs);
+      expect(loaded['apple_id'], utc(2026, 6, 1));
+    });
+
+    test('save empty clears the key', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      await store.save(
+        <String, DateTime>{'apple_id': utc(2026, 6, 1)},
+        prefs: prefs,
+      );
+      await store.save(const <String, DateTime>{}, prefs: prefs);
+      expect(await store.load(prefs: prefs), isEmpty);
+    });
+
+    test('load returns empty when nothing stored', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      expect(await store.load(prefs: prefs), isEmpty);
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -11,6 +11,7 @@ import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
+import 'package:my_web_app/services/asset_subscription_audit_store.dart';
 import 'package:my_web_app/services/asset_sync_dirty_keys_store.dart';
 import 'package:my_web_app/services/asset_sync_timestamp_store.dart';
 import 'package:my_web_app/services/asset_watchlist_service.dart';
@@ -1567,6 +1568,76 @@ void main() {
           local.map((c) => c.id),
           containsAll(<String>['fc_denki', 'fc_gym']),
         );
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'subscription audit syncs check state from the server mirror',
+      (tester) async {
+        // ローカルは空。新端末がサーバミラーから確認状況を取り込む。
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              debugSubscriptionAuditMirror:
+                  AssetSubscriptionAuditStore.encodeMirrorValue(
+                <String, DateTime>{'apple_id': DateTime.utc(2026, 6, 1)},
+              ),
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final state = await const AssetSubscriptionAuditStore().load();
+        expect(state['apple_id'], DateTime.utc(2026, 6, 1));
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'subscription audit MAX-merges and never clobbers a newer check',
+      (tester) async {
+        // apple_id: local 古 + mirror 新 → 新。au_kantan: local 新 + mirror 古 → 新。
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          AssetSubscriptionAuditStore.prefsKey: jsonEncode(
+            AssetSubscriptionAuditStore.encodeMirrorValue(
+              <String, DateTime>{
+                'apple_id': DateTime.utc(2026, 6, 1),
+                'au_kantan': DateTime.utc(2026, 6, 10),
+              },
+            ),
+          ),
+        });
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              debugSubscriptionAuditMirror:
+                  AssetSubscriptionAuditStore.encodeMirrorValue(
+                <String, DateTime>{
+                  'apple_id': DateTime.utc(2026, 6, 10),
+                  'au_kantan': DateTime.utc(2026, 6, 1),
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final state = await const AssetSubscriptionAuditStore().load();
+        // どちらの方向でも新しい確認が残る (MAX マージ)。
+        expect(state['apple_id'], DateTime.utc(2026, 6, 10));
+        expect(state['au_kantan'], DateTime.utc(2026, 6, 10));
 
         await _unmount(tester);
       },

--- a/test/widgets/subscription_audit_card_test.dart
+++ b/test/widgets/subscription_audit_card_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_subscription_audit_catalog.dart';
+import 'package:my_web_app/widgets/subscription_audit_card.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 6, 20);
+
+  const appleSource = SubscriptionAuditSource(
+    id: 'apple_id',
+    name: 'Apple (iOS) サブスク',
+    kind: SubscriptionAuditSourceKind.manualCheck,
+    checkSteps: <String>['設定アプリを開く', 'サブスクリプションをタップ'],
+  );
+  const cardSource = SubscriptionAuditSource(
+    id: 'card_aupay_card',
+    name: 'auPayカード',
+    kind: SubscriptionAuditSourceKind.autoAssisted,
+  );
+
+  group('SubscriptionAuditCard.statusFor', () {
+    test('null is unchecked', () {
+      expect(
+        SubscriptionAuditCard.statusFor(null, now),
+        SubscriptionAuditStatus.unchecked,
+      );
+    });
+
+    test('29 and 30 days are recentlyChecked, 31 needs recheck', () {
+      expect(
+        SubscriptionAuditCard.statusFor(
+          now.subtract(const Duration(days: 29)),
+          now,
+        ),
+        SubscriptionAuditStatus.recentlyChecked,
+      );
+      expect(
+        SubscriptionAuditCard.statusFor(
+          now.subtract(const Duration(days: 30)),
+          now,
+        ),
+        SubscriptionAuditStatus.recentlyChecked,
+      );
+      expect(
+        SubscriptionAuditCard.statusFor(
+          now.subtract(const Duration(days: 31)),
+          now,
+        ),
+        SubscriptionAuditStatus.needsRecheck,
+      );
+    });
+  });
+
+  Widget host({
+    Map<String, DateTime> lastCheckedAt = const <String, DateTime>{},
+    Map<String, int> counts = const <String, int>{},
+    required void Function(SubscriptionAuditSource) onMarkChecked,
+    required void Function(SubscriptionAuditSource) onRegister,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: SubscriptionAuditCard(
+            sources: const <SubscriptionAuditSource>[appleSource, cardSource],
+            lastCheckedAt: lastCheckedAt,
+            unregisteredCountBySourceId: counts,
+            now: now,
+            onMarkChecked: onMarkChecked,
+            onRegisterSubscription: onRegister,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('manual row shows steps; card row shows unregistered count',
+      (tester) async {
+    await tester.pumpWidget(
+      host(
+        counts: const <String, int>{'card_aupay_card': 2},
+        onMarkChecked: (_) {},
+        onRegister: (_) {},
+      ),
+    );
+
+    expect(find.text('サブスク棚卸し'), findsOneWidget);
+    expect(find.text('Apple (iOS) サブスク'), findsOneWidget);
+    // 手動ソースは確認手順、カードソースは未登録件数。
+    expect(find.text('確認手順'), findsOneWidget);
+    expect(find.textContaining('未登録の定期支出 2件'), findsOneWidget);
+    // 全ソース未確認なので「要確認 2」バッジ。
+    expect(find.textContaining('要確認 2'), findsOneWidget);
+  });
+
+  testWidgets('確認した and 登録 fire with the right source', (tester) async {
+    SubscriptionAuditSource? checked;
+    SubscriptionAuditSource? registered;
+    await tester.pumpWidget(
+      host(
+        onMarkChecked: (s) => checked = s,
+        onRegister: (s) => registered = s,
+      ),
+    );
+
+    final appleRow = find.byKey(const Key('asset_subscription_audit_apple_id'));
+    await tester.tap(
+      find.descendant(of: appleRow, matching: find.text('確認した')),
+    );
+    expect(checked?.id, 'apple_id');
+    await tester.tap(
+      find.descendant(of: appleRow, matching: find.text('サブスクを登録')),
+    );
+    expect(registered?.id, 'apple_id');
+  });
+
+  testWidgets('checked source shows 確認済み and clears the recheck badge',
+      (tester) async {
+    await tester.pumpWidget(
+      host(
+        lastCheckedAt: <String, DateTime>{
+          'apple_id': now.subtract(const Duration(days: 3)),
+          'card_aupay_card': now.subtract(const Duration(days: 1)),
+        },
+        onMarkChecked: (_) {},
+        onRegister: (_) {},
+      ),
+    );
+
+    expect(find.textContaining('確認済み (3日前)'), findsOneWidget);
+    // 全ソース確認済み (staleDays 以内) → 要確認バッジ無し。
+    expect(find.textContaining('要確認'), findsNothing);
+  });
+}


### PR DESCRIPTION
## 概要

サブスクの支払い元が **銀行引き落とし・複数のクレジットカード・Apple(iOS)・auかんたん決済・Google** に分散しているため、システムが能動的に確認状況を管理し、自動で見えないものは確認手順を提示してチェックを促す「**サブスク棚卸し**」機能を追加します。先の「サブスク登録」([PR #3519](https://github.com/kanta13jp1/my_web_app/pull/3519)) の続き。

## 「能動チェック」はデータ可用性で2分される（設計の肝）

| 支払い元 | アプリが見えるデータ | 本機能の扱い |
|---|---|---|
| 銀行引き落とし / 各カード | 取引フロー (`wealth_struggles`) に記録 | ✅ 既存の定期取引検出を流用し「未登録の定期支出 N件」を提示 |
| **Apple / au / Google** | 集約請求 (例 `APPLE.COM/BILL`) で個別が**不可視** | ❌ 自動検出不能 → **確認手順を提示**し「確認した」で記録 |

→ 構造的に中身が見えない Apple/au/Google は確認手順 + 確認記録 + 再確認リマインドで、見える銀行/カードは既存検出の流用で、それぞれ最適な手段でカバレッジを担保します。

## 変更点（9ファイル / +1185行）

- **カタログ** `AssetSubscriptionAuditCatalog` — Apple/au/Google の手動確認ソース（確認手順付き）+ 銀行 + カード別ソース(口座から `card_<id>` で導出)。
- **ストア** `AssetSubscriptionAuditStore` — ソースごとの最終確認日時のみを永続化。端末間は **`mergeMax`（単調 MAX マージ）** で統合。「確認した」は巻き戻らないので、固定費同期の tombstone/dirty/LWW 機構は不要で大幅に単純化。
- **カード** `SubscriptionAuditCard` — ソースごとに 未確認 / 確認済み(N日前) / 要再確認(>30日) のステータス、手動は確認手順を展開、カードは未登録件数、「確認した」「サブスクを登録」。
- **配線** — 専用セクション `subscriptionAudit` + ページの load/restore(MAX マージ)/mirror。

## 設計判断

- 棚卸しカードは「**カバレッジ(確認したか)**」のビュー。サブスク本体は既存の定期固定費 editor (category=subscription) に登録 → 提案/サブスク/棚卸し各カードから同時に消え、**二重計上しない**。
- バケツ分け（口座種別→ソースID）を純関数 `bucketUnregisteredCounts` として抽出し単体テスト化。

## レビュー（多エージェント敵対レビュー / 4次元 → 確定2件を反映）

- **(medium) バケツ分けロジックが未テスト** → 純関数へ抽出し、card/bank振り分け・未知/null→銀行フォールバック・非カード種別→銀行・同名カード集約・空 の4テストを追加。
- **(low) 名前ベース集計で同名口座が集約** → 検出器が口座名しか持たない既存仕様の不可避な制約。件数は失わずコメントで明記（dismissed 寄りだが上記抽出で挙動を pin）。
- 加えて dismissed の中から、取込み中の「確認した」タップ消失レースを `localBefore` ではなく**現在の in-memory state とマージ**して解消（MAX は単調なので安全）。

## 検証

- `flutter analyze`（**lib と test 全ファイル**）: No issues found（前回 CI 失敗の test analyze 漏れを是正）。
- `dart format`: クリーン。
- `flutter test`: 棚卸し catalog/store/card/smoke + 既存 smoke = **全 65 green**（MAX マージ同期・バケツ分けの新規テスト含む）。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Coverage-audit UI card + pure catalog/store logic covered by 65 widget+unit+smoke tests (incl MAX-merge sync + bucketing); reuses existing recurring-fixed-cost flow, no new e2e route

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive UI/model feature under lib/services,lib/widgets (not lib/subscription); no auth/billing/RLS/deploy/migration; new sync key uses monotonic MAX-merge; verified analyze+format clean, 65 tests, 4-dimension adversarial review (2 findings fixed via pure-fn extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
