### PR TITLE
fix(blog): BlogService の未配線 dead wrapper 9 メソッドを削除 (#3958 続き)

### DIFF
--- a/lib/services/blog_service.dart
+++ b/lib/services/blog_service.dart
@@ -1,5 +1,8 @@
 // lib/services/blog_service.dart
 // schedule-hub の blog.* actions への薄い Flutter wrapper
+// 利用元は blog_draft_editor_page / news_rss_aggregator_page のみ。
+// 管理ページ (blog_management_page) は schedule-hub を直接 invoke する
+// 独自実装を持つため、ここに wrapper を足しても配線されない (PR #3958 参照)。
 
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -69,44 +72,10 @@ class BlogService {
     await _invokeBlogAction('blog.update_post', params);
   }
 
-  Future<void> deletePost(String id) async {
-    await _invokeBlogAction('blog.delete_post', {'id': id});
-  }
-
   // ── 公開 ────────────────────────────────────────────────────────
 
   Future<Map<String, dynamic>> publishPost(String id) async {
     return _invokeBlogAction('blog.publish_post', {'id': id});
-  }
-
-  // ── Engagement 同期 ──────────────────────────────────────────────
-
-  Future<Map<String, dynamic>> syncEngagement() async {
-    return _invokeBlogAction('blog.sync_engagement', {});
-  }
-
-  // ── Qiita コメント返信 (item_id = Qiita 記事 ID) ──────────────
-  Future<void> qiitaCommentPost({
-    required String articleId,
-    required String body,
-  }) async {
-    await _invokeBlogAction('blog.qiita_comment_post', {
-      'item_id': articleId,
-      'body': body,
-    });
-  }
-
-  // ── 訂正承認 ────────────────────────────────────────────────────
-  Future<void> qiitaUpdate({
-    required String articleId,
-    required String title,
-    required String body,
-  }) async {
-    await _invokeBlogAction('blog.qiita_update', {
-      'item_id': articleId,
-      'title': title,
-      'body': body,
-    });
   }
 
   // ── blog_posts 単件取得 (エディタ用) ─────────────────────────────
@@ -120,63 +89,5 @@ class BlogService {
         .eq('id', id)
         .maybeSingle();
     return res;
-  }
-
-  // ── blog_posts slug 単件取得 (公開記事閲覧用) ─────────────────────
-
-  Future<Map<String, dynamic>?> fetchPostBySlug(String slug) async {
-    final res = await _client
-        .from('blog_posts')
-        .select(
-          'id, slug, title, content, excerpt, tags, posted_at, published_at, target_platforms, url, cover_image_url',
-        )
-        .eq('slug', slug)
-        .eq('status', 'posted')
-        .maybeSingle();
-    return res;
-  }
-
-  // ── 訂正 pending 一覧 ────────────────────────────────────────────
-
-  Future<List<Map<String, dynamic>>> fetchPendingCorrections() async {
-    final res = await _client
-        .from('blog_corrections')
-        .select(
-          'id, platform, article_id, title, url, confidence, errors_json, detected_at',
-        )
-        .eq('approved', false)
-        .isFilter('applied_at', null)
-        .order('detected_at', ascending: false)
-        .limit(50);
-    return List<Map<String, dynamic>>.from(res as List);
-  }
-
-  Future<void> approveCorrection({
-    required String correctionId,
-    required String articleId,
-    required String title,
-    required String body,
-  }) async {
-    await qiitaUpdate(articleId: articleId, title: title, body: body);
-    await _client.from('blog_corrections').update({
-      'approved': true,
-      'approved_at': DateTime.now().toIso8601String(),
-      'applied_at': DateTime.now().toIso8601String(),
-    }).eq('id', correctionId);
-  }
-
-  Future<void> rejectCorrection(String correctionId) async {
-    await _client
-        .from('blog_corrections')
-        .update({'approved': false}).eq('id', correctionId);
-  }
-
-  // ── Draft health check ───────────────────────────────────────────
-
-  Future<List<Map<String, dynamic>>> fetchStaleDrafts() async {
-    return _invokeBlogAction(
-      'blog.draft_health_check',
-      {},
-    ).then((r) => List<Map<String, dynamic>>.from(r['stale'] as List? ?? []));
   }
 }


### PR DESCRIPTION
## Summary

[PR #3958](https://github.com/kanta13jp1/my_web_app/pull/3958) (qiitaGetItem 削除) の続き。`lib/services/blog_service.dart` の残り未配線 wrapper 9 メソッドを棚卸しし、全て **dead code (削除)** と判定した。

## 判定内訳 (2026-07-12 git grep で呼び出し元ゼロを確認)

| メソッド | 判定根拠 |
|---|---|
| `deletePost` | blog_management_page L541 が `blog.delete_post` を直接 invoke する稼働実装を保有 |
| `syncEngagement` | 同ページ L142 が `blog.sync_engagement` を直接 invoke |
| `qiitaCommentPost` | 同ページ L783 が `blog.qiita_comment_post` を直接 invoke |
| `qiitaUpdate` | 同ページ L2153 が直接 invoke (稼働版は `body` を送らない = wrapper とシグネチャ乖離) |
| `fetchPendingCorrections` | 同ページ L100 が `blog_corrections` を直接 select |
| `approveCorrection` | 同ページ `_approveCorrection` が稼働実装。wrapper 版は稼働版が送らない `body` を必須要求する乖離あり |
| `rejectCorrection` | 同ページ `_rejectCorrection` が稼働実装 (`applied_at` セット)。wrapper 版は `approved: false` のみで **却下後も pending 一覧に残る潜在バグ** |
| `fetchPostBySlug` | 公開記事閲覧 (`/blog/post`) は `BlogPublishService.getPostById` (id ベース) に収斂済みで slug 設計は不採用系譜 |
| `fetchStaleDrafts` | `blog.draft_health_check` の呼び出し元が lib 全体でゼロ |

## 「配線統一」を採らなかった理由

- 稼働側 (blog_management_page) と wrapper 側で挙動が既にドリフト (`body` 有無 / `applied_at` 有無) しており、統一は未使用コードを正とする書き換えを強制する
- 同ページは 2200 行超 + 重い web 依存で VM テスト不可 (part321 教訓) のため、動作中コードへの churn はリスクだけ増える
- edge 側 action (schedule-hub) は実在するため「壊れている」のではなく「未配線」— 必要になれば git 履歴から復元可能

## 変更

- `lib/services/blog_service.dart` のみ (Dart-only / **3 insertions, 92 deletions**)
- 残置: `insertPost` / `updatePost` / `publishPost` / `fetchPost` (blog_draft_editor_page / news_rss_aggregator_page が使用中)
- ヘッダーコメントに利用元と管理ページが直接 invoke である旨を明記 (wrapper 再増殖防止)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Dead-code removal only: deletes nine BlogService methods with zero call sites (verified via git grep); no runtime behavior change, covered by flutter analyze in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
