### PR TITLE
feat(asset): 支払原資口座の不足先読み警告とカード明細照合の解消アクション

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -1047,6 +1047,41 @@ class AssetLiabilityCardStatementImportResult {
   bool get hasRejectedRows => rejectedRows.isNotEmpty;
 }
 
+/// 明細照合の差分をユーザーがその場で解消するための修正アクション種別。
+enum AssetLiabilityCardStatementFixActionKind {
+  /// カード明細を貼り付けて取り込む（明細未取込）。
+  importStatement,
+
+  /// 設定済みカード内訳（支払い方式・今月支払予定額）を見直す。
+  adjustConfiguredBreakdown,
+
+  /// 取込済み明細と請求額の差分行を確認する。
+  reviewStatementLines,
+
+  /// 請求先カード口座が見つからないため再設定する。
+  assignBillingAccount,
+}
+
+/// 明細照合アラートに対応する具体的な修正アクション。
+/// アラート文字列だけでは「次に何をすればよいか」が分からないため、
+/// 差分金額と操作内容をセットで planning service が算出する。
+class AssetLiabilityCardStatementFixAction {
+  final AssetLiabilityCardStatementFixActionKind kind;
+  final String title;
+  final String description;
+
+  /// 解消すべき差分金額（+は請求額超過 / −は不足）。差分が定義できない
+  /// アクション（明細未取込など）は null。
+  final double? amount;
+
+  const AssetLiabilityCardStatementFixAction({
+    required this.kind,
+    required this.title,
+    required this.description,
+    this.amount,
+  });
+}
+
 class AssetLiabilityCardStatementReconciliationGroup {
   final String billingAccountId;
   final String billingAccountName;
@@ -1056,6 +1091,9 @@ class AssetLiabilityCardStatementReconciliationGroup {
   final List<AssetLiabilityCardBillingReviewItem> configuredItems;
   final List<AssetLiabilityCardStatementLine> statementLines;
   final List<String> alerts;
+
+  /// アラートを解消するための修正アクション（planning service が算出）。
+  final List<AssetLiabilityCardStatementFixAction> fixActions;
 
   /// リボ払いカードの場合の今月請求内訳。null なら通常の一括払いカード。
   /// リボ払いでは 請求額 ≠ 明細合計 が正常なため、不一致アラートは抑止する。
@@ -1070,6 +1108,7 @@ class AssetLiabilityCardStatementReconciliationGroup {
     required this.configuredItems,
     required this.statementLines,
     required this.alerts,
+    this.fixActions = const <AssetLiabilityCardStatementFixAction>[],
     this.revolvingBilling,
   });
 
@@ -1077,6 +1116,14 @@ class AssetLiabilityCardStatementReconciliationGroup {
   double get configuredDifference => configuredDetailTotal - billedAmount;
   bool get hasStatementLines => statementLines.isNotEmpty;
   bool get needsReview => alerts.isNotEmpty;
+  bool get hasFixActions => fixActions.isNotEmpty;
+
+  /// 設定済み内訳合計が請求額とずれているか（＝内訳の修正が必要か）。
+  bool get hasConfiguredMismatchFix => fixActions.any(
+        (action) =>
+            action.kind ==
+            AssetLiabilityCardStatementFixActionKind.adjustConfiguredBreakdown,
+      );
 
   /// リボ払いカードか。
   bool get isRevolving => revolvingBilling != null;

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -391,6 +391,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   int _forecastHorizonMonths = 6;
   // カード明細取り込み・照合パネルへのスクロール用 (AIコメントからのジャンプ)。
   final _keyCardStatementReconciliation = GlobalKey();
+  // 口座間移動の提案セクションへのスクロール用 (残高不足バナーからのジャンプ)。
+  final _keyTransferSuggestionSection = GlobalKey();
 
   Timer? _deadlineTimer;
   DateTime _now = DateTime.now();
@@ -1137,6 +1139,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   void _jumpToCardStatementReconciliation() {
     _scrollTo(_keyCardStatementReconciliation);
+  }
+
+  void _jumpToTransferSuggestionSection() {
+    _scrollTo(_keyTransferSuggestionSection);
   }
 
   List<String> _paymentSourceCandidates() {
@@ -8411,6 +8417,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ],
             _buildSyncStatusBanner(),
             _buildUnsyncedBadgeRow(),
+            _buildAccountShortfallAlertBanner(assetLiabilityWorkbook),
             _buildAutoDebitConfirmationCard(assetLiabilityWorkbook),
             _buildSalaryDepositNudgeCard(assetLiabilityWorkbook),
             const SizedBox(height: 12),
@@ -13093,6 +13100,147 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  /// 支払原資口座の見込み残高不足を先読みしてページ最上部に警告する。
+  /// 全体の使用可能額が黒字でも口座割り当て次第で引き落とし失敗が起きるため、
+  /// 不足口座・不足額・解消のための口座移動提案とタスク化導線をセットで出す。
+  Widget _buildAccountShortfallAlertBanner(AssetLiabilityWorkbook? workbook) {
+    if (workbook == null || !workbook.hasAccountShortage) {
+      return const SizedBox.shrink();
+    }
+    final summaries = workbook.shortAccountSummaries
+      ..sort((a, b) => b.shortfall.compareTo(a.shortfall));
+    // 不足口座を移動先とする提案を紐付ける（同一移動先は先勝ち）。
+    final suggestionsByAccountId = <String, AssetLiabilityTransferSuggestion>{};
+    for (final suggestion in workbook.transferSuggestions) {
+      suggestionsByAccountId.putIfAbsent(
+        suggestion.toAccountId,
+        () => suggestion,
+      );
+    }
+    return Container(
+      key: const Key('asset_account_shortfall_banner'),
+      width: double.infinity,
+      margin: const EdgeInsets.only(top: 8, bottom: 12),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFEF2F2),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0xFFFECACA)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.warning_amber_rounded,
+                size: 16,
+                color: Color(0xFFB91C1C),
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  '支払原資口座の残高不足見込み（${summaries.length}口座）',
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFFB91C1C),
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          for (final summary in summaries.take(3)) ...[
+            Text(
+              '「${summary.accountName}」が${_formatManagementYen(summary.shortfall)}不足'
+              '（支払後見込み ${_formatManagementYen(summary.projectedBalance)}）',
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: Color(0xFFB91C1C),
+                height: 1.5,
+              ),
+            ),
+            if (suggestionsByAccountId[summary.accountId] case final suggestion?)
+              Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Text(
+                    '${suggestion.fromAccountName} → ${summary.accountName} '
+                    '${_formatManagementYen(suggestion.amount)}'
+                    '${suggestion.neededBy == null ? '' : '（${DateFormat('M月d日').format(suggestion.neededBy!)}まで）'}',
+                    // 背景が固定の淡赤のため、ダークテーマの onSurface(白)だと
+                    // 読めなくなる。文字色も固定の濃赤系にする。
+                    style: const TextStyle(
+                      fontSize: 11,
+                      color: Color(0xFF7F1D1D),
+                      height: 1.5,
+                    ),
+                  ),
+                  TextButton.icon(
+                    key: Key(
+                      'asset_account_shortfall_create_task_${summary.accountId}',
+                    ),
+                    style: TextButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      foregroundColor: const Color(0xFFB91C1C),
+                    ),
+                    onPressed: () =>
+                        _createTransferTaskFromSuggestion(suggestion),
+                    icon: const Icon(Icons.swap_horiz_rounded, size: 16),
+                    label: const Text('移動タスクを作成'),
+                  ),
+                ],
+              )
+            else
+              Text(
+                '移動元の候補が見つかりません。入金予定の登録または他口座からの出金で'
+                '${_formatManagementYen(summary.shortfall)}以上を確保してください。',
+                style: const TextStyle(
+                  fontSize: 11,
+                  color: Color(0xFF7F1D1D),
+                  height: 1.5,
+                ),
+              ),
+            const SizedBox(height: 4),
+          ],
+          if (summaries.length > 3)
+            Text(
+              'ほか${summaries.length - 3}口座で不足見込みがあります。口座別資金繰りを確認してください。',
+              style: const TextStyle(
+                fontSize: 11,
+                color: Color(0xFF7F1D1D),
+                height: 1.5,
+              ),
+            ),
+          // ジャンプ先の口座間移動セクションは workbookBoard 内にあり、表示
+          // モード次第で非描画になる。その場合スクロールが silent no-op に
+          // なるため、ボタン自体を出さない（タスク化ボタンは常に使える）。
+          if (_isSectionShown(AssetManagementSectionId.workbookBoard))
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                key: const Key('asset_account_shortfall_jump'),
+                style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  foregroundColor: const Color(0xFFB91C1C),
+                ),
+                onPressed: _jumpToTransferSuggestionSection,
+                icon: const Icon(Icons.arrow_downward, size: 16),
+                label: const Text('口座間移動の提案へ移動'),
+              ),
+            ),
+        ],
       ),
     );
   }
@@ -17929,7 +18077,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             const SizedBox(height: 16),
             _buildMonthlyReportSection(),
             const SizedBox(height: 16),
-            _buildTransferSuggestionSection(workbook),
+            KeyedSubtree(
+              key: _keyTransferSuggestionSection,
+              child: _buildTransferSuggestionSection(workbook),
+            ),
             const SizedBox(height: 16),
             _buildAssetWorkbookDebtTable(workbook),
             const SizedBox(height: 16),
@@ -21374,6 +21525,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         Icons.credit_card_off_outlined,
       AssetManagementInsightActionType.doubleCountingRisk =>
         Icons.difference_outlined,
+      AssetManagementInsightActionType.accountShortfallRisk =>
+        Icons.account_balance_wallet_outlined,
     };
   }
 
@@ -22088,7 +22241,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     AssetLiabilityWorkbook workbook,
   ) {
     final reconciliation = workbook.cardStatementReconciliation;
-    final cardOptions = _cardBillingAccountOptions(workbook);
+    // 照合グループのホストは shoppingDebt も正当（planning service の
+    // isCardBillingHostKind と同じ集合）。creditCard 限定だと解消アクション
+    // からの選択がサイレントに別カードへフォールバックし誤取込を招く。
+    final cardOptions =
+        _cardBillingAccountOptions(workbook, includeShoppingDebt: true);
     final selected = _selectedCardStatementBillingAccountId;
     final validSelected = selected != null &&
         cardOptions.any((account) => account.id == selected);
@@ -22205,9 +22362,106 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           ],
           const SizedBox(height: 10),
           _buildCardStatementReconciliationTable(reconciliation),
+          _buildCardStatementFixActionList(reconciliation, cardOptions),
         ],
       ),
     );
+  }
+
+  /// 照合アラートを「次に何をすればよいか」へ変換した解消アクション一覧。
+  /// 明細取り込みは請求先カードを選択して同パネルの取り込み欄へ、内訳修正は
+  /// 負債マスタの該当カード行へ誘導する。
+  Widget _buildCardStatementFixActionList(
+    AssetLiabilityCardStatementReconciliationData reconciliation,
+    List<AssetLiabilityAccount> cardOptions,
+  ) {
+    final groups = reconciliation.groups
+        .where((group) => group.hasFixActions)
+        .toList(growable: false);
+    if (groups.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final selectableCardIds = <String>{
+      for (final account in cardOptions) account.id,
+    };
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 10),
+        const Text(
+          '差分の解消アクション',
+          style: TextStyle(fontWeight: FontWeight.bold, height: 1.4),
+        ),
+        const SizedBox(height: 4),
+        for (final group in groups) ...[
+          Text(
+            group.billingAccountName,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              height: 1.6,
+            ),
+          ),
+          for (final action in group.fixActions) ...[
+            Text(
+              action.description,
+              style: TextStyle(
+                fontSize: 11,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                height: 1.5,
+              ),
+            ),
+            if (_cardStatementFixActionHandler(group, action, selectableCardIds)
+                case final onPressed?)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  key: Key(
+                    'asset_card_recon_fix_${action.kind.name}_${group.billingAccountId}',
+                  ),
+                  style: TextButton.styleFrom(
+                    visualDensity: VisualDensity.compact,
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    foregroundColor: const Color(0xFFD97706),
+                  ),
+                  onPressed: onPressed,
+                  icon: const Icon(Icons.build_circle_outlined, size: 16),
+                  label: Text(action.title),
+                ),
+              ),
+          ],
+          const SizedBox(height: 4),
+        ],
+      ],
+    );
+  }
+
+  /// 修正アクション種別ごとの実行ハンドラ。導線を用意できない種別は null
+  /// (説明文のみ表示)。
+  VoidCallback? _cardStatementFixActionHandler(
+    AssetLiabilityCardStatementReconciliationGroup group,
+    AssetLiabilityCardStatementFixAction action,
+    Set<String> selectableCardIds,
+  ) {
+    return switch (action.kind) {
+      // 取り込み欄の請求先カードを該当カードへ切り替え、貼り付けを促す。
+      // ドロップダウン候補に無いホストはサイレントに先頭カードへフォール
+      // バックして誤取込を招くため、ボタン自体を出さない。
+      AssetLiabilityCardStatementFixActionKind.importStatement
+          when selectableCardIds.contains(group.billingAccountId) =>
+        () {
+          setState(() {
+            _selectedCardStatementBillingAccountId = group.billingAccountId;
+            _cardStatementImportMessage =
+                '${group.billingAccountName}を選択しました。カード明細を貼り付けて「明細を取り込む」を押してください。';
+          });
+        },
+      AssetLiabilityCardStatementFixActionKind.importStatement => null,
+      AssetLiabilityCardStatementFixActionKind.adjustConfiguredBreakdown =>
+        () => _jumpToDebtMasterCard(group.billingAccountId),
+      AssetLiabilityCardStatementFixActionKind.reviewStatementLines => null,
+      AssetLiabilityCardStatementFixActionKind.assignBillingAccount => null,
+    };
   }
 
   /// 照合行の「確認事項」表示文。リボ払いカードは不一致アラートの代わりに
@@ -22264,7 +22518,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 DataCell(Text(_formatManagementYen(group.billedAmount))),
                 DataCell(Text(_formatManagementYen(group.statementLineTotal))),
                 DataCell(
-                  Text(_formatManagementYen(group.configuredDetailTotal)),
+                  Text(
+                    _formatManagementYen(group.configuredDetailTotal),
+                    // 設定内訳のずれ（設定差分）は差額列(明細合計基準)に出ない
+                    // ため、セル自体を強調して気付けるようにする。
+                    style: group.hasConfiguredMismatchFix
+                        ? const TextStyle(
+                            color: Color(0xFFD97706),
+                            fontWeight: FontWeight.bold,
+                          )
+                        : null,
+                  ),
                 ),
                 DataCell(
                   group.isRevolving

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -13167,7 +13167,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 height: 1.5,
               ),
             ),
-            if (suggestionsByAccountId[summary.accountId] case final suggestion?)
+            if (suggestionsByAccountId[summary.accountId]
+                case final suggestion?)
               Wrap(
                 spacing: 8,
                 runSpacing: 4,

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -86,6 +86,10 @@ class AssetLiabilityPlanningService {
       '設定済みカード内訳合計が請求額と一致しません';
   static const String cardStatementImportedConfiguredMismatchAlert =
       '取り込み明細合計が設定済み内訳合計と一致しません';
+  static const String cardStatementFixImportLabel = 'カード明細を取り込む';
+  static const String cardStatementFixAdjustBreakdownLabel = '設定内訳を修正する';
+  static const String cardStatementFixReviewLinesLabel = '取込明細を確認する';
+  static const String cardStatementFixAssignBillingLabel = '請求先カードを再設定する';
   static const String auCardBillingNotice =
       'auはauPayカード払いのため、資金繰りではauPayカード請求に含めて扱います。';
   static const String kddiProviderAccountId = 'kddi_provider';
@@ -1172,23 +1176,71 @@ class AssetLiabilityPlanningService {
       final revolvingBilling = billingRow?.revolvingBilling;
       final isRevolving = revolvingBilling != null;
       final alerts = <String>[];
+      // アラートは「何がずれているか」しか伝えないため、対応する修正
+      // アクション（何をすれば解消するか＋差分金額）を同時に算出する。
+      final fixActions = <AssetLiabilityCardStatementFixAction>[];
 
       if (billingRow == null) {
         alerts.add(cardStatementBillingAccountMissingAlert);
+        fixActions.add(
+          const AssetLiabilityCardStatementFixAction(
+            kind: AssetLiabilityCardStatementFixActionKind.assignBillingAccount,
+            title: cardStatementFixAssignBillingLabel,
+            description: '請求先カード口座が見つかりません。負債マスタで請求先カードを選び直してください。',
+          ),
+        );
       }
       if (!isRevolving && lines.isEmpty && group != null) {
         alerts.add(cardStatementMissingImportAlert);
+        // 請求先カード口座が無い(billingRow == null)場合、請求額はプレース
+        // ホルダ0のため取り込みより先に請求先の再設定(assignBillingAccount)
+        // を促す。取り込みアクションは請求額が実在するときだけ出す。
+        if (billingRow != null) {
+          fixActions.add(
+            AssetLiabilityCardStatementFixAction(
+              kind: AssetLiabilityCardStatementFixActionKind.importStatement,
+              title: cardStatementFixImportLabel,
+              description: 'カード明細を貼り付けて取り込むと、'
+                  '請求額${_formatFixActionAbsoluteYen(billedAmount)}と内訳の照合ができます。',
+            ),
+          );
+        }
       }
       if (!isRevolving &&
           lines.isNotEmpty &&
           _moneyDiffers(statementLineTotal, billedAmount)) {
         alerts.add(cardStatementAmountMismatchAlert);
+        if (billingRow != null) {
+          fixActions.add(
+            AssetLiabilityCardStatementFixAction(
+              kind:
+                  AssetLiabilityCardStatementFixActionKind.reviewStatementLines,
+              title: cardStatementFixReviewLinesLabel,
+              description: '取込明細合計が請求額と'
+                  '${_formatFixActionYen(statementLineTotal - billedAmount)}'
+                  'ずれています。取り込み漏れ・重複行・対象月違いの明細を確認してください。',
+              amount: statementLineTotal - billedAmount,
+            ),
+          );
+        }
       }
       if (!isRevolving &&
           group != null &&
           billingRow != null &&
           _moneyDiffers(configuredDetailTotal, billedAmount)) {
         alerts.add(cardStatementConfiguredMismatchAlert);
+        fixActions.add(
+          AssetLiabilityCardStatementFixAction(
+            kind: AssetLiabilityCardStatementFixActionKind
+                .adjustConfiguredBreakdown,
+            title: cardStatementFixAdjustBreakdownLabel,
+            description: '設定済みカード内訳合計が請求額と'
+                '${_formatFixActionYen(configuredDetailTotal - billedAmount)}'
+                'ずれています。負債マスタの「支払い方式」で内訳の追加・除外、'
+                '各行の今月支払予定額、またはカード側の請求額を見直してください。',
+            amount: configuredDetailTotal - billedAmount,
+          ),
+        );
       }
       if (!isRevolving &&
           lines.isNotEmpty &&
@@ -1208,6 +1260,7 @@ class AssetLiabilityPlanningService {
               group?.items ?? const <AssetLiabilityCardBillingReviewItem>[],
           statementLines: lines,
           alerts: alerts,
+          fixActions: fixActions,
           revolvingBilling: revolvingBilling,
         ),
       );
@@ -1220,6 +1273,25 @@ class AssetLiabilityPlanningService {
   }
 
   bool _moneyDiffers(double a, double b) => (a - b).abs() >= 0.5;
+
+  /// 修正アクションの説明文に使う符号付き差分円表記（例: +1,853円 / -947円）。
+  String _formatFixActionYen(double value) {
+    return '${value.round() < 0 ? '-' : '+'}'
+        '${_formatFixActionAbsoluteYen(value)}';
+  }
+
+  /// 修正アクションの説明文に使う絶対額の円表記（例: 20,000円）。
+  String _formatFixActionAbsoluteYen(double value) {
+    final digits = value.round().abs().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      if (i > 0 && (digits.length - i) % 3 == 0) {
+        buffer.write(',');
+      }
+      buffer.write(digits[i]);
+    }
+    return '$buffer円';
+  }
 
   int _compareCardStatementLines(
     AssetLiabilityCardStatementLine a,

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -1271,6 +1271,7 @@ class AssetManagementAiSummaryService {
       AssetManagementInsightActionType.emergencyLivingExpense => '生活費の不足',
       AssetManagementInsightActionType.cardBillingConfiguration => 'カード請求設定の確認',
       AssetManagementInsightActionType.doubleCountingRisk => '二重計上リスク',
+      AssetManagementInsightActionType.accountShortfallRisk => '口座別見込み残高の不足',
     };
   }
 

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -15,6 +15,7 @@ enum AssetManagementInsightActionType {
   emergencyLivingExpense,
   cardBillingConfiguration,
   doubleCountingRisk,
+  accountShortfallRisk,
 }
 
 enum AssetManagementInsightSeverity { info, warning, critical }
@@ -85,6 +86,33 @@ class AssetManagementMovementSuggestion {
     required this.neededBy,
     required this.reason,
   });
+}
+
+/// 口座別見込み残高が不足する口座への先読み警告。全体の使用可能額が黒字でも
+/// 支払原資口座の割り当て次第で引き落とし失敗が起きるため、不足口座と
+/// 「どこからいくら動かせば解消するか」(移動提案) をセットで UI へ渡す。
+class AssetManagementAccountShortfallAlert {
+  final String accountId;
+  final String accountName;
+
+  /// 今後の支払予定・入金予定・保留中の口座移動を反映した見込み残高（負値）。
+  final double projectedBalance;
+
+  /// 不足額（正値）。
+  final double shortfallAmount;
+
+  /// 不足を解消できる口座移動提案。移動元候補が無い場合は null。
+  final AssetManagementMovementSuggestion? transferSuggestion;
+
+  const AssetManagementAccountShortfallAlert({
+    required this.accountId,
+    required this.accountName,
+    required this.projectedBalance,
+    required this.shortfallAmount,
+    this.transferSuggestion,
+  });
+
+  bool get hasTransferSuggestion => transferSuggestion != null;
 }
 
 class AssetManagementDeveloperRequest {
@@ -223,6 +251,9 @@ class AssetManagementInsightReport {
   final AssetManagementAvailableMoneyInsight weekAvailable;
   final AssetManagementAvailableMoneyInsight monthAvailable;
   final List<AssetManagementMovementSuggestion> movementSuggestions;
+
+  /// 口座別見込み残高が不足する口座の先読み警告（不足額の大きい順）。
+  final List<AssetManagementAccountShortfallAlert> accountShortfallAlerts;
   final List<AssetManagementEmergencyAdvice> emergencyAdvices;
   final List<AssetManagementDeveloperRequest> developerRequests;
   final List<AssetManagementImplementationContext> implementationContexts;
@@ -241,6 +272,8 @@ class AssetManagementInsightReport {
     required this.weekAvailable,
     required this.monthAvailable,
     required this.movementSuggestions,
+    this.accountShortfallAlerts =
+        const <AssetManagementAccountShortfallAlert>[],
     required this.emergencyAdvices,
     required this.developerRequests,
     this.implementationContexts =
@@ -248,6 +281,8 @@ class AssetManagementInsightReport {
     this.debtTrendInsights = const <AssetDebtTrendInsight>[],
     this.disciplineReport,
   });
+
+  bool get hasAccountShortfallAlerts => accountShortfallAlerts.isNotEmpty;
 
   bool get hasDebtTrendInsights => debtTrendInsights.isNotEmpty;
 
@@ -324,12 +359,17 @@ class AssetManagementInsightService {
       windows: <AssetManagementAvailableMoneyInsight>[today, week, month],
       minimumSafetyBalance: minimumSafetyBalance,
     );
+    final accountShortfallAlerts = _buildAccountShortfallAlerts(
+      workbook: workbook,
+      movementSuggestions: movementSuggestions,
+    );
     final emergencyAdvices = _buildEmergencyAdvices(
       workbook: workbook,
       today: today,
       week: week,
       month: month,
       movementSuggestions: movementSuggestions,
+      accountShortfallAlerts: accountShortfallAlerts,
     );
     final developerRequests = _buildDeveloperRequests(
       workbook: workbook,
@@ -353,6 +393,7 @@ class AssetManagementInsightService {
       weekAvailable: week,
       monthAvailable: month,
       movementSuggestions: movementSuggestions,
+      accountShortfallAlerts: accountShortfallAlerts,
       emergencyAdvices: emergencyAdvices,
       developerRequests: developerRequests,
       implementationContexts: implementationContexts,
@@ -494,6 +535,26 @@ class AssetManagementInsightService {
           paymentDay: today.day,
           suggestedAction:
               '支払いを実行する前に、今日の食費・移動費・医療など最低限の生活費を先に確保し、払えない支払いは支払先へ猶予または分割相談をしてください。',
+        ),
+      );
+    }
+
+    // 口座別見込み残高の不足は、使用可能額(全体)が黒字でも支払原資口座の
+    // 割り当て次第で発生する（例: 現金口座だけが引き落とし分に足りない）。
+    for (final summary in workbook.shortAccountSummaries) {
+      actions.add(
+        AssetManagementInsightActionItem(
+          type: AssetManagementInsightActionType.accountShortfallRisk,
+          severity: AssetManagementInsightSeverity.critical,
+          title: '${summary.accountName}の見込み残高が不足します',
+          description: '今後の支払予定を差し引いた見込み残高が'
+              '${_formatYen(summary.projectedBalance)}となり、'
+              '${_formatYen(summary.shortfall)}不足します。',
+          relatedAccountId: null,
+          dueDate: null,
+          paymentDay: null,
+          suggestedAction:
+              '「口座間移動の提案」から${summary.accountName}への移動タスクを作成し、支払い前に実行してください。',
         ),
       );
     }
@@ -668,19 +729,48 @@ class AssetManagementInsightService {
     required AssetManagementAvailableMoneyInsight week,
     required AssetManagementAvailableMoneyInsight month,
     required List<AssetManagementMovementSuggestion> movementSuggestions,
+    required List<AssetManagementAccountShortfallAlert> accountShortfallAlerts,
   }) {
+    final advices = <AssetManagementEmergencyAdvice>[];
+
+    // 口座別の見込み残高不足は全体ウィンドウが黒字でも起きるため、
+    // ウィンドウ不足の有無に関わらず先頭で警告する。
+    for (final alert in accountShortfallAlerts.take(3)) {
+      final suggestion = alert.transferSuggestion;
+      // 期限は提案の neededBy がある場合のみ断言する（無い期限を捏造しない）。
+      final deadline = suggestion?.neededBy == null
+          ? 'できるだけ早く、'
+          : '${_formatDate(suggestion!.neededBy!)}までに';
+      advices.add(
+        AssetManagementEmergencyAdvice(
+          severity: AssetManagementInsightSeverity.critical,
+          title: '${alert.accountName}の残高不足を先に解消してください',
+          description: '支払予定を差し引くと${alert.accountName}の見込み残高は'
+              '${_formatYen(alert.projectedBalance)}'
+              '（${_formatYen(alert.shortfallAmount)}不足）です。'
+              'このままでは引き落としに失敗します。',
+          suggestedAction: suggestion == null
+              ? '入金予定の登録または他口座からの移動で'
+                  '${_formatYen(alert.shortfallAmount)}以上を確保してから支払いを実行してください。'
+              : '$deadline${suggestion.fromAccountName}から${alert.accountName}へ'
+                  '${_formatYen(suggestion.amount)}を移動してください。'
+                  '「口座間移動の提案」からタスク化すると見込み残高に反映されます。',
+          amount: alert.shortfallAmount,
+        ),
+      );
+    }
+
     final windows = <AssetManagementAvailableMoneyInsight>[today, week, month]
       ..sort((a, b) => a.availableAmount.compareTo(b.availableAmount));
     final worst = windows.first;
     final hasShortage = windows.any((window) => window.availableAmount < 0);
     if (!hasShortage) {
-      return const <AssetManagementEmergencyAdvice>[];
+      return advices;
     }
 
     final nextIncome = _nextIncomePlan(workbook);
     final shortfall =
         worst.availableAmount < 0 ? worst.availableAmount.abs() : 0.0;
-    final advices = <AssetManagementEmergencyAdvice>[];
 
     if (today.availableAmount < 0) {
       advices.add(
@@ -762,6 +852,41 @@ class AssetManagementInsightService {
     );
 
     return advices;
+  }
+
+  /// 口座別見込み残高が不足する口座を不足額の大きい順に並べ、その口座を
+  /// 移動先とする口座移動提案（あれば）を紐付けて返す。
+  List<AssetManagementAccountShortfallAlert> _buildAccountShortfallAlerts({
+    required AssetLiabilityWorkbook workbook,
+    required List<AssetManagementMovementSuggestion> movementSuggestions,
+  }) {
+    final summaries = workbook.shortAccountSummaries
+      ..sort((a, b) => b.shortfall.compareTo(a.shortfall));
+    return <AssetManagementAccountShortfallAlert>[
+      for (final summary in summaries)
+        AssetManagementAccountShortfallAlert(
+          accountId: summary.accountId,
+          accountName: summary.accountName,
+          projectedBalance: summary.projectedBalance,
+          shortfallAmount: summary.shortfall,
+          transferSuggestion: _firstSuggestionForAccount(
+            summary.accountId,
+            movementSuggestions,
+          ),
+        ),
+    ];
+  }
+
+  AssetManagementMovementSuggestion? _firstSuggestionForAccount(
+    String accountId,
+    List<AssetManagementMovementSuggestion> suggestions,
+  ) {
+    for (final suggestion in suggestions) {
+      if (suggestion.toAccountId == accountId) {
+        return suggestion;
+      }
+    }
+    return null;
   }
 
   AssetLiabilityIncomePlan? _nextIncomePlan(AssetLiabilityWorkbook workbook) {
@@ -1742,6 +1867,7 @@ class AssetManagementInsightPromptBuilder {
       AssetManagementInsightActionType.emergencyLivingExpense => '生活費の不足',
       AssetManagementInsightActionType.cardBillingConfiguration => 'カード請求設定の確認',
       AssetManagementInsightActionType.doubleCountingRisk => '二重計上リスク',
+      AssetManagementInsightActionType.accountShortfallRisk => '口座別見込み残高の不足',
     };
   }
 

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -892,6 +892,173 @@ void main() {
       );
     });
 
+    test('明細照合の差分に対して修正アクションを提案する', () {
+      // 設定内訳(KDDI 5764) ≠ 請求額(20000) かつ明細未取込 →
+      // 「内訳を修正する」「明細を取り込む」の両アクションが出る。
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'KDDI': -5764,
+          'PayPay': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+          'paypay_card': 20000,
+        },
+        cardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'paypay_card',
+        },
+      );
+
+      final group = workbook.cardStatementReconciliation.groups.singleWhere(
+        (group) => group.billingAccountId == 'paypay_card',
+      );
+      expect(group.hasFixActions, isTrue);
+      expect(group.hasConfiguredMismatchFix, isTrue);
+
+      final importFix = group.fixActions.singleWhere(
+        (action) =>
+            action.kind ==
+            AssetLiabilityCardStatementFixActionKind.importStatement,
+      );
+      expect(
+        importFix.title,
+        AssetLiabilityPlanningService.cardStatementFixImportLabel,
+      );
+
+      final breakdownFix = group.fixActions.singleWhere(
+        (action) =>
+            action.kind ==
+            AssetLiabilityCardStatementFixActionKind.adjustConfiguredBreakdown,
+      );
+      expect(
+        breakdownFix.title,
+        AssetLiabilityPlanningService.cardStatementFixAdjustBreakdownLabel,
+      );
+      // 差分金額 = 設定内訳 5764 − 請求額 20000 = -14236 が案内文に入る。
+      expect(breakdownFix.amount, 5764 - 20000);
+      expect(breakdownFix.description, contains('-14,236円'));
+    });
+
+    test('取込明細と請求額の差分は取込明細確認アクションを提案する', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'KDDI': -5764,
+          'PayPay': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+          'paypay_card': 20000,
+        },
+        cardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'paypay_card',
+        },
+        cardStatementLines: const <AssetLiabilityCardStatementLine>[
+          AssetLiabilityCardStatementLine(
+            id: 'line_kddi',
+            billingAccountId: 'paypay_card',
+            billingAccountName: 'PayPay',
+            postedAt: null,
+            description: 'KDDI',
+            amount: 5764,
+          ),
+        ],
+      );
+
+      final group = workbook.cardStatementReconciliation.groups.singleWhere(
+        (group) => group.billingAccountId == 'paypay_card',
+      );
+      final reviewFix = group.fixActions.singleWhere(
+        (action) =>
+            action.kind ==
+            AssetLiabilityCardStatementFixActionKind.reviewStatementLines,
+      );
+      expect(reviewFix.amount, 5764 - 20000);
+      // 明細取込済みなので取り込みアクションは出ない。
+      expect(
+        group.fixActions.any(
+          (action) =>
+              action.kind ==
+              AssetLiabilityCardStatementFixActionKind.importStatement,
+        ),
+        isFalse,
+      );
+    });
+
+    test('請求先カード口座が無いホストには請求先再設定アクションのみ出す', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{'cash': 50000, 'KDDI': -5764},
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 5764,
+        },
+        cardBillingAccountIds: const <String, String>{
+          AssetLiabilityPlanningService.kddiProviderAccountId: 'missing_card',
+        },
+      );
+
+      final group = workbook.cardStatementReconciliation.groups.singleWhere(
+        (group) => group.billingAccountId == 'missing_card',
+      );
+      expect(
+        group.alerts,
+        contains(
+          AssetLiabilityPlanningService.cardStatementBillingAccountMissingAlert,
+        ),
+      );
+      final kinds =
+          group.fixActions.map((action) => action.kind).toList(growable: false);
+      expect(
+        kinds,
+        contains(
+          AssetLiabilityCardStatementFixActionKind.assignBillingAccount,
+        ),
+      );
+      // 請求額がプレースホルダ0のため、取り込み・内訳修正は提案しない。
+      expect(
+        kinds,
+        isNot(
+          contains(AssetLiabilityCardStatementFixActionKind.importStatement),
+        ),
+      );
+      expect(
+        kinds,
+        isNot(
+          contains(
+            AssetLiabilityCardStatementFixActionKind.adjustConfiguredBreakdown,
+          ),
+        ),
+      );
+    });
+
+    test('リボ払いカードには修正アクションを出さない', () {
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 50000,
+          'auPayカード': -530163,
+          'au': -32152,
+        },
+        baseDate: DateTime(2026, 6, 1),
+        revolvingConfigs: const <String, AssetLiabilityRevolvingCreditConfig>{
+          'aupay_card': AssetLiabilityRevolvingCreditConfig(
+            monthlyAmount: 10000,
+            creditLimit: 500000,
+          ),
+        },
+        cardBillingAccountIds: const <String, String>{'au': 'aupay_card'},
+      );
+
+      final group = workbook.cardStatementReconciliation.groups.singleWhere(
+        (group) => group.billingAccountId == 'aupay_card',
+      );
+      // リボ払いは請求額 ≠ 内訳/明細合計が正常のため修正アクション対象外。
+      expect(group.fixActions, isEmpty);
+      expect(group.hasConfiguredMismatchFix, isFalse);
+    });
+
     test(
       'marks monthly and default setting sources in card billing review',
       () {

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -255,6 +255,171 @@ void main() {
       );
     });
 
+    test('flags account shortfall with matched transfer suggestion', () {
+      // 全体では黒字(三井住友 500000)でも、支払原資に割り当てた現金だけが
+      // 不足するケース。口座別見込みの先読み警告と移動提案の紐付けを検証する。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 1000,
+          '三井住友銀行大塚支店': 500000,
+          'モビット': -45000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 5000},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'wallet_cash'},
+      );
+
+      final report = service.buildReport(
+        workbook: workbook,
+        minimumSafetyBalance: 10000,
+      );
+
+      // 全体の使用可能額は黒字のまま。
+      expect(report.monthAvailable.availableAmount, greaterThan(0));
+
+      // 口座別では現金が 1000 − 5000 = -4000 で不足する。
+      expect(report.accountShortfallAlerts.length, 1);
+      final alert = report.accountShortfallAlerts.first;
+      expect(alert.accountId, 'wallet_cash');
+      expect(alert.projectedBalance, -4000);
+      expect(alert.shortfallAmount, 4000);
+
+      // 三井住友からの不足額ちょうどの移動提案が紐付く。
+      expect(alert.hasTransferSuggestion, true);
+      expect(alert.transferSuggestion!.fromAccountId, 'smbc_otsuka_branch');
+      expect(alert.transferSuggestion!.toAccountId, 'wallet_cash');
+      expect(alert.transferSuggestion!.amount, 4000);
+    });
+
+    test(
+        'account shortfall emits critical action item and emergency advice '
+        'even when windows are positive', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 1000,
+          '三井住友銀行大塚支店': 500000,
+          'モビット': -45000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 5000},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'wallet_cash'},
+      );
+
+      final report = service.buildReport(
+        workbook: workbook,
+        minimumSafetyBalance: 10000,
+      );
+      final cashName = workbook.accounts
+          .firstWhere((account) => account.id == 'wallet_cash')
+          .name;
+      final donorName = workbook.accounts
+          .firstWhere((account) => account.id == 'smbc_otsuka_branch')
+          .name;
+
+      final shortfallActions = report.actionItems.where(
+        (item) =>
+            item.type == AssetManagementInsightActionType.accountShortfallRisk,
+      );
+      expect(shortfallActions.length, 1);
+      expect(
+        shortfallActions.first.severity,
+        AssetManagementInsightSeverity.critical,
+      );
+      expect(shortfallActions.first.title, contains(cashName));
+
+      // ウィンドウ黒字でも口座別不足の緊急アドバイスが先頭に出る。
+      expect(report.emergencyAdvices.isNotEmpty, true);
+      final advice = report.emergencyAdvices.first;
+      expect(advice.severity, AssetManagementInsightSeverity.critical);
+      expect(advice.title, contains(cashName));
+      expect(advice.suggestedAction, contains(donorName));
+      expect(advice.amount, 4000);
+    });
+
+    test(
+        'no-donor account shortfall advice precedes living-expense advice '
+        'under combined shortage', () {
+      // 移動元候補が無く(現金のみ)、全体ウィンドウも赤字のケース。
+      // 口座別不足アドバイスが生活費アドバイスより先頭に来ることと、
+      // 提案なし文言(確保してから)へのフォールバックを検証する。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 1000,
+          'モビット': -300000,
+        },
+        baseDate: DateTime(2026, 5, 28),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 200000},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'wallet_cash'},
+      );
+
+      final report = service.buildReport(
+        workbook: workbook,
+        minimumSafetyBalance: 10000,
+      );
+
+      expect(report.todayAvailable.availableAmount, lessThan(0));
+      expect(report.accountShortfallAlerts.length, 1);
+      expect(report.accountShortfallAlerts.first.hasTransferSuggestion, false);
+
+      expect(report.emergencyAdvices.first.title, contains('残高不足を先に解消'));
+      expect(report.emergencyAdvices.first.suggestedAction, contains('確保してから'));
+      expect(
+        report.emergencyAdvices.any(
+          (advice) => advice.title.contains('今日の食費'),
+        ),
+        true,
+      );
+    });
+
+    test('orders account shortfall alerts by shortfall descending', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 1000,
+          '三井住友銀行大塚支店': 2000,
+          'モビット': -45000,
+          'auPayカード': -30000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 5000,
+          'aupay_card': 12000,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          'mobit': 'wallet_cash',
+          'aupay_card': 'smbc_otsuka_branch',
+        },
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      // 三井住友(不足10000) → 現金(不足4000) の降順。
+      expect(report.accountShortfallAlerts.length, 2);
+      expect(report.accountShortfallAlerts[0].accountId, 'smbc_otsuka_branch');
+      expect(report.accountShortfallAlerts[0].shortfallAmount, 10000);
+      expect(report.accountShortfallAlerts[1].accountId, 'wallet_cash');
+      expect(report.accountShortfallAlerts[1].shortfallAmount, 4000);
+    });
+
+    test('no account shortfall artifacts when projections stay positive', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 50000},
+        baseDate: DateTime(2026, 5, 1),
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      expect(report.accountShortfallAlerts, isEmpty);
+      expect(report.hasAccountShortfallAlerts, false);
+      expect(
+        report.actionItems.any(
+          (item) =>
+              item.type ==
+              AssetManagementInsightActionType.accountShortfallRisk,
+        ),
+        false,
+      );
+    });
+
     test('generates developer improvement requests', () {
       final workbook = planner.buildWorkbook(
         latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1186,6 +1186,125 @@ void main() {
       await _unmount(tester);
     });
 
+    testWidgets(
+        'account shortfall banner links a transfer task and clears on create',
+        (tester) async {
+      // 全体では黒字(三井住友 500000)でも、モビットの支払原資に割り当てた
+      // 現金だけが不足する。先読みバナー→移動タスク作成→見込み残高へ即時
+      // 反映されてバナーが解消するまでを検証する。
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        AssetLiabilityMonthlyStateStore.defaultPaymentSourcePrefsKey:
+            jsonEncode(<String, String>{'mobit': 'wallet_cash'}),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugCalendarNow: DateTime(2026, 7, 10),
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 1000,
+                '三井住友銀行大塚支店': 500000,
+                'モビット': -45000,
+              },
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.byKey(const Key('asset_account_shortfall_banner')),
+        findsOneWidget,
+      );
+
+      // 三井住友→現金の移動提案がタスク化ボタン付きで表示される。
+      final createButton = find.byKey(
+        const Key('asset_account_shortfall_create_task_wallet_cash'),
+      );
+      expect(createButton, findsOneWidget);
+
+      await tester.tap(createButton);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.text('Transfer task created.'), findsOneWidget);
+      // 保留中の口座移動が見込み残高に反映され、バナーが解消される。
+      expect(
+        find.byKey(const Key('asset_account_shortfall_banner')),
+        findsNothing,
+      );
+
+      await _unmount(tester);
+    });
+
+    testWidgets('card reconciliation shows fix actions for mismatches', (
+      tester,
+    ) async {
+      // KDDI(5764) を PayPay カード請求に含めるが、PayPay の請求額は 20000 →
+      // 設定内訳の不一致と明細未取込の両方の解消アクションが出る。
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        AssetLiabilityMonthlyStateStore.defaultCardBillingPrefsKey: jsonEncode(
+          <String, String>{'kddi_provider': 'paypay_card'},
+        ),
+      });
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugCalendarNow: DateTime(2026, 7, 10),
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 50000,
+                'KDDI': -5764,
+                'PayPay': -20000,
+              },
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final breakdownFix = find.byKey(
+        const Key(
+          'asset_card_recon_fix_adjustConfiguredBreakdown_paypay_card',
+        ),
+      );
+      await tester.ensureVisible(breakdownFix);
+      expect(breakdownFix, findsOneWidget);
+
+      final importFix = find.byKey(
+        const Key('asset_card_recon_fix_importStatement_paypay_card'),
+      );
+      expect(importFix, findsOneWidget);
+
+      // 設定内訳合計(KDDI 5,764)のセルは不一致ハイライト(琥珀色)になる。
+      final configuredCells = tester.widgetList<Text>(find.text('¥5,764'));
+      expect(
+        configuredCells.any(
+          (text) => text.style?.color == const Color(0xFFD97706),
+        ),
+        isTrue,
+      );
+
+      // 取り込みアクションのタップで初めて選択案内メッセージが出る
+      // (説明文の常時表示と区別するため、タップ前は無いことを先に確認)。
+      expect(find.textContaining('を選択しました'), findsNothing);
+      await tester.ensureVisible(importFix);
+      await tester.tap(importFix);
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.textContaining('を選択しました'), findsOneWidget);
+
+      await _unmount(tester);
+    });
+
     testWidgets('salary inflow suggestion registers a monthly rule in one tap',
         (tester) async {
       // 給与明細/salary_incomes でのみ給料を管理していると入金予定ルールが


### PR DESCRIPTION
## 概要

資産管理AIレポート「開発者向け改善提案」の2件を実装する。

1. 支払原資口座の残高不足を先読みし、ページ最上部の固定バナーで警告 + 口座移動提案のタスク化導線を直結
2. カード明細照合の差分に「次に何をすればよいか」の解消アクションを提示

## 変更内容

### 提案1 — 口座別見込み残高の不足先読み

- `AssetManagementInsightService` に `accountShortfallAlerts` を新設。`workbook.shortAccountSummaries`(不足額降順)に、その口座を移動先とする口座移動提案を紐付け
- 緊急生活防衛アドバイス: 全体の使用可能額が黒字でも、口座別不足を critical で先頭表示(期限は提案の neededBy がある場合のみ断言)
- アクションアイテムに `accountShortfallRisk`(至急)を追加
- ページ最上部に `asset_account_shortfall_banner`: 不足口座名・不足額・支払後見込み・移動提案(どこからどこへいくら・期限)・「移動タスクを作成」ボタン・「口座間移動の提案へ移動」ジャンプ(workbookBoard 非表示時はボタン抑止)
- タスク化 → `pendingTransferIn` が見込み残高へ即時反映され、バナーが解消(受け入れ条件3を widget テストで実証)

### 提案2 — カード明細照合の解消アクション

- `AssetLiabilityPlanningService._buildCardStatementReconciliation` がアラートと同時に構造化 `fixActions` を算出: 明細取り込み / 設定内訳の修正(差分金額付き) / 取込明細の確認 / 請求先カードの再設定。リボ払いは従来どおり対象外
- 照合パネル下に「差分の解消アクション」: 取り込み → 請求先カードを選択して案内表示、内訳修正 → 負債マスタの該当カードへジャンプ
- 設定内訳合計セルの不一致を琥珀色で強調
- 照合パネルの請求先候補を `includeShoppingDebt: true` に変更(解消アクションからの選択が候補外のときサイレントに先頭カードへフォールバックして誤取込となる経路を防止。候補外ホストはボタン自体を抑止)

## 敵対レビュー

Workflow 4レンズ(正しさ/実データ経路/UX規約/テスト妥当性)× 検証 25 agents。確定19件のうち、誤取込リスク(major)・ダークテーマ可読性(major)・ジャンプ silent no-op(major)・テスト空アサーション(major)を含む13件を反映。緊急パネル内での多重表示系(2件)は提案の意図(最も目立たせる)どおりのため据え置き。

## テスト

- `flutter analyze` 対象8ファイル: `No issues found!`
- unit: insight 6件新規 / planner 4件新規(計 82 passed)
- widget smoke: 2件新規(バナー表示 → タスク化 → 即時解消 / 解消アクション表示 → 選択案内 + セル強調)(計 57 passed)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: widget smoke テストで主要導線(バナー表示 → タスク化 → 解消 / 解消アクション → 選択案内)を実証済み。新規ルート・EF 変更なしの UI/サービス層追加のため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
