### PR TITLE
feat(asset): サブスクの請求経路 (Apple/Google/au 経由) と棚卸し突き合わせを追加

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -283,12 +283,34 @@ enum AssetRecurringFixedCostCategory {
   subscription,
 }
 
+/// サブスクの請求経路 (どこ経由で課金されるか)。
+///
+/// 例: ChatGPT Pro は Apple App Store のサブスクとして課金され、Apple ID の支払い方法
+/// (ファミペイ等のカード) に請求される。この場合カード明細には `APPLE.COM/BILL` の
+/// 集約名義で出るため、個別サービス名では現れない。請求経路を記録しておくと、棚卸しで
+/// 「Apple 経由のサブスク合計」を集約請求と突き合わせて確認できる。
+enum AssetSubscriptionBillingGateway {
+  /// 経由なし (口座/カードへ直接請求)。既定。
+  direct,
+
+  /// Apple App Store (iOS/Mac) のサブスク経由。
+  apple,
+
+  /// Google Play 定期購入経由。
+  googlePlay,
+
+  /// auかんたん決済 (キャリア決済) 経由。
+  auKantan,
+}
+
 /// UI から登録できる定期固定費 (家賃・光熱費・通信費など毎月/隔月の口座振替)。
 ///
 /// ハードコードされた既定固定費 (家賃/KDDI/水道/ガス) と同様に、資金繰りへ
 /// 「全額支払いの負債 (utility)」として計上される。`buildWorkbook` の
 /// `recurringFixedCosts` で渡し、`asset_pref_mirror` で端末間同期する。
-/// 保存形は `{id: {name, amount, paymentDay, cadence, sourceAccountId}}`。
+/// 保存形は `{id: {name, amount, paymentDay, cadence, sourceAccountId,
+/// category?, billingGateway?}}` (既定値 category=utility / billingGateway=direct
+/// は後方互換のため出力しない)。
 class AssetRecurringFixedCost {
   /// 安定した一意 ID (編集・削除のキー)。
   final String id;
@@ -311,6 +333,10 @@ class AssetRecurringFixedCost {
   /// 区分 (固定費 / サブスク)。既定は utility で、表示セクションの振り分けにのみ使う。
   final AssetRecurringFixedCostCategory category;
 
+  /// 請求経路 (Apple/Google/au 経由 or 直接)。既定は direct。棚卸しでの集約請求との
+  /// 突き合わせ表示に使い、資金繰りの計上額には影響しない。
+  final AssetSubscriptionBillingGateway billingGateway;
+
   const AssetRecurringFixedCost({
     required this.id,
     required this.name,
@@ -319,6 +345,7 @@ class AssetRecurringFixedCost {
     this.cadence = AssetRecurringFixedCostCadence.monthly,
     this.sourceAccountId,
     this.category = AssetRecurringFixedCostCategory.utility,
+    this.billingGateway = AssetSubscriptionBillingGateway.direct,
   });
 
   /// 指定した月 (1-12) にこの固定費が発生するか (隔月は偶数/奇数月のみ計上)。
@@ -342,6 +369,7 @@ class AssetRecurringFixedCost {
     String? sourceAccountId,
     bool clearSourceAccountId = false,
     AssetRecurringFixedCostCategory? category,
+    AssetSubscriptionBillingGateway? billingGateway,
   }) {
     return AssetRecurringFixedCost(
       id: id ?? this.id,
@@ -353,6 +381,7 @@ class AssetRecurringFixedCost {
           ? null
           : (sourceAccountId ?? this.sourceAccountId),
       category: category ?? this.category,
+      billingGateway: billingGateway ?? this.billingGateway,
     );
   }
 
@@ -368,6 +397,8 @@ class AssetRecurringFixedCost {
         'sourceAccountId': sourceAccountId,
       if (category != AssetRecurringFixedCostCategory.utility)
         'category': category.name,
+      if (billingGateway != AssetSubscriptionBillingGateway.direct)
+        'billingGateway': billingGateway.name,
     };
   }
 
@@ -405,6 +436,11 @@ class AssetRecurringFixedCost {
       (value) => value.name == categoryName,
       orElse: () => AssetRecurringFixedCostCategory.utility,
     );
+    final gatewayName = json['billingGateway']?.toString();
+    final billingGateway = AssetSubscriptionBillingGateway.values.firstWhere(
+      (value) => value.name == gatewayName,
+      orElse: () => AssetSubscriptionBillingGateway.direct,
+    );
     return AssetRecurringFixedCost(
       id: trimmedId,
       name: name,
@@ -414,6 +450,7 @@ class AssetRecurringFixedCost {
       sourceAccountId:
           rawSource == null || rawSource.isEmpty ? null : rawSource,
       category: category,
+      billingGateway: billingGateway,
     );
   }
 }

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -883,7 +883,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// AIコメントが指摘するカード明細の未取込・差分に対し、取り込み・照合
   /// パネルへ誘導するリンクの文言。確認が必要なカード名を織り込む。
   String _cardStatementReconciliationLinkLabel(
-      AssetLiabilityWorkbook workbook) {
+    AssetLiabilityWorkbook workbook,
+  ) {
     final groups = workbook.cardStatementReconciliation.needsReviewGroups;
     if (groups.length == 1) {
       return '${groups.first.billingAccountName}の明細を取り込んで照合する';
@@ -8015,17 +8016,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _buildCategoryBudgetCard(),
             ],
             if (_isSectionShown(
-                AssetManagementSectionId.recurringFixedCost)) ...[
+              AssetManagementSectionId.recurringFixedCost,
+            )) ...[
               _buildRecurringFixedCostCard(assetLiabilityWorkbook),
               const SizedBox(height: 16),
             ],
             if (_isSectionShown(
-                AssetManagementSectionId.subscriptionFixedCost)) ...[
+              AssetManagementSectionId.subscriptionFixedCost,
+            )) ...[
               _buildSubscriptionFixedCostCard(assetLiabilityWorkbook),
               const SizedBox(height: 16),
             ],
             if (_isSectionShown(
-                AssetManagementSectionId.subscriptionAudit)) ...[
+              AssetManagementSectionId.subscriptionAudit,
+            )) ...[
               _buildSubscriptionAuditCard(assetLiabilityWorkbook),
               const SizedBox(height: 16),
             ],
@@ -8237,9 +8241,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     if (day == null ||
                         day < AssetSalaryDayStore.minSalaryDay ||
                         day > AssetSalaryDayStore.maxSalaryDay) {
-                      setDialogState(
-                        () => errorText = '1〜28 の日付を入力してください',
-                      );
+                      setDialogState(() => errorText = '1〜28 の日付を入力してください');
                       return;
                     }
                     Navigator.of(dialogContext).pop();
@@ -8614,8 +8616,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final List<AssetRecurringFixedCost> serverList;
       final DateTime? mirrorUpdatedAt;
       if (debugMirror != null) {
-        serverList =
-            AssetRecurringFixedCostStore.decodeMirrorValue(debugMirror);
+        serverList = AssetRecurringFixedCostStore.decodeMirrorValue(
+          debugMirror,
+        );
         mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
         final rows = await _supabase
@@ -8756,8 +8759,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       final Map<String, DateTime> serverState;
       final DateTime? mirrorUpdatedAt;
       if (debugMirror != null) {
-        serverState =
-            AssetSubscriptionAuditStore.decodeMirrorValue(debugMirror);
+        serverState = AssetSubscriptionAuditStore.decodeMirrorValue(
+          debugMirror,
+        );
         mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
         final rows = await _supabase
@@ -8901,16 +8905,28 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       for (final account in accounts)
         if (account.balance > 0) (id: account.id, name: account.name),
     ];
+    final gatewayTotals = AssetSubscriptionAuditCatalog.gatewayTotalsBySourceId(
+      subscriptions: [
+        for (final cost in _recurringFixedCosts)
+          if (cost.category == AssetRecurringFixedCostCategory.subscription)
+            (gateway: cost.billingGateway, amount: cost.amount),
+      ],
+    );
     return SubscriptionAuditCard(
       sources: _subscriptionAuditSources(workbook),
       lastCheckedAt: _subscriptionAuditState,
       unregisteredCountBySourceId: _unregisteredCountBySourceId(workbook),
+      registeredByGatewaySourceId: gatewayTotals,
       now: _now,
       onMarkChecked: _markSubscriptionSourceChecked,
       onRegisterSubscription: (source) => unawaited(
         _openRecurringFixedCostEditor(
           sourceOptions: sourceOptions,
           category: AssetRecurringFixedCostCategory.subscription,
+          // Apple/au/Google 行から登録するときは請求経路を既定で合わせる。
+          gateway:
+              AssetSubscriptionAuditCatalog.gatewayForSourceId(source.id) ??
+                  AssetSubscriptionBillingGateway.direct,
         ),
       ),
     );
@@ -8919,9 +8935,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 削除した定期固定費のトゥームストーン。union マージ/backfill での復活を防ぎ、
   /// 他端末へ削除を伝播する (リボ設定と同じパターン)。
   static const MirrorTombstoneStore _recurringFixedCostTombstones =
-      MirrorTombstoneStore(
-    storageKey: 'recurring_fixed_costs_deleted_v1',
-  );
+      MirrorTombstoneStore(storageKey: 'recurring_fixed_costs_deleted_v1');
 
   /// 削除はトゥームストーン化、再追加 (同 id) は解除する。
   Future<void> _recordRecurringFixedCostTombstone(
@@ -9230,6 +9244,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     required List<RecurringFixedCostSourceOption> sourceOptions,
     AssetRecurringFixedCostCategory category =
         AssetRecurringFixedCostCategory.utility,
+    AssetSubscriptionBillingGateway gateway =
+        AssetSubscriptionBillingGateway.direct,
   }) async {
     final result = await showRecurringFixedCostEditor(
       context,
@@ -9237,6 +9253,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       prefill: prefill,
       sourceAccounts: sourceOptions,
       category: category,
+      gateway: gateway,
     );
     if (result != null) {
       _saveRecurringFixedCost(result);
@@ -9582,9 +9599,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       registerLabel: '定期収入に登録',
       suggestions: _detectRecurringIncome(),
       currencyFormatter: _formatYen,
-      onRegister: (detected) => unawaited(
-        _registerDetectedRecurringIncome(detected, workbook),
-      ),
+      onRegister: (detected) =>
+          unawaited(_registerDetectedRecurringIncome(detected, workbook)),
       onIgnore: _ignoreDetectedRecurringIncome,
     );
   }
@@ -9757,9 +9773,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 削除した (リボ OFF にした) リボ設定のトゥームストーン。union マージ/backfill
   /// での復活を防ぎ、他端末へ削除を伝播する (debt 上書きと同じパターン)。
   static const MirrorTombstoneStore _revolvingConfigTombstones =
-      MirrorTombstoneStore(
-    storageKey: 'revolving_credit_configs_deleted_v1',
-  );
+      MirrorTombstoneStore(storageKey: 'revolving_credit_configs_deleted_v1');
 
   void _persistRevolvingConfig(
     String debtId,
@@ -10088,7 +10102,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         <String>[
           'display_mode',
           'section_overrides',
-          'section_override_deleted'
+          'section_override_deleted',
         ],
       );
     } catch (e) {
@@ -10402,14 +10416,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final dateLabel = DateFormat('M月d日').format(date);
     if (_isSectionShown(AssetManagementSectionId.flow)) {
       _scrollTo(_keyFlow);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('$dateLabelを記録日にセットしました')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('$dateLabelを記録日にセットしました')));
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('$dateLabelを記録日にセットしました。収支セクション(標準/フル)で記録できます'),
-        ),
+        SnackBar(content: Text('$dateLabelを記録日にセットしました。収支セクション(標準/フル)で記録できます')),
       );
     }
   }
@@ -10656,8 +10668,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Future<void> _fetchExperimentSummary() async {
     try {
-      final dynamic result =
-          await _supabase.rpc('display_mode_experiment_summary');
+      final dynamic result = await _supabase.rpc(
+        'display_mode_experiment_summary',
+      );
       if (!mounted || result is! Map) {
         return;
       }
@@ -10689,11 +10702,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     try {
-      await _supabase
-          .from('asset_expected_inflow_items')
-          .upsert(<Map<String, dynamic>>[
-        for (final row in rows) <String, dynamic>{...row, 'user_id': userId},
-      ]);
+      await _supabase.from('asset_expected_inflow_items').upsert(
+        <Map<String, dynamic>>[
+          for (final row in rows) <String, dynamic>{...row, 'user_id': userId},
+        ],
+      );
     } catch (e) {
       debugPrint('inflow mirror upsert failed: $e');
     }
@@ -10794,9 +10807,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('入金予定をサーバのバックアップから復元しました')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('入金予定をサーバのバックアップから復元しました')));
     } catch (e) {
       debugPrint('inflow mirror restore failed: $e');
     }
@@ -11194,9 +11207,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (!mounted) {
       return;
     }
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('古い削除記録を${removed.total}件 掃除しました')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('古い削除記録を${removed.total}件 掃除しました')));
   }
 
   /// 各ドメインのトゥームストーンを掃除し、ドメイン別の削除件数を返す。
@@ -11346,9 +11359,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         return;
       }
       if (additions.isEmpty) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('サーバとの差分はありませんでした')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('サーバとの差分はありませんでした')));
         return;
       }
       final confirmed = await showDialog<bool>(
@@ -11402,9 +11415,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('$added件をサーバから統合しました')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('$added件をサーバから統合しました')));
     } catch (e) {
       debugPrint('inflow mirror merge failed: $e');
     }
@@ -11442,9 +11455,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text(
-          '$shiftedCount件の支払日を毎月$newDay日へまとめて変更しました(負債マスタから戻せます)',
-        ),
+        content: Text('$shiftedCount件の支払日を毎月$newDay日へまとめて変更しました(負債マスタから戻せます)'),
       ),
     );
   }
@@ -11543,9 +11554,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                                 ),
                               ),
                               IconButton(
-                                key: Key(
-                                  'asset_inflow_rule_delete_${rule.id}',
-                                ),
+                                key: Key('asset_inflow_rule_delete_${rule.id}'),
                                 tooltip: '削除',
                                 icon: const Icon(
                                   Icons.delete_outline,
@@ -11670,10 +11679,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                           const Color(0xFF6366F1),
                           '初期解決',
                         ),
-                        _buildCalendarLegendItem(
-                          const Color(0xFFF97316),
-                          '切替',
-                        ),
+                        _buildCalendarLegendItem(const Color(0xFFF97316), '切替'),
                       ],
                     ),
                   ],
@@ -12063,9 +12069,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         if (event.sourceId != null) event.sourceId!,
     ];
     final comboSuggestionIds = comboIds.length >= 2 &&
-            shiftCandidates.every(
-              (entry) => entry.value == '(単独では回避不可)',
-            )
+            shiftCandidates.every((entry) => entry.value == '(単独では回避不可)')
         ? AssetPaymentCalendarService.findMinimalShiftSet(
             month: _calendarMonth,
             flows: _recentFlows,
@@ -12247,10 +12251,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                                 workbook,
                                 entry.key.sourceId!,
                               ),
-                              icon: const Icon(
-                                Icons.schedule_send,
-                                size: 14,
-                              ),
+                              icon: const Icon(Icons.schedule_send, size: 14),
                               label: Text(
                                 '${entry.key.label}を26日へ${entry.value}',
                                 style: const TextStyle(fontSize: 11),
@@ -17001,8 +17002,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         occasion.date.month == _now.month &&
         occasion.date.day == _now.day;
     final isHoliday = occasion.reasons.contains(DrinkOccasionReason.holiday);
-    final isHolidayEve =
-        occasion.reasons.contains(DrinkOccasionReason.holidayEve);
+    final isHolidayEve = occasion.reasons.contains(
+      DrinkOccasionReason.holidayEve,
+    );
     final badge = isHoliday ? '祝' : (isHolidayEve ? '祝前' : '');
 
     return Padding(
@@ -17027,10 +17029,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
               child: Text(
                 badge,
-                style: const TextStyle(
-                  fontSize: 10,
-                  color: Color(0xFFB91C1C),
-                ),
+                style: const TextStyle(fontSize: 10, color: Color(0xFFB91C1C)),
               ),
             ),
           ],
@@ -17348,9 +17347,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         )
                       : const Icon(Icons.add_task_outlined, size: 16),
                   label: Text(
-                    _developerIssuesBulkButtonLabel(
-                      issueableDeveloperRequests,
-                    ),
+                    _developerIssuesBulkButtonLabel(issueableDeveloperRequests),
                   ),
                 ),
             ],
@@ -17483,11 +17480,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     final existingIssuesByTitle = <String, Map<String, dynamic>>{};
     for (final request in report.developerRequests) {
-      final existing = _developerRequestExistingIssueResults[
-          _developerRequestIssueKey(request)];
+      final existing =
+          _developerRequestExistingIssueResults[_developerRequestIssueKey(
+        request,
+      )];
       if (existing != null) {
-        existingIssuesByTitle[request.title] =
-            Map<String, dynamic>.from(existing);
+        existingIssuesByTitle[request.title] = Map<String, dynamic>.from(
+          existing,
+        );
       }
     }
     final result = await _assetManagementAiSummaryService.generateSummary(
@@ -17679,9 +17679,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     ];
   }
 
-  bool _isAiGeneratedDeveloperRequest(
-    AssetManagementDeveloperRequest request,
-  ) {
+  bool _isAiGeneratedDeveloperRequest(AssetManagementDeveloperRequest request) {
     final aiRequests = _assetManagementAiSummaryResult?.aiDeveloperRequests ??
         const <AssetManagementDeveloperRequest>[];
     if (aiRequests.isEmpty) {
@@ -17938,11 +17936,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     if (candidates.isEmpty) {
       return const SizedBox.shrink();
     }
-    final validSelected = candidates.any(
-      (account) => account.id == _assetManagementMainAccountId,
-    )
-        ? _assetManagementMainAccountId
-        : null;
+    final validSelected =
+        candidates.any((account) => account.id == _assetManagementMainAccountId)
+            ? _assetManagementMainAccountId
+            : null;
     return Row(
       children: [
         Icon(
@@ -22481,9 +22478,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 削除した支払日上書きのトゥームストーン (#part293: MirrorTombstoneStore 3例目)。
   /// ミラー復元で「自動へ戻した支払日」が復活するのを防ぐ。
   static const MirrorTombstoneStore _debtOverrideTombstones =
-      MirrorTombstoneStore(
-    storageKey: 'debt_payment_day_override_deleted_v1',
-  );
+      MirrorTombstoneStore(storageKey: 'debt_payment_day_override_deleted_v1');
 
   void _setDebtPaymentDayOverride(AssetLiabilityDebtRow row, int? day) {
     setState(() {
@@ -22998,10 +22993,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _formatManagementYen(billing.billedAmount),
               style: const TextStyle(fontWeight: FontWeight.bold, height: 1.3),
             ),
-            const Text(
-              'リボ自動算出',
-              style: TextStyle(fontSize: 11, height: 1.3),
-            ),
+            const Text('リボ自動算出', style: TextStyle(fontSize: 11, height: 1.3)),
           ],
         ),
       );
@@ -23102,10 +23094,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       children: [
         SizedBox(
           width: 64,
-          child: Text(
-            label,
-            style: const TextStyle(fontSize: 11, height: 1.3),
-          ),
+          child: Text(label, style: const TextStyle(fontSize: 11, height: 1.3)),
         ),
         Expanded(
           child: TextFormField(

--- a/lib/services/asset_subscription_audit_catalog.dart
+++ b/lib/services/asset_subscription_audit_catalog.dart
@@ -65,7 +65,7 @@ class AssetSubscriptionAuditCatalog {
   static const List<SubscriptionAuditSource> manualSources =
       <SubscriptionAuditSource>[
     SubscriptionAuditSource(
-      id: 'apple_id',
+      id: appleSourceId,
       name: 'Apple (iOS) サブスク',
       kind: SubscriptionAuditSourceKind.manualCheck,
       checkSteps: <String>[
@@ -76,7 +76,7 @@ class AssetSubscriptionAuditCatalog {
       ],
     ),
     SubscriptionAuditSource(
-      id: 'au_kantan',
+      id: auKantanSourceId,
       name: 'auかんたん決済',
       kind: SubscriptionAuditSourceKind.manualCheck,
       checkSteps: <String>[
@@ -87,7 +87,7 @@ class AssetSubscriptionAuditCatalog {
       ],
     ),
     SubscriptionAuditSource(
-      id: 'google_play',
+      id: googlePlaySourceId,
       name: 'Google Play 定期購入',
       kind: SubscriptionAuditSourceKind.manualCheck,
       checkSteps: <String>[
@@ -109,6 +109,62 @@ class AssetSubscriptionAuditCatalog {
   /// 口座 ID からカード別ソースの安定 ID を作る。
   static String cardSourceId(String accountId) =>
       '$cardSourceIdPrefix$accountId';
+
+  /// 各 manual ソースの安定 ID (請求経路との対応に使う / リネーム不可)。
+  static const String appleSourceId = 'apple_id';
+  static const String googlePlaySourceId = 'google_play';
+  static const String auKantanSourceId = 'au_kantan';
+
+  /// サブスクの請求経路 → 対応する棚卸し manual ソース ID。direct は対応なし (null)。
+  static String? sourceIdForGateway(AssetSubscriptionBillingGateway gateway) {
+    switch (gateway) {
+      case AssetSubscriptionBillingGateway.direct:
+        return null;
+      case AssetSubscriptionBillingGateway.apple:
+        return appleSourceId;
+      case AssetSubscriptionBillingGateway.googlePlay:
+        return googlePlaySourceId;
+      case AssetSubscriptionBillingGateway.auKantan:
+        return auKantanSourceId;
+    }
+  }
+
+  /// 棚卸し manual ソース ID → 対応する請求経路 (登録ダイアログの既定経路に使う)。
+  static AssetSubscriptionBillingGateway? gatewayForSourceId(String sourceId) {
+    switch (sourceId) {
+      case appleSourceId:
+        return AssetSubscriptionBillingGateway.apple;
+      case googlePlaySourceId:
+        return AssetSubscriptionBillingGateway.googlePlay;
+      case auKantanSourceId:
+        return AssetSubscriptionBillingGateway.auKantan;
+      default:
+        return null;
+    }
+  }
+
+  /// 登録済みサブスク (請求経路 + 月額) を、経由ソース ID ごとに件数・合計額へ集計する
+  /// 純関数。direct (経由なし) は集計対象外。棚卸しで「Apple 経由の合計」を集約請求
+  /// (例 `APPLE.COM/BILL`) と突き合わせるための表示に使う。
+  static Map<String, ({int count, double total})> gatewayTotalsBySourceId({
+    required Iterable<
+            ({AssetSubscriptionBillingGateway gateway, double amount})>
+        subscriptions,
+  }) {
+    final result = <String, ({int count, double total})>{};
+    for (final sub in subscriptions) {
+      final sourceId = sourceIdForGateway(sub.gateway);
+      if (sourceId == null || sub.amount <= 0) {
+        continue;
+      }
+      final existing = result[sourceId];
+      result[sourceId] = (
+        count: (existing?.count ?? 0) + 1,
+        total: (existing?.total ?? 0) + sub.amount,
+      );
+    }
+    return result;
+  }
 
   /// 検出した定期支出 ([suggestedSourceNames] = 各検出の引落元口座名) を支払い元
   /// ソース ID ごとに集計する純関数。

--- a/lib/widgets/recurring_fixed_cost_editor_dialog.dart
+++ b/lib/widgets/recurring_fixed_cost_editor_dialog.dart
@@ -21,6 +21,8 @@ Future<AssetRecurringFixedCost?> showRecurringFixedCostEditor(
       const <RecurringFixedCostSourceOption>[],
   AssetRecurringFixedCostCategory category =
       AssetRecurringFixedCostCategory.utility,
+  AssetSubscriptionBillingGateway gateway =
+      AssetSubscriptionBillingGateway.direct,
 }) {
   return showDialog<AssetRecurringFixedCost>(
     context: context,
@@ -29,6 +31,7 @@ Future<AssetRecurringFixedCost?> showRecurringFixedCostEditor(
       prefill: prefill,
       sourceAccounts: sourceAccounts,
       category: category,
+      gateway: gateway,
     ),
   );
 }
@@ -42,6 +45,7 @@ class RecurringFixedCostEditorDialog extends StatefulWidget {
     this.prefill,
     this.sourceAccounts = const <RecurringFixedCostSourceOption>[],
     this.category = AssetRecurringFixedCostCategory.utility,
+    this.gateway = AssetSubscriptionBillingGateway.direct,
   });
 
   final AssetRecurringFixedCost? existing;
@@ -53,6 +57,10 @@ class RecurringFixedCostEditorDialog extends StatefulWidget {
   /// 区分の初期値 (固定費 / サブスク)。[existing]/[prefill] が区分を持つ場合は
   /// そちらを優先する (サブスクカードから「その他を追加」する際の既定値)。
   final AssetRecurringFixedCostCategory category;
+
+  /// 請求経路の初期値。棚卸しの Apple/au/Google 行から登録する際に既定を与える。
+  /// [existing]/[prefill] が経路を持つ場合はそちらを優先する。
+  final AssetSubscriptionBillingGateway gateway;
 
   @override
   State<RecurringFixedCostEditorDialog> createState() =>
@@ -67,6 +75,7 @@ class _RecurringFixedCostEditorDialogState
   late final TextEditingController _dayController;
   late AssetRecurringFixedCostCadence _cadence;
   late AssetRecurringFixedCostCategory _category;
+  late AssetSubscriptionBillingGateway _gateway;
   String? _sourceAccountId;
 
   @override
@@ -76,6 +85,7 @@ class _RecurringFixedCostEditorDialogState
     final initial = widget.existing ?? widget.prefill;
     // 区分は initial が持つ値を最優先し、無ければ呼び出し側が指定した既定を使う。
     _category = initial?.category ?? widget.category;
+    _gateway = initial?.billingGateway ?? widget.gateway;
     _nameController = TextEditingController(text: initial?.name ?? '');
     _amountController = TextEditingController(
       text: initial == null ? '' : initial.amount.toStringAsFixed(0),
@@ -112,6 +122,10 @@ class _RecurringFixedCostEditorDialogState
       cadence: _cadence,
       sourceAccountId: _sourceAccountId,
       category: _category,
+      // 請求経路は区分=サブスクのときだけ意味を持つ。固定費では direct に固定する。
+      billingGateway: _category == AssetRecurringFixedCostCategory.subscription
+          ? _gateway
+          : AssetSubscriptionBillingGateway.direct,
     );
     Navigator.of(context).pop(cost);
   }
@@ -122,6 +136,19 @@ class _RecurringFixedCostEditorDialogState
         return '定期固定費';
       case AssetRecurringFixedCostCategory.subscription:
         return 'サブスク';
+    }
+  }
+
+  static String gatewayLabel(AssetSubscriptionBillingGateway gateway) {
+    switch (gateway) {
+      case AssetSubscriptionBillingGateway.direct:
+        return '直接 (口座/カード)';
+      case AssetSubscriptionBillingGateway.apple:
+        return 'Apple (App Store)';
+      case AssetSubscriptionBillingGateway.googlePlay:
+        return 'Google Play';
+      case AssetSubscriptionBillingGateway.auKantan:
+        return 'auかんたん決済';
     }
   }
 
@@ -215,14 +242,36 @@ class _RecurringFixedCostEditorDialogState
                   }
                 },
               ),
+              if (_category ==
+                  AssetRecurringFixedCostCategory.subscription) ...[
+                const SizedBox(height: 8),
+                DropdownButtonFormField<AssetSubscriptionBillingGateway>(
+                  initialValue: _gateway,
+                  decoration: const InputDecoration(
+                    labelText: '請求経路',
+                    helperText: 'Apple/Google/au 経由は明細に集約名義で出ます',
+                  ),
+                  items: [
+                    for (final gateway
+                        in AssetSubscriptionBillingGateway.values)
+                      DropdownMenuItem<AssetSubscriptionBillingGateway>(
+                        value: gateway,
+                        child: Text(gatewayLabel(gateway)),
+                      ),
+                  ],
+                  onChanged: (value) {
+                    if (value != null) {
+                      setState(() => _gateway = value);
+                    }
+                  },
+                ),
+              ],
               const SizedBox(height: 8),
               DropdownButtonFormField<String?>(
                 initialValue: _sourceAccountId,
                 decoration: const InputDecoration(labelText: '振替元 (任意)'),
                 items: [
-                  const DropdownMenuItem<String?>(
-                    child: Text('未設定'),
-                  ),
+                  const DropdownMenuItem<String?>(child: Text('未設定')),
                   for (final option in widget.sourceAccounts)
                     DropdownMenuItem<String?>(
                       value: option.id,
@@ -240,10 +289,7 @@ class _RecurringFixedCostEditorDialogState
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('キャンセル'),
         ),
-        FilledButton(
-          onPressed: _submit,
-          child: const Text('保存'),
-        ),
+        FilledButton(onPressed: _submit, child: const Text('保存')),
       ],
     );
   }

--- a/lib/widgets/subscription_audit_card.dart
+++ b/lib/widgets/subscription_audit_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 import '../services/asset_subscription_audit_catalog.dart';
 
@@ -30,6 +31,8 @@ class SubscriptionAuditCard extends StatelessWidget {
     required this.onMarkChecked,
     required this.onRegisterSubscription,
     this.unregisteredCountBySourceId = const <String, int>{},
+    this.registeredByGatewaySourceId =
+        const <String, ({int count, double total})>{},
     this.staleDays = AssetSubscriptionAuditCatalog.staleDays,
   });
 
@@ -41,6 +44,10 @@ class SubscriptionAuditCard extends StatelessWidget {
 
   /// autoAssisted ソースの未登録定期支出件数 (情報表示用)。
   final Map<String, int> unregisteredCountBySourceId;
+
+  /// manual ソース (Apple/au/Google) に登録済みのサブスク件数・月額合計。
+  /// 「この合計が明細の集約請求 (APPLE.COM/BILL 等) と一致するか」の突き合わせに使う。
+  final Map<String, ({int count, double total})> registeredByGatewaySourceId;
 
   /// ステータス判定の基準時刻 (テスト決定性のため注入)。
   final DateTime now;
@@ -160,6 +167,7 @@ class SubscriptionAuditCard extends StatelessWidget {
                   ),
                   unregisteredCount:
                       unregisteredCountBySourceId[source.id] ?? 0,
+                  registered: registeredByGatewaySourceId[source.id],
                   onMarkChecked: () => onMarkChecked(source),
                   onRegister: () => onRegisterSubscription(source),
                 ),
@@ -178,6 +186,7 @@ class _SourceTile extends StatelessWidget {
     required this.status,
     required this.statusLabel,
     required this.unregisteredCount,
+    required this.registered,
     required this.onMarkChecked,
     required this.onRegister,
   });
@@ -186,8 +195,13 @@ class _SourceTile extends StatelessWidget {
   final SubscriptionAuditStatus status;
   final String statusLabel;
   final int unregisteredCount;
+
+  /// この manual ソースに登録済みのサブスク件数・月額合計 (無ければ null)。
+  final ({int count, double total})? registered;
   final VoidCallback onMarkChecked;
   final VoidCallback onRegister;
+
+  static final NumberFormat _yen = NumberFormat('#,###');
 
   Color _statusColor(ColorScheme scheme) {
     switch (status) {
@@ -265,6 +279,17 @@ class _SourceTile extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           header,
+          if (isManual && registered != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                '登録済み ${registered!.count}件 / 月 ¥${_yen.format(registered!.total)}'
+                ' — 明細の集約請求 (例 APPLE.COM/BILL) と一致するか確認',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+              ),
+            ),
           if (isManual && source.checkSteps.isNotEmpty)
             Theme(
               // ExpansionTile の区切り線を消してリスト内に馴染ませる。

--- a/lib/widgets/subscription_fixed_cost_card.dart
+++ b/lib/widgets/subscription_fixed_cost_card.dart
@@ -43,9 +43,26 @@ class SubscriptionFixedCostCard extends StatelessWidget {
   static String _normalize(String value) =>
       value.replaceAll(RegExp(r'\s+'), '').toLowerCase();
 
-  /// サブタイトルは定期固定費カードと同じ表記を共有する。
-  String _subtitle(AssetRecurringFixedCost cost) =>
-      RecurringFixedCostCard.subtitleFor(cost, sourceAccountNames);
+  /// サブタイトルは定期固定費カードの表記に、請求経路 (Apple/Google/au 経由) を付す。
+  String _subtitle(AssetRecurringFixedCost cost) {
+    final base = RecurringFixedCostCard.subtitleFor(cost, sourceAccountNames);
+    final gateway = gatewayLabel(cost.billingGateway);
+    return gateway == null ? base : '$base・$gateway経由';
+  }
+
+  /// 請求経路の短いラベル。direct (経由なし) は null。
+  static String? gatewayLabel(AssetSubscriptionBillingGateway gateway) {
+    switch (gateway) {
+      case AssetSubscriptionBillingGateway.direct:
+        return null;
+      case AssetSubscriptionBillingGateway.apple:
+        return 'Apple';
+      case AssetSubscriptionBillingGateway.googlePlay:
+        return 'Google Play';
+      case AssetSubscriptionBillingGateway.auKantan:
+        return 'auかんたん決済';
+    }
+  }
 
   /// 既に登録済み (正規化した名前が一致) のプリセットは候補から除く。
   ///

--- a/test/services/asset_recurring_fixed_cost_store_test.dart
+++ b/test/services/asset_recurring_fixed_cost_store_test.dart
@@ -124,6 +124,58 @@ void main() {
       expect(updated.name, 'Notion');
       expect(updated.amount, 1650);
     });
+
+    test('billingGateway defaults to direct and is omitted from json', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'a',
+        name: '電気代',
+        amount: 8000,
+        paymentDay: 27,
+      );
+      expect(cost.billingGateway, AssetSubscriptionBillingGateway.direct);
+      expect(cost.toJson().containsKey('billingGateway'), isFalse);
+    });
+
+    test('apple gateway round-trips through json', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'sub_chatgpt',
+        name: 'ChatGPT Pro',
+        amount: 30000,
+        paymentDay: 20,
+        category: AssetRecurringFixedCostCategory.subscription,
+        billingGateway: AssetSubscriptionBillingGateway.apple,
+      );
+      final json = cost.toJson();
+      expect(json['billingGateway'], 'apple');
+      final restored = AssetRecurringFixedCost.fromJson('sub_chatgpt', json);
+      expect(restored!.billingGateway, AssetSubscriptionBillingGateway.apple);
+    });
+
+    test('fromJson without/unknown gateway falls back to direct (back-compat)',
+        () {
+      final noKey = AssetRecurringFixedCost.fromJson('x', _validJson());
+      expect(noKey!.billingGateway, AssetSubscriptionBillingGateway.direct);
+      final weird = AssetRecurringFixedCost.fromJson(
+        'x',
+        {..._validJson(), 'billingGateway': 'weird'},
+      );
+      expect(weird!.billingGateway, AssetSubscriptionBillingGateway.direct);
+    });
+
+    test('copyWith updates billingGateway', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'a',
+        name: 'iCloud+',
+        amount: 1500,
+        paymentDay: 20,
+        category: AssetRecurringFixedCostCategory.subscription,
+      );
+      final updated = cost.copyWith(
+        billingGateway: AssetSubscriptionBillingGateway.apple,
+      );
+      expect(updated.billingGateway, AssetSubscriptionBillingGateway.apple);
+      expect(updated.name, 'iCloud+');
+    });
   });
 
   group('AssetRecurringFixedCostStore category', () {

--- a/test/services/asset_subscription_audit_catalog_test.dart
+++ b/test/services/asset_subscription_audit_catalog_test.dart
@@ -108,4 +108,94 @@ void main() {
       );
     });
   });
+
+  group('AssetSubscriptionAuditCatalog gateway mapping', () {
+    test('sourceIdForGateway maps non-direct gateways to manual source ids',
+        () {
+      expect(
+        AssetSubscriptionAuditCatalog.sourceIdForGateway(
+          AssetSubscriptionBillingGateway.direct,
+        ),
+        isNull,
+      );
+      expect(
+        AssetSubscriptionAuditCatalog.sourceIdForGateway(
+          AssetSubscriptionBillingGateway.apple,
+        ),
+        AssetSubscriptionAuditCatalog.appleSourceId,
+      );
+      expect(
+        AssetSubscriptionAuditCatalog.sourceIdForGateway(
+          AssetSubscriptionBillingGateway.googlePlay,
+        ),
+        AssetSubscriptionAuditCatalog.googlePlaySourceId,
+      );
+      expect(
+        AssetSubscriptionAuditCatalog.sourceIdForGateway(
+          AssetSubscriptionBillingGateway.auKantan,
+        ),
+        AssetSubscriptionAuditCatalog.auKantanSourceId,
+      );
+    });
+
+    test('gatewayForSourceId is the inverse and null for unknown/bank', () {
+      expect(
+        AssetSubscriptionAuditCatalog.gatewayForSourceId(
+          AssetSubscriptionAuditCatalog.appleSourceId,
+        ),
+        AssetSubscriptionBillingGateway.apple,
+      );
+      expect(
+        AssetSubscriptionAuditCatalog.gatewayForSourceId(
+          AssetSubscriptionAuditCatalog.bankSourceId,
+        ),
+        isNull,
+      );
+      expect(
+        AssetSubscriptionAuditCatalog.gatewayForSourceId('card_aupay'),
+        isNull,
+      );
+    });
+
+    test('manual source ids align with the gateway mapping constants', () {
+      // カタログ定義の id と経路マッピングが drift しないことを pin。
+      final manualIds =
+          AssetSubscriptionAuditCatalog.manualSources.map((s) => s.id).toSet();
+      expect(manualIds, contains(AssetSubscriptionAuditCatalog.appleSourceId));
+      expect(
+        manualIds,
+        contains(AssetSubscriptionAuditCatalog.googlePlaySourceId),
+      );
+      expect(
+        manualIds,
+        contains(AssetSubscriptionAuditCatalog.auKantanSourceId),
+      );
+    });
+
+    test('gatewayTotalsBySourceId sums by gateway, excludes direct & non-pos',
+        () {
+      final totals = AssetSubscriptionAuditCatalog.gatewayTotalsBySourceId(
+        subscriptions: const <({
+          AssetSubscriptionBillingGateway gateway,
+          double amount,
+        })>[
+          (gateway: AssetSubscriptionBillingGateway.apple, amount: 30000),
+          (gateway: AssetSubscriptionBillingGateway.apple, amount: 1500),
+          (gateway: AssetSubscriptionBillingGateway.apple, amount: 980),
+          (gateway: AssetSubscriptionBillingGateway.googlePlay, amount: 1200),
+          (gateway: AssetSubscriptionBillingGateway.direct, amount: 3000),
+          (gateway: AssetSubscriptionBillingGateway.apple, amount: 0),
+        ],
+      );
+      final apple = totals[AssetSubscriptionAuditCatalog.appleSourceId];
+      expect(apple?.count, 3);
+      expect(apple?.total, 32480);
+      expect(
+        totals[AssetSubscriptionAuditCatalog.googlePlaySourceId]?.count,
+        1,
+      );
+      // direct と 0円 は集計対象外。Apple と Google の 2 ソースのみ。
+      expect(totals.length, 2);
+    });
+  });
 }

--- a/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
+++ b/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
@@ -203,4 +203,100 @@ void main() {
     expect(saved!.name, 'Cursor');
     expect(saved!.category, AssetRecurringFixedCostCategory.subscription);
   });
+
+  testWidgets('請求経路ドロップダウンはサブスク時に表示され apple を保存できる', (
+    tester,
+  ) async {
+    AssetRecurringFixedCost? saved;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                saved = await showRecurringFixedCostEditor(
+                  context,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                  gateway: AssetSubscriptionBillingGateway.apple,
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    // 請求経路ドロップダウンが表示される (Apple 既定)。
+    expect(find.text('請求経路'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField).at(0), 'ChatGPT Pro');
+    await tester.enterText(find.byType(TextFormField).at(1), '30000');
+    await tester.enterText(find.byType(TextFormField).at(2), '20');
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+
+    expect(saved!.billingGateway, AssetSubscriptionBillingGateway.apple);
+  });
+
+  testWidgets('請求経路ドロップダウンは固定費(utility)では非表示', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: RecurringFixedCostEditorDialog()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('請求経路'), findsNothing);
+  });
+
+  testWidgets('サブスク→固定費へ区分変更すると請求経路は direct に戻して保存される', (
+    tester,
+  ) async {
+    const existing = AssetRecurringFixedCost(
+      id: 'sub_x',
+      name: 'X Premium',
+      amount: 980,
+      paymentDay: 20,
+      category: AssetRecurringFixedCostCategory.subscription,
+      billingGateway: AssetSubscriptionBillingGateway.apple,
+    );
+    AssetRecurringFixedCost? saved;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                saved = await showRecurringFixedCostEditor(
+                  context,
+                  existing: existing,
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    // 区分を「定期固定費」へ切り替える。
+    await tester.tap(
+      find.byType(DropdownButtonFormField<AssetRecurringFixedCostCategory>),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('定期固定費').last);
+    await tester.pumpAndSettle();
+    // 区分=utility になり請求経路ドロップダウンは消える。
+    expect(find.text('請求経路'), findsNothing);
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+
+    expect(saved, isNotNull);
+    expect(saved!.category, AssetRecurringFixedCostCategory.utility);
+    expect(saved!.billingGateway, AssetSubscriptionBillingGateway.direct);
+  });
 }

--- a/test/widgets/subscription_audit_card_test.dart
+++ b/test/widgets/subscription_audit_card_test.dart
@@ -54,6 +54,8 @@ void main() {
   Widget host({
     Map<String, DateTime> lastCheckedAt = const <String, DateTime>{},
     Map<String, int> counts = const <String, int>{},
+    Map<String, ({int count, double total})> registered =
+        const <String, ({int count, double total})>{},
     required void Function(SubscriptionAuditSource) onMarkChecked,
     required void Function(SubscriptionAuditSource) onRegister,
   }) {
@@ -64,6 +66,7 @@ void main() {
             sources: const <SubscriptionAuditSource>[appleSource, cardSource],
             lastCheckedAt: lastCheckedAt,
             unregisteredCountBySourceId: counts,
+            registeredByGatewaySourceId: registered,
             now: now,
             onMarkChecked: onMarkChecked,
             onRegisterSubscription: onRegister,
@@ -129,5 +132,24 @@ void main() {
     expect(find.textContaining('確認済み (3日前)'), findsOneWidget);
     // 全ソース確認済み (staleDays 以内) → 要確認バッジ無し。
     expect(find.textContaining('要確認'), findsNothing);
+  });
+
+  testWidgets('manual row shows the gateway reconciliation total', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        registered: const <String, ({int count, double total})>{
+          'apple_id': (count: 3, total: 32480),
+        },
+        onMarkChecked: (_) {},
+        onRegister: (_) {},
+      ),
+    );
+
+    // Apple 行に「登録済み 3件 / 月 ¥32,480 ... 一致するか確認」が出る。
+    expect(find.textContaining('登録済み 3件'), findsOneWidget);
+    expect(find.textContaining('¥32,480'), findsOneWidget);
+    expect(find.textContaining('APPLE.COM/BILL'), findsOneWidget);
   });
 }

--- a/test/widgets/subscription_fixed_cost_card_test.dart
+++ b/test/widgets/subscription_fixed_cost_card_test.dart
@@ -140,5 +140,35 @@ void main() {
       await tester.tap(find.byTooltip('Anthropic (Claude) を削除'));
       expect(deleted?.id, 'sub_claude');
     });
+
+    testWidgets('shows the billing gateway suffix for Apple-billed subs',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SubscriptionFixedCostCard(
+              costs: const <AssetRecurringFixedCost>[
+                AssetRecurringFixedCost(
+                  id: 'sub_chatgpt',
+                  name: 'ChatGPT Pro',
+                  amount: 30000,
+                  paymentDay: 20,
+                  category: AssetRecurringFixedCostCategory.subscription,
+                  billingGateway: AssetSubscriptionBillingGateway.apple,
+                ),
+              ],
+              sourceAccountNames: const <String, String>{},
+              presets: presets,
+              onAddPreset: (_) {},
+              onAddCustom: () {},
+              onEdit: (_) {},
+              onDelete: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.textContaining('Apple経由'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## 概要

サブスクの**多段課金チェーン**（例: ChatGPT Pro → Apple App Store → Apple ID の支払い方法 → ファミペイカード）に対応します。集約ゲートウェイ (Apple/Google/au) 経由のサブスクはカード明細に `APPLE.COM/BILL` 等の**集約名義**でしか出ないため、サービス名では現れません。**請求経路**を記録し、棚卸しで経路ごとの合計を集約請求と突き合わせられるようにします。先の [PR #3519](https://github.com/kanta13jp1/my_web_app/pull/3519) / [PR #3526](https://github.com/kanta13jp1/my_web_app/pull/3526) の続き。

## 解決する課題

これまで `AssetRecurringFixedCost` は引落元 (`sourceAccountId`) を1つしか持たず、「サービス → ゲートウェイ → カード」の多段を表現できませんでした。そのため棚卸しの Apple 行は「内訳不明」のままで、明細の `APPLE.COM/BILL` が何の合計か照合できませんでした。

## 変更点（11ファイル / +569行）

- **モデル**: `AssetRecurringFixedCost.billingGateway`（`direct` 既定 / `apple` / `googlePlay` / `auKantan`）。`direct` 時は JSON 非出力で**後方互換**。固定費(utility)では `direct` 固定（区分をサブスク→固定費へ戻すと自動で direct）。資金繰りの計上額には**影響しない**（表示・突き合わせ専用）。
- **編集ダイアログ**: 「請求経路」ドロップダウン（区分=サブスク時のみ表示）。棚卸し各行からの登録時は経路を既定で合わせる。
- **サブスクカード**: 「Apple経由」等のサフィックス表示（a11y ラベルにも反映）。
- **棚卸し突き合わせ**（肝）: Apple/au/Google 行に「**登録済み N件 / 月 ¥X — 明細の集約請求 (APPLE.COM/BILL) と一致するか確認**」。ChatGPT + iCloud+ + X Premium を「Apple経由」で登録すれば、合計を実際の請求一本と照合できます。`gatewayTotalsBySourceId` 純関数で集計。

## 設計判断

- 請求経路は**区分=サブスクのときだけ**意味を持つ（utility では direct 固定）。
- ゲートウェイ↔棚卸しソースの対応 (`sourceIdForGateway`/`gatewayForSourceId`) を双方向の純関数で定義し、カタログ定義の id と drift しないようテストで pin。

## レビュー（多エージェント敵対レビュー / 4次元）

- **確定 0件**。dismissed 2件（いずれもテスト網羅の観察で挙動欠陥なし）のうち提案された「区分切替の force-direct」テストは追加採用、stale な保存形 doc コメントも更新。

## 検証

- `flutter analyze`（**lib と test 全ファイル**）: No issues found。
- `dart format`: クリーン。
- `flutter test`: 経路 round-trip/後方互換・突き合わせ合計の純関数・編集ダイアログ(経路選択/utility 非表示/force-direct)・サブスクカードのサフィックス・棚卸し突き合わせ行・既存 smoke = **全 96 green**。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Additive model field + UI/reconciliation covered by 96 widget+unit+smoke tests (gateway round-trip/back-compat, totals pure-fn, editor force-direct, audit line); reuses existing recurring-fixed-cost flow, no new e2e route

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive presentational field under lib/models,lib/widgets,lib/services (not lib/subscription); no auth/billing/RLS/deploy/migration; billingGateway does not affect cashflow; verified analyze+format clean, 96 tests, 4-dimension adversarial review (0 confirmed findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
