### PR TITLE
improve(election): 統一地方選700ページ 10仮説検証 第4弾 (確定4件・カレンダーassertクラッシュ修正含む)

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -1435,9 +1435,14 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
                       hasSnapshot
                           ? '公式議員ページと2023年の公式選挙結果ページを取得して、'
                               'AIで各県連の現職人数・目標擁立数・予定選挙数・公認期限を自動更新します。'
-                          : 'まだ最新データを取得できていません。'
-                              'ネット経由で公式ソースを再取得すると、'
-                              '計画値とのズレを把握できます。',
+                          : _isRealityLoading
+                              // 自動取得の実行中は「再取得を促す」文言だと
+                              // 矛盾するため、取得中である旨を出す。
+                              ? '公式ソースから最新の地方議員数を取得しています。'
+                                  '初回は20秒ほどかかることがあります。'
+                              : 'まだ最新データを取得できていません。'
+                                  'ネット経由で公式ソースを再取得すると、'
+                                  '計画値とのズレを把握できます。',
                       style: Theme.of(context).textTheme.bodySmall,
                     ),
                   ],
@@ -1630,7 +1635,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
             ],
             const SizedBox(height: 16),
             if (realitySnapshot == null && _isRealityLoading)
-              const Center(child: CircularProgressIndicator())
+              _buildRealityLoadingState()
             else if (realitySnapshot == null)
               _buildEmptyRealityState()
             else ...[
@@ -1707,6 +1712,55 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
             ],
           ],
         ),
+      ),
+    );
+  }
+
+  // 初回ロードは公式ソース巡回に 20 秒前後かかることがある。素の
+  // スピナーだけだと「固まった」と誤認されるため、何を待っているかと
+  // 目安時間を明示したローディング状態を出す。
+  Widget _buildRealityLoadingState() {
+    const accent = Color(0xFF0891B2);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: accent.withValues(alpha: 0.18)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(strokeWidth: 2.5, color: accent),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '最新の公式データを取得中…',
+                  style: TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                    height: 1.5,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  '公式議員ページと2023年の選挙結果を巡回して集計しています。'
+                  '初回は20秒ほどかかることがあります。取得後、計画値とのズレ・'
+                  '上位県・AI要約がここに表示されます。',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -2970,6 +3024,15 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     final selectedEvents = _scheduleEventsForDay(snapshot, selectedDay);
     final firstDay = _scheduleCalendarFirstDay(snapshot, selectedDay);
     final lastDay = _scheduleCalendarLastDay(snapshot, selectedDay);
+    // TableCalendar は focusedDay が [firstDay, lastDay] 内であることを assert
+    // する。_scheduleFocusedDay は firstDay/lastDay と独立に決まり (全日程が
+    // 過去/未来に偏る・null 日付エントリ先頭ソート等で) 範囲外へ出ると
+    // クラッシュするため、描画直前に必ずクランプする。
+    final focusedDay = _scheduleFocusedDay.isBefore(firstDay)
+        ? firstDay
+        : (_scheduleFocusedDay.isAfter(lastDay)
+            ? lastDay
+            : _scheduleFocusedDay);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -2988,7 +3051,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
               locale: 'ja_JP',
               firstDay: firstDay,
               lastDay: lastDay,
-              focusedDay: _scheduleFocusedDay,
+              focusedDay: focusedDay,
               calendarFormat: _scheduleCalendarFormat,
               selectedDayPredicate: (day) => isSameDay(day, selectedDay),
               eventLoader: (day) =>
@@ -3512,8 +3575,26 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
         .toList();
   }
 
+  static final RegExp _xUsernamePattern = RegExp(r'^[A-Za-z0-9_]{1,15}$');
+
+  /// スクレイプ由来の X ハンドルを正規化する。full URL / @ 前置 / 末尾スラッシュ
+  /// を取り除き、X ユーザー名規則 (英数字とアンダースコア 1〜15 文字) に
+  /// 合致しない値は空文字を返す。`https://x.com/$handle` へ埋め込むため、
+  /// `evil.com/path` や空白入りの不正値で壊れたリンク・誤表示が出るのを防ぐ。
   String _normalizeXHandle(String raw) {
-    return raw.trim().replaceFirst(RegExp(r'^@+'), '');
+    var value = raw.trim();
+    if (value.isEmpty) {
+      return '';
+    }
+    // full URL 形式ならパス末尾 (ユーザー名) を取り出す。
+    final lastSlash = value.lastIndexOf('/');
+    if (lastSlash >= 0) {
+      value = value.substring(lastSlash + 1);
+    }
+    value = value.replaceFirst(RegExp(r'^@+'), '').trim();
+    // クエリ/フラグメントが付いていれば切り落とす。
+    value = value.split(RegExp(r'[?#\s]')).first;
+    return _xUsernamePattern.hasMatch(value) ? value : '';
   }
 
   Color _scheduleCardBackgroundColor(


### PR DESCRIPTION
## 概要

`/local-election-700` (統一地方選700 必達管理室) の改善 **第4弾**。第1〜3弾で19件を着地させたので、今回はまだ深掘りしていない **ローディングUX・カレンダー境界・ハンドル安全性・空/エラー状態** を中心に10仮説を検証。確定4件を反映しました (副エージェントによる敵対的検証併用)。

## 10仮説の検証結果

| # | 仮説 | 判定 | 対応 |
|---|------|------|------|
| R4-H1 | 22秒EFの初回ロードで待機表示が貧弱 | ✅ 確定 (UX) | 説明付きローディング + 矛盾サブタイトル是正 |
| R4-H4 | スケジュールカレンダーの assert クラッシュ | ✅ 確定 (crash) | `focusedDay` を描画直前にクランプ |
| R4-H2 | Xハンドルリンクが不正値で壊れる | ✅ 確定 (data quality) | X ユーザー名規則で検証 |
| R4-H1b | reality節サブタイトルが取得中に矛盾表示 | ✅ 確定 | 取得中文言へ |
| R4-H5 | AI要約をロード毎に再生成している | ❌ 反証 | `includeAiSummary:false` 固定・自動再生成なし |
| R4-H3 | clipboardサマリーが古い値を混在 | ❌ 反証 | `buildAutoUpdatedPlan` で snapshot 値同期済 |
| R4-H8 | 地域フィルタ0件で `.first` クラッシュ | ❌ 反証 | `isEmpty` ガードで早期 return |
| R4-H7 | `.first/.last/.reduce` の空リストクラッシュ | ❌ 反証 | 全箇所ガード済 |
| R4-H2b | Xハンドルがオープンリダイレクト脆弱性 | ❌ 反証 | host が `x.com` 固定・ホスト超え不可 |
| R4-H6 | 空状態文言の不整合 | △ | ローディング/空/エラーの3状態を整理 |

## 確定4件の詳細

### R4-H1 22秒EFの初回ロードUX
初回ロード (キャッシュ無し) は `realitySnapshot == null && _isRealityLoading` で **素の中央スピナーのみ** を約22秒表示。公式ソース巡回中と分からず「固まった」と誤認されます。加えて reality節のサブタイトルが**自動取得が走っているのに「再取得すると…」と再取得を促す矛盾表示**でした。

→ 「最新の公式データを取得中… 初回は20秒ほどかかることがあります」と**何を待っているか+目安時間**を明示したローディング状態へ。サブタイトルも取得中は取得中文言に切替。

### R4-H4 スケジュールカレンダーの assert クラッシュ
`TableCalendar` は `focusedDay ∈ [firstDay, lastDay]` を assert (`table_calendar_base.dart:77-78`)。`firstDay`/`lastDay` は日程の実投票日から算出されるのに `_scheduleFocusedDay` は独立の state で、**全日程が過去/未来に偏る・null日付エントリが先頭ソートで `_bestScheduleSelection` が `now` を返す**等で範囲外に出ると assert クラッシュ (debug は赤画面、release は assert 除去され未定義動作)。特に「週末フィルタで該当0件時のフォールバックが `now` を焦点にする」経路が再現しやすい。

→ 描画直前に `focusedDay` を `[firstDay, lastDay]` へクランプ。

### R4-H2 Xハンドルの正規化強化
`_normalizeXHandle` は先頭 `@` 除去のみで、スクレイプ由来の full URL や不正文字が `https://x.com/$handle` に埋め込まれ、**壊れたリンク・誤った `@handle` 表示**を生みます (host は `x.com` 固定なのでオープンリダイレクトにはならず、実害はデータ品質問題)。

→ URL プレフィックス除去 + X ユーザー名規則 `^[A-Za-z0-9_]{1,15}$` 検証で、不正値は空文字にして既存の `where(isNotEmpty)` フィルタで除外。

## 検証

- `flutter analyze` (編集ファイル): `No issues found!`
- `flutter test test/widgets/election_charts_test.dart`: 5件全緑 (既存回帰)
- `dart format`: 適合確認済み
- 副エージェントによる敵対的コードレビュー (7領域) で確定/反証を相互検証

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: ローディング表示・カレンダー focusedDay クランプ・ハンドル正規化の UI 状態ロジック修正で新規画面遷移なし。全て Supabase 初期化を要する page State 内メソッドのため flutter analyze + 既存 widget test + 副エージェント敵対レビューで検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
