### PR TITLE
feat: add one-tap first-user landing trial

### DIFF
--- a/lib/pages/landing_page.dart
+++ b/lib/pages/landing_page.dart
@@ -278,6 +278,10 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     return GrowthAcquisitionService.isFirstUserGrowthUri(uri);
   }
 
+  bool get _usesHeroTrial {
+    return _isFirstUserGrowthTraffic || _hypothesisEnabled('h03');
+  }
+
   void _goToAuthenticatedEntry() {
     Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
   }
@@ -1201,7 +1205,7 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   }
 
   Widget _buildConversionSequence() {
-    final trialFirst = _hypothesisEnabled('h03');
+    final trialFirst = _usesHeroTrial;
     return Column(
       key: Key(
         trialFirst
@@ -1266,13 +1270,19 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
   }
 
   Widget _buildHeroSection() {
-    final trialFirst = _hypothesisEnabled('h03');
+    final firstUserGrowthMode = _isFirstUserGrowthTraffic;
+    final trialFirst = _usesHeroTrial;
     return _WorkflowLandingHero(
       achievementCount: _achievementCount,
-      showFirstUserGrowthCta: _isFirstUserGrowthTraffic,
+      showFirstUserGrowthCta: firstUserGrowthMode,
       outcomeFirstMessage: _hypothesisEnabled('h01'),
       showRiskReversal: _hypothesisEnabled('h05'),
-      inlineTrial: trialFirst ? _buildTrialSection(heroMode: true) : null,
+      inlineTrial: trialFirst
+          ? _buildTrialSection(
+              heroMode: true,
+              firstUserGrowthMode: firstUserGrowthMode,
+            )
+          : null,
       onGetStarted: _handleHeroSignup,
       onWatchDemo: _scrollToTrialSection,
     );
@@ -3863,7 +3873,10 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     );
   }
 
-  Widget _buildTrialSection({bool heroMode = false}) {
+  Widget _buildTrialSection({
+    bool heroMode = false,
+    bool firstUserGrowthMode = false,
+  }) {
     final compactHero = heroMode && MediaQuery.sizeOf(context).width < 480;
     return KeyedSubtree(
       key: const Key('landing_trial_section'),
@@ -3881,7 +3894,11 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                heroMode ? '30秒で試す: いま詰まっていることは？' : 'AIに「今日やる1件」を聞く',
+                firstUserGrowthMode
+                    ? 'Xから来た方へ: まず1タップで結果を見る'
+                    : heroMode
+                        ? '30秒で試す: いま詰まっていることは？'
+                        : 'AIに「今日やる1件」を聞く',
                 style: TextStyle(
                   fontSize: compactHero ? 16 : 18,
                   fontWeight: FontWeight.w800,
@@ -3890,11 +3907,13 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
               ),
               SizedBox(height: compactHero ? 4 : 6),
               Text(
-                compactHero
-                    ? '登録不要。例を押すか1行書くと「今やる1件」を返します。'
-                    : heroMode
-                        ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
-                        : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
+                firstUserGrowthMode
+                    ? '入力・登録・カードは不要です。下のボタンだけで「今やる1件」を確認し、役立った時だけ保存できます。'
+                    : compactHero
+                        ? '登録不要。例を押すか1行書くと「今やる1件」を返します。'
+                        : heroMode
+                            ? '登録はまだ不要です。1行書くか、下の例を押すと「今やる1件」を返します。'
+                            : 'まず1回だけ使って、価値があるかを確認してください。保存したくなった時だけ登録すれば十分です。',
                 style: TextStyle(
                   color: const Color(0xFF64748B),
                   fontSize: compactHero ? 12 : 14,
@@ -3902,10 +3921,13 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
                 ),
               ),
               SizedBox(height: compactHero ? 6 : 12),
-              _buildTrialAnswerPreview(compact: compactHero),
+              _buildTrialAnswerPreview(
+                compact: compactHero,
+                firstUserGrowthMode: firstUserGrowthMode,
+              ),
               SizedBox(height: compactHero ? 8 : 12),
               Text(
-                'ほかの悩みを1タップで試す',
+                firstUserGrowthMode ? '別の悩みで試す' : 'ほかの悩みを1タップで試す',
                 style: TextStyle(
                   color: const Color(0xFF475569),
                   fontSize: compactHero ? 11 : 12,
@@ -4081,7 +4103,10 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
     );
   }
 
-  Widget _buildTrialAnswerPreview({required bool compact}) {
+  Widget _buildTrialAnswerPreview({
+    required bool compact,
+    bool firstUserGrowthMode = false,
+  }) {
     const samplePrompt = '仕事が多すぎて、何から始めるか決められない';
     return Container(
       key: const Key('landing_h11_answer_preview'),
@@ -4132,22 +4157,59 @@ class _LandingPageState extends State<LandingPage> with RouteAware {
             ),
           ),
           const SizedBox(height: 8),
-          OutlinedButton.icon(
-            key: const Key('landing_h11_answer_preview_action'),
-            onPressed: _isTrialLoading
-                ? null
-                : () => _runQuickTrialSample(samplePrompt),
-            icon: const Icon(Icons.bolt, size: 17),
-            label: const Text('この例で即試す'),
-            style: OutlinedButton.styleFrom(
-              foregroundColor: const Color(0xFF1F7AE0),
-              minimumSize: Size.fromHeight(compact ? 40 : 44),
-              side: const BorderSide(color: Color(0xFF93C5FD)),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(6),
+          if (firstUserGrowthMode)
+            FilledButton.icon(
+              key: const Key('first_user_growth_one_tap_trial'),
+              onPressed: _isTrialLoading
+                  ? null
+                  : () => _runQuickTrialSample(samplePrompt),
+              icon: const Icon(Icons.bolt, size: 17),
+              label: const Text('1タップで「今日やる1件」を出す'),
+              style: FilledButton.styleFrom(
+                backgroundColor: const Color(0xFF1F7AE0),
+                foregroundColor: Colors.white,
+                minimumSize: Size.fromHeight(compact ? 44 : 48),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(6),
+                ),
+              ),
+            )
+          else
+            OutlinedButton.icon(
+              key: const Key('landing_h11_answer_preview_action'),
+              onPressed: _isTrialLoading
+                  ? null
+                  : () => _runQuickTrialSample(samplePrompt),
+              icon: const Icon(Icons.bolt, size: 17),
+              label: const Text('この例で即試す'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: const Color(0xFF1F7AE0),
+                minimumSize: Size.fromHeight(compact ? 40 : 44),
+                side: const BorderSide(color: Color(0xFF93C5FD)),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(6),
+                ),
               ),
             ),
-          ),
+          if (firstUserGrowthMode) ...[
+            const SizedBox(height: 8),
+            const Wrap(
+              key: Key('first_user_growth_trial_reassurance'),
+              alignment: WrapAlignment.center,
+              spacing: 14,
+              runSpacing: 6,
+              children: [
+                _TrustPoint(
+                  icon: Icons.visibility_outlined,
+                  label: '登録は結果を見てから',
+                ),
+                _TrustPoint(
+                  icon: Icons.credit_card_off_outlined,
+                  label: 'カード不要',
+                ),
+              ],
+            ),
+          ],
         ],
       ),
     );

--- a/test/pages/landing_page_conversion_test.dart
+++ b/test/pages/landing_page_conversion_test.dart
@@ -279,6 +279,108 @@ void main() {
     expect(find.byKey(const Key('landing_h03_auth_before_trial')), findsOne);
   });
 
+  testWidgets(
+    'first-user X traffic gets a one-tap trial before registration',
+    (tester) async {
+      final adapter = await pumpLanding(
+        tester,
+        assignment: _assignment('h03', LandingExperimentVariant.control),
+        landingUri: Uri.parse(
+          'https://example.com/?lp_intent=trial'
+          '&utm_source=x&utm_medium=organic'
+          '&utm_campaign=first_user_growth'
+          '&utm_content=outcome_first_a',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Xから来た方へ: まず1タップで結果を見る'),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('first_user_growth_one_tap_trial')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('first_user_growth_trial_reassurance')),
+        findsOneWidget,
+      );
+
+      await tester.tap(
+        find.byKey(const Key('first_user_growth_one_tap_trial')),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(adapter.trialRuns, 1);
+      expect(
+        adapter.lastTrialPrompt,
+        '仕事が多すぎて、何から始めるか決められない',
+      );
+      expect(
+        adapter.conversionEvents,
+        contains('lp_exp_h03_control_trial'),
+      );
+      expect(
+        find.byKey(const Key('landing_trial_result_action')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('landing_h04_inline_magic_capture')),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets('first-user one-tap trial stays in the mobile first viewport', (
+    tester,
+  ) async {
+    const size = Size(390, 844);
+    await pumpLanding(
+      tester,
+      assignment: _assignment('h03', LandingExperimentVariant.control),
+      size: size,
+      landingUri: Uri.parse(
+        'https://example.com/?lp_intent=trial'
+        '&utm_source=x&utm_medium=organic'
+        '&utm_campaign=first_user_growth',
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final oneTapButton = find.byKey(
+      const Key('first_user_growth_one_tap_trial'),
+    );
+    expect(oneTapButton, findsOneWidget);
+    final buttonTop = tester.getTopLeft(oneTapButton).dy;
+    final buttonBottom = tester.getBottomLeft(oneTapButton).dy;
+    expect(buttonTop, greaterThanOrEqualTo(0));
+    expect(buttonBottom, lessThanOrEqualTo(size.height));
+  });
+
+  testWidgets('non-campaign traffic keeps the generic one-tap trial', (
+    tester,
+  ) async {
+    await pumpLanding(
+      tester,
+      assignment: _assignment('h01', LandingExperimentVariant.treatment),
+      landingUri: Uri.parse('https://example.com/?lp_intent=trial'),
+    );
+
+    expect(
+      find.byKey(const Key('first_user_growth_one_tap_trial')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const Key('first_user_growth_trial_reassurance')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const Key('landing_h11_answer_preview_action')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('H07 renders anonymous-safe public aggregate social proof', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- turn the X first-user campaign landing path into a one-tap, no-input product trial in the first viewport
- show one concrete action result before asking for registration, then place the existing Magic Link save flow directly below the result
- keep ordinary landing traffic unchanged and prevent the campaign trial from being duplicated later on the page

## Why this is the next funnel move
- the latest H01-H10 report had about 31 effective landing views but zero trial, save, signup-submit, or signup-complete events
- the current measurable bottleneck is landing view -> first value, before registration and payment
- this isolates the strongest next hypothesis: X campaign visitors need one visible click to receive value before any form or account request

## Behavior
- campaign traffic (`utm_campaign=first_user_growth` or equivalent marker) always gets the one-tap hero trial, including H03 control assignment
- CTA: `1?????????1?????`
- result: one concrete action plus inline email Magic Link save/signup
- non-campaign traffic retains the existing generic trial button and experiment behavior

## Verification
- `flutter test --no-pub test/pages/landing_page_conversion_test.dart` (21 passed)
- `flutter analyze --no-pub lib/pages/landing_page.dart test/pages/landing_page_conversion_test.dart` (no issues)
- `flutter build web --release --no-pub` (succeeded)
- local Playwright/Chromium at 1440x1000 and 390x844: CTA visible in first viewport; click renders result and inline Magic Link; no duplicate trial
- full pre-push quality gate: passed, including Flutter VM suite, Deno 532 passed / 0 failed, formatter, analyzer, and Edge Function lint
- generated imagery: none

## Minimal E2E Gate
- Implementation-detail independent: widget tests assert the campaign URL's visible CTA, result, analytics event, and registration continuation.
- Minimal scope: campaign happy path, mobile first viewport, and non-campaign recovery/control behavior.
- E2E-Exception: no new backend or browser API boundary; the interaction was additionally verified in desktop and mobile Chromium against the release build.

## Visual QA
- Changed surface: public landing page for first-user X campaign traffic only.
- Desktop 1440x1000: one-tap CTA, reassurance, result, and inline Magic Link fit without overlap.
- Mobile 390x844: campaign CTA remains in the first viewport and the result flow stays readable.
- Browser console/request review: no new page errors or HTTP 5xx from the changed path.

Closes #4317
Related to #3745

## High-risk Ultrareview Gate
- Reviewer: Claude Code #1
- High-Risk-Ultrareview-Exception: Campaign-only landing UI change; no authentication, payment, backend, migration, secret, workflow, or production deploy behavior was changed.

## Publication boundary
- This PR does not publish an X post. The existing candidate remains approval-pending until the user explicitly approves the public action.
