### PR TITLE
ci: bump github-actions group (setup-cli v2→v3, slack-action v3.0.3→v3.0.5) [#3997 手動再現]

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -71,7 +71,7 @@ jobs:
 
       # Supabase Migration (Development)
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v2
+        uses: supabase/setup-cli@v3
         with:
           version: 2.84.2
 
@@ -219,7 +219,7 @@ jobs:
       - name: Notify Slack on success
         if: needs.deploy.result == 'success'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@v3.0.5
         with:
           payload: |
             {
@@ -278,7 +278,7 @@ jobs:
       - name: Notify Slack on failure
         if: needs.deploy.result == 'failure'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@v3.0.5
         with:
           payload: |
             {

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -125,7 +125,7 @@ jobs:
         run: python scripts/check_migration_timestamps.py
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v2
+        uses: supabase/setup-cli@v3
         with:
           version: 2.84.2
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -76,7 +76,7 @@ jobs:
 
       # Supabase Migration (Staging)
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v2
+        uses: supabase/setup-cli@v3
         with:
           version: 2.84.2
 
@@ -209,7 +209,7 @@ jobs:
       - name: Notify Slack on success
         if: needs.deploy.result == 'success'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@v3.0.5
         with:
           payload: |
             {
@@ -230,7 +230,7 @@ jobs:
       - name: Notify Slack on failure
         if: needs.deploy.result == 'failure'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@v3.0.5
         with:
           payload: |
             {


### PR DESCRIPTION
## Summary

dependabot の github-actions group PR #3997 が admin merge 時の `Base branch was modified` race + `--delete-branch` でブランチごと誤 close されたため、同一変更を手動再現。**ユーザー承認済み**。

### 変更 (元 #3997 と同一)
- `supabase/setup-cli@v2 → v3` (deploy-dev / deploy-prod / deploy-staging)
- `slackapi/slack-github-action@v3.0.3 → v3.0.5` (deploy-dev / deploy-staging)

### v3 互換の実証 (probe workflow / 実行後削除済み)
| v3 breaking change | 自社影響 |
|---|---|
| CLI を GitHub releases → npm から取得 | pinned `2.84.2` は npm に存在 → probe で解決・起動を実証 (`PROBE_OK`) |
| `github-token` input 削除 | 自社 3 workflow 未使用 → 影響なし |
| musl/Alpine 対応 | 全 runner `ubuntu-latest` (glibc) → 非該当 |

`supabase link` / `migration up` は CLI 本体 (2.84.2 で不変) の機能で、setup step が同じ CLI を用意する以上挙動は変わらない。**念のため初回 deploy-prod 実行の結果は確認推奨**。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: github-actions version bump only (setup-cli v3 empirically verified to resolve pinned 2.84.2 via npm; github-token unused; ubuntu runner); no deploy logic or migration content changed

## Minimal E2E Gate

- E2E-Exception: GitHub Actions のバージョン bump のみ。アプリコード・runtime 非関与 → `no-e2e-needed` label。