### PR TITLE
auto: issue #3764 [追加要望] 🎥 X-A/B: メディア種別(動画/画像/テキスト)を第1級のA/B次元に昇格

### DIFF
--- a/docs/issue-fix-plans/issue-3764.md
+++ b/docs/issue-fix-plans/issue-3764.md
@@ -1,0 +1,121 @@
+# Issue Fix Plan #3764
+
+- Issue: [[追加要望] 🎥 X-A/B: メディア種別(動画/画像/テキスト)を第1級のA/B次元に昇格](https://github.com/kanta13jp1/my_web_app/issues/3764)
+- Labels: priority:high,追加要望,growth,launch
+- Workflow: `.github/workflows/github-issue-fix.yml`
+- CI repair pair: `.github/workflows/ci-auto-fix.yml`
+- Run: https://github.com/kanta13jp1/my_web_app/actions/runs/28841749377
+- R13 added: 2026-07-07, after R12 thread-coherence shipped and live post improved from 2 views to 13 views.
+
+## Goal
+
+[追加要望] 🎥 X-A/B: メディア種別(動画/画像/テキスト)を第1級のA/B次元に昇格
+
+## Current Context
+
+```text
+## 背景（検証で確定）
+X投稿のインプレA/Bループ(x-post-metrics-optimizer + growth-hub + universal_x_share_service)は**稼働中**だが、A/Bは6テキストバリアント(dailyBriefing/pinnedPost/problemPost/featurePost/questionPost/usefulReply)のみ。**インプレの最大レバー=メディア種別が変数化されていない**。今日AI動画投稿が開通したのに、ループは動画の存在を知らない。
+
+## やること
+1. `x_post_log` metadata に `media_type`(video/image/text)を必ず記録（**AI動画シェア経路=viral-video-ad-generator→投稿 も含める**。現状この経路はvariantタグ無し）
+2. `x.performance_context` に media_type 別の平均インプレ/エンゲージを集計させ、prompt へ「動画>画像>テキストなら動画を優先」を注入
+3. `UniversalXGrowthShareVariant` に直交する `mediaVariant` 軸を追加し、1回1変数A/B（文言固定でmedia差, or media固定で文言差）
+## 受け入れ条件
+- x_post_metric_snapshot に media_type 列/フィールドが入る
+- x.performance_context 応答に by_media_type 集計が出る
+- 次のAI生成が「動画が勝っている」データで動画付き投稿を優先
+統括 #3663 / 親 #3744
+
+```
+
+## R13 10-Hypothesis Adversarial Verification
+
+| # | Hypothesis | Evidence / falsification check | Verdict | Implementation consequence |
+| --- | --- | --- | --- | --- |
+| H1 | R12でコピー品質は改善したため、次の最大レバーはメディア種別(video/image/text)である | 実投稿は2 views→13 viewsへ改善。残課題は文言よりdistribution/dwellの可能性が高い。Issue本文も「最大レバー=メディア種別が変数化されていない」と明記 | Survives | #3764をR13の主軸にする |
+| H2 | 6種類のtext variantだけでは、動画・画像・テキストの勝ち負けを学習できない | `UniversalXGrowthShareVariant` は dailyBriefing/pinnedPost/problemPost/featurePost/questionPost/usefulReply の6軸。media軸が直交していない | Survives | `UniversalXMediaVariant` または metadata `media_type` を追加 |
+| H3 | AI動画投稿経路がvariant/media metadataを残さないため、勝ちパターンがperformance_contextに戻らない | Issue本文が「AI動画シェア経路=viral-video-ad-generator→投稿も含める。現状この経路はvariantタグ無し」と明記 | Survives | video/image/text を `x_post_log.metadata` に必ず保存 |
+| H4 | R12のプロンプト改善だけではfallback経路の低品質pollを止められない | fallback poll は `今日の注目「$topic」、あなたは？` + 汎用選択肢。LLMプロンプト制約を通らない | Survives but separate PR | R13bでfallback pollも主題ロック/現在状態型へ寄せる |
+| H5 | 動画が勝っている時は、promptへ「動画優先」を注入しないと生成器は毎回同じmediaを選べない | `x.performance_context` の受け入れ条件に by_media_type が未実装 | Survives | growth-hubの集計に `by_media_type` を追加 |
+| H6 | 1回1変数A/Bを守らないと、文言差なのかmedia差なのか分からない | Issue本文が「1回1変数A/B」を明記。R12でもA/B変数の混線が問題化 | Survives | copy variant固定×media差、またはmedia固定×copy差のみ |
+| H7 | link-in-replyやthread lengthを同時に変えるとmedia効果が汚染される | R12/R11でlink位置・thread構造・pollが同時に効いているため混線しやすい | Survives | R13はmedia metadata/集計に限定し、投稿文プロンプトは最小変更 |
+| H8 | media_typeは投稿後ログだけでなくmetric snapshotにも必要 | 受け入れ条件が `x_post_metric_snapshot` への media_type を要求 | Survives | snapshot集計で欠損時は `unknown` として保持 |
+| H9 | media_type不明行を捨てると過去データが薄くなりすぎる | 既存ログはmedia未記録なので、完全除外すると初期の学習量が落ちる | Survives | `unknown` bucketを作り、既知mediaとは分けて表示 |
+| H10 | まずDB/metadata/集計を通し、UIは後回しが安全 | 今回の目的はインプレ改善ループ。UI変更はE2Eコストが高い | Survives | Edge/Dart service + tests中心。UI変更なし |
+
+### Result
+
+All 10 hypotheses survive enough to justify R13 as a **media-axis instrumentation PR**, not another prompt-only copy polish PR.
+
+## R13 Implementation Slices
+
+### Slice 1 — write media_type at post time
+
+- Add a stable media classifier:
+  - `video`: posted payload has a video media id/url or uses reusable/generated share video
+  - `image`: posted payload has image media but no video
+  - `text`: no attached media
+  - `unknown`: legacy or ambiguous row
+- Write `media_type` into `x_post_log.metadata` for every share path.
+- Include AI動画シェア経路 (`viral-video-ad-generator` → post) explicitly.
+
+### Slice 2 — surface media_type in metric snapshots
+
+- Ensure `x_post_metric_snapshot` carries `media_type` from metadata or joins back to `x_post_log`.
+- Do not discard old rows; bucket missing values as `unknown`.
+
+### Slice 3 — aggregate by media in `x.performance_context`
+
+Return a compact section such as:
+
+```text
+Media lift:
+- video: avg impressions 123 / n=4 / engagement 2.1%
+- image: avg impressions 48 / n=8 / engagement 0.9%
+- text: avg impressions 21 / n=6 / engagement 0.4%
+Recommendation: hold copy variant constant; test video vs image next.
+```
+
+### Slice 4 — prompt injection with guardrails
+
+- If video clearly wins: instruct UniversalXShareService to prefer video media for the next comparable post.
+- If sample size is too small: say `media data insufficient` and do not force a media decision.
+- Preserve R12 prompt rules unchanged unless directly needed.
+
+### Slice 5 — implementation-independent tests
+
+- Unit test that post metadata includes `media_type` for video/image/text cases.
+- Edge/Deno test that `x.performance_context` includes `by_media_type` or `Media lift` with `unknown` bucket handling.
+- Dart test that prompt receives the media recommendation line when performance context contains it.
+
+## Minimal E2E Gate
+
+- Implementation-detail independent: tests assert public input/output and persisted metadata, not private helper names.
+- Minimal scope: video/image/text metadata classification + performance_context aggregate + prompt injection.
+- E2E-Exception likely acceptable if UI routes do not change: Edge/Deno + Dart unit tests cover the external behaviors.
+
+## High-risk Review Gate
+
+- Risk is moderate because it touches analytics metadata, not auth/billing/private data.
+- No migration should delete existing data.
+- Legacy unknown bucket must preserve past rows.
+- Rollback: revert one metadata/aggregation PR; posting still works because media_type is additive.
+
+## Autonomous Repair Loop
+
+1. Reproduce the smallest failing path for this issue: create/inspect a post log row without media_type and show `x.performance_context` lacks by_media_type.
+2. Apply Slice 1-3 first; stop before prompt if aggregation is not reliable.
+3. Add Slice 4 only after the aggregate has sample-size guardrails.
+4. Run targeted Dart/Deno tests.
+5. Let normal CI run.
+6. If CI fails on mechanical issues, `ci-auto-fix.yml` attempts `dart fix --apply` and `deno fmt`.
+7. Merge only after CI is green and issue scope is satisfied.
+
+## Checklist
+
+- [x] Reproduction is clear: media_type is absent from the current A/B loop and #3764 specifies it as missing.
+- [x] R13 hypothesis matrix is written.
+- [ ] Smallest safe fix is implemented.
+- [ ] Analyze/tests/CI are checked.
+- [ ] PR notes explain the change and the remaining risk.

--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -1709,7 +1709,8 @@ Rules:
 - 例(リプの実質・BAD→GOOD、この差を真似て今日の内容で書け): BAD「AI技術の競争がますます激化しています。今後、業界全体に影響を及ぼすでしょう。」 GOOD「今日の見出しは3分でこのアプリの検索できる判断メモに放り込んだ。自分は毎朝これで前日の見出しを整理してる。」 / BAD「私たちの新しいウェブアプリは情報整理を強力にサポートします。」 GOOD「給料日サイクル機能を実装した狙いはこれ: 窓を給料日起点に切ると、月初にまたぐ支払いが二重計上されず支出が実額になる。」
 - Target 10K impressions by using the user's proven Daily Briefing style when trend context is strong: numbered items, headline, why it matters, outlook.
 - Use the measured performance context above. Prefer winning variants and avoid losing hook styles.
-- Treat the "Variant ranking", "Structural lift", and "Top hook to emulate" lines (when present) as authoritative measured data: adopt the winning structure (media choice, link placement, thread length, hook shape) but never copy winning wording verbatim.
+- Treat the "Variant ranking", "Structural lift", "Media lift", and "Top hook to emulate" lines (when present) as authoritative measured data: adopt the winning structure (media choice, link placement, thread length, hook shape) but never copy winning wording verbatim.
+- If a "Media lift (by type)" line recommends a winning media type (動画/画像/テキスト) with enough samples, invest the strongest hook in that media: when video wins, front-load the first ~3 seconds of videoPrompt with the day's concrete hook; when image wins, make imagePrompt carry the single sharpest visual. If it says samples are insufficient, do NOT change media strategy — keep今日の既定(動画優先)。
 - A/B test only one major variable at a time: hook style, link placement, media/no-media, or thread length.
 - If past results say a link in the first post underperforms, put the product URL in the final reply.
 - Put information value first and product CTA last. Avoid looking like an ad in the lead post.

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -30,6 +30,7 @@ import {
   resolveSignupChannel,
 } from "./signup_notification.ts";
 import { filterRecentLogs } from "./metrics_window.ts";
+import { buildMediaLiftLine, classifyPostMediaType } from "./x_media_type.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -679,19 +680,16 @@ function buildXPerformanceContextFromLogs(logs: XPostLogItem[]) {
       } (n=${withoutMedia.length}).`,
     );
   }
-  // 動画 vs 非動画(画像/なし)の lift。1:1 アスペクト実験(R4 defer)の判定
-  // データ。media_type が貯まるまでは自動的に沈黙する(sample ガード)。
-  const withVideo = rows.filter((r) => r.mediaType.startsWith("video/"));
-  const withoutVideo = rows.filter((r) => !r.mediaType.startsWith("video/"));
-  if (withVideo.length >= 2 && withoutVideo.length >= 2) {
-    structuralLines.push(
-      `Structural lift (video vs image/none): avg score video=${
-        avgScore(withVideo)
-      } (n=${withVideo.length}) vs non-video=${
-        avgScore(withoutVideo)
-      } (n=${withoutVideo.length}).`,
-    );
-  }
+  // media_type 別 lift(R13: video/image/text を第1級 A/B 次元に昇格 / #3764)。
+  // 純ロジックは x_media_type.ts に抽出。n>=2 のバケットだけ表示・比較可能が 2 つ
+  // 以上で勝ちメディア recommendation を付す・判定不能な既存行は unknown で保持。
+  // media_type が貯まるまでは null(=データ希薄時は自動的に沈黙 / 実質 default-off)。
+  const mediaLine = buildMediaLiftLine(
+    rows,
+    (row) => row.mediaType,
+    (row) => row.score,
+  );
+  if (mediaLine) structuralLines.push(mediaLine);
   const linkReply = rows.filter((r) => r.linkInReply);
   const linkLead = rows.filter((r) => !r.linkInReply);
   if (linkReply.length >= 2 && linkLead.length >= 2) {
@@ -1855,6 +1853,9 @@ serve(async (req: Request) => {
           posted_at: new Date().toISOString(),
           source: body.source ?? "growth-hub",
           media_url: mediaUrl || null,
+          // R13: media 軸 A/B の一次データ。全投稿で video/image/text を必ず記録。
+          // 実投稿時は下の posted 分岐が uploadMediaFromUrl の実 MIME で上書きする。
+          media_type: classifyPostMediaType(mediaUrl, mediaType),
           route: body.route ?? null,
           experiment_key: body.experimentKey ?? body.experiment_key ??
             "x_first_user_growth_10k",
@@ -1977,7 +1978,14 @@ serve(async (req: Request) => {
             reply_tweet_ids: replyTweetIds,
             account: result.account,
             media_id: uploadedMedia?.mediaId ?? null,
-            media_type: uploadedMedia?.mediaType ?? null,
+            // R13: アップロード実 MIME(authoritative)を意味カテゴリへ正規化して
+            // 記録(video/image/text)。baseLog の推定値を実測 MIME で上書きする。
+            media_type: classifyPostMediaType(
+              mediaUrl,
+              uploadedMedia?.mediaType ?? mediaType,
+            ),
+            // 生 MIME も監査用に残す(拡張子判定の突合せ・将来の 1:1 実験用)。
+            media_mime: uploadedMedia?.mediaType ?? null,
           });
           return json({
             success: true,

--- a/supabase/functions/growth-hub/x_media_type.ts
+++ b/supabase/functions/growth-hub/x_media_type.ts
@@ -1,0 +1,83 @@
+// R13: X 投稿の「メディア種別(動画/画像/テキスト)」を第1級の A/B 次元へ昇格する
+// ための純ロジック(#3764)。growth-hub/index.ts から使う classify/normalize と、
+// x.performance_context に出す "Media lift" 集計行の生成をここに切り出してテスト
+// 可能にする(metrics_window.ts / x_duplicate_content.ts と同じ抽出パターン)。
+
+export type MediaBucket = "video" | "image" | "text" | "unknown";
+
+/// 投稿メディアを video/image/text/unknown の意味カテゴリへ正規化する。
+/// MIME(video/mp4, image/png)・意味値(video/image/text)・空を許容し、判定
+/// 不能な既存行は "unknown" バケットに残す(過去データを捨てない = #3764 受け入れ
+/// 条件「既存は unknown bucket で保持」)。
+export function normalizeMediaBucket(raw: string): MediaBucket {
+  const v = (raw ?? "").toLowerCase().trim();
+  if (v === "video" || v.startsWith("video/")) return "video";
+  if (v === "image" || v.startsWith("image/") || v.startsWith("photo")) {
+    return "image";
+  }
+  if (v === "gif") return "image";
+  if (v === "text" || v === "none") return "text";
+  return "unknown";
+}
+
+/// 投稿時に x_post_log.metadata へ書く意味カテゴリを決める(Slice 1)。media URL が
+/// あればアップロード時 MIME(authoritative)や拡張子から video/image を判定し、
+/// media が無ければ "text"。判定不能な media は "image"(AI 動画経路は常に .mp4 の
+/// ため)。全 x.post 経路が growth-hub を通るので、ここ一箇所で全経路を賄う。
+export function classifyPostMediaType(
+  mediaUrl: string,
+  mediaTypeHint: string,
+): "video" | "image" | "text" {
+  const bucket = normalizeMediaBucket(mediaTypeHint);
+  if (bucket === "video" || bucket === "image") return bucket;
+  const url = (mediaUrl ?? "").toLowerCase();
+  if (url === "") return "text";
+  if (/\.(mp4|mov|webm|m4v)(\?|#|$)/.test(url)) return "video";
+  if (/\.(png|jpe?g|gif|webp|avif)(\?|#|$)/.test(url)) return "image";
+  return "image";
+}
+
+/// x.performance_context の "Media lift (by type)" 行を作る純関数(Slice 3)。
+/// score アクセサを注入し、n>=2 のバケットだけ平均を表示、判定不能な既存行は
+/// unknown として保持。比較可能(unknown 除く)なバケットが 2 つ以上あるとき、
+/// コピー variant を固定して勝ちメディアを次に優先する recommendation を測定事実
+/// として付す。表示可能なバケットが 1 つも無ければ null(=データ希薄時は沈黙)。
+export function buildMediaLiftLine<T>(
+  rows: readonly T[],
+  mediaTypeOf: (row: T) => string,
+  scoreOf: (row: T) => number,
+): string | null {
+  const buckets = new Map<MediaBucket, T[]>();
+  for (const row of rows) {
+    const bucket = normalizeMediaBucket(mediaTypeOf(row));
+    const list = buckets.get(bucket) ?? [];
+    list.push(row);
+    buckets.set(bucket, list);
+  }
+  const avg = (list: T[]): number =>
+    list.length === 0 ? 0 : Math.round(
+      list.reduce((sum, row) => sum + scoreOf(row), 0) / list.length,
+    );
+  const order: MediaBucket[] = ["video", "image", "text", "unknown"];
+  const shown = order
+    .map((bucket) => [bucket, buckets.get(bucket) ?? []] as [MediaBucket, T[]])
+    .filter(([, list]) => list.length >= 2);
+  if (shown.length < 1) return null;
+  const parts = shown.map(([bucket, list]) =>
+    `${bucket} avg=${avg(list)} (n=${list.length})`
+  );
+  let line = `Media lift (by type): ${parts.join(", ")}.`;
+  const comparable = shown.filter(([bucket]) => bucket !== "unknown");
+  if (comparable.length >= 2) {
+    const winner = [...comparable]
+      .sort((left, right) => avg(right[1]) - avg(left[1]))[0][0];
+    line +=
+      ` Recommendation: hold the copy variant constant and prefer ${winner}` +
+      ` media on the next comparable post.`;
+  } else {
+    line +=
+      " Recommendation: insufficient distinct-media samples — do not force a" +
+      " media choice yet.";
+  }
+  return line;
+}

--- a/supabase/functions/growth-hub/x_media_type_test.ts
+++ b/supabase/functions/growth-hub/x_media_type_test.ts
@@ -1,0 +1,86 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildMediaLiftLine,
+  classifyPostMediaType,
+  normalizeMediaBucket,
+} from "./x_media_type.ts";
+
+Deno.test("normalizeMediaBucket maps MIME, semantic, and legacy values", () => {
+  // MIME(旧行 = uploadMediaFromUrl の実 MIME)。
+  assertEquals(normalizeMediaBucket("video/mp4"), "video");
+  assertEquals(normalizeMediaBucket("image/png"), "image");
+  assertEquals(normalizeMediaBucket("image/gif"), "image");
+  // 意味値(R13 新規行)。
+  assertEquals(normalizeMediaBucket("video"), "video");
+  assertEquals(normalizeMediaBucket("image"), "image");
+  assertEquals(normalizeMediaBucket("text"), "text");
+  // 判定不能・欠損は unknown(過去データを捨てない)。
+  assertEquals(normalizeMediaBucket(""), "unknown");
+  assertEquals(normalizeMediaBucket("weird"), "unknown");
+});
+
+Deno.test("classifyPostMediaType prefers explicit hint, then URL extension", () => {
+  // 実 MIME ヒントが最優先。
+  assertEquals(classifyPostMediaType("", "video/mp4"), "video");
+  assertEquals(classifyPostMediaType("", "image/png"), "image");
+  // ヒントが無ければ URL 拡張子(AI 動画経路 = .mp4)。
+  assertEquals(
+    classifyPostMediaType("https://x/y/site_tour.mp4", ""),
+    "video",
+  );
+  assertEquals(classifyPostMediaType("https://x/y/ogp.png", ""), "image");
+  // media が無ければ text。
+  assertEquals(classifyPostMediaType("", ""), "text");
+  // media 有りだが拡張子不明 → image 既定(動画は常に .mp4)。
+  assertEquals(classifyPostMediaType("https://x/y/asset", ""), "image");
+});
+
+Deno.test("buildMediaLiftLine is silent until >=2 samples in a bucket", () => {
+  const rows = [
+    { mediaType: "video/mp4", score: 100 },
+    { mediaType: "image/png", score: 40 },
+  ];
+  // 各バケット n=1 のみ → 沈黙(sample ガード = default-off)。
+  assertEquals(
+    buildMediaLiftLine(rows, (r) => r.mediaType, (r) => r.score),
+    null,
+  );
+});
+
+Deno.test("buildMediaLiftLine ranks buckets and recommends the winner", () => {
+  const rows = [
+    { mediaType: "video", score: 120 },
+    { mediaType: "video/mp4", score: 100 },
+    { mediaType: "image", score: 50 },
+    { mediaType: "image/png", score: 30 },
+    { mediaType: "text", score: 20 },
+    { mediaType: "text", score: 10 },
+  ];
+  const line = buildMediaLiftLine(rows, (r) => r.mediaType, (r) => r.score);
+  assert(line !== null);
+  assert(line!.includes("Media lift (by type):"));
+  // video 平均 110, image 平均 40, text 平均 15 の順で並ぶ。
+  assert(line!.includes("video avg=110 (n=2)"));
+  assert(line!.includes("image avg=40 (n=2)"));
+  assert(line!.includes("text avg=15 (n=2)"));
+  // 比較可能 3 バケット → 勝ちメディア(video)を推奨。
+  assert(line!.includes("prefer video media"));
+});
+
+Deno.test("buildMediaLiftLine keeps legacy rows in an unknown bucket", () => {
+  const rows = [
+    { mediaType: "video", score: 100 },
+    { mediaType: "video", score: 90 },
+    { mediaType: "", score: 5 }, // 旧行 = media_type 欠損
+    { mediaType: "weird", score: 5 },
+  ];
+  const line = buildMediaLiftLine(rows, (r) => r.mediaType, (r) => r.score);
+  assert(line !== null);
+  // unknown バケットは表示されるが、比較対象からは除外される。
+  assert(line!.includes("unknown avg=5 (n=2)"));
+  // 比較可能なのは video のみ(1 種)→ 強制せず「サンプル不足」。
+  assert(line!.includes("insufficient distinct-media samples"));
+});

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -241,6 +241,9 @@ void main() {
     // 真正性クレームモード(作り話の個人的実績を禁止)。
     expect(prompt, contains('検証可能な範囲'));
     expect(prompt, contains('家計が健全になりました'));
+    // R13: media 軸。"Media lift" 行を authoritative 測定データとして扱い、勝ち
+    // メディアへ最強フックを寄せるルールがプロンプトに届くこと。
+    expect(prompt, contains('Media lift'));
   });
 
   test('generateDraft repairs LLM JSON with raw newlines inside strings',


### PR DESCRIPTION
## R13: media-axis A/B instrumentation (media_type + Media lift) — issue #3764

Copy quality is maxed (R11/R12; the live post improved 2→13 views). The next impression lever is **which media wins**, but the A/B loop only varied 6 text variants and never labeled media — so the loop is blind to video vs image vs text. This promotes media type to a first-class A/B dimension, instrumentation-only and additive.

- **Slice 1 — write media_type at post time.** Every `x.post` log now carries a semantic `media_type` (`video`/`image`/`text`). The posted branch normalizes the authoritative upload MIME; text-only posts are labeled `text` instead of `null`. All post paths (incl. the AI-video path) go through growth-hub, so one site covers them. Raw MIME kept as `media_mime` for audit.
- **Slice 2 — snapshot.** `x_post_metric_snapshot` already reads `media_type`; it is now populated.
- **Slice 3 — aggregate by media.** `x.performance_context` emits `Media lift (by type): video/image/text avg + n` with a *hold-copy-variant-constant* winner recommendation. Sample-guarded (n≥2 per shown bucket; ≥2 comparable buckets for a recommendation). Legacy rows are kept in an `unknown` bucket, never discarded. Replaces the old binary video-vs-nonvideo line.
- **Slice 4 — prompt.** The draft prompt treats `Media lift` as authoritative measured data and invests the strongest hook in the winning media.
- **Slice 5 — tests.** Pure logic extracted to `x_media_type.ts`; Deno tests (classify, bucketing, winner recommendation, unknown-bucket preservation) + a Dart test asserting the prompt carries the `Media lift` rule.

Additive / default-safe: the Media lift line is silent until ≥2 samples accrue; posting behavior is byte-unchanged. `deno test` 5 green, `flutter test` 50 green, `deno fmt`/`lint` clean.

Reach remains the true ceiling (account followers ~0, operator-only levers in `docs/X_GROWTH_PLAYBOOK.md`); this unblocks the media-learning loop for when reach grows.

統括 #3663 / 親 #3744

## Minimal E2E Gate

- Implementation-detail independent: tests assert persisted metadata + the aggregate string + the prompt contract, not private helper names.
- Minimal scope: video/image/text/unknown classification + performance_context aggregate + prompt injection (about 3 I/O cases each).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: analytics-metadata + prompt-content change verified by implementation-independent Deno unit tests (`x_media_type_test.ts`) and a Dart unit test that captures the prompt; no user-facing route flow changes, so no integration_test/Playwright route applies.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: R13 media-axis analytics instrumentation: additive media_type labeling + performance_context aggregation only; no auth/billing/secret/private-data path; legacy rows preserved as unknown bucket; rollback is a one-commit revert
