### PR TITLE
fix(web): web で毎起動発生していた zonedSchedule UnsupportedError を解消 (part340)

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,6 +1,17 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest.dart' as tz;
+
+/// R35: flutter_local_notifications はローカル通知の **スケジュール** を web で
+/// サポートせず、`zonedSchedule()` は `UnsupportedError` を投げる。
+/// main.dart は起動時に既定 true (`stock_tasks_saturday_reminder_enabled`) で
+/// `scheduleSaturdayReminder()` を呼ぶため、**web では毎回の起動で
+/// 例外→`FlutterError.reportError`→auto_error_report** が発生し、
+/// コンソールと hub_data のエラーログ (第5弾の可視化カードが読む先) を、
+/// web では原理的に成功し得ない条件で汚し続けていた。
+/// web ではスケジュール系を静かに no-op する (機能自体が web に存在しない)。
+bool get notificationSchedulingSupported => !kIsWeb;
 
 class NotificationService {
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
@@ -52,6 +63,8 @@ class NotificationService {
   }
 
   Future<void> scheduleSaturdayReminder() async {
+    // R35: web はスケジュール未対応 (zonedSchedule が UnsupportedError)。
+    if (!notificationSchedulingSupported) return;
     await init();
     const AndroidNotificationDetails androidPlatformChannelSpecifics =
         AndroidNotificationDetails(
@@ -88,6 +101,8 @@ class NotificationService {
     int hour = 21,
     int minute = 0,
   }) async {
+    // R35: web はスケジュール未対応 (zonedSchedule が UnsupportedError)。
+    if (!notificationSchedulingSupported) return;
     await init();
     const AndroidNotificationDetails androidPlatformChannelSpecifics =
         AndroidNotificationDetails(
@@ -123,6 +138,8 @@ class NotificationService {
     int id = abstinenceRecoveryReminderId,
     DateTime? dueAt,
   }) async {
+    // R35: web はスケジュール未対応 (zonedSchedule が UnsupportedError)。
+    if (!notificationSchedulingSupported) return;
     await init();
     const AndroidNotificationDetails androidPlatformChannelSpecifics =
         AndroidNotificationDetails(
@@ -172,6 +189,7 @@ class NotificationService {
     required DateTime startAt,
     required int reminderMinutes,
   }) async {
+    if (!notificationSchedulingSupported) return;
     final normalizedId = eventId.trim();
     if (normalizedId.isEmpty) return;
 

--- a/test/services/notification_service_web_guard_test.dart
+++ b/test/services/notification_service_web_guard_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/notification_service.dart';
+
+void main() {
+  // R35: flutter_local_notifications の zonedSchedule は web 未対応で
+  // UnsupportedError を投げる。main.dart は起動時に既定 true で
+  // scheduleSaturdayReminder() を呼ぶため、ガードが無いと web の毎起動で
+  // 例外→FlutterError.reportError→auto_error_report が発生する。
+  test('スケジュール可否は web かどうかで決まる', () {
+    expect(notificationSchedulingSupported, equals(!kIsWeb));
+  });
+
+  test('VM (非web) ではスケジュールが許可される', () {
+    // このテストは VM で走るため web ではない = スケジュール可。
+    expect(kIsWeb, isFalse);
+    expect(notificationSchedulingSupported, isTrue);
+  });
+}


### PR DESCRIPTION
## 概要

build 4901 のコンソールに出ていた実エラーを追跡し、**web の毎起動で必ず発生する例外**であることを確定して修正した。

```
Unsupported operation: zonedSchedule() is not supported on the web
```

## 原因の連鎖 (すべてコードで確認)

1. `main.dart:376` 起動時に `notificationService.init()`
2. `main.dart:378-381` が `stock_tasks_saturday_reminder_enabled` (**既定 true**) を読み `scheduleSaturdayReminder()`
3. → `flutterLocalNotificationsPlugin.zonedSchedule()` は **web 未対応**で `UnsupportedError`
4. `main.dart:385` が catch し **`FlutterError.reportError()`** → `FlutterError.onError` → コンソール + **auto_error_report (hub_data)**

`notification_service.dart` には **`kIsWeb` ガードが一つも無かった** (`foundation.dart` すら未 import)。つまり **web では原理的に成功し得ない処理**を毎起動で実行して例外を投げ、第5弾で作ったエラー可視化カード (#4181) が読む hub_data のエラーログを**恒常的に汚していた** — 直しようのないノイズで**本物のエラーが埋もれる**状態だった。

## 修正

`notificationSchedulingSupported` (= `!kIsWeb`) を導入し、**スケジュール系4メソッドすべての先頭で web は静かに no-op**。**サービス側1箇所**で塞ぐことで呼び出し元6箇所 (main.dart 起動 / stock_tasks / emergency_meeting×2 / calendar_events) を一度に保護する。ローカル通知のスケジュールは web に存在しない機能なので、skip が正しい挙動 (throw して報告するのは誤り)。

`cancel*` と `init()` は例外を投げていない (コンソールにも出ていない) ため**据え置き** — 観測していない挙動には手を入れない。

## 検証
- `notification_service_web_guard_test.dart` 追加 (ガードが `kIsWeb` に連動する不変条件を固定)
- `flutter analyze` 0 issue / `dart format` 差分なし

### 検証の限界 (正直な記載)
**web 実機での no-op 確認は未実施**。重い browser test はこの環境で "Connection closed" になるため。ガードは `kIsWeb` による静的分岐で、**非 web の挙動は構造上従来と同一**。

## 別件として分離
同じコンソールに出ていた `RenderBox was not laid out (#3237)` は **minified (`minified:aJN#536cc`) でウィジェット特定不可**。推測修正は誤修正リスクが高いため本PRでは触れず、profile ビルドでの特定手順を添えて **#4250** に分離した。

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Client-only platform guard: skip local-notification scheduling on web where the plugin throws UnsupportedError. No auth, RLS, payment, secret, schema, or edge changes; non-web behaviour is byte-identical via a kIsWeb static branch

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Platform guard verified by code-path analysis (main.dart boot -> scheduleSaturdayReminder -> zonedSchedule throws on web) plus a VM unit test locking the guard to kIsWeb. Web runtime no-op not exercised: heavy browser tests fail with Connection closed in this environment; non-web path is unchanged by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
