### PR TITLE
fix(e2e): public smoke を #4122 の SEO シェル刷新に追随 (全PRのスモーク赤を解消)

### DIFF
--- a/test/e2e/public_smoke.spec.ts
+++ b/test/e2e/public_smoke.spec.ts
@@ -9,7 +9,10 @@ test.describe('public production smoke', () => {
 
       expect(response?.ok()).toBeTruthy();
       await expect(page.locator('body')).toContainText('自分株式会社');
-      await expect(page.locator('body')).toContainText('Loading application');
+      // 起動中に表示される SEO フォールバックの準備文言。PR #4122 で
+      // index.html の boot 文言が 'Loading application' から日本語の
+      // 準備メッセージへ変わったため追随する。
+      await expect(page.locator('body')).toContainText('無料体験を準備しています');
     });
   }
 
@@ -18,8 +21,14 @@ test.describe('public production smoke', () => {
   }) => {
     await page.goto('/project-gantt', { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('link', { name: '無料で始める' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Proで支援する' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'WBSガントチャート' })).toBeVisible();
+    // PR #4122 で SEO シェルの CTA が刷新された (無料で始める/Proで支援する/
+    // WBSガントチャート → 5分だけ無料で試す/使い方を見る)。クローラブルな
+    // 入口リンクが app boot 前に描画されていることを現行文言で検証する。
+    await expect(
+      page.getByRole('link', { name: '5分だけ無料で試す' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: '使い方を見る' }),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## 概要

`test/e2e/public_smoke.spec.ts` (本番ライブサイトを叩く「Public E2E stability smoke」ゲート) が、[PR #4122](https://github.com/kanta13jp1/my_web_app/pull/4122)「optimize landing signup with ten experiments」による `web/index.html` の SEO シェル刷新に追随できておらず、**以降の全PRでこのゲートが一律 fail** していました (テストは main のコードではなく本番 `https://my-web-app-b67f4.web.app` を検証するため、全PRに波及)。

## 根本原因

#4122 が起動フォールバックの文言・CTA を変更:

| 項目 | 旧 (テストの期待値) | 新 (本番の現行値) |
|------|------|------|
| boot 文言 | `Loading application` | `無料体験を準備しています...` |
| CTA リンク | `無料で始める` / `Proで支援する` / `WBSガントチャート` | `5分だけ無料で試す` / `使い方を見る` |

テストが旧文言のままだったため、`/`・`/project-gantt`・`/referral` の全ケースが `toContainText` / `getByRole('link')` タイムアウトで失敗していました。

## 修正

本番の現行 HTML に合わせてアサーションを更新。3文字列とも本番 `/` および `/project-gantt` の静的 HTML に存在することを `curl` で確認済み:

```
[無料体験を準備しています] = 1
[5分だけ無料で試す]       = 存在 (SEO shell primary CTA)
[使い方を見る]           = 存在 (SEO shell secondary CTA)
```

SEO シェルの可視性挙動は #4122 前後で不変 (`nav.seo-links` 内の可視アンカー、ラベルのみ変更) のため、`toBeVisible()` の判定ロジックは維持しています。

## 検証

- 本番 HTML に対する文字列存在を curl で確認 (上記)
- 実 Playwright 実行はこの PR の CI「Public E2E stability smoke」ゲート自体が最終検証 (self-validating: 修正が正しければこのゲートが緑になる)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 本 PR 自体が E2E テスト (Playwright public_smoke) の修正であり、CI の同スモークゲートが self-validating で検証する。プロダクトコードの挙動変更はゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
