### PR TITLE
fix(blog): remove dead qiitaGetItem() wrapper (edge action never existed)

### DIFF
--- a/lib/services/blog_service.dart
+++ b/lib/services/blog_service.dart
@@ -96,11 +96,6 @@ class BlogService {
     });
   }
 
-  // ── Qiita 記事本文取得 ────────────────────────────────────────
-  Future<Map<String, dynamic>> qiitaGetItem(String itemId) async {
-    return _invokeBlogAction('blog.qiita_get_item', {'item_id': itemId});
-  }
-
   // ── 訂正承認 ────────────────────────────────────────────────────
   Future<void> qiitaUpdate({
     required String articleId,


### PR DESCRIPTION
## 概要

`lib/services/blog_service.dart` の `qiitaGetItem()` (旧 L99-102) を削除する dead code 除去。

## 背景

- `qiitaGetItem()` は schedule-hub Edge Function へ action `blog.qiita_get_item` を invoke するが、`supabase/functions/schedule-hub/index.ts` にこの action の case が**存在しない** — 呼べば必ず default の 400 "Unknown action: blog.qiita_get_item" になる。
- repo 全体 grep (`git grep qiitaGetItem` / `git grep qiita_get_item`) で参照は定義行のみ = **呼び出し元ゼロ**。
- 想定利用先だった訂正承認フローは `blog_management_page.dart` の `_approveCorrection` が `blog.qiita_update` (title のみの PATCH — edge 側で title/body/tags は全て optional) を直接 invoke しており、本メソッドに依存しない。
- 両端 (Dart wrapper / edge action) とも未実装・未使用のため、edge に case を追加するのではなく Dart 側メソッドを削除する。Edge Function への変更なし (Dart-only)。

## 変更内容

- `BlogService.qiitaGetItem()` メソッドとコメントヘッダを削除 (5 行削除のみ)。

## 影響範囲

- `BlogService` の利用箇所は `blog_draft_editor_page.dart` / `news_rss_aggregator_page.dart` の 2 箇所のみで、いずれも `qiitaGetItem` を呼んでいない。挙動変化なし。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Dead-code removal only: qiitaGetItem() had zero callers repo-wide and the edge action blog.qiita_get_item never existed; no runtime path changes, nothing to exercise E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
