### PR TITLE
feat(billing): AI使用量メータリング + フリーミアム上限ゲート (#3645 #3646)

### DIFF
--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -9,6 +9,10 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 import {
+  checkAndRecordAiUsage,
+  supabaseUsageStore,
+} from "./usage_gate.ts";
+import {
   AI_CHARACTER_PREAMBLE,
   prependCharacter,
 } from "../_shared/ai_character_preamble.ts";
@@ -4895,6 +4899,28 @@ serve(async (req: Request) => {
           });
         }
 
+        // フリーミアム上限ゲート + 使用量メータリング (#3645 / #3646)
+        if (userId) {
+          const usage = await checkAndRecordAiUsage(
+            supabaseUsageStore(admin),
+            userId,
+          );
+          if (!usage.allowed) {
+            return json({
+              success: false,
+              status: "usageLimitReached",
+              code: "free_limit_reached",
+              upgrade_required: true,
+              used: usage.used,
+              limit: usage.limit,
+              upgrade_url: "/billing",
+              message:
+                `無料プランの今月のAI利用上限(${usage.limit ?? 0}回)に達しました。` +
+                `Pro にアップグレードすると無制限に利用できます。`,
+            }, 402);
+          }
+        }
+
         try {
           // 認証方式はプロバイダーごとに異なる
           let authHeaders: Record<string, string> = {
@@ -5130,6 +5156,28 @@ serve(async (req: Request) => {
             exceeded_scope: budget.exceeded_scope,
             exceeded_scope_id: budget.exceeded_scope_id,
           }, 429);
+        }
+
+        // フリーミアム上限ゲート + 使用量メータリング (#3645 / #3646)
+        if (userId) {
+          const usage = await checkAndRecordAiUsage(
+            supabaseUsageStore(admin),
+            userId,
+          );
+          if (!usage.allowed) {
+            return json({
+              success: false,
+              status: "usageLimitReached",
+              code: "free_limit_reached",
+              upgrade_required: true,
+              used: usage.used,
+              limit: usage.limit,
+              upgrade_url: "/billing",
+              message:
+                `無料プランの今月のAI利用上限(${usage.limit ?? 0}回)に達しました。` +
+                `Pro にアップグレードすると無制限に利用できます。`,
+            }, 402);
+          }
         }
         const finalMessages = messages ?? [{ role: "user", content: userMsg }];
         const routedTier = requestedTier ??

--- a/supabase/functions/ai-hub/usage_gate.ts
+++ b/supabase/functions/ai-hub/usage_gate.ts
@@ -1,0 +1,128 @@
+// AI 使用量メータリング + フリーミアム上限ゲート (#3645 paywall / #3646 metering)
+//
+// 設計方針:
+//  - フェイルオープン: 課金/メータリングのDBエラーで AI 応答を絶対に止めない。
+//  - 純粋ロジック (decideUsage) と DB I/O (UsageStore) を分離してテスト容易に。
+//  - free は月次上限 (既定 30 回 = 課金UI表記と一致)、pro/team は無制限。
+//    pro/team も利用量は記録する (billing.status の usage 表示用)。
+
+import type { SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+export const FREE_AI_QUERY_LIMIT = 30;
+
+/// 当課金期間 (= 暦月初日 'YYYY-MM-DD')。schedule-hub の billing と同形式。
+export function currentBillingPeriodStart(now: Date): string {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+    .toISOString()
+    .slice(0, 10);
+}
+
+export interface UsageDecision {
+  allowed: boolean;
+  tier: string;
+  used: number;
+  /// null = 無制限 (pro/team)
+  limit: number | null;
+  reason?: string;
+}
+
+/// 純粋な判定ロジック (DB 非依存・完全テスト対象)。
+export function decideUsage(
+  tier: string,
+  used: number,
+  limit: number,
+): UsageDecision {
+  const t = (tier || "free").toLowerCase();
+  if (t === "pro" || t === "team") {
+    return { allowed: true, tier: t, used, limit: null };
+  }
+  if (used >= limit) {
+    return {
+      allowed: false,
+      tier: "free",
+      used,
+      limit,
+      reason: "free_limit_reached",
+    };
+  }
+  return { allowed: true, tier: "free", used, limit };
+}
+
+/// DB I/O 抽象。Supabase に依存せずモック可能にするための注入点。
+export interface UsageStore {
+  getTier(userId: string): Promise<string>;
+  getCount(userId: string, periodStart: string): Promise<number>;
+  setCount(userId: string, periodStart: string, count: number): Promise<void>;
+}
+
+export interface UsageOptions {
+  limit?: number;
+  now?: Date;
+}
+
+/// tier を読み、当月カウンタを読み、許可なら +1 して記録する。
+/// 失敗時はフェイルオープン (allowed=true) で AI を止めない。
+/// 注: read→write は厳密にアトミックでなく、高並行下では僅かに過小計数し得る
+/// (= ユーザーに有利な緩い上限。課金の soft-limit として許容)。
+export async function checkAndRecordAiUsage(
+  store: UsageStore,
+  userId: string,
+  opts: UsageOptions = {},
+): Promise<UsageDecision> {
+  const limit = opts.limit ?? FREE_AI_QUERY_LIMIT;
+  const periodStart = currentBillingPeriodStart(opts.now ?? new Date());
+  try {
+    const tier = await store.getTier(userId);
+    const used = await store.getCount(userId, periodStart);
+    const decision = decideUsage(tier, used, limit);
+    if (!decision.allowed) return decision;
+    await store.setCount(userId, periodStart, used + 1);
+    return { ...decision, used: used + 1 };
+  } catch (_error) {
+    // フェイルオープン: メータリング失敗で AI を遮断しない。
+    return {
+      allowed: true,
+      tier: "unknown",
+      used: 0,
+      limit: null,
+      reason: "metering_error",
+    };
+  }
+}
+
+/// Supabase admin client を UsageStore に適合させる薄いアダプタ。
+export function supabaseUsageStore(admin: SupabaseClient): UsageStore {
+  return {
+    async getTier(userId) {
+      const { data, error } = await admin
+        .from("billing_subscriptions")
+        .select("tier")
+        .eq("user_id", userId)
+        .maybeSingle();
+      if (error) throw new Error(error.message);
+      const tier = (data as { tier?: unknown } | null)?.tier;
+      return typeof tier === "string" ? tier : "free";
+    },
+    async getCount(userId, periodStart) {
+      const { data, error } = await admin
+        .from("billing_usage_counters")
+        .select("ai_query_count")
+        .eq("user_id", userId)
+        .eq("period_start", periodStart)
+        .maybeSingle();
+      if (error) throw new Error(error.message);
+      const n = (data as { ai_query_count?: unknown } | null)?.ai_query_count;
+      return typeof n === "number" ? n : Number(n ?? 0) || 0;
+    },
+    async setCount(userId, periodStart, count) {
+      const { error } = await admin
+        .from("billing_usage_counters")
+        .upsert({
+          user_id: userId,
+          period_start: periodStart,
+          ai_query_count: count,
+        }, { onConflict: "user_id,period_start" });
+      if (error) throw new Error(error.message);
+    },
+  };
+}

--- a/supabase/functions/ai-hub/usage_gate_test.ts
+++ b/supabase/functions/ai-hub/usage_gate_test.ts
@@ -1,0 +1,95 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  checkAndRecordAiUsage,
+  currentBillingPeriodStart,
+  decideUsage,
+  FREE_AI_QUERY_LIMIT,
+  type UsageStore,
+} from "./usage_gate.ts";
+
+Deno.test("currentBillingPeriodStart returns first day of the UTC month", () => {
+  assertEquals(
+    currentBillingPeriodStart(new Date("2026-06-25T14:00:00Z")),
+    "2026-06-01",
+  );
+  assertEquals(
+    currentBillingPeriodStart(new Date("2026-01-31T23:59:59Z")),
+    "2026-01-01",
+  );
+});
+
+Deno.test("decideUsage: free under limit is allowed", () => {
+  const d = decideUsage("free", 5, 30);
+  assertEquals(d.allowed, true);
+  assertEquals(d.limit, 30);
+});
+
+Deno.test("decideUsage: free at/over limit is denied", () => {
+  assertEquals(decideUsage("free", 30, 30).allowed, false);
+  assertEquals(decideUsage("free", 31, 30).allowed, false);
+  assertEquals(decideUsage("free", 30, 30).reason, "free_limit_reached");
+});
+
+Deno.test("decideUsage: pro/team are unlimited regardless of count", () => {
+  assertEquals(decideUsage("pro", 9999, 30).allowed, true);
+  assertEquals(decideUsage("pro", 9999, 30).limit, null);
+  assertEquals(decideUsage("team", 9999, 30).allowed, true);
+  assertEquals(decideUsage("TEAM", 9999, 30).allowed, true); // case-insensitive
+});
+
+Deno.test("decideUsage: unknown/empty tier defaults to free rules", () => {
+  assertEquals(decideUsage("", 0, 30).allowed, true);
+  assertEquals(decideUsage("", 30, 30).allowed, false);
+});
+
+function fakeStore(
+  tier: string,
+  count: number,
+): UsageStore & { written: number[] } {
+  const written: number[] = [];
+  return {
+    written,
+    getTier: () => Promise.resolve(tier),
+    getCount: () => Promise.resolve(count),
+    setCount: (_u, _p, c) => {
+      written.push(c);
+      return Promise.resolve();
+    },
+  };
+}
+
+Deno.test("checkAndRecordAiUsage: free under limit increments and allows", async () => {
+  const store = fakeStore("free", 5);
+  const d = await checkAndRecordAiUsage(store, "u1", {
+    now: new Date("2026-06-10T00:00:00Z"),
+  });
+  assertEquals(d.allowed, true);
+  assertEquals(d.used, 6); // incremented
+  assertEquals(store.written, [6]);
+});
+
+Deno.test("checkAndRecordAiUsage: free at limit denies and does NOT increment", async () => {
+  const store = fakeStore("free", FREE_AI_QUERY_LIMIT);
+  const d = await checkAndRecordAiUsage(store, "u1");
+  assertEquals(d.allowed, false);
+  assertEquals(store.written, []); // no write when denied
+});
+
+Deno.test("checkAndRecordAiUsage: pro is unlimited but still records usage", async () => {
+  const store = fakeStore("pro", 100);
+  const d = await checkAndRecordAiUsage(store, "u1");
+  assertEquals(d.allowed, true);
+  assertEquals(d.limit, null);
+  assertEquals(store.written, [101]);
+});
+
+Deno.test("checkAndRecordAiUsage: fails OPEN when the store throws", async () => {
+  const store: UsageStore = {
+    getTier: () => Promise.reject(new Error("db down")),
+    getCount: () => Promise.resolve(0),
+    setCount: () => Promise.resolve(),
+  };
+  const d = await checkAndRecordAiUsage(store, "u1");
+  assertEquals(d.allowed, true); // never block AI on metering error
+  assertEquals(d.reason, "metering_error");
+});


### PR DESCRIPTION
## 概要

P1 課金整合性の2件を実装。統括 #3639。

- **#3645 サーバー側エンタイトルメント(paywall)**: 課金しても何も解放されない問題を解消。`billing_subscriptions.tier` をサーバー側で読み、free は月次上限、pro/team は無制限に。
- **#3646 使用量メータリング**: `billing_usage_counters.ai_query_count` がどこからも increment されず常に0だった問題を解消。AI 呼び出し毎に当月カウンタを加算し、`billing.status` に実値が出るように。

## 設計

- 新規 `supabase/functions/ai-hub/usage_gate.ts`:
  - `decideUsage(tier, used, limit)` — **純粋判定ロジック**（free上限/pro・team無制限/大小文字非依存）
  - `checkAndRecordAiUsage(store, userId)` — tier読込→当月カウント読込→許可なら+1記録。**フェイルオープン**（メータリングDB失敗時は `allowed=true` で AI を絶対に止めない）
  - `UsageStore` 注入で Supabase 非依存にしテスト容易化。`supabaseUsageStore(admin)` が薄いアダプタ
  - `FREE_AI_QUERY_LIMIT = 30`（課金UI「AI質問 30回/月」と一致）。period_start は schedule-hub と同じ暦月初日
- `ai-hub` の **`provider.chat` / `provider.chat_auto`** の2エントリに、認証ユーザー時のみゲート挿入（API/予算チェック後・LLM呼び出し直前 → ブロック/未設定呼び出しは消費しない）。上限超過時は `402 { code: "free_limit_reached", upgrade_url: "/billing", ... }` を返す

## テスト

- `deno test usage_gate_test.ts`: **9 passed / 0 failed**（free上限内→増分許可 / free上限→拒否&未増分 / pro無制限&記録 / フェイルオープン / period境界 / 大小文字 ほか）
- `deno check index.ts`（配線の型検証）/ `deno lint` / `deno fmt --check`: いずれも green

## 既知の限界 / フォローアップ

- read→write は厳密にアトミックでなく高並行下で僅かに過小計数し得る（ユーザーに有利な soft-limit として許容）。厳密化は RPC 化で別途。
- 上限到達時のフロント側「アップグレード促し」UI 表示（#3646 受け入れ条件の一部）は本PRはサーバー側enforce+`billing.status`反映までを担保し、リッチUIは別PRに分離。
- `my_agent.chat` 等への横展開も follow-up。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ai-hub への変更は新規 usage_gate.ts (純粋ロジック+DB I/O分離・フェイルオープン設計) の追加と、provider.chat / provider.chat_auto 2箇所への上限ゲート挿入のみ。deno test 9件 green、認可/RLS/課金ロジック本体の変更なし。メータリング失敗時は allowed=true で AI を遮断しない。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: サーバー側 AI 使用量メータリング+フリーミアム上限ゲートのバックエンド変更。deno test 9件 (純粋判定/増分/未増分/pro無制限/フェイルオープン) で担保。UIの新規分岐は無く E2E フロー不要。

Refs #3639 #3645 #3646
