### PR TITLE
feat(asset): 支払い方式に「アコムショッピング請求に含む」を追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -24230,8 +24230,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     AssetLiabilityDebtRow row,
     AssetLiabilityWorkbook workbook,
   ) {
+    // アコムショッピング等のショッピング枠も請求のまとめ先に選べるようにする
+    // (請求ホストの正当性は AssetLiabilityPlanningService.isCardBillingHostKind と一致)。
     final cardOptions = _cardBillingAccountOptions(
       workbook,
+      includeShoppingDebt: true,
     ).where((account) => account.id != row.id).toList(growable: false);
     final configured = _cardBillingAccountIds[row.id];
     final selected = configured ??

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -959,21 +959,26 @@ class AssetLiabilityPlanningService {
     };
   }
 
+  /// カード請求のまとめ先（請求ホスト）になれる口座種別か。
+  /// クレジットカードに加え、アコムショッピング等のショッピング枠
+  /// (shoppingDebt) も複数購入をまとめて請求するためホストとして許可する。
+  static bool isCardBillingHostKind(AssetLiabilityAccountKind kind) =>
+      kind == AssetLiabilityAccountKind.creditCard ||
+      kind == AssetLiabilityAccountKind.shoppingDebt;
+
   AssetLiabilityCardBillingReviewData _buildCardBillingReview({
     required List<AssetLiabilityDebtRow> rows,
     required Map<String, AssetLiabilityAccount> accountsById,
   }) {
-    final creditCardAccountIds = accountsById.values
-        .where(
-          (account) => account.kind == AssetLiabilityAccountKind.creditCard,
-        )
+    final billingHostAccountIds = accountsById.values
+        .where((account) => isCardBillingHostKind(account.kind))
         .map((account) => account.id)
         .toSet();
     final items = [
       for (final row in rows)
         _cardBillingReviewItemFor(
           row: row,
-          creditCardAccountIds: creditCardAccountIds,
+          billingHostAccountIds: billingHostAccountIds,
         ),
     ]..sort(_compareCardBillingReviewItems);
 
@@ -999,14 +1004,14 @@ class AssetLiabilityPlanningService {
 
   AssetLiabilityCardBillingReviewItem _cardBillingReviewItemFor({
     required AssetLiabilityDebtRow row,
-    required Set<String> creditCardAccountIds,
+    required Set<String> billingHostAccountIds,
   }) {
     final alerts = <String>[];
     if (row.includedInBillingAccount) {
       final billingAccountId = row.billingAccountId?.trim();
       if (billingAccountId == null || billingAccountId.isEmpty) {
         alerts.add(cardBillingReviewMissingBillingAccountAlert);
-      } else if (!creditCardAccountIds.contains(billingAccountId)) {
+      } else if (!billingHostAccountIds.contains(billingAccountId)) {
         alerts.add(cardBillingReviewRemovedBillingAccountAlert);
       }
     }

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -635,6 +635,74 @@ void main() {
       expect(review.hasDoubleCountingRisk, isFalse);
     });
 
+    test('allows billing into an acom shopping (shoppingDebt) host', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'KDDI': -5764,
+          'アコムショッピング': -2234106,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+        },
+        cardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId:
+              AssetLiabilityPlanningService.acomShoppingAccountId,
+        },
+      );
+
+      final review = workbook.cardBillingReview;
+      final acomGroup = review.cardBillingGroups.firstWhere(
+        (group) =>
+            group.billingAccountId ==
+            AssetLiabilityPlanningService.acomShoppingAccountId,
+      );
+      final kddi = acomGroup.items.firstWhere(
+        (item) =>
+            item.accountId ==
+            AssetLiabilityPlanningService.kddiProviderAccountId,
+      );
+
+      expect(kddi.includedInBillingAccount, isTrue);
+      expect(
+        kddi.alerts,
+        isNot(
+          contains(
+            AssetLiabilityPlanningService
+                .cardBillingReviewRemovedBillingAccountAlert,
+          ),
+        ),
+      );
+    });
+
+    test('isCardBillingHostKind accepts credit card and shopping debt', () {
+      expect(
+        AssetLiabilityPlanningService.isCardBillingHostKind(
+          AssetLiabilityAccountKind.creditCard,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetLiabilityPlanningService.isCardBillingHostKind(
+          AssetLiabilityAccountKind.shoppingDebt,
+        ),
+        isTrue,
+      );
+      expect(
+        AssetLiabilityPlanningService.isCardBillingHostKind(
+          AssetLiabilityAccountKind.deposit,
+        ),
+        isFalse,
+      );
+      expect(
+        AssetLiabilityPlanningService.isCardBillingHostKind(
+          AssetLiabilityAccountKind.cardLoan,
+        ),
+        isFalse,
+      );
+    });
+
     test('reconciles imported card statement totals with billed amount', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: <String, double>{


### PR DESCRIPTION
## 概要

資産管理闘争ページで各負債の「支払い方式」ドロップダウンに **「アコムショッピング請求に含む」** を表示できるようにした。

これまで「○○請求に含む」の選択肢は **クレジットカード種別の口座のみ**で、支払元がアコムショッピング枠の負債（例: MICROSOFT XBOX GAME / X DEVELOPER PLATFORM）でも、請求のまとめ先としてアコムショッピングを選べなかった（ユーザー報告）。

## 原因

請求ホストの判定が `creditCard` 種別限定だった。アコムショッピングは `shoppingDebt` 種別（複数購入をまとめて請求するショッピング枠）のため除外され、ドロップダウンに出ず、仮に選んでも請求エンジン側で「請求先が削除済み」警告になる状態だった。

## 変更点

- 請求ホスト判定を共通述語 `AssetLiabilityPlanningService.isCardBillingHostKind`（`creditCard` または `shoppingDebt`）に集約
- 請求エンジン `_buildCardBillingReview` の正当ホスト集合を述語ベースに変更（ショッピング枠への請求が「削除済み」警告にならない）
- 支払い方式ドロップダウン `_buildPaymentMethodDropdown` で `includeShoppingDebt: true` を指定（自己請求除外はそのまま）

リボ系債務の集計（debt trend / insight）は既に `shoppingDebt || creditCard` を同列に扱っており、その整合に合わせた。請求集約モデル自体は不変（直接支払いを抑制し、ホスト側で差し引く既存仕様）。

## テスト

- `asset_liability_planning_service_test`: ショッピング枠(`acom_shopping`)へ請求しても削除警告にならず請求グループに入ること、述語の真偽を検証（新規2件・計59件緑）
- 既存 `asset_management_page_smoke_test`（49件）緑で UI 回帰なし
- `dart analyze` クリーン / `dart format --set-exit-if-changed` 差分なし

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 請求ホスト判定はサービス層のユニットテスト(planning service 59件・新規2件含む)で担保。UIは支払い方式ドロップダウンへの選択肢追加のみで既存スモーク49件が回帰を担保。
