### PR TITLE
perf(admin): メンテナンス banner の resumed force ポーリングを抑制 (10仮説検証 part340)

### DIFF
--- a/lib/widgets/maintenance_banner.dart
+++ b/lib/widgets/maintenance_banner.dart
@@ -50,10 +50,15 @@ class _MaintenanceShellState extends State<MaintenanceShell>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     // 非表示タブ/バックグラウンドでの schedule-hub 定期ポーリングを止める。
-    // 復帰時は即時 refresh してからタイマーを再開する。
+    // 復帰時はタイマーを再開し、refresh は **force:false** にする。Flutter Web は
+    // フォーカス往復(DevTools/タブ切替)のたびに resumed を送るため、force:true だと
+    // その都度 schedule-hub maintenance.list_active を叩いていた(キャッシュ TTL
+    // 無視)。非force なら 5分キャッシュが新しい間は再取得せず、TTL 超過(=実際に
+    // 長時間離席)のときだけ再取得する。version_check_service の _minCheckGap と同じ
+    // 「resumed 連発抑制」規律 (part337 H3 / version.json と同型)。
     if (state == AppLifecycleState.resumed) {
       _startTimer();
-      _refresh(force: true);
+      _refresh();
     } else if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden ||
         state == AppLifecycleState.detached) {

--- a/test/widgets/maintenance_shell_resume_gate_test.dart
+++ b/test/widgets/maintenance_shell_resume_gate_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/maintenance_service.dart';
+import 'package:my_web_app/services/universal_x_share_service.dart';
+import 'package:my_web_app/widgets/maintenance_banner.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _FakeSupabaseClient extends Fake implements SupabaseClient {}
+
+/// fetchActive の force 引数だけ記録するフェイク (ネットワークは張らない)。
+class _CountingMaintenanceService extends MaintenanceService {
+  _CountingMaintenanceService() : super(client: _FakeSupabaseClient());
+
+  int forceTrueCalls = 0;
+  int forceFalseCalls = 0;
+
+  @override
+  Future<MaintenanceSnapshot> fetchActive({bool force = false}) async {
+    if (force) {
+      forceTrueCalls += 1;
+    } else {
+      forceFalseCalls += 1;
+    }
+    return MaintenanceSnapshot(
+      windows: const [],
+      fetchedAt: DateTime.now(),
+    );
+  }
+}
+
+void main() {
+  testWidgets(
+    'MaintenanceShell: 初回ロードは force、resumed は非force '
+    '(フォーカス往復での schedule-hub 連打を抑制)',
+    (WidgetTester tester) async {
+      final service = _CountingMaintenanceService();
+      final routeListenable = ValueNotifier<UniversalSharePageContext>(
+        UniversalSharePageContext.fromRouteName('/admin'),
+      );
+      addTearDown(routeListenable.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MaintenanceShell(
+            routeListenable: routeListenable,
+            service: service,
+            child: const SizedBox.shrink(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // 初回ロードは即時性が必要なので force:true が1回。
+      expect(service.forceTrueCalls, 1);
+      expect(service.forceFalseCalls, 0);
+
+      // resumed をフォーカス往復ぶん連発しても force:true は増えず、
+      // 非force(=TTL 尊重)で処理される。
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      expect(service.forceTrueCalls, 1, reason: 'resumed は force しない');
+      expect(service.forceFalseCalls, 2, reason: 'resumed 2回は非force で処理');
+    },
+  );
+}


### PR DESCRIPTION
## 概要

part340。build 4842 (part338 #4097 + part339 #4106 反映済) の /admin 新 Network screenshot を起点に **10 仮説** を全件検証。新 signal は **「Finish: 2.3 min」/ DOMContentLoaded 5.18s** の長時間ネットワーク活動。調査の結果、尾の主因は presence 系タイマー (by-design) だが、その中で**唯一の実バグ**を修正した。

## 10 仮説 検証結果

| # | 仮説 | 判定 | 対応 |
|---|------|------|------|
| H1 | MaintenanceShell が resumed 毎に force refresh→schedule-hub 連打 | ✅確定 | **本PRで修正** |
| H2 | 「2.3分」の主因は presence 系(2分heartbeat) | ⚪by-design | heartbeat は自分のオンライン記録で正当 |
| H3 | presence が /admin でも作動し user_presence に書く | ⚪benign | admin も online user・global 設計 |
| H4 | wbs_tasks 999行(371kB非圧縮)中 lane該当は約66行のみ(93%破棄) | 🟡issue | #4092 (安全な行絞りは大小文字取りこぼしで RPC 必要) |
| H5 | schedule-hub が /admin で複数回 | ⚪一部確定 | digest.run(load・read-only) + maintenance(H1起因)。H1で解消 |
| H6 | DOMContentLoaded 5.18s | 🟡issue | css2 font link の render-block (#4104) |
| H7 | /admin はバナー非表示なのに maintenance を fetch | ⚪benign | H1で resume 連打は解消・route-gating は cache 温めとの trade-off |
| H8 | version.json が resumed 再チェック | ⚪benign | _minCheckGap 5分で既済 (part337 H3) |
| H9 | client 発 presence 維持RPC が全クライアント5分毎 | 🟡issue | #4081 に詳細追記 (cleanup_old_presence+update_site_statistics) |
| H10 | font storm (css2 + -F6..) | ⚪tracked | Path A=#4104 / Path B=CanvasKit CJK fallback(再提案不可) |

## 修正詳細 (H1)

`MaintenanceShell.didChangeAppLifecycleState` が `resumed` のたびに `_refresh(force: true)` を呼び、5分キャッシュ TTL を無視して `schedule-hub` `maintenance.list_active` を叩いていた。Flutter Web はフォーカス往復 (DevTools/タブ切替) で `resumed` を頻発させるため、タブに戻る度に無駄な EF 呼び出しが発火 (Network タブ末尾の遅延 schedule-hub の正体)。しかも `/admin` では `_isAdminRoute` によりバナー自体が非表示で結果は使われない。

→ `resumed` は `_refresh()` (非force) に。5分キャッシュが新しい間は再取得せず、TTL 超過 (=実際に長時間離席) のときだけ再取得する。初回ロードと5分タイマーは即時性/意図された周期のため force を継続。`version_check_service` の `_minCheckGap` と同じ「resumed 連発抑制」規律 (part337 H3 / version.json と同型)。

## テスト
- `test/widgets/maintenance_shell_resume_gate_test.dart` — 初回ロード force:true×1、resumed 2連発でも force:true は増えず非force×2 (TTL尊重) ✅
- `flutter analyze` 2ファイル 0 issue / `dart format --set-exit-if-changed` 差分なし

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Single client-side lifecycle-gating change (resume force->non-force) covered by a widget test (maintenance_shell_resume_gate_test.dart) asserting init forces once and repeated resumes use non-force. No edge/API/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
