### PR TITLE
fix(election): AI整理メモの立憲比較をバッチ取得値で表示

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -1890,7 +1890,8 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
                       ),
                 ),
                 const SizedBox(height: 8),
-                for (final item in snapshot.aiAlerts) _buildBulletLine(item),
+                for (final item in _displayAiAlerts(snapshot))
+                  _buildBulletLine(item),
               ],
               if (snapshot.aiStrategicNotes.isNotEmpty) ...[
                 const SizedBox(height: 14),
@@ -5288,6 +5289,45 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
         ],
       ),
     );
+  }
+
+  /// AI整理メモの注視ポイント。AI整理メモは includeCdpBenchmarks=false の snapshot を
+  /// 使うため立憲比較行が「取得していません」になる。週次cronでバッチ取得した立憲値
+  /// (plan に適用済み) から地力差を計算し、その行だけ差し替える。
+  List<String> _displayAiAlerts(LocalElectionRealitySnapshot snapshot) {
+    final cdpLine = _cdpBenchmarkAlertLine();
+    if (cdpLine == null) {
+      return snapshot.aiAlerts;
+    }
+    final result = <String>[];
+    var replaced = false;
+    for (final alert in snapshot.aiAlerts) {
+      if (!replaced && alert.contains('立憲')) {
+        result.add(cdpLine);
+        replaced = true;
+      } else {
+        result.add(alert);
+      }
+    }
+    return result;
+  }
+
+  /// バッチ取得した立憲値を適用済みの plan から、立憲との地力差(上位3県)を edge
+  /// function フォールバックと同じ書式で組み立てる。データが無ければ null。
+  String? _cdpBenchmarkAlertLine() {
+    final plan = _plan;
+    if (plan == null) {
+      return null;
+    }
+    final top = plan.topCdpGapPrefectures(limit: 3);
+    if (top.isEmpty) {
+      return null;
+    }
+    final parts = top.map((item) {
+      final gap = item.cdpMemberGap;
+      return '${item.prefecture}${gap >= 0 ? '+' : ''}$gap';
+    }).join(' / ');
+    return '立憲民主党との地力差（上位）：$parts。';
   }
 
   Widget _buildBulletLine(String text) {


### PR DESCRIPTION
## 概要

「AI整理メモ」の注視ポイントに出る「立憲民主党との地方議員数の比較は今回取得していません。」を、週次バッチで取得した立憲の値を使った**地力差表示**に差し替えます。

## 原因

AI整理メモは `includeAiSummary:false` の snapshot を使う（フォールバック生成）ため、注視ポイントの立憲比較行は snapshot 側 CDP（`includeCdpBenchmarks:false` で全0）を見て「取得していません」固定になっていました。一方、週次バッチで取得した立憲値はクライアント側で `_plan` に適用済みです。

## 変更（クライアント側のみ・edge function 不変）

- `lib/pages/election_victory_page.dart` に `_displayAiAlerts` / `_cdpBenchmarkAlertLine` を追加。
- バッチ値を適用済みの `_plan` から立憲との地力差（上位3県）を edge function フォールバックと同じ書式 `立憲民主党との地力差（上位）：東京+9 / 千葉+49 / …。` で計算し、注視ポイントの立憲行だけを差し替え（他の行・運用メモ・要約は不変）。
- データが無い場合は従来の文言を維持（フォールバック安全）。

## 検証

- `dart analyze lib/pages/election_victory_page.dart` → No issues found
- 差分は当該1ファイル（ヘルパー2つ + ループ差し替え）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 注視ポイントの立憲行のみを plan の地力差へ差し替える表示専用変更。plan 未取得時は従来文言維持。dart analyze クリーンで、実画面で立憲行の更新を確認する。
