### PR TITLE
feat(x-share): 動画ナレーションを固定ツアーから当日ニュースのブリーフィングへ (#3751)

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -1118,29 +1118,48 @@ ${draft.videoPrompt}
     if (_isMyFinanceUxContext(context)) {
       return _scriptLinesFromText(draft.text);
     }
-    // 動画スクリプトを毎回同一の固定文にせず、トレンド反映済みの draft.text から
-    // 導入フックを取り、機能ハイライトを draft ハッシュで日替りローテーションする
-    // (= 同一内容の量産を避け、当日のトレンド/日付が動画にも反映される)。
-    final draftLines = _scriptLinesFromText(draft.text);
+    // 動画ナレーションは「当日ニュース由来の draft.text(フック)+ スレッド返信
+    // (ブリーフィング本文)」から構成する。従来は本文が固定のツアー定型文で、
+    // フック1行以外は毎回同一 = ユーザーに「動画で話す内容が固定」と映っていた。
+    // draft.threadReplies には LLM が生成した当日ニュースの分析(現状/課題/解決策)が
+    // 入っているので、それをそのまま読み上げ台本にすると動画も毎回変化+当日反映になる。
+    final hookLines = _scriptLinesFromText(draft.text);
+    final bodyLines = <String>[
+      for (final reply in draft.threadReplies)
+        if (_narrationLineFromReply(reply).isNotEmpty)
+          _narrationLineFromReply(reply),
+    ];
+    final newsScript = <String>[...hookLines, ...bodyLines];
+    if (newsScript.length >= 3) {
+      return <String>[
+        ...newsScript.take(5),
+        '5分だけ試して、役に立った点と迷った点を教えてください。',
+      ];
+    }
+    // ニュース/スレッドが乏しい時のみ、従来のサイト案内フォールバックへ。
     final hook =
-        draftLines.isEmpty ? '今日のAI仕事OSの使い方を、AI秘書がご案内します。' : draftLines.first;
-    const tourPool = <String>[
-      'サイト案内AIに聞けば、どの機能から始めるか迷いません。',
-      'AI大学では主要AI企業・最新ニュース・プロンプト活用を体系的に学べます。',
-      'ノート、仕事ログ、資産管理、英語学習をひとつの作業空間でつなげます。',
-      '家計と資産をKPIで見える化し、お金の判断を能力投資へ戻します。',
-      'デイリー判定とAI秘書が、今日踏み出す一手を静かに後押しします。',
-      'リリースノートで、日々進化する機能をそのまま体験できます。',
-    ];
-    final seed = draft.text.hashCode.abs();
-    final tour = <String>[
-      for (var i = 0; i < 3; i++) tourPool[(seed + i) % tourPool.length],
-    ];
+        hookLines.isEmpty ? '今日のAI仕事OSの使い方を、AI秘書がご案内します。' : hookLines.first;
     return <String>[
       hook,
-      ...tour,
+      'サイト案内AIに聞けば、どの機能から始めるか迷いません。',
+      'ノート、仕事ログ、資産管理、英語学習をひとつの作業空間でつなげます。',
       '5分だけ試して、役に立った点と迷った点を教えてください。',
     ];
+  }
+
+  /// スレッド返信(例: "1. 現在の状況: 九州北部で激しい雨…" や
+  /// "1. 【AI】OpenAI\nなぜ重要か:…")を、読み上げやすい1行の話し言葉に整形する。
+  /// 番号/カテゴリ接頭辞を除き、URL 行はナレーションに載せない。
+  static String _narrationLineFromReply(String reply) {
+    final firstLine = reply
+        .split('\n')
+        .map((line) => line.trim())
+        .firstWhere((line) => line.isNotEmpty, orElse: () => '');
+    if (firstLine.isEmpty || firstLine.startsWith('http')) return '';
+    return firstLine
+        .replaceFirst(RegExp(r'^\d+[.)]\s*'), '')
+        .replaceFirst(RegExp(r'^【[^】]*】\s*'), '')
+        .trim();
   }
 
   static List<String> _scriptLinesFromText(String text) {

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -412,8 +412,8 @@ void main() {
       expect(capturedBody?['customPrompt'], contains('Hedra'));
       final scriptLines = capturedBody?['customScript'] as List;
       final script = scriptLines.join('\n');
-      // 動画スクリプトは固定文ではなく、トレンド反映済み draft のフック +
-      // 機能ツアー(日替りローテーション) + CTA で毎回変化する (#3766)。
+      // 動画スクリプトは固定文ではなく、当日ニュース反映済み draft のフック +
+      // スレッド返信(ブリーフィング本文) + CTA で毎回変化する。
       expect(script, contains('デイリーブリーフィング')); // draft由来の可変フック
       expect(script, contains('5分だけ試して')); // 末尾CTA
       expect(scriptLines.length, greaterThanOrEqualTo(4));
@@ -421,6 +421,39 @@ void main() {
       expect(script, isNot(contains(page.url)));
     },
   );
+
+  test('video narration reflects today news and drops the fixed tour',
+      () async {
+    Map<String, dynamic>? capturedBody;
+    final service = UniversalXShareService(
+      functionInvoker: (functionName, body) async {
+        capturedBody = body;
+        return {'success': true, 'status': 'fallback_text'};
+      },
+    );
+
+    final draft = UniversalXShareService.buildGrowthDraft(
+      page,
+      trendTopics: const [
+        UniversalXTrendTopic(name: '九州北部で非常に激しい雨'),
+        UniversalXTrendTopic(name: 'OpenAIが新モデルを発表'),
+      ],
+    );
+    await service.generateVideo(
+      context: page,
+      draft: draft,
+      imageUrl: 'https://example.com/secretary.png',
+    );
+
+    final scriptLines = (capturedBody?['customScript'] as List).cast<String>();
+    final script = scriptLines.join('\n');
+    // 当日ニュース(トレンド)が動画ナレーションに載ること。
+    expect(script, contains('九州北部で非常に激しい雨'));
+    // 固定のツアー定型文ではないこと。
+    expect(script, isNot(contains('AI大学では主要AI企業')));
+    expect(scriptLines.length, greaterThanOrEqualTo(3));
+    expect(script, isNot(contains('https://')));
+  });
 
   test(
     'generateVideo can poll an existing Hedra generation and use download URL',


### PR DESCRIPTION
## 背景（ユーザー実測: 「生成動画/動画で話す内容がほぼ固定」）
テキストは #3775/#3776 で当日ニュース反映になったが、**動画のナレーションは固定**のままだった。10仮説検証で真因を特定:
- `_videoScriptFor` は `[hook(=draft.text由来/ニュース), 固定tourPool×3, 固定CTA]` の**5行中4行が固定定型文**（スクショの `script`=九州の雨1行＋AI大学/ノート/家計/CTA）
- しかも **LLMが生成した当日ニュースの分析(draft.threadReplies: 現在の状況/課題/解決策)を動画で全く使っていなかった**

## 変更（`universal_x_share_service.dart` のみ / +テスト）
- `_videoScriptFor` を **draft.text(フック) + draft.threadReplies(当日ニュースのブリーフィング本文)** で構成。固定 tourPool を廃止し、ニュース分析をそのまま読み上げ台本にする → 動画も毎回変化＋当日反映
- `_narrationLineFromReply` ヘルパー: スレッド返信を1行の話し言葉へ整形（番号/カテゴリ接頭辞除去・URL行除外）
- ニュース/スレッドが乏しい時のみ従来のサイト案内フォールバック
- エッジ側 `scriptForSpokenAudio(ja)` は既に custom script を使う（検証済）ので Flutter 側のみで完結

## 検証
- `flutter test`: **22 passed / 0 failed**（新規: 動画スクリプトが当日ニュース`九州北部で非常に激しい雨`を含み、固定`AI大学では主要AI企業`を含まない）
- `dart analyze`: No issues found / `dart format`: 編集領域のみ

## 補足
- presenter画像の固定は別 finding(画像プロンプト)として別セッション対応中
- videoPrompt は Hedra が画像+音声駆動のため視覚への影響小

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: 動画台本生成は決定論的で、generateVideo が growth-hub/viral-video-ad-generator へ送る `customScript` を捕捉する単体テスト(ニュース反映有/固定ツアー非含有/URL非含有)で担保。実動画生成は有料クレジット消費のため自動E2E不適・ユーザー実機で確認。

Refs #3771 #3663 #3751