### PR TITLE
fix(asset): 収入の入金先候補を支払原資と分離し残高0以下の口座も選べるように

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -143,6 +143,26 @@ String? assetManagementActionJumpLabel(AssetManagementInsightActionItem item) {
   };
 }
 
+/// 収入予定・定期収入の「入金先」候補口座を返す純関数。
+/// 入金先は資産口座 (現金/預金) であればよく、支払原資 (_paymentSourceAccountOptions)
+/// と違い残高が 0 以下でも選べる。給料日前に残高が尽きた口座や、当座マイナスの口座
+/// (負債と闘うユーザーで頻出) にも入金先を設定できるようにするため balance > 0 の
+/// 制約を課さない。与信枠 (クレカ/ショッピング枠/カードローン) は入金先にならない。
+/// 残高の大きい順に並べる。
+@visibleForTesting
+List<AssetLiabilityAccount> incomeDestinationAccountOptions(
+  List<AssetLiabilityAccount> accounts,
+) {
+  return accounts
+      .where(
+        (account) =>
+            account.kind == AssetLiabilityAccountKind.cash ||
+            account.kind == AssetLiabilityAccountKind.deposit,
+      )
+      .toList()
+    ..sort((a, b) => b.balance.compareTo(a.balance));
+}
+
 class _PaymentSourceCandidate {
   final AssetLiabilityAccount account;
   final double currentBalance;
@@ -3834,9 +3854,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       text: existing == null ? '' : existing.amount.round().toString(),
     );
     var selectedDate = existing?.date ?? _now;
-    var selectedDestinationId = existing?.destinationAccountId;
     var received = existing?.received ?? false;
-    final destinationOptions = _paymentSourceAccountOptions(workbook);
+    final destinationOptions =
+        incomeDestinationAccountOptions(workbook.accounts);
+    // 候補に無い入金先IDは保持しない (Dropdown の value 整合を保つ)。
+    final destinationIds = destinationOptions.map((a) => a.id).toSet();
+    var selectedDestinationId =
+        destinationIds.contains(existing?.destinationAccountId)
+            ? existing?.destinationAccountId
+            : null;
 
     await showDialog<void>(
       context: context,
@@ -3980,7 +4006,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final dayController = TextEditingController(
       text: initial == null ? '' : initial.dayOfMonth.toString(),
     );
-    final destinationOptions = _paymentSourceAccountOptions(workbook);
+    final destinationOptions =
+        incomeDestinationAccountOptions(workbook.accounts);
     // 候補に無い入金先IDは保持しない(Dropdown の値整合を保つ)。
     final destinationIds = destinationOptions.map((a) => a.id).toSet();
     var selectedDestinationId =
@@ -10546,7 +10573,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     String? destinationAccountId;
     String? destinationAccountName;
     if (suggestedSource != null) {
-      for (final account in _paymentSourceAccountOptions(workbook)) {
+      final options = incomeDestinationAccountOptions(workbook.accounts);
+      for (final account in options) {
         if (account.name == suggestedSource) {
           destinationAccountId = account.id;
           destinationAccountName = account.name;

--- a/test/pages/income_destination_account_options_test.dart
+++ b/test/pages/income_destination_account_options_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/pages/asset_management_page.dart';
+
+/// 収入予定・定期収入の「入金先」候補口座を返す純関数を検証する。
+/// 支払原資 (_paymentSourceAccountOptions) と違い、入金先は残高が 0 以下でも選べる
+/// 必要がある (給料日前に残高が尽きた口座・当座マイナスの口座にも給料を入金するため)。
+AssetLiabilityAccount _account({
+  required String id,
+  required AssetLiabilityAccountKind kind,
+  required double balance,
+}) {
+  return AssetLiabilityAccount(
+    id: id,
+    name: id,
+    kind: kind,
+    balance: balance,
+  );
+}
+
+void main() {
+  group('incomeDestinationAccountOptions', () {
+    test('現金・預金は残高が 0 以下でも入金先候補に含める', () {
+      final options = incomeDestinationAccountOptions([
+        _account(
+          id: 'cash-zero',
+          kind: AssetLiabilityAccountKind.cash,
+          balance: 0,
+        ),
+        _account(
+          id: 'deposit-negative',
+          kind: AssetLiabilityAccountKind.deposit,
+          balance: -12000,
+        ),
+        _account(
+          id: 'deposit-positive',
+          kind: AssetLiabilityAccountKind.deposit,
+          balance: 50000,
+        ),
+      ]);
+
+      final ids = options.map((a) => a.id).toList();
+      // 残高 0 の現金・当座マイナスの預金も含まれる (支払原資フィルタとの決定的な差)。
+      expect(ids, containsAll(<String>['cash-zero', 'deposit-negative']));
+      expect(ids, contains('deposit-positive'));
+    });
+
+    test('与信枠 (クレカ/ショッピング枠/カードローン) は入金先にならない', () {
+      final options = incomeDestinationAccountOptions([
+        _account(
+          id: 'card',
+          kind: AssetLiabilityAccountKind.creditCard,
+          balance: -30000,
+        ),
+        _account(
+          id: 'shopping',
+          kind: AssetLiabilityAccountKind.shoppingDebt,
+          balance: -40000,
+        ),
+        _account(
+          id: 'loan',
+          kind: AssetLiabilityAccountKind.cardLoan,
+          balance: -100000,
+        ),
+        _account(
+          id: 'deposit',
+          kind: AssetLiabilityAccountKind.deposit,
+          balance: 1000,
+        ),
+      ]);
+
+      expect(options.map((a) => a.id), <String>['deposit']);
+    });
+
+    test('残高の大きい順に並ぶ (マイナスは末尾)', () {
+      final options = incomeDestinationAccountOptions([
+        _account(
+          id: 'mid',
+          kind: AssetLiabilityAccountKind.deposit,
+          balance: 10000,
+        ),
+        _account(
+          id: 'high',
+          kind: AssetLiabilityAccountKind.cash,
+          balance: 80000,
+        ),
+        _account(
+          id: 'low',
+          kind: AssetLiabilityAccountKind.deposit,
+          balance: -5000,
+        ),
+      ]);
+
+      expect(
+        options.map((a) => a.id).toList(),
+        <String>['high', 'mid', 'low'],
+      );
+    });
+
+    test('候補が無いときは空リストを返す', () {
+      final options = incomeDestinationAccountOptions([
+        _account(
+          id: 'card',
+          kind: AssetLiabilityAccountKind.creditCard,
+          balance: -1000,
+        ),
+      ]);
+
+      expect(options, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 背景

資産管理の収入予定・定期収入の「入金先」口座選択が、支払原資用ヘルパー `_paymentSourceAccountOptions`（`balance > 0 && (cash‖deposit)`）を流用していた。入金先に残高0超の制約は不適切で、**残高0や当座マイナスの口座**（負債と闘うユーザーで頻出）を給料の入金先に選べなかった。定期収入テンプレでは保存済み入金先が候補外だと `selectedDestinationId` を黙って null に落とし、設定が消失していた。

## 変更

- 入金先専用の純関数 `incomeDestinationAccountOptions`（cash/deposit・**残高制約なし**・与信枠は除外）を新設。
- 入金先を解決する3箇所を新ヘルパーへ統一:
  - `_showIncomePlanDialog`（収入予定ダイアログ）
  - `_showRecurringIncomeTemplateDialog`（定期収入テンプレ）
  - `_registerDetectedRecurringIncome`（検出した定期入金の destination 解決）
- `_showIncomePlanDialog` に「候補外の入金先IDは保持しない」ガードを追加し、保存済み入金先が候補外でも `DropdownButtonFormField` の value 不整合で落ちないよう定期収入ダイアログと一貫させた。
- 支払原資（debit）の3箇所は `balance > 0` が正しい（残高が無い口座からは払えない）ため `_paymentSourceAccountOptions` を据え置き。

## 検証

- 追加ユニットテスト `test/pages/income_destination_account_options_test.dart`（純関数）: 残高0/マイナスの cash/deposit を含む・与信枠を除外・残高降順・空リスト。
- part308 で確立した「与信枠を支払原資にすると二重計上」の懸念は本PRの入金先分離とは独立（source は `isDirectCashflowTarget` に非関与）で、退行なし。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数の単体テストでカバー。巨大ページのダイアログ配線は E2E 困難で実機ネットワーク確認。

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: lib/pages の入金先候補ヘルパー分離のみ（高リスクパス非該当）。supabase/functions・.github・SQL は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)