### PR TITLE
feat(asset): アクションアイテムに対処できる場所へのジャンプリンクを追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -113,6 +113,30 @@ enum _PaymentSourceSaveScope { monthlyOverride, defaultSetting }
 
 enum _DebtMasterReviewFilter { all, billingConfirmation, paymentSource }
 
+/// アクションアイテムから「対処できる場所」へのジャンプリンク文言を返す。
+/// null の場合はリンクを表示しない (関連口座が無い種別など)。
+/// 純関数なので widget を組まずに種別→文言の対応をテストできる。
+@visibleForTesting
+String? assetManagementActionJumpLabel(AssetManagementInsightActionItem item) {
+  final accountId = item.relatedAccountId;
+  if (accountId == null || accountId.trim().isEmpty) {
+    return null;
+  }
+  return switch (item.type) {
+    AssetManagementInsightActionType.missingPaymentDay => '支払日を入力する',
+    AssetManagementInsightActionType.missingInput => '今月支払予定額を入力する',
+    AssetManagementInsightActionType.missingAnnualRate => '利率を入力する',
+    AssetManagementInsightActionType.missingPaymentSource => '支払原資口座を設定する',
+    AssetManagementInsightActionType.cardBillingConfiguration =>
+      '支払い方式と請求先カードを設定する',
+    AssetManagementInsightActionType.doubleCountingRisk => '支払い方式を整理する',
+    AssetManagementInsightActionType.overduePayment => '支払済みチェックへ移動',
+    AssetManagementInsightActionType.upcomingPayment => '支払予定を確認する',
+    AssetManagementInsightActionType.cashShortageRisk => '支払予定を確認する',
+    _ => null,
+  };
+}
+
 class _PaymentSourceCandidate {
   final AssetLiabilityAccount account;
   final double currentBalance;
@@ -17611,7 +17635,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             _buildAssetManagementDisciplineCard(report.disciplineReport!),
             const SizedBox(height: 12),
           ],
-          _buildAssetManagementAssistantActionList(report.actionItems),
+          _buildAssetManagementAssistantActionList(
+            report.actionItems,
+            report.workbook.debtMasterRows.map((row) => row.id).toSet(),
+          ),
           if (report.movementSuggestions.isNotEmpty) ...[
             const SizedBox(height: 12),
             _buildAssetManagementMovementSuggestionList(
@@ -18915,6 +18942,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   Widget _buildAssetManagementAssistantActionList(
     List<AssetManagementInsightActionItem> actionItems,
+    Set<String> debtMasterCardIds,
   ) {
     if (actionItems.isEmpty) {
       return Container(
@@ -18945,7 +18973,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         for (final item in actionItems.take(8))
           Padding(
             padding: const EdgeInsets.only(bottom: 6),
-            child: _buildAssetManagementAssistantActionTile(item),
+            child: _buildAssetManagementAssistantActionTile(
+              item,
+              debtMasterCardIds,
+            ),
           ),
         if (actionItems.length > 8)
           Text(
@@ -18959,33 +18990,20 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
-  String? _assetManagementActionJumpLabel(
-    AssetManagementInsightActionItem item,
-  ) {
-    final accountId = item.relatedAccountId;
-    if (accountId == null || accountId.trim().isEmpty) {
-      return null;
-    }
-    return switch (item.type) {
-      AssetManagementInsightActionType.missingPaymentDay => '支払日を入力する',
-      AssetManagementInsightActionType.missingInput => '今月支払予定額を入力する',
-      AssetManagementInsightActionType.missingAnnualRate => '利率を入力する',
-      AssetManagementInsightActionType.missingPaymentSource => '支払原資口座を設定する',
-      AssetManagementInsightActionType.cardBillingConfiguration =>
-        '支払い方式と請求先カードを設定する',
-      AssetManagementInsightActionType.doubleCountingRisk => '支払い方式を整理する',
-      _ => null,
-    };
-  }
-
   Widget _buildAssetManagementAssistantActionTile(
     AssetManagementInsightActionItem item,
+    Set<String> debtMasterCardIds,
   ) {
     final color = _assetManagementInsightSeverityColor(item.severity);
     final dueLabel = item.dueDate == null
         ? (item.paymentDay == null ? null : '${item.paymentDay}日')
         : DateFormat('M/d').format(item.dueDate!);
-    final jumpLabel = _assetManagementActionJumpLabel(item);
+    final jumpLabel = assetManagementActionJumpLabel(item);
+    // 移動先の負債マスタカードが実在する項目だけリンクを出す
+    // (合成IDのアコムショッピング返済等で dead button を出さない)。
+    final canJump = jumpLabel != null &&
+        item.relatedAccountId != null &&
+        debtMasterCardIds.contains(item.relatedAccountId);
 
     return Container(
       width: double.infinity,
@@ -19050,7 +19068,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   item.suggestedAction,
                   style: const TextStyle(fontSize: 12, height: 1.5),
                 ),
-                if (jumpLabel != null)
+                if (canJump)
                   Align(
                     alignment: Alignment.centerLeft,
                     child: TextButton.icon(

--- a/test/pages/asset_management_action_jump_label_test.dart
+++ b/test/pages/asset_management_action_jump_label_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/asset_management_page.dart';
+import 'package:my_web_app/services/asset_management_insight_service.dart';
+
+/// アクションアイテムの「対処できる場所」へのジャンプリンク文言マッピングを検証する。
+/// widget を組まず、種別 → 文言の純粋な対応だけをテストする (#issue-1215 HITL)。
+AssetManagementInsightActionItem _item(
+  AssetManagementInsightActionType type, {
+  String? relatedAccountId = 'debt-1',
+}) {
+  return AssetManagementInsightActionItem(
+    type: type,
+    severity: AssetManagementInsightSeverity.warning,
+    title: 'title',
+    description: 'description',
+    relatedAccountId: relatedAccountId,
+    dueDate: null,
+    paymentDay: null,
+    suggestedAction: 'suggestedAction',
+  );
+}
+
+void main() {
+  group('assetManagementActionJumpLabel', () {
+    test('期限超過は支払済みチェックへのリンク文言を返す', () {
+      expect(
+        assetManagementActionJumpLabel(
+          _item(AssetManagementInsightActionType.overduePayment),
+        ),
+        '支払済みチェックへ移動',
+      );
+    });
+
+    test('支払日近接・資金ショートは支払予定確認リンクを返す', () {
+      expect(
+        assetManagementActionJumpLabel(
+          _item(AssetManagementInsightActionType.upcomingPayment),
+        ),
+        '支払予定を確認する',
+      );
+      expect(
+        assetManagementActionJumpLabel(
+          _item(AssetManagementInsightActionType.cashShortageRisk),
+        ),
+        '支払予定を確認する',
+      );
+    });
+
+    test('既存の入力不備系リンク文言は維持される (回帰)', () {
+      expect(
+        assetManagementActionJumpLabel(
+          _item(AssetManagementInsightActionType.missingPaymentDay),
+        ),
+        '支払日を入力する',
+      );
+      expect(
+        assetManagementActionJumpLabel(
+          _item(AssetManagementInsightActionType.missingPaymentSource),
+        ),
+        '支払原資口座を設定する',
+      );
+    });
+
+    test('関連口座が無い項目はリンクを出さない (null)', () {
+      expect(
+        assetManagementActionJumpLabel(
+          _item(
+            AssetManagementInsightActionType.overduePayment,
+            relatedAccountId: null,
+          ),
+        ),
+        isNull,
+      );
+      expect(
+        assetManagementActionJumpLabel(
+          _item(
+            AssetManagementInsightActionType.overduePayment,
+            relatedAccountId: '   ',
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('リンク対象外の種別は null を返す', () {
+      expect(
+        assetManagementActionJumpLabel(
+          _item(AssetManagementInsightActionType.emergencyLivingExpense),
+        ),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

資産管理闘争ページの「アクションアイテム」で、各項目から、その内容に対処できる UI へ移動するジャンプリンクを表示できるようにした。

これまでジャンプリンクは入力不備系の項目にしか出ておらず、「◯◯が期限超過です／支払済みならチェックを更新してください」のような項目には移動手段が無く、どこで操作すればよいか分かりにくかった（実機でのユーザー要望）。

## 変更点

- 期限超過・支払日近接・資金ショートのアクションアイテムにジャンプ文言を追加
  - 期限超過 → 「支払済みチェックへ移動」
  - 支払日近接 / 資金ショート → 「支払予定を確認する」
- クリックで既存の負債マスタカード（支払済みチェックを内蔵）へスクロール（既存の `_jumpToDebtMasterCard` 移動機構を再利用）
- 移動先カードが実在する項目のみリンクを表示し、リンク切れ（合成IDのアコムショッピング返済など）を防止
- ジャンプ文言判定を純関数 `assetManagementActionJumpLabel` に抽出し、種別→文言の対応をユニットテスト化

サービス層（モデル）の変更は無し。UI のみの加算的変更。

## テスト

- `test/pages/asset_management_action_jump_label_test.dart`: 種別→文言マッピング、関連口座が無い場合の非表示、対象外種別の null を検証（5 ケース）
- 既存の `asset_management_page_smoke_test`（48 ケース）緑で回帰なし
- `dart analyze` クリーン / `dart format --set-exit-if-changed` 差分なし

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純粋なリンク文言マッピングはユニットテスト、UI配線は既存スモーク(48ケース)で担保。対象アクションはログイン後データ依存で未ログインE2Eハーネスでは再現不可。
