### PR TITLE
[CI/CD自動最適化] 2026-07-07: mcp-anomaly cancel-in-progress + infra-check cron 4h

### DIFF
--- a/.github/workflows/infra-health-check.yml
+++ b/.github/workflows/infra-health-check.yml
@@ -3,7 +3,7 @@ name: Infra Health Check (インフラ監視)
 # 毎時 + 手動実行
 on:
   schedule:
-    - cron: "37 */2 * * *"  # 2時間ごと37分
+    - cron: "37 */4 * * *"  # 4時間ごと37分 (2026-07-07 ci-audit: health-monitor 2h cover あり)
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mcp-audit-anomaly-cron.yml
+++ b/.github/workflows/mcp-audit-anomaly-cron.yml
@@ -25,7 +25,7 @@ permissions:
 
 concurrency:
   group: mcp-audit-anomaly
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-07-07 ci-audit: 2h cron キュー積み防止・最新状態のみ評価
 
 jobs:
   script-test:


### PR DESCRIPTION
## 概要

CI/CD 監査 (2026-07-07) に基づく自動最適化。ホワイトリスト範囲内の 2 ファイル変更のみ。

## 変更内容

### 1. `mcp-audit-anomaly-cron.yml` — `cancel-in-progress: false → true`

- **理由**: 2h スケジュール実行時にキューが積み上がるのを防止。最新状態の anomaly 評価のみ重要で、古い run は不要。
- **分類**: ホワイトリスト ④ (deploy 以外の workflow への `concurrency.cancel-in-progress: true` 追加)
- **節約試算**: 最大 6,480 min/month のキュー積み上がりリスク解消

### 2. `infra-health-check.yml` — cron `37 */2 → 37 */4`

- **理由**: `health-monitor.yml` が同等の EF 監視を 2h 間隔で実施しており、infra-health-check の 2h 頻度は冗長。4h に変更しても監視空白は生じない。
- **分類**: ホワイトリスト ③ (過剰な schedule cron の頻度削減)
- **節約試算**: 月 180 run × 5min = **900 min/month 削減**

## 関連

- Audit report: `docs/ci-cd-audit/2026-07-07.md` (main にコミット済み)
- Tracking Issue: #3841

## 安全確認

- [x] deploy-prod / deploy-dev / deploy-staging は変更なし
- [x] secrets / permissions / trigger 種別は変更なし
- [x] 変更は 2 ファイル以内
- [x] 変更は可逆 (元の値にすぐ戻せる)
- [x] `concurrency.cancel-in-progress` 変更対象は非 deploy workflow のみ

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CI/CD workflow-only changes — cron frequency and cancel-in-progress toggle only. No application code, secrets, permissions, deploy paths, or data migrations touched. Changes are fully reversible single-line edits within the established whitelist. Unresolved ultrareview findings: 0.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- Note: this PR changes only `.github/workflows/` yml scheduling config — no application code paths were modified (application-code change detected: no). E2E coverage is not applicable to workflow cron/concurrency adjustments.