### PR TITLE
perf(web): index.html のランタイム Google Fonts 読み込みを廃止 (458kBのブロッキングCSS+シャード除去 / #4104)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -68,13 +68,18 @@
 
   <link rel="preconnect" href="https://smmkxxavexumewbfaqpy.supabase.co" crossorigin>
   <link rel="dns-prefetch" href="//smmkxxavexumewbfaqpy.supabase.co">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" href="flutter_bootstrap.js" as="script">
-  <link
-    href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@700&display=swap"
-    rel="stylesheet"
-  >
+  <!--
+    Google Fonts (Noto Sans JP / Noto Serif JP) のランタイム読み込みは廃止した。
+    - この CSS は日本語の unicode-range 分割により **458kB / 496 シャード宣言**
+      あり、しかも stylesheet はレンダーブロッキングでコールドロード毎に効く。
+    - 用途は Flutter 起動前の SEO シェル (:root と .seo-card h1) だけで、
+      アプリ本体はバンドル済み NotoSansJP を使う (google_fonts の
+      allowRuntimeFetching も false)。
+    - `Noto Serif JP` は要求していたが index.html のどこでも未使用だった。
+    シェルは下の system font stack で描画する (OS 標準の日本語フォントを使うため
+    追加ダウンロードゼロ / ローカルに Noto Sans JP があればそれを使う)。
+  -->
 
   <title>自分株式会社 | AIが今日の最優先タスクを整理</title>
   <link rel="manifest" href="manifest.json">
@@ -213,7 +218,9 @@
   <style>
     :root {
       color-scheme: light;
-      font-family: "Noto Sans JP", "Noto Sans", sans-serif;
+      font-family: system-ui, -apple-system, "Segoe UI",
+        "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic UI",
+        "Yu Gothic", Meiryo, "Noto Sans JP", "Noto Sans", sans-serif;
     }
 
     *,
@@ -259,7 +266,9 @@
 
     .seo-card h1 {
       margin: 0;
-      font-family: "Noto Sans JP", "Noto Sans", sans-serif;
+      font-family: system-ui, -apple-system, "Segoe UI",
+        "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic UI",
+        "Yu Gothic", Meiryo, "Noto Sans JP", "Noto Sans", sans-serif;
       font-size: 54px;
       line-height: 1.18;
       letter-spacing: 0;


### PR DESCRIPTION
# perf(web): index.html のランタイム Google Fonts 読み込みを廃止 (#4104)

資産管理闘争ページの本番トレース (build 4877) で、`css2?family=No...` を initiator とする **font 7 本 (各 17-19kB)** を観測。既知 Issue #4104 の現象を実測で裏取りし、根本を除去した。

## 実測 (これが効く理由)

`https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@700&display=swap` を Chrome UA で取得:

| 項目 | 実測値 |
|---|---|
| CSS 本体 | **458 kB** |
| 宣言されるフォントシャード URL | **496 本** |
| 実際に落ちるシャード (本番トレース) | 7 本 × 17-19 kB ≒ **130 kB** |
| stylesheet の性質 | **レンダーブロッキング** |

日本語は unicode-range で細かく分割されるため CSS 自体が巨大になる。これをコールドロードの度に払っていた。

## 用途の実態

- 使用箇所は **Flutter 起動前の SEO シェルのみ** (`:root` と `.seo-card h1` の 2 箇所)
- アプリ本体は**バンドル済み NotoSansJP** を使う (`GoogleFonts.config.allowRuntimeFetching = false` も設定済み)
- **`Noto Serif JP` は要求していたが index.html のどこでも未使用** — 要求フォントの半分が完全な無駄だった

## 変更内容

- `fonts.googleapis` / `fonts.gstatic` への `preconnect` 2 本と css2 `stylesheet` link を削除
- シェルの `font-family` を system font stack へ:
  `system-ui, -apple-system, "Segoe UI", "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic UI", "Yu Gothic", Meiryo, "Noto Sans JP", "Noto Sans", sans-serif`
  → OS 標準の日本語フォントで描画 (追加ダウンロードゼロ)。ローカルに Noto Sans JP があればそれを使う

## 効果とトレードオフ

**効果**: コールドロードから 458kB のレンダーブロッキング CSS + 実取得シャード ~130kB + 第三者オリジンへの preconnect 2 本が消える。

**トレードオフ**: Flutter 起動までの一瞬のシェルが OS 標準日本語フォント (Yu Gothic / Hiragino / Noto Sans CJK) で描画される。日本語では視覚的にほぼ同等で、シェルは遷移的表示 + クローラ向け。**SEO シェルのテキスト内容は不変**なので `public_smoke` の配信 HTML 検証には影響しない。

## 検証

- `grep fonts.googleapis` → リポジトリ内 0 件 (他 HTML にも同種の読み込み無し)
- Firebase hosting は `build/web` を配信し、これは `web/index.html` から生成されるため本 PR が本番に反映される
- 差分は 1 ファイル・フォント関連のみ (シェルのテキスト/構造は無変更)

## スコープ外

バンドル済み 11.2MB フォントの skip 決定 ([SEO_AUDIT_2026-07](docs/seo/SEO_AUDIT_2026-07.md) / UGC の豆腐リスク) とは**別問題**で、本 PR はそこに触れない。#4104 が明記するとおり「`<link>` を外すだけで独立に削減できる」部分のみを対象とする。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更は web/index.html のフォント読み込み除去と font-family 差し替えのみ。認証・認可・EF・migration・DB・アプリロジックに一切触れず、配信 HTML のテキスト内容も不変。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 変更は静的 HTML のフォント指定のみで、既存の `public_smoke` (配信 HTML の seo-shell 検証) がそのまま回帰テストになる。テキスト内容不変のため同 gate で担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
