### PR TITLE
fix(asset): AI要約の生成中表示を追加 + maxTokens の虚偽前提を是正 + プロンプト重複削減 (10仮説検証 第8弾)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -20041,6 +20041,44 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 value: _localizedAssetManagementAiSource(result.source),
                 color: color,
               ),
+              // 生成はページを止めずに裏で走り、完了時にカード本文が差し替わる。
+              // 何の予告もなく本文が変わると戸惑うため、生成中であることと
+              // 目安時間をカード内に明示する (ボタン内の小さなスピナーだけでは
+              // 気づけない / 本文は今もルールベース要約として読める旨も伝える)。
+              if (_isGeneratingAssetManagementAiSummary)
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 6,
+                  ),
+                  decoration: BoxDecoration(
+                    color: color.withValues(alpha: 0.10),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        width: 12,
+                        height: 12,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(color),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        'AI分析を生成中… (1分ほど) 完了すると上の要約が更新されます',
+                        style: TextStyle(
+                          color: color,
+                          fontSize: 11,
+                          fontWeight: FontWeight.w800,
+                          height: 1.5,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               if (_assetManagementAiSummaryReferencedHistory.isNotEmpty)
                 _buildAssetLiabilitySyncChip(
                   label: '履歴参照',

--- a/lib/services/asset_management_ai_summary_service.dart
+++ b/lib/services/asset_management_ai_summary_service.dart
@@ -65,10 +65,15 @@ class AssetManagementAiProposalExtraction {
 class AssetManagementAiSummaryService {
   // GPT-5 の reasoning トークンや Gemini の thinking トークンも
   // この上限 (maxOutputTokens) を消費するため、本文 (約3,000-4,000トークン) に
-  // 思考分の余裕を大きく足す。3,200→8,000 でも Gemini 3.1 Pro が thinking で
-  // 食い切り、本文出力前に MAX_TOKENS (outputLengthLimited) で途中終了したため、
-  // 24,000 へ引き上げる (思考に約20,000確保しても本文が収まる)。
-  static const int _summaryMaxTokens = 24000;
+  // 思考分の余裕を足す。
+  //
+  // ⚠️ 実際の上限はサーバ側で決まる: ai-hub の `normalizeMaxTokens` が
+  // `min(8192, ...)` にクランプするため、ここに 8192 超を書いても本番では
+  // 8192 として扱われる (旧実装の 24000 は「思考に20,000確保」と書かれていたが
+  // 本番でそうなったことは一度も無い)。誤解を避けるため実効値の 8192 を明示する。
+  // 実測の本文は ~3,000-3,500 トークンなので 8192 でも十分な余裕がある。
+  // 上限を実際に引き上げたい場合は ai-hub 側の clamp から変更すること。
+  static const int _summaryMaxTokens = 8192;
 
   final bool _aiEnabled;
   final AiHubChatService _chatService;
@@ -701,8 +706,11 @@ class AssetManagementAiSummaryService {
       'debt_master_rows': workbook.debtMasterRows
           .map((row) => _debtRowToJson(row, workbook.baseDate))
           .toList(growable: false),
-      'repayment_priority_rows': workbook.repaymentPriorityRows
-          .map((row) => _debtRowToJson(row, workbook.baseDate))
+      // 返済優先順は `debt_master_rows` と同一の行を並べ替えただけなので、
+      // 28 フィールドの再シリアライズはやめて「順序」だけを渡す。明細は
+      // debt_master_rows を id で引けばよい (プロンプトの重複を削減)。
+      'repayment_priority_order': workbook.repaymentPriorityRows
+          .map((row) => <String, dynamic>{'id': row.id, 'name': row.name})
           .toList(growable: false),
       'payment_day_risks': workbook.paymentDayRisks
           .map(_paymentDayRiskToJson)

--- a/test/services/asset_management_ai_summary_service_test.dart
+++ b/test/services/asset_management_ai_summary_service_test.dart
@@ -58,7 +58,8 @@ void main() {
       expect(result.text, 'AIが生成した日本語要約です。');
       expect(capturedBody?['action'], 'provider.chat_auto');
       expect(capturedBody?['tier'], 'performance');
-      expect(capturedBody?['max_tokens'], 24000);
+      // ai-hub 側で min(8192, ...) にクランプされるため実効値は 8192。
+      expect(capturedBody?['max_tokens'], 8192);
       expect(capturedBody?['trace_id'], 'asset-management-ai-summary');
       expect(
         capturedBody?['message'].toString().contains('AIに渡す詳細ペイロード'),
@@ -192,7 +193,8 @@ void main() {
         expect(calls.single['action'], 'provider.chat');
         expect(calls.single['provider'], 'anthropic');
         expect(calls.single['model'], 'claude-opus-4-7');
-        expect(calls.single['max_tokens'], 24000);
+        // ai-hub 側で min(8192, ...) にクランプされるため実効値は 8192。
+        expect(calls.single['max_tokens'], 8192);
         expect(calls.single['routing_use_case'], 'summary');
         expect(
           calls.single['provider_choice_reason'],
@@ -367,9 +369,13 @@ void main() {
 
       await service.generateSummary(report: _report());
 
-      // Gemini 3.1 Pro 等の thinking トークン + 長文要約に耐える予算であること。
+      // ai-hub の `normalizeMaxTokens` が min(8192, ...) にクランプするため、
+      // クライアントが 8192 超を送っても本番の実効値は 8192。ここでは
+      // 「実効上限いっぱいを要求している」ことを検証する (旧テストは 16000 以上を
+      // 期待していたが、その予算が本番で成立したことは一度も無かった)。
+      // 実測の本文は ~3,000-3,500 トークンなので 8192 で十分な余裕がある。
       expect(capturedMaxTokens, isNotNull);
-      expect(capturedMaxTokens! >= 16000, isTrue);
+      expect(capturedMaxTokens, 8192);
     });
 
     test('builds payload from calculated insights only', () {


### PR DESCRIPTION
# 資産管理闘争ページ改善 第8弾 — AI要約の初回生成まわり (10仮説検証)

本番トレース (build 4873) で `ai-hub` が **1.3 分** かかっていた件を調査。10仮説を全件検証し、確定3件を修正した。

## 最重要の訂正: ページはブロックされていなかった

当初「1.3分ブロック」と見立てたが、実際は:

- AIカードには最初から**ルールベース要約が全文表示**されており (`buildWaitingForAiResult` / チップは `ルールベース要約 / AI応答待ち`)、ページの他カードもすべて操作可能
- スピナーは「AI要約を更新」ボタン内の **14px のみ**
- 1.3分は 4プロバイダのタイムアウト積み重ねではなく、**~2秒の即失敗 + ~78秒の正当な単一生成** (成功して履歴に `201` insert)。78秒は Edge の 90秒 abort 未満でタイムアウトですらない

→ **真の UX ギャップは「78秒後にカード本文が予告なく差し替わること」**。本PRはそこを直す。

## 10仮説と判定

| # | 仮説 | 判定 |
|---|------|------|
| 1 | 1.3分がページ全体をブロック | ❌ **棄却 (最重要)** — 非ブロック。ルールベース要約が全文表示 |
| 2 | 4プロバイダのタイムアウト積み重ね | ❌ 棄却 — HTTP は2回のみ (即失敗+成功)。成功で loop return するため後続候補は呼ばれない |
| 3 | Edge の90秒タイムアウトに当たっている | ❌ 棄却 — 78秒 < 90秒 |
| 4 | `maxTokens=24000` が効いている | ❌ **棄却 → 修正** — ai-hub `normalizeMaxTokens` が `min(8192,...)` にクランプ。本番で一度も成立していない前提がコードとテストに固定されていた |
| 5 | クライアント側タイムアウトがある | ❌ 棄却 — 皆無 (最悪 4×90秒=6分待ちうる構造) |
| 6 | プロンプトに重複がある | ✅ 確定 → **修正** — `repayment_priority_rows` が同一行を28フィールドで再シリアライズ |
| 7 | 完了時にカード本文が予告なく差し替わる | ✅ 確定 → **修正** |
| 8 | Markdown↔JSON の二重エンコード | ✅ 事実 → **#4213** (削減余地大だが出力品質検証が要る) |
| 9 | 高速モデルを先頭にすべき | ⚠️ 保留 — 非ブロックゆえ体感利得が小さく、品質ルーティングを崩すリスクが上回る |
| 10 | 初回候補の即失敗(~2秒)は無駄 | ⚠️ 保留 — `ai_hub_chat_logs` (trace_id=`asset-management-ai-summary`) の実測が先 |

## 変更内容 (確定3件)

1. **生成中であることをカード内に明示** — チップ列に「AI分析を生成中… (1分ほど) 完了すると上の要約が更新されます」を表示。予告なき本文差し替えを、期待どおりの裏更新として読ませる。ボタン内14pxのスピナーだけでは気づけなかった。

2. **`maxTokens` の虚偽前提を是正** — `24000` → 実効値 `8192` + クランプの所在をコメント明記。**本番の挙動は変わらない** (元々サーバ側で 8192 にクランプされていたため)。旧コメントの「思考に約20,000確保」は事実ではなく、テストも `24000` / `>=16000` という本番で成立しない予算を固定していたため実態に合わせて更新。実測本文は ~3,000-3,500 トークンで 8192 に十分収まる。

3. **プロンプト重複の削減** — `repayment_priority_rows` は `debt_master_rows` と同一行の並べ替えで、付加情報は順序だけ。id+名前の `repayment_priority_order` に縮約し明細は id 参照に (旧キーへの参照は lib/test 全体に無いことを確認済み)。

## 検証

- `flutter analyze` (page / service / test): **No issues found!**
- `flutter test`: AI要約系 **33件緑** (assertion を実態 8192 に更新)
- 差分は3ファイル・62行の論理変更のみ (**ローカル `dart format` は掛けていない** — 直前PR #4205 でリポジトリと異なるスタイルへ全面変換し1935行churnがCIを落としたため)

## 別Issue

- **#4213** Markdown↔JSON 二重エンコードの解消 (プロンプト 100-200kB の主因)
- **#4127** 未デバウンス保存 / payment_source 二重読み / loadMonth 2分割

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 本文キーワード(支払/AI)による prose-only トリガ。変更は生成中インジケータのUI追加、実効値に合わせた定数是正 (本番挙動不変)、プロンプト内の重複キー縮約のみで、認証・認可・EF・migration・DB書き込み経路の変更を含まない。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 変更は認証必須ページ内の表示追加とプロンプト組み立てのみで headless E2E 到達不能。既存 unit 33件 + analyze 緑で担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
