### PR TITLE
feat(x-share): R24d 家計トラッカー常設入口 — 資産ページAppBarから1タップ投稿

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -8376,6 +8376,26 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         title: const Text('資産管理闘争'),
         backgroundColor: const Color(0xFF1B5E20),
         foregroundColor: Colors.white,
+        actions: [
+          // R24d: 家計トラッカー投稿の常設入口。従来は AI 分析レポート内の
+          // 負債トレンドカードにしか無く投稿手段が見つからなかった。検出0件
+          // でも「アラート: なし+給料日カウントダウン」の正直なスコアボードを
+          // 投稿できる(金額は一切含まない)。
+          if (_householdTrackerScheduleAllowed)
+            IconButton(
+              tooltip: '家計トラッカーをXへ投稿（計測対象・金額非公開）',
+              icon: _householdTrackerPosting
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.ios_share),
+              onPressed: _householdTrackerPosting
+                  ? null
+                  : () => _postHouseholdTrackerNow(assetLiabilityWorkbook),
+            ),
+        ],
       ),
       backgroundColor: const Color(0xFF64748B),
       body: SingleChildScrollView(
@@ -20456,6 +20476,33 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } finally {
       if (mounted) setState(() => _householdTrackerScheduleSaving = false);
     }
+  }
+
+  /// R24d: AppBar 常設ボタン用。現在の workbook から負債トレンド insights を
+  /// その場で算出して投稿する(AI 分析レポートカードの表示を待たない)。
+  Future<void> _postHouseholdTrackerNow(
+    AssetLiabilityWorkbook? workbook,
+  ) async {
+    if (workbook == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('資産データの読込中です。少し待ってからお試しください')),
+      );
+      return;
+    }
+    final currentMonthKey =
+        AssetAccountBalanceHistoryStore.formatMonthKey(workbook.baseDate);
+    // キャッシュ済み前月残高が当月のものでない間は渡さない(取り違え防止)。
+    final priorMonthAccountBalances =
+        _assetDebtTrendPriorBalancesMonth == currentMonthKey
+            ? _assetDebtTrendPriorBalances
+            : const <String, double>{};
+    final report = _assetManagementInsightService.buildReport(
+      workbook: workbook,
+      userProfile: _assetManagementUserProfile,
+      mainAccountId: _assetManagementMainAccountId,
+      priorMonthAccountBalances: priorMonthAccountBalances,
+    );
+    await _postHouseholdTracker(report.debtTrendInsights);
   }
 
   /// R24b: 負債トレンドの実データ(件数・日数・方向のみ/金額なし)を post A 同型の


### PR DESCRIPTION
## 概要

ユーザー報告「資産ページから家計トラッカーを投稿する手段が分かりません」への対応 (R24d)。

従来の投稿入口 (R24c) は AI 分析レポート内の負債トレンドカードのヘッダにしか無く、レポートを生成しないと到達できず発見不能だった。資産管理闘争ページの AppBar 右上に常設の共有ボタンを追加する。

## 変更内容 (Dart 1 ファイル / +47 行のみ)

- `lib/pages/asset_management_page.dart`
  - AppBar `actions:` に ios_share IconButton を追加 (管理者フラグ `_householdTrackerScheduleAllowed` が真のときのみ表示 / 投稿中はスピナー)
  - `_postHouseholdTrackerNow(AssetLiabilityWorkbook?)` を追加: 現在の workbook から `_assetManagementInsightService.buildReport` で負債トレンド insights をその場で算出し、既存の `_postHouseholdTracker` (R24c・管理者ゲート/給料日ゲート/金額非公開の合成を内包) に委譲。前月残高は当月キャッシュ一致時のみ渡す (既存 L17750 と同じ取り違え防止ガード)
  - 検出 0 件でも「アラート: なし + 給料日カウントダウン」の正直なスコアボードを投稿できる。円金額は一切含まない (variant=household_tracker / contentArchetype=data_report で計測対象)

## テスト

- `flutter analyze lib/pages/asset_management_page.dart` clean (No issues found)
- 合成ロジック本体は既存 `test/services/household_tracker_share_service_test.dart` 4 件緑でカバー済み (スコアボード内容 / 円・¥不在 / 給料日カウントダウン / payload タグ)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: UI wiring only: AppBar IconButton delegating to already-merged household tracker composer covered by 4 green VM tests in test/services/household_tracker_share_service_test.dart; flutter analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
