### PR TITLE
feat(x-share): シェア文言を「今日のニュース先頭」に変え固定化を解消 (#3771)

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -559,15 +559,23 @@ $url''',
         .map((trend) => trend.name)
         .where((name) => name.trim().isNotEmpty)
         .toList(growable: false);
-    final topicLine = names.isEmpty
-        ? 'AI仕事OS、学習、仕事ログ、情報整理'
-        : names.map((name) => '「$name」').join(' ');
-    return '''
+    // Real news headlines run 40-60 chars, so keep only the single top headline
+    // (clipped) in the <=280 char lead post; the rest go to thread replies.
+    String clip(String value, int max) =>
+        value.length <= max ? value : '${value.substring(0, max)}…';
+    if (names.isEmpty) {
+      return '''
 デイリーブリーフィング — $date 朝
 Xで伸びている論点を、AI仕事OS開発者の視点で整理します。
 
-今日の入口: $topicLine
+今日の入口: AI仕事OS、学習、仕事ログ、情報整理
 最後に、$title で試している「情報を残して使う」仕組みも共有します。
+$url''';
+    }
+    return '''
+デイリーブリーフィング — $date 朝
+今日の注目:「${clip(names.first, 42)}」
+この話題も、$title で情報を残して使う視点から整理します。
 $url''';
   }
 
@@ -931,7 +939,7 @@ Page:
 - canonicalUrl: ${context.url}
 - shareUrlWithUtm: $shareUrl
 
-Current X trends from Japan:
+Today's real Japanese news headlines (verbatim from NHK / ITmedia news RSS; these are sourced snippets you MAY quote or paraphrase as today's news):
 $trendContext
 
 Recent X analytics and A/B test feedback:
@@ -948,14 +956,16 @@ Rules:
 - A/B test only one major variable at a time: hook style, link placement, media/no-media, or thread length.
 - If past results say a link in the first post underperforms, put the product URL in the final reply.
 - Put information value first and product CTA last. Avoid looking like an ad in the lead post.
-- If using X trends, do not invent news facts. You may say a topic is trending, but only turn it into analysis, questions, and workflow implications unless source snippets are provided.
+- The headline list above is REAL, sourced news (verbatim from NHK / ITmedia RSS). You MAY quote or paraphrase a headline as today's news. Do NOT add facts beyond the headline wording, and do NOT invent numbers, quotes, or outcomes.
+- When headlines are present, OPEN the lead post by tying today's single most relevant headline to this app's angle (information organization / AI work OS), so the post visibly changes every day. Do not lead with a generic app description.
+- Every day's post must read as fresh and specific: pick a different concrete headline or angle rather than repeating yesterday's template.
 - Prefer conversation hooks and save-worthy analysis over hashtags.
 - Keep the lead post under 280 chars. Use threadReplies for the briefing body.
 - Treat the creative workflow as GPT image2 -> GPT-5.5 -> Seedance 2.0.
 - Keep the post natural, concise, and credible.
 $financeRule
 
-Fallback style:
+Emergency fallback only (DO NOT copy this verbatim; write fresh copy that leads with today's news. Use it only as a rough tone/length reference):
 ${fallback.text}
 ''';
   }

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -53,7 +53,10 @@ void main() {
     );
 
     expect(draft.text, contains('デイリーブリーフィング'));
+    // Lead post must open with today's top headline, not a generic app blurb.
+    expect(draft.text, contains('今日の注目'));
     expect(draft.text, contains('ワールドカップ'));
+    expect(draft.text, isNot(contains('Xで伸びている論点')));
     expect(draft.text, contains(page.url));
     expect(draft.text, contains('utm_content=daily_briefing'));
     expect(draft.text.length, lessThanOrEqualTo(280));


### PR DESCRIPTION
## 背景（ユーザー実測: 「AI生成シェア文言が固定」）
RSSフォールバック(#3775)で当日ニュースは取得できるのに、生成文が毎回「デイリーブリーフィング — DATE 朝。AI仕事OS…情報整理…」の**定型で日付しか変わらない**問題。10仮説検証で真因を2点特定:

1. **プロンプトがニュースを封じていた**: `If using X trends, do not invent news facts ... unless source snippets are provided` により、LLMは実見出しを本文に織り込まず汎用文を生成
2. **定型文をLLMに手渡していた**: `Fallback style: ${fallback.text}` でテンプレを渡し→LLMがそれを模倣→固定化

## 変更（`universal_x_share_service.dart` のみ / +テスト）
- **プロンプト**: トレンド欄を「NHK/ITmedia RSSの**実見出し(sourced)**。引用/言い換え可」と明示。「見出しがある時はリードを当日トップ見出し起点にし毎日変化させよ」を必須化。定型文は「緊急フォールバックのみ・逐語コピー禁止」に降格
- **フォールバック `_dailyBriefingLead`**: リードを`今日の注目:「<当日トップ見出し>」`起点に変更(≤280字のため42字クリップ・1件のみ / 残り見出しは既存スレッド返信`_dailyBriefingItem`が展開)
- ニュース事実の捏造防止(見出し文言を超える数字/引用/結果の追加禁止)は維持

## 検証
- `flutter test universal_x_share_service_test.dart`: **19 passed / 0 failed**
- 新アサート: リードが`今日の注目`+トップ見出しで始まり、旧定型`Xで伸びている論点`を含まない
- `dart format`: 編集領域のみ(全体churnなし)

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: 共有文言生成はLLM(GPT-5.5)出力に依存し決定論的E2E不能。buildGrowthDraft/フォールバックの決定論的単体テスト19件(トレンド有/無・280字境界・スレッド展開)で担保。実LLM経路はユーザー実機生成で確認。

Refs #3771 #3663