### PR TITLE
test(lp): wait for Flutter cold start in production

### DIFF
--- a/test/e2e/lp_first_user_acquisition.spec.ts
+++ b/test/e2e/lp_first_user_acquisition.spec.ts
@@ -106,9 +106,10 @@ async function openLanding(page: Page, path: string) {
 
   const response = await page.goto(path, { waitUntil: 'domcontentloaded' });
   expect(response?.ok()).toBeTruthy();
+  await expect(page).toHaveTitle('自分株式会社', { timeout: 60_000 });
   await expect(
     page.getByText('仕事・学習・お金の「次の1件」を、AIが1分で決める', {
       exact: true,
     }),
-  ).toBeVisible({ timeout: 30_000 });
+  ).toBeVisible({ timeout: 60_000 });
 }


### PR DESCRIPTION
## Summary
- make production LP verification wait for the Flutter title before checking conversion UI
- allow up to 60 seconds for the first production render on a cold browser
- keep the existing six desktop/mobile acquisition checks unchanged

## Validation
- production Playwright: `npx playwright test test/e2e/lp_first_user_acquisition.spec.ts --retries=0 --reporter=line` (6 passed)
- pre-commit fast quality gate
- pre-push `python scripts/quality_gate.py --full`
  - Flutter analyze: no issues
  - Dart format: 996 files, 0 changed
  - Flutter VM suite: passed
  - Deno edge-function suite: 496 passed

## Minimal E2E Gate
- Implementation-detail independent: the test waits on the public document title and asserts user-visible conversion UI.
- Minimal scope: the existing six desktop/mobile H03, H04, and control cases remain unchanged.
- E2E: Playwright `test/e2e/lp_first_user_acquisition.spec.ts` against production.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: PR commit changes only the Playwright cold-start wait; apparent high-risk paths come from base-branch drift, and no high-risk production path is changed by this commit.

Refs #4121
Refs #4129