### PR TITLE
feat(asset): サブスクの振替元にアコムショッピング枠 (shoppingDebt) を選べるように

### DIFF
--- a/lib/widgets/recurring_fixed_cost_editor_dialog.dart
+++ b/lib/widgets/recurring_fixed_cost_editor_dialog.dart
@@ -10,9 +10,10 @@ typedef RecurringFixedCostSourceOption = ({String id, String name});
 /// 振替元/請求先に選べる口座を組み立てる。
 ///
 /// 既定は資産口座 (残高>0) のみ。サブスク等カードへ請求される費用では
-/// [includeCards] = true で**残高の符号によらず**クレジット/プリペイドカード
-/// (例: ファミペイ バーチャルカード) も含める。FamiPay は後払い/残高0だと
-/// `balance > 0` だけのフィルタでは選べないため、請求先カードとして拾えるようにする。
+/// [includeCards] = true で**残高の符号によらず**クレジット/プリペイドカードや
+/// ショッピング枠 (例: ファミペイ バーチャルカード / アコムショッピング枠) も含める。
+/// これらは後払い/残高<=0 だと `balance > 0` だけのフィルタでは選べないため、請求先
+/// (リボ/分割で買い物に使う与信枠) として拾えるようにする。
 /// [includeCarrierBilling] = true で auかんたん決済 (au通信料金合算) 等のキャリア決済
 /// 口座 (au / KDDI) も含める。これらは負債(請求)口座で残高<=0 のため通常は出ない。
 List<RecurringFixedCostSourceOption> recurringFixedCostSourceOptions(
@@ -23,11 +24,18 @@ List<RecurringFixedCostSourceOption> recurringFixedCostSourceOptions(
   return <RecurringFixedCostSourceOption>[
     for (final account in accounts)
       if (account.balance > 0 ||
-          (includeCards &&
-              account.kind == AssetLiabilityAccountKind.creditCard) ||
+          (includeCards && _isChargeableCardAccount(account)) ||
           (includeCarrierBilling && _isCarrierBillingAccount(account)))
         (id: account.id, name: account.name),
   ];
+}
+
+/// 買い物に使える与信枠の口座か (請求先候補)。クレジット/プリペイドカードに加え、
+/// アコムショッピング枠などのショッピング枠 (shoppingDebt) も含める。消費者ローン
+/// (cardLoan = 現金借入) や公共料金 (utility) は買い物の請求先ではないため除外。
+bool _isChargeableCardAccount(AssetLiabilityAccount account) {
+  return account.kind == AssetLiabilityAccountKind.creditCard ||
+      account.kind == AssetLiabilityAccountKind.shoppingDebt;
 }
 
 /// auかんたん決済 (au通信料金合算) / KDDI などキャリア決済の口座か。残高の符号に依らず

--- a/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
+++ b/test/widgets/recurring_fixed_cost_editor_dialog_test.dart
@@ -24,25 +24,35 @@ void main() {
       acct('aupay', 'auPayカード', AssetLiabilityAccountKind.creditCard, 5000),
       acct('famipay', 'ファミペイカード', AssetLiabilityAccountKind.creditCard, 0),
       acct('mobit', 'モビット', AssetLiabilityAccountKind.cardLoan, -50000),
+      acct(
+        'acom_shopping',
+        'アコムショッピング',
+        AssetLiabilityAccountKind.shoppingDebt,
+        -180000,
+      ),
     ];
 
     test('default excludes non-positive cards (banks/positive cards only)', () {
       final ids =
           recurringFixedCostSourceOptions(accounts).map((o) => o.id).toList();
-      // 残高>0 の銀行と auPay は出る。残高0のファミペイと負債のモビットは出ない。
+      // 残高>0 の銀行と auPay は出る。残高0のファミペイと負債は出ない。
       expect(ids, containsAll(<String>['smbc', 'aupay']));
       expect(ids, isNot(contains('famipay')));
       expect(ids, isNot(contains('mobit')));
+      expect(ids, isNot(contains('acom_shopping')));
     });
 
-    test('includeCards surfaces zero/negative-balance credit cards', () {
+    test('includeCards surfaces cards and shopping credit', () {
       final ids = recurringFixedCostSourceOptions(
         accounts,
         includeCards: true,
       ).map((o) => o.id).toList();
-      // ファミペイ (creditCard / 残高0) が選べるようになる。
-      expect(ids, containsAll(<String>['smbc', 'aupay', 'famipay']));
-      // クレカでない負債 (cardLoan) は含めない。
+      // ファミペイ (creditCard / 残高0) とアコムショッピング枠 (shoppingDebt) が選べる。
+      expect(
+        ids,
+        containsAll(<String>['smbc', 'aupay', 'famipay', 'acom_shopping']),
+      );
+      // 現金借入の消費者ローン (cardLoan) は買い物の請求先でないため含めない。
       expect(ids, isNot(contains('mobit')));
       // 重複しない (auPay は1回だけ)。
       expect(ids.where((id) => id == 'aupay').length, 1);


### PR DESCRIPTION
## 概要

サブスクの**振替元に「アコムショッピング枠」を選べる**ようにします。Claude/Notion/Supabase/GCP 等をアコムショッピング枠(与信枠)で支払っているのに、当枠は `shoppingDebt` 種別(残高<=0)のため、従来の「残高>0 + creditCard」フィルタから漏れて振替元ドロップダウンに出ませんでした。先の [#3531](https://github.com/kanta13jp1/my_web_app/pull/3531)(ファミペイ=creditCard)/[#3541](https://github.com/kanta13jp1/my_web_app/pull/3541)(au=キャリア決済)に続くカバレッジ拡張。

## 変更点(2ファイル / +28-10)

- `recurringFixedCostSourceOptions` の `includeCards` 条件を `_isChargeableCardAccount` に集約し、`creditCard` に加え **`shoppingDebt`(アコムショッピング枠等)** も残高符号に依らず含める。
- 現金借入の**消費者ローン(`cardLoan`=モビット等)**や**公共料金(`utility`)**は「買い物の請求先」ではないため**除外**。
- サブスク登録/棚卸しの振替元は既に `includeCards: true` のため呼出側の変更なし。

## 検証

- `flutter analyze`(編集 lib + test): No issues found / `dart format`: 両ファイル 0 changed。
- `flutter test`: 振替元オプション(アコムショッピング枠を含む / モビット=cardLoan 除外 / 重複なし)含む全 13 green。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Additive funding-source filter (shoppingDebt) covered by unit tests (Acom shopping incl, cardLoan excluded, no dup); extends existing recurringFixedCostSourceOptions, no new e2e route

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive funding-source filter under lib/widgets (not lib/subscription); no auth/billing/RLS/deploy/migration; presentational dropdown option only, no cashflow change; analyze+13 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
