### PR TITLE
feat(asset): 棚卸しの「Apple経由」を請求先カード別に分解して突き合わせ

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -8958,6 +8958,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       lastCheckedAt: _subscriptionAuditState,
       unregisteredCountBySourceId: _unregisteredCountBySourceId(workbook),
       registeredByGatewaySourceId: gatewayTotals,
+      cardBreakdownBySourceId: _subscriptionGatewayCardBreakdown(accounts),
       now: _now,
       onMarkChecked: _markSubscriptionSourceChecked,
       onRegisterSubscription: (source) => unawaited(
@@ -8971,6 +8972,54 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       ),
     );
+  }
+
+  /// 登録済みサブスクを「経由ソース × 請求先カード」で集計し、カード名ラベルへ解決する。
+  /// 同じ Apple経由でも請求先カードが分かれる場合に、各カードの集約請求と突き合わせる。
+  Map<String, List<GatewayCardBreakdownLine>> _subscriptionGatewayCardBreakdown(
+      List<AssetLiabilityAccount> accounts) {
+    final accountNames = <String, String>{
+      for (final account in accounts) account.id: account.name,
+    };
+    final knownIds = accountNames.keys.toSet();
+    final inputs = <SubscriptionGatewayInput>[];
+    for (final cost in _recurringFixedCosts) {
+      if (cost.category != AssetRecurringFixedCostCategory.subscription) {
+        continue;
+      }
+      // 未知/削除済みカードは未設定 (null) へ寄せ、内訳の重複表示を防ぐ。
+      final fundingCard = AssetSubscriptionAuditCatalog.normalizeFundingCard(
+        cost.sourceAccountId,
+        knownIds,
+      );
+      inputs.add((
+        gateway: cost.billingGateway,
+        amount: cost.amount,
+        sourceAccountId: fundingCard,
+      ));
+    }
+    final raw = AssetSubscriptionAuditCatalog.gatewayCardBreakdownBySourceId(
+      subscriptions: inputs,
+    );
+    final result = <String, List<GatewayCardBreakdownLine>>{};
+    raw.forEach((sourceId, cards) {
+      result[sourceId] = <GatewayCardBreakdownLine>[
+        for (final card in cards)
+          (
+            label: _fundingCardLabel(card.fundingAccountId, accountNames),
+            count: card.count,
+            total: card.total,
+          ),
+      ];
+    });
+    return result;
+  }
+
+  String _fundingCardLabel(String? id, Map<String, String> accountNames) {
+    if (id == null) {
+      return '請求先カード未設定';
+    }
+    return accountNames[id] ?? '請求先カード未設定';
   }
 
   /// 削除した定期固定費のトゥームストーン。union マージ/backfill での復活を防ぎ、

--- a/lib/services/asset_subscription_audit_catalog.dart
+++ b/lib/services/asset_subscription_audit_catalog.dart
@@ -9,6 +9,22 @@ typedef SubscriptionAuditAccountView = ({
   AssetLiabilityAccountKind kind,
 });
 
+/// 経路ソース内の「請求先カード別」内訳 1 件。[fundingAccountId] が null のときは
+/// 請求先カード未設定 (どのカードに請求されるか未登録)。
+typedef GatewayCardTotal = ({
+  String? fundingAccountId,
+  int count,
+  double total,
+});
+
+/// [AssetSubscriptionAuditCatalog.gatewayCardBreakdownBySourceId] への入力 1 件
+/// (請求経路 + 月額 + 請求先カード ID)。
+typedef SubscriptionGatewayInput = ({
+  AssetSubscriptionBillingGateway gateway,
+  double amount,
+  String? sourceAccountId,
+});
+
 /// サブスク棚卸しで確認する「支払い元(ソース)」の種別。
 enum SubscriptionAuditSourceKind {
   /// アプリ側が個別サブスクを把握できない集約請求 (Apple/au/Google 等)。
@@ -164,6 +180,75 @@ class AssetSubscriptionAuditCatalog {
       );
     }
     return result;
+  }
+
+  /// 登録済みサブスクを「経由ソース × 請求先カード」で集計する純関数。
+  ///
+  /// 同じ Apple経由でもサブスクごとに請求先カードが分かれる場合 (例: ChatGPT は
+  /// ファミペイ・LINEスタンプは PayPay)、各カードの集約請求 (APPLE.COM/BILL) は
+  /// 別々に出る。経路ソース ID ごとに、請求先カード ([sourceAccountId]) 別の件数・
+  /// 合計を合計額の降順 (同額は accountId 昇順 / null は末尾) で返す。
+  static Map<String, List<GatewayCardTotal>> gatewayCardBreakdownBySourceId({
+    required Iterable<SubscriptionGatewayInput> subscriptions,
+  }) {
+    final byGateway = <String, Map<String?, ({int count, double total})>>{};
+    for (final sub in subscriptions) {
+      final sourceId = sourceIdForGateway(sub.gateway);
+      if (sourceId == null || sub.amount <= 0) {
+        continue;
+      }
+      final rawCard = sub.sourceAccountId;
+      final cardId = (rawCard == null || rawCard.isEmpty) ? null : rawCard;
+      final cards = byGateway.putIfAbsent(
+        sourceId,
+        () => <String?, ({int count, double total})>{},
+      );
+      final existing = cards[cardId];
+      cards[cardId] = (
+        count: (existing?.count ?? 0) + 1,
+        total: (existing?.total ?? 0) + sub.amount,
+      );
+    }
+    final result = <String, List<GatewayCardTotal>>{};
+    byGateway.forEach((sourceId, cards) {
+      final list = <GatewayCardTotal>[
+        for (final entry in cards.entries)
+          (
+            fundingAccountId: entry.key,
+            count: entry.value.count,
+            total: entry.value.total,
+          ),
+      ];
+      list.sort((a, b) {
+        final byTotal = b.total.compareTo(a.total);
+        if (byTotal != 0) {
+          return byTotal;
+        }
+        // null (未設定) は末尾へ。
+        if (a.fundingAccountId == null) {
+          return b.fundingAccountId == null ? 0 : 1;
+        }
+        if (b.fundingAccountId == null) {
+          return -1;
+        }
+        return a.fundingAccountId!.compareTo(b.fundingAccountId!);
+      });
+      result[sourceId] = list;
+    });
+    return result;
+  }
+
+  /// 請求先カード ID を「既知の口座だけ採用」に正規化する。null/空/未知 (削除済み口座等)
+  /// はすべて null (=請求先未設定) へ寄せる。これにより内訳で「未設定」が二重に出るのを
+  /// 防ぎ、未知 ID が単独グループとして見えるのを避ける。
+  static String? normalizeFundingCard(
+    String? sourceAccountId,
+    Set<String> knownAccountIds,
+  ) {
+    if (sourceAccountId == null || sourceAccountId.isEmpty) {
+      return null;
+    }
+    return knownAccountIds.contains(sourceAccountId) ? sourceAccountId : null;
   }
 
   /// 検出した定期支出 ([suggestedSourceNames] = 各検出の引落元口座名) を支払い元

--- a/lib/widgets/subscription_audit_card.dart
+++ b/lib/widgets/subscription_audit_card.dart
@@ -3,6 +3,9 @@ import 'package:intl/intl.dart';
 
 import '../services/asset_subscription_audit_catalog.dart';
 
+/// 棚卸しの請求先カード別内訳 1 行 (表示名 + 件数 + 月額合計)。
+typedef GatewayCardBreakdownLine = ({String label, int count, double total});
+
 /// サブスク棚卸しの確認状況。
 enum SubscriptionAuditStatus {
   /// 一度も確認していない。
@@ -33,6 +36,8 @@ class SubscriptionAuditCard extends StatelessWidget {
     this.unregisteredCountBySourceId = const <String, int>{},
     this.registeredByGatewaySourceId =
         const <String, ({int count, double total})>{},
+    this.cardBreakdownBySourceId =
+        const <String, List<GatewayCardBreakdownLine>>{},
     this.staleDays = AssetSubscriptionAuditCatalog.staleDays,
   });
 
@@ -48,6 +53,11 @@ class SubscriptionAuditCard extends StatelessWidget {
   /// manual ソース (Apple/au/Google) に登録済みのサブスク件数・月額合計。
   /// 「この合計が明細の集約請求 (APPLE.COM/BILL 等) と一致するか」の突き合わせに使う。
   final Map<String, ({int count, double total})> registeredByGatewaySourceId;
+
+  /// manual ソースの「請求先カード別」内訳 (ラベル + 件数 + 合計 / 合計降順)。
+  /// 同じ Apple経由でも請求先カードが 2 つ以上に分かれる場合だけ、各カードの集約請求
+  /// と突き合わせられるよう内訳行を出す (カードが 1 つなら合計行で十分なので出さない)。
+  final Map<String, List<GatewayCardBreakdownLine>> cardBreakdownBySourceId;
 
   /// ステータス判定の基準時刻 (テスト決定性のため注入)。
   final DateTime now;
@@ -168,6 +178,8 @@ class SubscriptionAuditCard extends StatelessWidget {
                   unregisteredCount:
                       unregisteredCountBySourceId[source.id] ?? 0,
                   registered: registeredByGatewaySourceId[source.id],
+                  cardBreakdown: cardBreakdownBySourceId[source.id] ??
+                      const <GatewayCardBreakdownLine>[],
                   onMarkChecked: () => onMarkChecked(source),
                   onRegister: () => onRegisterSubscription(source),
                 ),
@@ -187,6 +199,7 @@ class _SourceTile extends StatelessWidget {
     required this.statusLabel,
     required this.unregisteredCount,
     required this.registered,
+    required this.cardBreakdown,
     required this.onMarkChecked,
     required this.onRegister,
   });
@@ -198,6 +211,9 @@ class _SourceTile extends StatelessWidget {
 
   /// この manual ソースに登録済みのサブスク件数・月額合計 (無ければ null)。
   final ({int count, double total})? registered;
+
+  /// 請求先カード別の内訳 (合計降順)。2 件以上のときだけ内訳行を出す。
+  final List<GatewayCardBreakdownLine> cardBreakdown;
   final VoidCallback onMarkChecked;
   final VoidCallback onRegister;
 
@@ -290,6 +306,19 @@ class _SourceTile extends StatelessWidget {
                 ),
               ),
             ),
+          // 請求先カードが 2 つ以上に分かれる場合だけ、カード別の内訳を出す
+          // (各カードの集約請求と個別に突き合わせられるように)。
+          if (isManual && cardBreakdown.length >= 2)
+            for (final card in cardBreakdown)
+              Padding(
+                padding: const EdgeInsets.only(top: 2, left: 8),
+                child: Text(
+                  '・${card.label} ¥${_yen.format(card.total)}（${card.count}件）',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
           if (isManual && source.checkSteps.isNotEmpty)
             Theme(
               // ExpansionTile の区切り線を消してリスト内に馴染ませる。

--- a/test/services/asset_subscription_audit_catalog_test.dart
+++ b/test/services/asset_subscription_audit_catalog_test.dart
@@ -198,4 +198,99 @@ void main() {
       expect(totals.length, 2);
     });
   });
+
+  group('AssetSubscriptionAuditCatalog.gatewayCardBreakdownBySourceId', () {
+    SubscriptionGatewayInput sub(
+      AssetSubscriptionBillingGateway gateway,
+      double amount,
+      String? sourceAccountId,
+    ) {
+      return (
+        gateway: gateway,
+        amount: amount,
+        sourceAccountId: sourceAccountId,
+      );
+    }
+
+    test('splits an Apple gateway across funding cards, sorted by total', () {
+      final subs = <SubscriptionGatewayInput>[
+        sub(AssetSubscriptionBillingGateway.apple, 30000, 'famipay'),
+        sub(AssetSubscriptionBillingGateway.apple, 1500, 'famipay'),
+        sub(AssetSubscriptionBillingGateway.apple, 240, 'paypay'),
+        sub(AssetSubscriptionBillingGateway.apple, 590, 'paypay'),
+        sub(AssetSubscriptionBillingGateway.direct, 2900, 'paypay'),
+      ];
+      final breakdown =
+          AssetSubscriptionAuditCatalog.gatewayCardBreakdownBySourceId(
+        subscriptions: subs,
+      );
+      final apple = breakdown[AssetSubscriptionAuditCatalog.appleSourceId]!;
+      // ファミペイ (31,500) → PayPay (830) の降順。
+      final cardIds = apple.map((c) => c.fundingAccountId).toList();
+      expect(cardIds, <String?>['famipay', 'paypay']);
+      expect(apple[0].total, 31500);
+      expect(apple[0].count, 2);
+      expect(apple[1].total, 830);
+      // direct は対象外なので Apple ソースのみ。
+      expect(breakdown.length, 1);
+    });
+
+    test('unset funding card groups under null and sorts to the end', () {
+      final subs = <SubscriptionGatewayInput>[
+        sub(AssetSubscriptionBillingGateway.apple, 1000, null),
+        sub(AssetSubscriptionBillingGateway.apple, 5000, 'famipay'),
+        sub(AssetSubscriptionBillingGateway.apple, 200, ''),
+      ];
+      final breakdown =
+          AssetSubscriptionAuditCatalog.gatewayCardBreakdownBySourceId(
+        subscriptions: subs,
+      );
+      final apple = breakdown[AssetSubscriptionAuditCatalog.appleSourceId]!;
+      expect(apple.map((c) => c.fundingAccountId), <String?>['famipay', null]);
+      // null グループは 1000 + 200 (空文字も未設定扱い)。
+      expect(apple.last.fundingAccountId, isNull);
+      expect(apple.last.total, 1200);
+    });
+
+    test('normalizeFundingCard keeps known ids; unknown/empty/null → null', () {
+      const known = <String>{'famipay', 'paypay'};
+      final keep =
+          AssetSubscriptionAuditCatalog.normalizeFundingCard('famipay', known);
+      expect(keep, 'famipay');
+      expect(
+        AssetSubscriptionAuditCatalog.normalizeFundingCard('deleted', known),
+        isNull,
+      );
+      expect(
+        AssetSubscriptionAuditCatalog.normalizeFundingCard('', known),
+        isNull,
+      );
+      expect(
+        AssetSubscriptionAuditCatalog.normalizeFundingCard(null, known),
+        isNull,
+      );
+    });
+
+    test('unknown card ids merge into the unset group after normalize', () {
+      const known = <String>{'famipay'};
+      String? norm(String? id) {
+        return AssetSubscriptionAuditCatalog.normalizeFundingCard(id, known);
+      }
+
+      final subs = <SubscriptionGatewayInput>[
+        sub(AssetSubscriptionBillingGateway.apple, 1000, norm('deleted_card')),
+        sub(AssetSubscriptionBillingGateway.apple, 200, norm(null)),
+        sub(AssetSubscriptionBillingGateway.apple, 5000, norm('famipay')),
+      ];
+      final breakdown =
+          AssetSubscriptionAuditCatalog.gatewayCardBreakdownBySourceId(
+        subscriptions: subs,
+      );
+      final apple = breakdown[AssetSubscriptionAuditCatalog.appleSourceId]!;
+      // famipay (5000) と 未設定 (1000+200) の 2 グループ。削除済みは未設定へ統合。
+      expect(apple.length, 2);
+      expect(apple.last.fundingAccountId, isNull);
+      expect(apple.last.total, 1200);
+    });
+  });
 }

--- a/test/widgets/subscription_audit_card_test.dart
+++ b/test/widgets/subscription_audit_card_test.dart
@@ -56,6 +56,8 @@ void main() {
     Map<String, int> counts = const <String, int>{},
     Map<String, ({int count, double total})> registered =
         const <String, ({int count, double total})>{},
+    Map<String, List<GatewayCardBreakdownLine>> cardBreakdown =
+        const <String, List<GatewayCardBreakdownLine>>{},
     required void Function(SubscriptionAuditSource) onMarkChecked,
     required void Function(SubscriptionAuditSource) onRegister,
   }) {
@@ -67,6 +69,7 @@ void main() {
             lastCheckedAt: lastCheckedAt,
             unregisteredCountBySourceId: counts,
             registeredByGatewaySourceId: registered,
+            cardBreakdownBySourceId: cardBreakdown,
             now: now,
             onMarkChecked: onMarkChecked,
             onRegisterSubscription: onRegister,
@@ -151,5 +154,53 @@ void main() {
     expect(find.textContaining('登録済み 3件'), findsOneWidget);
     expect(find.textContaining('¥32,480'), findsOneWidget);
     expect(find.textContaining('APPLE.COM/BILL'), findsOneWidget);
+  });
+
+  testWidgets('manual row breaks down by funding card when 2+ cards', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        registered: const <String, ({int count, double total})>{
+          'apple_id': (count: 5, total: 33700),
+        },
+        cardBreakdown: const <String, List<GatewayCardBreakdownLine>>{
+          'apple_id': <GatewayCardBreakdownLine>[
+            (label: 'ファミペイ', count: 3, total: 32770),
+            (label: 'PayPayカード', count: 2, total: 930),
+          ],
+        },
+        onMarkChecked: (_) {},
+        onRegister: (_) {},
+      ),
+    );
+
+    // 合計行に加え、請求先カード別の内訳行が出る。
+    expect(find.textContaining('登録済み 5件'), findsOneWidget);
+    expect(find.textContaining('・ファミペイ ¥32,770（3件）'), findsOneWidget);
+    expect(find.textContaining('・PayPayカード ¥930（2件）'), findsOneWidget);
+  });
+
+  testWidgets('single funding card shows no per-card breakdown', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        registered: const <String, ({int count, double total})>{
+          'apple_id': (count: 3, total: 32770),
+        },
+        cardBreakdown: const <String, List<GatewayCardBreakdownLine>>{
+          'apple_id': <GatewayCardBreakdownLine>[
+            (label: 'ファミペイ', count: 3, total: 32770),
+          ],
+        },
+        onMarkChecked: (_) {},
+        onRegister: (_) {},
+      ),
+    );
+
+    // カードが 1 つなら内訳行は出さない (合計行で十分)。
+    expect(find.textContaining('登録済み 3件'), findsOneWidget);
+    expect(find.textContaining('・ファミペイ'), findsNothing);
   });
 }


### PR DESCRIPTION
## 概要

棚卸しの「Apple経由 合計」を**請求先カード別に分解**します。実機調査で判明したとおり、同じ Apple経由でもサブスクごとに請求先カードが分かれます(ChatGPT/iCloud+/X Premium → ファミペイ ¥32,770、LINEスタンプ/マネフォ/玉木サブスク → PayPay)。Apple は各カードに別々に `APPLE.COM/BILL` を請求するため、従来の「Apple経由 合計」1本ではどちらのカード明細とも一致しませんでした。先の [#3530](https://github.com/kanta13jp1/my_web_app/pull/3530)(請求経路)の精緻化。

## 変更点(5ファイル / +246行)

- **`AssetSubscriptionAuditCatalog.gatewayCardBreakdownBySourceId`**(純関数): 経路ソース × 請求先カードで件数・月額合計を集計(合計降順 / 請求先未設定は末尾)。`SubscriptionGatewayInput` / `GatewayCardTotal` typedef を導入。
- **`SubscriptionAuditCard`**: 請求先カードが **2 つ以上のときだけ**「・ファミペイ ¥32,770(3件)」のような内訳行を合計行の下に表示(1 つなら合計行で十分なので出さない)。`GatewayCardBreakdownLine` typedef。
- **ページ**: 口座 ID → 表示名へ解決して内訳をカードへ渡す。

これで棚卸しの Apple 行が「登録済み 5件 / 月 ¥33,700」の下に「・ファミペイ ¥32,770(3件) / ・PayPayカード ¥930(2件)」と並び、各カードの `APPLE.COM/BILL` とそのまま突き合わせられます。

## 検証

- `flutter analyze`(lib と test 全ファイル): No issues found。
- `flutter test`: breakdown 純関数(カード分割/未設定末尾)+ カード(2枚で内訳表示・1枚で非表示)+ 既存 audit/smoke = **全 green**。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Pure aggregation fn + audit-card breakdown rows covered by unit+widget+smoke tests (per-card split, unset-to-end, 2+ shows / 1 hides); extends existing #3530 gateway reconciliation, no new e2e route

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive pure aggregation + display rows under lib/services,lib/widgets (not lib/subscription); no auth/billing/RLS/deploy/migration; presentational reconciliation only, no cashflow change; analyze+tests green, adversarial review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
