### PR TITLE
fix(social-commerce-hub): digital-wallet / gift-registry の nested metadata 誤読を修正

### DIFF
--- a/lib/models/gift_registry_item.dart
+++ b/lib/models/gift_registry_item.dart
@@ -1,0 +1,133 @@
+/// ギフトレジストリのアイテムモデル。
+///
+/// `social-commerce-hub` Edge Function の `gift.list` レスポンスを
+/// 解析する純データモデル (Flutter 依存なし → VM 単体テスト可能)。
+///
+/// EF レスポンス形状:
+/// ```json
+/// {
+///   "success": true,
+///   "items": [
+///     {
+///       "id": "...",
+///       "metadata": {
+///         "name": "コーヒーメーカー",
+///         "url": "https://...",
+///         "price": 8000,
+///         "priority": "high",
+///         "purchased": false,
+///         "user_id": "..."
+///       },
+///       "created_at": "2026-07-12T..."   // トップレベル列
+///     }
+///   ]
+/// }
+/// ```
+///
+/// 旧実装は `gift['name']` / `gift['price']` / `gift['reserved']` という
+/// flat キーを読んでいたが、これらは nested `metadata` 配下にあるため、
+/// 全アイテムが「ギフト N・価格非表示・予約済バッジ消失」という
+/// 捏造表示になっていた (`purchased` を `reserved` と誤読)。
+/// 本モデルは nested `metadata` から正しく読み取る。
+library;
+
+num? _toNumOrNull(dynamic value) {
+  if (value == null) return null;
+  if (value is num) return value;
+  return num.tryParse(value.toString());
+}
+
+/// ギフト 1 件。
+class GiftRegistryItem {
+  const GiftRegistryItem({
+    required this.name,
+    required this.url,
+    required this.price,
+    required this.priority,
+    required this.purchased,
+    required this.createdAt,
+  });
+
+  /// 品名。
+  final String name;
+
+  /// 商品 URL (空文字の場合あり)。
+  final String url;
+
+  /// 価格 (JPY)。未設定なら null。
+  final num? price;
+
+  /// 優先度 ('high' / 'medium' / 'low')。
+  final String priority;
+
+  /// 購入 (予約) 済みなら true。
+  final bool purchased;
+
+  /// 生の ISO タイムスタンプ (空文字の場合あり)。
+  final String createdAt;
+
+  bool get hasPrice => price != null;
+
+  /// EF の hub_data 行 (nested metadata) から 1 件を構築する。
+  /// 後方互換のため flat キーもフォールバックとして読む。
+  factory GiftRegistryItem.fromMap(Map<String, dynamic> raw) {
+    final metadata = raw['metadata'];
+    final meta = metadata is Map
+        ? metadata.cast<String, dynamic>()
+        : const <String, dynamic>{};
+
+    final name =
+        (meta['name'] ?? meta['title'] ?? raw['name'] ?? raw['title'] ?? '')
+            .toString()
+            .trim();
+    final url = (meta['url'] ?? raw['url'] ?? '').toString().trim();
+    final price = _toNumOrNull(meta['price'] ?? raw['price'] ?? raw['amount']);
+    final priority =
+        (meta['priority'] ?? raw['priority'] ?? 'medium').toString().trim();
+    // EF は `purchased` を使う。旧 UI の `reserved` も後方互換で読む。
+    final purchased = (meta['purchased'] ?? raw['purchased'] ?? raw['reserved'])
+            ?.toString() ==
+        'true';
+    final createdAt =
+        (raw['created_at'] ?? meta['created_at'] ?? '').toString();
+
+    return GiftRegistryItem(
+      name: name,
+      url: url,
+      price: price,
+      priority: priority.isEmpty ? 'medium' : priority,
+      purchased: purchased,
+      createdAt: createdAt,
+    );
+  }
+}
+
+/// EF レスポンス (`{items|gifts}` / 生の List / null) を頑健に解析する。
+List<GiftRegistryItem> parseGiftRegistryItems(dynamic data) {
+  List<Map<String, dynamic>> rawList;
+  if (data is Map) {
+    final map = data.cast<String, dynamic>();
+    final list = map['gifts'] ?? map['items'];
+    rawList = list is List
+        ? list.whereType<Map>().map((e) => e.cast<String, dynamic>()).toList()
+        : <Map<String, dynamic>>[];
+  } else if (data is List) {
+    rawList =
+        data.whereType<Map>().map((e) => e.cast<String, dynamic>()).toList();
+  } else {
+    rawList = <Map<String, dynamic>>[];
+  }
+  return rawList.map(GiftRegistryItem.fromMap).toList();
+}
+
+/// 価格を桁区切り付きの円表示に整形する ('8,000' 等)。
+String formatGiftPrice(num value) {
+  final digits = value.round().toString();
+  final buffer = StringBuffer();
+  final len = digits.length;
+  for (var i = 0; i < len; i++) {
+    if (i > 0 && (len - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+  return buffer.toString();
+}

--- a/lib/models/wallet_summary.dart
+++ b/lib/models/wallet_summary.dart
@@ -1,0 +1,193 @@
+/// デジタルウォレットの集計モデル。
+///
+/// `social-commerce-hub` Edge Function の `wallet.balance` レスポンスを
+/// 解析する純データモデル (Flutter 依存なし → VM 単体テスト可能)。
+///
+/// EF レスポンス形状:
+/// ```json
+/// {
+///   "success": true,
+///   "balance": 1500,
+///   "currency": "JPY",
+///   "transactions": [
+///     {
+///       "id": "...",
+///       "metadata": {
+///         "amount": 2000,        // 入金は正 / 支払いは負
+///         "type": "deposit",     // deposit | payment
+///         "method": "card",      // 入金の資金源
+///         "currency": "JPY",
+///         "user_id": "..."
+///       },
+///       "created_at": "2026-07-12T..."   // トップレベル列
+///     }
+///   ]
+/// }
+/// ```
+///
+/// 旧実装は `tx['amount']` / `tx['type']` / `tx['description']` という
+/// 存在しない flat キーを読んでいたため、全取引行が
+/// 「取引 N / ¥0 / 支出(赤)」という捏造表示になり、
+/// さらに `balance` は取得しても一切表示されていなかった。
+/// 本モデルは nested `metadata` から正しく読み取り、金額の符号で
+/// 入出金を判定する。
+library;
+
+num _toNum(dynamic value) {
+  if (value is num) return value;
+  return num.tryParse(value?.toString() ?? '') ?? 0;
+}
+
+/// ウォレット取引 1 件。
+class WalletTransaction {
+  const WalletTransaction({
+    required this.amount,
+    required this.type,
+    required this.note,
+    required this.createdAt,
+  });
+
+  /// 符号付き金額 (JPY)。正 = 入金 / 負 = 支払い。
+  final num amount;
+
+  /// 取引種別。`deposit` / `payment` など。空文字の場合あり。
+  final String type;
+
+  /// 補足 (`reason` / 入金の `method` / 支払いの `to`)。空文字の場合あり。
+  final String note;
+
+  /// 生の ISO タイムスタンプ (空文字の場合あり)。
+  final String createdAt;
+
+  /// 入金 (money in) なら true、支払い (money out) なら false。
+  /// 通常は金額の符号で判定し、0 円だけは `type` で補完する。
+  bool get isCredit {
+    if (amount > 0) return true;
+    if (amount < 0) return false;
+    return type != 'payment';
+  }
+
+  /// 人が読める表示ラベル ('入金・card' / '支払い・alice' 等)。
+  String get label {
+    final base = _typeLabel();
+    return note.isEmpty ? base : '$base・$note';
+  }
+
+  String _typeLabel() {
+    switch (type) {
+      case 'deposit':
+        return '入金';
+      case 'payment':
+        return '支払い';
+      default:
+        // 種別不明時は符号で補完する。
+        return isCredit ? '入金' : '支払い';
+    }
+  }
+
+  /// EF の hub_data 行 (nested metadata) から 1 件を構築する。
+  /// 後方互換のため flat キーもフォールバックとして読む。
+  factory WalletTransaction.fromMap(Map<String, dynamic> raw) {
+    final metadata = raw['metadata'];
+    final meta = metadata is Map
+        ? metadata.cast<String, dynamic>()
+        : const <String, dynamic>{};
+
+    final rawAmount = meta['amount'] ?? raw['amount'] ?? 0;
+    final type = (meta['type'] ?? raw['type'] ?? '').toString().trim();
+    final note = (meta['reason'] ??
+            meta['method'] ??
+            meta['to'] ??
+            raw['reason'] ??
+            raw['method'] ??
+            raw['to'] ??
+            '')
+        .toString()
+        .trim();
+    final createdAt =
+        (raw['created_at'] ?? meta['created_at'] ?? '').toString();
+
+    return WalletTransaction(
+      amount: _toNum(rawAmount),
+      type: type,
+      note: note,
+      createdAt: createdAt,
+    );
+  }
+}
+
+/// 残高 + 取引履歴のまとめ。
+class WalletSummary {
+  const WalletSummary({required this.balance, required this.transactions});
+
+  /// 合計残高 (JPY)。
+  final num balance;
+
+  /// 取引履歴 (新しい順)。
+  final List<WalletTransaction> transactions;
+
+  bool get isEmpty => transactions.isEmpty;
+
+  static const WalletSummary empty =
+      WalletSummary(balance: 0, transactions: <WalletTransaction>[]);
+
+  /// EF レスポンス (`{balance, transactions}` / 生の List / null) を頑健に解析する。
+  factory WalletSummary.fromResponse(dynamic data) {
+    List<Map<String, dynamic>> rawList;
+    num? balance;
+
+    if (data is Map) {
+      final map = data.cast<String, dynamic>();
+      final txns = map['transactions'];
+      rawList = txns is List
+          ? txns.whereType<Map>().map((e) => e.cast<String, dynamic>()).toList()
+          : <Map<String, dynamic>>[];
+      // balance:0 は正当な残高なので「キー存在」で判定する (null のみ未取得扱い)。
+      if (map['balance'] != null) balance = _toNum(map['balance']);
+    } else if (data is List) {
+      rawList =
+          data.whereType<Map>().map((e) => e.cast<String, dynamic>()).toList();
+    } else {
+      rawList = <Map<String, dynamic>>[];
+    }
+
+    final transactions = rawList.map(WalletTransaction.fromMap).toList();
+    // EF が balance を省略した場合 (生 List 等) のみ履歴から算出する。
+    balance ??= transactions.fold<num>(0, (sum, t) => sum + t.amount);
+
+    return WalletSummary(balance: balance, transactions: transactions);
+  }
+}
+
+/// 金額を桁区切り付きの円表示に整形する ('1,500' 等)。
+/// 整数は小数点なし、非整数は小数第 2 位まで。負号は呼び出し側で付ける想定。
+String formatWalletYen(num value) {
+  final isNegative = value < 0;
+  final abs = value.abs();
+  final body = abs == abs.roundToDouble()
+      ? _addThousands(abs.round().toString())
+      : abs.toStringAsFixed(2);
+  return '${isNegative ? '-' : ''}$body';
+}
+
+String _addThousands(String digits) {
+  final buffer = StringBuffer();
+  final len = digits.length;
+  for (var i = 0; i < len; i++) {
+    if (i > 0 && (len - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+  return buffer.toString();
+}
+
+/// ISO タイムスタンプを 'yyyy/MM/dd HH:mm' (ローカル) に整形する。
+/// パース不能なら生文字列をそのまま返す。
+String formatWalletTimestamp(String raw) {
+  if (raw.isEmpty) return '';
+  final dt = DateTime.tryParse(raw);
+  if (dt == null) return raw;
+  final local = dt.toLocal();
+  String two(int n) => n.toString().padLeft(2, '0');
+  return '${local.year}/${two(local.month)}/${two(local.day)} '
+      '${two(local.hour)}:${two(local.minute)}';
+}

--- a/lib/pages/digital_wallet_page.dart
+++ b/lib/pages/digital_wallet_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/wallet_summary.dart';
+
 /// デジタルウォレットページ
-/// digital-wallet Edge Function と連携して残高・取引履歴を管理
+/// social-commerce-hub Edge Function (wallet.balance) と連携して
+/// 残高・取引履歴を管理する。
 class DigitalWalletPage extends StatefulWidget {
   const DigitalWalletPage({super.key});
 
@@ -13,8 +16,9 @@ class DigitalWalletPage extends StatefulWidget {
 class _DigitalWalletPageState extends State<DigitalWalletPage> {
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
+  bool _isSignedIn = true;
   String? _errorMessage;
-  List<Map<String, dynamic>> _transactions = [];
+  WalletSummary _summary = WalletSummary.empty;
 
   @override
   void initState() {
@@ -24,11 +28,15 @@ class _DigitalWalletPageState extends State<DigitalWalletPage> {
 
   Future<void> _fetchTransactions() async {
     if (_supabase.auth.currentUser == null) {
-      setState(() => _isLoading = false);
+      setState(() {
+        _isLoading = false;
+        _isSignedIn = false;
+      });
       return;
     }
     setState(() {
       _isLoading = true;
+      _isSignedIn = true;
       _errorMessage = null;
     });
     try {
@@ -36,17 +44,8 @@ class _DigitalWalletPageState extends State<DigitalWalletPage> {
         'social-commerce-hub',
         body: {'action': 'wallet.balance'},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['transactions'] is List) {
-        setState(
-          () => _transactions =
-              (data['transactions'] as List).cast<Map<String, dynamic>>(),
-        );
-      } else if (data is List) {
-        setState(() => _transactions = data.cast<Map<String, dynamic>>());
-      } else {
-        setState(() => _transactions = []);
-      }
+      final summary = WalletSummary.fromResponse(response.data);
+      if (mounted) setState(() => _summary = summary);
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = '取引履歴の取得に失敗しました: $e');
@@ -68,79 +67,7 @@ class _DigitalWalletPageState extends State<DigitalWalletPage> {
           ),
         ],
       ),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : _errorMessage != null
-              ? Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Icon(
-                        Icons.error_outline,
-                        size: 48,
-                        color: Color(0xFFE53935),
-                      ),
-                      const SizedBox(height: 16),
-                      Text(
-                        _errorMessage!,
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          color: Color(0xFFE53935),
-                          height: 1.5,
-                        ),
-                      ),
-                      const SizedBox(height: 16),
-                      ElevatedButton(
-                        onPressed: _fetchTransactions,
-                        child: const Text('再試行'),
-                      ),
-                    ],
-                  ),
-                )
-              : _transactions.isEmpty
-                  ? const Center(child: Text('取引履歴はありません'))
-                  : ListView.builder(
-                      padding: const EdgeInsets.all(16),
-                      itemCount: _transactions.length,
-                      itemBuilder: (context, index) {
-                        final tx = _transactions[index];
-                        final description =
-                            tx['description']?.toString() ?? '取引 ${index + 1}';
-                        final amount = tx['amount']?.toString() ?? '0';
-                        final type = tx['type']?.toString() ?? 'debit';
-                        return Card(
-                          margin: const EdgeInsets.only(bottom: 12),
-                          child: ListTile(
-                            leading: Icon(
-                              type == 'credit'
-                                  ? Icons.arrow_downward
-                                  : Icons.arrow_upward,
-                              color: type == 'credit'
-                                  ? const Color(0xFF4CAF50)
-                                  : const Color(0xFFE53935),
-                            ),
-                            title: Text(
-                              description,
-                              style: const TextStyle(
-                                fontWeight: FontWeight.bold,
-                                height: 1.5,
-                              ),
-                            ),
-                            subtitle: Text(tx['created_at']?.toString() ?? ''),
-                            trailing: Text(
-                              '¥$amount',
-                              style: TextStyle(
-                                color: type == 'credit'
-                                    ? const Color(0xFF4CAF50)
-                                    : const Color(0xFFE53935),
-                                fontWeight: FontWeight.bold,
-                                height: 1.5,
-                              ),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
+      body: _buildBody(),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -149,6 +76,144 @@ class _DigitalWalletPageState extends State<DigitalWalletPage> {
         },
         icon: const Icon(Icons.send),
         label: const Text('送金'),
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (!_isSignedIn) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'ログインすると残高と取引履歴が表示されます',
+            textAlign: TextAlign.center,
+            style: TextStyle(height: 1.5),
+          ),
+        ),
+      );
+    }
+    if (_errorMessage != null) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Color(0xFFE53935)),
+            const SizedBox(height: 16),
+            Text(
+              _errorMessage!,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Color(0xFFE53935), height: 1.5),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _fetchTransactions,
+              child: const Text('再試行'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _fetchTransactions,
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _buildBalanceCard(),
+          const SizedBox(height: 20),
+          const Text(
+            '取引履歴',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+          ),
+          const SizedBox(height: 8),
+          if (_summary.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 32),
+              child: Center(child: Text('取引履歴はありません')),
+            )
+          else
+            ..._summary.transactions.map(_buildTransactionTile),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBalanceCard() {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 28, horizontal: 20),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          gradient: const LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [Color(0xFF1565C0), Color(0xFF42A5F5)],
+          ),
+        ),
+        child: Column(
+          children: [
+            const Text(
+              '現在の残高',
+              style: TextStyle(color: Colors.white, fontSize: 14),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              children: [
+                const Text(
+                  '¥',
+                  style: TextStyle(color: Colors.white, fontSize: 22),
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  formatWalletYen(_summary.balance),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 40,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTransactionTile(WalletTransaction tx) {
+    final createdAt = formatWalletTimestamp(tx.createdAt);
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        leading: Icon(
+          tx.isCredit ? Icons.arrow_downward : Icons.arrow_upward,
+          color:
+              tx.isCredit ? const Color(0xFF4CAF50) : const Color(0xFFE53935),
+        ),
+        title: Text(
+          tx.label,
+          style: const TextStyle(fontWeight: FontWeight.bold, height: 1.5),
+        ),
+        subtitle: createdAt.isEmpty ? null : Text(createdAt),
+        trailing: Text(
+          '${tx.isCredit ? '+' : '-'}¥${formatWalletYen(tx.amount.abs())}',
+          style: TextStyle(
+            color:
+                tx.isCredit ? const Color(0xFF4CAF50) : const Color(0xFFE53935),
+            fontWeight: FontWeight.bold,
+            height: 1.5,
+          ),
+        ),
       ),
     );
   }

--- a/lib/pages/gift_registry_page.dart
+++ b/lib/pages/gift_registry_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/gift_registry_item.dart';
+
 /// ギフトレジストリページ
-/// gift-registry Edge Function と連携してギフトリストを管理
+/// social-commerce-hub Edge Function (gift.list) と連携してギフトリストを管理
 class GiftRegistryPage extends StatefulWidget {
   const GiftRegistryPage({super.key});
 
@@ -14,7 +16,7 @@ class _GiftRegistryPageState extends State<GiftRegistryPage> {
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
   String? _errorMessage;
-  List<Map<String, dynamic>> _gifts = [];
+  List<GiftRegistryItem> _gifts = [];
 
   @override
   void initState() {
@@ -36,19 +38,8 @@ class _GiftRegistryPageState extends State<GiftRegistryPage> {
         'social-commerce-hub',
         body: {'action': 'gift.list'},
       );
-      final data = response.data;
-      final giftList = data is Map<String, dynamic>
-          ? (data['gifts'] ?? data['items'])
-          : null;
-      if (giftList is List) {
-        setState(
-          () => _gifts = giftList.cast<Map<String, dynamic>>(),
-        );
-      } else if (data is List) {
-        setState(() => _gifts = data.cast<Map<String, dynamic>>());
-      } else {
-        setState(() => _gifts = []);
-      }
+      final gifts = parseGiftRegistryItems(response.data);
+      if (mounted) setState(() => _gifts = gifts);
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = 'ギフトリストの取得に失敗しました: $e');
@@ -127,11 +118,8 @@ class _GiftRegistryPageState extends State<GiftRegistryPage> {
                       itemBuilder: (context, index) {
                         final gift = _gifts[index];
                         final title =
-                            (gift['title'] ?? gift['name'] ?? 'ギフト $index')
-                                .toString();
-                        final price =
-                            (gift['price'] ?? gift['amount'] ?? '').toString();
-                        final reserved = gift['reserved'] == true;
+                            gift.name.isEmpty ? 'ギフト ${index + 1}' : gift.name;
+                        final reserved = gift.purchased;
                         return Card(
                           child: ListTile(
                             leading: Icon(
@@ -141,7 +129,9 @@ class _GiftRegistryPageState extends State<GiftRegistryPage> {
                                   : const Color(0xFFFF6B35),
                             ),
                             title: Text(title),
-                            subtitle: price.isNotEmpty ? Text('¥$price') : null,
+                            subtitle: gift.hasPrice
+                                ? Text('¥${formatGiftPrice(gift.price!)}')
+                                : null,
                             trailing: reserved
                                 ? const Chip(
                                     label: Text('予約済'),

--- a/test/gift_registry_item_test.dart
+++ b/test/gift_registry_item_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/gift_registry_item.dart';
+
+void main() {
+  group('parseGiftRegistryItems', () {
+    test('parses nested metadata items from EF response', () {
+      final items = parseGiftRegistryItems({
+        'success': true,
+        'items': [
+          {
+            'id': 'a',
+            'metadata': {
+              'name': 'コーヒーメーカー',
+              'url': 'https://example.com/a',
+              'price': 8000,
+              'priority': 'high',
+              'purchased': false,
+              'user_id': 'u1',
+            },
+            'created_at': '2026-07-10T09:00:00Z',
+          },
+          {
+            'id': 'b',
+            'metadata': {
+              'name': 'ワイングラス',
+              'price': 3500,
+              'priority': 'low',
+              'purchased': true,
+              'user_id': 'u1',
+            },
+            'created_at': '2026-07-11T12:00:00Z',
+          },
+        ],
+      });
+
+      expect(items.length, 2);
+
+      final first = items[0];
+      expect(first.name, 'コーヒーメーカー');
+      expect(first.url, 'https://example.com/a');
+      expect(first.price, 8000);
+      expect(first.priority, 'high');
+      expect(first.purchased, isFalse);
+
+      final second = items[1];
+      expect(second.name, 'ワイングラス');
+      expect(second.price, 3500);
+      expect(second.purchased, isTrue);
+    });
+
+    test(
+        'does NOT fabricate "ギフト N" / missing price / lost 予約済 badge '
+        '(regression: old code read flat name/price/reserved)', () {
+      // 旧実装は gift['name'] / gift['price'] / gift['reserved'] を読み、
+      // 存在しないため全行で品名捏造・価格消失・購入バッジ消失していた。
+      final items = parseGiftRegistryItems({
+        'items': [
+          {
+            'metadata': {'name': 'ギフトカード', 'price': 5000, 'purchased': true},
+            'created_at': '2026-07-12T00:00:00Z',
+          },
+        ],
+      });
+      final item = items.single;
+      expect(item.name, 'ギフトカード', reason: 'metadata.name を読むべき');
+      expect(
+        item.name,
+        isNot(startsWith('ギフト ')),
+        reason: 'index ベースの捏造品名を出してはならない',
+      );
+      expect(item.price, 5000, reason: 'metadata.price を読むべき');
+      expect(item.hasPrice, isTrue);
+      expect(item.purchased, isTrue, reason: 'metadata.purchased を読むべき');
+    });
+
+    test('accepts legacy flat keys and "gifts" wrapper', () {
+      final items = parseGiftRegistryItems({
+        'gifts': [
+          {'name': '旧形式', 'price': '1200', 'reserved': true, 'created_at': ''},
+        ],
+      });
+      final item = items.single;
+      expect(item.name, '旧形式');
+      expect(item.price, 1200);
+      expect(item.purchased, isTrue, reason: 'legacy reserved も予約済とみなす');
+    });
+
+    test('leaves price null when absent (no ¥0 fabrication)', () {
+      final items = parseGiftRegistryItems({
+        'items': [
+          {
+            'metadata': {'name': '値段未定'},
+            'created_at': '',
+          },
+        ],
+      });
+      final item = items.single;
+      expect(item.price, isNull);
+      expect(item.hasPrice, isFalse);
+      expect(item.priority, 'medium', reason: '既定の優先度');
+    });
+
+    test('handles null / malformed responses gracefully', () {
+      expect(parseGiftRegistryItems(null), isEmpty);
+      expect(parseGiftRegistryItems('oops'), isEmpty);
+      expect(parseGiftRegistryItems(<dynamic>[]), isEmpty);
+    });
+
+    test('parses a bare list response', () {
+      final items = parseGiftRegistryItems([
+        {
+          'metadata': {'name': 'A', 'price': 100},
+          'created_at': '',
+        },
+      ]);
+      expect(items.single.name, 'A');
+      expect(items.single.price, 100);
+    });
+  });
+
+  group('formatGiftPrice', () {
+    test('adds thousands separators', () {
+      expect(formatGiftPrice(8000), '8,000');
+      expect(formatGiftPrice(1000000), '1,000,000');
+      expect(formatGiftPrice(500), '500');
+    });
+  });
+}

--- a/test/wallet_summary_test.dart
+++ b/test/wallet_summary_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/wallet_summary.dart';
+
+void main() {
+  group('WalletSummary.fromResponse', () {
+    test('parses balance and nested metadata transactions from EF response',
+        () {
+      final summary = WalletSummary.fromResponse({
+        'success': true,
+        'balance': 1500,
+        'currency': 'JPY',
+        'transactions': [
+          {
+            'id': 'a',
+            'metadata': {
+              'amount': 2000,
+              'type': 'deposit',
+              'method': 'card',
+              'currency': 'JPY',
+              'user_id': 'u1',
+            },
+            'created_at': '2026-07-10T09:00:00Z',
+          },
+          {
+            'id': 'b',
+            'metadata': {
+              'amount': -500,
+              'type': 'payment',
+              'to': 'alice',
+              'currency': 'JPY',
+              'user_id': 'u1',
+            },
+            'created_at': '2026-07-11T12:00:00Z',
+          },
+        ],
+      });
+
+      expect(summary.balance, 1500);
+      expect(summary.transactions.length, 2);
+
+      final deposit = summary.transactions[0];
+      expect(deposit.amount, 2000);
+      expect(deposit.type, 'deposit');
+      expect(deposit.note, 'card');
+      expect(deposit.isCredit, isTrue);
+      expect(deposit.label, '入金・card');
+
+      final payment = summary.transactions[1];
+      expect(payment.amount, -500);
+      expect(payment.type, 'payment');
+      expect(payment.note, 'alice');
+      expect(payment.isCredit, isFalse);
+      expect(payment.label, '支払い・alice');
+    });
+
+    test(
+        'does NOT fabricate ¥0 / debit rows (regression: old code read '
+        'flat tx[amount]/tx[type]/tx[description])', () {
+      // 旧実装は tx['amount'] / tx['type'] / tx['description'] を読み、
+      // 存在しないため全行「取引 N / ¥0 / 支出(赤)」を描画していた。
+      final summary = WalletSummary.fromResponse({
+        'balance': 2000,
+        'transactions': [
+          {
+            'metadata': {'amount': 2000, 'type': 'deposit', 'method': 'bank'},
+            'created_at': '2026-07-12T00:00:00Z',
+          },
+        ],
+      });
+      final tx = summary.transactions.single;
+      expect(tx.amount, 2000, reason: 'metadata.amount を読むべき');
+      expect(tx.amount, isNot(0), reason: '捏造の 0 を出してはならない');
+      expect(tx.isCredit, isTrue, reason: '入金は緑・下矢印であるべき');
+      expect(tx.label, contains('入金'));
+    });
+
+    test('derives balance from transactions when EF omits balance (bare list)',
+        () {
+      final summary = WalletSummary.fromResponse([
+        {
+          'metadata': {'amount': 3000, 'type': 'deposit'},
+          'created_at': '2026-07-01T00:00:00Z',
+        },
+        {
+          'metadata': {'amount': -1000, 'type': 'payment'},
+          'created_at': '2026-07-02T00:00:00Z',
+        },
+      ]);
+      expect(summary.balance, 2000);
+      expect(summary.transactions.length, 2);
+    });
+
+    test('treats explicit balance:0 as valid (not derived)', () {
+      final summary = WalletSummary.fromResponse({
+        'balance': 0,
+        'transactions': <dynamic>[],
+      });
+      expect(summary.balance, 0);
+      expect(summary.isEmpty, isTrue);
+    });
+
+    test('handles null / malformed responses gracefully', () {
+      expect(WalletSummary.fromResponse(null).isEmpty, isTrue);
+      expect(WalletSummary.fromResponse(null).balance, 0);
+      expect(WalletSummary.fromResponse('oops').isEmpty, isTrue);
+    });
+
+    test('parses numeric strings and falls back to legacy flat keys', () {
+      final summary = WalletSummary.fromResponse({
+        'balance': '750',
+        'transactions': [
+          // legacy flat shape without nested metadata
+          {'amount': '750', 'type': 'deposit', 'created_at': ''},
+        ],
+      });
+      expect(summary.balance, 750);
+      expect(summary.transactions.single.amount, 750);
+      expect(summary.transactions.single.type, 'deposit');
+    });
+
+    test('label falls back to sign when type is missing/unknown', () {
+      final credit = WalletTransaction.fromMap({
+        'metadata': {'amount': 500},
+        'created_at': '',
+      });
+      expect(credit.label, '入金');
+
+      final debit = WalletTransaction.fromMap({
+        'metadata': {'amount': -500},
+        'created_at': '',
+      });
+      expect(debit.label, '支払い');
+    });
+
+    test('reads nested reason and uses type to classify zero amounts', () {
+      final payment = WalletTransaction.fromMap({
+        'metadata': {
+          'amount': 0,
+          'type': 'payment',
+          'reason': '返金調整',
+        },
+      });
+      final deposit = WalletTransaction.fromMap({
+        'metadata': {'amount': 0, 'type': 'deposit'},
+      });
+
+      expect(payment.note, '返金調整');
+      expect(payment.label, '支払い・返金調整');
+      expect(payment.isCredit, isFalse);
+      expect(deposit.isCredit, isTrue);
+    });
+  });
+
+  group('formatWalletYen', () {
+    test('adds thousands separators for integers', () {
+      expect(formatWalletYen(1500), '1,500');
+      expect(formatWalletYen(1000000), '1,000,000');
+      expect(formatWalletYen(0), '0');
+      expect(formatWalletYen(999), '999');
+    });
+
+    test('renders negatives and decimals', () {
+      expect(formatWalletYen(-1200), '-1,200');
+      expect(formatWalletYen(12.5), '12.50');
+    });
+  });
+
+  group('formatWalletTimestamp', () {
+    test('formats ISO timestamp to yyyy/MM/dd HH:mm', () {
+      // toLocal() depends on host timezone, so assert on the shape only.
+      final formatted = formatWalletTimestamp('2026-07-12T03:45:00Z');
+      expect(
+        RegExp(r'^\d{4}/\d{2}/\d{2} \d{2}:\d{2}$').hasMatch(formatted),
+        isTrue,
+        reason: 'got: $formatted',
+      );
+    });
+
+    test('returns empty string for empty input', () {
+      expect(formatWalletTimestamp(''), '');
+    });
+
+    test('returns raw string when unparseable', () {
+      expect(formatWalletTimestamp('not-a-date'), 'not-a-date');
+    });
+  });
+}


### PR DESCRIPTION
## 概要

社内ハブ EF (`social-commerce-hub`) は各レコードを `hub_data` 行として返し、実フィールドはすべて nested `metadata` 配下に入る (`id` / `created_at` のみトップレベル列)。2 ページが存在しない **flat キー**を読んでいたため、全行が捏造値で描画されていた。[PR #3948](https://github.com/kanta13jp1/my_web_app/pull/3948) (loyalty) と同型の **UI ↔ EF 応答契約のキー不一致**バグ。

Dart のみの変更 (EF は既に正しい)。

### 1. digital_wallet_page (`wallet.balance`)
- **旧**: `tx['amount']` / `tx['type']` / `tx['description']` を読取 → 実体は `metadata.amount` / `metadata.type` / (`description` は存在せず) → **全取引が「取引 N / ¥0 / 支出(赤)」に固定**。さらに応答の `balance` は取得しても**一切表示されていなかった**。
- **修正**: 純モデル `WalletSummary` / `WalletTransaction` を `lib/models/wallet_summary.dart` に抽出 (Flutter 依存ゼロ)。nested `metadata.amount` / `metadata.reason` を読み、**金額の符号**で入出金を判定 (0 円のみ種別で補完)。残高カードを追加。`balance:0` は正当な残高として保持し、生 List 応答のみ履歴から算出。

### 2. gift_registry_page (`gift.list`)
- **旧**: `gift['name']` / `gift['price']` / `gift['reserved']` を読取 → 実体は `metadata.name` / `metadata.price` / `metadata.purchased` → **品名は「ギフト N」捏造・価格は非表示・予約済バッジ消失** (`purchased` を存在しない `reserved` と誤読)。
- **修正**: 純モデル `GiftRegistryItem` + `parseGiftRegistryItems` を `lib/models/gift_registry_item.dart` に抽出。nested `metadata` から正しく読取。価格未設定は `null` を保持し ¥0 を捏造しない。

### テスト
捏造 0 / 捏造品名を出さない回帰テストを追加 (wallet 13 + gift 7 + 既存 loyalty 12 = 計 32 ケース、全緑)。`flutter test test/wallet_summary_test.dart test/gift_registry_item_test.dart` で確認。

## 横展開調査 (棚卸し結果 / 本 PR 対象外・別 PR 候補)

同 `listItems` 契約を使う他ページを敵対的レビューで棚卸しした結果、**同型の nested-metadata 誤読が 10 ページ**残存 (severity 順):

| ページ | action | 症状 |
|---|---|---|
| customer_feedback | `feedback.list` | `item.toString()` に落ち、**生の行 Map 全体**を見出しに描画 (最重症) |
| inventory_barcode | `inventory.list` | 名称捏造 + qty=0 ⇒ **全品「在庫不足」赤バナー** |
| social_feed | `feed.timeline` | 投稿本文が全て空・いいね/コメント数消失 |
| social_media_scheduler | `schedule.list` | カード見出し全て空・予約時刻が作成時刻に化ける |
| event_ticketing | `event.list` | 名称捏造 + **全イベント「残 0 枚」** |
| auction_marketplace | `auction.list` | 名称捏造・`current_bid`/`ends_at` を誤キーで読み消失 |
| affiliate_marketing | `affiliate.list_links` | 全カード「クリック: 0 / 報酬: ¥0」 |
| elearning_course_manager | `course.list` | 名称捏造・レベル消失 (+ `course.progress` の応答キー不一致で学習中タブ空) |
| language_learning | `lang.list_decks`/`lang.list_cards` | デッキ名・カード表裏が空 (+ 応答キー drift 多数) |
| budget_financial_planner | `budget.summary` ほか | カテゴリ照合不能で予算常に 0 (+ 無効 action `'get'` / 応答キー不一致) |

加えて `donation_crowdfunding` / `parking_reservation` は **別 EF (`lifestyle-hub`)** を使うが同じ flat-key 読取パターンあり → `lifestyle-hub` 契約の別途監査を推奨。

> これらは 1 ページ = 1 純モデル + 回帰テストの同型修正になるため、レビュー容易性を優先し**別 PR (数本にバッチ)** で対応する想定。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純データモデル (Flutter 依存ゼロ) の VM 単体テスト 32 ケースで契約解析を網羅。UI はログイン必須かつ EF 応答依存で headless E2E harness 不在のため exception。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
