### PR TITLE
fix(ai-hub): LLM プロバイダ呼び出しにタイムアウトを追加し 502 を回避

### DIFF
--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -656,22 +656,38 @@ async function callSingleProvider(
       authHeaders = {};
       fetchUrl = `${cfg.chatUrl}?key=${apiKey}`;
     }
-    const resp = await fetch(fetchUrl, {
-      method: "POST",
-      headers: {
-        ...authHeaders,
-        "Content-Type": "application/json",
-        ...(cfg.extraHeaders ?? {}),
-      },
-      body: JSON.stringify(
-        applyProviderGenerationOptions(
-          providerId,
-          cfg.buildBody(messages, model ?? cfg.defaultModel, inlineFiles),
-          options,
+    // プロバイダがハング/遅延すると edge function が wall-clock 上限を超えて
+    // ランタイムに kill され 502 になる。AbortController で時間を区切り、
+    // タイムアウトは catch で {ok:false, isRetriable:true} に落ちて別プロバイダ
+    // へのフォールバックに繋がる (502 を避ける)。
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      providerFetchTimeoutMs(),
+    );
+    let resp: Response;
+    let respText: string;
+    try {
+      resp = await fetch(fetchUrl, {
+        method: "POST",
+        headers: {
+          ...authHeaders,
+          "Content-Type": "application/json",
+          ...(cfg.extraHeaders ?? {}),
+        },
+        body: JSON.stringify(
+          applyProviderGenerationOptions(
+            providerId,
+            cfg.buildBody(messages, model ?? cfg.defaultModel, inlineFiles),
+            options,
+          ),
         ),
-      ),
-    });
-    const respText = await resp.text();
+        signal: controller.signal,
+      });
+      respText = await resp.text();
+    } finally {
+      clearTimeout(timeoutId);
+    }
     if (!resp.ok) {
       const paymentRequired = isProviderPaymentRequired(resp.status, respText);
       const isRetriable = paymentRequired || resp.status === 429 ||
@@ -713,6 +729,14 @@ async function callSingleProvider(
   } catch (e) {
     return { ok: false, error: String(e), isRetriable: true };
   }
+}
+
+/// LLM プロバイダ呼び出しのタイムアウト (ms)。遅延/ハングするプロバイダで edge
+/// function が wall-clock 上限を超えて 502 になるのを防ぐ。`AI_HUB_PROVIDER_TIMEOUT_MS`
+/// で調整可 (既定 90s = 正常な LLM 応答には十分長く、無限待機は防ぐ)。
+function providerFetchTimeoutMs(): number {
+  const raw = Number(Deno.env.get("AI_HUB_PROVIDER_TIMEOUT_MS"));
+  return Number.isFinite(raw) && raw > 0 ? raw : 90_000;
 }
 
 function asString(value: unknown): string {


### PR DESCRIPTION
## 概要

実機コンソールの `functions/v1/ai-hub 502 (Bad Gateway)` を解消する。AI要約のエッジ関数がゲートウェイ層で 502 を返していた。

## 真因

`callProvider`（ai-hub の LLM 呼び出し中核）の `fetch` に AbortController/タイムアウトが**一切なかった**。プロバイダが遅延/ハングすると ai-hub 関数が無限待機し、edge function の wall-clock 上限を超えてランタイムに強制終了され、ゲートウェイが **502** を返す（関数のトップレベル try/catch の外＝ハンドル済みエラーの 500/503 とは別）。

## 変更

- `callProvider` の `fetch` に `AbortController`（既定 90s / 環境変数 `AI_HUB_PROVIDER_TIMEOUT_MS` で調整可）を追加。
- タイムアウト時は abort → 既存の catch が `{ ok: false, error, isRetriable: true }` を返す → ルーティング層が別プロバイダへフォールバック/リトライ。
- これで **502（ランタイム kill）→ グレースフルなフォールバック**へ変換。`finally` で `clearTimeout` し、`fetch` + `resp.text()` の両方をタイムアウトでカバー。

90s は正常な LLM 応答には十分長く、無限待機のみを断つ値。タイムアウト追加は真因が時間超過でなくても無害で、`isRetriable:true` ゆえ単一プロバイダ障害時の自動切替も改善する。

## 影響範囲・注意

- ai-hub は全機能が依存する共有 AI 基盤。本変更は **callProvider（ルーテッド経路）のみ**で、AI要約・可処分残高・分類など同経路の全呼び出しに効く。レガシーの個別プロバイダ `fetch`（OpenAI/Anthropic 等の旧経路）は本 PR 対象外（フォローアップ）。
- 振る舞い保存の最小変更（既存の成功/エラー応答パスは不変）。

## テスト

- `deno lint` 0 / `deno check` 0。
- 既存 ai-hub deno test 11 緑（provider 生成オプション 8 / 可処分残高 3）。

## 注意（確定診断）

502 の実態（時間超過/メモリ/プロバイダエラー）の確定には Supabase の ai-hub 関数ログが確実だが、タイムアウト欠如は実機 502 を説明する実バグであり、本修正は原因が何であれ無害かつ resilience を上げる。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: ai-hub の LLM fetch タイムアウトはプロバイダのハングを擬似する必要があり integration_test の足場が無いため、deno lint/deno check 0 + 既存 ai-hub deno test 11 緑で担保。abort 時は既存 callProvider catch が {ok:false,isRetriable:true} を返す振る舞い保存の最小変更

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: callProvider の fetch に AbortController タイムアウト(既定90s/env調整可)を追加する振る舞い保存の最小変更。deno lint/check 0 + 既存 ai-hub deno test 11 緑。abort 時は既存 catch が isRetriable で別プロバイダへフォールバックし 502 をグレースフル化。ロールバックは本コミットの revert で即時、本番確認は AI要約のフォールバック表示で degrade 観測可、観測性はブラウザ console の 502 減少で確認
