### PR TITLE
feat(cmo): R21 dashboard X-post CTA anti-slop - shared guardrails + port R11-R15 prompt to CmoPage

### DIFF
--- a/lib/pages/cmo_page.dart
+++ b/lib/pages/cmo_page.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../main.dart';
 import '../services/magi_system_settings_service.dart';
+import '../services/x_copy_guardrails.dart';
 
 class CmoPage extends StatefulWidget {
   final String? initialChannel;
@@ -26,6 +27,10 @@ class _CmoPageState extends State<CmoPage> {
       const MagiSystemSettingsService();
   bool _isLoading = false;
   Map<String, dynamic>? _pressRelease;
+  // R21: 生成後にプロンプトをすり抜けたスロップ語/機能未言及を非ブロッキングで
+  // 警告する(auto-regenerate はしない = 有償生成の foot-gun 回避)。
+  List<String> _slopWarnings = const [];
+  bool _missingFeatureAnchor = false;
 
   static const Color _purple = Color(0xFF7C3AED);
 
@@ -75,7 +80,8 @@ class _CmoPageState extends State<CmoPage> {
   List<String> _defaultHashtags(String? channelKey) {
     switch (channelKey) {
       case 'x_share':
-        return const ['#自分株式会社', '#X投稿', '#集客改善'];
+        // R21: 自己言及的な #X投稿/#集客改善 でなく発見タグへ(成長/発見の意図に整合)。
+        return const ['#自分株式会社', '#個人開発', '#buildinpublic'];
       case 'line':
         return const ['#自分株式会社', '#LINE導線', '#導線改善'];
       case 'facebook':
@@ -128,36 +134,17 @@ class _CmoPageState extends State<CmoPage> {
   }
 
   String _buildDraftPrompt(String channelKey) {
-    final channelLabel = _channelLabel(channelKey);
-    final spec = _channelPromptSpec(channelKey);
-    final hashtags = _defaultHashtags(channelKey).join(' ');
-
-    return '''
-あなたは自分株式会社のCMOです。
-$channelLabel 向けの日本語コピーを作成してください。
-
-目的:
-- ${spec['goal']}
-
-出力条件:
-- JSONのみを返す
-- Markdownやコードフェンスは禁止
-- keys は title, body, hashtags
-- title: ${spec['titleRule']}
-- body: ${spec['bodyRule']}
-- tone: ${spec['tone']}
-- hashtags: $channelLabel に適した短いハッシュタグを3件
-
-出力形式:
-{
-  "title": "...",
-  "body": "...",
-  "hashtags": ["...", "...", "..."]
-}
-
-推奨ハッシュタグ:
-$hashtags
-''';
+    // R21: 旧実装は goal/tone だけの一般プロンプトで、ダッシュボードの「X投稿を
+    // 作る」CTA がここへ飛んだ結果、R11-R15 で潰した旧世代スロップ(「あなたの
+    // 価値、埋もれていませんか？…自分集客力」)を再生産していた。アンチスロップ
+    // 装置(実在機能事実/一人称persona/禁止語/具体性/BAD→GOOD)を共有ガードレール
+    // から注入する。per-channel の長さ/tone spec と {title,body,hashtags} 契約は不変。
+    return buildCmoDraftPrompt(
+      channelKey: channelKey,
+      channelLabel: _channelLabel(channelKey),
+      spec: _channelPromptSpec(channelKey),
+      hashtags: _defaultHashtags(channelKey),
+    );
   }
 
   String? _extractFirstJsonObject(String text) {
@@ -333,6 +320,11 @@ $hashtags
           data['result'],
           channelKey,
         );
+        // R21: X 系チャネルのみスロップ検査(facebook/x_share は成長コピー)。
+        final title = (_pressRelease?['title'] ?? '').toString();
+        final body = (_pressRelease?['body'] ?? '').toString();
+        _slopWarnings = detectSlop(title, body);
+        _missingFeatureAnchor = !hasFeatureAnchor(title, body);
       });
     } catch (error) {
       _showRecoverableAiError(error.toString());
@@ -393,6 +385,41 @@ $hashtags
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('X を直接開けなかったため、共有シートを表示しました。')),
+    );
+  }
+
+  /// R21: 生成物にスロップ語/機能未言及があるときの非ブロッキング警告。投稿は
+  /// 妨げず、再生成を促すだけ(自動再生成はしない = 有償生成の foot-gun 回避)。
+  Widget _buildSlopWarningBanner() {
+    final reasons = <String>[
+      if (_slopWarnings.isNotEmpty) '空虚な表現: ${_slopWarnings.take(3).join('・')}',
+      if (_missingFeatureAnchor) '実在機能(給料日サイクル 等)に触れていない',
+    ].join(' / ');
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF59E0B).withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(10),
+        border:
+            Border.all(color: const Color(0xFFF59E0B).withValues(alpha: 0.4)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.warning_amber_rounded,
+            size: 16,
+            color: Color(0xFFF59E0B),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '言い換え候補: $reasons。再生成を推奨します。',
+              style: const TextStyle(fontSize: 12, height: 1.6),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -522,6 +549,10 @@ $hashtags
               ),
             if (_pressRelease != null) ...[
               _buildResultCard(channelKey),
+              if (_slopWarnings.isNotEmpty || _missingFeatureAnchor) ...[
+                const SizedBox(height: 12),
+                _buildSlopWarningBanner(),
+              ],
               const SizedBox(height: 24),
               Row(
                 children: [

--- a/lib/services/universal_x_share_service.dart
+++ b/lib/services/universal_x_share_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'ai_hub_chat_service.dart';
+import 'x_copy_guardrails.dart';
 
 typedef UniversalShareFunctionInvoker = Future<Map<String, dynamic>> Function(
   String functionName,
@@ -671,13 +672,10 @@ class UniversalXShareService {
   /// 今日の見出しに最も直結する 1 つを名前で挙げるよう求められる。これが無いと
   /// モデルは製品を語る具体材料を持たず「強力なツール」等の一般名詞に堕ちる
   /// (R11 実測: 実投稿の product mention が全て generic だった真因)。
-  static const List<String> _appFeatureFacts = <String>[
-    '給料日サイクル: 給料日起点の窓で支出を実測し、過去分の二重控除を排除する家計把握',
-    '負債トレンド: 口座別の残高履歴を月次で検出し、翌月の具体アクションを提示',
-    'Xワンボタン投稿: 当日ニュースを字幕付きの短尺動画に自動要約して投稿',
-    '資産/負債の端末跨ぎ同期: 残高履歴を端末を跨いで同期し、いつでも同じ数字を見る',
-    '給与明細取込: 明細から手取りを取り込み、給料日サイクルの収入へ自動合算',
-  ];
+  // R21: 実体は x_copy_guardrails.dart の共有定数へ byte-identical に移動
+  // (CmoPage と両参照して語彙ドリフトを防ぐ)。private alias 経由なので参照箇所
+  // (_buildDraftPrompt 内)は一切変更しない。
+  static const List<String> _appFeatureFacts = kAppFeatureFacts;
 
   static const List<String> _ctaFinalReplies = <String>[
     '試せるURLはこちらです。5分だけ触って、A/B/Cか一言で返信ください。',

--- a/lib/services/x_copy_guardrails.dart
+++ b/lib/services/x_copy_guardrails.dart
@@ -1,0 +1,117 @@
+// R21: X コピー生成のアンチスロップ・ガードレール(依存ゼロ = VM テスト可能)。
+//
+// なぜ必要か: X 投稿コピーの生成経路が2つあり、universal_x_share_service だけが
+// R11-R15 でアンチスロップ強化されていた。ダッシュボードの「X投稿を作る」CTA が
+// 飛ぶ CmoPage は別プロンプトで、旧世代の一般論スロップ(実測 2026-07-10:
+// 「あなたの価値、埋もれていませんか？…自分集客力を構築」)を再生産していた。
+// FEATURE-FACT / 禁止トークン / 機能名を1箇所へ集約し、両経路のドリフトを防ぐ。
+
+/// アプリの実在する具体機能(一次事実)。LLM はこの一覧を渡され、今日の主題に
+/// 直結する1つを名前で挙げるよう求められる。universal_x_share_service と
+/// CmoPage の両方がこの単一定数を参照する(byte-identical MOVE)。
+const List<String> kAppFeatureFacts = <String>[
+  '給料日サイクル: 給料日起点の窓で支出を実測し、過去分の二重控除を排除する家計把握',
+  '負債トレンド: 口座別の残高履歴を月次で検出し、翌月の具体アクションを提示',
+  'Xワンボタン投稿: 当日ニュースを字幕付きの短尺動画に自動要約して投稿',
+  '資産/負債の端末跨ぎ同期: 残高履歴を端末を跨いで同期し、いつでも同じ数字を見る',
+  '給与明細取込: 明細から手取りを取り込み、給料日サイクルの収入へ自動合算',
+];
+
+/// 空虚な精神論・造語のスロップトークン。R11-R15 の中核禁止語 + 2026-07-10 に
+/// CmoPage が実際に出力したスロップ語。生成後の検出(detectSlop)にも使う。
+const List<String> kSlopBannedTokens = <String>[
+  // R11-R15 の中核(両経路の語彙が乖離しないための drift guard)
+  '可能性があります',
+  '強力なツール',
+  '劇的に',
+  '大幅に',
+  '格段に',
+  '重要性を認識',
+  '効率よく整理',
+  'と言えるでしょう',
+  'game-changer',
+  'powerful tool',
+  // R21 実測スロップ(CmoPage が出した型)
+  '埋もれた才能',
+  '埋もれていませんか',
+  '最大限にアピール',
+  '社会で輝く',
+  '理想の未来へ',
+  '今すぐ一歩',
+  '自分集客力',
+  '価値、埋もれ',
+];
+
+/// 実在機能名(短縮キー)。生成物が固有機能に触れているか(hasFeatureAnchor)の判定用。
+const List<String> kFeatureNames = <String>[
+  '給料日サイクル',
+  '負債トレンド',
+  'Xワンボタン投稿',
+  '端末跨ぎ同期',
+  '給与明細',
+];
+
+/// CmoPage 用の生成プロンプトを組み立てる純関数。channel 非依存のアンチスロップ
+/// テキスト(FEATURE-FACT / 一人称 persona / 禁止語 / 具体性要求 / BAD→GOOD)を
+/// 追加し、既存の per-channel spec(長さ/tone)と {title,body,hashtags} 契約は
+/// 一切上書きしない(facebook も同プロンプトを共有するため長さは spec のまま)。
+String buildCmoDraftPrompt({
+  required String channelKey,
+  required String channelLabel,
+  required Map<String, String> spec,
+  required List<String> hashtags,
+}) {
+  final facts = kAppFeatureFacts.map((fact) => '- $fact').join('\n');
+  final banned = kSlopBannedTokens.map((token) => '「$token」').join(' / ');
+  return '''
+あなたは「自分株式会社」という一人会社を運営する開発者本人です。$channelLabel 向けの日本語コピーを、build-in-public の一人称で書いてください。三人称のブランド口調(「私たち」「弊社」「本サービスは」「私たちの新しいウェブアプリは」)を禁止します。
+
+目的:
+- ${spec['goal']}
+
+App の実在する具体機能(この中から今日伝える1つを名前で挙げ、それが何を数値/画面/具体で解決するかを書く。アプリを「ツール」等の一般名詞で濁すな):
+$facts
+
+必須ルール:
+- 一人称の実体験で書く=自分が何を作った/実測した/つまずいたかを最低1つ具体で入れる。伝聞・一般論・精神論・造語を禁止。
+- 本文に上の実在機能を最低1つ名前で挙げる(固有機能名を必ず含める)。
+- 禁止フレーズ(これらを含む文は必ず書き直せ): $banned。
+- 誇張副詞(劇的に/大幅に/格段に/飛躍的に)で改善を主張するな。改善の大きさは具体的な数字か仕組み(何がどう動いて何が消えるか)でのみ語れ。
+
+例(実質・BAD→GOOD、この差を真似て今日の内容で書け):
+- BAD: 「あなたの価値、埋もれていませんか？埋もれた才能を最大限にアピールし、社会で輝くための自分集客力を構築。」
+- GOOD: 「『給料日サイクル』は支出の窓を給料日起点に切る機能。作って分かったのは、月初をまたぐ引き落としが二重計上されず支出が実額で出ること。5分触って一言もらえると助かります。」
+
+出力条件:
+- JSONのみを返す(Markdownやコードフェンスは禁止)
+- keys は title, body, hashtags
+- title: ${spec['titleRule']}。ただし空虚なフックでなく具体(機能名や数字)を入れる。
+- body: ${spec['bodyRule']}
+- tone: ${spec['tone']}
+- hashtags: $channelLabel に適した発見タグを3件
+
+出力形式:
+{
+  "title": "...",
+  "body": "...",
+  "hashtags": ["...", "...", "..."]
+}
+
+推奨ハッシュタグ:
+${hashtags.join(' ')}
+''';
+}
+
+/// 生成された title/body に含まれるスロップトークンを返す(空=クリーン)。
+/// プロンプトをすり抜けたスロップやクライアント側フォールバック文言を、投稿前に
+/// 非ブロッキングで警告するための検出器。
+List<String> detectSlop(String title, String body) {
+  final haystack = '$title\n$body';
+  return kSlopBannedTokens.where(haystack.contains).toList(growable: false);
+}
+
+/// 生成物が実在機能に1つでも触れているか。false=一般論に流れている疑い。
+bool hasFeatureAnchor(String title, String body) {
+  final haystack = '$title\n$body';
+  return kFeatureNames.any(haystack.contains);
+}

--- a/test/services/x_copy_guardrails_test.dart
+++ b/test/services/x_copy_guardrails_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/x_copy_guardrails.dart';
+
+void main() {
+  const xSpec = <String, String>{
+    'goal': 'X向けに3秒で伝わる短文を作る',
+    'titleRule': '見出しは28文字以内で強いフックを入れる',
+    'bodyRule': '本文は80-140文字。問題提起、便益、CTAを1つずつ入れる',
+    'tone': 'sharp, compact, high-contrast',
+  };
+  const fbSpec = <String, String>{
+    'goal': 'Facebook向けに文脈説明つきの長文を作る',
+    'titleRule': '見出しは28-48文字で内容が分かるようにする',
+    'bodyRule': '本文は220-420文字。課題、価値、CTAの3段落で書く',
+    'tone': 'warm, persuasive, slightly detailed',
+  };
+
+  group('buildCmoDraftPrompt injects the anti-slop apparatus', () {
+    final xPrompt = buildCmoDraftPrompt(
+      channelKey: 'x_share',
+      channelLabel: 'X',
+      spec: xSpec,
+      hashtags: const ['#自分株式会社', '#個人開発', '#buildinpublic'],
+    );
+
+    test('carries feature facts, first-person ban, and slop bans', () {
+      expect(xPrompt, contains('給料日サイクル'));
+      expect(xPrompt, contains('一人称'));
+      expect(xPrompt, contains('私たち')); // banned brand-voice explicitly listed
+      // observed slop tokens are present as bans.
+      for (final t in ['埋もれていませんか', '自分集客力', '最大限にアピール']) {
+        expect(xPrompt, contains(t), reason: 'ban $t missing');
+      }
+      // still a valid {title,body,hashtags} contract.
+      expect(xPrompt, contains('title'));
+      expect(xPrompt, contains('body'));
+      expect(xPrompt, contains('hashtags'));
+    });
+
+    test('preserves per-channel length spec (facebook 220-420 not overridden)',
+        () {
+      final fbPrompt = buildCmoDraftPrompt(
+        channelKey: 'facebook',
+        channelLabel: 'Facebook',
+        spec: fbSpec,
+        hashtags: const ['#自分株式会社'],
+      );
+      expect(fbPrompt, contains('220-420'));
+      expect(xPrompt, contains('80-140'));
+    });
+  });
+
+  group('detectSlop / hasFeatureAnchor', () {
+    const observedSlop = 'あなたの価値、埋もれていませんか？埋もれた才能を最大限にアピールし、'
+        '社会で輝くための自分集客力を構築。理想の未来へ、今すぐ一歩を踏み出しましょう。';
+    const goodCopy = '『給料日サイクル』は支出の窓を給料日起点に切る機能。作って分かったのは、'
+        '月初をまたぐ引き落としが二重計上されず支出が実額で出ること。';
+
+    test('detectSlop flags the real prod slop, passes the good copy', () {
+      final flagged = detectSlop('あなたの価値、埋もれていませんか？', observedSlop);
+      expect(flagged, contains('埋もれていませんか'));
+      expect(flagged, contains('自分集客力'));
+      expect(detectSlop('給料日サイクルの話', goodCopy), isEmpty);
+    });
+
+    test('hasFeatureAnchor: good copy names a feature, slop does not', () {
+      expect(hasFeatureAnchor('', goodCopy), isTrue);
+      expect(hasFeatureAnchor('', observedSlop), isFalse);
+    });
+
+    test('drift guard: core R11 terms are in the shared banlist', () {
+      expect(kSlopBannedTokens, contains('強力なツール'));
+      expect(kSlopBannedTokens, contains('可能性があります'));
+    });
+  });
+}


### PR DESCRIPTION
## R21: fix the dashboard 「X投稿を作る」 CTA generating pre-R11 AI-slop (CmoPage anti-slop port)

The dashboard's #1 growth CTA 「今やる流入改善アクション … X投稿を作る」 routes to CmoPage, which auto-generated (observed 2026-07-10) textbook pre-R11 slop:
> 「あなたの価値、埋もれていませんか？埋もれた才能を最大限にアピールし、社会で輝くための『自分集客力』を構築。理想の未来へ、今すぐ一歩を踏み出しましょう。」
No news hook, no first person, no real feature, no concrete number, an invented vague term (自分集客力), pure motivational filler — exactly the failure mode R11-R15 spent 5 rounds eliminating on the OTHER X-share path.

**Root cause: two separate X-copy generators.** `universal_x_share_service._buildDraftPrompt` (the AIシェア button) was hardened R11-R15 (feature facts, first-person persona, banned phrases, concreteness, BAD→GOOD). `CmoPage._buildDraftPrompt` (the dashboard CTA) is a bare generic prompt (goal/tone only) with none of it, so it silently undid the investment on the path the dashboard promotes.

**Fix = PORT, not unify/reroute** (unify hits a shape mismatch: lead+thread+poll+media vs flat {title,body,hashtags}; reroute leaves CmoPage's other entry points broken). One tight Dart-only PR:
- **New `lib/services/x_copy_guardrails.dart`** (dependency-zero, VM-testable): `kAppFeatureFacts` (moved byte-identical from universal_x_share_service so the two generators can't drift), `kSlopBannedTokens` (R11 core terms + the observed slop phrases), `kFeatureNames`, pure `buildCmoDraftPrompt(...)`, `detectSlop(...)`, `hasFeatureAnchor(...)`.
- `universal_x_share_service` now references the shared const via a private alias (`_appFeatureFacts = kAppFeatureFacts`) — every other line, incl. the R11-R15-tuned inline prose, byte-unchanged (its 57-test suite still green).
- `CmoPage._buildDraftPrompt` now calls `buildCmoDraftPrompt` — injecting feature facts + first-person operator persona (bans 私たち/弊社/本サービスは) + the banned-phrase block + a name-a-real-feature + one-concrete-anchor rule + a BAD→GOOD example, channel-agnostic so it fixes BOTH x_share AND facebook, keeping each channel's length/tone spec and the {title,body,hashtags} contract untouched.
- x_share hashtags: `#X投稿/#集客改善` → discovery tags `#個人開発 #buildinpublic`.
- Non-blocking slop guard: after generation, `detectSlop`/`hasFeatureAnchor` render a 「言い換え候補 … 再生成を推奨」 warning banner (never blocks the post button, never auto-fires a paid regenerate — known foot-gun).

`flutter test`: 5 new guardrails cases green + universal_x_share_service 57 green (no regression). Analyze clean, format fixpoint.

Deferred follow-ups (recorded, not this PR): unify the two generators through a single service; harden the line→AISecretaryPage and qr→NoteListPage dashboard CTAs similarly.

## Minimal E2E Gate

- Implementation-detail independent: tests assert the built prompt content and the slop/feature detectors from inputs, not private widget internals.
- Minimal scope: about 3 cases (prompt injects facts+bans+contract; per-channel length preserved; detectSlop flags real slop / passes good copy).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: prompt-content + pure-detector change verified by implementation-independent unit tests over dependency-zero functions; no user-facing route flow changes, so no integration_test/Playwright route applies.
