### PR TITLE
fix(admin): R19 登録ユーザー管理 all-blank rows (key mismatch + fabrication removal)

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -3705,32 +3705,22 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   }
 
   Widget _buildProfileCompletionSummary() {
-    final complete =
-        _adminUsers.where((u) => _toInt(u['completionPct']) >= 67).length;
-    final partial = _adminUsers.where((u) {
-      final pct = _toInt(u['completionPct']);
-      return pct >= 34 && pct < 67;
-    }).length;
-    final empty =
-        _adminUsers.where((u) => _toInt(u['completionPct']) < 34).length;
+    // R19: 旧サマリは未fetch の completionPct(全員0)で「0完成/0途中/44未設定」を
+    // 捏造していた。email 空=匿名 auth を信頼プロキシに「実ユーザー/匿名テスト」へ
+    // 誠実に分割する(合計44 vs 実CVR4 の乖離=匿名を実登録と誤認する虚栄を防ぐ)。
+    final split = summarizeAdminUsers(_adminUsers);
     return Row(
       children: [
         _profileStatChip(
-          Icons.check_circle,
-          '$complete 完成',
+          Icons.verified_user_outlined,
+          '実ユーザー ${split.real}人',
           const Color(0xFF0D9488),
         ),
         const SizedBox(width: 8),
         _profileStatChip(
-          Icons.pending,
-          '$partial 途中',
-          const Color(0xFFFF6B35),
-        ),
-        const SizedBox(width: 8),
-        _profileStatChip(
-          Icons.warning_amber,
-          '$empty 未設定',
-          const Color(0xFFB91C1C),
+          Icons.help_outline,
+          '匿名テスト ${split.anon}人',
+          const Color(0xFF9CA3AF),
         ),
       ],
     );
@@ -3770,7 +3760,11 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    '登録ユーザー管理 (合計 $_adminUsersTotal 人)',
+                    _adminUsers.isEmpty
+                        ? '登録ユーザー管理 (合計 $_adminUsersTotal 人)'
+                        : '登録ユーザー管理 (合計 $_adminUsersTotal 人 / '
+                            '実 ${summarizeAdminUsers(_adminUsers).real}・'
+                            '匿名 ${summarizeAdminUsers(_adminUsers).anon})',
                     style: const TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.bold,
@@ -3871,13 +3865,17 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                       final bio = user['bio']?.toString();
                       final location = user['location']?.toString();
                       final provider = user['provider']?.toString() ?? 'email';
-                      final createdAt = user['createdAt']?.toString() ?? '';
+                      // R19: edge は created_at(snake)を返すのに旧UIは createdAt
+                      // (camel)を読み全行の登録日が空だった。snake 優先で吸収する。
+                      final createdAt = adminUserCreatedRaw(user);
                       final lastSignIn = user['lastSignInAt']?.toString() ?? '';
-                      final hasProfile = user['hasProfile'] as bool? ?? false;
-                      final completionPct = _toInt(user['completionPct']);
+                      // R19: email 空 = Supabase 匿名 auth(headless 検証)の信頼プロキシ。
+                      final isAnonymous = adminUserIsAnonymous(user);
 
-                      String createdStr = '';
-                      String lastSignInStr = '';
+                      // R19: 登録日=parse 不可なら「日付なし」、最終ログインは edge が
+                      // 未送出のため「ログイン記録なし」と正直に出す(空欄で誤魔化さない)。
+                      String createdStr = '日付なし';
+                      String lastSignInStr = 'ログイン記録なし';
                       try {
                         createdStr = DateFormat('yyyy/MM/dd').format(
                           DateTime.parse(createdAt).toLocal(),
@@ -3892,15 +3890,6 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                       final isGoogle = provider.contains('google');
                       final isDark =
                           Theme.of(context).brightness == Brightness.dark;
-
-                      Color profileColor;
-                      if (!hasProfile || completionPct < 34) {
-                        profileColor = const Color(0xFFB91C1C);
-                      } else if (completionPct < 67) {
-                        profileColor = const Color(0xFFFF6B35);
-                      } else {
-                        profileColor = const Color(0xFF0D9488);
-                      }
 
                       return Padding(
                         padding: const EdgeInsets.symmetric(vertical: 6),
@@ -3917,7 +3906,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                                       ? const Color(0xFF1A1E3A)
                                       : const Color(0xFFE8EAF6)),
                               child: Text(
-                                email.isNotEmpty ? email[0].toUpperCase() : '?',
+                                email.isNotEmpty
+                                    ? email[0].toUpperCase()
+                                    : (isAnonymous ? '匿' : '?'),
                                 style: TextStyle(
                                   fontSize: 14,
                                   fontWeight: FontWeight.bold,
@@ -3940,7 +3931,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                                           displayName != null &&
                                                   displayName.isNotEmpty
                                               ? displayName
-                                              : email,
+                                              : (email.isNotEmpty
+                                                  ? email
+                                                  : '匿名ユーザー'),
                                           style: const TextStyle(
                                             fontSize: 13,
                                             fontWeight: FontWeight.w600,
@@ -3965,7 +3958,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                                               BorderRadius.circular(6),
                                         ),
                                         child: Text(
-                                          isGoogle ? 'Google' : 'Email',
+                                          isGoogle
+                                              ? 'Google'
+                                              : (isAnonymous ? '匿名' : 'Email'),
                                           style: TextStyle(
                                             fontSize: 10,
                                             fontWeight: FontWeight.w600,
@@ -4020,32 +4015,22 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                                       ],
                                     ),
                                   const SizedBox(height: 4),
-                                  Row(
+                                  // R19: completionPct は users.list が未送出で常に0。
+                                  // 「プロフィール 0%」バーは捏造なので出さず、未取得を
+                                  // 正直に表示する(R17 の display-truthfulness 規律)。
+                                  const Row(
                                     children: [
-                                      Expanded(
-                                        child: ClipRRect(
-                                          borderRadius:
-                                              BorderRadius.circular(4),
-                                          child: LinearProgressIndicator(
-                                            value: completionPct / 100,
-                                            minHeight: 4,
-                                            backgroundColor: Theme.of(context)
-                                                .colorScheme
-                                                .surfaceContainerHighest,
-                                            valueColor:
-                                                AlwaysStoppedAnimation<Color>(
-                                              profileColor,
-                                            ),
-                                          ),
-                                        ),
+                                      Icon(
+                                        Icons.info_outline,
+                                        size: 11,
+                                        color: Color(0xFF9CA3AF),
                                       ),
-                                      const SizedBox(width: 6),
+                                      SizedBox(width: 4),
                                       Text(
-                                        'プロフィール $completionPct%',
+                                        'プロフィール情報 未取得',
                                         style: TextStyle(
                                           fontSize: 10,
-                                          color: profileColor,
-                                          fontWeight: FontWeight.w600,
+                                          color: Color(0xFF9CA3AF),
                                           height: 1.5,
                                         ),
                                       ),
@@ -4131,7 +4116,8 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     final hasProfile = user['hasProfile'] as bool? ?? false;
     final provider = user['provider']?.toString() ?? 'email';
     final isGoogle = provider.contains('google');
-    final createdAt = user['createdAt']?.toString() ?? '';
+    // R19: 行と同じ契約バグ。edge の created_at(snake)を優先で拾う。
+    final createdAt = adminUserCreatedRaw(user);
     final lastSignIn = user['lastSignInAt']?.toString() ?? '';
 
     String createdStr = '';

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -103,3 +103,34 @@ WeeklyDigestCardState weeklyDigestCardState({
 bool streakAtWindowCap(int streak, int windowLen) {
   return streak > 0 && windowLen > 0 && streak >= windowLen;
 }
+
+// R19: 登録ユーザー管理カードの契約バグ+捏造を吸収する純ロジック。
+// admin-hub users.list は {id, email, created_at(snake)} しか返さないのに、UI は
+// camelCase createdAt / 未送出の completionPct・lastSignInAt を読んで「登録日空」
+// 「プロフィール 0%」を捏造していた。ここで snake 優先のキー吸収と、email 空を
+// Supabase 匿名 auth の信頼プロキシとした実/匿名判定を提供する。
+
+/// email が空 = Supabase 匿名 auth ユーザー(headless 検証用 anon-signup)の信頼
+/// プロキシ。実ユーザー(実登録)と匿名テストを区別する。
+bool adminUserIsAnonymous(Map<String, dynamic> user) {
+  return (user['email'] ?? '').toString().trim().isEmpty;
+}
+
+/// 登録日時の生文字列を取り出す。edge の created_at(snake)を優先し、旧 UI が
+/// 読んでいた createdAt(camel)へ後方互換フォールバックする(R19 契約バグ修正)。
+String adminUserCreatedRaw(Map<String, dynamic> user) {
+  final snake = (user['created_at'] ?? '').toString().trim();
+  if (snake.isNotEmpty) return snake;
+  return (user['createdAt'] ?? '').toString().trim();
+}
+
+/// 登録ユーザー一覧を「実ユーザー / 匿名テスト」に分割して数える。捏造の
+/// completionPct(全員0)で bucket 化していた旧サマリの置き換え(合計44 vs 実CVR4
+/// の乖離=匿名を実ユーザーと誤認する虚栄を防ぐ)。
+({int real, int anon}) summarizeAdminUsers(List<Map<String, dynamic>> users) {
+  var anon = 0;
+  for (final user in users) {
+    if (adminUserIsAnonymous(user)) anon += 1;
+  }
+  return (real: users.length - anon, anon: anon);
+}

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -133,4 +133,41 @@ void main() {
       expect(streakAtWindowCap(0, 30), isFalse);
     });
   });
+
+  group('R19 admin user list (contract bug + fabrication)', () {
+    test('adminUserIsAnonymous: empty email = anonymous auth', () {
+      expect(adminUserIsAnonymous({'email': ''}), isTrue);
+      expect(adminUserIsAnonymous({'email': '  '}), isTrue);
+      expect(adminUserIsAnonymous(<String, dynamic>{}), isTrue);
+      expect(adminUserIsAnonymous({'email': 'a@b.com'}), isFalse);
+    });
+
+    test('adminUserCreatedRaw: snake created_at preferred, camel fallback', () {
+      // edge が返す snake が優先される(契約バグの本丸)。
+      expect(
+        adminUserCreatedRaw({'created_at': '2026-07-01T00:00:00Z'}),
+        '2026-07-01T00:00:00Z',
+      );
+      // 旧 UI の camel も後方互換で拾う。
+      expect(
+        adminUserCreatedRaw({'createdAt': '2026-07-02T00:00:00Z'}),
+        '2026-07-02T00:00:00Z',
+      );
+      // どちらも無ければ空 → 呼び出し側で「日付なし」へ。
+      expect(adminUserCreatedRaw(<String, dynamic>{}), '');
+    });
+
+    test('summarizeAdminUsers: real vs anonymous split', () {
+      final users = <Map<String, dynamic>>[
+        {'email': 'real1@x.com'},
+        {'email': 'real2@x.com'},
+        {'email': ''},
+        <String, dynamic>{},
+        {'email': '  '},
+      ];
+      final s = summarizeAdminUsers(users);
+      expect(s.real, 2);
+      expect(s.anon, 3);
+    });
+  });
 }


### PR DESCRIPTION
## R19: 登録ユーザー管理カードの全行空白バグ修正（契約バグ + 捏造の除去）

Dashboard round after R16/R17/R18. The 登録ユーザー管理 (合計 44 人) card rendered EVERY row blank — 「?」 avatar, empty name, 「プロフィール 0%」, 「登録: (空)　最終ログイン: (空)」, and a 「0完成/0途中/44未設定」 summary. Root cause is a two-layer defect, not a display glitch. Dart-only fix (single file + pure logic), no edge change.

### ① 契約バグ: 登録日が読めていなかった
The edge `users.list` returns each row as `{id, email, created_at}` (snake_case). The card read `user['createdAt']` (camelCase) → always null → `DateTime.parse('')` threw → the 登録 date was blank for all 44 rows even though the data was returned. Fixed: read `created_at` with a `createdAt` fallback (pure `adminUserCreatedRaw`). The registration date now appears.

### ② 捏造の除去（R17 の n=0 誠実性規律の直系）
`completionPct` / `hasProfile` / `lastSignInAt` / `displayName` are NOT sent by the edge, yet the UI painted 「プロフィール 0%」 (red bar), a fabricated 「0完成/0途中/44未設定」 summary, and blank last-login as if measured. Removed: the fabricated completion bar → 「プロフィール情報 未取得」; the last-login blank → 「ログイン記録なし」; an unparseable date → 「日付なし」. Nothing absent is drawn as a real value.

### ③ 実ユーザー / 匿名テストの分離
Many of the 44 are anonymous test identities (created for headless verification, no email). The 合計 44 vs the real-CVR 4 is vanity inflation. Using empty-email as a reliable anonymous proxy (pure `summarizeAdminUsers`), the summary now reads 「実ユーザー Y人 / 匿名テスト N人」, the heading shows the breakdown, and anon rows render 「匿名ユーザー」/「匿」/「匿名」 instead of a blank 「?」.

Pure logic (`adminUserIsAnonymous` / `adminUserCreatedRaw` / `summarizeAdminUsers`) extracted to `admin_dashboard_signals.dart` for VM tests. `flutter test`: 21 green (+3 R19). Analyze clean, format fixpoint. Additive/display-only.

Deferred (follow-up): edge-enrich for real last-sign-in + is-anonymous ground truth + display name (needs the edge, dual gate); the Tool Guard 「Recent」 label (separate card).

## Minimal E2E Gate

- Implementation-detail independent: tests assert the anonymous classification, the snake/camel key fallback, and the real/anon split counts from inputs, not private widget internals.
- Minimal scope: about 3 cases (empty-email→anonymous; snake key preferred + camel fallback + absent→empty; real/anon split).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: admin-only display-truthfulness fix verified by implementation-independent unit tests over pure functions; no user-facing route flow changes, so no integration_test/Playwright route applies.
