### PR TITLE
feat: add CFO cost ledger

### DIFF
--- a/lib/models/cfo_cost_ledger.dart
+++ b/lib/models/cfo_cost_ledger.dart
@@ -1,0 +1,145 @@
+enum CfoCostType {
+  fixed,
+  variable;
+
+  String get databaseValue => switch (this) {
+        CfoCostType.fixed => 'fixed',
+        CfoCostType.variable => 'variable',
+      };
+
+  String get label => switch (this) {
+        CfoCostType.fixed => '固定費',
+        CfoCostType.variable => '変動費',
+      };
+
+  static CfoCostType fromValue(Object? value) {
+    return switch (value?.toString()) {
+      'fixed' => CfoCostType.fixed,
+      _ => CfoCostType.variable,
+    };
+  }
+}
+
+class CfoCostEntry {
+  const CfoCostEntry({
+    required this.id,
+    required this.item,
+    required this.category,
+    required this.amountJpy,
+    required this.incurredOn,
+    required this.costType,
+    required this.note,
+    this.createdAt,
+  });
+
+  final String id;
+  final String item;
+  final String category;
+  final int amountJpy;
+  final DateTime incurredOn;
+  final CfoCostType costType;
+  final String note;
+  final DateTime? createdAt;
+
+  factory CfoCostEntry.fromMap(Map<String, dynamic> map) {
+    return CfoCostEntry(
+      id: map['id']?.toString() ?? '',
+      item: map['item']?.toString() ?? '',
+      category: map['category']?.toString() ?? 'other',
+      amountJpy: (map['amount_jpy'] as num?)?.round() ?? 0,
+      incurredOn: DateTime.tryParse(map['incurred_on']?.toString() ?? '') ??
+          DateTime.now(),
+      costType: CfoCostType.fromValue(map['cost_type']),
+      note: map['note']?.toString() ?? '',
+      createdAt: DateTime.tryParse(map['created_at']?.toString() ?? ''),
+    );
+  }
+}
+
+class CfoCostEntryDraft {
+  const CfoCostEntryDraft({
+    required this.item,
+    required this.category,
+    required this.amountJpy,
+    required this.incurredOn,
+    required this.costType,
+    required this.note,
+  });
+
+  final String item;
+  final String category;
+  final int amountJpy;
+  final DateTime incurredOn;
+  final CfoCostType costType;
+  final String note;
+
+  Map<String, dynamic> toInsertMap(String userId) {
+    return <String, dynamic>{
+      'user_id': userId,
+      'item': item,
+      'category': category,
+      'amount_jpy': amountJpy,
+      'incurred_on': _dateOnly(incurredOn),
+      'cost_type': costType.databaseValue,
+      'note': note,
+    };
+  }
+}
+
+class CfoMonthlyBudget {
+  const CfoMonthlyBudget({required this.month, required this.budgetJpy});
+
+  final String month;
+  final int budgetJpy;
+
+  factory CfoMonthlyBudget.fromMap(Map<String, dynamic> map) {
+    return CfoMonthlyBudget(
+      month: map['month']?.toString() ?? '',
+      budgetJpy: (map['budget_jpy'] as num?)?.round() ?? 0,
+    );
+  }
+}
+
+class CfoMonthlyCostSummary {
+  const CfoMonthlyCostSummary({
+    required this.month,
+    required this.budgetJpy,
+    required this.fixedCostJpy,
+    required this.variableCostJpy,
+    required this.categoryTotals,
+    required this.entries,
+  });
+
+  final String month;
+  final int budgetJpy;
+  final int fixedCostJpy;
+  final int variableCostJpy;
+  final Map<String, int> categoryTotals;
+  final List<CfoCostEntry> entries;
+
+  int get totalCostJpy => fixedCostJpy + variableCostJpy;
+
+  int get budgetRemainingJpy => budgetJpy - totalCostJpy;
+
+  double get budgetUsageRatio {
+    if (budgetJpy <= 0) {
+      return 0;
+    }
+    return totalCostJpy / budgetJpy;
+  }
+
+  bool get isOverBudget => budgetJpy > 0 && totalCostJpy > budgetJpy;
+
+  bool get hasBudget => budgetJpy > 0;
+}
+
+String cfoLedgerMonth(DateTime date) {
+  final month = date.month.toString().padLeft(2, '0');
+  return '${date.year}-$month';
+}
+
+String _dateOnly(DateTime date) {
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '${date.year}-$month-$day';
+}

--- a/lib/pages/cfo_cost_ledger_page.dart
+++ b/lib/pages/cfo_cost_ledger_page.dart
@@ -1,0 +1,507 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/cfo_cost_ledger.dart';
+import '../services/cfo_cost_ledger_service.dart';
+
+class CfoCostLedgerPage extends StatefulWidget {
+  const CfoCostLedgerPage({super.key});
+
+  @override
+  State<CfoCostLedgerPage> createState() => _CfoCostLedgerPageState();
+}
+
+class _CfoCostLedgerPageState extends State<CfoCostLedgerPage> {
+  final _service = CfoCostLedgerService();
+  final _yenFormat = NumberFormat.currency(
+    locale: 'ja_JP',
+    symbol: '¥',
+    decimalDigits: 0,
+  );
+
+  late String _selectedMonth;
+  CfoCostLedgerSnapshot? _snapshot;
+  bool _isLoading = true;
+  bool _isSaving = false;
+  String? _errorMessage;
+
+  final _itemController = TextEditingController();
+  final _amountController = TextEditingController();
+  final _noteController = TextEditingController();
+  final _budgetController = TextEditingController();
+  String _category = 'operations';
+  CfoCostType _costType = CfoCostType.variable;
+  DateTime _incurredOn = DateTime.now();
+
+  static const _categories = <String, String>{
+    'operations': '運営費',
+    'tools': 'AI/ツール',
+    'marketing': '広告・販促',
+    'infrastructure': 'インフラ',
+    'legal': '法務・管理',
+    'travel': '交通・外出',
+    'other': 'その他',
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedMonth = cfoLedgerMonth(DateTime.now());
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _itemController.dispose();
+    _amountController.dispose();
+    _noteController.dispose();
+    _budgetController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+    try {
+      final snapshot = await _service.loadMonth(month: _selectedMonth);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _snapshot = snapshot;
+        if (snapshot.budget != null) {
+          _budgetController.text = snapshot.budget!.budgetJpy.toString();
+        }
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _errorMessage = '$error');
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  Future<void> _saveBudget() async {
+    final budget = _parseAmount(_budgetController.text);
+    if (budget == null) {
+      _showSnack('予算額を数字で入力してください', isError: true);
+      return;
+    }
+    setState(() => _isSaving = true);
+    try {
+      await _service.setMonthlyBudget(month: _selectedMonth, budgetJpy: budget);
+      await _load();
+      _showSnack('月次予算を保存しました');
+    } catch (error) {
+      _showSnack('予算保存に失敗しました: $error', isError: true);
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  Future<void> _addCostEntry() async {
+    final item = _itemController.text.trim();
+    final amount = _parseAmount(_amountController.text);
+    if (item.isEmpty || amount == null) {
+      _showSnack('コスト項目と金額を入力してください', isError: true);
+      return;
+    }
+    setState(() => _isSaving = true);
+    try {
+      await _service.addEntry(
+        CfoCostEntryDraft(
+          item: item,
+          category: _category,
+          amountJpy: amount,
+          incurredOn: _incurredOn,
+          costType: _costType,
+          note: _noteController.text.trim(),
+        ),
+      );
+      _itemController.clear();
+      _amountController.clear();
+      _noteController.clear();
+      _costType = CfoCostType.variable;
+      await _load();
+      _showSnack('コストを記録しました');
+    } catch (error) {
+      _showSnack('コスト記録に失敗しました: $error', isError: true);
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  int? _parseAmount(String value) {
+    final normalized = value.replaceAll(',', '').trim();
+    final parsed = int.tryParse(normalized);
+    if (parsed == null || parsed < 0) {
+      return null;
+    }
+    return parsed;
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _incurredOn,
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+    );
+    if (picked == null || !mounted) {
+      return;
+    }
+    setState(() {
+      _incurredOn = picked;
+      _selectedMonth = cfoLedgerMonth(picked);
+    });
+    await _load();
+  }
+
+  void _showSnack(String message, {bool isError = false}) {
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError ? const Color(0xFFB91C1C) : null,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot = _snapshot;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('CFO コスト台帳'),
+        backgroundColor: const Color(0xFF166534),
+        foregroundColor: Colors.white,
+        actions: <Widget>[
+          IconButton(
+            tooltip: '再読み込み',
+            icon: const Icon(Icons.refresh),
+            onPressed: _isSaving ? null : _load,
+          ),
+        ],
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _errorMessage != null
+              ? _buildError()
+              : RefreshIndicator(
+                  onRefresh: _load,
+                  child: ListView(
+                    padding: const EdgeInsets.all(16),
+                    children: <Widget>[
+                      if (snapshot != null) _buildSummary(snapshot.summary),
+                      const SizedBox(height: 12),
+                      _buildBudgetForm(),
+                      const SizedBox(height: 12),
+                      _buildCostForm(),
+                      const SizedBox(height: 12),
+                      if (snapshot != null)
+                        _buildEntryList(snapshot.summary.entries),
+                    ],
+                  ),
+                ),
+    );
+  }
+
+  Widget _buildError() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Icon(Icons.error_outline, size: 44, color: Color(0xFFB91C1C)),
+            const SizedBox(height: 12),
+            Text(_errorMessage!, textAlign: TextAlign.center),
+            const SizedBox(height: 12),
+            FilledButton.icon(
+              onPressed: _load,
+              icon: const Icon(Icons.refresh),
+              label: const Text('再試行'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSummary(CfoMonthlyCostSummary summary) {
+    final usage = summary.budgetUsageRatio.clamp(0.0, 1.0);
+    final remaining = summary.budgetRemainingJpy;
+    final statusColor = summary.isOverBudget
+        ? const Color(0xFFB91C1C)
+        : const Color(0xFF15803D);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                const Icon(Icons.account_balance_wallet_outlined),
+                const SizedBox(width: 8),
+                Text(
+                  '$_selectedMonth 月次コスト',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: <Widget>[
+                _summaryChip('総支出', summary.totalCostJpy),
+                _summaryChip('固定費', summary.fixedCostJpy),
+                _summaryChip('変動費', summary.variableCostJpy),
+                _summaryChip('予算差分', remaining, color: statusColor),
+              ],
+            ),
+            const SizedBox(height: 14),
+            LinearProgressIndicator(
+              value: usage,
+              minHeight: 10,
+              backgroundColor: Theme.of(
+                context,
+              ).colorScheme.surfaceContainerHighest,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              summary.hasBudget
+                  ? summary.isOverBudget
+                      ? '予算を ${_yenFormat.format(-remaining)} 超過しています。固定費とAI/ツール費から見直します。'
+                      : '残予算は ${_yenFormat.format(remaining)} です。'
+                  : '月次予算を設定すると、予算差分をCFOが即時確認できます。',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _summaryChip(String label, int amount, {Color? color}) {
+    return Chip(
+      avatar: Icon(Icons.payments_outlined, size: 18, color: color),
+      label: Text('$label ${_yenFormat.format(amount)}'),
+    );
+  }
+
+  Widget _buildBudgetForm() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              '月次予算',
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: TextField(
+                    key: const Key('cfo_monthly_budget_input'),
+                    controller: _budgetController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(
+                      labelText: '予算額 (円)',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                FilledButton.icon(
+                  onPressed: _isSaving ? null : _saveBudget,
+                  icon: const Icon(Icons.save_outlined),
+                  label: const Text('保存'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCostForm() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'コスト入力',
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            TextField(
+              key: const Key('cfo_cost_item_input'),
+              controller: _itemController,
+              decoration: const InputDecoration(
+                labelText: '項目名',
+                hintText: '例: Supabase Pro、広告テスト、外注レビュー',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 10),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: TextField(
+                    key: const Key('cfo_cost_amount_input'),
+                    controller: _amountController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(
+                      labelText: '金額 (円)',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: DropdownButtonFormField<String>(
+                    initialValue: _category,
+                    decoration: const InputDecoration(
+                      labelText: 'カテゴリ',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: _categories.entries
+                        .map(
+                          (entry) => DropdownMenuItem<String>(
+                            value: entry.key,
+                            child: Text(entry.value),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (value) {
+                      if (value != null) {
+                        setState(() => _category = value);
+                      }
+                    },
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            SegmentedButton<CfoCostType>(
+              segments: const <ButtonSegment<CfoCostType>>[
+                ButtonSegment<CfoCostType>(
+                  value: CfoCostType.variable,
+                  icon: Icon(Icons.trending_up),
+                  label: Text('変動費'),
+                ),
+                ButtonSegment<CfoCostType>(
+                  value: CfoCostType.fixed,
+                  icon: Icon(Icons.lock_clock),
+                  label: Text('固定費'),
+                ),
+              ],
+              selected: <CfoCostType>{_costType},
+              onSelectionChanged: (selection) {
+                setState(() => _costType = selection.single);
+              },
+            ),
+            const SizedBox(height: 10),
+            Row(
+              children: <Widget>[
+                OutlinedButton.icon(
+                  onPressed: _pickDate,
+                  icon: const Icon(Icons.event),
+                  label: Text(DateFormat('yyyy/MM/dd').format(_incurredOn)),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextField(
+                    controller: _noteController,
+                    decoration: const InputDecoration(
+                      labelText: 'メモ',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                key: const Key('cfo_cost_add_button'),
+                onPressed: _isSaving ? null : _addCostEntry,
+                icon: const Icon(Icons.add),
+                label: const Text('台帳に追加'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEntryList(List<CfoCostEntry> entries) {
+    if (entries.isEmpty) {
+      return const Card(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Text('当月のコスト記録はまだありません。'),
+        ),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          '当月の明細',
+          style: Theme.of(
+            context,
+          ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        ...entries.map(
+          (entry) => Card(
+            child: ListTile(
+              leading: Icon(
+                entry.costType == CfoCostType.fixed
+                    ? Icons.lock_clock
+                    : Icons.trending_up,
+              ),
+              title: Text(entry.item),
+              subtitle: Text(
+                '${_categories[entry.category] ?? entry.category} / ${entry.costType.label}'
+                '${entry.note.isEmpty ? '' : '\n${entry.note}'}',
+              ),
+              trailing: Text(
+                _yenFormat.format(entry.amountJpy),
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/cfo_office_page.dart
+++ b/lib/pages/cfo_office_page.dart
@@ -8,7 +8,9 @@ import 'package:my_web_app/pages/payment_channel_ledger_page.dart';
 import '../models/agent_task.dart';
 import '../services/agent_org_service.dart';
 import '../widgets/agent_workspace_panel.dart';
+import '../widgets/cfo_cost_summary_card.dart';
 import '../widgets/display_mode_experiment_card.dart';
+import 'cfo_cost_ledger_page.dart';
 
 class CfoOfficePage extends StatefulWidget {
   const CfoOfficePage({super.key});
@@ -21,6 +23,7 @@ class _CfoOfficePageState extends State<CfoOfficePage> {
   final AgentOrgService _agentOrgService = AgentOrgService();
   AgentWorkspaceSnapshot? _workspace;
   bool _isLoadingWorkspace = true;
+  int _summaryReloadToken = 0;
 
   @override
   void initState() {
@@ -46,24 +49,43 @@ class _CfoOfficePageState extends State<CfoOfficePage> {
     }
   }
 
+  Future<void> _refreshAll() async {
+    await _loadWorkspace();
+    if (!mounted) {
+      return;
+    }
+    setState(() => _summaryReloadToken += 1);
+  }
+
   Future<void> _processTask(AgentTask task, String status) async {
     try {
       await _agentOrgService.processTask(task: task, status: status);
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('CFOタスクを $status に更新しました。')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('CFOタスクを $status に更新しました。')));
       await _loadWorkspace();
     } catch (error) {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('CFOタスクの更新に失敗しました: $error')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('CFOタスクの更新に失敗しました: $error')));
     }
+  }
+
+  Future<void> _openCostLedger() async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const CfoCostLedgerPage()),
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() => _summaryReloadToken += 1);
   }
 
   @override
@@ -75,10 +97,10 @@ class _CfoOfficePageState extends State<CfoOfficePage> {
         foregroundColor: Colors.white,
       ),
       body: RefreshIndicator(
-        onRefresh: _loadWorkspace,
+        onRefresh: _refreshAll,
         child: ListView(
           padding: const EdgeInsets.all(16),
-          children: [
+          children: <Widget>[
             AgentWorkspacePanel(
               officeLabel: 'CFO',
               accentColor: Colors.green,
@@ -88,6 +110,11 @@ class _CfoOfficePageState extends State<CfoOfficePage> {
             ),
             const SizedBox(height: 16),
             const DisplayModeExperimentCard(),
+            const SizedBox(height: 16),
+            CfoCostSummaryCard(
+              key: ValueKey<int>(_summaryReloadToken),
+              onOpenLedger: _openCostLedger,
+            ),
             const SizedBox(height: 16),
             _buildMenuCard(
               context,
@@ -102,6 +129,13 @@ class _CfoOfficePageState extends State<CfoOfficePage> {
               '月次予算の設定・カテゴリ別支出入力・AI節約アドバイス・将来シミュレーション。',
               Icons.account_balance_wallet,
               const BudgetFinancialPlannerPage(),
+            ),
+            _buildMenuCard(
+              context,
+              'コスト入力台帳',
+              '固定費・変動費・月次予算差分を構造化して記録します。',
+              Icons.receipt_long,
+              const CfoCostLedgerPage(),
             ),
             _buildMenuCard(
               context,
@@ -148,18 +182,23 @@ class _CfoOfficePageState extends State<CfoOfficePage> {
         ),
         title: Text(
           title,
-          style: const TextStyle(
-            fontWeight: FontWeight.bold,
-            height: 1.5,
-          ),
+          style: const TextStyle(fontWeight: FontWeight.bold, height: 1.5),
         ),
         subtitle: Text(subtitle),
         trailing: const Icon(Icons.arrow_forward_ios, size: 16),
         onTap: page != null
-            ? () =>
-                Navigator.push(context, MaterialPageRoute(builder: (_) => page))
-            : () => ScaffoldMessenger.of(context)
-                .showSnackBar(const SnackBar(content: Text('準備中です'))),
+            ? () async {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => page),
+                );
+                if (mounted && page is CfoCostLedgerPage) {
+                  setState(() => _summaryReloadToken += 1);
+                }
+              }
+            : () => ScaffoldMessenger.of(
+                  context,
+                ).showSnackBar(const SnackBar(content: Text('準備中です'))),
       ),
     );
   }

--- a/lib/services/cfo_cost_ledger_service.dart
+++ b/lib/services/cfo_cost_ledger_service.dart
@@ -1,0 +1,140 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/cfo_cost_ledger.dart';
+
+class CfoCostLedgerSnapshot {
+  const CfoCostLedgerSnapshot({required this.summary, required this.budget});
+
+  final CfoMonthlyCostSummary summary;
+  final CfoMonthlyBudget? budget;
+}
+
+class CfoCostLedgerService {
+  CfoCostLedgerService({SupabaseClient? client})
+      : _client = client ?? Supabase.instance.client;
+
+  final SupabaseClient _client;
+
+  Future<CfoCostLedgerSnapshot> loadMonth({String? month}) async {
+    final selectedMonth = month ?? cfoLedgerMonth(DateTime.now());
+    final entries = await loadEntries(month: selectedMonth);
+    final budget = await loadBudget(month: selectedMonth);
+    return CfoCostLedgerSnapshot(
+      summary: summarize(
+        entries: entries,
+        month: selectedMonth,
+        budgetJpy: budget?.budgetJpy ?? 0,
+      ),
+      budget: budget,
+    );
+  }
+
+  Future<List<CfoCostEntry>> loadEntries({required String month}) async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) {
+      return <CfoCostEntry>[];
+    }
+    final start = DateTime.parse('$month-01');
+    final end = DateTime(start.year, start.month + 1, 0);
+    final data = await _client
+        .from('cfo_cost_entries')
+        .select()
+        .eq('user_id', userId)
+        .gte('incurred_on', _dateOnly(start))
+        .lte('incurred_on', _dateOnly(end))
+        .order('incurred_on', ascending: false)
+        .order('created_at', ascending: false);
+
+    return (data as List)
+        .whereType<Map>()
+        .map((row) => CfoCostEntry.fromMap(row.cast<String, dynamic>()))
+        .toList();
+  }
+
+  Future<CfoMonthlyBudget?> loadBudget({required String month}) async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) {
+      return null;
+    }
+    final data = await _client
+        .from('cfo_monthly_budgets')
+        .select()
+        .eq('user_id', userId)
+        .eq('month', month)
+        .maybeSingle();
+    if (data == null) {
+      return null;
+    }
+    return CfoMonthlyBudget.fromMap(data);
+  }
+
+  Future<void> addEntry(CfoCostEntryDraft draft) async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) {
+      throw StateError('ログインが必要です');
+    }
+    await _client.from('cfo_cost_entries').insert(draft.toInsertMap(userId));
+  }
+
+  Future<void> setMonthlyBudget({
+    required String month,
+    required int budgetJpy,
+  }) async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) {
+      throw StateError('ログインが必要です');
+    }
+    await _client.from('cfo_monthly_budgets').upsert(
+      <String, dynamic>{
+        'user_id': userId,
+        'month': month,
+        'budget_jpy': budgetJpy,
+      },
+      onConflict: 'user_id,month',
+    );
+  }
+
+  static CfoMonthlyCostSummary summarize({
+    required List<CfoCostEntry> entries,
+    required String month,
+    required int budgetJpy,
+  }) {
+    var fixedCost = 0;
+    var variableCost = 0;
+    final categoryTotals = <String, int>{};
+
+    for (final entry in entries) {
+      switch (entry.costType) {
+        case CfoCostType.fixed:
+          fixedCost += entry.amountJpy;
+        case CfoCostType.variable:
+          variableCost += entry.amountJpy;
+      }
+      categoryTotals.update(
+        entry.category,
+        (value) => value + entry.amountJpy,
+        ifAbsent: () => entry.amountJpy,
+      );
+    }
+
+    final sortedCategoryTotals = Map<String, int>.fromEntries(
+      categoryTotals.entries.toList()
+        ..sort((a, b) => b.value.compareTo(a.value)),
+    );
+
+    return CfoMonthlyCostSummary(
+      month: month,
+      budgetJpy: budgetJpy,
+      fixedCostJpy: fixedCost,
+      variableCostJpy: variableCost,
+      categoryTotals: sortedCategoryTotals,
+      entries: entries,
+    );
+  }
+}
+
+String _dateOnly(DateTime date) {
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '${date.year}-$month-$day';
+}

--- a/lib/widgets/cfo_cost_summary_card.dart
+++ b/lib/widgets/cfo_cost_summary_card.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/cfo_cost_ledger.dart';
+import '../services/cfo_cost_ledger_service.dart';
+
+class CfoCostSummaryCard extends StatefulWidget {
+  const CfoCostSummaryCard({super.key, this.service, this.onOpenLedger});
+
+  final CfoCostLedgerService? service;
+  final VoidCallback? onOpenLedger;
+
+  @override
+  State<CfoCostSummaryCard> createState() => _CfoCostSummaryCardState();
+}
+
+class _CfoCostSummaryCardState extends State<CfoCostSummaryCard> {
+  late final CfoCostLedgerService _service =
+      widget.service ?? CfoCostLedgerService();
+  late Future<CfoCostLedgerSnapshot> _future;
+  final _yenFormat = NumberFormat.currency(
+    locale: 'ja_JP',
+    symbol: '¥',
+    decimalDigits: 0,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _service.loadMonth();
+  }
+
+  Future<void> refresh() async {
+    setState(() {
+      _future = _service.loadMonth();
+    });
+    await _future;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<CfoCostLedgerSnapshot>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Card(
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: LinearProgressIndicator(),
+            ),
+          );
+        }
+        if (snapshot.hasError) {
+          return Card(
+            child: ListTile(
+              leading: const Icon(Icons.warning_amber_outlined),
+              title: const Text('CFOコスト台帳を読み込めません'),
+              subtitle: Text('${snapshot.error}'),
+              trailing: IconButton(
+                tooltip: '再読み込み',
+                icon: const Icon(Icons.refresh),
+                onPressed: refresh,
+              ),
+            ),
+          );
+        }
+        final summary = snapshot.data?.summary ??
+            CfoCostLedgerService.summarize(
+              entries: const <CfoCostEntry>[],
+              month: cfoLedgerMonth(DateTime.now()),
+              budgetJpy: 0,
+            );
+        return _buildSummary(context, summary);
+      },
+    );
+  }
+
+  Widget _buildSummary(BuildContext context, CfoMonthlyCostSummary summary) {
+    final remaining = summary.budgetRemainingJpy;
+    final usage = summary.budgetUsageRatio.clamp(0.0, 1.0);
+    final statusColor = summary.isOverBudget
+        ? const Color(0xFFB91C1C)
+        : const Color(0xFF15803D);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                const CircleAvatar(
+                  backgroundColor: Color(0xFFDCFCE7),
+                  child: Icon(
+                    Icons.receipt_long_outlined,
+                    color: Color(0xFF166534),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        '当月コスト台帳',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                      Text('${summary.month} / ${summary.entries.length}件'),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  tooltip: '台帳を開く',
+                  onPressed: widget.onOpenLedger,
+                  icon: const Icon(Icons.open_in_new),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: <Widget>[
+                _chip('総支出', summary.totalCostJpy),
+                _chip('固定費', summary.fixedCostJpy),
+                _chip('変動費', summary.variableCostJpy),
+                _chip('予算差分', remaining, color: statusColor),
+              ],
+            ),
+            const SizedBox(height: 12),
+            LinearProgressIndicator(
+              value: usage,
+              minHeight: 8,
+              backgroundColor: Theme.of(
+                context,
+              ).colorScheme.surfaceContainerHighest,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              summary.hasBudget
+                  ? summary.isOverBudget
+                      ? '予算超過です。固定費・ツール費・広告費を優先レビューします。'
+                      : '予算内です。次の支出判断に使えます。'
+                  : '月次予算を設定すると予算差分を表示します。',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _chip(String label, int amount, {Color? color}) {
+    return Chip(
+      label: Text('$label ${_yenFormat.format(amount)}'),
+      avatar: Icon(Icons.payments_outlined, size: 18, color: color),
+    );
+  }
+}

--- a/supabase/migrations/20260503103000_create_cfo_cost_ledger.sql
+++ b/supabase/migrations/20260503103000_create_cfo_cost_ledger.sql
@@ -1,0 +1,121 @@
+-- Issue #1669: CFO cost ledger and monthly budget summary.
+-- This is intentionally separate from cfo_assets: assets track balance sheet
+-- state, while this ledger tracks structured monthly cost decisions.
+
+CREATE TABLE IF NOT EXISTS public.cfo_cost_entries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  item text NOT NULL,
+  category text NOT NULL DEFAULT 'other',
+  amount_jpy bigint NOT NULL CHECK (amount_jpy >= 0),
+  incurred_on date NOT NULL DEFAULT current_date,
+  note text NOT NULL DEFAULT '',
+  cost_type text NOT NULL DEFAULT 'variable'
+    CHECK (cost_type IN ('fixed', 'variable')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.cfo_monthly_budgets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  month text NOT NULL CHECK (month ~ '^[0-9]{4}-[0-9]{2}$'),
+  budget_jpy bigint NOT NULL CHECK (budget_jpy >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, month)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cfo_cost_entries_user_month
+  ON public.cfo_cost_entries (user_id, incurred_on DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cfo_cost_entries_user_category
+  ON public.cfo_cost_entries (user_id, category);
+
+CREATE INDEX IF NOT EXISTS idx_cfo_monthly_budgets_user_month
+  ON public.cfo_monthly_budgets (user_id, month);
+
+CREATE OR REPLACE FUNCTION public.set_cfo_cost_ledger_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_cfo_cost_entries_updated_at
+  ON public.cfo_cost_entries;
+CREATE TRIGGER trg_cfo_cost_entries_updated_at
+  BEFORE UPDATE ON public.cfo_cost_entries
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_cfo_cost_ledger_updated_at();
+
+DROP TRIGGER IF EXISTS trg_cfo_monthly_budgets_updated_at
+  ON public.cfo_monthly_budgets;
+CREATE TRIGGER trg_cfo_monthly_budgets_updated_at
+  BEFORE UPDATE ON public.cfo_monthly_budgets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_cfo_cost_ledger_updated_at();
+
+ALTER TABLE public.cfo_cost_entries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.cfo_monthly_budgets ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "users_select_own_cfo_cost_entries"
+  ON public.cfo_cost_entries;
+CREATE POLICY "users_select_own_cfo_cost_entries"
+  ON public.cfo_cost_entries
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "users_insert_own_cfo_cost_entries"
+  ON public.cfo_cost_entries;
+CREATE POLICY "users_insert_own_cfo_cost_entries"
+  ON public.cfo_cost_entries
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "users_update_own_cfo_cost_entries"
+  ON public.cfo_cost_entries;
+CREATE POLICY "users_update_own_cfo_cost_entries"
+  ON public.cfo_cost_entries
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "users_delete_own_cfo_cost_entries"
+  ON public.cfo_cost_entries;
+CREATE POLICY "users_delete_own_cfo_cost_entries"
+  ON public.cfo_cost_entries
+  FOR DELETE
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "users_select_own_cfo_monthly_budgets"
+  ON public.cfo_monthly_budgets;
+CREATE POLICY "users_select_own_cfo_monthly_budgets"
+  ON public.cfo_monthly_budgets
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "users_insert_own_cfo_monthly_budgets"
+  ON public.cfo_monthly_budgets;
+CREATE POLICY "users_insert_own_cfo_monthly_budgets"
+  ON public.cfo_monthly_budgets
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "users_update_own_cfo_monthly_budgets"
+  ON public.cfo_monthly_budgets;
+CREATE POLICY "users_update_own_cfo_monthly_budgets"
+  ON public.cfo_monthly_budgets
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "users_delete_own_cfo_monthly_budgets"
+  ON public.cfo_monthly_budgets;
+CREATE POLICY "users_delete_own_cfo_monthly_budgets"
+  ON public.cfo_monthly_budgets
+  FOR DELETE
+  USING (auth.uid() = user_id);

--- a/test/services/cfo_cost_ledger_service_test.dart
+++ b/test/services/cfo_cost_ledger_service_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/cfo_cost_ledger.dart';
+import 'package:my_web_app/services/cfo_cost_ledger_service.dart';
+
+void main() {
+  group('CfoCostLedgerService', () {
+    test('summarizes fixed and variable costs with budget difference', () {
+      final entries = <CfoCostEntry>[
+        CfoCostEntry(
+          id: '1',
+          item: 'Supabase Pro',
+          category: 'infrastructure',
+          amountJpy: 3800,
+          incurredOn: DateTime(2026, 5, 1),
+          costType: CfoCostType.fixed,
+          note: '',
+        ),
+        CfoCostEntry(
+          id: '2',
+          item: '広告テスト',
+          category: 'marketing',
+          amountJpy: 12000,
+          incurredOn: DateTime(2026, 5, 2),
+          costType: CfoCostType.variable,
+          note: 'LP検証',
+        ),
+      ];
+
+      final summary = CfoCostLedgerService.summarize(
+        entries: entries,
+        month: '2026-05',
+        budgetJpy: 20000,
+      );
+
+      expect(summary.fixedCostJpy, 3800);
+      expect(summary.variableCostJpy, 12000);
+      expect(summary.totalCostJpy, 15800);
+      expect(summary.budgetRemainingJpy, 4200);
+      expect(summary.isOverBudget, isFalse);
+      expect(summary.categoryTotals.keys.first, 'marketing');
+    });
+
+    test('detects over-budget month', () {
+      final summary = CfoCostLedgerService.summarize(
+        entries: <CfoCostEntry>[
+          CfoCostEntry(
+            id: '1',
+            item: '外注レビュー',
+            category: 'operations',
+            amountJpy: 45000,
+            incurredOn: DateTime(2026, 5, 3),
+            costType: CfoCostType.variable,
+            note: '',
+          ),
+        ],
+        month: '2026-05',
+        budgetJpy: 30000,
+      );
+
+      expect(summary.isOverBudget, isTrue);
+      expect(summary.budgetRemainingJpy, -15000);
+      expect(summary.budgetUsageRatio, greaterThan(1));
+    });
+  });
+
+  group('CfoCostEntry', () {
+    test('parses Supabase rows', () {
+      final entry = CfoCostEntry.fromMap(<String, dynamic>{
+        'id': 'row-1',
+        'item': 'AIツール',
+        'category': 'tools',
+        'amount_jpy': 9800,
+        'incurred_on': '2026-05-03',
+        'cost_type': 'fixed',
+        'note': 'monthly',
+        'created_at': '2026-05-03T00:00:00Z',
+      });
+
+      expect(entry.id, 'row-1');
+      expect(entry.item, 'AIツール');
+      expect(entry.amountJpy, 9800);
+      expect(entry.costType, CfoCostType.fixed);
+      expect(cfoLedgerMonth(entry.incurredOn), '2026-05');
+    });
+
+    test('draft serializes insert payload with user id', () {
+      final draft = CfoCostEntryDraft(
+        item: '交通費',
+        category: 'travel',
+        amountJpy: 1200,
+        incurredOn: DateTime(2026, 5, 3),
+        costType: CfoCostType.variable,
+        note: '顧客訪問',
+      );
+
+      final payload = draft.toInsertMap('user-1');
+      expect(payload['user_id'], 'user-1');
+      expect(payload['amount_jpy'], 1200);
+      expect(payload['incurred_on'], '2026-05-03');
+      expect(payload['cost_type'], 'variable');
+    });
+  });
+}


### PR DESCRIPTION
Implements #1669.

Summary: adds a Supabase-backed CFO cost ledger, monthly budget table with RLS, CFO Office summary card, ledger input/list screen, and focused service tests.

Validation:
- dart format --set-exit-if-changed on touched Dart files
- dart analyze lib/models/cfo_cost_ledger.dart lib/services/cfo_cost_ledger_service.dart test/services/cfo_cost_ledger_service_test.dart
- dart analyze lib/pages/cfo_cost_ledger_page.dart lib/widgets/cfo_cost_summary_card.dart
- dart analyze lib/pages/cfo_office_page.dart
- flutter test --no-pub -r expanded --concurrency=1 test/services/cfo_cost_ledger_service_test.dart

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CFO ledger needs an authenticated Supabase fixture before a stable browser flow can cover save/reload without flake; this PR keeps deterministic model/service coverage and CI smoke coverage.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 ultrareview is not available in this Codex #5 session; migration risk is bounded to new CFO ledger tables with user_id RLS, and rollback is reverting this PR before applying the migration.