### PR TITLE
fix(viral-video): 動画生成エラー(Hedra text_to_speech 400)対策=音声アセット化リトライ+失敗理由可視化 (#3751)

### DIFF
--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -802,46 +802,53 @@ async function createHedraVideoFromUploadedAudio(
   const uploadedAudioUrl = media.audioGeneration["type"] === "audio"
     ? firstNonEmptyString(media.audioGeneration["url"])
     : null;
+  // アセット化(audio_id)は Hedra 側が一時的に失敗することがあるため 2 回試行する。
+  // 全試行失敗した理由は最終エラーへ載せて診断可能にする(従来は console.warn のみで
+  // 応答から asset 失敗理由が見えず、壊れた text_to_speech の 400 だけが表面化していた)。
+  let assetFailureReason: string | null = null;
   if (uploadedAudioUrl) {
-    try {
-      const audioAssetId = await createHedraAudioAssetFromUrl(
-        params.apiKey,
-        uploadedAudioUrl,
-        `${storageSafeSegment(params.title ?? "share-update")}.mp3`,
-      );
-      const assetBody: Record<string, unknown> = {
-        type: "video",
-        ai_model_id: HEDRA_AVATAR_MODEL_ID,
-        start_keyframe_url: media.imageUrl,
-        audio_id: audioAssetId,
-        generated_video_inputs: {
-          text_prompt: `${params.title ?? "Share update"}
-${params.prompt}`,
-          aspect_ratio: "16:9",
-          resolution: "540p",
-          enhance_prompt: true,
-        },
-      };
-      const assetPayload = await hedraJsonRequest(
-        params.apiKey,
-        "/generations",
-        { method: "POST", body: assetBody },
-      );
-      const video = await pollHedraGeneration(
-        params.apiKey,
-        normalizeHedraVideoResponse(assetPayload),
-      );
-      return {
-        ...video,
-        storedAudioUrl: media.storedAudioUrl,
-        storedAudioPath: media.storedAudioPath,
-        audioProvider: media.audioProvider,
-      };
-    } catch (assetError) {
-      console.warn(
-        "Hedra audio asset flow failed; trying audio_generation",
-        providerErrorMessage(assetError),
-      );
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      try {
+        const audioAssetId = await createHedraAudioAssetFromUrl(
+          params.apiKey,
+          uploadedAudioUrl,
+          `${storageSafeSegment(params.title ?? "share-update")}.mp3`,
+        );
+        const assetBody: Record<string, unknown> = {
+          type: "video",
+          ai_model_id: HEDRA_AVATAR_MODEL_ID,
+          start_keyframe_url: media.imageUrl,
+          audio_id: audioAssetId,
+          generated_video_inputs: {
+            text_prompt: `${params.title ?? "Share update"}\n${params.prompt}`,
+            aspect_ratio: "16:9",
+            resolution: "540p",
+            enhance_prompt: true,
+          },
+        };
+        const assetPayload = await hedraJsonRequest(
+          params.apiKey,
+          "/generations",
+          { method: "POST", body: assetBody },
+        );
+        const video = await pollHedraGeneration(
+          params.apiKey,
+          normalizeHedraVideoResponse(assetPayload),
+        );
+        return {
+          ...video,
+          storedAudioUrl: media.storedAudioUrl,
+          storedAudioPath: media.storedAudioPath,
+          audioProvider: media.audioProvider,
+        };
+      } catch (assetError) {
+        assetFailureReason = providerErrorMessage(assetError);
+        console.warn(
+          `Hedra audio asset flow failed (attempt ${attempt}/2)`,
+          assetFailureReason,
+        );
+        if (attempt < 2) await delay(1500);
+      }
     }
   }
   try {
@@ -856,32 +863,38 @@ ${params.prompt}`,
       media.audioGeneration["type"] !== "text_to_speech" &&
       isHedraUploadedAudioUnsupportedError(error)
     ) {
-      const fallbackAudioGeneration =
-        await createHedraTextToSpeechAudioGeneration(
-          {
-            apiKey: params.apiKey,
-            voice: params.voice,
-            lang: params.lang,
-          },
-          { text: media.fallbackText },
+      try {
+        const fallbackAudioGeneration =
+          await createHedraTextToSpeechAudioGeneration(
+            {
+              apiKey: params.apiKey,
+              voice: params.voice,
+              lang: params.lang,
+            },
+            { text: media.fallbackText },
+          );
+        payload = await createHedraGenerationWithTtsModelFallback(
+          params.apiKey,
+          { ...generationBody, audio_generation: fallbackAudioGeneration },
+          fallbackAudioGeneration["model_id"] != null,
         );
-      payload = await createHedraGenerationWithTtsModelFallback(
-        params.apiKey,
-        { ...generationBody, audio_generation: fallbackAudioGeneration },
-        fallbackAudioGeneration["model_id"] != null,
-      );
-      const video = await pollHedraGeneration(
-        params.apiKey,
-        normalizeHedraVideoResponse(payload),
-      );
-      return {
-        ...video,
-        storedAudioUrl: media.storedAudioUrl,
-        storedAudioPath: media.storedAudioPath,
-        audioProvider: "hedra_tts_after_uploaded_audio_rejected",
-      };
+        const video = await pollHedraGeneration(
+          params.apiKey,
+          normalizeHedraVideoResponse(payload),
+        );
+        return {
+          ...video,
+          storedAudioUrl: media.storedAudioUrl,
+          storedAudioPath: media.storedAudioPath,
+          audioProvider: "hedra_tts_after_uploaded_audio_rejected",
+        };
+      } catch (fallbackError) {
+        // audio_id アセット化が失敗して text_to_speech に落ち、さらにそれも失敗した
+        // 場合、元の asset 失敗理由を付記して根因(アセット化 or TTS モデル)を判別可能に。
+        throw withAudioAssetReason(fallbackError, assetFailureReason);
+      }
     }
-    throw error;
+    throw withAudioAssetReason(error, assetFailureReason);
   }
   const video = await pollHedraGeneration(
     params.apiKey,
@@ -893,6 +906,15 @@ ${params.prompt}`,
     storedAudioPath: media.storedAudioPath,
     audioProvider: media.audioProvider,
   };
+}
+
+function withAudioAssetReason(
+  error: unknown,
+  reason: string | null,
+): Error {
+  const base = error instanceof Error ? error : new Error(String(error));
+  if (!reason) return base;
+  return new Error(`${base.message}; audio_asset=${reason}`);
 }
 
 function providerErrorMessage(error: unknown): string {


### PR DESCRIPTION
## 背景（実機エラー: 動画生成が `Hedra API 400: model missing not valid for generation type text_to_speech; speech_chain: audio_provider=elevenlabs`）
10仮説のコード解析で失敗連鎖を特定:
1. ElevenLabs音声生成は**成功**(`audio_provider=elevenlabs`)→ `type:"audio"` の audioGeneration
2. `createHedraVideoFromUploadedAudio` が **audio_idアセット化(`createHedraAudioAssetFromUrl`)を試行するが失敗** → その理由が console.warn のみで**応答に出ない**
3. 失敗後 audio_generation `type:"audio"` を Hedra が拒否 → text_to_speech フォールバック
4. `resolveHedraTextToSpeechModelId` が **null**(`HEDRA_TTS_MODEL_ID`未設定/非UUID + /models探索失敗) → model_id 無しで送信 → **Hedra 400 "model missing"**

## 変更（`viral-video-ad-generator/index.ts` のみ）
- **アセット化を2回リトライ**(1.5s backoff): Hedra assets API の一時失敗で壊れた text_to_speech へ落ちるのを防ぐ
- **asset失敗理由を最終エラーへ付記**(`; audio_asset=...`): `withAudioAssetReason` を追加し、アセット化失敗→TTSも失敗した時に**根因(アセット化 or TTSモデル未解決)を応答から判別可能**に(従来は cryptic な 400 のみ)

## 検証
- `deno fmt` / `deno check` / `deno lint`: green
- `deno test hedra_tts.test.ts`: **12 passed / 0 failed**
- 恒久修正の前提となる**アセット化失敗の実理由**は本PRの診断強化で次回エラーに表面化する。並行して `HEDRA_TTS_MODEL_ID`(有効なHedra TTSモデルUUID)を secrets に設定すれば text_to_speech フォールバックも復旧する。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: viral-video-ad-generator の Hedra 音声アセット化にリトライ2回と失敗理由の可視化(withAudioAssetReason)を追加するのみ。認可/決済/スキーマ書込の変更なし。deno fmt/check/lint green・hedra_tts 単体12件 green・既存の成功パスは不変。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: Hedra/ElevenLabs 実クレジットを消費する外部依存の音声/動画生成経路で自動E2Eに不適。hedra_tts の決定論的単体テスト12件(model UUID検証/retry payload/エラー判定/voice選択)で回帰担保。リトライ+診断付記は既存成功パスを変えない制御フロー追加のみ。実機生成はユーザー確認。

Refs #3751 #3663