### PR TITLE
perf(x-report): index x_post_log benchmark lookup — 週次実測レポート cron timeout 修正

### DIFF
--- a/supabase/migrations/20260713213000_index_x_post_log_report_lookup.sql
+++ b/supabase/migrations/20260713213000_index_x_post_log_report_lookup.sql
@@ -1,0 +1,30 @@
+-- X 週次実測レポート (growth-hub x.growth_data_report) の statement timeout 修正。
+--
+-- buildXPerformanceContext は x_post_log を 2 通りで読む:
+--   1. listXPostLogs             : source='x_post_log' ORDER BY created_at DESC LIMIT N
+--   2. listXHistoricalBenchmarkLogs: source='x_post_log'
+--       AND metadata->>'learning_cohort'='historical_benchmark'
+--       ORDER BY created_at DESC LIMIT N
+--
+-- hub_data には単列 index (source / created_at) しか無いため、(2) は
+-- created_at 降順に x_post_log 行を全走査しつつ稀な旧 benchmark 行を探し、
+-- 本番 PostgREST が statement timeout でキャンセルしていた
+-- (2026-07-12/07-13 の X Growth Data Report Post cron が HTTP 500)。
+-- #4016 は x_post_metric_snapshot 側のみ index 化しており本経路は未修正だった。
+--
+-- source='x_post_log' に限定した partial index で両クエリを index scan 化する。
+
+-- listXPostLogs 用: x_post_log を created_at 降順で先頭 N 件。
+CREATE INDEX IF NOT EXISTS idx_hub_data_x_post_log_created
+  ON public.hub_data (created_at DESC)
+  WHERE source = 'x_post_log';
+
+-- listXHistoricalBenchmarkLogs 用: learning_cohort で直接ジャンプ + created_at 降順。
+-- user_id を含め service_role (cron) 経路と user 絞込み経路の双方を index scan 化する。
+CREATE INDEX IF NOT EXISTS idx_hub_data_x_post_log_cohort_created
+  ON public.hub_data (
+    (metadata->>'learning_cohort'),
+    (metadata->>'user_id'),
+    created_at DESC
+  )
+  WHERE source = 'x_post_log';


### PR DESCRIPTION
## Summary

Task5 (R26 X 候補キュー HITL 運用 + 週次実測レポート確認) の**運用確認で発見した実バグの修正**。

R26 の週次実測レポート cron `X Growth Data Report Post` (毎週土 21:00 UTC) が **HTTP 500 "canceling statement due to statement timeout"** で失敗し続けていた (2026-07-12 定期実行 + 2026-07-13 dry_run 再現)。R26 の HITL 候補キュー panel ([PR #3989](https://github.com/kanta13jp1/my_web_app/pull/3989)) と AIツールトラッカー系列は稼働しているが、実測レポート自動投稿だけが投稿前の合成段階で落ちていた。

### 真因

`growth-hub` の `x.growth_data_report` → `buildXPerformanceContext` → `listXHistoricalBenchmarkLogs` が

```sql
SELECT ... FROM hub_data
WHERE source = 'x_post_log'
  AND metadata->>'learning_cohort' = 'historical_benchmark'
ORDER BY created_at DESC LIMIT 10
```

を実行する。`hub_data` には単列 index (`source` / `created_at` / GIN metadata) しか無いため、Postgres は created_at 降順に x_post_log 行を全走査しながら稀な旧 benchmark 行 (migration で backfill された古い行) を探し、本番 PostgREST が statement timeout でキャンセルしていた。[PR #4016](https://github.com/kanta13jp1/my_web_app/pull/4016) は `x_post_metric_snapshot` 側のみ index 化しており、この benchmark lookup 経路は未修正だった。

### 修正

`source = 'x_post_log'` 限定の partial index を 2 本追加:

- `idx_hub_data_x_post_log_created` — `listXPostLogs` (`created_at DESC LIMIT N`) を index scan 化
- `idx_hub_data_x_post_log_cohort_created` — `(learning_cohort, user_id, created_at DESC)` で `listXHistoricalBenchmarkLogs` を直接ジャンプ (service_role cron / user 絞込み双方に対応)

partial index なので x_post_log 部分集合のみを対象とし小さく保たれる。

### 検証

- `python scripts/check_migration_timestamps.py` → OK (衝突なし / 1899 unique)
- **マージ後 deploy-prod でマイグレーション適用 → cron を `workflow_dispatch` の dry_run で再走し HTTP 200 (timeout 解消) を確認する** (現在は HTTP 500 で再現済み)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: DDL-only partial index migration on hub_data for x_post_log report queries; no auth or runtime code changed, fixes cron statement timeout

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: DDL-only index migration (partial indexes on hub_data for x_post_log report queries); no runtime code path changed, verified by re-running the weekly report cron dry_run post-deploy (HTTP 500 timeout -> 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

