### PR TITLE
feat(seo): 公開ブログをSSR + クロール可能URL化 (H7土台)

### DIFF
--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -93,6 +93,9 @@ jobs:
           check "view txt"         "$BASE?action=memo.public.view&id=$MEMO_ID&format=txt" "200" "App URL:"
           check "amp-mangled rescue" "$BASE?action=memo.public.view&amp;id=$MEMO_ID&amp;format=json" "200" "\"appUrl\""
 
+          # PR: 公開ブログ SSR (blog.public.list) が匿名で 200 + success を返すこと
+          check "blog list json"   "$BASE?action=blog.public.list&limit=3&format=json" "200" "\"success\":true"
+
           # PR #3899: prerender 済み /vs-<slug> が固有本文 + 自己参照 canonical で
           # 配信されること (SPA シェルではなく静的HTMLが Firebase 優先配信される)。
           VS="https://my-web-app-b67f4.web.app/vs-notion"

--- a/lib/pages/public_blog_post_page.dart
+++ b/lib/pages/public_blog_post_page.dart
@@ -21,7 +21,11 @@ class _PublicBlogPostPageState extends State<PublicBlogPostPage> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final args = ModalRoute.of(context)?.settings.arguments;
-    final id = (args is Map) ? args['id']?.toString() : null;
+    // アプリ内ナビの arguments を優先しつつ、URL クエリ (/blog/post?id=X) からも
+    // id を解決する。クローラー / 直リンク / SNS 共有からの直接アクセスを可能にし、
+    // 公開ブログをインデックス可能にする (SEO 監査 H7)。
+    final id = (args is Map ? args['id']?.toString() : null) ??
+        Uri.base.queryParameters['id'];
     if (id != null && id != _postId) {
       _postId = id;
       _future = BlogPublishService.getPostById(id);

--- a/supabase/functions/core-hub/blog_view.ts
+++ b/supabase/functions/core-hub/blog_view.ts
@@ -1,0 +1,227 @@
+// blog_view.ts — 公開ブログ (blog_posts status='posted') の bot / AI 可読ビュー
+//
+// /blog/post は Flutter SPA でアプリ内ナビ引数から記事を特定するため、クローラーが
+// URL で直接アクセスできず、公開ブログ (anon 可読 / migration 20260504050000) が
+// インデックスされていなかった (SEO 監査 H7)。core-hub の匿名 action
+// blog.public.view / blog.public.list が同じ記事をサーバー描画済みの
+// HTML / JSON / Markdown で返し、非JSクローラー / LLM / 検索エンジンに開放する。
+// 公開メモの public_memo_view.ts と同じ設計。汎用ヘルパーは同ファイルから再利用する。
+
+import {
+  buildPublicMemoExcerpt,
+  clampPublicMemoLimit,
+  escapeHtml,
+  normalizePublicMemoSearchQuery,
+  type PublicMemoViewFormat,
+  resolvePublicMemoViewFormat,
+  searchParamsToActionBody,
+} from "./public_memo_view.ts";
+
+export const BLOG_SITE_NAME = "自分株式会社";
+export const BLOG_APP_BASE_URL = "https://my-web-app-b67f4.web.app/blog/post";
+
+// 再エクスポート (core-hub index.ts が blog 用に import する汎用ヘルパー)
+export {
+  clampPublicMemoLimit,
+  normalizePublicMemoSearchQuery,
+  resolvePublicMemoViewFormat,
+  searchParamsToActionBody,
+};
+export type { PublicMemoViewFormat };
+
+export interface BlogPostRow {
+  id: string;
+  title: string | null;
+  content: string | null;
+  excerpt: string | null;
+  posted_at: string | null;
+  published_at: string | null;
+  url: string | null;
+  tags?: unknown;
+}
+
+export const BLOG_VIEW_COLUMNS =
+  "id, title, content, excerpt, posted_at, published_at, url, tags";
+
+export function buildBlogPostUrl(id: string): string {
+  return `${BLOG_APP_BASE_URL}?id=${encodeURIComponent(id)}`;
+}
+
+function blogExcerpt(row: BlogPostRow): string {
+  const raw = (row.excerpt ?? "").trim();
+  return raw || buildPublicMemoExcerpt(row.content);
+}
+
+export function extractBlogTags(row: BlogPostRow): string[] {
+  const raw = row.tags;
+  const tags: string[] = [];
+  const push = (v: unknown) => {
+    if (typeof v !== "string") return;
+    const t = v.trim();
+    if (t && !tags.includes(t)) tags.push(t);
+  };
+  if (Array.isArray(raw)) raw.forEach(push);
+  else if (typeof raw === "string") raw.split(",").forEach(push);
+  return tags;
+}
+
+export function blogPostToPayload(row: BlogPostRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    title: row.title ?? "",
+    content: row.content ?? "",
+    excerpt: blogExcerpt(row),
+    tags: extractBlogTags(row),
+    postedAt: row.posted_at,
+    publishedAt: row.published_at,
+    externalUrl: row.url,
+    appUrl: buildBlogPostUrl(row.id),
+  };
+}
+
+function blogDate(iso: string | null): string {
+  return iso ? iso.slice(0, 10) : "";
+}
+
+export function renderBlogArticleJsonLd(row: BlogPostRow): string {
+  const appUrl = buildBlogPostUrl(row.id);
+  const article: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: row.title ?? `Blog #${row.id}`,
+    description: blogExcerpt(row),
+    inLanguage: "ja",
+    mainEntityOfPage: appUrl,
+    url: appUrl,
+    author: { "@type": "Organization", name: BLOG_SITE_NAME },
+    publisher: {
+      "@type": "Organization",
+      name: BLOG_SITE_NAME,
+      logo: {
+        "@type": "ImageObject",
+        url: "https://my-web-app-b67f4.web.app/ogp-image-gen2-20260428.png",
+      },
+    },
+  };
+  const tags = extractBlogTags(row);
+  if (tags.length > 0) article.keywords = tags.join(", ");
+  const published = row.posted_at ?? row.published_at;
+  if (published) {
+    article.datePublished = published;
+    article.dateModified = published;
+  }
+  const json = JSON.stringify(article).replaceAll("<", "\\u003c");
+  return `<script type="application/ld+json">${json}</script>`;
+}
+
+function blogHtmlDocument(opts: {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  body: string;
+}): string {
+  const title = escapeHtml(opts.title);
+  const description = escapeHtml(opts.description);
+  const canonical = escapeHtml(opts.canonicalUrl);
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title} | ${BLOG_SITE_NAME}</title>
+<meta name="description" content="${description}">
+<link rel="canonical" href="${canonical}">
+<meta property="og:title" content="${title}">
+<meta property="og:description" content="${description}">
+<meta property="og:url" content="${canonical}">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="${BLOG_SITE_NAME}">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+<main style="max-width:720px;margin:0 auto;padding:24px;font-family:sans-serif;line-height:1.7">
+${opts.body}
+</main>
+</body>
+</html>
+`;
+}
+
+export function renderBlogHtml(row: BlogPostRow): string {
+  const title = row.title ?? `Blog #${row.id}`;
+  const appUrl = buildBlogPostUrl(row.id);
+  const meta: string[] = [];
+  const posted = blogDate(row.posted_at ?? row.published_at);
+  if (posted) meta.push(`公開日: ${posted}`);
+  const tags = extractBlogTags(row);
+  if (tags.length) meta.push(`タグ: ${tags.join(", ")}`);
+  const body = `${renderBlogArticleJsonLd(row)}
+<article>
+<h1>${escapeHtml(title)}</h1>
+<p>${escapeHtml(meta.join(" / "))}</p>
+<div style="white-space:pre-wrap">${escapeHtml(row.content ?? "")}</div>
+</article>
+<footer style="margin-top:32px;font-size:0.9em">
+<p><a href="${escapeHtml(appUrl)}">アプリで開く (${
+    escapeHtml(BLOG_SITE_NAME)
+  })</a></p>
+</footer>`;
+  return blogHtmlDocument({
+    title,
+    description: blogExcerpt(row),
+    canonicalUrl: appUrl,
+    body,
+  });
+}
+
+export function renderBlogMarkdown(row: BlogPostRow): string {
+  const title = row.title ?? `Blog #${row.id}`;
+  const posted = blogDate(row.posted_at ?? row.published_at);
+  const lines = [
+    `# ${title}`,
+    "",
+    posted ? `- 公開日: ${posted}` : "",
+    `- App URL: ${buildBlogPostUrl(row.id)}`,
+    "",
+    row.content ?? "",
+    "",
+  ].filter((l) => l !== "");
+  return lines.join("\n");
+}
+
+export function renderBlogNotFoundHtml(id: string): string {
+  return blogHtmlDocument({
+    title: `Blog ${escapeHtml(id)} not found`,
+    description: "指定された記事は存在しないか、未公開です。",
+    canonicalUrl: buildBlogPostUrl(id),
+    body:
+      `<h1>Blog post not found</h1><p>この記事は存在しないか、未公開です。</p>` +
+      `<p><a href="https://my-web-app-b67f4.web.app/blog">ブログ一覧</a></p>`,
+  });
+}
+
+export function renderBlogListHtml(rows: BlogPostRow[]): string {
+  const items = rows.map((row) => {
+    const href = escapeHtml(buildBlogPostUrl(row.id));
+    const title = escapeHtml(row.title ?? `Blog #${row.id}`);
+    const ex = escapeHtml(blogExcerpt(row));
+    const posted = escapeHtml(blogDate(row.posted_at ?? row.published_at));
+    return `<li style="margin-bottom:16px"><a href="${href}">${title}</a>` +
+      `<small> (${posted})</small><p style="margin:4px 0">${ex}</p></li>`;
+  }).join("\n");
+  return blogHtmlDocument({
+    title: "ブログ",
+    description: `${BLOG_SITE_NAME}の公式ブログ 最新${rows.length}件`,
+    canonicalUrl: "https://my-web-app-b67f4.web.app/blog",
+    body: `<h1>ブログ (${rows.length}件)</h1>\n<ol>\n${items}\n</ol>`,
+  });
+}
+
+export function renderBlogListMarkdown(rows: BlogPostRow[]): string {
+  const items = rows.map((row) =>
+    `- [${row.title ?? `Blog #${row.id}`}](${buildBlogPostUrl(row.id)}) (${
+      blogDate(row.posted_at ?? row.published_at)
+    })`
+  );
+  return [`# ブログ (${rows.length}件)`, "", ...items, ""].join("\n");
+}

--- a/supabase/functions/core-hub/blog_view_test.ts
+++ b/supabase/functions/core-hub/blog_view_test.ts
@@ -1,0 +1,114 @@
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  type BlogPostRow,
+  blogPostToPayload,
+  buildBlogPostUrl,
+  extractBlogTags,
+  renderBlogArticleJsonLd,
+  renderBlogHtml,
+  renderBlogListHtml,
+  renderBlogListMarkdown,
+  renderBlogMarkdown,
+  renderBlogNotFoundHtml,
+} from "./blog_view.ts";
+
+function sampleRow(overrides: Partial<BlogPostRow> = {}) {
+  return {
+    id: "abc-123",
+    title: "Flutter × Supabase 実装ログ",
+    content: "本文です。\n実装の詳細を書きます。",
+    excerpt: "実装ログの要約",
+    posted_at: "2026-07-01T09:30:00+09:00",
+    published_at: null,
+    url: "https://dev.to/kanta13jp1/foo",
+    tags: ["flutter", "supabase"],
+    ...overrides,
+  } as BlogPostRow;
+}
+
+Deno.test("buildBlogPostUrl builds crawlable /blog/post URL", () => {
+  assertEquals(
+    buildBlogPostUrl("abc-123"),
+    "https://my-web-app-b67f4.web.app/blog/post?id=abc-123",
+  );
+});
+
+Deno.test("extractBlogTags normalizes array and CSV", () => {
+  assertEquals(extractBlogTags(sampleRow()), ["flutter", "supabase"]);
+  assertEquals(
+    extractBlogTags(sampleRow({ tags: "a, b ,a," })),
+    ["a", "b"],
+  );
+  assertEquals(extractBlogTags(sampleRow({ tags: null })), []);
+});
+
+Deno.test("blogPostToPayload exposes app URL and excerpt fallback", () => {
+  const p = blogPostToPayload(sampleRow({ excerpt: null }));
+  assertEquals(
+    p.appUrl,
+    "https://my-web-app-b67f4.web.app/blog/post?id=abc-123",
+  );
+  assertEquals(p.excerpt, "本文です。 実装の詳細を書きます。");
+  assertEquals(p.externalUrl, "https://dev.to/kanta13jp1/foo");
+});
+
+Deno.test("renderBlogHtml embeds self-canonical + escaped content", () => {
+  const html = renderBlogHtml(sampleRow({ content: "<b>x</b> & y" }));
+  assertStringIncludes(
+    html,
+    '<link rel="canonical" href="https://my-web-app-b67f4.web.app/blog/post?id=abc-123">',
+  );
+  assertStringIncludes(
+    html,
+    "<title>Flutter × Supabase 実装ログ | 自分株式会社</title>",
+  );
+  assertStringIncludes(html, "&lt;b&gt;x&lt;/b&gt; &amp; y");
+  assert(!html.includes("<b>x</b>"));
+  assertStringIncludes(html, '"@type":"BlogPosting"');
+});
+
+Deno.test("renderBlogArticleJsonLd is valid and escaped", () => {
+  const script = renderBlogArticleJsonLd(
+    sampleRow({ content: "本文 </script>" }),
+  );
+  assert(!script.slice(30).includes("</script>本文"));
+  const json = script
+    .replace('<script type="application/ld+json">', "")
+    .replace("</script>", "")
+    .replaceAll("\\u003c", "<");
+  const parsed = JSON.parse(json);
+  assertEquals(parsed["@type"], "BlogPosting");
+  assertEquals(parsed.datePublished, "2026-07-01T09:30:00+09:00");
+  assertEquals(parsed.keywords, "flutter, supabase");
+});
+
+Deno.test("renderBlogMarkdown carries title/date/body", () => {
+  const md = renderBlogMarkdown(sampleRow());
+  assertStringIncludes(md, "# Flutter × Supabase 実装ログ");
+  assertStringIncludes(md, "公開日: 2026-07-01");
+  assertStringIncludes(md, "実装の詳細を書きます。");
+});
+
+Deno.test("renderBlogNotFoundHtml mentions not found", () => {
+  const html = renderBlogNotFoundHtml("zzz");
+  assertStringIncludes(html, "not found");
+  assertStringIncludes(html, "未公開");
+});
+
+Deno.test("renderBlogListHtml / Markdown list each post", () => {
+  const rows = [sampleRow(), sampleRow({ id: "d2", title: "第二の記事" })];
+  const html = renderBlogListHtml(rows);
+  assertStringIncludes(html, "ブログ (2件)");
+  assertStringIncludes(
+    html,
+    'href="https://my-web-app-b67f4.web.app/blog/post?id=abc-123"',
+  );
+  assertStringIncludes(html, "第二の記事");
+  const md = renderBlogListMarkdown(rows);
+  assertStringIncludes(md, "# ブログ (2件)");
+  assertStringIncludes(md, "第二の記事");
+});

--- a/supabase/functions/core-hub/index.ts
+++ b/supabase/functions/core-hub/index.ts
@@ -38,6 +38,16 @@ import {
   resolvePublicMemoViewFormat,
   searchParamsToActionBody,
 } from "./public_memo_view.ts";
+import {
+  BLOG_VIEW_COLUMNS,
+  type BlogPostRow,
+  blogPostToPayload,
+  renderBlogHtml,
+  renderBlogListHtml,
+  renderBlogListMarkdown,
+  renderBlogMarkdown,
+  renderBlogNotFoundHtml,
+} from "./blog_view.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -865,6 +875,8 @@ serve(async (req: Request) => {
       "memo.public.list",
       "memo.public.search",
       "memo.public.related",
+      "blog.public.view",
+      "blog.public.list",
     ]);
     const bearer = (req.headers.get("authorization") ?? "").replace(
       /^Bearer\s+/i,
@@ -1118,6 +1130,74 @@ serve(async (req: Request) => {
           category: category || null,
           memos: rows.map(publicMemoToPayload),
         });
+      }
+
+      // ---- Public blog bot/AI-readable view (anonymous / status='posted') ----
+      // /blog/post は SPA でアプリ内ナビ引数から記事を特定するため URL で
+      // クロールできない。GET ?action=blog.public.view&id=X で SSR 済み HTML
+      // (format=json / md 可) を返す。RLS と同じく status='posted' のみ。
+      case "blog.public.view": {
+        const id = String(body.id ?? "").trim();
+        const format = resolvePublicMemoViewFormat(body.format, req.method);
+        if (!id) return json({ error: "id required" }, 400);
+        const { data, error } = await admin
+          .from("blog_posts")
+          .select(BLOG_VIEW_COLUMNS)
+          .eq("id", id)
+          .eq("status", "posted")
+          .maybeSingle();
+        if (error) return json({ error: error.message }, 500);
+        if (!data) {
+          if (format === "html") {
+            return publicText(
+              renderBlogNotFoundHtml(id),
+              "text/html; charset=utf-8",
+              404,
+            );
+          }
+          return json({ error: `Blog ${id} not found` }, 404);
+        }
+        const row = data as BlogPostRow;
+        if (format === "json") {
+          return json({ success: true, post: blogPostToPayload(row) });
+        }
+        if (format === "md" || format === "txt") {
+          return publicText(
+            renderBlogMarkdown(row),
+            format === "md"
+              ? "text/markdown; charset=utf-8"
+              : "text/plain; charset=utf-8",
+          );
+        }
+        return publicText(renderBlogHtml(row), "text/html; charset=utf-8");
+      }
+
+      case "blog.public.list": {
+        const limit = clampPublicMemoLimit(body.limit, 20, 50);
+        const format = resolvePublicMemoViewFormat(body.format, req.method);
+        const { data, error } = await admin
+          .from("blog_posts")
+          .select(BLOG_VIEW_COLUMNS)
+          .eq("status", "posted")
+          .order("posted_at", { ascending: false })
+          .limit(limit);
+        if (error) return json({ error: error.message }, 500);
+        const rows = (data ?? []) as BlogPostRow[];
+        if (format === "html") {
+          return publicText(
+            renderBlogListHtml(rows),
+            "text/html; charset=utf-8",
+          );
+        }
+        if (format === "md" || format === "txt") {
+          return publicText(
+            renderBlogListMarkdown(rows),
+            format === "md"
+              ? "text/markdown; charset=utf-8"
+              : "text/plain; charset=utf-8",
+          );
+        }
+        return json({ success: true, posts: rows.map(blogPostToPayload) });
       }
 
       // ---- OGP fetch (stateless) ----

--- a/web/index.html
+++ b/web/index.html
@@ -984,6 +984,42 @@
         setCanonical(window.location.href);
       }
 
+      if (path === '/blog/post' || path.endsWith('/blog/post')) {
+        // 公開ブログ記事: URL クエリ id から自己参照 canonical + meta を設定し
+        // クローラーにインデックスさせる (SEO 監査 H7)。
+        var blogId = params.get('id');
+        if (blogId) {
+          setCanonical(
+            'https://my-web-app-b67f4.web.app/blog/post?id=' +
+              encodeURIComponent(blogId)
+          );
+          fetch(
+            SUPABASE_FUNC_BASE +
+              '/core-hub?action=blog.public.view&id=' +
+              encodeURIComponent(blogId) + '&format=json'
+          )
+            .then(function (res) { return res.json(); })
+            .then(function (data) {
+              if (!data || !data.success || !data.post) return;
+              var p = data.post;
+              if (p.title) {
+                document.title = p.title + ' | 自分株式会社';
+                setMeta('og:title', p.title);
+                setMeta('twitter:title', p.title);
+              }
+              if (p.excerpt) {
+                setMeta('description', p.excerpt);
+                setMeta('og:description', p.excerpt);
+                setMeta('twitter:description', p.excerpt);
+              }
+              setMeta('og:type', 'article');
+              setMeta('og:url', p.appUrl);
+              setMeta('twitter:url', p.appUrl);
+            })
+            .catch(function () { /* ignore, keep default */ });
+        }
+      }
+
       if ((path === '/public-memo' || path.endsWith('/public-memo')) && memoId) {
         // 公開メモは一意な公開コンテンツ。canonical をトップ固定のままにすると
         // 重複としてトップへ集約され独立インデックスされないため自URLへ。


### PR DESCRIPTION
# Pull Request

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: anonymous read-only blog SSR + client-side canonical for already-anon-readable content; user-visible I/O covered by blog_view_test.ts (8 tests: self-canonical / BlogPosting JSON-LD escape / tags / excerpt fallback / list); daily smoke adds blog.public.list (200+success); index.html JSON-LD parse + inline JS syntax-checked

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: anonymous read-only actions over blog_posts rows already exposed by RLS policy public_read_published (status='posted' only, migration 20260504050000); no auth/billing/data-migration/secret change; rollback = revert single commit; prod smoke = public-memo-smoke.yml blog.public.list after deploy; observability via EF logs

## 📝 変更内容

SEO監査 H7 の土台。dev.to へ syndicate した記事は `blog_posts`(status='posted', anon 可読)に content 付きで実在するが、`/blog/post` が SPA でアプリ内ナビ引数から記事を特定するため **URL でクロールできず、数百記事の公開ブログがインデックスされていなかった**。SSR + クロール可能URL化で開放する。

### 変更の種類

- [x] 新機能 (breaking changeを含まない機能追加)

## 📋 実装の詳細

- **core-hub** — `blog_view.ts` + 匿名 action `blog.public.view` / `blog.public.list`。`status='posted'` のみを SSR HTML / JSON / Markdown + `BlogPosting` JSON-LD + 自己参照 canonical(`/blog/post?id=X`)で配信。汎用ヘルパーは `public_memo_view` から再利用。
- **Dart** — `PublicBlogPostPage` が URL クエリ(`/blog/post?id=X`)からも `id` を解決。直リンク / SNS 共有 / クローラーの直接アクセスを可能に(従来はアプリ内ナビ引数のみ)。
- **index.html** — `/blog/post` ハンドラで自己参照 canonical + `blog.public.view` 取得の title/description/OG を設定。
- **日次 smoke** — `blog.public.list`(200 + success)を追加。
- **RLS** — 返すのは既存ポリシー `public_read_published`(status='posted' のみ anon 可読)の範囲内。公開範囲の拡大なし。

## ✅ テスト結果

| テストケース | 結果 | 備考 |
| --- | --- | --- |
| `blog_view_test.ts` 8件 (self-canonical / BlogPosting JSON-LD escape / tags正規化 / excerpt fallback / list) | ✅ | deno test 全パス |
| `deno lint` / `deno fmt` / `deno check blog_view.ts` | ✅ | 0エラー |
| index.html JSON-LD parse + インラインJS 2ブロック node --check | ✅ | 全OK |

## 🚨 Breaking Changes

- [x] このPRにはBreaking Changesが含まれていません

## 📊 パフォーマンスへの影響

- [x] パフォーマンスへの影響はありません

## 🔒 セキュリティへの影響

- [x] 公開範囲の拡大なし (既存 RLS `public_read_published` = status='posted' のみ)
- [x] 本文はHTMLエスケープ / JSON-LDは script-breakout 対策済

## 📚 ドキュメント更新

- [x] ドキュメント更新は不要

## ✅ レビュー観点

### 重点的にレビューしてほしい箇所

1. `blog.public.view` が status='posted' のみを返すこと (draft 漏洩なし)
2. index.html `/blog/post` ハンドラの canonical/meta が既存フローを壊さないこと

## 🚀 デプロイメモ

- [x] 特別なデプロイ手順は不要 (core-hub は --no-verify-jwt デプロイ済)

## ✅ チェックリスト

### コード品質

- [x] `deno lint` 0エラーを確認しました（Edge Function変更時は必須 — CIゲート）
- [x] ダミーデータを使用していません（Supabase実データのみ）
- [x] 不要なコメントや console.log を削除しました
- [x] コードレビューを受ける準備ができています

### Rule / Script / Hook wiring 同期（追加時のみ — part 185 finding）

- [x] 該当なし

### テスト

- [x] 新しいコードにテストを追加しました
- [x] すべてのテストが通ることを確認しました
- [x] エッジケースを考慮しました

### セキュリティ

- [x] 機密情報がコミットされていないことを確認しました
- [x] 入力値の検証を適切に実装しました
- [x] セキュリティベストプラクティスに従っています

### その他

- [x] Breaking Changesがないことを確認しました
- [x] パフォーマンスへの悪影響がないことを確認しました

## 💬 追加コメント

デプロイ後、`/blog/post?id=X` が直接アクセス可能になり、`?action=blog.public.view&id=X`(HTML/JSON/MD)で SSR 配信されます。これで dev.to `canonical_url` の正しい向け先が用意でき、後続 PR で authority 集約を実装できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc)_