### PR TITLE
fix(public-memo): allow HEAD and empty-body POST for anonymous memo actions

### DIFF
--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -63,3 +63,32 @@ jobs:
           check "not found"  "$BASE?action=memo.public.view&id=999999999" "404" ""
 
           exit "$FAIL"
+
+      # 外部 AI / ブラウザ系フェッチャーのリクエスト形状を再現し、
+      # どの形が 401 になるか特定する診断ステップ (失敗しても job は落とさない)。
+      - name: Diagnose external-AI request variants (informational)
+        if: always()
+        run: |
+          BASE="https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/core-hub"
+          MEMO_ID="${{ github.event.inputs.memo_id || '44' }}"
+          URL="$BASE?action=memo.public.view&id=$MEMO_ID"
+
+          probe() {
+            local label="$1"; shift
+            local out code
+            out=$(curl -sS --max-time 20 -o /tmp/body.txt -w "%{http_code}" "$@" 2>&1) || true
+            code="$out"
+            echo "=== $label → HTTP $code ==="
+            head -c 300 /tmp/body.txt; echo ""
+          }
+
+          probe "GET plain"            "$URL"
+          probe "HEAD"                 -I "$URL"
+          probe "GET UA=ChatGPT-User"  -H "User-Agent: ChatGPT-User/2.0 (+https://openai.com/bot)" "$URL"
+          probe "GET UA=OAI-SearchBot" -H "User-Agent: OAI-SearchBot/1.0; +https://openai.com/searchbot" "$URL"
+          probe "GET UA=Chrome+Origin" -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/126.0" -H "Origin: https://chatgpt.com" "$URL"
+          probe "GET Accept html"      -H "Accept: text/html,application/xhtml+xml" "$URL"
+          probe "GET amp-mangled URL"  "$BASE?action=memo.public.view&amp;id=$MEMO_ID"
+          probe "GET trailing slash"   "$BASE/?action=memo.public.view&id=$MEMO_ID"
+          probe "POST empty body"      -X POST "$URL"
+          probe "GET empty Authorization" -H "Authorization:" "$URL"

--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -1,0 +1,58 @@
+name: Public Memo Bot-View Smoke
+
+# core-hub の匿名 action memo.public.view / memo.public.list (PR #3870) の
+# 本番 smoke。WEB版 sandbox は *.supabase.co へ直接アクセスできないため、
+# GHA から匿名 (ヘッダーなし) で叩いて HTML / JSON / Markdown の応答を検証する。
+on:
+  workflow_dispatch:
+    inputs:
+      memo_id:
+        description: "検証する公開メモ ID"
+        required: false
+        default: "44"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Anonymous GET smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Smoke memo.public.view / memo.public.list (no auth headers)
+        run: |
+          BASE="https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/core-hub"
+          MEMO_ID="${{ github.event.inputs.memo_id || '44' }}"
+          FAIL=0
+
+          check() {
+            local label="$1" url="$2" expected="$3" needle="$4"
+            local body code
+            body=$(curl -sS --max-time 20 -w "\n%{http_code}" "$url" 2>&1) || true
+            code=$(echo "$body" | tail -1)
+            body=$(echo "$body" | head -n -1)
+            echo "=== $label ==="
+            echo "URL: $url"
+            echo "HTTP: $code (expected $expected)"
+            echo "$body" | head -c 600
+            echo ""
+            if [ "$code" != "$expected" ]; then
+              echo "::error::$label: HTTP $code != $expected"
+              FAIL=1
+            elif [ -n "$needle" ] && ! echo "$body" | grep -qF "$needle"; then
+              echo "::error::$label: response does not contain '$needle'"
+              FAIL=1
+            else
+              echo "✅ $label OK"
+            fi
+            echo ""
+          }
+
+          check "view html"  "$BASE?action=memo.public.view&id=$MEMO_ID" "200" "<html lang=\"ja\">"
+          check "view json"  "$BASE?action=memo.public.view&id=$MEMO_ID&format=json" "200" "\"appUrl\""
+          check "view md"    "$BASE?action=memo.public.view&id=$MEMO_ID&format=md" "200" "App URL:"
+          check "list html"  "$BASE?action=memo.public.list&limit=5" "200" "公開メモ一覧"
+          check "not found"  "$BASE?action=memo.public.view&id=999999999" "404" ""
+
+          exit "$FAIL"

--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -10,6 +10,13 @@ on:
         description: "検証する公開メモ ID"
         required: false
         default: "44"
+  # GitHub App からの workflow_dispatch が 403 になるため、
+  # この workflow 自身の変更 push でも smoke を実行する。
+  push:
+    branches:
+      - claude/page-accessibility-memo-qb499c
+    paths:
+      - ".github/workflows/public-memo-smoke.yml"
 
 permissions:
   contents: read

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -828,15 +828,23 @@ serve(async (req: Request) => {
     const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
     // deno-lint-ignore no-explicit-any
     let body: Record<string, any> = {};
-    if (req.method === "GET") {
-      // GET は query param を body 相当として扱う。ヘッダーを付けられない
+    if (req.method === "GET" || req.method === "HEAD") {
+      // GET/HEAD は query param を body 相当として扱う。ヘッダーを付けられない
       // クローラー / 外部 AI が匿名 action (memo.public.* 等) を叩けるようにする。
+      // HEAD はブラウザ / AI フェッチャーが本文取得前のプリフライトとして送る。
       body = Object.fromEntries(new URL(req.url).searchParams);
     } else {
       try {
         body = await req.json();
       } catch {
         body = {};
+      }
+      if (typeof body.action !== "string" || body.action === "") {
+        // 一部フェッチャーは POST でも body を送らない — query param を fallback。
+        body = {
+          ...Object.fromEntries(new URL(req.url).searchParams),
+          ...body,
+        };
       }
     }
 

--- a/supabase/functions/core-hub/public_memo_view.ts
+++ b/supabase/functions/core-hub/public_memo_view.ts
@@ -26,8 +26,9 @@ export type PublicMemoViewFormat = "html" | "json" | "md";
 export const PUBLIC_MEMO_VIEW_COLUMNS =
   "id, title, content, category, published_at, updated_at, view_count, like_count";
 
-/// format param 明示が最優先。未指定時は GET (ブラウザ / クローラー直アクセス)
-/// は HTML、POST (API クライアント) は JSON を既定とする。
+/// format param 明示が最優先。未指定時は GET/HEAD (ブラウザ / クローラー直
+/// アクセス。HEAD は AI フェッチャーのプリフライト) は HTML、POST (API
+/// クライアント) は JSON を既定とする。
 export function resolvePublicMemoViewFormat(
   format: unknown,
   method: string,
@@ -38,7 +39,8 @@ export function resolvePublicMemoViewFormat(
   if (normalized === "json") return "json";
   if (normalized === "md" || normalized === "markdown") return "md";
   if (normalized === "html") return "html";
-  return method.toUpperCase() === "GET" ? "html" : "json";
+  const upper = method.toUpperCase();
+  return upper === "GET" || upper === "HEAD" ? "html" : "json";
 }
 
 export function escapeHtml(value: string): string {

--- a/supabase/functions/core-hub/public_memo_view_test.ts
+++ b/supabase/functions/core-hub/public_memo_view_test.ts
@@ -41,6 +41,8 @@ Deno.test("resolvePublicMemoViewFormat honors explicit format first", () => {
 Deno.test("resolvePublicMemoViewFormat defaults by method", () => {
   assertEquals(resolvePublicMemoViewFormat(null, "GET"), "html");
   assertEquals(resolvePublicMemoViewFormat(undefined, "get"), "html");
+  assertEquals(resolvePublicMemoViewFormat(null, "HEAD"), "html");
+  assertEquals(resolvePublicMemoViewFormat(undefined, "head"), "html");
   assertEquals(resolvePublicMemoViewFormat("", "POST"), "json");
   assertEquals(resolvePublicMemoViewFormat("bogus", "POST"), "json");
 });


### PR DESCRIPTION
# Pull Request

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Edge Function request-shape fix; covered by deno unit tests + public-memo-smoke.yml prod workflow (GET/HEAD/POST/404 を GHA から実機検証); no UI route changed

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: HEAD/empty-POST fallback for already-anonymous read-only actions; no new data exposed (is_public=true rows only); no auth/billing/data-migration change; rollback = revert single commit; prod smoke = public-memo-smoke.yml after deploy; observability via existing EF logs

## 📝 変更内容

PR #3870 の公開メモ bot 可読ビューは GET では動作するが、ChatGPT 等の AI フェッチャーが本文取得前に送る **HEAD リクエストが 401** になり、フェッチャーはその時点で「401 Unauthorized」と報告する。GHA からのリクエスト形状再現診断 ([run 28868726525](https://github.com/kanta13jp1/my_web_app/actions/runs/28868726525)) で HEAD=401 / POST 空 body=401 / GET 全形状=200 を確認済み。

### 変更の種類

- [x] バグ修正 (breaking changeを含まないバグ修正)

## 🔗 関連Issue

Related to #3870 (公開メモ bot 可読ビュー本体)

## 🎯 変更の目的

ChatGPT 等の外部 AI フェッチャー (HEAD プリフライトを送る) からも公開メモの匿名アクセスを成立させる。

## 📋 実装の詳細

### 主な変更点

1. core-hub: HEAD リクエストも GET と同様に query param を action 入力として解釈
2. core-hub: POST で body に action が無い場合は query param を fallback として使用
3. `resolvePublicMemoViewFormat`: HEAD の既定 format を GET と同じ HTML に
4. 診断用に `public-memo-smoke.yml` へ外部 AI リクエスト形状バリアント (HEAD / UA / Origin / URL 変形) を追加

### 技術的な詳細

- 匿名で通るのは従来どおり `anonymousActions` (memo.public.view / memo.public.list / page.share_generate) のみ。その他の action は HEAD/POST fallback 経由でも認証必須のまま
- HEAD 応答の body はランタイムが自動で破棄するためヘッダーのみ返る (ステータスと Content-Type が正しく伝わることが目的)

## ✅ テスト結果

### テスト実施項目

- [x] 単体テスト
- [x] 手動テスト (GHA public-memo-smoke.yml による本番実機検証 — マージ後に再実行して HEAD=200 を確認予定)

### テストケース

| テストケース | 結果 | 備考 |
| --- | --- | --- |
| `public_memo_view_test.ts` 10 件 (HEAD format 既定含む) | ✅ | deno test 全パス |
| `deno lint` / `deno fmt --check` / `deno check` | ✅ | 0 エラー |
| 本番診断 (修正前): HEAD=401 / POST空=401 / GET=200 | ✅ 再現 | run 28868726525 |

## 🚨 Breaking Changes

- [x] このPRにはBreaking Changesが含まれていません

## 📊 パフォーマンスへの影響

- [x] パフォーマンスへの影響はありません

## 🔒 セキュリティへの影響

- [x] セキュリティへの影響はありません (匿名許可 action の集合は不変。HEAD/POST fallback は認証チェックより前の入力解釈のみの変更で、非匿名 action は従来どおり 401)

## 📚 ドキュメント更新

- [x] ドキュメント更新は不要 (EDGE_FUNCTION_LIST.md は #3870 で更新済み)

## ✅ レビュー観点

### 重点的にレビューしてほしい箇所

1. POST query-param fallback が既存の認証必須 action の挙動を変えないこと (`supabase/functions/core-hub/index.ts`)

### 懸念事項・相談したい点

なし

## 🚀 デプロイメモ

- [x] 特別なデプロイ手順は不要 (main マージ → deploy-prod で core-hub 自動デプロイ)

## ✅ チェックリスト

### コード品質

- [x] `deno lint` 0エラーを確認しました（Edge Function変更時は必須 — CIゲート）
- [x] ダミーデータを使用していません（Supabase実データのみ）
- [x] 不要なコメントや console.log を削除しました
- [x] コードレビューを受ける準備ができています（Claude Agent が自動レビューします）

### Rule / Script / Hook wiring 同期（追加時のみ — part 185 finding）

- [x] 該当なし（rule / script / hook 追加・変更なし）

### テスト

- [x] 新しいコードにテストを追加しました
- [x] すべてのテストが通ることを確認しました
- [x] エッジケースを考慮しました

### セキュリティ

- [x] 機密情報がコミットされていないことを確認しました
- [x] 入力値の検証を適切に実装しました
- [x] セキュリティベストプラクティスに従っています

### その他

- [x] Breaking Changesがないことを確認しました
- [x] パフォーマンスへの悪影響がないことを確認しました

## 💬 追加コメント

マージ + deploy-prod 完了後、`public-memo-smoke.yml` を再実行して HEAD=200 を確認し、ChatGPT からの再テストを依頼する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc)_