### PR TITLE
docs: cs-check の文字列補間 過剰エスケープ防止 + dart analyze ゲート追加

### DIFF
--- a/.claude/commands/cs-check-web.md
+++ b/.claude/commands/cs-check-web.md
@@ -5,6 +5,43 @@ WEB版 sandbox は外部HTTP (`*.supabase.co`, `*.web.app` 等) を全ブロッ�
 
 ---
 
+## ⚠️ コード修正の安全ルール (必須 / 2026-06-25 incident 由来)
+
+cs-check 中の「バグ修正 / P0 修復」で `.dart` / `.ts` ソースを編集する場合は、以下を**必ず**守る。
+
+### なぜこのルールがあるか
+2026-06-25, cs-check が Issue #3644 の URL typo (`b6f7f4`→`b67f4`) を修正した際、
+`lib/pages/subscription_billing_page.dart` の文字列補間 `${...}` を `\${...}` へ**過剰エスケープ**し、
+`flutter build` を全 PR/本番で失敗させた (compile 不能化 / commit `805166663` → PR #3652 で復旧)。
+原因 = この routine が教えるファイル書き込みは **unquoted heredoc** (`cat > file <<EOF`) で `$` がシェル展開されるため、
+ソース編集時に展開を防ごうと `$`→`\$` を付け、`\$` がそのままファイルへ残った。
+
+### ルール
+1. **`$` を絶対にエスケープしない**。Dart/TS の文字列補間 `${expr}` / `$var` はソース通りそのまま書く。
+2. ソース編集には **Edit ツール** を使う。`sed` / `create_or_update_file` で**全文を手書き上書きしない**。
+   やむを得ず heredoc を使う場合は **必ず quoted heredoc** (`<<'EOF'`) を使い `$` 展開を無効化する
+   (unquoted `<<EOF` は禁止)。
+3. **検証ゲート (必須)**: 編集後・commit 前に、変更ファイルを analyzer へ通し 0 エラーを確認する。
+   ```bash
+   dart analyze lib/pages/subscription_billing_page.dart   # Dart (変更ファイルのみ / 全体は OOM)
+   deno check supabase/functions/<fn>/index.ts             # TypeScript
+   ```
+   - エラーが残る場合は **commit しない**。
+   - 補間崩れの早期検知: `grep -nF '\${' <変更ファイル>` が 1 件でもヒットしたら過剰エスケープ → 修正する。
+4. **WEB版 sandbox は `flutter` / `dart` / `deno` を実行できない** ("flutter コマンド不可")。
+   analyzer を回せない以上、**`.dart` / `.ts` ソースを main へ直接 commit してはならない**。
+   代わりに **PR を作り ci.yml (Lint/Format/Test) にゲートさせる**:
+   ```bash
+   git switch -c fix/cs-<issue>
+   # Edit でソース修正 (heredoc/sed で全文上書きしない)
+   git commit -am "fix: <内容> (Issue #NNNN)"
+   git push origin HEAD
+   gh pr create --fill --base main
+   ```
+   docs (`docs/cs-notes/`, `docs/schedule-logs/` 等) のみの変更は従来通り main へ直接 commit 可。
+
+---
+
 ## Step 1-2: サポートチケット (代替: ticket-cache.json を読む)
 
 ```bash

--- a/docs/SCHEDULE_TASKS.md
+++ b/docs/SCHEDULE_TASKS.md
@@ -183,9 +183,17 @@ Content-Type: application/json
 
 1. 関連する Dart/TypeScript ソースを `lib/` または `supabase/functions/` から読んで原因を特定
 2. 修正可能な軽微なバグ（typo、null チェック漏れ、ロジック誤りなど）であれば:
-   a. コードを修正
-   b. `flutter analyze` を実行し 0 エラーを確認（Dart の場合）
+   a. コードを修正（**Edit ツールで局所修正**。`sed` / heredoc で全文上書きしない。
+      文字列補間 `${expr}` / `$var` の `$` を**絶対にエスケープしない** —
+      `$`→`\$` 過剰エスケープは compile 不能化の典型バグ。2026-06-25 incident 参照）
+   b. **検証ゲート (必須)**: 変更ファイルを analyzer へ通し 0 エラーを確認。
+      Dart → `dart analyze <変更ファイル>`（全体は OOM のため変更ファイルのみ） /
+      TypeScript → `deno check <変更ファイル>`。
+      早期検知 → `grep -nF '\${' <変更ファイル>` で `\${` を見つけたら過剰エスケープ。
+      0 エラーでなければ commit しない。
    c. `git add -p && git commit -m "fix: <バグ内容>" && git push origin main` でコミット
+      （**analyzer を実行できない実行環境 (例: WEB版 sandbox) では main へ直接 push 禁止。
+      PR を作り ci.yml にゲートさせる**）
    d. 返信文に「修正しました。本番デプロイまで数分お待ちください」と記載して返信
 3. 複雑な修正が必要な場合はエスカレーション (ケース C)
 


### PR DESCRIPTION
## 背景 / 事故

2026-06-25、cs-check (Claude Code WEB版) が Issue #3644 の返却URL typo を修正した際、
`lib/pages/subscription_billing_page.dart` の文字列補間 `${...}` を `\${...}` へ**過剰エスケープ**し、
`flutter build` を全 PR/本番で compile 不能化しました（commit `805166663` → PR #3652 で復旧、
残りの lint は `132d2d39f` で手動修正）。

## 真因（sed ではなく検証ゲート欠如）

`sed`/置換スクリプトは存在しません（`scripts/cs_check.py` も不在、`cs-check.yml` は docs cache しか書かず `.dart` を触らない）。
実体は **cs-check routine を実行する AI エージェント**で、次の 2 点が重なりました:

1. routine がファイル書き込みを **unquoted heredoc**（`cat > file <<EOF`）で教えるため、
   ソース編集時にエージェントが `$` の展開回避で `\$` を付け、それがファイルに残留した。
2. WEB版 sandbox は `flutter`/`dart` 実行不可なのに、**検証ゲート無しで `.dart` を main へ直 commit** した。

## 変更（routine / docs のみ・ソース変更なし）

- **`.claude/commands/cs-check-web.md`**: 「⚠️ コード修正の安全ルール (必須)」節を新設
  - 補間の `$` をエスケープしない / Edit ツール使用（`sed`・heredoc 全文上書き禁止、やむを得ねば quoted `<<'EOF'`）
  - **検証ゲート**: commit 前に `dart analyze <変更ファイル>` / `deno check <変更ファイル>` を 0 エラーで通す
  - **analyzer を実行できない環境（WEB版）は `.dart`/`.ts` を main へ直 commit 禁止 → PR で ci.yml にゲート**
- **`docs/SCHEDULE_TASKS.md`**: cs-check Task Step2 ケースB を同方針で補強

## 早期検知

`grep -nF '\${' <変更ファイル>` — broken commit `805166663` で **5 hit** / clean file で **0 hit** を実証済み。

## 影響範囲

Dart/TS ソース変更なし（routine markdown のみ）。ランタイム挙動への影響なし。
