### PR TITLE
fix(public-memo): rescue &amp;-mangled URLs + add text/plain format=txt

### DIFF
--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -15,12 +15,6 @@ on:
   # push トリガーは使わない — main push 直後は deploy-prod 完了前で誤検知するため。
   schedule:
     - cron: "7 21 * * *" # 毎日 06:07 JST
-  # 一時: PR #3879 デプロイ後の実機検証用 (branch 限定 / 検証後に削除)
-  push:
-    branches:
-      - claude/page-accessibility-memo-qb499c
-    paths:
-      - ".github/workflows/public-memo-smoke.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -89,6 +89,10 @@ jobs:
           check "search too short" "$BASE?action=memo.public.search&q=x" "400" ""
           check "related json"     "$BASE?action=memo.public.related&id=$MEMO_ID&limit=5&format=json" "200" "\"success\":true"
 
+          # AI フェッチャー救済: text/plain 版と HTML エンティティ化け URL (&amp;)
+          check "view txt"         "$BASE?action=memo.public.view&id=$MEMO_ID&format=txt" "200" "App URL:"
+          check "amp-mangled rescue" "$BASE?action=memo.public.view&amp;id=$MEMO_ID&amp;format=json" "200" "\"appUrl\""
+
           exit "$FAIL"
 
       # 外部 AI / ブラウザ系フェッチャーのリクエスト形状を再現し、

--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -15,6 +15,12 @@ on:
   # push トリガーは使わない — main push 直後は deploy-prod 完了前で誤検知するため。
   schedule:
     - cron: "7 21 * * *" # 毎日 06:07 JST
+  # 一時: PR #3879 デプロイ後の実機検証用 (branch 限定 / 検証後に削除)
+  push:
+    branches:
+      - claude/page-accessibility-memo-qb499c
+    paths:
+      - ".github/workflows/public-memo-smoke.yml"
 
 permissions:
   contents: read

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -36,6 +36,7 @@ import {
   renderPublicMemoMarkdown,
   renderPublicMemoNotFoundHtml,
   resolvePublicMemoViewFormat,
+  searchParamsToActionBody,
 } from "./public_memo_view.ts";
 
 const corsHeaders = {
@@ -836,7 +837,7 @@ serve(async (req: Request) => {
       // GET/HEAD は query param を body 相当として扱う。ヘッダーを付けられない
       // クローラー / 外部 AI が匿名 action (memo.public.* 等) を叩けるようにする。
       // HEAD はブラウザ / AI フェッチャーが本文取得前のプリフライトとして送る。
-      body = Object.fromEntries(new URL(req.url).searchParams);
+      body = searchParamsToActionBody(req.url);
     } else {
       try {
         body = await req.json();
@@ -845,10 +846,7 @@ serve(async (req: Request) => {
       }
       if (typeof body.action !== "string" || body.action === "") {
         // 一部フェッチャーは POST でも body を送らない — query param を fallback。
-        body = {
-          ...Object.fromEntries(new URL(req.url).searchParams),
-          ...body,
-        };
+        body = { ...searchParamsToActionBody(req.url), ...body };
       }
     }
 
@@ -969,10 +967,12 @@ serve(async (req: Request) => {
         if (format === "json") {
           return json({ success: true, memo: publicMemoToPayload(row) });
         }
-        if (format === "md") {
+        if (format === "md" || format === "txt") {
           return publicText(
             renderPublicMemoMarkdown(row),
-            "text/markdown; charset=utf-8",
+            format === "md"
+              ? "text/markdown; charset=utf-8"
+              : "text/plain; charset=utf-8",
           );
         }
         return publicText(
@@ -998,10 +998,12 @@ serve(async (req: Request) => {
             "text/html; charset=utf-8",
           );
         }
-        if (format === "md") {
+        if (format === "md" || format === "txt") {
           return publicText(
             renderPublicMemoListMarkdown(rows),
-            "text/markdown; charset=utf-8",
+            format === "md"
+              ? "text/markdown; charset=utf-8"
+              : "text/plain; charset=utf-8",
           );
         }
         return json({
@@ -1041,10 +1043,12 @@ serve(async (req: Request) => {
             "text/html; charset=utf-8",
           );
         }
-        if (format === "md") {
+        if (format === "md" || format === "txt") {
           return publicText(
             renderPublicMemoListMarkdown(rows),
-            "text/markdown; charset=utf-8",
+            format === "md"
+              ? "text/markdown; charset=utf-8"
+              : "text/plain; charset=utf-8",
           );
         }
         return json({
@@ -1100,10 +1104,12 @@ serve(async (req: Request) => {
             "text/html; charset=utf-8",
           );
         }
-        if (format === "md") {
+        if (format === "md" || format === "txt") {
           return publicText(
             renderPublicMemoListMarkdown(rows),
-            "text/markdown; charset=utf-8",
+            format === "md"
+              ? "text/markdown; charset=utf-8"
+              : "text/plain; charset=utf-8",
           );
         }
         return json({

--- a/supabase/functions/core-hub/public_memo_view.ts
+++ b/supabase/functions/core-hub/public_memo_view.ts
@@ -22,7 +22,7 @@ export interface PublicMemoViewRow {
   like_count: number | null;
 }
 
-export type PublicMemoViewFormat = "html" | "json" | "md";
+export type PublicMemoViewFormat = "html" | "json" | "md" | "txt";
 
 export const PUBLIC_MEMO_VIEW_COLUMNS =
   "id, title, content, category, metadata, published_at, updated_at, view_count, like_count";
@@ -39,9 +39,29 @@ export function resolvePublicMemoViewFormat(
     : "";
   if (normalized === "json") return "json";
   if (normalized === "md" || normalized === "markdown") return "md";
+  // 一部の AI フェッチャーは text/markdown・text/html を本文として扱えない
+  // ため、text/plain で返す txt を用意する (中身は Markdown と同一)。
+  if (normalized === "txt" || normalized === "text" || normalized === "plain") {
+    return "txt";
+  }
   if (normalized === "html") return "html";
   const upper = method.toUpperCase();
   return upper === "GET" || upper === "HEAD" ? "html" : "json";
+}
+
+/// URL query を action body 相当へ変換する。レンダリング済みテキストから
+/// URL をコピーすると `&` が `&amp;` に化け、`amp;id=44` のようなキーで
+/// 届くことがある (ChatGPT の fetch で実測 400)。キー先頭の `amp;` を
+/// 除去して救済する。同名キーは先勝ち。
+export function searchParamsToActionBody(url: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of new URL(url).searchParams) {
+    const normalized = key.replace(/^(amp;)+/, "");
+    if (!(normalized in result)) {
+      result[normalized] = value;
+    }
+  }
+  return result;
 }
 
 export function escapeHtml(value: string): string {

--- a/supabase/functions/core-hub/public_memo_view_test.ts
+++ b/supabase/functions/core-hub/public_memo_view_test.ts
@@ -18,6 +18,7 @@ import {
   renderPublicMemoMarkdown,
   renderPublicMemoNotFoundHtml,
   resolvePublicMemoViewFormat,
+  searchParamsToActionBody,
 } from "./public_memo_view.ts";
 
 function sampleRow(overrides: Partial<PublicMemoViewRow> = {}) {
@@ -39,6 +40,32 @@ Deno.test("resolvePublicMemoViewFormat honors explicit format first", () => {
   assertEquals(resolvePublicMemoViewFormat("md", "GET"), "md");
   assertEquals(resolvePublicMemoViewFormat("markdown", "POST"), "md");
   assertEquals(resolvePublicMemoViewFormat(" HTML ", "POST"), "html");
+});
+
+Deno.test("resolvePublicMemoViewFormat maps txt aliases to text/plain view", () => {
+  assertEquals(resolvePublicMemoViewFormat("txt", "GET"), "txt");
+  assertEquals(resolvePublicMemoViewFormat("text", "POST"), "txt");
+  assertEquals(resolvePublicMemoViewFormat("plain", "GET"), "txt");
+});
+
+Deno.test("searchParamsToActionBody rescues HTML-entity mangled query keys", () => {
+  const base = "https://example.com/functions/v1/core-hub";
+  assertEquals(
+    searchParamsToActionBody(`${base}?action=memo.public.view&id=44`),
+    { action: "memo.public.view", id: "44" },
+  );
+  // `&` が `&amp;` に化けた URL (ChatGPT fetch で実測) を救済
+  assertEquals(
+    searchParamsToActionBody(
+      `${base}?action=memo.public.view&amp;id=44&amp;format=json`,
+    ),
+    { action: "memo.public.view", id: "44", format: "json" },
+  );
+  // 二重化け (amp;amp;) にも耐える。同名キーは先勝ち
+  assertEquals(
+    searchParamsToActionBody(`${base}?id=1&amp;amp;id=2`),
+    { id: "1" },
+  );
 });
 
 Deno.test("resolvePublicMemoViewFormat defaults by method", () => {


### PR DESCRIPTION
# Pull Request

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Edge Function anonymous read-only view; user-visible I/O covered by 16 deno unit tests + 日次 public-memo-smoke.yml (txt 200 / amp-mangled 200 を実機検証); no UI route changed

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: query-key normalization + text/plain format for existing anonymous read-only actions; no new data exposed (is_public=true rows only); no auth/billing/data-migration change; rollback = revert single commit; prod smoke = public-memo-smoke.yml after deploy; observability via existing EF logs

## 📝 変更内容

ChatGPT fetch の「Failed to fetch: (400) OK」対応。原因はレンダリング済みテキスト経由で URL の `&` が `&amp;` に化け、`id` が `amp;id` キーで届いて欠落 → 400 (診断 run の amp-mangled probe と同一症状)。

### 変更の種類

- [x] バグ修正 (breaking changeを含まないバグ修正)

## 🔗 関連Issue

Related to #3870 / #3873 / #3879 (公開メモ AI 向け API)

## 🎯 変更の目的

外部 AI フェッチャーの URL 化け・Content-Type 制約に対する互換性向上。

## 📋 実装の詳細

### 主な変更点

1. `searchParamsToActionBody`: query キー先頭の `amp;` (多重化け含む) を除去して化けた URL を救済。GET/HEAD と POST fallback の両方に適用
2. `format=txt` (alias: `text` / `plain`) を追加 — 中身は Markdown と同一、`text/plain; charset=utf-8` で返す。`text/markdown` / `text/html` を本文として扱えないフェッチャー向け。view / list / search / related の 4 action すべて対応
3. 日次 smoke に `view txt` (200) / `amp-mangled rescue` (200) の強制チェックを追加

### 技術的な詳細

- 匿名許可 action の集合・公開範囲 (`is_public=true`) は不変
- 同名キーは先勝ちで解釈 (`?id=1&amp;amp;id=2` → id=1)

## ✅ テスト結果

### テスト実施項目

- [x] 単体テスト
- [x] 手動テスト (マージ + deploy-prod 後に public-memo-smoke.yml で実機検証予定)

### テストケース

| テストケース | 結果 | 備考 |
| --- | --- | --- |
| `public_memo_view_test.ts` 16 件 (txt alias / amp; 化け救済 / 二重化け / 先勝ち含む) | ✅ | deno test 全パス |
| `deno lint` / `deno fmt` / `deno check` | ✅ | 0 エラー |

## 🚨 Breaking Changes

- [x] このPRにはBreaking Changesが含まれていません (`amp;id` のような生キーを意図的に使う既存クライアントは存在しない)

## 📊 パフォーマンスへの影響

- [x] パフォーマンスへの影響はありません

## 🔒 セキュリティへの影響

- [x] セキュリティへの影響はありません (入力キーの正規化のみ。値の検証は従来どおり)

## 📚 ドキュメント更新

- [x] ドキュメント更新は不要 (EDGE_FUNCTION_LIST.md は format 一覧を網羅列挙していない)

## ✅ レビュー観点

### 重点的にレビューしてほしい箇所

1. `searchParamsToActionBody` のキー正規化が既存 action の入力を変えないこと

### 懸念事項・相談したい点

なし

## 🚀 デプロイメモ

- [x] 特別なデプロイ手順は不要 (main マージ → deploy-prod で core-hub 自動デプロイ)

## ✅ チェックリスト

### コード品質

- [x] `deno lint` 0エラーを確認しました（Edge Function変更時は必須 — CIゲート）
- [x] ダミーデータを使用していません（Supabase実データのみ）
- [x] 不要なコメントや console.log を削除しました
- [x] コードレビューを受ける準備ができています（Claude Agent が自動レビューします）

### Rule / Script / Hook wiring 同期（追加時のみ — part 185 finding）

- [x] 該当なし（rule / script / hook 追加・変更なし）

### テスト

- [x] 新しいコードにテストを追加しました
- [x] すべてのテストが通ることを確認しました
- [x] エッジケースを考慮しました

### セキュリティ

- [x] 機密情報がコミットされていないことを確認しました
- [x] 入力値の検証を適切に実装しました
- [x] セキュリティベストプラクティスに従っています

### その他

- [x] Breaking Changesがないことを確認しました
- [x] パフォーマンスへの悪影響がないことを確認しました

## 💬 追加コメント

デプロイ後、ChatGPT に渡す推奨 URL (text/plain):
`https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/core-hub?action=memo.public.view&id=44&format=txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc)_