### PR TITLE
feat(cmo): wire measured data into CmoPage prompt (R23 F3 permanent fix)

### DIFF
--- a/lib/pages/cmo_page.dart
+++ b/lib/pages/cmo_page.dart
@@ -133,18 +133,42 @@ class _CmoPageState extends State<CmoPage> {
     }
   }
 
-  String _buildDraftPrompt(String channelKey) {
+  String _buildDraftPrompt(String channelKey, {String? measuredDataLine}) {
     // R21: 旧実装は goal/tone だけの一般プロンプトで、ダッシュボードの「X投稿を
     // 作る」CTA がここへ飛んだ結果、R11-R15 で潰した旧世代スロップ(「あなたの
     // 価値、埋もれていませんか？…自分集客力」)を再生産していた。アンチスロップ
     // 装置(実在機能事実/一人称persona/禁止語/具体性/BAD→GOOD)を共有ガードレール
     // から注入する。per-channel の長さ/tone spec と {title,body,hashtags} 契約は不変。
+    // R23 F3 恒久解: 実測データ行(あれば)を渡すと「実数を使ってよい」経路になる。
     return buildCmoDraftPrompt(
       channelKey: channelKey,
       channelLabel: _channelLabel(channelKey),
       spec: _channelPromptSpec(channelKey),
       hashtags: _defaultHashtags(channelKey),
+      measuredDataLine: measuredDataLine,
     );
+  }
+
+  /// R23 F3 恒久解: このアカウント自身の実測インプレッション行(build-in-public
+  /// 実数として公開してよい唯一の恒常データ源)を best-effort で取得する。
+  /// operator 以外は 403 / データ薄は null で返り、その場合 CmoPage は従来の
+  /// 捏造禁止ガードに落ちる(投稿導線は必ず描画する = 失敗しても妨げない)。
+  Future<String?> _fetchMeasuredDataLine() async {
+    try {
+      final response = await supabase.functions.invoke(
+        'growth-hub',
+        body: const <String, dynamic>{
+          'action': 'x.performance_context',
+          'limit': 80,
+        },
+      );
+      if (response.status != 200) return null;
+      final data = _normalizeInvokePayload(response.data);
+      if (data['success'] != true) return null;
+      return extractOwnMeasuredDataLine(data['promptContext']?.toString());
+    } catch (_) {
+      return null;
+    }
   }
 
   String? _extractFirstJsonObject(String text) {
@@ -293,10 +317,16 @@ class _CmoPageState extends State<CmoPage> {
 
     setState(() => _isLoading = true);
     try {
+      // R23 F3: 実測データ行を先に取得(best-effort)。あれば実数を使える経路、
+      // 無ければ従来の捏造禁止ガードで生成する。
+      final measuredDataLine = await _fetchMeasuredDataLine();
       final payload = await _magiSettingsService.buildAiAssistantPayload(
         baseBody: <String, dynamic>{
           'action': 'improve',
-          'text': _buildDraftPrompt(channelKey),
+          'text': _buildDraftPrompt(
+            channelKey,
+            measuredDataLine: measuredDataLine,
+          ),
         },
       );
       final response = await supabase.functions.invoke(

--- a/lib/services/x_copy_guardrails.dart
+++ b/lib/services/x_copy_guardrails.dart
@@ -84,14 +84,43 @@ const String kDataReportArchetypeLesson =
 /// テキスト(FEATURE-FACT / 一人称 persona / 禁止語 / 具体性要求 / BAD→GOOD)を
 /// 追加し、既存の per-channel spec(長さ/tone)と {title,body,hashtags} 契約は
 /// 一切上書きしない(facebook も同プロンプトを共有するため長さは spec のまま)。
+/// performance_context の promptContext 文字列から "Own measured data" 行を
+/// 抽出する純関数(CmoPage が実測供給源として使う / R23 F3 恒久解)。
+/// この行はこのアカウント自身の実測インプレッションで、一人称の build-in-public
+/// 実数として公開してよい唯一の恒常データ源(growth-hub buildOwnDataFactsLine)。
+/// 見つからない/薄いデータ時は null(呼び出し側は捏造禁止ガードへ落とす)。
+String? extractOwnMeasuredDataLine(String? performanceContext) {
+  final source = (performanceContext ?? '').trim();
+  if (source.isEmpty) return null;
+  for (final rawLine in source.split('\n')) {
+    final line = rawLine.trim();
+    if (line.startsWith('Own measured data')) {
+      return line.isEmpty ? null : line;
+    }
+  }
+  return null;
+}
+
 String buildCmoDraftPrompt({
   required String channelKey,
   required String channelLabel,
   required Map<String, String> spec,
   required List<String> hashtags,
+  String? measuredDataLine,
 }) {
   final facts = kAppFeatureFacts.map((fact) => '- $fact').join('\n');
   final banned = kSlopBannedTokens.map((token) => '「$token」').join(' / ');
+  // R23 F3 恒久解: 実測データ行があれば「実数を使ってよい」経路(universal 経路と
+  // 対称)。無ければ従来どおり数字の新規生成を明示禁止する(供給源の無い経路へ
+  // 「冒頭に実数」命令だけ注入すると捏造圧力になる)。
+  final measured = (measuredDataLine ?? '').trim();
+  final dataRule = measured.isNotEmpty
+      ? '$kDataReportArchetypeLesson '
+          '実測データ(このアカウント自身のX投稿の実測値。一人称の build-in-public 実数として公開してよい): '
+          '$measured '
+          'データレポート型で書くなら冒頭1行目にこの実測値を1つ置け。ただしこの実測行と上の実在機能リストに無い数字は作るな。'
+      : '$kDataReportArchetypeLesson '
+          'このプロンプトには実数の供給源(当日見出し・実測データ)を渡していないので、新しい数字を作るな。使ってよい数字は上の実在機能リストの仕組みが定義する数のみ。';
   return '''
 あなたは「自分株式会社」という一人会社を運営する開発者本人です。$channelLabel 向けの日本語コピーを、build-in-public の一人称で書いてください。三人称のブランド口調(「私たち」「弊社」「本サービスは」「私たちの新しいウェブアプリは」)を禁止します。
 
@@ -106,7 +135,7 @@ $facts
 - 本文に上の実在機能を最低1つ名前で挙げる(固有機能名を必ず含める)。
 - 禁止フレーズ(これらを含む文は必ず書き直せ): $banned。
 - 誇張副詞(劇的に/大幅に/格段に/飛躍的に)で改善を主張するな。改善の大きさは具体的な数字か仕組み(何がどう動いて何が消えるか)でのみ語れ。
-- $kDataReportArchetypeLesson このプロンプトには実数の供給源(当日見出し・実測データ)を渡していないので、新しい数字を作るな。使ってよい数字は上の実在機能リストの仕組みが定義する数のみ。
+- $dataRule
 
 例(実質・BAD→GOOD、この差を真似て今日の内容で書け):
 - BAD: 「あなたの価値、埋もれていませんか？埋もれた才能を最大限にアピールし、社会で輝くための自分集客力を構築。」

--- a/test/services/x_copy_guardrails_test.dart
+++ b/test/services/x_copy_guardrails_test.dart
@@ -68,6 +68,54 @@ void main() {
         expect(xPrompt, contains('80-140'));
       },
     );
+
+    test('R23 F3: measured data line unlocks the real-number path', () {
+      // 実測供給源が無いとき(既定): 捏造禁止ガード。
+      expect(xPrompt, contains('新しい数字を作るな'));
+      expect(xPrompt, isNot(contains('冒頭1行目にこの実測値')));
+
+      // 実測データ行があるとき: 実数を使ってよい経路+この行に無い数字は禁止。
+      const line =
+          'Own measured data (REAL numbers you MAY publish first-person as '
+          'build-in-public stats): measured posts=12, median impressions=517, '
+          'best impressions=17200.';
+      final measuredPrompt = buildCmoDraftPrompt(
+        channelKey: 'x_share',
+        channelLabel: 'X (Twitter)',
+        spec: xSpec,
+        hashtags: const ['#自分株式会社'],
+        measuredDataLine: line,
+      );
+      expect(measuredPrompt, contains('best impressions=17200'));
+      expect(measuredPrompt, contains('冒頭1行目にこの実測値を1つ置け'));
+      expect(measuredPrompt, contains('この実測行と上の実在機能リストに無い数字は作るな'));
+      // 供給源がある日は「新しい数字を作るな(供給源なし)」ガードは出さない。
+      expect(measuredPrompt, isNot(contains('渡していないので、新しい数字を作るな')));
+    });
+  });
+
+  group('extractOwnMeasuredDataLine', () {
+    test('pulls the Own measured data line from performance context', () {
+      const context = 'Measured X performance context for the next post:\n'
+          'Target: 10K impressions. Current best variant: daily_briefing.\n'
+          'Own measured data (REAL numbers you MAY publish first-person as '
+          'build-in-public stats): measured posts=12, median impressions=517, '
+          'best impressions=17200.\n'
+          'Use the winning structure, test one variable at a time.';
+      final line = extractOwnMeasuredDataLine(context);
+      expect(line, isNotNull);
+      expect(line, startsWith('Own measured data'));
+      expect(line, contains('best impressions=17200'));
+    });
+
+    test('returns null when absent, empty, or null', () {
+      expect(extractOwnMeasuredDataLine(null), isNull);
+      expect(extractOwnMeasuredDataLine(''), isNull);
+      expect(
+        extractOwnMeasuredDataLine('No measured X performance yet.'),
+        isNull,
+      );
+    });
   });
 
   group('detectSlop / hasFeatureAnchor', () {


### PR DESCRIPTION
## 概要 (T4: CmoPage への実測データ供給配線 — R23 F3 恒久解)

R23 レビュー F3 の恒久解。CmoPage(ダッシュボードの「X投稿を作る」CTA の飛び先)は実数の供給源が無いため、共有教訓 `kDataReportArchetypeLesson` の「冒頭に実数」志向に対し**「新しい数字を作るな」という捏造禁止ガードだけ**を持っていた(universal 経路は実測データを持つので非対称)。

## 変更
- `buildCmoDraftPrompt` に任意 `measuredDataLine` を追加:
  - 実測データ行があれば → 「実数を使ってよい」経路(universal 経路と対称)+ この行に無い数字は禁止
  - 無ければ → 従来の捏造禁止ガード維持(供給源の無い経路へ実数命令だけ注入すると捏造圧力 = F3/F4 の原因)
- 新純関数 `extractOwnMeasuredDataLine`: performance_context の promptContext から "Own measured data" 行(このアカウント自身の実測 = 一人称で公開してよい唯一の恒常実数源)を抽出
- CmoPage は生成前に best-effort で実測行を取得(operator 以外 403 / 薄データは null → 従来ガードに落ちる。投稿導線は必ず描画 = 取得失敗しても妨げない)

## テスト
- `buildCmoDraftPrompt` の実測あり/なし両経路 + `extractOwnMeasuredDataLine`(抽出/null)を固定
- ローカル flutter test は当環境で hang するため CI(Linux)で検証(documented fallback)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts prompt input/output, not private internals.
- Minimal scope: measured-present path, measured-absent path, extraction happy/empty.
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Prompt-builder pure-logic + a best-effort fetch on the existing CmoPage generation flow (auth-gated, no new browser-reachable route); covered by widget/unit tests. The fetch degrades to the prior guard on any failure so the share path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: CmoPage generation-prompt change plus a best-effort read of existing performance_context; no auth/payment/RLS surface, degrades to the prior fabrication guard on any fetch failure; pure-logic covered by tests
