### PR TITLE
feat(election): 立憲地方議員ベンチマークを全県表示（上限8件を撤廃）

### DIFF
--- a/lib/models/local_election_plan.dart
+++ b/lib/models/local_election_plan.dart
@@ -604,6 +604,12 @@ class LocalElectionPlanDashboard {
     return sorted.take(limit).toList();
   }
 
+  /// All prefectures that have a CDP comparison, sorted by gap (largest CDP
+  /// lead first). Unlike [topCdpGapPrefectures] this is not capped, so it can
+  /// power the full benchmark list that shows every available prefecture.
+  List<LocalElectionPrefecturePlan> allCdpGapPrefectures() =>
+      topCdpGapPrefectures(limit: prefectures.length);
+
   int get confirmedEndorsementCount => prefectures.where((item) {
         return item.endorsementConfirmed;
       }).length;

--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -4283,7 +4283,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
       );
     }
 
-    final topGaps = plan.topCdpGapPrefectures();
+    final allGaps = plan.allCdpGapPrefectures();
 
     return Container(
       decoration: BoxDecoration(
@@ -4341,7 +4341,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
                 spacing: 8,
                 runSpacing: 8,
                 children: [
-                  for (final item in topGaps) _buildCdpGapPill(item),
+                  for (final item in allGaps) _buildCdpGapPill(item),
                 ],
               ),
             ),


### PR DESCRIPTION
## 概要

統一地方選700必達管理室（`/local-election-700`）の「立憲地方議員ベンチマーク」が**上位8件**しか表示されていなかったのを、立憲データのある**全県を表示**するようにします。

## 原因

`LocalElectionPlanDashboard.topCdpGapPrefectures({int limit = 8})`（`lib/models/local_election_plan.dart`）が、立憲との差（`cdpMemberGap`）が大きい順に**上位8件だけ** `take(8)` で返していたためです。呼び出しは `election_victory_page.dart` の1箇所のみ。

## 変更

- モデルに上限なしの `allCdpGapPrefectures()` を追加（既存 `topCdpGapPrefectures` へ `limit = 県数` で委譲。ソートは「差が大きい順」を踏襲）。
- ベンチマークセクションの呼び出しを `allCdpGapPrefectures()` へ差し替え（`topGaps` → `allGaps` の同字数リネームで行構造不変）。

立憲データ未取得の1県（`cdpLocalMembers = 0` ／「取得県連 46/47」）は従来どおり**非表示**（`国民+N` の誤表示を回避）。CDP 取得フラグ等の挙動は変更なし。

## 検証

- `dart analyze lib/models/local_election_plan.dart lib/pages/election_victory_page.dart` → **No issues found!**
- 差分は最小（モデル +6 行のデリゲートメソッド／page は同字数リネーム2行で折返し不変）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 立憲ベンチマークの上限8件を撤廃しデータのある全県表示にする最小変更。新メソッドは既存 topCdpGapPrefectures へ limit=県数 で委譲する純デリゲートで dart analyze クリーン。表示件数増のみでロジック・型不変、本番デプロイ後に実画面でカード件数を確認。
