### PR TITLE
feat(asset): 統合アラートパネル (異常検知+リマインダー統合) #2475

### DIFF
--- a/lib/models/asset_alert.dart
+++ b/lib/models/asset_alert.dart
@@ -1,0 +1,96 @@
+/// 資産アラートの重要度。数値が大きいほど緊急。
+enum AssetAlertSeverity {
+  info,
+  warning,
+  critical,
+}
+
+extension AssetAlertSeverityMeta on AssetAlertSeverity {
+  /// ソート用の重み (大きいほど上位)。
+  int get weight {
+    switch (this) {
+      case AssetAlertSeverity.critical:
+        return 3;
+      case AssetAlertSeverity.warning:
+        return 2;
+      case AssetAlertSeverity.info:
+        return 1;
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case AssetAlertSeverity.critical:
+        return '緊急';
+      case AssetAlertSeverity.warning:
+        return '注意';
+      case AssetAlertSeverity.info:
+        return '情報';
+    }
+  }
+}
+
+/// アラートの発生源カテゴリ。
+enum AssetAlertCategory {
+  /// 支払期日超過 (延滞)。
+  overduePayment,
+
+  /// 口座残高ショート見込み。
+  accountShortfall,
+
+  /// 支払日前リマインダー (#2453)。
+  paymentDue,
+
+  /// 支払原資未設定。
+  paymentSourceMissing,
+
+  /// 異常検知 (第2弾D / #2476-#2477)。将来の外部注入用。
+  anomaly,
+}
+
+extension AssetAlertCategoryMeta on AssetAlertCategory {
+  String get storageId {
+    switch (this) {
+      case AssetAlertCategory.overduePayment:
+        return 'overdue_payment';
+      case AssetAlertCategory.accountShortfall:
+        return 'account_shortfall';
+      case AssetAlertCategory.paymentDue:
+        return 'payment_due';
+      case AssetAlertCategory.paymentSourceMissing:
+        return 'payment_source_missing';
+      case AssetAlertCategory.anomaly:
+        return 'anomaly';
+    }
+  }
+}
+
+/// 統合アラートパネル (Issue #2475) の 1 件。
+///
+/// 複数の発生源 (延滞・口座ショート・支払リマインダー・原資未設定・異常検知) を
+/// 単一のリストへ集約するための正規化モデル。[id] は dismiss 永続化の鍵であり、
+/// 「同じ発生事象」には安定、期日など状態が変われば別値になるよう構築する
+/// (= 解消後に再発した事象は新しい id で再表示される)。
+class AssetAlert {
+  final String id;
+  final AssetAlertSeverity severity;
+  final AssetAlertCategory category;
+  final String title;
+  final String detail;
+
+  /// 並び替えの第2キー (期日等)。null は末尾寄せ。
+  final DateTime? occurredAt;
+
+  /// 関連口座 ID (任意)。
+  final String? accountId;
+
+  const AssetAlert({
+    required this.id,
+    required this.severity,
+    required this.category,
+    required this.title,
+    required this.detail,
+    this.occurredAt,
+    this.accountId,
+  });
+}

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -64,6 +64,8 @@ import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_triage_guide_service.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_inputs.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
+import 'package:my_web_app/services/asset_alert_center_service.dart';
+import 'package:my_web_app/services/asset_alert_dismissal_store.dart';
 import 'package:my_web_app/services/asset_cashflow_statement_service.dart';
 import 'package:my_web_app/services/asset_category_budget_service.dart';
 import 'package:my_web_app/services/asset_category_budget_store.dart';
@@ -92,6 +94,7 @@ import 'package:my_web_app/services/waste_tracking_service.dart';
 import 'package:my_web_app/utils/note_image_clipboard.dart';
 import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
+import 'package:my_web_app/widgets/asset_alert_center_card.dart';
 import 'package:my_web_app/widgets/asset_cashflow_statement_card.dart';
 import 'package:my_web_app/widgets/asset_category_budget_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
@@ -773,6 +776,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       const AssetLiabilityPlanningService();
   final AssetLiabilityPaymentReminderService _assetLiabilityReminderService =
       const AssetLiabilityPaymentReminderService();
+  final AssetAlertCenterService _assetAlertCenterService =
+      const AssetAlertCenterService();
+  final AssetAlertDismissalStore _assetAlertDismissalStore =
+      const AssetAlertDismissalStore();
+  Set<String> _assetAlertDismissedIds = <String>{};
   final AssetLiabilityRepaymentSimulationService
       _assetLiabilityRepaymentSimulationService =
       const AssetLiabilityRepaymentSimulationService();
@@ -1048,6 +1056,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     unawaited(_loadRecurringIncomeIgnored());
     unawaited(_loadDuplicateIgnored());
     unawaited(_loadDrinkChallenge());
+    unawaited(_loadAssetAlertDismissedIds());
     _loadExpectedInflows();
     // ローカル→サーバの順で GC 設定を反映してから削除トゥームストーンを取込む。
     unawaited(_initTombstoneGcAndPull());
@@ -8734,6 +8743,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             )) ...[
               _buildCashflowStatementCard(assetLiabilityWorkbook),
             ],
+            if (_isSectionShown(
+              AssetManagementSectionId.alertCenter,
+            )) ...[
+              _buildAssetAlertCenterCard(assetLiabilityWorkbook),
+            ],
             // 提案カード(定期取引/定期収入の自動検出)は給与内訳に相乗りせず専用
             // セクションへ。salaryBreakdown を隠しても提案だけ独立表示できる。
             if (_isSectionShown(AssetManagementSectionId.proposals)) ...[
@@ -14259,6 +14273,60 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       child: AssetCashflowStatementCard(
         statement: statement,
         currencyFormatter: _formatYen,
+      ),
+    );
+  }
+
+  /// dismiss 済みアラート id をローカルから読み込む (Issue #2475)。
+  Future<void> _loadAssetAlertDismissedIds() async {
+    final ids = await _assetAlertDismissalStore.load();
+    if (!mounted) {
+      return;
+    }
+    setState(() => _assetAlertDismissedIds = ids);
+  }
+
+  Future<void> _dismissAssetAlert(String id) async {
+    final next = await _assetAlertDismissalStore.dismiss(id);
+    if (!mounted) {
+      return;
+    }
+    setState(() => _assetAlertDismissedIds = next);
+  }
+
+  Future<void> _restoreDismissedAssetAlerts() async {
+    final store = await SharedPreferences.getInstance();
+    await store.remove(AssetAlertDismissalStore.prefsKey);
+    if (!mounted) {
+      return;
+    }
+    setState(() => _assetAlertDismissedIds = <String>{});
+  }
+
+  /// 統合アラートパネル (Issue #2475)。延滞・口座ショート・支払リマインダー(#2453)・
+  /// 支払原資未設定を重要度別に集約する。異常検知 (第2弾D) は将来 anomalyAlerts で
+  /// 注入する統合設計。金額・重要度判定は純サービスで deterministic に行う。
+  Widget _buildAssetAlertCenterCard(AssetLiabilityWorkbook? workbook) {
+    if (workbook == null) {
+      return const SizedBox.shrink();
+    }
+    final center = _assetAlertCenterService.build(
+      workbook: workbook,
+      now: _now,
+      dismissedIds: _assetAlertDismissedIds,
+    );
+    // 表示するアラートも dismiss 済みも無ければカードを出さない。
+    if (!center.hasAlerts && center.dismissedCount == 0) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: AssetAlertCenterCard(
+        center: center,
+        onDismiss: _dismissAssetAlert,
+        onRestoreDismissed: center.dismissedCount > 0
+            ? () => unawaited(_restoreDismissedAssetAlerts())
+            : null,
       ),
     );
   }

--- a/lib/services/asset_alert_center_service.dart
+++ b/lib/services/asset_alert_center_service.dart
@@ -1,0 +1,180 @@
+import 'package:intl/intl.dart';
+
+import '../models/asset_alert.dart';
+import '../models/asset_liability_workbook.dart';
+import 'asset_liability_payment_reminder_service.dart';
+
+/// 統合アラートパネル (Issue #2475) の集約結果。
+class AssetAlertCenter {
+  /// 重要度降順 → 発生日昇順 で並んだ、未 dismiss のアラート。
+  final List<AssetAlert> alerts;
+
+  /// dismiss 済みで非表示にした件数。
+  final int dismissedCount;
+
+  const AssetAlertCenter({
+    required this.alerts,
+    required this.dismissedCount,
+  });
+
+  static const AssetAlertCenter empty = AssetAlertCenter(
+    alerts: <AssetAlert>[],
+    dismissedCount: 0,
+  );
+
+  bool get hasAlerts => alerts.isNotEmpty;
+
+  int get criticalCount =>
+      alerts.where((a) => a.severity == AssetAlertSeverity.critical).length;
+
+  int get warningCount =>
+      alerts.where((a) => a.severity == AssetAlertSeverity.warning).length;
+}
+
+/// 複数の発生源から資産アラートを集約する純サービス。
+///
+/// - 延滞 / 支払リマインダーは [AssetLiabilityPaymentReminderService] の候補を
+///   単一の真実として使い、延滞行の二重計上を避ける。
+/// - 口座ショート・支払原資未設定は workbook から直接導出する。
+/// - 異常検知 (第2弾D / #2476-#2477) は [anomalyAlerts] として外部注入できる
+///   (D 未実装の現時点では空のまま統合設計だけ用意する)。
+/// - 判定・金額整形はすべて deterministic。AI は関与しない (issue 注意事項準拠)。
+class AssetAlertCenterService {
+  const AssetAlertCenterService({
+    this.reminderService = const AssetLiabilityPaymentReminderService(),
+  });
+
+  final AssetLiabilityPaymentReminderService reminderService;
+
+  static final NumberFormat _yen = NumberFormat.decimalPattern();
+
+  /// アラートを集約する。
+  ///
+  /// [dismissedIds] に含まれる id のアラートは除外し [AssetAlertCenter.dismissedCount]
+  /// に数える。[anomalyAlerts] は将来の異常検知結果を注入するための口。
+  AssetAlertCenter build({
+    required AssetLiabilityWorkbook workbook,
+    required DateTime now,
+    Set<String> dismissedIds = const <String>{},
+    List<AssetAlert> anomalyAlerts = const <AssetAlert>[],
+    int reminderLookAheadDays = 1,
+  }) {
+    final collected = <AssetAlert>[];
+
+    // 1. 延滞 + 支払日前リマインダー (#2453) — reminder 候補を単一ソースに。
+    final reminders = reminderService.buildCandidates(
+      workbook: workbook,
+      now: now,
+      lookAheadDays: reminderLookAheadDays,
+    );
+    for (final reminder in reminders) {
+      collected.add(_fromReminder(reminder));
+    }
+
+    // 2. 口座残高ショート見込み。
+    for (final summary in workbook.shortAccountSummaries) {
+      collected.add(
+        AssetAlert(
+          id: 'account_shortfall:${summary.accountId}',
+          severity: AssetAlertSeverity.critical,
+          category: AssetAlertCategory.accountShortfall,
+          title: '${summary.accountName} が残高不足の見込み',
+          detail: '見込み残高が ¥${_formatYen(summary.projectedBalance)} '
+              '(不足 ¥${_formatYen(summary.shortfall)})。入金または資金移動を検討してください。',
+          accountId: summary.accountId,
+        ),
+      );
+    }
+
+    // 3. 支払原資未設定。
+    for (final row in workbook.paymentSourceMissingRows) {
+      collected.add(
+        AssetAlert(
+          id: 'payment_source_missing:${row.id}',
+          severity: AssetAlertSeverity.warning,
+          category: AssetAlertCategory.paymentSourceMissing,
+          title: '${row.name} の支払原資が未設定',
+          detail:
+              '予定支払 ¥${_formatYen(row.scheduledPaymentAmount)} の引落口座が未設定です。',
+          accountId: row.id,
+        ),
+      );
+    }
+
+    // 4. 異常検知 (外部注入 / 第2弾D)。
+    collected.addAll(anomalyAlerts);
+
+    // id 重複排除 (同一 id は最初の 1 件を優先)。
+    final seen = <String>{};
+    final deduped = <AssetAlert>[];
+    for (final alert in collected) {
+      if (seen.add(alert.id)) {
+        deduped.add(alert);
+      }
+    }
+
+    // dismiss 済みを除外。
+    final visible = <AssetAlert>[];
+    var dismissed = 0;
+    for (final alert in deduped) {
+      if (dismissedIds.contains(alert.id)) {
+        dismissed += 1;
+      } else {
+        visible.add(alert);
+      }
+    }
+
+    // 重要度降順 → occurredAt 昇順 (null は末尾) → id 昇順 で安定ソート。
+    visible.sort((a, b) {
+      final bySeverity = b.severity.weight.compareTo(a.severity.weight);
+      if (bySeverity != 0) {
+        return bySeverity;
+      }
+      final byDate = _compareNullableDate(a.occurredAt, b.occurredAt);
+      if (byDate != 0) {
+        return byDate;
+      }
+      return a.id.compareTo(b.id);
+    });
+
+    return AssetAlertCenter(alerts: visible, dismissedCount: dismissed);
+  }
+
+  AssetAlert _fromReminder(AssetLiabilityPaymentReminderCandidate reminder) {
+    final row = reminder.cashflowRow;
+    final dateKey = DateFormat('yyyy-MM-dd').format(row.paymentDate);
+    final isOverdue =
+        reminder.status == AssetLiabilityPaymentReminderStatus.overdue;
+    final category = isOverdue
+        ? AssetAlertCategory.overduePayment
+        : AssetAlertCategory.paymentDue;
+    // 延滞は critical、期日前でもショートリスクがあれば critical、そうでなければ warning。
+    final severity = (isOverdue || reminder.hasShortageRisk)
+        ? AssetAlertSeverity.critical
+        : AssetAlertSeverity.warning;
+    return AssetAlert(
+      id: '${category.storageId}:${row.accountId}:$dateKey',
+      severity: severity,
+      category: category,
+      title: reminder.title,
+      detail: reminder.detail,
+      occurredAt: row.paymentDate,
+      accountId: row.accountId,
+    );
+  }
+
+  static int _compareNullableDate(DateTime? a, DateTime? b) {
+    if (a == null && b == null) {
+      return 0;
+    }
+    if (a == null) {
+      return 1; // null は末尾。
+    }
+    if (b == null) {
+      return -1;
+    }
+    return a.compareTo(b);
+  }
+
+  static String _formatYen(double value) => _yen.format(value.round());
+}

--- a/lib/services/asset_alert_dismissal_store.dart
+++ b/lib/services/asset_alert_dismissal_store.dart
@@ -1,0 +1,60 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 統合アラートパネル (Issue #2475) で dismiss したアラート id を永続化する。
+///
+/// ローカル (SharedPreferences) を一次ストアとする軽量な集合ストア。アラート id は
+/// 発生事象ごとに安定 (期日など状態が変われば別値) なので、解消後に再発した事象は
+/// 新しい id で再表示される。集合が肥大しないよう、[prune] で「現存する id」以外を
+/// 掃除できる。
+class AssetAlertDismissalStore {
+  static const String prefsKey = 'asset_alert_dismissed_ids_v1';
+
+  const AssetAlertDismissalStore();
+
+  Future<Set<String>> load({SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final raw = store.getStringList(prefsKey);
+    if (raw == null) {
+      return <String>{};
+    }
+    return raw.where((id) => id.trim().isNotEmpty).toSet();
+  }
+
+  Future<Set<String>> dismiss(String id, {SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final current = await load(prefs: store);
+    if (id.trim().isEmpty || current.contains(id)) {
+      return current;
+    }
+    final next = {...current, id};
+    await store.setStringList(prefsKey, next.toList());
+    return next;
+  }
+
+  Future<Set<String>> restore(String id, {SharedPreferences? prefs}) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final current = await load(prefs: store);
+    if (!current.contains(id)) {
+      return current;
+    }
+    final next = {...current}..remove(id);
+    await store.setStringList(prefsKey, next.toList());
+    return next;
+  }
+
+  /// [liveIds] に含まれない dismiss 済み id を削除する (集合の肥大防止)。
+  /// 返り値は掃除後の集合。
+  Future<Set<String>> prune(
+    Set<String> liveIds, {
+    SharedPreferences? prefs,
+  }) async {
+    final store = prefs ?? await SharedPreferences.getInstance();
+    final current = await load(prefs: store);
+    final next = current.intersection(liveIds);
+    if (next.length == current.length) {
+      return current;
+    }
+    await store.setStringList(prefsKey, next.toList());
+    return next;
+  }
+}

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -32,6 +32,7 @@ enum AssetManagementSectionId {
   mustTasks,
   chart,
   cashflowStatement,
+  alertCenter,
 }
 
 /// セクション単位の表示上書き。auto はティア×モードの既定に従う。
@@ -112,6 +113,8 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
         return 'グラフ';
       case AssetManagementSectionId.cashflowStatement:
         return '月次キャッシュフロー';
+      case AssetManagementSectionId.alertCenter:
+        return 'アラートセンター';
     }
   }
 
@@ -140,6 +143,7 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
       case AssetManagementSectionId.chart:
       // 新規パネルは段階的 rollout のため full モード限定 (= OFF by default)。
       case AssetManagementSectionId.cashflowStatement:
+      case AssetManagementSectionId.alertCenter:
         return AssetManagementSectionTier.full;
     }
   }

--- a/lib/widgets/asset_alert_center_card.dart
+++ b/lib/widgets/asset_alert_center_card.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+
+import '../models/asset_alert.dart';
+import '../services/asset_alert_center_service.dart';
+
+/// 統合アラートパネル (Issue #2475)。
+///
+/// 純サービス [AssetAlertCenterService] が集約した [AssetAlertCenter] を受け取り、
+/// 重要度別に並んだアラートを badge 付きで描画する。各行の dismiss ボタンで
+/// [onDismiss] を呼ぶ。ページ状態へ依存しないため単体検証できる。
+class AssetAlertCenterCard extends StatelessWidget {
+  const AssetAlertCenterCard({
+    super.key,
+    required this.center,
+    this.onDismiss,
+    this.onRestoreDismissed,
+  });
+
+  final AssetAlertCenter center;
+
+  /// アラートを dismiss したとき (id を渡す)。null なら dismiss ボタンを出さない。
+  final ValueChanged<String>? onDismiss;
+
+  /// 「非表示を戻す」リンク。null なら出さない。
+  final VoidCallback? onRestoreDismissed;
+
+  static const Color _critical = Color(0xFFDC2626);
+  static const Color _warning = Color(0xFFD97706);
+  static const Color _info = Color(0xFF4F46E5);
+  static const Color _muted = Color(0xFF6B7280);
+
+  Color _severityColor(AssetAlertSeverity severity) {
+    switch (severity) {
+      case AssetAlertSeverity.critical:
+        return _critical;
+      case AssetAlertSeverity.warning:
+        return _warning;
+      case AssetAlertSeverity.info:
+        return _info;
+    }
+  }
+
+  IconData _severityIcon(AssetAlertSeverity severity) {
+    switch (severity) {
+      case AssetAlertSeverity.critical:
+        return Icons.error_outline;
+      case AssetAlertSeverity.warning:
+        return Icons.warning_amber_outlined;
+      case AssetAlertSeverity.info:
+        return Icons.info_outline;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (!center.hasAlerts) {
+      return _buildEmpty(theme);
+    }
+
+    return Card(
+      key: const Key('asset_alert_center_card'),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(theme),
+            const SizedBox(height: 12),
+            for (final alert in center.alerts) _buildAlertRow(theme, alert),
+            if (center.dismissedCount > 0 && onRestoreDismissed != null) ...[
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  key: const Key('asset_alert_center_restore'),
+                  onPressed: onRestoreDismissed,
+                  child: Text('非表示 ${center.dismissedCount} 件を戻す'),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(ThemeData theme) {
+    return Row(
+      children: [
+        const Icon(Icons.notifications_active_outlined, color: _info),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            'アラートセンター',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        if (center.criticalCount > 0)
+          _buildCountChip(theme, '緊急 ${center.criticalCount}', _critical),
+        if (center.warningCount > 0) ...[
+          const SizedBox(width: 6),
+          _buildCountChip(theme, '注意 ${center.warningCount}', _warning),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildCountChip(ThemeData theme, String label, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAlertRow(ThemeData theme, AssetAlert alert) {
+    final color = _severityColor(alert.severity);
+    return Container(
+      key: Key('asset_alert_row_${alert.id}'),
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: color.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(_severityIcon(alert.severity), size: 20, color: color),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    _buildSeverityBadge(theme, alert.severity, color),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        alert.title,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  alert.detail,
+                  style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+                ),
+              ],
+            ),
+          ),
+          if (onDismiss != null)
+            IconButton(
+              key: Key('asset_alert_dismiss_${alert.id}'),
+              icon: const Icon(Icons.close, size: 18),
+              color: _muted,
+              tooltip: '非表示にする',
+              onPressed: () => onDismiss!(alert.id),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSeverityBadge(
+    ThemeData theme,
+    AssetAlertSeverity severity,
+    Color color,
+  ) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        severity.label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmpty(ThemeData theme) {
+    return Card(
+      key: const Key('asset_alert_center_card_empty'),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Row(
+          children: [
+            const Icon(Icons.check_circle_outline, color: Color(0xFF059669)),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                '対応が必要なアラートはありません。',
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+            if (center.dismissedCount > 0 && onRestoreDismissed != null)
+              TextButton(
+                key: const Key('asset_alert_center_restore_empty'),
+                onPressed: onRestoreDismissed,
+                child: Text('非表示 ${center.dismissedCount} 件を戻す'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/asset_alert_center_service_test.dart
+++ b/test/services/asset_alert_center_service_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_alert.dart';
+import 'package:my_web_app/services/asset_alert_center_service.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  const planner = AssetLiabilityPlanningService();
+  const service = AssetAlertCenterService();
+
+  AssetAlert anomaly(String id, AssetAlertSeverity severity) {
+    return AssetAlert(
+      id: id,
+      severity: severity,
+      category: AssetAlertCategory.anomaly,
+      title: 'anomaly $id',
+      detail: 'detail $id',
+    );
+  }
+
+  group('AssetAlertCenterService.build', () {
+    test('surfaces overdue payments as critical alerts', () {
+      final now = DateTime(2026, 5, 14);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: <String, double>{
+          '財布': 25000,
+          'アコムカードローン': -100000,
+          'モビット': -100000,
+        },
+        baseDate: now,
+        monthlyPaymentOverrides: const <String, double>{
+          'アコムカードローン': 5000,
+          'モビット': 9000,
+        },
+      );
+
+      final center = service.build(workbook: workbook, now: now);
+
+      expect(center.hasAlerts, isTrue);
+      expect(
+        center.alerts.any(
+          (a) => a.category == AssetAlertCategory.overduePayment,
+        ),
+        isTrue,
+      );
+      // 全アラートは重要度降順で並ぶ。
+      for (var i = 1; i < center.alerts.length; i++) {
+        expect(
+          center.alerts[i - 1].severity.weight >=
+              center.alerts[i].severity.weight,
+          isTrue,
+        );
+      }
+    });
+
+    test('injected anomaly alerts are merged and severity-sorted', () {
+      final now = DateTime(2026, 5, 15);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: <String, double>{'財布': 100000},
+        baseDate: now,
+      );
+
+      final center = service.build(
+        workbook: workbook,
+        now: now,
+        anomalyAlerts: [
+          anomaly('a-info', AssetAlertSeverity.info),
+          anomaly('a-critical', AssetAlertSeverity.critical),
+          anomaly('a-warning', AssetAlertSeverity.warning),
+        ],
+      );
+
+      expect(
+        center.alerts.map((a) => a.id).toList(),
+        ['a-critical', 'a-warning', 'a-info'],
+      );
+      expect(center.criticalCount, 1);
+      expect(center.warningCount, 1);
+    });
+
+    test('dismissed ids are filtered out and counted', () {
+      final now = DateTime(2026, 5, 15);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: <String, double>{'財布': 100000},
+        baseDate: now,
+      );
+
+      final center = service.build(
+        workbook: workbook,
+        now: now,
+        anomalyAlerts: [
+          anomaly('a-critical', AssetAlertSeverity.critical),
+          anomaly('a-warning', AssetAlertSeverity.warning),
+        ],
+        dismissedIds: {'a-warning'},
+      );
+
+      expect(center.alerts.map((a) => a.id).toList(), ['a-critical']);
+      expect(center.dismissedCount, 1);
+    });
+
+    test('duplicate ids are de-duplicated (first wins)', () {
+      final now = DateTime(2026, 5, 15);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: <String, double>{'財布': 100000},
+        baseDate: now,
+      );
+
+      final center = service.build(
+        workbook: workbook,
+        now: now,
+        anomalyAlerts: [
+          anomaly('dup', AssetAlertSeverity.critical),
+          anomaly('dup', AssetAlertSeverity.info),
+        ],
+      );
+
+      expect(center.alerts.where((a) => a.id == 'dup').length, 1);
+      expect(
+        center.alerts.firstWhere((a) => a.id == 'dup').severity,
+        AssetAlertSeverity.critical,
+      );
+    });
+
+    test('empty workbook with no anomalies yields no alerts', () {
+      final now = DateTime(2026, 5, 15);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: <String, double>{'財布': 500000},
+        baseDate: now,
+      );
+
+      final center = service.build(workbook: workbook, now: now);
+      expect(center.hasAlerts, isFalse);
+      expect(center.dismissedCount, 0);
+    });
+
+    test('same-severity alerts sort by occurredAt then id (stable)', () {
+      final now = DateTime(2026, 5, 15);
+      final workbook = planner.buildWorkbook(
+        latestSnapshot: <String, double>{'財布': 100000},
+        baseDate: now,
+      );
+
+      final center = service.build(
+        workbook: workbook,
+        now: now,
+        anomalyAlerts: [
+          // occurredAt null → 末尾。id 昇順で b→a ではなく a→b。
+          anomaly('z', AssetAlertSeverity.warning),
+          anomaly('a', AssetAlertSeverity.warning),
+        ],
+      );
+
+      expect(center.alerts.map((a) => a.id).toList(), ['a', 'z']);
+    });
+  });
+}

--- a/test/services/asset_alert_dismissal_store_test.dart
+++ b/test/services/asset_alert_dismissal_store_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_alert_dismissal_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const store = AssetAlertDismissalStore();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('load returns empty set when nothing stored', () async {
+    final prefs = await SharedPreferences.getInstance();
+    expect(await store.load(prefs: prefs), isEmpty);
+  });
+
+  test('dismiss persists and load returns the id', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final next = await store.dismiss('overdue:acc:2026-05-15', prefs: prefs);
+    expect(next, contains('overdue:acc:2026-05-15'));
+    expect(await store.load(prefs: prefs), contains('overdue:acc:2026-05-15'));
+  });
+
+  test('dismiss is idempotent and ignores blank ids', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.dismiss('a', prefs: prefs);
+    final again = await store.dismiss('a', prefs: prefs);
+    expect(again, {'a'});
+    final blank = await store.dismiss('   ', prefs: prefs);
+    expect(blank, {'a'});
+  });
+
+  test('restore removes a dismissed id', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.dismiss('a', prefs: prefs);
+    await store.dismiss('b', prefs: prefs);
+    final next = await store.restore('a', prefs: prefs);
+    expect(next, {'b'});
+  });
+
+  test('prune keeps only live ids', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await store.dismiss('a', prefs: prefs);
+    await store.dismiss('b', prefs: prefs);
+    await store.dismiss('c', prefs: prefs);
+    final next = await store.prune({'b', 'c', 'x'}, prefs: prefs);
+    expect(next, {'b', 'c'});
+    expect(await store.load(prefs: prefs), {'b', 'c'});
+  });
+}


### PR DESCRIPTION
## 概要
Issue #2475 (第2弾C)。資産管理ページに散在していたアラートを、重要度別の**単一の統合パネル**へ集約する。

## スコープ対応
- **#2453 支払日前リマインダー統合表示** — reminder 候補を取り込み
- **D feature 異常検知 result 統合表示** — 第2弾D (#2476/#2477) は未実装のため、`anomalyAlerts` として**外部注入できる統合設計**を用意 (D 着地後は注入するだけで表示に乗る)
- **重要度別 sort + dismiss** — 重要度降順ソート + 行ごとの dismiss (永続化)

## 実装
- 純サービス `AssetAlertCenterService` が 4 発生源を集約: 延滞 / 口座残高ショート / 支払日前リマインダー / 支払原資未設定。判定・整形はすべて **deterministic**（AI非関与 / issue注意事項準拠）。
- ウィジェット `AssetAlertCenterCard` は自己完結（ページ状態非依存）で単体検証可能。
- dismiss は `AssetAlertDismissalStore`（ローカル SharedPreferences）に永続化。

## 安全性 / 設計上の考慮
- **延滞の二重計上を回避**: 延滞は reminder 候補を単一ソースとし、`overdueCashflowRows` からの重複生成をしない。
- **dismiss id は「発生事象ごとに安定・状態が変われば別値」**（例 `payment_due:<accountId>:<期日>`）。これにより一度 dismiss しても、**解消後に再発した事象は新しい id で再表示**される（恒久的に隠れて見落とす事故を防ぐ）。
- 同一 id は重複排除（最初の1件優先）。同順位は発生日→id で**安定ソート**。
- dismiss 済み件数を表示し「非表示 N 件を戻す」導線を用意（隠したまま忘れない）。

## 受け入れ条件
- [x] 既存資産管理機能を壊さない (#2446-#2456 整合 / 既存バナー・パネルは非変更、新セクションを追加するのみ)
- [x] テスト緑 (新規 unit 11件 pass、変更ファイル analyze 0 / format clean)
- [x] feature flag OFF default + 段階的 rollout: セクション tier=`full` 限定（既定非表示、フルモード/ピンで opt-in）

## テスト
`test/services/asset_alert_center_service_test.dart` (6件) — 集約 / 重要度ソート / dismiss除外+件数 / 重複排除 / 異常検知注入 / 同順位安定ソート。
`test/services/asset_alert_dismissal_store_test.dart` (5件) — 永続化 / 冪等 / restore / prune。

Closes #2475

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 読み取り専用の集約表示パネルで full モード限定 (既定OFF)。集約・重要度ソート・dismiss の決定論的ロジックは表示層非依存の unit 11件で網羅済みのため、複数アラート源を seed する integration_test は不均衡

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更は lib/ のUI・純サービス・ローカル永続化のみでEF/認証/RLSに無関係。集約と重要度判定はdeterministicでunit11件で検証済み
