### PR TITLE
feat(x-share): scannable formatting + save/bookmark cue to lift dwell & reach

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -401,6 +401,8 @@ class UniversalXShareService {
     'ここから試せます。最初の1画面で迷った所があれば教えてください。',
     '実際に開けます。役に立ちそう/そうでない、どちらでも返信歓迎です。',
     'デモはこちら。5分だけ使って、続けたいと思ったか教えてください。',
+    '要点は後で使えるので保存推奨。触ったら一言だけ感想ください。',
+    'この投稿は保存しておくと後で効きます。使えたか一言返信歓迎です。',
   ];
 
   /// Builds the lead post + reply chain exactly like [postToX] does, so the
@@ -1215,9 +1217,11 @@ Rules:
 - When headlines are present, OPEN the lead post by tying today's single most relevant headline to this app's angle (information organization / AI work OS), so the post visibly changes every day. Do not lead with a generic app description.
 - The FIRST line (before the X "Show more" fold) must be a concrete curiosity/value/news hook that stops the scroll. Do NOT start with a label or date such as "デイリーブリーフィング — …朝"; do not prefix the post with the date. If you mention any date, use exactly today's real date (JST) given above and never invent another year (e.g. never write 2024).
 - Every day's post must read as fresh and specific: pick a different concrete headline or angle rather than repeating yesterday's template.
-- Prefer conversation hooks and save-worthy analysis over hashtags.
+- Prefer conversation hooks and save-worthy analysis over hashtags. When the thread genuinely helps later (a checklist, framework, or numbered briefing), add ONE natural save cue (e.g. "後で使えるよう保存を") — never on every post and never templated word-for-word.
 - This X account has X Premium, so the lead post is NOT limited to 280 chars. Write a rich long-form lead of roughly 400-900 chars: a headline, 2-4 concrete news points with brief analysis, and a low-friction CTA. Do not compress it into one short sentence.
 - Provide a FULL briefing thread: 5-8 substantive threadReplies that each add real analysis (状況/背景/なぜ重要か/仕事への活かし方/次の一手), not one-liners.
+- Format for scannability: break the lead and each reply into short one-idea lines with a blank line between meaning-chunks (no wall-of-text paragraph). Put labels (なぜ重要か / 見通し / 次の一手 など) at the start of a line and continue the explanation on the next line, so a reader can skim in 2 seconds.
+- Cap emoji at 1-2 per post and do NOT decorate every line (emoji spam and full-line decoration trigger spam down-ranking). Number only replies 2 onward. Optionally add ONE short, non-templated thread-continuation cue (e.g. "🧵つづく") just before the lead's CTA/URL, varying the wording day to day so it is never identical.
 - The FIRST reply must stand alone as its own scroll-stopping hook: one sharp claim + why it matters + a reply-provoking question, fully readable with zero context from the lead post. Do NOT repeat the lead hook verbatim and do NOT phrase it as "1つ目/item 1 of N". Replies 2 onward then form the numbered briefing.
 - Native poll (impressions booster): when today's top headline supports a crisp either/or, ranking, or opinion question, include a "poll" object with a short Japanese "question" and 2-4 "options" (each <=25 chars). X natively boosts impressions and early engagement on poll tweets.
 - DERIVE the poll question AND options from THE DAY'S single most relevant headline so the poll rotates daily and is specific — NEVER reuse a generic or hardcoded poll like "使ってみたい?はい/いいえ" (near-duplicate polls get down-ranked). Yesterday's poll must not be reusable today.

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -483,6 +483,24 @@ void main() {
     expect(seenCtas.length, greaterThanOrEqualTo(2));
   });
 
+  test('final-reply CTA pool includes a save/bookmark cue', () {
+    // ブックマーク(保存)は 2026 のリーチ品質シグナル。ローテプールに保存促しの
+    // バリアントが含まれ、複数入力のいずれかで最終リプに現れることを確認する。
+    var sawSaveCue = false;
+    for (var i = 0; i < 40; i += 1) {
+      final parts = UniversalXShareService.buildManualShareParts(
+        context: page,
+        text: 'body$i\n${page.url}',
+        linkInReply: true,
+      );
+      if (parts.replyTexts.last.contains('保存')) {
+        sawSaveCue = true;
+        break;
+      }
+    }
+    expect(sawSaveCue, isTrue);
+  });
+
   test('postToX surfaces X developer project guidance', () async {
     final service = UniversalXShareService(
       functionInvoker: (functionName, body) async {


### PR DESCRIPTION
## 背景（Round-2 / #3805,#3806,#3807,#3808 の後続）
インプレッション最大化の**第2ラウンド**。10新仮説×敵対的検証Workflow(9/10 worth_doing)で、**Dart単独・additive・インフラ不要・overlap最小**と判定された ship-first 2件を1本に集約。

## 変更（`lib/services/universal_x_share_service.dart` のみ）
1. **スキャン可能な整形（R2-scannable / medium）**: リード・各リプを1アイデア1行＋意味塊ごとに空行、ラベル行頭化を指示。**可読性＝dwell time（2026リーチ最大シグナル）**。絵文字は1-2/投稿に上限＋全行装飾禁止（スパム降格回避）。任意で**非定型のスレッド継続サイン**を1つ（毎回同一トークン化は近似重複リスクなので変化させる）。
2. **保存(ブックマーク)促し（R2-bookmark / 2026品質シグナル）**: プロンプトに「後で使えるスレッドなら1つだけ自然な保存促し（非定型）」を追加＋最終リプCTAプールに保存フレーム2種を追加（5→7、`text.hashCode` ローテが自動再均衡）。

## 検証
`flutter test` → **35件全パス**（CTAローテ＋保存促し到達性の各テスト追加）。

## スコープ外（follow-up / 別PR・別判断）
動画1:1/9:16化・動画最初の3秒フック・perf-loop集約・スレッドメディア・リサイクルは code follow-up。**字幕有効化(HIGH・要 transcoder インフラ設定(認証情報含む))** と**投稿cadence(要 go-live 承認)** はユーザー判断。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Prompt/CTA copy-only change to formatting guidance and the rotated final-reply pool; covered by updated + new flutter unit tests (35 green) asserting the CTA rotates and includes a save cue; no new user-facing route so a full integration_test is disproportionate.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Dart copy/prompt-only change (formatting guidance + rotated CTA pool); no supabase/functions, data-model, or permission change; the gate tripped on the English word in a follow-up note, not on the diff; verified by flutter test 35 green.
