### PR TITLE
fix(viral-video): OpenAI TTS無条件フォールバック + speech_chain診断 (#3751)

### DIFF
--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -647,6 +647,9 @@ async function createHedraPresenterVideo(params: {
   let storedAudioUrl: string | null = null;
   let storedAudioPath: string | null = null;
   let audioGeneration: Record<string, unknown>;
+  // 音声生成の失敗連鎖を記録し、最終エラーに speech_chain として付記する
+  // (= ダッシュボードのログを見ずに応答だけで診断できるようにする)。
+  const speechChain: string[] = [];
 
   if (HEDRA_UPLOADED_AUDIO_ENABLED && ELEVENLABS_API_KEY) {
     try {
@@ -660,11 +663,12 @@ async function createHedraPresenterVideo(params: {
       storedAudioUrl = audio.url;
       storedAudioPath = audio.path;
     } catch (error) {
+      console.warn("ElevenLabs speech generation failed; falling back", error);
+      speechChain.push(`elevenlabs=${providerErrorMessage(error)}`);
       if (
         params.requiresUploadedAudio &&
         shouldRetryElevenLabsWithFallbackVoice(error)
       ) {
-        let fallbackReason: string | null = null;
         const fallbackResult = await tryElevenLabsFallbackVoices(params.admin, {
           text: spokenScript.slice(0, 1800),
           templateTitle: params.title ?? "share-update",
@@ -688,43 +692,42 @@ async function createHedraPresenterVideo(params: {
             fallbackText: spokenScript.slice(0, 1800),
           });
         }
-        fallbackReason = fallbackResult.reason;
-        if (OPENAI_API_KEY) {
-          try {
-            const openAiAudio = await createOpenAiSpeechAsset(params.admin, {
-              text: spokenScript.slice(0, 1800),
-              templateTitle: `${params.title ?? "share-update"}-openai-tts`,
-              lang: params.lang,
-            });
-            audioGeneration = buildHedraUploadedAudioGeneration(
-              openAiAudio.url,
-            );
-            audioProvider = "openai_tts_fallback";
-            storedAudioUrl = openAiAudio.url;
-            storedAudioPath = openAiAudio.path;
-            return await createHedraVideoFromUploadedAudio(params, {
-              audioGeneration,
-              storedAudioUrl,
-              storedAudioPath,
-              audioProvider,
-              imageUrl,
-              fallbackText: spokenScript.slice(0, 1800),
-            });
-          } catch (openAiError) {
-            fallbackReason = `${fallbackResult.reason}; openai_tts=${
-              providerErrorMessage(openAiError)
-            }`;
-          }
-        } else {
-          fallbackReason =
-            `${fallbackResult.reason}; openai_tts=OPENAI_API_KEY not configured`;
-        }
-        console.warn(
-          "Premium speech generation failed; falling back to Hedra TTS",
-          fallbackReason,
-        );
+        speechChain.push(`fallback_voices=${fallbackResult.reason}`);
       }
-      console.warn("ElevenLabs speech generation failed; falling back", error);
+      // OpenAI TTS は ElevenLabs 失敗時の無条件フォールバック
+      // (従来は requiresUploadedAudio && 音声系エラーの時のみで、
+      //  それ以外の失敗が全て壊れた Hedra TTS へ直行していた)。
+      if (OPENAI_API_KEY) {
+        try {
+          const openAiAudio = await createOpenAiSpeechAsset(params.admin, {
+            text: spokenScript.slice(0, 1800),
+            templateTitle: `${params.title ?? "share-update"}-openai-tts`,
+            lang: params.lang,
+          });
+          audioGeneration = buildHedraUploadedAudioGeneration(
+            openAiAudio.url,
+          );
+          audioProvider = "openai_tts_fallback";
+          storedAudioUrl = openAiAudio.url;
+          storedAudioPath = openAiAudio.path;
+          return await createHedraVideoFromUploadedAudio(params, {
+            audioGeneration,
+            storedAudioUrl,
+            storedAudioPath,
+            audioProvider,
+            imageUrl,
+            fallbackText: spokenScript.slice(0, 1800),
+          });
+        } catch (openAiError) {
+          speechChain.push(`openai_tts=${providerErrorMessage(openAiError)}`);
+        }
+      } else {
+        speechChain.push("openai_tts=OPENAI_API_KEY not configured");
+      }
+      console.warn(
+        "Premium speech generation failed; falling back to Hedra TTS",
+        speechChain.join(" | "),
+      );
       audioGeneration = await createHedraTextToSpeechAudioGeneration(params, {
         text: spokenScript.slice(0, 1800),
       });
@@ -738,14 +741,22 @@ async function createHedraPresenterVideo(params: {
     });
   }
 
-  return await createHedraVideoFromUploadedAudio(params, {
-    audioGeneration,
-    storedAudioUrl,
-    storedAudioPath,
-    audioProvider,
-    imageUrl,
-    fallbackText: spokenScript.slice(0, 1800),
-  });
+  try {
+    return await createHedraVideoFromUploadedAudio(params, {
+      audioGeneration,
+      storedAudioUrl,
+      storedAudioPath,
+      audioProvider,
+      imageUrl,
+      fallbackText: spokenScript.slice(0, 1800),
+    });
+  } catch (error) {
+    if (speechChain.length === 0) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    // 音声フォールバック連鎖の失敗理由を最終エラーへ含め、
+    // videoReason だけで根因診断できるようにする。
+    throw new Error(`${message}; speech_chain: ${speechChain.join(" | ")}`);
+  }
 }
 
 async function createHedraVideoFromUploadedAudio(


### PR DESCRIPTION
## 概要

X動画投稿パイプライン（#3751 最優先）の残存障害への対処。動画生成が「Hedra API 400 text_to_speech model missing」で終わるが、**真の失敗（ElevenLabs/代替音声/OpenAI TTS）の理由が応答から見えず**、ダッシュボードログ往復が必要だった。

## 変更（`viral-video-ad-generator/index.ts` のみ）

1. **speech_chain 診断**: `speechChain[]` に `elevenlabs=` / `fallback_voices=` / `openai_tts=` の失敗理由を蓄積し、最終エラーに `"; speech_chain: ..."` を付記 → `videoReason` だけで根因診断可能に
2. **OpenAI TTS の無条件フォールバック化**: 従来は `requiresUploadedAudio && 音声系エラー` の時のみ試行で、それ以外の失敗（アップロード失敗・非音声系エラー等）が全て壊れた Hedra 内蔵TTS へ直行していた。ElevenLabs 失敗時は常に OpenAI TTS（キーは画像生成で動作実績あり）を試行

## 検証

- `deno fmt` / `deno check` / `deno lint`: green
- `deno test hedra_tts.test.ts`: **12 passed / 0 failed**
- **本番デプロイ済み**（feature は既に broken 状態のため、追加的レジリエンス+診断のみの本変更を先行反映）

## 経緯（本セッションで確定した事実）

- ElevenLabs 402 `paid_plan_required`（Library音声×無料プラン）→ ユーザーが Starter 加入
- 加入後も同エラー継続・ElevenCreative クレジット130消費の形跡 → 残る失敗点が応答から不可視だったため本パッチで自己記述化

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: viral-video-ad-generator への変更は音声フォールバックの拡張(OpenAI TTS無条件化)と診断文字列付記のみ。認可/決済/スキーマ書込の変更なし。deno test 12件 green・既存挙動(成功パス)は不変。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Edge Function の音声フォールバック経路の拡張のみ。動画生成POSTは有料クレジット(Hedra/ElevenLabs/OpenAI)を消費するためE2E自動化に不適。deno unit 12件+本番での実操作検証(ユーザー)で担保。

Refs #3751 #3744 #3663
