### PR TITLE
fix: preserve LP signup completion across auth redirects

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -310,6 +310,7 @@ import 'package:my_web_app/pages/health_check_page.dart';
 import 'package:my_web_app/dev/claude_design/importer_page.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:my_web_app/services/landing_signup_completion_service.dart';
 import 'package:my_web_app/services/notification_service.dart';
 import 'package:my_web_app/services/theme_service.dart';
 import 'package:my_web_app/widgets/global_header_clock_bar.dart';
@@ -396,7 +397,9 @@ Future<void> _configureStartupNotifications(
 }
 
 class _AuthenticatedHomePage extends StatefulWidget {
-  const _AuthenticatedHomePage();
+  const _AuthenticatedHomePage({required this.signupCompletionService});
+
+  final LandingSignupCompletionService signupCompletionService;
 
   @override
   State<_AuthenticatedHomePage> createState() => _AuthenticatedHomePageState();
@@ -407,8 +410,16 @@ class _AuthenticatedHomePageState extends State<_AuthenticatedHomePage> {
 
   Future<bool> _shouldShowOnboarding() async {
     try {
-      final userId = supabase.auth.currentUser?.id;
+      final user = supabase.auth.currentUser;
+      final userId = user?.id;
       if (userId == null) return false;
+      unawaited(
+        widget.signupCompletionService.completeIfPending(
+          signupUserId: userId,
+          signupEmail: user?.email,
+          accountCreatedAt: DateTime.tryParse(user?.createdAt ?? ''),
+        ),
+      );
       final response = await supabase
           .from('user_stats')
           .select('metadata')
@@ -455,7 +466,12 @@ String _initialRouteName() {
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({super.key});
+  const MyApp({
+    super.key,
+    this.signupCompletionService = const LandingSignupCompletionService(),
+  });
+
+  final LandingSignupCompletionService signupCompletionService;
 
   static final SentryNavigatorObserver? _sentryNavigatorObserver =
       ErrorReporter.instance.sentryEnabled ? SentryNavigatorObserver() : null;
@@ -557,11 +573,19 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           case '/':
             return MaterialPageRoute(
               builder: (_) => supabase.auth.currentSession != null
-                  ? const _AuthenticatedHomePage()
-                  : const LandingPage(),
+                  ? _AuthenticatedHomePage(
+                      signupCompletionService: widget.signupCompletionService,
+                    )
+                  : LandingPage(
+                      signupCompletionService: widget.signupCompletionService,
+                    ),
             );
           case '/login':
-            return MaterialPageRoute(builder: (_) => const LandingPage());
+            return MaterialPageRoute(
+              builder: (_) => LandingPage(
+                signupCompletionService: widget.signupCompletionService,
+              ),
+            );
           case '/home':
             return MaterialPageRoute(builder: (_) => const HomePage());
           case '/agents':
@@ -822,7 +846,11 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           case '/u':
             final userId = uri.queryParameters['id'] ?? '';
             if (userId.isEmpty) {
-              return MaterialPageRoute(builder: (_) => const LandingPage());
+              return MaterialPageRoute(
+                builder: (_) => LandingPage(
+                  signupCompletionService: widget.signupCompletionService,
+                ),
+              );
             }
             return MaterialPageRoute(
               builder: (_) => PublicProfilePage(userId: userId),
@@ -1723,7 +1751,11 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                 settings: settings,
               );
             }
-            return MaterialPageRoute(builder: (_) => const LandingPage());
+            return MaterialPageRoute(
+              builder: (_) => LandingPage(
+                signupCompletionService: widget.signupCompletionService,
+              ),
+            );
         }
       },
     );

--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -10,6 +10,7 @@ import '../services/growth_acquisition_service.dart';
 import '../services/growth_mission_service.dart';
 import '../services/landing_conversion_experiment_service.dart';
 import '../services/landing_page_adapter.dart';
+import '../services/landing_signup_completion_service.dart';
 import '../services/pending_landing_trial_service.dart';
 import '../services/route_visibility_observer.dart';
 import '../widgets/live_growth_banner.dart';
@@ -20,6 +21,7 @@ class LandingPage extends StatefulWidget {
   final LandingPageAdapter adapter;
   final GrowthMissionService growthService;
   final LandingConversionExperimentService conversionExperimentService;
+  final LandingSignupCompletionService signupCompletionService;
   final PendingLandingTrialService pendingTrialService;
   final LandingExperimentAssignment? experimentAssignment;
   final bool? analyticsEnabled;
@@ -29,6 +31,7 @@ class LandingPage extends StatefulWidget {
     LandingPageAdapter? adapter,
     GrowthMissionService? growthService,
     LandingConversionExperimentService? conversionExperimentService,
+    LandingSignupCompletionService? signupCompletionService,
     PendingLandingTrialService? pendingTrialService,
     this.experimentAssignment,
     this.analyticsEnabled,
@@ -36,6 +39,8 @@ class LandingPage extends StatefulWidget {
         growthService = growthService ?? const GrowthMissionService(),
         pendingTrialService =
             pendingTrialService ?? const PendingLandingTrialService(),
+        signupCompletionService =
+            signupCompletionService ?? const LandingSignupCompletionService(),
         conversionExperimentService = conversionExperimentService ??
             const LandingConversionExperimentService();
 
@@ -67,7 +72,6 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
   StreamSubscription<AuthState>? _authSubscription;
   Timer? _magicLinkCooldownTimer;
-  final Set<String> _signupNotificationUserIds = <String>{};
 
   bool _isLoading = false;
   bool _isTrialLoading = false;
@@ -130,8 +134,15 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     _authSubscription = widget.adapter.authStateChanges().listen((data) {
       if (!mounted) return;
       if (data.event == AuthChangeEvent.signedIn && data.session != null) {
-        unawaited(_recordConversionStage('signup_complete'));
-        unawaited(_notifySignupIfPossible(data.session?.user.id));
+        unawaited(
+          widget.signupCompletionService.completeIfPending(
+            signupUserId: data.session?.user.id,
+            signupEmail: data.session?.user.email,
+            accountCreatedAt: DateTime.tryParse(
+              data.session?.user.createdAt ?? '',
+            ),
+          ),
+        );
         unawaited(widget.growthService.applyPendingReferralIfPossible());
         _goToAuthenticatedEntry();
       }
@@ -246,17 +257,6 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
   }
 
-  Future<void> _notifySignupIfPossible(String? signupUserId) async {
-    final userId = signupUserId?.trim();
-    if (userId == null || userId.isEmpty) {
-      return;
-    }
-    if (!_signupNotificationUserIds.add(userId)) {
-      return;
-    }
-    await _acquisitionService.notifySignupSuccess(signupUserId: userId);
-  }
-
   Future<void> _bootstrapReferralInvite() async {
     await widget.growthService.capturePendingReferralFromUri();
     final pendingReferralCode =
@@ -344,8 +344,12 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     }
 
     setState(() => _isLoading = true);
+    final tracksSignup = _isSignUp && _analyticsEnabled;
     try {
       if (_isSignUp) {
+        if (tracksSignup) {
+          await _markSignupCompletionPending(email: email);
+        }
         unawaited(_recordConversionStage('signup_submit'));
         unawaited(_acquisitionService.recordLandingSignupSubmit());
         final result = await widget.adapter.signUp(
@@ -353,7 +357,6 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
           password: password,
           emailRedirectTo: _webRedirectUrl,
         );
-        unawaited(_notifySignupIfPossible(result.user?.id));
         if (!mounted) return;
         if (result.session == null) {
           _showMessage('確認メールを送信しました。メール内のリンクから登録を完了してください。');
@@ -365,8 +368,14 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
         );
       }
     } on LandingPageAuthUnavailableException {
+      if (tracksSignup) {
+        await widget.signupCompletionService.cancelPending(email: email);
+      }
       _showMessage('認証機能を初期化できませんでした。');
     } catch (error) {
+      if (tracksSignup) {
+        await widget.signupCompletionService.cancelPending(email: email);
+      }
       _showMessage(_resolveEmailAuthError(error));
     } finally {
       if (mounted) {
@@ -385,17 +394,29 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
     setState(() => _isLoading = true);
     try {
+      if (_analyticsEnabled) {
+        await _markSignupCompletionPending();
+      }
       unawaited(_recordConversionStage('signup_submit'));
       unawaited(_acquisitionService.recordLandingSignupSubmit());
       final launched = await widget.adapter.signInWithGoogle(
         redirectTo: _webRedirectUrl,
       );
       if (!launched) {
+        if (_analyticsEnabled) {
+          await widget.signupCompletionService.cancelPending();
+        }
         _showMessage('Googleログイン画面を開けませんでした。再読み込みしてから再実行してください。');
       }
     } on LandingPageAuthUnavailableException {
+      if (_analyticsEnabled) {
+        await widget.signupCompletionService.cancelPending();
+      }
       _showMessage('認証機能を初期化できませんでした。');
     } catch (error) {
+      if (_analyticsEnabled) {
+        await widget.signupCompletionService.cancelPending();
+      }
       _showMessage(_resolveGoogleAuthError(error));
     } finally {
       if (mounted) {
@@ -417,6 +438,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
     setState(() => _isLoading = true);
     try {
+      if (_analyticsEnabled) {
+        await _markSignupCompletionPending(email: email);
+      }
       unawaited(_recordConversionStage('signup_submit'));
       unawaited(_acquisitionService.recordLandingSignupSubmit());
       await widget.adapter.sendMagicLink(
@@ -433,8 +457,14 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       _startMagicLinkCooldown();
       _showMessage('Magic Link を送信しました。メール内のリンクからそのまま開始できます。');
     } on LandingPageAuthUnavailableException {
+      if (_analyticsEnabled) {
+        await widget.signupCompletionService.cancelPending(email: email);
+      }
       _showMessage('認証機能を初期化できませんでした。');
     } catch (error) {
+      if (_analyticsEnabled) {
+        await widget.signupCompletionService.cancelPending(email: email);
+      }
       if (mounted) {
         setState(() => _showInboxShortcut = false);
       }
@@ -443,6 +473,20 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       if (mounted) {
         setState(() => _isLoading = false);
       }
+    }
+  }
+
+  Future<void> _markSignupCompletionPending({String? email}) async {
+    try {
+      final assignment = await _resolveExperimentAssignment();
+      final visitorId = await _resolveExperimentVisitorId();
+      await widget.signupCompletionService.markPending(
+        email: email,
+        eventKey: assignment.eventKey('signup_complete'),
+        visitorId: visitorId,
+      );
+    } catch (error) {
+      debugPrint('Landing signup completion attribution failed: $error');
     }
   }
 

--- a/lib/services/landing_signup_completion_service.dart
+++ b/lib/services/landing_signup_completion_service.dart
@@ -1,0 +1,241 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'growth_acquisition_service.dart';
+import 'landing_conversion_experiment_service.dart';
+import 'landing_page_adapter.dart';
+
+class PendingLandingSignup {
+  const PendingLandingSignup({
+    required this.email,
+    required this.eventKey,
+    required this.visitorId,
+    required this.createdAt,
+  });
+
+  final String? email;
+  final String eventKey;
+  final String visitorId;
+  final DateTime createdAt;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'version': 1,
+        'email': email,
+        'event_key': eventKey,
+        'visitor_id': visitorId,
+        'created_at': createdAt.toUtc().toIso8601String(),
+      };
+
+  static PendingLandingSignup? fromJson(Object? value) {
+    if (value is! Map) return null;
+    final data = Map<String, dynamic>.from(value);
+    if (data['version'] != 1) return null;
+
+    final normalizedEmail = data['email']?.toString().trim().toLowerCase();
+    final eventKey = data['event_key']?.toString().trim() ?? '';
+    final visitorId = data['visitor_id']?.toString().trim().toLowerCase() ?? '';
+    final createdAt = DateTime.tryParse(data['created_at']?.toString() ?? '');
+    if ((normalizedEmail != null &&
+            normalizedEmail.isNotEmpty &&
+            !normalizedEmail.contains('@')) ||
+        !LandingConversionExperimentService.isExperimentEventKey(eventKey) ||
+        !eventKey.endsWith('_signup_complete') ||
+        !LandingConversionExperimentService.isValidVisitorId(visitorId) ||
+        createdAt == null) {
+      return null;
+    }
+
+    return PendingLandingSignup(
+      email: normalizedEmail == null || normalizedEmail.isEmpty
+          ? null
+          : normalizedEmail,
+      eventKey: eventKey,
+      visitorId: visitorId,
+      createdAt: createdAt.toUtc(),
+    );
+  }
+}
+
+/// Carries an LP signup intent across external auth redirects.
+///
+/// The authenticated route can be selected before [LandingPage] mounts, so
+/// signup completion cannot depend on the LP auth listener alone. This service
+/// stores only attribution metadata and consumes it after authentication.
+class LandingSignupCompletionService {
+  const LandingSignupCompletionService({
+    this.ttl = const Duration(hours: 48),
+    LandingPageAdapter? landingPageAdapter,
+    GrowthAcquisitionService? acquisitionService,
+    DateTime Function()? clock,
+  })  : _landingPageAdapter =
+            landingPageAdapter ?? const SupabaseLandingPageAdapter(),
+        _acquisitionService =
+            acquisitionService ?? const GrowthAcquisitionService(),
+        _clock = clock;
+
+  static const String storageKey = 'pending_landing_signup_v1';
+  static const Duration _accountCreationClockSkew = Duration(minutes: 5);
+  static final Map<String, Future<bool>> _inFlight = <String, Future<bool>>{};
+
+  final Duration ttl;
+  final LandingPageAdapter _landingPageAdapter;
+  final GrowthAcquisitionService _acquisitionService;
+  final DateTime Function()? _clock;
+
+  DateTime _now() => (_clock ?? DateTime.now)().toUtc();
+
+  Future<void> markPending({
+    required String eventKey,
+    required String visitorId,
+    String? email,
+    SharedPreferences? preferences,
+  }) async {
+    final pending = PendingLandingSignup(
+      email: _normalizeEmail(email),
+      eventKey: eventKey.trim(),
+      visitorId: visitorId.trim().toLowerCase(),
+      createdAt: _now(),
+    );
+    if (PendingLandingSignup.fromJson(pending.toJson()) == null) {
+      throw ArgumentError('Pending landing signup attribution is invalid.');
+    }
+
+    final prefs = preferences ?? await SharedPreferences.getInstance();
+    await prefs.setString(storageKey, jsonEncode(pending.toJson()));
+  }
+
+  Future<bool> cancelPending({
+    String? email,
+    SharedPreferences? preferences,
+  }) async {
+    final prefs = preferences ?? await SharedPreferences.getInstance();
+    final pending = await _readValid(prefs);
+    if (pending == null) return false;
+
+    final normalizedEmail = _normalizeEmail(email);
+    if (normalizedEmail != null && pending.email != normalizedEmail) {
+      return false;
+    }
+    return _removeIfCurrent(prefs, pending);
+  }
+
+  Future<bool> completeIfPending({
+    required String? signupUserId,
+    String? signupEmail,
+    DateTime? accountCreatedAt,
+    SharedPreferences? preferences,
+  }) async {
+    try {
+      final userId = signupUserId?.trim() ?? '';
+      if (userId.isEmpty) return false;
+
+      final prefs = preferences ?? await SharedPreferences.getInstance();
+      final pending = await _readValid(prefs);
+      if (pending == null) return false;
+
+      final normalizedSignupEmail = _normalizeEmail(signupEmail);
+      if (pending.email != null && pending.email != normalizedSignupEmail) {
+        return false;
+      }
+
+      final createdAt = accountCreatedAt?.toUtc();
+      if (createdAt != null &&
+          createdAt.isBefore(
+            pending.createdAt.subtract(_accountCreationClockSkew),
+          )) {
+        await _removeIfCurrent(prefs, pending);
+        return false;
+      }
+
+      final operationKey = '$userId:${pending.visitorId}:${pending.eventKey}';
+      final existing = _inFlight[operationKey];
+      if (existing != null) return existing;
+
+      final operation = _complete(
+        prefs: prefs,
+        pending: pending,
+        signupUserId: userId,
+      );
+      _inFlight[operationKey] = operation;
+      unawaited(
+        operation.whenComplete(() {
+          if (identical(_inFlight[operationKey], operation)) {
+            _inFlight.remove(operationKey);
+          }
+        }),
+      );
+      return operation;
+    } catch (error, stackTrace) {
+      debugPrint('Landing signup completion bootstrap failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      return false;
+    }
+  }
+
+  Future<bool> _complete({
+    required SharedPreferences prefs,
+    required PendingLandingSignup pending,
+    required String signupUserId,
+  }) async {
+    try {
+      await _landingPageAdapter.recordConversionEvent(
+        eventKey: pending.eventKey,
+        visitorId: pending.visitorId,
+      );
+      await _acquisitionService.notifySignupSuccess(signupUserId: signupUserId);
+      await _removeIfCurrent(prefs, pending);
+      return true;
+    } catch (error, stackTrace) {
+      debugPrint('Landing signup completion failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      return false;
+    }
+  }
+
+  Future<PendingLandingSignup?> _readValid(SharedPreferences prefs) async {
+    final encoded = prefs.getString(storageKey);
+    if (encoded == null || encoded.isEmpty) return null;
+
+    PendingLandingSignup? pending;
+    try {
+      pending = PendingLandingSignup.fromJson(jsonDecode(encoded));
+    } catch (_) {
+      pending = null;
+    }
+    if (pending == null || _now().difference(pending.createdAt) >= ttl) {
+      await prefs.remove(storageKey);
+      return null;
+    }
+    return pending;
+  }
+
+  Future<bool> _removeIfCurrent(
+    SharedPreferences prefs,
+    PendingLandingSignup pending,
+  ) async {
+    final encoded = prefs.getString(storageKey);
+    if (encoded == null) return false;
+
+    PendingLandingSignup? current;
+    try {
+      current = PendingLandingSignup.fromJson(jsonDecode(encoded));
+    } catch (_) {
+      current = null;
+    }
+    if (current == null ||
+        current.eventKey != pending.eventKey ||
+        current.visitorId != pending.visitorId ||
+        current.createdAt != pending.createdAt) {
+      return false;
+    }
+    return prefs.remove(storageKey);
+  }
+
+  static String? _normalizeEmail(String? value) {
+    final email = value?.trim().toLowerCase() ?? '';
+    return email.isEmpty ? null : email;
+  }
+}

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -11,6 +11,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:my_web_app/main.dart';
 import 'package:my_web_app/services/theme_service.dart';
+import 'package:my_web_app/services/landing_signup_completion_service.dart';
 import 'package:my_web_app/pages/home_page.dart';
 import 'package:my_web_app/pages/landing_page.dart';
 import 'package:my_web_app/pages/onboarding_page.dart';
@@ -43,6 +44,24 @@ class FakePostgrestTransformBuilder<T> extends Fake
     Function? onError,
   }) async {
     return onValue(_value);
+  }
+}
+
+class _SignupCompletionRecorder extends LandingSignupCompletionService {
+  _SignupCompletionRecorder();
+
+  final List<(String?, String?, DateTime?)> calls =
+      <(String?, String?, DateTime?)>[];
+
+  @override
+  Future<bool> completeIfPending({
+    required String? signupUserId,
+    String? signupEmail,
+    DateTime? accountCreatedAt,
+    SharedPreferences? preferences,
+  }) async {
+    calls.add((signupUserId, signupEmail, accountCreatedAt));
+    return true;
   }
 }
 
@@ -104,6 +123,9 @@ void main() {
       when(mockGoTrueClient.currentSession).thenReturn(mockSession);
       when(mockGoTrueClient.currentUser).thenReturn(mockUser);
       when(mockUser.id).thenReturn('test-user-id');
+      when(mockUser.email).thenReturn('new-user@example.com');
+      when(mockUser.createdAt).thenReturn('2026-07-23T01:00:02Z');
+      final signupCompletion = _SignupCompletionRecorder();
 
       // DB呼び出しのモック: user_stats が存在しない (null) -> オンボーディング表示
       final mockQueryBuilder = MockSupabaseQueryBuilder();
@@ -125,7 +147,7 @@ void main() {
       await tester.pumpWidget(
         ChangeNotifierProvider<ThemeService>.value(
           value: mockThemeService,
-          child: const MyApp(),
+          child: MyApp(signupCompletionService: signupCompletion),
         ),
       );
       // FutureBuilder の完了を待つ
@@ -136,6 +158,13 @@ void main() {
       // Assert
       expect(find.byType(OnboardingPage), findsOneWidget);
       expect(find.byType(HomePage), findsNothing);
+      expect(signupCompletion.calls, <(String?, String?, DateTime?)>[
+        (
+          'test-user-id',
+          'new-user@example.com',
+          DateTime.utc(2026, 7, 23, 1, 0, 2),
+        ),
+      ]);
     });
 
     testWidgets('ログイン済みでオンボーディング完了時は HomePage が表示されること',

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:my_web_app/pages/landing_page.dart';
 import 'package:my_web_app/services/landing_conversion_experiment_service.dart';
 import 'package:my_web_app/services/landing_page_adapter.dart';
+import 'package:my_web_app/services/landing_signup_completion_service.dart';
 import 'package:my_web_app/services/pending_landing_trial_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -279,6 +280,13 @@ void main() {
 
     expect(adapter.saveCtas, 1);
     expect(adapter.magicLinkEmails, ['first-user@example.com']);
+    final prefs = await SharedPreferences.getInstance();
+    final pendingSignup = prefs.getString(
+      LandingSignupCompletionService.storageKey,
+    );
+    expect(pendingSignup, isNotNull);
+    expect(pendingSignup, contains('lp_exp_h04_treatment_signup_complete'));
+    expect(pendingSignup, contains('first-user@example.com'));
     final pendingTrial = await const PendingLandingTrialService().loadForEmail(
       'first-user@example.com',
     );

--- a/test/services/landing_signup_completion_service_test.dart
+++ b/test/services/landing_signup_completion_service_test.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/growth_acquisition_service.dart';
+import 'package:my_web_app/services/landing_page_adapter.dart';
+import 'package:my_web_app/services/landing_signup_completion_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _RecordingLandingAdapter extends Fake implements LandingPageAdapter {
+  final List<String> eventKeys = <String>[];
+  final List<String> visitorIds = <String>[];
+  Completer<void>? release;
+
+  @override
+  Future<void> recordConversionEvent({
+    required String eventKey,
+    required String visitorId,
+  }) async {
+    eventKeys.add(eventKey);
+    visitorIds.add(visitorId);
+    await release?.future;
+  }
+}
+
+class _RecordingAcquisitionService extends GrowthAcquisitionService {
+  _RecordingAcquisitionService();
+
+  final List<String> notifiedUserIds = <String>[];
+
+  @override
+  Future<void> notifySignupSuccess({required String? signupUserId}) async {
+    if (signupUserId != null) notifiedUserIds.add(signupUserId);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const eventKey = 'lp_exp_h04_treatment_signup_complete';
+  const visitorId = '00000000-0000-4000-8000-000000000001';
+  late _RecordingLandingAdapter adapter;
+  late _RecordingAcquisitionService acquisitionService;
+  late DateTime now;
+  late LandingSignupCompletionService service;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    adapter = _RecordingLandingAdapter();
+    acquisitionService = _RecordingAcquisitionService();
+    now = DateTime.utc(2026, 7, 23, 1);
+    service = LandingSignupCompletionService(
+      landingPageAdapter: adapter,
+      acquisitionService: acquisitionService,
+      clock: () => now,
+    );
+  });
+
+  test(
+    'completes a matching pending signup and consumes attribution',
+    () async {
+      await service.markPending(
+        email: ' First.User@Example.com ',
+        eventKey: eventKey,
+        visitorId: visitorId,
+      );
+
+      expect(
+        await service.completeIfPending(
+          signupUserId: 'user-1',
+          signupEmail: 'first.user@example.com',
+          accountCreatedAt: now.add(const Duration(seconds: 2)),
+        ),
+        isTrue,
+      );
+
+      expect(adapter.eventKeys, <String>[eventKey]);
+      expect(adapter.visitorIds, <String>[visitorId]);
+      expect(acquisitionService.notifiedUserIds, <String>['user-1']);
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.containsKey(LandingSignupCompletionService.storageKey),
+        isFalse,
+      );
+    },
+  );
+
+  test('does not consume a pending signup for another email', () async {
+    await service.markPending(
+      email: 'owner@example.com',
+      eventKey: eventKey,
+      visitorId: visitorId,
+    );
+
+    expect(
+      await service.completeIfPending(
+        signupUserId: 'user-2',
+        signupEmail: 'other@example.com',
+      ),
+      isFalse,
+    );
+    expect(adapter.eventKeys, isEmpty);
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.containsKey(LandingSignupCompletionService.storageKey),
+      isTrue,
+    );
+  });
+
+  test('does not count an existing account as a new signup', () async {
+    await service.markPending(
+      email: 'existing@example.com',
+      eventKey: eventKey,
+      visitorId: visitorId,
+    );
+
+    expect(
+      await service.completeIfPending(
+        signupUserId: 'existing-user',
+        signupEmail: 'existing@example.com',
+        accountCreatedAt: now.subtract(const Duration(days: 30)),
+      ),
+      isFalse,
+    );
+    expect(adapter.eventKeys, isEmpty);
+    expect(acquisitionService.notifiedUserIds, isEmpty);
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.containsKey(LandingSignupCompletionService.storageKey),
+      isFalse,
+    );
+  });
+
+  test('expires stale signup intent without recording a conversion', () async {
+    await service.markPending(
+      email: 'first@example.com',
+      eventKey: eventKey,
+      visitorId: visitorId,
+    );
+    now = now.add(const Duration(hours: 48));
+
+    expect(
+      await service.completeIfPending(
+        signupUserId: 'user-3',
+        signupEmail: 'first@example.com',
+      ),
+      isFalse,
+    );
+    expect(adapter.eventKeys, isEmpty);
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.containsKey(LandingSignupCompletionService.storageKey),
+      isFalse,
+    );
+  });
+
+  test(
+    'coalesces concurrent LP listener and authenticated-route completion',
+    () async {
+      await service.markPending(
+        email: 'first@example.com',
+        eventKey: eventKey,
+        visitorId: visitorId,
+      );
+      adapter.release = Completer<void>();
+
+      final first = service.completeIfPending(
+        signupUserId: 'user-4',
+        signupEmail: 'first@example.com',
+      );
+      await Future<void>.delayed(Duration.zero);
+      final second = service.completeIfPending(
+        signupUserId: 'user-4',
+        signupEmail: 'first@example.com',
+      );
+      adapter.release!.complete();
+
+      expect(await Future.wait(<Future<bool>>[first, second]), <bool>[
+        true,
+        true,
+      ]);
+      expect(adapter.eventKeys, hasLength(1));
+      expect(acquisitionService.notifiedUserIds, <String>['user-4']);
+    },
+  );
+
+  test('cancels only the matching failed signup intent', () async {
+    await service.markPending(
+      email: 'first@example.com',
+      eventKey: eventKey,
+      visitorId: visitorId,
+    );
+
+    expect(await service.cancelPending(email: 'other@example.com'), isFalse);
+    expect(await service.cancelPending(email: 'first@example.com'), isTrue);
+  });
+}


### PR DESCRIPTION
﻿## Summary
- persist LP experiment attribution before password signup, Magic Link, and Google auth redirects
- complete `signup_complete` plus first-user notification from either the LP auth listener or the authenticated bootstrap route
- coalesce duplicate completion races, expire stale intents, and exclude existing-account logins from new-signup results
- add regression coverage for redirect persistence, email mismatch, expiry, duplicate completion, existing-account exclusion, and onboarding bootstrap

## Why
Magic Link, OAuth, and email-confirmation returns can select the authenticated route before `LandingPage` mounts. That dropped the conversion event and first-user notification exactly at the LP-to-activation boundary, making the 10 LP hypotheses under-report completions and hiding the first external signup.

## Verification
- `flutter test --no-pub -r expanded test/services/landing_signup_completion_service_test.dart` (6 passed)
- `flutter test --no-pub -r expanded test/pages/landing_page_conversion_test.dart` (13 passed)
- `flutter analyze --no-pub` for the six changed files: no issues before the final account-age guard; the guard is compiled by the passing service and LP suites
- Dart 3.10.9 formatter check: 6 files, 0 changed
- full pre-push quality gate passed before branch publication

## Minimal E2E Gate
- Implementation-detail independent: widget coverage asserts the persisted signup handoff and authenticated-route behavior.
- Minimal scope: redirect persistence, authenticated completion, duplicate race, stale state, and existing-account exclusion.
- E2E-Exception: External Magic Link delivery and OAuth provider redirects require production provider sessions; the deterministic boundary is covered here and production QA follows deployment.

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: No schema, RLS, secret, payment, or migration changes. Auth APIs are unchanged; this adds local attribution handoff and idempotent post-auth bookkeeping.

Closes #4303

