### PR TITLE
[CI/CD自動最適化] 2026-07-05 高頻度 cron の cancel-in-progress 追加

### DIFF
--- a/.github/workflows/horse-racing-update.yml
+++ b/.github/workflows/horse-racing-update.yml
@@ -25,7 +25,7 @@ on:
 
 concurrency:
   group: horse-racing-update
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-07-05 ci-audit: 4h cron queue積み防止
 
 permissions:
   contents: read

--- a/.github/workflows/schedule-resilience-watch.yml
+++ b/.github/workflows/schedule-resilience-watch.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: schedule-resilience-watch
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-07-05 ci-audit: 4h cron queue積み防止
 
 jobs:
   watch:


### PR DESCRIPTION
## 変更概要

高頻度 schedule ワークフロー 2本に `cancel-in-progress: true` を追加。

| ファイル | 変更内容 | cron 頻度 |
|---|---|---|
| `horse-racing-update.yml` | `false` → `true` | 4h ごと (180 run/月) |
| `schedule-resilience-watch.yml` | `false` → `true` | 4h ごと (180 run/月) |

## 問題

API 遅延等でジョブが 4 時間を超えた場合、次の schedule 実行が queue に積まれ、
並行実行が増えて billable 時間を浪費していた。

## 安全性

- 両ワークフローともデータ取得・監視ジョブであり、最新の実行だけ完了すれば十分
- deploy 系 (cancel-in-progress: false 規約) には触れていない
- ホワイトリスト適用 (deploy 以外への concurrency 追加)

## 推定削減効果

- queue 積みによる重複実行ゼロ化: 月最大 360 run 分の重複を防止
- 実際の削減は API 遅延頻度に依存

## 関連

監査レポート: `docs/ci-cd-audit/2026-07-05.md`  
Issue: #3656 ([CI/CD監査] 冗長フロー削減提案)

---
_Generated by [Claude Code](https://claude.ai/code/session_015bs8JU4KmBKsXDZpzL3fZ6)_