### PR TITLE
ci: claude-hygiene cron 8→4x/日 + public-memo-smoke concurrency (2026-07-11 ci-audit)

### DIFF
--- a/.github/workflows/claude-session-hygiene-cron.yml
+++ b/.github/workflows/claude-session-hygiene-cron.yml
@@ -2,9 +2,9 @@ name: Claude Session Hygiene Cron
 
 on:
   schedule:
-    # Every 180 minutes from 06:00 JST through 03:00 JST next day.
-    # (2026-06-12 ci-audit: 30分→60分 / 2026-06-18 ci-audit: 60分→120分, 21→11runs/日 / 2026-06-21 ci-audit: 120分→180分, 11→8runs/日削減)
-    - cron: "0 21,0,3,6,9,12,15,18 * * *"
+    # Every 360 minutes (6h) from 06:00 JST through 03:00 JST next day.
+    # (2026-06-12 ci-audit: 30分→60分 / 2026-06-18 ci-audit: 60分→120分, 21→11runs/日 / 2026-06-21 ci-audit: 120分→180分, 11→8runs/日 / 2026-07-11 ci-audit: 180分→360分, 8→4runs/日)
+    - cron: "0 21,3,9,15 * * *"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/public-memo-smoke.yml
+++ b/.github/workflows/public-memo-smoke.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: public-memo-smoke
+  cancel-in-progress: true  # 2026-07-11 ci-audit: 日次+手動重複実行防止
+
 jobs:
   smoke:
     name: Anonymous GET smoke


### PR DESCRIPTION
## 概要

CI/CD コスト監査 2026-07-11 の自動適用 PR。2026-07-10 の監査で宣言されたが未コミットだった 2 件の変更を再適用します。

## 変更内容

### 1. `claude-session-hygiene-cron.yml` — cron 8x/日 → 4x/日

- **変更前**: `"0 21,0,3,6,9,12,15,18 * * *"` (180 分間隔 / 8 runs/日)
- **変更後**: `"0 21,3,9,15 * * *"` (360 分間隔 / 4 runs/日)
- `windows-latest` runner (ubuntu の 2 倍課金) のため効果大
- 推定削減: **~120 windows-min/月 ≒ 240 ubuntu換算 min/月**
- `cancel-in-progress: true` は既設定のため変更なし
- ホワイトリスト項目: 「過剰な schedule cron の頻度削減」に該当

### 2. `public-memo-smoke.yml` — concurrency block 追加

- 日次 + 手動実行重複時のキュー積み上がりを防止
- `cancel-in-progress: true` を追加
- ホワイトリスト項目: 「deploy 以外の workflow への concurrency 追加」に該当

## 安全性確認

- deploy 系 (deploy-prod / deploy-dev / deploy-staging) は一切変更なし
- secrets / permissions / トリガー種別の変更なし
- 変更ファイル数: 2 (上限 2 以内)
- YAML 構文: `python3 -c "import yaml; yaml.safe_load(open(f))"` で両ファイル検証済み

## 参照

- 監査レポート: `docs/ci-cd-audit/2026-07-11.md`
- 追跡 Issue: #3841

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpY8nA8rDFnyTZ7X8YJhKj)_