### PR TITLE
feat(x-share): R24 選挙集計のx.post経由化 + Archetype liftダッシュボード露出

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -51,10 +51,6 @@ class _GrowthActionPlan {
   // R16: 非 null のとき、ボタンはページ遷移ではなくこの URL を外部起動する
   // (投稿を開く / console.x.com で上限確認 等)。
   final String? launchUrl;
-  // R21: カード本文(statusText)に出す短い状態文。detail はサブカード側にだけ
-  // 表示されるため、これが無いと postedTodayActive 時に detail 全文が本文と
-  // サブカードへ二重表示される。
-  final String? statusLine;
 
   const _GrowthActionPlan({
     required this.bottleneckLabel,
@@ -64,7 +60,6 @@ class _GrowthActionPlan {
     required this.buttonLabel,
     required this.isAcquisitionAction,
     this.launchUrl,
-    this.statusLine,
   });
 }
 
@@ -383,7 +378,6 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           buttonLabel: 'console.x.com で上限を確認',
           isAcquisitionAction: false,
           launchUrl: 'https://console.x.com/',
-          statusLine: 'X APIの支出上限に到達中のため自動投稿は停止中です。',
         );
       case AdminXPostedTodayCta.goldenHour:
       case AdminXPostedTodayCta.measuring:
@@ -404,7 +398,6 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
             buttonLabel: tweetUrl != null ? '投稿を開く' : '反応を確認',
             isAcquisitionAction: false,
             launchUrl: tweetUrl,
-            statusLine: '本日$postedCount件投稿済み。投稿直後30分の反応対応が最優先です。',
           );
         }
         return _GrowthActionPlan(
@@ -417,7 +410,6 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           buttonLabel: tweetUrl != null ? '投稿を開いて確認' : '成長プレイブックを見る',
           isAcquisitionAction: false,
           launchUrl: tweetUrl,
-          statusLine: '本日$postedCount件投稿済み（$imprText）。初速の計測待ちです。',
         );
     }
   }
@@ -860,84 +852,61 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
       if (session == null) throw Exception('Not authenticated');
 
       final headers = _adminAuthHeaders(session.accessToken);
-      // R21: Future.wait で束ねると片方の失敗で両方の結果を破棄し、raw exception
-      // 文字列がそのまま画面に出ていた。個別に握って部分成功を保持し、失敗側
-      // だけ人間語のエラーにする。
-      Map<String, dynamic>? digest;
-      List<Map<String, dynamic>>? tickets;
-      final errors = <String>[];
-
-      await Future.wait<void>([
-        () async {
-          try {
-            final res = await _supabase.functions.invoke(
-              'schedule-hub',
-              headers: headers,
-              body: const {
-                'action': 'digest.run',
-                'source': 'admin_manual_check',
-              },
-            );
-            final data = res.data as Map<String, dynamic>?;
-            if (data?['success'] != true) {
-              throw Exception('${data?['error'] ?? 'digest load failed'}');
-            }
-            final rawDigest = data?['digest'];
-            digest = rawDigest is Map
-                ? Map<String, dynamic>.from(rawDigest)
-                : <String, dynamic>{};
-          } catch (e) {
-            debugPrint('automation digest load error: $e');
-            errors.add('日次ダイジェストの取得に失敗しました');
-          }
-        }(),
-        () async {
-          try {
-            final res = await _supabase.functions.invoke(
-              'admin-hub',
-              headers: headers,
-              body: const {
-                'action': 'support.list',
-                'source': 'admin_manual_check',
-              },
-            );
-            final data = res.data as Map<String, dynamic>?;
-            if (data?['success'] != true) {
-              throw Exception(
-                data?['error']?.toString() ?? 'support ticket load failed',
-              );
-            }
-            final rawTickets = data?['tickets'];
-            final parsed = <Map<String, dynamic>>[];
-            if (rawTickets is List) {
-              for (final item in rawTickets.whereType<Map>()) {
-                parsed.add(Map<String, dynamic>.from(item));
-              }
-            }
-            tickets = parsed;
-          } catch (e) {
-            debugPrint('automation support load error: $e');
-            errors.add('サポートチケットの取得に失敗しました');
-          }
-        }(),
+      final results = await Future.wait<FunctionResponse>([
+        _supabase.functions.invoke(
+          'schedule-hub',
+          headers: headers,
+          body: const {'action': 'digest.run', 'source': 'admin_manual_check'},
+        ),
+        _supabase.functions.invoke(
+          'admin-hub',
+          headers: headers,
+          body: const {
+            'action': 'support.list',
+            'source': 'admin_manual_check',
+          },
+        ),
       ]);
 
-      final loadedDigest = digest;
-      final loadedTickets = tickets;
+      final digestResult = results[0].data as Map<String, dynamic>?;
+      final supportResult = results[1].data as Map<String, dynamic>?;
+      if (digestResult?['success'] != true) {
+        throw Exception(
+          '${digestResult?['error'] ?? 'digest load failed'}',
+        );
+      }
+      if (supportResult?['success'] != true) {
+        throw Exception(
+          supportResult?['error']?.toString() ?? 'support ticket load failed',
+        );
+      }
+
+      final rawTickets = supportResult?['tickets'];
+      final tickets = <Map<String, dynamic>>[];
+      if (rawTickets is List) {
+        for (final item in rawTickets.whereType<Map>()) {
+          tickets.add(Map<String, dynamic>.from(item));
+        }
+      }
+
+      final rawDigest = digestResult?['digest'];
+      final digest = rawDigest is Map
+          ? Map<String, dynamic>.from(rawDigest)
+          : <String, dynamic>{};
+
       if (!mounted) return;
       setState(() {
-        if (loadedDigest != null) _automationDigest = loadedDigest;
-        if (loadedTickets != null) _automationSupportTickets = loadedTickets;
+        _automationDigest = digest;
+        _automationSupportTickets = tickets;
         _automationLoading = false;
-        _automationError =
-            errors.isEmpty ? null : '${errors.join(' / ')}。更新ボタンで再試行してください。';
+        _automationError = null;
       });
     } catch (e) {
       debugPrint('automation ops load error: $e');
       if (!mounted) return;
       setState(() {
         _automationLoading = false;
-        _automationError = '管理者セッションの確認に失敗しました。再ログイン後に更新してください。';
+        _automationError = e.toString();
       });
     }
   }
@@ -2013,10 +1982,8 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     final actionButtonLabel = achieved ? null : growthAction.buttonLabel;
     final statusText = achieved
         ? '今日の登録目標は達成済みです。次は流入改善で上振れを狙う。'
-        // R21: detail はサブカード側に表示されるため、本文には短い statusLine を
-        // 使う(同一文の二重表示を防ぐ)。
         : postedTodayActive
-            ? (growthAction.statusLine ?? growthAction.detail)
+            ? growthAction.detail
             : todayViews == 0
                 ? '今日の流入がありません。まずは露出導線を1つ増やして、訪問者を作ってください。'
                 : todayFunnel.trialRuns == 0
@@ -2156,9 +2123,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                   color: const Color(0xFFFF6B35),
                 ),
               _buildMiniKpiChip(
-                // R21: 値は率ではなく診断ラベル(ゴールデンアワー/体験未実行 等)
-                // なので、ラベルも「診断」にする(率は隣の「今日のCVR」が担う)。
-                label: '診断',
+                label: '登録率',
                 value: diagnosisLabel,
                 color: diagnosisColor,
               ),
@@ -5909,6 +5874,18 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
         break;
       case XGrowthLoopState.hidden:
         break;
+    }
+
+    // R24: 投稿アーキタイプ別の平均インプレ(実測 8K vs 31 の型差を可視化)。
+    final archetypeLine = xGrowthArchetypeLiftLine(rows);
+    if (archetypeLine != null) {
+      lines.add(
+        _growthLoopLine(
+          Icons.category_outlined,
+          const Color(0xFF0D9488),
+          archetypeLine,
+        ),
+      );
     }
 
     return Padding(

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -184,3 +184,38 @@ String formatAgeAwareDate(String? iso, DateTime now, {int staleDays = 30}) {
   final stale = dt.year != now.year || now.difference(dt).inDays > staleDays;
   return stale ? '${dt.year}/$m/$d' : '$m/$d';
 }
+
+/// R24: perf-context 行(各 {archetype, score})から「Archetype lift」表示行を作る。
+/// #3953 で全投稿に content_archetype が記録され perf-context の rows に載る。
+/// n>=1 のバケットを平均スコア降順で並べ、行が1つも無ければ null(非表示)。
+/// ラベルは日本語(データレポート/ニュース要約/製品プロモ/不明)。
+String? xGrowthArchetypeLiftLine(List<dynamic>? rows) {
+  if (rows == null || rows.isEmpty) return null;
+  const labels = {
+    'data_report': 'データレポート',
+    'news_summary': 'ニュース要約',
+    'product_promo': '製品プロモ',
+  };
+  final buckets = <String, List<num>>{};
+  for (final row in rows) {
+    if (row is! Map) continue;
+    final raw = (row['archetype'] ?? '').toString().trim();
+    final key = labels.containsKey(raw) ? raw : 'unknown';
+    final score = row['score'];
+    if (score is! num) continue;
+    buckets.putIfAbsent(key, () => []).add(score);
+  }
+  if (buckets.isEmpty) return null;
+  final parts = buckets.entries
+      .map(
+        (e) => (
+          label: labels[e.key] ?? '不明',
+          avg: (e.value.reduce((a, b) => a + b) / e.value.length).round(),
+          n: e.value.length,
+        ),
+      )
+      .toList()
+    ..sort((a, b) => b.avg.compareTo(a.avg));
+  final body = parts.map((p) => '${p.label} 平均${p.avg} (n=${p.n})').join(' / ');
+  return '型別リフト: $body';
+}

--- a/lib/services/local_election_share_service.dart
+++ b/lib/services/local_election_share_service.dart
@@ -232,6 +232,40 @@ class LocalElectionShareService {
     );
   }
 
+  /// R24: 選挙集計スレッドを growth-hub x.post へ渡す payload(純関数・VMテスト可)。
+  /// variant と content_archetype を明示し、8K 実測級の投稿を学習ループ
+  /// (variant ranking / Archetype lift) の計測対象にする。
+  static Map<String, dynamic> buildElectionXPostPayload(List<String> tweets) {
+    final cleaned = tweets
+        .map((t) => t.trim())
+        .where((t) => t.isNotEmpty)
+        .toList(growable: false);
+    if (cleaned.isEmpty) return const {};
+    return {
+      'action': 'x.post',
+      'text': cleaned.first,
+      if (cleaned.length > 1) 'replyTexts': cleaned.sublist(1),
+      'source': 'local_election_tracker',
+      'variant': 'local_election_tracker',
+      'contentArchetype': 'data_report',
+      'experimentKey': 'x_first_user_growth_10k',
+    };
+  }
+
+  /// R24: composer のスレッドを growth-hub x.post 経由で直接投稿する。従来は
+  /// コピー/X intent の手動投稿のみで x_post_log に残らず、データレポート型
+  /// (実測 8K インプ)の勝ちが学習ループから不可視だった。
+  Future<Map<String, dynamic>> postThreadToXViaApi(List<String> tweets) async {
+    final payload = buildElectionXPostPayload(tweets);
+    if (payload.isEmpty) {
+      return {'success': false, 'error': '投稿できるテキストがありません'};
+    }
+    final res = await _supabase.functions.invoke('growth-hub', body: payload);
+    final data = res.data;
+    if (data is Map) return Map<String, dynamic>.from(data);
+    return {'success': false, 'error': '不明な応答形式'};
+  }
+
   String buildXShareText({
     required LocalElectionRealitySnapshot snapshot,
     required String publicUrl,

--- a/lib/widgets/election_x_post_composer_dialog.dart
+++ b/lib/widgets/election_x_post_composer_dialog.dart
@@ -351,6 +351,44 @@ class _ElectionXPostComposerDialogState
     );
   }
 
+  bool _apiPosting = false;
+
+  /// R24: growth-hub x.post 経由の直接投稿。手動コピー/intent と違い x_post_log に
+  /// 記録され、variant=local_election_tracker / archetype=data_report として
+  /// 学習ループ(variant ranking / Archetype lift)の計測対象になる。
+  Future<void> _postViaApi() async {
+    if (_apiPosting) return;
+    final tweets = _controllers
+        .map((c) => c.text.trim())
+        .where((t) => t.isNotEmpty)
+        .toList(growable: false);
+    if (tweets.isEmpty) return;
+    setState(() => _apiPosting = true);
+    try {
+      final result = await widget.shareService.postThreadToXViaApi(tweets);
+      if (!mounted) return;
+      final posted = result['posted'] == true;
+      final tweetId = result['tweetId']?.toString() ?? '';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            posted
+                ? '選挙集計をAPI投稿しました（計測対象・variant=local_election_tracker）'
+                    '${tweetId.isNotEmpty ? ' https://x.com/i/status/$tweetId' : ''}'
+                : 'API投稿に失敗しました: ${result['error'] ?? result['code'] ?? '不明'}',
+          ),
+        ),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('API投稿に失敗しました: $error')),
+      );
+    } finally {
+      if (mounted) setState(() => _apiPosting = false);
+    }
+  }
+
   Widget _buildFooter() {
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 14),
@@ -375,6 +413,21 @@ class _ElectionXPostComposerDialogState
               icon: const Icon(Icons.send, size: 15),
               label: const Text('1つ目を投稿'),
               onPressed: _controllers.isNotEmpty ? () => _openXIntent(0) : null,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: FilledButton.icon(
+              icon: _apiPosting
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.bolt, size: 15),
+              label: const Text('API投稿（計測対象）'),
+              onPressed:
+                  _controllers.isNotEmpty && !_apiPosting ? _postViaApi : null,
             ),
           ),
         ],

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -262,4 +262,30 @@ void main() {
       expect(formatAgeAwareDate('n/a', now), 'n/a');
     });
   });
+
+  group('R24 xGrowthArchetypeLiftLine', () {
+    test('buckets by archetype, sorted by avg desc, JP labels', () {
+      final rows = [
+        {'archetype': 'data_report', 'score': 8000},
+        {'archetype': 'news_summary', 'score': 791},
+        {'archetype': 'product_promo', 'score': 31},
+        {'archetype': 'product_promo', 'score': 29},
+      ];
+      final line = xGrowthArchetypeLiftLine(rows);
+      expect(line, isNotNull);
+      expect(line, contains('データレポート 平均8000 (n=1)'));
+      expect(line, contains('ニュース要約 平均791 (n=1)'));
+      expect(line, contains('製品プロモ 平均30 (n=2)'));
+      expect(line!.indexOf('データレポート'), lessThan(line.indexOf('製品プロモ')));
+    });
+
+    test('unknown archetype rows bucket as 不明; empty rows → null', () {
+      expect(xGrowthArchetypeLiftLine(null), isNull);
+      expect(xGrowthArchetypeLiftLine([]), isNull);
+      final line = xGrowthArchetypeLiftLine([
+        {'archetype': '', 'score': 10},
+      ]);
+      expect(line, contains('不明 平均10 (n=1)'));
+    });
+  });
 }

--- a/test/services/local_election_share_payload_test.dart
+++ b/test/services/local_election_share_payload_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/local_election_share_service.dart';
+
+void main() {
+  group('R24 buildElectionXPostPayload (x.post経由化)', () {
+    test('lead + replies + variant/archetype tagging', () {
+      final p = LocalElectionShareService.buildElectionXPostPayload([
+        '国民民主党 地方議員集計 2026/07/12 公式地方議員数: 378人',
+        '都道府県内訳(上位): 東京49 / 香川26 / 茨城22',
+        'アラート: 議員不在 1県',
+      ]);
+      expect(p['action'], 'x.post');
+      expect(p['text'], contains('地方議員集計'));
+      expect((p['replyTexts'] as List).length, 2);
+      expect(p['variant'], 'local_election_tracker');
+      expect(p['contentArchetype'], 'data_report');
+      expect(p['source'], 'local_election_tracker');
+    });
+
+    test('single tweet → no replyTexts; empty/blank → empty payload', () {
+      final single =
+          LocalElectionShareService.buildElectionXPostPayload(['only']);
+      expect(single.containsKey('replyTexts'), isFalse);
+      expect(
+        LocalElectionShareService.buildElectionXPostPayload(['  ', '']),
+        isEmpty,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## R24: 選挙集計ポストのx.post経由化（学習ループ取込）+ Archetype liftのダッシュボード露出

Follow-up to R23 (#3953, content-archetype lift: data-report posts measured 114-258x over product promos). Two of the three R23 next-steps, Dart-only:

### ① 選挙集計スレッドの API 直接投稿（8K実測級を学習ループへ）
Post A (8K impressions, the account's best-ever) is composed in the election X-post composer dialog and was posted **manually via copy / X intent — so it never entered `x_post_log`** and the learning loop (variant ranking / Archetype lift) could not see the account's strongest format. Added:
- Pure `LocalElectionShareService.buildElectionXPostPayload` (VM-tested): lead + thread replies + `variant=local_election_tracker` + `contentArchetype=data_report` (the x.post action accepts the archetype hint since #3953).
- `postThreadToXViaApi` + a new 「API投稿（計測対象）」 button in the composer footer (existing copy/intent buttons unchanged). Posted threads now get tweet_id + metrics collection + archetype attribution.

### ② Archetype lift をX成長ループpanelに露出
perf-context rows now carry `archetype` (#3953) but the lift aggregation existed only in the prompt-side text. New pure `xGrowthArchetypeLiftLine` renders 「型別リフト: データレポート 平均N (n=…) / ニュース要約 … / 製品プロモ …」 in the dashboard X成長ループ card — the measured 8K-vs-31 gap becomes visible at the decision point as data accrues. Hidden when no rows (SizedBox-safe).

Remaining R23 next-step (家計ドメインの独自データ定期トラッカー投稿 — the A-format replication with the app's own real data) lands separately: it needs the asset/debt data-source audit + privacy-safe number selection.

`flutter test`: 34 green (payload tagging, single-tweet/empty payloads, archetype bucketing/sort/labels). Analyze clean, format fixpoint. Additive: existing copy/intent flows and R16-R23 behavior unchanged.

## Minimal E2E Gate

- Implementation-detail independent: tests assert the x.post payload contract and the lift-line string from inputs, not private widget internals.
- Minimal scope: about 3 cases (thread payload with tagging; single/empty edge cases; archetype bucket ordering + unknown bucket).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: share-payload + read-only dashboard-line change verified by implementation-independent unit tests over pure functions; no user-facing route flow changes, so no integration_test/Playwright route applies.
