### PR TITLE
fix(captions): keep kanji compounds intact across a caption row break

### DIFF
--- a/supabase/functions/viral-video-ad-generator/captions.test.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.test.ts
@@ -230,6 +230,29 @@ Deno.test("wrapCaptionText prefers breaking after punctuation near the edge", ()
   assertEquals(rows.join(""), line.trim());
 });
 
+Deno.test("wrapCaptionText keeps a kanji compound intact across a row break", () => {
+  // 実機観測(2026-07-07 投稿):「後で使える判断材|料」で漢字熟語 判断材料 が
+  // 行境界(=cue境界)で語中割れした。句読点が無い連なりでも、書記素クラス境界
+  // (仮名↔漢字)や助詞の直後へ戻して折り、熟語を割らないこと。
+  const line =
+    "こうした話題も、AI仕事OSに残しておけば、後で使える判断材料になります。";
+  const rows = wrapCaptionText(line);
+  for (const row of rows) {
+    assert(
+      rowUnits(row) <= MAX_ROW_UNITS + 0.5,
+      `row exceeds width budget: ${row}`,
+    );
+    // 「判断材料」が 判断材|料 のように分断されない(行末が熟語の途中で終わらない)。
+    for (const frag of ["判断材", "判断", "材"]) {
+      assert(
+        !(row.endsWith(frag) && !row.endsWith("判断材料")),
+        `kanji compound split mid-token: ${row}`,
+      );
+    }
+  }
+  assertEquals(rows.join(""), line.trim());
+});
+
 Deno.test("wrapCaptionText does not split ASCII words or surrogate pairs", () => {
   const en = "Practical productivity insights for developers everywhere today";
   for (const row of wrapCaptionText(en)) {

--- a/supabase/functions/viral-video-ad-generator/captions.ts
+++ b/supabase/functions/viral-video-ad-generator/captions.ts
@@ -79,6 +79,33 @@ function isAsciiWordChar(ch: string): boolean {
   return /[A-Za-z0-9]/.test(ch);
 }
 
+// 折返し位置の善し悪し判定に使う書記素クラス。同一クラスの連なり(漢字熟語・
+// 仮名列)の途中で割ると読みにくい(実機観測:「判断材|料」)。クラスが切り替わる
+// 境界=形態素の切れ目に近いので、そこを優先折返し点にする。
+type ScriptClass = "kanji" | "kana" | "latin" | "other";
+function scriptClass(ch: string): ScriptClass {
+  const cp = ch.codePointAt(0) ?? 0;
+  if (
+    (cp >= 0x4e00 && cp <= 0x9fff) || // CJK 統合漢字
+    (cp >= 0x3400 && cp <= 0x4dbf) || // CJK 拡張 A
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK 互換漢字
+    cp === 0x3005 || cp === 0x3007 // 々 〇
+  ) {
+    return "kanji";
+  }
+  if (
+    (cp >= 0x3040 && cp <= 0x30ff) || // ひらがな/カタカナ
+    (cp >= 0xff66 && cp <= 0xff9f) // 半角カナ
+  ) {
+    return "kana";
+  }
+  if (/[A-Za-z0-9]/.test(ch)) return "latin";
+  return "other";
+}
+
+// 単独で文節末になりやすい助詞。この直後は自然な折返し点。
+const PARTICLE_BREAK_AFTER = "はがをにでとへのもや";
+
 /**
  * 字幕テキストを最大 [maxUnitsPerRow] 幅の行へ折り返す。コードポイント単位で
  * 走査するのでサロゲートペア(絵文字)は割れない。禁則(行頭/行末)と ASCII 単語
@@ -156,6 +183,31 @@ export function wrapCaptionText(
               carry = row.slice(cut);
               row = row.slice(0, cut);
               break;
+            }
+          }
+          // 句読点が見つからなければ、書記素クラスの境界(漢字↔仮名↔英数)か
+          // 助詞の直後へ戻して折る。同一クラスの連なり=漢字熟語(「判断材料」)や
+          // 仮名列を語中で割らないためのベストエフォート。幅上限は不変条件のまま。
+          if (carry.length === 0) {
+            for (let back = 1; back <= 6 && row.length - back > 0; back += 1) {
+              const cut = row.length - back;
+              const cutLast = row[cut - 1];
+              const cutNext = row[cut];
+              const boundary = scriptClass(cutLast) !== scriptClass(cutNext) ||
+                PARTICLE_BREAK_AFTER.includes(cutLast);
+              if (!boundary) continue;
+              const remainingUnits = row
+                .slice(0, cut)
+                .reduce((sum, c) => sum + charUnits(c), 0);
+              const compliant = remainingUnits >= 8 &&
+                !KINSOKU_NO_START.includes(cutNext) &&
+                !KINSOKU_NO_END.includes(cutLast) &&
+                !(isAsciiWordChar(cutLast) && isAsciiWordChar(cutNext));
+              if (compliant) {
+                carry = row.slice(cut);
+                row = row.slice(0, cut);
+                break;
+              }
             }
           }
         }


### PR DESCRIPTION
## What
The burned video caption on the 2026-07-07 live post split a kanji compound across the 2-row / cue boundary: 「…後で使える判断材|料」. `wrapCaptionText` backtracked only to punctuation, so a punctuation-free same-class run (a kanji compound or kana run) fell through to the hard width break and split mid-token.

## Fix (captions.ts only, additive, best-effort)
When no punctuation break is found near the edge, backtrack up to 6 chars to a **script-class boundary** (kanji↔kana↔latin) or a **助詞 boundary** (は/が/を/に/で/と/へ/の/も/や), keeping remaining width ≥ 8 units. The width cap stays the hard invariant; boundary preference is best-effort and falls through to current behavior when none exists. No text is ever dropped (fail-safe returns the input unchanged on error).

## Tests
New deno regression test reproduces the live 判断材料 split. `deno test`: 20 passed; `deno fmt` clean.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Pure caption line-wrap heuristic in captions.ts (script-class/助詞 boundary backtrack) with 20 passing deno tests; no auth/secret/network/data-flow change, width cap invariant preserved, fail-safe returns input unchanged.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge caption-wrapping helper verified by unit deno tests (width-budget, kanji-compound-intact regression, ASCII/surrogate safety); no Flutter/Playwright route flow is exercised by a text-wrapping pure function.
