### PR TITLE
feat(x-share): R24c 家計トラッカーUI配線 — 資産ページから1タップ投稿

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -41,6 +41,7 @@ import 'package:my_web_app/services/asset_account_balance_history_store.dart';
 import 'package:my_web_app/services/asset_pref_mirror_prefetch.dart';
 import 'package:my_web_app/services/asset_debt_discipline_monitor.dart';
 import 'package:my_web_app/services/asset_debt_trend_analyzer.dart';
+import 'package:my_web_app/services/household_tracker_share_service.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
@@ -19952,6 +19953,51 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   /// 今月の負債の問題点と「翌月こうしなさい」を、計算済みの具体額つきで描画する。
+  bool _householdTrackerPosting = false;
+
+  /// R24b: 負債トレンドの実データ(件数・日数・方向のみ/金額なし)を post A 同型の
+  /// データレポート型スコアボードとして X へ投稿し、variant=household_tracker で
+  /// 学習ループの計測対象にする。
+  Future<void> _postHouseholdTracker(
+    List<AssetDebtTrendInsight> insights,
+  ) async {
+    if (_householdTrackerPosting) return;
+    setState(() => _householdTrackerPosting = true);
+    try {
+      final snapshot = householdSnapshotFromInsights(
+        insights,
+        salaryDay: _salaryDay,
+        now: DateTime.now(),
+      );
+      final res = await _supabase.functions.invoke(
+        'growth-hub',
+        body: buildHouseholdTrackerPostPayload(snapshot),
+      );
+      if (!mounted) return;
+      final data = res.data is Map
+          ? Map<String, dynamic>.from(res.data as Map)
+          : <String, dynamic>{};
+      final posted = data['posted'] == true;
+      final tweetId = data['tweetId']?.toString() ?? '';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            posted
+                ? '家計トラッカーを投稿しました（計測対象・金額非公開）'
+                    '${tweetId.isNotEmpty ? ' https://x.com/i/status/$tweetId' : ''}'
+                : '投稿に失敗しました: ${data['error'] ?? data['code'] ?? '不明'}',
+          ),
+        ),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('投稿に失敗しました: $error')));
+    } finally {
+      if (mounted) setState(() => _householdTrackerPosting = false);
+    }
+  }
+
   Widget _buildAssetManagementMonthlyDebtTrendList(
     List<AssetDebtTrendInsight> insights,
   ) {
@@ -19984,6 +20030,19 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     height: 1.4,
                   ),
                 ),
+              ),
+              IconButton(
+                tooltip: '家計トラッカーを投稿（計測対象・金額非公開）',
+                icon: _householdTrackerPosting
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Icon(Icons.ios_share, color: headerColor, size: 18),
+                onPressed: _householdTrackerPosting
+                    ? null
+                    : () => _postHouseholdTracker(insights),
               ),
             ],
           ),

--- a/lib/services/household_tracker_share_service.dart
+++ b/lib/services/household_tracker_share_service.dart
@@ -9,6 +9,8 @@
 // - 投稿は growth-hub x.post 経由(variant=household_tracker /
 //   contentArchetype=data_report)で学習ループの計測対象にする。
 
+import 'asset_debt_trend_analyzer.dart';
+
 /// 家計トラッカー投稿の入力(すべて件数/日数/方向 — 金額は受け取らない)。
 class HouseholdTrackerSnapshot {
   /// 監視対象の負債口座数。
@@ -68,7 +70,7 @@ String buildHouseholdTrackerText(HouseholdTrackerSnapshot s) {
     '家計トラッカー $dateLabel（自分株式会社・実運用データ）',
     '',
     '取得日時: $timestamp',
-    '監視口座数: ${s.monitoredAccounts}',
+    'トレンド検出口座: ${s.monitoredAccounts}',
     '負債トレンド検出: ${s.totalFindings}件',
     '内訳: 残高増加 ${s.balanceIncreasing} / 利息超過 ${s.negativeAmortization} / 長期化 ${s.slowPayoff}',
     if (s.criticalCount > 0 || s.warningCount > 0)
@@ -96,4 +98,27 @@ Map<String, dynamic> buildHouseholdTrackerPostPayload(
     'contentArchetype': 'data_report',
     'experimentKey': 'x_first_user_growth_10k',
   };
+}
+
+/// 負債トレンド insights から Snapshot を組み立てる純ヘルパ(金額は一切読まない)。
+/// monitoredAccounts は insights 内の distinct 口座数(=検出対象口座)。
+HouseholdTrackerSnapshot householdSnapshotFromInsights(
+  List<AssetDebtTrendInsight> insights, {
+  required int salaryDay,
+  required DateTime now,
+}) {
+  int countBy(AssetDebtTrendCategory c) =>
+      insights.where((i) => i.category == c).length;
+  int severity(AssetDebtTrendSeverity sv) =>
+      insights.where((i) => i.severity == sv).length;
+  return HouseholdTrackerSnapshot(
+    monitoredAccounts: insights.map((i) => i.accountId).toSet().length,
+    balanceIncreasing: countBy(AssetDebtTrendCategory.balanceIncreasing),
+    negativeAmortization: countBy(AssetDebtTrendCategory.negativeAmortization),
+    slowPayoff: countBy(AssetDebtTrendCategory.slowPayoff),
+    criticalCount: severity(AssetDebtTrendSeverity.critical),
+    warningCount: severity(AssetDebtTrendSeverity.warning),
+    salaryDay: salaryDay,
+    now: now,
+  );
 }

--- a/test/services/household_tracker_share_service_test.dart
+++ b/test/services/household_tracker_share_service_test.dart
@@ -26,7 +26,7 @@ void main() {
     test('scoreboard text: counts/days/directions only, no yen amounts', () {
       final text = buildHouseholdTrackerText(snapshot);
       expect(text, contains('家計トラッカー 2026/07/12'));
-      expect(text, contains('監視口座数: 4'));
+      expect(text, contains('トレンド検出口座: 4'));
       expect(text, contains('負債トレンド検出: 3件'));
       expect(text, contains('内訳: 残高増加 1 / 利息超過 0 / 長期化 2'));
       expect(text, contains('アラート: 🔴1件 / 🟡2件'));


### PR DESCRIPTION
## R24c: 家計トラッカーのUI配線 — 資産ページから1タップでデータレポート型投稿

Completes the R23→R24b chain (data-report archetype measured 114-258x over product promos; #3968 landed the pure composer). This wires the button:

- 資産管理ページの「今月の問題点と翌月の改善（負債トレンド）」ヘッダに共有ボタンを追加。1タップで `householdSnapshotFromInsights`（insights の件数を category/severity で集計・distinct 口座数・金額は一切読まない）→ post-A 型スコアボードを合成 → growth-hub `x.post`（`variant=household_tracker` + `contentArchetype=data_report`）で投稿し、学習ループの計測対象に。
- スコアボードのラベルを「監視口座数」→「トレンド検出口座」へ修正（insights 由来の distinct 口座数を正直に表現・R17 誠実性規律）。
- 投稿中スピナー・成功時は tweet URL 付き snackbar・失敗時はコード/エラー表示。二重投稿ガード。プライバシー規律は R24b と同一（件数・日数・方向のみ／円・¥不在をテストでアサート）。

`flutter test` 4 green（ラベル更新反映）・analyze clean・format fixpoint。既存の負債トレンド表示・R16-R24 挙動は不変。

## Minimal E2E Gate

- Implementation-detail independent: tests assert the snapshot aggregation, composed scoreboard text (privacy assertions), countdown math, and x.post payload contract.
- Minimal scope: about 3 cases (insights aggregation; zero-findings; payload tagging).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: one share-button wiring over already-tested pure functions; posting result surfaces via snackbar only, no route flow changes, so no integration_test/Playwright route applies.
