### PR TITLE
[P0] Move LP trial and Magic Link into the first viewport

### DIFF
--- a/docs/marketing/lp-live-validation-2026-07-19.md
+++ b/docs/marketing/lp-live-validation-2026-07-19.md
@@ -1,0 +1,71 @@
+# LP acquisition validation - 2026-07-19
+
+## Goal
+
+Move one unknown visitor through the complete funnel:
+
+`X impression -> LP visit -> no-signup trial -> Magic Link signup -> first saved action -> 100 JPY supporter or Pro checkout -> Stripe payout -> bank deposit`
+
+The session goal remains open until a real external-user payment is paid out to the bank account. Test sessions, anonymous Supabase users, and Stripe Checkout creation do not count as completion.
+
+## Production baseline
+
+The anonymous production aggregate was checked before this change.
+
+- LP experiment view events are present.
+- Only one `funnel_trial_run` was observed in the recent period.
+- No `funnel_magic_link_send` was observed.
+- All recent `auth.users` rows were anonymous sessions; non-anonymous registrations were zero.
+- The supporter checkout event observed on 2026-07-19 was internal QA and is excluded from revenue evidence.
+
+The largest verified drop is therefore `LP view -> trial`, followed by `trial -> signup submit`.
+
+## Ten hypotheses
+
+| ID | Hypothesis | Treatment | Primary metric | Technical verification | Live conclusion |
+| --- | --- | --- | --- | --- | --- |
+| H01 | An outcome-first promise increases hero engagement. | Lead with the concrete result: AI chooses the next action in one minute. | `hero_cta / view` | Automated widget test | Pending sample |
+| H02 | Choosing work, learning, or money increases trial starts. | Show an intent selector and one-click example. | `trial / view` | Automated widget test | Pending sample |
+| H03 | Experiencing value before signup increases conversion. | Put the actual AI trial inside the first viewport; control keeps auth before trial. | `signup_submit / trial` | Automated position and control tests | Refined after baseline showed almost no trials |
+| H04 | A one-field Magic Link removes signup friction. | Show email and Magic Link directly below the generated result; control keeps password-first flow. | `signup_submit / trial` | Automated Magic Link and control tests | Refined after zero Magic Link sends |
+| H05 | Risk reversal increases CTA use. | Show free core, no card, and stop-anytime assurances. | `hero_cta / view` | Automated widget test | Pending sample |
+| H06 | Concrete input-output-continuity proof increases trials. | Show the three-step product proof before conversion. | `trial / view` | Automated widget test | Pending sample |
+| H07 | Real social proof near conversion increases signup. | Place real aggregate usage proof before auth. | `signup_submit / view` | Automated position test | Pending sample; never fabricate proof |
+| H08 | Privacy assurance increases completed signup. | Explain email privacy, Stripe handling, and data controls. | `signup_complete / signup_submit` | Automated widget test | Pending sample |
+| H09 | A mobile sticky CTA prevents lost opportunities. | Show a stable CTA below 720 px. | Mobile `signup_submit / view` | 390 px widget test | Pending sample |
+| H10 | Explaining saved continuity increases desire to register. | State that the suggestion, history, and next action remain available tomorrow. | `save_cta / trial` | Automated result-state test | Pending sample |
+
+## Experiment rules
+
+- A visitor is stably assigned to one of 20 arms: ten hypotheses times control/treatment.
+- The assigned hypothesis changes only its own mechanism; the other nine treatments remain enabled.
+- URL overrides are reserved for QA: `lp_hypothesis=h03&lp_variant=control`.
+- Events use `lp_exp_{hypothesis}_{variant}_{stage}`.
+- Supported stages are `view`, `hero_cta`, `intent`, `trial`, `save_cta`, `signup_submit`, `signup_complete`, and `sticky_cta`.
+- Do not declare a winner from implementation tests. Require at least 100 unique views per arm and at least 10 signup submits across both variants before evaluating direction.
+
+## Acquisition and revenue attribution
+
+- Any `utm_source=x&utm_campaign=first_user_growth` visit records `touch_x_first_user_growth`.
+- Profile traffic remains separately identified as `touch_profile`.
+- Signup submit records `signup_submit_x_first_user_growth` when that touchpoint is latest.
+- The latest X touchpoint survives the signup redirect and is added to supporter and Pro checkout metadata.
+- A unique `utm_content` must be used for each human-approved X creative. Do not publish near-duplicate posts or automate replies/DMs.
+
+## Release gate
+
+- [x] All ten hypotheses remain technically testable.
+- [x] H03 actual trial is in the hero treatment.
+- [x] H04 inline Magic Link is directly below the result.
+- [x] H03 and H04 controls preserve the prior flow.
+- [x] X attribution survives to supporter/Pro checkout.
+- [x] Targeted widget/service tests pass.
+- [x] Static analysis passes.
+- [ ] Production deployment completed.
+- [ ] One unknown visitor starts a trial.
+- [ ] One non-anonymous user completes signup.
+- [ ] That user completes a first saved action.
+- [ ] One real external-user payment succeeds.
+- [ ] Stripe payout is marked paid.
+- [ ] Bank deposit of at least 1 JPY is verified.
+

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -43,6 +43,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   );
 
   final _emailController = TextEditingController();
+  final _trialEmailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _trialPromptController = TextEditingController();
   final _emailFocusNode = FocusNode();
@@ -188,6 +189,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     _authSubscription?.cancel();
     _magicLinkCooldownTimer?.cancel();
     _emailController.dispose();
+    _trialEmailController.dispose();
     _passwordController.dispose();
     _trialPromptController.dispose();
     _emailFocusNode.dispose();
@@ -379,11 +381,15 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     }
   }
 
-  Future<void> _sendMagicLink() async {
-    final email = _emailController.text.trim();
+  Future<void> _sendMagicLink({String? emailOverride}) async {
+    final email = (emailOverride ?? _emailController.text).trim();
     if (email.isEmpty) {
       _showMessage('Magic Link を送るにはメールアドレスを入力してください。');
       return;
+    }
+
+    if (_emailController.text.trim() != email) {
+      _emailController.text = email;
     }
 
     setState(() => _isLoading = true);
@@ -497,6 +503,16 @@ $input
     });
     _showMessage('この結果を保存するには登録が必要です。下の登録セクションから30秒で保存を開始できます。');
     _scrollToAuthSection();
+  }
+
+  Future<void> _saveTrialWithMagicLink() async {
+    unawaited(_recordConversionStage('save_cta'));
+    unawaited(widget.adapter.recordSaveCta());
+    setState(() {
+      _showSaveCtaPrompt = true;
+      _isSignUp = true;
+    });
+    await _sendMagicLink(emailOverride: _trialEmailController.text);
   }
 
   void _runQuickTrialSample(String prompt) {
@@ -994,9 +1010,8 @@ $input
             : 'landing_h03_auth_before_trial',
       ),
       children: [
-        if (trialFirst) _buildTrialSection() else _buildAuthSection(),
-        const SizedBox(height: 20),
-        if (trialFirst) _buildAuthSection() else _buildTrialSection(),
+        _buildAuthSection(),
+        if (!trialFirst) ...[const SizedBox(height: 20), _buildTrialSection()],
       ],
     );
   }
@@ -1046,11 +1061,13 @@ $input
   }
 
   Widget _buildHeroSection() {
+    final trialFirst = _hypothesisEnabled('h03');
     return _WorkflowLandingHero(
       achievementCount: _achievementCount,
       showFirstUserGrowthCta: _isFirstUserGrowthTraffic,
       outcomeFirstMessage: _hypothesisEnabled('h01'),
       showRiskReversal: _hypothesisEnabled('h05'),
+      inlineTrial: trialFirst ? _buildTrialSection(heroMode: true) : null,
       onGetStarted: _handleHeroSignup,
       onWatchDemo: _scrollToTrialSection,
     );
@@ -3498,30 +3515,36 @@ $input
     );
   }
 
-  Widget _buildTrialSection() {
+  Widget _buildTrialSection({bool heroMode = false}) {
     return KeyedSubtree(
       key: const Key('landing_trial_section'),
       child: Card(
         key: _trialSectionKey,
-        elevation: 1,
+        elevation: heroMode ? 0 : 1,
+        color: Colors.white,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         child: Padding(
-          padding: const EdgeInsets.all(18),
+          key: Key(
+            heroMode ? 'landing_h03_inline_trial' : 'landing_h03_lower_trial',
+          ),
+          padding: EdgeInsets.all(heroMode ? 16 : 18),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Text(
-                'AIに「今日やる1件」を聞く',
-                style: TextStyle(
+              Text(
+                heroMode ? '30秒で試す: いま詰まっていることは？' : 'AIに「今日やる1件」を聞く',
+                style: const TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.w800,
                   height: 1.4,
                 ),
               ),
               const SizedBox(height: 6),
-              const Text(
-                'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
-                style: TextStyle(color: Color(0xFF64748B), height: 1.5),
+              Text(
+                heroMode
+                    ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
+                    : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
+                style: const TextStyle(color: Color(0xFF64748B), height: 1.5),
               ),
               const SizedBox(height: 12),
               Wrap(
@@ -3529,6 +3552,7 @@ $input
                 runSpacing: 8,
                 children: [
                   ActionChip(
+                    key: const Key('landing_trial_sample_priority'),
                     avatar: const Icon(Icons.flash_on, size: 18),
                     label: const Text('今日の最優先'),
                     onPressed: _isTrialLoading
@@ -3536,6 +3560,7 @@ $input
                         : () => _runQuickTrialSample('今日の最優先タスクを1件に絞りたい'),
                   ),
                   ActionChip(
+                    key: const Key('landing_trial_sample_plan'),
                     avatar: const Icon(Icons.event_note, size: 18),
                     label: const Text('今日の計画を立てる'),
                     onPressed: _isTrialLoading
@@ -3544,6 +3569,7 @@ $input
                             _runQuickTrialSample('今日1日の計画を立てて、最も重要なことに集中したい'),
                   ),
                   ActionChip(
+                    key: const Key('landing_trial_sample_procrastination'),
                     avatar: const Icon(Icons.done_all, size: 18),
                     label: const Text('先送り解消'),
                     onPressed: _isTrialLoading
@@ -3555,8 +3581,8 @@ $input
               const SizedBox(height: 14),
               TextField(
                 controller: _trialPromptController,
-                minLines: 2,
-                maxLines: 3,
+                minLines: heroMode ? 1 : 2,
+                maxLines: heroMode ? 2 : 3,
                 decoration: const InputDecoration(
                   labelText: '例: 今日いちばん詰まっていることを簡単に書く',
                   border: OutlineInputBorder(),
@@ -3585,7 +3611,7 @@ $input
                   padding: const EdgeInsets.all(14),
                   decoration: BoxDecoration(
                     color: const Color(0xFFF2F7FF),
-                    borderRadius: BorderRadius.circular(16),
+                    borderRadius: BorderRadius.circular(8),
                     border: Border.all(
                       color: const Color(0xFF3D5AFE).withValues(alpha: 0.2),
                     ),
@@ -3635,18 +3661,22 @@ $input
                         ),
                       ],
                       const SizedBox(height: 12),
-                      SizedBox(
-                        width: double.infinity,
-                        child: FilledButton.icon(
-                          onPressed: _promptRegistrationForTrialSave,
-                          icon: const Icon(Icons.save_outlined),
-                          label: Text(
-                            _hypothesisEnabled('h10')
-                                ? 'この結果を保存して明日も続ける'
-                                : 'この結果を保存して続ける',
+                      if (_hypothesisEnabled('h04'))
+                        _buildInlineTrialMagicLink()
+                      else
+                        SizedBox(
+                          width: double.infinity,
+                          child: FilledButton.icon(
+                            key: const Key('landing_h04_control_save_scroll'),
+                            onPressed: _promptRegistrationForTrialSave,
+                            icon: const Icon(Icons.save_outlined),
+                            label: Text(
+                              _hypothesisEnabled('h10')
+                                  ? 'この結果を保存して明日も続ける'
+                                  : 'この結果を保存して続ける',
+                            ),
                           ),
                         ),
-                      ),
                     ],
                   ),
                 ),
@@ -3654,6 +3684,87 @@ $input
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildInlineTrialMagicLink() {
+    return Container(
+      key: const Key('landing_h04_inline_magic_capture'),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0xFFB9D7F2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'この提案を保存して、明日もここから再開',
+            style: TextStyle(
+              color: Color(0xFF172033),
+              fontSize: 14,
+              fontWeight: FontWeight.w800,
+              height: 1.45,
+            ),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            key: const Key('landing_h04_inline_email'),
+            controller: _trialEmailController,
+            keyboardType: TextInputType.emailAddress,
+            autofillHints: const [AutofillHints.email],
+            onSubmitted: (_) {
+              if (!_isLoading && !_isMagicLinkCoolingDown) {
+                unawaited(_saveTrialWithMagicLink());
+              }
+            },
+            decoration: const InputDecoration(
+              labelText: 'メールアドレス',
+              hintText: 'you@example.com',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.email_outlined),
+              isDense: true,
+            ),
+          ),
+          const SizedBox(height: 8),
+          FilledButton.icon(
+            key: const Key('landing_h04_inline_magic_link'),
+            onPressed: (_isLoading || _isMagicLinkCoolingDown)
+                ? null
+                : _saveTrialWithMagicLink,
+            icon: Icon(
+              _showInboxShortcut
+                  ? Icons.check_circle_outline
+                  : Icons.bookmark_add_outlined,
+              size: 18,
+            ),
+            label: Text(
+              _showInboxShortcut ? 'Magic Linkを送信しました' : '無料で保存して始める',
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            _showInboxShortcut
+                ? '受信箱のリンクを開くと、保存した提案から開始できます。'
+                : 'パスワード・カード入力は不要です。',
+            style: const TextStyle(
+              color: Color(0xFF64748B),
+              fontSize: 12,
+              height: 1.45,
+            ),
+          ),
+          if (_showInboxShortcut) ...[
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              key: const Key('landing_h04_inline_open_inbox'),
+              onPressed: _openInbox,
+              icon: const Icon(Icons.open_in_new, size: 17),
+              label: const Text('受信箱を開く'),
+            ),
+          ],
+        ],
       ),
     );
   }
@@ -4540,6 +4651,7 @@ class _WorkflowLandingHero extends StatelessWidget {
   final bool showFirstUserGrowthCta;
   final bool outcomeFirstMessage;
   final bool showRiskReversal;
+  final Widget? inlineTrial;
   final VoidCallback onGetStarted;
   final VoidCallback onWatchDemo;
 
@@ -4548,6 +4660,7 @@ class _WorkflowLandingHero extends StatelessWidget {
     this.showFirstUserGrowthCta = false,
     required this.outcomeFirstMessage,
     required this.showRiskReversal,
+    this.inlineTrial,
     required this.onGetStarted,
     required this.onWatchDemo,
   });
@@ -4618,6 +4731,15 @@ class _WorkflowLandingHero extends StatelessWidget {
               ),
             ),
           ),
+          if (inlineTrial != null) ...[
+            const SizedBox(height: 18),
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 760),
+                child: inlineTrial,
+              ),
+            ),
+          ],
           if (achievementCount > 0) ...[
             const SizedBox(height: 12),
             Center(
@@ -4633,7 +4755,7 @@ class _WorkflowLandingHero extends StatelessWidget {
             ),
           ],
           const SizedBox(height: 24),
-          if (showFirstUserGrowthCta) ...[
+          if (showFirstUserGrowthCta && inlineTrial == null) ...[
             _FirstUserGrowthHeroCta(
               onGetStarted: onGetStarted,
               onWatchDemo: onWatchDemo,
@@ -4663,24 +4785,25 @@ class _WorkflowLandingHero extends StatelessWidget {
                   ),
                 ),
               ),
-              OutlinedButton.icon(
-                key: const Key('landing_primary_trial_cta'),
-                onPressed: onWatchDemo,
-                icon: const Icon(Icons.play_circle_outline, size: 19),
-                label: const Text('登録なしで1件試す'),
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: const Color(0xFF172033),
-                  minimumSize: const Size(190, 52),
-                  side: const BorderSide(color: Color(0xFF9CB7CC)),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                  textStyle: const TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w800,
+              if (inlineTrial == null)
+                OutlinedButton.icon(
+                  key: const Key('landing_primary_trial_cta'),
+                  onPressed: onWatchDemo,
+                  icon: const Icon(Icons.play_circle_outline, size: 19),
+                  label: const Text('登録なしで1件試す'),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: const Color(0xFF172033),
+                    minimumSize: const Size(190, 52),
+                    side: const BorderSide(color: Color(0xFF9CB7CC)),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    textStyle: const TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                    ),
                   ),
                 ),
-              ),
             ],
           ),
           if (showRiskReversal) ...[

--- a/lib/pages/subscription_billing_page.dart
+++ b/lib/pages/subscription_billing_page.dart
@@ -107,10 +107,15 @@ class _SubscriptionBillingPageState extends State<SubscriptionBillingPage> {
   Future<void> _openSupporterCheckout() async {
     await _record('supporter_checkout');
     await _openStripeSession(() {
-      return _service.createSupporterCheckoutSession(
-        returnUrl: _currentReturnUrl,
-        attribution: BillingSupporterAttribution.fromUri(_sourceUri),
-      );
+      return widget.acquisitionService.loadLatestTouchpoint().then(
+            (latestTouchpoint) => _service.createSupporterCheckoutSession(
+              returnUrl: _currentReturnUrl,
+              attribution: BillingSupporterAttribution.fromUri(
+                _sourceUri,
+                fallbackTouchpoint: latestTouchpoint,
+              ),
+            ),
+          );
     });
   }
 

--- a/lib/services/billing_service.dart
+++ b/lib/services/billing_service.dart
@@ -129,17 +129,29 @@ class BillingSupporterAttribution {
   factory BillingSupporterAttribution.fromUri(
     Uri uri, {
     String landingTouchpoint = 'subscription_billing',
+    String? fallbackTouchpoint,
   }) {
     final params = uri.queryParameters;
+    final isXProfile =
+        fallbackTouchpoint == GrowthAcquisitionService.touchProfile;
+    final isXFirstUserGrowth = isXProfile ||
+        fallbackTouchpoint == GrowthAcquisitionService.touchXFirstUserGrowth;
     return BillingSupporterAttribution(
-      utmSource: params['utm_source'],
-      utmMedium: params['utm_medium'],
-      utmCampaign: params['utm_campaign'],
-      utmContent: params['utm_content'],
-      experimentKey: params['experiment_key'] ?? params['utm_campaign'],
-      variant: params['variant'] ?? params['utm_content'],
+      utmSource: params['utm_source'] ?? (isXFirstUserGrowth ? 'x' : null),
+      utmMedium: params['utm_medium'] ??
+          (isXFirstUserGrowth ? (isXProfile ? 'profile' : 'organic') : null),
+      utmCampaign: params['utm_campaign'] ??
+          (isXFirstUserGrowth ? 'first_user_growth' : null),
+      utmContent: params['utm_content'] ??
+          (isXFirstUserGrowth ? 'activation_to_paid' : null),
+      experimentKey: params['experiment_key'] ??
+          params['utm_campaign'] ??
+          (isXFirstUserGrowth ? 'first_user_growth' : null),
+      variant: params['variant'] ??
+          params['utm_content'] ??
+          (isXFirstUserGrowth ? 'activation_to_paid' : null),
       sourceLogId: params['source_log_id'] ?? params['x_post_log_id'],
-      landingTouchpoint: landingTouchpoint,
+      landingTouchpoint: fallbackTouchpoint ?? landingTouchpoint,
     );
   }
 

--- a/lib/services/growth_acquisition_service.dart
+++ b/lib/services/growth_acquisition_service.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 class GrowthAcquisitionService {
   static const String touchLanding = 'touch_landing';
   static const String touchProfile = 'touch_profile';
+  static const String touchXFirstUserGrowth = 'touch_x_first_user_growth';
   static const String touchImport = 'touch_import';
   static const String touchPublicMemo = 'touch_public_memo';
   static const String touchReferral = 'touch_referral';
@@ -19,6 +20,8 @@ class GrowthAcquisitionService {
 
   static const String signupSubmitLanding = 'signup_submit_landing';
   static const String signupSubmitProfile = 'signup_submit_profile';
+  static const String signupSubmitXFirstUserGrowth =
+      'signup_submit_x_first_user_growth';
   static const String signupSubmitImport = 'signup_submit_import';
   static const String signupSubmitPublicMemo = 'signup_submit_public_memo';
   static const String signupSubmitReferral = 'signup_submit_referral';
@@ -81,7 +84,7 @@ class GrowthAcquisitionService {
       case 'profile':
         return touchProfile;
       default:
-        return null;
+        return touchXFirstUserGrowth;
     }
   }
 
@@ -102,6 +105,8 @@ class GrowthAcquisitionService {
     switch (latestTouchpoint) {
       case touchProfile:
         return signupSubmitProfile;
+      case touchXFirstUserGrowth:
+        return signupSubmitXFirstUserGrowth;
       case touchImport:
         return signupSubmitImport;
       case touchPublicMemo:

--- a/test/e2e/lp_first_user_acquisition.spec.ts
+++ b/test/e2e/lp_first_user_acquisition.spec.ts
@@ -1,0 +1,95 @@
+import { expect, Page, test } from '@playwright/test';
+
+const treatmentPath = '/?lp_hypothesis=h03&lp_variant=treatment';
+const controlPath = '/?lp_hypothesis=h03&lp_variant=control';
+
+test.describe('LP first-user acquisition', () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  test('H03 treatment puts a real no-signup trial in the first viewport', async ({
+    page,
+  }) => {
+    await openLanding(page, treatmentPath);
+
+    const trialHeading = page.getByText('30秒で試す: いま詰まっていることは？', {
+      exact: true,
+    });
+    const trialInput = page.getByLabel(
+      '例: 今日いちばん詰まっていることを簡単に書く',
+      { exact: true },
+    );
+
+    await expect(trialHeading).toBeVisible();
+    await expect(trialInput).toBeVisible();
+
+    const headingBox = await trialHeading.boundingBox();
+    const viewport = page.viewportSize();
+    expect(headingBox).not.toBeNull();
+    expect(viewport).not.toBeNull();
+    expect(headingBox!.y + headingBox!.height).toBeLessThanOrEqual(
+      viewport!.height,
+    );
+  });
+
+  test('H04 treatment reveals one-field Magic Link capture after value', async ({
+    page,
+  }) => {
+    await openLanding(page, treatmentPath);
+
+    await page.getByText('今やる1件を試す', { exact: true }).click();
+
+    await expect(page.getByText('提案された1件', { exact: true })).toBeVisible();
+    await expect(page.getByPlaceholder('you@example.com')).toBeVisible();
+    await expect(
+      page.getByText('無料で保存して始める', { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText('パスワード・カード入力は不要です。', { exact: true }),
+    ).toBeVisible();
+  });
+
+  test('H03 control keeps authentication before the lower trial', async ({
+    page,
+  }) => {
+    await openLanding(page, controlPath);
+
+    const authAction = page.getByText('Magic Linkで今すぐ始める', {
+      exact: true,
+    });
+    const lowerTrial = page.getByText('今やる1件を試す', { exact: true });
+
+    await expect(authAction).toBeVisible();
+    await expect(lowerTrial).toBeVisible();
+    await expect(
+      page.getByText('30秒で試す: いま詰まっていることは？', {
+        exact: true,
+      }),
+    ).toHaveCount(0);
+
+    const authBox = await authAction.boundingBox();
+    const trialBox = await lowerTrial.boundingBox();
+    expect(authBox).not.toBeNull();
+    expect(trialBox).not.toBeNull();
+    expect(authBox!.y).toBeLessThan(trialBox!.y);
+  });
+});
+
+async function openLanding(page: Page, path: string) {
+  await page.route('**/rest/v1/app_analytics*', async (route) => {
+    const isRead = route.request().method() === 'GET';
+    await route.fulfill({
+      status: isRead ? 200 : 204,
+      contentType: 'application/json',
+      headers: isRead ? { 'content-range': '0-0/0' } : undefined,
+      body: isRead ? '[]' : '',
+    });
+  });
+
+  const response = await page.goto(path, { waitUntil: 'domcontentloaded' });
+  expect(response?.ok()).toBeTruthy();
+  await expect(
+    page.getByText('仕事・学習・お金の「次の1件」を、AIが1分で決める', {
+      exact: true,
+    }),
+  ).toBeVisible({ timeout: 30_000 });
+}

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -8,7 +8,9 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 class _LandingAdapter extends Fake implements LandingPageAdapter {
   int lpViews = 0;
+  int saveCtas = 0;
   final List<String> conversionEvents = <String>[];
+  final List<String> magicLinkEmails = <String>[];
 
   @override
   Stream<AuthState> authStateChanges() => const Stream<AuthState>.empty();
@@ -25,6 +27,23 @@ class _LandingAdapter extends Fake implements LandingPageAdapter {
 
   @override
   Future<void> recordTrialRun() async {}
+
+  @override
+  Future<void> recordSaveCta() async {
+    saveCtas += 1;
+  }
+
+  @override
+  Future<void> recordInboxOpen() async {}
+
+  @override
+  Future<void> sendMagicLink({
+    required String email,
+    String? emailRedirectTo,
+    bool shouldCreateUser = true,
+  }) async {
+    magicLinkEmails.add(email);
+  }
 
   @override
   Future<String> improveTrialPrompt({required String prompt}) async {
@@ -65,9 +84,7 @@ void main() {
     final adapter = _LandingAdapter();
     await tester.pumpWidget(
       MaterialApp(
-        routes: {
-          '/privacy': (_) => const Scaffold(body: Text('privacy')),
-        },
+        routes: {'/privacy': (_) => const Scaffold(body: Text('privacy'))},
         home: LandingPage(
           key: ValueKey(
             '${assignment.hypothesis.id}-${assignment.variant.name}-${size.width}',
@@ -82,8 +99,9 @@ void main() {
     return adapter;
   }
 
-  testWidgets('treatment renders the complete conversion-first journey',
-      (tester) async {
+  testWidgets('treatment renders the complete conversion-first journey', (
+    tester,
+  ) async {
     final adapter = await pumpLanding(
       tester,
       assignment: _assignment('h01', LandingExperimentVariant.treatment),
@@ -118,18 +136,64 @@ void main() {
     );
     expect(adapter.lpViews, 1);
     expect(adapter.conversionEvents, contains('lp_exp_h01_treatment_view'));
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('landing_hero_section')),
+        matching: find.byKey(const Key('landing_h03_inline_trial')),
+      ),
+      findsOneWidget,
+    );
 
-    await tester.ensureVisible(find.text('今日の最優先'));
-    await tester.tap(find.text('今日の最優先'));
+    await tester.tap(find.byKey(const Key('landing_trial_sample_priority')));
     await tester.pump(const Duration(milliseconds: 100));
     expect(
       find.byKey(const Key('landing_h10_continuity_value')),
       findsOneWidget,
     );
+    expect(
+      find.byKey(const Key('landing_h04_inline_magic_capture')),
+      findsOneWidget,
+    );
   });
 
-  testWidgets('all ten control conditions remove only their tested mechanism',
-      (tester) async {
+  testWidgets('trial result converts inline with one-field Magic Link', (
+    tester,
+  ) async {
+    final adapter = await pumpLanding(
+      tester,
+      assignment: _assignment('h04', LandingExperimentVariant.treatment),
+    );
+
+    await tester.tap(find.byKey(const Key('landing_trial_sample_priority')));
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.enterText(
+      find.byKey(const Key('landing_h04_inline_email')),
+      'first-user@example.com',
+    );
+    await tester.tap(find.byKey(const Key('landing_h04_inline_magic_link')));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(adapter.saveCtas, 1);
+    expect(adapter.magicLinkEmails, ['first-user@example.com']);
+    expect(
+      adapter.conversionEvents,
+      containsAll(<String>[
+        'lp_exp_h04_treatment_trial',
+        'lp_exp_h04_treatment_save_cta',
+        'lp_exp_h04_treatment_signup_submit',
+      ]),
+    );
+    expect(
+      find.byKey(const Key('landing_h04_inline_open_inbox')),
+      findsOneWidget,
+    );
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+
+  testWidgets('all ten control conditions remove only their tested mechanism', (
+    tester,
+  ) async {
     for (final id in <String>[
       'h01',
       'h02',
@@ -174,6 +238,10 @@ void main() {
                   .dy,
             ),
           );
+          expect(
+            find.byKey(const Key('landing_h03_inline_trial')),
+            findsNothing,
+          );
           break;
         case 'h04':
           expect(
@@ -183,6 +251,18 @@ void main() {
           expect(
             find.byKey(const Key('landing_h04_password_toggle')),
             findsNothing,
+          );
+          await tester.tap(
+            find.byKey(const Key('landing_trial_sample_priority')),
+          );
+          await tester.pump(const Duration(milliseconds: 100));
+          expect(
+            find.byKey(const Key('landing_h04_inline_magic_capture')),
+            findsNothing,
+          );
+          expect(
+            find.byKey(const Key('landing_h04_control_save_scroll')),
+            findsOneWidget,
           );
           break;
         case 'h05':
@@ -222,8 +302,9 @@ void main() {
           );
           break;
         case 'h10':
-          await tester.ensureVisible(find.text('今日の最優先'));
-          await tester.tap(find.text('今日の最優先'));
+          await tester.tap(
+            find.byKey(const Key('landing_trial_sample_priority')),
+          );
           await tester.pump(const Duration(milliseconds: 100));
           expect(
             find.byKey(const Key('landing_h10_continuity_value')),
@@ -236,8 +317,9 @@ void main() {
     }
   });
 
-  testWidgets('mobile treatment exposes and measures the sticky signup CTA',
-      (tester) async {
+  testWidgets('mobile treatment exposes and measures the sticky signup CTA', (
+    tester,
+  ) async {
     final adapter = await pumpLanding(
       tester,
       assignment: _assignment('h09', LandingExperimentVariant.treatment),
@@ -246,8 +328,9 @@ void main() {
 
     final sticky = find.byKey(const Key('landing_h09_mobile_sticky_cta'));
     expect(sticky, findsOneWidget);
-    await tester
-        .tap(find.descendant(of: sticky, matching: find.text('無料で始める')));
+    await tester.tap(
+      find.descendant(of: sticky, matching: find.text('無料で始める')),
+    );
     await tester.pump(const Duration(milliseconds: 350));
     expect(
       adapter.conversionEvents,

--- a/test/services/billing_service_attribution_test.dart
+++ b/test/services/billing_service_attribution_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/billing_service.dart';
+import 'package:my_web_app/services/growth_acquisition_service.dart';
 
 void main() {
   test('builds supporter attribution from X share URL parameters', () {
@@ -34,4 +35,24 @@ void main() {
 
     expect(attribution.toJson(), {'variant': 'question_post'});
   });
+
+  test(
+    'keeps first-user X attribution after signup removed URL parameters',
+    () {
+      final attribution = BillingSupporterAttribution.fromUri(
+        Uri.parse('https://example.com/subscription-billing?entry=onboarding'),
+        fallbackTouchpoint: GrowthAcquisitionService.touchXFirstUserGrowth,
+      );
+
+      expect(attribution.toJson(), {
+        'utm_source': 'x',
+        'utm_medium': 'organic',
+        'utm_campaign': 'first_user_growth',
+        'utm_content': 'activation_to_paid',
+        'experiment_key': 'first_user_growth',
+        'variant': 'activation_to_paid',
+        'landing_touchpoint': 'touch_x_first_user_growth',
+      });
+    },
+  );
 }

--- a/test/services/growth_acquisition_service_test.dart
+++ b/test/services/growth_acquisition_service_test.dart
@@ -19,10 +19,7 @@ void main() {
       GrowthAcquisitionService.signalForPagePath('/referral'),
       GrowthAcquisitionService.touchReferral,
     );
-    expect(
-      GrowthAcquisitionService.signalForPagePath('/unknown'),
-      isNull,
-    );
+    expect(GrowthAcquisitionService.signalForPagePath('/unknown'), isNull);
   });
 
   test('maps preview source types to import preview signals', () {
@@ -44,7 +41,7 @@ void main() {
     );
   });
 
-  test('maps first-user profile UTM to profile touch signal', () {
+  test('maps first-user X UTMs to durable campaign touch signals', () {
     final profileUri = Uri.parse(
       'https://my-web-app-b67f4.web.app/'
       '?utm_source=x&utm_medium=profile&utm_campaign=first_user_growth'
@@ -59,7 +56,10 @@ void main() {
       GrowthAcquisitionService.signalForIncomingUri(profileUri),
       GrowthAcquisitionService.touchProfile,
     );
-    expect(GrowthAcquisitionService.signalForIncomingUri(shareUri), isNull);
+    expect(
+      GrowthAcquisitionService.signalForIncomingUri(shareUri),
+      GrowthAcquisitionService.touchXFirstUserGrowth,
+    );
   });
 
   test('resolves signup submit signal from latest touchpoint', () {
@@ -74,6 +74,12 @@ void main() {
         GrowthAcquisitionService.touchImport,
       ),
       GrowthAcquisitionService.signupSubmitImport,
+    );
+    expect(
+      GrowthAcquisitionService.resolveSignupSubmitSignal(
+        GrowthAcquisitionService.touchXFirstUserGrowth,
+      ),
+      GrowthAcquisitionService.signupSubmitXFirstUserGrowth,
     );
     expect(
       GrowthAcquisitionService.resolveSignupSubmitSignal(


### PR DESCRIPTION
## Summary
- move the actual no-signup AI trial into the H03 treatment hero
- place one-field Magic Link capture directly below the generated result for H04
- preserve H03/H04 control behavior and all ten experiment arms
- keep X first-user campaign attribution through signup to 100 JPY supporter and Pro checkout
- document the production baseline, ten hypotheses, metrics, and payout release gate

## Production diagnosis
Recent production data showed LP experiment views, only one trial run, zero Magic Link sends, and zero non-anonymous registrations. The verified bottlenecks are LP view -> trial and trial -> signup submit.

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output and visual order, not private internals.
- Minimal scope: about 3 cases (H03 treatment first-viewport path, H04 value-to-Magic-Link path, H03 control recovery path).
- E2E: Playwright test/e2e/lp_first_user_acquisition.spec.ts covers desktop and mobile projects.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: LP UI and attribution metadata only; no payment execution, auth policy, secret handling, data migration, or deploy logic changed.
- Unresolved ultrareview findings: none.

## Validation
- landing conversion widget tests: 4 passed
- acquisition/billing/subscription tests: 11 passed
- targeted flutter analyze: no issues
- full pre-push quality gate: passed
- dart format: 989 files checked, 0 changed
- Deno edge tests: 494 passed, 0 failed
- Playwright E2E discovery: 6 cases found
- H03 control E2E against current production: passed
- H03/H04 treatment E2E: run after deployment

## Goal status
Technical implementation is complete, but external validation remains open: one unknown visitor trial, one real signup, first saved action, real external payment, Stripe paid payout, and bank deposit >= 1 JPY.

Refs #4121
Refs #4129