### PR TITLE
ci(dependabot): flutter_native_splash を依存ごと ignore し pub group の隔週赤を止める

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,7 +89,13 @@ updates:
       # Flutter stable (3.38.x) は flutter_test が meta 1.17.0 を pin しており
       # group 全体の `flutter pub get` が version solving fail になる
       # (Issue #3209 / #3211 / 2026-06-02 #3057 から週次再発)。
-      # 解除条件: CI の Flutter stable が meta >=1.18.0 を同梱したらこの 2 行を削除。
+      #
+      # 2026-07-14: `versions: [">=2.4.8"]` 修飾付き ignore (2026-06-11 #3214) は
+      # 効いておらず、pubspec 側の上限 pin `">=2.4.7 <2.4.8"` (2026-06-22
+      # 7108258f4) も dependabot が pin ごと `^2.4.8` へ広げる提案を出すため
+      # 素通り。結果 #3606 / #3827 が赤で close、#3986 も同じ経路を辿った。
+      # → versions 修飾を外し「この依存の更新提案自体を出さない」形にする。
+      # 解除条件: CI の Flutter stable が meta >=1.18.0 を同梱したらこの entry を
+      # 削除し、pubspec の上限 pin も `^2.4.8` 以降へ戻す。
       - dependency-name: "flutter_native_splash"
-        versions: [">=2.4.8"]
     rebase-strategy: "auto"


### PR DESCRIPTION
## Summary

#3986 の棚卸しで、**「恒久解消」したはずの対策が 2 段とも効いていない**ことが判明したので根本を直す。

### 経緯 (証拠)

| 対策 | 日付 | 結果 |
|---|---|---|
| dependabot ignore `versions: [">=2.4.8"]` ([#3214](https://github.com/kanta13jp1/my_web_app/pull/3214)) | 2026-06-11 | ❌ 素通り |
| pubspec 上限 pin `">=2.4.7 <2.4.8"` (`7108258f4`) | 2026-06-22 | ❌ dependabot が pin ごと `^2.4.8` へ広げる提案を出す |

その結果、ignore 追加後も pub group PR に `flutter_native_splash 2.4.8` が再発し続けている:

| PR | 作成 | 状態 |
|----|------|------|
| #3606 | 06-22 | 赤 → **CLOSED** |
| #3705 | 06-29 | native_splash 無し → merged ✅ |
| #3827 | 07-06 | 赤 → **CLOSED** |
| #3986 | 07-12 | 赤 → 滞留中 |

隔週で「提案 → CI 赤 → 人手で close」を繰り返しており、純粋な浪費になっている。

### 失敗の中身

`flutter_native_splash 2.4.8` は `meta ^1.18.0` を要求するが、CI の Flutter 3.38.x は `flutter_test` が `meta 1.17.0` を pin。よって **group 全体の `flutter pub get` が version solving fail** し、1 パッケージが 14 更新の group ごと道連れにする。

```
Because every version of flutter_test from sdk depends on meta 1.17.0
and flutter_native_splash 2.4.8 depends on meta ^1.18.0,
flutter_test from sdk is incompatible with flutter_native_splash 2.4.8.
So, because my_web_app depends on both, version solving failed.
```

### 変更

`versions:` 修飾を外し、**当該依存の更新提案自体を出さない**形にする。

```yaml
- dependency-name: "flutter_native_splash"   # versions 修飾なし = 全更新を ignore
```

解除条件 (CI の Flutter stable が meta >=1.18.0 を同梱したら entry 削除 + pubspec pin も戻す) をコメントに明記。

`python -c "yaml.safe_load(...)"` でパース検証済み。

## Minimal E2E Gate

- E2E-Exception: dependabot 設定のみの変更でアプリコード・runtime 非関与 → `no-e2e-needed` label。

🤖 Generated with [Claude Code](https://claude.com/claude-code)