### PR TITLE
fix(x-share): R24e 給料日未設定の行き止まりを解消 — その場で設定して投稿へ続行

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -20402,10 +20402,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     if (!_salaryDayConfigured) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('先に給料日を保存してください（既定値のままでは投稿しません）')),
-      );
-      return;
+      // R24e: 行き止まりにせず、その場で給料日設定ダイアログを開いて続行する。
+      await _showSalaryDayDialog();
+      if (!mounted) return;
+      if (!_salaryDayConfigured) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('給料日を保存すると週次投稿を有効化できます（既定値では投稿しません）')),
+        );
+        return;
+      }
     }
 
     final nextEnabled = !_householdTrackerAutoPostEnabled;
@@ -20519,10 +20524,15 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       return;
     }
     if (!_salaryDayConfigured) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('先に給料日を保存してください（既定値は実測として投稿しません）')),
-      );
-      return;
+      // R24e: 行き止まりにせず、その場で給料日設定ダイアログを開いて続行する。
+      await _showSalaryDayDialog();
+      if (!mounted) return;
+      if (!_salaryDayConfigured) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('給料日を保存すると投稿できます（既定値は実測として投稿しません）')),
+        );
+        return;
+      }
     }
     final snapshot = _householdTrackerSnapshot(insights);
     final confirmed = await showDialog<bool>(


### PR DESCRIPTION
## 概要

ユーザー実機報告: 資産ページ AppBar の家計トラッカー共有ボタン (R24d / #4027) を押したが投稿できず、画面下部に「先に給料日を保存してください（既定値は実測として投稿しません）」とだけ出て**どこで保存すればよいか分からない行き止まり**になっていた。

給料日ゲート自体は正しい規律 (公開スコアボードの「給料日まであとN日」を既定値のまま実測として出さない) なので**維持**し、案内の行き止まりだけを解消する。

## 変更内容 (Dart 1 ファイル / +18 -8)

- `lib/pages/asset_management_page.dart`
  - `_postHouseholdTracker`: 給料日未設定なら早期リターンせず `_showSalaryDayDialog()` をその場で開く → 保存されたらそのまま投稿プレビューへ続行。キャンセル時のみ「給料日を保存すると投稿できます（既定値は実測として投稿しません）」を表示して終了
  - `_toggleHouseholdTrackerSchedule` (週次投稿トグル): 同様に行き止まりを解消

## 正当性の確認

- `_setSalaryDay` は `setState` 内で `_salaryDayConfigured = true` を**同期的に**セットする (await より前)。保存ボタンは `Navigator.pop()` → `unawaited(_setSalaryDay(day))` の順で、`await _showSalaryDayDialog()` の再開前に同期実行されるため、直後の `_salaryDayConfigured` 判定は保存結果を正しく反映する
- await 後は `if (!mounted) return;` でガードしてから `context` を使用 (use_build_context_synchronously 準拠)
- ゲートは明示保存でのみ通過。既定値のままでは投稿されない誠実性規律は不変。投稿前の確認プレビューも従来どおり
- 公開値は件数・日数・方向のみ (円金額なし) の規律も不変

## テスト

- `flutter analyze lib/pages/asset_management_page.dart` clean (No issues found)
- `dart format` fixpoint (0 changed)
- 合成ロジック本体は既存 `test/services/household_tracker_share_service_test.dart` 4 件緑でカバー済み

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Dialog-continuation UX fix in a 28k-line page with web-only JS interop; the composer it guards is covered by 4 green VM tests in test/services/household_tracker_share_service_test.dart; flutter analyze clean and format fixpoint verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
