### PR TITLE
feat(growth-hub): 7-day metrics window + video-vs-image structural lift

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -29,6 +29,7 @@ import {
   isRecentSignupCreatedAt,
   resolveSignupChannel,
 } from "./signup_notification.ts";
+import { filterRecentLogs } from "./metrics_window.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -43,6 +44,14 @@ const SERVICE_ROLE_KEY = Deno.env.get("SERVICE_ROLE_KEY") ??
 const X_DUP_SIMILARITY_THRESHOLD = Deno.env.get("X_DUP_SIMILARITY_THRESHOLD") ??
   null;
 const X_DUP_RECENT_COUNT = Deno.env.get("X_DUP_RECENT_COUNT") ?? null;
+// metrics 収集の鮮度窓(日)。X 指標は ~72h で定常化するため、窓外の再読は
+// X API の spend cap を浪費するだけ(実障害 2026-07-05〜07)。既定 7 日。
+// `supabase secrets set X_METRICS_WINDOW_DAYS=14` で再デプロイなしに調整可。
+const X_METRICS_WINDOW_DAYS = Deno.env.get("X_METRICS_WINDOW_DAYS") ?? null;
+const metricsWindowDays = (() => {
+  const n = Number(X_METRICS_WINDOW_DAYS);
+  return Number.isFinite(n) && n > 0 ? n : 7;
+})();
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -425,6 +434,8 @@ function metricSnapshotForLog(
     ),
     has_media: Boolean(metadata.media_url),
     media_url: firstString(metadata.media_url) || null,
+    // 動画 vs 画像の構造 lift 判定用(1:1 アスペクト実験のトリガーデータ)。
+    media_type: firstString(metadata.media_type) || null,
     link_in_reply: metadata.link_in_reply === true,
     thread_reply_count: Array.isArray(metadata.reply_texts)
       ? metadata.reply_texts.length
@@ -472,8 +483,12 @@ async function collectXPostMetrics(
     Math.min(100, Math.trunc(firstNumber(rawLimit) ?? 50)),
   );
   const logs = (await listXPostLogs(admin, userId, limit)) as XPostLogItem[];
+  // 鮮度窓フィルタ: 窓外の計測済み行を毎サイクル再読しない(X 指標は ~72h で
+  // 定常化)。未計測行は年齢に関わらず 1 回はレスキューされる(cap 停止中の
+  // 投稿を復旧後に必ず計測するため)。詳細は metrics_window.ts。
+  const recentLogs = filterRecentLogs(logs, metricsWindowDays, Date.now());
   const targetsByLogId = new Map(
-    logs.map((item) => [item.id, tweetTargetsForLog(item)]),
+    recentLogs.map((item) => [item.id, tweetTargetsForLog(item)]),
   );
   const tweetIds = [
     ...new Set(
@@ -485,7 +500,8 @@ async function collectXPostMetrics(
       success: true,
       collected: 0,
       metrics: [],
-      warning: "No posted x_post_log rows with tweet_id were found.",
+      warning: "No posted x_post_log rows with tweet_id were found " +
+        `within the ${metricsWindowDays}-day metrics window.`,
     };
   }
 
@@ -494,7 +510,7 @@ async function collectXPostMetrics(
   const checkedAt = new Date().toISOString();
   const snapshots: Record<string, unknown>[] = [];
 
-  for (const item of logs) {
+  for (const item of recentLogs) {
     const metadata = asRecord(item.metadata);
     const targets = targetsByLogId.get(item.id) ?? [];
     const itemSnapshots = targets
@@ -589,6 +605,7 @@ function buildXPerformanceContextFromLogs(logs: XPostLogItem[]) {
         route: firstString(latest.route, metadata.route),
         source: firstString(latest.source, metadata.source),
         hasMedia: Boolean(latest.has_media ?? metadata.media_url),
+        mediaType: firstString(metadata.media_type, latest.media_type),
         linkInReply: latest.link_in_reply === true ||
           metadata.link_in_reply === true,
         threadReplyCount: firstNumber(
@@ -654,6 +671,19 @@ function buildXPerformanceContextFromLogs(logs: XPostLogItem[]) {
       } (n=${withMedia.length}) vs without=${
         avgScore(withoutMedia)
       } (n=${withoutMedia.length}).`,
+    );
+  }
+  // 動画 vs 非動画(画像/なし)の lift。1:1 アスペクト実験(R4 defer)の判定
+  // データ。media_type が貯まるまでは自動的に沈黙する(sample ガード)。
+  const withVideo = rows.filter((r) => r.mediaType.startsWith("video/"));
+  const withoutVideo = rows.filter((r) => !r.mediaType.startsWith("video/"));
+  if (withVideo.length >= 2 && withoutVideo.length >= 2) {
+    structuralLines.push(
+      `Structural lift (video vs image/none): avg score video=${
+        avgScore(withVideo)
+      } (n=${withVideo.length}) vs non-video=${
+        avgScore(withoutVideo)
+      } (n=${withoutVideo.length}).`,
     );
   }
   const linkReply = rows.filter((r) => r.linkInReply);

--- a/supabase/functions/growth-hub/metrics_window.test.ts
+++ b/supabase/functions/growth-hub/metrics_window.test.ts
@@ -1,0 +1,44 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { filterRecentLogs } from "./metrics_window.ts";
+
+const NOW = Date.parse("2026-07-07T00:00:00Z");
+const DAY = 86_400_000;
+
+function log(
+  createdAgoDays: number,
+  checkedAt: string | null,
+): { id: string; created_at: string; metadata: Record<string, unknown> } {
+  return {
+    id: `${createdAgoDays}-${checkedAt}`,
+    created_at: new Date(NOW - createdAgoDays * DAY).toISOString(),
+    metadata: checkedAt == null ? {} : { metrics_checked_at: checkedAt },
+  };
+}
+
+Deno.test("filterRecentLogs keeps measured rows inside the window", () => {
+  const rows = [log(3, "2026-07-06T00:00:00Z")];
+  assertEquals(filterRecentLogs(rows, 7, NOW).length, 1);
+});
+
+Deno.test("filterRecentLogs drops measured rows outside the window", () => {
+  const rows = [log(8, "2026-07-01T00:00:00Z")];
+  assertEquals(filterRecentLogs(rows, 7, NOW).length, 0);
+});
+
+Deno.test("filterRecentLogs keeps unmeasured rows regardless of age", () => {
+  // cap 停止中に生まれた古い投稿も、復旧後 1 回は必ず計測する。
+  const rows = [log(30, null)];
+  assertEquals(filterRecentLogs(rows, 7, NOW).length, 1);
+});
+
+Deno.test("filterRecentLogs fail-opens on unparsable created_at", () => {
+  const broken = {
+    id: "broken",
+    created_at: "not-a-date",
+    metadata: { metrics_checked_at: "2026-07-01T00:00:00Z" },
+  };
+  assert(filterRecentLogs([broken], 7, NOW).length === 1);
+});

--- a/supabase/functions/growth-hub/metrics_window.ts
+++ b/supabase/functions/growth-hub/metrics_window.ts
@@ -1,0 +1,38 @@
+// growth-hub: metrics 収集対象の鮮度フィルタ (R8-recency-window)。
+//
+// なぜ必要か: X のポスト指標は投稿後 ~72h でほぼ定常化する。窓なしで全履歴を
+// 3 時間毎に再読すると、読取量が投稿の蓄積に比例して無限に増え、X API の
+// spend cap を焼き尽くす(実障害 2026-07-05〜07: cap 到達で投稿・計測が数日
+// 停止し、perf フィードバックループがデータ饑餓に陥った)。
+//
+// 保持条件(いずれか):
+//   (a) created_at が windowDays 以内(鮮度窓)
+//   (b) created_at がパース不能(fail-open — 壊れた行で計測を落とさない)
+//   (c) 未計測(metadata.metrics_checked_at 不在) — cap 停止中に生まれた投稿を
+//       復旧後 1 回は必ず計測するレスキュー。1 回計測されると (a) の窓判定へ
+//       自然移行するため、自己制限的で読取が再増殖しない。
+
+export interface MetricsWindowLog {
+  created_at?: unknown;
+  metadata?: unknown;
+}
+
+export function filterRecentLogs<T extends MetricsWindowLog>(
+  logs: T[],
+  windowDays: number,
+  nowMs: number,
+): T[] {
+  const windowMs = windowDays * 86_400_000;
+  return logs.filter((log) => {
+    const metadata = (log.metadata ?? {}) as Record<string, unknown>;
+    const checkedAt = metadata["metrics_checked_at"];
+    if (checkedAt == null || String(checkedAt).trim() === "") {
+      return true; // (c) 未計測レスキュー
+    }
+    const createdMs = Date.parse(String(log.created_at ?? ""));
+    if (!Number.isFinite(createdMs)) {
+      return true; // (b) fail-open
+    }
+    return nowMs - createdMs <= windowMs; // (a) 鮮度窓
+  });
+}


### PR DESCRIPTION
## 目的(R8 / high・7/10のX課金サイクルリセット前に反映)
3時間毎のメトリクス収集が**全履歴を毎サイクル再読**しており、読取量が投稿蓄積に比例して無限成長→X APIのspend capを焼き尽くし(実障害 7/5〜7/7: 投稿・計測が数日ブロック)、計測ループがデータ饑餓に陥った。
## 変更(growth-hub)
- **7日鮮度窓** `filterRecentLogs`(新規純モジュール+deno test 4件): (a)窓内 (b)created_atパース不能はfail-open (c)**未計測行はレスキュー**(cap停止中に生まれた投稿を復旧後1回は必ず計測→計測後は窓判定へ自然移行=自己制限型)。`X_METRICS_WINDOW_DAYS` で再デプロイなしに調整可。定常読取が**有界化(約85-90%削減)**。
- スナップショットに `media_type` を永続化し、perf文脈に**動画vs非動画の構造lift行**(sampleガード付き)を追加=1:1アスペクト実験(R4 defer)の判定データがAPI追加読取ゼロで貯まる。
## 検証
growth-hub deno tests **23 green**。performance_context/dup-guard経路の `listXPostLogs` は非接触。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge pure-function window filter covered by 4 black-box deno tests (23 green incl existing suite); the metrics cron path is not exercisable from a Flutter integration_test.
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Adds a recency window filter and one metadata field to the metrics reader; read-only analytics path, no permission or posting-behavior change; deno 23 green.
