### PR TITLE
Bound asset management Supabase history reads

### DIFF
--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -6186,50 +6186,65 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   Future<List<Map<String, dynamic>>> _fetchAssetHistoryRows(
     String userId,
   ) async {
+    late final List<Map<String, dynamic>> firstPage;
     try {
-      final rows = <Map<String, dynamic>>[];
-      for (var start = 0;; start += AssetManagementEgressPolicy.queryPageSize) {
-        final dynamic response = await _supabase.rpc(
+      firstPage = await _fetchAssetHistoryRpcPage(
+        0,
+        AssetManagementEgressPolicy.queryPageSize - 1,
+      );
+    } on PostgrestException catch (error) {
+      if (!AssetManagementEgressPolicy.isMissingAssetHistoryRpcCode(
+        error.code,
+      )) {
+        rethrow;
+      }
+      debugPrint(
+        'Bounded asset history RPC is not deployed; using fallback: $error',
+      );
+      return AssetManagementEgressPolicy.fetchBoundedPages(
+        maxRows: AssetManagementEgressPolicy.maxAssetHistoryRows,
+        fetchPage: (from, to) async {
+          final dynamic response = await _supabase
+              .from('cfo_assets')
+              .select('id,title,amount,created_at')
+              .eq('user_id', userId)
+              .order('created_at', ascending: true)
+              .order('id', ascending: true)
+              .range(from, to);
+          return (response as List)
+              .whereType<Map>()
+              .map((row) => Map<String, dynamic>.from(row))
+              .toList(growable: false);
+        },
+      );
+    }
+
+    return AssetManagementEgressPolicy.fetchBoundedPages(
+      maxRows: AssetManagementEgressPolicy.maxAssetHistoryRows,
+      firstPage: firstPage,
+      fetchPage: _fetchAssetHistoryRpcPage,
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchAssetHistoryRpcPage(
+    int from,
+    int to,
+  ) async {
+    final dynamic response = await _supabase
+        .rpc(
           'asset_management_recent_cfo_assets',
           params: <String, Object?>{
             'p_lookback_days':
                 AssetManagementEgressPolicy.assetHistoryLookbackDays,
           },
-        ).range(
-          start,
-          start + AssetManagementEgressPolicy.queryPageSize - 1,
-        );
-        final page = (response as List)
-            .whereType<Map>()
-            .map((row) => Map<String, dynamic>.from(row))
-            .toList(growable: false);
-        rows.addAll(page);
-        if (page.length < AssetManagementEgressPolicy.queryPageSize) break;
-      }
-      return rows;
-    } catch (error) {
-      debugPrint(
-          'Bounded asset history RPC unavailable; using fallback: $error');
-      final rows = <Map<String, dynamic>>[];
-      for (var start = 0;; start += AssetManagementEgressPolicy.queryPageSize) {
-        final dynamic response = await _supabase
-            .from('cfo_assets')
-            .select('title,amount,created_at')
-            .eq('user_id', userId)
-            .order('created_at', ascending: true)
-            .range(
-              start,
-              start + AssetManagementEgressPolicy.queryPageSize - 1,
-            );
-        final page = (response as List)
-            .whereType<Map>()
-            .map((row) => Map<String, dynamic>.from(row))
-            .toList(growable: false);
-        rows.addAll(page);
-        if (page.length < AssetManagementEgressPolicy.queryPageSize) break;
-      }
-      return rows;
-    }
+        )
+        .order('created_at', ascending: true)
+        .order('id', ascending: true)
+        .range(from, to);
+    return (response as List)
+        .whereType<Map>()
+        .map((row) => Map<String, dynamic>.from(row))
+        .toList(growable: false);
   }
 
   Future<void> _loadDataFromSupabase() async {
@@ -7590,31 +7605,26 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) return;
     try {
-      final data = <Map<String, dynamic>>[];
       final cutoff = AssetManagementEgressPolicy.recentFlowCutoff(
         DateTime.now(),
       ).toIso8601String();
-      for (var start = 0;
-          start < AssetManagementEgressPolicy.maxRecentFlowRows;
-          start += AssetManagementEgressPolicy.queryPageSize) {
-        final pageSize = min(
-          AssetManagementEgressPolicy.queryPageSize,
-          AssetManagementEgressPolicy.maxRecentFlowRows - start,
-        );
-        final dynamic response = await _supabase
-            .from('wealth_struggles')
-            .select('id,action_type,amount,description,occurred_at')
-            .eq('user_id', userId)
-            .gte('occurred_at', cutoff)
-            .order('occurred_at', ascending: false)
-            .range(start, start + pageSize - 1);
-        final page = (response as List)
-            .whereType<Map>()
-            .map((row) => Map<String, dynamic>.from(row))
-            .toList(growable: false);
-        data.addAll(page);
-        if (page.length < pageSize) break;
-      }
+      final data = await AssetManagementEgressPolicy.fetchBoundedPages(
+        maxRows: AssetManagementEgressPolicy.maxRecentFlowRows,
+        fetchPage: (from, to) async {
+          final dynamic response = await _supabase
+              .from('wealth_struggles')
+              .select('id,action_type,amount,description,occurred_at')
+              .eq('user_id', userId)
+              .gte('occurred_at', cutoff)
+              .order('occurred_at', ascending: false)
+              .order('id', ascending: false)
+              .range(from, to);
+          return (response as List)
+              .whereType<Map>()
+              .map((row) => Map<String, dynamic>.from(row))
+              .toList(growable: false);
+        },
+      );
 
       if (mounted) {
         setState(() {
@@ -7632,6 +7642,52 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     } catch (e) {
       debugPrint('Error fetching flows: $e');
     }
+  }
+
+  Future<Set<String>> _fetchSmbcImportKeys({
+    required String userId,
+    required DateTime firstTransactionDate,
+    required DateTime lastTransactionDate,
+  }) async {
+    final start = DateTime(
+      firstTransactionDate.year,
+      firstTransactionDate.month,
+      firstTransactionDate.day,
+    ).toUtc();
+    final end = DateTime(
+      lastTransactionDate.year,
+      lastTransactionDate.month,
+      lastTransactionDate.day + 1,
+    ).toUtc();
+    final rows = await AssetManagementEgressPolicy.fetchBoundedPages(
+      maxRows: AssetManagementEgressPolicy.maxImportDedupRows,
+      fetchPage: (from, to) async {
+        final dynamic response = await _supabase
+            .from('wealth_struggles')
+            .select('id,description,occurred_at')
+            .eq('user_id', userId)
+            .gte('occurred_at', start.toIso8601String())
+            .lt('occurred_at', end.toIso8601String())
+            .like('description', '%[import:smbc:%]')
+            .order('occurred_at', ascending: true)
+            .order('id', ascending: true)
+            .range(from, to);
+        return (response as List)
+            .whereType<Map>()
+            .map((row) => Map<String, dynamic>.from(row))
+            .toList(growable: false);
+      },
+    );
+    final keys = <String>{};
+    for (final row in rows) {
+      final key = _extractSmbcImportKey(
+        row['description']?.toString() ?? '',
+      );
+      if (key != null) {
+        keys.add(key);
+      }
+    }
+    return keys;
   }
 
   Future<void> _pickAndImportSmbcCsv() async {
@@ -7661,15 +7717,21 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
         throw Exception('登録できる三井住友銀行の入出金明細が見つかりませんでした');
       }
 
-      final knownImportKeys = <String>{};
-      for (final flow in _recentFlows) {
-        final key = _extractSmbcImportKey(
-          flow['description']?.toString() ?? '',
-        );
-        if (key != null) {
-          knownImportKeys.add(key);
+      var firstTransactionDate = parsed.transactions.first.date;
+      var lastTransactionDate = firstTransactionDate;
+      for (final transaction in parsed.transactions.skip(1)) {
+        if (transaction.date.isBefore(firstTransactionDate)) {
+          firstTransactionDate = transaction.date;
+        }
+        if (transaction.date.isAfter(lastTransactionDate)) {
+          lastTransactionDate = transaction.date;
         }
       }
+      final knownImportKeys = await _fetchSmbcImportKeys(
+        userId: userId,
+        firstTransactionDate: firstTransactionDate,
+        lastTransactionDate: lastTransactionDate,
+      );
       final records = <Map<String, dynamic>>[];
       final classificationExpenses = <Map<String, dynamic>>[];
       var duplicateCount = 0;

--- a/lib/pages/asset_management_page.dart
+++ b/lib/pages/asset_management_page.dart
@@ -38,6 +38,7 @@ import 'package:my_web_app/services/asset_management_ai_analysis_history_service
 import 'package:my_web_app/services/asset_management_ai_summary_refresh.dart';
 import 'package:my_web_app/services/asset_management_ai_summary_service.dart';
 import 'package:my_web_app/services/asset_management_display_mode_store.dart';
+import 'package:my_web_app/services/asset_management_egress_policy.dart';
 import 'package:my_web_app/services/asset_account_balance_history_store.dart';
 import 'package:my_web_app/services/asset_pref_mirror_prefetch.dart';
 import 'package:my_web_app/services/asset_debt_discipline_monitor.dart';
@@ -6182,15 +6183,60 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     }
   }
 
+  Future<List<Map<String, dynamic>>> _fetchAssetHistoryRows(
+    String userId,
+  ) async {
+    try {
+      final rows = <Map<String, dynamic>>[];
+      for (var start = 0;; start += AssetManagementEgressPolicy.queryPageSize) {
+        final dynamic response = await _supabase.rpc(
+          'asset_management_recent_cfo_assets',
+          params: <String, Object?>{
+            'p_lookback_days':
+                AssetManagementEgressPolicy.assetHistoryLookbackDays,
+          },
+        ).range(
+          start,
+          start + AssetManagementEgressPolicy.queryPageSize - 1,
+        );
+        final page = (response as List)
+            .whereType<Map>()
+            .map((row) => Map<String, dynamic>.from(row))
+            .toList(growable: false);
+        rows.addAll(page);
+        if (page.length < AssetManagementEgressPolicy.queryPageSize) break;
+      }
+      return rows;
+    } catch (error) {
+      debugPrint(
+          'Bounded asset history RPC unavailable; using fallback: $error');
+      final rows = <Map<String, dynamic>>[];
+      for (var start = 0;; start += AssetManagementEgressPolicy.queryPageSize) {
+        final dynamic response = await _supabase
+            .from('cfo_assets')
+            .select('title,amount,created_at')
+            .eq('user_id', userId)
+            .order('created_at', ascending: true)
+            .range(
+              start,
+              start + AssetManagementEgressPolicy.queryPageSize - 1,
+            );
+        final page = (response as List)
+            .whereType<Map>()
+            .map((row) => Map<String, dynamic>.from(row))
+            .toList(growable: false);
+        rows.addAll(page);
+        if (page.length < AssetManagementEgressPolicy.queryPageSize) break;
+      }
+      return rows;
+    }
+  }
+
   Future<void> _loadDataFromSupabase() async {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) return;
     try {
-      final data = await _supabase
-          .from('cfo_assets')
-          .select()
-          .eq('user_id', userId)
-          .order('created_at', ascending: true);
+      final data = await _fetchAssetHistoryRows(userId);
       final Map<String, Map<String, double>> loadedData = {};
       final Set<String> loadedTypes = {'現金'};
       for (var item in data) {
@@ -7024,8 +7070,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
                     .from('cfo_assets')
                     .delete()
                     .eq('user_id', userId)
-                    .eq('title', type)
-                    .select();
+                    .eq('title', type);
                 setState(() {
                   _setWatchlistEntries(watchlistEntries);
                   _assetTypes.remove(type);
@@ -7276,7 +7321,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
   }
 
   Future<void> _deleteSubscription(String id) async {
-    await _supabase.from('subscriptions').delete().eq('id', id).select();
+    await _supabase.from('subscriptions').delete().eq('id', id);
     _fetchSubscriptions();
     await _fetchTodayClosing();
   }
@@ -7545,11 +7590,31 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) return;
     try {
-      final data = await _supabase
-          .from('wealth_struggles')
-          .select()
-          .eq('user_id', userId)
-          .order('occurred_at', ascending: false);
+      final data = <Map<String, dynamic>>[];
+      final cutoff = AssetManagementEgressPolicy.recentFlowCutoff(
+        DateTime.now(),
+      ).toIso8601String();
+      for (var start = 0;
+          start < AssetManagementEgressPolicy.maxRecentFlowRows;
+          start += AssetManagementEgressPolicy.queryPageSize) {
+        final pageSize = min(
+          AssetManagementEgressPolicy.queryPageSize,
+          AssetManagementEgressPolicy.maxRecentFlowRows - start,
+        );
+        final dynamic response = await _supabase
+            .from('wealth_struggles')
+            .select('id,action_type,amount,description,occurred_at')
+            .eq('user_id', userId)
+            .gte('occurred_at', cutoff)
+            .order('occurred_at', ascending: false)
+            .range(start, start + pageSize - 1);
+        final page = (response as List)
+            .whereType<Map>()
+            .map((row) => Map<String, dynamic>.from(row))
+            .toList(growable: false);
+        data.addAll(page);
+        if (page.length < pageSize) break;
+      }
 
       if (mounted) {
         setState(() {
@@ -8311,8 +8376,7 @@ class _AssetManagementPageState extends State<AssetManagementPage> {
           .from('wealth_struggles')
           .delete()
           .eq('id', flowId)
-          .eq('user_id', userId)
-          .select();
+          .eq('user_id', userId);
 
       await _fetchRecentFlows();
       await _fetchTodayClosing();

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -1550,6 +1550,9 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
   AssetLiabilitySyncPreviewResult _buildSyncPreview(
     _AssetLiabilitySyncData data,
   ) {
+    final comparableLocalSnapshots = _latestMonthlySnapshots(
+      data.localSnapshots,
+    );
     final items = <AssetLiabilitySyncPreviewItem>[
       AssetLiabilitySyncPreviewItem(
         target: AssetLiabilitySyncTarget.monthlyState,
@@ -1600,13 +1603,16 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       ),
       AssetLiabilitySyncPreviewItem(
         target: AssetLiabilitySyncTarget.monthlySnapshots,
-        localHasData: data.localSnapshots.isNotEmpty,
+        localHasData: comparableLocalSnapshots.isNotEmpty,
         remoteHasData: data.remoteSnapshots?.isNotEmpty ?? false,
-        localCount: data.localSnapshots.length,
+        localCount: comparableLocalSnapshots.length,
         remoteCount: data.remoteSnapshots?.length ?? 0,
-        dataMatches: data.localSnapshots.isNotEmpty &&
+        dataMatches: comparableLocalSnapshots.isNotEmpty &&
             (data.remoteSnapshots?.isNotEmpty ?? false) &&
-            _monthlySnapshotsEqual(data.localSnapshots, data.remoteSnapshots!),
+            _monthlySnapshotsEqual(
+              comparableLocalSnapshots,
+              data.remoteSnapshots!,
+            ),
       ),
     ];
     return AssetLiabilitySyncPreviewResult.ready(items: items);
@@ -1853,6 +1859,18 @@ class FeatureFlaggedAssetLiabilityRepository extends AssetLiabilityRepository {
       }
     }
     return true;
+  }
+
+  List<AssetLiabilityMonthlySnapshot> _latestMonthlySnapshots(
+    List<AssetLiabilityMonthlySnapshot> snapshots,
+  ) {
+    final sorted = List<AssetLiabilityMonthlySnapshot>.from(snapshots)
+      ..sort((left, right) => left.monthKey.compareTo(right.monthKey));
+    const maxSnapshots = AssetManagementEgressPolicy.maxMonthlySnapshots;
+    if (sorted.length <= maxSnapshots) {
+      return sorted;
+    }
+    return sorted.sublist(sorted.length - maxSnapshots);
   }
 
   String? _userIdOrNull() {

--- a/lib/services/asset_liability_repository.dart
+++ b/lib/services/asset_liability_repository.dart
@@ -3,6 +3,7 @@ import 'package:my_web_app/models/asset_liability_persistence.dart';
 import 'package:my_web_app/models/asset_liability_sync_audit_log.dart';
 import 'package:my_web_app/models/asset_liability_workbook.dart';
 import 'package:my_web_app/services/asset_liability_monthly_state_store.dart';
+import 'package:my_web_app/services/asset_management_egress_policy.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 typedef AssetLiabilityUserIdProvider = String? Function();
@@ -2129,7 +2130,8 @@ class AssetLiabilitySupabaseRemoteStore extends AssetLiabilityRemoteStore {
         .from(AssetLiabilitySupabaseTablePlan.monthlySnapshotsTable)
         .select('month_key,payload')
         .eq('user_id', userId)
-        .order('month_key');
+        .order('month_key', ascending: false)
+        .limit(AssetManagementEgressPolicy.maxMonthlySnapshots);
 
     final snapshots = <AssetLiabilityMonthlySnapshot>[];
     for (final item in response) {

--- a/lib/services/asset_management_egress_policy.dart
+++ b/lib/services/asset_management_egress_policy.dart
@@ -1,12 +1,51 @@
 abstract final class AssetManagementEgressPolicy {
   static const int assetHistoryLookbackDays = 400;
   static const int queryPageSize = 500;
+  static const int maxAssetHistoryRows = 10000;
   static const int recentFlowMonthWindow = 24;
   static const int maxRecentFlowRows = 2000;
+  static const int maxImportDedupRows = 10000;
   static const int maxMonthlySnapshots = 120;
 
   static DateTime recentFlowCutoff(DateTime now) {
-    final utc = now.toUtc();
-    return DateTime.utc(utc.year, utc.month - recentFlowMonthWindow + 1);
+    final local = now.toLocal();
+    return DateTime(
+      local.year,
+      local.month - recentFlowMonthWindow + 1,
+    ).toUtc();
+  }
+
+  static bool isMissingAssetHistoryRpcCode(String? code) {
+    return code == 'PGRST202' || code == '42883';
+  }
+
+  static Future<List<T>> fetchBoundedPages<T>({
+    required int maxRows,
+    required Future<List<T>> Function(int from, int to) fetchPage,
+    List<T>? firstPage,
+    int pageSize = queryPageSize,
+  }) async {
+    if (maxRows < 1 || pageSize < 1) {
+      throw ArgumentError('maxRows and pageSize must be positive');
+    }
+
+    final rows = <T>[];
+    for (var start = 0; start <= maxRows; start += pageSize) {
+      final remainingWithOverflowProbe = maxRows + 1 - start;
+      final requestedRows = remainingWithOverflowProbe < pageSize
+          ? remainingWithOverflowProbe
+          : pageSize;
+      final page = start == 0 && firstPage != null
+          ? firstPage
+          : await fetchPage(start, start + requestedRows - 1);
+      rows.addAll(page);
+      if (rows.length > maxRows) {
+        throw StateError('Supabase history exceeded the safe row limit');
+      }
+      if (page.length < requestedRows) {
+        return rows;
+      }
+    }
+    return rows;
   }
 }

--- a/lib/services/asset_management_egress_policy.dart
+++ b/lib/services/asset_management_egress_policy.dart
@@ -1,0 +1,12 @@
+abstract final class AssetManagementEgressPolicy {
+  static const int assetHistoryLookbackDays = 400;
+  static const int queryPageSize = 500;
+  static const int recentFlowMonthWindow = 24;
+  static const int maxRecentFlowRows = 2000;
+  static const int maxMonthlySnapshots = 120;
+
+  static DateTime recentFlowCutoff(DateTime now) {
+    final utc = now.toUtc();
+    return DateTime.utc(utc.year, utc.month - recentFlowMonthWindow + 1);
+  }
+}

--- a/supabase/migrations/20260721183000_bound_asset_management_history_reads.sql
+++ b/supabase/migrations/20260721183000_bound_asset_management_history_reads.sql
@@ -4,6 +4,7 @@ CREATE OR REPLACE FUNCTION public.asset_management_recent_cfo_assets(
   p_lookback_days integer DEFAULT 400
 )
 RETURNS TABLE (
+  id bigint,
   title text,
   amount numeric,
   created_at timestamp with time zone
@@ -40,7 +41,11 @@ AS $function$
       asset.created_at DESC NULLS LAST,
       asset.id DESC
   )
-  SELECT result_rows.title, result_rows.amount, result_rows.created_at
+  SELECT
+    result_rows.id,
+    result_rows.title,
+    result_rows.amount,
+    result_rows.created_at
   FROM (
     SELECT * FROM recent_rows
     UNION ALL

--- a/supabase/migrations/20260721183000_bound_asset_management_history_reads.sql
+++ b/supabase/migrations/20260721183000_bound_asset_management_history_reads.sql
@@ -1,0 +1,61 @@
+-- Keep asset-management startup reads bounded without dropping the last known
+-- balance for accounts that have no activity inside the chart window.
+CREATE OR REPLACE FUNCTION public.asset_management_recent_cfo_assets(
+  p_lookback_days integer DEFAULT 400
+)
+RETURNS TABLE (
+  title text,
+  amount numeric,
+  created_at timestamp with time zone
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $function$
+  WITH cutoff AS (
+    SELECT now() - make_interval(
+      days => LEAST(GREATEST(COALESCE(p_lookback_days, 400), 1), 3650)
+    ) AS value
+  ),
+  recent_rows AS (
+    SELECT asset.id, asset.title, asset.amount, asset.created_at
+    FROM public.cfo_assets AS asset
+    CROSS JOIN cutoff
+    WHERE asset.user_id = auth.uid()
+      AND asset.created_at >= cutoff.value
+  ),
+  account_anchors AS (
+    SELECT DISTINCT ON (asset.title)
+      asset.id,
+      asset.title,
+      asset.amount,
+      asset.created_at
+    FROM public.cfo_assets AS asset
+    CROSS JOIN cutoff
+    WHERE asset.user_id = auth.uid()
+      AND asset.created_at < cutoff.value
+    ORDER BY
+      asset.title,
+      asset.created_at DESC NULLS LAST,
+      asset.id DESC
+  )
+  SELECT result_rows.title, result_rows.amount, result_rows.created_at
+  FROM (
+    SELECT * FROM recent_rows
+    UNION ALL
+    SELECT * FROM account_anchors
+  ) AS result_rows
+  ORDER BY
+    result_rows.created_at ASC,
+    result_rows.title ASC,
+    result_rows.id ASC;
+$function$;
+
+REVOKE ALL ON FUNCTION public.asset_management_recent_cfo_assets(integer)
+FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.asset_management_recent_cfo_assets(integer)
+TO authenticated;
+
+COMMENT ON FUNCTION public.asset_management_recent_cfo_assets(integer) IS
+  'Returns projected cfo_assets rows for a bounded chart window plus one pre-window anchor per account.';

--- a/test/services/asset_liability_repository_egress_test.dart
+++ b/test/services/asset_liability_repository_egress_test.dart
@@ -64,7 +64,49 @@ void main() {
       expect(local.defaultPaymentSources['mobit'], 'smbc_otsuka');
       expect(local.defaultCardBillingAccounts['au'], 'aupay_card');
     });
+
+    test('compares only the latest bounded monthly snapshot window', () async {
+      final snapshots = <AssetLiabilityMonthlySnapshot>[
+        for (var index = 0; index < 121; index++)
+          _snapshotFor(DateTime(2016, index + 1)),
+      ];
+      final local = _MemoryAssetLiabilityRepository()
+        ..monthlySnapshots = snapshots;
+      final remote = _CountingRemoteStore()
+        ..monthlySnapshots = snapshots.sublist(1);
+      final repository = FeatureFlaggedAssetLiabilityRepository(
+        localRepository: local,
+        remoteStore: remote,
+        syncEnabled: true,
+        userIdProvider: () => 'user-1',
+      );
+
+      final preview = await repository.previewSyncMonth(DateTime(2026, 1));
+      final snapshotItem = preview.items.singleWhere(
+        (item) => item.target == AssetLiabilitySyncTarget.monthlySnapshots,
+      );
+
+      expect(snapshotItem.dataMatches, isTrue);
+      expect(snapshotItem.localCount, 120);
+      expect(snapshotItem.remoteCount, 120);
+    });
   });
+}
+
+AssetLiabilityMonthlySnapshot _snapshotFor(DateTime month) {
+  final monthKey = '${month.year}-${month.month.toString().padLeft(2, '0')}';
+  return AssetLiabilityMonthlySnapshot(
+    monthKey: monthKey,
+    savedAt: DateTime.utc(month.year, month.month, 1),
+    positiveAssetTotal: 100000,
+    liabilityTotal: -1000000,
+    netWorth: -900000,
+    cashLikeTotal: 50000,
+    monthlyScheduledPaymentTotal: 100000,
+    monthlyPaidPaymentTotal: 50000,
+    monthlyUnpaidPaymentTotal: 50000,
+    overduePaymentCount: 0,
+  );
 }
 
 final class _MemoryAssetLiabilityRepository extends AssetLiabilityRepository {
@@ -72,6 +114,8 @@ final class _MemoryAssetLiabilityRepository extends AssetLiabilityRepository {
   Map<String, String> defaultPaymentSources = <String, String>{};
   Map<String, String> defaultCardBillingAccounts = <String, String>{};
   int savedMonthCount = 0;
+  List<AssetLiabilityMonthlySnapshot> monthlySnapshots =
+      <AssetLiabilityMonthlySnapshot>[];
 
   @override
   Future<AssetLiabilityMonthlyState> loadMonth(DateTime month) async {
@@ -130,7 +174,7 @@ final class _MemoryAssetLiabilityRepository extends AssetLiabilityRepository {
 
   @override
   Future<List<AssetLiabilityMonthlySnapshot>> loadMonthlySnapshots() async {
-    return const <AssetLiabilityMonthlySnapshot>[];
+    return List<AssetLiabilityMonthlySnapshot>.from(monthlySnapshots);
   }
 
   @override
@@ -146,6 +190,8 @@ final class _CountingRemoteStore extends AssetLiabilityRemoteStore {
   int monthLoadCount = 0;
   int defaultSettingsLoadCount = 0;
   int legacyDefaultLoadCount = 0;
+  List<AssetLiabilityMonthlySnapshot> monthlySnapshots =
+      <AssetLiabilityMonthlySnapshot>[];
 
   @override
   Future<AssetLiabilityMonthlyState?> loadMonth({
@@ -218,7 +264,7 @@ final class _CountingRemoteStore extends AssetLiabilityRemoteStore {
   Future<List<AssetLiabilityMonthlySnapshot>?> loadMonthlySnapshots({
     required String userId,
   }) async {
-    return null;
+    return List<AssetLiabilityMonthlySnapshot>.from(monthlySnapshots);
   }
 
   @override

--- a/test/services/asset_management_egress_policy_test.dart
+++ b/test/services/asset_management_egress_policy_test.dart
@@ -11,8 +11,10 @@ void main() {
     test('uses bounded query windows and result limits', () {
       expect(AssetManagementEgressPolicy.assetHistoryLookbackDays, 400);
       expect(AssetManagementEgressPolicy.queryPageSize, 500);
+      expect(AssetManagementEgressPolicy.maxAssetHistoryRows, 10000);
       expect(AssetManagementEgressPolicy.recentFlowMonthWindow, 24);
       expect(AssetManagementEgressPolicy.maxRecentFlowRows, 2000);
+      expect(AssetManagementEgressPolicy.maxImportDedupRows, 10000);
       expect(AssetManagementEgressPolicy.maxMonthlySnapshots, 120);
     });
 
@@ -21,7 +23,53 @@ void main() {
         AssetManagementEgressPolicy.recentFlowCutoff(
           DateTime.utc(2026, 7, 21, 12),
         ),
-        DateTime.utc(2024, 8),
+        DateTime(2024, 8).toUtc(),
+      );
+    });
+
+    test('falls back only for missing RPC error codes', () {
+      expect(
+        AssetManagementEgressPolicy.isMissingAssetHistoryRpcCode('PGRST202'),
+        isTrue,
+      );
+      expect(
+        AssetManagementEgressPolicy.isMissingAssetHistoryRpcCode('42883'),
+        isTrue,
+      );
+      expect(
+        AssetManagementEgressPolicy.isMissingAssetHistoryRpcCode('PGRST301'),
+        isFalse,
+      );
+    });
+
+    test('reuses the first page and returns every bounded row once', () async {
+      final requestedRanges = <(int, int)>[];
+      final rows = await AssetManagementEgressPolicy.fetchBoundedPages<int>(
+        maxRows: 5,
+        pageSize: 2,
+        firstPage: const <int>[0, 1],
+        fetchPage: (from, to) async {
+          requestedRanges.add((from, to));
+          return <int>[
+            for (var value = from; value <= to && value < 5; value++) value,
+          ];
+        },
+      );
+
+      expect(rows, <int>[0, 1, 2, 3, 4]);
+      expect(requestedRanges, <(int, int)>[(2, 3), (4, 5)]);
+    });
+
+    test('rejects an overflowing result instead of returning partial data', () {
+      expect(
+        () => AssetManagementEgressPolicy.fetchBoundedPages<int>(
+          maxRows: 3,
+          pageSize: 2,
+          fetchPage: (from, to) async => <int>[
+            for (var value = from; value <= to; value++) value,
+          ],
+        ),
+        throwsA(isA<StateError>()),
       );
     });
   });
@@ -39,7 +87,7 @@ void main() {
       expect(
         sql,
         contains(
-          'returns table (\n  title text,\n  amount numeric,\n  created_at timestamp with time zone',
+          'returns table (\n  id bigint,\n  title text,\n  amount numeric,\n  created_at timestamp with time zone',
         ),
       );
       expect(sql, contains('from public.cfo_assets as asset'));

--- a/test/services/asset_management_egress_policy_test.dart
+++ b/test/services/asset_management_egress_policy_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_web_app/services/asset_management_egress_policy.dart';
+
+const _migrationPath =
+    'supabase/migrations/20260721183000_bound_asset_management_history_reads.sql';
+
+void main() {
+  group('AssetManagementEgressPolicy', () {
+    test('uses bounded query windows and result limits', () {
+      expect(AssetManagementEgressPolicy.assetHistoryLookbackDays, 400);
+      expect(AssetManagementEgressPolicy.queryPageSize, 500);
+      expect(AssetManagementEgressPolicy.recentFlowMonthWindow, 24);
+      expect(AssetManagementEgressPolicy.maxRecentFlowRows, 2000);
+      expect(AssetManagementEgressPolicy.maxMonthlySnapshots, 120);
+    });
+
+    test('starts the recent-flow window at the first day 23 months ago', () {
+      expect(
+        AssetManagementEgressPolicy.recentFlowCutoff(
+          DateTime.utc(2026, 7, 21, 12),
+        ),
+        DateTime.utc(2024, 8),
+      );
+    });
+  });
+
+  group('asset-management bounded history migration', () {
+    late final String sql;
+
+    setUpAll(() {
+      sql = File(
+        _migrationPath,
+      ).readAsStringSync().replaceAll('\r\n', '\n').toLowerCase();
+    });
+
+    test('returns only the projected asset columns', () {
+      expect(
+        sql,
+        contains(
+          'returns table (\n  title text,\n  amount numeric,\n  created_at timestamp with time zone',
+        ),
+      );
+      expect(sql, contains('from public.cfo_assets as asset'));
+    });
+
+    test('keeps recent rows and one pre-window anchor per account', () {
+      expect(sql, contains('asset.created_at >= cutoff.value'));
+      expect(sql, contains('select distinct on (asset.title)'));
+      expect(sql, contains('asset.created_at < cutoff.value'));
+      expect(sql, contains('union all'));
+    });
+
+    test('uses caller permissions and limits execution to signed-in users', () {
+      expect(sql, contains('security invoker'));
+      expect(sql, contains("set search_path = ''"));
+      expect(sql, contains('asset.user_id = auth.uid()'));
+      expect(
+        sql,
+        contains(
+          'revoke all on function public.asset_management_recent_cfo_assets(integer)',
+        ),
+      );
+      expect(sql, contains('to authenticated'));
+    });
+  });
+}


### PR DESCRIPTION
## 概要

資産管理ページの起動時Supabase取得を、必要列・期間・件数で束縛します。

## 主な変更

- `cfo_assets` は直近400日と、期間外にしか履歴がない口座の最新アンカー1件だけを返すRPCへ移行
- RPC未配備時は必要4列だけをページ取得する互換フォールバックを使用
- `wealth_struggles` は必要5列、直近24か月、最大2,000件を500件単位で取得
- SMBC CSVの重複判定は表示用2,000件上限から分離し、専用の最大10,000件照会を使用
- 月次スナップショットはローカル/リモートとも最新120件で比較
- delete時の不要な行データ返却を停止
- migrationの権限・アンカー保持・期間上限をテスト

## 自動レビュー対応

- offset paginationに`id`の一意タイブレーカを追加
- RPCフォールバックを`PGRST202` / `42883`の未配備時だけに限定
- 資産履歴を最大10,000件で停止し、超過時は部分データを返さずエラーにする
- ローカル月初をUTCへ変換してJST境界欠落を防止
- ページ再利用・上限超過拒否・月次120件比較を振る舞いテストで検証

## データ安全性

- RPCは `SECURITY INVOKER` と `auth.uid()` で呼出ユーザーの行だけを返します。
- 古い口座残高が消えないよう、期間前の最新1件を口座ごとに保持します。
- migrationはリモートDB上の `BEGIN` / `ROLLBACK` で型・構文を確認し、検証時のDB変更は残していません。
- アプリとmigrationの配備順がずれても必要列projectionのフォールバックで既存画面を維持します。

## 検証

- `dart format --output=none --set-exit-if-changed ...`: OK
- 対象 `flutter analyze`: No issues found
- 関連Flutterテスト: 58 passed
- pre-push full quality gate: PASS
  - full `flutter analyze`: No issues found
  - full `dart format`: 1,075 files / 0 changed
  - full Flutter VM tests with coverage: PASS
  - Deno tests: 601 passed / 0 failed
- `git diff --check`（Windows CRLFを許容）: OK
- リモートDB `BEGIN` / `ROLLBACK` migration構文検証: OK

## Minimal E2E Gate

- Implementation-detail independent: the test asserts user-visible input/output, not private internals.
- Minimal scope: about 3 cases (happy path, error path, recovery or empty state).
- E2E: Flutter `integration_test/` flow or Playwright `test/e2e/` route.
- E2E-Exception: 画面操作は変更せず取得境界だけを変更するため、SQL rollback検証・関連Flutterテスト・CI DB smokeを採用します。

## Visual E2E

- UI/layout変更なし。スクリーンショット比較は対象外です。
- 生成画像は使用していません。

## High-risk Ultrareview Gate

- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: 自動レビューの全7指摘を反映し、非破壊SQL検証とGitHub CIのDB smokeを必須とします。

## 関連Issue

Closes #4094
Related to #2574

## 運用メモ

- WBS全体の期限順はdry-runで確認済みです。本PRはユーザーが明示したSupabaseエグレス削減の優先対応として実施しています。
- サブエージェントは使用していません。