### PR TITLE
fix(viral-video): 動画生成エラーの原因を特定する診断ログを追加 (#3751)

### DIFF
--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -656,6 +656,14 @@ async function createHedraPresenterVideo(params: {
   const useUploadedAudioPath =
     (HEDRA_UPLOADED_AUDIO_ENABLED || params.requiresUploadedAudio === true) &&
     Boolean(ELEVENLABS_API_KEY || OPENAI_API_KEY);
+  console.log(
+    `[vvag-audio] path=${
+      useUploadedAudioPath ? "uploaded" : "hedra_tts"
+    } requiresUploadedAudio=${params.requiresUploadedAudio === true} ` +
+      `elevenlabs=${Boolean(ELEVENLABS_API_KEY)} openai=${
+        Boolean(OPENAI_API_KEY)
+      }`,
+  );
   if (useUploadedAudioPath) {
     try {
       if (!ELEVENLABS_API_KEY) {
@@ -670,8 +678,12 @@ async function createHedraPresenterVideo(params: {
       audioProvider = "elevenlabs";
       storedAudioUrl = audio.url;
       storedAudioPath = audio.path;
+      console.log(`[vvag-audio] ElevenLabs OK storedAudioUrl=${audio.url}`);
     } catch (error) {
-      console.warn("ElevenLabs speech generation failed; falling back", error);
+      console.error(
+        "[vvag-audio] ElevenLabs speech generation failed; falling back",
+        providerErrorMessage(error),
+      );
       speechChain.push(`elevenlabs=${providerErrorMessage(error)}`);
       if (
         params.requiresUploadedAudio &&
@@ -1276,19 +1288,41 @@ async function createHedraAudioAssetFromUrl(
   url: string,
   name: string,
 ): Promise<string> {
+  // 動画生成失敗の主因である「音声アセット化」の各段階を Supabase ログに記録し、
+  // どの段階(download / create asset / upload)で失敗したかを特定可能にする。
+  console.log(`[vvag-asset] download start url=${url.slice(0, 140)}`);
   const download = await fetch(url);
   if (!download.ok) {
-    throw new Error(`uploaded audio download failed with ${download.status}`);
+    const body = await download.text().catch(() => "");
+    console.error(
+      `[vvag-asset] download failed status=${download.status} body=${
+        body.slice(0, 200)
+      }`,
+    );
+    throw new Error(
+      `uploaded audio download failed with ${download.status}: ${
+        body.trim().slice(0, 200) || download.statusText
+      }`,
+    );
   }
   const bytes = new Uint8Array(await download.arrayBuffer());
+  console.log(
+    `[vvag-asset] downloaded bytes=${bytes.byteLength}; creating Hedra asset`,
+  );
   const created = await hedraJsonRequest(apiKey, "/assets", {
     method: "POST",
     body: { name, type: "audio" },
   });
   const assetId = extractHedraAssetId(created);
   if (!assetId) {
+    console.error(
+      `[vvag-asset] create asset returned no id payload=${
+        JSON.stringify(created).slice(0, 300)
+      }`,
+    );
     throw new Error("Hedra asset id was missing from create asset response");
   }
+  console.log(`[vvag-asset] asset created id=${assetId}; uploading bytes`);
   const form = new FormData();
   const buffer = new ArrayBuffer(bytes.byteLength);
   new Uint8Array(buffer).set(bytes);
@@ -1299,12 +1333,18 @@ async function createHedraAudioAssetFromUrl(
   );
   if (!uploaded.ok) {
     const rawText = await uploaded.text();
+    console.error(
+      `[vvag-asset] upload failed status=${uploaded.status} body=${
+        rawText.slice(0, 200)
+      }`,
+    );
     throw new Error(
       `Hedra asset upload ${uploaded.status}: ${
         rawText.trim() || uploaded.statusText
       }`,
     );
   }
+  console.log(`[vvag-asset] upload OK asset=${assetId}`);
   return assetId;
 }
 
@@ -1473,17 +1513,31 @@ async function resolveHedraTextToSpeechModelId(
   const configured = resolveConfiguredHedraTextToSpeechModelId(
     HEDRA_TTS_MODEL_ID,
   );
-  if (configured) return configured;
-
+  if (configured) {
+    console.log(`[vvag-tts] using configured HEDRA_TTS_MODEL_ID=${configured}`);
+    return configured;
+  }
+  console.log(
+    `[vvag-tts] HEDRA_TTS_MODEL_ID unset/invalid (raw=${
+      HEDRA_TTS_MODEL_ID ? "set-but-non-uuid" : "empty"
+    }); discovering via /models`,
+  );
   try {
     const payload = await hedraJsonRequest(apiKey, "/models", {
       method: "GET",
     });
     const models = extractHedraModelList(payload);
-    return selectBestHedraTextToSpeechModelId(models);
+    const selected = selectBestHedraTextToSpeechModelId(models);
+    console.log(
+      `[vvag-tts] /models returned ${models.length} models; selected=${
+        selected ??
+          "NONE (no text_to_speech model matched → text_to_speech will 400)"
+      }`,
+    );
+    return selected;
   } catch (error) {
-    console.warn(
-      "Hedra TTS model discovery failed",
+    console.error(
+      "[vvag-tts] Hedra TTS model discovery failed",
       providerErrorMessage(error),
     );
     return null;


### PR DESCRIPTION
## 背景
動画生成が `Hedra API 400: model missing not valid for generation type text_to_speech` で失敗するが、**どの段階で音声経路が壊れたかがログに出ない**。原因特定のため、音声パイプラインの各段階に `[vvag-*]` prefix の診断ログを追加(Supabase Logs Explorer で追跡可能に)。

## 追加ログ（Supabaseログに出力）
- `[vvag-audio]`: 音声パス選択(uploaded/hedra_tts)・ElevenLabs成功/失敗(理由)
- `[vvag-asset]`: Hedra音声アセット化の**各段階**(download status+body / create asset / upload status+body)→ **どの段階で失敗したか**が判明
- `[vvag-tts]`: HEDRA_TTS_MODEL_ID の configured/discovered/**null(→text_to_speech 400の直因)** と /models の返却数・選択結果
- download失敗エラーに応答bodyを追加(従来はstatusのみ)

## 検証
- `deno fmt` / `deno check` / `deno lint`: green
- `deno test hedra_tts.test.ts`: **12 passed / 0 failed**
- ログ追加のみで既存の制御フロー・返却値は不変

## 注意（並行作業）
本ファイルは音声セッションの [PR #3790](https://github.com/kanta13jp1/my_web_app/pull/3790)(voice rotation)でも改修中。マージ時に競合しうるが、本PRは診断ログ追加のみで領域は最小。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: viral-video-ad-generator に console.log/console.error の診断ログを追加するのみ。認可/決済/スキーマ書込/制御フローの変更なし。deno fmt/check/lint green・hedra_tts 単体12件 green・返却値不変。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: 診断ログ追加のみで挙動不変。Hedra/ElevenLabs 実クレジット消費の外部依存経路で自動E2E不適。hedra_tts 決定論的単体12件で回帰担保。ログ出力は実機生成時に Supabase Logs で確認。

Refs #3751 #3663