### PR TITLE
ci: prevent broken grouped pub updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,6 +76,11 @@ updates:
       flutter-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        exclude-patterns:
+          - "flutter_native_splash"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

- Limit the grouped pub dependency updates to minor and patch versions.
- Exclude `flutter_native_splash` from the group while retaining its explicit ignore rule.
- Keep future grouped updates from reproducing the incompatible splash update and unexpected major updates seen in #4227.
- Repository label `dependencies` was created so Dependabot can apply the configured label.

## Root cause

The pub group matched every dependency without its own update-type boundary or group-level exclusion. PR #4227 therefore included both the intentionally pinned `flutter_native_splash 2.4.8` update and the `xml 7.x` major update, despite the existing ignore rules.

## Validation

- YAML parsed successfully with `yaml.safe_load`.
- Semantic assertions confirmed `update-types: [minor, patch]`, `exclude-patterns: [flutter_native_splash]`, and the retained explicit ignore rule.
- `git diff --check` passed.
- The repository fast quality gate reached Flutter dependency analysis but exceeded the five-minute local timeout; its generated lock/registrant changes were discarded. GitHub Actions remains the authoritative full gate.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Dependabot configuration only; no application runtime or user-visible flow changes.

Supersedes #4227.
