### PR TITLE
fix(schedule-hub): Qiita/dev.to API 失敗時の劣化挙動を統一 (502+構造化error code)

### DIFF
--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -21,6 +21,12 @@ import {
   isExternalFetchError,
 } from "../_shared/external_fetch.ts";
 import { buildOwnSiteBlogPostUrl } from "./blog_canonical.ts";
+import {
+  allPlatformsFailed,
+  type BlogUpstreamApi,
+  buildUpstreamErrorPayload,
+  summarizePlatformFailures,
+} from "./upstream_error.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -1063,6 +1069,21 @@ async function devtoFetch(
       headers: mergeHeaders({ "api-key": apiKey }, init.headers),
     },
     { traceId },
+  );
+}
+
+// 上流 4xx/5xx を統一 502 応答へ (単一 upstream action 用 / 方針は upstream_error.ts)
+async function upstreamErrorJson(
+  targetApi: BlogUpstreamApi,
+  res: Response,
+): Promise<Response> {
+  const detail = await res.text().catch(() => "");
+  return json(
+    {
+      success: false,
+      ...buildUpstreamErrorPayload({ targetApi, status: res.status, detail }),
+    },
+    502,
   );
 }
 
@@ -2159,8 +2180,11 @@ serve(async (req: Request) => {
               const qd = await qr.json() as { url: string; id: string };
               results.qiita = { ok: true, url: qd.url };
             } else {
-              const errText = await qr.text();
-              results.qiita = { ok: false, error: `${qr.status}: ${errText}` };
+              results.qiita = buildUpstreamErrorPayload({
+                targetApi: "qiita",
+                status: qr.status,
+                detail: await qr.text().catch(() => ""),
+              });
             }
           } catch (e) {
             results.qiita = isExternalFetchError(e)
@@ -2194,8 +2218,11 @@ serve(async (req: Request) => {
               const dd = await dr.json() as { url: string; id: number };
               results.devto = { ok: true, url: dd.url };
             } else {
-              const errText = await dr.text();
-              results.devto = { ok: false, error: `${dr.status}: ${errText}` };
+              results.devto = buildUpstreamErrorPayload({
+                targetApi: "dev.to",
+                status: dr.status,
+                detail: await dr.text().catch(() => ""),
+              });
             }
           } catch (e) {
             results.devto = isExternalFetchError(e)
@@ -2273,6 +2300,15 @@ serve(async (req: Request) => {
           console.error("blog.auto_publish DB write failed:", dbErr);
         }
 
+        // 部分成功は 200 (成功済み platform への再投稿リトライ防止) / 全滅のみ 502
+        if (allPlatformsFailed(results)) {
+          return json({
+            success: false,
+            error: summarizePlatformFailures(results),
+            error_code: "all_platforms_failed",
+            results,
+          }, 502);
+        }
         return json({ success: true, results });
       }
 
@@ -2343,16 +2379,19 @@ serve(async (req: Request) => {
               const qd = await qr.json() as { url: string; id: string };
               ppResults.qiita = { ok: true, url: qd.url };
             } else {
-              ppResults.qiita = {
-                ok: false,
-                error: `${qr.status}: ${await qr.text()}`,
-              };
+              ppResults.qiita = buildUpstreamErrorPayload({
+                targetApi: "qiita",
+                status: qr.status,
+                detail: await qr.text().catch(() => ""),
+              });
             }
           } catch (e) {
             ppResults.qiita = isExternalFetchError(e)
               ? externalFetchErrorPayload(e)
               : { ok: false, error: String(e) };
           }
+        } else if (ppPlatforms.includes("qiita")) {
+          ppResults.qiita = { ok: false, error: "QIITA_ACCESS_TOKEN not set" };
         }
 
         if (ppPlatforms.includes("devto") && devtoKey) {
@@ -2386,16 +2425,19 @@ serve(async (req: Request) => {
               const dd = await dr.json() as { url: string; id: number };
               ppResults.devto = { ok: true, url: dd.url };
             } else {
-              ppResults.devto = {
-                ok: false,
-                error: `${dr.status}: ${await dr.text()}`,
-              };
+              ppResults.devto = buildUpstreamErrorPayload({
+                targetApi: "dev.to",
+                status: dr.status,
+                detail: await dr.text().catch(() => ""),
+              });
             }
           } catch (e) {
             ppResults.devto = isExternalFetchError(e)
               ? externalFetchErrorPayload(e)
               : { ok: false, error: String(e) };
           }
+        } else if (ppPlatforms.includes("devto")) {
+          ppResults.devto = { ok: false, error: "DEVTO_API_KEY not set" };
         }
 
         const successUrls = (
@@ -2416,6 +2458,15 @@ serve(async (req: Request) => {
             .eq("id", postId);
         }
 
+        // 部分成功は 200 (成功済み platform への再投稿リトライ防止) / 全滅のみ 502
+        if (allPlatformsFailed(ppResults)) {
+          return json({
+            success: false,
+            error: summarizePlatformFailures(ppResults),
+            error_code: "all_platforms_failed",
+            results: ppResults,
+          }, 502);
+        }
         return json({ success: true, results: ppResults });
       }
 
@@ -2667,6 +2718,8 @@ serve(async (req: Request) => {
           skipped_dup: 0,
           skipped_old: 0,
         };
+        // source ごとの取得失敗を記録 (黙殺すると 0 件と区別できない)
+        const backfillErrors: Record<string, unknown> = {};
 
         // ── Qiita 取得 ──────────────────────────────────────────────────
         if (qiitaToken) {
@@ -2712,9 +2765,18 @@ serve(async (req: Request) => {
                 });
                 existingUrls.add(a.url);
               }
+            } else {
+              backfillErrors.qiita = buildUpstreamErrorPayload({
+                targetApi: "qiita",
+                status: qr.status,
+                detail: await qr.text().catch(() => ""),
+              });
             }
           } catch (e) {
             console.error("qiita backfill fetch failed:", e);
+            backfillErrors.qiita = isExternalFetchError(e)
+              ? externalFetchErrorPayload(e)
+              : { ok: false, error: String(e) };
           }
         }
 
@@ -2763,10 +2825,37 @@ serve(async (req: Request) => {
                 });
                 existingUrls.add(a.url);
               }
+            } else {
+              backfillErrors.devto = buildUpstreamErrorPayload({
+                targetApi: "dev.to",
+                status: dr.status,
+                detail: await dr.text().catch(() => ""),
+              });
             }
           } catch (e) {
             console.error("devto backfill fetch failed:", e);
+            backfillErrors.devto = isExternalFetchError(e)
+              ? externalFetchErrorPayload(e)
+              : { ok: false, error: String(e) };
           }
+        }
+
+        // 全 source 失敗時のみ 502 (部分成功は 200 + errors で継続)
+        const attemptedSources = [
+          qiitaToken ? "qiita" : "",
+          devtoKey ? "devto" : "",
+        ].filter(Boolean);
+        if (
+          attemptedSources.length > 0 &&
+          attemptedSources.every((s) => backfillErrors[s] !== undefined)
+        ) {
+          return json({
+            success: false,
+            error: summarizePlatformFailures(backfillErrors),
+            error_code: "all_sources_failed",
+            errors: backfillErrors,
+            summary,
+          }, 502);
         }
 
         // ── 一括 insert ─────────────────────────────────────────────────
@@ -2784,7 +2873,13 @@ serve(async (req: Request) => {
           summary.inserted = inserts.length;
         }
 
-        return json({ success: true, summary });
+        return json({
+          success: true,
+          summary,
+          ...(Object.keys(backfillErrors).length > 0
+            ? { errors: backfillErrors }
+            : {}),
+        });
       }
 
       // Win版#132 part 124: tech-blog-tracker page 用 public read action.
@@ -2837,9 +2932,7 @@ serve(async (req: Request) => {
           {},
           "schedule-hub.blog.qiita_list",
         );
-        if (!qr.ok) {
-          return json({ error: `Qiita ${qr.status}: ${await qr.text()}` }, 502);
-        }
+        if (!qr.ok) return await upstreamErrorJson("qiita", qr);
         const articles = await qr.json() as Array<{
           id: string;
           title: string;
@@ -2866,7 +2959,7 @@ serve(async (req: Request) => {
           {},
           "schedule-hub.blog.qiita_comments",
         );
-        if (!qr.ok) return json({ error: `Qiita ${qr.status}` }, 502);
+        if (!qr.ok) return await upstreamErrorJson("qiita", qr);
         const comments = await qr.json() as Array<{
           id: string;
           body: string;
@@ -2895,9 +2988,7 @@ serve(async (req: Request) => {
           },
           body: JSON.stringify({ item_id: itemId, body: replyBody }),
         }, "schedule-hub.blog.qiita_comment_post");
-        if (!qr.ok) {
-          return json({ error: `Qiita ${qr.status}: ${await qr.text()}` }, 502);
-        }
+        if (!qr.ok) return await upstreamErrorJson("qiita", qr);
         const comment = await qr.json();
         return json({ success: true, comment });
       }
@@ -2916,7 +3007,7 @@ serve(async (req: Request) => {
           {},
           "schedule-hub.blog.qiita_likers",
         );
-        if (!qr.ok) return json({ error: `Qiita ${qr.status}` }, 502);
+        if (!qr.ok) return await upstreamErrorJson("qiita", qr);
         const likers = await qr.json() as Array<
           { user: { id: string; name: string; profile_image_url: string } }
         >;
@@ -2937,9 +3028,9 @@ serve(async (req: Request) => {
           { method: "PUT" },
           "schedule-hub.blog.qiita_follow",
         );
-        // 204 No Content = success
-        const ok = qr.status === 204 || qr.ok;
-        return json({ success: ok, status: qr.status, user_id: userId });
+        // 204 No Content = success (Response.ok は 2xx 全体を含む)
+        if (!qr.ok) return await upstreamErrorJson("qiita", qr);
+        return json({ success: true, status: qr.status, user_id: userId });
       }
 
       // blog.qiita_delete — 記事を削除
@@ -2956,11 +3047,8 @@ serve(async (req: Request) => {
           { method: "DELETE" },
           "schedule-hub.blog.qiita_delete",
         );
-        return json({
-          success: qr.status === 204,
-          status: qr.status,
-          item_id: itemId,
-        });
+        if (!qr.ok) return await upstreamErrorJson("qiita", qr);
+        return json({ success: true, status: qr.status, item_id: itemId });
       }
 
       // blog.qiita_update — 記事を更新 (内容訂正)
@@ -2991,9 +3079,7 @@ serve(async (req: Request) => {
           },
           "schedule-hub.blog.qiita_update",
         );
-        if (!qr.ok) {
-          return json({ error: `Qiita ${qr.status}: ${await qr.text()}` }, 502);
-        }
+        if (!qr.ok) return await upstreamErrorJson("qiita", qr);
         const updated = await qr.json() as {
           id: string;
           url: string;
@@ -3017,12 +3103,7 @@ serve(async (req: Request) => {
           {},
           "schedule-hub.blog.devto_list",
         );
-        if (!dr.ok) {
-          return json(
-            { error: `dev.to ${dr.status}: ${await dr.text()}` },
-            502,
-          );
-        }
+        if (!dr.ok) return await upstreamErrorJson("dev.to", dr);
         const articles = await dr.json() as Array<{
           id: number;
           title: string;
@@ -3043,12 +3124,7 @@ serve(async (req: Request) => {
           `https://dev.to/api/articles/me/published?per_page=${perPage}`,
           { headers: { "api-key": devtoKey } },
         );
-        if (!dr.ok) {
-          return json(
-            { error: `dev.to ${dr.status}: ${await dr.text()}` },
-            502,
-          );
-        }
+        if (!dr.ok) return await upstreamErrorJson("dev.to", dr);
         const articles = await dr.json() as Array<{
           id: number;
           title: string;
@@ -3098,7 +3174,7 @@ serve(async (req: Request) => {
           "schedule-hub.blog.sync_engagement.articles",
         );
         if (!articlesRes.ok) {
-          return json({ error: `Qiita list: ${articlesRes.status}` }, 502);
+          return await upstreamErrorJson("qiita", articlesRes);
         }
         const articles = await articlesRes.json() as Array<{
           id: string;
@@ -3282,8 +3358,9 @@ serve(async (req: Request) => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ article: { published: false } }),
         }, "schedule-hub.blog.devto_delete");
+        if (!dr.ok) return await upstreamErrorJson("dev.to", dr);
         return json({
-          success: dr.ok,
+          success: true,
           status: dr.status,
           article_id: articleId,
         });

--- a/supabase/functions/schedule-hub/upstream_error.ts
+++ b/supabase/functions/schedule-hub/upstream_error.ts
@@ -1,0 +1,116 @@
+// upstream_error.ts — 外部ブログ API (Qiita / dev.to) 非 ok 応答の構造化 (純ロジック)
+//
+// 統一方針 (2026-07-12):
+//   - 単一 upstream の action: 上流 4xx/5xx → HTTP 502 + 本 payload
+//   - 複数 platform の action (auto_publish / publish_post / backfill_from_apis):
+//     results/errors に本 payload を埋め、全 platform 失敗時のみ HTTP 502
+//     (部分成功は 200 のまま — 502 にすると成功済み platform へ再投稿リトライを誘発する)
+//   - 一時障害 (timeout / retry 尽き 5xx/429) は従来通り ExternalFetchError
+//     → serve top-level catch が 503 + externalFetchErrorPayload を返す
+
+export type BlogUpstreamApi = "qiita" | "dev.to";
+
+export interface UpstreamErrorPayload {
+  ok: false;
+  error: string;
+  error_code:
+    | "upstream_auth_error"
+    | "upstream_rate_limited"
+    | "upstream_error";
+  target_api: BlogUpstreamApi;
+  upstream_status: number | null;
+  hint?: string;
+}
+
+const API_LABELS: Record<BlogUpstreamApi, string> = {
+  qiita: "Qiita",
+  "dev.to": "dev.to",
+};
+
+export const QIITA_TOKEN_ROTATE_HINT =
+  "QIITA_ACCESS_TOKEN が失効/権限不足の可能性。Qiita 設定 → アプリケーション → " +
+  "個人用アクセストークンを再発行し `supabase secrets set QIITA_ACCESS_TOKEN=<新トークン> " +
+  "--project-ref smmkxxavexumewbfaqpy` で更新してください。";
+
+export const DEVTO_KEY_ROTATE_HINT =
+  "DEVTO_API_KEY が失効した可能性。dev.to Settings → Extensions → DEV Community API Keys " +
+  "で再発行し `supabase secrets set DEVTO_API_KEY=<新キー> " +
+  "--project-ref smmkxxavexumewbfaqpy` で更新してください。";
+
+export const QIITA_RATE_LIMIT_HINT =
+  "Qiita API レート制限。72 時間級の長期 cooldown 実績あり — リトライ間隔を空けてください。";
+
+const DETAIL_MAX_CHARS = 300;
+
+// Qiita はレート超過を 403 body で返すことがあるため status + body で分類する
+export function classifyUpstreamError(
+  status: number | null,
+  detail = "",
+): UpstreamErrorPayload["error_code"] {
+  if (status === 429) return "upstream_rate_limited";
+  if (status === 403 && /rate ?limit/i.test(detail)) {
+    return "upstream_rate_limited";
+  }
+  if (status === 401 || status === 403) return "upstream_auth_error";
+  return "upstream_error";
+}
+
+function hintFor(
+  targetApi: BlogUpstreamApi,
+  code: UpstreamErrorPayload["error_code"],
+): string | undefined {
+  if (code === "upstream_auth_error") {
+    return targetApi === "qiita"
+      ? QIITA_TOKEN_ROTATE_HINT
+      : DEVTO_KEY_ROTATE_HINT;
+  }
+  if (code === "upstream_rate_limited" && targetApi === "qiita") {
+    return QIITA_RATE_LIMIT_HINT;
+  }
+  return undefined;
+}
+
+export function buildUpstreamErrorPayload(params: {
+  targetApi: BlogUpstreamApi;
+  status: number | null;
+  detail?: string;
+}): UpstreamErrorPayload {
+  const detail = (params.detail ?? "").trim().slice(0, DETAIL_MAX_CHARS);
+  const code = classifyUpstreamError(params.status, detail);
+  const label = API_LABELS[params.targetApi];
+  const statusPart = params.status !== null ? ` ${params.status}` : "";
+  const detailPart = detail ? `: ${detail}` : "";
+  const hint = hintFor(params.targetApi, code);
+  return {
+    ok: false,
+    error: `${label} API error${statusPart}${detailPart}`,
+    error_code: code,
+    target_api: params.targetApi,
+    upstream_status: params.status,
+    ...(hint ? { hint } : {}),
+  };
+}
+
+// results (platform → {ok,...}) が「1 件以上あり全滅」かを判定する。
+// 空 map は「何も試行していない」なので false (= 従来通り 200)。
+export function allPlatformsFailed(
+  results: Record<string, unknown>,
+): boolean {
+  const entries = Object.values(results);
+  if (entries.length === 0) return false;
+  return entries.every(
+    (r) => (r as { ok?: unknown } | null | undefined)?.ok !== true,
+  );
+}
+
+// 全滅時の top-level error メッセージ (platform: error の列挙)
+export function summarizePlatformFailures(
+  results: Record<string, unknown>,
+): string {
+  const parts = Object.entries(results).map(([platform, r]) => {
+    const rec = r as { error?: unknown } | null | undefined;
+    const msg = typeof rec?.error === "string" ? rec.error : "unknown error";
+    return `${platform}: ${msg}`;
+  });
+  return `All requested platforms failed — ${parts.join(" / ")}`;
+}

--- a/supabase/functions/schedule-hub/upstream_error_test.ts
+++ b/supabase/functions/schedule-hub/upstream_error_test.ts
@@ -1,0 +1,138 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  allPlatformsFailed,
+  buildUpstreamErrorPayload,
+  classifyUpstreamError,
+  DEVTO_KEY_ROTATE_HINT,
+  QIITA_RATE_LIMIT_HINT,
+  QIITA_TOKEN_ROTATE_HINT,
+  summarizePlatformFailures,
+} from "./upstream_error.ts";
+
+Deno.test("classifyUpstreamError: 401 は auth error", () => {
+  assertEquals(classifyUpstreamError(401), "upstream_auth_error");
+});
+
+Deno.test("classifyUpstreamError: 403 は auth error (rate limit body なし)", () => {
+  assertEquals(classifyUpstreamError(403, "Forbidden"), "upstream_auth_error");
+});
+
+Deno.test("classifyUpstreamError: 403 + rate limit body は rate_limited", () => {
+  assertEquals(
+    classifyUpstreamError(403, '{"message":"Rate limit exceeded"}'),
+    "upstream_rate_limited",
+  );
+  assertEquals(
+    classifyUpstreamError(403, "ratelimit reached"),
+    "upstream_rate_limited",
+  );
+});
+
+Deno.test("classifyUpstreamError: 429 は rate_limited", () => {
+  assertEquals(classifyUpstreamError(429), "upstream_rate_limited");
+});
+
+Deno.test("classifyUpstreamError: 404 / 500 / null は generic", () => {
+  assertEquals(classifyUpstreamError(404), "upstream_error");
+  assertEquals(classifyUpstreamError(500), "upstream_error");
+  assertEquals(classifyUpstreamError(null), "upstream_error");
+});
+
+Deno.test("buildUpstreamErrorPayload: qiita 401 → rotate hint 付き", () => {
+  const p = buildUpstreamErrorPayload({
+    targetApi: "qiita",
+    status: 401,
+    detail: "Unauthorized",
+  });
+  assertEquals(p.ok, false);
+  assertEquals(p.error_code, "upstream_auth_error");
+  assertEquals(p.target_api, "qiita");
+  assertEquals(p.upstream_status, 401);
+  assertEquals(p.hint, QIITA_TOKEN_ROTATE_HINT);
+  assertStringIncludes(p.error, "Qiita API error 401");
+  assertStringIncludes(p.error, "Unauthorized");
+});
+
+Deno.test("buildUpstreamErrorPayload: dev.to 401 → DEVTO hint", () => {
+  const p = buildUpstreamErrorPayload({ targetApi: "dev.to", status: 401 });
+  assertEquals(p.hint, DEVTO_KEY_ROTATE_HINT);
+  assertStringIncludes(p.error, "dev.to API error 401");
+});
+
+Deno.test("buildUpstreamErrorPayload: qiita 429 → rate limit hint", () => {
+  const p = buildUpstreamErrorPayload({ targetApi: "qiita", status: 429 });
+  assertEquals(p.error_code, "upstream_rate_limited");
+  assertEquals(p.hint, QIITA_RATE_LIMIT_HINT);
+});
+
+Deno.test("buildUpstreamErrorPayload: 404 は hint なし", () => {
+  const p = buildUpstreamErrorPayload({
+    targetApi: "qiita",
+    status: 404,
+    detail: "Not found",
+  });
+  assertEquals(p.error_code, "upstream_error");
+  assertEquals("hint" in p, false);
+});
+
+Deno.test("buildUpstreamErrorPayload: detail は 300 字に切り詰め", () => {
+  const p = buildUpstreamErrorPayload({
+    targetApi: "qiita",
+    status: 400,
+    detail: "x".repeat(1000),
+  });
+  // "Qiita API error 400: " + 300 chars
+  assertEquals(p.error.length <= "Qiita API error 400: ".length + 300, true);
+});
+
+Deno.test("buildUpstreamErrorPayload: status null / detail なし", () => {
+  const p = buildUpstreamErrorPayload({ targetApi: "qiita", status: null });
+  assertEquals(p.upstream_status, null);
+  assertEquals(p.error, "Qiita API error");
+});
+
+Deno.test("allPlatformsFailed: 空 map は false (未試行)", () => {
+  assertEquals(allPlatformsFailed({}), false);
+});
+
+Deno.test("allPlatformsFailed: 1 件でも成功があれば false", () => {
+  assertEquals(
+    allPlatformsFailed({
+      qiita: { ok: false, error: "401" },
+      devto: { ok: true, url: "https://dev.to/x" },
+    }),
+    false,
+  );
+});
+
+Deno.test("allPlatformsFailed: 全滅は true", () => {
+  assertEquals(
+    allPlatformsFailed({
+      qiita: { ok: false, error: "401" },
+      devto: { ok: false, error: "key not set" },
+    }),
+    true,
+  );
+});
+
+Deno.test("allPlatformsFailed: ok 欠落 entry は失敗扱い", () => {
+  assertEquals(allPlatformsFailed({ qiita: { status: 500 } }), true);
+});
+
+Deno.test("summarizePlatformFailures: platform 名 + error を列挙", () => {
+  const msg = summarizePlatformFailures({
+    qiita: { ok: false, error: "Qiita API error 401: Unauthorized" },
+    devto: { ok: false, error: "DEVTO_API_KEY not set" },
+  });
+  assertStringIncludes(msg, "All requested platforms failed");
+  assertStringIncludes(msg, "qiita: Qiita API error 401: Unauthorized");
+  assertStringIncludes(msg, "devto: DEVTO_API_KEY not set");
+});
+
+Deno.test("summarizePlatformFailures: error 欠落は unknown error", () => {
+  const msg = summarizePlatformFailures({ qiita: { ok: false } });
+  assertStringIncludes(msg, "qiita: unknown error");
+});


### PR DESCRIPTION
## 概要

`supabase/functions/schedule-hub/index.ts` で Qiita API 失敗時の劣化挙動が action ごとに **3通りに割れていた** のを統一する。

| 旧挙動 | 対象 action |
|---|---|
| ① 502 (ad-hoc payload) | blog.sync_engagement / qiita_list / qiita_comments / qiita_comment_post / qiita_likers / qiita_update |
| ② 200 + `success:false` | qiita_follow / qiita_delete |
| ③ 非 ok を黙殺して 200 | backfill_from_apis / publish_post / auto_publish |

## 統一方針

- **単一 upstream の action**: 上流 4xx/5xx → **HTTP 502 + 構造化 payload**
  `{ success:false, error, error_code, target_api, upstream_status, hint? }`
  - `error_code`: `upstream_auth_error` (401/403) / `upstream_rate_limited` (429, 403+rate-limit body) / `upstream_error`
  - **401 (トークン失効) は rotate 手順 hint 付き** (`supabase secrets set QIITA_ACCESS_TOKEN=... --project-ref smmkxxavexumewbfaqpy`)
  - Qiita 429/403-rate は 72h 級 cooldown 実績の hint 付き
- **複数 platform の action** (auto_publish / publish_post / backfill_from_apis): results/errors に同じ構造化 payload を埋め、**全 platform 失敗時のみ 502** (`error_code: all_platforms_failed` / `all_sources_failed`)
  - 部分成功は 200 のまま — 502 にすると GHA/cron が成功済み platform へ再投稿リトライを誘発するため
  - publish_post のトークン未設定黙殺も解消 (`QIITA_ACCESS_TOKEN not set` を results に記録)
  - backfill は source 失敗を `errors` に記録 (黙殺すると「0 件取得」と区別不能だった)
- 一時障害 (timeout / retry 尽き 5xx/429) は従来通り `ExternalFetchError` → top-level catch の 503 (変更なし)

## dev.to 側も同方針で統一

同じ 3 パターンが dev.to 側にも存在 (devto_delete が ②、devto_list / devto_sync_engagement が ①) のため同時に揃えた。

## クライアント/監視への影響

- Flutter `BlogService._invokeBlogAction` は非 200 で `BlogServiceException(error)` を throw する設計 → 502 化と整合 (旧②③は失敗が UI に届かなかった)
- `blog-backfill-from-apis.yml` は HTTP≠200 で fail する → 全 source 失敗が workflow 失敗として可視化される (従来は silent 200)
- `blog-publish.yml` は HTTP code をログするのみ + `.results.*.url // ""` 抽出 → 互換

## 実装

- 純ロジックを [`upstream_error.ts`](supabase/functions/schedule-hub/upstream_error.ts) (依存ゼロ) へ抽出し、[`upstream_error_test.ts`](supabase/functions/schedule-hub/upstream_error_test.ts) で 17 テスト
- 検証: `deno test` 20 緑 (新規17 + 既存 blog_canonical 3) / `deno check index.ts` / `deno lint` 通過

## スコープ外 (別途)

- `blog.publish` (旧 action) は `{ok, status}` を返しており黙殺ではないため未変更
- `blog.qiita_get_item` が client から呼ばれるのに EF 未実装 (常に 400) の既存バグを発見 → 別タスク化済み
- sync_engagement の記事ごと comments/likes 取得ループ内の個別失敗スキップは従来挙動を維持 (一覧取得の失敗のみ 502)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge function (schedule-hub) error-path unification; no browser-observable UI flow. Verified via deno test (17 new pure-logic tests green) + deno check + deno lint.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Error-response unification only: upstream Qiita/dev.to failure paths now return structured 502; no auth logic, no RLS, no new write paths. Pure logic extracted to upstream_error.ts with 17 deno tests; type-checked and linted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
