### PR TITLE
fix(asset): サブスクの振替元にカード (ファミペイ等) を選べるように

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -8901,10 +8901,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Widget _buildSubscriptionAuditCard(AssetLiabilityWorkbook? workbook) {
     final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
-    final sourceOptions = <RecurringFixedCostSourceOption>[
-      for (final account in accounts)
-        if (account.balance > 0) (id: account.id, name: account.name),
-    ];
+    // サブスクはカード (ファミペイ等) へ請求されることが多いため、残高<=0 のカードも
+    // 請求先として選べるようにする。
+    final sourceOptions =
+        recurringFixedCostSourceOptions(accounts, includeCards: true);
     final gatewayTotals = AssetSubscriptionAuditCatalog.gatewayTotalsBySourceId(
       subscriptions: [
         for (final cost in _recurringFixedCosts)
@@ -9287,10 +9287,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Widget _buildRecurringFixedCostCard(AssetLiabilityWorkbook? workbook) {
     final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
-    final sourceOptions = <RecurringFixedCostSourceOption>[
-      for (final account in accounts)
-        if (account.balance > 0) (id: account.id, name: account.name),
-    ];
+    final sourceOptions = recurringFixedCostSourceOptions(accounts);
     final sourceNames = <String, String>{
       for (final account in accounts) account.id: account.name,
     };
@@ -9317,10 +9314,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Widget _buildSubscriptionFixedCostCard(AssetLiabilityWorkbook? workbook) {
     final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
-    final sourceOptions = <RecurringFixedCostSourceOption>[
-      for (final account in accounts)
-        if (account.balance > 0) (id: account.id, name: account.name),
-    ];
+    // サブスクはカード (ファミペイ等) へ請求されることが多いため、残高<=0 のカードも
+    // 請求先として選べるようにする。
+    final sourceOptions =
+        recurringFixedCostSourceOptions(accounts, includeCards: true);
     final sourceNames = <String, String>{
       for (final account in accounts) account.id: account.name,
     };
@@ -9468,10 +9465,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     AssetLiabilityWorkbook? workbook,
   ) {
     final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
-    final sourceOptions = <RecurringFixedCostSourceOption>[
-      for (final account in accounts)
-        if (account.balance > 0) (id: account.id, name: account.name),
-    ];
+    final sourceOptions = recurringFixedCostSourceOptions(accounts);
     return AssetRecurringTransactionSuggestionCard(
       suggestions: _detectRecurringTransactions(),
       currencyFormatter: _formatYen,

--- a/lib/widgets/recurring_fixed_cost_editor_dialog.dart
+++ b/lib/widgets/recurring_fixed_cost_editor_dialog.dart
@@ -7,6 +7,25 @@ import 'recurring_fixed_cost_card.dart';
 /// 振替元ドロップダウンに渡す口座 (ID + 表示名)。
 typedef RecurringFixedCostSourceOption = ({String id, String name});
 
+/// 振替元/請求先に選べる口座を組み立てる。
+///
+/// 既定は資産口座 (残高>0) のみ。サブスク等カードへ請求される費用では
+/// [includeCards] = true で**残高の符号によらず**クレジット/プリペイドカード
+/// (例: ファミペイ バーチャルカード) も含める。FamiPay は後払い/残高0だと
+/// `balance > 0` だけのフィルタでは選べないため、請求先カードとして拾えるようにする。
+List<RecurringFixedCostSourceOption> recurringFixedCostSourceOptions(
+  Iterable<AssetLiabilityAccount> accounts, {
+  bool includeCards = false,
+}) {
+  return <RecurringFixedCostSourceOption>[
+    for (final account in accounts)
+      if (account.balance > 0 ||
+          (includeCards &&
+              account.kind == AssetLiabilityAccountKind.creditCard))
+        (id: account.id, name: account.name),
+  ];
+}
+
 /// 定期固定費の追加/編集ダイアログを開き、保存された [AssetRecurringFixedCost] を返す。
 /// キャンセル時は null。
 ///

--- a/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
+++ b/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
@@ -4,6 +4,51 @@ import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
 
 void main() {
+  group('recurringFixedCostSourceOptions', () {
+    AssetLiabilityAccount acct(
+      String id,
+      String name,
+      AssetLiabilityAccountKind kind,
+      double balance,
+    ) {
+      return AssetLiabilityAccount(
+        id: id,
+        name: name,
+        kind: kind,
+        balance: balance,
+      );
+    }
+
+    final accounts = <AssetLiabilityAccount>[
+      acct('smbc', '三井住友銀行', AssetLiabilityAccountKind.deposit, 100000),
+      acct('aupay', 'auPayカード', AssetLiabilityAccountKind.creditCard, 5000),
+      acct('famipay', 'ファミペイカード', AssetLiabilityAccountKind.creditCard, 0),
+      acct('mobit', 'モビット', AssetLiabilityAccountKind.cardLoan, -50000),
+    ];
+
+    test('default excludes non-positive cards (banks/positive cards only)', () {
+      final ids =
+          recurringFixedCostSourceOptions(accounts).map((o) => o.id).toList();
+      // 残高>0 の銀行と auPay は出る。残高0のファミペイと負債のモビットは出ない。
+      expect(ids, containsAll(<String>['smbc', 'aupay']));
+      expect(ids, isNot(contains('famipay')));
+      expect(ids, isNot(contains('mobit')));
+    });
+
+    test('includeCards surfaces zero/negative-balance credit cards', () {
+      final ids = recurringFixedCostSourceOptions(
+        accounts,
+        includeCards: true,
+      ).map((o) => o.id).toList();
+      // ファミペイ (creditCard / 残高0) が選べるようになる。
+      expect(ids, containsAll(<String>['smbc', 'aupay', 'famipay']));
+      // クレカでない負債 (cardLoan) は含めない。
+      expect(ids, isNot(contains('mobit')));
+      // 重複しない (auPay は1回だけ)。
+      expect(ids.where((id) => id == 'aupay').length, 1);
+    });
+  });
+
   const prefill = AssetRecurringFixedCost(
     id: 'fc_suggestion',
     name: '電気代',


### PR DESCRIPTION
## 概要

実機検証で、サブスク登録の「振替元」ドロップダウンに **ファミペイ（ファミペイ バーチャルカード）が出てこない**不具合を修正します。

## 原因

`振替元` の候補は**残高>0 の口座のみ**で組み立てていました。ファミペイは auPay/PayPay と同じ `creditCard` 分類ですが、auPay/PayPay は前払い残高が正なので候補に出る一方、ファミペイは後払い/残高0だと `balance > 0` で弾かれて選べませんでした。サブスクの請求先は多くがカード（Apple ID の支払い方法 = ファミペイ等）なので、カードを請求先として選べる必要があります。

## 変更点（3ファイル / +74-16）

- `recurringFixedCostSourceOptions(accounts, {includeCards})` を追加。`includeCards=true` で**残高の符号によらず**クレジット/プリペイドカードも候補に含める純関数。
- サブスクカード・棚卸しの登録は `includeCards=true`（カードを請求先に選べる）。従来の定期固定費・提案カードは挙動据え置き（`includeCards=false`）。
- `振替元`(sourceAccountId) は**表示属性のみ**で、資金繰りの計上額には影響しません（`planning_service` で payment source 名の解決にのみ使用）。

## 検証

- `flutter analyze`（変更3ファイル）: No issues found。
- `flutter test`: 新規ユニットテスト（カードの include/exclude を `includeCards` で検証）+ 既存の編集ダイアログ/スモーク = green。
- 注: ローカル dart 3.11.5 は CI(Flutter 3.38.10) と整形スタイルが異なるため、全体 `dart format` は行わず、CI と同じ整形スタイル（8 スペース継続）に手で揃えています。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Funding-source filter fix covered by unit test (recurringFixedCostSourceOptions: card include/exclude by includeCards) + existing editor/smoke tests; reuses existing recurring-fixed-cost flow, no new e2e route

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Display-only funding-source dropdown filter under lib/widgets,lib/pages (not lib/subscription); no auth/billing/RLS/deploy/migration; sourceAccountId is presentational and does not affect cashflow; verified analyze clean + unit/editor/smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
