### PR TITLE
feat(admin): 経営分析ダッシュボード 10仮説検証→6修正 (part338)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'package:my_web_app/pages/growth_mission_page.dart';
 import 'package:my_web_app/pages/site_guide_chat_page.dart';
 import 'package:my_web_app/pages/user_manual_page.dart';
 import 'package:my_web_app/pages/home_page.dart';
+import 'package:my_web_app/services/route_visibility_observer.dart';
 import 'package:my_web_app/pages/import_page.dart';
 import 'package:my_web_app/pages/landing_page.dart';
 import 'package:my_web_app/pages/memory_drill_page.dart';
@@ -532,6 +533,9 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
       navigatorObservers: <NavigatorObserver>[
         _growthPresenceObserver,
         universalAiShareRouteObserver,
+        // deep link 直開き時に下へ積まれた HomePage / LandingPage の fetch・
+        // LP View 計測を可視化まで遅延させる (可視化ゲート)。
+        deepLinkVisibilityRouteObserver,
         if (MyApp._sentryNavigatorObserver != null)
           MyApp._sentryNavigatorObserver!,
       ],

--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -1684,6 +1684,27 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     bodyCtrl.dispose();
   }
 
+  /// agent_tool_execution_logs を fail-safe に取得する (テーブル未整備でも
+  /// ダッシュボードは必ず描画する)。_loadStats の並列開始点から呼ぶ。
+  Future<List<Map<String, dynamic>>> _fetchToolExecutionLogsSafe() async {
+    try {
+      final dynamic rawToolLogs = await _supabase
+          .from('agent_tool_execution_logs')
+          .select('tool_name, allowed, blocked_reason, created_at')
+          .order('created_at', ascending: false)
+          .limit(80);
+      if (rawToolLogs is List) {
+        return [
+          for (final row in rawToolLogs.whereType<Map>())
+            Map<String, dynamic>.from(row),
+        ];
+      }
+    } catch (error) {
+      debugPrint('agent_tool_execution_logs is unavailable: $error');
+    }
+    return const [];
+  }
+
   Future<void> _loadStats() async {
     try {
       final today = _startOfDay(DateTime.now());
@@ -1691,7 +1712,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
       final startDateKey = _dateKey(startDate);
       final endDateKey = _dateKey(today);
 
-      final results = await Future.wait<dynamic>([
+      final statsFuture = Future.wait<dynamic>([
         _supabase
             .from('app_analytics')
             .select()
@@ -1708,7 +1729,16 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
             .count(CountOption.exact),
         _supabase.rpc('get_lp_view_stats'),
       ]);
+      // 相互依存の無いローダーは DB 4本と同時に開始する。旧実装は
+      // 「DB 4本 → growth-hub 4本 → tool logs」の3段直列で、全画面スピナーが
+      // 3段の合計時間 (数秒) ブロックしていた。並列化で最遅1本ぶんに縮む。
+      final paidConversionFuture = _loadPaidConversionMetrics();
+      final xTodayStatusFuture = _loadXTodayStatus();
+      final xPerformanceContextFuture = _loadXPerformanceContext();
+      final xCandidatesFuture = _loadXCandidateQueue();
+      final toolLogsFuture = _fetchToolExecutionLogsSafe();
 
+      final results = await statsFuture;
       final statsResponse = results[0] as List<dynamic>;
       final profileResponse = results[1] as List<dynamic>;
       final userCountResponse = results[2];
@@ -1729,12 +1759,6 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           ? Map<String, dynamic>.from(lpStatsResponse)
           : <String, dynamic>{};
       final hasLpViewStats = lpStats.isNotEmpty;
-      // 相互依存の無い4ローダーを並列化 (旧: 直列 await でスピナー時間が
-      // 4リクエスト分加算されていた)。
-      final paidConversionFuture = _loadPaidConversionMetrics();
-      final xTodayStatusFuture = _loadXTodayStatus();
-      final xPerformanceContextFuture = _loadXPerformanceContext();
-      final xCandidatesFuture = _loadXCandidateQueue();
       final paidConversionMetrics = await paidConversionFuture;
       final xTodayStatus = await xTodayStatusFuture;
       final xPerformanceContext = await xPerformanceContextFuture;
@@ -1745,35 +1769,22 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
       var allowedExecutionCount = 0;
       var blockedExecutionCount = 0;
 
-      try {
-        final dynamic rawToolLogs = await _supabase
-            .from('agent_tool_execution_logs')
-            .select('tool_name, allowed, blocked_reason, created_at')
-            .order('created_at', ascending: false)
-            .limit(80);
-
-        if (rawToolLogs is List) {
-          for (final row in rawToolLogs.whereType<Map>()) {
-            final log = Map<String, dynamic>.from(row);
-            final allowed = _toBool(log['allowed']);
-            if (allowed) {
-              allowedExecutionCount += 1;
-            } else {
-              blockedExecutionCount += 1;
-              final rawReason = log['blocked_reason']?.toString().trim() ?? '';
-              final reason =
-                  rawReason.isEmpty ? 'Unknown blocked reason' : rawReason;
-              blockedReasonCounts.update(
-                reason,
-                (current) => current + 1,
-                ifAbsent: () => 1,
-              );
-            }
-            toolExecutionLogs.add(log);
-          }
+      for (final log in await toolLogsFuture) {
+        final allowed = _toBool(log['allowed']);
+        if (allowed) {
+          allowedExecutionCount += 1;
+        } else {
+          blockedExecutionCount += 1;
+          final rawReason = log['blocked_reason']?.toString().trim() ?? '';
+          final reason =
+              rawReason.isEmpty ? 'Unknown blocked reason' : rawReason;
+          blockedReasonCounts.update(
+            reason,
+            (current) => current + 1,
+            ifAbsent: () => 1,
+          );
         }
-      } catch (error) {
-        debugPrint('agent_tool_execution_logs is unavailable: $error');
+        toolExecutionLogs.add(log);
       }
 
       final sortedBlockedReasons = blockedReasonCounts.entries.toList()
@@ -2451,8 +2462,11 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                   value: '${todayFunnel.magicLinkSends}',
                   color: const Color(0xFFFF6B35),
                 ),
+              // R27: 値は率ではなくボトルネック診断ラベル(体験未実行 等)なので、
+              // ラベルも「登録率」でなく「今日の診断」にする(label/value 不一致
+              // の解消。率は隣の「今日のCVR」チップが担う)。
               _buildMiniKpiChip(
-                label: '登録率',
+                label: '今日の診断',
                 value: diagnosisLabel,
                 color: diagnosisColor,
               ),
@@ -6162,12 +6176,29 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     final theme = Theme.of(context);
     // R20: 鮮度はパネル自身のデータ(perf-context 行)から出す。旧実装は今日の投稿の
     // 計測時刻を読み、12件計測済みでも今日未投稿だと「計測待ち」と矛盾していた。
+    final newestMeasuredAt = newestMeasuredCreatedAt(comparableRows);
     final freshness = resolveXGrowthLoopFreshness(
       measuredCount: comparisonSampleCount,
-      newestMeasuredAt: newestMeasuredCreatedAt(comparableRows),
+      newestMeasuredAt: newestMeasuredAt,
+      now: DateTime.now(),
+    );
+    // R27: 鮮度が3日を超えたら灰色フッター任せにせず警告行で知らせる
+    // (unlocked 以降は awaitingMetrics の cron 警告経路が二度と出ないため)。
+    final stalenessWarning = xGrowthLoopStalenessWarning(
+      measuredCount: comparisonSampleCount,
+      newestMeasuredAt: newestMeasuredAt,
       now: DateTime.now(),
     );
     final lines = <Widget>[];
+    if (stalenessWarning != null) {
+      lines.add(
+        _growthLoopLine(
+          Icons.warning_amber_rounded,
+          const Color(0xFFF59E0B),
+          stalenessWarning,
+        ),
+      );
+    }
 
     switch (loop.state) {
       case XGrowthLoopState.awaitingMetrics:
@@ -6191,8 +6222,13 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
         );
         break;
       case XGrowthLoopState.unlocked:
-        final bestVariant = perf['bestVariant']?.toString();
-        if (bestVariant != null && bestVariant.isNotEmpty) {
+        // R27: サーバが「unknown」(タグ無し投稿の受け皿バケット)を勝ち型として
+        // 返す除外漏れへの防御。variants から unknown 除外で勝ち型を再解決する。
+        final bestVariant = resolveDisplayBestVariant(
+          perf['bestVariant']?.toString(),
+          variants,
+        );
+        if (bestVariant != null) {
           lines.add(
             _growthLoopLine(
               Icons.emoji_events_outlined,

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -172,6 +172,45 @@ String resolveXGrowthLoopFreshness({
   return '最新サンプル: 1時間以内';
 }
 
+/// R27: 鮮度が閾値(既定3日)を超えたときだけ返る警告文。従来は unlocked に
+/// なった時点で cron 停止系の警告経路が消え、「最新サンプル: 3日前」が灰色
+/// フッターに埋もれて計測停止に気づけなかった。createdAt は投稿時刻なので
+/// 「投稿が止まった」「計測 cron が止まった」のどちらも有り得る旨を両論併記
+/// する(どちらか断定はデータ上できない)。
+String? xGrowthLoopStalenessWarning({
+  required int measuredCount,
+  required DateTime? newestMeasuredAt,
+  required DateTime now,
+  int staleAfterDays = 3,
+}) {
+  if (measuredCount <= 0 || newestMeasuredAt == null) return null;
+  final diff = now.difference(newestMeasuredAt);
+  if (diff.isNegative || diff.inDays < staleAfterDays) return null;
+  return '計測サンプルが${diff.inDays}日間増えていません。投稿が止まっているか、'
+      'metrics 収集 cron / spend-cap を確認してください。';
+}
+
+/// R27: サーバの bestVariant が「unknown」(variant タグ無し投稿の受け皿
+/// バケット)のとき、variants ランキング(平均スコア降順)から unknown を除いた
+/// 先頭を勝ち型として返す。有効な variant が無ければ null(勝ち型行を出さ
+/// ない)。growth-hub 側の除外漏れ(index.ts の bestVariant)への防御で、
+/// サーバ修正後も古いレスポンス/キャッシュに対して安全側に働く。
+String? resolveDisplayBestVariant(
+  String? bestVariant,
+  List<dynamic>? variants,
+) {
+  final trimmed = (bestVariant ?? '').trim();
+  if (trimmed.isNotEmpty && trimmed != 'unknown') return trimmed;
+  if (variants == null) return null;
+  for (final entry in variants) {
+    if (entry is! Map) continue;
+    final name = (entry['variant'] ?? '').toString().trim();
+    if (name.isEmpty || name == 'unknown') continue;
+    return name;
+  }
+  return null;
+}
+
 /// R20: 年なし MM/dd は 3か月前の機能リクエストや 2か月前のツール実行ログを
 /// 「今月」に見せてしまう。別年、もしくは staleDays(既定30日=1か月超)超は
 /// yyyy/MM/dd を返して年齢を明示する(パース不能は raw をそのまま返す)。

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -70,6 +70,7 @@ import '../widgets/home_tier/new_features_list.dart';
 import '../widgets/home_tier/ai_recommended_features_list.dart';
 import '../widgets/home_tier/popular_features_list.dart';
 import '../utils/feature_tap_logger.dart';
+import '../services/route_visibility_observer.dart';
 
 class HomePage extends StatefulWidget {
   final DateTime Function()? nowProvider;
@@ -85,7 +86,7 @@ class HomePage extends StatefulWidget {
   State<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends State<HomePage> {
+class _HomePageState extends State<HomePage> with RouteAware {
   static const bool _showLegacyHomeSections = false;
 
   // ✅ 改善ポイント:
@@ -145,18 +146,49 @@ class _HomePageState extends State<HomePage> {
   Map<String, dynamic>? _featureRequestAttachmentAnalysis;
   Map<String, dynamic>? _lastFeatureRequestSubmission;
 
+  // 可視化ゲート: 不可視のまま下に積まれている間は home 系 fetch を一切
+  // 開始しない (late Future 群も未初期化のまま build を空にする)。
+  bool _homeSignalsStarted = false;
+
   @override
   void initState() {
     super.initState();
     final today = _startOfDay(_now());
     _calendarMonthAnchor = DateTime(today.year, today.month, 1);
     _selectedCalendarDate = today;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route != null) {
+      deepLinkVisibilityRouteObserver.subscribe(this, route);
+    }
+    // route が取れない (テスト直 pump 等) 場合は従来どおり即ロードする。
+    if (route == null || route.isCurrent) {
+      _startHomeSignalsOnce();
+    }
+  }
+
+  @override
+  void didPopNext() {
+    // 上のルート (/admin 等) が pop されホームが初めて可視になった。
+    if (!_homeSignalsStarted) {
+      setState(_startHomeSignalsOnce);
+    }
+  }
+
+  void _startHomeSignalsOnce() {
+    if (_homeSignalsStarted) return;
+    _homeSignalsStarted = true;
     _reloadHomeSignals();
     _fetchNotifUnreadCount();
   }
 
   @override
   void dispose() {
+    deepLinkVisibilityRouteObserver.unsubscribe(this);
     _featureRequestTitleController.dispose();
     _featureRequestDescriptionController.dispose();
     _featureRequestOutcomeController.dispose();
@@ -5213,6 +5245,12 @@ abstinence_slip_details: $slipDetailsText
 
   @override
   Widget build(BuildContext context) {
+    // 可視化ゲート: /admin 等の deep link で不可視のまま下に積まれている間は
+    // 何も build しない。子 widget (ai-hub/app-hub を叩く curated sections 等) の
+    // initState も走らないため、admin 表示時の無関係な fetch/upsert がゼロになる。
+    if (!_homeSignalsStarted) {
+      return const Scaffold(body: SizedBox.shrink());
+    }
     final themeService = Provider.of<ThemeService>(context);
     final isDark = themeService.isDarkMode;
     final primaryColor = themeService.primaryColor;

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -9,6 +9,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../services/growth_acquisition_service.dart';
 import '../services/growth_mission_service.dart';
 import '../services/landing_page_adapter.dart';
+import '../services/route_visibility_observer.dart';
 import '../widgets/live_growth_banner.dart';
 
 class LandingPage extends StatefulWidget {
@@ -26,7 +27,7 @@ class LandingPage extends StatefulWidget {
   State<LandingPage> createState() => _LandingPageState();
 }
 
-class _LandingPageState extends State<LandingPage> {
+class _LandingPageState extends State<LandingPage> with RouteAware {
   static const bool _googleLoginFeatureEnabled = bool.fromEnvironment(
     'LANDING_GOOGLE_LOGIN_ENABLED',
     defaultValue: false,
@@ -72,6 +73,13 @@ class _LandingPageState extends State<LandingPage> {
     }
   }
 
+  // 可視化ゲート: 公開メモ等の deep link を直接開くと初期ルート展開で LP が
+  // 不可視のまま下に積まれる。その状態で LP View を計上すると「見ていない LP」
+  // が今日の登録ファネル最上段に混入するため、可視になるまで計測・表示用
+  // fetch を遅延する。referral 取り込みは URL 依存 (Uri.base) なので従来どおり
+  // initState で即時に行う。
+  bool _visibleBootstrapDone = false;
+
   @override
   void initState() {
     super.initState();
@@ -84,6 +92,30 @@ class _LandingPageState extends State<LandingPage> {
       }
     });
     unawaited(_bootstrapReferralInvite());
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route != null) {
+      deepLinkVisibilityRouteObserver.subscribe(this, route);
+    }
+    // route が取れない (テスト直 pump 等) 場合は従来どおり即時計測する。
+    if (route == null || route.isCurrent) {
+      _startVisibleBootstrapOnce();
+    }
+  }
+
+  @override
+  void didPopNext() {
+    // 上のルートが pop され LP が初めて実際に表示された。
+    _startVisibleBootstrapOnce();
+  }
+
+  void _startVisibleBootstrapOnce() {
+    if (_visibleBootstrapDone) return;
+    _visibleBootstrapDone = true;
     unawaited(_loadAchievementCount());
     unawaited(_loadSocialProofStats());
     // LP View 計測 (今日の登録ファネルの最上段)。失敗は adapter 側で握る。
@@ -92,6 +124,7 @@ class _LandingPageState extends State<LandingPage> {
 
   @override
   void dispose() {
+    deepLinkVisibilityRouteObserver.unsubscribe(this);
     _authSubscription?.cancel();
     _magicLinkCooldownTimer?.cancel();
     _emailController.dispose();

--- a/lib/services/route_visibility_observer.dart
+++ b/lib/services/route_visibility_observer.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/widgets.dart';
+
+/// deep link (/admin や公開メモ等) を直接開くと Flutter の初期ルート展開が
+/// ['/', '<deep link>'] を積み、ルート '/' の HomePage / LandingPage が不可視の
+/// まま下に mount される。その状態で fetch・計測 (LP View 等) を発火させない
+/// よう、「上のルートが pop され可視になった瞬間 (didPopNext)」を購読するための
+/// 共有 RouteObserver。main.dart の navigatorObservers に登録する。
+final RouteObserver<ModalRoute<void>> deepLinkVisibilityRouteObserver =
+    RouteObserver<ModalRoute<void>>();

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -24,6 +24,7 @@ import {
   resolveDuplicateGuardConfig,
   type XPostLogRowLike,
 } from "./x_duplicate_content.ts";
+import { hasNamedVariant, pickBestVariant } from "./x_best_variant.ts";
 import {
   buildSignupSlackPayload,
   isRecentSignupCreatedAt,
@@ -978,7 +979,11 @@ function buildXPerformanceContextFromLogs(
     }))
     .sort((left, right) => right.averageScore - left.averageScore);
 
-  const bestVariant = variants[0]?.variant ?? "daily_briefing";
+  // 「unknown」は variant タグ無し投稿の受け皿バケットで勝ち型ではない。
+  // 他の全消費箇所 (variant ランキング表示 / distinctVariants 計数) と同じく
+  // 除外して選ぶ (除外漏れでダッシュボードと投稿生成プロンプトの両方に
+  // 「勝ち型: unknown」が流れていた)。
+  const bestVariant = pickBestVariant(variants);
   // 集計ロールアップ (guarded): 両バケットに十分なサンプルがあるときだけ、
   // 変動要因(メディア有無/リンク位置/スレッド長)ごとの平均スコア差を測定事実と
   // して LLM へ渡す。データが薄い間は行自体を出さない(=実質 default-off で、
@@ -1148,7 +1153,9 @@ function buildXPerformanceContextFromLogs(
     ].join("\n")
     : [
       "Measured X performance context for the next post:",
-      variants.length > 0
+      // 実測 variant (unknown 以外) が無いとき fallback 名を実測済みの勝ち型
+      // かのように主張しない。
+      hasNamedVariant(variants)
         ? `Target: 10K impressions. Current best variant: ${bestVariant}.`
         : "Target: 10K impressions. No post-age comparable winner yet.",
       `Ranking basis: ${comparisonLabel} impressions ` +

--- a/supabase/functions/growth-hub/x_best_variant.ts
+++ b/supabase/functions/growth-hub/x_best_variant.ts
@@ -1,0 +1,28 @@
+// x.performance_context の勝ち型 (bestVariant) 選定。
+//
+// variants ランキングには variant タグ無し投稿の受け皿である「unknown」
+// バケットが混ざる。variant ランキング表示・distinctVariants 計数など他の
+// 全消費箇所は unknown を除外しているのに、bestVariant だけ variants[0] を
+// 素通ししていたため、タグ無し高インプレ投稿が貯まると「今の勝ち型:
+// unknown」がダッシュボードと投稿生成プロンプト (Current best variant) の
+// 両方へ流れていた。ここで除外を一元化する。
+
+export interface VariantRankingEntry {
+  variant: string;
+}
+
+/// unknown を除いた最上位 variant。無ければ fallback (既定 daily_briefing)。
+export function pickBestVariant(
+  variants: VariantRankingEntry[],
+  fallback = "daily_briefing",
+): string {
+  return variants.find((entry) => entry.variant !== "unknown")?.variant ??
+    fallback;
+}
+
+/// unknown 以外の実測 variant が1つでもあるか。promptContext が
+/// 「Current best variant: X」と主張してよいかのガード (全行 unknown のとき
+/// fallback 名を実測済みかのように主張しない)。
+export function hasNamedVariant(variants: VariantRankingEntry[]): boolean {
+  return variants.some((entry) => entry.variant !== "unknown");
+}

--- a/supabase/functions/growth-hub/x_best_variant_test.ts
+++ b/supabase/functions/growth-hub/x_best_variant_test.ts
@@ -1,0 +1,36 @@
+import {
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { hasNamedVariant, pickBestVariant } from "./x_best_variant.ts";
+
+Deno.test("pickBestVariant: unknown バケットが先頭でも除外して次点を返す", () => {
+  const variants = [
+    { variant: "unknown" },
+    { variant: "daily_briefing" },
+    { variant: "daily_briefing_v2_numbers" },
+  ];
+  assertEquals(pickBestVariant(variants), "daily_briefing");
+});
+
+Deno.test("pickBestVariant: named が先頭ならそのまま返す", () => {
+  const variants = [
+    { variant: "daily_briefing_fallback" },
+    { variant: "unknown" },
+  ];
+  assertEquals(pickBestVariant(variants), "daily_briefing_fallback");
+});
+
+Deno.test("pickBestVariant: 全行 unknown / 空は fallback へ", () => {
+  assertEquals(pickBestVariant([{ variant: "unknown" }]), "daily_briefing");
+  assertEquals(pickBestVariant([]), "daily_briefing");
+  assertEquals(pickBestVariant([], "question_post"), "question_post");
+});
+
+Deno.test("hasNamedVariant: unknown のみ→false / named 混在→true", () => {
+  assertEquals(hasNamedVariant([{ variant: "unknown" }]), false);
+  assertEquals(hasNamedVariant([]), false);
+  assertEquals(
+    hasNamedVariant([{ variant: "unknown" }, { variant: "daily_briefing" }]),
+    true,
+  );
+});

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -225,6 +225,47 @@ void main() {
       );
     });
 
+    test('R27 staleness warning: 3日以上でのみ警告文を返す', () {
+      String? warn(int days) => xGrowthLoopStalenessWarning(
+            measuredCount: 12,
+            newestMeasuredAt: now.subtract(Duration(days: days)),
+            now: now,
+          );
+      expect(warn(0), isNull);
+      expect(warn(2), isNull);
+      expect(warn(3), contains('3日間増えていません'));
+      expect(warn(7), contains('7日間増えていません'));
+      // 断定できないので投稿停止/cron 停止の両論併記であること。
+      expect(warn(3), contains('cron'));
+    });
+
+    test('R27 staleness warning: 計測0件 / 日付不明 / 未来時刻は警告しない', () {
+      expect(
+        xGrowthLoopStalenessWarning(
+          measuredCount: 0,
+          newestMeasuredAt: now.subtract(const Duration(days: 10)),
+          now: now,
+        ),
+        isNull,
+      );
+      expect(
+        xGrowthLoopStalenessWarning(
+          measuredCount: 12,
+          newestMeasuredAt: null,
+          now: now,
+        ),
+        isNull,
+      );
+      expect(
+        xGrowthLoopStalenessWarning(
+          measuredCount: 12,
+          newestMeasuredAt: now.add(const Duration(days: 1)),
+          now: now,
+        ),
+        isNull,
+      );
+    });
+
     test('newestMeasuredCreatedAt: max across rows (rows are score-sorted)',
         () {
       // rows[0] は高スコアの古い投稿、後続に新しい投稿 → 最新を返すこと。
@@ -382,6 +423,41 @@ void main() {
         archetypeLiftSummaryLine(resolveArchetypeLift(const [])),
         isNull,
       );
+    });
+  });
+
+  group('R27 resolveDisplayBestVariant (server unknown 除外漏れへの防御)', () {
+    test('named な bestVariant はそのまま返す', () {
+      expect(
+        resolveDisplayBestVariant('daily_briefing', const []),
+        'daily_briefing',
+      );
+    });
+
+    test('unknown のとき variants の unknown 以外の先頭へフォールバック', () {
+      final variants = [
+        {'variant': 'unknown', 'averageScore': 122, 'count': 16},
+        {'variant': 'daily_briefing_fallback', 'averageScore': 89, 'count': 1},
+        {'variant': 'daily_briefing', 'averageScore': 76, 'count': 7},
+      ];
+      expect(
+        resolveDisplayBestVariant('unknown', variants),
+        'daily_briefing_fallback',
+      );
+    });
+
+    test('unknown かつ named variant 無し → null (勝ち型行を出さない)', () {
+      expect(resolveDisplayBestVariant('unknown', null), isNull);
+      expect(
+        resolveDisplayBestVariant('unknown', [
+          {'variant': 'unknown'},
+          {'variant': ''},
+          'not-a-map',
+        ]),
+        isNull,
+      );
+      expect(resolveDisplayBestVariant('', const []), isNull);
+      expect(resolveDisplayBestVariant(null, null), isNull);
     });
   });
 }

--- a/test/routes/deep_link_visibility_gate_test.dart
+++ b/test/routes/deep_link_visibility_gate_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/route_visibility_observer.dart';
+
+// HomePage / LandingPage は共有 observer `deepLinkVisibilityRouteObserver` と
+// 「不可視の間は fetch/計測を開始せず、可視になった瞬間 (didPopNext) に一度だけ
+// 開始する」RouteAware ライフサイクルに依存する。HomePage 実体はアプリ全体を
+// 推移的に import し browser バンドルが巨大で読めないため、ここでは同じ observer
+// と同じライフサイクルを持つ軽量プローブでその契約を VM 上で検証する
+// (HomePage/LandingPage 側の配線同一性は flutter analyze が担保する)。
+class _VisibilityProbe extends StatefulWidget {
+  final void Function() onVisibleBootstrap;
+  const _VisibilityProbe({required this.onVisibleBootstrap});
+
+  @override
+  State<_VisibilityProbe> createState() => _VisibilityProbeState();
+}
+
+class _VisibilityProbeState extends State<_VisibilityProbe> with RouteAware {
+  bool _started = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route != null) {
+      deepLinkVisibilityRouteObserver.subscribe(this, route);
+    }
+    if (route == null || route.isCurrent) {
+      _startOnce();
+    }
+  }
+
+  @override
+  void didPopNext() {
+    _startOnce();
+  }
+
+  void _startOnce() {
+    if (_started) return;
+    _started = true;
+    widget.onVisibleBootstrap();
+  }
+
+  @override
+  void dispose() {
+    deepLinkVisibilityRouteObserver.unsubscribe(this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 可視化ゲート: 不可視の間は本体を build しない。
+    if (!_started) return const SizedBox.shrink();
+    return const Text('PROBE_BODY');
+  }
+}
+
+void main() {
+  testWidgets(
+    'deep link で下に積まれた間は bootstrap を開始せず本体も build しない',
+    (WidgetTester tester) async {
+      var bootstrapCalls = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorObservers: <NavigatorObserver>[
+            deepLinkVisibilityRouteObserver,
+          ],
+          initialRoute: '/second',
+          onGenerateRoute: (settings) {
+            if (settings.name == '/second') {
+              return MaterialPageRoute<void>(
+                settings: settings,
+                builder: (_) => Scaffold(
+                  body: Center(
+                    child: TextButton(
+                      onPressed: () => Navigator.of(
+                        tester.element(find.text('POP_ME')),
+                      ).pop(),
+                      child: const Text('POP_ME'),
+                    ),
+                  ),
+                ),
+              );
+            }
+            return MaterialPageRoute<void>(
+              settings: settings,
+              builder: (_) => _VisibilityProbe(
+                onVisibleBootstrap: () => bootstrapCalls += 1,
+              ),
+            );
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 上のルートが可視。下のプローブは不可視。
+      expect(find.text('POP_ME'), findsOneWidget);
+      // 不可視なので bootstrap は未実行・本体も未 build。
+      expect(bootstrapCalls, 0);
+      expect(find.text('PROBE_BODY'), findsNothing);
+
+      // 上のルートを pop → プローブが初めて可視に。
+      await tester.tap(find.text('POP_ME'));
+      await tester.pumpAndSettle();
+
+      // 可視化した瞬間に一度だけ bootstrap 実行・本体 build。
+      expect(bootstrapCalls, 1);
+      expect(find.text('PROBE_BODY'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    '最初から可視 (単独ルート) なら即 bootstrap する',
+    (WidgetTester tester) async {
+      var bootstrapCalls = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorObservers: <NavigatorObserver>[
+            deepLinkVisibilityRouteObserver,
+          ],
+          home: _VisibilityProbe(
+            onVisibleBootstrap: () => bootstrapCalls += 1,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(bootstrapCalls, 1);
+      expect(find.text('PROBE_BODY'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## 概要

part338。本番 `/admin` 経営分析ダッシュボードの Network 実測 (162 req・重複 fetch・ai-hub 3.18s・162 requests / 3.4 MB) を起点に **10 仮説** を立てて全件検証し、**6 件を修正 / 2 件を issue 化 / 2 件を benign と確定**した。

## 10 仮説 検証結果

| # | 仮説 | 判定 | 対応 |
|---|------|------|------|
| H1 | /admin 直開きで HomePage が不可視のまま下に積まれ home 系 fetch が無関係に発火 | ✅確定 | 可視化ゲートで修正 |
| H2 | 同展開で LandingPage も不可視のまま LP View を計上しうる | ✅確定 | 可視化ゲートで修正 |
| H3 | X成長ループ「勝ち型: unknown」= サーバ bestVariant の除外漏れ | ✅確定 | server+client 修正 |
| H4 | _loadStats が3段直列でスピナー加算 | ✅確定 | 完全並列化 |
| H5 | unlocked 後は計測停止警告が二度と出ない | ✅確定 | 3日超で警告行 |
| H6 | 「登録率」チップの label/value 不一致 | ✅確定 | ラベル修正 |
| H7 | admin-hub/schedule_task_runs の "2回" fetch | ⚪benign | CORS preflight+実体で app call は各1つ (#4080 が Max-Age 担当) |
| H8 | wbs_tasks 88kB を毎回転送しクライアント集計 | 🟡issue | #4092 |
| H9 | 参考ベンチマーク 8000 imp が古い | ⚪benign | 「I72比較外」と誠実表示済 (設計通り) |
| H10 | app_analytics が anon で write 可能 | 🔴issue | #4091 (RLS) |

## 修正詳細

### H1/H2 — deep-link 直開き時の無関係 fetch 抑制 (最大の発見)
`MaterialApp` が `onGenerateInitialRoutes` 未指定のため、`/admin` を直接開くと Flutter 既定のルート展開が `['/', '/admin']` を積み、`HomePage` が**不可視のまま下に mount**される。その結果 `mindless_tasks`×3 / `daily_todos`×3 / `wealth_struggles`×3 / `home_daily_status`×2 / `someday_tasks` / `feature_strategy_daily_snapshots` (upsert+select) と **ai-hub×2 + app-hub** が admin と無関係に発火していた。
→ 共有 `deepLinkVisibilityRouteObserver` (RouteObserver) + `RouteAware` の可視化ゲートを HomePage / LandingPage に導入。不可視の間は fetch・LP View 計測を開始せず本体も build しない。可視になった瞬間 (`didPopNext`) に一度だけ開始する。referral 取り込み等 URL 依存の処理は従来どおり即時。

### H3 — X成長ループ「勝ち型: unknown」
`variants` ランキングには variant タグ無し投稿の受け皿「unknown」バケットが混ざるが、他の全消費箇所 (ランキング表示 / distinctVariants 計数) は unknown を除外しているのに `bestVariant = variants[0]` だけ素通ししていた。タグ無し高インプレ投稿が貯まると「勝ち型: unknown」がダッシュボードと投稿生成プロンプト両方へ流れる。
→ server: `x_best_variant.ts` の `pickBestVariant`/`hasNamedVariant` で除外を一元化。client: `resolveDisplayBestVariant` で古いレスポンス/キャッシュにも防御。

### H4 — _loadStats 並列化
`DB4本 → growth-hub4本 → tool logs` の3段直列を、全ローダーを DB と同時開始する完全並列化に。全画面スピナーが最遅1本ぶんに縮む。

### H5 — 計測停止の可視化
`unlocked` 以降は `awaitingMetrics` の cron 警告経路が二度と出ず「最新サンプル: N日前」が灰色フッターに埋没していた。3日超で警告行を追加 (投稿停止/cron停止の両論併記=データ上どちらか断定できないため)。

### H6 — 「登録率」チップ
値が率でなくボトルネック診断ラベル(体験未実行 等)で label/value 不一致。ラベルを「今日の診断」に (率は隣の「今日のCVR」チップが担当)。

## テスト
- `x_best_variant_test.ts` — deno 4 件 (unknown 除外 / fallback / named 判定) ✅
- `admin_dashboard_signals_test.dart` — `xGrowthLoopStalenessWarning` / `resolveDisplayBestVariant` を追加 (計 39 件) ✅
- `deep_link_visibility_gate_test.dart` — 可視化ゲートの `isCurrent`/`didPopNext` 契約を VM で検証 ✅
- `flutter analyze` 7 ファイル 0 issue / `dart format --set-exit-if-changed` 差分なし / `deno lint` clean

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Dashboard perf/UX client fixes plus a small growth-hub winner-selection filter (unknown-bucket exclusion) covered by pure-function deno unit tests; no auth, RLS, payment, secret, or data-write path changes

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge change is a pure winner-selection helper covered by x_best_variant_test.ts (4 cases); Flutter changes covered by VM unit tests (admin_dashboard_signals_test.dart, deep_link_visibility_gate_test.dart). No user-visible black-box flow altered beyond these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
