### PR TITLE
feat(asset): 日次異常検知スキャン cron + scan_all バッチaction (第2弾D #2478)

### DIFF
--- a/.github/workflows/daily-anomaly-scan.yml
+++ b/.github/workflows/daily-anomaly-scan.yml
@@ -1,0 +1,100 @@
+name: Daily Anomaly Scan (資産管理・毎日03:00 JST)
+
+# Issue #2478 [資産管理][第2弾D]: 全 active user のカテゴリ別支出を
+# ai-hub asset.anomaly.scan_all (service_role 限定 / #2477) で日次スキャンする。
+# 対象月は EF 既定 = JST の前の完了月 (当月は集計途中のため対象にしない)。
+# 段階的 rollout: schedule 実行は repo variable ANOMALY_SCAN_CRON_ENABLED=true
+# を設定するまで no-op (monthly-asset-report と同じ規約)。
+
+on:
+  schedule:
+    - cron: "0 18 * * *" # 18:00 UTC = 03:00 JST
+  workflow_dispatch:
+    inputs:
+      target_month:
+        description: "Optional target month (YYYY-MM). Defaults to the previous JST month."
+        required: false
+        default: ""
+      dry_run:
+        description: "true=検知のみ(DB書込なし)"
+        required: false
+        default: "true"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daily-anomaly-scan
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Scan all active users
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD || 'https://smmkxxavexumewbfaqpy.supabase.co' }}
+      CRON_ENABLED: ${{ github.event_name == 'workflow_dispatch' && 'true' || vars.ANOMALY_SCAN_CRON_ENABLED || 'false' }}
+      TARGET_MONTH: ${{ github.event_name == 'workflow_dispatch' && inputs.target_month || '' }}
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+
+    steps:
+      - name: Gate scheduled runs until rollout variable is set
+        if: env.CRON_ENABLED != 'true'
+        run: |
+          echo "ANOMALY_SCAN_CRON_ENABLED != true → skip (staged rollout, #2478)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Call asset.anomaly.scan_all (retry x3)
+        if: env.CRON_ENABLED == 'true'
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg action "asset.anomaly.scan_all" \
+            --arg target_month "$TARGET_MONTH" \
+            --argjson dry_run "$([ "$DRY_RUN" = "true" ] && echo true || echo false)" \
+            '{action: $action, dry_run: $dry_run}
+             + (if $target_month != "" then {target_month: $target_month} else {} end)')
+
+          ATTEMPTS=3
+          for i in $(seq 1 $ATTEMPTS); do
+            echo "attempt $i/$ATTEMPTS"
+            set +e
+            RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X POST \
+              -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" \
+              "$SUPABASE_URL/functions/v1/ai-hub" \
+              --max-time 120)
+            CURL_EXIT=$?
+            set -e
+            HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+            BODY=$(echo "$RESPONSE" | head -n -1)
+            echo "HTTP: $HTTP_CODE (curl exit $CURL_EXIT)"
+            echo "$BODY" | jq . || echo "$BODY"
+
+            if [ "$CURL_EXIT" -eq 0 ] && [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+              {
+                echo "## Daily Anomaly Scan"
+                echo "- target_month: $(echo "$BODY" | jq -r '.target_month // "?"')"
+                echo "- dry_run: $(echo "$BODY" | jq -r '.dry_run // false')"
+                echo "- users_scanned: $(echo "$BODY" | jq -r '.users_scanned // 0')"
+                echo "- users_failed: $(echo "$BODY" | jq -r '.users_failed // 0')"
+                echo "- anomalies_total: $(echo "$BODY" | jq -r '.anomalies_total // 0')"
+              } >> "$GITHUB_STEP_SUMMARY"
+              FAILED=$(echo "$BODY" | jq -r '.users_failed // 0')
+              if [ "$FAILED" -gt 0 ]; then
+                echo "::warning::users_failed=$FAILED (see EF response failures[])"
+              fi
+              exit 0
+            fi
+
+            # 4xx は設定/認可の問題 = リトライしても直らないので即 fail
+            if [ "$CURL_EXIT" -eq 0 ] && [ "$HTTP_CODE" -ge 400 ] && [ "$HTTP_CODE" -lt 500 ]; then
+              echo "::error::HTTP $HTTP_CODE (non-retriable)"
+              exit 1
+            fi
+            [ "$i" -lt "$ATTEMPTS" ] && sleep 30
+          done
+          echo "::error::scan failed after $ATTEMPTS attempts"
+          exit 1

--- a/.github/workflows/workflow-failure-handler.yml
+++ b/.github/workflows/workflow-failure-handler.yml
@@ -26,6 +26,7 @@ on:
       - "Edge Function UI Audit (UI導線チェック)"
       - "GitHub Issue Fix"
       - "Self Devin Schedule"
+      - "Daily Anomaly Scan (資産管理・毎日03:00 JST)"
       # Schedule: competitor / AI
       - "Competitor Monitoring (競合インテリジェンスレポート)"
       - "Competitor Discovery (週次自動候補発掘)"

--- a/supabase/functions/ai-hub/anomaly_detection.ts
+++ b/supabase/functions/ai-hub/anomaly_detection.ts
@@ -315,19 +315,17 @@ async function fetchExpenseRows(
   return rows;
 }
 
-export async function handleDetectAnomaliesAction(options: {
+/** 1 ユーザー分の検知 + 永続化 (単発 action と scan_all の共通コア)。 */
+async function scanUserForMonth(options: {
   db: AnomalyDetectionDb;
-  body: UnknownRecord;
   userId: string;
-  explanationEnabled?: boolean;
+  targetMonth: string;
+  nowIso: string;
+  dryRun: boolean;
+  explanationEnabled: boolean;
   invokeProvider?: AnomalyProviderInvoker;
-  nowIso?: string;
-}): Promise<DetectAnomaliesResult> {
-  if (!options.userId) {
-    throw new AnomalyDetectionError("login required", 401);
-  }
-  const nowIso = options.nowIso ?? new Date().toISOString();
-  const targetMonth = resolveTargetMonth(nowIso, options.body.target_month);
+}): Promise<{ outcome: AnomalyScanOutcome; warnings: string[] }> {
+  const targetMonth = options.targetMonth;
   const nextMonth = addMonths(targetMonth, 1);
   const windowStart = addMonths(targetMonth, -PRIOR_MONTHS);
   const warnings: string[] = [];
@@ -340,11 +338,11 @@ export async function handleDetectAnomaliesAction(options: {
   );
   const outcome = computeCategoryAnomalies({ rows, targetMonth });
 
-  const explanationEnabled = options.explanationEnabled === true;
-  if (explanationEnabled && options.invokeProvider) {
+  const invoke = options.invokeProvider;
+  if (options.explanationEnabled && invoke) {
     for (const anomaly of outcome.anomalies.slice(0, EXPLANATION_CAP)) {
       try {
-        const result = await options.invokeProvider({
+        const result = await invoke({
           provider: "gemini",
           messages: buildExplanationPrompt(anomaly, targetMonth),
         });
@@ -367,31 +365,59 @@ export async function handleDetectAnomaliesAction(options: {
     }
   }
 
-  for (const anomaly of outcome.anomalies) {
-    // 同一 (user, category, target_month) は upsert で更新のみ。
-    // dismissed_at は供給しない = ユーザーの既読/却下を再スキャンで復活させない。
-    const { error } = await options.db.from("anomaly_detections").upsert(
-      {
-        user_id: options.userId,
-        target_month: targetMonth,
-        category: anomaly.category,
-        expected: anomaly.expected,
-        actual: anomaly.actual,
-        delta: anomaly.delta,
-        severity: anomaly.severity,
-        ai_explanation: anomaly.ai_explanation,
-        detected_at: nowIso,
-      },
-      { onConflict: "user_id,category,target_month" },
-    );
-    if (error) {
-      throw new AnomalyDetectionError(
-        `anomaly_detections upsert failed: ${error.message ?? "unknown"}`,
-        500,
+  if (!options.dryRun) {
+    for (const anomaly of outcome.anomalies) {
+      // 同一 (user, category, target_month) は upsert で更新のみ。
+      // dismissed_at は供給しない = ユーザーの既読/却下を再スキャンで復活させない。
+      const { error } = await options.db.from("anomaly_detections").upsert(
+        {
+          user_id: options.userId,
+          target_month: targetMonth,
+          category: anomaly.category,
+          expected: anomaly.expected,
+          actual: anomaly.actual,
+          delta: anomaly.delta,
+          severity: anomaly.severity,
+          ai_explanation: anomaly.ai_explanation,
+          detected_at: options.nowIso,
+        },
+        { onConflict: "user_id,category,target_month" },
       );
+      if (error) {
+        throw new AnomalyDetectionError(
+          `anomaly_detections upsert failed: ${error.message ?? "unknown"}`,
+          500,
+        );
+      }
     }
   }
 
+  return { outcome, warnings };
+}
+
+export async function handleDetectAnomaliesAction(options: {
+  db: AnomalyDetectionDb;
+  body: UnknownRecord;
+  userId: string;
+  explanationEnabled?: boolean;
+  invokeProvider?: AnomalyProviderInvoker;
+  nowIso?: string;
+}): Promise<DetectAnomaliesResult> {
+  if (!options.userId) {
+    throw new AnomalyDetectionError("login required", 401);
+  }
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const targetMonth = resolveTargetMonth(nowIso, options.body.target_month);
+  const explanationEnabled = options.explanationEnabled === true;
+  const { outcome, warnings } = await scanUserForMonth({
+    db: options.db,
+    userId: options.userId,
+    targetMonth,
+    nowIso,
+    dryRun: options.body.dry_run === true,
+    explanationEnabled,
+    invokeProvider: options.invokeProvider,
+  });
   return {
     status: "ok",
     target_month: targetMonth,
@@ -400,5 +426,107 @@ export async function handleDetectAnomaliesAction(options: {
     skipped: outcome.skipped,
     explanation_enabled: explanationEnabled,
     warnings,
+  };
+}
+
+export type ScanAllResult = {
+  status: "ok";
+  target_month: string;
+  dry_run: boolean;
+  users_scanned: number;
+  users_failed: number;
+  anomalies_total: number;
+  skipped_total: number;
+  failures: { user_id: string; error: string }[];
+};
+
+const FAILURE_LIST_CAP = 10;
+
+/** 対象窓に支出記録がある = active user。paged select + client-side dedupe。 */
+async function fetchActiveUserIds(
+  db: AnomalyDetectionDb,
+  windowStart: string,
+  nextMonth: string,
+): Promise<string[]> {
+  const ids = new Set<string>();
+  for (let page = 0; page < 200; page++) {
+    const from = page * PAGE_SIZE;
+    const { data, error } = await db
+      .from("expense_classifications")
+      .select("user_id")
+      .neq("status", "rejected")
+      .gte("posted_at", windowStart)
+      .lt("posted_at", nextMonth)
+      .order("user_id", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+    if (error) {
+      throw new AnomalyDetectionError(
+        `active user enumeration failed: ${error.message ?? "unknown"}`,
+        500,
+      );
+    }
+    const batch = (data ?? []) as UnknownRecord[];
+    for (const raw of batch) {
+      const id = String(raw.user_id ?? "");
+      if (id) ids.add(id);
+    }
+    if (batch.length < PAGE_SIZE) break;
+  }
+  return [...ids].sort();
+}
+
+/**
+ * 全 active user への日次スキャン (#2478 / daily-anomaly-scan.yml から
+ * service_role で呼ばれる)。LLM 説明はバッチではコスト制御のため常に OFF
+ * (単発 action 側の flag 経路のみ)。ユーザー単位で失敗を隔離して続行する。
+ */
+export async function handleScanAllAction(options: {
+  db: AnomalyDetectionDb;
+  body: UnknownRecord;
+  nowIso?: string;
+}): Promise<ScanAllResult> {
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const targetMonth = resolveTargetMonth(nowIso, options.body.target_month);
+  const dryRun = options.body.dry_run === true;
+  const windowStart = addMonths(targetMonth, -PRIOR_MONTHS);
+  const nextMonth = addMonths(targetMonth, 1);
+
+  const userIds = await fetchActiveUserIds(options.db, windowStart, nextMonth);
+  let anomaliesTotal = 0;
+  let skippedTotal = 0;
+  const failures: { user_id: string; error: string }[] = [];
+  let usersScanned = 0;
+
+  for (const userId of userIds) {
+    try {
+      const { outcome } = await scanUserForMonth({
+        db: options.db,
+        userId,
+        targetMonth,
+        nowIso,
+        dryRun,
+        explanationEnabled: false,
+      });
+      usersScanned += 1;
+      anomaliesTotal += outcome.anomalies.length;
+      skippedTotal += outcome.skipped.length;
+    } catch (err) {
+      failures.push({
+        user_id: userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return {
+    status: "ok",
+    target_month: targetMonth,
+    dry_run: dryRun,
+    users_scanned: usersScanned,
+    users_failed: failures.length,
+    anomalies_total: anomaliesTotal,
+    skipped_total: skippedTotal,
+    failures: failures.slice(0, FAILURE_LIST_CAP),
   };
 }

--- a/supabase/functions/ai-hub/anomaly_detection_test.ts
+++ b/supabase/functions/ai-hub/anomaly_detection_test.ts
@@ -5,6 +5,7 @@ import {
   type AnomalyExpenseRow,
   computeCategoryAnomalies,
   handleDetectAnomaliesAction,
+  handleScanAllAction,
   resolveTargetMonth,
   severityFor,
 } from "./anomaly_detection.ts";
@@ -323,4 +324,152 @@ Deno.test("provider failure downgrades to warning, detection still persists", as
   assertEquals(result.anomalies[0].ai_explanation, null);
   assertEquals(result.warnings.length, 1);
   assertEquals(db.upserts.length, 1);
+});
+
+// ---- scan_all (#2478) ----
+
+function urow(
+  user: string,
+  posted: string,
+  amount: number,
+  category: string,
+  status = "auto_confirmed",
+): Record<string, unknown> {
+  return { user_id: user, posted_at: posted, amount, category, status };
+}
+
+type RowPredicate = (r: Record<string, unknown>) => boolean;
+
+class FilteringFakeQuery implements AnomalyDbQuery {
+  private filters: RowPredicate[] = [];
+
+  constructor(
+    private readonly table: string,
+    private readonly db: FilteringFakeDb,
+  ) {}
+
+  select(): AnomalyDbQuery {
+    return this;
+  }
+  eq(column: string, value: string): AnomalyDbQuery {
+    this.filters.push((r) => String(r[column] ?? "") === value);
+    return this;
+  }
+  neq(column: string, value: string): AnomalyDbQuery {
+    this.filters.push((r) => String(r[column] ?? "") !== value);
+    return this;
+  }
+  gte(column: string, value: string): AnomalyDbQuery {
+    this.filters.push((r) => String(r[column] ?? "") >= value);
+    return this;
+  }
+  lt(column: string, value: string): AnomalyDbQuery {
+    this.filters.push((r) => String(r[column] ?? "") < value);
+    return this;
+  }
+  order(): AnomalyDbQuery {
+    return this;
+  }
+  range(from: number, to: number) {
+    const rows = this.db
+      .rowsFor(this.table)
+      .filter((r) => this.filters.every((f) => f(r)));
+    return Promise.resolve({ data: rows.slice(from, to + 1), error: null });
+  }
+  upsert(
+    value: Record<string, unknown>,
+    options?: { onConflict?: string },
+  ) {
+    if (this.db.failUpsertUserIds.has(String(value.user_id ?? ""))) {
+      return Promise.resolve({ error: { message: "forced upsert failure" } });
+    }
+    this.db.upserts.push({
+      table: this.table,
+      value,
+      onConflict: options?.onConflict ?? "",
+    });
+    return Promise.resolve({ error: null });
+  }
+}
+
+class FilteringFakeDb implements AnomalyDetectionDb {
+  upserts: Array<{
+    table: string;
+    value: Record<string, unknown>;
+    onConflict: string;
+  }> = [];
+  failUpsertUserIds = new Set<string>();
+
+  constructor(
+    private readonly rows: Record<string, Record<string, unknown>[]>,
+  ) {}
+
+  from(table: string): AnomalyDbQuery {
+    return new FilteringFakeQuery(table, this);
+  }
+
+  rowsFor(table: string) {
+    return this.rows[table] ?? [];
+  }
+}
+
+function twoUserRows(): Record<string, unknown>[] {
+  return [
+    urow("user-a", "2026-03-05", 30000, "food"),
+    urow("user-a", "2026-04-05", 30000, "food"),
+    urow("user-a", "2026-05-05", 30000, "food"),
+    urow("user-a", "2026-06-05", 60000, "food"),
+    urow("user-b", "2026-03-05", 30000, "food"),
+    urow("user-b", "2026-04-05", 30000, "food"),
+    urow("user-b", "2026-05-05", 30000, "food"),
+    urow("user-b", "2026-06-05", 30000, "food"),
+  ];
+}
+
+Deno.test("handleScanAllAction scans distinct users and aggregates", async () => {
+  const db = new FilteringFakeDb({ expense_classifications: twoUserRows() });
+  const result = await handleScanAllAction({
+    db,
+    body: { target_month: "2026-06" },
+    nowIso: "2026-07-22T03:00:00Z",
+  });
+  assertEquals(result.status, "ok");
+  assertEquals(result.target_month, "2026-06-01");
+  assertEquals(result.dry_run, false);
+  assertEquals(result.users_scanned, 2);
+  assertEquals(result.users_failed, 0);
+  assertEquals(result.anomalies_total, 1);
+  assertEquals(db.upserts.length, 1);
+  assertEquals(db.upserts[0].value.user_id, "user-a");
+});
+
+Deno.test("handleScanAllAction dry_run computes but persists nothing", async () => {
+  const db = new FilteringFakeDb({ expense_classifications: twoUserRows() });
+  const result = await handleScanAllAction({
+    db,
+    body: { target_month: "2026-06", dry_run: true },
+    nowIso: "2026-07-22T03:00:00Z",
+  });
+  assertEquals(result.dry_run, true);
+  assertEquals(result.anomalies_total, 1);
+  assertEquals(db.upserts.length, 0);
+});
+
+Deno.test("handleScanAllAction isolates per-user failures", async () => {
+  const rows = twoUserRows();
+  // user-b にも異常を持たせ、user-a の書込だけ失敗させて隔離を検証する。
+  rows[7] = urow("user-b", "2026-06-05", 60000, "food");
+  const db = new FilteringFakeDb({ expense_classifications: rows });
+  db.failUpsertUserIds.add("user-a");
+  const result = await handleScanAllAction({
+    db,
+    body: { target_month: "2026-06" },
+    nowIso: "2026-07-22T03:00:00Z",
+  });
+  assertEquals(result.users_scanned, 1);
+  assertEquals(result.users_failed, 1);
+  assertEquals(result.failures[0].user_id, "user-a");
+  assertEquals(result.anomalies_total, 1);
+  assertEquals(db.upserts.length, 1);
+  assertEquals(db.upserts[0].value.user_id, "user-b");
 });

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -73,6 +73,7 @@ import {
   type AnomalyDetectionDb,
   AnomalyDetectionError,
   handleDetectAnomaliesAction,
+  handleScanAllAction,
 } from "./anomaly_detection.ts";
 import {
   handleMarketPriceAction,
@@ -4835,6 +4836,23 @@ serve(async (req: Request) => {
               request.model,
             );
           },
+        });
+        return json({ success: true, ...result });
+      }
+
+      case "asset.anomaly.scan_all": {
+        // daily-anomaly-scan.yml (cron) 専用: schedule-hub の service_role
+        // レベルと同じく Bearer === SERVICE_ROLE_KEY の生比較で認可する
+        // (service role JWT は auth.getUser() で user にならないため
+        //  authRequired リストでは扱えない)。
+        const bearer = (req.headers.get("Authorization") ?? "")
+          .replace(/^Bearer\s+/i, "");
+        if (!SERVICE_ROLE_KEY || bearer !== SERVICE_ROLE_KEY) {
+          return json({ error: "Unauthorized" }, 401);
+        }
+        const result = await handleScanAllAction({
+          db: admin as unknown as AnomalyDetectionDb,
+          body,
         });
         return json({ success: true, ...result });
       }


### PR DESCRIPTION
## Summary

Issue #2478 [資産管理][第2弾D] daily anomaly scan cron — 第2弾Dの最終ピースです。

- **EF**: `asset.anomaly.scan_all` を ai-hub に追加 (schedule-hub と同じ `Bearer === SERVICE_ROLE_KEY` 生比較で認可 / #2477 の検知コアを共通化して全 active user を走査 / per-user 失敗隔離 / `dry_run` 対応 / バッチでは LLM 説明常時 OFF)
- **active user 定義**: 対象窓 (直近3月+対象月) に `expense_classifications` の非 rejected 行があるユーザー (paged enumeration + id タイエブレーカ)
- **GHA**: `daily-anomaly-scan.yml` (03:00 JST) — retry×3 (5xx/ネットワークのみ、4xx は即 fail) + step summary。**schedule 実行は repo variable `ANOMALY_SCAN_CRON_ENABLED=true` を設定するまで no-op** (monthly-asset-report と同じ段階的 rollout 規約)
- **失敗時 notify**: `workflow-failure-handler.yml` の監視リストに登録
- **deno test**: 16 件 (scan_all の集約 / dry_run 非永続 / 失敗隔離 3 件追加)

Closes #2478

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: service_role-only batch EF action + cron workflow, no user-facing I/O path (Deno EF)

## High-Risk Ultrareview

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: additive batch action reusing merged #4245 detection core; service-role raw-compare auth mirrors schedule-hub convention; cron gated OFF by default via repo variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
