### PR TITLE
feat(growth): X候補の却下action + 候補listのstatuses[]バッチ (#4080)

### DIFF
--- a/lib/pages/admin_analytics_page.dart
+++ b/lib/pages/admin_analytics_page.dart
@@ -99,6 +99,8 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   // R34: edge の total (limit 前の総数) を status 別に保持。空なら「N件以上」表示。
   Map<String, int> _xCandidateTotals = const <String, int>{};
   final Set<String> _xCandidatePublishing = <String>{};
+  // #4080: 鮮度切れ一括却下の実行中フラグ (二重送信防止)。
+  bool _xCandidateRejecting = false;
   bool _isLoading = true;
   WeeklyDigestSnapshot _weeklyDigest = const WeeklyDigestSnapshot.empty();
   // R18: fetch 完了フラグ。empty() のままか、完了して空かを区別し、静かに失敗/空の
@@ -374,51 +376,124 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   /// degrade して panel ごと消す(ダッシュボードは必ず描画する)。
   Future<XCandidateQueueSnapshot> _loadXCandidateQueue() async {
     const statuses = ['pending_approval', 'approved', 'publish_failed'];
-    final results = await Future.wait(
-      statuses.map((status) async {
-        try {
-          final res = await _supabase.functions.invoke(
-            'growth-hub',
-            body: {
-              'action': 'x.candidate.list',
-              'status': status,
-              // R32: ヘッダの「N件以上」判定と同じ定数を使う (両者が drift すると
-              // 上限到達を検出できず backlog を過小表示する)。
-              'limit': kXCandidateStatusFetchLimit,
-            },
-          );
-          final data = res.data;
-          if (data is Map && data['success'] == true) {
+    // #4080: statuses[] を渡して 1 往復にまとめる (従来は status ごとに 3 往復
+    // + それぞれに CORS preflight)。edge 側は per-status limit を維持するので
+    // 上記 F2 の窓圧迫は起きない。
+    final byStatus = <String, XCandidateStatusPage>{};
+    try {
+      final res = await _supabase.functions.invoke(
+        'growth-hub',
+        body: {
+          'action': 'x.candidate.list',
+          'statuses': statuses,
+          // R32: ヘッダの「N件以上」判定と同じ定数を使う (両者が drift すると
+          // 上限到達を検出できず backlog を過小表示する)。
+          'limit': kXCandidateStatusFetchLimit,
+        },
+      );
+      final data = res.data;
+      if (data is Map && data['success'] == true && data['byStatus'] is Map) {
+        final raw = Map<String, dynamic>.from(data['byStatus'] as Map);
+        for (final status in statuses) {
+          final entry = raw[status];
+          if (entry is Map) {
             // R34: edge の total (limit 前の総数) を拾う。返さない場合は null の
             // まま = ヘッダは「N件以上」へ degrade。
-            final rawTotal = data['total'];
-            final total = rawTotal is num ? rawTotal.toInt() : null;
-            return (
-              status: status,
-              candidates: parseXPostCandidates(data['candidates']),
-              total: total,
+            final rawTotal = entry['total'];
+            byStatus[status] = XCandidateStatusPage(
+              candidates: parseXPostCandidates(entry['candidates']),
+              total: rawTotal is num ? rawTotal.toInt() : null,
             );
           }
-        } catch (error) {
-          debugPrint('x.candidate.list($status) unavailable: $error');
         }
-        return (
-          status: status,
-          candidates: const <XPostCandidateSummary>[],
-          total: null,
-        );
-      }),
-    );
+      }
+    } catch (error) {
+      debugPrint('x.candidate.list(batch) unavailable: $error');
+    }
     final totals = <String, int>{
-      for (final result in results)
-        if (result.total != null) result.status: result.total!,
+      for (final entry in byStatus.entries)
+        if (entry.value.total != null) entry.key: entry.value.total!,
     };
     return XCandidateQueueSnapshot(
-      candidates: mergeCandidateSummaries(
-        results.map((result) => result.candidates).toList(),
-      ),
+      candidates: mergeCandidateSummaries([
+        for (final status in statuses)
+          byStatus[status]?.candidates ?? const <XPostCandidateSummary>[],
+      ]),
       totalsByStatus: totals,
     );
+  }
+
+  /// #4080: 鮮度切れ候補をまとめて却下する。鮮度切れは「承認して投稿」が
+  /// 既に無効化されている(古いニュースの誤公開防止)ため、そのままだと
+  /// キューに残り続けて本当に見るべき候補を埋没させる。終端 status
+  /// 'rejected' へ落として一覧から外す。
+  Future<void> _rejectStaleXCandidates(
+    List<XPostCandidateSummary> staleCandidates,
+  ) async {
+    if (staleCandidates.isEmpty || _xCandidateRejecting) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('鮮度切れ候補をまとめて却下'),
+        content: Text(
+          '${staleCandidates.length}件を却下します。'
+          '却下した候補は投稿できなくなります(一覧からは消えます)。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('却下する'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    setState(() => _xCandidateRejecting = true);
+    try {
+      final res = await _supabase.functions.invoke(
+        'growth-hub',
+        body: {
+          'action': 'x.candidate.reject',
+          'candidateIds': staleCandidates.map((c) => c.id).toList(),
+          'reason': 'freshness_expired',
+        },
+      );
+      final data = res.data;
+      final rejected = data is Map && data['rejected'] is List
+          ? (data['rejected'] as List).length
+          : 0;
+      final failures = data is Map && data['failures'] is List
+          ? (data['failures'] as List).length
+          : 0;
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            failures > 0
+                ? '$rejected件を却下しました($failures件は失敗)'
+                : '$rejected件を却下しました',
+          ),
+        ),
+      );
+      final refreshed = await _loadXCandidateQueue();
+      if (mounted) {
+        setState(() {
+          _xCandidates = refreshed.candidates;
+          _xCandidateTotals = refreshed.totalsByStatus;
+        });
+      }
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('却下に失敗しました: $error')));
+    } finally {
+      if (mounted) setState(() => _xCandidateRejecting = false);
+    }
   }
 
   /// R26: 候補を承認→投稿→確定する HITL フロー。無審査自動投稿はしない
@@ -6539,6 +6614,12 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
   Widget _buildXCandidateQueueSection() {
     if (_xCandidates.isEmpty) return const SizedBox.shrink();
     final theme = Theme.of(context);
+    // #4080: 鮮度切れ候補は「承認して投稿」が無効化済み = キューに滞留して
+    // 見るべき候補を埋没させる。まとめて終端 status へ落とせるようにする。
+    final now = DateTime.now();
+    final staleCandidates = _xCandidates
+        .where((candidate) => isCandidateExpired(candidate, now))
+        .toList(growable: false);
     return Padding(
       padding: const EdgeInsets.only(top: 16),
       child: Card(
@@ -6568,6 +6649,23 @@ class _AdminAnalyticsPageState extends State<AdminAnalyticsPage> {
                       ),
                     ),
                   ),
+                  if (staleCandidates.isNotEmpty)
+                    TextButton.icon(
+                      onPressed: _xCandidateRejecting
+                          ? null
+                          : () => _rejectStaleXCandidates(staleCandidates),
+                      icon: _xCandidateRejecting
+                          ? const SizedBox(
+                              width: 14,
+                              height: 14,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.block, size: 16),
+                      label: Text('鮮度切れ${staleCandidates.length}件を却下'),
+                      style: TextButton.styleFrom(
+                        foregroundColor: const Color(0xFFB91C1C),
+                      ),
+                    ),
                 ],
               ),
               const SizedBox(height: 4),

--- a/lib/pages/admin_x_candidate_queue.dart
+++ b/lib/pages/admin_x_candidate_queue.dart
@@ -275,6 +275,15 @@ String candidateQueueHeaderLabel(
 /// R34: 候補キューの取得結果。`totalsByStatus` は edge の `total`
 /// (limit で切る前の総数) を status 別に保持する。edge が返さなかった status は
 /// 欠落し、ヘッダは従来の「N件以上」表示へ degrade する。
+/// #4080: x.candidate.list の statuses[] バッチ応答 1 status 分。
+/// total は limit で切る前の総数 (取得できなければ null = 「N件以上」表示へ)。
+class XCandidateStatusPage {
+  final List<XPostCandidateSummary> candidates;
+  final int? total;
+
+  const XCandidateStatusPage({required this.candidates, this.total});
+}
+
 class XCandidateQueueSnapshot {
   final List<XPostCandidateSummary> candidates;
   final Map<String, int> totalsByStatus;

--- a/supabase/functions/growth-hub/index.ts
+++ b/supabase/functions/growth-hub/index.ts
@@ -69,6 +69,7 @@ import {
   approveXPostCandidateMetadata,
   buildXPostCandidateMetadata,
   finalizeXPostCandidateMetadata,
+  rejectXPostCandidateMetadata,
   X_POST_CANDIDATE_SOURCE,
 } from "./x_post_candidate.ts";
 import {
@@ -2699,33 +2700,65 @@ serve(async (req: Request) => {
           Math.min(100, Math.trunc(firstNumber(body.limit) ?? 50)),
         );
         const requestedStatus = firstString(body.status);
+        // #4080: statuses[] を渡すと 1 リクエストで複数 status を返す
+        // (client は従来 3 status を 3 往復していた)。
+        // 🔑 **per-status limit は維持する** — 単一 IN() + 共有 limit にすると
+        // finalized 行が created_at 降順 window を埋めて古い承認待ちを黙って
+        // 押し出す F2 の窓圧迫が status 間で再発する。
+        const rawStatuses = Array.isArray(body.statuses)
+          ? (body.statuses as unknown[]).map((entry) => firstString(entry))
+            .filter(Boolean)
+          : [];
+        const batchStatuses = [...new Set(rawStatuses)].slice(0, 10);
+
         // R34: count:"exact" で「limit で切る前の総数」も返す。従来は limit 件しか
         // 返さないため client 側は上限に達したかしか分からず、承認待ちが 11 件でも
         // 200 件でも「10件以上」としか出せなかった (backlog の規模が掴めない)。
         // source は idx_hub_data_source があり EF は service_role なので、count は
         // x_post_candidate 部分集合への index scan で収まる (agent_memories のような
         // 無索引全表走査にはならない)。
-        let query = admin
-          .from("hub_data")
-          .select("id, metadata, created_at", { count: "exact" })
-          .eq("source", X_POST_CANDIDATE_SOURCE)
-          .order("created_at", { ascending: false })
-          .limit(limit);
-        if (requestedStatus) {
-          query = query.filter(
-            "metadata->>status",
-            "eq",
-            requestedStatus,
+        const runQuery = async (status: string) => {
+          let query = admin
+            .from("hub_data")
+            .select("id, metadata, created_at", { count: "exact" })
+            .eq("source", X_POST_CANDIDATE_SOURCE)
+            .order("created_at", { ascending: false })
+            .limit(limit);
+          if (status) {
+            query = query.filter("metadata->>status", "eq", status);
+          }
+          const { data, error, count } = await query;
+          if (error) throw new Error(error.message);
+          return {
+            candidates: data ?? [],
+            // limit で切る前の総数。取得できないときは null (client は従来の
+            // 「N件以上」表示へ degrade する)。
+            total: typeof count === "number" ? count : null,
+          };
+        };
+
+        if (batchStatuses.length > 0) {
+          const results = await Promise.all(
+            batchStatuses.map(async (status) => ({
+              status,
+              ...(await runQuery(status)),
+            })),
           );
+          const byStatus: Record<string, unknown> = {};
+          for (const result of results) {
+            byStatus[result.status] = {
+              candidates: result.candidates,
+              total: result.total,
+            };
+          }
+          return json({ success: true, byStatus });
         }
-        const { data, error, count } = await query;
-        if (error) throw new Error(error.message);
+
+        const single = await runQuery(requestedStatus);
         return json({
           success: true,
-          candidates: data ?? [],
-          // limit で切る前の総数。取得できないときは null (client は従来の
-          // 「N件以上」表示へ degrade する)。
-          total: typeof count === "number" ? count : null,
+          candidates: single.candidates,
+          total: single.total,
         });
       }
 
@@ -2919,6 +2952,94 @@ serve(async (req: Request) => {
           // the exact whitelisted payload reviewed by the operator.
           postPayload: { ...approved.postPayload, candidateId },
         });
+      }
+
+      case "x.candidate.reject": {
+        if (!await isXOperator(admin, userId!)) {
+          return json({ error: "Forbidden: X operator role required" }, 403);
+        }
+        // 単体 (candidateId) と一括 (candidateIds[]) の両対応。UI の
+        // 「鮮度切れをまとめて却下」は後者を使う。
+        const rawIds = Array.isArray(body.candidateIds ?? body.candidate_ids)
+          ? (body.candidateIds ?? body.candidate_ids) as unknown[]
+          : [];
+        const singleId = firstString(body.candidateId, body.candidate_id);
+        const requestedIds = [
+          ...(singleId ? [singleId] : []),
+          ...rawIds.map((entry) => firstString(entry)),
+        ].filter(Boolean);
+        // 重複除去して順序は入力順を維持 (結果の突き合わせを容易にする)。
+        const candidateIds = [...new Set(requestedIds)];
+        if (candidateIds.length === 0) {
+          return json(
+            { success: false, error: "candidateId or candidateIds required" },
+            400,
+          );
+        }
+        if (candidateIds.some((id) => !isUuid(id))) {
+          return json(
+            { success: false, error: "all candidate ids must be uuid" },
+            400,
+          );
+        }
+        // 一括は 1 リクエストあたり 50 件で頭打ち (F2 window 圧迫と
+        // 長時間トランザクションを避ける)。超過は明示エラーで気付かせる。
+        if (candidateIds.length > 50) {
+          return json(
+            { success: false, error: "at most 50 candidate ids per request" },
+            400,
+          );
+        }
+        const rejectedBy = userId === "service_role"
+          ? firstString(body.rejectedBy, body.rejected_by, "service_role")
+          : userId!;
+        const reason = body.reason ?? body.rejectReason ?? body.reject_reason;
+
+        const rejected: string[] = [];
+        const unchanged: string[] = [];
+        const failures: { candidateId: string; error: string }[] = [];
+        for (const candidateId of candidateIds) {
+          try {
+            const { data: candidate, error: candidateError } = await admin
+              .from("hub_data")
+              .select("id, metadata, created_at")
+              .eq("id", candidateId)
+              .eq("source", X_POST_CANDIDATE_SOURCE)
+              .maybeSingle();
+            if (candidateError) throw new Error(candidateError.message);
+            if (!candidate) {
+              failures.push({ candidateId, error: "candidate not found" });
+              continue;
+            }
+            const result = rejectXPostCandidateMetadata(
+              asRecord(candidate.metadata),
+              { actorUserId: userId!, rejectedBy, reason },
+            );
+            if (!result.changed) {
+              // 既に終端 (rejected / rejected_duplicate) = 冪等 no-op。
+              unchanged.push(candidateId);
+              continue;
+            }
+            const { error: updateError } = await admin
+              .from("hub_data")
+              .update({ metadata: result.metadata })
+              .eq("id", candidateId)
+              .eq("source", X_POST_CANDIDATE_SOURCE);
+            if (updateError) throw new Error(updateError.message);
+            rejected.push(candidateId);
+          } catch (error) {
+            // 1 件の失敗で残りを巻き添えにしない (一括却下の途中終了防止)。
+            failures.push({ candidateId, error: errorMessage(error) });
+          }
+        }
+        return json({
+          success: failures.length === 0,
+          status: "rejected",
+          requested: candidateIds.length,
+          rejected,
+          unchanged,
+          failures,
+        }, failures.length > 0 && rejected.length === 0 ? 400 : 200);
       }
 
       case "x.candidate.finalize": {

--- a/supabase/functions/growth-hub/x_post_candidate.ts
+++ b/supabase/functions/growth-hub/x_post_candidate.ts
@@ -34,6 +34,12 @@ export type XPostCandidateApproval = {
   context?: unknown;
 };
 
+export type XPostCandidateRejection = {
+  actorUserId: string;
+  rejectedBy: string;
+  reason?: unknown;
+};
+
 function asRecord(value: unknown): JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? value as JsonRecord
@@ -302,6 +308,47 @@ export function approveXPostCandidateMetadata(
       post_payload: postPayload,
     },
     postPayload,
+  };
+}
+
+/// 却下 = 運用者が「もう投稿しない」と決めた終端状態 (#4080)。
+///
+/// 状態機械の設計判断:
+/// - 却下できるのは actionable な 3 状態のみ。`posted` は既に公開済みで
+///   取り消しにはならず、却下扱いにすると「投稿していない」と誤読させる。
+/// - `rejected` / `rejected_duplicate` は既に終端なので **冪等に no-op**
+///   (再押下やバッチ再送でエラーにしない)。ただし最初の却下情報は保持する。
+/// - 却下は投稿試行ではないので `publish_attempts` を増やさない。
+export function rejectXPostCandidateMetadata(
+  value: unknown,
+  rejection: XPostCandidateRejection,
+  now = new Date(),
+): { metadata: JsonRecord; changed: boolean } {
+  const metadata = asRecord(value);
+  const status = firstString(metadata.status);
+  if (status === "rejected" || status === "rejected_duplicate") {
+    return { metadata, changed: false };
+  }
+  if (!["pending_approval", "approved", "publish_failed"].includes(status)) {
+    throw new Error(`draft status ${status || "missing"} cannot be rejected`);
+  }
+  const actorUserId = firstString(rejection.actorUserId);
+  const rejectedBy = firstString(rejection.rejectedBy);
+  if (!actorUserId || !rejectedBy) {
+    throw new Error("rejection actor and rejector are required");
+  }
+  const rejectedAt = now.toISOString();
+  return {
+    metadata: {
+      ...metadata,
+      status: "rejected",
+      rejected_at: rejectedAt,
+      rejected_by: rejectedBy.slice(0, 200),
+      rejection_actor_user_id: actorUserId.slice(0, 200),
+      reject_reason: limitedString(rejection.reason, 500) ?? null,
+      updated_at: rejectedAt,
+    },
+    changed: true,
   };
 }
 

--- a/supabase/functions/growth-hub/x_post_candidate_test.ts
+++ b/supabase/functions/growth-hub/x_post_candidate_test.ts
@@ -7,6 +7,7 @@ import {
   buildXPostCandidateMetadata,
   finalizeXPostCandidateMetadata,
   normalizeXPostCandidatePayload,
+  rejectXPostCandidateMetadata,
 } from "./x_post_candidate.ts";
 
 const NOW = new Date("2026-07-12T10:00:00.000Z");
@@ -214,4 +215,148 @@ Deno.test("duplicate rejection is retained as an auditable terminal status", () 
   assertEquals(rejected.status, "rejected_duplicate");
   assertEquals(rejected.publish_code, "duplicate_content");
   assertEquals(rejected.publish_error, "same content");
+});
+
+const REJECTED_AT = new Date("2026-07-22T09:00:00.000Z");
+
+Deno.test("rejection is audited and moves an actionable draft to the terminal state", () => {
+  const draft = buildXPostCandidateMetadata({ text: "stale news" }, {
+    now: NOW,
+  });
+  const rejected = rejectXPostCandidateMetadata(
+    draft,
+    {
+      actorUserId: "operator-uuid",
+      rejectedBy: "operator-uuid",
+      reason: "freshness_expired",
+    },
+    REJECTED_AT,
+  );
+
+  assertEquals(rejected.changed, true);
+  assertEquals(rejected.metadata.status, "rejected");
+  assertEquals(rejected.metadata.rejected_at, REJECTED_AT.toISOString());
+  assertEquals(rejected.metadata.rejected_by, "operator-uuid");
+  assertEquals(rejected.metadata.reject_reason, "freshness_expired");
+});
+
+Deno.test("rejection does not count as a publish attempt", () => {
+  const draft = buildXPostCandidateMetadata({ text: "retry me" }, { now: NOW });
+  const approved = approveXPostCandidateMetadata(draft, {
+    actorUserId: "operator-uuid",
+    approvedBy: "operator-uuid",
+    channel: "admin_ui",
+  }, APPROVED_AT);
+  assertEquals(approved.metadata.publish_attempts, 1);
+
+  const rejected = rejectXPostCandidateMetadata(approved.metadata, {
+    actorUserId: "operator-uuid",
+    rejectedBy: "operator-uuid",
+  }, REJECTED_AT);
+  // 却下は投稿試行ではない: approve が積んだ回数をそのまま保つ。
+  assertEquals(rejected.metadata.publish_attempts, 1);
+});
+
+Deno.test("approved and publish_failed drafts can still be rejected", () => {
+  const draft = buildXPostCandidateMetadata({ text: "retry me" }, { now: NOW });
+  const approved = approveXPostCandidateMetadata(draft, {
+    actorUserId: "operator-uuid",
+    approvedBy: "operator-uuid",
+    channel: "admin_ui",
+  }, APPROVED_AT);
+  const failed = finalizeXPostCandidateMetadata(
+    approved.metadata,
+    { posted: false, error: "network", code: "transient" },
+    APPROVED_AT,
+  );
+  assertEquals(failed.status, "publish_failed");
+
+  for (const source of [approved.metadata, failed]) {
+    const rejected = rejectXPostCandidateMetadata(source, {
+      actorUserId: "operator-uuid",
+      rejectedBy: "operator-uuid",
+    }, REJECTED_AT);
+    assertEquals(rejected.changed, true);
+    assertEquals(rejected.metadata.status, "rejected");
+    assertEquals(rejected.metadata.reject_reason, null);
+  }
+});
+
+Deno.test("rejecting a terminal draft is an idempotent no-op that keeps the first audit", () => {
+  const draft = buildXPostCandidateMetadata({ text: "stale" }, { now: NOW });
+  const first = rejectXPostCandidateMetadata(draft, {
+    actorUserId: "operator-uuid",
+    rejectedBy: "operator-uuid",
+    reason: "freshness_expired",
+  }, REJECTED_AT);
+  const second = rejectXPostCandidateMetadata(first.metadata, {
+    actorUserId: "another-operator",
+    rejectedBy: "another-operator",
+    reason: "changed my mind",
+  }, new Date("2026-07-23T09:00:00.000Z"));
+
+  assertEquals(second.changed, false);
+  assertEquals(second.metadata.rejected_at, REJECTED_AT.toISOString());
+  assertEquals(second.metadata.rejected_by, "operator-uuid");
+  assertEquals(second.metadata.reject_reason, "freshness_expired");
+});
+
+Deno.test("rejected_duplicate is already terminal and is not overwritten", () => {
+  const draft = buildXPostCandidateMetadata({ text: "dupe" }, { now: NOW });
+  const approved = approveXPostCandidateMetadata(draft, {
+    actorUserId: "operator-uuid",
+    approvedBy: "operator-uuid",
+    channel: "admin_ui",
+  }, APPROVED_AT);
+  const duplicate = finalizeXPostCandidateMetadata(approved.metadata, {
+    posted: false,
+    code: "duplicate_content",
+  }, APPROVED_AT);
+  assertEquals(duplicate.status, "rejected_duplicate");
+
+  const result = rejectXPostCandidateMetadata(duplicate, {
+    actorUserId: "operator-uuid",
+    rejectedBy: "operator-uuid",
+  }, REJECTED_AT);
+  assertEquals(result.changed, false);
+  assertEquals(result.metadata.status, "rejected_duplicate");
+});
+
+Deno.test("a posted draft cannot be rejected", () => {
+  const draft = buildXPostCandidateMetadata({ text: "already live" }, {
+    now: NOW,
+  });
+  const approved = approveXPostCandidateMetadata(draft, {
+    actorUserId: "operator-uuid",
+    approvedBy: "operator-uuid",
+    channel: "admin_ui",
+  }, APPROVED_AT);
+  const posted = finalizeXPostCandidateMetadata(approved.metadata, {
+    posted: true,
+    tweetId: "2076129162553889018",
+  }, APPROVED_AT);
+  assertEquals(posted.status, "posted");
+
+  assertThrows(
+    () =>
+      rejectXPostCandidateMetadata(posted, {
+        actorUserId: "operator-uuid",
+        rejectedBy: "operator-uuid",
+      }, REJECTED_AT),
+    Error,
+    "cannot be rejected",
+  );
+});
+
+Deno.test("rejection requires actor and rejector", () => {
+  const draft = buildXPostCandidateMetadata({ text: "x" }, { now: NOW });
+  assertThrows(
+    () =>
+      rejectXPostCandidateMetadata(draft, {
+        actorUserId: "",
+        rejectedBy: "operator-uuid",
+      }, REJECTED_AT),
+    Error,
+    "required",
+  );
 });


### PR DESCRIPTION
## Summary

Issue #4080 (PR #4079 の10仮説検証 H1/H9 の EF 側積み残し) のうち、**差分精査で未実装と確定した2項目**を実装しました。

### 差分精査の結果 (着手前)

| 項目 | 状態 |
|------|------|
| 1. CORS `Access-Control-Max-Age` | ✅ **実装済み** — `_shared/edge.ts` ほか21ファイルに `86400` 済み。Issue記載の「現状 Max-Age 無し」は古い情報のため対応不要 |
| 2. `x.candidate.list` の statuses[] バッチ | ❌ 未実装 → 本PR |
| 3. `x.candidate.reject` | ❌ 未実装 → 本PR |
| 4. `dashboard.context` 集約 (任意) | ❌ 未実装 → per-section 認可の設計が要るため別Issueへ |

### 3. x.candidate.reject (状態機械の行き止まり解消)

UI には `'rejected' → '却下済み'` ラベルと鮮度切れ判定が既にある (PR #4079) のに、**その状態へ遷移する手段が EF に存在しませんでした**。鮮度切れ候補は「承認して投稿」が無効化されるだけでキューに滞留し、本当に見るべき候補を埋没させます。

- 純関数 `rejectXPostCandidateMetadata`: actionable 3状態のみ却下可 / `posted` は却下不可 (公開済みを「投稿していない」と誤読させるため) / `rejected`・`rejected_duplicate` は**冪等 no-op で初回の監査情報を保持** / 却下は投稿試行ではないので `publish_attempts` を増やさない
- action: `isXOperator` ゲート、`candidateId` 単体 + `candidateIds[]` 一括 (上限50)、**1件の失敗で残りを巻き添えにしない**per-candidate 隔離
- UI: キューヘッダに「鮮度切れN件を却下」ボタン (確認ダイアログ + 二重送信防止)

### 2. x.candidate.list の statuses[] バッチ

クライアントが3 status を3往復していたのを1往復に集約 (preflight 込みで削減)。🔑 **per-status limit は維持** — 単一 `IN()` + 共有 limit にすると finalized 行が `created_at` 降順 window を埋めて古い承認待ちを黙って押し出す F2 の窓圧迫が status 間で再発するため。`status` 単体指定の従来経路は後方互換で維持。

### 検証

- deno test 13件 (却下の状態遷移: 終端/不正遷移/冪等/監査保持/actor必須)
- `flutter analyze` No issues / `dart format` 0 changed

Closes #4080

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: Deno EF action + admin-only operator UI behind X-operator role, covered by deno unit tests for the state machine

## High-Risk Ultrareview

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: additive EF action guarded by the existing isXOperator gate; reject is a terminal metadata transition with no destructive delete, idempotent on already-terminal rows, and the batch list path keeps the per-status limit that prevents the F2 window regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
