### PR TITLE
Show upgrade dialog on free AI limit

### DIFF
--- a/lib/pages/note_editor_page.dart
+++ b/lib/pages/note_editor_page.dart
@@ -19,6 +19,7 @@ import '../services/undo_redo_service.dart';
 import '../utils/note_image_clipboard.dart';
 import '../utils/note_image_drop.dart';
 import '../widgets/attachment_list_widget.dart';
+import '../widgets/ai_free_limit_upgrade_dialog.dart';
 import '../widgets/markdown_preview.dart';
 import '../widgets/note_comments_panel.dart';
 import '../widgets/note_editor/ai_assistant_menu.dart';
@@ -376,6 +377,13 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(message)),
     );
+  }
+
+  Future<bool> _showUpgradeDialogIfNeeded(Object error) async {
+    if (error is! AIServiceException || !error.isFreeLimitReached || !mounted) {
+      return false;
+    }
+    return showAiFreeLimitUpgradeDialog(context, error);
   }
 
   Future<int?> _ensureNoteIdForAttachmentFlow() async {
@@ -804,6 +812,9 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
       _setContentText(result);
       _showMessage('Prompt applied: ${template.title}');
     } catch (e) {
+      if (await _showUpgradeDialogIfNeeded(e)) {
+        return;
+      }
       _showMessage('Prompt failed: $e');
     } finally {
       if (mounted) {
@@ -1172,6 +1183,9 @@ class _NoteEditorPageState extends State<NoteEditorPage> {
       }
       _slashCommandController.clear();
     } catch (e) {
+      if (await _showUpgradeDialogIfNeeded(e)) {
+        return;
+      }
       _showMessage('コマンドの実行に失敗しました: $e');
     } finally {
       if (mounted) {

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -12,13 +12,75 @@ class AIServiceException implements Exception {
   final String message;
   final String? errorType;
   final String? retryAfter;
+  final String? code;
+  final int? statusCode;
+  final String? upgradeUrl;
 
-  AIServiceException(this.message, {this.errorType, this.retryAfter});
+  AIServiceException(
+    this.message, {
+    this.errorType,
+    this.retryAfter,
+    this.code,
+    this.statusCode,
+    this.upgradeUrl,
+  });
+
+  factory AIServiceException.fromFunctionPayload(
+    Map<String, dynamic> payload, {
+    String fallbackMessage = 'AI処理に失敗しました',
+  }) {
+    final statusCode = _payloadStatusCode(payload);
+    final code = payload['code']?.toString();
+    final message = _payloadMessage(payload, fallbackMessage);
+    final upgradeUrl = _payloadString(payload, 'upgrade_url') ??
+        _payloadString(payload, 'upgradeUrl');
+    if (statusCode == 402 && code == 'free_limit_reached') {
+      return AIServiceException(
+        message,
+        errorType: 'FREE_LIMIT_REACHED',
+        code: code,
+        statusCode: statusCode,
+        upgradeUrl: upgradeUrl,
+      );
+    }
+
+    return AIServiceException(
+      message,
+      errorType: payload['errorType'] as String?,
+      retryAfter: payload['retryAfter']?.toString(),
+      code: code,
+      statusCode: statusCode,
+      upgradeUrl: upgradeUrl,
+    );
+  }
 
   bool get isRateLimitError => errorType == 'RATE_LIMIT';
+  bool get isFreeLimitReached =>
+      statusCode == 402 && code == 'free_limit_reached';
 
   @override
   String toString() => message;
+}
+
+String? _payloadString(Map<String, dynamic> payload, String key) {
+  final value = payload[key]?.toString().trim();
+  return value == null || value.isEmpty ? null : value;
+}
+
+int? _payloadStatusCode(Map<String, dynamic> payload) {
+  final value =
+      payload['status'] ?? payload['statusCode'] ?? payload['http_status'];
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value == null) return null;
+  return int.tryParse(value.toString());
+}
+
+String _payloadMessage(Map<String, dynamic> payload, String fallbackMessage) {
+  return _payloadString(payload, 'message') ??
+      _payloadString(payload, 'error') ??
+      _payloadString(payload, 'detail') ??
+      fallbackMessage;
 }
 
 /// グローバル 429 サーキットブレイカー
@@ -222,19 +284,13 @@ class AIService {
       AppLogger.debug('Supabase Function Response ($functionName): $data');
 
       if (data['success'] != true) {
-        final errorMessage = (data['error'] as String?) ?? 'AI処理に失敗しました';
-        final errorType = data['errorType'] as String?;
-        final retryAfter = data['retryAfter']?.toString();
+        final exception = AIServiceException.fromFunctionPayload(data);
 
         AppLogger.error(
-          'Supabase Function Error ($functionName): $errorMessage',
+          'Supabase Function Error ($functionName): ${exception.message}',
         );
 
-        throw AIServiceException(
-          errorMessage,
-          errorType: errorType,
-          retryAfter: retryAfter,
-        );
+        throw exception;
       }
 
       return data;
@@ -246,24 +302,31 @@ class AIService {
       );
 
       if (details is Map<String, dynamic>) {
-        final errorMessage =
-            details['error']?.toString() ?? 'Supabase Function からの詳細エラー';
-        final errorType = details['errorType'] as String?;
-        final retryAfter = details['retryAfter']?.toString();
+        final exception = AIServiceException.fromFunctionPayload(
+          details,
+          fallbackMessage: 'Supabase Function からの詳細エラー',
+        );
 
         // 429 / quota / rate limit を検知して circuit breaker を作動
-        final isQuota = errorType == 'RATE_LIMIT' ||
+        final isQuota = exception.errorType == 'RATE_LIMIT' ||
             RegExp(r'quota|rate.?limit|429', caseSensitive: false)
-                .hasMatch(errorMessage);
+                .hasMatch(exception.message);
         if (isQuota) {
           AiQuotaGuard.markQuotaExceeded();
         }
 
-        throw AIServiceException(
-          errorMessage,
-          errorType: isQuota ? 'RATE_LIMIT' : errorType,
-          retryAfter: retryAfter,
-        );
+        if (isQuota && !exception.isRateLimitError) {
+          throw AIServiceException(
+            exception.message,
+            errorType: 'RATE_LIMIT',
+            retryAfter: exception.retryAfter,
+            code: exception.code,
+            statusCode: exception.statusCode,
+            upgradeUrl: exception.upgradeUrl,
+          );
+        }
+
+        throw exception;
       }
 
       // details が読めない場合も 429 メッセージなら guard 作動

--- a/lib/widgets/ai_free_limit_upgrade_dialog.dart
+++ b/lib/widgets/ai_free_limit_upgrade_dialog.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import '../services/ai_service.dart';
+
+Future<bool> showAiFreeLimitUpgradeDialog(
+  BuildContext context,
+  AIServiceException error,
+) async {
+  if (!error.isFreeLimitReached) {
+    return false;
+  }
+
+  final route = _upgradeRoute(error.upgradeUrl);
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        key: const Key('ai_free_limit_upgrade_dialog'),
+        title: const Text('無料枠の上限に達しました'),
+        content: Text(
+          error.message.isEmpty
+              ? '今月の無料AI質問枠を使い切りました。Proプランに切り替えると、上限を気にせずAI機能を使えます。'
+              : error.message,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('あとで'),
+          ),
+          FilledButton.icon(
+            key: const Key('ai_free_limit_upgrade_primary_button'),
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              Navigator.of(context).pushNamed(route);
+            },
+            icon: const Icon(Icons.rocket_launch, size: 18),
+            label: const Text('Proプランを見る'),
+          ),
+        ],
+      );
+    },
+  );
+  return true;
+}
+
+String _upgradeRoute(String? rawUrl) {
+  final value = rawUrl?.trim();
+  if (value == null || value.isEmpty) {
+    return '/billing';
+  }
+  final parsed = Uri.tryParse(value);
+  final path = parsed?.path.trim();
+  if (path == null || path.isEmpty) {
+    return '/billing';
+  }
+  return path.startsWith('/') ? path : '/$path';
+}

--- a/test/pages/people_help_page_test.dart
+++ b/test/pages/people_help_page_test.dart
@@ -18,6 +18,8 @@ class _FakeEditorSupabaseClient extends Fake implements SupabaseClient {}
 class _FakeNoteEditorAIService extends AIService {
   _FakeNoteEditorAIService() : super(_FakeEditorSupabaseClient());
 
+  AIServiceException? summarizeError;
+  AIServiceException? customPromptError;
   String? lastSummarizeStyleName;
   String? lastSummarizeModel;
   String? lastSuggestTitlesModel;
@@ -31,6 +33,10 @@ class _FakeNoteEditorAIService extends AIService {
     String? styleName,
     String? styleInstruction,
   }) async {
+    final error = summarizeError;
+    if (error != null) {
+      throw error;
+    }
     lastSummarizeModel = model;
     lastSummarizeStyleName = styleName;
     return 'summary[$styleName]: $content';
@@ -52,6 +58,10 @@ class _FakeNoteEditorAIService extends AIService {
     String? styleName,
     String? styleInstruction,
   }) async {
+    final error = customPromptError;
+    if (error != null) {
+      throw error;
+    }
     lastCustomPrompt = prompt;
     lastCustomPromptModel = model;
     return 'custom[$model]: ${prompt.split('\n').first}';
@@ -200,6 +210,61 @@ void main() {
     expect(titleField.controller?.text, 'AI generated note title');
     expect(aiService.lastSuggestTitlesModel, 'gpt-4o-mini');
   });
+
+  testWidgets(
+    'NoteEditorPage shows upgrade dialog and opens billing on free limit',
+    (WidgetTester tester) async {
+      final aiService = _FakeNoteEditorAIService()
+        ..summarizeError = AIServiceException.fromFunctionPayload({
+          'status': 402,
+          'code': 'free_limit_reached',
+          'message': '今月の無料AI質問30回を使い切りました。',
+          'upgrade_url': '/billing',
+        });
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (_) => ThemeService(),
+          child: MaterialApp(
+            routes: {
+              '/billing': (_) => const Scaffold(
+                    body: Text('Billing upgrade page'),
+                  ),
+            },
+            home: NoteEditorPage(
+              initialContent: 'Revenue growth notes',
+              supabaseClient: _FakeEditorSupabaseClient(),
+              aiService: aiService,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final commandField = find.byKey(
+        const Key('note_editor_slash_command_field'),
+      );
+      await tester.ensureVisible(commandField);
+      await tester.showKeyboard(commandField);
+      await tester.enterText(commandField, '/summarize');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('ai_free_limit_upgrade_dialog')),
+        findsOneWidget,
+      );
+      expect(find.text('無料枠の上限に達しました'), findsOneWidget);
+      expect(find.text('今月の無料AI質問30回を使い切りました。'), findsOneWidget);
+
+      await tester.tap(
+        find.byKey(const Key('ai_free_limit_upgrade_primary_button')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Billing upgrade page'), findsOneWidget);
+    },
+  );
 
   testWidgets('NoteEditorPage prompt library saves and runs a custom prompt', (
     WidgetTester tester,

--- a/test/services/ai_service_exception_test.dart
+++ b/test/services/ai_service_exception_test.dart
@@ -1,0 +1,34 @@
+@TestOn('browser')
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/ai_service.dart';
+
+void main() {
+  test('maps 402 free_limit_reached payload to upgrade metadata', () {
+    final error = AIServiceException.fromFunctionPayload({
+      'status': 402,
+      'code': 'free_limit_reached',
+      'message': '無料AI質問枠を使い切りました。',
+      'upgrade_url': '/billing',
+    });
+
+    expect(error.isFreeLimitReached, isTrue);
+    expect(error.statusCode, 402);
+    expect(error.code, 'free_limit_reached');
+    expect(error.message, '無料AI質問枠を使い切りました。');
+    expect(error.upgradeUrl, '/billing');
+  });
+
+  test('keeps non-402 payloads as regular AIServiceException errors', () {
+    final error = AIServiceException.fromFunctionPayload({
+      'status': 500,
+      'code': 'provider_down',
+      'error': 'provider unavailable',
+    });
+
+    expect(error.isFreeLimitReached, isFalse);
+    expect(error.statusCode, 500);
+    expect(error.code, 'provider_down');
+    expect(error.message, 'provider unavailable');
+  });
+}


### PR DESCRIPTION
## Summary

- Map Supabase AI `free_limit_reached` 402 payloads into structured `AIServiceException` metadata.
- Show an in-app upgrade dialog from NoteEditor AI actions and route the primary CTA to `/billing`.
- Add browser-scoped tests for payload mapping and the NoteEditor dialog-to-billing flow.

## Validation

- PASS: `git diff --check`
- PASS: `dart format --output=none --set-exit-if-changed lib/services/ai_service.dart lib/pages/note_editor_page.dart lib/widgets/ai_free_limit_upgrade_dialog.dart test/pages/people_help_page_test.dart test/services/ai_service_exception_test.dart`
- PASS: `flutter pub get`
- ATTEMPTED: `flutter test --no-pub test/services/ai_service_exception_test.dart` fails on VM because `AIService` transitively imports existing browser-only `package:web` APIs; the new test is marked `@TestOn('browser')` like existing browser-only tests.
- ATTEMPTED: `flutter test --platform chrome --no-pub test/services/ai_service_exception_test.dart` timed out locally; CI remains the authoritative check.

## Minimal E2E Gate

- Implementation-detail independent: the coverage asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases are covered or specified: 402 free-limit payload maps to upgrade metadata, NoteEditor shows the upgrade dialog, and the primary dialog CTA opens `/billing`.
- E2E: Flutter widget coverage exercises the user-visible NoteEditor flow; no `integration_test/` or Playwright route is added in this PR.
- E2E-Exception: This is a focused in-app dialog/navigation fix for an existing editor flow, so widget coverage is the narrowest reliable black-box check without adding a full end-to-end harness.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: UI-only conversion handling for AI free-limit 402 responses; no auth execution, payment execution, subscription state mutation, migration, deploy, secret, production data path, or rollback-sensitive backend change.
- Unresolved findings: 0

Closes #3664
