### PR TITLE
feat(x-share): follow-conversion CTA + save-worthy まとめ + discovery hashtags

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -675,6 +675,10 @@ class UniversalXShareService {
     'デモはこちら。5分だけ使って、続けたいと思ったか教えてください。',
     '要点は後で使えるので保存推奨。触ったら一言だけ感想ください。',
     'この投稿は保存しておくと後で効きます。使えたか一言返信歓迎です。',
+    // フォロー変換バリアント: 毎日この形式で発信している事実を添え、スレッド
+    // 読者をプロフィール経由のフォローへ導く(全体の ~1/9 出現でスパム化しない)。
+    '毎日この形式で自分株式会社の開発を発信しています。役立ったらプロフィールからフォローどうぞ。試すURLはこちら。',
+    'この続きは毎日ここで出しています。よければプロフィールを覗いてみてください。試すURLはこちら。',
   ];
 
   /// Builds the lead post + reply chain exactly like [postToX] does, so the
@@ -1689,9 +1693,10 @@ Rules:
 - When headlines are present, OPEN the lead post by tying today's single most relevant headline to this app's angle (information organization / AI work OS), so the post visibly changes every day. Do not lead with a generic app description.
 - The FIRST line (before the X "Show more" fold) must be a concrete curiosity/value/news hook that stops the scroll. Do NOT start with a label or date such as "デイリーブリーフィング — …朝"; do not prefix the post with the date. If you mention any date, use exactly today's real date (JST) given above and never invent another year (e.g. never write 2024).
 - Every day's post must read as fresh and specific: pick a different concrete headline or angle rather than repeating yesterday's template.
-- Prefer conversation hooks and save-worthy analysis over hashtags. When the thread genuinely helps later (a checklist, framework, or numbered briefing), add ONE natural save cue (e.g. "後で使えるよう保存を") — never on every post and never templated word-for-word.
+- Keep the LEAD post strictly hashtag-free (the news hook must stay above the fold). Append 2-3 natural Japanese discovery hashtags on a trailing line of exactly ONE mid-thread reply (never the lead, never every reply), chosen from {#AI活用, #個人開発, #buildinpublic} plus at most one topic-specific tag — 3 tags max total, no stuffing.
 - This X account has X Premium, so the lead post is NOT limited to 280 chars. Write a rich long-form lead of roughly 400-900 chars: a headline, 2-4 concrete news points with brief analysis, and a low-friction CTA. Do not compress it into one short sentence.
 - Provide a FULL briefing thread: 5-8 substantive threadReplies that each add real analysis (状況/背景/なぜ重要か/仕事への活かし方/次の一手), not one-liners.
+- Make the thread SAVE-worthy: turn the LAST analysis reply (the one just before the final URL/CTA reply) into a self-contained "保存版まとめ" — a numbered 3-4 point 使えるチェックリスト that stands alone as a single screenshot. This IS the bookmark anchor. Write it fresh each day (never templated), at most once, and NEVER put it on the final URL/CTA reply. Do NOT add any other separate "保存を" save cue — this まとめ is the single save mechanism per thread.
 - Format for scannability: break the lead and each reply into short one-idea lines with a blank line between meaning-chunks (no wall-of-text paragraph). Put labels (なぜ重要か / 見通し / 次の一手 など) at the start of a line and continue the explanation on the next line, so a reader can skim in 2 seconds.
 - The multi-line formatting above applies to the RENDERED post; inside the JSON string values you must still encode every line break as the two characters \\n, never a real newline.
 - Cap emoji at 1-2 per post and do NOT decorate every line (emoji spam and full-line decoration trigger spam down-ranking). Number only replies 2 onward. Optionally add ONE short, non-templated thread-continuation cue (e.g. "🧵つづく") just before the lead's CTA/URL, varying the wording day to day so it is never identical.

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -854,6 +854,25 @@ void main() {
     expect(sawSaveCue, isTrue);
   });
 
+  test('final-reply CTA pool includes a follow-conversion cue', () {
+    // フォロワー変換レバー: ローテプールにフォロー誘導バリアントが含まれ、
+    // 複数入力のいずれかで最終リプに現れることを確認する。
+    var sawFollowCue = false;
+    for (var i = 0; i < 60; i += 1) {
+      final parts = UniversalXShareService.buildManualShareParts(
+        context: page,
+        text: 'follow$i\n${page.url}',
+        linkInReply: true,
+      );
+      final cta = parts.replyTexts.last;
+      if (cta.contains('フォロー') || cta.contains('プロフィール')) {
+        sawFollowCue = true;
+        break;
+      }
+    }
+    expect(sawFollowCue, isTrue);
+  });
+
   test('postToX surfaces X developer project guidance', () async {
     final service = UniversalXShareService(
       functionInvoker: (functionName, body) async {


### PR DESCRIPTION
## 目的(R10 / アカウント成長へ軸移し)
per-postの質は最適化完了。ボトルネックは**アカウントレベル**(フォロワー少・~6 imp/post)。純コードで押せる3レバーを1ファイルに集約。
## 変更(`universal_x_share_service.dart`)
1. **フォロー変換**: 最終リプCTAプールに**フォロー誘導2バリアント**追加(7→9・各~1/9出現でスパム化しない)。スレッド読者をプロフィール経由フォローへ。
2. **保存性**: 最後の分析リプを自己完結の**保存版まとめ**(3-4点チェックリスト・1スクショ)にするよう指示。既存inline save-cueとde-conflict(1スレッド1保存機構)。
3. **発見性**: リードはハッシュタグ無しを厳守し、**中間リプ1つに #AI活用/#個人開発 等を2-3個**集約(詰め込み禁止)。
## 検証
flutter test **48 green**(フォロー誘導到達性テスト追加)。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Prompt/copy-only Dart change to the rotated CTA pool and thread prompt rules; covered by flutter unit tests (48 green incl new follow-cue reachability); no new user-facing route so a full integration_test is disproportionate.
