### PR TITLE
fix(growth-hub): symmetric x.post log owner — unblock measurement loop for HITL series

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -62,7 +62,7 @@ import {
   HOUSEHOLD_TRACKER_MIRROR_KEY,
   parseHouseholdTrackerConsent,
 } from "./x_household_tracker.ts";
-import { isUuid, resolveXLogOwnerUserId } from "./x_operator_auth.ts";
+import { isUuid, resolveXPostLogOwner } from "./x_operator_auth.ts";
 import {
   approveXPostCandidateMetadata,
   buildXPostCandidateMetadata,
@@ -2740,9 +2740,14 @@ serve(async (req: Request) => {
           body.ownerUserId,
           body.owner_user_id,
         );
-        const logUserId = resolveXLogOwnerUserId(
+        // この地点は operator 確定(上の 403 ガードを通過している)。人間 operator の
+        // 投稿は共有グロースアカウント(service_role スコープ)へ束ね、metrics cron /
+        // performance_context の読み取りスコープと対称化する。service_role actor の
+        // per-user 束ね(家計トラッカー consent)は resolveXPostLogOwner が尊重する。
+        const logUserId = resolveXPostLogOwner(
           userId!,
           requestedOwnerUserId,
+          true,
         );
         const scheduledHouseholdPost = firstString(body.source) ===
           "x-household-tracker-post.yml";

--- a/supabase/functions/growth-hub/x_operator_auth.ts
+++ b/supabase/functions/growth-hub/x_operator_auth.ts
@@ -14,3 +14,34 @@ export function resolveXLogOwnerUserId(
   }
   return actorUserId;
 }
+
+/// x.post の x_post_log 所有者を決める(読み取りスコープと対称化する)。
+///
+/// 実バグ: xReadScopeUserId は X operator を "service_role" スコープへマップして
+/// performance_context / metrics cron を読むのに、書き込み(x_post_log 所有者)は
+/// resolveXLogOwnerUserId が operator の UUID のままにしていた。結果、人間 operator
+/// が投稿する系列(選挙集計 tally / 両党地力差 gap / AIツール / 選挙 delta =
+/// admin panel or 選挙ページ経由)は operator UUID で記録され、"service_role" を
+/// 走査する metrics cron から漏れ、Archetype lift / variant ranking に永久に
+/// 入らなかった(計測ループが該当系列を黙って取りこぼす)。
+///
+/// 対称化: X operator の投稿は共有グロースアカウント(= "service_role" スコープ)へ
+/// 束ねる。ただし service_role actor が per-user consent(家計トラッカー)で明示
+/// ownerUserId を渡す経路は従来どおり実ユーザー所有を尊重する。通常ユーザーが
+/// 自分のページを共有する経路は自分のスコープのまま(対称)。
+export function resolveXPostLogOwner(
+  actorUserId: string,
+  requestedOwnerUserId: string,
+  actorIsOperator: boolean,
+): string {
+  // service_role cron: 家計トラッカー等の per-user 所有束ねを尊重する。
+  if (actorUserId === "service_role") {
+    return resolveXLogOwnerUserId(actorUserId, requestedOwnerUserId);
+  }
+  // 人間 X operator: 共有グロースアカウントのスコープへ(読み取りと対称)。
+  if (actorIsOperator) {
+    return "service_role";
+  }
+  // 通常ユーザー: 自分のページ共有は自分のスコープのまま。
+  return resolveXLogOwnerUserId(actorUserId, requestedOwnerUserId);
+}

--- a/supabase/functions/growth-hub/x_operator_auth_test.ts
+++ b/supabase/functions/growth-hub/x_operator_auth_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { isUuid, resolveXLogOwnerUserId } from "./x_operator_auth.ts";
+import {
+  isUuid,
+  resolveXLogOwnerUserId,
+  resolveXPostLogOwner,
+} from "./x_operator_auth.ts";
 
 const OWNER = "123e4567-e89b-42d3-a456-426614174000";
 
@@ -19,4 +23,29 @@ Deno.test("operator owner IDs use strict UUID syntax", () => {
   assertEquals(isUuid(OWNER), true);
   assertEquals(isUuid(""), false);
   assertEquals(isUuid("service_role"), false);
+});
+
+Deno.test("x.post log owner is symmetric with the read scope", () => {
+  // 人間 operator の投稿は共有グロースアカウント(service_role)へ束ねる。
+  // これが無いと tally/gap/ai_tool/delta 系列が metrics cron から漏れる。
+  assertEquals(resolveXPostLogOwner(OWNER, "", true), "service_role");
+  // operator が ownerUserId を偽装しても共有スコープへ束ねる(実ユーザー所有に
+  // 逃がさない = 読み取りと対称)。
+  assertEquals(
+    resolveXPostLogOwner(OWNER, OWNER, true),
+    "service_role",
+  );
+  // service_role cron: per-user consent(家計トラッカー)の束ねは尊重する。
+  assertEquals(
+    resolveXPostLogOwner("service_role", OWNER, true),
+    OWNER,
+  );
+  // service_role cron で owner 未指定なら service_role スコープ。
+  assertEquals(
+    resolveXPostLogOwner("service_role", "", true),
+    "service_role",
+  );
+  // 通常ユーザー(非 operator)は自分のスコープのまま(対称)。
+  const other = "223e4567-e89b-42d3-a456-426614174000";
+  assertEquals(resolveXPostLogOwner(other, "", false), other);
 });


### PR DESCRIPTION
## 概要 (T5: x.post ログ所有者を読み取りスコープと対称化)

**読み書きの非対称バグ**を修正。`xReadScopeUserId` は X operator を `service_role` スコープへマップして performance_context / metrics cron / today_status / preflight を読むのに、`x.post` の `x_post_log` 所有者は operator の UUID のままだった。

`x.post` は operator 限定(403 ガード)。よって全 x.post は operator による投稿で、**人間 operator の投稿**(admin panel の HITL 承認投稿 + 選挙ページの集計 x.post = **tally / gap / ai_tool / election-delta 系列**)は operator UUID で記録され、`service_role` を走査する metrics cron から漏れて **Archetype lift / variant ranking に永久に入らなかった**。admin パネル自身も手動投稿を計測できていなかった(読み取りは service_role スコープなので operator-UUID 行が見えない)。

これは「系列実測レビュー」が空になる真因であり、量産基盤の計測ループが**承認経由の全系列を黙って取りこぼす**構造欠陥。

## 変更
- 新純関数 `resolveXPostLogOwner(actorUserId, requestedOwnerUserId, actorIsOperator)`:
  - service_role actor → `resolveXLogOwnerUserId`(家計トラッカーの per-user consent 束ねを尊重)
  - 人間 operator → `service_role`(共有グロースアカウントのスコープ = 読み取りと対称)
  - 通常ユーザー(非 operator)→ 自分のスコープ
- x.post は 403 ガード通過済み = operator 確定なので `actorIsOperator=true` を渡す(追加 DB 呼び出しなし)

## 注記
既存の operator-UUID ログ行は移行しない(将来分のみ修正)。過去分の backfill は別 migration 判断(orphan は少数)。

## テスト
- deno: growth-hub 97 green(operator auth 3 = 対称化5ケース新規)
- deno lint / fmt clean / typecheck (deno check) green

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge pure-logic auth-scope fix with no browser-reachable UI flow; covered by deno unit tests (5 symmetry cases) + typecheck. Production verification via metrics cron collecting operator-posted series after landing.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Write-path ownership fix that makes x.post log owner symmetric with the pre-existing read scope (xReadScopeUserId); no new auth surface, no RLS change, operator-only handler unchanged; household per-user consent path preserved; adversarial multi-agent review run; deno 97 green.
