### PR TITLE
feat(x-share): 動画の声を映像の性別に一致+スクリプト/ポストを大幅増量 (#3751)

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -236,7 +236,7 @@ class UniversalXShareService {
       'template': _videoTemplateFor(context),
       'lang': 'ja',
       'title': _shareTitleFor(context),
-      'voice': _videoVoiceFor(context),
+      'voice': _videoVoiceFor(context, draft),
       'customPrompt': _videoPromptFor(context, draft),
       'customScript': _videoScriptFor(context, draft),
       'customHashtags': draft.hashtags,
@@ -1056,7 +1056,7 @@ Secondary goal: earn useful impressions without sounding like spam.
 Return valid JSON only:
 {
   "text": "Japanese X post under 280 chars, must include $shareUrl",
-  "threadReplies": ["0 to 6 Japanese reply posts, each under 280 chars"],
+  "threadReplies": ["5 to 8 substantive Japanese reply posts, each 120-270 chars, forming a full briefing thread"],
   "imagePrompt": "English prompt for a 16:9 share image, no text overlay",
   "videoPrompt": "English prompt for a short presenter/share video",
   "hashtags": ["#buildinpublic", "#FlutterWeb", "#Supabase"]
@@ -1089,7 +1089,8 @@ Rules:
 - When headlines are present, OPEN the lead post by tying today's single most relevant headline to this app's angle (information organization / AI work OS), so the post visibly changes every day. Do not lead with a generic app description.
 - Every day's post must read as fresh and specific: pick a different concrete headline or angle rather than repeating yesterday's template.
 - Prefer conversation hooks and save-worthy analysis over hashtags.
-- Keep the lead post under 280 chars. Use threadReplies for the briefing body.
+- Make the lead post rich and specific: aim for roughly 180-270 chars (still under 280), not a single short sentence.
+- Provide a FULL briefing thread: 5-8 substantive threadReplies that each add real analysis (状況/背景/なぜ重要か/仕事への活かし方/次の一手), not one-liners.
 - Treat the creative workflow as GPT image2 -> GPT-5.5 -> Seedance 2.0.
 - Keep the post natural, concise, and credible.
 $financeRule
@@ -1160,8 +1161,24 @@ ${fallback.text}
         : 'ai_secretary_site_tour';
   }
 
-  static String _videoVoiceFor(UniversalSharePageContext context) {
-    return _isMyFinanceUxContext(context) ? 'ja-JP' : 'ai_secretary_female';
+  static String _videoVoiceFor(
+    UniversalSharePageContext context,
+    UniversalXShareDraft draft,
+  ) {
+    if (_isMyFinanceUxContext(context)) return 'ja-JP';
+    // 動画の presenter(人物)が男女ローテするので、ナレーション音声もその性別に
+    // 合わせる(男性キャラなのに女性の声、という不一致を解消)。画像/動画と同一 seed。
+    final character = _dailyPresenterCharacter(draft.text.hashCode);
+    return _isMalePresenter(character) ? 'male_narrator' : 'female_narrator';
+  }
+
+  /// presenter キャラ文字列から男性かどうかを判定する。プールの女性エントリは
+  /// 必ず female / woman / lady のいずれかを含み、男性エントリは含まない。
+  static bool _isMalePresenter(String character) {
+    final c = character.toLowerCase();
+    final isFemale =
+        c.contains('female') || c.contains('woman') || c.contains('lady');
+    return !isFemale;
   }
 
   static String _imagePromptFor(
@@ -1271,12 +1288,39 @@ ${draft.videoPrompt}
         : '${openings[seed % openings.length]} 今日の話題は「$topic」です。';
     final closing = closings[(seed ~/ openings.length) % closings.length];
 
+    // ナレーションを大幅に長く・充実させる。各トピックに「なぜ重要か/どう整理するか」
+    // の解説を添え、導入・締めも厚くして、短い読み上げにならないようにする。
+    const commentaries = <String>[
+      'この話題は、その場で眺めるだけだと流れて消えてしまいます。ノートや仕事ログに残し、AI秘書に要点を聞ける形にしておくと、明日の判断材料としてそのまま使えます。',
+      'ポイントは、事実と自分への影響を分けて書き留めておくことです。AI仕事OSなら、関連するメモやタスクにその場でひも付けられます。',
+      'こうしたニュースは、後から「なぜそう動いたか」を振り返れるように残しておくと、学びが積み上がっていきます。',
+      '気になった論点は、AI大学の最新ニュースや主要AI企業の動きと合わせて見ると、仕事への応用先が具体的に見えてきます。',
+      '情報を集めるより、集めた情報を「いつ・どこで使うか」を決めておくことが大切です。デイリー判定とAI秘書が、その一手を後押しします。',
+    ];
     if (body.isNotEmpty) {
-      return <String>[opening, ...body.take(4), closing];
+      final items = body.take(6).toList(growable: false);
+      final lines = <String>[
+        opening,
+        'このデイリーブリーフィングでは、今日の主な話題を取り上げ、それぞれをAI仕事OSでどう整理し、明日の段取りや判断へどうつなげるかまでご紹介します。',
+      ];
+      for (var i = 0; i < items.length; i += 1) {
+        lines.add('${i + 1}つ目のトピックです。${items[i]}');
+        lines.add(commentaries[(seed + i) % commentaries.length]);
+      }
+      lines.addAll(<String>[
+        'ニュースはその場で消費すると忘れてしまいますが、ノート、仕事ログ、資産管理、英語学習をひとつの作業空間に残しておくと、後からAI秘書に要点を聞いて、そのまま仕事の材料に変えられます。',
+        'AI大学では、主要なAI企業の動きや最新ニュース、プロンプトの活用法を体系的に学べるので、こうした話題を自分の仕事にどう応用するかまで踏み込めます。',
+        'サイト案内AIに「今日はどこから始めればいい?」と聞けば、迷わず必要な機能へ進めます。まずは軽く触ってみてください。',
+        closing,
+      ]);
+      return lines;
     }
     return <String>[
       opening,
-      'AI仕事OSで、学習・仕事ログ・資産管理・英語学習をひとつに整理できます。',
+      'AI仕事OSは、学習、仕事ログ、資産管理、英語学習、メモを、ひとつの作業空間にまとめて整理できるツールです。',
+      'バラバラのアプリを行き来する代わりに、必要な情報を一か所に残し、AI秘書に要点を聞ける形にしておけます。',
+      'AI大学では最新のAIニュースや主要企業の動き、プロンプト活用を体系的に学べます。',
+      'サイト案内AIに聞けば、どの機能から始めればいいか迷いません。',
       closing,
     ];
   }

--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -60,7 +60,22 @@ const ELEVENLABS_AI_SECRETARY_VOICE_ID =
     Deno.env.get("ELEVENLABS_SECRETARY_VOICE_ID") ??
     Deno.env.get("ELEVENLABS_VOICE_ID") ??
     ELEVENLABS_DEFAULT_FEMALE_VOICE_ID;
+// presenter が男性キャラの時に使う成人男性ナレーター。ElevenLabs 標準の "Daniel"
+// を既定にしているので、追加の secret 設定なしでも映像(男性)と音声が一致する。
+const ELEVENLABS_MALE_VOICE_ID = Deno.env.get("ELEVENLABS_VOICE_MALE_ID") ??
+  "onwK4e9ZLuTAKqWW03F9";
 const VIRAL_VIDEO_BUCKET = "viral-ad-videos";
+
+// Flutter が送る voice ラベル("male_narrator"/"female_narrator")を ElevenLabs の
+// voiceId に解決する。"female" は "male" を部分文字列に含むため female を先に判定。
+function resolveElevenLabsVoiceForLabel(
+  voiceLabel: string | undefined,
+): string {
+  const label = (voiceLabel ?? "").toLowerCase();
+  if (label.includes("female")) return ELEVENLABS_AI_SECRETARY_VOICE_ID;
+  if (label.includes("male")) return ELEVENLABS_MALE_VOICE_ID;
+  return ELEVENLABS_AI_SECRETARY_VOICE_ID;
+}
 
 // Dark War風 広告テンプレート定義
 const AD_TEMPLATES = {
@@ -670,12 +685,21 @@ async function createHedraPresenterVideo(params: {
         throw new Error("ELEVENLABS_API_KEY not configured");
       }
       const audio = await createElevenLabsSpeechAsset(params.admin, {
-        text: spokenScript.slice(0, 1800),
+        text: spokenScript.slice(0, 2600),
         templateTitle: params.title ?? "share-update",
         lang: params.lang,
+        voiceId: resolveElevenLabsVoiceForLabel(params.voice),
       });
       audioGeneration = buildHedraUploadedAudioGeneration(audio.url);
       audioProvider = "elevenlabs";
+      console.log(
+        `[vvag-audio] voice label=${params.voice} → ${
+          resolveElevenLabsVoiceForLabel(params.voice) ===
+              ELEVENLABS_MALE_VOICE_ID
+            ? "male"
+            : "female"
+        }`,
+      );
       storedAudioUrl = audio.url;
       storedAudioPath = audio.path;
       console.log(`[vvag-audio] ElevenLabs OK storedAudioUrl=${audio.url}`);

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -530,7 +530,11 @@ void main() {
       );
 
       expect(capturedBody?['template'], 'ai_secretary_site_tour');
-      expect(capturedBody?['voice'], 'ai_secretary_female');
+      // 声はキャラの性別に合わせたラベル(男女どちらか)を送る。
+      expect(
+        ['male_narrator', 'female_narrator'],
+        contains(capturedBody?['voice']),
+      );
       expect(capturedBody?['preferredModel'], 'seedance-2.0');
       expect(capturedBody?['creativePipeline'], const [
         'gpt-image-2',


### PR DESCRIPTION
## 背景（ユーザー実測の2点）
動画生成は成功したが、①**映像=男性なのに音声=女性**の不一致 ②**スクリプトもポスト文も短すぎる**(約10倍にしたい)。

## 変更
### ① 声を presenter の性別に一致
- **Flutter** : presenter キャラ(#3787の39種ローテ)の性別を判定し `male_narrator`/`female_narrator` を送信(画像/動画と同一 seed)。`_isMalePresenter`= female/woman/lady を含まない=男性
- **Edge** `resolveElevenLabsVoiceForLabel`: ラベルを ElevenLabs voiceId へ解決。男性は既定で ElevenLabs 標準の `Daniel`(onwK4e9...)を使うので**追加 secret 無しでも映像と音声が一致**。`ELEVENLABS_VOICE_MALE_ID` で上書き可

### ② スクリプト/ポストを大幅増量
- **動画スクリプト** `_videoScriptFor`: 各トピックに「なぜ重要か/どう整理するか」の解説を付与、導入・締めも厚くし、6行→十数行の充実ブリーフィングに(edge の TTS 上限も 1800→2600字へ)
- **ポスト文**: LLM プロンプトを更新しリードを 180-270字の充実文に、threadReplies を 5-8件の実質的な分析スレッドに

## 検証
- `flutter test`: **28 passed / 0 failed**（声が性別ラベルになることを固定）
- `dart analyze`: No issues / `deno check`+`deno test hedra_tts`: green(12件)

## 並行作業の整理
声の性別一致は音声セッション [PR #3790](https://github.com/kanta13jp1/my_web_app/pull/3790)(voice_labels.ts)と目的が重複。本PRは**男性既定ボイスで設定不要で即動く**方式に統合したので、#3790 はクローズ推奨(その voice_labels.ts の env 設計は将来トーン別音声を増やす時に再利用可)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: viral-video-ad-generator に voice ラベル→ElevenLabs voiceId 解決(男性既定)と TTS 文字数上限の引き上げを追加するのみ。認可/決済/スキーマ書込の変更なし。deno check/test(12件) green・既存の女性既定パス不変。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: 声/台本生成は決定論的で、generateVideo が送る voice ラベル/customScript を捕捉する単体テスト28件で担保。実音声合成は ElevenLabs 実クレジット消費で自動E2E不適・ユーザー実機で確認。

Refs #3751 #3663