### PR TITLE
ci(smoke): promote public-memo bot-view smoke to daily regression check

### DIFF
--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -10,13 +10,11 @@ on:
         description: "検証する公開メモ ID"
         required: false
         default: "44"
-  # GitHub App からの workflow_dispatch が 403 になるため、
-  # この workflow 自身の変更 push でも smoke を実行する。
-  push:
-    branches:
-      - claude/page-accessibility-memo-qb499c
-    paths:
-      - ".github/workflows/public-memo-smoke.yml"
+  # 日次回帰検知: core-hub リファクタで HEAD/GET/POST 匿名アクセスが壊れたら
+  # 検知する (外部 AI 互換性の継続保証 / PR #3870, #3873)。
+  # push トリガーは使わない — main push 直後は deploy-prod 完了前で誤検知するため。
+  schedule:
+    - cron: "7 21 * * *" # 毎日 06:07 JST
 
 permissions:
   contents: read
@@ -61,6 +59,29 @@ jobs:
           check "view md"    "$BASE?action=memo.public.view&id=$MEMO_ID&format=md" "200" "App URL:"
           check "list html"  "$BASE?action=memo.public.list&limit=5" "200" "公開メモ一覧"
           check "not found"  "$BASE?action=memo.public.view&id=999999999" "404" ""
+
+          # PR #3873: AI フェッチャーの HEAD プリフライト / 空 body POST も匿名で通ること
+          echo "=== HEAD ==="
+          HEAD_CODE=$(curl -sS --max-time 20 -o /dev/null -w "%{http_code}" -I \
+            "$BASE?action=memo.public.view&id=$MEMO_ID") || true
+          echo "HTTP: $HEAD_CODE (expected 200)"
+          if [ "$HEAD_CODE" != "200" ]; then
+            echo "::error::HEAD preflight: HTTP $HEAD_CODE != 200"
+            FAIL=1
+          else
+            echo "✅ HEAD OK"
+          fi
+          echo "=== POST empty body ==="
+          POST_BODY=$(curl -sS --max-time 20 -X POST -w "\n%{http_code}" \
+            "$BASE?action=memo.public.view&id=$MEMO_ID") || true
+          POST_CODE=$(echo "$POST_BODY" | tail -1)
+          echo "HTTP: $POST_CODE (expected 200)"
+          if [ "$POST_CODE" != "200" ] || ! echo "$POST_BODY" | grep -qF '"appUrl"'; then
+            echo "::error::POST empty body: HTTP $POST_CODE or missing appUrl"
+            FAIL=1
+          else
+            echo "✅ POST empty body OK"
+          fi
 
           exit "$FAIL"
 


### PR DESCRIPTION
# Pull Request

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CI workflow only change (smoke workflow trigger/checks); no app code touched

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CI smoke workflow only; read-only anonymous curl checks against public memo endpoint; rollback = revert single commit; no app code / no data-migration / no security surface change

## 📝 変更内容

PR #3873 で入った `public-memo-smoke.yml` を日次回帰チェックに昇格する。

### 変更の種類

- [x] CI/CD関連

## 🔗 関連Issue

Related to #3870 / #3873 (公開メモ bot 可読ビュー + HEAD 修正)

## 🎯 変更の目的

外部 AI (ChatGPT / Claude / Gemini) 向け公開メモ互換性の継続保証。将来の core-hub リファクタで HEAD/GET/POST の匿名アクセスが壊れた場合に CI で検知する。

## 📋 実装の詳細

### 主な変更点

1. HEAD プリフライト = 200 / 空 body POST = 200 を強制チェックに追加 (PR #3873 の回帰検知)
2. トリガーを daily cron (06:07 JST) + workflow_dispatch に整理 (ブランチ限定 push トリガーを削除)

### 技術的な詳細

- push トリガーは採用しない — main push 直後は deploy-prod 完了前のため誤検知する

## ✅ テスト結果

### テストケース

| テストケース | 結果 | 備考 |
| --- | --- | --- |
| 同内容の強制チェック (HEAD/POST 含む) を branch push で実行 | ✅ 全パス | [run 28870539790](https://github.com/kanta13jp1/my_web_app/actions/runs/28870539790) |

## 🚨 Breaking Changes

- [x] このPRにはBreaking Changesが含まれていません

## 📊 パフォーマンスへの影響

- [x] パフォーマンスへの影響はありません

## 🔒 セキュリティへの影響

- [x] セキュリティへの影響はありません (認証情報を使わない匿名 curl のみ)

## 📚 ドキュメント更新

- [x] ドキュメント更新は不要

## 🚀 デプロイメモ

- [x] 特別なデプロイ手順は不要

## ✅ チェックリスト

### コード品質

- [x] 不要なコメントや console.log を削除しました
- [x] コードレビューを受ける準備ができています（Claude Agent が自動レビューします）

### Rule / Script / Hook wiring 同期（追加時のみ — part 185 finding）

- [x] 該当なし（rule / script / hook 追加・変更なし）

### テスト

- [x] すべてのテストが通ることを確認しました

### セキュリティ

- [x] 機密情報がコミットされていないことを確認しました

### その他

- [x] Breaking Changesがないことを確認しました

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc)_