### PR TITLE
fix(ci): single-line the inline Python in daily-report Step 5

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -219,11 +219,8 @@ jobs:
         if: steps.gitlog.outputs.count != '0'
         id: xpost
         run: |
-          TODAY_UTC=$(python3 -c "
-          from datetime import datetime, timedelta, timezone
-          now_jst = datetime.now(timezone.utc) + timedelta(hours=9)
-          start_jst = now_jst.replace(hour=0, minute=0, second=0, microsecond=0)
-          print((start_jst - timedelta(hours=9)).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+          # JST の今日 0 時を UTC で表現 (repo 規約: 複数行 python3 -c 禁止)。
+          TODAY_UTC=$(python3 -c "from datetime import datetime, timedelta, timezone; now_jst = datetime.now(timezone.utc) + timedelta(hours=9); start_jst = now_jst.replace(hour=0, minute=0, second=0, microsecond=0); print((start_jst - timedelta(hours=9)).strftime('%Y-%m-%dT%H:%M:%SZ'))")
           set +e
           COUNT=$(curl -s --max-time 30 \
             -H "apikey: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \


### PR DESCRIPTION
## 緊急修正
#3851 で入れた `daily-report.yml` の **複数行 `python3 -c`** がリポジトリの GitHub Actions inline-Python 安全チェックに違反し、**以後の全PRの Lint ジョブが fail する**状態になっていた（自分のマージ判断ミス。CI red のまま merge してしまった）。
## 変更
JST 0時計算を単一行 `python3 -c` へ変換（1行）。`python scripts/check_github_actions_python_inline.py` ローカルで **109 files OK**。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: One-line workflow fix converting a multiline python3 -c to single-line to satisfy the repo inline-Python safety check; validated locally by scripts/check_github_actions_python_inline.py (109 files OK); no app runtime surface.
