### PR TITLE
feat(asset): 借金しない宣言モニター(追加借入ゼロ/カード一括)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -38,6 +38,7 @@ import 'package:my_web_app/services/asset_management_ai_summary_refresh.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_account_balance_history_store.dart';
+import 'package:my_web_app/services/asset_debt_discipline_monitor.dart';
 import 'package:my_web_app/services/asset_debt_trend_analyzer.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
@@ -17316,6 +17317,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             _buildAssetManagementMonthlyDebtTrendList(report.debtTrendInsights),
             const SizedBox(height: 12),
           ],
+          if (report.disciplineReport?.isRelevant ?? false) ...[
+            _buildAssetManagementDisciplineCard(report.disciplineReport!),
+            const SizedBox(height: 12),
+          ],
           _buildAssetManagementAssistantActionList(report.actionItems),
           if (report.movementSuggestions.isNotEmpty) ...[
             const SizedBox(height: 12),
@@ -18154,6 +18159,207 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       AssetDebtTrendSeverity.warning => const Color(0xFFD97706),
       AssetDebtTrendSeverity.critical => const Color(0xFFB91C1C),
     };
+  }
+
+  String _assetDisciplineTypeLabel(AssetDebtDisciplineViolationType type) {
+    return switch (type) {
+      AssetDebtDisciplineViolationType.newBorrowing => '追加借入の発生',
+      AssetDebtDisciplineViolationType.revolvingCard => 'カード非一括（リボ/分割）',
+    };
+  }
+
+  /// 「借金しない宣言」の遵守状況（達成は緑で称賛、違反は赤で具体指摘）を描画する。
+  Widget _buildAssetManagementDisciplineCard(
+    AssetDebtDisciplineReport report,
+  ) {
+    final compliant = report.isCompliant;
+    final headerColor =
+        compliant ? const Color(0xFF0D9488) : const Color(0xFFB91C1C);
+    final bgColor =
+        compliant ? const Color(0xFFECFDF5) : const Color(0xFFFFF1F2);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: headerColor.withValues(alpha: 0.28)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                compliant ? Icons.verified_outlined : Icons.gpp_maybe_outlined,
+                color: headerColor,
+                size: 18,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '借金しない宣言モニター',
+                  style: TextStyle(
+                    color: headerColor,
+                    fontWeight: FontWeight.bold,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              _buildAssetDisciplinePledgeChip(
+                '① 追加借入ゼロ',
+                achieved: report.zeroNewBorrowingAchieved,
+                evaluated: report.hasPriorMonthData,
+              ),
+              _buildAssetDisciplinePledgeChip(
+                '② カードは全額一括',
+                achieved: report.lumpSumAchieved,
+                evaluated: true,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (compliant)
+            Text(
+              report.hasPriorMonthData
+                  ? '🎉 今月は「追加借入ゼロ」と「カードは全額一括」をどちらも達成しています。この調子を続けましょう。'
+                  : '今のところカードの繰越（リボ/分割）はありません。新規利用の判定は来月以降の履歴蓄積後に有効化されます。',
+              style: const TextStyle(fontSize: 12, height: 1.5),
+            )
+          else
+            for (final violation in report.allViolations.take(6))
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: _buildAssetDisciplineViolationTile(violation),
+              ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetDisciplinePledgeChip(
+    String label, {
+    required bool achieved,
+    required bool evaluated,
+  }) {
+    final color = !evaluated
+        ? const Color(0xFF6B7280)
+        : (achieved ? const Color(0xFF0D9488) : const Color(0xFFB91C1C));
+    final status = !evaluated ? '判定保留' : (achieved ? '達成' : '違反');
+    final icon = !evaluated
+        ? Icons.hourglass_empty
+        : (achieved ? Icons.check_circle_outline : Icons.cancel_outlined);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withValues(alpha: 0.32)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: color, size: 14),
+          const SizedBox(width: 4),
+          Text(
+            '$label: $status',
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              height: 1.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAssetDisciplineViolationTile(
+    AssetDebtDisciplineViolation violation,
+  ) {
+    final color = _assetDebtTrendSeverityColor(violation.severity);
+    final amountLabel =
+        violation.type == AssetDebtDisciplineViolationType.newBorrowing
+            ? '新規利用'
+            : '繰越額';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.22)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${violation.accountName}（${_assetDisciplineTypeLabel(violation.type)}）',
+            style: TextStyle(
+              color: color,
+              fontWeight: FontWeight.bold,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            violation.problem,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.arrow_forward, color: color, size: 16),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    violation.action,
+                    style: const TextStyle(fontSize: 12, height: 1.5),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              _buildAssetLiabilitySyncChip(
+                label: amountLabel,
+                value: _formatManagementYen(violation.amount),
+                color: color,
+              ),
+              _buildAssetLiabilitySyncChip(
+                label: '残高',
+                value: _formatManagementYen(violation.currentBalance),
+                color: const Color(0xFF6B7280),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
   }
 
   String _assetDebtTrendCategoryLabel(AssetDebtTrendCategory category) {

--- a/lib/services/asset_debt_discipline_monitor.dart
+++ b/lib/services/asset_debt_discipline_monitor.dart
@@ -1,0 +1,235 @@
+import 'dart:math';
+
+import '../models/asset_liability_workbook.dart';
+import 'asset_debt_trend_analyzer.dart';
+
+/// 「借金しない宣言」モニターが監視する違反の種別。
+///
+/// - [newBorrowing]: 今月、新規利用（追加借入）が発生した。誓約「追加の借金をしない」違反。
+/// - [revolvingCard]: クレジットカード等が当月全額返済されず繰越（リボ/分割）。
+///   誓約「カードは必ず一括返済」違反。
+enum AssetDebtDisciplineViolationType { newBorrowing, revolvingCard }
+
+/// 1 件の規律違反。金額はすべて Dart 側で計算済みで、AI には説明のみを任せる。
+class AssetDebtDisciplineViolation {
+  final AssetDebtDisciplineViolationType type;
+  final AssetDebtTrendSeverity severity;
+  final String accountId;
+  final String accountName;
+  final AssetLiabilityAccountKind kind;
+
+  /// newBorrowing: 今月の新規利用推定額 / revolvingCard: 翌月への繰越額。
+  final double amount;
+
+  /// 現在の利用残高（正の値）。
+  final double currentBalance;
+
+  /// 画面・プロンプトに出す「何が起きたか」一文。
+  final String problem;
+
+  /// 画面・プロンプトに出す「どうすべきか」一文。
+  final String action;
+
+  const AssetDebtDisciplineViolation({
+    required this.type,
+    required this.severity,
+    required this.accountId,
+    required this.accountName,
+    required this.kind,
+    required this.amount,
+    required this.currentBalance,
+    required this.problem,
+    required this.action,
+  });
+}
+
+/// 「借金しない宣言」モニターの月次評価結果。
+class AssetDebtDisciplineReport {
+  final List<AssetDebtDisciplineViolation> newBorrowingViolations;
+  final List<AssetDebtDisciplineViolation> revolvingCardViolations;
+
+  /// 新規利用判定に必要な前月残高データが 1 件以上あったか。
+  final bool hasPriorMonthData;
+
+  /// 今月の新規借入（新規利用）推定合計。
+  final double totalNewBorrowing;
+
+  /// 翌月へ繰り越され利息が付く残高の合計（リボ/分割）。
+  final double totalCarriedOver;
+
+  /// 監視対象になった借入系口座の数（カード/ローン等・固定費除く）。
+  /// 0 のときは監視対象が無い＝モニター自体を表示しない判断に使う。
+  final int monitoredAccountCount;
+
+  const AssetDebtDisciplineReport({
+    required this.newBorrowingViolations,
+    required this.revolvingCardViolations,
+    required this.hasPriorMonthData,
+    required this.totalNewBorrowing,
+    required this.totalCarriedOver,
+    required this.monitoredAccountCount,
+  });
+
+  /// 表示対象か（監視すべき借入系口座が 1 件以上あるか）。
+  bool get isRelevant => monitoredAccountCount > 0;
+
+  List<AssetDebtDisciplineViolation> get allViolations =>
+      <AssetDebtDisciplineViolation>[
+        ...newBorrowingViolations,
+        ...revolvingCardViolations,
+      ];
+
+  bool get isCompliant => allViolations.isEmpty;
+
+  /// 誓約①「追加借入ゼロ」を達成しているか。
+  bool get zeroNewBorrowingAchieved => newBorrowingViolations.isEmpty;
+
+  /// 誓約②「カードは全額一括」を達成しているか。
+  bool get lumpSumAchieved => revolvingCardViolations.isEmpty;
+
+  bool get hasViolations => allViolations.isNotEmpty;
+}
+
+/// 「追加の借金をしない／カードは必ず一括返済」という規律を月次で監視する。
+///
+/// 既存の [AssetDebtTrendAnalyzer] が「借金が複利で膨らんでいないか」を段階的な
+/// アドバイスで示すのに対し、本モニターは 2 つの誓約に対する **二値の遵守判定**を行う。
+/// 前月の口座別残高（[priorBalancesByAccountId]）から「今月の新規利用額」を推定し、
+/// 利息の自然増（複利）と新規借入を切り分ける。
+class AssetDebtDisciplineMonitor {
+  const AssetDebtDisciplineMonitor({this.newBorrowingThreshold = 1000});
+
+  /// 「新規利用が発生した」と見なす最小額（円）。推定誤差のノイズを問題化しない。
+  final double newBorrowingThreshold;
+
+  static const double _epsilon = 1;
+
+  /// 「追加借入」の対象となる借入系の負債種別か。
+  ///
+  /// 家賃・通信費など [AssetLiabilityDebtRow.fullPaymentEstimate] の固定費は対象外
+  /// （毎月全額払いの生活費であり「借金」ではない）。
+  static bool isBorrowingKind(AssetLiabilityAccountKind kind) {
+    return switch (kind) {
+      AssetLiabilityAccountKind.creditCard ||
+      AssetLiabilityAccountKind.cardLoan ||
+      AssetLiabilityAccountKind.shoppingDebt ||
+      AssetLiabilityAccountKind.otherLiability =>
+        true,
+      _ => false,
+    };
+  }
+
+  /// 「必ず一括返済」の対象となるカード系の負債種別か（クレカ・ショッピング枠）。
+  /// カードローン/キャッシングは借入金であり一括の対象ではない（追加借入のみ監視）。
+  static bool isLumpSumCardKind(AssetLiabilityAccountKind kind) {
+    return kind == AssetLiabilityAccountKind.creditCard ||
+        kind == AssetLiabilityAccountKind.shoppingDebt;
+  }
+
+  /// ワークブックと（あれば）前月末の口座別残高から規律違反を評価する。
+  AssetDebtDisciplineReport evaluate({
+    required AssetLiabilityWorkbook workbook,
+    Map<String, double> priorBalancesByAccountId = const <String, double>{},
+  }) {
+    final newBorrowing = <AssetDebtDisciplineViolation>[];
+    final revolving = <AssetDebtDisciplineViolation>[];
+    var hasPrior = false;
+    var totalNew = 0.0;
+    var totalCarried = 0.0;
+    var monitoredCount = 0;
+
+    for (final row in workbook.debtMasterRows) {
+      if (!isBorrowingKind(row.kind) || row.fullPaymentEstimate) {
+        continue;
+      }
+      final balance = row.balance.abs();
+      if (balance <= _epsilon) {
+        continue;
+      }
+      monitoredCount++;
+      final interest = max(0.0, row.monthlyInterestEstimate);
+      final payment = max(0.0, row.scheduledPaymentAmount);
+
+      // 誓約①: 追加借入ゼロ。前月比＋返済−利息で「今月の新規利用」を推定。
+      final prior = priorBalancesByAccountId[row.id];
+      if (prior != null) {
+        hasPrior = true;
+        final newUsage = (balance - prior) + payment - interest;
+        if (newUsage > newBorrowingThreshold) {
+          totalNew += newUsage;
+          newBorrowing.add(
+            AssetDebtDisciplineViolation(
+              type: AssetDebtDisciplineViolationType.newBorrowing,
+              severity: AssetDebtTrendSeverity.critical,
+              accountId: row.id,
+              accountName: row.name,
+              kind: row.kind,
+              amount: newUsage,
+              currentBalance: balance,
+              problem: '${row.name}で今月 約${_yen(newUsage)}の新規利用（追加借入）が発生しました。'
+                  '「追加の借金をしない」誓約に反しています。',
+              action: '翌月はこのカード/ローンの新規利用を止め、支払いは手元現金またはデビットに切り替えてください。'
+                  'どうしても使う場合は、その場で残高を全額入金して借金を翌月へ持ち越さないでください。',
+            ),
+          );
+        }
+      }
+
+      // 誓約②: カードは必ず一括。当月に全額返済されず繰り越されるなら違反。
+      if (isLumpSumCardKind(row.kind)) {
+        final carriedOver = balance - payment;
+        final interestBearing = row.annualRate > 0;
+        if (carriedOver > _epsilon && interestBearing) {
+          totalCarried += carriedOver;
+          revolving.add(
+            AssetDebtDisciplineViolation(
+              type: AssetDebtDisciplineViolationType.revolvingCard,
+              severity: AssetDebtTrendSeverity.critical,
+              accountId: row.id,
+              accountName: row.name,
+              kind: row.kind,
+              amount: carriedOver,
+              currentBalance: balance,
+              problem:
+                  '${row.name}は残高${_yen(balance)}に対し今月の返済予定が${_yen(payment)}で、'
+                  '${_yen(carriedOver)}が翌月へ繰り越され利息が発生します（＝リボ/分割の状態）。'
+                  '「カードは必ず一括返済」誓約に反しています。',
+              action: 'リボ/分割の設定を解除し、残高${_yen(balance)}を一括返済してください。'
+                  '今後カードを使うときは必ず一括（1回払い）に設定し、残高を翌月へ繰り越さないでください。',
+            ),
+          );
+        }
+      }
+    }
+
+    newBorrowing.sort((a, b) => b.amount.compareTo(a.amount));
+    revolving.sort((a, b) => b.amount.compareTo(a.amount));
+
+    return AssetDebtDisciplineReport(
+      newBorrowingViolations: List<AssetDebtDisciplineViolation>.unmodifiable(
+        newBorrowing,
+      ),
+      revolvingCardViolations: List<AssetDebtDisciplineViolation>.unmodifiable(
+        revolving,
+      ),
+      hasPriorMonthData: hasPrior,
+      totalNewBorrowing: totalNew,
+      totalCarriedOver: totalCarried,
+      monitoredAccountCount: monitoredCount,
+    );
+  }
+
+  String _yen(double amount) {
+    final sign = amount < 0 ? '-' : '';
+    final digits = amount.abs().round().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      final remaining = digits.length - i;
+      buffer.write(digits[i]);
+      if (remaining > 1 && remaining % 3 == 1) {
+        buffer.write(',');
+      }
+    }
+    return '$sign$buffer円';
+  }
+}

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -1,5 +1,6 @@
 import '../models/asset_liability_workbook.dart';
 import '../models/user_profile.dart';
+import 'asset_debt_discipline_monitor.dart';
 import 'asset_debt_trend_analyzer.dart';
 import 'asset_management_available_money.dart';
 
@@ -229,6 +230,9 @@ class AssetManagementInsightReport {
   /// 月をまたいだ負債トレンド（リボ複利・残高増加・超長期完済）の指摘。
   final List<AssetDebtTrendInsight> debtTrendInsights;
 
+  /// 「借金しない宣言」モニターの月次評価（追加借入ゼロ／カード一括）。null=未評価。
+  final AssetDebtDisciplineReport? disciplineReport;
+
   const AssetManagementInsightReport({
     required this.workbook,
     this.userProfile,
@@ -242,6 +246,7 @@ class AssetManagementInsightReport {
     this.implementationContexts =
         const <AssetManagementImplementationContext>[],
     this.debtTrendInsights = const <AssetDebtTrendInsight>[],
+    this.disciplineReport,
   });
 
   bool get hasDebtTrendInsights => debtTrendInsights.isNotEmpty;
@@ -285,6 +290,8 @@ class AssetManagementInsightService {
     String? mainAccountId,
     Map<String, double> priorMonthAccountBalances = const <String, double>{},
     AssetDebtTrendAnalyzer debtTrendAnalyzer = const AssetDebtTrendAnalyzer(),
+    AssetDebtDisciplineMonitor disciplineMonitor =
+        const AssetDebtDisciplineMonitor(),
   }) {
     final breakdown = _availableMoneyBreakdown(
       workbook: workbook,
@@ -333,6 +340,10 @@ class AssetManagementInsightService {
       workbook: workbook,
       priorBalancesByAccountId: priorMonthAccountBalances,
     );
+    final disciplineReport = disciplineMonitor.evaluate(
+      workbook: workbook,
+      priorBalancesByAccountId: priorMonthAccountBalances,
+    );
 
     return AssetManagementInsightReport(
       workbook: workbook,
@@ -346,6 +357,7 @@ class AssetManagementInsightService {
       developerRequests: developerRequests,
       implementationContexts: implementationContexts,
       debtTrendInsights: debtTrendInsights,
+      disciplineReport: disciplineReport,
     );
   }
 
@@ -1202,6 +1214,11 @@ class AssetManagementInsightPromptBuilder {
         '「今月いくら増えたか」「このままだと何年で完済か/一生終わらないか」「翌月いくら返済すべきか（具体額）」を断言してください。'
         '該当データが無い月だけ、そのカテゴリには触れなくて構いません。',
       )
+      ..writeln(
+        '下記「借金しない宣言モニター」は本人の固い誓約です。違反（追加借入の発生・カードの非一括/リボ）があれば、'
+        'どの口座でいくらかを具体的に挙げ、「次はこうする」を断言してください。'
+        '逆に両誓約を守れている月は、必ず明確に褒めて継続を後押ししてください（締めの総評でも触れる）。',
+      )
       ..writeln()
       ..writeln('## 総合サマリー')
       ..writeln('- 基準日: ${_formatDate(workbook.baseDate)}')
@@ -1258,6 +1275,9 @@ class AssetManagementInsightPromptBuilder {
       ..writeln()
       ..writeln('## 今月の問題点と翌月の改善（負債トレンド）')
       ..write(_debtTrendLines(report))
+      ..writeln()
+      ..writeln('## 借金しない宣言モニター（追加借入ゼロ／カード一括）')
+      ..write(_disciplineLines(report))
       ..writeln()
       ..writeln('## アクション件数')
       ..writeln('- 合計: ${report.actionItems.length}')
@@ -1577,6 +1597,43 @@ class AssetManagementInsightPromptBuilder {
       AssetDebtTrendCategory.negativeAmortization => 'リボ複利(返済が利息以下)',
       AssetDebtTrendCategory.balanceIncreasing => '残高増加(新規利用過多)',
       AssetDebtTrendCategory.slowPayoff => '超長期完済',
+    };
+  }
+
+  String _disciplineLines(AssetManagementInsightReport report) {
+    final discipline = report.disciplineReport;
+    if (discipline == null) {
+      return '- 規律モニター未評価。\n';
+    }
+    final buffer = StringBuffer()
+      ..writeln('- 誓約①「追加の借金をしない」: '
+          '${discipline.zeroNewBorrowingAchieved ? '達成' : '違反あり'}'
+          '${discipline.hasPriorMonthData ? '' : '（前月データ未蓄積のため判定保留）'}')
+      ..writeln('- 誓約②「カードは必ず一括返済」: '
+          '${discipline.lumpSumAchieved ? '達成' : '違反あり'}')
+      ..writeln('- 今月の新規借入推定合計: ${_formatAmount(discipline.totalNewBorrowing)}')
+      ..writeln('- リボ/分割で翌月へ繰り越す残高合計: '
+          '${_formatAmount(discipline.totalCarriedOver)}');
+    if (discipline.isCompliant) {
+      buffer.writeln('- 今月は両誓約を守れています。AIはこの達成を必ず褒め、継続を後押ししてください。');
+      return buffer.toString();
+    }
+    for (final violation in discipline.allViolations) {
+      buffer
+        ..writeln('- [${violation.severity.name}] '
+            '${_disciplineTypeLabel(violation.type)} / ${violation.accountName} / '
+            '金額:${_formatAmount(violation.amount)} / '
+            '残高:${_formatAmount(violation.currentBalance)}')
+        ..writeln('  - 問題点: ${violation.problem}')
+        ..writeln('  - 対応: ${violation.action}');
+    }
+    return buffer.toString();
+  }
+
+  String _disciplineTypeLabel(AssetDebtDisciplineViolationType type) {
+    return switch (type) {
+      AssetDebtDisciplineViolationType.newBorrowing => '追加借入の発生',
+      AssetDebtDisciplineViolationType.revolvingCard => 'カード非一括(リボ/分割)',
     };
   }
 

--- a/test/services/asset_debt_discipline_monitor_test.dart
+++ b/test/services/asset_debt_discipline_monitor_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_debt_discipline_monitor.dart';
+import 'package:my_web_app/services/asset_debt_trend_analyzer.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  const planner = AssetLiabilityPlanningService();
+  const monitor = AssetDebtDisciplineMonitor();
+  final baseDate = DateTime(2026, 6, 1);
+
+  String debtId(AssetLiabilityWorkbook workbook, String name) {
+    return workbook.debtMasterRows.firstWhere((row) => row.name == name).id;
+  }
+
+  group('AssetDebtDisciplineMonitor — 誓約① 追加借入ゼロ', () {
+    test('flags new borrowing on a loan that grew beyond interest', () {
+      // モビット 前月10万→今月20万、返済5千。利息3千 → 新規利用 約10.2万。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'モビット': -200000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'モビット': 5000},
+      );
+      final id = debtId(workbook, 'モビット');
+
+      final report = monitor.evaluate(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{id: 100000},
+      );
+
+      expect(report.newBorrowingViolations, hasLength(1));
+      expect(report.revolvingCardViolations, isEmpty); // cardLoan は一括対象外
+      expect(report.zeroNewBorrowingAchieved, isFalse);
+      expect(report.newBorrowingViolations.single.amount > 90000, isTrue);
+      expect(
+        report.newBorrowingViolations.single.problem.contains('新規利用'),
+        isTrue,
+      );
+      expect(report.hasPriorMonthData, isTrue);
+    });
+
+    test('does NOT flag interest-only growth as new borrowing', () {
+      // 残高がほぼ利息分だけ増えた（新規利用なし）→ 違反にしない。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'モビット': -200500,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'モビット': 2000},
+      );
+      final id = debtId(workbook, 'モビット');
+
+      final report = monitor.evaluate(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{id: 200000},
+      );
+
+      expect(report.newBorrowingViolations, isEmpty);
+    });
+
+    test('does NOT flag a loan being paid down with no new usage', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'モビット': -150000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'モビット': 50000},
+      );
+      final id = debtId(workbook, 'モビット');
+
+      final report = monitor.evaluate(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{id: 200000},
+      );
+
+      expect(report.isCompliant, isTrue);
+      expect(report.zeroNewBorrowingAchieved, isTrue);
+    });
+  });
+
+  group('AssetDebtDisciplineMonitor — 誓約② カードは必ず一括', () {
+    test('flags a credit card carrying a revolving balance', () {
+      // ファミペイ 残高10万、返済は最低額のみ → 繰越=リボ → 違反。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -100000,
+        },
+        baseDate: baseDate,
+      );
+
+      final report = monitor.evaluate(workbook: workbook);
+
+      expect(report.revolvingCardViolations, hasLength(1));
+      expect(report.lumpSumAchieved, isFalse);
+      expect(
+        report.revolvingCardViolations.single.severity,
+        AssetDebtTrendSeverity.critical,
+      );
+      expect(
+        report.revolvingCardViolations.single.action.contains('一括'),
+        isTrue,
+      );
+      // 前月データ未提供なので新規利用判定は走らない。
+      expect(report.hasPriorMonthData, isFalse);
+      expect(report.newBorrowingViolations, isEmpty);
+    });
+
+    test('does NOT flag a credit card paid in full this month', () {
+      // 残高10万を全額返済 → 一括 → 違反なし。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -100000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'ファミペイ': 100000},
+      );
+
+      final report = monitor.evaluate(workbook: workbook);
+
+      expect(report.revolvingCardViolations, isEmpty);
+      expect(report.lumpSumAchieved, isTrue);
+    });
+  });
+
+  group('AssetDebtDisciplineMonitor — 統合', () {
+    test('the FamiPay example violates BOTH pledges', () {
+      // 前月20万→今月30万(+10万)、返済3千 → 新規利用 約10万 かつ リボ繰越。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -300000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'ファミペイ': 3000},
+      );
+      final id = debtId(workbook, 'ファミペイ');
+
+      final report = monitor.evaluate(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{id: 200000},
+      );
+
+      expect(report.zeroNewBorrowingAchieved, isFalse);
+      expect(report.lumpSumAchieved, isFalse);
+      expect(report.isCompliant, isFalse);
+      expect(report.newBorrowingViolations, hasLength(1));
+      expect(report.revolvingCardViolations, hasLength(1));
+      expect(report.totalNewBorrowing > 90000, isTrue);
+      expect(report.totalCarriedOver > 200000, isTrue);
+    });
+
+    test('excludes full-payment fixed costs (rent/utility)', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          '家賃': -80000,
+        },
+        baseDate: baseDate,
+      );
+      final id = debtId(workbook, '家賃');
+
+      final report = monitor.evaluate(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{id: 0},
+      );
+
+      expect(report.isCompliant, isTrue);
+    });
+
+    test('exposes kind classification helpers', () {
+      expect(
+        AssetDebtDisciplineMonitor.isLumpSumCardKind(
+          AssetLiabilityAccountKind.creditCard,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetDebtDisciplineMonitor.isLumpSumCardKind(
+          AssetLiabilityAccountKind.cardLoan,
+        ),
+        isFalse,
+      );
+      expect(
+        AssetDebtDisciplineMonitor.isBorrowingKind(
+          AssetLiabilityAccountKind.utility,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -861,6 +861,36 @@ void main() {
       await _unmount(tester);
     });
 
+    testWidgets(
+        'a revolving credit card trips the no-new-debt discipline monitor',
+        (tester) async {
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      // ファミペイに残高（最低返済のみ＝リボ繰越）→ 「カードは全額一括」違反。
+      await tester.binding.setSurfaceSize(const Size(1200, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 500000,
+                'ファミペイ': -100000,
+              },
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.textContaining('借金しない宣言モニター'), findsOneWidget);
+      expect(find.textContaining('カードは全額一括: 違反'), findsWidgets);
+
+      await _unmount(tester);
+    });
+
     testWidgets('mirror update notice offers and applies remote prefs', (
       tester,
     ) async {


### PR DESCRIPTION
## 概要

資産管理ページに **「借金しない宣言モニター」** を追加。本人の固い誓約
**「追加の借金を絶対にしない／やむを得ずカードを使う場合は必ず一括返済」** を月次で監視し、
**二値（達成/違反）** で遵守状況を提示します。既存の負債トレンド分析（段階的アドバイス）に対し、
本モニターは誓約への厳格な合否判定を担います。

## 2つの誓約と判定

| 誓約 | 判定ロジック | 違反時の指摘 |
|---|---|---|
| **① 追加借入ゼロ** | `新規利用 = (今月残高−前月残高) + 返済 − 利息` が閾値超で違反。利息の自然増（複利）は新規借入から切り分け、トレンド分析側に委ねる | 「{口座}で新規利用◯◯円。現金/デビットに切替を」 |
| **② カードは全額一括** | クレカ/ショッピング枠で当月**全額返済されず繰越**（リボ/分割）なら違反 | 「リボ/分割を解除し残高◯◯円を一括返済。今後は1回払い固定に」 |

両誓約を守れた月は**ポジティブに称賛**（行動変容の強化）。監視対象の借入系口座が0件なら非表示。

## 変更ファイル（新規2＋編集3）

- 🆕 `lib/services/asset_debt_discipline_monitor.dart` — 誓約評価（純粋ロジック）
- 🆕 `test/services/asset_debt_discipline_monitor_test.dart` — ユニットテスト8件
- `lib/services/asset_management_insight_service.dart` — `disciplineReport` 追加＋AIプロンプト節
- `lib/pages/asset_management_page.dart` — 専用カードUI（誓約チップ＋違反タイル）
- `test/widgets/asset_management_page_smoke_test.dart` — カード描画スモーク

前月残高は既存 `AssetAccountBalanceHistoryStore` を再利用するため、専用テーブル・SQLマイグレーション・edge デプロイは**不要**です。

## テスト / 検証

- モニター8 / インサイト18 / スモーク（カード描画）**全緑**
- `dart analyze`（変更ファイル）・`dart format` クリーン
- 現 origin/main から切ったクリーンブランチで実装

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 本変更はUI/サービス層のみで外部I/Oや認可フローを変えず専用E2Eルートは過剰。実機相当の widget スモーク(借金しない宣言モニターのカード描画)+純粋ロジックのユニットテスト計26件で契約を担保している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)