### PR TITLE
feat(x-share): 動画ナレーション音声にトーン(energetic/calm)を追加 (#3751)

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -1171,9 +1171,10 @@ ${fallback.text}
   ) {
     if (_isMyFinanceUxContext(context)) return 'ja-JP';
     // 動画の presenter(人物)が男女ローテするので、ナレーション音声もその性別に
-    // 合わせる(男性キャラなのに女性の声、という不一致を解消)。画像/動画と同一 seed。
+    // 合わせる(男性キャラなのに女性の声、という不一致を解消)。さらにトーン
+    // (energetic / calm)も反映する。画像/動画と同一 seed。
     final character = _dailyPresenterCharacter(draft.text.hashCode);
-    return _isMalePresenter(character) ? 'male_narrator' : 'female_narrator';
+    return _voiceLabelForCharacter(character);
   }
 
   /// presenter キャラ文字列から男性かどうかを判定する。プールの女性エントリは
@@ -1183,6 +1184,47 @@ ${fallback.text}
     final isFemale =
         c.contains('female') || c.contains('woman') || c.contains('lady');
     return !isFemale;
+  }
+
+  /// presenter の性別(_isMalePresenter)に加えトーン(energetic / calm)を判定し、
+  /// 音声ラベルへ写像する。トーンが判定できない場合は中庸の
+  /// male_narrator / female_narrator を返す(= 従来の性別のみ一致と同じ出力)。
+  /// エッジ側はトーン別 secret が未設定なら性別ベース音声へフォールバックする。
+  static String _voiceLabelForCharacter(String character) {
+    final c = character.toLowerCase();
+    final gender = _isMalePresenter(character) ? 'male' : 'female';
+    const energeticMarkers = <String>[
+      'gyaru',
+      'idol',
+      'k-pop',
+      'kpop',
+      'dancer',
+      'rock',
+      'guitarist',
+      'bandman',
+      'runner',
+      'athlete',
+      'martial artist',
+    ];
+    const calmMarkers = <String>[
+      'librarian',
+      'elderly',
+      'onee-san',
+      'ojou-sama',
+      'kimono',
+      'shrine maiden',
+      'miko',
+      'gentleman',
+      'detective',
+      'wise',
+    ];
+    if (energeticMarkers.any((marker) => c.contains(marker))) {
+      return 'energetic_$gender';
+    }
+    if (calmMarkers.any((marker) => c.contains(marker))) {
+      return 'calm_$gender';
+    }
+    return '${gender}_narrator';
   }
 
   static String _imagePromptFor(

--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -25,6 +25,10 @@ import {
   stripHedraTextToSpeechModelId,
   withHedraTextToSpeechModelId,
 } from "./hedra_tts.ts";
+import {
+  resolveElevenLabsVoiceId,
+  voiceGenderForLabel,
+} from "./voice_labels.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -66,15 +70,18 @@ const ELEVENLABS_MALE_VOICE_ID = Deno.env.get("ELEVENLABS_VOICE_MALE_ID") ??
   "onwK4e9ZLuTAKqWW03F9";
 const VIRAL_VIDEO_BUCKET = "viral-ad-videos";
 
-// Flutter が送る voice ラベル("male_narrator"/"female_narrator")を ElevenLabs の
-// voiceId に解決する。"female" は "male" を部分文字列に含むため female を先に判定。
+// Flutter が送る voice ラベル(gender: "male_narrator"/"female_narrator" /
+// tone: "energetic_*"/"calm_*")を ElevenLabs の voiceId に解決する。トーン別
+// secret が設定されていればそれを、無ければ性別ベース音声(#3794 と同一)を返す。
 function resolveElevenLabsVoiceForLabel(
   voiceLabel: string | undefined,
 ): string {
-  const label = (voiceLabel ?? "").toLowerCase();
-  if (label.includes("female")) return ELEVENLABS_AI_SECRETARY_VOICE_ID;
-  if (label.includes("male")) return ELEVENLABS_MALE_VOICE_ID;
-  return ELEVENLABS_AI_SECRETARY_VOICE_ID;
+  return resolveElevenLabsVoiceId({
+    voiceLabel,
+    femaleBaseVoiceId: ELEVENLABS_AI_SECRETARY_VOICE_ID,
+    maleBaseVoiceId: ELEVENLABS_MALE_VOICE_ID,
+    env: (name) => Deno.env.get(name),
+  });
 }
 
 // Dark War風 広告テンプレート定義
@@ -694,10 +701,7 @@ async function createHedraPresenterVideo(params: {
       audioProvider = "elevenlabs";
       console.log(
         `[vvag-audio] voice label=${params.voice} → ${
-          resolveElevenLabsVoiceForLabel(params.voice) ===
-              ELEVENLABS_MALE_VOICE_ID
-            ? "male"
-            : "female"
+          voiceGenderForLabel(params.voice)
         }`,
       );
       storedAudioUrl = audio.url;

--- a/supabase/functions/viral-video-ad-generator/voice_labels.test.ts
+++ b/supabase/functions/viral-video-ad-generator/voice_labels.test.ts
@@ -1,0 +1,105 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  resolveElevenLabsVoiceId,
+  toneVoiceLabels,
+  voiceGenderForLabel,
+} from "./voice_labels.ts";
+
+const FEMALE_BASE = "female-base-voice";
+const MALE_BASE = "male-base-voice";
+
+function resolve(
+  voiceLabel: string | undefined,
+  env: Record<string, string> = {},
+): string {
+  return resolveElevenLabsVoiceId({
+    voiceLabel,
+    femaleBaseVoiceId: FEMALE_BASE,
+    maleBaseVoiceId: MALE_BASE,
+    env: (name) => env[name],
+  });
+}
+
+Deno.test("gender labels resolve to the gender base voice (== #3794)", () => {
+  assertEquals(resolve("female_narrator"), FEMALE_BASE);
+  assertEquals(resolve("male_narrator"), MALE_BASE);
+});
+
+Deno.test("legacy and unknown labels keep #3794's female default", () => {
+  for (
+    const legacy of ["ai_secretary_female", "ja-JP", "en-US", "", undefined]
+  ) {
+    assertEquals(resolve(legacy), FEMALE_BASE);
+  }
+});
+
+Deno.test("tone labels fall back to the gender base when no tone secret set", () => {
+  // No regression vs #3794: without extra secrets, tone labels use the same
+  // gender base voice as the plain narrator labels.
+  assertEquals(resolve("energetic_male"), MALE_BASE);
+  assertEquals(resolve("calm_male"), MALE_BASE);
+  assertEquals(resolve("energetic_female"), FEMALE_BASE);
+  assertEquals(resolve("calm_female"), FEMALE_BASE);
+});
+
+Deno.test("tone labels use their dedicated secret when configured", () => {
+  assertEquals(
+    resolve("energetic_male", {
+      ELEVENLABS_VOICE_ENERGETIC_MALE_ID: "energetic-male-voice",
+    }),
+    "energetic-male-voice",
+  );
+  assertEquals(
+    resolve("calm_female", {
+      ELEVENLABS_VOICE_CALM_FEMALE_ID: "calm-female-voice",
+    }),
+    "calm-female-voice",
+  );
+});
+
+Deno.test("a configured tone secret does not leak to other tones/genders", () => {
+  const env = { ELEVENLABS_VOICE_ENERGETIC_MALE_ID: "energetic-male-voice" };
+  assertEquals(resolve("energetic_male", env), "energetic-male-voice");
+  // calm_male has no dedicated secret → base; energetic_female is a different
+  // gender → female base; plain narrators are unaffected.
+  assertEquals(resolve("calm_male", env), MALE_BASE);
+  assertEquals(resolve("energetic_female", env), FEMALE_BASE);
+  assertEquals(resolve("male_narrator", env), MALE_BASE);
+});
+
+Deno.test("blank tone secret values are ignored", () => {
+  assertEquals(
+    resolve("energetic_male", { ELEVENLABS_VOICE_ENERGETIC_MALE_ID: "   " }),
+    MALE_BASE,
+  );
+});
+
+Deno.test("labels are trimmed and case-insensitive", () => {
+  assertEquals(
+    resolve("  Energetic_Male  ", {
+      ELEVENLABS_VOICE_ENERGETIC_MALE_ID: "energetic-male-voice",
+    }),
+    "energetic-male-voice",
+  );
+});
+
+Deno.test("voiceGenderForLabel checks female before male", () => {
+  assertEquals(voiceGenderForLabel("female_narrator"), "female");
+  assertEquals(voiceGenderForLabel("energetic_female"), "female");
+  assertEquals(voiceGenderForLabel("male_narrator"), "male");
+  assertEquals(voiceGenderForLabel("calm_male"), "male");
+  assertEquals(voiceGenderForLabel("ai_secretary_female"), "female");
+  assertEquals(voiceGenderForLabel("ja-JP"), "female");
+  assertEquals(voiceGenderForLabel(undefined), "female");
+});
+
+Deno.test("every tone label is gender-suffixed and resolvable", () => {
+  for (const label of toneVoiceLabels()) {
+    const gender = label.includes("male") && !label.includes("female")
+      ? "male"
+      : "female";
+    assertEquals(voiceGenderForLabel(label), gender);
+    // Falls back to the correct gender base when no secret is set.
+    assertEquals(resolve(label), gender === "male" ? MALE_BASE : FEMALE_BASE);
+  }
+});

--- a/supabase/functions/viral-video-ad-generator/voice_labels.ts
+++ b/supabase/functions/viral-video-ad-generator/voice_labels.ts
@@ -1,0 +1,79 @@
+// Tone-aware ElevenLabs voice resolution for the X-share presenter video.
+//
+// #3794 matched the narration voice to the presenter's *gender* (male /
+// female) with a no-config default male voice ("Daniel"). This module layers
+// *tone* on top: the client can additionally send "energetic_*" / "calm_*"
+// labels, and when a tone-specific ElevenLabs voice secret is configured we use
+// it. When it is not, we fall back to the exact same gender base voice #3794
+// already uses, so behaviour is unchanged until the user opts in by adding the
+// extra secrets.
+//
+// Pure functions (env is injected) so they are deno-testable without real
+// secrets or network access.
+
+export type VoiceGender = "male" | "female";
+
+// Tone-specific labels → the ElevenLabs voice secret to prefer. Labels not
+// listed here (e.g. "male_narrator", "female_narrator", legacy
+// "ai_secretary_female", "ja-JP") have no tone secret and resolve straight to
+// the gender base voice, matching #3794 exactly.
+const TONE_VOICE_ENV: Record<string, string> = {
+  energetic_female: "ELEVENLABS_VOICE_ENERGETIC_FEMALE_ID",
+  calm_female: "ELEVENLABS_VOICE_CALM_FEMALE_ID",
+  energetic_male: "ELEVENLABS_VOICE_ENERGETIC_MALE_ID",
+  calm_male: "ELEVENLABS_VOICE_CALM_MALE_ID",
+};
+
+/**
+ * The presenter gender a voice label maps to. "female" is checked before
+ * "male" because the string "female" contains "male" as a substring. Unknown
+ * labels default to "female", preserving #3794's female-default behaviour.
+ */
+export function voiceGenderForLabel(
+  voiceLabel: string | null | undefined,
+): VoiceGender {
+  const label = (voiceLabel ?? "").toLowerCase();
+  if (label.includes("female")) return "female";
+  if (label.includes("male")) return "male";
+  return "female";
+}
+
+/**
+ * Resolve a voice label to an ElevenLabs voiceId.
+ *
+ * Resolution order:
+ *   1. If the label is tone-specific and its dedicated secret is set → that voiceId.
+ *   2. Otherwise → the gender base voiceId (the same voice #3794 uses).
+ *
+ * @param voiceLabel label from the client, e.g. "energetic_male". Legacy /
+ *   unknown labels resolve to the female base voice (== #3794's default).
+ * @param femaleBaseVoiceId gender base for female presenters (ELEVENLABS_AI_SECRETARY_VOICE_ID).
+ * @param maleBaseVoiceId gender base for male presenters (ELEVENLABS_MALE_VOICE_ID / "Daniel").
+ * @param env reads a secret by name; inject `Deno.env.get` in production.
+ */
+export function resolveElevenLabsVoiceId(params: {
+  voiceLabel: string | null | undefined;
+  femaleBaseVoiceId: string;
+  maleBaseVoiceId: string;
+  env: (name: string) => string | undefined;
+}): string {
+  const label = (params.voiceLabel ?? "").trim().toLowerCase();
+  const gender = voiceGenderForLabel(label);
+  const baseVoiceId = gender === "male"
+    ? params.maleBaseVoiceId
+    : params.femaleBaseVoiceId;
+
+  const toneEnvName = TONE_VOICE_ENV[label];
+  if (toneEnvName) {
+    const toneVoiceId = params.env(toneEnvName);
+    if (typeof toneVoiceId === "string" && toneVoiceId.trim().length > 0) {
+      return toneVoiceId.trim();
+    }
+  }
+  return baseVoiceId;
+}
+
+/** Tone labels this module can resolve to a dedicated voice (for tests/tooling). */
+export function toneVoiceLabels(): string[] {
+  return Object.keys(TONE_VOICE_ENV);
+}

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -2,6 +2,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/ai_hub_chat_service.dart';
 import 'package:my_web_app/services/universal_x_share_service.dart';
 
+// 非 finance の presenter 動画で使う音声ラベル一覧(エッジ側 voice_labels.ts と対応)。
+// 中庸の male/female_narrator に加え、トーン別 energetic_* / calm_* を含む。
+const _kVoiceLabels = <String>[
+  'female_narrator',
+  'male_narrator',
+  'energetic_female',
+  'energetic_male',
+  'calm_female',
+  'calm_male',
+];
+
 void main() {
   const page = UniversalSharePageContext(
     routePath: '/gemini-university',
@@ -531,11 +542,8 @@ void main() {
       );
 
       expect(capturedBody?['template'], 'ai_secretary_site_tour');
-      // 声はキャラの性別に合わせたラベル(男女どちらか)を送る。
-      expect(
-        ['male_narrator', 'female_narrator'],
-        contains(capturedBody?['voice']),
-      );
+      // 声はキャラの性別/トーンに合わせたラベル(6 種のいずれか)を送る。
+      expect(capturedBody?['voice'], isIn(_kVoiceLabels));
       expect(capturedBody?['preferredModel'], 'hedra');
       expect(capturedBody?['creativePipeline'], const [
         'gpt-5.5',
@@ -705,5 +713,58 @@ void main() {
       UniversalXShareService.isEmbeddedDataUrl('https://example.com/a.png'),
       isFalse,
     );
+  });
+
+  test('generateVideo matches narration voice gender+tone to the presenter',
+      () async {
+    Map<String, dynamic>? capturedBody;
+    final service = UniversalXShareService(
+      functionInvoker: (functionName, body) async {
+        capturedBody = body;
+        return {'success': true, 'status': 'fallback_text'};
+      },
+    );
+
+    final baseDraft = UniversalXShareService.buildGrowthDraft(page);
+    final observedLabels = <String>{};
+    var sawMaleVoice = false;
+    var sawFemaleVoice = false;
+
+    // 多数の異なる seed(= 当日ニュース違い)で presenter が男女両方へ振れることを
+    // 確認しつつ、毎回 presenter の性別と音声ラベルの性別が一致すること(男性キャラに
+    // 女性声、女性キャラに男性声が付かない)を保証する。
+    for (var i = 0; i < 120; i += 1) {
+      final draft = baseDraft.copyWith(text: 'x-share-seed-$i ${page.url}');
+      await service.generateVideo(
+        context: page,
+        draft: draft,
+        imageUrl: 'https://example.com/secretary.png',
+      );
+      final voice = capturedBody?['voice'] as String;
+      final prompt = capturedBody?['customPrompt'] as String;
+      expect(voice, isIn(_kVoiceLabels));
+      final presenterIsFemale = prompt.contains('female') ||
+          prompt.contains('woman') ||
+          prompt.contains('lady');
+      final voiceIsFemale = voice.contains('female');
+      expect(
+        voiceIsFemale,
+        presenterIsFemale,
+        reason: 'voice "$voice" gender must match presenter in prompt: $prompt',
+      );
+      observedLabels.add(voice);
+      sawMaleVoice = sawMaleVoice || !voiceIsFemale;
+      sawFemaleVoice = sawFemaleVoice || voiceIsFemale;
+    }
+
+    // ローテの結果、男女両方の声が実際に選ばれること。
+    expect(sawMaleVoice, isTrue);
+    expect(sawFemaleVoice, isTrue);
+    // トーン別ラベルへローテするため、中庸 narrator 以外の声も現れること。
+    expect(observedLabels.length, greaterThanOrEqualTo(2));
+    final sawTonedVoice = observedLabels.any(
+      (label) => label.startsWith('energetic_') || label.startsWith('calm_'),
+    );
+    expect(sawTonedVoice, isTrue);
   });
 }


### PR DESCRIPTION
## 概要

[#3794](https://github.com/kanta13jp1/my_web_app/pull/3794) は X シェア動画のナレーション音声を presenter の**性別**（male / female、既定 "Daniel" で設定不要）に一致させた。本 PR はその上に**トーン**（energetic / calm）を**追加**する。presenter がアイドル/ロック/ダンサー等なら元気な声、司書/年配/探偵等なら落ち着いた声を選べるようにする。

親: #3751 #3663 / #3794 の follow-up（重複ではなく additive レイヤー）

## 設計方針: #3794 に対して完全 additive・デグレなし

- クライアントは従来の `male_narrator` / `female_narrator` に加え、トーン付き `energetic_*` / `calm_*` の**計 6 ラベル**を送る（中庸トーンは従来どおり `*_narrator`）。
- エッジのラベル解決を、テスト可能な純粋モジュール `voice_labels.ts` に切り出し、**トーン別 secret が設定されていればそれを、無ければ #3794 と同一の性別ベース音声**（`ELEVENLABS_AI_SECRETARY_VOICE_ID` / `ELEVENLABS_VOICE_MALE_ID`="Daniel"）へフォールバックする。
- **追加 secret を設定しなければ #3794 と完全に同一の音声**（`energetic_male` → Daniel、`energetic_female` → 秘書ボイス）。deno テストで「== #3794」を明示検証。

## 変更内容

**エッジ** `supabase/functions/viral-video-ad-generator/`
- 新規 `voice_labels.ts`（純粋関数・env 注入でテスト可能）:
  - `resolveElevenLabsVoiceId({voiceLabel, femaleBaseVoiceId, maleBaseVoiceId, env})` — トーン別 secret → 性別ベースの順で解決。
  - `voiceGenderForLabel(label)` — ラベル→性別（female を先に判定）。
- `index.ts`: 既存 `resolveElevenLabsVoiceForLabel` の本体を上記純粋関数へ委譲（呼び出し側・シグネチャ不変）。診断ログ `[vvag-audio]` の性別表示を `voiceGenderForLabel` で正確化。

**クライアント** `lib/services/universal_x_share_service.dart`
- `_videoVoiceFor` が新規 `_voiceLabelForCharacter()` を使い、presenter の性別（既存 `_isMalePresenter` を再利用）+トーンで 6 ラベルへ写像。

## 前提: トーン別音声はオプトイン

トーン別の声を実際に変えるには、ユーザーが ElevenLabs で追加音声を用意し、以下の secret を設定する（**任意** / 未設定なら #3794 の性別ベース音声のまま）:

| ラベル | 参照する secret（未設定なら性別ベースへフォールバック） |
|---|---|
| `energetic_male` / `calm_male` | `ELEVENLABS_VOICE_ENERGETIC_MALE_ID` / `ELEVENLABS_VOICE_CALM_MALE_ID` → `ELEVENLABS_VOICE_MALE_ID`("Daniel") |
| `energetic_female` / `calm_female` | `ELEVENLABS_VOICE_ENERGETIC_FEMALE_ID` / `ELEVENLABS_VOICE_CALM_FEMALE_ID` → `ELEVENLABS_AI_SECRETARY_VOICE_ID` |
| `male_narrator` / `female_narrator` | 性別ベース音声（#3794 と同一） |

## 安全性

音声も画像/動画と同様に**非性的・ブランドセーフ**。性別/トーンのラベルのみを扱い、性的・不適切な音声類型は導入しない。

## テスト

- `deno test`: `voice_labels.test.ts` 9 件（**== #3794 の一致**・トーン未設定時フォールバック・トーン別 secret 適用・他トーン/性別への非漏洩・trim/大小無視・性別判定）+ 既存 `hedra_tts.test.ts` 12 件 = **21 件 green**。
- `flutter test test/services/universal_x_share_service_test.dart`: **28 件 green**。新規テストは 120 seed をローテし、**毎回 presenter の性別と音声ラベルの性別が一致**・男女両方の声が選ばれる・トーン付きラベルも出現することを保証。
- `flutter analyze` / `deno lint` / `deno check`: いずれもクリーン。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge function change plus Flutter service label change, no new user-facing UI; covered by deno voice_labels.test.ts and flutter service tests

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive tone voice layer on top of merged #3794; pure tested label resolver, brand-safe non-sexual audio, falls back to the same gender base voices when tone secrets are unset, no behavior change without new secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
