### PR TITLE
Add paid conversion metrics to admin analytics

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -27,6 +27,18 @@ class _FunnelMetrics {
   });
 }
 
+class _PaidConversionMetrics {
+  final int paidCustomers;
+  final int mrrYen;
+
+  const _PaidConversionMetrics({
+    required this.paidCustomers,
+    required this.mrrYen,
+  });
+
+  static const empty = _PaidConversionMetrics(paidCustomers: 0, mrrYen: 0);
+}
+
 class _GrowthActionPlan {
   final String bottleneckLabel;
   final String title;
@@ -62,6 +74,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   int _lpTotalViews = 0;
   int _allowedToolExecutionCount = 0;
   int _blockedToolExecutionCount = 0;
+  _PaidConversionMetrics _paidConversionMetrics = _PaidConversionMetrics.empty;
   bool _hasLpViewStats = false;
   bool _isLoading = true;
   WeeklyDigestSnapshot _weeklyDigest = const WeeklyDigestSnapshot.empty();
@@ -195,6 +208,47 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
       return '--';
     }
     return '${(numerator / denominator * 100).toStringAsFixed(1)}%';
+  }
+
+  String _formatPaidConversionRate(int paidCustomers, int totalUsers) {
+    if (totalUsers <= 0) {
+      return '0.0%';
+    }
+    return '${(paidCustomers / totalUsers * 100).toStringAsFixed(1)}%';
+  }
+
+  Map<String, dynamic> _firstMap(dynamic value) {
+    if (value is Map) {
+      return Map<String, dynamic>.from(value);
+    }
+    if (value is List && value.isNotEmpty && value.first is Map) {
+      return Map<String, dynamic>.from(value.first as Map);
+    }
+    return <String, dynamic>{};
+  }
+
+  _PaidConversionMetrics _paidConversionMetricsFromRpc(dynamic value) {
+    final row = _firstMap(value);
+    if (row.isEmpty) {
+      return _PaidConversionMetrics.empty;
+    }
+
+    return _PaidConversionMetrics(
+      paidCustomers: _toInt(row['paid_customers']),
+      mrrYen: _toInt(row['mrr_yen']),
+    );
+  }
+
+  Future<_PaidConversionMetrics> _loadPaidConversionMetrics() async {
+    try {
+      final response = await _supabase.rpc(
+        'get_billing_paid_conversion_summary',
+      );
+      return _paidConversionMetricsFromRpc(response);
+    } catch (error) {
+      debugPrint('billing paid conversion summary is unavailable: $error');
+      return _PaidConversionMetrics.empty;
+    }
   }
 
   int _estimateNeededMagicLinks({
@@ -1213,6 +1267,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           ? Map<String, dynamic>.from(lpStatsResponse)
           : <String, dynamic>{};
       final hasLpViewStats = lpStats.isNotEmpty;
+      final paidConversionMetrics = await _loadPaidConversionMetrics();
 
       final toolExecutionLogs = <Map<String, dynamic>>[];
       final blockedReasonCounts = <String, int>{};
@@ -1267,6 +1322,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           _blockedReasonBreakdown = normalizedBlockedReasons;
           _allowedToolExecutionCount = allowedExecutionCount;
           _blockedToolExecutionCount = blockedExecutionCount;
+          _paidConversionMetrics = paidConversionMetrics;
           _isLoading = false;
         });
       }
@@ -1552,6 +1608,11 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                       totalShares,
                       effectiveTotalLpViews,
                       todayFunnel,
+                    ),
+                    const SizedBox(height: 16),
+                    _buildPaidConversionCard(
+                      metrics: _paidConversionMetrics,
+                      totalUsers: _actualUserCount,
                     ),
                     const SizedBox(height: 16),
                     _buildRegistrationOpsCard(
@@ -2326,6 +2387,100 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                   '$totalLpViews',
                   Icons.analytics,
                   const Color(0xFF0D9488),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPaidConversionCard({
+    required _PaidConversionMetrics metrics,
+    required int totalUsers,
+  }) {
+    final conversionRate = _formatPaidConversionRate(
+      metrics.paidCustomers,
+      totalUsers,
+    );
+    final formattedMrr = NumberFormat.currency(
+      locale: 'ja_JP',
+      symbol: '¥',
+      decimalDigits: 0,
+    ).format(metrics.mrrYen);
+
+    return Card(
+      elevation: 3,
+      shadowColor: const Color(0x33000000),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      color: Theme.of(context).colorScheme.surfaceContainerLow,
+      child: Padding(
+        padding: const EdgeInsets.all(18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(
+                  Icons.workspace_premium,
+                  color: Color(0xFF0D9488),
+                ),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    '有料転換',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                Text(
+                  'active pro/team',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'billing_subscriptions の active な Pro/Team だけを集計します。',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 14),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                _buildMiniKpiChip(
+                  label: '課金ユーザー数',
+                  value: '${metrics.paidCustomers}',
+                  color: const Color(0xFF0D9488),
+                ),
+                _buildMiniKpiChip(
+                  label: 'MRR',
+                  value: formattedMrr,
+                  color: const Color(0xFF7C3AED),
+                ),
+                _buildMiniKpiChip(
+                  label: 'free→paid CVR',
+                  value: conversionRate,
+                  color: const Color(0xFF6366F1),
+                ),
+                _buildMiniKpiChip(
+                  label: '登録総数',
+                  value: '$totalUsers',
+                  color: const Color(0xFF475569),
                 ),
               ],
             ),

--- a/supabase/migrations/20260627210000_admin_read_billing_subscriptions.sql
+++ b/supabase/migrations/20260627210000_admin_read_billing_subscriptions.sql
@@ -1,0 +1,41 @@
+-- Admin-only paid conversion aggregate for AdminAnalyticsPage.
+-- Keeps billing_subscriptions row-level data behind RLS and exposes only
+-- count/MRR after the caller is confirmed via public.is_user_admin().
+
+CREATE OR REPLACE FUNCTION public.get_billing_paid_conversion_summary()
+RETURNS TABLE (
+  paid_customers integer,
+  mrr_yen integer
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT
+    CASE
+      WHEN public.is_user_admin(auth.uid()) THEN COUNT(*)::integer
+      ELSE 0
+    END AS paid_customers,
+    CASE
+      WHEN public.is_user_admin(auth.uid()) THEN COALESCE(
+        SUM(
+          CASE tier
+            WHEN 'pro' THEN 980
+            WHEN 'team' THEN 2980
+            ELSE 0
+          END
+        ),
+        0
+      )::integer
+      ELSE 0
+    END AS mrr_yen
+  FROM public.billing_subscriptions
+  WHERE status = 'active'
+    AND tier IN ('pro', 'team');
+$$;
+
+REVOKE ALL ON FUNCTION public.get_billing_paid_conversion_summary()
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_billing_paid_conversion_summary()
+  TO authenticated;

--- a/test/pages/admin_analytics_page_test.dart
+++ b/test/pages/admin_analytics_page_test.dart
@@ -13,9 +13,13 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 class FakeSupabaseClient extends Fake implements SupabaseClient {
   final _queryBuilder = FakeSupabaseQueryBuilder();
-  final Map<String, dynamic> _rpcResponse = <String, dynamic>{};
+  final Map<String, dynamic> _rpcResponses = <String, dynamic>{};
 
   FakeSupabaseQueryBuilder get queryBuilder => _queryBuilder;
+
+  void setRpcResponse(String functionName, dynamic data) {
+    _rpcResponses[functionName] = data;
+  }
 
   @override
   SupabaseQueryBuilder from(String table) {
@@ -26,7 +30,13 @@ class FakeSupabaseClient extends Fake implements SupabaseClient {
   @override
   dynamic noSuchMethod(Invocation invocation) {
     if (invocation.memberName == #rpc) {
-      return FakePostgrestFilterBuilder<dynamic>(_rpcResponse, false);
+      final functionName = invocation.positionalArguments.isEmpty
+          ? ''
+          : invocation.positionalArguments.first.toString();
+      return FakePostgrestFilterBuilder<dynamic>(
+        _rpcResponses[functionName] ?? <String, dynamic>{},
+        false,
+      );
     }
     return super.noSuchMethod(invocation);
   }
@@ -320,6 +330,32 @@ void main() {
     expect(find.text('4.0'), findsOneWidget);
   });
 
+  testWidgets('Shows paid conversion metrics from admin billing summary',
+      (WidgetTester tester) async {
+    fakeSupabaseClient.setRpcResponse(
+      'get_billing_paid_conversion_summary',
+      [
+        {'paid_customers': 2, 'mrr_yen': 3960},
+      ],
+    );
+    fakeSupabaseClient.queryBuilder
+      ..setData(sampleData())
+      ..setData(
+        profileData(todayRegistrations: 2, previousRegistrations: 18),
+        table: 'user_profiles',
+      );
+
+    await tester.pumpWidget(createTestWidget());
+    await tester.pumpAndSettle();
+
+    expect(find.text('有料転換'), findsOneWidget);
+    expect(find.text('課金ユーザー数'), findsOneWidget);
+    expect(find.text('MRR'), findsOneWidget);
+    expect(find.text('free→paid CVR'), findsOneWidget);
+    expect(find.text('¥3,960'), findsOneWidget);
+    expect(find.text('10.0%'), findsWidgets);
+  });
+
   testWidgets('Shows empty state when there is no data',
       (WidgetTester tester) async {
     fakeSupabaseClient.queryBuilder
@@ -331,6 +367,8 @@ void main() {
 
     expect(find.text('0.0'), findsOneWidget);
     expect(find.text('今日の登録目標'), findsOneWidget);
+    expect(find.text('有料転換'), findsOneWidget);
+    expect(find.text('¥0'), findsOneWidget);
   });
 
   testWidgets('Handles Supabase error gracefully', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary

- Add a paid-conversion section to `AdminAnalyticsPage` with paid user count, MRR, free→paid CVR, and total registered users.
- Add an admin-only `get_billing_paid_conversion_summary()` SQL RPC that aggregates active Pro/Team subscriptions without exposing subscription rows.
- Extend the AdminAnalytics widget test to cover the billing summary display and the zero paid/MRR empty state.

## Validation

- PASS: `python scripts/codex_session_check.py`
- PASS: `python scripts/ai_tool_watch.py --print-only`
- PASS: `git diff --check`
- NOTE: Local Flutter test execution is unreliable in this Windows worktree because repository hooks spawn long-running Flutter/Dart processes; GitHub Actions is the authoritative validation for analyze, format, tests, and migrations.

## Minimal E2E Gate

- Implementation-detail independent: the coverage asserts user-visible input/output on the admin dashboard, not private widget internals.
- Minimal scope: about 3 cases are covered or specified: paid summary values render from the admin billing summary, zero paid subscriptions render as `0` / `¥0`, and non-admin callers receive a zero aggregate from the SQL RPC.
- E2E: Flutter widget coverage in `test/pages/admin_analytics_page_test.dart` exercises the dashboard route; no `integration_test/` or Playwright route is added in this PR.
- E2E-Exception: This is a read-only admin dashboard aggregate plus an admin-checked SQL RPC, so a focused widget test and deterministic SQL review are the smallest reliable black-box checks.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Read-only billing aggregate and admin dashboard UI only; no Stripe checkout, webhook mutation, payment execution, subscription write path, secret, deploy, or production data mutation. Access is constrained by `public.is_user_admin(auth.uid())`, and rollback is dropping `public.get_billing_paid_conversion_summary()`.
- Unresolved findings: 0

Closes #3666
