### PR TITLE
perf(x-report): index x_post_metric_snapshot (source_log_id, created_at) — cron timeout 修正 第2弾

### DIFF
--- a/supabase/migrations/20260714003000_index_x_metric_snapshot_ordered.sql
+++ b/supabase/migrations/20260714003000_index_x_metric_snapshot_ordered.sql
@@ -1,0 +1,25 @@
+-- X 週次実測レポート cron の statement timeout 修正 (第 2 弾)。
+--
+-- listXMetricSnapshots は
+--   SELECT ... FROM hub_data
+--   WHERE source='x_post_metric_snapshot'
+--     AND metadata->>'source_log_id' IN (最大50件)
+--   ORDER BY created_at ASC
+-- を実行する。cron は service_role で走るため user_id 絞込みが無い。
+--
+-- #4016 の index は (source_log_id, user_id, created_at) の順で、
+-- user_id が固定される「ユーザー個別呼び出し」経路では created_at 順を
+-- index から得られるが、user_id が未制約の cron 経路では 2 列目 (user_id) が
+-- 開いているため 3 列目 created_at を order に使えず、source_log_id で絞った
+-- 大量行を丸ごと sort する。これが本番 PostgREST の statement timeout の真因
+-- (20260713213000 で x_post_log 側は index 化したが本経路は未修正だった)。
+--
+-- user_id を挟まない (source_log_id, created_at) の partial index を追加し、
+-- IN リストの各 source_log_id を created_at 昇順で index 走査 → merge-append
+-- (sort 不要) で返せるようにする。
+CREATE INDEX IF NOT EXISTS idx_hub_data_x_metric_snapshot_log_created
+  ON public.hub_data (
+    (metadata->>'source_log_id'),
+    created_at ASC
+  )
+  WHERE source = 'x_post_metric_snapshot';


### PR DESCRIPTION
## Summary

[PR #4028](https://github.com/kanta13jp1/my_web_app/pull/4028) (x_post_log 側 index) をマージ・デプロイ後も、`X Growth Data Report Post` cron の dry_run 再走で **HTTP 500 "statement timeout" が継続**することを実測した。#4028 は `listXPostLogs` / `listXHistoricalBenchmarkLogs` を index 化したが、真の bottleneck は **`listXMetricSnapshots`** だった。

### 真因 (第2弾)

`listXMetricSnapshots` は

```sql
SELECT ... FROM hub_data
WHERE source = 'x_post_metric_snapshot'
  AND metadata->>'source_log_id' IN (最大50件)
ORDER BY created_at ASC
```

を実行する。cron は **service_role で走るため `user_id` 絞込みが無い**。[PR #4016](https://github.com/kanta13jp1/my_web_app/pull/4016) の index は `(source_log_id, user_id, created_at)` の順で、user_id が固定されるユーザー個別呼び出しでは created_at 順を index から得られるが、**user_id 未制約の cron 経路では 2 列目 (user_id) が開いているため 3 列目 created_at を ORDER に使えず**、source_log_id で絞った大量スナップショット行を丸ごと sort → statement timeout。

### 修正

`user_id` を挟まない `(source_log_id, created_at ASC)` の partial index を追加。IN リストの各 source_log_id を created_at 昇順で index 走査し **merge-append (sort 不要)** で返せるようにする。

```sql
CREATE INDEX IF NOT EXISTS idx_hub_data_x_metric_snapshot_log_created
  ON public.hub_data ((metadata->>'source_log_id'), created_at ASC)
  WHERE source = 'x_post_metric_snapshot';
```

### 検証

- `check_migration_timestamps.py` → OK (衝突なし)
- **マージ後 deploy-prod でマイグレーション適用 → cron を `workflow_dispatch` dry_run 再走で HTTP 200 を確認する** (現在 HTTP 500 で再現済み)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: DDL-only partial index migration on hub_data for x_post_metric_snapshot ordered lookup; no auth or runtime code changed, fixes cron statement timeout

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: DDL-only index migration (partial index on hub_data for x_post_metric_snapshot ordered query); no runtime code path changed, verified by re-running the weekly report cron dry_run post-deploy (HTTP 500 timeout -> 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
