### PR TITLE
feat(admin): X投稿候補キューの実件数を表示する (第8弾「N件以上」の完成 / part340)

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -96,6 +96,8 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   // pending_approval 候補をここで承認→投稿する(UUID 手掘り+workflow dispatch
   // の運用ボトルネック解消)。X operator 権限が無い/取得失敗は空=panel 非表示。
   List<XPostCandidateSummary> _xCandidates = const [];
+  // R34: edge の total (limit 前の総数) を status 別に保持。空なら「N件以上」表示。
+  Map<String, int> _xCandidateTotals = const <String, int>{};
   final Set<String> _xCandidatePublishing = <String>{};
   bool _isLoading = true;
   WeeklyDigestSnapshot _weeklyDigest = const WeeklyDigestSnapshot.empty();
@@ -370,9 +372,9 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   /// window を埋め、古い承認待ちを黙って押し出す(レビュー F2)。
   /// X operator 権限が無いと edge が 403 を返すため、例外/非成功は空リストに
   /// degrade して panel ごと消す(ダッシュボードは必ず描画する)。
-  Future<List<XPostCandidateSummary>> _loadXCandidateQueue() async {
+  Future<XCandidateQueueSnapshot> _loadXCandidateQueue() async {
     const statuses = ['pending_approval', 'approved', 'publish_failed'];
-    final lists = await Future.wait(
+    final results = await Future.wait(
       statuses.map((status) async {
         try {
           final res = await _supabase.functions.invoke(
@@ -387,15 +389,36 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           );
           final data = res.data;
           if (data is Map && data['success'] == true) {
-            return parseXPostCandidates(data['candidates']);
+            // R34: edge の total (limit 前の総数) を拾う。返さない場合は null の
+            // まま = ヘッダは「N件以上」へ degrade。
+            final rawTotal = data['total'];
+            final total = rawTotal is num ? rawTotal.toInt() : null;
+            return (
+              status: status,
+              candidates: parseXPostCandidates(data['candidates']),
+              total: total,
+            );
           }
         } catch (error) {
           debugPrint('x.candidate.list($status) unavailable: $error');
         }
-        return const <XPostCandidateSummary>[];
+        return (
+          status: status,
+          candidates: const <XPostCandidateSummary>[],
+          total: null,
+        );
       }),
     );
-    return mergeCandidateSummaries(lists);
+    final totals = <String, int>{
+      for (final result in results)
+        if (result.total != null) result.status: result.total!,
+    };
+    return XCandidateQueueSnapshot(
+      candidates: mergeCandidateSummaries(
+        results.map((result) => result.candidates).toList(),
+      ),
+      totalsByStatus: totals,
+    );
   }
 
   /// R26: 候補を承認→投稿→確定する HITL フロー。無審査自動投稿はしない
@@ -517,7 +540,10 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
       );
       final refreshed = await _loadXCandidateQueue();
       if (mounted) {
-        setState(() => _xCandidates = refreshed);
+        setState(() {
+          _xCandidates = refreshed.candidates;
+          _xCandidateTotals = refreshed.totalsByStatus;
+        });
       }
     } catch (error) {
       if (!mounted) return;
@@ -1842,7 +1868,8 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
           _paidConversionMetrics = paidConversionMetrics;
           _xTodayStatus = xTodayStatus;
           _xPerformanceContext = xPerformanceContext;
-          _xCandidates = xCandidates;
+          _xCandidates = xCandidates.candidates;
+          _xCandidateTotals = xCandidates.totalsByStatus;
           _isLoading = false;
         });
       }
@@ -6533,7 +6560,7 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      'X投稿候補キュー（${candidateQueueHeaderLabel(_xCandidates)}）',
+                      'X投稿候補キュー（${candidateQueueHeaderLabel(_xCandidates, totalsByStatus: _xCandidateTotals)}）',
                       style: TextStyle(
                         fontSize: 15,
                         fontWeight: FontWeight.bold,

--- a/lib/pages/admin_x_candidate_queue.dart
+++ b/lib/pages/admin_x_candidate_queue.dart
@@ -238,6 +238,7 @@ const int kXCandidateStatusFetchLimit = 10;
 String candidateQueueHeaderLabel(
   List<XPostCandidateSummary> candidates, {
   int perStatusLimit = kXCandidateStatusFetchLimit,
+  Map<String, int> totalsByStatus = const <String, int>{},
 }) {
   final pending = candidates.where((c) => c.isPendingApproval).length;
   final retry = candidates.length - pending;
@@ -247,11 +248,46 @@ String candidateQueueHeaderLabel(
     (status) =>
         candidates.where((c) => c.status == status).length >= perStatusLimit,
   );
-  final pendingLabel =
-      pending >= perStatusLimit ? '承認待ち $pending件以上' : '承認待ち $pending件';
-  if (retry <= 0) return pendingLabel;
-  final retryLabel = retryCapped ? '再試行 $retry件以上' : '再試行 $retry件';
+
+  // R34: edge が limit 前の総数 (total) を返すならそれを断定表示する。
+  // 「10件以上」は正直だが backlog が 11 件なのか 200 件なのか分からず行動でき
+  // ないため、総数が取れるときは実数を出す。取れない (旧 edge / 取得失敗) 場合は
+  // 従来どおり取得上限到達で「N件以上」へ degrade する。
+  final pendingTotal = totalsByStatus['pending_approval'];
+  final approvedTotal = totalsByStatus['approved'];
+  final failedTotal = totalsByStatus['publish_failed'];
+  final retryTotal = (approvedTotal != null && failedTotal != null)
+      ? approvedTotal + failedTotal
+      : null;
+
+  final pendingLabel = pendingTotal != null
+      ? '承認待ち $pendingTotal件'
+      : (pending >= perStatusLimit ? '承認待ち $pending件以上' : '承認待ち $pending件');
+
+  final effectiveRetry = retryTotal ?? retry;
+  if (effectiveRetry <= 0) return pendingLabel;
+  final retryLabel = retryTotal != null
+      ? '再試行 $retryTotal件'
+      : (retryCapped ? '再試行 $retry件以上' : '再試行 $retry件');
   return '$pendingLabel・$retryLabel';
+}
+
+/// R34: 候補キューの取得結果。`totalsByStatus` は edge の `total`
+/// (limit で切る前の総数) を status 別に保持する。edge が返さなかった status は
+/// 欠落し、ヘッダは従来の「N件以上」表示へ degrade する。
+class XCandidateQueueSnapshot {
+  final List<XPostCandidateSummary> candidates;
+  final Map<String, int> totalsByStatus;
+
+  const XCandidateQueueSnapshot({
+    required this.candidates,
+    required this.totalsByStatus,
+  });
+
+  static const XCandidateQueueSnapshot empty = XCandidateQueueSnapshot(
+    candidates: <XPostCandidateSummary>[],
+    totalsByStatus: <String, int>{},
+  );
 }
 
 /// 一覧カードの本文プレビュー(1行化+切り詰め)。

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -2612,9 +2612,15 @@ serve(async (req: Request) => {
           Math.min(100, Math.trunc(firstNumber(body.limit) ?? 50)),
         );
         const requestedStatus = firstString(body.status);
+        // R34: count:"exact" で「limit で切る前の総数」も返す。従来は limit 件しか
+        // 返さないため client 側は上限に達したかしか分からず、承認待ちが 11 件でも
+        // 200 件でも「10件以上」としか出せなかった (backlog の規模が掴めない)。
+        // source は idx_hub_data_source があり EF は service_role なので、count は
+        // x_post_candidate 部分集合への index scan で収まる (agent_memories のような
+        // 無索引全表走査にはならない)。
         let query = admin
           .from("hub_data")
-          .select("id, metadata, created_at")
+          .select("id, metadata, created_at", { count: "exact" })
           .eq("source", X_POST_CANDIDATE_SOURCE)
           .order("created_at", { ascending: false })
           .limit(limit);
@@ -2625,9 +2631,15 @@ serve(async (req: Request) => {
             requestedStatus,
           );
         }
-        const { data, error } = await query;
+        const { data, error, count } = await query;
         if (error) throw new Error(error.message);
-        return json({ success: true, candidates: data ?? [] });
+        return json({
+          success: true,
+          candidates: data ?? [],
+          // limit で切る前の総数。取得できないときは null (client は従来の
+          // 「N件以上」表示へ degrade する)。
+          total: typeof count === "number" ? count : null,
+        });
       }
 
       case "x.candidate.create": {

--- a/test/pages/admin_x_candidate_queue_test.dart
+++ b/test/pages/admin_x_candidate_queue_test.dart
@@ -171,6 +171,45 @@ void main() {
       );
     });
 
+    test('R34 edge の total があれば実数を断定表示する', () {
+      // 取得は上限 10 件でも、総数 37 が来れば「37件」と出す。
+      final pendingAtCap = List.generate(
+        kXCandidateStatusFetchLimit,
+        (i) => make(id: 'p$i'),
+      );
+      expect(
+        candidateQueueHeaderLabel(
+          pendingAtCap,
+          totalsByStatus: const {'pending_approval': 37},
+        ),
+        '承認待ち 37件',
+      );
+
+      // 再試行は approved + publish_failed の総数を合算して出す。
+      expect(
+        candidateQueueHeaderLabel(
+          [make(id: 'p'), make(id: 'r', status: 'publish_failed')],
+          totalsByStatus: const {
+            'pending_approval': 5,
+            'approved': 2,
+            'publish_failed': 9,
+          },
+        ),
+        '承認待ち 5件・再試行 11件',
+      );
+    });
+
+    test('R34 total が無い status は従来の「N件以上」へ degrade する', () {
+      final pendingAtCap = List.generate(
+        kXCandidateStatusFetchLimit,
+        (i) => make(id: 'p$i'),
+      );
+      expect(
+        candidateQueueHeaderLabel(pendingAtCap),
+        '承認待ち $kXCandidateStatusFetchLimit件以上',
+      );
+    });
+
     test('R32 取得上限に達した status は「N件以上」と下限表示にする', () {
       // pending が取得上限ちょうど = 本当はもっとあるかもしれない → 「以上」。
       final pendingAtCap = List.generate(


### PR DESCRIPTION
## 概要

build 4889 で第8弾 (#4212) が本番反映され、ヘッダは「承認待ち **10件以上**」を表示した。これは **承認待ちが実際に取得上限を超えている**ことの実証でもある (前回は RLS のため件数を観測できず構造的根拠のみで着地させたが、本番が裏付けた)。

ただし「10件以上」は**正直だが行動可能ではない** — backlog が 11 件なのか 200 件なのか分からない。本PRで実数を出す。

## 変更

- **edge** `x.candidate.list` に `count: "exact"` を追加し、**limit で切る前の総数**を `total` として返す。
- **client** は status 別に `total` を保持し、ヘッダを実数で断定表示 (`承認待ち 37件` / 再試行は `approved` + `publish_failed` の合算)。
- **total が取れないときは従来の「N件以上」へ degrade** (旧 edge・取得失敗・デプロイ差分でも壊れない)。上限未満はこれまでどおり断定表示。

### count の安全性 (#4202 の教訓を適用)
`agent_memories` の無索引 `user_id` で本番 statement timeout を出した経験から、**count を足す前に索引を確認**した:
- `idx_hub_data_source ON hub_data (source)` あり → `source = 'x_post_candidate'` は index scan
- EF は service_role (RLS バイパス) なので、count は x_post_candidate 部分集合に収まる

→ 無索引全表走査にはならない。

## 検証
- `admin_x_candidate_queue_test.dart` R34 追加 — total あり=実数断定 / 再試行=2status合算 / total 無し=「N件以上」へ degrade。**計21件パス**
- `deno check` + `deno lint` clean / `flutter analyze` 0 issue / `dart format` 差分なし

## 検証の限界 (正直な記載)
`x.candidate.list` は **X operator 権限必須**のため匿名 probe は 403 で、**本番実測は行えていない** (第7弾のような本番 A/B 実測は取れていない)。型チェック+単体テストと、`total` 欠落時に従来表示へ落ちる degrade 設計で安全側に倒している。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Read-only addition of an exact count to an existing x.candidate.list select so the dashboard can show the real backlog size; index-bounded on idx_hub_data_source under service_role. No auth, RLS, payment, secret, or schema changes; client degrades to the previous lower-bound label when total is absent

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Edge change adds a count field to an existing read action (no new flow); label logic covered by VM unit tests in admin_x_candidate_queue_test.dart (total present -> exact, retry sums two statuses, total absent -> degrades to N件以上), 21 cases. deno check + lint clean, analyze 0 issues. Production measurement not possible: x.candidate.list requires the X operator role (anon probe returns 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
