### PR TITLE
refactor(election): edge fn の立憲CDPスクレイプ・デッドコードを整理

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -518,7 +518,6 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     try {
       final snapshot = await _realityService.fetchLatestSnapshot(
         includeAiSummary: false,
-        includeCdpBenchmarks: false,
         forceRefresh: forceRefresh,
       );
       final history = await _realityService.loadSnapshotHistory();

--- a/lib/services/local_election_reality_service.dart
+++ b/lib/services/local_election_reality_service.dart
@@ -160,7 +160,6 @@ class LocalElectionRealityService {
 
   Future<LocalElectionRealitySnapshot> fetchLatestSnapshot({
     bool includeAiSummary = true,
-    bool includeCdpBenchmarks = true,
     SharedPreferences? prefs,
     bool forceRefresh = false,
   }) async {
@@ -192,7 +191,6 @@ class LocalElectionRealityService {
         _fetchLatestSnapshotFromEdgeFunction(
       client: client,
       includeAiSummary: includeAiSummary,
-      includeCdpBenchmarks: includeCdpBenchmarks,
     ).then(_rejectSuspiciousSnapshot);
     _latestSnapshotInFlight = request;
 
@@ -271,13 +269,11 @@ class LocalElectionRealityService {
   Future<LocalElectionRealitySnapshot> _fetchLatestSnapshotFromEdgeFunction({
     required SupabaseClient client,
     required bool includeAiSummary,
-    required bool includeCdpBenchmarks,
   }) async {
     final response = await client.functions.invoke(
       'local-election-intelligence',
       body: <String, dynamic>{
         'includeAiSummary': includeAiSummary,
-        'includeCdpBenchmarks': includeCdpBenchmarks,
       },
     ).timeout(_edgeFunctionTimeout);
     final data = _toMap(response.data);

--- a/lib/services/local_election_share_service.dart
+++ b/lib/services/local_election_share_service.dart
@@ -1056,9 +1056,10 @@ class LocalElectionShareService {
     return '同数';
   }
 
-  /// AI整理メモの注視ポイント。AI整理メモは includeCdpBenchmarks=false の snapshot を
-  /// 使うため立憲比較行が「取得していません」になる。週次cronでバッチ取得した立憲値
-  /// (plan に適用済み) から地力差を計算し、その行だけ差し替える。データが無ければ原文。
+  /// AI整理メモの注視ポイント。snapshot の edge function は立憲値を取得しない
+  /// (週次cronが正本) ため立憲比較行が「取得していません」になる。週次cronで
+  /// バッチ取得した立憲値 (plan に適用済み) から地力差を計算し、その行だけ差し替える。
+  /// データが無ければ原文。
   List<String> displayAiAlerts(
     LocalElectionRealitySnapshot snapshot,
     LocalElectionPlanDashboard? plan,
@@ -1108,7 +1109,7 @@ class LocalElectionShareService {
     };
   }
 
-  /// snapshot は includeCdpBenchmarks=false で立憲値が 0 のため、plan のバッチ値が
+  /// snapshot の立憲値は edge function が取得せず常に 0 のため、plan のバッチ値が
   /// あればそれを優先する (_describePlanPrefecture のマージと同型 / 0・欠損は据置)。
   int _resolveCdpLocalMembers(
     LocalElectionPrefectureReality reality,

--- a/supabase/functions/local-election-intelligence/index.ts
+++ b/supabase/functions/local-election-intelligence/index.ts
@@ -17,8 +17,6 @@ const OFFICIAL_2023_SECOND_HALF_URL =
 const ELECTION_SCHEDULE_URL = "https://go2senkyo.com/schedule";
 const CDP_LOCAL_AUTHORITIES_URL =
   "https://cdp-japan.jp/members/house/local_authorities";
-const CDP_PREFECTURE_MEMBERS_BASE_URL =
-  "https://cdp-japan.jp/members/prefecture/";
 const NEW_KOKUMIN_ELECTIONS_URL =
   "https://local-elections.new-kokumin.jp/electionslist/";
 const NEXT_UNIFIED_LOCAL_ELECTION_INFO_URL =
@@ -37,7 +35,6 @@ const SCHEDULE_MAX_ENTRIES = 2000;
 const AI_ANALYSIS_TIMEOUT_MS = 6000;
 // 最低保証日数 (これを下回る window は使わない)
 const SCHEDULE_MIN_WINDOW_DAYS = 30;
-const CDP_PREFECTURE_MAX_PAGES = 24;
 
 const JP_LOCAL_ASSEMBLY_MEMBERS = "\u5730\u65b9\u81ea\u6cbb\u4f53\u8b70\u54e1";
 const JP_PLANNED_CANDIDATES = "\u5019\u88dc\u4e88\u5b9a\u8005";
@@ -139,13 +136,6 @@ interface PrefectureReality {
   prefecturalAssemblyMembers: number;
   municipalAssemblyMembers: number;
   members: LocalLegislatorProfile[];
-}
-
-interface CdpPrefectureLocalMemberStats {
-  prefecture: string;
-  sourceUrl: string;
-  localMembers: number;
-  pagesFetched: number;
 }
 
 interface HistoricalResult {
@@ -490,7 +480,6 @@ const MANUAL_SCHEDULE_SUPPLEMENTS: ManualScheduleSupplement[] = [
 interface SnapshotRequest {
   action: "snapshot";
   includeAiSummary: boolean;
-  includeCdpBenchmarks: boolean;
 }
 
 interface MemberDetailRequest {
@@ -520,12 +509,6 @@ serve(async (req) => {
       return jsonResponse({ success: true, profile });
     }
 
-    const cdpStatsPromise = parsedRequest.includeCdpBenchmarks
-      ? fetchCdpLocalMemberStatsByPrefecture().catch((error) => {
-        console.error("Failed to fetch CDP local member stats:", error);
-        return new Map<string, CdpPrefectureLocalMemberStats>();
-      })
-      : Promise.resolve(new Map<string, CdpPrefectureLocalMemberStats>());
     const memberPageHtml = await fetchText(OFFICIAL_MEMBER_PAGE_URL);
     const officialElectionHtml = await fetchText(OFFICIAL_ELECTION_PAGE_URL);
     const prefectureDirectoryEntries = parsePrefectureDirectoryEntries(
@@ -545,19 +528,17 @@ serve(async (req) => {
       compareMembers,
     );
     const officialCurrentLocalMembers = members.length;
-    const cdpStatsByPrefecture = await cdpStatsPromise;
+    // 立憲(CDP)地方議員数は週次 cron (update_cdp_benchmark.mjs → assets/data/
+    // cdp_local_members.json → plan) が正本。この EF は取得せず 0 を返し、
+    // クライアントは plan のバッチ値を利用する。
     const prefectures = prefectureResults.map((item) => ({
       prefecture: item.prefecture,
       sourceUrl: item.sourceUrl,
       currentMembers: item.currentMembers,
       prefecturalAssemblyMembers: item.prefecturalAssemblyMembers,
       municipalAssemblyMembers: item.municipalAssemblyMembers,
-      cdpLocalMembers:
-        cdpStatsByPrefecture.get(prefectureLookupKey(item.prefecture))
-          ?.localMembers ?? 0,
-      cdpSourceUrl:
-        cdpStatsByPrefecture.get(prefectureLookupKey(item.prefecture))
-          ?.sourceUrl ?? CDP_LOCAL_AUTHORITIES_URL,
+      cdpLocalMembers: 0,
+      cdpSourceUrl: CDP_LOCAL_AUTHORITIES_URL,
     }));
 
     const historical = await fetchHistoricalResult();
@@ -713,15 +694,12 @@ async function parseRequest(req: Request): Promise<ParsedRequest> {
     return {
       action: "snapshot",
       includeAiSummary: url.searchParams.get("includeAiSummary") !== "false",
-      includeCdpBenchmarks:
-        url.searchParams.get("includeCdpBenchmarks") !== "false",
     };
   }
 
   return {
     action: "snapshot",
     includeAiSummary: body.includeAiSummary !== false,
-    includeCdpBenchmarks: body.includeCdpBenchmarks !== false,
   };
 }
 
@@ -811,72 +789,6 @@ async function fetchPrefectureReality(
     municipalAssemblyMembers: 0,
     members: [],
   };
-}
-
-async function fetchCdpLocalMemberStatsByPrefecture(): Promise<
-  Map<string, CdpPrefectureLocalMemberStats>
-> {
-  const stats = await mapWithConcurrency(
-    [...PREFECTURES],
-    6,
-    fetchCdpPrefectureLocalMemberStats,
-  );
-  return new Map(
-    stats.map((item) => [prefectureLookupKey(item.prefecture), item]),
-  );
-}
-
-async function fetchCdpPrefectureLocalMemberStats(
-  prefecture: string,
-): Promise<CdpPrefectureLocalMemberStats> {
-  const sourceUrl = `${CDP_PREFECTURE_MEMBERS_BASE_URL}${
-    encodeURIComponent(prefectureSlug(prefecture))
-  }`;
-  let localMembers = 0;
-  let pagesFetched = 0;
-  let maxPage = 1;
-
-  try {
-    for (
-      let page = 1;
-      page <= Math.min(maxPage, CDP_PREFECTURE_MAX_PAGES);
-      page++
-    ) {
-      const pageUrl = page === 1 ? sourceUrl : `${sourceUrl}?page=${page}`;
-      const html = await fetchText(pageUrl);
-      pagesFetched += 1;
-      localMembers += countCdpLocalAuthorityCards(html);
-      if (page === 1) {
-        maxPage = Math.max(1, parseMaxPaginationPage(html));
-      }
-    }
-  } catch (error) {
-    console.error(`Failed to fetch CDP ${prefecture}:`, error);
-  }
-
-  return {
-    prefecture,
-    sourceUrl,
-    localMembers,
-    pagesFetched,
-  };
-}
-
-function countCdpLocalAuthorityCards(html: string): number {
-  return [
-    ...html.matchAll(
-      /class="[^"]*\bcard\b[^"]*\bmember\b[^"]*\bmember-local_[^"]*"/gi,
-    ),
-  ]
-    .length;
-}
-
-function parseMaxPaginationPage(html: string): number {
-  let maxPage = 1;
-  for (const match of html.matchAll(/\?page=(\d+)/g)) {
-    maxPage = Math.max(maxPage, toInt(match[1] ?? ""));
-  }
-  return maxPage;
 }
 
 function prefectureSlug(prefecture: string): string {


### PR DESCRIPTION
## 概要

立憲(CDP)地方議員数は **週次cron** (`update_cdp_benchmark.mjs` →
`assets/data/cdp_local_members.json` → plan) が正本で、クライアントは常に
`includeCdpBenchmarks=false` で `local-election-intelligence` を呼ぶため、
edge fn の CDP スクレイプ経路は **既に非実行のデッドコード**だった。これを整理する。

## 変更 (振る舞い不変)

- **edge fn**: `fetchCdpLocalMemberStatsByPrefecture` / `fetchCdpPrefectureLocalMemberStats`
  / `countCdpLocalAuthorityCards` / `parseMaxPaginationPage` と
  `CdpPrefectureLocalMemberStats` 型・`CDP_PREFECTURE_*` 定数を除去。
  `cdpStatsPromise` の gating を撤去し `cdpLocalMembers: 0` 固定
  (= 従来の flag=false 時と **byte-identical**)。`cdpSourceUrl` も従来同様
  `CDP_LOCAL_AUTHORITIES_URL`(sources 引用でも使用のため残置)。
  共有ヘルパー `prefectureSlug` / `prefectureLookupKey` は非CDP用途で保持。
- **client**: `includeCdpBenchmarks` フラグ plumbing を
  `local_election_reality_service` / `election_victory_page` から除去。
- 陳腐化した flag 参照コメントを更新。

## 検証

- `deno check` / `deno lint` (edge fn) → 緑。
- `dart analyze`(client 3ファイル)→ No issues。
- `dart format --set-exit-if-changed` → 差分なし。
- 応答スキーマ・値は従来(flag 常時 false)と同値のため既存 client 挙動は不変。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 非実行デッドコードの除去のみで振る舞い不変(includeCdpBenchmarks は既に常に false → CDP scrape 非実行 / 応答は cdpLocalMembers=0 で従来と byte-identical)。新規挙動なし。deno check/lint + dart analyze 緑、CI の DB+Edge smoke で edge fn health を担保。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 立憲CDP scrape の非実行デッドコード除去のみ。新 auth/RLS/データ境界を導入せず、応答スキーマ・値ともに従来(flag=false 時)と同値の振る舞い保存。deno check/lint 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
