### PR TITLE
[CI/CD自動最適化] 2026-07-20: orphan-cleanup + tools-hub-smoke 6h→12h

### DIFF
--- a/.github/workflows/blog-publish-orphan-cleanup.yml
+++ b/.github/workflows/blog-publish-orphan-cleanup.yml
@@ -2,7 +2,7 @@ name: Blog Publish Orphan Branch Cleanup
 
 on:
   schedule:
-    - cron: '0 */6 * * *'  # every 6 hours
+    - cron: '0 */12 * * *'  # every 12 hours (2026-07-20 ci-audit: 6h→12h, -60 runs/月)
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tools-hub-mcp-smoke.yml
+++ b/.github/workflows/tools-hub-mcp-smoke.yml
@@ -2,7 +2,7 @@ name: tools-hub MCP Smoke
 
 on:
   schedule:
-    - cron: "22 */6 * * *" # every 6 hours at :22
+    - cron: "22 */12 * * *" # every 12 hours at :22 (2026-07-20 ci-audit: 6h→12h, -60 runs/月; health-monitor 2h毎に tools-hub をカバー済)
   workflow_dispatch:
     inputs:
       base_url:


### PR DESCRIPTION
## 変更概要

2 ワークフローの cron 間隔を 6h → 12h に削減。

| ファイル | 変更 | 推定削減 |
|---------|------|---------|
| `blog-publish-orphan-cleanup.yml` | `0 */6 * * *` → `0 */12 * * *` (6h→12h) | -60 runs/月 ≈ -22 ubuntu-min/月 |
| `tools-hub-mcp-smoke.yml` | `22 */6 * * *` → `22 */12 * * *` (6h→12h) | -60 runs/月 ≈ -480 ubuntu-min/月 |
| **合計** | | **-120 runs/月 ≈ -502 ubuntu-min/月** |

## 安全性の根拠

- `blog-publish-orphan-cleanup`: orphan ブランチは 12h 待っても実害なし。`/blog-publish-cleanup` skill で随時手動実行可能。
- `tools-hub-mcp-smoke`: `health-monitor` が 2h 毎に `tools-hub` EF を HTTP 監視済。MCP 固有のシナリオテストは 12h で十分。
- 両ファイルとも `cancel-in-progress: true` 設定済で concurrency は変更なし。
- YAML 構文検証済 (`python3 yaml.safe_load` all 112 files: ok)
- **変更ファイルは `.github/workflows/*.yml` の 2 ファイルのみ。app code / supabase/ は一切変更なし。**

## 監査レポート

`docs/ci-cd-audit/2026-07-20.md` (main ブランチに直接 commit 済)

関連 Issue: #3841

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Schedule-only CI optimization; this PR touches only 2 workflow cron lines in .github/workflows. No supabase/functions, migrations, or prod-critical paths modified.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

E2E-Exception: workflow-only cron schedule change; no app code, UI, or integration paths modified in this PR