### PR TITLE
fix(wbs): Issueミラー行と素のタイトル行を collapse し幽霊タスク68件を解消

### DIFF
--- a/lib/pages/project_gantt_page.dart
+++ b/lib/pages/project_gantt_page.dart
@@ -513,13 +513,23 @@ List<WbsTask> dedupeWbsTasksForDisplay(Iterable<WbsTask> tasks) {
   final indexByKey = <String, int>{};
 
   for (final task in tasks) {
-    final issueNumber = task.linkedGithubIssueNumber;
+    // 正規化タイトルを第一キーにする。`_normalizeWbsTitleDuplicateKey` は
+    // `[Issue #N] ` プレフィックスを除去するため、同じ要望が
+    //   - `[Issue #3367] <タイトル>` (Issue 起票後のミラー行 / completed)
+    //   - `<タイトル>`             (起票前の WBS 素の行 / pending)
+    // の 2 行に分かれていても同一キーになり collapse できる。
+    //
+    // 以前は issue 番号があれば `issue:N` を優先していたため、この 2 行が
+    // `issue:3367` と `title:...` に割れて **完了済みの作業が未完了として
+    // 二重計上**されていた (実測 3695 行中 68 件が幽霊)。
+    // 別 Issue でもタイトルが異なればキーが異なるので分離は保たれる。
+    final titleKey = task.linkedDuplicateTitleKey;
     String? displayKey;
-    if (issueNumber != null) {
-      displayKey = 'issue:$issueNumber';
+    if (titleKey != null) {
+      displayKey = 'title:$titleKey';
     } else {
-      final titleKey = task.linkedDuplicateTitleKey;
-      if (titleKey != null) displayKey = 'title:$titleKey';
+      final issueNumber = task.linkedGithubIssueNumber;
+      if (issueNumber != null) displayKey = 'issue:$issueNumber';
     }
     if (displayKey == null) {
       ordered.add(task);

--- a/test/pages/project_gantt_dedupe_test.dart
+++ b/test/pages/project_gantt_dedupe_test.dart
@@ -121,4 +121,75 @@ void main() {
 
     expect(task.isGithubIssueLinkedTask, isTrue);
   });
+
+  // ── Issue ミラー行 と 素のタイトル行 の collapse (幽霊タスク対策) ──────────
+  // 同じ要望が「[Issue #N] タイトル」(起票後 / completed) と「タイトル」
+  // (起票前 / pending) の 2 行に分かれ、完了済みの作業が未完了として
+  // 二重計上されていた回帰の防止。
+
+  test('mirrored [Issue #N] row collapses with its bare-title row', () {
+    final tasks = dedupeWbsTasksForDisplay([
+      _task(
+        id: 'bare-pending',
+        title: '[追加要望] [資産管理] 月次支払不足額の早期アラートと強制対応フロー',
+        status: 'pending',
+      ),
+      _task(
+        id: 'issue-completed',
+        title: '[Issue #3367] [追加要望] [資産管理] 月次支払不足額の早期アラートと強制対応フロー',
+        issueNumber: 3367,
+        status: 'completed',
+        progress: 100,
+      ),
+    ]);
+
+    // 1 行に畳まれ、生存するのは Issue 番号を持つ完了行 (= 未完了に数えない)。
+    expect(tasks, hasLength(1));
+    expect(tasks.single.id, 'issue-completed');
+    expect(tasks.single.isEffectivelyCompleted, isTrue);
+  });
+
+  test('collapse works regardless of row order', () {
+    final tasks = dedupeWbsTasksForDisplay([
+      _task(
+        id: 'issue-completed',
+        title: '[Issue #3367] Shared title',
+        issueNumber: 3367,
+        status: 'completed',
+        progress: 100,
+      ),
+      _task(id: 'bare-pending', title: 'Shared title', status: 'pending'),
+    ]);
+
+    expect(tasks, hasLength(1));
+    expect(tasks.single.id, 'issue-completed');
+  });
+
+  test('repeated filings of the same request collapse to one row', () {
+    // 同一タイトルで別 Issue 番号の重複起票 (例 #2941/#2948/#2955) も 1 行に。
+    final tasks = dedupeWbsTasksForDisplay([
+      _task(id: 'i-2941', title: '[Issue #2941] 口座間移動タスク管理', issueNumber: 2941),
+      _task(id: 'i-2948', title: '[Issue #2948] 口座間移動タスク管理', issueNumber: 2948),
+      _task(id: 'i-2955', title: '[Issue #2955] 口座間移動タスク管理', issueNumber: 2955),
+    ]);
+
+    expect(tasks, hasLength(1));
+  });
+
+  test('different titles stay separate even when both are Issue rows', () {
+    final tasks = dedupeWbsTasksForDisplay([
+      _task(
+        id: 'issue-1',
+        title: '[Issue #1962] VSCode sync',
+        issueNumber: 1962,
+      ),
+      _task(
+        id: 'issue-2',
+        title: '[Issue #2204] Calendar sync',
+        issueNumber: 2204,
+      ),
+    ]);
+
+    expect(tasks.map((task) => task.id), ['issue-1', 'issue-2']);
+  });
 }


### PR DESCRIPTION
## 概要
WBS に**幽霊タスク**（すでに完了した作業が未完了として二重計上される行）が出る問題の修正。PR #4207 で全件が見えるようになった結果、規模が判明した。

## 症状 / 実測 (3695行)
同じ要望が2行に分かれて登録される:
```
[Issue #3367] [追加要望][資産管理] 月次支払不足額の早期アラートと強制対応フロー
   → github_issue_number=3367, state=CLOSED, status=completed
[追加要望][資産管理] 月次支払不足額の早期アラートと強制対応フロー
   → github_issue_number=None,  status=pending, p0%
   → remaining_work: "GitHub Issue: .../issues/3367"  ← 同じIssueを指している
```
`dedupeWbsTasksForDisplay` は issue番号があれば `issue:N`、無ければ `title:<正規化>` と**別キー**を使うため、この2行は collapse されない。

| | 件数 |
|---|---|
| 未完了行 | 1050 |
| うち**幽霊**（完了済みと同一タイトル） | **68** |
| Claude Code キュー | 84 中 **17 (20%)** が幽霊 |

実害: 「上から順に処理」すると最上位が #3367 の重複行で、**着手すれば完了済み機能の二重開発**になる（実際に着手直前で発覚）。

## 修正
- collapse キーを**正規化タイトル優先**に変更。`_normalizeWbsTitleDuplicateKey` は既に `[Issue #N] ` プレフィックスを除去しているため、両行が同一キーになる。タイトルが空の場合のみ issue 番号にフォールバック。
- **生存行の選択ロジックは変更なし**。既存の `_compareWbsTaskDisplayKeeper` は「明示的な issue 番号を持つ行」を優先する（step2）ため、CLOSED/completed のミラー行が残り、未完了から正しく外れる。
- タイトルが異なれば別キーなので、**別Issueの分離は従来どおり維持**（既存テストで保証）。

## 効果（実データ試算）
- unique: 3017 → **2109**
- 未完了: 952 → **900**

なお同一タイトルで複数回起票された Issue（例 #2941/#2948/#2955「口座間移動タスク管理」）も1行に畳まれる。これは重複起票なので意図した挙動。

## 残る課題（本PR対象外）
両行とも `github_issue_number` を持たない幽霊ペアでは、比較関数 step3 が「未完了を優先」するため幽霊が残る。上記の 68→52 の差分がこれに該当。keeper の優先順位変更は挙動影響が大きいため別途判断とした。

## 検証
- 新規4件: ミラー行と素行の collapse / 行順非依存 / 同一タイトル複数起票の collapse / 異なるタイトルは分離維持
- 既存 dedupe 6件 + paging 8件も緑（**「does not merge different GitHub Issues」を含め回帰なし**）
- analyze 0 / format clean

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 純関数 dedupeWbsTasksForDisplay のキー決定ロジック変更のみで、表示層・ネットワーク非依存の unit 10件に境界網羅済み。画面描画とデータ取得は非変更のため integration_test は不均衡

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更は lib/pages の表示用重複排除キーのみで書き込み・認証・RLS・EFに無関係。既存の分離保証テストを含め unit 10件で検証済み
