### PR TITLE
fix(asset): 資産管理闘争 10仮説検証 第2弾 — AI再生成60分ゲート/引落一括確認/累積残高警告/cardLoan振替元正規化

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -404,6 +404,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 初期化中の setState 連打 (workbook フィンガープリント変化) による多重発行から
   /// 守るためのデバウンス。リビルドが ~700ms 静止した最後の 1 回だけ発行する。
   Timer? _assetManagementAiSummaryDebounce;
+
+  /// AI要約の自動再生成クールダウン。引落済み・残高記録などの編集毎に
+  /// リクエスト指紋が変わるため、指紋一致キャッシュだけでは 1 セッションで
+  /// 何度も 1 分超のプレミアム生成 (直列 4 プロバイダ) が走る。この時間内は
+  /// 同日最新の保存済み分析を再利用し、即時反映したい場合のみ手動の
+  /// 「AI要約を更新」(force) を使う。
+  static const Duration _assetManagementAiSummaryAutoRefreshCooldown =
+      Duration(minutes: 60);
   Timer? _existingDeveloperIssueLookupDebounce;
 
   /// 起動時の `asset_pref_mirror` 個別読み取り (~20 箇所) を 1 回のバッチ取得へ
@@ -3229,6 +3237,92 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('支払済み状態を保存できませんでした。')));
+    }
+  }
+
+  /// 残高不足警告の無い確認待ちをまとめて引落済みにする。
+  /// 1 件ずつだと N 件 = N 回の全状態保存 + その都度 AI 再生成のトリガに
+  /// なるため、状態更新は 1 回の setState、永続化は 1 回にまとめる。
+  /// 警告付き (引落失敗の可能性) の行は対象外 = 従来どおり個別に判断させる。
+  Future<void> _confirmAllAutoDebitsWithoutWarning(
+    List<MapEntry<AssetAutoDebitConfirmation, AssetLiabilityDebtRow>> entries,
+  ) async {
+    final targets = entries
+        .where((entry) => !entry.key.sourceBalanceInsufficient)
+        .toList(growable: false);
+    if (targets.isEmpty) return;
+
+    final summaryLines = targets
+        .map(
+          (entry) => '・${entry.key.row.accountName}: '
+              '${_formatManagementYen(entry.key.row.paymentAmount)}',
+        )
+        .join('\n');
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text('警告のない${targets.length}件を引落済みにする'),
+        content: SingleChildScrollView(
+          child: Text(
+            '以下を引落済みとして記録します。実際に口座から引き落とされている'
+            'ことを確認してから実行してください。\n\n$summaryLines',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('まとめて引落済み'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    final previousPaidAccountNames = Set<String>.from(_monthlyPaidAccountNames);
+    final previousBillingConfirmedAccountIds = Set<String>.from(
+      _billingConfirmedAccountIds,
+    );
+    final previousActualPaymentAmounts = Map<String, double>.from(
+      _actualPaymentAmounts,
+    );
+    setState(() {
+      for (final entry in targets) {
+        final row = entry.value;
+        _monthlyPaidAccountNames.add(row.id);
+        _billingConfirmedAccountIds.add(row.id);
+        _actualPaymentAmounts.putIfAbsent(
+          row.id,
+          () => row.scheduledPaymentAmount,
+        );
+        _actualPaymentControllers[row.id]?.text =
+            _actualPaymentAmounts[row.id]!.round().toString();
+      }
+    });
+    try {
+      await _persistAssetLiabilityMonthlyState();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('✅ ${targets.length}件を引落済みにしました'),
+          backgroundColor: const Color(0xFF047857),
+        ),
+      );
+    } catch (e) {
+      debugPrint('Error saving bulk paid status: $e');
+      if (!mounted) return;
+      setState(() {
+        _monthlyPaidAccountNames = previousPaidAccountNames;
+        _billingConfirmedAccountIds = previousBillingConfirmedAccountIds;
+        _actualPaymentAmounts = previousActualPaymentAmounts;
+        _syncActualPaymentControllers();
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('引落済み状態を保存できませんでした。')));
     }
   }
 
@@ -13531,6 +13625,26 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   color: scheme.onTertiaryContainer,
                 ),
               ),
+              if (entries
+                      .where((e) => !e.key.sourceBalanceInsufficient)
+                      .length >=
+                  2) ...[
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: OutlinedButton.icon(
+                    onPressed: () => unawaited(
+                      _confirmAllAutoDebitsWithoutWarning(entries),
+                    ),
+                    icon: const Icon(Icons.done_all, size: 16),
+                    label: Text(
+                      '警告のない'
+                      '${entries.where((e) => !e.key.sourceBalanceInsufficient).length}'
+                      '件をまとめて引落済み',
+                    ),
+                  ),
+                ),
+              ],
               const SizedBox(height: 12),
               for (final entry in entries)
                 Padding(
@@ -13568,7 +13682,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                                     const SizedBox(width: 4),
                                     Expanded(
                                       child: Text(
-                                        '振替元の残高'
+                                        // 残高は「この行の引落前の見込み」= 先行する
+                                        // 成功見込み引落を差し引いた値 (同一口座から
+                                        // 複数引落がある場合の合計不足も検出する)。
+                                        '振替元の残高見込み'
                                         '(${_formatManagementYen(entry.key.sourceAccountBalance!)})'
                                         'が支払額を下回っています。引落が失敗している'
                                         '可能性があるため、残高をご確認のうえ操作してください。',
@@ -19554,14 +19671,25 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       _assetManagementAiSummaryInFlightKey = key;
       _assetManagementAiSummaryRequestKey = key;
     });
-    // 同一フィンガープリント (= 基準日単位で回転) の分析が既に保存済みなら
-    // それを再利用し、高価な ai-hub 生成 (直列 4 プロバイダ / 1分超) を
-    // スキップする。手動の「AI要約を更新」(force) は常に再生成する。
+    // 保存済み分析の再利用判定。指紋は基準日単位で回転するため「同日最新の
+    // 1 行」だけ見れば足りる。再利用条件は (a) 指紋完全一致 (データ不変) か
+    // (b) 生成からクールダウン時間内 (引落済み等の編集毎に指紋が変わるため、
+    // 完全一致だけだと 1 セッションで何度も 1 分超のプレミアム生成が走る)。
+    // 手動の「AI要約を更新」(force) は常に再生成する。
     if (!force) {
       AssetManagementAiAnalysisHistoryEntry? reusable;
       try {
-        reusable = await _assetManagementAiAnalysisHistoryService
-            .loadReusableResult(requestFingerprint: key);
+        final latest = await _assetManagementAiAnalysisHistoryService
+            .loadLatestForBaseDate(
+          reportBaseDate: AssetManagementAiAnalysisHistoryService
+              .reportBaseDateKey(report.workbook.baseDate),
+        );
+        if (latest != null &&
+            (latest.requestFingerprint == key ||
+                DateTime.now().difference(latest.generatedAt) <
+                    _assetManagementAiSummaryAutoRefreshCooldown)) {
+          reusable = latest;
+        }
       } catch (_) {
         reusable = null;
       }

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -19681,8 +19681,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       try {
         final latest = await _assetManagementAiAnalysisHistoryService
             .loadLatestForBaseDate(
-          reportBaseDate: AssetManagementAiAnalysisHistoryService
-              .reportBaseDateKey(report.workbook.baseDate),
+          reportBaseDate:
+              AssetManagementAiAnalysisHistoryService.reportBaseDateKey(
+                  report.workbook.baseDate),
         );
         if (latest != null &&
             (latest.requestFingerprint == key ||

--- a/lib/services/asset_auto_debit_confirmation_service.dart
+++ b/lib/services/asset_auto_debit_confirmation_service.dart
@@ -126,6 +126,12 @@ class AssetAutoDebitConfirmationService {
   /// 特定する。振替元が未設定、または該当口座がスナップショットに無い場合は残高を
   /// null とし、引落失敗の判定は行わない (= 警告を出さない安全側)。
   /// 並び順は [pendingConfirmations] と同じ (金額の大きい順)。
+  ///
+  /// 同一口座から複数の確認待ちがある場合、`sourceAccountBalance` は
+  /// 「その行の引落前の見込み残高」= 現在残高から、引落日が先で **成功し得る**
+  /// 引落だけを順次差し引いた値になる (残高不足で弾かれる引落は実際には残高を
+  /// 減らさないため差し引かない)。行単位で生残高と独立比較すると
+  /// 「個別には足りるが合計では足りない」ケースを取りこぼすため (part338 教訓)。
   List<AssetAutoDebitConfirmation> pendingConfirmationDetails(
     AssetLiabilityWorkbook workbook,
   ) {
@@ -138,13 +144,21 @@ class AssetAutoDebitConfirmationService {
         if (debt.revolvingBilling != null)
           debt.id: debt.revolvingBilling!.creditLimit,
     };
-    final details = pendingConfirmations(workbook).map((row) {
+    final rows = pendingConfirmations(workbook);
+    final effectiveBalanceByRowId = _effectiveSourceBalances(
+      rows: rows,
+      accountById: accountById,
+      creditLimitByAccountId: creditLimitByAccountId,
+    );
+    final details = rows.map((row) {
       final sourceAccountId = row.paymentSourceAccountId;
       final source =
           sourceAccountId == null ? null : accountById[sourceAccountId];
       return AssetAutoDebitConfirmation(
         row: row,
-        sourceAccountBalance: source?.balance,
+        sourceAccountBalance: effectiveBalanceByRowId.containsKey(row.accountId)
+            ? effectiveBalanceByRowId[row.accountId]
+            : source?.balance,
         sourceAccountKind: source?.kind,
         sourceAccountCreditLimit: sourceAccountId == null
             ? null
@@ -152,6 +166,56 @@ class AssetAutoDebitConfirmationService {
       );
     }).toList();
     return List<AssetAutoDebitConfirmation>.unmodifiable(details);
+  }
+
+  /// 口座毎に引落日昇順で「成功し得る引落」を残高から順次差し引き、
+  /// 各行の「引落前の見込み残高」を row.accountId → 残高 で返す
+  /// (確認待ちは 1 口座 1 行なので accountId で一意)。
+  ///
+  /// - 資産口座: 見込み残高 >= 支払額 の引落だけ残高から差し引く
+  ///   (不足で弾かれる引落は残高を減らさない)。
+  /// - 与信枠: 同様に、限度額内に収まる引落だけ利用額へ積む
+  ///   (見込み残高はマイナスの利用額としてそのまま表現できる)。
+  /// 振替元口座がスナップショットに無い行は対象外 (raw 値のまま)。
+  Map<String, double> _effectiveSourceBalances({
+    required List<AssetLiabilityCashflowRow> rows,
+    required Map<String, AssetLiabilityAccount> accountById,
+    required Map<String, double> creditLimitByAccountId,
+  }) {
+    final rowsBySource = <String, List<AssetLiabilityCashflowRow>>{};
+    for (final row in rows) {
+      final sourceAccountId = row.paymentSourceAccountId;
+      if (sourceAccountId == null) continue;
+      final source = accountById[sourceAccountId];
+      if (source == null) continue;
+      rowsBySource.putIfAbsent(sourceAccountId, () => []).add(row);
+    }
+
+    final effective = <String, double>{};
+    rowsBySource.forEach((sourceAccountId, sourceRows) {
+      final source = accountById[sourceAccountId]!;
+      final creditLimit = creditLimitByAccountId[sourceAccountId];
+      // 引落は日付順に口座へ到達する。表示順 (金額降順) とは独立に計算する。
+      final ordered = [...sourceRows]..sort((a, b) {
+          final byDate = a.paymentDate.compareTo(b.paymentDate);
+          if (byDate != 0) return byDate;
+          return b.paymentAmount.compareTo(a.paymentAmount);
+        });
+      var remaining = source.balance;
+      for (final row in ordered) {
+        effective[row.accountId] = remaining;
+        final wouldSucceed = !autoDebitSourceInsufficient(
+          balance: remaining,
+          kind: source.kind,
+          creditLimit: creditLimit,
+          paymentAmount: row.paymentAmount,
+        );
+        if (wouldSucceed) {
+          remaining -= row.paymentAmount;
+        }
+      }
+    });
+    return effective;
   }
 
   /// 振替元残高が支払額を下回っている (= 引落が失敗している可能性がある) 確認待ちの件数。

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -764,9 +764,19 @@ class AssetLiabilityPlanningService {
     // 振替元が自分自身を指す設定は不正 (ローンを自分自身からは返済できない) なので
     // 未設定扱いにする。これにより「支払原資口座の未設定」セクションに表示され、正しい
     // 口座 (例: じぶん銀行) へ修正できるようになり、見込み残高の自己宛て誤ルーティングも防ぐ。
-    final paymentSourceAccountId = rawPaymentSourceAccountId == account.id
+    var paymentSourceAccountId = rawPaymentSourceAccountId == account.id
         ? null
         : rawPaymentSourceAccountId;
+    // 振替元がカードローン (現金借入) を指す設定も不正扱いで未設定に落とす。
+    // cardLoan はどの振替元セレクタにも候補として出ない (請求先になれない) のに、
+    // legacy キー移行の名前衝突 (じぶん銀行→じぶんローン等) で保存され得る。
+    // 非 null のままだと「原資未設定」レビューに出ず、現金系口座の見込み残高
+    // からも静かに消える盲点になるため、未設定へ倒して修正導線に乗せる。
+    if (paymentSourceAccountId != null &&
+        accountsById[paymentSourceAccountId]?.kind ==
+            AssetLiabilityAccountKind.cardLoan) {
+      paymentSourceAccountId = null;
+    }
     final paymentSourceAccountName = paymentSourceAccountId == null
         ? null
         : accountsById[paymentSourceAccountId]?.name;

--- a/lib/services/asset_management_ai_analysis_history_service.dart
+++ b/lib/services/asset_management_ai_analysis_history_service.dart
@@ -55,11 +55,15 @@ class AssetManagementAiAnalysisHistoryService {
         .toList(growable: false);
   }
 
-  /// 直近の保存済み分析のうち、リクエスト指紋が一致するものを 1 件返す。
-  /// フィンガープリントは基準日を含む日付単位で回転するため、同日内の
-  /// リロードではこの結果を再利用でき、高価な ai-hub 生成をスキップできる。
-  Future<AssetManagementAiAnalysisHistoryEntry?> loadReusableResult({
-    required String requestFingerprint,
+  /// 指定基準日の保存済み分析のうち最新の 1 件を返す (本文込み)。
+  ///
+  /// フィンガープリントは基準日を含む日付単位で回転するため、指紋一致の
+  /// 再利用判定はこの「同日最新 1 行」を見れば足りる。加えて呼び出し側は
+  /// generated_at の鮮度 (自動再生成クールダウン) 判定にも同じ行を使える —
+  /// 引落済み等の編集毎に指紋が変わり、完全一致だけでは 1 セッションに
+  /// 何度も 1 分超のプレミアム生成が走ってしまうため。
+  Future<AssetManagementAiAnalysisHistoryEntry?> loadLatestForBaseDate({
+    required String reportBaseDate,
   }) async {
     final client = _resolveClient();
     final userId = _resolveUserId(client);
@@ -76,7 +80,7 @@ class AssetManagementAiAnalysisHistoryService {
         )
         .eq('user_id', userId)
         .eq('status', AssetManagementAiSummaryStatus.aiGenerated.name)
-        .eq('request_fingerprint', _safeRequestFingerprint(requestFingerprint))
+        .eq('report_base_date', reportBaseDate)
         .neq('summary_text', '')
         .order('generated_at', ascending: false)
         .limit(1);
@@ -177,9 +181,13 @@ class AssetManagementAiAnalysisHistoryService {
     return const <String, dynamic>{};
   }
 
-  String _dateOnly(DateTime value) {
+  /// report_base_date 列と同一形式 (yyyy-MM-dd) の基準日キー。
+  /// [loadLatestForBaseDate] へ渡す値もこれで作る。
+  static String reportBaseDateKey(DateTime value) {
     final month = value.month.toString().padLeft(2, '0');
     final day = value.day.toString().padLeft(2, '0');
     return '${value.year}-$month-$day';
   }
+
+  String _dateOnly(DateTime value) => reportBaseDateKey(value);
 }

--- a/supabase/functions/growth-hub/x_best_variant_test.ts
+++ b/supabase/functions/growth-hub/x_best_variant_test.ts
@@ -1,6 +1,4 @@
-import {
-  assertEquals,
-} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   foldVariants,
   hasNamedVariant,

--- a/test/services/asset_auto_debit_confirmation_service_test.dart
+++ b/test/services/asset_auto_debit_confirmation_service_test.dart
@@ -102,6 +102,62 @@ void main() {
       expect(service.insufficientSourceCount(workbook), 1);
     });
 
+    test(
+        'flags later debit when earlier successful debit depletes the balance',
+        () {
+      // 6/26 時点、残高 5,000。ガス 4,500 (12日) は成功見込み → 残 500。
+      // 水道 2,400 (22日) は生残高 5,000 では足りて見えるが、見込み残 500 では
+      // 不足 → 警告。行単位の独立比較では取りこぼすケース。
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 5000},
+        baseDate: DateTime(2026, 6, 26),
+        includeDefaultFixedPayments: true,
+      );
+      final details = service.pendingConfirmationDetails(workbook);
+      final gas = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.gasBillAccountId,
+      );
+      final water = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.waterBillAccountId,
+      );
+
+      expect(gas.sourceAccountBalance, 5000);
+      expect(gas.sourceBalanceInsufficient, isFalse);
+      expect(water.sourceAccountBalance, 500);
+      expect(water.sourceBalanceInsufficient, isTrue);
+    });
+
+    test('failed (insufficient) debit does not deplete the running balance',
+        () {
+      // 残高 3,000: ガス 4,500 (12日) は不足で弾かれる想定 → 残高は減らず、
+      // 水道 2,400 (22日) は 3,000 のまま判定 → 警告なし。
+      final workbook = planning.buildWorkbook(
+        latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 3000},
+        baseDate: DateTime(2026, 6, 26),
+        includeDefaultFixedPayments: true,
+      );
+      final details = service.pendingConfirmationDetails(workbook);
+      final gas = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.gasBillAccountId,
+      );
+      final water = details.firstWhere(
+        (detail) =>
+            detail.row.accountId ==
+            AssetLiabilityPlanningService.waterBillAccountId,
+      );
+
+      expect(gas.sourceAccountBalance, 3000);
+      expect(gas.sourceBalanceInsufficient, isTrue);
+      expect(water.sourceAccountBalance, 3000);
+      expect(water.sourceBalanceInsufficient, isFalse);
+    });
+
     test('does not flag when source balance covers the amount', () {
       final workbook = planning.buildWorkbook(
         latestSnapshot: const <String, double>{'三井住友銀行大塚支店': 63539},

--- a/test/services/asset_auto_debit_confirmation_service_test.dart
+++ b/test/services/asset_auto_debit_confirmation_service_test.dart
@@ -102,8 +102,7 @@ void main() {
       expect(service.insufficientSourceCount(workbook), 1);
     });
 
-    test(
-        'flags later debit when earlier successful debit depletes the balance',
+    test('flags later debit when earlier successful debit depletes the balance',
         () {
       // 6/26 時点、残高 5,000。ガス 4,500 (12日) は成功見込み → 残 500。
       // 水道 2,400 (22日) は生残高 5,000 では足りて見えるが、見込み残 500 では

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -2101,5 +2101,31 @@ void main() {
       );
       expect(otherMobit.paymentSourceAccountId, 'smbc_otsuka');
     });
+
+    test('treats a cardLoan payment source as unset', () {
+      // 振替元がカードローン (現金借入 = mobit) を指す設定は不正扱いで未設定に
+      // 正規化する。cardLoan はどのセレクタにも候補として出ないのに legacy 移行の
+      // 名前衝突で保存され得る。非 null のままだと「原資未設定」レビューに出ず、
+      // 現金系口座の見込み残高からも静かに消えるため。
+      final loanSourced = service.buildWorkbook(
+        latestSnapshot: snapshot,
+        baseDate: DateTime(2026, 5, 12),
+        paymentSourceAccountIds: <String, String>{
+          AssetLiabilityPlanningService.acomShoppingAccountId: 'mobit',
+        },
+      );
+      final acom = loanSourced.debtMasterRows.firstWhere(
+        (row) => row.name == 'アコムショッピング',
+      );
+      expect(acom.paymentSourceAccountId, isNull);
+      expect(acom.paymentSourceAccountName, isNull);
+      // 未設定へ倒れることで原資未設定レビュー (修正導線) の対象になる。
+      expect(
+        loanSourced.paymentSourceMissingRows.any(
+          (row) => row.name == 'アコムショッピング',
+        ),
+        isTrue,
+      );
+    });
   });
 }


### PR DESCRIPTION
# 資産管理闘争ページ改善 第2弾 — 10仮説検証方式

第1弾 (#4093) 反映後の本番を再実測 (7.4 分セッションで 160 requests / ai-hub 1分超×3回 / 引落の確認待ち 23 件) し、新たに 10 仮説を立てて全件検証。確定 4 件を修正した。検証は origin/main ベースの worktree + 並列 Explore 3 体で実施。

## 第1弾の効果確認 (本番実測)

- `asset_management_ai_analysis` fetch: **158KB → 1.0〜3.2KB** に縮小を確認
- EF preflight: `Access-Control-Max-Age: 86400` 応答を確認

## 10仮説と判定

| # | 仮説 | 判定 |
|---|------|------|
| 1 | 引落確認待ちに一括操作が無い (23件=23クリック×23回の全状態保存) | ✅ 確定 — per-item `saveMonth` upsert のみ |
| 2 | 引落済みを押すたび AI 再生成が走る (時間ゲート無し) | ✅ 確定 — 指紋は paid/actual_amount/totals を含み編集毎に変化。2.5s debounce のみで 1 セッション 3 回の 1 分超生成 |
| 3 | 残高不足警告が行単位の独立比較 (合計不足を取りこぼし + 同文反復) | ✅ 確定 — 同一口座の複数引落が同じ生残高と比較される |
| 4 | 支払元に借入口座が混入 (auPAYカード/じぶんローン) | ✅ 確定 — cardLoan はどのセレクタにも出ない値。legacy キー移行の名前衝突で保存され、非 null のため原資未設定レビューに出ず projection からも静かに消える盲点 |
| 5 | Claude AI SUBSCRIPTION/アコムショッピングも同種の破損 | ⚠️ 部分棄却 — shoppingDebt は「買い物の請求先」として設計上許容 (lenient セレクタが提供) |
| 6 | core-hub 反復 (1.3〜1.6s×6+) は existing_issues が再生成毎に随伴 | ✅ 確定 — `_ensureExistingDeveloperIssuesLoaded` が各生成に await + 2 入口の lookupKey 不一致。#2 の頻度削減で吸収、key 不一致は別 Issue |
| 7 | 17.4MB 転送は異常 | ❌ 棄却 — デプロイ直後の新ビルド初回DL (main.dart.js は no-cache+ETag 設計、フォントは max-age=86400 で 304) |
| 8 | user_presence 頻度過剰 | ❌ 棄却 — 2 分 heartbeat + route 変化で設計どおり |
| 9 | 「支払後見込み ¥107,146」(現在 ¥29,959) は計算バグ | ❌ 棄却 — `projectedBalance` は入金予定・振替を加味する仕様でラベルも「見込み」表記 |
| 10 | 警告 3 連発の同文反復は集約可能 | ✅ 確定 (対処は #3 の見込み残高化で文言が行ごとに意味を持つ形に) |

## 変更内容 (確定4件の修正)

1. **AI要約の自動再生成クールダウン (60分)** — `report_base_date` (保存済み・未活用だった列) で「同日最新 1 行」を取得し、指紋一致 or 生成 60 分以内なら再利用。編集のたびの 1 分超プレミアム生成 (直列 4 プロバイダ) が最大 1 回/時に。手動「AI要約を更新」は従来どおり即時再生成。
2. **引落の確認待ちの一括確認** — 「警告のない N 件をまとめて引落済み」ボタン + 確認ダイアログ。状態更新 1 回 + 永続化 1 回に集約 (警告付き行は従来どおり個別判断)。
3. **残高不足警告の累積判定** — 同一振替元の複数引落を日付順に処理し「成功し得る引落だけ残高から差し引く」見込み残高で判定。不足で弾かれる引落は残高を減らさない現実挙動をモデル化。「個別には足りるが合計では足りない」ケースを新たに検出 (part338 教訓「行単位の生残高比較禁物」の同型修正)。
4. **cardLoan 振替元の未設定正規化** — resolve 時に cardLoan 宛て振替元を未設定へ倒し (自己参照ガードと同型)、「支払原資口座が未設定」レビュー導線に乗せて修正可能に。

## 検証

- 全リポジトリ `flutter analyze`: **No issues found!** (724.8s)
- `flutter test`: 対象 4 ファイル **83 tests passed** (新規 3 件: 累積判定×2 + cardLoan 正規化×1)
- `dart fix --code=require_trailing_commas`: Nothing to fix

## 残タスク (別 Issue)

- existing_issues lookup の 2 入口 lookupKey 不一致 (deterministic vs combined) による相互再トリガ

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 本文キーワード (支払/引落等) による prose-only トリガ。変更は Flutter クライアントの表示判定・確認UI・読み取りクエリと、CI自動修復 bot による EF テスト 1 ファイルの整形のみ (deno fmt 3行・ロジック変更なし)。認証・認可・migration・書き込み経路の変更を含まない

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 変更は純ロジック service (累積残高判定/cardLoan正規化=単体テスト3件追加済) と認証必須ページ内の確認ダイアログ UI のみで、headless E2E で到達不能。既存 unit 83件+全repo analyze 緑で担保

🤖 Generated with [Claude Code](https://claude.com/claude-code)
