### PR TITLE
fix(ai-hub): レガシー個別プロバイダ fetch にもタイムアウトを横展開 (502 予防)

### DIFF
--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -739,6 +739,27 @@ function providerFetchTimeoutMs(): number {
   return Number.isFinite(raw) && raw > 0 ? raw : 90_000;
 }
 
+/// 外部プロバイダ呼び出しに providerFetchTimeoutMs() のタイムアウトを付与する
+/// `fetch` ラッパー。遅延/ハングするプロバイダで edge function が wall-clock 上限を
+/// 超えてランタイムに kill され 502 になるのを防ぐ (callProvider と同方針の横展開)。
+/// abort 時は AbortError を throw → 各 action / serve トップレベルの try/catch が
+/// 捕捉し、502 ではなくハンドル済みエラー応答へ落ちる。
+async function fetchWithProviderTimeout(
+  input: string | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    providerFetchTimeoutMs(),
+  );
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 function asString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -3274,18 +3295,24 @@ serve(async (req: Request) => {
           return json({ success: true, summary: result });
         }
         if (openaiKey) {
-          const r = await fetch("https://api.openai.com/v1/chat/completions", {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${openaiKey}`,
-              "Content-Type": "application/json",
+          const r = await fetchWithProviderTimeout(
+            "https://api.openai.com/v1/chat/completions",
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${openaiKey}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                model: "gpt-4o-mini",
+                messages: [{
+                  role: "user",
+                  content: `200字以内で要約: ${text}`,
+                }],
+                max_tokens: 300,
+              }),
             },
-            body: JSON.stringify({
-              model: "gpt-4o-mini",
-              messages: [{ role: "user", content: `200字以内で要約: ${text}` }],
-              max_tokens: 300,
-            }),
-          });
+          );
           const d = await r.json() as {
             choices?: [{ message: { content: string } }];
           };
@@ -4372,7 +4399,7 @@ serve(async (req: Request) => {
 スコアデータ: ${JSON.stringify(scores).slice(0, 2000)}
 弱点プロバイダー・得意プロバイダー・学習スタイルをJSONで返してください。
 形式: {"weak_providers":["..."],"strong_providers":["..."],"preferred_style":"visual|text|voice","insights":"..."}`;
-        const claudeResp = await fetch(
+        const claudeResp = await fetchWithProviderTimeout(
           "https://api.anthropic.com/v1/messages",
           {
             method: "POST",
@@ -4427,7 +4454,7 @@ serve(async (req: Request) => {
         if (!groqKey) {
           return json({ error: "GROQ_API_KEY not configured" }, 503);
         }
-        const groqResp = await fetch(
+        const groqResp = await fetchWithProviderTimeout(
           "https://api.groq.com/openai/v1/chat/completions",
           {
             method: "POST",
@@ -4488,7 +4515,7 @@ serve(async (req: Request) => {
 正解: ${correctAnswer}
 ユーザーの回答: ${userAnswer}
 なぜ正解がそうなるのか、関連する背景知識も含めて日本語で300字以内で説明してください。`;
-        const claudeResp2 = await fetch(
+        const claudeResp2 = await fetchWithProviderTimeout(
           "https://api.anthropic.com/v1/messages",
           {
             method: "POST",


### PR DESCRIPTION
## 概要

PR #3576 で `callProvider`(ルーテッド経路)の `fetch` にタイムアウトを追加したのと同方針を、**レガシーの個別プロバイダ直叩き `fetch`** へ横展開する。実機の 502 は #3576 で対処済みだが、同じ潜在リスクが他機能にも残っていた。

## 対象(タイムアウト欠如)

- `summarize.text` の OpenAI 呼び出し
- AI大学 v2 の `learner.update_profile` / `quiz.evaluate` / `quiz.explain`(Anthropic / Groq)

いずれもプロバイダが遅延/ハングすると ai-hub 関数が wall-clock 上限を超えてランタイムに kill され **502** になる潜在リスク。

## 変更

- 共有ヘルパー `fetchWithProviderTimeout(input, init)` を追加(既定 90s / `AI_HUB_PROVIDER_TIMEOUT_MS` で調整可)。`AbortController` で時間を区切り `finally` で `clearTimeout`。
- 上記 4 箇所の直叩き `fetch` を本ヘルパーへ置換。
- abort 時は `AbortError` を throw → 各 action / `serve` トップレベルの try/catch が捕捉し、**502 ではなくハンドル済みエラー応答**へ落ちる。振る舞い保存(成功/エラーパス不変)。

## テスト

- `deno lint` 0 / `deno check` 0。
- 既存 ai-hub deno test 緑(provider 生成オプション 8 / expense 3)。

## 影響範囲

ai-hub は共有 AI 基盤。本 PR は LLM プロバイダ直叩き 4 箇所への最小ラッパー適用のみ。TTS/STT(elevenlabs/deepgram)や embeddings 等の外部 fetch は対象外(別フォローアップ)。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: ai-hub レガシープロバイダ fetch のタイムアウト横展開はプロバイダのハングを擬似する必要があり integration_test の足場が無いため、deno lint/deno check 0 + 既存 ai-hub deno test 緑(provider 8/expense 3)で担保。fetchWithProviderTimeout は signal 付与のみの振る舞い保存ラッパー

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: PR #3576 と同方針で callProvider 以外のレガシー個別プロバイダ fetch(OpenAI/Anthropic/Groq)へ共有ヘルパーで AbortController タイムアウトを付与する振る舞い保存の横展開。deno lint/check 0 + ai-hub deno test 緑。abort 時は各 try/catch でハンドル済みエラーへ落ち 502 を回避。ロールバックは本コミット revert で即時、本番確認は該当機能のフォールバック表示、観測性は console の 502 減少
