### PR TITLE
feat(x-share): 自動Xシェア画像に alt text を付与しアクセシビリティ改善

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -280,8 +280,15 @@ class UniversalXShareService {
     List<String> threadReplies = const [],
     bool linkInReply = false,
     bool dryRun = false,
+    String? altText,
   }) async {
     final normalizedMediaUrl = _emptyToNull(mediaUrl);
+    final hasMedia =
+        normalizedMediaUrl != null && _isPublicHttpUrl(normalizedMediaUrl);
+    // アクセシビリティ用 alt text。画像がある時のみ、未指定ならページ題から既定生成。
+    final String? resolvedAltText = hasMedia
+        ? (_emptyToNull(altText) ?? _defaultShareAltText(context))
+        : null;
     final parts = buildManualShareParts(
       context: context,
       text: text,
@@ -295,10 +302,8 @@ class UniversalXShareService {
       'action': 'x.post',
       'text': mainText,
       if (replyTexts.isNotEmpty) 'replyTexts': replyTexts,
-      'mediaUrl':
-          normalizedMediaUrl != null && _isPublicHttpUrl(normalizedMediaUrl)
-              ? normalizedMediaUrl
-              : null,
+      'mediaUrl': hasMedia ? normalizedMediaUrl : null,
+      if (resolvedAltText != null) 'altText': resolvedAltText,
       'dryRun': dryRun,
       'source': 'universal_x_share',
       'route': context.routePath,
@@ -1157,6 +1162,13 @@ ${fallback.text}
   static String _shareTitleFor(UniversalSharePageContext context) {
     if (_isMyFinanceUxContext(context)) return 'My Finance';
     return context.title;
+  }
+
+  /// 共有カード画像の既定 alt text (= ページ題ベース)。
+  /// X の上限は 1000 字だが余裕を持って 900 字で切り詰める。
+  static String _defaultShareAltText(UniversalSharePageContext context) {
+    final base = '${_shareTitleFor(context)}の共有カード画像';
+    return base.length > 900 ? base.substring(0, 900) : base;
   }
 
   static String _videoTemplateFor(UniversalSharePageContext context) {

--- a/supabase/functions/_shared/x-client.ts
+++ b/supabase/functions/_shared/x-client.ts
@@ -179,6 +179,7 @@ export async function uploadMediaFromUrl(
     fileName?: string;
     mediaType?: string;
     mediaCategory?: string;
+    altText?: string;
   } = {},
 ): Promise<UploadedXMedia> {
   assertXConfigured();
@@ -187,6 +188,7 @@ export async function uploadMediaFromUrl(
     fileName: options.fileName || inferFileName(mediaUrl, binary.mediaType),
     mediaType: options.mediaType || binary.mediaType,
     mediaCategory: options.mediaCategory,
+    altText: options.altText,
   });
 }
 
@@ -196,6 +198,7 @@ export async function uploadMediaBytes(
     fileName?: string;
     mediaType?: string;
     mediaCategory?: string;
+    altText?: string;
   } = {},
 ): Promise<UploadedXMedia> {
   assertXConfigured();
@@ -243,6 +246,21 @@ export async function uploadMediaBytes(
     mediaId,
     finalizeResponse,
   );
+
+  // アクセシビリティ用の alt text を付与 (= 到達を僅かに広げ、ペナルティ無し)。
+  // 失敗しても投稿を絶対にブロックしないよう log のみで飲み込む。
+  const altText = asString(options.altText);
+  if (altText !== "") {
+    try {
+      await setMediaAltText(mediaId, altText);
+    } catch (error) {
+      console.error(
+        `[x-client] setMediaAltText failed for media ${mediaId} (non-fatal):`,
+        error,
+      );
+    }
+  }
+
   return {
     mediaId,
     mediaKey: asString(finalizeResponse.media_key) || null,
@@ -250,6 +268,41 @@ export async function uploadMediaBytes(
     sizeBytes: bytes.byteLength,
     processingState,
   };
+}
+
+/**
+ * media/metadata/create の JSON body を組み立てる純粋関数 (= test 可能に分離)。
+ * alt_text.text は X の上限 1000 字で切り詰める。
+ */
+export function buildMediaAltTextBody(
+  mediaId: string,
+  altText: string,
+): { media_id: string; alt_text: { text: string } } {
+  return {
+    media_id: mediaId,
+    alt_text: { text: altText.slice(0, 1000) },
+  };
+}
+
+/**
+ * アップロード済み media に alt text を付与する。
+ * JSON body なので requestParams は空 = postTweet と同じ署名パス。
+ * 呼び出し側 (uploadMediaBytes) が try/catch で飲み込むため、ここでは throw してよい。
+ */
+export async function setMediaAltText(
+  mediaId: string,
+  altText: string,
+): Promise<void> {
+  const url = "https://upload.twitter.com/1.1/media/metadata/create";
+  const oauthHeader = await buildOAuthHeader("POST", url);
+  await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: oauthHeader,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(buildMediaAltTextBody(mediaId, altText)),
+  });
 }
 
 export async function postTweet(input: {

--- a/supabase/functions/_shared/x-client_test.ts
+++ b/supabase/functions/_shared/x-client_test.ts
@@ -2,7 +2,7 @@ import {
   assertEquals,
   assertStringIncludes,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { buildXApiErrorPayload } from "./x-client.ts";
+import { buildMediaAltTextBody, buildXApiErrorPayload } from "./x-client.ts";
 
 Deno.test("buildXApiErrorPayload classifies client-not-enrolled", () => {
   const payload = buildXApiErrorPayload(403, {
@@ -19,4 +19,27 @@ Deno.test("buildXApiErrorPayload classifies client-not-enrolled", () => {
   assertEquals(payload.reason, "client-not-enrolled");
   assertStringIncludes(payload.actionRequired, "attach the App");
   assertStringIncludes(payload.actionRequired, "Read and write permissions");
+});
+
+Deno.test("buildMediaAltTextBody builds media/metadata/create JSON body", () => {
+  const body = buildMediaAltTextBody("1234567890", "自分株式会社の共有カード画像");
+
+  assertEquals(body, {
+    media_id: "1234567890",
+    alt_text: { text: "自分株式会社の共有カード画像" },
+  });
+  // JSON.stringify で送る形も検証 (= media_id / alt_text.text のキー構造)。
+  assertEquals(
+    JSON.stringify(body),
+    '{"media_id":"1234567890","alt_text":{"text":"自分株式会社の共有カード画像"}}',
+  );
+});
+
+Deno.test("buildMediaAltTextBody caps alt_text at 1000 chars", () => {
+  const longText = "あ".repeat(1500);
+  const body = buildMediaAltTextBody("42", longText);
+
+  assertEquals(body.media_id, "42");
+  assertEquals(body.alt_text.text.length, 1000);
+  assertEquals(body.alt_text.text, "あ".repeat(1000));
 });

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -1628,6 +1628,9 @@ serve(async (req: Request) => {
         const mediaUrl = String(body.mediaUrl ?? body.media_url ?? "").trim();
         const mediaType = String(body.mediaType ?? body.media_type ?? "")
           .trim();
+        const mediaAlt = String(
+          body.mediaAlt ?? body.media_alt ?? body.altText ?? "",
+        ).trim();
         const dryRun = body.dryRun === true;
         if (!text) return json({ success: false, error: "text required" }, 400);
         // X Premium(認証済みアカウント)は最大25,000字の長文ポストが可能。280字で弾かない。
@@ -1738,6 +1741,7 @@ serve(async (req: Request) => {
           const uploadedMedia = mediaUrl
             ? await uploadMediaFromUrl(mediaUrl, {
               mediaType: mediaType || undefined,
+              altText: mediaAlt || undefined,
             })
             : null;
           const result = await postTweet({


### PR DESCRIPTION
## 概要

自動 X シェアで投稿する画像に **alt text (代替テキスト)** を付与する。10 仮説インプレッション監査の **H4 (低インパクト・低コスト)** の着地。alt text はアクセシビリティを高め、到達を僅かに広げる一方でペナルティは無い。

**不変条件**: alt text 付与は投稿を**絶対にブロックしない**。`setMediaAltText` は `uploadMediaBytes` 内の `try/catch` で囲み、失敗しても `console.error` するだけで再スローしない。

## 変更点

- **`supabase/functions/_shared/x-client.ts`**
  - `setMediaAltText(mediaId, altText)` を追加。`media/metadata/create` へ JSON body で POST。JSON body なので `requestParams` は空 = `postTweet` と同じ OAuth 署名パス。
  - `buildMediaAltTextBody(mediaId, altText)` を純粋関数として分離 (1000 字上限 / テスト可能)。
  - `uploadMediaFromUrl` / `uploadMediaBytes` に `altText?` オプションを追加。`waitForMediaProcessing` 成功後に `altText` が非空なら付与。
- **`supabase/functions/growth-hub/index.ts`** (`x.post` case)
  - `body.mediaAlt ?? body.media_alt ?? body.altText` を受理し、`uploadMediaFromUrl` に `altText` を渡す。画像は LEAD tweet に付くので単一 `mediaId` に相乗り (返信への配線は不要)。
- **`lib/services/universal_x_share_service.dart`** (`postToX`)
  - `altText?` 引数を追加。画像がある時のみ、未指定ならページ題から既定生成 (`「<title>の共有カード画像」`、900 字切り詰め) して `x.post` payload に載せる。
- **`supabase/functions/_shared/x-client_test.ts`**
  - `buildMediaAltTextBody` の JSON body 構築 (`media_id` / `alt_text.text` キー構造) と 1000 字上限を検証する deno test を追加。

## テスト

```
deno test --allow-all --no-check --config supabase/functions/deno.json \
  supabase/functions/_shared/x-client_test.ts
# ok | 3 passed | 0 failed
```

`deno check` (x-client.ts) OK。growth-hub の既存 `TS2339` (`totalUsersResponse.data.total`) は origin/main から存在する無関係な型エラーで、CI は `--no-check` でテスト実行。Dart は編集行いずれも 80 桁以内 (origin/main と >80 行数不変)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive accessibility-only alt text on X media; upload/post paths unchanged and setMediaAltText is wrapped in try/catch that never throws so it cannot block posting; no auth/RLS/secret changes

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno Edge Function change with unit coverage (deno test x-client_test.ts: buildMediaAltTextBody JSON body + 1000-char cap, 3 passed); alt text is additive metadata on an already-tested media-upload path, no new user-facing E2E flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
