### PR TITLE
fix(blog): Qiita 401 の文言に「アカウント利用停止の可能性」を追記

### DIFF
--- a/lib/pages/admin/blog_sync_feedback.dart
+++ b/lib/pages/admin/blog_sync_feedback.dart
@@ -34,8 +34,12 @@ String composeBlogSyncErrorMessage({
 
   if (RegExp('qiita', caseSensitive: false).hasMatch(probe) &&
       probe.contains('401')) {
-    return 'Qiitaトークンが失効しています(401)。Qiitaで新しいアクセストークンを発行し、'
-        'Supabase secrets の QIITA_ACCESS_TOKEN を更新してから再同期してください。';
+    // 2026-07-12: 401 の実原因がアカウント利用停止だった実績があるため、
+    // トークン再発行より先に停止の可能性を案内する。
+    return 'Qiitaが認可エラー(401)を返しました。アカウントが利用停止されている'
+        '可能性があります(qiita.com のプロフィールで確認 — 停止中はトークン'
+        '再発行では復旧しません)。停止でなければ QIITA_ACCESS_TOKEN の失効です。'
+        '新しいトークンを発行し Supabase secrets を更新してから再同期してください。';
   }
   if (probe.contains('QIITA_ACCESS_TOKEN')) {
     return 'QIITA_ACCESS_TOKEN が未設定です。Supabase secrets に設定してください。';

--- a/supabase/functions/schedule-hub/upstream_error.ts
+++ b/supabase/functions/schedule-hub/upstream_error.ts
@@ -27,8 +27,12 @@ const API_LABELS: Record<BlogUpstreamApi, string> = {
   "dev.to": "dev.to",
 };
 
+// 2026-07-12: 実際に 401 の原因がアカウント利用停止だった実績があるため、
+// トークン再発行より先に停止の可能性を案内する。
 export const QIITA_TOKEN_ROTATE_HINT =
-  "QIITA_ACCESS_TOKEN が失効/権限不足の可能性。Qiita 設定 → アプリケーション → " +
+  "Qiita が認可エラーを返却。①アカウント利用停止の可能性 — qiita.com のプロフィールが " +
+  "suspended 表示ならトークン再発行では復旧せず、停止解除(異議申立て)が先。" +
+  "②停止でなければ QIITA_ACCESS_TOKEN の失効/権限不足 — Qiita 設定 → アプリケーション → " +
   "個人用アクセストークンを再発行し `supabase secrets set QIITA_ACCESS_TOKEN=<新トークン> " +
   "--project-ref smmkxxavexumewbfaqpy` で更新してください。";
 

--- a/test/pages/blog_sync_feedback_test.dart
+++ b/test/pages/blog_sync_feedback_test.dart
@@ -7,12 +7,12 @@ import 'package:my_web_app/pages/admin/blog_sync_feedback.dart';
 
 void main() {
   group('composeBlogSyncErrorMessage', () {
-    test('Qiita 401 はトークン失効+是正手順を名指しする(本番実ペイロード)', () {
+    test('Qiita 401 は利用停止の可能性+是正手順を名指しする(本番実ペイロード)', () {
       final message = composeBlogSyncErrorMessage(
         status: 502,
         details: {'error': 'Qiita list: 401'},
       );
-      expect(message, contains('Qiitaトークンが失効'));
+      expect(message, contains('利用停止'));
       expect(message, contains('QIITA_ACCESS_TOKEN'));
       expect(message, isNot(contains('FunctionException')));
     });
@@ -48,7 +48,7 @@ void main() {
             'FunctionException(status: 502, details: {error: Qiita list: 401},'
             ' reasonPhrase: )',
       );
-      expect(message, contains('Qiitaトークンが失効'));
+      expect(message, contains('利用停止'));
     });
 
     test('情報ゼロでも文として成立する', () {


### PR DESCRIPTION
## Summary

2026-07-12 に Qiita API 401 の実原因が **アカウント利用停止(規約違反)** だったため(qiita.com/kanta13jp1 が suspended 表示)、エラー文言を実態に合わせる。従来の文言は「トークン失効 → 再発行」だけを案内しており、停止中は誤誘導になっていた。

- **サーバー**: `upstream_error.ts` の `QIITA_TOKEN_ROTATE_HINT` を「①利用停止の可能性(suspended 表示なら再発行では復旧せず停止解除が先)②失効なら再発行手順」の2段構成へ。#3959 の構造化 payload 経由で全 Qiita 系 action に効く。
- **クライアント**: `blog_sync_feedback.dart` の 401 fallback 文言も同様に更新(サーバー hint が無い旧 payload 用)。
- 関連: #3954(hint 最優先表示)/ #3959(構造化エラー)/ #3973(自動化の Qiita 接触停止)

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: supabase/functions の差分は定数文字列(案内文言)とコメントのみで制御フロー変更なし。deno 17 + flutter 17 テスト緑で挙動同一を確認済み。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 文言定数のみの変更。deno test 17 + flutter test 17(文言アサーション更新込み)で担保、新規 e2e 経路なし。

## Test plan

- `deno test --allow-all schedule-hub/upstream_error_test.ts` → 17 passed
- `flutter test test/pages/blog_sync_feedback_test.dart` → 17 passed
- `deno fmt --check` / `dart format --set-exit-if-changed` → 差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
