### PR TITLE
feat(asset): 純資産パネル (前月比±¥/±% + 直近6月スパークライン) #2473

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -68,6 +68,7 @@ import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
 import 'package:my_web_app/services/asset_alert_center_service.dart';
 import 'package:my_web_app/services/asset_alert_dismissal_store.dart';
 import 'package:my_web_app/services/asset_cashflow_statement_service.dart';
+import 'package:my_web_app/services/asset_net_worth_panel_service.dart';
 import 'package:my_web_app/services/asset_category_budget_service.dart';
 import 'package:my_web_app/services/asset_category_budget_store.dart';
 import 'package:my_web_app/services/asset_payment_calendar_service.dart';
@@ -97,6 +98,7 @@ import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
 import 'package:my_web_app/widgets/asset_alert_center_card.dart';
 import 'package:my_web_app/widgets/asset_cashflow_statement_card.dart';
+import 'package:my_web_app/widgets/asset_net_worth_panel_card.dart';
 import 'package:my_web_app/widgets/asset_category_budget_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_editor_dialog.dart';
@@ -8777,6 +8779,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
             )) ...[
               _buildAssetAlertCenterCard(assetLiabilityWorkbook),
             ],
+            if (_isSectionShown(
+              AssetManagementSectionId.netWorthPanel,
+            )) ...[
+              _buildAssetNetWorthPanelCard(assetLiabilityWorkbook),
+            ],
             // 提案カード(定期取引/定期収入の自動検出)は給与内訳に相乗りせず専用
             // セクションへ。salaryBreakdown を隠しても提案だけ独立表示できる。
             if (_isSectionShown(AssetManagementSectionId.proposals)) ...[
@@ -14359,6 +14366,36 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       padding: const EdgeInsets.only(bottom: 16),
       child: AssetCashflowStatementCard(
         statement: statement,
+        currencyFormatter: _formatYen,
+      ),
+    );
+  }
+
+  /// 純資産パネル (Issue #2473)。履歴スナップショット + ライブの当月から
+  /// 「純資産」「前月比 ±¥ / ±%」「直近6月スパークライン」を集計する。
+  /// 金額・変化率は純サービス [AssetNetWorthPanelService] で deterministic に算出。
+  Widget _buildAssetNetWorthPanelCard(AssetLiabilityWorkbook? workbook) {
+    AssetLiabilityMonthlySnapshot? currentMonthSnapshot;
+    if (workbook != null) {
+      final monthKey =
+          AssetLiabilityMonthlyStateStore.formatMonthKey(DateTime.now());
+      currentMonthSnapshot = _assetLiabilityHistoryService.buildSnapshot(
+        monthKey: monthKey,
+        workbook: workbook,
+        savedAt: DateTime.now(),
+      );
+    }
+    final panel = const AssetNetWorthPanelService().build(
+      snapshots: _monthlySnapshots,
+      currentMonthSnapshot: currentMonthSnapshot,
+    );
+    if (!panel.hasData) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: AssetNetWorthPanelCard(
+        panel: panel,
         currencyFormatter: _formatYen,
       ),
     );

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -33,6 +33,7 @@ enum AssetManagementSectionId {
   chart,
   cashflowStatement,
   alertCenter,
+  netWorthPanel,
 }
 
 /// セクション単位の表示上書き。auto はティア×モードの既定に従う。
@@ -115,6 +116,8 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
         return '月次キャッシュフロー';
       case AssetManagementSectionId.alertCenter:
         return 'アラートセンター';
+      case AssetManagementSectionId.netWorthPanel:
+        return '純資産パネル';
     }
   }
 
@@ -144,6 +147,7 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
       // 新規パネルは段階的 rollout のため full モード限定 (= OFF by default)。
       case AssetManagementSectionId.cashflowStatement:
       case AssetManagementSectionId.alertCenter:
+      case AssetManagementSectionId.netWorthPanel:
         return AssetManagementSectionTier.full;
     }
   }

--- a/lib/services/asset_net_worth_panel_service.dart
+++ b/lib/services/asset_net_worth_panel_service.dart
@@ -1,0 +1,138 @@
+import '../models/asset_liability_workbook.dart';
+
+/// スパークライン 1 点分の純資産。
+class AssetNetWorthPoint {
+  /// `yyyy-MM` 形式。
+  final String monthKey;
+  final double netWorth;
+
+  const AssetNetWorthPoint({required this.monthKey, required this.netWorth});
+}
+
+/// 純資産パネル (Issue #2473) の集計結果。
+///
+/// 「資産合計 − 負債合計 = 純資産」「前月比 ±¥ / ±%」「直近 N 月のスパークライン」
+/// を 1 つにまとめる。
+class AssetNetWorthPanel {
+  /// 最新月の純資産。データが無ければ null。
+  final double? netWorth;
+
+  /// 最新月の資産合計 / 負債合計 (内訳表示用)。
+  final double? positiveAssetTotal;
+  final double? liabilityTotal;
+
+  /// 最新月の monthKey。
+  final String? monthKey;
+
+  /// 前月の純資産。前月データが無ければ null。
+  final double? previousNetWorth;
+
+  /// 前月比 (±¥)。前月データが無ければ null。
+  final double? deltaAmount;
+
+  /// 前月比 (±%)。**前月が正の値のときだけ**算出する。
+  ///
+  /// 前月が 0 だと除算不能、負だと符号の意味が反転する
+  /// (例: -100万 → -50万 は改善だが比率計算では -50% と出て誤読される)。
+  /// そうした場合は null を返し、UI 側は「—」を出して ±¥ のみで判断させる。
+  final double? deltaPercent;
+
+  /// スパークライン用の系列 (monthKey 昇順 / 最大 [AssetNetWorthPanelService.sparklineMonths] 件)。
+  final List<AssetNetWorthPoint> sparkline;
+
+  const AssetNetWorthPanel({
+    required this.netWorth,
+    required this.positiveAssetTotal,
+    required this.liabilityTotal,
+    required this.monthKey,
+    required this.previousNetWorth,
+    required this.deltaAmount,
+    required this.deltaPercent,
+    required this.sparkline,
+  });
+
+  static const AssetNetWorthPanel empty = AssetNetWorthPanel(
+    netWorth: null,
+    positiveAssetTotal: null,
+    liabilityTotal: null,
+    monthKey: null,
+    previousNetWorth: null,
+    deltaAmount: null,
+    deltaPercent: null,
+    sparkline: <AssetNetWorthPoint>[],
+  );
+
+  bool get hasData => netWorth != null;
+
+  bool get hasDelta => deltaAmount != null;
+
+  bool get hasDeltaPercent => deltaPercent != null;
+
+  /// 前月比がプラス (据え置き含む)。delta が無い場合は false。
+  bool get isImproved => (deltaAmount ?? 0) >= 0 && hasDelta;
+
+  /// スパークラインを描画するに足る点数があるか。
+  bool get hasSparkline => sparkline.length >= 2;
+}
+
+/// 月次スナップショットから純資産パネルを組み立てる純サービス。
+///
+/// 金額・変化率はすべてローカルで deterministic に算出し、AI は関与しない
+/// (issue 注意事項準拠)。
+class AssetNetWorthPanelService {
+  const AssetNetWorthPanelService();
+
+  /// スパークラインに用いる直近月数。
+  static const int sparklineMonths = 6;
+
+  /// [snapshots] (順不同可) から最新月を基準にパネルを構築する。
+  ///
+  /// [currentMonthSnapshot] を渡すと同一 monthKey の履歴より優先する
+  /// (ライブの当月を未保存でも反映するため)。
+  AssetNetWorthPanel build({
+    required List<AssetLiabilityMonthlySnapshot> snapshots,
+    AssetLiabilityMonthlySnapshot? currentMonthSnapshot,
+  }) {
+    final byMonth = <String, AssetLiabilityMonthlySnapshot>{};
+    for (final s in snapshots) {
+      final key = s.monthKey.trim();
+      if (key.isEmpty) continue;
+      byMonth[key] = s;
+    }
+    if (currentMonthSnapshot != null) {
+      final key = currentMonthSnapshot.monthKey.trim();
+      if (key.isNotEmpty) byMonth[key] = currentMonthSnapshot;
+    }
+    if (byMonth.isEmpty) {
+      return AssetNetWorthPanel.empty;
+    }
+
+    final keys = byMonth.keys.toList()..sort();
+    final latest = byMonth[keys.last]!;
+    final previous = keys.length >= 2 ? byMonth[keys[keys.length - 2]] : null;
+
+    final delta = previous == null ? null : latest.netWorth - previous.netWorth;
+    // 前月が正のときだけ変化率を出す (0 除算 / 負の基準での符号反転を回避)。
+    final percent = (previous != null && previous.netWorth > 0 && delta != null)
+        ? delta / previous.netWorth * 100
+        : null;
+
+    final tail = keys.length <= sparklineMonths
+        ? keys
+        : keys.sublist(keys.length - sparklineMonths);
+
+    return AssetNetWorthPanel(
+      netWorth: latest.netWorth,
+      positiveAssetTotal: latest.positiveAssetTotal,
+      liabilityTotal: latest.liabilityTotal,
+      monthKey: latest.monthKey,
+      previousNetWorth: previous?.netWorth,
+      deltaAmount: delta,
+      deltaPercent: percent,
+      sparkline: [
+        for (final k in tail)
+          AssetNetWorthPoint(monthKey: k, netWorth: byMonth[k]!.netWorth),
+      ],
+    );
+  }
+}

--- a/lib/widgets/asset_net_worth_panel_card.dart
+++ b/lib/widgets/asset_net_worth_panel_card.dart
@@ -1,0 +1,283 @@
+import 'package:flutter/material.dart';
+
+import '../services/asset_net_worth_panel_service.dart';
+
+/// 純資産パネル (Issue #2473)。
+///
+/// 純サービス [AssetNetWorthPanelService] の結果 ([AssetNetWorthPanel]) を受け取り、
+/// 「純資産」「前月比 ±¥ / ±%」「直近6月のミニスパークライン」を描画する
+/// 自己完結ウィジェット。ページ状態へ依存しないため単体検証できる。
+class AssetNetWorthPanelCard extends StatelessWidget {
+  const AssetNetWorthPanelCard({
+    super.key,
+    required this.panel,
+    this.currencyFormatter,
+  });
+
+  final AssetNetWorthPanel panel;
+
+  /// 金額整形 (ページの `_formatYen` を渡す)。null なら簡易整形。
+  final String Function(double value)? currencyFormatter;
+
+  static const Color _positive = Color(0xFF0D9488);
+  static const Color _negative = Color(0xFFB91C1C);
+  static const Color _accent = Color(0xFF2563EB);
+  static const Color _muted = Color(0xFF6B7280);
+
+  String _yen(double v) {
+    final f = currencyFormatter;
+    if (f != null) return f(v);
+    return '¥${v.round()}';
+  }
+
+  String _signedYen(double v) => '${v >= 0 ? '+' : '-'}${_yen(v.abs())}';
+
+  String _monthLabel(String monthKey) {
+    final parts = monthKey.split('-');
+    if (parts.length < 2) return monthKey;
+    final m = int.tryParse(parts[1]);
+    return m == null ? monthKey : '$m月';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (!panel.hasData) return const SizedBox.shrink();
+
+    final net = panel.netWorth!;
+    final netColor = net < 0 ? _negative : _positive;
+
+    return Card(
+      key: const Key('asset_net_worth_panel_card'),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.savings_outlined, color: _accent),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '純資産',
+                    style: theme.textTheme.titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                if (panel.monthKey != null)
+                  Text(
+                    _monthLabel(panel.monthKey!),
+                    style: theme.textTheme.labelSmall?.copyWith(color: _muted),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '資産合計 − 負債合計',
+              style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              _yen(net),
+              key: const Key('asset_net_worth_value'),
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: netColor,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _buildDeltaRow(theme),
+            if (panel.positiveAssetTotal != null &&
+                panel.liabilityTotal != null) ...[
+              const SizedBox(height: 10),
+              _buildBreakdown(theme),
+            ],
+            if (panel.hasSparkline) ...[
+              const SizedBox(height: 14),
+              _buildSparkline(theme),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDeltaRow(ThemeData theme) {
+    if (!panel.hasDelta) {
+      return Text(
+        '前月のデータが無いため前月比を表示できません。',
+        key: const Key('asset_net_worth_delta_missing'),
+        style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+      );
+    }
+    final delta = panel.deltaAmount!;
+    final color = delta >= 0 ? _positive : _negative;
+    return Row(
+      key: const Key('asset_net_worth_delta'),
+      children: [
+        Icon(
+          delta >= 0 ? Icons.trending_up : Icons.trending_down,
+          size: 18,
+          color: color,
+        ),
+        const SizedBox(width: 6),
+        Text(
+          '前月比 ',
+          style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+        ),
+        Text(
+          _signedYen(delta),
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(fontWeight: FontWeight.w700, color: color),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          panel.hasDeltaPercent
+              ? '(${panel.deltaPercent! >= 0 ? '+' : ''}'
+                  '${panel.deltaPercent!.toStringAsFixed(1)}%)'
+              : '(—)',
+          key: const Key('asset_net_worth_delta_percent'),
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: panel.hasDeltaPercent ? color : _muted,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBreakdown(ThemeData theme) {
+    return Row(
+      children: [
+        _chip(theme, '資産', _yen(panel.positiveAssetTotal!), _positive),
+        const SizedBox(width: 8),
+        _chip(theme, '負債', _yen(panel.liabilityTotal!), _negative),
+      ],
+    );
+  }
+
+  Widget _chip(ThemeData theme, String label, String value, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '$label ',
+            style: theme.textTheme.labelSmall?.copyWith(color: _muted),
+          ),
+          Text(
+            value,
+            style: theme.textTheme.labelSmall
+                ?.copyWith(fontWeight: FontWeight.w700, color: color),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSparkline(ThemeData theme) {
+    final first = panel.sparkline.first;
+    final last = panel.sparkline.last;
+    final rising = last.netWorth >= first.netWorth;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '直近${panel.sparkline.length}か月の推移',
+          style: theme.textTheme.labelSmall?.copyWith(color: _muted),
+        ),
+        const SizedBox(height: 6),
+        SizedBox(
+          key: const Key('asset_net_worth_sparkline'),
+          height: 44,
+          width: double.infinity,
+          child: CustomPaint(
+            painter: _NetWorthSparklinePainter(
+              values: [for (final p in panel.sparkline) p.netWorth],
+              color: rising ? _positive : _negative,
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              _monthLabel(first.monthKey),
+              style: theme.textTheme.labelSmall?.copyWith(color: _muted),
+            ),
+            Text(
+              _monthLabel(last.monthKey),
+              style: theme.textTheme.labelSmall?.copyWith(color: _muted),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+/// 外部依存なしのミニスパークライン描画。
+class _NetWorthSparklinePainter extends CustomPainter {
+  _NetWorthSparklinePainter({required this.values, required this.color});
+
+  final List<double> values;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (values.length < 2 || size.width <= 0 || size.height <= 0) return;
+
+    final minV = values.reduce((a, b) => a < b ? a : b);
+    final maxV = values.reduce((a, b) => a > b ? a : b);
+    final span = maxV - minV;
+    // 全点が同値だと span=0 → 0 除算になるため中央に water line を引く。
+    final flat = span.abs() < 1e-9;
+
+    final dx = size.width / (values.length - 1);
+    Offset pointAt(int i) {
+      final y = flat
+          ? size.height / 2
+          : size.height - ((values[i] - minV) / span) * size.height;
+      return Offset(dx * i, y);
+    }
+
+    final path = Path()..moveTo(pointAt(0).dx, pointAt(0).dy);
+    for (var i = 1; i < values.length; i++) {
+      final p = pointAt(i);
+      path.lineTo(p.dx, p.dy);
+    }
+
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = color
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round,
+    );
+
+    // 最終点を強調。
+    final lastP = pointAt(values.length - 1);
+    canvas.drawCircle(lastP, 3, Paint()..color = color);
+  }
+
+  @override
+  bool shouldRepaint(covariant _NetWorthSparklinePainter old) =>
+      old.color != color || !_sameValues(old.values, values);
+
+  static bool _sameValues(List<double> a, List<double> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/test/services/asset_net_worth_panel_service_test.dart
+++ b/test/services/asset_net_worth_panel_service_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_net_worth_panel_service.dart';
+
+AssetLiabilityMonthlySnapshot _snap(
+  String monthKey, {
+  required double netWorth,
+  double assets = 0,
+  double liabilities = 0,
+}) {
+  return AssetLiabilityMonthlySnapshot(
+    monthKey: monthKey,
+    savedAt: DateTime(2026, 1, 1),
+    positiveAssetTotal: assets,
+    liabilityTotal: liabilities,
+    netWorth: netWorth,
+    cashLikeTotal: 0,
+    monthlyScheduledPaymentTotal: 0,
+    monthlyPaidPaymentTotal: 0,
+    monthlyUnpaidPaymentTotal: 0,
+    overduePaymentCount: 0,
+  );
+}
+
+void main() {
+  const service = AssetNetWorthPanelService();
+
+  group('AssetNetWorthPanelService.build', () {
+    test('empty snapshots produce no data', () {
+      final p = service.build(
+        snapshots: const <AssetLiabilityMonthlySnapshot>[],
+      );
+      expect(p.hasData, isFalse);
+      expect(p.netWorth, isNull);
+      expect(p.sparkline, isEmpty);
+    });
+
+    test('latest month drives the headline value and breakdown', () {
+      final p = service.build(
+        snapshots: [
+          _snap('2026-05', netWorth: 100),
+          _snap('2026-07', netWorth: 300, assets: 500, liabilities: 200),
+          _snap('2026-06', netWorth: 200),
+        ],
+      );
+      expect(p.monthKey, '2026-07');
+      expect(p.netWorth, 300);
+      expect(p.positiveAssetTotal, 500);
+      expect(p.liabilityTotal, 200);
+    });
+
+    test('delta amount and percent versus previous month', () {
+      final p = service.build(
+        snapshots: [
+          _snap('2026-06', netWorth: 200000),
+          _snap('2026-07', netWorth: 250000),
+        ],
+      );
+      expect(p.deltaAmount, 50000);
+      expect(p.deltaPercent, closeTo(25.0, 1e-9));
+      expect(p.isImproved, isTrue);
+    });
+
+    test('negative delta is reported with a negative percent', () {
+      final p = service.build(
+        snapshots: [
+          _snap('2026-06', netWorth: 200000),
+          _snap('2026-07', netWorth: 150000),
+        ],
+      );
+      expect(p.deltaAmount, -50000);
+      expect(p.deltaPercent, closeTo(-25.0, 1e-9));
+      expect(p.isImproved, isFalse);
+    });
+
+    test('percent is null when previous month is zero (no divide by zero)', () {
+      final p = service.build(
+        snapshots: [
+          _snap('2026-06', netWorth: 0),
+          _snap('2026-07', netWorth: 50000),
+        ],
+      );
+      expect(p.deltaAmount, 50000);
+      expect(p.hasDelta, isTrue);
+      // 0 基準は除算不能 → % は出さず ±¥ のみ。
+      expect(p.deltaPercent, isNull);
+      expect(p.hasDeltaPercent, isFalse);
+    });
+
+    test('percent is null when previous month is negative (sign would flip)',
+        () {
+      // -1,000,000 → -500,000 は「改善」だが比率だと -50% と出て誤読される。
+      final p = service.build(
+        snapshots: [
+          _snap('2026-06', netWorth: -1000000),
+          _snap('2026-07', netWorth: -500000),
+        ],
+      );
+      expect(p.deltaAmount, 500000);
+      expect(p.isImproved, isTrue);
+      expect(p.deltaPercent, isNull);
+    });
+
+    test('single month has no delta at all', () {
+      final p = service.build(snapshots: [_snap('2026-07', netWorth: 100)]);
+      expect(p.hasData, isTrue);
+      expect(p.hasDelta, isFalse);
+      expect(p.deltaAmount, isNull);
+      expect(p.deltaPercent, isNull);
+      expect(p.hasSparkline, isFalse);
+    });
+
+    test('sparkline keeps the trailing 6 months in ascending order', () {
+      final p = service.build(
+        snapshots: [
+          for (var m = 1; m <= 9; m++)
+            _snap(
+              '2026-${m.toString().padLeft(2, '0')}',
+              netWorth: m.toDouble(),
+            ),
+        ],
+      );
+      expect(p.sparkline.length, AssetNetWorthPanelService.sparklineMonths);
+      expect(
+        p.sparkline.map((e) => e.monthKey).toList(),
+        ['2026-04', '2026-05', '2026-06', '2026-07', '2026-08', '2026-09'],
+      );
+      expect(p.sparkline.last.netWorth, 9);
+      expect(p.hasSparkline, isTrue);
+    });
+
+    test('current month snapshot overrides same-month history (fresher)', () {
+      final p = service.build(
+        snapshots: [
+          _snap('2026-06', netWorth: 100),
+          _snap('2026-07', netWorth: 200),
+        ],
+        currentMonthSnapshot: _snap('2026-07', netWorth: 999),
+      );
+      expect(p.netWorth, 999);
+      expect(p.deltaAmount, 899);
+    });
+
+    test('blank month keys are ignored', () {
+      final p = service.build(
+        snapshots: [
+          _snap('   ', netWorth: 12345),
+          _snap('2026-07', netWorth: 100),
+        ],
+      );
+      expect(p.monthKey, '2026-07');
+      expect(p.netWorth, 100);
+    });
+
+    test('zero delta counts as improved (not a decline)', () {
+      final p = service.build(
+        snapshots: [
+          _snap('2026-06', netWorth: 100000),
+          _snap('2026-07', netWorth: 100000),
+        ],
+      );
+      expect(p.deltaAmount, 0);
+      expect(p.deltaPercent, 0);
+      expect(p.isImproved, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 概要
Issue #2473 (第2弾C)。散在していた純資産の情報を 1 パネルへ集約し、未実装だった **前月比 ±%** と **ミニスパークライン** を追加する。

## 着手前の既存実装との差分精査
| スコープ項目 | 既存 | 本PR |
|---|---|---|
| 純資産 (資産合計−負債合計) | ✅ あり（別セクションの chip） | パネルへ集約 |
| 前月比 ±¥ | ✅ あり（さらに別セクションの chip） | パネルへ集約 |
| **前月比 ±%** | ❌ **未実装**（`netDiffText` は `_formatSignedYen` のみ） | **追加** |
| **mini sparkline (直近6月)** | ❌ **未実装**（既存は期間指定の全体グラフ） | **追加** |

## 実装
- 純サービス `AssetNetWorthPanelService`（最新月の純資産 / 前月比 ±¥ / ±% / 直近6月系列）で **deterministic** に算出。AI は非関与（issue 注意事項準拠）。
- 自己完結ウィジェット `AssetNetWorthPanelCard`。スパークラインは `CustomPainter` で **外部依存なし**。
- 既存の chip / グラフは**変更していません**（新セクションを追加するのみ）。

## 数値安全性（敵対観点）
- **前月が 0 のとき ±% を出さない** — 0 除算回避。
- **前月が負のとき ±% を出さない** — `-100万 → -50万` は実際には「改善」だが、比率計算では `-50%` と出て**改善を悪化と誤読させる**。この場合は ±¥ のみで判断させ、UI は「—」を表示。
- 前月データ無し / 単月のみ → 前月比そのものを出さず、その旨を明示。
- スパークラインは全点同値（span=0）でも 0 除算せず中央線を描画。

## 受け入れ条件
- [x] 既存資産管理機能を壊さない（#2446-#2456 整合 / 既存表示は非変更、新セクション追加のみ）
- [x] テスト緑（新規 unit 11件 pass、変更ファイル analyze 0 / format clean）
- [x] feature flag OFF default + 段階的 rollout: セクション tier=`full` 限定

## テスト
`test/services/asset_net_worth_panel_service_test.dart` — 最新月選択 / ±¥ / ±% / **0基準** / **負基準** / 単月 / 6月切出し / 当月上書き / 空キー無視 / 据え置き。

Closes #2473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 読み取り専用の集計表示パネルで full モード限定 (既定OFF)。集計と変化率の決定論的ロジックは表示層非依存の unit 11件で境界網羅済みのため、複数月スナップショットを seed する integration_test は不均衡

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更は lib/ のUI・純サービス追加のみでEF/認証/RLS/書き込みに無関係。金額と変化率はunit11件で0除算・負基準まで検証済み
