### PR TITLE
perf(x-report): snapshot クエリの ORDER を index と一致させ cron timeout 解消 (第3弾)

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -317,11 +317,19 @@ async function listXMetricSnapshots(
   for (let offset = 0; offset < sourceLogIds.length; offset += batchSize) {
     const ids = sourceLogIds.slice(offset, offset + batchSize);
     for (let page = 0; page < maxPagesPerBatch; page += 1) {
+      // ORDER は (source_log_id, created_at) — partial index
+      // idx_hub_data_x_metric_snapshot_log_created (#4030) と一致させ、
+      // source_log_id IN(...) を index 走査 + merge-append で返す (sort 回避)。
+      // created_at 単独 order だと index を order に使えず大量行 sort →
+      // service_role (cron) 経路で statement timeout していた。
+      // normalizeXMetricWindows は source_log_id 毎に snapshot を突合するため
+      // post 跨ぎの並び順には非依存。
       let query = admin
         .from("hub_data")
         .select("id, metadata, created_at")
         .eq("source", "x_post_metric_snapshot")
         .in("metadata->>source_log_id", ids)
+        .order("metadata->>source_log_id", { ascending: true })
         .order("created_at", { ascending: true })
         .range(page * pageSize, (page + 1) * pageSize - 1);
       if (userId !== "service_role") {


### PR DESCRIPTION
## Summary

Task5 の運用確認で見つかった週次実測レポート cron の statement timeout、[PR #4028](https://github.com/kanta13jp1/my_web_app/pull/4028) / [PR #4030](https://github.com/kanta13jp1/my_web_app/pull/4030) で partial index を 2 本追加しても HTTP 500 が継続。deploy+dry_run 再走で index 適用済みを確認した上でなお timeout することから、**index は存在するが query が使えていない**と判明。

### 真因 (第3弾・確定)

`listXMetricSnapshots` は `source='x_post_metric_snapshot' AND metadata->>'source_log_id' IN (…) ORDER BY created_at ASC` を実行する。#4030 の index は `(source_log_id, created_at)` だが、query の **`ORDER BY created_at` 単独では index を order に使えない** — 複数の source_log_id を跨いだ created_at 全体順序は、index leading 列 (source_log_id) と一致しないため Postgres が source_log_id で絞った大量スナップショット行を**丸ごと sort**する。cron は service_role で走り user_id 未制約なので対象行数が最大 → statement timeout。

### 修正

query の ORDER を **`(source_log_id, created_at)`** に変更し #4030 index と一致させる。各 source_log_id を index 走査し **merge-append** で返すため sort が消える。`normalizeXMetricWindows` は snapshot を source_log_id 毎に突合するため post 跨ぎの並び順に非依存 → **挙動不変**。

```ts
.order("metadata->>source_log_id", { ascending: true })
.order("created_at", { ascending: true })
```

### Tests

- `deno test x_growth_data_report_test.ts x_metric_windows_test.ts` → **14 passed**
- `deno check` / `deno fmt` 緑

### 検証

- **マージ後 deploy → cron `workflow_dispatch` dry_run で HTTP 200 を確認する** (現在 HTTP 500 で再現済み)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: read-only query ORDER change in growth-hub to match an existing index (cron timeout fix); no auth or write path changed, behavior-invariant per normalizeXMetricWindows grouping, covered by 14 deno tests

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: read-only Edge Function query ORDER change to enable index use; behavior-invariant (snapshots grouped per source_log_id downstream), covered by existing deno tests (14) + production cron dry_run HTTP 200 verification after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
