### PR TITLE
feat: add investment portfolio history chart

### DIFF
--- a/lib/models/investment_portfolio_history.dart
+++ b/lib/models/investment_portfolio_history.dart
@@ -37,9 +37,8 @@ double _requiredDouble(Map<String, dynamic> row, String key) {
 
 int _requiredInt(Map<String, dynamic> row, String key) {
   final value = row[key];
-  final parsed = value is num
-      ? value.toInt()
-      : int.tryParse(value?.toString() ?? '');
+  final parsed =
+      value is num ? value.toInt() : int.tryParse(value?.toString() ?? '');
   if (parsed == null || parsed < 0) {
     throw FormatException('Missing or invalid $key in portfolio history row');
   }

--- a/lib/models/investment_portfolio_history.dart
+++ b/lib/models/investment_portfolio_history.dart
@@ -1,0 +1,55 @@
+class InvestmentPortfolioHistoryPoint {
+  const InvestmentPortfolioHistoryPoint({
+    required this.recordedAt,
+    required this.marketValueJpy,
+    required this.acquisitionCostJpy,
+    required this.pricedAssetCount,
+    required this.unpricedAssetCount,
+  });
+
+  final DateTime recordedAt;
+  final double marketValueJpy;
+  final double acquisitionCostJpy;
+  final int pricedAssetCount;
+  final int unpricedAssetCount;
+
+  factory InvestmentPortfolioHistoryPoint.fromMap(Map<String, dynamic> row) {
+    return InvestmentPortfolioHistoryPoint(
+      recordedAt: _requiredDate(row, 'recorded_at').toUtc(),
+      marketValueJpy: _requiredDouble(row, 'market_value_jpy'),
+      acquisitionCostJpy: _requiredDouble(row, 'acquisition_cost_jpy'),
+      pricedAssetCount: _requiredInt(row, 'priced_asset_count'),
+      unpricedAssetCount: _requiredInt(row, 'unpriced_asset_count'),
+    );
+  }
+}
+
+double _requiredDouble(Map<String, dynamic> row, String key) {
+  final value = row[key];
+  final parsed = value is num
+      ? value.toDouble()
+      : double.tryParse(value?.toString() ?? '');
+  if (parsed == null || !parsed.isFinite || parsed < 0) {
+    throw FormatException('Missing or invalid $key in portfolio history row');
+  }
+  return parsed;
+}
+
+int _requiredInt(Map<String, dynamic> row, String key) {
+  final value = row[key];
+  final parsed = value is num
+      ? value.toInt()
+      : int.tryParse(value?.toString() ?? '');
+  if (parsed == null || parsed < 0) {
+    throw FormatException('Missing or invalid $key in portfolio history row');
+  }
+  return parsed;
+}
+
+DateTime _requiredDate(Map<String, dynamic> row, String key) {
+  final parsed = DateTime.tryParse(row[key]?.toString() ?? '');
+  if (parsed == null) {
+    throw FormatException('Missing or invalid $key in portfolio history row');
+  }
+  return parsed;
+}

--- a/lib/services/investment_asset_repository.dart
+++ b/lib/services/investment_asset_repository.dart
@@ -1,11 +1,16 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/investment_asset.dart';
+import '../models/investment_portfolio_history.dart';
 
 abstract class InvestmentAssetRepository {
   const InvestmentAssetRepository();
 
   Future<List<InvestmentAsset>> fetchByUser({required String userId});
+
+  Future<List<InvestmentPortfolioHistoryPoint>> fetchPortfolioHistory({
+    required String userId,
+  });
 
   Future<InvestmentAsset> create({
     required String userId,
@@ -26,6 +31,8 @@ class SupabaseInvestmentAssetRepository implements InvestmentAssetRepository {
       : _client = client ?? Supabase.instance.client;
 
   static const String tableName = 'investment_assets';
+  static const String historyTableName = 'investment_portfolio_history';
+  static const int _historyPageSize = 1000;
   static const String selectColumns =
       'id,user_id,asset_type,ticker,quantity,buy_price_jpy,buy_date,'
       'current_price_jpy,last_priced_at,created_at,updated_at';
@@ -46,6 +53,40 @@ class SupabaseInvestmentAssetRepository implements InvestmentAssetRepository {
         .whereType<Map>()
         .map((row) => InvestmentAsset.fromMap(row.cast<String, dynamic>()))
         .toList(growable: false);
+  }
+
+  @override
+  Future<List<InvestmentPortfolioHistoryPoint>> fetchPortfolioHistory({
+    required String userId,
+  }) async {
+    final normalizedUserId = _requiredId(userId, 'userId');
+    final points = <InvestmentPortfolioHistoryPoint>[];
+    var offset = 0;
+    while (true) {
+      final rows = await _client
+          .from(historyTableName)
+          .select(
+            'id,recorded_on,recorded_at,market_value_jpy,acquisition_cost_jpy,'
+            'priced_asset_count,unpriced_asset_count',
+          )
+          .eq('user_id', normalizedUserId)
+          .order('recorded_on', ascending: false)
+          .order('id', ascending: false)
+          .range(offset, offset + _historyPageSize - 1);
+      final page = rows as List;
+      points.addAll(
+        page.whereType<Map>().map(
+              (row) => InvestmentPortfolioHistoryPoint.fromMap(
+                row.cast<String, dynamic>(),
+              ),
+            ),
+      );
+      if (page.length < _historyPageSize) break;
+      offset += page.length;
+    }
+
+    points.sort((a, b) => a.recordedAt.compareTo(b.recordedAt));
+    return List<InvestmentPortfolioHistoryPoint>.unmodifiable(points);
   }
 
   @override

--- a/lib/services/investment_portfolio_history_service.dart
+++ b/lib/services/investment_portfolio_history_service.dart
@@ -1,0 +1,67 @@
+import 'dart:math' as math;
+
+import '../models/investment_portfolio_history.dart';
+
+enum InvestmentHistoryPeriod { oneYear, threeYears, lifetime }
+
+class InvestmentPortfolioHistoryService {
+  const InvestmentPortfolioHistoryService({this.maxChartPoints = 180});
+
+  final int maxChartPoints;
+
+  List<InvestmentPortfolioHistoryPoint> selectForChart(
+    Iterable<InvestmentPortfolioHistoryPoint> points, {
+    required InvestmentHistoryPeriod period,
+    required DateTime now,
+  }) {
+    if (maxChartPoints < 2) {
+      throw StateError('maxChartPoints must be at least 2');
+    }
+
+    final sorted = points.toList(growable: false)
+      ..sort((a, b) => a.recordedAt.compareTo(b.recordedAt));
+    final cutoff = _cutoff(period, now.toUtc());
+    final filtered = sorted
+        .where((point) => point.pricedAssetCount > 0)
+        .where(
+          (point) =>
+              cutoff == null || !point.recordedAt.toUtc().isBefore(cutoff),
+        )
+        .toList(growable: false);
+
+    if (filtered.length <= maxChartPoints) {
+      return List<InvestmentPortfolioHistoryPoint>.unmodifiable(filtered);
+    }
+
+    final lastIndex = filtered.length - 1;
+    final sampled = <InvestmentPortfolioHistoryPoint>[];
+    for (var index = 0; index < maxChartPoints; index++) {
+      final sourceIndex = (index * lastIndex / (maxChartPoints - 1)).round();
+      sampled.add(filtered[sourceIndex]);
+    }
+    return List<InvestmentPortfolioHistoryPoint>.unmodifiable(sampled);
+  }
+
+  DateTime? _cutoff(InvestmentHistoryPeriod period, DateTime now) {
+    return switch (period) {
+      InvestmentHistoryPeriod.oneYear => _yearsBefore(now, 1),
+      InvestmentHistoryPeriod.threeYears => _yearsBefore(now, 3),
+      InvestmentHistoryPeriod.lifetime => null,
+    };
+  }
+
+  DateTime _yearsBefore(DateTime value, int years) {
+    final year = value.year - years;
+    final lastDay = DateTime.utc(year, value.month + 1, 0).day;
+    return DateTime.utc(
+      year,
+      value.month,
+      math.min(value.day, lastDay),
+      value.hour,
+      value.minute,
+      value.second,
+      value.millisecond,
+      value.microsecond,
+    );
+  }
+}

--- a/lib/widgets/investment_asset_management_panel.dart
+++ b/lib/widgets/investment_asset_management_panel.dart
@@ -4,8 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../models/investment_asset.dart';
+import '../models/investment_portfolio_history.dart';
 import '../services/investment_asset_repository.dart';
+import '../services/investment_portfolio_history_service.dart';
 import '../services/investment_valuation_service.dart';
+import 'investment_portfolio_history_chart.dart';
 
 /// 投資資産の登録・一覧・編集・削除をまとめたダッシュボードパネル。
 class InvestmentAssetManagementPanel extends StatefulWidget {
@@ -14,13 +17,17 @@ class InvestmentAssetManagementPanel extends StatefulWidget {
     required this.repository,
     required this.userId,
     this.valuationService = const InvestmentValuationService(),
+    this.historyService = const InvestmentPortfolioHistoryService(),
     this.currencyFormatter,
+    this.now,
   });
 
   final InvestmentAssetRepository repository;
   final String? userId;
   final InvestmentValuationService valuationService;
+  final InvestmentPortfolioHistoryService historyService;
   final String Function(double value)? currencyFormatter;
+  final DateTime Function()? now;
 
   @override
   State<InvestmentAssetManagementPanel> createState() =>
@@ -42,10 +49,16 @@ class _InvestmentAssetManagementPanelState
   final NumberFormat _quantityFormat = NumberFormat('#,##0.########');
 
   List<InvestmentAsset> _assets = const <InvestmentAsset>[];
+  List<InvestmentPortfolioHistoryPoint> _history =
+      const <InvestmentPortfolioHistoryPoint>[];
   Object? _loadError;
+  Object? _historyLoadError;
   bool _loading = false;
+  bool _historyLoading = false;
   bool _saving = false;
   int _loadSequence = 0;
+  int _historyLoadSequence = 0;
+  InvestmentHistoryPeriod _historyPeriod = InvestmentHistoryPeriod.oneYear;
 
   String? get _normalizedUserId {
     final value = widget.userId?.trim();
@@ -56,6 +69,7 @@ class _InvestmentAssetManagementPanelState
   void initState() {
     super.initState();
     _loading = _normalizedUserId != null;
+    _historyLoading = _normalizedUserId != null;
     unawaited(_load(showLoading: false));
   }
 
@@ -72,11 +86,15 @@ class _InvestmentAssetManagementPanelState
     final sequence = ++_loadSequence;
     final userId = _normalizedUserId;
     if (userId == null) {
+      _historyLoadSequence++;
       if (!mounted) return;
       setState(() {
         _assets = const <InvestmentAsset>[];
+        _history = const <InvestmentPortfolioHistoryPoint>[];
         _loadError = null;
+        _historyLoadError = null;
         _loading = false;
+        _historyLoading = false;
       });
       return;
     }
@@ -85,6 +103,8 @@ class _InvestmentAssetManagementPanelState
       setState(() {
         _loading = true;
         _loadError = null;
+        _historyLoading = true;
+        _historyLoadError = null;
       });
     }
     try {
@@ -95,11 +115,44 @@ class _InvestmentAssetManagementPanelState
         _loadError = null;
         _loading = false;
       });
+      await _loadHistory(userId, parentSequence: sequence);
     } catch (error) {
       if (!mounted || sequence != _loadSequence) return;
       setState(() {
         _loadError = error;
         _loading = false;
+        _historyLoading = false;
+      });
+    }
+  }
+
+  Future<void> _loadHistory(String userId, {int? parentSequence}) async {
+    final sequence = ++_historyLoadSequence;
+    if (mounted) {
+      setState(() {
+        _historyLoading = true;
+        _historyLoadError = null;
+      });
+    }
+    try {
+      final history = await widget.repository.fetchPortfolioHistory(
+        userId: userId,
+      );
+      if (!mounted ||
+          sequence != _historyLoadSequence ||
+          (parentSequence != null && parentSequence != _loadSequence)) {
+        return;
+      }
+      setState(() {
+        _history = history;
+        _historyLoadError = null;
+        _historyLoading = false;
+      });
+    } catch (error) {
+      if (!mounted || sequence != _historyLoadSequence) return;
+      setState(() {
+        _historyLoadError = error;
+        _historyLoading = false;
       });
     }
   }
@@ -132,6 +185,7 @@ class _InvestmentAssetManagementPanelState
         ];
         _assets = _sorted(next);
       });
+      unawaited(_loadHistory(userId));
       _showMessage(
         asset == null ? '${saved.ticker}を追加しました。' : '${saved.ticker}を更新しました。',
       );
@@ -181,6 +235,7 @@ class _InvestmentAssetManagementPanelState
             if (current.id != asset.id) current,
         ];
       });
+      unawaited(_loadHistory(userId));
       _showMessage('${asset.ticker}を削除しました。');
     } catch (error, stackTrace) {
       debugPrint('Investment asset delete failed: $error');
@@ -301,12 +356,52 @@ class _InvestmentAssetManagementPanelState
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _buildPortfolioSummary(portfolio),
+        const SizedBox(height: 20),
+        _buildHistory(theme),
         const SizedBox(height: 12),
         for (var index = 0; index < portfolio.items.length; index++) ...[
           if (index > 0) const Divider(height: 20),
           _buildAssetRow(theme, portfolio.items[index]),
         ],
       ],
+    );
+  }
+
+  Widget _buildHistory(ThemeData theme) {
+    if (_historyLoading) {
+      return const SizedBox(
+        key: Key('investment_history_loading'),
+        height: 96,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (_historyLoadError != null) {
+      return Row(
+        key: const Key('investment_history_load_error'),
+        children: [
+          const Expanded(child: Text('投資資産の推移を読み込めませんでした。')),
+          IconButton(
+            tooltip: '推移を再読み込み',
+            onPressed: () {
+              final userId = _normalizedUserId;
+              if (userId != null) unawaited(_loadHistory(userId));
+            },
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      );
+    }
+
+    final points = widget.historyService.selectForChart(
+      _history,
+      period: _historyPeriod,
+      now: widget.now?.call() ?? DateTime.now(),
+    );
+    return InvestmentPortfolioHistoryChart(
+      points: points,
+      period: _historyPeriod,
+      onPeriodChanged: (period) => setState(() => _historyPeriod = period),
+      currencyFormatter: widget.currencyFormatter,
     );
   }
 

--- a/lib/widgets/investment_portfolio_history_chart.dart
+++ b/lib/widgets/investment_portfolio_history_chart.dart
@@ -78,10 +78,10 @@ class InvestmentPortfolioHistoryChart extends StatelessWidget {
             ),
           )
         else ...[
-          Wrap(
+          const Wrap(
             spacing: 16,
             runSpacing: 6,
-            children: const [
+            children: [
               _Legend(color: _marketColor, label: '評価額'),
               _Legend(color: _costColor, label: '取得額', dashed: true),
             ],

--- a/lib/widgets/investment_portfolio_history_chart.dart
+++ b/lib/widgets/investment_portfolio_history_chart.dart
@@ -1,0 +1,264 @@
+import 'dart:math' as math;
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/investment_portfolio_history.dart';
+import '../services/investment_portfolio_history_service.dart';
+
+class InvestmentPortfolioHistoryChart extends StatelessWidget {
+  const InvestmentPortfolioHistoryChart({
+    super.key,
+    required this.points,
+    required this.period,
+    required this.onPeriodChanged,
+    this.currencyFormatter,
+  });
+
+  static const Color _marketColor = Color(0xFF2563EB);
+  static const Color _costColor = Color(0xFF6B7280);
+
+  final List<InvestmentPortfolioHistoryPoint> points;
+  final InvestmentHistoryPeriod period;
+  final ValueChanged<InvestmentHistoryPeriod> onPeriodChanged;
+  final String Function(double value)? currencyFormatter;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      key: const Key('investment_portfolio_history'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                '評価額の推移',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            SegmentedButton<InvestmentHistoryPeriod>(
+              key: const Key('investment_history_period_toggle'),
+              showSelectedIcon: false,
+              segments: const [
+                ButtonSegment(
+                  value: InvestmentHistoryPeriod.oneYear,
+                  label: Text('1年'),
+                ),
+                ButtonSegment(
+                  value: InvestmentHistoryPeriod.threeYears,
+                  label: Text('3年'),
+                ),
+                ButtonSegment(
+                  value: InvestmentHistoryPeriod.lifetime,
+                  label: Text('全期間'),
+                ),
+              ],
+              selected: {period},
+              onSelectionChanged: (selection) {
+                if (selection.isNotEmpty) onPeriodChanged(selection.first);
+              },
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        if (points.isEmpty)
+          SizedBox(
+            key: const Key('investment_history_empty'),
+            height: 128,
+            child: Center(
+              child: Text(
+                '選択期間の推移データはありません',
+                style: theme.textTheme.bodySmall?.copyWith(color: _costColor),
+              ),
+            ),
+          )
+        else ...[
+          Wrap(
+            spacing: 16,
+            runSpacing: 6,
+            children: const [
+              _Legend(color: _marketColor, label: '評価額'),
+              _Legend(color: _costColor, label: '取得額', dashed: true),
+            ],
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            key: const Key('investment_history_chart'),
+            height: 220,
+            child: LineChart(_chartData(context)),
+          ),
+        ],
+      ],
+    );
+  }
+
+  LineChartData _chartData(BuildContext context) {
+    final values = <double>[
+      for (final point in points) ...[
+        point.marketValueJpy,
+        point.acquisitionCostJpy,
+      ],
+    ];
+    final maxValue = values.reduce(math.max);
+    final maxY = maxValue <= 0 ? 1.0 : maxValue * 1.1;
+    final lastIndex = points.length - 1;
+
+    return LineChartData(
+      minX: 0,
+      maxX: math.max(1, lastIndex).toDouble(),
+      minY: 0,
+      maxY: maxY,
+      gridData: FlGridData(
+        drawVerticalLine: false,
+        getDrawingHorizontalLine: (_) => FlLine(
+          color: Theme.of(context).dividerColor.withValues(alpha: 0.35),
+          strokeWidth: 1,
+        ),
+      ),
+      borderData: FlBorderData(show: false),
+      titlesData: FlTitlesData(
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        rightTitles: const AxisTitles(
+          sideTitles: SideTitles(showTitles: false),
+        ),
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 54,
+            getTitlesWidget: (value, meta) => SideTitleWidget(
+              meta: meta,
+              child: Text(
+                _compactYen(value),
+                style: Theme.of(context).textTheme.labelSmall,
+              ),
+            ),
+          ),
+        ),
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 28,
+            interval: math.max(1, lastIndex / 4).toDouble(),
+            getTitlesWidget: (value, meta) {
+              final index = value.round();
+              if (index < 0 || index >= points.length) {
+                return const SizedBox.shrink();
+              }
+              return SideTitleWidget(
+                meta: meta,
+                child: Text(
+                  DateFormat('yy/M').format(points[index].recordedAt),
+                  style: Theme.of(context).textTheme.labelSmall,
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+      lineBarsData: [
+        LineChartBarData(
+          spots: [
+            for (var index = 0; index < points.length; index++)
+              FlSpot(index.toDouble(), points[index].marketValueJpy),
+          ],
+          color: _marketColor,
+          barWidth: 3,
+          isCurved: false,
+          dotData: FlDotData(show: points.length <= 12),
+          belowBarData: BarAreaData(
+            show: true,
+            color: _marketColor.withValues(alpha: 0.08),
+          ),
+        ),
+        LineChartBarData(
+          spots: [
+            for (var index = 0; index < points.length; index++)
+              FlSpot(index.toDouble(), points[index].acquisitionCostJpy),
+          ],
+          color: _costColor,
+          barWidth: 2,
+          isCurved: false,
+          dashArray: const [6, 4],
+          dotData: const FlDotData(show: false),
+        ),
+      ],
+      lineTouchData: LineTouchData(
+        touchTooltipData: LineTouchTooltipData(
+          getTooltipItems: (spots) => spots.map((spot) {
+            final index = spot.x.round();
+            if (index < 0 || index >= points.length) return null;
+            return LineTooltipItem(
+              '${DateFormat('yyyy/M/d').format(points[index].recordedAt)}\n'
+              '${spot.barIndex == 0 ? '評価額' : '取得額'} '
+              '${_yen(spot.y)}',
+              const TextStyle(color: Colors.white),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+
+  String _yen(double value) {
+    final formatter = currencyFormatter;
+    return formatter == null
+        ? NumberFormat.currency(
+            locale: 'ja_JP',
+            symbol: '¥',
+            decimalDigits: 0,
+          ).format(value)
+        : formatter(value);
+  }
+
+  String _compactYen(double value) {
+    if (value.abs() >= 100000000) {
+      return '¥${(value / 100000000).toStringAsFixed(1)}億';
+    }
+    if (value.abs() >= 10000) {
+      return '¥${(value / 10000).toStringAsFixed(0)}万';
+    }
+    return '¥${value.round()}';
+  }
+}
+
+class _Legend extends StatelessWidget {
+  const _Legend({
+    required this.color,
+    required this.label,
+    this.dashed = false,
+  });
+
+  final Color color;
+  final String label;
+  final bool dashed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 20,
+          height: 2,
+          child: dashed
+              ? Row(
+                  key: const Key('investment_history_dashed_legend'),
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    for (var index = 0; index < 3; index++)
+                      Container(width: 5, height: 2, color: color),
+                  ],
+                )
+              : ColoredBox(color: color),
+        ),
+        const SizedBox(width: 5),
+        Text(label, style: Theme.of(context).textTheme.labelSmall),
+      ],
+    );
+  }
+}

--- a/supabase/migrations/20260721160000_create_investment_portfolio_history.sql
+++ b/supabase/migrations/20260721160000_create_investment_portfolio_history.sql
@@ -1,0 +1,135 @@
+-- Asset management phase 2B: deterministic daily portfolio history.
+-- Issue #2469. Snapshots are maintained by investment_assets triggers so
+-- chart history does not depend on client clocks or AI-generated values.
+
+begin;
+
+create table if not exists public.investment_portfolio_history (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  recorded_on date not null default current_date,
+  recorded_at timestamptz not null default now(),
+  market_value_jpy numeric(28, 4) not null default 0,
+  acquisition_cost_jpy numeric(28, 4) not null default 0,
+  priced_asset_count integer not null default 0,
+  unpriced_asset_count integer not null default 0,
+  constraint investment_portfolio_history_market_value_non_negative
+    check (market_value_jpy >= 0),
+  constraint investment_portfolio_history_acquisition_cost_non_negative
+    check (acquisition_cost_jpy >= 0),
+  constraint investment_portfolio_history_priced_count_non_negative
+    check (priced_asset_count >= 0),
+  constraint investment_portfolio_history_unpriced_count_non_negative
+    check (unpriced_asset_count >= 0),
+  constraint investment_portfolio_history_user_day_unique
+    unique (user_id, recorded_on)
+);
+
+create index if not exists investment_portfolio_history_user_recorded_idx
+  on public.investment_portfolio_history (user_id, recorded_at desc);
+
+comment on table public.investment_portfolio_history is
+  'Daily deterministic investment portfolio valuation snapshots for Issue #2469.';
+comment on column public.investment_portfolio_history.acquisition_cost_jpy is
+  'Acquisition cost for priced holdings only, aligned with market_value_jpy.';
+
+alter table public.investment_portfolio_history enable row level security;
+
+drop policy if exists investment_portfolio_history_select_own
+  on public.investment_portfolio_history;
+create policy investment_portfolio_history_select_own
+on public.investment_portfolio_history
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+create or replace function public.capture_investment_portfolio_history()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  target_user_id uuid;
+begin
+  target_user_id := case when tg_op = 'DELETE' then old.user_id else new.user_id end;
+
+  if not exists (select 1 from auth.users where id = target_user_id) then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+
+  insert into public.investment_portfolio_history (
+    user_id,
+    recorded_on,
+    recorded_at,
+    market_value_jpy,
+    acquisition_cost_jpy,
+    priced_asset_count,
+    unpriced_asset_count
+  )
+  select
+    target_user_id,
+    current_date,
+    now(),
+    coalesce(sum(quantity * current_price_jpy)
+      filter (where current_price_jpy is not null), 0),
+    coalesce(sum(quantity * buy_price_jpy)
+      filter (where current_price_jpy is not null), 0),
+    (count(*) filter (where current_price_jpy is not null))::integer,
+    (count(*) filter (where current_price_jpy is null))::integer
+  from public.investment_assets
+  where user_id = target_user_id
+  on conflict (user_id, recorded_on) do update
+  set recorded_at = excluded.recorded_at,
+      market_value_jpy = excluded.market_value_jpy,
+      acquisition_cost_jpy = excluded.acquisition_cost_jpy,
+      priced_asset_count = excluded.priced_asset_count,
+      unpriced_asset_count = excluded.unpriced_asset_count;
+
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$$;
+
+drop trigger if exists investment_assets_history_after_insert
+  on public.investment_assets;
+create trigger investment_assets_history_after_insert
+after insert on public.investment_assets
+for each row execute function public.capture_investment_portfolio_history();
+
+drop trigger if exists investment_assets_history_after_update
+  on public.investment_assets;
+create trigger investment_assets_history_after_update
+after update of quantity, buy_price_jpy, current_price_jpy
+on public.investment_assets
+for each row execute function public.capture_investment_portfolio_history();
+
+drop trigger if exists investment_assets_history_after_delete
+  on public.investment_assets;
+create trigger investment_assets_history_after_delete
+after delete on public.investment_assets
+for each row execute function public.capture_investment_portfolio_history();
+
+insert into public.investment_portfolio_history (
+  user_id,
+  recorded_on,
+  recorded_at,
+  market_value_jpy,
+  acquisition_cost_jpy,
+  priced_asset_count,
+  unpriced_asset_count
+)
+select
+  user_id,
+  current_date,
+  now(),
+  coalesce(sum(quantity * current_price_jpy)
+    filter (where current_price_jpy is not null), 0),
+  coalesce(sum(quantity * buy_price_jpy)
+    filter (where current_price_jpy is not null), 0),
+  (count(*) filter (where current_price_jpy is not null))::integer,
+  (count(*) filter (where current_price_jpy is null))::integer
+from public.investment_assets
+group by user_id
+on conflict (user_id, recorded_on) do nothing;
+
+commit;

--- a/test/services/investment_portfolio_history_schema_test.dart
+++ b/test/services/investment_portfolio_history_schema_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260721160000_create_investment_portfolio_history.sql';
+
+void main() {
+  group('investment portfolio history migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(_migrationPath).readAsStringSync().replaceAll('\r\n', '\n');
+    });
+
+    test('stores one deterministic portfolio snapshot per user and day', () {
+      final block = _createTableBlock(sql, 'investment_portfolio_history');
+
+      expect(
+        block,
+        contains('user_id uuid not null references auth.users(id)'),
+      );
+      expect(block, contains('recorded_on date not null'));
+      expect(block, contains('recorded_at timestamptz not null'));
+      expect(block, contains('market_value_jpy numeric(28, 4) not null'));
+      expect(block, contains('acquisition_cost_jpy numeric(28, 4) not null'));
+      expect(block, contains('priced_asset_count integer not null'));
+      expect(block, contains('unpriced_asset_count integer not null'));
+      expect(block, contains('unique (user_id, recorded_on)'));
+    });
+
+    test('allows authenticated users to read only their own history', () {
+      expect(
+        sql,
+        contains(
+          'alter table public.investment_portfolio_history enable row level security;',
+        ),
+      );
+      expect(
+        sql,
+        contains('create policy investment_portfolio_history_select_own'),
+      );
+      expect(sql, contains('for select\nto authenticated'));
+      expect(sql, contains('using (auth.uid() = user_id)'));
+      expect(sql, isNot(contains('for insert\nto authenticated')));
+    });
+
+    test('captures insert, valuation update, and delete changes', () {
+      expect(
+        sql,
+        contains(
+          'create or replace function public.capture_investment_portfolio_history()',
+        ),
+      );
+      expect(sql, contains('security definer\nset search_path = \'\''));
+      expect(sql, contains('on conflict (user_id, recorded_on) do update'));
+      expect(sql, contains('after insert on public.investment_assets'));
+      expect(
+        sql,
+        contains(
+          'after update of quantity, buy_price_jpy, current_price_jpy\non public.investment_assets',
+        ),
+      );
+      expect(sql, contains('after delete on public.investment_assets'));
+    });
+
+    test('aligns acquisition cost with priced holdings and backfills once', () {
+      expect(
+        RegExp(
+          r'sum\(quantity \* buy_price_jpy\)\s+filter \(where current_price_jpy is not null\)',
+        ).allMatches(sql),
+        hasLength(2),
+      );
+      expect(sql, contains('from public.investment_assets\ngroup by user_id'));
+      expect(sql, contains('on conflict (user_id, recorded_on) do nothing;'));
+    });
+  });
+}
+
+String _createTableBlock(String sql, String table) {
+  final start = sql.indexOf('create table if not exists public.$table');
+  expect(start, isNonNegative, reason: 'missing create table for $table');
+  final end = sql.indexOf('\n);', start);
+  expect(end, isNonNegative, reason: 'missing create table terminator');
+  return sql.substring(start, end);
+}

--- a/test/services/investment_portfolio_history_service_test.dart
+++ b/test/services/investment_portfolio_history_service_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/investment_portfolio_history.dart';
+import 'package:my_web_app/services/investment_portfolio_history_service.dart';
+
+void main() {
+  const service = InvestmentPortfolioHistoryService();
+  final now = DateTime.utc(2026, 7, 21, 12);
+
+  test('one year includes the exact cutoff and excludes older points', () {
+    final selected = service.selectForChart(
+      [
+        _point(DateTime.utc(2025, 7, 21, 11)),
+        _point(DateTime.utc(2025, 7, 21, 12)),
+        _point(DateTime.utc(2026, 7, 21, 12)),
+      ],
+      period: InvestmentHistoryPeriod.oneYear,
+      now: now,
+    );
+
+    expect(selected.map((point) => point.recordedAt), [
+      DateTime.utc(2025, 7, 21, 12),
+      DateTime.utc(2026, 7, 21, 12),
+    ]);
+  });
+
+  test('three years and lifetime use distinct deterministic windows', () {
+    final points = [
+      _point(DateTime.utc(2022, 7, 21)),
+      _point(DateTime.utc(2023, 7, 21, 12)),
+      _point(DateTime.utc(2026, 7, 21)),
+    ];
+
+    final threeYears = service.selectForChart(
+      points,
+      period: InvestmentHistoryPeriod.threeYears,
+      now: now,
+    );
+    final lifetime = service.selectForChart(
+      points.reversed,
+      period: InvestmentHistoryPeriod.lifetime,
+      now: now,
+    );
+
+    expect(threeYears, hasLength(2));
+    expect(lifetime, hasLength(3));
+    expect(lifetime.first.recordedAt, DateTime.utc(2022, 7, 21));
+    expect(lifetime.last.recordedAt, DateTime.utc(2026, 7, 21));
+  });
+
+  test('year cutoff clamps leap day to the final day of February', () {
+    final selected = service.selectForChart(
+      [
+        _point(DateTime.utc(2023, 2, 27, 12)),
+        _point(DateTime.utc(2023, 2, 28, 12)),
+      ],
+      period: InvestmentHistoryPeriod.oneYear,
+      now: DateTime.utc(2024, 2, 29, 12),
+    );
+
+    expect(selected.single.recordedAt, DateTime.utc(2023, 2, 28, 12));
+  });
+
+  test('year cutoff handles the final day of December', () {
+    final selected = service.selectForChart(
+      [
+        _point(DateTime.utc(2025, 12, 30, 12)),
+        _point(DateTime.utc(2025, 12, 31, 12)),
+      ],
+      period: InvestmentHistoryPeriod.oneYear,
+      now: DateTime.utc(2026, 12, 31, 12),
+    );
+
+    expect(selected.single.recordedAt, DateTime.utc(2025, 12, 31, 12));
+  });
+
+  test('downsampling preserves both endpoints and the point budget', () {
+    const compact = InvestmentPortfolioHistoryService(maxChartPoints: 5);
+    final points = [
+      for (var day = 1; day <= 10; day++) _point(DateTime.utc(2026, 7, day)),
+    ];
+
+    final selected = compact.selectForChart(
+      points,
+      period: InvestmentHistoryPeriod.lifetime,
+      now: now,
+    );
+
+    expect(selected, hasLength(5));
+    expect(selected.first.recordedAt, points.first.recordedAt);
+    expect(selected.last.recordedAt, points.last.recordedAt);
+  });
+
+  test('omits snapshots where no holding has a market price', () {
+    final selected = service.selectForChart(
+      [
+        InvestmentPortfolioHistoryPoint(
+          recordedAt: DateTime.utc(2026, 7, 20),
+          marketValueJpy: 0,
+          acquisitionCostJpy: 0,
+          pricedAssetCount: 0,
+          unpricedAssetCount: 2,
+        ),
+        _point(DateTime.utc(2026, 7, 21)),
+      ],
+      period: InvestmentHistoryPeriod.oneYear,
+      now: now,
+    );
+
+    expect(selected, hasLength(1));
+    expect(selected.single.recordedAt, DateTime.utc(2026, 7, 21));
+  });
+
+  test('rejects an invalid chart point budget', () {
+    const invalid = InvestmentPortfolioHistoryService(maxChartPoints: 1);
+
+    expect(
+      () => invalid.selectForChart(
+        const [],
+        period: InvestmentHistoryPeriod.lifetime,
+        now: now,
+      ),
+      throwsStateError,
+    );
+  });
+}
+
+InvestmentPortfolioHistoryPoint _point(DateTime recordedAt) {
+  return InvestmentPortfolioHistoryPoint(
+    recordedAt: recordedAt,
+    marketValueJpy: 1200,
+    acquisitionCostJpy: 1000,
+    pricedAssetCount: 1,
+    unpricedAssetCount: 0,
+  );
+}

--- a/test/widgets/investment_asset_management_panel_test.dart
+++ b/test/widgets/investment_asset_management_panel_test.dart
@@ -1,6 +1,8 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/models/investment_asset.dart';
+import 'package:my_web_app/models/investment_portfolio_history.dart';
 import 'package:my_web_app/services/investment_asset_repository.dart';
 import 'package:my_web_app/widgets/investment_asset_management_panel.dart';
 
@@ -71,6 +73,66 @@ void main() {
 
     expect(find.byKey(const Key('investment_asset_empty')), findsOne);
     expect(repository.fetchCalls, 2);
+  });
+
+  testWidgets('retries a history error without hiding holdings', (
+    tester,
+  ) async {
+    final repository = _FakeInvestmentAssetRepository([
+      _asset(
+        id: 'asset-1',
+        ticker: 'AAPL',
+        quantity: 2,
+        buyPriceJpy: 1000,
+        currentPriceJpy: 1200,
+      ),
+    ])
+      ..historyFetchError = Exception('temporary history failure');
+
+    await _pumpPanel(tester, repository: repository, userId: 'user-1');
+
+    expect(find.text('AAPL'), findsOne);
+    expect(find.byKey(const Key('investment_history_load_error')), findsOne);
+    expect(repository.historyFetchCalls, 1);
+
+    repository.historyFetchError = null;
+    await tester.tap(find.byTooltip('推移を再読み込み'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('investment_history_empty')), findsOne);
+    expect(repository.historyFetchCalls, 2);
+  });
+
+  testWidgets('filters portfolio history when the period changes', (
+    tester,
+  ) async {
+    final repository = _FakeInvestmentAssetRepository(
+      [
+        _asset(
+          id: 'asset-1',
+          ticker: 'AAPL',
+          quantity: 2,
+          buyPriceJpy: 1000,
+          currentPriceJpy: 1200,
+        ),
+      ],
+      history: [
+        _historyPoint(DateTime.utc(2024, 7, 21)),
+        _historyPoint(DateTime.utc(2026, 7, 21)),
+      ],
+    );
+
+    await _pumpPanel(
+      tester,
+      repository: repository,
+      userId: 'user-1',
+      now: () => DateTime.utc(2026, 7, 21),
+    );
+
+    expect(_marketSpotCount(tester), 1);
+    await tester.tap(find.text('3年'));
+    await tester.pumpAndSettle();
+    expect(_marketSpotCount(tester), 2);
   });
 
   testWidgets('clears holdings when the user logs out', (tester) async {
@@ -200,6 +262,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(repository.deleteCalls, 1);
+    expect(repository.historyFetchCalls, 5);
     expect(
       find.byKey(const ValueKey<String>('investment_asset_asset-1')),
       findsNothing,
@@ -212,6 +275,7 @@ Future<void> _pumpPanel(
   WidgetTester tester, {
   required InvestmentAssetRepository repository,
   required String? userId,
+  DateTime Function()? now,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -222,6 +286,7 @@ Future<void> _pumpPanel(
             child: InvestmentAssetManagementPanel(
               repository: repository,
               userId: userId,
+              now: now,
             ),
           ),
         ),
@@ -229,6 +294,11 @@ Future<void> _pumpPanel(
     ),
   );
   await tester.pumpAndSettle();
+}
+
+int _marketSpotCount(WidgetTester tester) {
+  final chart = tester.widget<LineChart>(find.byType(LineChart));
+  return chart.data.lineBarsData.first.spots.length;
 }
 
 InvestmentAsset _asset({
@@ -255,17 +325,23 @@ InvestmentAsset _asset({
 }
 
 class _FakeInvestmentAssetRepository implements InvestmentAssetRepository {
-  _FakeInvestmentAssetRepository(Iterable<InvestmentAsset> seed)
-      : assets = seed.toList();
+  _FakeInvestmentAssetRepository(
+    Iterable<InvestmentAsset> seed, {
+    Iterable<InvestmentPortfolioHistoryPoint> history = const [],
+  })  : assets = seed.toList(),
+        history = history.toList();
 
   final List<InvestmentAsset> assets;
+  final List<InvestmentPortfolioHistoryPoint> history;
   int fetchCalls = 0;
   int createCalls = 0;
   int updateCalls = 0;
   int deleteCalls = 0;
+  int historyFetchCalls = 0;
   InvestmentAssetDraft? lastCreatedDraft;
   InvestmentAssetDraft? lastUpdatedDraft;
   Exception? fetchError;
+  Exception? historyFetchError;
 
   @override
   Future<List<InvestmentAsset>> fetchByUser({required String userId}) async {
@@ -273,6 +349,16 @@ class _FakeInvestmentAssetRepository implements InvestmentAssetRepository {
     final error = fetchError;
     if (error != null) throw error;
     return List<InvestmentAsset>.from(assets);
+  }
+
+  @override
+  Future<List<InvestmentPortfolioHistoryPoint>> fetchPortfolioHistory({
+    required String userId,
+  }) async {
+    historyFetchCalls++;
+    final error = historyFetchError;
+    if (error != null) throw error;
+    return List<InvestmentPortfolioHistoryPoint>.from(history);
   }
 
   @override
@@ -306,6 +392,16 @@ class _FakeInvestmentAssetRepository implements InvestmentAssetRepository {
     deleteCalls++;
     assets.removeWhere((asset) => asset.id == assetId);
   }
+}
+
+InvestmentPortfolioHistoryPoint _historyPoint(DateTime recordedAt) {
+  return InvestmentPortfolioHistoryPoint(
+    recordedAt: recordedAt,
+    marketValueJpy: 2400,
+    acquisitionCostJpy: 2000,
+    pricedAssetCount: 1,
+    unpricedAssetCount: 0,
+  );
 }
 
 InvestmentAsset _fromDraft({

--- a/test/widgets/investment_portfolio_history_chart_test.dart
+++ b/test/widgets/investment_portfolio_history_chart_test.dart
@@ -1,0 +1,114 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/models/investment_portfolio_history.dart';
+import 'package:my_web_app/services/investment_portfolio_history_service.dart';
+import 'package:my_web_app/widgets/investment_portfolio_history_chart.dart';
+
+void main() {
+  testWidgets('renders market values and acquisition-cost baseline', (
+    tester,
+  ) async {
+    await _pumpChart(tester, points: [_point(1, 1200), _point(2, 1500)]);
+
+    final chart = tester.widget<LineChart>(find.byType(LineChart));
+    expect(chart.data.lineBarsData, hasLength(2));
+    expect(chart.data.lineBarsData.first.spots.map((spot) => spot.y), [
+      1200,
+      1500,
+    ]);
+    expect(chart.data.lineBarsData.last.spots.map((spot) => spot.y), [
+      1000,
+      1000,
+    ]);
+    expect(chart.data.lineBarsData.last.dashArray, [6, 4]);
+    expect(find.text('評価額'), findsOne);
+    expect(find.text('取得額'), findsOne);
+    expect(
+      find.byKey(const Key('investment_history_dashed_legend')),
+      findsOne,
+    );
+  });
+
+  testWidgets('keeps a single-point chart and tooltip bounds safe', (
+    tester,
+  ) async {
+    await _pumpChart(tester, points: [_point(1, 1200)]);
+
+    final chart = tester.widget<LineChart>(find.byType(LineChart));
+    expect(chart.data.maxX, 1);
+    expect(chart.data.lineBarsData.first.spots, hasLength(1));
+    final tooltip = chart.data.lineTouchData.touchTooltipData.getTooltipItems;
+    final outsideSpot = LineBarSpot(
+      chart.data.lineBarsData.first,
+      0,
+      const FlSpot(1, 1200),
+    );
+
+    expect(tooltip([outsideSpot]), [isNull]);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('emits all three period selections', (tester) async {
+    final selections = <InvestmentHistoryPeriod>[];
+    await _pumpChart(
+      tester,
+      points: [_point(1, 1200)],
+      onPeriodChanged: selections.add,
+    );
+
+    await tester.tap(find.text('3年'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('全期間'));
+    await tester.pumpAndSettle();
+
+    expect(selections, [
+      InvestmentHistoryPeriod.threeYears,
+      InvestmentHistoryPeriod.lifetime,
+    ]);
+  });
+
+  testWidgets('keeps period controls visible when history is empty', (
+    tester,
+  ) async {
+    await _pumpChart(tester, points: const []);
+
+    expect(find.byKey(const Key('investment_history_empty')), findsOne);
+    expect(find.text('1年'), findsOne);
+    expect(find.text('3年'), findsOne);
+    expect(find.text('全期間'), findsOne);
+    expect(find.byType(LineChart), findsNothing);
+  });
+}
+
+Future<void> _pumpChart(
+  WidgetTester tester, {
+  required List<InvestmentPortfolioHistoryPoint> points,
+  ValueChanged<InvestmentHistoryPeriod>? onPeriodChanged,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 520,
+          child: InvestmentPortfolioHistoryChart(
+            points: points,
+            period: InvestmentHistoryPeriod.oneYear,
+            onPeriodChanged: onPeriodChanged ?? (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+InvestmentPortfolioHistoryPoint _point(int day, double marketValue) {
+  return InvestmentPortfolioHistoryPoint(
+    recordedAt: DateTime.utc(2026, 7, day),
+    marketValueJpy: marketValue,
+    acquisitionCostJpy: 1000,
+    pricedAssetCount: 1,
+    unpricedAssetCount: 0,
+  );
+}


### PR DESCRIPTION
﻿## Summary
- add deterministic daily `investment_portfolio_history` snapshots maintained by `investment_assets` triggers with owner-only RLS
- page complete history reads past PostgREST's 1000-row cap, then filter/downsample 1y, 3y, and lifetime windows deterministically
- render evaluation value and acquisition-cost lines with `fl_chart`, period controls, graceful history-only error handling, and CRUD-triggered refresh

## Validation
- `flutter test --no-pub --concurrency=1 test/services/investment_portfolio_history_service_test.dart`
- `flutter test --no-pub --concurrency=1 test/services/investment_portfolio_history_schema_test.dart`
- `flutter test --no-pub --concurrency=1 test/widgets/investment_portfolio_history_chart_test.dart`
- `flutter test --no-pub --concurrency=1 test/widgets/investment_asset_management_panel_test.dart`
- `git diff --check`
- Claude Code #1 review completed; PostgREST paging, tooltip bounds, dashed legend, December cutoff, and retry/CRUD regression coverage were addressed

Full local `flutter analyze` was resource-blocked by concurrent Flutter lanes; GitHub Actions is the authoritative Flutter 3.38 analyze/format/build gate for this PR.

Closes #2469
## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 completed a read-only staged-diff review; the interactive slash ultrareview command is unavailable in this noninteractive lane.
- Security: owner-only RLS, a fixed empty search path, and trigger-only history writes were reviewed.
- Rollback: drop the three investment asset history triggers, then the capture function and history table; the existing holdings table remains intact.
- Data migration: deployment backfills one current daily snapshot per existing user and keeps one row per user/day.
- Prod smoke: verify migration application, own-user history reads, cross-user denial, and snapshot refresh after investment CRUD.
- Observability: migration/deploy logs plus the panel's isolated history error and retry state expose failures without hiding holdings.
- Unresolved findings: none.

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Repository-injected user-visible widget tests cover period switching, empty, error, recovery, and CRUD refresh; DB smoke and schema gates cover persistence boundaries.
