### PR TITLE
feat(asset): ジャンプ着地時に支払済みチェックボックスを点滅ハイライトして視線誘導

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -593,6 +593,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // カテゴリ別 月次予算 (category -> 金額)。予算/カテゴリ予実カードで使用。
   Map<String, double> _categoryBudgets = <String, double>{};
   final Map<String, GlobalKey> _debtMasterCardKeys = <String, GlobalKey>{};
+  // アクションアイテムからジャンプした直後に、対処すべき支払済みチェックボックスへ
+  // 視線誘導するため一時的に点滅ハイライトする負債マスタ行ID (2.6 秒で自動解除)。
+  String? _highlightedDebtCardId;
+  Timer? _debtCardHighlightTimer;
   Map<String, AssetLiabilityAnnualRateEvidence> _annualRateEvidences =
       <String, AssetLiabilityAnnualRateEvidence>{};
   Set<String> _monthlyPaidAccountNames = <String>{};
@@ -1019,6 +1023,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     _flowAmountController.dispose();
     _deadlineTimer?.cancel();
     _bootPrefMirrorExpiryTimer?.cancel();
+    _debtCardHighlightTimer?.cancel();
     _assetManagementAiSummaryDebounce?.cancel();
     _existingDeveloperIssueLookupDebounce?.cancel();
     _annualRateEvidencePasteRegistration?.dispose();
@@ -23984,7 +23989,28 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         return;
       }
       _scrollTo(key);
+      _flashDebtMasterCard(accountId);
     });
+  }
+
+  /// ジャンプ着地後、対象行の支払済みチェックボックスを一時的に点滅ハイライトして
+  /// 「ここをチェックすればよい」と視線誘導する。2.6 秒後に自動で解除する。
+  void _flashDebtMasterCard(String accountId) {
+    _debtCardHighlightTimer?.cancel();
+    setState(() {
+      _highlightedDebtCardId = accountId;
+    });
+    _debtCardHighlightTimer = Timer(
+      const Duration(milliseconds: 2600),
+      () {
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _highlightedDebtCardId = null;
+        });
+      },
+    );
   }
 
   /// 削除した支払日上書きのトゥームストーン (#part293: MirrorTombstoneStore 3例目)。
@@ -24201,7 +24227,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
               _buildDebtMasterControl(
                 label: '支払状態',
-                child: _buildPaidCheckbox(row),
+                child: _DebtPaidCheckboxHighlight(
+                  active: _highlightedDebtCardId == row.id,
+                  child: _buildPaidCheckbox(row),
+                ),
                 maxWidth: 220,
               ),
             ],
@@ -28029,6 +28058,82 @@ class _PaymentCheckGuideDialogState extends State<_PaymentCheckGuideDialog> {
           child: const Text('閉じる'),
         ),
       ],
+    );
+  }
+}
+
+/// 負債マスタ行の支払済みチェックボックスを、アクションアイテムからのジャンプ着地時に
+/// 一時的に点滅させて「ここをチェックすればよい」と視線誘導するラッパー。
+/// [active] が true の間だけ枠が明滅する。false のときは子をそのまま描画するが、
+/// レイアウトのずれを避けるため常に幅 2px の枠 (非アクティブ時は透明) を確保する。
+class _DebtPaidCheckboxHighlight extends StatefulWidget {
+  const _DebtPaidCheckboxHighlight({
+    required this.active,
+    required this.child,
+  });
+
+  final bool active;
+  final Widget child;
+
+  @override
+  State<_DebtPaidCheckboxHighlight> createState() =>
+      _DebtPaidCheckboxHighlightState();
+}
+
+class _DebtPaidCheckboxHighlightState extends State<_DebtPaidCheckboxHighlight>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 550),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.active) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void didUpdateWidget(_DebtPaidCheckboxHighlight oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.active && !oldWidget.active) {
+      _controller.repeat(reverse: true);
+    } else if (!widget.active && oldWidget.active) {
+      _controller.stop();
+      _controller.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final t =
+            widget.active ? Curves.easeInOut.transform(_controller.value) : 0.0;
+        // 自分株式会社ブランドのオレンジ (DESIGN.md) で明滅する。
+        const accent = Color(0xFFF97316);
+        return Container(
+          decoration: BoxDecoration(
+            color: accent.withValues(alpha: 0.12 * t),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: accent.withValues(alpha: 0.75 * t),
+              width: 2,
+            ),
+          ),
+          child: child,
+        );
+      },
+      child: widget.child,
     );
   }
 }


### PR DESCRIPTION
## 背景

アクションアイテムの「支払済みチェックへ移動」リンク (#3564) でジャンプすると対象の負債マスタ行までスクロールするが、着地後にどの支払済みチェックボックスを操作すればよいか一目では分かりづらかった。

## 変更

- `_jumpToDebtMasterCard` のスクロール直後に `_flashDebtMasterCard` を呼び、対象行IDを `_highlightedDebtCardId` にセット。**2.6 秒後に `Timer` で自動解除**。
- 支払済みチェックボックスを `_DebtPaidCheckboxHighlight` でラップし、`active` の間だけブランドオレンジ (DESIGN.md `#F97316`) の枠を明滅させて視線誘導。非アクティブ時はレイアウトのずれを避けるため**透明の同幅 (2px) 枠**を確保。
- `dispose` で `_debtCardHighlightTimer` を解除しリークを防止。
- 明滅は `SingleTickerProviderStateMixin` + `AnimationController.repeat(reverse: true)`。`active` が false になると停止・リセット。

## 検証

- 対象は `isDirectCashflowTarget`（＝チェックボックスを持つ直接支払い行）。請求集約行 (#3620) はチェックボックスでなくチップのため点滅対象外で、#3564 の dead-button ガードとも整合。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 装飾的なUIアニメーション配線のみ（既存のジャンプ挙動に一時ハイライトを重ねるラッパー）。巨大ページのアニメーションは E2E 困難で実機確認。

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: lib/pages の視線誘導ハイライト追加のみ（高リスクパス非該当）。supabase/functions・.github・SQL は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)