### PR TITLE
fix(wbs): roll overdue pinned tasks forward

### DIFF
--- a/supabase/functions/tools-hub/wbs_reschedule_realistic.ts
+++ b/supabase/functions/tools-hub/wbs_reschedule_realistic.ts
@@ -211,6 +211,11 @@ function daysBetween(base: Date, dateText: string): number {
   return Math.floor((target.getTime() - base.getTime()) / 86400000);
 }
 
+function shiftIsoDate(dateText: string, days: number): string {
+  const date = new Date(`${dateText}T00:00:00.000Z`);
+  return formatIsoDate(addDays(date, days));
+}
+
 function githubIssueNumberFromTask(task: WbsTaskRecord): number | null {
   const raw = task.github_issue_number;
   if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
@@ -327,17 +332,33 @@ export function buildWbsReschedulePlan(
   const scheduledIds = new Set<string>();
   let pinnedEndOffsetExclusive = 0;
 
-  for (const task of open) {
+  const pinnedTasks = open.flatMap((task) => {
     const issueNumber = githubIssueNumberFromTask(task);
-    if (!issueNumber) continue;
-    const pinned = ASSET_MANAGEMENT_PINNED_ISSUE_SCHEDULE[issueNumber];
-    if (!pinned) continue;
+    const pinned = issueNumber
+      ? ASSET_MANAGEMENT_PINNED_ISSUE_SCHEDULE[issueNumber]
+      : undefined;
+    return issueNumber && pinned ? [{ task, issueNumber, pinned }] : [];
+  });
+  const earliestPinnedStart = pinnedTasks.reduce<string | null>(
+    (earliest, { pinned }) =>
+      earliest === null || pinned.start_date < earliest
+        ? pinned.start_date
+        : earliest,
+    null,
+  );
+  const pinnedShiftDays = earliestPinnedStart === null
+    ? 0
+    : Math.max(0, -daysBetween(today, earliestPinnedStart));
+
+  for (const { task, issueNumber, pinned } of pinnedTasks) {
     const id = String(task.id);
+    const startDate = shiftIsoDate(pinned.start_date, pinnedShiftDays);
+    const endDate = shiftIsoDate(pinned.end_date, pinnedShiftDays);
     scheduledIds.add(id);
     updates.push({
       id,
-      start_date: pinned.start_date,
-      end_date: pinned.end_date,
+      start_date: startDate,
+      end_date: endDate,
       tier: "pinned",
       stagger_days: 0,
       github_issue_number: issueNumber,
@@ -345,7 +366,7 @@ export function buildWbsReschedulePlan(
     });
     pinnedEndOffsetExclusive = Math.max(
       pinnedEndOffsetExclusive,
-      daysBetween(today, pinned.end_date) + 1,
+      daysBetween(today, endDate) + 1,
     );
   }
 

--- a/supabase/functions/tools-hub/wbs_reschedule_realistic_test.ts
+++ b/supabase/functions/tools-hub/wbs_reschedule_realistic_test.ts
@@ -43,6 +43,64 @@ Deno.test("keeps pinned asset-management issue schedule after issue sync", () =>
   assertEquals(plan.updates[0].end_date, "2026-05-18");
 });
 
+Deno.test("rolls overdue pinned tasks forward while preserving roadmap spacing", () => {
+  const plan = buildWbsReschedulePlan(
+    [
+      task("asset-2468", {
+        github_issue_number: 2468,
+        github_issue_state: "OPEN",
+      }),
+      task("asset-2469", {
+        github_issue_number: 2469,
+        github_issue_state: "OPEN",
+      }),
+      task("asset-2486", {
+        github_issue_number: 2486,
+        github_issue_state: "OPEN",
+      }),
+    ],
+    {},
+    new Date("2026-07-19T12:00:00.000Z"),
+  );
+
+  const byIssue = new Map(
+    plan.updates.map((update) => [update.github_issue_number, update]),
+  );
+  assertEquals(byIssue.get(2468)?.start_date, "2026-07-19");
+  assertEquals(byIssue.get(2468)?.end_date, "2026-07-20");
+  assertEquals(byIssue.get(2469)?.start_date, "2026-07-21");
+  assertEquals(byIssue.get(2469)?.end_date, "2026-07-22");
+  assertEquals(byIssue.get(2486)?.start_date, "2026-08-14");
+  assertEquals(byIssue.get(2486)?.end_date, "2026-08-15");
+});
+
+Deno.test("starts computed issue work after the rolled-forward pinned window", () => {
+  const plan = buildWbsReschedulePlan(
+    [
+      task("asset-2468", {
+        github_issue_number: 2468,
+        github_issue_state: "OPEN",
+      }),
+      task("ordinary-issue", {
+        github_issue_number: 4000,
+        github_issue_state: "OPEN",
+      }),
+    ],
+    {
+      github_issue_offset_days: 0,
+      github_issue_duration_days: 0,
+      github_issue_parallel_capacity: 1,
+    },
+    new Date("2026-07-19T00:00:00.000Z"),
+  );
+
+  const ordinary = plan.updates.find((update) =>
+    update.id === "ordinary-issue"
+  );
+  assert(ordinary);
+  assertEquals(ordinary.start_date, "2026-07-21");
+});
+
 Deno.test("does not place a large feature-request queue on one day", () => {
   const tasks = Array.from(
     { length: 5 },


### PR DESCRIPTION
## Summary

- roll overdue open pinned WBS windows forward by one shared offset so the earliest pinned task starts today
- preserve each task's duration, relative order, and the gaps between pinned tasks
- start ordinary computed queues after the shifted pinned roadmap window

## Verification

- `deno fmt --check supabase/functions/tools-hub/wbs_reschedule_realistic.ts supabase/functions/tools-hub/wbs_reschedule_realistic_test.ts`
- `deno lint supabase/functions/tools-hub/wbs_reschedule_realistic.ts supabase/functions/tools-hub/wbs_reschedule_realistic_test.ts`
- `deno test --allow-net supabase/functions/tools-hub/wbs_reschedule_realistic_test.ts` (7 passed)
- repository pre-commit fast quality gate passed
- repository pre-push full quality gate passed before the remote branch was updated

## Context

- Canonical audit: #1422
- Unblocks realistic scheduling for asset-management Issue #2468 / WBS task `4211f293-12ff-4562-83e2-2d9e9238a7f5`

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: No user-facing route is changed; seven deterministic Deno tests cover the WBS scheduler happy, boundary, and queue-order cases.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 ultrareview was not run in this Codex-only continuation; the deterministic scheduler change is reverted with this PR and changes no auth, schema, or migration.
