### PR TITLE
feat(election): R24 post the tally to X via growth-hub API (measured data_report loop)

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -894,8 +894,13 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     if (!mounted) {
       return;
     }
-    final publicUrl =
-        memo == null ? '' : PublicMemoService.buildPublicMemoUrl(memo.id);
+    if (memo == null) {
+      // 公開ノートが無いまま投稿すると「続きは公開ノートへ」型の誘導だけが
+      // リンク無しで公開されて取り消せない(レビュー指摘)。発行失敗の
+      // snackbar は _publishSnapshotMemo が表示済みなのでここで中止する。
+      return;
+    }
+    final publicUrl = PublicMemoService.buildPublicMemoUrl(memo.id);
     final text = _shareService.buildXPostLongText(
       snapshot: snapshot,
       members: snapshot.members,
@@ -970,6 +975,16 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('地方議員集計をXへ投稿しました(計測ループに記録済み)'),
+          ),
+        );
+      } else if (data['code'] == 'duplicate_content') {
+        // このルートは集計データからの決定的テンプレなので「文面を変えて再生成」
+        // は実行不能。数値が動くまで再投稿を見送るのが正しい対処と案内する。
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              '直近の投稿と内容がほぼ同じため見送りました。集計数値が動いてから再投稿してください。',
+            ),
           ),
         );
       } else {

--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -125,6 +125,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
   bool _isLoading = true;
   bool _isRealityLoading = false;
   bool _isPublishingSnapshotMemo = false;
+  bool _isPostingSnapshotToX = false;
   bool _isPublishingKpiMemo = false;
   bool _isGeminiLoading = false;
   String? _realityError;
@@ -868,6 +869,134 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     );
   }
 
+  /// R24: 地方議員集計(ポストA型=実測 3.2K のデータレポート)を growth-hub
+  /// x.post で API 投稿する。intent 投稿は x_post_log の外で Archetype lift
+  /// 計測に入らないため、この経路が計測ループへの正式ルート。実投稿の前に
+  /// 必ず確認ダイアログを挟む。
+  Future<void> _postSnapshotToXViaApi() async {
+    final snapshot = _realitySnapshot;
+    if (snapshot == null || !snapshot.hasData) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('最新の実データ取得後にX API投稿できます')),
+      );
+      return;
+    }
+    if (Supabase.instance.client.auth.currentUser == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('X API投稿にはログインが必要です')),
+      );
+      return;
+    }
+    if (_isPostingSnapshotToX) {
+      return;
+    }
+    final memo = _publishedSnapshotMemo ?? await _publishSnapshotMemo();
+    if (!mounted) {
+      return;
+    }
+    final publicUrl =
+        memo == null ? '' : PublicMemoService.buildPublicMemoUrl(memo.id);
+    final text = _shareService.buildXPostLongText(
+      snapshot: snapshot,
+      members: snapshot.members,
+      plan: _plan,
+      publicUrl: publicUrl,
+    );
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('地方議員集計をXへ投稿'),
+        content: SizedBox(
+          width: 480,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('全${text.length}字の長文ポストとして実投稿されます(取り消し不可)。'),
+              const SizedBox(height: 8),
+              Flexible(
+                child: SingleChildScrollView(
+                  child: Text(
+                    text.length > 600 ? '${text.substring(0, 600)}…' : text,
+                    style: Theme.of(dialogContext).textTheme.bodySmall,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Xへ投稿する'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) {
+      return;
+    }
+    setState(() {
+      _isPostingSnapshotToX = true;
+    });
+    try {
+      final resp = await Supabase.instance.client.functions.invoke(
+        'growth-hub',
+        body: {
+          'action': 'x.post',
+          'text': text,
+          'source': 'local_election_share',
+          'route': '/election-victory',
+          'experimentKey': 'x_first_user_growth_10k',
+          'variant': 'local_election_tally',
+          'utmContent': 'local_election_tally',
+          'promptProfile': 'local_election_tally_template_v1',
+          'contentKind': 'data_report',
+          'contentArchetype': 'data_report',
+          'linkInReply': false,
+        },
+      );
+      final data = resp.data is Map
+          ? Map<String, dynamic>.from(resp.data as Map)
+          : <String, dynamic>{};
+      if (!mounted) {
+        return;
+      }
+      if (data['success'] == true && data['posted'] == true) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('地方議員集計をXへ投稿しました(計測ループに記録済み)'),
+          ),
+        );
+      } else {
+        final guidance = data['actionRequired']?.toString() ??
+            data['warning']?.toString() ??
+            data['error']?.toString() ??
+            '投稿に失敗しました';
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('X投稿できませんでした: $guidance')),
+        );
+      }
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('X投稿エラー: $error')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPostingSnapshotToX = false;
+        });
+      }
+    }
+  }
+
   Future<void> _openElectionXPostComposer() async {
     final snapshot = _realitySnapshot;
     if (snapshot == null || !snapshot.hasData) {
@@ -1280,6 +1409,23 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
                       onPressed: _isPublishingKpiMemo ? null : _shareKpiMemoOnX,
                       icon: const Icon(Icons.alternate_email),
                       label: const Text('X共有'),
+                    ),
+                    FilledButton.icon(
+                      onPressed: _isPostingSnapshotToX ||
+                              _isPublishingSnapshotMemo ||
+                              realitySnapshot == null
+                          ? null
+                          : _postSnapshotToXViaApi,
+                      icon: _isPostingSnapshotToX
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.send),
+                      label: Text(
+                        _isPostingSnapshotToX ? 'X投稿中' : '集計をX投稿(API)',
+                      ),
                     ),
                     FilledButton.tonalIcon(
                       onPressed: _isRealityLoading

--- a/lib/services/local_election_share_service.dart
+++ b/lib/services/local_election_share_service.dart
@@ -316,36 +316,67 @@ class LocalElectionShareService {
     );
   }
 
+  /// X の投稿長制限(25,000)は twitter-text の加重文字数で数えられる:
+  /// CJK/全角=2、半角(Latin 等)=1、URL=一律23。日本語主体の集計本文を Dart の
+  /// code unit 数で測ると実重みのほぼ半分にしか見えず、上限超過を素通しする
+  /// (レビュー指摘)。ここでは全文字を範囲判定で加重する近似を使う(ASCII の
+  /// URL を 1/字で数える=実際の 23/URL より過大評価で安全側)。
+  static int xWeightedLength(String text) {
+    var weighted = 0;
+    for (final rune in text.runes) {
+      weighted += rune < 0x1100 ? 1 : 2;
+    }
+    return weighted;
+  }
+
   /// R24: 地方議員集計を growth-hub x.post(API 投稿)へ載せるための長文本文。
   /// intent 投稿は x_post_log の外=Archetype lift 計測に入らないため、実測
   /// 3.2K インプレッションのポストA(集計ノート全文)を API 経由の第一級経路に
-  /// する。X Premium 上限(25,000字)に対し [maxChars] で安全側に収め、超過時は
-  /// 名簿セクション境界(\n\n◽️)で切り詰めて公開ノートへ誘導する。
+  /// する。X Premium 上限(25,000 weighted)に対し [maxWeightedChars] で安全側に
+  /// 収め、超過時は名簿セクション境界(\n\n◽️)で切り詰めて公開ノートへ誘導する。
   String buildXPostLongText({
     required LocalElectionRealitySnapshot snapshot,
     required List<LocalElectionLegislatorProfile> members,
     LocalElectionPlanDashboard? plan,
     String publicUrl = '',
-    int maxChars = 24000,
+    int maxWeightedChars = 24000,
   }) {
     final draft = buildDraft(snapshot: snapshot, members: members, plan: plan);
     final suffix =
         publicUrl.isEmpty ? '' : '\n\n全都道府県の内訳と現職名簿の公開ノート:\n$publicUrl';
     final body = draft.content.trim();
-    if (body.length + suffix.length <= maxChars) {
+    if (xWeightedLength(body) + xWeightedLength(suffix) <= maxWeightedChars) {
       return '$body$suffix';
     }
-    const truncationNote = '\n\n(文字数上限のため名簿の続きは公開ノートへ)';
-    final budget = maxChars - suffix.length - truncationNote.length;
+    // 公開ノート URL が無いときは「続きは公開ノートへ」と書かない(リンクの
+    // 無い誘導文が公開されたまま残る事故を防ぐ。呼び出し側でも memo 発行失敗
+    // 時は投稿自体を中止する)。
+    final truncationNote = publicUrl.isEmpty
+        ? '\n\n(文字数上限のため名簿は途中まで)'
+        : '\n\n(文字数上限のため名簿の続きは公開ノートへ)';
+    final budget = maxWeightedChars -
+        xWeightedLength(suffix) -
+        xWeightedLength(truncationNote);
     if (budget <= 0) {
       return buildXShareText(snapshot: snapshot, publicUrl: publicUrl);
     }
-    var cut = body.lastIndexOf('\n\n◽️', budget);
+    // weighted budget 内に収まる最大の code-unit 位置を前方走査で求める。
+    var weighted = 0;
+    var cutLimit = 0;
+    for (final rune in body.runes) {
+      final w = rune < 0x1100 ? 1 : 2;
+      if (weighted + w > budget) {
+        break;
+      }
+      weighted += w;
+      cutLimit += rune > 0xFFFF ? 2 : 1;
+    }
+    var cut = body.lastIndexOf('\n\n◽️', cutLimit);
     if (cut < 0) {
-      cut = body.lastIndexOf('\n\n', budget);
+      cut = body.lastIndexOf('\n\n', cutLimit);
     }
     if (cut <= 0) {
-      cut = budget;
+      cut = cutLimit;
     }
     return '${body.substring(0, cut).trimRight()}$truncationNote$suffix';
   }

--- a/lib/services/local_election_share_service.dart
+++ b/lib/services/local_election_share_service.dart
@@ -316,6 +316,40 @@ class LocalElectionShareService {
     );
   }
 
+  /// R24: 地方議員集計を growth-hub x.post(API 投稿)へ載せるための長文本文。
+  /// intent 投稿は x_post_log の外=Archetype lift 計測に入らないため、実測
+  /// 3.2K インプレッションのポストA(集計ノート全文)を API 経由の第一級経路に
+  /// する。X Premium 上限(25,000字)に対し [maxChars] で安全側に収め、超過時は
+  /// 名簿セクション境界(\n\n◽️)で切り詰めて公開ノートへ誘導する。
+  String buildXPostLongText({
+    required LocalElectionRealitySnapshot snapshot,
+    required List<LocalElectionLegislatorProfile> members,
+    LocalElectionPlanDashboard? plan,
+    String publicUrl = '',
+    int maxChars = 24000,
+  }) {
+    final draft = buildDraft(snapshot: snapshot, members: members, plan: plan);
+    final suffix =
+        publicUrl.isEmpty ? '' : '\n\n全都道府県の内訳と現職名簿の公開ノート:\n$publicUrl';
+    final body = draft.content.trim();
+    if (body.length + suffix.length <= maxChars) {
+      return '$body$suffix';
+    }
+    const truncationNote = '\n\n(文字数上限のため名簿の続きは公開ノートへ)';
+    final budget = maxChars - suffix.length - truncationNote.length;
+    if (budget <= 0) {
+      return buildXShareText(snapshot: snapshot, publicUrl: publicUrl);
+    }
+    var cut = body.lastIndexOf('\n\n◽️', budget);
+    if (cut < 0) {
+      cut = body.lastIndexOf('\n\n', budget);
+    }
+    if (cut <= 0) {
+      cut = budget;
+    }
+    return '${body.substring(0, cut).trimRight()}$truncationNote$suffix';
+  }
+
   Uri buildXShareIntentUri({
     required LocalElectionRealitySnapshot snapshot,
     required String publicUrl,

--- a/supabase/functions/growth-hub/x_duplicate_content.ts
+++ b/supabase/functions/growth-hub/x_duplicate_content.ts
@@ -166,6 +166,21 @@ export function editSimilarity(a: string, b: string): number {
 }
 
 /**
+ * 編集距離に渡す正規化本文の上限 (code point)。R24 で長文データレポート
+ * (選挙集計 10k-24k 字) が x.post を通るようになり、長文同士の Levenshtein は
+ * O(n*m) で edge の CPU 予算を超える (実測 18k×18k ≈ 3.1s)。テンプレ投稿は
+ * 先頭が最も安定するため、編集距離は先頭スライスの比較で近似する (Jaccard は
+ * 線形なので全文のまま)。
+ */
+export const EDIT_SIMILARITY_MAX_CODEPOINTS = 2000;
+
+function clampForEditSimilarity(normalized: string): string {
+  const points = [...normalized];
+  if (points.length <= EDIT_SIMILARITY_MAX_CODEPOINTS) return normalized;
+  return points.slice(0, EDIT_SIMILARITY_MAX_CODEPOINTS).join("");
+}
+
+/**
  * 2 本の投稿本文の類似度 (0..1)。Jaccard と編集距離の高い方を採用。
  * 正規化後に一方でも空になる場合は 0 (誤ブロックを避けるため fail-open)。
  */
@@ -174,7 +189,10 @@ export function contentSimilarity(rawA: string, rawB: string): number {
   const b = normalizeForSimilarity(rawB);
   if (a === "" || b === "") return 0;
   if (a === b) return 1;
-  return Math.max(jaccardSimilarity(a, b), editSimilarity(a, b));
+  return Math.max(
+    jaccardSimilarity(a, b),
+    editSimilarity(clampForEditSimilarity(a), clampForEditSimilarity(b)),
+  );
 }
 
 /**

--- a/supabase/functions/growth-hub/x_duplicate_content_test.ts
+++ b/supabase/functions/growth-hub/x_duplicate_content_test.ts
@@ -225,3 +225,29 @@ Deno.test("extractPostedTexts: tolerates missing/odd metadata shapes", () => {
   ];
   assertEquals(extractPostedTexts(rows, 10), []);
 });
+
+Deno.test("contentSimilarity: long-form posts stay fast via edit-distance clamp", () => {
+  // R24: 選挙集計等の長文(10k-24k字)が x.post を通るようになり、全文
+  // Levenshtein は O(n*m) で edge CPU 予算超過(実測 18k×18k ≈ 3.1s)。
+  // 先頭スライス近似でも「ほぼ同一の長文テンプレ」は依然 duplicate 検出される
+  // こと+完走時間が桁で縮むことを固定する。
+  const base = "国民民主党 地方議員集計 2026/07/10 公式地方議員数378人\n"
+    .repeat(700);
+  const refreshed = base.replaceAll("378人", "381人");
+  const start = Date.now();
+  const similar = contentSimilarity(base, refreshed);
+  const elapsed = Date.now() - start;
+  if (!(similar >= 0.9)) {
+    throw new Error(`expected near-duplicate, got ${similar}`);
+  }
+  if (!(elapsed < 1500)) {
+    throw new Error(`edit-distance clamp did not keep it fast: ${elapsed}ms`);
+  }
+  // 別内容の長文は duplicate にならない(clamp が false-positive を作らない)。
+  const other =
+    "全く別の話題。家計の負債トレンドを月次で検出して翌月の行動を出す。\n"
+      .repeat(600);
+  if (!(contentSimilarity(base, other) < 0.9)) {
+    throw new Error("unrelated long posts must not match");
+  }
+});

--- a/test/services/local_election_share_service_test.dart
+++ b/test/services/local_election_share_service_test.dart
@@ -333,7 +333,17 @@ void main() {
     expect(text, contains('現職地方議員名簿'));
     expect(text, contains('全都道府県の内訳と現職名簿の公開ノート:'));
     expect(text, contains('https://example.com/public-memo?id=10'));
-    expect(text.length, lessThanOrEqualTo(24000));
+    // 上限は X 実測の加重文字数(CJK=2)で守る(code unit 数ではない)。
+    expect(
+      LocalElectionShareService.xWeightedLength(text),
+      lessThanOrEqualTo(24000),
+    );
+  });
+
+  test('xWeightedLength doubles CJK per twitter-text weighting', () {
+    expect(LocalElectionShareService.xWeightedLength('abc'), 3);
+    expect(LocalElectionShareService.xWeightedLength('あいう'), 6);
+    expect(LocalElectionShareService.xWeightedLength('a議員1人'), 8);
   });
 
   test(
@@ -345,18 +355,42 @@ void main() {
       members: snapshot.members,
       publicUrl: '',
     );
+    final fullWeighted = LocalElectionShareService.xWeightedLength(full);
     final capped = service.buildXPostLongText(
       snapshot: snapshot,
       members: snapshot.members,
       publicUrl: 'https://example.com/public-memo?id=10',
-      maxChars: full.length - 50,
+      maxWeightedChars: fullWeighted - 50,
     );
 
-    expect(capped.length, lessThanOrEqualTo(full.length - 50));
+    expect(
+      LocalElectionShareService.xWeightedLength(capped),
+      lessThanOrEqualTo(fullWeighted - 50),
+    );
     expect(capped, contains('(文字数上限のため名簿の続きは公開ノートへ)'));
     expect(capped, contains('https://example.com/public-memo?id=10'));
     // 冒頭のデータレポート骨格は必ず残る。
     expect(capped, contains('公式地方議員数: 333人'));
+  });
+
+  test('buildXPostLongText omits the note-link cue when no public URL exists',
+      () {
+    final snapshot = buildSnapshot();
+    final full = service.buildXPostLongText(
+      snapshot: snapshot,
+      members: snapshot.members,
+      publicUrl: '',
+    );
+    final capped = service.buildXPostLongText(
+      snapshot: snapshot,
+      members: snapshot.members,
+      publicUrl: '',
+      maxWeightedChars: LocalElectionShareService.xWeightedLength(full) - 50,
+    );
+
+    // URL の無い投稿に「続きは公開ノートへ」というリンク無し誘導を残さない。
+    expect(capped, isNot(contains('公開ノートへ')));
+    expect(capped, contains('(文字数上限のため名簿は途中まで)'));
   });
 
   test('buildXShareIntentUri separates the body text and shared URL', () {

--- a/test/services/local_election_share_service_test.dart
+++ b/test/services/local_election_share_service_test.dart
@@ -316,6 +316,49 @@ void main() {
     expect(shareText, contains('https://example.com/public-memo?id=10'));
   });
 
+  test('buildXPostLongText carries the full post-A tally within the cap', () {
+    // R24: API 投稿(growth-hub x.post)経路の本文。集計ノート全文=実測 3.2K
+    // のポストA構造がそのまま入り、末尾に公開ノート URL が付く。
+    final snapshot = buildSnapshot();
+    final text = service.buildXPostLongText(
+      snapshot: snapshot,
+      members: snapshot.members,
+      publicUrl: 'https://example.com/public-memo?id=10',
+    );
+
+    expect(text, contains('国民民主党 地方議員集計 2026/03/28'));
+    expect(text, contains('取得日時:'));
+    expect(text, contains('公式地方議員数: 333人'));
+    expect(text, contains('700まで残り: 367人'));
+    expect(text, contains('現職地方議員名簿'));
+    expect(text, contains('全都道府県の内訳と現職名簿の公開ノート:'));
+    expect(text, contains('https://example.com/public-memo?id=10'));
+    expect(text.length, lessThanOrEqualTo(24000));
+  });
+
+  test(
+      'buildXPostLongText truncates at a roster section boundary when over cap',
+      () {
+    final snapshot = buildSnapshot();
+    final full = service.buildXPostLongText(
+      snapshot: snapshot,
+      members: snapshot.members,
+      publicUrl: '',
+    );
+    final capped = service.buildXPostLongText(
+      snapshot: snapshot,
+      members: snapshot.members,
+      publicUrl: 'https://example.com/public-memo?id=10',
+      maxChars: full.length - 50,
+    );
+
+    expect(capped.length, lessThanOrEqualTo(full.length - 50));
+    expect(capped, contains('(文字数上限のため名簿の続きは公開ノートへ)'));
+    expect(capped, contains('https://example.com/public-memo?id=10'));
+    // 冒頭のデータレポート骨格は必ず残る。
+    expect(capped, contains('公式地方議員数: 333人'));
+  });
+
   test('buildXShareIntentUri separates the body text and shared URL', () {
     final snapshot = buildSnapshot();
     final uri = service.buildXShareIntentUri(


### PR DESCRIPTION
## 概要 (R24-②: 選挙集計ポストを growth-hub x.post 経由へ)

実測 3.2K インプレッションのポストA(国民民主党 地方議員集計)は現状 x.com intent 投稿= `x_post_log` の外で、R23 Archetype lift 計測に入らない。API 投稿経路を第一級ルートにして、勝ちアーキタイプの実測を計測ループへ載せる。

## 変更内容

### Flutter (Dart)
- **`LocalElectionShareService.buildXPostLongText`**: 集計ノート全文(ポストA構造)を X の**加重文字数**(twitter-text: CJK=2 / 上限25,000 weighted)基準で 24,000 以内に収める。超過時は名簿セクション境界(`\n\n◽️`)で切り詰め公開ノートURLへ誘導。`xWeightedLength` を公開(日本語主体だと code unit 計測は実重みの約半分=素通しの罠)
- **必達管理室に「集計をX投稿(API)」ボタン**: 確認ダイアログ(文字数+冒頭プレビュー+取り消し不可の明示)→ `x.post` を `contentArchetype: data_report` / `variant: local_election_tally` で呼ぶ。公開ノート発行失敗時は投稿中止(リンク無し誘導文の公開事故防止)。`duplicate_content` 拒否は「数値が動くまで見送り」の専用案内

### growth-hub (Deno)
- **`x_duplicate_content.ts`**: 近似重複ガードの編集距離を先頭 2,000 code point スライスで近似。長文(10k-24k字)同士の全文 Levenshtein は O(n×m) で edge CPU 予算超過(レビュー実測 18k×18k ≈ 3.1s)。Jaccard は線形のため全文のまま

## 敵対的レビュー (7 agents / 確認3→全対応)
- CJK 加重で上限が実質2倍過大 → 加重文字数基準へ
- 長文同士の重複ガードで edge CPU 爆発 → 編集距離クランプ
- memo 発行失敗時にリンク無し「公開ノートへ」誘導が公開される → 投稿中止+文言分離

## テスト
- flutter test: local_election_share_service 16 green (新規 4)
- deno test: growth-hub 63 green (新規 1 = クランプ回帰・完走時間固定)
- dart format 差分なし / deno lint 0 エラー

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: The posting flow requires a logged-in session and performs an irreversible external X post behind a manual confirm dialog; covered by pure-logic VM tests (16 green) and deno tests (63 green) instead of automated E2E.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Dart share-text builder + one page button behind an explicit user confirm dialog; edge change is a CPU clamp inside the existing duplicate guard (no gate relaxation — threshold and window unchanged); no authentication/payment/RLS surface touched; adversarial 7-agent review confirmed 3 findings, all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
