### PR TITLE
fix: accept actionable Japanese trial copy

### DIFF
--- a/supabase/functions/growth-hub/landing_trial.ts
+++ b/supabase/functions/growth-hub/landing_trial.ts
@@ -49,8 +49,10 @@ const GENERIC_ACTION_PATTERNS = [
   /まず.{0,4}(?:考え|確認|整理)する/,
 ];
 
+// Japanese action copy commonly uses a verbal noun as an imperative
+// (for example, "1件をメモ" or "固定費を1件特定").
 const ACTION_VERB_PATTERN =
-  /(?:開く|書く|追記|削除|比較|送る|予約|設定|計測|選ぶ|分ける|作る|試す|止める|決める|入力|登録|更新|調べる|並べる|閉じる|返信|共有|変更|追加|外す|読む|数える)/;
+  /(?:開く|書く|追記|削除|比較|送る|予約|設定|計測|選ぶ|分ける|作る|試す|止める|決める|入力|登録|更新|調べる|並べる|閉じる|返信|共有|変更|追加|外す|読む|数える|見直す|確認|メモ|記録|特定|絞る|洗い出す|印を付ける|チェック|分類|解約|停止)/;
 const COMPLETION_BOUNDARY_PATTERN =
   /(?:\d+|[一二三四五六七八九十]|ひとつ|1つ|一つ|1件|一件|一文|1行|一行|10分|今日|直前|最初|末尾)/;
 const CAUSAL_REASON_PATTERN =

--- a/supabase/functions/growth-hub/landing_trial_test.ts
+++ b/supabase/functions/growth-hub/landing_trial_test.ts
@@ -69,6 +69,19 @@ Deno.test("landing trial quality gate rejects generic advice", () => {
   assertEquals(issues.includes("missing_prompt_anchor"), true);
 });
 
+Deno.test("landing trial quality gate accepts Japanese verbal noun actions", () => {
+  assertEquals(
+    landingTrialQualityIssues(
+      "毎月の支出が増えていて、どこから見直すべきか分かりません",
+      {
+        action: "先月の支出で最も高い固定費を1件特定",
+        reason: "支出の最大項目を先に特定すると見直し効果が明確になるため",
+      },
+    ),
+    [],
+  );
+});
+
 Deno.test("landing trial client address prefers trusted proxy headers", () => {
   assertEquals(
     resolveLandingTrialClientAddress(


### PR DESCRIPTION
## Summary
- accept natural Japanese verbal-noun imperatives such as `1件をメモ` and `固定費を1件特定`
- keep the existing generic-action, completion-boundary, prompt-anchor, and causal-reason checks
- add a regression test for the production household-spending prompt

Closes #4279

## Root cause
Production validation passed 2 of 3 inputs. The third response met every quality rule except `missing_action_verb` because concise Japanese imperative copy can end in a verbal noun. Growth Hub then returned 503 after the single model-repair attempt.

## Validation
- targeted landing trial tests: 10 passed
- Growth Hub tests: 104 passed
- full Edge Function tests: 522 passed, 0 failed
- Deno lint and `deno check` passed
- Flutter analyze: 0 issues
- pre-commit fast gate passed
- pre-push full quality gate passed

## Minimal E2E Gate
- Implementation-detail independent: validates the public anonymous trial's user-visible contract.
- Minimal scope: one production-regression input plus existing success and rejection cases.
- E2E: existing public landing-route smoke remains the cross-boundary route check.
- E2E-Exception: server-only response-quality classification is covered deterministically at the input/output boundary; no browser-only behavior changes.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: bounded response validation only; no auth, schema, migration, secret, payment, or destructive behavior.