### PR TITLE
fix(admin): ダッシュボードの捏造/空表示を正直化 (10仮説検証 第6弾 part340)

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -4341,9 +4341,11 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                                               BorderRadius.circular(6),
                                         ),
                                         child: Text(
-                                          isGoogle
-                                              ? 'Google'
-                                              : (isAnonymous ? '匿名' : 'Email'),
+                                          // R30: edge users.list は provider を
+                                          // 返さない → isGoogle は常に false で
+                                          // 全員 'Email' と誤表示していた。
+                                          // 判別不能なので中立の '登録済' にする。
+                                          isAnonymous ? '匿名' : '登録済',
                                           style: TextStyle(
                                             fontSize: 10,
                                             fontWeight: FontWeight.w600,
@@ -6126,9 +6128,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
         isDark ? const Color(0xFF2A3A55) : const Color(0xFFE2E8F0);
 
     final totalTouches = _comparisonTouches.values.fold(0, (a, b) => a + b);
-    final cvrPct = totalTouches > 0
-        ? (_comparisonSignups / totalTouches * 100).toStringAsFixed(1)
-        : '0.0';
+    // R30: 母数0で「0.0%」は計測した0%に見える捏造 → ダッシュボード共通の
+    // formatRatePercent(母数0=「—」)に揃える。到達0で登録>0の自己矛盾表示も回避。
+    final cvrLabel = formatRatePercent(_comparisonSignups, totalTouches);
 
     final sorted = _comparisonTouches.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
@@ -6185,7 +6187,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                 const Color(0xFF059669),
               ),
               const SizedBox(width: 16),
-              _cvrStat('CVR', '$cvrPct%', const Color(0xFFFF6B35)),
+              _cvrStat('CVR', cvrLabel, const Color(0xFFFF6B35)),
             ],
           ),
           const SizedBox(height: 12),
@@ -6807,7 +6809,20 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                 height: 1.6,
               ),
             )
-          else if (_growthSummary != null) ...[
+          // R30: 期待するメトリクスキーが無いレスポンス(achievement.list は
+          // items のみ返す)では捏造ゼロを出さず、集計未接続を正直に示す。
+          else if (!growthSummaryHasMetrics(_growthSummary) &&
+              !_growthSummaryLoading)
+            const Text(
+              '成長サマリーの集計はまだ接続されていません。'
+              '各カード(登録目標・累計登録・比較CVR等)で実数をご確認ください。',
+              style: TextStyle(
+                fontSize: 13,
+                color: Color(0xFF94A3B8),
+                height: 1.6,
+              ),
+            )
+          else if (growthSummaryHasMetrics(_growthSummary)) ...[
             Text(
               '期間: ${_growthSummary!['label'] ?? 'すべて'}',
               style: const TextStyle(

--- a/lib/pages/admin_dashboard_signals.dart
+++ b/lib/pages/admin_dashboard_signals.dart
@@ -464,3 +464,21 @@ String autoErrorReportsHealthLabel(int count) {
   if (count <= 0) return '自動エラー報告なし（正常）';
   return '自動エラー報告 $count件';
 }
+
+// R30: 成長実績サマリーカードは growth-hub `achievement.list` を呼ぶが、この
+// action は {success, items:[]} を返すだけで newUsers/totalUsersEver/
+// acquisitionSignals/referralsCompleted/importPreviews を一切返さない。カードは
+// それらのキーを `?? 0` で読むため、実データがあっても常に「0人/0件」を捏造表示
+// していた。集計 action が未実装なので、期待キーが無いレスポンスを「集計未接続」
+// として扱い、捏造ゼロを出さないためのガード。
+bool growthSummaryHasMetrics(Map<String, dynamic>? summary) {
+  if (summary == null) return false;
+  const metricKeys = [
+    'newUsers',
+    'totalUsersEver',
+    'acquisitionSignals',
+    'referralsCompleted',
+    'importPreviews',
+  ];
+  return metricKeys.any(summary.containsKey);
+}

--- a/lib/services/growth_mission_service.dart
+++ b/lib/services/growth_mission_service.dart
@@ -1165,7 +1165,12 @@ $inviteUrl
         throw Exception(data['error']?.toString() ?? 'Weekly digest failed.');
       }
 
-      return WeeklyDigestSnapshot.fromJson(data);
+      // R30: edge は {success, digest:{currentWeek,...}} と nested で返す。
+      // 兄弟の command-center brief (data['brief']) は unwrap しているのに
+      // ここだけ top-level を渡していたため fromJson が全キー null →
+      // currentWeekStart='' → カードが常に「計測待ち」を表示していた
+      // (成功レスポンス+実データでも空表示)。digest を unwrap する。
+      return WeeklyDigestSnapshot.fromJson(_toMapValue(data['digest']));
     } catch (error) {
       debugPrint('Weekly digest fallback: $error');
       return const WeeklyDigestSnapshot.empty();

--- a/test/pages/admin_dashboard_signals_test.dart
+++ b/test/pages/admin_dashboard_signals_test.dart
@@ -547,4 +547,22 @@ void main() {
       expect(autoErrorReportsHealthLabel(3), '自動エラー報告 3件');
     });
   });
+  group('R30 growthSummaryHasMetrics (捏造ゼロ防止)', () {
+    test('metric キーがあれば true', () {
+      expect(growthSummaryHasMetrics({'newUsers': 3, 'label': '今日'}), isTrue);
+      expect(growthSummaryHasMetrics({'totalUsersEver': 44}), isTrue);
+    });
+
+    test('achievement.list の {success, items} は false (集計未接続)', () {
+      expect(
+        growthSummaryHasMetrics({'success': true, 'items': <dynamic>[]}),
+        isFalse,
+      );
+    });
+
+    test('null / 空は false', () {
+      expect(growthSummaryHasMetrics(null), isFalse);
+      expect(growthSummaryHasMetrics(<String, dynamic>{}), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## 概要

part340 第6弾。経営分析ダッシュボードは5ラウンドで上部が健全化したため、今回は**下部カードを fresh-eyes 監査**。成功レスポンス+実データがあるのに**捏造ゼロ/空を表示する contract mismatch を2件確定**(本番 anon probe で実データ経路を実証)。すべて **part338 以来の「ダッシュボードは数字を捏造しない」規律**に沿う修正で、**クライアント側のみ**(EF 変更なし)。

## 10 仮説 検証結果

| # | 対象 | 判定 |
|---|------|------|
| H1 | 週次ダイジェストカード | 🔴確定→修正: nested `digest` 未unwrap で常に「計測待ち」 |
| H2 | 成長実績サマリーカード | 🔴確定→修正: `achievement.list` は集計キーを返さず常に「0人/0件」捏造 |
| H3 | 比較ページ別CVR | ⚪確定→修正: 母数0で「0.0%」捏造 (formatRatePercent へ統一) |
| H4 | 登録ユーザー provider バッジ | ⚪確定→修正: provider 未返却で全員 'Email' 誤表示→'登録済' |
| H5 | 有料転換カード | ✅監査OK: RGB `get_billing_paid_conversion_summary` 契約一致・formatRatePercent 済 |
| H6 | KPIサマリーカード | ✅監査OK: today スコープ整合・0除算ガード有 |
| H7 | 比較CVR集計 | ✅監査OK: touch 合算は算術的に正・per-competitor CVR は主張せず |
| H8 | admin users 合計>100 | 🟡latent: real/anon 分割は先頭100件のみ (現状44人で未発火) |
| H9 | 成長サマリー期間境界 | 🟡latent: local ISO(Zなし)+rolling 7d/30d (H2 で dead・#4187 で是正) |
| H10 | paid 分母=raw profile数 | ✅監査OK: anon は profile 行を持たない(auto-trigger drop 済)ため実ユーザーのみ |

## 修正詳細 (本番実証済)

### H1 — 週次ダイジェストが常に「計測待ち」🔴
`growth-weekly-digest` は `{success, digest:{currentWeek,...}}` と **nested** で返すのに、`growth_mission_service.dart` が **top-level envelope** を `WeeklyDigestSnapshot.fromJson` に渡していた → 全キー null → `currentWeekStart=''` → カードが成功レスポンス+実データでも常に「今週はまだ計測データがありません」。兄弟の command-center brief は `data['brief']` を unwrap 済。**`data['digest']` を unwrap** して修正。
本番 probe: `{"success":true,"digest":{"currentWeek":..,"channels":..,"signupSubmitTotal":..}}` — `currentWeek` は digest 内。

### H2 — 成長実績サマリーが常に「0人/0件」🔴
`growth-hub achievement.list` は `{success, items:[]}` を返すだけで **newUsers/totalUsersEver/acquisitionSignals/referralsCompleted/importPreviews を一切返さない**(全 EF grep でも不在=集計未実装)。カードは `?? 0` で読み捏造ゼロ+「期間: すべて」、期間チップも無反応だった。`growthSummaryHasMetrics` ガードで、期待キーが無い応答は**捏造せず「集計未接続」と正直表示**。恒久対応(集計 action 新設)は #4187。
本番 probe: `achievement.list` → `{"success":true,"items":[]}`。

### H3 / H4 — 小さな捏造の是正
- 比較CVR: 母数0で `'0.0'` を捏造 → `formatRatePercent`(母数0=「—」)に統一。
- provider バッジ: edge が provider を返さず `isGoogle` 常に false で全員 'Email' → 中立の '登録済'。

## テスト
- `admin_dashboard_signals_test.dart` R30 — `growthSummaryHasMetrics` 3件 (計50) ✅
- flutter analyze 0 issue / dart format 差分なし

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Client-only display-honesty fixes in Flutter admin dashboard: unwrap nested digest response, stop fabricating zero growth-summary metrics, use formatRatePercent for CVR, neutral user badge. No auth/RLS/payment/secret/schema/edge changes; covered by VM unit tests

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Client-only honesty fixes (unwrap nested digest; guard fabricated growth-summary zeros; formatRatePercent for zero-denominator CVR; neutral user badge). Confirmed via production anon probes; growthSummaryHasMetrics guard covered by VM unit tests (R30). No edge/API/schema change.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
