### PR TITLE
fix(asset): 引落確認の残高警告を与信枠は利用上限超過時のみに

### DIFF
--- a/lib/services/asset_auto_debit_confirmation_service.dart
+++ b/lib/services/asset_auto_debit_confirmation_service.dart
@@ -140,9 +140,8 @@ class AssetAutoDebitConfirmationService {
     };
     final details = pendingConfirmations(workbook).map((row) {
       final sourceAccountId = row.paymentSourceAccountId;
-      final source = sourceAccountId == null
-          ? null
-          : accountById[sourceAccountId];
+      final source =
+          sourceAccountId == null ? null : accountById[sourceAccountId];
       return AssetAutoDebitConfirmation(
         row: row,
         sourceAccountBalance: source?.balance,

--- a/lib/services/asset_auto_debit_confirmation_service.dart
+++ b/lib/services/asset_auto_debit_confirmation_service.dart
@@ -12,18 +12,71 @@ class AssetAutoDebitConfirmation {
   /// 該当口座が無く残高を特定できない場合は null。
   final double? sourceAccountBalance;
 
+  /// 振替元口座の種別。与信枠 (クレカ/ショッピング枠/カードローン) は残高が常に
+  /// マイナス (=利用額) になるため、資産口座とは異なる判定を行う。特定できなければ null。
+  final AssetLiabilityAccountKind? sourceAccountKind;
+
+  /// 振替元が与信枠の場合の利用限度額 (リボ払い設定の利用限度額)。リボ設定が無い、
+  /// または限度額未設定の場合は null。与信枠で限度額が分からないときは判定しない。
+  final double? sourceAccountCreditLimit;
+
   const AssetAutoDebitConfirmation({
     required this.row,
     required this.sourceAccountBalance,
+    this.sourceAccountKind,
+    this.sourceAccountCreditLimit,
   });
 
-  /// 振替元残高が判明しており、かつ支払額を下回っている = 引落が失敗している可能性。
+  /// 引落が失敗している可能性があるか (= 要確認の警告を出すか)。
   ///
-  /// 残高を特定できない (null) 場合は判定できないため false を返す (過剰警告を避ける)。
-  /// なお現在残高は引落成功後の減算を反映していることもあるため、これは「失敗の確証」
-  /// ではなく「要確認」のヒントであり、UI でもその旨を断定せずに案内する。
-  bool get sourceBalanceInsufficient =>
-      sourceAccountBalance != null && sourceAccountBalance! < row.paymentAmount;
+  /// - 資産口座 (現金/預金など): 現在残高が支払額を下回るなら警告 (従来通り)。
+  /// - 与信枠 (クレカ/ショッピング枠/カードローン): 残高は通常マイナス (=利用額) の
+  ///   ため「残高 < 支払額」では常に誤発火する。**利用限度額が分かるときだけ**、
+  ///   利用額 (= -残高) + 今回の支払額 が限度額を超える場合のみ警告する。限度額が
+  ///   不明 (null/0) のときは判定できないため警告しない (= 翌月払いカード等の常時誤発火を防ぐ)。
+  /// 残高を特定できない (null) 場合も警告しない。これは「失敗の確証」ではなく「要確認」
+  /// のヒントであり、UI でも断定せずに案内する。
+  bool get sourceBalanceInsufficient {
+    return autoDebitSourceInsufficient(
+      balance: sourceAccountBalance,
+      kind: sourceAccountKind,
+      creditLimit: sourceAccountCreditLimit,
+      paymentAmount: row.paymentAmount,
+    );
+  }
+}
+
+/// 「引落失敗の可能性 (= 要確認)」を振替元の種別に応じて判定する純関数。
+///
+/// - 資産口座 (現金/預金など) / 種別不明: 残高 < 支払額 なら true (従来通り)。
+/// - 与信枠 (クレカ/ショッピング枠/カードローン): 残高は通常マイナス (=利用額) の
+///   ため、利用上限 [creditLimit] が分かるときだけ「利用額 (= -残高) + 支払額 > 上限」
+///   で true。上限が不明 (null/0) なら false (翌月払いカード等の常時誤発火を防ぐ)。
+/// 残高 [balance] が null (特定不能) のときは判定できないため false。
+bool autoDebitSourceInsufficient({
+  required double? balance,
+  required AssetLiabilityAccountKind? kind,
+  required double? creditLimit,
+  required double paymentAmount,
+}) {
+  if (balance == null) {
+    return false;
+  }
+  if (kind != null && _isCreditLineKind(kind)) {
+    if (creditLimit == null || creditLimit <= 0) {
+      return false;
+    }
+    return (-balance) + paymentAmount > creditLimit;
+  }
+  return balance < paymentAmount;
+}
+
+/// 残高が通常マイナス (=利用額) になる与信枠の口座種別か。これらは「残高 < 支払額」
+/// では常に警告が出てしまうため、利用限度額ベースで引落可否を判定する。
+bool _isCreditLineKind(AssetLiabilityAccountKind kind) {
+  return kind == AssetLiabilityAccountKind.creditCard ||
+      kind == AssetLiabilityAccountKind.shoppingDebt ||
+      kind == AssetLiabilityAccountKind.cardLoan;
 }
 
 /// 「支払日を過ぎたが、まだ支払済み確認をしていない直接支払い(口座振替など)」を
@@ -76,16 +129,27 @@ class AssetAutoDebitConfirmationService {
   List<AssetAutoDebitConfirmation> pendingConfirmationDetails(
     AssetLiabilityWorkbook workbook,
   ) {
-    final balanceByAccountId = <String, double>{
-      for (final account in workbook.accounts) account.id: account.balance,
+    final accountById = <String, AssetLiabilityAccount>{
+      for (final account in workbook.accounts) account.id: account,
+    };
+    // 与信枠の利用限度額はリボ払い設定 (revolvingBilling) から取得する。
+    final creditLimitByAccountId = <String, double>{
+      for (final debt in workbook.debtMasterRows)
+        if (debt.revolvingBilling != null)
+          debt.id: debt.revolvingBilling!.creditLimit,
     };
     final details = pendingConfirmations(workbook).map((row) {
       final sourceAccountId = row.paymentSourceAccountId;
+      final source = sourceAccountId == null
+          ? null
+          : accountById[sourceAccountId];
       return AssetAutoDebitConfirmation(
         row: row,
-        sourceAccountBalance: sourceAccountId == null
+        sourceAccountBalance: source?.balance,
+        sourceAccountKind: source?.kind,
+        sourceAccountCreditLimit: sourceAccountId == null
             ? null
-            : balanceByAccountId[sourceAccountId],
+            : creditLimitByAccountId[sourceAccountId],
       );
     }).toList();
     return List<AssetAutoDebitConfirmation>.unmodifiable(details);

--- a/test/services/asset_auto_debit_confirmation_service_test.dart
+++ b/test/services/asset_auto_debit_confirmation_service_test.dart
@@ -230,4 +230,119 @@ void main() {
       expect(hint, contains('反映'));
     });
   });
+
+  group('autoDebitSourceInsufficient (credit-line vs asset)', () {
+    test('asset account: warns only when balance is below the amount', () {
+      expect(
+        autoDebitSourceInsufficient(
+          balance: 3000,
+          kind: AssetLiabilityAccountKind.deposit,
+          creditLimit: null,
+          paymentAmount: 4500,
+        ),
+        isTrue,
+      );
+      expect(
+        autoDebitSourceInsufficient(
+          balance: 63539,
+          kind: AssetLiabilityAccountKind.deposit,
+          creditLimit: null,
+          paymentAmount: 4500,
+        ),
+        isFalse,
+      );
+    });
+
+    test('credit line with no/zero limit never warns (avoid false alarm)', () {
+      // ファミペイ (翌月払い=残高常時マイナス) で利用上限未設定 → 誤発火させない。
+      for (final limit in const <double?>[null, 0]) {
+        expect(
+          autoDebitSourceInsufficient(
+            balance: -223441,
+            kind: AssetLiabilityAccountKind.creditCard,
+            creditLimit: limit,
+            paymentAmount: 30000,
+          ),
+          isFalse,
+          reason: 'limit=$limit should not warn',
+        );
+      }
+    });
+
+    test('credit line warns only when usage + payment exceeds the limit', () {
+      // 利用額 223,441 + 支払 30,000 = 253,441 <= 上限 300,000 → 警告しない。
+      expect(
+        autoDebitSourceInsufficient(
+          balance: -223441,
+          kind: AssetLiabilityAccountKind.creditCard,
+          creditLimit: 300000,
+          paymentAmount: 30000,
+        ),
+        isFalse,
+      );
+      // 利用額 280,000 + 支払 30,000 = 310,000 > 上限 300,000 → 警告する。
+      expect(
+        autoDebitSourceInsufficient(
+          balance: -280000,
+          kind: AssetLiabilityAccountKind.creditCard,
+          creditLimit: 300000,
+          paymentAmount: 30000,
+        ),
+        isTrue,
+      );
+    });
+
+    test('credit line at exactly the limit does not warn (strict >)', () {
+      // 利用額 270,000 + 支払 30,000 = 300,000 == 上限 → 超過でないので警告しない。
+      expect(
+        autoDebitSourceInsufficient(
+          balance: -270000,
+          kind: AssetLiabilityAccountKind.creditCard,
+          creditLimit: 300000,
+          paymentAmount: 30000,
+        ),
+        isFalse,
+      );
+    });
+
+    test('shoppingDebt and cardLoan are treated as credit lines too', () {
+      for (final kind in const <AssetLiabilityAccountKind>[
+        AssetLiabilityAccountKind.shoppingDebt,
+        AssetLiabilityAccountKind.cardLoan,
+      ]) {
+        expect(
+          autoDebitSourceInsufficient(
+            balance: -100000,
+            kind: kind,
+            creditLimit: 300000,
+            paymentAmount: 50000,
+          ),
+          isFalse,
+          reason: '$kind within limit',
+        );
+        expect(
+          autoDebitSourceInsufficient(
+            balance: -280000,
+            kind: kind,
+            creditLimit: 300000,
+            paymentAmount: 50000,
+          ),
+          isTrue,
+          reason: '$kind over limit',
+        );
+      }
+    });
+
+    test('null balance never warns', () {
+      expect(
+        autoDebitSourceInsufficient(
+          balance: null,
+          kind: AssetLiabilityAccountKind.deposit,
+          creditLimit: null,
+          paymentAmount: 4500,
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## 概要

「引落の確認待ち」の ⚠ 警告「振替元の残高(-¥X)が支払額を下回っています。引落が失敗している可能性があります」が、**ファミペイ(翌月払い=残高常時マイナス)・アコムショッピング枠・各クレカ・カードローンを振替元にした全行で常時誤発火**していた(実機 build 4595 で確認)。判定 `残高 < 支払額` が、残高が負の与信枠では必ず真になるため。

## 変更点(lib/services 1 + test 1)

- **`autoDebitSourceInsufficient` 純関数を新設**し判定を分岐:
  - **資産口座(現金/預金等)/種別不明**: `残高 < 支払額` なら警告(従来通り)。
  - **与信枠(creditCard / shoppingDebt / cardLoan)**: 残高は通常マイナス(=利用額)のため、**利用額(= -残高)+ 今回の支払額 が利用限度額を超えるときだけ**警告。限度額が不明(null/0)なら警告しない → **翌月払いカード等の常時誤発火を解消**。
- `AssetAutoDebitConfirmation` に `sourceAccountKind` / `sourceAccountCreditLimit` を追加。`pendingConfirmationDetails` で口座種別を `accounts` から、利用限度額を `debtMasterRows[].revolvingBilling.creditLimit`(= リボ払い設定の利用限度額)から解決。
- カード UI は getter 経由のため **page 変更なし**。**新 UI/モデル/マイグレ無し**(利用限度額は既存「リボ払い設定 → 利用限度額」で設定)。

## 動作

- **誤発火は即解消**: 与信枠で利用限度額が未設定なら警告は出ない。
- **超過時のみ警告**: 「リボ払い設定」で利用限度額(例 ファミペイ 300,000)を設定すると、`利用額 + 支払額 > 限度額` のときだけ ⚠ が出る。ファミペイは既にリボ設定(設定額 7,000)済みのため、同画面で**利用限度額 300,000 を入れるだけ**。

## 検証

- 純関数 **6 ケース**(資産: 残高不足/充足、与信枠: 上限内/超過/境界(==は非超過)、上限未設定(null/0)、null 残高)+ 既存統合テスト緑(計 16 緑)。
- `dart format` 版間安定 / `flutter analyze`(service+test)No issues。
- **ultracode 敵対レビュー**: 符号正(利用額=-残高)/ id 空間一致(`debt.id == account.id` でリボ限度額が解決)/ 資産口座は回帰なし / null 安全 — **blocking issue なし**。
- 🔴 確認カードはログイン後のユーザーデータ(overdue 行)依存のため自動描画検証は不可 → ユーザー実機で確認。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Pure-logic fix in lib/services (asset_auto_debit_confirmation_service): warning judgment extracted to top-level pure fn autoDebitSourceInsufficient + 6 new unit cases (asset under/over, credit under/over/at-limit, no-limit, null); existing integration tests green; confirmation card reads the getter so no widget change; the giant page is not e2e-testable in isolation; record-only logic change

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: App-code pure-logic fix in lib/services only (no firebase.json/.github/migration/RLS/deploy paths); the gate tripped on a literal text token in the body, not a real high-risk path; warning judgment extracted to a pure fn with 6 unit cases + ultracode adversarial review found no blocking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
