### PR TITLE
feat(asset): 残高不足の根拠を明示し、設定修正への導線を出す (入金先未設定の収入予定が原因の特定)

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -66,6 +66,7 @@ import 'package:my_web_app/services/asset_management_insight_service.dart';
 import 'package:my_web_app/services/asset_triage_guide_service.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_inputs.dart';
 import 'package:my_web_app/services/asset_cashflow_forecast_service.dart';
+import 'package:my_web_app/services/asset_account_shortfall_basis_service.dart';
 import 'package:my_web_app/services/asset_alert_center_service.dart';
 import 'package:my_web_app/services/asset_alert_dismissal_store.dart';
 import 'package:my_web_app/services/asset_cashflow_statement_service.dart';
@@ -408,6 +409,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   final _keyCardStatementReconciliation = GlobalKey();
   // 口座間移動の提案セクションへのスクロール用 (残高不足バナーからのジャンプ)。
   final _keyTransferSuggestionSection = GlobalKey();
+  final _keyIncomePlanSection = GlobalKey();
   // 負債コントロールレビュー (原資未設定一覧) へのスクロール用 (原資未設定バナーからのジャンプ)。
   final _keyDebtControlReviewSection = GlobalKey();
 
@@ -1226,6 +1228,13 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
 
   void _jumpToDebtControlReviewSection() {
     _scrollTo(_keyDebtControlReviewSection);
+  }
+
+  /// 残高不足バナーから「収入予定」セクションへ飛ぶ。入金先未設定の収入予定が
+  /// 口座別資金繰りに反映されないことが不足表示の原因になり得るため、その場で
+  /// 設定を直せるようにする。
+  void _jumpToIncomePlanSection() {
+    _scrollTo(_keyIncomePlanSection);
   }
 
   List<String> _paymentSourceCandidates() {
@@ -13578,6 +13587,10 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 height: 1.5,
               ),
             ),
+            // 結論(不足額)だけでは「なぜ足りないのか / 設定が悪いのか」が判らず
+            // 対処できない。計算の根拠 (現在残高・引き落とし明細・入金予定) と
+            // 原因の見立て、設定修正への導線をその場に出す。
+            _buildAccountShortfallBasis(workbook, summary.accountId),
             if (suggestionsByAccountId[summary.accountId]
                 case final suggestion?)
               Wrap(
@@ -13656,6 +13669,114 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                 label: const Text('口座間移動の提案へ移動'),
               ),
             ),
+        ],
+      ),
+    );
+  }
+
+  /// 残高不足の「根拠」をその場に開示する。
+  ///
+  /// 見込み残高 = 現在残高 − 引き落とし予定 + この口座への入金予定 (±移動) で、
+  /// **入金予定は入金先口座がこの口座のものだけ**が数えられる。そのため収入予定の
+  /// 入金先が未設定だと、収入があるのに口座別では不足に見える。この盲点を
+  /// バナー内で名指しし、設定修正へ飛べるようにする。
+  Widget _buildAccountShortfallBasis(
+    AssetLiabilityWorkbook workbook,
+    String accountId,
+  ) {
+    final basis = const AssetAccountShortfallBasisService().buildBasis(
+      workbook: workbook,
+      accountId: accountId,
+    );
+    if (basis == null) {
+      return const SizedBox.shrink();
+    }
+    const detailStyle = TextStyle(
+      fontSize: 11,
+      color: Color(0xFF7F1D1D),
+      height: 1.5,
+    );
+    const shownPaymentLimit = 3;
+    final shownPayments = basis.paymentLines.take(shownPaymentLimit).toList();
+    final hiddenPaymentCount = basis.paymentLines.length - shownPayments.length;
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 2, top: 2, bottom: 2),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '根拠: 現在残高 ${_formatManagementYen(basis.currentBalance)}'
+            ' − 引き落とし予定${basis.paymentLines.length}件 '
+            '${_formatManagementYen(basis.paymentTotal)}'
+            ' ＋ この口座への入金予定 ${_formatManagementYen(basis.incomeTotal)}'
+            '${basis.pendingTransferIn > 0 ? ' ＋ 移動入 ${_formatManagementYen(basis.pendingTransferIn)}' : ''}'
+            '${basis.pendingTransferOut > 0 ? ' − 移動出 ${_formatManagementYen(basis.pendingTransferOut)}' : ''}'
+            ' = ${_formatManagementYen(basis.projectedBalance)}',
+            style: detailStyle,
+          ),
+          for (final line in shownPayments)
+            Text(
+              '・${DateFormat('M月d日').format(line.date)} ${line.name} '
+              '${_formatManagementYen(line.amount)}',
+              style: detailStyle,
+            ),
+          if (hiddenPaymentCount > 0)
+            Text('・ほか$hiddenPaymentCount件', style: detailStyle),
+          // 原因の見立てと修正導線。入金先未設定は「設定だけで解消し得る」ため
+          // 最優先で名指しする。
+          if (basis.cause ==
+              AssetAccountShortfallCause.incomeDestinationUnassigned) ...[
+            Text(
+              '⚠ 入金先口座が未設定の収入予定が'
+              '${_formatManagementYen(basis.unassignedIncomeTotal)}あります'
+              '（${basis.unassignedIncomeNames.take(2).join('・')}'
+              '${basis.unassignedIncomeNames.length > 2 ? ' ほか' : ''}）。'
+              '未設定の収入は口座別の見込みに反映されません。'
+              '${basis.unassignedIncomeCouldCover ? 'この口座が入金先なら、設定するだけでこの不足は解消します。' : ''}',
+              style: const TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: Color(0xFF7F1D1D),
+                height: 1.5,
+              ),
+            ),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                key: Key('asset_shortfall_fix_income_destination_$accountId'),
+                style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  foregroundColor: const Color(0xFFB91C1C),
+                ),
+                onPressed: _jumpToIncomePlanSection,
+                icon: const Icon(Icons.tune, size: 16),
+                label: const Text('収入予定の入金先を設定'),
+              ),
+            ),
+          ] else if (basis.cause ==
+              AssetAccountShortfallCause.noIncomeForAccount) ...[
+            const Text(
+              'この口座への入金予定は登録されていません。'
+              '給料などの入金先がこの口座なら「収入予定」に登録すると見込みへ反映されます。',
+              style: detailStyle,
+            ),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                key: Key('asset_shortfall_add_income_$accountId'),
+                style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  foregroundColor: const Color(0xFFB91C1C),
+                ),
+                onPressed: _jumpToIncomePlanSection,
+                icon: const Icon(Icons.add_circle_outline, size: 16),
+                label: const Text('収入予定を確認・登録'),
+              ),
+            ),
+          ],
         ],
       ),
     );
@@ -24982,6 +25103,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final plans = workbook.incomePlans;
     final unassignedPlans = workbook.unassignedDestinationIncomePlans;
     return Container(
+      key: _keyIncomePlanSection,
       width: double.infinity,
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(

--- a/lib/services/asset_account_shortfall_basis_service.dart
+++ b/lib/services/asset_account_shortfall_basis_service.dart
@@ -1,0 +1,173 @@
+import '../models/asset_liability_workbook.dart';
+
+/// 不足額の根拠となる 1 明細 (引き落とし or 入金予定)。
+class AssetAccountShortfallLine {
+  const AssetAccountShortfallLine({
+    required this.date,
+    required this.name,
+    required this.amount,
+  });
+
+  final DateTime date;
+  final String name;
+
+  /// 正の金額 (引き落としか入金かは所属リストで決まる)。
+  final double amount;
+}
+
+/// なぜ不足するのかの診断。UI はこれに応じて修正導線を出し分ける。
+enum AssetAccountShortfallCause {
+  /// この口座への入金予定が無く、かつ**振込先口座が未設定の収入予定**がある。
+  /// 収入自体は登録されているのに口座別資金繰りへ反映されていない状態で、
+  /// 「給料は入るのに不足と出る」の最有力原因。振込先を設定すれば解消する。
+  incomeDestinationUnassigned,
+
+  /// この口座への入金予定が無く、振込先未設定の収入予定も無い。
+  /// 収入予定そのものが未登録か、他口座宛て。移動が要るか収入登録が要る。
+  noIncomeForAccount,
+
+  /// この口座への入金予定はあるが、引き落としを賄いきれない。
+  incomeInsufficient,
+}
+
+/// 口座の残高不足見込みについて「何が根拠でそうなったか」を組み立てた結果。
+///
+/// 見込み残高の式は
+/// `現在残高 − 未払いの引き落とし + この口座への入金予定 + 移動入 − 移動出`
+/// で、**入金予定は `destinationAccountId` がこの口座のものだけ**が数えられる。
+/// そのため収入予定の振込先が未設定だと、収入があるのに口座別では不足に見える。
+class AssetAccountShortfallBasis {
+  const AssetAccountShortfallBasis({
+    required this.accountId,
+    required this.accountName,
+    required this.currentBalance,
+    required this.paymentLines,
+    required this.incomeLines,
+    required this.pendingTransferIn,
+    required this.pendingTransferOut,
+    required this.projectedBalance,
+    required this.cause,
+    required this.unassignedIncomeTotal,
+    required this.unassignedIncomeNames,
+  });
+
+  final String accountId;
+  final String accountName;
+
+  /// 今この口座にある額。
+  final double currentBalance;
+
+  /// この口座から引き落とされる未払いの支払い (日付昇順)。
+  final List<AssetAccountShortfallLine> paymentLines;
+
+  /// この口座へ入る未受取の入金予定 (日付昇順)。
+  final List<AssetAccountShortfallLine> incomeLines;
+
+  final double pendingTransferIn;
+  final double pendingTransferOut;
+
+  /// 差し引き後の見込み残高 (負なら不足)。
+  final double projectedBalance;
+
+  final AssetAccountShortfallCause cause;
+
+  /// 振込先未設定の収入予定の合計額 (原因表示用)。
+  final double unassignedIncomeTotal;
+
+  /// 同上の名称 (最大数は呼び出し側で調整)。
+  final List<String> unassignedIncomeNames;
+
+  double get paymentTotal =>
+      paymentLines.fold<double>(0, (sum, line) => sum + line.amount);
+
+  double get incomeTotal =>
+      incomeLines.fold<double>(0, (sum, line) => sum + line.amount);
+
+  double get shortfall => projectedBalance < 0 ? projectedBalance.abs() : 0;
+
+  /// 振込先未設定の収入が解消された場合、この口座の不足が消え得るか。
+  /// (全額がこの口座宛てだったと仮定した上限見積り。断定はしない)
+  bool get unassignedIncomeCouldCover =>
+      cause == AssetAccountShortfallCause.incomeDestinationUnassigned &&
+      unassignedIncomeTotal >= shortfall;
+}
+
+/// 残高不足の根拠を組み立てる純関数サービス。
+class AssetAccountShortfallBasisService {
+  const AssetAccountShortfallBasisService();
+
+  /// [accountId] の不足根拠を組み立てる。対象口座のサマリが無ければ null。
+  AssetAccountShortfallBasis? buildBasis({
+    required AssetLiabilityWorkbook workbook,
+    required String accountId,
+  }) {
+    AssetLiabilityAccountCashflowSummary? summary;
+    for (final candidate in workbook.accountCashflowSummaries) {
+      if (candidate.accountId == accountId) {
+        summary = candidate;
+        break;
+      }
+    }
+    if (summary == null) {
+      return null;
+    }
+
+    // 見込み残高の計算 (_buildAccountCashflowSummaries) と同一条件で明細化する。
+    // ここがずれると「根拠の合計と結論が合わない」表示になるため揃える。
+    final paymentLines = <AssetAccountShortfallLine>[
+      for (final row in workbook.cashflowRows)
+        if (row.isPayment &&
+            row.isDirectCashflowTarget &&
+            !row.paid &&
+            row.paymentSourceAccountId == accountId)
+          AssetAccountShortfallLine(
+            date: row.paymentDate,
+            name: row.accountName,
+            amount: row.paymentAmount,
+          ),
+    ]..sort((a, b) => a.date.compareTo(b.date));
+
+    final incomeLines = <AssetAccountShortfallLine>[
+      for (final row in workbook.cashflowRows)
+        if (row.isIncome &&
+            !row.received &&
+            row.destinationAccountId == accountId)
+          AssetAccountShortfallLine(
+            date: row.paymentDate,
+            name: row.accountName,
+            amount: row.paymentAmount,
+          ),
+    ]..sort((a, b) => a.date.compareTo(b.date));
+
+    final unassigned = workbook.unassignedDestinationIncomePlans
+        .where((plan) => !plan.received)
+        .toList();
+    final unassignedTotal =
+        unassigned.fold<double>(0, (sum, plan) => sum + plan.amount);
+
+    final AssetAccountShortfallCause cause;
+    if (incomeLines.isEmpty && unassigned.isNotEmpty) {
+      cause = AssetAccountShortfallCause.incomeDestinationUnassigned;
+    } else if (incomeLines.isEmpty) {
+      cause = AssetAccountShortfallCause.noIncomeForAccount;
+    } else {
+      cause = AssetAccountShortfallCause.incomeInsufficient;
+    }
+
+    return AssetAccountShortfallBasis(
+      accountId: summary.accountId,
+      accountName: summary.accountName,
+      currentBalance: summary.currentBalance,
+      paymentLines: List.unmodifiable(paymentLines),
+      incomeLines: List.unmodifiable(incomeLines),
+      pendingTransferIn: summary.pendingTransferIn,
+      pendingTransferOut: summary.pendingTransferOut,
+      projectedBalance: summary.projectedBalance,
+      cause: cause,
+      unassignedIncomeTotal: unassignedTotal,
+      unassignedIncomeNames: List.unmodifiable(
+        unassigned.map((plan) => plan.name).toList(),
+      ),
+    );
+  }
+}

--- a/test/services/asset_account_shortfall_basis_service_test.dart
+++ b/test/services/asset_account_shortfall_basis_service_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/asset_liability_workbook.dart';
+import 'package:my_web_app/services/asset_account_shortfall_basis_service.dart';
+import 'package:my_web_app/services/asset_liability_planning_service.dart';
+
+void main() {
+  const planning = AssetLiabilityPlanningService();
+  const service = AssetAccountShortfallBasisService();
+
+  /// 現金 1 万円 / モビット返済 3 万円 (現金から引き落とし) で不足する構成。
+  AssetLiabilityWorkbook buildShortWorkbook({
+    List<AssetLiabilityIncomePlan> incomePlans =
+        const <AssetLiabilityIncomePlan>[],
+  }) {
+    return planning.buildWorkbook(
+      latestSnapshot: const <String, double>{'cash': 10000, 'mobit': -500000},
+      baseDate: DateTime(2026, 5, 1),
+      monthlyPaymentOverrides: const <String, double>{'mobit': 30000},
+      paymentSourceAccountIds: const <String, String>{'mobit': 'custom_cash'},
+      incomePlans: incomePlans,
+    );
+  }
+
+  test('明細と合計が見込み残高の計算式と一致する', () {
+    final workbook = buildShortWorkbook();
+    final basis = service.buildBasis(
+      workbook: workbook,
+      accountId: 'custom_cash',
+    );
+
+    expect(basis, isNotNull);
+    expect(basis!.currentBalance, 10000);
+    expect(basis.paymentLines, hasLength(1));
+    // 表示名はスナップショットのキーがそのまま入る (テスト fixture では 'mobit')。
+    expect(basis.paymentLines.single.name, 'mobit');
+    expect(basis.paymentLines.single.amount, 30000);
+    expect(basis.paymentTotal, 30000);
+    expect(basis.incomeLines, isEmpty);
+    // 現在残高 10,000 − 引き落とし 30,000 = -20,000
+    expect(basis.projectedBalance, -20000);
+    expect(basis.shortfall, 20000);
+  });
+
+  test('入金先未設定の収入予定があると原因を incomeDestinationUnassigned と診断する', () {
+    // 収入自体は登録されているが destinationAccountId が無い = 口座別資金繰りに
+    // 反映されない。「給料は入るのに不足と出る」の最有力原因。
+    final workbook = buildShortWorkbook(
+      incomePlans: <AssetLiabilityIncomePlan>[
+        AssetLiabilityIncomePlan(
+          id: 'income_salary',
+          date: DateTime(2026, 5, 25),
+          name: '給料',
+          amount: 200000,
+          destinationAccountId: null,
+          destinationAccountName: null,
+          received: false,
+        ),
+      ],
+    );
+    final basis = service.buildBasis(
+      workbook: workbook,
+      accountId: 'custom_cash',
+    );
+
+    expect(basis, isNotNull);
+    expect(basis!.incomeLines, isEmpty, reason: '口座別には反映されない');
+    expect(basis.cause, AssetAccountShortfallCause.incomeDestinationUnassigned);
+    expect(basis.unassignedIncomeTotal, 200000);
+    expect(basis.unassignedIncomeNames, contains('給料'));
+    // 未設定収入 (20万) が不足 (2万) を上回る = 設定すれば解消し得る。
+    expect(basis.unassignedIncomeCouldCover, isTrue);
+  });
+
+  test('入金先を設定すると口座別に反映され原因診断も変わる', () {
+    final workbook = buildShortWorkbook(
+      incomePlans: <AssetLiabilityIncomePlan>[
+        AssetLiabilityIncomePlan(
+          id: 'income_salary',
+          date: DateTime(2026, 5, 25),
+          name: '給料',
+          amount: 200000,
+          destinationAccountId: 'custom_cash',
+          destinationAccountName: null,
+          received: false,
+        ),
+      ],
+    );
+    final basis = service.buildBasis(
+      workbook: workbook,
+      accountId: 'custom_cash',
+    );
+
+    expect(basis, isNotNull);
+    expect(basis!.incomeLines, hasLength(1));
+    expect(basis.incomeTotal, 200000);
+    // 10,000 − 30,000 + 200,000 = 180,000 → 不足しない
+    expect(basis.projectedBalance, 180000);
+    expect(basis.shortfall, 0);
+  });
+
+  test('この口座宛ての入金があっても足りなければ incomeInsufficient', () {
+    final workbook = buildShortWorkbook(
+      incomePlans: <AssetLiabilityIncomePlan>[
+        AssetLiabilityIncomePlan(
+          id: 'income_small',
+          date: DateTime(2026, 5, 25),
+          name: '雑収入',
+          amount: 5000,
+          destinationAccountId: 'custom_cash',
+          destinationAccountName: null,
+          received: false,
+        ),
+      ],
+    );
+    final basis = service.buildBasis(
+      workbook: workbook,
+      accountId: 'custom_cash',
+    );
+
+    expect(basis, isNotNull);
+    expect(basis!.cause, AssetAccountShortfallCause.incomeInsufficient);
+    // 10,000 − 30,000 + 5,000 = -15,000
+    expect(basis.projectedBalance, -15000);
+    expect(basis.unassignedIncomeCouldCover, isFalse);
+  });
+
+  test('収入予定が全く無ければ noIncomeForAccount', () {
+    final workbook = buildShortWorkbook();
+    final basis = service.buildBasis(
+      workbook: workbook,
+      accountId: 'custom_cash',
+    );
+
+    expect(basis, isNotNull);
+    expect(basis!.cause, AssetAccountShortfallCause.noIncomeForAccount);
+    expect(basis.unassignedIncomeTotal, 0);
+    expect(basis.unassignedIncomeCouldCover, isFalse);
+  });
+
+  test('存在しない口座IDでは null を返す', () {
+    final workbook = buildShortWorkbook();
+    expect(
+      service.buildBasis(workbook: workbook, accountId: 'no_such_account'),
+      isNull,
+    );
+  });
+}


### PR DESCRIPTION
# feat(asset): 残高不足の根拠を明示し、設定修正への導線を出す

## ユーザー報告

> 「三井住友銀行大塚支店」が￥50041不足、と表示されますが、実際には給料日に給料が振り込まれるまでに不足しません。何が根拠となっているのかが表示されるようにしてください。例えば、「○○日に○○の引き落としが6万円されるが、引き落とし口座○○の残高は○○円しかない」など。また、設定が間違っているのであれば、その修正すべき設定に飛べるようなリンクも表示されるようにしてください。

## 構造的な原因 (調査結果)

見込み残高の計算は

```
見込み残高 = 現在残高 − 未払いの引き落とし + この口座への入金予定 (±移動)
```

で、**入金予定は `destinationAccountId` がその口座のものだけ**が数えられる (`_buildAccountCashflowSummaries`)。

つまり **収入予定の「入金先口座」が未設定だと、実際には入金があっても口座別の見込みには 1 円も反映されず、不足に見える**。

この注意書き自体は収入予定セクションに既に存在していた:

> 入金先口座未設定の収入予定があります。全体資金繰りには反映しますが、**口座別資金繰りには反映されません**

しかし不足バナー (ページ最上部) と繋がっておらず、ユーザーが原因に辿り着けなかった。**この 2 つを繋ぐ**のが本 PR。

## 対応

### 1. 純関数サービス `AssetAccountShortfallBasisService` (新設)

見込み残高の計算式と**同一条件**で明細化する (条件がずれると「根拠の合計と結論が合わない」表示になるため厳密に揃えた)。原因を 3 種に診断:

| 診断 | 条件 | 意味 |
|---|---|---|
| `incomeDestinationUnassigned` | この口座への入金予定が無く、入金先未設定の収入予定が存在 | **設定だけで解消し得る最有力原因** |
| `noIncomeForAccount` | 入金予定も未設定収入も無い | 収入登録か資金移動が要る |
| `incomeInsufficient` | 入金予定はあるが足りない | 本当に不足 |

### 2. 根拠の表示

```
「三井住友銀行大塚支店」が¥50,041不足（支払後見込み -¥50,041）
根拠: 現在残高 ¥29,959 − 引き落とし予定5件 ¥80,000 ＋ この口座への入金予定 ¥0 = -¥50,041
・7月8日 アコムショッピング ¥67,147
・7月12日 ガス代 ¥4,500
・ほか3件
```

移動タスクがある場合は「＋移動入 / −移動出」も式に含めて表示する。

### 3. 原因に応じた修正導線

入金先未設定が検出された場合:

```
⚠ 入金先口座が未設定の収入予定が¥200,000あります（給料）。
  未設定の収入は口座別の見込みに反映されません。
  この口座が入金先なら、設定するだけでこの不足は解消します。
  [収入予定の入金先を設定]  ← 収入予定セクションへスクロール
```

- 未設定収入が不足額を**上回る**場合のみ「設定するだけで解消します」と言い切る (下回る場合は断定しない)
- 収入予定セクションに `GlobalKey` を付与し `_jumpToIncomePlanSection` で既存の `_scrollTo` 機構に接続
- 入金予定自体が無い場合は「収入予定を確認・登録」導線

## テスト (新規 6 件 / 計 76 件緑)

- 明細の合計と見込み残高の計算式が一致する
- **入金先未設定の給料 20 万がある状態**: 口座別には反映されず不足 2 万、原因を `incomeDestinationUnassigned` と診断、金額と対象名を提示、「解消し得る」判定が true
- **入金先を設定すると**: 10,000 − 30,000 + 200,000 = 180,000 で不足解消 (ユーザー報告状況の再現と解決)
- 入金予定はあるが足りない → `incomeInsufficient`
- 収入予定が皆無 → `noIncomeForAccount`
- 存在しない口座 ID → null

## 検証

- `flutter test`: **76 件緑** (新規 6 + 既存 planning 70、回帰なし)
- `flutter analyze` (service / test / page): **No issues found!**
- 差分は 3 ファイルの論理変更のみ (ローカル `dart format` は掛けていない)

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 本文キーワード(支払/残高)による prose-only トリガ。変更は不足額の根拠を組み立てる純関数サービスの追加と、バナーへの内訳・診断・スクロール導線の表示のみ。金額計算そのもの・認証・認可・EF・migration・DB書き込み経路には触れない。

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 変更は純ロジック service (根拠の組み立てと原因診断=単体テスト6件追加済) と認証必須ページ内の表示のみで headless E2E 到達不能。既存 unit 76件 + analyze 緑で担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
