### PR TITLE
feat: add monetization legal pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ STRIPE_PRO_PRICE_ID=price_your_pro_monthly_price_id_here
 STRIPE_TEAM_PRICE_ID=price_your_team_monthly_price_id_here
 
 # Public app base URL used for Stripe return URLs
-PUBLIC_SITE_URL=https://my-web-app-b6f7f4.web.app
+PUBLIC_SITE_URL=https://my-web-app-b67f4.web.app
 
 # ================================
 # Environment Identifier

--- a/assets/legal/privacy_policy.md
+++ b/assets/legal/privacy_policy.md
@@ -35,7 +35,7 @@ Last updated: 2026-05-07
 - 位置情報 (= GPS / `ACCESS_FINE_LOCATION` 申請しない)
 - 連絡先 / カレンダー / 写真ライブラリ (= mobile permission 申請しない)
 - 生体認証データ (= 顔 / 指紋 / 声紋)
-- 決済情報 (= 本サービスは課金なし)
+- 決済関連情報 (= 有料プラン利用時のプラン種別・決済ステータス・Stripe customer/subscription identifiers。クレジットカード番号は本サービスで保持しません)
 
 ---
 
@@ -60,6 +60,7 @@ Last updated: 2026-05-07
 | **Supabase, Inc.** (= 米国) | DB (PostgreSQL) / 認証 / Edge Functions / ストレージ | §2 全カテゴリ | <https://supabase.com/privacy> |
 | **Google LLC (Firebase Hosting / Cloud Functions)** (= 米国) | Web ホスティング / アクセスログ | §2.2 利用ログ / IP | <https://policies.google.com/privacy> |
 | **Google LLC (OAuth)** (= 米国) | 認証 (= profile / email 取得のみ) | §2.1 アカウント識別情報 | <https://policies.google.com/privacy> |
+| **Stripe, Inc.** (= 米国) | クレジットカード決済 / 請求 / サブスクリプション管理 | 決済ステータス、Stripe customer/subscription/payment identifiers。カード情報はStripeが処理し、本サービスは保持しない | <https://stripe.com/privacy> |
 | **Anthropic / OpenAI / Google DeepMind 等 LLM プロバイダー** | AI 応答生成 (= §8 で詳述) | ユーザー入力テキストの一部 (= 個人特定要素は事前マスキング) | 各社プライバシー方針 |
 | **GitHub, Inc.** (= 米国) | Issue tracker (= サポート窓口) | ユーザーが自発的に投稿した内容 | <https://docs.github.com/site-policy/privacy-policies/github-privacy-statement> |
 

--- a/assets/legal/terms.md
+++ b/assets/legal/terms.md
@@ -1,0 +1,69 @@
+# Terms of Service / 利用規約
+
+Last updated: 2026-06-25
+
+These terms apply to Jibun K.K. ("the Service") at <https://my-web-app-b67f4.web.app/> and related mobile applications.
+
+## 1. Scope
+
+- These terms govern use of the Service by all users.
+- Additional terms shown on paid plan, checkout, or support pages apply when the user subscribes to a paid plan.
+- If these terms conflict with a mandatory law, the mandatory law prevails only to the required extent.
+
+## 2. Account
+
+- Users are responsible for keeping their login method, device, and account information secure.
+- Users must provide accurate information when the Service requires account, billing, or support details.
+- The operator may suspend or restrict accounts that violate these terms, create security risk, or interfere with stable operation.
+
+## 3. Prohibited Conduct
+
+Users must not:
+
+- use the Service for unlawful, harmful, abusive, or fraudulent activity;
+- upload data that infringes third-party rights or privacy;
+- attempt unauthorized access to accounts, APIs, databases, Edge Functions, or infrastructure;
+- reverse engineer, scrape, overload, or disrupt the Service beyond normal personal use;
+- bypass paywalls, usage limits, security controls, or billing controls;
+- publish secrets, credentials, personal data, or regulated data without authorization.
+
+## 4. Paid Plans
+
+- Paid plans are currently planned as Pro: JPY 980/month including tax, and Team: JPY 2,980/month including tax.
+- Paid plans renew automatically unless the user cancels before the next renewal date.
+- Payment is processed by Stripe. The Service does not store full credit card numbers.
+- Cancellation stops the next renewal. Unless required by law or separately stated, partial-month or prorated refunds are not provided.
+- Paid plan features, usage limits, and prices may change after notice on the Service or checkout surface.
+
+## 5. Service Changes and Availability
+
+- The Service may add, change, pause, or remove features to improve quality, security, legal compliance, or operations.
+- The Service is provided on a best-effort basis. Temporary interruption may occur due to maintenance, incidents, dependency outages, or abuse prevention.
+
+## 6. Disclaimer
+
+- AI output, summaries, financial hints, health hints, and task suggestions are informational support and do not replace professional advice.
+- The operator does not guarantee that the Service is error-free, uninterrupted, or suitable for every user purpose.
+- The operator is not liable for indirect, incidental, special, consequential, or lost-profit damages except where prohibited by mandatory law.
+
+## 7. User Data and Privacy
+
+- Privacy handling is described in the Privacy Policy.
+- Users should not upload information they are not authorized to process.
+- Users remain responsible for backups of important materials unless a paid plan explicitly states otherwise.
+
+## 8. Changes to These Terms
+
+- The operator may update these terms when features, billing, law, or operations change.
+- Material changes will be announced on the Service or another reasonable channel.
+- Continued use after the effective date means the user accepts the updated terms.
+
+## 9. Governing Law and Jurisdiction
+
+- These terms are governed by the laws of Japan.
+- The Tokyo District Court has exclusive jurisdiction as the court of first instance unless mandatory law requires otherwise.
+
+## 10. Contact
+
+- Operator: `{{OPERATOR_LEGAL_NAME}}`
+- Contact: `{{CONTACT}}`

--- a/assets/legal/tokushoho.md
+++ b/assets/legal/tokushoho.md
@@ -1,0 +1,25 @@
+# Specified Commercial Transactions Act Disclosure / 特定商取引法に基づく表記
+
+Last updated: 2026-06-25
+
+This page is the legal disclosure for paid plans provided by Jibun K.K.
+
+| Item | Disclosure |
+| --- | --- |
+| 販売事業者名 | `{{OPERATOR_LEGAL_NAME}}` |
+| 運営責任者 | `{{OPERATOR_LEGAL_NAME}}` |
+| 所在地 | `{{OPERATOR_ADDRESS}}` |
+| 連絡先 | `{{CONTACT}}` |
+| 販売価格 | Pro: JPY 980/month including tax. Team: JPY 2,980/month including tax. |
+| 商品代金以外の必要料金 | Internet connection fees, data communication fees, device costs, and any foreign exchange or card issuer fees are borne by the user. |
+| 支払方法 | Credit card payment processed by Stripe. |
+| 支払時期 | Charged at checkout, then automatically charged on each renewal date while the subscription remains active. |
+| 役務提供時期 | Paid features become available immediately after payment completion, subject to account and system propagation. |
+| 返品・キャンセル・解約条件 | Due to the nature of digital services, cancellation stops future renewal and does not provide prorated refunds unless required by law or separately stated. Users may cancel from the billing portal where available. |
+| 動作環境 | Latest stable versions of Chrome, Safari, Edge, or Firefox on desktop/mobile web. Native mobile app support follows each store release note. |
+
+## Notes
+
+- Full credit card numbers are handled by Stripe and are not stored by the Service.
+- The operator may update prices, plan names, or supported environments after notice on the Service or checkout surface.
+- Placeholders on this page must be replaced before public paid go-live.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,6 +52,8 @@ import 'package:my_web_app/pages/competitor_browse_page.dart';
 import 'package:my_web_app/pages/note_list_page.dart';
 import 'package:my_web_app/pages/philosophy_page.dart';
 import 'package:my_web_app/pages/privacy_policy_page.dart';
+import 'package:my_web_app/pages/terms_page.dart';
+import 'package:my_web_app/pages/tokushoho_page.dart';
 import 'package:my_web_app/pages/ai_dev_principles_page.dart';
 import 'package:my_web_app/pages/feature_requests_page.dart';
 import 'package:my_web_app/pages/profile_settings_page.dart';
@@ -664,6 +666,16 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
             return MaterialPageRoute(
               builder: (_) => const PrivacyPolicyPage(),
               settings: const RouteSettings(name: '/privacy'),
+            );
+          case '/terms':
+            return MaterialPageRoute(
+              builder: (_) => const TermsPage(),
+              settings: const RouteSettings(name: '/terms'),
+            );
+          case '/tokusho':
+            return MaterialPageRoute(
+              builder: (_) => const TokushohoPage(),
+              settings: const RouteSettings(name: '/tokusho'),
             );
           case '/ai-dev-principles':
             return MaterialPageRoute(

--- a/lib/main_mobile.dart
+++ b/lib/main_mobile.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:my_web_app/pages/privacy_policy_page.dart';
+import 'package:my_web_app/pages/terms_page.dart';
+import 'package:my_web_app/pages/tokushoho_page.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -23,6 +25,8 @@ class JibunMobileApp extends StatelessWidget {
       ),
       routes: {
         '/privacy': (_) => const PrivacyPolicyPage(showBackButton: false),
+        '/terms': (_) => const TermsPage(showBackButton: false),
+        '/tokusho': (_) => const TokushohoPage(showBackButton: false),
       },
       home: const MobileReleaseShell(),
     );
@@ -200,10 +204,7 @@ class _SurfaceTile extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 4),
-                Text(
-                  item.subtitle,
-                  style: const TextStyle(height: 1.35),
-                ),
+                Text(item.subtitle, style: const TextStyle(height: 1.35)),
               ],
             ),
           ),
@@ -243,10 +244,7 @@ class _ParkedPanel extends StatelessWidget {
                   Expanded(
                     child: Text(
                       item,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        height: 1.35,
-                      ),
+                      style: const TextStyle(color: Colors.white, height: 1.35),
                     ),
                   ),
                 ],

--- a/lib/pages/app_hub_page.dart
+++ b/lib/pages/app_hub_page.dart
@@ -85,87 +85,87 @@ class _AppHubPageState extends State<AppHubPage> {
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : _errorMessage != null
-              ? Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        _errorMessage!,
-                        style: const TextStyle(
-                          color: Color(0xFFE53935),
-                          height: 1.5,
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      ElevatedButton(
-                        onPressed: _fetchData,
-                        child: const Text('再試行'),
-                      ),
-                    ],
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    _errorMessage!,
+                    style: const TextStyle(
+                      color: Color(0xFFE53935),
+                      height: 1.5,
+                    ),
                   ),
-                )
-              : ListView(
-                  padding: const EdgeInsets.all(16),
-                  children: [
-                    // サブスクリプション状態
-                    Card(
-                      child: ListTile(
-                        leading: const Icon(Icons.star_outline),
-                        title: const Text('プラン'),
-                        subtitle: Text(plan == 'free' ? '無料プラン' : '$plan プラン'),
-                        trailing: TextButton(
-                          onPressed: () {},
-                          child: const Text('アップグレード'),
+                  const SizedBox(height: 12),
+                  ElevatedButton(
+                    onPressed: _fetchData,
+                    child: const Text('再試行'),
+                  ),
+                ],
+              ),
+            )
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                // サブスクリプション状態
+                Card(
+                  child: ListTile(
+                    leading: const Icon(Icons.star_outline),
+                    title: const Text('プラン'),
+                    subtitle: Text(plan == 'free' ? '無料プラン' : '$plan プラン'),
+                    trailing: TextButton(
+                      onPressed: () =>
+                          Navigator.of(context).pushNamed('/billing'),
+                      child: const Text('アップグレード'),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                // カレンダーイベント
+                Text('直近のイベント', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                if (_events.isEmpty)
+                  const Card(child: ListTile(title: Text('イベントなし')))
+                else
+                  ..._events
+                      .take(5)
+                      .map(
+                        (e) => Card(
+                          child: ListTile(
+                            leading: const Icon(Icons.event),
+                            title: Text(
+                              (e['metadata'] as Map<String, dynamic>?)?['title']
+                                      as String? ??
+                                  'イベント',
+                            ),
+                            subtitle: Text(e['created_at']?.toString() ?? ''),
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(height: 16),
-                    // カレンダーイベント
-                    Text(
-                      '直近のイベント',
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 8),
-                    if (_events.isEmpty)
-                      const Card(child: ListTile(title: Text('イベントなし')))
-                    else
-                      ..._events.take(5).map(
-                            (e) => Card(
-                              child: ListTile(
-                                leading: const Icon(Icons.event),
-                                title: Text(
-                                  (e['metadata'] as Map<String, dynamic>?)?[
-                                          'title'] as String? ??
-                                      'イベント',
-                                ),
-                                subtitle:
-                                    Text(e['created_at']?.toString() ?? ''),
-                              ),
+                const SizedBox(height: 16),
+                // タスク
+                Text('タスク', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                if (_tasks.isEmpty)
+                  const Card(child: ListTile(title: Text('タスクなし')))
+                else
+                  ..._tasks
+                      .take(5)
+                      .map(
+                        (t) => Card(
+                          child: ListTile(
+                            leading: const Icon(Icons.task_alt),
+                            title: Text(
+                              (t['metadata'] as Map<String, dynamic>?)?['title']
+                                      as String? ??
+                                  'タスク',
                             ),
+                            subtitle: Text(t['created_at']?.toString() ?? ''),
                           ),
-                    const SizedBox(height: 16),
-                    // タスク
-                    Text('タスク', style: Theme.of(context).textTheme.titleMedium),
-                    const SizedBox(height: 8),
-                    if (_tasks.isEmpty)
-                      const Card(child: ListTile(title: Text('タスクなし')))
-                    else
-                      ..._tasks.take(5).map(
-                            (t) => Card(
-                              child: ListTile(
-                                leading: const Icon(Icons.task_alt),
-                                title: Text(
-                                  (t['metadata'] as Map<String, dynamic>?)?[
-                                          'title'] as String? ??
-                                      'タスク',
-                                ),
-                                subtitle:
-                                    Text(t['created_at']?.toString() ?? ''),
-                              ),
-                            ),
-                          ),
-                  ],
-                ),
+                        ),
+                      ),
+              ],
+            ),
     );
   }
 }

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -19,8 +19,8 @@ class LandingPage extends StatefulWidget {
     super.key,
     LandingPageAdapter? adapter,
     GrowthMissionService? growthService,
-  })  : adapter = adapter ?? const SupabaseLandingPageAdapter(),
-        growthService = growthService ?? const GrowthMissionService();
+  }) : adapter = adapter ?? const SupabaseLandingPageAdapter(),
+       growthService = growthService ?? const GrowthMissionService();
 
   @override
   State<LandingPage> createState() => _LandingPageState();
@@ -108,8 +108,8 @@ class _LandingPageState extends State<LandingPage> {
 
   Future<void> _bootstrapReferralInvite() async {
     await widget.growthService.capturePendingReferralFromUri();
-    final pendingReferralCode =
-        await widget.growthService.loadPendingReferralCode();
+    final pendingReferralCode = await widget.growthService
+        .loadPendingReferralCode();
     if (!mounted) {
       return;
     }
@@ -303,8 +303,9 @@ class _LandingPageState extends State<LandingPage> {
     _magicLinkCooldownTimer?.cancel();
     if (!mounted) return;
     setState(() => _magicLinkCooldownSeconds = 30);
-    _magicLinkCooldownTimer =
-        Timer.periodic(const Duration(seconds: 1), (timer) {
+    _magicLinkCooldownTimer = Timer.periodic(const Duration(seconds: 1), (
+      timer,
+    ) {
       if (!mounted) {
         timer.cancel();
         return;
@@ -333,7 +334,8 @@ class _LandingPageState extends State<LandingPage> {
 
     setState(() => _isTrialLoading = true);
     try {
-      final prompt = '''
+      final prompt =
+          '''
 あなたは登録前LPの導線アシスタントです。
 ユーザーの入力を読み、今すぐ着手すべき最初の1件を日本語で返してください。
 出力は次の2行だけにしてください。
@@ -374,9 +376,7 @@ $input
       _showSaveCtaPrompt = true;
       _isSignUp = true;
     });
-    _showMessage(
-      'この結果を保存するには登録が必要です。下の登録セクションから30秒で保存を開始できます。',
-    );
+    _showMessage('この結果を保存するには登録が必要です。下の登録セクションから30秒で保存を開始できます。');
     _scrollToAuthSection();
   }
 
@@ -438,10 +438,7 @@ $input
       case 'mac.com':
         return Uri.parse('https://www.icloud.com/mail');
       default:
-        return Uri(
-          scheme: 'mailto',
-          path: email,
-        );
+        return Uri(scheme: 'mailto', path: email);
     }
   }
 
@@ -507,8 +504,9 @@ $input
 
     final compact = raw.replaceAll('\n', ' ').trim();
     if (compact.isNotEmpty) {
-      final safe =
-          compact.length > 80 ? '${compact.substring(0, 80)}...' : compact;
+      final safe = compact.length > 80
+          ? '${compact.substring(0, 80)}...'
+          : compact;
       return (safe, 'AIの返答をそのまま簡易表示しています。');
     }
 
@@ -518,46 +516,31 @@ $input
   (String, String) _buildTrialFallbackSuggestion(String input) {
     final text = input.trim();
     if (text.isEmpty) {
-      return (
-        '今日の最重要を1件決める',
-        '入力が空でも、最初に最重要を1件に絞るだけで着手はかなり早くなります。',
-      );
+      return ('今日の最重要を1件決める', '入力が空でも、最初に最重要を1件に絞るだけで着手はかなり早くなります。');
     }
 
     if (text.contains('メール') ||
         text.contains('SMS') ||
         text.contains('DM') ||
         text.contains('連絡')) {
-      return (
-        '未読の確認を1件だけ終える',
-        '連絡系は放置コストが高いので、最初に1件だけ処理すると全体が進みます。',
-      );
+      return ('未読の確認を1件だけ終える', '連絡系は放置コストが高いので、最初に1件だけ処理すると全体が進みます。');
     }
 
     if (text.contains('考える') ||
         text.contains('悩む') ||
         text.contains('迷う') ||
         text.contains('決めたい')) {
-      return (
-        '判断条件を1つだけ書き出す',
-        '条件を先に言語化すると、迷いが減って次の行動が決まりやすくなります。',
-      );
+      return ('判断条件を1つだけ書き出す', '条件を先に言語化すると、迷いが減って次の行動が決まりやすくなります。');
     }
 
     if (text.contains('タスク') ||
         RegExp('[Tt][Oo][Dd][Oo]').hasMatch(text) ||
         text.contains('仕事') ||
         text.contains('課題')) {
-      return (
-        '10分だけ使って最重要を1件に絞る',
-        '最重要を1件だけ先に固定すると、その後の先延ばしが大きく減ります。',
-      );
+      return ('10分だけ使って最重要を1件に絞る', '最重要を1件だけ先に固定すると、その後の先延ばしが大きく減ります。');
     }
 
-    return (
-      '20分だけ動ける最小単位に分解する',
-      '大きすぎる作業は始めにくいので、最小単位まで分けてから着手してください。',
-    );
+    return ('20分だけ動ける最小単位に分解する', '大きすぎる作業は始めにくいので、最小単位まで分けてから着手してください。');
   }
 
   String _resolveEmailAuthError(Object error) {
@@ -697,11 +680,7 @@ $input
         gradient: const LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: [
-            Color(0xFFFFF4ED),
-            Color(0xFFF6F7FF),
-            Color(0xFFF9FAFB),
-          ],
+          colors: [Color(0xFFFFF4ED), Color(0xFFF6F7FF), Color(0xFFF9FAFB)],
         ),
         borderRadius: BorderRadius.circular(28),
         border: Border.all(
@@ -777,8 +756,10 @@ $input
             Center(
               child: Container(
                 margin: const EdgeInsets.only(bottom: 14),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
                 decoration: BoxDecoration(
                   color: const Color(0xFFF0FDF4),
                   borderRadius: BorderRadius.circular(999),
@@ -847,10 +828,7 @@ $input
                 icon: const Icon(Icons.play_circle_outline, size: 18),
                 label: const Text(
                   '登録なしで1件試す',
-                  style: TextStyle(
-                    fontWeight: FontWeight.w600,
-                    height: 1.5,
-                  ),
+                  style: TextStyle(fontWeight: FontWeight.w600, height: 1.5),
                 ),
                 style: OutlinedButton.styleFrom(
                   foregroundColor: const Color(0xFFFF6B35),
@@ -1128,9 +1106,7 @@ $input
             decoration: BoxDecoration(
               color: const Color(0xFFFF6B35).withAlpha(15),
               borderRadius: BorderRadius.circular(8),
-              border: Border.all(
-                color: const Color(0xFFFF6B35).withAlpha(70),
-              ),
+              border: Border.all(color: const Color(0xFFFF6B35).withAlpha(70)),
             ),
             child: const Row(
               children: [
@@ -1150,11 +1126,7 @@ $input
                   ),
                 ),
                 Spacer(),
-                Icon(
-                  Icons.arrow_forward,
-                  color: Color(0xFFFF6B35),
-                  size: 14,
-                ),
+                Icon(Icons.arrow_forward, color: Color(0xFFFF6B35), size: 14),
               ],
             ),
           ),
@@ -1168,7 +1140,8 @@ $input
   Future<void> _shareOnX() async {
     const siteUrl = 'https://my-web-app-b67f4.web.app/';
     final userCount = _totalUsers > 10 ? '登録者$_totalUsers人突破！' : '';
-    final text = 'スマホでギター録音＋21のSaaSを1アプリに統合。'
+    final text =
+        'スマホでギター録音＋21のSaaSを1アプリに統合。'
         '自分株式会社 $userCount\n'
         '完全無料で使えます👇\n'
         '$siteUrl\n'
@@ -1507,10 +1480,7 @@ $input
                       children: [
                         Text(
                           guide.icon,
-                          style: const TextStyle(
-                            fontSize: 18,
-                            height: 1.4,
-                          ),
+                          style: const TextStyle(fontSize: 18, height: 1.4),
                         ),
                         const SizedBox(width: 6),
                         Text(
@@ -1587,26 +1557,26 @@ $input
         key: 'evernote',
         name: 'Evernote',
         emoji: '🐘',
-        color: Color(0xFF00A82D)
+        color: Color(0xFF00A82D),
       ),
       (
         key: 'moneyforward',
         name: 'MoneyForward',
         emoji: '💰',
-        color: Color(0xFF0D47A1)
+        color: Color(0xFF0D47A1),
       ),
       (key: 'x', name: 'X (Twitter)', emoji: '𝕏', color: Color(0xFF1C1C1E)),
       (
         key: 'animaworks',
         name: 'Animaworks',
         emoji: '🎯',
-        color: Color(0xFFFF6B35)
+        color: Color(0xFFFF6B35),
       ),
       (
         key: 'claude-code',
         name: 'Claude Code',
         emoji: '🤖',
-        color: Color(0xFFD97706)
+        color: Color(0xFFD97706),
       ),
       (key: 'codex', name: 'Codex', emoji: '⚡', color: Color(0xFF10B981)),
       (key: 'replit', name: 'Replit', emoji: '💻', color: Color(0xFFF5821B)),
@@ -1614,25 +1584,25 @@ $input
         key: 'netkeiba',
         name: 'netkeiba',
         emoji: '🐎',
-        color: Color(0xFF7C3AED)
+        color: Color(0xFF7C3AED),
       ),
       (
         key: 'openclaw',
         name: 'OpenClaw',
         emoji: '🦾',
-        color: Color(0xFF0EA5E9)
+        color: Color(0xFF0EA5E9),
       ),
       (
         key: 'claude-cowork',
         name: 'Claude Cowork',
         emoji: '🏛️',
-        color: Color(0xFF6366F1)
+        color: Color(0xFF6366F1),
       ),
       (
         key: 'chatwork',
         name: 'Chatwork',
         emoji: '🏢',
-        color: Color(0xFFE53935)
+        color: Color(0xFFE53935),
       ),
       (key: 'slack', name: 'Slack', emoji: '💬', color: Color(0xFF4A154B)),
       (key: 'jobcan', name: 'ジョブカン', emoji: '📋', color: Color(0xFF059669)),
@@ -1642,13 +1612,13 @@ $input
         key: 'google_agent_builder',
         name: 'Google Agent Builder',
         emoji: '🤖',
-        color: Color(0xFF34A853)
+        color: Color(0xFF34A853),
       ),
       (
         key: 'microsoft',
         name: 'Microsoft',
         emoji: '🪟',
-        color: Color(0xFF00A4EF)
+        color: Color(0xFF00A4EF),
       ),
       (key: 'discord', name: 'Discord', emoji: '🎮', color: Color(0xFF5865F2)),
       (key: 'line', name: 'LINE', emoji: '💚', color: Color(0xFF06C755)),
@@ -1656,7 +1626,7 @@ $input
         key: 'facebook',
         name: 'Facebook',
         emoji: '👥',
-        color: Color(0xFF1877F2)
+        color: Color(0xFF1877F2),
       ),
       (key: 'liven', name: 'Liven', emoji: '🍽️', color: Color(0xFFFF6B35)),
       (key: 'github', name: 'GitHub', emoji: '🐙', color: Color(0xFF24292E)),
@@ -1737,10 +1707,7 @@ $input
                       children: [
                         Text(
                           c.emoji,
-                          style: const TextStyle(
-                            fontSize: 14,
-                            height: 1.6,
-                          ),
+                          style: const TextStyle(fontSize: 14, height: 1.6),
                         ),
                         const SizedBox(width: 6),
                         Text(
@@ -1764,10 +1731,7 @@ $input
               child: TextButton.icon(
                 onPressed: () =>
                     Navigator.of(context).pushNamed('/competitors'),
-                icon: const Icon(
-                  Icons.grid_view_rounded,
-                  size: 14,
-                ),
+                icon: const Icon(Icons.grid_view_rounded, size: 14),
                 label: const Text(
                   '全1894社を見る →',
                   style: TextStyle(fontSize: 13, height: 1.5),
@@ -1927,26 +1891,26 @@ $input
         Icons.account_tree,
         '0xFF4F46E5',
         'AI組織OS (12部署20人)',
-        '自然言語でタスクを入力するだけで最適な部署が自動受付。ゴールを12部署に自動分解・配布。SlackもJiraも不要。'
+        '自然言語でタスクを入力するだけで最適な部署が自動受付。ゴールを12部署に自動分解・配布。SlackもJiraも不要。',
       ),
       (
         Icons.smart_toy,
         '0xFF6366F1',
         'AI役員会議 (MAGI)',
-        'CEO/CFO/CMO/CHROのAIペルソナが多角的にアドバイス。Notionにもない独自機能。'
+        'CEO/CFO/CMO/CHROのAIペルソナが多角的にアドバイス。Notionにもない独自機能。',
       ),
       (Icons.memory, '0xFF10B981', '記憶ドリル', '忘却曲線に基づく反復学習。Evernoteにはない学習機能。'),
       (
         Icons.account_balance_wallet,
         '0xFFF59E0B',
         '経営コックピット',
-        '収支・資産・KPIを一画面で管理。MoneyForwardの代替として使える。'
+        '収支・資産・KPIを一画面で管理。MoneyForwardの代替として使える。',
       ),
       (
         Icons.upload_file,
         '0xFF3B82F6',
         'Notion/Evernoteから移行',
-        'CSVやENEXをそのままインポート。移行コストゼロ。'
+        'CSVやENEXをそのままインポート。移行コストゼロ。',
       ),
       (Icons.hub, '0xFFA855F7', 'マインドマップ', '思考の整理をビジュアルで。ノートと連携。'),
       (Icons.public, '0xFF22C55E', '公開メモ・SEO', 'メモをURLで共有。知識のアウトプットが集客につながる。'),
@@ -1954,763 +1918,763 @@ $input
         Icons.psychology_alt,
         '0xFF8B5CF6',
         '性格診断 (16タイプ MBTI)',
-        'MBTIベースの自己分析でメモ術・学習スタイルを最適化。恋愛相性診断も。他にはない自己理解機能。'
+        'MBTIベースの自己分析でメモ術・学習スタイルを最適化。恋愛相性診断も。他にはない自己理解機能。',
       ),
       (
         Icons.do_not_disturb_on,
         '0xFFEF4444',
         '思考妨害排除ガード',
-        'SNS・通知・散漫思考をブロックして深い集中を守る。フォーカスセッション中はアプリ内通知を自動ミュート。他のサービスにはない認知コスト削減機能。'
+        'SNS・通知・散漫思考をブロックして深い集中を守る。フォーカスセッション中はアプリ内通知を自動ミュート。他のサービスにはない認知コスト削減機能。',
       ),
       (
         Icons.visibility_off,
         '0xFFF97316',
         '見栄ガード',
-        'かっこつけず・見栄をはらずに生きる仕組み。SNS承認欲求や衝動的な自己顕示を記録・可視化して断ち切る。競合21社に存在しない自己規律機能。'
+        'かっこつけず・見栄をはらずに生きる仕組み。SNS承認欲求や衝動的な自己顕示を記録・可視化して断ち切る。競合21社に存在しない自己規律機能。',
       ),
       (
         Icons.money_off,
         '0xFF14B8A6',
         '浪費トラッキング',
-        '投資を除いた資産放出を日次で記録・可視化。無意識の浪費パターンを把握してMoneyForwardを超える節制管理。'
+        '投資を除いた資産放出を日次で記録・可視化。無意識の浪費パターンを把握してMoneyForwardを超える節制管理。',
       ),
       (
         Icons.corporate_fare,
         '0xFF6366F1',
         '12部署AI仮想組織',
-        '自分一人でCEO・CFO・CMO・開発部・営業部など12部署20人のAI組織を持てる。Slack・Chatwork・ジョブカン対抗の次世代チーム管理。'
+        '自分一人でCEO・CFO・CMO・開発部・営業部など12部署20人のAI組織を持てる。Slack・Chatwork・ジョブカン対抗の次世代チーム管理。',
       ),
       (
         Icons.group_add,
         '0xFF22C55E',
         '友達招待・紹介コード',
-        '紹介リンクをシェアするだけで招待実績が積み上がる。バイラル成長の仕組みを個人レベルで実装。'
+        '紹介リンクをシェアするだけで招待実績が積み上がる。バイラル成長の仕組みを個人レベルで実装。',
       ),
       (
         Icons.chat_bubble_outline,
         '0xFF8B5CF6',
         'ノートコメント・リアクション',
-        '公開メモにコメント・絵文字リアクション・OGPシェアが可能。Notion/Evernoteを超えるソーシャル連携機能。'
+        '公開メモにコメント・絵文字リアクション・OGPシェアが可能。Notion/Evernoteを超えるソーシャル連携機能。',
       ),
       (
         Icons.notifications,
         '0xFF0EA5E9',
         '通知センター',
-        'アプリ内の全通知を一元管理。未読バッジ・フィルタリング・既読管理で重要な更新を見逃さない。'
+        'アプリ内の全通知を一元管理。未読バッジ・フィルタリング・既読管理で重要な更新を見逃さない。',
       ),
       (
         Icons.draw,
         '0xFF64748B',
         '電子署名',
-        '契約書・同意書をアプリ内で電子署名。法人・フリーランス向け。DocuSign連携と直接競合する機能を完全無料で提供。'
+        '契約書・同意書をアプリ内で電子署名。法人・フリーランス向け。DocuSign連携と直接競合する機能を完全無料で提供。',
       ),
       (
         Icons.storefront,
         '0xFFEC4899',
         'コンビニ経営シミュレーション',
-        '自分株式会社の中でコンビニを経営。春夏秋冬の季節・天気・トレンドをAIが反映した経営判断ゲーム。競合21社に存在しないゲーミフィケーション。'
+        '自分株式会社の中でコンビニを経営。春夏秋冬の季節・天気・トレンドをAIが反映した経営判断ゲーム。競合21社に存在しないゲーミフィケーション。',
       ),
       (
         Icons.timer,
         '0xFF10B981',
         '集中タイマー',
-        'ポモドーロ/ディープフォーカスモードで深い集中を実現。思考妨害排除ガードと連携しSNS通知を自動ブロック。'
+        'ポモドーロ/ディープフォーカスモードで深い集中を実現。思考妨害排除ガードと連携しSNS通知を自動ブロック。',
       ),
       (
         Icons.edit_note,
         '0xFF7C3AED',
         'AI文章アシスタント',
-        'メモ・ブログ・SNS投稿の文章作成・推敲・要約をAIが支援。Notion AIを超える日本語特化の文章強化機能。'
+        'メモ・ブログ・SNS投稿の文章作成・推敲・要約をAIが支援。Notion AIを超える日本語特化の文章強化機能。',
       ),
       (
         Icons.fitness_center,
         '0xFFF59E0B',
         '浪費耐性トレーニング',
-        '買わずに耐えた回数・防いだ出費・取り戻した時間を毎日記録。我慢を筋トレのように可視化して浪費を断つ精神性を育てる。'
+        '買わずに耐えた回数・防いだ出費・取り戻した時間を毎日記録。我慢を筋トレのように可視化して浪費を断つ精神性を育てる。',
       ),
       (
         Icons.video_camera_back,
         '0xFFDC2626',
         'バイラル動画パイプライン',
-        'AIが広告動画を自動生成→X/SNSに自動投稿→効果測定まで全自動。TikTok・YouTube Shortsを超えるバイラル成長エンジン。'
+        'AIが広告動画を自動生成→X/SNSに自動投稿→効果測定まで全自動。TikTok・YouTube Shortsを超えるバイラル成長エンジン。',
       ),
       (
         Icons.translate,
         '0xFF0891B2',
         '語学学習',
-        'フラッシュカード・発音練習・進捗管理をAIが支援。Duolingoを超える日本語圏特化の語学習得システム。'
+        'フラッシュカード・発音練習・進捗管理をAIが支援。Duolingoを超える日本語圏特化の語学習得システム。',
       ),
       (
         Icons.restaurant_menu,
         '0xFFB45309',
         'レシピ・献立管理',
-        '食材管理・献立提案・栄養分析をAIが自動化。MoneyForwardの家計管理と食費を連携した生活密着型機能。'
+        '食材管理・献立提案・栄養分析をAIが自動化。MoneyForwardの家計管理と食費を連携した生活密着型機能。',
       ),
       (
         Icons.flight_takeoff,
         '0xFF0369A1',
         '旅行計画・行程管理',
-        '行程管理・現地情報・費用管理を一元化。Google旅行機能を超えるAI行程最適化で旅をもっと豊かに。'
+        '行程管理・現地情報・費用管理を一元化。Google旅行機能を超えるAI行程最適化で旅をもっと豊かに。',
       ),
       (
         Icons.pets,
         '0xFF7E22CE',
         'ペット健康管理',
-        'ワクチン記録・健康日記・体重管理をアプリ内で完結。競合21社にない個人ライフ全領域カバーの証明。'
+        'ワクチン記録・健康日記・体重管理をアプリ内で完結。競合21社にない個人ライフ全領域カバーの証明。',
       ),
       (
         Icons.photo_library,
         '0xFF065F46',
         'フォトギャラリー',
-        'AI自動分類・思い出管理・家族共有まで対応。Google フォトに対抗しつつ自分株式会社データとシームレス連携。'
+        'AI自動分類・思い出管理・家族共有まで対応。Google フォトに対抗しつつ自分株式会社データとシームレス連携。',
       ),
       (
         Icons.emoji_events,
         '0xFFEAB308',
         '習慣ゲーミフィケーション',
-        'ストリーク・バッジ・XP獲得で習慣を楽しく継続。Duolingo式ゲーミフィケーションで継続率3倍。'
+        'ストリーク・バッジ・XP獲得で習慣を楽しく継続。Duolingo式ゲーミフィケーションで継続率3倍。',
       ),
       (
         Icons.code,
         '0xFF0F172A',
         'コードプレイグラウンド',
-        'ブラウザだけでコードを書いて即実行。学習・プロト制作・アイデア検証を一気通貫でサポート。'
+        'ブラウザだけでコードを書いて即実行。学習・プロト制作・アイデア検証を一気通貫でサポート。',
       ),
       (
         Icons.home_work,
         '0xFF0284C7',
         '不動産管理',
-        '物件情報・家賃・更新日を一元管理。投資用物件の収益計算もAIが自動化。'
+        '物件情報・家賃・更新日を一元管理。投資用物件の収益計算もAIが自動化。',
       ),
       (
         Icons.school,
         '0xFF4338CA',
         'eラーニング',
-        'コース作成・受講管理・修了証発行まで対応。Udemyを超える自分専用LMSを無料で構築。'
+        'コース作成・受講管理・修了証発行まで対応。Udemyを超える自分専用LMSを無料で構築。',
       ),
       (
         Icons.directions_car,
         '0xFF374151',
         '車両管理',
-        '車検・整備記録・燃費管理を自動追跡。複数台・法人向け車両フリートにも対応。'
+        '車検・整備記録・燃費管理を自動追跡。複数台・法人向け車両フリートにも対応。',
       ),
       (
         Icons.work_history,
         '0xFF059669',
         '採用ボード',
-        '求人票作成・応募者管理・面接スケジューリングをAIが支援。HR SaaSの代替を完全無料で実現。'
+        '求人票作成・応募者管理・面接スケジューリングをAIが支援。HR SaaSの代替を完全無料で実現。',
       ),
       (
         Icons.sensors,
         '0xFF7C3AED',
         'IoTダッシュボード',
-        '家電・センサー・スマートデバイスをダッシュボードで一元管理。スマートホームを自分株式会社に統合。'
+        '家電・センサー・スマートデバイスをダッシュボードで一元管理。スマートホームを自分株式会社に統合。',
       ),
       (
         Icons.gavel,
         '0xFFDC2626',
         '法務管理 / Harvey AI',
-        '契約書・利用規約・コンプライアンスチェックをAIが支援。法律AI特化のHarveyをバックエンドに据えた自動法務レビュー基盤として、社内法務の下書き・論点整理・引用付き確認を一気通貫で進められます。'
+        '契約書・利用規約・コンプライアンスチェックをAIが支援。法律AI特化のHarveyをバックエンドに据えた自動法務レビュー基盤として、社内法務の下書き・論点整理・引用付き確認を一気通貫で進められます。',
       ),
       (
         Icons.mark_email_read,
         '0xFF0891B2',
         'メールテンプレート管理',
-        '返信テンプレート・差し込み変数・ABテストをAIが最適化。メール生産性を10倍に引き上げる。'
+        '返信テンプレート・差し込み変数・ABテストをAIが最適化。メール生産性を10倍に引き上げる。',
       ),
       (
         Icons.security,
         '0xFF16A34A',
         '2FA/多要素認証',
-        'TOTP・SMSで全アカウントを堅牢に保護。パスワードマネージャーと連携して認証情報を一元管理。'
+        'TOTP・SMSで全アカウントを堅牢に保護。パスワードマネージャーと連携して認証情報を一元管理。',
       ),
       (
         Icons.music_video,
         '0xFFE11D48',
         '公開ギターギャラリー',
-        'スマホで録音したギター演奏をUGCとして公開共有。OGP・sitemap対応でSEO流入も獲得。競合21社にない音楽SNS機能。'
+        'スマホで録音したギター演奏をUGCとして公開共有。OGP・sitemap対応でSEO流入も獲得。競合21社にない音楽SNS機能。',
       ),
       (
         Icons.calendar_month,
         '0xFF0F766E',
         '月次カレンダービュー',
-        '月間スケジュールをカレンダー形式で一覧表示。タスク・習慣・イベントをTimeTree/Googleカレンダーを超える統合ビューで管理。'
+        '月間スケジュールをカレンダー形式で一覧表示。タスク・習慣・イベントをTimeTree/Googleカレンダーを超える統合ビューで管理。',
       ),
       (
         Icons.dynamic_feed,
         '0xFF0F172A',
         'アクティビティフィード',
-        '自分の行動ログ・達成記録・コミュニティ更新をタイムライン表示。Discord/Slackを超えるパーソナルアクティビティ可視化。'
+        '自分の行動ログ・達成記録・コミュニティ更新をタイムライン表示。Discord/Slackを超えるパーソナルアクティビティ可視化。',
       ),
       (
         Icons.emoji_events,
         '0xFFF59E0B',
         '報酬・達成バッジ',
-        '習慣継続・目標達成でポイントとバッジを獲得。ゲーミフィケーションでモチベーションを維持し継続率を劇的に改善。'
+        '習慣継続・目標達成でポイントとバッジを獲得。ゲーミフィケーションでモチベーションを維持し継続率を劇的に改善。',
       ),
       (
         Icons.alarm,
         '0xFF0369A1',
         '支払いリマインダー',
-        '月次サブスク・公共料金・ローン返済を自動リマインド。MoneyForwardを超える決済管理と浪費防止の統合機能。'
+        '月次サブスク・公共料金・ローン返済を自動リマインド。MoneyForwardを超える決済管理と浪費防止の統合機能。',
       ),
       (
         Icons.how_to_vote,
         '0xFF1D4ED8',
         '地方選挙インテリジェンス',
-        '47都道府県×1年先の選挙を自動追跡。X/SNSへの候補者分析スレッドをAIが自動生成。競合21社に存在しない市民×AI政治情報プラットフォーム。'
+        '47都道府県×1年先の選挙を自動追跡。X/SNSへの候補者分析スレッドをAIが自動生成。競合21社に存在しない市民×AI政治情報プラットフォーム。',
       ),
       (
         Icons.videocam,
         '0xFF6D28D9',
         'ビデオ会議・ミーティング管理',
-        'ビデオ通話・会議室予約・議事録自動生成をワンストップで提供。Zoom/Google Meetを超える統合ミーティングプラットフォーム。'
+        'ビデオ通話・会議室予約・議事録自動生成をワンストップで提供。Zoom/Google Meetを超える統合ミーティングプラットフォーム。',
       ),
       (
         Icons.inbox,
         '0xFF0F766E',
         'スマート受信箱',
-        'AIがメール・通知・タスクを自動分類・優先度付け。重要度の低いメールを自動整理して認知コストを削減。'
+        'AIがメール・通知・タスクを自動分類・優先度付け。重要度の低いメールを自動整理して認知コストを削減。',
       ),
       (
         Icons.lock,
         '0xFF7C3AED',
         'パスワード金庫',
-        '全パスワードをゼロ知識暗号化で保護・自動入力・セキュリティ監査。1Password/Bitwardenを超える統合認証管理を完全無料で提供。'
+        '全パスワードをゼロ知識暗号化で保護・自動入力・セキュリティ監査。1Password/Bitwardenを超える統合認証管理を完全無料で提供。',
       ),
       (
         Icons.podcasts,
         '0xFFF59E0B',
         'ポッドキャスト管理',
-        'ポッドキャスト制作・公開・リスナー分析をワンストップ。Anchor/Spotifyを超える個人ポッドキャスタープラットフォーム。'
+        'ポッドキャスト制作・公開・リスナー分析をワンストップ。Anchor/Spotifyを超える個人ポッドキャスタープラットフォーム。',
       ),
       (
         Icons.screen_share,
         '0xFF0369A1',
         'スクリーン録画',
-        'ブラウザから直接スクリーン録画・即時共有。Loomを超える非同期ビデオコミュニケーションを完全無料で提供。'
+        'ブラウザから直接スクリーン録画・即時共有。Loomを超える非同期ビデオコミュニケーションを完全無料で提供。',
       ),
       (
         Icons.storefront,
         '0xFFE11D48',
         'オークション・マーケットプレイス',
-        'フリマ・オークション出品から決済まで一括管理。メルカリ/ヤフオクの機能を自分株式会社内で完結。'
+        'フリマ・オークション出品から決済まで一括管理。メルカリ/ヤフオクの機能を自分株式会社内で完結。',
       ),
       (
         Icons.mic,
         '0xFF059669',
         '音声メモ文字起こし',
-        '録音した音声をAIが自動文字起こし・要約。会議・インタビュー・アイデアメモをテキスト化して検索可能に。'
+        '録音した音声をAIが自動文字起こし・要約。会議・インタビュー・アイデアメモをテキスト化して検索可能に。',
       ),
       (
         Icons.draw,
         '0xFF6D28D9',
         '仮想ホワイトボード',
-        'オンラインホワイトボードでアイデアをビジュアル整理。Miro/FigJamを超えるコラボ可能なキャンバス。'
+        'オンラインホワイトボードでアイデアをビジュアル整理。Miro/FigJamを超えるコラボ可能なキャンバス。',
       ),
       (
         Icons.alt_route,
         '0xFF0891B2',
         'ワークフロー自動化',
-        'タスク・メール・通知をトリガー&アクションで自動化。Zapierを超えるノーコード業務自動化エンジン。'
+        'タスク・メール・通知をトリガー&アクションで自動化。Zapierを超えるノーコード業務自動化エンジン。',
       ),
       (
         Icons.qr_code,
         '0xFF374151',
         'QRコード生成',
-        'URLやテキストを即座にQRコードに変換・保存・共有。業務・個人・イベント告知に対応した多用途QRジェネレーター。'
+        'URLやテキストを即座にQRコードに変換・保存・共有。業務・個人・イベント告知に対応した多用途QRジェネレーター。',
       ),
       (
         Icons.admin_panel_settings,
         '0xFF0F172A',
         'アクセス制御・権限管理',
-        'ロール設定・ユーザー権限付与・アクセスログを一元管理。法人チームのセキュリティをジョブカンを超えるきめ細かさで実現。'
+        'ロール設定・ユーザー権限付与・アクセスログを一元管理。法人チームのセキュリティをジョブカンを超えるきめ細かさで実現。',
       ),
       (
         Icons.inventory,
         '0xFF059669',
         '在庫・バーコード管理',
-        '商品バーコードスキャン・在庫数追跡・入出庫記録を自動化。Amazonの倉庫管理機能を個人・中小企業向けに完全無料で提供。'
+        '商品バーコードスキャン・在庫数追跡・入出庫記録を自動化。Amazonの倉庫管理機能を個人・中小企業向けに完全無料で提供。',
       ),
       (
         Icons.dashboard_customize,
         '0xFF7C3AED',
         'テンプレート広場',
-        'ビジネス・学習・ライフスタイル・技術開発など6カテゴリ18種のテンプレートを即適用。Notionマーケットプレイスを超える日本語特化テンプレート集。'
+        'ビジネス・学習・ライフスタイル・技術開発など6カテゴリ18種のテンプレートを即適用。Notionマーケットプレイスを超える日本語特化テンプレート集。',
       ),
       (
         Icons.bar_chart,
         '0xFF0891B2',
         'パーソナルダッシュボード',
-        'ノート数・タスク達成率・習慣ストリーク・集中時間をチャートで可視化。Notion 3.4のダッシュボードビューを超えるAIパーソナルKPI分析。'
+        'ノート数・タスク達成率・習慣ストリーク・集中時間をチャートで可視化。Notion 3.4のダッシュボードビューを超えるAIパーソナルKPI分析。',
       ),
       (
         Icons.calendar_today,
         '0xFF4285F4',
         'Google カレンダー同期',
-        'アプリの予定 ↔ Google カレンダーを双方向リアルタイム同期。OAuth 2.0による安全な認証で複数カレンダーを一元管理。Google カレンダーを超える統合スケジュール管理を実現。'
+        'アプリの予定 ↔ Google カレンダーを双方向リアルタイム同期。OAuth 2.0による安全な認証で複数カレンダーを一元管理。Google カレンダーを超える統合スケジュール管理を実現。',
       ),
       (
         Icons.account_balance_wallet,
         '0xFF00B900',
         'MoneyForward 連携',
-        '銀行・証券・クレカ・電子マネー残高を自動取り込み。総資産・取引履歴をAIが分析して資産増加アドバイス。MoneyForwardを超える完全無料の資産管理を提供。'
+        '銀行・証券・クレカ・電子マネー残高を自動取り込み。総資産・取引履歴をAIが分析して資産増加アドバイス。MoneyForwardを超える完全無料の資産管理を提供。',
       ),
       (
         Icons.webhook,
         '0xFF4A154B',
         'Slack 通知連携',
-        'タスク完了・習慣達成・機能リクエストをリアルタイムでSlackチャンネルに通知。Webhook URL設定だけで即稼働。Slack AI に対抗するインテリジェント通知ルーティング。'
+        'タスク完了・習慣達成・機能リクエストをリアルタイムでSlackチャンネルに通知。Webhook URL設定だけで即稼働。Slack AI に対抗するインテリジェント通知ルーティング。',
       ),
       (
         Icons.psychology,
         '0xFF6366F1',
         'マイスキル (AIプロンプト再利用)',
-        'よく使うAIプロンプトをスキルとして保存・1タップ再利用。Slackワークフロービルダーを超える個人AI自動化テンプレートを無制限登録。'
+        'よく使うAIプロンプトをスキルとして保存・1タップ再利用。Slackワークフロービルダーを超える個人AI自動化テンプレートを無制限登録。',
       ),
       (
         Icons.chat_bubble_outline,
         '0xFF5865F2',
         'チームチャット',
-        'チャンネル別リアルタイムメッセージング。Discord/LINEを超える目的別チャンネル管理と検索可能なメッセージ履歴をセキュアに提供。'
+        'チャンネル別リアルタイムメッセージング。Discord/LINEを超える目的別チャンネル管理と検索可能なメッセージ履歴をセキュアに提供。',
       ),
       (
         Icons.favorite_outline,
         '0xFF22C55E',
         'ヘルスコーチ',
-        '歩数・カロリー・睡眠・水分をAIが統合分析し毎日パーソナルアドバイス。Livenを超える日本語完全対応の無料ヘルスケアコーチング。'
+        '歩数・カロリー・睡眠・水分をAIが統合分析し毎日パーソナルアドバイス。Livenを超える日本語完全対応の無料ヘルスケアコーチング。',
       ),
       (
         Icons.shopping_cart_outlined,
         '0xFFF97316',
         'ショッピングリスト',
-        '買い物リスト作成・価格管理・購入チェックをスマート管理。Amazonの購入管理機能を超えるAI節約提案付きの完全無料ショッピングアシスタント。'
+        '買い物リスト作成・価格管理・購入チェックをスマート管理。Amazonの購入管理機能を超えるAI節約提案付きの完全無料ショッピングアシスタント。',
       ),
       (
         Icons.notifications_active,
         '0xFF5865F2',
         'Discord 通知連携',
-        'タスク完了・習慣達成・日次サマリーをリアルタイムでDiscordチャンネルに通知。Webhook URLを設定するだけで即稼働する自動通知ルーティング。'
+        'タスク完了・習慣達成・日次サマリーをリアルタイムでDiscordチャンネルに通知。Webhook URLを設定するだけで即稼働する自動通知ルーティング。',
       ),
       (
         Icons.notifications_active,
         '0xFF06C755',
         'LINE 通知連携',
-        'タスク完了・習慣達成・ゴール達成をLINEにリアルタイム通知。LINE Notify トークン1枚で設定完了。LINEを超えるタスク×通知の完全統合。'
+        'タスク完了・習慣達成・ゴール達成をLINEにリアルタイム通知。LINE Notify トークン1枚で設定完了。LINEを超えるタスク×通知の完全統合。',
       ),
       (
         Icons.merge_type,
         '0xFF24292F',
         'GitHub PR 管理',
-        'GitHubリポジトリのPull Request一覧・レビュー状況・マージ統計をアプリ内で一元管理。開発とライフマネジメントを自分株式会社に完全統合。'
+        'GitHubリポジトリのPull Request一覧・レビュー状況・マージ統計をアプリ内で一元管理。開発とライフマネジメントを自分株式会社に完全統合。',
       ),
       (
         Icons.psychology_alt,
         '0xFF4338CA',
         '思考妨害パターン診断',
-        '4つの質問で最大の思考妨害要因を特定し禁欲ガードの対象を自動設定。SNS・ゲーム・動画など6カテゴリから衝動パターンを診断し、集中が途切れる時間帯と前兆サインを可視化するAIセルフケアツール。'
+        '4つの質問で最大の思考妨害要因を特定し禁欲ガードの対象を自動設定。SNS・ゲーム・動画など6カテゴリから衝動パターンを診断し、集中が途切れる時間帯と前兆サインを可視化するAIセルフケアツール。',
       ),
       (
         Icons.analytics,
         '0xFF6366F1',
         '週次 Slip パターンレポート',
-        '思考妨害・衝動のslipを曜日別・時間帯別・要因別に分析。30日間のデータから最も危険な時間帯と要因を特定し、改善トレンドを可視化。'
+        '思考妨害・衝動のslipを曜日別・時間帯別・要因別に分析。30日間のデータから最も危険な時間帯と要因を特定し、改善トレンドを可視化。',
       ),
       (
         Icons.flag,
         '0xFF10B981',
         'ゴール追跡',
-        'OKR形式でスモールゴールから人生目標まで一元管理。進捗追跡・マイルストーン設定・期限リマインドをAIが支援し、目標達成率を劇的に向上。'
+        'OKR形式でスモールゴールから人生目標まで一元管理。進捗追跡・マイルストーン設定・期限リマインドをAIが支援し、目標達成率を劇的に向上。',
       ),
       (
         Icons.auto_awesome,
         '0xFF8B5CF6',
         'AIサマリー',
-        'ノート・タスク・習慣データをAIが自動要約。1日・1週間・1ヶ月の活動を3行でまとめ、意思決定に必要なインサイトを即座に提供。'
+        'ノート・タスク・習慣データをAIが自動要約。1日・1週間・1ヶ月の活動を3行でまとめ、意思決定に必要なインサイトを即座に提供。',
       ),
       (
         Icons.trending_up,
         '0xFF0EA5E9',
         '収益予測',
-        '過去データと市場トレンドからAIが収益を予測。キャッシュフロー・売上推移を視覚化してビジネス計画を最適化。MoneyForwardを超えるAI財務分析。'
+        '過去データと市場トレンドからAIが収益を予測。キャッシュフロー・売上推移を視覚化してビジネス計画を最適化。MoneyForwardを超えるAI財務分析。',
       ),
       (
         Icons.bookmarks,
         '0xFFF59E0B',
         'ブックマーク同期',
-        'ブラウザのブックマークをアプリと双方向同期。AI自動タグ付け・分類・検索で必要な情報を即座に発見。Notionリンクデータベースを超える知識管理。'
+        'ブラウザのブックマークをアプリと双方向同期。AI自動タグ付け・分類・検索で必要な情報を即座に発見。Notionリンクデータベースを超える知識管理。',
       ),
       (
         Icons.wb_sunny_outlined,
         '0xFF06B6D4',
         '天気・環境ウィジェット',
-        '現在地の天気・気温・紫外線をダッシュボードに常時表示。天気に合わせた活動提案・外出可否判断をAIが自動生成し、ライフマネジメントと環境情報を完全統合。'
+        '現在地の天気・気温・紫外線をダッシュボードに常時表示。天気に合わせた活動提案・外出可否判断をAIが自動生成し、ライフマネジメントと環境情報を完全統合。',
       ),
       (
         Icons.monetization_on,
         '0xFFEF4444',
         'アフィリエイト管理',
-        'アフィリエイトリンク管理・クリック追跡・報酬分析を一元化。収益源の多様化を自動最適化するAI収益化エンジン。'
+        'アフィリエイトリンク管理・クリック追跡・報酬分析を一元化。収益源の多様化を自動最適化するAI収益化エンジン。',
       ),
       (
         Icons.business_center,
         '0xFF0F766E',
         'CRM・営業パイプライン',
-        'リード管理・商談ステージ追跡・成約予測をAIが自動化。Salesforceを超えるパーソナルCRMを無料で実現。'
+        'リード管理・商談ステージ追跡・成約予測をAIが自動化。Salesforceを超えるパーソナルCRMを無料で実現。',
       ),
       (
         Icons.table_chart,
         '0xFF6366F1',
         'スプレッドシートDB',
-        'Notionデータベースを超える多機能スプレッドシート。フィルタ・ソート・数式・API連携に対応した柔軟なデータ管理。'
+        'Notionデータベースを超える多機能スプレッドシート。フィルタ・ソート・数式・API連携に対応した柔軟なデータ管理。',
       ),
       (
         Icons.schedule_send,
         '0xFFEC4899',
         'SNS投稿スケジューラー',
-        'X/Instagram/FacebookへのSNS投稿を最適時間に自動予約・一括投稿。AIが投稿内容の改善案も提案するコンテンツマーケ自動化ツール。'
+        'X/Instagram/FacebookへのSNS投稿を最適時間に自動予約・一括投稿。AIが投稿内容の改善案も提案するコンテンツマーケ自動化ツール。',
       ),
       (
         Icons.subscriptions,
         '0xFF7C3AED',
         'サブスク課金管理',
-        'サブスクリプション請求・顧客管理・解約防止分析を自動化。Stripeを超える自分株式会社内蔵の課金エンジン。'
+        'サブスクリプション請求・顧客管理・解約防止分析を自動化。Stripeを超える自分株式会社内蔵の課金エンジン。',
       ),
       (
         Icons.contacts,
         '0xFF0369A1',
         'アドレス帳・人脈管理',
-        '連絡先・誕生日・交流履歴・SNSリンクを一元管理。LinkedInを超えるパーソナルCRM×人脈グラフで関係性を見える化。'
+        '連絡先・誕生日・交流履歴・SNSリンクを一元管理。LinkedInを超えるパーソナルCRM×人脈グラフで関係性を見える化。',
       ),
       (
         Icons.book,
         '0xFF7E22CE',
         '読書リスト管理',
-        '読みたい本・読了記録・メモ・評価を一元管理。AIが次に読むべき本を推薦するパーソナル書評プラットフォーム。'
+        '読みたい本・読了記録・メモ・評価を一元管理。AIが次に読むべき本を推薦するパーソナル書評プラットフォーム。',
       ),
       (
         Icons.checkroom,
         '0xFFF97316',
         'ワードローブ管理',
-        '所持服の登録・コーデ提案・購入計画をAIが管理。ファッションコストを削減しながらスタイルを最適化。'
+        '所持服の登録・コーデ提案・購入計画をAIが管理。ファッションコストを削減しながらスタイルを最適化。',
       ),
       (
         Icons.eco,
         '0xFF22C55E',
         'カーボンフットプリント',
-        '日常行動のCO2排出量を自動計算・可視化。移動・食事・エネルギー消費から個人の環境負荷を数値化し持続可能な生活を設計。'
+        '日常行動のCO2排出量を自動計算・可視化。移動・食事・エネルギー消費から個人の環境負荷を数値化し持続可能な生活を設計。',
       ),
       (
         Icons.timer_outlined,
         '0xFF6366F1',
         'タイムトラッキング',
-        'プロジェクト別・タスク別の作業時間を自動記録。Toggleを超えるAI分析付き時間管理で生産性の無駄を即特定。'
+        'プロジェクト別・タスク別の作業時間を自動記録。Toggleを超えるAI分析付き時間管理で生産性の無駄を即特定。',
       ),
       (
         Icons.menu_book,
         '0xFF0F766E',
         'Wikiデータベース',
-        '階層式Wikiページ・社内マニュアル・チームナレッジを一元管理。Confluenceを超える個人・チーム向け知識ベースを完全無料で構築。'
+        '階層式Wikiページ・社内マニュアル・チームナレッジを一元管理。Confluenceを超える個人・チーム向け知識ベースを完全無料で構築。',
       ),
       (
         Icons.view_kanban,
         '0xFFF59E0B',
         'WIPリミット管理',
-        '進行中タスク数の上限設定・ボトルネック検出・フロー可視化。Jiraを超えるリーンカンバン管理で作業効率を最大化。'
+        '進行中タスク数の上限設定・ボトルネック検出・フロー可視化。Jiraを超えるリーンカンバン管理で作業効率を最大化。',
       ),
       (
         Icons.rss_feed,
         '0xFFEC4899',
         '技術ブログトラッカー',
-        'Zenn/Qiita/note/dev.toの投稿管理・PV分析・読者獲得トレンドを一元追跡。エンジニアの影響力成長を数値化。'
+        'Zenn/Qiita/note/dev.toの投稿管理・PV分析・読者獲得トレンドを一元追跡。エンジニアの影響力成長を数値化。',
       ),
       (
         Icons.calendar_view_day,
         '0xFF6366F1',
         '予約・アポイント管理',
-        '来客予約・医療予約・会議調整をカレンダー連携で一元管理。Calendlyを超えるAI最適スケジューリングシステム。'
+        '来客予約・医療予約・会議調整をカレンダー連携で一元管理。Calendlyを超えるAI最適スケジューリングシステム。',
       ),
       (
         Icons.terminal,
         '0xFF0F172A',
         'API プレイグラウンド',
-        'REST API・Supabase EF・外部APIをブラウザから即テスト。Postmanを超えるアプリ内API開発環境で実装速度を10倍に。'
+        'REST API・Supabase EF・外部APIをブラウザから即テスト。Postmanを超えるアプリ内API開発環境で実装速度を10倍に。',
       ),
       (
         Icons.download,
         '0xFF0891B2',
         'データ分析エクスポート',
-        'ノート・タスク・習慣・財務データをCSV/JSON/PDFで一括エクスポート。BIツールへの連携や外部分析が自由自在。'
+        'ノート・タスク・習慣・財務データをCSV/JSON/PDFで一括エクスポート。BIツールへの連携や外部分析が自由自在。',
       ),
       (
         Icons.local_parking,
         '0xFF374151',
         '駐車場予約管理',
-        '駐車場の空き確認・予約・支払い管理をアプリ内で完結。物件・店舗・イベント会場の駐車枠を効率的に運用。'
+        '駐車場の空き確認・予約・支払い管理をアプリ内で完結。物件・店舗・イベント会場の駐車枠を効率的に運用。',
       ),
       (
         Icons.view_in_ar,
         '0xFF6D28D9',
         'AR ナビゲーション',
-        '拡張現実(AR)で店舗・施設・商品へのルートをスマホ画面に重畳表示。競合21社に存在しない空間×AIナビゲーション機能。'
+        '拡張現実(AR)で店舗・施設・商品へのルートをスマホ画面に重畳表示。競合21社に存在しない空間×AIナビゲーション機能。',
       ),
       (
         Icons.account_balance,
         '0xFF059669',
         '資産管理',
-        '不動産・株・仮想通貨・現金など全資産をポートフォリオ形式で一元管理。AIが資産配分の最適化提案をリアルタイムに実行。'
+        '不動産・株・仮想通貨・現金など全資産をポートフォリオ形式で一元管理。AIが資産配分の最適化提案をリアルタイムに実行。',
       ),
       (
         Icons.trending_up,
         '0xFFF97316',
         '行動・習慣ログ詳細',
-        '1分単位の行動ログ・習慣連続記録・パターン分析をAIが自動集計。自分の生活リズムを科学的に可視化して最適な時間設計を実現。'
+        '1分単位の行動ログ・習慣連続記録・パターン分析をAIが自動集計。自分の生活リズムを科学的に可視化して最適な時間設計を実現。',
       ),
       (
         Icons.delete_sweep,
         '0xFF7E22CE',
         '断捨離アシスト',
-        'モノ・デジタルファイル・人間関係の断捨離を3ステップでAI支援。手放す/残す/保留を即決できる捨て活チェックリストで身軽な自分株式会社を構築。'
+        'モノ・デジタルファイル・人間関係の断捨離を3ステップでAI支援。手放す/残す/保留を即決できる捨て活チェックリストで身軽な自分株式会社を構築。',
       ),
       (
         Icons.lock_clock,
         '0xFF0F172A',
         'プリズンモード',
-        'スマホ依存・SNS中毒を断ち切る超高集中モード。指定時間内はSNS/動画を完全シャットアウトし、思考妨害をゼロに。刑務所級の集中力を自分で設計できる唯一のツール。'
+        'スマホ依存・SNS中毒を断ち切る超高集中モード。指定時間内はSNS/動画を完全シャットアウトし、思考妨害をゼロに。刑務所級の集中力を自分で設計できる唯一のツール。',
       ),
       (
         Icons.hub,
         '0xFF1D9BF0',
         'ソーシャルフィード',
-        'コミュニティメンバーの達成記録・習慣ストリーク・ノート共有をタイムラインで表示。FacebookとDiscordを超えるパーソナル×コミュニティ融合フィード。'
+        'コミュニティメンバーの達成記録・習慣ストリーク・ノート共有をタイムラインで表示。FacebookとDiscordを超えるパーソナル×コミュニティ融合フィード。',
       ),
       (
         Icons.psychology,
         '0xFF10B981',
         '意思決定チェック',
-        '重要な判断を迷わせる「認知バイアス」をAIが診断・可視化。見栄・衝動・過去の呪縛から解放されたクリアな意思決定を支援する競合21社にない独自機能。'
+        '重要な判断を迷わせる「認知バイアス」をAIが診断・可視化。見栄・衝動・過去の呪縛から解放されたクリアな意思決定を支援する競合21社にない独自機能。',
       ),
       (
         Icons.account_balance_wallet,
         '0xFF6366F1',
         'デジタルウォレット',
-        'ポイント・ギフト券・仮想通貨・電子マネー残高を一元管理。多様化する決済手段をスマートに統合して家計管理と資産管理を完全連携。'
+        'ポイント・ギフト券・仮想通貨・電子マネー残高を一元管理。多様化する決済手段をスマートに統合して家計管理と資産管理を完全連携。',
       ),
       (
         Icons.cruelty_free,
         '0xFFA855F7',
         'バーチャルペット',
-        'アプリのタスク達成・習慣継続でペットが成長するゲーミフィケーション。モチベーション維持の最強トリガーを個性的なデジタルコンパニオンで実現。'
+        'アプリのタスク達成・習慣継続でペットが成長するゲーミフィケーション。モチベーション維持の最強トリガーを個性的なデジタルコンパニオンで実現。',
       ),
       (
         Icons.home_repair_service,
         '0xFF0F766E',
         'リアル断捨離記録',
-        '実物のモノを写真で記録しながら断捨離を進行。手放した物品数・削減重量・解放スペースを数値化して身軽さを可視化。'
+        '実物のモノを写真で記録しながら断捨離を進行。手放した物品数・削減重量・解放スペースを数値化して身軽さを可視化。',
       ),
       (
         Icons.anchor,
         '0xFF4338CA',
         '思考アンカー',
-        '集中を乱す雑念・不安・タスク割り込みをその場でキャプチャしアンカーに変換。後で必ず戻ると約束することで今この瞬間の集中を守る認知制御機能。'
+        '集中を乱す雑念・不安・タスク割り込みをその場でキャプチャしアンカーに変換。後で必ず戻ると約束することで今この瞬間の集中を守る認知制御機能。',
       ),
       (
         Icons.flash_on,
         '0xFF8B5CF6',
         '思考キャプチャ',
-        'ひらめき・アイデア・メモを0.5秒でキャプチャ。Inboxに溜めてAIが後から自動分類・タグ付けするGTD式思考管理システム。'
+        'ひらめき・アイデア・メモを0.5秒でキャプチャ。Inboxに溜めてAIが後から自動分類・タグ付けするGTD式思考管理システム。',
       ),
       (
         Icons.manage_search,
         '0xFF0EA5E9',
         'セマンティック検索',
-        'キーワード一致ではなく意味・文脈で全ノート・タスク・習慣を横断検索。Notionの検索機能を超えるAI意味理解型の全文検索エンジン。'
+        'キーワード一致ではなく意味・文脈で全ノート・タスク・習慣を横断検索。Notionの検索機能を超えるAI意味理解型の全文検索エンジン。',
       ),
       (
         Icons.receipt_long,
         '0xFF059669',
         '購買ログ・支出記録',
-        '全購入品の記録・家計簿自動分類・支出トレンド分析。Amazonの購買履歴を超える節約インサイトをAIがリアルタイムで提供。'
+        '全購入品の記録・家計簿自動分類・支出トレンド分析。Amazonの購買履歴を超える節約インサイトをAIがリアルタイムで提供。',
       ),
       (
         Icons.audiotrack,
         '0xFF6D28D9',
         'オーディオエフェクト',
-        'ギター・楽器・音声にエフェクト処理・音質補正・ミキシングをブラウザだけで実現。GarageBandを超えるポータブル音楽制作スタジオ。'
+        'ギター・楽器・音声にエフェクト処理・音質補正・ミキシングをブラウザだけで実現。GarageBandを超えるポータブル音楽制作スタジオ。',
       ),
       (
         Icons.image,
         '0xFFF97316',
         'AI画像生成',
-        'テキストから画像を即時生成。プレゼン・SNS・ブログ素材をAIが自動制作。Midjourneyを超えるライフマネジメント統合型AIクリエイティブツール。'
+        'テキストから画像を即時生成。プレゼン・SNS・ブログ素材をAIが自動制作。Midjourneyを超えるライフマネジメント統合型AIクリエイティブツール。',
       ),
       (
         Icons.search,
         '0xFF0F766E',
         'AI横断検索',
-        '自分株式会社の全データ(ノート・タスク・習慣・財務)をAIが横断検索。Notionの検索・Googleを超えるパーソナルナレッジ検索エンジン。'
+        '自分株式会社の全データ(ノート・タスク・習慣・財務)をAIが横断検索。Notionの検索・Googleを超えるパーソナルナレッジ検索エンジン。',
       ),
       (
         Icons.balance,
         '0xFF4338CA',
         '現実確認チェック',
-        '自分の目標・計画・実績を客観的にスコアリングし「見栄・感情・バイアス」を排除した現実ベースの意思決定を支援。唯一無二のAI自己客観化機能。'
+        '自分の目標・計画・実績を客観的にスコアリングし「見栄・感情・バイアス」を排除した現実ベースの意思決定を支援。唯一無二のAI自己客観化機能。',
       ),
       (
         Icons.compare_arrows,
         '0xFF8B5CF6',
         '相性チェック',
-        '人・目標・習慣・ライフスタイルの相性をAIが多角分析。恋愛・ビジネスパートナー・チームメンバーとの相性スコアを科学的に算出。'
+        '人・目標・習慣・ライフスタイルの相性をAIが多角分析。恋愛・ビジネスパートナー・チームメンバーとの相性スコアを科学的に算出。',
       ),
       (
         Icons.analytics_outlined,
         '0xFFFE4E1E',
         'サイトマップ分析',
-        'サイトの全URLを可視化・SEO健全性チェック・クロール最適化をAIが自動分析。Googleサーチコンソールを超えるサイト構造把握ツール。'
+        'サイトの全URLを可視化・SEO健全性チェック・クロール最適化をAIが自動分析。Googleサーチコンソールを超えるサイト構造把握ツール。',
       ),
       (
         Icons.feedback,
         '0xFF22C55E',
         '顧客フィードバック',
-        'ユーザーの声・評価・要望を一元収集・AI分析・優先度付け。Intercomを超える個人×AI顧客インサイト管理プラットフォーム。'
+        'ユーザーの声・評価・要望を一元収集・AI分析・優先度付け。Intercomを超える個人×AI顧客インサイト管理プラットフォーム。',
       ),
       (
         Icons.history,
         '0xFF0891B2',
         '変更履歴管理',
-        'コード・ドキュメント・設定の変更履歴を自動追跡。Changelogを自動生成してチームと変更情報を透明に共有。'
+        'コード・ドキュメント・設定の変更履歴を自動追跡。Changelogを自動生成してチームと変更情報を透明に共有。',
       ),
       (
         Icons.payments,
         '0xFF10B981',
         '支払いチャンネル台帳',
-        '複数の支払い手段・口座・チャンネルを台帳形式で一元管理。誰に何をいくら支払ったかをAIが自動仕訳・可視化。'
+        '複数の支払い手段・口座・チャンネルを台帳形式で一元管理。誰に何をいくら支払ったかをAIが自動仕訳・可視化。',
       ),
       (
         Icons.smart_toy,
         '0xFF7C3AED',
         'AI自律エージェント',
-        '指定ゴールに向けてタスクを自律分解・実行するAIエージェント。AutoGPTを超える自分株式会社専用の自律実行AI。人間が指示しなくても仕事が進む。'
+        '指定ゴールに向けてタスクを自律分解・実行するAIエージェント。AutoGPTを超える自分株式会社専用の自律実行AI。人間が指示しなくても仕事が進む。',
       ),
       (
         Icons.support_agent,
         '0xFF0369A1',
         'AI仮想秘書',
-        'スケジュール・タスク・メール返信をAIが全自動管理。アシスタント雇用コストをゼロにする自分株式会社の専属デジタル秘書。'
+        'スケジュール・タスク・メール返信をAIが全自動管理。アシスタント雇用コストをゼロにする自分株式会社の専属デジタル秘書。',
       ),
       (
         Icons.insert_chart,
         '0xFF6366F1',
         '利用統計ダッシュボード',
-        'アプリの全機能利用状況・ユーザー行動・機能別エンゲージメントをリアルタイム可視化。自分のライフデータを科学する管理者コックピット。'
+        'アプリの全機能利用状況・ユーザー行動・機能別エンゲージメントをリアルタイム可視化。自分のライフデータを科学する管理者コックピット。',
       ),
       (
         Icons.label,
         '0xFFF59E0B',
         'タグ・カテゴリ管理',
-        'ノート・タスク・習慣・ファイルのタグ体系を一元設計。AI自動タグ付けと手動分類を組み合わせた最強の知識分類システム。'
+        'ノート・タスク・習慣・ファイルのタグ体系を一元設計。AI自動タグ付けと手動分類を組み合わせた最強の知識分類システム。',
       ),
       (
         Icons.assistant,
         '0xFF10B981',
         'AI文章添削',
-        '日本語文章の誤字・文法・表現をAIがリアルタイム添削。ブログ・メール・報告書の品質を即座に向上させる自分株式会社内蔵の校正エンジン。'
+        '日本語文章の誤字・文法・表現をAIがリアルタイム添削。ブログ・メール・報告書の品質を即座に向上させる自分株式会社内蔵の校正エンジン。',
       ),
       (
         Icons.workspace_premium,
         '0xFFDC2626',
         'プレミアムコンテンツ販売',
-        'ノート・テンプレート・スキルをコンテンツとして販売・収益化。Gumroadを超えるナレッジマーケットプレイスを自分株式会社に内蔵。'
+        'ノート・テンプレート・スキルをコンテンツとして販売・収益化。Gumroadを超えるナレッジマーケットプレイスを自分株式会社に内蔵。',
       ),
       (
         Icons.groups,
         '0xFF6D28D9',
         'オンラインコミュニティ',
-        'テーマ別コミュニティ・勉強会・習慣チャレンジをアプリ内で開催。Discordを超える目的特化型コミュニティプラットフォーム。'
+        'テーマ別コミュニティ・勉強会・習慣チャレンジをアプリ内で開催。Discordを超える目的特化型コミュニティプラットフォーム。',
       ),
       (
         Icons.favorite_border,
         '0xFFEC4899',
         'AIメンタルヘルスケア',
-        '気分・ストレス・睡眠を毎日記録しAIが統合分析。Calm/Headspaceを超えるパーソナライズドメンタルウェルネスを自分株式会社に内蔵。'
+        '気分・ストレス・睡眠を毎日記録しAIが統合分析。Calm/Headspaceを超えるパーソナライズドメンタルウェルネスを自分株式会社に内蔵。',
       ),
       (
         Icons.work_outline,
         '0xFF0891B2',
         'フリーランス管理',
-        '案件・請求書・契約・稼働時間・確定申告を一元管理。freee/MoneyForwardを超える個人事業主向けオールインワン経営管理ツール。'
+        '案件・請求書・契約・稼働時間・確定申告を一元管理。freee/MoneyForwardを超える個人事業主向けオールインワン経営管理ツール。',
       ),
       (
         Icons.present_to_all,
         '0xFF7C3AED',
         'AIプレゼンビルダー',
-        'テーマを入力するだけでAIがスライド構成を自動生成。Gamma/Canva/Beautiful.aiを超えるライフマネジメント統合型AIプレゼン作成エンジン。'
+        'テーマを入力するだけでAIがスライド構成を自動生成。Gamma/Canva/Beautiful.aiを超えるライフマネジメント統合型AIプレゼン作成エンジン。',
       ),
       (
         Icons.cloud_sync,
         '0xFF0F766E',
         'データバックアップ',
-        '全データを自動バックアップ・クラウド同期・ワンクリック復元。Dropbox/iCloudを超えるライフデータ保全インフラが自分株式会社に標準搭載。'
+        '全データを自動バックアップ・クラウド同期・ワンクリック復元。Dropbox/iCloudを超えるライフデータ保全インフラが自分株式会社に標準搭載。',
       ),
       (
         Icons.calendar_view_week,
         '0xFFD97706',
         'コンテンツカレンダー',
-        'SNS・ブログ・動画の制作スケジュールをカレンダーで一元管理。コンテンツ戦略・A/Bテスト計画・公開スケジュールを可視化するクリエイター向け投稿管理ツール。'
+        'SNS・ブログ・動画の制作スケジュールをカレンダーで一元管理。コンテンツ戦略・A/Bテスト計画・公開スケジュールを可視化するクリエイター向け投稿管理ツール。',
       ),
       (
         Icons.savings,
         '0xFF10B981',
         '家計・予算プランナー',
-        '月次予算設定・支出追跡・カテゴリ別分析・AI節約提案。MoneyForward/Zaimを超える家計管理とビジネス財務を同一アプリで完結させるスマート予算管理ツール。'
+        '月次予算設定・支出追跡・カテゴリ別分析・AI節約提案。MoneyForward/Zaimを超える家計管理とビジネス財務を同一アプリで完結させるスマート予算管理ツール。',
       ),
       (
         Icons.psychology_outlined,
         '0xFF8B5CF6',
         'ブレインダンプ',
-        '頭の中にある全てをGTD式に書き出し・AIが自動分類。タスク・アイデア・心配事を即座にキャプチャしマインドをクリアにするEvernoteを超える思考整理ツール。'
+        '頭の中にある全てをGTD式に書き出し・AIが自動分類。タスク・アイデア・心配事を即座にキャプチャしマインドをクリアにするEvernoteを超える思考整理ツール。',
       ),
       (
         Icons.account_tree_outlined,
         '0xFF0891B2',
         'プロジェクト管理',
-        'ガントチャート・スプリント計画・マイルストーン・依存関係を一元管理。Asana/Jira/GitHub Projectsを超えるライフマネジメント統合型プロジェクト管理ツール。'
+        'ガントチャート・スプリント計画・マイルストーン・依存関係を一元管理。Asana/Jira/GitHub Projectsを超えるライフマネジメント統合型プロジェクト管理ツール。',
       ),
       (
         Icons.contact_mail_outlined,
         '0xFFD97706',
         '名刺管理',
-        'OCR+AI連絡先自動抽出・タグ管理・人脈グラフ可視化。Eightを超えるAI名刺管理とビジネスネットワーキングを自分株式会社に標準搭載。'
+        'OCR+AI連絡先自動抽出・タグ管理・人脈グラフ可視化。Eightを超えるAI名刺管理とビジネスネットワーキングを自分株式会社に標準搭載。',
       ),
       (
         Icons.family_restroom,
         '0xFFEC4899',
         '家族カレンダー',
-        '家族のスケジュール共有・タスク割当・誕生日・記念日管理を一元化。Googleカレンダー家族共有を超えるプライバシー重視の家族専用スマートカレンダー。'
+        '家族のスケジュール共有・タスク割当・誕生日・記念日管理を一元化。Googleカレンダー家族共有を超えるプライバシー重視の家族専用スマートカレンダー。',
       ),
       (
         Icons.school,
         '0xFFFF6B35',
         'AI大学 (80社マスター)',
-        '80社のAIプロバイダーをクイズ形式で学習。FSRS間隔反復アルゴリズムで最適なタイミングに復習。競合21社に存在しないAI業界丸ごと習得プラットフォーム。'
+        '80社のAIプロバイダーをクイズ形式で学習。FSRS間隔反復アルゴリズムで最適なタイミングに復習。競合21社に存在しないAI業界丸ごと習得プラットフォーム。',
       ),
       (
         Icons.view_timeline,
         '0xFF3D5AFE',
         'WBS・ガントチャート',
-        'マイルストーン・タスク・進捗をガントチャートで可視化。α/β/v1リリース計画を全チームで共有。Asanaを超えるプロジェクト管理をライフマネジメントに統合。'
+        'マイルストーン・タスク・進捗をガントチャートで可視化。α/β/v1リリース計画を全チームで共有。Asanaを超えるプロジェクト管理をライフマネジメントに統合。',
       ),
       (
         Icons.psychology,
         '0xFF10B981',
         'FSRS間隔反復学習',
-        '科学的な忘却曲線アルゴリズム(FSRS)で学習カードを最適スケジューリング。今日の復習件数を可視化し、記憶定着率を最大化する次世代スペースドリピティションシステム。'
+        '科学的な忘却曲線アルゴリズム(FSRS)で学習カードを最適スケジューリング。今日の復習件数を可視化し、記憶定着率を最大化する次世代スペースドリピティションシステム。',
       ),
       (
         Icons.sports,
         '0xFFF59E0B',
         '競馬AI自動予想',
-        'NAR/JRAのレース情報をAIが自動収集・分析・予想。独自スコアリングアルゴリズムで穴馬・本命を特定。競合21社に存在しない趣味×AIライフマネジメント統合機能。'
+        'NAR/JRAのレース情報をAIが自動収集・分析・予想。独自スコアリングアルゴリズムで穴馬・本命を特定。競合21社に存在しない趣味×AIライフマネジメント統合機能。',
       ),
     ];
 
@@ -2799,10 +2763,10 @@ $input
             width: double.infinity,
             height: 46,
             child: FilledButton.icon(
-              onPressed: _scrollToAuthSection,
+              onPressed: () => Navigator.of(context).pushNamed('/billing'),
               icon: const Icon(Icons.rocket_launch, size: 16),
               label: const Text(
-                '無料で全機能を使う',
+                'Proプランを見る',
                 style: TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.w700,
@@ -2850,8 +2814,11 @@ $input
           const SizedBox(height: 8),
           const Text(
             'ファイルをアップロードするだけで、過去のデータがそのまま引き継げます。移行後も元のサービスを使い続けながら、少しずつ切り替えられます。',
-            style:
-                TextStyle(fontSize: 12, color: Color(0xB3FFFFFF), height: 1.6),
+            style: TextStyle(
+              fontSize: 12,
+              color: Color(0xB3FFFFFF),
+              height: 1.6,
+            ),
           ),
           const SizedBox(height: 12),
           OutlinedButton.icon(
@@ -2864,10 +2831,7 @@ $input
             icon: const Icon(Icons.arrow_forward, size: 16),
             label: const Text(
               '登録なしでインポートを試す',
-              style: TextStyle(
-                fontWeight: FontWeight.w700,
-                height: 1.5,
-              ),
+              style: TextStyle(fontWeight: FontWeight.w700, height: 1.5),
             ),
           ),
         ],
@@ -2891,7 +2855,7 @@ $input
       const _CompetitorRow('Google Workspace', '¥680〜/月', '80+', false),
       const _CompetitorRow('Microsoft 365', '¥1,241〜/月', '90+', false),
       const _CompetitorRow('LINE AI', '¥750〜/月 (5項目)', '5', false),
-      const _CompetitorRow('自分株式会社', '完全無料', '21サービス分', true),
+      const _CompetitorRow('自分株式会社', '無料コア + Pro', '21サービス分', true),
     ];
 
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -2909,17 +2873,11 @@ $input
         children: [
           const Row(
             children: [
-              Text(
-                '💰',
-                style: TextStyle(
-                  fontSize: 20,
-                  height: 1.4,
-                ),
-              ),
+              Text('💰', style: TextStyle(fontSize: 20, height: 1.4)),
               SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  '他社は有料。自分株式会社は完全無料。',
+                  'コアは無料。Proで支援と上限緩和。',
                   style: TextStyle(
                     fontSize: 17,
                     fontWeight: FontWeight.w800,
@@ -2932,7 +2890,7 @@ $input
           ),
           const SizedBox(height: 4),
           const Text(
-            '月額数千円のSaaS21本分の機能を、無料で使えます。',
+            '日常の基本機能は無料で使えます。Pro/Teamは決済後に追加機能と上限緩和を提供します。',
             style: TextStyle(
               fontSize: 13,
               color: Color(0xFF78350F),
@@ -2962,8 +2920,9 @@ $input
                       style: TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w700,
-                        color:
-                            row.isOurs ? Colors.white : const Color(0xFF1E293B),
+                        color: row.isOurs
+                            ? Colors.white
+                            : const Color(0xFF1E293B),
                         height: 1.5,
                       ),
                     ),
@@ -2974,8 +2933,9 @@ $input
                       row.price,
                       style: TextStyle(
                         fontSize: 13,
-                        fontWeight:
-                            row.isOurs ? FontWeight.w800 : FontWeight.w600,
+                        fontWeight: row.isOurs
+                            ? FontWeight.w800
+                            : FontWeight.w600,
                         color: row.isOurs
                             ? const Color(0xFFFFC107)
                             : const Color(0xFF64748B),
@@ -3013,19 +2973,19 @@ $input
         Icons.play_circle_outline,
         '1. 無料トライアル',
         'まず登録なしで1件試す。AIが今日の最優先タスクを提案。',
-        Color(0xFF6366F1)
+        Color(0xFF6366F1),
       ),
       (
         Icons.save_outlined,
         '2. 無料登録して保存',
         'メール認証だけで即登録。提案を保存して明日も続きから再開。',
-        Color(0xFF10B981)
+        Color(0xFF10B981),
       ),
       (
         Icons.upload_file_outlined,
         '3. 既存データを移行',
         'NotionのCSV・EvernoteのENEXをインポート。移行コストゼロ。',
-        Color(0xFFF59E0B)
+        Color(0xFFF59E0B),
       ),
     ];
 
@@ -3036,8 +2996,9 @@ $input
         color: isDarkSteps ? const Color(0xFF1A1A1A) : Colors.white,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color:
-              isDarkSteps ? const Color(0xFF2A2A2A) : const Color(0xFFE2E8F0),
+          color: isDarkSteps
+              ? const Color(0xFF2A2A2A)
+              : const Color(0xFFE2E8F0),
         ),
         boxShadow: [
           BoxShadow(
@@ -3166,10 +3127,7 @@ $input
               const SizedBox(height: 6),
               const Text(
                 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
-                style: TextStyle(
-                  color: Color(0xFF64748B),
-                  height: 1.5,
-                ),
+                style: TextStyle(color: Color(0xFF64748B), height: 1.5),
               ),
               const SizedBox(height: 12),
               Wrap(
@@ -3181,27 +3139,22 @@ $input
                     label: const Text('今日の最優先'),
                     onPressed: _isTrialLoading
                         ? null
-                        : () => _runQuickTrialSample(
-                              '今日の最優先タスクを1件に絞りたい',
-                            ),
+                        : () => _runQuickTrialSample('今日の最優先タスクを1件に絞りたい'),
                   ),
                   ActionChip(
                     avatar: const Icon(Icons.event_note, size: 18),
                     label: const Text('今日の計画を立てる'),
                     onPressed: _isTrialLoading
                         ? null
-                        : () => _runQuickTrialSample(
-                              '今日1日の計画を立てて、最も重要なことに集中したい',
-                            ),
+                        : () =>
+                              _runQuickTrialSample('今日1日の計画を立てて、最も重要なことに集中したい'),
                   ),
                   ActionChip(
                     avatar: const Icon(Icons.done_all, size: 18),
                     label: const Text('先送り解消'),
                     onPressed: _isTrialLoading
                         ? null
-                        : () => _runQuickTrialSample(
-                              '今いちばん先送りしていることを片付けたい',
-                            ),
+                        : () => _runQuickTrialSample('今いちばん先送りしていることを片付けたい'),
                   ),
                 ],
               ),
@@ -3308,15 +3261,15 @@ $input
     const faqs = [
       (
         q: 'Notion AI がカレンダー・メール・Slack連携を始めました。それでも違いはありますか?',
-        a: '2026年4月にNotion AIはカレンダー・Mail・Slack統合をGA化しました。ただし「財務管理」「健康・習慣管理」「KPI＝昨日の自分（自己比較）」「日本語文化対応」は依然として対象外です。自分株式会社はAIが「今日やるべき1件」を決め、MoneyForward型資産管理・習慣化・AI診断まで人生6部署を一元管理します。Notionは仕事を整理しますが、自分株式会社は人生全体を整理します。しかも完全無料です。',
+        a: '2026年4月にNotion AIはカレンダー・Mail・Slack統合をGA化しました。ただし「財務管理」「健康・習慣管理」「KPI＝昨日の自分（自己比較）」「日本語文化対応」は依然として対象外です。自分株式会社はAIが「今日やるべき1件」を決め、MoneyForward型資産管理・習慣化・AI診断まで人生6部署を一元管理します。Notionは仕事を整理しますが、自分株式会社は人生全体を整理します。基本機能は無料で、Pro/Teamで上限緩和と支援導線を用意します。',
       ),
       (
         q: '12部署20人のAI組織OSって何?',
         a: '自分1人で12の仮想部署（企画・開発・営業・CS・法務・広報・調達など）と20人のAIエージェントを動かせる機能です。自然言語でゴールを入力するだけでAIが最適な部署に自動振り分け、タスク分解・進捗管理まで担当します。SlackもJiraも不要で、1アプリで組織のように動けます。',
       ),
       (
-        q: '完全無料で使い続けられますか?',
-        a: 'はい、現在は完全無料です。登録なしでAI提案を1回体験でき、登録後は制限なくすべての機能を利用できます。将来的にプレミアムプランを検討していますが、基本機能は無料のままです。',
+        q: '無料のまま使い続けられますか?',
+        a: 'はい。登録なしでAI提案を1回体験でき、登録後も基本機能は無料で利用できます。Pro/Teamは追加機能・上限緩和・開発支援のための有料プランです。',
       ),
       (
         q: 'NotionやEvernoteからデータを移行できますか?',
@@ -3332,7 +3285,7 @@ $input
       ),
       (
         q: 'Claude Cowork (Anthropic公式) が出ましたが、何が違うの?',
-        a: 'Claude Cowork (Pro \$20/月〜) は仕事のSaaS連携に特化した企業向けAIエージェントです。分離VM内で動作するため、セッションが終わるとデータが消えます。自分株式会社は「財務・健康・習慣・KPI」など人生6部署をSupabaseに永続保存し、昨日の自分と毎日比較できます。仕事だけでなく人生全体を経営したい個人CEOには、完全無料の自分株式会社が最適です。',
+        a: 'Claude Cowork (Pro \$20/月〜) は仕事のSaaS連携に特化した企業向けAIエージェントです。分離VM内で動作するため、セッションが終わるとデータが消えます。自分株式会社は「財務・健康・習慣・KPI」など人生6部署をSupabaseに永続保存し、昨日の自分と毎日比較できます。仕事だけでなく人生全体を経営したい個人CEOには、無料コアから始めて必要に応じてProへ進める自分株式会社が最適です。',
       ),
       (
         q: 'Perplexity Mac Agentに毎日のタスクを任せればよいのでは?',
@@ -3340,11 +3293,11 @@ $input
       ),
       (
         q: 'OpenAI Codex DesktopとClaude Codeが競合していますが、自分株式会社はどう違うの?',
-        a: 'Claude Code（423 plugins / 2,849 skills）とOpenAI Codex Desktop（Computer Use先行・20+ plugins）はツール選択の問題です。自分株式会社のai-hubは両方を含むClaude・OpenAI・Geminiを束ねる「指揮所」です。どのAIを使うかより「AIを使い分けるハブを持つか」が個人CEOの合理解。単一vendorへの依存は負債、分散が資産（原則7）。しかも完全無料。',
+        a: 'Claude Code（423 plugins / 2,849 skills）とOpenAI Codex Desktop（Computer Use先行・20+ plugins）はツール選択の問題です。自分株式会社のai-hubは両方を含むClaude・OpenAI・Geminiを束ねる「指揮所」です。どのAIを使うかより「AIを使い分けるハブを持つか」が個人CEOの合理解。単一vendorへの依存は負債、分散が資産（原則7）。基本機能は無料で、Pro/Teamで継続支援できます。',
       ),
       (
         q: 'Notion Custom Agentsが課金されるようになりましたが?',
-        a: '2026年5月4日からNotion Custom Agentsは\$10/1,000 creditの従量課金（Business/Enterprise add-on）となりました。credit残高を気にしながらAIを使うより、自分株式会社は課金の概念自体が存在しません。予測可能なゼロコストで「KPI＝昨日の自分」を継続観察できます。',
+        a: '2026年5月4日からNotion Custom Agentsは\$10/1,000 creditの従量課金（Business/Enterprise add-on）となりました。credit残高を気にしながらAIを使うより、自分株式会社は無料コアと任意のPro/Teamを分けています。予測可能な基本利用で「KPI＝昨日の自分」を継続観察できます。',
       ),
       (
         q: 'Notion、LINE、Claude Cowork、Perplexity、Codex Desktopと比べる時の差別化軸は何ですか?',
@@ -3392,7 +3345,7 @@ $input
       ),
       (
         q: 'すでに Notion + Slack を使っています。なぜ自分株式会社が必要ですか?',
-        a: 'Notionはチームのナレッジを整理します。Slackはチームとのコミュニケーションを支えます。しかし「あなた自身の意思決定」「昨日の自分との比較」「資産・負債のバランスシート」を管理するツールはどこにも存在しません。自分株式会社はその空白を埋める個人向けライフOSです。Notionが仕事を整理するなら、自分株式会社はあなた自身を経営します。しかも完全無料です。',
+        a: 'Notionはチームのナレッジを整理します。Slackはチームとのコミュニケーションを支えます。しかし「あなた自身の意思決定」「昨日の自分との比較」「資産・負債のバランスシート」を管理するツールはどこにも存在しません。自分株式会社はその空白を埋める個人向けライフOSです。Notionが仕事を整理するなら、自分株式会社はあなた自身を経営します。基本機能は無料で始められます。',
       ),
       (
         q: 'Notion Japan DC開設で日本市場が変わりますが、自分株式会社との違いは？',
@@ -3419,10 +3372,7 @@ $input
             const SizedBox(height: 4),
             const Text(
               '気になることがあればお気軽にどうぞ。',
-              style: TextStyle(
-                color: Color(0xFF64748B),
-                height: 1.5,
-              ),
+              style: TextStyle(color: Color(0xFF64748B), height: 1.5),
             ),
             const SizedBox(height: 12),
             for (final faq in faqs) ...[
@@ -3434,6 +3384,36 @@ $input
     );
   }
 
+  Widget _buildLegalFooterLinks() {
+    return Wrap(
+      alignment: WrapAlignment.center,
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        TextButton.icon(
+          onPressed: () => Navigator.of(context).pushNamed('/terms'),
+          icon: const Icon(Icons.description_outlined, size: 18),
+          label: const Text('Terms'),
+        ),
+        TextButton.icon(
+          onPressed: () => Navigator.of(context).pushNamed('/tokusho'),
+          icon: const Icon(Icons.receipt_long_outlined, size: 18),
+          label: const Text('Commercial disclosure'),
+        ),
+        TextButton.icon(
+          onPressed: () => Navigator.of(context).pushNamed('/privacy'),
+          icon: const Icon(Icons.privacy_tip_outlined, size: 18),
+          label: const Text('Privacy'),
+        ),
+        TextButton.icon(
+          onPressed: () => Navigator.of(context).pushNamed('/billing'),
+          icon: const Icon(Icons.workspace_premium_outlined, size: 18),
+          label: const Text('Plans'),
+        ),
+      ],
+    );
+  }
+
   Widget _buildNotionVsSection() {
     const rows = [
       ('自分株式会社', 'Notion'),
@@ -3442,7 +3422,7 @@ $input
       ('資産/負債バランスシート（時間・お金）', 'プロジェクト管理'),
       ('IPO/ウェルビーイングという個人ゴール', 'ゴール設定なし'),
       ('6部署バランス（人事最優先の自己経営）', '業務効率化のみ'),
-      ('完全無料', '¥1,100〜/月 + AI従量課金'),
+      ('無料コア + Pro/Team', '¥1,100〜/月 + AI従量課金'),
     ];
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Card(
@@ -3465,10 +3445,7 @@ $input
             const SizedBox(height: 4),
             const Text(
               'Notionは仕事を整理します。自分株式会社はあなた自身を経営します。',
-              style: TextStyle(
-                color: Color(0xFF64748B),
-                height: 1.6,
-              ),
+              style: TextStyle(color: Color(0xFF64748B), height: 1.6),
             ),
             const SizedBox(height: 16),
             Table(
@@ -3477,8 +3454,9 @@ $input
                 1: FlexColumnWidth(1),
               },
               border: TableBorder.all(
-                color:
-                    isDark ? const Color(0xFF374151) : const Color(0xFFE5E7EB),
+                color: isDark
+                    ? const Color(0xFF374151)
+                    : const Color(0xFFE5E7EB),
                 borderRadius: BorderRadius.circular(8),
               ),
               children: [
@@ -3487,13 +3465,13 @@ $input
                     decoration: BoxDecoration(
                       color: i == 0
                           ? (isDark
-                              ? const Color(0xFF1E293B)
-                              : const Color(0xFFEEF2FF))
+                                ? const Color(0xFF1E293B)
+                                : const Color(0xFFEEF2FF))
                           : (i.isEven
-                              ? (isDark
-                                  ? const Color(0xFF111827)
-                                  : const Color(0xFFF9FAFB))
-                              : null),
+                                ? (isDark
+                                      ? const Color(0xFF111827)
+                                      : const Color(0xFFF9FAFB))
+                                : null),
                     ),
                     children: [
                       Padding(
@@ -3505,8 +3483,9 @@ $input
                           rows[i].$1,
                           style: TextStyle(
                             fontSize: 13,
-                            fontWeight:
-                                i == 0 ? FontWeight.w700 : FontWeight.w500,
+                            fontWeight: i == 0
+                                ? FontWeight.w700
+                                : FontWeight.w500,
                             color: i == 0 ? const Color(0xFF3949AB) : null,
                             height: 1.5,
                           ),
@@ -3521,8 +3500,9 @@ $input
                           rows[i].$2,
                           style: TextStyle(
                             fontSize: 13,
-                            fontWeight:
-                                i == 0 ? FontWeight.w700 : FontWeight.w400,
+                            fontWeight: i == 0
+                                ? FontWeight.w700
+                                : FontWeight.w400,
                             color: i == 0
                                 ? const Color(0xFF6B7280)
                                 : const Color(0xFF9CA3AF),
@@ -3586,17 +3566,14 @@ $input
                 _isSignUp
                     ? 'メールアドレスだけで30秒登録。AIが今日のタスクを整理し、資産管理・習慣化まで一元化。カード不要。'
                     : '既存ユーザーも Magic Link が最短です。パスワード入力なしで、そのまま再開できます。',
-                style: const TextStyle(
-                  color: Color(0xFF64748B),
-                  height: 1.5,
-                ),
+                style: const TextStyle(color: Color(0xFF64748B), height: 1.5),
               ),
               const SizedBox(height: 12),
               const Wrap(
                 spacing: 8,
                 runSpacing: 8,
                 children: [
-                  _BenefitChip(icon: Icons.card_membership, label: '完全無料'),
+                  _BenefitChip(icon: Icons.card_membership, label: '無料コア'),
                   _BenefitChip(icon: Icons.auto_awesome, label: 'AI自動整理'),
                   _BenefitChip(icon: Icons.import_export, label: 'Notionから移行可'),
                 ],
@@ -3626,7 +3603,8 @@ $input
               SizedBox(
                 height: 52,
                 child: FilledButton(
-                  onPressed: (_isLoading ||
+                  onPressed:
+                      (_isLoading ||
                           (_showInboxShortcut && _isMagicLinkCoolingDown))
                       ? null
                       : _sendMagicLink,
@@ -3637,8 +3615,8 @@ $input
                       Text(
                         _showInboxShortcut
                             ? (_isMagicLinkCoolingDown
-                                ? '送信済み'
-                                : 'Magic Linkを再送')
+                                  ? '送信済み'
+                                  : 'Magic Linkを再送')
                             : 'Magic Linkで今すぐ始める',
                       ),
                       if (_showInboxShortcut && _isMagicLinkCoolingDown) ...[
@@ -3756,10 +3734,7 @@ $input
                     padding: EdgeInsets.symmetric(horizontal: 12),
                     child: Text(
                       'パスワードで続ける',
-                      style: TextStyle(
-                        color: Color(0xFF94A3B8),
-                        height: 1.5,
-                      ),
+                      style: TextStyle(color: Color(0xFF94A3B8), height: 1.5),
                     ),
                   ),
                   Expanded(child: Divider()),
@@ -4012,6 +3987,8 @@ $input
                   // 12. B2B エンタープライズ CTA
                   _buildEnterpriseCta(),
                   const SizedBox(height: 20),
+                  _buildLegalFooterLinks(),
+                  const SizedBox(height: 20),
                   // 13. 紹介（紹介コードがある場合のみ表示）
                   _buildReferralInviteSection(),
                   if (_pendingReferralCode != null) const SizedBox(height: 20),
@@ -4029,10 +4006,7 @@ class _LandingNavButton extends StatelessWidget {
   final String label;
   final VoidCallback onPressed;
 
-  const _LandingNavButton({
-    required this.label,
-    required this.onPressed,
-  });
+  const _LandingNavButton({required this.label, required this.onPressed});
 
   @override
   Widget build(BuildContext context) {
@@ -4041,10 +4015,7 @@ class _LandingNavButton extends StatelessWidget {
       style: TextButton.styleFrom(
         foregroundColor: const Color(0xFF536173),
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-        textStyle: const TextStyle(
-          fontSize: 15,
-          fontWeight: FontWeight.w700,
-        ),
+        textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
       ),
       child: Text(label),
     );
@@ -4295,10 +4266,7 @@ class _WorkflowFeatureCard extends StatelessWidget {
               const SizedBox(height: 26),
               SizedBox(
                 height: 172,
-                child: Align(
-                  alignment: Alignment.bottomCenter,
-                  child: visual,
-                ),
+                child: Align(alignment: Alignment.bottomCenter, child: visual),
               ),
             ],
           ),
@@ -4379,10 +4347,7 @@ class _RuleLine extends StatelessWidget {
   final String prefix;
   final String text;
 
-  const _RuleLine({
-    required this.prefix,
-    required this.text,
-  });
+  const _RuleLine({required this.prefix, required this.text});
 
   @override
   Widget build(BuildContext context) {
@@ -4573,10 +4538,7 @@ class _LegendDot extends StatelessWidget {
   final Color color;
   final String label;
 
-  const _LegendDot({
-    required this.color,
-    required this.label,
-  });
+  const _LegendDot({required this.color, required this.label});
 
   @override
   Widget build(BuildContext context) {
@@ -4848,22 +4810,13 @@ class _MiniBarChartPainter extends CustomPainter {
     }
 
     const values = [0.52, 0.74, 0.45, 0.64, 0.38, 0.82, 0.56, 0.72];
-    const colors = [
-      Color(0xFF2F9DED),
-      Color(0xFFFFB547),
-      Color(0xFF43C77D),
-    ];
+    const colors = [Color(0xFF2F9DED), Color(0xFFFFB547), Color(0xFF43C77D)];
     final groupWidth = size.width / values.length;
     for (var i = 0; i < values.length; i++) {
       final barHeight = size.height * values[i];
       final x = i * groupWidth + groupWidth * 0.22;
       final rect = RRect.fromRectAndRadius(
-        Rect.fromLTWH(
-          x,
-          size.height - barHeight,
-          groupWidth * 0.42,
-          barHeight,
-        ),
+        Rect.fromLTWH(x, size.height - barHeight, groupWidth * 0.42, barHeight),
         const Radius.circular(2),
       );
       canvas.drawRRect(rect, Paint()..color = colors[i % colors.length]);
@@ -4912,10 +4865,7 @@ class _BenefitChip extends StatelessWidget {
   final IconData icon;
   final String label;
 
-  const _BenefitChip({
-    required this.icon,
-    required this.label,
-  });
+  const _BenefitChip({required this.icon, required this.label});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/legal_document_page.dart
+++ b/lib/pages/legal_document_page.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class LegalDocumentPage extends StatefulWidget {
+  const LegalDocumentPage({
+    super.key,
+    required this.assetPath,
+    required this.title,
+    required this.subtitle,
+    this.showBackButton = true,
+  });
+
+  final String assetPath;
+  final String title;
+  final String subtitle;
+  final bool showBackButton;
+
+  @override
+  State<LegalDocumentPage> createState() => _LegalDocumentPageState();
+}
+
+class _LegalDocumentPageState extends State<LegalDocumentPage> {
+  late final Future<String> _document;
+
+  @override
+  void initState() {
+    super.initState();
+    _document = rootBundle.loadString(widget.assetPath);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const bg = Color(0xFF0A0A0A);
+    const surface = Color(0xFF111827);
+    const orange = Color(0xFFFF6B35);
+    const indigo = Color(0xFF3D5AFE);
+    const text = Color(0xFFE5E7EB);
+    const muted = Color(0xFF9CA3AF);
+
+    return Scaffold(
+      backgroundColor: bg,
+      appBar: AppBar(
+        automaticallyImplyLeading: widget.showBackButton,
+        backgroundColor: bg,
+        foregroundColor: text,
+        elevation: 0,
+        title: Text(widget.title),
+      ),
+      body: FutureBuilder<String>(
+        future: _document,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(color: orange),
+            );
+          }
+          if (snapshot.hasError || !snapshot.hasData) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  '${widget.title} could not be loaded.',
+                  style: const TextStyle(color: text),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+
+          return Column(
+            children: [
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
+                decoration: const BoxDecoration(
+                  color: bg,
+                  border: Border(bottom: BorderSide(color: Color(0xFF1F2937))),
+                ),
+                child: Center(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 920),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          widget.title,
+                          style: const TextStyle(
+                            color: orange,
+                            fontSize: 32,
+                            fontWeight: FontWeight.w800,
+                            height: 1.15,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          widget.subtitle,
+                          style: const TextStyle(
+                            color: muted,
+                            fontSize: 15,
+                            height: 1.5,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Center(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 920),
+                    child: Markdown(
+                      data: snapshot.data!,
+                      selectable: true,
+                      padding: const EdgeInsets.fromLTRB(24, 24, 24, 48),
+                      onTapLink: (_, href, __) {
+                        if (href == null) return;
+                        unawaited(_openLink(href));
+                      },
+                      styleSheet:
+                          MarkdownStyleSheet.fromTheme(
+                            Theme.of(context),
+                          ).copyWith(
+                            p: const TextStyle(
+                              color: text,
+                              fontSize: 15,
+                              height: 1.75,
+                            ),
+                            h1: const TextStyle(
+                              color: orange,
+                              fontSize: 28,
+                              fontWeight: FontWeight.w800,
+                              height: 1.25,
+                            ),
+                            h2: const TextStyle(
+                              color: Color(0xFFFFB199),
+                              fontSize: 22,
+                              fontWeight: FontWeight.w800,
+                              height: 1.35,
+                            ),
+                            h3: const TextStyle(
+                              color: Color(0xFFB8C3FF),
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                              height: 1.45,
+                            ),
+                            strong: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w800,
+                            ),
+                            a: const TextStyle(
+                              color: Color(0xFF8EA2FF),
+                              decoration: TextDecoration.underline,
+                              decorationColor: Color(0xFF8EA2FF),
+                            ),
+                            listBullet: const TextStyle(color: orange),
+                            blockquote: const TextStyle(
+                              color: muted,
+                              fontStyle: FontStyle.italic,
+                            ),
+                            blockquoteDecoration: BoxDecoration(
+                              color: surface,
+                              border: const Border(
+                                left: BorderSide(color: indigo, width: 4),
+                              ),
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            code: const TextStyle(
+                              color: Color(0xFFFFD6C7),
+                              backgroundColor: Color(0xFF1F2937),
+                            ),
+                            codeblockDecoration: BoxDecoration(
+                              color: surface,
+                              borderRadius: BorderRadius.circular(6),
+                              border: Border.all(
+                                color: const Color(0xFF243044),
+                              ),
+                            ),
+                            tableHead: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w800,
+                            ),
+                            tableBody: const TextStyle(
+                              color: text,
+                              fontSize: 13,
+                              height: 1.45,
+                            ),
+                            tableBorder: TableBorder.all(
+                              color: const Color(0xFF374151),
+                            ),
+                            tableCellsPadding: const EdgeInsets.all(10),
+                            horizontalRuleDecoration: const BoxDecoration(
+                              border: Border(
+                                top: BorderSide(color: Color(0xFF374151)),
+                              ),
+                            ),
+                          ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _openLink(String href) async {
+    final uri = Uri.tryParse(href);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+}

--- a/lib/pages/subscription_billing_page.dart
+++ b/lib/pages/subscription_billing_page.dart
@@ -83,12 +83,13 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
     if (uri.hasScheme && (uri.scheme == 'http' || uri.scheme == 'https')) {
       return uri.replace(path: '/subscription-billing', query: '').toString();
     }
-    return 'https://my-web-app-b6f7f4.web.app/subscription-billing';
+    return 'https://my-web-app-b67f4.web.app/subscription-billing';
   }
 
   @override
   Widget build(BuildContext context) {
-    final status = _status ??
+    final status =
+        _status ??
         const BillingStatus(
           tier: 'free',
           status: 'active',
@@ -129,6 +130,8 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
                     isBusy: _isOpeningStripe,
                     onUpgrade: _openCheckout,
                   ),
+                  const SizedBox(height: 16),
+                  const _LegalLinksCard(),
                   const SizedBox(height: 16),
                   _UsageCard(status: status),
                   const SizedBox(height: 16),
@@ -239,8 +242,8 @@ class _PlanGrid extends StatelessWidget {
         final columns = constraints.maxWidth >= 900
             ? 3
             : constraints.maxWidth >= 620
-                ? 2
-                : 1;
+            ? 2
+            : 1;
         return GridView.count(
           crossAxisCount: columns,
           shrinkWrap: true,
@@ -321,6 +324,45 @@ class _PlanCard extends StatelessWidget {
                     : const Icon(Icons.lock_open_outlined),
                 label: Text(isCurrent ? '現在のプラン' : 'Stripeで開始'),
               ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LegalLinksCard extends StatelessWidget {
+  const _LegalLinksCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            const Text(
+              'Legal',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            TextButton.icon(
+              onPressed: () => Navigator.of(context).pushNamed('/terms'),
+              icon: const Icon(Icons.description_outlined),
+              label: const Text('Terms'),
+            ),
+            TextButton.icon(
+              onPressed: () => Navigator.of(context).pushNamed('/tokusho'),
+              icon: const Icon(Icons.receipt_long_outlined),
+              label: const Text('Commercial disclosure'),
+            ),
+            TextButton.icon(
+              onPressed: () => Navigator.of(context).pushNamed('/privacy'),
+              icon: const Icon(Icons.privacy_tip_outlined),
+              label: const Text('Privacy'),
             ),
           ],
         ),

--- a/lib/pages/terms_page.dart
+++ b/lib/pages/terms_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import 'legal_document_page.dart';
+
+class TermsPage extends StatelessWidget {
+  const TermsPage({super.key, this.showBackButton = true});
+
+  static const assetPath = 'assets/legal/terms.md';
+
+  final bool showBackButton;
+
+  @override
+  Widget build(BuildContext context) {
+    return LegalDocumentPage(
+      assetPath: assetPath,
+      title: 'Terms',
+      subtitle: 'Jibun K.K. / Terms of Service',
+      showBackButton: showBackButton,
+    );
+  }
+}

--- a/lib/pages/tokushoho_page.dart
+++ b/lib/pages/tokushoho_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import 'legal_document_page.dart';
+
+class TokushohoPage extends StatelessWidget {
+  const TokushohoPage({super.key, this.showBackButton = true});
+
+  static const assetPath = 'assets/legal/tokushoho.md';
+
+  final bool showBackButton;
+
+  @override
+  Widget build(BuildContext context) {
+    return LegalDocumentPage(
+      assetPath: assetPath,
+      title: 'Commercial Disclosure',
+      subtitle: 'Specified Commercial Transactions Act',
+      showBackButton: showBackButton,
+    );
+  }
+}

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -255,7 +255,7 @@ function billingReturnUrl(value: unknown, fallbackPath: string): string {
   }
   const base = Deno.env.get("PUBLIC_SITE_URL") ??
     Deno.env.get("SITE_URL") ??
-    "https://my-web-app-b6f7f4.web.app";
+    "https://my-web-app-b67f4.web.app";
   return new URL(fallbackPath, base).toString();
 }
 

--- a/test/legal_pages_test.dart
+++ b/test/legal_pages_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/terms_page.dart';
+import 'package:my_web_app/pages/tokushoho_page.dart';
+
+void main() {
+  testWidgets('terms page renders the terms asset', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: TermsPage(showBackButton: false)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Terms'), findsWidgets);
+    expect(find.textContaining('Terms of Service'), findsWidgets);
+    expect(find.textContaining('Paid Plans'), findsOneWidget);
+  });
+
+  testWidgets('tokushoho page renders the disclosure asset', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: TokushohoPage(showBackButton: false)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Commercial Disclosure'), findsWidgets);
+    expect(
+      find.textContaining('Specified Commercial Transactions'),
+      findsWidgets,
+    );
+    expect(find.textContaining('{{OPERATOR_LEGAL_NAME}}'), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary

- add Terms and Specified Commercial Transactions Act markdown assets plus Flutter routes (`/terms`, `/tokusho`)
- link Terms, Tokushoho, and Privacy from the billing screen and landing footer; wire the app hub upgrade button to `/billing`
- update the privacy policy for Stripe processing and remove the outdated no-billing statement
- fix the `b6f7f4` return URL typo in billing, schedule-hub, and `.env.example`
- adjust landing monetization copy from absolute free messaging to free core + optional Pro/Team

## Acceptance Mapping

- #3640: `assets/legal/tokushoho.md`, `TokushohoPage`, `/tokusho`, billing link, required disclosure placeholders and plan prices are included.
- #3641: `assets/legal/terms.md`, `TermsPage`, `/terms`, billing link, landing footer links, paid plan renewal/refund/governing-law sections are included.
- #3642: privacy policy removes the no-billing statement, adds Stripe as a processor, and billing links to privacy.
- #3643: app hub upgrade button navigates to `/billing`; landing has a visible Pro plan CTA and no longer uses the specified absolute-free contradiction copy.
- #3644: the three specified return URL fallbacks use `my-web-app-b67f4.web.app`.

## Validation

- `C:\\app\\flutter\\bin\\cache\\dart-sdk\\bin\\dart.exe format ...`
- `git diff --cached --check`
- `rg -n "b6f7f4" .env.example lib\\pages\\subscription_billing_page.dart supabase\\functions\\schedule-hub\\index.ts` returned no matches
- `rg -n "課金なし|決済なし" assets\\legal\\privacy_policy.md lib\\pages\\landing_page.dart lib\\pages\\subscription_billing_page.dart` returned no matches
- `deno check --config supabase\\functions\\deno.json supabase\\functions\\schedule-hub\\index.ts`
- Local `flutter pub get` / `flutter --version` hung in this sandbox and left Dart processes; Flutter analyze/test are left to GitHub Actions.

## Minimal E2E Gate

- Implementation-detail independent: assert visible legal links and checkout return behavior through routes, not private widget internals.
- Minimal scope: about 3 cases (billing legal links, `/terms` and `/tokusho` route render, app hub upgrade CTA opens billing).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

Part of #3639
Closes #3640
Closes #3641
Closes #3642
Closes #3643
Closes #3644
