### PR TITLE
perf(agent): agent_memories の本番 statement timeout(500) を既存索引経由で解消 (part340)

### DIFF
--- a/lib/services/agent_org_service.dart
+++ b/lib/services/agent_org_service.dart
@@ -412,10 +412,20 @@ class AgentOrgService {
         .map((row) => AgentTask.fromJson(Map<String, dynamic>.from(row)))
         .toList();
 
+    // R31: agent_memories は user_id に索引が無く (索引は
+    // idx_agent_memories_agent_created(agent_id, created_at DESC) のみ)、
+    // user_id 単独で絞ると追記専用ログの全表走査になり本番で statement timeout
+    // (500 / 57014) を起こしていた。自分の agent_id 群で絞れば既存索引に載る。
+    // 本番実測: agent_id 経由 122ms vs user_id 単独 7929ms(閾値8s付近で500と往復)。
+    // agent_memories.agent_id は agents(id) への NOT NULL FK で agents は本ユーザー
+    // の全件 (ensureExecutiveAgents→_loadAgentsForUser) のため取得行は同一。
+    // user_id 条件も RLS と意図明示のため残す (索引で絞った少数行への評価で安価)。
+    final agentIds = agents.map((agent) => agent.id).toList();
     final dynamic memoryRows = await _supabase
         .from('agent_memories')
         .select()
         .eq('user_id', userId)
+        .inFilter('agent_id', agentIds)
         .order('created_at', ascending: false)
         .limit(40);
     final memories = (memoryRows as List)


### PR DESCRIPTION
## 概要 🔴 本番 500 の解消

/admin の Network タブに出ていた **`agent_memories → 500 / 8.12s`** を追跡し、本番実測で根因と修正効果を確定した。**migration 無し**・クライアント1クエリの変更で解消。

## 根因: `user_id` に索引が無い

`agent_memories` の索引は **`idx_agent_memories_agent_created(agent_id, created_at DESC)` のみ** (`20260304000000_create_agent_org_tables.sql:74`)。一方 RLS は `auth.uid() = user_id` (`:134`)、`loadSnapshot()` も user_id 単独で絞る → **追記専用ログの全表走査** → 閾値(≈8s)付近で 500 `57014 statement timeout` と成功を往復する不安定症状。

### 本番実測 — 同一表 A/B (決定的)
| クエリ | 実測 |
|---|---|
| `agent_id=eq.<uuid>` (**索引あり**) | **122ms** |
| `user_id=eq.<uid>` (**索引なし**) | **7,929ms** |
| フィルタ無し (RLS の user_id のみ) | **500 @ 8,167ms** |

`limit=1` でもタイムアウトするのが missing-index の署名 (0行ユーザーは「該当なし」の証明に全表走査が要る)。

### 兄弟表との対照 (RLS は3表とも同一 `auth.uid() = user_id`)
| テーブル | user_id 索引 | 実測 |
|---|---|---|
| `agents` | ✅ | 337ms |
| `agent_tasks` | ✅ | 252ms |
| `agent_memories` | ❌ | **500 timeout** |

## 修正: 既存索引に載せる (migration 不要)

`loadSnapshot()` の agent_memories 取得に**本ユーザーの agent_id 群**を併用して絞る。
**行の同一性**: `agent_memories.agent_id` は `agents(id)` への NOT NULL FK / `ensureExecutiveAgents()→_loadAgentsForUser()` は executive だけでなく**本ユーザーの全 agent** を返す / RLS も不変 → 取得行は同一。user_id 条件は RLS・意図明示のため残す(索引で絞った少数行への評価なので安価)。

**修正後の本番実測 (同一形状 A/B): OLD 7,743ms → NEW 503ms**

大表への `CREATE INDEX`(要 CONCURRENTLY・トランザクション外) はリスクがあるため本PRでは行わず、再発防止の索引追加は **#4202** に evidence 付きで残置 (EXPLAIN 確認の上で適用)。

## 副次的に判明した実害
この500は `_loadStartupPromptFor` の catch で握りつぶされ、`_consultSecretary` はそのまま `ai-assistant` を呼ぶ (`ai_secretary_page.dart:152-155, 201-214`)。つまり **8秒待たされた上に AI秘書のプロンプトが記憶で補強されないまま劣化実行**されていた(無言)。本修正で待ち時間が解消し記憶補強も機能する。

## 補足: この通信は /admin の受動ロードではない
グローバルサービス無し・可視化ゲート漏れ無し(home_page に agent 参照ゼロ)。唯一の /admin 経路は「AI改善で体験導線改善」ボタン→`AISecretaryPage(autoRunOnOpen:true)`。Flutter Web は `Navigator.push` でリロードしないため **DevTools Network がクライアント側ルート跨ぎで累積**する。

## 検証
- 本番 anon probe で修正前後を同一形状 A/B 実測 (上表)
- `flutter analyze` 0 issue / `dart format` 差分なし

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Single client-side query change: add the users own agent_id IN filter to an existing agent_memories read so it uses the existing index; row-equivalent (FK + all-agents loader + unchanged RLS). No auth/RLS/payment/secret/schema/edge changes. Verified in production 7743ms to 503ms

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Single-query performance fix verified end-to-end against production data path (same-shape A/B probe: 7,743ms -> 503ms; indexed vs unindexed column A/B on the same table). Row-equivalence argued from FK + loader returning all agents + unchanged RLS. No new user-visible flow; flutter analyze 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
