### PR TITLE
sec(schedule-hub): 残り公開書き込み系 7 action を SERVICE_ROLE_ONLY 化 + digest.run を user レベル化

### DIFF
--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           RESP=$(curl -sS -X POST \
             "https://smmkxxavexumewbfaqpy.supabase.co/functions/v1/schedule-hub" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
             -H "Content-Type: application/json" \
             -d "{\"action\":\"notion.sync_wbs\",\"limit\":${{ github.event.inputs.limit || '30' }},\"offset\":${{ github.event.inputs.offset || '0' }}}" \
             --max-time 600)
@@ -125,7 +125,7 @@ jobs:
 
       - name: Call schedule-hub:notion.sync_roadmap
         env:
-          SUPABASE_AUTH_TOKEN: ${{ secrets.SUPABASE_ANON_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_AUTH_TOKEN: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           ROADMAP_MAX_CHARS: ${{ github.event.inputs.roadmap_max_chars || '24000' }}
         run: |
           python3 - <<'PY'
@@ -186,7 +186,7 @@ jobs:
 
       - name: Call schedule-hub:notion.sync_memory_index
         env:
-          SUPABASE_AUTH_TOKEN: ${{ secrets.SUPABASE_ANON_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_AUTH_TOKEN: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           MEMORY_LIMIT: ${{ github.event.inputs.memory_limit || '50' }}
         run: |
           python3 - <<'PY'

--- a/.github/workflows/wbs-ai-review.yml
+++ b/.github/workflows/wbs-ai-review.yml
@@ -232,9 +232,11 @@ jobs:
 
           curl -sf -X POST \
             "${SUPABASE_URL}/functions/v1/schedule-hub" \
+            -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
             -H "Content-Type: application/json" \
             -d '{"action":"wbs.unblock_dependents"}' \
-            --max-time 30 || echo "::warning::wbs.unblock_dependents action not yet deployed (skip)"
+            --max-time 30 || echo "::warning::wbs.unblock_dependents call failed (skip)"
 
       # ── Step 5: skip log ─────────────────────────────
       - name: Step 5 - No-op log if skipped

--- a/supabase/functions/schedule-hub/action_auth.ts
+++ b/supabase/functions/schedule-hub/action_auth.ts
@@ -4,40 +4,54 @@
 // - public: 認証不要 (read-only or 公開 endpoint)。書き込み系を足す前に
 //   service_role 化を検討すること (anon key は Web アプリ同梱 = 実質公開)。
 // - service_role: Bearer === SERVICE_ROLE_KEY 必須。オーナー資格情報
-//   (QIITA_ACCESS_TOKEN / DEVTO_API_KEY / X API) での投稿や hub_data への
-//   system 書き込みを行う action はここ。
+//   (QIITA_ACCESS_TOKEN / DEVTO_API_KEY / X API / NOTION_TOKEN) での投稿や
+//   hub_data / wbs_tasks への system 書き込みを行う action はここ。
 // - user: ログイン user JWT (or service role)。
 
 export type ActionAuthLevel = "public" | "service_role" | "user";
 
 // 認証不要 action。
+// billing.create_supporter_checkout_session は非ログイン支援者導線
+// (subscription_billing_page は未ログインで到達可能) のため public 維持:
+// handler は userId 不使用 / 金額はサーバ側 env 固定 / attribution metadata は
+// 160 字切詰のみ Stripe metadata へ透過。
 export const PUBLIC_ACTIONS: readonly string[] = [
-  "digest.run",
   "health.check",
   "blog.recent_posted", // Win版#132 part 124: tech-blog-tracker page 用 public read
-  "reminders.study",
-  "notion.sync_wbs",
-  "notion.preflight_wbs",
-  "notion.sync_roadmap",
-  "notion.sync_memory_index",
-  "notion.fix_wbs_all_instances",
-  "wbs.unblock_dependents",
   "billing.create_supporter_checkout_session",
   "maintenance.list_active",
 ];
 
 // SERVICE_ROLE_KEY Bearer 必須の書き込み系 action。
-// 呼び出し元は GHA workflow のみ: blog-publish.yml (blog.create /
-// blog.auto_publish) / blog-batch-publish.yml → scripts/batch_publish.py
-// (blog.auto_publish) / blog-backfill-from-apis.yml (blog.backfill_from_apis) /
-// post-x-with-media.yml (x.post_with_media) — 全て SERVICE_ROLE_KEY を送る。
+// 呼び出し元は GHA workflow / ops script のみ — 全て SERVICE_ROLE_KEY を送る:
+// - blog.create / blog.auto_publish: blog-publish.yml / blog-batch-publish.yml
+// - blog.backfill_from_apis: blog-backfill-from-apis.yml
+// - x.post_with_media: post-x-with-media.yml
+// - notion.sync_wbs: notion-sync.yml / issue-to-wbs.yml (Notion API 書き込み)
+// - notion.preflight_wbs: scripts/release_readiness_gate.py (Notion schema 読取)
+// - notion.sync_roadmap / notion.sync_memory_index: notion-sync.yml
+// - notion.fix_wbs_all_instances: 手動 ops のみ (リポジトリ内呼び出しなし)
+// - wbs.unblock_dependents: wbs-ai-review.yml (wbs_tasks status 更新)
+// - reminders.study: ai-university-reminder.yml / daily-report.yml
+//   (app_notifications insert / handler 内 service-role チェックも維持)
 // anon key・ログイン user JWT では 401 (匿名 signup JWT でも通せない)。
 export const SERVICE_ROLE_ONLY_ACTIONS: readonly string[] = [
   "blog.auto_publish",
   "blog.create",
   "blog.backfill_from_apis",
   "x.post_with_media",
+  "notion.sync_wbs",
+  "notion.preflight_wbs",
+  "notion.sync_roadmap",
+  "notion.sync_memory_index",
+  "notion.fix_wbs_all_instances",
+  "wbs.unblock_dependents",
+  "reminders.study",
 ];
+
+// digest.run は listed どちらにも無い = user レベル (要ログイン user JWT or
+// service role)。呼び出し元は daily-report.yml (SERVICE_ROLE_KEY) と
+// admin_analytics_page (session 必須 / user JWT) の 2 系統のみ。
 
 export function requiredAuthLevel(action: string): ActionAuthLevel {
   if (SERVICE_ROLE_ONLY_ACTIONS.includes(action)) return "service_role";

--- a/supabase/functions/schedule-hub/action_auth_test.ts
+++ b/supabase/functions/schedule-hub/action_auth_test.ts
@@ -5,7 +5,7 @@ import {
   SERVICE_ROLE_ONLY_ACTIONS,
 } from "./action_auth.ts";
 
-Deno.test("書き込み系 4 action は service_role 必須", () => {
+Deno.test("blog/x 書き込み系 4 action は service_role 必須", () => {
   for (
     const action of [
       "blog.auto_publish",
@@ -18,17 +18,39 @@ Deno.test("書き込み系 4 action は service_role 必須", () => {
   }
 });
 
-Deno.test("read-only public action は public のまま", () => {
+Deno.test("notion/wbs/reminders 書き込み系 7 action は service_role 必須", () => {
+  for (
+    const action of [
+      "notion.sync_wbs",
+      "notion.preflight_wbs",
+      "notion.sync_roadmap",
+      "notion.sync_memory_index",
+      "notion.fix_wbs_all_instances",
+      "wbs.unblock_dependents",
+      "reminders.study",
+    ]
+  ) {
+    assertEquals(requiredAuthLevel(action), "service_role");
+  }
+});
+
+Deno.test("read-only public action + 非ログイン支援者導線は public のまま", () => {
   for (
     const action of [
       "health.check",
       "blog.recent_posted",
       "maintenance.list_active",
-      "digest.run",
+      "billing.create_supporter_checkout_session",
     ]
   ) {
     assertEquals(requiredAuthLevel(action), "public");
   }
+});
+
+Deno.test("digest.run は user レベルへ降格 (public から削除)", () => {
+  assertEquals(requiredAuthLevel("digest.run"), "user");
+  assertEquals(PUBLIC_ACTIONS.includes("digest.run"), false);
+  assertEquals(SERVICE_ROLE_ONLY_ACTIONS.includes("digest.run"), false);
 });
 
 Deno.test("未知 / user 向け action は user JWT 必須", () => {


### PR DESCRIPTION
## Summary

[PR #3975](https://github.com/kanta13jp1/my_web_app/pull/3975) の続き (task_2ecc200a)。schedule-hub の `PUBLIC_ACTIONS` に残っていた書き込み系 9 action を、呼び出し元の Authorization ヘッダを全数 grep して監査した。

### 監査結果

| action | 呼び出し元 (送信 credential) | 判定 |
|---|---|---|
| notion.sync_wbs | notion-sync.yml (`ANON‖SR` fallback) / issue-to-wbs.yml (SR) | **service_role** |
| notion.preflight_wbs | scripts/release_readiness_gate.py (SR) | **service_role** |
| notion.sync_roadmap | notion-sync.yml (`ANON‖SR` fallback) | **service_role** |
| notion.sync_memory_index | notion-sync.yml (`ANON‖SR` fallback) | **service_role** |
| notion.fix_wbs_all_instances | リポジトリ内呼び出しなし (手動 ops) | **service_role** |
| wbs.unblock_dependents | wbs-ai-review.yml (**認証ヘッダなし**) | **service_role** |
| reminders.study | ai-university-reminder.yml (SR) / daily-report.yml (SR) — handler 内に既存 SR チェックあり (維持 = defense-in-depth) | **service_role** (形式化) |
| digest.run | daily-report.yml (SR) / admin_analytics_page.dart (session 必須 → user JWT) | **user レベル** (PUBLIC から削除のみ / read-only だが public 露出不要) |
| billing.create_supporter_checkout_session | subscription_billing_page.dart (非ログイン到達可能な支援者導線 / handler は userId 不使用・金額はサーバ側 env 固定・attribution は 160 字切詰で Stripe metadata へ) | **public 据え置き** |

### 実穴の修正

`wbs.unblock_dependents` は schedule-hub が `--no-verify-jwt` デプロイのため、**認証ヘッダ一切なしで誰でも wbs_tasks の status を書き換え可能**だった (wbs-ai-review.yml の curl 自体もヘッダなしで呼んでいた)。本 PR で service_role 必須化 + workflow 側に `Authorization`/`apikey` ヘッダ追加 (env に `SUPABASE_SERVICE_ROLE_KEY` 定義済みを確認)。

### Workflow 側の同時修正

- `notion-sync.yml`: `secrets.SUPABASE_ANON_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY` fallback を SR 直指定に変更 (3 箇所)。ANON_KEY secret が設定されている場合、service_role 化後に 401 になるのを防ぐ。
- `wbs-ai-review.yml`: 上記ヘッダ追加。

### Tests

- `deno test action_auth_test.ts` → **6 passed / 0 failed**
- `deno fmt --check` / `deno lint` 緑、workflow YAML parse 緑

### 本番検証プラン (マージ後 deploy-prod.yml 自動デプロイ後)

- anon key Bearer で `notion.sync_wbs` / `wbs.unblock_dependents` / `reminders.study` → 401
- anon key Bearer で `digest.run` → 401 (user レベル化)
- anon key Bearer で `blog.recent_posted` (public read) → 200 (regression なし)
- SR 側は次回の notion-sync / daily-report cron 緑で証明

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: GHA-only write actions moved behind SERVICE_ROLE_KEY gate; pure allowlist change with deno unit tests, no new handler logic

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno Edge Function auth allowlist change; covered by deno unit tests (action_auth_test.ts 6 tests) + production curl 401/200 verification after deploy; no Flutter runtime surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
