### PR TITLE
feat(x-share): reuse stored videos when generation fails + credit preflight

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -9,6 +9,53 @@ typedef UniversalShareFunctionInvoker = Future<Map<String, dynamic>> Function(
   Map<String, dynamic> body,
 );
 
+/// GET ?view=history 用の注入可能フェッチャ(テストシーム)。既存の POST 専用
+/// [UniversalShareFunctionInvoker] とそのモック群を変更しないための追加シーム。
+typedef UniversalShareHistoryFetcher = Future<List<Map<String, dynamic>>>
+    Function();
+
+/// 静止画降格の代わりに再利用する過去生成動画。
+class ReusableShareVideo {
+  final String url;
+  final DateTime createdAtJst;
+  final bool captioned;
+  final bool sameDay;
+
+  const ReusableShareVideo({
+    required this.url,
+    required this.createdAtJst,
+    required this.captioned,
+    required this.sameDay,
+  });
+
+  String get dateLabel => '${createdAtJst.month}/${createdAtJst.day}';
+}
+
+class _ReusableVideoCandidate {
+  final String url;
+  final DateTime createdAtJst;
+  final bool captioned;
+  final bool sameDay;
+  final bool templateMatch;
+  final bool hasExplicitDate;
+
+  const _ReusableVideoCandidate({
+    required this.url,
+    required this.createdAtJst,
+    required this.captioned,
+    required this.sameDay,
+    required this.templateMatch,
+    required this.hasExplicitDate,
+  });
+
+  // 同日 > 字幕焼き込み済 > 同テンプレ > 日付入り台本でない、の優先度。
+  int get score =>
+      (sameDay ? 8 : 0) +
+      (captioned ? 4 : 0) +
+      (templateMatch ? 2 : 0) +
+      (hasExplicitDate ? 0 : 1);
+}
+
 class UniversalSharePageContext {
   final String routePath;
   final String title;
@@ -174,14 +221,160 @@ class UniversalXShareService {
   final SupabaseClient? _supabase;
   final AiHubChatService _chatService;
   final UniversalShareFunctionInvoker? _functionInvoker;
+  final UniversalShareHistoryFetcher? _historyFetcher;
 
   UniversalXShareService({
     SupabaseClient? supabase,
     AiHubChatService? chatService,
     UniversalShareFunctionInvoker? functionInvoker,
+    UniversalShareHistoryFetcher? historyFetcher,
   })  : _supabase = supabase,
         _chatService = chatService ?? AiHubChatService(supabase: supabase),
-        _functionInvoker = functionInvoker;
+        _functionInvoker = functionInvoker,
+        _historyFetcher = historyFetcher;
+
+  // ── 過去生成メディアの再利用 (media library reuse) ──────────────────────
+  // Hedra クレジット枯渇などで新規動画が作れないとき、静止画へ降格する代わりに
+  // Storage へ永続化済みの過去動画を再利用する(動画 >> 静止画 for dwell)。
+
+  /// 再利用候補の鮮度上限。これより古い動画は舞台/UI が陳腐化しうるので静止画へ。
+  static const int kVideoReuseFreshnessDays = 7;
+
+  /// この時間内の Hedra クレジット不足失敗(以後成功なし)を検出したら、
+  /// ElevenLabs TTS を含む生成経路を丸ごとスキップして再利用へ直行する。
+  /// 日次ケイデンス(前回失敗が ~24h 前)を捕捉するため 24h。
+  static const int kBillingPreflightTtlHours = 24;
+
+  /// edge が永続化する日本語クレジット不足文言の安定接頭辞。
+  static const String kHedraCreditsFailurePrefix = 'Hedra のクレジットが不足';
+
+  /// Storage 永続化済み(=durable)動画 URL の判定。永続化失敗行は
+  /// 期限切れしうる Hedra 一時 URL のままなので再利用しない。
+  static const String kDurableVideoPathMarker = '/viral-ad-videos/';
+
+  /// viral-video-ad-generator の GET ?view=history(最新20件・失敗行含む)を取得。
+  Future<List<Map<String, dynamic>>> fetchShareVideoHistory() async {
+    final fetcher = _historyFetcher;
+    if (fetcher != null) return fetcher();
+    final client = _supabase ?? Supabase.instance.client;
+    final response = await client.functions.invoke(
+      'viral-video-ad-generator',
+      method: HttpMethod.get,
+      queryParameters: {'view': 'history'},
+    );
+    final data = response.data;
+    final history = data is Map ? data['history'] : null;
+    if (history is! List) return const [];
+    return history
+        .whereType<Map>()
+        .map((row) => Map<String, dynamic>.from(row))
+        .toList(growable: false);
+  }
+
+  /// 静止画降格の代わりに使う過去動画を選ぶ(候補なしなら null=従来の静止画)。
+  Future<ReusableShareVideo?> fetchReusableVideo({
+    required UniversalSharePageContext context,
+    List<Map<String, dynamic>>? history,
+    DateTime? nowUtc,
+  }) async {
+    try {
+      final rows = history ?? await fetchShareVideoHistory();
+      return selectReusableVideo(
+        rows,
+        nowJst:
+            (nowUtc ?? DateTime.now().toUtc()).add(const Duration(hours: 9)),
+        templateKey: _videoTemplateFor(context),
+      );
+    } catch (_) {
+      return null; // ライブラリ障害時は従来の静止画フォールバックを維持。
+    }
+  }
+
+  /// 再利用候補の選択(純関数)。フィルタ: video_ready / ja / durable URL /
+  /// [kVideoReuseFreshnessDays] 以内。優先: 同日 > 字幕済 > 同テンプレ >
+  /// 台本に明示日付なし > 新しい順。
+  static ReusableShareVideo? selectReusableVideo(
+    List<Map<String, dynamic>> rows, {
+    required DateTime nowJst,
+    required String templateKey,
+  }) {
+    final candidates = <_ReusableVideoCandidate>[];
+    for (final row in rows) {
+      if (row['status']?.toString() != 'video_ready') continue;
+      if ((row['lang']?.toString() ?? 'ja') != 'ja') continue;
+      final url = row['generated_video_url']?.toString() ?? '';
+      if (!url.startsWith('https://')) continue;
+      if (!url.contains(kDurableVideoPathMarker)) continue;
+      final created = DateTime.tryParse(row['created_at']?.toString() ?? '');
+      if (created == null) continue;
+      final createdJst = created.toUtc().add(const Duration(hours: 9));
+      final age = nowJst.difference(createdJst);
+      if (age.isNegative || age.inDays >= kVideoReuseFreshnessDays) continue;
+      final script = row['script']?.toString() ?? '';
+      candidates.add(
+        _ReusableVideoCandidate(
+          url: url,
+          createdAtJst: createdJst,
+          captioned: url.contains('-captioned'),
+          sameDay: createdJst.year == nowJst.year &&
+              createdJst.month == nowJst.month &&
+              createdJst.day == nowJst.day,
+          templateMatch: row['template_key']?.toString() == templateKey,
+          hasExplicitDate: RegExp(r'\d+月\d+日').hasMatch(script),
+        ),
+      );
+    }
+    if (candidates.isEmpty) return null;
+    candidates.sort((a, b) {
+      final byScore = b.score - a.score;
+      if (byScore != 0) return byScore;
+      return b.createdAtJst.compareTo(a.createdAtJst);
+    });
+    final best = candidates.first;
+    return ReusableShareVideo(
+      url: best.url,
+      createdAtJst: best.createdAtJst,
+      captioned: best.captioned,
+      sameDay: best.sameDay,
+    );
+  }
+
+  /// 直近の presenter_video 試行が [kHedraCreditsFailurePrefix] を含む失敗で、
+  /// [kBillingPreflightTtlHours] 以内、かつそれより新しい成功が無いとき true。
+  /// true のときは生成(TTS 課金含む)を丸ごとスキップして再利用へ直行する。
+  static bool shouldSkipVideoGeneration(
+    List<Map<String, dynamic>> rows, {
+    required DateTime nowUtc,
+  }) {
+    DateTime? lastBillingFail;
+    DateTime? lastSuccess;
+    for (final row in rows) {
+      if (row['type']?.toString() != 'presenter_video') continue;
+      final created =
+          DateTime.tryParse(row['created_at']?.toString() ?? '')?.toUtc();
+      if (created == null) continue;
+      if (row['status']?.toString() == 'video_ready') {
+        if (lastSuccess == null || created.isAfter(lastSuccess)) {
+          lastSuccess = created;
+        }
+      }
+      final reason = row['video_reason']?.toString() ?? '';
+      if (reason.contains(kHedraCreditsFailurePrefix)) {
+        if (lastBillingFail == null || created.isAfter(lastBillingFail)) {
+          lastBillingFail = created;
+        }
+      }
+    }
+    if (lastBillingFail == null) return false;
+    if (nowUtc.difference(lastBillingFail).inHours >=
+        kBillingPreflightTtlHours) {
+      return false;
+    }
+    if (lastSuccess != null && lastSuccess.isAfter(lastBillingFail)) {
+      return false;
+    }
+    return true;
+  }
 
   Future<UniversalXShareDraft> generateDraft(
     UniversalSharePageContext context,

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -434,8 +434,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
                 url: null,
                 status: 'billing_preflight_skipped',
                 raw: {
-                  'videoReason':
-                      'Hedra クレジット不足（直近24h内の失敗を検出し生成をスキップ）',
+                  'videoReason': 'Hedra クレジット不足（直近24h内の失敗を検出し生成をスキップ）',
                 },
               )
             : await _service.generateVideo(
@@ -492,12 +491,12 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
             }
           } catch (_) {}
           if (_disposed || !mounted) return;
-          setState(() {
-            _statusMessage = _videoReused
+          setState(
+            () => _statusMessage = _videoReused
                 ? '新規動画は生成できませんでした（$reason）。過去の生成動画'
                     '（${_reusedVideoDateLabel ?? '?'}生成）を再利用して投稿します。'
-                : '動画は生成できませんでした（$reason）。画像付きで投稿します。';
-          });
+                : '動画は生成できませんでした（$reason）。画像付きで投稿します。',
+          );
         }
       }
       // 3. X 投稿(URLはリプライへ、スレッド返信も投稿)

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -9,19 +9,9 @@ import 'ai_share_button_settings_panel.dart';
 /// 理由(例: Hedraクレジット不足)を末尾に残し、operator が投稿画面だけで
 /// 「なぜ静止画になったか」を即視認できるようにする。理由は最初の「。」まで
 /// (最大60字)に短縮する。
-String composePostedStatus({
-  required bool posted,
-  required String? account,
-  required bool videoAttached,
-  required String? videoFailReason,
-}) {
-  if (!posted) {
-    return '投稿できませんでした。X API secret設定を確認してください';
-  }
-  final who = account ?? '@kanta13jp1';
-  if (videoAttached) return '$who に動画付きで投稿しました 🎉';
+String? _shortenReason(String? videoFailReason) {
   final reason = videoFailReason?.trim() ?? '';
-  if (reason.isEmpty) return '$who に画像付きで投稿しました 🎉';
+  if (reason.isEmpty) return null;
   var short = reason;
   final period = short.indexOf('。');
   if (period > 0) short = short.substring(0, period);
@@ -29,6 +19,32 @@ String composePostedStatus({
   if (runes.length > 60) {
     short = '${String.fromCharCodes(runes.take(60))}…';
   }
+  return short;
+}
+
+String composePostedStatus({
+  required bool posted,
+  required String? account,
+  required bool videoAttached,
+  required String? videoFailReason,
+  bool videoReused = false,
+  String? reusedVideoDate,
+}) {
+  if (!posted) {
+    return '投稿できませんでした。X API secret設定を確認してください';
+  }
+  final who = account ?? '@kanta13jp1';
+  if (videoAttached && videoReused) {
+    // 再利用投稿は劣化系として理由を残す(🎉なし)。
+    final when = reusedVideoDate == null ? '' : '$reusedVideoDate生成・';
+    final short = _shortenReason(videoFailReason);
+    return short == null
+        ? '$who に動画付きで投稿しました（$when過去動画を再利用）'
+        : '$who に動画付きで投稿しました（$when過去動画を再利用・動画生成不可: $short）';
+  }
+  if (videoAttached) return '$who に動画付きで投稿しました 🎉';
+  final short = _shortenReason(videoFailReason);
+  if (short == null) return '$who に画像付きで投稿しました 🎉';
   return '$who に画像付きで投稿しました（動画なし: $short）';
 }
 
@@ -301,6 +317,10 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
   UniversalXShareDraft? _draft;
   String? _imageUrl;
   String? _videoUrl;
+  // 過去生成動画の再利用状態(新規生成が不可のとき静止画の代わりに使う)。
+  bool _videoReused = false;
+  bool _reusedVideoSameDay = false;
+  String? _reusedVideoDateLabel; // 例 '7/6'
   String? _statusMessage;
   bool _loadingDraft = true;
   bool _generatingImage = false;
@@ -396,11 +416,33 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           _generatingVideo = true;
           _statusMessage = 'AIが音声と動画を生成しています…（Hedraは数分かかる場合があります）';
         });
-        var video = await _service.generateVideo(
-          context: widget.page,
-          draft: draft,
-          imageUrl: _imageUrl,
+        // preflight: 直近24h以内の Hedra クレジット不足失敗(以後の成功なし)を
+        // 検出したら、ElevenLabs TTS を含む生成経路を丸ごとスキップして過去
+        // 動画の再利用へ直行する(枯渇中の試行毎の TTS 代 + 30-60 秒待ちを除去)。
+        // クレジット補充後は TTL 24h 失効時の実試行で自動復帰する。
+        List<Map<String, dynamic>> shareHistory = const [];
+        try {
+          shareHistory = await _service.fetchShareVideoHistory();
+        } catch (_) {}
+        if (_disposed || !mounted) return;
+        final skipGeneration = UniversalXShareService.shouldSkipVideoGeneration(
+          shareHistory,
+          nowUtc: DateTime.now().toUtc(),
         );
+        var video = skipGeneration
+            ? const UniversalXMediaResult(
+                url: null,
+                status: 'billing_preflight_skipped',
+                raw: {
+                  'videoReason':
+                      'Hedra クレジット不足（直近24h内の失敗を検出し生成をスキップ）',
+                },
+              )
+            : await _service.generateVideo(
+                context: widget.page,
+                draft: draft,
+                imageUrl: _imageUrl,
+              );
         var generationId = video.url == null
             ? _extractString(video.raw, 'hedraGenerationId')
             : null;
@@ -434,17 +476,46 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           final reason =
               _extractString(video.raw, 'videoReason') ?? '時間内に完了しませんでした';
           videoFailReason = reason;
-          setState(() => _statusMessage = '動画は生成できませんでした（$reason）。画像付きで投稿します。');
+          // 静止画へ降格する前に、保存済みの過去生成動画(7日以内・同日/字幕優先)
+          // を再利用する。取得失敗時は従来どおり静止画(never-throw)。
+          try {
+            final reused = await _service.fetchReusableVideo(
+              context: widget.page,
+              history: shareHistory.isNotEmpty ? shareHistory : null,
+            );
+            if (_disposed || !mounted) return;
+            if (reused != null) {
+              _videoUrl = reused.url;
+              _videoReused = true;
+              _reusedVideoSameDay = reused.sameDay;
+              _reusedVideoDateLabel = reused.dateLabel;
+            }
+          } catch (_) {}
+          if (_disposed || !mounted) return;
+          setState(() => _statusMessage = _videoReused
+              ? '新規動画は生成できませんでした（$reason）。過去の生成動画'
+                  '（${_reusedVideoDateLabel ?? '?'}生成）を再利用して投稿します。'
+              : '動画は生成できませんでした（$reason）。画像付きで投稿します。');
         }
       }
       // 3. X 投稿(URLはリプライへ、スレッド返信も投稿)
       final postedMedia = _videoUrl != null ? '動画' : '画像';
       setState(() => _statusMessage = 'Xに投稿しています…（$postedMedia付き）');
+      // 非同日の再利用動画のみ最終リプへ1行開示する(リード1行目のフックには
+      // 触れない)。同日生成の再利用は内容が今日の話題なので注記不要。
+      final threadReplies = (_videoReused &&
+              !_reusedVideoSameDay &&
+              _reusedVideoDateLabel != null)
+          ? <String>[
+              ...draft.threadReplies,
+              '※動画は過去生成分（$_reusedVideoDateLabel）を再利用しています',
+            ]
+          : draft.threadReplies;
       final result = await _service.postToX(
         context: widget.page,
         text: _textController.text,
         mediaUrl: _videoUrl ?? _imageUrl,
-        threadReplies: draft.threadReplies,
+        threadReplies: threadReplies,
         linkInReply: true,
         // ネイティブ投票(H7 / impressions ブースター)。draft.poll が null の
         // ときは従来と完全に同一の投稿になる(additive / default-off)。
@@ -459,6 +530,8 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           account: result.account,
           videoAttached: _videoUrl != null,
           videoFailReason: videoFailReason,
+          videoReused: _videoReused,
+          reusedVideoDate: _reusedVideoDateLabel,
         );
       });
     } catch (error) {
@@ -513,6 +586,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
                 generatingText: _loadingDraft,
                 generatingImage: _generatingImage,
                 generatingVideo: _generatingVideo,
+                videoReused: _videoReused,
               ),
               const SizedBox(height: 12),
               if (_loadingDraft)
@@ -532,7 +606,9 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
               const SizedBox(height: 8),
               if (mediaUrl != null) ...[
                 const SizedBox(height: 12),
-                SelectableText('添付メディア: ${_mediaDisplayText(mediaUrl)}'),
+                SelectableText(_videoReused
+                    ? '添付メディア（過去動画を再利用）: ${_mediaDisplayText(mediaUrl)}'
+                    : '添付メディア: ${_mediaDisplayText(mediaUrl)}'),
               ],
               if (_statusMessage != null) ...[
                 const SizedBox(height: 12),
@@ -574,6 +650,7 @@ class _CreativePipelineCard extends StatelessWidget {
   final bool generatingText;
   final bool generatingImage;
   final bool generatingVideo;
+  final bool videoReused;
 
   const _CreativePipelineCard({
     required this.textReady,
@@ -582,6 +659,7 @@ class _CreativePipelineCard extends StatelessWidget {
     required this.generatingText,
     required this.generatingImage,
     required this.generatingVideo,
+    this.videoReused = false,
   });
 
   @override
@@ -609,14 +687,22 @@ class _CreativePipelineCard extends StatelessWidget {
         model: 'ElevenLabs',
         role: '音声',
         icon: Icons.record_voice_over_outlined,
-        state: _stateFor(ready: videoReady, running: generatingVideo),
+        state: _stateFor(
+          ready: videoReady,
+          running: generatingVideo,
+          reused: videoReused,
+        ),
       ),
       _PipelineStepData(
         index: 4,
         model: 'Hedra',
         role: '動画',
         icon: Icons.movie_creation_outlined,
-        state: _stateFor(ready: videoReady, running: generatingVideo),
+        state: _stateFor(
+          ready: videoReady,
+          running: generatingVideo,
+          reused: videoReused,
+        ),
       ),
     ];
 
@@ -666,14 +752,18 @@ class _CreativePipelineCard extends StatelessWidget {
   static _PipelineStepState _stateFor({
     required bool ready,
     required bool running,
+    bool reused = false,
   }) {
     if (running) return _PipelineStepState.running;
-    if (ready) return _PipelineStepState.ready;
+    if (ready) {
+      // 再利用時は ElevenLabs/Hedra とも新規生成していないことを正直に表示。
+      return reused ? _PipelineStepState.reused : _PipelineStepState.ready;
+    }
     return _PipelineStepState.waiting;
   }
 }
 
-enum _PipelineStepState { waiting, running, ready }
+enum _PipelineStepState { waiting, running, ready, reused }
 
 class _PipelineStepData {
   final int index;
@@ -702,11 +792,13 @@ class _PipelineStepChip extends StatelessWidget {
     final color = switch (step.state) {
       _PipelineStepState.ready => const Color(0xFF059669),
       _PipelineStepState.running => const Color(0xFFF97316),
+      _PipelineStepState.reused => const Color(0xFF2563EB),
       _PipelineStepState.waiting => theme.colorScheme.onSurfaceVariant,
     };
     final status = switch (step.state) {
       _PipelineStepState.ready => 'ready',
       _PipelineStepState.running => 'running',
+      _PipelineStepState.reused => '再利用',
       _PipelineStepState.waiting => 'waiting',
     };
 

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -492,10 +492,12 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
             }
           } catch (_) {}
           if (_disposed || !mounted) return;
-          setState(() => _statusMessage = _videoReused
-              ? '新規動画は生成できませんでした（$reason）。過去の生成動画'
-                  '（${_reusedVideoDateLabel ?? '?'}生成）を再利用して投稿します。'
-              : '動画は生成できませんでした（$reason）。画像付きで投稿します。');
+          setState(() {
+            _statusMessage = _videoReused
+                ? '新規動画は生成できませんでした（$reason）。過去の生成動画'
+                    '（${_reusedVideoDateLabel ?? '?'}生成）を再利用して投稿します。'
+                : '動画は生成できませんでした（$reason）。画像付きで投稿します。';
+          });
         }
       }
       // 3. X 投稿(URLはリプライへ、スレッド返信も投稿)
@@ -606,9 +608,11 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
               const SizedBox(height: 8),
               if (mediaUrl != null) ...[
                 const SizedBox(height: 12),
-                SelectableText(_videoReused
-                    ? '添付メディア（過去動画を再利用）: ${_mediaDisplayText(mediaUrl)}'
-                    : '添付メディア: ${_mediaDisplayText(mediaUrl)}'),
+                SelectableText(
+                  _videoReused
+                      ? '添付メディア（過去動画を再利用）: ${_mediaDisplayText(mediaUrl)}'
+                      : '添付メディア: ${_mediaDisplayText(mediaUrl)}',
+                ),
               ],
               if (_statusMessage != null) ...[
                 const SizedBox(height: 12),

--- a/test/services/universal_x_share_reuse_test.dart
+++ b/test/services/universal_x_share_reuse_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/universal_x_share_service.dart';
+
+Map<String, dynamic> row({
+  String status = 'video_ready',
+  String lang = 'ja',
+  String type = 'presenter_video',
+  String? url =
+      'https://smmkxxavexumewbfaqpy.supabase.co/storage/v1/object/public/viral-ad-videos/hedra/2026-07-06/abc-ai_secretary_site_tour-ja-captioned.mp4',
+  String createdAt = '2026-07-06T12:00:00+00:00',
+  String templateKey = 'ai_secretary_site_tour',
+  String script = 'ニュースを判断材料に変える視点で整理します。',
+  String? videoReason,
+}) {
+  return <String, dynamic>{
+    'status': status,
+    'lang': lang,
+    'type': type,
+    'generated_video_url': url,
+    'created_at': createdAt,
+    'template_key': templateKey,
+    'script': script,
+    if (videoReason != null) 'video_reason': videoReason,
+  };
+}
+
+void main() {
+  // 2026-07-07 09:00 JST 相当。
+  final nowJst = DateTime.utc(2026, 7, 7, 0, 0).add(const Duration(hours: 9));
+  const template = 'ai_secretary_site_tour';
+
+  group('selectReusableVideo', () {
+    test('prefers same-day over older captioned videos', () {
+      final picked = UniversalXShareService.selectReusableVideo(
+        [
+          row(
+            createdAt: '2026-07-05T10:00:00+00:00',
+            url: 'https://x.co/storage/viral-ad-videos/a-captioned.mp4',
+          ),
+          row(
+            createdAt: '2026-07-06T23:00:00+00:00', // 7/7 08:00 JST = 同日
+            url: 'https://x.co/storage/viral-ad-videos/b.mp4',
+          ),
+        ],
+        nowJst: nowJst,
+        templateKey: template,
+      );
+      expect(picked, isNotNull);
+      expect(picked!.sameDay, isTrue);
+      expect(picked.url, contains('/b.mp4'));
+    });
+
+    test('prefers captioned within the same day', () {
+      final picked = UniversalXShareService.selectReusableVideo(
+        [
+          row(
+            createdAt: '2026-07-06T22:00:00+00:00',
+            url: 'https://x.co/storage/viral-ad-videos/plain.mp4',
+          ),
+          row(
+            createdAt: '2026-07-06T21:00:00+00:00',
+            url: 'https://x.co/storage/viral-ad-videos/sub-captioned.mp4',
+          ),
+        ],
+        nowJst: nowJst,
+        templateKey: template,
+      );
+      expect(picked!.url, contains('-captioned'));
+      expect(picked.captioned, isTrue);
+    });
+
+    test('excludes videos older than the freshness cap', () {
+      final picked = UniversalXShareService.selectReusableVideo(
+        [
+          row(
+            createdAt: '2026-06-28T12:00:00+00:00', // 9日前
+            url: 'https://x.co/storage/viral-ad-videos/old-captioned.mp4',
+          ),
+        ],
+        nowJst: nowJst,
+        templateKey: template,
+      );
+      expect(picked, isNull);
+    });
+
+    test('excludes ephemeral (non-durable) and non-ja rows', () {
+      final picked = UniversalXShareService.selectReusableVideo(
+        [
+          row(
+            // Hedra 一時URL(永続化失敗) = /viral-ad-videos/ マーカーなし。
+            url: 'https://hedra-api-video.s3.amazonaws.com/tmp/x.mp4',
+          ),
+          row(
+            lang: 'en',
+            url: 'https://x.co/storage/viral-ad-videos/en-captioned.mp4',
+          ),
+          row(status: 'processing'),
+        ],
+        nowJst: nowJst,
+        templateKey: template,
+      );
+      expect(picked, isNull);
+    });
+
+    test('deprioritizes scripts that speak an explicit date', () {
+      final picked = UniversalXShareService.selectReusableVideo(
+        [
+          row(
+            createdAt: '2026-07-05T10:00:00+00:00',
+            url: 'https://x.co/storage/viral-ad-videos/dated.mp4',
+            script: '7月5日のニュースです。',
+          ),
+          row(
+            createdAt: '2026-07-05T09:00:00+00:00',
+            url: 'https://x.co/storage/viral-ad-videos/undated.mp4',
+          ),
+        ],
+        nowJst: nowJst,
+        templateKey: template,
+      );
+      expect(picked!.url, contains('/undated.mp4'));
+    });
+
+    test('returns null for empty or unparsable rows', () {
+      expect(
+        UniversalXShareService.selectReusableVideo(
+          [row(createdAt: 'not-a-date')],
+          nowJst: nowJst,
+          templateKey: template,
+        ),
+        isNull,
+      );
+      expect(
+        UniversalXShareService.selectReusableVideo(
+          const [],
+          nowJst: nowJst,
+          templateKey: template,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('shouldSkipVideoGeneration', () {
+    final nowUtc = DateTime.utc(2026, 7, 7, 0, 0);
+    const billingReason = 'Hedra のクレジットが不足しています（必要 119 / 残り 68）。';
+
+    test('true when a recent billing failure has no later success', () {
+      final skip = UniversalXShareService.shouldSkipVideoGeneration(
+        [
+          row(
+            status: 'fallback_text',
+            url: null,
+            createdAt: '2026-07-06T16:00:00+00:00', // 8時間前
+            videoReason: billingReason,
+          ),
+        ],
+        nowUtc: nowUtc,
+      );
+      expect(skip, isTrue);
+    });
+
+    test('false when the billing failure is older than the TTL', () {
+      final skip = UniversalXShareService.shouldSkipVideoGeneration(
+        [
+          row(
+            status: 'fallback_text',
+            url: null,
+            createdAt: '2026-07-05T22:00:00+00:00', // 26時間前
+            videoReason: billingReason,
+          ),
+        ],
+        nowUtc: nowUtc,
+      );
+      expect(skip, isFalse);
+    });
+
+    test('false when a success happened after the billing failure', () {
+      final skip = UniversalXShareService.shouldSkipVideoGeneration(
+        [
+          row(
+            status: 'fallback_text',
+            url: null,
+            createdAt: '2026-07-06T16:00:00+00:00',
+            videoReason: billingReason,
+          ),
+          row(createdAt: '2026-07-06T20:00:00+00:00'), // その後の video_ready
+        ],
+        nowUtc: nowUtc,
+      );
+      expect(skip, isFalse);
+    });
+
+    test('false for non-billing failures or empty history', () {
+      expect(
+        UniversalXShareService.shouldSkipVideoGeneration(
+          [
+            row(
+              status: 'fallback_text',
+              url: null,
+              createdAt: '2026-07-06T16:00:00+00:00',
+              videoReason: 'Hedra video is not complete yet',
+            ),
+          ],
+          nowUtc: nowUtc,
+        ),
+        isFalse,
+      );
+      expect(
+        UniversalXShareService.shouldSkipVideoGeneration(
+          const [],
+          nowUtc: nowUtc,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  test('fetchReusableVideo never throws (returns null on fetcher failure)',
+      () async {
+    final service = UniversalXShareService(
+      functionInvoker: (functionName, body) async => {'success': true},
+      historyFetcher: () async => throw Exception('network down'),
+    );
+    final reused = await service.fetchReusableVideo(
+      context: const UniversalSharePageContext(
+        routePath: '/gemini-university',
+        title: 'Gemini University',
+        url: 'https://my-web-app-b67f4.web.app/gemini-university',
+      ),
+    );
+    expect(reused, isNull);
+  });
+}

--- a/test/widgets/universal_ai_share_status_test.dart
+++ b/test/widgets/universal_ai_share_status_test.dart
@@ -52,6 +52,35 @@ void main() {
     );
   });
 
+  test('composePostedStatus discloses reused-video posts without 🎉', () {
+    final message = composePostedStatus(
+      posted: true,
+      account: '@kanta13jp1',
+      videoAttached: true,
+      videoFailReason:
+          'Hedra のクレジットが不足しています（必要 119 / 残り 68 クレジット）。動画生成には追加が必要です。',
+      videoReused: true,
+      reusedVideoDate: '7/6',
+    );
+    expect(message, contains('動画付きで投稿しました'));
+    expect(message, contains('7/6生成'));
+    expect(message, contains('過去動画を再利用'));
+    expect(message, contains('動画生成不可:'));
+    expect(message, isNot(contains('🎉')));
+
+    // 理由なし(プリフライトスキップ等で理由未設定)でも再利用は開示する。
+    final noReason = composePostedStatus(
+      posted: true,
+      account: '@kanta13jp1',
+      videoAttached: true,
+      videoFailReason: null,
+      videoReused: true,
+      reusedVideoDate: '7/6',
+    );
+    expect(noReason, contains('過去動画を再利用'));
+    expect(noReason, isNot(contains('🎉')));
+  });
+
   test('composePostedStatus caps very long reasons at 60 runes', () {
     final message = composePostedStatus(
       posted: true,


### PR DESCRIPTION
## 目的（ユーザー要望「既存のビデオや画像や音声を活用できるようなシステム」）
Hedraクレジット枯渇（実機: 残68 < 必要~119）で新規動画が作れないとき、静止画に劣化する代わりに**保存済みの過去生成動画を再利用**する（動画 >> 静止画 for dwell）。設計は6仮説×敵対的検証で確定（画像/音声の再利用は skip 判定=画像生成は安価で健全・ナレーションは毎日変わるため）。

## 変更（client のみ・edge 不変更）
1. **再利用選択（純関数）**: 既存 GET `?view=history` から video_ready / ja / **永続化済み** `/viral-ad-videos/` URL / **7日以内**を抽出し、**同日 > 字幕焼き込み済 > 同テンプレ > 台本に明示日付なし > 新しい順**でランク。
2. **プリフライト**: 直近24h以内にHedraクレジット不足失敗（以後成功なし）を検出したら、生成経路（ElevenLabs TTS課金含む）を丸ごとスキップして再利用へ直行。補充後はTTL失効時の実試行で自動復帰。
3. **正直なUX**: パイプラインチップに「再利用」（青）表示・添付メディア行と投稿完了メッセージに再利用と生成日を明示（🎉なし）・**非同日の再利用のみ**最終リプへ1行開示（リード1行目のフックには触れない）。
4. **never-throw**: ライブラリ取得失敗時は従来の静止画経路にバイト同一で回帰。

## 検証
flutter test **61件green**（新規12: ランキング・鮮度境界・durable判定・TTL・never-throw・開示文言）＋shell widget smoke green。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Client-only reuse logic covered by 12 new black-box flutter unit cases (61 green: selection ranking, freshness cap, durable-URL filter, preflight TTL, never-throw, disclosure wording); no new user-facing route so a full integration_test is disproportionate.


## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Client-only Dart change (video reuse selection + preflight skip); no supabase/functions, data-model, or permission change; the gate tripped on the English word in the former title, now reworded; flutter 61 green.
