### PR TITLE
[CI/CD自動最適化] cancel-in-progress 修正 2 本 2026-06-24

### DIFF
--- a/.github/workflows/competitor-monitoring.yml
+++ b/.github/workflows/competitor-monitoring.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   group: competitor-monitoring
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-06-24 ci-audit: 日次モニタリング concurrent 防止
 
 permissions:
   contents: write

--- a/.github/workflows/cs-check.yml
+++ b/.github/workflows/cs-check.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: cs-check
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-06-24 ci-audit: 2h cron キュー積み防止
 
 permissions:
   contents: write

--- a/docs/ci-cd-audit/2026-06-24.md
+++ b/docs/ci-cd-audit/2026-06-24.md
@@ -1,0 +1,116 @@
+# CI/CD コスト監査 2026-06-24
+
+自動生成: ci-cd-audit スケジュールルーチン 2026-06-24
+
+---
+
+## サマリ
+
+| 項目 | 値 |
+|------|-----|
+| 総ワークフロー数 | 111 (active) / 107 yml ファイル |
+| cancel-in-progress: false 残存 | **72 本** |
+| 本実行で自動修正 | **2 本** |
+| 前回監査 (2026-06-20) 以降に外部修正済 | wbs-ai-review.yml (2026-06-23) |
+
+**TOP3 コスト源 (推定)**
+
+1. `horse-racing-update.yml` — 4h cron × ~273 sec/run × 180 run/月 ≈ **819 分/月** (前回 2h→4h 削減済)
+2. `cs-check.yml` — 2h cron × ~23 sec/run × 360 run/月 ≈ **138 分/月** + cancel 未設定による並行積み上げリスク
+3. `competitor-monitoring.yml` — 日次 × 推定 60-120 sec/run × 30 run/月 ≈ **30-60 分/月**
+
+---
+
+## ワークフロー別コスト表 (直近 30 実行サンプル)
+
+| ワークフロー名 | 頻度 | 平均秒 | 失敗率 | トリガー |
+|--------------|------|--------|--------|---------|
+| Workflow Failure Handler | event | 14s | 0% | workflow_run |
+| GitHub Issues WBS Sync | 4h/issues | 808s | 0% | schedule/issues |
+| WBS AI Review | 2h | 12s | 0% | schedule |
+| Horse Racing Auto Update | 4h | 273s | 0% | schedule |
+| Notion Mirror Sync | 毎時 | 193s | 0% | schedule |
+| Feature Review | 4h | 66s | 0% | schedule |
+| AI大学コンテンツ更新 | 4h | 59s | 0% | schedule |
+| Claude Session Hygiene | schedule | 37s | 0% | schedule |
+| Health Monitor | schedule | 26s | 0% | schedule |
+| CS Check | 2h | 23s | 0% | schedule |
+
+---
+
+## 検出した冗長フロー (A-G)
+
+### [E] HIGH: cache 未使用ワークフロー継続
+- `deploy-prod.yml` / `deploy-dev.yml` / `deploy-staging.yml` の Flutter pub キャッシュ効果の継続モニタリング推奨
+- `ci.yml` は既に `actions/cache@v5` でキャッシュ済 ✓
+
+### [B] HIGH: cancel-in-progress: false 残存 72 本
+前回 (#3533) 推奨 4 本の状況:
+- `cs-check.yml` → **false のまま ← 本実行で修正**
+- `wbs-ai-review.yml` → 2026-06-23 に true へ修正済 ✓
+- `issue-to-wbs.yml` (= GitHub Issues WBS Sync) → cancel-in-progress: true 確認済 ✓
+- `memory-search-sync.yml` → cancel-in-progress: true 確認済 ✓
+
+新規検出 (schedule + cancel: false):
+- `competitor-monitoring.yml` — 日次 07:00 JST, 読み取り + レポート生成 ← **本実行で修正**
+- `ai-university-reminder.yml` — 日次 09:00 JST, 通知送信
+- `codex-session-safety-cron.yml` — schedule
+- `competitor-discovery.yml` — 週次
+- `blog-draft.yml` — 日次 (ドラフト生成。重複リスクあり → 次回 Issue 提案のみ)
+
+### [D] MED: midnight cron 集中 (前回 #3175 から継続)
+以下 6 本が `0 0 * * *` に集中:
+`quota-monitor`, `codex-backlog-check`, `ai-university-reminder`, `ogp-image-refresh`, `wbs-user-notify`, `wbs-user-tasks-notify`
+→ 5 分ずつずらして GHA キュー遅延防止を提案 (Issue にて)
+
+### [F] LOW: ai-tool-watch / ai-tool-changelog-watch 名前重複
+両ファイルとも `name: AI Tool Changelog Watch` を使用。UI/ログ追跡が困難 (前回 #3533 HIGH-2 継続)
+
+---
+
+## 改善提案
+
+| 優先度 | 対象 | 変更内容 | 推定削減効果 |
+|-------|------|---------|------------|
+| HIGH | `cs-check.yml` | cancel-in-progress: false → true | キュー積み防止、concurrent run 削減 |
+| HIGH | `competitor-monitoring.yml` | cancel-in-progress: false → true | 日次 concurrent run 防止 |
+| MED | `ai-university-reminder.yml` | cancel-in-progress: false → true | 通知重複防止 |
+| MED | midnight cron 6本分散 | 5分ずつオフセット | GHA キュー遅延削減 |
+| MED | `ai-tool-watch.yml` name 変更 | `AI Tool Daily Changelog Watch` | UI 識別性改善 |
+| LOW | `blog-draft.yml` concurrency 検討 | cancel-in-progress 慎重に | ドラフト重複生成リスク評価後 |
+
+---
+
+## 自動適用した変更 (本実行)
+
+| ファイル | 変更内容 | 効果 |
+|---------|---------|------|
+| `.github/workflows/cs-check.yml` | `cancel-in-progress: false` → `true` | 2h schedule キュー積み防止 |
+| `.github/workflows/competitor-monitoring.yml` | `cancel-in-progress: false` → `true` | 日次競合モニタリング concurrent 防止 |
+
+---
+
+## 削除候補 (即削除しない・確認後対応)
+
+- `cron-batch.yml` — DISABLED、workflow_dispatch のみ (前回から継続)
+- `blog-backfill-from-apis.yml` — one-shot、schedule なし (前回から継続)
+- `fix-supabase-network.yml` — 単発修正系 (前回から継続)
+- `ai-tool-watch.yml` — `ai-tool-changelog-watch.yml` と完全重複の疑い。内容比較後に判断
+
+---
+
+## 累積改善サマリー (2026-06-04〜24)
+
+| 適用日 | 内容 | 削減効果 |
+|--------|------|---------:|
+| 06-04 | ci.yml pub cache 追加 | ~2 min/PR |
+| 06-04 | memory-search-sync.yml concurrency 追加 | エラー回避 |
+| 06-06 | health-monitor.yml cron 30分→1時間 | ~720 runs/月 |
+| 06-08 | feature-review.yml cron 毎時→毎4時間 | ~22.8 分/日 |
+| 06-08 | edge-function-audit.yml cron 毎時→毎4時間 | ~9 分/日 |
+| 06-09 | blog-publish-orphan-cleanup + stale-ef concurrency 追加 | git 競合エラー回避 |
+| 06-20 | infra-health-check.yml concurrency 追加 | キュー積み防止 |
+| 06-21 | horse-racing-update cron 2h→4h | ~180 runs/月削減 |
+| 06-23 | wbs-ai-review.yml cancel-in-progress: true | Gemini API 重複コスト防止 |
+| **06-24** | **cs-check.yml cancel-in-progress: true** | **2h cron キュー積み防止** |
+| **06-24** | **competitor-monitoring.yml cancel-in-progress: true** | **日次 concurrent 防止** |


### PR DESCRIPTION
## 変更概要

CI/CD コスト最適化ルーチン (2026-06-24) による自動修正。

| ファイル | 変更内容 | 効果 |
|---------|---------|------|
| `cs-check.yml` | `cancel-in-progress: false` → `true` | 2h cron でキューが積み上がる concurrent run を防止 |
| `competitor-monitoring.yml` | `cancel-in-progress: false` → `true` | 日次 07:00 JST の concurrent run 防止 |

## 推定削減効果

- `cs-check.yml`: 2h schedule で並行実行が積み上がるケースを排除。月に複数回の concurrent run が発生した場合の無駄な billable 分を削減。
- `competitor-monitoring.yml`: 手動 dispatch と schedule が重なるケース、または前回 run が長引いた場合の duplicate run を防止。

## 根拠

Issue #3533 (2026-06-20 監査) で推奨された `cs-check` の修正 + 新規検出の `competitor-monitoring`。

監査レポート: `docs/ci-cd-audit/2026-06-24.md`

## 安全性確認

- YAML 構文検証 OK (107 ファイル全件)
- 両 workflow とも idempotent な read/notify 系。キャンセルされても次回 run で再実行される。
- deploy 系 (deploy-prod/dev/staging) は触っていない。

🤖 自動生成: CI/CD コスト監査エージェント

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBV7vpGeqCxSNvdG8cNcsG)_