### PR TITLE
feat(ci): two-tier metrics collection cadence (3h fresh / daily backfill)

### DIFF
--- a/.github/workflows/x-post-metrics-optimizer.yml
+++ b/.github/workflows/x-post-metrics-optimizer.yml
@@ -2,7 +2,12 @@ name: X Post Metrics Optimizer
 
 on:
   schedule:
+    # fresh tier: 直近投稿の初速シグナル用 (limit=25 / 3h毎)。
     - cron: "17 */3 * * *"
+    # daily backfill: 未計測レスキュー+窓内全量 (limit=100 / 04:17 JST)。
+    # */3 グリッド外の 19 時 UTC を選び、fresh 便との衝突と
+    # cancel-in-progress レースを回避する。
+    - cron: "17 19 * * *"
   workflow_dispatch:
     inputs:
       limit:
@@ -32,7 +37,18 @@ jobs:
       - name: Collect X post metrics
         shell: bash
         run: |
-          limit="${INPUT_LIMIT:-100}"
+          # 手動 dispatch は入力値、daily backfill 便(19:17 UTC)は 100、
+          # fresh 便(3h毎)は 25 に絞って X API 読取を節約する。
+          # 25 の根拠: x_post_log には dry_run/rejected_duplicate 等の
+          # tweet-id なし行が混在するため(APIコストはゼロ)、実投稿が
+          # 押し出されない余裕を持たせる。edge 側の 7 日鮮度窓と併用。
+          if [ -n "${INPUT_LIMIT}" ]; then
+            limit="${INPUT_LIMIT}"
+          elif [ "${EVENT_SCHEDULE}" = "17 19 * * *" ]; then
+            limit=100
+          else
+            limit=25
+          fi
           response=$(curl --fail-with-body --show-error --silent \
             --request POST \
             --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
@@ -49,4 +65,5 @@ jobs:
           fi
         env:
           INPUT_LIMIT: ${{ github.event.inputs.limit }}
+          EVENT_SCHEDULE: ${{ github.event.schedule }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}


### PR DESCRIPTION
## 目的(R8 / medium)
3時間毎cronは何も変わっていない古い投稿も毎回再読していた。growth-hubの7日窓と対で、**二層ケイデンス**にして定常読取をさらに半減する。
## 変更(yml 1ファイル)
- 3時間便=limit **25**(直近投稿の初速シグナル用。dry_run等のid無し行が混在するため余裕を持たせる/APIコストはゼロ)
- **日次バックフィル便**(19:17 UTC=04:17 JST・`*/3`グリッド外でconcurrencyレース回避)=limit 100で未計測レスキューをフル回収
- 手動dispatchは入力値を尊重。x_billing_blockedのgraceful-skip warningは不変。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Workflow yml cadence/limit change only; validated by shell-branch inspection and the existing graceful-skip path; no app runtime surface to E2E.
