### PR TITLE
fix(loyalty): ポイント残高表示 + 履歴の捏造 +0pt 行を修正

### DIFF
--- a/lib/models/loyalty_points_summary.dart
+++ b/lib/models/loyalty_points_summary.dart
@@ -1,0 +1,157 @@
+/// ロイヤリティポイントの集計モデル。
+///
+/// `social-commerce-hub` Edge Function の `loyalty.balance` レスポンスを
+/// 解析する純データモデル (Flutter 依存なし → VM 単体テスト可能)。
+///
+/// EF レスポンス形状:
+/// ```json
+/// {
+///   "success": true,
+///   "balance": 1250,
+///   "history": [
+///     {
+///       "id": "...",
+///       "metadata": {
+///         "amount": 500,          // 付与は正 / 交換は負
+///         "reason": "初回登録ボーナス",
+///         "earned_at": "2026-07-12T...",
+///         "user_id": "..."
+///       },
+///       "created_at": "2026-07-12T..."   // トップレベル列
+///     }
+///   ]
+/// }
+/// ```
+///
+/// 旧実装は `item['points']` / `item['type']` / `item['description']` という
+/// 存在しないキーを読んでいたため、全行が「ポイント N / +0 pt」という
+/// 捏造表示になっていた。本モデルは nested `metadata` から正しく読み取る。
+library;
+
+num _toNum(dynamic value) {
+  if (value is num) return value;
+  return num.tryParse(value?.toString() ?? '') ?? 0;
+}
+
+/// ポイント履歴 1 件。
+class LoyaltyPointEntry {
+  const LoyaltyPointEntry({
+    required this.amount,
+    required this.reason,
+    required this.createdAt,
+  });
+
+  /// 符号付きポイント数。正 = 付与 / 負 = 交換 (redeem)。
+  final num amount;
+
+  /// 人が読める理由・説明。
+  final String reason;
+
+  /// 生の ISO タイムスタンプ (空文字の場合あり)。
+  final String createdAt;
+
+  /// 付与 (earn) なら true、交換 (redeem) なら false。
+  bool get isEarn => amount >= 0;
+
+  /// EF の hub_data 行 (nested metadata) から 1 件を構築する。
+  /// 後方互換のため flat キーもフォールバックとして読む。
+  factory LoyaltyPointEntry.fromMap(Map<String, dynamic> raw) {
+    final metadata = raw['metadata'];
+    final meta = metadata is Map
+        ? metadata.cast<String, dynamic>()
+        : const <String, dynamic>{};
+
+    final rawAmount = meta['amount'] ?? raw['amount'] ?? raw['points'] ?? 0;
+    final reason = (meta['reason'] ?? raw['reason'] ?? raw['description'] ?? '')
+        .toString()
+        .trim();
+    final createdAt =
+        (raw['created_at'] ?? meta['earned_at'] ?? meta['redeemed_at'] ?? '')
+            .toString();
+
+    return LoyaltyPointEntry(
+      amount: _toNum(rawAmount),
+      reason: reason.isEmpty ? 'ポイント履歴' : reason,
+      createdAt: createdAt,
+    );
+  }
+}
+
+/// ポイント残高 + 履歴のまとめ。
+class LoyaltyPointsSummary {
+  const LoyaltyPointsSummary({required this.balance, required this.entries});
+
+  /// 合計ポイント残高。
+  final num balance;
+
+  /// 履歴 (新しい順)。
+  final List<LoyaltyPointEntry> entries;
+
+  bool get isEmpty => entries.isEmpty;
+
+  static const LoyaltyPointsSummary empty =
+      LoyaltyPointsSummary(balance: 0, entries: <LoyaltyPointEntry>[]);
+
+  /// EF レスポンス (`{balance, history}` / 生の List / null) を頑健に解析する。
+  factory LoyaltyPointsSummary.fromResponse(dynamic data) {
+    List<Map<String, dynamic>> rawList;
+    num? balance;
+
+    if (data is Map) {
+      final map = data.cast<String, dynamic>();
+      final history = map['history'];
+      rawList = history is List
+          ? history
+              .whereType<Map>()
+              .map((e) => e.cast<String, dynamic>())
+              .toList()
+          : <Map<String, dynamic>>[];
+      // balance:0 は正当な値なので「キー存在」で判定する (null のみ未取得扱い)。
+      if (map['balance'] != null) balance = _toNum(map['balance']);
+    } else if (data is List) {
+      rawList =
+          data.whereType<Map>().map((e) => e.cast<String, dynamic>()).toList();
+    } else {
+      rawList = <Map<String, dynamic>>[];
+    }
+
+    final entries = rawList.map(LoyaltyPointEntry.fromMap).toList();
+    // EF が balance を省略した場合 (生 List 等) のみ履歴から算出する。
+    balance ??= entries.fold<num>(0, (sum, e) => sum + e.amount);
+
+    return LoyaltyPointsSummary(balance: balance, entries: entries);
+  }
+}
+
+/// ポイント数を桁区切り付きで表示用に整形する ('1,250' 等)。
+/// 整数は小数点なし、非整数は小数第 2 位まで。
+String formatLoyaltyPoints(num value) {
+  final isNegative = value < 0;
+  final abs = value.abs();
+  final body = abs == abs.roundToDouble()
+      ? _addThousands(abs.round().toString())
+      : abs.toStringAsFixed(2);
+  return '${isNegative ? '-' : ''}$body';
+}
+
+String _addThousands(String digits) {
+  final buffer = StringBuffer();
+  final len = digits.length;
+  for (var i = 0; i < len; i++) {
+    if (i > 0 && (len - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+  return buffer.toString();
+}
+
+/// ISO タイムスタンプを 'yyyy/MM/dd HH:mm' (ローカル) に整形する。
+/// パース不能なら生文字列をそのまま返す。
+String formatLoyaltyTimestamp(String raw) {
+  if (raw.isEmpty) return '';
+  final dt = DateTime.tryParse(raw);
+  if (dt == null) return raw;
+  final local = dt.toLocal();
+  String two(int n) => n.toString().padLeft(2, '0');
+  return '${local.year}/${two(local.month)}/${two(local.day)} '
+      '${two(local.hour)}:${two(local.minute)}';
+}

--- a/lib/pages/loyalty_points_page.dart
+++ b/lib/pages/loyalty_points_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/loyalty_points_summary.dart';
+
 /// ロイヤルティポイントページ
-/// loyalty-points Edge Function と連携してポイント残高・履歴を管理
+/// social-commerce-hub Edge Function (loyalty.balance) と連携して
+/// ポイント残高・履歴を管理する。
 class LoyaltyPointsPage extends StatefulWidget {
   const LoyaltyPointsPage({super.key});
 
@@ -13,8 +16,9 @@ class LoyaltyPointsPage extends StatefulWidget {
 class _LoyaltyPointsPageState extends State<LoyaltyPointsPage> {
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
+  bool _isSignedIn = true;
   String? _errorMessage;
-  List<Map<String, dynamic>> _history = [];
+  LoyaltyPointsSummary _summary = LoyaltyPointsSummary.empty;
 
   @override
   void initState() {
@@ -24,11 +28,15 @@ class _LoyaltyPointsPageState extends State<LoyaltyPointsPage> {
 
   Future<void> _fetchHistory() async {
     if (_supabase.auth.currentUser == null) {
-      setState(() => _isLoading = false);
+      setState(() {
+        _isLoading = false;
+        _isSignedIn = false;
+      });
       return;
     }
     setState(() {
       _isLoading = true;
+      _isSignedIn = true;
       _errorMessage = null;
     });
     try {
@@ -36,17 +44,8 @@ class _LoyaltyPointsPageState extends State<LoyaltyPointsPage> {
         'social-commerce-hub',
         body: {'action': 'loyalty.balance'},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['history'] is List) {
-        setState(
-          () =>
-              _history = (data['history'] as List).cast<Map<String, dynamic>>(),
-        );
-      } else if (data is List) {
-        setState(() => _history = data.cast<Map<String, dynamic>>());
-      } else {
-        setState(() => _history = []);
-      }
+      final summary = LoyaltyPointsSummary.fromResponse(response.data);
+      if (mounted) setState(() => _summary = summary);
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = 'ポイント履歴の取得に失敗しました: $e');
@@ -68,76 +67,7 @@ class _LoyaltyPointsPageState extends State<LoyaltyPointsPage> {
           ),
         ],
       ),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : _errorMessage != null
-              ? Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Icon(
-                        Icons.error_outline,
-                        size: 48,
-                        color: Color(0xFFE53935),
-                      ),
-                      const SizedBox(height: 16),
-                      Text(
-                        _errorMessage!,
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          color: Color(0xFFE53935),
-                          height: 1.5,
-                        ),
-                      ),
-                      const SizedBox(height: 16),
-                      ElevatedButton(
-                        onPressed: _fetchHistory,
-                        child: const Text('再試行'),
-                      ),
-                    ],
-                  ),
-                )
-              : _history.isEmpty
-                  ? const Center(child: Text('ポイント履歴はありません'))
-                  : ListView.builder(
-                      padding: const EdgeInsets.all(16),
-                      itemCount: _history.length,
-                      itemBuilder: (context, index) {
-                        final item = _history[index];
-                        final description = item['description']?.toString() ??
-                            'ポイント ${index + 1}';
-                        final points = item['points']?.toString() ?? '0';
-                        final type = item['type']?.toString() ?? 'earn';
-                        return Card(
-                          margin: const EdgeInsets.only(bottom: 12),
-                          child: ListTile(
-                            leading: const Icon(
-                              Icons.stars,
-                              color: Color(0xFFFFC107),
-                            ),
-                            title: Text(
-                              description,
-                              style: const TextStyle(
-                                fontWeight: FontWeight.bold,
-                                height: 1.5,
-                              ),
-                            ),
-                            subtitle:
-                                Text(item['created_at']?.toString() ?? ''),
-                            trailing: Text(
-                              '${type == 'earn' ? '+' : '-'}$points pt',
-                              style: TextStyle(
-                                color: type == 'earn'
-                                    ? const Color(0xFF4CAF50)
-                                    : const Color(0xFFE53935),
-                                fontWeight: FontWeight.bold,
-                                height: 1.5,
-                              ),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
+      body: _buildBody(),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -146,6 +76,145 @@ class _LoyaltyPointsPageState extends State<LoyaltyPointsPage> {
         },
         icon: const Icon(Icons.redeem),
         label: const Text('交換'),
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (!_isSignedIn) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'ログインするとポイント残高と履歴が表示されます',
+            textAlign: TextAlign.center,
+            style: TextStyle(height: 1.5),
+          ),
+        ),
+      );
+    }
+    if (_errorMessage != null) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Color(0xFFE53935)),
+            const SizedBox(height: 16),
+            Text(
+              _errorMessage!,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Color(0xFFE53935), height: 1.5),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _fetchHistory,
+              child: const Text('再試行'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _fetchHistory,
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _buildBalanceCard(),
+          const SizedBox(height: 20),
+          const Text(
+            '獲得・利用履歴',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+          ),
+          const SizedBox(height: 8),
+          if (_summary.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 32),
+              child: Center(child: Text('ポイント履歴はありません')),
+            )
+          else
+            ..._summary.entries.map(_buildHistoryTile),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBalanceCard() {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 28, horizontal: 20),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          gradient: const LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [Color(0xFFFF8F00), Color(0xFFFFC107)],
+          ),
+        ),
+        child: Column(
+          children: [
+            const Text(
+              '現在のポイント残高',
+              style: TextStyle(color: Colors.white, fontSize: 14),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              children: [
+                Text(
+                  formatLoyaltyPoints(_summary.balance),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 40,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(width: 6),
+                const Text(
+                  'pt',
+                  style: TextStyle(color: Colors.white, fontSize: 18),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHistoryTile(LoyaltyPointEntry entry) {
+    final createdAt = formatLoyaltyTimestamp(entry.createdAt);
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        leading: Icon(
+          entry.isEarn ? Icons.stars : Icons.redeem,
+          color:
+              entry.isEarn ? const Color(0xFFFFC107) : const Color(0xFF757575),
+        ),
+        title: Text(
+          entry.reason,
+          style: const TextStyle(fontWeight: FontWeight.bold, height: 1.5),
+        ),
+        subtitle: createdAt.isEmpty ? null : Text(createdAt),
+        trailing: Text(
+          '${entry.isEarn ? '+' : '-'}${formatLoyaltyPoints(entry.amount.abs())} pt',
+          style: TextStyle(
+            color: entry.isEarn
+                ? const Color(0xFF4CAF50)
+                : const Color(0xFFE53935),
+            fontWeight: FontWeight.bold,
+            height: 1.5,
+          ),
+        ),
       ),
     );
   }

--- a/test/loyalty_points_summary_test.dart
+++ b/test/loyalty_points_summary_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/loyalty_points_summary.dart';
+
+void main() {
+  group('LoyaltyPointsSummary.fromResponse', () {
+    test('parses balance and nested metadata history from EF response', () {
+      final summary = LoyaltyPointsSummary.fromResponse({
+        'success': true,
+        'balance': 1250,
+        'history': [
+          {
+            'id': 'a',
+            'metadata': {
+              'amount': 500,
+              'reason': '初回登録ボーナス',
+              'earned_at': '2026-07-10T09:00:00Z',
+              'user_id': 'u1',
+            },
+            'created_at': '2026-07-10T09:00:00Z',
+          },
+          {
+            'id': 'b',
+            'metadata': {
+              'amount': -200,
+              'reason': 'クーポン交換',
+              'redeemed_at': '2026-07-11T12:00:00Z',
+              'user_id': 'u1',
+            },
+            'created_at': '2026-07-11T12:00:00Z',
+          },
+        ],
+      });
+
+      expect(summary.balance, 1250);
+      expect(summary.entries.length, 2);
+
+      final earn = summary.entries[0];
+      expect(earn.amount, 500);
+      expect(earn.reason, '初回登録ボーナス');
+      expect(earn.isEarn, isTrue);
+
+      final redeem = summary.entries[1];
+      expect(redeem.amount, -200);
+      expect(redeem.reason, 'クーポン交換');
+      expect(redeem.isEarn, isFalse);
+    });
+
+    test('does NOT fabricate +0 pt rows (regression: old code read wrong keys)',
+        () {
+      // 旧実装は item['points'] / item['type'] / item['description'] を読み、
+      // 存在しないため全行「ポイント N / +0 pt」を描画していた。
+      final summary = LoyaltyPointsSummary.fromResponse({
+        'balance': 500,
+        'history': [
+          {
+            'metadata': {'amount': 500, 'reason': 'キャンペーン付与'},
+            'created_at': '2026-07-12T00:00:00Z',
+          },
+        ],
+      });
+      final entry = summary.entries.single;
+      expect(entry.amount, 500, reason: 'metadata.amount を読むべき');
+      expect(entry.amount, isNot(0), reason: '捏造の 0 を出してはならない');
+      expect(entry.reason, 'キャンペーン付与');
+    });
+
+    test('derives balance from entries when EF omits balance (bare list)', () {
+      final summary = LoyaltyPointsSummary.fromResponse([
+        {
+          'metadata': {'amount': 300, 'reason': 'A'},
+          'created_at': '2026-07-01T00:00:00Z',
+        },
+        {
+          'metadata': {'amount': -100, 'reason': 'B'},
+          'created_at': '2026-07-02T00:00:00Z',
+        },
+      ]);
+      expect(summary.balance, 200);
+      expect(summary.entries.length, 2);
+    });
+
+    test('treats explicit balance:0 as valid (not derived)', () {
+      final summary = LoyaltyPointsSummary.fromResponse({
+        'balance': 0,
+        'history': <dynamic>[],
+      });
+      expect(summary.balance, 0);
+      expect(summary.isEmpty, isTrue);
+    });
+
+    test('handles null / malformed responses gracefully', () {
+      expect(LoyaltyPointsSummary.fromResponse(null).isEmpty, isTrue);
+      expect(LoyaltyPointsSummary.fromResponse(null).balance, 0);
+      expect(LoyaltyPointsSummary.fromResponse('oops').isEmpty, isTrue);
+    });
+
+    test('parses numeric strings and falls back to legacy flat keys', () {
+      final summary = LoyaltyPointsSummary.fromResponse({
+        'balance': '750',
+        'history': [
+          // legacy flat shape without nested metadata
+          {'points': '750', 'description': '旧形式', 'created_at': ''},
+        ],
+      });
+      expect(summary.balance, 750);
+      expect(summary.entries.single.amount, 750);
+      expect(summary.entries.single.reason, '旧形式');
+    });
+
+    test('uses fallback reason when missing', () {
+      final summary = LoyaltyPointsSummary.fromResponse({
+        'balance': 10,
+        'history': [
+          {
+            'metadata': {'amount': 10},
+            'created_at': '2026-07-12T00:00:00Z',
+          },
+        ],
+      });
+      expect(summary.entries.single.reason, 'ポイント履歴');
+    });
+  });
+
+  group('formatLoyaltyPoints', () {
+    test('adds thousands separators for integers', () {
+      expect(formatLoyaltyPoints(1250), '1,250');
+      expect(formatLoyaltyPoints(1000000), '1,000,000');
+      expect(formatLoyaltyPoints(0), '0');
+      expect(formatLoyaltyPoints(999), '999');
+    });
+
+    test('renders negatives and decimals', () {
+      expect(formatLoyaltyPoints(-1200), '-1,200');
+      expect(formatLoyaltyPoints(12.5), '12.50');
+    });
+  });
+
+  group('formatLoyaltyTimestamp', () {
+    test('formats ISO timestamp to yyyy/MM/dd HH:mm', () {
+      // Use a value with explicit offset and assert on the shape only, since
+      // toLocal() depends on the host timezone.
+      final formatted = formatLoyaltyTimestamp('2026-07-12T03:45:00Z');
+      expect(
+        RegExp(r'^\d{4}/\d{2}/\d{2} \d{2}:\d{2}$').hasMatch(formatted),
+        isTrue,
+        reason: 'got: $formatted',
+      );
+    });
+
+    test('returns empty string for empty input', () {
+      expect(formatLoyaltyTimestamp(''), '');
+    });
+
+    test('returns raw string when unparseable', () {
+      expect(formatLoyaltyTimestamp('not-a-date'), 'not-a-date');
+    });
+  });
+}


### PR DESCRIPTION
## 概要

ロイヤリティポイントページ (`/loyalty-points`) の 2 つの実バグを修正。

`social-commerce-hub` の `loyalty.balance` は `{balance, history}` を返し、履歴各行は `metadata.amount` / `metadata.reason` に値を持つ。しかし UI は存在しない `item['points']` / `item['type']` / `item['description']` を読んでいたため:

1. **履歴が全行「ポイント N / +0 pt」の捏造表示** — 実際の付与/交換ポイントも理由も出ていなかった
2. **残高合計が一切表示されない** — `balance` を fetch していたのに UI に出していなかった

いずれも直近の R17-R20 で潰してきた「UI が誤ったキーを読んで捏造値を出す」型と同じ誠実性欠陥。

## 変更

- 純データモデル `LoyaltyPointsSummary` を `lib/models/` に抽出し、nested `metadata` の正しいキーから解析 (Flutter 依存ゼロ → VM 単体テスト可能)
- 残高合計カードを追加
- 履歴行は `amount` の正負で付与/交換を判定し、記号・色・アイコンを出し分け
- `balance:0` は正当値として保持、生 List 応答は履歴から残高を算出
- ログイン前は「ログインすると表示されます」を出す (以前は空履歴と区別なし)
- VM 単体テスト 12 件追加 (捏造 +0pt 回帰テスト含む)

Dart のみ。Edge Function / スキーマ変更なし。

## テスト

- `flutter test test/loyalty_points_summary_test.dart` → 12 件緑
- `flutter analyze` (対象 3 ファイル) → 0 件
- `dart format --set-exit-if-changed` → 差分なし

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Pure Dart model unit test covers loyalty.balance parsing (7 I/O cases); no new route, existing /loyalty-points flow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)