### PR TITLE
fix(viral-video): requiresUploadedAudioをフラグ非依存化 (#3751)

### DIFF
--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -651,8 +651,18 @@ async function createHedraPresenterVideo(params: {
   // (= ダッシュボードのログを見ずに応答だけで診断できるようにする)。
   const speechChain: string[] = [];
 
-  if (HEDRA_UPLOADED_AUDIO_ENABLED && ELEVENLABS_API_KEY) {
+  // requiresUploadedAudio テンプレ (= ai_secretary_site_tour) は
+  // HEDRA_UPLOADED_AUDIO_ENABLED フラグに関係なく ElevenLabs/OpenAI TTS の
+  // アップロード音声経路を必ず使う。壊れている Hedra 内蔵TTS
+  // (type=text_to_speech / model missing) へ落ちるのを構造的に防ぐ。
+  const useUploadedAudioPath =
+    (HEDRA_UPLOADED_AUDIO_ENABLED || params.requiresUploadedAudio === true) &&
+    Boolean(ELEVENLABS_API_KEY || OPENAI_API_KEY);
+  if (useUploadedAudioPath) {
     try {
+      if (!ELEVENLABS_API_KEY) {
+        throw new Error("ELEVENLABS_API_KEY not configured");
+      }
       const audio = await createElevenLabsSpeechAsset(params.admin, {
         text: spokenScript.slice(0, 1800),
         templateTitle: params.title ?? "share-update",


### PR DESCRIPTION
## 概要
ai_secretary_site_tour(requiresUploadedAudio=true)が、`HEDRA_UPLOADED_AUDIO_ENABLED` フラグの実行時反映待ち(=既存版へは再デプロイ必須)により else分岐→壊れたHedra内蔵TTS(text_to_speech model missing)へ落ちていた。`params.requiresUploadedAudio` で**フラグ非依存に**ElevenLabs/OpenAI音声アップロード経路を強制する。

## 検証
- deno fmt/check/lint + hedra_tts.test 12件 green
- ⚠️ 本番デプロイは Supabase バンドラ障害(os error 99)復旧後

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 音声経路のゲート条件を requiresUploadedAudio で緩和するのみ。認可/決済/スキーマ変更なし。deno test 12件 green。

## Minimal E2E Gate
- Implementation-detail independent: asserts user-visible input/output.
- Minimal scope: 3 cases.
- E2E: Flutter integration_test / Playwright.
- E2E-Exception: Edge Function音声経路のゲート緩和のみ。動画POSTは有料クレジット消費のためdeno unit+実操作(ユーザー)で担保。

Refs #3751 #3744