### PR TITLE
fix(x-report): avoid production statement timeout

### DIFF
--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -274,7 +274,7 @@ async function listXPostLogs(
     query = query.filter("metadata->>user_id", "eq", userId);
   }
   const { data, error } = await query;
-  if (error) throw new Error(error.message);
+  if (error) throw new Error(`x_post_logs: ${error.message}`);
   return data ?? [];
 }
 
@@ -294,7 +294,7 @@ async function listXHistoricalBenchmarkLogs(
     query = query.filter("metadata->>user_id", "eq", userId);
   }
   const { data, error } = await query;
-  if (error) throw new Error(error.message);
+  if (error) throw new Error(`x_historical_benchmarks: ${error.message}`);
   return data ?? [];
 }
 
@@ -311,7 +311,10 @@ async function listXMetricSnapshots(
   }> = [];
   // Snapshot volume can exceed PostgREST's usual 1,000-row response limit.
   // Page by bounded source-log batches so early post-age windows are retained.
-  const batchSize = 50;
+  // Metrics collection stops after seven days. Ten posts therefore fit in a
+  // single 1,000-row page under the normal three-hour collection cadence, and
+  // keep each PostgREST statement small enough for the production timeout.
+  const batchSize = 10;
   const pageSize = 1000;
   const maxPagesPerBatch = 10;
   for (let offset = 0; offset < sourceLogIds.length; offset += batchSize) {
@@ -336,7 +339,13 @@ async function listXMetricSnapshots(
         query = query.filter("metadata->>user_id", "eq", userId);
       }
       const { data, error } = await query;
-      if (error) throw new Error(error.message);
+      if (error) {
+        throw new Error(
+          `x_metric_snapshots(batch=${
+            Math.trunc(offset / batchSize)
+          },page=${page}): ${error.message}`,
+        );
+      }
       const pageRows = (data ?? []) as typeof rows;
       rows.push(...pageRows);
       if (pageRows.length < pageSize) break;
@@ -1223,6 +1232,31 @@ async function buildXPerformanceContext(
   ] as XPostLogItem[];
   const normalized = await loadNormalizedXMetricWindows(admin, userId, logs);
   return buildXPerformanceContextFromLogs(logs, normalized);
+}
+
+async function buildXGrowthDataReportContext(
+  admin: SupabaseClient,
+  userId: string,
+  rawLimit: unknown,
+) {
+  const limit = Math.max(
+    10,
+    Math.min(100, Math.trunc(firstNumber(rawLimit) ?? 50)),
+  );
+  // The weekly report excludes historical benchmark rows before composing its
+  // copy. Loading them through the generic performance context made the cron
+  // scan old x_post_log rows for data it immediately discarded.
+  const recentLogs = (await listXPostLogs(
+    admin,
+    userId,
+    limit,
+  )) as XPostLogItem[];
+  const normalized = await loadNormalizedXMetricWindows(
+    admin,
+    userId,
+    recentLogs,
+  );
+  return buildXPerformanceContextFromLogs(recentLogs, normalized);
 }
 
 async function buildScheduledHouseholdTrackerReport(
@@ -2346,7 +2380,7 @@ serve(async (req: Request) => {
         // (read-only / LLM 非使用 / 数値は全て x_post_log 実測)。実測 3 件
         // 未満は available:false で投稿見送りを指示する。
         const scopeUserId = await xReadScopeUserId(admin, userId!);
-        const perf = await buildXPerformanceContext(
+        const perf = await buildXGrowthDataReportContext(
           admin,
           scopeUserId,
           body.limit ?? 100,

--- a/supabase/migrations/20260716093000_index_x_post_log_historical_service_role.sql
+++ b/supabase/migrations/20260716093000_index_x_post_log_historical_service_role.sql
@@ -1,0 +1,11 @@
+-- Keep the service-role X performance query on an ordered partial index.
+--
+-- The existing index is (learning_cohort, user_id, created_at). Cron requests
+-- intentionally do not constrain user_id, so PostgreSQL cannot use that index
+-- to satisfy ORDER BY created_at DESC. Historical benchmark rows are old and
+-- sparse, which otherwise makes the query scan recent x_post_log rows until it
+-- reaches statement_timeout.
+CREATE INDEX IF NOT EXISTS idx_hub_data_x_post_log_historical_created
+  ON public.hub_data (created_at DESC)
+  WHERE source = 'x_post_log'
+    AND metadata->>'learning_cohort' = 'historical_benchmark';


### PR DESCRIPTION
## Summary
- use a report-specific X performance context that skips historical benchmark rows the weekly report discards
- load metric snapshots in smaller batches while preserving the 3h/24h/72h comparison windows
- label database errors by query stage for actionable production diagnostics
- add a partial index for service-role historical benchmark ordering

## Root cause
`x.growth_data_report` reused the generic performance-context loader. It queried unused historical benchmark data and fetched large snapshot batches. The service-role historical lookup also lacked an index matching its `created_at DESC` access path, causing the production statement timeout.

## Impact
The report retains the same normalized 3h/24h/72h metrics and output quality. The change only reduces unnecessary database work and makes any remaining timeout identify its exact query stage.

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: this is a backend query-plan optimization with no UI or public request contract change; focused integration tests and the production dry-run exercise the same report path.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: the opt-in workflow has no pull-request context on workflow_dispatch, so it cannot perform a real PR ultrareview; focused local and CI review plus a duplicate-guarded production dry-run are used instead.
- Security: no auth, secret, RLS, or public API contract changes; existing service-role access remains unchanged.
- Rollback: revert the Edge Function commit; the new partial index is additive and can remain safely or be dropped separately.
- Prod smoke: deploy migration and Edge Function, then run `x-growth-data-report-post.yml` with `dry_run=true` and `force=true`; require HTTP 200 before any public post.
- Observability: database failures now identify `x_post_logs`, historical benchmarks, or the exact snapshot batch/page.
- Unresolved findings: none from focused local review and repository CI.

## Validation
- `deno fmt --check supabase/functions/growth-hub/index.ts`
- `deno lint` and `deno check`
- focused X report/window tests: 14 passed
- migration timestamp check
- pre-commit quality gate
- full pre-push gate: Flutter analyze and VM tests, Deno tests (465 passed, 0 failed)

## Production verification
After merge and deployment, dispatch `x-growth-data-report-post.yml` with `dry_run=true` and `force=true`. Require HTTP 200 before considering any public X post.