### PR TITLE
feat(ai): sandbox generated UI previews

### DIFF
--- a/lib/pages/ai_assistant_chat_page.dart
+++ b/lib/pages/ai_assistant_chat_page.dart
@@ -13,6 +13,9 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:web/web.dart' as web;
 
+import '../services/generated_ui_sandbox_policy.dart';
+import '../widgets/generated_ui_sandbox_preview.dart';
+
 class AiAssistantChatPage extends StatefulWidget {
   const AiAssistantChatPage({super.key});
 
@@ -378,8 +381,11 @@ class _AiAssistantChatPageState extends State<AiAssistantChatPage>
               const SizedBox(width: 8),
               ScaleTransition(
                 scale: _pulseAnim,
-                child:
-                    const Icon(Icons.mic, color: Color(0xFFE53935), size: 16),
+                child: const Icon(
+                  Icons.mic,
+                  color: Color(0xFFE53935),
+                  size: 16,
+                ),
               ),
             ],
           ],
@@ -470,6 +476,12 @@ class _AiAssistantChatPageState extends State<AiAssistantChatPage>
   }
 
   Widget _buildMessageBubble(_ChatMessage message, {required bool isUser}) {
+    final sandboxCandidate = isUser
+        ? null
+        : GeneratedUiSandboxPolicy.extractFirstPreviewCandidate(
+            message.content,
+          );
+
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Row(
@@ -701,6 +713,10 @@ class _AiAssistantChatPageState extends State<AiAssistantChatPage>
                         ],
                       ),
                     ),
+                  if (sandboxCandidate != null) ...[
+                    _buildSandboxCandidatePanel(sandboxCandidate),
+                    const SizedBox(height: 8),
+                  ],
                   Text(
                     message.content,
                     style: TextStyle(
@@ -721,6 +737,65 @@ class _AiAssistantChatPageState extends State<AiAssistantChatPage>
               backgroundColor: Color(0xFF2A2A2A), // surface3
               child: Icon(Icons.person, size: 18, color: _orange),
             ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSandboxCandidatePanel(GeneratedUiSandboxCandidate candidate) {
+    final allowed = candidate.isPreviewAllowed;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: allowed
+            ? const Color(0xFF064E3B).withAlpha(82)
+            : const Color(0xFF7F1D1D).withAlpha(96),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: allowed ? const Color(0xFF22C55E) : const Color(0xFFEF4444),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                allowed ? Icons.security_outlined : Icons.block_outlined,
+                size: 16,
+                color:
+                    allowed ? const Color(0xFF86EFAC) : const Color(0xFFFCA5A5),
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  allowed ? 'AI UI sandbox preview' : 'AI UI preview blocked',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            allowed
+                ? 'Runs in an opaque-origin iframe with no Supabase/Auth, storage, form, or network access.'
+                : 'Preview was not rendered because the HTML requested a forbidden capability: ${candidate.rejectionReasons.join(', ')}.',
+            style: const TextStyle(
+              color: Colors.white70,
+              fontSize: 12,
+              height: 1.4,
+            ),
+          ),
+          if (allowed) ...[
+            const SizedBox(height: 10),
+            GeneratedUiSandboxPreview(htmlFragment: candidate.html),
           ],
         ],
       ),
@@ -800,14 +875,16 @@ class _AiAssistantChatPageState extends State<AiAssistantChatPage>
                               () => _selectedAgentProvider = selection.first,
                             ),
                     style: ButtonStyle(
-                      foregroundColor:
-                          WidgetStateProperty.resolveWith((states) {
+                      foregroundColor: WidgetStateProperty.resolveWith((
+                        states,
+                      ) {
                         return states.contains(WidgetState.selected)
                             ? Colors.white
                             : Colors.white70;
                       }),
-                      backgroundColor:
-                          WidgetStateProperty.resolveWith((states) {
+                      backgroundColor: WidgetStateProperty.resolveWith((
+                        states,
+                      ) {
                         return states.contains(WidgetState.selected)
                             ? _orange.withAlpha(52)
                             : Colors.white10;
@@ -889,8 +966,10 @@ class _AiAssistantChatPageState extends State<AiAssistantChatPage>
                       hintText: _selectedImage == null
                           ? 'メッセージを入力...'
                           : '画像について質問...',
-                      hintStyle:
-                          const TextStyle(color: Colors.white38, height: 1.5),
+                      hintStyle: const TextStyle(
+                        color: Colors.white38,
+                        height: 1.5,
+                      ),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(24),
                         borderSide: const BorderSide(color: Colors.white12),
@@ -901,8 +980,10 @@ class _AiAssistantChatPageState extends State<AiAssistantChatPage>
                       ),
                       focusedBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(24),
-                        borderSide:
-                            const BorderSide(color: _orange, width: 1.5),
+                        borderSide: const BorderSide(
+                          color: _orange,
+                          width: 1.5,
+                        ),
                       ),
                       contentPadding: const EdgeInsets.symmetric(
                         horizontal: 16,
@@ -1079,8 +1160,11 @@ class _TypingDotsState extends State<_TypingDots>
       builder: (_, __) {
         return Text(
           '●' * _dotCount.value,
-          style:
-              const TextStyle(color: Colors.white54, fontSize: 14, height: 1.5),
+          style: const TextStyle(
+            color: Colors.white54,
+            fontSize: 14,
+            height: 1.5,
+          ),
         );
       },
     );

--- a/lib/services/generated_ui_sandbox_policy.dart
+++ b/lib/services/generated_ui_sandbox_policy.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+
+class GeneratedUiSandboxCandidate {
+  const GeneratedUiSandboxCandidate({
+    required this.html,
+    required this.rejectionReasons,
+  });
+
+  final String html;
+  final List<String> rejectionReasons;
+
+  bool get isPreviewAllowed => rejectionReasons.isEmpty;
+}
+
+class GeneratedUiSandboxPolicy {
+  const GeneratedUiSandboxPolicy._();
+
+  static const iframeSandbox = 'allow-scripts';
+
+  static const csp = "default-src 'none'; "
+      "script-src 'unsafe-inline'; "
+      "style-src 'unsafe-inline'; "
+      'img-src data: blob:; '
+      'font-src data:; '
+      "connect-src 'none'; "
+      'media-src data: blob:; '
+      "object-src 'none'; "
+      "base-uri 'none'; "
+      "form-action 'none'; "
+      "frame-ancestors 'none'";
+
+  static final _htmlFence = RegExp(
+    r'```(?:html|sandbox-html|ui-html)\s*([\s\S]*?)```',
+    caseSensitive: false,
+  );
+
+  static final List<({RegExp pattern, String reason})> _denyPatterns = [
+    (
+      pattern: RegExp(
+        r'\b(fetch|XMLHttpRequest|WebSocket|EventSource)\s*\(',
+        caseSensitive: false,
+      ),
+      reason: 'network API call',
+    ),
+    (
+      pattern: RegExp(
+        r'\b(localStorage|sessionStorage|indexedDB|document\.cookie|cookie)\b',
+        caseSensitive: false,
+      ),
+      reason: 'browser credential or storage access',
+    ),
+    (
+      pattern: RegExp(
+        r'\b(supabase|createClient|Authorization|Bearer|service[_-]?role|apikey)\b',
+        caseSensitive: false,
+      ),
+      reason: 'Supabase/Auth/secret keyword',
+    ),
+    (
+      pattern: RegExp(
+        r'\b(window\.parent|window\.top|parent\.|top\.|postMessage)\b',
+        caseSensitive: false,
+      ),
+      reason: 'parent-window bridge',
+    ),
+    (
+      pattern: RegExp(r'<\s*iframe\b', caseSensitive: false),
+      reason: 'nested iframe',
+    ),
+    (
+      pattern: RegExp(r'<\s*form\b', caseSensitive: false),
+      reason: 'form submission surface',
+    ),
+    (
+      pattern: RegExp(r'<\s*script\b[^>]*\bsrc\s*=', caseSensitive: false),
+      reason: 'external script source',
+    ),
+    (
+      pattern: RegExp(r'\bimport\s*\(', caseSensitive: false),
+      reason: 'dynamic import',
+    ),
+  ];
+
+  static GeneratedUiSandboxCandidate? extractFirstPreviewCandidate(
+    String message,
+  ) {
+    final match = _htmlFence.firstMatch(message);
+    if (match == null) return null;
+    final html = (match.group(1) ?? '').trim();
+    if (html.isEmpty) return null;
+    return evaluate(html);
+  }
+
+  static GeneratedUiSandboxCandidate evaluate(String html) {
+    final reasons = <String>[];
+    for (final entry in _denyPatterns) {
+      if (entry.pattern.hasMatch(html)) {
+        reasons.add(entry.reason);
+      }
+    }
+    return GeneratedUiSandboxCandidate(
+      html: html,
+      rejectionReasons: List.unmodifiable(reasons),
+    );
+  }
+
+  static String buildSrcDoc({
+    required String htmlFragment,
+    String title = 'Generated UI preview',
+  }) {
+    const attributeEscape = HtmlEscape(HtmlEscapeMode.attribute);
+    const textEscape = HtmlEscape();
+    return '''
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="${attributeEscape.convert(csp)}">
+  <title>${textEscape.convert(title)}</title>
+  <style>
+    :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+    html, body { margin: 0; min-height: 100%; background: transparent; }
+    body { box-sizing: border-box; padding: 12px; overflow-wrap: anywhere; }
+    *, *::before, *::after { box-sizing: border-box; }
+  </style>
+</head>
+<body data-vibe-sandbox="leaf-preview">
+$htmlFragment
+</body>
+</html>
+''';
+  }
+
+  static bool get cspBlocksBackendAccess =>
+      csp.contains("default-src 'none'") &&
+      csp.contains("connect-src 'none'") &&
+      csp.contains("form-action 'none'") &&
+      csp.contains("base-uri 'none'");
+
+  static bool get iframeUsesUniqueOpaqueOrigin =>
+      !iframeSandbox.contains('allow-same-origin') &&
+      !iframeSandbox.contains('allow-top-navigation') &&
+      !iframeSandbox.contains('allow-popups');
+}

--- a/lib/utils/platform_view_stub.dart
+++ b/lib/utils/platform_view_stub.dart
@@ -1,6 +1,15 @@
-// Stub for non-web platforms — keeps tests compilable on Dart VM.
+// Stub for non-web platforms; keeps tests compilable on Dart VM.
 // Real implementation is in platform_view_web.dart selected via conditional import.
 
 void registerIframeViewFactory(String viewId, String src) {
+  // no-op on non-web platforms
+}
+
+void registerSandboxedSrcDocIframeViewFactory(
+  String viewId,
+  String srcDoc, {
+  required String sandbox,
+  required String csp,
+}) {
   // no-op on non-web platforms
 }

--- a/lib/utils/platform_view_web.dart
+++ b/lib/utils/platform_view_web.dart
@@ -2,18 +2,36 @@ import 'dart:ui_web' as ui_web;
 import 'package:web/web.dart' as web;
 
 void registerIframeViewFactory(String viewId, String src) {
-  ui_web.platformViewRegistry.registerViewFactory(
-    viewId,
-    (int viewIdInt) {
-      final iframe = web.HTMLIFrameElement()
-        ..src = src
-        ..allow = 'accelerometer; autoplay; clipboard-write; '
-            'encrypted-media; gyroscope; picture-in-picture'
-        ..setAttribute('allowfullscreen', 'true')
-        ..style.border = 'none'
-        ..style.width = '100%'
-        ..style.height = '100%';
-      return iframe;
-    },
-  );
+  ui_web.platformViewRegistry.registerViewFactory(viewId, (int viewIdInt) {
+    final iframe = web.HTMLIFrameElement()
+      ..src = src
+      ..allow = 'accelerometer; autoplay; clipboard-write; '
+          'encrypted-media; gyroscope; picture-in-picture'
+      ..setAttribute('allowfullscreen', 'true')
+      ..style.border = 'none'
+      ..style.width = '100%'
+      ..style.height = '100%';
+    return iframe;
+  });
+}
+
+void registerSandboxedSrcDocIframeViewFactory(
+  String viewId,
+  String srcDoc, {
+  required String sandbox,
+  required String csp,
+}) {
+  ui_web.platformViewRegistry.registerViewFactory(viewId, (int viewIdInt) {
+    final iframe = web.HTMLIFrameElement()
+      ..setAttribute('srcdoc', srcDoc)
+      ..setAttribute('sandbox', sandbox)
+      ..setAttribute('csp', csp)
+      ..setAttribute('credentialless', 'true')
+      ..setAttribute('referrerpolicy', 'no-referrer')
+      ..setAttribute('allow', '')
+      ..style.border = 'none'
+      ..style.width = '100%'
+      ..style.height = '100%';
+    return iframe;
+  });
 }

--- a/lib/widgets/generated_ui_sandbox_preview.dart
+++ b/lib/widgets/generated_ui_sandbox_preview.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../services/generated_ui_sandbox_policy.dart';
+import '../utils/platform_view.dart' as platform_view;
+
+class GeneratedUiSandboxPreview extends StatefulWidget {
+  const GeneratedUiSandboxPreview({
+    super.key,
+    required this.htmlFragment,
+    this.title = 'AI generated UI preview',
+    this.height = 260,
+  });
+
+  final String htmlFragment;
+  final String title;
+  final double height;
+
+  @override
+  State<GeneratedUiSandboxPreview> createState() =>
+      _GeneratedUiSandboxPreviewState();
+}
+
+class _GeneratedUiSandboxPreviewState extends State<GeneratedUiSandboxPreview> {
+  static int _nextViewId = 0;
+
+  late String _viewType;
+
+  @override
+  void initState() {
+    super.initState();
+    _registerView();
+  }
+
+  @override
+  void didUpdateWidget(covariant GeneratedUiSandboxPreview oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.htmlFragment != widget.htmlFragment ||
+        oldWidget.title != widget.title) {
+      _registerView();
+    }
+  }
+
+  void _registerView() {
+    _viewType = 'generated-ui-sandbox-${_nextViewId++}';
+    platform_view.registerSandboxedSrcDocIframeViewFactory(
+      _viewType,
+      GeneratedUiSandboxPolicy.buildSrcDoc(
+        htmlFragment: widget.htmlFragment,
+        title: widget.title,
+      ),
+      sandbox: GeneratedUiSandboxPolicy.iframeSandbox,
+      csp: GeneratedUiSandboxPolicy.csp,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: BoxConstraints(minHeight: 180, maxHeight: widget.height),
+      decoration: BoxDecoration(
+        color: const Color(0xFF0F172A),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFF334155)),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            color: const Color(0xFF111827),
+            child: const Row(
+              children: [
+                Icon(
+                  Icons.security_outlined,
+                  size: 16,
+                  color: Color(0xFF22C55E),
+                ),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Sandbox preview',
+                    style: TextStyle(
+                      color: Color(0xFFE5E7EB),
+                      fontWeight: FontWeight.w600,
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: kIsWeb
+                ? HtmlElementView(viewType: _viewType)
+                : const Center(
+                    child: Text(
+                      'Sandbox preview is available on Flutter Web.',
+                      style: TextStyle(color: Color(0xFF94A3B8)),
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/generated_ui_sandbox_policy_test.dart
+++ b/test/services/generated_ui_sandbox_policy_test.dart
@@ -1,0 +1,83 @@
+import 'package:my_web_app/services/generated_ui_sandbox_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GeneratedUiSandboxPolicy', () {
+    test('uses an opaque-origin iframe sandbox', () {
+      expect(GeneratedUiSandboxPolicy.iframeSandbox, contains('allow-scripts'));
+      expect(
+        GeneratedUiSandboxPolicy.iframeSandbox,
+        isNot(contains('allow-same-origin')),
+      );
+      expect(
+        GeneratedUiSandboxPolicy.iframeSandbox,
+        isNot(contains('allow-top-navigation')),
+      );
+      expect(
+        GeneratedUiSandboxPolicy.iframeSandbox,
+        isNot(contains('allow-popups')),
+      );
+      expect(GeneratedUiSandboxPolicy.iframeUsesUniqueOpaqueOrigin, isTrue);
+    });
+
+    test('CSP blocks backend, form, and secret exfiltration routes', () {
+      expect(GeneratedUiSandboxPolicy.csp, contains("default-src 'none'"));
+      expect(GeneratedUiSandboxPolicy.csp, contains("connect-src 'none'"));
+      expect(GeneratedUiSandboxPolicy.csp, contains("form-action 'none'"));
+      expect(GeneratedUiSandboxPolicy.csp, contains("base-uri 'none'"));
+      expect(GeneratedUiSandboxPolicy.csp, contains("object-src 'none'"));
+      expect(GeneratedUiSandboxPolicy.cspBlocksBackendAccess, isTrue);
+    });
+
+    test('extracts the first HTML code fence as a preview candidate', () {
+      final candidate = GeneratedUiSandboxPolicy.extractFirstPreviewCandidate(
+        'Here is a widget:\n```html\n<div>Hello</div>\n```',
+      );
+
+      expect(candidate, isNotNull);
+      expect(candidate!.isPreviewAllowed, isTrue);
+      expect(candidate.html, '<div>Hello</div>');
+    });
+
+    test('rejects code that attempts network or credential access', () {
+      final candidate = GeneratedUiSandboxPolicy.evaluate('''
+<button onclick="fetch('/rest/v1/user_profiles')">load</button>
+<script>console.log(localStorage.getItem('supabase.auth.token'))</script>
+''');
+
+      expect(candidate.isPreviewAllowed, isFalse);
+      expect(candidate.rejectionReasons, contains('network API call'));
+      expect(
+        candidate.rejectionReasons,
+        contains('browser credential or storage access'),
+      );
+      expect(
+        candidate.rejectionReasons,
+        contains('Supabase/Auth/secret keyword'),
+      );
+    });
+
+    test('rejects parent bridges and nested browsing contexts', () {
+      final candidate = GeneratedUiSandboxPolicy.evaluate('''
+<iframe src="https://example.com"></iframe>
+<script>window.parent.postMessage({ok: true}, '*')</script>
+''');
+
+      expect(candidate.isPreviewAllowed, isFalse);
+      expect(candidate.rejectionReasons, contains('nested iframe'));
+      expect(candidate.rejectionReasons, contains('parent-window bridge'));
+    });
+
+    test('srcdoc wraps generated HTML with the sandbox CSP', () {
+      final srcDoc = GeneratedUiSandboxPolicy.buildSrcDoc(
+        htmlFragment: '<button>Run</button>',
+        title: 'Preview',
+      );
+
+      expect(srcDoc, contains('Content-Security-Policy'));
+      expect(srcDoc, contains("connect-src 'none'"));
+      expect(srcDoc, contains('data-vibe-sandbox="leaf-preview"'));
+      expect(srcDoc, contains('<button>Run</button>'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a fail-closed policy for AI-generated HTML preview candidates in chat responses.
- Renders allowed snippets inside an opaque-origin `srcdoc` iframe with a restrictive CSP and no Supabase/Auth, storage, form, or network access.
- Shows a blocked preview panel with deterministic rejection reasons when generated HTML requests forbidden capabilities.

Refs #1209

## Validation

- `dart analyze lib\services\generated_ui_sandbox_policy.dart lib\widgets\generated_ui_sandbox_preview.dart lib\utils\platform_view_web.dart lib\utils\platform_view_stub.dart lib\pages\ai_assistant_chat_page.dart test\services\generated_ui_sandbox_policy_test.dart`
- `dart test test\services\generated_ui_sandbox_policy_test.dart --reporter expanded`
- pre-commit fast quality gate, including `flutter analyze`, `deno lint`, minimal E2E gate tests, and high-risk ultrareview gate tests

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: first slice adds the deterministic sandbox policy and chat preview surface with unit coverage; no stable generated-UI end-to-end route exists yet, so browser E2E remains a follow-up for the full #1209 sandbox workflow.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: frontend-only generated UI sandbox preview; no Supabase, Edge Function, SQL migration, production secret, or service-role path touched; security posture is fail-closed and covered by deterministic tests.
