### PR TITLE
feat(admin): R17 dashboard n=0 honesty + X growth-loop visibility panel

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -7,6 +7,7 @@ import '../widgets/schedule_task_monitor_card.dart';
 import '../widgets/competitor_monitoring_card.dart';
 import '../widgets/self_devin_control_tower_card.dart';
 import 'admin_x_posted_today.dart';
+import 'admin_dashboard_signals.dart';
 import 'ai_secretary_page.dart';
 import 'admin/feedback_list_page.dart';
 import 'admin/quota_dashboard_page.dart';
@@ -85,6 +86,10 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   // インプレ / spend-cap ブロック中か)。取得失敗や available:false のときは null
   // に戻し、アクションカードは従来文言(「X投稿を作る」)へ degrade する。
   Map<String, dynamic>? _xTodayStatus;
+  // R17: growth-hub x.performance_context の結果(計測済み投稿の variant ランキング
+  // / 勝ち型 / winner exemplar)。X 学習ループを意思決定点(ダッシュボード)に露出
+  // する。取得失敗時は null → 成長ループ panel は非表示に degrade。
+  Map<String, dynamic>? _xPerformanceContext;
   bool _isLoading = true;
   WeeklyDigestSnapshot _weeklyDigest = const WeeklyDigestSnapshot.empty();
   late final SupabaseClient _supabase;
@@ -220,10 +225,8 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   }
 
   String _formatPaidConversionRate(int paidCustomers, int totalUsers) {
-    if (totalUsers <= 0) {
-      return '0.0%';
-    }
-    return '${(paidCustomers / totalUsers * 100).toStringAsFixed(1)}%';
+    // R17: 母数0のとき「0.0%」は測定した0%に見えて誤解を生む → 計測不能の「—」。
+    return formatRatePercent(paidCustomers, totalUsers);
   }
 
   Map<String, dynamic> _firstMap(dynamic value) {
@@ -323,6 +326,25 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
       }
     } catch (error) {
       debugPrint('x.today_status unavailable: $error');
+    }
+    return null;
+  }
+
+  /// R17: growth-hub x.performance_context を fail-safe に取得する。edge 側に
+  /// server-side try/catch が無いため、ここで必ず握りつぶして null に degrade
+  /// する(取得失敗で成長ループ panel を消すだけ・ダッシュボードは必ず描画する)。
+  Future<Map<String, dynamic>?> _loadXPerformanceContext() async {
+    try {
+      final res = await _supabase.functions.invoke(
+        'growth-hub',
+        body: {'action': 'x.performance_context', 'limit': 50},
+      );
+      final data = res.data;
+      if (data is Map && data['success'] == true) {
+        return Map<String, dynamic>.from(data);
+      }
+    } catch (error) {
+      debugPrint('x.performance_context unavailable: $error');
     }
     return null;
   }
@@ -1380,6 +1402,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
       final hasLpViewStats = lpStats.isNotEmpty;
       final paidConversionMetrics = await _loadPaidConversionMetrics();
       final xTodayStatus = await _loadXTodayStatus();
+      final xPerformanceContext = await _loadXPerformanceContext();
 
       final toolExecutionLogs = <Map<String, dynamic>>[];
       final blockedReasonCounts = <String, int>{};
@@ -1436,6 +1459,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           _blockedToolExecutionCount = blockedExecutionCount;
           _paidConversionMetrics = paidConversionMetrics;
           _xTodayStatus = xTodayStatus;
+          _xPerformanceContext = xPerformanceContext;
           _isLoading = false;
         });
       }
@@ -1703,6 +1727,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                       sourceBreakdown: sourceBreakdown,
                       todayFunnel: todayFunnel,
                     ),
+                    // R17: X 学習ループ(勝ち型/計測待ち/cron警告)を意思決定点に露出。
+                    // データが無いときは SizedBox.shrink() で静かに消える。
+                    _buildXGrowthLoopSection(),
                     const SizedBox(height: 16),
                     _buildFunnelOverviewCard(
                       title: '今日の登録ファネル',
@@ -1911,8 +1938,6 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     // 出力)の診断・文言をそのまま使う。
     final postedTodayActive =
         !achieved && todayViews == 0 && _buildPostedTodayActionPlan() != null;
-    final todayCvr =
-        todayViews == 0 ? 0.0 : (todayRegistrations / todayViews * 100);
     final diagnosisLabel = achieved
         ? '登録発生'
         : postedTodayActive
@@ -2065,7 +2090,8 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
               ),
               _buildMiniKpiChip(
                 label: '今日のCVR',
-                value: '${todayCvr.toStringAsFixed(1)}%',
+                // R17: 流入0のとき「0.0%」は捏造 → 「—」(ファネル率セルと同じ規律)。
+                value: formatRatePercent(todayRegistrations, todayViews),
                 color: diagnosisColor,
               ),
               if (todayViews > 0)
@@ -2435,34 +2461,55 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
               ),
             ),
             const SizedBox(height: 4),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.baseline,
-              textBaseline: TextBaseline.alphabetic,
-              children: [
-                Text(
-                  cvr.toStringAsFixed(1),
-                  style: TextStyle(
-                    fontSize: 48,
-                    fontWeight: FontWeight.bold,
-                    color: _getCvrColor(cvr),
-                    height: 1.4,
-                  ),
+            // R17: 流入0のときは測定不能なので「0.0%」ではなく中立の「—」計測待ち
+            // を出す(母数=todayViews==0 で判定。流入>0で登録0は真の0.0%なので従来表示)。
+            if (todayViews == 0)
+              const Text(
+                '—',
+                style: TextStyle(
+                  fontSize: 48,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFF9CA3AF),
+                  height: 1.4,
                 ),
-                Padding(
-                  padding: const EdgeInsets.only(left: 4),
-                  child: Text(
-                    '%',
+              )
+            else
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    cvr.toStringAsFixed(1),
                     style: TextStyle(
-                      fontSize: 20,
+                      fontSize: 48,
                       fontWeight: FontWeight.bold,
                       color: _getCvrColor(cvr),
-                      height: 1.5,
+                      height: 1.4,
                     ),
                   ),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 4),
+                    child: Text(
+                      '%',
+                      style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        color: _getCvrColor(cvr),
+                        height: 1.5,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            if (todayViews == 0)
+              const Padding(
+                padding: EdgeInsets.only(top: 2),
+                child: Text(
+                  '計測待ち（流入なし）',
+                  style: TextStyle(fontSize: 11, color: Color(0xFF9CA3AF)),
                 ),
-              ],
-            ),
+              ),
             const SizedBox(height: 24),
             const Divider(height: 1),
             const SizedBox(height: 24),
@@ -3521,6 +3568,11 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
         final views = _toInt(stat['landing_views']);
         final conv = _toInt(stat['conversions']);
         final cvr = views == 0 ? 0.0 : (conv / views * 100);
+        // R17: 流入0の日は測定不能。「0.0%」赤バッジ(_getCvrColorは0→赤)ではなく
+        // 中立グレーの「—」を出す(流入>0で登録0は真の0.0%なので従来色)。
+        final cvrBadgeColor =
+            views == 0 ? const Color(0xFF9CA3AF) : _getCvrColor(cvr);
+        final cvrBadgeText = formatRatePercent(conv, views);
         final dayFunnel = _extractFunnelMetrics(
           _extractSourceCounts(stat['source_details']),
         );
@@ -3571,7 +3623,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
             trailing: Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               decoration: BoxDecoration(
-                color: _getCvrColor(cvr).withValues(alpha: 0.1),
+                color: cvrBadgeColor.withValues(alpha: 0.1),
                 borderRadius: BorderRadius.circular(4),
               ),
               child: Column(
@@ -3580,11 +3632,11 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
                   Text(
-                    '${cvr.toStringAsFixed(1)}%',
+                    cvrBadgeText,
                     style: TextStyle(
                       fontWeight: FontWeight.bold,
                       fontSize: 14,
-                      color: _getCvrColor(cvr),
+                      color: cvrBadgeColor,
                       height: 1.5,
                     ),
                   ),
@@ -3592,7 +3644,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                     'CVR',
                     style: TextStyle(
                       fontSize: 10,
-                      color: _getCvrColor(cvr),
+                      color: cvrBadgeColor,
                       height: 1.5,
                     ),
                   ),
@@ -5719,6 +5771,184 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     } catch (_) {
       if (mounted) setState(() => _growthSummaryLoading = false);
     }
+  }
+
+  /// R17: X 学習ループ(growth-hub x.performance_context)を意思決定点へ露出する
+  /// read-only カード。データ無しは SizedBox.shrink() で静かに消える。空(bestVariant
+  /// が既定 'daily_briefing' に落ちる)を勝ち型に見せないため、必ず非空ガードの内側。
+  Widget _buildXGrowthLoopSection() {
+    final perf = _xPerformanceContext;
+    if (perf == null) return const SizedBox.shrink();
+    final rows = perf['rows'] is List ? perf['rows'] as List : const [];
+    final variants = perf['variants'] is List ? perf['variants'] as List : null;
+    final loop = resolveXGrowthLoop(
+      measuredCount: rows.length,
+      distinctVariantCount: distinctMeasuredVariants(variants),
+      postedTodayCount: _toInt(_xTodayStatus?['postedTodayCount']),
+    );
+    if (loop.state == XGrowthLoopState.hidden) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final freshness = _xGrowthLoopFreshness();
+    final lines = <Widget>[];
+
+    switch (loop.state) {
+      case XGrowthLoopState.awaitingMetrics:
+        lines.add(
+          _growthLoopLine(
+            Icons.warning_amber_rounded,
+            const Color(0xFFF59E0B),
+            '本日の投稿はまだ計測されていません。spend-cap 到達や metrics 収集 cron の'
+            '停止で計測が止まっていないか確認してください（console.x.com の支出上限）。',
+          ),
+        );
+        break;
+      case XGrowthLoopState.sampling:
+        lines.add(
+          _growthLoopLine(
+            Icons.hourglass_bottom,
+            const Color(0xFF6366F1),
+            '学習サンプル ${loop.measuredCount}件（variant ${loop.distinctVariantCount}種）。'
+            '勝ちパターンの比較表示まで、あと数投稿ぶんのデータが必要です。',
+          ),
+        );
+        break;
+      case XGrowthLoopState.unlocked:
+        final bestVariant = perf['bestVariant']?.toString();
+        if (bestVariant != null && bestVariant.isNotEmpty) {
+          lines.add(
+            _growthLoopLine(
+              Icons.emoji_events_outlined,
+              const Color(0xFF0D9488),
+              '今の勝ち型: $bestVariant',
+            ),
+          );
+        }
+        for (final line in _xGrowthVariantRankingLines(variants)) {
+          lines.add(
+            _growthLoopLine(
+              Icons.leaderboard_outlined,
+              const Color(0xFF6366F1),
+              line,
+            ),
+          );
+        }
+        final winnerHook = _xGrowthWinnerHook(perf['winners']);
+        if (winnerHook != null) {
+          lines.add(
+            _growthLoopLine(
+              Icons.format_quote,
+              const Color(0xFF9CA3AF),
+              '真似る型: $winnerHook',
+            ),
+          );
+        }
+        break;
+      case XGrowthLoopState.hidden:
+        break;
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: Card(
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        color: theme.colorScheme.surfaceContainerLow,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(
+                    Icons.insights,
+                    size: 18,
+                    color: Color(0xFF0D9488),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    'X 成長ループ（計測から勝ち型を学ぶ）',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.bold,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              ...lines,
+              const SizedBox(height: 8),
+              Text(
+                freshness,
+                style: const TextStyle(fontSize: 11, color: Color(0xFF9CA3AF)),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _growthLoopLine(IconData icon, Color color, String text) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 15, color: color),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              text,
+              style: TextStyle(
+                fontSize: 12,
+                height: 1.6,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// variants(平均スコア降順)から上位3種を「{variant} 平均{score} (n={count})」に。
+  List<String> _xGrowthVariantRankingLines(List<dynamic>? variants) {
+    if (variants == null) return const [];
+    final lines = <String>[];
+    for (final entry in variants) {
+      if (entry is! Map) continue;
+      final name = (entry['variant'] ?? '').toString().trim();
+      if (name.isEmpty || name == 'unknown') continue;
+      final score = _toInt(entry['averageScore']);
+      final count = _toInt(entry['count']);
+      lines.add('$name 平均$score (n=$count)');
+      if (lines.length >= 3) break;
+    }
+    return lines;
+  }
+
+  String? _xGrowthWinnerHook(dynamic winners) {
+    if (winners is! List || winners.isEmpty) return null;
+    final first = winners.first;
+    if (first is! Map) return null;
+    final text = (first['text'] ?? '').toString().trim();
+    if (text.isEmpty) return null;
+    return text.length <= 60 ? text : '${text.substring(0, 58)}…';
+  }
+
+  String _xGrowthLoopFreshness() {
+    final collected =
+        DateTime.tryParse(_xTodayStatus?['lastCollectedAt']?.toString() ?? '')
+            ?.toLocal();
+    if (collected == null) return '最終計測: 計測待ち';
+    final days = DateTime.now().difference(collected).inDays;
+    final hours = DateTime.now().difference(collected).inHours;
+    if (days >= 1) return '最終計測: $days日前';
+    if (hours >= 1) return '最終計測: $hours時間前';
+    return '最終計測: 1時間以内';
   }
 
   Widget _buildGrowthAchievementSummaryCard() {

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -1,0 +1,80 @@
+// R17: /admin 経営分析ダッシュボードの純ロジック(依存ゼロ・VM テスト可能)。
+// admin_analytics_page.dart は supabase/url_launcher 等の web 専用 JS interop を
+// 含み VM テストで直接コンパイルできないため、テストしたい判定ロジックだけを
+// この依存ゼロのファイルへ切り出す(admin_x_posted_today.dart / edge の
+// x_today_status.ts と同じ抽出パターン / part321 の教訓)。
+
+/// 率(%)表示。分母0のときは捏造した「0.0%」ではなく計測不能を表す「—」を返す。
+/// ダッシュボードのファネル率セル(_formatRate)と同じ誠実性規律に揃える。
+String formatRatePercent(int numerator, int denominator) {
+  if (denominator <= 0) return '—';
+  return '${(numerator / denominator * 100).toStringAsFixed(1)}%';
+}
+
+/// X 成長ループ panel の表示状態。
+enum XGrowthLoopState {
+  /// 計測データも本日投稿も無い → panel を出さない(空を勝ち型に見せない)。
+  hidden,
+
+  /// 本日投稿はあるが計測0件 → metrics cron / spend-cap 確認の警告。
+  /// spend-cap で計測が止まった実績があるこのアカウントで最も効く signal。
+  awaitingMetrics,
+
+  /// 計測はあるが variant が1種のみ → 学習サンプル蓄積中(勝ち型はまだ)。
+  sampling,
+
+  /// variant が2種以上 → 勝ち型の比較を提示できる。
+  unlocked,
+}
+
+class XGrowthLoop {
+  final XGrowthLoopState state;
+  final int measuredCount;
+  final int distinctVariantCount;
+
+  const XGrowthLoop({
+    required this.state,
+    required this.measuredCount,
+    required this.distinctVariantCount,
+  });
+}
+
+/// perf-context の計測済み投稿数・variant 種数(unknown 除く)と本日投稿数から、
+/// 成長ループ panel の状態を純粋に決める。計測0でも本日投稿があれば
+/// awaitingMetrics(cron 警告)、投稿も無ければ hidden。
+XGrowthLoop resolveXGrowthLoop({
+  required int measuredCount,
+  required int distinctVariantCount,
+  required int postedTodayCount,
+}) {
+  if (measuredCount <= 0) {
+    return XGrowthLoop(
+      state: postedTodayCount > 0
+          ? XGrowthLoopState.awaitingMetrics
+          : XGrowthLoopState.hidden,
+      measuredCount: 0,
+      distinctVariantCount: 0,
+    );
+  }
+  return XGrowthLoop(
+    state: distinctVariantCount >= 2
+        ? XGrowthLoopState.unlocked
+        : XGrowthLoopState.sampling,
+    measuredCount: measuredCount,
+    distinctVariantCount: distinctVariantCount,
+  );
+}
+
+/// perf-context の variants 配列(各要素 {variant, averageScore, count})から、
+/// 比較可能な variant 種数を数える(unknown / 空を除外)。
+int distinctMeasuredVariants(List<dynamic>? variants) {
+  if (variants == null) return 0;
+  final seen = <String>{};
+  for (final entry in variants) {
+    if (entry is! Map) continue;
+    final name = (entry['variant'] ?? '').toString().trim();
+    if (name.isEmpty || name == 'unknown') continue;
+    seen.add(name);
+  }
+  return seen.length;
+}

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/admin_dashboard_signals.dart';
+
+void main() {
+  group('formatRatePercent (n=0 honesty)', () {
+    test('denominator 0 → 「—」 not fabricated 0.0%', () {
+      expect(formatRatePercent(0, 0), '—');
+      expect(formatRatePercent(5, 0), '—');
+    });
+
+    test('real 0 registrations with views is a true 0.0%', () {
+      expect(formatRatePercent(0, 5), '0.0%');
+    });
+
+    test('normal rate', () {
+      expect(formatRatePercent(1, 10), '10.0%');
+      expect(formatRatePercent(3, 8), '37.5%');
+    });
+  });
+
+  group('resolveXGrowthLoop', () {
+    test('no measured data and no post today → hidden', () {
+      final r = resolveXGrowthLoop(
+        measuredCount: 0,
+        distinctVariantCount: 0,
+        postedTodayCount: 0,
+      );
+      expect(r.state, XGrowthLoopState.hidden);
+    });
+
+    test('posted today but 0 measured → awaitingMetrics (cron warning)', () {
+      final r = resolveXGrowthLoop(
+        measuredCount: 0,
+        distinctVariantCount: 0,
+        postedTodayCount: 1,
+      );
+      expect(r.state, XGrowthLoopState.awaitingMetrics);
+    });
+
+    test('measured but <2 variants → sampling', () {
+      final r = resolveXGrowthLoop(
+        measuredCount: 3,
+        distinctVariantCount: 1,
+        postedTodayCount: 0,
+      );
+      expect(r.state, XGrowthLoopState.sampling);
+      expect(r.measuredCount, 3);
+    });
+
+    test('>=2 distinct variants → unlocked', () {
+      final r = resolveXGrowthLoop(
+        measuredCount: 6,
+        distinctVariantCount: 3,
+        postedTodayCount: 1,
+      );
+      expect(r.state, XGrowthLoopState.unlocked);
+    });
+  });
+
+  group('distinctMeasuredVariants', () {
+    test('excludes unknown and empty', () {
+      final variants = [
+        {'variant': 'daily_briefing', 'averageScore': 12, 'count': 4},
+        {'variant': 'unknown', 'averageScore': 3, 'count': 2},
+        {'variant': 'question_post', 'averageScore': 20, 'count': 1},
+        {'variant': '', 'averageScore': 0, 'count': 1},
+      ];
+      expect(distinctMeasuredVariants(variants), 2);
+    });
+
+    test('null → 0', () {
+      expect(distinctMeasuredVariants(null), 0);
+    });
+  });
+}


### PR DESCRIPTION
## R17: dashboard honesty (n=0 → 「—」) + 「X 成長ループ」visibility panel

Second improvement round on /admin after R16 (posted-today action loop). A 12-hypothesis adversarial workflow (11 survived) ranked two pillars. Dart-only, additive, display-only.

### 1. n=0 honesty — 今日のCVR shows 「0.0%」 at zero traffic (fabricated measurement)
The funnel rate cells already use `_formatRate` which returns 「—」 at denominator 0, but the CVR chip, the 48px hero CVR, the daily-history CVR badges, and `_formatPaidConversionRate` bypassed that discipline and rendered a fake 「0.0%」 with a red badge when there was simply no data. Now unified on the same discipline (extracted to a pure, VM-testable `formatRatePercent`): denominator 0 → 「—」/「計測待ち（流入なし）」 in neutral gray; a true 0.0% (views>0, registrations 0) still shows with the existing color split. No new helper on the widget — reuses the funnel-cell rule.

### 2. 「X 成長ループ」panel — surface the learning loop where decisions happen
The X growth-loop signals (variant ranking / winning variant / winner exemplar from growth-hub `x.performance_context`, already returned to the client as `rows`/`variants`/`bestVariant`/`winners`) were invisible on the dashboard. New read-only card, fed by a fail-safe fetch, with a pure state resolver (`resolveXGrowthLoop`) guarded against the empty state (the endpoint's `bestVariant` defaults to a literal variant name even with zero data, so the card stays behind a non-empty guard and disappears silently when there is nothing to show):
- posted today but 0 measured rows → 「本日の投稿はまだ計測されていません…」 cron/spend-cap liveness warning (the highest-value signal for this account — its metrics collection was previously halted by a spend cap)
- measured but <2 variants → 「学習サンプル N件…勝ちパターンまであと数投稿」
- ≥2 variants → 「今の勝ち型」+ top-3 variant ranking + winner exemplar hook
- freshness footer 「最終計測: N日前 / 計測待ち」

Both new fetches (`x.today_status` was R16; `x.performance_context` is new) are wrapped try/catch → null → the panel hides; the dashboard renders unchanged if either fails.

Pure logic extracted to `admin_dashboard_signals.dart` (dependency-zero, VM-testable — the page carries web-only JS interop and can't compile under the VM test runner). `flutter test`: 9 green (formatRatePercent n=0/real-0/normal; resolver hidden/awaitingMetrics/sampling/unlocked; variant counting). Analyze clean, format fixpoint.

Honest ROI: registrations stay 0 until reach grows — this round makes the dashboard tell the truth about zero and puts the learning loop at the decision point; it does not conjure traffic.

## Minimal E2E Gate

- Implementation-detail independent: tests assert the produced rate string and the resolver state from inputs, not private widget internals.
- Minimal scope: about 3 cases each (rate n=0 / real-0 / normal; resolver hidden / awaiting / sampling / unlocked).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: admin-only display/logic change (rate formatting + read-only panel state) verified by implementation-independent unit tests over pure functions; no user-facing route flow changes, so no integration_test/Playwright route applies.
