### PR TITLE
fix(ai-hub): 残りの外部/サブ関数 fetch にもタイムアウトを横展開 (502 予防の続き)

### DIFF
--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -739,8 +739,8 @@ function providerFetchTimeoutMs(): number {
   return Number.isFinite(raw) && raw > 0 ? raw : 90_000;
 }
 
-/// 外部プロバイダ呼び出しに providerFetchTimeoutMs() のタイムアウトを付与する
-/// `fetch` ラッパー。遅延/ハングするプロバイダで edge function が wall-clock 上限を
+/// 外部プロバイダ / 内部サブ関数呼び出しに providerFetchTimeoutMs() のタイムアウトを
+/// 付与する `fetch` ラッパー。遅延/ハングするプロバイダで edge function が wall-clock 上限を
 /// 超えてランタイムに kill され 502 になるのを防ぐ (callProvider と同方針の横展開)。
 /// abort 時は AbortError を throw → 各 action / serve トップレベルの try/catch が
 /// 捕捉し、502 ではなくハンドル済みエラー応答へ落ちる。
@@ -2664,7 +2664,7 @@ async function embedTextsWithGemini(
   apiKey: string,
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
-  const response = await fetch(
+  const response = await fetchWithProviderTimeout(
     "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents",
     {
       method: "POST",
@@ -2811,15 +2811,18 @@ async function invokeAiAssistant(
   payload: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   if (!authHeader) throw new Error("Missing authorization header");
-  const response = await fetch(`${SUPABASE_URL}/functions/v1/ai-assistant`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "apikey": SUPABASE_ANON_KEY,
-      "Authorization": authHeader,
+  const response = await fetchWithProviderTimeout(
+    `${SUPABASE_URL}/functions/v1/ai-assistant`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "apikey": SUPABASE_ANON_KEY,
+        "Authorization": authHeader,
+      },
+      body: JSON.stringify(payload),
     },
-    body: JSON.stringify(payload),
-  });
+  );
   const rawText = await response.text();
   let parsed: Record<string, unknown> = {};
   if (rawText.trim()) {
@@ -2851,7 +2854,7 @@ async function callGemini(
       },
     });
   }
-  const res = await fetch(
+  const res = await fetchWithProviderTimeout(
     `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
     {
       method: "POST",
@@ -2885,7 +2888,7 @@ async function callManusTask(
   const manusPrompt = image
     ? `${prompt}\n\nNote: an image was attached in my-ai-agent, but this Manus task.create integration sends the text prompt only.`
     : prompt;
-  const res = await fetch(`${baseUrl}/task.create`, {
+  const res = await fetchWithProviderTimeout(`${baseUrl}/task.create`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -4943,7 +4946,7 @@ serve(async (req: Request) => {
               // ignore logging errors
             }
           };
-          const resp = await fetch(fetchUrl, {
+          const resp = await fetchWithProviderTimeout(fetchUrl, {
             method: "POST",
             headers: {
               ...authHeaders,
@@ -5558,7 +5561,7 @@ serve(async (req: Request) => {
             reason: "ELEVENLABS_API_KEY not configured",
           });
         }
-        const ttsResp = await fetch(
+        const ttsResp = await fetchWithProviderTimeout(
           `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
           {
             method: "POST",
@@ -5626,7 +5629,7 @@ serve(async (req: Request) => {
         }
         const audioBody = new ArrayBuffer(audioBytes.byteLength);
         new Uint8Array(audioBody).set(audioBytes);
-        const dgResp = await fetch(
+        const dgResp = await fetchWithProviderTimeout(
           `https://api.deepgram.com/v1/listen?language=${language}&model=nova-2&punctuate=true`,
           {
             method: "POST",
@@ -5867,7 +5870,7 @@ serve(async (req: Request) => {
 }
 `;
         try {
-          const r = await fetch(
+          const r = await fetchWithProviderTimeout(
             `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${geminiApiKey}`,
             {
               method: "POST",


### PR DESCRIPTION
## 概要

[#3576](https://github.com/kanta13jp1/my_web_app/pull/3576) / [#3586](https://github.com/kanta13jp1/my_web_app/pull/3586) の続きで、ai-hub に残っていた素の `fetch` 呼び出し 8 サイトを `fetchWithProviderTimeout` でラップし、遅延/ハングする外部プロバイダによる 502 (Bad Gateway) を予防します。

成功パスの挙動は不変で、abort 時のみ AbortError を throw → 既存の各 action / serve トップレベルの try/catch がハンドル済みエラー応答へ落とします (502 ではなく 500 等へグレースフルに縮退)。

### 対象 8 サイト

| 関数 / action | 宛先 |
|---|---|
| `embedTextsWithGemini` | Gemini embeddings |
| `invokeAiAssistant` | 内部 ai-assistant サブ関数 |
| `callGemini` | Gemini 画像/テキスト生成 |
| `callManusTask` | Manus task.create |
| `provider.chat` | 直接プロバイダ chat ルーティング |
| `voice.tts` | ElevenLabs |
| `voice.stt` | Deepgram |
| 選挙 KPI 生成 | Gemini |

タイムアウト値は既存の `AI_HUB_PROVIDER_TIMEOUT_MS` (既定 90s) を共有します。新規の環境変数や権限、データ経路の追加はありません。

検証: `deno check` + `deno lint` 緑。残る素の `fetch` は `callProvider` (既存 AbortController で保護済) と `fetchWithProviderTimeout` 自身の 2 箇所のみ。

## Minimal E2E Gate

- この変更は outbound `fetch` へタイムアウト signal を付与するだけで、入出力 (I/O) の契約は不変。テスト観点は実装詳細に依存しない black-box の入出力で記述できる。
- E2E 計画は最小限の約 3ケース (正常応答 / タイムアウト abort でグレースフル縮退 / 既存フォールバック維持) を想定。
- E2E 機構: 通常は Flutter integration_test / Playwright を用いるが、本 PR は edge function 内部のネットワーク signal 付与のみで画面は不変。
- E2E-Exception: edge function の outbound タイムアウト付与のみで UI/画面遷移は一切変化せず、実ネットワーク依存のため integration_test 追加は非現実的。`deno check` + `deno lint` で型/構文を担保済み。

## High-Risk Ultrareview

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: supabase/functions 配下だが挙動保存の fetch ラップのみで、新規の権限/データ経路/外部公開面の変更は無し。共有 AI 基盤のため最終マージはユーザー承認後に実施する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
