### PR TITLE
fix(campaign): 断つ応援キャンペーンの動画フレーム空表示・共有ボタン被りを修正 (UX改善)

### DIFF
--- a/lib/pages/sobriety_campaign_page.dart
+++ b/lib/pages/sobriety_campaign_page.dart
@@ -159,13 +159,6 @@ class _SobrietyCampaignPageState extends State<SobrietyCampaignPage> {
     final videos = _visible;
     return Scaffold(
       backgroundColor: Colors.black,
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: _openComposer,
-        backgroundColor: DesignTokens.orange,
-        foregroundColor: Colors.white,
-        icon: const Icon(Icons.videocam),
-        label: const Text('投稿'),
-      ),
       body: SafeArea(
         child: Column(
           children: [
@@ -175,6 +168,7 @@ class _SobrietyCampaignPageState extends State<SobrietyCampaignPage> {
                 setState(() => _filter = c);
                 if (_pageController.hasClients) _pageController.jumpToPage(0);
               },
+              onPost: _openComposer,
             ),
             _DailyBanner(date: _today),
             Expanded(
@@ -217,10 +211,15 @@ class _SobrietyCampaignPageState extends State<SobrietyCampaignPage> {
 }
 
 class _TopBar extends StatelessWidget {
-  const _TopBar({required this.filter, required this.onFilter});
+  const _TopBar({
+    required this.filter,
+    required this.onFilter,
+    required this.onPost,
+  });
 
   final CampaignCategory? filter;
   final ValueChanged<CampaignCategory?> onFilter;
+  final VoidCallback onPost;
 
   @override
   Widget build(BuildContext context) {
@@ -257,6 +256,17 @@ class _TopBar extends StatelessWidget {
                 ],
               ),
             ),
+          ),
+          const SizedBox(width: DesignTokens.space8),
+          FilledButton.icon(
+            onPressed: onPost,
+            style: FilledButton.styleFrom(
+              backgroundColor: DesignTokens.orange,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(horizontal: 14),
+            ),
+            icon: const Icon(Icons.videocam, size: 18),
+            label: const Text('投稿'),
           ),
         ],
       ),
@@ -368,7 +378,8 @@ class _VideoCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: DesignTokens.space12),
+      // 下部パディングでグローバル「AIシェア」ボタン等と行の重なりを避ける。
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 56),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -441,6 +452,28 @@ class _VideoCard extends StatelessWidget {
   }
 }
 
+/// Wikimedia Commons の実画像を表示する。読み込み中・取得失敗時は透明を返し、
+/// 背後の絵文字土台がそのまま見えるようにする (フレームが空にならない)。
+class _PrintImage extends StatelessWidget {
+  const _PrintImage({required this.file});
+
+  final String file;
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.network(
+      _commonsImageUrl(file),
+      fit: BoxFit.cover,
+      gaplessPlayback: true,
+      loadingBuilder: (context, child, progress) {
+        if (progress == null) return child;
+        return const SizedBox.shrink();
+      },
+      errorBuilder: (context, error, stack) => const SizedBox.shrink(),
+    );
+  }
+}
+
 class _VideoFrame extends StatelessWidget {
   const _VideoFrame({required this.video, required this.onPlay});
 
@@ -469,23 +502,17 @@ class _VideoFrame extends StatelessWidget {
         child: Stack(
           fit: StackFit.expand,
           children: [
-            // 実際の風刺画 (取得失敗時は下のグラデ + 絵文字にフォールバック)。
+            // 絵文字＋グラデは常に土台として描画。画像の読込中/失敗時に
+            // この土台が見えることで、フレームが空(茶色一色)にならない。
+            Center(
+              child: Text(
+                video.category.emoji,
+                style: const TextStyle(fontSize: 120),
+              ),
+            ),
+            // 実際の風刺画を上に重ねる (成功時のみ土台を覆う)。
             if (video.imageFile != null)
-              Positioned.fill(
-                child: Image.network(
-                  _commonsImageUrl(video.imageFile!),
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, __, ___) => const SizedBox.shrink(),
-                ),
-              ),
-            // 画像が無いカードはカテゴリ絵文字を薄く背景に。
-            if (video.imageFile == null)
-              Center(
-                child: Text(
-                  video.category.emoji,
-                  style: const TextStyle(fontSize: 120),
-                ),
-              ),
+              Positioned.fill(child: _PrintImage(file: video.imageFile!)),
             // 下部グラデ + タイトル (スクショの黒帯テロップ再現)。
             Align(
               alignment: Alignment.bottomCenter,
@@ -611,7 +638,10 @@ class _CreatorRow extends StatelessWidget {
         CircleAvatar(
           radius: 20,
           backgroundColor: video.category.accent.withValues(alpha: 0.25),
-          child: Icon(video.category.icon, color: video.category.accent),
+          child: Text(
+            video.category.emoji,
+            style: const TextStyle(fontSize: 20),
+          ),
         ),
         const SizedBox(width: DesignTokens.space8),
         Expanded(


### PR DESCRIPTION
## Minimal E2E Gate

- [x] Implementation-detail independent: フォールバック描画の有無・ボタン配置というユーザー可視の出力を対象に検証。
- [x] Minimal scope: 画像失敗時（空フレーム→作品カード）/ 共有ボタン被り解消 / 読込中フォールバック の3観点。
- [ ] E2E included: 本セッション環境に Flutter ランタイムが無く未追加。
- [x] Exception reason: ランタイム不在のため、本番スクリーンショットに基づく**10仮説検証**＋静的検証で代替。UI は既存デザイントークン・既出ウィジェットAPIのみ。**CI（`flutter analyze` / `dart format` / `build web`）で最終検証**。

## 📝 変更内容

先にマージした #4222 の「断つ応援キャンペーン」動画シェアを、本番スクリーンショットで判明した問題に基づき改善。動画フレームが**茶色一色の空表示**になる不具合と、**共有ボタンが他のフローティングボタンに隠れる**問題を修正。

### 変更の種類

- [x] バグ修正 / UX改善（breaking change なし）

## 🎯 変更の目的

本番でユーザーが確認したところ、(1) 風刺画が表示されずフレームが空になる、(2) 機能の核である「共有」ボタンがグローバル「AIシェア」ボタン・自前の「投稿」FAB に隠れる、という2点が判明。これらを解消して機能を実用に耐える状態にする。

## 📋 実装の詳細（10仮説検証の結果）

| # | 問題 | 対応 |
| --- | --- | --- |
| H1/H2/H8/H10 | 画像未取得・失敗・読込中にフレームが空（茶色一色） | 絵文字＋グラデを**常に土台描画**し、実画像(`_PrintImage`)を上に重ねる方式へ変更。`loadingBuilder`/`errorBuilder` で読込中・失敗時は土台（絵文字＋作品タイトル＋作者行）が見える |
| H3/H6 | 最左「コメント」がグローバル「AIシェア」ボタン（左下）に被る | カード下部に **56px パディング**を追加して行を持ち上げ |
| H4/H5 | 最右「共有」（核心機能）が自前の「投稿」FAB（右下）に被る | **「投稿」を右下 FAB からトップバーへ移動**し FAB を撤去 |
| H9 | 作者アバターが空／薄く見える | カテゴリ絵文字（🍺/🚬/🌙）アバターに変更 |
| H7 | 静止画に ▶ と「0:03」が動画を誤示唆 | 意匠再現優先で据え置き（軽微） |

### 技術的な詳細

- 実画像は Wikimedia Commons のベストエフォート。**読めても読めなくても**常に「絵文字＋タイトル『ビール通り』(1751)＋作者」の作品カードが表示される（空フレームにならない）。
- 当セッション環境は proxy 制限で Wikimedia への直接検証不可。実画像の常時表示を保証したい場合は、正確な Commons ファイル名の確認、または画像のリポジトリ同梱（`Image.asset`）が別途必要。

## ✅ テスト結果

- [x] 静的検証（80桁・`dart format` 差分要因・`prefer_const_constructors` 等 error 級 lint・ブレース均衡・first-arg-inline なし）
- [ ] Flutter テスト／E2E（ランタイム不在のため CI に委譲）

既存の単体テスト（`campaign_video_test.dart` / `satirical_print_library_test.dart`）はロジック不変のため影響なし。

## 🚨 Breaking Changes

- [x] なし（表示・レイアウトのみの変更。モデル/ルート/公開APIの変更なし）

## 🔒 セキュリティへの影響

- [x] なし

## ✅ チェックリスト

### コード品質

- [ ] `flutter analyze` 0エラー — ⚠️ 本環境にツールチェーン無しのため**未実行**。error 級 lint を静的確認済。**CI で最終検証**。
- [ ] `dart format .` — ⚠️ 同上未実行。改行アルゴリズム・80桁・末尾空白・EOF を手動整合済。**CI で最終検証**。
- [x] 不要なコメント/デバッグ出力なし

### その他

- [x] Breaking Changes なし
- [x] モバイル対応（縦型フィード）

## 💬 追加コメント

#4222 はマージ済みのため、本ブランチは最新 main の上へ載せ替え済み（フォローアップ1コミット）。CI が赤くなった場合は本ブランチで追って修正します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbwavQrsoVHYUw27aXMp9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbwavQrsoVHYUw27aXMp9U)_