### PR TITLE
fix(lp): keep trial fallback relevant

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -476,6 +476,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       });
     } catch (e) {
       debugPrint('Trial preview failed: $e');
+      unawaited(_recordConversionStage('trial_fallback'));
       final fallback = _buildTrialFallbackSuggestion(input);
       if (!mounted) return;
       setState(() {
@@ -725,6 +726,53 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         text.contains('DM') ||
         text.contains('連絡')) {
       return ('未読の確認を1件だけ終える', '連絡系は放置コストが高いので、最初に1件だけ処理すると全体が進みます。');
+    }
+
+    if (RegExp(
+      r'支出|出費|家計|固定費|変動費|予算|浪費|お金|請求|明細|サブスク|収入|貯金|資産|借金|返済|税金|投資|削減',
+    ).hasMatch(text)) {
+      return (
+        '先月の明細で最も高い固定費を1件特定',
+        '最大の固定費を先に確認すると、削減効果を比較しやすくなるためです。',
+      );
+    }
+
+    if (RegExp(r'学習|勉強|英語|読書|復習|試験|資格|暗記|教材|授業').hasMatch(text)) {
+      return (
+        '今日復習する教材を1件開く',
+        '対象を1件に固定すると、短時間でも復習を完了しやすくなるためです。',
+      );
+    }
+
+    if (RegExp(
+      r'LP|ランディング|登録|サインアップ|フォーム|CTA|ボタン|申込|コンバージョン|離脱',
+      caseSensitive: false,
+    ).hasMatch(text)) {
+      return (
+        '登録ボタン直前の価値説明を1文見直す',
+        '登録後に得られる成果を明確にすると、迷った訪問者が判断しやすくなるためです。',
+      );
+    }
+
+    if (RegExp(r'健康|運動|睡眠|食事|体重|病院|服薬').hasMatch(text)) {
+      return (
+        '直近の健康記録を1件確認',
+        '最新の状態を1件確認すると、今日変える行動を具体化しやすくなるためです。',
+      );
+    }
+
+    if (RegExp(r'情報整理|ノート|メモ|資料|ファイル|知識|文書').hasMatch(text)) {
+      return (
+        '未整理のメモを1件開き用途を1行追記',
+        '用途を1行で固定すると、残すか行動に変えるかを判断しやすくなるためです。',
+      );
+    }
+
+    if (RegExp(r'予定|時間|先送り|後回し|着手|集中|習慣').hasMatch(text)) {
+      return (
+        '今日の予定から先送り中の1件を選ぶ',
+        '対象を1件に固定すると、使える時間をその行動に割り当てやすくなるためです。',
+      );
     }
 
     if (text.contains('考える') ||
@@ -3819,6 +3867,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
               ),
               SizedBox(height: compactHero ? 8 : 14),
               TextField(
+                key: const Key('landing_trial_prompt_input'),
                 controller: _trialPromptController,
                 minLines: heroMode ? 1 : 2,
                 maxLines: heroMode ? 2 : 3,

--- a/lib/services/landing_conversion_experiment_service.dart
+++ b/lib/services/landing_conversion_experiment_service.dart
@@ -111,6 +111,7 @@ class LandingConversionExperimentService {
     'hero_cta',
     'intent',
     'trial',
+    'trial_fallback',
     'save_cta',
     'signup_submit',
     'signup_complete',
@@ -120,7 +121,7 @@ class LandingConversionExperimentService {
   };
 
   static final RegExp _eventKeyPattern = RegExp(
-    r'^lp_exp_h(?:0[1-9]|10)_(?:control|treatment)_(?:view|hero_cta|intent|trial|save_cta|signup_submit|signup_complete|sticky_cta|feature_outcome_trial|feature_catalog_expand)$',
+    r'^lp_exp_h(?:0[1-9]|10)_(?:control|treatment)_(?:view|hero_cta|intent|trial|trial_fallback|save_cta|signup_submit|signup_complete|sticky_cta|feature_outcome_trial|feature_catalog_expand)$',
   );
 
   const LandingConversionExperimentService();

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -332,6 +332,33 @@ void main() {
     expect(find.textContaining('AI応答が不安定'), findsNothing);
   });
 
+  testWidgets('trial provider failure keeps a finance-specific result', (
+    tester,
+  ) async {
+    final adapter = await pumpLanding(
+      tester,
+      assignment: _assignment('h01', LandingExperimentVariant.treatment),
+    );
+    adapter.trialError = Exception('quality gate rejected response');
+
+    await tester.enterText(
+      find.byKey(const Key('landing_trial_prompt_input')),
+      '家計の固定費が高く、今月どの支出から見直すべきか決められません',
+    );
+    await tester.tap(
+      find.byKey(const Key('landing_h03_inline_trial_action')),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('先月の明細で最も高い固定費を1件特定'), findsOneWidget);
+    expect(find.textContaining('20分だけ動ける最小単位'), findsNothing);
+    expect(
+      adapter.conversionEvents,
+      contains('lp_exp_h01_treatment_trial_fallback'),
+    );
+  });
+
   testWidgets('all ten control conditions remove only their tested mechanism', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

Production QA found that a finance concern could fall through to the generic local trial suggestion after the Edge quality gate rejected a provider response. This keeps anonymous LP value delivery relevant even when the provider path fails.

- add deterministic finance, learning, LP, health, notes, and schedule fallbacks
- record `trial_fallback` separately from successful provider trials
- add a widget regression for the exact finance concern reproduced in production

## Production reproduction

Input:
`家計の固定費が高く、今月どの支出から見直すべきか決められません`

Before:
`20分だけ動ける最小単位に分解する`

Expected after deploy:
`先月の明細で最も高い固定費を1件特定`

## Verification

- `flutter test test/pages/landing_page_conversion_test.dart test/services/landing_conversion_experiment_service_test.dart` (16 passed)
- `flutter analyze` (no issues)
- full pre-push quality gate (Flutter VM suite + 525 Deno tests, 0 failures)

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.

E2E-Exception: Existing public Playwright LP stability coverage exercises desktop/mobile rendering and CTA routing; this PR adds a deterministic Widget regression for the provider-failure finance-input path.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Local deterministic LP fallback and analytics only; no auth, payments, secrets, migrations, or destructive data paths changed.

Closes #4282