### PR TITLE
feat(x-share): R28 party gap ranking series — second horizontal expansion of the data-report playbook

### DIFF
--- a/docs/X_TRACKER_SERIES_PLAYBOOK.md
+++ b/docs/X_TRACKER_SERIES_PLAYBOOK.md
@@ -33,6 +33,7 @@
 | 家計トラッカー | `household_tracker` | 資産管理ページ ([#3968](https://github.com/kanta13jp1/my_web_app/pull/3968)) | 週次トグル | スコアボード投稿(円金額禁止=件数/日数/方向のみ) |
 | デイリーブリーフィング | `daily_briefing_v2_*` | `x-daily-briefing-post.yml` (日次 22:00 UTC) | 日次 | 候補作成→publish op |
 | AIツール定点観測 | `ai_tool_tracker` | `x-ai-tool-tracker-queue.yml` (日次 21:45 UTC / R27) | 更新検知日のみ | 候補キュー(HITL) |
+| 選挙: 両党地力差 | `party_gap_ranking` | `local-election-snapshot-queue.yml` 内 (ISO週キー冪等 / R28) | 週次(日次cronから週1生成) | 候補キュー(HITL) |
 
 ラベルの表示用対応は `lib/pages/admin_x_candidate_queue.dart` の
 `kXTrackerSeriesLabels`(系列追加時にここも更新)。

--- a/lib/pages/admin_x_candidate_queue.dart
+++ b/lib/pages/admin_x_candidate_queue.dart
@@ -24,6 +24,7 @@ const Map<String, String> kXTrackerSeriesLabels = <String, String>{
   'weekly_data_report': 'X運用実測',
   'household_tracker': '家計トラッカー',
   'ai_tool_tracker': 'AIツール定点観測',
+  'party_gap_ranking': '選挙: 両党地力差',
 };
 
 /// variant から系列ラベルを解決する。daily_briefing 系はバリアント名が

--- a/supabase/functions/local-election-intelligence/index.ts
+++ b/supabase/functions/local-election-intelligence/index.ts
@@ -12,6 +12,7 @@ import {
   type ScheduleSourceFetchHealth,
   X_POST_CANDIDATE_HUB_SOURCE,
 } from "./snapshot_history.ts";
+import { normalizeCdpBenchmark } from "./party_gap_ranking.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -33,6 +34,9 @@ const OFFICIAL_2023_SECOND_HALF_URL =
 const ELECTION_SCHEDULE_URL = "https://go2senkyo.com/schedule";
 const CDP_LOCAL_AUTHORITIES_URL =
   "https://cdp-japan.jp/members/house/local_authorities";
+// R28: 立憲実数の repo asset(週次 update_cdp_benchmark.mjs が正本)。
+const CDP_BENCHMARK_ASSET_URL =
+  "https://raw.githubusercontent.com/kanta13jp1/my_web_app/main/assets/data/cdp_local_members.json";
 const NEW_KOKUMIN_ELECTIONS_URL =
   "https://local-elections.new-kokumin.jp/electionslist/";
 const NEXT_UNIFIED_LOCAL_ELECTION_INFO_URL =
@@ -760,10 +764,28 @@ serve(async (req) => {
         }`,
       );
     }
+    // R28: 立憲実数(週次 update_cdp_benchmark.mjs が正本の repo asset)を
+    // EF 側で取得して地力差系列へ渡す。この EF の snapshot は cdpLocalMembers
+    // を 0 ハードコードするため、これが本番で唯一の立憲実数源(レビュー F1:
+    // これ無しでは系列が一度も候補を生成しない)。取得失敗は null → composer
+    // 側の cdpTotal ゲートで自然に見送り(その週の候補を作らないだけで、
+    // snapshot 永続化と delta 系列には影響しない)。
+    let cdpByPrefecture: Record<string, number> | null = null;
+    if (parsedRequest.action === "snapshotAndQueue") {
+      try {
+        cdpByPrefecture = normalizeCdpBenchmark(
+          JSON.parse(await fetchText(CDP_BENCHMARK_ASSET_URL)),
+        );
+      } catch (_error) {
+        cdpByPrefecture = null;
+      }
+    }
     const persistence = parsedRequest.action === "snapshotAndQueue"
       ? await persistLocalElectionSnapshot(
         createLocalElectionHubStore(),
         snapshot,
+        new Date().toISOString(),
+        { cdpByPrefecture },
       )
       : null;
 

--- a/supabase/functions/local-election-intelligence/party_gap_ranking.ts
+++ b/supabase/functions/local-election-intelligence/party_gap_ranking.ts
@@ -21,6 +21,49 @@ const MIN_PREFECTURES = 40;
 const EVEN_GAP_THRESHOLD = 2;
 const TOP_LINES = 5;
 
+/// assets/data/cdp_local_members.json (週次 update_cdp_benchmark.mjs が正本)
+/// を EF 側で使える形へ正規化する。snapshot の cdpLocalMembers は EF では
+/// 常に 0 ハードコード(index.ts のコメント参照)のため、この asset が本番で
+/// 唯一の立憲実数源(レビュー F1: これ無しでは系列が一度も生成されない)。
+/// 形式: { prefectures: { "北海道": 57, "青森": 25, ... } } — キーは
+/// 都府県サフィックス無し(北海道のみ「道」付き)。
+export function normalizeCdpBenchmark(
+  raw: unknown,
+): Record<string, number> | null {
+  const record = raw as JsonRecord | null;
+  const prefectures = record && typeof record === "object"
+    ? (record as JsonRecord).prefectures
+    : null;
+  if (
+    typeof prefectures !== "object" || prefectures === null ||
+    Array.isArray(prefectures)
+  ) {
+    return null;
+  }
+  const result: Record<string, number> = {};
+  for (const [name, value] of Object.entries(prefectures as JsonRecord)) {
+    const count = typeof value === "number" && Number.isFinite(value)
+      ? Math.max(0, Math.trunc(value))
+      : null;
+    if (name.trim() === "" || count === null) continue;
+    result[name.trim()] = count;
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+/// snapshot の県名(東京都/京都府/香川県)を asset キー(東京/京都/香川)へ
+/// 名寄せする。北海道は「道」がクラス外なのでそのまま一致する。
+function cdpBenchmarkFor(
+  cdpByPrefecture: Record<string, number>,
+  prefectureName: string,
+): number | null {
+  const direct = cdpByPrefecture[prefectureName];
+  if (typeof direct === "number") return direct;
+  const stripped = prefectureName.replace(/[都府県]$/, "");
+  const bySuffix = cdpByPrefecture[stripped];
+  return typeof bySuffix === "number" ? bySuffix : null;
+}
+
 /// ISO 週キー (例: 2026-W28)。週次冪等の candidate_key に使う。
 export function isoWeekKey(observedAtIso: string): string | null {
   const parsed = Date.parse(observedAtIso);
@@ -75,6 +118,10 @@ export function buildPartyGapCandidateMetadata(
     datasetSource: string;
     dataset: string;
     targetUrl?: string;
+    /// EF 側の立憲実数源(normalizeCdpBenchmark の結果)。未指定/null 時は
+    /// snapshot の cdpLocalMembers へフォールバックする(EF snapshot では
+    /// 常に 0 のため cdpTotal ゲートで自然に見送りになる)。
+    cdpByPrefecture?: Record<string, number> | null;
   },
 ): JsonRecord | null {
   const prefectures: CanonicalPrefecture[] = snapshot.prefectures ?? [];
@@ -83,12 +130,18 @@ export function buildPartyGapCandidateMetadata(
   const dayLabel = jstDateLabel(options.observedAt);
   if (weekKey === null || dayLabel === null) return null;
 
-  const rows: GapRow[] = prefectures.map((prefecture) => ({
-    prefecture: prefecture.prefecture,
-    kokumin: prefecture.currentMembers,
-    cdp: prefecture.cdpLocalMembers,
-    gap: prefecture.currentMembers - prefecture.cdpLocalMembers,
-  }));
+  const cdpByPrefecture = options.cdpByPrefecture ?? null;
+  const rows: GapRow[] = prefectures.map((prefecture) => {
+    const cdp = cdpByPrefecture !== null
+      ? cdpBenchmarkFor(cdpByPrefecture, prefecture.prefecture) ?? 0
+      : prefecture.cdpLocalMembers;
+    return {
+      prefecture: prefecture.prefecture,
+      kokumin: prefecture.currentMembers,
+      cdp,
+      gap: prefecture.currentMembers - cdp,
+    };
+  });
   const cdpTotal = rows.reduce((sum, row) => sum + row.cdp, 0);
   // 立憲参考が全県 0 = 参考データ未同期の日。比較レポートとして成立しない
   // ので候補を作らない(0 との比較は「実測」を名乗れない)。
@@ -99,9 +152,14 @@ export function buildPartyGapCandidateMetadata(
   const cdpLead = rows.filter((row) => row.gap < -EVEN_GAP_THRESHOLD);
   const even = rows.length - kokuminLead.length - cdpLead.length;
   const byGapDesc = [...rows].sort((left, right) => right.gap - left.gap);
-  const topKokumin = byGapDesc.slice(0, TOP_LINES).filter((row) => row.gap > 0);
+  // 「リード上位」の掲載条件はサマリ行のリード定義(|gap| > EVEN_GAP_THRESHOLD)
+  // と同一にする。gap>0 で拾うとサマリ「リード0県」の直後に互角圏(+1/+2)の
+  // 県が「リード上位」として並ぶ自己矛盾レポートになる(レビュー F2)。
+  const topKokumin = byGapDesc.slice(0, TOP_LINES).filter((row) =>
+    row.gap > EVEN_GAP_THRESHOLD
+  );
   const topCdp = [...byGapDesc].reverse().slice(0, TOP_LINES).filter((row) =>
-    row.gap < 0
+    row.gap < -EVEN_GAP_THRESHOLD
   );
 
   const lead = [

--- a/supabase/functions/local-election-intelligence/party_gap_ranking.ts
+++ b/supabase/functions/local-election-intelligence/party_gap_ranking.ts
@@ -1,0 +1,216 @@
+// R28: 国民民主×立憲 都道府県地力差ランキング系列
+// (docs/X_TRACKER_SERIES_PLAYBOOK.md step 2 / 水平展開第2号)。
+// データ資産 = 日次 snapshot に既に揃っている両党の県別実数
+// (currentMembers = 国民民主公式 / cdpLocalMembers = 立憲参考)。追加
+// スクレイピング不要で、政治クラスタの別角度(比較・ギャップ枠)を取る。
+//
+// LLM 不使用の決定的合成のみ。candidate_key は ISO 週キー=日次 cron から
+// 呼ばれても週1回だけ候補が作られる(insertPostCandidate の冪等性)。
+// 立憲参考データ未同期(全県0)や県数欠損の日は null(候補を作らない)。
+
+import { buildXPostCandidateMetadata } from "../growth-hub/x_post_candidate.ts";
+import type {
+  CanonicalLocalElectionSnapshot,
+  CanonicalPrefecture,
+} from "./snapshot_history.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+export const PARTY_GAP_VARIANT = "party_gap_ranking";
+const MIN_PREFECTURES = 40;
+const EVEN_GAP_THRESHOLD = 2;
+const TOP_LINES = 5;
+
+/// ISO 週キー (例: 2026-W28)。週次冪等の candidate_key に使う。
+export function isoWeekKey(observedAtIso: string): string | null {
+  const parsed = Date.parse(observedAtIso);
+  if (!Number.isFinite(parsed)) return null;
+  // ISO 8601: 週の起点は月曜、第1週はその年の最初の木曜を含む週。
+  const date = new Date(parsed);
+  const target = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  const dayOfWeek = target.getUTCDay() || 7;
+  target.setUTCDate(target.getUTCDate() + 4 - dayOfWeek);
+  const isoYear = target.getUTCFullYear();
+  const yearStart = Date.UTC(isoYear, 0, 1);
+  const week = Math.ceil(
+    ((target.getTime() - yearStart) / 86400000 + 1) / 7,
+  );
+  return `${isoYear}-W${String(week).padStart(2, "0")}`;
+}
+
+function jstDateLabel(iso: string): string | null {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return null;
+  const jst = new Date(parsed + 9 * 60 * 60 * 1000);
+  return `${jst.getUTCFullYear()}/${jst.getUTCMonth() + 1}/${jst.getUTCDate()}`;
+}
+
+function signed(value: number): string {
+  return value > 0 ? `+${value}` : `${value}`;
+}
+
+type GapRow = {
+  prefecture: string;
+  kokumin: number;
+  cdp: number;
+  gap: number;
+};
+
+function gapLine(row: GapRow): string {
+  return `${row.prefecture} ${signed(row.gap)}（${row.kokumin} vs ${row.cdp}）`;
+}
+
+/// 週次の地力差ランキング候補メタデータを合成する。生成不能条件は null:
+/// 県数 < MIN_PREFECTURES(取得欠損)/ 立憲参考が全県 0(plan 未同期)/
+/// observedAt 不正。
+export function buildPartyGapCandidateMetadata(
+  snapshot: CanonicalLocalElectionSnapshot,
+  options: {
+    snapshotObservationId: string;
+    snapshotHash: string;
+    datasetVersion: string;
+    observedAt: string;
+    datasetSource: string;
+    dataset: string;
+    targetUrl?: string;
+  },
+): JsonRecord | null {
+  const prefectures: CanonicalPrefecture[] = snapshot.prefectures ?? [];
+  if (prefectures.length < MIN_PREFECTURES) return null;
+  const weekKey = isoWeekKey(options.observedAt);
+  const dayLabel = jstDateLabel(options.observedAt);
+  if (weekKey === null || dayLabel === null) return null;
+
+  const rows: GapRow[] = prefectures.map((prefecture) => ({
+    prefecture: prefecture.prefecture,
+    kokumin: prefecture.currentMembers,
+    cdp: prefecture.cdpLocalMembers,
+    gap: prefecture.currentMembers - prefecture.cdpLocalMembers,
+  }));
+  const cdpTotal = rows.reduce((sum, row) => sum + row.cdp, 0);
+  // 立憲参考が全県 0 = 参考データ未同期の日。比較レポートとして成立しない
+  // ので候補を作らない(0 との比較は「実測」を名乗れない)。
+  if (cdpTotal === 0) return null;
+  const kokuminTotal = rows.reduce((sum, row) => sum + row.kokumin, 0);
+
+  const kokuminLead = rows.filter((row) => row.gap > EVEN_GAP_THRESHOLD);
+  const cdpLead = rows.filter((row) => row.gap < -EVEN_GAP_THRESHOLD);
+  const even = rows.length - kokuminLead.length - cdpLead.length;
+  const byGapDesc = [...rows].sort((left, right) => right.gap - left.gap);
+  const topKokumin = byGapDesc.slice(0, TOP_LINES).filter((row) => row.gap > 0);
+  const topCdp = [...byGapDesc].reverse().slice(0, TOP_LINES).filter((row) =>
+    row.gap < 0
+  );
+
+  const lead = [
+    `国民民主党×立憲民主党 地方議員 地力差 ${dayLabel}`,
+    "",
+    `取得日時: ${options.observedAt}`,
+    `国民民主 公式地方議員数: ${kokuminTotal}人`,
+    `立憲民主 参考合計: ${cdpTotal}人`,
+    `両党差分: ${signed(kokuminTotal - cdpTotal)}人`,
+    `国民民主リード(差+${
+      EVEN_GAP_THRESHOLD + 1
+    }人以上): ${kokuminLead.length}県`,
+    `立憲民主リード(差-${EVEN_GAP_THRESHOLD + 1}人以上): ${cdpLead.length}県`,
+    `互角(±${EVEN_GAP_THRESHOLD}人): ${even}県`,
+    "",
+    "国民民主リード上位",
+    ...(topKokumin.length > 0 ? topKokumin.map(gapLine) : ["(リード県なし)"]),
+    "",
+    "開拓余地(立憲民主リード上位)",
+    ...(topCdp.length > 0 ? topCdp.map(gapLine) : ["(該当なし)"]),
+    "",
+    "数字は両党公式サイト掲載の現職一覧から自動集計した実測値です(立憲民主は参考値)。",
+  ].join("\n");
+
+  const replies: string[] = [];
+  // 全47都道府県の内訳(ポストAの名簿相当=検索面)。
+  replies.push(
+    [
+      "全都道府県の地力差(国民民主 vs 立憲民主参考)",
+      "",
+      ...byGapDesc.map(gapLine),
+    ].join("\n"),
+  );
+  // アラート(実測から機械的に導出できるものだけ)。
+  const alerts: string[] = [];
+  const missingKokumin = rows.filter((row) => row.kokumin === 0);
+  if (missingKokumin.length > 0) {
+    alerts.push(
+      `🔴 国民民主 議員不在 ${missingKokumin.length}県: ${
+        missingKokumin.map((row) => row.prefecture).join("、")
+      }`,
+    );
+  }
+  const missingCdp = rows.filter((row) => row.cdp === 0);
+  if (missingCdp.length > 0) {
+    alerts.push(
+      `🟡 立憲民主 参考データ0の県: ${missingCdp.length}県(参考値の欠落を含む可能性)`,
+    );
+  }
+  replies.push(
+    [
+      "アラート",
+      "",
+      ...(alerts.length > 0 ? alerts : ["今週のアラートなし"]),
+    ].join("\n"),
+  );
+  const targetUrl = options.targetUrl ??
+    "https://my-web-app-b67f4.web.app/election-victory?utm_source=x&utm_medium=data_report&utm_campaign=first_user_growth&utm_content=party_gap_ranking";
+  replies.push(
+    [
+      "この地力差レポートは毎週、両党公式サイトの自動巡回データから生成しています。",
+      "全都道府県の内訳と現職名簿はダッシュボードで公開中です。",
+      targetUrl,
+    ].join("\n"),
+  );
+
+  const sourceUrls = Array.from(
+    new Set(
+      (snapshot.sources ?? [])
+        .map((source) => source.url)
+        .filter((url) => typeof url === "string" && url !== ""),
+    ),
+  ).slice(0, 10);
+
+  const common = buildXPostCandidateMetadata({
+    action: "x.post",
+    text: lead,
+    replyTexts: replies,
+    source: options.datasetSource,
+    route: "local-election-intelligence.partyGapRanking",
+    variant: PARTY_GAP_VARIANT,
+    contentKind: "party_gap_ranking",
+    contentArchetype: "data_report",
+    linkInReply: true,
+    ownerUserId: "service_role",
+  }, {
+    candidateKey: `local-election:party-gap:${weekKey}`,
+    candidateType: "party_gap_ranking",
+    sourceKind: "local_election_snapshot",
+    sourceUrls,
+    createdBy: options.datasetSource,
+    now: new Date(options.observedAt),
+  });
+  return {
+    ...common,
+    dataset: options.dataset,
+    dataset_source: options.datasetSource,
+    dataset_version: options.datasetVersion,
+    snapshot_observation_id: options.snapshotObservationId,
+    dataset_snapshot_hash: options.snapshotHash,
+    observed_at: options.observedAt,
+    requires_human_approval: true,
+    auto_publish: false,
+    gap_summary: {
+      kokumin_total: kokuminTotal,
+      cdp_total: cdpTotal,
+      kokumin_lead_prefectures: kokuminLead.length,
+      cdp_lead_prefectures: cdpLead.length,
+      even_prefectures: even,
+    },
+  };
+}

--- a/supabase/functions/local-election-intelligence/party_gap_ranking_test.ts
+++ b/supabase/functions/local-election-intelligence/party_gap_ranking_test.ts
@@ -1,0 +1,192 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  buildPartyGapCandidateMetadata,
+  isoWeekKey,
+  PARTY_GAP_VARIANT,
+} from "./party_gap_ranking.ts";
+import type {
+  CanonicalLocalElectionSnapshot,
+  CanonicalPrefecture,
+} from "./snapshot_history.ts";
+import { classifyPostArchetype } from "../growth-hub/x_post_archetype.ts";
+
+function prefecture(
+  name: string,
+  kokumin: number,
+  cdp: number,
+): CanonicalPrefecture {
+  return {
+    prefecture: name,
+    sourceUrl: `https://new-kokumin.jp/member/${name}`,
+    currentMembers: kokumin,
+    prefecturalAssemblyMembers: 0,
+    municipalAssemblyMembers: kokumin,
+    cdpLocalMembers: cdp,
+    cdpSourceUrl: "https://cdp-japan.jp/members/house/local_authorities",
+  };
+}
+
+/// 47 都道府県のフィクスチャ。上位・下位の実測値(2026-07-10 のポストA)を
+/// 一部に埋め、残りは互角圏で埋める。
+function snapshot(
+  overridePrefectures?: CanonicalPrefecture[],
+): CanonicalLocalElectionSnapshot {
+  const names = Array.from({ length: 47 }, (_, index) => `県${index + 1}`);
+  const prefectures = overridePrefectures ?? [
+    prefecture("香川県", 26, 23),
+    prefecture("茨城県", 22, 14),
+    prefecture("北海道", 5, 57),
+    prefecture("千葉県", 8, 57),
+    prefecture("神奈川県", 14, 59),
+    prefecture("鳥取県", 0, 18),
+    ...names.slice(6).map((name) => prefecture(name, 3, 3)),
+  ];
+  return {
+    metrics: {
+      baselineCurrentLocalMembers: 340,
+      officialCurrentLocalMembers: 378,
+      targetLocalMembers: 700,
+      baselineNetIncreaseRequired: 360,
+      actualNetIncreaseRequired: 322,
+      official2023FirstHalfWins: 62,
+      official2023SecondHalfWins: 121,
+      official2023TotalWins: 183,
+    },
+    collectionQuality: {
+      complete: true,
+      failedPrefectureFetches: [],
+      linkedPrefectureCount: 47,
+      minimumExpectedMemberCount: 300,
+      officialElectionPrefectureLinkCount: 47,
+      minimumExpectedOfficialElectionPrefectureLinks: 40,
+      scheduleSourceCount: 1,
+      scheduleFetchSuccessCount: 1,
+      scheduleParsedSourceCount: 1,
+      scheduleParsedEntryCount: 1,
+      scheduleManualEntryCount: 0,
+      scheduleManualFallbackOnly: false,
+      failedScheduleSourceUrls: [],
+      parserEmptyScheduleSourceUrls: [],
+      failedRequiredScheduleSourceUrls: [],
+      parserEmptyRequiredScheduleSourceUrls: [],
+      issues: [],
+    },
+    sources: [
+      {
+        label: "Official members",
+        url: "https://new-kokumin.jp/member",
+        category: "official_members",
+        note: "",
+      },
+    ],
+    prefectures,
+    members: [],
+    upcomingSchedules: [],
+  };
+}
+
+const OPTIONS = {
+  snapshotObservationId: "obs-1",
+  snapshotHash: "hash-1",
+  datasetVersion: "v1",
+  observedAt: "2026-07-13T21:00:00Z",
+  datasetSource: "local-election-intelligence",
+  dataset: "kokumin_local_election_intelligence",
+};
+
+Deno.test("isoWeekKey produces stable weekly keys", () => {
+  // 同一 ISO 週(月曜起点)の日は同じキー=日次 cron でも週1候補。
+  assertEquals(isoWeekKey("2026-07-13T21:00:00Z"), "2026-W29");
+  assertEquals(isoWeekKey("2026-07-19T21:00:00Z"), "2026-W29");
+  assertEquals(isoWeekKey("2026-07-20T21:00:00Z"), "2026-W30");
+  assertEquals(isoWeekKey("not-a-date"), null);
+});
+
+Deno.test("buildPartyGapCandidateMetadata refuses thin or unsynced data", () => {
+  // 県数欠損(取得失敗日)。
+  assertEquals(
+    buildPartyGapCandidateMetadata(
+      snapshot([prefecture("東京都", 49, 56)]),
+      OPTIONS,
+    ),
+    null,
+  );
+  // 立憲参考が全県 0 = 未同期日は比較を名乗らない。
+  const zeroCdp = snapshot().prefectures.map((entry) => ({
+    ...entry,
+    cdpLocalMembers: 0,
+  }));
+  assertEquals(
+    buildPartyGapCandidateMetadata(snapshot(zeroCdp), OPTIONS),
+    null,
+  );
+  // observedAt 不正。
+  assertEquals(
+    buildPartyGapCandidateMetadata(snapshot(), {
+      ...OPTIONS,
+      observedAt: "junk",
+    }),
+    null,
+  );
+});
+
+Deno.test("buildPartyGapCandidateMetadata composes the gap ranking candidate", () => {
+  const metadata = buildPartyGapCandidateMetadata(snapshot(), OPTIONS);
+  assert(metadata !== null);
+  const text = String(metadata!.text);
+  // ポストA構造の骨格。
+  assert(text.includes("国民民主党×立憲民主党 地方議員 地力差 2026/7/14"));
+  assert(text.includes("取得日時: 2026-07-13T21:00:00Z"));
+  assert(text.includes("国民民主 公式地方議員数: 198人"));
+  assert(text.includes("立憲民主 参考合計: 351人"));
+  assert(text.includes("両党差分: -153人"));
+  // リード上位は実ギャップ順(香川 +3 → 茨城 +8 が上)。
+  assert(
+    text.indexOf("茨城県 +8（22 vs 14）") <
+      text.indexOf("香川県 +3（26 vs 23）"),
+  );
+  // 開拓余地は立憲リードの大きい順。
+  assert(
+    text.indexOf("神奈川県 -45（14 vs 59）") <
+        text.indexOf("北海道 -52（5 vs 57）") === false,
+  );
+  assert(text.includes("開拓余地(立憲民主リード上位)"));
+  assert(text.includes("参考値"));
+  // メタデータ契約。
+  assertEquals(metadata!.status, "pending_approval");
+  assertEquals(metadata!.variant, PARTY_GAP_VARIANT);
+  assertEquals(metadata!.content_archetype, "data_report");
+  assertEquals(
+    metadata!.candidate_key,
+    "local-election:party-gap:2026-W29",
+  );
+  assertEquals(metadata!.requires_human_approval, true);
+  assertEquals(metadata!.auto_publish, false);
+});
+
+Deno.test("gap ranking replies carry all-47 table, alerts, and final URL", () => {
+  const metadata = buildPartyGapCandidateMetadata(snapshot(), OPTIONS);
+  assert(metadata !== null);
+  const replies = (metadata!.reply_texts as string[]) ?? [];
+  assertEquals(replies.length, 3);
+  const [table, alerts, cta] = replies;
+  assert(table.includes("全都道府県の地力差"));
+  // 47 県すべて載る(名簿相当の検索面)。
+  assertEquals(table.split("\n").length, 2 + 47);
+  assert(alerts.includes("🔴 国民民主 議員不在 1県: 鳥取県"));
+  assert(cta.includes("utm_content=party_gap_ranking"));
+  assert(!String(metadata!.text).includes("https://my-web-app"));
+});
+
+Deno.test("gap ranking self-classifies as data_report", () => {
+  const metadata = buildPartyGapCandidateMetadata(snapshot(), OPTIONS);
+  assert(metadata !== null);
+  const full = [
+    String(metadata!.text),
+    ...((metadata!.reply_texts as string[]) ?? []),
+  ].join("\n");
+  assertEquals(classifyPostArchetype(full), "data_report");
+});

--- a/supabase/functions/local-election-intelligence/party_gap_ranking_test.ts
+++ b/supabase/functions/local-election-intelligence/party_gap_ranking_test.ts
@@ -5,11 +5,14 @@ import {
 import {
   buildPartyGapCandidateMetadata,
   isoWeekKey,
+  normalizeCdpBenchmark,
   PARTY_GAP_VARIANT,
 } from "./party_gap_ranking.ts";
-import type {
-  CanonicalLocalElectionSnapshot,
-  CanonicalPrefecture,
+import {
+  buildLocalElectionPostCandidates,
+  type CanonicalLocalElectionSnapshot,
+  type CanonicalPrefecture,
+  computeLocalElectionDiff,
 } from "./snapshot_history.ts";
 import { classifyPostArchetype } from "../growth-hub/x_post_archetype.ts";
 
@@ -179,6 +182,98 @@ Deno.test("gap ranking replies carry all-47 table, alerts, and final URL", () =>
   assert(alerts.includes("🔴 国民民主 議員不在 1県: 鳥取県"));
   assert(cta.includes("utm_content=party_gap_ranking"));
   assert(!String(metadata!.text).includes("https://my-web-app"));
+});
+
+Deno.test("normalizeCdpBenchmark parses the repo asset shape", () => {
+  // assets/data/cdp_local_members.json の実形(県サフィックス無しキー)。
+  const map = normalizeCdpBenchmark({
+    source: "https://cdp-japan.jp/members/prefecture/",
+    prefectures: { "北海道": 57, "東京": 56, "香川": 23, "junk": "x" },
+  });
+  assert(map !== null);
+  assertEquals(map!["東京"], 56);
+  assertEquals(map!["junk"], undefined);
+  assertEquals(normalizeCdpBenchmark(null), null);
+  assertEquals(normalizeCdpBenchmark({ prefectures: {} }), null);
+  assertEquals(normalizeCdpBenchmark({ prefectures: [] }), null);
+});
+
+Deno.test("cdpByPrefecture map overrides the hardcoded-zero snapshot cdp (F1)", () => {
+  // 本番 EF snapshot は cdpLocalMembers=0 ハードコード。asset 由来マップが
+  // 唯一の立憲実数源で、県名は「東京都↔東京」のサフィックス名寄せで一致する。
+  const zeroCdp = snapshot().prefectures.map((entry) => ({
+    ...entry,
+    cdpLocalMembers: 0,
+  }));
+  const cdpMap: Record<string, number> = {
+    "香川": 23,
+    "茨城": 14,
+    "北海道": 57,
+    "千葉": 57,
+    "神奈川": 59,
+    "鳥取": 18,
+  };
+  for (let index = 7; index <= 47; index++) cdpMap[`県${index}`] = 3;
+  const metadata = buildPartyGapCandidateMetadata(snapshot(zeroCdp), {
+    ...OPTIONS,
+    cdpByPrefecture: cdpMap,
+  });
+  assert(metadata !== null);
+  const text = String(metadata!.text);
+  assert(text.includes("香川県 +3（26 vs 23）"));
+  assert(text.includes("北海道 -52（5 vs 57）"));
+  // マップ未指定なら snapshot の 0 へフォールバック=ゲートで見送り。
+  assertEquals(
+    buildPartyGapCandidateMetadata(snapshot(zeroCdp), OPTIONS),
+    null,
+  );
+});
+
+Deno.test("リード上位 respects the same threshold as the summary counts (F2)", () => {
+  // 全県が互角圏(gap -2..+2)の週: サマリ「リード0県」と矛盾する
+  // 「リード上位」リストを出さない(自己矛盾レポート防止)。
+  const evenPrefectures = Array.from(
+    { length: 47 },
+    (_, index) => prefecture(`県${index + 1}`, 3 + (index % 3), 3),
+  ); // gap は 0/+1/+2 のみ
+  const metadata = buildPartyGapCandidateMetadata(
+    snapshot(evenPrefectures),
+    OPTIONS,
+  );
+  assert(metadata !== null);
+  const text = String(metadata!.text);
+  assert(text.includes("国民民主リード(差+3人以上): 0県"));
+  assert(text.includes("(リード県なし)"));
+  assert(text.includes("(該当なし)"));
+});
+
+Deno.test("weekly key uses wall-clock queueObservedAt on unchanged-data weeks (F3)", () => {
+  // isConsecutiveRetry 経路では snapshot 行の observed_at が前週のまま止まる。
+  // 週キーは wall-clock(queueObservedAt)から採らないと、データ無変化週に
+  // 候補が一度も作られない。buildLocalElectionPostCandidates の配線ごと固定。
+  const snap = snapshot();
+  const emptyDiff = computeLocalElectionDiff(snap, snap);
+  assertEquals(emptyDiff.significantKinds.length, 0);
+  const rows = buildLocalElectionPostCandidates(
+    snap,
+    emptyDiff,
+    "obs-1",
+    "hash-1",
+    "prev-id",
+    "prev-hash",
+    "v1",
+    "2026-07-06T21:00:00Z", // stale = 前週 W28
+    {
+      queueObservedAt: "2026-07-13T21:00:00Z", // wall clock = W29
+      cdpByPrefecture: null,
+    },
+  );
+  // diff 無しでも定点観測系列は生成され、週キーは wall clock の W29。
+  assertEquals(rows.length, 1);
+  assertEquals(
+    rows[0].candidate_key,
+    "local-election:party-gap:2026-W29",
+  );
 });
 
 Deno.test("gap ranking self-classifies as data_report", () => {

--- a/supabase/functions/local-election-intelligence/snapshot_history.ts
+++ b/supabase/functions/local-election-intelligence/snapshot_history.ts
@@ -2,6 +2,7 @@ import {
   buildXPostCandidateMetadata,
   X_POST_CANDIDATE_SOURCE,
 } from "../growth-hub/x_post_candidate.ts";
+import { buildPartyGapCandidateMetadata } from "./party_gap_ranking.ts";
 
 export const LOCAL_ELECTION_DATASET = "kokumin_local_election_intelligence";
 export const LOCAL_ELECTION_DATASET_SOURCE = "local-election-intelligence";
@@ -1064,6 +1065,20 @@ export function buildLocalElectionPostCandidates(
       },
     ));
   }
+
+  // R28: 週次の両党地力差ランキング(diff 非依存の定点観測系列)。日次 cron
+  // から毎回呼ばれるが candidate_key が ISO 週キーなので insertPostCandidate
+  // の冪等性により週1回だけ候補が作られる。生成不能条件(立憲参考未同期等)
+  // は composer 側で null。
+  const partyGap = buildPartyGapCandidateMetadata(snapshot, {
+    snapshotObservationId,
+    snapshotHash,
+    datasetVersion,
+    observedAt,
+    datasetSource: LOCAL_ELECTION_DATASET_SOURCE,
+    dataset: LOCAL_ELECTION_DATASET,
+  });
+  if (partyGap !== null) rows.push(partyGap);
 
   return rows;
 }

--- a/supabase/functions/local-election-intelligence/snapshot_history.ts
+++ b/supabase/functions/local-election-intelligence/snapshot_history.ts
@@ -893,6 +893,13 @@ export function buildLocalElectionPostCandidates(
   previousSnapshotHash: string,
   datasetVersion: string,
   observedAt: string,
+  partyGapOptions?: {
+    /// wall-clock の今回実行時刻。isConsecutiveRetry 経路の observedAt は
+    /// 「hash が最初に現れた時刻」で stale のため、週次系列の ISO 週キーに
+    /// そのまま使うとデータ無変化週に候補が一度も作られない(レビュー F3)。
+    queueObservedAt?: string;
+    cdpByPrefecture?: Record<string, number> | null;
+  },
 ): JsonRecord[] {
   const rows: JsonRecord[] = [];
 
@@ -1068,15 +1075,18 @@ export function buildLocalElectionPostCandidates(
 
   // R28: 週次の両党地力差ランキング(diff 非依存の定点観測系列)。日次 cron
   // から毎回呼ばれるが candidate_key が ISO 週キーなので insertPostCandidate
-  // の冪等性により週1回だけ候補が作られる。生成不能条件(立憲参考未同期等)
-  // は composer 側で null。
+  // の冪等性により週1回だけ候補が作られる。生成不能条件(立憲実数源の欠落等)
+  // は composer 側で null。observedAt は wall-clock(queueObservedAt)を使う:
+  // snapshot 行の observed_at はデータ無変化週に前週のまま止まり、週キーが
+  // 過去週で冪等スキップされ続ける(レビュー F3)。
   const partyGap = buildPartyGapCandidateMetadata(snapshot, {
     snapshotObservationId,
     snapshotHash,
     datasetVersion,
-    observedAt,
+    observedAt: partyGapOptions?.queueObservedAt ?? observedAt,
     datasetSource: LOCAL_ELECTION_DATASET_SOURCE,
     dataset: LOCAL_ELECTION_DATASET,
+    cdpByPrefecture: partyGapOptions?.cdpByPrefecture ?? null,
   });
   if (partyGap !== null) rows.push(partyGap);
 
@@ -1107,6 +1117,9 @@ export async function persistLocalElectionSnapshot(
   store: LocalElectionHubStore,
   rawSnapshot: unknown,
   observedAt = new Date().toISOString(),
+  partyGapOptions?: {
+    cdpByPrefecture?: Record<string, number> | null;
+  },
 ): Promise<PersistSnapshotResult> {
   const snapshot = canonicalizeLocalElectionSnapshot(rawSnapshot);
   if (!snapshot.collectionQuality.complete) {
@@ -1218,6 +1231,10 @@ export async function persistLocalElectionSnapshot(
     previousSnapshotHash,
     datasetVersion,
     asString(snapshotRow.metadata.observed_at) || observedAt,
+    {
+      queueObservedAt: observedAt,
+      cdpByPrefecture: partyGapOptions?.cdpByPrefecture ?? null,
+    },
   );
   const insertions: HubInsertResult[] = [];
   for (const metadata of candidateMetadata) {

--- a/test/pages/admin_x_candidate_queue_test.dart
+++ b/test/pages/admin_x_candidate_queue_test.dart
@@ -13,6 +13,8 @@ void main() {
       expect(xTrackerSeriesLabel('weekly_data_report'), 'X運用実測');
       // R27: AIツール動向トラッカー系列(playbook step 4 のラベル登録)。
       expect(xTrackerSeriesLabel('ai_tool_tracker'), 'AIツール定点観測');
+      // R28: 両党地力差ランキング系列(playbook step 4)。
+      expect(xTrackerSeriesLabel('party_gap_ranking'), '選挙: 両党地力差');
     });
 
     test('collapses daily_briefing variants and passes unknown through', () {


### PR DESCRIPTION
## 概要 (R28: 系列の水平展開第2号 — 国民民主×立憲 都道府県地力差ランキング)

ポストA(選挙集計 **17.2K** 実測)と同じ政治クラスタに対し、**比較・ギャップ枠**という別角度の系列を追加する。追加スクレイピング・新規 workflow とも不要 = 最小コストの水平展開([X_TRACKER_SERIES_PLAYBOOK.md](docs/X_TRACKER_SERIES_PLAYBOOK.md) 5手順準拠)。

## 変更内容

1. **データ資産**: 日次 snapshot の国民民主県別実数 × 立憲実数の正本 repo asset(`assets/data/cdp_local_members.json`・週次 update_cdp_benchmark.mjs 生成)
2. **決定的ジェネレータ**: 純ロジック `party_gap_ranking.ts` — ポストA構造(取得日時→両党合計→差分→リード県数→上位/開拓余地→全47県表→アラート→URL末尾)。立憲は「参考値」明記・LLM 不使用・`data_report` 自己整合テスト
3. **候補キュー**: 既存の日次 snapshot cron に相乗り。`candidate_key = ISO週キー` × `insertPostCandidate` の冪等性で**週1回だけ**候補生成(新規 workflow ゼロ)。直接投稿なし=HITL 承認必須
4. **variant 登録**: `party_gap_ranking` + ラベル「選挙: 両党地力差」
5. **レジストリ**: プレイブック表へ追加(2週間計測→伸縮判断)

## 敵対的レビュー (7 agents / 生5→確認3→全対応)
- **HIGH: DOA** — 本番 EF は `cdpLocalMembers: 0` ハードコード(立憲実数はクライアント asset のみ)で系列が一度も生成されない → EF が asset を取得し県名サフィックス名寄せ(東京都↔東京)込みで注入。取得失敗は自然見送り
- サマリのリード定義(|gap|>2)と「リード上位」リスト(gap>0)の不一致=自己矛盾レポート → 閾値統一
- データ無変化週は stale observed_at で週キーが前週に固定され候補が作られない → wall-clock 週キーへ

## テスト
- deno: 両EF 114 green(party_gap 9 = 週キー/見送りゲート/構造/47県表/自己分類/asset parse/名寄せ注入/互角週/wall-clock配線)
- flutter: candidate queue 13 green / dart format・deno lint 合格

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge pure-logic wired into an existing daily cron that only enqueues HITL candidates (no direct posting, no browser-reachable flow). Verified by deno test (114 green) across both edge functions.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Additive weekly HITL-candidate composer inside the existing snapshot pipeline (no direct posting, no auth/payment/RLS surface; snapshot hash and delta series untouched); adversarial 7-agent review confirmed 3 findings including a dead-on-arrival wiring gap, all fixed with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
