### PR TITLE
feat(admin): 自動エラー報告の可視化カードを /admin に追加 (10仮説検証 part340)

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -133,6 +133,11 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   int _comparisonSignups = 0;
   bool _comparisonCvrLoading = false;
 
+  // R29: 自動エラー報告 (error_reporter が hub_data へ無言送信する caught error)
+  // の可視化。管理者自身の直近報告を admin-hub errors.recent で取得する。
+  List<AutoErrorReportEntry> _autoErrorReports = const [];
+  bool _autoErrorReportsLoading = false;
+
   int _toInt(dynamic value) {
     if (value is int) return value;
     if (value is num) return value.toInt();
@@ -874,6 +879,34 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
     _loadGrowthSummary();
     _loadComparisonCvr();
     _loadAppFeedbacks();
+    _loadRecentErrors();
+  }
+
+  /// R29: 自動エラー報告を admin-hub errors.recent で取得する。取得失敗や未認証は
+  /// 空へ degrade し、カードは「正常」表示 or 非表示になる (ダッシュボードは必ず描画)。
+  Future<void> _loadRecentErrors() async {
+    if (!mounted) return;
+    if (_supabase.auth.currentUser == null) return;
+    setState(() => _autoErrorReportsLoading = true);
+    try {
+      final res = await _supabase.functions.invoke(
+        'admin-hub',
+        body: const {'action': 'errors.recent', 'limit': 20},
+      );
+      final data = res.data;
+      final entries = data is Map && data['success'] == true
+          ? parseAutoErrorReports(data['errors'])
+          : const <AutoErrorReportEntry>[];
+      if (mounted) {
+        setState(() {
+          _autoErrorReports = entries;
+          _autoErrorReportsLoading = false;
+        });
+      }
+    } catch (error) {
+      debugPrint('errors.recent unavailable: $error');
+      if (mounted) setState(() => _autoErrorReportsLoading = false);
+    }
   }
 
   Future<void> _loadAppFeedbacks() async {
@@ -2228,6 +2261,8 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                     _buildFeatureRequestsAdminCard(),
                     const SizedBox(height: 16),
                     _buildAutomationOpsCard(),
+                    const SizedBox(height: 16),
+                    _buildAutoErrorReportsCard(),
                     const SizedBox(height: 16),
                     const SelfDevinControlTowerCard(),
                     const SizedBox(height: 16),
@@ -5468,6 +5503,125 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                       ),
                     );
                   },
+                ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  // R29: 自動エラー報告 (error_reporter が hub_data へ無言送信していた caught
+  // error) の可視化カード。0件なら「正常」を明示し、あれば直近を先頭行だけ出す。
+  Widget _buildAutoErrorReportsCard() {
+    final theme = Theme.of(context);
+    final count = _autoErrorReports.length;
+    final hasErrors = count > 0;
+    final accent =
+        hasErrors ? const Color(0xFFB45309) : const Color(0xFF0D9488);
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  hasErrors
+                      ? Icons.report_gmailerrorred
+                      : Icons.verified_outlined,
+                  color: accent,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    autoErrorReportsHealthLabel(count),
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      height: 1.4,
+                      color: accent,
+                    ),
+                  ),
+                ),
+                if (_autoErrorReportsLoading)
+                  const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                else
+                  IconButton(
+                    icon: const Icon(Icons.refresh, size: 20),
+                    tooltip: '再取得',
+                    onPressed: _loadRecentErrors,
+                  ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              hasErrors
+                  ? 'アプリが自動で捕捉・記録した例外です (公開 Issue 化はされません)。'
+                      '本文は自分のセッション分のみ表示しています。'
+                  : 'アプリが捕捉した例外は記録されていません。',
+              style: TextStyle(
+                fontSize: 12,
+                height: 1.5,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            if (hasErrors) ...[
+              const SizedBox(height: 10),
+              ..._autoErrorReports.take(8).map((entry) {
+                final when =
+                    formatAgeAwareDate(entry.createdAt, DateTime.now());
+                final line =
+                    entry.firstLine.isEmpty ? '(本文なし)' : entry.firstLine;
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Icon(
+                        Icons.chevron_right,
+                        size: 16,
+                        color: Color(0xFFB45309),
+                      ),
+                      const SizedBox(width: 4),
+                      Expanded(
+                        child: Text(
+                          line,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 12.5,
+                            height: 1.5,
+                            color: theme.colorScheme.onSurface,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        when,
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }),
+              if (count > 8)
+                Text(
+                  'ほか ${count - 8}件',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
             ],
           ],

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -401,3 +401,66 @@ String? archetypeLiftSummaryLine(List<ArchetypeLiftEntry> entries) {
   });
   return '型別実測（投稿72時間後・imp）: ${parts.join(' / ')}';
 }
+
+// R29: error_reporter が hub_data へ無言で送っている caught error
+// (auto_error_report) を /admin で可視化するカードの純ロジック。edge の
+// admin-hub errors.recent が {id, message, firstLine, createdAt} を返す。
+
+class AutoErrorReportEntry {
+  final String id;
+  final String firstLine;
+  final String createdAt;
+
+  const AutoErrorReportEntry({
+    required this.id,
+    required this.firstLine,
+    required this.createdAt,
+  });
+}
+
+const String _autoErrorHeader = '[自動エラー報告]';
+
+/// message から表示用の先頭意味行を抽出する (edge の extractAutoErrorFirstLine
+/// と同じ規律)。firstLine が edge から来ていればそれを優先し、無ければ message
+/// から復元する (後方互換・防御)。
+String autoErrorPreviewLine(Map<String, dynamic> row) {
+  final firstLine = (row['firstLine'] ?? '').toString().trim();
+  if (firstLine.isNotEmpty) return firstLine;
+  final message = (row['message'] ?? '').toString();
+  final lines = message
+      .split('\n')
+      .map((line) => line.trim())
+      .where((line) => line.isNotEmpty)
+      .toList();
+  final meaningful = lines.firstWhere(
+    (line) => line != _autoErrorHeader,
+    orElse: () => '',
+  );
+  return meaningful.length > 140
+      ? '${meaningful.substring(0, 138)}…'
+      : meaningful;
+}
+
+/// errors.recent のレスポンス行を表示用エントリへ写像する。
+List<AutoErrorReportEntry> parseAutoErrorReports(dynamic rawErrors) {
+  if (rawErrors is! List) return const [];
+  final entries = <AutoErrorReportEntry>[];
+  for (final row in rawErrors) {
+    if (row is! Map) continue;
+    final map = Map<String, dynamic>.from(row);
+    entries.add(
+      AutoErrorReportEntry(
+        id: (map['id'] ?? '').toString(),
+        firstLine: autoErrorPreviewLine(map),
+        createdAt: (map['createdAt'] ?? map['created_at'] ?? '').toString(),
+      ),
+    );
+  }
+  return entries;
+}
+
+/// カードのヘッダラベル。0件は「異常なし」を明示し、誤って警戒させない。
+String autoErrorReportsHealthLabel(int count) {
+  if (count <= 0) return '自動エラー報告なし（正常）';
+  return '自動エラー報告 $count件';
+}

--- a/supabase/functions/admin-hub/auto_error_reports.ts
+++ b/supabase/functions/admin-hub/auto_error_reports.ts
@@ -1,0 +1,49 @@
+// error_reporter (クライアント auto error report) は hub_data に
+// source='user_feedback' + metadata.source='auto_error_report' で入る。
+// metadata.message は "[自動エラー報告]\n<本文>\n\n<stack 6行>" 形式。
+// 管理ダッシュボードの可視化カード用に、行を表示しやすい形へ写像する純関数。
+
+export interface HubDataRow {
+  id?: string | number | null;
+  created_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface AutoErrorReport {
+  id: string;
+  message: string;
+  firstLine: string;
+  createdAt: string;
+}
+
+const _autoReportHeader = "[自動エラー報告]";
+
+/// message から表示用の先頭意味行を抽出する。ヘッダ行と空行を除いた最初の行
+/// (= 実際のエラーメッセージ) を返し、長すぎる場合は省略する。
+export function extractAutoErrorFirstLine(message: string): string {
+  const lines = (message ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  // ヘッダ行以外の最初の行 (headerless message なら lines[0] が返る)。
+  // ヘッダのみ/空なら "" に落とす。
+  const meaningful = lines.find((line) => line !== _autoReportHeader) ?? "";
+  return meaningful.length > 140 ? `${meaningful.slice(0, 138)}…` : meaningful;
+}
+
+/// hub_data 行配列を AutoErrorReport 配列へ写像する。
+export function mapAutoErrorReports(
+  rows: HubDataRow[] | null | undefined,
+): AutoErrorReport[] {
+  return (rows ?? []).map((row) => {
+    const meta = row?.metadata ?? {};
+    const message = String((meta as Record<string, unknown>).message ?? "")
+      .trim();
+    return {
+      id: String(row?.id ?? ""),
+      message,
+      firstLine: extractAutoErrorFirstLine(message),
+      createdAt: String(row?.created_at ?? ""),
+    };
+  });
+}

--- a/supabase/functions/admin-hub/auto_error_reports_test.ts
+++ b/supabase/functions/admin-hub/auto_error_reports_test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  extractAutoErrorFirstLine,
+  mapAutoErrorReports,
+} from "./auto_error_reports.ts";
+
+Deno.test("extractAutoErrorFirstLine: ヘッダ行を飛ばし最初の意味行を返す", () => {
+  const msg = "[自動エラー報告]\nNull check operator used on a null value\n\n#0 foo\n#1 bar";
+  assertEquals(
+    extractAutoErrorFirstLine(msg),
+    "Null check operator used on a null value",
+  );
+});
+
+Deno.test("extractAutoErrorFirstLine: 空/ヘッダのみは空文字", () => {
+  assertEquals(extractAutoErrorFirstLine(""), "");
+  assertEquals(extractAutoErrorFirstLine("[自動エラー報告]"), "");
+});
+
+Deno.test("extractAutoErrorFirstLine: 長い行は140字で省略", () => {
+  const long = "E".repeat(200);
+  const out = extractAutoErrorFirstLine(`[自動エラー報告]\n${long}`);
+  assertEquals(out.length, 139); // 138 + "…"
+  assertEquals(out.endsWith("…"), true);
+});
+
+Deno.test("mapAutoErrorReports: 行を写像し先頭行を抽出", () => {
+  const rows = [
+    {
+      id: "a1",
+      created_at: "2026-07-18T09:00:00Z",
+      metadata: {
+        source: "auto_error_report",
+        message: "[自動エラー報告]\nRangeError: index out of range\n#0 x",
+      },
+    },
+    { id: 2, created_at: "2026-07-18T08:00:00Z", metadata: { message: "" } },
+  ];
+  const out = mapAutoErrorReports(rows);
+  assertEquals(out.length, 2);
+  assertEquals(out[0].id, "a1");
+  assertEquals(out[0].firstLine, "RangeError: index out of range");
+  assertEquals(out[0].createdAt, "2026-07-18T09:00:00Z");
+  assertEquals(out[1].id, "2");
+  assertEquals(out[1].firstLine, "");
+});
+
+Deno.test("mapAutoErrorReports: null/空入力は空配列", () => {
+  assertEquals(mapAutoErrorReports(null), []);
+  assertEquals(mapAutoErrorReports(undefined), []);
+  assertEquals(mapAutoErrorReports([]), []);
+});

--- a/supabase/functions/admin-hub/index.ts
+++ b/supabase/functions/admin-hub/index.ts
@@ -11,6 +11,7 @@ import {
   normalizeTaskBudgetTokens,
   runTaskBudgetAssistant,
 } from "../_shared/task_budget_assistant.ts";
+import { mapAutoErrorReports } from "./auto_error_reports.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -123,6 +124,30 @@ serve(async (req: Request) => {
           status: "open",
         });
         return json({ success: true, item });
+      }
+
+      // ---- 自動エラー報告 (error_reporter) の可視化 ----
+      // error_reporter が hub_data へ無言で送っている caught error を
+      // 管理ダッシュボードで見えるようにする読み取り専用 action。
+      // admin-hub に role ゲートが無いため、他ユーザーの stack を晒さないよう
+      // 呼び出し元(=管理者)自身の報告のみ返す (metadata.user_id 一致)。
+      // 全ユーザー横断は admin ロール導入後に広げること。
+      case "errors.recent": {
+        const limit = Math.min(
+          Math.max(Number(body.limit) || 20, 1),
+          50,
+        );
+        const { data, error } = await admin
+          .from("hub_data")
+          .select("id, metadata, created_at")
+          .eq("source", "user_feedback")
+          .filter("metadata->>source", "eq", "auto_error_report")
+          .filter("metadata->>user_id", "eq", effectiveUserId)
+          .order("created_at", { ascending: false })
+          .limit(limit);
+        if (error) return json({ error: error.message }, 400);
+        const errors = mapAutoErrorReports(data ?? []);
+        return json({ success: true, errors, count: errors.length });
       }
 
       case "support.reply": {

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -503,4 +503,48 @@ void main() {
       expect(line, contains('製品紹介型 実測不足 (1件・計測中1件)'));
     });
   });
+  group('R29 auto error report helpers (可視化カード)', () {
+    test('autoErrorPreviewLine: firstLine 優先', () {
+      expect(
+        autoErrorPreviewLine(
+          {'firstLine': 'Null check operator', 'message': 'x'},
+        ),
+        'Null check operator',
+      );
+    });
+
+    test('autoErrorPreviewLine: firstLine 空なら message から復元 (ヘッダ除外)', () {
+      expect(
+        autoErrorPreviewLine({
+          'message': '[自動エラー報告]\nRangeError: bad index\n#0 foo',
+        }),
+        'RangeError: bad index',
+      );
+      expect(autoErrorPreviewLine({'message': '[自動エラー報告]'}), '');
+      expect(autoErrorPreviewLine({}), '');
+    });
+
+    test('parseAutoErrorReports: 行を写像・非Mapは無視', () {
+      final entries = parseAutoErrorReports([
+        {
+          'id': 'a1',
+          'firstLine': 'boom',
+          'createdAt': '2026-07-18T09:00:00Z',
+        },
+        'not-a-map',
+        {'id': 2, 'message': '[自動エラー報告]\nsecond'},
+      ]);
+      expect(entries.length, 2);
+      expect(entries[0].id, 'a1');
+      expect(entries[0].firstLine, 'boom');
+      expect(entries[1].id, '2');
+      expect(entries[1].firstLine, 'second');
+      expect(parseAutoErrorReports(null), isEmpty);
+    });
+
+    test('autoErrorReportsHealthLabel: 0件は正常表記', () {
+      expect(autoErrorReportsHealthLabel(0), '自動エラー報告なし（正常）');
+      expect(autoErrorReportsHealthLabel(3), '自動エラー報告 3件');
+    });
+  });
 }


### PR DESCRIPTION
## 概要

part340。経営分析ダッシュボード 10 仮説検証を重ねる中で見つけた**観測ブラインドスポット**を埋める。`error_reporter` が捕捉した例外 (FlutterError.onError / PlatformDispatcher.onError) を `hub_data` (source='user_feedback' + metadata.source='auto_error_report') へ**無言で送っており、管理画面から一切見えなかった** (`app_feedback` テーブルとは別保存のため既存カードにも出ない)。/admin の Network タブに時々出る core-hub 呼び出しの正体候補でもある。

## 10 仮説 検証結果 (build 4847/4859)

part340 (#4113) 反映で **Finish 2.3分→13.6s / DOMContentLoaded 5.18s→1.19s** に改善確認。今回の2新signalは検証の結果いずれも実害なし:

| # | 仮説 | 判定 |
|---|------|------|
| H1 | wbs_tasks 2回 fetch | ⚪benign: 非完了1003行で page0 が1000cap→page1で残り3行の**正常ページング** (part337 fix動作)。payload=#4092 |
| H2 | core-hub が /admin で発火=可視化ゲート漏れ? | ⚪**ゲートは airtight**(part338)。HomePage fetch は非発火。唯一の受動経路は error_reporter の auto_error_report |
| H3 | core-hub は残存ログか実エラーか | ⚪waterfall 先頭=同一SPAで先にホーム経由した残存ログの公算大 (Preserve log off でも in-app遷移では消えない) |
| H4-H10 | font(#4104)/wbs payload(#4092)/presence(#4081)/CORS preflight(#4080)/勝ち型・型別実測(part339動作確認)/CVR 0.0%(107view0登録=正しい) | すべて tracked or benign |

→ 実害バグは無し。過程で見つけた**観測ブラインドスポット (auto_error_report 不可視)** を本PRで解消。

## 変更

- **admin-hub 新 action `errors.recent`** (読み取り専用)。auto_error_report を created_at 降順で取得。**admin-hub に role ゲートが無いため、他ユーザーの stack を晒さないよう呼び出し元(=管理者)自身の報告のみ返す** (metadata.user_id 一致・既存 listItems と同じ自己スコープ)。全ユーザー横断は admin ロール導入後に広げる。
- 純ヘルパー `auto_error_reports.ts` (mapAutoErrorReports / extractAutoErrorFirstLine): message "[自動エラー報告]\n<本文>\n<stack>" からヘッダ行を除いた先頭意味行を抽出。
- client: `admin_dashboard_signals.dart` に parseAutoErrorReports / autoErrorPreviewLine / autoErrorReportsHealthLabel (依存ゼロ・VMテスト可)。`admin_analytics_page.dart` に _loadRecentErrors() + _buildAutoErrorReportsCard() (0件は「自動エラー報告なし（正常）」明示、あれば直近8件を先頭行+相対日付)。取得失敗/未認証は空へ degrade。

## テスト
- `auto_error_reports_test.ts` — deno 5件 ✅
- `admin_dashboard_signals_test.dart` R29 — 4件 (計48) ✅
- flutter analyze 0 issue / dart format 差分なし / deno lint clean

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Read-only admin-hub errors.recent action that lists the caller's own auto_error_report rows from hub_data, plus a display card and pure helpers; self-scoped by metadata.user_id, no writes, no auth/RLS/payment/secret changes; covered by deno + Dart unit tests

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: New edge action is a read-only self-scoped list covered by pure-function deno tests (auto_error_reports_test.ts, 5 cases); Flutter card logic covered by VM unit tests in admin_dashboard_signals_test.dart (R29, 4 cases). Display-only, no new user mutation flow.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
