### PR TITLE
feat(asset): 異常検知 EF asset.anomaly.detect (±20%閾値+LLM説明flag) (第2弾D #2477)

### DIFF
--- a/supabase/functions/ai-hub/anomaly_detection.ts
+++ b/supabase/functions/ai-hub/anomaly_detection.ts
@@ -1,0 +1,404 @@
+// Issue #2477 [資産管理][第2弾D]: deterministic category-spend anomaly scan.
+// 直近3月平均 vs 対象月 ±20% で異常判定し anomaly_detections へ upsert する。
+// 金額計算・判定はすべて deterministic。LLM は ai_explanation の生成のみ
+// (feature flag OFF default / 失敗しても検知結果には影響しない)。
+
+type UnknownRecord = Record<string, unknown>;
+
+export class AnomalyDetectionError extends Error {
+  status: number;
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "AnomalyDetectionError";
+    this.status = status;
+  }
+}
+
+export type AnomalyProviderRequest = {
+  provider: string;
+  model?: string;
+  messages: { role: string; content: string }[];
+};
+
+export type AnomalyProviderResult = {
+  ok: boolean;
+  text?: string;
+  modelUsed?: string;
+  error?: string;
+};
+
+export type AnomalyProviderInvoker = (
+  request: AnomalyProviderRequest,
+) => Promise<AnomalyProviderResult>;
+
+type ListResult = {
+  data?: unknown[] | null;
+  error?: { message?: string } | null;
+};
+
+type MutationResult = {
+  error?: { message?: string } | null;
+};
+
+export type AnomalyDbQuery = {
+  select(columns?: string): AnomalyDbQuery;
+  eq(column: string, value: string): AnomalyDbQuery;
+  neq(column: string, value: string): AnomalyDbQuery;
+  gte(column: string, value: string): AnomalyDbQuery;
+  lt(column: string, value: string): AnomalyDbQuery;
+  order(
+    column: string,
+    options?: { ascending?: boolean },
+  ): AnomalyDbQuery;
+  range(from: number, to: number): Promise<ListResult>;
+  upsert(
+    value: UnknownRecord,
+    options?: { onConflict?: string },
+  ): Promise<MutationResult>;
+};
+
+export type AnomalyDetectionDb = {
+  from(table: string): AnomalyDbQuery;
+};
+
+export type AnomalyExpenseRow = {
+  posted_at: string;
+  amount: number;
+  category: string;
+  status: string;
+};
+
+export type CategoryAnomaly = {
+  category: string;
+  expected: number;
+  actual: number;
+  delta: number;
+  deviation_ratio: number;
+  severity: "low" | "medium" | "high";
+  months_averaged: number;
+  ai_explanation: string | null;
+};
+
+export type SkippedCategory = {
+  category: string;
+  reason: "no_prior_history" | "no_target_data" | "nonpositive_expected";
+};
+
+export type AnomalyScanOutcome = {
+  target_month: string;
+  window_start: string;
+  anomalies: CategoryAnomaly[];
+  skipped: SkippedCategory[];
+};
+
+export type DetectAnomaliesResult = {
+  status: "ok";
+  target_month: string;
+  anomalies_detected: number;
+  anomalies: CategoryAnomaly[];
+  skipped: SkippedCategory[];
+  explanation_enabled: boolean;
+  warnings: string[];
+};
+
+const DEFAULT_THRESHOLD_RATIO = 0.2;
+const PRIOR_MONTHS = 3;
+const EXPLANATION_CAP = 5;
+const PAGE_SIZE = 1000;
+const JST_OFFSET_MINUTES = 9 * 60;
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function monthFirstDay(year: number, monthIndex0: number): string {
+  const normalized = new Date(Date.UTC(year, monthIndex0, 1));
+  return `${normalized.getUTCFullYear()}-${
+    pad2(normalized.getUTCMonth() + 1)
+  }-01`;
+}
+
+/** monthFirstDay ("YYYY-MM-01") を n ヶ月ずらす。 */
+export function addMonths(monthDay: string, n: number): string {
+  const [y, m] = monthDay.split("-").map(Number);
+  return monthFirstDay(y, m - 1 + n);
+}
+
+/**
+ * 対象月を決める。requested があれば "YYYY-MM" / "YYYY-MM-01" のみ受理。
+ * 省略時は JST での「前の完了月」(当月は集計途中のため既定では対象にしない)。
+ */
+export function resolveTargetMonth(
+  nowIso: string,
+  requested?: unknown,
+): string {
+  if (requested !== undefined && requested !== null && requested !== "") {
+    if (typeof requested !== "string") {
+      throw new AnomalyDetectionError("target_month must be a string", 400);
+    }
+    const match = requested.match(/^(\d{4})-(\d{2})(?:-01)?$/);
+    if (!match) {
+      throw new AnomalyDetectionError(
+        "target_month must be YYYY-MM or YYYY-MM-01",
+        400,
+      );
+    }
+    const month = Number(match[2]);
+    if (month < 1 || month > 12) {
+      throw new AnomalyDetectionError("target_month month out of range", 400);
+    }
+    return `${match[1]}-${match[2]}-01`;
+  }
+  const now = new Date(nowIso);
+  if (Number.isNaN(now.getTime())) {
+    throw new AnomalyDetectionError("invalid now timestamp", 500);
+  }
+  const jst = new Date(now.getTime() + JST_OFFSET_MINUTES * 60 * 1000);
+  return monthFirstDay(jst.getUTCFullYear(), jst.getUTCMonth() - 1);
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/** 逸脱率→severity (deterministic tiers): <50% low / <100% medium / それ以上 high */
+export function severityFor(
+  deviationRatio: number,
+): "low" | "medium" | "high" {
+  if (deviationRatio < 0.5) return "low";
+  if (deviationRatio < 1.0) return "medium";
+  return "high";
+}
+
+/**
+ * カテゴリ別に「直近3月平均 vs 対象月」±threshold で異常を検出する純関数。
+ *
+ * Deterministic rules (テストが仕様):
+ * - status = 'rejected' の行は除外。
+ * - expected = 対象月より前の直近3ヶ月のうち「その category に行がある月」の平均。
+ *   行が無い月は 0 円ではなく「未記録」として平均から除外する
+ *   (記録開始直後の月を 0 扱いすると増加系の偽陽性になるため)。
+ * - 前歴 0 ヶ月 → skip (no_prior_history)。
+ * - 対象月に行が無い category → skip (no_target_data / 未記録と 0 円を区別できない)。
+ * - expected <= 0 → skip (nonpositive_expected / 負・ゼロ基準の比率は誤読を生む)。
+ * - |actual - expected| / expected >= threshold (既定 0.2) で異常。
+ */
+export function computeCategoryAnomalies(options: {
+  rows: AnomalyExpenseRow[];
+  targetMonth: string;
+  thresholdRatio?: number;
+}): AnomalyScanOutcome {
+  const threshold = options.thresholdRatio ?? DEFAULT_THRESHOLD_RATIO;
+  const target = options.targetMonth;
+  const windowStart = addMonths(target, -PRIOR_MONTHS);
+  const nextMonth = addMonths(target, 1);
+  const priorMonths = [-3, -2, -1].map((n) => addMonths(target, n));
+
+  const sums = new Map<string, Map<string, number>>();
+  for (const row of options.rows) {
+    if (row.status === "rejected") continue;
+    if (!row.category) continue;
+    const posted = row.posted_at;
+    if (posted < windowStart || posted >= nextMonth) continue;
+    const month = `${posted.slice(0, 7)}-01`;
+    let byMonth = sums.get(row.category);
+    if (!byMonth) {
+      byMonth = new Map<string, number>();
+      sums.set(row.category, byMonth);
+    }
+    byMonth.set(month, (byMonth.get(month) ?? 0) + row.amount);
+  }
+
+  const anomalies: CategoryAnomaly[] = [];
+  const skipped: SkippedCategory[] = [];
+  const categories = [...sums.keys()].sort();
+  for (const category of categories) {
+    const byMonth = sums.get(category)!;
+    const priorValues = priorMonths
+      .filter((m) => byMonth.has(m))
+      .map((m) => byMonth.get(m)!);
+    if (priorValues.length === 0) {
+      skipped.push({ category, reason: "no_prior_history" });
+      continue;
+    }
+    if (!byMonth.has(target)) {
+      skipped.push({ category, reason: "no_target_data" });
+      continue;
+    }
+    const expected = priorValues.reduce((a, b) => a + b, 0) /
+      priorValues.length;
+    if (expected <= 0) {
+      skipped.push({ category, reason: "nonpositive_expected" });
+      continue;
+    }
+    const actual = byMonth.get(target)!;
+    const delta = actual - expected;
+    const deviation = Math.abs(delta) / expected;
+    if (deviation < threshold) continue;
+    anomalies.push({
+      category,
+      expected: round2(expected),
+      actual: round2(actual),
+      delta: round2(delta),
+      deviation_ratio: round2(deviation),
+      severity: severityFor(deviation),
+      months_averaged: priorValues.length,
+      ai_explanation: null,
+    });
+  }
+
+  return {
+    target_month: target,
+    window_start: windowStart,
+    anomalies,
+    skipped,
+  };
+}
+
+export function buildExplanationPrompt(
+  anomaly: CategoryAnomaly,
+  targetMonth: string,
+): { role: string; content: string }[] {
+  const direction = anomaly.delta >= 0 ? "増加" : "減少";
+  return [
+    {
+      role: "user",
+      content:
+        `家計の異常検知結果を1〜2文の日本語で説明してください。数値の再計算や助言の追加はせず、事実の要約のみ。\n` +
+        `対象月: ${
+          targetMonth.slice(0, 7)
+        } / カテゴリ: ${anomaly.category} / ` +
+        `直近${anomaly.months_averaged}ヶ月平均: ${anomaly.expected}円 / 当月: ${anomaly.actual}円 / ` +
+        `${direction}率: ${Math.round(anomaly.deviation_ratio * 100)}%`,
+    },
+  ];
+}
+
+async function fetchExpenseRows(
+  db: AnomalyDetectionDb,
+  userId: string,
+  windowStart: string,
+  nextMonth: string,
+): Promise<AnomalyExpenseRow[]> {
+  // PostgREST は range 未指定だと既定 max-rows (1000) で無言打ち切りされるため
+  // 全件は range ページング + order に一意 id をタイエブレーカとして必ず含める。
+  const rows: AnomalyExpenseRow[] = [];
+  for (let page = 0; page < 50; page++) {
+    const from = page * PAGE_SIZE;
+    const { data, error } = await db
+      .from("expense_classifications")
+      .select("posted_at,amount,category,status")
+      .eq("user_id", userId)
+      .neq("status", "rejected")
+      .gte("posted_at", windowStart)
+      .lt("posted_at", nextMonth)
+      .order("posted_at", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+    if (error) {
+      throw new AnomalyDetectionError(
+        `expense_classifications load failed: ${error.message ?? "unknown"}`,
+        500,
+      );
+    }
+    const batch = (data ?? []) as UnknownRecord[];
+    for (const raw of batch) {
+      rows.push({
+        posted_at: String(raw.posted_at ?? ""),
+        amount: Number(raw.amount ?? 0),
+        category: String(raw.category ?? ""),
+        status: String(raw.status ?? ""),
+      });
+    }
+    if (batch.length < PAGE_SIZE) break;
+  }
+  return rows;
+}
+
+export async function handleDetectAnomaliesAction(options: {
+  db: AnomalyDetectionDb;
+  body: UnknownRecord;
+  userId: string;
+  explanationEnabled?: boolean;
+  invokeProvider?: AnomalyProviderInvoker;
+  nowIso?: string;
+}): Promise<DetectAnomaliesResult> {
+  if (!options.userId) {
+    throw new AnomalyDetectionError("login required", 401);
+  }
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const targetMonth = resolveTargetMonth(nowIso, options.body.target_month);
+  const nextMonth = addMonths(targetMonth, 1);
+  const windowStart = addMonths(targetMonth, -PRIOR_MONTHS);
+  const warnings: string[] = [];
+
+  const rows = await fetchExpenseRows(
+    options.db,
+    options.userId,
+    windowStart,
+    nextMonth,
+  );
+  const outcome = computeCategoryAnomalies({ rows, targetMonth });
+
+  const explanationEnabled = options.explanationEnabled === true;
+  if (explanationEnabled && options.invokeProvider) {
+    for (const anomaly of outcome.anomalies.slice(0, EXPLANATION_CAP)) {
+      try {
+        const result = await options.invokeProvider({
+          provider: "gemini",
+          messages: buildExplanationPrompt(anomaly, targetMonth),
+        });
+        if (result.ok && result.text) {
+          anomaly.ai_explanation = result.text.trim().slice(0, 500);
+        } else {
+          warnings.push(
+            `explanation skipped (${anomaly.category}): ${
+              result.error ?? "provider returned no text"
+            }`,
+          );
+        }
+      } catch (err) {
+        warnings.push(
+          `explanation failed (${anomaly.category}): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  }
+
+  for (const anomaly of outcome.anomalies) {
+    // 同一 (user, category, target_month) は upsert で更新のみ。
+    // dismissed_at は供給しない = ユーザーの既読/却下を再スキャンで復活させない。
+    const { error } = await options.db.from("anomaly_detections").upsert(
+      {
+        user_id: options.userId,
+        target_month: targetMonth,
+        category: anomaly.category,
+        expected: anomaly.expected,
+        actual: anomaly.actual,
+        delta: anomaly.delta,
+        severity: anomaly.severity,
+        ai_explanation: anomaly.ai_explanation,
+        detected_at: nowIso,
+      },
+      { onConflict: "user_id,category,target_month" },
+    );
+    if (error) {
+      throw new AnomalyDetectionError(
+        `anomaly_detections upsert failed: ${error.message ?? "unknown"}`,
+        500,
+      );
+    }
+  }
+
+  return {
+    status: "ok",
+    target_month: targetMonth,
+    anomalies_detected: outcome.anomalies.length,
+    anomalies: outcome.anomalies,
+    skipped: outcome.skipped,
+    explanation_enabled: explanationEnabled,
+    warnings,
+  };
+}

--- a/supabase/functions/ai-hub/anomaly_detection_test.ts
+++ b/supabase/functions/ai-hub/anomaly_detection_test.ts
@@ -1,0 +1,326 @@
+import {
+  addMonths,
+  type AnomalyDbQuery,
+  type AnomalyDetectionDb,
+  type AnomalyExpenseRow,
+  computeCategoryAnomalies,
+  handleDetectAnomaliesAction,
+  resolveTargetMonth,
+  severityFor,
+} from "./anomaly_detection.ts";
+
+function assertEquals(actual: unknown, expected: unknown) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `Assertion failed:\nactual:   ${JSON.stringify(actual)}\nexpected: ${
+        JSON.stringify(expected)
+      }`,
+    );
+  }
+}
+
+function assertThrows(fn: () => unknown, includes: string) {
+  let thrown = false;
+  try {
+    fn();
+  } catch (err) {
+    thrown = true;
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes(includes)) {
+      throw new Error(
+        `expected error containing "${includes}", got: ${message}`,
+      );
+    }
+  }
+  if (!thrown) throw new Error(`expected error containing "${includes}"`);
+}
+
+function row(
+  posted: string,
+  amount: number,
+  category: string,
+  status = "auto_confirmed",
+): AnomalyExpenseRow {
+  return { posted_at: posted, amount, category, status };
+}
+
+Deno.test("addMonths handles year boundaries", () => {
+  assertEquals(addMonths("2026-01-01", -3), "2025-10-01");
+  assertEquals(addMonths("2026-12-01", 1), "2027-01-01");
+});
+
+Deno.test("resolveTargetMonth accepts YYYY-MM and YYYY-MM-01", () => {
+  assertEquals(
+    resolveTargetMonth("2026-07-21T00:00:00Z", "2026-06"),
+    "2026-06-01",
+  );
+  assertEquals(
+    resolveTargetMonth("2026-07-21T00:00:00Z", "2026-06-01"),
+    "2026-06-01",
+  );
+  assertThrows(
+    () => resolveTargetMonth("2026-07-21T00:00:00Z", "2026/06"),
+    "target_month",
+  );
+  assertThrows(
+    () => resolveTargetMonth("2026-07-21T00:00:00Z", "2026-13"),
+    "out of range",
+  );
+});
+
+Deno.test("resolveTargetMonth defaults to previous complete month in JST", () => {
+  assertEquals(resolveTargetMonth("2026-07-21T00:30:00Z"), "2026-06-01");
+  // 2026-06-30T15:30Z = 2026-07-01T00:30 JST → 前の完了月は 6 月
+  assertEquals(resolveTargetMonth("2026-06-30T15:30:00Z"), "2026-06-01");
+  // その直前 (JST でまだ 6/30) → 前の完了月は 5 月
+  assertEquals(resolveTargetMonth("2026-06-30T14:30:00Z"), "2026-05-01");
+});
+
+Deno.test("severity tiers are deterministic", () => {
+  assertEquals(severityFor(0.2), "low");
+  assertEquals(severityFor(0.49), "low");
+  assertEquals(severityFor(0.5), "medium");
+  assertEquals(severityFor(0.99), "medium");
+  assertEquals(severityFor(1.0), "high");
+});
+
+Deno.test("computeCategoryAnomalies flags >=20% deviation vs 3-month average", () => {
+  const rows = [
+    row("2026-03-05", 30000, "food"),
+    row("2026-04-05", 30000, "food"),
+    row("2026-05-05", 30000, "food"),
+    row("2026-06-05", 39000, "food"),
+  ];
+  const outcome = computeCategoryAnomalies({ rows, targetMonth: "2026-06-01" });
+  assertEquals(outcome.anomalies.length, 1);
+  const anomaly = outcome.anomalies[0];
+  assertEquals(anomaly.category, "food");
+  assertEquals(anomaly.expected, 30000);
+  assertEquals(anomaly.actual, 39000);
+  assertEquals(anomaly.delta, 9000);
+  assertEquals(anomaly.deviation_ratio, 0.3);
+  assertEquals(anomaly.severity, "low");
+  assertEquals(anomaly.months_averaged, 3);
+});
+
+Deno.test("exactly 20% is flagged, 19.99% is not", () => {
+  const base = [
+    row("2026-03-05", 30000, "food"),
+    row("2026-04-05", 30000, "food"),
+    row("2026-05-05", 30000, "food"),
+  ];
+  const at20 = computeCategoryAnomalies({
+    rows: [...base, row("2026-06-05", 36000, "food")],
+    targetMonth: "2026-06-01",
+  });
+  assertEquals(at20.anomalies.length, 1);
+  const below = computeCategoryAnomalies({
+    rows: [...base, row("2026-06-05", 35999, "food")],
+    targetMonth: "2026-06-01",
+  });
+  assertEquals(below.anomalies.length, 0);
+});
+
+Deno.test("rejected rows are excluded from sums", () => {
+  const rows = [
+    row("2026-05-05", 30000, "food"),
+    row("2026-06-05", 30000, "food"),
+    row("2026-06-06", 50000, "food", "rejected"),
+  ];
+  const outcome = computeCategoryAnomalies({ rows, targetMonth: "2026-06-01" });
+  // rejected を除くと 30000 vs 30000 → 異常なし
+  assertEquals(outcome.anomalies.length, 0);
+});
+
+Deno.test("months without rows are treated as unrecorded, not zero", () => {
+  // 記録が 5 月に始まったユーザー: 3-4 月をゼロ扱いすると平均が萎んで
+  // 偽陽性になる。行がある月 (5月) のみで平均する。
+  const rows = [
+    row("2026-05-05", 30000, "food"),
+    row("2026-06-05", 33000, "food"),
+  ];
+  const outcome = computeCategoryAnomalies({ rows, targetMonth: "2026-06-01" });
+  assertEquals(outcome.anomalies.length, 0);
+  const spike = computeCategoryAnomalies({
+    rows: [row("2026-05-05", 30000, "food"), row("2026-06-05", 60000, "food")],
+    targetMonth: "2026-06-01",
+  });
+  assertEquals(spike.anomalies.length, 1);
+  assertEquals(spike.anomalies[0].months_averaged, 1);
+  assertEquals(spike.anomalies[0].severity, "high");
+});
+
+Deno.test("skip reasons: no_prior_history / no_target_data / nonpositive_expected", () => {
+  const outcome = computeCategoryAnomalies({
+    rows: [
+      // food: 対象月のみ → no_prior_history
+      row("2026-06-05", 10000, "food"),
+      // utilities: 前歴のみ → no_target_data
+      row("2026-05-05", 8000, "utilities"),
+      // refunds: 前月合計が負 → nonpositive_expected
+      row("2026-05-05", -5000, "refunds"),
+      row("2026-06-05", 1000, "refunds"),
+    ],
+    targetMonth: "2026-06-01",
+  });
+  assertEquals(outcome.anomalies.length, 0);
+  assertEquals(outcome.skipped, [
+    { category: "food", reason: "no_prior_history" },
+    { category: "refunds", reason: "nonpositive_expected" },
+    { category: "utilities", reason: "no_target_data" },
+  ]);
+});
+
+class FakeQuery implements AnomalyDbQuery {
+  constructor(
+    private readonly table: string,
+    private readonly db: FakeAnomalyDb,
+  ) {}
+
+  select(): AnomalyDbQuery {
+    return this;
+  }
+  eq(): AnomalyDbQuery {
+    return this;
+  }
+  neq(): AnomalyDbQuery {
+    return this;
+  }
+  gte(): AnomalyDbQuery {
+    return this;
+  }
+  lt(): AnomalyDbQuery {
+    return this;
+  }
+  order(): AnomalyDbQuery {
+    return this;
+  }
+  range(from: number, to: number) {
+    const rows = this.db.rowsFor(this.table).slice(from, to + 1);
+    return Promise.resolve({ data: rows, error: null });
+  }
+  upsert(
+    value: Record<string, unknown>,
+    options?: { onConflict?: string },
+  ) {
+    this.db.upserts.push({
+      table: this.table,
+      value,
+      onConflict: options?.onConflict ?? "",
+    });
+    return Promise.resolve({ error: null });
+  }
+}
+
+class FakeAnomalyDb implements AnomalyDetectionDb {
+  upserts: Array<{
+    table: string;
+    value: Record<string, unknown>;
+    onConflict: string;
+  }> = [];
+
+  constructor(
+    private readonly rows: Record<string, Record<string, unknown>[]>,
+  ) {}
+
+  from(table: string): AnomalyDbQuery {
+    return new FakeQuery(table, this);
+  }
+
+  rowsFor(table: string) {
+    return this.rows[table] ?? [];
+  }
+}
+
+Deno.test("handleDetectAnomaliesAction persists anomalies idempotently", async () => {
+  const db = new FakeAnomalyDb({
+    expense_classifications: [
+      row("2026-03-05", 30000, "food"),
+      row("2026-04-05", 30000, "food"),
+      row("2026-05-05", 30000, "food"),
+      row("2026-06-05", 60000, "food"),
+    ],
+  });
+  const result = await handleDetectAnomaliesAction({
+    db,
+    body: { target_month: "2026-06" },
+    userId: "user-1",
+    nowIso: "2026-07-21T03:00:00Z",
+  });
+  assertEquals(result.status, "ok");
+  assertEquals(result.anomalies_detected, 1);
+  assertEquals(result.explanation_enabled, false);
+  assertEquals(db.upserts.length, 1);
+  const upsert = db.upserts[0];
+  assertEquals(upsert.table, "anomaly_detections");
+  assertEquals(upsert.onConflict, "user_id,category,target_month");
+  assertEquals(upsert.value.user_id, "user-1");
+  assertEquals(upsert.value.target_month, "2026-06-01");
+  assertEquals(upsert.value.category, "food");
+  assertEquals(upsert.value.severity, "high");
+  assertEquals(upsert.value.ai_explanation, null);
+  // dismissed_at は供給しない = ユーザーの却下を再スキャンで復活させない
+  assertEquals("dismissed_at" in upsert.value, false);
+});
+
+Deno.test("handleDetectAnomaliesAction requires login", async () => {
+  const db = new FakeAnomalyDb({});
+  let message = "";
+  try {
+    await handleDetectAnomaliesAction({
+      db,
+      body: {},
+      userId: "",
+      nowIso: "2026-07-21T03:00:00Z",
+    });
+  } catch (err) {
+    message = err instanceof Error ? err.message : String(err);
+  }
+  assertEquals(message, "login required");
+});
+
+Deno.test("explanation flag ON calls provider and stores text", async () => {
+  const db = new FakeAnomalyDb({
+    expense_classifications: [
+      row("2026-05-05", 30000, "food"),
+      row("2026-06-05", 60000, "food"),
+    ],
+  });
+  const calls: string[] = [];
+  const result = await handleDetectAnomaliesAction({
+    db,
+    body: { target_month: "2026-06" },
+    userId: "user-1",
+    nowIso: "2026-07-21T03:00:00Z",
+    explanationEnabled: true,
+    invokeProvider: (request) => {
+      calls.push(request.messages[0].content);
+      return Promise.resolve({ ok: true, text: "食費が平均比+100%です。" });
+    },
+  });
+  assertEquals(calls.length, 1);
+  assertEquals(result.anomalies[0].ai_explanation, "食費が平均比+100%です。");
+  assertEquals(db.upserts[0].value.ai_explanation, "食費が平均比+100%です。");
+});
+
+Deno.test("provider failure downgrades to warning, detection still persists", async () => {
+  const db = new FakeAnomalyDb({
+    expense_classifications: [
+      row("2026-05-05", 30000, "food"),
+      row("2026-06-05", 60000, "food"),
+    ],
+  });
+  const result = await handleDetectAnomaliesAction({
+    db,
+    body: { target_month: "2026-06" },
+    userId: "user-1",
+    nowIso: "2026-07-21T03:00:00Z",
+    explanationEnabled: true,
+    invokeProvider: () =>
+      Promise.resolve({ ok: false, error: "budgetExceeded:ef" }),
+  });
+  assertEquals(result.anomalies_detected, 1);
+  assertEquals(result.anomalies[0].ai_explanation, null);
+  assertEquals(result.warnings.length, 1);
+  assertEquals(db.upserts.length, 1);
+});

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -70,6 +70,11 @@ import {
   handleDisposableBalanceAction,
 } from "./disposable_balance.ts";
 import {
+  type AnomalyDetectionDb,
+  AnomalyDetectionError,
+  handleDetectAnomaliesAction,
+} from "./anomaly_detection.ts";
+import {
   handleMarketPriceAction,
   isMarketPriceLiveFetchEnabled,
   MarketPriceActionError,
@@ -3062,6 +3067,8 @@ serve(async (req: Request) => {
       "expense.weekly_coaching.generate",
       "asset.disposable_balance.compute",
       "compute-disposable-balance",
+      "asset.anomaly.detect",
+      "detect-anomalies",
       "voice.tts",
       "voice.stt",
       // 英語速読カリキュラム (実力測定 / AI 生成は要認証 / 教材閲覧は公開)
@@ -4832,6 +4839,34 @@ serve(async (req: Request) => {
         return json({ success: true, ...result });
       }
 
+      case "asset.anomaly.detect":
+      case "detect-anomalies": {
+        const explanationEnabled =
+          (Deno.env.get("ANOMALY_AI_EXPLANATION_ENABLED") ?? "")
+            .toLowerCase() === "true";
+        const result = await handleDetectAnomaliesAction({
+          db: admin as unknown as AnomalyDetectionDb,
+          body,
+          userId: userId ?? "",
+          explanationEnabled,
+          invokeProvider: async (request) => {
+            const budget = await checkBudget("ef", "ai-hub");
+            if (!budget.ok) {
+              return {
+                ok: false,
+                error: `budgetExceeded:${budget.exceeded_scope ?? "unknown"}`,
+              };
+            }
+            return await callSingleProvider(
+              request.provider,
+              request.messages,
+              request.model,
+            );
+          },
+        });
+        return json({ success: true, ...result });
+      }
+
       case "asset.market_price.fetch":
       case "asset.investment.market_price.fetch":
       case "ai_hub.fetch_market_price": {
@@ -6198,6 +6233,9 @@ serve(async (req: Request) => {
       return json({ error: err.message }, err.status);
     }
     if (err instanceof DisposableBalanceError) {
+      return json({ error: err.message }, err.status);
+    }
+    if (err instanceof AnomalyDetectionError) {
       return json({ error: err.message }, err.status);
     }
     if (err instanceof MarketPriceActionError) {

--- a/supabase/migrations/20260721150000_anomaly_detections_target_month.sql
+++ b/supabase/migrations/20260721150000_anomaly_detections_target_month.sql
@@ -1,0 +1,33 @@
+-- Issue #2477: detect_anomalies の冪等な月次スキャンには対象月の安定キーが必要。
+-- anomaly_detections は 20260721120000 で追加されたばかりで書き込みコードは
+-- 本変更 (ai-hub detect_anomalies) が初のため、実質空テーブルへの追加列。
+-- 念のため空でない場合にも耐えるよう backfill してから NOT NULL 化する。
+
+alter table public.anomaly_detections
+  add column if not exists target_month date;
+
+update public.anomaly_detections
+  set target_month = date_trunc('month', detected_at)::date
+  where target_month is null;
+
+alter table public.anomaly_detections
+  alter column target_month set not null;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'anomaly_detections_target_month_first_day'
+  ) then
+    alter table public.anomaly_detections
+      add constraint anomaly_detections_target_month_first_day
+      check (extract(day from target_month) = 1);
+  end if;
+end $$;
+
+-- upsert onConflict (user_id, category, target_month) 用の一意キー。
+create unique index if not exists anomaly_detections_user_category_month_key
+  on public.anomaly_detections (user_id, category, target_month);
+
+comment on column public.anomaly_detections.target_month is
+  '検知対象月の月初日付 (YYYY-MM-01)。(user_id, category, target_month) で一意 = 再スキャンは更新のみ。';

--- a/supabase/migrations/20260721150000_anomaly_detections_target_month.sql
+++ b/supabase/migrations/20260721150000_anomaly_detections_target_month.sql
@@ -1,14 +1,11 @@
 -- Issue #2477: detect_anomalies の冪等な月次スキャンには対象月の安定キーが必要。
 -- anomaly_detections は 20260721120000 で追加されたばかりで書き込みコードは
--- 本変更 (ai-hub detect_anomalies) が初のため、実質空テーブルへの追加列。
--- 念のため空でない場合にも耐えるよう backfill してから NOT NULL 化する。
+-- 本変更 (ai-hub detect_anomalies) が初 = 空テーブルへの追加列。
+-- (時間依存 UPDATE は migration replay guard 対象のため backfill は置かない。
+--  万一行が存在すれば SET NOT NULL が明示的に失敗する = 無言破損しない。)
 
 alter table public.anomaly_detections
   add column if not exists target_month date;
-
-update public.anomaly_detections
-  set target_month = date_trunc('month', detected_at)::date
-  where target_month is null;
 
 alter table public.anomaly_detections
   alter column target_month set not null;


### PR DESCRIPTION
## Summary

Issue #2477 [資産管理][第2弾D] — ai-hub に `asset.anomaly.detect` (alias: `detect-anomalies`) action を追加します。

- **deterministic 検知** (`anomaly_detection.ts` 純関数モジュール): カテゴリ別に「直近3ヶ月平均 vs 対象月」±20% で異常判定。severity は逸脱率で low(<50%)/medium(<100%)/high 3段階
- 安全設計 (part341 の教訓踏襲): 行が無い月は 0 円でなく「未記録」として平均から除外 / 前歴なし・対象月データなし・期待値≤0 は skip (理由付きで応答に列挙)
- `expense_classifications` の読み取りは **range ページング + 一意 id タイエブレーカ** (PostgREST 1000行無言打ち切り対策) / status=rejected 除外
- **冪等**: `(user_id, category, target_month)` 一意キーで upsert。`dismissed_at` は供給せず、ユーザーの却下を再スキャンで復活させない
- migration `20260721150000`: `anomaly_detections` に `target_month` 列 (月初 CHECK) + 一意インデックス追加 (テーブルは #4244 で今日追加されたばかりで書き込みコード無し = 実質空)
- **LLM 説明は feature flag OFF default**: `ANOMALY_AI_EXPLANATION_ENABLED=true` の時のみ ai_explanation を生成 (上位5件まで / budget check 経由 / 失敗は warning に降格し検知結果へ影響なし)
- Deno test 13件 (±20%境界 / JST月境界 / rejected除外 / 未記録月の扱い / skip理由 / 冪等upsert / flag OFF・ON / provider失敗)

対象月既定は JST の「前の完了月」(当月は集計途中のため)。#2478 の daily cron はこの action を呼ぶ想定です。

Closes #2477

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno EF action のみの変更で browser 経路なし。deterministic core は deno test 13件で I/O 検証済み

## High-Risk Ultrareview

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: additive migration on empty table (今日 #4244 で新設・書き込みコード未存在) + EF は authRequired 登録済み action 追加のみで既存 action 変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
