### PR TITLE
fix(ui): AIシェアFABのtop配置がAppBarのactionsを覆って押せなくなるのを修正 (part340)

### DIFF
--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -89,6 +89,13 @@ class UniversalAiShareRouteObserver extends NavigatorObserver {
   }
 }
 
+/// R33: AI シェア FAB は Navigator の Overlay に載るため、ページの AppBar より
+/// 前面に出る。top 配置で `top: 20` のままだと標準 AppBar (kToolbarHeight=56) の
+/// actions を覆ってしまい、例えば /admin の「データをリセット」「データを更新」
+/// ボタンが押せなくなる (実機 build 4873/4877 で発生)。ツールバー高さぶん下げて
+/// アプリの chrome を塞がないようにする。bottom 配置は元から干渉しない。
+const double kAiShareFabTopOffset = kToolbarHeight + 20;
+
 class UniversalAiShareShell extends StatefulWidget {
   final Widget child;
   final GlobalKey<NavigatorState> navigatorKey;
@@ -195,9 +202,9 @@ class _UniversalAiShareShellState extends State<UniversalAiShareShell> {
   Widget _positionedFab(AiShareButtonPosition position, Widget child) {
     switch (position) {
       case AiShareButtonPosition.topLeft:
-        return Positioned(left: 16, top: 20, child: child);
+        return Positioned(left: 16, top: kAiShareFabTopOffset, child: child);
       case AiShareButtonPosition.topRight:
-        return Positioned(right: 16, top: 20, child: child);
+        return Positioned(right: 16, top: kAiShareFabTopOffset, child: child);
       case AiShareButtonPosition.bottomLeft:
         return Positioned(left: 16, bottom: 20, child: child);
       case AiShareButtonPosition.bottomRight:

--- a/test/widgets/universal_ai_share_fab_offset_test.dart
+++ b/test/widgets/universal_ai_share_fab_offset_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/universal_ai_share_shell.dart';
+
+void main() {
+  // R33: AI シェア FAB は Navigator Overlay に載りページの AppBar より前面に出る。
+  // top 配置が AppBar 高さより上だと actions (例 /admin のデータリセット・更新)
+  // を覆って押せなくなるため、ツールバー高さを必ず超える不変条件を固定する。
+  test('top 配置の FAB オフセットは標準 AppBar 高さを超える', () {
+    expect(
+      kAiShareFabTopOffset,
+      greaterThan(kToolbarHeight),
+      reason: 'top 配置で AppBar の actions を覆ってはならない',
+    );
+  });
+
+  test('よくある拡張 AppBar (toolbarHeight: 74) も塞がない', () {
+    // home_page など toolbarHeight を広げたページでも干渉しないこと。
+    expect(kAiShareFabTopOffset, greaterThan(74.0));
+  });
+}


### PR DESCRIPTION
## 概要

build 4873/4877 のスクリーンショットで **AIシェアボタンが右上に移動して以降、/admin の AppBar 右端 (データをリセット / データを更新) が押せなくなっていた**。

## 原因

AIシェア FAB は Navigator の **Overlay に OverlayEntry として挿入**されるため、ページの AppBar より前面に描画される。top 配置は `Positioned(top: 20)` 固定で、標準 AppBar (`kToolbarHeight` = 56) の領域に完全に重なる。AppBar の `actions` は右端にあるため、**topRight 配置では actions が FAB の下敷きになり操作不能**になる。

※ ボタン位置は `AiShareButtonPosition` のユーザー設定 (4隅) なので、**位置が変わったこと自体は正常**。top を選んだ瞬間にアプリの chrome が操作不能になるのが不具合。

## 修正

top 配置のオフセットを `kAiShareFabTopOffset = kToolbarHeight + 20` (=76) にし、FAB が必ずツールバーを下回るようにする。**右上/左上という配置意図は保ったまま** AppBar の直下に出る。bottom 配置は元から干渉しないため据え置き。

## 検証
- `universal_ai_share_fab_offset_test.dart` を追加し不変条件を固定 — 「top オフセットは `kToolbarHeight` を超える」「`toolbarHeight: 74` の拡張 AppBar (home_page 等) も塞がない」。**20 に戻すと落ちる回帰ガード**。
- 既存 `universal_ai_share_shell_test.dart` 8件パス (挙動非破壊を確認)
- `flutter analyze` 0 issue / `dart format` 差分なし

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Client-only UI offset fix: move the overlay-hosted AI share FAB below the toolbar when placed at a top corner so it stops covering AppBar actions. No auth, RLS, payment, secret, schema, or edge changes; covered by a VM regression test

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Single UI offset constant covered by a VM regression test (universal_ai_share_fab_offset_test.dart) locking the invariant that a top-placed FAB clears kToolbarHeight and a 74px extended AppBar; existing universal_ai_share_shell_test.dart (8 cases) still passes. analyze 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
