### PR TITLE
fix(x-share): 手動投稿(コピー/X画面)でもURLをリプライへ回す (#3771 P0)

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -278,33 +278,15 @@ class UniversalXShareService {
     bool dryRun = false,
   }) async {
     final normalizedMediaUrl = _emptyToNull(mediaUrl);
-    final existingUrl = _firstHttpUrl(text);
-    final existingUrlHasUtm = existingUrl != null &&
-        existingUrl.contains(context.url) &&
-        existingUrl.contains('utm_campaign=first_user_growth');
-    final textUrl = existingUrlHasUtm
-        ? existingUrl
-        : acquisitionUrlFor(context, content: 'post_to_x');
-    final baseText = existingUrl != null && existingUrl != textUrl
-        ? _removeUrl(text, existingUrl)
-        : text;
-    final mainText = linkInReply
-        ? sanitizeTweet(
-            _removeUrl(baseText, textUrl),
-            url: textUrl,
-            requireUrl: false,
-          )
-        : sanitizeTweet(baseText, url: textUrl);
-    final replyTexts = <String>[
-      ...threadReplies
-          .map((entry) => sanitizeTweet(entry, url: textUrl, requireUrl: false))
-          .where((entry) => entry.trim().isNotEmpty),
-      if (linkInReply)
-        sanitizeTweet(
-          '試せるURLはこちらです。5分だけ触って、A/B/Cか一言で返信ください。\n$textUrl',
-          url: textUrl,
-        ),
-    ];
+    final parts = buildManualShareParts(
+      context: context,
+      text: text,
+      threadReplies: threadReplies,
+      linkInReply: linkInReply,
+    );
+    final mainText = parts.leadText;
+    final textUrl = parts.textUrl;
+    final replyTexts = parts.replyTexts;
     final data = await _invoke('growth-hub', {
       'action': 'x.post',
       'text': mainText,
@@ -339,6 +321,48 @@ class UniversalXShareService {
           : const [],
       raw: data,
     );
+  }
+
+  /// Builds the lead post + reply chain exactly like [postToX] does, so the
+  /// manual share paths (X web intent button, copy button, API-failure
+  /// fallback) keep the product URL out of the lead post and move it to the
+  /// final reply whenever [linkInReply] is true. Without this, manual posts
+  /// leak the URL into the lead post and lose X impressions.
+  static ({String leadText, List<String> replyTexts, String textUrl})
+      buildManualShareParts({
+    required UniversalSharePageContext context,
+    required String text,
+    List<String> threadReplies = const [],
+    bool linkInReply = false,
+  }) {
+    final existingUrl = _firstHttpUrl(text);
+    final existingUrlHasUtm = existingUrl != null &&
+        existingUrl.contains(context.url) &&
+        existingUrl.contains('utm_campaign=first_user_growth');
+    final textUrl = existingUrlHasUtm
+        ? existingUrl
+        : acquisitionUrlFor(context, content: 'post_to_x');
+    final baseText = existingUrl != null && existingUrl != textUrl
+        ? _removeUrl(text, existingUrl)
+        : text;
+    final leadText = linkInReply
+        ? sanitizeTweet(
+            _removeUrl(baseText, textUrl),
+            url: textUrl,
+            requireUrl: false,
+          )
+        : sanitizeTweet(baseText, url: textUrl);
+    final replyTexts = <String>[
+      ...threadReplies
+          .map((entry) => sanitizeTweet(entry, url: textUrl, requireUrl: false))
+          .where((entry) => entry.trim().isNotEmpty),
+      if (linkInReply)
+        sanitizeTweet(
+          '試せるURLはこちらです。5分だけ触って、A/B/Cか一言で返信ください。\n$textUrl',
+          url: textUrl,
+        ),
+    ];
+    return (leadText: leadText, replyTexts: replyTexts, textUrl: textUrl);
   }
 
   Future<List<UniversalXTrendTopic>> _fetchXTrendTopics() async {

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -410,18 +410,45 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
     }
   }
 
+  // 手動投稿経路(コピー / X画面)でも、API投稿(_postToX)と同じく本文からURLを外し
+  // リプライへ回す。素の _textController.text を使うとURLがリード投稿に残り、Xの
+  // インプレッションが抑制されてしまうため。
+  ({String leadText, List<String> replyTexts, String textUrl}) _manualParts() {
+    return UniversalXShareService.buildManualShareParts(
+      context: widget.page,
+      text: _textController.text,
+      threadReplies: _draft?.threadReplies ?? const [],
+      linkInReply: true,
+    );
+  }
+
+  String _manualThreadPayload() {
+    final parts = _manualParts();
+    if (parts.replyTexts.isEmpty) return parts.leadText;
+    return [parts.leadText, ...parts.replyTexts].join('\n\n---\n\n');
+  }
+
   Future<void> _copyText() async {
-    await Clipboard.setData(ClipboardData(text: _textController.text));
+    await Clipboard.setData(ClipboardData(text: _manualThreadPayload()));
     if (mounted) {
-      setState(() => _statusMessage = '投稿文をコピーしました');
+      setState(() => _statusMessage = '投稿文をコピーしました（URLはリプライに配置済み）');
     }
   }
 
   Future<void> _openXComposer() async {
+    final parts = _manualParts();
+    // X Web Intent は単一ツイート。リード文(URL除去済)のみで開き、URL入りリプライ
+    // を含む全文はクリップボードへ入れてスレッド投稿できるようにする。
+    await Clipboard.setData(ClipboardData(text: _manualThreadPayload()));
     final uri = Uri.https('x.com', '/intent/tweet', {
-      'text': _textController.text,
+      'text': parts.leadText,
     });
     await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (_disposed || !mounted) return;
+    setState(() {
+      _statusMessage =
+          'X投稿画面を開きました（リード文のみ）。URLとスレッド返信はコピー済みなので、投稿後にリプライで貼ってください。';
+    });
   }
 
   static String? _extractString(Map<String, dynamic> raw, String key) {

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -215,6 +215,33 @@ void main() {
     expect(result.replyTweetIds, ['101', '102']);
   });
 
+  test('buildManualShareParts moves the URL out of the lead into a reply', () {
+    final parts = UniversalXShareService.buildManualShareParts(
+      context: page,
+      text: 'デイリーブリーフィング\n今日の注目:「テスト見出し」\n${page.url}',
+      threadReplies: const ['1. 【AI】OpenAI\nなぜ重要か: 仕事の入口が変わる。'],
+      linkInReply: true,
+    );
+
+    // Manual share (copy / X composer) must keep the product URL out of the
+    // lead post — same contract as postToX's linkInReply path.
+    expect(parts.leadText, isNot(contains(page.url)));
+    expect(parts.leadText, contains('今日の注目'));
+    expect(parts.replyTexts.first, contains('OpenAI'));
+    expect(parts.replyTexts.last, contains(page.url));
+  });
+
+  test('buildManualShareParts keeps the URL inline when not linking in reply',
+      () {
+    final parts = UniversalXShareService.buildManualShareParts(
+      context: page,
+      text: 'ふつうの投稿\n${page.url}',
+    );
+
+    expect(parts.leadText, contains(page.url));
+    expect(parts.replyTexts, isEmpty);
+  });
+
   test('postToX surfaces X developer project guidance', () async {
     final service = UniversalXShareService(
       functionInvoker: (functionName, body) async {


### PR DESCRIPTION
## 背景（多角監査で確定した P0）
X-share パイプラインの全網羅監査で、**API投稿(_postToX)はURLをリプライへ回す(linkInReply)が、手動経路が本文にURLを残す**ことが判明。ユーザー明示要件「URLはリプライに入れる」に反し、Xのインプレッションが抑制される。

- `_copyText`(コピーボタン): 素の`_textController.text`をコピー → URLがリード本文に残る
- `_openXComposer`(X画面ボタン): X Web IntentへURL入り本文を渡す → リード投稿にURL

（監査が報告した「動画スクリプト固定」「Hedra日本語破棄」は **stale ブランチ由来の誤検知**で、origin/main は既に draft.text 由来のニュース反映済み動画スクリプト + ja custom script 使用を確認。本PRはURLリークのみに絞る。）

## 変更（Flutter のみ / lib+test）
- **service**: `postToX`のリード/リプライ生成ロジックを `buildManualShareParts()`(public static)に抽出しDRY化。手動経路と同一契約でURLをリプライへ配置
- **shell**: `_copyText`/`_openXComposer` が `buildManualShareParts` を使用。X画面はリード文(URL除去済)のみで開き、URL入り全スレッドはクリップボードへ（投稿後にリプライ貼付を案内）

## 検証
- `flutter test universal_x_share_service_test.dart`: **21 passed / 0 failed**（`postToX`既存3件+`buildManualShareParts`新規2件）
- `dart analyze` (service+shell): No issues found
- `dart format`: 編集領域のみ

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: URL配置は決定論的純関数 `buildManualShareParts` に集約し単体テスト(linkInReply有: リードにURL無し+最終リプライにURL / 無: インライン維持)で担保。ボタン→クリップボード/Intentは launchUrl 実起動を伴い自動E2E不適。

Refs #3771 #3663