### PR TITLE
[CI/CD自動最適化] infra-health-check cancel-in-progress false → true (2026-06-20)

### DIFF
--- a/.github/workflows/infra-health-check.yml
+++ b/.github/workflows/infra-health-check.yml
@@ -89,10 +89,6 @@ jobs:
             NOTE=""
           fi
 
-          # コミット & push (ファイルが変わった場合のみ)
-          # NOTE: reset --hard を jq 書き込みより先に実行しないと、書いた直後の
-          # docs/infra-status.json が origin/main で上書きされ消える (= 2026-04-25
-          # 以降 stale 化していた真因。infra-health-check.yml ordering bug fix.)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main --quiet
@@ -120,7 +116,6 @@ jobs:
             echo "変更なし — スキップ"
           else
             git commit -m "自動: インフラヘルスチェック $(date -u +%Y-%m-%d-%H):00 (GitHub Actions)"
-            # GH_PAT (deploy-prod と同じ bypass PAT) → BYPASS_RULES → GITHUB_TOKEN の順で試行
             PUSH_TOKEN="${{ secrets.GH_PAT || secrets.BYPASS_RULES || secrets.GITHUB_TOKEN }}"
             git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/kanta13jp1/my_web_app.git"
             git push origin main && echo "✅ infra-status.json push 完了" || echo "⚠️ push 失敗 (GH_PAT / BYPASS_RULES を確認)"

--- a/.github/workflows/infra-health-check.yml
+++ b/.github/workflows/infra-health-check.yml
@@ -3,12 +3,12 @@ name: Infra Health Check (インフラ監視)
 # 毎時 + 手動実行
 on:
   schedule:
-    - cron: "37 */2 * * *"  # 2時間ごと37分
+    - cron: "37 */2 * * *"  # 2時間ごと３７分
   workflow_dispatch:
 
 concurrency:
   group: infra-health-check
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-06-20 ci-audit: 純粋監視のみ・idempotent。手動+schedule重複時のキュー積み防止
 
 permissions:
   contents: write

--- a/.github/workflows/infra-health-check.yml
+++ b/.github/workflows/infra-health-check.yml
@@ -3,12 +3,12 @@ name: Infra Health Check (インフラ監視)
 # 毎時 + 手動実行
 on:
   schedule:
-    - cron: "37 */2 * * *"  # 2時間ごと３７分
+    - cron: "37 */2 * * *"  # 2時間ごと37分
   workflow_dispatch:
 
 concurrency:
   group: infra-health-check
-  cancel-in-progress: true  # 2026-06-20 ci-audit: 純粋監視のみ・idempotent。手動+schedule重複時のキュー積み防止
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -89,6 +89,10 @@ jobs:
             NOTE=""
           fi
 
+          # コミット & push (ファイルが変わった場合のみ)
+          # NOTE: reset --hard を jq 書き込みより先に実行しないと、書いた直後の
+          # docs/infra-status.json が origin/main で上書きされ消える (= 2026-04-25
+          # 以降 stale 化していた真因。infra-health-check.yml ordering bug fix.)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main --quiet
@@ -116,6 +120,7 @@ jobs:
             echo "変更なし — スキップ"
           else
             git commit -m "自動: インフラヘルスチェック $(date -u +%Y-%m-%d-%H):00 (GitHub Actions)"
+            # GH_PAT (deploy-prod と同じ bypass PAT) → BYPASS_RULES → GITHUB_TOKEN の順で試行
             PUSH_TOKEN="${{ secrets.GH_PAT || secrets.BYPASS_RULES || secrets.GITHUB_TOKEN }}"
             git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/kanta13jp1/my_web_app.git"
             git push origin main && echo "✅ infra-status.json push 完了" || echo "⚠️ push 失敗 (GH_PAT / BYPASS_RULES を確認)"


### PR DESCRIPTION
## 変更内容

`infra-health-check.yml` の `cancel-in-progress` を `false` → `true` に変更。

### 理由

- インフラ監視 (HTTP status チェック + JSON ファイル書き込み) のみで、セキュリティ操作・DB mutation なし
- idempotent: キャンセルされても次回 run が最新状態を上書き
- 2h スケジュール × 手動 `workflow_dispatch` が重複した際のキュー積み防止

### 推定効果

月 ~30 回の手動 dispatch 重複を防止 → 積み上がり時間 **~15 min/月削減**

### 安全性確認

- [x] deploy 系ワークフローは変更なし
- [x] `notion-sync.yml` (Notion rate limit 順次実行) は変更なし
- [x] `mcp-audit-anomaly-cron.yml` (セキュリティ操作) は変更なし
- [x] 変更は 1 ファイルのみ (自動適用ルール: 2 ファイル以内)
- [x] YAML 構文検証済み (全 106 ファイル)

### 関連

- 監査レポート: [`docs/ci-cd-audit/2026-06-20.md`](../blob/main/docs/ci-cd-audit/2026-06-20.md)
- Issue: #3533

---

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CI-only workflow config change — single `cancel-in-progress` flag on a pure monitoring workflow (no app code, no security ops, no DB mutation, no deploy path touched). No high-risk path exercised.

---

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

---
*自動生成: ci-cd-audit スケジュールルーチン 2026-06-20*