### PR TITLE
feat(election): 統一地方選700に第1次公認の発表状況を反映 (出典付き構造化)

### DIFF
--- a/lib/data/dpj_prefecture_announced_targets.dart
+++ b/lib/data/dpj_prefecture_announced_targets.dart
@@ -27,6 +27,58 @@ enum DpjAnnouncedTargetKind {
   unconfirmed,
 }
 
+/// 県連が発表した第1次公認(公認内定)候補予定者の実績値。
+///
+/// これは「擁立目標」とは別物で、実際に党/県連が第1次として公認を決定した
+/// 候補予定者の人数。目標に対する進捗として表示する。数値は必ず県連公式発表・
+/// 報道で裏づけを取り、[sourceUrl] に出典を残す(捏造・推測値は入れない)。
+class DpjFirstEndorsement {
+  /// 第1次公認 候補予定者の総数。
+  final int totalCount;
+
+  /// うち現職。
+  final int incumbentCount;
+
+  /// うち新人。
+  final int newcomerCount;
+
+  /// うち元職(いれば)。
+  final int formerCount;
+
+  /// 発表・基準日 (ISO yyyy-MM-dd)。
+  final String asOf;
+
+  /// 出典URL(県連発表ページ・報道)。
+  final String sourceUrl;
+
+  /// 内訳の補足(選挙別など)。
+  final String note;
+
+  const DpjFirstEndorsement({
+    required this.totalCount,
+    this.incumbentCount = 0,
+    this.newcomerCount = 0,
+    this.formerCount = 0,
+    required this.asOf,
+    required this.sourceUrl,
+    this.note = '',
+  });
+
+  /// 現職/新人/元の内訳が1つでも入力されているか。
+  bool get hasBreakdown =>
+      incumbentCount > 0 || newcomerCount > 0 || formerCount > 0;
+
+  /// 「現職11 / 新人19」形式の内訳ラベル(未入力の区分は省く)。
+  String get breakdownLabel {
+    final parts = <String>[
+      if (incumbentCount > 0) '現職$incumbentCount',
+      if (newcomerCount > 0) '新人$newcomerCount',
+      if (formerCount > 0) '元$formerCount',
+    ];
+    return parts.join(' / ');
+  }
+}
+
 class DpjPrefectureAnnouncedTarget {
   final String prefecture;
   final int minCount;
@@ -37,6 +89,9 @@ class DpjPrefectureAnnouncedTarget {
   final bool verified;
   final String note;
 
+  /// 県連が発表した第1次公認の実績(あれば)。
+  final DpjFirstEndorsement? firstEndorsement;
+
   const DpjPrefectureAnnouncedTarget({
     required this.prefecture,
     required this.minCount,
@@ -44,6 +99,7 @@ class DpjPrefectureAnnouncedTarget {
     required this.kind,
     this.verified = false,
     this.note = '',
+    this.firstEndorsement,
   }) : maxCount = maxCount ?? minCount;
 
   bool get isRange => maxCount > minCount;
@@ -112,8 +168,16 @@ const List<DpjPrefectureAnnouncedTarget> dpjPrefectureAnnouncedTargets =
     minCount: 50,
     kind: DpjAnnouncedTargetKind.candidateFielding,
     verified: true,
-    note: '50人以上の候補者擁立目標(当選50人の目標ではない)。'
-        '2026年6月25日時点で第1次公認30人(現職11・新人19)。',
+    note: '50人以上の候補者擁立目標(当選50人の目標ではない)。',
+    firstEndorsement: DpjFirstEndorsement(
+      totalCount: 30,
+      incumbentCount: 11,
+      newcomerCount: 19,
+      asOf: '2026-06-25',
+      sourceUrl: 'https://kokumin-kanagawa.jp/candidate/',
+      note: '県議 新人7 / 横浜市議 現職6・新人5 / 川崎市議 現職3・新人2 / '
+          '相模原市議 現職1 / その他 現職1・新人5',
+    ),
   ),
   DpjPrefectureAnnouncedTarget(
     prefecture: '山梨',
@@ -245,3 +309,42 @@ int get dpjAnnouncedTargetVerifiedCount =>
 int get dpjAnnouncedTargetUnconfirmedCount => dpjPrefectureAnnouncedTargets
     .where((item) => item.kind == DpjAnnouncedTargetKind.unconfirmed)
     .length;
+
+/// 国民民主党公式の「地方自治体各級選挙 公認・推薦予定候補者一覧」。
+/// 第1次公認の最新値はここが正本。県連の発表に合わせて手動で構造化し
+/// 反映する(このページの自動巡回対象ではない)。
+const String dpjLocalElectionOfficialListUrl =
+    'https://new-kokumin.jp/local-election-list';
+
+/// 上記公式一覧の最終確認時点(手動更新のたびに合わせる)。
+const String dpjLocalElectionOfficialListAsOf = '2026-07-08';
+
+/// 第1次公認を発表済みの都道府県(発表順ではなく掲載順)。
+List<DpjPrefectureAnnouncedTarget> get dpjPrefecturesWithFirstEndorsement =>
+    dpjPrefectureAnnouncedTargets
+        .where((item) => item.firstEndorsement != null)
+        .toList();
+
+/// 第1次公認を発表済みの都道府県数。
+int get dpjFirstEndorsementPrefectureCount =>
+    dpjPrefecturesWithFirstEndorsement.length;
+
+/// 全国の第1次公認 合計人数。
+int get dpjFirstEndorsementTotal => dpjPrefectureAnnouncedTargets.fold<int>(
+      0,
+      (sum, item) => sum + (item.firstEndorsement?.totalCount ?? 0),
+    );
+
+/// 全国の第1次公認 うち現職合計。
+int get dpjFirstEndorsementIncumbentTotal =>
+    dpjPrefectureAnnouncedTargets.fold<int>(
+      0,
+      (sum, item) => sum + (item.firstEndorsement?.incumbentCount ?? 0),
+    );
+
+/// 全国の第1次公認 うち新人合計。
+int get dpjFirstEndorsementNewcomerTotal =>
+    dpjPrefectureAnnouncedTargets.fold<int>(
+      0,
+      (sum, item) => sum + (item.firstEndorsement?.newcomerCount ?? 0),
+    );

--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -4757,6 +4757,10 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
               color: const Color(0xFFB45309),
               icon: Icons.warning_amber_rounded,
             ),
+            if (dpjFirstEndorsementPrefectureCount > 0) ...[
+              const SizedBox(height: 12),
+              _buildFirstEndorsementSummary(),
+            ],
             const SizedBox(height: 12),
             Align(
               alignment: Alignment.centerLeft,
@@ -4796,6 +4800,100 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
         ),
       ),
     );
+  }
+
+  // 第1次公認(県連が実際に公認を決めた候補予定者)の全国サマリー。
+  // 「擁立目標」とは別の実績値で、目標に対する進捗として示す。
+  // 数値は県連公式発表・報道を出典に手動で構造化し、更新元は党公式一覧。
+  Widget _buildFirstEndorsementSummary() {
+    const accent = Color(0xFF2563EB);
+    final incumbent = dpjFirstEndorsementIncumbentTotal;
+    final newcomer = dpjFirstEndorsementNewcomerTotal;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: accent.withValues(alpha: 0.18)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.how_to_reg_outlined, size: 18, color: accent),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '第1次公認の発表状況',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w800,
+                        color: accent,
+                      ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildMiniStatChip(
+                '公認合計',
+                dpjFirstEndorsementTotal,
+                color: accent,
+              ),
+              if (incumbent > 0)
+                _buildMiniStatChip(
+                  '現職',
+                  incumbent,
+                  color: const Color(0xFF0F766E),
+                ),
+              if (newcomer > 0)
+                _buildMiniStatChip(
+                  '新人',
+                  newcomer,
+                  color: const Color(0xFF7C3AED),
+                ),
+              _buildMiniStatChip(
+                '発表済み',
+                dpjFirstEndorsementPrefectureCount,
+                suffix: '県',
+                color: const Color(0xFF64748B),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '県連が第1次として公認を決めた候補予定者の実績です(擁立目標とは別)。'
+            '数値は県連公式発表・報道を出典に確認できたものだけを掲載しています。',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: OutlinedButton.icon(
+              onPressed: () => _openUrl(dpjLocalElectionOfficialListUrl),
+              icon: const Icon(Icons.open_in_new, size: 16),
+              label: Text(
+                '党公式の公認予定候補一覧を開く'
+                '(${_formatOfficialListAsOf(dpjLocalElectionOfficialListAsOf)}現在)',
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatOfficialListAsOf(String iso) {
+    final parsed = DateTime.tryParse(iso);
+    if (parsed == null) {
+      return iso;
+    }
+    return _dateOnlyFormat.format(parsed);
   }
 
   Widget _buildAnnouncedTargetPill(DpjPrefectureAnnouncedTarget item) {
@@ -4850,7 +4948,54 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
               ),
             ),
           ],
+          if (item.firstEndorsement case final endorsement?) ...[
+            const SizedBox(height: 8),
+            _buildFirstEndorsementBadge(endorsement),
+          ],
         ],
+      ),
+    );
+  }
+
+  // 県別ピル内の第1次公認バッジ。出典タップで県連発表ページを開く。
+  Widget _buildFirstEndorsementBadge(DpjFirstEndorsement endorsement) {
+    const badgeColor = Color(0xFF1D4ED8);
+    final breakdown =
+        endorsement.hasBreakdown ? ' (${endorsement.breakdownLabel})' : '';
+    return InkWell(
+      onTap: endorsement.sourceUrl.isEmpty
+          ? null
+          : () => _openUrl(endorsement.sourceUrl),
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: badgeColor.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: badgeColor.withValues(alpha: 0.25)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.how_to_reg_outlined, size: 14, color: badgeColor),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                '第1次公認 ${_formatInt(endorsement.totalCount)}人$breakdown',
+                style: const TextStyle(
+                  color: badgeColor,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  height: 1.3,
+                ),
+              ),
+            ),
+            if (endorsement.sourceUrl.isNotEmpty) ...[
+              const SizedBox(width: 4),
+              const Icon(Icons.open_in_new, size: 12, color: badgeColor),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/test/data/dpj_prefecture_announced_targets_test.dart
+++ b/test/data/dpj_prefecture_announced_targets_test.dart
@@ -89,4 +89,60 @@ void main() {
     expect(toyama.isRange, isFalse);
     expect(toyama.countLabel, '7人');
   });
+
+  test('第1次公認は神奈川に出典付きで構造化されている', () {
+    final kanagawa = dpjPrefectureAnnouncedTargets.firstWhere(
+      (item) => item.prefecture == '神奈川',
+    );
+    final endorsement = kanagawa.firstEndorsement;
+    expect(endorsement, isNotNull);
+    expect(endorsement!.totalCount, 30);
+    expect(endorsement.incumbentCount, 11);
+    expect(endorsement.newcomerCount, 19);
+    // 現職+新人が総数と一致する(内訳の整合性)。
+    expect(
+      endorsement.incumbentCount + endorsement.newcomerCount,
+      endorsement.totalCount,
+    );
+    expect(endorsement.hasBreakdown, isTrue);
+    expect(endorsement.breakdownLabel, '現職11 / 新人19');
+    // 捏造防止: 出典URLが必ず付いている。
+    expect(endorsement.sourceUrl, isNotEmpty);
+    expect(endorsement.asOf, '2026-06-25');
+  });
+
+  test('第1次公認の全国集計が県別データと一致する', () {
+    expect(dpjFirstEndorsementPrefectureCount, 1);
+    expect(dpjFirstEndorsementTotal, 30);
+    expect(dpjFirstEndorsementIncumbentTotal, 11);
+    expect(dpjFirstEndorsementNewcomerTotal, 19);
+    // 集計は県別 firstEndorsement の合計と一致する。
+    final manualTotal = dpjPrefectureAnnouncedTargets.fold<int>(
+      0,
+      (sum, item) => sum + (item.firstEndorsement?.totalCount ?? 0),
+    );
+    expect(dpjFirstEndorsementTotal, manualTotal);
+  });
+
+  test('第1次公認の出典を持つ県はすべて出典URLと基準日を持つ', () {
+    for (final item in dpjPrefecturesWithFirstEndorsement) {
+      final endorsement = item.firstEndorsement!;
+      expect(endorsement.sourceUrl, isNotEmpty, reason: item.prefecture);
+      expect(endorsement.asOf, isNotEmpty, reason: item.prefecture);
+      // 内訳を入れる場合は現職+新人+元 <= 総数(過大内訳を防ぐ)。
+      expect(
+        endorsement.incumbentCount +
+            endorsement.newcomerCount +
+            endorsement.formerCount,
+        lessThanOrEqualTo(endorsement.totalCount),
+        reason: item.prefecture,
+      );
+    }
+  });
+
+  test('党公式一覧URLと基準日が定義されている', () {
+    expect(dpjLocalElectionOfficialListUrl, startsWith('https://'));
+    expect(dpjLocalElectionOfficialListUrl, contains('new-kokumin.jp'));
+    expect(DateTime.tryParse(dpjLocalElectionOfficialListAsOf), isNotNull);
+  });
 }


### PR DESCRIPTION
## 概要

ユーザー要望「**1次公認などの情報はネット上にあがってきている。それを収集してこのページに反映できるか**」への対応。第1次公認 (県連が実際に公認を決めた候補予定者) を、擁立目標とは別の**実績値**として構造化し `/local-election-700` に反映します。

## 実データの収集 (捏造なし・全て出典付き)

Web調査で実データ経路を確認:
- **正本** = 国民民主党公式「[地方自治体各級選挙 公認・推薦予定候補者一覧](https://new-kokumin.jp/local-election-list)」(2026/07/08現在)。ただし Google Sheets 埋め込みで自動巡回は脆く誤収集リスクが高いため、**更新元リンクとして配線**し自動スクレイプはしない。
- 第1次公認を内訳付きで発表済み = **神奈川** (第1次公認30人 = 現職11 / 新人19、2026-06-25発表)。内訳: 県議 新人7 / 横浜市議 現職6・新人5 / 川崎市議 現職3・新人2 / 相模原市議 現職1 / その他 現職1・新人5。
  - 出典: [国民民主党神奈川県連 公認内定予定候補者](https://kokumin-kanagawa.jp/candidate/) / [産経報道](https://news.yahoo.co.jp/articles/10f1504aeea311022381cd90975e4b9910d9176a)

## 収集方式の選択 (ユーザー選択: A)

| 方式 | 判断 |
|------|------|
| **A: 出典付き手動キュレーション** | ✅ 採用。選挙データは正確さが最優先で、誤った自動収集値は「未確認」より有害。過去にこのリポジトリでも自動スクレイパを避けた判断あり。 |
| B: EF自動収集 | ❌ 党発表ページは Google Sheets 埋め込みで構造化フィードでなく壊れやすい (DOAリスク)。 |

更新元 (党公式一覧) へのリンクを配線したので、県連が発表するたび出典付きで1エントリ追加するだけで反映できます。

## 実装

### data (`dpj_prefecture_announced_targets.dart`)
- `DpjFirstEndorsement` 新設: `totalCount / incumbentCount / newcomerCount / formerCount / asOf / sourceUrl / note`。**出典URL・基準日を必須**とし、捏造・推測値を入れない方針をコメントで明示。
- `DpjPrefectureAnnouncedTarget` に `firstEndorsement` (optional) を追加。神奈川を反映し、自由文 note に埋もれていた「第1次公認30人(現職11・新人19)」を構造化フィールドへ移動。
- 全国集計 getter (`dpjFirstEndorsementTotal` / `...IncumbentTotal` / `...NewcomerTotal` / `...PrefectureCount`) + 党公式一覧URL・最終確認日の定数。

### UI (`election_victory_page.dart`)
- Road to 700 セクションに「**第1次公認の発表状況**」サマリーを追加 (合計30人 / 現職11 / 新人19 / 発表済み1県 + 「党公式の公認予定候補一覧を開く(2026/07/08現在)」リンク)。
- 県別ピルに**第1次公認バッジ** (人数 + 現職/新人内訳、タップで県連発表ページを開く)。

## 検証

- `flutter test test/data/dpj_prefecture_announced_targets_test.dart`: **11件全緑** (追加: 神奈川の内訳整合 `現職+新人=総数`・全国集計一致・**出典URL/基準日必須**・内訳が総数を超えない・公式URL妥当性)
- `flutter analyze` (page + data): `No issues found!`
- `dart format`: 適合済み

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 静的データ + 表示ウィジェットの追加で新規画面遷移なし。データ整合・集計・出典必須はデータテスト11件で検証、表示は既存 chip/badge パターン踏襲で analyze 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
