### PR TITLE
feat: add approval-gated first-user X launch candidate

### DIFF
--- a/.github/workflows/x-first-user-launch-candidate.yml
+++ b/.github/workflows/x-first-user-launch-candidate.yml
@@ -1,0 +1,173 @@
+name: X First User Launch Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      save_for_approval:
+        description: "Save an approval-pending candidate (never publishes)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: x-first-user-launch-candidate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  candidate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SUPABASE_URL: https://smmkxxavexumewbfaqpy.supabase.co
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      MEDIA_URL: https://my-web-app-b67f4.web.app/lp-og-first-action-20260720.png
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v6
+
+      - name: Validate service credential
+        shell: bash
+        run: |
+          test -n "${SUPABASE_SERVICE_ROLE_KEY}" || {
+            echo "::error::SUPABASE_SERVICE_ROLE_KEY is required."
+            exit 1
+          }
+
+      - name: Validate reviewed campaign image
+        shell: bash
+        run: |
+          headers=$(mktemp)
+          curl --fail --location --silent --show-error \
+            --head --output /dev/null --dump-header "${headers}" \
+            "${MEDIA_URL}"
+          content_type=$(awk '
+            BEGIN { IGNORECASE=1 }
+            /^content-type:/ {
+              gsub("\r", "", $2)
+              value=$2
+            }
+            END { print value }
+          ' "${headers}")
+          if [ "${content_type}" != "image/png" ]; then
+            echo "::error::Expected image/png, received ${content_type:-missing}."
+            exit 1
+          fi
+
+      - name: Run read-only X preflight
+        shell: bash
+        run: |
+          http_code=$(curl --silent --show-error \
+            --output /tmp/x_post_preflight.json \
+            --write-out "%{http_code}" \
+            --request POST \
+            "${SUPABASE_URL}/functions/v1/growth-hub" \
+            --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Content-Type: application/json" \
+            --data '{"action":"x.post_preflight"}')
+          if [ "${http_code}" != "200" ]; then
+            echo "::warning::Read-only X preflight returned HTTP ${http_code}."
+          fi
+          jq -c . /tmp/x_post_preflight.json || cat /tmp/x_post_preflight.json
+
+      - name: Build exact candidate request
+        id: mode
+        shell: bash
+        env:
+          SAVE_FOR_APPROVAL: ${{ inputs.save_for_approval }}
+        run: |
+          dry_run=true
+          if [ "${SAVE_FOR_APPROVAL}" = "true" ]; then
+            dry_run=false
+          fi
+          python scripts/first_user_x_candidate.py \
+            --dry-run "${dry_run}" \
+            --actor "${GITHUB_ACTOR}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --ref "${GITHUB_REF}" \
+            --sha "${GITHUB_SHA}" \
+            --output /tmp/x_first_user_candidate_request.json
+          jq -e '
+            .action == "x.candidate.create" and
+            .postPayload.action == "x.post" and
+            (.postPayload.text | contains("https://") | not) and
+            (.postPayload.replyTexts | length == 1) and
+            .postPayload.linkInReply == true and
+            .postPayload.mediaType == "image/png"
+          ' /tmp/x_first_user_candidate_request.json >/dev/null
+          echo "dry_run=${dry_run}" >> "${GITHUB_OUTPUT}"
+
+      - name: Preview or save approval-pending candidate
+        id: create
+        shell: bash
+        run: |
+          http_code=$(curl --silent --show-error \
+            --output /tmp/x_first_user_candidate_response.json \
+            --write-out "%{http_code}" \
+            --request POST \
+            "${SUPABASE_URL}/functions/v1/growth-hub" \
+            --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            --header "Content-Type: application/json" \
+            --data @/tmp/x_first_user_candidate_request.json)
+          cat /tmp/x_first_user_candidate_response.json
+          if [ "${http_code}" != "200" ]; then
+            echo "::error::Candidate endpoint returned HTTP ${http_code}."
+            exit 1
+          fi
+          jq -e --argjson expected_dry_run "${{ steps.mode.outputs.dry_run }}" '
+            .success == true and
+            .dryRun == $expected_dry_run and
+            .status == "pending_approval"
+          ' /tmp/x_first_user_candidate_response.json >/dev/null
+          candidate_id=$(jq -r '.candidateId // ""' \
+            /tmp/x_first_user_candidate_response.json)
+          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ] &&
+             [ -n "${candidate_id}" ]; then
+            echo "::error::Preview mode unexpectedly persisted a candidate."
+            exit 1
+          fi
+          if [ "${{ steps.mode.outputs.dry_run }}" = "false" ] &&
+             ! [[ "${candidate_id}" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+            echo "::error::Stored mode did not return a candidate UUID."
+            exit 1
+          fi
+          echo "candidate_id=${candidate_id}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload review evidence
+        uses: actions/upload-artifact@v6
+        with:
+          name: x-first-user-launch-candidate-${{ github.run_id }}
+          path: |
+            /tmp/x_first_user_candidate_request.json
+            /tmp/x_first_user_candidate_response.json
+          retention-days: 30
+
+      - name: Publish review summary
+        shell: bash
+        env:
+          CANDIDATE_ID: ${{ steps.create.outputs.candidate_id }}
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+        run: |
+          {
+            echo "## X first-user launch candidate"
+            echo
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "- Result: preview only; nothing was saved or published"
+            else
+              echo "- Result: saved for approval; nothing was published"
+              echo "- Candidate ID: \`${CANDIDATE_ID}\`"
+              echo
+              echo "Publishing remains a separate explicit action:"
+              echo "- Workflow: \`X Candidate Draft & Approval\`"
+              echo "- operation: \`publish_approved_draft\`"
+              echo "- candidate_id: \`${CANDIDATE_ID}\`"
+              echo "- expected_candidate_type: \`first_user_launch\`"
+              echo "- expected_source_kind: \`x-first-user-launch-candidate.yml\`"
+              echo "- confirm_publish: \`true\`"
+              echo "- dry_run: \`false\`"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/scripts/first_user_x_candidate.py
+++ b/scripts/first_user_x_candidate.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Build the approval-gated X candidate for the first-user campaign."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+
+CANDIDATE_KEY = "first-user-launch/outcome-first-a/v1"
+CANDIDATE_TYPE = "first_user_launch"
+SOURCE_KIND = "x-first-user-launch-candidate.yml"
+MEDIA_URL = (
+    "https://my-web-app-b67f4.web.app/"
+    "lp-og-first-action-20260720.png"
+)
+TARGET_URL = (
+    "https://my-web-app-b67f4.web.app/"
+    "?lp_intent=trial"
+    "&src=x_share"
+    "&utm_source=x"
+    "&utm_medium=organic"
+    "&utm_campaign=first_user_growth"
+    "&utm_content=outcome_first_a"
+)
+PARENT_TEXT = """仕事・学習・お金の情報が散らかって、
+「結局、今日なにをやる？」で止まる人へ。
+
+悩みを1行入れると、AIが
+・今日やる1件
+・その理由
+・最初の10分行動
+まで返す「自分株式会社」を作りました。
+
+登録前に30秒で試せます。カード不要です。
+使って迷ったところを1つ教えてください。
+
+#個人開発 #AI活用"""
+REPLY_TEXT = f"無料で30秒試す:\n{TARGET_URL}"
+MEDIA_ALT = (
+    "自分株式会社のランディングページ。悩みを1行入力すると、"
+    "AIが今日やる1件と最初の10分行動を提案する画面。"
+)
+
+
+def parse_bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise argparse.ArgumentTypeError(f"expected boolean, got: {value}")
+
+
+def build_candidate_request(
+    *,
+    dry_run: bool,
+    actor: str = "",
+    run_id: str = "",
+    run_attempt: str = "",
+    ref: str = "",
+    sha: str = "",
+) -> dict[str, Any]:
+    """Return the exact payload reviewed before any public X action."""
+    return {
+        "action": "x.candidate.create",
+        "candidateKey": CANDIDATE_KEY,
+        "candidateType": CANDIDATE_TYPE,
+        "sourceKind": SOURCE_KIND,
+        "sourceUrls": [MEDIA_URL, TARGET_URL],
+        "createdBy": f"github-actions:{SOURCE_KIND}",
+        "postPayload": {
+            "action": "x.post",
+            "text": PARENT_TEXT,
+            "replyTexts": [REPLY_TEXT],
+            "mediaUrl": MEDIA_URL,
+            "mediaType": "image/png",
+            "mediaAlt": MEDIA_ALT,
+            "source": SOURCE_KIND,
+            "route": "/",
+            "experimentKey": "x_first_user_growth_10k",
+            "variant": "outcome_first_a",
+            "utmContent": "outcome_first_a",
+            "promptProfile": "first_user_outcome_first_v1",
+            "fallbackUsed": False,
+            "contentKind": CANDIDATE_TYPE,
+            "contentArchetype": "product_promo",
+            "linkInReply": True,
+        },
+        "context": {
+            "workflow": SOURCE_KIND,
+            "workflow_run_id": run_id,
+            "workflow_run_attempt": run_attempt,
+            "event": "workflow_dispatch",
+            "actor": actor,
+            "ref": ref,
+            "sha": sha,
+            "selected_variant": "outcome_first_a",
+            "target_url": TARGET_URL,
+        },
+        "dryRun": dry_run,
+    }
+
+
+def validate_candidate_request(payload: dict[str, Any]) -> None:
+    """Fail closed when campaign safety or attribution invariants drift."""
+    if payload.get("action") != "x.candidate.create":
+        raise ValueError("candidate action must be x.candidate.create")
+    if payload.get("candidateKey") != CANDIDATE_KEY:
+        raise ValueError("candidate key must remain stable")
+    if payload.get("candidateType") != CANDIDATE_TYPE:
+        raise ValueError("unexpected candidate type")
+    if payload.get("sourceKind") != SOURCE_KIND:
+        raise ValueError("unexpected source kind")
+
+    post = payload.get("postPayload")
+    if not isinstance(post, dict) or post.get("action") != "x.post":
+        raise ValueError("post payload must use x.post")
+    text = str(post.get("text", ""))
+    if "http://" in text or "https://" in text:
+        raise ValueError("the parent post must not contain a URL")
+    if not text or len(text) > 280:
+        raise ValueError("the parent post must fit the standard X limit")
+    if post.get("mediaUrl") != MEDIA_URL or post.get("mediaType") != "image/png":
+        raise ValueError("the reviewed PNG must be attached to the parent post")
+    if post.get("linkInReply") is not True:
+        raise ValueError("campaign link must be placed in a reply")
+
+    replies = post.get("replyTexts")
+    if not isinstance(replies, list) or len(replies) != 1:
+        raise ValueError("exactly one campaign reply is required")
+    reply = str(replies[0])
+    if TARGET_URL not in reply:
+        raise ValueError("the reviewed campaign URL is missing from the reply")
+
+    parsed = urlparse(TARGET_URL)
+    query = parse_qs(parsed.query)
+    required_query = {
+        "lp_intent": ["trial"],
+        "utm_source": ["x"],
+        "utm_medium": ["organic"],
+        "utm_campaign": ["first_user_growth"],
+        "utm_content": ["outcome_first_a"],
+    }
+    for key, expected in required_query.items():
+        if query.get(key) != expected:
+            raise ValueError(f"campaign URL has invalid {key}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", type=parse_bool, default=True)
+    parser.add_argument("--actor", default="")
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--run-attempt", default="")
+    parser.add_argument("--ref", default="")
+    parser.add_argument("--sha", default="")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    payload = build_candidate_request(
+        dry_run=args.dry_run,
+        actor=args.actor,
+        run_id=args.run_id,
+        run_attempt=args.run_attempt,
+        ref=args.ref,
+        sha=args.sha,
+    )
+    validate_candidate_request(payload)
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/test_first_user_x_candidate.py
+++ b/test/scripts/test_first_user_x_candidate.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Tests for the approval-gated first-user X candidate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/first_user_x_candidate.py"
+SPEC = importlib.util.spec_from_file_location("first_user_x_candidate", SCRIPT)
+assert SPEC and SPEC.loader
+first_user_x_candidate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(first_user_x_candidate)
+
+
+class FirstUserXCandidateTest(unittest.TestCase):
+    def build(self, dry_run: bool = True) -> dict[str, object]:
+        return first_user_x_candidate.build_candidate_request(
+            dry_run=dry_run,
+            actor="tester",
+            run_id="123",
+            run_attempt="1",
+            ref="refs/heads/main",
+            sha="abc123",
+        )
+
+    def test_candidate_is_review_only_and_stable(self) -> None:
+        payload = self.build()
+
+        self.assertEqual(payload["action"], "x.candidate.create")
+        self.assertEqual(
+            payload["candidateKey"],
+            "first-user-launch/outcome-first-a/v1",
+        )
+        self.assertEqual(payload["candidateType"], "first_user_launch")
+        self.assertEqual(
+            payload["sourceKind"],
+            "x-first-user-launch-candidate.yml",
+        )
+        self.assertIs(payload["dryRun"], True)
+        first_user_x_candidate.validate_candidate_request(payload)
+
+    def test_parent_has_image_but_no_link(self) -> None:
+        post = self.build()["postPayload"]
+
+        self.assertEqual(post["action"], "x.post")
+        self.assertNotIn("http://", post["text"])
+        self.assertNotIn("https://", post["text"])
+        self.assertLessEqual(len(post["text"]), 280)
+        self.assertEqual(post["mediaType"], "image/png")
+        self.assertTrue(post["mediaUrl"].endswith(".png"))
+        self.assertTrue(post["mediaAlt"])
+        self.assertIs(post["linkInReply"], True)
+
+    def test_reply_contains_trial_and_campaign_attribution(self) -> None:
+        post = self.build()["postPayload"]
+        reply = post["replyTexts"][0]
+        url = next(part for part in reply.split() if part.startswith("https://"))
+        query = parse_qs(urlparse(url).query)
+
+        self.assertEqual(query["lp_intent"], ["trial"])
+        self.assertEqual(query["utm_source"], ["x"])
+        self.assertEqual(query["utm_medium"], ["organic"])
+        self.assertEqual(query["utm_campaign"], ["first_user_growth"])
+        self.assertEqual(query["utm_content"], ["outcome_first_a"])
+
+    def test_store_mode_only_changes_dry_run(self) -> None:
+        preview = self.build(dry_run=True)
+        stored = self.build(dry_run=False)
+
+        self.assertIs(preview["dryRun"], True)
+        self.assertIs(stored["dryRun"], False)
+        preview["dryRun"] = False
+        self.assertEqual(preview, stored)
+
+    def test_cli_writes_valid_utf8_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp) / "candidate.json"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--dry-run",
+                    "false",
+                    "--actor",
+                    "workflow-user",
+                    "--output",
+                    str(output),
+                ],
+                check=True,
+                cwd=ROOT,
+            )
+            payload = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertIs(payload["dryRun"], False)
+        self.assertEqual(payload["context"]["actor"], "workflow-user")
+        first_user_x_candidate.validate_candidate_request(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- add a deterministic first-user X candidate builder for the reviewed image, parent copy, and UTM reply
- add a workflow-dispatch gate that defaults to preview-only and can only save a pending candidate
- keep public publishing in the existing separate approval workflow after explicit user approval

## Safety
- this workflow contains no `x.post`, approval, or publish call
- parent post is validated to contain no URL; the campaign URL is isolated in one reply
- the candidate key is stable, so retries are idempotent
- `save_for_approval=false` persists nothing; `true` still publishes nothing

## Verification
- `python test/scripts/test_first_user_x_candidate.py` (5 passed)
- `python scripts/check_github_actions_python_inline.py`
- `python scripts/check_github_actions_node_runtime.py`
- `git diff --check`
- full pre-commit quality gate: passed
- full pre-push quality gate: Flutter 1,891 passed; Deno 532 passed / 0 failed

Refs #4314
Related to #3745

## High-risk Ultrareview Gate
- High-Risk-Ultrareview-Exception: Workflow-only approval-gate addition; it cannot approve or publish and does not change secrets, payments, migrations, or production deploy behavior.

## Minimal E2E Gate
- Implementation-detail independent: the builder tests the externally reviewed post shape and acquisition attribution.
- Minimal scope: preview safety, image/no-link parent, one attributed reply, store toggle, and CLI JSON.
- E2E-Exception: No UI surface changes. A real workflow dry-run can only be executed after this workflow exists on `main`; it will be attached before issue closure.



- Reviewer: Claude Code #1
