### PR TITLE
perf(hosting): Firebase Hosting にキャッシュヘッダを追加し転送量を削減

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -26,11 +26,116 @@
         ]
       },
       {
+        "source": "/canvaskit/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=86400"
+          }
+        ]
+      },
+      {
+        "source": "/icons/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=86400"
+          }
+        ]
+      },
+      {
+        "source": "/index.html",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/main.dart.js",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "application/javascript"
+          },
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/flutter.js",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "application/javascript"
+          },
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/flutter_bootstrap.js",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "application/javascript"
+          },
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/version.json",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/manifest.json",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
         "source": "**/flutter_service_worker.js",
         "headers": [
           {
             "key": "Content-Type",
             "value": "application/javascript"
+          },
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
           }
         ]
       }


### PR DESCRIPTION
## 概要

本番 `my-web-app-b67f4` の Firebase Hosting **Outgoing Bandwidth が月 174GB / ¥7,352**(年約 ¥8.8万)に達していた。原因は `firebase.json` に **`Cache-Control` が無く**、訪問のたびに Flutter の重いバンドル(特に CanvasKit)を再ダウンロードしていたこと。鮮度を壊さない範囲でキャッシュを効かせ、転送量を削減する。

## 変更点(firebase.json のみ)

| パス | Cache-Control | 理由 |
|---|---|---|
| `/canvaskit/**` | `public, max-age=31536000, immutable` | Flutter SDK 同梱・**アプリのデプロイ間で不変** → 端末ごとに1回だけ配信(最大の egress 削減) |
| `/assets/**`, `/icons/**` | `public, max-age=86400`(1日) | 変更頻度が低い |
| `index.html` / `main.dart.js` / `flutter.js` / `flutter_bootstrap.js` / `flutter_service_worker.js` / `version.json` / `manifest.json` | **`no-cache`** | デプロイ即反映(ETag 再検証で 304)。**stale バンドル問題を再発させない** |

🔴 **安全性**: 「旧版が出る」事象の原因になる鮮度クリティカルなファイル(HTML/main.dart.js/SW/version)は **すべて no-cache 維持**。長期キャッシュは**内容不変な CanvasKit のみ**。よって今セッションで散々戦った stale バンドル問題は再発しません。

## 効果

不変な CanvasKit(~2-3MB)を端末ごとに1回しか配信しなくなり、繰り返し訪問・複数端末・多タブでの再DLが止まる → egress を大きく削減(6月は既に ¥3,171 へ半減傾向、本変更でさらに低下見込み)。

## 補足(別対応の候補)
- `web/index.html` が毎ロードで Service Worker を破棄しているのが egress のもう一つの要因。これは「鮮度 vs 転送量」のトレードオフでデリケート(stale バンドル再発リスク)なため**本PRには含めず**、別途相談。
- 毎時の自動コミット(health-monitor 等)が `deploy-prod` を起動し都度バンドルを再生成 → キャッシュバストしている可能性。docs のみ変更時の deploy スキップも別途検討余地。

## 検証
- `firebase.json` の JSON パース成功・ヘッダルール 12 件・鮮度クリティカル6種が `no-cache`・CanvasKit が immutable であることをアサート確認。
- 設定変更のため `deploy-prod` で本番反映され、次回以降の転送量に効きます。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Config-only change (firebase.json hosting cache headers); no app code, no testable runtime logic; verified by JSON parse + per-file Cache-Control assertion; effect observable only on deployed CDN egress

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Firebase Hosting cache headers only (no app code/auth/RLS/migration); freshness-critical files (index.html/main.dart.js/flutter_service_worker.js/version.json) kept no-cache so stale-bundle cannot recur; only immutable CanvasKit gets long cache; JSON validated, headers verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
