### PR TITLE
ci: claude-session-hygiene cron 8x→4x/日 (windows-latest コスト削減 / #3929/#3938/#3983 統合)

### DIFF
--- a/.github/workflows/claude-session-hygiene-cron.yml
+++ b/.github/workflows/claude-session-hygiene-cron.yml
@@ -2,9 +2,9 @@ name: Claude Session Hygiene Cron
 
 on:
   schedule:
-    # Every 180 minutes from 06:00 JST through 03:00 JST next day.
-    # (2026-06-12 ci-audit: 30分→60分 / 2026-06-18 ci-audit: 60分→120分, 21→11runs/日 / 2026-06-21 ci-audit: 120分→180分, 11→8runs/日削減)
-    - cron: "0 21,0,3,6,9,12,15,18 * * *"
+    # Every 360 minutes (6h) from 06:00 JST through 00:00 JST next day.
+    # (2026-06-12 ci-audit: 30分→60分 / 2026-06-18 ci-audit: 60分→120分, 21→11runs/日 / 2026-06-21 ci-audit: 120分→180分, 11→8runs/日 / 2026-07-14 ci-audit: 180分→360分, 8→4runs/日, windows-latest コスト削減)
+    - cron: "0 21,3,9,15 * * *"
   workflow_dispatch:
     inputs:
       apply:


### PR DESCRIPTION
## Summary

超過して滞留していた CI 自動最適化 PR 3 本 (#3929 / #3938 / #3983) の棚卸し結果を 1 本に統合。

### 判定

| PR | 内容 | 判定 |
|----|------|------|
| #3983 | public-memo-smoke concurrency 追加 | **完全に上書き済** — main `7650d171c` (2026-07-13 ci-audit) が同一 concurrency ブロックを既に着地 → close |
| #3929 | hygiene cron 8→4 + public-memo concurrency | public-memo 部は上記で冗長化。cron 削減のみ本 PR に統合 → close |
| #3938 | hygiene cron 8→4 + public-memo concurrency | 同上。cron 式 (06:00 JST アンカー保持) を採用 → close |

### 本 PR の変更

`claude-session-hygiene-cron.yml` の schedule を **8x/日 → 4x/日 (360分間隔)** に削減。
runner が `windows-latest` (高コスト) のため実コスト約 50% 削減。
cron `0 21,3,9,15 * * *` = 06:00 JST 起点を保持 (元コメントの JST アンカーと整合)。

コード変更なし・workflow schedule のみ。

## Minimal E2E Gate

- Implementation-detail independent: N/A — CI workflow schedule のみの変更でアプリコードに影響なし。
- E2E-Exception: `no-e2e-needed` label 付与 (cron 頻度削減のみ / runtime 挙動不変)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)