### PR TITLE
feat(x-share): graded 3-4 option polls + golden-hour open-post button

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -1657,7 +1657,7 @@ Return STRICT JSON only (RFC 8259). The raw response must parse with a standard 
   "imagePrompt": "English prompt for a 16:9 share image, no text overlay",
   "videoPrompt": "English prompt for a short presenter/share video",
   "hashtags": ["#buildinpublic", "#FlutterWeb", "#Supabase"],
-  "poll": { "question": "<=100 char Japanese poll question tied to today's top headline>", "options": ["<=25 char option", "<=25 char option"], "durationMinutes": 1440 }
+  "poll": { "question": "<=100 char Japanese poll question tied to today's top headline>", "options": ["<=25 char option", "<=25 char option", "<=25 char option"], "durationMinutes": 1440 }
 }
 
 Page:
@@ -1696,7 +1696,8 @@ Rules:
 - The multi-line formatting above applies to the RENDERED post; inside the JSON string values you must still encode every line break as the two characters \\n, never a real newline.
 - Cap emoji at 1-2 per post and do NOT decorate every line (emoji spam and full-line decoration trigger spam down-ranking). Number only replies 2 onward. Optionally add ONE short, non-templated thread-continuation cue (e.g. "🧵つづく") just before the lead's CTA/URL, varying the wording day to day so it is never identical.
 - The FIRST reply must stand alone as its own scroll-stopping hook: one sharp claim + why it matters + a reply-provoking question, fully readable with zero context from the lead post. Do NOT repeat the lead hook verbatim, do NOT phrase it as "1つ目/item 1 of N", and do NOT begin it with a number or list marker (never start with "1."). Replies 2 onward then form the numbered briefing.
-- Native poll (impressions booster): when today's top headline supports a crisp either/or, ranking, or opinion question, include a "poll" object with a short Japanese "question" and 2-4 "options" (each <=25 chars). X natively boosts impressions and early engagement on poll tweets.
+- Native poll (impressions booster): when today's top headline supports a crisp either/or, ranking, or opinion question, include a "poll" object with a short Japanese "question" and 3-4 "options" (prefer 4 when each option is genuinely distinct; never pad with filler; each <=25 chars). X natively boosts impressions and early engagement on poll tweets.
+- Poll options must be 3-4 GRADED reader stances or next actions (例: もう追っている/いま知った/後で調べる/仕事に直結) — never a flat binary such as 興味がある/興味がない or 賛成/反対 (binary polls collect fewer votes and read as low-effort).
 - The "poll" must be a TOP-LEVEL JSON key only. NEVER place a poll object (or any JSON object) inside the threadReplies array — every threadReplies element must be a plain Japanese string, or it will be posted as raw garbage text.
 - DERIVE the poll question AND options from THE DAY'S single most relevant headline so the poll rotates daily and is specific — NEVER reuse a generic or hardcoded poll like "使ってみたい?はい/いいえ" (near-duplicate polls get down-ranked). Yesterday's poll must not be reusable today.
 - The poll is posted as its own FIRST text-only thread reply (never on the media lead), so make the "question" self-contained. If no natural, honest poll fits today's news, OMIT the "poll" field entirely rather than forcing a weak one.

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../services/ai_share_button_preferences_service.dart';
 import '../services/universal_x_share_service.dart';
 import 'ai_share_button_settings_panel.dart';
+
+/// 投稿済みツイートの URL を組み立てる純関数。ハンドル名は不要な
+/// `https://x.com/i/status/<id>` 形式(アカウント名の @ 付き/表記ゆれに非依存)。
+String? composePostedTweetUrl(String? tweetId) {
+  final id = tweetId?.trim() ?? '';
+  if (id.isEmpty) return null;
+  return 'https://x.com/i/status/$id';
+}
 
 /// 投稿完了メッセージを組み立てる純関数。動画が付かなかった投稿では、その
 /// 理由(例: Hedraクレジット不足)を末尾に残し、operator が投稿画面だけで
@@ -322,6 +331,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
   bool _reusedVideoSameDay = false;
   String? _reusedVideoDateLabel; // 例 '7/6'
   String? _statusMessage;
+  String? _postedTweetUrl;
   bool _loadingDraft = true;
   bool _generatingImage = false;
   bool _generatingVideo = false;
@@ -380,6 +390,14 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
   /// ワンボタン: 文章(生成済)→画像→音声+動画(Hedra/ElevenLabs, 非同期はポーリング)
   /// →X投稿 を一括実行する。ユーザーは「AI生成して投稿」を押すだけ。失敗時は原因を
   /// 画面に明確表示する。
+  Future<void> _openPostedTweet() async {
+    final url = _postedTweetUrl;
+    if (url == null) return;
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
   Future<void> _generateAndPost() async {
     final draft = _draft;
     if (_posting || _loadingDraft) return;
@@ -390,6 +408,7 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
     setState(() {
       _posting = true;
       _statusMessage = null;
+      _postedTweetUrl = null;
     });
     // 動画が生成できなかった理由。投稿完了メッセージへ残し、静止画になった
     // 原因(例: Hedraクレジット不足)を operator が投稿画面で即視認できるようにする
@@ -534,6 +553,9 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
           videoReused: _videoReused,
           reusedVideoDate: _reusedVideoDateLabel,
         );
+        // ゴールデンアワー導線用(投稿を開くボタン)。
+        _postedTweetUrl =
+            result.posted ? composePostedTweetUrl(result.tweetId) : null;
       });
     } catch (error) {
       if (_disposed || !mounted) return;
@@ -623,6 +645,20 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
                         ? Theme.of(context).colorScheme.error
                         : Theme.of(context).colorScheme.primary,
                     fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+              if (_postedTweetUrl != null) ...[
+                const SizedBox(height: 4),
+                // ゴールデンアワー導線: 投稿直後 30-60 分の初速エンゲージが
+                // リーチを複利で伸ばす。開いて確認・当日の看板ならピン留め・
+                // 実コメントには手動で返信する(自動返信はしない)。
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton.icon(
+                    onPressed: _openPostedTweet,
+                    icon: const Icon(Icons.open_in_new, size: 16),
+                    label: const Text('投稿を開く（最初の30分の反応が伸びを決めます）'),
                   ),
                 ),
               ],

--- a/test/widgets/universal_ai_share_status_test.dart
+++ b/test/widgets/universal_ai_share_status_test.dart
@@ -92,4 +92,14 @@ void main() {
     expect(message.contains('…'), isTrue);
     expect(message.runes.length, lessThan(120));
   });
+
+  test('composePostedTweetUrl builds /i/status/ links and rejects blanks', () {
+    // /i/status/ 形式はアカウント名(@付き/表記ゆれ)に依存しない。
+    expect(
+      composePostedTweetUrl('2074234802048503845'),
+      'https://x.com/i/status/2074234802048503845',
+    );
+    expect(composePostedTweetUrl(null), isNull);
+    expect(composePostedTweetUrl('   '), isNull);
+  });
 }


### PR DESCRIPTION
## 目的(R9 / R8で敵対的検証済みのPR-5)
実投稿で**投票が2択フラット**(非常に興味がある/あまり興味がない)を連発=投票率が伸びずlow-effortに見える。また投稿直後の**最初の30分**の初速エンゲージがリーチを複利で決めるのに、投稿へ飛ぶ導線がなかった。
## 変更(Dart 3ファイル)
1. **投票の質**: プロンプトを「3-4個のgradedな読者スタンス/次アクション(例: もう追っている/いま知った/後で調べる/仕事に直結)・フラット2択禁止」に強化+JSONスキーマ例を3択にしてバイナリアンカー除去。検証パイプライン(_parsePoll/x-client)は2-4受理済みでコード変更なし。
2. **ゴールデンアワー導線**: 投稿成功後に「投稿を開く(最初の30分の反応が伸びを決めます)」ボタンを表示。URLは純関数 `composePostedTweetUrl` で `https://x.com/i/status/<id>` 形式(ハンドル表記に非依存)。自動エンゲージ(self-like/自動返信)は実装しない(ToSレッドライン)。
## 検証
flutter test **54 green**(新規: composePostedTweetUrl 3ケース)。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Prompt-rule change plus a pure URL helper and one dialog button; covered by flutter unit tests (54 green incl new composePostedTweetUrl cases); no new user-facing route so a full integration_test is disproportionate.
