### PR TITLE
i18n: AI大学プロバイダーページの英語UIを日本語化

### DIFF
--- a/lib/data/ai_university_genre_catalog.dart
+++ b/lib/data/ai_university_genre_catalog.dart
@@ -43,13 +43,11 @@ const AiUniversityGenreEntry kLegalAiGenre = AiUniversityGenreEntry(
 
 const AiUniversityGenreEntry kFintechTradingAiGenre = AiUniversityGenreEntry(
   id: 'fintech_trading_ai',
-  title: 'FinTech/Trading AI',
-  headline: 'Decompose institutional finance workflows with low-cost AI',
-  description:
-      'Compare professional terminals with Claude Pro, Cursor, and the '
-      'Jibun Company signal-to-action pipeline. The learning path covers raw '
-      'news capture, confidence scoring, fake-news filters, and human final '
-      'review.',
+  title: '金融・トレーディングAI',
+  headline: '機関投資家の金融ワークフローを低コストAIで分解する',
+  description: '専門端末を Claude Pro・Cursor・自分株式会社のシグナル→アクション '
+      'パイプラインと比較します。学習の流れは、生ニュースの取得・確信度スコアリング・'
+      'フェイクニュース判定・人による最終確認までをカバーします。',
   providerIds: [
     'bloomberg_terminal',
     'refinitiv_eikon',
@@ -61,10 +59,10 @@ const AiUniversityGenreEntry kFintechTradingAiGenre = AiUniversityGenreEntry(
     'cursor_jibun_finance',
   ],
   focusAreas: [
-    'market intelligence',
-    'signal detection',
-    'source confidence',
-    'cost discipline',
+    '市場インテリジェンス',
+    'シグナル検出',
+    '情報源の信頼度',
+    'コスト規律',
   ],
   accentColor: Color(0xFF0F766E),
   launchProviderId: 'claude_pro_finance',

--- a/lib/pages/gemini_university_v2_page.dart
+++ b/lib/pages/gemini_university_v2_page.dart
@@ -6491,7 +6491,7 @@ class _AiUniversityPageState extends State<AiUniversityPage>
                 const SizedBox(width: 8),
                 const Expanded(
                   child: Text(
-                    'RLHF quality loop',
+                    'RLHF 品質ループ',
                     style: TextStyle(
                       color: Color(0xFFE5E7EB),
                       fontWeight: FontWeight.w800,
@@ -6521,7 +6521,7 @@ class _AiUniversityPageState extends State<AiUniversityPage>
             ),
             const SizedBox(height: 10),
             Text(
-              'Learner reactions are stored as preference data, scored like a Scale-style feedback set, and used to decide what to improve next.',
+              '学習者の反応を選好データとして蓄積し、Scale 社流のフィードバックのようにスコア化して、次に改善すべき点の判断に使います。',
               style: TextStyle(
                 color: Colors.white.withValues(alpha: 0.74),
                 fontSize: 12,
@@ -6533,18 +6533,18 @@ class _AiUniversityPageState extends State<AiUniversityPage>
               spacing: 8,
               runSpacing: 8,
               children: [
-                _buildRlhfMetricChip('Signals', '${snapshot.totalSignals}'),
+                _buildRlhfMetricChip('シグナル', '${snapshot.totalSignals}'),
                 _buildRlhfMetricChip(
-                  'Provider',
+                  'このAI',
                   providerSignals.toString(),
                 ),
                 _buildRlhfMetricChip(
-                  'Avg',
+                  '平均',
                   snapshot.averageRating.toStringAsFixed(1),
                 ),
                 _buildRlhfMetricChip(
-                  'Ready',
-                  snapshot.readyForFineTune ? 'Yes' : 'No',
+                  '微調整',
+                  snapshot.readyForFineTune ? '可' : '未',
                 ),
               ],
             ),
@@ -6573,7 +6573,7 @@ class _AiUniversityPageState extends State<AiUniversityPage>
                       helpful: true,
                     ),
                     icon: const Icon(Icons.thumb_up_alt_outlined, size: 16),
-                    label: const Text('Useful'),
+                    label: const Text('役に立った'),
                     style: FilledButton.styleFrom(
                       backgroundColor: m.color,
                       foregroundColor: Colors.white,
@@ -6585,7 +6585,7 @@ class _AiUniversityPageState extends State<AiUniversityPage>
                       helpful: false,
                     ),
                     icon: const Icon(Icons.report_problem_outlined, size: 16),
-                    label: const Text('Needs fix'),
+                    label: const Text('改善が必要'),
                   ),
                 ],
               ),
@@ -6616,7 +6616,7 @@ class _AiUniversityPageState extends State<AiUniversityPage>
               const SizedBox(width: 8),
               const Expanded(
                 child: Text(
-                  'First-party data tuning readiness',
+                  '自社データ調整の準備度',
                   style: TextStyle(
                     color: Color(0xFFE5E7EB),
                     fontSize: 13,
@@ -6661,19 +6661,19 @@ class _AiUniversityPageState extends State<AiUniversityPage>
             runSpacing: 8,
             children: [
               _buildRlhfMetricChip(
-                'Eligible',
+                '有効',
                 '${snapshot.eligibleRecords}/${snapshot.eligibleTarget}',
               ),
-              _buildRlhfMetricChip('Total', '${snapshot.totalRecords}'),
-              _buildRlhfMetricChip('Blocked', '${snapshot.blockedRecords}'),
-              _buildRlhfMetricChip('PII', snapshot.piiRisk),
+              _buildRlhfMetricChip('総数', '${snapshot.totalRecords}'),
+              _buildRlhfMetricChip('除外', '${snapshot.blockedRecords}'),
+              _buildRlhfMetricChip('個人情報', _jaPiiRisk(snapshot.piiRisk)),
               _buildRlhfMetricChip(
-                'Eval',
-                snapshot.readyForEvalBatch ? 'Ready' : 'No',
+                '評価',
+                snapshot.readyForEvalBatch ? '可' : '未',
               ),
               _buildRlhfMetricChip(
-                'Tune',
-                snapshot.readyForFineTune ? 'Ready' : 'No',
+                '微調整',
+                snapshot.readyForFineTune ? '可' : '未',
               ),
             ],
           ),
@@ -6689,6 +6689,19 @@ class _AiUniversityPageState extends State<AiUniversityPage>
         ],
       ),
     );
+  }
+
+  String _jaPiiRisk(String risk) {
+    switch (risk) {
+      case 'low':
+        return '低';
+      case 'medium':
+        return '中';
+      case 'high':
+        return '高';
+      default:
+        return '不明';
+    }
   }
 
   Widget _buildRlhfMetricChip(String label, String value) {

--- a/lib/services/ai_university_rlhf_service.dart
+++ b/lib/services/ai_university_rlhf_service.dart
@@ -34,7 +34,7 @@ class AiUniversityRlhfSnapshot {
         qualityScore: 0,
         readyForFineTune: false,
         providerSignalCounts: {},
-        nextAction: 'Collect learner feedback on lessons and quizzes.',
+        nextAction: 'レッスンやクイズへの学習者フィードバックを集めましょう。',
       );
 
   factory AiUniversityRlhfSnapshot.fromJson(Map<String, dynamic> json) {
@@ -55,8 +55,8 @@ class AiUniversityRlhfSnapshot {
       qualityScore: (json['quality_score'] as num?)?.toInt() ?? 0,
       readyForFineTune: json['ready_for_fine_tune'] == true,
       providerSignalCounts: counts,
-      nextAction: json['next_action'] as String? ??
-          'Collect learner feedback on lessons and quizzes.',
+      nextAction:
+          json['next_action'] as String? ?? 'レッスンやクイズへの学習者フィードバックを集めましょう。',
     );
   }
 
@@ -150,12 +150,12 @@ class AiUniversityRlhfSnapshot {
     required int qualityScore,
   }) {
     if (totalSignals < 20) {
-      return 'Collect at least 20 preference signals before tuning.';
+      return 'チューニング前に、まず選好シグナルを20件以上集めましょう。';
     }
     if (qualityScore < 70) {
-      return 'Review low-rated lessons and regenerate weak explanations.';
+      return '低評価のレッスンを見直し、弱い解説を再生成しましょう。';
     }
-    return 'Dataset is ready for fine-tuning or evaluation batches.';
+    return 'データセットは微調整・評価バッチに利用できる状態です。';
   }
 }
 

--- a/lib/services/user_data_finetune_readiness_service.dart
+++ b/lib/services/user_data_finetune_readiness_service.dart
@@ -30,15 +30,14 @@ class UserDataFineTuneReadinessSnapshot {
       piiRisk: 'low',
       sourceCounts: {},
       signalSummary: {},
-      kgi: 'Use first-party product data to improve AI answer quality.',
+      kgi: '自社プロダクトのデータでAIの回答品質を高めます。',
       csf: [
         'Collect consent-aware feedback',
         'De-identify before export',
         'Evaluate before fine-tuning',
       ],
       kpi: {},
-      nextAction:
-          'Collect more explicit Useful/Needs fix feedback before tuning.',
+      nextAction: 'チューニング前に、「役に立った／改善が必要」の明示的なフィードバックをさらに集めましょう。',
     );
   }
 

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -2196,12 +2196,12 @@ function rlhfQualityScore(
 
 function rlhfNextAction(totalSignals: number, qualityScore: number): string {
   if (totalSignals < 20) {
-    return "Collect at least 20 preference signals before tuning.";
+    return "チューニング前に、まず選好シグナルを20件以上集めましょう。";
   }
   if (qualityScore < 70) {
-    return "Review low-rated lessons and regenerate weak explanations.";
+    return "低評価のレッスンを見直し、弱い解説を再生成しましょう。";
   }
-  return "Dataset is ready for fine-tuning or evaluation batches.";
+  return "データセットは微調整・評価バッチに利用できる状態です。";
 }
 
 function buildRlhfSnapshot(
@@ -2325,10 +2325,10 @@ function buildUserDataFineTuneReadiness(
     sourceCoverage >= 2;
   const piiRisk = commentRows > 0 || judgmentTotal > 0 ? "medium" : "low";
   const nextAction = readyForFineTune
-    ? "Freeze a de-identified JSONL training set and run an offline evaluation before any fine-tune job."
+    ? "匿名化済みの JSONL 学習セットを確定し、微調整ジョブの前にオフライン評価を実施しましょう。"
     : readyForEvalBatch
-    ? "Create an evaluation batch first; keep collecting preference pairs until 100+ eligible records."
-    : "Collect more explicit Useful/Needs fix feedback and daily judgment outcomes before tuning.";
+    ? "まず評価バッチを作成し、有効レコードが100件以上になるまで選好ペアを集め続けましょう。"
+    : "チューニング前に、「役に立った／改善が必要」の明示的なフィードバックと日々の判断結果をさらに集めましょう。";
 
   return {
     method: "scale_egp_first_party_data_engine_v1",
@@ -2352,7 +2352,7 @@ function buildUserDataFineTuneReadiness(
       review_judgments: reviewJudgments,
     },
     kgi:
-      "Use first-party product data to improve AI answer quality without unsafe raw-data fine-tuning.",
+      "安全でない生データの微調整に頼らず、自社プロダクトのデータでAIの回答品質を高めます。",
     csf: [
       "Consent-aware first-party signal collection",
       "De-identification before export",
@@ -3995,7 +3995,10 @@ serve(async (req: Request) => {
         if (!geminiKey) {
           return json({ error: "GEMINI_API_KEY not configured" }, 503);
         }
-        const level = Math.min(Math.max(Math.round(asNumber(body.level, 3)), 1), 6);
+        const level = Math.min(
+          Math.max(Math.round(asNumber(body.level, 3)), 1),
+          6,
+        );
         // ユーザー入力 topic はプロンプト注入面を絞るため空白正規化 + 80 字上限。
         const topic = asString(body.topic).replace(/\s+/g, " ").slice(0, 80)
           .trim();
@@ -4090,8 +4093,9 @@ serve(async (req: Request) => {
           );
         }
 
-        const wordCount =
-          passage.trim().split(/\s+/).filter((w) => w.length > 0).length;
+        const wordCount = passage.trim().split(/\s+/).filter((w) =>
+          w.length > 0
+        ).length;
         const lessonCode = `AI-L${level}-${userId.slice(0, 8)}-${Date.now()}`;
         const title = asString(parsed.title) || `AI Lesson (Level ${level})`;
         const topicOut = asString(parsed.topic) || topic || "general";
@@ -4122,7 +4126,10 @@ serve(async (req: Request) => {
         if (!userId) return json({ error: "Unauthorized" }, 401);
         const lessonCode = asString(body.lesson_code);
         const lessonId = asString(body.lesson_id);
-        const level = Math.min(Math.max(Math.round(asNumber(body.level, 1)), 1), 6);
+        const level = Math.min(
+          Math.max(Math.round(asNumber(body.level, 1)), 1),
+          6,
+        );
         const mode = asString(body.mode) === "rsvp" ? "rsvp" : "measure";
         const wordCount = Math.max(0, Math.round(asNumber(body.word_count, 0)));
         const elapsedMs = Math.max(0, Math.round(asNumber(body.elapsed_ms, 0)));
@@ -4140,9 +4147,7 @@ serve(async (req: Request) => {
         const wpm = wordCount > 0 && minutes > 0
           ? Math.round(wordCount / minutes)
           : 0;
-        const ratio = total > 0
-          ? Math.min(Math.max(correct / total, 0), 1)
-          : 1;
+        const ratio = total > 0 ? Math.min(Math.max(correct / total, 0), 1) : 1;
         const effectiveWpm = wpm > 0 ? Math.round(wpm * ratio) : 0;
 
         const insertRow: Record<string, unknown> = {

--- a/test/data/ai_university_genre_catalog_test.dart
+++ b/test/data/ai_university_genre_catalog_test.dart
@@ -42,6 +42,6 @@ void main() {
 
     expect(genre, isNotNull);
     expect(genre!.id, 'fintech_trading_ai');
-    expect(genre.title, 'FinTech/Trading AI');
+    expect(genre.title, '金融・トレーディングAI');
   });
 }

--- a/test/services/ai_university_rlhf_service_test.dart
+++ b/test/services/ai_university_rlhf_service_test.dart
@@ -57,7 +57,7 @@ void main() {
       expect(snapshot.readyForFineTune, isFalse);
       expect(
         snapshot.nextAction,
-        'Collect at least 20 preference signals before tuning.',
+        'チューニング前に、まず選好シグナルを20件以上集めましょう。',
       );
     });
 
@@ -77,7 +77,7 @@ void main() {
       expect(snapshot.qualityScore, 100);
       expect(
         snapshot.nextAction,
-        'Dataset is ready for fine-tuning or evaluation batches.',
+        'データセットは微調整・評価バッチに利用できる状態です。',
       );
     });
   });

--- a/test/services/user_data_finetune_readiness_service_test.dart
+++ b/test/services/user_data_finetune_readiness_service_test.dart
@@ -47,7 +47,7 @@ void main() {
       expect(snapshot.readyForEvalBatch, isFalse);
       expect(snapshot.readyForFineTune, isFalse);
       expect(snapshot.eligibleProgress, 0);
-      expect(snapshot.nextAction, contains('Collect more'));
+      expect(snapshot.nextAction, contains('さらに集めましょう'));
     });
   });
 }


### PR DESCRIPTION
## 概要

ユーザー報告「AI大学の英語表記を日本語に直したい」(UI全部) に対応。AI大学プロバイダーページの英語UIを日本語化します。掲載記事本文(DB seed)は対象外。

## 変更点

- **RLHF 品質ループ / 自社データ調整の準備度カード**: 見出し・説明・チップ（シグナル / このAI / 平均 / 微調整 / 有効 / 総数 / 除外 / 個人情報 / 評価）・ボタン（役に立った / 改善が必要）を日本語化。PII値（low/medium/high）は表示時に 低/中/高 へ写像（データ・ロジックは不変）
- **計算メッセージ**（nextAction / kgi）を Dartサービス + ai-hub サーバの双方で日本語化（ログイン時はサーバ値を表示するため両方必要）
- **FinTech/Trading AI ジャンルカタログ**（見出し・説明・タグ）を日本語化（法律AIは既に日本語）
- rlhf service テストの nextAction 期待値を日本語へ同期

## 検証

- `dart analyze` = No issues found / `dart format --set-exit-if-changed` = clean
- `flutter test`（rlhf service・日本語期待値）= 全3件 green
- ai-hub の変更は表示文字列のみ（認可ゲート・スキーマ・計算ロジックは不変）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: AI大学プロバイダーページの英語UI文字列を日本語化する表示専用の変更。ロジック変更はPII値の表示写像(low/medium/high→低/中/高)のみで計算・データ契約は不変。純関数テストは日本語期待値へ同期しgreen、視覚確認は反映後の実機で実施。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ai-hub変更は表示文字列(nextAction/kgi)の日本語化のみでロジック・権限・スキーマは不変。display-only i18n。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
