### PR TITLE
feat: add image generation quality controls

### DIFF
--- a/lib/pages/ai_image_generator_page.dart
+++ b/lib/pages/ai_image_generator_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../services/ai_image_generation_request.dart';
+
 /// AI 画像生成ページ
 /// media-hub Edge Function と連携して AI 画像を生成・管理
 class AiImageGeneratorPage extends StatefulWidget {
@@ -19,6 +21,7 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
   String? _errorMessage;
   String _selectedSize = '1024x1024';
   String _selectedStyle = 'vivid';
+  AiImageGenerationQuality _selectedQuality = AiImageGenerationQuality.medium;
   List<_GeneratedImage> _images = [];
 
   bool get _isBusy => _isFetching || _isGenerating;
@@ -69,9 +72,7 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
       final images = rows
           .whereType<Map>()
           .map(
-            (row) => _GeneratedImage.fromHubRow(
-              Map<String, dynamic>.from(row),
-            ),
+            (row) => _GeneratedImage.fromHubRow(Map<String, dynamic>.from(row)),
           )
           .where((image) => image.imageUrl.isNotEmpty)
           .toList();
@@ -95,12 +96,12 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
     try {
       final response = await _supabase.functions.invoke(
         'media-hub',
-        body: {
-          'action': 'image.generate',
-          'prompt': prompt,
-          'size': _selectedSize,
-          'style': _selectedStyle,
-        },
+        body: buildAiImageGenerateBody(
+          prompt: prompt,
+          size: _selectedSize,
+          style: _selectedStyle,
+          quality: _selectedQuality,
+        ),
       );
       final data = response.data;
       if (data is Map<String, dynamic> && data['error'] != null) {
@@ -182,6 +183,31 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
                   : (selection) =>
                       setState(() => _selectedStyle = selection.first),
             ),
+            const SizedBox(height: 8),
+            SegmentedButton<AiImageGenerationQuality>(
+              segments: AiImageGenerationQuality.values
+                  .map(
+                    (quality) => ButtonSegment<AiImageGenerationQuality>(
+                      value: quality,
+                      label: Text(quality.label),
+                      tooltip: quality.description,
+                      icon: Icon(
+                        switch (quality) {
+                          AiImageGenerationQuality.low => Icons.flash_on,
+                          AiImageGenerationQuality.medium =>
+                            Icons.balance_outlined,
+                          AiImageGenerationQuality.high => Icons.high_quality,
+                        },
+                      ),
+                    ),
+                  )
+                  .toList(),
+              selected: {_selectedQuality},
+              onSelectionChanged: _isBusy
+                  ? null
+                  : (selection) =>
+                      setState(() => _selectedQuality = selection.first),
+            ),
             const SizedBox(height: 12),
             ElevatedButton.icon(
               onPressed: _isBusy ? null : _generate,
@@ -197,10 +223,7 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
               const SizedBox(height: 8),
               Text(
                 _errorMessage!,
-                style: const TextStyle(
-                  color: Color(0xFFE53935),
-                  height: 1.5,
-                ),
+                style: const TextStyle(color: Color(0xFFE53935), height: 1.5),
                 textAlign: TextAlign.center,
               ),
             ],
@@ -275,9 +298,7 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
                 ),
               ),
             ] else
-              const Expanded(
-                child: Center(child: Text('生成済み画像はありません')),
-              ),
+              const Expanded(child: Center(child: Text('生成済み画像はありません'))),
           ],
         ),
       ),
@@ -291,6 +312,7 @@ class _GeneratedImage {
     required this.imageUrl,
     required this.size,
     required this.style,
+    required this.quality,
     required this.createdAt,
   });
 
@@ -298,6 +320,7 @@ class _GeneratedImage {
   final String imageUrl;
   final String size;
   final String style;
+  final String quality;
   final String createdAt;
 
   factory _GeneratedImage.fromHubRow(Map<String, dynamic> row) {
@@ -312,6 +335,7 @@ class _GeneratedImage {
           '',
       size: metadata['size']?.toString() ?? '',
       style: metadata['style']?.toString() ?? '',
+      quality: metadata['quality']?.toString() ?? '',
       createdAt: row['created_at']?.toString() ??
           row['createdAt']?.toString() ??
           metadata['created_at']?.toString() ??
@@ -323,6 +347,7 @@ class _GeneratedImage {
     final parts = [
       if (size.isNotEmpty) size,
       if (style.isNotEmpty) styleLabels[style] ?? style,
+      if (quality.isNotEmpty) AiImageGenerationQuality.fromValue(quality).label,
       if (createdAt.isNotEmpty) createdAt,
     ];
     return parts.join(' / ');

--- a/lib/services/ai_image_generation_request.dart
+++ b/lib/services/ai_image_generation_request.dart
@@ -1,0 +1,37 @@
+enum AiImageGenerationQuality {
+  low(value: 'low', label: '高速', description: 'アイデア出しや大量生成向け。待ち時間を短くします。'),
+  medium(value: 'medium', label: '標準', description: '速度と品質のバランスを取った通常設定です。'),
+  high(value: 'high', label: '高画質', description: '細部の忠実度を優先します。図解や仕上げ用途向けです。');
+
+  const AiImageGenerationQuality({
+    required this.value,
+    required this.label,
+    required this.description,
+  });
+
+  final String value;
+  final String label;
+  final String description;
+
+  static AiImageGenerationQuality fromValue(String? value) {
+    for (final quality in values) {
+      if (quality.value == value) return quality;
+    }
+    return medium;
+  }
+}
+
+Map<String, Object> buildAiImageGenerateBody({
+  required String prompt,
+  required String size,
+  required String style,
+  required AiImageGenerationQuality quality,
+}) {
+  return {
+    'action': 'image.generate',
+    'prompt': prompt,
+    'size': size,
+    'style': style,
+    'quality': quality.value,
+  };
+}

--- a/test/pages/ai_image_generator_page_test.dart
+++ b/test/pages/ai_image_generator_page_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/ai_image_generator_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await Supabase.initialize(
+      url: 'https://dummy.supabase.co',
+      publishableKey: 'dummy',
+    );
+  });
+
+  testWidgets('renders image quality choices with usage tooltips', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: AiImageGeneratorPage()),
+    );
+    await tester.pump();
+
+    expect(find.text('高速'), findsOneWidget);
+    expect(find.text('標準'), findsOneWidget);
+    expect(find.text('高画質'), findsOneWidget);
+    expect(find.byTooltip('アイデア出しや大量生成向け。待ち時間を短くします。'), findsOneWidget);
+    expect(find.byTooltip('速度と品質のバランスを取った通常設定です。'), findsOneWidget);
+    expect(
+      find.byTooltip('細部の忠実度を優先します。図解や仕上げ用途向けです。'),
+      findsOneWidget,
+    );
+  });
+}

--- a/test/services/ai_image_generation_request_test.dart
+++ b/test/services/ai_image_generation_request_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/ai_image_generation_request.dart';
+
+void main() {
+  test('builds image.generate body with selected quality', () {
+    final body = buildAiImageGenerateBody(
+      prompt: 'watercolor mountain calendar',
+      size: '1024x1024',
+      style: 'natural',
+      quality: AiImageGenerationQuality.high,
+    );
+
+    expect(body['action'], 'image.generate');
+    expect(body['prompt'], 'watercolor mountain calendar');
+    expect(body['size'], '1024x1024');
+    expect(body['style'], 'natural');
+    expect(body['quality'], 'high');
+  });
+
+  test('falls back to medium for unknown stored quality values', () {
+    expect(
+      AiImageGenerationQuality.fromValue('unexpected'),
+      AiImageGenerationQuality.medium,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Add a quality selector to the AI image generator with low / medium / high choices and usage tooltips.
- Pass the selected quality through the `image.generate` media-hub request body.
- Show stored quality in generated image metadata and add focused service/page tests.

Closes #1219

## Validation
- `flutter test --no-pub test\services\ai_image_generation_request_test.dart test\pages\ai_image_generator_page_test.dart`
- `flutter analyze lib\services\ai_image_generation_request.dart lib\pages\ai_image_generator_page.dart test\services\ai_image_generation_request_test.dart test\pages\ai_image_generator_page_test.dart`

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Focused selector UI plus request-body behavior is covered by widget and service tests; no new route-level E2E is needed for this narrow option wiring.
