### PR TITLE
feat(x-share): keep the video-failure reason in the posted-status message

### DIFF
--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -5,6 +5,33 @@ import '../services/ai_share_button_preferences_service.dart';
 import '../services/universal_x_share_service.dart';
 import 'ai_share_button_settings_panel.dart';
 
+/// 投稿完了メッセージを組み立てる純関数。動画が付かなかった投稿では、その
+/// 理由(例: Hedraクレジット不足)を末尾に残し、operator が投稿画面だけで
+/// 「なぜ静止画になったか」を即視認できるようにする。理由は最初の「。」まで
+/// (最大60字)に短縮する。
+String composePostedStatus({
+  required bool posted,
+  required String? account,
+  required bool videoAttached,
+  required String? videoFailReason,
+}) {
+  if (!posted) {
+    return '投稿できませんでした。X API secret設定を確認してください';
+  }
+  final who = account ?? '@kanta13jp1';
+  if (videoAttached) return '$who に動画付きで投稿しました 🎉';
+  final reason = videoFailReason?.trim() ?? '';
+  if (reason.isEmpty) return '$who に画像付きで投稿しました 🎉';
+  var short = reason;
+  final period = short.indexOf('。');
+  if (period > 0) short = short.substring(0, period);
+  final runes = short.runes.toList(growable: false);
+  if (runes.length > 60) {
+    short = '${String.fromCharCodes(runes.take(60))}…';
+  }
+  return '$who に画像付きで投稿しました（動画なし: $short）';
+}
+
 final universalAiShareRouteObserver = UniversalAiShareRouteObserver();
 
 class UniversalAiShareRouteObserver extends NavigatorObserver {
@@ -344,6 +371,10 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
       _posting = true;
       _statusMessage = null;
     });
+    // 動画が生成できなかった理由。投稿完了メッセージへ残し、静止画になった
+    // 原因(例: Hedraクレジット不足)を operator が投稿画面で即視認できるようにする
+    // (従来は投稿前の一瞬のステータスにしか出ず、気づけなかった)。
+    String? videoFailReason;
     try {
       // 1. 画像(presenter/舞台がローテ)
       if (_imageUrl == null) {
@@ -402,6 +433,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
         if (_videoUrl == null) {
           final reason =
               _extractString(video.raw, 'videoReason') ?? '時間内に完了しませんでした';
+          videoFailReason = reason;
           setState(() => _statusMessage = '動画は生成できませんでした（$reason）。画像付きで投稿します。');
         }
       }
@@ -422,9 +454,12 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
       );
       if (_disposed || !mounted) return;
       setState(() {
-        _statusMessage = result.posted
-            ? '${result.account ?? '@kanta13jp1'} に$postedMedia付きで投稿しました 🎉'
-            : '投稿できませんでした。X API secret設定を確認してください';
+        _statusMessage = composePostedStatus(
+          posted: result.posted,
+          account: result.account,
+          videoAttached: _videoUrl != null,
+          videoFailReason: videoFailReason,
+        );
       });
     } catch (error) {
       if (_disposed || !mounted) return;

--- a/test/widgets/universal_ai_share_status_test.dart
+++ b/test/widgets/universal_ai_share_status_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/universal_ai_share_shell.dart';
+
+void main() {
+  test('composePostedStatus keeps the video-failure reason visible', () {
+    // 実障害(2026-07-07): Hedraクレジット不足で静止画投稿になったが、理由は
+    // 投稿前の一瞬のステータスにしか出ず operator が気づけなかった。投稿完了
+    // メッセージに短縮した理由を残す。
+    final message = composePostedStatus(
+      posted: true,
+      account: '@kanta13jp1',
+      videoAttached: false,
+      videoFailReason:
+          'Hedra のクレジットが不足しています（必要 119 / 残り 68 クレジット）。動画生成には Hedra クレジットの追加が必要です。',
+    );
+    expect(message, contains('画像付きで投稿しました'));
+    expect(message, contains('動画なし:'));
+    expect(message, contains('クレジットが不足'));
+    // 最初の「。」までに短縮され、後続の説明文は落ちる。
+    expect(message, isNot(contains('追加が必要')));
+    // 🎉 は劣化投稿には付けない。
+    expect(message, isNot(contains('🎉')));
+  });
+
+  test('composePostedStatus is unchanged for healthy paths', () {
+    expect(
+      composePostedStatus(
+        posted: true,
+        account: '@kanta13jp1',
+        videoAttached: true,
+        videoFailReason: null,
+      ),
+      '@kanta13jp1 に動画付きで投稿しました 🎉',
+    );
+    expect(
+      composePostedStatus(
+        posted: true,
+        account: null,
+        videoAttached: false,
+        videoFailReason: null,
+      ),
+      '@kanta13jp1 に画像付きで投稿しました 🎉',
+    );
+    expect(
+      composePostedStatus(
+        posted: false,
+        account: null,
+        videoAttached: false,
+        videoFailReason: null,
+      ),
+      contains('投稿できませんでした'),
+    );
+  });
+
+  test('composePostedStatus caps very long reasons at 60 runes', () {
+    final message = composePostedStatus(
+      posted: true,
+      account: '@kanta13jp1',
+      videoAttached: false,
+      videoFailReason: 'あ' * 200,
+    );
+    // 60 runes + 省略記号 + 前後の定型文に収まる。
+    expect(message.contains('…'), isTrue);
+    expect(message.runes.length, lessThan(120));
+  });
+}


### PR DESCRIPTION
## 実機課題(2026-07-07)
動画が静止画に劣化した理由(Hedraクレジット不足 残68/必要119)が**投稿前の一瞬のステータスにしか出ず**、最終メッセージは「画像付きで投稿しました 🎉」= operatorがDB照会しないと原因が分からなかった。
## 変更(shell+テストのみ)
純関数 `composePostedStatus` を抽出し、劣化投稿の最終メッセージへ**短縮理由(最初の「。」まで・60runes上限)を永続表示**=「…に画像付きで投稿しました（動画なし: Hedra のクレジットが不足しています…）」(🎉なし・「不足」でエラー着色発火)。健全経路は従来と同一文言。
## 検証
flutter test 新規3件green(劣化理由表示・健全経路同一・長文cap)。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Pure message-composition function extracted and covered by 3 black-box unit tests (healthy paths byte-identical, degraded path carries the reason); no new user-facing route to E2E.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Dart-only client change (flutter unit tests green); any flagged supabase/functions paths would come from other sessions' commits via branch updates, not from this PR's diff.
