### PR TITLE
refactor(blog): BlogService.qiitaGetItem 休眠デッドコードを削除

### DIFF
--- a/lib/services/blog_service.dart
+++ b/lib/services/blog_service.dart
@@ -96,11 +96,6 @@ class BlogService {
     });
   }
 
-  // ── Qiita 記事本文取得 ────────────────────────────────────────
-  Future<Map<String, dynamic>> qiitaGetItem(String itemId) async {
-    return _invokeBlogAction('blog.qiita_get_item', {'item_id': itemId});
-  }
-
   // ── 訂正承認 ────────────────────────────────────────────────────
   Future<void> qiitaUpdate({
     required String articleId,


### PR DESCRIPTION
## 概要

`supabase/functions/schedule-hub/index.ts` に action `blog.qiita_get_item` の case が存在せず、`BlogService.qiitaGetItem()` を invoke すると常に default case の 400 "Unknown action" になる休眠デッドコードだった。

- `qiitaGetItem` の呼び出し元: リポジトリ全体でゼロ (定義 1 箇所のみ)
- `test/` からの参照: ゼロ
- 対応: (a) edge 側へ handler を追加 / (b) メソッド削除 のうち、誰も呼ばない API の実装は投機的なため **(b) 削除** を選択。edge function は無変更。

## 変更

- `lib/services/blog_service.dart`: `qiitaGetItem()` とコメントヘッダーを削除 (-5 行)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Dead-code removal only: deleted an unused method with zero call sites; no runtime flow exists to drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
