### PR TITLE
fix(x-share): hard-cap narration on every video path so posts are video, not still image

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -1298,7 +1298,16 @@ ${draft.videoPrompt}
     UniversalXShareDraft draft,
   ) {
     if (_isMyFinanceUxContext(context)) {
-      return _scriptLinesFromText(draft.text);
+      // finance も draft.text(400-900字の長文リード)をそのまま読み上げると
+      // 動画が長くなり静止画フォールバックになる。導入+2行(各60字上限)+締めに短縮。
+      const financeOpening = 'マイファイナンスの動くスマホUXを短くご紹介します。';
+      const financeClosing = '5分だけ触って、役立った点と迷った点を教えてください。';
+      final financeBody = _scriptLinesFromText(draft.text)
+          .take(2)
+          .map((line) => _clipNarrationLine(line, 60));
+      return _capNarration(
+        <String>[financeOpening, ...financeBody, financeClosing],
+      );
     }
     // 動画ナレーションを毎回「劇的に」変える。①導入(型)を draft 由来 seed で日替り
     // ローテ＋当日ニュースの話題を差し込み ②本文は LLM が当日ニュースから作った
@@ -1338,18 +1347,20 @@ ${draft.videoPrompt}
     // かかり、ワンボタン投稿のポーリング(最大5分)内に完成せず静止画で投稿されて
     // しまうため。ポスト本文(text/threadReplies)は長文のまま、読み上げる動画だけ簡潔に。
     if (body.isNotEmpty) {
-      return <String>[
+      // body 各行(threadReplies 由来。1行150-500字になりうる)を60字にクリップし、
+      // 総文字数も _capNarration で 450 字以内に抑えて短尺動画を保証する。
+      return _capNarration(<String>[
         opening,
-        ...body.take(2),
+        ...body.take(2).map((line) => _clipNarrationLine(line, 60)),
         'こうした話題も、AI仕事OSに残しておけば、後で使える判断材料に変わります。',
         closing,
-      ];
+      ]);
     }
-    return <String>[
+    return _capNarration(<String>[
       opening,
       'AI仕事OSは、学習・仕事ログ・資産管理・英語学習・メモをひとつに整理できるツールです。',
       closing,
-    ];
+    ]);
   }
 
   /// draft から動画で強調する「今日の話題」を短く1つ取り出す。
@@ -1393,6 +1404,41 @@ ${draft.videoPrompt}
         .take(5)
         .toList();
     return lines.isEmpty ? const ['ページの改善内容を紹介します。'] : lines;
+  }
+
+  /// 動画ナレーションの読み上げ総文字数を Hedra が 5 分ポーリング内に完成できる
+  /// 範囲へ制限する。実測: 145 字は video_ready まで到達 / 685 字は processing
+  /// 滞留→クライアントが打ち切り静止画。450 字なら余裕を持って窓内に収まる。
+  /// edge 側の `MAX_SPOKEN_CHARS` (viral-video-ad-generator) と同値。
+  static const int _maxNarrationChars = 450;
+
+  /// 1 行を最大 [max] 文字(runes 基準 / 日本語の結合文字割れを避ける)へクリップ。
+  static String _clipNarrationLine(String line, int max) {
+    final runes = line.runes.toList(growable: false);
+    if (runes.length <= max) return line;
+    return '${String.fromCharCodes(runes.take(max))}…';
+  }
+
+  /// ナレーション行群を総 [_maxNarrationChars] 文字以内へ切り詰める。どの分岐
+  /// (finance / 一般 / 空 body フォールバック)も必ずこれを通し、将来の分岐追加でも
+  /// 長尺化=静止画フォールバックが再発しないようにするための最終ガード。
+  static List<String> _capNarration(List<String> lines) {
+    final out = <String>[];
+    var total = 0;
+    for (final line in lines) {
+      if (line.isEmpty) continue;
+      final runes = line.runes.length;
+      if (total + runes > _maxNarrationChars) {
+        final remaining = _maxNarrationChars - total;
+        if (remaining > 8) {
+          out.add(_clipNarrationLine(line, remaining - 1));
+        }
+        break;
+      }
+      out.add(line);
+      total += runes;
+    }
+    return out.isEmpty ? lines.take(1).toList() : out;
   }
 
   static Map<String, dynamic> _asMap(Object? value) {

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -373,9 +373,10 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
         var generationId = video.url == null
             ? _extractString(video.raw, 'hedraGenerationId')
             : null;
-        // Hedra は非同期で、長めのナレーションだと数分かかる。静止画で投稿されないよう、
-        // 動画URLが返るまで最大約5分ポーリングして完成を待つ。
-        const maxPolls = 30;
+        // Hedra は非同期で、ナレーション長に応じて数分かかる。静止画で投稿されないよう、
+        // 動画URLが返るまでポーリングして完成を待つ。台本は短尺(<=450字)に制限済で通常
+        // 数分内に完成するが、Hedra のキュー変動に備え約7分半まで待つ(defense-in-depth)。
+        const maxPolls = 45;
         for (var polls = 0;
             video.url == null && generationId != null && polls < maxPolls;
             polls += 1) {
@@ -383,7 +384,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           if (_disposed || !mounted) return;
           final elapsed = (polls + 1) * 10;
           setState(() {
-            _statusMessage = '音声と動画を生成しています…（約$elapsed秒経過 / 最大5分）';
+            _statusMessage = '音声と動画を生成しています…（約$elapsed秒経過 / 最大約7分半）';
           });
           video = await _service.generateVideo(
             context: widget.page,

--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -41,6 +41,12 @@ const SERVICE_ROLE_KEY = Deno.env.get("SERVICE_ROLE_KEY") ?? "";
 const FAL_KEY = Deno.env.get("FAL_KEY") ?? "";
 const HEDRA_API_KEY = Deno.env.get("HEDRA_API_KEY") ?? "";
 const HEDRA_API_BASE = "https://api.hedra.com/web-app/public";
+// 読み上げ台本(spokenScript)の最大文字数。Hedra の動画生成は台本長に比例して
+// 長くなり、長すぎるとワンボタン投稿のクライアント側ポーリング内に完成せず静止画で
+// 投稿されてしまう。実測: 145 字は video_ready 到達 / 685 字は processing 滞留。
+// 全 TTS 経路(主 ElevenLabs / fallback voice / OpenAI / Hedra native / fallbackText)を
+// この単一上限で統一し、どの経路でも短尺動画を保証する。client 側 _maxNarrationChars と同値。
+const MAX_SPOKEN_CHARS = 450;
 const HEDRA_AVATAR_MODEL_ID = Deno.env.get("HEDRA_AVATAR_MODEL_ID") ??
   "26f0fc66-152b-40ab-abed-76c43df99bc8";
 const HEDRA_VOICE_ID = Deno.env.get("HEDRA_VOICE_ID") ?? "";
@@ -692,9 +698,8 @@ async function createHedraPresenterVideo(params: {
         throw new Error("ELEVENLABS_API_KEY not configured");
       }
       const audio = await createElevenLabsSpeechAsset(params.admin, {
-        // 動画は短尺(~40-60秒)に保つ。長い音声は Hedra 生成が数分以上かかり、
-        // ワンボタン投稿のポーリング内に完成しないため上限を抑える。
-        text: spokenScript.slice(0, 900),
+        // 動画を短尺に保つための上限。全 TTS 経路で MAX_SPOKEN_CHARS に統一。
+        text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
         templateTitle: params.title ?? "share-update",
         lang: params.lang,
         voiceId: resolveElevenLabsVoiceForLabel(params.voice),
@@ -720,7 +725,7 @@ async function createHedraPresenterVideo(params: {
         shouldRetryElevenLabsWithFallbackVoice(error)
       ) {
         const fallbackResult = await tryElevenLabsFallbackVoices(params.admin, {
-          text: spokenScript.slice(0, 1800),
+          text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
           templateTitle: params.title ?? "share-update",
           lang: params.lang,
           configuredVoiceId: ELEVENLABS_AI_SECRETARY_VOICE_ID,
@@ -739,7 +744,7 @@ async function createHedraPresenterVideo(params: {
             storedAudioPath,
             audioProvider,
             imageUrl,
-            fallbackText: spokenScript.slice(0, 1800),
+            fallbackText: spokenScript.slice(0, MAX_SPOKEN_CHARS),
           });
         }
         speechChain.push(`fallback_voices=${fallbackResult.reason}`);
@@ -750,7 +755,7 @@ async function createHedraPresenterVideo(params: {
       if (OPENAI_API_KEY) {
         try {
           const openAiAudio = await createOpenAiSpeechAsset(params.admin, {
-            text: spokenScript.slice(0, 1800),
+            text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
             templateTitle: `${params.title ?? "share-update"}-openai-tts`,
             lang: params.lang,
           });
@@ -766,7 +771,7 @@ async function createHedraPresenterVideo(params: {
             storedAudioPath,
             audioProvider,
             imageUrl,
-            fallbackText: spokenScript.slice(0, 1800),
+            fallbackText: spokenScript.slice(0, MAX_SPOKEN_CHARS),
           });
         } catch (openAiError) {
           speechChain.push(`openai_tts=${providerErrorMessage(openAiError)}`);
@@ -779,7 +784,7 @@ async function createHedraPresenterVideo(params: {
         speechChain.join(" | "),
       );
       audioGeneration = await createHedraTextToSpeechAudioGeneration(params, {
-        text: spokenScript.slice(0, 1800),
+        text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
       });
       audioProvider = params.requiresUploadedAudio
         ? "hedra_tts_after_premium_speech_failure"
@@ -787,7 +792,7 @@ async function createHedraPresenterVideo(params: {
     }
   } else {
     audioGeneration = await createHedraTextToSpeechAudioGeneration(params, {
-      text: spokenScript.slice(0, 1800),
+      text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
     });
   }
 
@@ -798,7 +803,7 @@ async function createHedraPresenterVideo(params: {
       storedAudioPath,
       audioProvider,
       imageUrl,
-      fallbackText: spokenScript.slice(0, 1800),
+      fallbackText: spokenScript.slice(0, MAX_SPOKEN_CHARS),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -753,4 +753,74 @@ void main() {
     );
     expect(sawTonedVoice, isTrue);
   });
+
+  test('video narration is capped to a Hedra-safe length for long news drafts',
+      () async {
+    Map<String, dynamic>? capturedBody;
+    final service = UniversalXShareService(
+      functionInvoker: (functionName, body) async {
+        capturedBody = body;
+        return {'success': true, 'status': 'fallback_text'};
+      },
+    );
+
+    // 1 行が 800 字超になる病的な長文 draft(=実測で processing 滞留→静止画に
+    // なった 685 字を大きく超える)。台本(customScript)が確実に短縮されること。
+    final longLine = 'とても長いニュース解説の一文です。' * 60;
+    final draft = UniversalXShareDraft(
+      text: '$longLine\n$longLine',
+      imagePrompt: 'x',
+      videoPrompt: 'y',
+      hashtags: const ['#AI'],
+      threadReplies: <String>['1. $longLine', '2. $longLine', '3. $longLine'],
+      fallbackUsed: false,
+      source: 'test',
+    );
+
+    await service.generateVideo(
+      context: page,
+      draft: draft,
+      imageUrl: 'https://example.com/secretary.png',
+    );
+
+    final scriptLines = (capturedBody?['customScript'] as List).cast<String>();
+    expect(scriptLines, isNotEmpty);
+    // 総ナレーションは 450 字(+省略記号の余白)以内に収まる。
+    expect(scriptLines.join().runes.length, lessThanOrEqualTo(460));
+  });
+
+  test('finance video narration is capped even with a long AI draft', () async {
+    Map<String, dynamic>? capturedBody;
+    final service = UniversalXShareService(
+      functionInvoker: (functionName, body) async {
+        capturedBody = body;
+        return {'success': true, 'status': 'fallback_text'};
+      },
+    );
+
+    const financePage = UniversalSharePageContext(
+      routePath: '/asset-management',
+      title: '資産管理',
+      url: 'https://my-web-app-b67f4.web.app/asset-management',
+    );
+    final longLine = 'とても長い資産管理の説明文です。' * 60;
+    final draft = UniversalXShareDraft(
+      text: '$longLine\n$longLine\n$longLine',
+      imagePrompt: 'x',
+      videoPrompt: 'y',
+      hashtags: const ['#AI'],
+      fallbackUsed: false,
+      source: 'test',
+    );
+
+    await service.generateVideo(
+      context: financePage,
+      draft: draft,
+      imageUrl: 'https://example.com/secretary.png',
+    );
+
+    final scriptLines = (capturedBody?['customScript'] as List).cast<String>();
+    expect(scriptLines, isNotEmpty);
+    expect(scriptLines.join().runes.length, lessThanOrEqualTo(460));
+  });
 }


### PR DESCRIPTION
## 背景（follow-up of #3802）
#3802 で「ワンボタン投稿が静止画になる」真因（長い動画台本→Hedra生成が5分ポーリング内に未完）を一次修正したが、**敵対的監査（origin/main を4次元×検証）で残存経路が11件confirmed**：一次修正は一般経路の台本短縮と edge の1スライス(→900)だけで、900 は実測失敗値685より高く、他経路は未対処だった。

## 実測の根拠
edge ジョブ履歴で **145字→`video_ready`（完成）/ 685字→`processing`滞留（クライアント打切り→静止画）**。安全閾値は685未満。全経路の読み上げ台本を **450字以内** に統一する。

## 修正（全動画経路で短尺を保証）
1. **client `_videoScriptFor`（P0）**: finance経路 `_scriptLinesFromText(draft.text)`（400-900字を無制限読み上げ）を導入+2行(各60字)+締めに短縮。一般経路も `body.take(2)` が**行数のみ制限で各行の文字数無制限**（threadReply 1行150-500字）だったため各行60字にクリップ。**全 return を共有 `_capNarration`（総450字上限・runes基準）** に通し将来の分岐追加でも回帰しないよう固定。
2. **edge（P0/P1）**: 8つの `spokenScript.slice(0, N)`（主900＋fallback 1800×7：fallback voice / OpenAI / Hedra-native / fallbackText）を **単一定数 `MAX_SPOKEN_CHARS=450`** に統一。どのTTS経路/フォールバックでも短尺を保証。
3. **client poll予算（P2）**: 30×10s=5分 → 45×10s=7.5分（Hedraキュー変動への defense-in-depth。主制御は長さキャップ）。
4. **テスト**: 病的長文draftで customScript が **≤460字** に収まることを一般経路・finance経路の2ケースで検証。

## 検証
`flutter test test/services/universal_x_share_service_test.dart` → **30件全パス**（新規cap 2件含む）。

## スコープ外（follow-up）
`no-async-video-backfill-guarantee`（P1）: クライアント打切り後に動画へ差し替える webhook/backfill は構造変更が大きいため別PR。本PRの長さキャップが主緩和策。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Narration length caps are covered by two new flutter unit tests asserting customScript stays <=460 chars for long drafts; the change spans no new user-facing route so a full integration_test flow is disproportionate.
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Edge change only replaces 8 TTS length-cap literals with a shared MAX_SPOKEN_CHARS constant; no data-model, permission, or network-contract change; verified by flutter test 30 green.
