### PR TITLE
feat(asset): サブスクの重複(同一提供元の複数契約)を検出して注意喚起

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -46,6 +46,7 @@ import 'package:my_web_app/services/asset_recurring_suggestion_ignore_store.dart
 import 'package:my_web_app/services/asset_subscription_audit_catalog.dart';
 import 'package:my_web_app/services/asset_subscription_audit_store.dart';
 import 'package:my_web_app/services/asset_subscription_catalog.dart';
+import 'package:my_web_app/services/asset_subscription_duplicate_detector.dart';
 import 'package:my_web_app/services/asset_salary_day_store.dart';
 import 'package:my_web_app/services/asset_recurring_transaction_detector.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
@@ -82,6 +83,7 @@ import 'package:my_web_app/widgets/asset_category_budget_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
 import 'package:my_web_app/widgets/subscription_audit_card.dart';
+import 'package:my_web_app/widgets/subscription_duplicate_alert_card.dart';
 import 'package:my_web_app/widgets/subscription_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/asset_recurring_transaction_suggestion_card.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
@@ -448,6 +450,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Map<String, DateTime> _subscriptionAuditState = <String, DateTime>{};
   // 定期取引の自動検出で「無視」した正規化ラベル(再提案しない / 支出側)。
   Set<String> _ignoredRecurringLabels = <String>{};
+  Set<String> _ignoredDuplicateProviders = <String>{};
   // 定期入金の自動検出で「無視」した正規化ラベル(再提案しない / 収入側)。
   Set<String> _ignoredRecurringIncomeLabels = <String>{};
   // カテゴリ別 月次予算 (category -> 金額)。予算/カテゴリ予実カードで使用。
@@ -653,6 +656,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   );
   static const String _recurringIncomeIgnoredMirrorKey =
       'recurring_income_suggestion_ignored';
+  final AssetRecurringSuggestionIgnoreStore _duplicateIgnoreStore =
+      const AssetRecurringSuggestionIgnoreStore(
+    prefsKey: 'asset_subscription_duplicate_ignored_v1',
+  );
+  static const String _duplicateIgnoredMirrorKey =
+      'subscription_duplicate_ignored';
   final AssetCategoryBudgetStore _categoryBudgetStore =
       const AssetCategoryBudgetStore();
   // 禁酒で借金完済チャレンジの記録(日付→我慢/飲んだ)。v1 はローカル永続化のみ。
@@ -772,6 +781,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_loadSubscriptionAudit());
     unawaited(_loadRecurringIgnored());
     unawaited(_loadRecurringIncomeIgnored());
+    unawaited(_loadDuplicateIgnored());
     unawaited(_loadDrinkChallenge());
     _loadExpectedInflows();
     // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
@@ -8024,6 +8034,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             if (_isSectionShown(
               AssetManagementSectionId.subscriptionFixedCost,
             )) ...[
+              SubscriptionDuplicateAlertCard(
+                groups: _detectSubscriptionDuplicates(),
+                onIgnore: _ignoreDuplicateGroup,
+              ),
               _buildSubscriptionFixedCostCard(assetLiabilityWorkbook),
               const SizedBox(height: 16),
             ],
@@ -9104,6 +9118,107 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       'recurring ignored save',
     );
     unawaited(_mirrorRecurringIgnored());
+  }
+
+  /// 起動時に「重複ではない」とした提供元集合をローカルから読み、ミラーと union する。
+  Future<void> _loadDuplicateIgnored() async {
+    try {
+      final ignored = await _duplicateIgnoreStore.load();
+      if (mounted && ignored.isNotEmpty) {
+        setState(() => _ignoredDuplicateProviders = ignored);
+      }
+    } catch (e) {
+      debugPrint('Error loading duplicate ignored: $e');
+    }
+    await _restoreDuplicateIgnoredFromMirror();
+  }
+
+  /// サーバミラー (pref_key: subscription_duplicate_ignored) を取り込み、ローカル集合と
+  /// union する(無視は単調増加なので union が安全)。
+  Future<void> _restoreDuplicateIgnoredFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('pref_key', _duplicateIgnoredMirrorKey);
+      if (rows.isEmpty) {
+        return;
+      }
+      final serverIgnored =
+          AssetRecurringSuggestionIgnoreStore.decodeMirrorValue(
+        rows.first['value'],
+      );
+      if (!mounted || serverIgnored.isEmpty) {
+        return;
+      }
+      final merged = <String>{..._ignoredDuplicateProviders, ...serverIgnored};
+      if (merged.length == _ignoredDuplicateProviders.length) {
+        return; // サーバに新規無視なし。
+      }
+      setState(() => _ignoredDuplicateProviders = merged);
+      _persistInBackground(
+        _duplicateIgnoreStore.save(merged),
+        'duplicate ignored restore save',
+      );
+    } catch (e) {
+      debugPrint('duplicate ignored mirror restore failed: $e');
+    }
+  }
+
+  /// 「重複ではない」集合の全量を `asset_pref_mirror` へ 1 行 upsert する。
+  Future<void> _mirrorDuplicateIgnored() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _duplicateIgnoredMirrorKey,
+        'value': AssetRecurringSuggestionIgnoreStore.encodeMirrorValue(
+          _ignoredDuplicateProviders,
+        ),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('duplicate ignored mirror upsert failed: $e');
+    }
+  }
+
+  /// 提供元グループを「重複ではない」として今後の提示から除外する(永続化 + ミラー)。
+  void _ignoreDuplicateGroup(SubscriptionDuplicateGroup group) {
+    final key = group.providerKey;
+    if (key.isEmpty || _ignoredDuplicateProviders.contains(key)) {
+      return;
+    }
+    setState(() {
+      _ignoredDuplicateProviders = <String>{..._ignoredDuplicateProviders, key};
+    });
+    _persistInBackground(
+      _duplicateIgnoreStore.save(_ignoredDuplicateProviders),
+      'duplicate ignored save',
+    );
+    unawaited(_mirrorDuplicateIgnored());
+  }
+
+  /// 登録済みサブスクから「同じ提供元の複数契約 = 重複の可能性」を検出する。
+  List<SubscriptionDuplicateGroup> _detectSubscriptionDuplicates() {
+    return AssetSubscriptionDuplicateDetector.detect(
+      <SubscriptionDuplicateMember>[
+        for (final cost in _recurringFixedCosts)
+          if (cost.category == AssetRecurringFixedCostCategory.subscription)
+            (
+              id: cost.id,
+              name: cost.name,
+              amount: cost.amount,
+              gateway: cost.billingGateway,
+            ),
+      ],
+      ignoredProviderKeys: _ignoredDuplicateProviders,
+    );
   }
 
   /// 起動時に収入の「無視」集合をローカルから読み、サーバミラーと union する。

--- a/lib/services/asset_subscription_duplicate_detector.dart
+++ b/lib/services/asset_subscription_duplicate_detector.dart
@@ -1,0 +1,128 @@
+import '../models/asset_liability_workbook.dart';
+
+/// 重複候補グループ内の 1 サブスク。
+typedef SubscriptionDuplicateMember = ({
+  String id,
+  String name,
+  double amount,
+  AssetSubscriptionBillingGateway gateway,
+});
+
+/// 同じ提供元 (Google/Apple 等) に紐づく 2 件以上のサブスク群。
+/// 「内容が重複していないか確認」を促すための soft な提示で、確定的な重複判定ではない。
+class SubscriptionDuplicateGroup {
+  /// 提供元キー (正規化済み / 無視集合・テストの安定キー)。
+  final String providerKey;
+
+  /// 表示用の提供元名 (例: Google)。
+  final String providerLabel;
+
+  /// この提供元に該当した 2 件以上のサブスク (登録順)。
+  final List<SubscriptionDuplicateMember> members;
+
+  const SubscriptionDuplicateGroup({
+    required this.providerKey,
+    required this.providerLabel,
+    required this.members,
+  });
+
+  /// グループの月額合計。
+  double get totalAmount {
+    var sum = 0.0;
+    for (final member in members) {
+      sum += member.amount;
+    }
+    return sum;
+  }
+}
+
+/// 登録済みサブスクから「同じ提供元の複数契約 = プラン重複の可能性」を検出する純関数。
+///
+/// クラウドストレージ/AI など**プラン内包で重複が起きやすい提供元**に絞った keyword
+/// マッチで誤検出を抑える (例: Google AI Pro 5TB に Google One 100GB が内包される、
+/// Apple経由と直接で同種契約が二重、など)。名称に既知 keyword を含むものだけを提供元へ
+/// 寄せ、同一提供元に 2 件以上集まったらグループ化する。未知提供元は対象外。
+class AssetSubscriptionDuplicateDetector {
+  const AssetSubscriptionDuplicateDetector._();
+
+  /// (keyword, providerKey, providerLabel)。keyword は正規化 (小文字/空白除去) 後の
+  /// 部分一致。ストレージ/AI/生産性など重複が起きやすい提供元に限定し、'x'/'line' 等の
+  /// 過度に一般的な語や 'aws' のような短い部分一致 (「Lawson」に誤当たり) は入れない
+  /// (誤検出回避)。
+  static const List<(String, String, String)> _providers =
+      <(String, String, String)>[
+    ('google', 'google', 'Google'),
+    ('youtube', 'google', 'Google'),
+    ('gemini', 'google', 'Google'),
+    ('gcp', 'google', 'Google'),
+    ('icloud', 'apple', 'Apple'),
+    ('apple', 'apple', 'Apple'),
+    ('microsoft', 'microsoft', 'Microsoft'),
+    ('office365', 'microsoft', 'Microsoft'),
+    ('onedrive', 'microsoft', 'Microsoft'),
+    ('amazon', 'amazon', 'Amazon'),
+    ('primevideo', 'amazon', 'Amazon'),
+    ('kindle', 'amazon', 'Amazon'),
+    ('audible', 'amazon', 'Amazon'),
+    ('adobe', 'adobe', 'Adobe'),
+    ('creativecloud', 'adobe', 'Adobe'),
+    ('dropbox', 'dropbox', 'Dropbox'),
+    ('openai', 'openai', 'OpenAI'),
+    ('chatgpt', 'openai', 'OpenAI'),
+    ('anthropic', 'anthropic', 'Anthropic'),
+    ('claude', 'anthropic', 'Anthropic'),
+  ];
+
+  static String _normalize(String value) =>
+      value.toLowerCase().replaceAll(RegExp(r'\s+'), '');
+
+  /// 名称が該当する提供元 (キー + 表示名)。未知なら null。
+  static ({String key, String label})? providerFor(String name) {
+    final normalized = _normalize(name);
+    if (normalized.isEmpty) {
+      return null;
+    }
+    for (final provider in _providers) {
+      if (normalized.contains(provider.$1)) {
+        return (key: provider.$2, label: provider.$3);
+      }
+    }
+    return null;
+  }
+
+  /// 同一提供元に 2 件以上集まったサブスク群を返す。[ignoredProviderKeys] の提供元は除外。
+  /// グループは合計額の降順 (同額は提供元キー昇順) で安定ソートする。
+  static List<SubscriptionDuplicateGroup> detect(
+    Iterable<SubscriptionDuplicateMember> subscriptions, {
+    Set<String> ignoredProviderKeys = const <String>{},
+  }) {
+    final byKey = <String, SubscriptionDuplicateGroup>{};
+    for (final sub in subscriptions) {
+      final provider = providerFor(sub.name);
+      if (provider == null || ignoredProviderKeys.contains(provider.key)) {
+        continue;
+      }
+      final group = byKey.putIfAbsent(
+        provider.key,
+        () => SubscriptionDuplicateGroup(
+          providerKey: provider.key,
+          providerLabel: provider.label,
+          members: <SubscriptionDuplicateMember>[],
+        ),
+      );
+      group.members.add(sub);
+    }
+    final groups = <SubscriptionDuplicateGroup>[
+      for (final group in byKey.values)
+        if (group.members.length >= 2) group,
+    ];
+    groups.sort((a, b) {
+      final byTotal = b.totalAmount.compareTo(a.totalAmount);
+      if (byTotal != 0) {
+        return byTotal;
+      }
+      return a.providerKey.compareTo(b.providerKey);
+    });
+    return groups;
+  }
+}

--- a/lib/widgets/subscription_duplicate_alert_card.dart
+++ b/lib/widgets/subscription_duplicate_alert_card.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../services/asset_subscription_duplicate_detector.dart';
+import 'subscription_fixed_cost_card.dart';
+
+/// 「同じ提供元のサブスクが複数 = プラン重複の可能性」を提示する自己完結カード。
+///
+/// 確定的な重複判定ではなく「内容が重複していないか確認」を促す soft な注意喚起。
+/// 重複でなければ提供元ごとに「重複ではない (非表示)」で今後表示を止められる。状態・
+/// 永続化は資産管理ページが持ち、本ウィジェットは表示とコールバックのみを担う。
+/// 検出グループが空のときは何も描画しない (SizedBox.shrink)。
+class SubscriptionDuplicateAlertCard extends StatelessWidget {
+  const SubscriptionDuplicateAlertCard({
+    super.key,
+    required this.groups,
+    required this.onIgnore,
+  });
+
+  /// 検出された重複候補グループ (空なら非表示)。
+  final List<SubscriptionDuplicateGroup> groups;
+
+  /// 提供元グループを「重複ではない」として今後の提示から除外する。
+  final void Function(SubscriptionDuplicateGroup group) onIgnore;
+
+  static final NumberFormat _yen = NumberFormat('#,###');
+
+  String _memberLine(SubscriptionDuplicateMember member) {
+    final gateway = SubscriptionFixedCostCard.gatewayLabel(member.gateway);
+    final suffix = gateway == null ? '' : '・$gateway経由';
+    return '・${member.name} ¥${_yen.format(member.amount)}$suffix';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (groups.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Card(
+        color: scheme.errorContainer,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Icons.warning_amber_rounded,
+                    color: scheme.onErrorContainer,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '重複の可能性',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: scheme.onErrorContainer,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '同じ提供元のサブスクが複数あります。プランが内包・重複していないか確認して'
+                'ください (例: ストレージや AI プランの二重契約・別アカウントの契約)。',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onErrorContainer,
+                ),
+              ),
+              for (final group in groups)
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: Semantics(
+                    container: true,
+                    label: '${group.providerLabel} のサブスク '
+                        '${group.members.length}件、重複の可能性',
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '${group.providerLabel}（${group.members.length}件 / '
+                          '月 ¥${_yen.format(group.totalAmount)}）',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: scheme.onErrorContainer,
+                          ),
+                        ),
+                        for (final member in group.members)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 2),
+                            child: Text(
+                              _memberLine(member),
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: scheme.onErrorContainer,
+                              ),
+                            ),
+                          ),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: TextButton(
+                            onPressed: () => onIgnore(group),
+                            child: Text(
+                              '重複ではない (非表示)',
+                              // 各グループのボタンを読み上げで区別できるよう提供元名を付す。
+                              semanticsLabel:
+                                  '${group.providerLabel} は重複ではない (非表示)',
+                              style: TextStyle(color: scheme.onErrorContainer),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/asset_subscription_duplicate_detector_test.dart
+++ b/test/services/asset_subscription_duplicate_detector_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_subscription_duplicate_detector.dart';
+
+void main() {
+  // 短いラッパー (長い式の折返しを避け、formatter のバージョン差に依存しない形にする)。
+  String? keyOf(String name) {
+    return AssetSubscriptionDuplicateDetector.providerFor(name)?.key;
+  }
+
+  SubscriptionDuplicateMember member(
+    String id,
+    String name,
+    double amount, {
+    AssetSubscriptionBillingGateway gateway =
+        AssetSubscriptionBillingGateway.direct,
+  }) {
+    return (id: id, name: name, amount: amount, gateway: gateway);
+  }
+
+  group('AssetSubscriptionDuplicateDetector.providerFor', () {
+    test('maps known cloud/AI providers; unknown is null', () {
+      expect(keyOf('Google One 100GB'), 'google');
+      expect(keyOf('Google AI Pro 5TB'), 'google');
+      expect(keyOf('iCloud+ 2TB'), 'apple');
+      expect(keyOf('ChatGPT Pro 20x'), 'openai');
+      // 過度に一般的な語 (X / LINE / マネフォ) は提供元化しない (誤検出回避)。
+      expect(keyOf('X Premium'), isNull);
+      expect(keyOf('LINEスタンプ プレミアム'), isNull);
+      expect(keyOf('マネーフォワードME'), isNull);
+    });
+
+    test('short-substring keywords do not false-match (no aws→Lawson)', () {
+      // 'aws' のような短い部分一致は「Lawson」に誤当たりするため keyword に入れない。
+      expect(keyOf('Lawson'), isNull);
+    });
+
+    test('multi-word keywords match after whitespace collapse', () {
+      // 正規化で空白を除くため、複数語ブランドも部分一致する契約を pin。
+      expect(keyOf('Office 365'), 'microsoft');
+      expect(keyOf('Creative Cloud'), 'adobe');
+      expect(keyOf('Amazon Prime Video'), 'amazon');
+    });
+  });
+
+  group('AssetSubscriptionDuplicateDetector.detect', () {
+    test('flags the real Google One + Google AI Pro overlap', () {
+      final subs = <SubscriptionDuplicateMember>[
+        member(
+          'a',
+          'Google One 100GB',
+          290,
+          gateway: AssetSubscriptionBillingGateway.apple,
+        ),
+        member('b', 'Google AI Pro 5TB', 2900),
+        member(
+          'c',
+          'iCloud+ 2TB',
+          1500,
+          gateway: AssetSubscriptionBillingGateway.apple,
+        ),
+        member(
+          'd',
+          'ChatGPT Pro 20x',
+          30000,
+          gateway: AssetSubscriptionBillingGateway.apple,
+        ),
+      ];
+      final groups = AssetSubscriptionDuplicateDetector.detect(subs);
+      // Google だけが 2 件 → 1 グループ。iCloud/ChatGPT は単独なので対象外。
+      expect(groups.length, 1);
+      expect(groups.single.providerKey, 'google');
+      expect(groups.single.providerLabel, 'Google');
+      expect(groups.single.members.map((m) => m.id), <String>['a', 'b']);
+      expect(groups.single.totalAmount, 3190);
+    });
+
+    test('single subscription per provider yields no group', () {
+      final subs = <SubscriptionDuplicateMember>[
+        member('a', 'Google One 100GB', 290),
+        member('b', 'iCloud+ 2TB', 1500),
+      ];
+      expect(AssetSubscriptionDuplicateDetector.detect(subs), isEmpty);
+    });
+
+    test('ignoredProviderKeys suppresses the group', () {
+      final subs = <SubscriptionDuplicateMember>[
+        member('a', 'Google One 100GB', 290),
+        member('b', 'Google AI Pro 5TB', 2900),
+      ];
+      final groups = AssetSubscriptionDuplicateDetector.detect(
+        subs,
+        ignoredProviderKeys: const <String>{'google'},
+      );
+      expect(groups, isEmpty);
+    });
+
+    test('groups sort by total amount descending', () {
+      final subs = <SubscriptionDuplicateMember>[
+        member('a', 'Dropbox Plus', 1500),
+        member('b', 'Dropbox Family', 2000), // dropbox 合計 3500
+        member('c', 'Google One 100GB', 290),
+        member('d', 'Google AI Pro 5TB', 2900), // google 合計 3190
+      ];
+      final groups = AssetSubscriptionDuplicateDetector.detect(subs);
+      // 合計の降順: dropbox (3500) → google (3190)。
+      expect(groups.map((g) => g.providerKey), <String>['dropbox', 'google']);
+    });
+  });
+}

--- a/test/widgets/subscription_duplicate_alert_card_test.dart
+++ b/test/widgets/subscription_duplicate_alert_card_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_subscription_duplicate_detector.dart';
+import 'package:my_web_app/widgets/subscription_duplicate_alert_card.dart';
+
+void main() {
+  const googleGroup = SubscriptionDuplicateGroup(
+    providerKey: 'google',
+    providerLabel: 'Google',
+    members: <SubscriptionDuplicateMember>[
+      (
+        id: 'a',
+        name: 'Google One 100GB',
+        amount: 290,
+        gateway: AssetSubscriptionBillingGateway.apple,
+      ),
+      (
+        id: 'b',
+        name: 'Google AI Pro 5TB',
+        amount: 2900,
+        gateway: AssetSubscriptionBillingGateway.direct,
+      ),
+    ],
+  );
+
+  testWidgets('renders nothing when there are no groups', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SubscriptionDuplicateAlertCard(
+            groups: const <SubscriptionDuplicateGroup>[],
+            onIgnore: (_) {},
+          ),
+        ),
+      ),
+    );
+    expect(find.byType(Card), findsNothing);
+    expect(find.text('重複の可能性'), findsNothing);
+  });
+
+  testWidgets('renders groups with members + gateway and fires ignore',
+      (tester) async {
+    SubscriptionDuplicateGroup? ignored;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SubscriptionDuplicateAlertCard(
+            groups: const <SubscriptionDuplicateGroup>[googleGroup],
+            onIgnore: (group) => ignored = group,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('重複の可能性'), findsOneWidget);
+    expect(find.textContaining('Google（2件'), findsOneWidget);
+    // メンバーは金額 + 経路 (Apple経由) を表示。
+    expect(
+      find.textContaining('Google One 100GB ¥290・Apple経由'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Google AI Pro 5TB ¥2,900'), findsOneWidget);
+
+    await tester.tap(find.text('重複ではない (非表示)'));
+    expect(ignored?.providerKey, 'google');
+  });
+}


### PR DESCRIPTION
## 概要

サブスクの**重複（同一提供元の複数契約）を能動的に検出**して注意喚起します。実機の棚卸しで「別 Google アカウントの Google One 100GB（月¥290・Apple経由）が、Google AI Pro 5TB（直接）と二重契約だった」幽霊サブスクを発見した事例を機能化したものです。先の [#3519](https://github.com/kanta13jp1/my_web_app/pull/3519)/[#3526](https://github.com/kanta13jp1/my_web_app/pull/3526)/[#3530](https://github.com/kanta13jp1/my_web_app/pull/3530)/[#3531](https://github.com/kanta13jp1/my_web_app/pull/3531) の続き。

## 変更点（5ファイル / +575行）

- **検出器** `AssetSubscriptionDuplicateDetector`（純関数）: クラウド/ストレージ/AI など**プラン内包で重複が起きやすい提供元**に絞った keyword マッチで、同一提供元 2 件以上をグループ化。`X`/`LINE`/`マネフォ` 等の一般語や `aws`（「Lawson」に誤当たり）のような短い部分一致は**意図的に除外**して誤検出を抑制。
- **警告カード** `SubscriptionDuplicateAlertCard`: 提供元ごとに件数・月額合計・各サブスク（金額＋請求経路）を提示し、「**重複ではない (非表示)**」で提供元単位に除外可能。検出ゼロなら非表示。
- **「重複ではない」の永続化**: 既存 `AssetRecurringSuggestionIgnoreStore` を `prefsKey` 流用 + `asset_pref_mirror` へ union ミラー（単調増加で tombstone 不要）。資金繰りには**影響しません**（表示専用）。

これにより、例えば「Google が2件あります（One 100GB ¥290・Apple経由 / AI Pro 5TB ¥2,900）— 内容が内包・重複していないか確認」と能動的に指摘します。

## レビュー（多エージェント敵対レビュー / 4次元 → 確定5件すべて反映）

- （correctness）`aws` が「Lawson」に誤当たり → **`aws` keyword 削除**（Amazon は amazon/prime video/kindle/audible で網羅）+ `providerFor('Lawson')==null` 回帰テスト
- （correctness）`microsoft365` が `microsoft` に隠れて到達不能 → **削除**
- （a11y）警告アイコン色 `error`→`onErrorContainer`（M3 ペアリング統一）
- （a11y）グループ別「非表示」ボタンが同一ラベル → `semanticsLabel` に**提供元名を付与**して読み上げ区別
- （tests）複数語 keyword（Office 365 / Creative Cloud / Amazon Prime Video）の空白畳み込み未テスト → 回帰テスト追加

## 検証

- `flutter analyze`（**lib と test 全ファイル**）: No issues found。
- `flutter test`: 検出器（提供元マッピング/グループ化/無視/ソート/Lawson 非当たり/複数語）+ カード（空→非表示/表示+無視発火）+ 既存 smoke = **全 green**。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Pure detector + alert-card UI + ignore-sync covered by widget+unit+smoke tests (provider mapping, group >=2, ignore, sort, empty->shrink); reuses recurring-ignore mirror pattern, no new e2e route

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive detector/alert under lib/services,lib/widgets (not lib/subscription); no auth/billing/RLS/deploy/migration; ignore set reuses union-monotonic mirror; presentational only, no cashflow change; analyze+tests green, 4-dimension adversarial review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
