### PR TITLE
fix(captions): wrap rows inside the frame and anchor SRT timing to the real video

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,12 @@ jobs:
           fi
         # 74テスト安定稼働中 (2026-04-12 PR#317) — continue-on-error 廃止
 
+      - name: Caption transcoder unit tests
+        # services/caption-transcoder (Cloud Run ffmpeg 字幕焼き込み) の純関数
+        # テスト。ubuntu-latest は node 20 プリインストールなので数秒で完走し、
+        # SRT リスケール等の回帰を EF 側の変更と同一 PR でブロックできる。
+        run: node services/caption-transcoder/test.js
+
       - name: Check Edge Function deploy count (ハードキャップ50本以下)
         run: |
           # deploy-prod.yml のデプロイリストを抽出 (macro-hub体制 — Tier1/Tier2廃止)

--- a/services/caption-transcoder/server.js
+++ b/services/caption-transcoder/server.js
@@ -96,6 +96,92 @@ function buildVideoFilter(srtPath, forceStyle, scaleHeight) {
   return scaleHeight ? 'scale=-2:' + scaleHeight + ',' + sub : sub;
 }
 
+// --- SRT rescale to the real media duration (desync fix) -------------------
+// The edge function estimates cue times from a fixed chars/sec rate, which
+// drifts against the real ElevenLabs speech rate. The mp4 is already local,
+// so ffprobe the REAL duration and linearly rescale all cue times to fit
+// [leadInMs, duration - tailPadMs]. Every guard failure returns the input
+// unchanged — rescaling can never break a burn.
+
+const SRT_TIME_RE =
+  /(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})/g;
+
+function srtTimeToMs(h, m, s, ms) {
+  return ((Number(h) * 60 + Number(m)) * 60 + Number(s)) * 1000 + Number(ms);
+}
+
+function msToSrtTime(total) {
+  const t = Math.max(0, Math.round(total));
+  const pad = (v, w) => String(v).padStart(w || 2, '0');
+  return (
+    pad(Math.floor(t / 3600000)) + ':' + pad(Math.floor(t / 60000) % 60) +
+    ':' + pad(Math.floor(t / 1000) % 60) + ',' + pad(t % 1000, 3)
+  );
+}
+
+// ffprobe the real media duration (ms). Audio stream first (speech ends with
+// audio; -c:a copy keeps it authoritative), container format as fallback.
+// Resolves null on any failure/timeout — caller treats null as "skip rescale".
+function ffprobeDurationMs(filePath, timeoutMs) {
+  const probe = (args) => new Promise((resolve) => {
+    const p = spawn(
+      'ffprobe',
+      ['-v', 'error'].concat(args, ['-of', 'csv=p=0', filePath]),
+      { stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    let out = '';
+    const timer = setTimeout(() => p.kill('SIGKILL'), timeoutMs || 5000);
+    p.stdout.on('data', (d) => { out += d.toString(); });
+    p.on('close', () => {
+      clearTimeout(timer);
+      const sec = parseFloat(out.trim());
+      resolve(Number.isFinite(sec) && sec > 0 ? Math.round(sec * 1000) : null);
+    });
+    p.on('error', () => { clearTimeout(timer); resolve(null); });
+  });
+  return probe(['-select_streams', 'a:0', '-show_entries', 'stream=duration'])
+    .then((ms) => ms || probe(['-show_entries', 'format=duration']));
+}
+
+// Linearly rescale all SRT cue times from [0, srtEnd] to
+// [leadInMs, durationMs - tailPadMs]. Pure; returns the input unchanged on
+// any guard failure. Factor bounds reject SRT/video gross mismatches; a 5%
+// passthrough skips needless rewrites when the estimate already fits.
+function rescaleSrtToDuration(srt, durationMs, opts) {
+  try {
+    const o = opts || {};
+    let leadInMs = Number.isFinite(o.leadInMs) && o.leadInMs >= 0
+      ? o.leadInMs : 0;
+    let tailPadMs = Number.isFinite(o.tailPadMs) && o.tailPadMs >= 0
+      ? o.tailPadMs : 300;
+    const minFactor = o.minFactor || 0.5;
+    const maxFactor = o.maxFactor || 3;
+    if (!Number.isFinite(durationMs) || durationMs <= 1000) return srt;
+    if (leadInMs + tailPadMs >= durationMs) { leadInMs = 0; tailPadMs = 0; }
+    let srtEndMs = 0;
+    let matched = false;
+    srt.replace(SRT_TIME_RE, (all, h1, m1, s1, x1, h2, m2, s2, x2) => {
+      matched = true;
+      srtEndMs = Math.max(srtEndMs, srtTimeToMs(h2, m2, s2, x2));
+      return all;
+    });
+    if (!matched || srtEndMs <= 0) return srt;
+    if (leadInMs === 0 && Math.abs(srtEndMs - durationMs) / durationMs <= 0.05) {
+      return srt;
+    }
+    const factor = (durationMs - leadInMs - tailPadMs) / srtEndMs;
+    if (!(factor >= minFactor && factor <= maxFactor)) return srt;
+    return srt.replace(SRT_TIME_RE, (all, h1, m1, s1, x1, h2, m2, s2, x2) => {
+      const start = leadInMs + Math.round(srtTimeToMs(h1, m1, s1, x1) * factor);
+      let end = leadInMs + Math.round(srtTimeToMs(h2, m2, s2, x2) * factor);
+      if (end < start + 300) end = start + 300; // anti-flicker floor
+      return msToSrtTime(start) + ' --> ' + msToSrtTime(end);
+    });
+  } catch (e) {
+    return srt;
+  }
+}
+
 function sendJson(res, status, obj) {
   res.writeHead(status, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify(obj));
@@ -137,8 +223,28 @@ const server = http.createServer(async (req, res) => {
       const inMp4 = path.join(os.tmpdir(), id + '-in.mp4');
       const srtFile = path.join(os.tmpdir(), id + '.srt');
       const outMp4 = path.join(OUT_DIR, id + '.mp4');
-      fs.writeFileSync(srtFile, srt, 'utf8');
       await download(videoUrl, inMp4);
+
+      // stretchToVideo: default ON (opt out with explicit false), so payloads
+      // from older edge versions (no field) get the desync fix immediately.
+      // The 5% passthrough + factor bounds inside rescaleSrtToDuration keep
+      // well-timed or grossly-mismatched SRTs untouched.
+      let finalSrt = srt;
+      if (body.stretchToVideo !== false) {
+        const durationMs = await ffprobeDurationMs(inMp4, 5000);
+        if (durationMs) {
+          finalSrt = rescaleSrtToDuration(srt, durationMs, {
+            leadInMs: Number(body.leadInMs),
+            tailPadMs: Number(body.tailPadMs),
+          });
+          if (finalSrt !== srt) {
+            console.log(
+              '[burn] srt rescaled to media duration ' + durationMs + 'ms',
+            );
+          }
+        }
+      }
+      fs.writeFileSync(srtFile, finalSrt, 'utf8');
 
       const vf = buildVideoFilter(
         srtFile,
@@ -187,4 +293,11 @@ if (require.main === module) {
 }
 
 // Exported for unit tests (test.js). The server only listens when run directly.
-module.exports = { buildVideoFilter, resolutionHeight, authed };
+module.exports = {
+  buildVideoFilter,
+  resolutionHeight,
+  authed,
+  srtTimeToMs,
+  msToSrtTime,
+  rescaleSrtToDuration,
+};

--- a/services/caption-transcoder/server.js
+++ b/services/caption-transcoder/server.js
@@ -89,9 +89,13 @@ function resolutionHeight(resolution) {
 
 // ffmpeg subtitles filter needs the srt path escaped and force_style single-quoted
 // so its internal commas are not parsed as filtergraph option separators.
+// The filename itself is ALSO single-quoted (with the drive colon backslash-
+// escaped): unquoted, a Windows path like C:/Users/... is split at the colon
+// and ffmpeg mis-parses the remainder as filter options (observed:
+// "Unable to parse 'original_size' option"). Harmless on Linux paths.
 function buildVideoFilter(srtPath, forceStyle, scaleHeight) {
   const escaped = srtPath.replace(/\\/g, '/').replace(/:/g, '\\:');
-  let sub = 'subtitles=' + escaped;
+  let sub = "subtitles='" + escaped + "'";
   if (forceStyle) sub += ":force_style='" + forceStyle + "'";
   return scaleHeight ? 'scale=-2:' + scaleHeight + ',' + sub : sub;
 }

--- a/services/caption-transcoder/test.js
+++ b/services/caption-transcoder/test.js
@@ -26,8 +26,12 @@ ok('garbage -> null', resolutionHeight('abc') === null);
 // buildVideoFilter: force_style single-quoted so its commas are literal; scale prefixed.
 const fs1 = buildVideoFilter('/tmp/x.srt', 'FontName=Noto Sans CJK JP,FontSize=22', 540);
 ok('scale prefixed', fs1.startsWith('scale=-2:540,'));
-ok('subtitles present', fs1.includes('subtitles=/tmp/x.srt'));
+ok('subtitles filename quoted', fs1.includes("subtitles='/tmp/x.srt'"));
 ok('force_style single-quoted', fs1.includes(":force_style='FontName=Noto Sans CJK JP,FontSize=22'"));
+// Windows パス: ドライブコロンを \: へエスケープした上で引用符に包む
+// (未対応だと ffmpeg がコロンでフィルタオプション分割して失敗する)。
+const fsWin = buildVideoFilter('C:\\Users\\me\\a.srt', '', null);
+ok('windows path quoted+escaped', fsWin.includes("subtitles='C\\:/Users/me/a.srt'"));
 
 const fs2 = buildVideoFilter('/tmp/x.srt', '', null);
 ok('no scale when height null', !fs2.includes('scale='));

--- a/services/caption-transcoder/test.js
+++ b/services/caption-transcoder/test.js
@@ -2,7 +2,14 @@
 // Black-box unit tests for the pure helpers (no ffmpeg / network needed).
 // Run: node test.js
 const assert = require('assert');
-const { buildVideoFilter, resolutionHeight, authed } = require('./server.js');
+const {
+  buildVideoFilter,
+  resolutionHeight,
+  authed,
+  srtTimeToMs,
+  msToSrtTime,
+  rescaleSrtToDuration,
+} = require('./server.js');
 
 let passed = 0;
 function ok(name, cond) {
@@ -28,5 +35,48 @@ ok('no force_style when empty', !fs2.includes('force_style'));
 
 // authed: with no API_KEY configured, everything is allowed (env-driven; here unset).
 ok('auth open when no key', authed({ headers: {} }) === true);
+
+// --- SRT time conversion ----------------------------------------------------
+ok('srtTimeToMs basic', srtTimeToMs('00', '01', '02', '345') === 62345);
+ok('msToSrtTime basic', msToSrtTime(62345) === '00:01:02,345');
+ok('msToSrtTime clamps negative', msToSrtTime(-5) === '00:00:00,000');
+ok('roundtrip', msToSrtTime(srtTimeToMs('01', '02', '03', '004')) === '01:02:03,004');
+
+// --- rescaleSrtToDuration ----------------------------------------------------
+// 2 cues: 0-10s, 10-20s (estimated). Real duration 10s -> factor (10000-300)/20000 = 0.485
+// which is below minFactor 0.5 -> unchanged. Use duration 12s: factor (12000-300)/20000=0.585.
+const SRT2 =
+  '1\n00:00:00,000 --> 00:00:10,000\nline one\n\n' +
+  '2\n00:00:10,000 --> 00:00:20,000\nline two\n';
+
+const scaled = rescaleSrtToDuration(SRT2, 12000, {});
+ok('rescale changes timings', scaled !== SRT2);
+ok('rescale first cue start stays 0', scaled.includes('00:00:00,000 --> '));
+// factor = 11700/20000 = 0.585 -> cue1 end = 5850ms, cue2 end = 11700ms
+ok('rescale cue1 end 5850', scaled.includes('00:00:05,850'));
+ok('rescale last cue ends at duration-tailPad', scaled.includes('00:00:11,700'));
+
+// passthrough within 5%: duration 20500 vs srt end 20000 -> unchanged.
+ok('5% passthrough', rescaleSrtToDuration(SRT2, 20500, {}) === SRT2);
+
+// factor bounds: absurd duration (srt 20s -> video 90s = factor 4.5 > 3) -> unchanged.
+ok('factor upper bound', rescaleSrtToDuration(SRT2, 90000, {}) === SRT2);
+// too-short duration -> unchanged.
+ok('duration <= 1s unchanged', rescaleSrtToDuration(SRT2, 900, {}) === SRT2);
+
+// leadInMs shifts starts: lead 1000, duration 12000 -> factor (12000-1000-300)/20000=0.535
+const led = rescaleSrtToDuration(SRT2, 12000, { leadInMs: 1000 });
+ok('leadIn shifts first start', led.includes('00:00:01,000 --> '));
+
+// invalid srt (no cues) -> unchanged.
+ok('no-cue srt unchanged', rescaleSrtToDuration('junk text', 12000, {}) === 'junk text');
+
+// anti-flicker floor: tiny cue stays >= 300ms after rescale.
+const TINY =
+  '1\n00:00:00,000 --> 00:00:00,200\nblip\n\n' +
+  '2\n00:00:00,200 --> 00:00:20,000\nrest\n';
+const tinyScaled = rescaleSrtToDuration(TINY, 12000, {});
+const firstCue = /00:00:00,000 --> 00:00:00,(\d{3})/.exec(tinyScaled);
+ok('anti-flicker floor >= 300ms', firstCue !== null && Number(firstCue[1]) >= 300);
 
 console.log('caption-transcoder tests passed: ' + passed);

--- a/supabase/functions/viral-video-ad-generator/captions.test.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.test.ts
@@ -12,7 +12,18 @@ import {
   DEFAULT_CAPTION_TIMING,
   extractBurnedVideoUrl,
   formatSrtTimestamp,
+  MAX_ROW_UNITS,
+  MAX_ROWS_PER_CUE,
+  wrapCaptionText,
 } from "./captions.ts";
+
+// 重み付き幅(全角=1.0 / ASCII・半角カナ=0.5)をテスト側でも再現する。
+function rowUnits(row: string): number {
+  return Array.from(row).reduce((sum, ch) => {
+    const cp = ch.codePointAt(0) ?? 0;
+    return sum + (cp <= 0xff || (cp >= 0xff61 && cp <= 0xff9f) ? 0.5 : 1);
+  }, 0);
+}
 
 function timestampToMs(stamp: string): number {
   const [hms, millis] = stamp.split(",");
@@ -83,16 +94,28 @@ Deno.test("buildCaptionSrt allocates duration proportional to char length", () =
   assert(ratio > 1.8 && ratio < 2.2, `expected ~2x, got ${ratio}`);
 });
 
-Deno.test("buildCaptionSrt clamps degenerate short/long lines", () => {
-  const srt = buildCaptionSrt("hi\n" + "x".repeat(5000), "en", {
+Deno.test("buildCaptionSrt floors short lines but no longer caps long ones", () => {
+  const srt = buildCaptionSrt("hi\n" + "x".repeat(600), "en", {
     jaCharsPerSecond: 6.5,
     enCharsPerSecond: 15,
     minLineSeconds: 1.2,
     maxLineSeconds: 7,
   });
-  const [b0, b1] = parseSrt(srt);
-  assertEquals(b0.end - b0.start, 1200); // min floor
-  assertEquals(b1.end - b1.start, 7000); // max ceiling
+  const blocks = parseSrt(srt);
+  // 短行は従来どおり minLineSeconds を床とする。
+  assertEquals(blocks[0].end - blocks[0].start, 1200);
+  // 長行は複数 cue に分割され、行合計は文字数比 (600/15=40s) を保つ。
+  // 旧実装の 7 秒天井は比例配分を歪めるため廃止(cue 単体は分割で十分短い)。
+  const longTotal = blocks.slice(1)
+    .reduce((sum, b) => sum + (b.end - b.start), 0);
+  assertEquals(longTotal, 40000);
+  assert(blocks.length > 2, "long line must split into multiple cues");
+  for (const b of blocks) {
+    assert(
+      b.text.split("\n").length <= MAX_ROWS_PER_CUE,
+      "every cue renders at most 2 rows",
+    );
+  }
 });
 
 Deno.test("buildCaptionSrt returns empty string for blank input", () => {
@@ -100,10 +123,80 @@ Deno.test("buildCaptionSrt returns empty string for blank input", () => {
   assertEquals(buildCaptionSrt("   \n \n\t", "en"), "");
 });
 
-Deno.test("buildCaptionSrt preserves the spoken text verbatim", () => {
+Deno.test("buildCaptionSrt preserves the spoken text (modulo row breaks)", () => {
   const line = "AI大学では、最新ニュースとプロンプト活用を学べます。";
   const srt = buildCaptionSrt(line, "ja");
-  assertStringIncludes(srt, line);
+  // 折返しで \n が入るため、改行を除去した連結が原文と一致することを確認。
+  const blocks = parseSrt(srt);
+  const joined = blocks.map((b) => b.text.replaceAll("\n", "")).join("");
+  assertEquals(joined, line);
+});
+
+Deno.test("wrapCaptionText keeps every row within the width budget", () => {
+  const line =
+    "流れてくるニュースを、判断材料に変えるコツを紹介します。今日の話題は「Meta、AIで『爆速開発』のはずが『想定より加速せず』」です。";
+  const rows = wrapCaptionText(line);
+  assert(rows.length >= 4, "70+ char ja line must wrap into several rows");
+  for (const row of rows) {
+    assert(
+      rowUnits(row) <= MAX_ROW_UNITS + 0.5,
+      `row exceeds width budget: ${row} (${rowUnits(row)})`,
+    );
+  }
+  // 連結すると原文に戻る(文字は一切失われない)。
+  assertEquals(rows.join(""), line.trim());
+  // 行頭禁則: 句読点・閉じ括弧などで行が始まらない(ベストエフォート)。
+  for (const row of rows.slice(1)) {
+    assert(
+      !"、。ー」』）".includes(Array.from(row)[0]),
+      `row starts with kinsoku char: ${row}`,
+    );
+  }
+});
+
+Deno.test("wrapCaptionText does not split ASCII words or surrogate pairs", () => {
+  const en = "Practical productivity insights for developers everywhere today";
+  for (const row of wrapCaptionText(en)) {
+    assert(rowUnits(row) <= MAX_ROW_UNITS + 0.5);
+  }
+  // 単語の途中で割れていない: 境界の空白は落ちるので、空白1つで連結し直すと
+  // 原文と一致する(=どの単語も分断されていない)ことを検証する。
+  const rows = wrapCaptionText(en);
+  assert(rows.length >= 2, "long en line must wrap");
+  assertEquals(rows.join(" "), en);
+  // サロゲートペア(絵文字)は割れず、例外も投げない。
+  const emoji = "🚀".repeat(20);
+  const emojiRows = wrapCaptionText(emoji);
+  assertEquals(emojiRows.join(""), emoji);
+  for (const row of emojiRows) {
+    assert(!row.includes("�"), "no broken surrogate halves");
+  }
+});
+
+Deno.test("buildCaptionSrt merges a tiny tail cue when width allows", () => {
+  // 30 全角 = 14+14+2 行 → 末尾 2 文字( <1.2s 相当)は前 cue の最終行(2文字)…
+  // ではなく幅上限を超えない場合のみ併合される。ここでは 16 文字 + 14 文字の
+  // 2 行に収まるケースで、cue 数が減ることを確認する。
+  const line = "あ".repeat(15); // 14 + 1 → tail 1 文字は前行(14)に足すと 15 > 14 で不可
+  const srt15 = buildCaptionSrt(line, "ja");
+  const blocks15 = parseSrt(srt15);
+  // 幅が許さないので tail cue は残る(2 cue) — かつ各行は幅上限以内。
+  for (const b of blocks15) {
+    for (const row of b.text.split("\n")) {
+      assert(rowUnits(row) <= MAX_ROW_UNITS + 0.5);
+    }
+  }
+  // 450 字の最悪ケースでも全 cue が 2 行以内・連番・連続タイムスタンプ。
+  const worst = ("今日の注目トピックを、AI仕事OS開発者の視点でまとめました。".repeat(10))
+    .slice(0, 450);
+  const blocks = parseSrt(buildCaptionSrt(worst, "ja"));
+  let prevEnd = 0;
+  blocks.forEach((b, i) => {
+    assertEquals(b.index, i + 1);
+    assertEquals(b.start, prevEnd);
+    prevEnd = b.end;
+    assert(b.text.split("\n").length <= MAX_ROWS_PER_CUE);
+  });
 });
 
 Deno.test("buildForceStyle encodes bottom-center high-contrast stroked style", () => {
@@ -113,7 +206,10 @@ Deno.test("buildForceStyle encodes bottom-center high-contrast stroked style", (
   assertStringIncludes(style, "PrimaryColour=&H00FFFFFF"); // white text
   assertStringIncludes(style, "OutlineColour=&H00000000"); // black outline
   assertStringIncludes(style, "Bold=1");
-  assertStringIncludes(style, "FontSize=22");
+  assertStringIncludes(style, "FontSize=20");
+  // 折返し幅を拘束する左右マージン(PlayRes 単位 / 960w で ~75px per side)。
+  assertStringIncludes(style, "MarginL=30");
+  assertStringIncludes(style, "MarginR=30");
 });
 
 Deno.test("extractBurnedVideoUrl reads common response shapes", () => {
@@ -152,6 +248,9 @@ const SAMPLE_REQUEST: BurnCaptionsRequest = {
   resolution: "540p",
   style: DEFAULT_CAPTION_STYLE,
   forceStyle: buildForceStyle(DEFAULT_CAPTION_STYLE),
+  stretchToVideo: true,
+  leadInMs: 0,
+  tailPadMs: 300,
 };
 
 Deno.test("burnCaptionsViaTranscoder returns ok with url on 200", async () => {

--- a/supabase/functions/viral-video-ad-generator/captions.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.ts
@@ -32,7 +32,9 @@ export interface CaptionTimingConfig {
 }
 
 export const DEFAULT_CAPTION_TIMING: CaptionTimingConfig = {
-  jaCharsPerSecond: 6.5,
+  // 実測の ElevenLabs 日本語話速は ~7.5-9 文字/秒。8.0 でリスケール前の推定
+  // 誤差を最小化する(最終同期はトランスコーダの実測動画長リスケールが担う)。
+  jaCharsPerSecond: 8.0,
   enCharsPerSecond: 15,
   minLineSeconds: 1.2,
   maxLineSeconds: 7,
@@ -50,11 +52,113 @@ export function formatSrtTimestamp(ms: number): string {
   return `${pad(hours)}:${pad(minutes)}:${pad(seconds)},${pad(millis, 3)}`;
 }
 
+// --- 行折返し (overflow fix) ------------------------------------------------
+// 実機で字幕がフレーム横幅からはみ出た(libass の自動折返しに任せると行幅が
+// 出力解像度を超えて見切れる)。折返しは自前で決定的に行う。
+// 幾何: scale=-2:540 の 16:9 出力 = 960x540。SRT→ASS の libass 既定 PlayRes は
+// 384x288 → フォント倍率 540/288=1.875。FontSize 20 → 全角 ~37.5px。
+// MarginL/R 30(PlayRes 単位)=75px/側 → 実効幅 810px。14 全角 ≈ 525px で余裕。
+
+/** 1 行の最大幅(重み付き単位)。全角=1.0 / ASCII・半角カナ=0.5 (英語 ~28字)。 */
+export const MAX_ROW_UNITS = 14;
+/** 1 字幕(cue)の最大行数。下部中央で高く積まない。 */
+export const MAX_ROWS_PER_CUE = 2;
+
+// 行頭禁則(行の先頭に来てはならない)と行末禁則(行の末尾に置けない開き括弧)。
+const KINSOKU_NO_START =
+  "、。，．・：；？！ー〜…」』）】〕｝〉》’”ゝゞ々ぁぃぅぇぉっゃゅょゎァィゥェォッャュョヮんン";
+const KINSOKU_NO_END = "「『（【〔｛〈《‘“";
+
+function charUnits(ch: string): number {
+  const cp = ch.codePointAt(0) ?? 0;
+  // ASCII と半角カナは 0.5、それ以外(CJK 等)は 1.0 として幅を見積もる。
+  return cp <= 0xff || (cp >= 0xff61 && cp <= 0xff9f) ? 0.5 : 1;
+}
+
+function isAsciiWordChar(ch: string): boolean {
+  return /[A-Za-z0-9]/.test(ch);
+}
+
 /**
- * 読み上げ台本から SRT を生成する。行ごとに `文字数 / 発話レート` 秒を割り当てる
- * (= 推定音声長 `総文字数 / 発話レート` を文字数比で比例配分したのと等価)。
- * 各行は [minLineSeconds, maxLineSeconds] にクランプして極端な尺を避ける。
- * 台本が空なら空文字列を返す (呼び出し側は焼き込みをスキップする)。
+ * 字幕テキストを最大 [maxUnitsPerRow] 幅の行へ折り返す。コードポイント単位で
+ * 走査するのでサロゲートペア(絵文字)は割れない。禁則(行頭/行末)と ASCII 単語
+ * 分断の回避は最大3文字のバックトラックによるベストエフォートで、行幅の上限が
+ * 不変条件。失敗時は入力をそのまま1行で返す(呼び出し側の fail-safe を維持)。
+ */
+export function wrapCaptionText(
+  text: string,
+  maxUnitsPerRow: number = MAX_ROW_UNITS,
+): string[] {
+  try {
+    const chars = Array.from(text.trim());
+    if (chars.length === 0) return [];
+    const rows: string[] = [];
+    let row: string[] = [];
+    let units = 0;
+    for (const ch of chars) {
+      const u = charUnits(ch);
+      if (row.length > 0 && units + u > maxUnitsPerRow) {
+        let carry: string[] = [];
+        const last = row[row.length - 1];
+        if (isAsciiWordChar(last) && isAsciiWordChar(ch)) {
+          // ASCII 単語の途中では折らない: 行内の最後の非単語文字(空白等)まで
+          // 戻って折る。1 単語が行より長い場合のみハードブレーク。
+          let cut = -1;
+          for (let i = row.length - 1; i >= 0; i -= 1) {
+            if (!isAsciiWordChar(row[i])) {
+              cut = i + 1;
+              break;
+            }
+          }
+          if (cut > 0) {
+            carry = row.slice(cut);
+            row = row.slice(0, cut);
+            // 行末の空白は描画不要なので落とす。
+            while (row.length > 0 && row[row.length - 1] === " ") row.pop();
+          }
+        } else if (
+          KINSOKU_NO_START.includes(ch) || KINSOKU_NO_END.includes(last)
+        ) {
+          // 禁則(行頭に句読点/閉じ括弧・行末に開き括弧)は最大 3 文字戻して
+          // 回避するベストエフォート。幅上限が不変条件で、禁則は妥協可。
+          for (let back = 1; back <= 3 && row.length - back > 0; back += 1) {
+            const cut = row.length - back;
+            const cutLast = row[cut - 1];
+            const cutNext = row[cut];
+            const compliant = !KINSOKU_NO_START.includes(cutNext) &&
+              !KINSOKU_NO_END.includes(cutLast) &&
+              !(isAsciiWordChar(cutLast) && isAsciiWordChar(cutNext));
+            if (compliant) {
+              carry = row.slice(cut);
+              row = row.slice(0, cut);
+              break;
+            }
+          }
+        }
+        rows.push(row.join(""));
+        row = [...carry, ch];
+        // 次行頭の空白も落とす(英語の折返し位置直後)。
+        while (row.length > 0 && row[0] === " ") row.shift();
+        units = row.reduce((sum, c) => sum + charUnits(c), 0);
+      } else {
+        row.push(ch);
+        units += u;
+      }
+    }
+    if (row.length > 0) rows.push(row.join(""));
+    return rows.length > 0 ? rows : [text];
+  } catch (_error) {
+    return [text];
+  }
+}
+
+/**
+ * 読み上げ台本から SRT を生成する。各行を [wrapCaptionText] で折り返し、
+ * 最大 [MAX_ROWS_PER_CUE] 行ずつの cue に分割。行の尺は `文字数 / 発話レート`
+ * を cue の文字数比で比例配分する(単一 cue の行のみ minLineSeconds を床とし、
+ * maxLineSeconds の天井は廃止 — 分割後の cue は十分短く、天井は比例配分を
+ * 歪めて実測長リスケール後も残る誤差の原因だった)。末尾の極小 cue は幅が
+ * 許す場合のみ直前の cue へ併合する。台本が空なら空文字列を返す。
  */
 export function buildCaptionSrt(
   spokenText: string,
@@ -75,29 +179,63 @@ export function buildCaptionSrt(
     : DEFAULT_CAPTION_TIMING.enCharsPerSecond;
 
   let cursorMs = 0;
+  let cueIndex = 0;
   const blocks: string[] = [];
-  lines.forEach((line, index) => {
-    const rawSeconds = line.length / safeCps;
-    const durationSeconds = Math.min(
-      timing.maxLineSeconds,
-      Math.max(timing.minLineSeconds, rawSeconds),
-    );
-    const startMs = cursorMs;
-    const endMs = startMs + Math.round(durationSeconds * 1000);
-    cursorMs = endMs;
-    blocks.push(
-      `${index + 1}\n${formatSrtTimestamp(startMs)} --> ${
-        formatSrtTimestamp(endMs)
-      }\n${line}`,
-    );
-  });
+  const joiner = lang === "ja" ? "" : " ";
+  for (const line of lines) {
+    const rows = wrapCaptionText(line);
+    const cues: string[][] = [];
+    for (let i = 0; i < rows.length; i += MAX_ROWS_PER_CUE) {
+      cues.push(rows.slice(i, i + MAX_ROWS_PER_CUE));
+    }
+    // 末尾の極小 cue (推定 < minLineSeconds) は、直前 cue の最終行に足しても
+    // 行幅の上限を破らない場合のみ併合する(タイムライン全体は膨らませない)。
+    if (cues.length >= 2) {
+      const tail = cues[cues.length - 1];
+      const tailText = tail.join(joiner);
+      const tailChars = Array.from(tailText).length;
+      if (tailChars / safeCps < timing.minLineSeconds) {
+        const prev = cues[cues.length - 2];
+        const mergedRow = prev[prev.length - 1] + joiner + tailText;
+        const mergedUnits = Array.from(mergedRow)
+          .reduce((sum, c) => sum + charUnits(c), 0);
+        if (mergedUnits <= MAX_ROW_UNITS) {
+          prev[prev.length - 1] = mergedRow;
+          cues.pop();
+        }
+      }
+    }
+    const lineChars = Array.from(line).length;
+    const lineDurationMs = cues.length === 1
+      ? Math.round(
+        Math.max(timing.minLineSeconds, lineChars / safeCps) * 1000,
+      )
+      : Math.round((lineChars / safeCps) * 1000);
+    let allocatedMs = 0;
+    for (let i = 0; i < cues.length; i += 1) {
+      const cueChars = Array.from(cues[i].join("")).length;
+      const durMs = i === cues.length - 1
+        ? lineDurationMs - allocatedMs
+        : Math.round(lineDurationMs * (cueChars / Math.max(1, lineChars)));
+      allocatedMs += durMs;
+      const startMs = cursorMs;
+      const endMs = startMs + durMs;
+      cursorMs = endMs;
+      cueIndex += 1;
+      blocks.push(
+        `${cueIndex}\n${formatSrtTimestamp(startMs)} --> ${
+          formatSrtTimestamp(endMs)
+        }\n${cues[i].join("\n")}`,
+      );
+    }
+  }
   return blocks.join("\n\n") + "\n";
 }
 
 export interface CaptionStyle {
   /** CJK グリフを含むフォント名。実際の可用性はトランスコーダ側の fontconfig 次第。 */
   fontName: string;
-  /** ~540p 想定のフォントサイズ (px)。 */
+  /** libass PlayRes 単位 (SRT 既定 PlayRes 384x288)。出力 px = 値 × 高さ/288 (540p で ×1.875)。 */
   fontSizePx: number;
   /** 本文色 (ASS の &HAABBGGRR)。既定は白。 */
   primaryColour: string;
@@ -109,20 +247,28 @@ export interface CaptionStyle {
   shadow: number;
   /** ASS Alignment。2 = 下中央。 */
   alignment: number;
-  /** 下端からの余白 (px)。 */
+  /** 下端からの余白 (PlayRes 単位 / × 高さ/288)。 */
   marginV: number;
+  /** 左余白 (PlayRes 単位 / × 幅/384。30 → 960w で ~75px)。折返し幅を拘束する。 */
+  marginL: number;
+  /** 右余白 (PlayRes 単位)。 */
+  marginR: number;
 }
 
 // 下中央・白文字・黒 stroke・影付きの高コントラスト字幕。~540p 短尺向け。
+// FontSize 20 × 1.875 = 37.5px/全角。MAX_ROW_UNITS=14 全角 ≈ 525px << 実効幅
+// 810px(960 - 75px×2) で、はみ出しない余裕を持つ。
 export const DEFAULT_CAPTION_STYLE: CaptionStyle = {
   fontName: "Noto Sans CJK JP",
-  fontSizePx: 22,
+  fontSizePx: 20,
   primaryColour: "&H00FFFFFF",
   outlineColour: "&H00000000",
   outline: 3,
   shadow: 1,
   alignment: 2,
   marginV: 40,
+  marginL: 30,
+  marginR: 30,
 };
 
 /**
@@ -141,6 +287,8 @@ export function buildForceStyle(style: CaptionStyle): string {
     "Bold=1",
     `Alignment=${style.alignment}`,
     `MarginV=${style.marginV}`,
+    `MarginL=${style.marginL}`,
+    `MarginR=${style.marginR}`,
   ].join(",");
 }
 
@@ -156,6 +304,12 @@ export interface BurnCaptionsRequest {
   resolution: string;
   style: CaptionStyle;
   forceStyle: string;
+  /** トランスコーダに実測動画長への SRT リスケールを指示 (旧版は無視する)。 */
+  stretchToVideo: boolean;
+  /** 全 cue 開始を後ろへずらすリード (ms)。Hedra の頭出し余白補正用。 */
+  leadInMs?: number;
+  /** 最終 cue を動画末尾より手前で終わらせる余白 (ms)。 */
+  tailPadMs?: number;
 }
 
 export type BurnResult =

--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -1558,6 +1558,11 @@ async function maybeBurnCaptions(params: {
         resolution: "540p",
         style,
         forceStyle: buildForceStyle(style),
+        // 実測動画長へ SRT を線形リスケール(トランスコーダ側 ffprobe)。推定
+        // 話速との乖離や Hedra の頭出し余白による字幕ずれを吸収する。
+        stretchToVideo: true,
+        leadInMs: positiveNumberEnv("VVAG_CAPTION_LEAD_MS", 0),
+        tailPadMs: positiveNumberEnv("VVAG_CAPTION_TAIL_MS", 300),
       },
     });
     if (result.ok) {


### PR DESCRIPTION
## 実機障害（初の字幕付き投稿）
1. **はみ出し**: 字幕行がフレーム横幅を超えて左右で見切れる
2. **ずれ**: 字幕のタイミングが音声・映像と合わない

## 真因（10仮説×敵対的検証Workflowで9件fix_now確定）
- **はみ出し**: SRTの各cueが台本1行まるごと(40-70字)で、折返しをlibass任せにすると描画行がフレーム幅を超える。FontSize 22(×1.875=~41px/全角)も大きめ。左右マージン未指定。
- **ずれ**: cue時刻が固定話速6.5字/秒の推定で、実際のElevenLabs日本語話速(~7.5-9字/秒)と乖離→累積ドリフト。1行7秒の天井が比例配分を歪め、線形リスケールでも直らない誤差を残す。

## 修正
**はみ出し（決定的折返し）**: `wrapCaptionText`=重み付き幅(全角1.0/ASCII・半角0.5)で**14単位/行**(~525px ≪ 実効幅810px)、**cueあたり最大2行**・長行は連続cueに分割。禁則(行頭句読点/行末開き括弧)はベストエフォート、ASCII単語は分断しない(行内最後の空白まで戻る)。FontSize **22→20**、force_styleに **MarginL/MarginR=30** 追加。

**ずれ（実測長アンカー）**: transcoderがダウンロード済みmp4を**ffprobeで実測**し、全cue時刻を `[leadInMs, 実測長 - tailPadMs]` へ**線形リスケール**(既定ON・`stretchToVideo:false`でopt-out・±5%は素通し・倍率0.5-3域外は不変・300msアンチフリッカー床・失敗時は元SRTで焼き込み継続)。話速既定 **6.5→8.0字/秒**でリスケール前誤差も縮小。**7秒天井は廃止**。極小の尻尾cueは幅上限を破らない場合のみ前cueへ併合。edge は `stretchToVideo:true` + `VVAG_CAPTION_LEAD_MS`/`VVAG_CAPTION_TAIL_MS` 調整ノブを送る。

**CI**: `services/caption-transcoder/test.js` を ci.yml の恒常ステップに追加(ubuntu-latest は node 20 標準・数秒)。

## 検証
- deno **37件green**(字幕16件: 折返し幅不変条件・禁則・サロゲートペア・cue2行上限・比例配分・天井廃止)
- node **24件green**(リスケール数学・倍率境界・5%素通し・アンチフリッカー・不正入力不変)
- **transcoderは新版をCloud Runへ再デプロイ済**(既定ONなので現行edgeの投稿も即ずれ改善)。本PRのedge変更はマージでdeploy-prodが自動反映。fail-safe不変=どんな失敗でも素のmp4で投稿続行。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge function + Node helper covered by black-box unit suites (deno 37 green incl. 16 caption cases; node 24 green for the SRT rescale math); captions render inside a video pipeline that a Flutter integration_test cannot exercise, so a full E2E flow is disproportionate.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Caption rendering/timing only: wraps subtitle rows and rescales SRT cue times; no data-model, permission, or network-contract change; fail-safe preserved (any error burns the plain video); deno 37 + node 24 tests green.
