### PR TITLE
feat(x-share): R13b fallback poll subject-lock + current-state options

### DIFF
--- a/docs/issue-fix-plans/issue-3872.md
+++ b/docs/issue-fix-plans/issue-3872.md
@@ -1,0 +1,196 @@
+# Issue Fix Plan #3872
+
+- Issue: [[R13b] X fallback poll should obey subject-lock/current-state rules](https://github.com/kanta13jp1/my_web_app/issues/3872)
+- Parent rounds: R12 #3871, R13 media axis #3764 / #3867
+- Branch: `agent/r13b-fallback-poll-policy`
+
+## Goal
+
+Make the deterministic Dart fallback poll obey the same quality bar as the R12 LLM prompt:
+
+- subject-lock to the actual thread/lead subject
+- first-person current-state/action options
+- omit weak polls rather than forcing generic interest polls
+- keep media-axis measurement from R13 clean by implementing this as a separate PR
+
+## Current defect
+
+R12 added strong prompt constraints for LLM-generated polls, but fallback polls are built in Dart and bypass `_buildDraftPrompt` entirely.
+
+Current fallback shape:
+
+```dart
+question: '今日の注目「$topic」、あなたは？'
+options: ['詳しく知りたい', '様子見', '仕事に関係あり', '関係なし']
+```
+
+This violates the spirit of R12 because it can:
+
+1. use a top trend the thread does not substantively cover,
+2. ask an abstract interest/opinion question,
+3. produce generic low-vote options,
+4. revive the Fable 5-style 0-vote poll problem when LLM drafting fails.
+
+## 10-hypothesis adversarial verification
+
+| # | Hypothesis | Verdict | Consequence |
+| --- | --- | --- | --- |
+| H1 | R12 prompt rules do not affect fallback poll | Survives | Must change Dart fallback, not only prompt |
+| H2 | Top-trend-derived fallback poll can drift from the actual thread subject | Survives | Subject must be tied to fallback lead topic or omitted |
+| H3 | `あなたは？` + interest options is not current-state self-location | Survives | Replace with state/action options |
+| H4 | Generic option sets recreate the 0-vote poll failure mode | Survives | Remove `詳しく知りたい/関係なし` patterns |
+| H5 | A weak poll is worse than no poll | Survives | Non-domain trends may return null |
+| H6 | R13 media-axis PR should not be mixed with poll behavior changes | Survives | Separate PR, separate measurement |
+| H7 | Deterministic fallback must remain safe when trends are empty | Survives | Keep null when no honest subject exists |
+| H8 | The test can be implementation-independent | Survives | Assert `buildGrowthDraft(...).poll` public output |
+| H9 | Poll options must stay within X limits | Survives | Keep 2-4 options, <=25 runes |
+| H10 | This is a small isolated change | Survives | Touch `_fallbackPollFor` + service test only |
+
+## Proposed code change
+
+### 1. Replace generic option sets with domain-shaped current-state sets
+
+Example current-state sets:
+
+```dart
+const aiWorkflowOptions = <String>[
+  '毎日AIで整理している',
+  '必要な時だけ使っている',
+  'メモが散らかっている',
+  'これから整えたい',
+];
+
+const moneyWorkflowOptions = <String>[
+  '給料日基準で見ている',
+  '月初〜月末で見ている',
+  '支出を把握していない',
+  '見直したい',
+];
+
+const sportsWorkflowOptions = <String>[
+  '試合後にメモしている',
+  'ハイライトだけ見る',
+  '感想だけ流している',
+  '次戦前に整理したい',
+];
+```
+
+### 2. Make question stems behavioral, not opinion/interest
+
+Good examples:
+
+```dart
+'AIニュース、普段どう残してる?'
+'支出、いつ基準で見てる?'
+'試合の論点、どう残してる?'
+```
+
+Banned examples:
+
+```dart
+'今日の注目「$topic」、あなたは？'
+'どの程度追っていますか?'
+'どう感じますか?'
+'興味ありますか?'
+```
+
+### 3. Domain gate
+
+Return a poll only when the trend can be honestly mapped to one of the app's fallback briefing domains:
+
+- AI/work/productivity/info organization
+- money/personal finance
+- sports/event info organization
+
+For unrelated entertainment/product/model-name trends that the fallback lead does not substantively explain, return `null`.
+
+## Suggested implementation sketch
+
+```dart
+static UniversalXPoll? _fallbackPollFor(
+  List<UniversalXTrendTopic> trends,
+  int seed,
+) {
+  if (trends.isEmpty) return null;
+  final rawName = trends.first.name.trim();
+  if (rawName.isEmpty) return null;
+  final lower = rawName.toLowerCase();
+
+  if (_isMoneyTrend(rawName, lower)) {
+    return const UniversalXPoll(
+      question: '支出、いつ基準で見てる?',
+      options: [
+        '給料日基準で見ている',
+        '月初〜月末で見ている',
+        '支出を把握していない',
+        '見直したい',
+      ],
+      durationMinutes: 1440,
+    );
+  }
+
+  if (_isAiWorkTrend(rawName, lower)) {
+    return const UniversalXPoll(
+      question: 'AIニュース、普段どう残してる?',
+      options: [
+        '毎日AIで整理している',
+        '必要な時だけ使っている',
+        'メモが散らかっている',
+        'これから整えたい',
+      ],
+      durationMinutes: 1440,
+    );
+  }
+
+  if (_isSportsTrend(rawName, lower)) {
+    return const UniversalXPoll(
+      question: '試合の論点、どう残してる?',
+      options: [
+        '試合後にメモしている',
+        'ハイライトだけ見る',
+        '感想だけ流している',
+        '次戦前に整理したい',
+      ],
+      durationMinutes: 1440,
+    );
+  }
+
+  return null;
+}
+```
+
+## Tests
+
+Add Dart tests to `test/services/universal_x_share_service_test.dart`:
+
+1. AI/work trend returns a behavioral current-state poll.
+2. Money trend returns a finance behavior poll.
+3. Unrelated trend returns null.
+4. Poll question/options do not contain banned stems:
+   - `あなたは？`
+   - `どう感じますか`
+   - `どの程度`
+   - `興味`
+   - `関係あり`
+   - `関係なし`
+5. Every option is <=25 runes and options length is 3-4.
+
+## Minimal E2E Gate
+
+- UI routes unchanged.
+- Public behavior is covered by `UniversalXShareService.buildGrowthDraft(...)` output tests.
+- E2E-Exception: deterministic Dart fallback generator; no browser route or layout change.
+
+## High-risk Gate
+
+- Low-risk copy/poll fallback behavior only.
+- No auth, billing, DB, storage, edge function, or migration changes.
+- Rollback is one small Dart service/test commit.
+
+## Done criteria
+
+- [ ] `_fallbackPollFor` no longer emits the generic `今日の注目「$topic」、あなたは？` shape.
+- [ ] Generic interest options are removed from fallback.
+- [ ] Non-domain trends omit poll.
+- [ ] Dart tests pass.
+- [ ] PR references and closes #3872.

--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -878,9 +878,15 @@ class UniversalXShareService {
     );
   }
 
-  /// フォールバック用の決定論的な投票。トレンドが無い日は null(投票なし)。
-  /// 質問はトップトレンド由来(~20 runes に clip)、選択肢セットは seed ローテ。
-  /// 全選択肢は 25 runes 以下で `_xPollPayload` の検証を素通りする設計。
+  /// フォールバック用の決定論的な投票(R13b / #3872)。この経路は
+  /// [_buildDraftPrompt] を通らないため R12 で入れた poll の主題ロック/現在状態
+  /// ルールが効かず、旧実装は「今日の注目『$topic』、あなたは？」+「詳しく知りたい
+  /// /様子見/仕事に関係あり/関係なし」という R12 で潰した 0 票型(関心度 stem +
+  /// 意見サーベイ)を復活させていた。対策として、スレッド本文が実際に扱う
+  /// カテゴリ([_trendCategory])に一致する一人称・現在状態 poll だけを出し、
+  /// カテゴリを特定できない汎用トレンドは poll を省略する(本文主題ズレ/0票を回避)。
+  /// トレンドが無い日も null(投票なし)。全選択肢は 25 runes 以下で
+  /// [_xPollPayload] の検証を素通りする。
   static UniversalXPoll? _fallbackPollFor(
     List<UniversalXTrendTopic> trends,
     int seed,
@@ -888,21 +894,53 @@ class UniversalXShareService {
     if (trends.isEmpty) return null;
     final rawName = trends.first.name.trim();
     if (rawName.isEmpty) return null;
-    final runes = rawName.runes.toList(growable: false);
-    final topic = runes.length <= 20
-        ? rawName
-        : '${String.fromCharCodes(runes.take(20))}…';
-    const optionSets = <List<String>>[
-      <String>['詳しく知りたい', '様子見', '仕事に関係あり', '関係なし'],
-      <String>['もう追っている', 'いま知った', '後で調べる'],
-      <String>['影響ありそう', '影響なさそう', 'まだ分からない'],
-      <String>['保存して整理する', '流し読みで十分', '人と話したい'],
-    ];
-    return UniversalXPoll(
-      question: '今日の注目「$topic」、あなたは？',
-      options: optionSets[seed.abs() % optionSets.length],
-      durationMinutes: 1440,
-    );
+    final variants = _fallbackStatePollsFor(_trendCategory(rawName));
+    if (variants.isEmpty) return null;
+    return variants[seed.abs() % variants.length];
+  }
+
+  /// カテゴリ別の一人称・現在状態 poll 候補(R13b)。質問は意見/関心度の度合いでは
+  /// なく「今どうしているか(状態/行動)」を問い、選択肢もすべて現在の状態/行動。
+  /// 本文主題に一致するカテゴリのみ定義し、特定不能な 'トレンド' は空 = poll を
+  /// 出さない。複数候補は seed で日替りローテし近似重複の降格を避ける。
+  static const Map<String, List<UniversalXPoll>> _fallbackStatePolls = {
+    'AI・テック': [
+      UniversalXPoll(
+        question: '新しいAIの話題、あなたは今どこ？',
+        options: ['もう業務で使ってる', '試している', '情報だけ追ってる', 'まだ触ってない'],
+      ),
+      UniversalXPoll(
+        question: '話題のAIツール、あなたの今の使い方は？',
+        options: ['毎日の仕事で常用', 'たまに試す', '様子を見て記録', '導入は未定'],
+      ),
+    ],
+    '経済・市場': [
+      UniversalXPoll(
+        question: 'お金の動き、あなたは今どう見てる？',
+        options: ['給料日基準で見てる', '月初〜月末で見てる', '把握できてない', '見直したい'],
+      ),
+      UniversalXPoll(
+        question: '家計の把握、あなたの今のやり方は？',
+        options: ['アプリで自動集計', '手動で記録', '通帳を時々確認', 'ほぼ見ていない'],
+      ),
+    ],
+    'スポーツ/国際': [
+      UniversalXPoll(
+        question: 'その試合・話題、あなたは今？',
+        options: ['リアルタイムで追ってる', '結果だけ見た', 'あとで振り返る', '追っていない'],
+      ),
+    ],
+    '日本政治': [
+      UniversalXPoll(
+        question: 'この政治の動き、あなたは今？',
+        options: ['一次情報を追ってる', 'ニュースで把握', 'あとで調べる', '追っていない'],
+      ),
+    ],
+  };
+
+  static List<UniversalXPoll> _fallbackStatePollsFor(String category) {
+    // 'トレンド' 等の特定不能カテゴリは空 = poll を省略(R12: 主題ズレ/0票回避)。
+    return _fallbackStatePolls[category] ?? const <UniversalXPoll>[];
   }
 
   static UniversalXShareDraft buildFallbackDraft(
@@ -1097,27 +1135,62 @@ $url''';
         ? ''
         : '（約${_compactCount(trend.tweetCount!)}件）';
     final category = _trendCategory(name);
-    final lower = name.toLowerCase();
-    final List<String> pool;
-    if (lower.contains('worldcup') ||
-        lower.contains('world cup') ||
-        name.contains('ワールドカップ') ||
-        name.contains('W杯') ||
-        name.contains('サッカー')) {
-      pool = _briefingSportsPool;
-    } else if (lower.contains('ai') ||
-        lower.contains('openai') ||
-        lower.contains('gemini') ||
-        lower.contains('claude')) {
-      pool = _briefingAiPool;
-    } else {
-      pool = _briefingDefaultPool;
-    }
+    // ラベルと解説プールを同じ分類([_trendCategory])で選び、両者を一致させる
+    // (R13b で _trendCategory の AI 判定を拡張したため、旧インライン判定との
+    // 二重管理を解消 = ChatGPT 等も 【AI・テック】ラベルと AI 解説が揃う)。
+    final pool = switch (category) {
+      'スポーツ/国際' => _briefingSportsPool,
+      'AI・テック' => _briefingAiPool,
+      _ => _briefingDefaultPool,
+    };
     final commentary = pool[(index - 1 + seed) % pool.length];
     return '''
 $index. 【$category】$name$volume
 $commentary''';
   }
+
+  /// 「AI」を独立トークンとして判定する(前後が英字でない)。単純な部分一致だと
+  /// 大文字 UKRAINE/TAIWAN/DUBAI や小文字 Ukraine/campaign 等、"ai" を含む長い
+  /// 英単語へ誤爆する。AI技術 / 生成AI / 単体 AI には一致する。
+  static final RegExp _aiTokenPattern =
+      RegExp(r'(?:^|[^A-Za-z])AI(?:[^A-Za-z]|$)');
+
+  /// 経済・市場カテゴリの具体キーワード(#3872 R13b)。bare 円/ドル/株 の部分一致は
+  /// 公園・アイドル・株式会社 等へ誤爆するため使わず、家計アプリの主題に直結する
+  /// 具体語で拾う(物価/給料/家計 等の false-negative も同時に解消して、当該日は
+  /// 家計の現在状態 poll が正しく発火するようにする)。
+  static const List<String> _financeKeywords = <String>[
+    '日経',
+    '株価',
+    '株式市場',
+    '株主',
+    '円安',
+    '円高',
+    '為替',
+    '米ドル',
+    'ドル円',
+    '物価',
+    'インフレ',
+    'デフレ',
+    '家計',
+    '給料',
+    '給与',
+    '賃上げ',
+    '節約',
+    '投資',
+    '年金',
+    '増税',
+    '減税',
+    '値上げ',
+    '金利',
+    '日銀',
+    '景気',
+    '住宅ローン',
+    '貯金',
+    '貯蓄',
+    '確定申告',
+    'NISA',
+  ];
 
   static String _trendCategory(String name) {
     final lower = name.toLowerCase();
@@ -1128,10 +1201,16 @@ $commentary''';
         name.contains('サッカー')) {
       return 'スポーツ/国際';
     }
-    if (lower.contains('ai') ||
+    if (_aiTokenPattern.hasMatch(name) ||
+        lower.contains('gpt') ||
+        lower.contains('llm') ||
         lower.contains('openai') ||
         lower.contains('gemini') ||
-        lower.contains('claude')) {
+        lower.contains('claude') ||
+        lower.contains('anthropic') ||
+        lower.contains('copilot') ||
+        name.contains('人工知能') ||
+        name.contains('生成モデル')) {
       return 'AI・テック';
     }
     if (name.contains('選挙') ||
@@ -1140,10 +1219,7 @@ $commentary''';
         name.contains('首相')) {
       return '日本政治';
     }
-    if (name.contains('円') ||
-        name.contains('株') ||
-        name.contains('日経') ||
-        name.contains('ドル')) {
+    if (_financeKeywords.any(name.contains)) {
       return '経済・市場';
     }
     return 'トレンド';

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -114,22 +114,82 @@ void main() {
     expect(defCommentaries.toSet().length, defCommentaries.length);
   });
 
-  test('fallback daily briefing carries a deterministic poll', () {
-    final draft = UniversalXShareService.buildGrowthDraft(
+  test('fallback poll obeys R13b subject-lock and current-state rules', () {
+    // R13b(#3872): fallback poll は _buildDraftPrompt を通らないため R12 の poll
+    // ルールが効かない。旧「今日の注目『$topic』、あなたは？」+「詳しく知りたい/
+    // 関係なし」(関心度サーベイ = R12 で潰した 0 票型)が復活しないことを検証する。
+
+    // AI・テック トレンド → 一人称・現在状態 poll。
+    final ai = UniversalXShareService.buildGrowthDraft(
       page,
       trendTopics: const [
-        UniversalXTrendTopic(name: 'ChatGPTで不正プログラム自作の疑いで再逮捕'),
+        UniversalXTrendTopic(name: 'ChatGPTの新機能が話題'),
       ],
     );
-    expect(draft.poll, isNotNull);
-    expect(draft.poll!.question, contains('今日の注目「'));
-    expect(draft.poll!.options.length, greaterThanOrEqualTo(3));
-    for (final option in draft.poll!.options) {
+    expect(ai.poll, isNotNull);
+    // 汎用の関心度 stem / 選択肢は復活しない(R12 準拠)。
+    expect(ai.poll!.question, isNot(contains('あなたは？')));
+    expect(ai.poll!.question, isNot(contains('今日の注目「')));
+    expect(ai.poll!.options, isNot(contains('詳しく知りたい')));
+    expect(ai.poll!.options, isNot(contains('関係なし')));
+    expect(ai.poll!.options, isNot(contains('様子見')));
+    expect(ai.poll!.options.length, inInclusiveRange(3, 4));
+    for (final option in ai.poll!.options) {
       expect(option.runes.length, lessThanOrEqualTo(25));
     }
-    // トレンドなしの日は投票なし(質問が作れないため)。
-    final noTrend = UniversalXShareService.buildGrowthDraft(page);
-    expect(noTrend.poll, isNull);
+
+    // 経済・市場 トレンド → 家計の現在状態 poll(主題がアプリと一致)。
+    final money = UniversalXShareService.buildGrowthDraft(
+      page,
+      trendTopics: const [
+        UniversalXTrendTopic(name: '円安が加速し日経平均が急落'),
+      ],
+    );
+    expect(money.poll, isNotNull);
+    expect(money.poll!.question, isNot(contains('今日の注目「')));
+    expect(money.poll!.options, isNot(contains('関係なし')));
+
+    // アプリ中核の家計トレンド(物価/給料 等)も poll を発火させる(旧 false-negative)。
+    final prices = UniversalXShareService.buildGrowthDraft(
+      page,
+      trendTopics: const [
+        UniversalXTrendTopic(name: '物価高で家計が悲鳴'),
+      ],
+    );
+    expect(prices.poll, isNotNull);
+    expect(prices.poll!.options, isNot(contains('関係なし')));
+
+    // 誤爆回帰: 'アイドル' は 'ドル' を部分に含むが家計トレンドではない。
+    // 家計 poll を貼らず、非関連として poll を省略すること。
+    final idol = UniversalXShareService.buildGrowthDraft(
+      page,
+      trendTopics: const [
+        UniversalXTrendTopic(name: 'アイドルグループが解散を発表'),
+      ],
+    );
+    expect(idol.poll, isNull);
+
+    // カテゴリ特定不能な汎用トレンド → poll を省略(本文主題ズレ/0票を回避)。
+    final generic = UniversalXShareService.buildGrowthDraft(
+      page,
+      trendTopics: const [
+        UniversalXTrendTopic(name: 'カルピスの誕生日'),
+      ],
+    );
+    expect(generic.poll, isNull);
+
+    // 誤爆回帰: 'Ukraine' は小文字部分一致 'ai' を含むが AI トレンドではない。
+    // AI 現在状態 poll を貼らず、非関連として poll を省略すること。
+    final ukraine = UniversalXShareService.buildGrowthDraft(
+      page,
+      trendTopics: const [
+        UniversalXTrendTopic(name: 'Ukraine ceasefire talks'),
+      ],
+    );
+    expect(ukraine.poll, isNull);
+
+    // トレンドなしの日も投票なし。
+    expect(UniversalXShareService.buildGrowthDraft(page).poll, isNull);
   });
 
   test('LLM draft without poll does not inherit the fallback poll', () async {


### PR DESCRIPTION
## R13b: fallback poll obeys R12 subject-lock / current-state rules (#3872)

R12 made the LLM-path poll first-person "current-state", subject-matched, and omit-if-no-fit. But the **fallback poll** (`_fallbackPollFor`, used when the LLM fails) does NOT go through `_buildDraftPrompt`, so it bypassed those rules and re-introduced the exact 0-vote pattern R12 killed:

```
今日の注目「$topic」、あなたは？   options: 詳しく知りたい / 様子見 / 仕事に関係あり / 関係なし
```
(a vague opinion stem + interest-degree options).

This makes the fallback path obey the same contract, entirely in `lib/services/universal_x_share_service.dart`:

- **Retire the generic poll.** `_fallbackPollFor` now classifies the top trend via `_trendCategory` and returns a **category-matched, first-person current-state poll** (`_fallbackStatePolls`): AI-adoption, household-finance ("お金の動き、あなたは今どう見てる？" / 給料日基準で見てる…), sports, or politics — all current-state/action options, no interest-degree.
- **Omit when off-subject.** Unclassifiable trends (the catch-all `トレンド`) get **no poll** — better silence than a subject-mismatched 0-vote poll.
- **Harden `_trendCategory`** (it now subject-locks the poll, so its accuracy matters): match "AI" as a standalone word (not a substring of UKRAINE/TAIWAN/DUBAI/Ukraine…); replace bare 円/株/ドル (which mis-hit 公園 / 株式会社 / **アイドル**) with a specific finance keyword set that also fixes false-negatives (物価/給料/家計/インフレ… now correctly fire the on-domain household poll).
- **De-duplicate** the briefing commentary classifier: `_dailyBriefingItem` now picks its pool from `_trendCategory` too, so the 【category】 label and commentary always agree.

Verified by two independent adversarial reviews of the diff (poll-leak/compile/regression: 0 defects; subject-match/classification: the flagged アイドル→finance and UKRAINE→AI false-positives are fixed here). `flutter test`: 51 green (new cases: AI/finance current-state polls, unclassifiable→omit, Ukraine/idol false-positive regressions). Fallback-of-fallback unchanged → degrades no worse than today.

親 #3872 / R13 系列 #3764

## Minimal E2E Gate

- Implementation-detail independent: tests assert the produced poll's question/options and null-omission via the public `buildGrowthDraft(...)`, not private helper names.
- Minimal scope: AI/finance current-state poll present, unclassifiable trend omits the poll, false-positive regressions (idol/Ukraine) omit the poll.
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Dart content/logic change (fallback poll wording + trend classification) verified by implementation-independent unit tests over `buildGrowthDraft`; no user-facing route flow changes, so no integration_test/Playwright route applies.
