### PR TITLE
fix: 紹介報酬を課金成立後のStripe Proクレジットへ接続 (#3669)

### DIFF
--- a/docs/issue-fix-plans/issue-3669.md
+++ b/docs/issue-fix-plans/issue-3669.md
@@ -1,0 +1,44 @@
+# Issue Fix Plan #3669
+
+- Issue: [[追加要望] 紹介報酬を不活性な500ポイントから実Stripe特典(クーポン/Proクレジット)へ接続](https://github.com/kanta13jp1/my_web_app/issues/3669)
+- Labels: priority:high,追加要望,monetization,growth,acquisition
+- Workflow: `.github/workflows/github-issue-fix.yml`
+- CI repair pair: `.github/workflows/ci-auto-fix.yml`
+- Run: https://github.com/kanta13jp1/my_web_app/actions/runs/28558847001
+
+## Goal
+
+[追加要望] 紹介報酬を不活性な500ポイントから実Stripe特典(クーポン/Proクレジット)へ接続
+
+## Current Context
+
+```text
+**P1 / acquisition / owner=either**
+
+REFERRAL_PROGRAM_DESIGN.md:37-50のgive-get 'Pro1ヶ月無料' はStripe待ちでdesign-onlyのまま。現状の唯一のlive報酬は引き換え不能な500 bonus_pointsでsignup時自動completed(gameable)。Stripeがliveになった今、UTMリンク/growth-hub EF/shareサービスという既存バイラル基盤を実際の/billingトラフィックへ変換できる最高ROIの一手。
+
+### 受け入れ条件
+- 紹介成立時にStripe coupon/Proクレジット等の実引き換え経路を付与
+- /referral とshareカードにgive-get('招待された人もPro特典')を表示
+- 報酬付与をsignup時自動completedからactivation gatingへ変更
+- redemptionが二重付与/自己紹介で悪用されないことを確認
+
+統括: #3663 ／ 親: 収益化 #3639
+
+
+```
+
+## Autonomous Repair Loop
+
+1. Reproduce the smallest failing path for this issue.
+2. Apply the minimum safe fix on this branch.
+3. Let normal CI run on the draft PR.
+4. If CI fails on mechanical issues, `ci-auto-fix.yml` attempts `dart fix --apply` and `deno fmt`.
+5. Merge only after CI is green and the issue scope is satisfied.
+
+## Checklist
+
+- [ ] Reproduction is clear
+- [ ] Smallest safe fix is implemented
+- [ ] Analyze/tests/CI are checked
+- [ ] PR notes explain the change and the remaining risk

--- a/lib/domain/referral_benefit_copy.dart
+++ b/lib/domain/referral_benefit_copy.dart
@@ -12,9 +12,8 @@ abstract final class ReferralBenefitCopy {
     String inviteUrl, {
     bool includeHashtags = false,
   }) {
-    final hashtags = includeHashtags
-        ? '\n\n#buildinpublic #FlutterWeb #自分株式会社'
-        : '';
+    final hashtags =
+        includeHashtags ? '\n\n#buildinpublic #FlutterWeb #自分株式会社' : '';
     return '自分株式会社を一緒に試してみませんか？\n\n'
         '$shareSummary\n\n'
         '招待リンク:\n${inviteUrl.trim()}$hashtags';

--- a/lib/domain/referral_benefit_copy.dart
+++ b/lib/domain/referral_benefit_copy.dart
@@ -1,0 +1,22 @@
+/// User-facing give-get terms shared by the referral page and share surfaces.
+abstract final class ReferralBenefitCopy {
+  static const headline = '招待した人も、招待された人もPro特典';
+
+  static const detail =
+      '友達のPro課金が成立すると、2人のStripe請求残高へPro月額1か月分のクレジットを付与し、次回請求に自動充当します。登録だけでは付与されません。';
+
+  static const shareSummary =
+      '招待リンクから登録してProを始めると、招待した人・された人の両方にPro月額1か月分のクレジット。';
+
+  static String buildShareText(
+    String inviteUrl, {
+    bool includeHashtags = false,
+  }) {
+    final hashtags = includeHashtags
+        ? '\n\n#buildinpublic #FlutterWeb #自分株式会社'
+        : '';
+    return '自分株式会社を一緒に試してみませんか？\n\n'
+        '$shareSummary\n\n'
+        '招待リンク:\n${inviteUrl.trim()}$hashtags';
+  }
+}

--- a/lib/pages/referral_page.dart
+++ b/lib/pages/referral_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../domain/referral_benefit_copy.dart';
 import '../services/growth_mission_service.dart';
 
 /// 紹介プログラムページ
@@ -74,14 +75,7 @@ class _ReferralPageState extends State<ReferralPage> {
   Future<void> _shareInvite() async {
     final inviteUrl = _inviteUrl;
     if (inviteUrl == null) return;
-    final text = '''
-自分株式会社を一緒に試してみませんか？
-
-Notion・Evernote・MoneyForward・Slack・X の機能を1つに統合したAIライフマネジメントアプリです。
-
-招待リンク:
-$inviteUrl
-''';
+    final text = ReferralBenefitCopy.buildShareText(inviteUrl);
     await SharePlus.instance.share(
       ShareParams(
         subject: '自分株式会社への招待',
@@ -178,7 +172,7 @@ $inviteUrl
           ),
           const SizedBox(height: 14),
           Text(
-            '紹介リンクで初回体験までつなげる',
+            ReferralBenefitCopy.headline,
             style: TextStyle(
               color: colorScheme.onPrimaryContainer,
               fontSize: 22,
@@ -187,7 +181,7 @@ $inviteUrl
           ),
           const SizedBox(height: 8),
           Text(
-            '招待リンクには紹介コードとUTMを付与します。友達がリンクから登録すると、紹介実績として集計されます。',
+            '招待リンクには紹介コードとUTMを付与します。${ReferralBenefitCopy.detail}',
             style: TextStyle(
               color: colorScheme.onPrimaryContainer.withValues(alpha: 0.82),
               height: 1.6,
@@ -252,7 +246,7 @@ $inviteUrl
         Expanded(
           child: _buildStatCard(
             colorScheme,
-            label: '登録完了',
+            label: '特典成立',
             value: '${_snapshot.successfulReferrals}',
             icon: Icons.verified_outlined,
           ),
@@ -403,7 +397,12 @@ $inviteUrl
         const SizedBox(height: 10),
         _buildStep(colorScheme, 1, 'リンクを送る', 'LINE・X・Slackなどで招待リンクを共有します。'),
         _buildStep(colorScheme, 2, '友達が登録する', '紹介コードは端末に保存され、ログイン後に紐づきます。'),
-        _buildStep(colorScheme, 3, '実績が増える', '登録完了した紹介は、グロースダッシュボードにも反映されます。'),
+        _buildStep(
+          colorScheme,
+          3,
+          'Pro課金で特典成立',
+          '登録だけでは報酬を付与せず、友達のPro課金が確認できた時点で2人分のクレジットを一度だけ付与します。',
+        ),
       ],
     );
   }
@@ -469,7 +468,7 @@ $inviteUrl
           const SizedBox(width: 12),
           Expanded(
             child: Text(
-              '報酬設計は 1 登録完了 = 500 bonus points を基準にしています。次の実装でランキングと報酬表示を広げます。',
+              ReferralBenefitCopy.detail,
               style: TextStyle(
                 color: colorScheme.onSecondaryContainer,
                 height: 1.6,

--- a/lib/widgets/referral_share_card.dart
+++ b/lib/widgets/referral_share_card.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:web/web.dart' as web;
+
+import '../domain/referral_benefit_copy.dart';
 import '../services/growth_mission_service.dart';
 
 /// ホーム画面に表示する友達招待カード。
@@ -62,10 +64,10 @@ class _ReferralShareCardState extends State<ReferralShareCard> {
   }
 
   void _shareToX() {
-    final text = '自分株式会社を一緒に試してみませんか？\n'
-        'Notion・Evernote・MoneyForward・Slack・Xなど21競合の機能を1アプリに統合。完全無料👇\n'
-        '$_shareUrl\n'
-        '#buildinpublic #FlutterWeb #自分株式会社';
+    final text = ReferralBenefitCopy.buildShareText(
+      _shareUrl,
+      includeHashtags: true,
+    );
     final intentUrl =
         'https://x.com/intent/tweet?text=${Uri.encodeComponent(text)}';
     web.window.open(intentUrl, '_blank');
@@ -73,9 +75,12 @@ class _ReferralShareCardState extends State<ReferralShareCard> {
 
   void _nativeShare() {
     try {
-      const text = '21SaaS統合の自分株式会社を試してみよう！完全無料。';
       web.window.navigator.share(
-        web.ShareData(title: '自分株式会社', text: text, url: _shareUrl),
+        web.ShareData(
+          title: '自分株式会社',
+          text: ReferralBenefitCopy.shareSummary,
+          url: _shareUrl,
+        ),
       );
     } catch (_) {
       // Web Share API 非対応ブラウザはフォールバックとしてコピー
@@ -132,7 +137,7 @@ class _ReferralShareCardState extends State<ReferralShareCard> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      '友達を招待する',
+                      ReferralBenefitCopy.headline,
                       style: TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w700,
@@ -141,7 +146,7 @@ class _ReferralShareCardState extends State<ReferralShareCard> {
                       ),
                     ),
                     Text(
-                      '招待リンクをシェアして一緒に使おう',
+                      'Pro課金成立で、2人の次回請求に1か月分を自動充当',
                       style: TextStyle(
                         fontSize: 11,
                         color: isDark

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -7,6 +7,10 @@ import {
 } from "./event_processing.ts";
 import { activateReferralForPaidCheckout } from "./referral_activation.ts";
 import {
+  fulfillReferralCreditsForPaidCheckout,
+  ReferralCreditGrant,
+} from "./referral_credit.ts";
+import {
   invoiceSubscriptionId,
   subscriptionCurrentPeriodEnd,
 } from "./stripe_api_compat.ts";
@@ -22,6 +26,7 @@ const SERVICE_ROLE_KEY = (Deno.env.get("SERVICE_ROLE_KEY") ?? "").trim();
 const STRIPE_SECRET_KEY = (Deno.env.get("STRIPE_SECRET_KEY") ?? "").trim();
 const STRIPE_WEBHOOK_SECRET = (Deno.env.get("STRIPE_WEBHOOK_SECRET") ?? "")
   .trim();
+const STRIPE_API_VERSION = "2026-06-24.dahlia";
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -142,7 +147,10 @@ async function verifyStripeEvent(rawBody: string, signatureHeader: string) {
 async function stripeGet(path: string): Promise<Record<string, unknown>> {
   if (!STRIPE_SECRET_KEY) throw new Error("STRIPE_SECRET_KEY not configured");
   const response = await fetch(`https://api.stripe.com/v1${path}`, {
-    headers: { Authorization: `Bearer ${STRIPE_SECRET_KEY}` },
+    headers: {
+      Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+      "Stripe-Version": STRIPE_API_VERSION,
+    },
   });
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
@@ -152,6 +160,120 @@ async function stripeGet(path: string): Promise<Record<string, unknown>> {
     );
   }
   return asRecord(data) ?? {};
+}
+
+async function stripePostForm(
+  path: string,
+  params: Record<string, string>,
+  idempotencyKey?: string,
+): Promise<Record<string, unknown>> {
+  if (!STRIPE_SECRET_KEY) throw new Error("STRIPE_SECRET_KEY not configured");
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+    "Content-Type": "application/x-www-form-urlencoded",
+    "Stripe-Version": STRIPE_API_VERSION,
+  };
+  if (idempotencyKey) headers["Idempotency-Key"] = idempotencyKey;
+  const response = await fetch(`https://api.stripe.com/v1${path}`, {
+    method: "POST",
+    headers,
+    body: new URLSearchParams(params),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const err = asRecord(data.error) ?? {};
+    throw new Error(
+      asString(err.message) || `Stripe API failed: ${response.status}`,
+    );
+  }
+  return asRecord(data) ?? {};
+}
+
+function stripeProPriceId(): string {
+  return (Deno.env.get("STRIPE_PRO_PRICE_ID") ??
+    Deno.env.get("STRIPE_PRICE_PRO") ?? "").trim();
+}
+
+async function loadReferralCreditValue(): Promise<{
+  amount: number;
+  currency: string;
+}> {
+  const priceId = stripeProPriceId();
+  if (!priceId) throw new Error("STRIPE_PRO_PRICE_ID not configured");
+  const price = await stripeGet(`/prices/${encodeURIComponent(priceId)}`);
+  const amount = asInteger(price.unit_amount) ?? 0;
+  const currency = asString(price.currency).toLowerCase();
+  const recurring = asRecord(price.recurring);
+  if (
+    amount <= 0 ||
+    !/^[a-z]{3}$/.test(currency) ||
+    asString(recurring?.interval) !== "month" ||
+    (asInteger(recurring?.interval_count) ?? 1) !== 1
+  ) {
+    throw new Error("Stripe Pro price must be a one-month recurring price");
+  }
+  return { amount, currency };
+}
+
+async function getOrCreateReferralStripeCustomer(
+  admin: SupabaseClient,
+  userId: string,
+): Promise<string> {
+  const { data: currentData, error: currentError } = await admin
+    .from("billing_subscriptions")
+    .select("stripe_customer_id, tier, status, metadata")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (currentError) throw new Error(currentError.message);
+  const current = asRecord(currentData) ?? {};
+  const existingCustomerId = asString(current.stripe_customer_id);
+  if (existingCustomerId) return existingCustomerId;
+
+  const { data: userData, error: userError } = await admin.auth.admin
+    .getUserById(userId);
+  if (userError) throw new Error(userError.message);
+  const customer = await stripePostForm("/customers", {
+    email: userData.user?.email ?? "",
+    "metadata[user_id]": userId,
+    "metadata[source]": "referral_credit",
+  }, `referral-customer-${userId}`);
+  const customerId = asString(customer.id);
+  if (!customerId) throw new Error("Stripe customer id missing");
+
+  const { error: upsertError } = await admin.from("billing_subscriptions")
+    .upsert({
+      user_id: userId,
+      stripe_customer_id: customerId,
+      tier: asString(current.tier, "free"),
+      status: asString(current.status, "active"),
+      metadata: {
+        ...(asRecord(current.metadata) ?? {}),
+        referral_credit_customer_created: true,
+      },
+    }, { onConflict: "user_id" });
+  if (upsertError) throw new Error(upsertError.message);
+  return customerId;
+}
+
+async function createReferralBalanceTransaction(input: {
+  grant: ReferralCreditGrant;
+  customerId: string;
+  amount: number;
+  currency: string;
+}): Promise<string> {
+  const transaction = await stripePostForm(
+    `/customers/${encodeURIComponent(input.customerId)}/balance_transactions`,
+    {
+      amount: String(input.amount),
+      currency: input.currency,
+      description: "紹介特典: Pro 1か月分クレジット",
+      "metadata[referral_credit_grant_id]": String(input.grant.id),
+      "metadata[referral_id]": String(input.grant.referralId),
+      "metadata[beneficiary_role]": input.grant.beneficiaryRole,
+    },
+    input.grant.stripeIdempotencyKey,
+  );
+  return asString(transaction.id);
 }
 
 async function userIdForCustomer(
@@ -393,11 +515,20 @@ async function handleCheckoutCompleted(
     await upsertSubscriptionFromStripe(admin, subscription, userId);
   }
 
-  await activateReferralForPaidCheckout(
+  const hasReferral = await activateReferralForPaidCheckout(
     admin,
     userId,
     asString(session.id),
   );
+  if (hasReferral) {
+    await fulfillReferralCreditsForPaidCheckout(userId, {
+      client: admin,
+      loadCreditValue: loadReferralCreditValue,
+      getOrCreateCustomer: (beneficiaryUserId) =>
+        getOrCreateReferralStripeCustomer(admin, beneficiaryUserId),
+      createBalanceTransaction: createReferralBalanceTransaction,
+    });
+  }
 }
 
 /**

--- a/supabase/functions/stripe-webhook/referral_credit.test.ts
+++ b/supabase/functions/stripe-webhook/referral_credit.test.ts
@@ -1,0 +1,138 @@
+import {
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  fulfillReferralCreditsForPaidCheckout,
+  ReferralCreditGrant,
+  ReferralCreditRpcClient,
+} from "./referral_credit.ts";
+
+type RpcCall = { functionName: string; args: Record<string, unknown> };
+
+class FakeClient implements ReferralCreditRpcClient {
+  calls: RpcCall[] = [];
+  grants: unknown[] = [];
+  failError: { message: string } | null = null;
+
+  rpc(functionName: string, args: Record<string, unknown>) {
+    this.calls.push({ functionName, args });
+    if (functionName === "claim_next_referral_credit_grant") {
+      return Promise.resolve({
+        data: this.grants.shift() ?? null,
+        error: null,
+      });
+    }
+    if (functionName === "fail_referral_credit_grant") {
+      return Promise.resolve({
+        data: this.failError === null,
+        error: this.failError,
+      });
+    }
+    return Promise.resolve({ data: true, error: null });
+  }
+}
+
+function grant(
+  id: number,
+  role: "referrer" | "referred",
+): Record<string, unknown> {
+  return {
+    id,
+    referral_id: 91,
+    beneficiary_user_id: `${role}-user`,
+    beneficiary_role: role,
+    stripe_idempotency_key: `referral-credit-91-${role}`,
+  };
+}
+
+Deno.test("paid activation grants one Pro-month credit to both users", async () => {
+  const client = new FakeClient();
+  client.grants = [grant(1, "referrer"), grant(2, "referred")];
+  const transactions: Array<{
+    grant: ReferralCreditGrant;
+    customerId: string;
+    amount: number;
+    currency: string;
+  }> = [];
+
+  const count = await fulfillReferralCreditsForPaidCheckout(" referred-user ", {
+    client,
+    loadCreditValue: () => Promise.resolve({ amount: 1200, currency: "JPY" }),
+    getOrCreateCustomer: (userId) => Promise.resolve(`cus_${userId}`),
+    createBalanceTransaction: (input) => {
+      transactions.push(input);
+      return Promise.resolve(`cbtxn_${input.grant.id}`);
+    },
+  });
+
+  assertEquals(count, 2);
+  assertEquals(
+    transactions.map((entry) => ({
+      role: entry.grant.beneficiaryRole,
+      amount: entry.amount,
+      currency: entry.currency,
+      idempotencyKey: entry.grant.stripeIdempotencyKey,
+    })),
+    [
+      {
+        role: "referrer",
+        amount: -1200,
+        currency: "jpy",
+        idempotencyKey: "referral-credit-91-referrer",
+      },
+      {
+        role: "referred",
+        amount: -1200,
+        currency: "jpy",
+        idempotencyKey: "referral-credit-91-referred",
+      },
+    ],
+  );
+  assertEquals(
+    client.calls.filter((call) =>
+      call.functionName === "complete_referral_credit_grant"
+    ).length,
+    2,
+  );
+});
+
+Deno.test("already granted referral is a no-op", async () => {
+  const client = new FakeClient();
+  let stripeCalls = 0;
+  const count = await fulfillReferralCreditsForPaidCheckout("user-1", {
+    client,
+    loadCreditValue: () => Promise.resolve({ amount: 1200, currency: "jpy" }),
+    getOrCreateCustomer: () => Promise.resolve("cus_1"),
+    createBalanceTransaction: () => {
+      stripeCalls++;
+      return Promise.resolve("cbtxn_1");
+    },
+  });
+
+  assertEquals(count, 0);
+  assertEquals(stripeCalls, 0);
+});
+
+Deno.test("Stripe failure persists a retryable grant state", async () => {
+  const client = new FakeClient();
+  client.grants = [grant(7, "referrer")];
+
+  await assertRejects(
+    () =>
+      fulfillReferralCreditsForPaidCheckout("user-1", {
+        client,
+        loadCreditValue: () =>
+          Promise.resolve({ amount: 1200, currency: "jpy" }),
+        getOrCreateCustomer: () => Promise.resolve("cus_1"),
+        createBalanceTransaction: () =>
+          Promise.reject(new Error("Stripe down")),
+      }),
+    Error,
+    "Stripe down",
+  );
+  assertEquals(client.calls.at(-1), {
+    functionName: "fail_referral_credit_grant",
+    args: { p_grant_id: 7, p_error: "Stripe down" },
+  });
+});

--- a/supabase/functions/stripe-webhook/referral_credit.ts
+++ b/supabase/functions/stripe-webhook/referral_credit.ts
@@ -1,0 +1,164 @@
+export type ReferralCreditRpcClient = {
+  rpc(
+    functionName: string,
+    args: Record<string, unknown>,
+  ): PromiseLike<{ data: unknown; error: { message: string } | null }>;
+};
+
+export type ReferralCreditValue = {
+  amount: number;
+  currency: string;
+};
+
+export type ReferralCreditGrant = {
+  id: number;
+  referralId: number;
+  beneficiaryUserId: string;
+  beneficiaryRole: "referrer" | "referred";
+  stripeIdempotencyKey: string;
+};
+
+export type ReferralCreditDependencies = {
+  client: ReferralCreditRpcClient;
+  loadCreditValue: () => Promise<ReferralCreditValue>;
+  getOrCreateCustomer: (userId: string) => Promise<string>;
+  createBalanceTransaction: (input: {
+    grant: ReferralCreditGrant;
+    customerId: string;
+    amount: number;
+    currency: string;
+  }) => Promise<string>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asPositiveInteger(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function parseGrant(value: unknown): ReferralCreditGrant | null {
+  const row = asRecord(value);
+  if (!row) return null;
+  const id = asPositiveInteger(row.id);
+  const referralId = asPositiveInteger(row.referral_id);
+  const beneficiaryUserId = asString(row.beneficiary_user_id);
+  const beneficiaryRole = asString(row.beneficiary_role);
+  const stripeIdempotencyKey = asString(row.stripe_idempotency_key);
+  if (
+    !id ||
+    !referralId ||
+    !beneficiaryUserId ||
+    !stripeIdempotencyKey ||
+    (beneficiaryRole !== "referrer" && beneficiaryRole !== "referred")
+  ) {
+    throw new Error("Malformed referral credit grant");
+  }
+  return {
+    id,
+    referralId,
+    beneficiaryUserId,
+    beneficiaryRole,
+    stripeIdempotencyKey,
+  };
+}
+
+function normalizeCreditValue(value: ReferralCreditValue): ReferralCreditValue {
+  const amount = asPositiveInteger(value.amount);
+  const currency = asString(value.currency).toLowerCase();
+  if (!amount || !/^[a-z]{3}$/.test(currency)) {
+    throw new Error("Stripe Pro price has an invalid referral credit value");
+  }
+  return { amount, currency };
+}
+
+async function markGrantFailed(
+  client: ReferralCreditRpcClient,
+  grantId: number,
+  error: unknown,
+): Promise<void> {
+  const message = error instanceof Error ? error.message : String(error);
+  const { error: rpcError } = await client.rpc("fail_referral_credit_grant", {
+    p_grant_id: grantId,
+    p_error: message,
+  });
+  if (rpcError) {
+    throw new Error(
+      `${message}; failed to persist retry state: ${rpcError.message}`,
+    );
+  }
+}
+
+/// Fulfills the two give-get credits created by referral activation.
+///
+/// The database claim is atomic and each Stripe request uses a stable,
+/// grant-specific idempotency key. A completed grant is never claimable again.
+export async function fulfillReferralCreditsForPaidCheckout(
+  referredUserId: string,
+  dependencies: ReferralCreditDependencies,
+): Promise<number> {
+  const userId = referredUserId.trim();
+  if (!userId) return 0;
+
+  let creditValue: ReferralCreditValue | null = null;
+  let grantedCount = 0;
+  for (let index = 0; index < 2; index++) {
+    const { data, error } = await dependencies.client.rpc(
+      "claim_next_referral_credit_grant",
+      { p_referred_user_id: userId },
+    );
+    if (error) throw new Error(error.message);
+    const grant = parseGrant(data);
+    if (!grant) break;
+
+    try {
+      creditValue ??= normalizeCreditValue(
+        await dependencies.loadCreditValue(),
+      );
+      const customerId = (
+        await dependencies.getOrCreateCustomer(grant.beneficiaryUserId)
+      ).trim();
+      if (!customerId) throw new Error("Stripe customer id missing");
+
+      const transactionId = (
+        await dependencies.createBalanceTransaction({
+          grant,
+          customerId,
+          amount: -creditValue.amount,
+          currency: creditValue.currency,
+        })
+      ).trim();
+      if (!transactionId) {
+        throw new Error("Stripe balance transaction id missing");
+      }
+
+      const completion = await dependencies.client.rpc(
+        "complete_referral_credit_grant",
+        {
+          p_grant_id: grant.id,
+          p_stripe_customer_id: customerId,
+          p_stripe_balance_transaction_id: transactionId,
+          p_credit_amount: creditValue.amount,
+          p_currency: creditValue.currency,
+        },
+      );
+      if (completion.error) throw new Error(completion.error.message);
+      if (completion.data !== true) {
+        throw new Error("Referral credit grant was not finalized");
+      }
+      grantedCount++;
+    } catch (error) {
+      await markGrantFailed(dependencies.client, grant.id, error);
+      throw error;
+    }
+  }
+  return grantedCount;
+}

--- a/supabase/migrations/20260815162827_referral_stripe_credit_grants.sql
+++ b/supabase/migrations/20260815162827_referral_stripe_credit_grants.sql
@@ -1,6 +1,8 @@
 -- Convert activation-gated referral points into an auditable Stripe credit
 -- outbox. Stripe calls remain in the webhook; these RPCs only claim/finalize
 -- short database transactions so external I/O never holds a row lock.
+-- nocheck: time-relative -- UPDATE statements below are runtime RPC bodies;
+-- this migration executes no data UPDATE while being applied or replayed.
 
 create table if not exists public.referral_credit_grants (
   id bigint generated always as identity primary key,

--- a/supabase/migrations/20260815162827_referral_stripe_credit_grants.sql
+++ b/supabase/migrations/20260815162827_referral_stripe_credit_grants.sql
@@ -1,0 +1,269 @@
+-- Convert activation-gated referral points into an auditable Stripe credit
+-- outbox. Stripe calls remain in the webhook; these RPCs only claim/finalize
+-- short database transactions so external I/O never holds a row lock.
+
+create table if not exists public.referral_credit_grants (
+  id bigint generated always as identity primary key,
+  referral_id bigint not null
+    references public.referrals(id) on delete cascade,
+  beneficiary_user_id uuid not null
+    references auth.users(id) on delete cascade,
+  beneficiary_role text not null
+    check (beneficiary_role in ('referrer', 'referred')),
+  reward_points integer not null default 500
+    check (reward_points > 0),
+  status text not null default 'pending'
+    check (status in ('pending', 'processing', 'granted', 'failed')),
+  stripe_idempotency_key text not null unique,
+  stripe_customer_id text,
+  stripe_balance_transaction_id text unique,
+  credit_amount integer check (credit_amount is null or credit_amount > 0),
+  currency text check (currency is null or currency ~ '^[a-z]{3}$'),
+  attempt_count integer not null default 0 check (attempt_count >= 0),
+  last_attempt_at timestamptz,
+  granted_at timestamptz,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (referral_id, beneficiary_role)
+);
+
+create index if not exists referral_credit_grants_beneficiary_idx
+  on public.referral_credit_grants (beneficiary_user_id, created_at desc);
+
+create index if not exists referral_credit_grants_pending_idx
+  on public.referral_credit_grants (referral_id, id)
+  where status in ('pending', 'failed');
+
+alter table public.referral_credit_grants enable row level security;
+
+revoke all on table public.referral_credit_grants
+  from public, anon, authenticated;
+grant select, insert, update on table public.referral_credit_grants
+  to service_role;
+revoke all on sequence public.referral_credit_grants_id_seq
+  from public, anon, authenticated;
+grant usage, select on sequence public.referral_credit_grants_id_seq
+  to service_role;
+
+comment on table public.referral_credit_grants is
+  'Service-role-only outbox for one-time Stripe invoice credits earned by referral activation.';
+
+-- Recreate the existing activation RPC so the referral state transition and
+-- both give-get outbox rows commit atomically. ON CONFLICT makes webhook
+-- retries and already-completed historical referrals safe.
+create or replace function public.complete_referral_activation(
+  p_referred_user_id uuid,
+  p_activation_source text default 'stripe_checkout_paid',
+  p_stripe_checkout_session_id text default null
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_referral_id bigint;
+  v_referrer_user_id uuid;
+  v_completed_at timestamptz := now();
+begin
+  select referral.id, referral.referrer_user_id
+    into v_referral_id, v_referrer_user_id
+  from public.referrals as referral
+  where referral.referred_user_id = p_referred_user_id
+    and referral.status in ('pending', 'pending_activation', 'completed')
+  for update;
+
+  if not found or
+    v_referrer_user_id is null or
+    v_referrer_user_id = p_referred_user_id then
+    return false;
+  end if;
+
+  update public.referrals as referral
+  set
+    status = 'completed',
+    completed_at = coalesce(referral.completed_at, v_completed_at),
+    metadata = coalesce(referral.metadata, '{}'::jsonb) ||
+      jsonb_strip_nulls(jsonb_build_object(
+        'activation_source', coalesce(
+          nullif(btrim(p_activation_source), ''),
+          'stripe_checkout_paid'
+        ),
+        'activated_at', coalesce(referral.completed_at, v_completed_at),
+        'stripe_checkout_session_id', nullif(
+          btrim(p_stripe_checkout_session_id),
+          ''
+        ),
+        'stripe_credit_outbox', true
+      ))
+  where referral.id = v_referral_id
+    and referral.status in ('pending', 'pending_activation');
+
+  insert into public.referral_credit_grants (
+    referral_id,
+    beneficiary_user_id,
+    beneficiary_role,
+    stripe_idempotency_key
+  )
+  values
+    (
+      v_referral_id,
+      v_referrer_user_id,
+      'referrer',
+      'referral-credit-' || v_referral_id::text || '-referrer'
+    ),
+    (
+      v_referral_id,
+      p_referred_user_id,
+      'referred',
+      'referral-credit-' || v_referral_id::text || '-referred'
+    )
+  on conflict (referral_id, beneficiary_role) do nothing;
+
+  update public.referral_codes as code
+  set
+    total_referrals = (
+      select count(*)::integer
+      from public.referrals as referral
+      where referral.referrer_user_id = v_referrer_user_id
+    ),
+    successful_referrals = (
+      select count(*)::integer
+      from public.referrals as referral
+      where referral.referrer_user_id = v_referrer_user_id
+        and referral.status = 'completed'
+    ),
+    bonus_points_earned = (
+      select coalesce(sum(referral.bonus_points), 0)::integer
+      from public.referrals as referral
+      where referral.referrer_user_id = v_referrer_user_id
+        and referral.status = 'completed'
+    )
+  where code.user_id = v_referrer_user_id;
+
+  return true;
+end;
+$$;
+
+revoke all on function public.complete_referral_activation(uuid, text, text)
+  from public, anon, authenticated;
+grant execute on function public.complete_referral_activation(uuid, text, text)
+  to service_role;
+
+create or replace function public.claim_next_referral_credit_grant(
+  p_referred_user_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_grant public.referral_credit_grants%rowtype;
+begin
+  update public.referral_credit_grants as grant_row
+  set
+    status = 'processing',
+    attempt_count = grant_row.attempt_count + 1,
+    last_attempt_at = now(),
+    last_error = null,
+    updated_at = now()
+  where grant_row.id = (
+    select candidate.id
+    from public.referral_credit_grants as candidate
+    join public.referrals as referral
+      on referral.id = candidate.referral_id
+    where referral.referred_user_id = p_referred_user_id
+      and candidate.status in ('pending', 'failed')
+    order by candidate.id
+    limit 1
+    for update of candidate skip locked
+  )
+  returning grant_row.* into v_grant;
+
+  if not found then
+    return null;
+  end if;
+
+  return jsonb_build_object(
+    'id', v_grant.id,
+    'referral_id', v_grant.referral_id,
+    'beneficiary_user_id', v_grant.beneficiary_user_id,
+    'beneficiary_role', v_grant.beneficiary_role,
+    'stripe_idempotency_key', v_grant.stripe_idempotency_key
+  );
+end;
+$$;
+
+revoke all on function public.claim_next_referral_credit_grant(uuid)
+  from public, anon, authenticated;
+grant execute on function public.claim_next_referral_credit_grant(uuid)
+  to service_role;
+
+create or replace function public.complete_referral_credit_grant(
+  p_grant_id bigint,
+  p_stripe_customer_id text,
+  p_stripe_balance_transaction_id text,
+  p_credit_amount integer,
+  p_currency text
+)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  with completed as (
+    update public.referral_credit_grants as grant_row
+    set
+      status = 'granted',
+      stripe_customer_id = nullif(btrim(p_stripe_customer_id), ''),
+      stripe_balance_transaction_id = nullif(
+        btrim(p_stripe_balance_transaction_id),
+        ''
+      ),
+      credit_amount = p_credit_amount,
+      currency = lower(nullif(btrim(p_currency), '')),
+      granted_at = now(),
+      last_error = null,
+      updated_at = now()
+    where grant_row.id = p_grant_id
+      and grant_row.status = 'processing'
+      and p_credit_amount > 0
+      and lower(p_currency) ~ '^[a-z]{3}$'
+    returning 1
+  )
+  select exists(select 1 from completed);
+$$;
+
+revoke all on function public.complete_referral_credit_grant(bigint, text, text, integer, text)
+  from public, anon, authenticated;
+grant execute on function public.complete_referral_credit_grant(bigint, text, text, integer, text)
+  to service_role;
+
+create or replace function public.fail_referral_credit_grant(
+  p_grant_id bigint,
+  p_error text
+)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  with failed as (
+    update public.referral_credit_grants as grant_row
+    set
+      status = 'failed',
+      last_error = left(coalesce(p_error, 'unknown Stripe credit error'), 1000),
+      updated_at = now()
+    where grant_row.id = p_grant_id
+      and grant_row.status = 'processing'
+    returning 1
+  )
+  select exists(select 1 from failed);
+$$;
+
+revoke all on function public.fail_referral_credit_grant(bigint, text)
+  from public, anon, authenticated;
+grant execute on function public.fail_referral_credit_grant(bigint, text)
+  to service_role;

--- a/test/domain/referral_benefit_copy_test.dart
+++ b/test/domain/referral_benefit_copy_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/domain/referral_benefit_copy.dart';
+
+void main() {
+  group('ReferralBenefitCopy', () {
+    test('states the give-get Stripe credit and activation gate honestly', () {
+      expect(ReferralBenefitCopy.headline, contains('招待した人も'));
+      expect(ReferralBenefitCopy.headline, contains('招待された人も'));
+      expect(ReferralBenefitCopy.detail, contains('Stripe請求残高'));
+      expect(ReferralBenefitCopy.detail, contains('次回請求に自動充当'));
+      expect(ReferralBenefitCopy.detail, contains('登録だけでは付与されません'));
+    });
+
+    test('share text includes the invite URL and optional hashtags', () {
+      const url = 'https://example.com/?ref=ABC123';
+      final plain = ReferralBenefitCopy.buildShareText(url);
+      final social = ReferralBenefitCopy.buildShareText(
+        url,
+        includeHashtags: true,
+      );
+
+      expect(plain, contains(url));
+      expect(plain, contains('両方にPro月額1か月分のクレジット'));
+      expect(plain, isNot(contains('#buildinpublic')));
+      expect(social, contains('#buildinpublic'));
+    });
+  });
+}

--- a/test/services/referral_credit_grants_schema_test.dart
+++ b/test/services/referral_credit_grants_schema_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260815162827_referral_stripe_credit_grants.sql';
+
+void main() {
+  group('referral Stripe credit outbox schema', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(
+        _migrationPath,
+      ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+    });
+
+    test(
+      'creates one grant per referral beneficiary with strict state checks',
+      () {
+        expect(
+          sql,
+          contains('create table if not exists public.referral_credit_grants'),
+        );
+        expect(sql, contains("beneficiary_role in ('referrer', 'referred')"));
+        expect(
+          sql,
+          contains("status in ('pending', 'processing', 'granted', 'failed')"),
+        );
+        expect(sql, contains('unique (referral_id, beneficiary_role)'));
+        expect(sql, contains('stripe_idempotency_key text not null unique'));
+      },
+    );
+
+    test('keeps the outbox service-role-only', () {
+      expect(
+        sql,
+        contains(
+          'alter table public.referral_credit_grants enable row level security',
+        ),
+      );
+      expect(
+        sql,
+        contains('revoke all on table public.referral_credit_grants'),
+      );
+      expect(sql, contains('from public, anon, authenticated'));
+      expect(
+        sql,
+        contains(
+          'grant select, insert, update on table public.referral_credit_grants',
+        ),
+      );
+      expect(sql, contains('to service_role'));
+    });
+
+    test('activation atomically creates both give-get grants', () {
+      expect(
+        sql,
+        contains(
+          'create or replace function public.complete_referral_activation',
+        ),
+      );
+      expect(sql, contains("'referrer'"));
+      expect(sql, contains("'referred'"));
+      expect(
+        sql,
+        contains('on conflict (referral_id, beneficiary_role) do nothing'),
+      );
+      expect(sql, contains('v_referrer_user_id = p_referred_user_id'));
+      expect(
+        sql,
+        isNot(contains('cross join lateral')),
+        reason: 'legacy signup-completed rows must not receive paid credits',
+      );
+    });
+
+    test('claims queue rows without worker lock contention', () {
+      expect(
+        sql,
+        contains(
+          'create or replace function public.claim_next_referral_credit_grant',
+        ),
+      );
+      expect(sql, contains('for update of candidate skip locked'));
+      expect(sql, contains("status = 'processing'"));
+      expect(
+        sql,
+        contains(
+          'revoke all on function public.claim_next_referral_credit_grant(uuid)',
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- replace signup-completed referral points with an actual give-get Stripe invoice credit
- grant one configured monthly Pro price credit to both the referrer and referred user only after a paid Pro checkout
- make referral activation, the two credit grants, and retry state auditable and idempotent
- update the referral page and share surfaces with honest activation-gated terms

## Why

The referral flow previously marked signups complete and displayed `500 bonus points`, but those points had no Stripe fulfillment path. That created a gap between the advertised referral benefit and what the billing system could deliver.

## Implementation

- `complete_referral_activation` atomically creates two service-role-only outbox rows
- workers claim grants with `FOR UPDATE ... SKIP LOCKED`
- stable Stripe idempotency keys prevent duplicate balance transactions
- self-referrals are rejected in the database as well as the existing application guard
- the configured `STRIPE_PRO_PRICE_ID` must resolve to a one-month recurring price
- negative Stripe customer-balance transactions automatically credit the next invoice
- legacy signup-completed rows are deliberately not backfilled without a paid checkout event

## User impact

The referral page now states that both people receive one Pro-month credit after the invited user pays for Pro, that the credit is applied to the next invoice, and that registration alone does not qualify.

## Validation

- `deno fmt --check` — passed
- `deno lint` for the Stripe webhook files — passed
- focused Deno tests — 20 passed
- focused Flutter tests — 9 passed
- targeted `flutter analyze` — no issues
- isolated PostgreSQL 16 migration/RPC exercise — activation, two grants, retry, self-referral rejection, and role denial passed
- migration timestamp check — 1,935 unique timestamps, no collision
- `flutter build web --release --no-wasm-dry-run -O2 --no-pub` — passed
- browser QA at 1440x900 and 390x844 — copy rendered correctly, mobile scrolling worked, no horizontal overflow, no console warnings/errors
- production Supabase secret inventory contains `STRIPE_PRO_PRICE_ID`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET` (values were not read)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Signed Stripe webhook and customer-balance fulfillment are not safely reproducible in CI; unit, PostgreSQL RPC, and responsive browser gates cover this change.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 ultrareview is unavailable in this Codex lane; deterministic evidence below covers the required review perspectives.
- Security: the outbox and RPCs are service-role-only, self-referrals are rejected, and stable Stripe idempotency keys prevent duplicate credits.
- Rollback: redeploying the previous webhook stops new Stripe fulfillment; the additive outbox remains auditable and existing grants remain idempotent.
- Data migration: the migration is additive and deliberately does not backfill legacy signup-completed referrals.
- Prod smoke: merge remains gated on deployment success and a production `/referral` route smoke test.
- Observability: grant status, attempt count, last error, customer ID, transaction ID, amount, currency, and timestamps are persisted.
- Unresolved ultrareview findings: none; this block records a truthful cross-instance exception plus deterministic evidence.

Closes #3669
