### PR TITLE
fix(admin): R25 archetype lift — fix #3965 news_briefing key mismatch + honesty gates

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -5876,14 +5876,29 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
         break;
     }
 
-    // R24: 投稿アーキタイプ別の平均インプレ(実測 8K vs 31 の型差を可視化)。
-    final archetypeLine = xGrowthArchetypeLiftLine(rows);
-    if (archetypeLine != null) {
+    // R25: 内容アーキタイプ別実測(R23 Archetype lift)。sampling 中でも型別の
+    // 実測は意思決定材料になるため state に依らず rows から出す。勝ち型は
+    // 実測バケット(n>=2・unknown 除く)が2種以上のときだけ主張する(edge と
+    // 同じ誠実性閾値)。
+    final archetypeEntries = resolveArchetypeLift(rows);
+    final archetypeWinner = archetypeLiftWinner(archetypeEntries);
+    if (archetypeWinner != null) {
+      lines.add(
+        _growthLoopLine(
+          Icons.emoji_events,
+          const Color(0xFF0EA5E9),
+          '勝ちアーキタイプ: ${archetypeWinner.label}'
+          '（平均${archetypeWinner.averageScore}）— 次の投稿はこの型で',
+        ),
+      );
+    }
+    final archetypeSummary = archetypeLiftSummaryLine(archetypeEntries);
+    if (archetypeSummary != null) {
       lines.add(
         _growthLoopLine(
           Icons.category_outlined,
-          const Color(0xFF0D9488),
-          archetypeLine,
+          const Color(0xFF0EA5E9),
+          archetypeSummary,
         ),
       );
     }

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -185,37 +185,100 @@ String formatAgeAwareDate(String? iso, DateTime now, {int staleDays = 30}) {
   return stale ? '${dt.year}/$m/$d' : '$m/$d';
 }
 
-/// R24: perf-context 行(各 {archetype, score})から「Archetype lift」表示行を作る。
-/// #3953 で全投稿に content_archetype が記録され perf-context の rows に載る。
-/// n>=1 のバケットを平均スコア降順で並べ、行が1つも無ければ null(非表示)。
-/// ラベルは日本語(データレポート/ニュース要約/製品プロモ/不明)。
-String? xGrowthArchetypeLiftLine(List<dynamic>? rows) {
-  if (rows == null || rows.isEmpty) return null;
-  const labels = {
-    'data_report': 'データレポート',
-    'news_summary': 'ニュース要約',
-    'product_promo': '製品プロモ',
-  };
-  final buckets = <String, List<num>>{};
+// R25: R23 の内容アーキタイプ別実測(Archetype lift)を X成長ループ panel へ
+// 露出する純ロジック。perf-context rows(各 {archetype, score})から型別平均を
+// 出す。n>=2 のみ「実測」とみなし、n<2 は実測不足として勝ち型を主張しない
+// (edge の buildArchetypeLiftLine と同じ閾値)。旧ログ(archetype 欠落)は
+// unknown として保持しデータを捨てない。
+// 注: 初版(#3965 の xGrowthArchetypeLiftLine)は edge の実バケット値
+// news_briefing を news_summary と誤記しニュース要約行が全て「不明」へ落ちる
+// R19 型の契約バグがあり、この実装で置き換えた。
+
+/// アーキタイプ意味値 → 表示ラベル。キー集合は edge の正本
+/// supabase/functions/growth-hub/x_post_archetype.ts の ArchetypeBucket と
+/// 同期を保つこと(新バケット追加時はここへ日本語ラベルも足す。欠けると
+/// panel には raw キーがそのまま出る)。
+const Map<String, String> kArchetypeLiftLabels = <String, String>{
+  'data_report': 'データレポート型',
+  'news_briefing': 'ニュース要約型',
+  'product_promo': '製品紹介型',
+  'general': 'その他',
+  'unknown': '分類前(旧ログ)',
+};
+
+class ArchetypeLiftEntry {
+  final String archetype;
+  final int averageScore;
+  final int count;
+
+  const ArchetypeLiftEntry({
+    required this.archetype,
+    required this.averageScore,
+    required this.count,
+  });
+
+  /// n>=2 のときだけ平均を実測として扱う(1件平均は勝ち型に見せない)。
+  bool get measured => count >= 2;
+
+  String get label => kArchetypeLiftLabels[archetype] ?? archetype;
+}
+
+/// perf-context rows から型別の平均スコアを集計する。実測(n>=2)を平均降順で
+/// 先に、実測不足を後に並べ、unknown は常に最後(分類前の旧ログが勝ち型の
+/// 位置に見えないように)。
+List<ArchetypeLiftEntry> resolveArchetypeLift(List<dynamic>? rows) {
+  if (rows == null) return const [];
+  final totals = <String, double>{};
+  final counts = <String, int>{};
   for (final row in rows) {
     if (row is! Map) continue;
-    final raw = (row['archetype'] ?? '').toString().trim();
-    final key = labels.containsKey(raw) ? raw : 'unknown';
-    final score = row['score'];
-    if (score is! num) continue;
-    buckets.putIfAbsent(key, () => []).add(score);
+    var key = (row['archetype'] ?? '').toString().trim();
+    if (key.isEmpty) key = 'unknown';
+    final rawScore = row['score'];
+    final score = rawScore is num
+        ? rawScore.toDouble()
+        : double.tryParse('$rawScore') ?? 0;
+    totals[key] = (totals[key] ?? 0) + score;
+    counts[key] = (counts[key] ?? 0) + 1;
   }
-  if (buckets.isEmpty) return null;
-  final parts = buckets.entries
+  final entries = counts.keys
       .map(
-        (e) => (
-          label: labels[e.key] ?? '不明',
-          avg: (e.value.reduce((a, b) => a + b) / e.value.length).round(),
-          n: e.value.length,
+        (key) => ArchetypeLiftEntry(
+          archetype: key,
+          averageScore: (totals[key]! / counts[key]!).round(),
+          count: counts[key]!,
         ),
       )
-      .toList()
-    ..sort((a, b) => b.avg.compareTo(a.avg));
-  final body = parts.map((p) => '${p.label} 平均${p.avg} (n=${p.n})').join(' / ');
-  return '型別リフト: $body';
+      .toList();
+  int rank(ArchetypeLiftEntry e) {
+    if (e.archetype == 'unknown') return 2;
+    return e.measured ? 0 : 1;
+  }
+
+  entries.sort((a, b) {
+    final byRank = rank(a).compareTo(rank(b));
+    if (byRank != 0) return byRank;
+    return b.averageScore.compareTo(a.averageScore);
+  });
+  return entries;
+}
+
+/// 実測バケットが2種以上あるときだけ勝ちアーキタイプを返す(1種では比較に
+/// ならないため null = 勝ち型を主張しない)。
+ArchetypeLiftEntry? archetypeLiftWinner(List<ArchetypeLiftEntry> entries) {
+  final measured =
+      entries.where((e) => e.measured && e.archetype != 'unknown').toList();
+  if (measured.length < 2) return null;
+  return measured.first;
+}
+
+/// panel 表示用の1行サマリ。空データは null(行自体を出さない)。
+String? archetypeLiftSummaryLine(List<ArchetypeLiftEntry> entries) {
+  if (entries.isEmpty) return null;
+  final parts = entries.map(
+    (e) => e.measured
+        ? '${e.label} 平均${e.averageScore} (${e.count}件)'
+        : '${e.label} 実測不足 (${e.count}件)',
+  );
+  return '型別実測: ${parts.join(' / ')}';
 }

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -263,29 +263,70 @@ void main() {
     });
   });
 
-  group('R24 xGrowthArchetypeLiftLine', () {
-    test('buckets by archetype, sorted by avg desc, JP labels', () {
-      final rows = [
-        {'archetype': 'data_report', 'score': 8000},
-        {'archetype': 'news_summary', 'score': 791},
-        {'archetype': 'product_promo', 'score': 31},
-        {'archetype': 'product_promo', 'score': 29},
-      ];
-      final line = xGrowthArchetypeLiftLine(rows);
-      expect(line, isNotNull);
-      expect(line, contains('データレポート 平均8000 (n=1)'));
-      expect(line, contains('ニュース要約 平均791 (n=1)'));
-      expect(line, contains('製品プロモ 平均30 (n=2)'));
-      expect(line!.indexOf('データレポート'), lessThan(line.indexOf('製品プロモ')));
+  group('R25 archetype lift exposure (R23 measured axis to the panel)', () {
+    // 初版(#3965)は edge の実バケット値 news_briefing を news_summary と
+    // 誤記しニュース要約行が全て「分類前」へ落ちる契約バグがあった。本実装は
+    // edge x_post_archetype.ts の ArchetypeBucket と同一キーで固定する。
+    List<Map<String, dynamic>> rows() => [
+          {'archetype': 'data_report', 'score': 3200},
+          {'archetype': 'data_report', 'score': 2800},
+          {'archetype': 'news_briefing', 'score': 517},
+          {'archetype': 'news_briefing', 'score': 28},
+          {'archetype': 'product_promo', 'score': 10},
+          // 旧ログ(archetype 欠落)は unknown 保持。
+          {'score': 99},
+        ];
+
+    test('groups by archetype, measured first, unknown always last', () {
+      final entries = resolveArchetypeLift(rows());
+      expect(entries.map((e) => e.archetype).toList(), [
+        'data_report',
+        'news_briefing',
+        'product_promo',
+        'unknown',
+      ]);
+      expect(entries[0].averageScore, 3000);
+      expect(entries[0].measured, isTrue);
+      expect(entries[1].averageScore, 273);
+      // n=1 は実測扱いしない。
+      expect(entries[2].measured, isFalse);
     });
 
-    test('unknown archetype rows bucket as 不明; empty rows → null', () {
-      expect(xGrowthArchetypeLiftLine(null), isNull);
-      expect(xGrowthArchetypeLiftLine([]), isNull);
-      final line = xGrowthArchetypeLiftLine([
-        {'archetype': '', 'score': 10},
+    test('edge contract: news_briefing rows carry the JP label (not 分類前)', () {
+      final line = archetypeLiftSummaryLine(resolveArchetypeLift(rows()));
+      expect(line, contains('ニュース要約型 平均273 (2件)'));
+      expect(line, isNot(contains('news_briefing')));
+    });
+
+    test('winner needs >=2 measured buckets (honesty gate)', () {
+      expect(
+        archetypeLiftWinner(resolveArchetypeLift(rows()))?.archetype,
+        'data_report',
+      );
+      // 実測バケット1種では勝ち型を主張しない。
+      final single = resolveArchetypeLift([
+        {'archetype': 'news_briefing', 'score': 517},
+        {'archetype': 'news_briefing', 'score': 28},
+        {'archetype': 'product_promo', 'score': 10},
       ]);
-      expect(line, contains('不明 平均10 (n=1)'));
+      expect(archetypeLiftWinner(single), isNull);
+      // unknown だけが n>=2 でも勝ち型にしない。
+      final unknownOnly = resolveArchetypeLift([
+        {'score': 1},
+        {'score': 2},
+        {'archetype': 'general', 'score': 3},
+        {'archetype': 'general', 'score': 4},
+      ]);
+      expect(archetypeLiftWinner(unknownOnly), isNull);
+    });
+
+    test('summary line labels measured vs 実測不足, null when empty', () {
+      final line = archetypeLiftSummaryLine(resolveArchetypeLift(rows()));
+      expect(line, contains('データレポート型 平均3000 (2件)'));
+      expect(line, contains('製品紹介型 実測不足 (1件)'));
+      expect(line, contains('分類前(旧ログ)'));
+      expect(archetypeLiftSummaryLine(resolveArchetypeLift(null)), isNull);
+      expect(archetypeLiftSummaryLine(resolveArchetypeLift(const [])), isNull);
     });
   });
 }


### PR DESCRIPTION
## 概要 (R25: Archetype lift 露出の完成 — #3965 初版の置き換え)

R23 の内容アーキタイプ別実測を /admin X成長ループ panel へ露出する。並行着地した #3965 の初版 `xGrowthArchetypeLiftLine` を、契約バグ修正+誠実性ゲート付きの実装で置き換える。

## #3965 初版からの差分

1. **契約バグ修正 (R19 型)**: 初版はラベルキーを `news_summary` と誤記。edge の実バケット値は `news_briefing`(正本 `x_post_archetype.ts` の ArchetypeBucket)のため、**ニュース要約の全行が「不明」バケットに落ちて表示されていた**。キー集合を正本と同期し、回帰テストで固定
2. **誠実性ゲート (R17 規律)**: n≥2 のみ実測扱い(1件平均を勝ち型に見せない)。勝ち型主張は実測バケット2種以上のときだけ(edge `buildArchetypeLiftLine` と同閾値)。n<2 は「実測不足」明記
3. **勝ちアーキタイプ行**: 「勝ちアーキタイプ: データレポート型(平均N)— 次の投稿はこの型で」を意思決定行として追加
4. unknown(分類前の旧ログ)は常に最後尾 = 勝ち型の位置に見せない

## テスト
- flutter test: admin_dashboard_signals 34 green (新規4 = 集計順序/edge契約キー/勝ち型ゲート/表示行)
- dart format 差分なし

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Read-only admin panel line behind login-gated /admin; display logic covered by pure-logic VM tests (34 green); no data mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
