### PR TITLE
fix(asset): アコムショッピング枠のAnthropic分を現金支出から除外（請求集約へ）

### DIFF
--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -1415,13 +1415,10 @@ class AssetLiabilityPlanningService {
       );
       final paid = paidAccountNames.contains(anthropicAcomShoppingPaymentId) ||
           paidAccountNames.contains(anthropicAcomShoppingPaymentName);
-      final sourceAccountId =
-          paymentSourceAccountIds[anthropicAcomShoppingPaymentId] ??
-              acomShoppingRow.paymentSourceAccountId;
-      final sourceAccountName = sourceAccountId == null
-          ? acomShoppingRow.paymentSourceAccountName
-          : accountsById[sourceAccountId]?.name ??
-              acomShoppingRow.paymentSourceAccountName;
+      // Anthropic サブスクはアコムショッピング枠に乗る購入であり、現金で別途
+      // 返済しない (アコム最低返済で吸収される)。アコムショッピング請求に含む
+      // 扱いにして、直接の現金支出として二重計上しないようにする。
+      final acomBillingLabel = '${acomShoppingRow.name}払い';
       result.add(
         AssetLiabilityCashflowRow(
           eventType: AssetLiabilityCashflowEventType.payment,
@@ -1429,17 +1426,17 @@ class AssetLiabilityPlanningService {
           accountName: anthropicAcomShoppingPaymentName,
           paymentDay: paymentDay,
           paymentDate: paymentDate,
-          paymentSourceAccountId: sourceAccountId,
-          paymentSourceAccountName: sourceAccountName,
-          destinationAccountId: acomShoppingRow.id,
-          destinationAccountName: acomShoppingRow.name,
-          paymentMethod: AssetLiabilityPaymentMethod.direct,
-          paymentMethodLabel: acomShoppingRow.paymentMethodLabel,
+          paymentSourceAccountId: null,
+          paymentSourceAccountName: null,
+          destinationAccountId: null,
+          destinationAccountName: acomBillingLabel,
+          paymentMethod: AssetLiabilityPaymentMethod.includedInCard,
+          paymentMethodLabel: acomBillingLabel,
           paymentMethodSettingSource:
               AssetLiabilityPaymentMethodSettingSource.builtInDefault,
-          billingAccountId: null,
-          billingAccountName: null,
-          includedInBillingAccount: false,
+          billingAccountId: acomShoppingRow.id,
+          billingAccountName: acomShoppingRow.name,
+          includedInBillingAccount: true,
           paymentAmount: anthropicAcomShoppingPaymentAmount,
           actualPaymentAmount: null,
           paymentDifferenceAmount: null,
@@ -1447,7 +1444,7 @@ class AssetLiabilityPlanningService {
           paymentAmountEstimated: false,
           paid: paid,
           received: false,
-          overdue: !paid && !paymentDate.isAfter(_dateOnly(baseDate)),
+          overdue: false,
           cashBeforePayment: 0,
           cashAfterPayment: 0,
           riskLevel: AssetLiabilityCashRiskLevel.normal,

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1054,7 +1054,7 @@ void main() {
       );
     });
 
-    test('adds Anthropic Acom shopping repayment on the 26th', () {
+    test('Anthropic Acom shopping charge is billed into acom (no cash)', () {
       const acomShoppingName =
           '\u30a2\u30b3\u30e0\u30b7\u30e7\u30c3\u30d4\u30f3\u30b0';
       final workbook = service.buildWorkbook(
@@ -1065,9 +1065,6 @@ void main() {
         baseDate: DateTime(2026, 5, 1),
         monthlyPaymentOverrides: const <String, double>{
           AssetLiabilityPlanningService.acomShoppingAccountId: 68000,
-        },
-        paymentSourceAccountIds: const <String, String>{
-          AssetLiabilityPlanningService.acomShoppingAccountId: 'custom_cash',
         },
       );
 
@@ -1086,19 +1083,25 @@ void main() {
         anthropicPayment.paymentAmount,
         AssetLiabilityPlanningService.anthropicAcomShoppingPaymentAmount,
       );
-      expect(anthropicPayment.paymentSourceAccountId, 'custom_cash');
+      // \u30a2\u30b3\u30e0\u30b7\u30e7\u30c3\u30d4\u30f3\u30b0\u8acb\u6c42\u306b\u542b\u3080\u6271\u3044 (\u73fe\u91d1\u3067\u5225\u9014\u8fd4\u6e08\u3057\u306a\u3044)\u3002
+      expect(anthropicPayment.includedInBillingAccount, isTrue);
+      expect(anthropicPayment.isDirectCashflowTarget, isFalse);
       expect(
-        anthropicPayment.destinationAccountId,
+        anthropicPayment.billingAccountId,
         AssetLiabilityPlanningService.acomShoppingAccountId,
+      );
+      expect(
+        anthropicPayment.paymentMethodLabel,
+        '$acomShoppingName\u6255\u3044',
       );
       expect(workbook.cashflowRows.map((row) => row.paymentDay).toList(), <int>[
         8,
         26,
       ]);
-      expect(workbook.monthlyScheduledPaymentTotal, 108000);
-      expect(workbook.monthlyUnpaidPaymentTotal, 108000);
-      expect(workbook.cashAfterScheduledPayments, -8000);
-      expect(anthropicPayment.cashAfterPayment, -8000);
+      // \u73fe\u91d1\u652f\u51fa\u306f\u30a2\u30b3\u30e0\u6700\u4f4e\u8fd4\u6e08 (68000) \u306e\u307f\u3002Anthropic \u306e 40000 \u306f\u4e8c\u91cd\u8a08\u4e0a\u3057\u306a\u3044\u3002
+      expect(workbook.monthlyScheduledPaymentTotal, 68000);
+      expect(workbook.monthlyUnpaidPaymentTotal, 68000);
+      expect(workbook.cashAfterScheduledPayments, 32000);
     });
 
     test('reflects unreceived income plans in chronological cashflow', () {

--- a/test/services/disposable_balance_asset_liability_adapter_test.dart
+++ b/test/services/disposable_balance_asset_liability_adapter_test.dart
@@ -76,7 +76,7 @@ void main() {
       expect(payPayDebt.interestPayment, payPayRow.monthlyInterestEstimate);
     });
 
-    test('routes supplemental Anthropic repayment into debts', () {
+    test('Anthropic Acom shopping charge is not a separate cash debt', () {
       const acomShoppingName =
           '\u30a2\u30b3\u30e0\u30b7\u30e7\u30c3\u30d4\u30f3\u30b0';
       final asOfDate = DateTime(2026, 5, 26);
@@ -88,9 +88,6 @@ void main() {
         baseDate: asOfDate,
         monthlyPaymentOverrides: const <String, double>{
           AssetLiabilityPlanningService.acomShoppingAccountId: 68000,
-        },
-        paymentSourceAccountIds: const <String, String>{
-          AssetLiabilityPlanningService.acomShoppingAccountId: 'custom_cash',
         },
       );
       final nextPayday = disposableBalance.nextPaydayFor(
@@ -106,22 +103,16 @@ void main() {
         nextPayday: nextPayday,
       );
 
-      final anthropicDebt = result.debts.singleWhere(
-        (debt) =>
-            debt.name ==
+      // \u30a2\u30b3\u30e0\u30b7\u30e7\u30c3\u30d4\u30f3\u30b0\u8acb\u6c42\u306b\u542b\u3080\u6271\u3044\u306b\u306a\u3063\u305f\u305f\u3081\u3001\u73fe\u91d1\u3067\u5225\u9014\u8fd4\u6e08\u3059\u308b
+      // \u30c7\u30d6\u30c8\u3068\u3057\u3066\u306f\u73fe\u308c\u306a\u3044 (\u30a2\u30b3\u30e0\u6700\u4f4e\u8fd4\u6e08\u3067\u5438\u53ce\u3055\u308c\u308b)\u3002
+      expect(
+        result.debts.map((debt) => debt.name),
+        isNot(
+          contains(
             AssetLiabilityPlanningService.anthropicAcomShoppingPaymentName,
+          ),
+        ),
       );
-      expect(
-        anthropicDebt.monthlyPayment,
-        AssetLiabilityPlanningService.anthropicAcomShoppingPaymentAmount,
-      );
-      expect(anthropicDebt.dayOfMonth, 26);
-      expect(anthropicDebt.principal, 0);
-      expect(
-        anthropicDebt.principalPayment,
-        AssetLiabilityPlanningService.anthropicAcomShoppingPaymentAmount,
-      );
-      expect(anthropicDebt.interestPayment, 0);
     });
   });
 }


### PR DESCRIPTION
## 概要

資産管理闘争ページの「Anthropicサブスク（アコムショッピング返済）」¥40,000 が、**アコム最低返済とは別枠の現金支出として二重計上**されていた問題を修正。

## 原因

この行は内蔵の合成行で、`includedInBillingAccount=false`(直接支払い)として作られていたため、現金支出（使用可能額・未払い合計）に ¥40,000 が加算され、さらに「期限超過」アラートの対象にもなっていた。実態はアコムショッピング枠に乗る購入で、現金で別途返済はしない（アコム最低返済で吸収される）。

## 変更点

合成行を **「アコムショッピング請求に含む」扱い**（`includedInBillingAccount=true` / `billingAccountId=acom_shopping`）に変更。

- 資金繰り表で 区分=カード請求 ／ 支払原資口座欄=「アコムショッピング払い」表示（MICROSOFT XBOX GAME と同じ扱い）
- `isDirectCashflowTarget=false` となり、使用可能額・未払い合計・期限超過判定から除外（現金支出はアコム最低返済のみ）
- disposable balance アダプタでも現金返済デブトには現れない

請求集約モデル自体は不変。アコム残高・最低返済が従来どおり全体を管理する。

## テスト

- `asset_liability_planning_service_test`: 合成行が請求集約扱い（`includedInBillingAccount=true`・現金合計に非加算）になることを検証（計60件緑）
- `disposable_balance_asset_liability_adapter_test`: 現金返済デブトに現れないことを検証
- 既存 `asset_management_page_smoke_test`（49件）緑で UI 回帰なし
- `dart analyze` クリーン / `dart format --set-exit-if-changed` 差分なし

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 資金繰り計算はサービス層のユニットテスト(planning service 60件・adapter)で担保。Anthropic分を請求集約扱いにし現金二重計上が解消されることをplanning/adapterテストで検証。UI表示は既存の請求集約描画を流用。
