### PR TITLE
perf(asset): 起動時の asset_pref_mirror 個別読み取りをバッチ取得へ集約 (ERR_INSUFFICIENT_RESOURCES 緩和)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -38,6 +38,7 @@ import 'package:my_web_app/services/asset_management_ai_summary_refresh.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
 import 'package:my_web_app/services/asset_account_balance_history_store.dart';
+import 'package:my_web_app/services/asset_pref_mirror_prefetch.dart';
 import 'package:my_web_app/services/asset_debt_discipline_monitor.dart';
 import 'package:my_web_app/services/asset_debt_trend_analyzer.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
@@ -313,6 +314,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Timer? _deadlineTimer;
   DateTime _now = DateTime.now();
 
+  /// 起動時の `asset_pref_mirror` 個別読み取り (~20 箇所) を 1 回のバッチ取得へ
+  /// 集約するためのプリフェッチ結果 (`pref_key` → 行)。null = 未起動 / 失効後 で、
+  /// その場合は各読み取りが従来どおり個別 `.eq('pref_key', X)` へフォールバックする。
+  /// 同時多発する REST が `ERR_INSUFFICIENT_RESOURCES` を誘発するのを緩和する。
+  Future<Map<String, Map<String, dynamic>>>? _bootPrefMirrorFuture;
+
+  /// 起動バーストが収束したらキャッシュを失効させ、以降の読み取りを最新化する。
+  Timer? _bootPrefMirrorExpiryTimer;
+
   // Supabaseに保存する「今日の締め」状態
   bool _assetsDone = false;
   bool _liabilitiesDone = false;
@@ -392,11 +402,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     try {
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select('pref_key')
-          .eq('pref_key', prefKey)
-          .limit(1);
+      final rows = await _bootSelectPrefMirror(prefKey);
       // select の間にログアウト/別アカウントへ切替わっていないか再確認する。
       // 前アカウントのローカル値を新しい user_id で誤アップロードしない (review medium)。
       if (_supabase.auth.currentUser?.id != userId) {
@@ -408,6 +414,58 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('pref backfill check failed ($prefKey): $e');
     }
+  }
+
+  /// 当該ユーザーの `asset_pref_mirror` 行を 1 回だけまとめて取得し `pref_key` で
+  /// 索引する。起動時の多数の個別読み取りを 1 回の REST に集約するための土台。
+  Future<Map<String, Map<String, dynamic>>> _fetchAllPrefMirror() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return <String, Map<String, dynamic>>{};
+    }
+    try {
+      final rows = await _supabase
+          .from('asset_pref_mirror')
+          .select()
+          .eq('user_id', userId);
+      return indexPrefMirrorRowsByKey(rows);
+    } catch (e) {
+      debugPrint('boot pref mirror prefetch failed: $e');
+      return <String, Map<String, dynamic>>{};
+    }
+  }
+
+  /// 起動時バッチ取得から [prefKey] の行群を返す。個別
+  /// `.eq('pref_key', prefKey)` select と同形 (0〜1 行のリスト) を返すため、各
+  /// 読み取り側のロジックは不変。バッチ未起動 / 失効後 / 未ログインなら従来どおり
+  /// 個別フェッチへフォールバックする (= 振る舞い保存)。
+  Future<List<Map<String, dynamic>>> _bootSelectPrefMirror(String prefKey) {
+    return _bootSelectPrefMirrorKeys(<String>[prefKey]);
+  }
+
+  /// [prefKeys] のいずれかに一致する行をまとめて返す (個別 `.inFilter('pref_key', …)`
+  /// select と同形)。バッチが有効なら 1 回の取得結果から抽出し、無効なら個別 select
+  /// へフォールバックする。
+  Future<List<Map<String, dynamic>>> _bootSelectPrefMirrorKeys(
+    List<String> prefKeys,
+  ) async {
+    final future = _bootPrefMirrorFuture;
+    if (future != null) {
+      final cache = await future;
+      return <Map<String, dynamic>>[
+        for (final key in prefKeys)
+          if (cache[key] != null) cache[key]!,
+      ];
+    }
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return <Map<String, dynamic>>[];
+    }
+    final rows = await _supabase
+        .from('asset_pref_mirror')
+        .select()
+        .inFilter('pref_key', prefKeys);
+    return List<Map<String, dynamic>>.from(rows);
   }
 
   /// union マージでローカルデータが変化した後、ローカル更新時刻をミラー版
@@ -805,6 +863,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         AssetLiabilityRepositoryFactory.createDefault(
           supabaseClient: _supabase,
         );
+    // 起動時の asset_pref_mirror 個別読み取りを 1 回のバッチ取得へ集約する
+    // (端末跨ぎ同期の多数 REST が ERR_INSUFFICIENT_RESOURCES を誘発するのを緩和)。
+    // 起動バーストが収束したらキャッシュを失効させ、以降は最新を個別取得する。
+    _bootPrefMirrorFuture = _fetchAllPrefMirror();
+    _bootPrefMirrorExpiryTimer = Timer(const Duration(seconds: 20), () {
+      _bootPrefMirrorFuture = null;
+    });
     _loadDataFromSupabase();
     _loadAssetLiabilityMonthlyState();
     _loadWatchlistEntries();
@@ -878,6 +943,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _flowMemoController.dispose();
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
+    _bootPrefMirrorExpiryTimer?.cancel();
     _annualRateEvidencePasteRegistration?.dispose();
     _scrollController.dispose();
     super.dispose();
@@ -5656,10 +5722,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     try {
       Map<String, dynamic>? value = debugMirror;
       if (value == null) {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', 'watchlist_entries_deleted');
+        final rows = await _bootSelectPrefMirror('watchlist_entries_deleted');
         if (rows.isEmpty) {
           return;
         }
@@ -5720,10 +5783,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         value = debugMirror;
         mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', _watchlistMirrorKey);
+        final rows = await _bootSelectPrefMirror(_watchlistMirrorKey);
         if (rows.isEmpty) {
           // サーバ行が無い: ローカルにあれば初回バックフィル。
           if (hasLocal) {
@@ -8295,10 +8355,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     try {
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select()
-          .eq('pref_key', _salaryDayMirrorKey);
+      final rows = await _bootSelectPrefMirror(_salaryDayMirrorKey);
       if (rows.isEmpty) {
         return;
       }
@@ -8460,10 +8517,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         value = debugMirror;
         mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', _mainAccountMirrorKey);
+        final rows = await _bootSelectPrefMirror(_mainAccountMirrorKey);
         if (rows.isEmpty) {
           return;
         }
@@ -8521,14 +8575,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       var hasInflowOnServer = false;
       if (user != null) {
         try {
-          final rows = await _supabase
-              .from('asset_pref_mirror')
-              .select('pref_key')
-              .eq('user_id', user.id);
-          for (final row in rows) {
-            final key = row['pref_key'];
-            if (key is String) {
-              presentPrefKeys.add(key);
+          final boot = _bootPrefMirrorFuture;
+          if (boot != null) {
+            presentPrefKeys.addAll((await boot).keys);
+          } else {
+            final rows = await _supabase
+                .from('asset_pref_mirror')
+                .select('pref_key')
+                .eq('user_id', user.id);
+            for (final row in rows) {
+              final key = row['pref_key'];
+              if (key is String) {
+                presentPrefKeys.add(key);
+              }
             }
           }
         } catch (e) {
@@ -8680,10 +8739,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     final hasLocal = _categoryBudgets.isNotEmpty;
     try {
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select()
-          .eq('pref_key', _categoryBudgetsMirrorKey);
+      final rows = await _bootSelectPrefMirror(_categoryBudgetsMirrorKey);
       if (rows.isEmpty) {
         if (hasLocal) {
           unawaited(_mirrorCategoryBudgets());
@@ -8779,10 +8835,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
         mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', _recurringFixedCostsMirrorKey);
+        final rows = await _bootSelectPrefMirror(_recurringFixedCostsMirrorKey);
         if (rows.isEmpty) {
           // サーバ行が無い: ローカルにあれば初回バックフィル (他端末へ同期させる)。
           if (hasLocal) {
@@ -8930,10 +8983,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         serverValue = debugMirror;
         mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', _subscriptionAuditMirrorKey);
+        final rows = await _bootSelectPrefMirror(_subscriptionAuditMirrorKey);
         if (rows.isEmpty) {
           // サーバ行無し: ローカルにあれば初回バックフィル。
           if (localCheckedBefore.isNotEmpty ||
@@ -9279,10 +9329,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     try {
       Map<String, dynamic>? value = debugMirror;
       if (value == null) {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', _recurringFixedCostsDeletedMirrorKey);
+        final rows = await _bootSelectPrefMirror(
+          _recurringFixedCostsDeletedMirrorKey,
+        );
         if (rows.isEmpty) {
           return;
         }
@@ -9339,10 +9388,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     try {
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select()
-          .eq('pref_key', _recurringIgnoredMirrorKey);
+      final rows = await _bootSelectPrefMirror(_recurringIgnoredMirrorKey);
       if (rows.isEmpty) {
         return;
       }
@@ -9425,10 +9471,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     try {
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select()
-          .eq('pref_key', _duplicateIgnoredMirrorKey);
+      final rows = await _bootSelectPrefMirror(_duplicateIgnoredMirrorKey);
       if (rows.isEmpty) {
         return;
       }
@@ -9526,10 +9569,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     try {
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select()
-          .eq('pref_key', _recurringIncomeIgnoredMirrorKey);
+      final rows = await _bootSelectPrefMirror(
+        _recurringIncomeIgnoredMirrorKey,
+      );
       if (rows.isEmpty) {
         return;
       }
@@ -10080,10 +10122,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
         mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', _revolvingConfigsMirrorKey);
+        final rows = await _bootSelectPrefMirror(_revolvingConfigsMirrorKey);
         if (rows.isEmpty) {
           // サーバ行が無い: ローカルにあれば初回バックフィル (旧端末で設定済みの
           // リボ設定をサーバへ上げ、他端末へ同期させる)。
@@ -10241,10 +10280,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     try {
       Map<String, dynamic>? value = debugMirror;
       if (value == null) {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', 'revolving_credit_configs_deleted');
+        final rows = await _bootSelectPrefMirror(
+          'revolving_credit_configs_deleted',
+        );
         if (rows.isEmpty) {
           return;
         }
@@ -10509,14 +10547,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   /// 集約行を優先し、無ければ legacy per-key 行を per-key 形へ正規化して返す。
   Future<List<Map<String, dynamic>>> _fetchDisplayPrefRows() async {
-    final rows = List<Map<String, dynamic>>.from(
-      await _supabase.from('asset_pref_mirror').select().inFilter(
-            'pref_key',
-            AssetMirrorReadPolicy.readPrefKeys(
-              aggregatedKey: _displayPrefsAggregatedKey,
-              legacyKeys: const <String>['display_mode', 'section_overrides'],
-            ),
-          ),
+    final rows = await _bootSelectPrefMirrorKeys(
+      AssetMirrorReadPolicy.readPrefKeys(
+        aggregatedKey: _displayPrefsAggregatedKey,
+        legacyKeys: const <String>['display_mode', 'section_overrides'],
+      ),
     );
     for (final row in rows) {
       if (row['pref_key'] == _displayPrefsAggregatedKey) {
@@ -10547,14 +10582,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         );
       } else {
         // 集約行 (asset_display_prefs_v1) を優先、無ければ legacy 行。
-        final rows =
-            await _supabase.from('asset_pref_mirror').select().inFilter(
-                  'pref_key',
-                  AssetMirrorReadPolicy.readPrefKeys(
-                    aggregatedKey: _displayPrefsAggregatedKey,
-                    legacyKeys: const <String>['section_override_deleted'],
-                  ),
-                );
+        final rows = await _bootSelectPrefMirrorKeys(
+          AssetMirrorReadPolicy.readPrefKeys(
+            aggregatedKey: _displayPrefsAggregatedKey,
+            legacyKeys: const <String>['section_override_deleted'],
+          ),
+        );
         Map<String, dynamic>? aggregated;
         Map<String, dynamic>? legacy;
         for (final row in rows) {
@@ -11257,10 +11290,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         value = debugMirror;
         mirrorUpdatedAt = DateTime.now().toUtc();
       } else {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', 'debt_payment_day_overrides');
+        final rows = await _bootSelectPrefMirror('debt_payment_day_overrides');
         if (rows.isEmpty) {
           // サーバ行が無い: ローカルにあれば初回バックフィル。
           if (hasLocal) {
@@ -11387,10 +11417,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     try {
-      final rows = await _supabase
-          .from('asset_pref_mirror')
-          .select()
-          .eq('pref_key', 'account_balance_history');
+      final rows = await _bootSelectPrefMirror('account_balance_history');
       if (rows.isEmpty) {
         return;
       }
@@ -11483,14 +11510,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ids = AssetExpectedInflowStore.decodeDeletedIdsMirror(debugMirror);
       } else {
         // 集約行 (asset_inflow_prefs_v1) を優先、無ければ legacy 行。
-        final rows =
-            await _supabase.from('asset_pref_mirror').select().inFilter(
-                  'pref_key',
-                  AssetMirrorReadPolicy.readPrefKeys(
-                    aggregatedKey: _inflowPrefsAggregatedKey,
-                    legacyKeys: const <String>['inflow_deleted_ids'],
-                  ),
-                );
+        final rows = await _bootSelectPrefMirrorKeys(
+          AssetMirrorReadPolicy.readPrefKeys(
+            aggregatedKey: _inflowPrefsAggregatedKey,
+            legacyKeys: const <String>['inflow_deleted_ids'],
+          ),
+        );
         Map<String, dynamic>? aggregated;
         Map<String, dynamic>? legacy;
         for (final row in rows) {
@@ -11553,13 +11578,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
     try {
       // 集約行 (asset_inflow_prefs_v1) を優先、無ければ legacy 行。
-      final rows = await _supabase.from('asset_pref_mirror').select().inFilter(
-            'pref_key',
-            AssetMirrorReadPolicy.readPrefKeys(
-              aggregatedKey: _inflowPrefsAggregatedKey,
-              legacyKeys: const <String>['inflow_tombstone_gc'],
-            ),
-          );
+      final rows = await _bootSelectPrefMirrorKeys(
+        AssetMirrorReadPolicy.readPrefKeys(
+          aggregatedKey: _inflowPrefsAggregatedKey,
+          legacyKeys: const <String>['inflow_tombstone_gc'],
+        ),
+      );
       Map<String, dynamic>? aggregated;
       Map<String, dynamic>? legacy;
       for (final row in rows) {
@@ -23148,10 +23172,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     try {
       Map<String, dynamic>? value = debugMirror;
       if (value == null) {
-        final rows = await _supabase
-            .from('asset_pref_mirror')
-            .select()
-            .eq('pref_key', 'debt_payment_day_override_deleted');
+        final rows = await _bootSelectPrefMirror(
+          'debt_payment_day_override_deleted',
+        );
         if (rows.isEmpty) {
           return;
         }

--- a/lib/services/asset_pref_mirror_prefetch.dart
+++ b/lib/services/asset_pref_mirror_prefetch.dart
@@ -1,0 +1,27 @@
+/// `asset_pref_mirror` の行リストを `pref_key` → 行 の Map へ索引する純関数。
+///
+/// 資産管理ページは起動時に多数の per-key 読み取り
+/// (`.from('asset_pref_mirror').select().eq('pref_key', X)`) を個別に発行しており、
+/// 端末跨ぎ同期の REST が同時多発して `ERR_INSUFFICIENT_RESOURCES` を誘発していた。
+/// 1 回のバッチ取得 (`.eq('user_id', uid)`) で得た全行をこの関数で `pref_key` 索引し、
+/// 各ローダーがネットワークを介さずキャッシュから引けるようにする。
+///
+/// `(user_id, pref_key)` は一意のため 1 キー 1 行。同一キーが複数あれば後勝ち
+/// (個別 `.eq('pref_key', X)` が返す `rows.first` 相当の安定性は upsert の一意制約に
+/// 依存する前提)。
+library;
+
+Map<String, Map<String, dynamic>> indexPrefMirrorRowsByKey(List<dynamic> rows) {
+  final map = <String, Map<String, dynamic>>{};
+  for (final row in rows) {
+    if (row is! Map) {
+      continue;
+    }
+    final key = row['pref_key']?.toString();
+    if (key == null || key.isEmpty) {
+      continue;
+    }
+    map[key] = Map<String, dynamic>.from(row);
+  }
+  return map;
+}

--- a/test/services/asset_pref_mirror_prefetch_test.dart
+++ b/test/services/asset_pref_mirror_prefetch_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_pref_mirror_prefetch.dart';
+
+void main() {
+  group('indexPrefMirrorRowsByKey', () {
+    test('empty input returns empty map', () {
+      expect(indexPrefMirrorRowsByKey(const <dynamic>[]), isEmpty);
+    });
+
+    test('indexes rows by pref_key preserving the full row', () {
+      final map = indexPrefMirrorRowsByKey(<dynamic>[
+        <String, dynamic>{
+          'pref_key': 'salary_day',
+          'value': 25,
+          'updated_at': '2026-06-21T00:00:00Z',
+        },
+        <String, dynamic>{
+          'pref_key': 'main_account',
+          'value': <String, dynamic>{'id': 'a'},
+        },
+      ]);
+      expect(map.keys, containsAll(<String>['salary_day', 'main_account']));
+      expect(map['salary_day']!['value'], 25);
+      expect(map['salary_day']!['updated_at'], '2026-06-21T00:00:00Z');
+      expect(map['main_account']!['value'], <String, dynamic>{'id': 'a'});
+    });
+
+    test('skips rows that are not maps or lack a pref_key', () {
+      final map = indexPrefMirrorRowsByKey(<dynamic>[
+        'not a map',
+        <String, dynamic>{'value': 1}, // pref_key 欠落
+        <String, dynamic>{'pref_key': '', 'value': 2}, // 空キー
+        <String, dynamic>{'pref_key': 'ok', 'value': 3},
+      ]);
+      expect(map.keys, <String>['ok']);
+      expect(map['ok']!['value'], 3);
+    });
+
+    test('last row wins for a duplicated pref_key', () {
+      final map = indexPrefMirrorRowsByKey(<dynamic>[
+        <String, dynamic>{'pref_key': 'k', 'value': 1},
+        <String, dynamic>{'pref_key': 'k', 'value': 2},
+      ]);
+      expect(map['k']!['value'], 2);
+    });
+
+    test('returned row is a defensive copy', () {
+      final source = <String, dynamic>{'pref_key': 'k', 'value': 1};
+      final map = indexPrefMirrorRowsByKey(<dynamic>[source]);
+      map['k']!['value'] = 99;
+      expect(source['value'], 1);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

実機の DevTools コンソールで多発していたエラーの根本原因 (起動時のリクエストバースト) を緩和する。データ損失や機能破壊はない非致命エラーだが、端末跨ぎ同期の信頼性を上げる。

## 観測されたエラー (本番)

- `net::ERR_INSUFFICIENT_RESOURCES` ×複数 (core-hub / ai-hub / asset_pref_mirror)
- `balance history mirror upsert failed: ClientException: Failed to fetch …/rest/v1/asset_pref_mirror`
- (別件) `ai-hub 502 Bad Gateway` ← サーバ側の一時障害。本PR対象外。

## 根本原因

資産管理ページの `initState` は ~26 個の非同期ローダーを一斉発火し、そのうち **約20 箇所が `asset_pref_mirror` への個別 read** (各 store の LWW チェック / union 復元 / tombstone pull / backfill 存在確認)。端末跨ぎ同期の REST が同時多発し、ブラウザのレンダラ資源を枯渇 (多タブで増幅) させて一部 fetch が発行できず、ミラー同期が一時失敗していた。

## 変更

- 当該ユーザーの `asset_pref_mirror` 行を起動時に **1 回だけまとめて取得** して `pref_key` で索引するプリフェッチ (`_bootPrefMirrorFuture` / `_fetchAllPrefMirror`) を導入。
- 各 read を共有ヘルパー `_bootSelectPrefMirror(prefKey)` / `_bootSelectPrefMirrorKeys(keys)` 経由へ置換。ヘルパーは**個別 select と同形 (0..N 行のリスト) を返す**ため読み取り側ロジックは不変 (= 振る舞い保存)。
- バッチ未起動 / 失効後 / 未ログインは従来の個別 select へ**フォールバック**。
- 起動バーストが収束したらキャッシュを失効 (Timer 20s / `dispose` で解放) させ、以降の read は最新を個別取得。
- 索引ロジックを純関数 `indexPrefMirrorRowsByKey` として切り出し unit test 化。

→ 起動時の `asset_pref_mirror` read が **~20 回 → 1 回** に集約され、バーストが大幅に低減する。egress 削減にも寄与 (cf. #3550 系 egress 施策)。

## テスト

- `flutter analyze` 0 エラー。
- 純関数 `indexPrefMirrorRowsByKey` の unit test 5 ケース。
- 既存ミラー系 widget smoke の回帰確認 (mirror 6 / tombstone 11 / union-merge 3 / per-key guard 5 / audit 2 / section 6 = 計 33) 緑。
- 新規コードは `dart format` (tall/old 両 style) で安定整形を確認 (trailing comma で強制分割)。

## 注意

- これは段階的リファクタの第 1 弾。読み取り経路の集約のみで、各 store の merge/LWW/tombstone ロジックは一切変更していない。
- ネットワーク経路 (認証必須) は CI の 未ログイン smoke では未到達のため、振る舞い保存設計 + フォールバック + 純関数 unit test + 既存 smoke 回帰で担保。本番では起動時のコンソールエラー減少で確認できる。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: asset_pref_mirror の起動時バッチ集約は端末跨ぎ同期 (ログイン必須) の読み取り経路で integration_test の足場が無いため、純関数 indexPrefMirrorRowsByKey の unit test + 既存ミラー系 widget smoke (mirror/tombstone/union-merge/per-key guard/audit/section 計 33) の回帰確認で担保する。読み取りヘルパーは個別 select と同形を返す振る舞い保存リファクタでフォールバック付き
