### PR TITLE
feat(asset): 給料振込の自動検知に想定給料額の登録導線を追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -51,6 +51,7 @@ import 'package:my_web_app/services/asset_subscription_catalog.dart';
 import 'package:my_web_app/services/asset_subscription_duplicate_detector.dart';
 import 'package:my_web_app/services/ai_hub_chat_service.dart';
 import 'package:my_web_app/services/asset_payment_check_guide_service.dart';
+import 'package:my_web_app/services/asset_salary_amount_store.dart';
 import 'package:my_web_app/services/asset_salary_day_store.dart';
 import 'package:my_web_app/services/asset_salary_deposit_detector.dart';
 import 'package:my_web_app/services/asset_salary_reset_marker_store.dart';
@@ -308,6 +309,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // 給料日(資産管理の月次サイクル基準日 / 設定で変更可 / clamp 1-28)。
   // AssetSalaryDayStore で永続化 + asset_pref_mirror(salary_day)で端末間同期。
   int _salaryDay = AssetSalaryDayStore.defaultSalaryDay;
+  // 想定給料額(手取りの目安 / 任意 / null=未登録)。登録すると給料振込の自動検知が
+  // heuristicFloor 依存から精密判定へ切り替わる。AssetSalaryAmountStore で永続化 +
+  // asset_pref_mirror(salary_amount)で端末間同期。
+  double? _salaryAmount;
   // 支払済みチェックのリセット契機を「給料がメインバンクへ振り込まれた検知」にする
   // ための、リセット承認済み給料サイクル(yyyy-MM)。AssetSalaryResetMarkerStore で
   // 永続化 + asset_pref_mirror(salary_reset_ack_cycle)で端末間同期(max-merge)。
@@ -768,6 +773,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   String? _assetDebtTrendSyncedSignature;
   final AssetSalaryDayStore _salaryDayStore = const AssetSalaryDayStore();
   static const String _salaryDayMirrorKey = 'salary_day';
+  final AssetSalaryAmountStore _salaryAmountStore =
+      const AssetSalaryAmountStore();
+  static const String _salaryAmountMirrorKey = 'salary_amount';
   final AssetRevolvingCreditConfigStore _revolvingConfigStore =
       const AssetRevolvingCreditConfigStore();
   final AssetRecurringFixedCostStore _recurringFixedCostStore =
@@ -932,6 +940,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _loadDisplayMode();
     _loadMainAccount();
     unawaited(_loadSalaryDay());
+    unawaited(_loadSalaryAmount());
     unawaited(_loadSalaryResetMarker());
     unawaited(_loadRevolvingConfigs());
     unawaited(_loadCategoryBudgets());
@@ -8492,6 +8501,69 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  /// 想定給料額を起動時にローカルから読み、サーバミラーで上書きする。
+  Future<void> _loadSalaryAmount() async {
+    try {
+      final amount = await _salaryAmountStore.load();
+      if (mounted && amount != _salaryAmount) {
+        setState(() => _salaryAmount = amount);
+      }
+    } catch (e) {
+      debugPrint('Error loading salary amount: $e');
+    }
+    await _restoreSalaryAmountFromMirror();
+  }
+
+  /// サーバミラー (pref_key: salary_amount) があれば採用する(設定は稀更新 +
+  /// AI 計算へは毎回 payload で渡すため scalar は集約優先で実害小)。
+  Future<void> _restoreSalaryAmountFromMirror() async {
+    if (_supabase.auth.currentUser == null) {
+      return;
+    }
+    try {
+      final rows = await _bootSelectPrefMirror(_salaryAmountMirrorKey);
+      if (rows.isEmpty) {
+        return;
+      }
+      final restored = AssetSalaryAmountStore.decodeMirrorValue(
+        rows.first['value'],
+      );
+      if (!mounted || restored == _salaryAmount) {
+        return;
+      }
+      setState(() => _salaryAmount = restored);
+      _persistInBackground(
+        _salaryAmountStore.save(restored),
+        'salary amount restore save',
+      );
+    } catch (e) {
+      debugPrint('salary amount mirror restore failed: $e');
+    }
+  }
+
+  /// 想定給料額を `asset_pref_mirror` (pref_key: salary_amount) へ 1 行 upsert する。
+  /// 未登録 (null) のときは upsert しない(削除は稀なので明示クリア時のみ反映)。
+  Future<void> _mirrorSalaryAmount() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) {
+      return;
+    }
+    final amount = _salaryAmount;
+    if (amount == null) {
+      return;
+    }
+    try {
+      await _supabase.from('asset_pref_mirror').upsert(<String, dynamic>{
+        'user_id': userId,
+        'pref_key': _salaryAmountMirrorKey,
+        'value': AssetSalaryAmountStore.encodeMirrorValue(amount),
+        'updated_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    } catch (e) {
+      debugPrint('salary amount mirror upsert failed: $e');
+    }
+  }
+
   /// 給料リセット承認マーカーをローカル + サーバミラーから読み込む。初回(未設定)は
   /// 当日サイクルを承認済みにして、以後のサイクル遷移だけを gating 対象にする
   /// (機能投入直後にいきなり前サイクルへ退避させない)。
@@ -8712,8 +8784,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     return bestKey == null ? null : _assetData[bestKey]![accountName];
   }
 
-  /// 登録済みの想定給料額(繰り返し入金ルール / 収入予定の最大額)。無ければ null。
+  /// 自動検知に使う登録給料額。明示登録された想定給料額を最優先し、無ければ
+  /// 繰り返し入金ルール / 収入予定の最大額で推定する。いずれも無ければ null
+  /// (= ヒューリスティック検知へフォールバック)。
   double? _registeredSalaryAmount() {
+    // 明示登録された想定給料額があれば最優先(検知精度が最も高い)。
+    final explicit = _salaryAmount;
+    if (explicit != null && explicit > 0) {
+      return explicit;
+    }
     var maxAmount = 0.0;
     for (final rule in _expectedInflowRules) {
       if (rule.amount > maxAmount) {
@@ -8822,6 +8901,93 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     }
                     Navigator.of(dialogContext).pop();
                     unawaited(_setSalaryDay(day));
+                  },
+                  child: const Text('保存'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  /// 想定給料額を更新して永続化 + ミラーする。null/0 以下はクリア(未登録)。
+  Future<void> _setSalaryAmount(double? amount) async {
+    final normalized = AssetSalaryAmountStore.normalize(amount);
+    if (normalized == _salaryAmount) {
+      return;
+    }
+    setState(() => _salaryAmount = normalized);
+    _persistInBackground(
+      _salaryAmountStore.save(normalized),
+      'salary amount save',
+    );
+    unawaited(_mirrorSalaryAmount());
+  }
+
+  /// 想定給料額(自動検知の精度を上げる手取りの目安)を設定するダイアログ。
+  Future<void> _showSalaryAmountDialog() async {
+    final initial = _salaryAmount;
+    final controller = TextEditingController(
+      text: initial == null ? '' : initial.round().toString(),
+    );
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        String? errorText;
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              title: const Text('想定給料額'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'メインバンクへ毎サイクル振り込まれる手取りの目安を登録すると、'
+                    '入金額の一致で給料振込を自動検知でき、誤検知や取りこぼしが減ります。'
+                    '(任意 / 未登録でも残高の大きな増加で推定します)',
+                    style: TextStyle(fontSize: 12, height: 1.5),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: controller,
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    decoration: InputDecoration(
+                      labelText: '想定給料額 (円)',
+                      hintText: '例: 280000',
+                      errorText: errorText,
+                    ),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                if (initial != null)
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(dialogContext).pop();
+                      unawaited(_setSalaryAmount(null));
+                    },
+                    child: const Text('クリア'),
+                  ),
+                FilledButton(
+                  onPressed: () {
+                    final raw = controller.text.trim();
+                    final amount = double.tryParse(raw);
+                    if (raw.isEmpty ||
+                        amount == null ||
+                        AssetSalaryAmountStore.normalize(amount) == null) {
+                      setDialogState(() => errorText = '1 円以上の金額を入力してください');
+                      return;
+                    }
+                    Navigator.of(dialogContext).pop();
+                    unawaited(_setSalaryAmount(amount));
                   },
                   child: const Text('保存'),
                 ),
@@ -12605,6 +12771,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return const SizedBox.shrink();
     }
     final scheme = Theme.of(context).colorScheme;
+    // 登録給料額が無いと検知は汎用しきい値 (heuristicFloor) 頼みで精度が落ちる。
+    // 未登録時は想定給料額の登録を促し、入金額一致での精密検知へ誘導する。
+    final salaryRegistered = _registeredSalaryAmount() != null;
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Card(
@@ -12651,6 +12820,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 label: '前サイクルの支払済みを表示中',
                 color: const Color(0xFF0E7490),
               ),
+              if (!salaryRegistered) ...[
+                const SizedBox(height: 8),
+                Text(
+                  '想定給料額を登録すると、入金額の一致で給料振込を自動検知でき、'
+                  '誤検知や取りこぼしが減ります。',
+                  style: TextStyle(
+                    fontSize: 12,
+                    height: 1.5,
+                    color: scheme.onTertiaryContainer,
+                  ),
+                ),
+              ],
               const SizedBox(height: 10),
               Wrap(
                 spacing: 8,
@@ -12661,6 +12842,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     icon: const Icon(Icons.refresh, size: 16),
                     label: const Text('残高を更新'),
                   ),
+                  if (!salaryRegistered)
+                    TextButton.icon(
+                      onPressed: () => unawaited(_showSalaryAmountDialog()),
+                      icon: const Icon(Icons.payments_outlined, size: 16),
+                      label: const Text('想定給料額を登録'),
+                    ),
                   TextButton.icon(
                     onPressed: _confirmManualSalaryReset,
                     icon: const Icon(Icons.check_circle_outline, size: 16),
@@ -21978,6 +22165,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     onPressed: () => unawaited(_showSalaryDayDialog()),
                     icon: const Icon(Icons.event_available_outlined),
                     label: Text('給料日 $_salaryDay日'),
+                  ),
+                  TextButton.icon(
+                    onPressed: () => unawaited(_showSalaryAmountDialog()),
+                    icon: const Icon(Icons.payments_outlined),
+                    label: Text(
+                      _salaryAmount == null
+                          ? '想定給料額'
+                          : '想定給料額 ¥${NumberFormat('#,###').format(_salaryAmount!.round())}',
+                    ),
                   ),
                   TextButton.icon(
                     onPressed: _copyPreviousMonthSettings,

--- a/lib/services/asset_salary_amount_store.dart
+++ b/lib/services/asset_salary_amount_store.dart
@@ -1,0 +1,58 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 想定給料額(メインバンクへ毎サイクル振り込まれる手取りの目安)を永続化する。
+///
+/// 給料振込の自動検知 ([AssetSalaryDepositDetector]) は、登録給料額があれば入金額
+/// または残高増を ±許容で精密に判定できる。登録が無いと汎用の `heuristicFloor`
+/// (既定 10 万円) に頼るしかなく、高収入では誤検知・低収入では取りこぼしが起きや
+/// すい。この値をユーザーが登録することで検知精度が上がる。
+///
+/// [AssetSalaryDayStore] と同じ方針で、ローカル (SharedPreferences) を一次ストア
+/// とし、端末間同期は資産管理ページが `asset_pref_mirror` (pref_key:
+/// `salary_amount`) へ 1 行 jsonb (`{amount: N}`) でミラーする。0・負・非数・上限
+/// 超過は「未登録」(null) として正規化する。
+class AssetSalaryAmountStore {
+  static const String prefsKey = 'asset_salary_amount_v1';
+
+  /// 誤入力ガードの上限 (1 億円)。これを超える値は上限へ丸める。
+  static const double maxSalaryAmount = 100000000;
+
+  const AssetSalaryAmountStore();
+
+  /// 0 以下・非数・null は未登録 (null)。上限超過は [maxSalaryAmount] へ丸める。
+  static double? normalize(double? amount) {
+    if (amount == null || !amount.isFinite || amount <= 0) {
+      return null;
+    }
+    return amount > maxSalaryAmount ? maxSalaryAmount : amount;
+  }
+
+  Future<double?> load({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    return normalize(store.getDouble(prefsKey));
+  }
+
+  Future<void> save(double? amount, {SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final normalized = normalize(amount);
+    if (normalized == null) {
+      await store.remove(prefsKey);
+    } else {
+      await store.setDouble(prefsKey, normalized);
+    }
+  }
+
+  /// `asset_pref_mirror.value` (jsonb) 用に `{amount: N}` へ変換する。
+  static Map<String, dynamic> encodeMirrorValue(double amount) {
+    return <String, dynamic>{'amount': amount};
+  }
+
+  /// `asset_pref_mirror.value` (jsonb) から想定給料額を復元する。
+  /// 不正値・未登録は null。
+  static double? decodeMirrorValue(dynamic value) {
+    if (value is Map && value['amount'] is num) {
+      return normalize((value['amount'] as num).toDouble());
+    }
+    return null;
+  }
+}

--- a/test/services/asset_salary_amount_store_test.dart
+++ b/test/services/asset_salary_amount_store_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_salary_amount_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const store = AssetSalaryAmountStore();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  test('load returns null when unset', () async {
+    final prefs = await SharedPreferences.getInstance();
+    expect(await store.load(prefs: prefs), isNull);
+  });
+
+  test('save then load round-trips a valid amount', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.save(280000, prefs: prefs);
+    expect(await store.load(prefs: prefs), 280000);
+  });
+
+  test('save with null or non-positive clears to unset (null)', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.save(280000, prefs: prefs);
+    expect(await store.load(prefs: prefs), 280000);
+    await store.save(0, prefs: prefs);
+    expect(await store.load(prefs: prefs), isNull);
+    await store.save(150000, prefs: prefs);
+    await store.save(null, prefs: prefs);
+    expect(await store.load(prefs: prefs), isNull);
+  });
+
+  test('normalize rejects 0/negative/NaN and caps the max', () {
+    expect(AssetSalaryAmountStore.normalize(null), isNull);
+    expect(AssetSalaryAmountStore.normalize(0), isNull);
+    expect(AssetSalaryAmountStore.normalize(-1), isNull);
+    expect(AssetSalaryAmountStore.normalize(double.nan), isNull);
+    expect(AssetSalaryAmountStore.normalize(280000), 280000);
+    const overMax = AssetSalaryAmountStore.maxSalaryAmount + 1;
+    expect(
+      AssetSalaryAmountStore.normalize(overMax),
+      AssetSalaryAmountStore.maxSalaryAmount,
+    );
+  });
+
+  test('encodeMirrorValue wraps as {amount: N}', () {
+    expect(AssetSalaryAmountStore.encodeMirrorValue(280000), <String, dynamic>{
+      'amount': 280000,
+    });
+  });
+
+  test('decodeMirrorValue parses, normalizes, and falls back to null', () {
+    expect(
+      AssetSalaryAmountStore.decodeMirrorValue(<String, dynamic>{
+        'amount': 280000,
+      }),
+      280000,
+    );
+    expect(
+      AssetSalaryAmountStore.decodeMirrorValue(<String, dynamic>{'amount': 0}),
+      isNull,
+    );
+    expect(AssetSalaryAmountStore.decodeMirrorValue('nope'), isNull);
+    expect(
+      AssetSalaryAmountStore.decodeMirrorValue(<String, dynamic>{}),
+      isNull,
+    );
+  });
+}


### PR DESCRIPTION
## 概要

給料振込の自動検知（#3565）で、**想定給料額の登録導線**を新設する。未登録時は汎用しきい値（`heuristicFloor` 既定 10 万円）に頼るしかなく、高収入では誤検知・低収入では取りこぼしが起きやすい。給料額を登録すると入金額一致での**精密検知**へ切り替わる。

## 背景

`AssetSalaryDepositDetector` は登録給料額があれば「入金額 ±許容」または「残高増 ≥ 給料額×(1-許容)」で精密に判定する。無いと `heuristicFloor`（10 万円）の単発入金/残高増でしか判定できず、しきい値を実データへ当てても万人に最適化できない。数値調整より「給料額を登録 → 精密経路」へ誘導するのが堅牢、という方針（ユーザー承認済み）。

## 変更

- `AssetSalaryAmountStore` を新設（`AssetSalaryDayStore` と同型 / ローカル一次 + `asset_pref_mirror` pref_key=`salary_amount` で端末間同期 / 0・負・非数・上限超過は未登録(null)へ正規化）。
- ページ配線（給料日と同型）: `_salaryAmount` フィールド / `_loadSalaryAmount` / `_restoreSalaryAmountFromMirror` / `_mirrorSalaryAmount` / `_setSalaryAmount` / `_showSalaryAmountDialog`。
- `_registeredSalaryAmount()` を**明示登録の想定給料額を最優先**へ（無ければ従来どおり収入予定/繰り返し入金ルールの最大額で推定）。
- 導線2箇所:
  - 収入予定セクションのヘッダに「想定給料額（¥金額/未登録）」設定ボタンを給料日ボタンの隣に追加。
  - 給料入金促しカードで、登録給料額が無いときだけ「想定給料額を登録すると…」のヒント + 「想定給料額を登録」ボタンを表示。
- `AssetSalaryAmountStore` の純粋単体テストを追加。

## 振る舞い

- 想定給料額を登録すると `expectedSalaryAmount` が確定し、入金額一致（high / flowAmountMatch）または残高ジャンプ（high / balanceJump）で検知 → ヒューリスティック非依存。
- 未登録時は従来動作を完全保持（heuristicFloor 経路 + 残高増推定）。

## テスト

- `flutter test test/services/asset_salary_amount_store_test.dart` 緑。
- `dart analyze`（変更ファイル）issue 0。
- 巨大ページの結合スモークはローカル環境で Dart VM が JIT クラッシュするため CI（Linux）に委譲。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 新規ストアの純粋単体テストで網羅。UI 結合スモークは巨大ページが本環境で JIT クラッシュするため CI(Linux) に委譲
