### PR TITLE
fix(admin): ダッシュボードR21 — 10仮説検証で確定した誠実性欠陥を修正

### DIFF
--- a/lib/pages/admin/blog_management_page.dart
+++ b/lib/pages/admin/blog_management_page.dart
@@ -1298,8 +1298,10 @@ class _BlogManagementPageState extends State<BlogManagementPage>
     }
 
     // R21: 表示中の数値がいつの同期かを明示する(同期失敗中の凍結値を
-    // 今の数値に見せない)。直近同期が失敗していれば警告も添える。
-    final freshness = blogEngagementFreshnessLabel(_engagement, DateTime.now());
+    // 今の数値に見せない)。フィルタ後の行を platform 別に評価する — 独立同期
+    // 化により「Qiita だけ凍結・dev.to は新鮮」が全体 max に隠れるのを防ぐ。
+    // 直近同期が失敗していれば警告も添える。
+    final freshness = blogEngagementFreshnessByPlatform(items, DateTime.now());
     return [
       if (freshness != null)
         SliverToBoxAdapter(

--- a/lib/pages/admin/blog_management_page.dart
+++ b/lib/pages/admin/blog_management_page.dart
@@ -5,6 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'blog_sync_feedback.dart';
+
 class _NewsSignalLintReport {
   final String checkedAt;
   final String status;
@@ -42,6 +44,9 @@ class _BlogManagementPageState extends State<BlogManagementPage>
   List<Map<String, dynamic>> _drafts = [];
   bool _isLoading = true;
   bool _isSyncing = false;
+  // R21: 最後の同期失敗を保持し、空状態を「Syncで取得できます」の失敗ループ
+  // ではなく失敗理由+是正手順の表示に切り替える。
+  String? _lastSyncError;
   bool _isLintingNewsSignals = false;
   final Set<String> _publishingIds = {};
   final Set<String> _togglingIds = {};
@@ -138,32 +143,47 @@ class _BlogManagementPageState extends State<BlogManagementPage>
   Future<void> _syncNow() async {
     if (_isSyncing) return;
     setState(() => _isSyncing = true);
+    // R21: Qiita と dev.to を独立に同期する(ボタンの文言どおり両方実行し、
+    // Qiita トークン失効が dev.to 同期を巻き添えにしない)。失敗は生
+    // FunctionException ではなく是正手順つきの文言へ変換する。
+    final lines = <String>[];
+    var anySuccess = false;
+    var anyFailure = false;
+
+    Future<void> runSync(String label, String action) async {
+      try {
+        final res = await _supabase.functions.invoke(
+          'schedule-hub',
+          body: {'action': action},
+        );
+        lines.add(composeBlogSyncSuccessLine(label, res.data));
+        anySuccess = true;
+      } on FunctionException catch (e) {
+        anyFailure = true;
+        lines.add(
+          '$label: ${composeBlogSyncErrorMessage(status: e.status, details: e.details)}',
+        );
+      } catch (e) {
+        anyFailure = true;
+        lines.add('$label: ${composeBlogSyncErrorMessage(fallback: '$e')}');
+      }
+    }
+
     try {
-      final res = await _supabase.functions.invoke(
-        'schedule-hub',
-        body: {'action': 'blog.sync_engagement'},
+      await runSync('Qiita', 'blog.sync_engagement');
+      await runSync('dev.to', 'blog.devto_sync_engagement');
+
+      if (!mounted) return;
+      final message = lines.join('\n');
+      setState(() => _lastSyncError = anyFailure ? message : null);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(anyFailure ? '⚠️ $message' : '✅ $message'),
+          backgroundColor: anyFailure ? _red : _green,
+          duration: Duration(seconds: anyFailure ? 8 : 3),
+        ),
       );
-      if (mounted) {
-        final success = res.status == 200;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(success ? '✅ 同期完了' : '⚠️ 同期エラー (${res.status})'),
-            backgroundColor: success ? _green : _red,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-        if (success) await _loadData();
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('❌ 同期失敗: $e'),
-            backgroundColor: _red,
-            duration: const Duration(seconds: 4),
-          ),
-        );
-      }
+      if (anySuccess) await _loadData();
     } finally {
       if (mounted) setState(() => _isSyncing = false);
     }
@@ -1229,16 +1249,27 @@ class _BlogManagementPageState extends State<BlogManagementPage>
             padding: const EdgeInsets.all(32),
             child: Column(
               children: [
-                const Icon(
-                  Icons.article_outlined,
-                  color: Colors.white24,
+                Icon(
+                  _lastSyncError != null
+                      ? Icons.sync_problem
+                      : Icons.article_outlined,
+                  color: _lastSyncError != null ? _orange : Colors.white24,
                   size: 48,
                 ),
                 const SizedBox(height: 12),
-                const Text(
-                  'データなし\nSync ボタンで Qiita / dev.to から取得できます',
+                // R21: 同期失敗後は「Syncで取得できます」ではなく失敗理由+
+                // 是正手順を出す(失敗ループのデッドエンド解消)。
+                Text(
+                  _lastSyncError != null
+                      ? '前回の同期に失敗しました。\n$_lastSyncError'
+                      : 'データなし\nSync ボタンで Qiita / dev.to から取得できます',
                   textAlign: TextAlign.center,
-                  style: TextStyle(color: Colors.white38, height: 1.6),
+                  style: TextStyle(
+                    color: _lastSyncError != null
+                        ? Colors.white70
+                        : Colors.white38,
+                    height: 1.6,
+                  ),
                 ),
                 const SizedBox(height: 16),
                 ElevatedButton.icon(
@@ -1266,7 +1297,24 @@ class _BlogManagementPageState extends State<BlogManagementPage>
       ];
     }
 
+    // R21: 表示中の数値がいつの同期かを明示する(同期失敗中の凍結値を
+    // 今の数値に見せない)。直近同期が失敗していれば警告も添える。
+    final freshness = blogEngagementFreshnessLabel(_engagement, DateTime.now());
     return [
+      if (freshness != null)
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+            child: Text(
+              _lastSyncError != null ? '$freshness(直近の同期は失敗しています)' : freshness,
+              style: TextStyle(
+                color: _lastSyncError != null ? _orange : Colors.white38,
+                fontSize: 12,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ),
       SliverPadding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
         sliver: SliverList(

--- a/lib/pages/admin/blog_sync_feedback.dart
+++ b/lib/pages/admin/blog_sync_feedback.dart
@@ -14,6 +14,10 @@ String composeBlogSyncErrorMessage({
   var detail = '';
   if (details is Map) {
     detail = (details['error'] ?? '').toString();
+    // error キーを持たない Map でも情報を全損させない。
+    if (detail.isEmpty && details.isNotEmpty) {
+      detail = details.toString();
+    }
   } else if (details != null) {
     detail = details.toString();
   }
@@ -55,6 +59,11 @@ String? blogEngagementFreshnessLabel(
   List<Map<String, dynamic>> rows,
   DateTime now,
 ) {
+  final age = _freshnessAge(rows, now);
+  return age == null ? null : '最終同期: $age';
+}
+
+String? _freshnessAge(List<Map<String, dynamic>> rows, DateTime now) {
   DateTime? newest;
   for (final row in rows) {
     final dt = DateTime.tryParse((row['updated_at'] ?? '').toString());
@@ -63,8 +72,53 @@ String? blogEngagementFreshnessLabel(
   }
   if (newest == null) return null;
   final diff = now.difference(newest);
-  if (diff.isNegative) return '最終同期: 1時間以内';
-  if (diff.inDays >= 1) return '最終同期: ${diff.inDays}日前';
-  if (diff.inHours >= 1) return '最終同期: ${diff.inHours}時間前';
-  return '最終同期: 1時間以内';
+  if (diff.isNegative) return '1時間以内';
+  if (diff.inDays >= 1) return '${diff.inDays}日前';
+  if (diff.inHours >= 1) return '${diff.inHours}時間前';
+  return '1時間以内';
+}
+
+String _platformDisplayName(String platform) {
+  switch (platform) {
+    case 'qiita':
+      return 'Qiita';
+    case 'devto':
+      return 'dev.to';
+    default:
+      return platform;
+  }
+}
+
+/// platform 別の鮮度ラベル(例:「最終同期 — Qiita: 3日前 / dev.to: 1時間以内」)。
+/// Qiita と dev.to は独立に同期されるため全体 max では「片方だけ数日凍結」が
+/// 新鮮側に隠れる — platform ごとに出して凍結を可視化する。platform 列が
+/// 無い行しか無ければ全体ラベルへフォールバック。
+String? blogEngagementFreshnessByPlatform(
+  List<Map<String, dynamic>> rows,
+  DateTime now,
+) {
+  final platforms = <String>[];
+  for (final row in rows) {
+    final platform = (row['platform'] ?? '').toString();
+    if (platform.isNotEmpty && !platforms.contains(platform)) {
+      platforms.add(platform);
+    }
+  }
+  if (platforms.isEmpty) return blogEngagementFreshnessLabel(rows, now);
+  if (platforms.length == 1) {
+    return blogEngagementFreshnessLabel(rows, now);
+  }
+
+  final parts = <String>[];
+  for (final platform in platforms) {
+    final subset = rows
+        .where((row) => (row['platform'] ?? '').toString() == platform)
+        .toList();
+    final age = _freshnessAge(subset, now);
+    if (age != null) {
+      parts.add('${_platformDisplayName(platform)}: $age');
+    }
+  }
+  if (parts.isEmpty) return null;
+  return '最終同期 — ${parts.join(' / ')}';
 }

--- a/lib/pages/admin/blog_sync_feedback.dart
+++ b/lib/pages/admin/blog_sync_feedback.dart
@@ -1,0 +1,70 @@
+// R21: ブログ同期の結果/エラー文言の純ロジック(依存ゼロ・VM テスト可能)。
+// blog_management_page.dart は supabase 依存を含むため、生 FunctionException を
+// 管理者が次に取る行動が分かる文言へ変換する判定だけをここへ切り出す
+// (admin_dashboard_signals.dart と同じ抽出パターン)。
+
+/// FunctionException の status/details (または任意のエラー文字列) から、管理者
+/// 向けの同期エラー文言を作る。Qiita 401 (トークン失効) を最優先で名指しし、
+/// 是正手順 (トークン再発行 + Supabase secrets 更新) まで案内する。
+String composeBlogSyncErrorMessage({
+  int? status,
+  Object? details,
+  String? fallback,
+}) {
+  var detail = '';
+  if (details is Map) {
+    detail = (details['error'] ?? '').toString();
+  } else if (details != null) {
+    detail = details.toString();
+  }
+  final probe = detail.isNotEmpty ? detail : (fallback ?? '');
+
+  if (RegExp('qiita', caseSensitive: false).hasMatch(probe) &&
+      probe.contains('401')) {
+    return 'Qiitaトークンが失効しています(401)。Qiitaで新しいアクセストークンを発行し、'
+        'Supabase secrets の QIITA_ACCESS_TOKEN を更新してから再同期してください。';
+  }
+  if (probe.contains('QIITA_ACCESS_TOKEN')) {
+    return 'QIITA_ACCESS_TOKEN が未設定です。Supabase secrets に設定してください。';
+  }
+  if (probe.contains('DEVTO_API_KEY')) {
+    return 'DEVTO_API_KEY が未設定です。Supabase secrets に設定してください。';
+  }
+
+  final head = status != null ? '同期に失敗しました (HTTP $status)' : '同期に失敗しました';
+  return probe.isEmpty ? '$head。' : '$head: $probe';
+}
+
+/// 同期成功レスポンスから件数付きの結果文言を作る。Qiita は articles_synced、
+/// dev.to は synced を返す(schedule-hub の blog.sync_engagement /
+/// blog.devto_sync_engagement)。件数が読めない場合は「同期完了」に留める。
+String composeBlogSyncSuccessLine(String label, Object? data) {
+  if (data is Map) {
+    final count = data['articles_synced'] ?? data['synced'];
+    if (count is num) {
+      return '$label: ${count.toInt()}件同期';
+    }
+  }
+  return '$label: 同期完了';
+}
+
+/// blog_engagement 行(各 {updated_at})の最新同期時刻から鮮度ラベルを作る。
+/// 同期が失敗し続けている間、凍結した いいね/閲覧数を「今の数値」に見せない
+/// (R20 の age-aware 規律)。パース可能な行が無ければ null。
+String? blogEngagementFreshnessLabel(
+  List<Map<String, dynamic>> rows,
+  DateTime now,
+) {
+  DateTime? newest;
+  for (final row in rows) {
+    final dt = DateTime.tryParse((row['updated_at'] ?? '').toString());
+    if (dt == null) continue;
+    if (newest == null || dt.isAfter(newest)) newest = dt;
+  }
+  if (newest == null) return null;
+  final diff = now.difference(newest);
+  if (diff.isNegative) return '最終同期: 1時間以内';
+  if (diff.inDays >= 1) return '最終同期: ${diff.inDays}日前';
+  if (diff.inHours >= 1) return '最終同期: ${diff.inHours}時間前';
+  return '最終同期: 1時間以内';
+}

--- a/lib/pages/admin/blog_sync_feedback.dart
+++ b/lib/pages/admin/blog_sync_feedback.dart
@@ -12,8 +12,10 @@ String composeBlogSyncErrorMessage({
   String? fallback,
 }) {
   var detail = '';
+  var hint = '';
   if (details is Map) {
     detail = (details['error'] ?? '').toString();
+    hint = (details['hint'] ?? '').toString();
     // error キーを持たない Map でも情報を全損させない。
     if (detail.isEmpty && details.isNotEmpty) {
       detail = details.toString();
@@ -22,6 +24,13 @@ String composeBlogSyncErrorMessage({
     detail = details.toString();
   }
   final probe = detail.isNotEmpty ? detail : (fallback ?? '');
+
+  // schedule-hub (upstream_error.ts) が是正手順 hint を同梱する場合は、
+  // サーバー側の正本(正確な rotate コマンド入り)を最優先で表示する。
+  if (hint.isNotEmpty) {
+    final head = status != null ? '同期に失敗しました (HTTP $status)' : '同期に失敗しました';
+    return probe.isEmpty ? '$head。$hint' : '$head: $probe\n$hint';
+  }
 
   if (RegExp('qiita', caseSensitive: false).hasMatch(probe) &&
       probe.contains('401')) {

--- a/lib/pages/admin/quota_dashboard_page.dart
+++ b/lib/pages/admin/quota_dashboard_page.dart
@@ -3,6 +3,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import 'quota_dashboard_signals.dart';
+
 class QuotaDashboardPage extends StatefulWidget {
   final SupabaseClient? supabaseClient;
   const QuotaDashboardPage({super.key, this.supabaseClient});
@@ -17,6 +19,9 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
   List<Map<String, dynamic>> _history = [];
   bool _isLoading = true;
   bool _historyLoading = false;
+  // R21: 取得失敗を無音で握りつぶすと「データなし(未計測)」と描画上区別
+  // できない(読めていないのに計測してないと誤診させない)。
+  String? _loadError;
 
   static const _bg = Color(0xFF0A0A0A);
   static const _card = Color(0xFF1A1A2E);
@@ -59,10 +64,16 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
 
   Future<void> _loadLatest() async {
     if (_supabase.auth.currentUser == null) {
-      setState(() => _isLoading = false);
+      setState(() {
+        _isLoading = false;
+        _loadError = '未ログインのためクォータ情報を取得できません。ログイン後に更新してください。';
+      });
       return;
     }
-    setState(() => _isLoading = true);
+    setState(() {
+      _isLoading = true;
+      _loadError = null;
+    });
     try {
       final res = await _supabase.functions.invoke(
         'admin-hub',
@@ -74,9 +85,19 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
         setState(() {
           _latest = rows.cast<Map<String, dynamic>>();
         });
+      } else {
+        setState(() {
+          _loadError = 'クォータ情報の取得に失敗しました'
+              '(${data?['error'] ?? 'admin-hub 応答が不正'})。更新ボタンで再試行してください。';
+        });
       }
     } catch (e) {
       debugPrint('quota.latest error: $e');
+      if (mounted) {
+        setState(() {
+          _loadError = 'クォータ情報の取得に失敗しました。更新ボタンで再試行してください。';
+        });
+      }
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }
@@ -157,6 +178,8 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
+                    if (_loadError != null) _buildLoadErrorBanner(),
+                    if (_loadError != null) const SizedBox(height: 16),
                     if (_hasAlert) _buildAlertBanner(),
                     if (_hasAlert) const SizedBox(height: 16),
                     _buildToolCards(),
@@ -170,7 +193,44 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
     );
   }
 
+  Widget _buildLoadErrorBanner() {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: _orange.withAlpha(30),
+        border: Border.all(color: _orange, width: 1.5),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.cloud_off, color: _orange, size: 20),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              _loadError ?? '',
+              style: const TextStyle(
+                color: Colors.white70,
+                fontSize: 13,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildAlertBanner() {
+    // R21: どのツールのアラートでも「Claude MAX レート制限到達」と決め打ち
+    // していた捏造原因を、実際にアラート中のツール名に置き換える。コーディング
+    // 用フォールバック表は Claude のアラート時のみ意味を持つ。
+    final alertTools = _latest
+        .where((r) => r['alert'] == true)
+        .map((r) => _toolNames[r['tool']] ?? (r['tool'] ?? '').toString())
+        .toList();
+    final hasAnthropicAlert = _latest.any(
+      (r) => r['tool'] == 'anthropic' && r['alert'] == true,
+    );
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -186,7 +246,7 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
               Icon(Icons.warning_amber_rounded, color: _alertRed, size: 20),
               SizedBox(width: 8),
               Text(
-                '⚠️ フォールバック推奨',
+                '⚠️ クォータアラート',
                 style: TextStyle(
                   color: _alertRed,
                   fontWeight: FontWeight.bold,
@@ -197,16 +257,28 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
             ],
           ),
           const SizedBox(height: 12),
-          const Text(
-            'Claude MAX レート制限到達。ファイル種別に応じて代替AIを使用してください:',
-            style: TextStyle(
+          Text(
+            '${alertTools.join(' / ')} のクォータが閾値を超えています。'
+            '該当カードの詳細を確認してください。',
+            style: const TextStyle(
               color: Colors.white70,
               fontSize: 13,
               height: 1.5,
             ),
           ),
-          const SizedBox(height: 8),
-          _buildFallbackTable(),
+          if (hasAnthropicAlert) ...[
+            const SizedBox(height: 8),
+            const Text(
+              'Claude はファイル種別に応じて代替AIへフォールバック:',
+              style: TextStyle(
+                color: Colors.white70,
+                fontSize: 13,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _buildFallbackTable(),
+          ],
         ],
       ),
     );
@@ -264,13 +336,34 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
   }
 
   Widget _buildToolCard(String tool, Map<String, dynamic>? row) {
-    final isAlert = row?['alert'] == true;
-    final statusColor = isAlert ? _alertRed : _okGreen;
+    final checkedAt = row?['checked_at'] as String?;
+    // R21: 未計測(行なし)/計測停止(古い checked_at)を「正常」と捏造しない
+    // 3+1状態バッジ(未計測/アラート/計測停止?/正常)。
+    final status = resolveQuotaToolStatus(
+      hasRow: row != null,
+      alert: row?['alert'] == true,
+      checkedAt: checkedAt,
+      now: DateTime.now(),
+    );
+    final isAlert = status == QuotaToolStatus.alert;
+    final statusColor = switch (status) {
+      QuotaToolStatus.alert => _alertRed,
+      QuotaToolStatus.ok => _okGreen,
+      QuotaToolStatus.stale => _orange,
+      QuotaToolStatus.unmeasured => Colors.white38,
+    };
+    final statusIcon = switch (status) {
+      QuotaToolStatus.alert => Icons.error_outline,
+      QuotaToolStatus.ok => Icons.check_circle_outline,
+      QuotaToolStatus.stale => Icons.history_toggle_off,
+      QuotaToolStatus.unmeasured => Icons.help_outline,
+    };
     final displayName = _toolNames[tool] ?? tool;
     final icon = _toolIcons[tool] ?? Icons.smart_toy;
 
     final usageJson = row?['usage_json'] as Map<String, dynamic>? ?? {};
-    final costUsd = (usageJson['cost_usd'] as num?)?.toDouble() ?? 0.0;
+    // R21: cost_usd 欠落時は $0.00 を捏造せず「コスト未取得」を表示する。
+    final costUsd = quotaCostUsd(usageJson);
     final tokens = (usageJson['tokens'] as num?)?.toInt();
     final remainingCredits = (usageJson['remaining'] as num?)?.toInt();
     final usedCredits = (usageJson['used'] as num?)?.toInt();
@@ -278,9 +371,11 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
     final creditThreshold = (usageJson['threshold'] as num?)?.toInt();
     final severity = usageJson['severity']?.toString();
     final errorMessage = usageJson['error']?.toString();
-    final checkedAt = row?['checked_at'] as String?;
     final limit = _toolLimits[tool] ?? 0.0;
-    final progress = (limit > 0) ? (costUsd / limit).clamp(0.0, 1.0) : 0.0;
+    final progress = (limit > 0 && costUsd != null)
+        ? (costUsd / limit).clamp(0.0, 1.0)
+        : 0.0;
+    final checkedAgeDays = quotaCheckedAgeDays(checkedAt, DateTime.now());
 
     return Card(
       color: _card,
@@ -323,15 +418,13 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Icon(
-                        isAlert
-                            ? Icons.error_outline
-                            : Icons.check_circle_outline,
+                        statusIcon,
                         color: statusColor,
                         size: 14,
                       ),
                       const SizedBox(width: 4),
                       Text(
-                        isAlert ? 'アラート' : '正常',
+                        quotaStatusBadgeLabel(status),
                         style: TextStyle(
                           color: statusColor,
                           fontSize: 12,
@@ -347,7 +440,8 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
             if (row == null) ...[
               const SizedBox(height: 12),
               const Text(
-                'データなし',
+                '計測データなし。quota-monitor がこのツールを記録していません'
+                '(APIキー未設定 or 計測ステップ失敗)。',
                 style: TextStyle(
                   color: Colors.white38,
                   fontSize: 13,
@@ -377,7 +471,7 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
                       ),
                     ),
                     const SizedBox(width: 16),
-                  ] else if (costUsd > 0 || limit > 0) ...[
+                  ] else if (costUsd != null) ...[
                     Text(
                       '\$${costUsd.toStringAsFixed(2)}',
                       style: TextStyle(
@@ -397,6 +491,17 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
                         ),
                       ),
                     ],
+                    const SizedBox(width: 16),
+                  ] else ...[
+                    // R21: cost_usd 未取得のとき $0.00 を捏造しない。
+                    const Text(
+                      'コスト未取得',
+                      style: TextStyle(
+                        color: Colors.white38,
+                        fontSize: 14,
+                        height: 1.5,
+                      ),
+                    ),
                     const SizedBox(width: 16),
                   ],
                   if (tokens != null)
@@ -440,7 +545,8 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
                   ),
                 ),
               ],
-              if (limit > 0) ...[
+              // R21: cost 未取得時は 0% 使用バーを捏造しない。
+              if (limit > 0 && costUsd != null) ...[
                 const SizedBox(height: 8),
                 ClipRRect(
                   borderRadius: BorderRadius.circular(4),
@@ -466,7 +572,10 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
               if (checkedAt != null) ...[
                 const SizedBox(height: 8),
                 Text(
-                  '最終確認: $checkedAt',
+                  // R21: 古い計測を今の状態に見せない(2日以上前は経過日数を明示)。
+                  checkedAgeDays != null && checkedAgeDays >= 2
+                      ? '最終確認: $checkedAt ($checkedAgeDays日前・計測停止の可能性)'
+                      : '最終確認: $checkedAt',
                   style: const TextStyle(
                     color: Colors.white38,
                     fontSize: 11,

--- a/lib/pages/admin/quota_dashboard_page.dart
+++ b/lib/pages/admin/quota_dashboard_page.dart
@@ -22,6 +22,7 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
   // R21: 取得失敗を無音で握りつぶすと「データなし(未計測)」と描画上区別
   // できない(読めていないのに計測してないと誤診させない)。
   String? _loadError;
+  String? _historyError;
 
   static const _bg = Color(0xFF0A0A0A);
   static const _card = Color(0xFF1A1A2E);
@@ -80,6 +81,7 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
         body: {'action': 'quota.latest'},
       );
       final data = res.data as Map<String, dynamic>?;
+      if (!mounted) return;
       if (data != null && data['success'] == true) {
         final rows = data['data'] as List<dynamic>? ?? [];
         setState(() {
@@ -89,6 +91,16 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
         setState(() {
           _loadError = 'クォータ情報の取得に失敗しました'
               '(${data?['error'] ?? 'admin-hub 応答が不正'})。更新ボタンで再試行してください。';
+        });
+      }
+    } on FunctionException catch (e) {
+      debugPrint('quota.latest error: $e');
+      if (mounted) {
+        setState(() {
+          // 401/403 は再試行しても直らない — 権限系の案内に分ける。
+          _loadError = e.status == 401 || e.status == 403
+              ? 'クォータ情報を閲覧する権限がありません。管理者アカウントで再ログインしてください。'
+              : 'クォータ情報の取得に失敗しました (HTTP ${e.status})。更新ボタンで再試行してください。';
         });
       }
     } catch (e) {
@@ -108,21 +120,31 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
       setState(() => _isLoading = false);
       return;
     }
-    setState(() => _historyLoading = true);
+    setState(() {
+      _historyLoading = true;
+      _historyError = null;
+    });
     try {
       final res = await _supabase.functions.invoke(
         'admin-hub',
         body: {'action': 'quota.list', 'days': 30},
       );
       final data = res.data as Map<String, dynamic>?;
+      if (!mounted) return;
       if (data != null && data['success'] == true) {
         final rows = data['data'] as List<dynamic>? ?? [];
         setState(() {
           _history = rows.cast<Map<String, dynamic>>();
         });
+      } else {
+        // R21: 取得失敗を「データなし」に見せない(_loadLatest と同じ規律)。
+        setState(() => _historyError = '履歴の取得に失敗しました。開き直して再試行してください。');
       }
     } catch (e) {
       debugPrint('quota.list error: $e');
+      if (mounted) {
+        setState(() => _historyError = '履歴の取得に失敗しました。開き直して再試行してください。');
+      }
     } finally {
       if (mounted) setState(() => _historyLoading = false);
     }
@@ -614,6 +636,17 @@ class _QuotaDashboardPageState extends State<QuotaDashboardPage> {
             const Padding(
               padding: EdgeInsets.all(24),
               child: CircularProgressIndicator(color: _orange),
+            )
+          else if (_historyError != null)
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                _historyError!,
+                style: const TextStyle(
+                  color: _orange,
+                  height: 1.5,
+                ),
+              ),
             )
           else if (_history.isEmpty)
             const Padding(

--- a/lib/pages/admin/quota_dashboard_signals.dart
+++ b/lib/pages/admin/quota_dashboard_signals.dart
@@ -1,0 +1,74 @@
+// R21: AI クォータ監視ダッシュボードの純ロジック(依存ゼロ・VM テスト可能)。
+// quota_dashboard_page.dart は supabase 依存を含むため、バッジ状態・コスト表示の
+// 判定だけをこのファイルへ切り出す(admin_dashboard_signals.dart と同じ
+// 抽出パターン / part321 の教訓)。
+
+/// ツールカードのバッジ状態。R17/R19 の誠実性規律: 未計測(行なし)や計測停止を
+/// 「正常」と捏造しない。
+enum QuotaToolStatus {
+  /// quota.latest にそのツールの行が1件も無い = quota-monitor が計測していない
+  /// (APIキー未設定 or 計測ステップ失敗で書き込みスキップ)。健全とは言えない。
+  unmeasured,
+
+  /// 最新行の alert フラグが真。
+  alert,
+
+  /// 最新行はあるが checked_at が staleDays 超え = 日次計測 cron が止まっている
+  /// 可能性。古い「正常」を今の「正常」に見せない。
+  stale,
+
+  /// 最新行があり、alert でも stale でもない。
+  ok,
+}
+
+/// quota.latest の行有無・alert フラグ・checked_at 鮮度からバッジ状態を決める。
+/// checked_at は quota-monitor.yml (日次 cron / 09:00 JST) が書く日付文字列。
+/// 正常時の最大 age は約1日なので staleDays 既定は2日(48h)。パース不能な
+/// checked_at は鮮度を主張できないため stale 扱いにする。
+QuotaToolStatus resolveQuotaToolStatus({
+  required bool hasRow,
+  required bool alert,
+  required String? checkedAt,
+  required DateTime now,
+  int staleDays = 2,
+}) {
+  if (!hasRow) return QuotaToolStatus.unmeasured;
+  if (alert) return QuotaToolStatus.alert;
+  final checked = DateTime.tryParse(checkedAt ?? '');
+  if (checked == null) return QuotaToolStatus.stale;
+  final age = now.difference(checked);
+  if (age.inDays >= staleDays) return QuotaToolStatus.stale;
+  return QuotaToolStatus.ok;
+}
+
+/// バッジ文言。
+String quotaStatusBadgeLabel(QuotaToolStatus status) {
+  switch (status) {
+    case QuotaToolStatus.unmeasured:
+      return '未計測';
+    case QuotaToolStatus.alert:
+      return 'アラート';
+    case QuotaToolStatus.stale:
+      return '計測停止?';
+    case QuotaToolStatus.ok:
+      return '正常';
+  }
+}
+
+/// usage_json の実測コスト。cost_usd → cost_usd_est の順で読む(quota-monitor の
+/// openai step は cost_usd_est を書く)。どちらも無い場合は null を返し、UI は
+/// 「$0.00」を捏造せず「コスト未取得」を表示する(測った $0 と未取得の区別)。
+double? quotaCostUsd(Map<String, dynamic> usageJson) {
+  final cost = usageJson['cost_usd'] ?? usageJson['cost_usd_est'];
+  if (cost is num) return cost.toDouble();
+  return null;
+}
+
+/// checked_at からの経過日数。パース不能は null。表示側は staleDays 以上のとき
+/// 「(N日前)」を後置して古さを明示する。
+int? quotaCheckedAgeDays(String? checkedAt, DateTime now) {
+  final checked = DateTime.tryParse(checkedAt ?? '');
+  if (checked == null) return null;
+  final days = now.difference(checked).inDays;
+  return days < 0 ? 0 : days;
+}

--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -51,6 +51,10 @@ class _GrowthActionPlan {
   // R16: 非 null のとき、ボタンはページ遷移ではなくこの URL を外部起動する
   // (投稿を開く / console.x.com で上限確認 等)。
   final String? launchUrl;
+  // R21: カード本文(statusText)に出す短い状態文。detail はサブカード側にだけ
+  // 表示されるため、これが無いと postedTodayActive 時に detail 全文が本文と
+  // サブカードへ二重表示される。
+  final String? statusLine;
 
   const _GrowthActionPlan({
     required this.bottleneckLabel,
@@ -60,6 +64,7 @@ class _GrowthActionPlan {
     required this.buttonLabel,
     required this.isAcquisitionAction,
     this.launchUrl,
+    this.statusLine,
   });
 }
 
@@ -378,6 +383,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           buttonLabel: 'console.x.com で上限を確認',
           isAcquisitionAction: false,
           launchUrl: 'https://console.x.com/',
+          statusLine: 'X APIの支出上限に到達中のため自動投稿は停止中です。',
         );
       case AdminXPostedTodayCta.goldenHour:
       case AdminXPostedTodayCta.measuring:
@@ -398,6 +404,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
             buttonLabel: tweetUrl != null ? '投稿を開く' : '反応を確認',
             isAcquisitionAction: false,
             launchUrl: tweetUrl,
+            statusLine: '本日$postedCount件投稿済み。投稿直後30分の反応対応が最優先です。',
           );
         }
         return _GrowthActionPlan(
@@ -410,6 +417,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           buttonLabel: tweetUrl != null ? '投稿を開いて確認' : '成長プレイブックを見る',
           isAcquisitionAction: false,
           launchUrl: tweetUrl,
+          statusLine: '本日$postedCount件投稿済み（$imprText）。初速の計測待ちです。',
         );
     }
   }
@@ -852,61 +860,84 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
       if (session == null) throw Exception('Not authenticated');
 
       final headers = _adminAuthHeaders(session.accessToken);
-      final results = await Future.wait<FunctionResponse>([
-        _supabase.functions.invoke(
-          'schedule-hub',
-          headers: headers,
-          body: const {'action': 'digest.run', 'source': 'admin_manual_check'},
-        ),
-        _supabase.functions.invoke(
-          'admin-hub',
-          headers: headers,
-          body: const {
-            'action': 'support.list',
-            'source': 'admin_manual_check',
-          },
-        ),
+      // R21: Future.wait で束ねると片方の失敗で両方の結果を破棄し、raw exception
+      // 文字列がそのまま画面に出ていた。個別に握って部分成功を保持し、失敗側
+      // だけ人間語のエラーにする。
+      Map<String, dynamic>? digest;
+      List<Map<String, dynamic>>? tickets;
+      final errors = <String>[];
+
+      await Future.wait<void>([
+        () async {
+          try {
+            final res = await _supabase.functions.invoke(
+              'schedule-hub',
+              headers: headers,
+              body: const {
+                'action': 'digest.run',
+                'source': 'admin_manual_check',
+              },
+            );
+            final data = res.data as Map<String, dynamic>?;
+            if (data?['success'] != true) {
+              throw Exception('${data?['error'] ?? 'digest load failed'}');
+            }
+            final rawDigest = data?['digest'];
+            digest = rawDigest is Map
+                ? Map<String, dynamic>.from(rawDigest)
+                : <String, dynamic>{};
+          } catch (e) {
+            debugPrint('automation digest load error: $e');
+            errors.add('日次ダイジェストの取得に失敗しました');
+          }
+        }(),
+        () async {
+          try {
+            final res = await _supabase.functions.invoke(
+              'admin-hub',
+              headers: headers,
+              body: const {
+                'action': 'support.list',
+                'source': 'admin_manual_check',
+              },
+            );
+            final data = res.data as Map<String, dynamic>?;
+            if (data?['success'] != true) {
+              throw Exception(
+                data?['error']?.toString() ?? 'support ticket load failed',
+              );
+            }
+            final rawTickets = data?['tickets'];
+            final parsed = <Map<String, dynamic>>[];
+            if (rawTickets is List) {
+              for (final item in rawTickets.whereType<Map>()) {
+                parsed.add(Map<String, dynamic>.from(item));
+              }
+            }
+            tickets = parsed;
+          } catch (e) {
+            debugPrint('automation support load error: $e');
+            errors.add('サポートチケットの取得に失敗しました');
+          }
+        }(),
       ]);
 
-      final digestResult = results[0].data as Map<String, dynamic>?;
-      final supportResult = results[1].data as Map<String, dynamic>?;
-      if (digestResult?['success'] != true) {
-        throw Exception(
-          '${digestResult?['error'] ?? 'digest load failed'}',
-        );
-      }
-      if (supportResult?['success'] != true) {
-        throw Exception(
-          supportResult?['error']?.toString() ?? 'support ticket load failed',
-        );
-      }
-
-      final rawTickets = supportResult?['tickets'];
-      final tickets = <Map<String, dynamic>>[];
-      if (rawTickets is List) {
-        for (final item in rawTickets.whereType<Map>()) {
-          tickets.add(Map<String, dynamic>.from(item));
-        }
-      }
-
-      final rawDigest = digestResult?['digest'];
-      final digest = rawDigest is Map
-          ? Map<String, dynamic>.from(rawDigest)
-          : <String, dynamic>{};
-
+      final loadedDigest = digest;
+      final loadedTickets = tickets;
       if (!mounted) return;
       setState(() {
-        _automationDigest = digest;
-        _automationSupportTickets = tickets;
+        if (loadedDigest != null) _automationDigest = loadedDigest;
+        if (loadedTickets != null) _automationSupportTickets = loadedTickets;
         _automationLoading = false;
-        _automationError = null;
+        _automationError =
+            errors.isEmpty ? null : '${errors.join(' / ')}。更新ボタンで再試行してください。';
       });
     } catch (e) {
       debugPrint('automation ops load error: $e');
       if (!mounted) return;
       setState(() {
         _automationLoading = false;
-        _automationError = e.toString();
+        _automationError = '管理者セッションの確認に失敗しました。再ログイン後に更新してください。';
       });
     }
   }
@@ -1982,8 +2013,10 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     final actionButtonLabel = achieved ? null : growthAction.buttonLabel;
     final statusText = achieved
         ? '今日の登録目標は達成済みです。次は流入改善で上振れを狙う。'
+        // R21: detail はサブカード側に表示されるため、本文には短い statusLine を
+        // 使う(同一文の二重表示を防ぐ)。
         : postedTodayActive
-            ? growthAction.detail
+            ? (growthAction.statusLine ?? growthAction.detail)
             : todayViews == 0
                 ? '今日の流入がありません。まずは露出導線を1つ増やして、訪問者を作ってください。'
                 : todayFunnel.trialRuns == 0
@@ -2123,7 +2156,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                   color: const Color(0xFFFF6B35),
                 ),
               _buildMiniKpiChip(
-                label: '登録率',
+                // R21: 値は率ではなく診断ラベル(ゴールデンアワー/体験未実行 等)
+                // なので、ラベルも「診断」にする(率は隣の「今日のCVR」が担う)。
+                label: '診断',
                 value: diagnosisLabel,
                 color: diagnosisColor,
               ),

--- a/supabase/functions/tools-hub/jibun_api.ts
+++ b/supabase/functions/tools-hub/jibun_api.ts
@@ -72,7 +72,10 @@ export function normalizeScopes(input: unknown): JibunApiScope[] | null {
 function base64UrlEncode(bytes: Uint8Array): string {
   let binary = "";
   for (const b of bytes) binary += String.fromCharCode(b);
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(
+    /=+$/,
+    "",
+  );
 }
 
 export function generateApiKey(): { key: string; prefix: string } {
@@ -431,7 +434,9 @@ export function createSupabaseJibunApiStore(
         .from("user_api_keys")
         .update({ last_used_at: new Date().toISOString() })
         .eq("id", keyId);
-      if (error) console.warn(`jibun-api touchKeyLastUsed skipped: ${error.message}`);
+      if (error) {
+        console.warn(`jibun-api touchKeyLastUsed skipped: ${error.message}`);
+      }
     },
     async countWorkers(userId) {
       const { count, error } = await admin
@@ -516,7 +521,9 @@ export function createSupabaseJibunApiStore(
     },
     async insertAuditLog(row) {
       const { error } = await admin.from("user_api_audit_log").insert(row);
-      if (error) console.warn(`jibun-api audit insert skipped: ${error.message}`);
+      if (error) {
+        console.warn(`jibun-api audit insert skipped: ${error.message}`);
+      }
     },
     async countAuditSince(apiKeyId, sinceIso, actionPrefix) {
       let query = admin
@@ -760,7 +767,8 @@ async function handleManagementAction(
       const activeKeys = await store.countKeys(userId);
       if (activeKeys >= MAX_KEYS_PER_USER) {
         return json({
-          error: `key limit reached (max ${MAX_KEYS_PER_USER}). Revoke an existing key first.`,
+          error:
+            `key limit reached (max ${MAX_KEYS_PER_USER}). Revoke an existing key first.`,
         }, 409);
       }
       let expiresAt: string | null = null;
@@ -1209,7 +1217,10 @@ async function dispatchExternalApiAction(
       );
       if (dnsError) {
         return {
-          response: json({ error: `worker endpoint rejected: ${dnsError}` }, 400),
+          response: json(
+            { error: `worker endpoint rejected: ${dnsError}` },
+            400,
+          ),
           workerId: worker.id,
         };
       }

--- a/supabase/functions/tools-hub/jibun_api_test.ts
+++ b/supabase/functions/tools-hub/jibun_api_test.ts
@@ -20,9 +20,9 @@ import {
   JIBUN_API_SCOPES,
   type JibunApiStore,
   MAX_KEYS_PER_USER,
-  type NoteRow,
   normalizeScopes,
   normalizeWorkerSlug,
+  type NoteRow,
   parseInetOrNull,
   resolveHostToPrivateError,
   sanitizeSearchQuery,
@@ -161,7 +161,7 @@ Deno.test("sanitizeSearchQuery strips PostgREST filter metacharacters", () => {
     sanitizeSearchQuery("foo,id.gt.0(bar)"),
     "foo id.gt.0 bar",
   );
-  assertEquals(sanitizeSearchQuery('a"b\'c\\d'), "a b c d");
+  assertEquals(sanitizeSearchQuery("a\"b'c\\d"), "a b c d");
   assertEquals(sanitizeSearchQuery("100%_off*"), "100 off");
   assertEquals(sanitizeSearchQuery(42), "");
   assertEquals(sanitizeSearchQuery("  hello  "), "hello");
@@ -181,8 +181,7 @@ Deno.test("resolveHostToPrivateError flags hosts resolving to private IPs", asyn
   // A レコードが内部 IP を指すホスト名を検出する (DNS rebinding 対策)
   const rebind = await resolveHostToPrivateError(
     "evil.example.com",
-    (_host, type) =>
-      Promise.resolve(type === "A" ? ["169.254.169.254"] : []),
+    (_host, type) => Promise.resolve(type === "A" ? ["169.254.169.254"] : []),
   );
   assert(rebind !== null);
   assertStringIncludes(rebind ?? "", "169.254.169.254");
@@ -346,12 +345,10 @@ class FakeJibunApiStore implements JibunApiStore {
     options: { limit: number; query: string },
   ): Promise<NoteRow[]> {
     void userId;
-    const filtered = options.query === ""
-      ? this.notes
-      : this.notes.filter(
-        (n) =>
-          n.title.includes(options.query) || n.content.includes(options.query),
-      );
+    const filtered = options.query === "" ? this.notes : this.notes.filter(
+      (n) =>
+        n.title.includes(options.query) || n.content.includes(options.query),
+    );
     return Promise.resolve(filtered.slice(0, options.limit));
   }
   createNote(

--- a/test/pages/admin_analytics_page_test.dart
+++ b/test/pages/admin_analytics_page_test.dart
@@ -279,7 +279,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.textContaining('登録率 体験未実行', findRichText: true),
+      find.textContaining('診断 体験未実行', findRichText: true),
       findsOneWidget,
     );
     expect(find.text('今やる単独改善アクション'), findsOneWidget);

--- a/test/pages/blog_sync_feedback_test.dart
+++ b/test/pages/blog_sync_feedback_test.dart
@@ -1,0 +1,115 @@
+// R21: ブログ同期エラー人間語化の純ロジックテスト。
+// 本番実障害 (schedule-hub 502 {"error":"Qiita list: 401"} = QIITA_ACCESS_TOKEN
+// 失効) を生 FunctionException のまま表示せず、是正手順つき文言へ変換する
+// 回帰を固定する。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/admin/blog_sync_feedback.dart';
+
+void main() {
+  group('composeBlogSyncErrorMessage', () {
+    test('Qiita 401 はトークン失効+是正手順を名指しする(本番実ペイロード)', () {
+      final message = composeBlogSyncErrorMessage(
+        status: 502,
+        details: {'error': 'Qiita list: 401'},
+      );
+      expect(message, contains('Qiitaトークンが失効'));
+      expect(message, contains('QIITA_ACCESS_TOKEN'));
+      expect(message, isNot(contains('FunctionException')));
+    });
+
+    test('QIITA_ACCESS_TOKEN 未設定は secrets 設定を案内', () {
+      final message = composeBlogSyncErrorMessage(
+        status: 500,
+        details: {'error': 'QIITA_ACCESS_TOKEN not set'},
+      );
+      expect(message, contains('QIITA_ACCESS_TOKEN が未設定'));
+    });
+
+    test('DEVTO_API_KEY 未設定は secrets 設定を案内', () {
+      final message = composeBlogSyncErrorMessage(
+        status: 500,
+        details: {'error': 'DEVTO_API_KEY not set'},
+      );
+      expect(message, contains('DEVTO_API_KEY が未設定'));
+    });
+
+    test('その他は HTTP status + エラー本文', () {
+      final message = composeBlogSyncErrorMessage(
+        status: 502,
+        details: {'error': 'dev.to 500: oops'},
+      );
+      expect(message, contains('HTTP 502'));
+      expect(message, contains('dev.to 500: oops'));
+    });
+
+    test('details が Map でない場合は fallback 文字列で判定する', () {
+      final message = composeBlogSyncErrorMessage(
+        fallback:
+            'FunctionException(status: 502, details: {error: Qiita list: 401},'
+            ' reasonPhrase: )',
+      );
+      expect(message, contains('Qiitaトークンが失効'));
+    });
+
+    test('情報ゼロでも文として成立する', () {
+      expect(composeBlogSyncErrorMessage(), '同期に失敗しました。');
+    });
+  });
+
+  group('composeBlogSyncSuccessLine', () {
+    test('Qiita は articles_synced を件数表示', () {
+      expect(
+        composeBlogSyncSuccessLine('Qiita', {
+          'success': true,
+          'articles_synced': 12,
+        }),
+        'Qiita: 12件同期',
+      );
+    });
+
+    test('dev.to は synced を件数表示', () {
+      expect(
+        composeBlogSyncSuccessLine('dev.to', {'success': true, 'synced': 7}),
+        'dev.to: 7件同期',
+      );
+    });
+
+    test('件数が読めない場合は同期完了に留める', () {
+      expect(
+        composeBlogSyncSuccessLine('Qiita', {'success': true}),
+        'Qiita: 同期完了',
+      );
+      expect(composeBlogSyncSuccessLine('Qiita', null), 'Qiita: 同期完了');
+    });
+  });
+
+  group('blogEngagementFreshnessLabel', () {
+    final now = DateTime.utc(2026, 7, 12, 11, 0);
+
+    test('最新 updated_at から鮮度を出す(全行走査で max)', () {
+      final rows = [
+        {'updated_at': '2026-07-10T10:00:00Z'},
+        {'updated_at': '2026-07-12T09:30:00Z'},
+        {'updated_at': '2026-07-11T10:00:00Z'},
+      ];
+      expect(blogEngagementFreshnessLabel(rows, now), '最終同期: 1時間前');
+    });
+
+    test('1日以上前は日数表示(凍結値を今に見せない)', () {
+      final rows = [
+        {'updated_at': '2026-07-09T10:00:00Z'},
+      ];
+      expect(blogEngagementFreshnessLabel(rows, now), '最終同期: 3日前');
+    });
+
+    test('updated_at が読めない場合は null', () {
+      expect(blogEngagementFreshnessLabel([], now), isNull);
+      expect(
+        blogEngagementFreshnessLabel([
+          {'updated_at': 'bad'},
+        ], now),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/pages/blog_sync_feedback_test.dart
+++ b/test/pages/blog_sync_feedback_test.dart
@@ -62,6 +62,22 @@ void main() {
       );
       expect(message, contains('unexpected'));
     });
+
+    test('サーバー同梱 hint (upstream_error.ts) を最優先で表示する', () {
+      final message = composeBlogSyncErrorMessage(
+        status: 502,
+        details: {
+          'ok': false,
+          'error': 'Qiita API error 401',
+          'error_code': 'upstream_auth_error',
+          'upstream_status': 401,
+          'hint': 'QIITA_ACCESS_TOKEN が失効/権限不足の可能性。再発行して更新してください。',
+        },
+      );
+      expect(message, contains('HTTP 502'));
+      expect(message, contains('Qiita API error 401'));
+      expect(message, contains('再発行して更新してください'));
+    });
   });
 
   group('composeBlogSyncSuccessLine', () {

--- a/test/pages/blog_sync_feedback_test.dart
+++ b/test/pages/blog_sync_feedback_test.dart
@@ -54,6 +54,14 @@ void main() {
     test('情報ゼロでも文として成立する', () {
       expect(composeBlogSyncErrorMessage(), '同期に失敗しました。');
     });
+
+    test('error キーの無い Map details でも情報を全損させない', () {
+      final message = composeBlogSyncErrorMessage(
+        status: 500,
+        details: {'message': 'unexpected'},
+      );
+      expect(message, contains('unexpected'));
+    });
   });
 
   group('composeBlogSyncSuccessLine', () {
@@ -109,6 +117,41 @@ void main() {
           {'updated_at': 'bad'},
         ], now),
         isNull,
+      );
+    });
+  });
+
+  group('blogEngagementFreshnessByPlatform', () {
+    final now = DateTime.utc(2026, 7, 12, 11, 0);
+
+    test('複数 platform は個別表示(Qiita凍結が dev.to の新鮮さに隠れない)', () {
+      final rows = [
+        {'platform': 'qiita', 'updated_at': '2026-07-09T10:00:00Z'},
+        {'platform': 'devto', 'updated_at': '2026-07-12T10:30:00Z'},
+      ];
+      expect(
+        blogEngagementFreshnessByPlatform(rows, now),
+        '最終同期 — Qiita: 3日前 / dev.to: 1時間以内',
+      );
+    });
+
+    test('単一 platform は従来形式', () {
+      final rows = [
+        {'platform': 'qiita', 'updated_at': '2026-07-12T09:30:00Z'},
+      ];
+      expect(
+        blogEngagementFreshnessByPlatform(rows, now),
+        '最終同期: 1時間前',
+      );
+    });
+
+    test('platform 列が無ければ全体ラベルへフォールバック', () {
+      final rows = [
+        {'updated_at': '2026-07-11T10:00:00Z'},
+      ];
+      expect(
+        blogEngagementFreshnessByPlatform(rows, now),
+        '最終同期: 1日前',
       );
     });
   });

--- a/test/pages/blog_sync_feedback_test.dart
+++ b/test/pages/blog_sync_feedback_test.dart
@@ -112,12 +112,10 @@ void main() {
 
     test('updated_at が読めない場合は null', () {
       expect(blogEngagementFreshnessLabel([], now), isNull);
-      expect(
-        blogEngagementFreshnessLabel([
-          {'updated_at': 'bad'},
-        ], now),
-        isNull,
-      );
+      final badRows = [
+        {'updated_at': 'bad'},
+      ];
+      expect(blogEngagementFreshnessLabel(badRows, now), isNull);
     });
   });
 

--- a/test/pages/quota_dashboard_page_test.dart
+++ b/test/pages/quota_dashboard_page_test.dart
@@ -1,0 +1,167 @@
+// R21: AI クォータ監視ページの widget テスト。
+// 未計測ツールへの緑「正常」バッジ捏造・$0.00 捏造・アラートバナーの
+// 「Claude MAX レート制限」原因決め打ちの回帰を固定する。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/admin/quota_dashboard_page.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _FakeUser extends Fake implements User {
+  @override
+  String get id => 'quota-admin-id';
+}
+
+class _FakeGoTrueClient extends Fake implements GoTrueClient {
+  @override
+  User? get currentUser => _FakeUser();
+}
+
+class _FakeFunctionResponse extends Fake implements FunctionResponse {
+  final dynamic _data;
+  _FakeFunctionResponse(this._data);
+
+  @override
+  dynamic get data => _data;
+
+  @override
+  int get status => 200;
+}
+
+class _FakeFunctionsClient extends Fake implements FunctionsClient {
+  final List<Map<String, dynamic>> latestRows;
+  _FakeFunctionsClient(this.latestRows);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #invoke) {
+      final body = invocation.namedArguments[#body];
+      final action = body is Map ? '${body['action']}' : '';
+      if (action == 'quota.latest') {
+        return Future.value(
+          _FakeFunctionResponse({'success': true, 'data': latestRows}),
+        );
+      }
+      return Future.value(
+        _FakeFunctionResponse({'success': true, 'data': <dynamic>[]}),
+      );
+    }
+    return super.noSuchMethod(invocation);
+  }
+}
+
+class _FakeSupabaseClient extends Fake implements SupabaseClient {
+  final FunctionsClient _functions;
+  _FakeSupabaseClient(this._functions);
+
+  @override
+  FunctionsClient get functions => _functions;
+
+  @override
+  GoTrueClient get auth => _FakeGoTrueClient();
+}
+
+Future<void> _pumpQuotaPage(
+  WidgetTester tester,
+  List<Map<String, dynamic>> rows,
+) async {
+  final client = _FakeSupabaseClient(_FakeFunctionsClient(rows));
+  await tester.pumpWidget(
+    MaterialApp(home: QuotaDashboardPage(supabaseClient: client)),
+  );
+  await tester.pumpAndSettle();
+}
+
+String _today() {
+  final now = DateTime.now();
+  final m = now.month.toString().padLeft(2, '0');
+  final d = now.day.toString().padLeft(2, '0');
+  return '${now.year}-$m-$d';
+}
+
+String _daysAgo(int days) {
+  final dt = DateTime.now().subtract(Duration(days: days));
+  final m = dt.month.toString().padLeft(2, '0');
+  final d = dt.day.toString().padLeft(2, '0');
+  return '${dt.year}-$m-$d';
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('未計測ツールは「正常」ではなく「未計測」バッジ', (tester) async {
+    await _pumpQuotaPage(tester, [
+      {
+        'tool': 'anthropic',
+        'alert': false,
+        'checked_at': _today(),
+        'usage_json': {'cost_usd': 1.25},
+      },
+    ]);
+
+    // anthropic のみ計測済み → 正常1 / 残り4ツールは未計測。
+    expect(find.text('正常'), findsOneWidget);
+    expect(find.text('未計測'), findsNWidgets(4));
+    expect(find.text('\$1.25'), findsOneWidget);
+  });
+
+  testWidgets('cost_usd 欠落時は \$0.00 を捏造せず「コスト未取得」', (tester) async {
+    await _pumpQuotaPage(tester, [
+      {
+        'tool': 'github_copilot',
+        'alert': false,
+        'checked_at': _today(),
+        'usage_json': {'plan': 'copilot_pro'},
+      },
+    ]);
+
+    expect(find.text('コスト未取得'), findsOneWidget);
+    expect(find.text('\$0.00'), findsNothing);
+    expect(find.textContaining('% 使用'), findsNothing);
+  });
+
+  testWidgets('古い checked_at は「計測停止?」+経過日数を明示', (tester) async {
+    await _pumpQuotaPage(tester, [
+      {
+        'tool': 'anthropic',
+        'alert': false,
+        'checked_at': _daysAgo(5),
+        'usage_json': {'cost_usd': 0.0},
+      },
+    ]);
+
+    expect(find.text('計測停止?'), findsOneWidget);
+    expect(find.textContaining('計測停止の可能性'), findsOneWidget);
+  });
+
+  testWidgets('非Claudeアラートで「Claude MAX」原因を捏造しない', (tester) async {
+    await _pumpQuotaPage(tester, [
+      {
+        'tool': 'hedra',
+        'alert': true,
+        'checked_at': _today(),
+        'usage_json': {'remaining': 10, 'threshold': 50},
+      },
+    ]);
+
+    expect(find.text('⚠️ クォータアラート'), findsOneWidget);
+    expect(
+      find.textContaining('Hedra API のクォータが閾値を超えています'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Claude はファイル種別'), findsNothing);
+  });
+
+  testWidgets('Claudeアラート時のみフォールバック表を出す', (tester) async {
+    await _pumpQuotaPage(tester, [
+      {
+        'tool': 'anthropic',
+        'alert': true,
+        'checked_at': _today(),
+        'usage_json': {'cost_usd': 51.0},
+      },
+    ]);
+
+    expect(find.textContaining('Claude はファイル種別'), findsOneWidget);
+    expect(find.textContaining('Gemini Code Assist'), findsOneWidget);
+  });
+}

--- a/test/pages/quota_dashboard_signals_test.dart
+++ b/test/pages/quota_dashboard_signals_test.dart
@@ -1,0 +1,111 @@
+// R21: AI クォータ監視の純ロジックテスト。
+// 未計測(行なし)/計測停止(古い checked_at)を「正常」と捏造しない誠実性規律
+// (R17/R19) の回帰を固定する。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/admin/quota_dashboard_signals.dart';
+
+void main() {
+  final now = DateTime(2026, 7, 12, 11, 0);
+
+  group('resolveQuotaToolStatus', () {
+    test('行なしは unmeasured(正常と捏造しない)', () {
+      expect(
+        resolveQuotaToolStatus(
+          hasRow: false,
+          alert: false,
+          checkedAt: null,
+          now: now,
+        ),
+        QuotaToolStatus.unmeasured,
+      );
+    });
+
+    test('alert フラグは鮮度より優先して alert', () {
+      expect(
+        resolveQuotaToolStatus(
+          hasRow: true,
+          alert: true,
+          checkedAt: '2026-07-01',
+          now: now,
+        ),
+        QuotaToolStatus.alert,
+      );
+    });
+
+    test('前日計測(日次 cron 正常範囲)は ok', () {
+      expect(
+        resolveQuotaToolStatus(
+          hasRow: true,
+          alert: false,
+          checkedAt: '2026-07-11',
+          now: now,
+        ),
+        QuotaToolStatus.ok,
+      );
+    });
+
+    test('2日以上前の計測は stale(計測停止を正常に見せない)', () {
+      expect(
+        resolveQuotaToolStatus(
+          hasRow: true,
+          alert: false,
+          checkedAt: '2026-07-09',
+          now: now,
+        ),
+        QuotaToolStatus.stale,
+      );
+    });
+
+    test('checked_at パース不能は stale(不明を健全に見せない)', () {
+      expect(
+        resolveQuotaToolStatus(
+          hasRow: true,
+          alert: false,
+          checkedAt: 'not-a-date',
+          now: now,
+        ),
+        QuotaToolStatus.stale,
+      );
+    });
+  });
+
+  group('quotaStatusBadgeLabel', () {
+    test('4状態のラベル', () {
+      expect(quotaStatusBadgeLabel(QuotaToolStatus.unmeasured), '未計測');
+      expect(quotaStatusBadgeLabel(QuotaToolStatus.alert), 'アラート');
+      expect(quotaStatusBadgeLabel(QuotaToolStatus.stale), '計測停止?');
+      expect(quotaStatusBadgeLabel(QuotaToolStatus.ok), '正常');
+    });
+  });
+
+  group('quotaCostUsd', () {
+    test('cost_usd を読む', () {
+      expect(quotaCostUsd({'cost_usd': 1.25}), 1.25);
+    });
+
+    test('cost_usd_est へフォールバック(openai step の書式)', () {
+      expect(quotaCostUsd({'cost_usd_est': 0.5}), 0.5);
+    });
+
+    test('どちらも無い場合は null(\$0.00 を捏造しない)', () {
+      expect(quotaCostUsd({'plan': 'copilot_pro'}), isNull);
+      expect(quotaCostUsd({}), isNull);
+    });
+
+    test('測定済み \$0 は 0.0 として返す(未取得と区別)', () {
+      expect(quotaCostUsd({'cost_usd': 0}), 0.0);
+    });
+  });
+
+  group('quotaCheckedAgeDays', () {
+    test('経過日数を返す', () {
+      expect(quotaCheckedAgeDays('2026-07-09', now), 3);
+      expect(quotaCheckedAgeDays('2026-07-12', now), 0);
+    });
+
+    test('パース不能/null は null', () {
+      expect(quotaCheckedAgeDays('bad', now), isNull);
+      expect(quotaCheckedAgeDays(null, now), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

経営分析ダッシュボード改善 **R21**。本番スクリーンショット起点で **10仮説を立て、Workflow(検証エージェント10+critic1)で全件敵対的検証**(9 CONFIRMED / 1 PARTIAL)し、completeness critic の追加3件も含めて実装した。

### 本番で確定した実障害(コード外の是正が別途必要)

- 本番の schedule-hub 502 は `blog.sync_engagement` のみで、実体は **Qiita 側 401 = QIITA_ACCESS_TOKEN の失効**(`{"error":"Qiita list: 401"}` を実測)。`digest.run` は 200 正常。
- 是正はユーザー操作: Qiita で新しいアクセストークンを発行 → Supabase secrets の `QIITA_ACCESS_TOKEN` を更新。本PRはその障害を**管理画面が正しく伝える**ようにする。

### 修正内容

**AIクォータ監視(H6/H7/H8 + critic H11/H12)**
- 未計測(行なし)・計測停止(checked_at 2日超)を「正常」と捏造しない4状態バッジ(未計測/アラート/計測停止?/正常)。純ロジックを `quota_dashboard_signals.dart` へ抽出。
- `cost_usd` 欠落時に「$0.00 / $50」「0% 使用」を捏造せず「コスト未取得」(`cost_usd_est` フォールバック対応)。
- アラートバナーが常に「Claude MAX レート制限到達」と原因を決め打ちしていた問題 → 実際にアラート中のツール名を表示(コーディング代替表は Claude アラート時のみ)。
- 取得失敗を無音で「データなし」に見せず、失敗バナーで可視化。

**経営分析ダッシュボード(H4/H5/H9)**
- ゴールデンアワー/計測待ち/上限時に同一の長文が本文とサブカードへ**二重表示**される問題を `statusLine` 導入で解消。
- 「登録率」チップの値が常に診断ラベル(率ではない)だったラベル不整合 → 「診断」へ。
- `_loadAutomationOps` の Future.wait 一括破棄をやめ、個別 try-catch で部分成功維持+エラー文言の人間語化。

**ブログ管理(H1/H2/H3/H10 + critic H13)**
- 同期ボタンを Qiita / dev.to **独立実行**へ(ボタン・tooltip の文言どおり両方実行し、片方失敗の巻き添えを防ぐ)。
- 生 `FunctionException(...)` トーストをやめ、Qiita 401 = トークン失効を名指しし**是正手順つき文言**へ変換(純ロジック `blog_sync_feedback.dart` へ抽出)。
- 空状態が同期失敗後も「Sync ボタンで取得できます」と同じ失敗ボタンへ誘導する**デッドエンドを解消**(直近の同期エラーを空状態に表示)。
- エンゲージメント数値に「最終同期: N時間前」の鮮度表示(同期失敗中の凍結値を今の数値に見せない)。

実変更は Dart-only(`lib/` + `test/` のみ)。`supabase/functions/tools-hub` の差分は ci-auto-fix bot による deno fmt 整形のみ(挙動変更なし)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: ci-auto-fix bot による tools-hub deno fmt 整形のみで挙動変更なし。本PRの実変更は lib/ + test/ の Dart-only 管理画面誠実性修正。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Dart-only admin dashboard honesty fixes covered by pure-logic VM tests + widget tests (quota page 5 / signals 13 / sync feedback 12); no new e2e route

## Test plan

- `flutter test test/pages/quota_dashboard_signals_test.dart test/pages/blog_sync_feedback_test.dart test/pages/admin_dashboard_signals_test.dart` → 54 green
- `flutter test test/pages/quota_dashboard_page_test.dart` → 5 green(未計測バッジ/コスト未取得/計測停止?/非Claudeアラート文言/Claude限定フォールバック表)
- `flutter build web --release` → green(コンパイルゲート)
- `dart format --set-exit-if-changed` → 差分なし(全変更ファイルで確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
