### PR TITLE
[CI/CD自動最適化] mcp-audit-anomaly-cron cancel-in-progress PR条件付きtrue (2026-07-09)

### DIFF
--- a/.github/workflows/mcp-audit-anomaly-cron.yml
+++ b/.github/workflows/mcp-audit-anomaly-cron.yml
@@ -25,7 +25,7 @@ permissions:
 
 concurrency:
   group: mcp-audit-anomaly
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}  # 2026-07-09 ci-audit: PR 連続 push キュー積み防止 / schedule は false 維持 (セキュリティ監査ギャップ防止)
 
 jobs:
   script-test:


### PR DESCRIPTION
## 変更概要

`mcp-audit-anomaly-cron.yml` の `cancel-in-progress` を `false` → PR 条件付き `true` に変更。

### 変更内容

```diff
 concurrency:
   group: mcp-audit-anomaly
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}  # 2026-07-09 ci-audit
```

### 根拠

- **前回 #3841 監査 HIGH 提案**の自動適用（2026-07-06, 2026-07-08 に提案済み・未着手だったもの）
- `schedule` (毎 2h) は `cancel-in-progress: false` を維持 → セキュリティ監査ギャップなし
- `pull_request` トリガー時のみ `cancel=true` → PR 連続 push 時のキュー積み防止
- `timeout-minutes: 8-10` × 2h 間隔 → schedule 実行での実際のキャンセル発生なし

### 推定削減効果

PR 連続 push 時の無効ランキャンセル（月数回 × ~18min = 推定 ~50min/月削減）

### 監査レポート

`docs/ci-cd-audit/2026-07-09.md`

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

---

🤖 自動適用: Claude Schedule ci-cd-audit 2026-07-09
関連 Issue: #3841

---
_Generated by [Claude Code](https://claude.ai/code/session_012uJHhCmg8JHQCh822doVRN)_