### PR TITLE
refactor: DesignTokens 基盤を新設＋AI大学ホームカードの色を移行（デザインシステム整合の第一歩）

### DIFF
--- a/lib/theme/design_tokens.dart
+++ b/lib/theme/design_tokens.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+/// docs/DESIGN.md の Orange + Indigo ダークテーマ デザイントークン。
+///
+/// 色・余白・角丸をここへ集約し、各 Widget に散在するハードコード値を
+/// 本クラス参照へ段階的に寄せることで、テーマ一貫性と将来の一括改修容易性を高める。
+/// 値は DESIGN.md の正本トークンに一致する (挙動を変えずに名前を与える)。
+abstract final class DesignTokens {
+  DesignTokens._();
+
+  // ── 背景 / サーフェス ───────────────────────────────
+  static const Color background = Color(0xFF0A0A0A);
+  static const Color surface1 = Color(0xFF1A1A1A); // カード
+  static const Color surface2 = Color(0xFF1E1E1E); // カード内
+  static const Color surface3 = Color(0xFF2A2A2A); // チップ/入力
+  static const Color divider = Color(0xFF2A2A2A);
+
+  // ── アクセント ─────────────────────────────────────
+  static const Color orange = Color(0xFFFF6B35); // CTA / メインアクション
+  static const Color orangeLight = Color(0xFFFF8C5A);
+  static const Color orangeDark = Color(0xFFCC4A1A);
+  static const Color indigo = Color(0xFF3D5AFE); // AI / プレミアム
+  static const Color indigoLight = Color(0xFF7986CB);
+  static const Color green = Color(0xFF4CAF50); // 成功
+  static const Color red = Color(0xFFE53935); // エラー
+  static const Color amber = Color(0xFFFFC107);
+  static const Color gold = Color(0xFFFFD700);
+  static const Color blueLight = Color(0xFF90CAF9);
+
+  // ── テキスト ───────────────────────────────────────
+  static const Color textPrimary = Color(0xFFFFFFFF);
+
+  /// 長文・本文向けのやや柔らかい白 (純白より眼にやさしい / a11y)。
+  static const Color textOnDark = Color(0xFFE5E7EB);
+  static const Color textSecondary = Color(0xFFB0B0B0);
+  static const Color textTertiary = Color(0xFF707070);
+  static const Color textDisabled = Color(0xFF404040);
+
+  // ── 余白 (4px ベース) ──────────────────────────────
+  static const double space2 = 2;
+  static const double space4 = 4;
+  static const double space8 = 8;
+  static const double space12 = 12;
+  static const double space16 = 16;
+  static const double space20 = 20;
+  static const double space24 = 24;
+  static const double space32 = 32;
+
+  // ── 角丸 ───────────────────────────────────────────
+  static const double radiusSmall = 8; // チップ / バッジ
+  static const double radiusMedium = 12; // カード (標準)
+  static const double radiusLarge = 16; // モーダル
+  static const double radiusXl = 24; // ボトムシート
+  static const double radiusCircle = 999;
+}

--- a/lib/widgets/ai_university_home_card.dart
+++ b/lib/widgets/ai_university_home_card.dart
@@ -8,6 +8,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../data/ai_university_genre_catalog.dart';
 import '../services/ai_university_x_post_service.dart';
+import '../theme/design_tokens.dart';
 
 /// AI大学ホームカード — ホーム最上部に表示するキラーコンテンツバナー
 ///
@@ -427,12 +428,12 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                   ),
                   boxShadow: [
                     BoxShadow(
-                      color: const Color(0xFFFF6B35).withValues(alpha: 0.10),
+                      color: DesignTokens.orange.withValues(alpha: 0.10),
                       blurRadius: 24,
                       offset: const Offset(0, 12),
                     ),
                     BoxShadow(
-                      color: const Color(0xFF3D5AFE).withValues(alpha: 0.12),
+                      color: DesignTokens.indigo.withValues(alpha: 0.12),
                       blurRadius: 32,
                       offset: const Offset(0, 8),
                     ),
@@ -461,7 +462,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                           ),
                           child: const Icon(
                             Icons.school_rounded,
-                            color: Color(0xFFFF8C5A),
+                            color: DesignTokens.orangeLight,
                             size: 26,
                           ),
                         ),
@@ -494,7 +495,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                                     _buildStatusPill(
                                       icon: Icons.replay_rounded,
                                       label: '復習 $_dueCardCount問',
-                                      color: const Color(0xFF3D5AFE),
+                                      color: DesignTokens.indigo,
                                     ),
                                 ],
                               ),
@@ -661,7 +662,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                             icon: Icons.hub_outlined,
                             label: '掲載AI',
                             value: providerCountText,
-                            accent: const Color(0xFF3D5AFE),
+                            accent: DesignTokens.indigo,
                           ),
                         ),
                         SizedBox(
@@ -670,7 +671,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                             icon: Icons.check_circle_outline,
                             label: '学習済み',
                             value: '$_answeredCount社',
-                            accent: const Color(0xFF4CAF50),
+                            accent: DesignTokens.green,
                           ),
                         ),
                         SizedBox(
@@ -679,7 +680,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                             icon: Icons.local_fire_department_outlined,
                             label: '連続学習',
                             value: '$_currentStreak日',
-                            accent: const Color(0xFFFF6B35),
+                            accent: DesignTokens.orange,
                           ),
                         ),
                         SizedBox(
@@ -779,7 +780,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                           label: primaryCta,
                           icon: Icons.play_arrow_rounded,
                           foregroundColor: Colors.white,
-                          backgroundColor: const Color(0xFFFF6B35),
+                          backgroundColor: DesignTokens.orange,
                           onTap: _openUniversity,
                         ),
                       ),
@@ -791,7 +792,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                             label: '復習する ($_dueCardCount問)',
                             icon: Icons.replay_rounded,
                             foregroundColor: Colors.white,
-                            backgroundColor: const Color(0xFF3D5AFE),
+                            backgroundColor: DesignTokens.indigo,
                             onTap: _openUniversity,
                           ),
                         ),
@@ -824,7 +825,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                         child: _AiCardActionButton(
                           label: '英語速読',
                           icon: Icons.speed_outlined,
-                          foregroundColor: const Color(0xFF4CAF50),
+                          foregroundColor: DesignTokens.green,
                           borderColor: const Color(0x334CAF50),
                           onTap: _openEnglishReading,
                         ),
@@ -844,7 +845,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                             label: primaryCta,
                             icon: Icons.play_arrow_rounded,
                             foregroundColor: Colors.white,
-                            backgroundColor: const Color(0xFFFF6B35),
+                            backgroundColor: DesignTokens.orange,
                             onTap: _openUniversity,
                           ),
                           _AiCardActionButton(
@@ -865,7 +866,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                           _AiCardActionButton(
                             label: '英語速読',
                             icon: Icons.speed_outlined,
-                            foregroundColor: const Color(0xFF4CAF50),
+                            foregroundColor: DesignTokens.green,
                             borderColor: const Color(0x334CAF50),
                             compact: true,
                             onTap: _openEnglishReading,
@@ -874,7 +875,7 @@ class _AiUniversityHomeCardState extends State<AiUniversityHomeCard> {
                           _AiCardActionButton(
                             label: '音声で学ぶ',
                             icon: Icons.mic,
-                            foregroundColor: const Color(0xFF3D5AFE),
+                            foregroundColor: DesignTokens.indigo,
                             borderColor: const Color(0x333D5AFE),
                             compact: true,
                             onTap: () => Navigator.pushNamed(


### PR DESCRIPTION
## 概要

UI/UX 監査の**デザインシステム整合**（ハードコード色/余白/角丸の散在）への第一歩。トークン基盤を新設し、安全な範囲で適用します。

## 前提: Noto フォントは対応不要だった

監査の「フォント未指定→tofuリスク」は**誤検知**でした。`theme_service.dart` が `fontFamily: 'NotoSansJP'` + フォールバックを **ThemeData に全体適用**済み、pubspec にフォント同梱、web/index.html に @import 済み。よってフォント修正は不要（コンソールの Noto 警告は既知の benign 事象）。

## 変更点

- **`lib/theme/design_tokens.dart` を新設**: DESIGN.md の色/余白/角丸トークンを集約した `DesignTokens`（挙動を変えず名前を与える基盤）
- **AI大学ホームカードのブランド色を移行**: orange/indigo/green/orangeLight を `DesignTokens` 参照へ（値は同一＝**挙動保存**）

## 段階実施の方針

色/余白/角丸の**全面移行**と **a11yスイープ**（白→#E5E7EB のコントラスト調整・タップ44px 等）は app 全体に波及するため、ファイル単位で段階的に進めるのが安全。本PRはその基盤＋1ファイル適用。

## 検証

- `dart analyze` = No issues found / `dart format` = clean（値は不変で挙動保存）

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: デザイントークン基盤(DesignTokens)の新設と、ホームカードのブランド色をトークン参照へ寄せる挙動保存リファクタ。色の値は同一でロジック・遷移・データは不変。dart analyze/formatクリーンで、視覚確認は反映後の実機で実施する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
