### PR TITLE
feat(public-memo): AI-friendly payload + search / related v1 actions

### DIFF
--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -83,6 +83,11 @@ jobs:
             echo "✅ POST empty body OK"
           fi
 
+          # AI 向け search / related action (匿名)。search は 0 件でも 200 が正。
+          check "search json"      "$BASE?action=memo.public.search&q=2026&limit=5" "200" "\"success\":true"
+          check "search too short" "$BASE?action=memo.public.search&q=x" "400" ""
+          check "related json"     "$BASE?action=memo.public.related&id=$MEMO_ID&limit=5" "200" "\"success\":true"
+
           exit "$FAIL"
 
       # 外部 AI / ブラウザ系フェッチャーのリクエスト形状を再現し、

--- a/docs/EDGE_FUNCTION_LIST.md
+++ b/docs/EDGE_FUNCTION_LIST.md
@@ -7,7 +7,7 @@
 
 | Function | 用途 |
 | --- | --- |
-| `core-hub` | コアUI・メモ・通知統合。公開メモ bot 可読ビュー `memo.public.view` / `memo.public.list` (= 認証不要 GET / format=html\|json\|md / SPA を読めない ChatGPT 等の AI・クローラー向け) |
+| `core-hub` | コアUI・メモ・通知統合。公開メモ AI 向け API `memo.public.view` / `memo.public.list` / `memo.public.search` / `memo.public.related` (= 認証不要 GET・HEAD・POST / format=html\|json\|md / JSON は summary・markdown・tags 付き / SPA を読めない ChatGPT 等の AI・クローラー向け / 日次回帰 = public-memo-smoke.yml) |
 | `tools-hub` | 個人生産性ツール統合 (= WBS / Issue / digest / agent_tool_policy 等) |
 | `schedule-hub` (`digest.run`) | Schedule 用日次メトリクス API + blog auto_publish + blog.recent_posted (= part 124) + blog.backfill_from_apis |
 | `growth-hub` | グロース指標 / share track / command analyze (= part 112 EF 移行) |

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -23,6 +23,10 @@ import {
 } from "./feature_request_dedupe.ts";
 import { buildFeedbackIssue } from "./feedback_issue.ts";
 import {
+  clampPublicMemoLimit,
+  normalizePublicMemoSearchQuery,
+  PUBLIC_MEMO_SEARCH_MAX_QUERY_LENGTH,
+  PUBLIC_MEMO_SEARCH_MIN_QUERY_LENGTH,
   PUBLIC_MEMO_VIEW_COLUMNS,
   publicMemoToPayload,
   type PublicMemoViewRow,
@@ -861,6 +865,8 @@ serve(async (req: Request) => {
       "page.share_generate",
       "memo.public.view",
       "memo.public.list",
+      "memo.public.search",
+      "memo.public.related",
     ]);
     const bearer = (req.headers.get("authorization") ?? "").replace(
       /^Bearer\s+/i,
@@ -976,10 +982,7 @@ serve(async (req: Request) => {
       }
 
       case "memo.public.list": {
-        const rawLimit = Number(body.limit);
-        const limit = Number.isFinite(rawLimit)
-          ? Math.min(Math.max(Math.trunc(rawLimit), 1), 50)
-          : 20;
+        const limit = clampPublicMemoLimit(body.limit, 20, 50);
         const format = resolvePublicMemoViewFormat(body.format, req.method);
         const { data, error } = await admin
           .from("public_memos")
@@ -1003,6 +1006,110 @@ serve(async (req: Request) => {
         }
         return json({
           success: true,
+          memos: rows.map(publicMemoToPayload),
+        });
+      }
+
+      // ---- Public memo search (anonymous / AI 向け) ----
+      // 負荷対策: query は正規化 + 2〜100 字ガード、limit は 1..50 clamp、
+      // is_public=true のみ。ilike ワイルドカードは無害化済み。
+      case "memo.public.search": {
+        const query = normalizePublicMemoSearchQuery(body.q ?? body.query);
+        if (query === null) {
+          return json({
+            error: `q (${PUBLIC_MEMO_SEARCH_MIN_QUERY_LENGTH}-` +
+              `${PUBLIC_MEMO_SEARCH_MAX_QUERY_LENGTH} chars) required`,
+          }, 400);
+        }
+        const limit = clampPublicMemoLimit(body.limit, 20, 50);
+        const format = resolvePublicMemoViewFormat(body.format, req.method);
+        const pattern = `%${query}%`;
+        const { data, error } = await admin
+          .from("public_memos")
+          .select(PUBLIC_MEMO_VIEW_COLUMNS)
+          .eq("is_public", true)
+          .or(
+            `title.ilike.${pattern},content.ilike.${pattern},category.ilike.${pattern}`,
+          )
+          .order("published_at", { ascending: false })
+          .limit(limit);
+        if (error) return json({ error: error.message }, 500);
+        const rows = (data ?? []) as PublicMemoViewRow[];
+        if (format === "html") {
+          return publicText(
+            renderPublicMemoListHtml(rows),
+            "text/html; charset=utf-8",
+          );
+        }
+        if (format === "md") {
+          return publicText(
+            renderPublicMemoListMarkdown(rows),
+            "text/markdown; charset=utf-8",
+          );
+        }
+        return json({
+          success: true,
+          query,
+          memos: rows.map(publicMemoToPayload),
+        });
+      }
+
+      // ---- Public memo related v1 (anonymous / 同カテゴリ・自分以外・新しい順) ----
+      case "memo.public.related": {
+        const memoId = Number(body.id ?? body.memo_id);
+        if (!Number.isInteger(memoId) || memoId <= 0) {
+          return json({ error: "id (positive integer) required" }, 400);
+        }
+        const limit = clampPublicMemoLimit(body.limit, 5, 20);
+        const format = resolvePublicMemoViewFormat(body.format, req.method);
+        const { data: base, error: baseError } = await admin
+          .from("public_memos")
+          .select("id, category")
+          .eq("id", memoId)
+          .eq("is_public", true)
+          .maybeSingle();
+        if (baseError) return json({ error: baseError.message }, 500);
+        if (!base) {
+          if (format === "html") {
+            return publicText(
+              renderPublicMemoNotFoundHtml(memoId),
+              "text/html; charset=utf-8",
+              404,
+            );
+          }
+          return json({ error: `Public memo ${memoId} not found` }, 404);
+        }
+        const category = ((base as { category: string | null }).category ?? "")
+          .trim();
+        let rows: PublicMemoViewRow[] = [];
+        if (category) {
+          const { data, error } = await admin
+            .from("public_memos")
+            .select(PUBLIC_MEMO_VIEW_COLUMNS)
+            .eq("is_public", true)
+            .eq("category", category)
+            .neq("id", memoId)
+            .order("published_at", { ascending: false })
+            .limit(limit);
+          if (error) return json({ error: error.message }, 500);
+          rows = (data ?? []) as PublicMemoViewRow[];
+        }
+        if (format === "html") {
+          return publicText(
+            renderPublicMemoListHtml(rows),
+            "text/html; charset=utf-8",
+          );
+        }
+        if (format === "md") {
+          return publicText(
+            renderPublicMemoListMarkdown(rows),
+            "text/markdown; charset=utf-8",
+          );
+        }
+        return json({
+          success: true,
+          memoId,
+          category: category || null,
           memos: rows.map(publicMemoToPayload),
         });
       }

--- a/supabase/functions/core-hub/public_memo_view.ts
+++ b/supabase/functions/core-hub/public_memo_view.ts
@@ -15,6 +15,7 @@ export interface PublicMemoViewRow {
   title: string | null;
   content: string | null;
   category: string | null;
+  metadata?: unknown;
   published_at: string | null;
   updated_at: string | null;
   view_count: number | null;
@@ -24,7 +25,7 @@ export interface PublicMemoViewRow {
 export type PublicMemoViewFormat = "html" | "json" | "md";
 
 export const PUBLIC_MEMO_VIEW_COLUMNS =
-  "id, title, content, category, published_at, updated_at, view_count, like_count";
+  "id, title, content, category, metadata, published_at, updated_at, view_count, like_count";
 
 /// format param 明示が最優先。未指定時は GET/HEAD (ブラウザ / クローラー直
 /// アクセス。HEAD は AI フェッチャーのプリフライト) は HTML、POST (API
@@ -69,6 +70,24 @@ export function buildPublicMemoExcerpt(
   return `${normalized.slice(0, maxLength - 3)}...`;
 }
 
+/// category + metadata.tags (JSONB / OGP シェアカード用に既存) を合成した
+/// AI 向けタグ。文字列以外・空白・重複は除外する。
+export function extractPublicMemoTags(row: PublicMemoViewRow): string[] {
+  const tags: string[] = [];
+  const push = (value: unknown) => {
+    if (typeof value !== "string") return;
+    const trimmed = value.trim();
+    if (trimmed && !tags.includes(trimmed)) tags.push(trimmed);
+  };
+  push(row.category);
+  const metadata = row.metadata;
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
+    const raw = (metadata as Record<string, unknown>).tags;
+    if (Array.isArray(raw)) raw.forEach(push);
+  }
+  return tags;
+}
+
 export function publicMemoToPayload(
   row: PublicMemoViewRow,
 ): Record<string, unknown> {
@@ -76,6 +95,9 @@ export function publicMemoToPayload(
     id: row.id,
     title: row.title ?? "",
     content: row.content ?? "",
+    summary: buildPublicMemoExcerpt(row.content),
+    markdown: renderPublicMemoMarkdown(row),
+    tags: extractPublicMemoTags(row),
     category: row.category,
     publishedAt: row.published_at,
     updatedAt: row.updated_at,
@@ -83,6 +105,37 @@ export function publicMemoToPayload(
     likeCount: row.like_count ?? 0,
     appUrl: buildPublicMemoPageUrl(row.id),
   };
+}
+
+export const PUBLIC_MEMO_SEARCH_MIN_QUERY_LENGTH = 2;
+export const PUBLIC_MEMO_SEARCH_MAX_QUERY_LENGTH = 100;
+
+/// 匿名検索の入力ガード (負荷対策)。PostgREST の or() 構文を壊す文字と
+/// ilike ワイルドカードを空白へ無害化し、最大長へ切り詰めた上で
+/// 最小長未満なら null (= 400 にする) を返す。
+export function normalizePublicMemoSearchQuery(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const sanitized = raw
+    .replace(/[,()%_\\]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, PUBLIC_MEMO_SEARCH_MAX_QUERY_LENGTH)
+    .trim();
+  if (sanitized.length < PUBLIC_MEMO_SEARCH_MIN_QUERY_LENGTH) {
+    return null;
+  }
+  return sanitized;
+}
+
+/// 匿名 action 共通の limit clamp。数値でなければ fallback、1..max に収める。
+export function clampPublicMemoLimit(
+  raw: unknown,
+  fallback: number,
+  max: number,
+): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(Math.trunc(n), 1), max);
 }
 
 function formatDate(iso: string | null): string {

--- a/supabase/functions/core-hub/public_memo_view_test.ts
+++ b/supabase/functions/core-hub/public_memo_view_test.ts
@@ -6,7 +6,10 @@ import {
 import {
   buildPublicMemoExcerpt,
   buildPublicMemoPageUrl,
+  clampPublicMemoLimit,
   escapeHtml,
+  extractPublicMemoTags,
+  normalizePublicMemoSearchQuery,
   publicMemoToPayload,
   type PublicMemoViewRow,
   renderPublicMemoHtml,
@@ -75,6 +78,55 @@ Deno.test("publicMemoToPayload exposes app URL and normalized counts", () => {
     payload.appUrl,
     "https://my-web-app-b67f4.web.app/public-memo?id=44",
   );
+});
+
+Deno.test("publicMemoToPayload includes AI-friendly summary/markdown/tags", () => {
+  const payload = publicMemoToPayload(
+    sampleRow({ metadata: { tags: ["地方議員", "国民民主党"] } }),
+  );
+  assertEquals(payload.summary, buildPublicMemoExcerpt(sampleRow().content));
+  assertStringIncludes(String(payload.markdown), "# 地方議員データ更新メモ");
+  assertEquals(payload.tags, ["選挙", "地方議員", "国民民主党"]);
+});
+
+Deno.test("extractPublicMemoTags merges category and metadata.tags safely", () => {
+  assertEquals(extractPublicMemoTags(sampleRow()), ["選挙"]);
+  assertEquals(
+    extractPublicMemoTags(
+      sampleRow({ metadata: { tags: ["選挙", " 議員 ", 7, "", null] } }),
+    ),
+    ["選挙", "議員"],
+  );
+  assertEquals(
+    extractPublicMemoTags(sampleRow({ category: null, metadata: null })),
+    [],
+  );
+  assertEquals(
+    extractPublicMemoTags(sampleRow({ category: null, metadata: "junk" })),
+    [],
+  );
+});
+
+Deno.test("normalizePublicMemoSearchQuery guards anonymous search input", () => {
+  assertEquals(normalizePublicMemoSearchQuery("地方議員"), "地方議員");
+  assertEquals(normalizePublicMemoSearchQuery("  foo   bar "), "foo bar");
+  // or() 構文破壊文字と ilike ワイルドカードは空白へ無害化
+  assertEquals(normalizePublicMemoSearchQuery("a%b_c,d(e)f"), "a b c d e f");
+  assertEquals(normalizePublicMemoSearchQuery("x"), null);
+  assertEquals(normalizePublicMemoSearchQuery("%_"), null);
+  assertEquals(normalizePublicMemoSearchQuery(42), null);
+  assertEquals(normalizePublicMemoSearchQuery(null), null);
+  const long = normalizePublicMemoSearchQuery("あ".repeat(300));
+  assertEquals(long?.length, 100);
+});
+
+Deno.test("clampPublicMemoLimit clamps and falls back", () => {
+  assertEquals(clampPublicMemoLimit(undefined, 20, 50), 20);
+  assertEquals(clampPublicMemoLimit("abc", 5, 20), 5);
+  assertEquals(clampPublicMemoLimit("7", 20, 50), 7);
+  assertEquals(clampPublicMemoLimit(0, 20, 50), 1);
+  assertEquals(clampPublicMemoLimit(999, 20, 50), 50);
+  assertEquals(clampPublicMemoLimit(3.9, 5, 20), 3);
 });
 
 Deno.test("renderPublicMemoHtml embeds escaped content and OGP tags", () => {


### PR DESCRIPTION
# Pull Request

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Edge Function anonymous read-only actions; user-visible I/O covered by 14 deno unit tests + 日次 public-memo-smoke.yml (search 200/400, related 200 を実機検証); no UI route changed

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: anonymous read-only actions over already-public RLS rows (is_public=true); search input sanitized + length/limit guarded; no auth/billing/data-migration change; rollback = revert single commit; prod smoke = public-memo-smoke.yml after deploy; observability via existing EF logs

## 📝 変更内容

公開メモ bot 可読ビュー (PR #3870/#3873) を「AI 向け正式 API」へ拡張する。

### 変更の種類

- [x] 新機能 (breaking changeを含まない機能追加)

## 🔗 関連Issue

Related to #3870 / #3873 (公開メモ bot 可読ビュー + HEAD 対応)

## 🎯 変更の目的

ChatGPT / Claude / Gemini 等の外部 AI が公開メモを検索・関連参照・要約付きで扱えるようにする (AI フレンドリーな公開コンテンツ基盤)。

## 📋 実装の詳細

### 主な変更点

1. JSON payload に `summary` (140字抜粋) / `markdown` / `tags` (category + `metadata.tags` 合成) を追加 — フィールド追加のみで後方互換
2. `memo.public.search`: 匿名 ilike 検索 (title/content/category)。query 正規化 + 2〜100 字ガード、PostgREST `or()` 構文破壊文字と ilike ワイルドカードの無害化、limit 1..50 clamp
3. `memo.public.related` v1: 同カテゴリ・自分以外・published_at 降順 (limit 1..20, 既定 5)。カテゴリ無しは空配列、対象メモ非公開/不存在は 404
4. `memo.public.list` の limit clamp を共通ヘルパー `clampPublicMemoLimit` に統一
5. 日次 smoke に search (200 / 短すぎ query 400) / related (200) を追加
6. `docs/EDGE_FUNCTION_LIST.md` の core-hub 行を更新

latest 相当は既存 `memo.public.list` のため新 action は追加しない。

### 技術的な詳細

- 匿名で通る action は `anonymousActions` allowlist (deny-by-default) に明示追加。返すのは RLS 上すでに匿名 SELECT 可能な `is_public=true` 行のみ
- `metadata` は OGP シェアカード用の既存 JSONB カラムを再利用 — migration 不要

## ✅ テスト結果

### テスト実施項目

- [x] 単体テスト
- [x] 手動テスト (マージ + deploy-prod 後に public-memo-smoke.yml で実機検証予定)

### テストケース

| テストケース | 結果 | 備考 |
| --- | --- | --- |
| `public_memo_view_test.ts` 14 件 (payload 拡張 / tags 合成 / search query ガード / limit clamp 含む) | ✅ | deno test 全パス |
| `deno lint` / `deno fmt --check` / `deno check` | ✅ | 0 エラー |

## 🚨 Breaking Changes

- [x] このPRにはBreaking Changesが含まれていません (JSON はフィールド追加のみ)

## 📊 パフォーマンスへの影響

- [x] パフォーマンスへの影響はありません (search/related は limit clamp 済みの読み取りのみ)

## 🔒 セキュリティへの影響

- [x] 入力値の検証を適切に実装しました (query 2〜100 字 + サニタイズ / id 正整数 / limit clamp)
- 公開範囲は不変 (`is_public=true` のみ)。search の `%`/`_`/`,`/`(`/`)`/`\` は空白へ無害化

## 📚 ドキュメント更新

- [x] 技術ドキュメントの更新 (`docs/EDGE_FUNCTION_LIST.md` の core-hub 行に search/related と日次 smoke を追記)

## ✅ レビュー観点

### 重点的にレビューしてほしい箇所

1. `normalizePublicMemoSearchQuery` のサニタイズが PostgREST `or()`/ilike に対して十分か (`supabase/functions/core-hub/public_memo_view.ts`)
2. related の 2 クエリ構成 (対象取得 → 同カテゴリ検索) の 404/空配列ハンドリング

### 懸念事項・相談したい点

なし

## 🚀 デプロイメモ

- [x] 特別なデプロイ手順は不要 (main マージ → deploy-prod で core-hub 自動デプロイ)

## ✅ チェックリスト

### コード品質

- [x] `deno lint` 0エラーを確認しました（Edge Function変更時は必須 — CIゲート）
- [x] ダミーデータを使用していません（Supabase実データのみ）
- [x] 不要なコメントや console.log を削除しました
- [x] コードレビューを受ける準備ができています（Claude Agent が自動レビューします）

### Rule / Script / Hook wiring 同期（追加時のみ — part 185 finding）

- [x] 該当なし（rule / script / hook 追加・変更なし）

### テスト

- [x] 新しいコードにテストを追加しました
- [x] すべてのテストが通ることを確認しました
- [x] エッジケースを考慮しました

### セキュリティ

- [x] 機密情報がコミットされていないことを確認しました
- [x] 入力値の検証を適切に実装しました
- [x] セキュリティベストプラクティスに従っています

### その他

- [x] Breaking Changesがないことを確認しました
- [x] パフォーマンスへの悪影響がないことを確認しました

## 💬 追加コメント

デプロイ後の AI 向けエンドポイント例:
- 検索: `?action=memo.public.search&q=地方議員&format=json`
- 関連: `?action=memo.public.related&id=44&format=json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc)_