### PR TITLE
feat(asset): サブスク棚卸しの「確認した」を取り消し/解除できるUIを追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -455,6 +455,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       <AssetRecurringFixedCost>[];
   // サブスク棚卸し: 支払い元ごとの最終確認日時 (sourceId → UTC)。
   Map<String, DateTime> _subscriptionAuditState = <String, DateTime>{};
+  // サブスク棚卸し: 確認の取り消し日時 (tombstone / sourceId → UTC)。checked と
+  // 突き合わせ、新しい方の操作が勝つ (確認 > 取り消し で確認済み)。誤クリックの解除を
+  // 端末間で正しく伝播させ、キー削除による誤復活を防ぐ。
+  Map<String, DateTime> _subscriptionAuditUnconfirmed = <String, DateTime>{};
   // 定期取引の自動検出で「無視」した正規化ラベル(再提案しない / 支出側)。
   Set<String> _ignoredRecurringLabels = <String>{};
   Set<String> _ignoredDuplicateProviders = <String>{};
@@ -8780,8 +8784,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<void> _loadSubscriptionAudit() async {
     try {
       final state = await _subscriptionAuditStore.load();
-      if (mounted && state.isNotEmpty) {
-        setState(() => _subscriptionAuditState = state);
+      final unconfirmed = await _subscriptionAuditStore.loadUnconfirmed();
+      if (mounted && (state.isNotEmpty || unconfirmed.isNotEmpty)) {
+        setState(() {
+          _subscriptionAuditState = state;
+          _subscriptionAuditUnconfirmed = unconfirmed;
+        });
       }
     } catch (e) {
       debugPrint('Error loading subscription audit: $e');
@@ -8790,20 +8798,24 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   /// サーバ集約ミラー (pref_key: subscription_audit_state) から復元する。
-  /// 「確認した」は単調なので、tombstone/dirty/LWW ではなく MAX マージで統合する。
+  /// 確認 (checked) と取り消し (unconfirmed = tombstone) を独立に MAX マージして統合する。
+  /// 新しい方の操作が勝つので誤復活せず、確認の取り消しも端末間で伝播する。
   Future<void> _restoreSubscriptionAuditFromMirror() async {
     final debugMirror = widget.debugSubscriptionAuditMirror;
     if (debugMirror == null && _supabase.auth.currentUser == null) {
       return;
     }
-    final localBefore = Map<String, DateTime>.from(_subscriptionAuditState);
+    final localCheckedBefore = Map<String, DateTime>.from(
+      _subscriptionAuditState,
+    );
+    final localUnconfirmedBefore = Map<String, DateTime>.from(
+      _subscriptionAuditUnconfirmed,
+    );
     try {
-      final Map<String, DateTime> serverState;
+      final dynamic serverValue;
       final DateTime? mirrorUpdatedAt;
       if (debugMirror != null) {
-        serverState = AssetSubscriptionAuditStore.decodeMirrorValue(
-          debugMirror,
-        );
+        serverValue = debugMirror;
         mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
         final rows = await _supabase
@@ -8812,14 +8824,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             .eq('pref_key', _subscriptionAuditMirrorKey);
         if (rows.isEmpty) {
           // サーバ行無し: ローカルにあれば初回バックフィル。
-          if (localBefore.isNotEmpty) {
+          if (localCheckedBefore.isNotEmpty ||
+              localUnconfirmedBefore.isNotEmpty) {
             unawaited(_mirrorSubscriptionAudit());
           }
           return;
         }
-        serverState = AssetSubscriptionAuditStore.decodeMirrorValue(
-          rows.first['value'],
-        );
+        serverValue = rows.first['value'];
         mirrorUpdatedAt = DateTime.tryParse(
           rows.first['updated_at']?.toString() ?? '',
         );
@@ -8827,31 +8838,72 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (!mounted) {
         return;
       }
-      // 取込み中に「確認した」が入っても失わないよう、localBefore ではなく現在の
-      // in-memory state とマージする (MAX は単調なので新しい確認を消さない)。
-      final current = _subscriptionAuditState;
-      final merged = AssetSubscriptionAuditStore.mergeMax(current, serverState);
-      if (!_sameSubscriptionAuditState(current, merged)) {
-        setState(() => _subscriptionAuditState = merged);
+      final serverState = AssetSubscriptionAuditStore.decodeMirrorPayload(
+        serverValue,
+      );
+      // 取込み中に確認/取り消しが入っても失わないよう、現在の in-memory state と
+      // マージする (MAX は単調なので新しい操作を消さない)。
+      final currentChecked = _subscriptionAuditState;
+      final currentUnconfirmed = _subscriptionAuditUnconfirmed;
+      final mergedChecked = AssetSubscriptionAuditStore.mergeMax(
+        currentChecked,
+        serverState.checked,
+      );
+      final mergedUnconfirmed = AssetSubscriptionAuditStore.mergeMax(
+        currentUnconfirmed,
+        serverState.unconfirmed,
+      );
+      final checkedChanged = !_sameSubscriptionAuditState(
+        currentChecked,
+        mergedChecked,
+      );
+      final unconfirmedChanged = !_sameSubscriptionAuditState(
+        currentUnconfirmed,
+        mergedUnconfirmed,
+      );
+      if (checkedChanged || unconfirmedChanged) {
+        setState(() {
+          _subscriptionAuditState = mergedChecked;
+          _subscriptionAuditUnconfirmed = mergedUnconfirmed;
+        });
         _persistInBackground(
-          _subscriptionAuditStore.save(merged),
+          _subscriptionAuditStore.save(mergedChecked),
           'subscription audit restore save',
+        );
+        _persistInBackground(
+          _subscriptionAuditStore.saveUnconfirmed(mergedUnconfirmed),
+          'subscription audit restore save (unconfirmed)',
         );
         unawaited(
           _realignMirrorTimestamp(_subscriptionAuditMirrorKey, mirrorUpdatedAt),
         );
       }
-      // ローカルにサーバより新しい確認があればサーバへ反映 (和集合維持)。
-      final localHasNewer = localBefore.entries.any((entry) {
-        final server = serverState[entry.key];
-        return server == null || entry.value.isAfter(server);
-      });
-      if (localHasNewer && debugMirror == null) {
+      // ローカルにサーバより新しい確認/取り消しがあればサーバへ反映 (和集合維持)。
+      final checkedNewer = _subscriptionAuditLocalHasNewer(
+        localCheckedBefore,
+        serverState.checked,
+      );
+      final unconfirmedNewer = _subscriptionAuditLocalHasNewer(
+        localUnconfirmedBefore,
+        serverState.unconfirmed,
+      );
+      if ((checkedNewer || unconfirmedNewer) && debugMirror == null) {
         unawaited(_mirrorSubscriptionAudit());
       }
     } catch (e) {
       debugPrint('subscription audit mirror restore failed: $e');
     }
+  }
+
+  /// local に server より新しい (= server に無いか後の) 時刻があれば true。
+  bool _subscriptionAuditLocalHasNewer(
+    Map<String, DateTime> local,
+    Map<String, DateTime> server,
+  ) {
+    return local.entries.any((entry) {
+      final remote = server[entry.key];
+      return remote == null || entry.value.isAfter(remote);
+    });
   }
 
   bool _sameSubscriptionAuditState(
@@ -8869,7 +8921,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return true;
   }
 
-  /// 確認状況の全量を `asset_pref_mirror` へ 1 行 upsert する。
+  /// 確認状況の全量 (確認 + 取り消し) を `asset_pref_mirror` へ 1 行 upsert する。
   Future<void> _mirrorSubscriptionAudit() async {
     unawaited(_syncTimestampStore.markChanged(_subscriptionAuditMirrorKey));
     final userId = _supabase.auth.currentUser?.id;
@@ -8880,8 +8932,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
         'user_id': userId,
         'pref_key': _subscriptionAuditMirrorKey,
-        'value': AssetSubscriptionAuditStore.encodeMirrorValue(
+        'value': AssetSubscriptionAuditStore.encodeMirrorPayload(
           _subscriptionAuditState,
+          _subscriptionAuditUnconfirmed,
         ),
         'updated_at': DateTime.now().toUtc().toIso8601String(),
       });
@@ -8899,6 +8952,42 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       'subscription audit save',
     );
     unawaited(_mirrorSubscriptionAudit());
+    // 誤クリック救済: 直後に「元に戻す」で未確認へ戻せる SnackBar を出す。
+    if (!mounted) {
+      return;
+    }
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.clearSnackBars();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text('「${source.name}」を確認済みにしました'),
+        action: SnackBarAction(
+          label: '元に戻す',
+          onPressed: () => _unmarkSubscriptionSourceChecked(source),
+        ),
+      ),
+    );
+  }
+
+  /// 確認を取り消して当該ソースを未確認へ戻す (常設「確認を取り消す」/ SnackBar の
+  /// 「元に戻す」の共通経路)。確認時刻は履歴として残し、取り消し時刻 (tombstone) を now で
+  /// 記録する。effective 判定で「取り消し > 確認」となり未確認表示になり、端末間も MAX
+  /// マージで誤復活しない (キー削除と違い、最後の操作が確実に勝つ)。
+  void _unmarkSubscriptionSourceChecked(SubscriptionAuditSource source) {
+    final next = Map<String, DateTime>.from(_subscriptionAuditUnconfirmed);
+    next[source.id] = DateTime.now().toUtc();
+    setState(() => _subscriptionAuditUnconfirmed = next);
+    _persistInBackground(
+      _subscriptionAuditStore.saveUnconfirmed(next),
+      'subscription audit unconfirm save',
+    );
+    unawaited(_mirrorSubscriptionAudit());
+    if (!mounted) {
+      return;
+    }
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.clearSnackBars();
+    messenger.showSnackBar(const SnackBar(content: Text('確認を取り消しました')));
   }
 
   /// 棚卸し対象の支払い元: manual (Apple/au/Google) + 銀行 + カード別 (口座から導出)。
@@ -8959,12 +9048,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
     return SubscriptionAuditCard(
       sources: _subscriptionAuditSources(workbook),
-      lastCheckedAt: _subscriptionAuditState,
+      lastCheckedAt: AssetSubscriptionAuditStore.effectiveCheckedAt(
+        _subscriptionAuditState,
+        _subscriptionAuditUnconfirmed,
+      ),
       unregisteredCountBySourceId: _unregisteredCountBySourceId(workbook),
       registeredByGatewaySourceId: gatewayTotals,
       cardBreakdownBySourceId: _subscriptionGatewayCardBreakdown(accounts),
       now: _now,
       onMarkChecked: _markSubscriptionSourceChecked,
+      onUnmarkChecked: _unmarkSubscriptionSourceChecked,
       onRegisterSubscription: (source) => unawaited(
         _openRecurringFixedCostEditor(
           sourceOptions: sourceOptions,

--- a/lib/services/asset_subscription_audit_store.dart
+++ b/lib/services/asset_subscription_audit_store.dart
@@ -2,22 +2,57 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// サブスク棚卸しの「支払い元ごとの最終確認日時」を永続化する。
+/// サブスク棚卸しの「支払い元ごとの最終確認日時」と「取り消し日時」を永続化する。
 ///
 /// ローカル (SharedPreferences) を一次ストアとし、資産管理ページが `asset_pref_mirror`
 /// (pref_key: `subscription_audit_state`) へ 1 行 jsonb でミラーする (定期固定費と同方針)。
-/// 保存形は `{sourceId: iso8601(UTC)}`。
 ///
-/// 「確認した」は単調 (巻き戻らない) なので、端末間マージは **各 sourceId で最新時刻を
-/// 採用する MAX マージ** ([mergeMax]) で十分。tombstone / dirty-key / LWW は不要。
+/// 「確認した」は単調だが、誤クリックの取り消し / 確認解除を端末間で正しく伝播させるため、
+/// 確認時刻 (checked) と並行して **取り消し時刻 (unconfirmed = tombstone)** も保持する。
+/// 各マップを独立に [mergeMax] し、sourceId ごとに **新しい方の操作が勝つ**
+/// ([effectiveCheckedAt]: checked > unconfirmed のときだけ確認済み)。これにより
+/// confirm / unconfirm の双方が単調・順序非依存・冪等になり、キー削除で起きる誤復活
+/// (他端末の古い確認時刻が MAX マージで蘇る) を避けられる。
+///
+/// ミラー保存形は v2 ネスト `{'v': 2, 'checked': {id: iso}, 'unconfirmed': {id: iso}}`。
+/// 旧フラット形 `{id: iso}` (本番既存データ) は checked のみとして後方互換 decode する
+/// ([decodeMirrorPayload])。ローカルは checked / unconfirmed を 2 キーに分けて保存する。
 class AssetSubscriptionAuditStore {
+  /// 確認時刻 (checked) のローカル保存キー。旧来からのキーで後方互換。
   static const String prefsKey = 'asset_subscription_audit_state_v1';
+
+  /// 取り消し時刻 (unconfirmed = tombstone) のローカル保存キー。
+  static const String unconfirmedPrefsKey =
+      'asset_subscription_audit_unconfirmed_v1';
 
   const AssetSubscriptionAuditStore();
 
-  Future<Map<String, DateTime>> load({SharedPreferences? prefs}) async {
+  Future<Map<String, DateTime>> load({SharedPreferences? prefs}) =>
+      _loadKey(prefsKey, prefs: prefs);
+
+  /// 取り消し時刻 (tombstone) をローカルから読み出す。
+  Future<Map<String, DateTime>> loadUnconfirmed({SharedPreferences? prefs}) =>
+      _loadKey(unconfirmedPrefsKey, prefs: prefs);
+
+  Future<void> save(
+    Map<String, DateTime> state, {
+    SharedPreferences? prefs,
+  }) =>
+      _saveKey(prefsKey, state, prefs: prefs);
+
+  /// 取り消し時刻 (tombstone) をローカルへ保存する。
+  Future<void> saveUnconfirmed(
+    Map<String, DateTime> state, {
+    SharedPreferences? prefs,
+  }) =>
+      _saveKey(unconfirmedPrefsKey, state, prefs: prefs);
+
+  Future<Map<String, DateTime>> _loadKey(
+    String key, {
+    SharedPreferences? prefs,
+  }) async {
     final store = prefs ?? await SharedPreferences.getInstance();
-    final raw = store.getString(prefsKey);
+    final raw = store.getString(key);
     if (raw == null || raw.isEmpty) {
       return <String, DateTime>{};
     }
@@ -28,16 +63,17 @@ class AssetSubscriptionAuditStore {
     }
   }
 
-  Future<void> save(
+  Future<void> _saveKey(
+    String key,
     Map<String, DateTime> state, {
     SharedPreferences? prefs,
   }) async {
     final store = prefs ?? await SharedPreferences.getInstance();
     if (state.isEmpty) {
-      await store.remove(prefsKey);
+      await store.remove(key);
       return;
     }
-    await store.setString(prefsKey, jsonEncode(encodeMirrorValue(state)));
+    await store.setString(key, jsonEncode(encodeMirrorValue(state)));
   }
 
   /// `{sourceId: iso8601(UTC)}` へ変換する (ローカル保存とサーバミラー共通形)。
@@ -68,8 +104,8 @@ class AssetSubscriptionAuditStore {
     return result;
   }
 
-  /// 端末間マージ: キー和集合を取り、各 sourceId で **新しい方** の確認時刻を採用する。
-  /// 単調なので順序非依存・冪等 (確認を取り消さない限り情報を失わない)。
+  /// 端末間マージ: キー和集合を取り、各 sourceId で **新しい方** の時刻を採用する。
+  /// 単調なので順序非依存・冪等。checked / unconfirmed の両マップに同じく使う。
   static Map<String, DateTime> mergeMax(
     Map<String, DateTime> a,
     Map<String, DateTime> b,
@@ -82,5 +118,53 @@ class AssetSubscriptionAuditStore {
       }
     });
     return result;
+  }
+
+  /// confirm / unconfirm を突き合わせ、いま **確認済み** と判定できる sourceId だけを
+  /// 残した確認時刻マップを返す (カードへ渡す `lastCheckedAt`)。
+  /// 判定 = checked が存在し、かつ取り消し時刻より後 (= 最後の操作が確認)。
+  static Map<String, DateTime> effectiveCheckedAt(
+    Map<String, DateTime> checked,
+    Map<String, DateTime> unconfirmed,
+  ) {
+    final result = <String, DateTime>{};
+    checked.forEach((key, value) {
+      final undone = unconfirmed[key];
+      if (undone == null || value.isAfter(undone)) {
+        result[key] = value;
+      }
+    });
+    return result;
+  }
+
+  /// サーバミラー (`asset_pref_mirror.value`) 用に checked / unconfirmed をまとめた
+  /// v2 ネスト形へ変換する。
+  static Map<String, dynamic> encodeMirrorPayload(
+    Map<String, DateTime> checked,
+    Map<String, DateTime> unconfirmed,
+  ) {
+    return <String, dynamic>{
+      'v': 2,
+      'checked': encodeMirrorValue(checked),
+      'unconfirmed': encodeMirrorValue(unconfirmed),
+    };
+  }
+
+  /// サーバミラー / 保存値から checked / unconfirmed を復元する。
+  /// v2 ネスト形 (`{'checked': {...}, 'unconfirmed': {...}}`) と、旧フラット形
+  /// `{id: iso}` (= checked のみ) の両方を受ける後方互換 decode。
+  static ({Map<String, DateTime> checked, Map<String, DateTime> unconfirmed})
+      decodeMirrorPayload(dynamic value) {
+    if (value is Map && value['checked'] is Map) {
+      return (
+        checked: decodeMirrorValue(value['checked']),
+        unconfirmed: decodeMirrorValue(value['unconfirmed']),
+      );
+    }
+    // 旧フラット形: 全て確認時刻として扱い、取り消しは無し。
+    return (
+      checked: decodeMirrorValue(value),
+      unconfirmed: <String, DateTime>{},
+    );
   }
 }

--- a/lib/widgets/subscription_audit_card.dart
+++ b/lib/widgets/subscription_audit_card.dart
@@ -32,6 +32,7 @@ class SubscriptionAuditCard extends StatelessWidget {
     required this.lastCheckedAt,
     required this.now,
     required this.onMarkChecked,
+    required this.onUnmarkChecked,
     required this.onRegisterSubscription,
     this.unregisteredCountBySourceId = const <String, int>{},
     this.registeredByGatewaySourceId =
@@ -65,6 +66,9 @@ class SubscriptionAuditCard extends StatelessWidget {
   final int staleDays;
 
   final void Function(SubscriptionAuditSource source) onMarkChecked;
+
+  /// 「確認した」を誤って押した / 解除したいときに、当該ソースを未確認へ戻す。
+  final void Function(SubscriptionAuditSource source) onUnmarkChecked;
   final void Function(SubscriptionAuditSource source) onRegisterSubscription;
 
   /// 最終確認日時と現在時刻からステータスを判定する (純関数)。
@@ -181,6 +185,7 @@ class SubscriptionAuditCard extends StatelessWidget {
                   cardBreakdown: cardBreakdownBySourceId[source.id] ??
                       const <GatewayCardBreakdownLine>[],
                   onMarkChecked: () => onMarkChecked(source),
+                  onUnmark: () => onUnmarkChecked(source),
                   onRegister: () => onRegisterSubscription(source),
                 ),
             ],
@@ -201,6 +206,7 @@ class _SourceTile extends StatelessWidget {
     required this.registered,
     required this.cardBreakdown,
     required this.onMarkChecked,
+    required this.onUnmark,
     required this.onRegister,
   });
 
@@ -215,6 +221,9 @@ class _SourceTile extends StatelessWidget {
   /// 請求先カード別の内訳 (合計降順)。2 件以上のときだけ内訳行を出す。
   final List<GatewayCardBreakdownLine> cardBreakdown;
   final VoidCallback onMarkChecked;
+
+  /// 確認を取り消して未確認へ戻す。
+  final VoidCallback onUnmark;
   final VoidCallback onRegister;
 
   static final NumberFormat _yen = NumberFormat('#,###');
@@ -246,6 +255,8 @@ class _SourceTile extends StatelessWidget {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
     final isManual = source.kind == SubscriptionAuditSourceKind.manualCheck;
+    // 確認済み/要再確認のときだけ「確認を取り消す」を出す (誤クリック解除用)。
+    final isChecked = status != SubscriptionAuditStatus.unchecked;
     final actions = Wrap(
       spacing: 8,
       children: [
@@ -254,6 +265,19 @@ class _SourceTile extends StatelessWidget {
           icon: const Icon(Icons.check, size: 18),
           label: const Text('確認した'),
         ),
+        if (isChecked)
+          Semantics(
+            button: true,
+            label: '${source.name}の確認を取り消す',
+            child: TextButton.icon(
+              onPressed: onUnmark,
+              style: TextButton.styleFrom(
+                foregroundColor: scheme.onSurfaceVariant,
+              ),
+              icon: const Icon(Icons.undo, size: 18),
+              label: const Text('確認を取り消す'),
+            ),
+          ),
         TextButton.icon(
           onPressed: onRegister,
           icon: const Icon(Icons.add, size: 18),

--- a/test/services/asset_subscription_audit_store_test.dart
+++ b/test/services/asset_subscription_audit_store_test.dart
@@ -115,5 +115,84 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       expect(await store.load(prefs: prefs), isEmpty);
     });
+
+    test('unconfirmed save/load round-trips on its own key', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      await store.saveUnconfirmed(
+        <String, DateTime>{'apple_id': utc(2026, 6, 2)},
+        prefs: prefs,
+      );
+      // checked と取り消しは別キーなので互いに混ざらない。
+      expect(await store.load(prefs: prefs), isEmpty);
+      expect(
+        (await store.loadUnconfirmed(prefs: prefs))['apple_id'],
+        utc(2026, 6, 2),
+      );
+    });
+  });
+
+  group('AssetSubscriptionAuditStore.effectiveCheckedAt', () {
+    test('checked with no tombstone stays confirmed', () {
+      final effective = AssetSubscriptionAuditStore.effectiveCheckedAt(
+        <String, DateTime>{'apple_id': utc(2026, 6, 1)},
+        const <String, DateTime>{},
+      );
+      expect(effective['apple_id'], utc(2026, 6, 1));
+    });
+
+    test('newer unconfirm hides the source (= 未確認)', () {
+      final effective = AssetSubscriptionAuditStore.effectiveCheckedAt(
+        <String, DateTime>{'apple_id': DateTime.utc(2026, 6, 1, 9)},
+        <String, DateTime>{'apple_id': DateTime.utc(2026, 6, 1, 10)},
+      );
+      expect(effective.containsKey('apple_id'), isFalse);
+    });
+
+    test('re-confirm after unconfirm wins (= 確認済み)', () {
+      final effective = AssetSubscriptionAuditStore.effectiveCheckedAt(
+        <String, DateTime>{'apple_id': DateTime.utc(2026, 6, 1, 11)},
+        <String, DateTime>{'apple_id': DateTime.utc(2026, 6, 1, 10)},
+      );
+      expect(effective['apple_id'], DateTime.utc(2026, 6, 1, 11));
+    });
+
+    test('equal timestamps favour unconfirm (tie → 未確認)', () {
+      final t = DateTime.utc(2026, 6, 1, 10);
+      final effective = AssetSubscriptionAuditStore.effectiveCheckedAt(
+        <String, DateTime>{'apple_id': t},
+        <String, DateTime>{'apple_id': t},
+      );
+      expect(effective.containsKey('apple_id'), isFalse);
+    });
+  });
+
+  group('AssetSubscriptionAuditStore mirror payload (v2)', () {
+    test('encode/decode round-trips both maps', () {
+      final checked = <String, DateTime>{'apple_id': utc(2026, 6, 1)};
+      final unconfirmed = <String, DateTime>{'au_kantan': utc(2026, 6, 2)};
+      final encoded = AssetSubscriptionAuditStore.encodeMirrorPayload(
+        checked,
+        unconfirmed,
+      );
+      expect(encoded['v'], 2);
+      final decoded = AssetSubscriptionAuditStore.decodeMirrorPayload(encoded);
+      expect(decoded.checked['apple_id'], utc(2026, 6, 1));
+      expect(decoded.unconfirmed['au_kantan'], utc(2026, 6, 2));
+    });
+
+    test('legacy flat {id: iso} decodes as checked-only', () {
+      final decoded = AssetSubscriptionAuditStore.decodeMirrorPayload(
+        <String, dynamic>{'apple_id': '2026-06-01T00:00:00.000Z'},
+      );
+      expect(decoded.checked['apple_id'], utc(2026, 6, 1));
+      expect(decoded.unconfirmed, isEmpty);
+    });
+
+    test('null / non-map decodes to empty maps', () {
+      final decoded = AssetSubscriptionAuditStore.decodeMirrorPayload(null);
+      expect(decoded.checked, isEmpty);
+      expect(decoded.unconfirmed, isEmpty);
+    });
   });
 }

--- a/test/widgets/subscription_audit_card_test.dart
+++ b/test/widgets/subscription_audit_card_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/asset_subscription_audit_catalog.dart';
 import 'package:my_web_app/widgets/subscription_audit_card.dart';
 
+void _noop(SubscriptionAuditSource _) {}
+
 void main() {
   final now = DateTime.utc(2026, 6, 20);
 
@@ -60,6 +62,7 @@ void main() {
         const <String, List<GatewayCardBreakdownLine>>{},
     required void Function(SubscriptionAuditSource) onMarkChecked,
     required void Function(SubscriptionAuditSource) onRegister,
+    void Function(SubscriptionAuditSource) onUnmark = _noop,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -72,6 +75,7 @@ void main() {
             cardBreakdownBySourceId: cardBreakdown,
             now: now,
             onMarkChecked: onMarkChecked,
+            onUnmarkChecked: onUnmark,
             onRegisterSubscription: onRegister,
           ),
         ),
@@ -117,6 +121,53 @@ void main() {
       find.descendant(of: appleRow, matching: find.text('サブスクを登録')),
     );
     expect(registered?.id, 'apple_id');
+  });
+
+  testWidgets('unchecked source does not show 確認を取り消す', (tester) async {
+    await tester.pumpWidget(
+      host(
+        onMarkChecked: (_) {},
+        onRegister: (_) {},
+      ),
+    );
+
+    // 未確認のあいだは取り消しボタンを出さない (出す対象が無い)。
+    expect(find.text('確認を取り消す'), findsNothing);
+  });
+
+  testWidgets('confirmed source shows 確認を取り消す and fires with the source',
+      (tester) async {
+    SubscriptionAuditSource? unmarked;
+    await tester.pumpWidget(
+      host(
+        lastCheckedAt: <String, DateTime>{
+          'apple_id': now.subtract(const Duration(days: 3)),
+        },
+        onMarkChecked: (_) {},
+        onUnmark: (s) => unmarked = s,
+        onRegister: (_) {},
+      ),
+    );
+
+    final appleRow = find.byKey(const Key('asset_subscription_audit_apple_id'));
+    // 確認済みの Apple 行にだけ取り消しボタンが出る。
+    expect(
+      find.descendant(of: appleRow, matching: find.text('確認を取り消す')),
+      findsOneWidget,
+    );
+    // 未確認の card 行には出ない。
+    final cardRow = find.byKey(
+      const Key('asset_subscription_audit_card_aupay_card'),
+    );
+    expect(
+      find.descendant(of: cardRow, matching: find.text('確認を取り消す')),
+      findsNothing,
+    );
+
+    await tester.tap(
+      find.descendant(of: appleRow, matching: find.text('確認を取り消す')),
+    );
+    expect(unmarked?.id, 'apple_id');
   });
 
   testWidgets('checked source shows 確認済み and clears the recheck badge',


### PR DESCRIPTION
## 背景

「サブスク棚卸し」カードで支払い元ごとの「確認した」を**誤って押しても取り消す手段が無かった**（一度確認すると 30 日経って「要再確認」になるまで戻せない）。誤クリックの取り消しと、確認済みの解除の両方をできる UI を追加する。

## 変更点

- **常設「確認を取り消す」ボタン**: 確認済み / 要再確認の行にだけ表示し、押すと当該支払い元を「未確認」へ戻す。
- **即時「元に戻す」SnackBar**: 「確認した」直後に出し、誤クリックをその場で取り消せる。両経路とも同じ取り消し処理を通る。
- **端末跨ぎの正しい伝播**: 既存ストアは確認時刻の MAX マージ前提（巻き戻らない想定）。単純なキー削除だと他端末の古い時刻で**誤復活**するため、確認時刻と並行して**取り消し時刻（tombstone）も MAX マージ**し、新しい方の操作が勝つ方式にした（`effectiveCheckedAt`）。取り消し後は「未確認」に統一。
- サーバ集約値は後方互換のため v2 ネスト形 `{checked, unconfirmed}` に拡張（旧フラット形は確認のみとして読める）。

## テスト

- ストア単体: v2 エンコード/デコード往復・旧フラット形の後方互換・両マップの MAX マージ・`effectiveCheckedAt`（確認のみ / 取り消しが新しい→未確認 / 再確認が勝つ / 同時刻）。
- カード widget: 未確認行に取り消しボタンが出ない / 確認済み行に出て正しい支払い元で発火。
- `flutter analyze` 0 / 該当テスト 27 件緑 / `dart format` 差分なし（編集行を CI 整形に手合わせ）。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 確認解除はストア純関数(effectiveCheckedAt/decodeMirrorPayload)の単体テストとカードのwidgetテストで入出力を網羅し、認証必須の深い画面へのE2Eは費用対効果が低いため見送る
