### PR TITLE
feat(growth-hub): separate fallback posts from LLM posts in the perf loop

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -559,12 +559,25 @@ function buildXPerformanceContextFromLogs(logs: XPostLogItem[]) {
         id: item.id,
         tweetId: firstString(metadata.tweet_id),
         text: compactPostText(latest.text ?? metadata.text),
-        variant: firstString(
-          latest.variant,
-          metadata.variant,
-          metadata.utm_content,
-          "unknown",
-        ),
+        // 定型文フォールバック投稿は `${variant}_fallback` の別バケットで計測
+        // する(低品質な定型データが winner exemplar / ランキングを汚染しない
+        // ように)。旧行はフィールド欠落 = 非フォールバック扱いで後方互換。
+        variant: (metadata.fallback_used === true ||
+            String(metadata.prompt_profile ?? "") === "fallback_template_v1")
+          ? `${
+            firstString(
+              latest.variant,
+              metadata.variant,
+              metadata.utm_content,
+              "unknown",
+            )
+          }_fallback`
+          : firstString(
+            latest.variant,
+            metadata.variant,
+            metadata.utm_content,
+            "unknown",
+          ),
         route: firstString(latest.route, metadata.route),
         source: firstString(latest.source, metadata.source),
         hasMedia: Boolean(latest.has_media ?? metadata.media_url),
@@ -1747,6 +1760,10 @@ serve(async (req: Request) => {
             "x_first_user_growth_10k",
           variant: body.variant ?? body.utmContent ?? body.utm_content ?? null,
           prompt_profile: body.promptProfile ?? body.prompt_profile ?? null,
+          // 定型文フォールバック投稿を perf 計測で LLM 投稿と分離するための
+          // 明示フラグ(旧行はフィールド欠落 = 非フォールバック扱いで後方互換)。
+          fallback_used: body.fallbackUsed === true ||
+            body.fallback_used === true,
           content_kind: body.contentKind ?? body.content_kind ?? null,
           link_in_reply: body.linkInReply === true ||
             body.link_in_reply === true,


### PR DESCRIPTION
## 目的
定型文フォールバック投稿がLLM投稿と同じ `variant=daily_briefing` で計測され、**低品質な定型データがwinner exemplar/ランキングを汚染**していた。
## 変更(growth-hub 1ファイル)
- x_post_log に明示フラグ `fallback_used` を永続化(旧行はフィールド欠落=非フォールバック扱いで後方互換)。
- perf文脈ビルダーで該当行を `${variant}_fallback` の**別バケット**に分離=ランキング/構造lift/Top hookはLLM投稿から計算されつつ、フォールバックも独自バケットで計測継続。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge metadata field + bucketing string change, backward compatible for rows missing the field; validated by deno lint; no user-facing route to E2E.
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Adds one boolean metadata field and a variant bucketing suffix in the perf context builder; read/write shape otherwise unchanged and backward compatible; deno lint clean.
