### PR TITLE
feat(asset): 月次の負債トレンド検出+翌月アクション提示と端末跨ぎ同期

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -37,6 +37,8 @@ import 'package:my_web_app/services/asset_management_ai_analysis_history_service
 import 'package:my_web_app/services/asset_management_ai_summary_refresh.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
+import 'package:my_web_app/services/asset_account_balance_history_store.dart';
+import 'package:my_web_app/services/asset_debt_trend_analyzer.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
@@ -620,6 +622,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetManagementDisplayModeStore.defaultMode;
   final AssetManagementMainAccountStore _mainAccountStore =
       const AssetManagementMainAccountStore();
+  // 月をまたいだ負債トレンド(リボ複利・残高増加)判定のための口座別残高履歴。
+  final AssetAccountBalanceHistoryStore _assetBalanceHistoryStore =
+      const AssetAccountBalanceHistoryStore();
+  // 前月末の口座別残高(accountId -> 残高絶対値)。非同期ロードでキャッシュ。
+  Map<String, double> _assetDebtTrendPriorBalances = const <String, double>{};
+  // 上記キャッシュが対象としている月キー(月跨ぎでの取り違え防止)。
+  String? _assetDebtTrendPriorBalancesMonth;
+  // 今月の残高記録の重複実行を防ぐシグネチャ(monthKey + 残高内容)。
+  String? _assetDebtTrendSyncedSignature;
   final AssetSalaryDayStore _salaryDayStore = const AssetSalaryDayStore();
   static const String _salaryDayMirrorKey = 'salary_day';
   final AssetRevolvingCreditConfigStore _revolvingConfigStore =
@@ -1536,6 +1547,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       // ローカル(_debtPaymentDayOverrides)反映後に呼ぶ。空でなくても union
       // マージ/バックフィルするため常に実行する。
       unawaited(_restoreDebtPaymentDayOverridesFromMirror());
+      // 他端末の残高履歴を取り込み、負債トレンドの前月比を端末跨ぎで有効化。
+      unawaited(_restoreAssetBalanceHistoryFromMirror());
       if (generatedTemplatePlans) {
         unawaited(_saveAssetLiabilityMonthlyState());
       }
@@ -10930,6 +10943,69 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   /// 入金予定のミラー取り込みプレビュー行を組み立てる。
+  /// 口座別残高履歴を asset_pref_mirror へ丸ごと退避する（端末跨ぎ同期）。
+  ///
+  /// 汎用 jsonb ミラーの 1 pref_key を使うためマイグレーション不要。値は
+  /// `{monthKey: {accountId: 残高}}`。負債トレンドの前月比を別端末でも使える。
+  Future<void> _mirrorAssetBalanceHistory() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      final history = await _assetBalanceHistoryStore.loadAll();
+      if (history.isEmpty) {
+        return;
+      }
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': 'account_balance_history',
+        'value': history,
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('balance history mirror upsert failed: $e');
+    }
+  }
+
+  /// 他端末の残高履歴をミラーから取り込み、ローカルへ和集合マージする。
+  ///
+  /// マージは非破壊（月キー・口座を消さない/巻き戻さない）。取り込みで前月残高が
+  /// 変わったら、当月基準の前月残高キャッシュを更新して負債トレンドを再評価する。
+  Future<void> _restoreAssetBalanceHistoryFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', 'account_balance_history');
+      if (rows.isEmpty) {
+        return;
+      }
+      final changed =
+          await _assetBalanceHistoryStore.mergeRemote(rows.first['value']);
+      if (!changed || !mounted) {
+        return;
+      }
+      final monthKey = AssetAccountBalanceHistoryStore.formatMonthKey(_now);
+      final prior = await _assetBalanceHistoryStore.priorMonthBalances(_now);
+      if (!mounted) {
+        return;
+      }
+      if (_assetDebtTrendPriorBalancesMonth != monthKey ||
+          !_sameDoubleMap(_assetDebtTrendPriorBalances, prior)) {
+        setState(() {
+          _assetDebtTrendPriorBalances = prior;
+          _assetDebtTrendPriorBalancesMonth = monthKey;
+        });
+      }
+    } catch (e) {
+      debugPrint('balance history mirror restore failed: $e');
+    }
+  }
+
   String _inflowMergeRowLabel(Map<String, dynamic> row) {
     final label = row['label']?.toString() ?? '入金予定';
     final amount = (row['amount'] as num?)?.toDouble() ?? 0;
@@ -15929,15 +16005,83 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  /// 今月の口座別負債残高を履歴へ記録し、前月末残高をロードして負債トレンド
+  /// 判定(リボ複利・残高増加)に供給する。残高が変わったときだけ再記録し、
+  /// 前月残高が更新されたときだけ setState で再描画する。
+  void _scheduleAssetDebtTrendHistorySync(AssetLiabilityWorkbook workbook) {
+    final monthKey =
+        AssetAccountBalanceHistoryStore.formatMonthKey(workbook.baseDate);
+    final balances = <String, double>{
+      for (final row in workbook.debtMasterRows)
+        if (row.balance < 0) row.id: row.balance.abs(),
+    };
+    final signatureParts = balances.entries
+        .map((entry) => '${entry.key}:${entry.value.round()}')
+        .toList()
+      ..sort();
+    final signature = '$monthKey|${signatureParts.join(',')}';
+    if (_assetDebtTrendSyncedSignature == signature) {
+      return;
+    }
+    _assetDebtTrendSyncedSignature = signature;
+    unawaited(
+      _syncAssetDebtTrendHistory(
+        workbook.baseDate,
+        monthKey,
+        balances,
+        signature,
+      ),
+    );
+  }
+
+  Future<void> _syncAssetDebtTrendHistory(
+    DateTime baseDate,
+    String monthKey,
+    Map<String, double> balances,
+    String signature,
+  ) async {
+    try {
+      final prior =
+          await _assetBalanceHistoryStore.priorMonthBalances(baseDate);
+      await _assetBalanceHistoryStore.recordMonth(baseDate, balances);
+      // 記録した最新履歴を端末跨ぎミラーへ退避（ログイン時のみ実効）。
+      unawaited(_mirrorAssetBalanceHistory());
+      if (!mounted) {
+        return;
+      }
+      if (_assetDebtTrendPriorBalancesMonth != monthKey ||
+          !_sameDoubleMap(_assetDebtTrendPriorBalances, prior)) {
+        setState(() {
+          _assetDebtTrendPriorBalances = prior;
+          _assetDebtTrendPriorBalancesMonth = monthKey;
+        });
+      }
+    } catch (_) {
+      // 失敗時はシグネチャを解除し、次のビルドで再試行できるようにする。
+      if (_assetDebtTrendSyncedSignature == signature) {
+        _assetDebtTrendSyncedSignature = null;
+      }
+    }
+  }
+
   Widget _buildAssetLiabilityWorkbookBoard(AssetLiabilityWorkbook? workbook) {
     if (workbook == null) {
       return const SizedBox.shrink();
     }
     _scheduleAssetLiabilityStateIdMigration(workbook);
+    _scheduleAssetDebtTrendHistorySync(workbook);
+    final currentMonthKey =
+        AssetAccountBalanceHistoryStore.formatMonthKey(workbook.baseDate);
+    // キャッシュ済み前月残高が当月のものでない間は渡さない(取り違え防止)。
+    final priorMonthAccountBalances =
+        _assetDebtTrendPriorBalancesMonth == currentMonthKey
+            ? _assetDebtTrendPriorBalances
+            : const <String, double>{};
     final insightReport = _assetManagementInsightService.buildReport(
       workbook: workbook,
       userProfile: _assetManagementUserProfile,
       mainAccountId: _assetManagementMainAccountId,
+      priorMonthAccountBalances: priorMonthAccountBalances,
     );
     final warningColor = workbook.cashAfterScheduledPayments < 0
         ? const Color(0xFFB91C1C)
@@ -17060,6 +17204,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             _buildAssetManagementEmergencyAdviceList(report.emergencyAdvices),
             const SizedBox(height: 12),
           ],
+          if (report.debtTrendInsights.isNotEmpty) ...[
+            _buildAssetManagementMonthlyDebtTrendList(report.debtTrendInsights),
+            const SizedBox(height: 12),
+          ],
           _buildAssetManagementAssistantActionList(report.actionItems),
           if (report.movementSuggestions.isNotEmpty) ...[
             const SizedBox(height: 12),
@@ -17888,6 +18036,182 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               fontSize: 11,
               height: 1.4,
             ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _assetDebtTrendSeverityColor(AssetDebtTrendSeverity severity) {
+    return switch (severity) {
+      AssetDebtTrendSeverity.info => const Color(0xFF2563EB),
+      AssetDebtTrendSeverity.warning => const Color(0xFFD97706),
+      AssetDebtTrendSeverity.critical => const Color(0xFFB91C1C),
+    };
+  }
+
+  String _assetDebtTrendCategoryLabel(AssetDebtTrendCategory category) {
+    return switch (category) {
+      AssetDebtTrendCategory.negativeAmortization => 'リボ複利・返済が利息以下',
+      AssetDebtTrendCategory.balanceIncreasing => '残高が先月より増加',
+      AssetDebtTrendCategory.slowPayoff => '完済まで超長期',
+    };
+  }
+
+  /// 今月の負債の問題点と「翌月こうしなさい」を、計算済みの具体額つきで描画する。
+  Widget _buildAssetManagementMonthlyDebtTrendList(
+    List<AssetDebtTrendInsight> insights,
+  ) {
+    final hasCritical = insights.any(
+      (insight) => insight.severity == AssetDebtTrendSeverity.critical,
+    );
+    final headerColor =
+        hasCritical ? const Color(0xFFB91C1C) : const Color(0xFFD97706);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF7ED),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: headerColor.withValues(alpha: 0.28)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.trending_up, color: headerColor, size: 18),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '今月の問題点と翌月の改善（負債トレンド）',
+                  style: TextStyle(
+                    color: headerColor,
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            'リボ払いで返済が利息に負けている／先月より残高が増えた負債を検出し、翌月の具体的な返済額を提示します。',
+            style: TextStyle(fontSize: 12, height: 1.5),
+          ),
+          const SizedBox(height: 8),
+          for (final insight in insights.take(5))
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _buildAssetManagementMonthlyDebtTrendTile(insight),
+            ),
+          if (insights.length > 5)
+            Text(
+              'ほか ${insights.length - 5}件',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetManagementMonthlyDebtTrendTile(
+    AssetDebtTrendInsight insight,
+  ) {
+    final color = _assetDebtTrendSeverityColor(insight.severity);
+    final payoffValue = insight.estimatedPayoffMonths == null
+        ? 'この返済額では完済不能'
+        : '約${insight.estimatedPayoffMonths}ヶ月';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.22)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${insight.accountName}（${_assetDebtTrendCategoryLabel(insight.category)}）',
+            style: TextStyle(
+              color: color,
+              fontWeight: FontWeight.bold,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            insight.problem,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.arrow_forward, color: color, size: 16),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    '翌月: ${insight.nextMonthAction}',
+                    style: const TextStyle(fontSize: 12, height: 1.5),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              _buildAssetLiabilitySyncChip(
+                label: '残高',
+                value: _formatManagementYen(insight.currentBalance),
+                color: color,
+              ),
+              if (insight.balanceDelta != null)
+                _buildAssetLiabilitySyncChip(
+                  label: '前月比',
+                  value: _formatManagementDeltaYen(insight.balanceDelta),
+                  color: color,
+                ),
+              _buildAssetLiabilitySyncChip(
+                label: '月利息',
+                value: _formatManagementYen(insight.monthlyInterest),
+                color: const Color(0xFF6B7280),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: '今月返済',
+                value: _formatManagementYen(insight.scheduledPayment),
+                color: const Color(0xFF6B7280),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: '24ヶ月完済ライン',
+                value: _formatManagementYen(insight.payoffIn24MonthsPayment),
+                color: const Color(0xFF0D9488),
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: '完済見込み',
+                value: payoffValue,
+                color: const Color(0xFF6B7280),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/services/asset_account_balance_history_store.dart
+++ b/lib/services/asset_account_balance_history_store.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 口座（負債）ごとの月末残高を月キー単位で蓄積するローカルストア。
+///
+/// 既存の月次スナップショット同期（過去に LWW でのデータ消失バグあり）には触れず、
+/// 独立した SharedPreferences キーへ自動蓄積する。これにより
+/// [AssetDebtTrendAnalyzer] の「前月比で残高が増えたか」判定に必要な
+/// 前月末残高を、マイグレーションや edge deploy 無しで供給できる。
+///
+/// 保存形式: `{ "yyyy-MM": { accountId: balanceMagnitude(正の値) } }`。
+class AssetAccountBalanceHistoryStore {
+  static const String prefsKey = 'asset_account_balance_history_v1';
+
+  /// 保持する月数の上限（古い月から間引く）。
+  static const int maxMonths = 13;
+
+  const AssetAccountBalanceHistoryStore();
+
+  static String formatMonthKey(DateTime month) {
+    return '${month.year.toString().padLeft(4, '0')}-'
+        '${month.month.toString().padLeft(2, '0')}';
+  }
+
+  /// 指定月の口座別残高を保存（同じ月キーは上書き）。
+  ///
+  /// [balancesByAccountId] は accountId -> 利用残高の絶対額（正の値）。
+  Future<void> recordMonth(
+    DateTime month,
+    Map<String, double> balancesByAccountId, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final history = _decode(store.getString(prefsKey));
+    final monthKey = formatMonthKey(month);
+    final sanitized = <String, double>{
+      for (final entry in balancesByAccountId.entries)
+        if (entry.key.trim().isNotEmpty && entry.value.isFinite)
+          entry.key.trim(): entry.value.abs(),
+    };
+    if (sanitized.isEmpty) {
+      // 負債が無い月でも「空である」事実を残すと前月比が壊れるため、
+      // 空マップでも上書き記録する（負債が消えた=完済の検出にも使える）。
+      history[monthKey] = <String, double>{};
+    } else {
+      history[monthKey] = sanitized;
+    }
+    _pruneOldMonths(history);
+    await store.setString(prefsKey, jsonEncode(history));
+  }
+
+  /// 指定月より前で「残高データがある」最も新しい月の口座別残高を返す（無ければ空）。
+  ///
+  /// 負債ゼロの月は空マップで記録されるため、それを飛ばして実データのある
+  /// 直近の月まで遡る。これにより「先月は完済 → 今月新規借入」でも前月比を
+  /// 取りこぼさない（空マップを返すと残高増加検出が壊れるのを防ぐ）。
+  Future<Map<String, double>> priorMonthBalances(
+    DateTime month, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final history = _decode(store.getString(prefsKey));
+    final currentKey = formatMonthKey(month);
+    final priorKeys = history.keys
+        .where((key) => key.compareTo(currentKey) < 0)
+        .toList()
+      ..sort();
+    for (final key in priorKeys.reversed) {
+      final balances = history[key]!;
+      if (balances.isNotEmpty) {
+        return Map<String, double>.unmodifiable(balances);
+      }
+    }
+    return const <String, double>{};
+  }
+
+  /// 蓄積済みの全月キー（昇順）。デバッグ・テスト用。
+  Future<List<String>> recordedMonthKeys({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final history = _decode(store.getString(prefsKey));
+    return history.keys.toList()..sort();
+  }
+
+  /// 蓄積済みの全履歴（monthKey -> {accountId: 残高}）。端末跨ぎミラー同期用。
+  Future<Map<String, Map<String, double>>> loadAll({
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return _decode(store.getString(prefsKey));
+  }
+
+  /// 他端末由来のミラー値（jsonb 由来の Map）をローカル履歴へ和集合マージする。
+  ///
+  /// 月キー・口座とも非破壊（消さない・上書きしない）で、ローカルに無いものだけ
+  /// 補完する。競合する口座はローカル値を優先する（各端末は同期済みの残高から
+  /// 同値を導くため実害は小さく、月の取りこぼし/巻き戻しを防ぐことを優先）。
+  /// 変更があれば true を返す。
+  Future<bool> mergeRemote(
+    Object? remoteValue, {
+    SharedPreferences? prefs,
+  }) async {
+    final remote = remoteValue is Map
+        ? _decodeMap(remoteValue)
+        : const <String, Map<String, double>>{};
+    if (remote.isEmpty) {
+      return false;
+    }
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final local = _decode(store.getString(prefsKey));
+    var changed = false;
+    remote.forEach((monthKey, remoteBalances) {
+      final localBalances = local[monthKey];
+      if (localBalances == null) {
+        local[monthKey] = Map<String, double>.from(remoteBalances);
+        changed = true;
+        return;
+      }
+      remoteBalances.forEach((accountId, balance) {
+        if (!localBalances.containsKey(accountId)) {
+          localBalances[accountId] = balance;
+          changed = true;
+        }
+      });
+    });
+    if (changed) {
+      _pruneOldMonths(local);
+      await store.setString(prefsKey, jsonEncode(local));
+    }
+    return changed;
+  }
+
+  void _pruneOldMonths(Map<String, Map<String, double>> history) {
+    if (history.length <= maxMonths) {
+      return;
+    }
+    final keys = history.keys.toList()..sort();
+    final removeCount = history.length - maxMonths;
+    for (var i = 0; i < removeCount; i++) {
+      history.remove(keys[i]);
+    }
+  }
+
+  Map<String, Map<String, double>> _decode(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, Map<String, double>>{};
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      return decoded is Map
+          ? _decodeMap(decoded)
+          : <String, Map<String, double>>{};
+    } catch (_) {
+      return <String, Map<String, double>>{};
+    }
+  }
+
+  Map<String, Map<String, double>> _decodeMap(Map decoded) {
+    final result = <String, Map<String, double>>{};
+    decoded.forEach((monthKey, value) {
+      if (monthKey is! String || value is! Map) {
+        return;
+      }
+      final balances = <String, double>{};
+      value.forEach((accountId, balance) {
+        if (accountId is! String) {
+          return;
+        }
+        final parsed = balance is num
+            ? balance.toDouble()
+            : double.tryParse(balance.toString());
+        // 残高は絶対値（正の値）で保存する契約。負値は破損データとして拒否する。
+        if (parsed != null && parsed.isFinite && parsed >= 0) {
+          balances[accountId] = parsed;
+        }
+      });
+      result[monthKey] = balances;
+    });
+    return result;
+  }
+}

--- a/lib/services/asset_debt_trend_analyzer.dart
+++ b/lib/services/asset_debt_trend_analyzer.dart
@@ -1,0 +1,444 @@
+import 'dart:math';
+
+import '../models/asset_liability_workbook.dart';
+
+/// 今月の負債の「問題点」を分類するカテゴリ。
+///
+/// - [negativeAmortization]: 返済額が利息以下で、残高が永遠に減らない（リボ複利地獄）。
+/// - [balanceIncreasing]: 前月比で利用残高が増えており、新規利用が返済を上回っている。
+/// - [slowPayoff]: 元金は減るが、今のペースだと完済まで極端に長い。
+enum AssetDebtTrendCategory {
+  negativeAmortization,
+  balanceIncreasing,
+  slowPayoff,
+}
+
+/// 指摘の重要度。資金繰り系インサイトと同じ 3 段階に揃える。
+enum AssetDebtTrendSeverity { info, warning, critical }
+
+/// 1 件の負債に対する「今月の問題点」と「翌月の具体アクション」。
+///
+/// 金額はすべて Dart 側で計算済みで、AI には説明と優先順位付けのみを任せる
+/// （[AssetManagementInsightPromptBuilder] と同じ方針）。
+class AssetDebtTrendInsight {
+  final String accountId;
+  final String accountName;
+  final AssetLiabilityAccountKind kind;
+  final AssetDebtTrendCategory category;
+  final AssetDebtTrendSeverity severity;
+
+  /// 現在の利用残高（負債の絶対額・正の値）。
+  final double currentBalance;
+
+  /// 前月末の利用残高（履歴がある場合のみ・正の値）。
+  final double? priorBalance;
+
+  /// 前月比の残高変動（正 = 増加）。履歴がある場合のみ。
+  final double? balanceDelta;
+
+  /// 今月の月利息見込み。
+  final double monthlyInterest;
+
+  /// 今月の返済予定額。
+  final double scheduledPayment;
+
+  /// 残高を減らさずに済む「止血ライン」= 利息を 1 円でも上回る返済額。
+  final double interestBreakEvenPayment;
+
+  /// 24 ヶ月で完済するための目安返済額（年金現価式）。
+  final double payoffIn24MonthsPayment;
+
+  /// 今の返済額のままでの完済月数（null = この返済額では一生終わらない）。
+  final int? estimatedPayoffMonths;
+
+  /// 今の返済額のままでの総支払利息見込み（完済する場合のみ）。
+  final double? estimatedTotalInterest;
+
+  /// 画面・プロンプトに出す「今月の問題点」一文。
+  final String problem;
+
+  /// 画面・プロンプトに出す「翌月の具体アクション」一文。
+  final String nextMonthAction;
+
+  const AssetDebtTrendInsight({
+    required this.accountId,
+    required this.accountName,
+    required this.kind,
+    required this.category,
+    required this.severity,
+    required this.currentBalance,
+    required this.priorBalance,
+    required this.balanceDelta,
+    required this.monthlyInterest,
+    required this.scheduledPayment,
+    required this.interestBreakEvenPayment,
+    required this.payoffIn24MonthsPayment,
+    required this.estimatedPayoffMonths,
+    required this.estimatedTotalInterest,
+    required this.problem,
+    required this.nextMonthAction,
+  });
+}
+
+/// 固定額返済を続けたときの完済シミュレーション結果。
+class DebtPayoffEstimate {
+  /// 完済までの月数（null = [maxMonths] 以内に完済できない）。
+  final int? months;
+
+  /// 完済までに支払う利息の総額（完済できない場合は [maxMonths] までの累計）。
+  final double totalInterest;
+
+  /// この返済額で元金がいつか 0 になるか。
+  final bool everPaysOff;
+
+  const DebtPayoffEstimate({
+    required this.months,
+    required this.totalInterest,
+    required this.everPaysOff,
+  });
+}
+
+/// 月をまたいだ負債トレンドを決定論的に分析するサービス。
+///
+/// 既存の [AssetManagementInsightService] は「今〜給料日」の資金繰りに特化しており、
+/// 「先月より借金が増えていないか」「返済額が利息に負けていないか」を判定しない。
+/// 本サービスがその欠落を埋め、リボ複利・残高増加・超長期完済を検出して
+/// 翌月の具体アクションを生成する。
+class AssetDebtTrendAnalyzer {
+  const AssetDebtTrendAnalyzer({
+    this.balanceIncreaseThreshold = 5000,
+    this.slowPayoffMonthThreshold = 60,
+  });
+
+  /// 「残高が増えた」と見なす最小増加額（円）。小さなブレを問題化しない。
+  final double balanceIncreaseThreshold;
+
+  /// 「完済が遅すぎる」と見なす月数の閾値。
+  final int slowPayoffMonthThreshold;
+
+  static const double _epsilon = 1;
+
+  /// 利息を持ちうる（=リボ・分割が発生しうる）負債種別か。
+  ///
+  /// 家賃・通信費など [AssetLiabilityDebtRow.fullPaymentEstimate] の固定費は除外する
+  /// （毎月全額払いで残高が累積しないため）。
+  static bool isRevolvingLikeKind(AssetLiabilityAccountKind kind) {
+    return switch (kind) {
+      AssetLiabilityAccountKind.cardLoan ||
+      AssetLiabilityAccountKind.shoppingDebt ||
+      AssetLiabilityAccountKind.creditCard ||
+      AssetLiabilityAccountKind.otherLiability =>
+        true,
+      _ => false,
+    };
+  }
+
+  /// ワークブックと（あれば）前月末の口座別残高から負債トレンド指摘を生成する。
+  ///
+  /// [priorBalancesByAccountId] は accountId -> 前月末の利用残高（正の値）。
+  /// 空の場合でも、履歴の要らない①負の償却 ③超長期完済 は検出される。
+  List<AssetDebtTrendInsight> analyze({
+    required AssetLiabilityWorkbook workbook,
+    Map<String, double> priorBalancesByAccountId = const <String, double>{},
+  }) {
+    final insights = <AssetDebtTrendInsight>[];
+    for (final row in workbook.debtMasterRows) {
+      final insight = _analyzeRow(row, priorBalancesByAccountId);
+      if (insight != null) {
+        insights.add(insight);
+      }
+    }
+    insights.sort(_compare);
+    return List<AssetDebtTrendInsight>.unmodifiable(insights);
+  }
+
+  AssetDebtTrendInsight? _analyzeRow(
+    AssetLiabilityDebtRow row,
+    Map<String, double> priorBalances,
+  ) {
+    if (!isRevolvingLikeKind(row.kind) || row.fullPaymentEstimate) {
+      return null;
+    }
+    final balance = row.balance.abs();
+    if (balance <= _epsilon) {
+      return null;
+    }
+
+    final interest = max(0.0, row.monthlyInterestEstimate);
+    final payment = max(0.0, row.scheduledPaymentAmount);
+    final monthlyRate = row.annualRate / 12;
+    final priorBalance = priorBalances[row.id];
+    final delta = priorBalance == null ? null : balance - priorBalance;
+
+    final breakEven = interest + 1;
+    final payoff24 = _paymentToClearIn(balance, monthlyRate, 24);
+    final estimate = estimatePayoff(
+      balance: balance,
+      monthlyRate: monthlyRate,
+      monthlyPayment: payment,
+    );
+
+    final category = _classify(
+      row: row,
+      payment: payment,
+      delta: delta,
+      estimate: estimate,
+    );
+    if (category == null) {
+      return null;
+    }
+
+    final severity = _severityFor(
+      category: category,
+      payment: payment,
+      delta: delta,
+    );
+    final problem = _problemText(
+      category: category,
+      row: row,
+      balance: balance,
+      delta: delta,
+      interest: interest,
+      payment: payment,
+      estimate: estimate,
+    );
+    final action = _actionText(
+      category: category,
+      balance: balance,
+      delta: delta,
+      payment: payment,
+      breakEven: breakEven,
+      payoff24: payoff24,
+    );
+
+    return AssetDebtTrendInsight(
+      accountId: row.id,
+      accountName: row.name,
+      kind: row.kind,
+      category: category,
+      severity: severity,
+      currentBalance: balance,
+      priorBalance: priorBalance,
+      balanceDelta: delta,
+      monthlyInterest: interest,
+      scheduledPayment: payment,
+      interestBreakEvenPayment: breakEven,
+      payoffIn24MonthsPayment: payoff24,
+      estimatedPayoffMonths: estimate.months,
+      estimatedTotalInterest:
+          estimate.everPaysOff ? estimate.totalInterest : null,
+      problem: problem,
+      nextMonthAction: action,
+    );
+  }
+
+  AssetDebtTrendCategory? _classify({
+    required AssetLiabilityDebtRow row,
+    required double payment,
+    required double? delta,
+    required DebtPayoffEstimate estimate,
+  }) {
+    // ① 返済額が利息以下 → 元金が 1 円も減らない（最優先で指摘）。
+    if (payment > 0 && row.principalPaymentEstimate < _epsilon) {
+      return AssetDebtTrendCategory.negativeAmortization;
+    }
+    // ② 前月比で残高が増加（新規利用が返済を侵食）。
+    if (delta != null && delta > balanceIncreaseThreshold) {
+      return AssetDebtTrendCategory.balanceIncreasing;
+    }
+    // ③ 元金は減るが完済まで極端に長い。
+    if (estimate.everPaysOff &&
+        estimate.months != null &&
+        estimate.months! > slowPayoffMonthThreshold) {
+      return AssetDebtTrendCategory.slowPayoff;
+    }
+    return null;
+  }
+
+  AssetDebtTrendSeverity _severityFor({
+    required AssetDebtTrendCategory category,
+    required double payment,
+    required double? delta,
+  }) {
+    switch (category) {
+      case AssetDebtTrendCategory.negativeAmortization:
+        return AssetDebtTrendSeverity.critical;
+      case AssetDebtTrendCategory.balanceIncreasing:
+        // 増加額が返済額を上回る = 払っても追いつかない → critical。
+        if (delta != null && delta > payment) {
+          return AssetDebtTrendSeverity.critical;
+        }
+        return AssetDebtTrendSeverity.warning;
+      case AssetDebtTrendCategory.slowPayoff:
+        return AssetDebtTrendSeverity.warning;
+    }
+  }
+
+  String _problemText({
+    required AssetDebtTrendCategory category,
+    required AssetLiabilityDebtRow row,
+    required double balance,
+    required double? delta,
+    required double interest,
+    required double payment,
+    required DebtPayoffEstimate estimate,
+  }) {
+    switch (category) {
+      case AssetDebtTrendCategory.negativeAmortization:
+        return '${row.name}は今月の返済予定額${_yen(payment)}が利息${_yen(interest)}以下です。'
+            'このままでは元金が1円も減らず、残高${_yen(balance)}は利息分だけ毎月膨らみ続けます。';
+      case AssetDebtTrendCategory.balanceIncreasing:
+        final increase = delta ?? 0;
+        final net = increase - payment;
+        final netClause = net > 0
+            ? '返済${_yen(payment)}を払っても純増${_yen(net)}で、借金は雪だるま式に増えています。'
+            : '返済${_yen(payment)}でかろうじて吸収していますが、新規利用が返済を圧迫しています。';
+        return '${row.name}の利用残高が先月比+${_yen(increase)}（${_yen(balance)}）に増えました。'
+            '$netClause';
+      case AssetDebtTrendCategory.slowPayoff:
+        final months = estimate.months;
+        final years = months == null ? null : (months / 12);
+        final yearsText =
+            years == null ? '' : '（約${years.toStringAsFixed(1)}年）';
+        final interestText = estimate.everPaysOff
+            ? '完済までに利息だけで${_yen(estimate.totalInterest)}を支払う計算です。'
+            : '';
+        return '${row.name}は今の返済額${_yen(payment)}だと完済まで約${months ?? '-'}ヶ月$yearsText。'
+            '$interestText';
+    }
+  }
+
+  String _actionText({
+    required AssetDebtTrendCategory category,
+    required double balance,
+    required double? delta,
+    required double payment,
+    required double breakEven,
+    required double payoff24,
+  }) {
+    switch (category) {
+      case AssetDebtTrendCategory.negativeAmortization:
+        return '①リボ払いを解除して一括返済する、'
+            '②または翌月から返済額を最低でも利息を上回る${_yen(breakEven)}（24ヶ月で完済するなら${_yen(payoff24)}）以上に引き上げてください。'
+            '元金を確実に減らすため、新規利用も止めるのが理想です。';
+      case AssetDebtTrendCategory.balanceIncreasing:
+        final increase = delta ?? 0;
+        return '翌月は新規利用を返済額${_yen(payment)}以下に抑えるか、'
+            '返済額を今月の増加分${_yen(increase)}以上に引き上げて残高を増やさないでください。'
+            '可能ならリボを解除して一括返済し、24ヶ月で完済するなら月${_yen(payoff24)}が目安です。';
+      case AssetDebtTrendCategory.slowPayoff:
+        return '返済額を月${_yen(payoff24)}まで引き上げると24ヶ月で完済でき、利息総額を大きく圧縮できます。'
+            '余力がある月は繰上返済を、新規利用は控えてください。';
+    }
+  }
+
+  int _compare(AssetDebtTrendInsight a, AssetDebtTrendInsight b) {
+    final severity =
+        _severityRank(b.severity).compareTo(_severityRank(a.severity));
+    if (severity != 0) {
+      return severity;
+    }
+    // 重要度が同じなら、残高への影響が大きい順（増加額 → 残高）。
+    final aImpact = (a.balanceDelta ?? 0).abs();
+    final bImpact = (b.balanceDelta ?? 0).abs();
+    final impact = bImpact.compareTo(aImpact);
+    if (impact != 0) {
+      return impact;
+    }
+    final balance = b.currentBalance.compareTo(a.currentBalance);
+    if (balance != 0) {
+      return balance;
+    }
+    return a.accountName.compareTo(b.accountName);
+  }
+
+  int _severityRank(AssetDebtTrendSeverity severity) {
+    return switch (severity) {
+      AssetDebtTrendSeverity.critical => 3,
+      AssetDebtTrendSeverity.warning => 2,
+      AssetDebtTrendSeverity.info => 1,
+    };
+  }
+
+  /// 固定額返済を続けたときの完済シミュレーション。
+  ///
+  /// [monthlyPayment] が初月の利息以下なら元金が減らないため、
+  /// [DebtPayoffEstimate.everPaysOff] = false / [DebtPayoffEstimate.months] = null を返す。
+  static DebtPayoffEstimate estimatePayoff({
+    required double balance,
+    required double monthlyRate,
+    required double monthlyPayment,
+    int maxMonths = 600,
+  }) {
+    if (balance <= _epsilon) {
+      return const DebtPayoffEstimate(
+        months: 0,
+        totalInterest: 0,
+        everPaysOff: true,
+      );
+    }
+    final rate = max(0.0, monthlyRate);
+    final firstInterest = balance * rate;
+    if (monthlyPayment <= firstInterest + _epsilon) {
+      // 返済額が利息を超えない限り元金は減らない。
+      return DebtPayoffEstimate(
+        months: null,
+        totalInterest: firstInterest,
+        everPaysOff: false,
+      );
+    }
+    var remaining = balance;
+    var totalInterest = 0.0;
+    for (var month = 1; month <= maxMonths; month++) {
+      final interest = remaining * rate;
+      totalInterest += interest;
+      remaining = remaining + interest - monthlyPayment;
+      if (remaining <= _epsilon) {
+        return DebtPayoffEstimate(
+          months: month,
+          totalInterest: totalInterest,
+          everPaysOff: true,
+        );
+      }
+    }
+    return DebtPayoffEstimate(
+      months: null,
+      totalInterest: totalInterest,
+      everPaysOff: false,
+    );
+  }
+
+  /// [targetMonths] ヶ月で完済するために必要な毎月返済額（年金現価式）。
+  ///
+  /// 月利 0 のときは単純に balance / months。100 円単位へ切り上げる。
+  double _paymentToClearIn(
+    double balance,
+    double monthlyRate,
+    int targetMonths,
+  ) {
+    final months = max(1, targetMonths);
+    final rate = max(0.0, monthlyRate);
+    final double raw;
+    if (rate <= 0) {
+      raw = balance / months;
+    } else {
+      final factor = pow(1 + rate, months).toDouble();
+      raw = balance * rate * factor / (factor - 1);
+    }
+    return (raw / 100).ceilToDouble() * 100;
+  }
+
+  String _yen(double amount) {
+    final sign = amount < 0 ? '-' : '';
+    final digits = amount.abs().round().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      final remaining = digits.length - i;
+      buffer.write(digits[i]);
+      if (remaining > 1 && remaining % 3 == 1) {
+        buffer.write(',');
+      }
+    }
+    return '$sign$buffer円';
+  }
+}

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -1,5 +1,6 @@
 import '../models/asset_liability_workbook.dart';
 import '../models/user_profile.dart';
+import 'asset_debt_trend_analyzer.dart';
 import 'asset_management_available_money.dart';
 
 enum AssetManagementInsightActionType {
@@ -225,6 +226,9 @@ class AssetManagementInsightReport {
   final List<AssetManagementDeveloperRequest> developerRequests;
   final List<AssetManagementImplementationContext> implementationContexts;
 
+  /// 月をまたいだ負債トレンド（リボ複利・残高増加・超長期完済）の指摘。
+  final List<AssetDebtTrendInsight> debtTrendInsights;
+
   const AssetManagementInsightReport({
     required this.workbook,
     this.userProfile,
@@ -237,7 +241,18 @@ class AssetManagementInsightReport {
     required this.developerRequests,
     this.implementationContexts =
         const <AssetManagementImplementationContext>[],
+    this.debtTrendInsights = const <AssetDebtTrendInsight>[],
   });
+
+  bool get hasDebtTrendInsights => debtTrendInsights.isNotEmpty;
+
+  List<AssetDebtTrendInsight> get criticalDebtTrendInsights {
+    return debtTrendInsights
+        .where(
+          (insight) => insight.severity == AssetDebtTrendSeverity.critical,
+        )
+        .toList(growable: false);
+  }
 
   bool get hasCriticalActions {
     return actionItems.any(
@@ -268,6 +283,8 @@ class AssetManagementInsightService {
     double minimumSafetyBalance = defaultMinimumSafetyBalance,
     int upcomingPaymentWarningDays = defaultUpcomingPaymentWarningDays,
     String? mainAccountId,
+    Map<String, double> priorMonthAccountBalances = const <String, double>{},
+    AssetDebtTrendAnalyzer debtTrendAnalyzer = const AssetDebtTrendAnalyzer(),
   }) {
     final breakdown = _availableMoneyBreakdown(
       workbook: workbook,
@@ -312,6 +329,10 @@ class AssetManagementInsightService {
       actions: actions,
       movementSuggestions: movementSuggestions,
     );
+    final debtTrendInsights = debtTrendAnalyzer.analyze(
+      workbook: workbook,
+      priorBalancesByAccountId: priorMonthAccountBalances,
+    );
 
     return AssetManagementInsightReport(
       workbook: workbook,
@@ -324,6 +345,7 @@ class AssetManagementInsightService {
       emergencyAdvices: emergencyAdvices,
       developerRequests: developerRequests,
       implementationContexts: implementationContexts,
+      debtTrendInsights: debtTrendInsights,
     );
   }
 
@@ -1174,6 +1196,12 @@ class AssetManagementInsightPromptBuilder {
       ..writeln(
         '「7. 開発者向け改善提案」では、各提案ごとに「現状の痛み」「根拠データ」「変更ファイル」「実装手順」「受け入れ条件」「テスト/確認コマンド」「リスク」を必ず書いてください。',
       )
+      ..writeln(
+        '「4. 今月の支払いと利息」と「5. 今後3〜5年の運気と借金圧縮」では、下記「今月の問題点と翌月の改善（負債トレンド）」を最優先で扱ってください。'
+        '特にリボ払いで返済額が利息以下の負債、前月比で利用残高が増えた負債は、'
+        '「今月いくら増えたか」「このままだと何年で完済か/一生終わらないか」「翌月いくら返済すべきか（具体額）」を断言してください。'
+        '該当データが無い月だけ、そのカテゴリには触れなくて構いません。',
+      )
       ..writeln()
       ..writeln('## 総合サマリー')
       ..writeln('- 基準日: ${_formatDate(workbook.baseDate)}')
@@ -1227,6 +1255,9 @@ class AssetManagementInsightPromptBuilder {
       ..writeln()
       ..writeln('## カード請求内訳と照合')
       ..write(_cardBillingLines(workbook))
+      ..writeln()
+      ..writeln('## 今月の問題点と翌月の改善（負債トレンド）')
+      ..write(_debtTrendLines(report))
       ..writeln()
       ..writeln('## アクション件数')
       ..writeln('- 合計: ${report.actionItems.length}')
@@ -1509,6 +1540,44 @@ class AssetManagementInsightPromptBuilder {
       }
     }
     return buffer.toString();
+  }
+
+  String _debtTrendLines(AssetManagementInsightReport report) {
+    if (report.debtTrendInsights.isEmpty) {
+      return '- 月をまたいだ負債の悪化トレンドは検出されていません。'
+          '前月比のデータが無い場合は、来月以降の比較のために今月の残高を保存してください。\n';
+    }
+    final buffer = StringBuffer();
+    for (final insight in report.debtTrendInsights) {
+      final priorText = insight.priorBalance == null
+          ? '前月残高:履歴なし'
+          : '前月残高:${_formatAmount(insight.priorBalance!)} / '
+              '前月比:${_formatAmount(insight.balanceDelta ?? 0)}';
+      final payoffText = insight.estimatedPayoffMonths == null
+          ? '完済見込み:この返済額では完済不能'
+          : '完済見込み:約${insight.estimatedPayoffMonths}ヶ月';
+      buffer
+        ..writeln(
+          '- ${insight.accountName} / 区分:${_debtTrendCategoryLabel(insight.category)} / '
+          '重要度:${insight.severity.name} / 残高:${_formatAmount(insight.currentBalance)} / '
+          '$priorText / 月利息:${_formatAmount(insight.monthlyInterest)} / '
+          '今月返済:${_formatAmount(insight.scheduledPayment)} / '
+          '止血ライン(利息超え):${_formatAmount(insight.interestBreakEvenPayment)} / '
+          '24ヶ月完済ライン:${_formatAmount(insight.payoffIn24MonthsPayment)} / '
+          '$payoffText',
+        )
+        ..writeln('  - 問題点: ${insight.problem}')
+        ..writeln('  - 翌月アクション: ${insight.nextMonthAction}');
+    }
+    return buffer.toString();
+  }
+
+  String _debtTrendCategoryLabel(AssetDebtTrendCategory category) {
+    return switch (category) {
+      AssetDebtTrendCategory.negativeAmortization => 'リボ複利(返済が利息以下)',
+      AssetDebtTrendCategory.balanceIncreasing => '残高増加(新規利用過多)',
+      AssetDebtTrendCategory.slowPayoff => '超長期完済',
+    };
   }
 
   String _redactedSituationCards(AssetManagementInsightReport report) {

--- a/test/services/asset_account_balance_history_store_test.dart
+++ b/test/services/asset_account_balance_history_store_test.dart
@@ -1,0 +1,237 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_account_balance_history_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const store = AssetAccountBalanceHistoryStore();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('records a month and reads it back from a later month', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{'famipay': 30000, 'mobit': -200000},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    // 負債残高は絶対値（正の値）で保存される。
+    expect(prior['famipay'], 30000);
+    expect(prior['mobit'], 200000);
+  });
+
+  test('prior month excludes the current month entry', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{'famipay': 30000},
+      prefs: prefs,
+    );
+    await store.recordMonth(
+      DateTime(2026, 6, 1),
+      <String, double>{'famipay': 100000},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    expect(prior['famipay'], 30000);
+  });
+
+  test('returns empty when no prior month exists', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.recordMonth(
+      DateTime(2026, 6, 1),
+      <String, double>{'famipay': 100000},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    expect(prior, isEmpty);
+  });
+
+  test('re-recording the same month overwrites it', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{'famipay': 30000},
+      prefs: prefs,
+    );
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{'famipay': 45000},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    expect(prior['famipay'], 45000);
+    expect(await store.recordedMonthKeys(prefs: prefs), <String>['2026-05']);
+  });
+
+  test('skips a debt-free (empty) month and returns the last month with debt',
+      () async {
+    final prefs = await SharedPreferences.getInstance();
+    // 4月に借金あり → 5月に完済(空) → 6月に新規借入。
+    await store.recordMonth(
+      DateTime(2026, 4, 1),
+      <String, double>{'famipay': 30000},
+      prefs: prefs,
+    );
+    await store.recordMonth(
+      DateTime(2026, 5, 1),
+      <String, double>{},
+      prefs: prefs,
+    );
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    // 空の5月を飛ばして4月の残高を前月比の基準にする。
+    expect(prior['famipay'], 30000);
+  });
+
+  test('rejects negative balances on read (corrupted data)', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'asset_account_balance_history_v1': jsonEncode(<String, dynamic>{
+        '2026-05': <String, dynamic>{'good': 100000, 'bad': -50000},
+      }),
+    });
+    final prefs = await SharedPreferences.getInstance();
+
+    final prior = await store.priorMonthBalances(
+      DateTime(2026, 6, 1),
+      prefs: prefs,
+    );
+
+    expect(prior['good'], 100000);
+    expect(prior.containsKey('bad'), isFalse);
+  });
+
+  group('mergeRemote (cross-device sync)', () {
+    test('adds a remote-only month (union, no data loss)', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await store.recordMonth(
+        DateTime(2026, 6, 1),
+        <String, double>{'famipay': 100000},
+        prefs: prefs,
+      );
+
+      final changed = await store.mergeRemote(
+        <String, dynamic>{
+          '2026-05': <String, dynamic>{'mobit': 200000},
+        },
+        prefs: prefs,
+      );
+
+      expect(changed, isTrue);
+      final all = await store.loadAll(prefs: prefs);
+      expect(all['2026-05']!['mobit'], 200000);
+      expect(all['2026-06']!['famipay'], 100000);
+    });
+
+    test('fills remote-only accounts but keeps local on conflict', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await store.recordMonth(
+        DateTime(2026, 6, 1),
+        <String, double>{'famipay': 100000},
+        prefs: prefs,
+      );
+
+      final changed = await store.mergeRemote(
+        <String, dynamic>{
+          '2026-06': <String, dynamic>{'famipay': 999999, 'mobit': 50000},
+        },
+        prefs: prefs,
+      );
+
+      expect(changed, isTrue);
+      final all = await store.loadAll(prefs: prefs);
+      // 共有口座はローカル値を優先、リモート限定口座だけ補完。
+      expect(all['2026-06']!['famipay'], 100000);
+      expect(all['2026-06']!['mobit'], 50000);
+    });
+
+    test('returns false and changes nothing for empty/invalid remote',
+        () async {
+      final prefs = await SharedPreferences.getInstance();
+      await store.recordMonth(
+        DateTime(2026, 6, 1),
+        <String, double>{'famipay': 100000},
+        prefs: prefs,
+      );
+
+      expect(await store.mergeRemote(null, prefs: prefs), isFalse);
+      expect(
+        await store.mergeRemote(<String, dynamic>{}, prefs: prefs),
+        isFalse,
+      );
+      expect(await store.mergeRemote('garbage', prefs: prefs), isFalse);
+
+      final all = await store.loadAll(prefs: prefs);
+      expect(all['2026-06']!['famipay'], 100000);
+    });
+
+    test('merged remote month becomes the prior-month basis', () async {
+      final prefs = await SharedPreferences.getInstance();
+      // 今月だけローカルにある状態へ、他端末の先月分をマージ。
+      await store.recordMonth(
+        DateTime(2026, 6, 1),
+        <String, double>{'famipay': 100000},
+        prefs: prefs,
+      );
+      await store.mergeRemote(
+        <String, dynamic>{
+          '2026-05': <String, dynamic>{'famipay': 30000},
+        },
+        prefs: prefs,
+      );
+
+      final prior = await store.priorMonthBalances(
+        DateTime(2026, 6, 1),
+        prefs: prefs,
+      );
+      expect(prior['famipay'], 30000);
+    });
+  });
+
+  test('prunes history beyond the retention window', () async {
+    final prefs = await SharedPreferences.getInstance();
+    for (var i = 0; i < AssetAccountBalanceHistoryStore.maxMonths + 4; i++) {
+      final month = DateTime(2025, 1 + i, 1);
+      await store.recordMonth(
+        month,
+        <String, double>{'famipay': 1000.0 * i},
+        prefs: prefs,
+      );
+    }
+
+    final keys = await store.recordedMonthKeys(prefs: prefs);
+    expect(keys.length, AssetAccountBalanceHistoryStore.maxMonths);
+    // 最古の月から間引かれている。
+    expect(keys.first.compareTo(keys.last) < 0, isTrue);
+  });
+}

--- a/test/services/asset_debt_trend_analyzer_test.dart
+++ b/test/services/asset_debt_trend_analyzer_test.dart
@@ -1,0 +1,192 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_debt_trend_analyzer.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  const planner = AssetLiabilityPlanningService();
+  const analyzer = AssetDebtTrendAnalyzer();
+  final baseDate = DateTime(2026, 6, 1);
+
+  String debtId(AssetLiabilityWorkbook workbook, String name) {
+    return workbook.debtMasterRows.firstWhere((row) => row.name == name).id;
+  }
+
+  group('AssetDebtTrendAnalyzer.estimatePayoff', () {
+    test('returns null months when payment does not exceed interest', () {
+      // 30万円 @ 年15% → 月利息 3,750円。返済 3,000円では元金が減らない。
+      final estimate = AssetDebtTrendAnalyzer.estimatePayoff(
+        balance: 300000,
+        monthlyRate: 0.15 / 12,
+        monthlyPayment: 3000,
+      );
+      expect(estimate.everPaysOff, isFalse);
+      expect(estimate.months, isNull);
+    });
+
+    test('returns finite months when payment exceeds interest', () {
+      final estimate = AssetDebtTrendAnalyzer.estimatePayoff(
+        balance: 100000,
+        monthlyRate: 0.15 / 12,
+        monthlyPayment: 20000,
+      );
+      expect(estimate.everPaysOff, isTrue);
+      expect(estimate.months, isNotNull);
+      expect(estimate.months! > 0, isTrue);
+      expect(estimate.totalInterest > 0, isTrue);
+    });
+
+    test('returns zero months for a cleared balance', () {
+      final estimate = AssetDebtTrendAnalyzer.estimatePayoff(
+        balance: 0,
+        monthlyRate: 0.15 / 12,
+        monthlyPayment: 1000,
+      );
+      expect(estimate.months, 0);
+      expect(estimate.everPaysOff, isTrue);
+    });
+  });
+
+  group('AssetDebtTrendAnalyzer.analyze', () {
+    test('flags negative amortization when payment is below interest', () {
+      // 30万円 @ 15% / 返済 3,000円 → 月利息 3,750円 > 返済 → 元金が減らない。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'リボカード': -300000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'リボカード': 3000},
+      );
+
+      final insights = analyzer.analyze(workbook: workbook);
+
+      expect(insights, hasLength(1));
+      final insight = insights.single;
+      expect(insight.category, AssetDebtTrendCategory.negativeAmortization);
+      expect(insight.severity, AssetDebtTrendSeverity.critical);
+      expect(insight.estimatedPayoffMonths, isNull);
+      expect(insight.nextMonthAction.contains('一括返済'), isTrue);
+      expect(insight.nextMonthAction.contains('新規利用'), isTrue);
+      expect(insight.problem.contains('元金'), isTrue);
+    });
+
+    test(
+        'flags a revolving balance that grew month over month '
+        '(the FamiPay example)', () {
+      // 先月 3万円 → 今月 10万円 (+7万) なのに返済は 5,000円。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 80000,
+          'ファミペイ': -100000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'ファミペイ': 5000},
+      );
+      final famipayId = debtId(workbook, 'ファミペイ');
+
+      final insights = analyzer.analyze(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{famipayId: 30000},
+      );
+
+      expect(insights, hasLength(1));
+      final insight = insights.single;
+      expect(insight.category, AssetDebtTrendCategory.balanceIncreasing);
+      // 増加額 7万 > 返済 5,000 → 払っても追いつかない → critical。
+      expect(insight.severity, AssetDebtTrendSeverity.critical);
+      expect(insight.balanceDelta, 70000);
+      expect(insight.problem.contains('先月比+70,000円'), isTrue);
+      expect(insight.problem.contains('純増'), isTrue);
+      expect(insight.nextMonthAction.contains('新規利用'), isTrue);
+      expect(insight.nextMonthAction.contains('一括返済'), isTrue);
+    });
+
+    test('flags a very slow payoff even without history', () {
+      // 30万円 @ 15% / 返済 6,000円 → 元金は減るが完済まで 60ヶ月超。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'ショッピングカード': -300000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'ショッピングカード': 6000},
+      );
+
+      final insights = analyzer.analyze(workbook: workbook);
+
+      expect(insights, hasLength(1));
+      final insight = insights.single;
+      expect(insight.category, AssetDebtTrendCategory.slowPayoff);
+      expect(insight.estimatedPayoffMonths, isNotNull);
+      expect(insight.estimatedPayoffMonths! > 60, isTrue);
+      expect(insight.problem.contains('完済まで'), isTrue);
+    });
+
+    test('produces no insight for a healthy, shrinking revolving balance', () {
+      // 5万円 @ 15% / 返済 2万円 → すぐ完済。先月より残高は減少。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 200000,
+          '優等生カード': -50000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'優等生カード': 20000},
+      );
+      final cardId = debtId(workbook, '優等生カード');
+
+      final insights = analyzer.analyze(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{cardId: 80000},
+      );
+
+      expect(insights, isEmpty);
+    });
+
+    test('ignores non-revolving kinds', () {
+      expect(
+        AssetDebtTrendAnalyzer.isRevolvingLikeKind(
+          AssetLiabilityAccountKind.utility,
+        ),
+        isFalse,
+      );
+      expect(
+        AssetDebtTrendAnalyzer.isRevolvingLikeKind(
+          AssetLiabilityAccountKind.creditCard,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetDebtTrendAnalyzer.isRevolvingLikeKind(
+          AssetLiabilityAccountKind.cardLoan,
+        ),
+        isTrue,
+      );
+    });
+
+    test('prioritises critical insights first', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 50000,
+          'リボカード':
+              -300000, // payment < interest → negative amortization (critical)
+          'ショッピングカード': -300000, // slow payoff (warning)
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{
+          'リボカード': 3000,
+          'ショッピングカード': 6000,
+        },
+      );
+
+      final insights = analyzer.analyze(workbook: workbook);
+
+      expect(insights.length, 2);
+      expect(insights.first.severity, AssetDebtTrendSeverity.critical);
+      expect(
+        insights.first.category,
+        AssetDebtTrendCategory.negativeAmortization,
+      );
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -819,6 +819,48 @@ void main() {
       await _unmount(tester);
     });
 
+    testWidgets('revolving balance growth surfaces the monthly debt trend card',
+        (tester) async {
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      final priorMonth = DateTime(now.year, now.month - 1, 1);
+      final priorKey = '${priorMonth.year.toString().padLeft(4, '0')}-'
+          '${priorMonth.month.toString().padLeft(2, '0')}';
+      // 前月末のモビット残高 3 万円を履歴に仕込み、今月 30 万へ増加させる。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'asset_account_balance_history_v1': jsonEncode(<String, dynamic>{
+          priorKey: <String, dynamic>{'mobit': 30000},
+        }),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 500000,
+                'モビット': -300000,
+              },
+            },
+          ),
+        ),
+      );
+      // 履歴の非同期ロード → setState → 再描画を待つ。
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.textContaining('今月の問題点と翌月の改善（負債トレンド）'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('残高が先月より増加'), findsWidgets);
+
+      await _unmount(tester);
+    });
+
     testWidgets('mirror update notice offers and applies remote prefs', (
       tester,
     ) async {


### PR DESCRIPTION
## 概要

資産管理ページに **「今月の問題点と翌月の改善（負債トレンド）」** を新設。既存の資金繰り（今〜給料日）インサイトには無かった「月をまたいだ借金の増減トレンド」を決定論的に検出し、翌月の**具体的な返済額**を提示します。

例: ファミペイのリボ残高が先月比+10万、返済3,000円では純増 →「①リボ解除して一括返済、②または返済額を利息超え/24ヶ月完済ライン以上に」を自動生成。

## 検出ロジック（3シグナル）

| 検出 | 条件 | 履歴要否 |
|---|---|---|
| リボ複利（負の償却） | 返済額 ≤ 利息（`principalPaymentEstimate==0`） | 不要（初月から動作） |
| 残高増加トレンド | 前月比で残高増（増加額>返済→critical） | 前月の口座別残高 |
| 超長期完済 | 完済まで60ヶ月超 | 不要 |

金額は Dart 側で計算済み。AIプロンプトには「再計算するな」契約を維持したまま数値を渡します。

## 端末跨ぎ同期（マイグレーション不要）

前月残高は汎用 jsonb ミラー `asset_pref_mirror`（`pref_key='account_balance_history'`）で端末跨ぎ同期。専用テーブル・SQLマイグレーション・edge デプロイは**不要**。マージは月キー・口座を消さない**和集合・非破壊**（競合はローカル優先で巻き戻し/取りこぼし防止）。

## 変更ファイル（新規4＋編集3）

- 🆕 `lib/services/asset_debt_trend_analyzer.dart` — 完済シミュレーション＋分類＋翌月アクション（純粋ロジック）
- 🆕 `lib/services/asset_account_balance_history_store.dart` — 前月残高の自動蓄積＋和集合マージ（同期スナップショット非干渉でLWWデータ消失を回避）
- `lib/services/asset_management_insight_service.dart` — `debtTrendInsights` 追加＋AIプロンプト節
- `lib/pages/asset_management_page.dart` — 専用カードUI＋月キーガード前月残高ロード＋ミラー退避/復元

## テスト / 検証

- アナライザ9 / ストア11（マージ4含む）/ インサイト18 / スモーク（実機カード描画）**全緑**
- `dart analyze` 全変更ファイルでクリーン
- 26エージェントの敵対的レビュー確定4件を修正済み（空月スキップ/負残高拒否/月キーガード/符号付き差分）
- 現 origin/main から切ったクリーンブランチに再適用（旧 PR #3516 は 611-behind ブランチ由来のため close 予定）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 本変更はUI/サービス層のみで外部I/Oや認可フローを変えず専用E2Eルートは過剰。実機相当の widget スモーク(負債トレンドカード描画)+純粋ロジックのユニットテスト計38件で契約を担保している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)