### PR TITLE
sec(schedule-hub): billing return_url を host allowlist で検証 — open-redirect 遮断

### DIFF
--- a/supabase/functions/schedule-hub/billing_return_url.ts
+++ b/supabase/functions/schedule-hub/billing_return_url.ts
@@ -1,0 +1,58 @@
+// billing return URL の解決 (純ロジック / Deno API 非依存 → unit testable)
+//
+// Stripe checkout の success_url / cancel_url に使う return URL を検証する。
+// billing.create_supporter_checkout_session は非ログイン公開 action のため、
+// `body.return_url` を無検証で Stripe に渡すと **open-redirect** になる
+// (攻撃者が checkout 後に任意の外部フィッシングサイトへ誘導可能)。
+// host を allowlist で照合し、許可外・不正なら deployment fallback に落とす。
+
+/// return URL の host が allowlist に含まれるか (大文字小文字無視・完全一致)。
+export function isBillingHostAllowed(
+  hostname: string,
+  allowedHosts: readonly string[],
+): boolean {
+  const host = hostname.toLowerCase();
+  return allowedHosts.some((h) => h.toLowerCase() === host);
+}
+
+/// deployment base URL の host + localhost + 追加許可 host から allowlist を作る。
+export function billingAllowedHosts(
+  base: string,
+  extraHosts: readonly string[] = [],
+): string[] {
+  const hosts = new Set<string>(["localhost", "127.0.0.1"]);
+  try {
+    hosts.add(new URL(base).hostname.toLowerCase());
+  } catch {
+    // base が不正 URL でも localhost 群は残す。
+  }
+  for (const h of extraHosts) {
+    const trimmed = h.trim().toLowerCase();
+    if (trimmed) hosts.add(trimmed);
+  }
+  return [...hosts];
+}
+
+/// return URL を解決する。
+/// - http/https かつ host が allowlist 内 → そのまま返す (path/query 温存)。
+/// - それ以外 (別 host / javascript: 等の別 protocol / パース不能 / 空) →
+///   base + fallbackPath に落とす。
+export function resolveBillingReturnUrl(
+  value: unknown,
+  fallbackPath: string,
+  opts: { base: string; allowedHosts: readonly string[] },
+): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (raw) {
+    try {
+      const url = new URL(raw);
+      const protocolOk = url.protocol === "https:" || url.protocol === "http:";
+      if (protocolOk && isBillingHostAllowed(url.hostname, opts.allowedHosts)) {
+        return url.toString();
+      }
+    } catch {
+      // Fall through to the deployment fallback.
+    }
+  }
+  return new URL(fallbackPath, opts.base).toString();
+}

--- a/supabase/functions/schedule-hub/billing_return_url_test.ts
+++ b/supabase/functions/schedule-hub/billing_return_url_test.ts
@@ -1,0 +1,86 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  billingAllowedHosts,
+  isBillingHostAllowed,
+  resolveBillingReturnUrl,
+} from "./billing_return_url.ts";
+
+const BASE = "https://my-web-app-b67f4.web.app";
+const HOSTS = billingAllowedHosts(BASE);
+
+Deno.test("allowlist は base host + localhost 群を含む", () => {
+  assertEquals(HOSTS.includes("my-web-app-b67f4.web.app"), true);
+  assertEquals(HOSTS.includes("localhost"), true);
+  assertEquals(HOSTS.includes("127.0.0.1"), true);
+});
+
+Deno.test("追加許可 host は env csv から取り込む (空白・空要素は無視)", () => {
+  const hosts = billingAllowedHosts(BASE, [" staging.example.com ", "", "  "]);
+  assertEquals(hosts.includes("staging.example.com"), true);
+});
+
+Deno.test("host 照合は大文字小文字を無視した完全一致", () => {
+  assertEquals(isBillingHostAllowed("My-Web-App-B67F4.Web.App", HOSTS), true);
+  assertEquals(isBillingHostAllowed("evil.example.com", HOSTS), false);
+  // 部分一致・サブドメイン偽装は許可しない。
+  assertEquals(
+    isBillingHostAllowed("my-web-app-b67f4.web.app.evil.com", HOSTS),
+    false,
+  );
+});
+
+Deno.test("許可 host の return_url は path/query 温存でそのまま通す", () => {
+  const url = resolveBillingReturnUrl(
+    "https://my-web-app-b67f4.web.app/subscription-billing?ref=x",
+    "/subscription-billing",
+    { base: BASE, allowedHosts: HOSTS },
+  );
+  assertEquals(
+    url,
+    "https://my-web-app-b67f4.web.app/subscription-billing?ref=x",
+  );
+});
+
+Deno.test("localhost の return_url も許可 (dev)", () => {
+  const url = resolveBillingReturnUrl(
+    "http://localhost:3000/subscription-billing",
+    "/subscription-billing",
+    { base: BASE, allowedHosts: HOSTS },
+  );
+  assertEquals(url, "http://localhost:3000/subscription-billing");
+});
+
+Deno.test("許可外 host は deployment fallback に落とす (open-redirect 遮断)", () => {
+  const url = resolveBillingReturnUrl(
+    "https://evil.example.com/phish",
+    "/subscription-billing",
+    { base: BASE, allowedHosts: HOSTS },
+  );
+  assertEquals(url, "https://my-web-app-b67f4.web.app/subscription-billing");
+});
+
+Deno.test("javascript: など http/https 以外の protocol は fallback", () => {
+  const url = resolveBillingReturnUrl(
+    "javascript:alert(1)",
+    "/subscription-billing",
+    { base: BASE, allowedHosts: HOSTS },
+  );
+  assertEquals(url, "https://my-web-app-b67f4.web.app/subscription-billing");
+});
+
+Deno.test("空文字・null・パース不能は fallback", () => {
+  const opts = { base: BASE, allowedHosts: HOSTS };
+  const expected = "https://my-web-app-b67f4.web.app/subscription-billing";
+  assertEquals(
+    resolveBillingReturnUrl("", "/subscription-billing", opts),
+    expected,
+  );
+  assertEquals(
+    resolveBillingReturnUrl(null, "/subscription-billing", opts),
+    expected,
+  );
+  assertEquals(
+    resolveBillingReturnUrl("not a url", "/subscription-billing", opts),
+    expected,
+  );
+});

--- a/supabase/functions/schedule-hub/index.ts
+++ b/supabase/functions/schedule-hub/index.ts
@@ -32,6 +32,10 @@ import {
   summarizePlatformFailures,
 } from "./upstream_error.ts";
 import { requiredAuthLevel } from "./action_auth.ts";
+import {
+  billingAllowedHosts,
+  resolveBillingReturnUrl,
+} from "./billing_return_url.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -256,21 +260,16 @@ function currentBillingPeriodStart(): string {
 }
 
 function billingReturnUrl(value: unknown, fallbackPath: string): string {
-  const raw = asString(value);
-  if (raw) {
-    try {
-      const url = new URL(raw);
-      if (url.protocol === "http:" || url.protocol === "https:") {
-        return url.toString();
-      }
-    } catch {
-      // Fall through to the deployment fallback.
-    }
-  }
   const base = (Deno.env.get("PUBLIC_SITE_URL") ??
     Deno.env.get("SITE_URL") ??
     "https://my-web-app-b67f4.web.app").trim();
-  return new URL(fallbackPath, base).toString();
+  // open-redirect 対策: return_url は host allowlist で検証する。
+  // billing.create_supporter_checkout_session は非ログイン公開 action のため、
+  // 無検証だと攻撃者が checkout 後に任意の外部サイトへ誘導できる。
+  const extraHosts = (Deno.env.get("BILLING_RETURN_URL_ALLOWED_HOSTS") ?? "")
+    .split(",");
+  const allowedHosts = billingAllowedHosts(base, extraHosts);
+  return resolveBillingReturnUrl(value, fallbackPath, { base, allowedHosts });
 }
 
 function withBillingParam(url: string, value: string): string {


### PR DESCRIPTION
## Summary

part334 の schedule-hub 監査で確認した残課題。`billingReturnUrl` が `body.return_url` の任意 http/https URL を**無検証で** Stripe checkout の `success_url` / `cancel_url` に渡していた。`billing.create_supporter_checkout_session` は非ログイン公開 action ([PR #3992](https://github.com/kanta13jp1/my_web_app/pull/3992) で public 据え置き) のため、攻撃者が `return_url=https://evil.example/phish` を指定すると checkout 完了後にユーザーを外部フィッシングサイトへ誘導できる **open-redirect** だった。

### 変更内容

- 純ロジック `billing_return_url.ts` を新設 (Deno API 非依存 → unit testable):
  - `resolveBillingReturnUrl`: host allowlist で照合し、許可外 host / `http(s)` 以外の protocol (`javascript:` 等) / パース不能 / 空 は **deployment fallback** に落とす。許可 host は path/query 温存でそのまま通す。
  - allowlist = deployment base host (`PUBLIC_SITE_URL`/`SITE_URL`/`my-web-app-b67f4.web.app`) + `localhost` + `127.0.0.1` + env `BILLING_RETURN_URL_ALLOWED_HOSTS` (csv)。
  - host 照合は**大文字小文字無視の完全一致** — サブドメイン偽装 `my-web-app-b67f4.web.app.evil.com` を弾く。
- `billingReturnUrl` を `resolveBillingReturnUrl` 経由に置換。3 呼び出し元 (`billing.create_checkout_session` / `create_supporter_checkout_session` / `create_portal_session`) すべてが経由。

### Tests

- `deno test billing_return_url_test.ts` → **8 passed / 0 failed** (許可通過 / localhost / 許可外遮断 / サブドメイン偽装遮断 / `javascript:` 遮断 / 空・null・不正 fallback)
- `deno check schedule-hub/index.ts` 緑 / `deno fmt` / `deno lint` 緑

### 本番検証プラン (マージ後 deploy-prod 自動デプロイ後)

- anon key で `billing.create_supporter_checkout_session` + `return_url=https://evil.example/x` → 返る `checkout_url` の success/cancel が evil ではなく `my-web-app-b67f4.web.app` に落ちること (Stripe セッション metadata 経由で確認)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Adds host-allowlist validation to billing return_url resolver (open-redirect fix); pure logic + 8 deno unit tests, no new write or credential path

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno Edge Function security hardening (return_url host allowlist); covered by 8 deno unit tests (billing_return_url_test.ts) + deno check; production curl verification after deploy; no Flutter runtime surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
