### PR TITLE
ci: disambiguate monthly AI tool watch

### DIFF
--- a/.github/workflows/ai-tool-changelog-watch.yml
+++ b/.github/workflows/ai-tool-changelog-watch.yml
@@ -1,4 +1,4 @@
-name: AI Tool Changelog Watch
+name: AI Tool Monthly Changelog Watch
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

- rename the monthly AI tool changelog workflow display name
- keep the daily AI Tool Changelog Watch name unchanged
- address HIGH-2 from #3533 by preventing GitHub Actions UI name collisions

## Validation

- `rg "^name: AI Tool" .github/workflows/ai-tool-watch.yml .github/workflows/ai-tool-changelog-watch.yml`

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

## E2E Exception Note

- This PR only changes a GitHub Actions workflow display name.
- No Flutter route, user flow, step, permission, secret, or schedule changed.

## High-risk ultrareview note

- Workflow file touched, but only the top-level display name changed.
- No job logic, permissions, trigger, token, or shell command changed.

Refs #3533
