### PR TITLE
feat: add structured image prompt fields

### DIFF
--- a/lib/pages/ai_image_generator_page.dart
+++ b/lib/pages/ai_image_generator_page.dart
@@ -14,7 +14,10 @@ class AiImageGeneratorPage extends StatefulWidget {
 
 class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
   final _supabase = Supabase.instance.client;
-  final _promptController = TextEditingController();
+  final _sceneSubjectController = TextEditingController();
+  final _detailsStyleController = TextEditingController();
+  final _constraintsController = TextEditingController();
+  final _imageTextController = TextEditingController();
 
   bool _isFetching = false;
   bool _isGenerating = false;
@@ -45,7 +48,10 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
 
   @override
   void dispose() {
-    _promptController.dispose();
+    _sceneSubjectController.dispose();
+    _detailsStyleController.dispose();
+    _constraintsController.dispose();
+    _imageTextController.dispose();
     super.dispose();
   }
 
@@ -87,8 +93,14 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
   }
 
   Future<void> _generate() async {
-    final prompt = _promptController.text.trim();
-    if (prompt.isEmpty) return;
+    final structuredPrompt = AiImageStructuredPrompt(
+      sceneAndSubject: _sceneSubjectController.text,
+      detailsAndStyle: _detailsStyleController.text,
+      constraints: _constraintsController.text,
+      imageText: _imageTextController.text,
+    );
+    if (!structuredPrompt.hasInput) return;
+    final prompt = structuredPrompt.buildPrompt();
     setState(() {
       _isGenerating = true;
       _errorMessage = null;
@@ -108,7 +120,10 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
         setState(() => _errorMessage = data['error'].toString());
         return;
       }
-      _promptController.clear();
+      _sceneSubjectController.clear();
+      _detailsStyleController.clear();
+      _constraintsController.clear();
+      _imageTextController.clear();
       await _fetchImages();
     } catch (e) {
       if (mounted) {
@@ -117,6 +132,39 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
     } finally {
       if (mounted) setState(() => _isGenerating = false);
     }
+  }
+
+  Widget _buildPromptField({
+    required TextEditingController controller,
+    required String label,
+    required IconData icon,
+    int maxLines = 1,
+    bool highlight = false,
+  }) {
+    return TextField(
+      controller: controller,
+      maxLines: maxLines,
+      decoration: InputDecoration(
+        labelText: label,
+        border: const OutlineInputBorder(),
+        enabledBorder: highlight
+            ? const OutlineInputBorder(
+                borderSide: BorderSide(color: Color(0xFFE65100)),
+              )
+            : const OutlineInputBorder(),
+        focusedBorder: highlight
+            ? const OutlineInputBorder(
+                borderSide: BorderSide(color: Color(0xFFE65100), width: 2),
+              )
+            : null,
+        prefixIcon: Icon(icon),
+        suffixIcon: highlight
+            ? const Icon(Icons.priority_high, color: Color(0xFFE65100))
+            : null,
+        filled: highlight,
+        fillColor: highlight ? const Color(0xFFFFF8E1) : null,
+      ),
+    );
   }
 
   @override
@@ -137,18 +185,30 @@ class _AiImageGeneratorPageState extends State<AiImageGeneratorPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            TextField(
-              controller: _promptController,
-              maxLines: 2,
-              decoration: const InputDecoration(
-                labelText: '画像プロンプト',
-                hintText: '例: 青い空と富士山の風景、水彩画風',
-                border: OutlineInputBorder(),
-                prefixIcon: Icon(Icons.image_search),
-              ),
-              onSubmitted: (_) {
-                if (!_isBusy) _generate();
-              },
+            _buildPromptField(
+              controller: _sceneSubjectController,
+              label: 'シーンと対象',
+              icon: Icons.image_search,
+            ),
+            const SizedBox(height: 8),
+            _buildPromptField(
+              controller: _detailsStyleController,
+              label: 'スタイル',
+              icon: Icons.palette_outlined,
+            ),
+            const SizedBox(height: 8),
+            _buildPromptField(
+              controller: _constraintsController,
+              label: '制約（維持・除外するもの）',
+              icon: Icons.rule,
+              highlight: true,
+            ),
+            const SizedBox(height: 8),
+            _buildPromptField(
+              controller: _imageTextController,
+              label: '画像内テキスト',
+              icon: Icons.text_fields,
+              maxLines: 1,
             ),
             const SizedBox(height: 12),
             Wrap(

--- a/lib/services/ai_image_generation_request.dart
+++ b/lib/services/ai_image_generation_request.dart
@@ -21,6 +21,51 @@ enum AiImageGenerationQuality {
   }
 }
 
+class AiImageStructuredPrompt {
+  const AiImageStructuredPrompt({
+    required this.sceneAndSubject,
+    required this.detailsAndStyle,
+    required this.constraints,
+    required this.imageText,
+  });
+
+  final String sceneAndSubject;
+  final String detailsAndStyle;
+  final String constraints;
+  final String imageText;
+
+  bool get hasInput =>
+      sceneAndSubject.trim().isNotEmpty ||
+      detailsAndStyle.trim().isNotEmpty ||
+      constraints.trim().isNotEmpty ||
+      imageText.trim().isNotEmpty;
+
+  String buildPrompt() {
+    final parts = <String>[];
+    final scene = sceneAndSubject.trim();
+    final details = detailsAndStyle.trim();
+    final constraintText = constraints.trim();
+    final typographyText = imageText.trim();
+
+    if (scene.isNotEmpty) {
+      parts.add('Scene and subject:\n$scene');
+    }
+    if (details.isNotEmpty) {
+      parts.add('Details and style:\n$details');
+    }
+    if (constraintText.isNotEmpty) {
+      parts.add('Constraints to preserve or avoid:\n$constraintText');
+    }
+    if (typographyText.isNotEmpty) {
+      parts.add(
+        'Image text:\n"${typographyText.toUpperCase()}" in clean, readable typography.',
+      );
+    }
+
+    return parts.join('\n\n');
+  }
+}
+
 Map<String, Object> buildAiImageGenerateBody({
   required String prompt,
   required String size,

--- a/test/pages/ai_image_generator_page_test.dart
+++ b/test/pages/ai_image_generator_page_test.dart
@@ -18,9 +18,7 @@ void main() {
   testWidgets('renders image quality choices with usage tooltips', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: AiImageGeneratorPage()),
-    );
+    await tester.pumpWidget(const MaterialApp(home: AiImageGeneratorPage()));
     await tester.pump();
 
     expect(find.text('高速'), findsOneWidget);
@@ -28,9 +26,17 @@ void main() {
     expect(find.text('高画質'), findsOneWidget);
     expect(find.byTooltip('アイデア出しや大量生成向け。待ち時間を短くします。'), findsOneWidget);
     expect(find.byTooltip('速度と品質のバランスを取った通常設定です。'), findsOneWidget);
-    expect(
-      find.byTooltip('細部の忠実度を優先します。図解や仕上げ用途向けです。'),
-      findsOneWidget,
-    );
+    expect(find.byTooltip('細部の忠実度を優先します。図解や仕上げ用途向けです。'), findsOneWidget);
+  });
+
+  testWidgets('renders structured prompt input fields', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: AiImageGeneratorPage()));
+    await tester.pump();
+
+    expect(find.byType(TextField), findsNWidgets(4));
+    expect(find.text('シーンと対象'), findsOneWidget);
+    expect(find.text('スタイル'), findsOneWidget);
+    expect(find.text('制約（維持・除外するもの）'), findsOneWidget);
+    expect(find.text('画像内テキスト'), findsOneWidget);
   });
 }

--- a/test/services/ai_image_generation_request_test.dart
+++ b/test/services/ai_image_generation_request_test.dart
@@ -23,4 +23,25 @@ void main() {
       AiImageGenerationQuality.medium,
     );
   });
+
+  test('builds a structured prompt in a stable labeled order', () {
+    final prompt = const AiImageStructuredPrompt(
+      sceneAndSubject: 'a small robot arranging notebooks',
+      detailsAndStyle: 'flat editorial illustration, teal and coral',
+      constraints: 'preserve the desk layout, avoid extra fingers',
+      imageText: 'daily reset',
+    ).buildPrompt();
+
+    expect(
+      prompt,
+      'Scene and subject:\n'
+      'a small robot arranging notebooks\n\n'
+      'Details and style:\n'
+      'flat editorial illustration, teal and coral\n\n'
+      'Constraints to preserve or avoid:\n'
+      'preserve the desk layout, avoid extra fingers\n\n'
+      'Image text:\n'
+      '"DAILY RESET" in clean, readable typography.',
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- Split the AI image prompt form into scene/subject, style, constraints, and image-text fields.
- Build a stable labeled prompt from those fields before calling `image.generate`.
- Automatically upper-case and quote image text with a readable typography instruction.
- Highlight the constraints field so preserve/exclude requirements stand out.

Closes #1220

## Validation

- `flutter test --no-pub test\services\ai_image_generation_request_test.dart test\pages\ai_image_generator_page_test.dart`
- `flutter analyze lib\services\ai_image_generation_request.dart lib\pages\ai_image_generator_page.dart test\services\ai_image_generation_request_test.dart test\pages\ai_image_generator_page_test.dart`

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Structured prompt fields and request-body behavior are covered by widget and service tests; no new route-level E2E is needed for this narrow form wiring.