### PR TITLE
feat(asset): 過去給料日サイクルに実績サマリを表示 (part310 候補③)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -13466,6 +13466,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final selectedDay =
         selectedDate == null ? null : calendar.dayFor(selectedDate);
     final today = _calendarNow;
+    final todayDate = DateTime(today.year, today.month, today.day);
+    // サイクル終了(排他)が今日以前なら予定系イベントが存在しない過去サイクル。
+    // 予定チップの代わりに記録済みフローの実績サマリを見せる。
+    final isPastCycle = !cycleEndExclusive.isAfter(todayDate);
+    var cycleActualExpenseTotal = 0.0;
+    var cycleActualIncomeTotal = 0.0;
+    var cycleRecordedDayCount = 0;
+    for (final day in calendar.days) {
+      cycleActualExpenseTotal += day.expenseTotal;
+      cycleActualIncomeTotal += day.incomeTotal;
+      if (day.expenseTotal > 0 || day.incomeTotal > 0) {
+        cycleRecordedDayCount++;
+      }
+    }
+    final cycleActualNet = cycleActualIncomeTotal - cycleActualExpenseTotal;
     final shortfallDaySummary = calendar.firstShortfallDate == null
         ? null
         : calendar.dayFor(calendar.firstShortfallDate!);
@@ -13657,27 +13672,101 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               ),
             ],
             const SizedBox(height: 10),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                _buildOverviewStatChip(
-                  label: '返済予定',
-                  value: _formatYen(calendar.scheduledDebtPaymentTotal),
-                  color: const Color(0xFFB91C1C),
+            if (isPastCycle)
+              Container(
+                key: const Key('asset_calendar_cycle_actual_summary'),
+                width: double.infinity,
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF8FAFC),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: const Color(0xFFE2E8F0)),
                 ),
-                _buildOverviewStatChip(
-                  label: '固定費予定',
-                  value: _formatYen(calendar.subscriptionTotal),
-                  color: const Color(0xFF9333EA),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(
+                          Icons.history,
+                          size: 16,
+                          color: Color(0xFF475569),
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            'このサイクルの実績サマリ'
+                            '(${DateFormat('M/d').format(calendar.rangeStart)}'
+                            '〜${DateFormat('M/d').format(cycleLastDay)})',
+                            style: const TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w800,
+                              height: 1.4,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        _buildOverviewStatChip(
+                          label: '収入実績',
+                          value: _formatYen(cycleActualIncomeTotal),
+                          color: const Color(0xFF2563EB),
+                        ),
+                        _buildOverviewStatChip(
+                          label: '支出実績',
+                          value: _formatYen(cycleActualExpenseTotal),
+                          color: const Color(0xFFB91C1C),
+                        ),
+                        _buildOverviewStatChip(
+                          label: '差引収支',
+                          value: _formatSignedYen(cycleActualNet),
+                          color: cycleActualNet >= 0
+                              ? const Color(0xFF047857)
+                              : const Color(0xFFB91C1C),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      cycleRecordedDayCount > 0
+                          ? '記録がある日: $cycleRecordedDayCount日。終了したサイクルのため予定(返済・固定費・入金予定)は表示せず、記録済みフローのみを集計しています。'
+                          : '終了したサイクルです。この期間に記録されたフローはありません。',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        height: 1.5,
+                      ),
+                    ),
+                  ],
                 ),
-                _buildOverviewStatChip(
-                  label: '支払予定合計',
-                  value: _formatYen(calendar.scheduledOutflowTotal),
-                  color: const Color(0xFFC05621),
-                ),
-              ],
-            ),
+              )
+            else
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _buildOverviewStatChip(
+                    label: '返済予定',
+                    value: _formatYen(calendar.scheduledDebtPaymentTotal),
+                    color: const Color(0xFFB91C1C),
+                  ),
+                  _buildOverviewStatChip(
+                    label: '固定費予定',
+                    value: _formatYen(calendar.subscriptionTotal),
+                    color: const Color(0xFF9333EA),
+                  ),
+                  _buildOverviewStatChip(
+                    label: '支払予定合計',
+                    value: _formatYen(calendar.scheduledOutflowTotal),
+                    color: const Color(0xFFC05621),
+                  ),
+                ],
+              ),
             if (calendar.firstShortfallDate != null) ...[
               const SizedBox(height: 8),
               Container(

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -149,6 +149,89 @@ void main() {
       await _unmount(tester);
     });
 
+    testWidgets('past cycle shows the actual summary instead of plan chips', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // 「今日」= 2026-07-10 → 表示サイクルは 6/25〜7/24。前サイクル(5/25〜6/24)は
+      // 全日が過去なので予定チップの代わりに実績サマリが出る。
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugCalendarNow: DateTime(2026, 7, 10),
+            debugInitialRecentFlows: <Map<String, dynamic>>[
+              <String, dynamic>{
+                'action_type': 'conquer',
+                'amount': 300000,
+                'description': '給料',
+                'occurred_at': DateTime(2026, 5, 25, 12).toIso8601String(),
+              },
+              <String, dynamic>{
+                'action_type': 'expense',
+                'amount': 12000,
+                'description': '食費',
+                'occurred_at': DateTime(2026, 6, 10, 12).toIso8601String(),
+              },
+            ],
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // 現在サイクルでは実績サマリは出ず、予定チップが出る。
+      expect(
+        find.byKey(const Key('asset_calendar_cycle_actual_summary')),
+        findsNothing,
+      );
+      expect(find.text('支払予定合計'), findsOneWidget);
+
+      await tester.ensureVisible(
+        find.byKey(const Key('asset_calendar_prev_month')),
+      );
+      await tester.tap(find.byKey(const Key('asset_calendar_prev_month')));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('2026/5/25〜6/24'), findsOneWidget);
+      final summary = find.byKey(
+        const Key('asset_calendar_cycle_actual_summary'),
+      );
+      expect(summary, findsOneWidget);
+      expect(find.text('支払予定合計'), findsNothing);
+
+      // 実績合算: 収入 300,000 / 支出 12,000 / 差引 +288,000 / 記録 2 日。
+      expect(
+        find.descendant(of: summary, matching: find.text('¥300,000')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: summary, matching: find.text('¥12,000')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: summary, matching: find.text('+¥288,000')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: summary,
+          matching: find.textContaining('記録がある日: 2日'),
+        ),
+        findsOneWidget,
+      );
+
+      // さらに前(4/25〜5/24)は記録なし → 空メッセージ。
+      await tester.tap(find.byKey(const Key('asset_calendar_prev_month')));
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(
+        find.textContaining('この期間に記録されたフローはありません'),
+        findsOneWidget,
+      );
+
+      await _unmount(tester);
+    });
+
     testWidgets(
       'monthly flow card aggregates over the salary cycle, not the month',
       (tester) async {


### PR DESCRIPTION
## 概要 (part312 / part310 候補③)

#3799 で予定系(返済・固定費・入金予定)が asOf(今日)起点の計上になったため、過去サイクルへ戻ると予定が全て非表示 = 予定チップが ¥0 のまま並ぶだけで閲覧価値が薄かった。本 PR は過去サイクル閲覧時に「このサイクルの実績サマリ」を表示し、過去サイクル閲覧に意味を持たせる。

## 変更点

- `lib/pages/asset_management_page.dart`
  - サイクル終了(排他)が今日以前 = 過去サイクルの判定 `isPastCycle` を追加
  - 過去サイクルでは予定チップ(返済予定/固定費予定/支払予定合計)の代わりに実績サマリ `asset_calendar_cycle_actual_summary` を表示
  - 内容: 期間ラベル + 収入実績 / 支出実績 / 差引収支(`_formatSignedYen`・黒字緑/赤字赤) + 記録がある日数。記録ゼロなら空メッセージ
  - 集計は表示中カレンダーの `days`(記録済みフロー)からのみ。現在・未来サイクルは従来表示のまま
- `test/widgets/asset_management_page_smoke_test.dart`: smoke 1件追加(現在サイクル=予定チップ表示・サマリ非表示 / 前サイクル=サマリ表示・収入/支出/差引/記録日数の値検証 / さらに前=記録なし空メッセージ)。`debugCalendarNow` 固定で実行日非依存

## 検証

- `flutter analyze` 対象2ファイル 0 issues / `dart format` 差分なし
- `flutter test test/widgets/asset_management_page_smoke_test.dart` 55件 all green

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: widget smoke test covers current-cycle chips / past-cycle summary values / empty past cycle; no new route or E2E-reachable flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
