### PR TITLE
feat(asset): 支払原資口座の未設定ドロップダウンにカード/与信枠を追加

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -21879,7 +21879,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     AssetLiabilityDebtRow row,
     AssetLiabilityWorkbook workbook,
   ) {
-    final options = _paymentSourceAccountOptions(workbook);
+    // 支払原資はサブスク同様、銀行/現金に加えカード/与信枠 (auPayカード/ファミペイ/
+    // アコムショッピング枠) やキャリア決済 (au) も候補に含める。auかんたん決済→auPay
+    // リボのように、原資が銀行口座でなくカードのリボ枠になるケースに対応する。
+    // (今月/既定の候補チップは資金ショート判定用に銀行のみのまま据え置き。)
+    final options = recurringFixedCostSourceOptions(
+      workbook.accounts,
+      includeCards: true,
+      includeCarrierBilling: true,
+    );
     if (options.isEmpty) {
       return const Text(
         '候補口座なし',


### PR DESCRIPTION
## 背景
資産管理「支払原資口座の未設定」セクションの振替元ドロップダウンが**銀行/現金しか出さない**ため、
**auかんたん決済 → auPay リボ枠** のように原資が銀行口座でなく**カードの与信枠**になるケースを設定できなかった。

実例(ユーザー報告): Pontaパス ¥548 → au通信料金合算 → **auPay リボ枠に積み上がる** → auPay リボ(月¥10,000 + 上限¥500,000超過分)を じぶん銀行 から引き落とし。
この場合の Pontaパス の正しい振替元は **auPayカード(リボ枠)** であり、じぶん銀行を直接指定すると auPay のリボ支払いと**二重計上**になる。

## 変更
`_buildPaymentSourceDebtDropdown` の選択肢生成を、サブスク編集・「別口座で支払った」シート(#3568)と同じ
`recurringFixedCostSourceOptions(includeCards: true, includeCarrierBilling: true)` に統一。
→ auPayカード / ファミペイ / アコムショッピング枠 / au キャリア決済 も支払原資の候補に出る。

- 「今月/既定」の候補チップ(資金ショート判定=銀行残高の安全性アドバイス)は**銀行のみのまま据え置き**(与信枠は残高マイナス前提のため資金ショート判定に不適)。
- `lib/pages/asset_management_page.dart` 1ファイル・実質9行。`dart analyze` クリーン。
- 選択肢生成ヘルパーの includeCards/includeCarrierBilling 挙動は `test/widgets/recurring_fixed_cost_editor_dialog_test.dart` で既にテスト済(カード/与信枠/キャリアの表示・非表示)。

## 検証
- `dart analyze lib/pages/asset_management_page.dart` → No issues。
- format 版間安定(3.11 / CI 旧フォーマッタとも追加行 0 diff)。
- 本番反映後、実機で Pontaパス の振替元ドロップダウンに auPayカード が出て選択できることをユーザー確認予定。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: UI配線のみ: 支払原資ドロップダウンの選択肢生成を既存のテスト済みヘルパー recurringFixedCostSourceOptions(includeCards/includeCarrierBilling) に切替。巨大pageはE2E困難・実機Networkで検証。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: lib/pages のUI配線のみ (高リスクパス非該当)。supabase/functions・.github・SQL は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
