### PR TITLE
feat(asset): 月次キャッシュフローパネル (月収-月支出+累積) #2474

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -833,6 +833,15 @@ class AssetLiabilityMonthlySnapshot {
   final double monthlyPaymentDifferenceTotal;
   final int overduePaymentCount;
 
+  /// その月に受領済み (received=true) となった収入の合計。
+  ///
+  /// 収入は従来スナップショットに保存されておらず、旧データ / Supabase 同期分は
+  /// null (= 未追跡) になる。キャッシュフロー計算では null を「0 円の収入」と
+  /// 誤認すると全月が赤字に倒れるため、null の月は月次CF・黒字赤字カウントから
+  /// 除外する (= [AssetCashflowStatementService])。非 null の 0 は「収入 0 円」を
+  /// 意味し、追跡済みとして扱う。
+  final double? monthlyReceivedIncomeTotal;
+
   const AssetLiabilityMonthlySnapshot({
     required this.monthKey,
     required this.savedAt,
@@ -846,6 +855,7 @@ class AssetLiabilityMonthlySnapshot {
     this.monthlyActualPaymentTotal = 0,
     this.monthlyPaymentDifferenceTotal = 0,
     required this.overduePaymentCount,
+    this.monthlyReceivedIncomeTotal,
   });
 }
 

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -64,6 +64,7 @@ import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_triage_guide_service.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_inputs.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
+import 'package:my_web_app/services/asset_cashflow_statement_service.dart';
 import 'package:my_web_app/services/asset_category_budget_service.dart';
 import 'package:my_web_app/services/asset_category_budget_store.dart';
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
@@ -91,6 +92,7 @@ import 'package:my_web_app/services/waste_tracking_service.dart';
 import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
+import 'package:my_web_app/widgets/asset_cashflow_statement_card.dart';
 import 'package:my_web_app/widgets/asset_category_budget_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
@@ -8727,6 +8729,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               const SizedBox(height: 16),
               _buildCashflowForecastCard(assetLiabilityWorkbook),
             ],
+            if (_isSectionShown(
+              AssetManagementSectionId.cashflowStatement,
+            )) ...[
+              _buildCashflowStatementCard(assetLiabilityWorkbook),
+            ],
             // 提案カード(定期取引/定期収入の自動検出)は給与内訳に相乗りせず専用
             // セクションへ。salaryBreakdown を隠しても提案だけ独立表示できる。
             if (_isSectionShown(AssetManagementSectionId.proposals)) ...[
@@ -14220,6 +14227,38 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         onHorizonChanged: (months) =>
             setState(() => _forecastHorizonMonths = months),
         onReviewPaymentDays: () => _scrollTo(_keyCalendar),
+      ),
+    );
+  }
+
+  /// 月次キャッシュフローパネル (Issue #2474)。履歴スナップショット + ライブの当月から
+  /// 「当月CF (月収 − 月支出)」「年初来累積CF」「直近12か月の黒字/赤字月数」を集計する。
+  /// 金額計算は純サービス [AssetCashflowStatementService] で deterministic に行う。
+  Widget _buildCashflowStatementCard(AssetLiabilityWorkbook? workbook) {
+    // ライブの当月スナップショットを履歴サービスで生成し、未保存でも当月CFを反映する。
+    AssetLiabilityMonthlySnapshot? currentMonthSnapshot;
+    if (workbook != null) {
+      final monthKey =
+          AssetLiabilityMonthlyStateStore.formatMonthKey(DateTime.now());
+      currentMonthSnapshot = _assetLiabilityHistoryService.buildSnapshot(
+        monthKey: monthKey,
+        workbook: workbook,
+        savedAt: DateTime.now(),
+      );
+    }
+    final statement = const AssetCashflowStatementService().build(
+      snapshots: _monthlySnapshots,
+      currentMonthSnapshot: currentMonthSnapshot,
+      asOf: DateTime.now(),
+    );
+    if (!statement.hasData) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: AssetCashflowStatementCard(
+        statement: statement,
+        currencyFormatter: _formatYen,
       ),
     );
   }

--- a/lib/services/asset_cashflow_statement_service.dart
+++ b/lib/services/asset_cashflow_statement_service.dart
@@ -1,0 +1,221 @@
+import '../models/asset_liability_workbook.dart';
+
+/// 1 か月分のキャッシュフロー (収入 − 支出) を表すビュー。
+///
+/// [income] が null の月は収入が未追跡 (旧スナップショット / Supabase 同期分)
+/// であり、支出だけを 0 円収入とみなすと赤字に倒れて誤誘導になるため、
+/// [cashflow] も null を返し、累積・黒字/赤字カウントから除外される。
+class AssetCashflowMonth {
+  /// `yyyy-MM` 形式。
+  final String monthKey;
+
+  /// その月に受領済みとなった収入合計。null = 未追跡。
+  final double? income;
+
+  /// その月に実際に支払った支出合計 (paid payment total)。
+  final double expense;
+
+  const AssetCashflowMonth({
+    required this.monthKey,
+    required this.income,
+    required this.expense,
+  });
+
+  /// 収入が追跡されているか (0 円でも追跡済みなら true)。
+  bool get hasIncome => income != null;
+
+  /// 当月キャッシュフロー。収入未追跡なら null。
+  double? get cashflow => income == null ? null : income! - expense;
+
+  /// 黒字 (CF >= 0)。未追跡月は false。
+  bool get isSurplus {
+    final value = cashflow;
+    return value != null && value >= 0;
+  }
+
+  /// 赤字 (CF < 0)。未追跡月は false。
+  bool get isDeficit {
+    final value = cashflow;
+    return value != null && value < 0;
+  }
+
+  int get year => int.tryParse(monthKey.split('-').first) ?? 0;
+}
+
+/// キャッシュフローパネル (Issue #2474) の集計結果。
+class AssetCashflowStatement {
+  /// monthKey 昇順。
+  final List<AssetCashflowMonth> months;
+
+  /// asOf の当月 (存在する場合)。
+  final AssetCashflowMonth? currentMonth;
+
+  /// 年初来 (同一暦年・当月まで) の累積キャッシュフロー。追跡済み月のみ加算。
+  final double yearToDateCashflow;
+
+  /// 年初来で収入が追跡されていた月数。
+  final int yearToDateTrackedMonths;
+
+  /// 年初来で収入が未追跡だった月数 (= 累積から除外した月数)。
+  final int yearToDateUntrackedMonths;
+
+  /// 直近ウィンドウ内で黒字だった月数。
+  final int surplusMonthCount;
+
+  /// 直近ウィンドウ内で赤字だった月数。
+  final int deficitMonthCount;
+
+  /// 直近ウィンドウ内で収入が追跡されていた月数 (= surplus + deficit)。
+  final int trackedMonthCount;
+
+  /// 黒字/赤字カウントの対象ウィンドウ月数 (既定 12)。
+  final int windowMonths;
+
+  const AssetCashflowStatement({
+    required this.months,
+    required this.currentMonth,
+    required this.yearToDateCashflow,
+    required this.yearToDateTrackedMonths,
+    required this.yearToDateUntrackedMonths,
+    required this.surplusMonthCount,
+    required this.deficitMonthCount,
+    required this.trackedMonthCount,
+    required this.windowMonths,
+  });
+
+  static const AssetCashflowStatement empty = AssetCashflowStatement(
+    months: <AssetCashflowMonth>[],
+    currentMonth: null,
+    yearToDateCashflow: 0,
+    yearToDateTrackedMonths: 0,
+    yearToDateUntrackedMonths: 0,
+    surplusMonthCount: 0,
+    deficitMonthCount: 0,
+    trackedMonthCount: 0,
+    windowMonths: AssetCashflowStatementService.trailingWindowMonths,
+  );
+
+  double? get currentMonthCashflow => currentMonth?.cashflow;
+
+  bool get hasCurrentMonthCashflow => currentMonth?.hasIncome ?? false;
+
+  bool get hasData => currentMonth != null || months.isNotEmpty;
+
+  /// 年初来に収入未追跡の月が含まれているか (UI の注意書き用)。
+  bool get hasUntrackedYearToDateMonths => yearToDateUntrackedMonths > 0;
+}
+
+/// 月次スナップショットから決定論的にキャッシュフローパネルを組み立てる純サービス。
+///
+/// - 金額計算はすべてローカルで deterministic に行い、AI は関与しない。
+/// - 収入が未追跡 (null) の月は月次CF・累積・黒字/赤字カウントから除外し、
+///   支出だけを 0 円収入とみなして赤字に倒すことを防ぐ。
+class AssetCashflowStatementService {
+  const AssetCashflowStatementService();
+
+  /// 黒字/赤字カウントの対象とする直近月数。
+  static const int trailingWindowMonths = 12;
+
+  /// [snapshots] (履歴) と、任意で [currentMonthSnapshot] (ライブの当月; 未保存でも
+  /// 反映するため別引数) からキャッシュフローパネルを構築する。
+  ///
+  /// [currentMonthSnapshot] は同一 monthKey の履歴スナップショットより優先される
+  /// (ライブの方が新しいため)。
+  AssetCashflowStatement build({
+    required List<AssetLiabilityMonthlySnapshot> snapshots,
+    AssetLiabilityMonthlySnapshot? currentMonthSnapshot,
+    required DateTime asOf,
+  }) {
+    final byMonth = <String, AssetCashflowMonth>{};
+    for (final snapshot in snapshots) {
+      final key = snapshot.monthKey.trim();
+      if (key.isEmpty) {
+        continue;
+      }
+      byMonth[key] = AssetCashflowMonth(
+        monthKey: key,
+        income: snapshot.monthlyReceivedIncomeTotal,
+        expense: snapshot.monthlyPaidPaymentTotal,
+      );
+    }
+
+    final currentMonthKey = _formatMonthKey(asOf);
+    if (currentMonthSnapshot != null) {
+      final key = currentMonthSnapshot.monthKey.trim().isEmpty
+          ? currentMonthKey
+          : currentMonthSnapshot.monthKey.trim();
+      byMonth[key] = AssetCashflowMonth(
+        monthKey: key,
+        income: currentMonthSnapshot.monthlyReceivedIncomeTotal,
+        expense: currentMonthSnapshot.monthlyPaidPaymentTotal,
+      );
+    }
+
+    final months = byMonth.values.toList()
+      ..sort((a, b) => a.monthKey.compareTo(b.monthKey));
+
+    final currentMonth = byMonth[currentMonthKey];
+
+    // 年初来累積 (同一暦年・当月まで)。
+    var ytdCashflow = 0.0;
+    var ytdTracked = 0;
+    var ytdUntracked = 0;
+    for (final month in months) {
+      if (month.year != asOf.year) {
+        continue;
+      }
+      if (month.monthKey.compareTo(currentMonthKey) > 0) {
+        continue; // 未来月は除外 (安全側)。
+      }
+      if (month.hasIncome) {
+        ytdCashflow += month.cashflow!;
+        ytdTracked += 1;
+      } else {
+        ytdUntracked += 1;
+      }
+    }
+
+    // 直近ウィンドウの黒字/赤字カウント。
+    final windowStartKey = _formatMonthKey(
+      DateTime(asOf.year, asOf.month - (trailingWindowMonths - 1)),
+    );
+    var surplus = 0;
+    var deficit = 0;
+    var tracked = 0;
+    for (final month in months) {
+      if (month.monthKey.compareTo(windowStartKey) < 0) {
+        continue;
+      }
+      if (month.monthKey.compareTo(currentMonthKey) > 0) {
+        continue;
+      }
+      if (!month.hasIncome) {
+        continue;
+      }
+      tracked += 1;
+      if (month.isSurplus) {
+        surplus += 1;
+      } else {
+        deficit += 1;
+      }
+    }
+
+    return AssetCashflowStatement(
+      months: months,
+      currentMonth: currentMonth,
+      yearToDateCashflow: ytdCashflow,
+      yearToDateTrackedMonths: ytdTracked,
+      yearToDateUntrackedMonths: ytdUntracked,
+      surplusMonthCount: surplus,
+      deficitMonthCount: deficit,
+      trackedMonthCount: tracked,
+      windowMonths: trailingWindowMonths,
+    );
+  }
+
+  static String _formatMonthKey(DateTime date) {
+    final normalized = DateTime(date.year, date.month);
+    final month = normalized.month.toString().padLeft(2, '0');
+    return '${normalized.year}-$month';
+  }
+}

--- a/lib/services/asset_liability_history_service.dart
+++ b/lib/services/asset_liability_history_service.dart
@@ -26,6 +26,13 @@ class AssetLiabilityHistoryService {
     final overduePaymentCount = workbook.cashflowRows
         .where((row) => row.isPayment && row.overdue)
         .length;
+    // その月に受領済みとなった収入合計。income plan の received=true 分を集計する。
+    // 現金収支 (income − expense) の income 側を月次スナップショットに保存し、
+    // 過去月のキャッシュフローパネルを再構成できるようにする (Issue #2474)。
+    final receivedIncomeTotal = workbook.incomePlans.fold<double>(
+      0,
+      (sum, plan) => plan.received ? sum + plan.amount : sum,
+    );
 
     return AssetLiabilityMonthlySnapshot(
       monthKey: monthKey,
@@ -40,6 +47,7 @@ class AssetLiabilityHistoryService {
       monthlyActualPaymentTotal: workbook.monthlyActualPaymentTotal,
       monthlyPaymentDifferenceTotal: paymentDifferenceTotal,
       overduePaymentCount: overduePaymentCount,
+      monthlyReceivedIncomeTotal: receivedIncomeTotal,
     );
   }
 

--- a/lib/services/asset_liability_monthly_state_store.dart
+++ b/lib/services/asset_liability_monthly_state_store.dart
@@ -1266,6 +1266,10 @@ class AssetLiabilityMonthlyStateStore {
       final overduePaymentCount = _parseNonNullInt(
         rawSnapshot['overduePaymentCount'],
       );
+      // キー欠落は null (= 収入未追跡) のまま保持し、0 円収入と区別する。
+      final monthlyReceivedIncomeTotal = _parseNonNullDouble(
+        rawSnapshot['monthlyReceivedIncomeTotal'],
+      );
       if (monthKey == null ||
           monthKey.isEmpty ||
           savedAt == null ||
@@ -1294,6 +1298,7 @@ class AssetLiabilityMonthlyStateStore {
               monthlyActualPaymentTotal ?? monthlyPaidPaymentTotal,
           monthlyPaymentDifferenceTotal: monthlyPaymentDifferenceTotal ?? 0,
           overduePaymentCount: overduePaymentCount,
+          monthlyReceivedIncomeTotal: monthlyReceivedIncomeTotal,
         ),
       );
     }
@@ -1669,6 +1674,9 @@ class AssetLiabilityMonthlyStateStore {
           'monthlyPaymentDifferenceTotal':
               snapshot.monthlyPaymentDifferenceTotal,
           'overduePaymentCount': snapshot.overduePaymentCount,
+          // null (= 収入未追跡) はキーを書かず、旧データと区別できるようにする。
+          if (snapshot.monthlyReceivedIncomeTotal != null)
+            'monthlyReceivedIncomeTotal': snapshot.monthlyReceivedIncomeTotal,
         },
     ];
   }

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -31,6 +31,7 @@ enum AssetManagementSectionId {
   subscriptions,
   mustTasks,
   chart,
+  cashflowStatement,
 }
 
 /// セクション単位の表示上書き。auto はティア×モードの既定に従う。
@@ -109,6 +110,8 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
         return '必須タスク(⑤)';
       case AssetManagementSectionId.chart:
         return 'グラフ';
+      case AssetManagementSectionId.cashflowStatement:
+        return '月次キャッシュフロー';
     }
   }
 
@@ -135,6 +138,8 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
         return AssetManagementSectionTier.standard;
       case AssetManagementSectionId.wasteAi:
       case AssetManagementSectionId.chart:
+      // 新規パネルは段階的 rollout のため full モード限定 (= OFF by default)。
+      case AssetManagementSectionId.cashflowStatement:
         return AssetManagementSectionTier.full;
     }
   }

--- a/lib/widgets/asset_cashflow_statement_card.dart
+++ b/lib/widgets/asset_cashflow_statement_card.dart
@@ -1,0 +1,349 @@
+import 'package:flutter/material.dart';
+
+import '../services/asset_cashflow_statement_service.dart';
+
+/// 月次キャッシュフローパネル (Issue #2474)。
+///
+/// 純サービス [AssetCashflowStatementService] の集計結果
+/// ([AssetCashflowStatement]) を受け取り、
+/// 「当月CF (月収 − 月支出)」「年初来累積CF」「直近12か月の黒字/赤字月数」を
+/// 描画する自己完結ウィジェット。ページ状態へ依存しないため単体検証できる。
+class AssetCashflowStatementCard extends StatelessWidget {
+  const AssetCashflowStatementCard({
+    super.key,
+    required this.statement,
+    this.currencyFormatter,
+    this.recentMonthsToShow = 6,
+  });
+
+  final AssetCashflowStatement statement;
+
+  /// 金額整形 (ページの `_formatYen` を渡す)。null なら簡易整形。
+  final String Function(double value)? currencyFormatter;
+
+  /// 明細に表示する直近月数。
+  final int recentMonthsToShow;
+
+  static const Color _accent = Color(0xFF4F46E5);
+  static const Color _danger = Color(0xFFDC2626);
+  static const Color _safe = Color(0xFF059669);
+  static const Color _muted = Color(0xFF6B7280);
+
+  String _yen(double value) {
+    final formatter = currencyFormatter;
+    if (formatter != null) {
+      return formatter(value);
+    }
+    return '¥${value.round()}';
+  }
+
+  /// 符号付き整形 (黒字 +, 赤字 −)。
+  String _signedYen(double value) {
+    final sign = value >= 0 ? '+' : '-';
+    return '$sign${_yen(value.abs())}';
+  }
+
+  Color _cashflowColor(double? value) {
+    if (value == null) {
+      return _muted;
+    }
+    return value >= 0 ? _safe : _danger;
+  }
+
+  String _monthLabel(String monthKey) {
+    final parts = monthKey.split('-');
+    if (parts.length < 2) {
+      return monthKey;
+    }
+    final month = int.tryParse(parts[1]);
+    if (month == null) {
+      return monthKey;
+    }
+    return '$month月';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (!statement.hasData) {
+      return const SizedBox.shrink();
+    }
+
+    return Card(
+      key: const Key('asset_cashflow_statement_card'),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(
+                  Icons.account_balance_wallet_outlined,
+                  color: _accent,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '月次キャッシュフロー',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '月収 − 月支出 = 当月キャッシュフロー',
+              style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+            ),
+            const SizedBox(height: 16),
+            _buildCurrentMonth(theme),
+            const SizedBox(height: 16),
+            _buildSummaryRow(theme),
+            if (statement.months.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              _buildRecentMonths(theme),
+            ],
+            if (statement.hasUntrackedYearToDateMonths) ...[
+              const SizedBox(height: 12),
+              _buildUntrackedNote(theme),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCurrentMonth(ThemeData theme) {
+    final current = statement.currentMonth;
+    final cashflow = statement.currentMonthCashflow;
+    final label = current == null ? '当月' : _monthLabel(current.monthKey);
+
+    if (current == null || !statement.hasCurrentMonthCashflow) {
+      return Container(
+        key: const Key('asset_cashflow_statement_current_untracked'),
+        width: double.infinity,
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: _muted.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          '$label の収入データが未登録のため当月キャッシュフローを計算できません。'
+          '収入予定を「受領済み」にすると集計されます。',
+          style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+        ),
+      );
+    }
+
+    return Container(
+      key: const Key('asset_cashflow_statement_current'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: _cashflowColor(cashflow).withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: _cashflowColor(cashflow).withValues(alpha: 0.3),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '$label のキャッシュフロー',
+            style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            _signedYen(cashflow!),
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: _cashflowColor(cashflow),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              _buildInlineFigure(theme, '収入', _yen(current.income!), _safe),
+              const SizedBox(width: 16),
+              _buildInlineFigure(theme, '支出', _yen(current.expense), _danger),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInlineFigure(
+    ThemeData theme,
+    String label,
+    String value,
+    Color color,
+  ) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '$label ',
+          style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+        ),
+        Text(
+          value,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: color,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSummaryRow(ThemeData theme) {
+    return Row(
+      children: [
+        Expanded(
+          child: _buildStatTile(
+            theme,
+            key: const Key('asset_cashflow_statement_ytd'),
+            label: '年初来累積CF',
+            value: _signedYen(statement.yearToDateCashflow),
+            valueColor: _cashflowColor(statement.yearToDateCashflow),
+            caption: '${statement.yearToDateTrackedMonths}か月分',
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: _buildStatTile(
+            theme,
+            key: const Key('asset_cashflow_statement_counts'),
+            label: '直近${statement.windowMonths}か月',
+            value: '黒字 ${statement.surplusMonthCount} / '
+                '赤字 ${statement.deficitMonthCount}',
+            valueColor:
+                statement.surplusMonthCount >= statement.deficitMonthCount
+                    ? _safe
+                    : _danger,
+            caption: '集計 ${statement.trackedMonthCount}か月',
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStatTile(
+    ThemeData theme, {
+    required Key key,
+    required String label,
+    required String value,
+    required Color valueColor,
+    required String caption,
+  }) {
+    return Container(
+      key: key,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: _muted.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: valueColor,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            caption,
+            style: theme.textTheme.labelSmall?.copyWith(color: _muted),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRecentMonths(ThemeData theme) {
+    final months = statement.months.reversed
+        .take(recentMonthsToShow)
+        .toList(growable: false);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '月別明細',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: _muted,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        for (final month in months) _buildMonthRow(theme, month),
+      ],
+    );
+  }
+
+  Widget _buildMonthRow(ThemeData theme, AssetCashflowMonth month) {
+    final cashflow = month.cashflow;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 48,
+            child: Text(
+              _monthLabel(month.monthKey),
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+          Expanded(
+            child: cashflow == null
+                ? Text(
+                    '収入未登録',
+                    style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+                  )
+                : Text(
+                    '収入 ${_yen(month.income!)} / 支出 ${_yen(month.expense)}',
+                    style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+                  ),
+          ),
+          Text(
+            cashflow == null ? '—' : _signedYen(cashflow),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: _cashflowColor(cashflow),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUntrackedNote(ThemeData theme) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Icon(Icons.info_outline, size: 16, color: _muted),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            '収入が未登録の月 (${statement.yearToDateUntrackedMonths}か月) は'
+            '累積・黒字/赤字カウントから除外しています。',
+            style: theme.textTheme.labelSmall?.copyWith(color: _muted),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/supabase/functions/admin-hub/auto_error_reports_test.ts
+++ b/supabase/functions/admin-hub/auto_error_reports_test.ts
@@ -5,7 +5,8 @@ import {
 } from "./auto_error_reports.ts";
 
 Deno.test("extractAutoErrorFirstLine: ヘッダ行を飛ばし最初の意味行を返す", () => {
-  const msg = "[自動エラー報告]\nNull check operator used on a null value\n\n#0 foo\n#1 bar";
+  const msg =
+    "[自動エラー報告]\nNull check operator used on a null value\n\n#0 foo\n#1 bar";
   assertEquals(
     extractAutoErrorFirstLine(msg),
     "Null check operator used on a null value",

--- a/test/services/asset_cashflow_statement_service_test.dart
+++ b/test/services/asset_cashflow_statement_service_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_cashflow_statement_service.dart';
+
+AssetLiabilityMonthlySnapshot _snapshot(
+  String monthKey, {
+  double? income,
+  double expense = 0,
+}) {
+  return AssetLiabilityMonthlySnapshot(
+    monthKey: monthKey,
+    savedAt: DateTime(2026, 1, 1),
+    positiveAssetTotal: 0,
+    liabilityTotal: 0,
+    netWorth: 0,
+    cashLikeTotal: 0,
+    monthlyScheduledPaymentTotal: 0,
+    monthlyPaidPaymentTotal: expense,
+    monthlyUnpaidPaymentTotal: 0,
+    overduePaymentCount: 0,
+    monthlyReceivedIncomeTotal: income,
+  );
+}
+
+void main() {
+  const service = AssetCashflowStatementService();
+
+  group('AssetCashflowStatementService.build', () {
+    test('empty snapshots produce no data', () {
+      final statement = service.build(
+        snapshots: const <AssetLiabilityMonthlySnapshot>[],
+        asOf: DateTime(2026, 7, 15),
+      );
+      expect(statement.hasData, isFalse);
+      expect(statement.currentMonth, isNull);
+      expect(statement.yearToDateCashflow, 0);
+    });
+
+    test('current month cashflow = income - expense', () {
+      final statement = service.build(
+        snapshots: [
+          _snapshot('2026-07', income: 400000, expense: 250000),
+        ],
+        asOf: DateTime(2026, 7, 15),
+      );
+      expect(statement.hasCurrentMonthCashflow, isTrue);
+      expect(statement.currentMonthCashflow, 150000);
+      expect(statement.currentMonth!.isSurplus, isTrue);
+    });
+
+    test('current month snapshot overrides same-month history (fresher)', () {
+      final statement = service.build(
+        snapshots: [
+          _snapshot('2026-07', income: 100000, expense: 100000),
+        ],
+        currentMonthSnapshot:
+            _snapshot('2026-07', income: 400000, expense: 250000),
+        asOf: DateTime(2026, 7, 15),
+      );
+      expect(statement.currentMonthCashflow, 150000);
+    });
+
+    test('year-to-date accumulates only same-year tracked months', () {
+      final statement = service.build(
+        snapshots: [
+          // 前年は除外される。
+          _snapshot('2025-12', income: 999999, expense: 0),
+          _snapshot('2026-01', income: 300000, expense: 200000), // +100k
+          _snapshot('2026-02', income: 300000, expense: 350000), // -50k
+          _snapshot('2026-07', income: 400000, expense: 250000), // +150k
+        ],
+        asOf: DateTime(2026, 7, 15),
+      );
+      expect(statement.yearToDateCashflow, 200000);
+      expect(statement.yearToDateTrackedMonths, 3);
+      expect(statement.yearToDateUntrackedMonths, 0);
+    });
+
+    test('untracked income month is excluded from YTD, not treated as 0', () {
+      final statement = service.build(
+        snapshots: [
+          _snapshot('2026-01', income: null, expense: 200000), // 除外
+          _snapshot('2026-02', income: 300000, expense: 100000), // +200k
+        ],
+        asOf: DateTime(2026, 2, 15),
+      );
+      // 未追跡月を 0 円収入とみなすと -200k が混ざり +0 になるが、除外するので +200k。
+      expect(statement.yearToDateCashflow, 200000);
+      expect(statement.yearToDateTrackedMonths, 1);
+      expect(statement.yearToDateUntrackedMonths, 1);
+      expect(statement.hasUntrackedYearToDateMonths, isTrue);
+    });
+
+    test('surplus/deficit counts over trailing 12 months, tracked only', () {
+      final statement = service.build(
+        snapshots: [
+          _snapshot('2026-01', income: 300000, expense: 100000), // 黒字
+          _snapshot('2026-02', income: 100000, expense: 300000), // 赤字
+          _snapshot('2026-03', income: null, expense: 300000), // 未追跡→除外
+          _snapshot('2026-04',
+              income: 200000, expense: 200000), // 黒字(0はsurplus)
+        ],
+        asOf: DateTime(2026, 4, 15),
+      );
+      expect(statement.surplusMonthCount, 2);
+      expect(statement.deficitMonthCount, 1);
+      expect(statement.trackedMonthCount, 3);
+      expect(statement.windowMonths, 12);
+    });
+
+    test('months older than trailing window are excluded from counts', () {
+      final statement = service.build(
+        snapshots: [
+          _snapshot('2025-06', income: 100000, expense: 300000), // 13か月前→除外
+          _snapshot('2025-08', income: 300000, expense: 100000), // 窓内
+          _snapshot('2026-07', income: 300000, expense: 100000), // 当月
+        ],
+        asOf: DateTime(2026, 7, 15),
+      );
+      // 窓は 2025-08..2026-07。2025-06 は除外。
+      expect(statement.surplusMonthCount, 2);
+      expect(statement.deficitMonthCount, 0);
+    });
+
+    test('future months are excluded from YTD (safety)', () {
+      final statement = service.build(
+        snapshots: [
+          _snapshot('2026-01', income: 300000, expense: 100000), // +200k
+          _snapshot('2026-12', income: 999999, expense: 0), // 未来→除外
+        ],
+        asOf: DateTime(2026, 7, 15),
+      );
+      expect(statement.yearToDateCashflow, 200000);
+      expect(statement.yearToDateTrackedMonths, 1);
+    });
+
+    test('months are sorted ascending by monthKey', () {
+      final statement = service.build(
+        snapshots: [
+          _snapshot('2026-03', income: 0, expense: 0),
+          _snapshot('2026-01', income: 0, expense: 0),
+          _snapshot('2026-02', income: 0, expense: 0),
+        ],
+        asOf: DateTime(2026, 3, 15),
+      );
+      expect(
+        statement.months.map((m) => m.monthKey).toList(),
+        ['2026-01', '2026-02', '2026-03'],
+      );
+    });
+
+    test('current month with untracked income cannot compute cashflow', () {
+      final statement = service.build(
+        snapshots: [
+          _snapshot('2026-07', income: null, expense: 250000),
+        ],
+        asOf: DateTime(2026, 7, 15),
+      );
+      expect(statement.currentMonth, isNotNull);
+      expect(statement.hasCurrentMonthCashflow, isFalse);
+      expect(statement.currentMonthCashflow, isNull);
+    });
+  });
+}

--- a/test/services/asset_cashflow_statement_service_test.dart
+++ b/test/services/asset_cashflow_statement_service_test.dart
@@ -97,8 +97,11 @@ void main() {
           _snapshot('2026-01', income: 300000, expense: 100000), // 黒字
           _snapshot('2026-02', income: 100000, expense: 300000), // 赤字
           _snapshot('2026-03', income: null, expense: 300000), // 未追跡→除外
-          _snapshot('2026-04',
-              income: 200000, expense: 200000), // 黒字(0はsurplus)
+          _snapshot(
+            '2026-04',
+            income: 200000,
+            expense: 200000,
+          ), // 黒字(0はsurplus)
         ],
         asOf: DateTime(2026, 4, 15),
       );


### PR DESCRIPTION
## 概要
Issue #2474 (第2弾C)。資産管理ページに「月次キャッシュフロー」パネルを追加する。

- **当月CF** = 当月収入 − 当月支出
- **年初来累積CF** (同一暦年・当月まで)
- **直近12か月の黒字/赤字月数**

## 実装
- 純サービス `AssetCashflowStatementService` で金額計算を **deterministic** に実施 (AIは非関与 / issue 注意事項準拠)。ウィジェット `AssetCashflowStatementCard` は自己完結で単体検証可能。
- 収入履歴を月次スナップショット (`AssetLiabilityMonthlySnapshot.monthlyReceivedIncomeTotal`, **nullable**) に追加。ローカル schemaless ストアのみに永続化し **Supabase シリアライズは非変更** → 未知列 upsert によるクロスデバイス同期の破壊を回避。
- 履歴サービスの `buildSnapshot` で受領済み income plan を集計して保存。

## 安全性 (敵対レビュー観点)
- **収入未追跡 (null) の月を「0円収入」と誤認しない**: null の月は月次CF・年初来累積・黒字/赤字カウントから**除外**する (支出だけで全月赤字に倒す誤誘導を防止)。非nullの0は「収入0円」として追跡済み扱い。UI に除外月数の注意書きを表示。
- 未来月は年初来累積から除外 (安全側)。
- 直近12か月ウィンドウは年跨ぎを正しく処理 (DateTime 月アンダーフロー正規化)。

## 受け入れ条件
- [x] 既存資産管理機能を壊さない (#2446-#2456 整合 / スナップショット追加フィールドは後方互換 nullable)
- [x] テスト緑 (新規 unit 10件 + 既存 history/state_store/report テスト 38件 pass、変更ファイル analyze 0 / format clean)
- [x] feature flag OFF default + 段階的 rollout: セクション tier=`full` 限定 (= 既定非表示、フルモード/ピンで opt-in)

## テスト
`test/services/asset_cashflow_statement_service_test.dart` — 境界網羅: 未追跡除外 / 前年除外 / 未来除外 / 12か月窓 / 当月スナップショット上書き / ソート / 当月未追跡。

Closes #2474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 読み取り専用の集計表示パネルで full モード限定 (既定OFF)。決定論的な集計ロジックは表示層非依存の unit テスト10件で境界網羅済みのため、複数月スナップショットを seed する integration_test は不均衡

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 唯一のEF差分はci-auto-fix.ymlによるdeno fmtの行折り返しのみでロジック変更なし。機能本体はlib/のUI/サービスとunit10件で表示層非依存に検証済み
