### PR TITLE
feat(asset): 月次資産ダッシュボード 4パネルgrid layout #2472

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -98,6 +98,7 @@ import 'package:my_web_app/utils/web_image_downloader.dart';
 import 'package:my_web_app/widgets/asset_cashflow_forecast_card.dart';
 import 'package:my_web_app/widgets/asset_alert_center_card.dart';
 import 'package:my_web_app/widgets/asset_cashflow_statement_card.dart';
+import 'package:my_web_app/widgets/asset_dashboard_grid.dart';
 import 'package:my_web_app/widgets/asset_net_worth_panel_card.dart';
 import 'package:my_web_app/widgets/asset_category_budget_card.dart';
 import 'package:my_web_app/widgets/recurring_fixed_cost_card.dart';
@@ -8770,19 +8771,9 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
               _buildCashflowForecastCard(assetLiabilityWorkbook),
             ],
             if (_isSectionShown(
-              AssetManagementSectionId.cashflowStatement,
+              AssetManagementSectionId.monthlyDashboard,
             )) ...[
-              _buildCashflowStatementCard(assetLiabilityWorkbook),
-            ],
-            if (_isSectionShown(
-              AssetManagementSectionId.alertCenter,
-            )) ...[
-              _buildAssetAlertCenterCard(assetLiabilityWorkbook),
-            ],
-            if (_isSectionShown(
-              AssetManagementSectionId.netWorthPanel,
-            )) ...[
-              _buildAssetNetWorthPanelCard(assetLiabilityWorkbook),
+              _buildMonthlyDashboardGrid(assetLiabilityWorkbook),
             ],
             // 提案カード(定期取引/定期収入の自動検出)は給与内訳に相乗りせず専用
             // セクションへ。salaryBreakdown を隠しても提案だけ独立表示できる。
@@ -14342,7 +14333,59 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 月次キャッシュフローパネル (Issue #2474)。履歴スナップショット + ライブの当月から
   /// 「当月CF (月収 − 月支出)」「年初来累積CF」「直近12か月の黒字/赤字月数」を集計する。
   /// 金額計算は純サービス [AssetCashflowStatementService] で deterministic に行う。
-  Widget _buildCashflowStatementCard(AssetLiabilityWorkbook? workbook) {
+  /// 月次資産ダッシュボード (Issue #2472)。純資産 / キャッシュフロー / アラートを
+  /// responsive な 2x2 グリッド (mobile 1 列) に並べる。
+  ///
+  /// 4 枚目の「投資」パネルは第2弾B (#2468-#2470) が未実装のため現時点では
+  /// 渡していない。着地後にこの配列へ 1 要素足すだけでグリッドに乗る。
+  /// データが無いパネルは配列に入れないので空セルは発生しない。
+  Widget _buildMonthlyDashboardGrid(AssetLiabilityWorkbook? workbook) {
+    final panels = <AssetDashboardPanel>[];
+
+    final netWorth = _assetNetWorthPanelChild(workbook);
+    if (netWorth != null) {
+      panels.add(
+        AssetDashboardPanel(
+          title: '純資産',
+          onOpenDetail: () => _scrollTo(_keyStock),
+          child: netWorth,
+        ),
+      );
+    }
+
+    final cashflow = _cashflowStatementPanelChild(workbook);
+    if (cashflow != null) {
+      panels.add(
+        AssetDashboardPanel(
+          title: 'キャッシュフロー',
+          onOpenDetail: () => _scrollTo(_keyFlow),
+          child: cashflow,
+        ),
+      );
+    }
+
+    final alerts = _assetAlertCenterPanelChild(workbook);
+    if (alerts != null) {
+      panels.add(
+        AssetDashboardPanel(
+          title: 'アラート',
+          onOpenDetail: () => _scrollTo(_keyCalendar),
+          child: alerts,
+        ),
+      );
+    }
+
+    if (panels.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: AssetDashboardGrid(panels: panels),
+    );
+  }
+
+  /// キャッシュフローパネルの中身。データが無ければ null (グリッドから除外される)。
+  Widget? _cashflowStatementPanelChild(AssetLiabilityWorkbook? workbook) {
     // ライブの当月スナップショットを履歴サービスで生成し、未保存でも当月CFを反映する。
     AssetLiabilityMonthlySnapshot? currentMonthSnapshot;
     if (workbook != null) {
@@ -14360,21 +14403,18 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       asOf: DateTime.now(),
     );
     if (!statement.hasData) {
-      return const SizedBox.shrink();
+      return null;
     }
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 16),
-      child: AssetCashflowStatementCard(
-        statement: statement,
-        currencyFormatter: _formatYen,
-      ),
+    return AssetCashflowStatementCard(
+      statement: statement,
+      currencyFormatter: _formatYen,
     );
   }
 
   /// 純資産パネル (Issue #2473)。履歴スナップショット + ライブの当月から
   /// 「純資産」「前月比 ±¥ / ±%」「直近6月スパークライン」を集計する。
   /// 金額・変化率は純サービス [AssetNetWorthPanelService] で deterministic に算出。
-  Widget _buildAssetNetWorthPanelCard(AssetLiabilityWorkbook? workbook) {
+  Widget? _assetNetWorthPanelChild(AssetLiabilityWorkbook? workbook) {
     AssetLiabilityMonthlySnapshot? currentMonthSnapshot;
     if (workbook != null) {
       final monthKey =
@@ -14390,14 +14430,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
       currentMonthSnapshot: currentMonthSnapshot,
     );
     if (!panel.hasData) {
-      return const SizedBox.shrink();
+      return null;
     }
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 16),
-      child: AssetNetWorthPanelCard(
-        panel: panel,
-        currencyFormatter: _formatYen,
-      ),
+    return AssetNetWorthPanelCard(
+      panel: panel,
+      currencyFormatter: _formatYen,
     );
   }
 
@@ -14430,9 +14467,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 統合アラートパネル (Issue #2475)。延滞・口座ショート・支払リマインダー(#2453)・
   /// 支払原資未設定を重要度別に集約する。異常検知 (第2弾D) は将来 anomalyAlerts で
   /// 注入する統合設計。金額・重要度判定は純サービスで deterministic に行う。
-  Widget _buildAssetAlertCenterCard(AssetLiabilityWorkbook? workbook) {
+  /// アラートパネルの中身。データが無ければ null (グリッドから除外される)。
+  Widget? _assetAlertCenterPanelChild(AssetLiabilityWorkbook? workbook) {
     if (workbook == null) {
-      return const SizedBox.shrink();
+      return null;
     }
     final center = _assetAlertCenterService.build(
       workbook: workbook,
@@ -14441,17 +14479,14 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     );
     // 表示するアラートも dismiss 済みも無ければカードを出さない。
     if (!center.hasAlerts && center.dismissedCount == 0) {
-      return const SizedBox.shrink();
+      return null;
     }
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 16),
-      child: AssetAlertCenterCard(
-        center: center,
-        onDismiss: _dismissAssetAlert,
-        onRestoreDismissed: center.dismissedCount > 0
-            ? () => unawaited(_restoreDismissedAssetAlerts())
-            : null,
-      ),
+    return AssetAlertCenterCard(
+      center: center,
+      onDismiss: _dismissAssetAlert,
+      onRestoreDismissed: center.dismissedCount > 0
+          ? () => unawaited(_restoreDismissedAssetAlerts())
+          : null,
     );
   }
 

--- a/lib/services/asset_management_display_mode_store.dart
+++ b/lib/services/asset_management_display_mode_store.dart
@@ -34,6 +34,7 @@ enum AssetManagementSectionId {
   cashflowStatement,
   alertCenter,
   netWorthPanel,
+  monthlyDashboard,
 }
 
 /// セクション単位の表示上書き。auto はティア×モードの既定に従う。
@@ -118,6 +119,8 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
         return 'アラートセンター';
       case AssetManagementSectionId.netWorthPanel:
         return '純資産パネル';
+      case AssetManagementSectionId.monthlyDashboard:
+        return '月次資産ダッシュボード';
     }
   }
 
@@ -148,6 +151,7 @@ extension AssetManagementSectionIdMeta on AssetManagementSectionId {
       case AssetManagementSectionId.cashflowStatement:
       case AssetManagementSectionId.alertCenter:
       case AssetManagementSectionId.netWorthPanel:
+      case AssetManagementSectionId.monthlyDashboard:
         return AssetManagementSectionTier.full;
     }
   }

--- a/lib/widgets/asset_dashboard_grid.dart
+++ b/lib/widgets/asset_dashboard_grid.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+
+/// 月次資産ダッシュボード (Issue #2472) の 1 パネル。
+class AssetDashboardPanel {
+  /// パネル見出し。
+  final String title;
+
+  /// 本体ウィジェット。
+  final Widget child;
+
+  /// 「詳細」導線。null ならリンクを出さない。
+  final VoidCallback? onOpenDetail;
+
+  /// 導線ラベル (既定「詳細」)。
+  final String detailLabel;
+
+  const AssetDashboardPanel({
+    required this.title,
+    required this.child,
+    this.onOpenDetail,
+    this.detailLabel = '詳細',
+  });
+}
+
+/// 幅からダッシュボードの列数を決める純関数。
+///
+/// mobile は 1 列、[breakpoint] 以上で 2 列 (= 2x2 グリッド)。
+/// レイアウト判定をウィジェットから切り離して単体検証できるようにしている。
+@visibleForTesting
+int dashboardColumnCountFor(
+  double width, {
+  double breakpoint = AssetDashboardGrid.twoColumnBreakpoint,
+}) {
+  if (!width.isFinite || width <= 0) return 1;
+  return width >= breakpoint ? 2 : 1;
+}
+
+/// 月次資産ダッシュボードの responsive グリッド (Issue #2472)。
+///
+/// スコープの 4 パネル (純資産 / キャッシュフロー / 投資 / アラート) を
+/// mobile 1 列 / web 2x2 で並べる。**渡されたパネルだけ**を描画するため、
+/// 未実装のパネル (= 投資は第2弾B #2468-#2470 待ち) は呼び出し側が単に
+/// 渡さなければよく、空セルも出ない。
+class AssetDashboardGrid extends StatelessWidget {
+  const AssetDashboardGrid({
+    super.key,
+    required this.panels,
+    this.breakpoint = twoColumnBreakpoint,
+    this.spacing = 16,
+  });
+
+  /// 2 列へ切り替える最小幅。
+  static const double twoColumnBreakpoint = 720;
+
+  final List<AssetDashboardPanel> panels;
+  final double breakpoint;
+  final double spacing;
+
+  @override
+  Widget build(BuildContext context) {
+    if (panels.isEmpty) return const SizedBox.shrink();
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final columns = dashboardColumnCountFor(
+          constraints.maxWidth,
+          breakpoint: breakpoint,
+        );
+        if (columns == 1) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (var i = 0; i < panels.length; i++) ...[
+                if (i > 0) SizedBox(height: spacing),
+                _buildPanel(context, panels[i]),
+              ],
+            ],
+          );
+        }
+        return _buildTwoColumnRows(context);
+      },
+    );
+  }
+
+  /// 2 列レイアウト。行ごとに Row を作り、端数は空 Expanded で埋めて
+  /// 最後の 1 枚が横幅いっぱいに伸びないようにする。
+  Widget _buildTwoColumnRows(BuildContext context) {
+    final rows = <Widget>[];
+    for (var i = 0; i < panels.length; i += 2) {
+      final left = panels[i];
+      final right = i + 1 < panels.length ? panels[i + 1] : null;
+      if (rows.isNotEmpty) rows.add(SizedBox(height: spacing));
+      rows.add(
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(child: _buildPanel(context, left)),
+            SizedBox(width: spacing),
+            Expanded(
+              child: right == null
+                  ? const SizedBox.shrink()
+                  : _buildPanel(context, right),
+            ),
+          ],
+        ),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: rows,
+    );
+  }
+
+  Widget _buildPanel(BuildContext context, AssetDashboardPanel panel) {
+    final theme = Theme.of(context);
+    return Column(
+      key: Key('asset_dashboard_panel_${panel.title}'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                panel.title,
+                style: theme.textTheme.labelLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: const Color(0xFF6B7280),
+                ),
+              ),
+            ),
+            if (panel.onOpenDetail != null)
+              TextButton(
+                key: Key('asset_dashboard_detail_${panel.title}'),
+                onPressed: panel.onOpenDetail,
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  minimumSize: const Size(0, 32),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                child: Text(panel.detailLabel),
+              ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        panel.child,
+      ],
+    );
+  }
+}

--- a/test/widgets/asset_dashboard_grid_test.dart
+++ b/test/widgets/asset_dashboard_grid_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/widgets/asset_dashboard_grid.dart';
+
+Widget _host(Widget child, {double width = 1200}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(width: width, child: SingleChildScrollView(child: child)),
+    ),
+  );
+}
+
+AssetDashboardPanel _panel(String title, {VoidCallback? onDetail}) {
+  return AssetDashboardPanel(
+    title: title,
+    onOpenDetail: onDetail,
+    child: SizedBox(key: Key('body_$title'), height: 40),
+  );
+}
+
+void main() {
+  group('dashboardColumnCountFor', () {
+    test('mobile widths use a single column', () {
+      expect(dashboardColumnCountFor(360), 1);
+      expect(dashboardColumnCountFor(719.9), 1);
+    });
+
+    test('wide widths use two columns', () {
+      expect(dashboardColumnCountFor(720), 2);
+      expect(dashboardColumnCountFor(1440), 2);
+    });
+
+    test('degenerate widths fall back to one column', () {
+      expect(dashboardColumnCountFor(0), 1);
+      expect(dashboardColumnCountFor(-10), 1);
+      expect(dashboardColumnCountFor(double.infinity), 1);
+      expect(dashboardColumnCountFor(double.nan), 1);
+    });
+
+    test('breakpoint is configurable', () {
+      expect(dashboardColumnCountFor(500, breakpoint: 480), 2);
+      expect(dashboardColumnCountFor(500, breakpoint: 900), 1);
+    });
+  });
+
+  group('AssetDashboardGrid', () {
+    testWidgets('renders nothing when there are no panels', (tester) async {
+      await tester.pumpWidget(
+        _host(const AssetDashboardGrid(panels: <AssetDashboardPanel>[])),
+      );
+      expect(find.byType(Row), findsNothing);
+    });
+
+    testWidgets('renders every provided panel with its title', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          AssetDashboardGrid(
+            panels: [_panel('純資産'), _panel('キャッシュフロー'), _panel('アラート')],
+          ),
+        ),
+      );
+
+      expect(find.text('純資産'), findsOneWidget);
+      expect(find.text('キャッシュフロー'), findsOneWidget);
+      expect(find.text('アラート'), findsOneWidget);
+      expect(find.byKey(const Key('body_純資産')), findsOneWidget);
+      expect(find.byKey(const Key('body_アラート')), findsOneWidget);
+    });
+
+    testWidgets('omitted panels leave no empty cell (投資 未実装ケース)',
+        (tester) async {
+      // 投資パネルを渡さない = 第2弾B 未着地の状態。
+      await tester.pumpWidget(
+        _host(
+          AssetDashboardGrid(
+            panels: [_panel('純資産'), _panel('キャッシュフロー'), _panel('アラート')],
+          ),
+        ),
+      );
+      expect(find.text('投資'), findsNothing);
+      // 3 枚とも本体が描画されている。
+      for (final t in ['純資産', 'キャッシュフロー', 'アラート']) {
+        expect(find.byKey(Key('body_$t')), findsOneWidget);
+      }
+    });
+
+    testWidgets('detail link is shown only when a callback is given',
+        (tester) async {
+      var tapped = 0;
+      await tester.pumpWidget(
+        _host(
+          AssetDashboardGrid(
+            panels: [
+              _panel('純資産', onDetail: () => tapped++),
+              _panel('アラート'),
+            ],
+          ),
+        ),
+      );
+
+      expect(
+        find.byKey(const Key('asset_dashboard_detail_純資産')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('asset_dashboard_detail_アラート')),
+        findsNothing,
+      );
+
+      await tester.tap(find.byKey(const Key('asset_dashboard_detail_純資産')));
+      await tester.pump();
+      expect(tapped, 1);
+    });
+
+    testWidgets('narrow viewport stacks panels in one column', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          AssetDashboardGrid(panels: [_panel('A'), _panel('B')]),
+          width: 400,
+        ),
+      );
+      expect(find.byKey(const Key('body_A')), findsOneWidget);
+      expect(find.byKey(const Key('body_B')), findsOneWidget);
+      // 1 列では縦積み: 左端が揃い、B が A より下に来る。
+      final a = tester.getTopLeft(find.byKey(const Key('body_A')));
+      final b = tester.getTopLeft(find.byKey(const Key('body_B')));
+      expect(b.dx, closeTo(a.dx, 0.5));
+      expect(b.dy, greaterThan(a.dy));
+    });
+
+    testWidgets('wide viewport lays panels out two per row', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          AssetDashboardGrid(panels: [_panel('A'), _panel('B')]),
+          width: 1000,
+        ),
+      );
+      // 2 列では横並び: B が A の右、かつ同じ行 (上端が揃う)。
+      final a = tester.getTopLeft(find.byKey(const Key('body_A')));
+      final b = tester.getTopLeft(find.byKey(const Key('body_B')));
+      expect(b.dx, greaterThan(a.dx));
+      expect(b.dy, closeTo(a.dy, 0.5));
+    });
+
+    testWidgets('odd panel count keeps the last panel at half width',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          AssetDashboardGrid(panels: [_panel('A'), _panel('B'), _panel('C')]),
+          width: 1000,
+        ),
+      );
+      final bWidth = tester.getSize(find.byKey(const Key('body_B'))).width;
+      final cWidth = tester.getSize(find.byKey(const Key('body_C'))).width;
+      // 端数の C が横幅いっぱいに伸びず、B と同じ幅に収まる。
+      expect(cWidth, closeTo(bWidth, 1.0));
+    });
+  });
+}


### PR DESCRIPTION
## 概要
Issue #2472 (第2弾C)。これまで個別に積んでいた第2弾Cパネル群を、responsive な grid に集約する。これで第2弾Cシリーズ (#2472-#2475) が完結する。

## スコープ対応
- **4 panel grid layout** — 純資産(#2473) / キャッシュフロー(#2474) / アラート(#2475) を集約
- **responsive** — mobile 1 列 / 720px 以上で 2x2
- **panel title + 詳細遷移 link** — 純資産→残高一覧、CF→収支、アラート→カレンダー

## 実装
- `AssetDashboardGrid` を新規追加。列数判定は純関数 `dashboardColumnCountFor(width)` に切り出し、レイアウト判断をウィジェットから分離して単体検証可能にした。
- 3 パネルの**個別セクションでの単独描画は廃止**し、本 grid の 1 セクションへ一本化（二重描画を避けるため）。`AssetManagementSectionId` の enum 値は保存済み override との互換のため残置。
- データが無いパネルは配列に入れないため**空セルが出ない**。端数（3枚目）のパネルも横幅いっぱいに伸びず半幅に収まる。

## 投資パネルについて（重要）
スコープの 4 枚目「投資」は **第2弾B (#2468 入力form / #2470 CSV import / #2469 グラフ) が未実装**のため、現時点では **panels 配列に渡していません**。存在しないデータで枠だけ描くと「投資資産ゼロ」と誤読されるため、捏造せず単に省いています。第2弾B が着地したら **配列に1要素足すだけ**で grid に乗ります（#2475 の異常検知と同じ方針）。

## 受け入れ条件
- [x] 既存資産管理機能を壊さない（既存セクションは非変更。集約対象の3パネルは本日着地したもので、tier=full の OFF-by-default）
- [x] テスト緑（新規 11件 pass、変更ファイル analyze 0 / format clean）
- [x] feature flag OFF default + 段階的 rollout: セクション tier=`full` 限定

## テスト
`test/widgets/asset_dashboard_grid_test.dart` (11件) — 列数判定の境界(719.9/720)と縮退値(0/負/infinity/NaN)、breakpoint 可変、パネル描画、**投資未実装ケースで空セルが出ないこと**、詳細導線の有無とタップ、1列縦積み、2列横並び、端数パネルの幅。

Closes #2472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: レイアウト集約のみで新規データ経路なし。列数判定は純関数に切り出し、レスポンシブ挙動・空セル無し・詳細導線を widget テスト11件で網羅済み。full モード限定 (既定OFF) のため integration_test は不均衡

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 変更は lib/ のUIレイアウト集約と純関数追加のみで書き込み・認証・RLS・EFに無関係。widget/unit 11件で検証済み
