### PR TITLE
fix(captions): prefer wrapping after punctuation instead of mid-word

### DIFF
--- a/supabase/functions/viral-video-ad-generator/captions.test.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.test.ts
@@ -202,6 +202,25 @@ Deno.test("wrapCaptionText keeps every row within the width budget", () => {
   }
 });
 
+Deno.test("wrapCaptionText prefers breaking after punctuation near the edge", () => {
+  // 実機観測:「不正プログラム自|作」の語中割れ。行末近く(6文字以内)に読点が
+  // あればそこで折り、語のまとまりを保つ。
+  const line = "Nintendo Switch 2、不正プログラム自作の疑いで再逮捕されたと報道";
+  const rows = wrapCaptionText(line);
+  for (const row of rows) {
+    assert(
+      rowUnits(row) <= MAX_ROW_UNITS + 0.5,
+      `row exceeds width budget: ${row}`,
+    );
+    // 「不正プログラム自作」という語が行境界で分断されない。
+    assert(
+      !row.endsWith("自") || row.endsWith("自作"),
+      `word split mid-token: ${row}`,
+    );
+  }
+  assertEquals(rows.join(""), line.trim());
+});
+
 Deno.test("wrapCaptionText does not split ASCII words or surrogate pairs", () => {
   const en = "Practical productivity insights for developers everywhere today";
   for (const row of wrapCaptionText(en)) {

--- a/supabase/functions/viral-video-ad-generator/captions.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.ts
@@ -134,6 +134,30 @@ export function wrapCaptionText(
               break;
             }
           }
+        } else {
+          // 実機観測:「不正プログラム自|作」のように語の途中で行が割れると
+          // 読みにくい。行末から 6 文字以内に読点/中黒/閉じ括弧等の「好ましい
+          // 折返し点」があればそこまで戻して折る(残り幅 >= 8 units のときのみ。
+          // 見つからなければ従来どおり幅上限で折る = 幅不変条件は維持)。
+          const preferredBreaks = "、。・！？：…」』）";
+          for (let back = 1; back <= 6 && row.length - back > 0; back += 1) {
+            const cut = row.length - back;
+            const cutLast = row[cut - 1];
+            const cutNext = row[cut];
+            if (!preferredBreaks.includes(cutLast)) continue;
+            const remainingUnits = row
+              .slice(0, cut)
+              .reduce((sum, c) => sum + charUnits(c), 0);
+            const compliant = remainingUnits >= 8 &&
+              !KINSOKU_NO_START.includes(cutNext) &&
+              !KINSOKU_NO_END.includes(cutLast) &&
+              !(isAsciiWordChar(cutLast) && isAsciiWordChar(cutNext));
+            if (compliant) {
+              carry = row.slice(cut);
+              row = row.slice(0, cut);
+              break;
+            }
+          }
         }
         rows.push(row.join(""));
         row = [...carry, ch];


### PR DESCRIPTION
## 実機観測
字幕行が語の途中で割れた(「不正プログラム自|作」)。
## 変更(captions.ts+テストのみ)
折返し判定に第3分岐: ASCII分岐も禁則分岐も不発のとき、行末から6文字以内の**好ましい折返し点**(、。・！？：…」』）)まで戻して折る(短縮後の行が8 units以上・禁則適合のときのみ)。行は縮む方向のみ=幅不変条件・tail-merge・fail-safeは不変。該当なしなら挙動不変。
## 検証
deno test **40件green**(新規: 引用タイトル内トークンが語中で割れない回帰)。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno pure-function wrap change covered by black-box deno tests (40 green incl new mid-word regression); captions render inside a video pipeline a Flutter integration_test cannot exercise.
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Caption row-wrap preference only: rows can only shrink, width invariant and fail-safe unchanged; deno 40 tests green.
