### PR TITLE
docs(security): 依存パッケージ脆弱性チェック 2026-07-13 (週次)

### DIFF
--- a/docs/security-audit/2026-07-13.md
+++ b/docs/security-audit/2026-07-13.md
@@ -1,0 +1,195 @@
+# 依存パッケージ脆弱性チェック 2026-07-13
+
+> 自動週次タスク `scheduled-tasks/dependency-audit` 実行ログ。前回: 2026-07-06 (~1週前)。
+
+## サマリ
+
+| 項目 | 結果 |
+|---|---|
+| Flutter advisory-affected (`isCurrentAffectedByAdvisory`) | **0** ✅ |
+| Flutter discontinued (`pub get` 解決時警告) | **1** ⚠️ 繰越 — `flutter_markdown` 0.7.7+1 (→ `flutter_markdown_plus`) |
+| Direct 制約内 upgradable (lockfile のみ) | 6 件 (`cross_file` / `flutter_map` / `image_picker` / `sentry_flutter` / `timezone` / `build_runner`) |
+| Direct/Dev 制約 bump 要 (pubspec.yaml 制約変更) | 18 件 (うち major 4: `flutter_lints` / `mime` / `package_info_plus` / `share_plus`) |
+| Deno EF `std` 統一バージョン | `@0.224.0` **76 import** (前回 53 / 100% 統一・`.ts` stale 0) ✅ |
+| Deno EF `npm:@supabase/supabase-js@2` | **27 import** (前回 25 / メジャー固定) ✅ |
+| Deno EF `jose` | `v5.9.6` (1 箇所) — **v6.x が現行 major** ⚠️ 監視継続 (CVE 該当無・前回審査済) |
+
+**今回の自動アップグレード**: **適用なし** (report-only)。理由は下記「自動化を見送った理由」。
+
+---
+
+## 🟡 今週のハイライト: 前回検出 3 項目はいずれも据置 (advisory 0 継続)
+
+先週 (7/06) に新規検出した `flutter_markdown` discontinued を含め、今週も**新規の advisory / discontinued はゼロ**。既知項目は全て前進 or 据置で、緊急対応を要する脆弱性は無し。
+
+- **advisory-affected: 0** (`flutter pub outdated --json` の 81 パッケージ全件 `isCurrentAffectedByAdvisory: false`) ✅
+- **discontinued: 1** (`flutter_markdown` — 繰越 / 下記)
+- セキュリティ中核 (`supabase_flutter` / `gotrue` / `crypto` / `http` / `flutter_secure_storage` / `sentry_flutter` / `jose`) は全て advisory 無し。version drift のみ。
+
+---
+
+## 🔴 繰越: `flutter_markdown` が discontinued (先週新規検出)
+
+`flutter pub get` 解決時警告 (今週も継続):
+
+```
+flutter_markdown 0.7.7+1 (discontinued replaced by flutter_markdown_plus)
+1 package is discontinued.
+```
+
+- **状況**: Flutter 公式 `flutter_markdown` は開発終了。後継はコミュニティ fork の **`flutter_markdown_plus`** (API 互換)。
+- **advisory ではない**: 既知 CVE / advisory 無し (`isCurrentAffectedByAdvisory: false`)。緊急性は低いが、**今後セキュリティ修正・Flutter 新版追随が来ない**サプライチェーン保守リスク。
+- **影響範囲**: **12 ファイル**が `package:flutter_markdown/flutter_markdown.dart` を import (`blog_draft_editor` / `ai_secretary` / `ai_university_content` / `asset_management` / `blog_post` / `gemini_university_v2` / `legal_document` / `morning_briefing` / `philosophy` / `privacy_policy` / `ai_dev_principles` / `widgets/markdown_preview`)。先週と件数変化なし。
+- **pubspec 制約**: `flutter_markdown: ^0.7.4+1`。lock 解決版 `0.7.7+1` = 既に latest (これ以上の更新は出ない)。
+- **移行の形**: `pubspec.yaml` の依存を `flutter_markdown_plus` へ差替え + 12 ファイルの import path を `package:flutter_markdown_plus/flutter_markdown_plus.dart` へ一括置換。API 互換 fork のため型名 (`MarkdownBody` 等) は基本据置。
+- **判断**: **autonomous 本タスクでは実施しない** = 12 ファイル横断の依存置換は `flutter analyze` / render smoke での回帰確認が必須で、当環境は analyze OOM・smoke JIT クラッシュ実績あり (memory 既知)。未検証 push はリスク → **interactive / CI verify 可能セッション (Codex #1 / Win Claude) で 1 PR** 推奨。
+
+> ⚠️ 注 (教訓の再掲): `flutter pub outdated --json` の `isDiscontinued` は **0 と出る**。`flutter_markdown` は既に latest 版で「新バージョン無し」→ outdated 一覧に載らず、discontinued フラグも付かない。discontinued 判定は **`flutter pub get` の解決時警告が正**。outdated JSON だけでは取りこぼす。
+
+---
+
+## Flutter/Dart パッケージ
+
+`flutter pub outdated` (81 パッケージ) で取得。`flutter pub get` は「79 packages have newer versions incompatible with dependency constraints / 31 upgradable locked / 18 constrained older than resolvable」を報告。
+
+### A. 制約内 upgradable (= `flutter pub upgrade <pkg>` で lockfile のみ更新)
+
+| パッケージ | 種別 | 現在 | upgradable | latest | 種類 |
+|---|---|---|---|---|---|
+| `cross_file` | direct | 0.3.5+2 | **0.3.5+4** | 0.3.5+4 | patch |
+| `flutter_map` | direct | 8.3.0 | **8.3.1** | 8.3.1 | patch |
+| `image_picker` | direct | 1.2.2 | **1.2.3** | 1.2.3 | patch |
+| `sentry_flutter` | direct | 9.22.0 | **9.24.0** | 9.24.0 | minor |
+| `timezone` | direct | 0.11.0 | **0.11.1** | 0.11.1 | patch |
+| `build_runner` | dev | 2.15.0 | **2.15.1** | 2.15.1 | patch |
+
+> 前回 (7/06) 比: `sentry_flutter` は 9.23.0 → **9.24.0** へ再前進。`build_runner` 2.15.1 が今週新たに制約内 upgradable として出現。他 5 件は前回同様。
+
+### B. pubspec.yaml 制約 bump が必要 (constraint が現行を pin)
+
+| パッケージ | 種別 | 現在 | resolvable | latest | 種類 | 備考 |
+|---|---|---|---|---|---|---|
+| `flutter_lints` | dev | 3.0.2 | 6.0.0 | 6.0.0 | **major (+3)** | lint ルール変更あり。要 `flutter analyze` 差分確認 |
+| `mime` | direct | 1.0.6 | 2.0.0 | 2.0.0 | **major** | MIME 判定。API 変更要確認 (繰越) |
+| `package_info_plus` | direct | 8.3.1 | 10.2.0 | 10.2.0 | **major (+2)** | アプリ情報。2 メジャー跳び (繰越) |
+| `share_plus` | direct | 12.0.2 | 13.2.0 | 13.2.0 | **major** | 4/20 audit からの繰越 |
+| `latlong2` | direct | 0.9.1 | 0.10.1 | 0.10.1 | minor (pre-1.0=breaking) | flutter_map 連動。地図機能 |
+| `supabase_flutter` | direct | 2.14.2 | 2.16.0 | 2.16.0 | minor | **`supabase` dev exact-pin (2.12.2) が transitive を gate** → 同時 bump 要 |
+| `supabase` (dev) | dev | 2.12.2 | 2.14.0 | 2.14.0 | minor | pubspec.yaml で `2.12.2` 完全固定。supabase_flutter 連動 |
+
+> 前回 (7/06) 比: `supabase_flutter` resolvable 2.15.4 → **2.16.0** / dev `supabase` 2.13.4 → **2.14.0** へ前進 (依然同時 bump 必須の関係は不変)。major 4 件は据置。
+
+### C. latest のみ更新あり (resolvable == 現在 / SDK・依存グラフが上限を pin)
+
+| パッケージ | 種別 | 現在 | latest | 種類 | 備考 |
+|---|---|---|---|---|---|
+| `pdf` | direct | 3.12.0 | 3.13.0 | minor | 現グラフでは resolvable 外。選挙 KPI レポート PDF |
+| `printing` | direct | 5.14.3 | 5.15.0 | minor | 同上 |
+| `audioplayers` | direct | 6.7.1 | 6.8.1 | minor | 現グラフで resolvable 外 |
+| `intl` | direct | 0.20.2 | 0.20.3 | patch | Flutter SDK (flutter_localizations) が pin |
+| `xml` | direct | 6.6.1 | 7.0.1 | **major** | resolvable も 6.6.1 (`archive` 等 transitive が gate)。要依存グラフ調整 |
+| `mockito` | dev | 5.6.4 | 5.7.0 | minor | 現 SDK グラフで resolvable 外 |
+| `flutter_native_splash` | dev | 2.4.7 | 2.4.8 | patch | pubspec で `>=2.4.7 <2.4.8` 明示 pin → 対象外 |
+| `test` | dev | 1.30.0 | 1.31.2 | minor | **Flutter SDK が pin** (SDK 同梱版が上限) |
+
+> `xml` 7.0.1 は今週の新規注記: latest は major だが resolvable は 6.6.1 に留まる (transitive gate)。単独 bump 不可のため据置監視。
+
+### Advisory / Discontinued
+- `isCurrentAffectedByAdvisory: true` → **0 件** ✅ (81 パッケージ全件確認)
+- `isDiscontinued` (outdated JSON) → 0 件だが、`pub get` 解決時警告で **`flutter_markdown` 1 件**を検出 (上記ハイライト参照)。
+
+### セキュリティ関連パッケージの現況
+| パッケージ | 制約 | 解決版 | 状態 |
+|---|---|---|---|
+| `supabase_flutter` | `^2.0.0` | 2.14.2 | minor 遅れ (resolvable 2.16.0)・advisory 無 ✅ |
+| `gotrue` (transitive / 認証本体) | (supabase 連動) | 2.21.0 | resolvable 2.26.0・advisory 無 ✅ (supabase 同時 bump で追随) |
+| `flutter_secure_storage` | `^10.3.1` | 10.3.1 | 最新 ✅ |
+| `crypto` | `^3.0.7` | 最新追随 | ✅ |
+| `http` | `any` | 最新追随 | ✅ |
+| `sentry_flutter` | `^9.22.0` | 9.22.0 | minor 遅れ (9.24.0 制約内)・advisory 無 ✅ |
+
+---
+
+## Supabase Edge Functions (Deno)
+
+### `deno.land/std` 統一状況
+
+| バージョン | `.ts` import 数 | 状態 |
+|---|---|---|
+| `@0.224.0` | **76** | ✅ 100% 統一 (前回 53 / `.ts` ソースの stale 版 0) |
+| 旧版 (`@0.168.0` / `@0.177.0` 等) | **0** (`.ts` ソース) | ✅ 残存なし |
+
+`.ts` ソースからの旧 `std` 直接 import は **0 件** (統一状態を維持)。
+
+> ⚠️ 注: `deno.lock` には transitive 解決の副産物として `std@0.168.0` (11 参照) と `@supabase/supabase-js@2.90.1` / `@2.105.1` の pin が残るが、これは lockfile の解決グラフ由来で**ソース側の直接 import ではない** (ソースは floating `@2`)。ソース healthy を確認済。
+
+### npm: / x: 依存
+
+| 依存 | 箇所 (`.ts`) | 状態 |
+|---|---|---|
+| `npm:@supabase/supabase-js@2` | **27 import** | ✅ メジャー固定 (`@2` で自動最新) |
+| `https://deno.land/x/jose@v5.9.6` | `_shared/mcp_auth_guard.ts` 1 箇所 | ⚠️ **v6.x が現行 major** — 下記参照 |
+| `esm.sh/*` (ソース pin) | 0 | ✅ 使用なし |
+| その他 `deno.land/x/*` / `npm:*` pin | 0 | ✅ 上記以外の外部 pin 依存なし |
+
+### `jose` v5.9.6 (前回 audit 繰越の監視項目)
+
+- 用途: WorkOS JWKS による JWT 検証本体 (= MCP 認可基盤 / `MCP_AUTH_SECURITY_PRINCIPLES.md` 原則 #2/#5/#7/#8 の中核)。
+- **CVE 調査結果 (据置有効)**: 2025-2026 の JWT 系 CVE は Nimbus JOSE+JWT (Java) / pac4j-jwt (Java) 向けで、当方の **panva/jose (JS/Deno)** には非該当。**v5.9.6 に対する既知有効 advisory 無し** ✅。
+- **バージョン状況**: 現行 major は v6.x。v5→v6 は Node 18 サポート廃止等が主で、セキュリティ駆動の必須 upgrade ではない。
+- **判断**: **据置 (監視継続)**。v6 major upgrade は MCP 認可中核ゆえ JWKS 検証・cache 挙動・API 差分を確認できる interactive セッションで実施。緊急性無。
+
+---
+
+## 自動化を見送った理由 (report-only の根拠)
+
+本タスクは「patch は自動更新してコミット」を原則とするが、今回も **全件見送り** (前回 7/06・前々回 6/22 と同判断)。根拠:
+
+1. **クリーンな patch 更新が単独で取り出せない**: origin/main 起点の fresh worktree で `flutter pub get` を実行しただけで stale lockfile が更新され transitive churn ＋ native `generated_plugin_registrant` 再生成が巻き込まれる。`flutter pub upgrade <pkg>` で patch を隔離しても最小 diff にならない (前回審査と同一の構造問題が継続)。
+2. **本環境で検証不能**: 当 Win 環境は全ツリー `flutter analyze` が OOM・巨大 page smoke が JIT クラッシュする実績 (memory 既知)。lockfile + native registrant churn を `analyze`/`test` で verify できないまま push するのはリスク。
+3. **native registrant churn は Web アプリに無関係なノイズ**: 本番は **Flutter Web** (Firebase Hosting) デプロイ。linux/macOS/windows の plugin registrant 差分はデプロイに一切寄与せず、commit するのは純ノイズ。
+4. **stale branch 実行**: 本セッションの checkout は `codex/issue-1215-hitl` で **origin/main から 1761 commit behind**。依存ファイルは全て origin/main の fresh worktree から読取り (`feedback_scheduled_task_stale_branch_origin_main_authoritative` 準拠)。stale ツリーからの依存変更 push は履歴巻き戻しリスク。
+5. **unattended 実行**: user 不在の autonomous 実行で未検証の依存変更 + 無関係 native 差分を push するのは過剰。→ 「迷ったらレポート出力が正しい出力」に従い report-only を採用。
+
+---
+
+## アクション
+
+### ✅ 完了 (今回 audit)
+- `flutter pub outdated --json` で direct/dev/advisory/discontinued 一括判定 (81 パッケージ / advisory 0)
+- **`flutter_markdown` discontinued を再確認** (pub get 解決時警告 / 影響 12 ファイル据置 / 後継 `flutter_markdown_plus`)
+- Deno EF `std` 横断 grep (`.ts` stale 版 0 / `@0.224.0` 76 import 統一を再確認 / deno.lock の transitive 残存を切り分け)
+- `npm:@supabase/supabase-js@2` 全 27 箇所のメジャー固定を確認 / esm.sh・その他 x: pin = 0 を確認
+- `jose@v5.9.6` = 前回 CVE 調査結果を据置 (v6 監視継続・緊急性無)
+
+### 📋 次回推奨 (interactive / CI verify 可能セッションで)
+
+- [ ] 🔴 **`flutter_markdown` → `flutter_markdown_plus` 移行** (最優先の保守リスク解消 / 1 PR): pubspec 依存差替え + 12 ファイル import path 一括置換 → `flutter analyze` 0 + markdown 描画 render 確認 + CI gate。
+- [ ] **patch/minor (制約内・低リスク)**: `cross_file` 0.3.5+4 / `flutter_map` 8.3.1 / `image_picker` 1.2.3 / `sentry_flutter` 9.24.0 / `timezone` 0.11.1 / `build_runner` 2.15.1 を `flutter pub upgrade <pkg>` で lockfile 更新 → `flutter analyze` 0 + CI gate 通過確認。
+- [ ] **major (要 breaking 確認・PR 単位)**: `flutter_lints` 6.x / `package_info_plus` 10.x / `mime` 2.x / `share_plus` 13.x — 各 1 PR で API 差分確認。
+- [ ] **supabase 連動**: `supabase_flutter` 2.16.0 ＋ dev `supabase` 2.14.0 を **同時** bump (exact-pin gate ゆえ片方だけでは resolvable 外 / 認証 `gotrue` 2.26.0 も追随)。
+- [ ] **`jose` v6**: MCP 認可影響度評価込みで interactive 実施 (緊急性無 = CVE 該当無し)。
+- [ ] **`xml` 7.x**: `archive` 等 transitive gate ゆえ依存グラフ全体調整が必要。単独不可のため据置監視。
+
+### 🟢 残課題 (前回 audit からの繰越状況)
+
+| 前回 (7/06) 宿題 | 状況 |
+|---|---|
+| `flutter_markdown` → `flutter_markdown_plus` 移行 | ⏳ 未着手 (今回も report / 影響 12 ファイル据置) |
+| patch/minor (`cross_file`/`flutter_map`/`image_picker`/`sentry_flutter`/`timezone`) lockfile 更新 | ⏳ 未着手 (`sentry_flutter` は 9.24.0 へ前進・`build_runner` が新規追加) |
+| major (`flutter_lints`/`package_info_plus`/`mime`/`share_plus`) | ⏳ 未着手 (今回も report) |
+| `supabase_flutter` + dev `supabase` 同時 bump | ⏳ 未着手 (resolvable 2.16.0 / 2.14.0 へ前進) |
+| `jose` v6 interactive 評価 | ⏳ 監視継続 (CVE 該当無・緊急性無) |
+| Deno std `@0.224.0` 統一 | ✅ 維持 (`.ts` stale 0 / import 53→76) |
+
+---
+
+## 環境メタ
+
+- Flutter SDK: 3.41.7 (stable / `flutter pub outdated` 正常完了 / 81 パッケージ判定)
+- Dart: 3.11.5 / Deno: 2.8.2
+- Branch: セッション checkout は `codex/issue-1215-hitl` (origin/main `1d2a8a017` から **1761 behind**) → 依存ファイルは全て **origin/main fresh worktree** (`/c/tmp/dep-audit-main`) から読取り。本 report のみを origin/main 起点の docs-only branch で landing。
+- Caller: scheduled `dependency-audit` (週次 / autonomous / user 不在)
+- 本 report のみコミット (依存ファイル・lockfile 変更なし = report-only)
+
+> 前回 audit: [`2026-07-06.md`](./2026-07-06.md) / [`2026-06-22.md`](./2026-06-22.md) / [`2026-06-15.md`](./2026-06-15.md)


### PR DESCRIPTION
## 概要

週次 scheduled task `dependency-audit` の自動レポート (2026-07-13)。**docs-only / report-only** (依存ファイル・lockfile の変更なし)。

## 結果サマリ

| 項目 | 結果 |
|---|---|
| Flutter advisory-affected | **0** ✅ |
| Flutter discontinued | 1 ⚠️ 繰越 (`flutter_markdown` → `flutter_markdown_plus`) |
| Deno EF `std@0.224.0` | 76 import 統一 ✅ (`.ts` stale 0) |
| Deno EF `supabase-js@2` | 27 import (メジャー固定) ✅ |
| `jose` v5.9.6 | 監視継続 (CVE 非該当) ⚠️ |

## 主な所見

- **緊急対応を要する脆弱性なし** (81 パッケージ全件 `isCurrentAffectedByAdvisory: false`)。
- `flutter_markdown` discontinued は前回 (7/06) 検出分の繰越。影響 12 ファイル。移行は要 render 検証のため interactive/CI セッションで 1 PR 推奨。
- 制約内 upgradable 6 件・制約 bump 要 18 件 (major 4) は全て report のみ (下記理由)。
- セキュリティ中核 (`supabase_flutter` / `gotrue` / `crypto` / `http` / `flutter_secure_storage` / `sentry_flutter`) は version drift のみで advisory 無し。

## report-only の理由

- 本環境は全ツリー `flutter analyze` OOM で依存変更を検証不能。
- `flutter pub get` が native registrant + lockfile churn を巻き込み、clean な patch 隔離が不可。
- セッション checkout が `codex/issue-1215-hitl` (origin/main から 1761 behind) のため、依存ファイルは origin/main fresh worktree から読取り・本 report のみ landing。
- unattended 実行ゆえ未検証 push は回避 (「迷ったらレポート出力が正しい出力」)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)