### PR TITLE
fix(x-client): map X API 402/spend-cap errors to an actionable Japanese message

### DIFF
--- a/.github/workflows/x-post-metrics-optimizer.yml
+++ b/.github/workflows/x-post-metrics-optimizer.yml
@@ -33,13 +33,20 @@ jobs:
         shell: bash
         run: |
           limit="${INPUT_LIMIT:-100}"
-          curl --fail-with-body --show-error --silent \
+          response=$(curl --fail-with-body --show-error --silent \
             --request POST \
             --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
             --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
             --header "Content-Type: application/json" \
             --data "{\"action\":\"x.metrics_collect\",\"limit\":${limit}}" \
-            "https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/growth-hub"
+            "https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/growth-hub")
+          echo "${response}"
+          # X API クレジット枯渇時は edge が HTTP 200 + skipped:true を返す
+          # (次の請求サイクルまで自然復旧しないため cron を赤く落とさない)。
+          # operator への信号は warning annotation で残す。
+          if echo "${response}" | grep -q '"code":"x_billing_blocked"'; then
+            echo "::warning::X API billing blocked — metrics collection skipped. console.x.com でクレジット追加/上限引き上げが必要です。"
+          fi
         env:
           INPUT_LIMIT: ${{ github.event.inputs.limit }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/supabase/functions/_shared/x-client.ts
+++ b/supabase/functions/_shared/x-client.ts
@@ -640,7 +640,15 @@ export function buildXApiErrorPayload(
   const detail = asString(parsed.detail) || null;
   const registrationUrl = asString(parsed.registration_url) || null;
   const requiredEnrollment = asString(parsed.required_enrollment) || null;
-  const code = reason === "client-not-enrolled"
+  // 実障害(2026-07-06): X API のクレジット制プランで残高ゼロになると
+  // 402 "does not have any credits" で全投稿・計測がブロックされる。
+  // spend cap 到達由来の 403 も同じ課金起因なので単一コードへ正規化する。
+  const billingText = `${detail ?? ""} ${title ?? ""} ${rawText}`;
+  const isBillingBlocked = status === 402 ||
+    (status === 403 && /spend cap|billing cycle|credit/i.test(billingText));
+  const code = isBillingBlocked
+    ? "x_billing_blocked"
+    : reason === "client-not-enrolled"
     ? "x_client_not_enrolled"
     : status === 403
     ? "x_forbidden"
@@ -767,6 +775,9 @@ function buildXActionRequired(
   if (code === "x_forbidden") {
     return "Check the X Developer App permissions, API access tier, and OAuth user-context access token.";
   }
+  if (code === "x_billing_blocked") {
+    return "X APIのクレジット不足/spend cap到達です。X Developer Portal (console.x.com) の該当プロジェクトでクレジット追加または上限引き上げをしてください。解除まで投稿・計測は失敗します。";
+  }
   return "Check the X API response, credentials, and endpoint permissions.";
 }
 
@@ -778,6 +789,13 @@ function buildXApiErrorMessage(payload: XApiErrorPayload): string {
       "Use keys and tokens from an X Developer App attached to a Project.",
       payload.actionRequired,
     ].join(" ");
+  }
+  if (payload.code === "x_billing_blocked") {
+    // 生 detail はデバッグ用に残しつつ、対処が一目で分かる日本語を先頭に。
+    return [
+      `X APIのクレジットが不足しています（${payload.detail ?? payload.status}）。`,
+      payload.actionRequired,
+    ].filter((part) => part).join(" ");
   }
   return `X API error ${payload.status}: ${
     payload.detail || payload.title || JSON.stringify(payload.raw)

--- a/supabase/functions/_shared/x_client_error_test.ts
+++ b/supabase/functions/_shared/x_client_error_test.ts
@@ -1,0 +1,49 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { buildXApiErrorPayload } from "./x-client.ts";
+
+Deno.test("402 credits exhaustion maps to x_billing_blocked", () => {
+  // 実障害(2026-07-06): "Your enrolled account [id] does not have any
+  // credits to fulfill this request." が生英語のまま UI に出た。
+  const payload = buildXApiErrorPayload(
+    402,
+    {
+      detail:
+        "Your enrolled account [1601394201349935104] does not have any credits to fulfill this request.",
+    },
+    "",
+  );
+  assertEquals(payload.code, "x_billing_blocked");
+  assertStringIncludes(payload.actionRequired, "クレジット");
+  assertStringIncludes(payload.actionRequired, "console.x.com");
+});
+
+Deno.test("spend-cap 403 also maps to x_billing_blocked", () => {
+  const payload = buildXApiErrorPayload(
+    403,
+    { detail: "Monthly spend cap reached for this billing cycle." },
+    "",
+  );
+  assertEquals(payload.code, "x_billing_blocked");
+});
+
+Deno.test("ordinary 403 keeps the x_forbidden mapping", () => {
+  const payload = buildXApiErrorPayload(
+    403,
+    { detail: "You are not permitted to perform this action." },
+    "",
+  );
+  assertEquals(payload.code, "x_forbidden");
+});
+
+Deno.test("client-not-enrolled mapping is unchanged", () => {
+  const payload = buildXApiErrorPayload(
+    403,
+    { reason: "client-not-enrolled" },
+    "",
+  );
+  // reason=client-not-enrolled は billing 語を含まない限り従来コードを維持。
+  assertEquals(payload.code, "x_client_not_enrolled");
+});

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -1664,6 +1664,20 @@ serve(async (req: Request) => {
           return json(await collectXPostMetrics(admin, userId!, body.limit));
         } catch (error) {
           const xPayload = isXApiError(error) ? error.payload : null;
+          // X API クレジット枯渇/spend cap は次の請求サイクルまで自然復旧
+          // しない運用事象。3 時間毎の cron を赤く落とし続けず、HTTP 200 の
+          // skipped で返して workflow 側の warning 表示に委ねる。
+          if (xPayload?.code === "x_billing_blocked") {
+            return json({
+              success: false,
+              skipped: true,
+              collected: 0,
+              error: errorMessage(error),
+              code: "x_billing_blocked",
+              actionRequired: xPayload?.actionRequired ??
+                "X APIクレジット/spend cap枯渇。console.x.com で上限引き上げ、または次の請求サイクルまで収集は自動スキップされます。",
+            });
+          }
           return json({
             success: false,
             error: errorMessage(error),


### PR DESCRIPTION
## 実機障害(2026-07-06)
X APIが **402**(残高ゼロ)で投稿を拒否し、UIには生の英語エラーが表示された。3時間毎の計測cronも次の請求サイクルまで赤く落ち続ける構造だった。
## 変更(edge 2ファイル+workflow 1ファイル)
1. **x-client**: 402(および spend cap/cycle 文言を含む403)を単一コード `x_billing_blocked` へ正規化。通常403と client-not-enrolled の既存マッピングは不変(denoテスト4件で担保)。
2. **実用的な日本語ガイダンス**: 「X APIのクレジット不足/spend cap到達。console.x.com の該当プロジェクトで追加/上限引き上げを」— 既存のUI配送経路(actionRequired転送)は無変更で表示される。
3. **growth-hub x.metrics_collect**: `x_billing_blocked` はHTTP 200+`skipped:true` で返す(自然復旧しない運用事象でcronを赤く落とし続けない)。その他エラーは従来どおり502=アラート維持。
4. **x-post-metrics-optimizer.yml**: 応答に `x_billing_blocked` を検知したら `::warning::` を出力(緑のままoperator信号は残す)。
## 検証
deno test **4件green**(402→x_billing_blocked+日本語actionRequired/spend-cap 403→同/通常403→x_forbidden維持/enrolled不変)・deno lint clean。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge error-code mapping + graceful cron skip covered by 4 new black-box deno tests (402 mapping, spend-cap 403, ordinary 403, enrolled mapping unchanged); the external X API failure mode cannot be exercised from a Flutter integration_test.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Error-code normalization and Japanese guidance strings only; no data-model, permission, or posting-behavior change; cron returns 200 skipped instead of 502 for one operational code; deno 4 tests green.
