### PR TITLE
feat(admin): 経営分析ダッシュボード改善 — 10仮説検証に基づく8修正

### DIFF
--- a/.github/workflows/quota-monitor.yml
+++ b/.github/workflows/quota-monitor.yml
@@ -56,24 +56,40 @@ jobs:
           end = today.isoformat()
 
           try:
+              # Cost 取得は Admin API (要 sk-ant-admin... キー)。旧実装の
+              # https://api.anthropic.com/v1/usage は実在せず、失敗時に
+              # cost=0 を status=ok として保存していた (捏造値 / H6)。
               resp = requests.get(
-                  'https://api.anthropic.com/v1/usage',
+                  'https://api.anthropic.com/v1/organizations/cost_report',
                   headers={
                       'x-api-key': api_key,
                       'anthropic-version': '2023-06-01',
                   },
-                  params={'start_time': start, 'end_time': end},
+                  params={'starting_at': f'{start}T00:00:00Z', 'limit': 31},
                   timeout=10
               )
-              data = resp.json() if resp.ok else {}
-              usage = data.get('data', [{}])
-              total_cost = sum(u.get('cost', 0) for u in usage) if usage else 0
-              print(f'Anthropic usage: ${total_cost:.4f} this month')
-
-              with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-                  f.write(f'status=ok\n')
-                  f.write(f'cost={total_cost:.4f}\n')
-                  f.write(f'usage_json={json.dumps({"tool":"anthropic","cost_usd":round(total_cost,4),"period":f"{start}/{end}","alert":total_cost>50})}\n')
+              if resp.ok:
+                  data = resp.json()
+                  total_cost = 0.0
+                  for bucket in data.get('data', []):
+                      for r in bucket.get('results', []):
+                          try:
+                              # amount は最小通貨単位 (USD ならセント) の
+                              # decimal 文字列。"123.45" = $1.2345。
+                              total_cost += float(r.get('amount', 0) or 0) / 100.0
+                          except (TypeError, ValueError):
+                              pass
+                  print(f'Anthropic cost: ${total_cost:.4f} this month')
+                  with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                      f.write('status=ok\n')
+                      f.write(f'cost={total_cost:.4f}\n')
+                      f.write(f'usage_json={json.dumps({"tool":"anthropic","cost_usd":round(total_cost,4),"period":f"{start}/{end}","alert":total_cost>50})}\n')
+              else:
+                  # 通常 API キーは 401 になる。行を書かず UI は「未計測」を
+                  # 表示する (偽の「正常 $0」より誠実)。
+                  print(f'Anthropic cost_report error: {resp.status_code} — Admin API key (sk-ant-admin...) required')
+                  with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                      f.write('status=api_error\nusage_json={}\n')
           except Exception as e:
               print(f'Error: {e}')
               with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
@@ -83,11 +99,12 @@ jobs:
       - name: Check OpenAI (CODEX) Usage
         id: openai
         env:
+          # Admin API キー (sk-admin-...) が必要。通常キーでは 401。
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           python3 - << 'EOF'
           import os, requests, json
-          from datetime import date
+          from datetime import date, datetime, timezone
 
           api_key = os.environ.get('OPENAI_API_KEY', '')
           if not api_key:
@@ -97,24 +114,36 @@ jobs:
               exit(0)
 
           try:
+              # 旧 /v1/usage は廃止系で通常キーでも 401 → 常に api_error だった
+              # (H6)。Costs API (Admin キー) で当月コストを取得する。
               today = date.today()
+              start_epoch = int(
+                  datetime(
+                      today.year, today.month, 1, tzinfo=timezone.utc
+                  ).timestamp()
+              )
               resp = requests.get(
-                  'https://api.openai.com/v1/usage',
+                  'https://api.openai.com/v1/organization/costs',
                   headers={'Authorization': f'Bearer {api_key}'},
-                  params={'date': today.strftime('%Y-%m-%d')},
+                  params={'start_time': start_epoch, 'limit': 31},
                   timeout=10
               )
               if resp.ok:
                   data = resp.json()
-                  total_tokens = data.get('total_tokens', 0)
-                  # 概算コスト: gpt-4.1 $2/1M tokens
-                  cost_est = total_tokens / 1_000_000 * 2.0
-                  print(f'OpenAI usage today: {total_tokens} tokens (~${cost_est:.4f})')
+                  total_cost = 0.0
+                  for bucket in data.get('data', []):
+                      for r in bucket.get('results', []):
+                          amount = r.get('amount') or {}
+                          try:
+                              total_cost += float(amount.get('value', 0) or 0)
+                          except (TypeError, ValueError):
+                              pass
+                  print(f'OpenAI cost this month: ${total_cost:.4f}')
                   with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-                      f.write(f'status=ok\n')
-                      f.write(f'usage_json={json.dumps({"tool":"openai","tokens":total_tokens,"cost_usd_est":round(cost_est,4),"alert":cost_est>20})}\n')
+                      f.write('status=ok\n')
+                      f.write(f'usage_json={json.dumps({"tool":"openai","cost_usd":round(total_cost,4),"alert":total_cost>20})}\n')
               else:
-                  print(f'OpenAI API error: {resp.status_code}')
+                  print(f'OpenAI costs API error: {resp.status_code} — Admin API key (sk-admin-...) required')
                   with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
                       f.write('status=api_error\nusage_json={}\n')
           except Exception as e:
@@ -220,7 +249,9 @@ jobs:
       - name: Check Gemini Code Assist Quota
         id: gemini
         env:
-          GOOGLE_AI_API_KEY: ${{ secrets.GOOGLE_AI_API_KEY }}
+          # repo secrets の登録名は GEMINI_API_KEY (GOOGLE_AI_API_KEY は未登録)。
+          # 参照名 mismatch で毎日 skip されていた (H6)。
+          GOOGLE_AI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           python3 - << 'EOF'
           import os, requests, json
@@ -425,6 +456,11 @@ jobs:
           COPILOT_USAGE: ${{ steps.copilot.outputs.usage_json }}
           GEMINI_USAGE: ${{ steps.gemini.outputs.usage_json }}
           HEDRA_USAGE: ${{ steps.hedra.outputs.usage_json }}
+          ANTHROPIC_STATUS: ${{ steps.anthropic.outputs.status }}
+          OPENAI_STATUS: ${{ steps.openai.outputs.status }}
+          COPILOT_STATUS: ${{ steps.copilot.outputs.status }}
+          GEMINI_STATUS: ${{ steps.gemini.outputs.status }}
+          HEDRA_STATUS: ${{ steps.hedra.outputs.status }}
         run: |
           python3 - << 'EOF'
           import os, json
@@ -443,7 +479,19 @@ jobs:
           ]:
               raw = os.environ.get(env_key, '{}')
               if not raw or raw == '{}':
-                  lines.append(f'- **{label}**: スキップ (APIキー未設定)')
+                  # キー未設定 (skipped) と API 失敗 (api_error/error) を
+                  # 混同しない — 原因が違えば是正手順も違う。
+                  status = os.environ.get(
+                      env_key.replace('_USAGE', '_STATUS'), ''
+                  )
+                  if status in ('api_error', 'error'):
+                      lines.append(
+                          f'- **{label}**: ⚠️ API エラー'
+                          ' (キーの権限/Admin キー要否を確認)'
+                      )
+                      alerts.append(label)
+                  else:
+                      lines.append(f'- **{label}**: スキップ (APIキー未設定)')
                   continue
               try:
                   d = json.loads(raw)

--- a/lib/pages/admin/blog_management_page.dart
+++ b/lib/pages/admin/blog_management_page.dart
@@ -28,6 +28,12 @@ class _NewsSignalLintReport {
       );
 }
 
+/// Qiita アカウント (@kanta13jp1) は 2026-07-12 に ToS 違反で停止済み
+/// (全記事非公開・異議申し立て中・当面 dev.to 一本化)。停止が解除されるまで
+/// Qiita への同期・返信・新規投稿の導線を無効化する単一ソースのフラグ。
+/// 解除されたらここを false に戻すだけで全導線が復活する。
+const bool kQiitaAccountSuspended = true;
+
 class BlogManagementPage extends StatefulWidget {
   const BlogManagementPage({super.key});
 
@@ -57,6 +63,7 @@ class _BlogManagementPageState extends State<BlogManagementPage>
   String _tab =
       'articles'; // 'articles' | 'comments' | 'drafts' | 'corrections'
   String _platformFilter = 'all'; // 'all' | 'qiita' | 'devto'
+  String _commentFilter = 'all'; // 'all' | 'unreplied'
   String _draftSearch = '';
   String _draftStatusFilter = 'all'; // 'all' | 'draft' | 'ready'
   final _draftSearchCtrl = TextEditingController();
@@ -93,10 +100,12 @@ class _BlogManagementPageState extends State<BlogManagementPage>
             .select()
             .order('fetched_at', ascending: false)
             .limit(300),
+        // content (記事全文 = 転送量の~84%) は一覧では取得しない。
+        // 編集時に _editDraft が対象1件だけ lazy fetch する。
         _supabase
             .from('blog_posts')
             .select(
-              'id, title, status, target_platforms, draft_path, posted_at, url, created_at, content, tags, notes',
+              'id, title, status, target_platforms, draft_path, posted_at, url, created_at, tags, notes',
             )
             .inFilter('status', ['draft', 'ready'])
             .order('created_at', ascending: false)
@@ -170,7 +179,11 @@ class _BlogManagementPageState extends State<BlogManagementPage>
     }
 
     try {
-      await runSync('Qiita', 'blog.sync_engagement');
+      if (kQiitaAccountSuspended) {
+        lines.add('Qiita: アカウント停止中 (2026-07-12〜) のため同期スキップ');
+      } else {
+        await runSync('Qiita', 'blog.sync_engagement');
+      }
       await runSync('dev.to', 'blog.devto_sync_engagement');
 
       if (!mounted) return;
@@ -420,14 +433,39 @@ class _BlogManagementPageState extends State<BlogManagementPage>
   Future<void> _editDraft(Map<String, dynamic> d) async {
     final id = d['id']?.toString() ?? '';
     if (id.isEmpty) return;
+    // 一覧クエリは content を含まないため、編集対象の1件だけここで取得する。
+    // 取得失敗のままダイアログを開くと、保存時に blog.update_post が
+    // 空本文で実データを上書きしてしまうため、必ず中断する。
+    String initialContent;
+    try {
+      final row = await _supabase
+          .from('blog_posts')
+          .select('content')
+          .eq('id', id)
+          .maybeSingle();
+      if (row == null) {
+        throw StateError('post not found: $id');
+      }
+      initialContent = row['content'] as String? ?? '';
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('❌ 本文の取得に失敗したため編集を中止しました: $e'),
+            backgroundColor: _red,
+          ),
+        );
+      }
+      return;
+    }
+    if (!mounted) return;
     final titleCtrl = TextEditingController(text: d['title'] as String? ?? '');
     final tagsCtrl = TextEditingController(
       text: (d['tags'] is List)
           ? (d['tags'] as List).join(', ')
           : d['tags']?.toString() ?? '',
     );
-    final contentCtrl =
-        TextEditingController(text: d['content'] as String? ?? '');
+    final contentCtrl = TextEditingController(text: initialContent);
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -587,7 +625,7 @@ class _BlogManagementPageState extends State<BlogManagementPage>
     final titleCtrl = TextEditingController();
     final tagsCtrl = TextEditingController();
     final contentCtrl = TextEditingController();
-    String selectedPlatform = 'qiita';
+    String selectedPlatform = kQiitaAccountSuspended ? 'devto' : 'qiita';
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => StatefulBuilder(
@@ -623,19 +661,25 @@ class _BlogManagementPageState extends State<BlogManagementPage>
                         style: TextStyle(color: Colors.white54, height: 1.5),
                       ),
                       ...['qiita', 'devto', 'qiita,devto'].map(
-                        (p) => Padding(
-                          padding: const EdgeInsets.only(left: 8),
-                          child: ChoiceChip(
-                            label: Text(
-                              p,
-                              style: const TextStyle(height: 1.5),
+                        (p) {
+                          // Qiita 停止中は Qiita を含む投稿先を選ばせない。
+                          final disabled = kQiitaAccountSuspended &&
+                              p.contains('qiita');
+                          return Padding(
+                            padding: const EdgeInsets.only(left: 8),
+                            child: ChoiceChip(
+                              label: Text(
+                                disabled ? '$p (停止中)' : p,
+                                style: const TextStyle(height: 1.5),
+                              ),
+                              selected: selectedPlatform == p,
+                              onSelected: disabled
+                                  ? null
+                                  : (_) => setSt(() => selectedPlatform = p),
+                              selectedColor: _orange,
                             ),
-                            selected: selectedPlatform == p,
-                            onSelected: (_) =>
-                                setSt(() => selectedPlatform = p),
-                            selectedColor: _orange,
-                          ),
-                        ),
+                          );
+                        },
                       ),
                     ],
                   ),
@@ -968,6 +1012,10 @@ class _BlogManagementPageState extends State<BlogManagementPage>
             '$unreplied',
             Icons.comment_outlined,
             color: unreplied > 0 ? _red : _green,
+            onTap: () => setState(() {
+              _tab = 'comments';
+              _commentFilter = 'unreplied';
+            }),
           ),
           const SizedBox(width: 8),
           _statCard(
@@ -986,38 +1034,46 @@ class _BlogManagementPageState extends State<BlogManagementPage>
     String value,
     IconData icon, {
     Color color = _orange,
+    VoidCallback? onTap,
   }) {
-    return Expanded(
-      child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-        decoration: BoxDecoration(
-          color: _card,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: Column(
-          children: [
-            Icon(icon, color: color, size: 20),
-            const SizedBox(height: 4),
-            Text(
-              value,
-              style: TextStyle(
-                color: color,
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-                height: 1.5,
-              ),
-            ),
-            Text(
-              label,
-              style: const TextStyle(
-                color: Colors.white38,
-                fontSize: 10,
-                height: 1.5,
-              ),
-            ),
-          ],
-        ),
+    final card = Container(
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
+      decoration: BoxDecoration(
+        color: _card,
+        borderRadius: BorderRadius.circular(12),
       ),
+      child: Column(
+        children: [
+          Icon(icon, color: color, size: 20),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: TextStyle(
+              color: color,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              height: 1.5,
+            ),
+          ),
+          Text(
+            label,
+            style: const TextStyle(
+              color: Colors.white38,
+              fontSize: 10,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+    return Expanded(
+      child: onTap == null
+          ? card
+          : InkWell(
+              onTap: onTap,
+              borderRadius: BorderRadius.circular(12),
+              child: card,
+            ),
     );
   }
 
@@ -1054,9 +1110,22 @@ class _BlogManagementPageState extends State<BlogManagementPage>
               children: [
                 _filterBtn('all', '全て'),
                 const SizedBox(width: 6),
-                _filterBtn('qiita', 'Qiita'),
+                _filterBtn(
+                  'qiita',
+                  kQiitaAccountSuspended ? 'Qiita (停止中)' : 'Qiita',
+                ),
                 const SizedBox(width: 6),
                 _filterBtn('devto', 'dev.to'),
+              ],
+            ),
+          ],
+          if (_tab == 'comments') ...[
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                _commentFilterBtn('all', '全て'),
+                const SizedBox(width: 6),
+                _commentFilterBtn('unreplied', '未返信のみ ($_unrepliedCount)'),
               ],
             ),
           ],
@@ -1195,6 +1264,31 @@ class _BlogManagementPageState extends State<BlogManagementPage>
     );
   }
 
+  Widget _commentFilterBtn(String id, String label) {
+    final selected = _commentFilter == id;
+    return GestureDetector(
+      onTap: () => setState(() => _commentFilter = id),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: selected ? Colors.white24 : Colors.transparent,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: selected ? Colors.white38 : Colors.white12,
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: selected ? Colors.white70 : Colors.white38,
+            fontSize: 11,
+            height: 1.5,
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _draftStatusBtn(String id, String label) {
     final selected = _draftStatusFilter == id;
     return GestureDetector(
@@ -1301,7 +1395,14 @@ class _BlogManagementPageState extends State<BlogManagementPage>
     // 今の数値に見せない)。フィルタ後の行を platform 別に評価する — 独立同期
     // 化により「Qiita だけ凍結・dev.to は新鮮」が全体 max に隠れるのを防ぐ。
     // 直近同期が失敗していれば警告も添える。
-    final freshness = blogEngagementFreshnessByPlatform(items, DateTime.now());
+    final rawFreshness =
+        blogEngagementFreshnessByPlatform(items, DateTime.now());
+    // Qiita 停止中は「58日前」等の凍結値が異常に見えないよう理由を添える。
+    final freshness = rawFreshness != null &&
+            kQiitaAccountSuspended &&
+            rawFreshness.contains('Qiita')
+        ? '$rawFreshness(Qiita はアカウント停止中 2026-07-12〜)'
+        : rawFreshness;
     return [
       if (freshness != null)
         SliverToBoxAdapter(
@@ -1445,7 +1546,10 @@ class _BlogManagementPageState extends State<BlogManagementPage>
 
   // ── コメント一覧 ─────────────────────────────────────────────
   List<Widget> _buildCommentSliver() {
-    final sorted = [..._comments]..sort((a, b) {
+    final filtered = _commentFilter == 'unreplied'
+        ? _comments.where((c) => (c['replied'] as bool?) != true).toList()
+        : _comments;
+    final sorted = [...filtered]..sort((a, b) {
         final ra = (a['replied'] as bool?) == true ? 1 : 0;
         final rb = (b['replied'] as bool?) == true ? 1 : 0;
         return ra.compareTo(rb); // 未返信を先頭に
@@ -1453,13 +1557,13 @@ class _BlogManagementPageState extends State<BlogManagementPage>
 
     if (sorted.isEmpty) {
       return [
-        const SliverToBoxAdapter(
+        SliverToBoxAdapter(
           child: Padding(
-            padding: EdgeInsets.all(32),
+            padding: const EdgeInsets.all(32),
             child: Center(
               child: Text(
-                'コメントなし',
-                style: TextStyle(
+                _commentFilter == 'unreplied' ? '未返信コメントなし' : 'コメントなし',
+                style: const TextStyle(
                   color: Colors.white38,
                   height: 1.5,
                 ),
@@ -1483,12 +1587,28 @@ class _BlogManagementPageState extends State<BlogManagementPage>
     ];
   }
 
+  /// コメントの属する記事 URL を engagement 一覧から引く (platform +
+  /// article_id 一致)。blog_comments 自体は url 列を持たないため。
+  String _commentArticleUrl(Map<String, dynamic> c) {
+    final platform = c['platform']?.toString() ?? '';
+    final articleId = c['article_id']?.toString() ?? '';
+    if (platform.isEmpty || articleId.isEmpty) return '';
+    for (final e in _engagement) {
+      if ((e['platform']?.toString() ?? '') == platform &&
+          (e['article_id']?.toString() ?? '') == articleId) {
+        return e['url']?.toString() ?? '';
+      }
+    }
+    return '';
+  }
+
   Widget _buildCommentCard(Map<String, dynamic> c) {
     final platform = c['platform'] as String? ?? '';
     final author = c['author'] as String? ?? '';
     final body = c['body'] as String? ?? '';
     final replied = (c['replied'] as bool?) == true;
     final replyText = c['reply_text'] as String? ?? '';
+    final articleUrl = _commentArticleUrl(c);
 
     return Card(
       color: _card,
@@ -1527,6 +1647,20 @@ class _BlogManagementPageState extends State<BlogManagementPage>
                     height: 1.5,
                   ),
                 ),
+                if (articleUrl.isNotEmpty) ...[
+                  const SizedBox(width: 4),
+                  InkWell(
+                    onTap: () => _openUrl(articleUrl),
+                    child: const Padding(
+                      padding: EdgeInsets.all(2),
+                      child: Icon(
+                        Icons.open_in_new,
+                        size: 13,
+                        color: Colors.white38,
+                      ),
+                    ),
+                  ),
+                ],
                 const Spacer(),
                 Container(
                   padding:
@@ -1599,6 +1733,18 @@ class _BlogManagementPageState extends State<BlogManagementPage>
                 alignment: Alignment.centerRight,
                 child: Builder(
                   builder: (ctx) {
+                    // Qiita 停止中は返信 API (blog.qiita_comment_post) が
+                    // 停止済みアカウントで失敗するため導線ごと無効化する。
+                    if (kQiitaAccountSuspended) {
+                      return const Text(
+                        'Qiita停止中のため返信不可',
+                        style: TextStyle(
+                          color: Colors.white38,
+                          fontSize: 11,
+                          height: 1.5,
+                        ),
+                      );
+                    }
                     final id = c['id']?.toString() ?? '';
                     final isReplying = _replyingIds.contains(id);
                     return SizedBox(

--- a/lib/pages/admin/blog_management_page.dart
+++ b/lib/pages/admin/blog_management_page.dart
@@ -663,8 +663,8 @@ class _BlogManagementPageState extends State<BlogManagementPage>
                       ...['qiita', 'devto', 'qiita,devto'].map(
                         (p) {
                           // Qiita 停止中は Qiita を含む投稿先を選ばせない。
-                          final disabled = kQiitaAccountSuspended &&
-                              p.contains('qiita');
+                          final disabled =
+                              kQiitaAccountSuspended && p.contains('qiita');
                           return Padding(
                             padding: const EdgeInsets.only(left: 8),
                             child: ChoiceChip(

--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -1729,10 +1729,16 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           ? Map<String, dynamic>.from(lpStatsResponse)
           : <String, dynamic>{};
       final hasLpViewStats = lpStats.isNotEmpty;
-      final paidConversionMetrics = await _loadPaidConversionMetrics();
-      final xTodayStatus = await _loadXTodayStatus();
-      final xPerformanceContext = await _loadXPerformanceContext();
-      final xCandidates = await _loadXCandidateQueue();
+      // 相互依存の無い4ローダーを並列化 (旧: 直列 await でスピナー時間が
+      // 4リクエスト分加算されていた)。
+      final paidConversionFuture = _loadPaidConversionMetrics();
+      final xTodayStatusFuture = _loadXTodayStatus();
+      final xPerformanceContextFuture = _loadXPerformanceContext();
+      final xCandidatesFuture = _loadXCandidateQueue();
+      final paidConversionMetrics = await paidConversionFuture;
+      final xTodayStatus = await xTodayStatusFuture;
+      final xPerformanceContext = await xPerformanceContextFuture;
+      final xCandidates = await xCandidatesFuture;
 
       final toolExecutionLogs = <Map<String, dynamic>>[];
       final blockedReasonCounts = <String, int>{};
@@ -6361,7 +6367,11 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   Widget _buildXCandidateRow(XPostCandidateSummary candidate) {
     final theme = Theme.of(context);
     final publishing = _xCandidatePublishing.contains(candidate.id);
-    final age = candidateAgeLabel(candidate.generatedAt, DateTime.now());
+    final now = DateTime.now();
+    final age = candidateAgeLabel(candidate.generatedAt, now);
+    // 鮮度切れ (news_briefing 24h / data_report 72h / 既定7日) の候補は
+    // 承認ボタンを無効化し、古いニュースの誤投稿を防ぐ。
+    final expired = isCandidateExpired(candidate, now);
     return Padding(
       padding: const EdgeInsets.only(bottom: 10),
       child: Row(
@@ -6419,6 +6429,27 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                           color: Color(0xFF9CA3AF),
                         ),
                       ),
+                    if (expired)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: 2,
+                        ),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFFEF4444).withValues(
+                            alpha: 0.12,
+                          ),
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        child: const Text(
+                          '鮮度切れ',
+                          style: TextStyle(
+                            fontSize: 10,
+                            color: Color(0xFFB91C1C),
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
                   ],
                 ),
                 const SizedBox(height: 4),
@@ -6431,7 +6462,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           ),
           const SizedBox(width: 8),
           FilledButton.tonal(
-            onPressed: publishing || !candidate.isActionable
+            onPressed: publishing || !candidate.isActionable || expired
                 ? null
                 : () => _publishXCandidate(candidate),
             child: publishing
@@ -6440,7 +6471,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                     height: 14,
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
-                : const Text('承認して投稿'),
+                : Text(expired ? '鮮度切れ' : '承認して投稿'),
           ),
         ],
       ),

--- a/lib/pages/admin_x_candidate_queue.dart
+++ b/lib/pages/admin_x_candidate_queue.dart
@@ -92,10 +92,50 @@ class XPostCandidateSummary {
         return '投稿済み';
       case 'rejected_duplicate':
         return '近似重複で見送り';
+      case 'rejected':
+        return '却下済み';
       default:
         return status;
     }
   }
+}
+
+/// content_archetype → 鮮度ウィンドウ。ニュース系は鮮度が命なので短い。
+/// ここに無い archetype は選挙系 variant の個別判定を経て既定7日に落ちる。
+const Map<String, Duration> kCandidateFreshnessWindows = <String, Duration>{
+  'news_briefing': Duration(hours: 24),
+  'data_report': Duration(hours: 72),
+  'data_report_thread': Duration(hours: 72),
+};
+
+/// 鮮度ウィンドウの既定値 (エバーグリーン寄りの系列)。
+const Duration kCandidateDefaultFreshnessWindow = Duration(days: 7);
+
+/// 候補の鮮度ウィンドウを解決する。archetype 優先、次に選挙系 variant
+/// (diff/速報系のため 72h)、最後に既定7日。
+Duration candidateFreshnessWindow(XPostCandidateSummary candidate) {
+  final byArchetype = kCandidateFreshnessWindows[candidate.archetype.trim()];
+  if (byArchetype != null) return byArchetype;
+  final variant = candidate.variant.trim();
+  if (variant.startsWith('local_election') ||
+      variant == 'member_delta_national_progress' ||
+      variant == 'scheduled_candidate_delta' ||
+      variant == 'party_gap_ranking') {
+    return const Duration(hours: 72);
+  }
+  return kCandidateDefaultFreshnessWindow;
+}
+
+/// 鮮度切れ判定。生成時刻不明の候補は判定しない (誤ブロックより見せる方を
+/// 選ぶ — 未知系列の追い漏れに気づける)。鮮度切れ候補は「承認して投稿」を
+/// 無効化し、誤って古いニュースを公開する事故を防ぐ (Qiita 停止事件の教訓 =
+/// 公開系の安全側デフォルト)。
+bool isCandidateExpired(XPostCandidateSummary candidate, DateTime now) {
+  final generatedAt = candidate.generatedAt;
+  if (generatedAt == null) return false;
+  final age = now.difference(generatedAt);
+  if (age.isNegative) return false;
+  return age > candidateFreshnessWindow(candidate);
 }
 
 /// 一覧から操作対象(actionable)だけを残す。posted / rejected_duplicate は

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -86,6 +86,8 @@ class _LandingPageState extends State<LandingPage> {
     unawaited(_bootstrapReferralInvite());
     unawaited(_loadAchievementCount());
     unawaited(_loadSocialProofStats());
+    // LP View 計測 (今日の登録ファネルの最上段)。失敗は adapter 側で握る。
+    unawaited(widget.adapter.recordLpView());
   }
 
   @override

--- a/lib/services/growth_mission_service.dart
+++ b/lib/services/growth_mission_service.dart
@@ -1412,10 +1412,13 @@ class GrowthPresenceNavigatorObserver extends NavigatorObserver
   Timer? _heartbeatTimer;
   Timer? _metricsTimer;
   Future<void>? _immediatePresenceSyncInFlight;
-  String? _immediatePresenceSyncInFlightPagePath;
   DateTime? _lastImmediatePresenceSyncAt;
-  String? _lastImmediatePresenceSyncPagePath;
   String _currentPagePath = '/';
+
+  /// まだ 1 ルートも track していない状態の区別。初期値 _currentPagePath='/'
+  /// と初回ルート '/' (root 直行 = 最多の入口) が一致して同一 path skip に
+  /// 入ると、touchpoint/referral 記録が丸ごと消えるため。
+  bool _hasTrackedRoute = false;
 
   GrowthPresenceNavigatorObserver({
     GrowthMissionService service = const GrowthMissionService(),
@@ -1428,33 +1431,44 @@ class GrowthPresenceNavigatorObserver extends NavigatorObserver
 
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    _heartbeatTimer?.cancel();
-    _metricsTimer?.cancel();
+    _cancelTimers();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden) {
-      _heartbeatTimer?.cancel();
-      _metricsTimer?.cancel();
+      _cancelTimers();
     } else if (state == AppLifecycleState.resumed) {
-      _restartTimers();
+      // バックグラウンド復帰時はタイマーを作り直し、即時 sync も試みる
+      // (グローバル cooldown 内なら書き込みはスキップされる)。
+      _cancelTimers();
+      _startTimersIfNeeded(syncNow: true);
     }
   }
 
-  void _restartTimers() {
+  void _cancelTimers() {
     _heartbeatTimer?.cancel();
+    _heartbeatTimer = null;
     _metricsTimer?.cancel();
+    _metricsTimer = null;
+  }
+
+  /// タイマーが未生成のときだけ生成する。ルート遷移のたびに周期を
+  /// リセットしていた旧実装と違い、2分 heartbeat / 5分 metrics の周期を
+  /// 遷移頻度と無関係に保つ。
+  void _startTimersIfNeeded({required bool syncNow}) {
     if (!_service.isPresenceTrackingAvailable) return;
-    _syncPresenceImmediately();
-    _heartbeatTimer = Timer.periodic(const Duration(minutes: 2), (_) {
+    if (syncNow) {
+      _syncPresenceImmediately();
+    }
+    _heartbeatTimer ??= Timer.periodic(const Duration(minutes: 2), (_) {
       _runSafely(
         _service.syncPresence(pagePath: _currentPagePath),
         'syncPresence heartbeat',
       );
     });
-    _metricsTimer = Timer.periodic(const Duration(minutes: 5), (_) {
+    _metricsTimer ??= Timer.periodic(const Duration(minutes: 5), (_) {
       _runSafely(
         _service.refreshAggregateMetrics(),
         'refreshAggregateMetrics',
@@ -1488,7 +1502,17 @@ class GrowthPresenceNavigatorObserver extends NavigatorObserver
   }
 
   void _trackRoute(Route<dynamic> route) {
-    _currentPagePath = _resolvePagePath(route);
+    final resolved = _resolvePagePath(route);
+    if (resolved == null ||
+        (_hasTrackedRoute && resolved == _currentPagePath)) {
+      // ダイアログ等の無名ルートや同一ページへの出入りでは presence 書き込み
+      // もタッチポイント記録も行わない (直前ページに滞在している扱い)。
+      // アプリ起動直後の初回ルートでまだタイマーが無い場合のみ起動する。
+      _startTimersIfNeeded(syncNow: _heartbeatTimer == null);
+      return;
+    }
+    _hasTrackedRoute = true;
+    _currentPagePath = resolved;
     _runSafely(
       _acquisitionService.recordTouchpointForPagePath(_currentPagePath),
       'recordTouchpointForPagePath',
@@ -1501,35 +1525,31 @@ class GrowthPresenceNavigatorObserver extends NavigatorObserver
       _service.applyPendingReferralIfPossible(),
       'applyPendingReferralIfPossible',
     );
-    _restartTimers();
+    _syncPresenceImmediately();
+    _startTimersIfNeeded(syncNow: false);
   }
 
   void _syncPresenceImmediately() {
-    final pagePath = _currentPagePath;
-    final inFlight = _immediatePresenceSyncInFlight;
-    if (inFlight != null &&
-        _immediatePresenceSyncInFlightPagePath == pagePath) {
+    if (_immediatePresenceSyncInFlight != null) {
       return;
     }
 
+    // cooldown は pagePath 非依存 (グローバル)。cooldown 中の遷移は
+    // _currentPagePath の更新だけ行い、書き込みは次の heartbeat に委ねる。
     final lastSyncedAt = _lastImmediatePresenceSyncAt;
-    if (_lastImmediatePresenceSyncPagePath == pagePath &&
-        lastSyncedAt != null &&
+    if (lastSyncedAt != null &&
         DateTime.now().difference(lastSyncedAt) < _immediatePresenceCooldown) {
       return;
     }
 
-    final syncFuture = _service.syncPresence(pagePath: pagePath);
+    final syncFuture = _service.syncPresence(pagePath: _currentPagePath);
     _immediatePresenceSyncInFlight = syncFuture;
-    _immediatePresenceSyncInFlightPagePath = pagePath;
     _lastImmediatePresenceSyncAt = DateTime.now();
-    _lastImmediatePresenceSyncPagePath = pagePath;
 
     _runSafely(
       syncFuture.whenComplete(() {
         if (identical(_immediatePresenceSyncInFlight, syncFuture)) {
           _immediatePresenceSyncInFlight = null;
-          _immediatePresenceSyncInFlightPagePath = null;
         }
       }),
       'syncPresence',
@@ -1545,7 +1565,11 @@ class GrowthPresenceNavigatorObserver extends NavigatorObserver
     );
   }
 
-  String _resolvePagePath(Route<dynamic> route) {
+  /// ルート名から page_path を解決する。ダイアログ等の無名ルートは null を
+  /// 返し、呼び出し側で「直前ページに滞在中」として扱う (旧実装の
+  /// runtimeType 文字列は 'minified:yL<dynamic>' のようなゴミ行を
+  /// user_presence に量産していた)。
+  String? _resolvePagePath(Route<dynamic> route) {
     final name = route.settings.name;
     if (name != null && name.trim().isNotEmpty) {
       final uri = Uri.tryParse(name);
@@ -1554,6 +1578,6 @@ class GrowthPresenceNavigatorObserver extends NavigatorObserver
       }
       return name;
     }
-    return route.runtimeType.toString();
+    return null;
   }
 }

--- a/lib/services/landing_page_adapter.dart
+++ b/lib/services/landing_page_adapter.dart
@@ -49,6 +49,13 @@ abstract interface class LandingPageAdapter {
 
   Future<LandingPageViewStats> loadLpViewStats();
 
+  /// LP 表示を1回記録する (LP View カウンタ + 流入元帰属)。
+  ///
+  /// 2026-03-28 の LP 改修 (7b92a33d6) で loadLpViewStats ごと呼び出しが
+  /// 消えて以来カウンタが凍結していたため、書き込みを読み出しから分離して
+  /// LandingPage の initState から明示的に呼ぶ。
+  Future<void> recordLpView();
+
   Future<String> improveTrialPrompt({
     required String prompt,
   });
@@ -130,6 +137,21 @@ class SupabaseLandingPageAdapter implements LandingPageAdapter {
   }
 
   @override
+  Future<void> recordLpView() async {
+    final client = _supabaseClientOrNull;
+    if (client == null) {
+      return;
+    }
+    try {
+      await client.rpc('increment_lp_view');
+      await LandingShareService.recordIncomingShareVisit(client: client);
+    } catch (error) {
+      // 計測失敗で LP 表示自体を妨げない。
+      debugPrint('LP view record failed: $error');
+    }
+  }
+
+  @override
   Future<LandingPageViewStats> loadLpViewStats() async {
     final client = _supabaseClientOrNull;
     if (client == null) {
@@ -137,8 +159,6 @@ class SupabaseLandingPageAdapter implements LandingPageAdapter {
     }
 
     try {
-      await client.rpc('increment_lp_view');
-      await LandingShareService.recordIncomingShareVisit(client: client);
       final dynamic raw = await client.rpc('get_lp_view_stats');
       final data =
           raw is Map ? Map<String, dynamic>.from(raw) : <String, dynamic>{};

--- a/lib/services/schedule_task_runs_repository.dart
+++ b/lib/services/schedule_task_runs_repository.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// schedule_task_runs の直近履歴を1回だけ取得して使い回す共有リポジトリ。
+///
+/// SelfDevinControlTowerCard と ScheduleTaskMonitorCard がほぼ同一クエリを
+/// initState で各自発行していた二重取得を、短 TTL の memoized Future 共有で
+/// 1リクエストに畳む。列は両カードの必要列の和集合。
+class ScheduleTaskRunsRepository {
+  ScheduleTaskRunsRepository._();
+
+  /// 同一初期表示バースト内の共有が目的なので TTL は短くてよい。
+  static const Duration _ttl = Duration(seconds: 30);
+
+  static Future<List<Map<String, dynamic>>>? _inflight;
+  static DateTime? _fetchedAt;
+
+  /// [force] は手動 Refresh ボタン用: TTL 内でもキャッシュを無効化して
+  /// 再取得する (memoization は初期表示バーストの共有だけが目的で、明示的な
+  /// ユーザー操作まで吸収しない)。
+  static Future<List<Map<String, dynamic>>> fetch({
+    SupabaseClient? supabaseClient,
+    bool force = false,
+  }) {
+    final now = DateTime.now();
+    final cached = _inflight;
+    final at = _fetchedAt;
+    if (!force && cached != null && at != null && now.difference(at) < _ttl) {
+      return cached;
+    }
+    final client = supabaseClient ?? Supabase.instance.client;
+    late final Future<List<Map<String, dynamic>>> future;
+    future = _load(client).catchError((Object error, StackTrace stackTrace) {
+      // 失敗した Future をキャッシュし続けると TTL 内の再試行まで
+      // 全 consumer が同じエラーを見るため、即座に無効化する。
+      if (identical(_inflight, future)) {
+        _inflight = null;
+        _fetchedAt = null;
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    });
+    _inflight = future;
+    _fetchedAt = now;
+    return future;
+  }
+
+  static Future<List<Map<String, dynamic>>> _load(
+    SupabaseClient supabase,
+  ) async {
+    final data = await supabase
+        .from('schedule_task_runs')
+        .select(
+          'task_id, status, started_at, finished_at, summary, error_message',
+        )
+        .order('started_at', ascending: false)
+        .limit(120);
+    return List<Map<String, dynamic>>.from(data as List);
+  }
+
+  /// テスト用: memoization を破棄する。
+  @visibleForTesting
+  static void reset() {
+    _inflight = null;
+    _fetchedAt = null;
+  }
+}

--- a/lib/services/self_devin_control_tower_service.dart
+++ b/lib/services/self_devin_control_tower_service.dart
@@ -1,5 +1,7 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import 'schedule_task_runs_repository.dart';
+
 class SelfDevinControlTowerSnapshot {
   final double readiness;
   final int openFeatureRequestCount;
@@ -127,19 +129,23 @@ class SelfDevinControlTowerService {
     ),
   ];
 
+  /// PostgREST の max-rows (既定1000行) を跨いでも取りこぼさないための
+  /// ページング設定。lane 統計は非 completed 行しか使わないため、
+  /// completed はサーバ側で除外して転送・切断の両方を避ける。
+  static const int _taskPageSize = 1000;
+  static const int _maxTaskRows = 3000;
+
   Future<SelfDevinControlTowerSnapshot> load({
     SupabaseClient? supabaseClient,
+    bool forceRefreshRuns = false,
   }) async {
     final supabase = supabaseClient ?? Supabase.instance.client;
     final results = await Future.wait<dynamic>(<Future<dynamic>>[
-      supabase.from('wbs_tasks').select(
-            'title, category, instance, owner_instance, status, progress, end_date, priority, updated_at',
-          ),
-      supabase
-          .from('schedule_task_runs')
-          .select('task_id, status, started_at, summary, error_message')
-          .order('started_at', ascending: false)
-          .limit(120),
+      _loadOpenTasks(supabase),
+      ScheduleTaskRunsRepository.fetch(
+        supabaseClient: supabase,
+        force: forceRefreshRuns,
+      ),
     ]);
 
     return buildSnapshot(
@@ -147,6 +153,36 @@ class SelfDevinControlTowerService {
       rawRuns: List<Map<String, dynamic>>.from(results[1] as List<dynamic>),
       now: DateTime.now(),
     );
+  }
+
+  Future<List<Map<String, dynamic>>> _loadOpenTasks(
+    SupabaseClient supabase,
+  ) async {
+    final rows = <Map<String, dynamic>>[];
+    // updated_at は同値がありうるため id を tiebreaker にして全順序を保証し、
+    // ページ間の並行更新による重複は id で dedupe する (どちらも欠けると
+    // 1000 行超過時に lane 統計が二重計上/欠落する)。
+    final seenIds = <String>{};
+    for (var offset = 0; offset < _maxTaskRows; offset += _taskPageSize) {
+      final page = await supabase
+          .from('wbs_tasks')
+          .select(
+            'id, title, category, instance, owner_instance, status, progress, end_date, priority, updated_at',
+          )
+          .neq('status', 'completed')
+          .order('updated_at', ascending: false)
+          .order('id')
+          .range(offset, offset + _taskPageSize - 1);
+      final list = List<Map<String, dynamic>>.from(page as List<dynamic>);
+      for (final row in list) {
+        final id = row['id']?.toString() ?? '';
+        if (id.isEmpty || seenIds.add(id)) {
+          rows.add(row);
+        }
+      }
+      if (list.length < _taskPageSize) break;
+    }
+    return rows;
   }
 
   static SelfDevinControlTowerSnapshot buildSnapshot({

--- a/lib/services/version_check_service.dart
+++ b/lib/services/version_check_service.dart
@@ -8,9 +8,17 @@ import '../core/app_version.dart';
 
 class VersionCheckService {
   static const Duration _pollInterval = Duration(minutes: 30);
+
+  /// checkNow の最小間隔。Flutter Web ではフォーカス取得のたびに
+  /// AppLifecycleState.resumed が来る (DevTools やタブの往復含む) ため、
+  /// 時間ベースで抑制しないとフォーカス往復がそのままリクエスト数になる。
+  /// バックグラウンド復帰後のデプロイ検知は最大この時間だけ遅れるトレードオフ。
+  static const Duration _minCheckGap = Duration(minutes: 5);
+
   Timer? _timer;
   VoidCallback? _onOutdated;
   bool _checking = false;
+  DateTime? _lastCheckedAt;
 
   Future<String?> fetchLatestVersion() async {
     final uri = Uri.parse(
@@ -50,7 +58,10 @@ class VersionCheckService {
     if (!kIsWeb || AppVersion.isDev) return;
     final callback = onOutdated ?? _onOutdated;
     if (callback == null || _checking) return;
+    final now = DateTime.now();
+    if (!shouldCheck(now)) return;
     _checking = true;
+    _lastCheckedAt = now;
     try {
       final latest = await fetchLatestVersion();
       if (latest != null && isOutdated(AppVersion.value, latest)) {
@@ -60,6 +71,18 @@ class VersionCheckService {
       _checking = false;
     }
   }
+
+  /// [checkNow] の時間ベース cooldown 判定。前回チェックから
+  /// [_minCheckGap] 未満なら false (フォーカス往復による連続発火を抑制)。
+  @visibleForTesting
+  bool shouldCheck(DateTime now) {
+    final last = _lastCheckedAt;
+    return last == null || now.difference(last) >= _minCheckGap;
+  }
+
+  /// テスト用: 前回チェック時刻を注入する。
+  @visibleForTesting
+  void debugSetLastCheckedAt(DateTime? value) => _lastCheckedAt = value;
 
   void startPolling(VoidCallback onOutdated) {
     if (!kIsWeb) return;

--- a/lib/widgets/schedule_task_monitor_card.dart
+++ b/lib/widgets/schedule_task_monitor_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
+
+import '../services/schedule_task_runs_repository.dart';
 
 class ScheduleTaskMonitorCard extends StatefulWidget {
   const ScheduleTaskMonitorCard({super.key});
@@ -138,20 +139,15 @@ class _ScheduleTaskMonitorCardState extends State<ScheduleTaskMonitorCard> {
     _loadTaskStatus();
   }
 
-  Future<void> _loadTaskStatus() async {
+  Future<void> _loadTaskStatus({bool force = false}) async {
     setState(() => _loading = true);
     try {
-      final SupabaseClient supabase = Supabase.instance.client;
       List<Map<String, dynamic>> runs = <Map<String, dynamic>>[];
       try {
-        final dynamic data = await supabase
-            .from('schedule_task_runs')
-            .select(
-              'task_id, status, started_at, finished_at, summary, error_message',
-            )
-            .order('started_at', ascending: false)
-            .limit(120);
-        runs = List<Map<String, dynamic>>.from(data as List<dynamic>);
+        // SelfDevinControlTowerCard と同一データのため共有リポジトリ経由で
+        // 取得し、初期表示での二重リクエストを避ける。手動 Refresh は
+        // force でキャッシュを飛ばす。
+        runs = await ScheduleTaskRunsRepository.fetch(force: force);
       } catch (_) {
         runs = <Map<String, dynamic>>[];
       }
@@ -240,7 +236,7 @@ class _ScheduleTaskMonitorCardState extends State<ScheduleTaskMonitorCard> {
                 ),
                 IconButton(
                   icon: const Icon(Icons.refresh, size: 20),
-                  onPressed: _loadTaskStatus,
+                  onPressed: () => _loadTaskStatus(force: true),
                   tooltip: 'Refresh',
                 ),
               ],

--- a/lib/widgets/self_devin_control_tower_card.dart
+++ b/lib/widgets/self_devin_control_tower_card.dart
@@ -37,7 +37,7 @@ class _SelfDevinControlTowerCardState extends State<SelfDevinControlTowerCard> {
     }
   }
 
-  Future<void> _load() async {
+  Future<void> _load({bool force = false}) async {
     setState(() {
       _loading = true;
       _error = null;
@@ -45,6 +45,7 @@ class _SelfDevinControlTowerCardState extends State<SelfDevinControlTowerCard> {
     try {
       final snapshot = await _service.load(
         supabaseClient: widget.supabaseClient,
+        forceRefreshRuns: force,
       );
       if (!mounted) return;
       setState(() {
@@ -99,7 +100,7 @@ class _SelfDevinControlTowerCardState extends State<SelfDevinControlTowerCard> {
                 ),
                 if (widget.snapshotOverride == null)
                   IconButton(
-                    onPressed: _loading ? null : _load,
+                    onPressed: _loading ? null : () => _load(force: true),
                     tooltip: 'Refresh',
                     icon: const Icon(Icons.refresh, size: 20),
                   ),

--- a/test/pages/admin_x_candidate_queue_test.dart
+++ b/test/pages/admin_x_candidate_queue_test.dart
@@ -304,7 +304,8 @@ void main() {
       );
     });
 
-    test('unknown series falls back to 7 days and null generatedAt never '
+    test(
+        'unknown series falls back to 7 days and null generatedAt never '
         'expires', () {
       final unknown = make(
         archetype: 'product_intro',
@@ -326,8 +327,7 @@ void main() {
       expect(isCandidateExpired(make(generatedAt: null), now), isFalse);
     });
 
-    test('rejected status label is defined for the upcoming reject action',
-        () {
+    test('rejected status label is defined for the upcoming reject action', () {
       const rejected = XPostCandidateSummary(
         id: 'r',
         status: 'rejected',

--- a/test/pages/admin_x_candidate_queue_test.dart
+++ b/test/pages/admin_x_candidate_queue_test.dart
@@ -247,4 +247,99 @@ void main() {
       );
     });
   });
+
+  group('candidate freshness (stale queue guard)', () {
+    final now = DateTime.utc(2026, 7, 17, 0, 0);
+
+    XPostCandidateSummary make({
+      String archetype = 'data_report',
+      String variant = 'household_tracker',
+      DateTime? generatedAt,
+    }) =>
+        XPostCandidateSummary(
+          id: 'id',
+          status: 'pending_approval',
+          candidateType: 't',
+          variant: variant,
+          archetype: archetype,
+          text: 'x',
+          replyTexts: const [],
+          generatedAt: generatedAt,
+        );
+
+    test('news_briefing expires after 24h', () {
+      final fresh = make(
+        archetype: 'news_briefing',
+        generatedAt: now.subtract(const Duration(hours: 23)),
+      );
+      final stale = make(
+        archetype: 'news_briefing',
+        generatedAt: now.subtract(const Duration(hours: 25)),
+      );
+      expect(isCandidateExpired(fresh, now), isFalse);
+      expect(isCandidateExpired(stale, now), isTrue);
+    });
+
+    test('data_report expires after 72h', () {
+      final fresh = make(
+        generatedAt: now.subtract(const Duration(hours: 71)),
+      );
+      final stale = make(
+        generatedAt: now.subtract(const Duration(days: 4)),
+      );
+      expect(isCandidateExpired(fresh, now), isFalse);
+      expect(isCandidateExpired(stale, now), isTrue);
+    });
+
+    test('election variants get the 72h window even without archetype', () {
+      final stale = make(
+        archetype: '',
+        variant: 'local_election_schedule_delta',
+        generatedAt: now.subtract(const Duration(days: 4)),
+      );
+      expect(isCandidateExpired(stale, now), isTrue);
+      expect(
+        candidateFreshnessWindow(stale),
+        const Duration(hours: 72),
+      );
+    });
+
+    test('unknown series falls back to 7 days and null generatedAt never '
+        'expires', () {
+      final unknown = make(
+        archetype: 'product_intro',
+        variant: 'brand_new_series',
+        generatedAt: now.subtract(const Duration(days: 6)),
+      );
+      expect(isCandidateExpired(unknown, now), isFalse);
+      expect(
+        isCandidateExpired(
+          make(
+            archetype: 'product_intro',
+            variant: 'brand_new_series',
+            generatedAt: now.subtract(const Duration(days: 8)),
+          ),
+          now,
+        ),
+        isTrue,
+      );
+      expect(isCandidateExpired(make(generatedAt: null), now), isFalse);
+    });
+
+    test('rejected status label is defined for the upcoming reject action',
+        () {
+      const rejected = XPostCandidateSummary(
+        id: 'r',
+        status: 'rejected',
+        candidateType: 't',
+        variant: 'household_tracker',
+        archetype: 'data_report',
+        text: 'x',
+        replyTexts: [],
+        generatedAt: null,
+      );
+      expect(rejected.statusLabel, '却下済み');
+      expect(rejected.isActionable, isFalse);
+    });
+  });
 }

--- a/test/services/growth_mission_service_test.dart
+++ b/test/services/growth_mission_service_test.dart
@@ -147,8 +147,79 @@ void main() {
       syncCompleter.complete();
       await Future<void>.delayed(Duration.zero);
     });
+
+    test('global cooldown suppresses immediate sync across different routes',
+        () async {
+      final service = _FakePresenceService(Future<void>.value());
+      final observer = GrowthPresenceNavigatorObserver(
+        service: service,
+        acquisitionService: const _NoopGrowthAcquisitionService(),
+      );
+      addTearDown(observer.dispose);
+
+      observer.didPush(_namedRoute('/a'), null);
+      await Future<void>.delayed(Duration.zero);
+      // 45秒のグローバル cooldown 内なので、別ページへの遷移でも
+      // 即時 sync は走らない (次の heartbeat が正しい path を書く)。
+      observer.didPush(_namedRoute('/b'), null);
+
+      expect(service.syncPresenceCalls, 1);
+      expect(service.syncedPagePaths, <String>['/a']);
+    });
+
+    test(
+        'first route "/" (root entry) still records touchpoint and referral '
+        'hooks despite matching the initial page path', () async {
+      final service = _FakePresenceService(Future<void>.value());
+      final acquisition = _RecordingAcquisitionService();
+      final observer = GrowthPresenceNavigatorObserver(
+        service: service,
+        acquisitionService: acquisition,
+      );
+      addTearDown(observer.dispose);
+
+      // _currentPagePath の初期値 '/' と初回ルート '/' が一致しても、
+      // 初回は必ず track する (root 直行流入の獲得計測が沈黙する回帰の防止)。
+      observer.didPush(_namedRoute('/'), null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service.syncPresenceCalls, 1);
+      expect(acquisition.recordedPagePaths, <String>['/']);
+
+      // 2回目以降の同一 path は skip される。
+      observer.didPush(_namedRoute('/'), null);
+      expect(acquisition.recordedPagePaths, <String>['/']);
+    });
+
+    test('unnamed routes (dialogs) do not trigger presence writes', () async {
+      final service = _FakePresenceService(Future<void>.value());
+      final observer = GrowthPresenceNavigatorObserver(
+        service: service,
+        acquisitionService: const _NoopGrowthAcquisitionService(),
+      );
+      addTearDown(observer.dispose);
+
+      observer.didPush(_namedRoute('/a'), null);
+      await Future<void>.delayed(Duration.zero);
+      // ダイアログ等の無名ルートは「直前ページに滞在中」として扱い、
+      // presence 書き込みを発生させない。
+      observer.didPush(_unnamedRoute(), null);
+      observer.didPop(_unnamedRoute(), _namedRoute('/a'));
+
+      expect(service.syncPresenceCalls, 1);
+      expect(service.syncedPagePaths, <String>['/a']);
+    });
   });
 }
+
+MaterialPageRoute<void> _namedRoute(String name) => MaterialPageRoute<void>(
+      settings: RouteSettings(name: name),
+      builder: (_) => const SizedBox.shrink(),
+    );
+
+MaterialPageRoute<void> _unnamedRoute() => MaterialPageRoute<void>(
+      builder: (_) => const SizedBox.shrink(),
+    );
 
 class _FakePresenceService extends GrowthMissionService {
   _FakePresenceService(this._syncFuture);
@@ -182,4 +253,16 @@ class _NoopGrowthAcquisitionService extends GrowthAcquisitionService {
     String pagePath, {
     Uri? currentUri,
   }) async {}
+}
+
+class _RecordingAcquisitionService extends GrowthAcquisitionService {
+  final List<String> recordedPagePaths = <String>[];
+
+  @override
+  Future<void> recordTouchpointForPagePath(
+    String pagePath, {
+    Uri? currentUri,
+  }) async {
+    recordedPagePaths.add(pagePath);
+  }
 }

--- a/test/services/landing_share_service_test.dart
+++ b/test/services/landing_share_service_test.dart
@@ -21,6 +21,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 class _FakeLandingPageAdapter implements LandingPageAdapter {
   int loadShareSnapshotCallCount = 0;
   int loadLpViewStatsCallCount = 0;
+  int recordLpViewCallCount = 0;
   final List<String> sharedChannels = <String>[];
 
   LandingShareSnapshot shareSnapshot = const LandingShareSnapshot(
@@ -56,6 +57,11 @@ class _FakeLandingPageAdapter implements LandingPageAdapter {
   Future<LandingPageViewStats> loadLpViewStats() async {
     loadLpViewStatsCallCount += 1;
     return lpViewStats;
+  }
+
+  @override
+  Future<void> recordLpView() async {
+    recordLpViewCallCount += 1;
   }
 
   @override
@@ -614,6 +620,8 @@ void main() {
     expect(find.byKey(const Key('landing_comparison_links')), findsOneWidget);
     expect(adapter.loadShareSnapshotCallCount, 0);
     expect(adapter.loadLpViewStatsCallCount, 0);
+    // LP View 計測 (increment_lp_view + 流入元帰属) は初期表示で1回だけ走る。
+    expect(adapter.recordLpViewCallCount, 1);
   });
 
   testWidgets(

--- a/test/services/version_check_service_test.dart
+++ b/test/services/version_check_service_test.dart
@@ -37,4 +37,27 @@ void main() {
       expect(service.isOutdated('1.0.1', '1.0.x'), isFalse);
     });
   });
+
+  group('VersionCheckService.shouldCheck (checkNow cooldown)', () {
+    test('first check (no previous timestamp) is allowed', () {
+      final s = VersionCheckService();
+      expect(s.shouldCheck(DateTime(2026, 7, 17, 9, 0)), isTrue);
+    });
+
+    test('check within 5 minutes of the previous one is suppressed', () {
+      final s = VersionCheckService();
+      s.debugSetLastCheckedAt(DateTime(2026, 7, 17, 9, 0));
+      // フォーカス往復相当: 数秒〜数分後の再チェックは抑制される。
+      expect(s.shouldCheck(DateTime(2026, 7, 17, 9, 0, 30)), isFalse);
+      expect(s.shouldCheck(DateTime(2026, 7, 17, 9, 4, 59)), isFalse);
+    });
+
+    test('check after the 5 minute gap is allowed again', () {
+      final s = VersionCheckService();
+      s.debugSetLastCheckedAt(DateTime(2026, 7, 17, 9, 0));
+      expect(s.shouldCheck(DateTime(2026, 7, 17, 9, 5)), isTrue);
+      // 30分ポーリングは常に gap より長いので影響を受けない。
+      expect(s.shouldCheck(DateTime(2026, 7, 17, 9, 30)), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## 概要

経営分析ダッシュボードについて **10 の改善仮説を立て、全件を並列検証** (検証エージェント 10 + 敵対レビュー 2 レンズ×10、本番 API 実測込み) した結果に基づく改善 PR。10 仮説すべてが生存 (confirmed 5 / partially_confirmed 5 / 棄却 0) し、クライアント側で修正可能な 8 件を本 PR で実装した。

実測ベースライン (2026-07-17 08:41 JST, DevTools): 初期表示 81 リクエスト / 492kB。

## 仮説→検証→修正の対応表

| # | 仮説 | 検証結果 (本番実測) | 本PRでの修正 |
|---|------|---------------------|--------------|
| H1 | growth-hub/admin-hub 呼び出し過多 | confirmed: growth-hub×6 + admin-hub×3/初期表示、`_loadStats` 内は直列 await | 4 ローダーを並列化 (スピナー時間短縮)。バッチ action 化は次 PR |
| H2 | user_presence 書き込み過剰 (実測 3.66s) | partially: DB スキーマは健全 (3行/143ms)。真因はルート遷移毎の即時 upsert+タイマーリセット。歴代 upsert 試行 ≈11.6万回、`minified:yL<dynamic>` 汚染行も実在 | 同一 path skip / 無名ルート(ダイアログ)は直前 path 維持 / グローバル 45 秒 cooldown / タイマー温存。**初回ルート `/` は必ず track** (敵対レビューが検出した獲得計測沈黙の回帰を防止) |
| H3 | version.json 過剰ポーリング (~6分に8回) | partially: Timer 多重化ではなく、フォーカス復帰毎の `checkNow()` 無条件発火が真因 | `checkNow` に 5 分 cooldown + 単体テスト |
| H4 | blog_posts 取得 219kB 肥大 | confirmed: `content` 列が転送の 84% (実測 59,987B→9,406B) | 一覧 select から content 除去、編集時に単件 lazy fetch (取得失敗時はダイアログを開かず中断 = 空本文上書き事故ガード) |
| H5 | wbs_tasks 56.8kB + schedule_task_runs 二重取得 | confirmed: 3599 行が PostgREST 上限 1000 で切断され **lane 統計が約 90% 過小** (非 completed 979 行中 101 行のみ集計) | 非 completed のみ+id tiebreaker 付きページング取得。schedule_task_runs は共有リポジトリで一本化 (手動 Refresh は force 付き) |
| H6 | AI クォータ「未計測」= 計測パイプライン故障 | confirmed: Gemini は参照名 mismatch (実登録は GEMINI_API_KEY)。Anthropic の「正常 $0」は実在しないエンドポイントへの silent failure の捏造値 | Gemini 参照名修正 / Anthropic を cost_report API へ (最小通貨単位→/100 換算、失敗時は行を書かず「未計測」表示に倒す) / OpenAI を costs API へ刷新 / summary でキー未設定と API エラーを区別 |
| H7 | 6955 行モノリシック page の全体 rebuild | partially: スピナーゲートで初期 rebuild は限定的だが、検索 1 キーストロークで全体 rebuild 等の実害あり | 本 PR ではスコープ外 (段階分割計画を Issue 化) |
| H8 | 登録ファネル全ゼロ = 計測配線 or TZ バグ | **LP View 計測は 2026-03-28 (7b92a33d6) に配線ごと削除され累計 89 で凍結** (今日の登録ファネル最上段が恒久ゼロ)。TZ バグは棄却 | `recordLpView()` を新設して LandingPage initState から発火 (increment_lp_view + 流入元帰属の復旧)。回帰テスト追加 |
| H9 | X投稿候補キューに 4 日前の news_briefing が残存 | confirmed: 状態機械に却下/expire が無く、鮮度チェックゼロで承認可能 | 鮮度ゲート (news_briefing 24h / data_report 72h / 選挙系 72h / 既定 7 日)。鮮度切れは承認ボタン無効化+バッジ。EF 側 reject action は次 PR |
| H10 | 未返信 36 件の導線欠如 + 停止済み Qiita の表示 | partially: dev.to コメントは日次同期で生きており「全件 Qiita」ではない (敵対レビューで確定)。返信済みマーク経路も不在 | Qiita 停止の単一ソースフラグ (`kQiitaAccountSuspended`): 同期 skip / チップ「停止中」/ 返信ボタン無効化 / 新規下書き既定 devto。未返信 statCard タップ→コメントタブ未返信フィルタ+記事リンク |

## 敵対レビュー (実装後)

3 レンズ (正確性 / 回帰 / 本番データ経路) × 指摘毎の敵対検証で **実在欠陥 5 件を検出し全て修正済み**:

1. major: 初回ルート `/` で touchpoint/referral 記録が沈黙する回帰 → `_hasTrackedRoute` で初回は必ず track + 回帰テスト
2. major: Anthropic cost_report の amount は最小通貨単位 (セント) — 100 倍の誤値を保存するところだった → `/100` 換算 (公式ドキュメントで裏取り)
3. minor: 共有リポジトリの TTL が手動 Refresh を 30 秒 no-op 化 → `force` パラメータ
4. minor: wbs_tasks ページングに tiebreaker 無し → `.order('id')` + id dedupe
5. minor: quota summary が API エラーを「キー未設定」と誤表示 → status 出し分け

## 検証

- flutter analyze: 変更ファイル全バッチ **No issues found!** (pre-commit の全体 analyze も green)
- flutter test: VM テスト全パス (既存 35 + 新規 8 = 回帰/鮮度/cooldown/初回ルート)
- quota-monitor.yml: YAML パース + 埋め込み Python 8 ブロックの構文検証済み
- 本番 API 実測 (読み取りのみ) で仮説の根拠を裏取り済み

## ユーザー作業 (コード外・任意)

- OPENAI_API_KEY (Admin キー) / HEDRA_API_KEY / Anthropic Admin キーの登録で該当プロバイダの計測が有効化されます (未登録でも「未計測」と誠実表示されるだけで障害なし)

## Follow-up (次 PR / Issue 化予定)

- growth-hub バッチ action + CORS Access-Control-Max-Age + x.candidate.reject (EF 変更のため別 PR)
- presence メンテナンス RPC の pg_cron 化
- H7: admin_analytics_page の段階的セクション分割

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 変更は管理ダッシュボードの読み取り経路と純ロジックが中心で、VM ユニットテスト43件+回帰テストで入出力を検証済み。UI 到達経路は管理者ログイン必須のため E2E 追加は次PRで検討

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Client-side dashboard fixes only: no edge functions, no schema changes, no CI workflow behavior change beyond quota monitoring accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
