### PR TITLE
fix: 匿名LPのAIシェアFAB競合を除去

### DIFF
--- a/lib/widgets/universal_ai_share_shell.dart
+++ b/lib/widgets/universal_ai_share_shell.dart
@@ -98,6 +98,13 @@ const double kAiShareFabTopOffset = kToolbarHeight + 20;
 const double kAiShareFabDefaultBottomOffset = 20;
 const double kAiShareFabLandingBottomOffset = 88;
 
+bool shouldShowUniversalAiShareFab({
+  required String routePath,
+  required bool isLoggedIn,
+}) {
+  return routePath != '/' || isLoggedIn;
+}
+
 double resolveAiShareFabBottomOffset({
   required String routePath,
   required double screenWidth,
@@ -279,6 +286,13 @@ class _UniversalAiShareFab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isLoggedIn = _isLoggedIn;
+    if (!shouldShowUniversalAiShareFab(
+      routePath: page.routePath,
+      isLoggedIn: isLoggedIn,
+    )) {
+      return const SizedBox.shrink();
+    }
+
     final colorScheme = Theme.of(context).colorScheme;
     final backgroundColor = isLoggedIn
         ? colorScheme.primaryContainer

--- a/test/widgets/universal_ai_share_fab_offset_test.dart
+++ b/test/widgets/universal_ai_share_fab_offset_test.dart
@@ -40,4 +40,19 @@ void main() {
       kAiShareFabDefaultBottomOffset,
     );
   });
+
+  test('anonymous landing hides only the universal share FAB', () {
+    expect(
+      shouldShowUniversalAiShareFab(routePath: '/', isLoggedIn: false),
+      isFalse,
+    );
+    expect(
+      shouldShowUniversalAiShareFab(routePath: '/', isLoggedIn: true),
+      isTrue,
+    );
+    expect(
+      shouldShowUniversalAiShareFab(routePath: '/notes', isLoggedIn: false),
+      isTrue,
+    );
+  });
 }

--- a/test/widgets/universal_ai_share_shell_test.dart
+++ b/test/widgets/universal_ai_share_shell_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/services/ai_share_button_preferences_service.dart';
+import 'package:my_web_app/services/universal_x_share_service.dart';
 import 'package:my_web_app/widgets/universal_ai_share_shell.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -10,6 +11,20 @@ void main() {
   setUp(() async {
     SharedPreferences.setMockInitialValues(<String, Object>{});
     await aiShareButtonPreferencesController.reload();
+    universalAiShareRouteObserver.currentPage.value =
+        UniversalSharePageContext.fromRouteName('/notes');
+  });
+
+  testWidgets('anonymous landing hides the universal share button',
+      (tester) async {
+    universalAiShareRouteObserver.currentPage.value =
+        UniversalSharePageContext.fromRouteName('/');
+
+    await tester.pumpWidget(_buildShell());
+    await tester.pump();
+
+    expect(find.byTooltip('AIシェア'), findsNothing);
+    expect(find.byTooltip('AIシェアボタン設定'), findsNothing);
   });
 
   testWidgets('AI share tooltip is hosted inside the navigator overlay',


### PR DESCRIPTION
## ??
- ??????????LP?`/`?????????????????AI???FAB?????????
- ?????????????????LP????????????????????
- LP??????????????????????

## ?? H17
??????LP???????FAB??????????????CTA??????????????????????????

## ??
- `flutter test test/widgets/universal_ai_share_fab_offset_test.dart test/widgets/universal_ai_share_shell_test.dart`
- `flutter analyze --no-pub lib/widgets/universal_ai_share_shell.dart test/widgets/universal_ai_share_fab_offset_test.dart test/widgets/universal_ai_share_shell_test.dart`
- pre-commit quality gate: pass
- pre-push full quality gate: 525 passed / 0 failed

## Minimal E2E Gate
- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Focused widget coverage validates all route and identity cases; browser mobile QA will verify the rendered anonymous LP.

Closes #4287
