### PR TITLE
fix(x-share): ワンボタン投稿で動画完成を待ってから投稿(静止画になる問題を解消) (#3751)

### DIFF
--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -363,7 +363,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
       if (_videoUrl == null) {
         setState(() {
           _generatingVideo = true;
-          _statusMessage = 'AIが音声と動画を生成しています…（30〜60秒かかります）';
+          _statusMessage = 'AIが音声と動画を生成しています…（Hedraは数分かかる場合があります）';
         });
         var video = await _service.generateVideo(
           context: widget.page,
@@ -373,10 +373,18 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
         var generationId = video.url == null
             ? _extractString(video.raw, 'hedraGenerationId')
             : null;
-        var polls = 0;
-        while (video.url == null && generationId != null && polls < 12) {
-          await Future<void>.delayed(const Duration(seconds: 8));
+        // Hedra は非同期で、長めのナレーションだと数分かかる。静止画で投稿されないよう、
+        // 動画URLが返るまで最大約5分ポーリングして完成を待つ。
+        const maxPolls = 30;
+        for (var polls = 0;
+            video.url == null && generationId != null && polls < maxPolls;
+            polls += 1) {
+          await Future<void>.delayed(const Duration(seconds: 10));
           if (_disposed || !mounted) return;
+          final elapsed = (polls + 1) * 10;
+          setState(() {
+            _statusMessage = '音声と動画を生成しています…（約$elapsed秒経過 / 最大5分）';
+          });
           video = await _service.generateVideo(
             context: widget.page,
             draft: draft,
@@ -386,19 +394,19 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           generationId = video.url == null
               ? (_extractString(video.raw, 'hedraGenerationId') ?? generationId)
               : null;
-          polls += 1;
         }
         if (_disposed || !mounted) return;
         _videoUrl = video.url;
         setState(() => _generatingVideo = false);
         if (_videoUrl == null) {
           final reason =
-              _extractString(video.raw, 'videoReason') ?? '完了しませんでした';
+              _extractString(video.raw, 'videoReason') ?? '時間内に完了しませんでした';
           setState(() => _statusMessage = '動画は生成できませんでした（$reason）。画像付きで投稿します。');
         }
       }
       // 3. X 投稿(URLはリプライへ、スレッド返信も投稿)
-      setState(() => _statusMessage = 'Xに投稿しています…');
+      final postedMedia = _videoUrl != null ? '動画' : '画像';
+      setState(() => _statusMessage = 'Xに投稿しています…（$postedMedia付き）');
       final result = await _service.postToX(
         context: widget.page,
         text: _textController.text,
@@ -409,7 +417,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
       if (_disposed || !mounted) return;
       setState(() {
         _statusMessage = result.posted
-            ? '${result.account ?? '@kanta13jp1'} に投稿しました 🎉'
+            ? '${result.account ?? '@kanta13jp1'} に$postedMedia付きで投稿しました 🎉'
             : '投稿できませんでした。X API secret設定を確認してください';
       });
     } catch (error) {


### PR DESCRIPTION
## 背景（実機）
ワンボタン「AI生成して投稿」で投稿すると、pipelineの ElevenLabs/Hedra が `waiting`(動画未完成)のまま**静止画で投稿**されていた。

## 真因（10仮説で特定）
Hedra動画生成は非同期で、長めのナレーションだと**数分**かかる。 のポーリング予算が **12×8秒=96秒**と短く、動画完成前にタイムアウト→`_videoUrl`=null→`_imageUrl`(静止画)で投稿していた。さらに「画像付きで投稿」メッセージが投稿成功メッセージで上書きされ、ユーザーに静止画投稿が伝わっていなかった。

## 変更（`universal_ai_share_shell.dart` のみ）
- 動画ポーリング予算を **96秒 → 最大5分(30×10秒)** に拡大。動画URLが返るまで待ってから投稿
- 進捗を **「約N秒経過 / 最大5分」** と逐次表示
- 投稿メッセージに **「動画付き / 画像付き」** を明示（何が投稿されたか分かる）
- 5分でも完成しない場合のみ videoReason を出して画像付き投稿へフォールバック

## 検証
- `dart analyze`: No issues / `flutter test`(service): 28 passed
- widget単独の制御フロー変更（待機時間+表示）でロジック不変

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter integration_test/ flow or Playwright test/e2e/ route.
- E2E-Exception: 動画生成〜投稿はHedra/ElevenLabs/X APIの実クレジット消費+非同期(数分)UIフローで自動E2E不適。ポーリング待機は制御フロー追加のみで、service層の生成/投稿ロジック(単体テスト28件)は不変。実機で動画付き投稿を確認。

Refs #3751 #3663