### PR TITLE
perf(asset): 資産管理闘争 10仮説検証 第7弾 — 給料日ミラー復元の無駄リロード解消 + ID移行の暴走書き込みガード

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -849,6 +849,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   String? _assetDebtTrendPriorBalancesMonth;
   // 今月の残高記録の重複実行を防ぐシグネチャ(monthKey + 残高内容)。
   String? _assetDebtTrendSyncedSignature;
+
+  /// レガシーキー移行 (`_scheduleAssetLiabilityStateIdMigration`) の適用回数。
+  /// この移行は build から毎フレーム評価され、差分があると setState + 月次state
+  /// 保存を行うため、変換が不動点にならない場合フレーム毎に upsert が走り得る。
+  /// 本来1回で収束する処理なので上限で暴走を止める (超過時は debugPrint)。
+  int _assetLiabilityStateIdMigrationApplies = 0;
+  static const int _assetLiabilityStateIdMigrationMaxApplies = 5;
   final AssetSalaryDayStore _salaryDayStore = const AssetSalaryDayStore();
   static const String _salaryDayMirrorKey = 'salary_day';
   final AssetSalaryAmountStore _salaryAmountStore =
@@ -2679,6 +2686,22 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _sameTransferTasks(_transferTasks, migrated.transferTasks)) {
       return;
     }
+
+    // このメソッドは build から毎フレーム呼ばれ、差分があると setState + 月次state
+    // 保存 (2テーブル upsert) を行い、その setState が次の build を呼ぶ。
+    // migrateLegacyKeys が不動点でない場合 (ある負債行の name が別行の id と一致し
+    // キーが連鎖する等) 収束せずフレーム毎に upsert が走り得る。レガシーキー移行は
+    // 本来1回で収束するため、マウントあたりの適用回数に上限を設けて暴走書き込みを
+    // 止め、異常を可視化する。
+    if (_assetLiabilityStateIdMigrationApplies >=
+        _assetLiabilityStateIdMigrationMaxApplies) {
+      debugPrint(
+        'asset liability state id migration did not converge '
+        '(applied $_assetLiabilityStateIdMigrationApplies times); skipping',
+      );
+      return;
+    }
+    _assetLiabilityStateIdMigrationApplies++;
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -8912,7 +8935,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       if (!mounted) {
         return;
       }
-      if (restored != _salaryDay || !_salaryDayConfigured) {
+      final changed = restored != _salaryDay || !_salaryDayConfigured;
+      if (changed) {
         setState(() {
           _salaryDay = restored;
           _salaryDayConfigured = true;
@@ -8922,8 +8946,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         _salaryDayStore.save(restored),
         'salary day restore save',
       );
-      // サイクル基準が変わるため月次stateを読み直す。
-      unawaited(_loadAssetLiabilityMonthlyState());
+      // サイクル基準が変わったときだけ月次stateを読み直す。ミラー値が現在値と
+      // 同じなら同一サイクル月の同一データで、起動毎に7往復のフルバッチが余分に
+      // 走るだけだった (兄弟の _restoreSalaryAmountFromMirror は同値なら早期
+      // return しており、そちらに揃える)。
+      if (changed) {
+        unawaited(_loadAssetLiabilityMonthlyState());
+      }
     } catch (e) {
       debugPrint('salary day mirror restore failed: $e');
     }


### PR DESCRIPTION
# 資産管理闘争ページ改善 第7弾 — 10仮説検証方式

本番トレース (build 4866 / 36分セッション) で `asset_liability_monthly_state` と `asset_liability_income_plans` が各 **~15回** 観測されたため、発火源を全数調査。10仮説を全件検証し、確定2件を修正した。

## 最重要の発見: 「~15回」の正体

**`saveMonth` も `loadMonth` と同じ2テーブルへペアで書き込む**ため、テーブル別リクエスト数では読み書きが区別できない。

```
loadMonth : _loadPayloadRow(monthlyStates) + _loadPayloadRow(incomePlans)   ← ペア
saveMonth : _upsertPayloadRow(monthlyStates) + _upsertPayloadRow(incomePlans) ← 同じペア
```

このセッションではユーザーが「引落済み」を連打しており (確認待ち 18→12→10件)、各クリックが即時 upsert ペアを発生させる。**~15ペアの大半は保存であり、ロードの暴走ではない。** 自動ループは存在しない (全7呼び出し箇所を追跡し確認)。

## 10仮説と判定

| # | 仮説 | 判定 |
|---|------|------|
| 1 | 月次stateを反復ロードする自動ループがある | ❌ 棄却 — 全7呼び出し箇所を追跡、ループ無し |
| 2 | ~15ペアは全て読み込み | ❌ **棄却 (核心)** — save も同ペアを書く。大半は「引落済み」操作の保存 |
| 3 | 給料検知 (毎秒) がリロードを繰り返す | ❌ 棄却 — `_salaryResetPending` + `_pendingSalaryResetAck` + max-mergeマーカーで確実にラッチ、サイクル最大1回 |
| 4 | 保存→ミラー→復元→再ロードの循環 | ❌ 棄却 — ミラーは `asset_pref_mirror` のみで月次stateテーブル非接触 |
| 5 | USD/為替機能 (#4200) が再ロードを誘発 | ❌ 棄却 — `_loadUsdJpyRate` は initState のみ、ローダー非呼出 |
| 6 | ライフサイクル/RouteObserver での再取得 | ❌ 棄却 — 該当observer無し、タイマーはdisposeで全解除 |
| 7 | **給料日ミラー復元が無変化でも再ロード** | ✅ 確定 → **本PRで修正** |
| 8 | **build から呼ばれるID移行に収束保証が無い** | ✅ 確定 → **本PRで修正** |
| 9 | 35箇所の保存が未デバウンス | ⚠️ 事実 → #4127 (即時保存は設計判断が要る) |
| 10 | ページ再マウント毎に2-3回ロード | ⚠️ 部分 → #7修正で1回削減、残りは #4127 |

## 変更内容 (確定2件)

1. **給料日ミラー復元の無駄ロード除去** — `_restoreSalaryDayFromMirror` がミラー値と現在値が同じでも無条件に `_loadAssetLiabilityMonthlyState()` を呼び、ページを開くたび7往復のフルバッチが余分に走っていた。サイクル基準が変わらなければ同一月キーの同一データで再取得は無意味。兄弟の `_restoreSalaryAmountFromMirror` は同値なら早期returnしており、**そちらに揃えて変化時のみ再ロード**する。

2. **ID移行の暴走書き込みガード** — `_scheduleAssetLiabilityStateIdMigration` は `build()` から毎フレーム評価され、差分があると setState + 月次state保存 (2テーブルupsert) を行い、その setState が次の build を呼ぶ。`migrateLegacyKeys` が不動点にならない場合 (負債行の name が別行の id と一致しキーが連鎖する等) 収束せずフレーム毎に upsert が走り得る。レガシーキー移行は本来1回で収束するため、**マウントあたりの適用回数に上限(5)** を設け、超過時は debugPrint して停止。隣接の `_scheduleAssetDebtTrendHistorySync` が持つ署名ガードと同趣旨。

## 検証

- `flutter analyze` (page): **No issues found!**
- `flutter test`: planning + auto-debit confirmation **87件緑** (回帰なし)
- `dart format`: 適用済み
- 修正1は「変化時のみ再ロード」= 取得データ不変 (同一月キー) / 修正2は上限まで従来どおり動作し、超過時のみ停止 = 正常な1回収束の移行には影響なし

## 別Issue

- **#4127** 35箇所の未デバウンス保存 / payment_source global行の二重読み / loadMonth の2分割解消 (抽象リポジトリ横断改修要)

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 本文キーワード(支払/引落)による prose-only トリガ。変更はFlutterクライアントの再ロード条件の絞り込みと移行適用回数の上限追加のみで、認証・認可・EF・migration・DB書き込み内容のロジック変更を含まない。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 変更は認証必須ページ内のロード条件/暴走ガードのみで headless E2E 到達不能。既存 unit 87件 + page analyze 緑で担保 (取得データ・保存内容は不変)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
