### PR TITLE
feat: handle billing checkout return state

### DIFF
--- a/lib/pages/subscription_billing_page.dart
+++ b/lib/pages/subscription_billing_page.dart
@@ -5,7 +5,10 @@ import '../services/billing_service.dart';
 import '../widgets/paddle_approval_readiness_card.dart';
 
 class SubscriptionBillingPage extends StatefulWidget {
-  const SubscriptionBillingPage({super.key});
+  const SubscriptionBillingPage({super.key, this.service, this.initialUri});
+
+  final BillingGateway? service;
+  final Uri? initialUri;
 
   @override
   State<SubscriptionBillingPage> createState() =>
@@ -13,15 +16,18 @@ class SubscriptionBillingPage extends StatefulWidget {
 }
 
 class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
-  final _service = BillingService();
+  late final BillingGateway _service;
   bool _isLoading = true;
   bool _isOpeningStripe = false;
   String? _errorMessage;
   BillingStatus? _status;
+  _BillingReturnNotice? _returnNotice;
 
   @override
   void initState() {
     super.initState();
+    _service = widget.service ?? BillingService();
+    _returnNotice = _BillingReturnNotice.fromUri(widget.initialUri ?? Uri.base);
     _fetchBillingInfo();
   }
 
@@ -88,7 +94,8 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
 
   @override
   Widget build(BuildContext context) {
-    final status = _status ??
+    final status =
+        _status ??
         const BillingStatus(
           tier: 'free',
           status: 'active',
@@ -114,6 +121,10 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   if (_errorMessage != null) _ErrorBanner(_errorMessage!),
+                  if (_returnNotice != null) ...[
+                    _BillingReturnBanner(_returnNotice!),
+                    const SizedBox(height: 12),
+                  ],
                   PaddleApprovalReadinessCard(
                     compact: true,
                     touchesRegulatedData: true,
@@ -138,6 +149,75 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
                 ],
               ),
             ),
+    );
+  }
+}
+
+enum _BillingReturnKind { success, cancel }
+
+class _BillingReturnNotice {
+  const _BillingReturnNotice._(this.kind);
+
+  final _BillingReturnKind kind;
+
+  static _BillingReturnNotice? fromUri(Uri uri) {
+    final value = uri.queryParameters['billing']?.trim().toLowerCase();
+    return switch (value) {
+      'success' => const _BillingReturnNotice._(_BillingReturnKind.success),
+      'cancel' => const _BillingReturnNotice._(_BillingReturnKind.cancel),
+      _ => null,
+    };
+  }
+
+  bool get isSuccess => kind == _BillingReturnKind.success;
+
+  IconData get icon =>
+      isSuccess ? Icons.celebration_outlined : Icons.info_outline;
+
+  String get title => isSuccess ? 'ありがとうございます。決済を確認しています' : 'チェックアウトをキャンセルしました';
+
+  String get message => isSuccess
+      ? 'Stripeから戻りました。最新のプラン情報を再取得しました。反映に少し時間がかかる場合があります。'
+      : '請求は発生していません。必要になったらいつでも再開できます。';
+}
+
+class _BillingReturnBanner extends StatelessWidget {
+  const _BillingReturnBanner(this.notice);
+
+  final _BillingReturnNotice notice;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final color = notice.isSuccess ? scheme.primary : scheme.secondary;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.08),
+        border: Border.all(color: color.withOpacity(0.35)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(notice.icon, color: color),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  notice.title,
+                  style: TextStyle(fontWeight: FontWeight.bold, color: color),
+                ),
+                const SizedBox(height: 4),
+                Text(notice.message),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -241,8 +321,8 @@ class _PlanGrid extends StatelessWidget {
         final columns = constraints.maxWidth >= 900
             ? 3
             : constraints.maxWidth >= 620
-                ? 2
-                : 1;
+            ? 2
+            : 1;
         return GridView.count(
           crossAxisCount: columns,
           shrinkWrap: true,
@@ -395,10 +475,7 @@ class _LegalLinksCard extends StatelessWidget {
               spacing: 8,
               runSpacing: 4,
               children: [
-                _LegalLinkButton(
-                  label: '特定商取引法に基づく表記',
-                  route: '/tokusho',
-                ),
+                _LegalLinkButton(label: '特定商取引法に基づく表記', route: '/tokusho'),
                 _LegalLinkButton(label: '利用規約', route: '/terms'),
                 _LegalLinkButton(label: 'プライバシーポリシー', route: '/privacy'),
               ],

--- a/lib/pages/subscription_billing_page.dart
+++ b/lib/pages/subscription_billing_page.dart
@@ -5,7 +5,10 @@ import '../services/billing_service.dart';
 import '../widgets/paddle_approval_readiness_card.dart';
 
 class SubscriptionBillingPage extends StatefulWidget {
-  const SubscriptionBillingPage({super.key});
+  const SubscriptionBillingPage({super.key, this.service, this.initialUri});
+
+  final BillingGateway? service;
+  final Uri? initialUri;
 
   @override
   State<SubscriptionBillingPage> createState() =>
@@ -13,15 +16,18 @@ class SubscriptionBillingPage extends StatefulWidget {
 }
 
 class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
-  final _service = BillingService();
+  late final BillingGateway _service;
   bool _isLoading = true;
   bool _isOpeningStripe = false;
   String? _errorMessage;
   BillingStatus? _status;
+  _BillingReturnNotice? _returnNotice;
 
   @override
   void initState() {
     super.initState();
+    _service = widget.service ?? BillingService();
+    _returnNotice = _BillingReturnNotice.fromUri(widget.initialUri ?? Uri.base);
     _fetchBillingInfo();
   }
 
@@ -88,7 +94,8 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
 
   @override
   Widget build(BuildContext context) {
-    final status = _status ??
+    final status =
+        _status ??
         const BillingStatus(
           tier: 'free',
           status: 'active',
@@ -114,6 +121,10 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   if (_errorMessage != null) _ErrorBanner(_errorMessage!),
+                  if (_returnNotice != null) ...[
+                    _BillingReturnBanner(_returnNotice!),
+                    const SizedBox(height: 12),
+                  ],
                   PaddleApprovalReadinessCard(
                     compact: true,
                     touchesRegulatedData: true,
@@ -138,6 +149,75 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
                 ],
               ),
             ),
+    );
+  }
+}
+
+enum _BillingReturnKind { success, cancel }
+
+class _BillingReturnNotice {
+  const _BillingReturnNotice._(this.kind);
+
+  final _BillingReturnKind kind;
+
+  static _BillingReturnNotice? fromUri(Uri uri) {
+    final value = uri.queryParameters['billing']?.trim().toLowerCase();
+    return switch (value) {
+      'success' => const _BillingReturnNotice._(_BillingReturnKind.success),
+      'cancel' => const _BillingReturnNotice._(_BillingReturnKind.cancel),
+      _ => null,
+    };
+  }
+
+  bool get isSuccess => kind == _BillingReturnKind.success;
+
+  IconData get icon =>
+      isSuccess ? Icons.celebration_outlined : Icons.info_outline;
+
+  String get title => isSuccess ? 'ありがとうございます。決済を確認しています' : 'チェックアウトをキャンセルしました';
+
+  String get message => isSuccess
+      ? 'Stripeから戻りました。最新のプラン情報を再取得しました。反映に少し時間がかかる場合があります。'
+      : '請求は発生していません。必要になったらいつでも再開できます。';
+}
+
+class _BillingReturnBanner extends StatelessWidget {
+  const _BillingReturnBanner(this.notice);
+
+  final _BillingReturnNotice notice;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final color = notice.isSuccess ? scheme.primary : scheme.secondary;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        border: Border.all(color: color.withValues(alpha: 0.35)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(notice.icon, color: color),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  notice.title,
+                  style: TextStyle(fontWeight: FontWeight.bold, color: color),
+                ),
+                const SizedBox(height: 4),
+                Text(notice.message),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -241,8 +321,8 @@ class _PlanGrid extends StatelessWidget {
         final columns = constraints.maxWidth >= 900
             ? 3
             : constraints.maxWidth >= 620
-                ? 2
-                : 1;
+            ? 2
+            : 1;
         return GridView.count(
           crossAxisCount: columns,
           shrinkWrap: true,
@@ -395,10 +475,7 @@ class _LegalLinksCard extends StatelessWidget {
               spacing: 8,
               runSpacing: 4,
               children: [
-                _LegalLinkButton(
-                  label: '特定商取引法に基づく表記',
-                  route: '/tokusho',
-                ),
+                _LegalLinkButton(label: '特定商取引法に基づく表記', route: '/tokusho'),
                 _LegalLinkButton(label: '利用規約', route: '/terms'),
                 _LegalLinkButton(label: 'プライバシーポリシー', route: '/privacy'),
               ],

--- a/lib/pages/subscription_billing_page.dart
+++ b/lib/pages/subscription_billing_page.dart
@@ -94,8 +94,7 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
 
   @override
   Widget build(BuildContext context) {
-    final status =
-        _status ??
+    final status = _status ??
         const BillingStatus(
           tier: 'free',
           status: 'active',
@@ -321,8 +320,8 @@ class _PlanGrid extends StatelessWidget {
         final columns = constraints.maxWidth >= 900
             ? 3
             : constraints.maxWidth >= 620
-            ? 2
-            : 1;
+                ? 2
+                : 1;
         return GridView.count(
           crossAxisCount: columns,
           shrinkWrap: true,

--- a/lib/services/billing_service.dart
+++ b/lib/services/billing_service.dart
@@ -73,17 +73,30 @@ class BillingPortalSession {
   }
 }
 
-class BillingService {
+abstract class BillingGateway {
+  Future<BillingStatus> fetchStatus();
+
+  Future<BillingCheckoutSession> createCheckoutSession({
+    required String tier,
+    required String returnUrl,
+  });
+
+  Future<BillingPortalSession> createPortalSession({required String returnUrl});
+}
+
+class BillingService implements BillingGateway {
   BillingService({SupabaseClient? client})
-      : _client = client ?? Supabase.instance.client;
+    : _client = client ?? Supabase.instance.client;
 
   final SupabaseClient _client;
 
+  @override
   Future<BillingStatus> fetchStatus() async {
     final data = await _invokeBillingAction('billing.status', {});
     return BillingStatus.fromJson(data);
   }
 
+  @override
   Future<BillingCheckoutSession> createCheckoutSession({
     required String tier,
     required String returnUrl,
@@ -95,6 +108,7 @@ class BillingService {
     return BillingCheckoutSession.fromJson(data);
   }
 
+  @override
   Future<BillingPortalSession> createPortalSession({
     required String returnUrl,
   }) async {

--- a/lib/services/billing_service.dart
+++ b/lib/services/billing_service.dart
@@ -86,7 +86,7 @@ abstract class BillingGateway {
 
 class BillingService implements BillingGateway {
   BillingService({SupabaseClient? client})
-    : _client = client ?? Supabase.instance.client;
+      : _client = client ?? Supabase.instance.client;
 
   final SupabaseClient _client;
 

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -8,10 +8,7 @@
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
-import {
-  checkAndRecordAiUsage,
-  supabaseUsageStore,
-} from "./usage_gate.ts";
+import { checkAndRecordAiUsage, supabaseUsageStore } from "./usage_gate.ts";
 import {
   AI_CHARACTER_PREAMBLE,
   prependCharacter,
@@ -4915,7 +4912,9 @@ serve(async (req: Request) => {
               limit: usage.limit,
               upgrade_url: "/billing",
               message:
-                `無料プランの今月のAI利用上限(${usage.limit ?? 0}回)に達しました。` +
+                `無料プランの今月のAI利用上限(${
+                  usage.limit ?? 0
+                }回)に達しました。` +
                 `Pro にアップグレードすると無制限に利用できます。`,
             }, 402);
           }
@@ -5174,7 +5173,9 @@ serve(async (req: Request) => {
               limit: usage.limit,
               upgrade_url: "/billing",
               message:
-                `無料プランの今月のAI利用上限(${usage.limit ?? 0}回)に達しました。` +
+                `無料プランの今月のAI利用上限(${
+                  usage.limit ?? 0
+                }回)に達しました。` +
                 `Pro にアップグレードすると無制限に利用できます。`,
             }, 402);
           }

--- a/test/pages/subscription_billing_page_test.dart
+++ b/test/pages/subscription_billing_page_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/subscription_billing_page.dart';
+import 'package:my_web_app/services/billing_service.dart';
+
+void main() {
+  testWidgets('shows success confirmation and refreshes billing status', (
+    tester,
+  ) async {
+    final billing = _FakeBillingGateway();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SubscriptionBillingPage(
+          service: billing,
+          initialUri: Uri.parse(
+            'https://example.com/subscription-billing?billing=success',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('ありがとうございます。決済を確認しています'), findsOneWidget);
+    expect(find.textContaining('最新のプラン情報を再取得しました'), findsOneWidget);
+    expect(billing.fetchStatusCount, 1);
+  });
+
+  testWidgets('shows neutral cancel confirmation', (tester) async {
+    final billing = _FakeBillingGateway();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SubscriptionBillingPage(
+          service: billing,
+          initialUri: Uri.parse(
+            'https://example.com/subscription-billing?billing=cancel',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('チェックアウトをキャンセルしました'), findsOneWidget);
+    expect(find.textContaining('請求は発生していません'), findsOneWidget);
+    expect(billing.fetchStatusCount, 1);
+  });
+}
+
+class _FakeBillingGateway implements BillingGateway {
+  int fetchStatusCount = 0;
+
+  @override
+  Future<BillingStatus> fetchStatus() async {
+    fetchStatusCount += 1;
+    return const BillingStatus(
+      tier: 'free',
+      status: 'active',
+      aiQueryCount: 0,
+      efCallCount: 0,
+    );
+  }
+
+  @override
+  Future<BillingCheckoutSession> createCheckoutSession({
+    required String tier,
+    required String returnUrl,
+  }) async {
+    return const BillingCheckoutSession(url: 'https://stripe.example.test');
+  }
+
+  @override
+  Future<BillingPortalSession> createPortalSession({
+    required String returnUrl,
+  }) async {
+    return const BillingPortalSession(url: 'https://stripe.example.test');
+  }
+}


### PR DESCRIPTION
## Summary

- handle `?billing=success` and `?billing=cancel` on `/subscription-billing`
- show a visible success/cancel confirmation banner after Stripe returns
- keep the success path refreshing `billing.status` through the existing page load
- make `BillingService` injectable through a small `BillingGateway` interface
- add widget coverage for success and cancel return states

## Acceptance Mapping

- #3648: `billing=success` now shows a thank-you confirmation and reloads billing status.
- #3648: `billing=cancel` now shows a neutral cancellation confirmation.
- #3648: no checkout, portal, or payment execution code paths were changed.

## Validation

- `C:\app\flutter\bin\cache\dart-sdk\bin\dart.exe format lib\pages\subscription_billing_page.dart lib\services\billing_service.dart test\pages\subscription_billing_page_test.dart`
- `git diff --check`
- `flutter test test\pages\subscription_billing_page_test.dart` was attempted locally but timed out after 120s with no output in this sandbox; the leftover Dart process was stopped. Flutter analyze/test are left to GitHub Actions.

## Minimal E2E Gate

- Implementation-detail independent: widget tests assert user-visible success/cancel messages from URL query input.
- Minimal scope: 2 cases, checkout success and checkout cancel return.
- E2E: Flutter widget coverage for the route state; no browser payment round-trip is executed in this PR.
- E2E-Exception: scoped post-checkout return-state UI only; no new data write, auth, payment execution, webhook, or persistence flow.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: PR text mentions billing/payment return states, but the code change is limited to client-side confirmation UI, dependency injection for testing, and widget tests; no Stripe execution, secrets, webhook, migrations, or production deploy path changed.

Closes #3648
