### PR TITLE
fix(election): 立憲先行/国民同数以上チップの単位を人→県へ修正

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -4324,11 +4324,13 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
                 _buildMiniStatChip(
                   '立憲先行',
                   plan.cdpLeadPrefectureCount,
+                  suffix: '県',
                   color: const Color(0xFFF59E0B),
                 ),
                 _buildMiniStatChip(
                   '国民同数以上',
                   plan.kokuminLeadPrefectureCount,
+                  suffix: '県',
                   color: const Color(0xFF0F766E),
                 ),
               ],


### PR DESCRIPTION
## 概要

統一地方選700必達管理室の「立憲地方議員ベンチマーク」のチップ「立憲先行」「国民同数以上」が**人**単位で表示されていたのを、正しい**県**単位に修正します。

## 原因

これらは県の数（`cdpLeadPrefectureCount` = 立憲が国民を上回る県数、`kokuminLeadPrefectureCount` = 国民が同数以上の県数。39 + 7 = 46 = 取得県連）ですが、`_buildMiniStatChip` の `suffix` 既定値 `'人'` がそのまま付いていました。

## 変更

`立憲先行` / `国民同数以上` チップに `suffix: '県'` を指定（`立憲合計` は人のまま、`取得県連` は `/47` のまま）。

## 検証

- `dart analyze lib/pages/election_victory_page.dart` → No issues found
- 差分 2 行のみ（既存の `suffix: '/47'` と同形式）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 県数チップの単位ラベルを人→県へ直す2行の表示専用修正でロジック・型不変。dart analyze クリーン、本番デプロイ後に実画面でチップ表記を確認。
