### PR TITLE
feat(growth-hub): expose bookmarks / profile-clicks / url-clicks in perf context

### DIFF
--- a/supabase/functions/_shared/x-client.ts
+++ b/supabase/functions/_shared/x-client.ts
@@ -44,6 +44,9 @@ export interface XTweetMetrics {
   repostCount: number;
   quoteCount: number;
   bookmarkCount: number;
+  // 保存性/変換シグナル(既に計算済だが従来は返していなかった)。
+  urlClicks: number;
+  profileClicks: number;
   score: number;
   raw: Record<string, unknown>;
 }
@@ -742,6 +745,8 @@ function normalizeXTweetMetrics(payload: unknown): XTweetMetrics[] {
         repostCount,
         quoteCount,
         bookmarkCount,
+        urlClicks,
+        profileClicks,
         score,
         raw: tweet,
       };

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -447,6 +447,9 @@ function metricSnapshotForLog(
     repost_count: metric.repostCount,
     quote_count: metric.quoteCount,
     bookmark_count: metric.bookmarkCount,
+    // 保存性/プロフィール変換シグナル(アカウント成長レバーの判定用)。
+    url_clicks: metric.urlClicks,
+    profile_clicks: metric.profileClicks,
     score: metric.score,
     public_metrics: metric.publicMetrics,
     non_public_metrics: metric.nonPublicMetrics,
@@ -618,6 +621,9 @@ function buildXPerformanceContextFromLogs(logs: XPostLogItem[]) {
         likeCount: firstNumber(latest.like_count) ?? 0,
         replyCount: firstNumber(latest.reply_count) ?? 0,
         repostCount: firstNumber(latest.repost_count) ?? 0,
+        bookmarkCount: firstNumber(latest.bookmark_count) ?? 0,
+        urlClicks: firstNumber(latest.url_clicks) ?? 0,
+        profileClicks: firstNumber(latest.profile_clicks) ?? 0,
         score: score ?? impressions ?? 0,
         createdAt: firstString(item.created_at),
       };
@@ -718,6 +724,30 @@ function buildXPerformanceContextFromLogs(logs: XPostLogItem[]) {
       );
     }
   }
+  // 保存性/プロフィール変換のリーダーを露出(アカウント成長レバーの判定材料)。
+  // どちらも >=2 サンプルかつ非ゼロ合計のときだけ出す(データ希薄時は沈黙)。
+  const bookmarkRows = rows.filter((r) => r.bookmarkCount > 0);
+  if (bookmarkRows.length >= 2) {
+    const top = [...bookmarkRows]
+      .sort((a, b) => b.bookmarkCount - a.bookmarkCount)
+      .slice(0, 2);
+    structuralLines.push(
+      `Save-worthiness leaders (by bookmarks): ${
+        top.map((r) => `${r.bookmarkCount} bookmarks — "${r.text}"`).join(" | ")
+      }. Emulate what made these save-worthy (checklist/まとめ structure).`,
+    );
+  }
+  const profileRows = rows.filter((r) => r.profileClicks > 0);
+  if (profileRows.length >= 2) {
+    const top = [...profileRows]
+      .sort((a, b) => b.profileClicks - a.profileClicks)
+      .slice(0, 2);
+    structuralLines.push(
+      `Best profile-conversion posts (by profile clicks): ${
+        top.map((r) => `${r.profileClicks} clicks — "${r.text}"`).join(" | ")
+      }. These drove the most profile visits — reuse their hook/format.`,
+    );
+  }
   const distinctVariants = variants.filter((v) => v.variant !== "unknown");
   const rankingLine = distinctVariants.length >= 2
     ? `Variant ranking (avg score, n): ${
@@ -738,7 +768,7 @@ function buildXPerformanceContextFromLogs(logs: XPostLogItem[]) {
       ...winners.map((row, index) =>
         `Winner ${index + 1}: variant=${row.variant}, impressions=${
           row.impressions ?? "unknown"
-        }, score=${row.score}, media=${row.hasMedia}, linkInReply=${row.linkInReply}, replies=${row.threadReplyCount}, hook="${row.text}"`
+        }, score=${row.score}, bookmarks=${row.bookmarkCount}, profileClicks=${row.profileClicks}, urlClicks=${row.urlClicks}, media=${row.hasMedia}, linkInReply=${row.linkInReply}, replies=${row.threadReplyCount}, hook="${row.text}"`
       ),
       ...underperformers.slice(0, 3).map((row, index) =>
         `Avoid ${


### PR DESCRIPTION
## 目的(R10 / 計測基盤・準備PR)
アカウント成長レバー(何が保存される/どの投稿がプロフィール訪問を生むか)の判定に、保存性/変換シグナルを計測ループへ露出。`fetchXTweetMetrics`は`url_link_clicks`/`user_profile_clicks`を**計算済みなのに返していなかった**。
## 変更(x-client + growth-hub)
- `XTweetMetrics`に`urlClicks`/`profileClicks`追加(返すだけ)。スナップショットに`url_clicks`/`profile_clicks`列を永続。
- perf行に`bookmarkCount`/`urlClicks`/`profileClicks`を運搬(bookmark_countは列在ったが行に未搬送だった)。winner行にも表示。
- **サンプル数ガード(n>=2)付き**で「Save-worthiness leaders(bookmark順)」「Best profile-conversion posts(profile clicks順)」を出力。
純加算でデータ希薄時は沈黙。X計測は課金上限で~7/10まで凍結中なので**安全に先行着地し、解除と同時に点灯**。
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge additive metric fields + sample-guarded prompt-context lines; validated by deno lint and existing suite; the metrics cron path is not exercisable from a Flutter integration_test.
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Adds two already-computed read-only metric fields (url/profile clicks) and sample-guarded summary lines to the analytics context; no data-model migration, permission, or posting-behavior change.
