### PR TITLE
fix(x-share): stop truncating the LLM draft at 512 tokens and escalate tiers

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -195,14 +195,23 @@ class UniversalXShareService {
     // 定型文フォールバック(スレッド定型・投票なし)へ劣化した。45 秒 timeout で
     // 失敗を早期検知し 1 回だけ再試行して LLM 経路(長文リード+多様リプ+投票)の
     // 成功率を上げる。traceId で ai_hub_chat_logs と attempt 単位の相関が可能。
-    // 注意: .timeout は実行中の edge 呼び出し自体は中断しない(free tier の重複
-    // 実行は許容)。ai-hub 側のプロバイダ timeout 変更時はこの 45s も見直す。
+    // 注意: .timeout は実行中の edge 呼び出し自体は中断しない(重複実行は許容)。
+    // ai-hub 側のプロバイダ timeout 変更時はこの 45s も見直す。
+    //
+    // 実障害2(2026-07-07 / 2連続503の真因): ①maxTokens 未指定だと edge 既定の
+    // max_tokens=512 で 2,000+ トークンの JSON が途中切断され、健全なプロバイダ
+    // 応答まで finish_reason=length で全滅していた → 8192(サーバ上限)を明示。
+    // ②free ティア先頭の遅延プロバイダが 45 秒予算を焼き尽くす → 収益直結の
+    // この呼び出しは budget ティア開始・リトライは performance ティアへ昇格
+    // (サーバ側でさらに上位ティアへの自動フォールバックが続く)。コストは
+    // テキストのみ数円/投稿で、動画(Hedra)コストとは無関係。
     final traceId = 'uxs-${DateTime.now().microsecondsSinceEpoch}';
     for (var attempt = 0; attempt < 2; attempt += 1) {
       try {
         final response = await _chatService
             .sendAutoChat(
-              tier: 'free',
+              tier: attempt == 0 ? 'budget' : 'performance',
+              maxTokens: 8192,
               sessionId: 'universal-x-share',
               traceId: traceId,
               message: _buildDraftPrompt(

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -168,9 +168,13 @@ void main() {
     'generateDraft retries once after a transient ai-hub failure',
     () async {
       var calls = 0;
+      final tiers = <String?>[];
+      final maxTokens = <Object?>[];
       final chat = AiHubChatService(
         invoker: (body) async {
           calls += 1;
+          tiers.add(body['tier']?.toString());
+          maxTokens.add(body['max_tokens']);
           if (calls == 1) {
             throw Exception('ai-hub 502');
           }
@@ -195,6 +199,10 @@ void main() {
       final draft = await service.generateDraft(page);
       expect(calls, 2);
       expect(draft.fallbackUsed, isFalse);
+      // 収益直結呼び出しは budget ティア開始・リトライで performance へ昇格。
+      expect(tiers, ['budget', 'performance']);
+      // edge 既定の max_tokens=512 で長文 JSON が切断されないよう上限を明示。
+      expect(maxTokens, [8192, 8192]);
     },
     timeout: const Timeout(Duration(minutes: 2)),
   );


### PR DESCRIPTION
## 実機障害(2026-07-07 / 2連続503の真因)
LLMドラフト呼び出しが **maxTokens未指定→edge既定の max_tokens=512** で走っており、2,000+トークンのJSONパッケージが**途中切断(finish_reason=length)→健全なプロバイダ応答まで全滅**→時間予算枯渇の503になっていた。
## 変更(generateDraftのみ)
1. **maxTokens: 8192**(サーバ上限)を明示=長文JSONが切断されない。
2. **ティア昇格**: attempt 0 は `budget` 開始(freeの遅延ヘッドをスキップ)・リトライは `performance`(サーバ側でさらに上位への自動フォールバック継続)。コストはテキストのみ数円/投稿。
## 検証
flutter test **49件green**(リトライテストが `['budget','performance']` と max_tokens=8192 を両attemptで検証)。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Client-side tier/maxTokens change to one LLM call covered by black-box flutter unit tests (49 green incl tier-escalation and max_tokens assertions); no new user-facing route so a full integration_test is disproportionate.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Dart-only client change (flutter unit tests green); any flagged supabase/functions paths would come from other sessions' commits via branch updates, not from this PR's diff.
