### PR TITLE
fix: send trial campaign visitors straight to LP value

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -25,6 +25,7 @@ class LandingPage extends StatefulWidget {
   final PendingLandingTrialService pendingTrialService;
   final LandingExperimentAssignment? experimentAssignment;
   final bool? analyticsEnabled;
+  final Uri? landingUri;
 
   const LandingPage({
     super.key,
@@ -35,6 +36,7 @@ class LandingPage extends StatefulWidget {
     PendingLandingTrialService? pendingTrialService,
     this.experimentAssignment,
     this.analyticsEnabled,
+    this.landingUri,
   })  : adapter = adapter ?? const SupabaseLandingPageAdapter(),
         growthService = growthService ?? const GrowthMissionService(),
         pendingTrialService =
@@ -47,6 +49,11 @@ class LandingPage extends StatefulWidget {
   @visibleForTesting
   static bool analyticsEnabledForUri(Uri? uri) {
     return uri?.queryParameters['lp_qa'] != '1';
+  }
+
+  @visibleForTesting
+  static bool shouldFocusTrialForUri(Uri? uri) {
+    return uri?.queryParameters['lp_intent']?.trim().toLowerCase() == 'trial';
   }
 
   @override
@@ -96,13 +103,16 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   Future<LandingExperimentAssignment>? _experimentBootstrapFuture;
   Future<String>? _experimentVisitorIdFuture;
   final Set<String> _recordedExperimentStages = <String>{};
+  bool _landingIntentHandled = false;
+
+  Uri? get _landingUri => widget.landingUri ?? (kIsWeb ? Uri.base : null);
 
   bool get _analyticsEnabled {
     final override = widget.analyticsEnabled;
     if (override != null) {
       return override;
     }
-    return LandingPage.analyticsEnabledForUri(kIsWeb ? Uri.base : null);
+    return LandingPage.analyticsEnabledForUri(_landingUri);
   }
 
   SupabaseClient? get _supabaseClientOrNull {
@@ -152,7 +162,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
 
   Future<LandingExperimentAssignment> _loadConversionExperiment() async {
     final assignment = await widget.conversionExperimentService.resolve(
-      uri: kIsWeb ? Uri.base : null,
+      uri: _landingUri,
     );
     if (mounted && _experimentAssignment != assignment) {
       setState(() => _experimentAssignment = assignment);
@@ -226,6 +236,21 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
       unawaited(widget.adapter.recordLpView());
     }
     unawaited(_recordConversionStage('view'));
+    unawaited(_honorLandingIntent());
+  }
+
+  Future<void> _honorLandingIntent() async {
+    if (_landingIntentHandled ||
+        !LandingPage.shouldFocusTrialForUri(_landingUri)) {
+      return;
+    }
+    _landingIntentHandled = true;
+
+    // The H03 assignment can move the trial below auth. Wait for that layout
+    // decision before honoring the campaign promise to start with the trial.
+    await _resolveExperimentAssignment();
+    if (!mounted) return;
+    _scheduleTrialSectionScroll();
   }
 
   @override
@@ -248,8 +273,9 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   }
 
   bool get _isFirstUserGrowthTraffic {
-    if (!kIsWeb) return false;
-    return GrowthAcquisitionService.isFirstUserGrowthUri(Uri.base);
+    final uri = _landingUri;
+    if (uri == null) return false;
+    return GrowthAcquisitionService.isFirstUserGrowthUri(uri);
   }
 
   void _goToAuthenticatedEntry() {
@@ -618,16 +644,40 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   }
 
   void _scrollToTrialSection() {
+    final currentContext = _trialSectionKey.currentContext;
+    if (currentContext != null) {
+      unawaited(
+        Scrollable.ensureVisible(
+          currentContext,
+          duration: const Duration(milliseconds: 320),
+          curve: Curves.easeOut,
+          alignment: 0.08,
+        ),
+      );
+      return;
+    }
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final trialContext = _trialSectionKey.currentContext;
       if (!mounted || trialContext == null) return;
-      Scrollable.ensureVisible(
-        trialContext,
-        duration: const Duration(milliseconds: 320),
-        curve: Curves.easeOut,
-        alignment: 0.08,
+      unawaited(
+        Scrollable.ensureVisible(
+          trialContext,
+          duration: const Duration(milliseconds: 320),
+          curve: Curves.easeOut,
+          alignment: 0.08,
+        ),
       );
     });
+    WidgetsBinding.instance.scheduleFrame();
+  }
+
+  void _scheduleTrialSectionScroll() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _scrollToTrialSection();
+    });
+    WidgetsBinding.instance.scheduleFrame();
   }
 
   void _scrollToAuthSection() {
@@ -793,48 +843,30 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     if (RegExp(
       r'支出|出費|家計|固定費|変動費|予算|浪費|お金|請求|明細|サブスク|収入|貯金|資産|借金|返済|税金|投資|削減',
     ).hasMatch(text)) {
-      return (
-        '先月の明細で最も高い固定費を1件特定',
-        '最大の固定費を先に確認すると、削減効果を比較しやすくなるためです。',
-      );
+      return ('先月の明細で最も高い固定費を1件特定', '最大の固定費を先に確認すると、削減効果を比較しやすくなるためです。');
     }
 
     if (RegExp(r'学習|勉強|英語|読書|復習|試験|資格|暗記|教材|授業').hasMatch(text)) {
-      return (
-        '今日復習する教材を1件開く',
-        '対象を1件に固定すると、短時間でも復習を完了しやすくなるためです。',
-      );
+      return ('今日復習する教材を1件開く', '対象を1件に固定すると、短時間でも復習を完了しやすくなるためです。');
     }
 
     if (RegExp(
       r'LP|ランディング|登録|サインアップ|フォーム|CTA|ボタン|申込|コンバージョン|離脱',
       caseSensitive: false,
     ).hasMatch(text)) {
-      return (
-        '登録ボタン直前の価値説明を1文見直す',
-        '登録後に得られる成果を明確にすると、迷った訪問者が判断しやすくなるためです。',
-      );
+      return ('登録ボタン直前の価値説明を1文見直す', '登録後に得られる成果を明確にすると、迷った訪問者が判断しやすくなるためです。');
     }
 
     if (RegExp(r'健康|運動|睡眠|食事|体重|病院|服薬').hasMatch(text)) {
-      return (
-        '直近の健康記録を1件確認',
-        '最新の状態を1件確認すると、今日変える行動を具体化しやすくなるためです。',
-      );
+      return ('直近の健康記録を1件確認', '最新の状態を1件確認すると、今日変える行動を具体化しやすくなるためです。');
     }
 
     if (RegExp(r'情報整理|ノート|メモ|資料|ファイル|知識|文書').hasMatch(text)) {
-      return (
-        '未整理のメモを1件開き用途を1行追記',
-        '用途を1行で固定すると、残すか行動に変えるかを判断しやすくなるためです。',
-      );
+      return ('未整理のメモを1件開き用途を1行追記', '用途を1行で固定すると、残すか行動に変えるかを判断しやすくなるためです。');
     }
 
     if (RegExp(r'予定|時間|先送り|後回し|着手|集中|習慣').hasMatch(text)) {
-      return (
-        '今日の予定から先送り中の1件を選ぶ',
-        '対象を1件に固定すると、使える時間をその行動に割り当てやすくなるためです。',
-      );
+      return ('今日の予定から先送り中の1件を選ぶ', '対象を1件に固定すると、使える時間をその行動に割り当てやすくなるためです。');
     }
 
     if (text.contains('考える') ||
@@ -3404,9 +3436,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   final willShow = !_showAllUniqueFeatures;
                   setState(() => _showAllUniqueFeatures = willShow);
                   if (willShow) {
-                    unawaited(
-                      _recordConversionStage('feature_catalog_expand'),
-                    );
+                    unawaited(_recordConversionStage('feature_catalog_expand'));
                   }
                 },
                 icon: Icon(
@@ -3901,10 +3931,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   ),
                   ActionChip(
                     key: const Key('landing_trial_sample_plan'),
-                    avatar: Icon(
-                      Icons.event_note,
-                      size: compactHero ? 16 : 18,
-                    ),
+                    avatar: Icon(Icons.event_note, size: compactHero ? 16 : 18),
                     label: Text(compactHero ? '計画' : '今日の計画を立てる'),
                     visualDensity: compactHero ? VisualDensity.compact : null,
                     materialTapTargetSize:
@@ -3939,10 +3966,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                   prefixIcon: const Icon(Icons.bolt),
                   isDense: compactHero,
                   contentPadding: compactHero
-                      ? const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 12,
-                        )
+                      ? const EdgeInsets.symmetric(horizontal: 12, vertical: 12)
                       : null,
                 ),
               ),

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -87,6 +87,21 @@ class _LandingAdapter extends Fake implements LandingPageAdapter {
   }
 }
 
+class _DelayedExperimentService extends LandingConversionExperimentService {
+  final Future<LandingExperimentAssignment> assignment;
+
+  const _DelayedExperimentService(this.assignment);
+
+  @override
+  Future<LandingExperimentAssignment> resolve({
+    Uri? uri,
+    SharedPreferences? preferences,
+    int? deterministicBucket,
+  }) {
+    return assignment;
+  }
+}
+
 LandingConversionHypothesis _hypothesis(String id) {
   return LandingConversionExperimentService.hypotheses.firstWhere(
     (hypothesis) => hypothesis.id == id,
@@ -103,6 +118,16 @@ LandingExperimentAssignment _assignment(
   );
 }
 
+double _landingScrollOffset(WidgetTester tester) {
+  final pageScrollable = find
+      .descendant(
+        of: find.byType(SingleChildScrollView),
+        matching: find.byType(Scrollable),
+      )
+      .first;
+  return tester.state<ScrollableState>(pageScrollable).position.pixels;
+}
+
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
@@ -110,9 +135,11 @@ void main() {
 
   Future<_LandingAdapter> pumpLanding(
     WidgetTester tester, {
-    required LandingExperimentAssignment assignment,
+    LandingExperimentAssignment? assignment,
     Size size = const Size(1200, 900),
     bool? analyticsEnabled,
+    Uri? landingUri,
+    LandingConversionExperimentService? conversionExperimentService,
   }) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = size;
@@ -124,11 +151,14 @@ void main() {
         routes: {'/privacy': (_) => const Scaffold(body: Text('privacy'))},
         home: LandingPage(
           key: ValueKey(
-            '${assignment.hypothesis.id}-${assignment.variant.name}-${size.width}',
+            '${assignment?.hypothesis.id ?? 'async'}-'
+            '${assignment?.variant.name ?? 'pending'}-${size.width}',
           ),
           adapter: adapter,
           experimentAssignment: assignment,
+          conversionExperimentService: conversionExperimentService,
           analyticsEnabled: analyticsEnabled,
+          landingUri: landingUri,
         ),
       ),
     );
@@ -151,6 +181,102 @@ void main() {
       isTrue,
     );
     expect(LandingPage.analyticsEnabledForUri(null), isTrue);
+  });
+
+  test('lp_intent focuses only the explicit trial campaign', () {
+    expect(
+      LandingPage.shouldFocusTrialForUri(
+        Uri.parse('https://example.com/?lp_intent=trial'),
+      ),
+      isTrue,
+    );
+    expect(
+      LandingPage.shouldFocusTrialForUri(
+        Uri.parse('https://example.com/?lp_intent=TRIAL'),
+      ),
+      isTrue,
+    );
+    expect(
+      LandingPage.shouldFocusTrialForUri(
+        Uri.parse('https://example.com/?lp_intent=signup'),
+      ),
+      isFalse,
+    );
+    expect(LandingPage.shouldFocusTrialForUri(null), isFalse);
+  });
+
+  testWidgets(
+    'lp_intent trial brings the promised trial into view for every H03 arm and viewport',
+    (tester) async {
+      for (final size in <Size>[const Size(1200, 900), const Size(390, 844)]) {
+        for (final variant in LandingExperimentVariant.values) {
+          final adapter = await pumpLanding(
+            tester,
+            assignment: _assignment('h03', variant),
+            size: size,
+            landingUri: Uri.parse(
+              'https://example.com/?lp_intent=trial&lp_qa=1',
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final trialTop = tester
+              .getTopLeft(find.byKey(const Key('landing_trial_section')))
+              .dy;
+          expect(trialTop, lessThan(size.height));
+          expect(trialTop, greaterThanOrEqualTo(0));
+          expect(_landingScrollOffset(tester), greaterThan(0));
+          expect(adapter.lpViews, 0);
+          expect(adapter.conversionEvents, isEmpty);
+        }
+      }
+    },
+  );
+
+  testWidgets(
+    'lp_intent waits for an asynchronous H03 layout before focusing the trial',
+    (tester) async {
+      const size = Size(390, 844);
+      final assignment = Completer<LandingExperimentAssignment>();
+      await pumpLanding(
+        tester,
+        size: size,
+        analyticsEnabled: false,
+        landingUri: Uri.parse(
+          'https://example.com/?lp_intent=trial&lp_qa=1',
+        ),
+        conversionExperimentService: _DelayedExperimentService(
+          assignment.future,
+        ),
+      );
+
+      assignment.complete(
+        _assignment('h03', LandingExperimentVariant.control),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('landing_h03_auth_before_trial')), findsOne);
+      final trialTop =
+          tester.getTopLeft(find.byKey(const Key('landing_trial_section'))).dy;
+      expect(trialTop, inInclusiveRange(0, size.height));
+      expect(_landingScrollOffset(tester), greaterThan(0));
+    },
+  );
+
+  testWidgets('landing without lp_intent keeps the H03 control at the top', (
+    tester,
+  ) async {
+    const size = Size(390, 844);
+    await pumpLanding(
+      tester,
+      assignment: _assignment('h03', LandingExperimentVariant.control),
+      size: size,
+      landingUri: Uri.parse('https://example.com/?lp_qa=1'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(_landingScrollOffset(tester), 0);
+    expect(find.byKey(const Key('landing_h03_auth_before_trial')), findsOne);
   });
 
   testWidgets('H07 renders anonymous-safe public aggregate social proof', (
@@ -386,8 +512,9 @@ void main() {
         contains('lp_exp_h01_treatment_feature_outcome_trial'),
       );
 
-      final toggle =
-          find.byKey(const Key('landing_h15_feature_catalog_toggle'));
+      final toggle = find.byKey(
+        const Key('landing_h15_feature_catalog_toggle'),
+      );
       await Scrollable.ensureVisible(tester.element(toggle), alignment: 0.7);
       await tester.pump();
       await tester.tap(toggle);
@@ -472,9 +599,7 @@ void main() {
       find.byKey(const Key('landing_trial_prompt_input')),
       '家計の固定費が高く、今月どの支出から見直すべきか決められません',
     );
-    await tester.tap(
-      find.byKey(const Key('landing_h03_inline_trial_action')),
-    );
+    await tester.tap(find.byKey(const Key('landing_h03_inline_trial_action')));
     await tester.pump();
     await tester.pump();
 
@@ -684,9 +809,7 @@ void main() {
     final trialAction = find.byKey(
       const Key('landing_h03_inline_trial_action'),
     );
-    final stickyCta = find.byKey(
-      const Key('landing_h09_mobile_sticky_cta'),
-    );
+    final stickyCta = find.byKey(const Key('landing_h09_mobile_sticky_cta'));
     expect(trialAction, findsOneWidget);
     expect(stickyCta, findsOneWidget);
     expect(


### PR DESCRIPTION
## Summary
- honor `lp_intent=trial` from X/acquisition links by bringing the anonymous 30-second trial into the initial viewport
- wait for the H03 control/treatment layout decision before scrolling so asynchronous experiment assignment cannot land on the wrong section
- keep non-campaign landing visits at the top and keep `lp_qa=1` analytics-free

## Why
The first-user X link promises an immediate trial, but the Flutter LP previously ignored `lp_intent=trial`. Unknown visitors could land on a signup-first H03 arm and leave before finding the promised experience.

## Verification
- `flutter test test/pages/landing_page_conversion_test.dart` (18 passed)
- `flutter test test/routes/deep_link_visibility_gate_test.dart` (2 passed)
- `flutter analyze lib/pages/landing_page.dart test/pages/landing_page_conversion_test.dart`
- full pre-push quality gate: Flutter VM suite passed; Deno 532 passed / 0 failed
- desktop/mobile x H03 control/treatment viewport assertions
- asynchronous H03 assignment regression test

Fixes #4312

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Display-only LP campaign navigation fix; no security, migration, payment, secret, or privileged path changed.

## Minimal E2E Gate
- Implementation-detail independent: Campaign URLs are verified by the visible outcome that the anonymous trial is inside the initial viewport, regardless of widget ordering internals.
- Minimal scope: four viewport/experiment combinations plus one asynchronous assignment regression and one no-intent control.
- E2E: Widget-level route behavior covers desktop/mobile, H03 control/treatment, async assignment, and analytics gating; production browser QA will run after deployment.
- E2E-Exception: No external X post, account creation, or payment is performed by this PR; those require explicit user action/approval and real external state.