### PR TITLE
feat(x-share): 画像プロンプトに当日日付+RSS見出しを反映し日替り化 (#3771)

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -441,7 +441,7 @@ class UniversalXShareService {
         url: url,
       ),
       imagePrompt:
-          'A sophisticated adult AI executive secretary for "$title", intelligent and elegant, subtly glamorous but brand-safe, tasteful dark suit, premium futuristic office, holographic Flutter web app dashboards, AI assistant, AI University, notes, finance, work logs, English learning, cinematic lighting, no nudity, no explicit sexualization, 16:9, no text overlays.',
+          'A sophisticated adult AI executive secretary for "$title", intelligent and elegant, subtly glamorous but brand-safe, tasteful dark suit, premium futuristic office, holographic Flutter web app dashboards, AI assistant, AI University, notes, finance, work logs, English learning, cinematic lighting, no nudity, no explicit sexualization, 16:9, no text overlays. ${_dailyImageAccent(trendTopics)}',
       videoPrompt:
           'A concise presenter video inviting one real X user to try "$title", give first-user feedback, and explain where the app helps or confuses them.',
       hashtags: const ['#buildinpublic'],
@@ -488,8 +488,8 @@ ${context.url}
     return UniversalXShareDraft(
       text: text,
       imagePrompt: isFinanceUx
-          ? 'A 16:9 moving smartphone app UX validation key visual for "My Finance", Japanese personal finance app, asset dashboard, spending review, KPI cards, tap gestures, clean fintech UI, no text overlays.'
-          : 'A clean 16:9 product screenshot style hero image for "$title", Flutter web app UI, crisp dashboard details, no text overlays, modern Japanese productivity app, bright and trustworthy.',
+          ? 'A 16:9 moving smartphone app UX validation key visual for "My Finance", Japanese personal finance app, asset dashboard, spending review, KPI cards, tap gestures, clean fintech UI, no text overlays. ${_dailyImageAccent(trendTopics)}'
+          : 'A clean 16:9 product screenshot style hero image for "$title", Flutter web app UI, crisp dashboard details, no text overlays, modern Japanese productivity app, bright and trustworthy. ${_dailyImageAccent(trendTopics)}',
       videoPrompt: isFinanceUx
           ? 'A short moving smartphone app UX validation video for "My Finance", showing a Japanese mobile finance app flow with assets, spending, KGI/CSF/KPI, and an improvement loop. Creative pipeline: GPT image2 -> GPT-5.5 -> Seedance 2.0.'
           : 'A short 16:9 presenter video concept introducing "$title" as a practical improvement in a Flutter web life-management app.',
@@ -674,6 +674,32 @@ $index. 【$category】$name$volume
   static String _jstDateLabel() {
     final now = DateTime.now().toUtc().add(const Duration(hours: 9));
     return '${now.year}/${now.month}/${now.day}';
+  }
+
+  /// 当日の日付と（あれば）当日の実ニュース見出しを、画像プロンプトへ
+  /// "視覚テーマのアクセント" として織り込む。固定キービジュアルが毎回ほぼ同一に
+  /// なり、X アルゴリズムへ重複アカウント信号を送っていた問題を解消し、日替りで
+  /// 画像が変わるようにする（テキスト側の [_trendAwareGrowthText] と同じ発想）。
+  /// 見出しは文言の範囲でムード・配色に反映するのみで、ニュース事実の捏造や、
+  /// 見出しを画像内テキスト／実シーンとして描画させることはしない。
+  /// 見出しが無い日でも日付だけで最低限の日替り変化を保証する。
+  static String _dailyImageAccent(List<UniversalXTrendTopic> trendTopics) {
+    final date = _jstDateLabel();
+    final names = trendTopics
+        .map((trend) => trend.name.trim())
+        .where((name) => name.isNotEmpty)
+        .take(3)
+        .toList(growable: false);
+    if (names.isEmpty) {
+      return 'Daily edition $date: refresh the mood for today through lighting, '
+          'a seasonal color palette, and subtle composition changes, without '
+          'rendering any date, headline, or text on the image.';
+    }
+    return 'Daily edition $date, today\'s news mood: ${names.join(' / ')}. '
+        'Reflect only the general atmosphere of these topics as background '
+        'palette, lighting, and abstract holographic motifs — never as literal '
+        'news scenes, logos, headlines, or any on-image text, and do not invent '
+        'facts beyond these words.';
   }
 
   static String _compactCount(int value) {

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -66,6 +66,76 @@ void main() {
     expect(draft.threadReplies.first.length, lessThanOrEqualTo(280));
   });
 
+  test('growth draft imagePrompt weaves today\'s date and trend headlines', () {
+    final draft = UniversalXShareService.buildGrowthDraft(
+      page,
+      trendTopics: const [
+        UniversalXTrendTopic(name: 'OpenAI 新モデル発表', tweetCount: 42000),
+        UniversalXTrendTopic(name: 'ワールドカップ', tweetCount: 120000),
+      ],
+    );
+
+    final now = DateTime.now().toUtc().add(const Duration(hours: 9));
+    final date = '${now.year}/${now.month}/${now.day}';
+    // 固定キービジュアルが毎回ほぼ同一で X アルゴリズムへ重複信号を送っていた
+    // 問題(#3776)を解消 — 当日の日付と実ニュース見出しを画像テーマへ反映する。
+    expect(draft.imagePrompt, contains('Daily edition $date'));
+    expect(draft.imagePrompt, contains('OpenAI 新モデル発表'));
+    // 見出しは視覚テーマへ反映するのみで、事実の捏造や画像内テキスト描画はしない。
+    expect(draft.imagePrompt, contains('do not invent'));
+    expect(draft.imagePrompt, contains('any on-image text'));
+    // 既存のブランドセーフなキービジュアル指定は維持する。
+    expect(draft.imagePrompt, contains('AI executive secretary'));
+    expect(draft.imagePrompt, contains('no text overlays'));
+  });
+
+  test('growth draft imagePrompt still varies by date without trends', () {
+    final draft = UniversalXShareService.buildGrowthDraft(page);
+
+    final now = DateTime.now().toUtc().add(const Duration(hours: 9));
+    final date = '${now.year}/${now.month}/${now.day}';
+    // 見出しが無い日でも、日付だけで最低限の日替り変化を保証する。
+    expect(draft.imagePrompt, contains('Daily edition $date'));
+    expect(draft.imagePrompt, isNot(contains('today\'s news mood')));
+  });
+
+  test('fallback draft (no URL) weaves date and trend into imagePrompt', () {
+    const emptyUrlPage = UniversalSharePageContext(
+      routePath: '/gemini-university',
+      title: 'Gemini University',
+      url: '',
+    );
+
+    final draft = UniversalXShareService.buildFallbackDraft(
+      emptyUrlPage,
+      trendTopics: const [
+        UniversalXTrendTopic(name: 'ITmedia 生成AI', tweetCount: 3000),
+      ],
+    );
+
+    final now = DateTime.now().toUtc().add(const Duration(hours: 9));
+    final date = '${now.year}/${now.month}/${now.day}';
+    expect(draft.imagePrompt, contains('Daily edition $date'));
+    expect(draft.imagePrompt, contains('ITmedia 生成AI'));
+    expect(draft.imagePrompt, contains('product screenshot style hero image'));
+  });
+
+  test('fallback draft (no URL, finance) weaves date into finance imagePrompt',
+      () {
+    const emptyUrlFinance = UniversalSharePageContext(
+      routePath: '/asset-management',
+      title: 'Asset Management',
+      url: '',
+    );
+
+    final draft = UniversalXShareService.buildFallbackDraft(emptyUrlFinance);
+
+    final now = DateTime.now().toUtc().add(const Duration(hours: 9));
+    final date = '${now.year}/${now.month}/${now.day}';
+    expect(draft.imagePrompt, contains('My Finance'));
+    expect(draft.imagePrompt, contains('Daily edition $date'));
+  });
+
   test('acquisitionUrlFor preserves existing query and strips fragments', () {
     const pageWithQuery = UniversalSharePageContext(
       routePath: '/work-menu',


### PR DESCRIPTION
## 概要

X-shareパイプライン多角監査(2026-07-04)で確定した **P1**: 生成されるシェア画像が毎回ほぼ同一で、Xのアルゴリズムへ重複アカウント信号を送っていた問題に対処します。

`buildGrowthDraft` / `buildFallbackDraft` の `imagePrompt` は `$title` 以外が固定文で、日替りの変化がありませんでした。テキスト側 (`_trendAwareGrowthText` / `_dailyBriefingLead`) は既にトレンド反映済みなので、同じ発想を画像プロンプトにも適用します。

## 変更内容

- **新規ヘルパー `_dailyImageAccent(trendTopics)`** を追加し、当日の日付(JST)と当日の実ニュース見出し(`trendTopics` / #3775 で NHK・ITmedia RSS 取得済)を画像プロンプトへ「視覚テーマのアクセント」として織り込む。
- **日付は常に反映** → 見出しが空の日でも `Daily edition YYYY/M/D` で最低限の日替り変化を保証。
- **見出しは文言の範囲でムード・配色に反映するのみ**。`never as literal news scenes, logos, headlines, or any on-image text` / `do not invent facts beyond these words` を明示し、**ニュース事実の捏造・画像内テキスト描画を禁止**(既存の `no text overlays` とも整合)。
- 織り込み先3箇所: `buildGrowthDraft`(本番の実経路 / AI秘書キービジュアル)、`buildFallbackDraft` の finance / general 両分岐。
- `_imagePromptFor` の "Supporting prompt" として実際の media-hub 呼び出しへ流れる。既存のブランドセーフ指定・キービジュアルは維持。

## テスト

- `imagePrompt` がトレンド・日付を含むアサートを4件追加(`test/services/universal_x_share_service_test.dart`):
  1. growth draft: 日付 + 見出し反映 + 捏造禁止ガード + 既存キービジュアル維持
  2. growth draft: 見出し無しでも日付で変化
  3. fallback (URL空 / general): 日付 + 見出し
  4. fallback (URL空 / finance): `My Finance` + 日付
- `flutter analyze`: **No issues found**
- `flutter test test/services/universal_x_share_service_test.dart`: **22 passed**(既存18 + 新規4)

Flutter 単独変更のため高リスク ultrareview ゲート対象外。親: #3771 #3663

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 画像プロンプト文字列生成のみの純粋変更で、UI/E2Eフロー無し。トレンド・日付反映は universal_x_share_service_test.dart のユニットテスト4件で検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
