### PR TITLE
feat(asset): 負債マスタ(サブスク)にドル建て入力+為替自動換算 (Claude/Notion等のUSD建て月額)

### DIFF
--- a/lib/models/asset_liability_workbook.dart
+++ b/lib/models/asset_liability_workbook.dart
@@ -283,6 +283,17 @@ enum AssetRecurringFixedCostCategory {
   subscription,
 }
 
+/// 定期固定費の入力通貨。既定は円 (jpy)。ドル建て (usd) の場合は毎月の為替で
+/// 円換算額が変動するため、原資の USD 額を保持し、最新レートで円へ materialize する。
+enum AssetRecurringFixedCostCurrency {
+  /// 円建て (既定)。[AssetRecurringFixedCost.amount] がそのまま月額。
+  jpy,
+
+  /// ドル建て。[AssetRecurringFixedCost.usdAmount] が原資で、[amount] は
+  /// 最新レートで換算した円額 (レート未取得時は前回換算値を据え置く)。
+  usd,
+}
+
 /// サブスクの請求経路 (どこ経由で課金されるか)。
 ///
 /// 例: ChatGPT Pro は Apple App Store のサブスクとして課金され、Apple ID の支払い方法
@@ -337,6 +348,15 @@ class AssetRecurringFixedCost {
   /// 突き合わせ表示に使い、資金繰りの計上額には影響しない。
   final AssetSubscriptionBillingGateway billingGateway;
 
+  /// 入力通貨。既定は円 (jpy)。ドル建て (usd) のサブスク (Claude/Notion 等) は
+  /// 毎月の為替で円額が変わるため usd を指定し、[usdAmount] に原資の USD 額を持つ。
+  final AssetRecurringFixedCostCurrency currency;
+
+  /// ドル建て時の原資 (USD 額)。[currency] == usd のときのみ意味を持つ。
+  /// 円換算額 [amount] は「最新レートで再計算した値」を都度保存するため、
+  /// レート未取得時でも前回値で計上でき、レート更新時に自動で追随する。
+  final double? usdAmount;
+
   const AssetRecurringFixedCost({
     required this.id,
     required this.name,
@@ -346,7 +366,22 @@ class AssetRecurringFixedCost {
     this.sourceAccountId,
     this.category = AssetRecurringFixedCostCategory.utility,
     this.billingGateway = AssetSubscriptionBillingGateway.direct,
+    this.currency = AssetRecurringFixedCostCurrency.jpy,
+    this.usdAmount,
   });
+
+  /// ドル建てか。
+  bool get isUsd => currency == AssetRecurringFixedCostCurrency.usd;
+
+  /// 指定レート (1 USD = [usdJpyRate] 円) で円換算した月額を返す。
+  /// ドル建てかつ原資・レートが有効なときのみ再計算し、それ以外は現行の
+  /// [amount] を据え置く (レート未取得時に 0 円へ落ちないようにする)。
+  double resolveJpyAmount(double? usdJpyRate) {
+    if (!isUsd || usdAmount == null || usdJpyRate == null || usdJpyRate <= 0) {
+      return amount;
+    }
+    return (usdAmount! * usdJpyRate).roundToDouble();
+  }
 
   /// 指定した月 (1-12) にこの固定費が発生するか (隔月は偶数/奇数月のみ計上)。
   bool appliesToMonth(int month) {
@@ -370,6 +405,9 @@ class AssetRecurringFixedCost {
     bool clearSourceAccountId = false,
     AssetRecurringFixedCostCategory? category,
     AssetSubscriptionBillingGateway? billingGateway,
+    AssetRecurringFixedCostCurrency? currency,
+    double? usdAmount,
+    bool clearUsdAmount = false,
   }) {
     return AssetRecurringFixedCost(
       id: id ?? this.id,
@@ -382,6 +420,8 @@ class AssetRecurringFixedCost {
           : (sourceAccountId ?? this.sourceAccountId),
       category: category ?? this.category,
       billingGateway: billingGateway ?? this.billingGateway,
+      currency: currency ?? this.currency,
+      usdAmount: clearUsdAmount ? null : (usdAmount ?? this.usdAmount),
     );
   }
 
@@ -399,6 +439,10 @@ class AssetRecurringFixedCost {
         'category': category.name,
       if (billingGateway != AssetSubscriptionBillingGateway.direct)
         'billingGateway': billingGateway.name,
+      // 通貨は既定 (jpy) のとき出力しない (既存ペイロードと互換を保つ)。
+      if (currency != AssetRecurringFixedCostCurrency.jpy)
+        'currency': currency.name,
+      if (usdAmount != null) 'usdAmount': usdAmount,
     };
   }
 
@@ -441,6 +485,13 @@ class AssetRecurringFixedCost {
       (value) => value.name == gatewayName,
       orElse: () => AssetSubscriptionBillingGateway.direct,
     );
+    final currencyName = json['currency']?.toString();
+    final currency = AssetRecurringFixedCostCurrency.values.firstWhere(
+      (value) => value.name == currencyName,
+      orElse: () => AssetRecurringFixedCostCurrency.jpy,
+    );
+    final usdAmount = (json['usdAmount'] as num?)?.toDouble() ??
+        double.tryParse(json['usdAmount']?.toString() ?? '');
     return AssetRecurringFixedCost(
       id: trimmedId,
       name: name,
@@ -451,6 +502,8 @@ class AssetRecurringFixedCost {
           rawSource == null || rawSource.isEmpty ? null : rawSource,
       category: category,
       billingGateway: billingGateway,
+      currency: currency,
+      usdAmount: usdAmount != null && usdAmount > 0 ? usdAmount : null,
     );
   }
 }

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -48,6 +48,7 @@ import 'package:my_web_app/services/household_tracker_share_service.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
+import 'package:my_web_app/services/fx_rate_service.dart';
 import 'package:my_web_app/services/asset_recurring_suggestion_ignore_store.dart';
 import 'package:my_web_app/services/asset_subscription_audit_catalog.dart';
 import 'package:my_web_app/services/asset_subscription_audit_store.dart';
@@ -634,6 +635,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   // UI 登録の定期固定費 (家賃・光熱費など)。振替日昇順で保持する。
   List<AssetRecurringFixedCost> _recurringFixedCosts =
       <AssetRecurringFixedCost>[];
+  // USD/JPY 為替レート (ドル建てサブスクの円換算用)。null = 未取得。
+  final FxRateService _fxRateService = FxRateService();
+  FxRate? _usdJpyRate;
   // サブスク棚卸し: 支払い元ごとの最終確認日時 (sourceId → UTC)。
   Map<String, DateTime> _subscriptionAuditState = <String, DateTime>{};
   // サブスク棚卸し: 確認の取り消し日時 (tombstone / sourceId → UTC)。checked と
@@ -1043,6 +1047,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_loadRevolvingConfigs());
     unawaited(_loadCategoryBudgets());
     unawaited(_loadRecurringFixedCosts());
+    // ドル建てサブスクの円換算に使う USD/JPY を取得し、最新レートで再計算する。
+    unawaited(_loadUsdJpyRate());
     unawaited(_loadSubscriptionAudit());
     unawaited(_loadRecurringIgnored());
     unawaited(_loadRecurringIncomeIgnored());
@@ -10597,6 +10603,56 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_mirrorRecurringIncomeIgnored());
   }
 
+  /// USD/JPY レートを取得し、ドル建てサブスクの円額を最新レートで再計算する。
+  Future<void> _loadUsdJpyRate() async {
+    try {
+      // まずキャッシュで即時反映 → 次にネットワークで鮮度を更新。
+      final cached = await _fxRateService.cachedUsdJpy();
+      if (cached != null && mounted) {
+        _applyUsdJpyRate(cached);
+      }
+      final fresh = await _fxRateService.getUsdJpy();
+      if (fresh != null && mounted) {
+        _applyUsdJpyRate(fresh);
+      }
+    } catch (e) {
+      debugPrint('Error loading USD/JPY rate: $e');
+    }
+  }
+
+  /// 取得したレートを保持し、ドル建てサブスクの円額 (amount) を再計算する。
+  /// 円額が変わったものだけ差し替えて永続化する (レート変動を自動追随)。
+  void _applyUsdJpyRate(FxRate rate) {
+    final recomputed = <AssetRecurringFixedCost>[];
+    var changed = false;
+    for (final cost in _recurringFixedCosts) {
+      if (!cost.isUsd || cost.usdAmount == null) {
+        recomputed.add(cost);
+        continue;
+      }
+      final jpy = cost.resolveJpyAmount(rate.jpyPerUnit);
+      if (jpy > 0 && jpy != cost.amount) {
+        recomputed.add(cost.copyWith(amount: jpy));
+        changed = true;
+      } else {
+        recomputed.add(cost);
+      }
+    }
+    setState(() {
+      _usdJpyRate = rate;
+      if (changed) {
+        _recurringFixedCosts = recomputed;
+      }
+    });
+    if (changed) {
+      _persistInBackground(
+        _recurringFixedCostStore.save(_recurringFixedCosts),
+        'recurring fixed cost fx recompute',
+      );
+      unawaited(_mirrorRecurringFixedCosts());
+    }
+  }
+
   void _saveRecurringFixedCost(AssetRecurringFixedCost cost) {
     setState(() {
       final next = List<AssetRecurringFixedCost>.from(_recurringFixedCosts);
@@ -10652,6 +10708,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       sourceAccounts: sourceOptions,
       category: category,
       gateway: gateway,
+      usdJpyRate: _usdJpyRate?.jpyPerUnit,
+      usdJpyRateAsOf: _usdJpyRate?.asOf,
     );
     if (result != null) {
       _saveRecurringFixedCost(result);

--- a/lib/services/fx_rate_service.dart
+++ b/lib/services/fx_rate_service.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 為替レート (1 通貨 = 円) と取得時刻。
+@immutable
+class FxRate {
+  const FxRate({
+    required this.jpyPerUnit,
+    required this.fetchedAt,
+    required this.asOf,
+  });
+
+  /// 1 単位 (例: 1 USD) あたりの円。
+  final double jpyPerUnit;
+
+  /// 端末がこのレートを取得/読込した時刻 (鮮度判定用)。
+  final DateTime fetchedAt;
+
+  /// レート提供元が示す基準日 (例: ECB/銀行の更新日)。表示用。
+  final DateTime asOf;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'jpyPerUnit': jpyPerUnit,
+        'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+        'asOf': asOf.toUtc().toIso8601String(),
+      };
+
+  static FxRate? fromJson(Map<String, dynamic> json) {
+    final rate = (json['jpyPerUnit'] as num?)?.toDouble();
+    final fetchedAt = DateTime.tryParse(json['fetchedAt']?.toString() ?? '');
+    final asOf = DateTime.tryParse(json['asOf']?.toString() ?? '');
+    if (rate == null || rate <= 0 || fetchedAt == null) {
+      return null;
+    }
+    return FxRate(
+      jpyPerUnit: rate,
+      fetchedAt: fetchedAt,
+      asOf: asOf ?? fetchedAt,
+    );
+  }
+}
+
+/// USD/JPY 為替レートを自動取得し端末にキャッシュするサービス。
+///
+/// 取得元は open.er-api.com (無料・APIキー不要・CORS 対応)。鮮度 [ttl] 内なら
+/// キャッシュを返し、超過時に再取得する。取得失敗時は**最後に取得できたレートに
+/// フォールバック**する (古くても 0 円換算に落とさない)。一度も取得できていなければ
+/// null を返し、呼び出し側は前回換算済みの円額を据え置く。
+///
+/// 注意: 提供元は銀行間/参照レートのため、カード会社の請求レート (手数料上乗せ
+/// ~1.6-3%) とは差が出る。あくまで見込み額の推定に使う。
+class FxRateService {
+  FxRateService({
+    http.Client? client,
+    Future<SharedPreferences> Function()? prefsProvider,
+    DateTime Function()? now,
+    Duration ttl = const Duration(hours: 12),
+    Uri? endpoint,
+  })  : _client = client ?? http.Client(),
+        _prefsProvider = prefsProvider ?? SharedPreferences.getInstance,
+        _now = now ?? DateTime.now,
+        _ttl = ttl,
+        _endpoint =
+            endpoint ?? Uri.parse('https://open.er-api.com/v6/latest/USD');
+
+  static const String _prefsKey = 'fx_rate_usd_jpy_v1';
+
+  final http.Client _client;
+  final Future<SharedPreferences> Function() _prefsProvider;
+  final DateTime Function() _now;
+  final Duration _ttl;
+  final Uri _endpoint;
+
+  FxRate? _memory;
+  Future<FxRate?>? _inFlight;
+
+  /// USD/JPY レートを返す。鮮度内はキャッシュ、超過時は再取得。
+  /// 取得失敗時は最後のレートにフォールバックし、無ければ null。
+  /// [forceRefresh] で TTL を無視して再取得する (手動更新)。
+  Future<FxRate?> getUsdJpy({bool forceRefresh = false}) async {
+    final cached = _memory ?? await _readCache();
+    if (!forceRefresh && cached != null && _isFresh(cached)) {
+      return cached;
+    }
+    // 同時多発呼び出しを 1 リクエストに束ねる。
+    _inFlight ??= _refresh(fallback: cached).whenComplete(() {
+      _inFlight = null;
+    });
+    return _inFlight;
+  }
+
+  /// キャッシュがあれば即座に返す (ネットワーク往復なし)。UI の初期表示用。
+  Future<FxRate?> cachedUsdJpy() async => _memory ?? await _readCache();
+
+  bool _isFresh(FxRate rate) => _now().difference(rate.fetchedAt) < _ttl;
+
+  Future<FxRate?> _refresh({FxRate? fallback}) async {
+    try {
+      final resp =
+          await _client.get(_endpoint).timeout(const Duration(seconds: 8));
+      if (resp.statusCode != 200) {
+        return fallback;
+      }
+      final body = jsonDecode(resp.body);
+      if (body is! Map<String, dynamic>) {
+        return fallback;
+      }
+      if (body['result'] != null && body['result'] != 'success') {
+        return fallback;
+      }
+      final rates = body['rates'];
+      final jpy = rates is Map ? (rates['JPY'] as num?)?.toDouble() : null;
+      if (jpy == null || jpy <= 0) {
+        return fallback;
+      }
+      final asOfUnix = (body['time_last_update_unix'] as num?)?.toInt();
+      final asOf = asOfUnix != null
+          ? DateTime.fromMillisecondsSinceEpoch(asOfUnix * 1000, isUtc: true)
+          : _now();
+      final rate = FxRate(jpyPerUnit: jpy, fetchedAt: _now(), asOf: asOf);
+      _memory = rate;
+      await _writeCache(rate);
+      return rate;
+    } catch (_) {
+      // ネットワーク/タイムアウト/パース失敗はフォールバックへ。
+      return fallback;
+    }
+  }
+
+  Future<FxRate?> _readCache() async {
+    try {
+      final prefs = await _prefsProvider();
+      final raw = prefs.getString(_prefsKey);
+      if (raw == null) {
+        return null;
+      }
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        return null;
+      }
+      final rate = FxRate.fromJson(decoded);
+      _memory = rate;
+      return rate;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _writeCache(FxRate rate) async {
+    try {
+      final prefs = await _prefsProvider();
+      await prefs.setString(_prefsKey, jsonEncode(rate.toJson()));
+    } catch (_) {
+      // 永続化失敗はメモリキャッシュで継続 (致命ではない)。
+    }
+  }
+}

--- a/lib/widgets/recurring_fixed_cost_editor_dialog.dart
+++ b/lib/widgets/recurring_fixed_cost_editor_dialog.dart
@@ -65,6 +65,8 @@ Future<AssetRecurringFixedCost?> showRecurringFixedCostEditor(
       AssetRecurringFixedCostCategory.utility,
   AssetSubscriptionBillingGateway gateway =
       AssetSubscriptionBillingGateway.direct,
+  double? usdJpyRate,
+  DateTime? usdJpyRateAsOf,
 }) {
   return showDialog<AssetRecurringFixedCost>(
     context: context,
@@ -74,6 +76,8 @@ Future<AssetRecurringFixedCost?> showRecurringFixedCostEditor(
       sourceAccounts: sourceAccounts,
       category: category,
       gateway: gateway,
+      usdJpyRate: usdJpyRate,
+      usdJpyRateAsOf: usdJpyRateAsOf,
     ),
   );
 }
@@ -88,6 +92,8 @@ class RecurringFixedCostEditorDialog extends StatefulWidget {
     this.sourceAccounts = const <RecurringFixedCostSourceOption>[],
     this.category = AssetRecurringFixedCostCategory.utility,
     this.gateway = AssetSubscriptionBillingGateway.direct,
+    this.usdJpyRate,
+    this.usdJpyRateAsOf,
   });
 
   final AssetRecurringFixedCost? existing;
@@ -104,6 +110,13 @@ class RecurringFixedCostEditorDialog extends StatefulWidget {
   /// [existing]/[prefill] が経路を持つ場合はそちらを優先する。
   final AssetSubscriptionBillingGateway gateway;
 
+  /// 最新の USD/JPY レート (1 ドル = ◯円)。ドル建て入力の円換算プレビューと
+  /// 保存時の円額 materialize に使う。null のときはレート未取得。
+  final double? usdJpyRate;
+
+  /// [usdJpyRate] の基準日 (表示用)。
+  final DateTime? usdJpyRateAsOf;
+
   @override
   State<RecurringFixedCostEditorDialog> createState() =>
       _RecurringFixedCostEditorDialogState();
@@ -118,6 +131,7 @@ class _RecurringFixedCostEditorDialogState
   late AssetRecurringFixedCostCadence _cadence;
   late AssetRecurringFixedCostCategory _category;
   late AssetSubscriptionBillingGateway _gateway;
+  late AssetRecurringFixedCostCurrency _currency;
   String? _sourceAccountId;
 
   @override
@@ -128,9 +142,15 @@ class _RecurringFixedCostEditorDialogState
     // 区分は initial が持つ値を最優先し、無ければ呼び出し側が指定した既定を使う。
     _category = initial?.category ?? widget.category;
     _gateway = initial?.billingGateway ?? widget.gateway;
+    _currency = initial?.currency ?? AssetRecurringFixedCostCurrency.jpy;
     _nameController = TextEditingController(text: initial?.name ?? '');
+    // ドル建てなら金額欄には USD の原資額を、円建てなら円額を初期表示する。
     _amountController = TextEditingController(
-      text: initial == null ? '' : initial.amount.toStringAsFixed(0),
+      text: initial == null
+          ? ''
+          : (initial.isUsd && initial.usdAmount != null
+              ? _trimAmount(initial.usdAmount!)
+              : initial.amount.toStringAsFixed(0)),
     );
     _dayController = TextEditingController(
       text: initial == null ? '' : initial.paymentDay.toString(),
@@ -140,6 +160,16 @@ class _RecurringFixedCostEditorDialogState
     final ids = widget.sourceAccounts.map((option) => option.id).toSet();
     final source = initial?.sourceAccountId;
     _sourceAccountId = source != null && ids.contains(source) ? source : null;
+  }
+
+  bool get _isUsd => _currency == AssetRecurringFixedCostCurrency.usd;
+
+  /// USD 額は小数点以下を許容するため、整数なら小数を省いて表示する。
+  static String _trimAmount(double value) {
+    if (value == value.roundToDouble()) {
+      return value.toStringAsFixed(0);
+    }
+    return value.toString();
   }
 
   @override
@@ -156,10 +186,25 @@ class _RecurringFixedCostEditorDialogState
     }
     final id =
         widget.existing?.id ?? 'fc_${DateTime.now().microsecondsSinceEpoch}';
+    final entered = double.parse(_amountController.text.trim());
+    final double amountJpy;
+    final double? usdAmount;
+    if (_isUsd) {
+      usdAmount = entered;
+      // レートがあれば円へ materialize。無ければ既存の円額 (編集時) か 0 を暫定値に
+      // 置き、ロード時のレート反映で自動的に正しい円額へ更新される。
+      final rate = widget.usdJpyRate;
+      amountJpy = (rate != null && rate > 0)
+          ? (entered * rate).roundToDouble()
+          : (widget.existing?.amount ?? 0);
+    } else {
+      usdAmount = null;
+      amountJpy = entered;
+    }
     final cost = AssetRecurringFixedCost(
       id: id,
       name: _nameController.text.trim(),
-      amount: double.parse(_amountController.text.trim()),
+      amount: amountJpy,
       paymentDay: int.parse(_dayController.text.trim()),
       cadence: _cadence,
       sourceAccountId: _sourceAccountId,
@@ -168,8 +213,70 @@ class _RecurringFixedCostEditorDialogState
       billingGateway: _category == AssetRecurringFixedCostCategory.subscription
           ? _gateway
           : AssetSubscriptionBillingGateway.direct,
+      currency: _currency,
+      usdAmount: usdAmount,
     );
     Navigator.of(context).pop(cost);
+  }
+
+  String _formatYen(double value) {
+    final rounded = value.round();
+    final digits = rounded.abs().toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      if (i > 0 && (digits.length - i) % 3 == 0) {
+        buffer.write(',');
+      }
+      buffer.write(digits[i]);
+    }
+    return '${rounded < 0 ? '-' : ''}¥$buffer';
+  }
+
+  /// ドル建て入力欄の下に「≈ ¥X (1ドル=¥Y, MM/DD時点)」の換算プレビューを出す。
+  /// レート未取得時は取得中/据え置きの案内にする。
+  Widget _buildUsdConversionHint() {
+    final rate = widget.usdJpyRate;
+    final usd = double.tryParse(_amountController.text.trim());
+    final theme = Theme.of(context);
+    final style = theme.textTheme.bodySmall?.copyWith(
+      color: const Color(0xFF0D9488),
+      fontWeight: FontWeight.w700,
+    );
+    final Widget child;
+    if (rate == null || rate <= 0) {
+      child = Text(
+        '為替レート取得中… 保存後、最新レートで自動換算します。',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: const Color(0xFF64748B),
+        ),
+      );
+    } else if (usd == null || usd <= 0) {
+      child = Text(
+        '1ドル=${_formatYen(rate)}${_rateAsOfSuffix()} で円換算します。',
+        style: style,
+      );
+    } else {
+      child = Text(
+        '≈ ${_formatYen(usd * rate)}'
+        '(1ドル=${_formatYen(rate)}${_rateAsOfSuffix()})',
+        style: style,
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Align(alignment: Alignment.centerLeft, child: child),
+    );
+  }
+
+  String _rateAsOfSuffix() {
+    final asOf = widget.usdJpyRateAsOf;
+    if (asOf == null) {
+      return '';
+    }
+    final local = asOf.toLocal();
+    final mm = local.month.toString().padLeft(2, '0');
+    final dd = local.day.toString().padLeft(2, '0');
+    return ' / $mm/$dd時点';
   }
 
   static String categoryLabel(AssetRecurringFixedCostCategory category) {
@@ -235,22 +342,55 @@ class _RecurringFixedCostEditorDialogState
                     ? '名称を入力してください'
                     : null,
               ),
+              const SizedBox(height: 8),
+              // 通貨トグル。ドル建て (Claude/Notion 等) は毎月の為替で円額が
+              // 変わるため、USD 原資を保持し最新レートで円換算する。
+              SegmentedButton<AssetRecurringFixedCostCurrency>(
+                segments: const [
+                  ButtonSegment(
+                    value: AssetRecurringFixedCostCurrency.jpy,
+                    label: Text('円'),
+                    icon: Icon(Icons.currency_yen, size: 16),
+                  ),
+                  ButtonSegment(
+                    value: AssetRecurringFixedCostCurrency.usd,
+                    label: Text('USD'),
+                    icon: Icon(Icons.attach_money, size: 16),
+                  ),
+                ],
+                selected: {_currency},
+                onSelectionChanged: (selection) {
+                  setState(() => _currency = selection.first);
+                },
+              ),
+              const SizedBox(height: 8),
               TextFormField(
                 controller: _amountController,
-                decoration: const InputDecoration(
-                  labelText: '月額 (円)',
-                  hintText: '例: 8000',
+                decoration: InputDecoration(
+                  labelText: _isUsd ? '月額 (USD)' : '月額 (円)',
+                  hintText: _isUsd ? '例: 20' : '例: 8000',
+                  prefixText: _isUsd ? r'$ ' : null,
                 ),
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                keyboardType: TextInputType.numberWithOptions(
+                  decimal: _isUsd,
+                ),
+                inputFormatters: _isUsd
+                    ? [
+                        FilteringTextInputFormatter.allow(
+                          RegExp(r'[0-9.]'),
+                        ),
+                      ]
+                    : [FilteringTextInputFormatter.digitsOnly],
+                onChanged: (_) => setState(() {}),
                 validator: (value) {
                   final amount = double.tryParse((value ?? '').trim());
                   if (amount == null || amount <= 0) {
-                    return '1円以上の金額を入力してください';
+                    return _isUsd ? '0より大きい金額を入力してください' : '1円以上の金額を入力してください';
                   }
                   return null;
                 },
               ),
+              if (_isUsd) _buildUsdConversionHint(),
               TextFormField(
                 controller: _dayController,
                 decoration: const InputDecoration(

--- a/test/models/asset_recurring_fixed_cost_currency_test.dart
+++ b/test/models/asset_recurring_fixed_cost_currency_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+
+void main() {
+  group('AssetRecurringFixedCost currency (USD)', () {
+    test('JPY (default) omits currency/usdAmount from json (back-compat)', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'fc_1',
+        name: '電気代',
+        amount: 8000,
+        paymentDay: 27,
+      );
+      final json = cost.toJson();
+      expect(json.containsKey('currency'), isFalse);
+      expect(json.containsKey('usdAmount'), isFalse);
+      expect(cost.isUsd, isFalse);
+    });
+
+    test('legacy json without currency parses as JPY', () {
+      final cost = AssetRecurringFixedCost.fromJson('fc_1', <String, dynamic>{
+        'name': 'Notion',
+        'amount': 1200,
+        'paymentDay': 1,
+      });
+      expect(cost, isNotNull);
+      expect(cost!.currency, AssetRecurringFixedCostCurrency.jpy);
+      expect(cost.usdAmount, isNull);
+    });
+
+    test('USD cost round-trips currency + usdAmount', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'fc_claude',
+        name: 'Anthropic (Claude)',
+        amount: 3200, // materialized JPY (20 USD * 160)
+        paymentDay: 5,
+        category: AssetRecurringFixedCostCategory.subscription,
+        currency: AssetRecurringFixedCostCurrency.usd,
+        usdAmount: 20,
+      );
+      final decoded =
+          AssetRecurringFixedCost.fromJson('fc_claude', cost.toJson());
+      expect(decoded, isNotNull);
+      expect(decoded!.currency, AssetRecurringFixedCostCurrency.usd);
+      expect(decoded.usdAmount, 20);
+      expect(decoded.amount, 3200);
+      expect(decoded.isUsd, isTrue);
+    });
+
+    test('resolveJpyAmount converts USD by rate, rounds to yen', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'fc_claude',
+        name: 'Claude',
+        amount: 3000,
+        paymentDay: 5,
+        currency: AssetRecurringFixedCostCurrency.usd,
+        usdAmount: 20,
+      );
+      // 20 USD * 162.39 = 3247.8 -> 3248
+      expect(cost.resolveJpyAmount(162.39), 3248);
+    });
+
+    test('resolveJpyAmount keeps existing JPY when rate is missing', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'fc_claude',
+        name: 'Claude',
+        amount: 3100, // last computed JPY
+        paymentDay: 5,
+        currency: AssetRecurringFixedCostCurrency.usd,
+        usdAmount: 20,
+      );
+      expect(cost.resolveJpyAmount(null), 3100);
+      expect(cost.resolveJpyAmount(0), 3100);
+    });
+
+    test('resolveJpyAmount is a no-op for JPY costs', () {
+      const cost = AssetRecurringFixedCost(
+        id: 'fc_rent',
+        name: '家賃',
+        amount: 63000,
+        paymentDay: 25,
+      );
+      expect(cost.resolveJpyAmount(162.39), 63000);
+    });
+
+    test('usdAmount<=0 or invalid is dropped on parse', () {
+      final cost = AssetRecurringFixedCost.fromJson('fc_1', <String, dynamic>{
+        'name': 'x',
+        'amount': 100,
+        'paymentDay': 1,
+        'currency': 'usd',
+        'usdAmount': 0,
+      });
+      expect(cost, isNotNull);
+      expect(cost!.usdAmount, isNull);
+    });
+  });
+}

--- a/test/services/fx_rate_service_test.dart
+++ b/test/services/fx_rate_service_test.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:my_web_app/services/fx_rate_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  http.Client okClient(double jpy, {int? asOfUnix}) {
+    return MockClient((request) async {
+      return http.Response(
+        jsonEncode(<String, dynamic>{
+          'result': 'success',
+          'rates': <String, dynamic>{'JPY': jpy, 'EUR': 0.9},
+          if (asOfUnix != null) 'time_last_update_unix': asOfUnix,
+        }),
+        200,
+      );
+    });
+  }
+
+  FxRateService service(
+    http.Client client, {
+    DateTime Function()? now,
+    Duration ttl = const Duration(hours: 12),
+  }) {
+    return FxRateService(
+      client: client,
+      prefsProvider: SharedPreferences.getInstance,
+      now: now,
+      ttl: ttl,
+    );
+  }
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  test('fetches and parses USD/JPY', () async {
+    final rate =
+        await service(okClient(162.39, asOfUnix: 1700000000)).getUsdJpy();
+    expect(rate, isNotNull);
+    expect(rate!.jpyPerUnit, 162.39);
+    expect(rate.asOf.toUtc().year, 2023);
+  });
+
+  test('caches to prefs and serves cache while fresh (no 2nd fetch)', () async {
+    var calls = 0;
+    final client = MockClient((request) async {
+      calls++;
+      return http.Response(
+        jsonEncode(<String, dynamic>{
+          'result': 'success',
+          'rates': <String, dynamic>{'JPY': 160.0},
+        }),
+        200,
+      );
+    });
+    final svc = service(client);
+    final first = await svc.getUsdJpy();
+    final second = await svc.getUsdJpy();
+    expect(first!.jpyPerUnit, 160.0);
+    expect(second!.jpyPerUnit, 160.0);
+    expect(calls, 1, reason: 'fresh cache should avoid a second network call');
+  });
+
+  test('falls back to last cached rate when fetch fails', () async {
+    // Seed a stale cached rate.
+    final good = service(okClient(155.0));
+    await good.getUsdJpy();
+
+    // New service (fresh memory) with a failing client + forceRefresh.
+    final failing = MockClient((request) async => http.Response('boom', 500));
+    final svc = service(failing);
+    final rate = await svc.getUsdJpy(forceRefresh: true);
+    expect(rate, isNotNull);
+    expect(rate!.jpyPerUnit, 155.0, reason: 'should reuse cached rate');
+  });
+
+  test('returns null when no cache and fetch fails', () async {
+    final failing = MockClient((request) async => throw Exception('offline'));
+    final rate = await service(failing).getUsdJpy();
+    expect(rate, isNull);
+  });
+
+  test('ignores result:error payloads', () async {
+    final errClient = MockClient((request) async {
+      return http.Response(
+        jsonEncode(<String, dynamic>{'result': 'error', 'error-type': 'x'}),
+        200,
+      );
+    });
+    final rate = await service(errClient).getUsdJpy();
+    expect(rate, isNull);
+  });
+
+  test('refetches once TTL elapses', () async {
+    var calls = 0;
+    final client = MockClient((request) async {
+      calls++;
+      return http.Response(
+        jsonEncode(<String, dynamic>{
+          'result': 'success',
+          'rates': <String, dynamic>{'JPY': 160.0 + calls},
+        }),
+        200,
+      );
+    });
+    var clock = DateTime(2026, 1, 1, 10);
+    final svc =
+        service(client, now: () => clock, ttl: const Duration(hours: 1));
+    final first = await svc.getUsdJpy();
+    expect(first!.jpyPerUnit, 161.0);
+    clock = clock.add(const Duration(hours: 2));
+    final second = await svc.getUsdJpy();
+    expect(second!.jpyPerUnit, 162.0);
+    expect(calls, 2);
+  });
+}


### PR DESCRIPTION
# feat(asset): 負債マスタ (サブスク) にドル建て入力 + 為替自動換算

## ユーザー要望

> 負債マスターについて、ドルで入力可能なようにできますか？（為替によって毎月の支払額が変わるものがあるため（Claude、Notionなど））

Claude/Notion などドル建てサブスクは毎月の為替で円額が変わるため、USD で入力して自動で円換算できるようにした。為替レートは**自動取得** (ユーザー選択)。

## 調査で判明した設計上の要点

- Claude/Notion は「負債」ではなく `AssetRecurringFixedCost` (category=subscription) として登録され、負債マスタには**合成負債として注入**される。金額はサブスク編集ダイアログの「月額 (円)」で入力。→ ここに USD 対応を足すのが自然。
- 資産/負債サブシステムは全て `double` の円建てで、通貨/為替の概念は皆無 (グリーンフィールド)。
- `AssetRecurringFixedCost.toJson/fromJson` は既定値キーを省略し未知キーを許容 → 後方互換で新フィールドを追加可能。

## 変更内容

1. **モデル** (`asset_liability_workbook.dart`): `AssetRecurringFixedCostCurrency` (jpy/usd) + `currency` + `usdAmount` を追加。`amount` は「最新レートで materialize した円額」を保持し、下流の資金繰り計算 (負債注入・合計・使用可能額) は従来どおり `amount`(円) を読むだけで動く。`resolveJpyAmount(rate)` で `usdAmount × rate` を円へ換算 (レート欠如時は現行 `amount` 据え置き)。`toJson` は既定(jpy)のとき出力せず後方互換維持。
2. **`FxRateService`** (新規): USD/JPY を `open.er-api.com` (無料・APIキー不要・CORS対応) から自動取得し端末キャッシュ (TTL 12h)。取得失敗時は**最後のレートにフォールバック**、未取得なら null (呼び出し側は前回換算円額を据え置く)。同時呼び出しは1リクエストに集約。テストのため http.Client / clock / endpoint を注入可能。
3. **編集ダイアログ**: 通貨トグル (円/USD)。USD 時は `$` 入力 + 小数許容 + 「≈ ¥X (1ドル=¥Y, MM/DD時点)」の換算プレビュー。保存時に円へ materialize。
4. **ページ**: ロード時に USD/JPY を取得 (キャッシュ即時反映→ネットワーク鮮度更新)、ドル建てサブスクの円額を最新レートで再計算・保存 (レート変動に自動追随)。編集ダイアログへ現行レートを受け渡し。

## 制約 (PR body に明記)

取得元は銀行間/参照レートのため、カード会社の実際の請求レート (手数料上乗せ ~1.6-3%) とは差が出る。あくまで見込み額の推定に使う。将来的にレート源のエッジ関数化や手数料%上乗せの設定は follow-up 可能。

## 検証

- `flutter analyze` (変更5ファイル + page): **No issues found!**
- `flutter test`: モデル通貨 **7件** (json後方互換 / USD往復 / 換算+丸め / レート欠如据え置き / JPY no-op / 不正usdAmount除外) + `FxRateService` **6件** (取得+パース / 鮮度キャッシュで再fetch無し / 失敗時フォールバック / 未取得時null / result:error無視 / TTL経過で再取得) = 全緑。既存の recurring fixed cost 系テスト (injection/store/editor dialog) も回帰なし。
- `dart fix` / `dart format`: 適用済み

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 本文キーワード(支払/負債)による prose-only トリガ。変更は Flutter クライアントのサブスク金額の通貨対応 (モデル/入力UI/為替取得サービス=単体テスト13件追加) のみで、認証・認可・EF・migration・DB書き込み経路のロジック変更を含まない。外部取得は無料・キー不要の公開為替APIをクライアントから read-only 取得しキャッシュ (フォールバック付き)。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 変更は純ロジック (モデル通貨換算/FxRateService=単体テスト13件追加済) と認証必須ページ内の編集ダイアログUIのみで headless E2E 到達不能。既存 unit + 全repo analyze 緑で担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
