### PR TITLE
fix(blog): require publish success before marking posted

### DIFF
--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -425,9 +425,21 @@ jobs:
           echo "qiita_url=$QIITA_URL" >> $GITHUB_OUTPUT
           echo "devto_url=$DEVTO_URL" >> $GITHUB_OUTPUT
 
+          # Fail closed: a requested publish that produced no platform URL must
+          # never advance the DB/frontmatter to a published state. This is
+          # especially important for scheduled dev.to-only runs, where an
+          # English draft may not exist.
+          if [ -z "$QIITA_URL" ] && [ -z "$DEVTO_URL" ]; then
+            echo "::error::No platform publish succeeded; leaving the draft unpublished"
+            exit 1
+          fi
+
       # ── Step 4.5: blog_posts.status を 'posted' に更新 (UI反映) ────────
       - name: Step 4.5 - Update blog_posts status
-        if: steps.auto_select.outputs.has_draft == 'true' && github.event.inputs.dry_run != 'true'
+        if: >-
+          steps.auto_select.outputs.has_draft == 'true' &&
+          github.event.inputs.dry_run != 'true' &&
+          (steps.publish.outputs.qiita_url != '' || steps.publish.outputs.devto_url != '')
         continue-on-error: true
         env:
           SUPABASE_URL: https://smmkxxavexumewbfaqpy.supabase.co
@@ -454,7 +466,10 @@ jobs:
       # Branch-protection safe: always push a status branch, then auto-merge when BLOG_PAT can.
       # If auto-merge fails, the branch/PR remains as the manual fallback.
       - name: Step 5 - Mark draft as published
-        if: steps.auto_select.outputs.has_draft == 'true' && github.event.inputs.dry_run != 'true'
+        if: >-
+          steps.auto_select.outputs.has_draft == 'true' &&
+          github.event.inputs.dry_run != 'true' &&
+          (steps.publish.outputs.qiita_url != '' || steps.publish.outputs.devto_url != '')
         env:
           GH_TOKEN: ${{ secrets.BLOG_PAT || secrets.GH_PAT_BLOG_MERGE || secrets.BYPASS_RULES || github.token }}
           BLOG_PAT: ${{ secrets.BLOG_PAT }}
@@ -477,6 +492,11 @@ jobs:
         run: |
           DRY_RUN="${{ github.event.inputs.dry_run }}"
           STATUS="success"
+          if [ "${{ steps.auto_select.outputs.has_draft }}" = "true" ] && \
+             [ "$DRY_RUN" != "true" ] && \
+             [ -z "$QIITA_URL" ] && [ -z "$DEVTO_URL" ]; then
+            STATUS="failure"
+          fi
           SUMMARY="blog-publish: $ARTICLE_TITLE | dry_run=$DRY_RUN | qiita=$QIITA_URL | devto=$DEVTO_URL"
           curl -s -o /dev/null \
             -X POST \

--- a/test/scripts/test_qiita_suspension_workflows.py
+++ b/test/scripts/test_qiita_suspension_workflows.py
@@ -34,3 +34,16 @@ def test_scheduled_publish_is_devto_only_and_ready_queue_fails_closed() -> None:
     assert 'PLATFORMS="qiita,devto"' not in publish
     assert publish.count('PLATFORMS="devto"') >= 2
     assert '"platforms": ["devto"]' in publish
+
+
+def test_publish_status_only_advances_after_a_platform_returns_a_url() -> None:
+    publish = workflow("blog-publish.yml")
+
+    assert 'if [ -z "$QIITA_URL" ] && [ -z "$DEVTO_URL" ]; then' in publish
+    assert "No platform publish succeeded; leaving the draft unpublished" in publish
+    success_gate = (
+        "(steps.publish.outputs.qiita_url != '' || "
+        "steps.publish.outputs.devto_url != '')"
+    )
+    assert publish.count(success_gate) == 2
+    assert 'STATUS="failure"' in publish


### PR DESCRIPTION
## Summary
- fail closed when no platform returns a publish URL
- only mark DB/frontmatter posted after a successful platform URL
- record failed scheduled attempts as failure

## Why
After Qiita was disabled, scheduled dev.to-only runs can have no `draft_path_en`. The old flow still advanced the DB and frontmatter despite publishing nowhere.

## Validation
- `python -m pytest test/scripts/test_qiita_suspension_workflows.py -q` (4 passed)
- workflow YAML parse
- full pre-commit and pre-push quality gates (391 Deno tests passed)

## Minimal E2E Gate
- Implementation-detail independent: the regression test asserts workflow-visible success/failure behavior, not private internals.
- Minimal scope: successful URL, empty-result failure, and failure-status propagation.
- E2E-Exception: Workflow-only fail-closed control; no interactive UI surface changed.