### PR TITLE
fix(x-share): 動画の開始画像を固定OGPでなく当日ローテ画像に(見た目の固定を解消) (#3751)

### DIFF
--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -448,7 +448,9 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
     // X Web Intent は単一ツイート。リード文(URL除去済)のみで開き、URL入りリプライ
     // を含む全文はクリップボードへ入れてスレッド投稿できるようにする。
     await Clipboard.setData(ClipboardData(text: _manualThreadPayload()));
-    final uri = Uri.https('x.com', '/intent/tweet', {'text': parts.leadText});
+    final uri = Uri.https('x.com', '/intent/tweet', {
+      'text': parts.leadText,
+    });
     await launchUrl(uri, mode: LaunchMode.externalApplication);
     if (_disposed || !mounted) return;
     setState(() {

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -12,8 +12,8 @@ final universalAiShareRouteObserver = UniversalAiShareRouteObserver();
 class UniversalAiShareRouteObserver extends NavigatorObserver {
   final ValueNotifier<UniversalSharePageContext> currentPage =
       ValueNotifier<UniversalSharePageContext>(
-        UniversalSharePageContext.fromRouteName('/'),
-      );
+    UniversalSharePageContext.fromRouteName('/'),
+  );
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -205,9 +205,8 @@ class _UniversalAiShareFab extends StatelessWidget {
     final backgroundColor = isLoggedIn
         ? colorScheme.primaryContainer
         : colorScheme.surfaceContainerHighest;
-    final foregroundColor = isLoggedIn
-        ? colorScheme.onPrimaryContainer
-        : colorScheme.onSurface;
+    final foregroundColor =
+        isLoggedIn ? colorScheme.onPrimaryContainer : colorScheme.onSurface;
 
     return Material(
       color: backgroundColor,
@@ -312,9 +311,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
         _draft = draft;
         _textController.text = draft.text;
         _loadingDraft = false;
-        _statusMessage = draft.fallbackUsed
-            ? 'AI生成が不安定なため、安全な定型文を使っています'
-            : null;
+        _statusMessage =
+            draft.fallbackUsed ? 'AI生成が不安定なため、安全な定型文を使っています' : null;
       });
     } catch (error) {
       if (_disposed || !mounted) return;
@@ -340,9 +338,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
       if (_disposed || !mounted) return;
       setState(() {
         _imageUrl = result.url;
-        _statusMessage = result.url == null
-            ? '画像生成URLを取得できませんでした'
-            : 'シェア画像を生成しました';
+        _statusMessage =
+            result.url == null ? '画像生成URLを取得できませんでした' : 'シェア画像を生成しました';
       });
     } catch (error) {
       if (_disposed || !mounted) return;
@@ -562,8 +559,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
                       _generatingVideo
                           ? '動画生成中'
                           : _hedraGenerationId == null
-                          ? '動画生成'
-                          : '動画確認',
+                              ? '動画生成'
+                              : '動画確認',
                     ),
                   ),
                 ],
@@ -613,8 +610,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           label: const Text('X画面'),
         ),
         FilledButton.icon(
-          onPressed:
-              _loadingDraft ||
+          onPressed: _loadingDraft ||
                   _posting ||
                   textLength > UniversalXShareService.maxTweetLength
               ? null

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -12,8 +12,8 @@ final universalAiShareRouteObserver = UniversalAiShareRouteObserver();
 class UniversalAiShareRouteObserver extends NavigatorObserver {
   final ValueNotifier<UniversalSharePageContext> currentPage =
       ValueNotifier<UniversalSharePageContext>(
-    UniversalSharePageContext.fromRouteName('/'),
-  );
+        UniversalSharePageContext.fromRouteName('/'),
+      );
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -205,8 +205,9 @@ class _UniversalAiShareFab extends StatelessWidget {
     final backgroundColor = isLoggedIn
         ? colorScheme.primaryContainer
         : colorScheme.surfaceContainerHighest;
-    final foregroundColor =
-        isLoggedIn ? colorScheme.onPrimaryContainer : colorScheme.onSurface;
+    final foregroundColor = isLoggedIn
+        ? colorScheme.onPrimaryContainer
+        : colorScheme.onSurface;
 
     return Material(
       color: backgroundColor,
@@ -311,8 +312,9 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
         _draft = draft;
         _textController.text = draft.text;
         _loadingDraft = false;
-        _statusMessage =
-            draft.fallbackUsed ? 'AI生成が不安定なため、安全な定型文を使っています' : null;
+        _statusMessage = draft.fallbackUsed
+            ? 'AI生成が不安定なため、安全な定型文を使っています'
+            : null;
       });
     } catch (error) {
       if (_disposed || !mounted) return;
@@ -338,8 +340,9 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
       if (_disposed || !mounted) return;
       setState(() {
         _imageUrl = result.url;
-        _statusMessage =
-            result.url == null ? '画像生成URLを取得できませんでした' : 'シェア画像を生成しました';
+        _statusMessage = result.url == null
+            ? '画像生成URLを取得できませんでした'
+            : 'シェア画像を生成しました';
       });
     } catch (error) {
       if (_disposed || !mounted) return;
@@ -357,6 +360,14 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
       _statusMessage = null;
     });
     try {
+      // 開始キーフレームが固定の OGP 画像になり、presenter/舞台のローテが動画の
+      // 見た目に反映されない問題を防ぐ。既存の生成画像も継続中の Hedra ジョブも
+      // 無ければ、先に当日の画像(presenter/舞台がローテ済)を生成し、それを動画の
+      // 開始画像として使う。
+      if (_imageUrl == null && _hedraGenerationId == null) {
+        await _generateImage();
+        if (_disposed || !mounted) return;
+      }
       final result = await _service.generateVideo(
         context: widget.page,
         draft: draft,
@@ -440,9 +451,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
     // X Web Intent は単一ツイート。リード文(URL除去済)のみで開き、URL入りリプライ
     // を含む全文はクリップボードへ入れてスレッド投稿できるようにする。
     await Clipboard.setData(ClipboardData(text: _manualThreadPayload()));
-    final uri = Uri.https('x.com', '/intent/tweet', {
-      'text': parts.leadText,
-    });
+    final uri = Uri.https('x.com', '/intent/tweet', {'text': parts.leadText});
     await launchUrl(uri, mode: LaunchMode.externalApplication);
     if (_disposed || !mounted) return;
     setState(() {
@@ -553,8 +562,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
                       _generatingVideo
                           ? '動画生成中'
                           : _hedraGenerationId == null
-                              ? '動画生成'
-                              : '動画確認',
+                          ? '動画生成'
+                          : '動画確認',
                     ),
                   ),
                 ],
@@ -604,7 +613,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           label: const Text('X画面'),
         ),
         FilledButton.icon(
-          onPressed: _loadingDraft ||
+          onPressed:
+              _loadingDraft ||
                   _posting ||
                   textLength > UniversalXShareService.maxTweetLength
               ? null

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -844,6 +844,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -928,18 +936,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1533,26 +1541,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
## 背景（end-to-end検証ワークフローが特定した支配的固定点）
presenter(#3787)・舞台(#3786)・ニュース(#3778/#3785)は本番反映済だが、**動画の見た目が固定に見える最大要因**が別にあった:
- 「画像生成」と「動画生成」ボタンは独立。**画像未生成のまま動画生成すると `_imageUrl`=null** → `generateVideo` が `defaultHedraStartImageUrl`(=`ogp-image-gen2-20260428.png` の**2026-04-28固定画像**)にフォールバック
- **Hedra は顔を開始キーフレームに固定**するため、text_prompt でキャラ/舞台をローテしても、固定画像が使われる限り画面の人物は毎回同じになる

## 変更（`universal_ai_share_shell.dart` のみ）
- `_generateVideo`: 生成画像も継続中の Hedra ジョブも無ければ、**先に `_generateImage()`(presenter/舞台がローテ済の当日画像)を生成**し、それを開始キーフレームに使う
- 画像生成が失敗した場合のみ従来の OGP フォールバック（最終手段）

→ 動画生成のたびに、ローテした当日画像から動画が作られ、見た目が毎回変化する。

## 検証
- `dart analyze`(shell): No issues found（pub get 後）
- `dart format`: 編集領域のみ
- ロジックは制御フロー追加のみ（画像が無ければ先に生成）で既存挙動を壊さない

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: 動画生成は有料クレジット(Hedra/画像生成)を消費するUIフロー(ボタン押下→非同期生成)で自動E2Eに不適。変更は`_imageUrl==null`時に先に画像生成する制御フロー追加のみで、サービス層の既存単体テスト28件(prompt生成)が回帰を担保。実機フローはユーザー確認。

Refs #3771 #3663 #3751