### PR TITLE
feat(asset): マネーカレンダーを給料日サイクル窓へ移行

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -287,6 +287,12 @@ class AssetManagementPage extends StatefulWidget {
   @visibleForTesting
   final List<Map<String, dynamic>>? debugInitialPayslipRows;
 
+  /// テスト専用: マネーカレンダーの「今日」(サイクル決定・予定系の起点) を固定し、
+  /// 給料日サイクル窓の表示・ショート試算を実行日非依存で検証する。
+  /// null なら実時刻。
+  @visibleForTesting
+  final DateTime? debugCalendarNow;
+
   const AssetManagementPage({
     super.key,
     this.initialFocus = AssetManagementInitialFocus.overview,
@@ -315,6 +321,7 @@ class AssetManagementPage extends StatefulWidget {
     this.debugInitialRecentFlows,
     this.debugInitialPayslipSalaryIncomes,
     this.debugInitialPayslipRows,
+    this.debugCalendarNow,
   });
 
   @override
@@ -845,7 +852,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   String? _displayModeStatsLabel;
   String? _experimentServerSummary;
   List<Map<String, dynamic>> _experimentWeekly = const <Map<String, dynamic>>[];
-  DateTime _calendarMonth = DateTime.now();
+  // マネーカレンダーの表示サイクルを指すアンカー日(この日を含む給料日サイクルを
+  // 表示する)。サイクル送りは給料日を保ったまま暦月を±1する。
+  DateTime _calendarCycleAnchor = DateTime.now();
   DateTime? _calendarSelectedDate;
   Future<AssetWasteTrainingAiReview>? _wasteTrainingAiReviewFuture;
   String? _wasteTrainingAiReviewKey;
@@ -913,6 +922,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   @override
   void initState() {
     super.initState();
+    final debugCalendarNow = widget.debugCalendarNow;
+    if (debugCalendarNow != null) {
+      _calendarCycleAnchor = debugCalendarNow;
+    }
     final debugAssetData = widget.debugInitialAssetData;
     if (debugAssetData != null) {
       _assetData = <String, Map<String, double>>{
@@ -1491,6 +1504,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         return false;
       }
       return dueDate.year == target.year && dueDate.month == target.month;
+    }).toList();
+  }
+
+  /// [start]〜[endExclusive)(給料日サイクル窓)に請求日が入る固定費。
+  List<Map<String, dynamic>> _subscriptionsForRange(
+    DateTime start,
+    DateTime endExclusive,
+  ) {
+    return _subscriptionsThreeMonths.where((subscription) {
+      final dueDateRaw = subscription['due_date']?.toString();
+      if (dueDateRaw == null || dueDateRaw.isEmpty) {
+        return false;
+      }
+      final dueDate = DateTime.tryParse(dueDateRaw);
+      if (dueDate == null) {
+        return false;
+      }
+      final dueDay = DateTime(dueDate.year, dueDate.month, dueDate.day);
+      return !dueDay.isBefore(start) && dueDay.isBefore(endExclusive);
     }).toList();
   }
 
@@ -11758,8 +11790,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     required double? startingCashBalance,
   }) {
     final newDay = _salaryDay + 1;
-    final shifted = AssetPaymentCalendarService.buildMonth(
-      month: _calendarMonth,
+    final shifted = AssetPaymentCalendarService.buildRange(
+      start: _calendarCycleStart,
+      endExclusive: _calendarCycleEndExclusive,
       flows: _recentFlows,
       subscriptions: subscriptions,
       debts: [
@@ -11777,6 +11810,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             debt,
       ],
       salaryDay: _salaryDay,
+      asOf: _calendarNow,
       startingCashBalance: startingCashBalance,
       expectedInflows: inflows,
     );
@@ -12788,12 +12822,31 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
-  void _shiftCalendarMonth(int delta) {
-    setState(() {
-      _calendarMonth = DateTime(
-        _calendarMonth.year,
-        _calendarMonth.month + delta,
+  /// マネーカレンダーの「今日」。サイクル決定・予定系(返済/固定費/入金予定)の
+  /// 計上起点・本日ハイライトに使う。テストは [AssetManagementPage.debugCalendarNow]
+  /// で固定できる。
+  DateTime get _calendarNow => widget.debugCalendarNow ?? _now;
+
+  /// 表示中サイクルの開始日(= 給料日)。
+  DateTime get _calendarCycleStart =>
+      AssetLiabilityMonthlyStateStore.salaryCycleStart(
+        _calendarCycleAnchor,
+        salaryDay: _salaryDay,
       );
+
+  /// 表示中サイクルの終了(排他 = 次の給料日)。
+  DateTime get _calendarCycleEndExclusive =>
+      AssetLiabilityMonthlyStateStore.salaryCycleEndExclusive(
+        _calendarCycleAnchor,
+        salaryDay: _salaryDay,
+      );
+
+  void _shiftCalendarCycle(int delta) {
+    setState(() {
+      final start = _calendarCycleStart;
+      // start.day = 給料日 (clamp 1-28) なので月加算で日あふれしない。
+      _calendarCycleAnchor =
+          DateTime(start.year, start.month + delta, start.day);
       _calendarSelectedDate = null;
     });
   }
@@ -13249,12 +13302,34 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       }
       startingCashBalance = liquid;
     }
-    final monthInflowEntries = AssetExpectedInflowStore.materializeMonth(
-      oneTime: _expectedInflows,
-      rules: _expectedInflowRules,
-      month: _calendarMonth,
+    final cycleStart = _calendarCycleStart;
+    final cycleEndExclusive = _calendarCycleEndExclusive;
+    final cycleLastDay = DateTime(
+      cycleEndExclusive.year,
+      cycleEndExclusive.month,
+      cycleEndExclusive.day - 1,
     );
-    final monthSubscriptions = _subscriptionsForMonth(_calendarMonth);
+    // サイクルは高々2暦月に跨るので、両月へ展開してから窓内へ絞る。
+    final inflowMonths = <DateTime>[
+      DateTime(cycleStart.year, cycleStart.month),
+      if (cycleLastDay.month != cycleStart.month ||
+          cycleLastDay.year != cycleStart.year)
+        DateTime(cycleLastDay.year, cycleLastDay.month),
+    ];
+    final monthInflowEntries = <AssetExpectedInflow>[
+      for (final month in inflowMonths)
+        ...AssetExpectedInflowStore.materializeMonth(
+          oneTime: _expectedInflows,
+          rules: _expectedInflowRules,
+          month: month,
+        ).where(
+          (inflow) =>
+              !inflow.date.isBefore(cycleStart) &&
+              inflow.date.isBefore(cycleEndExclusive),
+        ),
+    ];
+    final monthSubscriptions =
+        _subscriptionsForRange(cycleStart, cycleEndExclusive);
     final debtInputs = <AssetCalendarDebtInput>[
       for (final row in debtRows)
         AssetCalendarDebtInput(
@@ -13274,19 +13349,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           label: inflow.label,
         ),
     ];
-    final calendar = AssetPaymentCalendarService.buildMonth(
-      month: _calendarMonth,
+    final calendar = AssetPaymentCalendarService.buildRange(
+      start: cycleStart,
+      endExclusive: cycleEndExclusive,
       flows: _recentFlows,
       subscriptions: monthSubscriptions,
       debts: debtInputs,
       salaryDay: _salaryDay,
+      asOf: _calendarNow,
       startingCashBalance: startingCashBalance,
       expectedInflows: inflowInputs,
     );
     final selectedDate = _calendarSelectedDate;
     final selectedDay =
         selectedDate == null ? null : calendar.dayFor(selectedDate);
-    final today = DateTime.now();
+    final today = _calendarNow;
     final shortfallDaySummary = calendar.firstShortfallDate == null
         ? null
         : calendar.dayFor(calendar.firstShortfallDate!);
@@ -13319,13 +13396,16 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final comboSuggestionIds = comboIds.length >= 2 &&
             shiftCandidates.every((entry) => entry.value == '(単独では回避不可)')
         ? AssetPaymentCalendarService.findMinimalShiftSet(
-            month: _calendarMonth,
+            month: cycleStart,
+            rangeStart: cycleStart,
+            rangeEndExclusive: cycleEndExclusive,
             flows: _recentFlows,
             subscriptions: monthSubscriptions,
             debts: debtInputs,
             candidateIds: comboIds,
             shiftToDay: _salaryDay + 1,
             salaryDay: _salaryDay,
+            asOf: _calendarNow,
             startingCashBalance: startingCashBalance,
             expectedInflows: inflowInputs,
           )
@@ -13361,12 +13441,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 ),
                 IconButton(
                   key: const Key('asset_calendar_prev_month'),
-                  tooltip: '前の月',
+                  tooltip: '前のサイクル',
                   icon: const Icon(Icons.chevron_left),
-                  onPressed: () => _shiftCalendarMonth(-1),
+                  onPressed: () => _shiftCalendarCycle(-1),
                 ),
                 Text(
-                  DateFormat('yyyy年M月').format(calendar.month),
+                  '${DateFormat('yyyy/M/d').format(calendar.rangeStart)}'
+                  '〜${DateFormat('M/d').format(cycleLastDay)}',
                   style: const TextStyle(
                     fontWeight: FontWeight.w700,
                     height: 1.4,
@@ -13374,15 +13455,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 ),
                 IconButton(
                   key: const Key('asset_calendar_next_month'),
-                  tooltip: '次の月',
+                  tooltip: '次のサイクル',
                   icon: const Icon(Icons.chevron_right),
-                  onPressed: () => _shiftCalendarMonth(1),
+                  onPressed: () => _shiftCalendarCycle(1),
                 ),
               ],
             ),
             const SizedBox(height: 4),
             Text(
-              '日ごとの支出と、返済日・固定費・給料日のイベントをまとめて見渡せます。',
+              '給料日サイクル(給料日〜翌給料日前日)で、日ごとの支出と返済日・固定費・給料日のイベントをまとめて見渡せます。',
               style: TextStyle(
                 fontSize: 11,
                 color: Theme.of(context).colorScheme.onSurface,
@@ -13448,7 +13529,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      '現金・預金 ${_formatYen(startingCashBalance ?? 0)} と登録済み入金予定を起点に、返済予定と固定費を差し引いた見込みです。未登録の入金は含まれません。',
+                      '現金・預金 ${_formatYen(startingCashBalance ?? 0)} と登録済み入金予定を起点に、今日以降の返済予定と固定費を差し引いた見込みです。未登録の入金は含まれません。',
                       style: TextStyle(
                         fontSize: 11,
                         color: Theme.of(context).colorScheme.onSurface,
@@ -13457,7 +13538,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     ),
                     const SizedBox(height: 6),
                     Text(
-                      '回避ライン: ショート日までに ${_formatYen(calendar.shortfallRecoveryAmount)} の入金、または月内支払の同額圧縮で黒字化します。',
+                      '回避ライン: ショート日までに ${_formatYen(calendar.shortfallRecoveryAmount)} の入金、またはサイクル内支払の同額圧縮で黒字化します。',
                       style: const TextStyle(
                         fontSize: 11,
                         fontWeight: FontWeight.w800,
@@ -13477,7 +13558,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      '返済日の変更は「負債マスタ」の支払日設定から。給料日(25日)以降へ動かすとショートを避けやすくなります。',
+                      '返済日の変更は「負債マスタ」の支払日設定から。給料日($_salaryDay日)以降へ動かすと次サイクル(給料日後)の支払いになり、ショートを避けやすくなります。',
                       style: TextStyle(
                         fontSize: 10,
                         color: Theme.of(context).colorScheme.onSurfaceVariant,
@@ -13737,7 +13818,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         child: Column(
           children: [
             Text(
-              '${day.date.day}',
+              // サイクルは月を跨ぐので、月替わりの初日は M/d で区切りを示す。
+              day.date.day == 1
+                  ? DateFormat('M/d').format(day.date)
+                  : '${day.date.day}',
               style: TextStyle(
                 fontSize: 11,
                 fontWeight: isToday ? FontWeight.w800 : FontWeight.w600,

--- a/lib/services/asset_payment_calendar_service.dart
+++ b/lib/services/asset_payment_calendar_service.dart
@@ -101,10 +101,12 @@ class AssetCalendarDaySummary {
   bool get hasAnyEvent => events.isNotEmpty;
 }
 
-/// 月単位のカレンダー。weeks は日曜始まり・null は空セル。
+/// 表示期間(暦月 or 給料日サイクル)のカレンダー。weeks は日曜始まり・null は空セル。
 class AssetPaymentCalendarMonth {
   const AssetPaymentCalendarMonth({
     required this.month,
+    required this.rangeStart,
+    required this.rangeEndExclusive,
     required this.days,
     required this.weeks,
     this.scheduledDebtPaymentTotal = 0,
@@ -114,13 +116,20 @@ class AssetPaymentCalendarMonth {
   });
 
   final DateTime month;
+
+  /// 表示期間の開始日(暦月なら1日 / 給料日サイクルなら給料日)。
+  final DateTime rangeStart;
+
+  /// 表示期間の終了(排他)。
+  final DateTime rangeEndExclusive;
+
   final List<AssetCalendarDaySummary> days;
   final List<List<AssetCalendarDaySummary?>> weeks;
 
-  /// 月内の返済予定額合計(金額が分かるもののみ)。
+  /// 期間内の返済予定額合計(金額が分かるもののみ)。
   final double scheduledDebtPaymentTotal;
 
-  /// 月内の固定費(サブスク)請求額合計。
+  /// 期間内の固定費(サブスク)請求額合計。
   final double subscriptionTotal;
 
   /// 見込み残高が最初にマイナスへ落ちる日。資金リスクの早期警告。
@@ -177,40 +186,112 @@ class AssetPaymentCalendarService {
     List<AssetCalendarInflowInput> expectedInflows =
         const <AssetCalendarInflowInput>[],
   }) {
-    final normalizedMonth = DateTime(month.year, month.month);
-    final lastDay = DateTime(month.year, month.month + 1, 0).day;
-    final expenseByDay = <int, double>{};
-    final incomeByDay = <int, double>{};
-    final outflowByDay = <int, double>{};
-    final inflowByDay = <int, double>{};
-    final eventsByDay = <int, List<AssetCalendarEvent>>{};
+    return buildRange(
+      start: DateTime(month.year, month.month),
+      endExclusive: DateTime(month.year, month.month + 1),
+      flows: flows,
+      subscriptions: subscriptions,
+      debts: debts,
+      salaryDay: salaryDay,
+      startingCashBalance: startingCashBalance,
+      expectedInflows: expectedInflows,
+    );
+  }
+
+  /// [start]〜[endExclusive)(給料日サイクル等の複数暦月に跨りうる窓)の
+  /// カレンダーを組み立てる。支払日・給料日(日指定)は窓内に落ちる暦月へ解決する。
+  ///
+  /// [asOf] を渡すと予定系(返済・固定費・入金予定)は `asOf` 以降の日付のみ
+  /// 予定として計上する(過去分は現在残高に織り込み済みとみなし、実績は
+  /// フロー記録が担う)。null なら窓内全日を予定として扱う(暦月互換)。
+  static AssetPaymentCalendarMonth buildRange({
+    required DateTime start,
+    required DateTime endExclusive,
+    required List<Map<String, dynamic>> flows,
+    required List<Map<String, dynamic>> subscriptions,
+    required List<AssetCalendarDebtInput> debts,
+    int? salaryDay,
+    DateTime? asOf,
+    double? startingCashBalance,
+    List<AssetCalendarInflowInput> expectedInflows =
+        const <AssetCalendarInflowInput>[],
+  }) {
+    final rangeStart = DateTime(start.year, start.month, start.day);
+    final rangeEnd = DateTime(
+      endExclusive.year,
+      endExclusive.month,
+      endExclusive.day,
+    );
+    // 予定系イベントを計上する下限(この日を含む)。
+    final scheduleStart = asOf == null
+        ? rangeStart
+        : _laterDate(rangeStart, DateTime(asOf.year, asOf.month, asOf.day));
+    final expenseByDate = <int, double>{};
+    final incomeByDate = <int, double>{};
+    final outflowByDate = <int, double>{};
+    final inflowByDate = <int, double>{};
+    final eventsByDate = <int, List<AssetCalendarEvent>>{};
     var scheduledDebtPaymentTotal = 0.0;
     var subscriptionTotal = 0.0;
 
-    void addEvent(int day, AssetCalendarEvent event) {
-      eventsByDay.putIfAbsent(day, () => <AssetCalendarEvent>[]).add(event);
+    bool inRange(DateTime date) =>
+        !date.isBefore(rangeStart) && date.isBefore(rangeEnd);
+
+    bool inSchedule(DateTime date) =>
+        !date.isBefore(scheduleStart) && date.isBefore(rangeEnd);
+
+    void addEvent(DateTime date, AssetCalendarEvent event) {
+      eventsByDate
+          .putIfAbsent(_dateKey(date), () => <AssetCalendarEvent>[])
+          .add(event);
+    }
+
+    // 窓に重なる暦月ごとに「毎月N日」を実日付へ解決する(月末クランプ)。
+    // 窓は高々2暦月に跨るが、任意長でも正しく動く。
+    final overlappingMonths = <DateTime>[];
+    if (rangeStart.isBefore(rangeEnd)) {
+      final lastMonth = DateTime(rangeEnd.year, rangeEnd.month, rangeEnd.day)
+          .subtract(const Duration(days: 1));
+      var cursor = DateTime(rangeStart.year, rangeStart.month);
+      final endMonth = DateTime(lastMonth.year, lastMonth.month);
+      while (!cursor.isAfter(endMonth)) {
+        overlappingMonths.add(cursor);
+        cursor = DateTime(cursor.year, cursor.month + 1);
+      }
     }
 
     if (salaryDay != null && salaryDay > 0) {
-      addEvent(
-        clampDayToMonth(salaryDay, normalizedMonth),
-        const AssetCalendarEvent(
-          kind: AssetCalendarEventKind.salary,
-          label: '給料日',
-        ),
-      );
+      for (final month in overlappingMonths) {
+        final date = DateTime(
+          month.year,
+          month.month,
+          clampDayToMonth(salaryDay, month),
+        );
+        if (inRange(date)) {
+          addEvent(
+            date,
+            const AssetCalendarEvent(
+              kind: AssetCalendarEventKind.salary,
+              label: '給料日',
+            ),
+          );
+        }
+      }
     }
 
     for (final inflow in expectedInflows) {
-      if (inflow.date.year != normalizedMonth.year ||
-          inflow.date.month != normalizedMonth.month ||
-          inflow.amount <= 0) {
+      final date = DateTime(
+        inflow.date.year,
+        inflow.date.month,
+        inflow.date.day,
+      );
+      if (!inSchedule(date) || inflow.amount <= 0) {
         continue;
       }
-      inflowByDay[inflow.date.day] =
-          (inflowByDay[inflow.date.day] ?? 0) + inflow.amount;
+      inflowByDate[_dateKey(date)] =
+          (inflowByDate[_dateKey(date)] ?? 0) + inflow.amount;
       addEvent(
-        inflow.date.day,
+        date,
         AssetCalendarEvent(
           kind: AssetCalendarEventKind.expectedInflow,
           label: inflow.label,
@@ -227,42 +308,55 @@ class AssetPaymentCalendarService {
       if (row.balance >= -_epsilon || !row.isDirectCashflowTarget) {
         continue;
       }
-      final clampedDay = clampDayToMonth(paymentDay, normalizedMonth);
-      final amount = row.scheduledPaymentAmount > _epsilon
-          ? row.scheduledPaymentAmount
-          : null;
-      if (amount != null) {
-        scheduledDebtPaymentTotal += amount;
-        outflowByDay[clampedDay] = (outflowByDay[clampedDay] ?? 0) + amount;
+      for (final month in overlappingMonths) {
+        final date = DateTime(
+          month.year,
+          month.month,
+          clampDayToMonth(paymentDay, month),
+        );
+        if (!inSchedule(date)) {
+          continue;
+        }
+        final amount = row.scheduledPaymentAmount > _epsilon
+            ? row.scheduledPaymentAmount
+            : null;
+        if (amount != null) {
+          scheduledDebtPaymentTotal += amount;
+          outflowByDate[_dateKey(date)] =
+              (outflowByDate[_dateKey(date)] ?? 0) + amount;
+        }
+        addEvent(
+          date,
+          AssetCalendarEvent(
+            kind: AssetCalendarEventKind.debtPayment,
+            label: '${row.name} 返済',
+            amount: amount,
+            sourceId: row.id.isEmpty ? null : row.id,
+          ),
+        );
       }
-      addEvent(
-        clampedDay,
-        AssetCalendarEvent(
-          kind: AssetCalendarEventKind.debtPayment,
-          label: '${row.name} 返済',
-          amount: amount,
-          sourceId: row.id.isEmpty ? null : row.id,
-        ),
-      );
     }
 
     for (final subscription in subscriptions) {
       final dueDate = DateTime.tryParse(
         subscription['due_date']?.toString() ?? '',
       )?.toLocal();
-      if (dueDate == null ||
-          dueDate.year != normalizedMonth.year ||
-          dueDate.month != normalizedMonth.month) {
+      if (dueDate == null) {
+        continue;
+      }
+      final date = DateTime(dueDate.year, dueDate.month, dueDate.day);
+      if (!inSchedule(date)) {
         continue;
       }
       final name = subscription['service_name']?.toString().trim() ?? '';
       final price = (subscription['price'] as num?)?.toDouble();
       if (price != null && price > 0) {
         subscriptionTotal += price;
-        outflowByDay[dueDate.day] = (outflowByDay[dueDate.day] ?? 0) + price;
+        outflowByDate[_dateKey(date)] =
+            (outflowByDate[_dateKey(date)] ?? 0) + price;
       }
       addEvent(
-        dueDate.day,
+        date,
         AssetCalendarEvent(
           kind: AssetCalendarEventKind.subscription,
           label: name.isEmpty ? '固定費' : name,
@@ -275,19 +369,21 @@ class AssetPaymentCalendarService {
       final occurredAt = DateTime.tryParse(
         flow['occurred_at']?.toString() ?? '',
       )?.toLocal();
-      if (occurredAt == null ||
-          occurredAt.year != normalizedMonth.year ||
-          occurredAt.month != normalizedMonth.month) {
+      if (occurredAt == null) {
+        continue;
+      }
+      final date = DateTime(occurredAt.year, occurredAt.month, occurredAt.day);
+      if (!inRange(date)) {
         continue;
       }
       final amount = (flow['amount'] as num?)?.toDouble() ?? 0;
       final actionType = flow['action_type']?.toString() ?? '';
       final description = flow['description']?.toString().trim() ?? '';
-      final day = occurredAt.day;
       if (expenseActionTypes.contains(actionType)) {
-        expenseByDay[day] = (expenseByDay[day] ?? 0) + amount.abs();
+        expenseByDate[_dateKey(date)] =
+            (expenseByDate[_dateKey(date)] ?? 0) + amount.abs();
         addEvent(
-          day,
+          date,
           AssetCalendarEvent(
             kind: AssetCalendarEventKind.expense,
             label: description.isEmpty ? '支出' : description,
@@ -295,9 +391,10 @@ class AssetPaymentCalendarService {
           ),
         );
       } else if (incomeActionTypes.contains(actionType)) {
-        incomeByDay[day] = (incomeByDay[day] ?? 0) + amount.abs();
+        incomeByDate[_dateKey(date)] =
+            (incomeByDate[_dateKey(date)] ?? 0) + amount.abs();
         addEvent(
-          day,
+          date,
           AssetCalendarEvent(
             kind: AssetCalendarEventKind.income,
             label: description.isEmpty ? '収入' : description,
@@ -311,13 +408,14 @@ class AssetPaymentCalendarService {
     DateTime? firstShortfallDate;
     double? worstProjectedBalance;
     final days = <AssetCalendarDaySummary>[];
-    for (var day = 1; day <= lastDay; day++) {
-      final outflow = outflowByDay[day] ?? 0;
-      final inflow = inflowByDay[day] ?? 0;
+    var date = rangeStart;
+    while (date.isBefore(rangeEnd)) {
+      final key = _dateKey(date);
+      final outflow = outflowByDate[key] ?? 0;
+      final inflow = inflowByDate[key] ?? 0;
       if (runningBalance != null) {
         runningBalance = runningBalance + inflow - outflow;
       }
-      final date = DateTime(normalizedMonth.year, normalizedMonth.month, day);
       if (firstShortfallDate == null &&
           runningBalance != null &&
           runningBalance < 0) {
@@ -331,25 +429,34 @@ class AssetPaymentCalendarService {
       days.add(
         AssetCalendarDaySummary(
           date: date,
-          expenseTotal: expenseByDay[day] ?? 0,
-          incomeTotal: incomeByDay[day] ?? 0,
-          events: _sortEvents(eventsByDay[day] ?? const <AssetCalendarEvent>[]),
+          expenseTotal: expenseByDate[key] ?? 0,
+          incomeTotal: incomeByDate[key] ?? 0,
+          events:
+              _sortEvents(eventsByDate[key] ?? const <AssetCalendarEvent>[]),
           scheduledOutflow: outflow,
           projectedBalance: runningBalance,
         ),
       );
+      date = DateTime(date.year, date.month, date.day + 1);
     }
 
     return AssetPaymentCalendarMonth(
-      month: normalizedMonth,
+      month: DateTime(rangeStart.year, rangeStart.month),
+      rangeStart: rangeStart,
+      rangeEndExclusive: rangeEnd,
       days: days,
-      weeks: _buildWeeks(normalizedMonth, days),
+      weeks: _buildWeeks(rangeStart, days),
       scheduledDebtPaymentTotal: scheduledDebtPaymentTotal,
       subscriptionTotal: subscriptionTotal,
       firstShortfallDate: firstShortfallDate,
       worstProjectedBalance: worstProjectedBalance,
     );
   }
+
+  static int _dateKey(DateTime date) =>
+      date.year * 10000 + date.month * 100 + date.day;
+
+  static DateTime _laterDate(DateTime a, DateTime b) => a.isAfter(b) ? a : b;
 
   /// [candidateIds] のうち、支払日を [shiftToDay] へ移すことでショートが
   /// 解消する最小の部分集合を返す。同サイズ候補が複数ある場合は
@@ -363,13 +470,20 @@ class AssetPaymentCalendarService {
     required List<String> candidateIds,
     required int shiftToDay,
     int? salaryDay,
+    DateTime? rangeStart,
+    DateTime? rangeEndExclusive,
+    DateTime? asOf,
     double? startingCashBalance,
     List<AssetCalendarInflowInput> expectedInflows =
         const <AssetCalendarInflowInput>[],
   }) {
+    final start = rangeStart ?? DateTime(month.year, month.month);
+    final endExclusive =
+        rangeEndExclusive ?? DateTime(month.year, month.month + 1);
     bool clears(List<String> subset) {
-      final shifted = buildMonth(
-        month: month,
+      final shifted = buildRange(
+        start: start,
+        endExclusive: endExclusive,
         flows: flows,
         subscriptions: subscriptions,
         debts: [
@@ -387,6 +501,7 @@ class AssetPaymentCalendarService {
               debt,
         ],
         salaryDay: salaryDay,
+        asOf: asOf,
         startingCashBalance: startingCashBalance,
         expectedInflows: expectedInflows,
       );
@@ -447,12 +562,12 @@ class AssetPaymentCalendarService {
     return sorted;
   }
 
-  /// 日曜始まりの週リストへ整形。月初までの空きと月末以降は null。
+  /// 日曜始まりの週リストへ整形。期間開始日までの空きと終了以降は null。
   static List<List<AssetCalendarDaySummary?>> _buildWeeks(
-    DateTime month,
+    DateTime start,
     List<AssetCalendarDaySummary> days,
   ) {
-    final leadingBlanks = DateTime(month.year, month.month, 1).weekday % 7;
+    final leadingBlanks = start.weekday % 7;
     final cells = <AssetCalendarDaySummary?>[
       for (var i = 0; i < leadingBlanks; i++) null,
       ...days,

--- a/test/services/asset_payment_calendar_service_test.dart
+++ b/test/services/asset_payment_calendar_service_test.dart
@@ -402,4 +402,247 @@ void main() {
       expect(minimal, isNull);
     });
   });
+
+  group('AssetPaymentCalendarService.buildRange (給料日サイクル窓)', () {
+    test('cycle window spans two months and resolves payment days', () {
+      final calendar = AssetPaymentCalendarService.buildRange(
+        start: DateTime(2026, 6, 25),
+        endExclusive: DateTime(2026, 7, 25),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[
+          AssetCalendarDebtInput(
+            id: 'late',
+            name: '給料日直後',
+            balance: -100000,
+            paymentDay: 27,
+            scheduledPaymentAmount: 8000,
+          ),
+          AssetCalendarDebtInput(
+            id: 'early',
+            name: '月前半',
+            balance: -100000,
+            paymentDay: 10,
+            scheduledPaymentAmount: 7000,
+          ),
+        ],
+        salaryDay: 25,
+      );
+
+      expect(calendar.rangeStart, DateTime(2026, 6, 25));
+      expect(calendar.rangeEndExclusive, DateTime(2026, 7, 25));
+      expect(calendar.days.first.date, DateTime(2026, 6, 25));
+      expect(calendar.days.last.date, DateTime(2026, 7, 24));
+      expect(calendar.days, hasLength(30));
+
+      // 支払日は窓内に落ちる暦月へ解決される (27→6/27 / 10→7/10)。
+      expect(calendar.dayFor(DateTime(2026, 6, 27))!.hasDebtPayment, isTrue);
+      expect(calendar.dayFor(DateTime(2026, 7, 10))!.hasDebtPayment, isTrue);
+      expect(calendar.scheduledDebtPaymentTotal, 15000);
+
+      // 給料日マーカーはサイクル開始日のみ (7/25 は窓外)。
+      expect(calendar.dayFor(DateTime(2026, 6, 25))!.hasSalary, isTrue);
+      expect(
+        calendar.days.where((day) => day.hasSalary).toList(),
+        hasLength(1),
+      );
+
+      // 週グリッドは開始日の曜日で先頭を空ける (2026-06-25 は木曜)。
+      expect(calendar.weeks.first[4]!.date, DateTime(2026, 6, 25));
+      for (var i = 0; i < 4; i++) {
+        expect(calendar.weeks.first[i], isNull);
+      }
+    });
+
+    test('asOf excludes already-passed scheduled items from the projection',
+        () {
+      final calendar = AssetPaymentCalendarService.buildRange(
+        start: DateTime(2026, 6, 25),
+        endExclusive: DateTime(2026, 7, 25),
+        asOf: DateTime(2026, 7, 10),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'service_name': '過去の家賃',
+            'price': 65000,
+            'due_date': '2026-06-27T00:00:00',
+          },
+          <String, dynamic>{
+            'service_name': 'サブスク',
+            'price': 980,
+            'due_date': '2026-07-20T00:00:00',
+          },
+        ],
+        debts: const <AssetCalendarDebtInput>[
+          AssetCalendarDebtInput(
+            id: 'past',
+            name: '支払済み側',
+            balance: -100000,
+            paymentDay: 27,
+            scheduledPaymentAmount: 8000,
+          ),
+          AssetCalendarDebtInput(
+            id: 'future',
+            name: 'これから',
+            balance: -100000,
+            paymentDay: 15,
+            scheduledPaymentAmount: 7000,
+          ),
+        ],
+        salaryDay: 25,
+        startingCashBalance: 10000,
+      );
+
+      // 6/27 の返済・家賃は今日(7/10)より前 → 予定に計上しない
+      // (現在残高に織り込み済みとみなす)。
+      expect(calendar.dayFor(DateTime(2026, 6, 27))!.hasDebtPayment, isFalse);
+      expect(calendar.dayFor(DateTime(2026, 6, 27))!.hasSubscription, isFalse);
+      expect(calendar.scheduledDebtPaymentTotal, 7000);
+      expect(calendar.subscriptionTotal, 980);
+
+      // 見込み残高は今日以降の予定だけを差し引く: 7/15 に 10000-7000=3000。
+      expect(
+        calendar.dayFor(DateTime(2026, 7, 15))!.projectedBalance,
+        3000,
+      );
+      expect(calendar.firstShortfallDate, isNull);
+    });
+
+    test('moving a payment to just after payday defers it to the next cycle',
+        () {
+      AssetPaymentCalendarMonth build(int paymentDay) {
+        return AssetPaymentCalendarService.buildRange(
+          start: DateTime(2026, 6, 25),
+          endExclusive: DateTime(2026, 7, 25),
+          asOf: DateTime(2026, 7, 10),
+          flows: const <Map<String, dynamic>>[],
+          subscriptions: const <Map<String, dynamic>>[],
+          debts: <AssetCalendarDebtInput>[
+            AssetCalendarDebtInput(
+              id: 'mobit',
+              name: 'モビット',
+              balance: -300000,
+              paymentDay: paymentDay,
+              scheduledPaymentAmount: 15000,
+            ),
+          ],
+          salaryDay: 25,
+          startingCashBalance: 10000,
+        );
+      }
+
+      // 15日のままだと 7/15 にショート。
+      expect(build(15).firstShortfallDate, DateTime(2026, 7, 15));
+
+      // 26日へ移すと次回は 7/26 = 窓外(次サイクル=給料日後)→ 当サイクルの
+      // 支払が消えショートも消える(「26日へ移動」提案の根拠)。
+      final shifted = build(26);
+      expect(shifted.firstShortfallDate, isNull);
+      expect(shifted.scheduledDebtPaymentTotal, 0);
+    });
+
+    test('February cycle clamps day-30 payments into the short month', () {
+      final calendar = AssetPaymentCalendarService.buildRange(
+        start: DateTime(2026, 2, 25),
+        endExclusive: DateTime(2026, 3, 25),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[
+          AssetCalendarDebtInput(
+            id: 'd30',
+            name: '30日払い',
+            balance: -100000,
+            paymentDay: 30,
+            scheduledPaymentAmount: 5000,
+          ),
+        ],
+        salaryDay: 25,
+      );
+
+      // 2月は28日まで → 2/28 へ丸め、3/30 は窓外なので1回だけ。
+      expect(calendar.dayFor(DateTime(2026, 2, 28))!.hasDebtPayment, isTrue);
+      expect(
+        calendar.days.where((day) => day.hasDebtPayment).toList(),
+        hasLength(1),
+      );
+      expect(calendar.scheduledDebtPaymentTotal, 5000);
+    });
+
+    test('flows aggregate across the month boundary within the window', () {
+      final calendar = AssetPaymentCalendarService.buildRange(
+        start: DateTime(2026, 6, 25),
+        endExclusive: DateTime(2026, 7, 25),
+        flows: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'occurred_at': '2026-06-20T03:00:00',
+            'amount': 999,
+            'action_type': 'expense',
+            'description': '窓より前',
+          },
+          <String, dynamic>{
+            'occurred_at': '2026-06-26T03:00:00',
+            'amount': 580,
+            'action_type': 'expense',
+            'description': '前半月',
+          },
+          <String, dynamic>{
+            'occurred_at': '2026-07-10T03:00:00',
+            'amount': 200,
+            'action_type': 'expense',
+            'description': '後半月',
+          },
+          <String, dynamic>{
+            'occurred_at': '2026-07-25T03:00:00',
+            'amount': 999,
+            'action_type': 'expense',
+            'description': '窓より後',
+          },
+        ],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: const <AssetCalendarDebtInput>[],
+      );
+
+      expect(calendar.dayFor(DateTime(2026, 6, 20)), isNull);
+      expect(calendar.dayFor(DateTime(2026, 6, 26))!.expenseTotal, 580);
+      expect(calendar.dayFor(DateTime(2026, 7, 10))!.expenseTotal, 200);
+      expect(calendar.dayFor(DateTime(2026, 7, 25)), isNull);
+    });
+
+    test('findMinimalShiftSet honors the cycle window and asOf', () {
+      const debts = <AssetCalendarDebtInput>[
+        AssetCalendarDebtInput(
+          id: 'a',
+          name: 'A',
+          balance: -100000,
+          paymentDay: 15,
+          scheduledPaymentAmount: 8000,
+        ),
+        AssetCalendarDebtInput(
+          id: 'b',
+          name: 'B',
+          balance: -100000,
+          paymentDay: 18,
+          scheduledPaymentAmount: 7000,
+        ),
+      ];
+
+      final minimal = AssetPaymentCalendarService.findMinimalShiftSet(
+        month: DateTime(2026, 6, 25),
+        rangeStart: DateTime(2026, 6, 25),
+        rangeEndExclusive: DateTime(2026, 7, 25),
+        asOf: DateTime(2026, 7, 10),
+        flows: const <Map<String, dynamic>>[],
+        subscriptions: const <Map<String, dynamic>>[],
+        debts: debts,
+        candidateIds: const <String>['a', 'b'],
+        shiftToDay: 26,
+        salaryDay: 25,
+        startingCashBalance: 10000,
+      );
+
+      // 両方を26日へ移すと次回支払が 7/26(窓外) になりショート解消。
+      expect(minimal, isNotNull);
+      expect(minimal!.toSet(), <String>{'a', 'b'});
+    });
+  });
 }

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -121,18 +121,21 @@ void main() {
       await _unmount(tester);
     });
 
-    testWidgets('calendar month navigation updates the label', (tester) async {
+    testWidgets('calendar cycle navigation updates the range label', (
+      tester,
+    ) async {
       await tester.binding.setSurfaceSize(const Size(1200, 2400));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
-      await _pumpAssetPage(tester);
+      // 「今日」を 2026-07-10 に固定 → 表示サイクルは 6/25〜7/24 (給料日既定25)。
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(debugCalendarNow: DateTime(2026, 7, 10)),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
 
-      final now = DateTime.now();
-      final current = DateFormat('yyyy年M月').format(now);
-      final next = DateFormat(
-        'yyyy年M月',
-      ).format(DateTime(now.year, now.month + 1));
-      expect(find.text(current), findsOneWidget);
+      expect(find.text('2026/6/25〜7/24'), findsOneWidget);
 
       await tester.ensureVisible(
         find.byKey(const Key('asset_calendar_next_month')),
@@ -140,8 +143,8 @@ void main() {
       await tester.tap(find.byKey(const Key('asset_calendar_next_month')));
       await tester.pump(const Duration(milliseconds: 100));
 
-      expect(find.text(next), findsOneWidget);
-      expect(find.text(current), findsNothing);
+      expect(find.text('2026/7/25〜8/24'), findsOneWidget);
+      expect(find.text('2026/6/25〜7/24'), findsNothing);
 
       await _unmount(tester);
     });
@@ -502,13 +505,11 @@ void main() {
     testWidgets('seeded inflows surface as chips and managed rules', (
       tester,
     ) async {
-      final now = DateTime.now();
-      final monthKey = '${now.year}${now.month.toString().padLeft(2, '0')}';
       SharedPreferences.setMockInitialValues(<String, Object>{
         'asset_expected_inflows_v1': jsonEncode(<Map<String, dynamic>>[
           <String, dynamic>{
             'id': 'seeded_one',
-            'date': DateTime(now.year, now.month, 10).toUtc().toIso8601String(),
+            'date': DateTime(2026, 7, 10).toUtc().toIso8601String(),
             'amount': 5000,
             'label': '臨時収入',
           },
@@ -525,7 +526,13 @@ void main() {
       await tester.binding.setSurfaceSize(const Size(1200, 2400));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
-      await _pumpAssetPage(tester);
+      // サイクル窓 6/25〜7/24: 単発 7/10 と毎月25日ルールの 6/25 分が窓内。
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(debugCalendarNow: DateTime(2026, 7, 10)),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
       await tester.pump(const Duration(milliseconds: 200));
 
       await tester.ensureVisible(
@@ -536,7 +543,7 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.byKey(Key('asset_inflow_chip_rule_seeded_rule_$monthKey')),
+        find.byKey(const Key('asset_inflow_chip_rule_seeded_rule_202606')),
         findsOneWidget,
       );
 
@@ -928,18 +935,17 @@ void main() {
     testWidgets('remote inflow tombstone removes the matching local chip', (
       tester,
     ) async {
-      final now = DateTime.now();
       SharedPreferences.setMockInitialValues(<String, Object>{
         'asset_expected_inflows_v1': jsonEncode(<Map<String, dynamic>>[
           <String, dynamic>{
             'id': 'keep_me',
-            'date': DateTime(now.year, now.month, 10).toUtc().toIso8601String(),
+            'date': DateTime(2026, 7, 10).toUtc().toIso8601String(),
             'amount': 5000,
             'label': '残す入金',
           },
           <String, dynamic>{
             'id': 'delete_me',
-            'date': DateTime(now.year, now.month, 12).toUtc().toIso8601String(),
+            'date': DateTime(2026, 7, 12).toUtc().toIso8601String(),
             'amount': 8000,
             'label': '他端末で削除',
           },
@@ -949,10 +955,12 @@ void main() {
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
       // 他端末が delete_me を削除した状態をミラー経由で注入。
+      // サイクル窓 6/25〜7/24 に seed 日付が入るよう「今日」を固定する。
       await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: AssetManagementPage(
-            debugInflowDeletedIdsMirror: <String, dynamic>{
+            debugCalendarNow: DateTime(2026, 7, 10),
+            debugInflowDeletedIdsMirror: const <String, dynamic>{
               'ids': <String>['delete_me'],
             },
           ),
@@ -1007,6 +1015,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: AssetManagementPage(
+            debugCalendarNow: DateTime(2026, 7, 10),
             debugInitialAssetData: <String, Map<String, double>>{
               dateKey: const <String, double>{
                 '財布(現金)': 10000,
@@ -1018,7 +1027,8 @@ void main() {
       );
       await tester.pump(const Duration(milliseconds: 200));
 
-      // モビット既定支払日15日の予定額が現金1万を超え、ショート警告が出る。
+      // サイクル窓 6/25〜7/24 / 今日=7/10: モビット既定支払日15日(7/15)の
+      // 予定額が現金1万を超え、ショート警告が出る。
       await tester.ensureVisible(
         find.byKey(const Key('asset_calendar_add_inflow_button')),
       );
@@ -1071,6 +1081,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: AssetManagementPage(
+            debugCalendarNow: DateTime(2026, 7, 10),
             debugInitialAssetData: <String, Map<String, double>>{
               dateKey: const <String, double>{
                 '財布(現金)': 10000,
@@ -1082,7 +1093,7 @@ void main() {
       );
       await tester.pump(const Duration(milliseconds: 200));
 
-      // 14日の繰り返し入金が15日のモビット返済を覆い、警告は出ない。
+      // 14日(7/14)の繰り返し入金が15日(7/15)のモビット返済を覆い、警告は出ない。
       expect(
         find.byKey(const Key('asset_calendar_add_inflow_button')),
         findsNothing,
@@ -1113,6 +1124,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: AssetManagementPage(
+            debugCalendarNow: DateTime(2026, 7, 10),
             debugInitialAssetData: <String, Map<String, double>>{
               dateKey: const <String, double>{
                 '財布(現金)': 10000,
@@ -1124,12 +1136,13 @@ void main() {
       );
       await tester.pump(const Duration(milliseconds: 200));
 
-      // 入金が返済日(15日)より後ろなので警告は残る。
+      // 入金(7/20)が返済日(7/15)より後ろなので警告は残る。
       await tester.ensureVisible(
         find.byKey(const Key('asset_calendar_add_inflow_button')),
       );
       expect(find.textContaining('回避ライン'), findsOneWidget);
-      // ただし26日へ移せば20日の入金で賄えるため、事前判定が「回避できます」。
+      // ただし26日へ移せば次回支払は 7/26 = 次サイクル(給料日後)扱いになり、
+      // 当サイクルの支払が消えるため事前判定が「回避できます」。
       expect(find.textContaining('を26日へ(回避できます)'), findsOneWidget);
 
       await _unmount(tester);


### PR DESCRIPTION
## 概要

給料日サイクル統一(Phase1 #3500 / Phase2 #3504 / Phase3 #3514)で意図的に暦月のまま残されていた**マネーカレンダー(支払カレンダーグリッド)を給料日サイクル窓 `[給料日, 翌給料日)` へ移行**します。part306〜309 の持ち越し候補。

## 変更内容

### service (`lib/services/asset_payment_calendar_service.dart`)
- `buildRange(start, endExclusive, asOf, ...)` 新設: 複数暦月に跨る窓でカレンダーを構築。「毎月N日」の返済日・給料日は窓内に落ちる暦月へ解決(月末クランプ / 2月30日→2/28 等)。
- `buildMonth` は `buildRange` への委譲となり既存挙動は完全互換(既存ユニットテスト無変更で green)。
- **`asOf`(今日)以降の予定だけ**を見込み残高・予定合計に計上。過去分は現在残高に織り込み済みとみなし、従来の「過去支払の二重控除」を解消。実績(フロー記録)は窓内全表示。
- 「26日(給料日翌日)へ移動」提案は、次回支払が窓外=**次サイクル送り**になるため回避判定が正しく機能(テストで実証)。
- `findMinimalShiftSet` に窓/asOf パラメータ追加。

### page (`lib/pages/asset_management_page.dart`)
- サイクルアンカー + サイクル送りナビ(◀▶)+ 期間ラベル `yyyy/M/d〜M/d`。
- 月替わり初日セルは `M/d` 表示で区切りを明示。
- 固定費・入金予定(単発/毎月ルール)をサイクル窓で抽出。
- 給料日ハードコード「(25日)」を設定値 `_salaryDay` へ。
- テスト専用 `debugCalendarNow` を追加し「今日」を固定可能に(実行日非依存のテストを実現)。

## テスト

- `test/services/asset_payment_calendar_service_test.dart`: buildRange 6ケース追加(跨月解決 / asOf 予定絞り込み / 次サイクル送り回避 / 2月クランプ / 窓内フロー集計 / findMinimalShiftSet 窓対応)。既存 13 ケースは無変更で green。
- `test/widgets/asset_management_page_smoke_test.dart`: カレンダー依存 5 テストを `debugCalendarNow` 固定時計化(従来は実行日により flaky になり得た)。
- ローカル検証: `dart format --set-exit-if-changed` exit 0 / `dart analyze` No issues / `flutter test`(service + smoke)**70 tests all passed**。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 既存ルート内のカレンダーカード表示変更のみ。widget smoke test + service unit test で 3 ケース以上を検証済み(新規画面/ルートなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
