### PR TITLE
feat(x-share): 共有を1ボタン化+pipeline表示を実態に+失敗原因表示+X Premium長文ポスト (#3751)

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -134,13 +134,17 @@ class UniversalXTrendTopic {
 }
 
 class UniversalXShareService {
-  static const int maxTweetLength = 280;
+  // X Premium(認証済みアカウント)は最大25,000字の長文ポストが可能。280字で切らない。
+  static const int maxTweetLength = 25000;
   static const String defaultHedraStartImageUrl =
       'https://my-web-app-b67f4.web.app/ogp-image-gen2-20260428.png';
+  // 実際に使うツール(嘘のパイプラインにしない): 文章=GPT-5.5 / 画像=GPT image /
+  // 音声=ElevenLabs / 動画=Hedra。
   static const List<String> _creativePipeline = <String>[
-    'gpt-image-2',
     'gpt-5.5',
-    'seedance-2.0',
+    'gpt-image',
+    'elevenlabs',
+    'hedra',
   ];
 
   final SupabaseClient? _supabase;
@@ -240,7 +244,7 @@ class UniversalXShareService {
       'customPrompt': _videoPromptFor(context, draft),
       'customScript': _videoScriptFor(context, draft),
       'customHashtags': draft.hashtags,
-      'preferredModel': 'seedance-2.0',
+      'preferredModel': 'hedra',
       'creativePipeline': _creativePipeline,
       'source': 'universal_x_share',
       'route': context.routePath,
@@ -500,7 +504,7 @@ class UniversalXShareService {
         ? sanitizeTweet(
             '''動くスマホアプリUX検証動画「マイファイナンス」
 お金の浪費を減らすため、資産・支出・KGI/CSF/KPIを一画面で検証します。
-GPT image2 → GPT-5.5 → Seedance 2.0
+GPT image → GPT-5.5 → ElevenLabs → Hedra
 
 ${context.url}
 
@@ -522,7 +526,7 @@ ${context.url}
           ? 'A 16:9 moving smartphone app UX validation key visual for "My Finance", Japanese personal finance app, asset dashboard, spending review, KPI cards, tap gestures, clean fintech UI, no text overlays. ${_dailyImageAccent(trendTopics)}'
           : 'A clean 16:9 product screenshot style hero image for "$title", Flutter web app UI, crisp dashboard details, no text overlays, modern Japanese productivity app, bright and trustworthy. ${_dailyImageAccent(trendTopics)}',
       videoPrompt: isFinanceUx
-          ? 'A short moving smartphone app UX validation video for "My Finance", showing a Japanese mobile finance app flow with assets, spending, KGI/CSF/KPI, and an improvement loop. Creative pipeline: GPT image2 -> GPT-5.5 -> Seedance 2.0.'
+          ? 'A short moving smartphone app UX validation video for "My Finance", showing a Japanese mobile finance app flow with assets, spending, KGI/CSF/KPI, and an improvement loop. Creative pipeline: GPT image -> GPT-5.5 -> ElevenLabs -> Hedra.'
           : 'A short 16:9 presenter video concept introducing "$title" as a practical improvement in a Flutter web life-management app.',
       hashtags: isFinanceUx
           ? const ['#AI動画', '#FlutterWeb', '#資産管理']
@@ -1045,7 +1049,7 @@ $url''';
     final shareUrl = shareUrlOverride ?? acquisitionUrlFor(context);
     final trendContext = _formatTrendContext(trendTopics);
     final financeRule = _isMyFinanceUxContext(context)
-        ? '- For finance routes, frame this as 動くスマホアプリUX検証動画「マイファイナンス」 and mention GPT image2 -> GPT-5.5 -> Seedance 2.0 when natural.'
+        ? '- For finance routes, frame this as 動くスマホアプリUX検証動画「マイファイナンス」 and mention GPT image -> GPT-5.5 -> ElevenLabs -> Hedra when natural.'
         : '';
     return '''
 You are a Japanese build-in-public growth strategist.
@@ -1055,8 +1059,8 @@ Secondary goal: earn useful impressions without sounding like spam.
 
 Return valid JSON only:
 {
-  "text": "Japanese X post under 280 chars, must include $shareUrl",
-  "threadReplies": ["5 to 8 substantive Japanese reply posts, each 120-270 chars, forming a full briefing thread"],
+  "text": "Japanese X post, a rich 400-900 char long-form lead (this account has X Premium so it is NOT limited to 280 chars), must include $shareUrl",
+  "threadReplies": ["4 to 8 substantive Japanese reply posts, each 150-500 chars, forming a full briefing thread"],
   "imagePrompt": "English prompt for a 16:9 share image, no text overlay",
   "videoPrompt": "English prompt for a short presenter/share video",
   "hashtags": ["#buildinpublic", "#FlutterWeb", "#Supabase"]
@@ -1089,9 +1093,9 @@ Rules:
 - When headlines are present, OPEN the lead post by tying today's single most relevant headline to this app's angle (information organization / AI work OS), so the post visibly changes every day. Do not lead with a generic app description.
 - Every day's post must read as fresh and specific: pick a different concrete headline or angle rather than repeating yesterday's template.
 - Prefer conversation hooks and save-worthy analysis over hashtags.
-- Make the lead post rich and specific: aim for roughly 180-270 chars (still under 280), not a single short sentence.
+- This X account has X Premium, so the lead post is NOT limited to 280 chars. Write a rich long-form lead of roughly 400-900 chars: a headline, 2-4 concrete news points with brief analysis, and a low-friction CTA. Do not compress it into one short sentence.
 - Provide a FULL briefing thread: 5-8 substantive threadReplies that each add real analysis (状況/背景/なぜ重要か/仕事への活かし方/次の一手), not one-liners.
-- Treat the creative workflow as GPT image2 -> GPT-5.5 -> Seedance 2.0.
+- Treat the creative workflow as GPT image -> GPT-5.5 -> ElevenLabs -> Hedra.
 - Keep the post natural, concise, and credible.
 $financeRule
 
@@ -1231,7 +1235,7 @@ $topicLine
 Presenter for today: $character, adult, brand-safe, tasteful appropriate attire (the same presenter as the key visual).
 Voice: a warm, professional Japanese voice that matches the presenter's face and lip movement.
 Tone: premium, calm, confident, brand-safe, no minors, no nudity, no explicit sexualization.
-Visual direction: image-gen2 creates the key visual, GPT-5.5 structures the explanation, ElevenLabs provides the voice, Hedra turns the character into a presenter, and Seedance 2.0 style motion adds refined UI cutaways.
+Visual direction: GPT image creates the key visual, GPT-5.5 structures the explanation, ElevenLabs provides the voice, and Hedra turns the character into a talking presenter with refined UI cutaways.
 Show concrete product surfaces: site guide AI, AI secretary, AI University, notes, asset management, English reading dashboard, release notes, and supporter checkout.
 ${draft.videoPrompt}
 '''
@@ -1241,7 +1245,7 @@ ${draft.videoPrompt}
 Moving smartphone app UX validation video for "My Finance".
 Use the actual product context from ${context.url}.
 Show a Japanese mobile finance app flow: assets, spending, KGI/CSF/KPI, waste reduction, and an improvement loop.
-Creative pipeline: GPT image2 -> GPT-5.5 -> Seedance 2.0.
+Creative pipeline: GPT image -> GPT-5.5 -> ElevenLabs -> Hedra.
 ${draft.videoPrompt}
 '''
         .trim();

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../services/ai_share_button_preferences_service.dart';
 import '../services/universal_x_share_service.dart';
@@ -276,7 +274,6 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
   UniversalXShareDraft? _draft;
   String? _imageUrl;
   String? _videoUrl;
-  String? _hedraGenerationId;
   String? _statusMessage;
   bool _loadingDraft = true;
   bool _generatingImage = false;
@@ -323,140 +320,110 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
     }
   }
 
-  Future<void> _generateImage() async {
-    final draft = _draft;
-    if (draft == null || _generatingImage) return;
-    setState(() {
-      _generatingImage = true;
-      _statusMessage = null;
-    });
-    try {
-      final result = await _service.generateImage(
-        context: widget.page,
-        draft: draft,
-      );
-      if (_disposed || !mounted) return;
-      setState(() {
-        _imageUrl = result.url;
-        _statusMessage =
-            result.url == null ? '画像生成URLを取得できませんでした' : 'シェア画像を生成しました';
-      });
-    } catch (error) {
-      if (_disposed || !mounted) return;
-      setState(() => _statusMessage = '画像生成に失敗しました: $error');
-    } finally {
-      if (!_disposed && mounted) setState(() => _generatingImage = false);
-    }
+  bool get _statusIsError {
+    final s = _statusMessage;
+    if (s == null) return false;
+    return s.contains('失敗') ||
+        s.contains('エラー') ||
+        s.contains('できませんでした') ||
+        s.contains('不足') ||
+        s.contains('確認してください');
   }
 
-  Future<void> _generateVideo() async {
+  /// ワンボタン: 文章(生成済)→画像→音声+動画(Hedra/ElevenLabs, 非同期はポーリング)
+  /// →X投稿 を一括実行する。ユーザーは「AI生成して投稿」を押すだけ。失敗時は原因を
+  /// 画面に明確表示する。
+  Future<void> _generateAndPost() async {
     final draft = _draft;
-    if (draft == null || _generatingVideo) return;
-    setState(() {
-      _generatingVideo = true;
-      _statusMessage = null;
-    });
-    try {
-      // 開始キーフレームが固定の OGP 画像になり、presenter/舞台のローテが動画の
-      // 見た目に反映されない問題を防ぐ。既存の生成画像も継続中の Hedra ジョブも
-      // 無ければ、先に当日の画像(presenter/舞台がローテ済)を生成し、それを動画の
-      // 開始画像として使う。
-      if (_imageUrl == null && _hedraGenerationId == null) {
-        await _generateImage();
-        if (_disposed || !mounted) return;
-      }
-      final result = await _service.generateVideo(
-        context: widget.page,
-        draft: draft,
-        imageUrl: _imageUrl,
-        hedraGenerationId: _hedraGenerationId,
-      );
-      if (_disposed || !mounted) return;
-      setState(() {
-        _videoUrl = result.url;
-        _hedraGenerationId = result.url == null
-            ? _extractString(result.raw, 'hedraGenerationId')
-            : null;
-        _statusMessage = _videoStatusMessage(result);
-      });
-    } catch (error) {
-      if (_disposed || !mounted) return;
-      setState(() => _statusMessage = '動画生成に失敗しました: $error');
-    } finally {
-      if (!_disposed && mounted) setState(() => _generatingVideo = false);
+    if (_posting || _loadingDraft) return;
+    if (draft == null) {
+      setState(() => _statusMessage = 'AIが文章を生成中です。数秒待ってからもう一度押してください。');
+      return;
     }
-  }
-
-  Future<void> _postToX() async {
-    if (_posting) return;
     setState(() {
       _posting = true;
       _statusMessage = null;
     });
     try {
-      final mediaUrl = _videoUrl ?? _imageUrl;
+      // 1. 画像(presenter/舞台がローテ)
+      if (_imageUrl == null) {
+        setState(() {
+          _generatingImage = true;
+          _statusMessage = 'AIが画像を生成しています…';
+        });
+        final image = await _service.generateImage(
+          context: widget.page,
+          draft: draft,
+        );
+        if (_disposed || !mounted) return;
+        _imageUrl = image.url;
+        setState(() => _generatingImage = false);
+      }
+      // 2. 音声+動画(Hedra は非同期。生成IDが返ったら完了までポーリング)
+      if (_videoUrl == null) {
+        setState(() {
+          _generatingVideo = true;
+          _statusMessage = 'AIが音声と動画を生成しています…（30〜60秒かかります）';
+        });
+        var video = await _service.generateVideo(
+          context: widget.page,
+          draft: draft,
+          imageUrl: _imageUrl,
+        );
+        var generationId = video.url == null
+            ? _extractString(video.raw, 'hedraGenerationId')
+            : null;
+        var polls = 0;
+        while (video.url == null && generationId != null && polls < 12) {
+          await Future<void>.delayed(const Duration(seconds: 8));
+          if (_disposed || !mounted) return;
+          video = await _service.generateVideo(
+            context: widget.page,
+            draft: draft,
+            imageUrl: _imageUrl,
+            hedraGenerationId: generationId,
+          );
+          generationId = video.url == null
+              ? (_extractString(video.raw, 'hedraGenerationId') ?? generationId)
+              : null;
+          polls += 1;
+        }
+        if (_disposed || !mounted) return;
+        _videoUrl = video.url;
+        setState(() => _generatingVideo = false);
+        if (_videoUrl == null) {
+          final reason =
+              _extractString(video.raw, 'videoReason') ?? '完了しませんでした';
+          setState(() => _statusMessage = '動画は生成できませんでした（$reason）。画像付きで投稿します。');
+        }
+      }
+      // 3. X 投稿(URLはリプライへ、スレッド返信も投稿)
+      setState(() => _statusMessage = 'Xに投稿しています…');
       final result = await _service.postToX(
         context: widget.page,
         text: _textController.text,
-        mediaUrl: mediaUrl,
-        // 本文にURLを入れるとXがインプレを抑制するため、URLはリプライへ回す。
-        // スレッド返信(Q&A)も投稿してエンゲージとリーチを伸ばす。
-        threadReplies: _draft?.threadReplies ?? const [],
+        mediaUrl: _videoUrl ?? _imageUrl,
+        threadReplies: draft.threadReplies,
         linkInReply: true,
       );
       if (_disposed || !mounted) return;
       setState(() {
         _statusMessage = result.posted
-            ? '${result.account ?? '@kanta13jp1'} に投稿しました'
-            : '投稿文を保存しました。X API secret設定を確認してください';
+            ? '${result.account ?? '@kanta13jp1'} に投稿しました 🎉'
+            : '投稿できませんでした。X API secret設定を確認してください';
       });
     } catch (error) {
       if (_disposed || !mounted) return;
-      setState(() => _statusMessage = 'X投稿に失敗しました: $error');
+      setState(() => _statusMessage = '投稿に失敗しました: $error');
     } finally {
-      if (!_disposed && mounted) setState(() => _posting = false);
+      if (!_disposed && mounted) {
+        setState(() {
+          _posting = false;
+          _generatingImage = false;
+          _generatingVideo = false;
+        });
+      }
     }
-  }
-
-  // 手動投稿経路(コピー / X画面)でも、API投稿(_postToX)と同じく本文からURLを外し
-  // リプライへ回す。素の _textController.text を使うとURLがリード投稿に残り、Xの
-  // インプレッションが抑制されてしまうため。
-  ({String leadText, List<String> replyTexts, String textUrl}) _manualParts() {
-    return UniversalXShareService.buildManualShareParts(
-      context: widget.page,
-      text: _textController.text,
-      threadReplies: _draft?.threadReplies ?? const [],
-      linkInReply: true,
-    );
-  }
-
-  String _manualThreadPayload() {
-    final parts = _manualParts();
-    if (parts.replyTexts.isEmpty) return parts.leadText;
-    return [parts.leadText, ...parts.replyTexts].join('\n\n---\n\n');
-  }
-
-  Future<void> _copyText() async {
-    await Clipboard.setData(ClipboardData(text: _manualThreadPayload()));
-    if (mounted) {
-      setState(() => _statusMessage = '投稿文をコピーしました（URLはリプライに配置済み）');
-    }
-  }
-
-  Future<void> _openXComposer() async {
-    final parts = _manualParts();
-    // X Web Intent は単一ツイート。リード文(URL除去済)のみで開き、URL入りリプライ
-    // を含む全文はクリップボードへ入れてスレッド投稿できるようにする。
-    await Clipboard.setData(ClipboardData(text: _manualThreadPayload()));
-    final uri = Uri.https('x.com', '/intent/tweet', {
-      'text': parts.leadText,
-    });
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
-    if (_disposed || !mounted) return;
-    setState(() {
-      _statusMessage =
-          'X投稿画面を開きました（リード文のみ）。URLとスレッド返信はコピー済みなので、投稿後にリプライで貼ってください。';
-    });
   }
 
   static String? _extractString(Map<String, dynamic> raw, String key) {
@@ -473,30 +440,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
         : '${mediaUrl.substring(0, 220)}...';
   }
 
-  static String _videoStatusMessage(UniversalXMediaResult result) {
-    if (result.url != null) return 'シェア動画を生成しました';
-    final reason = _extractString(result.raw, 'videoReason');
-    if (reason != null && reason.contains('public URL')) {
-      return 'Video needs a public image URL. Please regenerate the share image, then retry video generation.';
-    }
-    if (reason == 'Hedra avatar video requires imageUrl') {
-      return '先に画像生成を実行してから、動画生成を開始してください';
-    }
-    final status = _extractString(result.raw, 'videoStatus') ?? result.status;
-    final generationId = _extractString(result.raw, 'hedraGenerationId');
-    final eta = _extractString(result.raw, 'hedraEtaSec');
-    if (generationId != null &&
-        const {'queued', 'processing', 'submitted'}.contains(status)) {
-      final etaText = eta == null ? '' : ' 目安: 約$eta秒';
-      return 'Hedra動画生成ジョブを開始しました。少し待ってからもう一度「動画生成」を押すと結果を確認します。$etaText';
-    }
-    if (reason != null) return '動画生成結果を確認してください: $reason';
-    return '動画生成は完了待ちです。少し待ってからもう一度確認してください';
-  }
-
   @override
   Widget build(BuildContext context) {
-    final textLength = _textController.text.length;
     final mediaUrl = _videoUrl ?? _imageUrl;
     return AlertDialog(
       title: Text('${widget.page.title} をAIシェア'),
@@ -536,89 +481,37 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
                   ),
                 ),
               const SizedBox(height: 8),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: [
-                  OutlinedButton.icon(
-                    onPressed: _loadingDraft ? null : _generateDraft,
-                    icon: const Icon(Icons.refresh),
-                    label: const Text('文言再生成'),
-                  ),
-                  OutlinedButton.icon(
-                    onPressed: _generatingImage ? null : _generateImage,
-                    icon: _generatingImage
-                        ? const _TinyProgress()
-                        : const Icon(Icons.image_outlined),
-                    label: Text(_generatingImage ? '画像生成中' : '画像生成'),
-                  ),
-                  OutlinedButton.icon(
-                    onPressed: _generatingVideo ? null : _generateVideo,
-                    icon: _generatingVideo
-                        ? const _TinyProgress()
-                        : const Icon(Icons.movie_creation_outlined),
-                    label: Text(
-                      _generatingVideo
-                          ? '動画生成中'
-                          : _hedraGenerationId == null
-                              ? '動画生成'
-                              : '動画確認',
-                    ),
-                  ),
-                ],
-              ),
               if (mediaUrl != null) ...[
                 const SizedBox(height: 12),
                 SelectableText('添付メディア: ${_mediaDisplayText(mediaUrl)}'),
               ],
               if (_statusMessage != null) ...[
                 const SizedBox(height: 12),
+                // 失敗時は赤で原因を明確に表示する。
                 Text(
                   _statusMessage!,
                   style: TextStyle(
-                    color: Theme.of(context).colorScheme.primary,
+                    color: _statusIsError
+                        ? Theme.of(context).colorScheme.error
+                        : Theme.of(context).colorScheme.primary,
                     fontWeight: FontWeight.w700,
                   ),
                 ),
               ],
-              if (textLength > UniversalXShareService.maxTweetLength)
-                Padding(
-                  padding: const EdgeInsets.only(top: 8),
-                  child: Text(
-                    '280文字を超えています。投稿前に短くしてください。',
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.error,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
             ],
           ),
         ),
       ),
+      // 操作はワンボタン。「AI生成して投稿」で 文章→画像→音声→動画→投稿 を自動実行。
       actions: [
         TextButton(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: _posting ? null : () => Navigator.of(context).pop(),
           child: const Text('閉じる'),
         ),
-        OutlinedButton.icon(
-          onPressed: _loadingDraft ? null : _copyText,
-          icon: const Icon(Icons.copy),
-          label: const Text('コピー'),
-        ),
-        OutlinedButton.icon(
-          onPressed: _loadingDraft ? null : _openXComposer,
-          icon: const Icon(Icons.open_in_new),
-          label: const Text('X画面'),
-        ),
         FilledButton.icon(
-          onPressed: _loadingDraft ||
-                  _posting ||
-                  textLength > UniversalXShareService.maxTweetLength
-              ? null
-              : _postToX,
+          onPressed: _loadingDraft || _posting ? null : _generateAndPost,
           icon: _posting ? const _TinyProgress() : const Icon(Icons.send),
-          label: Text(_posting ? '投稿中' : 'AI生成して投稿'),
+          label: Text(_posting ? '生成して投稿中…' : 'AI生成して投稿'),
         ),
       ],
     );
@@ -646,24 +539,33 @@ class _CreativePipelineCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final steps = <_PipelineStepData>[
+      // 実際に使うツールを正確に表示する(嘘のパイプラインにしない)。
+      // 文章=GPT-5.5(ai-hub) / 画像=GPT image / 音声=ElevenLabs / 動画=Hedra。
       _PipelineStepData(
         index: 1,
-        model: 'GPT image2',
-        role: 'share image',
-        icon: Icons.image_outlined,
-        state: _stateFor(ready: imageReady, running: generatingImage),
-      ),
-      _PipelineStepData(
-        index: 2,
         model: 'GPT-5.5',
-        role: 'X copy',
+        role: '文章',
         icon: Icons.edit_note,
         state: _stateFor(ready: textReady, running: generatingText),
       ),
       _PipelineStepData(
+        index: 2,
+        model: 'GPT image',
+        role: '画像',
+        icon: Icons.image_outlined,
+        state: _stateFor(ready: imageReady, running: generatingImage),
+      ),
+      _PipelineStepData(
         index: 3,
-        model: 'Seedance 2.0',
-        role: 'short video',
+        model: 'ElevenLabs',
+        role: '音声',
+        icon: Icons.record_voice_over_outlined,
+        state: _stateFor(ready: videoReady, running: generatingVideo),
+      ),
+      _PipelineStepData(
+        index: 4,
+        model: 'Hedra',
+        role: '動画',
         icon: Icons.movie_creation_outlined,
         state: _stateFor(ready: videoReady, running: generatingVideo),
       ),

--- a/supabase/functions/_shared/x-client.ts
+++ b/supabase/functions/_shared/x-client.ts
@@ -262,8 +262,9 @@ export async function postTweet(input: {
   if (text === "") {
     throw new Error("text is required.");
   }
-  if (text.length > 280) {
-    throw new Error("text exceeds 280 characters.");
+  // X Premium(認証済みアカウント)は最大25,000字の長文ポストが可能。280字で弾かない。
+  if (text.length > 25000) {
+    throw new Error("text exceeds 25000 characters.");
   }
 
   const payload: Record<string, unknown> = { text };

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -497,12 +497,13 @@ void main() {
       expect(capturedBody?['template'], 'mobile_ux_validation');
       expect(capturedBody?['title'], 'My Finance');
       expect(capturedBody?['voice'], 'ja-JP');
-      expect(capturedBody?['preferredModel'], 'seedance-2.0');
+      expect(capturedBody?['preferredModel'], 'hedra');
       expect(capturedBody?['imageUrl'], 'https://example.com/share.png');
       expect(capturedBody?['creativePipeline'], const [
-        'gpt-image-2',
         'gpt-5.5',
-        'seedance-2.0',
+        'gpt-image',
+        'elevenlabs',
+        'hedra',
       ]);
       expect(
         capturedBody?['customPrompt'],
@@ -535,11 +536,12 @@ void main() {
         ['male_narrator', 'female_narrator'],
         contains(capturedBody?['voice']),
       );
-      expect(capturedBody?['preferredModel'], 'seedance-2.0');
+      expect(capturedBody?['preferredModel'], 'hedra');
       expect(capturedBody?['creativePipeline'], const [
-        'gpt-image-2',
         'gpt-5.5',
-        'seedance-2.0',
+        'gpt-image',
+        'elevenlabs',
+        'hedra',
       ]);
       // presenter は日替りローテ、声はそれに合わせた日本語ボイス。
       expect(capturedBody?['customPrompt'], contains('Presenter for today'));


### PR DESCRIPTION
## 背景（ユーザーの4要望）
1. **AI creative pipeline 表示が実態と不一致**（`GPT image2/GPT-5.5/Seedance 2.0`）。実際は音声=ElevenLabs、動画=Hedra。ユーザーに嘘を表示している。
2. **何個もボタンを押さないと投稿できず煩わしい** → 操作は「AI生成して投稿」1つだけにしたい、他ボタンは削除。
3. **失敗時に原因が分かる表示**が欲しい。
4. **X Premium加入済みなので長文ポスト**（280字上限でない）を可能に。

## 変更
### 1. pipeline表示を実態に（嘘をなくす）
- カードを **文章=GPT-5.5 → 画像=GPT image → 音声=ElevenLabs → 動画=Hedra** の4ステップに修正。`_creativePipeline` const と `preferredModel`、プロンプト内の「Seedance 2.0」も Hedra/ElevenLabs へ統一。

### 2. ワンボタン化
- ダイアログのアクションを **「閉じる」+「AI生成して投稿」の2つだけ**に。文言再生成/画像生成/動画生成/コピー/X画面ボタンを削除。
- `_generateAndPost`: 「AI生成して投稿」1回で **文章(生成済)→画像→音声+動画(Hedraは非同期→完了までポーリング)→X投稿** を自動実行。

### 3. 失敗時の明確表示
- ステータスメッセージを**失敗時は赤**で表示（`失敗/エラー/不足/確認してください` を検出）。動画が作れない時は原因(videoReason)を出して画像付き投稿へフォールバック。

### 4. X Premium 長文ポスト
- `maxTweetLength` 280→**25000**、edge `x-client.ts` の280字チェックも25000へ。プロンプトを「X Premiumなので280字上限でない、400-900字の充実リード」に更新。

## 検証
- `flutter test`: **27 passed / 0 failed**（pipeline/preferredModelの実態値を固定）
- `dart analyze`: No issues（1ボタン化で死にコード/未使用importも除去）/ `deno check` x-client green・`deno test hedra_tts` 12件green

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: x-client.ts の投稿本文長チェックを 280→25000(X Premium 長文)へ緩めるのみ。認可/決済/スキーマ書込の変更なし。deno check green・投稿処理の他ロジック不変。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: ワンボタン生成〜投稿はHedra/ElevenLabs/X APIの実クレジット消費+非同期UIフローで自動E2E不適。pipeline値/長文上限/プロンプトはservice単体テスト27件で担保。実操作はユーザー確認。

Refs #3751 #3663
