### PR TITLE
feat(x-share): R24b 家計トラッカー合成コア（データレポート型スコアボード）

### DIFF
--- a/lib/services/household_tracker_share_service.dart
+++ b/lib/services/household_tracker_share_service.dart
@@ -1,0 +1,99 @@
+// R24b: 家計ドメインの独自データ資産を、X で実測 8K インプを出した「データ
+// レポート型(スコアボード)」で定期投稿するための純合成ロジック。
+//
+// 設計原則:
+// - 決定的合成(LLM 不使用)。post A(選挙集計)と同じく、テンプレートに実データを
+//   流し込むだけにして捏造を構造的に不可能にする(R23 G2 教訓)。
+// - プライバシー規律: 公開するのは「件数・日数・方向・重大度」のみ。
+//   円金額・残高絶対値・口座名は絶対に出力しない。
+// - 投稿は growth-hub x.post 経由(variant=household_tracker /
+//   contentArchetype=data_report)で学習ループの計測対象にする。
+
+/// 家計トラッカー投稿の入力(すべて件数/日数/方向 — 金額は受け取らない)。
+class HouseholdTrackerSnapshot {
+  /// 監視対象の負債口座数。
+  final int monitoredAccounts;
+
+  /// 負債トレンド検出件数(内訳の合計と一致させる)。
+  final int balanceIncreasing;
+  final int negativeAmortization;
+  final int slowPayoff;
+
+  /// 重大度別件数。
+  final int criticalCount;
+  final int warningCount;
+
+  /// 給料日設定(毎月 N 日)。
+  final int salaryDay;
+
+  /// 集計時刻(JST 前提の DateTime を渡す)。
+  final DateTime now;
+
+  const HouseholdTrackerSnapshot({
+    required this.monitoredAccounts,
+    required this.balanceIncreasing,
+    required this.negativeAmortization,
+    required this.slowPayoff,
+    required this.criticalCount,
+    required this.warningCount,
+    required this.salaryDay,
+    required this.now,
+  });
+
+  int get totalFindings =>
+      balanceIncreasing + negativeAmortization + slowPayoff;
+}
+
+/// 次の給料日まで残り日数(当日は 0)。salaryDay は 1..28 の前提
+/// (AssetSalaryDayStore.clampDay 済みの値を渡す)。
+int daysUntilSalaryDay(DateTime now, int salaryDay) {
+  final today = DateTime(now.year, now.month, now.day);
+  var next = DateTime(now.year, now.month, salaryDay);
+  if (next.isBefore(today)) {
+    next = DateTime(now.year, now.month + 1, salaryDay);
+  }
+  return next.difference(today).inDays;
+}
+
+String _two(int v) => v.toString().padLeft(2, '0');
+
+/// スコアボード形式の投稿本文を決定的に合成する(post A と同型: 取得日時/主要
+/// 数値/内訳/アラート/カウントダウン)。金額は一切含まない。
+String buildHouseholdTrackerText(HouseholdTrackerSnapshot s) {
+  final d = s.now;
+  final dateLabel = '${d.year}/${_two(d.month)}/${_two(d.day)}';
+  final timestamp = '$dateLabel ${_two(d.hour)}:${_two(d.minute)}';
+  final remaining = daysUntilSalaryDay(s.now, s.salaryDay);
+  final lines = <String>[
+    '家計トラッカー $dateLabel（自分株式会社・実運用データ）',
+    '',
+    '取得日時: $timestamp',
+    '監視口座数: ${s.monitoredAccounts}',
+    '負債トレンド検出: ${s.totalFindings}件',
+    '内訳: 残高増加 ${s.balanceIncreasing} / 利息超過 ${s.negativeAmortization} / 長期化 ${s.slowPayoff}',
+    if (s.criticalCount > 0 || s.warningCount > 0)
+      'アラート: 🔴${s.criticalCount}件 / 🟡${s.warningCount}件'
+    else
+      'アラート: なし',
+    '給料日まで: あと$remaining日（毎月${s.salaryDay}日起点）',
+    '',
+    '※公開は件数・日数・方向のみ（金額は非公開）',
+  ];
+  return lines.join('\n');
+}
+
+/// growth-hub x.post へ渡す payload(純関数)。選挙トラッカー(R24)と同型の
+/// variant/archetype タグ付けで学習ループ(variant ranking / Archetype lift)の
+/// 計測対象にする。
+Map<String, dynamic> buildHouseholdTrackerPostPayload(
+  HouseholdTrackerSnapshot snapshot,
+) {
+  return {
+    'action': 'x.post',
+    'text': buildHouseholdTrackerText(snapshot),
+    'source': 'household_tracker',
+    'variant': 'household_tracker',
+    'contentArchetype': 'data_report',
+    'experimentKey': 'x_first_user_growth_10k',
+  };
+}

--- a/test/services/household_tracker_share_service_test.dart
+++ b/test/services/household_tracker_share_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/household_tracker_share_service.dart';
+
+void main() {
+  final snapshot = HouseholdTrackerSnapshot(
+    monitoredAccounts: 4,
+    balanceIncreasing: 1,
+    negativeAmortization: 0,
+    slowPayoff: 2,
+    criticalCount: 1,
+    warningCount: 2,
+    salaryDay: 25,
+    now: DateTime(2026, 7, 12, 9, 30),
+  );
+
+  group('R24b household tracker (data-report scoreboard)', () {
+    test('daysUntilSalaryDay: before/on/after the salary day', () {
+      expect(daysUntilSalaryDay(DateTime(2026, 7, 12), 25), 13);
+      expect(daysUntilSalaryDay(DateTime(2026, 7, 25), 25), 0);
+      // 給料日を過ぎたら翌月へ回る(7/26 → 8/25 = 30日)。
+      expect(daysUntilSalaryDay(DateTime(2026, 7, 26), 25), 30);
+      // 月末跨ぎ(12月→1月)。
+      expect(daysUntilSalaryDay(DateTime(2026, 12, 30), 25), 26);
+    });
+
+    test('scoreboard text: counts/days/directions only, no yen amounts', () {
+      final text = buildHouseholdTrackerText(snapshot);
+      expect(text, contains('家計トラッカー 2026/07/12'));
+      expect(text, contains('監視口座数: 4'));
+      expect(text, contains('負債トレンド検出: 3件'));
+      expect(text, contains('内訳: 残高増加 1 / 利息超過 0 / 長期化 2'));
+      expect(text, contains('アラート: 🔴1件 / 🟡2件'));
+      expect(text, contains('給料日まで: あと13日（毎月25日起点）'));
+      expect(text, contains('金額は非公開'));
+      // プライバシー規律: 円記号や金額パターンを含まない。
+      expect(text.contains('円'), isFalse);
+      expect(text.contains('¥'), isFalse);
+    });
+
+    test('no findings → アラート: なし', () {
+      final calm = HouseholdTrackerSnapshot(
+        monitoredAccounts: 3,
+        balanceIncreasing: 0,
+        negativeAmortization: 0,
+        slowPayoff: 0,
+        criticalCount: 0,
+        warningCount: 0,
+        salaryDay: 25,
+        now: DateTime(2026, 7, 12),
+      );
+      final text = buildHouseholdTrackerText(calm);
+      expect(text, contains('負債トレンド検出: 0件'));
+      expect(text, contains('アラート: なし'));
+    });
+
+    test('post payload: variant/archetype tagging (learning-loop ready)', () {
+      final p = buildHouseholdTrackerPostPayload(snapshot);
+      expect(p['action'], 'x.post');
+      expect(p['variant'], 'household_tracker');
+      expect(p['contentArchetype'], 'data_report');
+      expect(p['source'], 'household_tracker');
+      expect(p['text'], contains('家計トラッカー'));
+    });
+  });
+}


### PR DESCRIPTION
## R24b: 家計トラッカー（データレポート型）の合成コア — 実測8K形式の家計ドメイン版

R23 (#3953) が実測した「データレポート型 >> 製品プロモ（114-258倍）」の家計ドメイン適用・第1弾。post A（選挙集計・8K imp）と同じスコアボード形式で、アプリの実運用データを定期投稿するための**決定的合成コア**（LLM不使用＝捏造が構造的に不可能・R23 G2教訓）。

### 設計原則（プライバシー規律）
公開するのは**件数・日数・方向・重大度のみ**。円金額・残高絶対値・口座名は出力しない（テストで `円`/`¥` 不在をアサート）。

### 内容
- `HouseholdTrackerSnapshot`：監視口座数／負債トレンド内訳（残高増加・利息超過・長期化）／重大度件数／給料日設定（すべて件数・日数）
- 純 `buildHouseholdTrackerText`：post A同型のスコアボード（取得日時→主要数値→内訳→アラート→給料日カウントダウン→非公開注記）
- 純 `daysUntilSalaryDay`：給料日カウントダウン（当日0・月跨ぎ・年跨ぎテスト済み）
- 純 `buildHouseholdTrackerPostPayload`：growth-hub `x.post` payload（`variant=household_tracker`＋`contentArchetype=data_report`＝学習ループ計測対象、R24選挙payloadと同型）

`flutter test`: 4 green。Analyze clean、format fixpoint。純関数のみの追加（UIからの参照はまだ無し）。

### Follow-up（次PR）
資産ページに「家計トラッカーを投稿」ボタンを配線：`AssetDebtTrendAnalyzer` の insights と `AssetSalaryDayStore` から Snapshot を組み立て → 本payloadで投稿。定期化（Schedule cron）はデータ蓄積と初回実測後。

## Minimal E2E Gate

- Implementation-detail independent: tests assert the composed scoreboard text, the countdown math, and the x.post payload contract from inputs.
- Minimal scope: about 3 cases (countdown before/on/after + month/year rollover; scoreboard content incl. privacy assertions; zero-findings state; payload tagging).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: pure composer functions with no UI/route changes yet, verified by implementation-independent unit tests; the UI wiring PR will carry its own declaration.
