### PR TITLE
[CI/CD自動最適化] schedule-resilience-watch cancel-in-progress fix 2026-07-16

### DIFF
--- a/.github/workflows/schedule-resilience-watch.yml
+++ b/.github/workflows/schedule-resilience-watch.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: schedule-resilience-watch
-  cancel-in-progress: false
+  cancel-in-progress: true  # 2026-07-16 ci-audit: 4h毎モニタリングのキュー積み防止
 
 jobs:
   watch:


### PR DESCRIPTION
## 変更概要

`schedule-resilience-watch.yml` の `concurrency.cancel-in-progress` を `false` → `true` に変更。

### 変更理由

- 4h 毎 (180 runs/月) スケジュール実行ワークフロー
- GitHub API 遅延でスタックした場合、次の 4h 実行がキューに積まれる問題
- モニタリング専用 (gh run rerun 呼び出しのみ) で非破壊的 → cancel-in-progress: true が安全
- ホワイトリスト該当: 「deploy 以外の workflow への concurrency(cancel-in-progress: true) 追加」

### 推定削減効果

- キュー積み防止: 長時間スタック時に次サイクル (4h後) が待機状態にならない
- 滞留ジョブによる GitHub Actions 分消費を防止

### 監査レポート

詳細: `docs/ci-cd-audit/2026-07-16.md`

関連 Issue: #3841

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CI workflow YAML-only 1-line concurrency change; no app code or user-facing surface changed, existing e2e-smoke suite already covers the app.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: YAML-only 1-line concurrency change to a non-deploy monitoring workflow; secrets / permissions / triggers untouched; fully reversible.

<!-- gate re-run 2026-07-17: 前回 run は GitHub API 503 (一過性) で deterministic CI 確認が失敗。CI 本体は全て green 済み -->

---
*自動生成: Claude Schedule CI/CD コスト監査 2026-07-16*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk5XD7et558Y43xs1qo6Fc)_