### PR TITLE
feat(admin): R18 X-perf recency filter + dashboard truth fixes

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -92,6 +92,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   Map<String, dynamic>? _xPerformanceContext;
   bool _isLoading = true;
   WeeklyDigestSnapshot _weeklyDigest = const WeeklyDigestSnapshot.empty();
+  // R18: fetch 完了フラグ。empty() のままか、完了して空かを区別し、静かに失敗/空の
+  // 週を無限「読み込み中」ではなく正直な「計測待ち」に落とす。
+  bool _weeklyDigestLoaded = false;
   late final SupabaseClient _supabase;
   final _growthService = const GrowthMissionService();
   List<Map<String, dynamic>> _featureRequests = [];
@@ -747,9 +750,15 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     try {
       final digest = await _growthService.loadWeeklyDigest();
       if (!mounted) return;
-      if (mounted) setState(() => _weeklyDigest = digest);
+      // R18: 完了フラグを立てて loading と loaded-empty を区別する
+      // (loadWeeklyDigest は内部で握りつぶし empty() を返すため rethrow しない)。
+      setState(() {
+        _weeklyDigest = digest;
+        _weeklyDigestLoaded = true;
+      });
     } catch (e) {
       debugPrint('weekly digest load error: $e');
+      if (mounted) setState(() => _weeklyDigestLoaded = true);
     }
   }
 
@@ -1608,6 +1617,12 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
         : 0;
     final zeroRegistrationStreakDays =
         _countConsecutiveNoRegistrationDays(_dailyStats);
+    // R18: streak が集計窓(_dailyStats)を使い切っていると値は下限。実際はそれ以上
+    // なので「N日以上」と正直に出す(30 をちょうどの安心値に見せない)。
+    final zeroStreakAtCap = streakAtWindowCap(
+      zeroRegistrationStreakDays,
+      _dailyStats.length,
+    );
     final averageViewsLast7Days = _averageViews(_dailyStats);
 
     return Scaffold(
@@ -1759,6 +1774,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                       todayDropBeforeTrial: todayDropBeforeTrial,
                       totalDropBeforeTrial: totalDropBeforeTrial,
                       zeroRegistrationStreakDays: zeroRegistrationStreakDays,
+                      zeroStreakAtCap: zeroStreakAtCap,
                       averageViewsLast7Days: averageViewsLast7Days,
                       totalTrialRate: _formatRate(
                         totalFunnel.trialRuns,
@@ -2666,12 +2682,16 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     required int todayDropBeforeTrial,
     required int totalDropBeforeTrial,
     required int zeroRegistrationStreakDays,
+    required bool zeroStreakAtCap,
     required double averageViewsLast7Days,
     required String totalTrialRate,
     required String? registrationsPerLpView,
   }) {
+    // R18: 集計窓を使い切っていたら「N日以上」(実際はそれ以上)と正直に。
+    final streakLabel =
+        '$zeroRegistrationStreakDays日${zeroStreakAtCap ? '以上' : ''}';
     final alertText = zeroRegistrationStreakDays >= 3
-        ? '登録ゼロが$zeroRegistrationStreakDays日連続です。流入ではなく、体験開始と認証前の離脱を最優先で潰してください。'
+        ? '登録ゼロが$streakLabel連続です。流入ではなく、体験開始と認証前の離脱を最優先で潰してください。'
         : todayDropBeforeTrial > 0
             ? '今日は流入がありますが、体験前に$todayDropBeforeTrial件が離脱しています。無料体験の訴求を最優先で確認してください。'
             : '直近の登録導線は動いています。次は送信後の完了率を維持できているかを確認してください。';
@@ -2719,7 +2739,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                 ),
                 _buildMiniKpiChip(
                   label: '連続登録ゼロ日',
-                  value: '$zeroRegistrationStreakDays日',
+                  value: streakLabel,
                   color: const Color(0xFFB91C1C),
                 ),
                 _buildMiniKpiChip(
@@ -3393,6 +3413,17 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   Widget _buildWeeklyDigestCard(BuildContext context) {
     final d = _weeklyDigest;
     final hasData = d.currentWeekStart.isNotEmpty;
+    // R18: loading / loaded-empty / loaded-data の3状態に分けてヘッダ文言を決める。
+    final cardState = weeklyDigestCardState(
+      loaded: _weeklyDigestLoaded,
+      hasData: hasData,
+    );
+    final headerText = switch (cardState) {
+      WeeklyDigestCardState.loading => '読み込み中...',
+      WeeklyDigestCardState.empty => '今週はまだ計測データがありません（計測待ち）',
+      WeeklyDigestCardState.data =>
+        '${d.currentWeekStart} 〜 ${d.currentWeekEnd}',
+    };
 
     return Container(
       padding: const EdgeInsets.all(16),
@@ -3410,9 +3441,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  hasData
-                      ? '${d.currentWeekStart} 〜 ${d.currentWeekEnd}'
-                      : '読み込み中...',
+                  headerText,
                   style: const TextStyle(
                     fontSize: 13,
                     fontWeight: FontWeight.w700,

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -72,9 +72,34 @@ int distinctMeasuredVariants(List<dynamic>? variants) {
   final seen = <String>{};
   for (final entry in variants) {
     if (entry is! Map) continue;
-    final name = (entry['variant'] ?? '').toString().trim();
+    var name = (entry['variant'] ?? '').toString().trim();
     if (name.isEmpty || name == 'unknown') continue;
+    // R18: `${variant}_fallback`(定型フォールバックの劣化版)は base variant と
+    // 同一戦略なので base に畳んで数える。daily_briefing + daily_briefing_fallback
+    // を2種と誤認して「勝ち型」を false-unlock しない(実データはまだ1戦略のみ)。
+    if (name.endsWith('_fallback')) {
+      name = name.substring(0, name.length - '_fallback'.length);
+    }
+    if (name.isEmpty) continue;
     seen.add(name);
   }
   return seen.length;
+}
+
+/// R18: 週次ダイジェストカードの3状態。fetch 完了(loaded)とデータ有無(hasData)を
+/// 分離し、静かに失敗/空の週を無限「読み込み中」ではなく正直な「計測待ち」にする。
+enum WeeklyDigestCardState { loading, empty, data }
+
+WeeklyDigestCardState weeklyDigestCardState({
+  required bool loaded,
+  required bool hasData,
+}) {
+  if (!loaded) return WeeklyDigestCardState.loading;
+  return hasData ? WeeklyDigestCardState.data : WeeklyDigestCardState.empty;
+}
+
+/// R18: 連続登録ゼロ日が集計窓(30日)を使い切っているか。true のとき値は下限で、
+/// 実際はそれ以上の可能性があるため「N日以上」と正直に表示する。
+bool streakAtWindowCap(int streak, int windowLen) {
+  return streak > 0 && windowLen > 0 && streak >= windowLen;
 }

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -29,7 +29,10 @@ import {
   isRecentSignupCreatedAt,
   resolveSignupChannel,
 } from "./signup_notification.ts";
-import { filterRecentLogs } from "./metrics_window.ts";
+import {
+  filterCurrentStrategyLogs,
+  filterRecentLogs,
+} from "./metrics_window.ts";
 import { decideXPostPreflight } from "./x_post_preflight.ts";
 import { computeTodayStatus } from "./x_today_status.ts";
 import { buildMediaLiftLine, classifyPostMediaType } from "./x_media_type.ts";
@@ -578,7 +581,27 @@ function compactPostText(value: unknown): string {
 }
 
 function buildXPerformanceContextFromLogs(logs: XPostLogItem[]) {
-  const rows = logs
+  // R18: 学習(勝ち型/winner exemplar/生成プロンプトの Top hook)を「現行コピー
+  // 戦略」の投稿だけで測る。旧フォーマット(誤年 2024 の「デイリーブリーフィング —
+  // 日付 朝」)の高スコア旧投稿が勝ち型を占拠し廃止スタイルを再教育する実障害
+  // (2026-07-09)への対策。epoch 既定 2026-07-05 = 実日付注入/コピーリセット着地日。
+  // フィルタで全滅したら未フィルタへ fallback(データを絶対に隠さない)。両 knob は env。
+  const windowDays = Number(Deno.env.get("X_PERF_LEARN_WINDOW_DAYS") ?? "28");
+  const epochMs = Date.parse(
+    Deno.env.get("X_PERF_STRATEGY_EPOCH") ?? "2026-07-05",
+  );
+  const strategyLogs = filterCurrentStrategyLogs(
+    logs,
+    {
+      windowDays: Number.isFinite(windowDays) && windowDays > 0
+        ? windowDays
+        : 28,
+      epochMs,
+    },
+    Date.now(),
+  );
+  const effectiveLogs = strategyLogs.length > 0 ? strategyLogs : logs;
+  const rows = effectiveLogs
     .map((item) => {
       const metadata = asRecord(item.metadata);
       const latest = asRecord(metadata.latest_metrics);

--- a/supabase/functions/growth-hub/metrics_window.test.ts
+++ b/supabase/functions/growth-hub/metrics_window.test.ts
@@ -2,7 +2,10 @@ import {
   assert,
   assertEquals,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { filterRecentLogs } from "./metrics_window.ts";
+import {
+  filterCurrentStrategyLogs,
+  filterRecentLogs,
+} from "./metrics_window.ts";
 
 const NOW = Date.parse("2026-07-07T00:00:00Z");
 const DAY = 86_400_000;
@@ -41,4 +44,65 @@ Deno.test("filterRecentLogs fail-opens on unparsable created_at", () => {
     metadata: { metrics_checked_at: "2026-07-01T00:00:00Z" },
   };
   assert(filterRecentLogs([broken], 7, NOW).length === 1);
+});
+
+// R18: filterCurrentStrategyLogs — 現行コピー戦略窓で学習を測る。
+const R18_NOW = Date.parse("2026-07-09T02:00:00Z");
+const EPOCH = Date.parse("2026-07-05");
+
+function logAt(iso: string): {
+  id: string;
+  created_at: string;
+  metadata: Record<string, unknown>;
+} {
+  return { id: iso, created_at: iso, metadata: {} };
+}
+
+Deno.test("filterCurrentStrategyLogs excludes pre-epoch old-format posts", () => {
+  const rows = [logAt("2026-07-02T00:00:00Z")]; // epoch より前
+  assertEquals(
+    filterCurrentStrategyLogs(rows, { windowDays: 28, epochMs: EPOCH }, R18_NOW)
+      .length,
+    0,
+  );
+});
+
+Deno.test("filterCurrentStrategyLogs keeps a within-window current post", () => {
+  const rows = [logAt("2026-07-08T00:00:00Z")];
+  assertEquals(
+    filterCurrentStrategyLogs(rows, { windowDays: 28, epochMs: EPOCH }, R18_NOW)
+      .length,
+    1,
+  );
+});
+
+Deno.test("filterCurrentStrategyLogs fail-opens on unparsable created_at", () => {
+  const broken = { id: "b", created_at: "not-a-date", metadata: {} };
+  assertEquals(
+    filterCurrentStrategyLogs(
+      [broken],
+      { windowDays: 28, epochMs: EPOCH },
+      R18_NOW,
+    ).length,
+    1,
+  );
+});
+
+Deno.test("filterCurrentStrategyLogs windowDays tightens beyond epoch", () => {
+  // epoch は古いが window 3 日なら 07-06 より前は落とす。
+  const rows = [logAt("2026-07-05T12:00:00Z"), logAt("2026-07-08T00:00:00Z")];
+  assertEquals(
+    filterCurrentStrategyLogs(rows, { windowDays: 3, epochMs: EPOCH }, R18_NOW)
+      .length,
+    1,
+  );
+});
+
+Deno.test("filterCurrentStrategyLogs falls back to windowDays when epoch NaN", () => {
+  const rows = [logAt("2026-07-08T00:00:00Z")];
+  assertEquals(
+    filterCurrentStrategyLogs(rows, { windowDays: 28, epochMs: NaN }, R18_NOW)
+      .length,
+    1,
+  );
 });

--- a/supabase/functions/growth-hub/metrics_window.ts
+++ b/supabase/functions/growth-hub/metrics_window.ts
@@ -36,3 +36,34 @@ export function filterRecentLogs<T extends MetricsWindowLog>(
     return nowMs - createdMs <= windowMs; // (a) 鮮度窓
   });
 }
+
+// R18: X パフォーマンス学習(勝ち型ランキング/winner exemplar/生成プロンプトの
+// 「Top hook to emulate」)を「現行コピー戦略」の投稿だけで測るためのフィルタ。
+//
+// なぜ必要か: buildXPerformanceContextFromLogs は score 降順の winners[0] を
+// verbatim で生成プロンプトへ注入する。recency フィルタが無いと、R11-R15 で
+// 廃止した旧フォーマット(誤年 2024 の「デイリーブリーフィング — 日付 朝」)の
+// 高スコア旧投稿が「勝ち型」を占拠し、廃止済みスタイルを毎回再教育してしまう
+// (実障害 2026-07-09 観測: 真似る型に 2024/07/05 の旧投稿)。
+//
+// filterRecentLogs とは別関数にする理由: あちらは (c) 未計測レスキューで古い
+// 未計測行を保持する = ランキングに旧投稿を再流入させてしまうため不可。
+//
+// 保持条件: created_at が max(now-windowDays, epochMs) 以降。境界:
+//   - created_at がパース不能/不在 → 保持(fail-open — 壊れた行で学習を落とさない)
+//   - epochMs が NaN(env 未設定/不正) → windowDays のみで判定
+export function filterCurrentStrategyLogs<T extends MetricsWindowLog>(
+  logs: T[],
+  options: { windowDays: number; epochMs: number },
+  nowMs: number,
+): T[] {
+  const windowStartMs = nowMs - options.windowDays * 86_400_000;
+  const cutoffMs = Number.isFinite(options.epochMs)
+    ? Math.max(windowStartMs, options.epochMs)
+    : windowStartMs;
+  return logs.filter((log) => {
+    const createdMs = Date.parse(String(log.created_at ?? ""));
+    if (!Number.isFinite(createdMs)) return true; // fail-open
+    return createdMs >= cutoffMs;
+  });
+}

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -72,4 +72,65 @@ void main() {
       expect(distinctMeasuredVariants(null), 0);
     });
   });
+
+  group('R18 distinctMeasuredVariants folds _fallback into base', () {
+    test('base + its fallback count as 1 (no false 勝ち型 unlock)', () {
+      final variants = [
+        {'variant': 'daily_briefing', 'averageScore': 124, 'count': 8},
+        {'variant': 'daily_briefing_fallback', 'averageScore': 94, 'count': 1},
+      ];
+      expect(distinctMeasuredVariants(variants), 1);
+    });
+
+    test('two distinct bases each with a fallback count as 2', () {
+      final variants = [
+        {'variant': 'daily_briefing', 'count': 4},
+        {'variant': 'daily_briefing_fallback', 'count': 1},
+        {'variant': 'question_post', 'count': 2},
+        {'variant': 'question_post_fallback', 'count': 1},
+      ];
+      expect(distinctMeasuredVariants(variants), 2);
+    });
+
+    test('bare _fallback and unknown excluded', () {
+      final variants = [
+        {'variant': '_fallback', 'count': 1},
+        {'variant': 'unknown', 'count': 3},
+      ];
+      expect(distinctMeasuredVariants(variants), 0);
+    });
+  });
+
+  group('R18 weeklyDigestCardState', () {
+    test('not loaded → loading', () {
+      expect(
+        weeklyDigestCardState(loaded: false, hasData: false),
+        WeeklyDigestCardState.loading,
+      );
+    });
+    test('loaded but no data → empty (not infinite spinner)', () {
+      expect(
+        weeklyDigestCardState(loaded: true, hasData: false),
+        WeeklyDigestCardState.empty,
+      );
+    });
+    test('loaded with data → data', () {
+      expect(
+        weeklyDigestCardState(loaded: true, hasData: true),
+        WeeklyDigestCardState.data,
+      );
+    });
+  });
+
+  group('R18 streakAtWindowCap', () {
+    test('streak below window → false', () {
+      expect(streakAtWindowCap(12, 30), isFalse);
+    });
+    test('streak saturates window → true (show N日以上)', () {
+      expect(streakAtWindowCap(30, 30), isTrue);
+    });
+    test('zero streak → false', () {
+      expect(streakAtWindowCap(0, 30), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## R18: dashboard tells the truth + stops re-teaching retired copy (X-perf recency + tri-state fixes)

Third round on /admin after R16 (posted-today loop) + R17 (n=0 「—」 + X成長ループ panel). Fresh prod screenshots showed the R17 panel is live but its **勝ち型 / 真似る型 was a stale pre-reset post** (「デイリーブリーフィング — 2024/07/05 朝…」, the wrong-year 2024 + old label format that R11–R15 retired). A 12-hypothesis adversarial workflow (11 survived) ranked the fixes. Critically, `winners[0].text` is injected verbatim as the "Top hook to emulate" line into **every future X-generation prompt** — so the stale exemplar was actively re-teaching the old copy style, not just a cosmetic dashboard bug.

### Lever 1 — X-perf recency/epoch filter (root fix; reaches panel AND generator)
`buildXPerformanceContextFromLogs` had no recency filter — a high-score OLD post dominated the ranking, the winner exemplar, and the generation prompt. New pure `filterCurrentStrategyLogs(logs, {windowDays, epochMs}, nowMs)` in `metrics_window.ts` keeps only posts with `created_at >= max(now-windowDays, epochMs)`; fail-open on unparsable dates; the caller falls back to the unfiltered set when the filtered set is empty (never hides the founder's only data). Env-tunable: `X_PERF_LEARN_WINDOW_DAYS` (default 28), `X_PERF_STRATEGY_EPOCH` (default 2026-07-05, the real-date-injection / copy-reset landing). A separate function from `filterRecentLogs` because that one rescues old un-measured rows (correct for metrics collection, wrong for ranking).

### Lever 2 — collapse `${variant}_fallback` into its base family
`distinctMeasuredVariants` counted `daily_briefing` + `daily_briefing_fallback` as two variants, false-unlocking a 「勝ち型」 from what is really one strategy plus its degraded template. Now folds `_fallback` into the base → the panel honestly stays in 「学習サンプル蓄積中」 until a genuinely different variant (question_post / useful_reply) runs.

### Lever 3 — weekly-digest tri-state (kill the infinite spinner)
The 週次ダイジェスト card was stuck on 「読み込み中...」 forever because it couldn't distinguish loading from loaded-empty (the service swallows errors and returns an empty snapshot). New pure `weeklyDigestCardState(loaded, hasData)` + a `_weeklyDigestLoaded` flag → a quiet/failed week now reads 「今週はまだ計測データがありません（計測待ち）」.

### Lever 4 — zero-registration streak honesty
「連続登録ゼロ日 30日」 was clamped at the 30-day window but read as exactly 30. Pure `streakAtWindowCap(streak, windowLen)` → renders 「30日以上」 / 「登録ゼロが30日以上連続です」 when the drought saturates the window.

Pure logic extracted to `admin_dashboard_signals.dart` + `metrics_window.ts` (VM/Deno-testable). `deno test` 9 green, `flutter test` 18 green, analyze clean, format fixpoint. Additive/default-safe: filter falls back to unfiltered, both dashboard fetches degrade to null → panel hidden, dashboard renders unchanged if anything fails.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno unit tests over the pure recency filter + Dart unit tests over the pure dashboard resolvers; analytics-display + prompt-input change, no user-facing route flow

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: R18 X-perf learning recency filter: additive pure filterCurrentStrategyLogs + env-tunable window/epoch in a read-only analytics aggregation; fail-open on bad dates, falls back to unfiltered when empty; no write path, no credential change; rollback is a one-commit revert
