### PR TITLE
Add TTS reading lexicon to fix kanji misreadings in narration

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"07a26637-a421-5adc-abe6-14c3f7b7dd1c","pid":571,"procStart":"8239","acquiredAt":1783606739112}
+{"sessionId":"4bb21e27-97da-5cd0-983b-426ed3da8eaf","pid":554,"procStart":"4636","acquiredAt":1783770605632}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"4bb21e27-97da-5cd0-983b-426ed3da8eaf","pid":554,"procStart":"4636","acquiredAt":1783770605632}

--- a/supabase/functions/viral-video-ad-generator/index.ts
+++ b/supabase/functions/viral-video-ad-generator/index.ts
@@ -29,6 +29,7 @@ import {
   resolveElevenLabsVoiceId,
   voiceGenderForLabel,
 } from "./voice_labels.ts";
+import { applyTtsReadings } from "./tts_reading_lexicon.ts";
 import {
   buildCaptionSrt,
   buildForceStyle,
@@ -726,6 +727,10 @@ async function createHedraPresenterVideo(params: {
     params.title,
   )
     .join("\n");
+  // TTS へ渡すテキストにだけ読み辞書を適用する (誤読対策 / 例: 負債→ふさい)。
+  // 字幕 (index.ts の spokenForCaptions) は漢字表記のまま維持される。
+  const ttsText = applyTtsReadings(spokenScript, params.lang)
+    .slice(0, MAX_SPOKEN_CHARS);
   let audioProvider = "hedra_tts";
   let storedAudioUrl: string | null = null;
   let storedAudioPath: string | null = null;
@@ -754,7 +759,7 @@ async function createHedraPresenterVideo(params: {
       }
       const audio = await createElevenLabsSpeechAsset(params.admin, {
         // 動画を短尺に保つための上限。全 TTS 経路で MAX_SPOKEN_CHARS に統一。
-        text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
+        text: ttsText,
         templateTitle: params.title ?? "share-update",
         lang: params.lang,
         voiceId: resolveElevenLabsVoiceForLabel(params.voice),
@@ -780,7 +785,7 @@ async function createHedraPresenterVideo(params: {
         shouldRetryElevenLabsWithFallbackVoice(error)
       ) {
         const fallbackResult = await tryElevenLabsFallbackVoices(params.admin, {
-          text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
+          text: ttsText,
           templateTitle: params.title ?? "share-update",
           lang: params.lang,
           configuredVoiceId: ELEVENLABS_AI_SECRETARY_VOICE_ID,
@@ -799,7 +804,7 @@ async function createHedraPresenterVideo(params: {
             storedAudioPath,
             audioProvider,
             imageUrl,
-            fallbackText: spokenScript.slice(0, MAX_SPOKEN_CHARS),
+            fallbackText: ttsText,
           });
         }
         speechChain.push(`fallback_voices=${fallbackResult.reason}`);
@@ -810,7 +815,7 @@ async function createHedraPresenterVideo(params: {
       if (OPENAI_API_KEY) {
         try {
           const openAiAudio = await createOpenAiSpeechAsset(params.admin, {
-            text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
+            text: ttsText,
             templateTitle: `${params.title ?? "share-update"}-openai-tts`,
             lang: params.lang,
           });
@@ -826,7 +831,7 @@ async function createHedraPresenterVideo(params: {
             storedAudioPath,
             audioProvider,
             imageUrl,
-            fallbackText: spokenScript.slice(0, MAX_SPOKEN_CHARS),
+            fallbackText: ttsText,
           });
         } catch (openAiError) {
           speechChain.push(`openai_tts=${providerErrorMessage(openAiError)}`);
@@ -839,7 +844,7 @@ async function createHedraPresenterVideo(params: {
         speechChain.join(" | "),
       );
       audioGeneration = await createHedraTextToSpeechAudioGeneration(params, {
-        text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
+        text: ttsText,
       });
       audioProvider = params.requiresUploadedAudio
         ? "hedra_tts_after_premium_speech_failure"
@@ -847,7 +852,7 @@ async function createHedraPresenterVideo(params: {
     }
   } else {
     audioGeneration = await createHedraTextToSpeechAudioGeneration(params, {
-      text: spokenScript.slice(0, MAX_SPOKEN_CHARS),
+      text: ttsText,
     });
   }
 
@@ -858,7 +863,7 @@ async function createHedraPresenterVideo(params: {
       storedAudioPath,
       audioProvider,
       imageUrl,
-      fallbackText: spokenScript.slice(0, MAX_SPOKEN_CHARS),
+      fallbackText: ttsText,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/supabase/functions/viral-video-ad-generator/tts_reading_lexicon.test.ts
+++ b/supabase/functions/viral-video-ad-generator/tts_reading_lexicon.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  applyTtsReadings,
+  JA_TTS_READING_LEXICON,
+} from "./tts_reading_lexicon.ts";
+
+Deno.test("負債 is read ふさい (observed TTS misread ふくたく / 2026-07-10)", () => {
+  assertEquals(
+    applyTtsReadings("負債トレンド機能を強化しました。", "ja"),
+    "ふさいトレンド機能を強化しました。",
+  );
+});
+
+Deno.test("compound words containing lexicon entries stay readable", () => {
+  assertEquals(
+    applyTtsReadings("資産負債のバランスと固定費・変動費を確認。", "ja"),
+    "資産ふさいのバランスとこていひ・へんどうひを確認。",
+  );
+});
+
+Deno.test("all lexicon occurrences are replaced, not just the first", () => {
+  assertEquals(
+    applyTtsReadings("負債を減らす。負債トレンドを見る。", "ja"),
+    "ふさいを減らす。ふさいトレンドを見る。",
+  );
+});
+
+Deno.test("text without lexicon entries is returned unchanged", () => {
+  const text = "AI仕事OSは、学習・仕事ログ・資産管理をひとつに整理できます。";
+  assertEquals(applyTtsReadings(text, "ja"), text);
+});
+
+Deno.test("english narration is never rewritten", () => {
+  const text = "負債 trend feature explained in English narration.";
+  assertEquals(applyTtsReadings(text, "en"), text);
+});
+
+Deno.test("lexicon readings are hiragana/katakana only (no kanji left)", () => {
+  for (const [surface, reading] of JA_TTS_READING_LEXICON) {
+    const hasKanji = /[一-鿿]/u.test(reading);
+    assertEquals(
+      hasKanji,
+      false,
+      `reading for ${surface} must not contain kanji: ${reading}`,
+    );
+  }
+});

--- a/supabase/functions/viral-video-ad-generator/tts_reading_lexicon.ts
+++ b/supabase/functions/viral-video-ad-generator/tts_reading_lexicon.ts
@@ -1,0 +1,44 @@
+// viral-video-ad-generator: TTS 読み辞書 (kanji → kana)。
+//
+// なぜ必要か:
+//   ElevenLabs / OpenAI / Hedra の各 TTS は漢字の読みを文脈から推測するため、
+//   アプリ固有の熟語を誤読することがある (実観測: 「負債トレンド機能」→
+//   「ふくたくトレンド機能」/ 2026-07-10 ユーザー報告)。
+//
+// 設計:
+//   - TTS へ渡す直前の spoken text に **だけ** 適用する。字幕 (captions.ts の
+//     buildCaptionSrt へ渡すテキスト) と X 投稿本文は漢字表記のまま維持する。
+//   - 字幕の行尺推定 (文字数比) は字幕側テキストで行われるので、かな置換で
+//     TTS 文字数が数文字伸びても同期への影響は誤差レベル (最終的に実測動画長で
+//     リスケールされる)。
+//   - エントリは「観測された誤読」または「金融・アプリ用語で誤読リスクが明確な語」
+//     に限定する。一般語を無闇に足すと、かな連続で逆にアクセントが崩れるため。
+//   - 置換は最長一致 (エントリを長い順に適用) で、複合語 (例: 資産負債) の
+//     部分置換でも読みが保たれる組だけ登録する。
+
+/** 日本語 TTS 読み辞書。[表記, 読み(ひらがな)] を長い順に適用する。 */
+export const JA_TTS_READING_LEXICON: ReadonlyArray<readonly [string, string]> =
+  [
+    // 実観測の誤読 (2026-07-10): 「負債」を「ふくたく」と誤読。
+    ["負債", "ふさい"],
+    // 以下はアプリのナレーションに頻出し、TTS が誤読しやすい熟語。
+    ["変動費", "へんどうひ"],
+    ["固定費", "こていひ"],
+    ["前月比", "ぜんげつひ"],
+    ["前日比", "ぜんじつひ"],
+  ];
+
+/**
+ * TTS へ渡すテキストに読み辞書を適用する。
+ * 字幕・投稿本文には適用しないこと (漢字表記が正)。
+ */
+export function applyTtsReadings(text: string, lang: "ja" | "en"): string {
+  if (lang !== "ja" || text.length === 0) return text;
+  let spoken = text;
+  const entries = [...JA_TTS_READING_LEXICON]
+    .sort((a, b) => b[0].length - a[0].length);
+  for (const [surface, reading] of entries) {
+    spoken = spoken.split(surface).join(reading);
+  }
+  return spoken;
+}


### PR DESCRIPTION
# Pull Request

## 📝 変更内容

Added a Japanese TTS reading lexicon system to correct kanji misreadings in text-to-speech narration. The system applies hiragana/katakana substitutions only to the spoken text passed to TTS providers (ElevenLabs, OpenAI, Hedra), while preserving kanji in captions and social media posts.

### 変更の種類

- [x] 新機能 (breaking changeを含まない機能追加)
- [x] テスト追加・修正

## 🎯 変更の目的

ElevenLabs, OpenAI, and Hedra TTS engines misread certain Japanese kanji based on context. Observed case: 「負債」(fusai / debt) was misread as 「ふくたく」(fukutaku) instead of the correct reading. This feature allows us to pre-substitute known problematic kanji with their correct hiragana readings before sending text to TTS, while keeping the original kanji in captions and posts.

## 📋 実装の詳細

### 主な変更点

1. **New file: `tts_reading_lexicon.ts`**
   - Exports `JA_TTS_READING_LEXICON`: a readonly array of `[kanji, reading]` tuples applied longest-first for greedy matching
   - Exports `applyTtsReadings(text, lang)`: applies the lexicon only for Japanese (`lang === "ja"`)
   - Lexicon entries limited to observed misreadings or high-risk financial/app terminology
   - All readings are hiragana/katakana only (no kanji in the reading itself)

2. **New file: `tts_reading_lexicon.test.ts`**
   - 5 test cases covering:
     - Observed misreading correction (負債 → ふさい)
     - Compound word handling (複合語での部分置換)
     - Multiple occurrences replaced (not just first)
     - Unchanged text when no lexicon entries match
     - English text never rewritten
   - 1 validation test ensuring all lexicon readings contain no kanji

3. **Modified: `index.ts` (createHedraPresenterVideo)**
   - Apply `applyTtsReadings()` to `spokenScript` before passing to any TTS provider
   - Store result in `ttsText` variable
   - Replace all 8 instances of `spokenScript.slice(0, MAX_SPOKEN_CHARS)` with `ttsText` across:
     - ElevenLabs primary call
     - ElevenLabs fallback voice retry
     - OpenAI TTS fallback
     - Hedra native TTS fallback (incl. `fallbackText`)
   - Captions and social posts continue using original `spokenScript` (kanji preserved)

### 技術的な詳細

- **Design principle**: TTS text path only. Captions use `spokenForCaptions` (original kanji), posts use original text. This avoids breaking caption line-length estimation since the final video is rescaled to actual audio duration.
- **Longest-match strategy**: Entries sorted descending by length to handle compound words correctly (e.g., 「資産負債」 → 「資産ふさい」).
- **Conservative lexicon**: Only entries with observed misreadings or clear financial/app terminology risk. General kanji substitution avoided to prevent accent degradation in continuous hiragana sequences.

## ✅ テスト結果

### テスト実施項目

- [x] 単体テスト (5 functional + 1 validation test in `tts_reading_lexicon.test.ts`)
- [x] `deno lint` / `deno fmt --check` 通過 (edited files)

### テストケース

| テストケース | 結果 | 備考 |
| --- | --- | --- |
| 負債 misreading correction | ✅ | Observed TTS misread (2026-07-10) |
| Compound words (資産負債/固定費/変動費) | ✅ | Longest-first greedy matching |
| Multiple occurrences replaced | ✅ | `split().join()` replaces all |
| No-op text unchanged | ✅ | Lexicon-free text passes through |
| English narration untouched | ✅ | `lang !== "ja"` returns input |
| Lexicon readings kana-only | ✅ | Guards future lexicon additions |

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Edge Function narration-only change; no user-visible UI flow to drive; covered by deno unit tests on the pure text transform

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: TTS narration text-only transform in viral-video-ad-generator EF; no auth/RLS/schema/secret change; unit-tested pure function; graceful TTS fallback chain unchanged

https://claude.ai/code/session_01NBd7ysPkoTySAUauKzBvG2