### PR TITLE
feat(asset): 収入¥0 時に手入力収入導線(CTA)を収支サマリーへ追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -13995,6 +13995,49 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 ),
               ],
             ),
+            if (totalIncome == 0) ...[
+              const SizedBox(height: 14),
+              Container(
+                key: const Key('asset_monthly_flow_income_cta'),
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF0F766E).withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: const Color(0xFF99F6E4)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '収入がまだ記録されていません。給与明細を使わなくても、'
+                      '手入力で収入を記録すれば黒字/赤字を正しく把握できます。',
+                      style: TextStyle(
+                        fontSize: 12,
+                        height: 1.5,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: FilledButton.icon(
+                        key: const Key('asset_monthly_flow_income_cta_button'),
+                        onPressed: () {
+                          _updateSelectedFlowType('収入');
+                          _scrollTo(_keyFlow);
+                        },
+                        style: FilledButton.styleFrom(
+                          backgroundColor: const Color(0xFF0F766E),
+                        ),
+                        icon: const Icon(Icons.add, size: 18),
+                        label: const Text('収入を記録する'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ],
         ),
       ),
@@ -26616,6 +26659,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 Expanded(
                   flex: 2,
                   child: DropdownButtonFormField<String>(
+                    key: const Key('asset_flow_type_dropdown'),
                     initialValue: _selectedFlowType,
                     decoration: const InputDecoration(
                       border: OutlineInputBorder(),

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -294,6 +294,114 @@ void main() {
     );
 
     testWidgets(
+      'monthly flow card shows manual income CTA when no income is recorded',
+      (tester) async {
+        // 給与明細も収入フロー(conquer)も無く支出だけのユーザーは収入¥0=赤字に
+        // 見える。手入力収入への導線(CTA)が出て、ワンタップで収支記録の種別が
+        // 「収入」へ切り替わることを検証する。
+        final now = DateTime.now();
+        final cycleExpense = DateTime(now.year, now.month, now.day, 12);
+
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              debugInitialRecentFlows: <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'action_type': 'expense',
+                  'amount': 50000,
+                  'description': '食費',
+                  'occurred_at': cycleExpense.toIso8601String(),
+                },
+              ],
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(
+          find.byKey(const Key('asset_monthly_flow_income_cta')),
+          findsOneWidget,
+        );
+
+        final dropdownFinder = find.byKey(
+          const Key('asset_flow_type_dropdown'),
+        );
+        // タップ前は既定の支出。
+        expect(
+          tester
+              .widget<DropdownButtonFormField<String>>(dropdownFinder)
+              .initialValue,
+          '支出',
+        );
+
+        final ctaButton = find.byKey(
+          const Key('asset_monthly_flow_income_cta_button'),
+        );
+        await tester.ensureVisible(ctaButton);
+        await tester.pump();
+        await tester.tap(ctaButton);
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // CTA で収支記録の種別が「収入」へ切り替わる(記録時に conquer になる)。
+        expect(
+          tester
+              .widget<DropdownButtonFormField<String>>(dropdownFinder)
+              .initialValue,
+          '収入',
+        );
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
+      'monthly flow card hides manual income CTA when income exists',
+      (tester) async {
+        // 当サイクルに収入フロー(conquer)があれば収入¥0ではないので CTA は出ない。
+        final now = DateTime.now();
+        final cycleStart = AssetLiabilityMonthlyStateStore.salaryCycleStart(
+          now,
+          salaryDay: AssetSalaryDayStore.defaultSalaryDay,
+        );
+        final cycleSalary = DateTime(
+          cycleStart.year,
+          cycleStart.month,
+          cycleStart.day,
+          12,
+        );
+
+        await tester.binding.setSurfaceSize(const Size(1200, 2400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AssetManagementPage(
+              debugInitialRecentFlows: <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'action_type': 'conquer',
+                  'amount': 280000,
+                  'description': '給料',
+                  'occurred_at': cycleSalary.toIso8601String(),
+                },
+              ],
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(
+          find.byKey(const Key('asset_monthly_flow_income_cta')),
+          findsNothing,
+        );
+
+        await _unmount(tester);
+      },
+    );
+
+    testWidgets(
       'payslip row and salary_income with same pay date/amount are counted once',
       (tester) async {
         // 1枚の給与明細は payslips と salary_incomes の両方に同日同額で入る。


### PR DESCRIPTION
## 概要

「④収支の記録」カードには種別ドロップダウン `['支出','収入','振替']` があり '収入' を選べば手入力で収入を記録できます（`action_type=conquer` → 収支サマリーの収入へ合算）。しかし既定が「支出」のため、給与明細を使わない汎用ユーザーは**収入を手入力できることに気づきにくく、収入¥0=常に赤字に見えてしまう**問題がありました。

本 PR は給料サイクルの収支サマリーカードで、当サイクルの収入が ¥0 のときだけ CTA「収入を記録する」を表示します。タップで「④収支の記録」カードへスクロールし、種別を「収入」にプリセットして手入力を促します。

- 収入¥0 のときだけ表示 (`asset_monthly_flow_income_cta`)。給与明細 or `conquer` フローのいずれかで収入があれば非表示 → **従来の表示は不変**（純粋に additive）。
- 種別ドロップダウンに Key を付与しテスト容易化。
- `dart analyze`（変更ファイル）緑 / 変更コードは format-stable。

## Minimal E2E Gate

- テスト観点は実装詳細に依存しない入出力 (I/O / black-box) で記述できる: 収入¥0 → CTA 表示・タップで種別が「収入」へ / 収入あり → CTA 非表示。
- E2E 計画は最小限の約 3ケース（収入無=CTA表示 / タップで収入選択 / 収入有=CTA非表示）。
- E2E 機構: 巨大ページ化で Win 実機の page smoke が JIT クラッシュするため、integration_test ではなく widget smoke test (testWidgets) で検証。既存 `asset_management_page_smoke_test.dart` に 2 件追加し緑。
- E2E-Exception: UI 導線の表示/タップ/状態遷移は widget smoke test で決定的に検証済み。巨大ページの統合 E2E は CI の Public E2E stability smoke へ委譲する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
