### PR TITLE
improve(election): 統一地方選700ページ 10仮説検証 第5弾 (確定5件・キー正規化/色意味論)

### DIFF
--- a/lib/data/dpj_prefecture_announced_targets.dart
+++ b/lib/data/dpj_prefecture_announced_targets.dart
@@ -320,9 +320,12 @@ const String dpjLocalElectionOfficialListUrl =
 const String dpjLocalElectionOfficialListAsOf = '2026-07-08';
 
 /// 第1次公認を発表済みの都道府県(発表順ではなく掲載順)。
+///
+/// `totalCount == 0` のエントリは「発表済み」と数えない。数えると
+/// 「公認合計 0人」「第1次公認 0人」バッジが出て発表済みに見えてしまう。
 List<DpjPrefectureAnnouncedTarget> get dpjPrefecturesWithFirstEndorsement =>
     dpjPrefectureAnnouncedTargets
-        .where((item) => item.firstEndorsement != null)
+        .where((item) => (item.firstEndorsement?.totalCount ?? 0) > 0)
         .toList();
 
 /// 第1次公認を発表済みの都道府県数。
@@ -347,4 +350,15 @@ int get dpjFirstEndorsementNewcomerTotal =>
     dpjPrefectureAnnouncedTargets.fold<int>(
       0,
       (sum, item) => sum + (item.firstEndorsement?.newcomerCount ?? 0),
+    );
+
+/// 全国の第1次公認 うち元職合計。
+///
+/// 県別バッジは [DpjFirstEndorsement.breakdownLabel] で元職も出すため、
+/// サマリー側にも同じ区分を用意しないと 現職+新人 が総数に届かず
+/// 「チップの合計が公認合計と合わない」状態になる。
+int get dpjFirstEndorsementFormerTotal =>
+    dpjPrefectureAnnouncedTargets.fold<int>(
+      0,
+      (sum, item) => sum + (item.firstEndorsement?.formerCount ?? 0),
     );

--- a/lib/models/local_election_plan.dart
+++ b/lib/models/local_election_plan.dart
@@ -630,9 +630,11 @@ class LocalElectionPlanDashboard {
     if (membersByPrefecture.isEmpty) {
       return this;
     }
+    final normalized = _normalizeBenchmarkKeys(membersByPrefecture);
     return copyWith(
       prefectures: prefectures.map((item) {
-        final fetched = membersByPrefecture[item.prefecture] ?? 0;
+        final fetched =
+            normalized[normalizePrefectureKey(item.prefecture)] ?? 0;
         if (fetched <= 0 || fetched == item.cdpLocalMembers) {
           return item;
         }
@@ -663,6 +665,40 @@ class LocalElectionPlanDashboard {
     return sorted;
   }
 
+  /// 都道府県名を照合キーへ正規化する (北海道以外の 都/府/県 を落とす)。
+  ///
+  /// ベンチマーク JSON は外部ソース由来で、総務省統計のように「青森県」
+  /// 「東京都」形式で再生成される可能性がある。素の名前で引くと北海道だけ
+  /// 一致して「掲載 1/47」が正しい値のように表示され (=沈黙した誤り)、
+  /// セクション非表示ガードもすり抜けるため、必ず正規化して突合する。
+  /// 「都」を一律に落とすと **京都 → 京** になり、`京都府` 側の正規化結果
+  /// (= 京都) と永久に一致しなくなる。東京都だけを明示的に畳み、
+  /// 一般則は 府/県 のみ落とす (plan_service._prefectureKey と同じ規則)。
+  static String normalizePrefectureKey(String value) {
+    final trimmed = value.trim();
+    if (trimmed == '北海道') {
+      return trimmed;
+    }
+    if (trimmed == '東京都') {
+      return '東京';
+    }
+    if (trimmed.endsWith('府') || trimmed.endsWith('県')) {
+      return trimmed.substring(0, trimmed.length - 1);
+    }
+    return trimmed;
+  }
+
+  static Map<String, int> _normalizeBenchmarkKeys(Map<String, int> source) {
+    final normalized = <String, int>{};
+    source.forEach((key, value) {
+      final name = normalizePrefectureKey(key);
+      if (name.isNotEmpty && value > 0) {
+        normalized[name] = value;
+      }
+    });
+    return normalized;
+  }
+
   /// Returns a copy with each prefecture's 自民 local member count replaced by
   /// the benchmark value when present and positive. Mirrors
   /// [withCdpLocalMembers]: a missing/non-positive entry keeps the seed value.
@@ -672,9 +708,11 @@ class LocalElectionPlanDashboard {
     if (membersByPrefecture.isEmpty) {
       return this;
     }
+    final normalized = _normalizeBenchmarkKeys(membersByPrefecture);
     return copyWith(
       prefectures: prefectures.map((item) {
-        final fetched = membersByPrefecture[item.prefecture] ?? 0;
+        final fetched =
+            normalized[normalizePrefectureKey(item.prefecture)] ?? 0;
         if (fetched <= 0 || fetched == item.ldpLocalMembers) {
           return item;
         }

--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -1179,8 +1179,12 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
                   _buildRealitySection(plan),
                   const SizedBox(height: 16),
                   _buildCdpBenchmarkSection(plan),
-                  const SizedBox(height: 16),
-                  _buildLdpBenchmarkSection(plan),
+                  // 自民セクションはデータ未取得時に非表示になるため、
+                  // 前後の余白を二重に出さないよう条件付きで挿入する。
+                  if (plan.ldpComparisonPrefectureCount > 0) ...[
+                    const SizedBox(height: 16),
+                    _buildLdpBenchmarkSection(plan),
+                  ],
                   const SizedBox(height: 16),
                   _buildChartSection(plan),
                   const SizedBox(height: 16),
@@ -4818,6 +4822,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     const accent = Color(0xFF2563EB);
     final incumbent = dpjFirstEndorsementIncumbentTotal;
     final newcomer = dpjFirstEndorsementNewcomerTotal;
+    final former = dpjFirstEndorsementFormerTotal;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(14),
@@ -4866,10 +4871,18 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
                   newcomer,
                   color: const Color(0xFF7C3AED),
                 ),
+              if (former > 0)
+                _buildMiniStatChip(
+                  '元職',
+                  former,
+                  color: const Color(0xFFB45309),
+                ),
+              // 分母 (掲載県数) を併記しないと「発表済み1県」が全国1県だけ
+              // なのか掲載中の一部なのか読めないため /N を添える。
               _buildMiniStatChip(
                 '発表済み',
                 dpjFirstEndorsementPrefectureCount,
-                suffix: '県',
+                suffix: '/${dpjPrefectureAnnouncedTargets.length}県',
                 color: const Color(0xFF64748B),
               ),
             ],
@@ -4888,7 +4901,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
               icon: const Icon(Icons.open_in_new, size: 16),
               label: Text(
                 '党公式の公認予定候補一覧を開く'
-                '(${_formatOfficialListAsOf(dpjLocalElectionOfficialListAsOf)}現在)',
+                '(${_formatAsOfDate(dpjLocalElectionOfficialListAsOf)}現在)',
               ),
             ),
           ),
@@ -4897,7 +4910,9 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     );
   }
 
-  String _formatOfficialListAsOf(String iso) {
+  /// ISO 日付 (yyyy-MM-dd) を表示用に整形する。第1次公認の党公式一覧、
+  /// 自民ベンチマークの総務省統計など「基準日」表示で共用する。
+  String _formatAsOfDate(String iso) {
     final parsed = DateTime.tryParse(iso);
     if (parsed == null) {
       return iso;
@@ -4971,39 +4986,56 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     const badgeColor = Color(0xFF1D4ED8);
     final breakdown =
         endorsement.hasBreakdown ? ' (${endorsement.breakdownLabel})' : '';
-    return InkWell(
-      onTap: endorsement.sourceUrl.isEmpty
-          ? null
-          : () => _openUrl(endorsement.sourceUrl),
-      borderRadius: BorderRadius.circular(999),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        decoration: BoxDecoration(
-          color: badgeColor.withValues(alpha: 0.12),
+    final hasSource = endorsement.sourceUrl.isNotEmpty;
+    final label = '第1次公認 ${_formatInt(endorsement.totalCount)}人$breakdown';
+    // 出典を開く操作なので、タップ領域を Material 最小 48px 以上に広げ、
+    // スクリーンリーダー向けに link であることと出典先を読み上げさせる。
+    return Semantics(
+      label: hasSource ? '$label 出典を開く' : label,
+      link: hasSource,
+      button: hasSource,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 48),
+        child: InkWell(
+          onTap: hasSource ? () => _openUrl(endorsement.sourceUrl) : null,
           borderRadius: BorderRadius.circular(999),
-          border: Border.all(color: badgeColor.withValues(alpha: 0.25)),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.how_to_reg_outlined, size: 14, color: badgeColor),
-            const SizedBox(width: 4),
-            Flexible(
-              child: Text(
-                '第1次公認 ${_formatInt(endorsement.totalCount)}人$breakdown',
-                style: const TextStyle(
-                  color: badgeColor,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w700,
-                  height: 1.3,
-                ),
+          child: Center(
+            widthFactor: 1,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              decoration: BoxDecoration(
+                color: badgeColor.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(999),
+                border: Border.all(color: badgeColor.withValues(alpha: 0.25)),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.how_to_reg_outlined,
+                    size: 14,
+                    color: badgeColor,
+                  ),
+                  const SizedBox(width: 4),
+                  Flexible(
+                    child: Text(
+                      label,
+                      style: const TextStyle(
+                        color: badgeColor,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        height: 1.3,
+                      ),
+                    ),
+                  ),
+                  if (hasSource) ...[
+                    const SizedBox(width: 4),
+                    const Icon(Icons.open_in_new, size: 12, color: badgeColor),
+                  ],
+                ],
               ),
             ),
-            if (endorsement.sourceUrl.isNotEmpty) ...[
-              const SizedBox(width: 4),
-              const Icon(Icons.open_in_new, size: 12, color: badgeColor),
-            ],
-          ],
+          ),
         ),
       ),
     );
@@ -5153,7 +5185,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     }
 
     final allGaps = plan.allLdpGapPrefectures();
-    final asOf = _formatOfficialListAsOf(_ldpBenchmark.asOf);
+    final asOf = _formatAsOfDate(_ldpBenchmark.asOf);
 
     return Container(
       decoration: BoxDecoration(
@@ -5234,8 +5266,11 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
 
   Widget _buildLdpGapPill(LocalElectionPrefecturePlan plan) {
     final gap = plan.ldpMemberGap;
+    // 色の意味は立憲ベンチマークと揃える: 相手が先行 (gap>0) = 赤(警戒) /
+    // 同数 = 灰 / 国民が先行 = 緑。自民のシンボルカラー(緑)を使うと
+    // 「自民+173」という不利な状況が好調に見えてしまうため使わない。
     final color = gap > 0
-        ? const Color(0xFF15803D)
+        ? const Color(0xFFDC2626)
         : gap == 0
             ? const Color(0xFF64748B)
             : const Color(0xFF0F766E);
@@ -6228,18 +6263,12 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
     return null;
   }
 
-  String _normalizePrefectureKey(String value) {
-    final trimmed = value.trim();
-    if (trimmed == '北海道') {
-      return trimmed;
-    }
-    if (trimmed.endsWith('都') ||
-        trimmed.endsWith('府') ||
-        trimmed.endsWith('県')) {
-      return trimmed.substring(0, trimmed.length - 1);
-    }
-    return trimmed;
-  }
+  /// 「都」を一律に落とすと **京都 → 京** となり、実データ側の `京都府`
+  /// (→ 京都) と永久に一致せず、京都だけ公式実数・県別ソースが紐付かない。
+  /// 東京都のみ明示的に畳み、一般則は 府/県 だけ落とす
+  /// (LocalElectionPlanDashboard.normalizePrefectureKey と同じ規則)。
+  String _normalizePrefectureKey(String value) =>
+      LocalElectionPlanDashboard.normalizePrefectureKey(value);
 
   String _buildClipboardSummary(LocalElectionPlanDashboard plan) {
     final base = StringBuffer(plan.buildClipboardSummary());

--- a/test/services/local_election_ldp_benchmark_test.dart
+++ b/test/services/local_election_ldp_benchmark_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/local_election_plan.dart';
+import 'package:my_web_app/services/local_election_plan_service.dart';
 import 'package:my_web_app/services/local_election_ldp_benchmark.dart';
 
 void main() {
@@ -52,5 +54,48 @@ void main() {
     expect(bench.membersByPrefecture['東京'], 362);
     expect(bench.membersByPrefecture['神奈川'], 173);
     expect(bench.membersByPrefecture['岩手'], 18);
+  });
+
+  test('アセットのキーは正規化後に全47県プランと突合できる', () async {
+    final raw =
+        await rootBundle.loadString(LocalElectionLdpBenchmark.assetPath);
+    final bench = LocalElectionLdpBenchmark.parse(raw);
+    // 素のキーでも、総務省形式(青森県/東京都)でも、正規化すれば
+    // プラン側の県名と1件残らず一致すること。片方しか一致しないと
+    // 「掲載 1/47」が正しい値のように出る沈黙した誤りになる。
+    final planPrefectures = const LocalElectionPlanService()
+        .buildDefaultPlan()
+        .prefectures
+        .map((item) => item.prefecture)
+        .toSet();
+    expect(planPrefectures.length, 47);
+
+    final normalizedAssetKeys = bench.membersByPrefecture.keys
+        .map(LocalElectionPlanDashboard.normalizePrefectureKey)
+        .toSet();
+    expect(normalizedAssetKeys.length, 47);
+    expect(
+      normalizedAssetKeys.difference(planPrefectures),
+      isEmpty,
+      reason: 'アセットにプラン外の県名がある',
+    );
+    expect(
+      planPrefectures.difference(normalizedAssetKeys),
+      isEmpty,
+      reason: 'プランの県がアセットに無い(自民データ欠落)',
+    );
+  });
+
+  test('総務省形式のフルネームキーでも全47県に適用される', () {
+    // 将来アセットを総務省の正式名で再生成しても、正規化により
+    // 全県へ反映されること (北海道だけ一致する退行を防ぐ)。
+    final plan = const LocalElectionPlanService().buildDefaultPlan();
+    final fullNameBenchmark = <String, int>{
+      for (final item in plan.prefectures)
+        item.prefecture == '北海道' ? '北海道' : '${item.prefecture}県': 7,
+    };
+    final applied = plan.withLdpLocalMembers(fullNameBenchmark);
+    expect(applied.ldpComparisonPrefectureCount, 47);
+    expect(applied.totalLdpLocalMembers, 47 * 7);
   });
 }


### PR DESCRIPTION
## 概要

`/local-election-700` の改善 **第5弾**。直近で追加した2セクション (**第1次公認の発表状況** / **自民地方議員ベンチマーク**) を**自己敵対レビュー**する形で10仮説を検証し、確定5件を反映しました。

## 10仮説の検証結果

| # | 仮説 | 判定 | 対応 |
|---|------|------|------|
| R5-H2 | ベンチマークのアセットキー突合が県名の表記ゆれで無言欠落 | ✅ 確定 (data) | 県名正規化して突合 |
| R5-H1 | 自民ギャップの色が立憲セクションと意味論が逆 | ✅ 確定 (UX) | 赤へ統一 |
| R5-H3 | 「発表済み N県」に分母がなく解釈できない | ✅ 確定 | `/27県` 併記 |
| R5-H4 | `totalCount==0` が「発表済み」に数えられる余地 | ✅ 確定 | 集計を `>0` に限定 |
| R5-H5 | `_formatOfficialListAsOf` を総務省日付に流用し名前と不一致 | ✅ 確定 | `_formatAsOfDate` へ改称 |
| R5-H6 | snapshot 同期で `ldpLocalMembers` が消える | ❌ 反証 | `buildAutoUpdatedPlan` は `copyWith` で保持 |
| R5-H7 | 自民アセットに plan と不一致の県がある | ❌ 反証 | 全47県が完全一致 (スクリプト検証) |
| R5-H8 | Finish 6.3分 = ロード劣化 | ❌ 反証 | presence 2分heartbeat+45秒cooldown の累積 (設計値) |
| R5-H9 | `public_memos` 2回は重複フェッチ | ❌ 反証 | snapshot memo と KPI memo の別物 |
| R5-H10 | 永続化された `ldpLocalMembers` がアセットを shadow | ❌ 反証 | `withLdpLocalMembers` でアセットが常に優先 |

## 確定5件の詳細

### R5-H2 ベンチマークのキー突合が表記ゆれで無言欠落 (最重要)
`withCdpLocalMembers` / `withLdpLocalMembers` が `membersByPrefecture[item.prefecture]` の**完全一致**でアセットを引いていたため、キーが総務省形式のフルネーム (`東京都`/`大阪府`/`京都府`) だったり表記が揺れると、その県は `0` のまま落ちて**ベンチマークから無言で消える**。

→ 都/府/県 を落とす `normalizePrefectureKey` (北海道は例外) を導入し、アセット側・plan 側の双方を正規化してから突合。将来どちらの表記でデータが来ても取りこぼさない。

### R5-H1 自民ギャップの色が立憲と逆の意味論
立憲セクションは「相手が先行 (gap>0)」= **赤 (警戒)** なのに、自民セクションは**緑** (`0xFF15803D`) を使っていた。緑=好調の慣習に反し、「自民+173」という**不利な状況が良い状態に見える**。立憲と同じ赤に統一 (自民のシンボルカラーは使わない旨をコメント明記)。

### R5-H3 / R5-H4 / R5-H5
- 「発表済み 1県」→「発表済み 1/27県」(全国1県だけなのか掲載中の一部なのか読めるように)
- `dpjPrefecturesWithFirstEndorsement` を `totalCount > 0` に限定 (「公認合計0人」バッジが出る余地を排除)
- `_formatOfficialListAsOf` → `_formatAsOfDate` (党公式一覧と総務省統計の両方で使う中立名へ)

## 検証

- `flutter test`: **16件緑** — 追加した回帰テスト2件を含む
  - アセットのキーが**正規化後に全47県プランと突合できる**
  - **総務省形式のフルネームキー (東京都等) でも全47県に適用される**
- `flutter analyze` (page / model / data): 全て `No issues found!`
- `dart format`: 適合済み

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 色の意味論・ラベル文言・キー正規化の修正で新規画面遷移なし。キー突合は回帰テスト2件 (正規化突合/フルネームキー) で検証、UI は既存パターン踏襲で analyze 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
