### PR TITLE
fix(asset): 口座間移動の提案を移動元の現在残高で上限する (残高が無いのに移動を提案していたユーザー報告バグ)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -13581,7 +13581,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                   Text(
                     '${suggestion.fromAccountName} → ${summary.accountName} '
                     '${_formatManagementYen(suggestion.amount)}'
-                    '${suggestion.neededBy == null ? '' : '（${DateFormat('M月d日').format(suggestion.neededBy!)}まで）'}',
+                    '${suggestion.neededBy == null ? '' : '（${DateFormat('M月d日').format(suggestion.neededBy!)}まで）'}'
+                    // 移動元の現在残高で上限を掛けるため、不足額の全額を
+                    // 賄えないことがある。full/partial を明示しないと
+                    // 「移動したのにまだ足りない」と誤解させる。
+                    '${suggestion.amount + 0.5 < summary.shortfall ? '（一部・移動後も${_formatManagementYen(summary.shortfall - suggestion.amount)}不足）' : ''}',
                     // 背景が固定の淡赤のため、ダークテーマの onSurface(白)だと
                     // 読めなくなる。文字色も固定の濃赤系にする。
                     style: const TextStyle(

--- a/lib/services/asset_liability_planning_service.dart
+++ b/lib/services/asset_liability_planning_service.dart
@@ -1827,12 +1827,16 @@ class AssetLiabilityPlanningService {
     ];
   }
 
+  /// 口座間移動の提案で、移動元に残しておく最低額。この額を割り込む提案は
+  /// しない (移動元を新たな残高不足にしないため)。
+  static const double _transferDonorReserve = 30000;
+
   List<AssetLiabilityTransferSuggestion> _buildTransferSuggestions({
     required List<AssetLiabilityAccountCashflowSummary> summaries,
     required List<AssetLiabilityCashflowRow> cashflowRows,
   }) {
     final donors = summaries
-        .where((summary) => summary.projectedBalance > 30000)
+        .where((summary) => summary.projectedBalance > _transferDonorReserve)
         .toList()
       ..sort((a, b) => b.projectedBalance.compareTo(a.projectedBalance));
     final shortages = summaries.where((summary) => summary.isShort).toList()
@@ -1840,27 +1844,37 @@ class AssetLiabilityPlanningService {
 
     final suggestions = <AssetLiabilityTransferSuggestion>[];
     for (final shortage in shortages) {
-      final donor = donors.firstWhere(
-        (summary) => summary.accountId != shortage.accountId,
-        orElse: () => const AssetLiabilityAccountCashflowSummary(
-          accountId: '',
-          accountName: '',
-          currentBalance: 0,
-          upcomingPayments: 0,
-          upcomingIncome: 0,
-          projectedBalance: 0,
-          riskLevel: AssetLiabilityCashRiskLevel.short,
-        ),
-      );
-      if (donor.accountId.isEmpty) {
-        continue;
+      // 移動元は「見込み残高に余裕がある」だけでは不十分で、**今この口座に
+      // 実際にいくらあるか**で上限を掛ける必要がある。projectedBalance は
+      // 未着金の収入 (給料/入金予定) を含むため、それだけで決めると
+      // 「残高が無いのに移動を提案する」実行不能な提案になる (ユーザー報告:
+      // じぶん銀行 現在¥18,918 に対し ¥50,041 の移動を提案していた)。
+      // さらに移動予約済み (pendingTransferOut) は既に他へ約束済みなので、
+      // 同じ資金を二重に当て込まないよう差し引く。
+      AssetLiabilityAccountCashflowSummary? donor;
+      var amount = 0.0;
+      for (final candidate in donors) {
+        if (candidate.accountId == shortage.accountId) {
+          continue;
+        }
+        final donorSurplus = candidate.projectedBalance - _transferDonorReserve;
+        if (donorSurplus <= 0) {
+          continue;
+        }
+        final movableNow =
+            candidate.currentBalance - candidate.pendingTransferOut;
+        if (movableNow <= 0) {
+          continue;
+        }
+        final feasible = min(min(shortage.shortfall, donorSurplus), movableNow);
+        if (feasible <= 0) {
+          continue;
+        }
+        donor = candidate;
+        amount = feasible;
+        break;
       }
-      final donorSurplus = donor.projectedBalance - 30000;
-      if (donorSurplus <= 0) {
-        continue;
-      }
-      final amount = min(shortage.shortfall, donorSurplus);
-      if (amount <= 0) {
+      if (donor == null || amount <= 0) {
         continue;
       }
       suggestions.add(

--- a/test/services/asset_liability_planning_service_test.dart
+++ b/test/services/asset_liability_planning_service_test.dart
@@ -1362,6 +1362,104 @@ void main() {
       expect(workbook.transferSuggestions.single.toAccountId, 'custom_bank');
     });
 
+    test('caps the transfer suggestion by the donor current balance', () {
+      // ユーザー報告: 「じぶん銀行の残高より多い額を移動提案に出さないで」。
+      // 移動元の projectedBalance は未着金の収入を含むため、それだけで決めると
+      // 実際には無い残高の移動を提案してしまう。現在残高で上限を掛ける。
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          // 移動元: 今は 18,918 しかないが、給料 80,000 の入金予定がある。
+          'cash': 18918,
+          'bank': 10000,
+          'mobit': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 60041},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'custom_bank'},
+        incomePlans: <AssetLiabilityIncomePlan>[
+          AssetLiabilityIncomePlan(
+            id: 'income_cash_salary',
+            date: DateTime(2026, 5, 25),
+            name: 'Salary',
+            amount: 80000,
+            destinationAccountId: 'custom_cash',
+            destinationAccountName: null,
+            received: false,
+          ),
+        ],
+      );
+
+      final donor = workbook.accountCashflowSummaries.firstWhere(
+        (summary) => summary.accountId == 'custom_cash',
+      );
+      final shortage = workbook.accountCashflowSummaries.firstWhere(
+        (summary) => summary.accountId == 'custom_bank',
+      );
+
+      // 見込みは膨らむが、今動かせるのは現在残高まで。
+      expect(donor.currentBalance, 18918);
+      expect(donor.projectedBalance, 98918);
+      expect(shortage.shortfall, 50041);
+
+      final suggestion = workbook.transferSuggestions.single;
+      expect(suggestion.fromAccountId, 'custom_cash');
+      expect(suggestion.toAccountId, 'custom_bank');
+      // 修正前は min(不足額, 見込み余剰) = 50,041 を提案していた (実行不能)。
+      expect(suggestion.amount, 18918);
+    });
+
+    test('excludes already-reserved transfers from the movable amount', () {
+      // 移動予約済み (未完了の移動タスク) の資金は既に他へ約束済みなので、
+      // 同じ現金を二重に当て込まないよう移動可能額から差し引く。
+      final workbook = service.buildWorkbook(
+        latestSnapshot: <String, double>{
+          'cash': 60000,
+          'bank': 10000,
+          'mobit': -100000,
+        },
+        baseDate: DateTime(2026, 5, 1),
+        monthlyPaymentOverrides: const <String, double>{'mobit': 60041},
+        paymentSourceAccountIds: const <String, String>{'mobit': 'custom_bank'},
+        incomePlans: <AssetLiabilityIncomePlan>[
+          // 未着金の収入。見込みは膨らむが今は動かせない。
+          AssetLiabilityIncomePlan(
+            id: 'income_cash_salary',
+            date: DateTime(2026, 5, 25),
+            name: 'Salary',
+            amount: 100000,
+            destinationAccountId: 'custom_cash',
+            destinationAccountName: null,
+            received: false,
+          ),
+        ],
+        transferTasks: <AssetLiabilityTransferTask>[
+          AssetLiabilityTransferTask(
+            id: 'transfer_reserved',
+            fromAccountId: 'custom_cash',
+            fromAccountName: 'cash',
+            toAccountId: 'custom_other',
+            toAccountName: 'other',
+            amount: 40000,
+            dueDate: DateTime(2026, 5, 20),
+          ),
+        ],
+      );
+
+      final donor = workbook.accountCashflowSummaries.firstWhere(
+        (summary) => summary.accountId == 'custom_cash',
+      );
+      expect(donor.currentBalance, 60000);
+      expect(donor.pendingTransferOut, 40000);
+      // 見込みは 60,000 + 100,000(未着金) - 40,000(予約) = 120,000 と潤沢。
+      expect(donor.projectedBalance, 120000);
+
+      // だが今動かせるのは 60,000 - 40,000(予約済み) = 20,000 まで。
+      // 見込みだけで判断すると不足額 50,041 を提案してしまう。
+      final suggestion = workbook.transferSuggestions.single;
+      expect(suggestion.fromAccountId, 'custom_cash');
+      expect(suggestion.amount, 20000);
+    });
+
     test('applies pending transfer tasks to account-level cashflow', () {
       final workbook = service.buildWorkbook(
         latestSnapshot: <String, double>{


### PR DESCRIPTION
# fix(asset): 口座間移動の提案を移動元の現在残高で上限する

## ユーザー報告

> じぶん銀行の口座の残高より多い額を口座間移動の提案に出さないでください。実際には残高がないので実現できません。

## 原因

提案額を移動元の **`projectedBalance` (見込み残高)** だけで決めていた。これは**未着金の収入 (給料・入金予定) を含む**値なので、実際には存在しない残高の移動を提案してしまう。

報告例:

| じぶん銀行 | 金額 |
|---|---|
| 現在残高 (実際に今動かせる額) | **¥18,918** |
| 見込み残高 (入金予定 +¥80,000 込み) | ¥98,918 |
| 見込み余剰 (¥98,918 − 移動元に残す ¥30,000) | ¥68,918 |
| 不足額 (三井住友銀行大塚支店) | ¥50,041 |
| **旧: min(不足額, 見込み余剰)** | **¥50,041** ← 実行不能 |

`_buildTransferSuggestions` は `min(shortage.shortfall, donorSurplus)` のみで、現在残高を一切参照していなかった。

## 修正

1. **移動可能額で上限を掛ける** — `移動可能額 = 現在残高 − 移動予約済み額`、`amount = min(不足額, 見込み余剰, 移動可能額)`。予約済み (未完了の移動タスク) を差し引くのは、同じ資金を複数の提案へ二重に当て込まないため。
2. **移動元候補を順に評価** — 従来は見込み残高が最大の 1 口座だけを見て、それが実際には拠出できないと提案ごと諦めていた。実際に拠出できる口座を順に探す。
3. **一部しか賄えない場合を明示** — 上限により不足額の全額を賄えないことがあるため、UI に「（一部・移動後も¥X不足）」と表示。「移動したのにまだ足りない」という誤解を防ぐ。
4. 移動元に残す最低額 `30000` を名前付き定数 `_transferDonorReserve` に切り出し (2 箇所で使用)。

上記の例では提案が **¥18,918 (一部・移動後も¥31,123不足)** となり、実行可能かつ正直な表示になる。

## テスト (新規 2 件 / 計 70 件緑)

- **ユーザー報告ケースの再現**: 現在 ¥18,918 / 見込み ¥98,918 の口座に対し不足額 ¥50,041 → 修正前は ¥50,041 を提案、修正後は **¥18,918** で上限
- **移動予約済みの二重当て込み防止**: 現在 ¥60,000 のうち ¥40,000 が予約済み → 見込みは ¥120,000 と潤沢でも提案は **¥20,000** まで

## 検証

- `flutter test`: planning 70 件緑 (新規 2 件含む) / auto-debit・insight も回帰なし
- `flutter analyze` (service / test / page): **No issues found!**
- 差分は 3 ファイル・138 行の論理変更のみ (ローカル `dart format` は掛けていない)

## 設計メモ

既存の「移動元に ¥30,000 は残す」ルールはそのまま維持している。今回の変更は**物理的な制約 (今その口座にいくらあるか)** を追加で課すもので、将来の資金繰り上の制約 (見込み余剰) と両方を満たす額だけを提案する。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 本文キーワード(支払/残高)による prose-only トリガ。変更は移動提案額の算出に現在残高の上限を追加する純ロジックと、一部充当時の表示追加のみ。認証・認可・EF・migration・DB書き込み経路の変更を含まない。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 変更は純ロジック service (提案額の上限計算=単体テスト2件追加済) と認証必須ページ内の表示のみで headless E2E 到達不能。既存 unit 70件 + analyze 緑で担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
