### PR TITLE
feat(x-share): add native X poll (H7) to lift impressions (additive/default-off)

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -47,12 +47,29 @@ class UniversalSharePageContext {
   }
 }
 
+/// ネイティブ X 投票(H7 / impressions ブースター)。
+/// [question] は投票を載せる最初のリプライ本文になり、[options] は 2〜4 個・
+/// 各<=25 文字、[durationMinutes] は 5〜10080 分。null のドラフトは従来と完全に
+/// 同一の投稿になる(additive / default-off)。
+class UniversalXPoll {
+  final String question;
+  final List<String> options;
+  final int durationMinutes;
+
+  const UniversalXPoll({
+    required this.question,
+    required this.options,
+    this.durationMinutes = 1440,
+  });
+}
+
 class UniversalXShareDraft {
   final String text;
   final String imagePrompt;
   final String videoPrompt;
   final List<String> hashtags;
   final List<String> threadReplies;
+  final UniversalXPoll? poll;
   final bool fallbackUsed;
   final String source;
 
@@ -62,6 +79,7 @@ class UniversalXShareDraft {
     required this.videoPrompt,
     required this.hashtags,
     this.threadReplies = const [],
+    this.poll,
     required this.fallbackUsed,
     required this.source,
   });
@@ -72,6 +90,7 @@ class UniversalXShareDraft {
     String? videoPrompt,
     List<String>? hashtags,
     List<String>? threadReplies,
+    UniversalXPoll? poll,
     bool? fallbackUsed,
     String? source,
   }) {
@@ -81,6 +100,7 @@ class UniversalXShareDraft {
       videoPrompt: videoPrompt ?? this.videoPrompt,
       hashtags: hashtags ?? this.hashtags,
       threadReplies: threadReplies ?? this.threadReplies,
+      poll: poll ?? this.poll,
       fallbackUsed: fallbackUsed ?? this.fallbackUsed,
       source: source ?? this.source,
     );
@@ -281,6 +301,7 @@ class UniversalXShareService {
     bool linkInReply = false,
     bool dryRun = false,
     String? altText,
+    UniversalXPoll? poll,
   }) async {
     final normalizedMediaUrl = _emptyToNull(mediaUrl);
     final hasMedia =
@@ -297,7 +318,18 @@ class UniversalXShareService {
     );
     final mainText = parts.leadText;
     final textUrl = parts.textUrl;
-    final replyTexts = parts.replyTexts;
+    // ネイティブ投票(H7)は media を持たない最初のリプライにのみ載せられる
+    // (X は poll と media の同居を禁止)。投票の質問文をスレッド先頭のリプライへ
+    // 前置し、edge 側でその最初のリプライに poll を添付する。poll が無い/不正な
+    // ときは replyTexts も payload も従来と完全に同一(byte-identical)にする。
+    final pollPayload = _xPollPayload(poll);
+    final pollQuestion = pollPayload == null || poll == null
+        ? ''
+        : sanitizeTweet(poll.question, url: textUrl, requireUrl: false).trim();
+    final hasPoll = pollPayload != null && pollQuestion.isNotEmpty;
+    final replyTexts = hasPoll
+        ? <String>[pollQuestion, ...parts.replyTexts]
+        : parts.replyTexts;
     final data = await _invoke('growth-hub', {
       'action': 'x.post',
       'text': mainText,
@@ -312,6 +344,7 @@ class UniversalXShareService {
       'promptProfile': 'performance_context_v1',
       'contentKind': normalizedMediaUrl == null ? 'text' : 'media',
       'linkInReply': linkInReply,
+      if (hasPoll) 'poll': pollPayload,
     });
     if (data['success'] != true) {
       throw Exception(buildXPostFailureMessage(data));
@@ -330,6 +363,32 @@ class UniversalXShareService {
           : const [],
       raw: data,
     );
+  }
+
+  /// Normalizes an optional [UniversalXPoll] into the growth-hub wire shape
+  /// `{ options, durationMinutes }`, or null when it does not qualify as a real
+  /// poll (fewer than 2 non-empty options). Options are trimmed, de-duplicated
+  /// (X rejects duplicate options), capped at 4 and <=25 chars each; duration is
+  /// clamped to X's 5〜10080 minute range. Returning null keeps posts
+  /// byte-identical to the no-poll path.
+  static Map<String, dynamic>? _xPollPayload(UniversalXPoll? poll) {
+    if (poll == null) return null;
+    final seen = <String>{};
+    final options = <String>[];
+    for (final entry in poll.options) {
+      var option = entry.trim();
+      if (option.isEmpty) continue;
+      if (option.runes.length > 25) {
+        option = String.fromCharCodes(option.runes.take(25));
+      }
+      if (seen.add(option)) options.add(option);
+      if (options.length == 4) break;
+    }
+    if (options.length < 2) return null;
+    var duration = poll.durationMinutes;
+    if (duration < 5) duration = 5;
+    if (duration > 10080) duration = 10080;
+    return {'options': options, 'durationMinutes': duration};
   }
 
   /// URL を載せる最終リプライの CTA 文面プール。毎回同一文だと近似重複として
@@ -1043,6 +1102,7 @@ $url''';
           hashtags: hashtags,
           threadReplies:
               threadReplies.isNotEmpty ? threadReplies : fallback.threadReplies,
+          poll: _parsePoll(decoded['poll']) ?? fallback.poll,
           fallbackUsed: true,
           source: 'ai-json',
         );
@@ -1051,6 +1111,45 @@ $url''';
       // Fall through to treating the response as a tweet body.
     }
     return fallback.copyWith(text: sanitizeTweet(raw, url: shareUrl));
+  }
+
+  /// Parses an optional LLM-generated `poll` object into a [UniversalXPoll], or
+  /// null when it is missing/malformed so the post stays byte-identical to the
+  /// no-poll path. Requires a non-empty question and >=2 usable options; each
+  /// option is trimmed, de-duplicated and truncated to X's 25-char limit;
+  /// duration is clamped to X's 5〜10080 minute range (default 1440 = 1 day).
+  static UniversalXPoll? _parsePoll(dynamic raw) {
+    if (raw is! Map) return null;
+    final rawQuestion = raw['question'] ?? raw['q'] ?? raw['title'] ?? '';
+    final question = rawQuestion.toString().trim();
+    final rawOptions = raw['options'] ?? raw['choices'];
+    if (question.isEmpty || rawOptions is! List) return null;
+    final seen = <String>{};
+    final options = <String>[];
+    for (final entry in rawOptions) {
+      var option = entry.toString().trim();
+      if (option.isEmpty) continue;
+      if (option.runes.length > 25) {
+        option = String.fromCharCodes(option.runes.take(25));
+      }
+      if (seen.add(option)) options.add(option);
+      if (options.length == 4) break;
+    }
+    if (options.length < 2) return null;
+    final durationRaw = raw['durationMinutes'] ?? raw['duration_minutes'];
+    var duration = 1440;
+    if (durationRaw is num) {
+      duration = durationRaw.toInt();
+    } else if (durationRaw is String) {
+      duration = int.tryParse(durationRaw.trim()) ?? 1440;
+    }
+    if (duration < 5) duration = 5;
+    if (duration > 10080) duration = 10080;
+    return UniversalXPoll(
+      question: question,
+      options: options,
+      durationMinutes: duration,
+    );
   }
 
   static bool _isUsableText(String text, String url) {
@@ -1084,7 +1183,8 @@ Return valid JSON only:
   "threadReplies": ["4 to 8 substantive Japanese reply posts, each 150-500 chars, forming a full briefing thread"],
   "imagePrompt": "English prompt for a 16:9 share image, no text overlay",
   "videoPrompt": "English prompt for a short presenter/share video",
-  "hashtags": ["#buildinpublic", "#FlutterWeb", "#Supabase"]
+  "hashtags": ["#buildinpublic", "#FlutterWeb", "#Supabase"],
+  "poll": { "question": "<=100 char Japanese poll question tied to today's top headline>", "options": ["<=25 char option", "<=25 char option"], "durationMinutes": 1440 }
 }
 
 Page:
@@ -1119,6 +1219,9 @@ Rules:
 - This X account has X Premium, so the lead post is NOT limited to 280 chars. Write a rich long-form lead of roughly 400-900 chars: a headline, 2-4 concrete news points with brief analysis, and a low-friction CTA. Do not compress it into one short sentence.
 - Provide a FULL briefing thread: 5-8 substantive threadReplies that each add real analysis (状況/背景/なぜ重要か/仕事への活かし方/次の一手), not one-liners.
 - The FIRST reply must stand alone as its own scroll-stopping hook: one sharp claim + why it matters + a reply-provoking question, fully readable with zero context from the lead post. Do NOT repeat the lead hook verbatim and do NOT phrase it as "1つ目/item 1 of N". Replies 2 onward then form the numbered briefing.
+- Native poll (impressions booster): when today's top headline supports a crisp either/or, ranking, or opinion question, include a "poll" object with a short Japanese "question" and 2-4 "options" (each <=25 chars). X natively boosts impressions and early engagement on poll tweets.
+- DERIVE the poll question AND options from THE DAY'S single most relevant headline so the poll rotates daily and is specific — NEVER reuse a generic or hardcoded poll like "使ってみたい?はい/いいえ" (near-duplicate polls get down-ranked). Yesterday's poll must not be reusable today.
+- The poll is posted as its own FIRST text-only thread reply (never on the media lead), so make the "question" self-contained. If no natural, honest poll fits today's news, OMIT the "poll" field entirely rather than forcing a weak one.
 - Treat the creative workflow as GPT image -> GPT-5.5 -> ElevenLabs -> Hedra.
 - Keep the post natural, concise, and credible.
 $financeRule

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -414,6 +414,9 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
         mediaUrl: _videoUrl ?? _imageUrl,
         threadReplies: draft.threadReplies,
         linkInReply: true,
+        // ネイティブ投票(H7 / impressions ブースター)。draft.poll が null の
+        // ときは従来と完全に同一の投稿になる(additive / default-off)。
+        poll: draft.poll,
       );
       if (_disposed || !mounted) return;
       setState(() {

--- a/supabase/functions/_shared/x-client.ts
+++ b/supabase/functions/_shared/x-client.ts
@@ -305,12 +305,28 @@ export async function setMediaAltText(
   });
 }
 
-export async function postTweet(input: {
+export interface XTweetPoll {
+  options: string[];
+  durationMinutes: number;
+}
+
+export interface PostTweetInput {
   text: string;
   mediaIds?: string[];
   replyToTweetId?: string;
-}): Promise<XTweetResult> {
-  assertXConfigured();
+  // ネイティブ投票(H7 / impressions ブースター)。省略時は従来と完全に同一の
+  // payload になる(additive / default-off)。
+  poll?: XTweetPoll;
+}
+
+/**
+ * POST /2/tweets の request body を組み立てる純関数(ネットワーク非依存)。
+ * postTweet 本体から切り出して deno test 可能にしている。
+ * poll+media 同居ガードと 2 選択肢以上のゲートはここに集約する。
+ */
+export function buildTweetPayload(
+  input: PostTweetInput,
+): Record<string, unknown> {
   const text = asString(input.text);
   if (text === "") {
     throw new Error("text is required.");
@@ -333,6 +349,33 @@ export async function postTweet(input: {
   if (replyToTweetId !== "") {
     payload.reply = { in_reply_to_tweet_id: replyToTweetId };
   }
+
+  // X API v2 は POST /2/tweets に poll を直接受け付ける(新エンドポイント/scope 不要)。
+  // 各選択肢<=25字・2〜4個・期間5〜10080分。X は 1 ツイートに poll と media の同居を
+  // 禁止するため、poll は media を持たない text-only の最初のリプライにのみ載せる
+  // (media 付きのリード投稿には絶対に載せない)。
+  const pollOptions = (input.poll?.options ?? [])
+    .map((option) => asString(option))
+    .filter((option) => option !== "")
+    .slice(0, 4);
+  if (pollOptions.length >= 2) {
+    if (payload.media) {
+      throw new Error("poll and media cannot coexist on one tweet");
+    }
+    payload.poll = {
+      options: pollOptions,
+      duration_minutes: Math.max(
+        5,
+        Math.min(10080, Math.trunc(input.poll!.durationMinutes || 1440)),
+      ),
+    };
+  }
+  return payload;
+}
+
+export async function postTweet(input: PostTweetInput): Promise<XTweetResult> {
+  assertXConfigured();
+  const payload = buildTweetPayload(input);
 
   const tweetUrl = "https://api.twitter.com/2/tweets";
   const oauthHeader = await buildOAuthHeader("POST", tweetUrl);

--- a/supabase/functions/_shared/x-client_test.ts
+++ b/supabase/functions/_shared/x-client_test.ts
@@ -1,8 +1,15 @@
 import {
   assertEquals,
+  assertFalse,
+  assertObjectMatch,
   assertStringIncludes,
+  assertThrows,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { buildMediaAltTextBody, buildXApiErrorPayload } from "./x-client.ts";
+import {
+  buildMediaAltTextBody,
+  buildTweetPayload,
+  buildXApiErrorPayload,
+} from "./x-client.ts";
 
 Deno.test("buildXApiErrorPayload classifies client-not-enrolled", () => {
   const payload = buildXApiErrorPayload(403, {
@@ -42,4 +49,92 @@ Deno.test("buildMediaAltTextBody caps alt_text at 1000 chars", () => {
   assertEquals(body.media_id, "42");
   assertEquals(body.alt_text.text.length, 1000);
   assertEquals(body.alt_text.text, "あ".repeat(1000));
+});
+
+Deno.test("buildTweetPayload without poll is byte-identical to plain text", () => {
+  const payload = buildTweetPayload({ text: "hello" });
+  assertEquals(payload, { text: "hello" });
+  assertFalse("poll" in payload);
+});
+
+Deno.test("buildTweetPayload attaches poll when 2+ options are present", () => {
+  const payload = buildTweetPayload({
+    text: "どっちが好き?",
+    poll: { options: ["きのこ", "たけのこ"], durationMinutes: 1440 },
+  });
+  assertObjectMatch(payload, {
+    text: "どっちが好き?",
+    poll: { options: ["きのこ", "たけのこ"], duration_minutes: 1440 },
+  });
+});
+
+Deno.test("buildTweetPayload gates out polls with fewer than 2 usable options", () => {
+  const single = buildTweetPayload({
+    text: "poll?",
+    poll: { options: ["only one"], durationMinutes: 1440 },
+  });
+  assertFalse("poll" in single);
+
+  // Empty / whitespace options are dropped, so this collapses to <2 options.
+  const collapsed = buildTweetPayload({
+    text: "poll?",
+    poll: { options: ["ok", "", "   "], durationMinutes: 1440 },
+  });
+  assertFalse("poll" in collapsed);
+
+  const none = buildTweetPayload({
+    text: "poll?",
+    poll: { options: [], durationMinutes: 1440 },
+  });
+  assertFalse("poll" in none);
+});
+
+Deno.test("buildTweetPayload rejects poll + media on the same tweet", () => {
+  assertThrows(
+    () =>
+      buildTweetPayload({
+        text: "lead with media",
+        mediaIds: ["media_123"],
+        poll: { options: ["a", "b"], durationMinutes: 1440 },
+      }),
+    Error,
+    "poll and media cannot coexist on one tweet",
+  );
+});
+
+Deno.test("buildTweetPayload clamps poll duration and caps options at 4", () => {
+  const tooShort = buildTweetPayload({
+    text: "p",
+    poll: { options: ["a", "b"], durationMinutes: 1 },
+  });
+  assertEquals((tooShort.poll as { duration_minutes: number }).duration_minutes, 5);
+
+  const tooLong = buildTweetPayload({
+    text: "p",
+    poll: { options: ["a", "b"], durationMinutes: 99999 },
+  });
+  assertEquals(
+    (tooLong.poll as { duration_minutes: number }).duration_minutes,
+    10080,
+  );
+
+  const zeroDefaults = buildTweetPayload({
+    text: "p",
+    poll: { options: ["a", "b"], durationMinutes: 0 },
+  });
+  assertEquals(
+    (zeroDefaults.poll as { duration_minutes: number }).duration_minutes,
+    1440,
+  );
+
+  const fiveOptions = buildTweetPayload({
+    text: "p",
+    poll: { options: ["a", "b", "c", "d", "e"], durationMinutes: 1440 },
+  });
+  assertEquals((fiveOptions.poll as { options: string[] }).options, [
+    "a",
+    "b",
+    "c",
+    "d",
+  ]);
 });

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -1631,6 +1631,33 @@ serve(async (req: Request) => {
         const mediaAlt = String(
           body.mediaAlt ?? body.media_alt ?? body.altText ?? "",
         ).trim();
+        // ネイティブ投票(H7 / impressions ブースター)。>=2 選択肢のときだけ有効化し、
+        // 最初の text-only リプライにのみ載せる(media 付きリードには載せない)。
+        // 未指定(既定)のときは poll=null となり従来と完全に同一の投稿になる。
+        const rawPoll = (body.poll ?? null) as
+          | { options?: unknown; durationMinutes?: unknown; duration_minutes?: unknown }
+          | null;
+        const pollOptions = Array.isArray(rawPoll?.options)
+          ? rawPoll!.options
+            .map((option) => String(option ?? "").trim())
+            .filter((option) => option !== "")
+            .slice(0, 4)
+          : [];
+        const poll = pollOptions.length >= 2
+          ? {
+            options: pollOptions,
+            durationMinutes: Math.max(
+              5,
+              Math.min(
+                10080,
+                Math.trunc(
+                  Number(rawPoll?.durationMinutes ?? rawPoll?.duration_minutes) ||
+                    1440,
+                ),
+              ),
+            ),
+          }
+          : null;
         const dryRun = body.dryRun === true;
         if (!text) return json({ success: false, error: "text required" }, 400);
         // X Premium(認証済みアカウント)は最大25,000字の長文ポストが可能。280字で弾かない。
@@ -1750,14 +1777,19 @@ serve(async (req: Request) => {
           });
           const replyResults = [];
           let parentTweetId = result.tweetId;
+          let replyIndex = 0;
           for (const nextReplyText of replyTexts) {
             if (!parentTweetId) break;
+            // poll は最初の text-only リプライにのみ添付する(media 付きリードには
+            // 載せない = X の poll+media 同居禁止に準拠)。
             const replyResult = await postTweet({
               text: nextReplyText,
               replyToTweetId: parentTweetId,
+              ...(replyIndex === 0 && poll ? { poll } : {}),
             });
             replyResults.push(replyResult);
             parentTweetId = replyResult.tweetId ?? parentTweetId;
+            replyIndex += 1;
           }
           const replyTweetIds = replyResults
             .map((replyResult) => replyResult.tweetId)
@@ -1782,6 +1814,7 @@ serve(async (req: Request) => {
             replyTweetId: replyTweetIds[0] ?? null,
             replyTweetIds,
             account: result.account,
+            ...(poll ? { pollAttached: true } : {}),
             log,
           });
         } catch (error) {

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -309,6 +309,87 @@ void main() {
     expect(capturedBody?['variant'], 'post_to_x');
     expect(capturedBody?['promptProfile'], 'performance_context_v1');
     expect(capturedBody?['contentKind'], 'media');
+    // 投票なしの既定経路には poll キーを一切足さない(default-off)。
+    expect(capturedBody?.containsKey('poll'), isFalse);
+  });
+
+  test('postToX stays poll-free (byte-identical) when no poll is given',
+      () async {
+    Map<String, dynamic>? capturedBody;
+    final service = UniversalXShareService(
+      functionInvoker: (functionName, body) async {
+        capturedBody = body;
+        return {'success': true, 'posted': true};
+      },
+    );
+
+    await service.postToX(
+      context: page,
+      text: 'リード投稿\n${page.url}',
+      threadReplies: const ['1. 【AI】本文\nなぜ重要か: 変わる。'],
+      linkInReply: true,
+    );
+
+    expect(capturedBody?.containsKey('poll'), isFalse);
+    final replies = capturedBody?['replyTexts'] as List;
+    // 先頭は投票質問ではなく従来どおりスレッド本文で始まる。
+    expect(replies.first.toString(), contains('本文'));
+  });
+
+  test('postToX attaches a native poll to a prepended first reply', () async {
+    Map<String, dynamic>? capturedBody;
+    final service = UniversalXShareService(
+      functionInvoker: (functionName, body) async {
+        capturedBody = body;
+        return {'success': true, 'posted': true, 'tweetId': '1'};
+      },
+    );
+
+    await service.postToX(
+      context: page,
+      text: 'リード投稿\n${page.url}',
+      threadReplies: const ['1. 【AI】本文\nなぜ重要か: 変わる。'],
+      linkInReply: true,
+      poll: const UniversalXPoll(
+        question: 'あなたはどっち派?',
+        options: ['きのこ', 'たけのこ'],
+        durationMinutes: 1440,
+      ),
+    );
+
+    final poll = capturedBody?['poll'] as Map<String, dynamic>;
+    expect(poll['options'], ['きのこ', 'たけのこ']);
+    expect(poll['durationMinutes'], 1440);
+    final replies = capturedBody?['replyTexts'] as List;
+    // 投票質問がスレッド先頭リプライとして前置される(edge がここへ poll を添付)。
+    expect(replies.first.toString(), contains('どっち'));
+    expect(replies[1].toString(), contains('本文'));
+  });
+
+  test('postToX drops a poll with fewer than 2 usable options', () async {
+    Map<String, dynamic>? capturedBody;
+    final service = UniversalXShareService(
+      functionInvoker: (functionName, body) async {
+        capturedBody = body;
+        return {'success': true, 'posted': true};
+      },
+    );
+
+    await service.postToX(
+      context: page,
+      text: 'リード投稿\n${page.url}',
+      threadReplies: const ['1. 本文だけ'],
+      poll: const UniversalXPoll(
+        question: '選べる?',
+        options: ['ひとつだけ', '  ', 'ひとつだけ'],
+        durationMinutes: 1440,
+      ),
+    );
+
+    // 実質 1 択(空白除去+重複排除後)なので投票は付かず本文が先頭のまま。
+    expect(capturedBody?.containsKey('poll'), isFalse);
+    final replies = capturedBody?['replyTexts'] as List;
+    expect(replies.first.toString(), contains('本文だけ'));
   });
 
   test('postToX adds X acquisition URL when text has no URL', () async {


### PR DESCRIPTION
## What & why

Adds a **native X poll** (H7 from the 10-hypothesis impression audit) to the auto-generated X share package. Native polls strongly boost impressions and early engagement, which is reply-weighted — so a poll on the thread lifts reach for the whole post.

**Additive and default-off**: posts without a poll are byte-identical to today. The feature only activates when the drafting LLM produces a valid poll.

### Changes
- **`supabase/functions/_shared/x-client.ts`** — `postTweet` gains an optional `poll?: { options; durationMinutes }`. Extracted a pure, unit-tested `buildTweetPayload()` that:
  - throws if a tweet would carry **both poll and media** (X forbids this),
  - only sets `payload.poll` when there are **≥2 non-empty options** (caps at 4),
  - clamps `duration_minutes` to X's **5–10080** range.
  - X API v2 accepts `poll` directly on `POST /2/tweets` — no new endpoint or scope.
- **`supabase/functions/growth-hub/index.ts`** — the `x.post` reply loop reads `body.poll` and attaches it to **only the first (text-only) reply**, never the media-bearing lead. `poll` is null unless ≥2 options are present.
- **`lib/services/universal_x_share_service.dart`** — new `UniversalXPoll` model + `_parsePoll`. `_buildDraftPrompt` asks the LLM for a poll question + 2–4 short (≤25 char) options **derived from the day's top news hook and rotated daily** (a hardcoded/near-duplicate poll gets down-ranked). `postToX` normalizes the poll and **prepends the question as the first thread reply** so the edge attaches the poll to it. No poll → payload is unchanged.
- **`lib/widgets/universal_ai_share_shell.dart`** — passes `draft.poll` into `postToX`.

## Test plan
- `deno test supabase/functions/_shared/x-client_test.ts` — 6 pass, incl. poll+media guard, ≥2-option gating, duration clamp, 4-option cap, and no-poll byte-identical payload.
- `flutter test test/services/universal_x_share_service_test.dart` — 34 pass, incl. 3 new poll cases (default-off byte-identical, poll attached to prepended first reply, <2-option drop) and all pre-existing `postToX`/`buildManualShareParts` behavior.
- `deno lint` (3 edge files) and `dart analyze` (2 lib files) clean.
- Rebased onto `#3805` (parallel X-share impression PR that touched the same service file); this PR is purely additive on top of it — no revert.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Edge-only additive change to X poll plumbing (x-client buildTweetPayload + growth-hub reply loop); covered by deno unit tests for poll+media guard and >=2-option gating; no user-facing E2E-testable route added

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive default-off native X poll: no-poll path is byte-identical (verified by deno + dart tests); no authentication/RLS/secret/migration change; edge poll attaches only to the first text-only reply, never the media lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
