### PR TITLE
test(mcp): notes.list/notes.create をカタログ期待値に反映 — main の Deno test 赤を修復

### DIFF
--- a/supabase/functions/_shared/mcp_my_web_app_tools_test.ts
+++ b/supabase/functions/_shared/mcp_my_web_app_tools_test.ts
@@ -9,15 +9,25 @@ import {
   mcpRequestedScopes,
 } from "./mcp_my_web_app_tools.ts";
 
-Deno.test("MCP tool catalog exposes the three Issue 793 prototype tools", () => {
+Deno.test("MCP tool catalog exposes the Issue 793 prototype tools + 自分API v2 notes tools", () => {
   const tools = buildMcpToolCatalog();
 
   assertEquals(tools.map((tool) => tool.name), [
     "wbs.tasks.list",
     "feature_request.create",
     "user_tasks.list",
+    "notes.list",
+    "notes.create",
   ]);
   assertEquals(tools[1].write_confirmation_required, true);
+});
+
+Deno.test("notes.create is a write tool with its own confirmation phrase", () => {
+  assertEquals(isMcpWriteTool("notes.create"), true);
+  assertEquals(isMcpWriteTool("notes.list"), false);
+  assertEquals(mcpRequestedScopes("notes.create"), ["create"]);
+  assertEquals(mcpConfirmationPhrase("notes.create"), "create_note");
+  assertEquals(mcpActionToToolName("mcp.notes.list"), "notes.list");
 });
 
 Deno.test("MCP action names map to tool scopes", () => {


### PR DESCRIPTION
## Summary

main が全 PR で赤になっている緊急修復。`2d38e1b85` (自分API v2 — Webhooks + Notes CRUD + MCP Batch) が MCP tool catalog に `notes.list` / `notes.create` を追加した際、`mcp_my_web_app_tools_test.ts` の期待値が未更新のままだったため、`Lint, Format, and Test` の Deno test が main 由来で失敗する (例: [PR #4011](https://github.com/kanta13jp1/my_web_app/pull/4011) の 439 passed / 1 failed)。

- カタログ期待リストに `notes.list` / `notes.create` を追加 (カタログ実装側が正・テストが古い)
- `notes.create` の write tool 判定 / scope / confirmation phrase (`create_note`) / action マッピングの回帰テストを追加

ローカル `deno test` 5/5 緑 / `deno fmt` 緑。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: test-only expectation update to match already-merged catalog change; no runtime code touched

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: test-only change fixing a stale unit-test expectation on main; no user-facing flow altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
