### PR TITLE
feat: automate daily anomaly scans for #2478

### DIFF
--- a/.github/workflows/daily-anomaly-scan.yml
+++ b/.github/workflows/daily-anomaly-scan.yml
@@ -1,0 +1,125 @@
+name: Daily Anomaly Scan
+
+on:
+  schedule:
+    # 03:00 JST daily.
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+    inputs:
+      user_id:
+        description: "Optional single Supabase Auth user UUID."
+        required: false
+        default: ""
+      target_month:
+        description: "Optional target month (YYYY-MM). Defaults to previous complete JST month."
+        required: false
+        default: ""
+      confirm_all_users:
+        description: "Required for a manual all-user scan."
+        required: true
+        type: boolean
+        default: false
+      max_attempts:
+        description: "Attempts per user (1-5)."
+        required: true
+        default: "3"
+      workers:
+        description: "Parallel user scans (1-16)."
+        required: true
+        default: "4"
+  pull_request:
+    paths:
+      - ".github/workflows/daily-anomaly-scan.yml"
+      - "scripts/daily_anomaly_scan.py"
+      - "scripts/daily_anomaly_scan_test.py"
+      - "supabase/functions/ai-hub/anomaly_detection.ts"
+      - "supabase/functions/ai-hub/anomaly_detection_test.ts"
+      - "supabase/functions/ai-hub/index.ts"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daily-anomaly-scan-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'scheduled' }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate daily anomaly scheduler
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run scheduler unit tests
+        run: python scripts/daily_anomaly_scan_test.py
+
+      - name: Run anomaly detection contract tests
+        run: deno test supabase/functions/ai-hub/anomaly_detection_test.ts
+
+  scan:
+    name: Scan eligible users
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD || 'https://smmkxxavexumewbfaqpy.supabase.co' }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      CRON_ENABLED: ${{ vars.DAILY_ANOMALY_SCAN_ENABLED || 'false' }}
+      USER_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.user_id || '' }}
+      TARGET_MONTH: ${{ github.event_name == 'workflow_dispatch' && inputs.target_month || '' }}
+      CONFIRM_ALL_USERS: ${{ github.event_name == 'workflow_dispatch' && inputs.confirm_all_users || 'false' }}
+      MAX_ATTEMPTS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_attempts || '3' }}
+      WORKERS: ${{ github.event_name == 'workflow_dispatch' && inputs.workers || '4' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Run daily anomaly scan
+        env:
+          MANUAL_RUN: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
+        run: |
+          mkdir -p tmp/daily-anomaly-scan
+          set +e
+          python scripts/daily_anomaly_scan.py \
+            --supabase-url "$SUPABASE_URL" \
+            --cron-enabled "$CRON_ENABLED" \
+            --manual-run "$MANUAL_RUN" \
+            --confirm-all-users "$CONFIRM_ALL_USERS" \
+            --user-id "$USER_ID" \
+            --target-month "$TARGET_MONTH" \
+            --max-attempts "$MAX_ATTEMPTS" \
+            --workers "$WORKERS" \
+            --report tmp/daily-anomaly-scan/report.json \
+            --summary-md tmp/daily-anomaly-scan/summary.md
+          exit_code=$?
+          cat tmp/daily-anomaly-scan/summary.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$exit_code"
+
+      - name: Upload scan report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: daily-anomaly-scan-${{ github.run_id }}
+          path: tmp/daily-anomaly-scan
+          if-no-files-found: ignore
+          retention-days: 14

--- a/docs/issue-fix-plans/issue-2478.md
+++ b/docs/issue-fix-plans/issue-2478.md
@@ -1,0 +1,32 @@
+# Issue #2478: Daily anomaly scan cron
+
+## Scope
+
+- Run at 03:00 JST every day when `DAILY_ANOMALY_SCAN_ENABLED=true`.
+- Discover eligible users through Supabase Auth Admin.
+- Invoke `asset.anomaly.detect.scheduled` once per eligible user.
+- Retry transient failures and notify configured Slack/Discord webhooks.
+- Keep AI explanations controlled by the existing Edge Function flag.
+
+## Safety decisions
+
+- The scheduled action requires an exact service-role bearer token and a valid
+  user UUID. The existing user-authenticated action remains unchanged.
+- Deleted, currently banned, anonymous, and malformed Auth users are skipped.
+- Scheduled execution is OFF by default. Manual all-user execution requires an
+  explicit confirmation input; a single-user manual run does not.
+- Reports expose hashed user references instead of raw user UUIDs.
+
+## Validation
+
+- `python scripts/daily_anomaly_scan_test.py`
+- `deno fmt --check supabase/functions/ai-hub/anomaly_detection.ts supabase/functions/ai-hub/anomaly_detection_test.ts supabase/functions/ai-hub/index.ts`
+- `deno test supabase/functions/ai-hub/anomaly_detection_test.ts`
+- GitHub Actions workflow syntax and repository quality gates
+
+## Rollout
+
+1. Merge and deploy `ai-hub` with the scheduled action.
+2. Manually scan one test user with `user_id` and verify the artifact.
+3. Manually scan all users with `confirm_all_users=true`.
+4. Set repository variable `DAILY_ANOMALY_SCAN_ENABLED=true`.

--- a/scripts/daily_anomaly_scan.py
+++ b/scripts/daily_anomaly_scan.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Run the daily asset anomaly scan for eligible Supabase Auth users."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+DEFAULT_SUPABASE_URL = "https://smmkxxavexumewbfaqpy.supabase.co"
+ISSUE = "#2478"
+UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+TARGET_MONTH_PATTERN = re.compile(r"^\d{4}-(0[1-9]|1[0-2])(?:-01)?$")
+
+
+@dataclass(frozen=True)
+class ScanConfig:
+    supabase_url: str
+    service_role_key: str
+    cron_enabled: bool
+    manual_run: bool
+    confirm_all_users: bool
+    user_id: str
+    target_month: str
+    max_attempts: int
+    workers: int
+    timeout: int
+    slack_webhook_url: str
+    discord_webhook_url: str
+
+
+class DailyAnomalyScanError(RuntimeError):
+    pass
+
+
+def parse_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", ""}:
+        return False
+    return default
+
+
+def normalize_base_url(value: str) -> str:
+    return (value or DEFAULT_SUPABASE_URL).rstrip("/")
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def is_eligible_auth_user(user: dict[str, Any], now: datetime) -> bool:
+    user_id = str(user.get("id", "")).strip()
+    if not UUID_PATTERN.fullmatch(user_id):
+        return False
+    if user.get("is_anonymous") is True or user.get("deleted_at"):
+        return False
+    banned_until = parse_timestamp(user.get("banned_until"))
+    return banned_until is None or banned_until <= now.astimezone(timezone.utc)
+
+
+def user_reference(user_id: str) -> str:
+    return hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:12]
+
+
+def get_json(
+    url: str,
+    headers: dict[str, str],
+    timeout: int,
+) -> tuple[int, dict[str, Any]]:
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        body = response.read().decode("utf-8", errors="replace")
+        parsed = json.loads(body) if body.strip() else {}
+        if not isinstance(parsed, dict):
+            raise DailyAnomalyScanError("response must be a JSON object")
+        return int(response.status), parsed
+
+
+def post_json(
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    timeout: int,
+) -> tuple[int, dict[str, Any]]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        body = response.read().decode("utf-8", errors="replace")
+        parsed = json.loads(body) if body.strip() else {}
+        if not isinstance(parsed, dict):
+            raise DailyAnomalyScanError("response must be a JSON object")
+        return int(response.status), parsed
+
+
+def post_webhook(url: str, payload: dict[str, Any], timeout: int) -> None:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        response.read()
+
+
+def auth_headers(config: ScanConfig) -> dict[str, str]:
+    return {
+        "apikey": config.service_role_key,
+        "Authorization": f"Bearer {config.service_role_key}",
+        "Content-Type": "application/json",
+        "User-Agent": "my-web-app-daily-anomaly-scan/1.0",
+    }
+
+
+def list_auth_users(
+    config: ScanConfig,
+    *,
+    requester: Callable[
+        [str, dict[str, str], int], tuple[int, dict[str, Any]]
+    ] = get_json,
+) -> list[dict[str, Any]]:
+    users: list[dict[str, Any]] = []
+    per_page = 1000
+    base_url = normalize_base_url(config.supabase_url)
+    for page in range(1, 101):
+        query = urllib.parse.urlencode({"page": page, "per_page": per_page})
+        _, response = requester(
+            f"{base_url}/auth/v1/admin/users?{query}",
+            auth_headers(config),
+            config.timeout,
+        )
+        raw_users = response.get("users")
+        if not isinstance(raw_users, list):
+            raise DailyAnomalyScanError("Auth Admin response is missing users")
+        batch = [item for item in raw_users if isinstance(item, dict)]
+        users.extend(batch)
+        if len(batch) < per_page:
+            return users
+    raise DailyAnomalyScanError("Auth Admin pagination exceeded 100 pages")
+
+
+def build_scan_payload(config: ScanConfig, user_id: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "action": "asset.anomaly.detect.scheduled",
+        "user_id": user_id,
+    }
+    if config.target_month:
+        payload["target_month"] = config.target_month
+    return payload
+
+
+def should_retry_http(status: int) -> bool:
+    return status == 429 or status >= 500
+
+
+def scan_user(
+    config: ScanConfig,
+    user_id: str,
+    *,
+    requester: Callable[
+        [str, dict[str, Any], dict[str, str], int], tuple[int, dict[str, Any]]
+    ] = post_json,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    endpoint = f"{normalize_base_url(config.supabase_url)}/functions/v1/ai-hub"
+    payload = build_scan_payload(config, user_id)
+    last_reason = "unknown"
+    last_error = ""
+
+    for attempt in range(1, config.max_attempts + 1):
+        retryable = True
+        try:
+            http_status, response = requester(
+                endpoint,
+                payload,
+                auth_headers(config),
+                config.timeout,
+            )
+            if response.get("success") is True and response.get("status") == "ok":
+                return {
+                    "status": "pass",
+                    "user_ref": user_reference(user_id),
+                    "attempts": attempt,
+                    "anomalies_detected": int(response.get("anomalies_detected", 0)),
+                    "warnings": len(response.get("warnings", [])),
+                }
+            last_reason = f"edge_function_http_{http_status}"
+            last_error = str(response.get("error", "edge function returned failure"))[:500]
+            retryable = should_retry_http(http_status) or http_status == 200
+        except urllib.error.HTTPError as exc:
+            last_reason = f"http_{exc.code}"
+            last_error = exc.read().decode("utf-8", errors="replace")[:500]
+            retryable = should_retry_http(exc.code)
+        except Exception as exc:
+            last_reason = "request_error"
+            last_error = str(exc)[:500]
+
+        if attempt < config.max_attempts and retryable:
+            sleeper(float(2 ** (attempt - 1)))
+            continue
+        break
+
+    return {
+        "status": "fail",
+        "user_ref": user_reference(user_id),
+        "attempts": attempt,
+        "reason": last_reason,
+        "error": last_error,
+    }
+
+
+def build_report(
+    config: ScanConfig,
+    *,
+    now: datetime | None = None,
+    user_lister: Callable[[ScanConfig], list[dict[str, Any]]] = list_auth_users,
+    scanner: Callable[[ScanConfig, str], dict[str, Any]] = scan_user,
+) -> dict[str, Any]:
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    base = {
+        "issue": ISSUE,
+        "target_month": config.target_month or "previous_complete_month_jst",
+    }
+
+    if not config.manual_run and not config.cron_enabled:
+        return {**base, "status": "skipped", "reason": "feature_flag_off"}
+    if config.manual_run and not config.user_id and not config.confirm_all_users:
+        return {
+            **base,
+            "status": "skipped",
+            "reason": "manual_all_users_not_confirmed",
+        }
+    if not config.service_role_key:
+        return {
+            **base,
+            "status": "fail",
+            "reason": "missing_SUPABASE_SERVICE_ROLE_KEY",
+        }
+    if config.target_month and not TARGET_MONTH_PATTERN.fullmatch(config.target_month):
+        return {**base, "status": "fail", "reason": "invalid_target_month"}
+
+    if config.user_id:
+        if not UUID_PATTERN.fullmatch(config.user_id):
+            return {**base, "status": "fail", "reason": "invalid_user_id"}
+        user_ids = [config.user_id]
+        discovered_count = 1
+    else:
+        try:
+            users = user_lister(config)
+        except Exception as exc:
+            return {
+                **base,
+                "status": "fail",
+                "reason": "auth_user_list_failed",
+                "error": str(exc)[:500],
+            }
+        discovered_count = len(users)
+        user_ids = sorted(
+            str(user["id"]).strip()
+            for user in users
+            if is_eligible_auth_user(user, current)
+        )
+
+    results: list[dict[str, Any]] = []
+    workers = min(max(config.workers, 1), max(len(user_ids), 1))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(scanner, config, user_id): user_id for user_id in user_ids}
+        for future in as_completed(futures):
+            user_id = futures[future]
+            try:
+                results.append(future.result())
+            except Exception as exc:
+                results.append(
+                    {
+                        "status": "fail",
+                        "user_ref": user_reference(user_id),
+                        "attempts": 1,
+                        "reason": "worker_error",
+                        "error": str(exc)[:500],
+                    }
+                )
+
+    results.sort(key=lambda item: str(item.get("user_ref", "")))
+    failed = [item for item in results if item.get("status") != "pass"]
+    return {
+        **base,
+        "status": "fail" if failed else "pass",
+        "reason": "user_scan_failed" if failed else "all_eligible_users_scanned",
+        "users_discovered": discovered_count,
+        "users_eligible": len(user_ids),
+        "users_succeeded": len(results) - len(failed),
+        "users_failed": len(failed),
+        "anomalies_detected": sum(
+            int(item.get("anomalies_detected", 0)) for item in results
+        ),
+        "results": results,
+    }
+
+
+def build_failure_text(report: dict[str, Any]) -> str:
+    return (
+        f"Daily anomaly scan failed ({ISSUE})\n"
+        f"- reason: {report.get('reason', 'unknown')}\n"
+        f"- eligible: {report.get('users_eligible', 0)}\n"
+        f"- failed: {report.get('users_failed', 0)}\n"
+        f"- run: {os.environ.get('GITHUB_SERVER_URL', 'https://github.com')}/"
+        f"{os.environ.get('GITHUB_REPOSITORY', 'unknown')}/actions/runs/"
+        f"{os.environ.get('GITHUB_RUN_ID', 'unknown')}"
+    )
+
+
+def notify_failure(
+    config: ScanConfig,
+    report: dict[str, Any],
+    *,
+    poster: Callable[[str, dict[str, Any], int], None] = post_webhook,
+) -> list[str]:
+    delivered: list[str] = []
+    text = build_failure_text(report)
+    for name, url, payload in (
+        ("slack", config.slack_webhook_url, {"text": text}),
+        ("discord", config.discord_webhook_url, {"content": text}),
+    ):
+        if not url:
+            continue
+        try:
+            poster(url, payload, min(config.timeout, 10))
+            delivered.append(name)
+        except Exception as exc:  # pragma: no cover - transport failures vary.
+            delivered.append(f"{name}_error:{exc}")
+    return delivered
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Daily Anomaly Scan",
+        "",
+        f"- Issue: `{report.get('issue', ISSUE)}`",
+        f"- Status: `{report.get('status', 'unknown')}`",
+        f"- Reason: `{report.get('reason', 'unknown')}`",
+        f"- Target month: `{report.get('target_month', 'unknown')}`",
+        f"- Users discovered: `{report.get('users_discovered', 0)}`",
+        f"- Users eligible: `{report.get('users_eligible', 0)}`",
+        f"- Users succeeded: `{report.get('users_succeeded', 0)}`",
+        f"- Users failed: `{report.get('users_failed', 0)}`",
+        f"- Anomalies detected: `{report.get('anomalies_detected', 0)}`",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(report: dict[str, Any], report_path: str, summary_path: str) -> None:
+    if report_path:
+        path = Path(report_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    if summary_path:
+        path = Path(summary_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(render_markdown(report), encoding="utf-8", newline="\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--supabase-url", default=os.environ.get("SUPABASE_URL", DEFAULT_SUPABASE_URL))
+    parser.add_argument("--service-role-key", default=os.environ.get("SUPABASE_SERVICE_ROLE_KEY", ""))
+    parser.add_argument("--cron-enabled", default=os.environ.get("DAILY_ANOMALY_SCAN_ENABLED", "false"))
+    parser.add_argument("--manual-run", default=os.environ.get("DAILY_ANOMALY_SCAN_MANUAL_RUN", "false"))
+    parser.add_argument("--confirm-all-users", default=os.environ.get("DAILY_ANOMALY_SCAN_CONFIRM_ALL_USERS", "false"))
+    parser.add_argument("--user-id", default=os.environ.get("DAILY_ANOMALY_SCAN_USER_ID", ""))
+    parser.add_argument("--target-month", default=os.environ.get("DAILY_ANOMALY_SCAN_TARGET_MONTH", ""))
+    parser.add_argument("--max-attempts", type=int, default=3)
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--slack-webhook-url", default=os.environ.get("SLACK_WEBHOOK_URL", ""))
+    parser.add_argument("--discord-webhook-url", default=os.environ.get("DISCORD_WEBHOOK_URL", ""))
+    parser.add_argument("--report", default="")
+    parser.add_argument("--summary-md", default="")
+    return parser
+
+
+def config_from_args(args: argparse.Namespace) -> ScanConfig:
+    return ScanConfig(
+        supabase_url=args.supabase_url.strip(),
+        service_role_key=args.service_role_key.strip(),
+        cron_enabled=parse_bool(args.cron_enabled),
+        manual_run=parse_bool(args.manual_run),
+        confirm_all_users=parse_bool(args.confirm_all_users),
+        user_id=args.user_id.strip(),
+        target_month=args.target_month.strip(),
+        max_attempts=min(max(args.max_attempts, 1), 5),
+        workers=min(max(args.workers, 1), 16),
+        timeout=min(max(args.timeout, 1), 120),
+        slack_webhook_url=args.slack_webhook_url.strip(),
+        discord_webhook_url=args.discord_webhook_url.strip(),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = config_from_args(args)
+    report = build_report(config)
+    if report["status"] == "fail":
+        report["notifications"] = notify_failure(config, report)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    write_outputs(report, args.report, args.summary_md)
+    return 1 if report["status"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/daily_anomaly_scan_test.py
+++ b/scripts/daily_anomaly_scan_test.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+import urllib.error
+from datetime import datetime, timezone
+
+from daily_anomaly_scan import (
+    ScanConfig,
+    build_report,
+    is_eligible_auth_user,
+    notify_failure,
+    scan_user,
+)
+
+
+USER_A = "8d2cc7d2-34f1-4eca-9f6c-0f84c23163d0"
+USER_B = "7a6f7086-abef-4e70-8a94-9fc15598c5fe"
+
+
+def config(**overrides: object) -> ScanConfig:
+    defaults: dict[str, object] = {
+        "supabase_url": "https://example.supabase.co",
+        "service_role_key": "service-secret",
+        "cron_enabled": True,
+        "manual_run": False,
+        "confirm_all_users": False,
+        "user_id": "",
+        "target_month": "2026-06",
+        "max_attempts": 3,
+        "workers": 1,
+        "timeout": 10,
+        "slack_webhook_url": "",
+        "discord_webhook_url": "",
+    }
+    defaults.update(overrides)
+    return ScanConfig(**defaults)  # type: ignore[arg-type]
+
+
+class DailyAnomalyScanTest(unittest.TestCase):
+    def test_eligible_users_exclude_anonymous_deleted_and_current_ban(self) -> None:
+        now = datetime(2026, 7, 21, tzinfo=timezone.utc)
+        self.assertTrue(is_eligible_auth_user({"id": USER_A}, now))
+        self.assertFalse(
+            is_eligible_auth_user({"id": USER_A, "is_anonymous": True}, now)
+        )
+        self.assertFalse(
+            is_eligible_auth_user({"id": USER_A, "deleted_at": "2026-07-01"}, now)
+        )
+        self.assertFalse(
+            is_eligible_auth_user(
+                {"id": USER_A, "banned_until": "2026-07-22T00:00:00Z"}, now
+            )
+        )
+        self.assertTrue(
+            is_eligible_auth_user(
+                {"id": USER_A, "banned_until": "2026-07-20T00:00:00Z"}, now
+            )
+        )
+
+    def test_scheduled_run_skips_while_feature_flag_is_off(self) -> None:
+        report = build_report(config(cron_enabled=False))
+        self.assertEqual(report["status"], "skipped")
+        self.assertEqual(report["reason"], "feature_flag_off")
+
+    def test_manual_all_user_run_requires_confirmation(self) -> None:
+        report = build_report(config(manual_run=True, cron_enabled=False))
+        self.assertEqual(report["status"], "skipped")
+        self.assertEqual(report["reason"], "manual_all_users_not_confirmed")
+
+    def test_invalid_target_month_fails_before_user_discovery(self) -> None:
+        report = build_report(config(target_month="2026-13"))
+        self.assertEqual(report["status"], "fail")
+        self.assertEqual(report["reason"], "invalid_target_month")
+
+    def test_report_scans_only_eligible_users(self) -> None:
+        seen: list[str] = []
+
+        def list_users(_: ScanConfig) -> list[dict[str, object]]:
+            return [
+                {"id": USER_A},
+                {"id": USER_B, "is_anonymous": True},
+                {"id": "invalid"},
+            ]
+
+        def scanner(_: ScanConfig, user_id: str) -> dict[str, object]:
+            seen.append(user_id)
+            return {
+                "status": "pass",
+                "user_ref": "ref",
+                "attempts": 1,
+                "anomalies_detected": 2,
+                "warnings": 0,
+            }
+
+        report = build_report(config(), user_lister=list_users, scanner=scanner)
+        self.assertEqual(seen, [USER_A])
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["users_discovered"], 3)
+        self.assertEqual(report["users_eligible"], 1)
+        self.assertEqual(report["anomalies_detected"], 2)
+
+    def test_transient_edge_function_failure_is_retried(self) -> None:
+        calls = 0
+        sleeps: list[float] = []
+
+        def requester(
+            _: str,
+            __: dict[str, object],
+            ___: dict[str, str],
+            ____: int,
+        ) -> tuple[int, dict[str, object]]:
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise urllib.error.URLError("temporary")
+            return 200, {
+                "success": True,
+                "status": "ok",
+                "anomalies_detected": 1,
+                "warnings": [],
+            }
+
+        result = scan_user(
+            config(),
+            USER_A,
+            requester=requester,  # type: ignore[arg-type]
+            sleeper=sleeps.append,
+        )
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["attempts"], 3)
+        self.assertEqual(sleeps, [1.0, 2.0])
+
+    def test_non_retryable_failure_stops_after_first_attempt(self) -> None:
+        calls = 0
+
+        def requester(
+            _: str,
+            __: dict[str, object],
+            ___: dict[str, str],
+            ____: int,
+        ) -> tuple[int, dict[str, object]]:
+            nonlocal calls
+            calls += 1
+            error = urllib.error.HTTPError("url", 401, "unauthorized", {}, None)
+            error.read = lambda: b'{"error":"unauthorized"}'  # type: ignore[method-assign]
+            raise error
+
+        result = scan_user(
+            config(),
+            USER_A,
+            requester=requester,  # type: ignore[arg-type]
+            sleeper=lambda _: None,
+        )
+        self.assertEqual(calls, 1)
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["reason"], "http_401")
+
+    def test_failure_notification_uses_configured_channels(self) -> None:
+        delivered: list[tuple[str, dict[str, object]]] = []
+
+        def poster(url: str, payload: dict[str, object], _: int) -> None:
+            delivered.append((url, payload))
+
+        channels = notify_failure(
+            config(slack_webhook_url="https://slack", discord_webhook_url="https://discord"),
+            {"reason": "user_scan_failed", "users_eligible": 2, "users_failed": 1},
+            poster=poster,  # type: ignore[arg-type]
+        )
+        self.assertEqual(channels, ["slack", "discord"])
+        self.assertEqual([item[0] for item in delivered], ["https://slack", "https://discord"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/supabase/functions/ai-hub/anomaly_detection.ts
+++ b/supabase/functions/ai-hub/anomaly_detection.ts
@@ -14,6 +14,38 @@ export class AnomalyDetectionError extends Error {
   }
 }
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function resolveScheduledAnomalyUserId(options: {
+  authorization: string;
+  serviceRoleKey: string;
+  requestedUserId: unknown;
+}): string {
+  if (!options.serviceRoleKey) {
+    throw new AnomalyDetectionError(
+      "scheduled anomaly scan is not configured",
+      503,
+    );
+  }
+  if (options.authorization !== `Bearer ${options.serviceRoleKey}`) {
+    throw new AnomalyDetectionError(
+      "scheduled anomaly scan requires service role",
+      401,
+    );
+  }
+  if (
+    typeof options.requestedUserId !== "string" ||
+    !UUID_PATTERN.test(options.requestedUserId.trim())
+  ) {
+    throw new AnomalyDetectionError(
+      "scheduled anomaly scan requires a valid user_id",
+      400,
+    );
+  }
+  return options.requestedUserId.trim();
+}
+
 export type AnomalyProviderRequest = {
   provider: string;
   model?: string;

--- a/supabase/functions/ai-hub/anomaly_detection_test.ts
+++ b/supabase/functions/ai-hub/anomaly_detection_test.ts
@@ -5,6 +5,7 @@ import {
   type AnomalyExpenseRow,
   computeCategoryAnomalies,
   handleDetectAnomaliesAction,
+  resolveScheduledAnomalyUserId,
   resolveTargetMonth,
   severityFor,
 } from "./anomaly_detection.ts";
@@ -74,6 +75,38 @@ Deno.test("resolveTargetMonth defaults to previous complete month in JST", () =>
   assertEquals(resolveTargetMonth("2026-06-30T15:30:00Z"), "2026-06-01");
   // その直前 (JST でまだ 6/30) → 前の完了月は 5 月
   assertEquals(resolveTargetMonth("2026-06-30T14:30:00Z"), "2026-05-01");
+});
+
+Deno.test("scheduled scan accepts a service-role authenticated user id", () => {
+  assertEquals(
+    resolveScheduledAnomalyUserId({
+      authorization: "Bearer service-secret",
+      serviceRoleKey: "service-secret",
+      requestedUserId: "8d2cc7d2-34f1-4eca-9f6c-0f84c23163d0",
+    }),
+    "8d2cc7d2-34f1-4eca-9f6c-0f84c23163d0",
+  );
+});
+
+Deno.test("scheduled scan rejects non-service and invalid user ids", () => {
+  assertThrows(
+    () =>
+      resolveScheduledAnomalyUserId({
+        authorization: "Bearer user-token",
+        serviceRoleKey: "service-secret",
+        requestedUserId: "8d2cc7d2-34f1-4eca-9f6c-0f84c23163d0",
+      }),
+    "requires service role",
+  );
+  assertThrows(
+    () =>
+      resolveScheduledAnomalyUserId({
+        authorization: "Bearer service-secret",
+        serviceRoleKey: "service-secret",
+        requestedUserId: "not-a-user-id",
+      }),
+    "valid user_id",
+  );
 });
 
 Deno.test("severity tiers are deterministic", () => {

--- a/supabase/functions/ai-hub/index.ts
+++ b/supabase/functions/ai-hub/index.ts
@@ -73,6 +73,7 @@ import {
   type AnomalyDetectionDb,
   AnomalyDetectionError,
   handleDetectAnomaliesAction,
+  resolveScheduledAnomalyUserId,
 } from "./anomaly_detection.ts";
 import {
   handleMarketPriceAction,
@@ -4839,15 +4840,23 @@ serve(async (req: Request) => {
         return json({ success: true, ...result });
       }
 
+      case "asset.anomaly.detect.scheduled":
       case "asset.anomaly.detect":
       case "detect-anomalies": {
+        const anomalyUserId = action === "asset.anomaly.detect.scheduled"
+          ? resolveScheduledAnomalyUserId({
+            authorization: req.headers.get("Authorization") ?? "",
+            serviceRoleKey: SERVICE_ROLE_KEY,
+            requestedUserId: body.user_id,
+          })
+          : userId ?? "";
         const explanationEnabled =
           (Deno.env.get("ANOMALY_AI_EXPLANATION_ENABLED") ?? "")
             .toLowerCase() === "true";
         const result = await handleDetectAnomaliesAction({
           db: admin as unknown as AnomalyDetectionDb,
           body,
-          userId: userId ?? "",
+          userId: anomalyUserId,
           explanationEnabled,
           invokeProvider: async (request) => {
             const budget = await checkBudget("ef", "ai-hub");


### PR DESCRIPTION
## Summary
- add a service-role-only `asset.anomaly.detect.scheduled` action without changing the existing user-authenticated action
- add a 03:00 JST daily scheduler that discovers eligible Auth users, retries transient failures, and reports hashed user references
- keep scheduled rollout OFF by default and require explicit confirmation for manual all-user runs
- notify configured Slack/Discord webhooks after final failure and retain a 14-day Actions artifact

## Safety and rollout
- deleted, currently banned, anonymous, and malformed Auth users are excluded
- service-role values stay in Actions environment variables and are not written to commands, reports, summaries, or notifications
- merge and deploy `ai-hub`, run one user manually, run all users manually, then set `DAILY_ANOMALY_SCAN_ENABLED=true`
- rollback: disable `DAILY_ANOMALY_SCAN_ENABLED`; the existing user action remains available and unchanged
- observability: Actions summary/artifact, failure status, retry counts, hashed user references, Slack/Discord failure notice
- data migration: none; uses the existing `anomaly_detections` table and idempotent upsert
- production smoke: manual single-user scan is required before enabling the schedule

## Validation
- `python scripts/daily_anomaly_scan_test.py` (8 passed)
- `deno test supabase/functions/ai-hub/anomaly_detection_test.ts` (15 passed)
- `deno check supabase/functions/ai-hub/index.ts`
- `deno lint supabase/functions/ai-hub/anomaly_detection.ts supabase/functions/ai-hub/anomaly_detection_test.ts supabase/functions/ai-hub/index.ts`
- `python scripts/check_edge_function_imports.py`
- GitHub Actions Node runtime and inline Python checks
- repository fast gate reached `flutter analyze` but did not return within 15 minutes; PR CI is the final full-repository proof

## Minimal E2E Gate
- Implementation-detail independent: validates scheduler eligibility, retry behavior, service authentication, and EF result handling.
- Minimal scope: feature flag skip, one eligible user, transient retry, non-retryable auth rejection, and notification delivery.
- E2E: PR-triggered `Daily Anomaly Scan / Validate daily anomaly scheduler` runs the Python scheduler and Deno EF contract suites.
- E2E-Exception: No user-visible browser route changes; the PR-triggered scheduler-to-EF contract is the minimal end-to-end surface.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 review remains required before merge; this Draft records deterministic checks and staged rollout safeguards while review is pending.

Closes #2478