### PR TITLE
[CI/CD自動最適化] cancel-in-progress: true 追加 2026-07-08

### DIFF
--- a/.github/workflows/mcp-container-isolation-smoke.yml
+++ b/.github/workflows/mcp-container-isolation-smoke.yml
@@ -18,7 +18,7 @@ permissions:
 
 concurrency:
   group: mcp-container-isolation-smoke-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-07-08 ci-audit: workflow_dispatch二重実行・PR連続push防止
 
 jobs:
   smoke:

--- a/.github/workflows/roadmap-append-only-guard.yml
+++ b/.github/workflows/roadmap-append-only-guard.yml
@@ -24,7 +24,7 @@ permissions:
 
 concurrency:
   group: roadmap-append-only-guard-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-07-08 ci-audit: PR連続push時のキュー積み防止
 
 jobs:
   guard:


### PR DESCRIPTION
## 変更概要

非デプロイ・軽量スクリプト実行の 2 ワークフローに `cancel-in-progress: true` を追加。
PR 連続 push や `workflow_dispatch` 二重実行時の古いランが自動キャンセルされ、不要な ubuntu-min 消費を防止する。

| ファイル | 変更前 | 変更後 |
|---------|--------|--------|
| `roadmap-append-only-guard.yml` | `cancel-in-progress: false` | `cancel-in-progress: true` |
| `mcp-container-isolation-smoke.yml` | `cancel-in-progress: false` | `cancel-in-progress: true` |

## 安全性確認

- どちらも非デプロイワークフロー (deploy-prod / deploy-dev / deploy-staging は対象外)
- 両ワークフローとも `paths` フィルタ済みで特定ファイル変更時のみ起動
- 外部状態変更なし (Python スクリプトの検証・テストのみ)
- YAML 構文検証: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('yaml ok')"` → **ok**

## 推定削減効果

同一 PR への連続 push 時に古い実行が即座にキャンセルされ、ランナー待機時間を削減。
頻繁な ROADMAP 編集 PR ブランチでは 1 PR あたり最大数 ubuntu-min を節約。

## 監査レポート

`docs/ci-cd-audit/2026-07-08.md` (main へ別途直接コミット済)

関連 Issue: #3841

---
_Generated by [Claude Code](https://claude.ai/code/session_019niSQ5NLpMviExaDPTunK8)_