### PR TITLE
fix(viral-video): Hedra音声アセット(audio_id)復活+ゲート非依存化+診断常時付記 (#3751)

### DIFF
--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -651,8 +651,16 @@ async function createHedraPresenterVideo(params: {
   // (= ダッシュボードのログを見ずに応答だけで診断できるようにする)。
   const speechChain: string[] = [];
 
-  if (HEDRA_UPLOADED_AUDIO_ENABLED && ELEVENLABS_API_KEY) {
+  // requiresUploadedAudio テンプレ (= ai_secretary_site_tour) はフラグ非依存で
+  // アップロード音声経路を使う (壊れた Hedra 内蔵TTSへ落ちるのを構造的に防ぐ)。
+  const useUploadedAudioPath =
+    (HEDRA_UPLOADED_AUDIO_ENABLED || params.requiresUploadedAudio === true) &&
+    Boolean(ELEVENLABS_API_KEY || OPENAI_API_KEY);
+  if (useUploadedAudioPath) {
     try {
+      if (!ELEVENLABS_API_KEY) {
+        throw new Error("ELEVENLABS_API_KEY not configured");
+      }
       const audio = await createElevenLabsSpeechAsset(params.admin, {
         text: spokenScript.slice(0, 1800),
         templateTitle: params.title ?? "share-update",
@@ -751,11 +759,11 @@ async function createHedraPresenterVideo(params: {
       fallbackText: spokenScript.slice(0, 1800),
     });
   } catch (error) {
-    if (speechChain.length === 0) throw error;
     const message = error instanceof Error ? error.message : String(error);
-    // 音声フォールバック連鎖の失敗理由を最終エラーへ含め、
+    // 音声経路(成功時含む)と失敗連鎖を最終エラーへ含め、
     // videoReason だけで根因診断できるようにする。
-    throw new Error(`${message}; speech_chain: ${speechChain.join(" | ")}`);
+    const chain = [`audio_provider=${audioProvider}`, ...speechChain];
+    throw new Error(`${message}; speech_chain: ${chain.join(" | ")}`);
   }
 }
 
@@ -789,6 +797,53 @@ async function createHedraVideoFromUploadedAudio(
     },
   };
   let payload: unknown;
+  // Hedra は audio_generation.type="audio" (URL渡し) を拒否するため、
+  // アップロード音声は歴史的に実績のあるアセット方式 (audio_id) を最優先で使う。
+  const uploadedAudioUrl = media.audioGeneration["type"] === "audio"
+    ? firstNonEmptyString(media.audioGeneration["url"])
+    : null;
+  if (uploadedAudioUrl) {
+    try {
+      const audioAssetId = await createHedraAudioAssetFromUrl(
+        params.apiKey,
+        uploadedAudioUrl,
+        `${storageSafeSegment(params.title ?? "share-update")}.mp3`,
+      );
+      const assetBody: Record<string, unknown> = {
+        type: "video",
+        ai_model_id: HEDRA_AVATAR_MODEL_ID,
+        start_keyframe_url: media.imageUrl,
+        audio_id: audioAssetId,
+        generated_video_inputs: {
+          text_prompt: `${params.title ?? "Share update"}
+${params.prompt}`,
+          aspect_ratio: "16:9",
+          resolution: "540p",
+          enhance_prompt: true,
+        },
+      };
+      const assetPayload = await hedraJsonRequest(
+        params.apiKey,
+        "/generations",
+        { method: "POST", body: assetBody },
+      );
+      const video = await pollHedraGeneration(
+        params.apiKey,
+        normalizeHedraVideoResponse(assetPayload),
+      );
+      return {
+        ...video,
+        storedAudioUrl: media.storedAudioUrl,
+        storedAudioPath: media.storedAudioPath,
+        audioProvider: media.audioProvider,
+      };
+    } catch (assetError) {
+      console.warn(
+        "Hedra audio asset flow failed; trying audio_generation",
+        providerErrorMessage(assetError),
+      );
+    }
+  }
   try {
     payload = await createHedraGenerationWithTtsModelFallback(
       params.apiKey,
@@ -1192,6 +1247,57 @@ async function uploadBytesToStorage(
     return { ok: false, error: error.message };
   }
   return { ok: true };
+}
+
+async function createHedraAudioAssetFromUrl(
+  apiKey: string,
+  url: string,
+  name: string,
+): Promise<string> {
+  const download = await fetch(url);
+  if (!download.ok) {
+    throw new Error(`uploaded audio download failed with ${download.status}`);
+  }
+  const bytes = new Uint8Array(await download.arrayBuffer());
+  const created = await hedraJsonRequest(apiKey, "/assets", {
+    method: "POST",
+    body: { name, type: "audio" },
+  });
+  const assetId = extractHedraAssetId(created);
+  if (!assetId) {
+    throw new Error("Hedra asset id was missing from create asset response");
+  }
+  const form = new FormData();
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  form.append("file", new Blob([buffer], { type: "audio/mpeg" }), name);
+  const uploaded = await fetch(
+    `${HEDRA_API_BASE}/assets/${encodeURIComponent(assetId)}/upload`,
+    { method: "POST", headers: { "X-API-Key": apiKey }, body: form },
+  );
+  if (!uploaded.ok) {
+    const rawText = await uploaded.text();
+    throw new Error(
+      `Hedra asset upload ${uploaded.status}: ${
+        rawText.trim() || uploaded.statusText
+      }`,
+    );
+  }
+  return assetId;
+}
+
+function extractHedraAssetId(payload: unknown): string | null {
+  const record = asRecord(payload);
+  const data = asRecord(record?.["data"]);
+  const asset = asRecord(record?.["asset"]);
+  return firstNonEmptyString(
+    record?.["id"],
+    record?.["asset_id"],
+    data?.["id"],
+    data?.["asset_id"],
+    asset?.["id"],
+    asset?.["asset_id"],
+  );
 }
 
 async function persistRemoteMediaToStorage(


### PR DESCRIPTION
## 概要 (H6確定対応)
仮説検証の結論: ElevenLabs音声生成は**成功**している(Starter加入後・クレジット消費実績)が、Hedraが `audio_generation.type="audio"`(URL渡し)を**拒否**→壊れた内蔵TTS(model missing 400)へ落ち、**ElevenLabs成功時はspeechChainが空**のため診断suffixも付かず旧エラーと同一に見えていた。

## 変更 (現main `5a785324c` 基点)
1. **Hedra音声アセット方式(audio_id)を復活**: 6月に動画生成できていた実績方式。音声URLをDL→`POST /assets`→`/assets/{id}/upload`→`audio_id`で動画生成。失敗時は既存のaudio_generation経路へフォールバック
2. **ゲートのフラグ非依存化**: requiresUploadedAudioテンプレは `HEDRA_UPLOADED_AUDIO_ENABLED` に依らずアップロード音声経路を使用
3. **speech_chain常時付記**: 成功経路の失敗でも `audio_provider=` を先頭に必ず診断を付記

## 検証
- deno fmt/check/lint + hedra_tts.test **12 passed**

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: viral-video-ad-generator の音声経路修正のみ。認可/決済/スキーマ変更なし。deno test 12件green。仮説5件の系統的検証(secret digest/版番号/git履歴)に基づく修正。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: Edge Function音声経路の修正のみ。動画生成POSTは有料クレジット消費のためdeno unit 12件+実操作検証(ユーザー)で担保。

Refs #3751