### PR TITLE
feat(x-share): R24 weekly build-in-public data report (winning post-A archetype, deterministic)

### DIFF
--- a/.github/workflows/x-growth-data-report-post.yml
+++ b/.github/workflows/x-growth-data-report-post.yml
@@ -7,8 +7,10 @@ name: X Growth Data Report Post
 
 on:
   schedule:
-    # Every Saturday 22:00 UTC (= Sunday 07:00 JST)
-    - cron: "0 22 * * 6"
+    # Every Saturday 21:00 UTC (= Sunday 06:00 JST)。daily briefing の
+    # `0 22 * * *` と同時刻に重ねない(同一アカウント2スレッド同時投下は
+    # ゴールデンアワーの自己共食い+burst 信号 / レビュー指摘)。
+    - cron: "0 21 * * 6"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -158,7 +160,22 @@ jobs:
             exit 1
           fi
           success=$(jq -r '.success' /tmp/x_report_result.json)
+          posted=$(jq -r '.posted // false' /tmp/x_report_result.json)
+          code=$(jq -r '.code // empty' /tmp/x_report_result.json)
+          # 統計が横ばいの週は近似重複ガードが前週レポートと判定して拒否する。
+          # 同内容の再投稿はスパム=投稿しないのが正しい挙動なので、失敗では
+          # なく「変化なし週スキップ」として正常終了する(レビュー指摘の設計化)。
+          if [ "${code}" = "duplicate_content" ]; then
+            echo "::warning::Weekly report skipped: near-duplicate of a recent post (stats unchanged week-over-week)."
+            exit 0
+          fi
           if [ "${success}" != "true" ]; then
-            echo "::error::x.post reported failure (duplicate guard or billing preflight?)"
+            echo "::error::x.post reported failure (billing preflight?)"
+            exit 1
+          fi
+          # posted 検証: credentials_missing 等は success:true + posted:false で
+          # 返る。scheduled 実行の無言グリーン化を防ぐ(daily briefing と同じ守り)。
+          if [ "${DRY_RUN}" != "true" ] && [ "${posted}" != "true" ]; then
+            echo "::error::Scheduled weekly report did not post (X credentials missing or rotated?)"
             exit 1
           fi

--- a/.github/workflows/x-growth-data-report-post.yml
+++ b/.github/workflows/x-growth-data-report-post.yml
@@ -1,0 +1,164 @@
+name: X Growth Data Report Post
+
+# R24: ポストA型「独自データ資産」の週次 build-in-public 実測レポート。
+# 2026-07-12 実測(データレポート型 3.2K vs ニュース要約 517 vs 製品転換 28)を
+# 受け、勝ちアーキタイプの投稿を毎週自動生成する。数値は growth-hub が
+# x_post_log の実測から合成する(LLM 非使用=捏造が構造的に不可能)。
+
+on:
+  schedule:
+    # Every Saturday 22:00 UTC (= Sunday 07:00 JST)
+    - cron: "0 22 * * 6"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run without posting"
+        type: boolean
+        default: true
+      force:
+        description: "Post even if this week's report already exists"
+        type: boolean
+        default: false
+
+concurrency:
+  group: x-growth-data-report-post
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SUPABASE_URL: https://smmkxxavexumewbfaqpy.supabase.co
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SOURCE: x-growth-data-report-post.yml
+      EXPERIMENT_KEY: x_first_user_growth_10k
+      VARIANT: weekly_data_report
+      TARGET_URL: https://my-web-app-b67f4.web.app/?utm_source=x&utm_medium=data_report&utm_campaign=first_user_growth&utm_content=weekly_data_report
+    steps:
+      - name: Validate secrets
+        shell: bash
+        run: |
+          test -n "${SUPABASE_SERVICE_ROLE_KEY}" || {
+            echo "SUPABASE_SERVICE_ROLE_KEY is required."
+            exit 1
+          }
+
+      - name: Resolve run mode
+        id: mode
+        shell: bash
+        run: |
+          dry_run="${{ github.event.inputs.dry_run }}"
+          force="${{ github.event.inputs.force }}"
+          if [ -z "${dry_run}" ]; then
+            dry_run="false"
+          fi
+          if [ -z "${force}" ]; then
+            force="false"
+          fi
+          echo "dry_run=${dry_run}" >> "${GITHUB_OUTPUT}"
+          echo "force=${force}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check existing report for this week
+        id: duplicate
+        shell: bash
+        run: |
+          week_start=$(node -e 'console.log(new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString())')
+          http_code=$(curl --get --silent --show-error --output /tmp/x_report_existing.json --write-out "%{http_code}" \
+            "${SUPABASE_URL}/rest/v1/hub_data" \
+            --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --data-urlencode "source=eq.x_post_log" \
+            --data-urlencode "created_at=gte.${week_start}" \
+            --data-urlencode "metadata->>source=eq.${SOURCE}" \
+            --data-urlencode "metadata->>status=eq.posted" \
+            --data-urlencode "select=id" \
+            --data-urlencode "limit=1")
+          if [ "${http_code}" != "200" ]; then
+            echo "::warning::Duplicate guard returned HTTP ${http_code}; continuing so growth-hub duplicate guard can decide."
+            echo "already_posted=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          count=$(jq 'length' /tmp/x_report_existing.json)
+          if [ "${count}" -gt 0 ]; then
+            echo "already_posted=true" >> "${GITHUB_OUTPUT}"
+            echo "Weekly growth data report already posted within 6 days."
+          else
+            echo "already_posted=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Compose data report from measured logs
+        id: compose
+        if: steps.duplicate.outputs.already_posted != 'true' || steps.mode.outputs.force == 'true' || steps.mode.outputs.dry_run == 'true'
+        shell: bash
+        run: |
+          http_code=$(curl --silent --show-error --output /tmp/x_growth_report.json --write-out "%{http_code}" \
+            --request POST \
+            "${SUPABASE_URL}/functions/v1/growth-hub" \
+            --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Content-Type: application/json" \
+            --data "{\"action\":\"x.growth_data_report\",\"limit\":100,\"targetUrl\":\"${TARGET_URL}\"}")
+          if [ "${http_code}" != "200" ]; then
+            echo "::error::x.growth_data_report returned HTTP ${http_code}"
+            cat /tmp/x_growth_report.json || true
+            exit 1
+          fi
+          available=$(jq -r '.available' /tmp/x_growth_report.json)
+          echo "available=${available}" >> "${GITHUB_OUTPUT}"
+          if [ "${available}" != "true" ]; then
+            echo "Not enough measured rows for an honest report — skipping this week."
+            jq . /tmp/x_growth_report.json
+          fi
+
+      - name: Post data report to X
+        if: steps.compose.outputs.available == 'true' && (steps.duplicate.outputs.already_posted != 'true' || steps.mode.outputs.force == 'true' || steps.mode.outputs.dry_run == 'true')
+        shell: bash
+        env:
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const report = JSON.parse(fs.readFileSync('/tmp/x_growth_report.json', 'utf8'));
+          const payload = {
+            action: 'x.post',
+            text: report.text,
+            replyTexts: report.replyTexts,
+            source: process.env.SOURCE,
+            route: 'growth/weekly-data-report',
+            experimentKey: process.env.EXPERIMENT_KEY,
+            variant: process.env.VARIANT,
+            utmContent: process.env.VARIANT,
+            promptProfile: 'workflow_weekly_data_report_v1_deterministic',
+            contentKind: 'data_report_thread',
+            contentArchetype: 'data_report',
+            linkInReply: true,
+            dryRun: process.env.DRY_RUN === 'true',
+          };
+          fs.writeFileSync('/tmp/x_report_payload.json', JSON.stringify(payload));
+          console.log(JSON.stringify({
+            lead: payload.text.split('\n')[0],
+            replyCount: payload.replyTexts.length,
+            dryRun: payload.dryRun,
+          }, null, 2));
+          NODE
+          http_code=$(curl --silent --show-error --output /tmp/x_report_result.json --write-out "%{http_code}" \
+            --request POST \
+            "${SUPABASE_URL}/functions/v1/growth-hub" \
+            --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Content-Type: application/json" \
+            --data @/tmp/x_report_payload.json)
+          jq . /tmp/x_report_result.json || cat /tmp/x_report_result.json
+          if [ "${http_code}" != "200" ]; then
+            echo "::error::x.post returned HTTP ${http_code}"
+            exit 1
+          fi
+          success=$(jq -r '.success' /tmp/x_report_result.json)
+          if [ "${success}" != "true" ]; then
+            echo "::error::x.post reported failure (duplicate guard or billing preflight?)"
+            exit 1
+          fi

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -43,6 +43,10 @@ import {
   normalizeArchetypeBucket,
   resolveLoggedArchetype,
 } from "./x_post_archetype.ts";
+import {
+  buildGrowthDataReport,
+  type GrowthReportRow,
+} from "./x_growth_data_report.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -1819,6 +1823,35 @@ serve(async (req: Request) => {
 
       case "x.performance_context": {
         return json(await buildXPerformanceContext(admin, userId!, body.limit));
+      }
+
+      case "x.growth_data_report": {
+        // R24: ポストA型の週次 build-in-public 実測レポートを合成する
+        // (read-only / LLM 非使用 / 数値は全て x_post_log 実測)。実測 3 件
+        // 未満は available:false で投稿見送りを指示する。
+        const perf = await buildXPerformanceContext(
+          admin,
+          userId!,
+          body.limit ?? 100,
+        );
+        const targetUrl = firstString(
+          body.targetUrl,
+          body.target_url,
+          "https://my-web-app-b67f4.web.app/?utm_source=x&utm_medium=data_report&utm_campaign=first_user_growth&utm_content=weekly_data_report",
+        );
+        const report = buildGrowthDataReport(
+          perf.rows as GrowthReportRow[],
+          new Date(),
+          targetUrl,
+        );
+        if (report === null) {
+          return json({
+            success: true,
+            available: false,
+            reason: "measured impressions rows < 3",
+          });
+        }
+        return json({ success: true, available: true, ...report });
       }
 
       case "x.post_preflight": {

--- a/supabase/functions/growth-hub/x_growth_data_report.ts
+++ b/supabase/functions/growth-hub/x_growth_data_report.ts
@@ -1,0 +1,167 @@
+// R24: ポストA型「独自データ資産」の家計/build-in-public 版。2026-07-12 実測で
+// データレポート型(独自集計の実数を密に並べる)が 3.2K imp とニュース要約(517)
+// ・製品転換(28)を 6-114 倍上回った。このモジュールは x_post_log の実測値
+// **のみ**から、ポストAと同じ構造(取得日時→主要実数→基準との差分→内訳→
+// 増加履歴→アラート)の X 投稿パッケージを決定的に組み立てる。LLM を使わない
+// (=ポストA自体がテンプレ生成だったことを踏襲。数値の捏造が構造的に不可能)。
+//
+// 数値の出所は全て perf rows(x_post_log 由来の実測)。実測 3 件未満の週は
+// null を返して投稿自体を見送る(薄いデータで「実測レポート」を名乗らない)。
+
+import { computeOwnDataFacts } from "./x_post_archetype.ts";
+
+/// buildXPerformanceContextFromLogs が返す rows の、このレポートが使う部分形。
+export type GrowthReportRow = {
+  archetype: string;
+  variant: string;
+  impressions: number | null;
+  score: number;
+  bookmarkCount: number;
+  text: string;
+  createdAt: string;
+};
+
+export type GrowthDataReport = {
+  text: string;
+  replyTexts: string[];
+  measuredCount: number;
+  medianImpressions: number;
+  bestImpressions: number;
+};
+
+const IMPRESSION_TARGET = 10000;
+
+function jstDateLabel(now: Date): string {
+  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  return `${jst.getUTCFullYear()}/${jst.getUTCMonth() + 1}/${jst.getUTCDate()}`;
+}
+
+function compactHook(text: string, max = 48): string {
+  const clean = (text ?? "").replace(/\s+/g, " ").trim();
+  return clean.length <= max ? clean : `${clean.slice(0, max - 1)}…`;
+}
+
+/// x_post_log の実測 rows からポストA型の週次実測レポートを組み立てる。
+/// 実測(impressions 非 null)3 件未満は null(投稿見送り)。
+export function buildGrowthDataReport(
+  rows: readonly GrowthReportRow[],
+  now: Date,
+  targetUrl: string,
+): GrowthDataReport | null {
+  const facts = computeOwnDataFacts(rows, (row) => row.impressions);
+  if (facts === null) return null;
+
+  const weekAgoMs = now.getTime() - 7 * 24 * 60 * 60 * 1000;
+  const recent7 = rows.filter((row) => {
+    const created = Date.parse(row.createdAt);
+    return Number.isFinite(created) && created >= weekAgoMs;
+  }).length;
+
+  // リード: ポストAと同じ「取得日時→主要実数→基準との差分→残り」の骨格。
+  // 「基準10,000との差分」の語形は classifyPostArchetype の強シグナルと一致
+  // させ、このレポート自身が data_report に分類されることを保証する。
+  const gap = IMPRESSION_TARGET - facts.best;
+  const lead = [
+    `自分株式会社 X運用実測レポート ${jstDateLabel(now)}`,
+    "",
+    `取得日時: ${now.toISOString()}`,
+    `計測済み投稿数: ${facts.count}件`,
+    `中央値インプレッション: ${facts.median}`,
+    `最高インプレッション: ${facts.best}`,
+    `基準10,000との差分: ${gap > 0 ? `-${gap}` : `+${-gap}`}`,
+    `10,000まで残り: ${Math.max(0, gap)}`,
+    `直近7日の計測対象: ${recent7}件`,
+    "",
+    "数字は全て自分のX投稿ログの実測値。集計はアプリが自動生成しています。",
+  ].join("\n");
+
+  const replies: string[] = [];
+
+  // 型別実測(アーキタイプ内訳)。集計行ビルダーを再利用しつつ、表向きは
+  // 日本語の内訳リストで出す。
+  const buckets = new Map<string, { total: number; n: number }>();
+  for (const row of rows) {
+    const key = row.archetype || "unknown";
+    const current = buckets.get(key) ?? { total: 0, n: 0 };
+    current.total += row.score;
+    current.n += 1;
+    buckets.set(key, current);
+  }
+  const bucketLabel: Record<string, string> = {
+    data_report: "データレポート型",
+    news_briefing: "ニュース要約型",
+    product_promo: "製品紹介型",
+    general: "その他",
+    unknown: "分類前(旧ログ)",
+  };
+  const bucketLines = [...buckets.entries()]
+    .sort((a, b) => b[1].total / b[1].n - a[1].total / a[1].n)
+    .map(([key, { total, n }]) => {
+      const label = bucketLabel[key] ?? key;
+      const avg = Math.round(total / Math.max(1, n));
+      return n >= 2
+        ? `${label} 平均スコア${avg} (${n}件)`
+        : `${label} 実測不足 (${n}件)`;
+    });
+  if (bucketLines.length > 0) {
+    replies.push(["投稿の型別実測", "", ...bucketLines].join("\n"));
+  }
+
+  // 実測上位(増加履歴に相当)。impressions のある行だけを上位3件。
+  const top = rows
+    .filter((row) => typeof row.impressions === "number")
+    .sort((a, b) => (b.impressions ?? 0) - (a.impressions ?? 0))
+    .slice(0, 3);
+  if (top.length > 0) {
+    replies.push(
+      [
+        "インプレッション上位",
+        "",
+        ...top.map((row) =>
+          `${row.impressions} — 「${compactHook(row.text)}」`
+        ),
+      ].join("\n"),
+    );
+  }
+
+  // アラート(実測から機械的に導出できるものだけ)。
+  const alerts: string[] = [];
+  if (recent7 === 0) {
+    alerts.push("🔴 直近7日の計測対象が0件(投稿または計測が止まっています)");
+  }
+  const thinBuckets = [...buckets.entries()]
+    .filter(([key, { n }]) => key !== "unknown" && n < 2)
+    .map(([key]) => bucketLabel[key] ?? key);
+  if (thinBuckets.length > 0) {
+    alerts.push(`🟡 実測不足の型: ${thinBuckets.join("、")}`);
+  }
+  const fallbackCount = rows.filter((row) =>
+    row.variant.endsWith("_fallback")
+  ).length;
+  if (rows.length > 0 && fallbackCount * 2 >= rows.length) {
+    alerts.push(
+      `🟡 定型文フォールバック比率が高い: ${fallbackCount}/${rows.length}件`,
+    );
+  }
+  replies.push(
+    ["アラート", "", ...(alerts.length > 0 ? alerts : ["今週のアラートなし"])]
+      .join("\n"),
+  );
+
+  // 最終リプライ: URL は実測の勝ち構造(link-in-reply)に従い末尾のみ。
+  replies.push(
+    [
+      "この実測レポートは毎週、アプリのX投稿ログから自動集計しています。",
+      "同じ「実測を並べる」仕組みを家計側では給料日サイクルと負債トレンドが担います。",
+      targetUrl,
+    ].join("\n"),
+  );
+
+  return {
+    text: lead,
+    replyTexts: replies,
+    measuredCount: facts.count,
+    medianImpressions: facts.median,
+    bestImpressions: facts.best,
+  };
+}

--- a/supabase/functions/growth-hub/x_growth_data_report.ts
+++ b/supabase/functions/growth-hub/x_growth_data_report.ts
@@ -57,9 +57,20 @@ export function buildGrowthDataReport(
     return Number.isFinite(created) && created >= weekAgoMs;
   }).length;
 
+  // 実測上位(リードの可変トークン+リプの内訳で使う)。
+  const top = rows
+    .filter((row) => typeof row.impressions === "number")
+    .sort((a, b) => (b.impressions ?? 0) - (a.impressions ?? 0))
+    .slice(0, 3);
+
   // リード: ポストAと同じ「取得日時→主要実数→基準との差分→残り」の骨格。
   // 「基準10,000との差分」の語形は classifyPostArchetype の強シグナルと一致
   // させ、このレポート自身が data_report に分類されることを保証する。
+  // 「今週の実測トップ」行はリード唯一の自由テキスト=週替わりの可変トークン。
+  // 固定テンプレ+数字だけだと前週リードとの正規化類似度が近似重複ガードの
+  // 閾値(0.9)を超え得る(レビュー実測 0.93-0.95)。それでも統計が完全に
+  // 横ばいの週はガードに拒否させ、workflow 側で「変化なし週はスキップ」として
+  // 正常終了する(重複投稿しないのが正しい挙動)。
   const gap = IMPRESSION_TARGET - facts.best;
   const lead = [
     `自分株式会社 X運用実測レポート ${jstDateLabel(now)}`,
@@ -71,6 +82,13 @@ export function buildGrowthDataReport(
     `基準10,000との差分: ${gap > 0 ? `-${gap}` : `+${-gap}`}`,
     `10,000まで残り: ${Math.max(0, gap)}`,
     `直近7日の計測対象: ${recent7}件`,
+    ...(top.length > 0
+      ? [
+        `今週の実測トップ: ${top[0].impressions} — 「${
+          compactHook(top[0].text)
+        }」`,
+      ]
+      : []),
     "",
     "数字は全て自分のX投稿ログの実測値。集計はアプリが自動生成しています。",
   ].join("\n");
@@ -108,10 +126,6 @@ export function buildGrowthDataReport(
   }
 
   // 実測上位(増加履歴に相当)。impressions のある行だけを上位3件。
-  const top = rows
-    .filter((row) => typeof row.impressions === "number")
-    .sort((a, b) => (b.impressions ?? 0) - (a.impressions ?? 0))
-    .slice(0, 3);
   if (top.length > 0) {
     replies.push(
       [
@@ -135,9 +149,8 @@ export function buildGrowthDataReport(
   if (thinBuckets.length > 0) {
     alerts.push(`🟡 実測不足の型: ${thinBuckets.join("、")}`);
   }
-  const fallbackCount = rows.filter((row) =>
-    row.variant.endsWith("_fallback")
-  ).length;
+  const fallbackCount =
+    rows.filter((row) => row.variant.endsWith("_fallback")).length;
   if (rows.length > 0 && fallbackCount * 2 >= rows.length) {
     alerts.push(
       `🟡 定型文フォールバック比率が高い: ${fallbackCount}/${rows.length}件`,

--- a/supabase/functions/growth-hub/x_growth_data_report_test.ts
+++ b/supabase/functions/growth-hub/x_growth_data_report_test.ts
@@ -1,0 +1,138 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildGrowthDataReport,
+  type GrowthReportRow,
+} from "./x_growth_data_report.ts";
+import { classifyPostArchetype } from "./x_post_archetype.ts";
+
+const NOW = new Date("2026-07-12T03:00:00Z");
+const URL = "https://my-web-app-b67f4.web.app/?utm_content=weekly_data_report";
+
+function row(partial: Partial<GrowthReportRow>): GrowthReportRow {
+  return {
+    archetype: "news_briefing",
+    variant: "daily_briefing",
+    impressions: null,
+    score: 0,
+    bookmarkCount: 0,
+    text: "hook",
+    createdAt: "2026-07-10T00:00:00Z",
+    ...partial,
+  };
+}
+
+const MEASURED_ROWS: GrowthReportRow[] = [
+  row({
+    archetype: "data_report",
+    variant: "local_election_tally",
+    impressions: 3200,
+    score: 3200,
+    text: "国民民主党 地方議員集計 2026/07/10",
+    createdAt: "2026-07-10T12:24:00Z",
+  }),
+  row({
+    impressions: 517,
+    score: 517,
+    text: "デイリーブリーフィング — 2026年7月12日朝",
+    createdAt: "2026-07-11T22:00:00Z",
+  }),
+  row({
+    impressions: 28,
+    score: 28,
+    text: "今日の見出しは「Apple、OpenAIと元従業員2人を提訴」",
+    createdAt: "2026-07-12T01:00:00Z",
+  }),
+];
+
+Deno.test("buildGrowthDataReport refuses to compose from <3 measured rows", () => {
+  assertEquals(buildGrowthDataReport([], NOW, URL), null);
+  assertEquals(
+    buildGrowthDataReport(MEASURED_ROWS.slice(0, 2), NOW, URL),
+    null,
+  );
+  // impressions null の行は実測に数えない。
+  assertEquals(
+    buildGrowthDataReport(
+      [...MEASURED_ROWS.slice(0, 2), row({ impressions: null })],
+      NOW,
+      URL,
+    ),
+    null,
+  );
+});
+
+Deno.test("buildGrowthDataReport composes a post-A style lead from real numbers", () => {
+  const report = buildGrowthDataReport(MEASURED_ROWS, NOW, URL);
+  assert(report !== null);
+  // 主要実数は全て入力行から導出された実測値。
+  assert(report!.text.includes("取得日時: 2026-07-12T03:00:00.000Z"));
+  assert(report!.text.includes("計測済み投稿数: 3件"));
+  assert(report!.text.includes("中央値インプレッション: 517"));
+  assert(report!.text.includes("最高インプレッション: 3200"));
+  assert(report!.text.includes("基準10,000との差分: -6800"));
+  assert(report!.text.includes("10,000まで残り: 6800"));
+  assert(report!.text.includes("直近7日の計測対象: 3件"));
+  // JST 日付ラベル(UTC 03:00 = JST 12:00 同日)。
+  assert(report!.text.includes("X運用実測レポート 2026/7/12"));
+  assertEquals(report!.measuredCount, 3);
+  assertEquals(report!.medianImpressions, 517);
+  assertEquals(report!.bestImpressions, 3200);
+});
+
+Deno.test("buildGrowthDataReport output self-classifies as data_report", () => {
+  // R23 の教訓の自己整合: このレポート自身が data_report バケットに入り、
+  // Archetype lift の実測を自力で蓄積できる形であることを固定する。
+  const report = buildGrowthDataReport(MEASURED_ROWS, NOW, URL);
+  assert(report !== null);
+  const full = [report!.text, ...report!.replyTexts].join("\n");
+  assertEquals(classifyPostArchetype(full), "data_report");
+});
+
+Deno.test("buildGrowthDataReport replies carry breakdown, top posts, alerts, and final URL", () => {
+  const report = buildGrowthDataReport(MEASURED_ROWS, NOW, URL);
+  assert(report !== null);
+  const [buckets, top, alerts, cta] = report!.replyTexts;
+  // 型別実測: n>=2 は平均、n=1 は実測不足表記。
+  assert(buckets.includes("投稿の型別実測"));
+  assert(buckets.includes("データレポート型 実測不足 (1件)"));
+  assert(buckets.includes("ニュース要約型 平均スコア273 (2件)"));
+  // 実測上位は impressions 降順。
+  assert(top.includes("インプレッション上位"));
+  assert(top.indexOf("3200") < top.indexOf("517"));
+  // アラート: 実測不足の型が列挙される(直近7日は投稿ありなので🔴なし)。
+  assert(alerts.includes("アラート"));
+  assert(alerts.includes("🟡 実測不足の型: データレポート型"));
+  assert(!alerts.includes("🔴"));
+  // URL は最終リプライのみ(link-in-reply の実測勝ち構造)。
+  assert(cta.includes(URL));
+  assert(!report!.text.includes(URL));
+});
+
+Deno.test("buildGrowthDataReport raises alerts for stale weeks and fallback floods", () => {
+  const staleRows = MEASURED_ROWS.map((entry) => ({
+    ...entry,
+    createdAt: "2026-06-01T00:00:00Z",
+    variant: "daily_briefing_fallback",
+  }));
+  const report = buildGrowthDataReport(staleRows, NOW, URL);
+  assert(report !== null);
+  assert(report!.text.includes("直近7日の計測対象: 0件"));
+  const alerts = report!.replyTexts.find((entry) => entry.includes("アラート"))!;
+  assert(alerts.includes("🔴 直近7日の計測対象が0件"));
+  assert(alerts.includes("🟡 定型文フォールバック比率が高い: 3/3件"));
+});
+
+Deno.test("buildGrowthDataReport reports surplus once past the 10K target", () => {
+  const winners = MEASURED_ROWS.map((entry, index) => ({
+    ...entry,
+    impressions: 12000 + index,
+    score: 12000 + index,
+  }));
+  const report = buildGrowthDataReport(winners, NOW, URL);
+  assert(report !== null);
+  assert(report!.text.includes("基準10,000との差分: +2002"));
+  assert(report!.text.includes("10,000まで残り: 0"));
+});

--- a/supabase/functions/growth-hub/x_growth_data_report_test.ts
+++ b/supabase/functions/growth-hub/x_growth_data_report_test.ts
@@ -75,6 +75,12 @@ Deno.test("buildGrowthDataReport composes a post-A style lead from real numbers"
   assert(report!.text.includes("基準10,000との差分: -6800"));
   assert(report!.text.includes("10,000まで残り: 6800"));
   assert(report!.text.includes("直近7日の計測対象: 3件"));
+  // 週替わり可変トークン: リード唯一の自由テキスト(近似重複ガード対策)。
+  assert(
+    report!.text.includes(
+      "今週の実測トップ: 3200 — 「国民民主党 地方議員集計 2026/07/10」",
+    ),
+  );
   // JST 日付ラベル(UTC 03:00 = JST 12:00 同日)。
   assert(report!.text.includes("X運用実測レポート 2026/7/12"));
   assertEquals(report!.measuredCount, 3);
@@ -120,7 +126,9 @@ Deno.test("buildGrowthDataReport raises alerts for stale weeks and fallback floo
   const report = buildGrowthDataReport(staleRows, NOW, URL);
   assert(report !== null);
   assert(report!.text.includes("直近7日の計測対象: 0件"));
-  const alerts = report!.replyTexts.find((entry) => entry.includes("アラート"))!;
+  const alerts = report!.replyTexts.find((entry) =>
+    entry.includes("アラート")
+  )!;
   assert(alerts.includes("🔴 直近7日の計測対象が0件"));
   assert(alerts.includes("🟡 定型文フォールバック比率が高い: 3/3件"));
 });

--- a/supabase/functions/growth-hub/x_post_archetype.ts
+++ b/supabase/functions/growth-hub/x_post_archetype.ts
@@ -61,7 +61,12 @@ export function classifyPostArchetype(
   text: string,
 ): "data_report" | "news_briefing" | "product_promo" | "general" {
   const body = text ?? "";
-  if (body.includes("デイリーブリーフィング")) return "news_briefing";
+  // ラベルは投稿の「先頭」にあってこそラベル(自前テンプレのリード書式)。
+  // 本文深部の出現は他投稿の引用(例: 週次実測レポートが勝ちフックを引用)で
+  // あり得るため、冒頭 120 字に限定して判定する。
+  if (body.slice(0, 120).includes("デイリーブリーフィング")) {
+    return "news_briefing";
+  }
   let dataScore = 0;
   if (/取得日時|現職名簿|基準\s*\d[\d,]*\s*との差分/.test(body)) dataScore += 2;
   if (/集計/.test(body)) dataScore += 1;
@@ -159,14 +164,13 @@ export function buildArchetypeLiftLine<T>(
   return line;
 }
 
-/// LLM が「データレポート型」投稿で一人称公開してよい実測数値行を作る純関数。
-/// 捏造禁止ルールと両立する唯一の恒常データ源=このアカウント自身の実測
-/// インプレッション。実測行(impressions 非 null)が 3 件以上あるときだけ
-/// 中央値/最高値/件数を返し、薄いうちは null(沈黙)。
-export function buildOwnDataFactsLine<T>(
+/// 実測インプレッションの要約統計(数値版)。実測行(impressions 非 null)が
+/// 3 件以上あるときだけ件数/中央値/最高値を返し、薄いうちは null(ノイズを
+/// 公開実数として扱わない)。行ビルダーと週次データレポート(R24)が共用する。
+export function computeOwnDataFacts<T>(
   rows: readonly T[],
   impressionsOf: (row: T) => number | null,
-): string | null {
+): { count: number; median: number; best: number } | null {
   const measured = rows
     .map((row) => impressionsOf(row))
     .filter((value): value is number =>
@@ -178,8 +182,23 @@ export function buildOwnDataFactsLine<T>(
   const median = measured.length % 2 === 1
     ? measured[mid]
     : Math.round((measured[mid - 1] + measured[mid]) / 2);
-  const best = measured[measured.length - 1];
+  return {
+    count: measured.length,
+    median,
+    best: measured[measured.length - 1],
+  };
+}
+
+/// LLM が「データレポート型」投稿で一人称公開してよい実測数値行を作る純関数。
+/// 捏造禁止ルールと両立する唯一の恒常データ源=このアカウント自身の実測
+/// インプレッション。実測 3 件未満は null(沈黙)。
+export function buildOwnDataFactsLine<T>(
+  rows: readonly T[],
+  impressionsOf: (row: T) => number | null,
+): string | null {
+  const facts = computeOwnDataFacts(rows, impressionsOf);
+  if (facts === null) return null;
   return `Own measured data (REAL numbers you MAY publish first-person as ` +
-    `build-in-public stats): measured posts=${measured.length}, median ` +
-    `impressions=${median}, best impressions=${best}.`;
+    `build-in-public stats): measured posts=${facts.count}, median ` +
+    `impressions=${facts.median}, best impressions=${facts.best}.`;
 }

--- a/supabase/functions/growth-hub/x_post_archetype_test.ts
+++ b/supabase/functions/growth-hub/x_post_archetype_test.ts
@@ -72,6 +72,20 @@ Deno.test("classifyPostArchetype does not misfile briefings as data_report", () 
     "2. 【選挙】投開票まであと3日、期日前投票は増加",
   ].join("\n");
   assertEquals(classifyPostArchetype(unlabeledElectionNews), "news_briefing");
+  // 逆方向の誤爆も防ぐ: ラベルが本文深部の「引用」として現れるデータレポート
+  // (週次実測レポートが勝ちフックを引用する形)は data_report のまま。
+  const reportQuotingBriefing = [
+    "自分株式会社 X運用実測レポート 2026/7/12",
+    "取得日時: 2026-07-12T03:00:00.000Z",
+    "計測済み投稿数: 3件",
+    "中央値インプレッション: 517",
+    "最高インプレッション: 3200",
+    "基準10,000との差分: -6800",
+    "10,000まで残り: 6800",
+    "インプレッション上位",
+    "517 — 「デイリーブリーフィング — 2026年7月12日朝」",
+  ].join("\n");
+  assertEquals(classifyPostArchetype(reportQuotingBriefing), "data_report");
 });
 
 Deno.test("classifyPostArchetype resolves hybrids by payload precedence", () => {


### PR DESCRIPTION
## 概要 (R24-①: ポストA型「独自データ資産」の週次 build-in-public 実測レポート)

2026-07-12 実測(データレポート型 3.2K vs ニュース要約 517 vs 製品転換 28)の勝ちアーキタイプを、毎週自動生成する。ポストA と同じ「テンプレ+実データ」方式で **LLM 非使用=数値捏造が構造的に不可能**。

## 変更内容

### growth-hub (Deno)
- **新規 `x_growth_data_report.ts`**: x_post_log 実測値のみからポストA構造(取得日時→主要実数→基準10,000との差分→残り→今週の実測トップ→型別内訳→実測上位→アラート→URL最終リプ)の投稿パッケージを決定的に合成。実測3件未満の週は null(薄いデータで「実測レポート」を名乗らない)
- **`x_post_archetype.ts`**: `computeOwnDataFacts` 抽出(数値版・行ビルダーと共用)+ デイリーブリーフィングラベル判定を**冒頭120字に限定**(レポートが勝ちフックを引用しても data_report 分類を維持。逆方向の回帰テスト追加)
- **新 action `x.growth_data_report`** (read-only compose / available:false で投稿見送り指示)

### GHA cron
- **新規 `x-growth-data-report-post.yml`**: 毎週土 21:00 UTC (= 日 06:00 JST)。daily briefing (22:00 UTC) と同時刻衝突しないようオフセット。週内重複ガード+`contentArchetype: data_report` 明示+`posted` 検証(credentials_missing の無言グリーン化防止)+近似重複拒否は「変化なし週スキップ」として正常終了

## 敵対的レビュー (9 agents / 生6→確認4→全対応)
- 週次テンプレの前週類似度 0.93-0.95 > ガード閾値0.9 → リードへ可変トークン追加+拒否時はスキップ設計化
- posted 未検証の無言グリーン → daily briefing と同じ守りを追加
- cron 同時刻衝突 → 21:00 UTC へオフセット

## テスト
- deno test: growth-hub 62 green (新規 x_growth_data_report 6 + archetype 回帰 2)
- deno lint: 0 エラー / YAML: parse OK

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge pure-logic + GHA cron workflow; no browser-reachable UI flow. Verified by deno test (62 green incl. 8 new) and YAML parse; workflow has dry_run-default manual dispatch for staging verification.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive read-only compose action + weekly cron mirroring the existing x-daily-briefing-post.yml pattern; numbers sourced only from measured logs (no LLM); no authentication/payment/RLS surface touched; adversarial 9-agent review confirmed 4 findings, all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
