### PR TITLE
perf: prevent X growth report snapshot timeouts

### DIFF
--- a/supabase/migrations/20260712163000_index_x_post_metric_snapshot_lookup.sql
+++ b/supabase/migrations/20260712163000_index_x_post_metric_snapshot_lookup.sql
@@ -1,0 +1,11 @@
+-- The X growth report normalizes impressions by post age. It reads metric
+-- snapshots for up to 100 source logs, ordered by observation time. Without
+-- this expression index, each page scans every x_post_metric_snapshot row and
+-- production PostgREST cancels the statement before the weekly report can run.
+CREATE INDEX IF NOT EXISTS idx_hub_data_x_metric_snapshot_log_user_created
+  ON public.hub_data (
+    (metadata->>'source_log_id'),
+    (metadata->>'user_id'),
+    created_at ASC
+  )
+  WHERE source = 'x_post_metric_snapshot';


### PR DESCRIPTION
## Why

The first-user X acquisition loop is blocked by the weekly measured-data report. Dry-run [#29197410383](https://github.com/kanta13jp1/my_web_app/actions/runs/29197410383) failed before posting with:

```
x.growth_data_report returned HTTP 500
canceling statement due to statement timeout
```

Production evidence shows 8,034 `x_post_metric_snapshot` rows and 65 `x_post_log` rows. The snapshot lookup filters `metadata->>'source_log_id'` and orders by `created_at`, but production only has generic `source`, `created_at`, and JSON GIN indexes. An exact one-log lookup exceeded 34 seconds.

Related: #3883, #3744

## Fix

- Add a partial expression index for `x_post_metric_snapshot`
- Key it by source log ID, user ID, then observation time
- Leave unrelated `hub_data` sources out of the index
- Keep the migration idempotent with `IF NOT EXISTS`

## Validation

- Migration timestamp collision check: passed (1,896 unique timestamps)
- `git diff --check`: passed
- `flutter analyze`: no issues
- Dart format check: 910 files checked, 0 changed
- Full pre-push quality gate: passed
- Full Supabase Functions suite: 427 passed, 0 failed
- Branch is based on current `origin/main`

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 is unavailable in this Codex session; focused review covers security, rollback, data migration, production smoke, and observability for this additive performance index.

## Minimal E2E Gate

- Implementation-detail independent: verify the same production snapshot lookup and the `x.growth_data_report` workflow result.
- Minimal scope: about 3 cases (migration applies, lookup completes within statement timeout, dry-run composes without posting).
- E2E: the Supabase production migration followed by the existing GitHub Actions dry-run is the relevant integration path.
- E2E-Exception: This migration-only performance repair has no user-facing Flutter route; production query and workflow verification are the relevant end-to-end checks.

## Production verification and rollback

- Security: no grants, RLS policies, secrets, or application permissions change.
- Data migration: additive index only; no rows are inserted, updated, or deleted.
- Production smoke: confirm the index exists, rerun the formerly timing-out lookup with `EXPLAIN ANALYZE`, then dispatch `x-growth-data-report-post.yml` with `dry_run=true`.
- Observability: compare query execution time and the workflow compose step against failed run #29197410383.
- Rollback: `DROP INDEX IF EXISTS public.idx_hub_data_x_metric_snapshot_log_user_created;`
- Unresolved findings: the report should remain dry-run only until production lookup latency is verified.
