### PR TITLE
fix(schedule-hub): publicActions の書き込み系 4 action を service-role 必須化

### DIFF
--- a/supabase/functions/schedule-hub/action_auth.ts
+++ b/supabase/functions/schedule-hub/action_auth.ts
@@ -1,0 +1,46 @@
+// schedule-hub action 認可レベル (純ロジック / Deno API 非依存 → unit testable)
+//
+// 3 レベル:
+// - public: 認証不要 (read-only or 公開 endpoint)。書き込み系を足す前に
+//   service_role 化を検討すること (anon key は Web アプリ同梱 = 実質公開)。
+// - service_role: Bearer === SERVICE_ROLE_KEY 必須。オーナー資格情報
+//   (QIITA_ACCESS_TOKEN / DEVTO_API_KEY / X API) での投稿や hub_data への
+//   system 書き込みを行う action はここ。
+// - user: ログイン user JWT (or service role)。
+
+export type ActionAuthLevel = "public" | "service_role" | "user";
+
+// 認証不要 action。
+export const PUBLIC_ACTIONS: readonly string[] = [
+  "digest.run",
+  "health.check",
+  "blog.recent_posted", // Win版#132 part 124: tech-blog-tracker page 用 public read
+  "reminders.study",
+  "notion.sync_wbs",
+  "notion.preflight_wbs",
+  "notion.sync_roadmap",
+  "notion.sync_memory_index",
+  "notion.fix_wbs_all_instances",
+  "wbs.unblock_dependents",
+  "billing.create_supporter_checkout_session",
+  "maintenance.list_active",
+];
+
+// SERVICE_ROLE_KEY Bearer 必須の書き込み系 action。
+// 呼び出し元は GHA workflow のみ: blog-publish.yml (blog.create /
+// blog.auto_publish) / blog-batch-publish.yml → scripts/batch_publish.py
+// (blog.auto_publish) / blog-backfill-from-apis.yml (blog.backfill_from_apis) /
+// post-x-with-media.yml (x.post_with_media) — 全て SERVICE_ROLE_KEY を送る。
+// anon key・ログイン user JWT では 401 (匿名 signup JWT でも通せない)。
+export const SERVICE_ROLE_ONLY_ACTIONS: readonly string[] = [
+  "blog.auto_publish",
+  "blog.create",
+  "blog.backfill_from_apis",
+  "x.post_with_media",
+];
+
+export function requiredAuthLevel(action: string): ActionAuthLevel {
+  if (SERVICE_ROLE_ONLY_ACTIONS.includes(action)) return "service_role";
+  if (PUBLIC_ACTIONS.includes(action)) return "public";
+  return "user";
+}

--- a/supabase/functions/schedule-hub/action_auth_test.ts
+++ b/supabase/functions/schedule-hub/action_auth_test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  PUBLIC_ACTIONS,
+  requiredAuthLevel,
+  SERVICE_ROLE_ONLY_ACTIONS,
+} from "./action_auth.ts";
+
+Deno.test("書き込み系 4 action は service_role 必須", () => {
+  for (
+    const action of [
+      "blog.auto_publish",
+      "blog.create",
+      "blog.backfill_from_apis",
+      "x.post_with_media",
+    ]
+  ) {
+    assertEquals(requiredAuthLevel(action), "service_role");
+  }
+});
+
+Deno.test("read-only public action は public のまま", () => {
+  for (
+    const action of [
+      "health.check",
+      "blog.recent_posted",
+      "maintenance.list_active",
+      "digest.run",
+    ]
+  ) {
+    assertEquals(requiredAuthLevel(action), "public");
+  }
+});
+
+Deno.test("未知 / user 向け action は user JWT 必須", () => {
+  assertEquals(requiredAuthLevel("billing.status"), "user");
+  assertEquals(requiredAuthLevel("blog.list"), "user");
+  assertEquals(requiredAuthLevel("blog.publish_post"), "user");
+  assertEquals(requiredAuthLevel(""), "user");
+  assertEquals(requiredAuthLevel("nonexistent.action"), "user");
+});
+
+Deno.test("service_role 集合と public 集合は重複しない", () => {
+  for (const action of SERVICE_ROLE_ONLY_ACTIONS) {
+    assertEquals(PUBLIC_ACTIONS.includes(action), false);
+  }
+});

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -27,6 +27,7 @@ import {
   buildUpstreamErrorPayload,
   summarizePlatformFailures,
 } from "./upstream_error.ts";
+import { requiredAuthLevel } from "./action_auth.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -1622,32 +1623,16 @@ serve(async (req: Request) => {
 
     const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
 
-    // Public actions that don't require auth
-    const publicActions = [
-      "digest.run",
-      "health.check",
-      "blog.auto_publish",
-      "blog.create",
-      "blog.recent_posted", // Win版#132 part 124: tech-blog-tracker page 用 public read
-      "blog.backfill_from_apis", // Win版#132 part 124: 過去 dev.to + Qiita 投稿を hub_data に backfill
-      "reminders.study",
-      "notion.sync_wbs",
-      "notion.preflight_wbs",
-      "notion.sync_roadmap",
-      "notion.sync_memory_index",
-      "notion.fix_wbs_all_instances",
-      "wbs.unblock_dependents",
-      "x.post_with_media",
-      "billing.create_supporter_checkout_session",
-      "maintenance.list_active",
-    ];
+    // 認可: action ごとの必要レベルは action_auth.ts (純ロジック) に集約
+    const authLevel = requiredAuthLevel(action);
     const serviceRoleRequest = isServiceRoleRequest(req);
     let userId: string | null = null;
-    if (!publicActions.includes(action)) {
-      if (!serviceRoleRequest) {
-        userId = await getUserId(req);
-        if (!userId) return json({ error: "Unauthorized" }, 401);
-      }
+    if (authLevel === "service_role" && !serviceRoleRequest) {
+      return json({ error: "Unauthorized" }, 401);
+    }
+    if (authLevel === "user" && !serviceRoleRequest) {
+      userId = await getUserId(req);
+      if (!userId) return json({ error: "Unauthorized" }, 401);
     }
 
     switch (action) {


### PR DESCRIPTION
## Summary

schedule-hub の `publicActions` に認証不要で公開されていた書き込み系 4 action を service-role 必須化する。

Web アプリに同梱される anon key (= 実質公開) だけで、第三者が以下を実行できる状態だった:

- `blog.auto_publish` — オーナーの `QIITA_ACCESS_TOKEN` / `DEVTO_API_KEY` で任意記事を投稿
- `blog.create` — `hub_data` へ `user_id="system"` の row を insert
- `blog.backfill_from_apis` — 外部 API fetch + `hub_data` insert
- `x.post_with_media` — オーナーの X アカウントで任意テキスト+画像を投稿

## Changes

- `action_auth.ts` (新規・純ロジック): action → `public | service_role | user` の 3 レベル判定 `requiredAuthLevel()` を集約
- `index.ts`: インライン `publicActions` 配列を廃し、上記 4 action は `isServiceRoleRequest` 必須に。ログイン user JWT (匿名 signup JWT 含む) でも 401
- read-only の `blog.recent_posted` / `health.check` / `maintenance.list_active` 等の public は不変
- `action_auth_test.ts`: deno test 4 件

## Caller audit (挙動不変の根拠)

全呼び出し元が `Bearer SERVICE_ROLE_KEY` を送信していることを確認済み:

| Action | Caller | Auth |
|---|---|---|
| `blog.auto_publish` | `blog-publish.yml` Step 4 (×2) / `blog-batch-publish.yml` → `scripts/batch_publish.py` | `secrets.SUPABASE_SERVICE_ROLE_KEY` |
| `blog.create` | `blog-publish.yml` Step 3 | `secrets.SUPABASE_SERVICE_ROLE_KEY` |
| `blog.backfill_from_apis` | `blog-backfill-from-apis.yml` | `secrets.SUPABASE_SERVICE_ROLE_KEY` |
| `x.post_with_media` | `post-x-with-media.yml` | `secrets.SUPABASE_SERVICE_ROLE_KEY` |

`blog-draft-register.yml` はコメントに blog.create 言及があるが実装は REST API (`rest/v1/blog_posts`) 直叩きで schedule-hub EF を呼ばない → 影響なし。Flutter クライアント (`lib/`) にこの 4 action の呼び出しなし。

ハンドラ側は `userId ?? "system"` / `userId ?? "gha"` の null fallback で、service-role 経路では従来どおり `userId=null` のまま → GHA 経路のレスポンス・DB 書き込みは byte 同等。

過去の同型修正: memory `feedback_correction_20260504_schedule_hub_admin_writes` (admin client writes の ownership check)。

## Verification

- `deno test supabase/functions/schedule-hub/action_auth_test.ts` → 4 passed
- `deno lint` / `deno check` → clean (index.ts の fmt 差分は CRLF checkout 起因のみ / CI は LF で緑)
- Qiita アカウントは 2026-07-12 現在停止中のため、Qiita 経路の実呼び出し確認は 502 `upstream_auth_error` が期待値 (本 PR の対象外)

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Auth gate tightening only: moves 4 write actions from public to service-role-required; callers are GHA workflows already sending SERVICE_ROLE_KEY; pure-logic module with deno tests

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno Edge Function auth gate change; no browser-observable surface. Verified via deno unit tests (action_auth_test.ts 4 pass) + caller audit of GHA workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
