### PR TITLE
ops(blog): Qiita アカウント利用停止につき自動化の Qiita 接触を全停止

### DIFF
--- a/.github/workflows/blog-batch-publish.yml
+++ b/.github/workflows/blog-batch-publish.yml
@@ -20,9 +20,11 @@ on:
         required: false
         default: 'true'
       platforms:
-        description: '投稿先: qiita / devto / qiita,devto'
+        # 2026-07-12: Qiita アカウント利用停止につき既定を devto へ変更。
+        # 停止解除まで qiita を指定しないこと。
+        description: '投稿先: devto (qiita は停止中につき指定しない)'
         required: false
-        default: 'qiita'
+        default: 'devto'
 
 concurrency:
   group: blog-batch-publish
@@ -82,7 +84,8 @@ jobs:
           MAX_POSTS: ${{ github.event.inputs.max_posts || '999' }}
           DELAY: ${{ github.event.inputs.delay_seconds || '30' }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
-          PLATFORMS: ${{ github.event.inputs.platforms || 'qiita' }}
+          # 2026-07-12: fallback も devto へ (qiita はアカウント利用停止中)
+          PLATFORMS: ${{ github.event.inputs.platforms || 'devto' }}
         run: |
           python3 scripts/batch_publish.py
 

--- a/.github/workflows/blog-draft-register.yml
+++ b/.github/workflows/blog-draft-register.yml
@@ -96,7 +96,8 @@ jobs:
 
             # blog_posts テーブルに直接 INSERT (content付き)
             ISO_NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-            INSERT_PAYLOAD=$(TITLE="$TITLE" DRAFT_PATH="$DRAFT_PATH" ISO_NOW="$ISO_NOW" CONTENT="$CONTENT" python3 -c 'import json, os; print(json.dumps({"title": os.environ["TITLE"], "draft_path": os.environ["DRAFT_PATH"], "content": os.environ["CONTENT"], "status": "draft", "target_platforms": ["qiita", "devto"], "created_at": os.environ["ISO_NOW"]}))')
+            # 2026-07-12: Qiita アカウント利用停止につき、新規登録は dev.to のみ。
+            INSERT_PAYLOAD=$(TITLE="$TITLE" DRAFT_PATH="$DRAFT_PATH" ISO_NOW="$ISO_NOW" CONTENT="$CONTENT" python3 -c 'import json, os; print(json.dumps({"title": os.environ["TITLE"], "draft_path": os.environ["DRAFT_PATH"], "content": os.environ["CONTENT"], "status": "draft", "target_platforms": ["devto"], "created_at": os.environ["ISO_NOW"]}))')
 
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
               -X POST \

--- a/.github/workflows/blog-engagement.yml
+++ b/.github/workflows/blog-engagement.yml
@@ -1,13 +1,16 @@
 name: Blog Engagement (毎日・コメント返信/フォロー/重複削除)
 
-# 毎日 10:00 JST に Qiita/dev.to の engagement を処理する:
+# 毎日 10:00 JST に dev.to の engagement を処理する:
 # 1. 記事一覧取得 → 重複削除
 # 2. コメント取得 → Claude → Gemini → template fallback で返信
 # 3. いいねしたユーザー → フォロー
 # 4. 結果を Supabase に保存 → アプリ画面で閲覧可能に
+#
+# ⚠️ 2026-07-12: Qiita アカウント利用停止 (ToS 違反) につき Qiita への接触を
+# 全停止。QIITA_ACCESS_TOKEN を env に渡さない = blog_engagement.py が Qiita を
+# スキップする。停止解除まで再有効化しないこと。
 
 # 必要な GitHub Secrets:
-#   QIITA_ACCESS_TOKEN      — Qiita設定 > アプリケーション > 新しいトークン
 #   DEVTO_API_KEY           — dev.to設定 > Extensions > DEV Community API Keys
 #   SUPABASE_SERVICE_ROLE_KEY — Supabase > Project Settings > API > service_role
 #   ANTHROPIC_API_KEY       — console.anthropic.com (コメント返信AI生成用・任意)
@@ -74,7 +77,8 @@ jobs:
       - name: Run engagement script
         if: steps.quota_check.outputs.anthropic_available == 'true'
         env:
-          QIITA_ACCESS_TOKEN: ${{ secrets.QIITA_ACCESS_TOKEN }}
+          # QIITA_ACCESS_TOKEN は渡さない (2026-07-12 アカウント利用停止 →
+          # script 側の「not set → skipping Qiita」ガードで接触ゼロにする)
           DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -106,9 +110,7 @@ jobs:
           echo "| 項目 | 値 |" >> $GITHUB_STEP_SUMMARY
           echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
           echo "| dry_run | ${{ github.event.inputs.dry_run || 'false' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Qiita token | ${{ secrets.QIITA_ACCESS_TOKEN != '' && 'set' || '❌ NOT SET' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Qiita | ⛔ 停止中 (2026-07-12 アカウント利用停止 → 接触停止) |" >> $GITHUB_STEP_SUMMARY
           echo "| dev.to key | ${{ secrets.DEVTO_API_KEY != '' && 'set' || '⚠️ not set' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Claude key | ${{ secrets.ANTHROPIC_API_KEY != '' && 'set (primary)' || '⚠️ not set' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Gemini key | ${{ secrets.GEMINI_API_KEY != '' && 'set (fallback)' || '⚠️ not set (template fallback)' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "ℹ️ Qiitaトークン未設定の場合: Settings > Secrets > QIITA_ACCESS_TOKEN を追加" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/blog-news-signal-draft.yml
+++ b/.github/workflows/blog-news-signal-draft.yml
@@ -56,7 +56,9 @@ jobs:
               "signal_limit": signal_limit,
               "force": force,
               "external_brain": True,
-              "target_platforms": ["note", "qiita", "devto"],
+              # 2026-07-12: Qiita アカウント利用停止につき新規ドラフトの
+              # 投稿先から qiita を除外 (停止解除まで戻さないこと)
+              "target_platforms": ["note", "devto"],
               "tags": ["AI", "ニュース", "自動化", "外部脳"],
           }
           print(json.dumps(payload, ensure_ascii=False, indent=2))

--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -14,9 +14,11 @@ on:
         required: false
         default: ''
       platforms:
-        description: '投稿先プラットフォーム (qiita, devto, 両方: qiita,devto)'
+        # ⚠️ 2026-07-12: Qiita アカウント利用停止につき既定から qiita を除外。
+        # 停止解除まで qiita を指定しないこと。
+        description: '投稿先プラットフォーム (通常は devto のみ / qiita は停止中)'
         required: false
-        default: 'qiita,devto'
+        default: 'devto'
       dry_run:
         description: 'ドライラン (true=投稿しない, false=実投稿)'
         required: false
@@ -272,9 +274,10 @@ jobs:
           DRAFT_PATH="$DRAFT_PATH_VAR"
           TITLE="$ARTICLE_TITLE"
           # Scheduled実行の場合は自動投稿 (dry_run=false), 手動実行の場合は入力値を使用
+          # 2026-07-12: Qiita アカウント利用停止につき schedule は devto のみ
           if [ "${{ github.event_name }}" = "schedule" ]; then
             DRY_RUN="false"
-            PLATFORMS="qiita,devto"
+            PLATFORMS="devto"
           else
             DRY_RUN="${{ github.event.inputs.dry_run }}"
             PLATFORMS="${{ github.event.inputs.platforms }}"

--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -148,7 +148,13 @@ jobs:
               pid = p["id"]
               title = p["title"]
               print(f"[trace={trace}] Publishing DB post: {pid} — {title}")
-              payload = json.dumps({"action": "blog.publish_post", "id": pid}).encode()
+              # Scheduled ready-post publishing is dev.to-only while Qiita is suspended.
+              # schedule-hub intersects this allowlist with the stored targets.
+              payload = json.dumps({
+                  "action": "blog.publish_post",
+                  "id": pid,
+                  "platforms": ["devto"],
+              }).encode()
               req = urllib.request.Request(
                   f"{url}/functions/v1/schedule-hub",
                   data=payload,
@@ -330,10 +336,10 @@ jobs:
           TITLE="$ARTICLE_TITLE"
           TAGS="$TAGS_VAR"
           
-          # Scheduled実行の場合は自動投稿 (dry_run=false, platforms=qiita,devto)
+          # 2026-07-12: Qiita アカウント利用停止につき schedule は devto のみ
           if [ "${{ github.event_name }}" = "schedule" ]; then
             DRY_RUN="false"
-            PLATFORMS="qiita,devto"
+            PLATFORMS="devto"
           else
             DRY_RUN="${{ github.event.inputs.dry_run }}"
             PLATFORMS="${{ github.event.inputs.platforms }}"

--- a/.github/workflows/blog-verify.yml
+++ b/.github/workflows/blog-verify.yml
@@ -46,7 +46,8 @@ jobs:
 
       - name: Verify past posts
         env:
-          QIITA_ACCESS_TOKEN: ${{ secrets.QIITA_ACCESS_TOKEN }}
+          # QIITA_ACCESS_TOKEN は渡さない (2026-07-12 アカウント利用停止 →
+          # script 側の「not set → skipping Qiita」ガードで接触ゼロにする)
           DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/supabase/functions/schedule-hub/blog_publish_policy.ts
+++ b/supabase/functions/schedule-hub/blog_publish_policy.ts
@@ -1,0 +1,71 @@
+export type BlogPublishPlatform = "qiita" | "devto";
+
+const SUPPORTED_PLATFORMS = new Set<BlogPublishPlatform>([
+  "qiita",
+  "devto",
+]);
+const LEGACY_DEFAULT_PLATFORMS: BlogPublishPlatform[] = ["qiita", "devto"];
+
+export interface BlogPublishPlatformResolution {
+  platforms: BlogPublishPlatform[];
+  error?: string;
+}
+
+function isSupportedPlatform(value: unknown): value is BlogPublishPlatform {
+  return typeof value === "string" &&
+    SUPPORTED_PLATFORMS.has(value as BlogPublishPlatform);
+}
+
+function uniquePlatforms(values: unknown[]): BlogPublishPlatform[] {
+  return Array.from(new Set(values.filter(isSupportedPlatform)));
+}
+
+/**
+ * Resolve the platforms used by blog.publish_post.
+ *
+ * An omitted override preserves the legacy DB-driven behavior. An explicit
+ * override is an allowlist intersected with the stored targets, so callers can
+ * narrow a publish operation but cannot add a destination. Invalid or empty
+ * overrides fail closed.
+ */
+export function resolveBlogPublishPlatforms(
+  storedTargets: unknown,
+  requestedOverride: unknown,
+): BlogPublishPlatformResolution {
+  const stored = Array.isArray(storedTargets)
+    ? uniquePlatforms(storedTargets)
+    : [...LEGACY_DEFAULT_PLATFORMS];
+
+  if (requestedOverride === undefined) {
+    return { platforms: stored };
+  }
+  if (!Array.isArray(requestedOverride) || requestedOverride.length === 0) {
+    return {
+      platforms: [],
+      error: "platforms override must be a non-empty array",
+    };
+  }
+  if (!requestedOverride.every(isSupportedPlatform)) {
+    return {
+      platforms: [],
+      error: "platforms override contains an unsupported value",
+    };
+  }
+
+  const requested = uniquePlatforms(requestedOverride);
+  const platforms = requested.filter((platform) => stored.includes(platform));
+  if (platforms.length === 0) {
+    return {
+      platforms: [],
+      error: "platforms override does not match the stored targets",
+    };
+  }
+  return { platforms };
+}
+
+/** Qiita traffic stays disabled unless operators explicitly opt it back in. */
+export function isQiitaAccessEnabled(
+  value: string | null | undefined,
+): boolean {
+  return value?.trim().toLowerCase() === "true";
+}

--- a/supabase/functions/schedule-hub/blog_publish_policy_test.ts
+++ b/supabase/functions/schedule-hub/blog_publish_policy_test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  isQiitaAccessEnabled,
+  resolveBlogPublishPlatforms,
+} from "./blog_publish_policy.ts";
+
+Deno.test("scheduled override narrows stored Qiita+dev.to targets to dev.to", () => {
+  assertEquals(
+    resolveBlogPublishPlatforms(["qiita", "devto"], ["devto"]),
+    { platforms: ["devto"] },
+  );
+});
+
+Deno.test("omitted override preserves the stored targets", () => {
+  assertEquals(
+    resolveBlogPublishPlatforms(["qiita", "devto"], undefined),
+    { platforms: ["qiita", "devto"] },
+  );
+});
+
+Deno.test("override cannot add a destination absent from stored targets", () => {
+  assertEquals(
+    resolveBlogPublishPlatforms(["devto"], ["qiita", "devto"]),
+    { platforms: ["devto"] },
+  );
+});
+
+Deno.test("invalid, empty, and non-matching overrides fail closed", () => {
+  for (const override of [[], ["note"], "devto", null]) {
+    const result = resolveBlogPublishPlatforms(["qiita", "devto"], override);
+    assertEquals(result.platforms, []);
+    assertEquals(typeof result.error, "string");
+  }
+  const nonMatching = resolveBlogPublishPlatforms(["qiita"], ["devto"]);
+  assertEquals(nonMatching.platforms, []);
+  assertEquals(typeof nonMatching.error, "string");
+});
+
+Deno.test("Qiita access is disabled by default and requires explicit true", () => {
+  assertEquals(isQiitaAccessEnabled(undefined), false);
+  assertEquals(isQiitaAccessEnabled(null), false);
+  assertEquals(isQiitaAccessEnabled("false"), false);
+  assertEquals(isQiitaAccessEnabled(" true "), true);
+});

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -22,6 +22,10 @@ import {
 } from "../_shared/external_fetch.ts";
 import { buildOwnSiteBlogPostUrl } from "./blog_canonical.ts";
 import {
+  isQiitaAccessEnabled,
+  resolveBlogPublishPlatforms,
+} from "./blog_publish_policy.ts";
+import {
   allPlatformsFailed,
   type BlogUpstreamApi,
   buildUpstreamErrorPayload,
@@ -1040,6 +1044,19 @@ async function qiitaFetch(
   init: RequestInit = {},
   traceId = "schedule-hub.qiita",
 ): Promise<Response> {
+  // 2026-07-12: account suspension kill switch. A token alone must never
+  // reactivate traffic; operations must explicitly set QIITA_ACCESS_ENABLED=true.
+  if (!isQiitaAccessEnabled(Deno.env.get("QIITA_ACCESS_ENABLED"))) {
+    return new Response(
+      JSON.stringify({
+        message: "Qiita access disabled by QIITA_ACCESS_ENABLED",
+      }),
+      {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
   const url = path.startsWith("http")
     ? path
     : `https://qiita.com/api/v2${path}`;
@@ -2350,9 +2367,17 @@ serve(async (req: Request) => {
             : (body.tags as string[]) ?? [];
         const ppTargetPlatforms = (post as Record<string, unknown>)
           .target_platforms;
-        const ppPlatforms: string[] = Array.isArray(ppTargetPlatforms)
-          ? ppTargetPlatforms
-          : ["qiita", "devto"];
+        const ppPlatformResolution = resolveBlogPublishPlatforms(
+          ppTargetPlatforms,
+          body.platforms,
+        );
+        if (ppPlatformResolution.error) {
+          return json({
+            error: ppPlatformResolution.error,
+            error_code: "invalid_platform_override",
+          }, 400);
+        }
+        const ppPlatforms = ppPlatformResolution.platforms;
         const ppResults: Record<string, unknown> = {};
 
         if (ppPlatforms.includes("qiita") && qiitaToken) {

--- a/test/scripts/test_qiita_suspension_workflows.py
+++ b/test/scripts/test_qiita_suspension_workflows.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def workflow(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def test_scheduled_qiita_credentials_are_not_injected() -> None:
+    engagement = workflow("blog-engagement.yml")
+    verification = workflow("blog-verify.yml")
+
+    secret_binding = "QIITA_ACCESS_TOKEN: ${{ secrets.QIITA_ACCESS_TOKEN }}"
+    assert secret_binding not in engagement
+    assert secret_binding not in verification
+
+
+def test_scheduled_drafts_no_longer_target_qiita() -> None:
+    news_draft = workflow("blog-news-signal-draft.yml")
+    draft_register = workflow("blog-draft-register.yml")
+
+    assert '"target_platforms": ["note", "devto"]' in news_draft
+    assert '"target_platforms": ["note", "qiita", "devto"]' not in news_draft
+    assert '"target_platforms": ["devto"]' in draft_register
+    assert '"target_platforms": ["qiita", "devto"]' not in draft_register
+
+
+def test_scheduled_publish_is_devto_only_and_ready_queue_fails_closed() -> None:
+    publish = workflow("blog-publish.yml")
+
+    assert 'PLATFORMS="qiita,devto"' not in publish
+    assert publish.count('PLATFORMS="devto"') >= 2
+    assert '"platforms": ["devto"]' in publish


### PR DESCRIPTION
## Summary  **2026-07-12 判明: Qiita アカウント @kanta13jp1 が利用規約違反で利用停止**(qiita.com/kanta13jp1 が suspended 表示)。異議申立て/撤退のどちらを選ぶ場合でも、停止中アカウントへ自動アクセスを続けるのは不適切なため、**自動化の Qiita 接触を全停止**する(dev.to 経路は維持)。  停止事由として最有力なのは `blog-engagement.yml`(毎日 10:00 JST)が回していた **Qiita コメントへの AI 自動返信+いいねユーザーの自動フォロー**、および日次の自動記事投稿。異議申立て時に「自動投稿・自動フォロー・自動返信は停止済み」と言える状態を先に作る。  ### 変更内容(cron 4本+手動系 footgun 2箇所)  | Workflow | 変更 | |---|---| | blog-engagement.yml(日次) | QIITA_ACCESS_TOKEN を env から撤去 → script の「not set → skipping Qiita」ガードで接触ゼロ(AI 自動返信・自動フォローも停止) | | blog-publish.yml(日次) | schedule 実行の PLATFORMS を `devto` のみへ(2箇所)+ dispatch 既定値も `devto` | | blog-news-signal-draft.yml(日次) | 新規ドラフトの target_platforms から `qiita` を除外 | | blog-verify.yml(週次) | QIITA_ACCESS_TOKEN を env から撤去(同ガード) | | blog-batch-publish.yml(手動) | 既定値と fallback を `qiita`→`devto`(誤操作防止) |  - スクリプト本体は無変更(両スクリプトともトークン未設定で Qiita を丸ごとスキップする既存ガードを利用) - 停止解除まで再有効化しないこと(各所にコメントで明記) - 関連: #3954(管理画面の同期エラー可視化)/ #3959(schedule-hub の構造化エラー)  ## Minimal E2E Gate  - Implementation-detail independent: the test asserts user-visible input/output, not private internals. - Minimal scope: about 3 cases (happy path, error path, recovery or empty state). - E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route. - E2E-Exception: cron/Edge の外向き通信ポリシー変更で新規 UI 経路なし。純ロジック Deno 5件 + workflow policy 3件 + 全体 pre-push gate で担保。  ## Test plan  - `git diff` で cron スケジュール・dev.to 経路が無変更であることを確認済み - 各 workflow の YAML 構文は GitHub 側の workflow パースで検証される  🤖 Generated with [Claude Code](https://claude.com/claude-code)  
## Follow-up hardening (Codex #1)

初回差分を独立監査したところ、`blog-publish.yml` に2つの残存経路が見つかったため、merge前に修正した。

- Step 4 の schedule 分岐に残っていた `PLATFORMS=qiita,devto` を `devto` のみに修正。
- Step 1.7 (`blog.publish_post`) はDBの既存 `target_platforms`を読むため、workflowから `platforms: [devto]` allowlistを渡し、Edge側で保存先との積集合だけを許可。不正・空・非一致overrideは400でfail closed。
- `blog-draft-register.yml` の新規DBドラフト既定値も `devto` のみに変更。
- schedule-hub全体に `QIITA_ACCESS_ENABLED=true` が明示されない限り外向きQiita通信を拒否するkill switchを追加。トークンだけを戻しても再開しない。
- 即時運用停止としてGitHub Actions / Supabase双方から `QIITA_ACCESS_TOKEN` を削除済み。`DEVTO_API_KEY` は維持。対象4 workflowのqueued/runningは0件を確認。

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 緊急のアカウント利用停止対応で `/ultrareview` は未実施。変更は外向き通信を狭めるkill switchとallowlistのみで、純ロジックテスト・型検査・全体quality gateを通し、rollbackはフラグとsecretを明示復旧するまでfail closed。

## Additional validation

- `deno test --allow-all --no-check --config supabase/functions/deno.json supabase/functions/schedule-hub/` — 25 passed
- `deno check --config supabase/functions/deno.json supabase/functions/schedule-hub/index.ts` — pass
- `deno lint` / `deno fmt --check` (changed Edge files) — pass
- `python -m pytest test/scripts/test_qiita_suspension_workflows.py -q` — 3 passed
- YAML parse (6 related workflows) — pass
- Repository pre-commit fast gate + pre-push full gate — pass

Subagent evidence:
- Lead: Codex #1
- Subagent roles: cron-route explorer, client/server hint explorer, repository/PR-state auditor
- Scope and write set: read-only discovery; no subagent edits
- Summary received: exactly 4 scheduled routes plus latent DB-ready/push-registration paths; initial PR left Step 4 and DB target routing open
- Validation impact: findings drove the Step 1.7 allowlist, global kill switch, workflow policy regression test, and secret removal
- Cleanup impact: no subagent processes or worktrees created