### PR TITLE
fix(admin): X成長ループ勝ち型の誠実性強化 10仮説検証→4修正 (part339)

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -6539,15 +6539,13 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
 
   /// variants(平均スコア降順)から上位3種を「{variant} 平均{score} (n={count})」に。
   List<String> _xGrowthVariantRankingLines(List<dynamic>? variants) {
-    if (variants == null) return const [];
+    // R28: 勝ち型と同じ畳み込み (unknown 除外 + `_fallback` を base へ) 済みの
+    // ランキングを出す。畳まないと「勝ち型: daily_briefing」なのに直下の
+    // ランキング先頭が「daily_briefing_fallback 平均89」という矛盾表示になる。
+    final folded = foldVariantsForDisplay(variants);
     final lines = <String>[];
-    for (final entry in variants) {
-      if (entry is! Map) continue;
-      final name = (entry['variant'] ?? '').toString().trim();
-      if (name.isEmpty || name == 'unknown') continue;
-      final score = _toInt(entry['averageScore']);
-      final count = _toInt(entry['count']);
-      lines.add('$name 平均$score (n=$count)');
+    for (final entry in folded) {
+      lines.add('${entry.variant} 平均${entry.averageScore} (n=${entry.count})');
       if (lines.length >= 3) break;
     }
     return lines;

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -190,23 +190,79 @@ String? xGrowthLoopStalenessWarning({
       'metrics 収集 cron / spend-cap を確認してください。';
 }
 
-/// R27: サーバの bestVariant が「unknown」(variant タグ無し投稿の受け皿
-/// バケット)のとき、variants ランキング(平均スコア降順)から unknown を除いた
-/// 先頭を勝ち型として返す。有効な variant が無ければ null(勝ち型行を出さ
-/// ない)。growth-hub 側の除外漏れ(index.ts の bestVariant)への防御で、
-/// サーバ修正後も古いレスポンス/キャッシュに対して安全側に働く。
-String? resolveDisplayBestVariant(
-  String? bestVariant,
-  List<dynamic>? variants,
-) {
-  final trimmed = (bestVariant ?? '').trim();
-  if (trimmed.isNotEmpty && trimmed != 'unknown') return trimmed;
-  if (variants == null) return null;
+/// 畳み込み済み variant 実測。edge の x_best_variant.ts FoldedVariant と対の
+/// クライアント表現。
+class FoldedVariant {
+  final String variant;
+  final int averageScore;
+  final int count;
+
+  const FoldedVariant({
+    required this.variant,
+    required this.averageScore,
+    required this.count,
+  });
+}
+
+/// R28: variants(各 {variant, averageScore, count})を unknown 除外 + `_fallback`
+/// を base へ畳んで再集計する。edge の x_best_variant.ts foldVariants と同じ戦略
+/// 同一視。クライアントには totalScore が無いため averageScore*count で近似
+/// (edge は exact totalScore を持つ)。平均降順・同点は件数降順。
+List<FoldedVariant> foldVariantsForDisplay(List<dynamic>? variants) {
+  if (variants == null) return const [];
+  final totals = <String, num>{};
+  final counts = <String, int>{};
   for (final entry in variants) {
     if (entry is! Map) continue;
-    final name = (entry['variant'] ?? '').toString().trim();
+    var name = (entry['variant'] ?? '').toString().trim();
     if (name.isEmpty || name == 'unknown') continue;
-    return name;
+    if (name.endsWith('_fallback')) {
+      name = name.substring(0, name.length - '_fallback'.length);
+    }
+    if (name.isEmpty) continue;
+    final count = _toIntSignal(entry['count']);
+    final effectiveCount = count <= 0 ? 1 : count;
+    final avg = _toIntSignal(entry['averageScore']);
+    totals[name] = (totals[name] ?? 0) + avg * effectiveCount;
+    counts[name] = (counts[name] ?? 0) + effectiveCount;
+  }
+  final folded = counts.keys
+      .map(
+        (name) => FoldedVariant(
+          variant: name,
+          averageScore: (totals[name]! / counts[name]!).round(),
+          count: counts[name]!,
+        ),
+      )
+      .toList()
+    ..sort((a, b) {
+      final byAvg = b.averageScore.compareTo(a.averageScore);
+      if (byAvg != 0) return byAvg;
+      return b.count.compareTo(a.count);
+    });
+  return folded;
+}
+
+int _toIntSignal(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
+}
+
+/// R28: 勝ち型は畳み込み後 count>=minSample の最上位のみ。n=1 の外れ値や
+/// `_fallback` 単独 (part338 で unknown 除外を入れた副作用で 1 サンプルの
+/// daily_briefing_fallback が n=7 の daily_briefing を抑えて昇格していた) を
+/// 勝ち型に断定しない。該当が無ければ null(勝ち型行を出さない)。第1引数
+/// bestVariant はサーバ計算値だが、畳み込み前の生値なので信用せず variants
+/// から再判定する(古いレスポンス/キャッシュにも安全側)。
+String? resolveDisplayBestVariant(
+  String? bestVariant,
+  List<dynamic>? variants, {
+  int minSample = 2,
+}) {
+  for (final folded in foldVariantsForDisplay(variants)) {
+    if (folded.count >= minSample) return folded.variant;
   }
   return null;
 }
@@ -333,10 +389,15 @@ String? archetypeLiftSummaryLine(List<ArchetypeLiftEntry> entries) {
   if (entries.isEmpty) return null;
   final parts = entries.map((e) {
     final pending = e.pendingCount > 0 ? '・計測中${e.pendingCount}件' : '';
-    return e.measured
-        ? '${e.label} 平均${e.averageImpressions} imp '
-            '(${e.count}件$pending)'
-        : '${e.label} 実測不足 (${e.count}件$pending)';
+    if (e.measured) {
+      return '${e.label} 平均${e.averageImpressions} imp (${e.count}件$pending)';
+    }
+    // R28: 実測 0 件のバケット(全て計測中)は「実測不足 (0件・計測中N件)」だと
+    // 「0件」が二重に不自然。計測中のみ簡潔に出す。
+    if (e.count == 0) {
+      return '${e.label} 計測中${e.pendingCount}件';
+    }
+    return '${e.label} 実測不足 (${e.count}件$pending)';
   });
   return '型別実測（投稿72時間後・imp）: ${parts.join(' / ')}';
 }

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -24,7 +24,7 @@ import {
   resolveDuplicateGuardConfig,
   type XPostLogRowLike,
 } from "./x_duplicate_content.ts";
-import { hasNamedVariant, pickBestVariant } from "./x_best_variant.ts";
+import { pickBestVariant, pickConfidentVariant } from "./x_best_variant.ts";
 import {
   buildSignupSlackPayload,
   isRecentSignupCreatedAt,
@@ -980,11 +980,13 @@ function buildXPerformanceContextFromLogs(
     }))
     .sort((left, right) => right.averageScore - left.averageScore);
 
-  // 「unknown」は variant タグ無し投稿の受け皿バケットで勝ち型ではない。
-  // 他の全消費箇所 (variant ランキング表示 / distinctVariants 計数) と同じく
-  // 除外して選ぶ (除外漏れでダッシュボードと投稿生成プロンプトの両方に
-  // 「勝ち型: unknown」が流れていた)。
+  // 勝ち型は unknown 除外 + `_fallback` を base へ畳む + 最小サンプル(n>=2)で
+  // 選ぶ (x_best_variant.ts)。畳まないと 1 サンプルの `daily_briefing_fallback`
+  // (平均89 n=1) が 7 サンプルの `daily_briefing` (平均76 n=7) を抑えて勝ち型に
+  // 昇格していた。bestVariant は保存/後方互換用、confidentBest は「実測で勝ちと
+  // 言える型」(無ければ null=断定しない)。
   const bestVariant = pickBestVariant(variants);
+  const confidentBest = pickConfidentVariant(variants);
   // 集計ロールアップ (guarded): 両バケットに十分なサンプルがあるときだけ、
   // 変動要因(メディア有無/リンク位置/スレッド長)ごとの平均スコア差を測定事実と
   // して LLM へ渡す。データが薄い間は行自体を出さない(=実質 default-off で、
@@ -1154,10 +1156,10 @@ function buildXPerformanceContextFromLogs(
     ].join("\n")
     : [
       "Measured X performance context for the next post:",
-      // 実測 variant (unknown 以外) が無いとき fallback 名を実測済みの勝ち型
-      // かのように主張しない。
-      hasNamedVariant(variants)
-        ? `Target: 10K impressions. Current best variant: ${bestVariant}.`
+      // n>=2 で畳み込んだ勝ち型が無いとき、1 サンプルの外れ値や fallback 名を
+      // 実測済みの勝ち型かのように LLM へ主張しない。
+      confidentBest
+        ? `Target: 10K impressions. Current best variant: ${confidentBest.variant} (n=${confidentBest.count}).`
         : "Target: 10K impressions. No post-age comparable winner yet.",
       `Ranking basis: ${comparisonLabel} impressions ` +
       `(comparable n=${learningRows.length}; total measured n=${rows.length}).`,

--- a/supabase/functions/growth-hub/x_best_variant.ts
+++ b/supabase/functions/growth-hub/x_best_variant.ts
@@ -1,28 +1,92 @@
 // x.performance_context の勝ち型 (bestVariant) 選定。
 //
-// variants ランキングには variant タグ無し投稿の受け皿である「unknown」
-// バケットが混ざる。variant ランキング表示・distinctVariants 計数など他の
-// 全消費箇所は unknown を除外しているのに、bestVariant だけ variants[0] を
-// 素通ししていたため、タグ無し高インプレ投稿が貯まると「今の勝ち型:
-// unknown」がダッシュボードと投稿生成プロンプト (Current best variant) の
-// 両方へ流れていた。ここで除外を一元化する。
+// 2 段階の誠実性ガードを一元化する:
+//  (1) unknown 除外 — variant タグ無し投稿の受け皿バケットは勝ち型ではない。
+//  (2) `_fallback` を base variant へ畳む — `daily_briefing_fallback` は
+//      `daily_briefing` の定型フォールバック版で戦略としては同一。畳まないと
+//      1 サンプルの fallback (平均89 n=1) が 7 サンプルの本命 (平均76 n=7) を
+//      抑えて「勝ち型」に昇格していた (part338 で unknown 除外を入れた副作用)。
+//  (3) 最小サンプル — n=1 の外れ値を勝ち型に断定しない (archetype winner の
+//      n>=2 規律と対称)。
+// distinctMeasuredVariants (client) の畳み込みロジックと同一の戦略同一視を保つ。
 
 export interface VariantRankingEntry {
   variant: string;
+  count?: number;
+  averageScore?: number;
+  totalScore?: number;
 }
 
-/// unknown を除いた最上位 variant。無ければ fallback (既定 daily_briefing)。
+export interface FoldedVariant {
+  variant: string;
+  count: number;
+  averageScore: number;
+}
+
+/// unknown を除外し `_fallback` を base へ畳んで再集計する。平均スコア降順
+/// (同点は件数降順) でソートして返す。count/totalScore が無い要素は
+/// count=1・totalScore=averageScore として扱う (client 側の近似入力に対応)。
+export function foldVariants(
+  variants: VariantRankingEntry[] | null | undefined,
+): FoldedVariant[] {
+  const byBase = new Map<
+    string,
+    { variant: string; count: number; totalScore: number }
+  >();
+  for (const entry of variants ?? []) {
+    let name = (entry?.variant ?? "").trim();
+    if (!name || name === "unknown") continue;
+    if (name.endsWith("_fallback")) {
+      name = name.slice(0, -"_fallback".length);
+    }
+    if (!name) continue;
+    const count = entry.count ?? 1;
+    const total = entry.totalScore ?? (entry.averageScore ?? 0) * count;
+    const current = byBase.get(name) ?? {
+      variant: name,
+      count: 0,
+      totalScore: 0,
+    };
+    current.count += count;
+    current.totalScore += total;
+    byBase.set(name, current);
+  }
+  return [...byBase.values()]
+    .map((entry) => ({
+      variant: entry.variant,
+      count: entry.count,
+      averageScore: Math.round(entry.totalScore / Math.max(1, entry.count)),
+    }))
+    .sort((left, right) =>
+      right.averageScore - left.averageScore || right.count - left.count
+    );
+}
+
+/// 自信を持って主張できる勝ち型 (畳み込み後 count>=minSample の最上位)。
+/// 該当が無ければ null (勝ち型を主張しない)。
+export function pickConfidentVariant(
+  variants: VariantRankingEntry[] | null | undefined,
+  minSample = 2,
+): FoldedVariant | null {
+  const eligible = foldVariants(variants).filter((e) => e.count >= minSample);
+  return eligible[0] ?? null;
+}
+
+/// 保存フィールド/プロンプト用の bestVariant 文字列。confident があればそれ、
+/// 無ければ畳み込み後の最上位、それも無ければ fallback 既定。
 export function pickBestVariant(
-  variants: VariantRankingEntry[],
+  variants: VariantRankingEntry[] | null | undefined,
   fallback = "daily_briefing",
+  minSample = 2,
 ): string {
-  return variants.find((entry) => entry.variant !== "unknown")?.variant ??
-    fallback;
+  const folded = foldVariants(variants);
+  const confident = folded.find((e) => e.count >= minSample);
+  return (confident ?? folded[0])?.variant ?? fallback;
 }
 
-/// unknown 以外の実測 variant が1つでもあるか。promptContext が
-/// 「Current best variant: X」と主張してよいかのガード (全行 unknown のとき
-/// fallback 名を実測済みかのように主張しない)。
-export function hasNamedVariant(variants: VariantRankingEntry[]): boolean {
-  return variants.some((entry) => entry.variant !== "unknown");
+/// unknown/空を除いた実測 variant が (畳み込み後) 1 つでもあるか。
+export function hasNamedVariant(
+  variants: VariantRankingEntry[] | null | undefined,
+): boolean {
+  return foldVariants(variants).length > 0;
 }

--- a/supabase/functions/growth-hub/x_best_variant_test.ts
+++ b/supabase/functions/growth-hub/x_best_variant_test.ts
@@ -1,36 +1,93 @@
 import {
   assertEquals,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { hasNamedVariant, pickBestVariant } from "./x_best_variant.ts";
+import {
+  foldVariants,
+  hasNamedVariant,
+  pickBestVariant,
+  pickConfidentVariant,
+} from "./x_best_variant.ts";
 
-Deno.test("pickBestVariant: unknown バケットが先頭でも除外して次点を返す", () => {
-  const variants = [
-    { variant: "unknown" },
-    { variant: "daily_briefing" },
-    { variant: "daily_briefing_v2_numbers" },
-  ];
-  assertEquals(pickBestVariant(variants), "daily_briefing");
+// 本番で観測された実データ形状: fallback(平均89 n=1) が本命(平均76 n=7)を
+// 抑えて勝ち型に昇格していたケース。
+const observed = [
+  {
+    variant: "daily_briefing_fallback",
+    averageScore: 89,
+    count: 1,
+    totalScore: 89,
+  },
+  { variant: "daily_briefing", averageScore: 76, count: 7, totalScore: 532 },
+  {
+    variant: "daily_briefing_v2_numbers",
+    averageScore: 27,
+    count: 1,
+    totalScore: 27,
+  },
+];
+
+Deno.test("foldVariants: _fallback を base へ畳んで再集計する", () => {
+  const folded = foldVariants(observed);
+  // daily_briefing = (89 + 532)/8 = 77.6 → 78, n=8
+  const db = folded.find((v) => v.variant === "daily_briefing");
+  assertEquals(db?.count, 8);
+  assertEquals(db?.averageScore, 78);
+  // v2 はそのまま
+  const v2 = folded.find((v) => v.variant === "daily_briefing_v2_numbers");
+  assertEquals(v2?.count, 1);
+  // daily_briefing_fallback は独立キーとして残らない
+  assertEquals(
+    folded.some((v) => v.variant === "daily_briefing_fallback"),
+    false,
+  );
 });
 
-Deno.test("pickBestVariant: named が先頭ならそのまま返す", () => {
-  const variants = [
-    { variant: "daily_briefing_fallback" },
-    { variant: "unknown" },
-  ];
-  assertEquals(pickBestVariant(variants), "daily_briefing_fallback");
+Deno.test("foldVariants: unknown / 空を除外", () => {
+  const folded = foldVariants([
+    { variant: "unknown", averageScore: 999, count: 20 },
+    { variant: "", averageScore: 5, count: 1 },
+    { variant: "question_post", averageScore: 40, count: 3 },
+  ]);
+  assertEquals(folded.map((v) => v.variant), ["question_post"]);
 });
 
-Deno.test("pickBestVariant: 全行 unknown / 空は fallback へ", () => {
-  assertEquals(pickBestVariant([{ variant: "unknown" }]), "daily_briefing");
+Deno.test("pickConfidentVariant: n>=2 の畳み込み最上位のみ返す", () => {
+  // 畳み込み後 daily_briefing n=8 が唯一 n>=2 → それが勝ち型
+  assertEquals(pickConfidentVariant(observed)?.variant, "daily_briefing");
+  // 全て n=1 → confident 無し
+  assertEquals(
+    pickConfidentVariant([
+      { variant: "a", averageScore: 90, count: 1 },
+      { variant: "b", averageScore: 10, count: 1 },
+    ]),
+    null,
+  );
+});
+
+Deno.test("pickBestVariant: 観測データで fallback ではなく base を返す", () => {
+  // 旧実装は daily_briefing_fallback を返していた。畳み込みで daily_briefing。
+  assertEquals(pickBestVariant(observed), "daily_briefing");
+});
+
+Deno.test("pickBestVariant: 全 n=1 は最上位平均へ / 空は fallback", () => {
+  assertEquals(
+    pickBestVariant([
+      { variant: "a", averageScore: 90, count: 1 },
+      { variant: "b", averageScore: 10, count: 1 },
+    ]),
+    "a",
+  );
   assertEquals(pickBestVariant([]), "daily_briefing");
+  assertEquals(
+    pickBestVariant([{ variant: "unknown", count: 9 }]),
+    "daily_briefing",
+  );
   assertEquals(pickBestVariant([], "question_post"), "question_post");
 });
 
 Deno.test("hasNamedVariant: unknown のみ→false / named 混在→true", () => {
-  assertEquals(hasNamedVariant([{ variant: "unknown" }]), false);
+  assertEquals(hasNamedVariant([{ variant: "unknown", count: 5 }]), false);
   assertEquals(hasNamedVariant([]), false);
-  assertEquals(
-    hasNamedVariant([{ variant: "unknown" }, { variant: "daily_briefing" }]),
-    true,
-  );
+  assertEquals(hasNamedVariant(null), false);
+  assertEquals(hasNamedVariant(observed), true);
 });

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -426,38 +426,81 @@ void main() {
     });
   });
 
-  group('R27 resolveDisplayBestVariant (server unknown 除外漏れへの防御)', () {
-    test('named な bestVariant はそのまま返す', () {
-      expect(
-        resolveDisplayBestVariant('daily_briefing', const []),
+  group('R28 foldVariantsForDisplay + 勝ち型/ランキングの畳み込み', () {
+    // 本番観測: fallback(平均89 n=1) が本命(平均76 n=7)を抑えて勝ち型昇格。
+    final observed = [
+      {'variant': 'unknown', 'averageScore': 122, 'count': 16},
+      {'variant': 'daily_briefing_fallback', 'averageScore': 89, 'count': 1},
+      {'variant': 'daily_briefing', 'averageScore': 76, 'count': 7},
+      {'variant': 'daily_briefing_v2_numbers', 'averageScore': 27, 'count': 1},
+    ];
+
+    test('foldVariants: _fallback を base へ畳み unknown を除外', () {
+      final folded = foldVariantsForDisplay(observed);
+      expect(folded.map((e) => e.variant), [
         'daily_briefing',
-      );
+        'daily_briefing_v2_numbers',
+      ]);
+      // (89*1 + 76*7)/8 = 77.6 → 78, n=8
+      expect(folded.first.averageScore, 78);
+      expect(folded.first.count, 8);
     });
 
-    test('unknown のとき variants の unknown 以外の先頭へフォールバック', () {
-      final variants = [
-        {'variant': 'unknown', 'averageScore': 122, 'count': 16},
-        {'variant': 'daily_briefing_fallback', 'averageScore': 89, 'count': 1},
-        {'variant': 'daily_briefing', 'averageScore': 76, 'count': 7},
+    test('勝ち型は畳み込み後 n>=2 の最上位 (fallback 単独 n=1 は昇格させない)', () {
+      // 旧バグは daily_briefing_fallback を返していた。
+      expect(resolveDisplayBestVariant('unknown', observed), 'daily_briefing');
+    });
+
+    test('全 variant が n=1 → 勝ち型 null (断定しない)', () {
+      final allSingle = [
+        {'variant': 'daily_briefing', 'averageScore': 90, 'count': 1},
+        {'variant': 'question_post', 'averageScore': 10, 'count': 1},
       ];
-      expect(
-        resolveDisplayBestVariant('unknown', variants),
-        'daily_briefing_fallback',
-      );
+      expect(resolveDisplayBestVariant('daily_briefing', allSingle), isNull);
     });
 
-    test('unknown かつ named variant 無し → null (勝ち型行を出さない)', () {
-      expect(resolveDisplayBestVariant('unknown', null), isNull);
+    test('サーバ bestVariant が名前でも実測が薄ければ信用しない', () {
+      // bestVariant='daily_briefing' でも variants 空 → 実測無し → null。
+      expect(resolveDisplayBestVariant('daily_briefing', const []), isNull);
+      expect(resolveDisplayBestVariant('daily_briefing', null), isNull);
+    });
+
+    test('不正要素は無視', () {
       expect(
         resolveDisplayBestVariant('unknown', [
-          {'variant': 'unknown'},
+          {'variant': 'unknown', 'count': 9},
           {'variant': ''},
           'not-a-map',
         ]),
         isNull,
       );
-      expect(resolveDisplayBestVariant('', const []), isNull);
-      expect(resolveDisplayBestVariant(null, null), isNull);
+    });
+  });
+
+  group('R28 archetypeLiftSummaryLine: 実測0件バケットは計測中のみ表示', () {
+    test('count=0 & pending>0 → 「実測不足 (0件…)」でなく「計測中N件」', () {
+      final line = archetypeLiftSummaryLine(
+        resolveArchetypeLift([
+          {'archetype': 'product_promo', 'i72h': 119},
+          {'archetype': 'product_promo', 'i72h': 118},
+          {'archetype': 'data_report', 'i72h': null},
+        ]),
+      );
+      expect(line, contains('データレポート型 計測中1件'));
+      expect(line, isNot(contains('データレポート型 実測不足')));
+      expect(line, isNot(contains('0件')));
+    });
+
+    test('count>=1 だが n<2 は従来どおり「実測不足 (N件…)」', () {
+      final line = archetypeLiftSummaryLine(
+        resolveArchetypeLift([
+          {'archetype': 'news_briefing', 'i72h': 100},
+          {'archetype': 'news_briefing', 'i72h': 90},
+          {'archetype': 'product_promo', 'i72h': 10},
+          {'archetype': 'product_promo', 'i72h': null},
+        ]),
+      );
+      expect(line, contains('製品紹介型 実測不足 (1件・計測中1件)'));
     });
   });
 }


### PR DESCRIPTION
## 概要

part339。build 4839 (part338 の #4097 反映済) の /admin 新 Network screenshot を起点に **10 仮説** を全件検証。**4 件を修正 / 2 件を issue / 4 件を benign 確定**。

最大の発見は **part338 の unknown 除外の副作用**: 勝ち型が「daily_briefing_fallback (平均89 **n=1**)」で「daily_briefing (平均76 **n=7**)」を抑えて昇格していた。

## 10 仮説 検証結果

| # | 仮説 | 判定 | 対応 |
|---|------|------|------|
| H1 | 勝ち型が `_fallback` を base に畳まず1サンプルfallbackが本命を抑える | ✅確定 | fold で修正 |
| H2 | 勝ち型に最小サンプルガード無し・n=1外れ値を断定 | ✅確定 | n>=2 ゲート |
| H3 | ランキング表示が勝ち型と非整合(fallbackを別行) | ✅確定 | ランキングも fold |
| H4 | 型別実測に「実測不足 (0件・計測中1件)」の0件二重表示 | ✅確定 | 「計測中N件」に |
| H5 | n=1 の「平均27 (n=1)」表示 | ⚪benign | (n=1) 明示で誠実 |
| H6 | part338 LandingPage 可視化ゲートが通常訪問の LP View を壊す回帰 | ⚪benign | 通常'/'は即計測(回帰なし・既存gate testでカバー) |
| H7 | wbs_tasks 96.9kB を毎回転送 | 🟡issue | #4092 に実装計画追記 |
| H8 | index.html のランタイム Google Fonts <link> がcss2約20本取得 | 🟡issue | #4104 (バンドルskipとは別) |
| H9 | main.dart -F6.. fetch | ⚪benign | CanvasKit CJK fallback=バンドルskipの裏返し |
| H10 | admin-hub/schedule_task_runs 重複 | ⚪benign | CORS preflight+実体 (#4080) |

## 修正詳細 (H1-H4)

### H1/H2 — 勝ち型の畳み込み + 最小サンプル
part338 で unknown を除外したが、`daily_briefing_fallback` (定型フォールバック版=戦略は daily_briefing と同一) を別バケットのままにしていたため、1 サンプルの fallback (平均89) が 7 サンプルの本命 (平均76) を抑えて「勝ち型」に昇格。加えて n=1 の外れ値を勝ち型に断定していた。
→ server `x_best_variant.ts` に `foldVariants` (unknown 除外 + `_fallback` を base へ集約) と `pickConfidentVariant` (畳み込み後 n>=2 の最上位のみ) を新設。client も `foldVariantsForDisplay` + `resolveDisplayBestVariant` を畳み込み+n>=2 に刷新。畳むと daily_briefing = (89 + 76×7)/8 = 平均78 n=8 が勝ち型。`distinctMeasuredVariants` の既存の `_fallback` 畳み込みと戦略同一視を統一。

### H3 — ランキング表示の整合
`_xGrowthVariantRankingLines` も同じ畳み込みで「daily_briefing 平均78 (n=8) / daily_briefing_v2_numbers 平均27 (n=1)」に統一 (勝ち型と直下ランキング先頭の矛盾を解消)。

### H4 — 実測0件バケットの表示
`archetypeLiftSummaryLine`: count=0 (全て計測中) のバケットは「実測不足 (0件・計測中1件)」の 0件二重表示をやめ「計測中N件」のみ簡潔表示。

### promptContext
LLM へ渡す「Current best variant」も `confidentBest` (n>=2) の有無で出し分け、1 サンプル外れ値を実測の勝ち型として渡さない。

## テスト
- `x_best_variant_test.ts` — deno 6 件 (fold / confident / 観測データで fallback→base) ✅
- `admin_dashboard_signals_test.dart` — fold・勝ち型 n>=2・count=0 表示を追加 (計43件) ✅
- `flutter analyze` 3 ファイル 0 issue / `dart format --set-exit-if-changed` 差分なし / `deno lint` clean

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: X growth-loop winner-selection honesty fixes: fold _fallback into base variant + minimum-sample gate, covered by pure-function deno + Dart unit tests; no auth, RLS, payment, secret, schema, or data-write path changes

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno edge change is pure variant-folding/winner-selection helpers covered by x_best_variant_test.ts (6 cases); Flutter changes covered by VM unit tests in admin_dashboard_signals_test.dart (43 cases). No new user-visible black-box flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
