### PR TITLE
fix(growth-hub): x.postの投稿本文長を280→25000字へ(X Premium長文ポスト対応) (#3751)

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -1630,19 +1630,20 @@ serve(async (req: Request) => {
           .trim();
         const dryRun = body.dryRun === true;
         if (!text) return json({ success: false, error: "text required" }, 400);
-        if (text.length > 280) {
+        // X Premium(認証済みアカウント)は最大25,000字の長文ポストが可能。280字で弾かない。
+        if (text.length > 25000) {
           return json({
             success: false,
-            error: "text exceeds 280 characters",
+            error: "text exceeds 25000 characters",
           }, 400);
         }
         const longReplyIndex = replyTexts.findIndex((entry) =>
-          entry.length > 280
+          entry.length > 25000
         );
         if (longReplyIndex >= 0) {
           return json({
             success: false,
-            error: `replyTexts[${longReplyIndex}] exceeds 280 characters`,
+            error: `replyTexts[${longReplyIndex}] exceeds 25000 characters`,
           }, 400);
         }
 


### PR DESCRIPTION
## 背景（実機エラー）
build 4680(Flutter は25,000字対応済み)で745字の長文ポストを投稿すると `投稿に失敗しました: FunctionException(status: 400, {success:false, error:"text exceeds 280 characters"})`。

## 真因（10仮説で特定）
`_shared/x-client.ts` は #3795 で25,000へ緩和済み(デプロイ確認済)だが、**growth-hub/index.ts の x.post アクション自体に別の280字チェック**があり、x-client を呼ぶ前に弾いていた(エラー文言「text exceeds 280 characters」=末尾ピリオド無し=growth-hub側。x-client は「exceeds 25000 characters.」)。

## 変更（`growth-hub/index.ts` のみ）
- x.post のリード本文チェック `text.length > 280` → `> 25000`
- スレッド返信チェック `entry.length > 280` → `> 25000`
- エラー文言も25000へ

これで Flutter(25000) / x-client(25000) / growth-hub(25000) が揃い、X Premium の長文ポストが通る。

## 検証
- `deno fmt` / `deno lint`: green
- `deno check`: 既存の型不一致(1200行 `listUsers().data.total` = Supabase SDK型、origin/main から存在・本変更と無関係・デプロイは許容)以外は問題なし
- 変更は数値上限のみで投稿ロジック不変

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: growth-hub x.post の投稿本文長上限を 280→25000(X Premium 長文)へ緩めるのみ。認可/決済/スキーマ書込の変更なし。x-client/Flutter と整合。投稿ロジック不変。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: x.post は X API 実投稿(実クレジット/実アカウント)を伴う外部依存で自動E2E不適。上限は純粋な数値ガードで、Flutter/x-client 側の同値テストと実機投稿(長文745字)で担保。

Refs #3751 #3663
