### PR TITLE
feat: ランディングの価値提案を成果ベース化＋はじめ方3ステップ（発見性改善）

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -747,7 +747,7 @@ $input
           const SizedBox(height: 20),
           // メインヘッドライン
           const Text(
-            'Google Workspaceだけじゃない\n財務・健康・習慣・6部署を1つに。',
+            '今日やるべき1件を、AIが決める。\n迷いが消えて、毎日が動き出す。',
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 32,
@@ -759,7 +759,7 @@ $input
           ),
           const SizedBox(height: 14),
           const Text(
-            'Gmail・Calendar・Driveの予定整理に加えて、お金、健康、習慣、学習、広報、開発までAIが横断。今日の最優先タスクを1件に絞り、人生全体を経営するための無料コックピットです。',
+            'Gmail・予定・お金・習慣・学習までを1画面に集約。Notion や MoneyForward を渡り歩く代わりに、AIが今日の最優先1件を提案します。AI大学・英語速読で「学ぶ習慣」まで続く、人生を経営する無料コックピットです。',
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 16,
@@ -767,6 +767,8 @@ $input
               height: 1.7,
             ),
           ),
+          const SizedBox(height: 16),
+          const _GettingStartedStrip(),
           const SizedBox(height: 14),
           const _PlannerGapStrip(),
           const SizedBox(height: 14),
@@ -5012,6 +5014,68 @@ class _FaqItemState extends State<_FaqItem> {
             ),
           ),
         const Divider(height: 1),
+      ],
+    );
+  }
+}
+
+class _GettingStartedStrip extends StatelessWidget {
+  const _GettingStartedStrip();
+
+  @override
+  Widget build(BuildContext context) {
+    const steps = <(String, String)>[
+      ('1', '無料で始める（30秒）'),
+      ('2', '今日の最優先1件をAIが提案'),
+      ('3', 'AI大学・英語速読で学ぶ習慣に'),
+    ];
+    return Wrap(
+      alignment: WrapAlignment.center,
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final s in steps)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.9),
+              borderRadius: BorderRadius.circular(999),
+              border: Border.all(color: const Color(0xFFE2E8F0)),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 20,
+                  height: 20,
+                  alignment: Alignment.center,
+                  decoration: const BoxDecoration(
+                    color: Color(0xFFFF6B35),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Text(
+                    s.$1,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w800,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  s.$2,
+                  style: const TextStyle(
+                    color: Color(0xFF334155),
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
       ],
     );
   }


### PR DESCRIPTION
## 概要

UI/UX 監査の指摘（価値提案が複雑で3秒で伝わらない / 最初の一手が不明 / 学習機能が発見されない）に対応し、ランディングの導線を改善します。

## 変更点

- **ヒーロー見出しを成果ベース化**: 競合比較「Google Workspaceだけじゃない…」→「**今日やるべき1件を、AIが決める。迷いが消えて、毎日が動き出す。**」
- **サブコピーで学習機能を前面化**: AI大学・英語速読（学ぶ習慣）を明記し発見性を向上
- **「はじめ方3ステップ」を追加**: ①無料で始める（30秒）②今日の最優先1件をAIが提案 ③AI大学・英語速読で学ぶ習慣に — 最初の一手を明示

## 検証

- `dart analyze` = No issues found / `dart format` = clean
- 旧ヒーロー文言を参照するテストなし（grep確認）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: ランディングの表示コピーと静的な『はじめ方』ストリップの追加で、認証・遷移・データ取得のロジックは不変。純粋なプレゼンテーション変更で、旧文言を参照するテストが無いことをgrepで確認済み。視覚確認は反映後の実機で実施する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
