### PR TITLE
feat(x-share): burn on-screen captions into presenter video for muted-autoplay dwell (H3)

### DIFF
--- a/supabase/functions/viral-video-ad-generator/captions.test.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.test.ts
@@ -1,0 +1,221 @@
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildCaptionSrt,
+  buildForceStyle,
+  burnCaptionsViaTranscoder,
+  type BurnCaptionsRequest,
+  DEFAULT_CAPTION_STYLE,
+  DEFAULT_CAPTION_TIMING,
+  extractBurnedVideoUrl,
+  formatSrtTimestamp,
+} from "./captions.ts";
+
+function timestampToMs(stamp: string): number {
+  const [hms, millis] = stamp.split(",");
+  const [h, m, s] = hms.split(":").map(Number);
+  return ((h * 60 + m) * 60 + s) * 1000 + Number(millis);
+}
+
+// SRT を [index, startMs, endMs, text] のブロック配列へパースする最小パーサ。
+function parseSrt(
+  srt: string,
+): Array<{ index: number; start: number; end: number; text: string }> {
+  return srt
+    .split("\n\n")
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0)
+    .map((block) => {
+      const [indexLine, timeLine, ...rest] = block.split("\n");
+      const [start, end] = timeLine.split(" --> ");
+      return {
+        index: Number(indexLine),
+        start: timestampToMs(start),
+        end: timestampToMs(end),
+        text: rest.join("\n"),
+      };
+    });
+}
+
+Deno.test("formatSrtTimestamp formats ms into HH:MM:SS,mmm", () => {
+  assertEquals(formatSrtTimestamp(0), "00:00:00,000");
+  assertEquals(formatSrtTimestamp(1500), "00:00:01,500");
+  assertEquals(formatSrtTimestamp(61_234), "00:01:01,234");
+  assertEquals(formatSrtTimestamp(3_661_007), "01:01:01,007");
+  // 負値は 0 にクランプする。
+  assertEquals(formatSrtTimestamp(-10), "00:00:00,000");
+});
+
+Deno.test("buildCaptionSrt emits one contiguous block per non-empty line", () => {
+  const srt = buildCaptionSrt(
+    "First line here.\nSecond line is a bit longer than first.\n\n  \nThird.",
+    "en",
+  );
+  const blocks = parseSrt(srt);
+  assertEquals(blocks.length, 3);
+  // 連番で、最初は 0 開始、隣接ブロックは端が接する (start_{i+1} == end_i)。
+  assertEquals(blocks.map((b) => b.index), [1, 2, 3]);
+  assertEquals(blocks[0].start, 0);
+  assertEquals(blocks[1].start, blocks[0].end);
+  assertEquals(blocks[2].start, blocks[1].end);
+  for (const block of blocks) {
+    assert(block.end > block.start, "each caption must have positive duration");
+  }
+});
+
+Deno.test("buildCaptionSrt allocates duration proportional to char length", () => {
+  // クランプに掛からない中程度の長さの2行で、長い行がより長い尺になることを確認。
+  const short = "A".repeat(30);
+  const long = "B".repeat(60);
+  const srt = buildCaptionSrt(`${short}\n${long}`, "en", {
+    ...DEFAULT_CAPTION_TIMING,
+    minLineSeconds: 0.1,
+    maxLineSeconds: 100,
+  });
+  const [b0, b1] = parseSrt(srt);
+  const d0 = b0.end - b0.start;
+  const d1 = b1.end - b1.start;
+  // 2倍の文字数はおおよそ2倍の尺 (丸め誤差を許容)。
+  const ratio = d1 / d0;
+  assert(ratio > 1.8 && ratio < 2.2, `expected ~2x, got ${ratio}`);
+});
+
+Deno.test("buildCaptionSrt clamps degenerate short/long lines", () => {
+  const srt = buildCaptionSrt("hi\n" + "x".repeat(5000), "en", {
+    jaCharsPerSecond: 6.5,
+    enCharsPerSecond: 15,
+    minLineSeconds: 1.2,
+    maxLineSeconds: 7,
+  });
+  const [b0, b1] = parseSrt(srt);
+  assertEquals(b0.end - b0.start, 1200); // min floor
+  assertEquals(b1.end - b1.start, 7000); // max ceiling
+});
+
+Deno.test("buildCaptionSrt returns empty string for blank input", () => {
+  assertEquals(buildCaptionSrt("", "ja"), "");
+  assertEquals(buildCaptionSrt("   \n \n\t", "en"), "");
+});
+
+Deno.test("buildCaptionSrt preserves the spoken text verbatim", () => {
+  const line = "AI大学では、最新ニュースとプロンプト活用を学べます。";
+  const srt = buildCaptionSrt(line, "ja");
+  assertStringIncludes(srt, line);
+});
+
+Deno.test("buildForceStyle encodes bottom-center high-contrast stroked style", () => {
+  const style = buildForceStyle(DEFAULT_CAPTION_STYLE);
+  assertStringIncludes(style, "Alignment=2"); // bottom center
+  assertStringIncludes(style, "Outline=3"); // stroke width
+  assertStringIncludes(style, "PrimaryColour=&H00FFFFFF"); // white text
+  assertStringIncludes(style, "OutlineColour=&H00000000"); // black outline
+  assertStringIncludes(style, "Bold=1");
+  assertStringIncludes(style, "FontSize=22");
+});
+
+Deno.test("extractBurnedVideoUrl reads common response shapes", () => {
+  assertEquals(
+    extractBurnedVideoUrl({ url: "https://cdn.example.com/out.mp4" }),
+    "https://cdn.example.com/out.mp4",
+  );
+  assertEquals(
+    extractBurnedVideoUrl({ video_url: "https://x.test/a.mp4" }),
+    "https://x.test/a.mp4",
+  );
+  assertEquals(
+    extractBurnedVideoUrl({ data: { output_url: "https://x.test/b.mp4" } }),
+    "https://x.test/b.mp4",
+  );
+  assertEquals(
+    extractBurnedVideoUrl({ result: { video: { url: "https://x.test/c.mp4" } } }),
+    "https://x.test/c.mp4",
+  );
+});
+
+Deno.test("extractBurnedVideoUrl rejects non-http and missing urls", () => {
+  assertEquals(extractBurnedVideoUrl({ url: "ftp://x.test/a.mp4" }), null);
+  assertEquals(extractBurnedVideoUrl({ url: "not a url" }), null);
+  assertEquals(extractBurnedVideoUrl({ status: "queued" }), null);
+  assertEquals(extractBurnedVideoUrl(null), null);
+  assertEquals(extractBurnedVideoUrl("plain string"), null);
+});
+
+const SAMPLE_REQUEST: BurnCaptionsRequest = {
+  videoUrl: "https://hedra.test/raw.mp4",
+  mp4Url: "https://hedra.test/raw.mp4",
+  srt: "1\n00:00:00,000 --> 00:00:01,200\nhi\n",
+  subtitleFormat: "srt",
+  format: "mp4",
+  resolution: "540p",
+  style: DEFAULT_CAPTION_STYLE,
+  forceStyle: buildForceStyle(DEFAULT_CAPTION_STYLE),
+};
+
+Deno.test("burnCaptionsViaTranscoder returns ok with url on 200", async () => {
+  let seenAuth: string | null = null;
+  const fetchImpl = ((_url: string | URL | Request, init?: RequestInit) => {
+    seenAuth =
+      new Headers(init?.headers).get("authorization");
+    return Promise.resolve(
+      new Response(JSON.stringify({ url: "https://cdn.test/captioned.mp4" }), {
+        status: 200,
+      }),
+    );
+  }) as typeof fetch;
+  const result = await burnCaptionsViaTranscoder({
+    endpoint: "https://transcoder.test/burn",
+    apiKey: "secret-key",
+    timeoutMs: 5000,
+    request: SAMPLE_REQUEST,
+    fetchImpl,
+  });
+  assert(result.ok);
+  if (result.ok) assertEquals(result.url, "https://cdn.test/captioned.mp4");
+  assertEquals(seenAuth, "Bearer secret-key");
+});
+
+Deno.test("burnCaptionsViaTranscoder returns not-ok on HTTP error", async () => {
+  const fetchImpl = (() =>
+    Promise.resolve(
+      new Response("boom", { status: 500 }),
+    )) as typeof fetch;
+  const result = await burnCaptionsViaTranscoder({
+    endpoint: "https://transcoder.test/burn",
+    timeoutMs: 5000,
+    request: SAMPLE_REQUEST,
+    fetchImpl,
+  });
+  assert(!result.ok);
+  if (!result.ok) assertStringIncludes(result.reason, "500");
+});
+
+Deno.test("burnCaptionsViaTranscoder returns not-ok when url missing", async () => {
+  const fetchImpl = (() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ status: "queued" }), { status: 200 }),
+    )) as typeof fetch;
+  const result = await burnCaptionsViaTranscoder({
+    endpoint: "https://transcoder.test/burn",
+    timeoutMs: 5000,
+    request: SAMPLE_REQUEST,
+    fetchImpl,
+  });
+  assert(!result.ok);
+  if (!result.ok) assertStringIncludes(result.reason, "no video url");
+});
+
+Deno.test("burnCaptionsViaTranscoder never throws when fetch rejects", async () => {
+  const fetchImpl = (() =>
+    Promise.reject(new Error("network down"))) as typeof fetch;
+  const result = await burnCaptionsViaTranscoder({
+    endpoint: "https://transcoder.test/burn",
+    timeoutMs: 5000,
+    request: SAMPLE_REQUEST,
+    fetchImpl,
+  });
+  assert(!result.ok);
+  if (!result.ok) assertStringIncludes(result.reason, "network down");
+});

--- a/supabase/functions/viral-video-ad-generator/captions.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.ts
@@ -1,0 +1,273 @@
+// viral-video-ad-generator: on-screen caption burn-in helpers.
+//
+// なぜ必要か (H3 / impression audit):
+//   X の muted-autoplay 視聴者は音声なしで動画を見るため、字幕が無いと内容が
+//   伝わらず即スクロールされる。dwell time はリーチの主要シグナルなので、生成済み
+//   presenter 動画へオンスクリーン字幕を焼き込むと視聴維持が伸びる。
+//
+// 設計:
+//   - 読み上げ台本 (TTS に渡した spokenScript) は既知なので ASR/whisper は使わない。
+//   - 各行に「文字数比 × 言語別の推定発話レート」で尺を割り当てて SRT を生成する
+//     (= 既知の音声長を行ごとに比例配分)。muted 視聴では厳密同期より字幕の存在が重要。
+//   - Deno Edge Function は ffmpeg をプロセス内実行できないため、焼き込みは外部の
+//     ホスト型 ffmpeg トランスコーダ (Cloud Run / fal.ai ffmpeg-api 等) へ委譲する。
+//   - スタイル (下中央・大きめ・高コントラスト・stroke・~540p) は本モジュールで決めて
+//     force_style として送るので、見た目の決定はこの PR に閉じる。
+//
+// 呼び出し側 (index.ts) は VVAG_BURN_CAPTIONS フラグと transcoder URL/KEY が揃った
+// ときだけ本経路を使い、あらゆる失敗で素の mp4 へフォールバックする
+// (= 既存 fallback_text と同じ graceful-degradation で投稿を絶対にブロックしない)。
+
+export type CaptionLang = "ja" | "en";
+
+export interface CaptionTimingConfig {
+  /** 日本語 TTS の推定発話レート (文字/秒)。SRT の行尺推定に使う。 */
+  jaCharsPerSecond: number;
+  /** 英語 TTS の推定発話レート (文字/秒)。 */
+  enCharsPerSecond: number;
+  /** 1 字幕あたりの最短表示秒 (点滅防止のガード)。 */
+  minLineSeconds: number;
+  /** 1 字幕あたりの最長表示秒 (長文が居座り過ぎるのを防ぐガード)。 */
+  maxLineSeconds: number;
+}
+
+export const DEFAULT_CAPTION_TIMING: CaptionTimingConfig = {
+  jaCharsPerSecond: 6.5,
+  enCharsPerSecond: 15,
+  minLineSeconds: 1.2,
+  maxLineSeconds: 7,
+};
+
+/** SRT の `HH:MM:SS,mmm` タイムスタンプへ整形する。 */
+export function formatSrtTimestamp(ms: number): string {
+  const clamped = Math.max(0, Math.round(ms));
+  const totalSeconds = Math.floor(clamped / 1000);
+  const millis = clamped % 1000;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (value: number, width = 2) => String(value).padStart(width, "0");
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)},${pad(millis, 3)}`;
+}
+
+/**
+ * 読み上げ台本から SRT を生成する。行ごとに `文字数 / 発話レート` 秒を割り当てる
+ * (= 推定音声長 `総文字数 / 発話レート` を文字数比で比例配分したのと等価)。
+ * 各行は [minLineSeconds, maxLineSeconds] にクランプして極端な尺を避ける。
+ * 台本が空なら空文字列を返す (呼び出し側は焼き込みをスキップする)。
+ */
+export function buildCaptionSrt(
+  spokenText: string,
+  lang: CaptionLang,
+  timing: CaptionTimingConfig = DEFAULT_CAPTION_TIMING,
+): string {
+  const lines = spokenText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) return "";
+
+  const charsPerSecond = lang === "ja"
+    ? timing.jaCharsPerSecond
+    : timing.enCharsPerSecond;
+  const safeCps = Number.isFinite(charsPerSecond) && charsPerSecond > 0
+    ? charsPerSecond
+    : DEFAULT_CAPTION_TIMING.enCharsPerSecond;
+
+  let cursorMs = 0;
+  const blocks: string[] = [];
+  lines.forEach((line, index) => {
+    const rawSeconds = line.length / safeCps;
+    const durationSeconds = Math.min(
+      timing.maxLineSeconds,
+      Math.max(timing.minLineSeconds, rawSeconds),
+    );
+    const startMs = cursorMs;
+    const endMs = startMs + Math.round(durationSeconds * 1000);
+    cursorMs = endMs;
+    blocks.push(
+      `${index + 1}\n${formatSrtTimestamp(startMs)} --> ${
+        formatSrtTimestamp(endMs)
+      }\n${line}`,
+    );
+  });
+  return blocks.join("\n\n") + "\n";
+}
+
+export interface CaptionStyle {
+  /** CJK グリフを含むフォント名。実際の可用性はトランスコーダ側の fontconfig 次第。 */
+  fontName: string;
+  /** ~540p 想定のフォントサイズ (px)。 */
+  fontSizePx: number;
+  /** 本文色 (ASS の &HAABBGGRR)。既定は白。 */
+  primaryColour: string;
+  /** 縁取り色。既定は黒。 */
+  outlineColour: string;
+  /** 縁取り (stroke) の太さ。 */
+  outline: number;
+  /** 影の太さ。 */
+  shadow: number;
+  /** ASS Alignment。2 = 下中央。 */
+  alignment: number;
+  /** 下端からの余白 (px)。 */
+  marginV: number;
+}
+
+// 下中央・白文字・黒 stroke・影付きの高コントラスト字幕。~540p 短尺向け。
+export const DEFAULT_CAPTION_STYLE: CaptionStyle = {
+  fontName: "Noto Sans CJK JP",
+  fontSizePx: 22,
+  primaryColour: "&H00FFFFFF",
+  outlineColour: "&H00000000",
+  outline: 3,
+  shadow: 1,
+  alignment: 2,
+  marginV: 40,
+};
+
+/**
+ * ffmpeg の `subtitles=...:force_style='<...>'` にそのまま渡せる force_style 文字列。
+ * トランスコーダは style オブジェクトか、この完成済み文字列のどちらでも使える。
+ */
+export function buildForceStyle(style: CaptionStyle): string {
+  return [
+    `FontName=${style.fontName}`,
+    `FontSize=${style.fontSizePx}`,
+    `PrimaryColour=${style.primaryColour}`,
+    `OutlineColour=${style.outlineColour}`,
+    "BorderStyle=1",
+    `Outline=${style.outline}`,
+    `Shadow=${style.shadow}`,
+    "Bold=1",
+    `Alignment=${style.alignment}`,
+    `MarginV=${style.marginV}`,
+  ].join(",");
+}
+
+export interface BurnCaptionsRequest {
+  /** 焼き込み対象の mp4 (Hedra 生成 URL)。 */
+  videoUrl: string;
+  /** 互換用エイリアス (サービスによっては mp4Url を期待する)。 */
+  mp4Url: string;
+  /** SRT 本文。 */
+  srt: string;
+  subtitleFormat: "srt";
+  format: "mp4";
+  resolution: string;
+  style: CaptionStyle;
+  forceStyle: string;
+}
+
+export type BurnResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: string };
+
+/** 焼き込み済み動画 URL を返しうるレスポンス形のいずれからも URL を取り出す。 */
+export function extractBurnedVideoUrl(payload: unknown): string | null {
+  const visit = (value: unknown, depth: number): string | null => {
+    if (depth > 4 || value == null) return null;
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return isHttpUrl(trimmed) ? trimmed : null;
+    }
+    if (typeof value !== "object") return null;
+    const record = value as Record<string, unknown>;
+    const preferredKeys = [
+      "url",
+      "videoUrl",
+      "video_url",
+      "outputUrl",
+      "output_url",
+      "downloadUrl",
+      "download_url",
+      "result",
+      "output",
+      "data",
+      "video",
+    ];
+    for (const key of preferredKeys) {
+      if (key in record) {
+        const found = visit(record[key], depth + 1);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+  return visit(payload, 0);
+}
+
+function isHttpUrl(value: string): boolean {
+  if (!value || value.length > 2083) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * ホスト型 ffmpeg トランスコーダへ {videoUrl, srt, style} を POST し、焼き込み済み
+ * mp4 の URL を得る。HTTP エラー・タイムアウト・URL 欠落は例外にせず
+ * `{ ok: false, reason }` で返し、呼び出し側が素の mp4 へフォールバックできるようにする。
+ * タイムアウトは AbortController で必ず設定する (このEFの既知の fetch-timeout 脆弱性対策)。
+ */
+export async function burnCaptionsViaTranscoder(params: {
+  endpoint: string;
+  apiKey?: string | null;
+  request: BurnCaptionsRequest;
+  timeoutMs: number;
+  fetchImpl?: typeof fetch;
+}): Promise<BurnResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), params.timeoutMs);
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    const apiKey = params.apiKey?.trim();
+    if (apiKey) {
+      // サービスの認証方式に依存しないよう両ヘッダを送る (どちらか一方が一致すれば良い)。
+      headers["Authorization"] = `Bearer ${apiKey}`;
+      headers["x-api-key"] = apiKey;
+    }
+    const doFetch = params.fetchImpl ?? fetch;
+    const response = await doFetch(params.endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(params.request),
+      signal: controller.signal,
+    });
+    const rawText = await response.text();
+    if (!response.ok) {
+      return {
+        ok: false,
+        reason: `transcoder ${response.status}: ${rawText.slice(0, 200)}`,
+      };
+    }
+    let parsed: unknown = {};
+    if (rawText.trim().length > 0) {
+      try {
+        parsed = JSON.parse(rawText) as unknown;
+      } catch {
+        parsed = rawText;
+      }
+    }
+    const url = extractBurnedVideoUrl(parsed);
+    if (!url) {
+      return {
+        ok: false,
+        reason: `transcoder response had no video url: ${rawText.slice(0, 200)}`,
+      };
+    }
+    return { ok: true, url };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const reason = controller.signal.aborted
+      ? `transcoder timed out after ${params.timeoutMs}ms`
+      : message;
+    return { ok: false, reason: reason.slice(0, 300) };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -29,6 +29,15 @@ import {
   resolveElevenLabsVoiceId,
   voiceGenderForLabel,
 } from "./voice_labels.ts";
+import {
+  buildCaptionSrt,
+  buildForceStyle,
+  burnCaptionsViaTranscoder,
+  type CaptionStyle,
+  type CaptionTimingConfig,
+  DEFAULT_CAPTION_STYLE,
+  DEFAULT_CAPTION_TIMING,
+} from "./captions.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -75,6 +84,25 @@ const ELEVENLABS_AI_SECRETARY_VOICE_ID =
 const ELEVENLABS_MALE_VOICE_ID = Deno.env.get("ELEVENLABS_VOICE_MALE_ID") ??
   "onwK4e9ZLuTAKqWW03F9";
 const VIRAL_VIDEO_BUCKET = "viral-ad-videos";
+
+// --- On-screen caption burn-in (H3 / muted-autoplay dwell time) ---------------
+// muted-autoplay の X 視聴者向けに、生成済み presenter 動画へ字幕を焼き込む。
+// Deno EF は ffmpeg を実行できないため外部のホスト型トランスコーダへ委譲する。
+// 全 env が揃わない/どこかで失敗したら必ず素の mp4 へフォールバックし、投稿を
+// 絶対にブロックしない (= 既存 fallback_text と同じ graceful-degradation)。
+// 既定は OFF。Supabase secrets に以下を設定して初めて有効化される:
+//   VVAG_BURN_CAPTIONS=1
+//   VVAG_CAPTION_TRANSCODER_URL=<ffmpeg burn-in service endpoint>
+//   VVAG_CAPTION_TRANSCODER_KEY=<service api key>  (認証不要なサービスなら省略可)
+const VVAG_BURN_CAPTIONS = envFlag(Deno.env.get("VVAG_BURN_CAPTIONS"));
+const VVAG_CAPTION_TRANSCODER_URL =
+  Deno.env.get("VVAG_CAPTION_TRANSCODER_URL") ?? "";
+const VVAG_CAPTION_TRANSCODER_KEY =
+  Deno.env.get("VVAG_CAPTION_TRANSCODER_KEY") ?? "";
+const VVAG_CAPTION_TIMEOUT_MS = positiveNumberEnv(
+  "VVAG_CAPTION_TIMEOUT_MS",
+  45000,
+);
 
 // Flutter が送る voice ラベル(gender: "male_narrator"/"female_narrator" /
 // tone: "energetic_*"/"calm_*")を ElevenLabs の voiceId に解決する。トーン別
@@ -376,6 +404,8 @@ serve(async (req) => {
     let hedraGenerationId: string | null = null;
     let hedraProgress: number | null = null;
     let hedraEtaSec: number | null = null;
+    let captionStatus: string | null = null;
+    let captionReason: string | null = null;
 
     // FAL.ai で画像生成 (キーが設定されている場合)
     if (FAL_KEY && type === "image") {
@@ -449,17 +479,40 @@ serve(async (req) => {
           hedraGenerationId = hedraVideo.id;
           hedraProgress = hedraVideo.progress;
           hedraEtaSec = hedraVideo.etaSec;
-          const videoToStore = firstNonEmptyString(
+          const rawVideoUrl = firstNonEmptyString(
             hedraVideo.videoUrl,
             hedraVideo.downloadUrl,
           );
+          // Hedra 生成 mp4 を Storage へ保存する前に、muted-autoplay 向けの字幕を
+          // 焼き込む。フラグ未設定/失敗時は素の mp4 (rawVideoUrl) をそのまま保存する。
+          let videoToStore = rawVideoUrl;
+          if (rawVideoUrl) {
+            const spokenForCaptions = scriptForSpokenAudio(
+              script,
+              lang,
+              body.title ?? template.name,
+            ).join("\n").slice(0, MAX_SPOKEN_CHARS);
+            const burn = await maybeBurnCaptions({
+              videoUrl: rawVideoUrl,
+              spokenText: spokenForCaptions,
+              lang,
+            });
+            captionStatus = burn.status;
+            captionReason = burn.reason;
+            if (burn.videoUrl) {
+              // 焼き込み成功: Storage コピーが失敗しても字幕版を返せるよう先に反映。
+              videoToStore = burn.videoUrl;
+              generatedVideoUrl = burn.videoUrl;
+            }
+          }
           if (videoToStore) {
+            const captioned = captionStatus === "captions_burned";
             const stored = await persistRemoteMediaToStorage(admin, {
               url: videoToStore,
               prefix: "hedra",
               fileName: `${hedraVideo.id ?? crypto.randomUUID()}-${
                 storageSafeSegment(templateKey)
-              }-${lang}.mp4`,
+              }-${lang}${captioned ? "-captioned" : ""}.mp4`,
               contentType: "video/mp4",
             });
             storedVideoUrl = stored?.url ?? null;
@@ -543,6 +596,8 @@ serve(async (req) => {
       videoProvider,
       videoStatus,
       videoReason,
+      captionStatus,
+      captionReason,
       status: generatedVideoUrl != null || generatedImageUrl != null
         ? "ready_to_post"
         : generationStatus,
@@ -1456,6 +1511,107 @@ async function persistRemoteMediaToStorage(
     console.warn("Remote media storage copy failed", error);
     return null;
   }
+}
+
+// 生成済み Hedra 動画へ字幕を焼き込む。フラグ/transcoder が未設定、SRT が空、
+// あるいは焼き込みが失敗した場合は videoUrl=null を返し、呼び出し側は素の mp4 へ
+// フォールバックする。status/reason は診断用に応答へ載せる (DB スキーマは変更しない)。
+async function maybeBurnCaptions(params: {
+  videoUrl: string;
+  spokenText: string;
+  lang: "ja" | "en";
+}): Promise<{ status: string; reason: string | null; videoUrl: string | null }> {
+  if (!VVAG_BURN_CAPTIONS) {
+    return { status: "captions_disabled", reason: null, videoUrl: null };
+  }
+  if (!VVAG_CAPTION_TRANSCODER_URL) {
+    return {
+      status: "captions_skipped",
+      reason: "VVAG_CAPTION_TRANSCODER_URL not configured",
+      videoUrl: null,
+    };
+  }
+  try {
+    const srt = buildCaptionSrt(
+      params.spokenText,
+      params.lang,
+      captionTimingFromEnv(),
+    );
+    if (!srt.trim()) {
+      return {
+        status: "captions_skipped",
+        reason: "no spoken script lines to caption",
+        videoUrl: null,
+      };
+    }
+    const style = captionStyleFromEnv();
+    const result = await burnCaptionsViaTranscoder({
+      endpoint: VVAG_CAPTION_TRANSCODER_URL,
+      apiKey: VVAG_CAPTION_TRANSCODER_KEY || null,
+      timeoutMs: VVAG_CAPTION_TIMEOUT_MS,
+      request: {
+        videoUrl: params.videoUrl,
+        mp4Url: params.videoUrl,
+        srt,
+        subtitleFormat: "srt",
+        format: "mp4",
+        resolution: "540p",
+        style,
+        forceStyle: buildForceStyle(style),
+      },
+    });
+    if (result.ok) {
+      console.log(
+        `[vvag-caption] burned OK lang=${params.lang} url=${
+          result.url.slice(0, 140)
+        }`,
+      );
+      return { status: "captions_burned", reason: null, videoUrl: result.url };
+    }
+    console.warn(
+      `[vvag-caption] burn failed; using un-captioned mp4: ${result.reason}`,
+    );
+    return { status: "captions_failed", reason: result.reason, videoUrl: null };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[vvag-caption] burn threw; using un-captioned mp4: ${reason}`,
+    );
+    return { status: "captions_failed", reason, videoUrl: null };
+  }
+}
+
+function captionTimingFromEnv(): CaptionTimingConfig {
+  return {
+    ...DEFAULT_CAPTION_TIMING,
+    jaCharsPerSecond: positiveNumberEnv(
+      "VVAG_CAPTION_JA_CPS",
+      DEFAULT_CAPTION_TIMING.jaCharsPerSecond,
+    ),
+    enCharsPerSecond: positiveNumberEnv(
+      "VVAG_CAPTION_EN_CPS",
+      DEFAULT_CAPTION_TIMING.enCharsPerSecond,
+    ),
+  };
+}
+
+function captionStyleFromEnv(): CaptionStyle {
+  return {
+    ...DEFAULT_CAPTION_STYLE,
+    fontName: Deno.env.get("VVAG_CAPTION_FONT_NAME")?.trim() ||
+      DEFAULT_CAPTION_STYLE.fontName,
+    fontSizePx: positiveNumberEnv(
+      "VVAG_CAPTION_FONT_SIZE",
+      DEFAULT_CAPTION_STYLE.fontSizePx,
+    ),
+  };
+}
+
+function positiveNumberEnv(name: string, fallback: number): number {
+  const raw = Deno.env.get(name);
+  if (raw == null || raw.trim().length === 0) return fallback;
+  const parsed = Number(raw.trim());
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function mediaStoragePath(


### PR DESCRIPTION
## What

Burn on-screen captions into the auto-generated **presenter video** so muted-autoplay X viewers keep watching. Dwell time is the dominant reach signal, and a caption-less talking-head is silent-scrolled. From the 10-hypothesis impression audit (**H3**, medium impact, feasibility HARD → its own PR, env-flagged, fallback-tested).

Single Edge Function: `supabase/functions/viral-video-ad-generator/`.

## How

- **No ASR/whisper.** The spoken script (the `spokenScript` used for TTS) is already known, so an SRT is built by allocating each line a duration **proportional to its char-length** across the estimated audio length (`chars / language-specific chars-per-second`), clamped to a sane per-line floor/ceiling. Muted viewers need the caption present and roughly paced, not frame-accurate sync.
- **Where:** after Hedra returns the mp4 but **before** `persistRemoteMediaToStorage`, the raw mp4 URL + SRT are POSTed to a hosted ffmpeg transcoder (a Deno edge function cannot run ffmpeg in-process). The burned result is stored as `generatedVideoUrl` (Supabase copy preferred; transcoder URL only if the storage copy fails).
- **Style** (decided in this PR, sent as ffmpeg `force_style`): bottom-center (`Alignment=2`), white text + black stroke (`Outline=3`) + shadow, bold, sized for ~540p. Hedra has no native caption param.
- New pure module `captions.ts` (SRT builder, timestamp, force_style, transcoder client) + `captions.test.ts`.

## GUARD — posting is NEVER blocked

Gated behind env flag `VVAG_BURN_CAPTIONS`. On a missing flag, missing transcoder URL, empty SRT, HTTP error, timeout, or any thrown error, the function **falls through to the current un-captioned mp4** — mirroring the existing `fallback_text` graceful-degradation. The transcoder call has an `AbortController` timeout (default 45s) so a hung transcoder can never blow the client polling budget. `captionStatus` / `captionReason` are surfaced in the response for diagnosis (DB schema unchanged).

## Enabling (Supabase secrets — feature is OFF until all are set)

| Secret | Purpose |
|--------|---------|
| `VVAG_BURN_CAPTIONS=1` | master flag |
| `VVAG_CAPTION_TRANSCODER_URL` | hosted ffmpeg burn-in endpoint (Cloud Run / fal.ai ffmpeg-api / Shotstack) |
| `VVAG_CAPTION_TRANSCODER_KEY` | service API key (sent as `Authorization: Bearer` + `x-api-key`; omit if unauthenticated) |
| `VVAG_CAPTION_TIMEOUT_MS` | optional, default 45000 |
| `VVAG_CAPTION_JA_CPS` / `VVAG_CAPTION_EN_CPS` | optional timing tuning (defaults 6.5 / 15) |
| `VVAG_CAPTION_FONT_SIZE` / `VVAG_CAPTION_FONT_NAME` | optional style tuning |

Service contract: `POST { videoUrl, mp4Url, srt, subtitleFormat, format, resolution, style, forceStyle }` → `{ url }` (also accepts `video_url` / `output_url` / `download_url`, nested under `data`/`result`/`output`).

## Risk

Adds a NEW external paid dependency + secret + failure mode to an EF with documented Hedra-credit / fetch-timeout fragility — hence its own PR, env flag, bounded timeout, and fallback-first design. **Ship only AFTER the lead-hook PR #3805** (reach is gated upstream by the first line).

## Verify

- `deno lint` — 0 errors (7 files)
- `deno test` — 34 passed (13 new caption tests + 21 existing), covering SRT proportional timing, clamps, `force_style`, URL extraction, and transcoder ok / HTTP-error / missing-url / network-reject fallback.
- Post-merge: confirm `deploy-prod` success (EF auto-deploys via `deploy-prod.yml`).

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: AI-authored single-file Edge Function change: adds caption burn-in behind the VVAG_BURN_CAPTIONS flag with graceful fallback to the un-captioned mp4 on any transcoder error or missing secret. No auth/RLS/payment/migration touched; posting is never blocked.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Supabase Edge Functions have no Flutter integration_test/ or Playwright harness; caption SRT timing, force_style, and transcoder ok/fail/timeout fallback are covered by deno unit tests in captions.test.ts.
