### PR TITLE
fix(wbs): WBSタスクを全件取得する (PostgREST 1000行上限で未完了件数が動かない)

### DIFF
--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -471,6 +471,43 @@ int _compareWbsTaskDisplayKeeper(WbsTask a, WbsTask b) {
 }
 
 @visibleForTesting
+
+/// PostgREST の既定 max-rows (1000) を超える表を全件取得するための汎用ページャ。
+///
+/// `.select()` に range を付けないと PostgREST は先頭 1000 行で打ち切る。WBS の
+/// `wbs_tasks` は 3695 行あり、打ち切られた結果ページ側の「未完了 N 件」は
+/// 全体ではなく先頭 1000 行だけの集計になっていた (= タスクを完了させても
+/// 窓の外の未完了行が滑り込むため件数がほぼ動かない)。
+///
+/// [fetchPage] は `[from, to]` (両端含む) の 1 ページを返す。返却件数が
+/// [pageSize] 未満になったら最終ページとみなして停止する。[maxRows] は
+/// 想定外の増殖・無限ループに対する安全弁 (超過分は取得しない)。
+///
+/// 注意: 呼び出し側は **一意なタイエブレーカを含む安定した order** を指定すること。
+/// 非一意なキーだけで並べるとページ境界で行の重複・欠落が起こりうる。
+Future<List<Map<String, dynamic>>> fetchAllPagedRows({
+  required Future<List<Map<String, dynamic>>> Function(int from, int to)
+      fetchPage,
+  int pageSize = 1000,
+  int maxRows = 20000,
+}) async {
+  assert(pageSize > 0, 'pageSize must be positive');
+  final rows = <Map<String, dynamic>>[];
+  var from = 0;
+  while (from < maxRows) {
+    final remaining = maxRows - from;
+    final take = remaining < pageSize ? remaining : pageSize;
+    final page = await fetchPage(from, from + take - 1);
+    rows.addAll(page);
+    // 返却件数が要求未満なら最終ページ (空ページ含む)。
+    if (page.length < take) {
+      break;
+    }
+    from += page.length;
+  }
+  return rows;
+}
+
 List<WbsTask> dedupeWbsTasksForDisplay(Iterable<WbsTask> tasks) {
   final ordered = <WbsTask>[];
   final indexByKey = <String, int>{};
@@ -636,20 +673,28 @@ class _ProjectGanttPageState extends State<ProjectGanttPage>
     try {
       final mData =
           await _supabase.from('wbs_milestones').select().order('target_date');
-      final tData = await _supabase
-          .from('wbs_tasks')
-          .select()
-          .order('category_order')
-          .order('status');
+      // wbs_tasks は PostgREST の既定 max-rows (1000) を超えるため全ページ取得する。
+      // order には一意な id をタイエブレーカとして必ず含める (非一意キーのみだと
+      // ページ境界で行の重複・欠落が起こる)。
+      final tData = await fetchAllPagedRows(
+        fetchPage: (from, to) async {
+          final page = await _supabase
+              .from('wbs_tasks')
+              .select()
+              .order('category_order')
+              .order('status')
+              .order('id')
+              .range(from, to);
+          return (page as List).cast<Map<String, dynamic>>();
+        },
+      );
       if (mounted) {
         setState(() {
           _milestones = (mData as List)
               .map((e) => WbsMilestone.fromMap(e as Map<String, dynamic>))
               .toList();
           _tasks = dedupeWbsTasksForDisplay(
-            (tData as List).map(
-              (e) => WbsTask.fromMap(e as Map<String, dynamic>),
-            ),
+            tData.map(WbsTask.fromMap),
           )..sort(_compareWbsTasks);
         });
       }

--- a/test/pages/project_gantt_paging_test.dart
+++ b/test/pages/project_gantt_paging_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/pages/project_gantt_page.dart';
+
+/// `[from, to]` (両端含む) を PostgREST と同じ意味で切り出す擬似サーバ。
+/// [maxRows] は PostgREST の max-rows 上限 (既定 1000) を模す。
+List<Map<String, dynamic>> _serve(
+  List<Map<String, dynamic>> all,
+  int from,
+  int to, {
+  int maxRows = 1000,
+}) {
+  if (from >= all.length) {
+    return <Map<String, dynamic>>[];
+  }
+  final requested = to - from + 1;
+  final capped = requested > maxRows ? maxRows : requested;
+  final end = (from + capped) > all.length ? all.length : from + capped;
+  return all.sublist(from, end);
+}
+
+List<Map<String, dynamic>> _rows(int n) =>
+    List.generate(n, (i) => <String, dynamic>{'id': 'id-$i'});
+
+void main() {
+  group('fetchAllPagedRows', () {
+    test('fetches every row when the table exceeds one page', () async {
+      final all = _rows(3695);
+      var calls = 0;
+      final result = await fetchAllPagedRows(
+        fetchPage: (from, to) async {
+          calls++;
+          return _serve(all, from, to);
+        },
+      );
+
+      // 打ち切られず 3695 件すべて取得できる (回帰の本体)。
+      expect(result.length, 3695);
+      expect(result.first['id'], 'id-0');
+      expect(result.last['id'], 'id-3694');
+      expect(calls, 4); // 1000*3 + 695
+    });
+
+    test('rows are returned in page order without gaps or duplicates',
+        () async {
+      final all = _rows(2500);
+      final result = await fetchAllPagedRows(
+        fetchPage: (from, to) async => _serve(all, from, to),
+      );
+
+      expect(result.map((r) => r['id']).toList(), all.map((r) => r['id']));
+      expect(result.map((r) => r['id']).toSet().length, 2500);
+    });
+
+    test('stops after a single call when the table fits in one page', () async {
+      final all = _rows(42);
+      var calls = 0;
+      final result = await fetchAllPagedRows(
+        fetchPage: (from, to) async {
+          calls++;
+          return _serve(all, from, to);
+        },
+      );
+
+      expect(result.length, 42);
+      expect(calls, 1);
+    });
+
+    test('exact multiple of pageSize needs one extra empty page', () async {
+      final all = _rows(2000);
+      var calls = 0;
+      final result = await fetchAllPagedRows(
+        fetchPage: (from, to) async {
+          calls++;
+          return _serve(all, from, to);
+        },
+      );
+
+      expect(result.length, 2000);
+      // 2 ページ満杯 → 終端判定のため 3 回目 (空) が必要。
+      expect(calls, 3);
+    });
+
+    test('empty table yields empty result with one call', () async {
+      var calls = 0;
+      final result = await fetchAllPagedRows(
+        fetchPage: (from, to) async {
+          calls++;
+          return <Map<String, dynamic>>[];
+        },
+      );
+
+      expect(result, isEmpty);
+      expect(calls, 1);
+    });
+
+    test('maxRows caps the fetch and prevents runaway loops', () async {
+      final all = _rows(100000);
+      final result = await fetchAllPagedRows(
+        fetchPage: (from, to) async => _serve(all, from, to),
+        maxRows: 2500,
+      );
+
+      expect(result.length, 2500);
+    });
+
+    test('respects a custom pageSize', () async {
+      final all = _rows(250);
+      var calls = 0;
+      final result = await fetchAllPagedRows(
+        fetchPage: (from, to) async {
+          calls++;
+          // ページサイズが要求どおり渡っていること。
+          expect(to - from + 1, lessThanOrEqualTo(100));
+          return _serve(all, from, to, maxRows: 100);
+        },
+        pageSize: 100,
+      );
+
+      expect(result.length, 250);
+      expect(calls, 3);
+    });
+
+    test('a short page ends pagination even mid-table (server truncation)',
+        () async {
+      // サーバが要求より少なく返したら最終ページとみなす。
+      var calls = 0;
+      final result = await fetchAllPagedRows(
+        fetchPage: (from, to) async {
+          calls++;
+          return _rows(10); // 常に 10 件 (< pageSize) → 1 回で終了
+        },
+      );
+
+      expect(result.length, 10);
+      expect(calls, 1);
+    });
+  });
+}


### PR DESCRIPTION
## 概要
WBSの「未完了 N 件 / 全体 M 件」が**全体集計になっていなかった**バグの修正。タスクをクローズしても未完了件数がほぼ動かない原因の本体。

## 症状
GitHub Issue #2474 / #2475 をクローズし `wbs_tasks` 側も `status=completed` / `github_issue_state=CLOSED` に正しく同期されたにもかかわらず、画面の「436 件 未完了 / 531 件 全体」が変化しなかった。

## 原因
[project_gantt_page.dart](lib/pages/project_gantt_page.dart) の `_loadWbs()` は `.select()` に range を指定していないため、**PostgREST の既定 max-rows (1000) で打ち切られていた**。

実測 (anon REST):
```
GET /rest/v1/wbs_tasks?select=*&order=category_order,status
Content-Range: 0-999/3695     ← 3695行中1000行しか取得していない
```

| | 画面表示 | 実際 |
|---|---|---|
| 総タスク | 531 | **3022**（unique） |
| 未完了 | 436 | **1047** |

さらに order が `category_order, status` のみ。`'completed'` は `'in_progress'`/`'pending'` よりアルファベット順で**前**に来るため、完了行が1000行の窓の前方を占有する。結果、タスクを完了させると窓の外から別の未完了行が滑り込み、**作業量に関わらず表示上の未完了件数がほぼ動かない**トレッドミル状態になっていた。

## 修正
- 汎用ページャ `fetchAllPagedRows` を追加し全ページ取得（pageSize 1000 / 安全弁 `maxRows` 20000）。返却件数が要求未満なら最終ページとみなして停止。
- **order に一意な `id` をタイエブレーカとして追加**。非一意キーのみで並べるとページ境界で行の重複・欠落が起こるため、ページング前提では必須。
- `tData` が型付きになったため冗長な cast を削除。

## 影響 (重要)
本修正後、**表示件数が実態まで増えます**（未完了 ~436 → ~1047）。これは回帰ではなく、**これまで1000行の窓に隠れていた分が見えるようになったもの**です。

なお `wbs_milestones` は 12 行のため対象外。

## 検証
- 新規 unit 8件: 超過分割(3695→4ページ) / 順序保全・重複欠落なし / 単ページ / pageSize丁度(空ページで終端) / 空表 / maxRows上限 / カスタムpageSize / サーバ切り詰め
- 既存 `project_gantt_dedupe_test.dart` 6件も緑（回帰なし）
- 変更ファイル analyze 0 / format clean

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: データ取得のページング修正で、追加した fetchAllPagedRows は fetchPage コールバック注入により表示層・ネットワーク非依存で unit 8件に境界網羅済み。ページ描画自体は非変更のため integration_test は不均衡

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更は lib/pages の読み取りクエリのページング化のみで書き込み・認証・RLS・EFに無関係。純関数ページャを unit 8件で検証済み
