### PR TITLE
fix(asset): 振替元が自分自身を指す不正設定を未設定扱いにする

### DIFF
--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -756,7 +756,13 @@ class AssetLiabilityPlanningService {
     );
     final principalPayment = max(0.0, scheduledPayment - interest);
     final afterPayment = -max(0.0, principal + interest - scheduledPayment);
-    final paymentSourceAccountId = paymentSourceAccountIds[account.id];
+    final rawPaymentSourceAccountId = paymentSourceAccountIds[account.id];
+    // 振替元が自分自身を指す設定は不正 (ローンを自分自身からは返済できない) なので
+    // 未設定扱いにする。これにより「支払原資口座の未設定」セクションに表示され、正しい
+    // 口座 (例: じぶん銀行) へ修正できるようになり、見込み残高の自己宛て誤ルーティングも防ぐ。
+    final paymentSourceAccountId = rawPaymentSourceAccountId == account.id
+        ? null
+        : rawPaymentSourceAccountId;
     final paymentSourceAccountName = paymentSourceAccountId == null
         ? null
         : accountsById[paymentSourceAccountId]?.name;

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1905,5 +1905,31 @@ void main() {
       );
       expect(excluded.accounts.any((a) => a.name.contains('水道')), isFalse);
     });
+
+    test('treats a self-referential payment source as unset', () {
+      // 振替元が自分自身を指す不正設定は「未設定」に正規化する
+      // (ローンを自分自身からは返済できない / 自己宛て誤ルーティング防止)。
+      final selfRef = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+        paymentSourceAccountIds: const <String, String>{'mobit': 'mobit'},
+      );
+      final selfMobit = selfRef.debtMasterRows.firstWhere(
+        (row) => row.name == 'モビット',
+      );
+      expect(selfMobit.paymentSourceAccountId, isNull);
+      expect(selfMobit.paymentSourceAccountName, isNull);
+
+      // 自分以外の口座IDは従来どおり保持する (回帰なし)。
+      final other = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+        paymentSourceAccountIds: const <String, String>{'mobit': 'smbc_otsuka'},
+      );
+      final otherMobit = other.debtMasterRows.firstWhere(
+        (row) => row.name == 'モビット',
+      );
+      expect(otherMobit.paymentSourceAccountId, 'smbc_otsuka');
+    });
   });
 }


### PR DESCRIPTION
## 概要

実機で「じぶんローン」の振替元(支払原資口座)が**その負債自身**に設定されており、修正導線が無かった。「支払原資口座の未設定」セクションは**振替元が空のものだけ**を表示するため、自分自身に設定された負債は出てこない。さらに見込み残高で**「自分自身へ支払う」誤ルーティング**が起きていた。

## 変更点(lib/services 1 + test 1 / +33 -1)

- planning service の負債行生成で **`振替元 == その負債の口座id`(自己参照)を null(未設定)に正規化**。
  - → 当該負債が**「支払原資口座の未設定」セクションに表示**され、ドロップダウンで正しい口座(例: じぶん銀行)へ設定できる(**引落済みにせず**修正可能)。
  - → 見込み残高の**自己宛てルーティングが消える**。
- 自分以外の口座IDは**従来どおり保持**(回帰なし)。

## 検証

- planning service テストに **`自己参照→null` / `他口座IDは保持`** を追加 → **全60緑**。
- `flutter analyze`(service+test)No issues / `dart format` 版間安定。

## 修正後のユーザー操作(本番反映後)

資産管理 →「支払原資口座の未設定」セクションに**じぶんローン**が出る → ドロップダウンで**じぶん銀行**を選択(今月 or 既定)。引落済みにせず振替元だけ正しく設定できます。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Pure planner-logic fix in lib/services: normalizes a self-referential funding source (source==the debt's own id) to unset; covered by a new unit test (self-ref to null + non-self preserved) in asset_liability_planning_service_test (60 green); no UI/runtime path needs an e2e route

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: App-code planner-logic fix in lib/services only (no firebase.json/.github/RLS/migration/deploy-logic paths); normalizes self-referential funding source to unset so the debt appears in the unset-source section; unit-tested, flutter analyze clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
