### PR TITLE
improve(election): 統一地方選700 共有面に第1次公認・自民参考値を反映 (第6弾・確定4件)

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -4972,7 +4972,11 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
               ),
             ),
           ],
-          if (item.firstEndorsement case final endorsement?) ...[
+          // totalCount==0 のエントリはバッジも出さない。集計 getter 側と
+          // 条件を揃えないと「第1次公認 0人」バッジが出て未発表県が
+          // 発表済みに見える (data 側コメントの不変条件)。
+          if (item.firstEndorsement case final endorsement?
+              when endorsement.totalCount > 0) ...[
             const SizedBox(height: 8),
             _buildFirstEndorsementBadge(endorsement),
           ],

--- a/lib/services/local_election_share_service.dart
+++ b/lib/services/local_election_share_service.dart
@@ -3,6 +3,7 @@
 import 'package:intl/intl.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../data/dpj_prefecture_announced_targets.dart';
 import '../models/local_election_plan.dart';
 import '../models/local_election_reality.dart';
 import '../models/public_memo.dart';
@@ -419,10 +420,16 @@ class LocalElectionShareService {
   String buildPlanDashboardXShareBody({
     required LocalElectionPlanDashboard plan,
   }) {
+    // X は文字数制限があるため、第1次公認は発表がある場合だけ1行足す。
+    final hasFirstEndorsement = dpjFirstEndorsementTotal > 0;
     return [
       '統一地方選700 県連KPI一覧',
-      '全${plan.prefectures.length}県連のKGI、CSF、KPI、現職人数、候補者進捗、公認期限、立憲参考値を公開ノートにまとめました。',
+      '全${plan.prefectures.length}県連のKGI、CSF、KPI、現職人数、候補者進捗、公認期限、立憲・自民の参考値を公開ノートにまとめました。',
       '現職 ${plan.currentLocalMembers}人 / 700まで残り${plan.requiredNetIncrease}人',
+      if (hasFirstEndorsement)
+        '第1次公認 $dpjFirstEndorsementTotal人'
+            '(現職$dpjFirstEndorsementIncumbentTotal/'
+            '新人$dpjFirstEndorsementNewcomerTotal)',
       buildNextUnifiedLocalElectionCountdownLine(now: plan.updatedAt.toLocal()),
       '純増目標 ${plan.allocatedNetIncrease}人 / 新人 ${plan.totalNewCandidateTarget}人',
       '#統一地方選 #国民民主党',
@@ -762,6 +769,24 @@ class LocalElectionShareService {
           '議員在籍県数: ${prefectures.where((item) => item.currentMembers > 0).length}県')
       ..writeln('現職名簿件数: ${members.length}人');
 
+    // 画面に出している比較指標 (第1次公認 / 自民地力差) を共有本文にも載せる。
+    // 載せないと「ノート化」「X投稿」した先で最新の重要指標だけが欠落する。
+    if (dpjFirstEndorsementTotal > 0) {
+      buffer.writeln(
+        '第1次公認: $dpjFirstEndorsementTotal人'
+        '(現職$dpjFirstEndorsementIncumbentTotal / '
+        '新人$dpjFirstEndorsementNewcomerTotal) '
+        '※$dpjFirstEndorsementPrefectureCount'
+        '/${dpjPrefectureAnnouncedTargets.length}県が発表済み',
+      );
+    }
+    final ldpTotal = plan?.totalLdpLocalMembers ?? 0;
+    if (ldpTotal > 0) {
+      buffer.writeln(
+        '自民地方議員参考合計: $ldpTotal人(総務省 所属党派別人員調)',
+      );
+    }
+
     if (snapshot.aiSummary.trim().isNotEmpty) {
       buffer
         ..writeln()
@@ -938,7 +963,14 @@ class LocalElectionShareService {
       ..writeln('- 予定支援回数: ${plan.totalCloseRaceSupportRounds}回')
       ..writeln('- 公認内定済み県連: '
           '${plan.confirmedEndorsementCount}/${plan.prefectures.length}')
-      ..writeln('- 立憲地方議員参考合計: ${plan.totalCdpLocalMembers}人');
+      ..writeln('- 立憲地方議員参考合計: ${plan.totalCdpLocalMembers}人')
+      ..writeln('- 自民地方議員参考合計: ${plan.totalLdpLocalMembers}人'
+          '(総務省 所属党派別人員調)')
+      ..writeln('- 第1次公認: $dpjFirstEndorsementTotal人'
+          '(現職$dpjFirstEndorsementIncumbentTotal / '
+          '新人$dpjFirstEndorsementNewcomerTotal) '
+          '※$dpjFirstEndorsementPrefectureCount'
+          '/${dpjPrefectureAnnouncedTargets.length}県が発表済み');
 
     buffer
       ..writeln()
@@ -989,6 +1021,11 @@ class LocalElectionShareService {
       'totalCloseRaceSupportRounds': plan.totalCloseRaceSupportRounds,
       'confirmedEndorsementCount': plan.confirmedEndorsementCount,
       'totalCdpLocalMembers': plan.totalCdpLocalMembers,
+      'totalLdpLocalMembers': plan.totalLdpLocalMembers,
+      'firstEndorsementTotal': dpjFirstEndorsementTotal,
+      'firstEndorsementIncumbent': dpjFirstEndorsementIncumbentTotal,
+      'firstEndorsementNewcomer': dpjFirstEndorsementNewcomerTotal,
+      'firstEndorsementPrefectureCount': dpjFirstEndorsementPrefectureCount,
       'prefectures': plan.prefectures
           .map(
             (item) => <String, dynamic>{
@@ -1015,6 +1052,8 @@ class LocalElectionShareService {
               'closeRaceSupportRounds': item.closeRaceSupportRounds,
               'cdpLocalMembers': item.cdpLocalMembers,
               'cdpMemberGap': item.cdpMemberGap,
+              'ldpLocalMembers': item.ldpLocalMembers,
+              'ldpMemberGap': item.ldpMemberGap,
               'csfKpis': item.csfKpis.map((kpi) => kpi.toJson()).toList(),
             },
           )
@@ -1126,6 +1165,9 @@ class LocalElectionShareService {
       '支援${plan.closeRaceSupportRounds}回',
       if (cdpMembers > 0)
         '立憲参考$cdpMembers人(${_formatPrefectureKpiGap(cdpMembers - currentMembers)})',
+      if (plan.ldpLocalMembers > 0)
+        '自民参考${plan.ldpLocalMembers}人'
+            '(${_formatPrefectureKpiGap(plan.ldpMemberGap, rivalLabel: '自民')})',
       if (reality != null)
         '公式内訳 都道府県議${reality.prefecturalAssemblyMembers}/市区町村議${reality.municipalAssemblyMembers}',
     ];
@@ -1155,9 +1197,12 @@ class LocalElectionShareService {
     return '';
   }
 
-  String _formatPrefectureKpiGap(int gap) {
+  /// 地力差ラベル。比較相手の党名は呼び出し側が渡す。
+  /// (汎用名のまま '立憲+' を直書きすると、自民の差分に立憲ラベルが付いて
+  /// しまうため必ず [rivalLabel] を明示する)
+  String _formatPrefectureKpiGap(int gap, {String rivalLabel = '立憲'}) {
     if (gap > 0) {
-      return '立憲+$gap';
+      return '$rivalLabel+$gap';
     }
     if (gap < 0) {
       return '国民+${-gap}';

--- a/test/services/local_election_share_service_test.dart
+++ b/test/services/local_election_share_service_test.dart
@@ -184,6 +184,7 @@ void main() {
           prefectureOfficerSourceUrl:
               'https://www.new-kokumin.tokyo/2025/10/yakuin2025/',
           cdpLocalMembers: 83,
+          ldpLocalMembers: 362,
         ),
         LocalElectionPrefecturePlan(
           prefecture: '香川県',
@@ -199,6 +200,7 @@ void main() {
           announcedCandidateCount: 3,
           confirmedCandidateCount: 2,
           cdpLocalMembers: 20,
+          ldpLocalMembers: 112,
           endorsementConfirmed: true,
         ),
       ],
@@ -493,6 +495,42 @@ void main() {
       uri.queryParameters['text'],
       isNot(contains('https://example.com/public/local-election-700')),
     );
+  });
+
+  test('公開ノートに自民参考値と第1次公認が載る (共有面の欠落防止)', () {
+    final plan = buildPlan();
+    final draft = service.buildPlanDashboardDraft(
+      plan: plan,
+      snapshot: buildSnapshot(),
+      publicDashboardUrl: 'https://example.com/public/local-election-700',
+    );
+
+    // 全国サマリー: 立憲だけでなく自民と第1次公認も出す。
+    expect(draft.content, contains('自民地方議員参考合計: 474人'));
+    expect(draft.content, contains('第1次公認:'));
+    expect(draft.content, contains('県が発表済み'));
+    // 県別行: 自民参考と地力差 (ラベルは自民であって立憲ではない)。
+    expect(draft.content, contains('自民参考362人'));
+    expect(draft.content, contains('自民+319'));
+    // metadata にも機械可読で載る。
+    expect(draft.metadata['totalLdpLocalMembers'], 474);
+    expect(draft.metadata['firstEndorsementTotal'], isA<int>());
+    final prefectures = draft.metadata['prefectures'] as List<dynamic>;
+    final tokyo =
+        Map<String, dynamic>.from(prefectures.first as Map<dynamic, dynamic>);
+    expect(tokyo['ldpLocalMembers'], 362);
+    expect(tokyo['ldpMemberGap'], 319);
+  });
+
+  test('地力差ラベルは比較相手の党名を取り違えない', () {
+    final plan = buildPlan();
+    final draft = service.buildPlanDashboardDraft(
+      plan: plan,
+      snapshot: buildSnapshot(),
+      publicDashboardUrl: 'https://example.com/public/local-election-700',
+    );
+    // 自民の差分行に立憲ラベルが混入しない (汎用ヘルパの党名直書き対策)。
+    expect(draft.content, isNot(contains('自民参考362人(立憲')));
   });
 
   test('buildPlanDashboardDraft creates a public note for all prefecture KPIs',


### PR DESCRIPTION
## 概要

`/local-election-700` の改善 **第6弾**。今回の中心は「**画面には出ているのに共有すると消える**」データ欠落の是正です。

直近で追加した **第1次公認の発表状況** と **自民地方議員ベンチマーク** は画面に表示されますが、共有サービス (`local_election_share_service.dart`) には一切反映されていませんでした (立憲=**25箇所** vs 第1次公認/自民=**0箇所**)。そのため「全県連KPIノート化」「X共有」「集計をX投稿(API)」で共有した先に、最新の重要指標だけが載らない状態でした。

## 10仮説の検証結果

| # | 仮説 | 判定 | 対応 |
|---|------|------|------|
| R6-H1 | 共有テキストに第1次公認・自民が欠落 | ✅ 確定 | 5面すべてに追加 |
| R6-H1b | `_formatPrefectureKpiGap` が汎用名なのに党名直書き | ✅ 確定 (地雷) | `rivalLabel` 引数化 |
| R6-H2 | metadata JSON に新データがなく機械可読が不整合 | ✅ 確定 | 全国+県別キー追加 |
| R6-H3 | 第1次公認ピルが `totalCount==0` 不変条件を破る | ✅ 確定 (潜在) | `when totalCount > 0` |
| R6-H4 | 新セクションがダークモードで不可読 | ❌ 反証 | 半透明背景でテーマ追随・禁止パターン非該当 |
| R6-H5 | モバイル360pxでオーバーフロー | ❌ 反証 | `minWidth:148` は Wrap で1行1件・崩れなし |
| R6-H6 | PDF出力に立憲だけ入り自民が抜ける | ❌ 反証 | 画像ベースで両党とも不在 (データ表ではない) |
| R6-H7 | X投稿コンポーザに新データが必要 | ❌ 反証 | 週末日程スレッドで立憲も元から無く不整合ではない |
| R6-H8 | clipboardサマリーに新データ欠落 | ❌ 反証 | 立憲も含まない対称仕様 (既存ギャップ) |
| R6-H9 | 自民アセットの `asOf` が出典URLと不一致 | ❌ 反証 | URL名(r06)と内容年(令和7=2025)の相違は総務省側の命名。`2025-12-31` が正 |

## 確定4件の詳細

### R6-H1 共有面への反映 (5面)
| 面 | 関数 | 追加内容 |
|---|------|---------|
| 公開ノート 全国サマリー | `_buildPlanDashboardContent` | 自民参考合計 + 第1次公認(現職/新人/発表済み県数) |
| 公開ノート 県別行 | `_describePlanPrefecture` | `自民参考N人(地力差)` |
| スナップショットノート | `_buildContent` (X API長文の元) | 第1次公認 + 自民合計 |
| X投稿本文 | `buildPlanDashboardXShareBody` | 「立憲・自民の参考値」表記 + 発表がある時だけ第1次公認1行 (文字数制限に配慮し条件付き) |
| metadata JSON | `_buildPlanDashboardMetadata` | 全国 `totalLdpLocalMembers`/`firstEndorsement*` + 県別 `ldpLocalMembers`/`ldpMemberGap` |

### R6-H1b 党名取り違えの地雷を先回りで除去
`_formatPrefectureKpiGap(int gap)` という**汎用名の関数が `'立憲+$gap'` を直書き**していました。そのまま自民の地力差に流用すると **「自民参考362人(立憲+319)」** と党名を取り違えた文言が共有ノートに出ます。`rivalLabel` 引数化し (既定は `立憲` なので既存呼び出しは無変更)、取り違え防止の回帰テストを追加しました。

### R6-H3 自分で書いた不変条件をUIが破っていた
`dpj_prefecture_announced_targets.dart` に「`totalCount == 0` は発表済みと数えない (0人バッジで未発表県が発表済みに見えるため)」と明記し集計 getter はそれを守っていましたが、**ピル側のガードは null 判定のみ**でした。未発表県のプレースホルダを1件足すだけで「第1次公認 0人」バッジが出て、サマリーの「発表済み 1/27県」と矛盾する状態になります。`when totalCount > 0` を追加。

## 検証

- `flutter test test/services/local_election_share_service_test.dart`: **19件緑** (追加2件: 公開ノートへの自民・第1次公認反映 / 地力差ラベルの党名取り違え防止)
- `flutter analyze` (share service / page): 両方 `No issues found!`
- `dart format`: 適合済み

## 今後の候補 (本PR対象外)

日本地図の県別詳細シート (`election_japan_map.dart`) に立憲行はありますが自民・第1次公認の行がありません。共有面に絞るため今回は見送りました。

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 共有テキスト生成とバッジ表示条件の修正で新規画面遷移なし。生成される本文・metadata はサービステスト19件で検証、UI ガードは analyze 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
