### PR TITLE
perf(election): 県連カード news badge を県別個別クエリから一括取得に改修

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -15,6 +15,7 @@ import '../services/local_election_cdp_benchmark.dart';
 import '../services/local_election_plan_service.dart';
 import '../utils/web_image_downloader.dart';
 import '../services/local_election_reality_service.dart';
+import '../services/prefecture_election_news_service.dart';
 import '../services/local_election_share_service.dart';
 import '../services/public_memo_service.dart';
 import '../widgets/election_japan_map.dart';
@@ -98,6 +99,8 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
   final LocalElectionPlanService _service = const LocalElectionPlanService();
   final LocalElectionRealityService _realityService =
       const LocalElectionRealityService();
+  final PrefectureElectionNewsService _newsService =
+      const PrefectureElectionNewsService();
   final ScrollController _scrollController = ScrollController();
   final GlobalKey _historySectionKey = GlobalKey(debugLabel: 'realityHistory');
   final GlobalKey _scheduleSectionKey =
@@ -117,6 +120,8 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
 
   LocalElectionPlanDashboard? _plan;
   LocalElectionRealitySnapshot? _realitySnapshot;
+  Map<String, List<Map<String, dynamic>>> _newsByPrefecture =
+      const <String, List<Map<String, dynamic>>>{};
   final Map<String, LocalElectionLegislatorProfile> _memberProfileOverrides =
       <String, LocalElectionLegislatorProfile>{};
   final Set<String> _memberProfileLoadingUrls = <String>{};
@@ -242,6 +247,19 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     unawaited(_loadPublishedSnapshotMemo(cachedSnapshot));
     unawaited(_loadPublishedKpiMemo());
     unawaited(_refreshRealityData(showSnackBar: false));
+    unawaited(_loadPrefectureNews());
+  }
+
+  Future<void> _loadPrefectureNews() async {
+    try {
+      final grouped = await _newsService.fetchActiveNewsByPrefecture();
+      if (!mounted) {
+        return;
+      }
+      setState(() => _newsByPrefecture = grouped);
+    } catch (_) {
+      // news は付加情報のため、取得失敗時はバッジ非表示のままにする。
+    }
   }
 
   Future<void> _loadPlan() async {
@@ -5459,7 +5477,13 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
               ],
             ),
             const SizedBox(height: 12),
-            ElectionNewsBadge(prefecture: plan.prefecture),
+            ElectionNewsBadge(
+              newsItems: _newsByPrefecture[
+                      PrefectureElectionNewsService.normalizePrefectureKey(
+                    plan.prefecture,
+                  )] ??
+                  const <Map<String, dynamic>>[],
+            ),
             _buildKgiCsfKpiPanel(plan),
             const SizedBox(height: 12),
             _buildPrefectureOfficerPanel(plan),

--- a/lib/services/prefecture_election_news_service.dart
+++ b/lib/services/prefecture_election_news_service.dart
@@ -1,0 +1,92 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// prefecture_election_news を 1 クエリで全県分取得し、県別に配布する。
+///
+/// 従来は ElectionNewsBadge が県連カードごとに個別クエリを発行しており、
+/// 本番で県数分 (数十件) の fetch + CORS preflight が観測されたための一括化
+/// (2026-07-18)。ページ側は [fetchActiveNewsByPrefecture] の結果を
+/// [normalizePrefectureKey] で引いて各カードへ渡す。
+class PrefectureElectionNewsService {
+  /// 1 県あたりの表示上限 (旧 ElectionNewsBadge の limit(3) と同値)。
+  static const int maxItemsPerPrefecture = 3;
+
+  /// 47 都道府県 × 蓄積 news 件数に対する安全上限。
+  static const int _fetchLimit = 400;
+
+  static const Duration _fetchTimeout = Duration(seconds: 8);
+
+  final SupabaseClient? _client;
+
+  const PrefectureElectionNewsService({SupabaseClient? client})
+      : _client = client;
+
+  SupabaseClient? get _resolvedClient {
+    if (_client != null) {
+      return _client;
+    }
+    try {
+      return Supabase.instance.client;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// active な news を announced_at 降順で一括取得し、正規化県名キー →
+  /// 上位 [maxItemsPerPrefecture] 件の Map として返す。
+  Future<Map<String, List<Map<String, dynamic>>>>
+      fetchActiveNewsByPrefecture() async {
+    final client = _resolvedClient;
+    if (client == null) {
+      return const <String, List<Map<String, dynamic>>>{};
+    }
+    final rows = await client
+        .from('prefecture_election_news')
+        .select(
+          'prefecture, news_title, news_summary, news_source_url, '
+          'news_source_label, announced_at, total_candidate_target, '
+          'confirmed_candidate_count, public_recruitment_count, '
+          'representative_name',
+        )
+        .eq('is_active', true)
+        .order('announced_at', ascending: false)
+        .limit(_fetchLimit)
+        .timeout(_fetchTimeout);
+    return groupByPrefecture(List<Map<String, dynamic>>.from(rows));
+  }
+
+  /// announced_at 降順で並んだ行を県別に振り分け、各県先頭
+  /// [maxItemsPerPrefecture] 件のみ保持する。
+  static Map<String, List<Map<String, dynamic>>> groupByPrefecture(
+    List<Map<String, dynamic>> rows,
+  ) {
+    final grouped = <String, List<Map<String, dynamic>>>{};
+    for (final row in rows) {
+      final key = normalizePrefectureKey(row['prefecture'] as String? ?? '');
+      if (key.isEmpty) {
+        continue;
+      }
+      final bucket = grouped.putIfAbsent(key, () => <Map<String, dynamic>>[]);
+      if (bucket.length < maxItemsPerPrefecture) {
+        bucket.add(row);
+      }
+    }
+    return grouped;
+  }
+
+  /// プラン側の長形式 ('宮崎県'/'東京都'/'大阪府') と DB 格納の短形式
+  /// ('宮崎'/'東京'/'大阪') を同一キーへ正規化する。短形式の '京都' を
+  /// '京' に潰さないため 2 文字以下は suffix を落とさない。北海道はそのまま。
+  static String normalizePrefectureKey(String value) {
+    final trimmed = value.trim();
+    if (trimmed == '北海道') {
+      return trimmed;
+    }
+    if (trimmed.length > 2 &&
+        (trimmed.endsWith('都') ||
+            trimmed.endsWith('府') ||
+            trimmed.endsWith('県'))) {
+      return trimmed.substring(0, trimmed.length - 1);
+    }
+    return trimmed;
+  }
+}

--- a/lib/widgets/election_news_badge.dart
+++ b/lib/widgets/election_news_badge.dart
@@ -1,65 +1,16 @@
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class ElectionNewsBadge extends StatefulWidget {
-  final String prefecture;
+/// 県連カードに公式発表 news を表示するバッジ。
+///
+/// データ取得は行わない。ページ側が PrefectureElectionNewsService で
+/// 全県分を一括取得し、該当県の news を [newsItems] として渡す
+/// (旧実装は県ごとに個別 Supabase クエリを発行しており本番で
+/// 県数分の fetch + CORS preflight が発生していた)。
+class ElectionNewsBadge extends StatelessWidget {
+  final List<Map<String, dynamic>> newsItems;
 
-  const ElectionNewsBadge({super.key, required this.prefecture});
-
-  @override
-  State<ElectionNewsBadge> createState() => _ElectionNewsBadgeState();
-}
-
-class _ElectionNewsBadgeState extends State<ElectionNewsBadge> {
-  List<Map<String, dynamic>> _newsItems = [];
-  bool _loaded = false;
-
-  String get _prefCode => widget.prefecture.endsWith('県')
-      ? widget.prefecture.substring(0, widget.prefecture.length - 1)
-      : widget.prefecture;
-
-  @override
-  void initState() {
-    super.initState();
-    _fetch();
-  }
-
-  @override
-  void didUpdateWidget(ElectionNewsBadge old) {
-    super.didUpdateWidget(old);
-    if (old.prefecture != widget.prefecture) {
-      setState(() {
-        _newsItems = [];
-        _loaded = false;
-      });
-      _fetch();
-    }
-  }
-
-  Future<void> _fetch() async {
-    try {
-      final rows = await Supabase.instance.client
-          .from('prefecture_election_news')
-          .select(
-            'news_title, news_summary, news_source_url, news_source_label, '
-            'announced_at, total_candidate_target, confirmed_candidate_count, '
-            'public_recruitment_count, representative_name',
-          )
-          .eq('prefecture', _prefCode)
-          .eq('is_active', true)
-          .order('announced_at', ascending: false)
-          .limit(3)
-          .timeout(const Duration(seconds: 5));
-      if (!mounted) return;
-      setState(() {
-        _newsItems = List<Map<String, dynamic>>.from(rows);
-        _loaded = true;
-      });
-    } catch (_) {
-      if (mounted) setState(() => _loaded = true);
-    }
-  }
+  const ElectionNewsBadge({super.key, required this.newsItems});
 
   Future<void> _openUrl(String? url) async {
     if (url == null || url.isEmpty) return;
@@ -70,13 +21,13 @@ class _ElectionNewsBadgeState extends State<ElectionNewsBadge> {
 
   @override
   Widget build(BuildContext context) {
-    if (!_loaded || _newsItems.isEmpty) return const SizedBox.shrink();
+    if (newsItems.isEmpty) return const SizedBox.shrink();
 
     const accent = Color(0xFF4F46E5);
 
     return Column(
       children: [
-        for (final item in _newsItems) ...[
+        for (final item in newsItems) ...[
           _buildBadge(context, item, accent),
           const SizedBox(height: 8),
         ],

--- a/test/services/prefecture_election_news_service_test.dart
+++ b/test/services/prefecture_election_news_service_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/prefecture_election_news_service.dart';
+
+void main() {
+  group('normalizePrefectureKey', () {
+    test('長形式 (都/府/県 付き) を短形式へ正規化する', () {
+      expect(
+        PrefectureElectionNewsService.normalizePrefectureKey('宮崎県'),
+        '宮崎',
+      );
+      expect(
+        PrefectureElectionNewsService.normalizePrefectureKey('東京都'),
+        '東京',
+      );
+      expect(
+        PrefectureElectionNewsService.normalizePrefectureKey('大阪府'),
+        '大阪',
+      );
+      expect(
+        PrefectureElectionNewsService.normalizePrefectureKey('神奈川県'),
+        '神奈川',
+      );
+    });
+
+    test('DB 格納の短形式はそのまま維持する (京都 を 京 に潰さない)', () {
+      expect(
+        PrefectureElectionNewsService.normalizePrefectureKey('宮崎'),
+        '宮崎',
+      );
+      expect(
+        PrefectureElectionNewsService.normalizePrefectureKey('京都'),
+        '京都',
+      );
+      expect(
+        PrefectureElectionNewsService.normalizePrefectureKey('京都府'),
+        '京都',
+      );
+    });
+
+    test('北海道は suffix を落とさない', () {
+      expect(
+        PrefectureElectionNewsService.normalizePrefectureKey('北海道'),
+        '北海道',
+      );
+    });
+  });
+
+  group('groupByPrefecture', () {
+    Map<String, dynamic> row(String prefecture, String title) =>
+        <String, dynamic>{
+          'prefecture': prefecture,
+          'news_title': title,
+        };
+
+    test('県別に振り分け、announced_at 降順の先頭 3 件のみ保持する', () {
+      final grouped = PrefectureElectionNewsService.groupByPrefecture([
+        row('宮崎', 'news-1'),
+        row('北海道', 'hokkaido-1'),
+        row('宮崎', 'news-2'),
+        row('宮崎', 'news-3'),
+        row('宮崎', 'news-4'),
+        row('大阪', 'osaka-1'),
+      ]);
+
+      expect(grouped['宮崎']!.map((r) => r['news_title']), [
+        'news-1',
+        'news-2',
+        'news-3',
+      ]);
+      expect(grouped['北海道']!.single['news_title'], 'hokkaido-1');
+      expect(grouped['大阪']!.single['news_title'], 'osaka-1');
+    });
+
+    test('prefecture 空の行は捨てる', () {
+      final grouped = PrefectureElectionNewsService.groupByPrefecture([
+        row('', 'dropped'),
+        row('宮崎', 'kept'),
+      ]);
+      expect(grouped.keys, ['宮崎']);
+    });
+  });
+}

--- a/test/widgets/election_news_badge_test.dart
+++ b/test/widgets/election_news_badge_test.dart
@@ -1,0 +1,182 @@
+// ElectionNewsBadge の一括取得経路テスト。
+//
+// election_victory_page.dart は package:web を推移 import するため VM テスト
+// から読み込めない。ここではページ側と同じ配線 (一括 fetch → normalize key で
+// 県別配布) を最小ハーネスで再現し、Supabase クエリが 1 回だけ発行されることを
+// 検証する。
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/prefecture_election_news_service.dart';
+import 'package:my_web_app/widgets/election_news_badge.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class FakeSupabaseClient extends Fake implements SupabaseClient {
+  FakeSupabaseClient(List<Map<String, dynamic>> rows)
+      : _queryBuilder = FakeSupabaseQueryBuilder(rows);
+
+  final FakeSupabaseQueryBuilder _queryBuilder;
+  int fromCallCount = 0;
+  String? lastTable;
+
+  @override
+  SupabaseQueryBuilder from(String table) {
+    fromCallCount++;
+    lastTable = table;
+    return _queryBuilder;
+  }
+}
+
+class FakeSupabaseQueryBuilder extends Fake implements SupabaseQueryBuilder {
+  FakeSupabaseQueryBuilder(this._rows);
+
+  final List<Map<String, dynamic>> _rows;
+
+  @override
+  PostgrestFilterBuilder<List<Map<String, dynamic>>> select([
+    String? columns = '*',
+  ]) {
+    return FakePostgrestFilterBuilder<List<Map<String, dynamic>>>(_rows);
+  }
+}
+
+class FakePostgrestFilterBuilder<T> extends Fake
+    implements PostgrestFilterBuilder<T> {
+  FakePostgrestFilterBuilder(this._value);
+
+  final T _value;
+
+  // testWidgets の FakeAsync 内で await されるため、時間経過を要する
+  // Future.delayed ではなく即時完了の Future で返す。
+  @override
+  Future<U> then<U>(
+    FutureOr<U> Function(T value) onValue, {
+    Function? onError,
+  }) {
+    return Future<T>.value(_value).then(onValue, onError: onError);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #eq ||
+        invocation.memberName == #order ||
+        invocation.memberName == #limit ||
+        invocation.memberName == #timeout) {
+      return this;
+    }
+    return super.noSuchMethod(invocation);
+  }
+}
+
+List<Map<String, dynamic>> sampleRows() => <Map<String, dynamic>>[
+      <String, dynamic>{
+        'prefecture': '宮崎',
+        'news_title': '宮崎県連が地方選で計25人擁立目標',
+        'news_summary': '20人決定済+公募5人追加方針',
+        'news_source_url': 'https://www.yomiuri.co.jp/',
+        'news_source_label': '読売新聞',
+        'announced_at': '2026-04-29',
+        'total_candidate_target': 25,
+        'confirmed_candidate_count': 20,
+        'public_recruitment_count': 5,
+        'representative_name': '長友慎治',
+      },
+      <String, dynamic>{
+        'prefecture': '北海道',
+        'news_title': '道連、統一地方選で20〜30人目標',
+        'news_summary': '札幌中心に公募で新顔擁立',
+        'news_source_url': 'https://www.asahi.com/',
+        'news_source_label': '朝日新聞',
+        'announced_at': '2026-04-12',
+        'representative_name': '臼木秀剛',
+      },
+      <String, dynamic>{
+        'prefecture': '大阪',
+        'news_title': '大阪府連 統一選挙で30名超擁立目標',
+        'news_summary': '玉木代表が定期大会で発信',
+        'news_source_url': 'https://x.com/tamakiyuichiro',
+        'news_source_label': 'X (@tamakiyuichiro)',
+        'announced_at': '2026-04-25',
+      },
+    ];
+
+/// ページ側 (_buildPrefectureCard) と同じ配布ロジックの最小再現。
+Widget buildDistributionHarness(
+  Map<String, List<Map<String, dynamic>>> newsByPrefecture,
+  List<String> prefectures,
+) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            for (final prefecture in prefectures)
+              ElectionNewsBadge(
+                newsItems: newsByPrefecture[
+                        PrefectureElectionNewsService.normalizePrefectureKey(
+                      prefecture,
+                    )] ??
+                    const <Map<String, dynamic>>[],
+              ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('一括取得 1 クエリで全県連カードの news badge が描画される', (tester) async {
+    final fakeClient = FakeSupabaseClient(sampleRows());
+    final service = PrefectureElectionNewsService(client: fakeClient);
+
+    final newsByPrefecture = await service.fetchActiveNewsByPrefecture();
+
+    // ページ表示形式 (長形式) の県名で配布する。佐賀県は news 無し。
+    await tester.pumpWidget(
+      buildDistributionHarness(
+        newsByPrefecture,
+        const ['宮崎県', '北海道', '大阪府', '佐賀県'],
+      ),
+    );
+
+    // 県数分ではなく 1 クエリのみ。
+    expect(fakeClient.fromCallCount, 1);
+    expect(fakeClient.lastTable, 'prefecture_election_news');
+
+    // 各県のカードに該当 news が配布される (大阪府 → DB短形式 '大阪' も一致)。
+    expect(find.text('宮崎県連が地方選で計25人擁立目標'), findsOneWidget);
+    expect(find.text('道連、統一地方選で20〜30人目標'), findsOneWidget);
+    expect(find.text('大阪府連 統一選挙で30名超擁立目標'), findsOneWidget);
+    expect(find.text('計 25 人'), findsOneWidget);
+    expect(find.text('確定 20 人'), findsOneWidget);
+    expect(find.text('公募 5 人'), findsOneWidget);
+    expect(find.text('代表: 長友慎治'), findsOneWidget);
+  });
+
+  testWidgets('news が無い県のバッジは何も描画しない', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ElectionNewsBadge(newsItems: <Map<String, dynamic>>[]),
+        ),
+      ),
+    );
+
+    expect(
+      find.descendant(
+        of: find.byType(ElectionNewsBadge),
+        matching: find.byType(SizedBox),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(ElectionNewsBadge),
+        matching: find.byType(Container),
+      ),
+      findsNothing,
+    );
+  });
+}


### PR DESCRIPTION
## 概要

県連カード内 ElectionNewsBadge が都道府県ごとに個別の Supabase クエリ (`prefecture_election_news?select=...`) を発行し、本番 DevTools で県数分 (数十件) の fetch + CORS preflight が観測されていた (2026-07-18)。対象テーブルを 1 クエリで一括取得し、ページ側で県別に配布する形へ改修する。

## 変更点

- **PrefectureElectionNewsService 新設** (`lib/services/prefecture_election_news_service.dart`)
  - `is_active=true` を `announced_at` 降順で一括取得 (limit 400 / timeout 8s)
  - 正規化県名キー → 先頭 3 件 (旧 badge の `limit(3)` と同値) の Map で返却
- **ElectionNewsBadge を描画専用 StatelessWidget 化** — 自前 fetch / didUpdateWidget を廃止し、ページから渡された news を描画するだけに
- **election_victory_page**: `_loadInitialState` から `_loadPrefectureNews()` を 1 回発火して `_newsByPrefecture` に保持し、各県連カードへ配布
- **正規化バグ修正 (同梱)**: 旧実装は末尾「県」のみ strip していたため、東京都/大阪府/京都府 は DB 短形式 ('東京'/'大阪'/'京都') と永久不一致で badge が表示されなかった。`normalizePrefectureKey` は 都/府/県 を strip し、2 文字以下は保持 ('京都' を '京' に潰さない)。北海道はそのまま

## local-election-intelligence EF 初回 11.7s の確認結果 (コード検証)

- **EF サーバー側にキャッシュは存在しない**: snapshot アクションは毎回、公式議員名簿 + 47 都道府県ページ (並列 12) + 公式選挙ページ (並列 6) + 2023 結果 + 日程ソースをライブスクレイプする。11.7s は現設計の実力値
- **クライアント側の即時返却は実装済みで有効**: `LocalElectionRealityService.fetchLatestSnapshot` は SharedPreferences + memory snapshot が 2h 以内なら EF を呼ばず即返す。ページは cached snapshot を先に描画し、EF 呼び出しは `unawaited` の background refresh のため初回ペイントをブロックしない
- **キャッシュが効かないケース**: ①初訪問/別ブラウザ (キャッシュ無し) ②2h 経過後 ③直近 14 日内投票日の候補者当落 status 未解決時は毎ロード強制 refresh (`_hasUnresolvedRecentPastCandidateElection`)
- 改善余地 (スコープ外・別 Issue 候補): cron (snapshotAndQueue) が永続化した snapshot を EF が短期 TTL で返す server-side cache を足せば初訪問ユーザーも即時応答になる

## テスト

- `test/services/prefecture_election_news_service_test.dart`: normalize (長形式/短形式/北海道/京都) + group (3 件 cap / 空 prefecture 除外)
- `test/widgets/election_news_badge_test.dart`: Fake SupabaseClient で **クエリ 1 回のみ** + 宮崎県/北海道/大阪府への配布 + news 無し県は非描画を widget test で検証 (election_victory_page は package:web 推移 import で browser-only のため、ページ側と同一配線の最小ハーネスで再現)
- `flutter analyze` (service/badge/page) `No issues found!` / `flutter test` 7 件 `All tests passed!`

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: UI-layer bulk-fetch refactor covered by VM widget tests asserting a single bulk query and per-prefecture distribution; election_victory_page transitively imports package:web (browser-only) so no VM-runnable integration_test route exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
