### PR TITLE
docs: 2026-07-12 daily 実績記録 + 技術記事ドラフト (ロイヤリティ誠実性修正)

### DIFF
--- a/docs/GROWTH_STRATEGY_ROADMAP.md
+++ b/docs/GROWTH_STRATEGY_ROADMAP.md
@@ -32586,3 +32586,27 @@ Step 5: ROADMAP KPI table append (= v(N) trigger row + v(N) verify row)
 - 該当原則: 7 (資産負債: 競合情報を knowledge asset として蓄積) / 8 (KPI=昨日の自分: 競合追跡の継続) / 2 (ミッション: 21社競合を上回る戦略情報の常時把握)。
 - 整合性スコア: **2/9** (情報収集のみ / コード実装なし)。
 - 懸念: Supabase egress policy 制約により schedule-daily-digest / viral-growth-engine が到達不可。日次レポートの二重生成防止が正常に機能している (GH Actions 先行実行 → WEB版は補完のみ)。
+
+## セッション記録: ロイヤリティポイント 誠実性欠陥修正 (2026-07-12 / Win Claude daily-development)
+
+**背景**: ダッシュボード磨き (R16-R20) は収穫逓減という前回の結論を受け、成長レバー / 実バグ潰しへ移行。ダミーデータ・捏造表示の棚卸しを実施。
+
+**発見した実バグ** (`/loyalty-points` = ロイヤリティポイントページ):
+- `social-commerce-hub` の `loyalty.balance` は `{balance, history}` を返し、履歴各行は `metadata.amount` / `metadata.reason` に値を持つ。
+- しかし UI は存在しない `item['points']` / `item['type']` / `item['description']` を読んでおり、**全履歴行が「ポイント N / +0 pt」の捏造表示**になっていた。
+- さらに **残高合計 (`balance`) を fetch していたのに UI へ一切表示していなかった**。
+- いずれも R17-R20 で潰してきた「UI が誤ったキーを読んで捏造値を出す」型と同型の誠実性欠陥。
+
+**対応** ([PR #3948](https://github.com/kanta13jp1/my_web_app/pull/3948) / Dart のみ / merged):
+- 純データモデル `LoyaltyPointsSummary` を `lib/models/` に抽出し nested `metadata` の正しいキーから解析 (Flutter 依存ゼロ → VM 単体テスト可能)。
+- 残高合計カードを追加。履歴行は `amount` の正負で付与/交換を判定し記号・色・アイコンを出し分け。
+- `balance:0` は正当値として保持、生 List 応答は履歴から残高を算出。ログイン前は専用メッセージ。
+- VM 単体テスト 12 件追加 (捏造 +0pt 回帰テスト含む)。`flutter analyze` 0 / `dart format` 差分なし / CI 全緑。
+
+**教訓**: 「一覧ページが全行同じ捏造値を出す」時は表示バグでなく **UI とバックエンド応答契約のキー不一致** をまず疑う (nested `metadata` vs flat)。fetch しているのに描画していないフィールド (balance) も棚卸し対象。
+
+### Philosophy Alignment (Win Claude 2026-07-12)
+
+- 主要実装: 誠実性欠陥の修正 (捏造値の除去 = 「測っていないものを測ったように見せない」)。
+- 該当原則: 8 (KPI=昨日の自分: 正しい数字を出す) / 5 (商品=価値: ユーザーに見せる残高・履歴の信頼性) / 7 (資産負債: 純ロジックを再利用可能な asset として抽出)。
+- 整合性スコア: **3/9** (単一ページのバグ修正 + テスト)。

--- a/docs/blog-drafts/2026-07-12-ui-backend-contract-fabricated-values.md
+++ b/docs/blog-drafts/2026-07-12-ui-backend-contract-fabricated-values.md
@@ -1,0 +1,103 @@
+---
+title: "『全行 +0』の正体 — Flutter × Supabase で UI がレスポンス契約とズレて捏造値を出すバグ"
+tags: Flutter,Supabase,dart,webdev
+published: false
+---
+
+一覧ページが「どの行も同じそれっぽい初期値」を出しているとき、それは表示崩れではなく **UI とバックエンドのレスポンス契約のズレ** であることが多い。実際に自作アプリのロイヤリティポイント画面で踏んだバグと、再発させないための直し方をまとめる。
+
+## 症状
+
+ポイント履歴の一覧が、どの行も「ポイント 1 / +0 pt」「ポイント 2 / +0 pt」…と表示される。日時だけは正しい。残高の合計はどこにも出ていない。
+
+## 原因: nested な応答を flat なキーで読んでいた
+
+Edge Function 側はこう返していた。
+
+```json
+{
+  "success": true,
+  "balance": 1250,
+  "history": [
+    {
+      "id": "...",
+      "metadata": { "amount": 500, "reason": "初回登録ボーナス" },
+      "created_at": "2026-07-12T..."
+    }
+  ]
+}
+```
+
+一方、UI 側はこう読んでいた。
+
+```dart
+final points = item['points']?.toString() ?? '0';      // 存在しない → '0'
+final type = item['type']?.toString() ?? 'earn';        // 存在しない → 'earn'
+final desc = item['description']?.toString() ?? 'ポイント ${index + 1}';
+```
+
+`amount` は `metadata.amount` に、`reason` は `metadata.reason` にあるのに、UI はトップレベルの `points` / `type` / `description` を読んでいた。結果、全部フォールバック値になり **「+0 pt」という数字を UI が捏造** していた。さらに `balance` は取得しているのに描画していなかった。
+
+これは「測っていない値を、測ったように見せている」誠実性の問題でもある。ユーザーは 0 と表示されれば「本当に 0 なんだ」と受け取る。
+
+## 直し方 1: 純データモデルに解析を閉じ込める
+
+パースを UI から切り離し、Flutter 非依存の純関数/モデルにする。VM 単体テストが書けるようになり、契約ズレを回帰テストで固定できる。
+
+```dart
+class LoyaltyPointEntry {
+  const LoyaltyPointEntry({
+    required this.amount,
+    required this.reason,
+    required this.createdAt,
+  });
+
+  final num amount; // 正 = 付与 / 負 = 交換
+  final String reason;
+  final String createdAt;
+
+  bool get isEarn => amount >= 0;
+
+  factory LoyaltyPointEntry.fromMap(Map<String, dynamic> raw) {
+    final meta = raw['metadata'] is Map
+        ? (raw['metadata'] as Map).cast<String, dynamic>()
+        : const <String, dynamic>{};
+    // 正しいキーを読む。旧 flat キーはフォールバックとして残す。
+    final rawAmount = meta['amount'] ?? raw['amount'] ?? raw['points'] ?? 0;
+    final reason =
+        (meta['reason'] ?? raw['reason'] ?? raw['description'] ?? '')
+            .toString()
+            .trim();
+    return LoyaltyPointEntry(
+      amount: rawAmount is num ? rawAmount : num.tryParse('$rawAmount') ?? 0,
+      reason: reason.isEmpty ? 'ポイント履歴' : reason,
+      createdAt: (raw['created_at'] ?? '').toString(),
+    );
+  }
+}
+```
+
+## 直し方 2: 捏造ゼロを回帰テストで固定する
+
+「0 を出してはならない」という意図をテストに書く。次に誰かがキーを間違えたら赤で気づける。
+
+```dart
+test('does NOT fabricate +0 pt rows', () {
+  final entry = LoyaltyPointEntry.fromMap({
+    'metadata': {'amount': 500, 'reason': 'キャンペーン付与'},
+    'created_at': '2026-07-12T00:00:00Z',
+  });
+  expect(entry.amount, 500);
+  expect(entry.amount, isNot(0)); // 捏造の 0 を許さない
+  expect(entry.reason, 'キャンペーン付与');
+});
+```
+
+## 教訓
+
+- 「一覧の全行が同じ初期値」= まず **応答契約のキー不一致** を疑う。nested (`metadata.x`) と flat (`x`) の取り違えが定番。
+- フォールバック値 (`?? '0'`) は、契約ズレを **静かに捏造値へ変換する装置** になりうる。0 が返ってきたのか、キーが無くて 0 になったのかを区別する。
+- 取得しているのに描画していないフィールド (この例では `balance`) がないか棚卸しする。
+- パースは純モデルへ抽出し、意図 (捏造ゼロ) を回帰テストで固定する。
+
+小さなページの小さなバグだが、「アプリが出す数字は信じてよい」という信頼を守るための修正である。


### PR DESCRIPTION
## 概要

2026-07-12 Win Claude daily-development の実績記録。コード変更なし (docs のみ)。

関連コード PR は [#3948](https://github.com/kanta13jp1/my_web_app/pull/3948) (merged): ロイヤリティポイントページの捏造 +0pt 表示 + 残高非表示バグ修正。

## 変更

- `docs/GROWTH_STRATEGY_ROADMAP.md` — #3948 のセッション記録 + Philosophy Alignment を末尾に追記
- `docs/blog-drafts/2026-07-12-ui-backend-contract-fabricated-values.md` — 新規技術記事ドラフト (`published: false`)。「UI とバックエンドの応答契約のキー不一致で捏造値を出すバグ」の解説

`published: false` のため外部公開キューには載らない (人手レビュー用ドラフト)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)