### PR TITLE
feat(asset): 引落失敗時に実際の振替元(アコムショッピング枠等)を記録できるUIを追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -12349,18 +12349,175 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                         ),
                       ),
                       const SizedBox(width: 8),
-                      FilledButton.tonal(
-                        onPressed: () {
-                          unawaited(
-                            _toggleMonthlyPaymentPaid(entry.value, true),
-                          );
-                        },
-                        child: const Text('引落済み'),
+                      Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          FilledButton.tonal(
+                            onPressed: () {
+                              unawaited(
+                                _toggleMonthlyPaymentPaid(entry.value, true),
+                              );
+                            },
+                            child: const Text('引落済み'),
+                          ),
+                          TextButton(
+                            onPressed: () {
+                              unawaited(
+                                _showAutoDebitAlternateSourceSheet(
+                                  entry.value,
+                                  entry.key.row,
+                                  workbook,
+                                ),
+                              );
+                            },
+                            child: const Text('別口座で支払った'),
+                          ),
+                        ],
                       ),
                     ],
                   ),
                 ),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // 引落が設定上の振替元で失敗し、別の口座・カード (例: アコムショッピング枠) で
+  // 支払った場合に、実際の振替元を記録するためのシート。残高は自動変更せず、振替元の
+  // 上書き (今回のみ / 今後も) + 引落済み化のみ行う。見込み残高・AI・借入モニターは
+  // 記録した振替元基準で再計算される。
+  Future<void> _showAutoDebitAlternateSourceSheet(
+    AssetLiabilityDebtRow debtRow,
+    AssetLiabilityCashflowRow cashflowRow,
+    AssetLiabilityWorkbook workbook,
+  ) async {
+    // サブスク等はカード (ファミペイ等) やアコムショッピング枠 (shoppingDebt) へ
+    // 請求されるため、残高<=0 のカード/与信枠・キャリア決済も候補に含める。
+    final options = recurringFixedCostSourceOptions(
+      workbook.accounts,
+      includeCards: true,
+      includeCarrierBilling: true,
+    );
+    final currentSource = _paymentSourceAccountIds[debtRow.id] ??
+        _defaultPaymentSourceAccountIds[debtRow.id] ??
+        debtRow.paymentSourceAccountId;
+    final theme = Theme.of(context);
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '実際に支払った振替元を選択',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${cashflowRow.accountName} / '
+                  '${_formatManagementYen(cashflowRow.paymentAmount)}\n'
+                  '引落が失敗し別の口座・カードで支払った場合に、実際の振替元を記録します。'
+                  '残高は自動変更しません。',
+                  style: theme.textTheme.bodySmall,
+                ),
+                const SizedBox(height: 12),
+                if (options.isEmpty)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 12),
+                    child: Text('選択できる振替元がありません。'),
+                  )
+                else
+                  Flexible(
+                    child: ListView(
+                      shrinkWrap: true,
+                      children: [
+                        for (final option in options)
+                          ListTile(
+                            dense: true,
+                            contentPadding: EdgeInsets.zero,
+                            selected: option.id == currentSource,
+                            title: Text(option.name),
+                            trailing: Wrap(
+                              spacing: 6,
+                              children: [
+                                OutlinedButton(
+                                  onPressed: () {
+                                    Navigator.of(sheetContext).pop();
+                                    _applyAutoDebitAlternateSource(
+                                      debtRow,
+                                      option,
+                                      _PaymentSourceSaveScope.monthlyOverride,
+                                    );
+                                  },
+                                  child: const Text('今回のみ'),
+                                ),
+                                OutlinedButton(
+                                  onPressed: () {
+                                    Navigator.of(sheetContext).pop();
+                                    _applyAutoDebitAlternateSource(
+                                      debtRow,
+                                      option,
+                                      _PaymentSourceSaveScope.defaultSetting,
+                                    );
+                                  },
+                                  child: const Text('今後も'),
+                                ),
+                              ],
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _applyAutoDebitAlternateSource(
+    AssetLiabilityDebtRow debtRow,
+    RecurringFixedCostSourceOption option,
+    _PaymentSourceSaveScope scope,
+  ) {
+    // 振替元の上書きを in-memory に設定してから引落済み化する。`_toggleMonthlyPaymentPaid`
+    // が月次 state を 1 回だけ保存し、その snapshot に上書きも paid も両方含める。
+    // (`_savePaymentSourceReviewChoice` を呼ぶと月次 state の保存が 2 回走り、上書きのみの
+    //  古い snapshot が paid 付き snapshot の後に着地して paid を取りこぼす競合があるため避ける。)
+    setState(() {
+      if (scope == _PaymentSourceSaveScope.defaultSetting) {
+        _defaultPaymentSourceAccountIds[debtRow.id] = option.id;
+        _paymentSourceAccountIds.remove(debtRow.id);
+      } else {
+        _paymentSourceAccountIds[debtRow.id] = option.id;
+      }
+    });
+    if (scope == _PaymentSourceSaveScope.defaultSetting) {
+      // 既定の振替元は月次 state とは別ストアのため独立保存で競合しない。
+      unawaited(_saveDefaultPaymentSources());
+    }
+    unawaited(_toggleMonthlyPaymentPaid(debtRow, true));
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          autoDebitAlternateSourcePaidHint(
+            option.name,
+            _formatManagementYen(debtRow.scheduledPaymentAmount),
           ),
         ),
       ),

--- a/lib/services/asset_auto_debit_confirmation_service.dart
+++ b/lib/services/asset_auto_debit_confirmation_service.dart
@@ -98,3 +98,14 @@ class AssetAutoDebitConfirmationService {
     ).where((detail) => detail.sourceBalanceInsufficient).length;
   }
 }
+
+/// 引落が失敗し別の振替元 ([sourceName]) で支払ったと記録したときに表示する案内文。
+/// 残高は自動変更しないため、ユーザーに実残高への反映を促す ([formattedAmount] は
+/// 表示用に整形済みの金額文字列)。
+String autoDebitAlternateSourcePaidHint(
+  String sourceName,
+  String formattedAmount,
+) {
+  return '$sourceName を振替元に記録しました。'
+      '残高一覧で $sourceName の残高に $formattedAmount を反映してください。';
+}

--- a/test/services/asset_auto_debit_confirmation_service_test.dart
+++ b/test/services/asset_auto_debit_confirmation_service_test.dart
@@ -220,4 +220,14 @@ void main() {
       expect(service.insufficientSourceCount(workbook), 1);
     });
   });
+
+  group('autoDebitAlternateSourcePaidHint', () {
+    test('names the recorded source and prompts the balance update', () {
+      final hint = autoDebitAlternateSourcePaidHint('アコムショッピング', '¥36,525');
+      expect(hint, contains('アコムショッピング'));
+      expect(hint, contains('¥36,525'));
+      expect(hint, contains('残高一覧'));
+      expect(hint, contains('反映'));
+    });
+  });
 }


### PR DESCRIPTION
## 概要

実機の「資産管理闘争 → 引落の確認待ち」で、設定上の振替元で引落が**失敗**し、ユーザーが**別の口座・カード(例: アコムショッピング枠リボ)で支払い直した**実態を記録する手段が無かった。「引落済み」を押すと設定振替元で払った前提で確定してしまう。本PRで、**実際に支払った振替元を記録**できるようにする(先の [#3543](https://github.com/kanta13jp1/my_web_app/pull/3543) アコムショッピング枠 振替元対応の続き)。

ユーザー方針(2026-06-21): **振替元の記録のみ**(残高の自動加算はしない / アプリの「残高は手入力スナップショット」モデルに忠実・二重計上回避)。

## 変更点(lib 2 + test 1 / +185)

- **`引落の確認待ち` カード**: 各行に「**別口座で支払った**」ボタンを追加。タップで振替元シートを開き、**カード/アコムショッピング枠(shoppingDebt)/キャリア決済を含む**候補から実支払先を選び「**今回のみ**」/「**今後も**」で適用 → 振替元を上書き + 引落済み化 + 「残高一覧で残高を反映してください」ヒント表示。
- 候補は `recurringFixedCostSourceOptions(includeCards, includeCarrierBilling)` を流用(bank-only な `_paymentSourceAccountOptions` はアコムを選べないため使わない)。
- 上書きは**既存の月次 state `paymentSourceAccountIds` / 既定 `_defaultPaymentSourceAccountIds` を再利用**(新モデル/マイグレ/同期変更なし)。cashflow planner が振替元を再ルーティング → 見込み残高・AI・借入モニターは記録した振替元基準で再計算され、元の振替元には課金されない。
- **競合回避**: 上書きを in-memory に設定後 `_toggleMonthlyPaymentPaid` で月次 state を**1回だけ保存**し、上書きと paid を同一 snapshot に含める(別経路の二重保存で paid を取りこぼす競合を回避)。
- 純関数 `autoDebitAlternateSourcePaidHint` + 単体テスト追加。

## 検証

- `dart analyze`(page + service + test): **No issues found**。`dart format`: 追加行は版間安定(0 diff)。
- `flutter test`(確認サービス): 純関数ヒント含む **10 緑**。
- **ultracode 敵対レビュー**: override キー一致(`debtRow.id == account.id`)/ 保存競合なし / paid 行は projection 除外で二重計上なし / default scope 解決順(override ?? default ?? row)/ non-null 昇格 OK — **blocking issue なし**。
- 🔴 本番の確認カードは**ユーザーデータ(期限超過行)依存=auth-gated** のため自動描画検証不可 → **ユーザー実機**で「Claude → 別口座で支払った → アコムショッピング → 今回のみ/今後も」を確認予定。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: UI wiring on the 24k-line asset_management_page surfacing the existing payment-source override (paymentSourceAccountIds) + paid toggle in the auto-debit confirmation card; pure logic extracted to autoDebitAlternateSourcePaidHint with a unit test; funding-source options reuse the already-tested recurringFixedCostSourceOptions; the giant page widget is not unit/e2e-testable in isolation; analyze 0 + confirmation-service tests 10 green + ultracode adversarial review (no blocking issues)

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: App-code UI feature in lib/pages + lib/services only (no firebase.json/.github/migration/RLS/deploy paths); surfaces existing per-occurrence payment-source override + paid toggle in the auto-debit confirmation card; record-only (no balance mutation); analyze 0 + 10 service tests green + ultracode adversarial review found no blocking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
