### PR TITLE
feat(admin): R16 close the X posted-today loop in dashboard action card

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -6,6 +6,7 @@ import '../services/growth_mission_service.dart';
 import '../widgets/schedule_task_monitor_card.dart';
 import '../widgets/competitor_monitoring_card.dart';
 import '../widgets/self_devin_control_tower_card.dart';
+import 'admin_x_posted_today.dart';
 import 'ai_secretary_page.dart';
 import 'admin/feedback_list_page.dart';
 import 'admin/quota_dashboard_page.dart';
@@ -46,6 +47,9 @@ class _GrowthActionPlan {
   final IconData icon;
   final String buttonLabel;
   final bool isAcquisitionAction;
+  // R16: 非 null のとき、ボタンはページ遷移ではなくこの URL を外部起動する
+  // (投稿を開く / console.x.com で上限確認 等)。
+  final String? launchUrl;
 
   const _GrowthActionPlan({
     required this.bottleneckLabel,
@@ -54,6 +58,7 @@ class _GrowthActionPlan {
     required this.icon,
     required this.buttonLabel,
     required this.isAcquisitionAction,
+    this.launchUrl,
   });
 }
 
@@ -76,6 +81,10 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   int _blockedToolExecutionCount = 0;
   _PaidConversionMetrics _paidConversionMetrics = _PaidConversionMetrics.empty;
   bool _hasLpViewStats = false;
+  // R16: growth-hub x.today_status の結果(今日すでに投稿したか / 最新tweet+初速
+  // インプレ / spend-cap ブロック中か)。取得失敗や available:false のときは null
+  // に戻し、アクションカードは従来文言(「X投稿を作る」)へ degrade する。
+  Map<String, dynamic>? _xTodayStatus;
   bool _isLoading = true;
   WeeklyDigestSnapshot _weeklyDigest = const WeeklyDigestSnapshot.empty();
   late final SupabaseClient _supabase;
@@ -293,6 +302,93 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     return total / window.length;
   }
 
+  /// R16: growth-hub x.today_status を fail-safe に取得する。今日境界はブラウザ
+  /// ローカル深夜を UTC ISO(絶対時刻)で渡す(サーバは epoch 比較する)。
+  /// 例外・available!=true のときは null を返し、アクションカードは従来動作へ degrade。
+  Future<Map<String, dynamic>?> _loadXTodayStatus() async {
+    try {
+      final startOfDayIso =
+          _startOfDay(DateTime.now()).toUtc().toIso8601String();
+      final res = await _supabase.functions.invoke(
+        'growth-hub',
+        body: {
+          'action': 'x.today_status',
+          'startOfDayIso': startOfDayIso,
+          'tz': 'Asia/Tokyo',
+        },
+      );
+      final data = res.data;
+      if (data is Map && data['available'] == true) {
+        return Map<String, dynamic>.from(data);
+      }
+    } catch (error) {
+      debugPrint('x.today_status unavailable: $error');
+    }
+    return null;
+  }
+
+  /// R16: 今日すでに X 投稿済みなら「投稿を作れ」ではなく、投稿直後30分は
+  /// ゴールデンアワー(手動リプ/poll確認)、以降は計測待ち、spend-cap 中は上限
+  /// 確認案内へ切り替える。今日未投稿(または status 未取得)なら null を返し、
+  /// 呼び出し側の従来ロジック(流入不足→X投稿を作る)へフォールバックする。
+  _GrowthActionPlan? _buildPostedTodayActionPlan() {
+    final status = _xTodayStatus;
+    if (status == null) return null;
+    final cta = adminXPostedTodayCta(status, DateTime.now());
+
+    switch (cta) {
+      case AdminXPostedTodayCta.none:
+        return null;
+      case AdminXPostedTodayCta.blocked:
+        final resetAt = status['resetAt']?.toString();
+        final resetNote = resetAt != null && resetAt.isNotEmpty
+            ? '（$resetAt に自動リセット見込み）'
+            : '';
+        return _GrowthActionPlan(
+          bottleneckLabel: 'X API上限',
+          title: 'X APIの支出上限に到達中',
+          detail: 'console.x.com の「支出上限を管理」で引き上げると即時解除されます$resetNote。'
+              '解除まで自動投稿はスキップされます。再投稿の前に上限を確認してください。',
+          icon: Icons.credit_card_off,
+          buttonLabel: 'console.x.com で上限を確認',
+          isAcquisitionAction: false,
+          launchUrl: 'https://console.x.com/',
+        );
+      case AdminXPostedTodayCta.goldenHour:
+      case AdminXPostedTodayCta.measuring:
+        final postedCount = _toInt(status['postedTodayCount']);
+        final impressions = status['latestImpressions'];
+        final imprText = impressions == null ? '計測待ち' : 'インプレ $impressions';
+        final tweetId = status['lastTweetId']?.toString();
+        final tweetUrl = tweetId != null && tweetId.isNotEmpty
+            ? 'https://x.com/i/web/status/$tweetId'
+            : null;
+        if (cta == AdminXPostedTodayCta.goldenHour) {
+          return _GrowthActionPlan(
+            bottleneckLabel: 'ゴールデンアワー',
+            title: '投稿直後30分: 反応を取りにいく',
+            detail: '本日$postedCount件投稿済み。今は新規投稿より、投稿を開いて実際に来た'
+                'コメントへ手動で返信し、poll票と初速($imprText)を確認するのが伸びを決めます。',
+            icon: Icons.bolt,
+            buttonLabel: tweetUrl != null ? '投稿を開く' : '反応を確認',
+            isAcquisitionAction: false,
+            launchUrl: tweetUrl,
+          );
+        }
+        return _GrowthActionPlan(
+          bottleneckLabel: 'リーチ→LP変換待ち',
+          title: '本日は投稿済み（計測待ち）',
+          detail: '本日$postedCount件投稿済み（$imprText）。再投稿は近似重複ガードに当たるため'
+              '避け、bio・固定ツイート導線(X_PROFILE_CONVERSION_KIT)の見直しや大型'
+              'アカウントへの手動返信で発見性を上げてください。次の投稿はJST 20-22時が目安です。',
+          icon: Icons.hourglass_bottom,
+          buttonLabel: tweetUrl != null ? '投稿を開いて確認' : '成長プレイブックを見る',
+          isAcquisitionAction: false,
+          launchUrl: tweetUrl,
+        );
+    }
+  }
+
   _GrowthActionPlan _buildGrowthActionPlan({
     required bool achieved,
     required int todayViews,
@@ -313,6 +409,11 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     }
 
     if (todayViews == 0) {
+      // R16: 今日すでに投稿済みなら「作れ」ではなくゴールデンアワー/計測待ち/上限
+      // 確認へ切り替える(再投稿の near-dup ガード踏み+有償生成を防ぐ)。今日未投稿
+      // or status 未取得なら null → 従来の「X投稿を作る」へフォールバック。
+      final postedTodayPlan = _buildPostedTodayActionPlan();
+      if (postedTodayPlan != null) return postedTodayPlan;
       return _GrowthActionPlan(
         bottleneckLabel: '流入不足',
         title: '今やる流入改善アクション',
@@ -468,7 +569,17 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     required bool isAcquisitionAction,
     String? priorityChannelKey,
     String? priorityChannelLabel,
+    String? ctaUrl,
   }) {
+    // R16: 投稿済み/上限ブロック状態のボタンはページ遷移ではなく URL を外部起動
+    // する(投稿を開く / console.x.com)。CmoPage への遷移(有償生成トリガ)を回避。
+    if (ctaUrl != null && ctaUrl.isNotEmpty) {
+      final uri = Uri.tryParse(ctaUrl);
+      if (uri != null) {
+        launchUrl(uri, mode: LaunchMode.externalApplication);
+      }
+      return;
+    }
     final targetPage = isAcquisitionAction
         ? _buildAcquisitionTargetPage(priorityChannelKey)
         : const AISecretaryPage(
@@ -1268,6 +1379,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           : <String, dynamic>{};
       final hasLpViewStats = lpStats.isNotEmpty;
       final paidConversionMetrics = await _loadPaidConversionMetrics();
+      final xTodayStatus = await _loadXTodayStatus();
 
       final toolExecutionLogs = <Map<String, dynamic>>[];
       final blockedReasonCounts = <String, int>{};
@@ -1323,6 +1435,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           _allowedToolExecutionCount = allowedExecutionCount;
           _blockedToolExecutionCount = blockedExecutionCount;
           _paidConversionMetrics = paidConversionMetrics;
+          _xTodayStatus = xTodayStatus;
           _isLoading = false;
         });
       }
@@ -1793,43 +1906,54 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     );
     final accentColor =
         achieved ? const Color(0xFF0D9488) : const Color(0xFFB91C1C);
+    // R16: 今日すでに投稿済み(または spend-cap ブロック中)なら、todayViews==0 でも
+    // 「流入不足/今日の流入がありません」を出さず、growthAction(投稿済み状態機械の
+    // 出力)の診断・文言をそのまま使う。
+    final postedTodayActive =
+        !achieved && todayViews == 0 && _buildPostedTodayActionPlan() != null;
     final todayCvr =
         todayViews == 0 ? 0.0 : (todayRegistrations / todayViews * 100);
     final diagnosisLabel = achieved
         ? '登録発生'
-        : todayViews == 0
-            ? '流入不足'
-            : growthAction.bottleneckLabel;
+        : postedTodayActive
+            ? growthAction.bottleneckLabel
+            : todayViews == 0
+                ? '流入不足'
+                : growthAction.bottleneckLabel;
     final diagnosisColor = achieved
         ? const Color(0xFF0D9488)
-        : todayViews == 0
-            ? const Color(0xFFFF6B35)
-            : todayFunnel.trialRuns == 0
-                ? const Color(0xFF0D9488)
-                : todayFunnel.saveClicks == 0
-                    ? const Color(0xFF6366F1)
-                    : todayFunnel.magicLinkSends == 0
-                        ? const Color(0xFFFF6B35)
-                        : todayFunnel.inboxOpens == 0
-                            ? const Color(0xFF92400E)
-                            : const Color(0xFFB91C1C);
+        : postedTodayActive
+            ? const Color(0xFF6366F1)
+            : todayViews == 0
+                ? const Color(0xFFFF6B35)
+                : todayFunnel.trialRuns == 0
+                    ? const Color(0xFF0D9488)
+                    : todayFunnel.saveClicks == 0
+                        ? const Color(0xFF6366F1)
+                        : todayFunnel.magicLinkSends == 0
+                            ? const Color(0xFFFF6B35)
+                            : todayFunnel.inboxOpens == 0
+                                ? const Color(0xFF92400E)
+                                : const Color(0xFFB91C1C);
     final actionTitle = achieved ? null : growthAction.title;
     final actionDetail = achieved ? null : growthAction.detail;
     final actionIcon = achieved ? null : growthAction.icon;
     final actionButtonLabel = achieved ? null : growthAction.buttonLabel;
     final statusText = achieved
         ? '今日の登録目標は達成済みです。次は流入改善で上振れを狙う。'
-        : todayViews == 0
-            ? '今日の流入がありません。まずは露出導線を1つ増やして、訪問者を作ってください。'
-            : todayFunnel.trialRuns == 0
-                ? '流れ込みはありますが、無料体験がまだ1回も実行されていません。最初の一手を試したくなる導線を最優先で短くしてください。'
-                : todayFunnel.saveClicks == 0
-                    ? '無料体験の実行はありますが、保存CTAが押されていません。体験直後に「保存すると残る価値」を再提示する必要があります。'
-                    : todayFunnel.magicLinkSends == 0
-                        ? '保存CTAまでは到達していますが、Magic Link送信が0件です。メール入力前の不安を減らす必要があります。'
-                        : todayFunnel.inboxOpens == 0
-                            ? 'Magic Link送信はありますが、受信箱が開かれていません。送信後の次の行動をさらに明確にしてください。'
-                            : '流れ込みはありますが登録が出ていません。登録完了直前での離脱が発生しています。';
+        : postedTodayActive
+            ? growthAction.detail
+            : todayViews == 0
+                ? '今日の流入がありません。まずは露出導線を1つ増やして、訪問者を作ってください。'
+                : todayFunnel.trialRuns == 0
+                    ? '流れ込みはありますが、無料体験がまだ1回も実行されていません。最初の一手を試したくなる導線を最優先で短くしてください。'
+                    : todayFunnel.saveClicks == 0
+                        ? '無料体験の実行はありますが、保存CTAが押されていません。体験直後に「保存すると残る価値」を再提示する必要があります。'
+                        : todayFunnel.magicLinkSends == 0
+                            ? '保存CTAまでは到達していますが、Magic Link送信が0件です。メール入力前の不安を減らす必要があります。'
+                            : todayFunnel.inboxOpens == 0
+                                ? 'Magic Link送信はありますが、受信箱が開かれていません。送信後の次の行動をさらに明確にしてください。'
+                                : '流れ込みはありますが登録が出ていません。登録完了直前での離脱が発生しています。';
 
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
@@ -2050,6 +2174,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                                   growthAction.isAcquisitionAction,
                               priorityChannelKey: priorityChannelKey,
                               priorityChannelLabel: priorityChannelLabel,
+                              ctaUrl: growthAction.launchUrl,
                             );
                           },
                           icon: const Icon(Icons.arrow_forward, size: 16),

--- a/lib/pages/admin_x_posted_today.dart
+++ b/lib/pages/admin_x_posted_today.dart
@@ -1,0 +1,40 @@
+// R16: /admin 経営分析ダッシュボードのアクションカード状態機械の純ロジック。
+// admin_analytics_page.dart は supabase/url_launcher 等の重い(web専用 JS interop を
+// 含む)依存を持ち VM テストで直接コンパイルできないため、テスト可能な純ロジックだけ
+// をこの依存ゼロのファイルへ切り出す(edge の x_today_status.ts と同じ抽出パターン)。
+
+/// 今日の X 投稿状況(growth-hub x.today_status)から決まるアクションカードの状態。
+enum AdminXPostedTodayCta {
+  /// 今日未投稿 or status 未取得 → 従来の「X投稿を作る」へフォールバック。
+  none,
+
+  /// spend-cap ブロック中 → console.x.com で上限確認。
+  blocked,
+
+  /// 投稿後60分以内 → ゴールデンアワー(投稿を開いて手動リプ/poll確認)。
+  goldenHour,
+
+  /// 投稿後60分超 → 計測待ち(再投稿せずアカウント導線へ)。
+  measuring,
+}
+
+/// x.today_status のマップと現在時刻から CTA 状態を純粋に決める。blocked を最優先し、
+/// 次に「今日投稿済みか」、そして投稿からの経過時間(<=60分でゴールデンアワー)で分岐。
+AdminXPostedTodayCta adminXPostedTodayCta(
+  Map<String, dynamic>? status,
+  DateTime now,
+) {
+  if (status == null) return AdminXPostedTodayCta.none;
+  if (status['blocked'] == true) return AdminXPostedTodayCta.blocked;
+  final rawCount = status['postedTodayCount'];
+  final count = rawCount is int
+      ? rawCount
+      : int.tryParse(rawCount?.toString() ?? '') ?? 0;
+  if (count <= 0) return AdminXPostedTodayCta.none;
+  final postedAt =
+      DateTime.tryParse(status['lastPostedAt']?.toString() ?? '')?.toLocal();
+  if (postedAt != null && now.difference(postedAt).inMinutes <= 60) {
+    return AdminXPostedTodayCta.goldenHour;
+  }
+  return AdminXPostedTodayCta.measuring;
+}

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./signup_notification.ts";
 import { filterRecentLogs } from "./metrics_window.ts";
 import { decideXPostPreflight } from "./x_post_preflight.ts";
+import { computeTodayStatus } from "./x_today_status.ts";
 import { buildMediaLiftLine, classifyPostMediaType } from "./x_media_type.ts";
 
 const corsHeaders = {
@@ -1785,6 +1786,31 @@ serve(async (req: Request) => {
           success: true,
           ...decideXPostPreflight(rows, new Date()),
         });
+      }
+
+      case "x.today_status": {
+        // R16: /admin ダッシュボードへ「今日すでに投稿したか / 最新tweetと初速
+        // インプレ / spend-cap ブロック中か」を返す read-only チェック(X API 非
+        // 呼出・ゼロコスト)。どんな例外でも 200 {available:false} を返し、
+        // ダッシュボードが必ず degrade(現行文言に戻る)できることを保証する。
+        try {
+          const logs =
+            (await listXPostLogs(admin, userId!, 20)) as XPostLogItem[];
+          const rows = logs.map((item) => ({
+            created_at: item.created_at,
+            metadata: asRecord(item.metadata),
+          }));
+          return json({
+            success: true,
+            ...computeTodayStatus(
+              rows,
+              String(body.startOfDayIso ?? ""),
+              new Date(),
+            ),
+          });
+        } catch (_error) {
+          return json({ success: true, available: false });
+        }
       }
 
       case "revenue.funnel_report": {

--- a/supabase/functions/growth-hub/x_today_status.ts
+++ b/supabase/functions/growth-hub/x_today_status.ts
@@ -1,0 +1,93 @@
+// R16: /admin 経営分析ダッシュボードの「今日の投稿を知る」ループを閉じる純ロジック。
+// ダッシュボードは従来 x_post_log を一切読まず、todayViews==0 だけ見て無条件に
+// 「X投稿を作る」を出していた。今日 11:57 に投稿済み(動画+poll)でも再投稿を促し、
+// 近似重複ガード踏み+ゴールデンアワー(手動リプ)喪失+CmoPage の有償生成を誘発した
+// (R15 の spend-cap 事件と同型の foot-gun)。この関数は直近ログから「今日すでに
+// 投稿したか / 何件 / 最新の tweet と初速インプレ / spend-cap ブロック中か」を返す。
+
+import { decideXPostPreflight, XPostPreflightRow } from "./x_post_preflight.ts";
+
+export interface XTodayStatusRow {
+  created_at: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface XTodayStatus {
+  available: true;
+  postedTodayCount: number;
+  lastPostedAt: string | null;
+  lastTweetId: string | null;
+  lastMediaType: string | null;
+  lastVariant: string | null;
+  latestImpressions: number | null;
+  lastCollectedAt: string | null;
+  blocked: boolean;
+  resetAt: string | null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function strOrNull(value: unknown): string | null {
+  const s = value === null || value === undefined ? "" : String(value).trim();
+  return s === "" ? null : s;
+}
+
+function numOrNull(value: unknown): number | null {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/// 今日投稿されたか等を集計する。今日境界 = クライアントのローカル深夜を UTC ISO で
+/// 受け取り(例: JST 深夜 → 前日 15:00Z)、posted_at と epoch ms で絶対時刻比較する
+/// (文字列の日付比較は JST/UTC ズレで誤る)。status==='posted' 行だけを数えるので、
+/// 失敗行や x_billing_blocked 行が「投稿済み」に化けることはない。
+/// startOfDayIso が不正なときは直近24hへ degrade(全件でも0件でもなく安全側)。
+export function computeTodayStatus(
+  rows: readonly XTodayStatusRow[],
+  startOfDayIso: string,
+  nowUtc: Date,
+): XTodayStatus {
+  const parsedStart = Date.parse(startOfDayIso ?? "");
+  const startMs = Number.isNaN(parsedStart)
+    ? nowUtc.getTime() - 24 * 3600 * 1000
+    : parsedStart;
+
+  let count = 0;
+  let last: { at: number; meta: Record<string, unknown> } | null = null;
+  for (const row of rows) {
+    const meta = asRecord(row.metadata);
+    if (String(meta.status ?? "") !== "posted") continue;
+    const postedMs = Date.parse(
+      String(meta.posted_at ?? row.created_at ?? ""),
+    );
+    if (Number.isNaN(postedMs) || postedMs < startMs) continue;
+    count += 1;
+    if (last === null || postedMs > last.at) last = { at: postedMs, meta };
+  }
+
+  const preflight = decideXPostPreflight(
+    rows as readonly XPostPreflightRow[],
+    nowUtc,
+  );
+  const meta = last?.meta ?? {};
+  const latest = asRecord(meta.latest_metrics);
+
+  return {
+    available: true,
+    postedTodayCount: count,
+    lastPostedAt: last ? new Date(last.at).toISOString() : null,
+    lastTweetId: strOrNull(meta.tweet_id),
+    lastMediaType: strOrNull(meta.media_type),
+    lastVariant: strOrNull(meta.variant),
+    latestImpressions: last
+      ? numOrNull(latest.impressions ?? meta.impressions)
+      : null,
+    lastCollectedAt: strOrNull(meta.metrics_checked_at),
+    blocked: preflight.blocked,
+    resetAt: preflight.resetAt ?? null,
+  };
+}

--- a/supabase/functions/growth-hub/x_today_status_test.ts
+++ b/supabase/functions/growth-hub/x_today_status_test.ts
@@ -1,0 +1,108 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { computeTodayStatus } from "./x_today_status.ts";
+
+// JST 深夜 = 前日 15:00Z。クライアントはこの絶対時刻を送る。
+const START_OF_DAY_JST = "2026-07-07T15:00:00.000Z"; // 2026-07-08 00:00 JST
+const NOW = new Date("2026-07-08T04:00:00Z"); // = 13:00 JST
+
+function row(
+  createdAt: string,
+  metadata: Record<string, unknown>,
+): { created_at: string; metadata: Record<string, unknown> } {
+  return { created_at: createdAt, metadata };
+}
+
+const POSTED_TODAY = row("2026-07-08T02:57:00Z", {
+  status: "posted",
+  tweet_id: "2074687597742616995",
+  posted_at: "2026-07-08T02:57:00Z", // 11:57 JST
+  media_type: "video",
+  variant: "daily_briefing",
+  latest_metrics: { impressions: 13 },
+  metrics_checked_at: "2026-07-08T03:30:00Z",
+});
+
+Deno.test("counts a post made today and maps its fields", () => {
+  const s = computeTodayStatus([POSTED_TODAY], START_OF_DAY_JST, NOW);
+  assertEquals(s.available, true);
+  assertEquals(s.postedTodayCount, 1);
+  assertEquals(s.lastTweetId, "2074687597742616995");
+  assertEquals(s.lastMediaType, "video");
+  assertEquals(s.latestImpressions, 13);
+  assertEquals(s.blocked, false);
+});
+
+Deno.test("no post today → count 0, null fields", () => {
+  const yesterday = row("2026-07-07T02:00:00Z", {
+    status: "posted",
+    tweet_id: "old",
+    posted_at: "2026-07-07T02:00:00Z", // before today's JST midnight
+  });
+  const s = computeTodayStatus([yesterday], START_OF_DAY_JST, NOW);
+  assertEquals(s.postedTodayCount, 0);
+  assertEquals(s.lastTweetId, null);
+  assertEquals(s.latestImpressions, null);
+});
+
+Deno.test("failed / billing-blocked rows never count as posted", () => {
+  const rows = [
+    row("2026-07-08T02:00:00Z", { status: "failed", code: "x_post_failed" }),
+    row("2026-07-08T02:30:00Z", {
+      status: "failed",
+      code: "x_billing_blocked",
+      posted_at: "2026-07-08T02:30:00Z",
+    }),
+    row("2026-07-08T01:00:00Z", { status: "dry_run" }),
+  ];
+  assertEquals(
+    computeTodayStatus(rows, START_OF_DAY_JST, NOW).postedTodayCount,
+    0,
+  );
+});
+
+Deno.test("JST 00:30 post (= prior-day 15:30 UTC) still counts as today", () => {
+  const earlyMorning = row("2026-07-07T15:30:00Z", {
+    status: "posted",
+    tweet_id: "early",
+    posted_at: "2026-07-07T15:30:00Z", // 00:30 JST 2026-07-08
+  });
+  const s = computeTodayStatus([earlyMorning], START_OF_DAY_JST, NOW);
+  assertEquals(s.postedTodayCount, 1);
+  assertEquals(s.lastTweetId, "early");
+});
+
+Deno.test("missing latest_metrics → latestImpressions null (計測待ち)", () => {
+  const noMetrics = row("2026-07-08T02:57:00Z", {
+    status: "posted",
+    tweet_id: "t",
+    posted_at: "2026-07-08T02:57:00Z",
+  });
+  const s = computeTodayStatus([noMetrics], START_OF_DAY_JST, NOW);
+  assertEquals(s.postedTodayCount, 1);
+  assertEquals(s.latestImpressions, null);
+});
+
+Deno.test("multiple posts today → count all, last = newest", () => {
+  const earlier = row("2026-07-08T00:10:00Z", {
+    status: "posted",
+    tweet_id: "first",
+    posted_at: "2026-07-08T00:10:00Z",
+  });
+  const s = computeTodayStatus([POSTED_TODAY, earlier], START_OF_DAY_JST, NOW);
+  assertEquals(s.postedTodayCount, 2);
+  assertEquals(s.lastTweetId, "2074687597742616995"); // 02:57 > 00:10
+});
+
+Deno.test("spend-cap block surfaces from decideXPostPreflight", () => {
+  const blockedRows = [
+    row("2026-07-08T02:30:00Z", {
+      status: "failed",
+      code: "x_billing_blocked",
+      billing_blocked_until: "2026-07-10",
+    }),
+  ];
+  const s = computeTodayStatus(blockedRows, START_OF_DAY_JST, NOW);
+  assertEquals(s.blocked, true);
+  assertEquals(s.resetAt, "2026-07-10");
+  assertEquals(s.postedTodayCount, 0);
+});

--- a/test/pages/admin_x_posted_today_cta_test.dart
+++ b/test/pages/admin_x_posted_today_cta_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/admin_x_posted_today.dart';
+
+void main() {
+  // R16: /admin アクションカードの状態機械。今日投稿済みなら「X投稿を作る」を出さず、
+  // ゴールデンアワー / 計測待ち / spend-cap 上限確認へ切り替える純ロジックを検証する。
+  final now = DateTime(2026, 7, 8, 13, 0); // JST 想定のローカル時刻
+
+  test('status 未取得(null) は none = 従来の「X投稿を作る」へフォールバック', () {
+    expect(adminXPostedTodayCta(null, now), AdminXPostedTodayCta.none);
+  });
+
+  test('今日未投稿(count 0) も none', () {
+    expect(
+      adminXPostedTodayCta({'postedTodayCount': 0}, now),
+      AdminXPostedTodayCta.none,
+    );
+  });
+
+  test('blocked は最優先(投稿有無に関わらず)', () {
+    expect(
+      adminXPostedTodayCta(
+        {'blocked': true, 'postedTodayCount': 1, 'resetAt': '2026-07-10'},
+        now,
+      ),
+      AdminXPostedTodayCta.blocked,
+    );
+  });
+
+  test('投稿後60分以内 → goldenHour', () {
+    final status = {
+      'postedTodayCount': 1,
+      'lastPostedAt':
+          now.toUtc().subtract(const Duration(minutes: 30)).toIso8601String(),
+      'lastTweetId': '123',
+    };
+    expect(adminXPostedTodayCta(status, now), AdminXPostedTodayCta.goldenHour);
+  });
+
+  test('60分ちょうどは goldenHour、61分で measuring(境界)', () {
+    Map<String, dynamic> at(int minutes) => {
+          'postedTodayCount': 1,
+          'lastPostedAt': now
+              .toUtc()
+              .subtract(Duration(minutes: minutes))
+              .toIso8601String(),
+        };
+    expect(adminXPostedTodayCta(at(60), now), AdminXPostedTodayCta.goldenHour);
+    expect(adminXPostedTodayCta(at(61), now), AdminXPostedTodayCta.measuring);
+  });
+
+  test('投稿後60分超 → measuring', () {
+    final status = {
+      'postedTodayCount': 2,
+      'lastPostedAt':
+          now.toUtc().subtract(const Duration(hours: 3)).toIso8601String(),
+    };
+    expect(adminXPostedTodayCta(status, now), AdminXPostedTodayCta.measuring);
+  });
+
+  test('postedTodayCount が文字列でもパースされる', () {
+    final status = {
+      'postedTodayCount': '1',
+      'lastPostedAt':
+          now.toUtc().subtract(const Duration(hours: 2)).toIso8601String(),
+    };
+    expect(adminXPostedTodayCta(status, now), AdminXPostedTodayCta.measuring);
+  });
+}


### PR DESCRIPTION
## R16: close the X "posted-today" loop in the /admin dashboard action card

The 経営分析ダッシュボード never read x_post_log, so it judged the day only by `todayViews==0` and unconditionally commanded 「X投稿を作る」 — even though an X post was published at 11:57 JST today (video + subject-locked poll, ~13 impressions). Acting on that command re-posts, which trips the near-duplicate guard, wastes the golden-hour manual-reply window, and triggers CmoPage's paid Hedra/TTS/image generation (same foot-gun class as the R15 spend-cap incident). A 12-hypothesis adversarial workflow (12 survived) ranked the fix.

**One tight PR: one edge read-action feeds a dashboard state machine.**

- **Edge — new read-only `x.today_status`** (growth-hub): reuses R15's `decideXPostPreflight` helper (does NOT repurpose the posting-pipeline-wired `x.post_preflight`). Scans the last 20 x_post_log rows; counts `status==='posted'` rows whose `posted_at >= startOfDayIso` (JST-day boundary passed from the client as an absolute UTC instant, compared as epoch ms — not string dates), and folds in blocked/resetAt. Zero X-API cost. Returns 200 `{available:false}` on ANY throw so the dashboard always degrades.
- **Dart — 4-state action card**: `_buildGrowthActionPlan`'s unconditional `todayViews==0 → 「X投稿を作る」` now first checks today's post status: (none/unposted → verbatim current behavior) · (posted <=60min → ゴールデンアワー「投稿を開く」, opens the tweet) · (posted >60min → 計測待ち, re-post demoted, points at bio/pinned/manual-reply levers) · (spend-cap blocked → 「console.x.com で上限を確認」, no CmoPage nav). The goal-card diagnosis label + status text follow the same state. Everything additive: status null/unavailable → the dashboard renders exactly as today.
- Decision logic extracted to pure, dependency-light units so it is testable: `x_today_status.ts` (`computeTodayStatus`) and `lib/pages/admin_x_posted_today.dart` (`adminXPostedTodayCta`).

Tests: deno 7 green (posted-today count, failed/blocked rows excluded, JST-00:30 boundary, missing metrics → null, multi-post, spend-cap surfaced) + flutter 7 green (none/blocked/goldenHour/measuring branches + the exact 60/61-minute boundary + string-count parse). `flutter analyze` clean, dart/deno fmt clean. Honest ROI: this cannot conjure traffic — it stops a wasteful re-post and points the operator's next 30 minutes at the right lever.

## Minimal E2E Gate

- Implementation-detail independent: tests assert the today-status decision from persisted log rows and the CTA-state from a status map — not private helper internals.
- Minimal scope: about 3 cases (unposted→current CTA, posted→golden/measuring, spend-cap blocked); plus the JST day boundary.
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: read-only analytics action + dashboard action-card copy change verified by implementation-independent Deno unit tests (computeTodayStatus) and Dart unit tests (adminXPostedTodayCta); no user-facing route flow changes, so no integration_test/Playwright route applies.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: R16 adds a read-only x_post_log inspection action and dashboard copy; no new write path, no credential/permission change, zero X-API cost; dashboard degrades to current behavior on any failure; rollback is a one-commit revert
