### PR TITLE
feat(asset): カード請求負債の確認手順をカード利用明細ベースへ

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -24269,12 +24269,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final cashflow = _cashflowRowForDebt(workbook, row.id);
     final paymentDate = cashflow?.paymentDate;
     final paymentAmount = cashflow?.paymentAmount;
+    // カード請求にまとめて支払う負債は、実際の引き落としがカード締め日にまとまるため
+    // 銀行口座でなく請求元カードの利用明細で計上を確認する手順へ切り替える。
+    final billingCardName = row.includedInBillingAccount
+        ? (row.billingAccountName ?? row.paymentMethodLabel)
+        : null;
     final baseGuide = _paymentCheckGuideService.buildBaseGuide(
       debtName: row.name,
       paymentSourceAccountName: row.paymentSourceAccountName,
       paymentDate: paymentDate,
       paymentDay: row.paymentDay,
       paymentAmount: paymentAmount,
+      billingCardName: billingCardName,
     );
     final aiPrompt = _paymentCheckGuideService.buildAiPrompt(
       debtName: row.name,
@@ -24282,6 +24288,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       paymentDate: paymentDate,
       paymentDay: row.paymentDay,
       paymentAmount: paymentAmount,
+      billingCardName: billingCardName,
     );
     await showDialog<void>(
       context: context,

--- a/lib/services/asset_payment_check_guide_service.dart
+++ b/lib/services/asset_payment_check_guide_service.dart
@@ -12,13 +12,29 @@ class AssetPaymentCheckGuideService {
   const AssetPaymentCheckGuideService();
 
   /// 決定論的な確認手順。AI が使えなくても必ず返す。
+  ///
+  /// [billingCardName] が指定されたとき(= その負債が「カード請求にまとめて支払い」)
+  /// は、銀行口座の入出金明細ではなく **そのカードの利用明細** で計上を確認する手順を
+  /// 返す。実際の口座引き落としはカードの締め日にまとめて行われ、個別額では引き落と
+  /// されないため、銀行明細での個別照合は誤りになる。
   String buildBaseGuide({
     required String debtName,
     String? paymentSourceAccountName,
     DateTime? paymentDate,
     int? paymentDay,
     double? paymentAmount,
+    String? billingCardName,
   }) {
+    final card = (billingCardName ?? '').trim();
+    if (card.isNotEmpty) {
+      return _buildCardBilledBaseGuide(
+        debtName: debtName,
+        cardName: card,
+        paymentDate: paymentDate,
+        paymentDay: paymentDay,
+        paymentAmount: paymentAmount,
+      );
+    }
     final account = (paymentSourceAccountName ?? '').trim();
     final accountLabel = account.isEmpty ? '引き落とし元の口座' : account;
     final dateLabel = _dateLabel(paymentDate, paymentDay);
@@ -43,23 +59,76 @@ class AssetPaymentCheckGuideService {
     return buffer.toString();
   }
 
+  /// カード請求にまとめて支払う負債の確認手順(= [billingCardName] の利用明細で計上確認)。
+  String _buildCardBilledBaseGuide({
+    required String debtName,
+    required String cardName,
+    DateTime? paymentDate,
+    int? paymentDay,
+    double? paymentAmount,
+  }) {
+    final dateLabel = _dateLabel(paymentDate, paymentDay);
+    final amountLabel = _amountLabel(paymentAmount);
+    final buffer = StringBuffer()
+      ..writeln('「$debtName」は $cardName の請求にまとめて支払われます。確認する手順:')
+      ..writeln('1. $cardName のアプリまたは Web 明細にログインします。')
+      ..writeln('2. 「ご利用明細（利用照会）」を開きます。');
+    if (amountLabel != null) {
+      buffer.writeln(
+        '3. $dateLabel 頃に $amountLabel の $debtName の利用が計上されているか確認します。',
+      );
+    } else {
+      buffer.writeln('3. $dateLabel 頃に $debtName の利用が計上されているか確認します。');
+    }
+    buffer
+      ..writeln('4. 計上を確認できたら「支払済み」にチェックを入れます。')
+      ..write(
+        '5. 実際の口座引き落としは $cardName の引き落とし日にまとめて行われます'
+        '（この負債だけが個別に引き落とされるわけではありません）。'
+        '引き落としが不安なときは $cardName の引き落とし元口座の残高を確認してください。',
+      );
+    return buffer.toString();
+  }
+
   /// ネット検索対応プロバイダへ渡すプロンプト。その金融機関に即した具体手順を求める。
+  ///
+  /// [billingCardName] が指定されたとき(= カード請求にまとめて支払い)は、銀行の
+  /// 入出金明細ではなく **そのカードの利用明細** で計上を確認する手順を求める。
   String buildAiPrompt({
     required String debtName,
     String? paymentSourceAccountName,
     DateTime? paymentDate,
     int? paymentDay,
     double? paymentAmount,
+    String? billingCardName,
   }) {
+    final card = (billingCardName ?? '').trim();
+    final dateLabel = _dateLabel(paymentDate, paymentDay);
+    final amountLabel = _amountLabel(paymentAmount) ?? '利用額';
+    if (card.isNotEmpty) {
+      return [
+        'あなたは家計管理アシスタントです。日本の利用者が、ある支払いがカードの利用',
+        '明細に計上されたかを自分で確認する手順を、そのカード発行会社に即して案内して',
+        'ください。',
+        '対象: 「$debtName」は $card の請求にまとめて支払われます。',
+        '確認したいこと: $dateLabel 頃に $amountLabel の $debtName の利用が計上されているか。',
+        '出力要件:',
+        '- $card の公式アプリ名／Web 明細名と、ログインから利用明細にたどり着くまでの',
+        '  操作手順を、番号付きで簡潔に。',
+        '- 実際の口座引き落としはカードの引き落とし日にまとめて行われ、この負債だけが',
+        '  個別に引き落とされるわけではない点を補足する。',
+        '- 不確かな点は断定せず、公式サイト/アプリで確認するよう促す。',
+        '- 日本語。手順以外の前置きは最小限に。',
+      ].join('\n');
+    }
     final account = (paymentSourceAccountName ?? '').trim();
     final accountClause = account.isEmpty ? '引き落とし元の金融機関口座' : account;
-    final dateLabel = _dateLabel(paymentDate, paymentDay);
-    final amountLabel = _amountLabel(paymentAmount) ?? '引き落とし額';
+    final fallbackAmountLabel = _amountLabel(paymentAmount) ?? '引き落とし額';
     return [
       'あなたは家計管理アシスタントです。日本の利用者が、ある引き落としが実際に',
       '行われたかを自分で確認する手順を、その金融機関に即して具体的に案内してください。',
       '対象: 「$debtName」の引き落とし。引き落とし元: $accountClause。',
-      '確認したいこと: $dateLabel 前後に $amountLabel の引き落としがあるか。',
+      '確認したいこと: $dateLabel 前後に $fallbackAmountLabel の引き落としがあるか。',
       '出力要件:',
       '- その金融機関の公式アプリ名／ネットバンキング名と、ログインから入出金明細に',
       '  たどり着くまでの操作手順を、番号付きで簡潔に。',

--- a/test/services/asset_payment_check_guide_service_test.dart
+++ b/test/services/asset_payment_check_guide_service_test.dart
@@ -80,4 +80,62 @@ void main() {
       expect(prompt, contains('毎月27日'));
     });
   });
+
+  group('card-billed (billingCardName) guidance', () {
+    test('buildBaseGuide points at the card usage statement, not a bank', () {
+      final guide = service.buildBaseGuide(
+        debtName: 'Netflix',
+        paymentSourceAccountName: '三井住友銀行',
+        paymentDate: DateTime(2026, 6, 8),
+        paymentAmount: 1980,
+        billingCardName: 'ファミペイ',
+      );
+      // カード名と利用明細・締め日にまとめて引き落とし、を案内する。
+      expect(guide, contains('ファミペイ'));
+      expect(guide, contains('ご利用明細'));
+      expect(guide, contains('まとめて'));
+      expect(guide, contains('1,980円'));
+      // 銀行口座の入出金明細での個別照合は出さない(誤誘導の回避)。
+      expect(guide, isNot(contains('入出金明細')));
+    });
+
+    test('buildBaseGuide drops the amount line when amount unknown', () {
+      final guide = service.buildBaseGuide(
+        debtName: 'Spotify',
+        paymentDay: 10,
+        paymentAmount: 0,
+        billingCardName: 'au PAY カード',
+      );
+      expect(guide, contains('au PAY カード'));
+      expect(guide, contains('毎月10日'));
+      expect(guide, isNot(contains('0円')));
+    });
+
+    test('buildAiPrompt asks for card statement steps', () {
+      final prompt = service.buildAiPrompt(
+        debtName: 'Netflix',
+        paymentSourceAccountName: '三井住友銀行',
+        paymentDate: DateTime(2026, 6, 8),
+        paymentAmount: 1980,
+        billingCardName: 'ファミペイ',
+      );
+      expect(prompt, contains('ファミペイ'));
+      expect(prompt, contains('利用明細'));
+      expect(prompt, contains('まとめて'));
+      expect(prompt, contains('日本語'));
+      expect(prompt, isNot(contains('入出金明細')));
+    });
+
+    test('blank billingCardName falls back to the bank-account guide', () {
+      final guide = service.buildBaseGuide(
+        debtName: 'カードローン',
+        paymentSourceAccountName: 'みずほ銀行',
+        paymentDate: DateTime(2026, 6, 27),
+        paymentAmount: 30000,
+        billingCardName: '   ',
+      );
+      expect(guide, contains('入出金明細'));
+      expect(guide, contains('みずほ銀行'));
+    });
+  });
 }


### PR DESCRIPTION
## 概要

「手順を確認」（#3571）で、**カード請求にまとめて支払う負債**（`includedInCard`）の確認手順を、銀行口座の入出金明細ではなく **請求元カードの利用明細** を見る手順へ切り替える。

## 背景

カード請求に含む負債（例: ファミペイ / au PAY カードにまとめる固定費・サブスク）は、実際の口座引き落としが**カードの締め日にまとまった金額**で行われる。従来の手順は「(自分の支払日に) 引き落とし元口座の入出金明細で個別額を確認」だったため、銀行明細にその金額・日付では現れず**誤誘導**になっていた（前回セッションの Task C 調査で特定）。

## 変更

- `AssetPaymentCheckGuideService.buildBaseGuide` / `buildAiPrompt` に任意引数 `billingCardName` を追加。指定時（カード請求）はカード利用明細での計上確認手順へ分岐:
  - カードのアプリ/Web 明細 → ご利用明細（利用照会）→ 当該利用の計上を確認。
  - 実際の引き落としはカードの締め日にまとめて行われ、この負債だけが個別に引き落とされるわけではない旨を明示。
- ページ `_showPaymentCheckGuide`: `row.includedInBillingAccount` のとき `billingAccountName`（無ければ `paymentMethodLabel`）を `billingCardName` として渡す。直接引き落とし負債は従来手順のまま（振る舞い不変）。
- 純粋単体テストを追加（カード手順 / 金額欠落 / 空 billingCardName の銀行手順フォールバック）。

## 振る舞い

- 直接引き落とし（`paymentMethod=direct`）: 従来どおり銀行入出金明細の手順。
- カード請求（`includedInCard`）: カード利用明細の手順 + 「締め日にまとめて引き落とし」注記。

## テスト

- `flutter test test/services/asset_payment_check_guide_service_test.dart` 緑。
- `dart analyze`（変更ファイル）issue 0。
- 巨大ページの結合スモークはローカル環境で Dart VM が JIT クラッシュするため CI（Linux）に委譲。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純粋サービスの単体テストで網羅。UI 結合スモークは巨大ページが本環境で JIT クラッシュするため CI(Linux) に委譲
