### PR TITLE
feat(seo): metadata hardening — Organization/WebSite/Article JSON-LD + public canonical fixes

### DIFF
--- a/supabase/functions/core-hub/public_memo_view.ts
+++ b/supabase/functions/core-hub/public_memo_view.ts
@@ -210,13 +210,46 @@ ${options.body}
 `;
 }
 
+/// Article 構造化データ (JSON-LD)。非JSクローラー / LLM / 検索エンジンに
+/// 公開メモを「記事」として認識させる。<script> ブレイクアウト防止のため
+/// `<` を < にエスケープする。
+export function renderPublicMemoArticleJsonLd(row: PublicMemoViewRow): string {
+  const title = row.title ?? `Public Memo #${row.id}`;
+  const appUrl = buildPublicMemoPageUrl(row.id);
+  const article: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: title,
+    description: buildPublicMemoExcerpt(row.content),
+    inLanguage: "ja",
+    mainEntityOfPage: appUrl,
+    url: appUrl,
+    author: { "@type": "Organization", name: PUBLIC_MEMO_SITE_NAME },
+    publisher: {
+      "@type": "Organization",
+      name: PUBLIC_MEMO_SITE_NAME,
+      logo: {
+        "@type": "ImageObject",
+        url: "https://my-web-app-b67f4.web.app/ogp-image-gen2-20260428.png",
+      },
+    },
+  };
+  const tags = extractPublicMemoTags(row);
+  if (tags.length > 0) article.keywords = tags.join(", ");
+  if (row.published_at) article.datePublished = row.published_at;
+  if (row.updated_at) article.dateModified = row.updated_at;
+  const json = JSON.stringify(article).replaceAll("<", "\\u003c");
+  return `<script type="application/ld+json">${json}</script>`;
+}
+
 export function renderPublicMemoHtml(row: PublicMemoViewRow): string {
   const title = row.title ?? `Public Memo #${row.id}`;
   const appUrl = buildPublicMemoPageUrl(row.id);
   const jsonHref = escapeHtml(
     `?action=memo.public.view&id=${row.id}&format=json`,
   );
-  const body = `<article>
+  const body = `${renderPublicMemoArticleJsonLd(row)}
+<article>
 <h1>${escapeHtml(title)}</h1>
 <p>${escapeHtml(memoMetaLine(row))}</p>
 <div style="white-space:pre-wrap">${escapeHtml(row.content ?? "")}</div>

--- a/supabase/functions/core-hub/public_memo_view_test.ts
+++ b/supabase/functions/core-hub/public_memo_view_test.ts
@@ -12,6 +12,7 @@ import {
   normalizePublicMemoSearchQuery,
   publicMemoToPayload,
   type PublicMemoViewRow,
+  renderPublicMemoArticleJsonLd,
   renderPublicMemoHtml,
   renderPublicMemoListHtml,
   renderPublicMemoListMarkdown,
@@ -180,6 +181,39 @@ Deno.test("renderPublicMemoHtml embeds escaped content and OGP tags", () => {
     html,
     "?action=memo.public.view&amp;id=44&amp;format=json",
   );
+});
+
+Deno.test("renderPublicMemoArticleJsonLd emits valid escaped Article schema", () => {
+  const script = renderPublicMemoArticleJsonLd(
+    sampleRow({
+      content: "本文 </script><b>x</b>",
+      metadata: { tags: ["選挙"] },
+    }),
+  );
+  assertStringIncludes(script, '<script type="application/ld+json">');
+  // <script> ブレイクアウト防止: 生の </script> が本文由来で出てはいけない
+  assert(!script.slice(30).includes("</script><b>"));
+  const jsonText = script
+    .replace('<script type="application/ld+json">', "")
+    .replace("</script>", "")
+    .replaceAll("\\u003c", "<");
+  const parsed = JSON.parse(jsonText);
+  assertEquals(parsed["@type"], "Article");
+  assertEquals(parsed.headline, "地方議員データ更新メモ");
+  assertEquals(parsed.datePublished, "2026-07-01T09:30:00+09:00");
+  assertEquals(parsed.dateModified, "2026-07-02T10:00:00+09:00");
+  assertEquals(parsed.keywords, "選挙");
+  assertEquals(
+    parsed.mainEntityOfPage,
+    "https://my-web-app-b67f4.web.app/public-memo?id=44",
+  );
+  assertEquals(parsed.author.name, "自分株式会社");
+});
+
+Deno.test("renderPublicMemoHtml embeds the Article JSON-LD in body", () => {
+  const html = renderPublicMemoHtml(sampleRow());
+  assertStringIncludes(html, '"@type":"Article"');
+  assertStringIncludes(html, '<script type="application/ld+json">');
 });
 
 Deno.test("renderPublicMemoMarkdown carries title, meta, and body", () => {

--- a/web/index.html
+++ b/web/index.html
@@ -176,6 +176,40 @@
   }
   </script>
 
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://my-web-app-b67f4.web.app/#organization",
+        "name": "自分株式会社",
+        "alternateName": "Jibun Inc.",
+        "url": "https://my-web-app-b67f4.web.app/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://my-web-app-b67f4.web.app/ogp-image-gen2-20260428.png",
+          "width": 1200,
+          "height": 630
+        },
+        "sameAs": [
+          "https://x.com/kanta13jp1",
+          "https://github.com/kanta13jp1"
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://my-web-app-b67f4.web.app/#website",
+        "url": "https://my-web-app-b67f4.web.app/",
+        "name": "自分株式会社",
+        "alternateName": "Jibun Inc.",
+        "inLanguage": "ja",
+        "publisher": { "@id": "https://my-web-app-b67f4.web.app/#organization" }
+      }
+    ]
+  }
+  </script>
+
   <style>
     :root {
       color-scheme: light;
@@ -941,9 +975,16 @@
         );
         setMeta('og:url', window.location.href);
         setMeta('twitter:url', window.location.href);
+        setCanonical(window.location.href);
       }
 
       if ((path === '/public-memo' || path.endsWith('/public-memo')) && memoId) {
+        // 公開メモは一意な公開コンテンツ。canonical をトップ固定のままにすると
+        // 重複としてトップへ集約され独立インデックスされないため自URLへ。
+        setCanonical(
+          'https://my-web-app-b67f4.web.app/public-memo?id=' +
+            encodeURIComponent(memoId)
+        );
         fetch(SUPABASE_FUNC_BASE + '/get-public-memo-preview?id=' + encodeURIComponent(memoId))
           .then(function (res) { return res.json(); })
           .then(function (data) {


### PR DESCRIPTION
# Pull Request

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: static metadata / JSON-LD additions; SSR Article JSON-LD covered by deno unit tests (valid schema / script-breakout escape / date+keywords); index.html JSON-LD validated as parseable + inline JS syntax-checked; no UI route or app logic changed

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: additive SEO metadata only (JSON-LD + client-side canonical for already-public routes); no auth/billing/data-migration/DB change; sameAs/logo use verified handles only (no fabricated E-E-A-T); rollback = revert single commit; prod smoke = existing public-memo-smoke.yml still green; observability via existing EF logs

## 📝 変更内容

SEO監査 (10仮説検証ワークフロー) の結果に基づく quick-win 群。戦略判断に依存しない低リスク metadata 強化のみを本PRに含める。

### 変更の種類

- [x] 新機能 (breaking changeを含まない機能追加)

## 🎯 変更の目的

サイト全体のインデックス性・E-E-A-T シグナルを、アーキ変更なしで底上げする。

## 📋 実装の詳細

1. **Organization + WebSite JSON-LD** — `web/index.html` の `<head>` に `@graph` で静的追加。全1990ページに波及。`sameAs` は検証済みハンドルのみ (X `@kanta13jp1` / GitHub `kanta13jp1`)、`logo`/`url` 明示。運営者名は確認できなかったため捏造せず未記載。
2. **公開ルートの canonical 修正** — `/public-memo?id=X` と `/public/local-election-700` は meta を更新しながら canonical がトップ固定のまま (バグ) → 自URLへ。一意な公開コンテンツがトップへ重複集約されるのを防止。
3. **SSR Article JSON-LD** — `core-hub` の `renderPublicMemoHtml` に Article 構造化データを注入。非JSクローラー/LLM/検索に公開メモを記事として認識させる。`<script>` ブレイクアウトは `<`→`<` エスケープで防止。

## ✅ テスト結果

| テストケース | 結果 | 備考 |
| --- | --- | --- |
| `public_memo_view_test.ts` 18件 (Article schema妥当性 / script-breakout / date+keywords / 埋込確認 追加) | ✅ | deno test 全パス |
| `deno lint` / `deno fmt` / `deno check` | ✅ | 0 エラー |
| index.html JSON-LD 3ブロック parse + インラインJS 2ブロック node --check | ✅ | 全OK |

## 🚨 Breaking Changes

- [x] このPRにはBreaking Changesが含まれていません (metadata 追加とフィールド追加のみ)

## 📊 パフォーマンスへの影響

- [x] パフォーマンスへの影響はありません

## 🔒 セキュリティへの影響

- [x] セキュリティへの影響はありません (公開済みデータのみ。E-E-A-T は検証済み情報のみで捏造なし)

## 📚 ドキュメント更新

- [x] ドキュメント更新は不要

## ✅ チェックリスト

### コード品質

- [x] `deno lint` 0エラーを確認しました（Edge Function変更時は必須 — CIゲート）
- [x] ダミーデータを使用していません（Supabase実データのみ）
- [x] 不要なコメントや console.log を削除しました
- [x] コードレビューを受ける準備ができています（Claude Agent が自動レビューします）

### Rule / Script / Hook wiring 同期（追加時のみ — part 185 finding）

- [x] 該当なし（rule / script / hook 追加・変更なし）

### テスト

- [x] 新しいコードにテストを追加しました
- [x] すべてのテストが通ることを確認しました
- [x] エッジケースを考慮しました

### セキュリティ

- [x] 機密情報がコミットされていないことを確認しました
- [x] 入力値の検証を適切に実装しました
- [x] セキュリティベストプラクティスに従っています

### その他

- [x] Breaking Changesがないことを確認しました
- [x] パフォーマンスへの悪影響がないことを確認しました

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc)_