### PR TITLE
feat(x-share): add caption-transcoder Cloud Run service to activate video captions

### DIFF
--- a/services/caption-transcoder/.dockerignore
+++ b/services/caption-transcoder/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+test.js
+*.md
+.git

--- a/services/caption-transcoder/Dockerfile
+++ b/services/caption-transcoder/Dockerfile
@@ -1,0 +1,16 @@
+# caption-transcoder: ffmpeg burn-in service for X-share presenter videos.
+# ffmpeg + Noto Sans CJK JP (so Japanese captions render, not tofu).
+FROM node:20-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ffmpeg \
+      fonts-noto-cjk \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY server.js ./
+ENV PORT=8080
+EXPOSE 8080
+CMD ["node", "server.js"]

--- a/services/caption-transcoder/README.md
+++ b/services/caption-transcoder/README.md
@@ -1,0 +1,115 @@
+# caption-transcoder
+
+On-screen **caption burn-in** service for the X-share presenter video
+(`supabase/functions/viral-video-ad-generator`, hypothesis H3).
+
+X autoplays video **muted**, so viewers who can't hear the narration scroll past.
+Burning captions into the video raises watch-through / dwell time — the dominant
+2026 X reach signal. The edge function already builds the SRT + style and calls a
+transcoder; a Deno edge function can't run ffmpeg in-process, so this tiny stateless
+Cloud Run service does the burn-in.
+
+The burn code in the edge function is **already merged but dormant** behind
+`VVAG_BURN_CAPTIONS`. Deploying this service + setting 3 secrets activates it.
+Everything fails safe: any transcoder error → the un-captioned mp4 is posted, so
+posting is never blocked.
+
+## How it fits together
+
+```
+viral-video-ad-generator (Deno EF)
+  → POST /burn { videoUrl, srt, forceStyle, resolution, style }   (this service)
+  → ffmpeg burns SRT with force_style, returns { url }
+  → EF fetches that url ONCE and re-persists it to Supabase Storage
+```
+Because the EF immediately re-persists the result to Supabase Storage, the URL this
+service returns only needs to live for a few seconds — **no GCS / object store
+needed**; the file is self-served from `/tmp` and auto-deleted after a short TTL.
+
+## Prerequisites
+- `gcloud` CLI authenticated on the Google Cloud project that backs this app.
+- Supabase CLI authenticated (project ref `smmkxxavexumewbfaqpy`).
+
+## 1. Deploy to Cloud Run
+
+From this directory (`services/caption-transcoder/`):
+
+```bash
+# Pick any strong random string as the shared key:
+API_KEY="$(openssl rand -hex 24)"
+echo "API_KEY=$API_KEY"   # save this — you set it as a Supabase secret in step 2
+
+gcloud run deploy caption-transcoder \
+  --source . \
+  --region asia-northeast1 \
+  --allow-unauthenticated \
+  --max-instances 1 \
+  --memory 1Gi \
+  --cpu 1 \
+  --timeout 300 \
+  --set-env-vars "API_KEY=$API_KEY"
+```
+
+Notes:
+- `--max-instances 1` guarantees the `GET /file/<id>.mp4` fetch hits the same
+  instance that produced the file (it holds the burned mp4 in `/tmp`). Low volume
+  (a few videos/day) never needs more than one instance.
+- `--allow-unauthenticated` exposes the HTTP endpoint publicly; the `API_KEY`
+  header check (Bearer or `x-api-key`) is what actually gates `/burn`. If you prefer
+  IAM auth instead, drop `--allow-unauthenticated` and give the Supabase function's
+  identity `roles/run.invoker` — but the header key is simpler here.
+- Scales to zero when idle → ~free at this volume.
+
+Grab the service URL it prints (e.g. `https://caption-transcoder-xxxx.a.run.app`).
+`PUBLIC_BASE_URL` is optional — the service auto-derives the self URL from the
+request `Host` header, which on Cloud Run is the correct `*.run.app` host.
+
+Smoke-test it:
+```bash
+curl https://caption-transcoder-xxxx.a.run.app/healthz   # -> ok
+```
+
+## 2. Point the edge function at it (Supabase secrets)
+
+```bash
+supabase secrets set \
+  VVAG_BURN_CAPTIONS=1 \
+  VVAG_CAPTION_TRANSCODER_URL="https://caption-transcoder-xxxx.a.run.app/burn" \
+  VVAG_CAPTION_TRANSCODER_KEY="$API_KEY" \
+  --project-ref smmkxxavexumewbfaqpy
+```
+
+`deploy-prod.yml` redeploys the edge functions on the next `main` merge, or run
+`supabase functions deploy viral-video-ad-generator --project-ref smmkxxavexumewbfaqpy`
+to pick up the new secrets immediately.
+
+Optional tuning secrets (all have safe defaults):
+`VVAG_CAPTION_FONT_NAME` (default `Noto Sans CJK JP`), `VVAG_CAPTION_FONT_SIZE`
+(22), `VVAG_CAPTION_JA_CPS` (6.5), `VVAG_CAPTION_EN_CPS` (15),
+`VVAG_CAPTION_TIMEOUT_MS`.
+
+## 3. Verify
+
+Generate one presenter video from the app (the one-button X share), then check the
+edge logs (Supabase → Logs → viral-video-ad-generator):
+- `[vvag-caption] burned OK lang=ja url=...` → burn succeeded.
+- The stored video filename ends in `-captioned.mp4`.
+- If you see `[vvag-caption] burn failed; using un-captioned mp4: ...`, the reason
+  is in the log; the post still went out with the plain video.
+
+If Japanese captions render as boxes (tofu), the container is missing the CJK font —
+confirm `fonts-noto-cjk` installed in the image and `VVAG_CAPTION_FONT_NAME` is
+`Noto Sans CJK JP`.
+
+## Kill switch
+
+```bash
+supabase secrets unset VVAG_BURN_CAPTIONS --project-ref smmkxxavexumewbfaqpy
+```
+(or set it to `0`) → the edge function immediately reverts to plain, un-captioned
+video. No redeploy of this service needed.
+
+## Local test (pure helpers, no ffmpeg/network)
+```bash
+node test.js
+```

--- a/services/caption-transcoder/package.json
+++ b/services/caption-transcoder/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "caption-transcoder",
+  "version": "1.0.0",
+  "private": true,
+  "description": "ffmpeg caption burn-in service for X-share presenter videos (VVAG H3).",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node test.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/services/caption-transcoder/server.js
+++ b/services/caption-transcoder/server.js
@@ -1,0 +1,190 @@
+'use strict';
+// caption-transcoder — a tiny stateless ffmpeg burn-in service for the
+// viral-video-ad-generator edge function (H3 / muted-autoplay dwell time).
+//
+// Contract (must match supabase/functions/viral-video-ad-generator/captions.ts):
+//   POST /burn  (auth: Authorization: Bearer <API_KEY>  OR  x-api-key: <API_KEY>)
+//     body: { videoUrl, mp4Url, srt, subtitleFormat:"srt", format:"mp4",
+//             resolution:"540p", style:{...}, forceStyle:"FontName=...,FontSize=..." }
+//     -> downloads the mp4, burns the SRT with force_style, and returns { url }
+//        pointing at a short-lived self-served file. The edge function fetches that
+//        url ONCE and re-persists it to Supabase Storage, so the url only needs to
+//        live for a few seconds — no GCS/object store required.
+//   GET /file/:id.mp4  -> streams the burned result (deleted after a short TTL).
+//   GET /healthz       -> ok.
+//
+// Deploy as Cloud Run with --max-instances=1 so the GET /file hits the same
+// instance that produced it (see README). No npm dependencies (plain Node core).
+
+const http = require('http');
+const https = require('https');
+const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const PORT = process.env.PORT || 8080;
+const API_KEY = (process.env.API_KEY || '').trim();
+const PUBLIC_BASE_URL = (process.env.PUBLIC_BASE_URL || '').trim();
+const FILE_TTL_MS = Number(process.env.FILE_TTL_MS || 10 * 60 * 1000);
+const OUT_DIR = path.join(os.tmpdir(), 'caption-out');
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+function authed(req) {
+  if (!API_KEY) return true; // auth optional; set API_KEY to require it
+  const bearer = String(req.headers['authorization'] || '')
+    .replace(/^Bearer\s+/i, '')
+    .trim();
+  const xkey = String(req.headers['x-api-key'] || '').trim();
+  return bearer === API_KEY || xkey === API_KEY;
+}
+
+function download(url, dest, redirects) {
+  return new Promise((resolve, reject) => {
+    if ((redirects || 0) > 5) return reject(new Error('too many redirects'));
+    const mod = url.startsWith('http:') ? http : https;
+    const request = mod.get(url, (resp) => {
+      if (
+        resp.statusCode >= 300 &&
+        resp.statusCode < 400 &&
+        resp.headers.location
+      ) {
+        resp.resume();
+        return download(resp.headers.location, dest, (redirects || 0) + 1).then(
+          resolve,
+          reject,
+        );
+      }
+      if (resp.statusCode !== 200) {
+        resp.resume();
+        return reject(new Error('download status ' + resp.statusCode));
+      }
+      const file = fs.createWriteStream(dest);
+      resp.pipe(file);
+      file.on('finish', () => file.close(() => resolve()));
+      file.on('error', reject);
+    });
+    request.on('error', reject);
+    request.setTimeout(120000, () => request.destroy(new Error('download timeout')));
+  });
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => {
+      data += chunk;
+      if (data.length > 5_000_000) req.destroy(new Error('body too large'));
+    });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function resolutionHeight(resolution) {
+  const match = /(\d{3,4})p/.exec(String(resolution || ''));
+  return match ? parseInt(match[1], 10) : null;
+}
+
+// ffmpeg subtitles filter needs the srt path escaped and force_style single-quoted
+// so its internal commas are not parsed as filtergraph option separators.
+function buildVideoFilter(srtPath, forceStyle, scaleHeight) {
+  const escaped = srtPath.replace(/\\/g, '/').replace(/:/g, '\\:');
+  let sub = 'subtitles=' + escaped;
+  if (forceStyle) sub += ":force_style='" + forceStyle + "'";
+  return scaleHeight ? 'scale=-2:' + scaleHeight + ',' + sub : sub;
+}
+
+function sendJson(res, status, obj) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
+const server = http.createServer(async (req, res) => {
+  const urlPath = req.url.split('?')[0];
+  try {
+    if (req.method === 'GET' && urlPath === '/healthz') {
+      res.writeHead(200);
+      return res.end('ok');
+    }
+
+    if (req.method === 'GET' && urlPath.startsWith('/file/')) {
+      const name = path.basename(urlPath);
+      const filePath = path.join(OUT_DIR, name);
+      if (!filePath.startsWith(OUT_DIR) || !fs.existsSync(filePath)) {
+        res.writeHead(404);
+        return res.end('not found');
+      }
+      res.writeHead(200, { 'Content-Type': 'video/mp4' });
+      return fs.createReadStream(filePath).pipe(res);
+    }
+
+    if (req.method === 'POST' && urlPath === '/burn') {
+      if (!authed(req)) {
+        res.writeHead(401);
+        return res.end('unauthorized');
+      }
+      const body = JSON.parse(await readBody(req));
+      const videoUrl = body.videoUrl || body.mp4Url;
+      const srt = String(body.srt || '');
+      const forceStyle = String(body.forceStyle || '');
+      if (!videoUrl || !srt.trim()) {
+        return sendJson(res, 400, { error: 'missing videoUrl or srt' });
+      }
+
+      const id = crypto.randomBytes(12).toString('hex');
+      const inMp4 = path.join(os.tmpdir(), id + '-in.mp4');
+      const srtFile = path.join(os.tmpdir(), id + '.srt');
+      const outMp4 = path.join(OUT_DIR, id + '.mp4');
+      fs.writeFileSync(srtFile, srt, 'utf8');
+      await download(videoUrl, inMp4);
+
+      const vf = buildVideoFilter(
+        srtFile,
+        forceStyle,
+        resolutionHeight(body.resolution),
+      );
+      const args = [
+        '-y',
+        '-i', inMp4,
+        '-vf', vf,
+        '-c:a', 'copy',
+        '-movflags', '+faststart',
+        outMp4,
+      ];
+      const ff = spawn('ffmpeg', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+      let errTail = '';
+      ff.stderr.on('data', (d) => {
+        errTail = (errTail + d.toString()).slice(-4000);
+      });
+      const code = await new Promise((resolve) => ff.on('close', resolve));
+      fs.unlink(inMp4, () => {});
+      fs.unlink(srtFile, () => {});
+      if (code !== 0 || !fs.existsSync(outMp4)) {
+        return sendJson(res, 500, {
+          error: 'ffmpeg failed',
+          detail: errTail.slice(-500),
+        });
+      }
+      setTimeout(() => fs.unlink(outMp4, () => {}), FILE_TTL_MS);
+
+      const base = PUBLIC_BASE_URL || 'https://' + req.headers.host;
+      return sendJson(res, 200, { url: base + '/file/' + id + '.mp4' });
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  } catch (error) {
+    sendJson(res, 500, { error: String((error && error.message) || error) });
+  }
+});
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log('caption-transcoder listening on ' + PORT);
+  });
+}
+
+// Exported for unit tests (test.js). The server only listens when run directly.
+module.exports = { buildVideoFilter, resolutionHeight, authed };

--- a/services/caption-transcoder/test.js
+++ b/services/caption-transcoder/test.js
@@ -1,0 +1,32 @@
+'use strict';
+// Black-box unit tests for the pure helpers (no ffmpeg / network needed).
+// Run: node test.js
+const assert = require('assert');
+const { buildVideoFilter, resolutionHeight, authed } = require('./server.js');
+
+let passed = 0;
+function ok(name, cond) {
+  assert.ok(cond, name);
+  passed += 1;
+}
+
+// resolutionHeight: parses "540p" -> 540, ignores junk.
+ok('540p -> 540', resolutionHeight('540p') === 540);
+ok('1080p -> 1080', resolutionHeight('1080p') === 1080);
+ok('empty -> null', resolutionHeight('') === null);
+ok('garbage -> null', resolutionHeight('abc') === null);
+
+// buildVideoFilter: force_style single-quoted so its commas are literal; scale prefixed.
+const fs1 = buildVideoFilter('/tmp/x.srt', 'FontName=Noto Sans CJK JP,FontSize=22', 540);
+ok('scale prefixed', fs1.startsWith('scale=-2:540,'));
+ok('subtitles present', fs1.includes('subtitles=/tmp/x.srt'));
+ok('force_style single-quoted', fs1.includes(":force_style='FontName=Noto Sans CJK JP,FontSize=22'"));
+
+const fs2 = buildVideoFilter('/tmp/x.srt', '', null);
+ok('no scale when height null', !fs2.includes('scale='));
+ok('no force_style when empty', !fs2.includes('force_style'));
+
+// authed: with no API_KEY configured, everything is allowed (env-driven; here unset).
+ok('auth open when no key', authed({ headers: {} }) === true);
+
+console.log('caption-transcoder tests passed: ' + passed);


### PR DESCRIPTION
## 目的
インプレッション改善レバー **H3=動画字幕の有効化**（ユーザー選択・最大効果）。Xの動画はミュート自動再生が大半→**オンスクリーン字幕で視聴完了率(dwell time=リーチ最大シグナル)を伸ばす**。焼き込みロジックは #3807 で実装済みだが `VVAG_BURN_CAPTIONS` 既定OFFで休眠中。Deno Edge Function は ffmpeg をプロセス内実行できないため、焼き込みを担う小さな外部サービスを追加する。

## 追加物（`services/caption-transcoder/` 新規のみ・既存コード不変更）
- `server.js`: 依存なしの Node サービス。`viral-video-ad-generator/captions.ts` の**正確なコントラクトに一致**＝`POST /burn { videoUrl, srt, forceStyle, resolution, style }` → ffmpeg の `subtitles + force_style` で焼き込み → `{ url }`。EF が返却URLを**即 Supabase Storage へ再保存**するので自己配信の一時URLで足り、**GCS等のオブジェクトストア不要**。全失敗で素のmp4へフォールバック（投稿を絶対にブロックしない）。
- `Dockerfile`: `ffmpeg` + `fonts-noto-cjk`（日本語字幕がtofuにならないよう同梱）。
- `test.js`: 純関数(force_style単一引用符化・解像度パース・認可)の黒箱ユニットテスト（`node test.js` = 10 green）。
- `README.md`: **1コマンドの Cloud Run デプロイ + 有効化3設定 + 検証/kill-switch**手順。

## 有効化（ユーザー操作 / README詳細）
1. `gcloud run deploy caption-transcoder --source . --max-instances 1 ...`（scale-to-zeroで低volumeはほぼ無料）
2. Supabase 側で `VVAG_BURN_CAPTIONS=1` + transcoderのURL/キーを設定
3. 動画1本生成→ログ `[vvag-caption] burned OK` と `-captioned.mp4` を確認

本PRは**コード追加のみ**でCIデプロイ対象外（サービスはユーザーが手動デプロイ）。既定OFFのままなら本番挙動は不変。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: New standalone Cloud Run service (services/) with node test.js pure-helper unit tests (10 green); it is deployed manually by the operator, not by CI, and touches no app runtime path, so a Flutter/Playwright E2E is not applicable.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: New services/ Cloud Run helper only; touches no supabase/functions, migration, or app runtime path; gate tripped on prose keywords (Supabase/Storage/deploy) describing the manual ops setup; behavior stays default-off; node test.js 10 green.
