### PR TITLE
feat: deduplicate landing experiment funnels

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -83,6 +83,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   _LandingIntent _selectedIntent = _LandingIntent.work;
   LandingExperimentAssignment? _experimentAssignment;
   Future<LandingExperimentAssignment>? _experimentBootstrapFuture;
+  Future<String>? _experimentVisitorIdFuture;
   final Set<String> _recordedExperimentStages = <String>{};
 
   SupabaseClient? get _supabaseClientOrNull {
@@ -143,6 +144,11 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     return _experimentBootstrapFuture ??= _loadConversionExperiment();
   }
 
+  Future<String> _resolveExperimentVisitorId() {
+    return _experimentVisitorIdFuture ??=
+        widget.conversionExperimentService.resolveVisitorId();
+  }
+
   bool _hypothesisEnabled(String hypothesisId) {
     return _experimentAssignment?.enables(hypothesisId) ?? true;
   }
@@ -150,11 +156,13 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   Future<void> _recordConversionStage(String stage) async {
     try {
       final assignment = await _resolveExperimentAssignment();
+      final visitorId = await _resolveExperimentVisitorId();
       if (!_recordedExperimentStages.add(stage)) {
         return;
       }
       await widget.adapter.recordConversionEvent(
         eventKey: assignment.eventKey(stage),
+        visitorId: visitorId,
       );
     } catch (error) {
       debugPrint('LP conversion event failed ($stage): $error');

--- a/lib/services/landing_conversion_experiment_service.dart
+++ b/lib/services/landing_conversion_experiment_service.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
 
 enum LandingExperimentVariant { control, treatment }
 
@@ -52,6 +53,7 @@ class LandingConversionExperimentService {
   static const String _hypothesisPreferenceKey =
       'landing_conversion_hypothesis_v1';
   static const String _variantPreferenceKey = 'landing_conversion_variant_v1';
+  static const String _visitorPreferenceKey = 'landing_conversion_visitor_v1';
 
   static const List<LandingConversionHypothesis> hypotheses = [
     LandingConversionHypothesis(
@@ -123,8 +125,29 @@ class LandingConversionExperimentService {
   static final RegExp _eventKeyPattern = RegExp(
     r'^lp_exp_h(?:0[1-9]|10)_(?:control|treatment)_(?:view|hero_cta|intent|trial|trial_fallback|save_cta|signup_submit|signup_complete|sticky_cta|feature_outcome_trial|feature_catalog_expand)$',
   );
+  static final RegExp _visitorIdPattern = RegExp(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+  );
 
   const LandingConversionExperimentService();
+
+  Future<String> resolveVisitorId({
+    SharedPreferences? preferences,
+    String Function()? generator,
+  }) async {
+    final prefs = preferences ?? await SharedPreferences.getInstance();
+    final stored = prefs.getString(_visitorPreferenceKey)?.trim().toLowerCase();
+    if (stored != null && isValidVisitorId(stored)) {
+      return stored;
+    }
+
+    final visitorId = (generator?.call() ?? const Uuid().v4()).toLowerCase();
+    if (!isValidVisitorId(visitorId)) {
+      throw StateError('LP visitor ID generator returned an invalid UUID v4');
+    }
+    await prefs.setString(_visitorPreferenceKey, visitorId);
+    return visitorId;
+  }
 
   Future<LandingExperimentAssignment> resolve({
     Uri? uri,
@@ -158,6 +181,10 @@ class LandingConversionExperimentService {
 
   static bool isExperimentEventKey(String eventKey) {
     return _eventKeyPattern.hasMatch(eventKey);
+  }
+
+  static bool isValidVisitorId(String visitorId) {
+    return _visitorIdPattern.hasMatch(visitorId.trim().toLowerCase());
   }
 
   LandingExperimentAssignment? _resolveOverride(Uri? uri) {

--- a/lib/services/landing_page_adapter.dart
+++ b/lib/services/landing_page_adapter.dart
@@ -86,7 +86,10 @@ abstract interface class LandingPageAdapter {
 
   Future<void> recordInboxOpen();
 
-  Future<void> recordConversionEvent({required String eventKey});
+  Future<void> recordConversionEvent({
+    required String eventKey,
+    required String visitorId,
+  });
 }
 
 class SupabaseLandingPageAdapter implements LandingPageAdapter {
@@ -291,10 +294,29 @@ class SupabaseLandingPageAdapter implements LandingPageAdapter {
   }
 
   @override
-  Future<void> recordConversionEvent({required String eventKey}) {
-    return LandingShareService.recordFunnelEvent(
+  Future<void> recordConversionEvent({
+    required String eventKey,
+    required String visitorId,
+  }) async {
+    final client = _supabaseClientOrNull;
+    await LandingShareService.recordFunnelEvent(
       eventKey: eventKey,
-      client: _supabaseClientOrNull,
+      client: client,
     );
+    if (client == null) {
+      return;
+    }
+
+    try {
+      await client.rpc(
+        'record_landing_experiment_event',
+        params: <String, dynamic>{
+          'p_visitor_id': visitorId,
+          'p_event_key': eventKey,
+        },
+      );
+    } catch (error) {
+      debugPrint('Unique LP experiment event failed: $error');
+    }
   }
 }

--- a/supabase/migrations/20260722211500_create_landing_experiment_events.sql
+++ b/supabase/migrations/20260722211500_create_landing_experiment_events.sql
@@ -1,0 +1,253 @@
+-- Deduplicate LP experiment funnels by a random browser-scoped visitor UUID.
+-- This ledger intentionally stores no email, IP address, user agent, prompt,
+-- answer, or browser fingerprint.
+CREATE TABLE public.landing_experiment_events (
+  visitor_id uuid NOT NULL,
+  hypothesis_id text NOT NULL
+    CHECK (hypothesis_id ~ '^h(0[1-9]|10)$'),
+  variant text NOT NULL
+    CHECK (variant IN ('control', 'treatment')),
+  stage text NOT NULL
+    CHECK (
+      stage IN (
+        'view',
+        'hero_cta',
+        'intent',
+        'trial',
+        'trial_fallback',
+        'save_cta',
+        'signup_submit',
+        'signup_complete',
+        'sticky_cta',
+        'feature_outcome_trial',
+        'feature_catalog_expand'
+      )
+    ),
+  first_occurred_at timestamptz NOT NULL DEFAULT now(),
+  auth_user_id uuid,
+  auth_is_anonymous boolean,
+  PRIMARY KEY (visitor_id, hypothesis_id, variant, stage),
+  CHECK (
+    (auth_user_id IS NULL AND auth_is_anonymous IS NULL)
+    OR (auth_user_id IS NOT NULL AND auth_is_anonymous IS NOT NULL)
+  )
+);
+
+CREATE INDEX landing_experiment_events_first_occurred_idx
+  ON public.landing_experiment_events (first_occurred_at DESC);
+
+ALTER TABLE public.landing_experiment_events ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.landing_experiment_events
+  FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.landing_experiment_events TO service_role;
+
+CREATE OR REPLACE FUNCTION public.record_landing_experiment_event(
+  p_visitor_id uuid,
+  p_event_key text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_hypothesis_id text;
+  v_variant text;
+  v_stage text;
+  v_auth_user_id uuid := auth.uid();
+  v_auth_is_anonymous boolean;
+  v_inserted_rows integer := 0;
+BEGIN
+  IF p_visitor_id IS NULL THEN
+    RAISE EXCEPTION 'visitor ID is required';
+  END IF;
+
+  IF p_event_key IS NULL
+     OR length(p_event_key) > 160
+     OR p_event_key !~ '^lp_exp_h(0[1-9]|10)_(control|treatment)_(view|hero_cta|intent|trial|trial_fallback|save_cta|signup_submit|signup_complete|sticky_cta|feature_outcome_trial|feature_catalog_expand)$' THEN
+    RAISE EXCEPTION 'invalid LP experiment event key';
+  END IF;
+
+  v_hypothesis_id := split_part(p_event_key, '_', 3);
+  v_variant := split_part(p_event_key, '_', 4);
+  v_stage := regexp_replace(
+    p_event_key,
+    '^lp_exp_h(0[1-9]|10)_(control|treatment)_',
+    ''
+  );
+
+  IF v_auth_user_id IS NOT NULL THEN
+    v_auth_is_anonymous := COALESCE(
+      (auth.jwt() ->> 'is_anonymous')::boolean,
+      false
+    );
+  END IF;
+
+  INSERT INTO public.landing_experiment_events (
+    visitor_id,
+    hypothesis_id,
+    variant,
+    stage,
+    auth_user_id,
+    auth_is_anonymous
+  )
+  VALUES (
+    p_visitor_id,
+    v_hypothesis_id,
+    v_variant,
+    v_stage,
+    v_auth_user_id,
+    v_auth_is_anonymous
+  )
+  ON CONFLICT (visitor_id, hypothesis_id, variant, stage) DO NOTHING;
+
+  GET DIAGNOSTICS v_inserted_rows = ROW_COUNT;
+  RETURN v_inserted_rows = 1;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_landing_experiment_event(uuid, text)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.record_landing_experiment_event(uuid, text)
+  TO anon, authenticated, service_role;
+
+CREATE VIEW public.landing_experiment_arm_stats
+WITH (security_invoker = true)
+AS
+WITH experiment_arms(hypothesis_id, variant) AS (
+  VALUES
+    ('h01', 'control'), ('h01', 'treatment'),
+    ('h02', 'control'), ('h02', 'treatment'),
+    ('h03', 'control'), ('h03', 'treatment'),
+    ('h04', 'control'), ('h04', 'treatment'),
+    ('h05', 'control'), ('h05', 'treatment'),
+    ('h06', 'control'), ('h06', 'treatment'),
+    ('h07', 'control'), ('h07', 'treatment'),
+    ('h08', 'control'), ('h08', 'treatment'),
+    ('h09', 'control'), ('h09', 'treatment'),
+    ('h10', 'control'), ('h10', 'treatment')
+)
+SELECT
+  arm.hypothesis_id,
+  arm.variant,
+  COUNT(DISTINCT event.visitor_id)
+    FILTER (WHERE event.stage = 'view') AS unique_views,
+  COUNT(DISTINCT event.visitor_id)
+    FILTER (WHERE event.stage = 'trial') AS unique_trials,
+  COUNT(DISTINCT event.visitor_id)
+    FILTER (WHERE event.stage = 'save_cta') AS unique_save_ctas,
+  COUNT(DISTINCT event.visitor_id)
+    FILTER (WHERE event.stage = 'signup_submit') AS unique_signup_submits,
+  COUNT(DISTINCT event.visitor_id)
+    FILTER (WHERE event.stage = 'signup_complete') AS unique_signup_completes,
+  COUNT(DISTINCT event.visitor_id) FILTER (
+    WHERE event.stage = 'signup_complete'
+      AND event.auth_user_id IS NOT NULL
+      AND event.auth_is_anonymous = false
+  ) AS non_anonymous_signup_completes,
+  MIN(event.first_occurred_at) AS first_event_at,
+  MAX(event.first_occurred_at) AS last_event_at
+FROM experiment_arms AS arm
+LEFT JOIN public.landing_experiment_events AS event
+  ON event.hypothesis_id = arm.hypothesis_id
+ AND event.variant = arm.variant
+GROUP BY arm.hypothesis_id, arm.variant;
+
+REVOKE ALL ON TABLE public.landing_experiment_arm_stats
+  FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.landing_experiment_arm_stats TO service_role;
+
+-- Keep the pre-existing daily aggregate compatible with every current LP stage.
+CREATE OR REPLACE FUNCTION public.increment_app_analytics_source_detail(
+  p_source_key text,
+  p_event_date date DEFAULT (timezone('Asia/Tokyo', now()))::date,
+  p_share_increment integer DEFAULT 0
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_today date := (timezone('Asia/Tokyo', now()))::date;
+BEGIN
+  IF p_source_key IS NULL
+     OR btrim(p_source_key) = ''
+     OR length(p_source_key) > 160
+     OR NOT (
+       p_source_key IN (
+         'x_share',
+         'line',
+         'facebook',
+         'copy_link',
+         'share_x',
+         'share_line',
+         'share_facebook',
+         'share_copy',
+         'funnel_trial_run',
+         'funnel_save_cta',
+         'funnel_magic_link_send',
+         'funnel_inbox_open'
+       )
+       OR p_source_key ~ '^lp_exp_h(0[1-9]|10)_(control|treatment)_(view|hero_cta|intent|trial|trial_fallback|save_cta|signup_submit|signup_complete|sticky_cta|feature_outcome_trial|feature_catalog_expand)$'
+       OR p_source_key ~ '^activation_exp_a(0[1-9]|10)_(control|treatment)_(onboarding_view|intent_selected|first_action_started|first_action_completed|onboarding_completed|value_recap_view|billing_view|supporter_checkout|pro_checkout|checkout_return)$'
+     ) THEN
+    RAISE EXCEPTION 'invalid analytics source key';
+  END IF;
+
+  IF p_event_date IS NULL
+     OR p_event_date < v_today - 1
+     OR p_event_date > v_today + 1 THEN
+    RAISE EXCEPTION 'invalid analytics event date';
+  END IF;
+
+  IF p_share_increment IS NULL
+     OR p_share_increment < 0
+     OR p_share_increment > 1 THEN
+    RAISE EXCEPTION 'invalid share increment';
+  END IF;
+
+  INSERT INTO public.app_analytics AS analytics (
+    date,
+    landing_views,
+    conversions,
+    share_count,
+    source_details
+  )
+  VALUES (
+    p_event_date,
+    0,
+    0,
+    p_share_increment,
+    jsonb_build_object(p_source_key, 1)
+  )
+  ON CONFLICT (date) DO UPDATE
+  SET
+    share_count = COALESCE(analytics.share_count, 0)
+      + p_share_increment,
+    source_details = COALESCE(
+      analytics.source_details,
+      '{}'::jsonb
+    ) || jsonb_build_object(
+      p_source_key,
+      CASE
+        WHEN (analytics.source_details ->> p_source_key) ~ '^[0-9]+$'
+          THEN (analytics.source_details ->> p_source_key)::integer
+        ELSE 0
+      END + 1
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.increment_app_analytics_source_detail(
+  text,
+  date,
+  integer
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.increment_app_analytics_source_detail(
+  text,
+  date,
+  integer
+) TO anon, authenticated, service_role;

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -14,6 +14,7 @@ class _LandingAdapter extends Fake implements LandingPageAdapter {
   int trialRuns = 0;
   int saveCtas = 0;
   final List<String> conversionEvents = <String>[];
+  final List<String> conversionVisitorIds = <String>[];
   final List<String> magicLinkEmails = <String>[];
   Completer<String>? trialResponse;
   Exception? trialError;
@@ -28,8 +29,12 @@ class _LandingAdapter extends Fake implements LandingPageAdapter {
   }
 
   @override
-  Future<void> recordConversionEvent({required String eventKey}) async {
+  Future<void> recordConversionEvent({
+    required String eventKey,
+    required String visitorId,
+  }) async {
     conversionEvents.add(eventKey);
+    conversionVisitorIds.add(visitorId);
   }
 
   @override
@@ -154,6 +159,13 @@ void main() {
     );
     expect(adapter.lpViews, 1);
     expect(adapter.conversionEvents, contains('lp_exp_h01_treatment_view'));
+    expect(adapter.conversionVisitorIds, hasLength(1));
+    expect(
+      LandingConversionExperimentService.isValidVisitorId(
+        adapter.conversionVisitorIds.single,
+      ),
+      isTrue,
+    );
     expect(
       find.descendant(
         of: find.byKey(const Key('landing_hero_section')),
@@ -217,6 +229,7 @@ void main() {
         'lp_exp_h04_treatment_signup_submit',
       ]),
     );
+    expect(adapter.conversionVisitorIds.toSet(), hasLength(1));
     expect(
       find.byKey(const Key('landing_h04_inline_open_inbox')),
       findsOneWidget,

--- a/test/services/landing_conversion_experiment_service_test.dart
+++ b/test/services/landing_conversion_experiment_service_test.dart
@@ -74,6 +74,63 @@ void main() {
     expect(first.variant, LandingExperimentVariant.control);
   });
 
+  test('visitor identity is a stable persisted UUID v4', () async {
+    final prefs = await SharedPreferences.getInstance();
+    var generated = 0;
+    final first = await service.resolveVisitorId(
+      preferences: prefs,
+      generator: () {
+        generated += 1;
+        return '8c5f6a6e-1e06-4dbe-9b42-c0f68a41f208';
+      },
+    );
+    final second = await service.resolveVisitorId(
+      preferences: prefs,
+      generator: () {
+        generated += 1;
+        return '1065506c-d79b-4a9d-a6a6-a622ec87e171';
+      },
+    );
+
+    expect(first, '8c5f6a6e-1e06-4dbe-9b42-c0f68a41f208');
+    expect(second, first);
+    expect(generated, 1);
+    expect(
+      LandingConversionExperimentService.isValidVisitorId(first),
+      isTrue,
+    );
+  });
+
+  test('invalid stored visitor identity is replaced', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'landing_conversion_visitor_v1': 'not-a-uuid',
+    });
+    final prefs = await SharedPreferences.getInstance();
+
+    final visitorId = await service.resolveVisitorId(
+      preferences: prefs,
+      generator: () => '1065506c-d79b-4a9d-a6a6-a622ec87e171',
+    );
+
+    expect(visitorId, '1065506c-d79b-4a9d-a6a6-a622ec87e171');
+    expect(
+      prefs.getString('landing_conversion_visitor_v1'),
+      visitorId,
+    );
+  });
+
+  test('invalid generated visitor identity fails closed', () async {
+    final prefs = await SharedPreferences.getInstance();
+
+    expect(
+      () => service.resolveVisitorId(
+        preferences: prefs,
+        generator: () => 'predictable-visitor',
+      ),
+      throwsStateError,
+    );
+  });
+
   test(
     'query override supports deterministic QA without changing storage',
     () async {

--- a/test/services/landing_experiment_events_schema_test.dart
+++ b/test/services/landing_experiment_events_schema_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260722211500_create_landing_experiment_events.sql';
+
+void main() {
+  group('landing experiment event schema', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(
+        _migrationPath,
+      ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+    });
+
+    test('deduplicates each visitor and funnel stage', () {
+      expect(
+        sql,
+        contains('create table public.landing_experiment_events'),
+      );
+      expect(
+        sql,
+        contains(
+          'primary key (visitor_id, hypothesis_id, variant, stage)',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'on conflict (visitor_id, hypothesis_id, variant, stage) do nothing',
+        ),
+      );
+      expect(sql, contains("hypothesis_id ~ '^h(0[1-9]|10)\$'"));
+      expect(sql, contains("variant in ('control', 'treatment')"));
+      for (final stage in <String>[
+        'view',
+        'hero_cta',
+        'intent',
+        'trial',
+        'trial_fallback',
+        'save_cta',
+        'signup_submit',
+        'signup_complete',
+        'sticky_cta',
+        'feature_outcome_trial',
+        'feature_catalog_expand',
+      ]) {
+        expect(sql, contains("'$stage'"));
+      }
+    });
+
+    test('accepts writes only through a validated security definer RPC', () {
+      expect(
+        sql,
+        contains(
+          'alter table public.landing_experiment_events enable row level security',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'revoke all on table public.landing_experiment_events\n  from public, anon, authenticated',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'create or replace function public.record_landing_experiment_event',
+        ),
+      );
+      expect(sql, contains('security definer'));
+      expect(sql, contains('set search_path = pg_catalog, public'));
+      expect(sql, contains('auth.uid()'));
+      expect(sql, contains("auth.jwt() ->> 'is_anonymous'"));
+      expect(
+        sql,
+        contains(
+          'grant execute on function public.record_landing_experiment_event(uuid, text)',
+        ),
+      );
+    });
+
+    test('exposes all twenty arms only to service role', () {
+      expect(
+        RegExp(r"\('h(?:0[1-9]|10)', '(?:control|treatment)'\)")
+            .allMatches(sql)
+            .length,
+        20,
+      );
+      expect(sql, contains('with (security_invoker = true)'));
+      expect(sql, contains('as unique_views'));
+      expect(sql, contains('as non_anonymous_signup_completes'));
+      expect(
+        sql,
+        contains(
+          'revoke all on table public.landing_experiment_arm_stats\n  from public, anon, authenticated',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'grant select on table public.landing_experiment_arm_stats to service_role',
+        ),
+      );
+    });
+
+    test('does not collect visitor PII or content', () {
+      for (final forbiddenColumn in <String>[
+        'email',
+        'ip_address',
+        'user_agent',
+        'browser_fingerprint',
+        'prompt_text',
+        'answer_text',
+      ]) {
+        expect(
+          RegExp('\\n\\s*$forbiddenColumn\\s').hasMatch(sql),
+          isFalse,
+          reason: '$forbiddenColumn must not be persisted',
+        );
+      }
+    });
+
+    test('keeps daily aggregate validation aligned with current stages', () {
+      expect(
+        sql,
+        contains(
+          'trial|trial_fallback|save_cta|signup_submit|signup_complete|sticky_cta|feature_outcome_trial|feature_catalog_expand',
+        ),
+      );
+      expect(
+        sql,
+        contains(
+          'create or replace function public.increment_app_analytics_source_detail',
+        ),
+      );
+    });
+  });
+}

--- a/test/services/landing_share_service_test.dart
+++ b/test/services/landing_share_service_test.dart
@@ -133,7 +133,10 @@ class _FakeLandingPageAdapter implements LandingPageAdapter {
   Future<void> recordTrialRun() async {}
 
   @override
-  Future<void> recordConversionEvent({required String eventKey}) async {
+  Future<void> recordConversionEvent({
+    required String eventKey,
+    required String visitorId,
+  }) async {
     conversionEvents.add(eventKey);
   }
 }


### PR DESCRIPTION
## Summary
- persist a random browser-scoped UUID v4 for LP experiment attribution
- write deduplicated H01-H10 funnel stages through a validated SECURITY DEFINER RPC
- expose a service-role-only 20-arm statistics view while preserving the existing daily aggregate

## Validation
- `python scripts/quality_gate.py --fast`
- `dart format --output=none --set-exit-if-changed .`
- `flutter test --coverage --concurrency=1` (1866 passed)
- `deno test --allow-all --no-check --config supabase/functions/deno.json supabase/functions/` (525 passed)
- `python scripts/check_migration_timestamps.py`
- `supabase db push --dry-run --include-all --yes`

## Notes
- The ledger stores no email, IP address, user agent, browser fingerprint, prompt, or answer content.
- Direct table/view access is revoked from anonymous and authenticated clients.

Closes #4289
## Minimal E2E Gate

- Implementation-detail independent: tests assert user-visible input/output and persisted funnel results, not private internals.
- Minimal scope: about 3 cases (first event, duplicate event, unauthorized read/error path).
- E2E: the existing Playwright public smoke and Flutter landing-page widget flow cover the public route.
- E2E-Exception: This telemetry-only change adds no new user-visible route; landing widget I/O tests, public E2E smoke, and DB integration smoke cover the behavior.

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Claude Code #1 is unavailable inside this Codex session; the required risk perspectives were reviewed manually and by CI.
- Security: the ledger stores no email, IP, user-agent, fingerprint, prompt, or answer; anonymous/authenticated direct reads and writes are revoked.
- Rollback: revert the app commit while leaving the additive table/RPC/view in place; remove them only with a later forward migration after confirming no needed evidence would be lost.
- Data migration: additive schema only, no backfill or mutation of existing analytics rows.
- Production-smoke: call the RPC twice with one UUID (true then false), verify 20 report arms, and verify anonymous direct reads are denied.
- Observability: the service-role statistics view exposes unique views through signup completion while legacy daily aggregates remain available.
- Manual review unresolved findings: none.
