### PR TITLE
fix(lp): keep mobile trial CTA above sticky signup

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -3516,6 +3516,7 @@ $input
   }
 
   Widget _buildTrialSection({bool heroMode = false}) {
+    final compactHero = heroMode && MediaQuery.sizeOf(context).width < 480;
     return KeyedSubtree(
       key: const Key('landing_trial_section'),
       child: Card(
@@ -3527,42 +3528,57 @@ $input
           key: Key(
             heroMode ? 'landing_h03_inline_trial' : 'landing_h03_lower_trial',
           ),
-          padding: EdgeInsets.all(heroMode ? 16 : 18),
+          padding: EdgeInsets.all(compactHero ? 10 : (heroMode ? 16 : 18)),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
                 heroMode ? '30秒で試す: いま詰まっていることは？' : 'AIに「今日やる1件」を聞く',
-                style: const TextStyle(
-                  fontSize: 18,
+                style: TextStyle(
+                  fontSize: compactHero ? 16 : 18,
                   fontWeight: FontWeight.w800,
-                  height: 1.4,
+                  height: compactHero ? 1.3 : 1.4,
                 ),
               ),
-              const SizedBox(height: 6),
+              SizedBox(height: compactHero ? 4 : 6),
               Text(
-                heroMode
-                    ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
-                    : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
-                style: const TextStyle(color: Color(0xFF64748B), height: 1.5),
+                compactHero
+                    ? '登録不要。例を押すか1行書くと「今やる1件」を返します。'
+                    : heroMode
+                        ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
+                        : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
+                style: TextStyle(
+                  color: const Color(0xFF64748B),
+                  fontSize: compactHero ? 12 : 14,
+                  height: compactHero ? 1.35 : 1.5,
+                ),
               ),
-              const SizedBox(height: 12),
+              SizedBox(height: compactHero ? 6 : 12),
               Wrap(
-                spacing: 8,
-                runSpacing: 8,
+                spacing: compactHero ? 6 : 8,
+                runSpacing: compactHero ? 6 : 8,
                 children: [
                   ActionChip(
                     key: const Key('landing_trial_sample_priority'),
-                    avatar: const Icon(Icons.flash_on, size: 18),
-                    label: const Text('今日の最優先'),
+                    avatar: Icon(Icons.flash_on, size: compactHero ? 16 : 18),
+                    label: Text(compactHero ? '最優先' : '今日の最優先'),
+                    visualDensity: compactHero ? VisualDensity.compact : null,
+                    materialTapTargetSize:
+                        compactHero ? MaterialTapTargetSize.shrinkWrap : null,
                     onPressed: _isTrialLoading
                         ? null
                         : () => _runQuickTrialSample('今日の最優先タスクを1件に絞りたい'),
                   ),
                   ActionChip(
                     key: const Key('landing_trial_sample_plan'),
-                    avatar: const Icon(Icons.event_note, size: 18),
-                    label: const Text('今日の計画を立てる'),
+                    avatar: Icon(
+                      Icons.event_note,
+                      size: compactHero ? 16 : 18,
+                    ),
+                    label: Text(compactHero ? '計画' : '今日の計画を立てる'),
+                    visualDensity: compactHero ? VisualDensity.compact : null,
+                    materialTapTargetSize:
+                        compactHero ? MaterialTapTargetSize.shrinkWrap : null,
                     onPressed: _isTrialLoading
                         ? null
                         : () =>
@@ -3570,29 +3586,44 @@ $input
                   ),
                   ActionChip(
                     key: const Key('landing_trial_sample_procrastination'),
-                    avatar: const Icon(Icons.done_all, size: 18),
-                    label: const Text('先送り解消'),
+                    avatar: Icon(Icons.done_all, size: compactHero ? 16 : 18),
+                    label: Text(compactHero ? '先送り' : '先送り解消'),
+                    visualDensity: compactHero ? VisualDensity.compact : null,
+                    materialTapTargetSize:
+                        compactHero ? MaterialTapTargetSize.shrinkWrap : null,
                     onPressed: _isTrialLoading
                         ? null
                         : () => _runQuickTrialSample('今いちばん先送りしていることを片付けたい'),
                   ),
                 ],
               ),
-              const SizedBox(height: 14),
+              SizedBox(height: compactHero ? 8 : 14),
               TextField(
                 controller: _trialPromptController,
                 minLines: heroMode ? 1 : 2,
                 maxLines: heroMode ? 2 : 3,
-                decoration: const InputDecoration(
+                decoration: InputDecoration(
                   labelText: '例: 今日いちばん詰まっていることを簡単に書く',
-                  border: OutlineInputBorder(),
-                  prefixIcon: Icon(Icons.bolt),
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.bolt),
+                  isDense: compactHero,
+                  contentPadding: compactHero
+                      ? const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 12,
+                        )
+                      : null,
                 ),
               ),
-              const SizedBox(height: 12),
+              SizedBox(height: compactHero ? 8 : 12),
               SizedBox(
                 width: double.infinity,
                 child: FilledButton.icon(
+                  key: Key(
+                    heroMode
+                        ? 'landing_h03_inline_trial_action'
+                        : 'landing_h03_lower_trial_action',
+                  ),
                   onPressed: _isTrialLoading ? null : _runTrialActionPreview,
                   icon: const Icon(Icons.play_arrow),
                   label: _isTrialLoading
@@ -3602,6 +3633,11 @@ $input
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
                       : const Text('今やる1件を試す'),
+                  style: compactHero
+                      ? FilledButton.styleFrom(
+                          minimumSize: const Size.fromHeight(44),
+                        )
+                      : null,
                 ),
               ),
               if (_trialAction != null) ...[
@@ -4382,7 +4418,7 @@ $input
       key: const Key('landing_page_scaffold'),
       appBar: AppBar(
         automaticallyImplyLeading: false,
-        toolbarHeight: 72,
+        toolbarHeight: screenWidth < 480 ? 56 : 72,
         elevation: 0,
         scrolledUnderElevation: 1,
         surfaceTintColor: Colors.transparent,
@@ -4464,7 +4500,7 @@ $input
           child: SingleChildScrollView(
             padding: EdgeInsets.symmetric(
               horizontal: screenWidth < 640 ? 14 : 28,
-              vertical: 22,
+              vertical: screenWidth < 480 ? 12 : 22,
             ),
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 1180),
@@ -4667,30 +4703,37 @@ class _WorkflowLandingHero extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final compactTrialHero = screenWidth < 480 && inlineTrial != null;
+
     return Container(
       key: const Key('landing_hero_section'),
       decoration: BoxDecoration(
         color: const Color(0xFFEAF4FB),
         borderRadius: BorderRadius.circular(8),
       ),
-      padding: const EdgeInsets.fromLTRB(22, 46, 22, 42),
+      padding: compactTrialHero
+          ? const EdgeInsets.fromLTRB(10, 12, 10, 16)
+          : const EdgeInsets.fromLTRB(22, 46, 22, 42),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Center(
-            child: Text(
-              '自分株式会社',
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: Color(0xFF172033),
-                fontSize: 42,
-                fontWeight: FontWeight.w800,
-                height: 1.16,
-                letterSpacing: 0,
+          if (!compactTrialHero) ...[
+            const Center(
+              child: Text(
+                '自分株式会社',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Color(0xFF172033),
+                  fontSize: 42,
+                  fontWeight: FontWeight.w800,
+                  height: 1.16,
+                  letterSpacing: 0,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 18),
+            const SizedBox(height: 18),
+          ],
           Center(
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 820),
@@ -4704,16 +4747,16 @@ class _WorkflowLandingHero extends StatelessWidget {
                       : 'landing_h01_control_offer',
                 ),
                 textAlign: TextAlign.center,
-                style: const TextStyle(
-                  color: Color(0xFF102A43),
-                  fontSize: 28,
-                  height: 1.45,
+                style: TextStyle(
+                  color: const Color(0xFF102A43),
+                  fontSize: compactTrialHero ? 22 : 28,
+                  height: compactTrialHero ? 1.25 : 1.45,
                   fontWeight: FontWeight.w800,
                 ),
               ),
             ),
           ),
-          const SizedBox(height: 12),
+          SizedBox(height: compactTrialHero ? 8 : 12),
           Center(
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 720),
@@ -4722,17 +4765,17 @@ class _WorkflowLandingHero extends StatelessWidget {
                     ? '散らばった予定・メモ・資産・学習をまとめ、迷いを「今やる具体的な行動」に変えます。'
                     : '情報を一か所にまとめ、AIが今日の最優先アクションまで案内します。',
                 textAlign: TextAlign.center,
-                style: const TextStyle(
-                  color: Color(0xFF475569),
-                  fontSize: 16,
-                  height: 1.7,
+                style: TextStyle(
+                  color: const Color(0xFF475569),
+                  fontSize: compactTrialHero ? 13 : 16,
+                  height: compactTrialHero ? 1.45 : 1.7,
                   fontWeight: FontWeight.w500,
                 ),
               ),
             ),
           ),
           if (inlineTrial != null) ...[
-            const SizedBox(height: 18),
+            SizedBox(height: compactTrialHero ? 10 : 18),
             Center(
               child: ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 760),

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -37,6 +37,12 @@ def include_browser_smoke() -> bool:
     }
 
 
+def flutter_vm_test_concurrency(platform_name: str | None = None) -> int:
+    """Keep the long Windows VM suite on one stable test worker."""
+    resolved_platform = os.name if platform_name is None else platform_name
+    return 1 if resolved_platform == "nt" else 2
+
+
 def base_commands() -> list[GateCommand]:
     python = sys.executable
     return [
@@ -127,7 +133,12 @@ def full_commands(root: Path) -> list[GateCommand]:
         ),
         GateCommand(
             "flutter vm tests",
-            ["flutter", "test", "--coverage", "--concurrency=2"],
+            [
+                "flutter",
+                "test",
+                "--coverage",
+                f"--concurrency={flutter_vm_test_concurrency()}",
+            ],
             "flutter",
         ),
     ]

--- a/scripts/quality_gate_test.py
+++ b/scripts/quality_gate_test.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-from quality_gate import full_commands
+from quality_gate import flutter_vm_test_concurrency, full_commands
 
 
 class QualityGateTest(unittest.TestCase):
@@ -16,8 +16,15 @@ class QualityGateTest(unittest.TestCase):
 
         self.assertEqual(
             command.args,
-            ["flutter", "test", "--coverage", "--concurrency=2"],
+            [
+                "flutter",
+                "test",
+                "--coverage",
+                f"--concurrency={flutter_vm_test_concurrency()}",
+            ],
         )
+        self.assertEqual(flutter_vm_test_concurrency("nt"), 1)
+        self.assertEqual(flutter_vm_test_concurrency("posix"), 2)
 
         workflow = (root / ".github" / "workflows" / "ci.yml").read_text(
             encoding="utf-8"

--- a/test/e2e/lp_first_user_acquisition.spec.ts
+++ b/test/e2e/lp_first_user_acquisition.spec.ts
@@ -4,31 +4,37 @@ const treatmentPath = '/?lp_hypothesis=h03&lp_variant=treatment';
 const controlPath = '/?lp_hypothesis=h03&lp_variant=control';
 
 test.describe('LP first-user acquisition', () => {
-  test.describe.configure({ timeout: 60_000 });
+  test.describe.configure({ timeout: 120_000 });
 
   test('H03 treatment puts a real no-signup trial in the first viewport', async ({
     page,
   }) => {
     await openLanding(page, treatmentPath);
 
-    const trialHeading = page.getByText('30秒で試す: いま詰まっていることは？', {
+    const trialInput = page.getByRole('textbox', { name: /30秒で試す/ });
+    const trialAction = page.getByRole('button', {
+      name: '今やる1件を試す',
       exact: true,
     });
-    const trialInput = page.getByLabel(
-      '例: 今日いちばん詰まっていることを簡単に書く',
-      { exact: true },
-    );
 
-    await expect(trialHeading).toBeVisible();
     await expect(trialInput).toBeVisible();
+    await expect(trialAction).toBeVisible();
 
-    const headingBox = await trialHeading.boundingBox();
+    const inputBox = await trialInput.boundingBox();
+    const actionBox = await trialAction.boundingBox();
     const viewport = page.viewportSize();
-    expect(headingBox).not.toBeNull();
+    expect(inputBox).not.toBeNull();
+    expect(actionBox).not.toBeNull();
     expect(viewport).not.toBeNull();
-    expect(headingBox!.y + headingBox!.height).toBeLessThanOrEqual(
-      viewport!.height,
+    const unobscuredViewportBottom =
+      viewport!.width < 720 ? viewport!.height - 68 : viewport!.height;
+    expect(inputBox!.y + inputBox!.height).toBeLessThanOrEqual(
+      unobscuredViewportBottom,
     );
+    expect(actionBox!.y + actionBox!.height).toBeLessThanOrEqual(
+      unobscuredViewportBottom,
+    );
+    expect(inputBox!.y).toBeLessThan(actionBox!.y);
   });
 
   test('H04 treatment reveals one-field Magic Link capture after value', async ({
@@ -36,15 +42,26 @@ test.describe('LP first-user acquisition', () => {
   }) => {
     await openLanding(page, treatmentPath);
 
-    await page.getByText('今やる1件を試す', { exact: true }).click();
+    await page
+      .getByRole('button', { name: '今やる1件を試す', exact: true })
+      .click();
 
-    await expect(page.getByText('提案された1件', { exact: true })).toBeVisible();
-    await expect(page.getByPlaceholder('you@example.com')).toBeVisible();
     await expect(
-      page.getByText('無料で保存して始める', { exact: true }),
+      page.getByRole('group', { name: /提案された1件/ }),
     ).toBeVisible();
     await expect(
-      page.getByText('パスワード・カード入力は不要です。', { exact: true }),
+      page.getByRole('textbox', { name: 'メールアドレス', exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', {
+        name: '無料で保存して始める',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('group', {
+        name: /パスワード・カード入力は不要です。/,
+      }),
     ).toBeVisible();
   });
 
@@ -53,17 +70,19 @@ test.describe('LP first-user acquisition', () => {
   }) => {
     await openLanding(page, controlPath);
 
-    const authAction = page.getByText('Magic Linkで今すぐ始める', {
+    const authAction = page.getByRole('button', {
+      name: 'Magic Linkで今すぐ始める',
       exact: true,
     });
-    const lowerTrial = page.getByText('今やる1件を試す', { exact: true });
+    const lowerTrial = page.getByRole('button', {
+      name: '今やる1件を試す',
+      exact: true,
+    });
 
     await expect(authAction).toBeVisible();
     await expect(lowerTrial).toBeVisible();
     await expect(
-      page.getByText('30秒で試す: いま詰まっていることは？', {
-        exact: true,
-      }),
+      page.getByRole('textbox', { name: /30秒で試す/ }),
     ).toHaveCount(0);
 
     const authBox = await authAction.boundingBox();

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -337,4 +337,27 @@ void main() {
       contains('lp_exp_h09_treatment_sticky_cta'),
     );
   });
+
+  testWidgets('mobile H03 keeps the trial action above the sticky CTA', (
+    tester,
+  ) async {
+    await pumpLanding(
+      tester,
+      assignment: _assignment('h03', LandingExperimentVariant.treatment),
+      size: const Size(393, 727),
+    );
+
+    final trialAction = find.byKey(
+      const Key('landing_h03_inline_trial_action'),
+    );
+    final stickyCta = find.byKey(
+      const Key('landing_h09_mobile_sticky_cta'),
+    );
+    expect(trialAction, findsOneWidget);
+    expect(stickyCta, findsOneWidget);
+    expect(
+      tester.getBottomRight(trialAction).dy,
+      lessThanOrEqualTo(tester.getTopLeft(stickyCta).dy),
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- compact the H03 mobile hero so the anonymous trial input and action remain visible above the 68px sticky signup CTA
- replace brittle text-based production E2E selectors with semantic role/accessibility selectors across all six desktop/mobile hypothesis checks
- add a 393x727 widget regression proving the trial action is not obscured
- keep the long Windows Flutter VM gate on one stable worker while preserving concurrency=2 on Linux/CI

## Conversion hypotheses covered
- H03: meaningful anonymous trial before signup
- H04: one-field Magic Link immediately after value
- H09: persistent mobile signup CTA without obscuring the trial
- control conditions: all ten hypothesis switches still remove only their tested mechanism

## Validation
- `flutter test test/pages/landing_page_conversion_test.dart` (5/5)
- `python scripts/quality_gate_test.py`
- pre-push `python scripts/quality_gate.py --full`
  - Flutter analyze: no issues
  - Dart format: 994 files, 0 changed
  - Flutter VM suite: passed with the Windows stable-worker setting
  - Deno edge-function suite: 494 passed
- production desktop/mobile Playwright verification will run after deploy

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: LP layout, semantic E2E selectors, and Windows test-runner concurrency only; no security, migration, deployment, production data, or auth path changed.

Refs #4121
Refs #4129
