### PR TITLE
fix(captions): start every caption cue at a sentence boundary

### DIFF
--- a/supabase/functions/viral-video-ad-generator/captions.test.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.test.ts
@@ -14,8 +14,56 @@ import {
   formatSrtTimestamp,
   MAX_ROW_UNITS,
   MAX_ROWS_PER_CUE,
+  splitAtSentenceBoundaries,
   wrapCaptionText,
 } from "./captions.ts";
+
+Deno.test("splitAtSentenceBoundaries splits after 。？！ outside quotes", () => {
+  // 実機観測行: cue が「た。今日の話題は…」と文の途中から始まっていた。
+  const line =
+    "流れてくるニュースを、判断材料に変えるコツを紹介します。今日の話題は「マイクロン、AI需要で広島工場増強へ」です。";
+  const segs = splitAtSentenceBoundaries(line);
+  assertEquals(segs.length, 2);
+  assertEquals(segs[0], "流れてくるニュースを、判断材料に変えるコツを紹介します。");
+  assertEquals(segs[1], "今日の話題は「マイクロン、AI需要で広島工場増強へ」です。");
+  // 「」内の 、や終端記号では割らない。
+  const quoted = "話題は「爆速開発。想定より加速せず？」です！続きへ。";
+  const qsegs = splitAtSentenceBoundaries(quoted);
+  assertEquals(qsegs.length, 2);
+  assertEquals(qsegs[0], "話題は「爆速開発。想定より加速せず？」です！");
+  // 終端記号なし・空入力の fail-safe。
+  assertEquals(splitAtSentenceBoundaries("終端記号なしの一文"), ["終端記号なしの一文"]);
+});
+
+Deno.test("buildCaptionSrt cues start at sentence boundaries", () => {
+  const line =
+    "流れてくるニュースを、判断材料に変えるコツを紹介します。今日の話題は「マイクロン、AI需要で広島工場増強へ」です。";
+  const blocks = parseSrt(buildCaptionSrt(line, "ja"));
+  // 各 cue の先頭は「文頭」か「同一文の折返し継続」— 前文の断片(た。等)で
+  // 始まる cue が存在しないこと = どの cue 先頭も 。？！ 直後の文字ではなく
+  // 文境界で区切ったセグメント由来であることを、cue 連結の再構成で検証する。
+  const joined = blocks.map((b) => b.text.replaceAll("\n", "")).join("");
+  assertEquals(joined, line);
+  // 2文に分かれているので、2文目の先頭「今日の話題は」で始まる cue が存在する。
+  assert(
+    blocks.some((b) => b.text.replaceAll("\n", "").startsWith("今日の話題は")),
+    "second sentence must start its own cue",
+  );
+  // どの cue も「た。」のような前文断片で始まらない。
+  for (const b of blocks) {
+    const head = Array.from(b.text)[0];
+    assert(
+      !"。？！、".includes(head),
+      `cue starts with dangling punctuation: ${b.text}`,
+    );
+  }
+  // 行合計尺は従来どおり文字数比(トリム差は最終 cue が吸収)。
+  const total = blocks.reduce((sum, b) => sum + (b.end - b.start), 0);
+  const expected = Math.round(
+    (Array.from(line).length / DEFAULT_CAPTION_TIMING.jaCharsPerSecond) * 1000,
+  );
+  assertEquals(total, expected);
+});
 
 // 重み付き幅(全角=1.0 / ASCII・半角カナ=0.5)をテスト側でも再現する。
 function rowUnits(row: string): number {

--- a/supabase/functions/viral-video-ad-generator/captions.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.ts
@@ -153,6 +153,39 @@ export function wrapCaptionText(
 }
 
 /**
+ * 台本行を文境界(。？！ の直後)で分割する。cue が文の途中(実機観測:
+ * 「た。今日の話題は…」)から始まらないようにするための前処理。
+ * 「」『』（） 内の終端記号では分割しない(引用ニュースタイトルを割らない)。
+ * 失敗時は [line] を返す fail-safe(wrapCaptionText と同型)。
+ */
+export function splitAtSentenceBoundaries(line: string): string[] {
+  try {
+    const openers = "「『（";
+    const closers = "」』）";
+    const enders = "。？！";
+    const segments: string[] = [];
+    let current = "";
+    let depth = 0;
+    for (const ch of Array.from(line)) {
+      current += ch;
+      if (openers.includes(ch)) depth += 1;
+      else if (closers.includes(ch)) depth = Math.max(0, depth - 1);
+      else if (depth === 0 && enders.includes(ch)) {
+        segments.push(current);
+        current = "";
+      }
+    }
+    if (current.trim().length > 0) segments.push(current);
+    const cleaned = segments
+      .map((seg) => seg.trim())
+      .filter((seg) => seg.length > 0);
+    return cleaned.length > 0 ? cleaned : [line];
+  } catch (_error) {
+    return [line];
+  }
+}
+
+/**
  * 読み上げ台本から SRT を生成する。各行を [wrapCaptionText] で折り返し、
  * 最大 [MAX_ROWS_PER_CUE] 行ずつの cue に分割。行の尺は `文字数 / 発話レート`
  * を cue の文字数比で比例配分する(単一 cue の行のみ minLineSeconds を床とし、
@@ -183,10 +216,15 @@ export function buildCaptionSrt(
   const blocks: string[] = [];
   const joiner = lang === "ja" ? "" : " ";
   for (const line of lines) {
-    const rows = wrapCaptionText(line);
+    // 文境界(。？！)で区切ってから折り返す。cue が前文の断片(「た。今日の…」)
+    // から始まらず、必ず文頭 or 同一文の折返し継続で始まるようにする。
+    const segments = splitAtSentenceBoundaries(line);
     const cues: string[][] = [];
-    for (let i = 0; i < rows.length; i += MAX_ROWS_PER_CUE) {
-      cues.push(rows.slice(i, i + MAX_ROWS_PER_CUE));
+    for (const segment of segments) {
+      const rows = wrapCaptionText(segment);
+      for (let i = 0; i < rows.length; i += MAX_ROWS_PER_CUE) {
+        cues.push(rows.slice(i, i + MAX_ROWS_PER_CUE));
+      }
     }
     // 末尾の極小 cue (推定 < minLineSeconds) は、直前 cue の最終行に足しても
     // 行幅の上限を破らない場合のみ併合する(タイムライン全体は膨らませない)。


### PR DESCRIPTION
## 目的(第4ラウンド/medium)
実機の字幕cueが**文の途中**(「た。今日の話題は…」)から始まっていた=行を行数ペアのみで分割していたため。
## 変更(captions.ts+テストのみ)
`splitAtSentenceBoundaries`=。？！の直後で分割(「」『』（）内の終端記号は無視=引用タイトルを割らない・fail-safe)→折返し前に適用。**cueは必ず文頭か同一文の折返し継続から始まる**。幅/2行上限/行毎の比例配分は不変。
## 検証
deno test 39 green(実機観測行での境界分割・引用ガード・cue再構成・合計尺の各テスト追加)。mergeでdeploy-prod自動反映。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge pure-function change covered by black-box deno tests (39 green incl new sentence-boundary cases); captions render inside a video pipeline a Flutter integration_test cannot exercise.
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Caption cue segmentation only: splits subtitle lines at sentence boundaries before wrapping; no data-model, permission, or network-contract change; deno 39 green.
