### PR TITLE
[CI/CD自動最適化] cancel-in-progress: true 追加 2026-07-14

### DIFF
--- a/.github/workflows/ai-tool-watch.yml
+++ b/.github/workflows/ai-tool-watch.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: ai-tool-watch
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-07-14 ci-audit: 手動dispatch×schedule重複時の旧run即キャンセル
 
 jobs:
   watch:

--- a/.github/workflows/knowledge-vault-lint.yml
+++ b/.github/workflows/knowledge-vault-lint.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: knowledge-vault-lint
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-07-14 ci-audit: 週次lint二重実行防止
 
 permissions:
   contents: write


### PR DESCRIPTION
## 変更概要

CI/CD コスト監査 (2026-07-14) による低リスク自動最適化。

| ファイル | 変更 | 推定削減効果 |
|---------|------|------------|
| `ai-tool-watch.yml` | `cancel-in-progress: false → true` | 手動dispatch × schedule 重複時に旧 run を即キャンセル (~40 ubuntu-min/月) |
| `knowledge-vault-lint.yml` | `cancel-in-progress: false → true` | 週次 lint 二重実行防止 (~40 ubuntu-min/月) |

**合計: ~80 ubuntu-min/月 削減**

## 安全性確認

- deploy 系ワークフロー: **変更なし**
- secrets / permissions / トリガー種別: **変更なし**
- YAML 構文検証: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` → **yaml ok**
- 変更対象は schedule cron のみのワークフロー。cancel-in-progress: true にしても、scheduled run が手動 dispatch と重複しない限り発動しない。

## 監査レポート

`docs/ci-cd-audit/2026-07-14.md` (main への別コミット) に全詳細。

## 過去6週累計削減実績

| 日付 | 内容 |
|------|------|
| 2026-06-10 | notion/memory/cs-check 毎時→2h (1,080 runs/月削減) |
| 2026-06-15 | health-monitor 毎時→2h (360 runs/月) |
| 2026-06-22 | ai-university 2h→4h (180 runs/月) |
| 2026-07-03 | issue-to-wbs 4h→6h (~690 min/月) |
| 2026-07-04 | wbs-ai-review 2h→4h (~540 min/月) |
| 2026-07-06 | claude-hygiene + x-metrics (~528 min/月) |
| **2026-07-14** | **cancel-in-progress: true × 2本 (~80 min/月)** |

**累積: ~3,930 ubuntu換算min/月超 削減達成**

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfRMpnRj3fdMD38eMzR94c)_