### PR TITLE
feat(admin): R20 X-growth-loop freshness source fix + reply clamp + age-aware dates

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -3030,7 +3030,12 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     if (parsed == null) {
       return '--';
     }
-    return DateFormat('MM/dd HH:mm:ss').format(parsed);
+    // R20: 年なし MM/dd は2か月前(05/11)のログを今週に見せる。1か月超/別年は
+    // 年を前置して年齢を明示する(「Recent」ラベルの誤読を解消)。
+    final now = DateTime.now();
+    final stale = parsed.year != now.year || now.difference(parsed).inDays > 30;
+    return DateFormat(stale ? 'yyyy/MM/dd HH:mm:ss' : 'MM/dd HH:mm:ss')
+        .format(parsed);
   }
 
   Color _getCvrColor(double cvr) {
@@ -4729,11 +4734,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                   final createdAt = req['created_at']?.toString() ?? '';
                   final adminReply = req['admin_reply']?.toString();
                   final adminRepliedAt = req['admin_replied_at']?.toString();
-                  String dateStr = createdAt;
-                  try {
-                    dateStr = DateFormat('MM/dd')
-                        .format(DateTime.parse(createdAt).toLocal());
-                  } catch (_) {}
+                  // R20: 年なし MM/dd は3か月前(04月)の要望を「今月」に見せる。
+                  // 1か月超/別年は yyyy/ を前置して年齢を明示する。
+                  final dateStr = formatAgeAwareDate(createdAt, DateTime.now());
                   String? repliedAtStr;
                   if (adminRepliedAt != null) {
                     try {
@@ -4910,6 +4913,10 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                             ),
                             child: Text(
                               'AI: $adminReply',
+                              // R20: 数百字の返信が50件リストを支配する wall-of-text
+                              // を抑制。全文は返信編集ダイアログで到達可能=無損失。
+                              maxLines: 3,
+                              overflow: TextOverflow.ellipsis,
                               style: const TextStyle(
                                 fontSize: 11,
                                 color: Color(0xFF4338CA),
@@ -5804,7 +5811,13 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     if (loop.state == XGrowthLoopState.hidden) return const SizedBox.shrink();
 
     final theme = Theme.of(context);
-    final freshness = _xGrowthLoopFreshness();
+    // R20: 鮮度はパネル自身のデータ(perf-context 行)から出す。旧実装は今日の投稿の
+    // 計測時刻を読み、12件計測済みでも今日未投稿だと「計測待ち」と矛盾していた。
+    final freshness = resolveXGrowthLoopFreshness(
+      measuredCount: rows.length,
+      newestMeasuredAt: newestMeasuredCreatedAt(rows),
+      now: DateTime.now(),
+    );
     final lines = <Widget>[];
 
     switch (loop.state) {
@@ -5952,18 +5965,6 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     final text = (first['text'] ?? '').toString().trim();
     if (text.isEmpty) return null;
     return text.length <= 60 ? text : '${text.substring(0, 58)}…';
-  }
-
-  String _xGrowthLoopFreshness() {
-    final collected =
-        DateTime.tryParse(_xTodayStatus?['lastCollectedAt']?.toString() ?? '')
-            ?.toLocal();
-    if (collected == null) return '最終計測: 計測待ち';
-    final days = DateTime.now().difference(collected).inDays;
-    final hours = DateTime.now().difference(collected).inHours;
-    if (days >= 1) return '最終計測: $days日前';
-    if (hours >= 1) return '最終計測: $hours時間前';
-    return '最終計測: 1時間以内';
   }
 
   Widget _buildGrowthAchievementSummaryCard() {

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -134,3 +134,53 @@ String adminUserCreatedRaw(Map<String, dynamic> user) {
   }
   return (real: users.length - anon, anon: anon);
 }
+
+// R20: X成長ループ panel の鮮度フッター。R17 は鮮度だけ「今日の投稿の計測時刻」
+// (_xTodayStatus.lastCollectedAt)を読んでいたため、12件計測済みでも今日未投稿だと
+// 「計測待ち」と矛盾表示していた(偽の計測停止アラーム)。パネル自身が描く
+// perf-context の行から鮮度を出す。
+
+/// perf-context 行(各 {createdAt}) の中で最も新しい created_at を返す。行は
+/// growth-hub 側で score 降順ソート済みなので rows[0] は最新でない → 全行走査で
+/// max を取る。パース可能な行が無ければ null。
+DateTime? newestMeasuredCreatedAt(List<dynamic>? rows) {
+  if (rows == null) return null;
+  DateTime? newest;
+  for (final row in rows) {
+    if (row is! Map) continue;
+    final dt = DateTime.tryParse((row['createdAt'] ?? '').toString());
+    if (dt == null) continue;
+    if (newest == null || dt.isAfter(newest)) newest = dt;
+  }
+  return newest;
+}
+
+/// X成長ループ鮮度ラベル。計測済み(measuredCount>0)なら決して「計測待ち」と
+/// 言わない。createdAt は投稿時刻で計測実行時刻ではないためラベルは「最新
+/// サンプル」に留め「最終計測」と過剰主張しない。
+String resolveXGrowthLoopFreshness({
+  required int measuredCount,
+  required DateTime? newestMeasuredAt,
+  required DateTime now,
+}) {
+  if (measuredCount <= 0) return '最終計測: 計測待ち';
+  if (newestMeasuredAt == null) return '計測済み $measuredCount件';
+  final diff = now.difference(newestMeasuredAt);
+  if (diff.isNegative) return '計測済み $measuredCount件';
+  if (diff.inDays >= 1) return '最新サンプル: ${diff.inDays}日前';
+  if (diff.inHours >= 1) return '最新サンプル: ${diff.inHours}時間前';
+  return '最新サンプル: 1時間以内';
+}
+
+/// R20: 年なし MM/dd は 3か月前の機能リクエストや 2か月前のツール実行ログを
+/// 「今月」に見せてしまう。別年、もしくは staleDays(既定30日=1か月超)超は
+/// yyyy/MM/dd を返して年齢を明示する(パース不能は raw をそのまま返す)。
+String formatAgeAwareDate(String? iso, DateTime now, {int staleDays = 30}) {
+  final raw = (iso ?? '').toString();
+  final dt = DateTime.tryParse(raw)?.toLocal();
+  if (dt == null) return raw;
+  final m = dt.month.toString().padLeft(2, '0');
+  final d = dt.day.toString().padLeft(2, '0');
+  final stale = dt.year != now.year || now.difference(dt).inDays > staleDays;
+  return stale ? '${dt.year}/$m/$d' : '$m/$d';
+}

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -170,4 +170,96 @@ void main() {
       expect(s.anon, 3);
     });
   });
+
+  group('R20 X成長ループ freshness (perf-context source, not today-status)', () {
+    final now = DateTime(2026, 7, 10, 12, 0);
+
+    test('measuredCount 0 → 計測待ち (the only honest waiting state)', () {
+      expect(
+        resolveXGrowthLoopFreshness(
+          measuredCount: 0,
+          newestMeasuredAt: null,
+          now: now,
+        ),
+        '最終計測: 計測待ち',
+      );
+    });
+
+    test('measured but no parseable date → 計測済み N件, never 計測待ち', () {
+      final r = resolveXGrowthLoopFreshness(
+        measuredCount: 12,
+        newestMeasuredAt: null,
+        now: now,
+      );
+      expect(r, '計測済み 12件');
+      expect(r.contains('計測待ち'), isFalse);
+    });
+
+    test('measured with recent date → 最新サンプル relative', () {
+      expect(
+        resolveXGrowthLoopFreshness(
+          measuredCount: 12,
+          newestMeasuredAt: now.subtract(const Duration(days: 3)),
+          now: now,
+        ),
+        '最新サンプル: 3日前',
+      );
+      expect(
+        resolveXGrowthLoopFreshness(
+          measuredCount: 12,
+          newestMeasuredAt: now.subtract(const Duration(hours: 2)),
+          now: now,
+        ),
+        '最新サンプル: 2時間前',
+      );
+    });
+
+    test('future timestamp → falls through to 計測済み N件', () {
+      expect(
+        resolveXGrowthLoopFreshness(
+          measuredCount: 12,
+          newestMeasuredAt: now.add(const Duration(hours: 5)),
+          now: now,
+        ),
+        '計測済み 12件',
+      );
+    });
+
+    test('newestMeasuredCreatedAt: max across rows (rows are score-sorted)',
+        () {
+      // rows[0] は高スコアの古い投稿、後続に新しい投稿 → 最新を返すこと。
+      final rows = [
+        {'createdAt': '2026-07-01T00:00:00Z', 'score': 200},
+        {'createdAt': '2026-07-08T00:00:00Z', 'score': 10},
+        {'createdAt': '2026-07-05T00:00:00Z', 'score': 50},
+      ];
+      expect(
+        newestMeasuredCreatedAt(rows),
+        DateTime.parse('2026-07-08T00:00:00Z'),
+      );
+      expect(newestMeasuredCreatedAt(null), isNull);
+      expect(
+        newestMeasuredCreatedAt([
+          {'createdAt': 'bad'},
+        ]),
+        isNull,
+      );
+    });
+  });
+
+  group('R20 formatAgeAwareDate (yearless MM/dd hides old dates)', () {
+    final now = DateTime(2026, 7, 10);
+    test('recent same-year → MM/dd', () {
+      expect(formatAgeAwareDate('2026-07-05T00:00:00Z', now), '07/05');
+    });
+    test('same-year but > staleDays → yyyy/MM/dd', () {
+      expect(formatAgeAwareDate('2026-04-14T00:00:00Z', now), '2026/04/14');
+    });
+    test('different year → yyyy/MM/dd', () {
+      expect(formatAgeAwareDate('2025-12-20T00:00:00Z', now), '2025/12/20');
+    });
+    test('unparseable → raw', () {
+      expect(formatAgeAwareDate('n/a', now), 'n/a');
+    });
+  });
 }


### PR DESCRIPTION
## R20: X成長ループ鮮度の出所修正（自傷R17バグ）+ 機能リクエストwall-of-text抑制 + 年齢明示日付

Polish round after R16-R19. The dashboard is now honest and functional; this fixes the one remaining correctness bug plus two cheap real UX/honesty defects. Dart-only, additive, display-only. Pure cosmetics (expand toggle, heading rename, extra footers) were explicitly dropped as negligible-ROI.

### ① X成長ループ 鮮度フッターの出所修正（唯一の実バグ・R17 の自傷）
The panel renders 12 measured posts from `x.performance_context`, but the freshness footer read `_xTodayStatus['lastCollectedAt']` (today's post metrics time). On a day with no post yet it printed 「最終計測: 計測待ち」 while 12 posts were measured — a contradiction that mimics a false metrics-halt alarm (spend-cap / cron stopped) and wastes founder time. Fixed: derive freshness from the panel's own data (`newestMeasuredCreatedAt` over all `rows` — NOT `rows[0]`, since rows are score-sorted so the top row is not the newest). `resolveXGrowthLoopFreshness` never says 計測待ち when measuredCount>0; label is 「最新サンプル: N日前」 (not 「最終計測」, since createdAt is post time, not measurement time) with a 「計測済み N件」 fallback when no date parses.

### ② 機能リクエスト管理: inline reply の wall-of-text 抑制
The 50-item list was dominated by one hundreds-of-char multi-paragraph inline reply. Added `maxLines: 3` + ellipsis; the full text remains reachable via the existing reply-edit dialog (no data loss).

### ③ 年齢明示の日付（年なし MM/dd が古い日付を「今月」に見せる）
Feature-request dates (April, ~3 months old) and the Agent Tool Guard 「Recent Tool Executions」 (May 11, ~2 months old) rendered as yearless MM/dd, reading as this week/month. Pure `formatAgeAwareDate` (default: different year OR >30 days → `yyyy/MM/dd`) applied to both, so stale rows honestly show their year.

Pure logic (`newestMeasuredCreatedAt` / `resolveXGrowthLoopFreshness` / `formatAgeAwareDate`) in `admin_dashboard_signals.dart`. `flutter test`: 30 green (+9). Analyze clean, format fixpoint.

Honest note: with R16-R19 shipped, per-round dashboard polish is at diminishing returns after this. The remaining backlog (edge-enrich for real last-sign-in; sampling→unlocked once metrics accrue) is data/feature work, not correctness.

## Minimal E2E Gate

- Implementation-detail independent: tests assert the freshness string and age-aware date from inputs, not private widget internals.
- Minimal scope: about 3 cases (measuredCount 0→計測待ち; measured→never 計測待ち; recent/stale date formatting).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: admin-only display-truthfulness fix verified by implementation-independent unit tests over pure functions; no user-facing route flow changes, so no integration_test/Playwright route applies.
