### PR TITLE
feat(asset): 「まず、これだけ」段階別トリアージガイド (今日3件→今週→今月→相談窓口)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -20217,7 +20217,6 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     };
   }
 
-  /// 「借金しない宣言」の遵守状況（達成は緑で称賛、違反は赤で具体指摘）を描画する。
   /// 「まず、これだけ」段階別トリアージカード。数字の洪水で混乱している
   /// 利用者向けに、今日 (最大3件)→今週→今月の順で絞って提示する。
   /// 背景が固定の淡ティールのため、文字色も固定の濃ティール系にする。
@@ -20366,6 +20365,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
   }
 
+  /// 「借金しない宣言」の遵守状況（達成は緑で称賛、違反は赤で具体指摘）を描画する。
   Widget _buildAssetManagementDisciplineCard(
     AssetDebtDisciplineReport report,
   ) {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -60,6 +60,7 @@ import 'package:my_web_app/services/asset_salary_deposit_detector.dart';
 import 'package:my_web_app/services/asset_salary_reset_marker_store.dart';
 import 'package:my_web_app/services/asset_recurring_transaction_detector.dart';
 import 'package:my_web_app/services/asset_management_insight_service.dart';
+import 'package:my_web_app/services/asset_triage_guide_service.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_inputs.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
 import 'package:my_web_app/services/asset_category_budget_service.dart';
@@ -19279,6 +19280,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             ],
           ),
           const SizedBox(height: 12),
+          if (report.triagePlan?.hasContent ?? false) ...[
+            _buildAssetTriageGuideCard(report.triagePlan!),
+            const SizedBox(height: 12),
+          ],
           if (report.emergencyAdvices.isNotEmpty) ...[
             _buildAssetManagementEmergencyAdviceList(report.emergencyAdvices),
             const SizedBox(height: 12),
@@ -20213,6 +20218,154 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   /// 「借金しない宣言」の遵守状況（達成は緑で称賛、違反は赤で具体指摘）を描画する。
+  /// 「まず、これだけ」段階別トリアージカード。数字の洪水で混乱している
+  /// 利用者向けに、今日 (最大3件)→今週→今月の順で絞って提示する。
+  /// 背景が固定の淡ティールのため、文字色も固定の濃ティール系にする。
+  Widget _buildAssetTriageGuideCard(AssetTriagePlan plan) {
+    var stepNumber = 0;
+    Widget buildStage(String label, List<AssetTriageStep> steps) {
+      if (steps.isEmpty) {
+        return const SizedBox.shrink();
+      }
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 8),
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w800,
+              color: Color(0xFF0F766E),
+              height: 1.4,
+            ),
+          ),
+          for (final step in steps) ...[
+            const SizedBox(height: 4),
+            Text(
+              '${++stepNumber}. ${step.title}',
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: Color(0xFF134E4A),
+                height: 1.4,
+              ),
+            ),
+            Text(
+              step.detail,
+              style: const TextStyle(
+                fontSize: 11,
+                color: Color(0xFF115E59),
+                height: 1.5,
+              ),
+            ),
+          ],
+        ],
+      );
+    }
+
+    return Container(
+      key: const Key('asset_triage_guide_card'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF0FDFA),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0xFF99F6E4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.checklist_rounded,
+                size: 16,
+                color: Color(0xFF0F766E),
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  plan.todaySteps.isEmpty
+                      ? 'まず、これだけ'
+                      : 'まず、これだけ（今日やること ${plan.todaySteps.length}つ）',
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFF134E4A),
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 2),
+          const Text(
+            AssetTriagePlan.disclaimer,
+            style: TextStyle(
+              fontSize: 10,
+              color: Color(0xFF0F766E),
+              height: 1.4,
+            ),
+          ),
+          buildStage(
+            '今日やること（${plan.todaySteps.length}つだけ）',
+            plan.todaySteps,
+          ),
+          if (plan.todaySteps.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            const Text(
+              AssetTriagePlan.todayClosingNote,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: Color(0xFF0F766E),
+                height: 1.4,
+              ),
+            ),
+          ],
+          buildStage('今週やること', plan.weekSteps),
+          buildStage('今月〜来月やること', plan.monthSteps),
+          if (plan.showConsultation && plan.consultationNote != null) ...[
+            const SizedBox(height: 8),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: const Color(0xFFEFF6FF),
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: const Color(0xFFBFDBFE)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '一人で抱えないでください',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w800,
+                      color: Color(0xFF1E3A8A),
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    plan.consultationNote!,
+                    style: const TextStyle(
+                      fontSize: 11,
+                      color: Color(0xFF1E40AF),
+                      height: 1.5,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
   Widget _buildAssetManagementDisciplineCard(
     AssetDebtDisciplineReport report,
   ) {

--- a/lib/services/asset_management_insight_service.dart
+++ b/lib/services/asset_management_insight_service.dart
@@ -3,6 +3,7 @@ import '../models/user_profile.dart';
 import 'asset_debt_discipline_monitor.dart';
 import 'asset_debt_trend_analyzer.dart';
 import 'asset_management_available_money.dart';
+import 'asset_triage_guide_service.dart';
 
 enum AssetManagementInsightActionType {
   missingInput,
@@ -264,6 +265,9 @@ class AssetManagementInsightReport {
   /// 「借金しない宣言」モニターの月次評価（追加借入ゼロ／カード一括）。null=未評価。
   final AssetDebtDisciplineReport? disciplineReport;
 
+  /// 「まず、これだけ」段階別トリアージ (今日3件まで/今週/今月/専門窓口)。null=未評価。
+  final AssetTriagePlan? triagePlan;
+
   const AssetManagementInsightReport({
     required this.workbook,
     this.userProfile,
@@ -280,6 +284,7 @@ class AssetManagementInsightReport {
         const <AssetManagementImplementationContext>[],
     this.debtTrendInsights = const <AssetDebtTrendInsight>[],
     this.disciplineReport,
+    this.triagePlan,
   });
 
   bool get hasAccountShortfallAlerts => accountShortfallAlerts.isNotEmpty;
@@ -327,6 +332,8 @@ class AssetManagementInsightService {
     AssetDebtTrendAnalyzer debtTrendAnalyzer = const AssetDebtTrendAnalyzer(),
     AssetDebtDisciplineMonitor disciplineMonitor =
         const AssetDebtDisciplineMonitor(),
+    AssetTriageGuideService triageGuideService =
+        const AssetTriageGuideService(),
   }) {
     final breakdown = _availableMoneyBreakdown(
       workbook: workbook,
@@ -384,6 +391,12 @@ class AssetManagementInsightService {
       workbook: workbook,
       priorBalancesByAccountId: priorMonthAccountBalances,
     );
+    final triagePlan = triageGuideService.buildPlan(
+      workbook: workbook,
+      disciplineReport: disciplineReport,
+      todayAvailableAmount: today.availableAmount,
+      userProfile: userProfile,
+    );
 
     return AssetManagementInsightReport(
       workbook: workbook,
@@ -399,6 +412,7 @@ class AssetManagementInsightService {
       implementationContexts: implementationContexts,
       debtTrendInsights: debtTrendInsights,
       disciplineReport: disciplineReport,
+      triagePlan: triagePlan,
     );
   }
 
@@ -1472,6 +1486,9 @@ class AssetManagementInsightPromptBuilder {
       ..writeln('## 借金しない宣言モニター（追加借入ゼロ／カード一括）')
       ..write(_disciplineLines(report))
       ..writeln()
+      ..writeln('## 今日やることトリアージ（Dart計算・この順番のまま提示すること）')
+      ..write(_triageLines(report))
+      ..writeln()
       ..writeln('## アクション件数')
       ..writeln('- 合計: ${report.actionItems.length}')
       ..writeln('- 重要度別: ${_formatCounts(severityCounts)}')
@@ -1828,6 +1845,38 @@ class AssetManagementInsightPromptBuilder {
       AssetDebtDisciplineViolationType.newBorrowing => '追加借入の発生',
       AssetDebtDisciplineViolationType.revolvingCard => 'カード非一括(リボ/分割)',
     };
+  }
+
+  /// 「まず、これだけ」トリアージを AI プロンプトへ渡す。
+  /// 混乱している利用者向けの提示順そのものが成果物なので、AI には
+  /// 順番の変更や項目の追加をさせない (言い換えのみ許可)。
+  String _triageLines(AssetManagementInsightReport report) {
+    final plan = report.triagePlan;
+    if (plan == null || !plan.hasContent) {
+      return '- 今日の緊急対応はありません。現状維持と入力精度の確認を優先してください。\n';
+    }
+    final buffer = StringBuffer()
+      ..writeln('- 免責（利用者にも明示すること）: ${AssetTriagePlan.disclaimer}');
+    void writeSteps(String stage, List<AssetTriageStep> steps) {
+      if (steps.isEmpty) {
+        return;
+      }
+      buffer.writeln('- $stage:');
+      for (var i = 0; i < steps.length; i++) {
+        buffer.writeln('  ${i + 1}. ${steps[i].title} — ${steps[i].detail}');
+      }
+    }
+
+    writeSteps('今日やること（最大3件・この件数以上を今日に割り当てない）', plan.todaySteps);
+    if (plan.todaySteps.isNotEmpty) {
+      buffer.writeln('  - 締めの一文: ${AssetTriagePlan.todayClosingNote}');
+    }
+    writeSteps('今週やること', plan.weekSteps);
+    writeSteps('今月〜来月やること', plan.monthSteps);
+    if (plan.showConsultation && plan.consultationNote != null) {
+      buffer.writeln('- 専門窓口（一人で抱えない）: ${plan.consultationNote}');
+    }
+    return buffer.toString();
   }
 
   String _redactedSituationCards(AssetManagementInsightReport report) {

--- a/lib/services/asset_triage_guide_service.dart
+++ b/lib/services/asset_triage_guide_service.dart
@@ -209,8 +209,7 @@ class AssetTriageGuideService {
     final discipline = disciplineReport;
     if (discipline != null && discipline.hasViolations) {
       final names = <String>{
-        for (final violation in discipline.allViolations)
-          violation.accountName,
+        for (final violation in discipline.allViolations) violation.accountName,
       }.take(3).join('・');
       final newBorrowingNote = discipline.totalNewBorrowing > 0
           ? '今月すでに約${_yen(discipline.totalNewBorrowing)}の新規利用があります。'
@@ -262,10 +261,8 @@ class AssetTriageGuideService {
     final revolving = discipline?.revolvingCardViolations ??
         const <AssetDebtDisciplineViolation>[];
     if (revolving.isNotEmpty) {
-      final names = revolving
-          .map((violation) => violation.accountName)
-          .take(4)
-          .join('・');
+      final names =
+          revolving.map((violation) => violation.accountName).take(4).join('・');
       weekSteps.add(
         AssetTriageStep(
           kind: AssetTriageStepKind.disableRevolving,
@@ -282,13 +279,12 @@ class AssetTriageGuideService {
     final annualRateById = <String, double>{
       for (final row in workbook.debtMasterRows) row.id: row.annualRate,
     };
-    final planned = revolving
-        .where((violation) => violation.hasEscapePlan)
-        .toList()
-      ..sort(
-        (a, b) => (annualRateById[b.accountId] ?? 0)
-            .compareTo(annualRateById[a.accountId] ?? 0),
-      );
+    final planned =
+        revolving.where((violation) => violation.hasEscapePlan).toList()
+          ..sort(
+            (a, b) => (annualRateById[b.accountId] ?? 0)
+                .compareTo(annualRateById[a.accountId] ?? 0),
+          );
     if (planned.isNotEmpty) {
       final top = planned.first;
       monthSteps.add(

--- a/lib/services/asset_triage_guide_service.dart
+++ b/lib/services/asset_triage_guide_service.dart
@@ -116,39 +116,62 @@ class AssetTriageGuideService {
     final weekSteps = <AssetTriageStep>[];
     final monthSteps = <AssetTriageStep>[];
 
-    // ① 生活費確保 (健康を削らない)。
-    final cashOnHand = workbook.accounts
-        .where(
-          (account) =>
-              account.kind == AssetLiabilityAccountKind.cash &&
-              account.balance > 0,
-        )
+    // ① 生活費確保 (健康を削らない)。現金口座を登録していないだけの利用者に
+    // 「現金0円」の偽危機を出さないため、現金口座がある場合の残高不足か、
+    // 本日使用可能額のマイナスのどちらかでのみ発火する。
+    final cashAccounts = workbook.accounts
+        .where((account) => account.kind == AssetLiabilityAccountKind.cash)
+        .toList();
+    final cashOnHand = cashAccounts
+        .where((account) => account.balance > 0)
         .fold<double>(0, (sum, account) => sum + account.balance);
-    if (cashOnHand < livingExpenseCashThreshold || todayAvailableAmount < 0) {
-      AssetLiabilityAccount? largestDeposit;
+    final lowCash =
+        cashAccounts.isNotEmpty && cashOnHand < livingExpenseCashThreshold;
+    if (lowCash || todayAvailableAmount < 0) {
+      // 引出元は生残高でなく「引落予定を除いた見込み残高」最大の預金を選ぶ
+      // (残高最大口座が引落原資だと、下ろした結果引き落とし不能になるため)。
+      final summariesById = <String, AssetLiabilityAccountCashflowSummary>{
+        for (final summary in workbook.accountCashflowSummaries)
+          summary.accountId: summary,
+      };
+      AssetLiabilityAccount? source;
+      var sourceProjected = 0.0;
       for (final account in workbook.accounts) {
         if (account.kind != AssetLiabilityAccountKind.deposit ||
             account.balance <= 0) {
           continue;
         }
-        if (largestDeposit == null ||
-            account.balance > largestDeposit.balance) {
-          largestDeposit = account;
+        final projected =
+            summariesById[account.id]?.projectedBalance ?? account.balance;
+        if (source == null || projected > sourceProjected) {
+          source = account;
+          sourceProjected = projected;
         }
       }
-      final reason = cashOnHand < livingExpenseCashThreshold
+      final reason = lowCash
           ? '手元現金が${_yen(cashOnHand)}しかありません。'
           : '本日の使用可能額が${_yen(todayAvailableAmount)}です。';
+      final String detail;
+      if (source == null || sourceProjected <= 0) {
+        detail = '$reason現金・預金として登録された口座に余力が見つかりません。'
+            '他に使える資産がないか確認し、無ければ今日の食費は家族・自治体・'
+            'フードバンク等への相談も選択肢にしてください。食事を抜く判断はしないでください。';
+      } else if (sourceProjected >= 20000) {
+        detail = '$reason${source.name}（残高 ${_yen(source.balance)} / '
+            '引落予定を除いた余力 ${_yen(sourceProjected)}）から'
+            '1〜2万円を下ろして今日の食費・移動費を確保してください。'
+            '食事を抜く判断はしないでください。';
+      } else {
+        detail = '$reason${source.name}の引落予定を除いた余力は'
+            '${_yen(sourceProjected)}です。引き落としに影響しないよう、'
+            'この範囲で今日の食費・移動費を確保してください。'
+            '食事を抜く判断はしないでください。';
+      }
       todaySteps.add(
         AssetTriageStep(
           kind: AssetTriageStepKind.secureLivingExpense,
           title: '食費・移動費を確保する',
-          detail: largestDeposit == null
-              ? '$reason現金・預金に余力がないため、今日の食費は家族・自治体・'
-                  'フードバンク等への相談も選択肢にしてください。食事を抜く判断はしないでください。'
-              : '$reason${largestDeposit.name}（残高 ${_yen(largestDeposit.balance)}）から'
-                  '1〜2万円を下ろして今日の食費・移動費を確保してください。'
-                  '食事を抜く判断はしないでください。',
+          detail: detail,
         ),
       );
     }
@@ -206,7 +229,19 @@ class AssetTriageGuideService {
     final cappedToday = todaySteps.take(maxTodaySteps).toList();
 
     // ④ 期限超過の処理 (放置だけが最悪)。
-    final overdueRows = workbook.overdueCashflowRows;
+    // overdueCashflowRows は未受領の収入行も含み、本日期日 (=ステップ②) も
+    // overdue 扱いのため、「支払 かつ 昨日以前」に絞る (収入を延滞額扱いしない・
+    // 本日期日を②と二重計上しない)。
+    final overdueRows = workbook.cashflowRows
+        .where(
+          (row) =>
+              row.isPayment &&
+              row.isDirectCashflowTarget &&
+              !row.paid &&
+              row.overdue &&
+              _dateOnly(row.paymentDate).isBefore(today),
+        )
+        .toList();
     if (overdueRows.isNotEmpty) {
       final total = overdueRows.fold<double>(
         0,
@@ -236,16 +271,24 @@ class AssetTriageGuideService {
           kind: AssetTriageStepKind.disableRevolving,
           title: 'リボ/分割の設定解除を電話する',
           detail: '$namesに電話し、今後の利用分の支払い方式を一括（1回払い）に'
-              '変更してください。残高を今すぐ全額返す必要はありません。'
-              '「これ以上リボが増えない設定」にすることが目的です。',
+              '変更してください。理想は残高の一括返済ですが、難しい場合でも'
+              'まず「これ以上リボが増えない設定」へ変えることが目的です。',
         ),
       );
     }
 
-    // ⑥ 返済ペースを脱却プランで決める (金利の高い順)。
+    // ⑥ 返済ペースを脱却プランで決める。例示カードも本文どおり
+    // 「金利の高い順」で選ぶ (違反リスト自体は繰越額順のため並べ直す)。
+    final annualRateById = <String, double>{
+      for (final row in workbook.debtMasterRows) row.id: row.annualRate,
+    };
     final planned = revolving
         .where((violation) => violation.hasEscapePlan)
-        .toList();
+        .toList()
+      ..sort(
+        (a, b) => (annualRateById[b.accountId] ?? 0)
+            .compareTo(annualRateById[a.accountId] ?? 0),
+      );
     if (planned.isNotEmpty) {
       final top = planned.first;
       monthSteps.add(
@@ -280,22 +323,35 @@ class AssetTriageGuideService {
       }
     }
 
-    // 専門窓口の案内 (負債が絶対額または年収比の閾値を超えたら)。
-    final totalDebt = workbook.debtMasterRows.fold<double>(
-      0,
-      (sum, row) => sum + row.balance.abs(),
-    );
+    // 専門窓口の案内 (借入が絶対額または年収比の閾値を超えたら)。
+    // 家賃・通信費など毎月全額払いの固定費は「借金」ではないため、
+    // 規律モニターと同じ基準 (isBorrowingKind + 非固定費) で合算する。
+    final totalDebt = workbook.debtMasterRows
+        .where(
+          (row) =>
+              !row.fullPaymentEstimate &&
+              AssetDebtDisciplineMonitor.isBorrowingKind(row.kind),
+        )
+        .fold<double>(0, (sum, row) => sum + row.balance.abs());
     final showConsultation = totalDebt >= consultationDebtThreshold ||
         (annualIncome != null &&
             annualIncome > 0 &&
             totalDebt >= annualIncome * consultationDebtIncomeRatio);
     String? consultationNote;
     if (showConsultation) {
-      final incomeNote = (annualIncome != null && annualIncome > 0)
-          ? '年収${_yen(annualIncome)}の収入があるので、増やすのを止めて計画を立て直せば'
-              '十分立て直せる数字です。'
-          : '';
-      consultationNote = '負債合計 約${_yen(totalDebt)}は、任意整理などで利息を'
+      // 「立て直せる」の断言は借入が年収1.5倍以内のときだけ。それ以上は
+      // 結果を請け合わず、専門家との計画づくりへ誘導する。
+      final String incomeNote;
+      if (annualIncome == null || annualIncome <= 0) {
+        incomeNote = '';
+      } else if (totalDebt <= annualIncome * 1.5) {
+        incomeNote = '年収${_yen(annualIncome)}の収入があるので、増やすのを止めて'
+            '計画を立て直せば十分立て直せる数字です。';
+      } else {
+        incomeNote = '年収${_yen(annualIncome)}の収入があることは大きな強みです。'
+            'どの手続きが合うかも含めて、専門家と一緒に現実的な計画を立てましょう。';
+      }
+      consultationNote = '借入合計 約${_yen(totalDebt)}は、任意整理などで利息を'
           '止められる可能性がある水準です。無料で相談できます: '
           '法テラス 0570-078374（収入基準を満たせば弁護士相談が無料）/ '
           '消費者ホットライン 188（最寄りの消費生活センター）/ '

--- a/lib/services/asset_triage_guide_service.dart
+++ b/lib/services/asset_triage_guide_service.dart
@@ -1,0 +1,332 @@
+import '../models/asset_liability_workbook.dart';
+import '../models/user_profile.dart';
+import 'asset_debt_discipline_monitor.dart';
+
+/// トリアージステップの種別。
+enum AssetTriageStepKind {
+  /// 今日: 食費・移動費など最低限の生活費を確保する。
+  secureLivingExpense,
+
+  /// 今日: 本日期日の支払いの原資を確認する。
+  dueTodayPayment,
+
+  /// 今日: カードの新規利用を止める（財布から抜く）。
+  stopNewCardUsage,
+
+  /// 今週: 期限超過の支払いを上から処理する。
+  processOverdue,
+
+  /// 今週: リボ/分割の設定解除を支払先へ電話する。
+  disableRevolving,
+
+  /// 今月: 脱却プランを見て返済ペースを決める。
+  reviewRepaymentPace,
+
+  /// 今月: 支払予定と収入の差を固定費見直しで埋める。
+  closeIncomeGap,
+}
+
+/// 1 ステップ。金額・口座名はすべて Dart 側で計算済みの確定値。
+class AssetTriageStep {
+  final AssetTriageStepKind kind;
+  final String title;
+  final String detail;
+
+  const AssetTriageStep({
+    required this.kind,
+    required this.title,
+    required this.detail,
+  });
+}
+
+/// 「まず、これだけ」段階別トリアージ計画。
+///
+/// 数字が多く混乱している利用者向けに、今日 (最大3件)・今週・今月の順で
+/// やることを絞って提示する。全ステップ決定論的 (calculation_owner:
+/// dart_service)。AI は文面の言い換えのみ。
+class AssetTriagePlan {
+  /// 今日やること (最大 [AssetTriageGuideService.maxTodaySteps] 件)。
+  final List<AssetTriageStep> todaySteps;
+  final List<AssetTriageStep> weekSteps;
+  final List<AssetTriageStep> monthSteps;
+
+  /// 専門窓口 (法テラス等) の案内を出すべき負債水準か。
+  final bool showConsultation;
+
+  /// 専門窓口案内の本文 (showConsultation=true のときのみ非 null)。
+  final String? consultationNote;
+
+  const AssetTriagePlan({
+    required this.todaySteps,
+    required this.weekSteps,
+    required this.monthSteps,
+    required this.showConsultation,
+    this.consultationNote,
+  });
+
+  /// 免責: アプリは FP・弁護士ではない。UI とプロンプトの双方で明示する。
+  static const String disclaimer =
+      '本アプリはファイナンシャルプランナー・弁護士ではありません。アプリ内の数値に基づく優先順位の整理です。';
+
+  /// 今日のステップを締める一文。「全部やらなくていい」ことを明示する。
+  static const String todayClosingNote = '今日はこれで終わりです。それ以上やらなくていいです。';
+
+  /// 表示すべき内容が 1 つでもあるか。
+  bool get hasContent =>
+      todaySteps.isNotEmpty ||
+      weekSteps.isNotEmpty ||
+      monthSteps.isNotEmpty ||
+      showConsultation;
+
+  List<AssetTriageStep> get allSteps => <AssetTriageStep>[
+        ...todaySteps,
+        ...weekSteps,
+        ...monthSteps,
+      ];
+}
+
+/// 資産管理レポートの計算結果から段階別トリアージ計画を組み立てる。
+///
+/// 優先順位の設計原則: ①生活費 (健康) → ②本日期日 → ③止血 (新規利用停止)
+/// → ④期限超過の処理 → ⑤リボ解除 → ⑥返済ペース → ⑦収支ギャップ。
+/// 「増やさない」を「返す」より先に置く。
+class AssetTriageGuideService {
+  const AssetTriageGuideService();
+
+  /// 今日のステップ上限。多いと逆に動けなくなるため 3 で固定。
+  static const int maxTodaySteps = 3;
+
+  /// 手元現金がこの額を下回ったら生活費確保を最優先ステップにする。
+  static const double livingExpenseCashThreshold = 10000;
+
+  /// 専門窓口案内を出す負債合計の絶対閾値。
+  static const double consultationDebtThreshold = 3000000;
+
+  /// 年収が分かる場合、負債が年収のこの割合を超えたら専門窓口案内を出す。
+  static const double consultationDebtIncomeRatio = 0.5;
+
+  AssetTriagePlan buildPlan({
+    required AssetLiabilityWorkbook workbook,
+    AssetDebtDisciplineReport? disciplineReport,
+    double todayAvailableAmount = 0,
+    UserProfile? userProfile,
+  }) {
+    final today = _dateOnly(workbook.baseDate);
+    final todaySteps = <AssetTriageStep>[];
+    final weekSteps = <AssetTriageStep>[];
+    final monthSteps = <AssetTriageStep>[];
+
+    // ① 生活費確保 (健康を削らない)。
+    final cashOnHand = workbook.accounts
+        .where(
+          (account) =>
+              account.kind == AssetLiabilityAccountKind.cash &&
+              account.balance > 0,
+        )
+        .fold<double>(0, (sum, account) => sum + account.balance);
+    if (cashOnHand < livingExpenseCashThreshold || todayAvailableAmount < 0) {
+      AssetLiabilityAccount? largestDeposit;
+      for (final account in workbook.accounts) {
+        if (account.kind != AssetLiabilityAccountKind.deposit ||
+            account.balance <= 0) {
+          continue;
+        }
+        if (largestDeposit == null ||
+            account.balance > largestDeposit.balance) {
+          largestDeposit = account;
+        }
+      }
+      final reason = cashOnHand < livingExpenseCashThreshold
+          ? '手元現金が${_yen(cashOnHand)}しかありません。'
+          : '本日の使用可能額が${_yen(todayAvailableAmount)}です。';
+      todaySteps.add(
+        AssetTriageStep(
+          kind: AssetTriageStepKind.secureLivingExpense,
+          title: '食費・移動費を確保する',
+          detail: largestDeposit == null
+              ? '$reason現金・預金に余力がないため、今日の食費は家族・自治体・'
+                  'フードバンク等への相談も選択肢にしてください。食事を抜く判断はしないでください。'
+              : '$reason${largestDeposit.name}（残高 ${_yen(largestDeposit.balance)}）から'
+                  '1〜2万円を下ろして今日の食費・移動費を確保してください。'
+                  '食事を抜く判断はしないでください。',
+        ),
+      );
+    }
+
+    // ② 本日期日の支払い。
+    final dueTodayRows = workbook.cashflowRows
+        .where(
+          (row) =>
+              row.isPayment &&
+              row.isDirectCashflowTarget &&
+              !row.paid &&
+              _dateOnly(row.paymentDate) == today,
+        )
+        .toList()
+      ..sort((a, b) => b.paymentAmount.compareTo(a.paymentAmount));
+    if (dueTodayRows.isNotEmpty) {
+      final total = dueTodayRows.fold<double>(
+        0,
+        (sum, row) => sum + row.paymentAmount,
+      );
+      final first = dueTodayRows.first;
+      final others = dueTodayRows.length - 1;
+      todaySteps.add(
+        AssetTriageStep(
+          kind: AssetTriageStepKind.dueTodayPayment,
+          title: '本日期日の支払いを確認する',
+          detail: '本日期日は${first.accountName} ${_yen(first.paymentAmount)}'
+              '${others > 0 ? ' ほか$others件（合計 ${_yen(total)}）' : ''}です。'
+              '引落口座の残高が足りているか確認し、不足なら生活費とは別に移してください。',
+        ),
+      );
+    }
+
+    // ③ 止血: カードの新規利用を止める (返済より先)。
+    final discipline = disciplineReport;
+    if (discipline != null && discipline.hasViolations) {
+      final names = <String>{
+        for (final violation in discipline.allViolations)
+          violation.accountName,
+      }.take(3).join('・');
+      final newBorrowingNote = discipline.totalNewBorrowing > 0
+          ? '今月すでに約${_yen(discipline.totalNewBorrowing)}の新規利用があります。'
+          : '残高が翌月へ繰り越され利息が発生しています。';
+      todaySteps.add(
+        AssetTriageStep(
+          kind: AssetTriageStepKind.stopNewCardUsage,
+          title: 'カードを財布から抜く',
+          detail: '$namesを今日から使わないでください。$newBorrowingNote'
+              '「増やさない」が返済より先です。支払いは現金かデビットに切り替えてください。',
+        ),
+      );
+    }
+
+    // 今日のステップは最大 3 件 (多いと動けなくなる)。溢れた分は翌日以降に回る。
+    final cappedToday = todaySteps.take(maxTodaySteps).toList();
+
+    // ④ 期限超過の処理 (放置だけが最悪)。
+    final overdueRows = workbook.overdueCashflowRows;
+    if (overdueRows.isNotEmpty) {
+      final total = overdueRows.fold<double>(
+        0,
+        (sum, row) => sum + row.paymentAmount,
+      );
+      weekSteps.add(
+        AssetTriageStep(
+          kind: AssetTriageStepKind.processOverdue,
+          title: '期限超過リストを上から処理する',
+          detail: '期限超過が${overdueRows.length}件（合計 ${_yen(total)}）あります。'
+              '各項目の「次の一手」に従って払えるものから払い、払えないものは放置せず'
+              '支払先へ電話して支払日の再約束か分割の相談をしてください。放置だけが最悪の選択です。',
+        ),
+      );
+    }
+
+    // ⑤ リボ/分割の設定解除 (全額返済は不要、増やさない設定が目的)。
+    final revolving = discipline?.revolvingCardViolations ??
+        const <AssetDebtDisciplineViolation>[];
+    if (revolving.isNotEmpty) {
+      final names = revolving
+          .map((violation) => violation.accountName)
+          .take(4)
+          .join('・');
+      weekSteps.add(
+        AssetTriageStep(
+          kind: AssetTriageStepKind.disableRevolving,
+          title: 'リボ/分割の設定解除を電話する',
+          detail: '$namesに電話し、今後の利用分の支払い方式を一括（1回払い）に'
+              '変更してください。残高を今すぐ全額返す必要はありません。'
+              '「これ以上リボが増えない設定」にすることが目的です。',
+        ),
+      );
+    }
+
+    // ⑥ 返済ペースを脱却プランで決める (金利の高い順)。
+    final planned = revolving
+        .where((violation) => violation.hasEscapePlan)
+        .toList();
+    if (planned.isNotEmpty) {
+      final top = planned.first;
+      monthSteps.add(
+        AssetTriageStep(
+          kind: AssetTriageStepKind.reviewRepaymentPace,
+          title: '返済ペースを宣言モニターで決める',
+          detail: '宣言モニターの「${top.escapeMonths}ヶ月脱却の月額」を見て、'
+              '金利の高いカードから月の返済額を決めてください。'
+              '例: ${top.accountName}は月${_yen(top.escapeMonthlyPayment!)}を'
+              '${top.escapeMonths}ヶ月続ければ脱却できます。',
+        ),
+      );
+    }
+
+    // ⑦ 支払予定と収入の差を固定費で埋める。
+    final monthlyPaymentTotal = workbook.cashflowRows
+        .where((row) => row.isPayment && row.isDirectCashflowTarget)
+        .fold<double>(0, (sum, row) => sum + row.paymentAmount);
+    final annualIncome = userProfile?.annualIncome;
+    if (annualIncome != null && annualIncome > 0 && monthlyPaymentTotal > 0) {
+      final monthlyIncome = annualIncome / 12;
+      if (monthlyPaymentTotal > monthlyIncome * 0.8) {
+        monthSteps.add(
+          AssetTriageStep(
+            kind: AssetTriageStepKind.closeIncomeGap,
+            title: '支払予定と収入の差を埋める',
+            detail: '今月の支払予定合計${_yen(monthlyPaymentTotal)}は'
+                '月収目安${_yen(monthlyIncome)}に対して重すぎます。'
+                '通信費・サブスクなど固定費の解約候補を明細から洗い出してください。',
+          ),
+        );
+      }
+    }
+
+    // 専門窓口の案内 (負債が絶対額または年収比の閾値を超えたら)。
+    final totalDebt = workbook.debtMasterRows.fold<double>(
+      0,
+      (sum, row) => sum + row.balance.abs(),
+    );
+    final showConsultation = totalDebt >= consultationDebtThreshold ||
+        (annualIncome != null &&
+            annualIncome > 0 &&
+            totalDebt >= annualIncome * consultationDebtIncomeRatio);
+    String? consultationNote;
+    if (showConsultation) {
+      final incomeNote = (annualIncome != null && annualIncome > 0)
+          ? '年収${_yen(annualIncome)}の収入があるので、増やすのを止めて計画を立て直せば'
+              '十分立て直せる数字です。'
+          : '';
+      consultationNote = '負債合計 約${_yen(totalDebt)}は、任意整理などで利息を'
+          '止められる可能性がある水準です。無料で相談できます: '
+          '法テラス 0570-078374（収入基準を満たせば弁護士相談が無料）/ '
+          '消費者ホットライン 188（最寄りの消費生活センター）/ '
+          '各自治体の無料法律相談（多重債務相談）。'
+          '相談は「破産する人がするもの」ではなく、利息を止めて返済計画を'
+          '立て直すための普通の手段です。$incomeNote';
+    }
+
+    return AssetTriagePlan(
+      todaySteps: cappedToday,
+      weekSteps: weekSteps,
+      monthSteps: monthSteps,
+      showConsultation: showConsultation,
+      consultationNote: consultationNote,
+    );
+  }
+
+  DateTime _dateOnly(DateTime value) =>
+      DateTime(value.year, value.month, value.day);
+
+  String _yen(double amount) {
+    final sign = amount < 0 ? '-' : '';
+    final digits = amount.abs().round().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      final remaining = digits.length - i;
+      buffer.write(digits[i]);
+      if (remaining > 1 && remaining % 3 == 1) {
+        buffer.write(',');
+      }
+    }
+    return '$sign$buffer円';
+  }
+}

--- a/supabase/functions/growth-hub/x_best_variant_test.ts
+++ b/supabase/functions/growth-hub/x_best_variant_test.ts
@@ -1,93 +1,36 @@
 import {
   assertEquals,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import {
-  foldVariants,
-  hasNamedVariant,
-  pickBestVariant,
-  pickConfidentVariant,
-} from "./x_best_variant.ts";
+import { hasNamedVariant, pickBestVariant } from "./x_best_variant.ts";
 
-// 本番で観測された実データ形状: fallback(平均89 n=1) が本命(平均76 n=7)を
-// 抑えて勝ち型に昇格していたケース。
-const observed = [
-  {
-    variant: "daily_briefing_fallback",
-    averageScore: 89,
-    count: 1,
-    totalScore: 89,
-  },
-  { variant: "daily_briefing", averageScore: 76, count: 7, totalScore: 532 },
-  {
-    variant: "daily_briefing_v2_numbers",
-    averageScore: 27,
-    count: 1,
-    totalScore: 27,
-  },
-];
-
-Deno.test("foldVariants: _fallback を base へ畳んで再集計する", () => {
-  const folded = foldVariants(observed);
-  // daily_briefing = (89 + 532)/8 = 77.6 → 78, n=8
-  const db = folded.find((v) => v.variant === "daily_briefing");
-  assertEquals(db?.count, 8);
-  assertEquals(db?.averageScore, 78);
-  // v2 はそのまま
-  const v2 = folded.find((v) => v.variant === "daily_briefing_v2_numbers");
-  assertEquals(v2?.count, 1);
-  // daily_briefing_fallback は独立キーとして残らない
-  assertEquals(
-    folded.some((v) => v.variant === "daily_briefing_fallback"),
-    false,
-  );
+Deno.test("pickBestVariant: unknown バケットが先頭でも除外して次点を返す", () => {
+  const variants = [
+    { variant: "unknown" },
+    { variant: "daily_briefing" },
+    { variant: "daily_briefing_v2_numbers" },
+  ];
+  assertEquals(pickBestVariant(variants), "daily_briefing");
 });
 
-Deno.test("foldVariants: unknown / 空を除外", () => {
-  const folded = foldVariants([
-    { variant: "unknown", averageScore: 999, count: 20 },
-    { variant: "", averageScore: 5, count: 1 },
-    { variant: "question_post", averageScore: 40, count: 3 },
-  ]);
-  assertEquals(folded.map((v) => v.variant), ["question_post"]);
+Deno.test("pickBestVariant: named が先頭ならそのまま返す", () => {
+  const variants = [
+    { variant: "daily_briefing_fallback" },
+    { variant: "unknown" },
+  ];
+  assertEquals(pickBestVariant(variants), "daily_briefing_fallback");
 });
 
-Deno.test("pickConfidentVariant: n>=2 の畳み込み最上位のみ返す", () => {
-  // 畳み込み後 daily_briefing n=8 が唯一 n>=2 → それが勝ち型
-  assertEquals(pickConfidentVariant(observed)?.variant, "daily_briefing");
-  // 全て n=1 → confident 無し
-  assertEquals(
-    pickConfidentVariant([
-      { variant: "a", averageScore: 90, count: 1 },
-      { variant: "b", averageScore: 10, count: 1 },
-    ]),
-    null,
-  );
-});
-
-Deno.test("pickBestVariant: 観測データで fallback ではなく base を返す", () => {
-  // 旧実装は daily_briefing_fallback を返していた。畳み込みで daily_briefing。
-  assertEquals(pickBestVariant(observed), "daily_briefing");
-});
-
-Deno.test("pickBestVariant: 全 n=1 は最上位平均へ / 空は fallback", () => {
-  assertEquals(
-    pickBestVariant([
-      { variant: "a", averageScore: 90, count: 1 },
-      { variant: "b", averageScore: 10, count: 1 },
-    ]),
-    "a",
-  );
+Deno.test("pickBestVariant: 全行 unknown / 空は fallback へ", () => {
+  assertEquals(pickBestVariant([{ variant: "unknown" }]), "daily_briefing");
   assertEquals(pickBestVariant([]), "daily_briefing");
-  assertEquals(
-    pickBestVariant([{ variant: "unknown", count: 9 }]),
-    "daily_briefing",
-  );
   assertEquals(pickBestVariant([], "question_post"), "question_post");
 });
 
 Deno.test("hasNamedVariant: unknown のみ→false / named 混在→true", () => {
-  assertEquals(hasNamedVariant([{ variant: "unknown", count: 5 }]), false);
+  assertEquals(hasNamedVariant([{ variant: "unknown" }]), false);
   assertEquals(hasNamedVariant([]), false);
-  assertEquals(hasNamedVariant(null), false);
-  assertEquals(hasNamedVariant(observed), true);
+  assertEquals(
+    hasNamedVariant([{ variant: "unknown" }, { variant: "daily_briefing" }]),
+    true,
+  );
 });

--- a/supabase/functions/growth-hub/x_best_variant_test.ts
+++ b/supabase/functions/growth-hub/x_best_variant_test.ts
@@ -1,6 +1,4 @@
-import {
-  assertEquals,
-} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import { hasNamedVariant, pickBestVariant } from "./x_best_variant.ts";
 
 Deno.test("pickBestVariant: unknown バケットが先頭でも除外して次点を返す", () => {

--- a/supabase/functions/growth-hub/x_best_variant_test.ts
+++ b/supabase/functions/growth-hub/x_best_variant_test.ts
@@ -1,34 +1,93 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { hasNamedVariant, pickBestVariant } from "./x_best_variant.ts";
+import {
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  foldVariants,
+  hasNamedVariant,
+  pickBestVariant,
+  pickConfidentVariant,
+} from "./x_best_variant.ts";
 
-Deno.test("pickBestVariant: unknown バケットが先頭でも除外して次点を返す", () => {
-  const variants = [
-    { variant: "unknown" },
-    { variant: "daily_briefing" },
-    { variant: "daily_briefing_v2_numbers" },
-  ];
-  assertEquals(pickBestVariant(variants), "daily_briefing");
+// 本番で観測された実データ形状: fallback(平均89 n=1) が本命(平均76 n=7)を
+// 抑えて勝ち型に昇格していたケース。
+const observed = [
+  {
+    variant: "daily_briefing_fallback",
+    averageScore: 89,
+    count: 1,
+    totalScore: 89,
+  },
+  { variant: "daily_briefing", averageScore: 76, count: 7, totalScore: 532 },
+  {
+    variant: "daily_briefing_v2_numbers",
+    averageScore: 27,
+    count: 1,
+    totalScore: 27,
+  },
+];
+
+Deno.test("foldVariants: _fallback を base へ畳んで再集計する", () => {
+  const folded = foldVariants(observed);
+  // daily_briefing = (89 + 532)/8 = 77.6 → 78, n=8
+  const db = folded.find((v) => v.variant === "daily_briefing");
+  assertEquals(db?.count, 8);
+  assertEquals(db?.averageScore, 78);
+  // v2 はそのまま
+  const v2 = folded.find((v) => v.variant === "daily_briefing_v2_numbers");
+  assertEquals(v2?.count, 1);
+  // daily_briefing_fallback は独立キーとして残らない
+  assertEquals(
+    folded.some((v) => v.variant === "daily_briefing_fallback"),
+    false,
+  );
 });
 
-Deno.test("pickBestVariant: named が先頭ならそのまま返す", () => {
-  const variants = [
-    { variant: "daily_briefing_fallback" },
-    { variant: "unknown" },
-  ];
-  assertEquals(pickBestVariant(variants), "daily_briefing_fallback");
+Deno.test("foldVariants: unknown / 空を除外", () => {
+  const folded = foldVariants([
+    { variant: "unknown", averageScore: 999, count: 20 },
+    { variant: "", averageScore: 5, count: 1 },
+    { variant: "question_post", averageScore: 40, count: 3 },
+  ]);
+  assertEquals(folded.map((v) => v.variant), ["question_post"]);
 });
 
-Deno.test("pickBestVariant: 全行 unknown / 空は fallback へ", () => {
-  assertEquals(pickBestVariant([{ variant: "unknown" }]), "daily_briefing");
+Deno.test("pickConfidentVariant: n>=2 の畳み込み最上位のみ返す", () => {
+  // 畳み込み後 daily_briefing n=8 が唯一 n>=2 → それが勝ち型
+  assertEquals(pickConfidentVariant(observed)?.variant, "daily_briefing");
+  // 全て n=1 → confident 無し
+  assertEquals(
+    pickConfidentVariant([
+      { variant: "a", averageScore: 90, count: 1 },
+      { variant: "b", averageScore: 10, count: 1 },
+    ]),
+    null,
+  );
+});
+
+Deno.test("pickBestVariant: 観測データで fallback ではなく base を返す", () => {
+  // 旧実装は daily_briefing_fallback を返していた。畳み込みで daily_briefing。
+  assertEquals(pickBestVariant(observed), "daily_briefing");
+});
+
+Deno.test("pickBestVariant: 全 n=1 は最上位平均へ / 空は fallback", () => {
+  assertEquals(
+    pickBestVariant([
+      { variant: "a", averageScore: 90, count: 1 },
+      { variant: "b", averageScore: 10, count: 1 },
+    ]),
+    "a",
+  );
   assertEquals(pickBestVariant([]), "daily_briefing");
+  assertEquals(
+    pickBestVariant([{ variant: "unknown", count: 9 }]),
+    "daily_briefing",
+  );
   assertEquals(pickBestVariant([], "question_post"), "question_post");
 });
 
 Deno.test("hasNamedVariant: unknown のみ→false / named 混在→true", () => {
-  assertEquals(hasNamedVariant([{ variant: "unknown" }]), false);
+  assertEquals(hasNamedVariant([{ variant: "unknown", count: 5 }]), false);
   assertEquals(hasNamedVariant([]), false);
-  assertEquals(
-    hasNamedVariant([{ variant: "unknown" }, { variant: "daily_briefing" }]),
-    true,
-  );
+  assertEquals(hasNamedVariant(null), false);
+  assertEquals(hasNamedVariant(observed), true);
 });

--- a/test/services/asset_management_insight_service_test.dart
+++ b/test/services/asset_management_insight_service_test.dart
@@ -311,6 +311,36 @@ void main() {
       expect(missing.suggestedAction.contains('候補: 三井住友銀行大塚支店'), false);
     });
 
+    test('report carries a triage plan and the prompt includes the section',
+        () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 4817,
+          '三井住友銀行大塚支店': 400000,
+          'モビット': -3200000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 37000},
+      );
+
+      final report = service.buildReport(workbook: workbook);
+
+      expect(report.triagePlan, isNotNull);
+      expect(report.triagePlan!.hasContent, isTrue);
+      expect(
+        report.triagePlan!.todaySteps.first.detail.contains('三井住友銀行大塚支店'),
+        isTrue,
+      );
+
+      final prompt =
+          const AssetManagementInsightPromptBuilder().buildDetailedAdvicePrompt(
+        report,
+      );
+      expect(prompt.contains('今日やることトリアージ'), isTrue);
+      expect(prompt.contains('食費・移動費を確保する'), isTrue);
+      expect(prompt.contains('法テラス'), isTrue);
+    });
+
     test('missing payment source action suggests the largest cash-like account',
         () {
       final workbook = planner.buildWorkbook(

--- a/test/services/asset_triage_guide_service_test.dart
+++ b/test/services/asset_triage_guide_service_test.dart
@@ -32,9 +32,8 @@ void main() {
           'auPayカード': 10,
         },
       );
-      final famipayId = workbook.debtMasterRows
-          .firstWhere((row) => row.name == 'ファミペイ')
-          .id;
+      final famipayId =
+          workbook.debtMasterRows.firstWhere((row) => row.name == 'ファミペイ').id;
       final discipline = monitor.evaluate(
         workbook: workbook,
         priorBalancesByAccountId: <String, double>{famipayId: 200000},

--- a/test/services/asset_triage_guide_service_test.dart
+++ b/test/services/asset_triage_guide_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/models/user_profile.dart';
 import 'package:my_web_app/services/asset_debt_discipline_monitor.dart';
 import 'package:my_web_app/services/asset_liability_planning_service.dart';
@@ -11,20 +12,25 @@ void main() {
 
   group('AssetTriageGuideService', () {
     test('crisis state produces at most 3 ordered today steps', () {
-      // 現金4,817円 + 本日期日のモビット + ファミペイのリボ/新規利用。
+      // 現金4,817円 + 本日期日のモビット + 期限超過のauPay + ファミペイのリボ/新規利用。
       final workbook = planner.buildWorkbook(
         latestSnapshot: const <String, double>{
           '財布(現金)': 4817,
           '三井住友銀行大塚支店': 400000,
           'ファミペイ': -3200000,
           'モビット': -100000,
+          'auPayカード': -200000,
         },
         baseDate: DateTime(2026, 5, 15),
         monthlyPaymentOverrides: const <String, double>{
           'ファミペイ': 3000,
           'mobit': 10000,
+          'aupay_card': 20000,
         },
-        paymentDayOverrides: const <String, int>{'モビット': 15},
+        paymentDayOverrides: const <String, int>{
+          'モビット': 15,
+          'auPayカード': 10,
+        },
       );
       final famipayId = workbook.debtMasterRows
           .firstWhere((row) => row.name == 'ファミペイ')
@@ -52,7 +58,8 @@ void main() {
       // ③ 止血 (カード新規利用停止)。
       expect(plan.todaySteps[2].kind, AssetTriageStepKind.stopNewCardUsage);
       expect(plan.todaySteps[2].detail.contains('ファミペイ'), isTrue);
-      // 今週: 期限超過処理 + リボ解除電話。
+      // 今週: 期限超過処理 + リボ解除電話。期限超過は昨日以前の支払のみ
+      // (本日期日のモビット10,000円は②に載せ、④へは二重計上しない)。
       expect(
         plan.weekSteps.map((step) => step.kind),
         containsAll(<AssetTriageStepKind>[
@@ -60,6 +67,11 @@ void main() {
           AssetTriageStepKind.disableRevolving,
         ]),
       );
+      final overdueStep = plan.weekSteps.firstWhere(
+        (step) => step.kind == AssetTriageStepKind.processOverdue,
+      );
+      expect(overdueStep.detail.contains('1件'), isTrue);
+      expect(overdueStep.detail.contains('20,000円'), isTrue);
       // 今月: 脱却プランに基づく返済ペース。
       expect(
         plan.monthSteps.any(
@@ -72,6 +84,116 @@ void main() {
       expect(plan.consultationNote, isNotNull);
       expect(plan.consultationNote!.contains('法テラス'), isTrue);
       expect(plan.consultationNote!.contains('188'), isTrue);
+    });
+
+    test('overdue step ignores unreceived income and due-today payments', () {
+      // 未受領の給料 (期日超過で overdue フラグが立つ) と本日期日の支払は
+      // 「期限超過」ステップに数えない。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 50000,
+          'モビット': -100000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 10000},
+        paymentDayOverrides: const <String, int>{'モビット': 15},
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'salary',
+            date: DateTime(2026, 5, 10),
+            name: '給料',
+            amount: 200000,
+            destinationAccountId: null,
+            destinationAccountName: null,
+            received: false,
+          ),
+        ],
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      expect(
+        plan.weekSteps.where(
+          (step) => step.kind == AssetTriageStepKind.processOverdue,
+        ),
+        isEmpty,
+      );
+      expect(
+        plan.todaySteps.any(
+          (step) => step.kind == AssetTriageStepKind.dueTodayPayment,
+        ),
+        isTrue,
+      );
+    });
+
+    test('no fake cash crisis for users without a cash account', () {
+      // 現金口座を記録していないだけの健全ユーザーには生活費ステップを出さない。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 500000},
+        baseDate: DateTime(2026, 5, 1),
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+        todayAvailableAmount: 100000,
+      );
+
+      expect(
+        plan.todaySteps.where(
+          (step) => step.kind == AssetTriageStepKind.secureLivingExpense,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('consultation threshold counts only borrowing-kind debt', () {
+      // 家賃 (毎月全額払いの固定費) は借入合計に含めない → 閾値未満で案内なし。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          '家賃': -80000,
+          'モビット': -2950000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      expect(plan.showConsultation, isFalse);
+    });
+
+    test('repayment pace example picks the highest annual rate card', () {
+      // PayPay (繰越額最大・年利15%) より ファミペイ (年利18%) を例示する。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'PayPay': -800000,
+          'ファミペイ': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{
+          'paypay_card': 10000,
+          'ファミペイ': 10000,
+        },
+        annualRateOverrides: const <String, double>{'famipay_card': 0.18},
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      final pace = plan.monthSteps.firstWhere(
+        (step) => step.kind == AssetTriageStepKind.reviewRepaymentPace,
+      );
+      expect(pace.detail.contains('例: ファミペイ'), isTrue);
     });
 
     test('calm state has no content', () {

--- a/test/services/asset_triage_guide_service_test.dart
+++ b/test/services/asset_triage_guide_service_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/user_profile.dart';
+import 'package:my_web_app/services/asset_debt_discipline_monitor.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+import 'package:my_web_app/services/asset_triage_guide_service.dart';
+
+void main() {
+  const planner = AssetLiabilityPlanningService();
+  const monitor = AssetDebtDisciplineMonitor();
+  const triage = AssetTriageGuideService();
+
+  group('AssetTriageGuideService', () {
+    test('crisis state produces at most 3 ordered today steps', () {
+      // 現金4,817円 + 本日期日のモビット + ファミペイのリボ/新規利用。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 4817,
+          '三井住友銀行大塚支店': 400000,
+          'ファミペイ': -3200000,
+          'モビット': -100000,
+        },
+        baseDate: DateTime(2026, 5, 15),
+        monthlyPaymentOverrides: const <String, double>{
+          'ファミペイ': 3000,
+          'mobit': 10000,
+        },
+        paymentDayOverrides: const <String, int>{'モビット': 15},
+      );
+      final famipayId = workbook.debtMasterRows
+          .firstWhere((row) => row.name == 'ファミペイ')
+          .id;
+      final discipline = monitor.evaluate(
+        workbook: workbook,
+        priorBalancesByAccountId: <String, double>{famipayId: 200000},
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: discipline,
+        todayAvailableAmount: -5619,
+      );
+
+      expect(plan.hasContent, isTrue);
+      expect(plan.todaySteps.length, AssetTriageGuideService.maxTodaySteps);
+      // ① 生活費確保が最優先 (最大残高の預金口座と手元現金額を名指し)。
+      expect(plan.todaySteps[0].kind, AssetTriageStepKind.secureLivingExpense);
+      expect(plan.todaySteps[0].detail.contains('4,817円'), isTrue);
+      expect(plan.todaySteps[0].detail.contains('三井住友銀行大塚支店'), isTrue);
+      // ② 本日期日の支払い。
+      expect(plan.todaySteps[1].kind, AssetTriageStepKind.dueTodayPayment);
+      expect(plan.todaySteps[1].detail.contains('モビット'), isTrue);
+      // ③ 止血 (カード新規利用停止)。
+      expect(plan.todaySteps[2].kind, AssetTriageStepKind.stopNewCardUsage);
+      expect(plan.todaySteps[2].detail.contains('ファミペイ'), isTrue);
+      // 今週: 期限超過処理 + リボ解除電話。
+      expect(
+        plan.weekSteps.map((step) => step.kind),
+        containsAll(<AssetTriageStepKind>[
+          AssetTriageStepKind.processOverdue,
+          AssetTriageStepKind.disableRevolving,
+        ]),
+      );
+      // 今月: 脱却プランに基づく返済ペース。
+      expect(
+        plan.monthSteps.any(
+          (step) => step.kind == AssetTriageStepKind.reviewRepaymentPace,
+        ),
+        isTrue,
+      );
+      // 負債330万 ≥ 300万 → 専門窓口案内。
+      expect(plan.showConsultation, isTrue);
+      expect(plan.consultationNote, isNotNull);
+      expect(plan.consultationNote!.contains('法テラス'), isTrue);
+      expect(plan.consultationNote!.contains('188'), isTrue);
+    });
+
+    test('calm state has no content', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'財布(現金)': 50000},
+        baseDate: DateTime(2026, 5, 1),
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      expect(plan.hasContent, isFalse);
+      expect(plan.todaySteps, isEmpty);
+      expect(plan.showConsultation, isFalse);
+    });
+
+    test('income gap step appears when payments outweigh monthly income', () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 50000,
+          'モビット': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 13000},
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+        userProfile: UserProfile(userId: 'u', annualIncome: 150000),
+      );
+
+      final gap = plan.monthSteps.where(
+        (step) => step.kind == AssetTriageStepKind.closeIncomeGap,
+      );
+      expect(gap.length, 1);
+      expect(gap.first.detail.contains('13,000円'), isTrue);
+      expect(gap.first.detail.contains('12,500円'), isTrue);
+    });
+
+    test('living expense step degrades gracefully without a deposit account',
+        () {
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 500,
+          'モビット': -50000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 5000},
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      final living = plan.todaySteps.firstWhere(
+        (step) => step.kind == AssetTriageStepKind.secureLivingExpense,
+      );
+      expect(living.detail.contains('フードバンク'), isTrue);
+      expect(living.detail.contains('食事を抜く判断はしないでください'), isTrue);
+    });
+  });
+}

--- a/test/widgets/asset_management_page_smoke_test.dart
+++ b/test/widgets/asset_management_page_smoke_test.dart
@@ -1241,6 +1241,44 @@ void main() {
       await _unmount(tester);
     });
 
+    testWidgets('triage guide card shows staged first steps in crisis', (
+      tester,
+    ) async {
+      // 現金1,000円 + 負債 → 「まず、これだけ」カードが生活費確保を最優先で出す。
+      final now = DateTime.now();
+      final dateKey = DateFormat('yyyy-MM-dd').format(now);
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      await tester.binding.setSurfaceSize(const Size(1200, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AssetManagementPage(
+            debugCalendarNow: DateTime(2026, 7, 10),
+            debugInitialAssetData: <String, Map<String, double>>{
+              dateKey: const <String, double>{
+                '財布(現金)': 1000,
+                '三井住友銀行大塚支店': 500000,
+                'モビット': -3200000,
+              },
+            },
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.byKey(const Key('asset_triage_guide_card')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('まず、これだけ'), findsWidgets);
+      expect(find.textContaining('食費・移動費を確保する'), findsOneWidget);
+      // 負債 320万 ≥ 300万 → 専門窓口の案内も出る。
+      expect(find.textContaining('一人で抱えないでください'), findsOneWidget);
+
+      await _unmount(tester);
+    });
+
     testWidgets('payment source missing banner lists unset payment sources', (
       tester,
     ) async {


### PR DESCRIPTION
## 概要

「混乱しており何からやっていけばいいか分かりません」というユーザーの声に応える機能。数字の洪水で動けなくなっている利用者向けに、**今日やること (最大3件) → 今週 → 今月 → 専門窓口**の順で行動を絞って提示する。

- **新サービス `AssetTriageGuideService`** (決定論的 Dart / calculation_owner: dart_service):
  - 今日: ①生活費確保 (見込み残高最大の預金口座を名指し・引落不能を誘発しない選定) ②本日期日の原資確認 ③カード新規利用停止 (「増やさない」が返済より先)
  - 今週: ④期限超過処理 (昨日以前の支払のみ・放置だけが最悪) ⑤リボ解除電話 (理想は一括、まず増やさない設定)
  - 今月: ⑥脱却プランで返済ペース (年利降順で例示) ⑦収支ギャップの固定費見直し
  - 借入合計 (固定費除外) が 300万円以上 or 年収の50%以上で法テラス 0570-078374・消費者ホットライン 188 等の無料相談窓口を案内。「破産する人がするもの」ではないことを明示
- insight report に `triagePlan` を追加し、AI プロンプトへ**順番固定・言い換えのみ許可**で渡す
- AI アシスタントセクション先頭に「まず、これだけ」カード (固定淡ティール背景 + 固定濃色文字 / FP・弁護士でない免責を常時表示 / 「今日はこれで終わりです」で打ち切りを明示)

## 敵対レビュー (Ultracode 4レンズ)

確定指摘 8 グループを全て反映済み:
- 未受領給与が「期限超過の延滞額」に混入する critical / 本日期日の二重計上
- 現金口座未登録ユーザーへの「現金0円」偽危機 / 引出先口座の見込み残高無視 (引落不能誘発)
- 専門窓口判定への家賃等固定費の混入 / 借入が年収1.5倍超でも「十分立て直せる」と断言する過剰保証
- 例示カードの順位基準不一致 (年利降順へ) / 宣言モニターとの文言矛盾 / dartdoc 付け違い

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.（実装詳細に依存しない入出力ベース）
- Minimal scope: about 3 cases（最小限の3ケース: ①危機状態で今日3件が優先順で出る ②現金口座なし健全ユーザーには偽危機を出さない ③借入閾値超過で相談窓口案内）
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数サービス + widget smoke test (test/widgets/asset_management_page_smoke_test.dart) で入出力を検証済みのため専用 E2E 追加なし

## テスト

- 新規 10 件 (トリアージ 8 + insight/prompt 1 + smoke 1) 含め service 34 + smoke 59 全緑
- `dart analyze` 対象ファイル `No issues found!` / `require_trailing_commas` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
