### PR TITLE
feat(seo): dev.to syndicate 記事の canonical_url を自サイトへ向ける (H7本体)

### DIFF
--- a/supabase/functions/schedule-hub/blog_canonical.ts
+++ b/supabase/functions/schedule-hub/blog_canonical.ts
@@ -1,0 +1,16 @@
+// blog_canonical.ts — dev.to / Qiita へ syndicate する記事の canonical_url を
+// 自サイトの公開ブログ (/blog/post?id=X) に向けるためのヘルパー。
+//
+// SEO 監査 H7: dev.to に投稿した記事は dev.to 側が canonical 扱いになり、
+// 検索エンジンの評価 (authority) が外部ドメインに流出していた。Forem (dev.to) API の
+// article.canonical_url に自サイト URL を渡すと「原典は自サイト」と宣言でき、
+// authority を自ドメインへ集約できる。向け先は core-hub blog_view.ts が SSR 配信する
+// /blog/post?id=X (= blog_posts の status='posted' 行) と同一形状にする。
+
+export const BLOG_APP_BASE_URL = "https://my-web-app-b67f4.web.app/blog/post";
+
+// blog_posts.id を受け取り、自サイトの公開ブログ URL を返す。
+// core-hub blog_view.ts の buildBlogPostUrl と同じ形状 (?id=<encoded>)。
+export function buildOwnSiteBlogPostUrl(id: string): string {
+  return `${BLOG_APP_BASE_URL}?id=${encodeURIComponent(id)}`;
+}

--- a/supabase/functions/schedule-hub/blog_canonical_test.ts
+++ b/supabase/functions/schedule-hub/blog_canonical_test.ts
@@ -1,0 +1,24 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { buildOwnSiteBlogPostUrl } from "./blog_canonical.ts";
+
+Deno.test("buildOwnSiteBlogPostUrl: 自サイト /blog/post?id=X を返す", () => {
+  assertEquals(
+    buildOwnSiteBlogPostUrl("123"),
+    "https://my-web-app-b67f4.web.app/blog/post?id=123",
+  );
+});
+
+Deno.test("buildOwnSiteBlogPostUrl: id を URL エンコードする", () => {
+  const url = buildOwnSiteBlogPostUrl("a b/c?d");
+  assertStringIncludes(url, "id=a%20b%2Fc%3Fd");
+  // クエリ区切りが 1 つだけ (injection されない)
+  assertEquals(url.split("?").length, 2);
+});
+
+Deno.test("buildOwnSiteBlogPostUrl: 自ドメインを指す (dev.to 側ではない)", () => {
+  const url = buildOwnSiteBlogPostUrl("456");
+  assertStringIncludes(url, "https://my-web-app-b67f4.web.app/blog/post");
+});

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -20,6 +20,7 @@ import {
   externalFetchErrorPayload,
   isExternalFetchError,
 } from "../_shared/external_fetch.ts";
+import { buildOwnSiteBlogPostUrl } from "./blog_canonical.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -2373,6 +2374,11 @@ serve(async (req: Request) => {
                   body_markdown: ppContent,
                   published: true,
                   tags: cleanTags.length > 0 ? cleanTags : ["flutter"],
+                  // SEO 監査 H7: postId は blog_posts.id で、直後に status='posted'
+                  // へ更新され core-hub blog_view.ts が /blog/post?id=X で SSR 配信する。
+                  // canonical_url を自サイトへ向け、dev.to へ流出していた検索 authority を
+                  // 自ドメインに集約する。
+                  canonical_url: buildOwnSiteBlogPostUrl(postId),
                 },
               }),
             }, "schedule-hub.blog.publish_post.devto");


### PR DESCRIPTION
## Minimal E2E Gate

- E2E-Exception: 純粋関数 `buildOwnSiteBlogPostUrl(id)` の追加と、それを既存 `blog.publish_post` の dev.to payload に 1 フィールド (`canonical_url`) 差し込むだけの変更。user-visible I/O は `blog_canonical_test.ts` の 3 unit test (URL 形状 / URL エンコード安全性 / 自ドメイン指定) でカバー。実際の dev.to 投稿は外部 API 副作用のため E2E 化不能 (DEVTO_API_KEY 必須 / 本番投稿が発生)。canonical 先 `/blog/post?id=X` の解決性は土台 PR #3925 の日次 smoke (`blog.public.list`) が担保。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: schedule-hub の `blog.publish_post` dev.to payload に `canonical_url` を 1 行追加するのみ。auth/billing/data-migration/secret 変更なし。`postId` は既存の `blog_posts.id` (直後に status='posted' 更新) で必ず解決する URL を生成。公開範囲・DB スキーマ・認証分岐は不変。rollback = 単一 revert。observability = EF logs (schedule-hub.blog.publish_post.devto trace)。

## 📝 変更内容

SEO監査 **H7 本体**。dev.to へ syndicate した記事は dev.to 側が canonical 扱いになり、検索エンジンの評価 (authority) が外部ドメインへ流出していた。Forem (dev.to) API の `article.canonical_url` に自サイト URL を渡し「原典は自サイト」と宣言、authority を自ドメインへ集約する。向け先は土台 PR #3925 で SSR 可能にした `/blog/post?id=X` (= `blog_posts` の status='posted' 行)。

### 変更の種類

- [x] 新機能 (breaking changeを含まない機能追加)

## 📋 実装の詳細

- **`blog_canonical.ts` (新規)** — `buildOwnSiteBlogPostUrl(id)`。core-hub `blog_view.ts` の `buildBlogPostUrl` と同一 URL 形状 (`/blog/post?id=<encoded>`)。schedule-hub は単一 `index.ts` (top-level `serve()`) のため、テスト時にサーバ起動しないよう独立モジュールへ抽出。
- **`blog_canonical_test.ts` (新規)** — 3 tests (URL 形状 / `encodeURIComponent` によるクエリ injection 防止 / 自ドメイン指定)。
- **`index.ts`** — `blog.publish_post` の dev.to `article` に `canonical_url: buildOwnSiteBlogPostUrl(postId)` を付与。`postId` は `blog_posts.id` で、投稿成功直後に `status='posted'` へ更新されるため canonical 先は必ず解決する。

## 🎯 対象範囲の明示 (誠実な限界)

- **対象**: `blog.publish_post` (admin レビュー公開経路 / admin UI + blog-publish.yml の review-approved step)。ここは `postId` が `blog_posts.id` で SSR 解決可能。
- **対象外**: `blog.auto_publish` (T-1 自動 syndication 経路)。この `id` は `blog.create` が作る **`hub_data`** 行由来で `/blog/post?id=X` (= `blog_posts` を読む) では解決しない。canonical を向けると 404 先を宣言してしまうため意図的に除外。auto_publish 記事の canonical 集約には blog_posts 化が必要 (別 issue / スコープ外)。

## ✅ テスト結果

| テストケース | 結果 | 備考 |
| --- | --- | --- |
| `blog_canonical_test.ts` 3件 | ✅ | ローカル assert shim で全パス |
| `deno lint` / `deno fmt --check` (blog_canonical.ts / _test.ts / index.ts) | ✅ | 0エラー |
| `deno check blog_canonical.ts` | ✅ | 型OK |

## 🔒 セキュリティへの影響

- [x] 公開範囲の拡大なし。DB スキーマ・認証・secret 不変。
- [x] `encodeURIComponent` で URL injection を防止 (test でカバー)。

## 🚀 デプロイメモ

- [x] 特別なデプロイ手順は不要 (schedule-hub は既存デプロイ対象)。
- 反映後、`blog.publish_post` 経由の新規 dev.to 記事に canonical_url が付き、Google が自サイトを原典として評価する。既存記事は再投稿時に反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEjNJ4X3zqyc6ffjLoozjc)_