### PR TITLE
fix(x-share): stop raw poll JSON leaking into replies; recover nested poll; dedupe OG cards

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -327,9 +327,12 @@ class UniversalXShareService {
         ? ''
         : sanitizeTweet(poll.question, url: textUrl, requireUrl: false).trim();
     final hasPoll = pollPayload != null && pollQuestion.isNotEmpty;
-    final replyTexts = hasPoll
-        ? <String>[pollQuestion, ...parts.replyTexts]
-        : parts.replyTexts;
+    final replyTexts = assembleReplyTexts(
+      partsReplyTexts: parts.replyTexts,
+      pollQuestion: pollQuestion,
+      hasPoll: hasPoll,
+      linkInReply: linkInReply,
+    );
     final data = await _invoke('growth-hub', {
       'action': 'x.post',
       'text': mainText,
@@ -363,6 +366,36 @@ class UniversalXShareService {
           : const [],
       raw: data,
     );
+  }
+
+  /// growth-hub x.post は replyTexts を slice(0, 8) で切り捨てる。poll 質問の
+  /// 前置(+1)と URL 入り最終 CTA(+1)で 8 を超えると、サーバ側が末尾 = CTA
+  /// (link-in-reply 時は投稿全体で唯一の商品 URL)を黙って落とす。クライアント
+  /// 側で同じ上限を適用しつつ、溢れは末尾側の分析リプライから落として CTA を
+  /// 必ず残す。合計 8 件以下のときは従来と同一のパススルー。
+  static const int _serverReplyCap = 8; // growth-hub の slice(0, 8) と一致
+
+  static List<String> assembleReplyTexts({
+    required List<String> partsReplyTexts,
+    required String pollQuestion,
+    required bool hasPoll,
+    required bool linkInReply,
+  }) {
+    final base = <String>[if (hasPoll) pollQuestion, ...partsReplyTexts];
+    if (base.length <= _serverReplyCap) return base;
+    if (linkInReply && partsReplyTexts.isNotEmpty) {
+      // buildManualShareParts は linkInReply=true のとき URL 入り CTA を必ず
+      // 末尾に置くので .last が CTA。溢れた分は CTA 直前の分析リプを落とす。
+      final budget = _serverReplyCap - (hasPoll ? 1 : 0);
+      final analysis = partsReplyTexts.sublist(0, partsReplyTexts.length - 1);
+      final cta = partsReplyTexts.last;
+      return <String>[
+        if (hasPoll) pollQuestion,
+        ...analysis.take(budget - 1),
+        cta,
+      ];
+    }
+    return base.take(_serverReplyCap).toList(growable: false);
   }
 
   /// Normalizes an optional [UniversalXPoll] into the growth-hub wire shape
@@ -435,8 +468,16 @@ class UniversalXShareService {
           )
         : sanitizeTweet(baseText, url: textUrl);
     final replyTexts = <String>[
+      // linkInReply では URL を最終 CTA リプライだけに載せる。LLM が自リプへ
+      // 製品 URL を含めると OG カードが複数リプで重複表示されるため剥がす。
       ...threadReplies
-          .map((entry) => sanitizeTweet(entry, url: textUrl, requireUrl: false))
+          .map(
+            (entry) => sanitizeTweet(
+              linkInReply ? _removeUrl(entry, textUrl) : entry,
+              url: textUrl,
+              requireUrl: false,
+            ),
+          )
           .where((entry) => entry.trim().isNotEmpty),
       if (linkInReply)
         sanitizeTweet(
@@ -1032,6 +1073,15 @@ $url''';
     return next.replaceAll(RegExp(r'\n{3,}'), '\n\n').trim();
   }
 
+  /// 全体がオブジェクト/配列リテラルの文字列(=二重エンコードされた JSON や
+  /// Map/List.toString() のダンプ)かどうか。先頭と末尾の両方に括弧を要求する
+  /// ので、「手順は {設定→実行→確認} の3段階」のような日本語散文は落ちない。
+  static bool _looksLikeSerializedObject(String s) {
+    final t = s.trim();
+    return (t.startsWith('{') && t.endsWith('}')) ||
+        (t.startsWith('[') && t.endsWith(']'));
+  }
+
   Future<Map<String, dynamic>> _invoke(
     String functionName,
     Map<String, dynamic> body,
@@ -1078,19 +1128,34 @@ $url''';
             : decoded['thread'] is List
                 ? decoded['thread'] as List
                 : const [];
-        final threadReplies = rawThreadReplies
-            .map(
-              (entry) => sanitizeTweet(
-                entry.toString(),
-                url: shareUrl,
-                requireUrl: false,
-              ),
-            )
-            .where((entry) => entry.trim().isNotEmpty)
-            // プロンプトは 5-8 リプライを要求。各リプライは独自にインプレッションを
-            // 稼ぐので 6 で切らず 8 まで通す(サーバ側も slice(0,8))。
-            .take(8)
-            .toList(growable: false);
+        // LLM が threadReplies の要素へ poll 等のオブジェクトを紛れ込ませることが
+        // ある(実害: Map.toString() の生テキスト `{text: , poll: {...}}` がその
+        // ままリプ投稿された)。文字列以外を無条件 toString() せず、Map からは
+        // poll を回収してトップレベル poll 欠落時の代わりに使い、text は非空の
+        // 文字列のときだけ採用する。その他の型は破棄する。
+        UniversalXPoll? recoveredPoll;
+        final threadReplies = <String>[];
+        for (final entry in rawThreadReplies) {
+          String? line;
+          if (entry is String) {
+            line = entry;
+          } else if (entry is Map) {
+            recoveredPoll ??= _parsePoll(entry['poll']);
+            final text = entry['text'];
+            if (text is String) line = text;
+          }
+          if (line == null) continue;
+          final sanitized =
+              sanitizeTweet(line, url: shareUrl, requireUrl: false);
+          if (sanitized.trim().isEmpty) continue;
+          // 二重エンコード({"text": …} を JSON 文字列として返す drift)対策:
+          // 全体がオブジェクト/配列リテラルの文字列は散文ではないので捨てる。
+          if (_looksLikeSerializedObject(sanitized)) continue;
+          threadReplies.add(sanitized);
+          // プロンプトは 5-8 リプライを要求。各リプライは独自にインプレッションを
+          // 稼ぐので 6 で切らず 8 まで通す(サーバ側も slice(0,8))。
+          if (threadReplies.length >= 8) break;
+        }
         return UniversalXShareDraft(
           text: text,
           imagePrompt:
@@ -1104,7 +1169,9 @@ $url''';
           hashtags: hashtags,
           threadReplies:
               threadReplies.isNotEmpty ? threadReplies : fallback.threadReplies,
-          poll: _parsePoll(decoded['poll']) ?? fallback.poll,
+          // トップレベル poll が正だが、threadReplies 内へ迷い込んだ poll も
+          // 回収して native 投票を復元する(生テキスト漏出の再発防止とセット)。
+          poll: _parsePoll(decoded['poll']) ?? recoveredPoll ?? fallback.poll,
           fallbackUsed: true,
           source: 'ai-json',
         );
@@ -1182,7 +1249,7 @@ Secondary goal: earn useful impressions without sounding like spam.
 Return valid JSON only:
 {
   "text": "Japanese X post, a rich 400-900 char long-form lead (this account has X Premium so it is NOT limited to 280 chars), must include $shareUrl",
-  "threadReplies": ["4 to 8 substantive Japanese reply posts, each 150-500 chars, forming a full briefing thread"],
+  "threadReplies": ["4 to 8 substantive Japanese reply posts, each 150-500 chars, forming a full briefing thread. PLAIN STRINGS ONLY - never JSON objects"],
   "imagePrompt": "English prompt for a 16:9 share image, no text overlay",
   "videoPrompt": "English prompt for a short presenter/share video",
   "hashtags": ["#buildinpublic", "#FlutterWeb", "#Supabase"],
@@ -1222,8 +1289,9 @@ Rules:
 - Provide a FULL briefing thread: 5-8 substantive threadReplies that each add real analysis (状況/背景/なぜ重要か/仕事への活かし方/次の一手), not one-liners.
 - Format for scannability: break the lead and each reply into short one-idea lines with a blank line between meaning-chunks (no wall-of-text paragraph). Put labels (なぜ重要か / 見通し / 次の一手 など) at the start of a line and continue the explanation on the next line, so a reader can skim in 2 seconds.
 - Cap emoji at 1-2 per post and do NOT decorate every line (emoji spam and full-line decoration trigger spam down-ranking). Number only replies 2 onward. Optionally add ONE short, non-templated thread-continuation cue (e.g. "🧵つづく") just before the lead's CTA/URL, varying the wording day to day so it is never identical.
-- The FIRST reply must stand alone as its own scroll-stopping hook: one sharp claim + why it matters + a reply-provoking question, fully readable with zero context from the lead post. Do NOT repeat the lead hook verbatim and do NOT phrase it as "1つ目/item 1 of N". Replies 2 onward then form the numbered briefing.
+- The FIRST reply must stand alone as its own scroll-stopping hook: one sharp claim + why it matters + a reply-provoking question, fully readable with zero context from the lead post. Do NOT repeat the lead hook verbatim, do NOT phrase it as "1つ目/item 1 of N", and do NOT begin it with a number or list marker (never start with "1."). Replies 2 onward then form the numbered briefing.
 - Native poll (impressions booster): when today's top headline supports a crisp either/or, ranking, or opinion question, include a "poll" object with a short Japanese "question" and 2-4 "options" (each <=25 chars). X natively boosts impressions and early engagement on poll tweets.
+- The "poll" must be a TOP-LEVEL JSON key only. NEVER place a poll object (or any JSON object) inside the threadReplies array — every threadReplies element must be a plain Japanese string, or it will be posted as raw garbage text.
 - DERIVE the poll question AND options from THE DAY'S single most relevant headline so the poll rotates daily and is specific — NEVER reuse a generic or hardcoded poll like "使ってみたい?はい/いいえ" (near-duplicate polls get down-ranked). Yesterday's poll must not be reusable today.
 - The poll is posted as its own FIRST text-only thread reply (never on the media lead), so make the "question" self-contained. If no natural, honest poll fits today's news, OMIT the "poll" field entirely rather than forcing a weak one.
 - Treat the creative workflow as GPT image -> GPT-5.5 -> ElevenLabs -> Hedra.

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -278,6 +278,163 @@ void main() {
     expect(capturedPrompt, contains('utm_content=daily_briefing'));
   });
 
+  test('generateDraft recovers a poll leaked inside threadReplies', () async {
+    // 実障害: LLM が poll をトップレベルでなく threadReplies の要素(オブジェクト)
+    // に入れ、Map.toString() の生テキスト `{text: , poll: {...}}` がそのまま
+    // リプ投稿された。オブジェクトは文字列化せず、poll は回収して native 投票を
+    // 復元し、text は非空文字列のときだけ採用する。
+    final chat = AiHubChatService(
+      invoker: (body) async => {
+        'success': true,
+        'provider': 'groq',
+        'text': '''
+{
+  "text": "AI大学をアップデートしました。\\n${page.url}\\n#buildinpublic",
+  "imagePrompt": "16:9 product UI share image",
+  "videoPrompt": "short presenter video",
+  "hashtags": ["#buildinpublic"],
+  "threadReplies": [
+    {"text": "", "poll": {"question": "AI導入、どこに壁を感じますか？", "options": ["開発の複雑性", "データの整理", "人材不足", "期待値ギャップ"], "durationMinutes": 1440}},
+    "現状の解説です。なぜ重要か: 明日の判断材料になるからです。",
+    "背景の解説です。"
+  ]
+}
+''',
+      },
+    );
+    final service = UniversalXShareService(
+      chatService: chat,
+      functionInvoker: (functionName, body) async => {'success': true},
+    );
+
+    final draft = await service.generateDraft(page);
+
+    expect(draft.fallbackUsed, isFalse);
+    // 生オブジェクトのテキスト漏出が一切ないこと。
+    for (final reply in draft.threadReplies) {
+      expect(reply, isNot(contains('{text')));
+      expect(reply, isNot(contains('durationMinutes')));
+    }
+    expect(draft.threadReplies.length, 2);
+    // 迷い込んだ poll をトップレベル poll として回収できていること。
+    expect(draft.poll, isNotNull);
+    expect(draft.poll!.question, 'AI導入、どこに壁を感じますか？');
+    expect(draft.poll!.options.length, 4);
+  });
+
+  test('generateDraft drops non-string junk threadReplies entries', () async {
+    final chat = AiHubChatService(
+      invoker: (body) async => {
+        'success': true,
+        'provider': 'groq',
+        'text': '''
+{
+  "text": "AI大学をアップデートしました。\\n${page.url}\\n#buildinpublic",
+  "imagePrompt": "16:9 product UI share image",
+  "videoPrompt": "short presenter video",
+  "hashtags": ["#buildinpublic"],
+  "threadReplies": [123, ["a", "b"], {"foo": "bar"}]
+}
+''',
+      },
+    );
+    final service = UniversalXShareService(
+      chatService: chat,
+      functionInvoker: (functionName, body) async => {'success': true},
+    );
+
+    final draft = await service.generateDraft(page);
+
+    // 文字列以外は全て破棄され(空なら fallback リプへ)、生テキスト漏出がない。
+    for (final reply in draft.threadReplies) {
+      expect(reply, isNot(contains('foo')));
+      expect(reply, isNot(contains('[a')));
+      expect(reply, isNot(contains('123')));
+    }
+  });
+
+  test('buildManualShareParts keeps the product URL only on the final reply',
+      () {
+    // LLM が自リプへ製品 URL を含めると OG カードが複数リプで重複表示される
+    // (実機で同一カードが2連続)。linkInReply ではリプ本文から URL を剥がし、
+    // URL は最終 CTA リプライだけに載せる。
+    final parts = UniversalXShareService.buildManualShareParts(
+      context: page,
+      text: 'リード本文\n${page.url}',
+      threadReplies: <String>[
+        'ポイント解説です。',
+        '締めです。詳しくは ${page.url} を見てください。',
+      ],
+      linkInReply: true,
+    );
+
+    expect(parts.replyTexts.length, 3);
+    // 中間リプに URL が残らない(重複 OG カード防止)。
+    expect(parts.replyTexts[0], isNot(contains('my-web-app')));
+    expect(parts.replyTexts[1], isNot(contains('my-web-app')));
+    // URL は最終 CTA リプライのみ。
+    expect(parts.replyTexts.last, contains(parts.textUrl));
+  });
+
+  test('assembleReplyTexts keeps the URL CTA when poll+replies exceed 8', () {
+    // growth-hub は replyTexts を slice(0,8) で切る。poll 質問(+1)と最終
+    // CTA(+1)で 8 を超えると、素通しではサーバ側で CTA(唯一の商品 URL)が
+    // 黙って落ちる。溢れは CTA 直前の分析リプから落とし CTA を必ず残す。
+    final analysis = List<String>.generate(8, (i) => '分析リプライ${i + 1}です。');
+    final partsReplies = <String>[...analysis, 'CTAです。\nhttps://example.com/x'];
+
+    final capped = UniversalXShareService.assembleReplyTexts(
+      partsReplyTexts: partsReplies,
+      pollQuestion: 'どこに壁を感じますか？',
+      hasPoll: true,
+      linkInReply: true,
+    );
+
+    expect(capped.length, 8);
+    expect(capped.first, 'どこに壁を感じますか？');
+    expect(capped.last, contains('https://example.com/x'));
+
+    // 8 件以下は従来と同一のパススルー。
+    final passthrough = UniversalXShareService.assembleReplyTexts(
+      partsReplyTexts: const ['a', 'b'],
+      pollQuestion: '',
+      hasPoll: false,
+      linkInReply: true,
+    );
+    expect(passthrough, const ['a', 'b']);
+  });
+
+  test('generateDraft drops double-encoded JSON string replies', () async {
+    final chat = AiHubChatService(
+      invoker: (body) async => {
+        'success': true,
+        'provider': 'groq',
+        'text': '''
+{
+  "text": "AI大学をアップデートしました。\\n${page.url}\\n#buildinpublic",
+  "imagePrompt": "16:9 product UI share image",
+  "videoPrompt": "short presenter video",
+  "hashtags": ["#buildinpublic"],
+  "threadReplies": [
+    "{\\"text\\": \\"\\", \\"poll\\": {\\"question\\": \\"Q\\"}}",
+    "手順は {設定→実行→確認} の3段階で進めると迷いません。"
+  ]
+}
+''',
+      },
+    );
+    final service = UniversalXShareService(
+      chatService: chat,
+      functionInvoker: (functionName, body) async => {'success': true},
+    );
+
+    final draft = await service.generateDraft(page);
+
+    // オブジェクトリテラル全体の文字列は捨てるが、括弧を含む日本語散文は残す。
+    expect(draft.threadReplies.length, 1);
+    expect(draft.threadReplies.first, contains('3段階'));
+  });
+
   test('postToX forwards optional media URL to growth-hub', () async {
     Map<String, dynamic>? capturedBody;
     String? capturedFunction;


### PR DESCRIPTION
## 実機障害（2026-07-05 の実投稿スクショ）
1. リプライに **生オブジェクトのテキスト** `{text: , poll: {question: …, options: […], durationMinutes: 1440}}` がそのまま投稿された
2. **ネイティブ投票が未添付**（投票カードがどこにも出ない）
3. 同一の OG カードが **2連続リプで重複** 表示

## 真因（10仮説×敵対的検証Workflowで10/10確定）
- LLM が poll を **トップレベルでなく threadReplies の要素（オブジェクト）** に入れた → `_parseDraft` が **無条件 `entry.toString()`** で Dart Map のダンプをリプ本文化＋トップレベル poll 不在で native 投票も不成立
- LLM が自リプへ製品 URL を含め、最終 CTA リプの URL と合わせて **OG カードが2枚** 出た
- 追加発見: growth-hub は replyTexts を **slice(0,8)** で切るため、poll 質問(+1)+最終 CTA(+1) で 8 超過時に **唯一の製品 URL を持つ CTA がサーバ側で黙って落ちる**

## 修正（Dart のみ・2ファイル）
1. **型安全パース**: threadReplies は文字列のみ採用。Map からは `_parsePoll` で **迷い込んだ poll を回収**（トップレベル欠落時の代替）＋ `text` は非空文字列のみ。その他の型は破棄。**全体が `{…}`/`[…]` リテラルの文字列**（二重エンコード）も破棄（括弧を含む日本語散文は落ちない判定）。
2. **OG カード重複解消**: `buildManualShareParts` が linkInReply 時にリプ本文から製品 URL を剥がし、URL は最終 CTA リプのみに。
3. **CTA 保全 cap**: `assembleReplyTexts` がサーバ上限 8 に収めつつ **poll 質問=先頭・URL 入り CTA=末尾** を必ず保持（溢れは CTA 直前の分析リプから落とす）。8 件以下は従来と同一。
4. **プロンプト強化**: threadReplies は**プレーン文字列のみ**／poll は**トップレベルのみ**／先頭リプは**番号で始めない**を明示。

## 検証
`flutter test` → **40件全パス**（新規6: 漏出回収・junk破棄・二重エンコード破棄・URL重複解消・cap時CTA保持・8件以下パススルー）。

## インプレッション観点
生 JSON リプ＝アカウントの信頼毀損（スパムシグナル）、投票不成立＝ #3808 の効果喪失、カード重複＝near-duplicate。いずれも即時修正が妥当。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Dart-only parser/assembly hardening covered by 6 new black-box flutter unit cases (40 green) asserting no leaked object text, nested-poll recovery, URL dedupe, and cap-keeps-CTA; no new user-facing route, so a full integration_test flow is disproportionate.
