### PR TITLE
[CI/CD自動最適化] cron 頻度削減 2026-07-06

### DIFF
--- a/.github/workflows/claude-session-hygiene-cron.yml
+++ b/.github/workflows/claude-session-hygiene-cron.yml
@@ -2,9 +2,9 @@ name: Claude Session Hygiene Cron
 
 on:
   schedule:
-    # Every 180 minutes from 06:00 JST through 03:00 JST next day.
-    # (2026-06-12 ci-audit: 30分→60分 / 2026-06-18 ci-audit: 60分→120分, 21→11runs/日 / 2026-06-21 ci-audit: 120分→180分, 11→8runs/日削減)
-    - cron: "0 21,0,3,6,9,12,15,18 * * *"
+    # Every 360 minutes (6h): 09:00/15:00/21:00/03:00 JST (4 runs/day).
+    # (2026-06-12 ci-audit: 30分→60分 / 2026-06-18 ci-audit: 60分→120分, 21→11runs/日 / 2026-06-21 ci-audit: 120分→180分, 11→8runs/日削減 / 2026-07-06 ci-audit: 180分→360分, 8→4runs/日削減, ~144 windows-billing-min/月削減)
+    - cron: "0 0,6,12,18 * * *"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/x-post-metrics-optimizer.yml
+++ b/.github/workflows/x-post-metrics-optimizer.yml
@@ -2,7 +2,7 @@ name: X Post Metrics Optimizer
 
 on:
   schedule:
-    - cron: "17 */3 * * *"
+    - cron: "17 */6 * * *"  # 2026-07-06 ci-audit: 3h→6h, 8→4runs/日削減, ~240 ubuntu-min/月削減
   workflow_dispatch:
     inputs:
       limit:


### PR DESCRIPTION
## 変更概要

自動監査エージェント (2026-07-06) による低リスク cron 頻度削減。

### 変更ファイル (2 ファイル)

| ファイル | 変更前 | 変更後 | 削減効果 |
|---------|--------|--------|---------|
| `claude-session-hygiene-cron.yml` | `0 21,0,3,6,9,12,15,18 * * *` (8x/日) | `0 0,6,12,18 * * *` (4x/日) | ~144 windows-billing-min/月 |
| `x-post-metrics-optimizer.yml` | `17 */3 * * *` (3h=8x/日) | `17 */6 * * *` (6h=4x/日) | ~240 ubuntu-min/月 |

**合計推定削減: ~240 runs/月・~528 ubuntu換算min/月**

### 根拠

- `claude-session-hygiene-cron` は windows-latest (2× billing) で 8x/日実行中。過去監査での段階的削減実績 (30min→60→120→180→**360min**) に沿った継続改善。
- `x-post-metrics-optimizer` は X API への短時間 API call で 3h 粒度は過剰。6h でも X クレジット節約に寄与。
- 両ファイルとも YAML 構文検証済み (`python yaml.safe_load` 109 ファイル全 OK)。

### 安全確認

- [x] ホワイトリスト該当: 過剰な schedule cron の頻度削減
- [x] deploy 系 concurrency 未変更
- [x] 変更ファイル ≤ 2
- [x] YAML 構文検証 OK
- [x] secrets / permissions / トリガー種別 変更なし

### 監査レポート

`docs/ci-cd-audit/2026-07-06.md` (main へ別途 push)

### CI green 確認後に squash merge してください

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScF4KVzmhjC4LP9jWwTuEu)_