### PR TITLE
feat(asset): サブスクの振替元に au (auかんたん決済/通信料金合算) を選べるように

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -8944,8 +8944,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
     // サブスクはカード (ファミペイ等) へ請求されることが多いため、残高<=0 のカードも
     // 請求先として選べるようにする。
-    final sourceOptions =
-        recurringFixedCostSourceOptions(accounts, includeCards: true);
+    final sourceOptions = recurringFixedCostSourceOptions(
+      accounts,
+      includeCards: true,
+      includeCarrierBilling: true,
+    );
     final gatewayTotals = AssetSubscriptionAuditCatalog.gatewayTotalsBySourceId(
       subscriptions: [
         for (final cost in _recurringFixedCosts)
@@ -9507,8 +9510,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final accounts = workbook?.accounts ?? const <AssetLiabilityAccount>[];
     // サブスクはカード (ファミペイ等) へ請求されることが多いため、残高<=0 のカードも
     // 請求先として選べるようにする。
-    final sourceOptions =
-        recurringFixedCostSourceOptions(accounts, includeCards: true);
+    final sourceOptions = recurringFixedCostSourceOptions(
+      accounts,
+      includeCards: true,
+      includeCarrierBilling: true,
+    );
     final sourceNames = <String, String>{
       for (final account in accounts) account.id: account.name,
     };

--- a/lib/widgets/recurring_fixed_cost_editor_dialog.dart
+++ b/lib/widgets/recurring_fixed_cost_editor_dialog.dart
@@ -13,17 +13,32 @@ typedef RecurringFixedCostSourceOption = ({String id, String name});
 /// [includeCards] = true で**残高の符号によらず**クレジット/プリペイドカード
 /// (例: ファミペイ バーチャルカード) も含める。FamiPay は後払い/残高0だと
 /// `balance > 0` だけのフィルタでは選べないため、請求先カードとして拾えるようにする。
+/// [includeCarrierBilling] = true で auかんたん決済 (au通信料金合算) 等のキャリア決済
+/// 口座 (au / KDDI) も含める。これらは負債(請求)口座で残高<=0 のため通常は出ない。
 List<RecurringFixedCostSourceOption> recurringFixedCostSourceOptions(
   Iterable<AssetLiabilityAccount> accounts, {
   bool includeCards = false,
+  bool includeCarrierBilling = false,
 }) {
   return <RecurringFixedCostSourceOption>[
     for (final account in accounts)
       if (account.balance > 0 ||
           (includeCards &&
-              account.kind == AssetLiabilityAccountKind.creditCard))
+              account.kind == AssetLiabilityAccountKind.creditCard) ||
+          (includeCarrierBilling && _isCarrierBillingAccount(account)))
         (id: account.id, name: account.name),
   ];
+}
+
+/// auかんたん決済 (au通信料金合算) / KDDI などキャリア決済の口座か。残高の符号に依らず
+/// サブスクの振替元候補に含めるための判定。id は planning service の
+/// `auAccountId`('au') / `kddiProviderAccountId`('kddi_provider') と一致させる。
+bool _isCarrierBillingAccount(AssetLiabilityAccount account) {
+  final name = account.name.toLowerCase().replaceAll(RegExp(r'\s+'), '');
+  return name == 'au' ||
+      account.id == 'au' ||
+      name.contains('kddi') ||
+      account.id == 'kddi_provider';
 }
 
 /// 定期固定費の追加/編集ダイアログを開き、保存された [AssetRecurringFixedCost] を返す。

--- a/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
+++ b/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
@@ -47,6 +47,38 @@ void main() {
       // 重複しない (auPay は1回だけ)。
       expect(ids.where((id) => id == 'aupay').length, 1);
     });
+
+    test('includeCarrierBilling surfaces au/KDDI carrier accounts only', () {
+      final withCarrier = <AssetLiabilityAccount>[
+        ...accounts,
+        acct('au', 'au', AssetLiabilityAccountKind.otherLiability, -28797),
+        acct('kddi_provider', 'KDDI', AssetLiabilityAccountKind.utility, -5764),
+        acct('rent', '家賃', AssetLiabilityAccountKind.utility, -63000),
+      ];
+      final ids = recurringFixedCostSourceOptions(
+        withCarrier,
+        includeCards: true,
+        includeCarrierBilling: true,
+      ).map((o) => o.id).toList();
+      // au / KDDI (auかんたん決済 / 通信料金合算) は振替元に出る。
+      expect(ids, containsAll(<String>['au', 'kddi_provider']));
+      // 家賃 (utility だがキャリア決済でない) は出ない。
+      expect(ids, isNot(contains('rent')));
+      // auPayカードを au と誤判定しない (残高>0 のカードとして1回だけ)。
+      expect(ids.where((id) => id == 'aupay').length, 1);
+    });
+
+    test('carrier accounts stay hidden without includeCarrierBilling', () {
+      final withCarrier = <AssetLiabilityAccount>[
+        ...accounts,
+        acct('au', 'au', AssetLiabilityAccountKind.otherLiability, -28797),
+      ];
+      final ids = recurringFixedCostSourceOptions(
+        withCarrier,
+        includeCards: true,
+      ).map((o) => o.id).toList();
+      expect(ids, isNot(contains('au')));
+    });
   });
 
   const prefill = AssetRecurringFixedCost(


### PR DESCRIPTION
## 概要

auかんたん決済 (au通信料金合算) のサブスク (例: Pontaパス) の**振替元として「au」を選べる**ようにします。au/KDDI はキャリア請求の負債口座 (残高<=0・utility/otherLiability) のため、従来の「残高>0 + クレカ」フィルタから漏れて振替元ドロップダウンに出ませんでした。先の [#3531](https://github.com/kanta13jp1/my_web_app/pull/3531)(ファミペイ=カード対応)の au キャリア決済版。

## 変更点(3ファイル / +58)

- **`recurringFixedCostSourceOptions`** に `includeCarrierBilling` フラグを追加。`_isCarrierBillingAccount`(正規化名 == `au` 完全一致 / `kddi` 部分一致 / id `au`・`kddi_provider`)に該当する口座を**残高の符号に依らず**振替元候補へ含める。
- ページのサブスク登録ダイアログ(サブスクカード・棚卸し)で `includeCarrierBilling: true`。固定費/提案カードは従来どおり(キャリア決済は対象外)。

`au` は完全一致なので `auPay` / `auPAYカード` を誤検出しません(テスト済み)。これで Pontaパス を「請求経路=auかんたん決済 / 振替元=au」で登録でき、棚卸しの auかんたん決済 行と突き合わせられます。

## 検証

- `flutter analyze`(編集 lib + test): No issues found。
- `flutter test`: 振替元オプション(au/KDDI 包含・auPay 非誤検出・フラグ無しで非表示)含む全 14 green。
- 多エージェントレビュー: 確定 0 件(誤検出/二重計上/スコープすべて refute 済み)。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Additive funding-source flag covered by unit tests (au/KDDI carrier incl, auPay not false-matched, hidden without flag); extends existing recurringFixedCostSourceOptions, no new e2e route

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive funding-source filter flag under lib/widgets,lib/pages (not lib/subscription); no auth/billing/RLS/deploy/migration; presentational dropdown option only, no cashflow change; analyze+14 tests green, adversarial review 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
