### PR TITLE
feat(asset): 期限超過の次の一手具体化 + 原資未設定バナー + リボ脱却プラン (advisory 提案 part338)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -393,6 +393,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final _keyCardStatementReconciliation = GlobalKey();
   // 口座間移動の提案セクションへのスクロール用 (残高不足バナーからのジャンプ)。
   final _keyTransferSuggestionSection = GlobalKey();
+  // 負債コントロールレビュー (原資未設定一覧) へのスクロール用 (原資未設定バナーからのジャンプ)。
+  final _keyDebtControlReviewSection = GlobalKey();
 
   Timer? _deadlineTimer;
   DateTime _now = DateTime.now();
@@ -1143,6 +1145,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   void _jumpToTransferSuggestionSection() {
     _scrollTo(_keyTransferSuggestionSection);
+  }
+
+  void _jumpToDebtControlReviewSection() {
+    _scrollTo(_keyDebtControlReviewSection);
   }
 
   List<String> _paymentSourceCandidates() {
@@ -8418,6 +8424,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             _buildSyncStatusBanner(),
             _buildUnsyncedBadgeRow(),
             _buildAccountShortfallAlertBanner(assetLiabilityWorkbook),
+            _buildPaymentSourceMissingBanner(assetLiabilityWorkbook),
             _buildAutoDebitConfirmationCard(assetLiabilityWorkbook),
             _buildSalaryDepositNudgeCard(assetLiabilityWorkbook),
             const SizedBox(height: 12),
@@ -13246,6 +13253,133 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  /// 支払原資口座が未設定の支払いをページ最上部で警告する。
+  /// 原資未設定の支払いはどの口座の見込み残高からも差し引かれず、
+  /// 残高不足バナー（口座別先読み）が働かない盲点になるため、
+  /// 件数・金額・残高付きの設定候補と設定導線をセットで出す。
+  Widget _buildPaymentSourceMissingBanner(AssetLiabilityWorkbook? workbook) {
+    if (workbook == null || !workbook.hasPaymentSourceMissingRows) {
+      return const SizedBox.shrink();
+    }
+    final rows = workbook.paymentSourceMissingRows
+      ..sort(
+        (a, b) => b.scheduledPaymentAmount.compareTo(a.scheduledPaymentAmount),
+      );
+    return Container(
+      key: const Key('asset_payment_source_missing_banner'),
+      width: double.infinity,
+      margin: const EdgeInsets.only(top: 8, bottom: 12),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0xFFFDE68A)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.account_balance_wallet_outlined,
+                size: 16,
+                color: Color(0xFFB45309),
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  '支払原資口座が未設定の支払い'
+                  '（${rows.length}件 / 合計 ${_formatManagementYen(workbook.paymentSourceMissingTotal)}）',
+                  // 背景が固定の淡黄のため、ダークテーマの onSurface(白)だと
+                  // 読めなくなる。文字色も固定の濃橙系にする。
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFFB45309),
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          for (final row in rows.take(3))
+            _buildPaymentSourceMissingBannerRow(row, workbook),
+          if (rows.length > 3)
+            Text(
+              'ほか${rows.length - 3}件の支払いで原資口座が未設定です。',
+              style: const TextStyle(
+                fontSize: 11,
+                color: Color(0xFF92400E),
+                height: 1.5,
+              ),
+            ),
+          // ジャンプ先の原資未設定一覧は workbookBoard 内にあり、表示モード次第で
+          // 非描画になる。その場合スクロールが silent no-op になるため出さない。
+          if (_isSectionShown(AssetManagementSectionId.workbookBoard))
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                key: const Key('asset_payment_source_missing_jump'),
+                style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  foregroundColor: const Color(0xFFB45309),
+                ),
+                onPressed: _jumpToDebtControlReviewSection,
+                icon: const Icon(Icons.arrow_downward, size: 16),
+                label: const Text('原資未設定の一覧へ移動'),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPaymentSourceMissingBannerRow(
+    AssetLiabilityDebtRow row,
+    AssetLiabilityWorkbook workbook,
+  ) {
+    // じぶん銀行のように預金と負債が同一 id になる名前があるため自分自身は除外。
+    _PaymentSourceCandidate? candidate;
+    for (final entry in _paymentSourceCandidatesForRow(row, workbook)) {
+      if (entry.account.id != row.id) {
+        candidate = entry;
+        break;
+      }
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '「${row.name}」支払日 ${row.paymentDay ?? '-'}日 / '
+            '予定 ${_formatManagementYen(row.scheduledPaymentAmount)}',
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: Color(0xFFB45309),
+              height: 1.5,
+            ),
+          ),
+          Text(
+            candidate == null
+                ? '残高のある現金・預金口座が見つかりません。入金後に原資口座を設定してください。'
+                : '候補: ${candidate.account.name}'
+                    '（現在 ${_formatManagementYen(candidate.currentBalance)} / '
+                    '支払後見込み ${_formatManagementYen(candidate.projectedAfterPayment)}）',
+            style: const TextStyle(
+              fontSize: 11,
+              color: Color(0xFF92400E),
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildAutoDebitConfirmationCard(AssetLiabilityWorkbook? workbook) {
     if (workbook == null) {
       return const SizedBox.shrink();
@@ -18062,7 +18196,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             const SizedBox(height: 12),
             _buildAssetWorkbookWarning(workbook),
             const SizedBox(height: 16),
-            _buildDebtControlReviewSection(workbook),
+            KeyedSubtree(
+              key: _keyDebtControlReviewSection,
+              child: _buildDebtControlReviewSection(workbook),
+            ),
             const SizedBox(height: 16),
             _buildAssetPaymentReminderPanel(workbook),
             const SizedBox(height: 16),
@@ -20130,6 +20267,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 value: _formatManagementYen(violation.currentBalance),
                 color: const Color(0xFF6B7280),
               ),
+              if (violation.hasEscapePlan)
+                _buildAssetLiabilitySyncChip(
+                  label: '${violation.escapeMonths}ヶ月脱却の月額',
+                  value: _formatManagementYen(violation.escapeMonthlyPayment!),
+                  color: const Color(0xFF0D9488),
+                ),
+              if (violation.currentPlanPayoffMonths case final months?)
+                _buildAssetLiabilitySyncChip(
+                  label: '現状ペース完済',
+                  value: '約$monthsヶ月',
+                  color: const Color(0xFF6B7280),
+                ),
             ],
           ),
         ],

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -20224,8 +20224,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           const SizedBox(height: 4),
           Text(
             violation.problem,
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            // 背景が固定の白のため、ダークテーマの onSurfaceVariant(淡色)だと
+            // 読めなくなる。文字色も固定の濃スレート系にする。
+            style: const TextStyle(
+              color: Color(0xFF475569),
               fontSize: 12,
               height: 1.5,
             ),
@@ -20246,7 +20248,12 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 Expanded(
                   child: Text(
                     violation.action,
-                    style: const TextStyle(fontSize: 12, height: 1.5),
+                    // 固定白タイル上のためテーマ色でなく固定の濃色にする。
+                    style: const TextStyle(
+                      color: Color(0xFF1F2937),
+                      fontSize: 12,
+                      height: 1.5,
+                    ),
                   ),
                 ),
               ],

--- a/lib/services/asset_debt_discipline_monitor.dart
+++ b/lib/services/asset_debt_discipline_monitor.dart
@@ -63,7 +63,8 @@ class AssetDebtDisciplineViolation {
   });
 
   /// 具体的な脱却プラン（月額×期間）を提示できるか。
-  bool get hasEscapePlan => escapeMonths != null && escapeMonthlyPayment != null;
+  bool get hasEscapePlan =>
+      escapeMonths != null && escapeMonthlyPayment != null;
 }
 
 /// 「借金しない宣言」モニターの月次評価結果。
@@ -238,8 +239,7 @@ class AssetDebtDisciplineMonitor {
                 '現在の予定額 月${_yen(payment)}では利息に追いつかず、完済の見込みが立ちません。';
           } else {
             // 利息は上回るがシミュレーション上限 (600ヶ月) 内に完済しない。
-            currentPlanText =
-                '現在の予定額 月${_yen(payment)}では完済まで50年以上かかる見込みです。';
+            currentPlanText = '現在の予定額 月${_yen(payment)}では完済まで50年以上かかる見込みです。';
           }
           revolving.add(
             AssetDebtDisciplineViolation(

--- a/lib/services/asset_debt_discipline_monitor.dart
+++ b/lib/services/asset_debt_discipline_monitor.dart
@@ -30,6 +30,22 @@ class AssetDebtDisciplineViolation {
   /// 画面・プロンプトに出す「どうすべきか」一文。
   final String action;
 
+  /// revolvingCard: リボ状態から脱却する目標月数（現状は
+  /// [AssetDebtDisciplineMonitor.escapeTargetMonths]）。newBorrowing は null。
+  final int? escapeMonths;
+
+  /// revolvingCard: [escapeMonths] ヶ月で残高を完済するために必要な
+  /// 毎月返済額（年利込み・100円単位切り上げ）。newBorrowing は null。
+  final double? escapeMonthlyPayment;
+
+  /// revolvingCard: 今月の返済予定額を続けた場合の完済見込み月数。
+  /// 完済できない（返済が利息以下）か返済予定 0 の場合は null。
+  final int? currentPlanPayoffMonths;
+
+  /// revolvingCard: 今月の返済予定額を続けた場合の利息総額見込み。
+  /// [currentPlanPayoffMonths] が null のときは null。
+  final double? currentPlanTotalInterest;
+
   const AssetDebtDisciplineViolation({
     required this.type,
     required this.severity,
@@ -40,7 +56,14 @@ class AssetDebtDisciplineViolation {
     required this.currentBalance,
     required this.problem,
     required this.action,
+    this.escapeMonths,
+    this.escapeMonthlyPayment,
+    this.currentPlanPayoffMonths,
+    this.currentPlanTotalInterest,
   });
+
+  /// 具体的な脱却プラン（月額×期間）を提示できるか。
+  bool get hasEscapePlan => escapeMonths != null && escapeMonthlyPayment != null;
 }
 
 /// 「借金しない宣言」モニターの月次評価結果。
@@ -101,6 +124,9 @@ class AssetDebtDisciplineMonitor {
 
   /// 「新規利用が発生した」と見なす最小額（円）。推定誤差のノイズを問題化しない。
   final double newBorrowingThreshold;
+
+  /// リボ/分割違反に提示する脱却プランの目標月数。
+  static const int escapeTargetMonths = 12;
 
   static const double _epsilon = 1;
 
@@ -181,6 +207,36 @@ class AssetDebtDisciplineMonitor {
         final interestBearing = row.annualRate > 0;
         if (carriedOver > _epsilon && interestBearing) {
           totalCarried += carriedOver;
+          // 「いつまでに・いくら返せば脱却できるか」を Dart 側で確定させる。
+          // AI は説明のみ（calculation_owner: dart_service）。
+          final monthlyRate = row.annualRate / 12;
+          final escapePayment = AssetDebtTrendAnalyzer.paymentToClearIn(
+            balance,
+            monthlyRate,
+            escapeTargetMonths,
+          );
+          final currentPlan = payment > 0
+              ? AssetDebtTrendAnalyzer.estimatePayoff(
+                  balance: balance,
+                  monthlyRate: monthlyRate,
+                  monthlyPayment: payment,
+                )
+              : null;
+          final currentPlanMonths =
+              (currentPlan != null && currentPlan.everPaysOff)
+                  ? currentPlan.months
+                  : null;
+          final String currentPlanText;
+          if (payment <= 0) {
+            currentPlanText = '今月の返済予定が未入力のため、現状ペースの完済見込みを出せません。';
+          } else if (currentPlanMonths != null) {
+            currentPlanText =
+                '現在の予定額 月${_yen(payment)}のままでは完済まで約$currentPlanMonthsヶ月・'
+                '利息総額 約${_yen(currentPlan!.totalInterest)}かかります。';
+          } else {
+            currentPlanText =
+                '現在の予定額 月${_yen(payment)}では利息に追いつかず、完済の見込みが立ちません。';
+          }
           revolving.add(
             AssetDebtDisciplineViolation(
               type: AssetDebtDisciplineViolationType.revolvingCard,
@@ -194,8 +250,16 @@ class AssetDebtDisciplineMonitor {
                   '${row.name}は残高${_yen(balance)}に対し今月の返済予定が${_yen(payment)}で、'
                   '${_yen(carriedOver)}が翌月へ繰り越され利息が発生します（＝リボ/分割の状態）。'
                   '「カードは必ず一括返済」誓約に反しています。',
-              action: 'リボ/分割の設定を解除し、残高${_yen(balance)}を一括返済してください。'
+              action: 'リボ/分割の設定を解除し、残高${_yen(balance)}の一括返済が最優先です。'
+                  '一括が難しい場合も、月${_yen(escapePayment)}以上の返済を続ければ'
+                  '約$escapeTargetMonthsヶ月でリボ状態から脱却できます。'
+                  '$currentPlanText'
                   '今後カードを使うときは必ず一括（1回払い）に設定し、残高を翌月へ繰り越さないでください。',
+              escapeMonths: escapeTargetMonths,
+              escapeMonthlyPayment: escapePayment,
+              currentPlanPayoffMonths: currentPlanMonths,
+              currentPlanTotalInterest:
+                  currentPlanMonths == null ? null : currentPlan!.totalInterest,
             ),
           );
         }

--- a/lib/services/asset_debt_discipline_monitor.dart
+++ b/lib/services/asset_debt_discipline_monitor.dart
@@ -233,9 +233,13 @@ class AssetDebtDisciplineMonitor {
             currentPlanText =
                 '現在の予定額 月${_yen(payment)}のままでは完済まで約$currentPlanMonthsヶ月・'
                 '利息総額 約${_yen(currentPlan!.totalInterest)}かかります。';
-          } else {
+          } else if (payment <= balance * monthlyRate + _epsilon) {
             currentPlanText =
                 '現在の予定額 月${_yen(payment)}では利息に追いつかず、完済の見込みが立ちません。';
+          } else {
+            // 利息は上回るがシミュレーション上限 (600ヶ月) 内に完済しない。
+            currentPlanText =
+                '現在の予定額 月${_yen(payment)}では完済まで50年以上かかる見込みです。';
           }
           revolving.add(
             AssetDebtDisciplineViolation(

--- a/lib/services/asset_debt_trend_analyzer.dart
+++ b/lib/services/asset_debt_trend_analyzer.dart
@@ -171,7 +171,7 @@ class AssetDebtTrendAnalyzer {
     final delta = priorBalance == null ? null : balance - priorBalance;
 
     final breakEven = interest + 1;
-    final payoff24 = _paymentToClearIn(balance, monthlyRate, 24);
+    final payoff24 = paymentToClearIn(balance, monthlyRate, 24);
     final estimate = estimatePayoff(
       balance: balance,
       monthlyRate: monthlyRate,
@@ -411,7 +411,7 @@ class AssetDebtTrendAnalyzer {
   /// [targetMonths] ヶ月で完済するために必要な毎月返済額（年金現価式）。
   ///
   /// 月利 0 のときは単純に balance / months。100 円単位へ切り上げる。
-  double _paymentToClearIn(
+  static double paymentToClearIn(
     double balance,
     double monthlyRate,
     int targetMonths,

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -411,6 +411,20 @@ class AssetManagementInsightService {
     final actions = <AssetManagementInsightActionItem>[];
     final today = _dateOnly(workbook.baseDate);
     final upcomingLimit = today.add(Duration(days: upcomingPaymentWarningDays));
+    final accountsById = <String, AssetLiabilityAccount>{
+      for (final account in workbook.accounts) account.id: account,
+    };
+    // 原資未設定の負債に提示する引落口座候補（ページ側の候補一覧と同じ
+    // 現金/預金・残高ありの条件）。残高降順で最有力を 1 件だけ本文に載せる。
+    final paymentSourceCandidates = workbook.accounts
+        .where(
+          (account) =>
+              account.balance > 0 &&
+              (account.kind == AssetLiabilityAccountKind.cash ||
+                  account.kind == AssetLiabilityAccountKind.deposit),
+        )
+        .toList()
+      ..sort((a, b) => b.balance.compareTo(a.balance));
 
     for (final row in workbook.debtMasterRows) {
       if (row.paymentAmountEstimated && row.isDirectCashflowTarget) {
@@ -459,16 +473,30 @@ class AssetManagementInsightService {
           !row.paid &&
           (row.paymentSourceAccountId == null ||
               row.paymentSourceAccountId!.trim().isEmpty)) {
+        // じぶん銀行のように預金と負債が同一 id になる名前があるため自分自身は除外。
+        AssetLiabilityAccount? candidate;
+        for (final account in paymentSourceCandidates) {
+          if (account.id != row.id) {
+            candidate = account;
+            break;
+          }
+        }
         actions.add(
           AssetManagementInsightActionItem(
             type: AssetManagementInsightActionType.missingPaymentSource,
             severity: AssetManagementInsightSeverity.warning,
             title: '${row.name}の支払原資口座が未設定です',
-            description: 'どの口座から引き落とすか未設定のため、口座別資金繰りに反映しにくい状態です。',
+            description: 'どの口座から引き落とすか未設定のため、'
+                '今月予定${_formatYen(row.scheduledPaymentAmount)}が'
+                'どの口座の見込み残高からも差し引かれず、残高不足を先読みできない状態です。',
             relatedAccountId: row.id,
             dueDate: _paymentDateFor(row, workbook.baseDate),
             paymentDay: row.paymentDay,
-            suggestedAction: '通常使う引落口座をデフォルト、または今月だけ上書きで設定してください。',
+            suggestedAction: candidate == null
+                ? '残高のある現金・預金口座が見つかりません。入金後に'
+                    '「支払原資口座の未設定」一覧から引落口座を設定してください。'
+                : '候補: ${candidate.name}（残高 ${_formatYen(candidate.balance)}）。'
+                    '「支払原資口座の未設定」一覧から今月だけ上書き、または既定で設定してください。',
           ),
         );
       }
@@ -479,16 +507,44 @@ class AssetManagementInsightService {
         continue;
       }
       if (row.overdue) {
+        // 期限超過は「いくらを・どうやって」まで具体化する（金額は支払予定額。
+        // 残高を延滞額扱いしない、のプロンプト規約と揃える）。
+        final overdueDays = today.difference(_dateOnly(row.paymentDate)).inDays;
+        final sourceAccountId = row.paymentSourceAccountId?.trim() ?? '';
+        final sourceAccount =
+            sourceAccountId.isEmpty ? null : accountsById[sourceAccountId];
+        final String suggestedAction;
+        if (sourceAccount == null) {
+          suggestedAction = '支払原資口座が未設定です。引落口座を設定したうえで、'
+              '振込・口座振替・支払先への連絡のどれで支払うかを確認してください。'
+              '支払済みの場合は支払済みチェックを更新してください。';
+        } else if (sourceAccount.balance >= row.paymentAmount) {
+          suggestedAction =
+              '${sourceAccount.name}の残高${_formatYen(sourceAccount.balance)}で'
+              '支払可能です。引落状況を確認し、未処理なら'
+              '${_formatYen(row.paymentAmount)}を支払って支払済みチェックを更新してください。';
+        } else {
+          final shortage = row.paymentAmount - sourceAccount.balance;
+          suggestedAction =
+              '${sourceAccount.name}の残高が${_formatYen(shortage)}不足しています。'
+              '他口座から${_formatYen(shortage)}以上を${sourceAccount.name}へ移動してから、'
+              '${_formatYen(row.paymentAmount)}を支払ってください。';
+        }
         actions.add(
           AssetManagementInsightActionItem(
             type: AssetManagementInsightActionType.overduePayment,
             severity: AssetManagementInsightSeverity.critical,
             title: '${row.accountName}が期限超過です',
-            description: '支払日を過ぎた未払い予定があります。',
+            description: overdueDays <= 0
+                ? '本日${row.paymentDate.month}月${row.paymentDate.day}日支払予定の'
+                    '${_formatYen(row.paymentAmount)}が未払いです。'
+                : '${row.paymentDate.month}月${row.paymentDate.day}日支払予定の'
+                    '${_formatYen(row.paymentAmount)}が未払いのまま'
+                    '$overdueDays日経過しています。',
             relatedAccountId: row.accountId,
             dueDate: row.paymentDate,
             paymentDay: row.paymentDay,
-            suggestedAction: '残高と引落状況を確認し、支払済みならチェックを更新してください。',
+            suggestedAction: suggestedAction,
           ),
         );
       } else if (!row.paymentDate.isBefore(today) &&

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -411,20 +411,20 @@ class AssetManagementInsightService {
     final actions = <AssetManagementInsightActionItem>[];
     final today = _dateOnly(workbook.baseDate);
     final upcomingLimit = today.add(Duration(days: upcomingPaymentWarningDays));
-    final accountsById = <String, AssetLiabilityAccount>{
-      for (final account in workbook.accounts) account.id: account,
+    // 口座別見込み残高 (同口座の未払い・保留中の口座移動を合算済み)。
+    // 期限超過の支払可否判定と原資候補の順位付けは、口座別不足バナーと
+    // 同じこの数字に揃える (行単位の生残高比較は同一口座の兄弟未払いを
+    // 二重取りするため使わない)。cash-like 口座のみ含まれるので、
+    // じぶん銀行のように預金と負債が同一 id になる名前でも負債側を拾わない。
+    final summariesByAccountId = <String, AssetLiabilityAccountCashflowSummary>{
+      for (final summary in workbook.accountCashflowSummaries)
+        summary.accountId: summary,
     };
-    // 原資未設定の負債に提示する引落口座候補（ページ側の候補一覧と同じ
-    // 現金/預金・残高ありの条件）。残高降順で最有力を 1 件だけ本文に載せる。
-    final paymentSourceCandidates = workbook.accounts
-        .where(
-          (account) =>
-              account.balance > 0 &&
-              (account.kind == AssetLiabilityAccountKind.cash ||
-                  account.kind == AssetLiabilityAccountKind.deposit),
-        )
-        .toList()
-      ..sort((a, b) => b.balance.compareTo(a.balance));
+    // 原資未設定の負債に提示する引落口座候補。ページ上部バナーの候補一覧と
+    // 同じ順位付け (支払後見込み残高の大きい順) で最有力を 1 件だけ本文に載せる。
+    final paymentSourceCandidateSummaries =
+        workbook.accountCashflowSummaries.toList()
+          ..sort((a, b) => b.projectedBalance.compareTo(a.projectedBalance));
 
     for (final row in workbook.debtMasterRows) {
       if (row.paymentAmountEstimated && row.isDirectCashflowTarget) {
@@ -474,10 +474,10 @@ class AssetManagementInsightService {
           (row.paymentSourceAccountId == null ||
               row.paymentSourceAccountId!.trim().isEmpty)) {
         // じぶん銀行のように預金と負債が同一 id になる名前があるため自分自身は除外。
-        AssetLiabilityAccount? candidate;
-        for (final account in paymentSourceCandidates) {
-          if (account.id != row.id) {
-            candidate = account;
+        AssetLiabilityAccountCashflowSummary? candidate;
+        for (final summary in paymentSourceCandidateSummaries) {
+          if (summary.accountId != row.id) {
+            candidate = summary;
             break;
           }
         }
@@ -495,7 +495,9 @@ class AssetManagementInsightService {
             suggestedAction: candidate == null
                 ? '残高のある現金・預金口座が見つかりません。入金後に'
                     '「支払原資口座の未設定」一覧から引落口座を設定してください。'
-                : '候補: ${candidate.name}（残高 ${_formatYen(candidate.balance)}）。'
+                : '候補: ${candidate.accountName}'
+                    '（残高 ${_formatYen(candidate.currentBalance)} / 支払後見込み '
+                    '${_formatYen(candidate.projectedBalance - row.scheduledPaymentAmount)}）。'
                     '「支払原資口座の未設定」一覧から今月だけ上書き、または既定で設定してください。',
           ),
         );
@@ -511,23 +513,34 @@ class AssetManagementInsightService {
         // 残高を延滞額扱いしない、のプロンプト規約と揃える）。
         final overdueDays = today.difference(_dateOnly(row.paymentDate)).inDays;
         final sourceAccountId = row.paymentSourceAccountId?.trim() ?? '';
-        final sourceAccount =
-            sourceAccountId.isEmpty ? null : accountsById[sourceAccountId];
+        final sourceSummary = sourceAccountId.isEmpty
+            ? null
+            : summariesByAccountId[sourceAccountId];
         final String suggestedAction;
-        if (sourceAccount == null) {
+        if (sourceAccountId.isEmpty) {
           suggestedAction = '支払原資口座が未設定です。引落口座を設定したうえで、'
               '振込・口座振替・支払先への連絡のどれで支払うかを確認してください。'
               '支払済みの場合は支払済みチェックを更新してください。';
-        } else if (sourceAccount.balance >= row.paymentAmount) {
+        } else if (sourceSummary == null) {
+          // id は設定済みだが残高一覧に現れない (残高0で除外・口座名変更・
+          // じぶん銀行のような負債側 id 等)。「未設定」と断定しない。
+          final sourceName = row.paymentSourceAccountName ?? sourceAccountId;
+          suggestedAction = '原資口座「$sourceName」の残高を今の資産一覧で確認できません'
+              '（残高0か口座名変更の可能性）。残高を入力し直すか、'
+              '残高のある口座へ原資設定を変更してから支払ってください。';
+        } else if (sourceSummary.projectedBalance >= 0) {
           suggestedAction =
-              '${sourceAccount.name}の残高${_formatYen(sourceAccount.balance)}で'
+              '${sourceSummary.accountName}の残高${_formatYen(sourceSummary.currentBalance)}で'
               '支払可能です。引落状況を確認し、未処理なら'
               '${_formatYen(row.paymentAmount)}を支払って支払済みチェックを更新してください。';
         } else {
-          final shortage = row.paymentAmount - sourceAccount.balance;
+          // 同一口座の未払い・保留中の口座移動を合算した見込み不足
+          // (口座別不足バナーと同じ数字) を提示する。
+          final shortage = sourceSummary.shortfall;
           suggestedAction =
-              '${sourceAccount.name}の残高が${_formatYen(shortage)}不足しています。'
-              '他口座から${_formatYen(shortage)}以上を${sourceAccount.name}へ移動してから、'
+              '${sourceSummary.accountName}は同口座の未払い分を含めると見込み残高が'
+              '${_formatYen(shortage)}不足します。他口座から${_formatYen(shortage)}以上を'
+              '${sourceSummary.accountName}へ移動してから、'
               '${_formatYen(row.paymentAmount)}を支払ってください。';
         }
         actions.add(

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -422,9 +422,9 @@ class AssetManagementInsightService {
     };
     // 原資未設定の負債に提示する引落口座候補。ページ上部バナーの候補一覧と
     // 同じ順位付け (支払後見込み残高の大きい順) で最有力を 1 件だけ本文に載せる。
-    final paymentSourceCandidateSummaries =
-        workbook.accountCashflowSummaries.toList()
-          ..sort((a, b) => b.projectedBalance.compareTo(a.projectedBalance));
+    final paymentSourceCandidateSummaries = workbook.accountCashflowSummaries
+        .toList()
+      ..sort((a, b) => b.projectedBalance.compareTo(a.projectedBalance));
 
     for (final row in workbook.debtMasterRows) {
       if (row.paymentAmountEstimated && row.isDirectCashflowTarget) {
@@ -537,8 +537,7 @@ class AssetManagementInsightService {
           // 同一口座の未払い・保留中の口座移動を合算した見込み不足
           // (口座別不足バナーと同じ数字) を提示する。
           final shortage = sourceSummary.shortfall;
-          suggestedAction =
-              '${sourceSummary.accountName}は同口座の未払い分を含めると見込み残高が'
+          suggestedAction = '${sourceSummary.accountName}は同口座の未払い分を含めると見込み残高が'
               '${_formatYen(shortage)}不足します。他口座から${_formatYen(shortage)}以上を'
               '${sourceSummary.accountName}へ移動してから、'
               '${_formatYen(row.paymentAmount)}を支払ってください。';

--- a/test/services/asset_debt_discipline_monitor_test.dart
+++ b/test/services/asset_debt_discipline_monitor_test.dart
@@ -139,6 +139,28 @@ void main() {
       expect(violation.action.contains('完済まで約'), isTrue);
     });
 
+    test('revolving violation reports 50+ years when payoff exceeds the cap',
+        () {
+      // 月12,505円は初月利息 (100万×月利1.25% = 12,500円) を僅かに上回るが、
+      // 完済まで約630ヶ月 (>600ヶ月キャップ) かかる →
+      // 「利息に追いつかず」ではなく50年以上と説明する。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -1000000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'ファミペイ': 12505},
+      );
+
+      final report = monitor.evaluate(workbook: workbook);
+
+      final violation = report.revolvingCardViolations.single;
+      expect(violation.currentPlanPayoffMonths, isNull);
+      expect(violation.action.contains('50年以上'), isTrue);
+      expect(violation.action.contains('利息に追いつかず'), isFalse);
+    });
+
     test('revolving violation warns when payment never clears the balance', () {
       // 月1,000円は初月利息 (年利15%なら1,250円) 以下 → 元金が減らない。
       final workbook = planner.buildWorkbook(

--- a/test/services/asset_debt_discipline_monitor_test.dart
+++ b/test/services/asset_debt_discipline_monitor_test.dart
@@ -111,6 +111,54 @@ void main() {
       expect(report.newBorrowingViolations, isEmpty);
     });
 
+    test('revolving violation carries a concrete escape plan', () {
+      // 残高10万・返済1万 → 繰越9万でリボ違反。脱却プランを具体化する。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -100000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'ファミペイ': 10000},
+      );
+
+      final report = monitor.evaluate(workbook: workbook);
+
+      final violation = report.revolvingCardViolations.single;
+      expect(violation.hasEscapePlan, isTrue);
+      expect(
+        violation.escapeMonths,
+        AssetDebtDisciplineMonitor.escapeTargetMonths,
+      );
+      // 12ヶ月完済の月額は単純割 (100,000/12 ≒ 8,334円) より利息分だけ大きい。
+      expect(violation.escapeMonthlyPayment! >= 100000 / 12, isTrue);
+      expect(violation.action.contains('リボ状態から脱却'), isTrue);
+      // 月1万円は利息を上回る → 現状ペースの完済見込みも提示できる。
+      expect(violation.currentPlanPayoffMonths, isNotNull);
+      expect(violation.currentPlanTotalInterest, isNotNull);
+      expect(violation.action.contains('完済まで約'), isTrue);
+    });
+
+    test('revolving violation warns when payment never clears the balance', () {
+      // 月1,000円は初月利息 (年利15%なら1,250円) 以下 → 元金が減らない。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'ファミペイ': -100000,
+        },
+        baseDate: baseDate,
+        monthlyPaymentOverrides: const <String, double>{'ファミペイ': 1000},
+      );
+
+      final report = monitor.evaluate(workbook: workbook);
+
+      final violation = report.revolvingCardViolations.single;
+      expect(violation.hasEscapePlan, isTrue);
+      expect(violation.currentPlanPayoffMonths, isNull);
+      expect(violation.currentPlanTotalInterest, isNull);
+      expect(violation.action.contains('完済の見込みが立ちません'), isTrue);
+    });
+
     test('does NOT flag a credit card paid in full this month', () {
       // 残高10万を全額返済 → 一括 → 違反なし。
       final workbook = planner.buildWorkbook(

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -174,7 +174,8 @@ void main() {
       expect(overdue.suggestedAction.contains('支払原資口座が未設定'), true);
     });
 
-    test('overdue payment action computes transfer shortage from source balance',
+    test(
+        'overdue payment action computes transfer shortage from source balance',
         () {
       final workbook = planner.buildWorkbook(
         latestSnapshot: const <String, double>{
@@ -197,7 +198,8 @@ void main() {
       expect(overdue.suggestedAction.contains('移動'), true);
     });
 
-    test('overdue payment action confirms payable when source balance covers it',
+    test(
+        'overdue payment action confirms payable when source balance covers it',
         () {
       final workbook = planner.buildWorkbook(
         latestSnapshot: const <String, double>{

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -153,6 +153,94 @@ void main() {
       expect(overdue.first.severity, AssetManagementInsightSeverity.critical);
     });
 
+    test('overdue payment action names amount and flags unset payment source',
+        () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布': 50000,
+          'モビット': -300000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 37000},
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      final overdue = report.actionItems.firstWhere(
+        (item) => item.type == AssetManagementInsightActionType.overduePayment,
+      );
+      // 金額は支払予定額 (残高を延滞額扱いしない)。
+      expect(overdue.description.contains('37,000円'), true);
+      expect(overdue.suggestedAction.contains('支払原資口座が未設定'), true);
+    });
+
+    test('overdue payment action computes transfer shortage from source balance',
+        () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布': 3000,
+          'モビット': -300000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 37000},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'wallet_cash'},
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      final overdue = report.actionItems.firstWhere(
+        (item) => item.type == AssetManagementInsightActionType.overduePayment,
+      );
+      // 不足額 = 37,000 − 3,000 = 34,000。
+      expect(overdue.suggestedAction.contains('34,000円'), true);
+      expect(overdue.suggestedAction.contains('財布'), true);
+      expect(overdue.suggestedAction.contains('移動'), true);
+    });
+
+    test('overdue payment action confirms payable when source balance covers it',
+        () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布': 50000,
+          'モビット': -300000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 37000},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'wallet_cash'},
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      final overdue = report.actionItems.firstWhere(
+        (item) => item.type == AssetManagementInsightActionType.overduePayment,
+      );
+      expect(overdue.suggestedAction.contains('支払可能'), true);
+      expect(overdue.suggestedAction.contains('支払済みチェック'), true);
+    });
+
+    test('missing payment source action suggests the largest cash-like account',
+        () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布': 1000,
+          '三井住友銀行大塚支店': 500000,
+          'PayPay': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'paypay_card': 20000},
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      final missing = report.actionItems.firstWhere(
+        (item) =>
+            item.type == AssetManagementInsightActionType.missingPaymentSource,
+      );
+      expect(missing.description.contains('20,000円'), true);
+      expect(missing.suggestedAction.contains('候補: 三井住友銀行大塚支店'), true);
+      expect(missing.suggestedAction.contains('500,000円'), true);
+    });
+
     test('calculates today, week, and month available amounts', () {
       final workbook = planner.buildWorkbook(
         latestSnapshot: const <String, double>{'bank': 50000, 'PayPay': -20000},

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -218,6 +218,97 @@ void main() {
       expect(overdue.suggestedAction.contains('支払済みチェック'), true);
     });
 
+    test('overdue actions on a shared source use the account-level shortfall',
+        () {
+      // 同一原資口座 (財布 40,000) に期限超過が2件 (30,000×2)。行単位の
+      // 生残高比較だと両方「支払可能」になるが、口座別見込み (40,000−60,000
+      // = −20,000) で判定し、不足バナーと同じ 20,000円不足を両方に出す。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布': 40000,
+          'モビット': -300000,
+          'auPayカード': -200000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 30000,
+          AssetLiabilityPlanningService.auPayCardAccountId: 30000,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          'mobit': 'wallet_cash',
+          AssetLiabilityPlanningService.auPayCardAccountId: 'wallet_cash',
+        },
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      final overdueActions = report.actionItems
+          .where(
+            (item) =>
+                item.type == AssetManagementInsightActionType.overduePayment,
+          )
+          .toList();
+      expect(overdueActions.length, 2);
+      for (final action in overdueActions) {
+        expect(action.suggestedAction.contains('20,000円'), true);
+        expect(action.suggestedAction.contains('支払可能'), false);
+      }
+    });
+
+    test('overdue action does not claim unset when source id is unresolvable',
+        () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布': 50000,
+          'モビット': -300000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 37000},
+        paymentSourceAccountIds: const <String, String>{
+          'mobit': 'ghost_account',
+        },
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      final overdue = report.actionItems.firstWhere(
+        (item) => item.type == AssetManagementInsightActionType.overduePayment,
+      );
+      expect(overdue.suggestedAction.contains('確認できません'), true);
+      expect(overdue.suggestedAction.contains('支払原資口座が未設定'), false);
+    });
+
+    test('missing payment source candidate is ranked by projected balance', () {
+      // 三井住友は残高最大 (500,000) だがモビットの支払 480,000 が割当済みで
+      // 見込み 20,000。財布 (100,000・割当なし) が候補になるべき —
+      // ページ上部バナーの候補順位 (支払後見込み降順) と一致させる。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '三井住友銀行大塚支店': 500000,
+          '財布': 100000,
+          'モビット': -600000,
+          'PayPay': -20000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'mobit': 480000,
+          'paypay_card': 20000,
+        },
+        paymentSourceAccountIds: const <String, String>{
+          'mobit': 'smbc_otsuka_branch',
+        },
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      final missing = report.actionItems.firstWhere(
+        (item) =>
+            item.type == AssetManagementInsightActionType.missingPaymentSource,
+      );
+      expect(missing.suggestedAction.contains('候補: 財布'), true);
+      expect(missing.suggestedAction.contains('候補: 三井住友銀行大塚支店'), false);
+    });
+
     test('missing payment source action suggests the largest cash-like account',
         () {
       final workbook = planner.buildWorkbook(

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1241,6 +1241,55 @@ void main() {
       await _unmount(tester);
     });
 
+    testWidgets('payment source missing banner lists unset payment sources', (
+      tester,
+    ) async {
+      // PayPay の支払原資口座が未設定 → 最上部バナーで件数・金額と、残高付きの
+      // 設定候補口座 + 原資未設定一覧へのジャンプ導線を出す。
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugCalendarNow: DateTime(2026, 7, 10),
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 1000,
+                '三井住友銀行大塚支店': 500000,
+                'PayPay': -20000,
+              },
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.byKey(const Key('asset_payment_source_missing_banner')),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('支払原資口座が未設定の支払い'),
+        findsOneWidget,
+      );
+      // 残高最大の三井住友大塚支店が候補として提示される (現在残高付き)。
+      // 本番経路ではデフォルト固定費 (家賃等) も原資未設定になるため複数行出る。
+      expect(
+        find.textContaining('候補: 三井住友銀行大塚支店（現在 ¥500,000'),
+        findsWidgets,
+      );
+      expect(
+        find.byKey(const Key('asset_payment_source_missing_jump')),
+        findsOneWidget,
+      );
+
+      await _unmount(tester);
+    });
+
     testWidgets('card reconciliation shows fix actions for mismatches', (
       tester,
     ) async {


### PR DESCRIPTION
## 概要

細木数子AIレポート (part338) の「開発者向け改善提案」3件を実装。

- **P1 未払いの早期検知とアラート強化**: 期限超過アクションに支払予定額・経過日数と、原資口座の**口座別見込み残高** (同口座の兄弟未払い・保留中の口座移動を合算) に基づく具体的な次の一手を提示。不足時は口座別不足バナーと同一の不足額で「◯円以上を◯◯へ移動」と指示
- **P2 支払原資口座の自動補完・確認機能**: 原資未設定の支払いをページ最上部バナー (`asset_payment_source_missing_banner`) で件数・合計と残高付き候補口座つきで警告し、原資未設定一覧へのジャンプ導線を追加。insight アクション側も最有力候補 (支払後見込み降順 = バナーと同一順位) を本文で提示
- **P3 リボ違反への具体的返済計画**: 借金しない宣言モニターのカード非一括違反に、12ヶ月脱却の必要月額 (`AssetDebtTrendAnalyzer.paymentToClearIn` 年金現価式) と現状ペースの完済見込み (月数・利息総額 / 利息以下・600ヶ月超は別文言) を Dart 計算で提示。違反タイルに脱却プランチップ 2 種を追加

計算はすべて Dart 側 (calculation_owner: dart_service)。AI は説明のみ。

## 敵対レビュー (Ultracode 4レンズ×43agents)

確定指摘 11 件 (実質 5 グループ) を全て反映済み:
- 行単位の生残高比較 → 口座別見込み残高へ統一 (兄弟未払い二重取り解消 + じぶん銀行 id 衝突で負債残高を参照する critical 解消)
- dangling 原資 id を「未設定」と誤断定しない
- 候補口座の順位をバナー/insight で統一
- 完済 600ヶ月超の誤説明修正・固定白タイル上の theme 文字色を固定濃色化

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.（実装詳細に依存しない入出力ベース）
- Minimal scope: about 3 cases（最小限の3ケース: ①期限超過→口座別見込み不足額の提示 ②原資未設定バナー表示+候補口座 ③リボ違反→脱却プラン提示）
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: サービス純関数 + widget smoke test (test/widgets/asset_management_page_smoke_test.dart) で入出力を検証済みのため専用 E2E 追加なし

## テスト

- `flutter test` 影響範囲 6 ファイル全緑 (service 129 + smoke 58)
- 追加テスト 10 件: 期限超過3分岐 + 共有原資の合算不足 + dangling id + 候補順位 + 原資候補提示 + リボ脱却プラン/利息以下/600ヶ月超 + バナー smoke
- `dart analyze` 対象 4 ファイル `No issues found!` / `require_trailing_commas` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
