### PR TITLE
feat(x-share): R15 spend-cap stop-loss preflight + guidance dedupe + copy-drift hardening

### DIFF
--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -797,13 +797,38 @@ class UniversalXShareService {
     final error = data['error']?.toString().trim();
     final actionRequired = data['actionRequired']?.toString().trim();
     final registrationUrl = data['registrationUrl']?.toString().trim();
-    final parts = <String>[
+    final candidates = <String>[
       if (error != null && error.isNotEmpty) error else 'X post failed',
       if (actionRequired != null && actionRequired.isNotEmpty) actionRequired,
       if (registrationUrl != null && registrationUrl.isNotEmpty)
         'Developer Portal: $registrationUrl',
     ];
+    // 実障害(2026-07-08): edge が error 本文にガイダンスを埋め込み、同文が
+    // actionRequired としても返るため、連結すると同じ段落が二重表示された。
+    // 既に採用済みの部分に substring として含まれる部分は落とす(コード非依存
+    // = 旧 edge デプロイや他コードパスの同型二重化にも効く)。
+    final parts = <String>[];
+    for (final candidate in candidates) {
+      if (parts.any((existing) => existing.contains(candidate))) continue;
+      parts.add(candidate);
+    }
     return parts.join('\n');
+  }
+
+  /// R15: 投稿前の spend-cap preflight。growth-hub の read-only
+  /// `x.post_preflight`(X API 非呼出・直近ログ判定)を呼び、ブロック中なら
+  /// 高価な画像/音声/動画生成と投稿試行を丸ごとスキップさせる。
+  /// preflight 自体の失敗で本流を止めない(never-throw / fail-open)。
+  Future<({bool blocked, String? resetAt})> checkXPostPreflight() async {
+    try {
+      final data = await _invoke('growth-hub', {'action': 'x.post_preflight'});
+      return (
+        blocked: data['blocked'] == true,
+        resetAt: data['resetAt']?.toString(),
+      );
+    } catch (_) {
+      return (blocked: false, resetAt: null);
+    }
   }
 
   static String acquisitionUrlFor(
@@ -1777,7 +1802,12 @@ Rules:
 - Prefer concrete pain, feature, or question hooks over generic app promotion.
 - 一人称の実体験で書け: 運営者本人が実際にやったこと・作ったこと・実測したこと・つまずいたことを最低1つ具体で入れる(数値・固有機能名・失敗を歓迎)。三人称のブランド口調(「私たちの新しいウェブアプリは」「企業がAIを取り入れると」等の伝聞・一般論)を禁止する。
 - 一人称は《検証可能な範囲》に限れ: (A)アプリを作った/実装した/直した(実在の機能・意図)や、(B)機能が何をする/読者が何をできるか(FEATURE-FACTに基づく現在形の能力)は書いてよい。だが payload に無い個人的実績(「先月○○に気づいた」「家計が健全になった」式の、日付・金額・生活改善の作り話)を事実として書くな。具体を出したいときは機能の仕組みか、明示ヘッジ付きの1例(「例えば給料日サイクルで見ると〜という形で出る」)にせよ。
-- 禁止フレーズ(これらを含む文は削除して書き直せ): 「可能性があります」「影響を及ぼすでしょう」「ますます激化」「激化しています」「強力なツール」「重要性を認識」「効率よく整理」「活用するためのサポート」「注目のニュース」「〜と言えるでしょう」、および「〜化が加速する中」の型。英語の game-changer / powerful tool / the future of も禁止。さらに作り話の個人的実績・誇張の型も禁止: 「〜に気づきました」「〜が劇的に変わりました」「家計が健全になりました」「劇的に」「大幅に」。
+- 捏造実績の文法テンプレートも禁止(言い換えでも不可): 一人称+過去形の《体験→成果》構文(「〜してみたところ/〜したら/〜した結果/〜を使ってみて」+「できました/なりました/楽になりました/解消しました/気づくことができました」)は、その成果が上の実在機能リストに明記されている場合を除き全面禁止。許可形は (A)構築行為の過去形(作った/実装した/直した) (B)機能の現在形 (C)明示ヘッジ付き仮例 のみ。出力前に各文を検査: 過去形の成果主張があれば実在機能リストに根拠があるか確認し、なければ(C)のヘッジ形へ書き直せ。
+- 禁止フレーズ(これらを含む文は削除して書き直せ): 「可能性があります」「影響を及ぼすでしょう」「ますます激化」「激化しています」「強力なツール」「重要性を認識」「効率よく整理」「活用するためのサポート」「注目のニュース」「〜と言えるでしょう」。英語の game-changer / powerful tool / the future of も禁止。さらに作り話の個人的実績の型も禁止: 「〜に気づきました」「〜が劇的に変わりました」「家計が健全になりました」。
+- 程度を誇張する副詞で改善・変化を主張するな: 「劇的に」「大幅に」「格段に」「飛躍的に」「圧倒的に」「一気に」およびこれらに類する副詞すべて。改善の大きさは具体的な数値か仕組み(何がどう動いて何が消えるか)でのみ語れ。BAD「家計の把握が格段に楽になりました」 GOOD「給料日起点に窓を切ると月初またぎの支払いが二重計上されない=支出が実額になる」。
+- 「〜が…する中、」「〜が…される中、」「〜が進む中、」型の一般論→自アプリ転換ブリッジを禁止(「〜化が加速する中」を含む全変種)。見出しとの接続は関連性ゲートの因果1文形のみ許可。BAD「企業の定型業務が効率化される中、私のウェブアプリでは…」。
+- 自分のアプリを一般名詞で呼ぶ型も禁止(所有格を付けても不可): 「ウェブアプリ」「私のアプリでは」「このツール」「私のサービス」。アプリ自体に言及するときは必ず固有機能名(給料日サイクル 等、上の実在機能リストの名前)か「自分株式会社」で呼べ(「このアプリ」は既出文脈の照応としてのみ可)。BAD「私のウェブアプリでは『給料日サイクル』機能を実装しました」 GOOD「『給料日サイクル』は支出窓を給料日起点に切る機能。作った狙いは月初またぎ支払いの二重計上をなくすこと。」
+- threadReplies のどのリプも poll の question 文をそのまま繰り返すな(poll は独立したリプとして自動投稿されるため、同文で始まるリプは連続重複に見える)。このプロンプト内の例文(GOOD例・保存版の良い例)を一言一句コピーするのも禁止=型だけ真似て今日の内容で必ず書き直せ。
 - 各文ルール: 断定・具体・数字・一次体験(自分が実際にやったこと)のいずれかを含まない文は入れるな。誰でも書ける当てずっぽうの一般予測を禁止。
 - 具体性の下限: 少なくとも3つのリプはそれぞれ固有アンカー(具体的な数字 / 見出し以外の固有名詞 / このアプリを作って分かった一次体験)を1つ以上持つこと。
 - アプリに触れるときはリードで今日の見出しに最も直結する1機能を主役にしつつ、リプでは他の機能も名前を挙げて具体で出す。いずれも上の「App の実在する具体機能」から選び、それが何を数値/画面/具体で解決するかを書く。一般名詞で濁すな。
@@ -1792,7 +1822,7 @@ Rules:
 - Put information value first and product CTA last. Avoid looking like an ad in the lead post.
 - The headline list above is REAL, sourced news (verbatim from NHK / ITmedia RSS). You MAY quote or paraphrase a headline as today's news. Do NOT add facts beyond the headline wording, and do NOT invent numbers, quotes, or outcomes.
 - 見出しの使い方(関連性ゲート): まず注入した見出しの中に、このアプリのドメイン(家計・資産・給与・負債・支出・節約・投資・AIによる仕事効率化/情報整理)と《具体的な因果でつながる》見出しが1つでもあるか判定せよ。(A)ある場合のみ、その見出しをフックにし1文でドメインへ橋を架ける。橋は必ず同じ1文の中で因果を通す=「(見出しの事象)→お金/仕事にこう効く→だから(FEATURE-FACT)でこう対処」の形。(B)真につながる見出しが1つも無い日は、見出しに一切触れず、上の『App の実在する具体機能』の1つから始まる運営者の実体験ストーリーをリードにせよ(一般名詞のアプリ紹介は禁止=必ず固有機能名で始める)。無関係なトレンド語(モデル名・製品名)をフックとして貼り付けることを禁止する。
-- 橋渡しの禁止形: 話題名を出すだけで内容的に捨てる逆接ブリッジ(「◯◯が気になる方も多いですが、私の△△機能は」「◯◯の話題ですが、それはさておき」「◯◯が話題ですが、」)を禁止する。1文で自然に因果が書けないなら、その見出しとアプリは本当につながっていない→別の見出し/角度を選ぶか、上記(B)へ切り替えて見出しに触れず書け。BAD「Fable 5が気になる方も多いですが、給料日サイクル機能は…」 GOOD「AIの月額サブスクが乱立する今、固定費が見えにくい。給料日サイクル機能で今月の支出を実測したら、契約したまま忘れていた引き落としが浮いた。」
+- 橋渡しの禁止形: 話題名を出すだけで内容的に捨てる逆接ブリッジ(「◯◯が気になる方も多いですが、私の△△機能は」「◯◯の話題ですが、それはさておき」「◯◯が話題ですが、」)を禁止する。1文で自然に因果が書けないなら、その見出しとアプリは本当につながっていない→別の見出し/角度を選ぶか、上記(B)へ切り替えて見出しに触れず書け。BAD「Fable 5が気になる方も多いですが、給料日サイクル機能は…」 GOOD「AIの月額サブスクが乱立する今、固定費が見えにくい。給料日サイクルで見ると、月初をまたぐ引き落としが二重計上されずに実額で出る。」
 - The FIRST line (before the X "Show more" fold) must be a concrete curiosity/value/news hook that stops the scroll. Do NOT start with a label or date such as "デイリーブリーフィング — …朝"; do not prefix the post with the date. If you mention any date, use exactly today's real date (JST) given above and never invent another year (e.g. never write 2024).
 - Every day's post must read as fresh and specific: pick a different concrete headline or angle rather than repeating yesterday's template.
 - Keep the LEAD post strictly hashtag-free (the news hook must stay above the fold). Append 2-3 natural Japanese discovery hashtags on a trailing line of exactly ONE mid-thread reply (never the lead, never every reply), chosen from {#AI活用, #個人開発, #buildinpublic} plus at most one topic-specific tag — 3 tags max total, no stuffing.

--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -415,6 +415,26 @@ class _UniversalAiShareDialogState extends State<UniversalAiShareDialog> {
     // (従来は投稿前の一瞬のステータスにしか出ず、気づけなかった)。
     String? videoFailReason;
     try {
+      // 0. X spend-cap preflight(R15)。cap 到達中は投稿が確定失敗するのに、
+      // 従来は GPT画像+ElevenLabs+Hedra(~119クレジット+最大7.5分)を全部生成
+      // してから投稿で失敗していた(実障害 2026-07-08)。ブロック中は有償生成と
+      // 投稿試行を丸ごとスキップし、解除手段を即提示する。文面は生成済みなので
+      // このダイアログからコピーして X の投稿画面で手動投稿は引き続き可能。
+      final preflight = await _service.checkXPostPreflight();
+      if (_disposed || !mounted) return;
+      if (preflight.blocked) {
+        final resetNote = preflight.resetAt == null
+            ? ''
+            : '（${preflight.resetAt} に自動リセット見込み）';
+        setState(() {
+          _posting = false;
+          _statusMessage = 'X APIのspend cap到達中のため、画像・音声・動画の生成と'
+              'API投稿をスキップしました$resetNote。console.x.com の'
+              '「支出上限を管理」で引き上げると即時解除されます。上の文面を'
+              'コピーして X で手動投稿することは可能です。';
+        });
+        return;
+      }
       // 1. 画像(presenter/舞台がローテ)
       if (_imageUrl == null) {
         setState(() {

--- a/supabase/functions/_shared/x-client.ts
+++ b/supabase/functions/_shared/x-client.ts
@@ -60,6 +60,8 @@ export interface XApiErrorPayload {
   requiredEnrollment: string | null;
   registrationUrl: string | null;
   actionRequired: string;
+  // R15: spend cap 解除見込み日(ISO, 例 "2026-07-10")。billing 起因以外は null。
+  billingBlockedUntil?: string | null;
   raw: Record<string, unknown> | string;
 }
 
@@ -665,8 +667,21 @@ export function buildXApiErrorPayload(
     requiredEnrollment,
     registrationUrl,
     actionRequired: buildXActionRequired(code, requiredEnrollment),
+    // R15: spend cap 解除見込み日(ISO)。X の 402/403 エラーメッセージから
+    // 機械可読化し、preflight(生成前スキップ)と UI 表示の基盤にする。
+    billingBlockedUntil: isBillingBlocked
+      ? parseBillingBlockedUntil(billingText)
+      : null,
     raw: Object.keys(parsed).length > 0 ? parsed : rawText,
   };
+}
+
+/// X の spend-cap エラー文(例: "API requests will be blocked until the next
+/// cycle begins on 2026-07-10.")からリセット日を ISO 日付で抽出する純関数。
+/// 一致しなければ null(呼び出し側は TTL フォールバックへ degrade)。
+export function parseBillingBlockedUntil(text: string): string | null {
+  const match = /next cycle begins on (\d{4}-\d{2}-\d{2})/i.exec(text ?? "");
+  return match ? match[1] : null;
 }
 
 function normalizeXTrends(payload: unknown): XTrend[] {
@@ -796,13 +811,12 @@ function buildXApiErrorMessage(payload: XApiErrorPayload): string {
     ].join(" ");
   }
   if (payload.code === "x_billing_blocked") {
-    // 生 detail はデバッグ用に残しつつ、対処が一目で分かる日本語を先頭に。
-    return [
-      `X APIのクレジットが不足しています（${
-        payload.detail ?? payload.status
-      }）。`,
-      payload.actionRequired,
-    ].filter((part) => part).join(" ");
+    // 生 detail(リセット日を含む)はデバッグ/ログ永続用に保持。対処ガイダンスは
+    // actionRequired のみへ単一化(R15: 従来は error にも同文を埋め込んでおり、
+    // クライアントが error + actionRequired を連結して同じ段落が二重表示された)。
+    return `X APIのクレジットが不足しています（${
+      payload.detail ?? payload.status
+    }）。`;
   }
   return `X API error ${payload.status}: ${
     payload.detail || payload.title || JSON.stringify(payload.raw)

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -30,6 +30,7 @@ import {
   resolveSignupChannel,
 } from "./signup_notification.ts";
 import { filterRecentLogs } from "./metrics_window.ts";
+import { decideXPostPreflight } from "./x_post_preflight.ts";
 import { buildMediaLiftLine, classifyPostMediaType } from "./x_media_type.ts";
 
 const corsHeaders = {
@@ -1770,6 +1771,22 @@ serve(async (req: Request) => {
         return json(await buildXPerformanceContext(admin, userId!, body.limit));
       }
 
+      case "x.post_preflight": {
+        // R15: spend cap 到達中に高価な創作パイプライン(GPT image + TTS +
+        // Hedra)を燃やす前に、直近ログから「投稿しても billing で確定失敗
+        // するか」を返す read-only チェック。X API は一切呼ばない(ゼロコスト)。
+        const logs =
+          (await listXPostLogs(admin, userId!, 20)) as XPostLogItem[];
+        const rows = logs.map((item) => ({
+          created_at: item.created_at,
+          metadata: asRecord(item.metadata),
+        }));
+        return json({
+          success: true,
+          ...decideXPostPreflight(rows, new Date()),
+        });
+      }
+
       case "revenue.funnel_report": {
         return json(
           await buildRevenueFunnelReport(admin, userId!, body.limit),
@@ -2011,6 +2028,9 @@ serve(async (req: Request) => {
             x_api_status: xPayload?.status ?? null,
             x_api_reason: xPayload?.reason ?? null,
             action_required: xPayload?.actionRequired ?? null,
+            // R15: spend cap 解除見込み日(ISO)。x.post_preflight が構造化値
+            // として優先参照する(無ければ error 文の regex にフォールバック)。
+            billing_blocked_until: xPayload?.billingBlockedUntil ?? null,
           };
           let log: unknown = null;
           try {
@@ -2031,6 +2051,7 @@ serve(async (req: Request) => {
             registrationUrl: xPayload?.registrationUrl ?? null,
             actionRequired: xPayload?.actionRequired ??
               "Check X API credentials and posting permissions.",
+            billingBlockedUntil: xPayload?.billingBlockedUntil ?? null,
             log,
           });
         }

--- a/supabase/functions/growth-hub/x_post_preflight.ts
+++ b/supabase/functions/growth-hub/x_post_preflight.ts
@@ -1,0 +1,83 @@
+// R15: X spend-cap 到達中に高価な創作パイプライン(GPT image + ElevenLabs +
+// Hedra ~119 credits + 最大7.5分ポーリング)を毎回燃やしてから投稿が確定失敗する
+// 実障害(2026-07-08 観測)への止血。x_post_log の失敗行から「今 x.post しても
+// billing で確定失敗するか」を判定する純ロジック。Hedra 側の
+// shouldSkipVideoGeneration と同じ log-scan + TTL + 成功で自己解除の契約。
+
+import { parseBillingBlockedUntil } from "../_shared/x-client.ts";
+
+export interface XPostPreflightRow {
+  created_at: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface XPostPreflightResult {
+  blocked: boolean;
+  code?: "x_billing_blocked";
+  resetAt?: string;
+}
+
+/// リセット日を parse できない時の TTL(時間)。Hedra preflight(24h)と同契約。
+export const X_BILLING_PREFLIGHT_TTL_HOURS = 24;
+
+/// 直近の x_post_log 行から billing ブロック中かを判定する。
+/// blocked ⟺ 最新の code=x_billing_blocked 失敗行が存在し、それより新しい
+/// status=posted 成功行が無く、かつ now < resetAt(構造化済み
+/// billing_blocked_until、無ければエラー文の "next cycle begins on YYYY-MM-DD"
+/// を解釈。どちらも無ければ失敗時刻 + 24h TTL)。
+/// 注意: x.post は投稿前 rejection 行(dry_run / rejected_duplicate 等)も書く
+/// ため「単純に最新行を見る」判定は不可 — billing 失敗行と posted 成功行だけを
+/// 比較する。operator が cap を上げて投稿が成功すれば自動解除(自己修復)。
+export function decideXPostPreflight(
+  rows: readonly XPostPreflightRow[],
+  nowUtc: Date,
+): XPostPreflightResult {
+  let fail: { at: Date; resetDate: string | null } | null = null;
+  let lastSuccess: Date | null = null;
+  for (const row of rows) {
+    const metadata = row.metadata ?? {};
+    const created = new Date(row.created_at);
+    if (Number.isNaN(created.getTime())) continue;
+    const status = String(metadata.status ?? "");
+    if (status === "posted") {
+      if (lastSuccess === null || created > lastSuccess) lastSuccess = created;
+      continue;
+    }
+    if (
+      status === "failed" && String(metadata.code ?? "") === "x_billing_blocked"
+    ) {
+      if (fail === null || created > fail.at) {
+        const structured = String(metadata.billing_blocked_until ?? "").trim();
+        const resetDate = /^\d{4}-\d{2}-\d{2}$/.test(structured)
+          ? structured
+          : parseBillingBlockedUntil(
+            `${metadata.error ?? ""} ${metadata.action_required ?? ""}`,
+          );
+        fail = { at: created, resetDate };
+      }
+    }
+  }
+  if (fail === null) return { blocked: false };
+  if (lastSuccess !== null && lastSuccess > fail.at) {
+    return { blocked: false };
+  }
+  if (fail.resetDate) {
+    // リセット日は「その日の開始」でサイクルが切り替わる。タイムゾーン差と
+    // X 側の処理遅延を吸収するため +12h の grace を置く(早すぎる解除でも 1 回
+    // 失敗して新しい失敗行で再アームされるだけなので安全側)。
+    const resetAt = new Date(`${fail.resetDate}T12:00:00Z`);
+    if (nowUtc < resetAt) {
+      return {
+        blocked: true,
+        code: "x_billing_blocked",
+        resetAt: fail.resetDate,
+      };
+    }
+    return { blocked: false };
+  }
+  const ttlMs = X_BILLING_PREFLIGHT_TTL_HOURS * 3600 * 1000;
+  if (nowUtc.getTime() - fail.at.getTime() < ttlMs) {
+    return { blocked: true, code: "x_billing_blocked" };
+  }
+  return { blocked: false };
+}

--- a/supabase/functions/growth-hub/x_post_preflight_test.ts
+++ b/supabase/functions/growth-hub/x_post_preflight_test.ts
@@ -1,0 +1,99 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { decideXPostPreflight } from "./x_post_preflight.ts";
+import { parseBillingBlockedUntil } from "../_shared/x-client.ts";
+
+const NOW = new Date("2026-07-08T03:00:00Z");
+
+function row(
+  createdAt: string,
+  metadata: Record<string, unknown>,
+): { created_at: string; metadata: Record<string, unknown> } {
+  return { created_at: createdAt, metadata };
+}
+
+const BILLING_FAIL = row("2026-07-08T00:15:00Z", {
+  status: "failed",
+  code: "x_billing_blocked",
+  error:
+    "X APIのクレジットが不足しています（Your enrolled account has reached its billing cycle spend cap. API requests will be blocked until the next cycle begins on 2026-07-10.）。",
+});
+
+Deno.test("parseBillingBlockedUntil extracts the cycle reset date", () => {
+  assertEquals(
+    parseBillingBlockedUntil(
+      "API requests will be blocked until the next cycle begins on 2026-07-10.",
+    ),
+    "2026-07-10",
+  );
+  assertEquals(parseBillingBlockedUntil("no credits"), null);
+  assertEquals(parseBillingBlockedUntil(""), null);
+});
+
+Deno.test("blocked before reset date, with resetAt surfaced", () => {
+  const result = decideXPostPreflight([BILLING_FAIL], NOW);
+  assertEquals(result.blocked, true);
+  assertEquals(result.code, "x_billing_blocked");
+  assertEquals(result.resetAt, "2026-07-10");
+});
+
+Deno.test("unblocked after the reset date (+grace)", () => {
+  const after = new Date("2026-07-10T13:00:00Z");
+  assertEquals(decideXPostPreflight([BILLING_FAIL], after).blocked, false);
+});
+
+Deno.test("a newer posted success self-heals the block", () => {
+  const rows = [
+    BILLING_FAIL,
+    row("2026-07-08T02:00:00Z", { status: "posted" }),
+  ];
+  assertEquals(decideXPostPreflight(rows, NOW).blocked, false);
+});
+
+Deno.test("pre-post rejection rows never unblock (dry_run newest)", () => {
+  // x.post は投稿前 rejection 行も書く。最新行が dry_run でも billing 失敗が
+  // 生きている限り blocked を維持する。
+  const rows = [
+    row("2026-07-08T02:30:00Z", { status: "dry_run" }),
+    BILLING_FAIL,
+  ];
+  assertEquals(decideXPostPreflight(rows, NOW).blocked, true);
+});
+
+Deno.test("structured billing_blocked_until wins over prose", () => {
+  const rows = [
+    row("2026-07-08T00:15:00Z", {
+      status: "failed",
+      code: "x_billing_blocked",
+      billing_blocked_until: "2026-07-11",
+      error: "no parseable prose here",
+    }),
+  ];
+  const result = decideXPostPreflight(rows, NOW);
+  assertEquals(result.resetAt, "2026-07-11");
+});
+
+Deno.test("unparseable reset date falls back to 24h TTL", () => {
+  const rows = [
+    row("2026-07-08T00:15:00Z", {
+      status: "failed",
+      code: "x_billing_blocked",
+      error: "generic 402 without a date",
+    }),
+  ];
+  assert(decideXPostPreflight(rows, NOW).blocked);
+  const afterTtl = new Date("2026-07-09T01:00:00Z");
+  assertEquals(decideXPostPreflight(rows, afterTtl).blocked, false);
+});
+
+Deno.test("no billing failure means not blocked", () => {
+  assertEquals(decideXPostPreflight([], NOW).blocked, false);
+  const rows = [row("2026-07-08T01:00:00Z", {
+    status: "failed",
+    code: "x_post_failed",
+    error: "some other error",
+  })];
+  assertEquals(decideXPostPreflight(rows, NOW).blocked, false);
+});

--- a/test/services/universal_x_share_service_test.dart
+++ b/test/services/universal_x_share_service_test.dart
@@ -304,6 +304,55 @@ void main() {
     // R13: media 軸。"Media lift" 行を authoritative 測定データとして扱い、勝ち
     // メディアへ最強フックを寄せるルールがプロンプトに届くこと。
     expect(prompt, contains('Media lift'));
+    // R15: 言い換え回避への強化。文法テンプレート禁止・誇張副詞クラス禁止・
+    // 一般名詞呼称の exact 禁止・poll 質問文の反復禁止・例文コピー禁止が届くこと。
+    expect(prompt, contains('捏造実績の文法テンプレート'));
+    expect(prompt, contains('格段に'));
+    expect(prompt, contains('程度を誇張する副詞'));
+    expect(prompt, contains('私のアプリでは'));
+    expect(prompt, contains('question 文をそのまま繰り返すな'));
+    // 矛盾 few-shot(禁止テンプレートを実演していた GOOD 例)が除去済みなこと。
+    expect(prompt, isNot(contains('引き落としが浮いた')));
+  });
+
+  test('buildXPostFailureMessage dedupes guidance embedded in the error', () {
+    // 実障害(2026-07-08): edge が error にガイダンスを埋め込み + actionRequired
+    // にも同文が返る → 連結で同じ段落が二重表示された。
+    const guidance = 'X APIのクレジット不足/spend cap到達です。console.x.com で引き上げてください。';
+    final message = UniversalXShareService.buildXPostFailureMessage({
+      'error': 'X APIのクレジットが不足しています（spend cap reached）。 $guidance',
+      'actionRequired': guidance,
+    });
+    expect(RegExp(RegExp.escape(guidance)).allMatches(message).length, 1);
+    // 独立した error / actionRequired は両方描画される(no-op 保証)。
+    final independent = UniversalXShareService.buildXPostFailureMessage({
+      'error': 'X post failed with 500',
+      'actionRequired': 'Check credentials.',
+    });
+    expect(independent, contains('X post failed with 500'));
+    expect(independent, contains('Check credentials.'));
+  });
+
+  test('checkXPostPreflight parses blocked state and fails open', () async {
+    final service = UniversalXShareService(
+      chatService: AiHubChatService(invoker: (body) async => {'success': true}),
+      functionInvoker: (functionName, body) async {
+        expect(body['action'], 'x.post_preflight');
+        return {'success': true, 'blocked': true, 'resetAt': '2026-07-10'};
+      },
+    );
+    final result = await service.checkXPostPreflight();
+    expect(result.blocked, isTrue);
+    expect(result.resetAt, '2026-07-10');
+
+    // preflight 自体の障害では本流を止めない(fail-open)。
+    final failing = UniversalXShareService(
+      chatService: AiHubChatService(invoker: (body) async => {'success': true}),
+      functionInvoker: (functionName, body) async =>
+          throw Exception('edge down'),
+    );
+    final open = await failing.checkXPostPreflight();
+    expect(open.blocked, isFalse);
   });
 
   test('generateDraft repairs LLM JSON with raw newlines inside strings',


### PR DESCRIPTION
## R15: X spend-cap stop-loss preflight + guidance dedupe + copy-drift hardening

Live incident (2026-07-08): with the X API spend cap reached, every share attempt ran the FULL paid creative pipeline (GPT image + ElevenLabs TTS + Hedra presenter video ~119 credits + up to 7.5min polling) and THEN deterministically failed at x.post — burning a fresh captioned video per attempt. The failure status also printed the same JP guidance paragraph twice. A 12-hypothesis adversarial workflow (12 survived) ranked the fixes:

1. **Spend-cap fail-fast preflight.** New read-only growth-hub action `x.post_preflight` (zero X-API cost): scans recent `x_post_log` rows; blocked iff the newest `x_billing_blocked` failure has no newer `posted` success AND now < reset date (parsed from the stored error via new `parseBillingBlockedUntil`, structured `billing_blocked_until` preferred, 24h TTL fallback). Pre-post rejection rows (dry_run etc.) never unblock. Self-heals when the operator raises the cap and a post succeeds. The share shell calls it as **step 0 before any media generation** — blocked: skip image/TTS/video/post entirely, show the reset date + console.x.com fix, keep the generated copy for manual posting. Fail-open (preflight errors never degrade the happy path). Mirrors the existing Hedra-credit preflight contract.
2. **Guidance dedupe.** `buildXPostFailureMessage` drops parts already contained in earlier parts (works for old edge deploys too); the edge no longer embeds the guidance inside the `x_billing_blocked` error text (raw upstream detail with the reset date is kept for logs).
3. **Structured reset date.** `billingBlockedUntil` flows payload → failure JSON → `x_post_log` (additive, no migration).
4. **Copy-drift hardening (prompt-only).** The LLM paraphrased around exact bans (「私のウェブアプリでは」「格段に」「〜が効率化される中」「実測してみたところ…できました」) — generalized to: fabricated-outcome grammar-template ban, degree-adverb class ban, generic app-naming ban incl. possessives, 「〜が…する/される/進む中、」bridge-template ban, poll-question verbatim-reuse ban in replies, few-shot verbatim-copy ban; and the contradictory bridge GOOD few-shot (which itself modeled the fabricated-outcome template) rewritten to a grounded capability form.

Tests: deno 8 green (`x_post_preflight_test.ts`: parse/blocked/reset+grace/self-heal/rejection-rows/structured/TTL/none) + flutter 52 green (dedupe exactly-once + no-op guarantee, preflight parse + fail-open, prompt carries all new constraints, contradictory few-shot absent). All additive/default-safe; when not blocked the flow is byte-identical.

## Minimal E2E Gate

- Implementation-detail independent: tests assert the preflight decision from persisted log rows, the user-visible failure message, and the prompt contract — not private helper names.
- Minimal scope: about 3 cases (blocked path, unblocked/self-heal path, fail-open path).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: cost-control preflight + message/prompt change verified by implementation-independent Deno unit tests and Dart unit tests over the public service surface; no user-facing route flow changes, so no integration_test/Playwright route applies.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: R15 cost-control preflight is read-only log inspection plus additive JSON fields; no new write path, no credential/permission change; posting behavior unchanged when unblocked; rollback is a one-commit revert
