### PR TITLE
feat(asset): 定期固定費カードを給料日サイクル順に並べ替え

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -9250,10 +9250,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       });
       if (changed && mounted) {
         final nextList = merged.values.toList()
-          ..sort((a, b) {
-            final byDay = a.paymentDay.compareTo(b.paymentDay);
-            return byDay != 0 ? byDay : a.name.compareTo(b.name);
-          });
+          ..sort(_compareRecurringFixedCostsByPaymentDay);
         setState(() {
           _recurringFixedCosts = nextList;
         });
@@ -10014,10 +10011,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       } else {
         next.add(cost);
       }
-      next.sort((a, b) {
-        final byDay = a.paymentDay.compareTo(b.paymentDay);
-        return byDay != 0 ? byDay : a.name.compareTo(b.name);
-      });
+      next.sort(_compareRecurringFixedCostsByPaymentDay);
       _recurringFixedCosts = next;
     });
     _persistInBackground(
@@ -10104,7 +10098,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final utilityCosts = <AssetRecurringFixedCost>[
       for (final cost in _recurringFixedCosts)
         if (cost.category == AssetRecurringFixedCostCategory.utility) cost,
-    ];
+    ]..sort(_compareRecurringFixedCostsByPaymentDay);
     return RecurringFixedCostCard(
       costs: utilityCosts,
       sourceAccountNames: sourceNames,
@@ -10136,7 +10130,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final subscriptionCosts = <AssetRecurringFixedCost>[
       for (final cost in _recurringFixedCosts)
         if (cost.category == AssetRecurringFixedCostCategory.subscription) cost,
-    ];
+    ]..sort(_compareRecurringFixedCostsByPaymentDay);
     return SubscriptionFixedCostCard(
       costs: subscriptionCosts,
       sourceAccountNames: sourceNames,
@@ -24190,15 +24184,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   ) {
     // 給料日サイクル順 (給料日起点) に並べる。salaryDay=25 なら
     // 25,26…31,1…24 の順。未設定 (null) は末尾。
-    final rankA = AssetLiabilityMonthlyStateStore.salaryCyclePaymentDayRank(
+    final day = AssetLiabilityMonthlyStateStore.compareSalaryCyclePaymentDays(
       a.paymentDay,
-      salaryDay: _salaryDay,
-    );
-    final rankB = AssetLiabilityMonthlyStateStore.salaryCyclePaymentDayRank(
       b.paymentDay,
       salaryDay: _salaryDay,
     );
-    final day = rankA.compareTo(rankB);
     if (day != 0) {
       return day;
     }
@@ -24207,6 +24197,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return balance;
     }
     return a.name.compareTo(b.name);
+  }
+
+  /// 定期固定費を給料日サイクル順に並べる。負債マスタ
+  /// ([_compareDebtRowsByPaymentDay]) と同じ起点・同じ rank を共有し、支払日が同じ
+  /// ときは名前順。paymentDay は非 null int なので null 救済は不要。
+  int _compareRecurringFixedCostsByPaymentDay(
+    AssetRecurringFixedCost a,
+    AssetRecurringFixedCost b,
+  ) {
+    final day = AssetLiabilityMonthlyStateStore.compareSalaryCyclePaymentDays(
+      a.paymentDay,
+      b.paymentDay,
+      salaryDay: _salaryDay,
+    );
+    return day != 0 ? day : a.name.compareTo(b.name);
   }
 
   List<AssetLiabilityDebtRow> _filteredDebtMasterRows(

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -641,6 +641,18 @@ class AssetLiabilityMonthlyStateStore {
     return day >= anchor ? day - anchor : day - anchor + 31;
   }
 
+  /// 支払日 2 件を給料日サイクル順 ([salaryCyclePaymentDayRank]) で比較する共有
+  /// コンパレータ。負債マスタ・定期固定費など「給料日サイクル順に並べたい」複数の
+  /// リストで同じ並びを共有するため。null (未設定) は末尾へ寄る。
+  static int compareSalaryCyclePaymentDays(
+    int? a,
+    int? b, {
+    int salaryDay = 25,
+  }) {
+    return salaryCyclePaymentDayRank(a, salaryDay: salaryDay)
+        .compareTo(salaryCyclePaymentDayRank(b, salaryDay: salaryDay));
+  }
+
   static AssetLiabilityMonthlyState copyPreviousMonthState({
     required AssetLiabilityMonthlyState previousState,
     required DateTime targetMonth,

--- a/test/services/asset_liability_monthly_state_store_test.dart
+++ b/test/services/asset_liability_monthly_state_store_test.dart
@@ -102,6 +102,27 @@ void main() {
       expect(rank(32), rank(31));
     });
 
+    test('compareSalaryCyclePaymentDays sorts a list into salary-cycle order',
+        () {
+      int cmp(int? a, int? b, {int salaryDay = 25}) =>
+          AssetLiabilityMonthlyStateStore.compareSalaryCyclePaymentDays(
+            a,
+            b,
+            salaryDay: salaryDay,
+          );
+      // salaryDay=25: 給料日以降 (25..31) が翌月分 (1..24) より前へ。
+      expect(cmp(27, 5).isNegative, isTrue);
+      expect(cmp(5, 27), greaterThan(0));
+      expect(cmp(25, 25), 0);
+      // null (未設定) は末尾へ。
+      expect(cmp(24, null).isNegative, isTrue);
+      expect(cmp(null, 1), greaterThan(0));
+      // 実リスト (定期固定費の paymentDay 相当) を並べ替えると、暦日昇順ではなく
+      // 給料日(25)起点の cycle 順へ: rank は 25→0,27→2,1→7,5→11,10→16,24→30。
+      final days = <int>[5, 27, 1, 24, 25, 10]..sort(cmp);
+      expect(days, <int>[25, 27, 1, 5, 10, 24]);
+    });
+
     test('saves and restores monthly paid statuses', () async {
       await store.saveMonth(
         month: DateTime(2026, 5, 13),


### PR DESCRIPTION
## 概要

定期固定費カード（光熱費・サブスク）の表示順を、負債マスタ（#3524）と同じ **給料日サイクル順** に統一する。PR1（#3452）で対象外にした follow-up。

## 背景

負債マスタは #3524 で `salaryCyclePaymentDayRank` により給料日起点（salaryDay=25 なら 25→翌24 の順）で並ぶようになったが、定期固定費カードは暦日昇順（1→31）のままで、同じ画面内で並び基準が食い違っていた。

## 変更

- `AssetLiabilityMonthlyStateStore.compareSalaryCyclePaymentDays` を新設（既存 `salaryCyclePaymentDayRank` を使う純粋な共有コンパレータ / null は末尾）。
- 負債マスタのコンパレータ `_compareDebtRowsByPaymentDay` を上記ヘルパー利用へ DRY 化（並びは不変）。
- 定期固定費の表示順を給料日サイクル順へ:
  - 光熱費カード / サブスクカードの表示直前に `..sort` を適用（表示が正本）。
  - 保存・端末間復元時のソートも同コンパレータへ統一（永続順を表示と一致）。
- 純粋な単体テストを追加（サイクル順 / null 末尾 / リスト並べ替え）。

## 振る舞い

- salaryDay=25 のとき、固定費は 25,26,…,31,1,…,24 の順で表示される。
- 給料日設定（`_salaryDay`）に追従（負債マスタと同じ起点を共有）。

## テスト

- `flutter test test/services/asset_liability_monthly_state_store_test.dart` 緑。
- `dart analyze`（変更 3 ファイル）issue 0。
- 巨大ページの結合スモークはローカル環境で Dart VM が JIT クラッシュするため CI（Linux）に委譲。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純粋コンパレータの単体テストで網羅。UI 結合スモークは巨大ページが本環境で JIT クラッシュするため CI(Linux) に委譲
