### PR TITLE
fix(social-commerce/lifestyle-hub): nested-metadata 10 ページの flat-key 誤読を一括修正

### DIFF
--- a/lib/models/affiliate_link_stats.dart
+++ b/lib/models/affiliate_link_stats.dart
@@ -1,0 +1,69 @@
+/// アフィリエイトリンク実績モデル。
+///
+/// `social-commerce-hub` の `affiliate.list_links`
+/// (`{success, links: [hub_data 行]}`) を解析する純データモデル。
+/// 実フィールドは `metadata.title` / `metadata.code` / `metadata.url` /
+/// `metadata.clicks` / `metadata.conversions` / `metadata.commission_pct`。
+/// 旧実装は誤キー (`name` / `earnings` / `status`) + EF 非返却の
+/// `data['summary']` を読み、**全カード「クリック 0 / 報酬 ¥0」**だった。
+/// 報酬額は EF に売上ベースが無く算出不能 — 捏造 ¥0 を出さず、
+/// 実在する clicks / conversions / commission_pct を表示する。
+library;
+
+import 'hub_data_parsing.dart';
+
+class AffiliateLinkStats {
+  const AffiliateLinkStats({
+    required this.title,
+    required this.code,
+    required this.url,
+    required this.clicks,
+    required this.conversions,
+    required this.commissionPct,
+  });
+
+  final String title;
+  final String code;
+  final String url;
+  final num clicks;
+  final num conversions;
+  final num commissionPct;
+
+  factory AffiliateLinkStats.fromMap(Map<String, dynamic> raw) {
+    return AffiliateLinkStats(
+      title: hubString(hubField(raw, 'title') ?? raw['name']),
+      code: hubString(hubField(raw, 'code')),
+      url: hubString(hubField(raw, 'url')),
+      clicks: hubNum(hubField(raw, 'clicks')),
+      conversions: hubNum(hubField(raw, 'conversions')),
+      commissionPct: hubNum(hubField(raw, 'commission_pct')),
+    );
+  }
+
+  static List<AffiliateLinkStats> listFromResponse(dynamic data) {
+    var rows = hubRowsFromResponse(data, 'links');
+    if (rows.isEmpty) rows = hubRowsFromResponse(data, 'campaigns');
+    return rows.map(AffiliateLinkStats.fromMap).toList();
+  }
+}
+
+/// リンク一覧から算出する集計 (EF は summary を返さない)。
+class AffiliateSummary {
+  const AffiliateSummary({
+    required this.totalClicks,
+    required this.totalConversions,
+    required this.linkCount,
+  });
+
+  final num totalClicks;
+  final num totalConversions;
+  final int linkCount;
+
+  factory AffiliateSummary.fromLinks(List<AffiliateLinkStats> links) {
+    return AffiliateSummary(
+      totalClicks: links.fold<num>(0, (sum, l) => sum + l.clicks),
+      totalConversions: links.fold<num>(0, (sum, l) => sum + l.conversions),
+      linkCount: links.length,
+    );
+  }
+}

--- a/lib/models/auction_listing.dart
+++ b/lib/models/auction_listing.dart
@@ -1,0 +1,52 @@
+/// オークション出品モデル。
+///
+/// `social-commerce-hub` の `auction.list` (`{success, auctions: [hub_data 行]}`)
+/// を解析する純データモデル。実フィールドは `metadata.title` /
+/// `metadata.current_bid` / `metadata.start_price` / `metadata.ends_at`。
+/// 旧実装は誤キー `current_price` / `end_at` (不存在) を読み、名称捏造 +
+/// 価格・終了時刻が全行非表示だった。`description` は EF に保存されない。
+library;
+
+import 'hub_data_parsing.dart';
+
+class AuctionListing {
+  const AuctionListing({
+    required this.title,
+    required this.currentBid,
+    required this.startPrice,
+    required this.endsAt,
+    required this.status,
+  });
+
+  final String title;
+
+  /// 現在入札額 (未設定なら null)。
+  final num? currentBid;
+  final num? startPrice;
+
+  /// 終了時刻 (ISO / 未設定は空文字)。
+  final String endsAt;
+  final String status;
+
+  /// 表示する価格: 現在入札額 → 開始価格の順 (どちらも無ければ null)。
+  num? get displayPrice => currentBid ?? startPrice;
+
+  factory AuctionListing.fromMap(Map<String, dynamic> raw) {
+    final rawBid = hubField(raw, 'current_bid') ?? raw['current_price'];
+    final rawStart = hubField(raw, 'start_price');
+    return AuctionListing(
+      title: hubString(hubField(raw, 'title')),
+      currentBid: rawBid == null ? null : hubNum(rawBid),
+      startPrice: rawStart == null ? null : hubNum(rawStart),
+      endsAt: hubString(hubField(raw, 'ends_at') ?? raw['end_at']),
+      status: hubString(hubField(raw, 'status')),
+    );
+  }
+
+  /// `auction.list` は `auctions`、旧クライアント互換で `items` も許容。
+  static List<AuctionListing> listFromResponse(dynamic data) {
+    var rows = hubRowsFromResponse(data, 'auctions');
+    if (rows.isEmpty) rows = hubRowsFromResponse(data, 'items');
+    return rows.map(AuctionListing.fromMap).toList();
+  }
+}

--- a/lib/models/budget_entry.dart
+++ b/lib/models/budget_entry.dart
@@ -1,0 +1,57 @@
+/// 家計簿 予算 / 支出 / 収入エントリモデル。
+///
+/// `social-commerce-hub`:
+/// - `budget.summary` → `{success, budgets: [hub_data 行]}`
+///   実フィールド `metadata.category` / `metadata.amount` / `metadata.period`。
+/// - `budget.expense_list` → `{success, expenses: [hub_data 行]}`
+///   実フィールド `metadata.category` / `metadata.amount` / `metadata.date`。
+/// - `budget.income_list` → `{success, income: [hub_data 行]}` (キーは単数 `income`)
+///   実フィールド `metadata.source` / `metadata.amount` / `metadata.date`。
+///
+/// 旧実装のバグ:
+/// - 収入取得に無効 action `'get'` を使い EF 400 → 支出常に空。
+/// - 収入を `budget.expense_list` で取得し応答キー `incomes` を読む
+///   (正: action=`budget.income_list` / キー=`income`)。
+/// - category / amount を flat `e['category']`/`e['amount']` で読み全行 null →
+///   カテゴリ照合不能で予算・実績が常に 0。
+library;
+
+import 'hub_data_parsing.dart';
+
+class BudgetEntry {
+  const BudgetEntry({
+    required this.category,
+    required this.amount,
+    required this.label,
+  });
+
+  /// 予算・支出の分類キー (収入は source を category として扱う)。
+  final String category;
+  final num amount;
+
+  /// 収入 source 等の表示ラベル (category と別に保持)。
+  final String label;
+
+  factory BudgetEntry.fromMap(Map<String, dynamic> raw) {
+    final category = hubString(hubField(raw, 'category'));
+    final source = hubString(hubField(raw, 'source'));
+    return BudgetEntry(
+      category: category.isNotEmpty ? category : source,
+      amount: hubNum(hubField(raw, 'amount')),
+      label: hubString(hubField(raw, 'description')),
+    );
+  }
+
+  static List<BudgetEntry> listFromResponse(dynamic data, String listKey) =>
+      hubRowsFromResponse(data, listKey).map(BudgetEntry.fromMap).toList();
+
+  /// カテゴリ別 amount 合計。
+  static num sumForCategory(List<BudgetEntry> entries, String category) =>
+      entries
+          .where((e) => e.category == category)
+          .fold<num>(0, (sum, e) => sum + e.amount);
+
+  /// 全 amount 合計。
+  static num total(List<BudgetEntry> entries) =>
+      entries.fold<num>(0, (sum, e) => sum + e.amount);
+}

--- a/lib/models/donation_project.dart
+++ b/lib/models/donation_project.dart
@@ -1,0 +1,48 @@
+/// 寄付・クラウドファンディングプロジェクトモデル。
+///
+/// `lifestyle-hub` の `donation.list` (`{success, projects: [hub_data 行]}`)
+/// を解析する純データモデル。実フィールドは `metadata.title` /
+/// `metadata.description` / `metadata.goal_amount` / `metadata.raised_amount`
+/// / `metadata.status`。旧実装は flat キー読みで全プロジェクトが
+/// 「タイトル不明 / ¥0 / ¥0」表示だった。
+library;
+
+import 'hub_data_parsing.dart';
+
+class DonationProject {
+  const DonationProject({
+    required this.title,
+    required this.description,
+    required this.goalAmount,
+    required this.raisedAmount,
+    required this.status,
+  });
+
+  final String title;
+  final String description;
+  final num goalAmount;
+  final num raisedAmount;
+  final String status;
+
+  /// 達成率 (0.0-1.0 にクランプ / 目標 0 は 0.0)。
+  double get progress {
+    if (goalAmount <= 0) return 0.0;
+    final ratio = raisedAmount / goalAmount;
+    return ratio.clamp(0.0, 1.0).toDouble();
+  }
+
+  factory DonationProject.fromMap(Map<String, dynamic> raw) {
+    return DonationProject(
+      title: hubString(hubField(raw, 'title')),
+      description: hubString(hubField(raw, 'description')),
+      goalAmount: hubNum(hubField(raw, 'goal_amount')),
+      raisedAmount: hubNum(hubField(raw, 'raised_amount')),
+      status: hubString(hubField(raw, 'status')),
+    );
+  }
+
+  static List<DonationProject> listFromResponse(dynamic data) =>
+      hubRowsFromResponse(data, 'projects')
+          .map(DonationProject.fromMap)
+          .toList();
+}

--- a/lib/models/elearning_course.dart
+++ b/lib/models/elearning_course.dart
@@ -1,0 +1,84 @@
+/// eラーニング コース + 受講状況モデル。
+///
+/// `social-commerce-hub`:
+/// - `course.list` → `{success, courses: [hub_data 行]}`
+///   実フィールド `metadata.title` / `description` / `level` / `language`。
+/// - `course.progress` → `{success, enrollments: [hub_data 行]}`
+///   実フィールド `metadata.course_id` / `metadata.progress`。
+///
+/// 旧実装のバグ:
+/// - コース一覧: flat `c['title']` 等 + EF 非存在の `instructor`/`rating`/
+///   `emoji`/`enrolled` を読み名称捏造・レベル消失。
+/// - 学習中タブ: 応答キー `enrollments` を `courses` で読み**常に空**。
+///   さらに enrollment は course_id しか持たないので course と join が必要。
+library;
+
+import 'hub_data_parsing.dart';
+
+class ELearningCourse {
+  const ELearningCourse({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.level,
+    required this.language,
+    this.progress = 0,
+  });
+
+  final String id;
+  final String title;
+  final String description;
+  final String level;
+  final String language;
+
+  /// 受講進捗 0-100 (course.progress と join した場合のみ非 0)。
+  final num progress;
+
+  ELearningCourse withProgress(num p) => ELearningCourse(
+        id: id,
+        title: title,
+        description: description,
+        level: level,
+        language: language,
+        progress: p,
+      );
+
+  factory ELearningCourse.fromMap(Map<String, dynamic> raw) {
+    return ELearningCourse(
+      id: hubString(raw['id']),
+      title: hubString(hubField(raw, 'title')),
+      description: hubString(hubField(raw, 'description')),
+      level: hubString(hubField(raw, 'level')),
+      language: hubString(hubField(raw, 'language')),
+    );
+  }
+
+  static List<ELearningCourse> listFromResponse(dynamic data) =>
+      hubRowsFromResponse(data, 'courses')
+          .map(ELearningCourse.fromMap)
+          .toList();
+
+  /// `course.progress` の enrollments を course_id→progress へ畳む。
+  static Map<String, num> progressByCourseId(dynamic data) {
+    final result = <String, num>{};
+    for (final row in hubRowsFromResponse(data, 'enrollments')) {
+      final courseId = hubString(hubField(row, 'course_id'));
+      if (courseId.isEmpty) continue;
+      result[courseId] = hubNum(hubField(row, 'progress'));
+    }
+    return result;
+  }
+
+  /// コース一覧に受講進捗を join し、受講中 (progress>0) のみ返す。
+  static List<ELearningCourse> inProgress(
+    List<ELearningCourse> courses,
+    Map<String, num> progressById,
+  ) {
+    final out = <ELearningCourse>[];
+    for (final c in courses) {
+      final p = progressById[c.id];
+      if (p != null && p > 0) out.add(c.withProgress(p));
+    }
+    return out;
+  }
+}

--- a/lib/models/event_ticketing_summary.dart
+++ b/lib/models/event_ticketing_summary.dart
@@ -1,0 +1,59 @@
+/// イベントチケット販売モデル。
+///
+/// `social-commerce-hub` の `event.list` (`{success, events: [hub_data 行]}`)
+/// を解析する純データモデル。実フィールドは `metadata.title` / `metadata.date`
+/// / `metadata.capacity` / `metadata.sold`。旧実装は flat キー読みで名称捏造 +
+/// 不存在キー `tickets_remaining` により**全イベント「残 0 枚」**表示だった。
+/// 残数は `capacity - sold` から算出する (capacity 未設定は「捏造 0」に
+/// しない — null を返し表示側で「定員未設定」)。
+library;
+
+import 'hub_data_parsing.dart';
+
+class EventTicketingSummary {
+  const EventTicketingSummary({
+    required this.title,
+    required this.date,
+    required this.venue,
+    required this.capacity,
+    required this.sold,
+  });
+
+  final String title;
+  final String date;
+  final String venue;
+
+  /// 定員 (EF 未設定なら null — 0 と区別する)。
+  final num? capacity;
+  final num sold;
+
+  /// 残チケット数。定員未設定なら null (0 枚と偽らない)。
+  num? get remaining {
+    final cap = capacity;
+    if (cap == null) return null;
+    final rest = cap - sold;
+    return rest < 0 ? 0 : rest;
+  }
+
+  /// 一覧 trailing 用ラベル。
+  String get remainingLabel {
+    final rest = remaining;
+    return rest == null ? '定員未設定' : '残 ${rest.toInt()}枚';
+  }
+
+  factory EventTicketingSummary.fromMap(Map<String, dynamic> raw) {
+    final rawCapacity = hubField(raw, 'capacity');
+    return EventTicketingSummary(
+      title: hubString(hubField(raw, 'title')),
+      date: hubString(hubField(raw, 'date')),
+      venue: hubString(hubField(raw, 'venue')),
+      capacity: rawCapacity == null ? null : hubNum(rawCapacity),
+      sold: hubNum(hubField(raw, 'sold')),
+    );
+  }
+
+  static List<EventTicketingSummary> listFromResponse(dynamic data) =>
+      hubRowsFromResponse(data, 'events')
+          .map(EventTicketingSummary.fromMap)
+          .toList();
+}

--- a/lib/models/hub_data_parsing.dart
+++ b/lib/models/hub_data_parsing.dart
@@ -1,0 +1,57 @@
+/// hub_data 行 (social-commerce-hub / lifestyle-hub) 共通パースヘルパー。
+///
+/// 両 EF の list 系 action は各レコードを
+/// `{id, created_at, metadata: {...実フィールド}}` で返す (トップレベルは
+/// `id` / `created_at` のみ)。UI が flat キー `row['field']` を読むと全行が
+/// フォールバック値に化ける contract バグの温床なので、モデルは必ず
+/// ここを経由して nested `metadata` から読む (flat キーは後方互換)。
+///
+/// 純 Dart (Flutter 依存なし) → VM 単体テスト可能。
+/// 修正正本パターン: [loyalty_points_summary.dart] (PR #3948) 参照。
+library;
+
+/// hub_data 行から nested `metadata` を取り出す (無ければ空 Map)。
+Map<String, dynamic> hubMetadataOf(Map<String, dynamic> raw) {
+  final metadata = raw['metadata'];
+  return metadata is Map
+      ? metadata.cast<String, dynamic>()
+      : const <String, dynamic>{};
+}
+
+/// `metadata[key]` 優先・flat `raw[key]` フォールバックで値を読む。
+dynamic hubField(Map<String, dynamic> raw, String key) {
+  final meta = hubMetadataOf(raw);
+  return meta[key] ?? raw[key];
+}
+
+/// 数値化 (num / 数値文字列以外は fallback)。
+num hubNum(dynamic value, [num fallback = 0]) {
+  if (value is num) return value;
+  return num.tryParse(value?.toString() ?? '') ?? fallback;
+}
+
+/// 文字列化 + trim (null は空文字)。
+String hubString(dynamic value) => (value ?? '').toString().trim();
+
+/// EF レスポンスから hub_data 行リストを取り出す。
+/// `{success, <listKey>: [...]}` 形式 / 生 List / null を頑健に処理する。
+List<Map<String, dynamic>> hubRowsFromResponse(dynamic data, String listKey) {
+  final dynamic rawList = data is Map ? data[listKey] : data;
+  if (rawList is! List) return const <Map<String, dynamic>>[];
+  return rawList
+      .whereType<Map>()
+      .map((e) => e.cast<String, dynamic>())
+      .toList();
+}
+
+/// ISO タイムスタンプを 'yyyy/MM/dd HH:mm' (ローカル) に整形する。
+/// パース不能なら生文字列をそのまま返す (捏造しない)。
+String hubFormatTimestamp(String raw) {
+  if (raw.isEmpty) return '';
+  final dt = DateTime.tryParse(raw);
+  if (dt == null) return raw;
+  final local = dt.toLocal();
+  String two(int n) => n.toString().padLeft(2, '0');
+  return '${local.year}/${two(local.month)}/${two(local.day)} '
+      '${two(local.hour)}:${two(local.minute)}';
+}

--- a/lib/models/language_deck.dart
+++ b/lib/models/language_deck.dart
@@ -1,0 +1,89 @@
+/// 語学学習 単語帳 + フラッシュカードモデル。
+///
+/// `social-commerce-hub`:
+/// - `lang.list_decks` → `{success, decks: [hub_data 行]}`
+///   実フィールド `metadata.name` / `metadata.language` / `metadata.description`。
+/// - `lang.list_cards` / `lang.review_session` → `{success, cards: [hub_data 行]}`
+///   実フィールド `metadata.front` / `metadata.back` / `metadata.example` /
+///   `metadata.deck`。
+///
+/// 旧実装のバグ:
+/// - デッキ: `deck['deck_id']` (実 `id`) / デッキ名空 (`metadata.name`)。
+/// - カード: 表裏空 (`front`/`back`)。
+/// - `lang.review_session` は `cards` キーだが旧実装は `dueCards` を読み常に空。
+/// - `lang.streak` は `{streak_days: N}`、`lang.stats` は `{total_cards, decks}`
+///   だが旧実装は `{streak:{...}}` / `{stats:{...}}` を期待し常に空。
+library;
+
+import 'hub_data_parsing.dart';
+
+class LanguageDeck {
+  const LanguageDeck({
+    required this.id,
+    required this.name,
+    required this.language,
+    required this.description,
+  });
+
+  /// hub_data 行のトップレベル id (旧実装が読んでいた `deck_id` は不存在)。
+  final String id;
+  final String name;
+  final String language;
+  final String description;
+
+  factory LanguageDeck.fromMap(Map<String, dynamic> raw) {
+    return LanguageDeck(
+      id: hubString(raw['id']),
+      name: hubString(hubField(raw, 'name')),
+      language: hubString(hubField(raw, 'language')),
+      description: hubString(hubField(raw, 'description')),
+    );
+  }
+
+  static List<LanguageDeck> listFromResponse(dynamic data) =>
+      hubRowsFromResponse(data, 'decks').map(LanguageDeck.fromMap).toList();
+}
+
+class Flashcard {
+  const Flashcard({
+    required this.id,
+    required this.front,
+    required this.back,
+    required this.example,
+  });
+
+  final String id;
+  final String front;
+  final String back;
+  final String example;
+
+  factory Flashcard.fromMap(Map<String, dynamic> raw) {
+    return Flashcard(
+      id: hubString(raw['id']),
+      front: hubString(hubField(raw, 'front')),
+      back: hubString(hubField(raw, 'back')),
+      example: hubString(hubField(raw, 'example')),
+    );
+  }
+
+  /// `lang.list_cards` / `lang.review_session` はどちらも `cards` キー。
+  static List<Flashcard> listFromResponse(dynamic data) =>
+      hubRowsFromResponse(data, 'cards').map(Flashcard.fromMap).toList();
+}
+
+/// `lang.streak` (`{streak_days}`) / `lang.stats` (`{total_cards, decks}`) の
+/// scalar トップレベル値を安全に読む。
+class LanguageStats {
+  const LanguageStats({required this.streakDays, required this.totalCards});
+
+  final num streakDays;
+  final num totalCards;
+
+  factory LanguageStats.fromResponses(dynamic streakData, dynamic statsData) {
+    num streak = 0;
+    num total = 0;
+    if (streakData is Map) streak = hubNum(streakData['streak_days']);
+    if (statsData is Map) total = hubNum(statsData['total_cards']);
+    return LanguageStats(streakDays: streak, totalCards: total);
+  }
+}

--- a/lib/models/parking_reservation_entry.dart
+++ b/lib/models/parking_reservation_entry.dart
@@ -1,0 +1,64 @@
+/// 駐車場予約モデル。
+///
+/// `lifestyle-hub` の `parking.list` (`{success, reservations: [hub_data 行]}`)
+/// を解析する純データモデル。実フィールドは `metadata.lot_id` /
+/// `metadata.spot` / `metadata.start_time` / `metadata.end_time` /
+/// `metadata.plate` / `metadata.fee`。旧実装は誤キー (`spot_name` /
+/// `reserved_at` / `status` — いずれも不存在) を読み、全行が
+/// 「スポット N / 予約済み」の捏造表示だった。
+library;
+
+import 'hub_data_parsing.dart';
+
+class ParkingReservationEntry {
+  const ParkingReservationEntry({
+    required this.lotId,
+    required this.spot,
+    required this.startTime,
+    required this.endTime,
+    required this.plate,
+    required this.fee,
+    required this.createdAt,
+  });
+
+  final String lotId;
+  final String spot;
+  final String startTime;
+  final String endTime;
+  final String plate;
+
+  /// 料金 (未設定なら null — ¥0 と偽らない)。
+  final num? fee;
+  final String createdAt;
+
+  /// 一覧タイトル: 'スポット spot (lot)' / どちらも無ければ空文字。
+  String get spotLabel {
+    if (spot.isNotEmpty && lotId.isNotEmpty) return '$spot ($lotId)';
+    if (spot.isNotEmpty) return spot;
+    return lotId;
+  }
+
+  /// 'start 〜 end' の時間帯ラベル (整形は表示側)。
+  String get timeRangeLabel {
+    if (startTime.isEmpty && endTime.isEmpty) return '';
+    return '${hubFormatTimestamp(startTime)} 〜 ${hubFormatTimestamp(endTime)}';
+  }
+
+  factory ParkingReservationEntry.fromMap(Map<String, dynamic> raw) {
+    final rawFee = hubField(raw, 'fee');
+    return ParkingReservationEntry(
+      lotId: hubString(hubField(raw, 'lot_id')),
+      spot: hubString(hubField(raw, 'spot') ?? raw['spot_name']),
+      startTime: hubString(hubField(raw, 'start_time') ?? raw['reserved_at']),
+      endTime: hubString(hubField(raw, 'end_time')),
+      plate: hubString(hubField(raw, 'plate')),
+      fee: rawFee == null ? null : hubNum(rawFee),
+      createdAt: hubString(raw['created_at']),
+    );
+  }
+
+  static List<ParkingReservationEntry> listFromResponse(dynamic data) =>
+      hubRowsFromResponse(data, 'reservations')
+          .map(ParkingReservationEntry.fromMap)
+          .toList();
+}

--- a/lib/models/scheduled_post_entry.dart
+++ b/lib/models/scheduled_post_entry.dart
@@ -1,0 +1,63 @@
+/// SNS 予約投稿モデル。
+///
+/// `social-commerce-hub` の `schedule.list` (`{success, posts: [hub_data 行]}`)
+/// を解析する純データモデル。実フィールドは `metadata.content` /
+/// `metadata.platforms` (配列) / `metadata.scheduled_at` / `metadata.status`。
+/// 旧実装は flat `post['platform']` (単数・不存在) と `post['scheduled_at']`
+/// を読み、見出し全空 + 予約時刻が作成時刻に化けていた。
+library;
+
+import 'hub_data_parsing.dart';
+
+class ScheduledPostEntry {
+  const ScheduledPostEntry({
+    required this.content,
+    required this.platforms,
+    required this.scheduledAt,
+    required this.status,
+    required this.createdAt,
+  });
+
+  final String content;
+
+  /// 予約先プラットフォーム (例: ['x', 'facebook'])。
+  final List<String> platforms;
+
+  /// 予約時刻 (ISO / 未設定は空文字)。
+  final String scheduledAt;
+  final String status;
+  final String createdAt;
+
+  /// アイコン表示用の代表プラットフォーム。
+  String? get primaryPlatform => platforms.isEmpty ? null : platforms.first;
+
+  /// 'X | FACEBOOK' 形式の表示ラベル (空なら '-')。
+  String get platformsLabel => platforms.isEmpty
+      ? '-'
+      : platforms.map((p) => p.toUpperCase()).join(' / ');
+
+  /// 一覧に出す時刻: 予約時刻があればそれ、無ければ作成時刻。
+  String get displayTime => scheduledAt.isNotEmpty ? scheduledAt : createdAt;
+
+  factory ScheduledPostEntry.fromMap(Map<String, dynamic> raw) {
+    final rawPlatforms = hubField(raw, 'platforms');
+    final platforms = rawPlatforms is List
+        ? rawPlatforms
+            .map((p) => hubString(p))
+            .where((p) => p.isNotEmpty)
+            .toList()
+        : <String>[];
+    return ScheduledPostEntry(
+      content: hubString(hubField(raw, 'content')),
+      platforms: platforms,
+      scheduledAt: hubString(hubField(raw, 'scheduled_at')),
+      status: hubString(hubField(raw, 'status')),
+      createdAt: hubString(raw['created_at']),
+    );
+  }
+
+  static List<ScheduledPostEntry> listFromResponse(dynamic data) =>
+      hubRowsFromResponse(data, 'posts')
+          .map(ScheduledPostEntry.fromMap)
+          .toList();
+}

--- a/lib/models/social_feed_post.dart
+++ b/lib/models/social_feed_post.dart
@@ -1,0 +1,38 @@
+/// ソーシャルフィード投稿モデル。
+///
+/// `social-commerce-hub` の `feed.timeline` (`{success, posts: [hub_data 行]}`)
+/// を解析する純データモデル。実フィールドは `metadata.content` /
+/// `metadata.likes` / `metadata.comments` (旧実装は flat キー読みで
+/// 本文全空・件数消失)。`username` は EF に保存されず、timeline は
+/// 自分の投稿のみ返す (metadata->>user_id filter) ため作者は「自分」。
+library;
+
+import 'hub_data_parsing.dart';
+
+class SocialFeedPost {
+  const SocialFeedPost({
+    required this.content,
+    required this.likes,
+    required this.comments,
+    required this.createdAt,
+  });
+
+  final String content;
+  final num likes;
+  final num comments;
+
+  /// トップレベル `created_at` (ISO / 空文字あり)。
+  final String createdAt;
+
+  factory SocialFeedPost.fromMap(Map<String, dynamic> raw) {
+    return SocialFeedPost(
+      content: hubString(hubField(raw, 'content')),
+      likes: hubNum(hubField(raw, 'likes')),
+      comments: hubNum(hubField(raw, 'comments')),
+      createdAt: hubString(raw['created_at']),
+    );
+  }
+
+  static List<SocialFeedPost> listFromResponse(dynamic data) =>
+      hubRowsFromResponse(data, 'posts').map(SocialFeedPost.fromMap).toList();
+}

--- a/lib/pages/affiliate_marketing_page.dart
+++ b/lib/pages/affiliate_marketing_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/affiliate_link_stats.dart';
+
 /// アフィリエイト・マーケティングページ
 /// affiliate-marketing Edge Function と連携してアフィリエイト情報を管理
 class AffiliateMarketingPage extends StatefulWidget {
@@ -14,8 +16,8 @@ class _AffiliateMarketingPageState extends State<AffiliateMarketingPage> {
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
   String? _errorMessage;
-  List<Map<String, dynamic>> _campaigns = [];
-  Map<String, dynamic>? _summary;
+  List<AffiliateLinkStats> _campaigns = [];
+  AffiliateSummary? _summary;
 
   @override
   void initState() {
@@ -37,17 +39,11 @@ class _AffiliateMarketingPageState extends State<AffiliateMarketingPage> {
         'social-commerce-hub',
         body: {'action': 'affiliate.list_links'},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic>) {
-        setState(() {
-          _campaigns = ((data['links'] ?? data['campaigns']) as List?)
-                  ?.cast<Map<String, dynamic>>() ??
-              [];
-          _summary = data['summary'] as Map<String, dynamic>?;
-        });
-      } else if (data is List) {
-        setState(() => _campaigns = data.cast<Map<String, dynamic>>());
-      }
+      final links = AffiliateLinkStats.listFromResponse(response.data);
+      setState(() {
+        _campaigns = links;
+        _summary = AffiliateSummary.fromLinks(links);
+      });
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = 'アフィリエイト情報の取得に失敗しました: $e');
@@ -68,20 +64,20 @@ class _AffiliateMarketingPageState extends State<AffiliateMarketingPage> {
           children: [
             _buildStat(
               '総クリック数',
-              _summary!['total_clicks']?.toString() ?? '0',
+              _summary!.totalClicks.toString(),
               Icons.touch_app,
               const Color(0xFF3D5AFE),
             ),
             _buildStat(
               'コンバージョン',
-              _summary!['total_conversions']?.toString() ?? '0',
+              _summary!.totalConversions.toString(),
               Icons.check_circle,
               const Color(0xFF4CAF50),
             ),
             _buildStat(
-              '報酬合計',
-              '¥${_summary!['total_earnings']?.toString() ?? '0'}',
-              Icons.monetization_on,
+              'リンク数',
+              _summary!.linkCount.toString(),
+              Icons.link,
               const Color(0xFFFF6B35),
             ),
           ],
@@ -170,10 +166,10 @@ class _AffiliateMarketingPageState extends State<AffiliateMarketingPage> {
                     )
                   else
                     ..._campaigns.map((c) {
-                      final name = c['name']?.toString() ?? 'キャンペーン';
-                      final status = c['status']?.toString() ?? '';
-                      final clicks = c['clicks']?.toString() ?? '0';
-                      final earnings = c['earnings']?.toString() ?? '0';
+                      final name = c.title.isNotEmpty ? c.title : 'キャンペーン';
+                      final commission = c.commissionPct > 0
+                          ? '  |  報酬率: ${c.commissionPct}%'
+                          : '';
                       return Card(
                         color: const Color(0xFF1E1E1E),
                         child: ListTile(
@@ -182,15 +178,20 @@ class _AffiliateMarketingPageState extends State<AffiliateMarketingPage> {
                             color: Color(0xFF3D5AFE),
                           ),
                           title: Text(name),
-                          subtitle: Text('クリック: $clicks  |  報酬: ¥$earnings'),
-                          trailing: Chip(
-                            label: Text(status),
-                            backgroundColor: status == 'active'
-                                ? const Color(0xFFC8E6C9)
-                                : Theme.of(context)
-                                    .colorScheme
-                                    .surfaceContainerHighest,
+                          subtitle: Text(
+                            'クリック: ${c.clicks}  |  CV: ${c.conversions}$commission',
                           ),
+                          trailing: c.code.isNotEmpty
+                              ? Chip(
+                                  label: Text(
+                                    c.code,
+                                    style: const TextStyle(fontSize: 11),
+                                  ),
+                                  backgroundColor: Theme.of(context)
+                                      .colorScheme
+                                      .surfaceContainerHighest,
+                                )
+                              : null,
                         ),
                       );
                     }),

--- a/lib/pages/auction_marketplace_page.dart
+++ b/lib/pages/auction_marketplace_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/auction_listing.dart';
+
 /// オークション・マーケットプレイスページ
 /// auction-marketplace Edge Function と連携してオークション出品・入札を管理
 class AuctionMarketplacePage extends StatefulWidget {
@@ -14,7 +16,7 @@ class _AuctionMarketplacePageState extends State<AuctionMarketplacePage> {
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
   String? _errorMessage;
-  List<Map<String, dynamic>> _items = [];
+  List<AuctionListing> _items = [];
 
   @override
   void initState() {
@@ -36,19 +38,9 @@ class _AuctionMarketplacePageState extends State<AuctionMarketplacePage> {
         'social-commerce-hub',
         body: {'action': 'auction.list'},
       );
-      final data = response.data;
-      final auctionList = data is Map<String, dynamic>
-          ? (data['items'] ?? data['auctions'])
-          : null;
-      if (auctionList is List) {
-        setState(
-          () => _items = auctionList.cast<Map<String, dynamic>>(),
-        );
-      } else if (data is List) {
-        setState(() => _items = data.cast<Map<String, dynamic>>());
-      } else {
-        setState(() => _items = []);
-      }
+      setState(
+        () => _items = AuctionListing.listFromResponse(response.data),
+      );
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = 'オークション一覧の取得に失敗しました: $e');
@@ -110,12 +102,12 @@ class _AuctionMarketplacePageState extends State<AuctionMarketplacePage> {
                       itemCount: _items.length,
                       itemBuilder: (context, index) {
                         final item = _items[index];
-                        final title =
-                            item['title']?.toString() ?? 'アイテム ${index + 1}';
-                        final currentPrice = item['current_price'];
-                        final description =
-                            item['description']?.toString() ?? '';
-                        final endAt = item['end_at'];
+                        final title = item.title.isNotEmpty
+                            ? item.title
+                            : 'アイテム ${index + 1}';
+                        final currentPrice = item.displayPrice;
+                        final endAt =
+                            item.endsAt.isNotEmpty ? item.endsAt : null;
                         return Card(
                           margin: const EdgeInsets.only(bottom: 12),
                           child: ListTile(
@@ -133,7 +125,7 @@ class _AuctionMarketplacePageState extends State<AuctionMarketplacePage> {
                             subtitle: Text(
                               currentPrice != null
                                   ? '現在価格: ¥$currentPrice'
-                                  : description,
+                                  : '価格情報なし',
                             ),
                             trailing: endAt != null
                                 ? Text(

--- a/lib/pages/budget_financial_planner_page.dart
+++ b/lib/pages/budget_financial_planner_page.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'asset_management_page.dart';
+import '../models/budget_entry.dart';
 import '../models/kgi_csf_kpi.dart';
 import '../widgets/kgi_csf_kpi_panel.dart';
 
@@ -29,9 +30,9 @@ class _BudgetFinancialPlannerPageState extends State<BudgetFinancialPlannerPage>
   String _selectedMonth = DateFormat('yyyy-MM').format(DateTime.now());
 
   // Budget data
-  List<Map<String, dynamic>> _budgets = [];
-  List<Map<String, dynamic>> _expenses = [];
-  List<Map<String, dynamic>> _incomes = [];
+  List<BudgetEntry> _budgets = [];
+  List<BudgetEntry> _expenses = [];
+  List<BudgetEntry> _incomes = [];
 
   // AI advice
   String? _aiAdvice;
@@ -111,19 +112,20 @@ class _BudgetFinancialPlannerPageState extends State<BudgetFinancialPlannerPage>
           'social-commerce-hub',
           body: {'action': 'budget.summary', 'month': _selectedMonth},
         ),
-        _supabase.functions.invoke(
-          'social-commerce-hub',
-          body: {
-            'action': 'get',
-            'view': 'expenses',
-            'month': _selectedMonth,
-          },
-        ),
+        // 旧実装は無効 action 'get' (EF 400) で支出常に空だった。
         _supabase.functions.invoke(
           'social-commerce-hub',
           body: {
             'action': 'budget.expense_list',
-            'view': 'income',
+            'month': _selectedMonth,
+          },
+        ),
+        // 収入は budget.income_list (応答キーは単数 'income')。
+        // 旧実装は budget.expense_list を叩き 'incomes' を読んでいた。
+        _supabase.functions.invoke(
+          'social-commerce-hub',
+          body: {
+            'action': 'budget.income_list',
             'month': _selectedMonth,
           },
         ),
@@ -131,9 +133,9 @@ class _BudgetFinancialPlannerPageState extends State<BudgetFinancialPlannerPage>
 
       if (!mounted) return;
       setState(() {
-        _budgets = _extractList(results[0].data, 'budgets');
-        _expenses = _extractList(results[1].data, 'expenses');
-        _incomes = _extractList(results[2].data, 'incomes');
+        _budgets = BudgetEntry.listFromResponse(results[0].data, 'budgets');
+        _expenses = BudgetEntry.listFromResponse(results[1].data, 'expenses');
+        _incomes = BudgetEntry.listFromResponse(results[2].data, 'income');
       });
     } catch (e) {
       debugPrint('BudgetPage load error: $e');
@@ -142,34 +144,15 @@ class _BudgetFinancialPlannerPageState extends State<BudgetFinancialPlannerPage>
     }
   }
 
-  List<Map<String, dynamic>> _extractList(dynamic data, String key) {
-    if (data is Map<String, dynamic> && data[key] is List) {
-      return (data[key] as List).cast<Map<String, dynamic>>();
-    }
-    return [];
-  }
+  double _totalIncome() => BudgetEntry.total(_incomes).toDouble();
 
-  double _totalIncome() => _incomes.fold(
-        0,
-        (sum, e) => sum + ((e['amount'] as num?)?.toDouble() ?? 0),
-      );
+  double _totalExpenses() => BudgetEntry.total(_expenses).toDouble();
 
-  double _totalExpenses() => _expenses.fold(
-        0,
-        (sum, e) => sum + ((e['amount'] as num?)?.toDouble() ?? 0),
-      );
+  double _budgetForCategory(String cat) =>
+      BudgetEntry.sumForCategory(_budgets, cat).toDouble();
 
-  double _budgetForCategory(String cat) {
-    final b = _budgets.firstWhere(
-      (b) => b['category'] == cat,
-      orElse: () => {},
-    );
-    return (b['amount'] as num?)?.toDouble() ?? 0;
-  }
-
-  double _expenseForCategory(String cat) => _expenses
-      .where((e) => e['category'] == cat)
-      .fold(0, (sum, e) => sum + ((e['amount'] as num?)?.toDouble() ?? 0));
+  double _expenseForCategory(String cat) =>
+      BudgetEntry.sumForCategory(_expenses, cat).toDouble();
 
   Future<void> _addBudget(String category, double amount) async {
     try {
@@ -608,8 +591,8 @@ $breakdown
   List<Map<String, dynamic>> _topExpenses() {
     final map = <String, double>{};
     for (final e in _expenses) {
-      final cat = e['category'] as String? ?? 'other';
-      map[cat] = (map[cat] ?? 0) + ((e['amount'] as num?)?.toDouble() ?? 0);
+      final cat = e.category.isNotEmpty ? e.category : 'other';
+      map[cat] = (map[cat] ?? 0) + e.amount.toDouble();
     }
     final sorted = map.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));

--- a/lib/pages/donation_crowdfunding_page.dart
+++ b/lib/pages/donation_crowdfunding_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/donation_project.dart';
+
 /// 寄付・クラウドファンディングページ
 /// donation-crowdfunding Edge Function と連携して寄付プロジェクトを管理
 class DonationCrowdfundingPage extends StatefulWidget {
@@ -15,7 +17,7 @@ class _DonationCrowdfundingPageState extends State<DonationCrowdfundingPage> {
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
   String? _errorMessage;
-  List<Map<String, dynamic>> _projects = [];
+  List<DonationProject> _projects = [];
 
   @override
   void initState() {
@@ -37,17 +39,9 @@ class _DonationCrowdfundingPageState extends State<DonationCrowdfundingPage> {
         'lifestyle-hub',
         body: {'action': 'donation.list'},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['projects'] is List) {
-        setState(
-          () => _projects =
-              (data['projects'] as List).cast<Map<String, dynamic>>(),
-        );
-      } else if (data is List) {
-        setState(() => _projects = data.cast<Map<String, dynamic>>());
-      } else {
-        setState(() => _projects = []);
-      }
+      setState(
+        () => _projects = DonationProject.listFromResponse(response.data),
+      );
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = 'データ取得に失敗しました: $e');
@@ -100,11 +94,9 @@ class _DonationCrowdfundingPageState extends State<DonationCrowdfundingPage> {
                       itemCount: _projects.length,
                       itemBuilder: (context, index) {
                         final project = _projects[index];
-                        final goal =
-                            (project['goal_amount'] as num?)?.toDouble() ?? 0;
-                        final raised =
-                            (project['raised_amount'] as num?)?.toDouble() ?? 0;
-                        final progress = goal > 0 ? raised / goal : 0.0;
+                        final goal = project.goalAmount.toDouble();
+                        final raised = project.raisedAmount.toDouble();
+                        final progress = project.progress;
                         return Card(
                           margin: const EdgeInsets.only(bottom: 12),
                           child: Padding(
@@ -113,7 +105,9 @@ class _DonationCrowdfundingPageState extends State<DonationCrowdfundingPage> {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text(
-                                  project['title']?.toString() ?? 'タイトル不明',
+                                  project.title.isNotEmpty
+                                      ? project.title
+                                      : 'タイトル不明',
                                   style: const TextStyle(
                                     fontWeight: FontWeight.bold,
                                     fontSize: 16,
@@ -121,7 +115,7 @@ class _DonationCrowdfundingPageState extends State<DonationCrowdfundingPage> {
                                   ),
                                 ),
                                 const SizedBox(height: 4),
-                                Text(project['description']?.toString() ?? ''),
+                                Text(project.description),
                                 const SizedBox(height: 8),
                                 LinearProgressIndicator(
                                   value: progress.clamp(0.0, 1.0),

--- a/lib/pages/elearning_course_manager_page.dart
+++ b/lib/pages/elearning_course_manager_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/elearning_course.dart';
+
 /// eラーニングコース管理ページ
 /// コース一覧・学習進捗・クイズ・証明書。
 /// elearning-course-manager Edge Function と連携。
@@ -19,8 +21,8 @@ class _ElearningCourseManagerPageState extends State<ElearningCourseManagerPage>
 
   bool _isLoading = false;
   String? _errorMessage;
-  List<Map<String, dynamic>> _courses = [];
-  List<Map<String, dynamic>> _inProgress = [];
+  List<ELearningCourse> _courses = [];
+  List<ELearningCourse> _inProgress = [];
   List<Map<String, dynamic>> _certificates = [];
 
   @override
@@ -59,9 +61,11 @@ class _ElearningCourseManagerPageState extends State<ElearningCourseManagerPage>
         body: {'action': 'course.certificates'},
       );
 
+      final courses = ELearningCourse.listFromResponse(coursesRes.data);
+      final progressById = ELearningCourse.progressByCourseId(progressRes.data);
       setState(() {
-        _courses = _extractList(coursesRes.data, 'courses');
-        _inProgress = _extractList(progressRes.data, 'courses');
+        _courses = courses;
+        _inProgress = ELearningCourse.inProgress(courses, progressById);
         _certificates = _extractList(certRes.data, 'certificates');
       });
     } catch (e) {
@@ -130,7 +134,7 @@ class _ElearningCourseManagerPageState extends State<ElearningCourseManagerPage>
   }
 
   Widget _buildCoursesTab(
-    List<Map<String, dynamic>> courses, {
+    List<ELearningCourse> courses, {
     bool showProgress = false,
   }) {
     if (courses.isEmpty) {
@@ -156,14 +160,11 @@ class _ElearningCourseManagerPageState extends State<ElearningCourseManagerPage>
       itemCount: courses.length,
       itemBuilder: (ctx, i) {
         final c = courses[i];
-        final title = c['title'] as String? ?? 'コース ${i + 1}';
-        final instructor = c['instructor'] as String? ?? '';
-        final duration = c['durationHours'] as int? ?? 0;
-        final level = c['level'] as String? ?? '';
-        final progress = (c['progress'] as num?)?.toDouble() ?? 0;
-        final enrolled = c['enrolled'] as bool? ?? false;
-        final rating = (c['rating'] as num?)?.toDouble() ?? 0;
-        final emoji = c['emoji'] as String? ?? '📚';
+        final title = c.title.isNotEmpty ? c.title : 'コース ${i + 1}';
+        final language = c.language;
+        final level = c.level;
+        final progress = c.progress.toDouble();
+        final enrolled = c.progress > 0;
 
         return Card(
           margin: const EdgeInsets.only(bottom: 10),
@@ -174,9 +175,9 @@ class _ElearningCourseManagerPageState extends State<ElearningCourseManagerPage>
                 leading: CircleAvatar(
                   backgroundColor:
                       Theme.of(context).colorScheme.primaryContainer,
-                  child: Text(
-                    emoji,
-                    style: const TextStyle(
+                  child: const Text(
+                    '📚',
+                    style: TextStyle(
                       fontSize: 20,
                       height: 1.5,
                     ),
@@ -189,9 +190,7 @@ class _ElearningCourseManagerPageState extends State<ElearningCourseManagerPage>
                     height: 1.5,
                   ),
                 ),
-                subtitle: Text(
-                  '${instructor.isNotEmpty ? "$instructor · " : ""}${duration > 0 ? "$duration時間" : ""}',
-                ),
+                subtitle: language.isNotEmpty ? Text('言語: $language') : null,
                 trailing: level.isNotEmpty
                     ? Chip(
                         label: Text(
@@ -227,49 +226,34 @@ class _ElearningCourseManagerPageState extends State<ElearningCourseManagerPage>
                     ],
                   ),
                 ),
-              if (rating > 0 || enrolled)
+              if (!enrolled)
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
                   child: Row(
                     children: [
-                      if (rating > 0) ...[
-                        const Icon(
-                          Icons.star,
-                          size: 14,
-                          color: Color(0xFFFFC107),
-                        ),
-                        Text(
-                          ' $rating',
-                          style: const TextStyle(
-                            fontSize: 12,
-                            height: 1.5,
-                          ),
-                        ),
-                      ],
                       const Spacer(),
-                      if (!enrolled)
-                        OutlinedButton.icon(
-                          onPressed: () async {
-                            try {
-                              await _supabase.functions.invoke(
-                                'social-commerce-hub',
-                                body: {
-                                  'action': 'course.enroll',
-                                  'courseId': c['id'],
-                                },
-                              );
-                              await _fetchData();
-                            } catch (_) {}
-                          },
-                          icon: const Icon(Icons.add, size: 14),
-                          label: const Text('受講する'),
-                          style: OutlinedButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 4,
-                            ),
+                      OutlinedButton.icon(
+                        onPressed: () async {
+                          try {
+                            await _supabase.functions.invoke(
+                              'social-commerce-hub',
+                              body: {
+                                'action': 'course.enroll',
+                                'course_id': c.id,
+                              },
+                            );
+                            await _fetchData();
+                          } catch (_) {}
+                        },
+                        icon: const Icon(Icons.add, size: 14),
+                        label: const Text('受講する'),
+                        style: OutlinedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 4,
                           ),
                         ),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/pages/event_ticketing_page.dart
+++ b/lib/pages/event_ticketing_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/event_ticketing_summary.dart';
+
 /// イベントチケット管理ページ
 /// event-ticketing Edge Function と連携してイベントとチケットを管理する
 class EventTicketingPage extends StatefulWidget {
@@ -14,7 +16,7 @@ class _EventTicketingPageState extends State<EventTicketingPage> {
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
   String? _errorMessage;
-  List<Map<String, dynamic>> _events = [];
+  List<EventTicketingSummary> _events = [];
   final _titleController = TextEditingController();
   final _dateController = TextEditingController();
 
@@ -103,16 +105,9 @@ class _EventTicketingPageState extends State<EventTicketingPage> {
         'social-commerce-hub',
         body: {'action': 'event.list'},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['events'] is List) {
-        setState(
-          () => _events = (data['events'] as List).cast<Map<String, dynamic>>(),
-        );
-      } else if (data is List) {
-        setState(() => _events = data.cast<Map<String, dynamic>>());
-      } else {
-        setState(() => _events = []);
-      }
+      setState(
+        () => _events = EventTicketingSummary.listFromResponse(response.data),
+      );
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = 'イベント一覧の取得に失敗しました: $e');
@@ -165,11 +160,12 @@ class _EventTicketingPageState extends State<EventTicketingPage> {
                         return ListTile(
                           leading: const Icon(Icons.event),
                           title: Text(
-                            event['title']?.toString() ?? 'イベント ${index + 1}',
+                            event.title.isNotEmpty
+                                ? event.title
+                                : 'イベント ${index + 1}',
                           ),
-                          subtitle: Text(event['date']?.toString() ?? ''),
-                          trailing:
-                              Text('残 ${event['tickets_remaining'] ?? 0}枚'),
+                          subtitle: Text(event.date),
+                          trailing: Text(event.remainingLabel),
                         );
                       },
                     ),

--- a/lib/pages/language_learning_page.dart
+++ b/lib/pages/language_learning_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/language_deck.dart';
+
 /// 語学学習ページ
 /// language-learning Edge Function と連携
 /// Duolingo / Anki 競合
@@ -17,14 +19,13 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
   late final TabController _tabController;
   bool _isLoading = false;
   String? _errorMessage;
-  List<Map<String, dynamic>> _decks = [];
-  Map<String, dynamic>? _selectedDeck;
-  List<Map<String, dynamic>> _cards = [];
-  List<Map<String, dynamic>> _reviewCards = [];
+  List<LanguageDeck> _decks = [];
+  LanguageDeck? _selectedDeck;
+  List<Flashcard> _cards = [];
+  List<Flashcard> _reviewCards = [];
   int _reviewIndex = 0;
   bool _showAnswer = false;
-  Map<String, dynamic> _streak = {};
-  Map<String, dynamic> _stats = {};
+  LanguageStats _langStats = const LanguageStats(streakDays: 0, totalCards: 0);
 
   final _deckTitleCtrl = TextEditingController();
   final _deckDescCtrl = TextEditingController();
@@ -55,7 +56,6 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
     _fetchDecks();
-    _fetchStreak();
     _fetchStats();
   }
 
@@ -84,14 +84,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
         'social-commerce-hub',
         body: {'action': 'lang.list_decks'},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['decks'] is List) {
-        setState(() {
-          _decks = (data['decks'] as List).cast<Map<String, dynamic>>();
-        });
-      } else {
-        setState(() => _decks = []);
-      }
+      setState(() => _decks = LanguageDeck.listFromResponse(response.data));
     } catch (e) {
       if (mounted) setState(() => _errorMessage = '単語帳の取得に失敗しました: $e');
     } finally {
@@ -105,12 +98,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
         'social-commerce-hub',
         body: {'action': 'lang.list_cards', 'deck_id': deckId},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['cards'] is List) {
-        setState(() {
-          _cards = (data['cards'] as List).cast<Map<String, dynamic>>();
-        });
-      }
+      setState(() => _cards = Flashcard.listFromResponse(response.data));
     } catch (_) {}
   }
 
@@ -120,45 +108,34 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
         'social-commerce-hub',
         body: {'action': 'lang.review_session', 'deck_id': deckId},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['dueCards'] is List) {
-        setState(() {
-          _reviewCards =
-              (data['dueCards'] as List).cast<Map<String, dynamic>>();
-          _reviewIndex = 0;
-          _showAnswer = false;
-        });
-      }
-    } catch (_) {}
-  }
-
-  Future<void> _fetchStreak() async {
-    try {
-      final response = await _supabase.functions.invoke(
-        'social-commerce-hub',
-        body: {'action': 'lang.streak'},
-      );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['streak'] is Map) {
-        setState(
-          () => _streak = Map<String, dynamic>.from(data['streak'] as Map),
-        );
-      }
+      // EF は review_session でも `cards` キーで返す (旧実装の `dueCards` は
+      // 常に空だった)。
+      setState(() {
+        _reviewCards = Flashcard.listFromResponse(response.data);
+        _reviewIndex = 0;
+        _showAnswer = false;
+      });
     } catch (_) {}
   }
 
   Future<void> _fetchStats() async {
     try {
-      final response = await _supabase.functions.invoke(
+      final streakRes = await _supabase.functions.invoke(
+        'social-commerce-hub',
+        body: {'action': 'lang.streak'},
+      );
+      final statsRes = await _supabase.functions.invoke(
         'social-commerce-hub',
         body: {'action': 'lang.stats'},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['stats'] is Map) {
-        setState(
-          () => _stats = Map<String, dynamic>.from(data['stats'] as Map),
-        );
-      }
+      // EF は `{streak_days}` / `{total_cards, decks}` を top-level で返す
+      // (旧実装の `{streak:{...}}` / `{stats:{...}}` 期待は常に空だった)。
+      setState(
+        () => _langStats = LanguageStats.fromResponses(
+          streakRes.data,
+          statsRes.data,
+        ),
+      );
     } catch (_) {}
   }
 
@@ -200,7 +177,9 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
         'social-commerce-hub',
         body: {
           'action': 'lang.add_card',
-          'deck_id': deck['deck_id'] as String? ?? '',
+          // EF は `deck` キーで受ける (旧実装の `deck_id` は無視され default 化)。
+          'deck': deck.id,
+          'deck_id': deck.id,
           'front': _cardFrontCtrl.text.trim(),
           'back': _cardBackCtrl.text.trim(),
           'example': _cardExampleCtrl.text.trim(),
@@ -210,7 +189,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
       _cardBackCtrl.clear();
       _cardExampleCtrl.clear();
       if (mounted) Navigator.of(context).pop();
-      await _fetchCards(deck['deck_id'] as String? ?? '');
+      await _fetchCards(deck.id);
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -228,7 +207,8 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
         'social-commerce-hub',
         body: {
           'action': 'lang.review_card',
-          'card_id': card['card_id'] as String? ?? '',
+          // EF は `id` キーで更新する (旧実装の `card_id` では no-op だった)。
+          'id': card.id,
           'correct': correct,
           'quality': correct ? 4 : 1,
         },
@@ -243,7 +223,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
           _showAnswer = false;
         }
       });
-      await _fetchStreak();
+      await _fetchStats();
     } catch (_) {}
   }
 
@@ -442,7 +422,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
     return Column(
       children: [
         // Streak banner
-        if (_streak.isNotEmpty)
+        if (_langStats.streakDays > 0)
           Container(
             color: Theme.of(context).brightness == Brightness.dark
                 ? const Color(0xFF2A1F0A)
@@ -459,7 +439,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                 ),
                 const SizedBox(width: 8),
                 Text(
-                  '${_streak['current'] ?? 0}日連続学習中',
+                  '${_langStats.streakDays}日連続学習中',
                   style: const TextStyle(
                     fontWeight: FontWeight.bold,
                     color: Color(0xFFFF6B35),
@@ -468,7 +448,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                 ),
                 const Spacer(),
                 Text(
-                  '最長: ${_streak['longest'] ?? 0}日',
+                  'カード ${_langStats.totalCards}枚',
                   style: const TextStyle(
                     color: Color(0xFF9CA3AF),
                     height: 1.5,
@@ -484,18 +464,19 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
             separatorBuilder: (_, __) => const SizedBox(height: 8),
             itemBuilder: (_, i) {
               final deck = _decks[i];
-              final fromLang = deck['language_from'] as String? ?? '';
-              final toLang = deck['language_to'] as String? ?? '';
-              final cardCount = deck['card_count'] ?? 0;
-              final isSelected = _selectedDeck?['deck_id'] == deck['deck_id'];
+              final lang = deck.language;
+              final isSelected = _selectedDeck?.id == deck.id;
               return Card(
                 elevation: isSelected ? 4 : 1,
                 color: isSelected ? const Color(0xFFFFF3E0) : null,
                 child: ListTile(
                   leading: const Icon(Icons.book, color: Color(0xFFFF6B35)),
-                  title: Text(deck['title'] as String? ?? ''),
+                  title: Text(deck.name),
                   subtitle: Text(
-                    '${_langLabels[fromLang] ?? fromLang} → ${_langLabels[toLang] ?? toLang} | $cardCount 枚',
+                    [
+                      if (lang.isNotEmpty) _langLabels[lang] ?? lang,
+                      if (deck.description.isNotEmpty) deck.description,
+                    ].join(' | '),
                   ),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
@@ -517,9 +498,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                         tooltip: 'レビュー開始',
                         onPressed: () async {
                           setState(() => _selectedDeck = deck);
-                          await _fetchReviewCards(
-                            deck['deck_id'] as String? ?? '',
-                          );
+                          await _fetchReviewCards(deck.id);
                           _tabController.animateTo(1);
                         },
                       ),
@@ -527,7 +506,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                   ),
                   onTap: () async {
                     setState(() => _selectedDeck = deck);
-                    await _fetchCards(deck['deck_id'] as String? ?? '');
+                    await _fetchCards(deck.id);
                   },
                 ),
               );
@@ -550,7 +529,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                 Padding(
                   padding: const EdgeInsets.all(8),
                   child: Text(
-                    '「${_selectedDeck!['title']}」のカード (${_cards.length}枚)',
+                    '「${_selectedDeck!.name}」のカード (${_cards.length}枚)',
                     style: const TextStyle(
                       fontWeight: FontWeight.bold,
                       height: 1.5,
@@ -565,8 +544,8 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                       final card = _cards[i];
                       return ListTile(
                         dense: true,
-                        title: Text(card['front'] as String? ?? ''),
-                        trailing: Text(card['back'] as String? ?? ''),
+                        title: Text(card.front),
+                        trailing: Text(card.back),
                       );
                     },
                   ),
@@ -627,8 +606,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
             ),
             const SizedBox(height: 24),
             ElevatedButton.icon(
-              onPressed: () =>
-                  _fetchReviewCards(_selectedDeck!['deck_id'] as String? ?? ''),
+              onPressed: () => _fetchReviewCards(_selectedDeck!.id),
               icon: const Icon(Icons.refresh),
               label: const Text('再チェック'),
             ),
@@ -699,7 +677,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                         ),
                         const SizedBox(height: 16),
                         Text(
-                          card['front'] as String? ?? '',
+                          card.front,
                           style: const TextStyle(
                             fontSize: 32,
                             fontWeight: FontWeight.bold,
@@ -726,7 +704,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                         ),
                         const SizedBox(height: 16),
                         Text(
-                          card['back'] as String? ?? '',
+                          card.back,
                           style: const TextStyle(
                             fontSize: 28,
                             fontWeight: FontWeight.bold,
@@ -735,13 +713,12 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                           ),
                           textAlign: TextAlign.center,
                         ),
-                        if (card['example'] != null &&
-                            (card['example'] as String).isNotEmpty) ...[
+                        if (card.example.isNotEmpty) ...[
                           const SizedBox(height: 16),
                           Padding(
                             padding: const EdgeInsets.symmetric(horizontal: 24),
                             child: Text(
-                              '例: ${card['example']}',
+                              '例: ${card.example}',
                               style: TextStyle(
                                 color: Theme.of(context)
                                     .colorScheme
@@ -819,16 +796,11 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
   }
 
   Widget _buildStatsTab() {
-    final totalCards = _stats['totalCards'] ?? 0;
-    final totalReviews = _stats['totalReviews'] ?? 0;
-    final correctRate = _stats['correctRate'] ?? 0;
-    final deckCount = _stats['deckCount'] ?? _decks.length;
+    final totalCards = _langStats.totalCards;
+    final deckCount = _decks.length;
 
     return RefreshIndicator(
-      onRefresh: () async {
-        await _fetchStats();
-        await _fetchStreak();
-      },
+      onRefresh: _fetchStats,
       child: ListView(
         padding: const EdgeInsets.all(16),
         children: [
@@ -853,7 +825,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        '${_streak['current'] ?? 0}日連続',
+                        '${_langStats.streakDays}日連続',
                         style: const TextStyle(
                           fontSize: 28,
                           fontWeight: FontWeight.bold,
@@ -862,7 +834,7 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                         ),
                       ),
                       Text(
-                        '最長: ${_streak['longest'] ?? 0}日',
+                        'カード ${_langStats.totalCards}枚',
                         style: const TextStyle(
                           color: Color(0xFF9CA3AF),
                           height: 1.5,
@@ -897,16 +869,10 @@ class _LanguageLearningPageState extends State<LanguageLearningPage>
                 const Color(0xFFFF6B35),
               ),
               _buildStatCard(
-                '総レビュー',
-                '$totalReviews',
-                Icons.history,
+                '連続学習',
+                '${_langStats.streakDays}日',
+                Icons.local_fire_department,
                 const Color(0xFF4CAF50),
-              ),
-              _buildStatCard(
-                '正解率',
-                '$correctRate%',
-                Icons.percent,
-                const Color(0xFF3D5AFE),
               ),
             ],
           ),

--- a/lib/pages/parking_reservation_page.dart
+++ b/lib/pages/parking_reservation_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/parking_reservation_entry.dart';
+
 /// 駐車場予約ページ
 /// parking-reservation Edge Function と連携して駐車場の予約を管理
 class ParkingReservationPage extends StatefulWidget {
@@ -14,7 +16,7 @@ class _ParkingReservationPageState extends State<ParkingReservationPage> {
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
   String? _errorMessage;
-  List<Map<String, dynamic>> _reservations = [];
+  List<ParkingReservationEntry> _reservations = [];
 
   @override
   void initState() {
@@ -36,17 +38,10 @@ class _ParkingReservationPageState extends State<ParkingReservationPage> {
         'lifestyle-hub',
         body: {'action': 'parking.list'},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['reservations'] is List) {
-        setState(
-          () => _reservations =
-              (data['reservations'] as List).cast<Map<String, dynamic>>(),
-        );
-      } else if (data is List) {
-        setState(() => _reservations = data.cast<Map<String, dynamic>>());
-      } else {
-        setState(() => _reservations = []);
-      }
+      setState(
+        () => _reservations =
+            ParkingReservationEntry.listFromResponse(response.data),
+      );
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = '予約一覧の取得に失敗しました: $e');
@@ -104,10 +99,12 @@ class _ParkingReservationPageState extends State<ParkingReservationPage> {
                       itemCount: _reservations.length,
                       itemBuilder: (context, index) {
                         final res = _reservations[index];
-                        final spotName =
-                            res['spot_name']?.toString() ?? 'スポット ${index + 1}';
-                        final reservedAt = res['reserved_at']?.toString();
-                        final status = res['status']?.toString() ?? '予約済み';
+                        final spotName = res.spotLabel.isNotEmpty
+                            ? res.spotLabel
+                            : 'スポット ${index + 1}';
+                        final timeRange = res.timeRangeLabel;
+                        final feeLabel =
+                            res.fee != null ? '¥${res.fee}' : '予約済み';
                         return Card(
                           margin: const EdgeInsets.only(bottom: 12),
                           child: ListTile(
@@ -122,20 +119,20 @@ class _ParkingReservationPageState extends State<ParkingReservationPage> {
                                 height: 1.5,
                               ),
                             ),
-                            subtitle: Text(reservedAt ?? status),
+                            subtitle: Text(
+                              timeRange.isNotEmpty ? timeRange : '予約済み',
+                            ),
                             trailing: Chip(
                               label: Text(
-                                status,
+                                feeLabel,
                                 style: const TextStyle(
                                   fontSize: 12,
                                   height: 1.5,
                                 ),
                               ),
-                              backgroundColor: status == 'active'
-                                  ? const Color(0xFFC8E6C9)
-                                  : Theme.of(context)
-                                      .colorScheme
-                                      .surfaceContainerHigh,
+                              backgroundColor: Theme.of(context)
+                                  .colorScheme
+                                  .surfaceContainerHigh,
                             ),
                           ),
                         );

--- a/lib/pages/social_feed_page.dart
+++ b/lib/pages/social_feed_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/social_feed_post.dart';
+
 /// ソーシャルフィードページ
 /// social-feed Edge Function と連携してユーザーの投稿フィードを表示
 class SocialFeedPage extends StatefulWidget {
@@ -14,7 +16,7 @@ class _SocialFeedPageState extends State<SocialFeedPage> {
   final _supabase = Supabase.instance.client;
   bool _isLoading = false;
   String? _errorMessage;
-  List<dynamic> _posts = [];
+  List<SocialFeedPost> _posts = [];
   String _feedType = 'public';
 
   @override
@@ -37,12 +39,7 @@ class _SocialFeedPageState extends State<SocialFeedPage> {
         'social-commerce-hub',
         body: {'action': 'feed.timeline', 'type': _feedType, 'limit': 30},
       );
-      final data = response.data;
-      if (data is Map<String, dynamic> && data['posts'] is List) {
-        setState(() => _posts = data['posts'] as List);
-      } else if (data is List) {
-        setState(() => _posts = data);
-      }
+      setState(() => _posts = SocialFeedPost.listFromResponse(response.data));
     } catch (e) {
       if (mounted) {
         setState(() => _errorMessage = 'フィード取得に失敗しました: $e');
@@ -113,7 +110,10 @@ class _SocialFeedPageState extends State<SocialFeedPage> {
                             separatorBuilder: (_, __) =>
                                 const SizedBox(height: 8),
                             itemBuilder: (context, i) {
-                              final post = _posts[i] as Map<String, dynamic>;
+                              final post = _posts[i];
+                              final createdLabel = post.createdAt.length >= 10
+                                  ? post.createdAt.substring(0, 10)
+                                  : post.createdAt;
                               return Card(
                                 child: Padding(
                                   padding: const EdgeInsets.all(12),
@@ -128,37 +128,24 @@ class _SocialFeedPageState extends State<SocialFeedPage> {
                                             backgroundColor:
                                                 const Color(0xFF009688)
                                                     .withAlpha(30),
-                                            child: Text(
-                                              (post['username']
-                                                          ?.toString()
-                                                          .isNotEmpty ==
-                                                      true
-                                                  ? post['username']
-                                                      .toString()[0]
-                                                      .toUpperCase()
-                                                  : '?'),
-                                              style: const TextStyle(
-                                                color: Color(0xFF009688),
-                                                fontWeight: FontWeight.bold,
-                                                height: 1.5,
-                                              ),
+                                            child: const Icon(
+                                              Icons.person,
+                                              size: 18,
+                                              color: Color(0xFF009688),
                                             ),
                                           ),
                                           const SizedBox(width: 8),
-                                          Text(
-                                            post['username']?.toString() ??
-                                                '匿名',
-                                            style: const TextStyle(
+                                          const Text(
+                                            '自分の投稿',
+                                            style: TextStyle(
                                               fontWeight: FontWeight.w600,
                                               height: 1.5,
                                             ),
                                           ),
                                           const Spacer(),
-                                          if (post['created_at'] != null)
+                                          if (createdLabel.isNotEmpty)
                                             Text(
-                                              post['created_at']
-                                                  .toString()
-                                                  .substring(0, 10),
+                                              createdLabel,
                                               style: const TextStyle(
                                                 fontSize: 11,
                                                 color: Color(0xFF9CA3AF),
@@ -168,50 +155,41 @@ class _SocialFeedPageState extends State<SocialFeedPage> {
                                         ],
                                       ),
                                       const SizedBox(height: 8),
-                                      Text(
-                                        post['content']?.toString() ?? '',
+                                      Text(post.content),
+                                      const SizedBox(height: 8),
+                                      Row(
+                                        children: [
+                                          const Icon(
+                                            Icons.favorite_border,
+                                            size: 14,
+                                            color: Color(0xFF9CA3AF),
+                                          ),
+                                          const SizedBox(width: 4),
+                                          Text(
+                                            post.likes.toString(),
+                                            style: const TextStyle(
+                                              fontSize: 12,
+                                              color: Color(0xFF9CA3AF),
+                                              height: 1.5,
+                                            ),
+                                          ),
+                                          const SizedBox(width: 12),
+                                          const Icon(
+                                            Icons.comment_outlined,
+                                            size: 14,
+                                            color: Color(0xFF9CA3AF),
+                                          ),
+                                          const SizedBox(width: 4),
+                                          Text(
+                                            post.comments.toString(),
+                                            style: const TextStyle(
+                                              fontSize: 12,
+                                              color: Color(0xFF9CA3AF),
+                                              height: 1.5,
+                                            ),
+                                          ),
+                                        ],
                                       ),
-                                      if (post['likes'] != null ||
-                                          post['comments'] != null) ...[
-                                        const SizedBox(height: 8),
-                                        Row(
-                                          children: [
-                                            if (post['likes'] != null) ...[
-                                              const Icon(
-                                                Icons.favorite_border,
-                                                size: 14,
-                                                color: Color(0xFF9CA3AF),
-                                              ),
-                                              const SizedBox(width: 4),
-                                              Text(
-                                                post['likes'].toString(),
-                                                style: const TextStyle(
-                                                  fontSize: 12,
-                                                  color: Color(0xFF9CA3AF),
-                                                  height: 1.5,
-                                                ),
-                                              ),
-                                              const SizedBox(width: 12),
-                                            ],
-                                            if (post['comments'] != null) ...[
-                                              const Icon(
-                                                Icons.comment_outlined,
-                                                size: 14,
-                                                color: Color(0xFF9CA3AF),
-                                              ),
-                                              const SizedBox(width: 4),
-                                              Text(
-                                                post['comments'].toString(),
-                                                style: const TextStyle(
-                                                  fontSize: 12,
-                                                  color: Color(0xFF9CA3AF),
-                                                  height: 1.5,
-                                                ),
-                                              ),
-                                            ],
-                                          ],
-                                        ),
-                                      ],
                                     ],
                                   ),
                                 ),

--- a/lib/pages/social_media_scheduler_page.dart
+++ b/lib/pages/social_media_scheduler_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/scheduled_post_entry.dart';
+
 /// SNS投稿スケジュール管理ページ
 /// social-media-scheduler Edge Function と連携
 class SocialMediaSchedulerPage extends StatefulWidget {
@@ -17,9 +19,9 @@ class _SocialMediaSchedulerPageState extends State<SocialMediaSchedulerPage>
   late TabController _tabController;
   bool _isLoading = false;
   String? _errorMessage;
-  List<dynamic> _scheduled = [];
-  List<dynamic> _published = [];
-  List<dynamic> _drafts = [];
+  List<ScheduledPostEntry> _scheduled = [];
+  List<ScheduledPostEntry> _published = [];
+  List<ScheduledPostEntry> _drafts = [];
 
   @override
   void initState() {
@@ -48,14 +50,12 @@ class _SocialMediaSchedulerPageState extends State<SocialMediaSchedulerPage>
         'social-commerce-hub',
         body: {'action': 'schedule.list'},
       );
-      final data = res.data;
-      if (data is Map<String, dynamic>) {
-        setState(() {
-          _scheduled = (data['posts'] as List?) ?? [];
-          _published = [];
-          _drafts = [];
-        });
-      }
+      final all = ScheduledPostEntry.listFromResponse(res.data);
+      setState(() {
+        _scheduled = all.where((p) => p.status != 'published').toList();
+        _published = all.where((p) => p.status == 'published').toList();
+        _drafts = all.where((p) => p.status == 'draft').toList();
+      });
     } catch (e) {
       if (mounted) setState(() => _errorMessage = 'データ取得に失敗しました: $e');
     } finally {
@@ -247,7 +247,7 @@ class _SocialMediaSchedulerPageState extends State<SocialMediaSchedulerPage>
     );
   }
 
-  Widget _buildPostList(List<dynamic> posts, String emptyMessage) {
+  Widget _buildPostList(List<ScheduledPostEntry> posts, String emptyMessage) {
     if (posts.isEmpty) {
       return Center(
         child: Column(
@@ -272,8 +272,9 @@ class _SocialMediaSchedulerPageState extends State<SocialMediaSchedulerPage>
       itemCount: posts.length,
       separatorBuilder: (_, __) => const SizedBox(height: 8),
       itemBuilder: (context, i) {
-        final post = posts[i] as Map<String, dynamic>;
-        final platform = post['platform']?.toString();
+        final post = posts[i];
+        final platform = post.primaryPlatform;
+        final time = post.displayTime.isNotEmpty ? post.displayTime : '-';
         return Card(
           color: const Color(0xFF1E1E1E),
           child: ListTile(
@@ -286,13 +287,12 @@ class _SocialMediaSchedulerPageState extends State<SocialMediaSchedulerPage>
               ),
             ),
             title: Text(
-              post['content']?.toString() ?? '',
+              post.content,
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
             ),
             subtitle: Text(
-              '${platform?.toUpperCase() ?? '-'}  |  '
-              '${post['scheduled_at'] ?? post['published_at'] ?? post['created_at'] ?? '-'}',
+              '${post.platformsLabel}  |  $time',
               style: const TextStyle(
                 fontSize: 11,
                 height: 1.5,

--- a/test/nested_metadata_models_test.dart
+++ b/test/nested_metadata_models_test.dart
@@ -1,0 +1,303 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/affiliate_link_stats.dart';
+import 'package:my_web_app/models/auction_listing.dart';
+import 'package:my_web_app/models/budget_entry.dart';
+import 'package:my_web_app/models/donation_project.dart';
+import 'package:my_web_app/models/elearning_course.dart';
+import 'package:my_web_app/models/event_ticketing_summary.dart';
+import 'package:my_web_app/models/language_deck.dart';
+import 'package:my_web_app/models/parking_reservation_entry.dart';
+import 'package:my_web_app/models/scheduled_post_entry.dart';
+import 'package:my_web_app/models/social_feed_post.dart';
+
+/// hub_data 行 (nested metadata) を模したヘルパー。
+Map<String, dynamic> row(Map<String, dynamic> metadata, {String? createdAt}) =>
+    {
+      'id': 'row-1',
+      'created_at': createdAt ?? '2026-07-13T00:00:00Z',
+      'metadata': {'user_id': 'u1', ...metadata},
+    };
+
+void main() {
+  group('SocialFeedPost', () {
+    test('nested metadata から本文・件数を読む', () {
+      final posts = SocialFeedPost.listFromResponse({
+        'posts': [
+          row({'content': 'こんにちは', 'likes': 3, 'comments': 1}),
+        ],
+      });
+      expect(posts.single.content, 'こんにちは');
+      expect(posts.single.likes, 3);
+      expect(posts.single.comments, 1);
+    });
+
+    test('flat キー(旧形式)でも読めるが空応答は空リスト', () {
+      expect(SocialFeedPost.listFromResponse(null), isEmpty);
+      final legacy = SocialFeedPost.listFromResponse({
+        'posts': [
+          {'id': 'x', 'content': 'flat', 'likes': 9},
+        ],
+      });
+      expect(legacy.single.content, 'flat');
+      expect(legacy.single.likes, 9);
+    });
+  });
+
+  group('ScheduledPostEntry', () {
+    test('platforms 配列と予約時刻を読む', () {
+      final list = ScheduledPostEntry.listFromResponse({
+        'posts': [
+          row({
+            'content': '予約投稿',
+            'platforms': ['x', 'facebook'],
+            'scheduled_at': '2026-07-20T10:00:00Z',
+            'status': 'pending',
+          }),
+        ],
+      });
+      final p = list.single;
+      expect(p.content, '予約投稿');
+      expect(p.platforms, ['x', 'facebook']);
+      expect(p.primaryPlatform, 'x');
+      expect(p.platformsLabel, 'X / FACEBOOK');
+      expect(p.displayTime, '2026-07-20T10:00:00Z');
+    });
+
+    test('予約時刻が無ければ作成時刻を使う', () {
+      final list = ScheduledPostEntry.listFromResponse({
+        'posts': [
+          row({'content': 'x'}, createdAt: '2026-07-13T09:00:00Z'),
+        ],
+      });
+      expect(list.single.displayTime, '2026-07-13T09:00:00Z');
+      expect(list.single.platformsLabel, '-');
+    });
+  });
+
+  group('EventTicketingSummary', () {
+    test('残数は capacity - sold で算出', () {
+      final list = EventTicketingSummary.listFromResponse({
+        'events': [
+          row({
+            'title': 'ライブ',
+            'date': '2026-08-01',
+            'capacity': 100,
+            'sold': 30,
+          }),
+        ],
+      });
+      expect(list.single.title, 'ライブ');
+      expect(list.single.remaining, 70);
+      expect(list.single.remainingLabel, '残 70枚');
+    });
+
+    test('定員未設定は 0 枚と偽らず null を返す', () {
+      final list = EventTicketingSummary.listFromResponse({
+        'events': [
+          row({'title': '未定', 'sold': 5}),
+        ],
+      });
+      expect(list.single.remaining, isNull);
+      expect(list.single.remainingLabel, '定員未設定');
+    });
+
+    test('売り切れは 0 枚 (負にならない)', () {
+      final list = EventTicketingSummary.listFromResponse({
+        'events': [
+          row({'title': '完売', 'capacity': 10, 'sold': 15}),
+        ],
+      });
+      expect(list.single.remaining, 0);
+    });
+  });
+
+  group('AuctionListing', () {
+    test('current_bid を優先し ends_at を読む', () {
+      final list = AuctionListing.listFromResponse({
+        'auctions': [
+          row({
+            'title': '骨董品',
+            'current_bid': 5000,
+            'start_price': 1000,
+            'ends_at': '2026-08-01T00:00:00Z',
+          }),
+        ],
+      });
+      expect(list.single.title, '骨董品');
+      expect(list.single.displayPrice, 5000);
+      expect(list.single.endsAt, '2026-08-01T00:00:00Z');
+    });
+
+    test('入札なしは開始価格にフォールバック', () {
+      final list = AuctionListing.listFromResponse({
+        'auctions': [
+          row({'title': '新規', 'start_price': 800}),
+        ],
+      });
+      expect(list.single.displayPrice, 800);
+    });
+  });
+
+  group('AffiliateLinkStats', () {
+    test('clicks/conversions/commission を読み summary を算出', () {
+      final links = AffiliateLinkStats.listFromResponse({
+        'links': [
+          row({'title': 'A', 'code': 'aa', 'clicks': 10, 'conversions': 2}),
+          row({'title': 'B', 'code': 'bb', 'clicks': 5, 'conversions': 1}),
+        ],
+      });
+      expect(links.first.title, 'A');
+      expect(links.first.clicks, 10);
+      final summary = AffiliateSummary.fromLinks(links);
+      expect(summary.totalClicks, 15);
+      expect(summary.totalConversions, 3);
+      expect(summary.linkCount, 2);
+    });
+  });
+
+  group('DonationProject', () {
+    test('goal/raised を読み progress をクランプ', () {
+      final list = DonationProject.listFromResponse({
+        'projects': [
+          row({
+            'title': '支援',
+            'description': '説明',
+            'goal_amount': 10000,
+            'raised_amount': 2500,
+          }),
+        ],
+      });
+      expect(list.single.title, '支援');
+      expect(list.single.progress, 0.25);
+    });
+
+    test('目標超過でも progress は 1.0 上限', () {
+      final list = DonationProject.listFromResponse({
+        'projects': [
+          row({'title': 'x', 'goal_amount': 100, 'raised_amount': 500}),
+        ],
+      });
+      expect(list.single.progress, 1.0);
+    });
+  });
+
+  group('ParkingReservationEntry', () {
+    test('spot/lot/fee を読む', () {
+      final list = ParkingReservationEntry.listFromResponse({
+        'reservations': [
+          row({
+            'lot_id': 'L1',
+            'spot': 'A-3',
+            'start_time': '2026-07-13T10:00:00Z',
+            'fee': 500,
+          }),
+        ],
+      });
+      expect(list.single.spotLabel, 'A-3 (L1)');
+      expect(list.single.fee, 500);
+    });
+
+    test('fee 未設定は null (¥0 と偽らない)', () {
+      final list = ParkingReservationEntry.listFromResponse({
+        'reservations': [
+          row({'spot': 'B-1'}),
+        ],
+      });
+      expect(list.single.fee, isNull);
+      expect(list.single.spotLabel, 'B-1');
+    });
+  });
+
+  group('ELearningCourse', () {
+    test('コースに progress を join し受講中のみ抽出', () {
+      final courses = ELearningCourse.listFromResponse({
+        'courses': [
+          {
+            'id': 'c1',
+            'metadata': {'title': '入門', 'level': 'beginner'},
+          },
+          {
+            'id': 'c2',
+            'metadata': {'title': '応用', 'level': 'advanced'},
+          },
+        ],
+      });
+      final progress = ELearningCourse.progressByCourseId({
+        'enrollments': [
+          row({'course_id': 'c1', 'progress': 40}),
+        ],
+      });
+      final inProgress = ELearningCourse.inProgress(courses, progress);
+      expect(inProgress.single.id, 'c1');
+      expect(inProgress.single.progress, 40);
+      expect(inProgress.single.title, '入門');
+    });
+  });
+
+  group('LanguageDeck / Flashcard', () {
+    test('deck は id/name を読む (deck_id ではない)', () {
+      final decks = LanguageDeck.listFromResponse({
+        'decks': [
+          {
+            'id': 'd1',
+            'metadata': {'name': '英単語', 'language': 'en'},
+          },
+        ],
+      });
+      expect(decks.single.id, 'd1');
+      expect(decks.single.name, '英単語');
+    });
+
+    test('card は front/back を読み review_session の cards キーも読む', () {
+      final cards = Flashcard.listFromResponse({
+        'cards': [
+          {
+            'id': 'f1',
+            'metadata': {'front': 'apple', 'back': 'りんご'},
+          },
+        ],
+      });
+      expect(cards.single.front, 'apple');
+      expect(cards.single.back, 'りんご');
+    });
+
+    test('stats は streak_days/total_cards を top-level から読む', () {
+      final stats = LanguageStats.fromResponses(
+        {'success': true, 'streak_days': 7},
+        {'success': true, 'total_cards': 42},
+      );
+      expect(stats.streakDays, 7);
+      expect(stats.totalCards, 42);
+    });
+  });
+
+  group('BudgetEntry', () {
+    test('category/amount を nested metadata から読みカテゴリ集計', () {
+      final expenses = BudgetEntry.listFromResponse(
+        {
+          'expenses': [
+            row({'category': 'food', 'amount': 1200}),
+            row({'category': 'food', 'amount': 800}),
+            row({'category': 'housing', 'amount': 50000}),
+          ],
+        },
+        'expenses',
+      );
+      expect(BudgetEntry.sumForCategory(expenses, 'food'), 2000);
+      expect(BudgetEntry.total(expenses), 52000);
+    });
+
+    test('income は source を category として扱う (income キー)', () {
+      final incomes = BudgetEntry.listFromResponse(
+        {
+          'income': [
+            row({'source': 'salary', 'amount': 300000}),
+          ],
+        },
+        'income',
+      );
+      expect(incomes.single.category, 'salary');
+      expect(incomes.single.amount, 300000);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`social-commerce-hub` / `lifestyle-hub` は hub_data 行を `{id, created_at, metadata:{...}}` で返すが、UI が flat キー `row['field']` を読んでいたため全行が捏造フォールバック値になる contract バグ。loyalty ([#3948](https://github.com/kanta13jp1/my_web_app/pull/3948)) / wallet+gift ([#3969](https://github.com/kanta13jp1/my_web_app/pull/3969)) / feedback+inventory ([#4014](https://github.com/kanta13jp1/my_web_app/pull/4014)) と同型で、棚卸し済みの**残 10 ページ**を純データモデル抽出パターンで一括修正した。

### 修正内容 (1 ページ = 1 純モデル + 回帰テスト)

| ページ | 主なバグ | 修正 |
|---|---|---|
| social_feed | 本文全空・likes/comments 消失 | `metadata.content/likes/comments`。作者は EF 非保存のため「自分の投稿」表記に |
| scheduler | 見出し空・予約時刻が作成時刻に化ける | `metadata.content` + `platforms` 配列 + `scheduled_at` |
| event_ticketing | **全イベント「残 0 枚」** | 残数を `capacity - sold` 算出。定員未設定は「定員未設定」(0枚と偽らない) |
| auction | 名称捏造・価格/終了時刻が全非表示 | 誤キー `current_price`/`end_at` → `metadata.current_bid`/`ends_at` |
| affiliate | 全カード「クリック0/報酬¥0」 | `metadata.clicks/conversions/commission_pct`。summary は EF 非返却→リストから算出。捏造 ¥0 は撤去 |
| donation (lifestyle) | 全「タイトル不明 / ¥0」 | `metadata.title/goal_amount/raised_amount` |
| parking (lifestyle) | 全「スポットN / 予約済み」 | `metadata.spot/lot_id/start_time/fee`。fee 未設定は null |
| elearning | 名称捏造・学習中タブ常時空 | `metadata.title/level/language` + `course.progress` の `enrollments` を course に join。enroll の `courseId`→`course_id` 誤キーも修正 |
| language | デッキ名/カード表裏空・streak/stats 常時空 | `deck.id`(旧`deck_id`)/`deck.name`, `card.front/back`, `review_session` の `cards` キー(旧`dueCards`), `streak_days`/`total_cards` を top-level 読み。`add_card` の `deck` キー / `review_card` の `id` キー修正 |
| budget | 支出常時空・予算常時0 | 無効 action `'get'`→`budget.expense_list`, 収入は `budget.income_list` の `income` キー(旧 `budget.expense_list`+`incomes`), category/amount を metadata 読み |

### 共通基盤

- `lib/models/hub_data_parsing.dart` — nested `metadata` 優先読みヘルパー (flat キーは後方互換フォールバック)
- 純モデル 10 個を新規追加、各ページは fetch→モデル→描画に差し替え

### Tests

- `test/nested_metadata_models_test.dart` — **20 VM 単体テスト緑** (残数算出/progress クランプ/income キー/フォールバック等)
- `flutter analyze` 対象 21 ファイル (10 ページ + 10 モデル + テスト) **issue 0**
- `dart format` 適用済み

これで棚卸しした 13 消費ページ (loyalty/wallet/gift/feedback/inventory + 本 PR 8) は全て nested-metadata 契約に整合。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Dart-only UI parsing fix (nested-metadata read models); no auth or security logic changed, covered by 20 VM unit tests

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Pure model extraction + widget wiring; covered by 20 VM unit tests (test/nested_metadata_models_test.dart) asserting user-visible parsing output; auth-gated pages need real user data for full E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)

