### PR TITLE
feat(election): 公開ノートの立憲ベンチマークを週次cronバッチ値へ同期

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -768,6 +768,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
       final memo = await _shareService.publishSnapshot(
         snapshot: snapshot,
         members: snapshot.members,
+        plan: _plan,
       );
       if (!mounted) {
         return memo;
@@ -5291,43 +5292,10 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     );
   }
 
-  /// AI整理メモの注視ポイント。AI整理メモは includeCdpBenchmarks=false の snapshot を
-  /// 使うため立憲比較行が「取得していません」になる。週次cronでバッチ取得した立憲値
-  /// (plan に適用済み) から地力差を計算し、その行だけ差し替える。
+  /// AI整理メモの注視ポイント。立憲比較行を週次cronのバッチ値で差し替える処理は
+  /// 公開ノート生成 (LocalElectionShareService) と単一正本を共有する。
   List<String> _displayAiAlerts(LocalElectionRealitySnapshot snapshot) {
-    final cdpLine = _cdpBenchmarkAlertLine();
-    if (cdpLine == null) {
-      return snapshot.aiAlerts;
-    }
-    final result = <String>[];
-    var replaced = false;
-    for (final alert in snapshot.aiAlerts) {
-      if (!replaced && alert.contains('立憲')) {
-        result.add(cdpLine);
-        replaced = true;
-      } else {
-        result.add(alert);
-      }
-    }
-    return result;
-  }
-
-  /// バッチ取得した立憲値を適用済みの plan から、立憲との地力差(上位3県)を edge
-  /// function フォールバックと同じ書式で組み立てる。データが無ければ null。
-  String? _cdpBenchmarkAlertLine() {
-    final plan = _plan;
-    if (plan == null) {
-      return null;
-    }
-    final top = plan.topCdpGapPrefectures(limit: 3);
-    if (top.isEmpty) {
-      return null;
-    }
-    final parts = top.map((item) {
-      final gap = item.cdpMemberGap;
-      return '${item.prefecture}${gap >= 0 ? '+' : ''}$gap';
-    }).join(' / ');
-    return '立憲民主党との地力差（上位）：$parts。';
+    return _shareService.displayAiAlerts(snapshot, _plan);
   }
 
   Widget _buildBulletLine(String text) {

--- a/lib/services/local_election_share_service.dart
+++ b/lib/services/local_election_share_service.dart
@@ -784,8 +784,7 @@ class LocalElectionShareService {
             (item) => <String, dynamic>{
               'prefecture': item.prefecture,
               'currentMembers': item.currentMembers,
-              'cdpLocalMembers':
-                  _resolveCdpLocalMembers(item, cdpByPrefecture),
+              'cdpLocalMembers': _resolveCdpLocalMembers(item, cdpByPrefecture),
             },
           )
           .toList(),
@@ -1115,7 +1114,8 @@ class LocalElectionShareService {
     LocalElectionPrefectureReality reality,
     Map<String, int> cdpByPrefecture,
   ) {
-    final planCdp = cdpByPrefecture[_normalizePrefectureKey(reality.prefecture)];
+    final planCdp =
+        cdpByPrefecture[_normalizePrefectureKey(reality.prefecture)];
     if (planCdp != null && planCdp > 0) {
       return planCdp;
     }

--- a/lib/services/local_election_share_service.dart
+++ b/lib/services/local_election_share_service.dart
@@ -92,6 +92,7 @@ class LocalElectionShareService {
   Future<PublicMemo?> publishSnapshot({
     required LocalElectionRealitySnapshot snapshot,
     required List<LocalElectionLegislatorProfile> members,
+    LocalElectionPlanDashboard? plan,
   }) async {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) {
@@ -101,6 +102,7 @@ class LocalElectionShareService {
     final draft = buildDraft(
       snapshot: snapshot,
       members: members,
+      plan: plan,
     );
     final publishMemo = _publishMemo;
     if (publishMemo == null) {
@@ -180,6 +182,7 @@ class LocalElectionShareService {
   LocalElectionShareDraft buildDraft({
     required LocalElectionRealitySnapshot snapshot,
     required List<LocalElectionLegislatorProfile> members,
+    LocalElectionPlanDashboard? plan,
   }) {
     final resolvedMembers = _sortedMembers(members);
     final prefectures = _prefecturesForDisplay(snapshot);
@@ -194,11 +197,13 @@ class LocalElectionShareService {
         snapshot: snapshot,
         prefectures: prefectures,
         members: resolvedMembers,
+        plan: plan,
       ),
       metadata: _buildMetadata(
         snapshot: snapshot,
         prefectures: prefectures,
         members: resolvedMembers,
+        plan: plan,
       ),
     );
   }
@@ -615,7 +620,9 @@ class LocalElectionShareService {
     required LocalElectionRealitySnapshot snapshot,
     required List<LocalElectionPrefectureReality> prefectures,
     required List<LocalElectionLegislatorProfile> members,
+    LocalElectionPlanDashboard? plan,
   }) {
+    final cdpByPrefecture = _cdpByPrefecture(plan);
     final missing =
         prefectures.where((item) => item.currentMembers == 0).toList();
     final low = prefectures
@@ -653,11 +660,12 @@ class LocalElectionShareService {
         ..writeln(snapshot.aiSummary.trim());
     }
 
-    if (snapshot.aiAlerts.isNotEmpty) {
+    final alerts = displayAiAlerts(snapshot, plan);
+    if (alerts.isNotEmpty) {
       buffer
         ..writeln()
         ..writeln('注視ポイント');
-      for (final item in snapshot.aiAlerts) {
+      for (final item in alerts) {
         buffer.writeln('- $item');
       }
     }
@@ -695,7 +703,7 @@ class LocalElectionShareService {
       buffer.writeln(
         '${_prefectureMarker(prefecture)}${prefecture.prefecture} '
         '地方議員 ${prefecture.currentMembers}人 '
-        '立憲参考 ${prefecture.cdpLocalMembers}人 '
+        '立憲参考 ${_resolveCdpLocalMembers(prefecture, cdpByPrefecture)}人 '
         '都道府県議 ${prefecture.prefecturalAssemblyMembers} / '
         '市区町村議 ${prefecture.municipalAssemblyMembers}',
       );
@@ -735,7 +743,9 @@ class LocalElectionShareService {
     required LocalElectionRealitySnapshot snapshot,
     required List<LocalElectionPrefectureReality> prefectures,
     required List<LocalElectionLegislatorProfile> members,
+    LocalElectionPlanDashboard? plan,
   }) {
+    final cdpByPrefecture = _cdpByPrefecture(plan);
     final missing =
         prefectures.where((item) => item.currentMembers == 0).toList();
     final low = prefectures
@@ -758,7 +768,7 @@ class LocalElectionShareService {
       'actualNetIncreaseRequired': snapshot.actualNetIncreaseRequired,
       'cdpLocalMembers': prefectures.fold<int>(
         0,
-        (sum, item) => sum + item.cdpLocalMembers,
+        (sum, item) => sum + _resolveCdpLocalMembers(item, cdpByPrefecture),
       ),
       'activePrefectureCount':
           prefectures.where((item) => item.currentMembers > 0).length,
@@ -774,7 +784,8 @@ class LocalElectionShareService {
             (item) => <String, dynamic>{
               'prefecture': item.prefecture,
               'currentMembers': item.currentMembers,
-              'cdpLocalMembers': item.cdpLocalMembers,
+              'cdpLocalMembers':
+                  _resolveCdpLocalMembers(item, cdpByPrefecture),
             },
           )
           .toList(),
@@ -1044,6 +1055,71 @@ class LocalElectionShareService {
       return '国民+${-gap}';
     }
     return '同数';
+  }
+
+  /// AI整理メモの注視ポイント。AI整理メモは includeCdpBenchmarks=false の snapshot を
+  /// 使うため立憲比較行が「取得していません」になる。週次cronでバッチ取得した立憲値
+  /// (plan に適用済み) から地力差を計算し、その行だけ差し替える。データが無ければ原文。
+  List<String> displayAiAlerts(
+    LocalElectionRealitySnapshot snapshot,
+    LocalElectionPlanDashboard? plan,
+  ) {
+    final cdpLine = cdpBenchmarkAlertLine(plan);
+    if (cdpLine == null) {
+      return snapshot.aiAlerts;
+    }
+    final result = <String>[];
+    var replaced = false;
+    for (final alert in snapshot.aiAlerts) {
+      if (!replaced && alert.contains('立憲')) {
+        result.add(cdpLine);
+        replaced = true;
+      } else {
+        result.add(alert);
+      }
+    }
+    return result;
+  }
+
+  /// バッチ取得した立憲値を適用済みの plan から、立憲との地力差(上位3県)を edge
+  /// function フォールバックと同じ書式で組み立てる。データが無ければ null。
+  String? cdpBenchmarkAlertLine(LocalElectionPlanDashboard? plan) {
+    if (plan == null) {
+      return null;
+    }
+    final top = plan.topCdpGapPrefectures(limit: 3);
+    if (top.isEmpty) {
+      return null;
+    }
+    final parts = top.map((item) {
+      final gap = item.cdpMemberGap;
+      return '${item.prefecture}${gap >= 0 ? '+' : ''}$gap';
+    }).join(' / ');
+    return '立憲民主党との地力差（上位）：$parts。';
+  }
+
+  /// plan の各県のバッチ取得済み立憲値を正規化キーで索引する。plan が無ければ空。
+  Map<String, int> _cdpByPrefecture(LocalElectionPlanDashboard? plan) {
+    if (plan == null) {
+      return const <String, int>{};
+    }
+    return <String, int>{
+      for (final item in plan.prefectures)
+        _normalizePrefectureKey(item.prefecture): item.cdpLocalMembers,
+    };
+  }
+
+  /// snapshot は includeCdpBenchmarks=false で立憲値が 0 のため、plan のバッチ値が
+  /// あればそれを優先する (_describePlanPrefecture のマージと同型 / 0・欠損は据置)。
+  int _resolveCdpLocalMembers(
+    LocalElectionPrefectureReality reality,
+    Map<String, int> cdpByPrefecture,
+  ) {
+    final planCdp = cdpByPrefecture[_normalizePrefectureKey(reality.prefecture)];
+    if (planCdp != null && planCdp > 0) {
+      return planCdp;
+    }
+    return reality.cdpLocalMembers;
   }
 
   DateTime _normalizeDate(DateTime dt) => DateTime(dt.year, dt.month, dt.day);

--- a/test/services/local_election_share_service_test.dart
+++ b/test/services/local_election_share_service_test.dart
@@ -235,6 +235,73 @@ void main() {
     expect(draft.metadata['missingPrefectureCount'], greaterThanOrEqualTo(1));
   });
 
+  LocalElectionRealitySnapshot buildSnapshotWithCdpFallbackAlert() {
+    return LocalElectionRealitySnapshot.fromJson(<String, dynamic>{
+      'fetchedAt': '2026-03-28T09:00:00.000Z',
+      'officialCurrentLocalMembers': 333,
+      'actualNetIncreaseRequired': 367,
+      'aiSummary': '地方議員数は333人です。',
+      'aiAlerts': <String>[
+        '議員不在県の穴埋めが必要です。',
+        '立憲民主党との地方議員数の比較は今回取得していません。',
+      ],
+      'prefectures': <Map<String, dynamic>>[
+        <String, dynamic>{
+          'prefecture': '東京都',
+          'sourceUrl': 'https://example.com/tokyo',
+          'currentMembers': 43,
+          'prefecturalAssemblyMembers': 9,
+          'municipalAssemblyMembers': 34,
+        },
+        <String, dynamic>{
+          'prefecture': '香川県',
+          'sourceUrl': 'https://example.com/kagawa',
+          'currentMembers': 23,
+          'prefecturalAssemblyMembers': 5,
+          'municipalAssemblyMembers': 18,
+        },
+      ],
+    });
+  }
+
+  test('buildDraft syncs CDP benchmark from plan batch values', () {
+    final snapshot = buildSnapshotWithCdpFallbackAlert();
+    final plan = buildPlan();
+    final draft = service.buildDraft(
+      snapshot: snapshot,
+      members: snapshot.members,
+      plan: plan,
+    );
+
+    // 注視ポイント: 立憲フォールバック行がバッチ地力差行へ差し替わる。
+    expect(
+      draft.content,
+      contains('立憲民主党との地力差（上位）：東京都+40 / 香川県-3。'),
+    );
+    expect(draft.content, isNot(contains('今回取得していません')));
+    // 非立憲の注視ポイントは残る。
+    expect(draft.content, contains('議員不在県の穴埋めが必要です。'));
+    // 全都道府県内訳: 各県の立憲参考が plan のバッチ値へ。
+    expect(draft.content, contains('立憲参考 83人'));
+    expect(draft.content, contains('立憲参考 20人'));
+    // metadata: 解決済み立憲値の合計 (83 + 20)。
+    expect(draft.metadata['cdpLocalMembers'], 103);
+  });
+
+  test('buildDraft keeps fallback alert and zero CDP when plan is absent', () {
+    final snapshot = buildSnapshotWithCdpFallbackAlert();
+    final draft = service.buildDraft(
+      snapshot: snapshot,
+      members: snapshot.members,
+    );
+
+    // plan 無し = 後方互換: 差し替えなし・立憲参考は snapshot 由来の 0。
+    expect(draft.content, contains('今回取得していません'));
+    expect(draft.content, isNot(contains('立憲民主党との地力差（上位）')));
+    expect(draft.content, contains('立憲参考 0人'));
+    expect(draft.metadata['cdpLocalMembers'], 0);
+  });
+
   test('buildXShareText includes public note link and alert counts', () {
     final snapshot = buildSnapshot();
     final shareText = service.buildXShareText(


### PR DESCRIPTION
## 概要

統一地方選700「地方議員集計」公開ノート(`LocalElectionShareService.buildDraft`)は
`includeCdpBenchmarks=false` の snapshot をそのまま書くため、立憲(CDP)値が **3 箇所すべて
未取得**(0 / 「取得していません」)のままだった。#3589 は画面側のみ修正済で公開ノートは未対応。

本PRで公開ノートの立憲値を週次cron取得(plan適用済)のバッチ値へ同期し、ノート内を整合させる:

1. **注視ポイント** — 立憲フォールバック行「…今回取得していません。」を `#3589` と同一書式の
   地力差行「立憲民主党との地力差（上位）：東京都+40 / 香川県-3。」へ差替
2. **全都道府県内訳** — 各県「立憲参考 N人」を plan のバッチ値へ(0/欠損は snapshot 値据置)
3. **metadata** — `cdpLocalMembers` 合計 / `topPrefectures[].cdpLocalMembers` も解決値へ

## 実装

- `#3589` の差替ロジック(`displayAiAlerts` / `cdpBenchmarkAlertLine`)を
  `LocalElectionShareService` へ**正本化**し、`election_victory_page` はそれをデリゲート
  (書式文字列の二重定義ドリフトを解消)。
- `buildDraft`/`publishSnapshot` に任意の `plan` を追加(null 既定 = 後方互換)。
- CDP 解決ヘルパー `_cdpByPrefecture` / `_resolveCdpLocalMembers`
  (`_describePlanPrefecture` の既存マージと同型)。
- edge function は不変(クライアント/共有サービス側のみ = #3589 と同型)。

## テスト

- `flutter test test/services/local_election_share_service_test.dart` → **12 件緑**
  - 新規: plan バッチ値同期(注視ポイント差替 / 各県立憲参考 / metadata 合計103)
  - 新規: plan 無しの後方互換(差替なし / 立憲参考0 / metadata 0)
- `dart analyze`(変更3ファイル)→ No issues

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 公開ノート生成は LocalElectionShareService の純粋関数で、共有サービス単体テスト12件(立憲バッチ同期3挙動+plan無し後方互換)が入出力契約を網羅。実機UATは別タスクで本番ハードリロード後に実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
