### PR TITLE
feat(asset): 投資資産の入力・一覧・編集削除を追加 (#2468)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -1679,11 +1679,11 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   String _formatYen(num value) =>
-      '¥${NumberFormat('#,###').format(value.round())}';
+      '¥${NumberFormat('#,##0').format(value.round())}';
 
   String _formatSignedYen(num value) {
     final sign = value >= 0 ? '+' : '-';
-    return '$sign¥${NumberFormat('#,###').format(value.abs().round())}';
+    return '$sign¥${NumberFormat('#,##0').format(value.abs().round())}';
   }
 
   double _numberFromDynamic(Object? value) {

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -45,6 +45,7 @@ import 'package:my_web_app/services/asset_debt_trend_analyzer.dart';
 import 'package:my_web_app/services/asset_advisory_briefing_service.dart';
 import 'package:my_web_app/services/advisory_briefing_share_service.dart';
 import 'package:my_web_app/services/household_tracker_share_service.dart';
+import 'package:my_web_app/services/investment_asset_repository.dart';
 import 'package:my_web_app/services/asset_management_main_account_store.dart';
 import 'package:my_web_app/services/asset_revolving_credit_config_store.dart';
 import 'package:my_web_app/services/asset_recurring_fixed_cost_store.dart';
@@ -108,6 +109,7 @@ import 'package:my_web_app/widgets/subscription_duplicate_alert_card.dart';
 import 'package:my_web_app/widgets/subscription_fixed_cost_card.dart';
 import 'package:my_web_app/widgets/asset_recurring_transaction_suggestion_card.dart';
 import 'package:my_web_app/widgets/kgi_csf_kpi_panel.dart';
+import 'package:my_web_app/widgets/investment_asset_management_panel.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -198,6 +200,7 @@ class AssetManagementPage extends StatefulWidget {
   final bool emphasizeMonthlyFlow;
   final AssetWatchlistService watchlistService;
   final AssetLiabilityRepository? assetLiabilityRepository;
+  final InvestmentAssetRepository? investmentAssetRepository;
   final String? entryLabel;
   final String? entryDescription;
 
@@ -313,6 +316,7 @@ class AssetManagementPage extends StatefulWidget {
     this.emphasizeMonthlyFlow = false,
     this.watchlistService = const AssetWatchlistService(),
     this.assetLiabilityRepository,
+    this.investmentAssetRepository,
     this.entryLabel,
     this.entryDescription,
     this.debugInitialAssetData,
@@ -779,6 +783,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   // --- 返済計画用 ---
   late final AssetLiabilityRepository _assetLiabilityRepository;
+  late final InvestmentAssetRepository _investmentAssetRepository;
   final AssetLiabilityPlanningService _assetLiabilityPlanner =
       const AssetLiabilityPlanningService();
   final AssetLiabilityPaymentReminderService _assetLiabilityReminderService =
@@ -1040,6 +1045,8 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         AssetLiabilityRepositoryFactory.createDefault(
           supabaseClient: _supabase,
         );
+    _investmentAssetRepository = widget.investmentAssetRepository ??
+        SupabaseInvestmentAssetRepository(client: _supabase);
     unawaited(_loadMinimumSafetyBalance());
     // 起動時の asset_pref_mirror 個別読み取りを 1 回のバッチ取得へ集約する
     // (端末跨ぎ同期の多数 REST が ERR_INSUFFICIENT_RESOURCES を誘発するのを緩和)。
@@ -14343,12 +14350,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   /// 月次キャッシュフローパネル (Issue #2474)。履歴スナップショット + ライブの当月から
   /// 「当月CF (月収 − 月支出)」「年初来累積CF」「直近12か月の黒字/赤字月数」を集計する。
   /// 金額計算は純サービス [AssetCashflowStatementService] で deterministic に行う。
-  /// 月次資産ダッシュボード (Issue #2472)。純資産 / キャッシュフロー / アラートを
+  /// 月次資産ダッシュボード (Issue #2472)。純資産 / キャッシュフロー / 投資 / アラートを
   /// responsive な 2x2 グリッド (mobile 1 列) に並べる。
   ///
-  /// 4 枚目の「投資」パネルは第2弾B (#2468-#2470) が未実装のため現時点では
-  /// 渡していない。着地後にこの配列へ 1 要素足すだけでグリッドに乗る。
-  /// データが無いパネルは配列に入れないので空セルは発生しない。
+  /// 投資パネルは未登録状態でも追加導線を表示するため常に配列へ含める。
   Widget _buildMonthlyDashboardGrid(AssetLiabilityWorkbook? workbook) {
     final panels = <AssetDashboardPanel>[];
 
@@ -14373,6 +14378,17 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         ),
       );
     }
+
+    panels.add(
+      AssetDashboardPanel(
+        title: '投資',
+        child: InvestmentAssetManagementPanel(
+          repository: _investmentAssetRepository,
+          userId: _supabase.auth.currentUser?.id,
+          currencyFormatter: (value) => _formatYen(value),
+        ),
+      ),
+    );
 
     final alerts = _assetAlertCenterPanelChild(workbook);
     if (alerts != null) {

--- a/lib/widgets/asset_dashboard_grid.dart
+++ b/lib/widgets/asset_dashboard_grid.dart
@@ -39,8 +39,7 @@ int dashboardColumnCountFor(
 ///
 /// スコープの 4 パネル (純資産 / キャッシュフロー / 投資 / アラート) を
 /// mobile 1 列 / web 2x2 で並べる。**渡されたパネルだけ**を描画するため、
-/// 未実装のパネル (= 投資は第2弾B #2468-#2470 待ち) は呼び出し側が単に
-/// 渡さなければよく、空セルも出ない。
+/// 利用できないパネルは呼び出し側が単に渡さなければよく、空セルも出ない。
 class AssetDashboardGrid extends StatelessWidget {
   const AssetDashboardGrid({
     super.key,

--- a/lib/widgets/investment_asset_management_panel.dart
+++ b/lib/widgets/investment_asset_management_panel.dart
@@ -296,7 +296,7 @@ class _InvestmentAssetManagementPanelState
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _buildPortfolioSummary(theme, portfolio),
+        _buildPortfolioSummary(portfolio),
         const SizedBox(height: 12),
         for (var index = 0; index < portfolio.items.length; index++) ...[
           if (index > 0) const Divider(height: 20),
@@ -306,22 +306,29 @@ class _InvestmentAssetManagementPanelState
     );
   }
 
-  Widget _buildPortfolioSummary(
-    ThemeData theme,
-    InvestmentPortfolioValuation portfolio,
-  ) {
-    final pricedText = portfolio.pricedMarketValueJpy == 0 &&
-            portfolio.unpricedAssetCount == portfolio.items.length
-        ? '未取得'
-        : _yen(portfolio.pricedMarketValueJpy);
+  Widget _buildPortfolioSummary(InvestmentPortfolioValuation portfolio) {
+    final pricedCount = portfolio.items.length - portfolio.unpricedAssetCount;
+    final pricedText =
+        pricedCount == 0 ? '未取得' : _yen(portfolio.pricedMarketValueJpy);
+    final acquisitionLabel = portfolio.unpricedAssetCount > 0 && pricedCount > 0
+        ? '取得額（評価済）'
+        : '取得額';
+    final acquisitionValue = pricedCount > 0
+        ? portfolio.pricedAcquisitionCostJpy
+        : portfolio.totalAcquisitionCostJpy;
     return Wrap(
       key: const Key('investment_asset_portfolio_summary'),
       spacing: 20,
       runSpacing: 8,
       children: [
         _Metric(label: '評価額', value: pricedText),
-        _Metric(label: '取得額', value: _yen(portfolio.totalAcquisitionCostJpy)),
+        _Metric(label: acquisitionLabel, value: _yen(acquisitionValue)),
         _Metric(label: '銘柄数', value: '${portfolio.items.length}'),
+        if (portfolio.unpricedAssetCount > 0)
+          _Metric(
+            label: '価格未取得',
+            value: '${portfolio.unpricedAssetCount}件',
+          ),
       ],
     );
   }

--- a/lib/widgets/investment_asset_management_panel.dart
+++ b/lib/widgets/investment_asset_management_panel.dart
@@ -135,7 +135,9 @@ class _InvestmentAssetManagementPanelState
       _showMessage(
         asset == null ? '${saved.ticker}を追加しました。' : '${saved.ticker}を更新しました。',
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
+      debugPrint('Investment asset save failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
       if (!mounted) return;
       _showMessage('投資資産を保存できませんでした。時間をおいて再試行してください。');
     } finally {
@@ -180,7 +182,9 @@ class _InvestmentAssetManagementPanelState
         ];
       });
       _showMessage('${asset.ticker}を削除しました。');
-    } catch (_) {
+    } catch (error, stackTrace) {
+      debugPrint('Investment asset delete failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
       if (!mounted) return;
       _showMessage('投資資産を削除できませんでした。時間をおいて再試行してください。');
     } finally {

--- a/lib/widgets/investment_asset_management_panel.dart
+++ b/lib/widgets/investment_asset_management_panel.dart
@@ -1,0 +1,674 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/investment_asset.dart';
+import '../services/investment_asset_repository.dart';
+import '../services/investment_valuation_service.dart';
+
+/// 投資資産の登録・一覧・編集・削除をまとめたダッシュボードパネル。
+class InvestmentAssetManagementPanel extends StatefulWidget {
+  const InvestmentAssetManagementPanel({
+    super.key,
+    required this.repository,
+    required this.userId,
+    this.valuationService = const InvestmentValuationService(),
+    this.currencyFormatter,
+  });
+
+  final InvestmentAssetRepository repository;
+  final String? userId;
+  final InvestmentValuationService valuationService;
+  final String Function(double value)? currencyFormatter;
+
+  @override
+  State<InvestmentAssetManagementPanel> createState() =>
+      _InvestmentAssetManagementPanelState();
+}
+
+class _InvestmentAssetManagementPanelState
+    extends State<InvestmentAssetManagementPanel> {
+  static const Color _accent = Color(0xFF2563EB);
+  static const Color _positive = Color(0xFF0D7A70);
+  static const Color _negative = Color(0xFFB91C1C);
+  static const Color _muted = Color(0xFF6B7280);
+
+  final NumberFormat _yenFormat = NumberFormat.currency(
+    locale: 'ja_JP',
+    symbol: '¥',
+    decimalDigits: 0,
+  );
+  final NumberFormat _quantityFormat = NumberFormat('#,##0.########');
+
+  List<InvestmentAsset> _assets = const <InvestmentAsset>[];
+  Object? _loadError;
+  bool _loading = false;
+  bool _saving = false;
+  int _loadSequence = 0;
+
+  String? get _normalizedUserId {
+    final value = widget.userId?.trim();
+    return value == null || value.isEmpty ? null : value;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loading = _normalizedUserId != null;
+    unawaited(_load(showLoading: false));
+  }
+
+  @override
+  void didUpdateWidget(covariant InvestmentAssetManagementPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.userId?.trim() != widget.userId?.trim() ||
+        !identical(oldWidget.repository, widget.repository)) {
+      unawaited(_load());
+    }
+  }
+
+  Future<void> _load({bool showLoading = true}) async {
+    final sequence = ++_loadSequence;
+    final userId = _normalizedUserId;
+    if (userId == null) {
+      if (!mounted) return;
+      setState(() {
+        _assets = const <InvestmentAsset>[];
+        _loadError = null;
+        _loading = false;
+      });
+      return;
+    }
+
+    if (showLoading && mounted) {
+      setState(() {
+        _loading = true;
+        _loadError = null;
+      });
+    }
+    try {
+      final assets = await widget.repository.fetchByUser(userId: userId);
+      if (!mounted || sequence != _loadSequence) return;
+      setState(() {
+        _assets = _sorted(assets);
+        _loadError = null;
+        _loading = false;
+      });
+    } catch (error) {
+      if (!mounted || sequence != _loadSequence) return;
+      setState(() {
+        _loadError = error;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _openEditor([InvestmentAsset? asset]) async {
+    final userId = _normalizedUserId;
+    if (userId == null || _saving) return;
+
+    final draft = await showDialog<InvestmentAssetDraft>(
+      context: context,
+      builder: (context) => InvestmentAssetEditorDialog(asset: asset),
+    );
+    if (draft == null || !mounted) return;
+
+    setState(() => _saving = true);
+    try {
+      final saved = asset == null
+          ? await widget.repository.create(userId: userId, draft: draft)
+          : await widget.repository.update(
+              userId: userId,
+              assetId: asset.id,
+              draft: draft,
+            );
+      if (!mounted) return;
+      setState(() {
+        final next = <InvestmentAsset>[
+          for (final current in _assets)
+            if (current.id != saved.id) current,
+          saved,
+        ];
+        _assets = _sorted(next);
+      });
+      _showMessage(
+        asset == null ? '${saved.ticker}を追加しました。' : '${saved.ticker}を更新しました。',
+      );
+    } catch (_) {
+      if (!mounted) return;
+      _showMessage('投資資産を保存できませんでした。時間をおいて再試行してください。');
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  Future<void> _confirmDelete(InvestmentAsset asset) async {
+    final userId = _normalizedUserId;
+    if (userId == null || _saving) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('投資資産を削除'),
+        content: Text('${asset.ticker}を一覧から削除しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton.icon(
+            key: const Key('investment_asset_delete_confirm'),
+            onPressed: () => Navigator.of(context).pop(true),
+            icon: const Icon(Icons.delete_outline),
+            label: const Text('削除'),
+            style: FilledButton.styleFrom(backgroundColor: _negative),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _saving = true);
+    try {
+      await widget.repository.delete(userId: userId, assetId: asset.id);
+      if (!mounted) return;
+      setState(() {
+        _assets = <InvestmentAsset>[
+          for (final current in _assets)
+            if (current.id != asset.id) current,
+        ];
+      });
+      _showMessage('${asset.ticker}を削除しました。');
+    } catch (_) {
+      if (!mounted) return;
+      _showMessage('投資資産を削除できませんでした。時間をおいて再試行してください。');
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  void _showMessage(String message) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  List<InvestmentAsset> _sorted(Iterable<InvestmentAsset> assets) {
+    final sorted = assets.toList()
+      ..sort((a, b) {
+        final typeOrder = a.assetType.index.compareTo(b.assetType.index);
+        return typeOrder != 0 ? typeOrder : a.ticker.compareTo(b.ticker);
+      });
+    return List<InvestmentAsset>.unmodifiable(sorted);
+  }
+
+  String _yen(double value) {
+    final formatter = widget.currencyFormatter;
+    return formatter == null ? _yenFormat.format(value) : formatter(value);
+  }
+
+  String _signedYen(double value) {
+    return '${value >= 0 ? '+' : '-'}${_yen(value.abs())}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      key: const Key('investment_asset_management_panel'),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.show_chart, color: _accent),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '投資資産',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  key: const Key('investment_asset_add'),
+                  tooltip: '銘柄を追加',
+                  onPressed:
+                      _normalizedUserId == null || _saving ? null : _openEditor,
+                  icon: const Icon(Icons.add_circle_outline),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '株式・暗号資産・REIT・ETF',
+              style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+            ),
+            const SizedBox(height: 12),
+            _buildBody(theme),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(ThemeData theme) {
+    if (_normalizedUserId == null) {
+      return Text(
+        'ログインすると投資資産を登録できます。',
+        key: const Key('investment_asset_logged_out'),
+        style: theme.textTheme.bodyMedium?.copyWith(color: _muted),
+      );
+    }
+    if (_loading) {
+      return const SizedBox(
+        height: 72,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (_loadError != null) {
+      return Row(
+        key: const Key('investment_asset_load_error'),
+        children: [
+          const Expanded(child: Text('投資資産を読み込めませんでした。')),
+          IconButton(
+            tooltip: '再読み込み',
+            onPressed: _load,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      );
+    }
+    if (_assets.isEmpty) {
+      return Text(
+        '登録済みの銘柄はありません。',
+        key: const Key('investment_asset_empty'),
+        style: theme.textTheme.bodyMedium?.copyWith(color: _muted),
+      );
+    }
+
+    final portfolio = widget.valuationService.summarize(_assets);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _buildPortfolioSummary(theme, portfolio),
+        const SizedBox(height: 12),
+        for (var index = 0; index < portfolio.items.length; index++) ...[
+          if (index > 0) const Divider(height: 20),
+          _buildAssetRow(theme, portfolio.items[index]),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildPortfolioSummary(
+    ThemeData theme,
+    InvestmentPortfolioValuation portfolio,
+  ) {
+    final pricedText = portfolio.pricedMarketValueJpy == 0 &&
+            portfolio.unpricedAssetCount == portfolio.items.length
+        ? '未取得'
+        : _yen(portfolio.pricedMarketValueJpy);
+    return Wrap(
+      key: const Key('investment_asset_portfolio_summary'),
+      spacing: 20,
+      runSpacing: 8,
+      children: [
+        _Metric(label: '評価額', value: pricedText),
+        _Metric(label: '取得額', value: _yen(portfolio.totalAcquisitionCostJpy)),
+        _Metric(label: '銘柄数', value: '${portfolio.items.length}'),
+      ],
+    );
+  }
+
+  Widget _buildAssetRow(ThemeData theme, InvestmentAssetValuation valuation) {
+    final asset = valuation.asset;
+    final gainLoss = valuation.unrealizedGainLossJpy;
+    final gainRate = valuation.unrealizedGainLossRate;
+    final valueColor = gainLoss == null
+        ? null
+        : gainLoss >= 0
+            ? _positive
+            : _negative;
+    final date = asset.buyDate;
+    final purchaseDate = date == null
+        ? '取得日未入力'
+        : '${date.year}/${date.month.toString().padLeft(2, '0')}/'
+            '${date.day.toString().padLeft(2, '0')}';
+
+    return Column(
+      key: ValueKey<String>('investment_asset_${asset.id}'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Text(
+                    asset.ticker,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  Text(
+                    _assetTypeLabel(asset.assetType),
+                    style: theme.textTheme.labelSmall?.copyWith(color: _muted),
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              key: ValueKey<String>('investment_asset_edit_${asset.id}'),
+              tooltip: '${asset.ticker}を編集',
+              onPressed: _saving ? null : () => _openEditor(asset),
+              icon: const Icon(Icons.edit_outlined),
+              iconSize: 20,
+            ),
+            IconButton(
+              key: ValueKey<String>('investment_asset_delete_${asset.id}'),
+              tooltip: '${asset.ticker}を削除',
+              onPressed: _saving ? null : () => _confirmDelete(asset),
+              icon: const Icon(Icons.delete_outline),
+              iconSize: 20,
+            ),
+          ],
+        ),
+        Text(
+          '${_quantityFormat.format(asset.quantity)} × '
+          '${_yen(asset.buyPriceJpy)} / $purchaseDate',
+          style: theme.textTheme.bodySmall?.copyWith(color: _muted),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 20,
+          runSpacing: 8,
+          children: [
+            _Metric(
+              label: '評価額',
+              value: valuation.marketValueJpy == null
+                  ? '未取得'
+                  : _yen(valuation.marketValueJpy!),
+            ),
+            _Metric(
+              label: '損益',
+              value: gainLoss == null ? '未取得' : _signedYen(gainLoss),
+              valueColor: valueColor,
+            ),
+            _Metric(
+              label: '比率',
+              value: gainRate == null
+                  ? '未取得'
+                  : '${gainRate >= 0 ? '+' : ''}'
+                      '${(gainRate * 100).toStringAsFixed(1)}%',
+              valueColor: valueColor,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({required this.label, required this.value, this.valueColor});
+
+  final String label;
+  final String value;
+  final Color? valueColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 72),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: const Color(0xFF6B7280),
+            ),
+          ),
+          Text(
+            value,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: valueColor,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class InvestmentAssetEditorDialog extends StatefulWidget {
+  const InvestmentAssetEditorDialog({super.key, this.asset});
+
+  final InvestmentAsset? asset;
+
+  @override
+  State<InvestmentAssetEditorDialog> createState() =>
+      _InvestmentAssetEditorDialogState();
+}
+
+class _InvestmentAssetEditorDialogState
+    extends State<InvestmentAssetEditorDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late InvestmentAssetType _assetType;
+  late final TextEditingController _tickerController;
+  late final TextEditingController _quantityController;
+  late final TextEditingController _buyPriceController;
+  late final TextEditingController _buyDateController;
+  DateTime? _buyDate;
+
+  @override
+  void initState() {
+    super.initState();
+    final asset = widget.asset;
+    _assetType = asset?.assetType ?? InvestmentAssetType.stock;
+    _tickerController = TextEditingController(text: asset?.ticker ?? '');
+    _quantityController = TextEditingController(
+      text: asset == null ? '' : _plainNumber(asset.quantity),
+    );
+    _buyPriceController = TextEditingController(
+      text: asset == null ? '' : _plainNumber(asset.buyPriceJpy),
+    );
+    _buyDate = asset?.buyDate;
+    _buyDateController = TextEditingController(text: _formatDate(_buyDate));
+  }
+
+  @override
+  void dispose() {
+    _tickerController.dispose();
+    _quantityController.dispose();
+    _buyPriceController.dispose();
+    _buyDateController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickBuyDate() async {
+    final now = DateTime.now();
+    final selected = await showDatePicker(
+      context: context,
+      initialDate: _buyDate ?? now,
+      firstDate: DateTime(1900),
+      lastDate: now,
+    );
+    if (selected != null && mounted) {
+      setState(() {
+        _buyDate = selected;
+        _buyDateController.text = _formatDate(selected);
+      });
+    }
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+    Navigator.of(context).pop(
+      InvestmentAssetDraft(
+        assetType: _assetType,
+        ticker: _tickerController.text,
+        quantity: _parseNumber(_quantityController.text)!,
+        buyPriceJpy: _parseNumber(_buyPriceController.text)!,
+        buyDate: _buyDate,
+        currentPriceJpy: widget.asset?.currentPriceJpy,
+        lastPricedAt: widget.asset?.lastPricedAt,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      scrollable: true,
+      title: Text(widget.asset == null ? '銘柄を追加' : '銘柄を編集'),
+      content: SizedBox(
+        width: 420,
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              DropdownButtonFormField<InvestmentAssetType>(
+                key: const Key('investment_asset_type_field'),
+                initialValue: _assetType,
+                decoration: const InputDecoration(
+                  labelText: '種別',
+                  border: OutlineInputBorder(),
+                ),
+                items: [
+                  for (final type in InvestmentAssetType.values)
+                    DropdownMenuItem(
+                      value: type,
+                      child: Text(_assetTypeLabel(type)),
+                    ),
+                ],
+                onChanged: (value) {
+                  if (value != null) setState(() => _assetType = value);
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                key: const Key('investment_asset_ticker_field'),
+                controller: _tickerController,
+                textCapitalization: TextCapitalization.characters,
+                decoration: const InputDecoration(
+                  labelText: '銘柄コード',
+                  hintText: '例: AAPL / BTC',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) => value == null || value.trim().isEmpty
+                    ? '銘柄コードを入力してください。'
+                    : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                key: const Key('investment_asset_quantity_field'),
+                controller: _quantityController,
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
+                decoration: const InputDecoration(
+                  labelText: '数量',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  final number = _parseNumber(value);
+                  return number == null || !number.isFinite || number <= 0
+                      ? '0より大きい数量を入力してください。'
+                      : null;
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                key: const Key('investment_asset_buy_price_field'),
+                controller: _buyPriceController,
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
+                decoration: const InputDecoration(
+                  labelText: '取得価格（1単位・円）',
+                  prefixText: '¥ ',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  final number = _parseNumber(value);
+                  return number == null || !number.isFinite || number < 0
+                      ? '0以上の取得価格を入力してください。'
+                      : null;
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                key: const Key('investment_asset_buy_date_field'),
+                readOnly: true,
+                onTap: _pickBuyDate,
+                controller: _buyDateController,
+                decoration: InputDecoration(
+                  labelText: '取得日（任意）',
+                  hintText: _buyDate == null ? '未入力' : null,
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    tooltip: '取得日を選択',
+                    onPressed: _pickBuyDate,
+                    icon: const Icon(Icons.calendar_today_outlined),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton.icon(
+          key: const Key('investment_asset_save'),
+          onPressed: _submit,
+          icon: const Icon(Icons.save_outlined),
+          label: const Text('保存'),
+        ),
+      ],
+    );
+  }
+}
+
+String _assetTypeLabel(InvestmentAssetType type) {
+  return switch (type) {
+    InvestmentAssetType.stock => '株式',
+    InvestmentAssetType.crypto => '暗号資産',
+    InvestmentAssetType.reit => 'REIT',
+    InvestmentAssetType.etf => 'ETF',
+  };
+}
+
+double? _parseNumber(String? value) {
+  if (value == null) return null;
+  return double.tryParse(value.replaceAll(',', '').trim());
+}
+
+String _plainNumber(double value) {
+  return value == value.roundToDouble()
+      ? value.toInt().toString()
+      : value.toString();
+}
+
+String _formatDate(DateTime? value) {
+  if (value == null) return '';
+  return '${value.year}/${value.month.toString().padLeft(2, '0')}/'
+      '${value.day.toString().padLeft(2, '0')}';
+}

--- a/lib/widgets/investment_asset_management_panel.dart
+++ b/lib/widgets/investment_asset_management_panel.dart
@@ -523,15 +523,20 @@ class _InvestmentAssetEditorDialogState
 
   void _submit() {
     if (!_formKey.currentState!.validate()) return;
+    final ticker = _tickerController.text.trim().toUpperCase();
+    final asset = widget.asset;
+    final keepsPriceCache = asset != null &&
+        asset.assetType == _assetType &&
+        asset.ticker.trim().toUpperCase() == ticker;
     Navigator.of(context).pop(
       InvestmentAssetDraft(
         assetType: _assetType,
-        ticker: _tickerController.text,
+        ticker: ticker,
         quantity: _parseNumber(_quantityController.text)!,
         buyPriceJpy: _parseNumber(_buyPriceController.text)!,
         buyDate: _buyDate,
-        currentPriceJpy: widget.asset?.currentPriceJpy,
-        lastPricedAt: widget.asset?.lastPricedAt,
+        currentPriceJpy: keepsPriceCache ? asset.currentPriceJpy : null,
+        lastPricedAt: keepsPriceCache ? asset.lastPricedAt : null,
       ),
     );
   }

--- a/test/widgets/investment_asset_management_panel_test.dart
+++ b/test/widgets/investment_asset_management_panel_test.dart
@@ -33,6 +33,13 @@ void main() {
         buyPriceJpy: 1000,
         currentPriceJpy: 1200,
       ),
+      _asset(
+        id: 'asset-2',
+        ticker: 'BTC',
+        quantity: 0.5,
+        buyPriceJpy: 9000000,
+        assetType: InvestmentAssetType.crypto,
+      ),
     ]);
 
     await _pumpPanel(tester, repository: repository, userId: 'user-1');
@@ -41,7 +48,49 @@ void main() {
     expect(find.text('¥2,400'), findsWidgets);
     expect(find.text('+¥400'), findsOne);
     expect(find.text('+20.0%'), findsOne);
+    expect(find.text('取得額（評価済）'), findsOne);
+    expect(find.text('¥2,000'), findsOne);
+    expect(find.text('¥4,502,000'), findsNothing);
+    expect(find.text('価格未取得'), findsOne);
+    expect(find.text('1件'), findsOne);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('retries after a repository load error', (tester) async {
+    final repository = _FakeInvestmentAssetRepository(const [])
+      ..fetchError = Exception('temporary load failure');
+
+    await _pumpPanel(tester, repository: repository, userId: 'user-1');
+
+    expect(find.byKey(const Key('investment_asset_load_error')), findsOne);
+    expect(repository.fetchCalls, 1);
+
+    repository.fetchError = null;
+    await tester.tap(find.byTooltip('再読み込み'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('investment_asset_empty')), findsOne);
+    expect(repository.fetchCalls, 2);
+  });
+
+  testWidgets('clears holdings when the user logs out', (tester) async {
+    final repository = _FakeInvestmentAssetRepository([
+      _asset(
+        id: 'asset-1',
+        ticker: 'AAPL',
+        quantity: 2,
+        buyPriceJpy: 1000,
+      ),
+    ]);
+
+    await _pumpPanel(tester, repository: repository, userId: 'user-1');
+    expect(find.text('AAPL'), findsOne);
+
+    await _pumpPanel(tester, repository: repository, userId: null);
+
+    expect(find.byKey(const Key('investment_asset_logged_out')), findsOne);
+    expect(find.text('AAPL'), findsNothing);
+    expect(repository.fetchCalls, 1);
   });
 
   testWidgets('adds, edits, and deletes an investment asset', (tester) async {
@@ -137,12 +186,13 @@ InvestmentAsset _asset({
   required String ticker,
   required double quantity,
   required double buyPriceJpy,
+  InvestmentAssetType assetType = InvestmentAssetType.stock,
   double? currentPriceJpy,
 }) {
   return InvestmentAsset(
     id: id,
     userId: 'user-1',
-    assetType: InvestmentAssetType.stock,
+    assetType: assetType,
     ticker: ticker,
     quantity: quantity,
     buyPriceJpy: buyPriceJpy,
@@ -165,10 +215,13 @@ class _FakeInvestmentAssetRepository implements InvestmentAssetRepository {
   int deleteCalls = 0;
   InvestmentAssetDraft? lastCreatedDraft;
   InvestmentAssetDraft? lastUpdatedDraft;
+  Exception? fetchError;
 
   @override
   Future<List<InvestmentAsset>> fetchByUser({required String userId}) async {
     fetchCalls++;
+    final error = fetchError;
+    if (error != null) throw error;
     return List<InvestmentAsset>.from(assets);
   }
 

--- a/test/widgets/investment_asset_management_panel_test.dart
+++ b/test/widgets/investment_asset_management_panel_test.dart
@@ -93,6 +93,38 @@ void main() {
     expect(repository.fetchCalls, 1);
   });
 
+  testWidgets('clears cached price when the asset type changes', (
+    tester,
+  ) async {
+    final repository = _FakeInvestmentAssetRepository([
+      _asset(
+        id: 'asset-1',
+        ticker: 'AAPL',
+        quantity: 2,
+        buyPriceJpy: 1000,
+        currentPriceJpy: 1200,
+      ),
+    ]);
+    await _pumpPanel(tester, repository: repository, userId: 'user-1');
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('investment_asset_edit_asset-1')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('investment_asset_type_field')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('ETF').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('investment_asset_save')));
+    await tester.pumpAndSettle();
+
+    expect(repository.updateCalls, 1);
+    expect(repository.lastUpdatedDraft?.assetType, InvestmentAssetType.etf);
+    expect(repository.lastUpdatedDraft?.normalizedTicker, 'AAPL');
+    expect(repository.lastUpdatedDraft?.currentPriceJpy, isNull);
+    expect(repository.lastUpdatedDraft?.lastPricedAt, isNull);
+  });
+
   testWidgets('adds, edits, and deletes an investment asset', (tester) async {
     final repository = _FakeInvestmentAssetRepository([
       _asset(

--- a/test/widgets/investment_asset_management_panel_test.dart
+++ b/test/widgets/investment_asset_management_panel_test.dart
@@ -141,6 +141,24 @@ void main() {
     expect(repository.updateCalls, 1);
     expect(repository.lastUpdatedDraft?.quantity, 3);
     expect(repository.lastUpdatedDraft?.currentPriceJpy, 1200);
+    expect(repository.lastUpdatedDraft?.lastPricedAt, isNotNull);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('investment_asset_edit_asset-1')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('investment_asset_ticker_field')),
+      '7203',
+    );
+    await tester.tap(find.byKey(const Key('investment_asset_save')));
+    await tester.pumpAndSettle();
+
+    expect(repository.updateCalls, 2);
+    expect(repository.lastUpdatedDraft?.normalizedTicker, '7203');
+    expect(repository.lastUpdatedDraft?.currentPriceJpy, isNull);
+    expect(repository.lastUpdatedDraft?.lastPricedAt, isNull);
+    expect(find.text('7203'), findsOne);
 
     await tester.tap(
       find.byKey(const ValueKey<String>('investment_asset_delete_asset-1')),

--- a/test/widgets/investment_asset_management_panel_test.dart
+++ b/test/widgets/investment_asset_management_panel_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/investment_asset.dart';
+import 'package:my_web_app/services/investment_asset_repository.dart';
+import 'package:my_web_app/widgets/investment_asset_management_panel.dart';
+
+void main() {
+  testWidgets('logged-out state does not query the repository', (tester) async {
+    final repository = _FakeInvestmentAssetRepository(const []);
+
+    await _pumpPanel(tester, repository: repository, userId: null);
+
+    expect(find.byKey(const Key('investment_asset_logged_out')), findsOne);
+    expect(repository.fetchCalls, 0);
+    expect(
+      tester
+          .widget<IconButton>(find.byKey(const Key('investment_asset_add')))
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('shows valuation, gain, and rate on a narrow layout', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(360, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final repository = _FakeInvestmentAssetRepository([
+      _asset(
+        id: 'asset-1',
+        ticker: 'AAPL',
+        quantity: 2,
+        buyPriceJpy: 1000,
+        currentPriceJpy: 1200,
+      ),
+    ]);
+
+    await _pumpPanel(tester, repository: repository, userId: 'user-1');
+
+    expect(find.text('AAPL'), findsOne);
+    expect(find.text('¥2,400'), findsWidgets);
+    expect(find.text('+¥400'), findsOne);
+    expect(find.text('+20.0%'), findsOne);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('adds, edits, and deletes an investment asset', (tester) async {
+    final repository = _FakeInvestmentAssetRepository([
+      _asset(
+        id: 'asset-1',
+        ticker: 'AAPL',
+        quantity: 2,
+        buyPriceJpy: 1000,
+        currentPriceJpy: 1200,
+      ),
+    ]);
+    await _pumpPanel(tester, repository: repository, userId: 'user-1');
+
+    await tester.tap(find.byKey(const Key('investment_asset_add')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('investment_asset_ticker_field')),
+      'btc',
+    );
+    await tester.enterText(
+      find.byKey(const Key('investment_asset_quantity_field')),
+      '0.5',
+    );
+    await tester.enterText(
+      find.byKey(const Key('investment_asset_buy_price_field')),
+      '9000000',
+    );
+    await tester.tap(find.byKey(const Key('investment_asset_save')));
+    await tester.pumpAndSettle();
+
+    expect(repository.createCalls, 1);
+    expect(repository.lastCreatedDraft?.normalizedTicker, 'BTC');
+    expect(find.text('BTC'), findsOne);
+    expect(find.text('未取得'), findsWidgets);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('investment_asset_edit_asset-1')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('investment_asset_quantity_field')),
+      '3',
+    );
+    await tester.tap(find.byKey(const Key('investment_asset_save')));
+    await tester.pumpAndSettle();
+
+    expect(repository.updateCalls, 1);
+    expect(repository.lastUpdatedDraft?.quantity, 3);
+    expect(repository.lastUpdatedDraft?.currentPriceJpy, 1200);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('investment_asset_delete_asset-1')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('investment_asset_delete_confirm')));
+    await tester.pumpAndSettle();
+
+    expect(repository.deleteCalls, 1);
+    expect(
+      find.byKey(const ValueKey<String>('investment_asset_asset-1')),
+      findsNothing,
+    );
+    expect(find.text('BTC'), findsOne);
+  });
+}
+
+Future<void> _pumpPanel(
+  WidgetTester tester, {
+  required InvestmentAssetRepository repository,
+  required String? userId,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: SizedBox(
+            width: 520,
+            child: InvestmentAssetManagementPanel(
+              repository: repository,
+              userId: userId,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+InvestmentAsset _asset({
+  required String id,
+  required String ticker,
+  required double quantity,
+  required double buyPriceJpy,
+  double? currentPriceJpy,
+}) {
+  return InvestmentAsset(
+    id: id,
+    userId: 'user-1',
+    assetType: InvestmentAssetType.stock,
+    ticker: ticker,
+    quantity: quantity,
+    buyPriceJpy: buyPriceJpy,
+    buyDate: DateTime.utc(2026, 1, 2),
+    currentPriceJpy: currentPriceJpy,
+    lastPricedAt: currentPriceJpy == null ? null : DateTime.utc(2026, 7, 20, 3),
+    createdAt: DateTime.utc(2026, 1, 2),
+    updatedAt: DateTime.utc(2026, 7, 20),
+  );
+}
+
+class _FakeInvestmentAssetRepository implements InvestmentAssetRepository {
+  _FakeInvestmentAssetRepository(Iterable<InvestmentAsset> seed)
+      : assets = seed.toList();
+
+  final List<InvestmentAsset> assets;
+  int fetchCalls = 0;
+  int createCalls = 0;
+  int updateCalls = 0;
+  int deleteCalls = 0;
+  InvestmentAssetDraft? lastCreatedDraft;
+  InvestmentAssetDraft? lastUpdatedDraft;
+
+  @override
+  Future<List<InvestmentAsset>> fetchByUser({required String userId}) async {
+    fetchCalls++;
+    return List<InvestmentAsset>.from(assets);
+  }
+
+  @override
+  Future<InvestmentAsset> create({
+    required String userId,
+    required InvestmentAssetDraft draft,
+  }) async {
+    createCalls++;
+    lastCreatedDraft = draft;
+    final asset = _fromDraft(id: 'asset-created', userId: userId, draft: draft);
+    assets.add(asset);
+    return asset;
+  }
+
+  @override
+  Future<InvestmentAsset> update({
+    required String userId,
+    required String assetId,
+    required InvestmentAssetDraft draft,
+  }) async {
+    updateCalls++;
+    lastUpdatedDraft = draft;
+    final updated = _fromDraft(id: assetId, userId: userId, draft: draft);
+    final index = assets.indexWhere((asset) => asset.id == assetId);
+    assets[index] = updated;
+    return updated;
+  }
+
+  @override
+  Future<void> delete({required String userId, required String assetId}) async {
+    deleteCalls++;
+    assets.removeWhere((asset) => asset.id == assetId);
+  }
+}
+
+InvestmentAsset _fromDraft({
+  required String id,
+  required String userId,
+  required InvestmentAssetDraft draft,
+}) {
+  return InvestmentAsset(
+    id: id,
+    userId: userId,
+    assetType: draft.assetType,
+    ticker: draft.normalizedTicker,
+    quantity: draft.quantity,
+    buyPriceJpy: draft.buyPriceJpy,
+    buyDate: draft.buyDate,
+    currentPriceJpy: draft.currentPriceJpy,
+    lastPricedAt: draft.lastPricedAt,
+    createdAt: DateTime.utc(2026, 7, 20),
+    updatedAt: DateTime.utc(2026, 7, 20),
+  );
+}


### PR DESCRIPTION
## Summary

- Add a self-contained investment asset panel to the monthly asset dashboard.
- Support create, list, edit, and delete for stock, crypto, REIT, and ETF holdings through the existing repository.
- Show deterministic market value, gain/loss, and gain/loss rate while keeping unpriced holdings explicit.

Closes #2468

## Scope

- `InvestmentAssetManagementPanel` owns loading, logged-out, empty, error, and save/delete states.
- The editor captures type, ticker, quantity, JPY acquisition price, and optional acquisition date.
- Editing preserves `currentPriceJpy` and `lastPricedAt` only when asset type and normalized ticker are unchanged; identity changes clear both stale cache fields. Live price retrieval remains in #2469.
- `AssetManagementPage` accepts repository injection and mounts the panel as the fourth monthly dashboard item.

## Minimal E2E Gate

- Implementation-detail independent: tests assert user-visible input/output and repository-observable CRUD results.
- Minimal scope: 6 cases cover logged-out behavior, narrow-layout valuation output, load retry, logout cleanup, identity cache invalidation, and the add/edit/delete happy path.
- E2E mechanism: Flutter `integration_test/` would be the route-level mechanism.
- E2E-Exception: The signed-in route requires external session data; focused widget CRUD coverage plus the existing page smoke test exercises this isolated panel without adding a brittle external-session test.

## Visual QA

- Changed surface: Asset management > monthly dashboard > investment panel.
- Codex in-app browser / Playwright: not run because the signed-in data route depends on an external session and local resources were constrained.
- Desktop equivalent: the component harness was verified at 520 px width.
- Mobile equivalent: the component harness was verified at 360 px width with no Flutter layout exception.
- Generated imagery: none.

## Validation

- `flutter test test/widgets/investment_asset_management_panel_test.dart --reporter expanded` (6 passed)
- Model and valuation coverage: 9 focused tests passed before final review fixes.
- `flutter test test/widgets/asset_management_page_smoke_test.dart --plain-name "display mode chips reduce visible sections" --reporter expanded` (1 passed)
- Pre-commit quality gate: PASS; `flutter analyze` reported no issues.
- Pre-push full quality gate on `7033af28f`: PASS; `flutter analyze` 0 issues, format check 1003 files / 0 changed, Flutter VM suite 1818 passed, Deno suite 496 passed / 0 failed.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- Evidence: Claude ultrareview completed for PR #4238, including follow-up verification of review fixes.
- Perspectives covered: security, rollback, data migration, prod smoke, observability.
- Unresolved findings: none.

## Risk And Rollback

- Unpriced holdings display `未取得` instead of being treated as zero.
- Logged-out users do not call the investment repository.
- Save/delete failures retain user-facing recovery messages and emit diagnostic logs with stack traces.
- Rollback is a single commit revert; no data migration is required.
