### PR TITLE
feat(x-share): R27 AI tool tracker series — first horizontal expansion of the data-report playbook

### DIFF
--- a/.github/workflows/x-ai-tool-tracker-queue.yml
+++ b/.github/workflows/x-ai-tool-tracker-queue.yml
@@ -65,7 +65,7 @@ jobs:
           echo "force=${force}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout report data
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             docs/ai-tool-watch

--- a/.github/workflows/x-ai-tool-tracker-queue.yml
+++ b/.github/workflows/x-ai-tool-tracker-queue.yml
@@ -141,13 +141,14 @@ jobs:
               contentArchetype: 'data_report',
               linkInReply: true,
             },
+            // 注: context は normalizeXPostCandidateContext の whitelist キー
+            // のみ永続化される。数値カウント等は whitelist 外で黙って落ちる
+            // (レビュー F3)ため送らない — 件数は投稿本文と Actions ログにある。
             context: {
               workflow: process.env.SOURCE,
               workflow_run_id: process.env.GITHUB_RUN_ID,
               workflow_run_attempt: process.env.GITHUB_RUN_ATTEMPT,
               event: process.env.GITHUB_EVENT_NAME,
-              changed_count: compose.changedCount,
-              source_count: compose.sourceCount,
             },
             dryRun: process.env.DRY_RUN === 'true',
           };

--- a/.github/workflows/x-ai-tool-tracker-queue.yml
+++ b/.github/workflows/x-ai-tool-tracker-queue.yml
@@ -1,0 +1,178 @@
+name: X AI Tool Tracker Queue
+
+# R27: AIツール動向トラッカー系列 (docs/X_TRACKER_SERIES_PLAYBOOK.md step 3)。
+# ai-tool-watch.yml (日次 21:15 UTC) が生成する latest-report.json から
+# ポストA構造のデータレポート候補を合成し、候補キュー(HITL 承認面)へ載せる。
+# 直接投稿はしない=公開の最終判断は admin「X投稿候補キュー」panel の人間。
+# 変化が無い日は候補を作らない(compose が available:false を返す)。
+
+on:
+  schedule:
+    # Daily 21:45 UTC (= 06:45 JST)。ai-tool-watch (21:15) の後、
+    # daily briefing (22:00)・週次実測レポート (土 21:00) と重ねない。
+    - cron: "45 21 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run without creating a candidate"
+        type: boolean
+        default: true
+      force:
+        description: "Create a candidate even if one already exists today"
+        type: boolean
+        default: false
+
+concurrency:
+  group: x-ai-tool-tracker-queue
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  queue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SUPABASE_URL: https://smmkxxavexumewbfaqpy.supabase.co
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SOURCE: x-ai-tool-tracker-queue.yml
+      EXPERIMENT_KEY: x_first_user_growth_10k
+      VARIANT: ai_tool_tracker
+      TARGET_URL: https://my-web-app-b67f4.web.app/?utm_source=x&utm_medium=data_report&utm_campaign=first_user_growth&utm_content=ai_tool_tracker
+    steps:
+      - name: Validate secrets
+        shell: bash
+        run: |
+          test -n "${SUPABASE_SERVICE_ROLE_KEY}" || {
+            echo "SUPABASE_SERVICE_ROLE_KEY is required."
+            exit 1
+          }
+
+      - name: Resolve run mode
+        id: mode
+        shell: bash
+        run: |
+          dry_run="${{ github.event.inputs.dry_run }}"
+          force="${{ github.event.inputs.force }}"
+          if [ -z "${dry_run}" ]; then
+            dry_run="false"
+          fi
+          if [ -z "${force}" ]; then
+            force="false"
+          fi
+          echo "dry_run=${dry_run}" >> "${GITHUB_OUTPUT}"
+          echo "force=${force}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout report data
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            docs/ai-tool-watch
+          sparse-checkout-cone-mode: true
+
+      - name: Compose tracker candidate from measured report
+        id: compose
+        shell: bash
+        run: |
+          if [ ! -f docs/ai-tool-watch/latest-report.json ]; then
+            echo "::warning::latest-report.json not found; skipping."
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          jq -n \
+            --arg action "x.ai_tool_tracker_compose" \
+            --arg targetUrl "${TARGET_URL}" \
+            --slurpfile report docs/ai-tool-watch/latest-report.json \
+            '{action: $action, targetUrl: $targetUrl, report: $report[0]}' \
+            > /tmp/x_ai_tool_compose_request.json
+          http_code=$(curl --silent --show-error --output /tmp/x_ai_tool_compose.json --write-out "%{http_code}" \
+            --request POST \
+            "${SUPABASE_URL}/functions/v1/growth-hub" \
+            --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Content-Type: application/json" \
+            --data @/tmp/x_ai_tool_compose_request.json)
+          if [ "${http_code}" != "200" ]; then
+            echo "::error::x.ai_tool_tracker_compose returned HTTP ${http_code}"
+            cat /tmp/x_ai_tool_compose.json || true
+            exit 1
+          fi
+          available=$(jq -r '.available' /tmp/x_ai_tool_compose.json)
+          echo "available=${available}" >> "${GITHUB_OUTPUT}"
+          if [ "${available}" != "true" ]; then
+            echo "No changed sources today — no candidate created (correct skip)."
+            jq '{available, reason}' /tmp/x_ai_tool_compose.json
+          else
+            jq '{candidateKey, changedCount, sourceCount, lead: (.text | split("\n")[0])}' /tmp/x_ai_tool_compose.json
+          fi
+
+      - name: Create HITL candidate
+        if: steps.compose.outputs.available == 'true'
+        shell: bash
+        env:
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+          FORCE: ${{ steps.mode.outputs.force }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const compose = JSON.parse(fs.readFileSync('/tmp/x_ai_tool_compose.json', 'utf8'));
+          const baseCandidateKey = compose.candidateKey;
+          const candidateKey = process.env.FORCE === 'true'
+            ? `${baseCandidateKey}:${process.env.GITHUB_RUN_ID}:${process.env.GITHUB_RUN_ATTEMPT}`
+            : baseCandidateKey;
+          const payload = {
+            action: 'x.candidate.create',
+            candidateKey,
+            candidateType: 'ai_tool_tracker',
+            sourceKind: 'ai_tool_watch',
+            sourceUrls: compose.sourceUrls ?? [],
+            createdBy: `github-actions:${process.env.SOURCE}`,
+            postPayload: {
+              text: compose.text,
+              replyTexts: compose.replyTexts ?? [],
+              source: process.env.SOURCE,
+              route: 'growth/ai-tool-tracker',
+              experimentKey: process.env.EXPERIMENT_KEY,
+              variant: process.env.VARIANT,
+              utmContent: process.env.VARIANT,
+              promptProfile: 'workflow_ai_tool_tracker_v1_deterministic',
+              contentKind: 'data_report_thread',
+              contentArchetype: 'data_report',
+              linkInReply: true,
+            },
+            context: {
+              workflow: process.env.SOURCE,
+              workflow_run_id: process.env.GITHUB_RUN_ID,
+              workflow_run_attempt: process.env.GITHUB_RUN_ATTEMPT,
+              event: process.env.GITHUB_EVENT_NAME,
+              changed_count: compose.changedCount,
+              source_count: compose.sourceCount,
+            },
+            dryRun: process.env.DRY_RUN === 'true',
+          };
+          fs.writeFileSync('/tmp/x_ai_tool_candidate_request.json', JSON.stringify(payload));
+          console.log(JSON.stringify({
+            candidateKey,
+            lead: payload.postPayload.text.split('\n')[0],
+            replyCount: payload.postPayload.replyTexts.length,
+            dryRun: payload.dryRun,
+          }, null, 2));
+          NODE
+          http_code=$(curl --silent --show-error --output /tmp/x_ai_tool_candidate.json --write-out "%{http_code}" \
+            --request POST \
+            "${SUPABASE_URL}/functions/v1/growth-hub" \
+            --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Content-Type: application/json" \
+            --data @/tmp/x_ai_tool_candidate_request.json)
+          jq . /tmp/x_ai_tool_candidate.json || cat /tmp/x_ai_tool_candidate.json
+          if [ "${http_code}" != "200" ]; then
+            echo "::error::x.candidate.create returned HTTP ${http_code}"
+            exit 1
+          fi
+          success=$(jq -r '.success' /tmp/x_ai_tool_candidate.json)
+          if [ "${success}" != "true" ]; then
+            echo "::error::candidate creation reported failure"
+            exit 1
+          fi

--- a/docs/X_TRACKER_SERIES_PLAYBOOK.md
+++ b/docs/X_TRACKER_SERIES_PLAYBOOK.md
@@ -32,6 +32,7 @@
 | X運用実測 | `weekly_data_report` | `x-growth-data-report-post.yml` ([#3964](https://github.com/kanta13jp1/my_web_app/pull/3964)) | 週次(土 21:00 UTC) | 直接投稿(実測3件未満/横ばい週は自動見送り) |
 | 家計トラッカー | `household_tracker` | 資産管理ページ ([#3968](https://github.com/kanta13jp1/my_web_app/pull/3968)) | 週次トグル | スコアボード投稿(円金額禁止=件数/日数/方向のみ) |
 | デイリーブリーフィング | `daily_briefing_v2_*` | `x-daily-briefing-post.yml` (日次 22:00 UTC) | 日次 | 候補作成→publish op |
+| AIツール定点観測 | `ai_tool_tracker` | `x-ai-tool-tracker-queue.yml` (日次 21:45 UTC / R27) | 更新検知日のみ | 候補キュー(HITL) |
 
 ラベルの表示用対応は `lib/pages/admin_x_candidate_queue.dart` の
 `kXTrackerSeriesLabels`(系列追加時にここも更新)。

--- a/lib/pages/admin_x_candidate_queue.dart
+++ b/lib/pages/admin_x_candidate_queue.dart
@@ -23,6 +23,7 @@ const Map<String, String> kXTrackerSeriesLabels = <String, String>{
   'local_election_schedule_delta': '選挙: 選挙予定更新',
   'weekly_data_report': 'X運用実測',
   'household_tracker': '家計トラッカー',
+  'ai_tool_tracker': 'AIツール定点観測',
 };
 
 /// variant から系列ラベルを解決する。daily_briefing 系はバリアント名が

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -55,6 +55,7 @@ import {
   buildGrowthDataReport,
   type GrowthReportRow,
 } from "./x_growth_data_report.ts";
+import { buildAiToolTrackerPost } from "./x_ai_tool_tracker.ts";
 import {
   buildHouseholdTrackerReport,
   HOUSEHOLD_TRACKER_CONSENT_MIRROR_KEY,
@@ -2376,6 +2377,27 @@ serve(async (req: Request) => {
           });
         }
         return json({ success: true, available: true, ...report });
+      }
+
+      case "x.ai_tool_tracker_compose": {
+        // R27: AIツール動向トラッカー系列の read-only 合成(playbook step 2)。
+        // レポート(docs/ai-tool-watch/latest-report.json)は呼び出し元 cron が
+        // body.report で渡す。変化 0 件/データ薄は available:false = 候補を
+        // 作らない(投稿は x.candidate.create → HITL 承認経由のみ)。
+        const targetUrl = firstString(
+          body.targetUrl,
+          body.target_url,
+          "https://my-web-app-b67f4.web.app/?utm_source=x&utm_medium=data_report&utm_campaign=first_user_growth&utm_content=ai_tool_tracker",
+        );
+        const post = buildAiToolTrackerPost(body.report, targetUrl);
+        if (post === null) {
+          return json({
+            success: true,
+            available: false,
+            reason: "no changed sources, thin data, or invalid checked_at",
+          });
+        }
+        return json({ success: true, available: true, ...post });
       }
 
       case "x.household_tracker_report": {

--- a/supabase/functions/growth-hub/x_ai_tool_tracker.ts
+++ b/supabase/functions/growth-hub/x_ai_tool_tracker.ts
@@ -1,0 +1,180 @@
+// R27: AIツール動向トラッカー系列 (docs/X_TRACKER_SERIES_PLAYBOOK.md step 2)。
+// データ資産 = docs/ai-tool-watch/latest-report.json (ai-tool-watch.yml が
+// 公式 changelog / リリースノート 9 ソースを日次巡回して生成する実測)。
+// 「読者コミュニティ(AI開発者)が既に追っている固有テーマ」×「自分だけが
+// この形で集計している実数」= ポストA(選挙集計 17.2K 実測)の勝ち条件を
+// AI ツールニッチへ水平展開する。
+//
+// LLM 不使用の決定的合成のみ(数値捏造が構造的に不可能)。変化が無い日と
+// ソース数が薄い日は null(候補を作らない=近似重複ガードに拒否させるの
+// ではなく生成側で見送る / playbook step 3)。
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as JsonRecord
+    : {};
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/// 監視ソース 1 件の正規化ビュー。
+export type AiToolWatchSourceView = {
+  name: string;
+  url: string;
+  changed: boolean;
+  firstSeen: boolean;
+  hasError: boolean;
+  keywords: string[];
+};
+
+export function parseAiToolWatchSources(
+  rawSources: unknown,
+): AiToolWatchSourceView[] {
+  return asArray(rawSources).map((entry) => {
+    const record = asRecord(entry);
+    const groups = asRecord(record.keyword_groups);
+    const keywords: string[] = [];
+    for (const groupValues of Object.values(groups)) {
+      for (const keyword of asArray(groupValues)) {
+        const clean = text(keyword);
+        if (clean !== "" && !keywords.includes(clean)) keywords.push(clean);
+      }
+    }
+    return {
+      name: text(record.name),
+      url: text(record.url),
+      changed: record.changed === true,
+      firstSeen: record.first_seen === true,
+      hasError: record.error !== null && record.error !== undefined &&
+        text(record.error) !== "",
+      keywords,
+    };
+  }).filter((source) => source.name !== "");
+}
+
+export type AiToolTrackerPost = {
+  text: string;
+  replyTexts: string[];
+  sourceUrls: string[];
+  candidateKey: string;
+  changedCount: number;
+  sourceCount: number;
+};
+
+const MIN_SOURCES = 3;
+const MAX_KEYWORDS_PER_SOURCE = 8;
+
+function jstDateLabel(iso: string): { label: string; key: string } | null {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return null;
+  const jst = new Date(parsed + 9 * 60 * 60 * 1000);
+  const y = jst.getUTCFullYear();
+  const m = jst.getUTCMonth() + 1;
+  const d = jst.getUTCDate();
+  return {
+    label: `${y}/${m}/${d}`,
+    key: `${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`,
+  };
+}
+
+/// ai-tool-watch レポートからポストA構造の X 投稿候補を決定的に合成する。
+/// 更新検知 0 件 / ソース数 MIN_SOURCES 未満 / checked_at 不正は null。
+export function buildAiToolTrackerPost(
+  rawReport: unknown,
+  targetUrl: string,
+): AiToolTrackerPost | null {
+  const report = asRecord(rawReport);
+  const sources = parseAiToolWatchSources(report.sources);
+  if (sources.length < MIN_SOURCES) return null;
+  const changed = sources.filter((source) => source.changed);
+  if (changed.length === 0) return null;
+  const checkedAt = text(report.checked_at);
+  const day = jstDateLabel(checkedAt);
+  if (day === null) return null;
+
+  const activeGroups = asArray(report.active_groups).map(text).filter(
+    (group) => group !== "",
+  );
+  const highPriority = asArray(report.high_priority_groups).map(text).filter(
+    (group) => group !== "",
+  );
+
+  // リード: ポストA構造(取得日時→主要実数→検知内訳)。「集計」の語は
+  // classifyPostArchetype の data_report シグナル(自己整合テストで固定)。
+  const lead = [
+    `AIコーディングツール定点観測 ${day.label}`,
+    "",
+    `取得日時: ${checkedAt}`,
+    `監視ソース: ${sources.length}件`,
+    `24hで更新検知: ${changed.length}件`,
+    `アクティブ話題群: ${activeGroups.length}群`,
+    `高優先シグナル: ${
+      highPriority.length > 0 ? highPriority.join("、") : "なし"
+    }`,
+    "",
+    "更新を検知した公式ソース",
+    ...changed.map((source) => {
+      const keywords = source.keywords.slice(0, MAX_KEYWORDS_PER_SOURCE);
+      const suffix = keywords.length > 0 ? `: ${keywords.join(" / ")}` : "";
+      return `・${source.name}${suffix}`;
+    }),
+    "",
+    `公式changelog・リリースノート${sources.length}件を毎日自動巡回して集計した実測値です。`,
+  ].join("\n");
+
+  const replies: string[] = [];
+
+  // 全監視対象(ポストAの「名簿」相当 = 固有名詞の検索面)。
+  replies.push(
+    [
+      "監視対象の全ソース",
+      "",
+      ...sources.map((source) =>
+        source.changed ? `🔄 ${source.name}(24hで更新)` : `・${source.name}`
+      ),
+    ].join("\n"),
+  );
+
+  // アラート(実測から機械的に導出できるものだけ)。
+  const errored = sources.filter((source) => source.hasError);
+  replies.push(
+    [
+      "アラート",
+      "",
+      ...(errored.length > 0
+        ? errored.map((source) => `🟡 ${source.name}: 取得エラー`)
+        : [`取得エラーなし。全${sources.length}ソース正常巡回。`]),
+    ].join("\n"),
+  );
+
+  // URL は実測の勝ち構造(link-in-reply)に従い最終リプライのみ。
+  replies.push(
+    [
+      "この定点観測はアプリ内のAIツール監視cronが毎日生成しています。",
+      "同じ「実測を並べる」型のトラッカーを選挙・家計・X運用でも公開中です。",
+      targetUrl,
+    ].join("\n"),
+  );
+
+  const sourceUrls = changed
+    .map((source) => source.url)
+    .filter((url) => url !== "")
+    .slice(0, 10);
+
+  return {
+    text: lead,
+    replyTexts: replies,
+    sourceUrls,
+    candidateKey: `ai-tool-tracker:${day.key}`,
+    changedCount: changed.length,
+    sourceCount: sources.length,
+  };
+}

--- a/supabase/functions/growth-hub/x_ai_tool_tracker.ts
+++ b/supabase/functions/growth-hub/x_ai_tool_tracker.ts
@@ -33,7 +33,11 @@ export type AiToolWatchSourceView = {
   firstSeen: boolean;
   hasError: boolean;
   keywords: string[];
+  latestSignal: string;
 };
+
+/// 生成側 (scripts/ai_tool_watch.py) が signal 抽出に失敗した時のプレースホルダ。
+const NO_SIGNAL_PLACEHOLDER = "No title detected";
 
 export function parseAiToolWatchSources(
   rawSources: unknown,
@@ -48,6 +52,7 @@ export function parseAiToolWatchSources(
         if (clean !== "" && !keywords.includes(clean)) keywords.push(clean);
       }
     }
+    const rawSignal = text(record.latest_signal);
     return {
       name: text(record.name),
       url: text(record.url),
@@ -56,6 +61,7 @@ export function parseAiToolWatchSources(
       hasError: record.error !== null && record.error !== undefined &&
         text(record.error) !== "",
       keywords,
+      latestSignal: rawSignal === NO_SIGNAL_PLACEHOLDER ? "" : rawSignal,
     };
   }).filter((source) => source.name !== "");
 }
@@ -71,6 +77,14 @@ export type AiToolTrackerPost = {
 
 const MIN_SOURCES = 3;
 const MAX_KEYWORDS_PER_SOURCE = 8;
+const MAX_SIGNAL_CHARS = 70;
+
+function compactSignal(signal: string): string {
+  const clean = signal.replace(/\s+/g, " ").trim();
+  return clean.length <= MAX_SIGNAL_CHARS
+    ? clean
+    : `${clean.slice(0, MAX_SIGNAL_CHARS - 1)}…`;
+}
 
 function jstDateLabel(iso: string): { label: string; key: string } | null {
   const parsed = Date.parse(iso);
@@ -94,7 +108,13 @@ export function buildAiToolTrackerPost(
   const report = asRecord(rawReport);
   const sources = parseAiToolWatchSources(report.sources);
   if (sources.length < MIN_SOURCES) return null;
-  const changed = sources.filter((source) => source.changed);
+  // 取得エラーのソースを「更新検知」に数えない(レビュー F1): 生成側は
+  // fetch 失敗時もエラーページ本文の hash 変化で changed=true を立てるため、
+  // 403/timeout の遷移日に偽の検知件数が載る。「実測値」を掲げる系列で
+  // 捏造相当の数値を出さないための除外(エラー自体はアラートに出す)。
+  const changed = sources.filter(
+    (source) => source.changed && !source.hasError,
+  );
   if (changed.length === 0) return null;
   const checkedAt = text(report.checked_at);
   const day = jstDateLabel(checkedAt);
@@ -121,10 +141,19 @@ export function buildAiToolTrackerPost(
     }`,
     "",
     "更新を検知した公式ソース",
-    ...changed.map((source) => {
+    // 検知シグナル(生成側が実本文から抽出した見出し)を必ず併記する:
+    // (a) 「何が変わったか」の実データで情報価値を上げる (b) リード唯一の
+    // 日替わり自由テキスト=連日同一ソースが更新されるリリース週でも前日
+    // リードとの類似度を下げ、承認後の近似重複拒否を防ぐ(レビュー F2:
+    // シグナル無しだと類似度 0.99 で threshold 0.9 を踏む実測)。
+    ...changed.flatMap((source) => {
       const keywords = source.keywords.slice(0, MAX_KEYWORDS_PER_SOURCE);
       const suffix = keywords.length > 0 ? `: ${keywords.join(" / ")}` : "";
-      return `・${source.name}${suffix}`;
+      const lines = [`・${source.name}${suffix}`];
+      if (source.latestSignal !== "") {
+        lines.push(`　└「${compactSignal(source.latestSignal)}」`);
+      }
+      return lines;
     }),
     "",
     `公式changelog・リリースノート${sources.length}件を毎日自動巡回して集計した実測値です。`,
@@ -138,7 +167,9 @@ export function buildAiToolTrackerPost(
       "監視対象の全ソース",
       "",
       ...sources.map((source) =>
-        source.changed ? `🔄 ${source.name}(24hで更新)` : `・${source.name}`
+        source.changed && !source.hasError
+          ? `🔄 ${source.name}(24hで更新)`
+          : `・${source.name}`
       ),
     ].join("\n"),
   );

--- a/supabase/functions/growth-hub/x_ai_tool_tracker_test.ts
+++ b/supabase/functions/growth-hub/x_ai_tool_tracker_test.ts
@@ -1,0 +1,151 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildAiToolTrackerPost,
+  parseAiToolWatchSources,
+} from "./x_ai_tool_tracker.ts";
+import { classifyPostArchetype } from "./x_post_archetype.ts";
+
+const URL =
+  "https://my-web-app-b67f4.web.app/?utm_source=x&utm_content=ai_tool_tracker";
+
+// docs/ai-tool-watch/latest-report.json の実形を写したフィクスチャ。
+function report(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    checked_at: "2026-07-12T22:08:46Z",
+    previous_checked_at: "2026-07-11T22:09:19Z",
+    active_groups: ["codex-runtime", "hooks", "integration"],
+    high_priority_groups: ["codex-runtime", "hooks"],
+    sources: [
+      {
+        name: "Claude Code changelog",
+        url: "https://code.claude.com/docs/en/changelog",
+        changed: false,
+        first_seen: false,
+        error: null,
+        keyword_groups: {},
+      },
+      {
+        name: "Codex changelog",
+        url: "https://developers.openai.com/codex/changelog",
+        changed: true,
+        first_seen: false,
+        error: null,
+        keyword_groups: {
+          "codex-runtime": ["GPT-5.5", "model picker", "worktree"],
+          "hooks": ["hook"],
+        },
+      },
+      {
+        name: "Gemini Code Assist release notes",
+        url:
+          "https://developers.google.com/gemini-code-assist/resources/release-notes",
+        changed: true,
+        first_seen: false,
+        error: null,
+        keyword_groups: {
+          "integration": ["MCP", "IDE extension"],
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+Deno.test("buildAiToolTrackerPost skips no-change days and thin data", () => {
+  // 変化 0 件の日は候補を作らない(playbook step 3)。
+  const unchanged = report({
+    sources: (report() as Record<string, unknown>).sources as unknown[],
+  }) as Record<string, unknown>;
+  const allUnchanged = (unchanged.sources as Record<string, unknown>[]).map(
+    (source) => ({ ...source, changed: false }),
+  );
+  assertEquals(
+    buildAiToolTrackerPost(report({ sources: allUnchanged }), URL),
+    null,
+  );
+  // ソース数が MIN 未満(データ欠損日)も見送り。
+  assertEquals(
+    buildAiToolTrackerPost(report({ sources: [] }), URL),
+    null,
+  );
+  // checked_at 不正も見送り(日付キーが作れない)。
+  assertEquals(
+    buildAiToolTrackerPost(report({ checked_at: "not-a-date" }), URL),
+    null,
+  );
+});
+
+Deno.test("buildAiToolTrackerPost composes a post-A style lead from the report", () => {
+  const post = buildAiToolTrackerPost(report(), URL);
+  assert(post !== null);
+  // JST 日付ラベル(UTC 22:08 = JST 翌 07:08)。
+  assert(post!.text.includes("AIコーディングツール定点観測 2026/7/13"));
+  assert(post!.text.includes("取得日時: 2026-07-12T22:08:46Z"));
+  assert(post!.text.includes("監視ソース: 3件"));
+  assert(post!.text.includes("24hで更新検知: 2件"));
+  assert(post!.text.includes("アクティブ話題群: 3群"));
+  assert(post!.text.includes("高優先シグナル: codex-runtime、hooks"));
+  // 更新検知ソースは名前+実キーワード(固有名詞)で列挙される。
+  assert(post!.text.includes("・Codex changelog: GPT-5.5 / model picker"));
+  assert(post!.text.includes("・Gemini Code Assist release notes: MCP"));
+  assertEquals(post!.changedCount, 2);
+  assertEquals(post!.sourceCount, 3);
+  // 冪等キーは JST 日付。
+  assertEquals(post!.candidateKey, "ai-tool-tracker:2026-07-13");
+  // 出典 URL は更新検知ソースのもの。
+  assertEquals(post!.sourceUrls.length, 2);
+});
+
+Deno.test("buildAiToolTrackerPost replies carry roster, alerts, and final URL", () => {
+  const post = buildAiToolTrackerPost(report(), URL);
+  assert(post !== null);
+  const [roster, alerts, cta] = post!.replyTexts;
+  // 名簿相当: 全監視対象を更新マーク付きで列挙。
+  assert(roster.includes("監視対象の全ソース"));
+  assert(roster.includes("🔄 Codex changelog(24hで更新)"));
+  assert(roster.includes("・Claude Code changelog"));
+  // アラート: エラー無し時は正常巡回の明示。
+  assert(alerts.includes("取得エラーなし。全3ソース正常巡回。"));
+  // URL は最終リプライのみ(link-in-reply の実測勝ち構造)。
+  assert(cta.includes(URL));
+  assert(!post!.text.includes(URL));
+  assert(!roster.includes(URL));
+});
+
+Deno.test("buildAiToolTrackerPost surfaces per-source fetch errors as alerts", () => {
+  const base = report() as Record<string, unknown>;
+  const sources = (base.sources as Record<string, unknown>[]).map((source) =>
+    source.name === "Claude Code changelog"
+      ? { ...source, error: "HTTP 503" }
+      : source
+  );
+  const post = buildAiToolTrackerPost(report({ sources }), URL);
+  assert(post !== null);
+  const alerts = post!.replyTexts.find((entry) => entry.includes("アラート"))!;
+  assert(alerts.includes("🟡 Claude Code changelog: 取得エラー"));
+});
+
+Deno.test("buildAiToolTrackerPost output self-classifies as data_report", () => {
+  // R23 自己整合(playbook step 2): この系列自身が data_report バケットへ
+  // 入り、Archetype lift の実測を蓄積できる形であることを固定する。
+  const post = buildAiToolTrackerPost(report(), URL);
+  assert(post !== null);
+  const full = [post!.text, ...post!.replyTexts].join("\n");
+  assertEquals(classifyPostArchetype(full), "data_report");
+});
+
+Deno.test("parseAiToolWatchSources tolerates junk shapes", () => {
+  assertEquals(parseAiToolWatchSources(null), []);
+  assertEquals(parseAiToolWatchSources("junk"), []);
+  const parsed = parseAiToolWatchSources([
+    { name: "A", keyword_groups: { g: ["k1", "k1", ""] }, changed: 1 },
+    { keyword_groups: null },
+    "junk",
+  ]);
+  assertEquals(parsed.length, 1);
+  assertEquals(parsed[0].keywords, ["k1"]);
+  assertEquals(parsed[0].changed, false);
+});

--- a/supabase/functions/growth-hub/x_ai_tool_tracker_test.ts
+++ b/supabase/functions/growth-hub/x_ai_tool_tracker_test.ts
@@ -7,6 +7,7 @@ import {
   parseAiToolWatchSources,
 } from "./x_ai_tool_tracker.ts";
 import { classifyPostArchetype } from "./x_post_archetype.ts";
+import { contentSimilarity } from "./x_duplicate_content.ts";
 
 const URL =
   "https://my-web-app-b67f4.web.app/?utm_source=x&utm_content=ai_tool_tracker";
@@ -33,6 +34,8 @@ function report(overrides: Record<string, unknown> = {}): unknown {
         changed: true,
         first_seen: false,
         error: null,
+        latest_signal:
+          "2026-07-09 / Codex joins the ChatGPT desktop app on macOS",
         keyword_groups: {
           "codex-runtime": ["GPT-5.5", "model picker", "worktree"],
           "hooks": ["hook"],
@@ -135,6 +138,77 @@ Deno.test("buildAiToolTrackerPost output self-classifies as data_report", () => 
   assert(post !== null);
   const full = [post!.text, ...post!.replyTexts].join("\n");
   assertEquals(classifyPostArchetype(full), "data_report");
+});
+
+Deno.test("buildAiToolTrackerPost excludes fetch-error sources from 更新検知 (F1)", () => {
+  // 生成側は fetch 失敗(403/timeout)でもエラーページ本文の hash 変化で
+  // changed=true を立てる。「実測値」を掲げる系列で偽の検知件数を出さない。
+  const base = report() as Record<string, unknown>;
+  const sources = (base.sources as Record<string, unknown>[]).map((source) =>
+    source.name === "Codex changelog"
+      ? { ...source, error: "HTTP 403" }
+      : source
+  );
+  const post = buildAiToolTrackerPost(report({ sources }), URL);
+  assert(post !== null);
+  // エラー行は検知件数・リード列挙・🔄マークから外れ、アラートには出る。
+  assert(post!.text.includes("24hで更新検知: 1件"));
+  assert(!post!.text.includes("・Codex changelog"));
+  assertEquals(post!.changedCount, 1);
+  const roster = post!.replyTexts[0];
+  assert(!roster.includes("🔄 Codex changelog"));
+  assert(roster.includes("・Codex changelog"));
+  const alerts = post!.replyTexts.find((entry) => entry.includes("アラート"))!;
+  assert(alerts.includes("🟡 Codex changelog: 取得エラー"));
+  // エラー行しか changed が無い日は候補を作らない。
+  const onlyErrored = (base.sources as Record<string, unknown>[]).map(
+    (source) =>
+      source.name === "Codex changelog"
+        ? { ...source, error: "HTTP 403" }
+        : { ...source, changed: false },
+  );
+  assertEquals(
+    buildAiToolTrackerPost(report({ sources: onlyErrored }), URL),
+    null,
+  );
+});
+
+Deno.test("consecutive-day leads with fresh signals stay under the dup threshold (F2)", () => {
+  // リリース週に同一ソース集合が連日更新されるケース: 検知シグナル(実本文
+  // 由来の日替わりデータ)がリードの類似度を近似重複ガード閾値(0.9)未満に
+  // 下げることを実測で固定する(シグナル無し時代は 0.99 で拒否されていた)。
+  const day1 = buildAiToolTrackerPost(report(), URL);
+  const day2Sources = (report() as Record<string, unknown>)
+    .sources as Record<string, unknown>[];
+  const day2 = buildAiToolTrackerPost(
+    report({
+      checked_at: "2026-07-13T22:08:46Z",
+      sources: day2Sources.map((source) =>
+        source.name === "Codex changelog"
+          ? {
+            ...source,
+            latest_signal:
+              "2026-07-13 / Codex adds parallel worktree execution for large refactors",
+          }
+          : source.name === "Gemini Code Assist release notes"
+          ? {
+            ...source,
+            latest_signal: "VS Code Gemini Code Assist 2.88.0 / July 13, 2026",
+          }
+          : source
+      ),
+    }),
+    URL,
+  );
+  assert(day1 !== null && day2 !== null);
+  // シグナルがリードに載っている(情報価値+日替わり可変トークン)。
+  assert(day1!.text.includes("Codex joins the ChatGPT desktop app"));
+  assert(day2!.text.includes("parallel worktree execution"));
+  const similarity = contentSimilarity(day1!.text, day2!.text);
+  assert(
+    similarity < 0.9,
+    `expected < 0.9 (dup guard threshold), got ${similarity}`,
+  );
 });
 
 Deno.test("parseAiToolWatchSources tolerates junk shapes", () => {

--- a/test/pages/admin_x_candidate_queue_test.dart
+++ b/test/pages/admin_x_candidate_queue_test.dart
@@ -11,6 +11,8 @@ void main() {
       );
       expect(xTrackerSeriesLabel('household_tracker'), '家計トラッカー');
       expect(xTrackerSeriesLabel('weekly_data_report'), 'X運用実測');
+      // R27: AIツール動向トラッカー系列(playbook step 4 のラベル登録)。
+      expect(xTrackerSeriesLabel('ai_tool_tracker'), 'AIツール定点観測');
     });
 
     test('collapses daily_briefing variants and passes unknown through', () {


### PR DESCRIPTION
## 概要 (R27: 系列の水平展開第1号 — AIツール定点観測トラッカー)

ポストA(選挙集計 **17.2K** 実測)の勝ち条件「読者コミュニティが既に追っている固有テーマ × 独自集計の実数」を AI ツールニッチへ複製する。[X_TRACKER_SERIES_PLAYBOOK.md](docs/X_TRACKER_SERIES_PLAYBOOK.md) の5手順に完全準拠した最初の水平展開系列。

## 変更内容

1. **データ資産(step 1)**: `docs/ai-tool-watch/latest-report.json` — 既存の日次 cron が公式 changelog/リリースノート **9ソース**を巡回する実測(Claude Code / Codex / Gemini 等 = AI開発者コミュニティの固有名詞)
2. **決定的ジェネレータ(step 2)**: 新純ロジック `x_ai_tool_tracker.ts` — LLM 不使用・ポストA構造(取得日時→監視数→検知数→話題群→検知ソース+実シグナル→名簿→アラート→URL末尾)。`classifyPostArchetype = data_report` 自己整合テスト+**実データ smoke 済み**
3. **候補キュー(step 3)**: `x-ai-tool-tracker-queue.yml`(日次 21:45 UTC)— compose(read-only action)→ `x.candidate.create`。**直接投稿なし=HITL 承認必須**。更新0件の日は候補を作らない。candidateKey=JST日付で冪等
4. **variant 登録(step 4)**: `ai_tool_tracker` + `kXTrackerSeriesLabels`「AIツール定点観測」
5. **レジストリ(step 5)**: プレイブック表へ追加(2週間計測→伸縮判断)

## 敵対的レビュー (6 agents / 生4→確認3→全対応)
- fetch エラー由来の偽「更新検知」(実データの Codex overview HTTP 403 で再現)→ エラーソース除外
- 連日同一ソース更新時に類似度 0.99 → 承認後拒否 → **検知シグナル(実本文の見出し)をリードへ併記**し類似度を閾値未満へ(回帰テストで固定)
- whitelist 外 context フィールドの無言破棄 → 削除

## テスト
- deno: growth-hub 96 green(新規 x_ai_tool_tracker 8 = スキップ判定/構造/名簿/アラート/自己分類/F1/F2/防御的parse)
- flutter: candidate queue 13 green / dart format・deno lint・YAML parse 合格

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge pure-logic + GHA cron that only enqueues HITL candidates (no direct posting, no browser-reachable flow). Verified by deno test (96 green incl. real-data smoke) and dry_run-default manual dispatch.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive read-only compose action + daily cron that only creates HITL-approval candidates (no direct posting, no auth/payment/RLS surface); mirrors the existing x-daily-briefing-post.yml candidate pattern; adversarial 6-agent review confirmed 3 findings, all fixed with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
