### PR TITLE
fix(election): 公開ノートの重複フェッチを解消 (第7弾・noteId基準ガード)

### DIFF
--- a/lib/pages/election_victory_page.dart
+++ b/lib/pages/election_victory_page.dart
@@ -129,6 +129,11 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
   final Map<String, String> _memberProfileErrors = <String, String>{};
   PublicMemo? _publishedSnapshotMemo;
   PublicMemo? _publishedKpiMemo;
+
+  /// KPI公開ノートを一度でも読みに行ったか。KPIノートIDは固定値なので、
+  /// 自動リフレッシュでの再取得を抑止する判定に使う (結果が null=未公開でも
+  /// 「試行済み」として扱い、毎回リトライして重複フェッチに戻るのを防ぐ)。
+  bool _kpiMemoLoadAttempted = false;
   bool _isLoading = true;
   bool _isRealityLoading = false;
   bool _isPublishingSnapshotMemo = false;
@@ -528,6 +533,7 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
   }
 
   Future<void> _loadPublishedKpiMemo() async {
+    _kpiMemoLoadAttempted = true;
     final memo = await _shareService.loadPublishedPlanDashboard();
     if (!mounted) {
       return;
@@ -590,10 +596,15 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
       if (!mounted) {
         return;
       }
-      // 初期ロード直後の refresh がキャッシュと同一 snapshot を返すケースでは
-      // 公開ノートの再ロードを省略する (page load ごとの public_memos 二重
-      // フェッチ対策)。fetchedAt が変わったときだけ再取得する。
-      final snapshotChanged = _realitySnapshot?.fetchedAt != snapshot.fetchedAt;
+      // 公開ノートの再取得は「参照するノートIDが変わったとき」だけに絞る。
+      // snapshot ノートIDは日付のみから作られ (buildSyntheticNoteId)、
+      // KPIノートIDは固定定数なので、fetchedAt (時刻込み) を基準にすると
+      // EF 再取得のたびに必ず変化して同じIDを取り直してしまう
+      // (初回ロードで public_memos が 4 フェッチになる原因)。
+      final previousSnapshot = _realitySnapshot;
+      final snapshotNoteChanged = previousSnapshot == null ||
+          _shareService.buildSyntheticNoteId(previousSnapshot) !=
+              _shareService.buildSyntheticNoteId(snapshot);
       setState(() {
         if (syncedPlan != null) {
           _plan = syncedPlan;
@@ -604,15 +615,20 @@ class _ElectionVictoryPageState extends State<ElectionVictoryPage> {
         _realitySnapshot = snapshot;
         _realityHistory = history;
         _realityError = null;
-        if (snapshotChanged) {
+        if (snapshotNoteChanged) {
           _publishedSnapshotMemo = null;
-          _publishedKpiMemo = null;
         }
         _syncMemberSelection(snapshot);
         _syncScheduleSelection(snapshot);
       });
-      if (snapshotChanged) {
+      if (snapshotNoteChanged) {
         unawaited(_loadPublishedSnapshotMemo(snapshot));
+      }
+      // KPIノートIDは snapshot に依存しない固定値なので、自動リフレッシュでは
+      // 再取得しない (未公開でメモが null のときも「試行済み」で判定する。
+      // 結果 null を条件にすると毎回リトライして重複フェッチが戻る)。
+      // ユーザーが明示的に再取得したときだけ取り直す。
+      if (forceRefresh || !_kpiMemoLoadAttempted) {
         unawaited(_loadPublishedKpiMemo());
       }
       if (showSnackBar) {


### PR DESCRIPTION
## 概要

`/local-election-700` の改善 **第7弾**。本番 DevTools の Network で `public_memos` の**実フェッチが4回** (同じ2メモを2度ずつ取得) されていたのを追跡し、根本原因を修正しました。

## 根本原因: ガードの判定基準がノートIDと一致していなかった

第2弾 ([#4115](https://github.com/kanta13jp1/my_web_app/pull/4115)) で公開ノートの二重フェッチ対策として再取得抑止を入れましたが、条件が **`_realitySnapshot.fetchedAt != snapshot.fetchedAt`** でした。

しかし実際に参照するノートIDは `fetchedAt` では変わりません:

| ノート | ID の作り方 | fetchedAt で変わるか |
|--------|------------|---------------------|
| スナップショットノート | `buildSyntheticNoteId` = `base + 日付のみ` | ❌ 同じ日なら同一ID |
| KPIノート | `_planDashboardNoteId` = **固定定数** | ❌ snapshot に一切依存しない |

一方 `fetchedAt` は EF が再取得するたび (時刻込みなので) **必ず変化**します。結果、初期ロード直後の自動リフレッシュでガードが毎回通過し、**同じ2つのメモを取り直していました**。

## 修正

- スナップショットノート: **noteId 同士を比較**し、実際にIDが変わったときだけ再取得
- KPIノート: 固定IDなので自動リフレッシュでは再取得しない。`forceRefresh` (ユーザーの明示的な再取得) のときだけ取り直す
- 未公開でメモが `null` のときに毎回リトライして重複が戻らないよう、**結果ではなく「試行済み」フラグ** `_kpiMemoLoadAttempted` で判定

## 10仮説の検証結果

| # | 仮説 | 判定 |
|---|------|------|
| R7-H1 | `public_memos` の重複フェッチ | ✅ 確定 → 上記修正 |
| R7-H2 | `core-hub` が2回 | ❌ 反証 — preflight + 実fetch の正常な組 |
| R7-H3 | `prefecture_election_news` が2回 | ❌ 反証 — 同上 (取得自体は初期1回のみ) |
| R7-H4 | `local-election-intelligence` 16.46s | ❌ 反証 (既知) — サーバー側キャッシュ不在の構造要因。クライアント2hキャッシュは有効 |
| R7-H5 | `user_presence` 多重 | ❌ 反証 — 2分heartbeat の設計値 (part340 で確認済) |
| R7-H6 | プルリフレッシュで自民ベンチマークが消える | ❌ 反証 (自己レビュー) — `_loadPlan` も `withCdpLocalMembers`+`withLdpLocalMembers` を再適用 |
| R7-H7 | 第6弾の自民行が一部経路で出ない | ❌ 反証 (自己レビュー) — `_buildContent` の呼び出しは1箇所で `plan` を渡している |
| R7-H8 | `ldp_local_members.json` の取得タイミング異常 | ❌ 反証 — 初期1回のみ (910B) |
| R7-H9 | `version.json` 重複 | ❌ 反証 — 1回のみ |
| R7-H10 | Finish 2.1分 = ロード劣化 | ❌ 反証 — presence heartbeat の累積 (DOMContentLoaded 576ms) |

## 検証

- `flutter analyze` (編集ファイル): `No issues found!`
- `dart format` / `require_trailing_commas`: 適合済み

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 公開ノートの再取得条件 (fetch 抑止) のみの変更で UI 表示・画面遷移の変更なし。判定は page State 内メソッドのため Supabase 初期化を伴う全ページ pump が必要で、flutter analyze + 本番 Network の実測 (修正前4フェッチ) で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
