### PR TITLE
feat(x-share): 投稿前に近似重複ガードを追加し量産ポストを拒否 (#3771)

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -18,6 +18,12 @@ import {
   uploadMediaFromUrl,
   type XTweetMetrics,
 } from "../_shared/x-client.ts";
+import {
+  extractPostedTexts,
+  findDuplicateContent,
+  resolveDuplicateGuardConfig,
+  type XPostLogRowLike,
+} from "./x_duplicate_content.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -28,6 +34,10 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
 const SERVICE_ROLE_KEY = Deno.env.get("SERVICE_ROLE_KEY") ??
   Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+// x.post 近似重複ガードの調整用 env (未設定時は既定 0.9 / 直近 5 件)。
+const X_DUP_SIMILARITY_THRESHOLD = Deno.env.get("X_DUP_SIMILARITY_THRESHOLD") ??
+  null;
+const X_DUP_RECENT_COUNT = Deno.env.get("X_DUP_RECENT_COUNT") ?? null;
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -1565,6 +1575,56 @@ serve(async (req: Request) => {
               ? undefined
               : "X API credentials are not configured in Supabase secrets.",
           });
+        }
+
+        // ── 近似重複ガード (実投稿の直前) ──────────────────────────────────
+        // 同一/ほぼ同一の投稿を量産すると X に重複アカウント信号を送り、凍結
+        // リスク+インプレ低下を招く。直近の投稿済み本文と類似度を測り、閾値
+        // 超なら投稿せず拒否する。閾値/件数は env で調整可能。
+        const dupConfig = resolveDuplicateGuardConfig({
+          threshold: X_DUP_SIMILARITY_THRESHOLD,
+          recentCount: X_DUP_RECENT_COUNT,
+        });
+        if (dupConfig.recentCount > 0) {
+          // status!=posted の行で漏れないよう多めに取得してから posted を抽出。
+          const scanLimit = Math.min(
+            50,
+            Math.max(dupConfig.recentCount * 4, dupConfig.recentCount),
+          );
+          const recentLogs = await listXPostLogs(admin, userId!, scanLimit);
+          const recentPosts = extractPostedTexts(
+            recentLogs as XPostLogRowLike[],
+            dupConfig.recentCount,
+          );
+          const duplicate = findDuplicateContent(text, recentPosts, dupConfig);
+          if (duplicate) {
+            const rejectionLog = {
+              ...baseLog,
+              status: "rejected_duplicate",
+              duplicate_similarity: duplicate.similarity,
+              duplicate_threshold: duplicate.threshold,
+              duplicate_matched_log_id: duplicate.matchedId,
+              duplicate_matched_created_at: duplicate.matchedCreatedAt,
+            };
+            let log: unknown = null;
+            try {
+              log = await addItem(admin, "x_post_log", userId!, rejectionLog);
+            } catch (_logError) {
+              log = rejectionLog;
+            }
+            return json({
+              success: false,
+              posted: false,
+              code: "duplicate_content",
+              similarity: duplicate.similarity,
+              threshold: duplicate.threshold,
+              recentCount: dupConfig.recentCount,
+              matchedCreatedAt: duplicate.matchedCreatedAt,
+              account: getXAccountHandle(),
+              actionRequired: "文面を変えて再生成してください",
+              log,
+            });
+          }
         }
 
         try {

--- a/supabase/functions/growth-hub/x_duplicate_content.ts
+++ b/supabase/functions/growth-hub/x_duplicate_content.ts
@@ -1,0 +1,243 @@
+// x_duplicate_content — X 投稿の近似重複ガード (投稿前チェック)
+//
+// 同一/ほぼ同一の投稿を量産すると、X のアルゴリズムに重複アカウント信号を送り、
+// 凍結リスク+インプレッション低下を招く。実投稿 (postTweet) の直前に、直近 N 件の
+// 投稿済み本文と現在の本文の類似度を計算し、閾値を超えたら投稿を拒否する。
+//
+// 類似度 = 文字バイグラム Jaccard と 正規化編集距離 (Levenshtein) の高い方。
+//   - Jaccard: 語順の入れ替え・部分再利用を検出。日本語 (空白なし) にも強い文字 n-gram。
+//   - 編集距離: 数語だけ差し替えた微修正コピーを検出。
+// 両者の max を取ることで、どちらかの観点で「ほぼ同一」なら弾く。
+
+export interface DuplicateGuardConfig {
+  /** 類似度がこの値以上なら投稿拒否 (0..1) */
+  threshold: number;
+  /** 比較対象とする直近の投稿済みポスト件数 (0 = ガード無効) */
+  recentCount: number;
+}
+
+export const DEFAULT_DUPLICATE_THRESHOLD = 0.9;
+export const DEFAULT_DUPLICATE_RECENT_COUNT = 5;
+export const MAX_DUPLICATE_RECENT_COUNT = 50;
+/** 閾値の下限 (これ未満は誤検出が増えるため許可しない) */
+export const MIN_DUPLICATE_THRESHOLD = 0.5;
+
+export interface RecentPost {
+  text: string;
+  id?: string;
+  createdAt?: string;
+}
+
+export interface DuplicateMatch {
+  /** 検出した最大類似度 (0..1, 小数第3位で丸め) */
+  similarity: number;
+  /** 判定に用いた閾値 */
+  threshold: number;
+  /** 重複と判定された過去投稿の本文 */
+  matchedText: string;
+  /** 過去投稿の hub_data 行 id (取得できなければ null) */
+  matchedId: string | null;
+  /** 過去投稿の作成日時 (取得できなければ null) */
+  matchedCreatedAt: string | null;
+}
+
+function clampNumber(
+  value: number,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * 環境変数 (文字列) から重複ガード設定を解決する。
+ * - X_DUP_SIMILARITY_THRESHOLD: 類似度閾値 (既定 0.9, 下限 0.5, 上限 1.0)
+ * - X_DUP_RECENT_COUNT: 比較件数 (既定 5, 範囲 0..50, 0 でガード無効)
+ * 未設定/不正値は既定値にフォールバックする。
+ */
+export function resolveDuplicateGuardConfig(env: {
+  threshold?: string | null;
+  recentCount?: string | null;
+}): DuplicateGuardConfig {
+  const thresholdRaw = env.threshold != null && env.threshold.trim() !== ""
+    ? Number(env.threshold)
+    : NaN;
+  const recentRaw = env.recentCount != null && env.recentCount.trim() !== ""
+    ? Number(env.recentCount)
+    : NaN;
+  return {
+    threshold: clampNumber(
+      thresholdRaw,
+      MIN_DUPLICATE_THRESHOLD,
+      1,
+      DEFAULT_DUPLICATE_THRESHOLD,
+    ),
+    recentCount: clampNumber(
+      Number.isFinite(recentRaw) ? Math.trunc(recentRaw) : NaN,
+      0,
+      MAX_DUPLICATE_RECENT_COUNT,
+      DEFAULT_DUPLICATE_RECENT_COUNT,
+    ),
+  };
+}
+
+/**
+ * 類似度比較用に本文を正規化する。
+ * NFKC 正規化 → 小文字化 → URL 除去 → 記号/句読点/絵文字除去 → 空白除去。
+ * URL や末尾 CTA リンクの差分ノイズを排除し、本文の実質的な同一性を測る。
+ */
+export function normalizeForSimilarity(value: unknown): string {
+  return String(value ?? "")
+    .normalize("NFKC")
+    .toLowerCase()
+    // URL は空白/文字列末尾まで。空白除去より先に落とす必要がある。
+    .replace(/https?:\/\/\S+/g, " ")
+    // 記号・句読点・絵文字 (Symbol) を除去。URL 除去後に行う。
+    .replace(/[\p{P}\p{S}]+/gu, " ")
+    // 残った空白 (半角/全角) をすべて除去。
+    .replace(/\s+/gu, "");
+}
+
+/** 正規化済み文字列から文字バイグラム集合を作る (サロゲートペア対応)。 */
+export function bigramSet(normalized: string): Set<string> {
+  const chars = [...normalized];
+  const set = new Set<string>();
+  if (chars.length === 0) return set;
+  if (chars.length === 1) {
+    set.add(chars[0]);
+    return set;
+  }
+  for (let i = 0; i < chars.length - 1; i++) {
+    set.add(chars[i] + chars[i + 1]);
+  }
+  return set;
+}
+
+/** 文字バイグラムの Jaccard 係数 (0..1)。入力は正規化済み文字列を想定。 */
+export function jaccardSimilarity(a: string, b: string): number {
+  const setA = bigramSet(a);
+  const setB = bigramSet(b);
+  if (setA.size === 0 || setB.size === 0) {
+    return setA.size === 0 && setB.size === 0 && a === b ? 1 : 0;
+  }
+  let intersection = 0;
+  for (const gram of setA) {
+    if (setB.has(gram)) intersection++;
+  }
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/** Levenshtein 編集距離 (2 行 DP, サロゲートペア対応)。 */
+export function levenshtein(a: string, b: string): number {
+  const s = [...a];
+  const t = [...b];
+  const n = s.length;
+  const m = t.length;
+  if (n === 0) return m;
+  if (m === 0) return n;
+  let prev = new Array<number>(m + 1);
+  let curr = new Array<number>(m + 1);
+  for (let j = 0; j <= m; j++) prev[j] = j;
+  for (let i = 1; i <= n; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= m; j++) {
+      const cost = s[i - 1] === t[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        prev[j] + 1, // 削除
+        curr[j - 1] + 1, // 挿入
+        prev[j - 1] + cost, // 置換/一致
+      );
+    }
+    const tmp = prev;
+    prev = curr;
+    curr = tmp;
+  }
+  return prev[m];
+}
+
+/** 正規化編集距離を類似度 (0..1) に変換。入力は正規化済み文字列を想定。 */
+export function editSimilarity(a: string, b: string): number {
+  const maxLen = Math.max([...a].length, [...b].length);
+  if (maxLen === 0) return 1;
+  return 1 - levenshtein(a, b) / maxLen;
+}
+
+/**
+ * 2 本の投稿本文の類似度 (0..1)。Jaccard と編集距離の高い方を採用。
+ * 正規化後に一方でも空になる場合は 0 (誤ブロックを避けるため fail-open)。
+ */
+export function contentSimilarity(rawA: string, rawB: string): number {
+  const a = normalizeForSimilarity(rawA);
+  const b = normalizeForSimilarity(rawB);
+  if (a === "" || b === "") return 0;
+  if (a === b) return 1;
+  return Math.max(jaccardSimilarity(a, b), editSimilarity(a, b));
+}
+
+/**
+ * 候補本文が直近の投稿群のいずれかと閾値以上に類似していれば、最も類似する
+ * ものを返す。閾値を超えるものが無ければ null。
+ */
+export function findDuplicateContent(
+  candidate: string,
+  recentPosts: RecentPost[],
+  config: DuplicateGuardConfig,
+): DuplicateMatch | null {
+  if (config.recentCount <= 0) return null;
+  if (normalizeForSimilarity(candidate) === "") return null;
+
+  let best: DuplicateMatch | null = null;
+  const posts = recentPosts.slice(0, config.recentCount);
+  for (const post of posts) {
+    const text = String(post?.text ?? "");
+    if (text.trim() === "") continue;
+    const similarity = contentSimilarity(candidate, text);
+    if (similarity < config.threshold) continue;
+    if (best && similarity <= best.similarity) continue;
+    best = {
+      similarity: Math.round(similarity * 1000) / 1000,
+      threshold: config.threshold,
+      matchedText: text,
+      matchedId: post.id != null ? String(post.id) : null,
+      matchedCreatedAt: post.createdAt != null ? String(post.createdAt) : null,
+    };
+  }
+  return best;
+}
+
+export interface XPostLogRowLike {
+  id?: unknown;
+  created_at?: unknown;
+  metadata?: unknown;
+}
+
+/**
+ * hub_data の x_post_log 行群から「実際に投稿済み (status=posted) かつ本文あり」の
+ * ものだけを新しい順に取り出す。dry_run / failed / rejected_* は比較対象外
+ * (X のタイムラインに載っていない = 重複信号を発生させていないため)。
+ */
+export function extractPostedTexts(
+  rows: XPostLogRowLike[],
+  limit: number,
+): RecentPost[] {
+  const posts: RecentPost[] = [];
+  if (limit <= 0) return posts;
+  for (const row of rows) {
+    const meta = (row?.metadata && typeof row.metadata === "object")
+      ? row.metadata as Record<string, unknown>
+      : {};
+    if (String(meta.status ?? "") !== "posted") continue;
+    const text = typeof meta.text === "string" ? meta.text : "";
+    if (text.trim() === "") continue;
+    posts.push({
+      text,
+      id: row.id != null ? String(row.id) : undefined,
+      createdAt: row.created_at != null ? String(row.created_at) : undefined,
+    });
+    if (posts.length >= limit) break;
+  }
+  return posts;
+}

--- a/supabase/functions/growth-hub/x_duplicate_content_test.ts
+++ b/supabase/functions/growth-hub/x_duplicate_content_test.ts
@@ -1,0 +1,227 @@
+import {
+  assert,
+  assertAlmostEquals,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  contentSimilarity,
+  DEFAULT_DUPLICATE_RECENT_COUNT,
+  DEFAULT_DUPLICATE_THRESHOLD,
+  editSimilarity,
+  extractPostedTexts,
+  findDuplicateContent,
+  jaccardSimilarity,
+  MAX_DUPLICATE_RECENT_COUNT,
+  MIN_DUPLICATE_THRESHOLD,
+  normalizeForSimilarity,
+  resolveDuplicateGuardConfig,
+  type XPostLogRowLike,
+} from "./x_duplicate_content.ts";
+
+Deno.test("normalizeForSimilarity strips URLs, punctuation, whitespace and NFKC-folds", () => {
+  // 全角英数 → 半角、URL 除去、記号除去、空白除去
+  assertEquals(
+    normalizeForSimilarity(
+      "Ｈｅｌｌｏ  World!!  https://example.com/x?y=1 #tag",
+    ),
+    "helloworldtag",
+  );
+  assertEquals(
+    normalizeForSimilarity("今日 は、良い 天気。"),
+    "今日は良い天気",
+  );
+  assertEquals(normalizeForSimilarity("   "), "");
+  assertEquals(normalizeForSimilarity(null), "");
+});
+
+Deno.test("jaccardSimilarity: identical=1, disjoint=0, symmetric", () => {
+  assertEquals(jaccardSimilarity("abcd", "abcd"), 1);
+  assertEquals(jaccardSimilarity("abcd", "wxyz"), 0);
+  assertEquals(
+    jaccardSimilarity("abcd", "abce"),
+    jaccardSimilarity("abce", "abcd"),
+  );
+});
+
+Deno.test("editSimilarity: identical=1, both-empty=1, one-char diff is high", () => {
+  assertEquals(editSimilarity("abcde", "abcde"), 1);
+  assertEquals(editSimilarity("", ""), 1);
+  assertAlmostEquals(editSimilarity("abcde", "abcdX"), 0.8, 1e-9);
+});
+
+Deno.test("contentSimilarity: exact duplicate scores 1", () => {
+  assertEquals(
+    contentSimilarity(
+      "今日のニュース: AIが世界を変える #自分株式会社",
+      "今日のニュース: AIが世界を変える #自分株式会社",
+    ),
+    1,
+  );
+});
+
+Deno.test("contentSimilarity: only the trailing URL differs → near duplicate", () => {
+  const a =
+    "自分株式会社なら21個のアプリが1つに。無料で始めよう https://a.example.com/1";
+  const b =
+    "自分株式会社なら21個のアプリが1つに。無料で始めよう https://b.example.com/2";
+  assert(
+    contentSimilarity(a, b) >= DEFAULT_DUPLICATE_THRESHOLD,
+    `expected near-duplicate, got ${contentSimilarity(a, b)}`,
+  );
+});
+
+Deno.test("contentSimilarity: distinct posts score below default threshold", () => {
+  const a = "本日のAIトレンド: 大規模モデルの推論コストが急落しています。";
+  const b = "週末は資産管理を見直そう。負債の返済計画を立てる3ステップ。";
+  assert(
+    contentSimilarity(a, b) < DEFAULT_DUPLICATE_THRESHOLD,
+    `expected distinct, got ${contentSimilarity(a, b)}`,
+  );
+});
+
+Deno.test("contentSimilarity: empty-after-normalize is fail-open (0)", () => {
+  // URL のみ → 正規化で空 → 誤ブロック回避のため 0
+  assertEquals(contentSimilarity("https://x.com/a", "https://x.com/b"), 0);
+});
+
+Deno.test("findDuplicateContent: blocks a near-identical candidate", () => {
+  const config = { threshold: 0.9, recentCount: 5 };
+  const match = findDuplicateContent(
+    "自分株式会社は21個のアプリを1つに統合します。無料で使えます。",
+    [
+      { text: "資産管理で負債を減らす方法を紹介します。", id: "1" },
+      {
+        text: "自分株式会社は21個のアプリを1つに統合します。無料で使える！",
+        id: "2",
+        createdAt: "2026-07-04T00:00:00Z",
+      },
+    ],
+    config,
+  );
+  assert(match !== null, "expected a duplicate match");
+  assertEquals(match?.matchedId, "2");
+  assertEquals(match?.matchedCreatedAt, "2026-07-04T00:00:00Z");
+  assert((match?.similarity ?? 0) >= 0.9);
+});
+
+Deno.test("findDuplicateContent: returns null for a genuinely fresh post", () => {
+  const config = { threshold: 0.9, recentCount: 5 };
+  const match = findDuplicateContent(
+    "全く新しい話題: 今日は競馬の予想ロジックをAIで検証しました。",
+    [
+      { text: "自分株式会社は21個のアプリを1つに統合します。", id: "1" },
+      { text: "資産管理で負債を減らす方法を紹介します。", id: "2" },
+    ],
+    config,
+  );
+  assertEquals(match, null);
+});
+
+Deno.test("findDuplicateContent: picks the highest-similarity match", () => {
+  const config = { threshold: 0.8, recentCount: 5 };
+  const candidate = "AIが世界を変える。今日のニュースをまとめました。";
+  const match = findDuplicateContent(
+    candidate,
+    [
+      { text: "AIが世界を変える。今日のニュースをまとめた。", id: "close" },
+      { text: "AIが世界を変える。今日のニュースをまとめました。", id: "exact" },
+    ],
+    config,
+  );
+  assertEquals(match?.matchedId, "exact");
+  assertEquals(match?.similarity, 1);
+});
+
+Deno.test("findDuplicateContent: recentCount=0 disables the guard", () => {
+  const match = findDuplicateContent(
+    "同じ文面",
+    [{ text: "同じ文面", id: "1" }],
+    { threshold: 0.9, recentCount: 0 },
+  );
+  assertEquals(match, null);
+});
+
+Deno.test("findDuplicateContent: only compares up to recentCount posts", () => {
+  const older = { text: "限定コピーの投稿本文です。", id: "old" };
+  const filler = Array.from({ length: 5 }, (_v, i) => ({
+    text: `無関係な投稿 ${i} 全然別の話題`,
+    id: `f${i}`,
+  }));
+  // older は先頭から数えて 6 番目 → recentCount=5 なら比較対象外
+  const match = findDuplicateContent(
+    "限定コピーの投稿本文です。",
+    [...filler, older],
+    { threshold: 0.9, recentCount: 5 },
+  );
+  assertEquals(match, null);
+});
+
+Deno.test("resolveDuplicateGuardConfig: defaults when unset", () => {
+  const cfg = resolveDuplicateGuardConfig({});
+  assertEquals(cfg.threshold, DEFAULT_DUPLICATE_THRESHOLD);
+  assertEquals(cfg.recentCount, DEFAULT_DUPLICATE_RECENT_COUNT);
+});
+
+Deno.test("resolveDuplicateGuardConfig: parses and clamps env values", () => {
+  assertEquals(
+    resolveDuplicateGuardConfig({ threshold: "0.95", recentCount: "3" }),
+    { threshold: 0.95, recentCount: 3 },
+  );
+  // 下限/上限へクランプ
+  assertEquals(
+    resolveDuplicateGuardConfig({ threshold: "0.1", recentCount: "999" }),
+    {
+      threshold: MIN_DUPLICATE_THRESHOLD,
+      recentCount: MAX_DUPLICATE_RECENT_COUNT,
+    },
+  );
+  assertEquals(
+    resolveDuplicateGuardConfig({ threshold: "5", recentCount: "-4" }),
+    { threshold: 1, recentCount: 0 },
+  );
+  // 不正値 → 既定
+  assertEquals(
+    resolveDuplicateGuardConfig({ threshold: "abc", recentCount: "" }),
+    {
+      threshold: DEFAULT_DUPLICATE_THRESHOLD,
+      recentCount: DEFAULT_DUPLICATE_RECENT_COUNT,
+    },
+  );
+});
+
+Deno.test("extractPostedTexts: keeps only posted rows with text, newest-first, capped", () => {
+  const rows: XPostLogRowLike[] = [
+    { id: 1, created_at: "t1", metadata: { status: "posted", text: "A" } },
+    { id: 2, created_at: "t2", metadata: { status: "dry_run", text: "B" } },
+    { id: 3, created_at: "t3", metadata: { status: "failed", text: "C" } },
+    { id: 4, created_at: "t4", metadata: { status: "posted", text: "   " } },
+    { id: 5, created_at: "t5", metadata: { status: "posted", text: "D" } },
+    {
+      id: 6,
+      created_at: "t6",
+      metadata: { status: "rejected_duplicate", text: "E" },
+    },
+    { id: 7, created_at: "t7", metadata: { status: "posted", text: "F" } },
+  ];
+  assertEquals(extractPostedTexts(rows, 10), [
+    { text: "A", id: "1", createdAt: "t1" },
+    { text: "D", id: "5", createdAt: "t5" },
+    { text: "F", id: "7", createdAt: "t7" },
+  ]);
+  // limit を尊重
+  assertEquals(extractPostedTexts(rows, 1), [
+    { text: "A", id: "1", createdAt: "t1" },
+  ]);
+  assertEquals(extractPostedTexts(rows, 0), []);
+});
+
+Deno.test("extractPostedTexts: tolerates missing/odd metadata shapes", () => {
+  const rows: XPostLogRowLike[] = [
+    { id: 1 },
+    { id: 2, metadata: null },
+    { id: 3, metadata: "nope" },
+    { id: 4, metadata: { status: "posted" } }, // text 欠落
+    { id: 5, metadata: { status: "posted", text: 123 } }, // text が非文字列
+  ];
+  assertEquals(extractPostedTexts(rows, 10), []);
+});


### PR DESCRIPTION
## 概要

X-share パイプライン多角監査(2026-07-04)で確定した **P1**: 投稿前にコンテンツの近似重複を弾くガードが存在しない、を解消する。

同一/ほぼ同一の投稿を量産すると X のアルゴリズムに重複アカウント信号を送り、**凍結リスク + インプレッション低下**を招く。ユーザー要件「全く同じ内容のポストを量産しても意味がない」に直結。

`ignoreDuplicates: true` 等は DB insert の冪等性であって投稿本文の類似判定ではないため、実投稿の直前に本文類似度チェックを追加する。

## 変更点

- **`supabase/functions/growth-hub/x_duplicate_content.ts`(新規)** — 純粋ロジック
  - `contentSimilarity` = 文字バイグラム **Jaccard** と **正規化編集距離(Levenshtein)** の高い方
    - Jaccard: 語順入れ替え・部分再利用を検出。日本語(空白なし)にも強い文字 n-gram
    - 編集距離: 数語だけ差し替えた微修正コピーを検出
  - `normalizeForSimilarity`: NFKC → 小文字化 → URL 除去 → 記号/絵文字除去 → 空白除去(末尾 CTA リンク差分のノイズを排除)
  - `extractPostedTexts`: `x_post_log` から **status=posted かつ本文あり**のみ新しい順に抽出(dry_run/failed/rejected_* は X タイムラインに載っていない=重複信号を発生させていないため対象外)
  - `resolveDuplicateGuardConfig`: env をパース・クランプ
- **`supabase/functions/growth-hub/index.ts`** — `x.post` の実投稿(`postTweet`)**直前**にガードを配線
  - 閾値超なら投稿せず `{success:false, code:"duplicate_content", actionRequired:"文面を変えて再生成してください"}` を返す
  - 拒否は `x_post_log` に `status=rejected_duplicate` + 類似度/閾値/一致 log_id を記録(観測性)
  - `x.post` の **userId 認可は従来どおり維持**。`dry_run` / 認証情報未設定は実投稿しないため非対象
- **`supabase/functions/growth-hub/x_duplicate_content_test.ts`(新規)** — deno 単体テスト16件

## 調整可能な環境変数

| env | 既定 | 範囲 | 用途 |
|-----|------|------|------|
| `X_DUP_SIMILARITY_THRESHOLD` | `0.9` | 0.5–1.0 | この類似度以上で拒否 |
| `X_DUP_RECENT_COUNT` | `5` | 0–50 | 比較する直近投稿件数(0でガード無効) |

未設定/不正値は既定値にフォールバック。

## 検証

- `deno fmt --check` ✅ / `deno lint` ✅ / `deno check` ✅
- `deno test`(Edge Functions 全体)✅ **181 passed / 0 failed**(新規16件含む)

## 親

#3771 #3663

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Supabase Edge Function (Deno) の投稿前ガード。Flutter/Playwright の UI フローに乗らないため、純粋ロジックを x_duplicate_content_test.ts の deno 単体テスト16件(happy/類似/別文面/空正規化/env clamp)で担保

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: duplicate-content guard adds a read-only pre-post similarity check before postTweet; no auth/RLS/secret change, x.post userId auth preserved, covered by deno unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
