### PR TITLE
docs(security): weekly dependency audit 2026-06-22

### DIFF
--- a/docs/security-audit/2026-06-22.md
+++ b/docs/security-audit/2026-06-22.md
@@ -1,0 +1,136 @@
+# 依存パッケージ脆弱性チェック 2026-06-22
+
+> 自動週次タスク `scheduled-tasks/dependency-audit` 実行ログ。前回: 2026-05-25 (~4週前)。
+
+## サマリ
+
+| 項目 | 結果 |
+|---|---|
+| Flutter advisory-affected (`isCurrentAffectedByAdvisory`) | **0** ✅ |
+| Flutter discontinued (`isDiscontinued`) | **0** ✅ |
+| Direct 要 upgrade (制約内 patch/minor = lockfile のみ) | 2 件 (`path_provider`, `sentry_flutter`) |
+| Direct/Dev 要 upgrade (pubspec.yaml 制約 bump 要) | 13 件 (うち major 4: flutter_lints / flutter_local_notifications / mime / package_info_plus / share_plus) |
+| Deno EF `std` 統一バージョン | `@0.224.0` 46 import (前回 41 / 100% 統一・stale 0) ✅ |
+| Deno EF `npm:@supabase/supabase-js@2` | 26 import (メジャー固定) ✅ |
+| Deno EF `jose` | `v5.9.6` (1 箇所) — **v6.1.3 が現行 major** ⚠️ 監視 |
+
+**今回の自動アップグレード**: **適用なし** (report-only)。理由は下記「自動化を見送った理由」。
+
+---
+
+## Flutter/Dart パッケージ
+
+`flutter pub outdated --json` で取得 (advisory / discontinued / direct / dev を一括判定)。
+
+### A. 制約内 upgradable (= `flutter pub upgrade <pkg>` で lockfile のみ更新)
+
+| パッケージ | 種別 | 現在 | upgradable | latest | 種類 |
+|---|---|---|---|---|---|
+| `path_provider` | direct | 2.1.5 | **2.1.6** | 2.1.6 | patch |
+| `sentry_flutter` | direct | 9.21.0 | **9.22.0** | 9.22.0 | minor |
+
+### B. pubspec.yaml 制約 bump が必要 (constraint が現行を pin)
+
+| パッケージ | 種別 | 現在 | resolvable | latest | 種類 | 備考 |
+|---|---|---|---|---|---|---|
+| `flutter_lints` | dev | 3.0.2 | 6.0.0 | 6.0.0 | **major** | lint ルール変更あり。要 `flutter analyze` 差分確認 |
+| `flutter_local_notifications` | direct | 21.0.0 | 22.0.1 | 22.0.1 | **major** | 通知基盤。Android/iOS 設定差分確認要 |
+| `mime` | direct | 1.0.6 | 2.0.0 | 2.0.0 | **major** | MIME 判定。API 変更要確認 |
+| `package_info_plus` | direct | 8.3.1 | 10.1.0 | 10.1.0 | **major (+2)** | アプリ情報。2 メジャー跳び |
+| `share_plus` | direct | 12.0.2 | 13.1.0 | 13.1.0 | **major** | 前回 audit からの繰越 (4/20 既出) |
+| `latlong2` | direct | 0.9.1 | 0.10.1 | 0.10.1 | minor (pre-1.0=breaking) | flutter_map 連動。地図機能 |
+| `supabase_flutter` | direct | 2.14.2 | 2.15.0 | 2.15.0 | minor | **`supabase` dev exact-pin (2.12.2) が transitive を gate** → 同時 bump 要 |
+| `supabase` (dev) | dev | 2.12.2 | 2.13.0 | 2.13.0 | minor | pubspec.yaml で `2.12.2` 完全固定 (line 74)。supabase_flutter 連動 |
+| `pdf` | direct | 3.12.0 | 3.12.0 | 3.13.0 | minor | 現依存グラフでは resolvable 外 (latest のみ) |
+| `printing` | direct | 5.14.3 | 5.14.3 | 5.15.0 | minor | 同上。選挙 KPI レポート PDF 出力 |
+| `mockito` | dev | 5.6.4 | 5.6.4 | 5.7.0 | minor | 現 SDK グラフで resolvable 外 |
+| `flutter_native_splash` | dev | 2.4.7 | 2.4.7 | 2.4.8 | patch | 現グラフで resolvable 外 (latest のみ) |
+| `test` | dev | 1.30.0 | 1.30.0 | 1.31.1 | minor | **Flutter SDK が pin** (前回 audit でも同様。SDK 同梱版が上限) |
+
+### Advisory / Discontinued
+- `isCurrentAffectedByAdvisory: true` → **0 件** ✅
+- `isDiscontinued: true` → **0 件** ✅
+
+### セキュリティ関連パッケージの現況
+| パッケージ | 制約 | 解決版 | 状態 |
+|---|---|---|---|
+| `supabase_flutter` | `^2.0.0` | 2.14.2 | minor 遅れ (latest 2.15.0)・advisory 無 ✅ |
+| `flutter_secure_storage` | `^10.3.1` | 10.3.1 | 最新 ✅ (前回 audit 宿題 10.2.0→10.3.0 は解消済) |
+| `crypto` | `^3.0.7` | 最新追随 | ✅ |
+| `http` | `any` | 最新追随 | ✅ |
+| `sentry_flutter` | `^9.21.0` | 9.21.0 | minor 遅れ (9.22.0)・advisory 無 ✅ |
+
+---
+
+## Supabase Edge Functions (Deno)
+
+### `deno.land/std` 統一状況
+
+| バージョン | import 数 | 状態 |
+|---|---|---|
+| `@0.224.0` | 46 | ✅ 100% 統一 (前回 41 / 今回も stale 版 0) |
+| `@0.168.0` / `@0.177.0` 等の旧版 | **0** | ✅ 残存なし |
+
+`.ts` ソースからの旧 `std` 直接 import は **0 件** (前回 audit でクローズ済の状態を維持)。
+
+### npm: / x: 依存
+
+| 依存 | 箇所 | 状態 |
+|---|---|---|
+| `npm:@supabase/supabase-js@2` | 26 import | ✅ メジャー固定 (`@2` で自動最新) |
+| `https://deno.land/x/jose@v5.9.6` | `_shared/mcp_auth_guard.ts` 1 箇所 | ⚠️ **v6.1.3 が現行 major** — 下記参照 |
+
+### `jose` v5.9.6 詳細評価 (前回 audit 繰越タスクの実施)
+
+- 用途: WorkOS JWKS による JWT 検証本体 (= MCP 認可基盤 / `MCP_AUTH_SECURITY_PRINCIPLES.md` 原則 #2/#5/#7/#8 の中核)。
+- **CVE 調査結果**: 2025-2026 の JWT 系 CVE (CVE-2025-53864 / CVE-2026-29000 等) は **Nimbus JOSE+JWT (Java)** および **pac4j-jwt (Java)** に対するもので、当方が使う **panva/jose (JS/Deno)** には該当しない。**v5.9.6 に対する既知の有効 advisory は無し** ✅。
+- **バージョン状況**: 現行 major は **v6.x** (deno.land/x/jose@v6.1.3 / npm 6.2.3)。v5→v6 は Node 18 サポート廃止等が主で、セキュリティ駆動の必須 upgrade ではない。
+- **判断**: **据置 (監視継続)**。v6 への major upgrade は MCP 認可の中核ゆえ、JWKS 検証・cache 挙動・API 差分を確認できる **interactive / Win Claude セッション**で実施 (autonomous の本タスクでは扱わない)。
+
+---
+
+## 自動化を見送った理由 (report-only の根拠)
+
+本タスクは「patch は自動更新してコミット」を原則とするが、今回は **全件見送り**。根拠:
+
+1. **クリーンな patch 更新が単独で取り出せない**: `path_provider` 2.1.5→2.1.6 (唯一の真 patch) を `flutter pub upgrade path_provider sentry_flutter` で隔離 worktree (origin/main 起点) に適用したところ、origin/main の lockfile が stale だったため `test` 1.26.3→1.30.0 等 **8 依存の transitive churn** + linux/macOS/windows の `generated_plugin_registrant` 再生成が巻き込まれた。最小 patch diff にならない。
+2. **本環境で検証不能**: 当 Win 環境は全ツリー `flutter analyze` が OOM・巨大 page smoke が JIT クラッシュする実績 (memory 既知)。lockfile + native registrant churn を `analyze`/`test` で verify できないまま push するのはリスク。検証は CI に委譲する運用方針だが、**unattended 実行で未検証の依存変更を push** するのは過剰。
+3. **タスク方針の fallback**: 「迷ったらレポート出力が正しい出力」。→ report-only を採用 (前回 2026-05-25 audit も同様に upgrade を全件委譲)。
+
+---
+
+## アクション
+
+### ✅ 完了 (今回 audit)
+- `flutter pub outdated --json` で direct/dev/advisory/discontinued 一括判定 (advisory 0 / discontinued 0)
+- Deno EF `std` バージョン横断 grep (stale 版 0 / `@0.224.0` 統一を再確認)
+- `npm:@supabase/supabase-js@2` 全 26 箇所のメジャー固定を確認
+- **前回繰越「jose 最新版チェック」を実施** (上記詳細 / CVE 該当無し・v6 は監視継続と判断)
+
+### 📋 次回推奨 (interactive / Codex #1 = full CI verify 可能なセッションで)
+
+- [ ] **patch/minor (制約内・低リスク)**: `path_provider` 2.1.6 + `sentry_flutter` 9.22.0 を `flutter pub upgrade <pkg>` で lockfile 更新 → `flutter analyze` 0 + CI gate 通過確認
+- [ ] **dev pin の minor**: `test` は Flutter SDK 同梱版が上限のため pubspec 触らず据置 (前回同様)
+- [ ] **major (要 breaking 確認・PR 単位)**: `flutter_lints` 6.x / `package_info_plus` 10.x / `flutter_local_notifications` 22.x / `mime` 2.x / `share_plus` 13.x — 各 1 PR で API 差分確認
+- [ ] **supabase 連動**: `supabase_flutter` 2.15.0 ＋ dev `supabase` 2.13.0 を **同時** bump (exact-pin gate ゆえ片方だけでは resolvable 外)
+- [ ] **`jose` v6**: MCP 認可影響度評価込みで interactive 実施 (緊急性は無 = CVE 該当無し)
+
+### 🟢 残課題 (前回 audit からの繰越状況)
+
+| 前回 (5/25) 宿題 | 状況 |
+|---|---|
+| `flutter_secure_storage` 10.2.0→10.3.0 patch (Codex) | ✅ **解消** (pubspec `^10.3.1` / outdated 一覧から消滅) |
+| `test` 1.26.3→1.31.1 minor (Codex / SDK 互換確認) | ⏳ SDK pin により上限 1.30.0 で据置 (今回 lock は既に 1.30.0) |
+| `jose@v5.9.6` 最新版チェック (Win Claude) | ✅ **実施** (本 audit / CVE 該当無し・v6 監視) |
+| Deno std `@0.224.0` 統一 | ✅ 維持 (stale 0) |
+
+---
+
+## 環境メタ
+
+- Flutter SDK: `flutter pub outdated` 正常完了 (JSON 32KB)
+- Branch: `auto/dependency-audit-20260622` (origin/main `b735a09f0` から fresh worktree / WORKDIR-ISOLATION 準拠)
+- Caller: scheduled `dependency-audit` (週次 / autonomous / user 不在)
+- 本 report のみコミット (依存ファイル変更なし)
+
+> 前回 audit: [`2026-05-25.md`](./2026-05-25.md) / [`2026-04-20.md`](./2026-04-20.md) / [`2026-03-28.md`](./2026-03-28.md)


### PR DESCRIPTION
## Weekly Dependency Audit 2026-06-22 (automated `dependency-audit`)

docs-only. No dependency file changes (report-only).

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

### Main Results

- Flutter advisory-affected: 0 / discontinued: 0.
- Constraint-compatible upgradable packages: 2 (`path_provider` 2.1.6 patch / `sentry_flutter` 9.22.0 minor).
- Constraint bump required: 13 (major 4: `flutter_lints` / `flutter_local_notifications` / `mime` / `package_info_plus` / `share_plus`).
- Deno EF: `std@0.224.0` 100% unified (stale 0) / `npm:@supabase/supabase-js@2` pinned at 26 locations.
- `jose@v5.9.6`: 2025/26 JWT CVEs are for Nimbus/pac4j (Java), not panva/jose (JS); no known advisory. v6.1.3 is the current major, but auth-critical code remains under monitoring.

### Why Report-Only

Applying the true patch (`path_provider`) in an isolated worktree pulled in stale-lock transitive churn across 8 packages plus native registrant regeneration, and this Windows environment could not prove `flutter analyze`/CI. Upgrade work is delegated to an interactive/Codex session with CI verification, matching the 2026-05-25 audit policy.

Details: [`docs/security-audit/2026-06-22.md`](docs/security-audit/2026-06-22.md)

Generated with Claude Code.
