### PR TITLE
Fix first-yen WBS milestone foreign keys

### DIFF
--- a/supabase/migrations/20260712101000_wbs_first_yen_bank_payout_gate.sql
+++ b/supabase/migrations/20260712101000_wbs_first_yen_bank_payout_gate.sql
@@ -2,6 +2,38 @@
 -- are separate gates. The goal remains open until an external buyer's payment
 -- is recorded and at least JPY 1 reaches the configured bank account.
 
+INSERT INTO public.wbs_milestones (
+  code,
+  name,
+  target_date,
+  goal_users,
+  description,
+  color
+)
+VALUES
+  (
+    'first-yen-webhook-hardening',
+    'Stripe webhook revenue integrity',
+    DATE '2026-07-12',
+    0,
+    'Deploy the paid-session guard and event-id ledger before accepting the first external payment.',
+    '#DC2626'
+  ),
+  (
+    'first-yen-revenue',
+    'First external-buyer bank deposit',
+    DATE '2026-07-20',
+    1,
+    'Verify one external buyer, a paid Stripe event, a payout, and at least JPY 1 in the configured bank account.',
+    '#16A34A'
+  )
+ON CONFLICT (code) DO UPDATE SET
+  name = EXCLUDED.name,
+  target_date = EXCLUDED.target_date,
+  goal_users = EXCLUDED.goal_users,
+  description = EXCLUDED.description,
+  color = EXCLUDED.color;
+
 INSERT INTO public.wbs_tasks (
   category,
   category_icon,


### PR DESCRIPTION
## Why

Production deploy [#29180493150](https://github.com/kanta13jp1/my_web_app/actions/runs/29180493150) stopped safely while applying `20260712101000_wbs_first_yen_bank_payout_gate.sql`:

```
SQLSTATE 23503
Key (milestone_code)=(first-yen-webhook-hardening) is not present in table "wbs_milestones".
```

The Stripe event-ledger migration had already applied; the following WBS seed migration was rolled back because its two referenced milestone codes did not exist.

## Fix

- Upsert `first-yen-webhook-hardening` and `first-yen-revenue` into `wbs_milestones`
- Create both milestones before inserting the dependent WBS tasks
- Keep the migration idempotent with `ON CONFLICT (code) DO UPDATE`
- Preserve the external-buyer and bank-deposit evidence requirements

## Validation

- Migration timestamp collision check: passed (1,889 unique timestamps)
- Migration time-relative check: passed
- `git diff --check`: passed
- `flutter analyze`: no issues
- Full pre-push quality gate: passed
- Full Supabase Functions suite: 382 passed

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 is unavailable in this Codex session; focused review covers security, rollback, data migration, production smoke, and observability for this additive WBS seed repair.

## Minimal E2E Gate

- Implementation-detail independent: production verification asserts migration success and the resulting milestone/task relationship.
- Minimal scope: about 3 cases (missing milestone repair, idempotent replay, dependent WBS task insert).
- E2E: the Supabase production migration job is the integration path; no Flutter or Playwright route executes database migration ordering.
- E2E-Exception: This migration-only repair has no user-facing route; the production database push is the relevant end-to-end verification.

## Production verification and rollback

- Security: no grants, policies, secrets, or application permissions change.
- Data migration: additive milestone UPSERTs precede the dependent task UPSERTs.
- Production smoke: rerun Deploy to Production and verify migration `20260712101000` completes before Edge Function deploy.
- Observability: deployment logs identify the exact migration and SQLSTATE.
- Rollback: the WBS rows are metadata only; the Stripe event ledger remains intact if deployment stops again.
- Unresolved findings: none in the focused Codex review.
