### PR TITLE
fix(admin): X投稿候補キューの件数が取得上限を総数として表示していたのを是正 (part340)

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -380,7 +380,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
             body: {
               'action': 'x.candidate.list',
               'status': status,
-              'limit': 10,
+              // R32: ヘッダの「N件以上」判定と同じ定数を使う (両者が drift すると
+              // 上限到達を検出できず backlog を過小表示する)。
+              'limit': kXCandidateStatusFetchLimit,
             },
           );
           final data = res.data;

--- a/lib/pages/admin_x_candidate_queue.dart
+++ b/lib/pages/admin_x_candidate_queue.dart
@@ -225,13 +225,33 @@ List<XPostCandidateSummary> mergeCandidateSummaries(
   return merged;
 }
 
+/// R32: 候補キューは status ごとに [kXCandidateStatusFetchLimit] 件で取得する。
+/// 取得件数がこの上限に達している status は「本当は上限以上あるかもしれない」ため、
+/// 上限をそのまま総数として出すと backlog を過小表示する (実際 header は数日間
+/// 「承認待ち 10件」= 取得上限のまま張り付いていた)。取得窓を使い切った値は下限
+/// でしかないので「N件以上」と正直に出す (streakAtWindowCap と同じ規律 /
+/// [[feedback_postgrest_1000row_cap_silent_truncation]] の cap=総数 誤認防止)。
+const int kXCandidateStatusFetchLimit = 10;
+
 /// panel ヘッダの内訳ラベル。「承認待ち」に再試行行を混ぜて数えない
 /// (n=0 捏造を排した R17 以降のカウンタ誠実性規律 / レビュー F3)。
-String candidateQueueHeaderLabel(List<XPostCandidateSummary> candidates) {
+String candidateQueueHeaderLabel(
+  List<XPostCandidateSummary> candidates, {
+  int perStatusLimit = kXCandidateStatusFetchLimit,
+}) {
   final pending = candidates.where((c) => c.isPendingApproval).length;
   final retry = candidates.length - pending;
-  if (retry <= 0) return '承認待ち $pending件';
-  return '承認待ち $pending件・再試行 $retry件';
+  // 再試行は approved / publish_failed の2 status を束ねた数なので、
+  // どちらか一方でも取得上限に達していれば下限扱いにする。
+  final retryCapped = <String>['approved', 'publish_failed'].any(
+    (status) =>
+        candidates.where((c) => c.status == status).length >= perStatusLimit,
+  );
+  final pendingLabel =
+      pending >= perStatusLimit ? '承認待ち $pending件以上' : '承認待ち $pending件';
+  if (retry <= 0) return pendingLabel;
+  final retryLabel = retryCapped ? '再試行 $retry件以上' : '再試行 $retry件';
+  return '$pendingLabel・$retryLabel';
 }
 
 /// 一覧カードの本文プレビュー(1行化+切り詰め)。

--- a/test/pages/admin_x_candidate_queue_test.dart
+++ b/test/pages/admin_x_candidate_queue_test.dart
@@ -170,6 +170,37 @@ void main() {
         '承認待ち 1件',
       );
     });
+
+    test('R32 取得上限に達した status は「N件以上」と下限表示にする', () {
+      // pending が取得上限ちょうど = 本当はもっとあるかもしれない → 「以上」。
+      final pendingAtCap = List.generate(
+        kXCandidateStatusFetchLimit,
+        (i) => make(id: 'p$i'),
+      );
+      expect(
+        candidateQueueHeaderLabel(pendingAtCap),
+        '承認待ち $kXCandidateStatusFetchLimit件以上',
+      );
+
+      // 上限未満はそのまま断定してよい。
+      expect(
+        candidateQueueHeaderLabel([make(id: 'a'), make(id: 'b')]),
+        '承認待ち 2件',
+      );
+
+      // 再試行側 (approved / publish_failed) が上限に達した場合も下限表示。
+      final retryAtCap = <XPostCandidateSummary>[
+        make(id: 'p'),
+        ...List.generate(
+          kXCandidateStatusFetchLimit,
+          (i) => make(id: 'r$i', status: 'publish_failed'),
+        ),
+      ];
+      expect(
+        candidateQueueHeaderLabel(retryAtCap),
+        '承認待ち 1件・再試行 $kXCandidateStatusFetchLimit件以上',
+      );
+    });
   });
 
   group('R26 preview and age labels', () {


### PR DESCRIPTION
## 概要

ダッシュボードのヘッダが**数日間・6ビルド以上「承認待ち 10件」から動かない**ことに気づき調査したところ、表示していたのは実件数ではなく**取得上限**だった。

- `_loadXCandidateQueue()` は status ごとに `limit: 10` で取得
- `candidateQueueHeaderLabel()` は「取得できた件数」を数えるだけ

→ 承認待ちが 40 件あっても「承認待ち 10件」と表示され、運用者は backlog を小さく見誤る。part337 の wbs_tasks 1000行無言打ち切りと同じ **cap を総数と誤認**するパターン。

## 修正

取得窓を使い切った値は**下限でしかない**ため「N件以上」と正直に出す (既存 `streakAtWindowCap`「N日以上」と同じ規律)。

- 取得件数が上限に達した status は `承認待ち 10件以上` / `再試行 10件以上`
- **再試行は approved / publish_failed の2 status を束ねた数**なので、合算ではなく **status 別に**上限到達を判定 (合算だと誤判定する)
- 取得側とラベル側で上限が drift すると上限到達を検出できなくなるため、`kXCandidateStatusFetchLimit` を**共有定数**にして両者から参照 (drift 自体が本バグの再発経路)
- 上限未満は従来どおり断定表示 (誇張しない)

## 検証
- `admin_x_candidate_queue_test.dart` に R32 テスト追加 (上限ちょうど→「以上」/ 上限未満→断定 / 再試行側の上限到達) — 計19件パス
- `flutter analyze` 0 issue / `dart format` 差分なし

## 証拠の範囲について (正直な限界)
本番の**実 backlog 件数は観測できていない** — `hub_data` の RLS が所有者スコープのため匿名 probe では 0 件しか見えない。本修正は「**cap を総数として出すのは実件数に関わらず誤り**」という構造的根拠に基づくもので、実測値の主張はしていない。実際に 10 件以下であればヘッダは従来どおり正確な件数を出す (挙動が変わるのは上限に達したときだけ)。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Client-only display-honesty fix: report a fetch-capped candidate count as a lower bound and share the limit constant between fetcher and label. No auth, RLS, payment, secret, schema, or edge changes; covered by VM unit tests

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Client-only label logic covered by VM unit tests in admin_x_candidate_queue_test.dart (at-cap shows lower bound, under-cap states exact count, retry bucket judged per-status). No new user-visible flow; analyze 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
