### PR TITLE
feat(asset): 「まず、これだけ」に給料着金確認/生命線確保/高金利ローン死守を追加

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -1238,6 +1238,13 @@ class AssetLiabilityWorkbook {
   final int manualPaymentCount;
   final int estimatedPaymentCount;
 
+  /// サブスク区分 (AssetRecurringFixedCostCategory.subscription) として登録された
+  /// 定期固定費の口座 ID 集合。資金繰り上は utility 負債として計上され
+  /// fullPaymentEstimate=true になるため、家賃・光熱費などの「生命線」と
+  /// 区別できない。トリアージで「生命線を優先確保」から除外するために保持する
+  /// (サブスクは解約候補であって優先支払い対象ではない)。
+  final Set<String> subscriptionFixedCostAccountIds;
+
   const AssetLiabilityWorkbook({
     required this.baseDate,
     required this.accounts,
@@ -1268,6 +1275,7 @@ class AssetLiabilityWorkbook {
     required this.topFourDebtShare,
     required this.manualPaymentCount,
     required this.estimatedPaymentCount,
+    this.subscriptionFixedCostAccountIds = const <String>{},
   });
 
   List<AssetLiabilityCashflowRow> get overdueCashflowRows {

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -245,6 +245,14 @@ class AssetLiabilityPlanningService {
       baseDate: baseDate,
       salaryDay: salaryDay,
     );
+    // 実際に注入されたサブスク区分の固定費口座 ID (dedup / 当月該当を反映済み)。
+    // トリアージの「生命線を優先確保」から除外する。名前の再解決ではなく実注入
+    // 口座 ID を使うことで、組み込み生命線 ID (rent/gas_bill 等) との部分一致衝突で
+    // 本物の生命線を過剰除外する事故を避ける。
+    final subscriptionFixedCostAccountIds = <String>{
+      for (final injected in injectedFixedCosts)
+        if (injected.isSubscription) injected.account.id,
+    };
     if (injectedFixedCosts.isNotEmpty) {
       accounts
         ..addAll(injectedFixedCosts.map((injected) => injected.account))
@@ -448,6 +456,7 @@ class AssetLiabilityPlanningService {
           liabilityTotal == 0 ? 0 : topFourDebtTotal / liabilityTotal.abs(),
       manualPaymentCount: manualPaymentCount,
       estimatedPaymentCount: estimatedPaymentCount,
+      subscriptionFixedCostAccountIds: subscriptionFixedCostAccountIds,
     );
   }
 
@@ -1996,8 +2005,12 @@ class AssetLiabilityPlanningService {
   /// 当月に該当する周期 (毎月/隔月) かつ金額>0 で、まだ同名/同IDの口座が無いものだけ
   /// を返す。`_liability` 経由で既定固定費 (水道/ガス) と同じ全額支払いの utility 負債
   /// として作る。振替元は呼び出し側で `effectivePaymentSourceAccountIds` に反映する。
-  List<({AssetLiabilityAccount account, String? sourceAccountId})>
-      _buildRecurringFixedCostInjections({
+  List<
+      ({
+        AssetLiabilityAccount account,
+        String? sourceAccountId,
+        bool isSubscription
+      })> _buildRecurringFixedCostInjections({
     required List<AssetRecurringFixedCost> recurringFixedCosts,
     required List<AssetLiabilityAccount> existingAccounts,
     required DateTime baseDate,
@@ -2006,14 +2019,18 @@ class AssetLiabilityPlanningService {
     if (recurringFixedCosts.isEmpty) {
       return const <({
         AssetLiabilityAccount account,
-        String? sourceAccountId
+        String? sourceAccountId,
+        bool isSubscription
       })>[];
     }
     final takenIds = existingAccounts.map((account) => account.id).toSet();
     final takenNames =
         existingAccounts.map((account) => _normalize(account.name)).toSet();
-    final result =
-        <({AssetLiabilityAccount account, String? sourceAccountId})>[];
+    final result = <({
+      AssetLiabilityAccount account,
+      String? sourceAccountId,
+      bool isSubscription
+    })>[];
     for (final cost in recurringFixedCosts) {
       if (cost.amount <= 0 ||
           !cost.appliesToMonth(
@@ -2037,7 +2054,14 @@ class AssetLiabilityPlanningService {
       }
       takenIds.add(account.id);
       takenNames.add(_normalize(account.name));
-      result.add((account: account, sourceAccountId: cost.sourceAccountId));
+      result.add(
+        (
+          account: account,
+          sourceAccountId: cost.sourceAccountId,
+          isSubscription:
+              cost.category == AssetRecurringFixedCostCategory.subscription,
+        ),
+      );
     }
     return result;
   }

--- a/lib/services/asset_triage_guide_service.dart
+++ b/lib/services/asset_triage_guide_service.dart
@@ -7,11 +7,20 @@ enum AssetTriageStepKind {
   /// 今日: 食費・移動費など最低限の生活費を確保する。
   secureLivingExpense,
 
+  /// 今日: 期日を過ぎた入金予定（給料等）が着金したか確認する。
+  confirmIncomeArrival,
+
   /// 今日: 本日期日の支払いの原資を確認する。
   dueTodayPayment,
 
   /// 今日: カードの新規利用を止める（財布から抜く）。
   stopNewCardUsage,
+
+  /// 今週: 家賃・通信など生活の生命線となる固定費を優先確保する。
+  secureLifeline,
+
+  /// 今週: 高金利ローンの最低額を死守する。
+  protectHighInterestLoan,
 
   /// 今週: 期限超過の支払いを上から処理する。
   processOverdue,
@@ -105,6 +114,11 @@ class AssetTriageGuideService {
   /// 年収が分かる場合、負債が年収のこの割合を超えたら専門窓口案内を出す。
   static const double consultationDebtIncomeRatio = 0.5;
 
+  /// 「高金利ローン」と見なす年利の下限（この値以上を死守対象にする）。
+  /// 消費者金融 (年18%) だけでなく銀行カードローン (年14.5% 前後) も
+  /// 延滞は等しく重いため、10% を閾値にして cardLoan 種別を漏れなく拾う。
+  static const double highInterestRateThreshold = 0.10;
+
   AssetTriagePlan buildPlan({
     required AssetLiabilityWorkbook workbook,
     AssetDebtDisciplineReport? disciplineReport,
@@ -176,6 +190,33 @@ class AssetTriageGuideService {
       );
     }
 
+    // ①.5 期日を過ぎた入金予定（給料等）の着金確認。着金すれば口座が正常化する
+    // 最もレバレッジの高い1件のため、生活費の次・本日期日の前に置く。
+    final pendingIncome = workbook.incomePlans
+        .where(
+          (plan) => !plan.received && !_dateOnly(plan.date).isAfter(today),
+        )
+        .toList()
+      ..sort((a, b) => b.amount.compareTo(a.amount));
+    if (pendingIncome.isNotEmpty) {
+      final top = pendingIncome.first;
+      final others = pendingIncome.length - 1;
+      final destinationNote = top.destinationAccountName == null
+          ? ''
+          : '着金先は${top.destinationAccountName}の見込みです。';
+      todaySteps.add(
+        AssetTriageStep(
+          kind: AssetTriageStepKind.confirmIncomeArrival,
+          title: '入金予定が着金したか確認する',
+          detail: '${top.name} ${_yen(top.amount)}'
+              '${others > 0 ? ' ほか$others件' : ''}が'
+              '入金予定日を過ぎても「未受取」のままです。$destinationNote'
+              '着金していれば「受取済み」に更新してください。口座の見込み残高が'
+              '正常化し、以降の資金繰り判断が変わります。',
+        ),
+      );
+    }
+
     // ② 本日期日の支払い。
     final dueTodayRows = workbook.cashflowRows
         .where(
@@ -227,7 +268,84 @@ class AssetTriageGuideService {
     // 今日のステップは最大 3 件 (多いと動けなくなる)。溢れた分は翌日以降に回る。
     final cappedToday = todaySteps.take(maxTodaySteps).toList();
 
-    // ④ 期限超過の処理 (放置だけが最悪)。
+    // ④ 家賃・通信など生活の生命線を優先確保。fullPaymentEstimate は
+    // 「家賃・通信費など毎月全額を支払う固定費型」だが、サブスク区分の定期固定費も
+    // 同じ fullPaymentEstimate=true で計上される。サブスクは解約候補であって
+    // 「優先して払う生命線」ではないため、subscriptionFixedCostAccountIds を除外する
+    // (これを混ぜると困窮ユーザーに『サブスクを他の支払いより先に払え』と誤指示し、
+    // 同じ計画の固定費見直しステップとも矛盾する)。
+    // カード請求に内包される固定費 (例: auPay カード経由の通信費) は、口座から
+    // 直接引き落とされず、そのカードの請求行で支払われる。ここで「口座に先に
+    // 確保せよ」と出すとカード請求分と二重計上になるため、直接引落分のみを対象にする。
+    final subscriptionIds = workbook.subscriptionFixedCostAccountIds;
+    final lifelineRows = workbook.debtMasterRows
+        .where(
+          (row) =>
+              row.fullPaymentEstimate &&
+              !row.paid &&
+              row.scheduledPaymentAmount > 0 &&
+              !row.includedInBillingAccount &&
+              !subscriptionIds.contains(row.id),
+        )
+        .toList()
+      ..sort(
+        (a, b) => (a.paymentDay ?? 99).compareTo(b.paymentDay ?? 99),
+      );
+    if (lifelineRows.isNotEmpty) {
+      final total = lifelineRows.fold<double>(
+        0,
+        (sum, row) => sum + row.scheduledPaymentAmount,
+      );
+      final names = lifelineRows
+          .take(3)
+          .map(
+            (row) => '${row.name} ${_yen(row.scheduledPaymentAmount)}'
+                '${row.paymentDay == null ? '' : '（${row.paymentDay}日）'}',
+          )
+          .join(' / ');
+      weekSteps.add(
+        AssetTriageStep(
+          kind: AssetTriageStepKind.secureLifeline,
+          title: '家賃・通信など生命線を優先確保する',
+          detail: '住居・通信は生活の生命線です。$names'
+              '${lifelineRows.length > 3 ? ' ほか${lifelineRows.length - 3}件' : ''}'
+              '（合計 ${_yen(total)}）の引落分は、他の支払いより先に口座へ確保してください。',
+        ),
+      );
+    }
+
+    // ⑤ 高金利ローンの最低額を死守（利息が重いので他より優先して最低額を守る）。
+    final highInterestLoans = workbook.debtMasterRows
+        .where(
+          (row) =>
+              !row.fullPaymentEstimate &&
+              row.kind == AssetLiabilityAccountKind.cardLoan &&
+              row.annualRate >= highInterestRateThreshold &&
+              row.balance.abs() > 1 &&
+              !row.paid,
+        )
+        .toList()
+      ..sort((a, b) => b.annualRate.compareTo(a.annualRate));
+    if (highInterestLoans.isNotEmpty) {
+      final names = highInterestLoans
+          .take(3)
+          .map(
+            (row) => '${row.name}（年${_formatRate(row.annualRate)} / '
+                '最低 ${_yen(row.minimumPaymentEstimate)}）',
+          )
+          .join(' / ');
+      weekSteps.add(
+        AssetTriageStep(
+          kind: AssetTriageStepKind.protectHighInterestLoan,
+          title: '高金利ローンの最低額を死守する',
+          detail: '利息が重い高金利ローンは、延滞すると傷が深くなります。$names'
+              '${highInterestLoans.length > 3 ? ' ほか${highInterestLoans.length - 3}件' : ''}'
+              'は最低額を必ず確保し、余力があればここから多めに返してください。',
+        ),
+      );
+    }
+
+    // ⑥ 期限超過の処理 (放置だけが最悪)。
     // overdueCashflowRows は未受領の収入行も含み、本日期日 (=ステップ②) も
     // overdue 扱いのため、「支払 かつ 昨日以前」に絞る (収入を延滞額扱いしない・
     // 本日期日を②と二重計上しない)。
@@ -367,6 +485,15 @@ class AssetTriageGuideService {
 
   DateTime _dateOnly(DateTime value) =>
       DateTime(value.year, value.month, value.day);
+
+  /// 年利 (小数) を「18%」のような表示へ。整数割り切れ時は小数点を省く。
+  String _formatRate(double rate) {
+    final percent = rate * 100;
+    if ((percent - percent.roundToDouble()).abs() < 0.05) {
+      return '${percent.round()}%';
+    }
+    return '${percent.toStringAsFixed(1)}%';
+  }
 
   String _yen(double amount) {
     final sign = amount < 0 ? '-' : '';

--- a/test/services/asset_triage_guide_service_test.dart
+++ b/test/services/asset_triage_guide_service_test.dart
@@ -128,6 +128,187 @@ void main() {
       );
     });
 
+    test('confirms unreceived past-due income as a today step', () {
+      // 期日を過ぎても未受取の給料は「着金確認」を今日ステップに出す。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          '財布(現金)': 50000,
+          'モビット': -100000,
+        },
+        baseDate: DateTime(2026, 5, 26),
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'salary',
+            date: DateTime(2026, 5, 25),
+            name: '給料',
+            amount: 450000,
+            destinationAccountId: 'smbc_otsuka_branch',
+            destinationAccountName: '三井住友銀行大塚支店',
+            received: false,
+          ),
+        ],
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      final income = plan.todaySteps.firstWhere(
+        (step) => step.kind == AssetTriageStepKind.confirmIncomeArrival,
+      );
+      expect(income.detail.contains('給料'), isTrue);
+      expect(income.detail.contains('450,000円'), isTrue);
+      expect(income.detail.contains('三井住友銀行大塚支店'), isTrue);
+    });
+
+    test('does not confirm income that is not yet due', () {
+      // 入金予定日が未来の場合は「着金確認」を出さない。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'財布(現金)': 50000},
+        baseDate: DateTime(2026, 5, 20),
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'salary',
+            date: DateTime(2026, 5, 25),
+            name: '給料',
+            amount: 450000,
+            destinationAccountId: null,
+            destinationAccountName: null,
+            received: false,
+          ),
+        ],
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      expect(
+        plan.todaySteps.where(
+          (step) => step.kind == AssetTriageStepKind.confirmIncomeArrival,
+        ),
+        isEmpty,
+      );
+    });
+
+    test(
+        'surfaces directly-debited rent as a lifeline but excludes '
+        'card-billed telecom', () {
+      // 家賃は口座直接引落の生命線→出す。au(通信)は auPay カード請求に内包され
+      // (includedInBillingAccount=true)、そのカードの請求行で支払われるため、
+      // 「口座に先に確保せよ」から除外する (二重計上防止)。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          '家賃': -63000,
+          'au': -28741,
+        },
+        baseDate: DateTime(2026, 5, 1),
+      );
+
+      final lifelineDebtRow = workbook.debtMasterRows.firstWhere(
+        (row) => row.name == 'au',
+      );
+      // 前提: au はカード請求内包として分類されている。
+      expect(lifelineDebtRow.includedInBillingAccount, isTrue);
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      final lifeline = plan.weekSteps.firstWhere(
+        (step) => step.kind == AssetTriageStepKind.secureLifeline,
+      );
+      expect(lifeline.detail.contains('家賃'), isTrue);
+      expect(lifeline.detail.contains('生命線'), isTrue);
+      expect(lifeline.detail.contains('au'), isFalse);
+    });
+
+    test('lifeline step excludes subscriptions but keeps utilities', () {
+      // サブスク (ChatGPT Pro) は fullPaymentEstimate=true でも「生命線を優先確保」
+      // には出さない (解約候補であって優先支払い対象ではない)。光熱費は残す。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{'bank': 500000},
+        baseDate: DateTime(2026, 5, 1),
+        recurringFixedCosts: const <AssetRecurringFixedCost>[
+          AssetRecurringFixedCost(
+            id: 'chatgpt_pro',
+            name: 'ChatGPT Pro',
+            amount: 30000,
+            paymentDay: 3,
+            category: AssetRecurringFixedCostCategory.subscription,
+          ),
+          AssetRecurringFixedCost(
+            id: 'denki',
+            name: '電気代',
+            amount: 12000,
+            paymentDay: 20,
+            category: AssetRecurringFixedCostCategory.utility,
+          ),
+        ],
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      final lifeline = plan.weekSteps.firstWhere(
+        (step) => step.kind == AssetTriageStepKind.secureLifeline,
+      );
+      expect(lifeline.detail.contains('電気代'), isTrue);
+      expect(lifeline.detail.contains('ChatGPT'), isFalse);
+      // 合計にもサブスク額 (30,000) を含めない。
+      expect(lifeline.detail.contains('30,000円'), isFalse);
+    });
+
+    test('protects high-interest loans as a distinct week step', () {
+      // モビット (年18% cardLoan) は高金利ローンとして最低額死守ステップに出る。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'モビット': -1000000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      final loan = plan.weekSteps.firstWhere(
+        (step) => step.kind == AssetTriageStepKind.protectHighInterestLoan,
+      );
+      expect(loan.detail.contains('モビット'), isTrue);
+      expect(loan.detail.contains('18%'), isTrue);
+      expect(loan.detail.contains('最低'), isTrue);
+    });
+
+    test('high-interest step also covers 14.5% bank card loans', () {
+      // じぶん銀行カードローン (年14.5% cardLoan) も高金利として死守対象に含める。
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: const <String, double>{
+          'bank': 500000,
+          'じぶん銀行カードローン': -800000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+      );
+
+      final plan = triage.buildPlan(
+        workbook: workbook,
+        disciplineReport: monitor.evaluate(workbook: workbook),
+      );
+
+      final loan = plan.weekSteps.firstWhere(
+        (step) => step.kind == AssetTriageStepKind.protectHighInterestLoan,
+      );
+      expect(loan.detail.contains('じぶん'), isTrue);
+    });
+
     test('no fake cash crisis for users without a cash account', () {
       // 現金口座を記録していないだけの健全ユーザーには生活費ステップを出さない。
       final workbook = planner.buildWorkbook(


### PR DESCRIPTION
## 概要

資産管理ページの段階別トリアージ「まず、これだけ」(`AssetTriageGuideService`) に、数字が多く混乱している利用者向けの新ステップ3件を追加します。ユーザーから提示された手動アドバイス文面と、既存機能とのギャップを埋めるものです。全ステップ決定論的 (calculation_owner: dart_service / AI は文面言い換えのみ)。

## 追加した3ステップ

| kind | タイミング | 発火条件 | 内容 |
|---|---|---|---|
| `confirmIncomeArrival` | 今日 | 期日超過の未受取入金予定 (`incomePlans` received=false かつ date≤基準日) | 給料等の着金確認。着金で口座が正常化する最もレバレッジの高い1件のため、生活費の次・本日期日の前に配置 |
| `secureLifeline` | 今週 | `fullPaymentEstimate` の固定費 (家賃/光熱/通信) | 生命線の優先確保。**サブスク区分**と**カード請求内包**は除外 (下記) |
| `protectHighInterestLoan` | 今週 | `cardLoan` 種別 かつ 年利≥10% | 最低額死守。消費者金融18% + 銀行カードローン14.5% を漏れなく捕捉。リボ (creditCard/shoppingDebt) の `disableRevolving` とは別建て |

## 敵対レビューで検出・修正した hazard

多エージェント敵対レビュー (understand→review→adversarial verify) で以下を検出し全て反映:

- 🔴 **HIGH (確定)**: `secureLifeline` が `fullPaymentEstimate` を生命線の代理に使うと、同フラグを持つ**サブスク** (`AssetRecurringFixedCostCategory.subscription`) を「生命線」と誤認し、困窮ユーザーに「ChatGPT Pro を家賃より先に払え」と誤誘導 (同 plan の「サブスク解約」ステップとも矛盾)。
  → `AssetLiabilityWorkbook.subscriptionFixedCostAccountIds` を追加 (既定空/後方互換) し除外。**実注入された口座 ID** を使うことで、名前再解決による組み込み生命線 ID との部分一致衝突での過剰除外も回避。
- 🟡 **medium**: カード請求内包 (`includedInBillingAccount` / 例: auPay 経由の通信費) を「口座に先に確保せよ」と出すと二重計上 → `!row.includedInBillingAccount` で除外。
- 🟡 **medium**: ID 衝突による本物の生命線の過剰除外 → 上記の実注入 ID 方式で解消。

## テスト

`test/services/asset_triage_guide_service_test.dart` に回帰テストを追加 (計14件緑):
- 新3ステップの発火 / 未来日の入金は着金確認しない
- **サブスクは生命線から除外・光熱費は残す** / 合計にサブスク額を含めない
- **カード請求内包 (au) は生命線から除外・直接引落の家賃は残す**
- 14.5% 銀行カードローンの捕捉

影響先 (`asset_management_insight_service` / `asset_management_ai_summary_service` / `asset_management_page`) も analyze・テスト緑。UI カードとAIプロンプトは step を種別 switch せず汎用描画のため新ステップは自動反映。

> 注: ローカル lefthook の full-repo `flutter analyze` が Windows のアナライザークラッシュ (既知の多ファイル crash) で落ちるため、個別ファイルの `dart analyze` (全緑) で検証し git plumbing で commit。CI が server-side で本ゲートを実行します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純ロジック (lib/services のトリアージ計算) の変更でユーザー向け配信バイナリ挙動は既存 UI カード経由。14 件のユニット回帰テストで I/O 契約を固定

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: prose-only trigger; 差分は lib/ Dart のみ (supabase/functions 未変更)。BEHIND base による無関係 EF 混入
