### PR TITLE
fix(x-client): batch tweet metrics beyond the 100-id API cap

### DIFF
--- a/supabase/functions/_shared/x-client.ts
+++ b/supabase/functions/_shared/x-client.ts
@@ -129,29 +129,42 @@ export async function fetchXTweetMetrics(
   tweetIds: string[],
 ): Promise<XTweetMetrics[]> {
   assertXConfigured();
-  const ids = [...new Set(tweetIds.map(asString).filter((id) => id !== ""))]
-    .slice(0, 100);
+  // X API v2 の /2/tweets は 1 リクエスト最大 100 id。従来は `.slice(0, 100)` で
+  // 101 件目以降を黙って切り捨てており、投稿数が増えるほど計測から漏れた
+  // (perf フィードバックループの入力欠損)。100 件ずつ順次バッチで全件取得する。
+  const ids = [...new Set(tweetIds.map(asString).filter((id) => id !== ""))];
   if (ids.length === 0) return [];
 
-  try {
-    return await fetchXTweetMetricsWithFields(ids, [
-      "created_at",
-      "text",
-      "public_metrics",
-      "non_public_metrics",
-      "organic_metrics",
-    ]);
-  } catch (error) {
-    const payload = isXApiError(error) ? error.payload : null;
-    if (payload && (payload.status === 400 || payload.status === 403)) {
-      return await fetchXTweetMetricsWithFields(ids, [
-        "created_at",
-        "text",
-        "public_metrics",
-      ]);
+  const results: XTweetMetrics[] = [];
+  for (let i = 0; i < ids.length; i += 100) {
+    const batch = ids.slice(i, i + 100);
+    try {
+      results.push(
+        ...await fetchXTweetMetricsWithFields(batch, [
+          "created_at",
+          "text",
+          "public_metrics",
+          "non_public_metrics",
+          "organic_metrics",
+        ]),
+      );
+    } catch (error) {
+      const payload = isXApiError(error) ? error.payload : null;
+      if (payload && (payload.status === 400 || payload.status === 403)) {
+        // 昇格フィールド非対応(未認可)時のダウングレードはバッチ単位で維持。
+        results.push(
+          ...await fetchXTweetMetricsWithFields(batch, [
+            "created_at",
+            "text",
+            "public_metrics",
+          ]),
+        );
+      } else {
+        throw error;
+      }
     }
-    throw error;
   }
+  return results;
 }
 
 async function fetchXTweetMetricsWithFields(


### PR DESCRIPTION
## 目的(第4ラウンド/low・計測基盤)
`fetchXTweetMetrics`が重複除去後のid列を**黙って100件に切り捨て**=投稿が増えるほど3時間cronの計測から古いスレッドが漏れ、計測ループの入力が欠損する構造バグ。
## 変更(_shared/x-client.ts 1ファイル)
100件ずつの**逐次バッチ**で全件取得。400/403時のpublic_metricsへのダウングレードはバッチ単位で維持、その他のthrowセマンティクス不変。**100件以下では挙動同一**。
## 検証
deno lint clean。additive ~15行。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge batching change with behavior identical for <=100 ids; error-downgrade semantics preserved per batch; validated by deno lint; external X API loop is not exercisable from a Flutter integration_test.
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Replaces a silent 100-id truncation with sequential batches in the metrics reader; read-only analytics path, identical behavior at <=100 ids, error semantics preserved.
