### PR TITLE
fix(seo): trailingSlash=false so /vs-<slug> serves prerendered HTML at 200

### DIFF
--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -15,12 +15,6 @@ on:
   # push トリガーは使わない — main push 直後は deploy-prod 完了前で誤検知するため。
   schedule:
     - cron: "7 21 * * *" # 毎日 06:07 JST
-  # 一時: PR #3899 (prerender) デプロイ後の実機検証用 (branch 限定 / 検証後に削除)
-  push:
-    branches:
-      - claude/page-accessibility-memo-qb499c
-    paths:
-      - ".github/workflows/public-memo-smoke.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -15,6 +15,12 @@ on:
   # push トリガーは使わない — main push 直後は deploy-prod 完了前で誤検知するため。
   schedule:
     - cron: "7 21 * * *" # 毎日 06:07 JST
+  # 一時: PR #3899 (prerender) デプロイ後の実機検証用 (branch 限定 / 検証後に削除)
+  push:
+    branches:
+      - claude/page-accessibility-memo-qb499c
+    paths:
+      - ".github/workflows/public-memo-smoke.yml"
 
 permissions:
   contents: read
@@ -92,6 +98,12 @@ jobs:
           # AI フェッチャー救済: text/plain 版と HTML エンティティ化け URL (&amp;)
           check "view txt"         "$BASE?action=memo.public.view&id=$MEMO_ID&format=txt" "200" "App URL:"
           check "amp-mangled rescue" "$BASE?action=memo.public.view&amp;id=$MEMO_ID&amp;format=json" "200" "\"appUrl\""
+
+          # PR #3899: prerender 済み /vs-<slug> が固有本文 + 自己参照 canonical で
+          # 配信されること (SPA シェルではなく静的HTMLが Firebase 優先配信される)。
+          VS="https://my-web-app-b67f4.web.app/vs-notion"
+          check "prerender vs-notion body"      "$VS" "200" "data-prerender=\"vs-body\""
+          check "prerender vs-notion canonical" "$VS" "200" "href=\"https://my-web-app-b67f4.web.app/vs-notion\""
 
           exit "$FAIL"
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "hosting": {
     "public": "build/web",
+    "trailingSlash": false,
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
# Pull Request

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Firebase hosting config (trailingSlash) + CI smoke check only; verified by deploy log (prerendered 30 /vs-* live) and public-memo-smoke.yml が /vs-notion の 200 + prerender本文 + 自己参照canonical を実機検証; no app code changed

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: firebase.json adds trailingSlash=false only (directory-index static files served without trailing slash); SPA ** rewrite unaffected (non-directory routes); no auth/billing/data-migration/secret change; rollback = revert single commit; prod smoke = public-memo-smoke.yml /vs-notion check after deploy; observability via deploy-prod logs

## 📝 変更内容

PR #3899 の prerender デプロイ検証で判明した URL 不整合の修正。

### 変更の種類

- [x] バグ修正 (breaking changeを含まないバグ修正)

## 🎯 変更の目的

Firebase Hosting は `vs-notion/index.html` を `/vs-notion/`(末尾スラッシュ)で配信し、`/vs-notion` → **301 → `/vs-notion/`** とリダイレクトしていた。sitemap と canonical は `/vs-notion`(スラッシュなし)のため URL 不整合となり SEO 品質を毀損する。

## 📋 実装の詳細

- **`firebase.json`** に `"trailingSlash": false` を追加。`/vs-<slug>` を末尾スラッシュなしで直接 **200 配信**し、canonical/sitemap/内部リンク(全て `/vs-notion` 規約)と一致させる。SPA rewrite (`** → /index.html`) は非ディレクトリのため無影響。
- **`public-memo-smoke.yml`** に `/vs-notion` の prerender 実機チェック(200 + `data-prerender="vs-body"` + 自己参照 canonical)を日次回帰として追加。

## ✅ テスト結果

| 項目 | 結果 | 備考 |
| --- | --- | --- |
| PR #3899 デプロイログ: `prerendered 30 /vs-* routes` / `Deploy verified: live` | ✅ | prerender は本番稼働済 |
| 検証 smoke: `/vs-notion` が **301 → /vs-notion/** を返すことを検出 | ✅ 検出 | 本PRで解消する不整合 |
| firebase.json valid JSON / smoke YAML valid | ✅ | ローカル検証 |

マージ・デプロイ後、`/vs-notion` が 200 で prerender 本文を直接配信することを smoke で再確認する。

## 🚨 Breaking Changes

- [x] このPRにはBreaking Changesが含まれていません (末尾スラッシュ正規化のみ)

## 📊 パフォーマンスへの影響

- [x] パフォーマンスへの影響はありません

## 🔒 セキュリティへの影響

- [x] セキュリティへの影響はありません (hosting のURL正規化設定のみ)

## 📚 ドキュメント更新

- [x] ドキュメント更新は不要

## 🚀 デプロイメモ

- [x] 特別なデプロイ手順は不要 (main マージ → deploy-prod で反映)

## ✅ チェックリスト

### コード品質

- [x] 不要なコメントや console.log を削除しました
- [x] コードレビューを受ける準備ができています（Claude Agent が自動レビューします）

### Rule / Script / Hook wiring 同期（追加時のみ — part 185 finding）

- [x] 該当なし（rule / script / hook 追加・変更なし）

### セキュリティ

- [x] 機密情報がコミットされていないことを確認しました

### その他

- [x] Breaking Changesがないことを確認しました
- [x] パフォーマンスへの悪影響がないことを確認しました

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc)_