### PR TITLE
feat(x-share): 動画presenterを多様な成人キャラでランダムローテ(劇的な視覚変化) (#3751)

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -464,14 +464,15 @@ class UniversalXShareService {
       url: url,
     );
     // 動画の主視覚(=この share 画像)が毎回同じ「AI秘書＋同じオフィス」で固定に
-    // 見える問題を解消するため、舞台/照明/構図を6種で劇的にローテする。seed は
-    // text.hashCode(当日ニュースで変わる)なので、動画側 _videoPromptFor と同一舞台に
-    // 揃い、日替り+生成毎に見た目が大きく変化する。
+    // 見える問題を解消するため、presenter(人物)と舞台/照明/構図を大きくローテする。
+    // seed は text.hashCode(当日ニュース/生成毎で変わる)なので、動画側 _videoPromptFor
+    // と同一人物・同一舞台に揃い、生成毎に見た目が劇的に変化する。
     final scene = _dailyImageScene(text.hashCode);
+    final character = _dailyPresenterCharacter(text.hashCode);
     return UniversalXShareDraft(
       text: text,
       imagePrompt:
-          'A sophisticated adult AI executive secretary for "$title", intelligent and elegant, brand-safe, tasteful outfit, in the setting of $scene, with holographic Flutter web app dashboards (site guide AI, AI University, notes, finance, work logs, English learning) as subtle background panels, cinematic lighting, no nudity, no explicit sexualization, 16:9, no text overlays. ${_dailyImageAccent(trendTopics)}',
+          'Key visual with $character as the friendly presenter for "$title", in the setting of $scene, with holographic Flutter web app dashboards (site guide AI, AI University, notes, finance, work logs, English learning) as subtle background panels, cinematic lighting, adult, brand-safe, tasteful appropriate attire, no minors, no nudity, no explicit sexualization, 16:9, no text overlays. ${_dailyImageAccent(trendTopics)}',
       videoPrompt:
           'A concise presenter video inviting one real X user to try "$title", give first-user feedback, and explain where the app helps or confuses them.',
       hashtags: const ['#buildinpublic'],
@@ -722,6 +723,60 @@ $index. 【$category】$name$volume
   /// 画像側と動画側で同じ seed を使うことで、静止画と動画のシーンが一致する。
   static String _dailyImageScene(int seed) {
     return _presenterScenes[seed.abs() % _presenterScenes.length];
+  }
+
+  /// presenter(動画に登場する人物)をランダムに大きく変えるための候補。動画が毎回
+  /// 同じ「女性AI秘書」で固定に見える問題を解消するため、ファッション/職業/創作/
+  /// スポーツ/ファンタジー系の多様な人物へローテする。
+  /// 安全方針: **成人のみ**(未成年は一切含めない)、ブランド安全、適切な服装、
+  /// 非性的。夜職/グラビア系など性的文脈になりやすい類型は含めない。
+  /// Hedra は顔を必要とするため、いずれも「顔のある人物」に限定している。
+  static const List<String> _presenterCharacters = <String>[
+    'a poised adult female AI executive secretary in a tasteful suit',
+    'a cheerful adult gyaru-style woman with bright trendy fashion',
+    'an elegant adult onee-san woman in a refined modern outfit',
+    'a graceful adult ojou-sama lady in a classic tasteful dress',
+    'a natural mori-girl style adult woman in soft earth-tone layers',
+    'a chic adult woman in Korean-style minimal fashion',
+    'a cool adult woman in sharp monochrome mode fashion',
+    'a boyish short-haired adult woman in casual streetwear',
+    'an adult woman in a tasteful gothic-lolita style dress',
+    'a professional adult female news anchor in a smart blazer',
+    'a warm adult female nurse in clean scrubs',
+    'a calm adult female librarian with glasses and a cardigan',
+    'a dignified adult female CEO in a tailored suit',
+    'a friendly adult female cafe barista in an apron',
+    'an adult female flight attendant in a neat uniform',
+    'a bright adult idol-style woman in tasteful stage fashion',
+    'a cool adult female rock guitarist in stylish stage attire',
+    'a trendy adult K-pop-style female dancer',
+    'an adult female ballet dancer in an elegant practice outfit',
+    'a sporty adult female runner in athletic wear',
+    'an adult female martial artist in a clean karate gi',
+    'an adult female shrine maiden in traditional miko attire',
+    'an adult woman in a graceful kimono',
+    'a fantasy adult female knight in ornate armor',
+    'a magical-girl style adult woman in a colorful brand-safe costume',
+    'an adult female elf ranger with pointed ears in a woodland outfit',
+    'a friendly adult android-style woman with subtle sci-fi styling',
+    'a wise elderly woman with silver hair and a kind expression',
+    'a fresh clean-cut adult young man with a friendly look',
+    'a dandy adult gentleman in a refined suit',
+    'a rugged adult man with a confident outdoorsy style',
+    'a trendy adult male K-pop idol in stage fashion',
+    'a cool adult male rock bandman with an edgy style',
+    'an adult male chef in a crisp white uniform',
+    'a professional adult male news anchor in a sharp suit',
+    'a fantasy adult male knight in shining armor',
+    'a mysterious adult male detective in a long coat',
+    'a fit adult male athlete in sportswear',
+    'a distinguished elderly man with silver hair and a warm smile',
+  ];
+
+  /// [seed]（通常は draft.text.hashCode = 当日ニュース/生成毎で変化）から presenter
+  /// を1人選ぶ。画像側と動画側で同じ seed を使い、静止画と動画の人物を一致させる。
+  static String _dailyPresenterCharacter(int seed) {
+    return _presenterCharacters[seed.abs() % _presenterCharacters.length];
   }
 
   /// 当日の日付と（あれば）当日の実ニュース見出しを、画像プロンプトへ
@@ -1124,12 +1179,13 @@ ${draft.imagePrompt}
           .trim();
     }
     final scene = _dailyImageScene(draft.text.hashCode);
+    final character = _dailyPresenterCharacter(draft.text.hashCode);
     return '''
 High-end 16:9 cinematic key visual for ${context.url}.
-Main subject: an intelligent adult female AI executive secretary, refined feminine presence, confident warm expression, tasteful outfit, in the setting of $scene, brand-safe.
-Change the setting, lighting, wardrobe, and camera angle so each day's key visual looks clearly different, while keeping the same brand-safe female presenter.
-Show concrete product context around her as subtle holographic UI panels: Site Guide AI, AI secretary, AI University, notes, asset management, English reading dashboard, release notes, and supporter checkout.
-Avoid generic landing-page mockups, random English marketing text, text overlays, nudity, explicit sexualization, or a masculine presenter.
+Main subject: $character as the presenter, adult, brand-safe, tasteful appropriate attire, confident warm expression, in the setting of $scene.
+Rotate the character, setting, lighting, wardrobe, and camera angle so each day's key visual looks dramatically different.
+Show concrete product context around them as subtle holographic UI panels: Site Guide AI, AI secretary, AI University, notes, asset management, English reading dashboard, release notes, and supporter checkout.
+Strictly avoid minors, nudity, explicit sexualization, text overlays, and random English marketing text.
 Supporting prompt:
 ${draft.imagePrompt}
 '''
@@ -1146,6 +1202,7 @@ ${draft.imagePrompt}
       // 舞台は開始画像(share画像)と同一 seed(draft.text.hashCode)で選ぶため、
       // 静止画と動画のシーンが一致し、全体として一貫して大きく変わる。
       final scene = _dailyImageScene(draft.text.hashCode);
+      final character = _dailyPresenterCharacter(draft.text.hashCode);
       final topic = _topNewsTopicFor(draft);
       final topicLine = topic.isEmpty
           ? ''
@@ -1154,10 +1211,10 @@ ${draft.imagePrompt}
 High-quality 16:9 product tour video for ${context.url}.
 Setting for today: $scene. Change the composition, lighting, and camera movement so each day's video looks visibly different.
 $topicLine
-Presenter: an intelligent, elegant adult female AI executive secretary in a tasteful dark suit.
-Voice: polished feminine Japanese voice, warm and professional, matching the secretary's face and lip movement.
-Tone: premium, calm, confident, brand-safe, no nudity, no explicit sexualization.
-Visual direction: image-gen2 creates a polished female secretary/key visual, GPT-5.5 structures the explanation, ElevenLabs provides the feminine voice, Hedra turns the secretary into a presenter, and Seedance 2.0 style motion adds refined UI cutaways.
+Presenter for today: $character, adult, brand-safe, tasteful appropriate attire (the same presenter as the key visual).
+Voice: a warm, professional Japanese voice that matches the presenter's face and lip movement.
+Tone: premium, calm, confident, brand-safe, no minors, no nudity, no explicit sexualization.
+Visual direction: image-gen2 creates the key visual, GPT-5.5 structures the explanation, ElevenLabs provides the voice, Hedra turns the character into a presenter, and Seedance 2.0 style motion adds refined UI cutaways.
 Show concrete product surfaces: site guide AI, AI secretary, AI University, notes, asset management, English reading dashboard, release notes, and supporter checkout.
 ${draft.videoPrompt}
 '''

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -38,7 +38,7 @@ void main() {
     expect(draft.text, isNot(contains('譛')));
     expect(draft.text, isNot(contains('/#/')));
     expect(draft.text.length, lessThanOrEqualTo(280));
-    expect(draft.imagePrompt, contains('AI executive secretary'));
+    expect(draft.imagePrompt, contains('presenter'));
     expect(draft.imagePrompt, contains('no explicit sexualization'));
   });
 
@@ -72,9 +72,13 @@ void main() {
       trendTopics: const [UniversalXTrendTopic(name: '熊本豪雨から6年')],
     );
 
-    // 固定オフィスでなく「舞台のローテ」が画像プロンプトに入っていること。
+    // 固定オフィスでなく「舞台のローテ」+「presenterキャラのローテ」が
+    // 画像プロンプトに入っていること。
     expect(draft.imagePrompt, contains('in the setting of'));
-    expect(draft.imagePrompt, contains('AI executive secretary'));
+    expect(draft.imagePrompt, contains('as the friendly presenter'));
+    // 安全ガード: 未成年除外・非性的が入っていること。
+    expect(draft.imagePrompt, contains('no minors'));
+    expect(draft.imagePrompt, contains('no explicit sexualization'));
     final hasScene = <String>[
       'broadcast news desk',
       'glass studio',
@@ -84,6 +88,50 @@ void main() {
       'control room',
     ].any(draft.imagePrompt.contains);
     expect(hasScene, isTrue);
+  });
+
+  test('presenter character rotates across a diverse adult pool', () {
+    // 異なるニュース(=異なる draft.text)で presenter が変わり得ること、
+    // かつ全て成人・ブランドセーフ指定であることを確認する。
+    final seenCharacters = <String>{};
+    for (final topic in const [
+      '熊本豪雨から6年',
+      'OpenAI 新モデル発表',
+      'ワールドカップ開幕',
+      '株価が最高値を更新',
+      '大型連休の交通情報',
+    ]) {
+      final draft = UniversalXShareService.buildGrowthDraft(
+        page,
+        trendTopics: [UniversalXTrendTopic(name: topic)],
+      );
+      expect(draft.imagePrompt, contains('as the friendly presenter'));
+      expect(draft.imagePrompt, contains('adult'));
+      expect(draft.imagePrompt, isNot(contains('child')));
+      final matched = <String>[
+        'secretary',
+        'gyaru',
+        'news anchor',
+        'nurse',
+        'CEO',
+        'guitarist',
+        'knight',
+        'chef',
+        'detective',
+        'athlete',
+        'barista',
+        'librarian',
+        'kimono',
+        'elf',
+        'android',
+        'dancer',
+        'idol',
+        'gentleman',
+      ].where(draft.imagePrompt.contains);
+      seenCharacters.addAll(matched);
+    }
+    // 5トピックで少なくとも2種類以上の異なるキャラが登場すること。
+    expect(seenCharacters.length, greaterThanOrEqualTo(2));
   });
 
   test('growth draft imagePrompt weaves today\'s date and trend headlines', () {
@@ -104,8 +152,8 @@ void main() {
     // 見出しは視覚テーマへ反映するのみで、事実の捏造や画像内テキスト描画はしない。
     expect(draft.imagePrompt, contains('do not invent'));
     expect(draft.imagePrompt, contains('any on-image text'));
-    // 既存のブランドセーフなキービジュアル指定は維持する。
-    expect(draft.imagePrompt, contains('AI executive secretary'));
+    // presenter はローテしつつ、ブランドセーフ指定は維持する。
+    expect(draft.imagePrompt, contains('presenter'));
     expect(draft.imagePrompt, contains('no text overlays'));
   });
 
@@ -410,11 +458,10 @@ void main() {
       final result = await service.generateImage(context: page, draft: draft);
 
       expect(capturedFunction, 'media-hub');
-      expect(
-        capturedBody?['prompt'],
-        contains('adult female AI executive secretary'),
-      );
-      expect(capturedBody?['prompt'], contains('masculine presenter'));
+      expect(capturedBody?['prompt'], contains('as the presenter'));
+      // presenter はローテするが、未成年除外・非性的の安全ガードは全画像で必須。
+      expect(capturedBody?['prompt'], contains('minors'));
+      expect(capturedBody?['prompt'], contains('explicit sexualization'));
       expect(result.url, isNull);
       expect(result.status, 'text_only_fallback');
       expect(result.raw['canPostTextOnly'], isTrue);
@@ -490,18 +537,15 @@ void main() {
         'gpt-5.5',
         'seedance-2.0',
       ]);
-      expect(
-        capturedBody?['customPrompt'],
-        contains('intelligent, elegant adult female AI executive secretary'),
-      );
-      expect(
-        capturedBody?['customPrompt'],
-        contains('polished feminine Japanese voice'),
-      );
+      // presenter は日替りローテ、声はそれに合わせた日本語ボイス。
+      expect(capturedBody?['customPrompt'], contains('Presenter for today'));
+      expect(capturedBody?['customPrompt'], contains('Japanese voice'));
       expect(capturedBody?['customPrompt'], contains('ElevenLabs'));
       expect(capturedBody?['customPrompt'], contains('Hedra'));
       // シーン/照明/カメラが日替りで変わる指示が入っていること。
       expect(capturedBody?['customPrompt'], contains('Setting for today'));
+      // 安全ガード(未成年除外)が動画プロンプトにも入っていること。
+      expect(capturedBody?['customPrompt'], contains('no minors'));
       final scriptLines = capturedBody?['customScript'] as List;
       final script = scriptLines.join('\n');
       // 動画スクリプトは固定ツアー定型文ではなく、日替りローテの導入 +


### PR DESCRIPTION
## 背景（ユーザー要望: 「劇的に変化させたい。キャラがランダムで登場するように」）
これまで動画の主視覚 presenter が**固定の女性AI秘書**だったため、舞台(#3786)を変えても人物が毎回同じで固定に見えた。ユーザー提供の広範なキャラ分類を基に、**presenter 自体を多様な人物へランダムローテ**する。

## 安全方針（最優先）
- **未成年キャラは presenter プールから完全除外（成人のみ）**。全プロンプトに `adult / no minors / no nudity / no explicit sexualization / tasteful appropriate attire / no text overlays` を強制
- 夜職・グラビア系（キャバ嬢/ホステス/グラビア/レースクイーン等）は**ブランド安全のため不採用**。ファッション/職業/創作/スポーツ/ファンタジー系の多様な成人キャラで構成
- ブランドの「AI秘書」も1候補として存置

## 変更（`universal_x_share_service.dart` のみ / +テスト）
- `_presenterCharacters`(39種) + `_dailyPresenterCharacter(seed)` 新設: ギャル/清楚/OL/看護師/CEO/ロックギタリスト/巫女/騎士/エルフ/アンドロイド/シェフ/探偵/男性アイドル/紳士 等、成人・ブランド安全・顔のある人物
- buildGrowthDraft / _imagePromptFor / _videoPromptFor が **同一 seed(draft.text.hashCode) で同じ presenter + 舞台** を選択 → 静止画と動画で人物・舞台が一致し、ニュース/生成毎に**劇的に変化**
- `avoid a masculine presenter` の排他を撤廃（多様なキャラを許容）

## 検証
- `flutter test`: **28 passed / 0 failed**（新規: 5トピックで presenter が2種以上に変化・全て`adult`・`child`非含有・`no minors`/`explicit sexualization` 安全ガード）
- `dart analyze`: No issues / `dart format`: 編集領域のみ
- Hedra は顔を必要とするため候補は全て人物キャラに限定

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: presenter/画像/動画プロンプトは決定論的で、buildGrowthDraft/generateImage/generateVideo が送る prompt を捕捉する単体テストで担保(ローテ+安全ガード)。実生成は有料クレジット消費のため自動E2E不適・ユーザー実機で確認。

Refs #3771 #3663 #3751