### PR TITLE
improve(election): 統一地方選700ページ 10仮説検証 第3弾 (確定5件・CSV式インジェクション修正含む)

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -1216,7 +1216,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
         ? snapshot!.actualNetIncreaseRequired
         : plan.requiredNetIncrease;
     final progressLabel = plan.targetLocalMembers > 0
-        ? '${(officialCount / plan.targetLocalMembers * 100).toStringAsFixed(1)}%'
+        ? '${(officialCount / plan.targetLocalMembers * 100).clamp(0, 100).toStringAsFixed(1)}%'
         : '-';
     final daysToElection = _shareService.daysUntilNextUnifiedLocalElection();
     final monthsToElection = (daysToElection / 30).ceil().clamp(1, 24);
@@ -2429,6 +2429,8 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
 
     final buffer = StringBuffer();
 
+    String row(List<String> cells) => cells.map(_csvCell).join(',');
+
     if (alertSchedules.isNotEmpty) {
       alertSchedules.sort((a, b) {
         final aDate = a.parsedVoteDate;
@@ -2439,42 +2441,56 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
         return a.voteDate.compareTo(b.voteDate);
       });
       buffer.writeln('--- 未擁立・単騎の選挙 ---');
-      buffer.writeln('投票日,都道府県,自治体,選挙名,候補者数,候補者一覧,Xハンドル');
+      buffer.writeln(
+        row(['投票日', '都道府県', '自治体', '選挙名', '候補者数', '候補者一覧', 'Xハンドル']),
+      );
       for (final s in alertSchedules) {
-        final date = s.voteDate.replaceAll(',', '、');
-        final pref = s.prefecture.replaceAll(',', '、');
-        final muni = s.municipality.replaceAll(',', '、');
-        final name = s.electionName.replaceAll(',', '、');
-        final count = s.kokuminCandidateCount.toString();
-        final candidates =
-            _buildScheduleCandidateSummary(s).replaceAll(',', '、');
-        final handles = _candidateHandles(s)
-            .map((handle) => '@$handle')
-            .join(' / ')
-            .replaceAll(',', '、');
-        buffer.writeln('$date,$pref,$muni,$name,$count,$candidates,$handles');
+        final handles =
+            _candidateHandles(s).map((handle) => '@$handle').join(' / ');
+        buffer.writeln(
+          row([
+            s.voteDate,
+            s.prefecture,
+            s.municipality,
+            s.electionName,
+            s.kokuminCandidateCount.toString(),
+            _buildScheduleCandidateSummary(s),
+            handles,
+          ]),
+        );
       }
       buffer.writeln('');
     }
 
     if (pastResults.isNotEmpty) {
       buffer.writeln('--- 過去の選挙結果 ---');
-      buffer.writeln('投票日,場所,選挙名,候補者名,当落,得票数');
+      buffer.writeln(row(['投票日', '場所', '選挙名', '候補者名', '当落', '得票数']));
       for (final result in pastResults) {
-        final date = result.date.replaceAll(',', '、');
-        final location = result.location.replaceAll(',', '、');
-        final electionName = result.electionName.replaceAll(',', '、');
         final candidates = result.resolvedCandidates.toList();
 
         if (candidates.isEmpty) {
-          buffer.writeln('$date,$location,$electionName,候補者情報なし,N/A,0');
+          buffer.writeln(
+            row([
+              result.date,
+              result.location,
+              result.electionName,
+              '候補者情報なし',
+              'N/A',
+              '0',
+            ]),
+          );
         } else {
           for (final candidate in candidates) {
-            final name = candidate.name;
-            final status = candidate.status;
-            final votes = candidate.votes.toString();
-            buffer
-                .writeln('$date,$location,$electionName,$name,$status,$votes');
+            buffer.writeln(
+              row([
+                result.date,
+                result.location,
+                result.electionName,
+                candidate.name,
+                candidate.status,
+                candidate.votes.toString(),
+              ]),
+            );
           }
         }
       }
@@ -4275,7 +4291,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
         else
           _buildMemberRosterAccordion(
             visibleMembers: visibleMembers,
-            totalFilteredCount: filteredMembers.length,
+            filteredMembers: filteredMembers,
           ),
       ],
     );
@@ -4283,14 +4299,22 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
 
   Widget _buildMemberRosterAccordion({
     required List<LocalElectionLegislatorProfile> visibleMembers,
-    required int totalFilteredCount,
+    required List<LocalElectionLegislatorProfile> filteredMembers,
   }) {
     final grouped = <String, List<LocalElectionLegislatorProfile>>{};
     for (final member in visibleMembers) {
       grouped.putIfAbsent(member.prefecture, () => []).add(member);
     }
+    // 県別のフィルタ済み総数 (ページング前) を先に集計し、可視分が
+    // 県の途中で切れてもグループヘッダーが正しい総数を出せるようにする。
+    final totalByPrefecture = <String, int>{};
+    for (final member in filteredMembers) {
+      totalByPrefecture[member.prefecture] =
+          (totalByPrefecture[member.prefecture] ?? 0) + 1;
+    }
     final entries = grouped.entries.toList()
       ..sort((left, right) => left.key.compareTo(right.key));
+    final remaining = filteredMembers.length - visibleMembers.length;
 
     return Column(
       children: [
@@ -4298,17 +4322,17 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
           _buildMemberRosterGroup(
             prefecture: entries[index].key,
             members: entries[index].value,
+            prefectureTotal: totalByPrefecture[entries[index].key] ??
+                entries[index].value.length,
             initiallyExpanded: entries.length <= 2 || index == 0,
           ),
-        if (totalFilteredCount > visibleMembers.length)
+        if (remaining > 0)
           Padding(
             padding: const EdgeInsets.only(top: 8),
             child: OutlinedButton.icon(
               onPressed: _showMoreMembers,
               icon: const Icon(Icons.expand_more),
-              label: Text(
-                'さらに ${_formatInt((totalFilteredCount - visibleMembers.length).clamp(0, _memberPageSize))} 人表示',
-              ),
+              label: Text('さらに表示（残り ${_formatInt(remaining)} 人）'),
             ),
           ),
       ],
@@ -4318,12 +4342,18 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
   Widget _buildMemberRosterGroup({
     required String prefecture,
     required List<LocalElectionLegislatorProfile> members,
+    required int prefectureTotal,
     required bool initiallyExpanded,
   }) {
     final prefecturalCount =
         members.where((item) => item.assemblyCategory == 'prefectural').length;
     final municipalCount =
         members.where((item) => item.assemblyCategory == 'municipal').length;
+    // 可視分がこの県の総数より少ない (ページ境界で途中まで) 場合は
+    // 「表示中/総数」を明示し、ヘッダー数が過少に見えないようにする。
+    final headerCount = members.length < prefectureTotal
+        ? '${_formatInt(members.length)}/${_formatInt(prefectureTotal)}人'
+        : '${_formatInt(members.length)}人';
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
@@ -4342,7 +4372,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
                 const EdgeInsets.symmetric(horizontal: 14, vertical: 2),
             childrenPadding: const EdgeInsets.fromLTRB(10, 0, 10, 8),
             title: Text(
-              '$prefecture ${_formatInt(members.length)}人',
+              '$prefecture $headerCount',
               style: Theme.of(context).textTheme.titleSmall?.copyWith(
                     fontWeight: FontWeight.w700,
                   ),
@@ -5951,6 +5981,26 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
       return const Color(0xFFFF8F00);
     }
     return const Color(0xFFFF6B35);
+  }
+
+  // CSV セル安全化: 先頭が式記号 (= + - @ タブ/改行) のセルは
+  // Excel/Sheets で数式として実行されうるため `'` を前置し、
+  // 区切り/引用符/改行を含むセルは RFC 4180 の二重引用符でクオートする。
+  // 候補者名・選挙名は外部スクレイプ由来の非信頼値なので必須。
+  static const String _csvFormulaPrefixes = '=+-@\t\r\n';
+
+  String _csvCell(String value) {
+    final guarded =
+        value.isNotEmpty && _csvFormulaPrefixes.contains(value.substring(0, 1))
+            ? "'$value"
+            : value;
+    if (guarded.contains(',') ||
+        guarded.contains('"') ||
+        guarded.contains('\n') ||
+        guarded.contains('\r')) {
+      return '"${guarded.replaceAll('"', '""')}"';
+    }
+    return guarded;
   }
 
   String _formatInt(int value) => _numberFormat.format(value);

--- a/lib/widgets/election_progress_chart.dart
+++ b/lib/widgets/election_progress_chart.dart
@@ -90,7 +90,8 @@ class ElectionProgressChart extends StatelessWidget {
                     PieChartSectionData(
                       color: Colors.redAccent.shade400,
                       value: shortfallValue <= 0 ? 1 : shortfallValue,
-                      title: '残り\n$shortfall人',
+                      // 目標到達後 (残り<=0) は負数を出さず「達成」と表示。
+                      title: shortfall <= 0 ? '達成' : '残り\n$shortfall人',
                       radius: 60,
                       titleStyle: const TextStyle(
                         fontSize: 14,
@@ -123,7 +124,7 @@ class ElectionProgressChart extends StatelessWidget {
             const SizedBox(height: 8),
             Text(
               targetValue > 0
-                  ? '達成率 ${(currentTotal / targetValue * 100).toStringAsFixed(1)}%'
+                  ? '達成率 ${(currentTotal / targetValue * 100).clamp(0, 100).toStringAsFixed(1)}%'
                   : '達成率 0%',
               style: const TextStyle(
                 fontSize: 12,

--- a/lib/widgets/election_regional_kpi_chart.dart
+++ b/lib/widgets/election_regional_kpi_chart.dart
@@ -710,7 +710,9 @@ class _ElectionRegionalKpiChartState extends State<ElectionRegionalKpiChart> {
   }
 
   void _showMonthlyDetailsDialog(BuildContext context, String month) {
-    final prefecturesInMonth = widget.prefectures
+    // 月次テーブルの件数は allPrefectures 集計なので、ドリルダウンの一覧も
+    // 全県連を母数にする (prefectures=重点上位部分集合で絞ると件数と乖離する)。
+    final prefecturesInMonth = widget.allPrefectures
         .where((p) => p.endorsementDeadlineMonth == month)
         .toList();
     // 未確定の県連が上に来るようにソート

--- a/test/widgets/election_charts_test.dart
+++ b/test/widgets/election_charts_test.dart
@@ -28,6 +28,27 @@ void main() {
     expect(find.textContaining('達成率'), findsOneWidget);
   });
 
+  testWidgets(
+      'ElectionProgressChart clamps 達成率 to 100% and shows 達成 when over target',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ElectionProgressChart(
+            currentTotal: 720,
+            shortfall: -20,
+            target: 700,
+          ),
+        ),
+      ),
+    );
+
+    // 目標超過でも 100% を上限にクランプし、102.9% のような値を出さない
+    // (パイスライスの title は canvas 描画のため達成率 Text のみ検証)。
+    expect(find.textContaining('達成率 100.0%'), findsOneWidget);
+    expect(find.textContaining('102'), findsNothing);
+  });
+
   testWidgets('ElectionRegionalKpiChart renders prefecture labels and legends',
       (
     tester,


### PR DESCRIPTION
## 概要

`/local-election-700` (統一地方選700 必達管理室) の改善 **第3弾**。第1弾([#4098](https://github.com/kanta13jp1/my_web_app/pull/4098)・8件)/第2弾([#4115](https://github.com/kanta13jp1/my_web_app/pull/4115)・6件)でヒーロー・日程・鮮度・母数を扱ったので、今回はまだ深掘りしていない **CSVエクスポート・議員名簿・チャート数値処理** を中心に10仮説を検証。確定5件を反映しました。

## 10仮説の検証結果

| # | 仮説 | 判定 | 対応 |
|---|------|------|------|
| R3-H4 | CSVエクスポートに式インジェクション防御が無い | ✅ 確定 (security) | 標準 `_csvCell` 導入 |
| R3-H6a | 達成率が100%を超えて表示されうる | ✅ 確定 | `clamp(0,100)` |
| R3-H6b | パイチャートが負の「残り」を表示 | ✅ 確定 | 「達成」表示へ |
| R3-H1 | 議員名簿グループヘッダーがページ境界で過少件数 | ✅ 確定 | 真の県別総数を表示 |
| R3-bonus | 月次KPIドリルダウンの母数不一致 | ✅ 確定 | 一覧も `allPrefectures` 母数へ |
| R3-H5 | AI整理メモの空状態が壊れる | ❌ 反証 | 到達可能かつフォールバック正常 |
| R3-H8 | progressRatio のゼロ除算/>1.0 assert | ❌ 反証 | 全消費箇所 `clamp`+`target<=0` ガード済 |
| R3-H3 | 日本地図のデフォルト東京が data 不在で壊れる | ❌ 反証 | `initState` で `_firstPriorityIndex()` が上書き |
| R3-H7 | ステータスが色のみ (アクセシビリティ) | △ 一部 | 県連/日程カードはテキストバッジ併記済み。地図タイルは色のみ→ Issue 化 |
| R3-H9 | 議員個別プロフィール取得が N+1 | ❌ 反証 | ボタン毎の遅延取得 (一括発火なし) |

## 確定5件の詳細

### R3-H4 CSV式インジェクション (CWE-1236) — 最重要
`_downloadElectionDataCsv` はセル値を `.replaceAll(',', '、')` するだけで、先頭が `=` `+` `-` `@` タブ/改行 の値に対する防御がありませんでした。候補者名・選挙名・Xハンドル・当落は**外部の党公式ページやWeb日程からスクレイプした非信頼値**で、Excel/Sheets で開くと数式として実行されます。特に **Xハンドル列は `@handle` で必ず `@` 始まり=確定トリガー**。

リポジトリ標準の `asset_tax_export_service._csvCell` と同一ロジック (式prefix前置 `'` + RFC 4180 二重引用符クオート) を導入。あわせて、過去結果セクションで `name`/`status` だけ comma 置換が漏れて**列ズレする既存バグ**も全セル `_csvCell` 経由化で解消。

### R3-H6 チャート数値の無クランプ
- `達成率` = `current/target*100` が無クランプで、目標到達 (= 成功状態) に `102.9%` 等を出す → `clamp(0,100)`。進捗チャート・ヒーロー両方。
- パイチャートの `残り` slice title が `shortfall<=0` で `残り-20人` → `達成`。

### R3-H1 議員名簿ヘッダーの過少件数
`take(_visibleMemberCount)` の可視分だけをグループ化しヘッダーに `県 N人` を出すため、ページ境界で県が途中まで可視のとき「東京都 12人」(実30人) と過少表示。ページング前の全フィルタ済みリストから県別総数を集計し「12/30人」表示に。「さらにN人表示」の `clamp(0, pageSize)` による過少表示も「残りN人」へ是正。

### R3-bonus 月次KPIドリルダウンの母数不一致
月次テーブルの件数は `allPrefectures` 集計なのに、行タップのドリルダウン一覧は重点上位部分集合 `prefectures` を絞っており件数が乖離 (ダイアログが過少報告) → 一覧も `allPrefectures` を母数に。

## 検証

- `flutter analyze` (編集3ファイル・個別実行): 全て `No issues found!`
- `flutter test test/widgets/election_charts_test.dart`: 5件全緑 (達成率100%クランプの回帰テスト追加)
- `dart format`: 適合確認済み

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: CSV安全化・数値クランプ・名簿件数表示の UI ロジック修正で新規画面遷移なし。widget test (達成率クランプ回帰) + flutter analyze で検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
